### PR TITLE
refactor(queue): compose Nitro Cloudflare output

### DIFF
--- a/docs/content/docs/frameworks-hosts/cloudflare.md
+++ b/docs/content/docs/frameworks-hosts/cloudflare.md
@@ -78,7 +78,7 @@ Agent routes should come from generated Provider Output. Raw Cloudflare Worker f
 
 ### Rate Limiting bindings
 
-Register the Rate Limit integration. A Cloudflare Nitro preset infers the provider, and each source-local `defineRateLimit()` call contributes one `ratelimits` entry to generated `wrangler.json`.
+Register the Rate Limit integration. A Cloudflare Nitro preset infers the provider, and each source-local `defineRateLimit()` call contributes one `ratelimits` entry to Nitro's Wrangler config. Do not repeat those bindings in `nitro.cloudflare.wrangler`; plain Vite builds continue to write them to generated `wrangler.json`.
 
 ```ts [vite.config.ts]
 import { hubRateLimit } from '@vite-hub/rate-limit/vite'

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -483,7 +483,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   const localOnly = !shouldCreateProviderOutput(options.blob)
   const createCloudflare = !localOnly && !options.cloudflareOwnedByNitro
   const hasCurrentCloudflareContribution = Boolean(createCloudflareR2Bindings(resolveBlobConfig(options.blob, "cloudflare"))?.length)
-  if (options.cloudflareOwnedByNitro && !localOnly) {
+  if (options.cloudflareOwnedByNitro) {
     await writeProviderDeploymentOutputs({
       clientOutDir: options.clientOutDir,
       cleanup: { cloudflare: () => createNitroCloudflareCleanup(options.rootDir, hasCurrentCloudflareContribution) },

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -14,6 +14,7 @@ import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, Vercel
 
 export const blobPackageName = "@vite-hub/blob"
 const cloudflareBlobWorkerMarker = "vitehub-blob-worker"
+const cloudflareBlobOutputState = ".vitehub/blob/cloudflare-output.json"
 const productName = "blob"
 const packageDir = computePackageDir(import.meta.url)
 const resolveRuntimeModule = (modulePath: string) => resolveRuntimeFromPkg(packageDir, modulePath)
@@ -353,6 +354,7 @@ function isLegacyCloudflareBlobWorker(worker: string, wrangler: unknown): boolea
 async function createNitroCloudflareCleanup(rootDir: string) {
   const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
   let ownsWorker = false
+  let ownsR2Buckets = false
   try {
     const worker = await readFile(resolve(outputRoot, "index.js"), "utf8")
     ownsWorker = worker.includes(cloudflareBlobWorkerMarker)
@@ -368,11 +370,25 @@ async function createNitroCloudflareCleanup(rootDir: string) {
   catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
   }
+  try {
+    const [state, wrangler] = await Promise.all([
+      readFile(resolve(rootDir, cloudflareBlobOutputState), "utf8").then(value => JSON.parse(value) as Record<string, unknown>),
+      readFile(resolve(outputRoot, "wrangler.json"), "utf8").then(value => JSON.parse(value) as Record<string, unknown>),
+    ])
+    ownsR2Buckets = JSON.stringify(state.r2_buckets) === JSON.stringify(wrangler.r2_buckets)
+    await rm(resolve(rootDir, cloudflareBlobOutputState), { force: true })
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
   return {
     fileNames: ownsWorker ? ["index.js"] : [],
     outputRoot,
     wranglerConfigOwnership: {
-      keys: ownsWorker ? ["compatibility_date", "compatibility_flags", "main", "observability", "r2_buckets"] : [],
+      keys: [
+        ...(ownsWorker ? ["compatibility_date", "compatibility_flags", "main", "observability"] : []),
+        ...(ownsR2Buckets || ownsWorker ? ["r2_buckets"] : []),
+      ],
     },
   }
 }
@@ -480,6 +496,11 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     rootDir: options.rootDir,
     vercel: localOnly ? undefined : createVercelOutput(artifacts, options.providerOutput, options.serverFunctionName),
   })
+  if (createCloudflare) {
+    const r2Buckets = createCloudflareR2Bindings(resolveBlobConfig(options.blob, "cloudflare"))
+    await mkdir(dirname(resolve(options.rootDir, cloudflareBlobOutputState)), { recursive: true })
+    await writeFile(resolve(options.rootDir, cloudflareBlobOutputState), `${JSON.stringify({ r2_buckets: r2Buckets }, null, 2)}\n`, "utf8")
+  }
   return artifacts
 }
 

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -1,8 +1,8 @@
-import { mkdir, writeFile } from "node:fs/promises"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { resolve } from "pathe"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
-import { getProviderRuntimeModule, registerProviderRuntimeModules, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
+import { createDefaultCloudflareOutputRoot, getProviderRuntimeModule, registerProviderRuntimeModules, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vite-hub/internal/build/paths"
 import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
 import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
@@ -13,6 +13,7 @@ import type { BlobModuleOptions, ResolvedBlobModuleOptions, ResolvedCloudflareR2
 import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const blobPackageName = "@vite-hub/blob"
+const cloudflareBlobWorkerMarker = "vitehub-blob-worker"
 const productName = "blob"
 const packageDir = computePackageDir(import.meta.url)
 const resolveRuntimeModule = (modulePath: string) => resolveRuntimeFromPkg(packageDir, modulePath)
@@ -44,6 +45,7 @@ interface GenerateProviderOutputsOptions {
   artifacts?: GeneratedBlobArtifacts
   blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined
   clientOutDir: string
+  cloudflareOwnedByNitro?: boolean
   providerOutput?: ComposedProviderOutput
   rootDir: string
   serverFunctionName?: string
@@ -102,7 +104,7 @@ function isCloudflareR2StoreWithBucket(store: ResolvedBlobModuleOptions["store"]
   return store.driver === "cloudflare-r2" && Boolean(store.bucketName)
 }
 
-function createCloudflareR2Bindings(config: false | ResolvedBlobModuleOptions | undefined): Array<{ binding: string, bucket_name: string }> | undefined {
+export function createCloudflareR2Bindings(config: false | ResolvedBlobModuleOptions | undefined): Array<{ binding: string, bucket_name: string }> | undefined {
   if (!config) {
     return undefined
   }
@@ -315,6 +317,7 @@ function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOpti
         "@vite-hub/blob": artifacts.runtimeModuleFiles.cloudflare,
         ...(databaseRuntime ? { "@vite-hub/database/drizzle": databaseRuntime } : {}),
       },
+      banner: `// ${cloudflareBlobWorkerMarker}`,
       conditions: ["workerd", "worker", "browser", "default"],
       external: [
         "@aws-sdk/client-s3",
@@ -330,6 +333,47 @@ function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOpti
     },
     wranglerConfigKeys: ["r2_buckets"],
     wranglerConfig,
+  }
+}
+
+function isLegacyCloudflareBlobWorker(worker: string, wrangler: unknown): boolean {
+  if (!wrangler || typeof wrangler !== "object" || Array.isArray(wrangler)) return false
+  const config = wrangler as Record<string, unknown>
+  const compatibilityFlags = Array.isArray(config.compatibility_flags) ? config.compatibility_flags : []
+  const observability = config.observability && typeof config.observability === "object" && !Array.isArray(config.observability)
+    ? config.observability as Record<string, unknown>
+    : {}
+  return worker.includes("function createBlobCloudflareWorker(")
+    && worker.includes("setBlobRuntimeConfig(")
+    && config.main === "index.js"
+    && compatibilityFlags.includes("nodejs_compat")
+    && observability.enabled === true
+}
+
+async function createNitroCloudflareCleanup(rootDir: string) {
+  const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
+  let ownsWorker = false
+  try {
+    const worker = await readFile(resolve(outputRoot, "index.js"), "utf8")
+    ownsWorker = worker.includes(cloudflareBlobWorkerMarker)
+    if (!ownsWorker) {
+      try {
+        ownsWorker = isLegacyCloudflareBlobWorker(worker, JSON.parse(await readFile(resolve(outputRoot, "wrangler.json"), "utf8")))
+      }
+      catch (error) {
+        if (!(error instanceof SyntaxError) && (error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+      }
+    }
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
+  return {
+    fileNames: ownsWorker ? ["index.js"] : [],
+    outputRoot,
+    wranglerConfigOwnership: {
+      keys: ownsWorker ? ["compatibility_date", "compatibility_flags", "main", "observability", "r2_buckets"] : [],
+    },
   }
 }
 
@@ -421,10 +465,18 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   const artifacts = options.artifacts ?? await prepareProviderOutputs(options)
   registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.blob)
   const localOnly = !shouldCreateProviderOutput(options.blob)
+  const createCloudflare = !localOnly && !options.cloudflareOwnedByNitro
+  if (options.cloudflareOwnedByNitro && !localOnly) {
+    await writeProviderDeploymentOutputs({
+      clientOutDir: options.clientOutDir,
+      cleanup: { cloudflare: () => createNitroCloudflareCleanup(options.rootDir) },
+      rootDir: options.rootDir,
+    })
+  }
   await writeProviderDeploymentOutputs({
     afterWrite: localOnly ? undefined : () => copyVercelBlobRuntimePackages(options),
     clientOutDir: options.clientOutDir,
-    cloudflare: localOnly ? undefined : createCloudflareOutput(options.blob, artifacts, options.providerOutput),
+    cloudflare: createCloudflare ? createCloudflareOutput(options.blob, artifacts, options.providerOutput) : undefined,
     rootDir: options.rootDir,
     vercel: localOnly ? undefined : createVercelOutput(artifacts, options.providerOutput, options.serverFunctionName),
   })

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -351,7 +351,7 @@ function isLegacyCloudflareBlobWorker(worker: string, wrangler: unknown): boolea
     && observability.enabled === true
 }
 
-async function createNitroCloudflareCleanup(rootDir: string) {
+async function createNitroCloudflareCleanup(rootDir: string, hasCurrentContribution: boolean) {
   const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
   let ownsWorker = false
   let ownsR2Buckets = false
@@ -387,7 +387,7 @@ async function createNitroCloudflareCleanup(rootDir: string) {
     wranglerConfigOwnership: {
       keys: [
         ...(ownsWorker ? ["compatibility_date", "compatibility_flags", "main", "observability"] : []),
-        ...(ownsR2Buckets || ownsWorker ? ["r2_buckets"] : []),
+        ...(ownsWorker || (ownsR2Buckets && !hasCurrentContribution) ? ["r2_buckets"] : []),
       ],
     },
   }
@@ -482,10 +482,11 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.blob)
   const localOnly = !shouldCreateProviderOutput(options.blob)
   const createCloudflare = !localOnly && !options.cloudflareOwnedByNitro
+  const hasCurrentCloudflareContribution = Boolean(createCloudflareR2Bindings(resolveBlobConfig(options.blob, "cloudflare"))?.length)
   if (options.cloudflareOwnedByNitro && !localOnly) {
     await writeProviderDeploymentOutputs({
       clientOutDir: options.clientOutDir,
-      cleanup: { cloudflare: () => createNitroCloudflareCleanup(options.rootDir) },
+      cleanup: { cloudflare: () => createNitroCloudflareCleanup(options.rootDir, hasCurrentCloudflareContribution) },
       rootDir: options.rootDir,
     })
   }

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -1,5 +1,5 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises"
-import { resolve } from "pathe"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { dirname, resolve } from "pathe"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
 import { createDefaultCloudflareOutputRoot, getProviderRuntimeModule, registerProviderRuntimeModules, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -502,6 +502,9 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     await mkdir(dirname(resolve(options.rootDir, cloudflareBlobOutputState)), { recursive: true })
     await writeFile(resolve(options.rootDir, cloudflareBlobOutputState), `${JSON.stringify({ r2_buckets: r2Buckets }, null, 2)}\n`, "utf8")
   }
+  else {
+    await rm(resolve(options.rootDir, cloudflareBlobOutputState), { force: true })
+  }
   return artifacts
 }
 

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -1,10 +1,11 @@
 import { writeFileIfChanged } from "@vite-hub/internal/definition-catalog"
 import { getViteMode } from "@vite-hub/internal/build/mode"
-import { resetComposedProviderOutput, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
+import { composeNitroCloudflareProviderOutput, registerCloudflareProviderOutput, resetComposedProviderOutput, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
+import { createNoExternalMerger, hasNitroVitePlugin, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
+import { getHostingProvider } from "@vite-hub/internal/hosting"
 import { resolve } from "pathe"
 
-import { generateProviderOutputs, prepareProviderOutputs, blobPackageName } from "./internal/vite-build.ts"
+import { createCloudflareR2Bindings, generateProviderOutputs, prepareProviderOutputs, blobPackageName } from "./internal/vite-build.ts"
 import { createBlobCloudflareProvisionStep, createBlobVercelProvisionStep } from "./provision.ts"
 import {
   BLOB_VIRTUAL_CONFIG_ID,
@@ -53,6 +54,49 @@ function cloneNitroConfig(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {}
 }
 
+function hasNitroVitePluginOption(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(hasNitroVitePluginOption)
+  return Boolean(value)
+    && typeof value === "object"
+    && hasNitroVitePlugin({ plugins: [value as { name: string }] })
+}
+
+function mergeNitroExternal(value: unknown, addition: string): unknown {
+  if (typeof value === "undefined") return [addition]
+  if (Array.isArray(value)) return value.includes(addition) ? [...value] : [...value, addition]
+  if (typeof value === "string" || value instanceof RegExp) return [value, addition]
+  if (typeof value === "function") {
+    return (source: string, importer?: string, isResolved?: boolean) => source === addition || Boolean(value(source, importer, isResolved))
+  }
+  return value
+}
+
+function isNitroCloudflareHost(value: unknown): boolean {
+  const nitro = cloneNitroConfig(value)
+  const preset = typeof nitro.preset === "string" ? nitro.preset : process.env.NITRO_PRESET || process.env.SERVER_PRESET || process.env.VITEHUB_HOSTING
+  return typeof preset === "string" ? getHostingProvider(preset) === "cloudflare" : Object.hasOwn(nitro, "cloudflare")
+}
+
+function mergeNitroCloudflareBlobOutput(config: object, nitro: Record<string, unknown>, blob: BlobModuleOptions | undefined, cloudflareOwnedByNitro: boolean): Record<string, unknown> {
+  if (!cloudflareOwnedByNitro) {
+    registerCloudflareProviderOutput(config, "blob", {})
+    return nitro
+  }
+  const bindings = createCloudflareR2Bindings(resolveBlobViteConfig(blob, { hosting: "cloudflare" }).blob)
+  const cloudflare = cloneNitroConfig(nitro.cloudflare)
+  const wrangler = cloneNitroConfig(cloudflare.wrangler)
+  const compatibilityFlags = Array.isArray(wrangler.compatibility_flags) ? [...wrangler.compatibility_flags] : []
+  if (!compatibilityFlags.includes("nodejs_compat")) compatibilityFlags.push("nodejs_compat")
+  const rollupConfig = cloneNitroConfig(nitro.rollupConfig)
+  const baseNitro = {
+    ...nitro,
+    cloudflare: { ...cloudflare, wrangler: { ...wrangler, compatibility_flags: compatibilityFlags } },
+    rollupConfig: { ...rollupConfig, external: mergeNitroExternal(rollupConfig.external, "cloudflare:workers") },
+  }
+  registerCloudflareProviderOutput(config, "blob", bindings ? { r2Buckets: bindings } : {})
+  return composeNitroCloudflareProviderOutput(config, baseNitro)
+}
+
 function normalizeNitroRoute(route: string): string {
   return (route.startsWith("/") ? route : `/${route}`).replace(/\[([^\]]+)\]/g, ":$1")
 }
@@ -77,17 +121,20 @@ function mergeNitroBlobConfig(value: unknown, serve?: BlobServeConfig): Record<s
   }
 }
 
-function renderNitroBlobPlugin(blob: BlobViteRuntimeConfig["blob"], importBase = blobPackageName): string {
+function renderNitroBlobPlugin(blob: BlobViteRuntimeConfig["blob"], cloudflare: boolean, importBase = blobPackageName): string {
   return [
-    `import { setBlobRuntimeConfig } from '${importBase}/runtime/state'`,
+    cloudflare ? "import { env as vitehubEnv } from 'cloudflare:workers'" : undefined,
+    `import { ${cloudflare ? "setActiveCloudflareEnv, " : ""}setBlobRuntimeConfig } from '${importBase}/runtime/state'`,
     "",
     `const blobConfig = ${JSON.stringify(blob)}`,
     "",
-    "export default function vitehubBlobPlugin() {",
+    `export default function vitehubBlobPlugin(${cloudflare ? "nitro" : ""}) {`,
+    cloudflare ? "  setActiveCloudflareEnv(vitehubEnv)" : undefined,
     "  setBlobRuntimeConfig(blobConfig)",
+    cloudflare ? "  nitro.hooks.hook('request', (event) => setActiveCloudflareEnv(event.env ?? event.context?.cloudflare?.env ?? event.context?._platform?.cloudflare?.env ?? event.req?.runtime?.cloudflare?.env ?? event.node?.req?.runtime?.cloudflare?.env ?? vitehubEnv))" : undefined,
     "}",
     "",
-  ].join("\n")
+  ].filter(line => typeof line === "string").join("\n")
 }
 
 function renderBlobServeRouteHandler(serve: BlobServeConfig, importBase = blobPackageName): string {
@@ -106,8 +153,8 @@ function renderBlobServeRouteHandler(serve: BlobServeConfig, importBase = blobPa
   ].join("\n")
 }
 
-async function refreshBlobGeneratedFiles(root: string, blob: BlobViteRuntimeConfig["blob"], importBase = blobPackageName): Promise<void> {
-  await writeFileIfChanged(resolve(root, generatedNitroBlobPlugin), renderNitroBlobPlugin(blob, importBase))
+async function refreshBlobGeneratedFiles(root: string, blob: BlobViteRuntimeConfig["blob"], cloudflare: boolean, importBase = blobPackageName): Promise<void> {
+  await writeFileIfChanged(resolve(root, generatedNitroBlobPlugin), renderNitroBlobPlugin(blob, cloudflare, importBase))
   const serve = blob ? blob.serve : undefined
   if (!serve) return
   const file = resolve(root, generatedBlobServeRouteHandler)
@@ -119,6 +166,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
   let blob: BlobModuleOptions | undefined = options
   let clientOutDir = "dist"
   let command: "build" | "serve" = "serve"
+  let cloudflareOwnedByNitro = false
   let providerArtifacts: Awaited<ReturnType<typeof prepareProviderOutputs>> | undefined
   let providerOutput: ComposedProviderOutput | undefined
   let rootDir = process.cwd()
@@ -140,22 +188,28 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
     config(config, env) {
       command = env.command
       blob = config.blob ?? blob
-      const blobConfig = resolveBlobViteConfig(blob)
+      const configuredNitro = (config as { nitro?: unknown }).nitro
+      cloudflareOwnedByNitro = hasNitroVitePluginOption(config.plugins) && isNitroCloudflareHost(configuredNitro)
+      const blobConfig = resolveBlobViteConfig(blob, cloudflareOwnedByNitro ? { hosting: "cloudflare" } : undefined)
       const nitro = mergeNitroBlobConfig(
-        (config as { nitro?: unknown }).nitro,
+        configuredNitro,
         blobConfig.blob ? blobConfig.blob.serve : undefined,
       )
-      ;(config as { nitro?: unknown }).nitro = nitro
-      return { nitro } as never
+      const composedNitro = mergeNitroCloudflareBlobOutput(config, nitro, blob, cloudflareOwnedByNitro)
+      ;(config as { nitro?: unknown }).nitro = composedNitro
+      return { nitro: composedNitro } as never
     },
     async configResolved(config) {
       resolved = config
       clientOutDir = config.build.outDir
       rootDir = config.root
       blob = config.blob ?? blob
+      const configuredNitro = (config as { nitro?: unknown }).nitro
+      cloudflareOwnedByNitro = hasNitroVitePlugin(config) && isNitroCloudflareHost(configuredNitro)
+      ;(config as { nitro?: unknown }).nitro = mergeNitroCloudflareBlobOutput(config, cloneNitroConfig(configuredNitro), blob, cloudflareOwnedByNitro)
       providerOutput = useComposedProviderOutput(config)
-      runtimeConfig = resolveBlobViteConfig(blob)
-      await refreshBlobGeneratedFiles(config.root, runtimeConfig.blob, importBase)
+      runtimeConfig = resolveBlobViteConfig(blob, cloudflareOwnedByNitro ? { hosting: "cloudflare" } : undefined)
+      await refreshBlobGeneratedFiles(config.root, runtimeConfig.blob, cloudflareOwnedByNitro, importBase)
     },
     configEnvironment(name, config) {
       if (!isServerEnvironment(name, config)) {
@@ -190,6 +244,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       await generateProviderOutputs({
         blob,
         clientOutDir,
+        cloudflareOwnedByNitro,
         artifacts: providerArtifacts,
         providerOutput,
         rootDir,

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -80,7 +80,7 @@ function isNitroCloudflareHost(value: unknown): boolean {
 function mergeNitroCloudflareBlobOutput(config: object, nitro: Record<string, unknown>, blob: BlobModuleOptions | undefined, cloudflareOwnedByNitro: boolean): Record<string, unknown> {
   if (!cloudflareOwnedByNitro) {
     registerCloudflareProviderOutput(config, "blob", {})
-    return nitro
+    return composeNitroCloudflareProviderOutput(config, nitro)
   }
   const bindings = createCloudflareR2Bindings(resolveBlobViteConfig(blob, { hosting: "cloudflare" }).blob)
   const cloudflare = cloneNitroConfig(nitro.cloudflare)

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -206,7 +206,8 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       blob = config.blob ?? blob
       const configuredNitro = (config as { nitro?: unknown }).nitro
       cloudflareOwnedByNitro = hasNitroVitePlugin(config) && isNitroCloudflareHost(configuredNitro)
-      ;(config as { nitro?: unknown }).nitro = mergeNitroCloudflareBlobOutput(config, cloneNitroConfig(configuredNitro), blob, cloudflareOwnedByNitro)
+      const nitro = configuredNitro && typeof configuredNitro === "object" && !Array.isArray(configuredNitro) ? configuredNitro as Record<string, unknown> : {}
+      ;(config as { nitro?: unknown }).nitro = mergeNitroCloudflareBlobOutput(config, nitro, blob, cloudflareOwnedByNitro)
       providerOutput = useComposedProviderOutput(config)
       runtimeConfig = resolveBlobViteConfig(blob, cloudflareOwnedByNitro ? { hosting: "cloudflare" } : undefined)
       await refreshBlobGeneratedFiles(config.root, runtimeConfig.blob, cloudflareOwnedByNitro, importBase)

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -74,7 +74,7 @@ function mergeNitroExternal(value: unknown, addition: string): unknown {
 function isNitroCloudflareHost(value: unknown): boolean {
   const nitro = cloneNitroConfig(value)
   const preset = typeof nitro.preset === "string" ? nitro.preset : process.env.NITRO_PRESET || process.env.SERVER_PRESET || process.env.VITEHUB_HOSTING
-  return typeof preset === "string" ? getHostingProvider(preset) === "cloudflare" : Object.hasOwn(nitro, "cloudflare")
+  return typeof preset === "string" && getHostingProvider(preset) === "cloudflare"
 }
 
 function mergeNitroCloudflareBlobOutput(config: object, nitro: Record<string, unknown>, blob: BlobModuleOptions | undefined, cloudflareOwnedByNitro: boolean): Record<string, unknown> {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -348,13 +348,20 @@ describe("Vite provider outputs", () => {
     await generateProviderOutputs({
       blob: { driver: "fs" },
       clientOutDir: "dist",
+      rootDir,
+    })
+
+    expect(existsSync(join(rootDir, ".vitehub", "blob", "cloudflare-output.json"))).toBe(false)
+
+    await generateProviderOutputs({
+      blob: { driver: "fs" },
+      clientOutDir: "dist",
       cloudflareOwnedByNitro: true,
       rootDir,
     })
 
     expect(existsSync(join(outputRoot, "index.js"))).toBe(false)
     expect(existsSync(join(outputRoot, "wrangler.json"))).toBe(false)
-    expect(existsSync(join(rootDir, ".vitehub", "blob", "cloudflare-output.json"))).toBe(false)
   })
 
   it("omits Cloudflare bucket bindings when none are configured", { timeout: 15_000 }, async () => {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -319,7 +319,7 @@ describe("Vite provider outputs", () => {
     expect(existsSync(join(cloudflareOutput, "wrangler.json"))).toBe(false)
   })
 
-  it("cleans standalone R2 bindings after another primitive replaces the Worker", { timeout: 30_000 }, async () => {
+  it("preserves current Nitro R2 bindings after another primitive replaces the Worker", { timeout: 30_000 }, async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-shared-worker-")
     const outputRoot = join(rootDir, "dist", toSafeAppName(rootDir))
     await mkdir(join(rootDir, "src"), { recursive: true })
@@ -331,7 +331,7 @@ describe("Vite provider outputs", () => {
     await generateProviderOutputs({ ...options, cloudflareOwnedByNitro: true })
 
     await expect(readFile(join(outputRoot, "index.js"), "utf8")).resolves.toBe("// workflow worker\n")
-    expect(await readFile(join(outputRoot, "wrangler.json"), "utf8").then(JSON.parse)).not.toHaveProperty("r2_buckets")
+    expect(await readFile(join(outputRoot, "wrangler.json"), "utf8").then(JSON.parse)).toHaveProperty("r2_buckets")
   })
 
   it("omits Cloudflare bucket bindings when none are configured", { timeout: 15_000 }, async () => {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -195,6 +195,7 @@ describe("Vite provider outputs", () => {
     const vercelServerContents = await readFile(vercelServer, "utf8")
 
     expect(existsSync(cloudflareWorker)).toBe(true)
+    expect(await readFile(cloudflareWorker, "utf8")).toContain("vitehub-blob-worker")
     expect(await readFile(cloudflareConfig, "utf8")).toContain("\"bucket_name\": \"assets\"")
     expect(await readFile(vercelConfig, "utf8")).toContain("\"/__server\"")
     expect(existsSync(vercelServer)).toBe(true)
@@ -242,6 +243,80 @@ describe("Vite provider outputs", () => {
     await expect(readFile(nitroFunction, "utf8")).resolves.toBe("export default 'nitro'\n")
     await expect(readFile(join(outputRoot, "config.json"), "utf8").then(JSON.parse)).resolves.toEqual(nitroConfig)
     expect(existsSync(join(outputRoot, "functions", "__blob.func", "index.mjs"))).toBe(true)
+  })
+
+  it("leaves Cloudflare Worker output to Nitro while retaining Vercel output", { timeout: 45_000 }, async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-nitro-cloudflare-")
+    const cloudflareOutput = join(rootDir, "dist", toSafeAppName(rootDir))
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist", "client"), { recursive: true })
+    await mkdir(cloudflareOutput, { recursive: true })
+    await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
+    await writeFile(join(cloudflareOutput, "index.js"), "// workflow worker\nexport default {}\n", "utf8")
+    const foreignWrangler = {
+      compatibility_date: "2026-06-01",
+      compatibility_flags: ["nodejs_compat"],
+      main: "index.js",
+      observability: { enabled: true },
+      r2_buckets: [{ binding: "ASSETS", bucket_name: "assets", jurisdiction: "eu" }],
+      triggers: { crons: ["0 0 * * *"] },
+    }
+    await writeFile(join(cloudflareOutput, "wrangler.json"), `${JSON.stringify(foreignWrangler, null, 2)}\n`, "utf8")
+
+    const options = {
+      blob: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+      clientOutDir: "dist",
+      cloudflareOwnedByNitro: true,
+      rootDir,
+      serverFunctionName: "__blob.func",
+    } as const
+    await generateProviderOutputs(options)
+
+    await expect(readFile(join(cloudflareOutput, "index.js"), "utf8")).resolves.toBe("// workflow worker\nexport default {}\n")
+    await expect(readFile(join(cloudflareOutput, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual(foreignWrangler)
+
+    await generateProviderOutputs({ ...options, cloudflareOwnedByNitro: false })
+    const currentWorker = await readFile(join(cloudflareOutput, "index.js"), "utf8")
+    const legacyWorker = currentWorker.replace("// vitehub-blob-worker\n", "")
+    expect(currentWorker).toBe(`// vitehub-blob-worker\n${legacyWorker}`)
+    expect(legacyWorker).toContain("function createBlobCloudflareWorker(")
+    expect(legacyWorker).toContain("setBlobRuntimeConfig(")
+    expect(legacyWorker).toContain("R2 binding")
+    await writeFile(join(cloudflareOutput, "index.js"), legacyWorker, "utf8")
+    await generateProviderOutputs(options)
+
+    expect(existsSync(join(cloudflareOutput, "index.js"))).toBe(false)
+    await expect(readFile(join(cloudflareOutput, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+      triggers: { crons: ["0 0 * * *"] },
+    })
+    expect(existsSync(join(rootDir, ".vercel", "output", "static", toSafeAppName(rootDir), "index.js"))).toBe(false)
+    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__blob.func", "index.mjs"))).toBe(true)
+  })
+
+  it("cleans legacy standalone workers without R2 runtime code when Nitro takes ownership", { timeout: 30_000 }, async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-nitro-non-r2-")
+    const cloudflareOutput = join(rootDir, "dist", toSafeAppName(rootDir))
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist", "client"), { recursive: true })
+    await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
+
+    const options = {
+      blob: { driver: "vercel-blob", token: "test-token" },
+      clientOutDir: "dist/client",
+      rootDir,
+    } as const
+    await generateProviderOutputs(options)
+    const workerPath = join(cloudflareOutput, "index.js")
+    const legacyWorker = (await readFile(workerPath, "utf8")).replace("// vitehub-blob-worker\n", "")
+    expect(legacyWorker).toContain("function createBlobCloudflareWorker(")
+    expect(legacyWorker).toContain("setBlobRuntimeConfig(")
+    expect(legacyWorker).not.toContain("R2 binding")
+    await writeFile(workerPath, legacyWorker, "utf8")
+
+    await generateProviderOutputs({ ...options, cloudflareOwnedByNitro: true })
+
+    expect(existsSync(workerPath)).toBe(false)
+    expect(existsSync(join(cloudflareOutput, "wrangler.json"))).toBe(false)
   })
 
   it("omits Cloudflare bucket bindings when none are configured", { timeout: 15_000 }, async () => {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -319,6 +319,21 @@ describe("Vite provider outputs", () => {
     expect(existsSync(join(cloudflareOutput, "wrangler.json"))).toBe(false)
   })
 
+  it("cleans standalone R2 bindings after another primitive replaces the Worker", { timeout: 30_000 }, async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-shared-worker-")
+    const outputRoot = join(rootDir, "dist", toSafeAppName(rootDir))
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
+    const options = { blob: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" }, clientOutDir: "dist", rootDir } as const
+    await generateProviderOutputs(options)
+    await writeFile(join(outputRoot, "index.js"), "// workflow worker\n", "utf8")
+
+    await generateProviderOutputs({ ...options, cloudflareOwnedByNitro: true })
+
+    await expect(readFile(join(outputRoot, "index.js"), "utf8")).resolves.toBe("// workflow worker\n")
+    expect(await readFile(join(outputRoot, "wrangler.json"), "utf8").then(JSON.parse)).not.toHaveProperty("r2_buckets")
+  })
+
   it("omits Cloudflare bucket bindings when none are configured", { timeout: 15_000 }, async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-no-bucket-")
     await mkdir(join(rootDir, "src"), { recursive: true })

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -334,6 +334,29 @@ describe("Vite provider outputs", () => {
     expect(await readFile(join(outputRoot, "wrangler.json"), "utf8").then(JSON.parse)).toHaveProperty("r2_buckets")
   })
 
+  it("cleans standalone Cloudflare output when Blob becomes local under Nitro", { timeout: 30_000 }, async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-local-nitro-")
+    const outputRoot = join(rootDir, "dist", toSafeAppName(rootDir))
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
+    await generateProviderOutputs({
+      blob: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+      clientOutDir: "dist",
+      rootDir,
+    })
+
+    await generateProviderOutputs({
+      blob: { driver: "fs" },
+      clientOutDir: "dist",
+      cloudflareOwnedByNitro: true,
+      rootDir,
+    })
+
+    expect(existsSync(join(outputRoot, "index.js"))).toBe(false)
+    expect(existsSync(join(outputRoot, "wrangler.json"))).toBe(false)
+    expect(existsSync(join(rootDir, ".vitehub", "blob", "cloudflare-output.json"))).toBe(false)
+  })
+
   it("omits Cloudflare bucket bindings when none are configured", { timeout: 15_000 }, async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-no-bucket-")
     await mkdir(join(rootDir, "src"), { recursive: true })

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -201,6 +201,21 @@ describe("hubBlob", () => {
     expect(nitroPlugin).not.toContain("cloudflare:workers")
   })
 
+  it("removes an early R2 contribution when the final Nitro host changes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-final-nitro-cleanup-"))
+    const plugin = hubBlob({ binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" })
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown
+    const configResolved = plugin.configResolved as (config: unknown) => void | Promise<void>
+    const value = { nitro: { preset: "cloudflare_module" }, plugins: [{ name: "nitro:main" }], root }
+
+    config(value, { command: "build" })
+    ;(value.nitro as Record<string, unknown>).preset = "vercel"
+    const resolved = { ...value, build: { outDir: "dist" } }
+    await configResolved(resolved as never)
+
+    expect(resolved).not.toHaveProperty("nitro.cloudflare.wrangler.r2_buckets.0")
+  })
+
   it("does not contribute Cloudflare config for plain Vite or non-R2 stores", { timeout: 30_000 }, async () => {
     const config = (plugin: ReturnType<typeof hubBlob>, value: Record<string, unknown>) =>
       (plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown)(value, { command: "build" })

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -201,6 +201,19 @@ describe("hubBlob", () => {
     expect(nitroPlugin).not.toContain("cloudflare:workers")
   })
 
+  it("does not yield Cloudflare output to a non-Cloudflare Nitro host", async () => {
+    const plugin = hubBlob({ binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" })
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown
+    const value = {
+      nitro: { cloudflare: { wrangler: { routes: ["example.com/*"] } }, preset: "vercel" },
+      plugins: [{ name: "nitro:main" }],
+    }
+
+    config(value, { command: "build" })
+
+    expect(value).not.toHaveProperty("nitro.cloudflare.wrangler.r2_buckets")
+  })
+
   it("removes an early R2 contribution when the final Nitro host changes", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-blob-final-nitro-cleanup-"))
     const plugin = hubBlob({ binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" })

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -1,8 +1,10 @@
+import { existsSync } from "node:fs"
 import { mkdtemp, readFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { describe, expect, it } from "vitest"
+import { toSafeAppName } from "@vite-hub/internal/build/user-entry"
 
 import { BLOB_VIRTUAL_CONFIG_ID, hubBlob } from "../src/vite.ts"
 
@@ -88,6 +90,141 @@ describe("hubBlob", () => {
     expect(nitroPlugin).toContain('"base":".runtime/blob"')
     expect(nitroPlugin).not.toContain("#vitehub/blob/config")
     expect(nitroPlugin).toContain("setBlobRuntimeConfig(blobConfig)")
+  })
+
+  it("contributes deduplicated R2 bindings when Nitro owns Cloudflare output", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-nitro-r2-"))
+    const plugin = hubBlob({
+      stores: {
+        default: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+        assets: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+        assetsAlias: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+      },
+    })
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown
+    const configResolved = plugin.configResolved as (config: unknown) => void | Promise<void>
+    const userConfig = { nitro: { preset: "cloudflare_module" }, plugins: [{ name: "nitro:main" }] }
+
+    config(userConfig, { command: "build" })
+    expect(userConfig).toHaveProperty("nitro.cloudflare.wrangler.r2_buckets", [
+      { binding: "ASSETS", bucket_name: "assets" },
+    ])
+
+    const resolved = {
+      blob: {
+        stores: {
+          default: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+          assets: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+          assetsAlias: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+        },
+      },
+      build: { outDir: "dist" },
+      nitro: {
+        ...(userConfig as { nitro?: object }).nitro,
+        cloudflare: {
+          wrangler: {
+            compatibility_flags: ["custom"],
+            r2_buckets: [{ binding: "ASSETS", bucket_name: "assets", jurisdiction: "eu" }],
+            routes: ["example.com/*"],
+          },
+        },
+        preset: "cloudflare_module",
+      },
+      plugins: [{ name: "nitro:main" }],
+      root,
+    }
+    await configResolved(resolved as never)
+
+    expect(resolved).toHaveProperty("nitro.cloudflare.wrangler.r2_buckets", [
+      { binding: "ASSETS", bucket_name: "assets", jurisdiction: "eu" },
+    ])
+    expect(resolved).toHaveProperty("nitro.cloudflare.wrangler.routes", ["example.com/*"])
+    expect(resolved).toHaveProperty("nitro.cloudflare.wrangler.compatibility_flags", ["custom", "nodejs_compat"])
+    expect(resolved).toHaveProperty("nitro.rollupConfig.external", ["cloudflare:workers"])
+    expect(resolved).not.toHaveProperty("nitro.cloudflare.wrangler.observability")
+  })
+
+  it("uses Cloudflare defaults for the Nitro runtime when hosting is inferred", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-inferred-cloudflare-"))
+    const previousBucket = process.env.BLOB_BUCKET_NAME
+    const previousHosting = process.env.VITEHUB_HOSTING
+    process.env.BLOB_BUCKET_NAME = "assets"
+    process.env.VITEHUB_HOSTING = "cloudflare"
+    try {
+      const plugin = hubBlob()
+      const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown
+      const configResolved = plugin.configResolved as (config: unknown) => void | Promise<void>
+      const value = { nitro: {}, build: { outDir: "dist" }, plugins: [{ name: "nitro:main" }], root }
+
+      config(value, { command: "build" })
+      await configResolved(value as never)
+
+      expect(value).toHaveProperty("nitro.cloudflare.wrangler.r2_buckets", [
+        { binding: "BLOB", bucket_name: "assets" },
+      ])
+      const nitroPlugin = await readFile(join(root, ".vitehub", "nitro", "blob", "plugin.ts"), "utf8")
+      expect(nitroPlugin).toContain('"driver":"cloudflare-r2"')
+      expect(nitroPlugin).toContain('"bucketName":"assets"')
+      expect(nitroPlugin).toContain("import { env as vitehubEnv } from 'cloudflare:workers'")
+      expect(nitroPlugin).toContain("setActiveCloudflareEnv(vitehubEnv)")
+      expect(nitroPlugin).toContain("hooks.hook('request'")
+      expect(nitroPlugin).toContain("event.context?._platform?.cloudflare?.env")
+      expect(nitroPlugin).toContain("event.node?.req?.runtime?.cloudflare?.env ?? vitehubEnv")
+    }
+    finally {
+      if (typeof previousBucket === "undefined") delete process.env.BLOB_BUCKET_NAME
+      else process.env.BLOB_BUCKET_NAME = previousBucket
+      if (typeof previousHosting === "undefined") delete process.env.VITEHUB_HOSTING
+      else process.env.VITEHUB_HOSTING = previousHosting
+    }
+  })
+
+  it("uses final Nitro ownership when the resolved preset changes", { timeout: 30_000 }, async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-final-nitro-host-"))
+    const plugin = hubBlob({ binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" })
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown
+    const configResolved = plugin.configResolved as (config: unknown) => void | Promise<void>
+    const closeBundle = plugin.closeBundle as () => void | Promise<void>
+    const value = { nitro: { preset: "cloudflare_module" }, plugins: [{ name: "nitro:main" }] }
+
+    config(value, { command: "build" })
+    await configResolved({
+      build: { outDir: "dist/client" },
+      nitro: { cloudflare: { wrangler: { routes: ["inactive.example/*"] } }, preset: "vercel" },
+      plugins: [{ name: "nitro:main" }],
+      root,
+    } as never)
+    await closeBundle()
+
+    expect(existsSync(join(root, "dist", toSafeAppName(root), "index.js"))).toBe(true)
+    const nitroPlugin = await readFile(join(root, ".vitehub", "nitro", "blob", "plugin.ts"), "utf8")
+    expect(nitroPlugin).not.toContain("cloudflare:workers")
+  })
+
+  it("does not contribute Cloudflare config for plain Vite or non-R2 stores", { timeout: 30_000 }, async () => {
+    const config = (plugin: ReturnType<typeof hubBlob>, value: Record<string, unknown>) =>
+      (plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown)(value, { command: "build" })
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-plain-vite-"))
+    const previousPreset = process.env.NITRO_PRESET
+    process.env.NITRO_PRESET = "cloudflare_module"
+    try {
+      const plugin = hubBlob({ binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" })
+      const plainVite = { build: { outDir: "dist" }, root }
+      config(plugin, plainVite)
+      expect(plainVite).not.toHaveProperty("nitro.cloudflare")
+      await (plugin.configResolved as (config: unknown) => void | Promise<void>)(plainVite as never)
+      await (plugin.closeBundle as () => void | Promise<void>)()
+      expect(existsSync(join(root, "dist", toSafeAppName(root), "index.js"))).toBe(true)
+    }
+    finally {
+      if (typeof previousPreset === "undefined") delete process.env.NITRO_PRESET
+      else process.env.NITRO_PRESET = previousPreset
+    }
+
+    const fsOnCloudflare = { nitro: { preset: "cloudflare_module" }, plugins: [{ name: "nitro:main" }] }
+    config(hubBlob({ base: ".data/blob", driver: "fs" }), fsOnCloudflare)
+    expect(fsOnCloudflare).not.toHaveProperty("nitro.cloudflare.wrangler.r2_buckets")
+    expect(fsOnCloudflare).toHaveProperty("nitro.cloudflare.wrangler.compatibility_flags", ["nodejs_compat"])
   })
 
   it("masks credentials embedded in Nitro runtime setup", async () => {

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -211,6 +211,7 @@ describe("hubBlob", () => {
     config(value, { command: "build" })
     ;(value.nitro as Record<string, unknown>).preset = "vercel"
     const resolved = { ...value, build: { outDir: "dist" } }
+    delete (resolved as Record<symbol, unknown>)[Symbol.for("vitehub.cloudflareProviderOutput")]
     await configResolved(resolved as never)
 
     expect(resolved).not.toHaveProperty("nitro.cloudflare.wrangler.r2_buckets.0")

--- a/packages/internal/src/build/cloudflare-provider-output.ts
+++ b/packages/internal/src/build/cloudflare-provider-output.ts
@@ -34,6 +34,7 @@ interface CloudflareProviderOutputContribution {
 }
 
 interface CloudflareProviderOutputCatalog {
+  appliedByOwner: Map<string, CloudflareProviderOutputContribution>
   contributionsByOwner: Map<string, CloudflareProviderOutputContribution>
 }
 
@@ -56,7 +57,7 @@ function cloneProviderValue(value: unknown): unknown {
 
 function useCloudflareProviderOutput(config: object): CloudflareProviderOutputCatalog {
   const owner = config as Record<symbol, CloudflareProviderOutputCatalog | undefined>
-  return (owner[cloudflareProviderOutputKey] ??= { contributionsByOwner: new Map() })
+  return (owner[cloudflareProviderOutputKey] ??= { appliedByOwner: new Map(), contributionsByOwner: new Map() })
 }
 
 export function registerCloudflareProviderOutput(config: object, owner: string, contribution: CloudflareProviderOutputContribution): void {
@@ -79,7 +80,29 @@ function compatibleEntries<T extends Record<string, unknown>>(existing: unknown,
   })
 }
 
-function mergeContribution(wrangler: Record<string, unknown>, owner: string, contribution: CloudflareProviderOutputContribution): Record<string, unknown> {
+function removeEntries(existing: unknown, entries: Array<Record<string, unknown>> | undefined): unknown[] {
+  if (!Array.isArray(existing) || !entries?.length) return Array.isArray(existing) ? existing : []
+  return existing.filter(entry => !entries.some(previous => isDeepStrictEqual(entry, previous)))
+}
+
+function removeContribution(wrangler: Record<string, unknown>, contribution: CloudflareProviderOutputContribution): Record<string, unknown> {
+  const queues = cloneProviderRecord(wrangler.queues)
+  const hasQueues = Boolean(contribution.queues?.consumers?.length || contribution.queues?.producers?.length)
+  return {
+    ...wrangler,
+    ...(hasQueues ? {
+      queues: {
+        ...queues,
+        consumers: removeEntries(queues.consumers, contribution.queues?.consumers),
+        producers: removeEntries(queues.producers, contribution.queues?.producers),
+      },
+    } : {}),
+    ...(contribution.r2Buckets?.length ? { r2_buckets: removeEntries(wrangler.r2_buckets, contribution.r2Buckets) } : {}),
+    ...(contribution.rateLimits?.length ? { ratelimits: removeEntries(wrangler.ratelimits, contribution.rateLimits) } : {}),
+  }
+}
+
+function mergeContribution(wrangler: Record<string, unknown>, owner: string, contribution: CloudflareProviderOutputContribution): [Record<string, unknown>, CloudflareProviderOutputContribution] {
   const queues = cloneProviderRecord(wrangler.queues)
   const consumers = compatibleEntries(queues.consumers, contribution.queues?.consumers, "queue", [], owner)
   const producers = compatibleEntries(queues.producers, contribution.queues?.producers, "binding", ["queue"], owner)
@@ -98,7 +121,7 @@ function mergeContribution(wrangler: Record<string, unknown>, owner: string, con
       },
     },
   )
-  return mergeProviderOutputConfig(
+  return [mergeProviderOutputConfig(
     wrangler,
     {
       ...(Object.keys(nextQueues).length ? { queues: nextQueues } : {}),
@@ -111,15 +134,24 @@ function mergeContribution(wrangler: Record<string, unknown>, owner: string, con
         ratelimits: { key: "name" },
       },
     },
-  )
+  ), {
+    queues: { consumers, producers },
+    r2Buckets,
+    rateLimits,
+  }]
 }
 
 export function composeNitroCloudflareProviderOutput(config: object, value: unknown): Record<string, unknown> {
   const nitro = cloneRecord(value)
   const cloudflare = cloneRecord(nitro.cloudflare)
+  const catalog = useCloudflareProviderOutput(config)
   let wrangler = cloneProviderRecord(cloudflare.wrangler)
-  for (const [owner, contribution] of useCloudflareProviderOutput(config).contributionsByOwner) {
-    wrangler = mergeContribution(wrangler, owner, contribution)
+  for (const contribution of catalog.appliedByOwner.values()) wrangler = removeContribution(wrangler, contribution)
+  catalog.appliedByOwner.clear()
+  for (const [owner, contribution] of catalog.contributionsByOwner) {
+    const [merged, applied] = mergeContribution(wrangler, owner, contribution)
+    wrangler = merged
+    catalog.appliedByOwner.set(owner, applied)
   }
   return { ...nitro, cloudflare: { ...cloudflare, wrangler } }
 }

--- a/packages/internal/src/build/cloudflare-provider-output.ts
+++ b/packages/internal/src/build/cloudflare-provider-output.ts
@@ -40,13 +40,17 @@ interface CloudflareProviderOutputCatalog {
 const cloudflareProviderOutputKey = Symbol.for("vitehub.cloudflareProviderOutput")
 
 function cloneRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {}
+}
+
+function cloneProviderRecord(value: unknown): Record<string, unknown> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {}
   return Object.fromEntries(Object.entries(value).flatMap(([key, entry]) => typeof entry === "undefined" ? [] : [[key, cloneProviderValue(entry)]]))
 }
 
 function cloneProviderValue(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(entry => typeof entry === "undefined" ? null : cloneProviderValue(entry))
-  if (value && typeof value === "object") return cloneRecord(value)
+  if (value && typeof value === "object") return cloneProviderRecord(value)
   return value
 }
 
@@ -60,7 +64,7 @@ export function registerCloudflareProviderOutput(config: object, owner: string, 
 }
 
 function compatibleEntries<T extends Record<string, unknown>>(existing: unknown, incoming: T[] | undefined, identityKey: keyof T & string, conflictKeys: Array<keyof T & string>, owner: string): T[] {
-  const current = Array.isArray(existing) ? existing.map(cloneRecord) : []
+  const current = Array.isArray(existing) ? existing.map(cloneProviderRecord) : []
   return (incoming ?? []).filter((entry) => {
     const identity = entry[identityKey]
     const match = current.find((candidate) => candidate[identityKey] === identity)
@@ -76,7 +80,7 @@ function compatibleEntries<T extends Record<string, unknown>>(existing: unknown,
 }
 
 function mergeContribution(wrangler: Record<string, unknown>, owner: string, contribution: CloudflareProviderOutputContribution): Record<string, unknown> {
-  const queues = cloneRecord(wrangler.queues)
+  const queues = cloneProviderRecord(wrangler.queues)
   const consumers = compatibleEntries(queues.consumers, contribution.queues?.consumers, "queue", [], owner)
   const producers = compatibleEntries(queues.producers, contribution.queues?.producers, "binding", ["queue"], owner)
   const r2Buckets = compatibleEntries(wrangler.r2_buckets, contribution.r2Buckets, "binding", ["bucket_name"], owner)
@@ -113,7 +117,7 @@ function mergeContribution(wrangler: Record<string, unknown>, owner: string, con
 export function composeNitroCloudflareProviderOutput(config: object, value: unknown): Record<string, unknown> {
   const nitro = cloneRecord(value)
   const cloudflare = cloneRecord(nitro.cloudflare)
-  let wrangler = cloneRecord(cloudflare.wrangler)
+  let wrangler = cloneProviderRecord(cloudflare.wrangler)
   for (const [owner, contribution] of useCloudflareProviderOutput(config).contributionsByOwner) {
     wrangler = mergeContribution(wrangler, owner, contribution)
   }

--- a/packages/internal/src/build/cloudflare-provider-output.ts
+++ b/packages/internal/src/build/cloudflare-provider-output.ts
@@ -89,15 +89,20 @@ function removeEntries(existing: unknown, entries: Array<Record<string, unknown>
 function removeContribution(wrangler: Record<string, unknown>, contribution: CloudflareProviderOutputContribution): Record<string, unknown> {
   const queues = cloneProviderRecord(wrangler.queues)
   const hasQueues = Boolean(contribution.queues?.consumers?.length || contribution.queues?.producers?.length)
+  if (contribution.queues?.consumers?.length) {
+    const consumers = removeEntries(queues.consumers, contribution.queues.consumers)
+    if (consumers.length) queues.consumers = consumers
+    else delete queues.consumers
+  }
+  if (contribution.queues?.producers?.length) {
+    const producers = removeEntries(queues.producers, contribution.queues.producers)
+    if (producers.length) queues.producers = producers
+    else delete queues.producers
+  }
+  const { queues: _queues, ...withoutQueues } = wrangler
   return {
-    ...wrangler,
-    ...(hasQueues ? {
-      queues: {
-        ...queues,
-        consumers: removeEntries(queues.consumers, contribution.queues?.consumers),
-        producers: removeEntries(queues.producers, contribution.queues?.producers),
-      },
-    } : {}),
+    ...(hasQueues ? withoutQueues : wrangler),
+    ...(hasQueues && Object.keys(queues).length ? { queues } : {}),
     ...(contribution.r2Buckets?.length ? { r2_buckets: removeEntries(wrangler.r2_buckets, contribution.r2Buckets) } : {}),
     ...(contribution.rateLimits?.length ? { ratelimits: removeEntries(wrangler.ratelimits, contribution.rateLimits) } : {}),
   }

--- a/packages/internal/src/build/cloudflare-provider-output.ts
+++ b/packages/internal/src/build/cloudflare-provider-output.ts
@@ -40,7 +40,14 @@ interface CloudflareProviderOutputCatalog {
 const cloudflareProviderOutputKey = Symbol.for("vitehub.cloudflareProviderOutput")
 
 function cloneRecord(value: unknown): Record<string, unknown> {
-  return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {}
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {}
+  return Object.fromEntries(Object.entries(value).flatMap(([key, entry]) => typeof entry === "undefined" ? [] : [[key, cloneProviderValue(entry)]]))
+}
+
+function cloneProviderValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(entry => typeof entry === "undefined" ? null : cloneProviderValue(entry))
+  if (value && typeof value === "object") return cloneRecord(value)
+  return value
 }
 
 function useCloudflareProviderOutput(config: object): CloudflareProviderOutputCatalog {

--- a/packages/internal/src/build/cloudflare-provider-output.ts
+++ b/packages/internal/src/build/cloudflare-provider-output.ts
@@ -24,7 +24,7 @@ interface CloudflareRateLimit {
   [key: string]: unknown
 }
 
-export interface CloudflareProviderOutputContribution {
+interface CloudflareProviderOutputContribution {
   queues?: {
     consumers?: CloudflareQueueConsumer[]
     producers?: CloudflareQueueProducer[]

--- a/packages/internal/src/build/cloudflare-provider-output.ts
+++ b/packages/internal/src/build/cloudflare-provider-output.ts
@@ -153,5 +153,6 @@ export function composeNitroCloudflareProviderOutput(config: object, value: unkn
     wrangler = merged
     catalog.appliedByOwner.set(owner, applied)
   }
+  if (!Object.keys(cloudflare).length && !Object.keys(wrangler).length) return nitro
   return { ...nitro, cloudflare: { ...cloudflare, wrangler } }
 }

--- a/packages/internal/src/build/cloudflare-provider-output.ts
+++ b/packages/internal/src/build/cloudflare-provider-output.ts
@@ -39,6 +39,7 @@ interface CloudflareProviderOutputCatalog {
 }
 
 const cloudflareProviderOutputKey = Symbol.for("vitehub.cloudflareProviderOutput")
+const cloudflareProviderOutputByNitro = new WeakMap<object, CloudflareProviderOutputCatalog>()
 
 function cloneRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {}
@@ -145,6 +146,11 @@ export function composeNitroCloudflareProviderOutput(config: object, value: unkn
   const nitro = cloneRecord(value)
   const cloudflare = cloneRecord(nitro.cloudflare)
   const catalog = useCloudflareProviderOutput(config)
+  const inherited = value && typeof value === "object" ? cloudflareProviderOutputByNitro.get(value) : undefined
+  if (inherited && inherited !== catalog) {
+    for (const [owner, contribution] of inherited.appliedByOwner) catalog.appliedByOwner.set(owner, contribution)
+    catalog.contributionsByOwner = new Map([...inherited.contributionsByOwner, ...catalog.contributionsByOwner])
+  }
   let wrangler = cloneProviderRecord(cloudflare.wrangler)
   for (const contribution of catalog.appliedByOwner.values()) wrangler = removeContribution(wrangler, contribution)
   catalog.appliedByOwner.clear()
@@ -153,6 +159,9 @@ export function composeNitroCloudflareProviderOutput(config: object, value: unkn
     wrangler = merged
     catalog.appliedByOwner.set(owner, applied)
   }
-  if (!Object.keys(cloudflare).length && !Object.keys(wrangler).length) return nitro
-  return { ...nitro, cloudflare: { ...cloudflare, wrangler } }
+  const output = !Object.keys(cloudflare).length && !Object.keys(wrangler).length
+    ? nitro
+    : { ...nitro, cloudflare: { ...cloudflare, wrangler } }
+  cloudflareProviderOutputByNitro.set(output, catalog)
+  return output
 }

--- a/packages/internal/src/build/cloudflare-provider-output.ts
+++ b/packages/internal/src/build/cloudflare-provider-output.ts
@@ -1,0 +1,114 @@
+import { isDeepStrictEqual } from "node:util"
+
+import { mergeProviderOutputConfig } from "./provider-output-config.ts"
+
+interface CloudflareQueueConsumer {
+  queue: string
+  [key: string]: unknown
+}
+
+interface CloudflareQueueProducer {
+  binding: string
+  queue: string
+  [key: string]: unknown
+}
+
+interface CloudflareR2Bucket {
+  binding: string
+  bucket_name: string
+  [key: string]: unknown
+}
+
+interface CloudflareRateLimit {
+  name: string
+  [key: string]: unknown
+}
+
+export interface CloudflareProviderOutputContribution {
+  queues?: {
+    consumers?: CloudflareQueueConsumer[]
+    producers?: CloudflareQueueProducer[]
+  }
+  r2Buckets?: CloudflareR2Bucket[]
+  rateLimits?: CloudflareRateLimit[]
+}
+
+interface CloudflareProviderOutputCatalog {
+  contributionsByOwner: Map<string, CloudflareProviderOutputContribution>
+}
+
+const cloudflareProviderOutputKey = Symbol.for("vitehub.cloudflareProviderOutput")
+
+function cloneRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {}
+}
+
+function useCloudflareProviderOutput(config: object): CloudflareProviderOutputCatalog {
+  const owner = config as Record<symbol, CloudflareProviderOutputCatalog | undefined>
+  return (owner[cloudflareProviderOutputKey] ??= { contributionsByOwner: new Map() })
+}
+
+export function registerCloudflareProviderOutput(config: object, owner: string, contribution: CloudflareProviderOutputContribution): void {
+  useCloudflareProviderOutput(config).contributionsByOwner.set(owner, contribution)
+}
+
+function compatibleEntries<T extends Record<string, unknown>>(existing: unknown, incoming: T[] | undefined, identityKey: keyof T & string, conflictKeys: Array<keyof T & string>, owner: string): T[] {
+  const current = Array.isArray(existing) ? existing.map(cloneRecord) : []
+  return (incoming ?? []).filter((entry) => {
+    const identity = entry[identityKey]
+    const match = current.find((candidate) => candidate[identityKey] === identity)
+    if (!match) {
+      current.push(entry)
+      return true
+    }
+    if (conflictKeys.some((key) => !isDeepStrictEqual(match[key], entry[key]))) {
+      throw new Error(`[vitehub] Cloudflare ${identityKey} ${JSON.stringify(identity)} from ${owner} is already assigned to an incompatible resource.`)
+    }
+    return false
+  })
+}
+
+function mergeContribution(wrangler: Record<string, unknown>, owner: string, contribution: CloudflareProviderOutputContribution): Record<string, unknown> {
+  const queues = cloneRecord(wrangler.queues)
+  const consumers = compatibleEntries(queues.consumers, contribution.queues?.consumers, "queue", [], owner)
+  const producers = compatibleEntries(queues.producers, contribution.queues?.producers, "binding", ["queue"], owner)
+  const r2Buckets = compatibleEntries(wrangler.r2_buckets, contribution.r2Buckets, "binding", ["bucket_name"], owner)
+  const rateLimits = compatibleEntries(wrangler.ratelimits, contribution.rateLimits, "name", ["namespace_id", "simple"], owner)
+  const nextQueues = mergeProviderOutputConfig(
+    queues,
+    {
+      ...(consumers.length ? { consumers } : {}),
+      ...(producers.length ? { producers } : {}),
+    },
+    {
+      arrays: {
+        consumers: { key: "queue" },
+        producers: { key: "binding" },
+      },
+    },
+  )
+  return mergeProviderOutputConfig(
+    wrangler,
+    {
+      ...(Object.keys(nextQueues).length ? { queues: nextQueues } : {}),
+      ...(r2Buckets.length ? { r2_buckets: r2Buckets } : {}),
+      ...(rateLimits.length ? { ratelimits: rateLimits } : {}),
+    },
+    {
+      arrays: {
+        r2_buckets: { key: "binding" },
+        ratelimits: { key: "name" },
+      },
+    },
+  )
+}
+
+export function composeNitroCloudflareProviderOutput(config: object, value: unknown): Record<string, unknown> {
+  const nitro = cloneRecord(value)
+  const cloudflare = cloneRecord(nitro.cloudflare)
+  let wrangler = cloneRecord(cloudflare.wrangler)
+  for (const [owner, contribution] of useCloudflareProviderOutput(config).contributionsByOwner) {
+    wrangler = mergeContribution(wrangler, owner, contribution)
+  }
+  return { ...nitro, cloudflare: { ...cloudflare, wrangler } }
+}

--- a/packages/internal/src/build/cloudflare-provider-output.ts
+++ b/packages/internal/src/build/cloudflare-provider-output.ts
@@ -151,7 +151,9 @@ export function composeNitroCloudflareProviderOutput(config: object, value: unkn
   const nitro = cloneRecord(value)
   const cloudflare = cloneRecord(nitro.cloudflare)
   const catalog = useCloudflareProviderOutput(config)
-  const inherited = value && typeof value === "object" ? cloudflareProviderOutputByNitro.get(value) : undefined
+  const inherited = value && typeof value === "object"
+    ? (value as Record<symbol, CloudflareProviderOutputCatalog | undefined>)[cloudflareProviderOutputKey] ?? cloudflareProviderOutputByNitro.get(value)
+    : undefined
   if (inherited && inherited !== catalog) {
     for (const [owner, contribution] of inherited.appliedByOwner) catalog.appliedByOwner.set(owner, contribution)
     catalog.contributionsByOwner = new Map([...inherited.contributionsByOwner, ...catalog.contributionsByOwner])
@@ -167,6 +169,7 @@ export function composeNitroCloudflareProviderOutput(config: object, value: unkn
   const output = !Object.keys(cloudflare).length && !Object.keys(wrangler).length
     ? nitro
     : { ...nitro, cloudflare: { ...cloudflare, wrangler } }
+  Object.defineProperty(output, cloudflareProviderOutputKey, { enumerable: true, value: catalog })
   cloudflareProviderOutputByNitro.set(output, catalog)
   return output
 }

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -10,6 +10,7 @@ import { createNodeFunctionConfig, createVercelConfigJson } from "./vercel-confi
 import type { ProviderOutputConfigOwnership } from "./provider-output-config.ts"
 
 export { createDefaultCloudflareOutputRoot } from "./cloudflare.ts"
+export { composeNitroCloudflareProviderOutput, registerCloudflareProviderOutput } from "./cloudflare-provider-output.ts"
 export { shouldSkipViteProviderBuild } from "./vite.ts"
 
 type BundleOptions = NonNullable<Parameters<typeof bundleEsmEntry>[2]>

--- a/packages/internal/src/build/esbuild.ts
+++ b/packages/internal/src/build/esbuild.ts
@@ -8,6 +8,7 @@ import { resolveViteHubProjectRoot } from "./vite.ts"
 
 interface BundleEsmEntryOptions {
   alias?: Record<string, string>
+  banner?: string
   conditions?: string[]
   external?: string[]
   format?: "esm" | "cjs"
@@ -239,16 +240,19 @@ export async function bundleEsmEntry(
 
   await bundle({
     alias: aliases,
-    banner: format === "esm" && platform === "node"
+    banner: options.banner || (format === "esm" && platform === "node")
       ? {
           js: [
-            'import { createRequire as __createRequire } from "node:module";',
-            'import { dirname as __vitehubDirname } from "node:path";',
-            'import { fileURLToPath as __vitehubFileURLToPath } from "node:url";',
-            "globalThis.require = __createRequire(import.meta.url);",
-            "globalThis.__filename = __vitehubFileURLToPath(import.meta.url);",
-            "globalThis.__dirname = __vitehubDirname(globalThis.__filename);",
-          ].join("\n"),
+            options.banner,
+            ...(format === "esm" && platform === "node" ? [
+              'import { createRequire as __createRequire } from "node:module";',
+              'import { dirname as __vitehubDirname } from "node:path";',
+              'import { fileURLToPath as __vitehubFileURLToPath } from "node:url";',
+              "globalThis.require = __createRequire(import.meta.url);",
+              "globalThis.__filename = __vitehubFileURLToPath(import.meta.url);",
+              "globalThis.__dirname = __vitehubDirname(globalThis.__filename);",
+            ] : []),
+          ].filter(Boolean).join("\n"),
         }
       : undefined,
     bundle: true,

--- a/packages/internal/src/build/provider-output-config.ts
+++ b/packages/internal/src/build/provider-output-config.ts
@@ -154,12 +154,21 @@ export async function writeProviderOutputConfig(
   options: { removeIfEmpty?: boolean } = {},
 ): Promise<void> {
   const existing = await readProviderJsonRecord(file) ?? {}
+  const next = mergeProviderOutputConfig(existing, value, ownership)
+  await persistProviderJsonRecord(file, next, options.removeIfEmpty === true)
+}
+
+export function mergeProviderOutputConfig(
+  existing: unknown,
+  value: unknown,
+  ownership: ProviderOutputConfigOwnership = {},
+): ProviderJsonRecord {
+  assertProviderJsonRecord(existing)
   assertProviderJsonRecord(value)
-  const next = {
+  return {
     ...deleteOwnedFields(existing, ownership),
     ...mergeOwnedArrays(existing, value, ownership.arrays),
   }
-  await persistProviderJsonRecord(file, next, options.removeIfEmpty === true)
 }
 
 export function stringifyProviderOutputConfig(value: unknown): string {

--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -46,13 +46,17 @@ interface NitroVercelConfig {
   plugins?: readonly { name: string }[]
 }
 
+export function hasNitroVitePlugin(config: { plugins?: readonly { name: string }[] }): boolean {
+  return config.plugins?.some(plugin => plugin.name === "nitro:main") === true
+}
+
 export function resolveNitroVercelFunctionName(
   config: NitroVercelConfig,
   product: string,
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
   const preset = config.nitro?.preset || env.NITRO_PRESET || env.SERVER_PRESET
-  const nitro = Boolean(preset) || config.plugins?.some(plugin => plugin.name === "nitro:main")
+  const nitro = Boolean(preset) || hasNitroVitePlugin(config)
   const clientOutDir = config.environments?.client?.build?.outDir
   const vercel = preset
     ? preset.startsWith("vercel")

--- a/packages/internal/test/cloudflare-provider-output.test.ts
+++ b/packages/internal/test/cloudflare-provider-output.test.ts
@@ -88,6 +88,18 @@ describe("Cloudflare provider output", () => {
     expect(output).not.toHaveProperty("cloudflare.wrangler.compatibility_date")
   })
 
+  it("removes an owner's previously composed entries when recomposing", () => {
+    const config = {}
+    registerCloudflareProviderOutput(config, "queue", { queues: { producers: [{ binding: "OLD", queue: "old" }] } })
+    const first = composeNitroCloudflareProviderOutput(config, { cloudflare: { wrangler: {} } })
+    registerCloudflareProviderOutput(config, "queue", { queues: { producers: [{ binding: "NEW", queue: "new" }] } })
+
+    expect(composeNitroCloudflareProviderOutput(config, first)).toHaveProperty(
+      "cloudflare.wrangler.queues.producers",
+      [{ binding: "NEW", queue: "new" }],
+    )
+  })
+
   it("preserves non-plain Nitro config outside Wrangler composition", () => {
     const config = {}
     const external = /^node:/

--- a/packages/internal/test/cloudflare-provider-output.test.ts
+++ b/packages/internal/test/cloudflare-provider-output.test.ts
@@ -19,32 +19,29 @@ describe("Cloudflare provider output", () => {
       rateLimits: [{ name: "UPLOADS", namespace_id: "1", simple: { limit: 10, period: 60 } }],
     })
 
-    expect(
-      composeNitroCloudflareProviderOutput(config, {
-        cloudflare: {
-          wrangler: {
-            compatibility_date: "2026-07-18",
-            name: undefined,
-            queues: { producers: [{ binding: "USER", queue: "user", delivery_delay: 1 }] },
-            routes: ["example.com/*"],
-          },
-        },
-      }),
-    ).toEqual({
+    const output = composeNitroCloudflareProviderOutput(config, {
       cloudflare: {
         wrangler: {
           compatibility_date: "2026-07-18",
-          queues: {
-            producers: [
-              { binding: "USER", queue: "user", delivery_delay: 1 },
-              { binding: "JOBS", queue: "jobs" },
-              { binding: "EMAILS", queue: "emails" },
-            ],
-          },
-          r2_buckets: [{ binding: "BLOB", bucket_name: "assets" }],
-          ratelimits: [{ name: "UPLOADS", namespace_id: "1", simple: { limit: 10, period: 60 } }],
+          name: undefined,
+          queues: { producers: [{ binding: "USER", queue: "user", delivery_delay: 1 }] },
           routes: ["example.com/*"],
         },
+      },
+    })
+    expect(output.cloudflare).toEqual({
+      wrangler: {
+        compatibility_date: "2026-07-18",
+        queues: {
+          producers: [
+            { binding: "USER", queue: "user", delivery_delay: 1 },
+            { binding: "JOBS", queue: "jobs" },
+            { binding: "EMAILS", queue: "emails" },
+          ],
+        },
+        r2_buckets: [{ binding: "BLOB", bucket_name: "assets" }],
+        ratelimits: [{ name: "UPLOADS", namespace_id: "1", simple: { limit: 10, period: 60 } }],
+        routes: ["example.com/*"],
       },
     })
   })
@@ -101,6 +98,19 @@ describe("Cloudflare provider output", () => {
     )
     registerCloudflareProviderOutput(config, "queue", {})
     expect(composeNitroCloudflareProviderOutput(config, second)).not.toHaveProperty("cloudflare.wrangler.queues")
+  })
+
+  it("carries applied ownership through copied Nitro configs", () => {
+    const firstConfig = {}
+    registerCloudflareProviderOutput(firstConfig, "queue", {
+      queues: { producers: [{ binding: "OLD", queue: "old" }] },
+    })
+    const first = composeNitroCloudflareProviderOutput(firstConfig, {})
+    const copied = { ...first, cloudflare: { ...(first.cloudflare as object) } }
+    const finalConfig = {}
+    registerCloudflareProviderOutput(finalConfig, "queue", {})
+
+    expect(composeNitroCloudflareProviderOutput(finalConfig, copied)).not.toHaveProperty("cloudflare.wrangler.queues")
   })
 
   it("preserves non-plain Nitro config outside Wrangler composition", () => {

--- a/packages/internal/test/cloudflare-provider-output.test.ts
+++ b/packages/internal/test/cloudflare-provider-output.test.ts
@@ -24,6 +24,7 @@ describe("Cloudflare provider output", () => {
         cloudflare: {
           wrangler: {
             compatibility_date: "2026-07-18",
+            name: undefined,
             queues: { producers: [{ binding: "USER", queue: "user", delivery_delay: 1 }] },
             routes: ["example.com/*"],
           },

--- a/packages/internal/test/cloudflare-provider-output.test.ts
+++ b/packages/internal/test/cloudflare-provider-output.test.ts
@@ -87,4 +87,25 @@ describe("Cloudflare provider output", () => {
     expect(output).toHaveProperty("cloudflare.wrangler.observability.enabled", false)
     expect(output).not.toHaveProperty("cloudflare.wrangler.compatibility_date")
   })
+
+  it("preserves non-plain Nitro config outside Wrangler composition", () => {
+    const config = {}
+    const external = /^node:/
+    const buildBefore = () => undefined
+    const hooks = { "build:before": buildBefore }
+    const rollupConfig = { external }
+    registerCloudflareProviderOutput(config, "queue", {
+      queues: { producers: [{ binding: "JOBS", queue: "jobs" }] },
+    })
+
+    const output = composeNitroCloudflareProviderOutput(config, {
+      cloudflare: { wrangler: { name: undefined } },
+      hooks,
+      rollupConfig,
+    })
+
+    expect(output.hooks).toBe(hooks)
+    expect(output.rollupConfig).toBe(rollupConfig)
+    expect(output).not.toHaveProperty("cloudflare.wrangler.name")
+  })
 })

--- a/packages/internal/test/cloudflare-provider-output.test.ts
+++ b/packages/internal/test/cloudflare-provider-output.test.ts
@@ -94,10 +94,13 @@ describe("Cloudflare provider output", () => {
     const first = composeNitroCloudflareProviderOutput(config, { cloudflare: { wrangler: {} } })
     registerCloudflareProviderOutput(config, "queue", { queues: { producers: [{ binding: "NEW", queue: "new" }] } })
 
-    expect(composeNitroCloudflareProviderOutput(config, first)).toHaveProperty(
+    const second = composeNitroCloudflareProviderOutput(config, first)
+    expect(second).toHaveProperty(
       "cloudflare.wrangler.queues.producers",
       [{ binding: "NEW", queue: "new" }],
     )
+    registerCloudflareProviderOutput(config, "queue", {})
+    expect(composeNitroCloudflareProviderOutput(config, second)).not.toHaveProperty("cloudflare.wrangler.queues")
   })
 
   it("preserves non-plain Nitro config outside Wrangler composition", () => {

--- a/packages/internal/test/cloudflare-provider-output.test.ts
+++ b/packages/internal/test/cloudflare-provider-output.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest"
+
+import { composeNitroCloudflareProviderOutput, registerCloudflareProviderOutput } from "../src/build/cloudflare-provider-output.ts"
+
+describe("Cloudflare provider output", () => {
+  it("composes current ViteHub resources into Nitro's Wrangler config by identity", () => {
+    const config = {}
+    registerCloudflareProviderOutput(config, "queue", {
+      queues: { producers: [{ binding: "JOBS", queue: "jobs" }] },
+    })
+    registerCloudflareProviderOutput(config, "storage", {
+      queues: {
+        producers: [
+          { binding: "JOBS", queue: "jobs" },
+          { binding: "EMAILS", queue: "emails" },
+        ],
+      },
+      r2Buckets: [{ binding: "BLOB", bucket_name: "assets" }],
+      rateLimits: [{ name: "UPLOADS", namespace_id: "1", simple: { limit: 10, period: 60 } }],
+    })
+
+    expect(
+      composeNitroCloudflareProviderOutput(config, {
+        cloudflare: {
+          wrangler: {
+            compatibility_date: "2026-07-18",
+            queues: { producers: [{ binding: "USER", queue: "user", delivery_delay: 1 }] },
+            routes: ["example.com/*"],
+          },
+        },
+      }),
+    ).toEqual({
+      cloudflare: {
+        wrangler: {
+          compatibility_date: "2026-07-18",
+          queues: {
+            producers: [
+              { binding: "USER", queue: "user", delivery_delay: 1 },
+              { binding: "JOBS", queue: "jobs" },
+              { binding: "EMAILS", queue: "emails" },
+            ],
+          },
+          r2_buckets: [{ binding: "BLOB", bucket_name: "assets" }],
+          ratelimits: [{ name: "UPLOADS", namespace_id: "1", simple: { limit: 10, period: 60 } }],
+          routes: ["example.com/*"],
+        },
+      },
+    })
+  })
+
+  it("preserves compatible user resources and rejects conflicting identities", () => {
+    const config = {}
+    registerCloudflareProviderOutput(config, "queue", {
+      queues: { producers: [{ binding: "JOBS", queue: "jobs" }] },
+    })
+
+    expect(
+      composeNitroCloudflareProviderOutput(config, {
+        cloudflare: {
+          wrangler: {
+            queues: { producers: [{ binding: "JOBS", queue: "jobs", delivery_delay: 1 }] },
+          },
+        },
+      }),
+    ).toHaveProperty("cloudflare.wrangler.queues.producers", [{ binding: "JOBS", queue: "jobs", delivery_delay: 1 }])
+    expect(() =>
+      composeNitroCloudflareProviderOutput(config, {
+        cloudflare: { wrangler: { queues: { producers: [{ binding: "JOBS", queue: "other" }] } } },
+      }),
+    ).toThrow(/already assigned/)
+  })
+
+  it("replaces an owner's contribution without changing application policy", () => {
+    const config = {}
+    registerCloudflareProviderOutput(config, "queue", {
+      queues: { consumers: [{ queue: "old" }] },
+    })
+    registerCloudflareProviderOutput(config, "queue", {
+      queues: { consumers: [{ queue: "current" }] },
+    })
+
+    const output = composeNitroCloudflareProviderOutput(config, {
+      cloudflare: { wrangler: { observability: { enabled: false } } },
+    })
+    expect(output).toHaveProperty("cloudflare.wrangler.queues.consumers", [{ queue: "current" }])
+    expect(output).toHaveProperty("cloudflare.wrangler.observability.enabled", false)
+    expect(output).not.toHaveProperty("cloudflare.wrangler.compatibility_date")
+  })
+})

--- a/packages/internal/test/vite-build.test.ts
+++ b/packages/internal/test/vite-build.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest"
 
-import { resolveNitroVercelFunctionName } from "../src/build/vite.ts"
+import { hasNitroVitePlugin, resolveNitroVercelFunctionName } from "../src/build/vite.ts"
 
 describe("Vite provider builds", () => {
+  it("distinguishes the Nitro host plugin from ViteHub bridge plugins", () => {
+    expect(hasNitroVitePlugin({ plugins: [{ name: "nitro:main" }] })).toBe(true)
+    expect(hasNitroVitePlugin({ plugins: [{ name: "@vite-hub/blob/vite" }, { name: "@vite-hub/queue/vite" }] })).toBe(false)
+  })
+
   it("isolates provider functions when Nitro owns the Vercel output", () => {
     const plugins = [{ name: "vitehub" }, { name: "nitro:main" }]
 

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, rm, writeFile } from "node:fs/promises"
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { dirname, relative, resolve } from "node:path"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
@@ -18,7 +18,7 @@ import type { DiscoveredQueueDefinition, QueueModuleOptions, QueueProvider } fro
 import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const queuePackageName = "@vite-hub/queue"
-const cloudflareQueueOutputMarker = ".vitehub-queue-output"
+const cloudflareQueueWorkerMarker = "vitehub-queue-worker"
 const productName = "queue"
 
 const generatedRegistryFileName = "registry.mjs"
@@ -245,12 +245,12 @@ function createCloudflareOutput(artifacts: GeneratedQueueArtifacts): CloudflareP
   return {
     bundleEntry: artifacts.cloudflareWorkerFile,
     bundleOptions: {
+      banner: `// ${cloudflareQueueWorkerMarker}`,
       conditions: ["workerd", "worker", "browser", "default"],
       external: ["@vercel/queue", "node:async_hooks", "node:fs", "node:fs/promises", "node:path", "node:url"],
       format: "esm",
       platform: "neutral",
     },
-    files: { [cloudflareQueueOutputMarker]: "" },
     wranglerConfigKeys: ["queues"],
     wranglerConfig,
   }
@@ -258,19 +258,18 @@ function createCloudflareOutput(artifacts: GeneratedQueueArtifacts): CloudflareP
 
 async function createNitroCloudflareCleanup(rootDir: string) {
   const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
-  let ownsWorker = true
+  let ownsWorker = false
   try {
-    await access(resolve(outputRoot, cloudflareQueueOutputMarker))
+    ownsWorker = (await readFile(resolve(outputRoot, "index.js"), "utf8")).includes(cloudflareQueueWorkerMarker)
   }
   catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
-    ownsWorker = false
   }
   return {
-    fileNames: ownsWorker ? ["index.js", cloudflareQueueOutputMarker] : [cloudflareQueueOutputMarker],
+    fileNames: ownsWorker ? ["index.js"] : [],
     outputRoot,
     wranglerConfigOwnership: {
-      keys: ownsWorker ? ["compatibility_date", "compatibility_flags", "main", "observability", "queues"] : ["queues"],
+      keys: ownsWorker ? ["compatibility_date", "compatibility_flags", "main", "observability", "queues"] : [],
     },
   }
 }

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -256,11 +256,33 @@ function createCloudflareOutput(artifacts: GeneratedQueueArtifacts): CloudflareP
   }
 }
 
+function isLegacyCloudflareQueueWorker(contents: string, wrangler: unknown): boolean {
+  if (!contents.includes("createQueueCloudflareWorker({")
+    || !contents.includes("getCloudflareQueueDefinitionName(batch.queue)")
+    || !contents.includes('label: "queue"')) return false
+  if (!wrangler || typeof wrangler !== "object" || Array.isArray(wrangler)) return false
+  const config = wrangler as Record<string, unknown>
+  const observability = config.observability
+  return config.main === "index.js"
+    && Array.isArray(config.compatibility_flags)
+    && config.compatibility_flags.includes("nodejs_compat")
+    && Boolean(observability)
+    && typeof observability === "object"
+    && !Array.isArray(observability)
+    && (observability as Record<string, unknown>).enabled === true
+}
+
 async function createNitroCloudflareCleanup(rootDir: string) {
   const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
   let ownsWorker = false
   try {
-    ownsWorker = (await readFile(resolve(outputRoot, "index.js"), "utf8")).includes(cloudflareQueueWorkerMarker)
+    const contents = await readFile(resolve(outputRoot, "index.js"), "utf8")
+    if (contents.includes(cloudflareQueueWorkerMarker)) {
+      ownsWorker = true
+    } else {
+      const wrangler = JSON.parse(await readFile(resolve(outputRoot, "wrangler.json"), "utf8")) as unknown
+      ownsWorker = isLegacyCloudflareQueueWorker(contents, wrangler)
+    }
   }
   catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -445,6 +445,9 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     await mkdir(dirname(resolve(options.rootDir, cloudflareQueueOutputState)), { recursive: true })
     await writeFile(resolve(options.rootDir, cloudflareQueueOutputState), `${JSON.stringify({ queues }, null, 2)}\n`, "utf8")
   }
+  else {
+    await rm(resolve(options.rootDir, cloudflareQueueOutputState), { force: true })
+  }
   await writeVercelQueueFunctions(options.rootDir, options.queue, artifacts)
   return artifacts
 }

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -1,8 +1,8 @@
-import { mkdir, rm, writeFile } from "node:fs/promises"
+import { access, mkdir, rm, writeFile } from "node:fs/promises"
 import { dirname, relative, resolve } from "node:path"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
-import { createDefaultVercelOutputRoot, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
+import { createDefaultCloudflareOutputRoot, createDefaultVercelOutputRoot, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { bundleEsmEntry } from "@vite-hub/internal/build/esbuild"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg, toGeneratedPath } from "@vite-hub/internal/build/paths"
 import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
@@ -18,6 +18,7 @@ import type { DiscoveredQueueDefinition, QueueModuleOptions, QueueProvider } fro
 import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const queuePackageName = "@vite-hub/queue"
+const cloudflareQueueOutputMarker = ".vitehub-queue-output"
 const productName = "queue"
 
 const generatedRegistryFileName = "registry.mjs"
@@ -249,8 +250,28 @@ function createCloudflareOutput(artifacts: GeneratedQueueArtifacts): CloudflareP
       format: "esm",
       platform: "neutral",
     },
+    files: { [cloudflareQueueOutputMarker]: "" },
     wranglerConfigKeys: ["queues"],
     wranglerConfig,
+  }
+}
+
+async function createNitroCloudflareCleanup(rootDir: string) {
+  const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
+  let ownsWorker = true
+  try {
+    await access(resolve(outputRoot, cloudflareQueueOutputMarker))
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+    ownsWorker = false
+  }
+  return {
+    fileNames: ownsWorker ? ["index.js", cloudflareQueueOutputMarker] : [cloudflareQueueOutputMarker],
+    outputRoot,
+    wranglerConfigOwnership: {
+      keys: ownsWorker ? ["compatibility_date", "compatibility_flags", "main", "observability", "queues"] : ["queues"],
+    },
   }
 }
 
@@ -366,10 +387,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
       clientOutDir: options.clientOutDir,
       cleanup: {
         cloudflare: options.cloudflareOwnedByNitro
-          ? {
-              fileNames: ["index.js"],
-              wranglerConfigOwnership: { keys: ["compatibility_date", "compatibility_flags", "main", "observability", "queues"] },
-            }
+          ? () => createNitroCloudflareCleanup(options.rootDir)
           : { wranglerConfigOwnership: { keys: ["queues"] } },
       },
       rootDir: options.rootDir,

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -258,7 +258,8 @@ function createCloudflareOutput(artifacts: GeneratedQueueArtifacts): CloudflareP
 function isLegacyCloudflareQueueWorker(contents: string, wrangler: unknown): boolean {
   if (!contents.includes("createQueueCloudflareWorker({")
     || !contents.includes("getCloudflareQueueDefinitionName(batch.queue)")
-    || !contents.includes('label: "queue"')) return false
+    || !contents.includes('label: "queue"')
+    || contents.includes("cloudflare:queue")) return false
   if (!wrangler || typeof wrangler !== "object" || Array.isArray(wrangler)) return false
   const config = wrangler as Record<string, unknown>
   const observability = config.observability

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -77,6 +77,7 @@ interface GeneratedQueueArtifacts {
 interface GenerateProviderOutputsOptions {
   clientOutDir: string
   cloudflareOwnedByNitro?: boolean
+  definitions?: DiscoveredQueueDefinition[]
   queue: QueueModuleOptions | undefined
   rootDir: string
   serverFunctionName?: string
@@ -127,12 +128,11 @@ function renderProviderEntry(spec: ProviderEntrySpec, entryFile: string, registr
   ].filter(Boolean).join("\n")
 }
 
-async function writeProviderEntries(rootDir: string, queue: QueueModuleOptions | undefined) {
+async function writeProviderEntries(rootDir: string, queue: QueueModuleOptions | undefined, definitions = discoverQueueDefinitions({ rootDir })) {
   const generatedDir = ensureGeneratedDir(rootDir, productName)
   await mkdir(generatedDir, { recursive: true })
 
   const registryFile = resolve(generatedDir, generatedRegistryFileName)
-  const definitions = discoverQueueDefinitions({ rootDir })
   const userAppEntry = resolveUserAppEntry(rootDir)
 
   await writeFile(registryFile, createRuntimeRegistryContents(registryFile, definitions), "utf8")
@@ -201,11 +201,10 @@ function renderNitroPlugin(pluginFile: string, registryFile: string, queueConfig
   ].join("\n")
 }
 
-export async function writeQueueNitroIntegration(rootDir: string, queue: QueueModuleOptions | undefined, hosting: string, cloudflareQueues = true): Promise<void> {
+export async function writeQueueNitroIntegration(rootDir: string, queue: QueueModuleOptions | undefined, hosting: string, cloudflareQueues = true, definitions: DiscoveredQueueDefinition[] = discoverQueueDefinitions({ rootDir })): Promise<void> {
   const generatedDir = ensureGeneratedDir(rootDir, productName)
   const registryFile = resolve(generatedDir, generatedRegistryFileName)
   const pluginFile = resolve(rootDir, generatedQueueNitroPlugin)
-  const definitions = discoverQueueDefinitions({ rootDir })
   const queueConfig = resolveOutputQueueConfig(typeof queue === "undefined" ? {} : queue, hosting)
   await Promise.all([
     mkdir(dirname(pluginFile), { recursive: true }),
@@ -400,7 +399,7 @@ async function writeVercelQueueFunctions(rootDir: string, queue: QueueModuleOpti
 }
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedQueueArtifacts> {
-  const artifacts = await writeProviderEntries(options.rootDir, options.queue)
+  const artifacts = await writeProviderEntries(options.rootDir, options.queue, options.definitions)
   const createCloudflare = !options.cloudflareOwnedByNitro && shouldCreateCloudflareOutput(options.queue)
   const createVercel = shouldCreateVercelOutput(options.queue)
   if (!createCloudflare) {

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -400,13 +400,14 @@ async function writeVercelQueueFunctions(rootDir: string, queue: QueueModuleOpti
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedQueueArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.queue, options.definitions)
-  const createCloudflare = !options.cloudflareOwnedByNitro && shouldCreateCloudflareOutput(options.queue)
+  const usesCloudflare = shouldCreateCloudflareOutput(options.queue)
+  const createCloudflare = !options.cloudflareOwnedByNitro && usesCloudflare
   const createVercel = shouldCreateVercelOutput(options.queue)
   if (!createCloudflare) {
     await writeProviderDeploymentOutputs({
       clientOutDir: options.clientOutDir,
       cleanup: {
-        cloudflare: options.cloudflareOwnedByNitro
+        cloudflare: options.cloudflareOwnedByNitro && usesCloudflare
           ? () => createNitroCloudflareCleanup(options.rootDir)
           : { wranglerConfigOwnership: { keys: ["queues"] } },
       },

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -361,11 +361,24 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   const artifacts = await writeProviderEntries(options.rootDir, options.queue)
   const createCloudflare = !options.cloudflareOwnedByNitro && shouldCreateCloudflareOutput(options.queue)
   const createVercel = shouldCreateVercelOutput(options.queue)
+  if (!createCloudflare) {
+    await writeProviderDeploymentOutputs({
+      clientOutDir: options.clientOutDir,
+      cleanup: {
+        cloudflare: options.cloudflareOwnedByNitro
+          ? {
+              fileNames: ["index.js"],
+              wranglerConfigOwnership: { keys: ["compatibility_date", "compatibility_flags", "main", "observability", "queues"] },
+            }
+          : { wranglerConfigOwnership: { keys: ["queues"] } },
+      },
+      rootDir: options.rootDir,
+    })
+  }
   await writeProviderDeploymentOutputs({
     clientOutDir: options.clientOutDir,
     cloudflare: createCloudflare ? createCloudflareOutput(artifacts) : undefined,
     cleanup: {
-      cloudflare: createCloudflare ? undefined : { wranglerConfigOwnership: { keys: ["queues"] } },
       vercel: { serverFunctionName: options.serverFunctionName ?? "__server.func" },
     },
     rootDir: options.rootDir,

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -75,6 +75,7 @@ interface GeneratedQueueArtifacts {
 
 interface GenerateProviderOutputsOptions {
   clientOutDir: string
+  cloudflareOwnedByNitro?: boolean
   queue: QueueModuleOptions | undefined
   rootDir: string
   serverFunctionName?: string
@@ -358,21 +359,13 @@ async function writeVercelQueueFunctions(rootDir: string, queue: QueueModuleOpti
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedQueueArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.queue)
-  const createCloudflare = shouldCreateCloudflareOutput(options.queue)
+  const createCloudflare = !options.cloudflareOwnedByNitro && shouldCreateCloudflareOutput(options.queue)
   const createVercel = shouldCreateVercelOutput(options.queue)
-  if (!createCloudflare && createVercel) {
-    await writeProviderDeploymentOutputs({
-      cleanup: {
-        cloudflare: { wranglerConfigOwnership: { keys: ["queues"] } },
-      },
-      clientOutDir: options.clientOutDir,
-      rootDir: options.rootDir,
-    })
-  }
   await writeProviderDeploymentOutputs({
     clientOutDir: options.clientOutDir,
     cloudflare: createCloudflare ? createCloudflareOutput(artifacts) : undefined,
     cleanup: {
+      cloudflare: createCloudflare ? undefined : { wranglerConfigOwnership: { keys: ["queues"] } },
       vercel: { serverFunctionName: options.serverFunctionName ?? "__server.func" },
     },
     rootDir: options.rootDir,

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -19,6 +19,7 @@ import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput
 
 export const queuePackageName = "@vite-hub/queue"
 const cloudflareQueueWorkerMarker = "vitehub-queue-worker"
+const cloudflareQueueOutputState = ".vitehub/queue/cloudflare-output.json"
 const productName = "queue"
 
 const generatedRegistryFileName = "registry.mjs"
@@ -275,6 +276,7 @@ function isLegacyCloudflareQueueWorker(contents: string, wrangler: unknown): boo
 async function createNitroCloudflareCleanup(rootDir: string) {
   const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
   let ownsWorker = false
+  let ownsQueues = false
   try {
     const contents = await readFile(resolve(outputRoot, "index.js"), "utf8")
     if (contents.includes(cloudflareQueueWorkerMarker)) {
@@ -287,11 +289,25 @@ async function createNitroCloudflareCleanup(rootDir: string) {
   catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
   }
+  try {
+    const [state, wrangler] = await Promise.all([
+      readFile(resolve(rootDir, cloudflareQueueOutputState), "utf8").then(value => JSON.parse(value) as Record<string, unknown>),
+      readFile(resolve(outputRoot, "wrangler.json"), "utf8").then(value => JSON.parse(value) as Record<string, unknown>),
+    ])
+    ownsQueues = JSON.stringify(state.queues) === JSON.stringify(wrangler.queues)
+    await rm(resolve(rootDir, cloudflareQueueOutputState), { force: true })
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
   return {
     fileNames: ownsWorker ? ["index.js"] : [],
     outputRoot,
     wranglerConfigOwnership: {
-      keys: ownsWorker ? ["compatibility_date", "compatibility_flags", "main", "observability", "queues"] : [],
+      keys: [
+        ...(ownsWorker ? ["compatibility_date", "compatibility_flags", "main", "observability"] : []),
+        ...(ownsQueues || ownsWorker ? ["queues"] : []),
+      ],
     },
   }
 }
@@ -424,6 +440,11 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     rootDir: options.rootDir,
     vercel: createVercel ? createVercelOutput(artifacts, options.serverFunctionName) : undefined,
   })
+  if (createCloudflare) {
+    const queues = createCloudflareQueueBindings(artifacts.definitions)
+    await mkdir(dirname(resolve(options.rootDir, cloudflareQueueOutputState)), { recursive: true })
+    await writeFile(resolve(options.rootDir, cloudflareQueueOutputState), `${JSON.stringify({ queues }, null, 2)}\n`, "utf8")
+  }
   await writeVercelQueueFunctions(options.rootDir, options.queue, artifacts)
   return artifacts
 }

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -407,7 +407,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     await writeProviderDeploymentOutputs({
       clientOutDir: options.clientOutDir,
       cleanup: {
-        cloudflare: options.cloudflareOwnedByNitro && usesCloudflare
+        cloudflare: options.cloudflareOwnedByNitro
           ? () => createNitroCloudflareCleanup(options.rootDir)
           : { wranglerConfigOwnership: { keys: ["queues"] } },
       },

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -273,7 +273,7 @@ function isLegacyCloudflareQueueWorker(contents: string, wrangler: unknown): boo
     && (observability as Record<string, unknown>).enabled === true
 }
 
-async function createNitroCloudflareCleanup(rootDir: string) {
+async function createNitroCloudflareCleanup(rootDir: string, hasCurrentContribution: boolean) {
   const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
   let ownsWorker = false
   let ownsQueues = false
@@ -306,7 +306,7 @@ async function createNitroCloudflareCleanup(rootDir: string) {
     wranglerConfigOwnership: {
       keys: [
         ...(ownsWorker ? ["compatibility_date", "compatibility_flags", "main", "observability"] : []),
-        ...(ownsQueues || ownsWorker ? ["queues"] : []),
+        ...(ownsWorker || (ownsQueues && !hasCurrentContribution) ? ["queues"] : []),
       ],
     },
   }
@@ -425,7 +425,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
       clientOutDir: options.clientOutDir,
       cleanup: {
         cloudflare: options.cloudflareOwnedByNitro
-          ? () => createNitroCloudflareCleanup(options.rootDir)
+          ? () => createNitroCloudflareCleanup(options.rootDir, usesCloudflare && artifacts.definitions.length > 0)
           : { wranglerConfigOwnership: { keys: ["queues"] } },
       },
       rootDir: options.rootDir,

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -94,7 +94,6 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
   let queue: QueueModuleOptions | undefined = options
   let hosting = "vercel"
   let cloudflareQueues = true
-  let configHookRan = false
   let nitroOwnsCloudflareWorker = false
 
   return {
@@ -107,17 +106,16 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
     config(config) {
       queue = config.queue ?? queue
       const nitro = (config as { nitro?: unknown }).nitro
-      nitroOwnsCloudflareWorker = Boolean(nitro && resolveQueueHosting(queue, cloneNitroConfig(nitro)) === "cloudflare")
-      configHookRan = true
+      const nitroConfig = cloneNitroConfig(nitro)
+      nitroOwnsCloudflareWorker = Boolean(nitro && resolveQueueHosting(queue, nitroConfig) === "cloudflare" && supportsCloudflareQueues(nitroConfig))
       ;(config as { nitro?: unknown }).nitro = mergeNitroConfig(config, nitro, queue, config.root || process.cwd())
     },
     async configResolved(config) {
       resolved = config
       queue = config.queue ?? queue
       const configuredNitro = (config as { nitro?: unknown }).nitro
-      if (!configHookRan) {
-        nitroOwnsCloudflareWorker = Boolean(configuredNitro && resolveQueueHosting(queue, cloneNitroConfig(configuredNitro)) === "cloudflare")
-      }
+      const configuredNitroConfig = cloneNitroConfig(configuredNitro)
+      nitroOwnsCloudflareWorker = Boolean(configuredNitro && resolveQueueHosting(queue, configuredNitroConfig) === "cloudflare" && supportsCloudflareQueues(configuredNitroConfig))
       const nitro = mergeNitroConfig(config, configuredNitro, queue, config.root)
       ;(config as { nitro?: unknown }).nitro = nitro
       hosting = resolveQueueHosting(queue, nitro)

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -78,7 +78,7 @@ function mergeNitroConfig(config: object, value: unknown, queue: QueueModuleOpti
   }
   if (!generated) {
     registerCloudflareProviderOutput(config, "queue", {})
-    return baseNitro
+    return composeNitroCloudflareProviderOutput(config, baseNitro)
   }
   const binding = queue?.provider === "cloudflare" && typeof queue.binding === "string" ? queue.binding : undefined
   if (binding && generated.producers.length > 1) {

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -99,6 +99,8 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
   let queue: QueueModuleOptions | undefined = options
   let hosting = "vercel"
   let cloudflareQueues = true
+  let configHookRan = false
+  let hasUserNitroIntegration = false
   let nitroOwnsCloudflareWorker = false
 
   return {
@@ -112,7 +114,11 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
       queue = config.queue ?? queue
       const nitro = (config as { nitro?: unknown }).nitro
       const nitroConfig = cloneNitroConfig(nitro)
-      nitroOwnsCloudflareWorker = Boolean(nitro && resolveNitroHosting(nitroConfig) === "cloudflare" && supportsCloudflareQueues(nitroConfig))
+      if (!configHookRan) {
+        configHookRan = true
+        hasUserNitroIntegration = Boolean(nitro)
+      }
+      nitroOwnsCloudflareWorker = Boolean(hasUserNitroIntegration && resolveNitroHosting(nitroConfig) === "cloudflare" && supportsCloudflareQueues(nitroConfig))
       ;(config as { nitro?: unknown }).nitro = mergeNitroConfig(config, nitro, queue, config.root || process.cwd())
     },
     async configResolved(config) {
@@ -120,7 +126,8 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
       queue = config.queue ?? queue
       const configuredNitro = (config as { nitro?: unknown }).nitro
       const configuredNitroConfig = cloneNitroConfig(configuredNitro)
-      nitroOwnsCloudflareWorker = Boolean(configuredNitro && resolveNitroHosting(configuredNitroConfig) === "cloudflare" && supportsCloudflareQueues(configuredNitroConfig))
+      const nitroOwnsOutput = configHookRan ? hasUserNitroIntegration : Boolean(configuredNitro)
+      nitroOwnsCloudflareWorker = Boolean(nitroOwnsOutput && resolveNitroHosting(configuredNitroConfig) === "cloudflare" && supportsCloudflareQueues(configuredNitroConfig))
       const nitro = mergeNitroConfig(config, configuredNitro, queue, config.root)
       ;(config as { nitro?: unknown }).nitro = nitro
       hosting = resolveQueueHosting(queue, nitro)

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -56,12 +56,12 @@ function mergeNitroConfig(config: object, value: unknown, queue: QueueModuleOpti
   const plugins = Array.isArray(nitro.plugins) ? nitro.plugins.filter(plugin => queue !== false || plugin !== generatedQueueNitroPlugin) : []
   if (queue === false) {
     registerCloudflareProviderOutput(config, "queue", {})
-    return { ...nitro, plugins }
+    return composeNitroCloudflareProviderOutput(config, { ...nitro, plugins })
   }
   if (!plugins.includes(generatedQueueNitroPlugin)) plugins.unshift(generatedQueueNitroPlugin)
   if (resolveQueueHosting(queue, nitro) !== "cloudflare") {
     registerCloudflareProviderOutput(config, "queue", {})
-    return { ...nitro, plugins }
+    return composeNitroCloudflareProviderOutput(config, { ...nitro, plugins })
   }
   const cloudflare = cloneNitroConfig(nitro.cloudflare)
   const wrangler = cloneNitroConfig(cloudflare.wrangler)

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -1,5 +1,5 @@
 import { getViteMode } from "@vite-hub/internal/build/mode"
-import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
+import { composeNitroCloudflareProviderOutput, registerCloudflareProviderOutput, shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
 import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
 import { getHostingProvider } from "@vite-hub/internal/hosting"
 
@@ -46,12 +46,18 @@ function supportsCloudflareQueues(nitro: Record<string, unknown>): boolean {
   return !preset.replaceAll("-", "_").includes("cloudflare_pages")
 }
 
-function mergeNitroConfig(value: unknown, queue: QueueModuleOptions | undefined, root: string): Record<string, unknown> {
+function mergeNitroConfig(config: object, value: unknown, queue: QueueModuleOptions | undefined, root: string): Record<string, unknown> {
   const nitro = cloneNitroConfig(value)
   const plugins = Array.isArray(nitro.plugins) ? nitro.plugins.filter(plugin => queue !== false || plugin !== generatedQueueNitroPlugin) : []
-  if (queue === false) return { ...nitro, plugins }
+  if (queue === false) {
+    registerCloudflareProviderOutput(config, "queue", {})
+    return { ...nitro, plugins }
+  }
   if (!plugins.includes(generatedQueueNitroPlugin)) plugins.unshift(generatedQueueNitroPlugin)
-  if (resolveQueueHosting(queue, nitro) !== "cloudflare") return { ...nitro, plugins }
+  if (resolveQueueHosting(queue, nitro) !== "cloudflare") {
+    registerCloudflareProviderOutput(config, "queue", {})
+    return { ...nitro, plugins }
+  }
   const cloudflare = cloneNitroConfig(nitro.cloudflare)
   const wrangler = cloneNitroConfig(cloudflare.wrangler)
   const compatibilityFlags = Array.isArray(wrangler.compatibility_flags) ? [...wrangler.compatibility_flags] : []
@@ -59,45 +65,28 @@ function mergeNitroConfig(value: unknown, queue: QueueModuleOptions | undefined,
   const cloudflareQueues = supportsCloudflareQueues(nitro)
   const rollupConfig = cloneNitroConfig(nitro.rollupConfig)
   const generated = createCloudflareQueueBindings(discoverQueueDefinitions({ rootDir: root }))
+  const baseNitro = {
+    ...nitro,
+    ...(cloudflareQueues ? { rollupConfig: { ...rollupConfig, external: mergeNitroExternal(rollupConfig.external, "cloudflare:workers") } } : {}),
+    cloudflare: { ...cloudflare, wrangler: { ...wrangler, compatibility_flags: compatibilityFlags } },
+    plugins,
+  }
   if (!generated) {
-    return {
-      ...nitro,
-      ...(cloudflareQueues ? { rollupConfig: { ...rollupConfig, external: mergeNitroExternal(rollupConfig.external, "cloudflare:workers") } } : {}),
-      cloudflare: { ...cloudflare, wrangler: { ...wrangler, compatibility_flags: compatibilityFlags } },
-      plugins,
-    }
+    registerCloudflareProviderOutput(config, "queue", {})
+    return baseNitro
   }
   const binding = queue?.provider === "cloudflare" && typeof queue.binding === "string" ? queue.binding : undefined
   if (binding && generated.producers.length > 1) {
     throw new Error("A custom Cloudflare queue binding can only be used with one Queue Definition.")
   }
   const generatedProducers = binding ? generated.producers.map(producer => ({ ...producer, binding })) : generated.producers
-  const queues = cloneNitroConfig(wrangler.queues)
-  const consumers = Array.isArray(queues.consumers) ? queues.consumers : []
-  const producers = Array.isArray(queues.producers) ? queues.producers : []
-  return {
-    ...nitro,
-    ...(cloudflareQueues ? { rollupConfig: { ...rollupConfig, external: mergeNitroExternal(rollupConfig.external, "cloudflare:workers") } } : {}),
-    cloudflare: {
-      ...cloudflare,
-      wrangler: {
-        ...wrangler,
-        compatibility_flags: compatibilityFlags,
-        queues: {
-          ...queues,
-          ...(cloudflareQueues ? { consumers: [...consumers, ...generated.consumers.filter(entry => !consumers.some(current => cloneNitroConfig(current).queue === entry.queue))] } : {}),
-          producers: [...producers, ...generatedProducers.filter((entry) => {
-            const existing = producers.find(current => cloneNitroConfig(current).binding === entry.binding)
-            if (existing && cloneNitroConfig(existing).queue !== entry.queue) {
-              throw new Error(`Cloudflare queue binding ${entry.binding} is already assigned to another queue.`)
-            }
-            return !existing
-          })],
-        },
-      },
+  registerCloudflareProviderOutput(config, "queue", {
+    queues: {
+      ...(cloudflareQueues ? { consumers: generated.consumers } : {}),
+      producers: generatedProducers,
     },
-    plugins,
-  }
+  })
+  return composeNitroCloudflareProviderOutput(config, baseNitro)
 }
 
 export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
@@ -105,6 +94,8 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
   let queue: QueueModuleOptions | undefined = options
   let hosting = "vercel"
   let cloudflareQueues = true
+  let configHookRan = false
+  let nitroOwnsCloudflareWorker = false
 
   return {
     name: "@vite-hub/queue/vite",
@@ -115,12 +106,19 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
     },
     config(config) {
       queue = config.queue ?? queue
-      ;(config as { nitro?: unknown }).nitro = mergeNitroConfig((config as { nitro?: unknown }).nitro, queue, config.root || process.cwd())
+      const nitro = (config as { nitro?: unknown }).nitro
+      nitroOwnsCloudflareWorker = Boolean(nitro && resolveQueueHosting(queue, cloneNitroConfig(nitro)) === "cloudflare")
+      configHookRan = true
+      ;(config as { nitro?: unknown }).nitro = mergeNitroConfig(config, nitro, queue, config.root || process.cwd())
     },
     async configResolved(config) {
       resolved = config
       queue = config.queue ?? queue
-      const nitro = mergeNitroConfig((config as { nitro?: unknown }).nitro, queue, config.root)
+      const configuredNitro = (config as { nitro?: unknown }).nitro
+      if (!configHookRan) {
+        nitroOwnsCloudflareWorker = Boolean(configuredNitro && resolveQueueHosting(queue, cloneNitroConfig(configuredNitro)) === "cloudflare")
+      }
+      const nitro = mergeNitroConfig(config, configuredNitro, queue, config.root)
       ;(config as { nitro?: unknown }).nitro = nitro
       hosting = resolveQueueHosting(queue, nitro)
       cloudflareQueues = supportsCloudflareQueues(nitro)
@@ -146,6 +144,7 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
       }
       await generateProviderOutputs({
         clientOutDir: resolved.build.outDir,
+        cloudflareOwnedByNitro: nitroOwnsCloudflareWorker,
         queue: queue ?? { provider: (hosting === "cloudflare" ? "cloudflare" : "vercel") satisfies QueueProvider },
         rootDir: resolved.root,
         serverFunctionName: resolveNitroVercelFunctionName(resolved, "queue"),

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -7,7 +7,7 @@ import { createCloudflareQueueBindings, generateProviderOutputs, generatedQueueN
 import { discoverQueueDefinitions } from "./discovery.ts"
 import { createQueueProvisionStep } from "./provision.ts"
 
-import type { QueueModuleOptions, QueueProvider } from "./types.ts"
+import type { DiscoveredQueueDefinition, QueueModuleOptions, QueueProvider } from "./types.ts"
 import type { ViteHubCliContributor } from "@vite-hub/internal/cli"
 import type { Plugin, ResolvedConfig } from "vite"
 
@@ -51,7 +51,7 @@ function supportsCloudflareQueues(nitro: Record<string, unknown>): boolean {
   return !preset.replaceAll("-", "_").includes("cloudflare_pages")
 }
 
-function mergeNitroConfig(config: object, value: unknown, queue: QueueModuleOptions | undefined, root: string): Record<string, unknown> {
+function mergeNitroConfig(config: object, value: unknown, queue: QueueModuleOptions | undefined, root: string, definitions = discoverQueueDefinitions({ rootDir: root })): Record<string, unknown> {
   const nitro = cloneNitroConfig(value)
   const plugins = Array.isArray(nitro.plugins) ? nitro.plugins.filter(plugin => queue !== false || plugin !== generatedQueueNitroPlugin) : []
   if (queue === false) {
@@ -69,7 +69,7 @@ function mergeNitroConfig(config: object, value: unknown, queue: QueueModuleOpti
   if (!compatibilityFlags.includes("nodejs_compat")) compatibilityFlags.push("nodejs_compat")
   const cloudflareQueues = supportsCloudflareQueues(nitro)
   const rollupConfig = cloneNitroConfig(nitro.rollupConfig)
-  const generated = createCloudflareQueueBindings(discoverQueueDefinitions({ rootDir: root }))
+  const generated = createCloudflareQueueBindings(definitions)
   const baseNitro = {
     ...nitro,
     ...(cloudflareQueues ? { rollupConfig: { ...rollupConfig, external: mergeNitroExternal(rollupConfig.external, "cloudflare:workers") } } : {}),
@@ -99,6 +99,7 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
   let queue: QueueModuleOptions | undefined = options
   let hosting = "vercel"
   let cloudflareQueues = true
+  let configuredDefinitions: DiscoveredQueueDefinition[] = []
   let nitroOwnsCloudflareWorker = false
 
   return {
@@ -119,11 +120,12 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
       const configuredNitro = (config as { nitro?: unknown }).nitro
       const configuredNitroConfig = cloneNitroConfig(configuredNitro)
       nitroOwnsCloudflareWorker = hasNitroVitePlugin(config) && resolveNitroHosting(configuredNitroConfig) === "cloudflare" && supportsCloudflareQueues(configuredNitroConfig)
-      const nitro = mergeNitroConfig(config, configuredNitro, queue, config.root)
+      configuredDefinitions = discoverQueueDefinitions({ rootDir: config.root })
+      const nitro = mergeNitroConfig(config, configuredNitro, queue, config.root, configuredDefinitions)
       ;(config as { nitro?: unknown }).nitro = nitro
       hosting = resolveQueueHosting(queue, nitro)
       cloudflareQueues = supportsCloudflareQueues(nitro)
-      await writeQueueNitroIntegration(config.root, queue, hosting, cloudflareQueues)
+      await writeQueueNitroIntegration(config.root, queue, hosting, cloudflareQueues, configuredDefinitions)
     },
     configEnvironment(name, config) {
       if (!isServerEnvironment(name, config)) {
@@ -143,9 +145,17 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
       if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) {
         return
       }
+      let definitions: DiscoveredQueueDefinition[] | undefined
+      if (nitroOwnsCloudflareWorker) {
+        definitions = discoverQueueDefinitions({ rootDir: resolved.root })
+        if (JSON.stringify(definitions) !== JSON.stringify(configuredDefinitions)) {
+          throw new Error("[vitehub] Nitro Cloudflare Queue Definitions changed after config resolution. Generate Queue Definition source files before Vite config resolves.")
+        }
+      }
       await generateProviderOutputs({
         clientOutDir: resolved.build.outDir,
         cloudflareOwnedByNitro: nitroOwnsCloudflareWorker,
+        definitions,
         queue: queue ?? { provider: (hosting === "cloudflare" ? "cloudflare" : "vercel") satisfies QueueProvider },
         rootDir: resolved.root,
         serverFunctionName: resolveNitroVercelFunctionName(resolved, "queue"),

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -1,6 +1,6 @@
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { composeNitroCloudflareProviderOutput, registerCloudflareProviderOutput, shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, hasNitroVitePlugin, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
 import { getHostingProvider } from "@vite-hub/internal/hosting"
 
 import { createCloudflareQueueBindings, generateProviderOutputs, generatedQueueNitroPlugin, queuePackageName, writeQueueNitroIntegration } from "./internal/vite-build.ts"
@@ -99,8 +99,6 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
   let queue: QueueModuleOptions | undefined = options
   let hosting = "vercel"
   let cloudflareQueues = true
-  let configHookRan = false
-  let hasUserNitroIntegration = false
   let nitroOwnsCloudflareWorker = false
 
   return {
@@ -113,12 +111,6 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
     config(config) {
       queue = config.queue ?? queue
       const nitro = (config as { nitro?: unknown }).nitro
-      const nitroConfig = cloneNitroConfig(nitro)
-      if (!configHookRan) {
-        configHookRan = true
-        hasUserNitroIntegration = Boolean(nitro)
-      }
-      nitroOwnsCloudflareWorker = Boolean(hasUserNitroIntegration && resolveNitroHosting(nitroConfig) === "cloudflare" && supportsCloudflareQueues(nitroConfig))
       ;(config as { nitro?: unknown }).nitro = mergeNitroConfig(config, nitro, queue, config.root || process.cwd())
     },
     async configResolved(config) {
@@ -126,8 +118,7 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
       queue = config.queue ?? queue
       const configuredNitro = (config as { nitro?: unknown }).nitro
       const configuredNitroConfig = cloneNitroConfig(configuredNitro)
-      const nitroOwnsOutput = configHookRan ? hasUserNitroIntegration : Boolean(configuredNitro)
-      nitroOwnsCloudflareWorker = Boolean(nitroOwnsOutput && resolveNitroHosting(configuredNitroConfig) === "cloudflare" && supportsCloudflareQueues(configuredNitroConfig))
+      nitroOwnsCloudflareWorker = hasNitroVitePlugin(config) && resolveNitroHosting(configuredNitroConfig) === "cloudflare" && supportsCloudflareQueues(configuredNitroConfig)
       const nitro = mergeNitroConfig(config, configuredNitro, queue, config.root)
       ;(config as { nitro?: unknown }).nitro = nitro
       hosting = resolveQueueHosting(queue, nitro)

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -41,6 +41,11 @@ function resolveQueueHosting(queue: QueueModuleOptions | undefined, nitro: Recor
   return getHostingProvider(preset) || "vercel"
 }
 
+function resolveNitroHosting(nitro: Record<string, unknown>): string | undefined {
+  const preset = typeof nitro.preset === "string" ? nitro.preset : process.env.NITRO_PRESET || process.env.SERVER_PRESET || process.env.VITEHUB_HOSTING
+  return getHostingProvider(preset)
+}
+
 function supportsCloudflareQueues(nitro: Record<string, unknown>): boolean {
   const preset = typeof nitro.preset === "string" ? nitro.preset : process.env.NITRO_PRESET || process.env.SERVER_PRESET || process.env.VITEHUB_HOSTING || ""
   return !preset.replaceAll("-", "_").includes("cloudflare_pages")
@@ -107,7 +112,7 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
       queue = config.queue ?? queue
       const nitro = (config as { nitro?: unknown }).nitro
       const nitroConfig = cloneNitroConfig(nitro)
-      nitroOwnsCloudflareWorker = Boolean(nitro && resolveQueueHosting(queue, nitroConfig) === "cloudflare" && supportsCloudflareQueues(nitroConfig))
+      nitroOwnsCloudflareWorker = Boolean(nitro && resolveNitroHosting(nitroConfig) === "cloudflare" && supportsCloudflareQueues(nitroConfig))
       ;(config as { nitro?: unknown }).nitro = mergeNitroConfig(config, nitro, queue, config.root || process.cwd())
     },
     async configResolved(config) {
@@ -115,7 +120,7 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
       queue = config.queue ?? queue
       const configuredNitro = (config as { nitro?: unknown }).nitro
       const configuredNitroConfig = cloneNitroConfig(configuredNitro)
-      nitroOwnsCloudflareWorker = Boolean(configuredNitro && resolveQueueHosting(queue, configuredNitroConfig) === "cloudflare" && supportsCloudflareQueues(configuredNitroConfig))
+      nitroOwnsCloudflareWorker = Boolean(configuredNitro && resolveNitroHosting(configuredNitroConfig) === "cloudflare" && supportsCloudflareQueues(configuredNitroConfig))
       const nitro = mergeNitroConfig(config, configuredNitro, queue, config.root)
       ;(config as { nitro?: unknown }).nitro = nitro
       hosting = resolveQueueHosting(queue, nitro)

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -173,6 +173,27 @@ describe("Vite provider outputs", () => {
     })
   })
 
+  it("leaves Cloudflare Worker output to Nitro", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-queue-nitro-cloudflare-")
+    const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(cloudflareOutputRoot, { recursive: true })
+    await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
+    await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
+      queues: { producers: [{ binding: "STALE", queue: "stale" }] },
+    }, null, 2)}\n`, "utf8")
+
+    await generateProviderOutputs({
+      clientOutDir: "dist",
+      cloudflareOwnedByNitro: true,
+      queue: { provider: "cloudflare" },
+      rootDir,
+    })
+
+    expect(existsSync(join(cloudflareOutputRoot, "index.js"))).toBe(false)
+    expect(existsSync(join(cloudflareOutputRoot, "wrangler.json"))).toBe(false)
+  })
+
   it("does not preload Vercel queue without queue definitions", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-no-definitions-")
     await mkdir(join(rootDir, "src"), { recursive: true })

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -77,6 +77,7 @@ describe("Vite provider outputs", () => {
     const vercelConsumerTrigger = JSON.parse(await readFile(vercelConsumerConfig, "utf8")).experimentalTriggers?.[0]
 
     expect(existsSync(cloudflareWorker)).toBe(true)
+    expect(await readFile(cloudflareWorker, "utf8")).toContain("vitehub-queue-worker")
     expect(await readFile(cloudflareConfig, "utf8")).not.toContain("\"run_worker_first\"")
     expect(await readFile(vercelConfig, "utf8")).toContain("\"/__server\"")
     expect(existsSync(vercelServer)).toBe(true)
@@ -180,8 +181,7 @@ describe("Vite provider outputs", () => {
     await mkdir(join(rootDir, "src"), { recursive: true })
     await mkdir(cloudflareOutputRoot, { recursive: true })
     await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
-    await writeFile(join(cloudflareOutputRoot, "index.js"), "export default {}\n", "utf8")
-    await writeFile(join(cloudflareOutputRoot, ".vitehub-queue-output"), "", "utf8")
+    await writeFile(join(cloudflareOutputRoot, "index.js"), "// vitehub-queue-worker\nexport default {}\n", "utf8")
     await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
       compatibility_date: "2026-04-20",
       main: "index.js",
@@ -226,6 +226,7 @@ describe("Vite provider outputs", () => {
     await expect(readFile(join(cloudflareOutputRoot, "index.js"), "utf8")).resolves.toBe("// workflow worker\n")
     await expect(readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
       main: "index.js",
+      queues: { producers: [{ binding: "STALE", queue: "stale" }] },
       workflows: [{ binding: "WORKFLOW", class_name: "Workflow" }],
     })
   })

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -181,6 +181,7 @@ describe("Vite provider outputs", () => {
     await mkdir(cloudflareOutputRoot, { recursive: true })
     await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
     await writeFile(join(cloudflareOutputRoot, "index.js"), "export default {}\n", "utf8")
+    await writeFile(join(cloudflareOutputRoot, ".vitehub-queue-output"), "", "utf8")
     await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
       compatibility_date: "2026-04-20",
       main: "index.js",
@@ -199,6 +200,33 @@ describe("Vite provider outputs", () => {
     expect(existsSync(join(cloudflareOutputRoot, "index.js"))).toBe(false)
     await expect(readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
       triggers: { crons: ["0 0 * * *"] },
+    })
+  })
+
+  it("preserves another primitive's Cloudflare Worker during Nitro takeover", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-queue-shared-nitro-cloudflare-")
+    const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(cloudflareOutputRoot, { recursive: true })
+    await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
+    await writeFile(join(cloudflareOutputRoot, "index.js"), "// workflow worker\n", "utf8")
+    await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
+      main: "index.js",
+      queues: { producers: [{ binding: "STALE", queue: "stale" }] },
+      workflows: [{ binding: "WORKFLOW", class_name: "Workflow" }],
+    }, null, 2)}\n`, "utf8")
+
+    await generateProviderOutputs({
+      clientOutDir: "dist",
+      cloudflareOwnedByNitro: true,
+      queue: { provider: "cloudflare" },
+      rootDir,
+    })
+
+    await expect(readFile(join(cloudflareOutputRoot, "index.js"), "utf8")).resolves.toBe("// workflow worker\n")
+    await expect(readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+      main: "index.js",
+      workflows: [{ binding: "WORKFLOW", class_name: "Workflow" }],
     })
   })
 

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -135,7 +135,6 @@ describe("Vite provider outputs", () => {
 
     await generateProviderOutputs({
       clientOutDir: "dist",
-      cloudflareOwnedByNitro: true,
       queue: { provider: "vercel" },
       rootDir,
     })
@@ -176,7 +175,7 @@ describe("Vite provider outputs", () => {
     expect(existsSync(join(rootDir, ".vercel", "output", "static", basename(rootDir), "wrangler.json"))).toBe(false)
   })
 
-  it("leaves Cloudflare Worker output to Nitro", async () => {
+  it("cleans a Queue-owned Cloudflare Worker when Queue is disabled under Nitro", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-queue-nitro-cloudflare-")
     const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
     await mkdir(join(rootDir, "src"), { recursive: true })
@@ -194,7 +193,7 @@ describe("Vite provider outputs", () => {
     await generateProviderOutputs({
       clientOutDir: "dist",
       cloudflareOwnedByNitro: true,
-      queue: { provider: "cloudflare" },
+      queue: false,
       rootDir,
     })
 

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -203,18 +203,25 @@ describe("Vite provider outputs", () => {
     })
   })
 
-  it("preserves another primitive's Cloudflare Worker during Nitro takeover", async () => {
-    const rootDir = await createWorkspaceTempDir("vitehub-queue-shared-nitro-cloudflare-")
+  it("cleans standalone Queue output created before worker banners", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-queue-legacy-nitro-cloudflare-")
     const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
     await mkdir(join(rootDir, "src"), { recursive: true })
-    await mkdir(cloudflareOutputRoot, { recursive: true })
+    await mkdir(join(rootDir, "dist"), { recursive: true })
     await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
-    await writeFile(join(cloudflareOutputRoot, "index.js"), "// workflow worker\n", "utf8")
-    await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
-      main: "index.js",
-      queues: { producers: [{ binding: "STALE", queue: "stale" }] },
-      workflows: [{ binding: "WORKFLOW", class_name: "Workflow" }],
-    }, null, 2)}\n`, "utf8")
+
+    await generateProviderOutputs({
+      clientOutDir: "dist",
+      queue: { provider: "cloudflare" },
+      rootDir,
+    })
+    const workerFile = join(cloudflareOutputRoot, "index.js")
+    const legacyWorker = (await readFile(workerFile, "utf8")).replace("// vitehub-queue-worker\n", "")
+    expect(legacyWorker).not.toContain("vitehub-queue-worker")
+    await writeFile(workerFile, legacyWorker, "utf8")
+    const wranglerFile = join(cloudflareOutputRoot, "wrangler.json")
+    const wrangler = JSON.parse(await readFile(wranglerFile, "utf8")) as Record<string, unknown>
+    await writeFile(wranglerFile, `${JSON.stringify({ ...wrangler, triggers: { crons: ["0 0 * * *"] } }, null, 2)}\n`, "utf8")
 
     await generateProviderOutputs({
       clientOutDir: "dist",
@@ -223,12 +230,44 @@ describe("Vite provider outputs", () => {
       rootDir,
     })
 
-    await expect(readFile(join(cloudflareOutputRoot, "index.js"), "utf8")).resolves.toBe("// workflow worker\n")
-    await expect(readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
-      main: "index.js",
-      queues: { producers: [{ binding: "STALE", queue: "stale" }] },
-      workflows: [{ binding: "WORKFLOW", class_name: "Workflow" }],
+    expect(existsSync(workerFile)).toBe(false)
+    await expect(readFile(wranglerFile, "utf8").then(JSON.parse)).resolves.toEqual({
+      triggers: { crons: ["0 0 * * *"] },
     })
+  })
+
+  it("preserves another primitive's Cloudflare Worker during Nitro takeover", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-queue-shared-nitro-cloudflare-")
+    const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(cloudflareOutputRoot, { recursive: true })
+    await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
+    for (const worker of ["// workflow worker\n", "// vitehub-blob-worker\n", "export default { fetch() {} }\n"]) {
+      await writeFile(join(cloudflareOutputRoot, "index.js"), worker, "utf8")
+      await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
+        compatibility_flags: ["nodejs_compat"],
+        main: "index.js",
+        observability: { enabled: true },
+        queues: { producers: [{ binding: "STALE", queue: "stale" }] },
+        workflows: [{ binding: "WORKFLOW", class_name: "Workflow" }],
+      }, null, 2)}\n`, "utf8")
+
+      await generateProviderOutputs({
+        clientOutDir: "dist",
+        cloudflareOwnedByNitro: true,
+        queue: { provider: "cloudflare" },
+        rootDir,
+      })
+
+      await expect(readFile(join(cloudflareOutputRoot, "index.js"), "utf8")).resolves.toBe(worker)
+      await expect(readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+        compatibility_flags: ["nodejs_compat"],
+        main: "index.js",
+        observability: { enabled: true },
+        queues: { producers: [{ binding: "STALE", queue: "stale" }] },
+        workflows: [{ binding: "WORKFLOW", class_name: "Workflow" }],
+      })
+    }
   })
 
   it("does not preload Vercel queue without queue definitions", async () => {

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -198,6 +198,7 @@ describe("Vite provider outputs", () => {
     })
 
     expect(existsSync(join(cloudflareOutputRoot, "index.js"))).toBe(false)
+    expect(existsSync(join(rootDir, ".vitehub", "queue", "cloudflare-output.json"))).toBe(false)
     await expect(readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
       triggers: { crons: ["0 0 * * *"] },
     })

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -171,6 +171,7 @@ describe("Vite provider outputs", () => {
     await expect(readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
       triggers: { crons: ["0 0 * * *"] },
     })
+    expect(existsSync(join(rootDir, ".vercel", "output", "static", basename(rootDir), "wrangler.json"))).toBe(false)
   })
 
   it("leaves Cloudflare Worker output to Nitro", async () => {
@@ -179,8 +180,13 @@ describe("Vite provider outputs", () => {
     await mkdir(join(rootDir, "src"), { recursive: true })
     await mkdir(cloudflareOutputRoot, { recursive: true })
     await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
+    await writeFile(join(cloudflareOutputRoot, "index.js"), "export default {}\n", "utf8")
     await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
+      compatibility_date: "2026-04-20",
+      main: "index.js",
+      observability: { enabled: true },
       queues: { producers: [{ binding: "STALE", queue: "stale" }] },
+      triggers: { crons: ["0 0 * * *"] },
     }, null, 2)}\n`, "utf8")
 
     await generateProviderOutputs({
@@ -191,7 +197,9 @@ describe("Vite provider outputs", () => {
     })
 
     expect(existsSync(join(cloudflareOutputRoot, "index.js"))).toBe(false)
-    expect(existsSync(join(cloudflareOutputRoot, "wrangler.json"))).toBe(false)
+    await expect(readFile(join(cloudflareOutputRoot, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+      triggers: { crons: ["0 0 * * *"] },
+    })
   })
 
   it("does not preload Vercel queue without queue definitions", async () => {

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -270,6 +270,36 @@ describe("Vite provider outputs", () => {
     }
   })
 
+  it("preserves a Nitro Cloudflare Worker during legacy Queue cleanup", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-queue-nitro-worker-")
+    const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(cloudflareOutputRoot, { recursive: true })
+    await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
+    const worker = [
+      "createQueueCloudflareWorker({",
+      "getCloudflareQueueDefinitionName(batch.queue)",
+      'label: "queue"',
+      'nitro.hooks.hook("cloudflare:queue", () => {})',
+    ].join("\n")
+    await writeFile(join(cloudflareOutputRoot, "index.js"), worker, "utf8")
+    await writeFile(join(cloudflareOutputRoot, "wrangler.json"), `${JSON.stringify({
+      compatibility_flags: ["nodejs_compat"],
+      main: "index.js",
+      observability: { enabled: true },
+      queues: { producers: [{ binding: "QUEUE", queue: "queue" }] },
+    }, null, 2)}\n`, "utf8")
+
+    await generateProviderOutputs({
+      clientOutDir: "dist",
+      cloudflareOwnedByNitro: true,
+      queue: { provider: "cloudflare" },
+      rootDir,
+    })
+
+    await expect(readFile(join(cloudflareOutputRoot, "index.js"), "utf8")).resolves.toBe(worker)
+  })
+
   it("does not preload Vercel queue without queue definitions", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-no-definitions-")
     await mkdir(join(rootDir, "src"), { recursive: true })

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -300,6 +300,20 @@ describe("Vite provider outputs", () => {
     await expect(readFile(join(cloudflareOutputRoot, "index.js"), "utf8")).resolves.toBe(worker)
   })
 
+  it("cleans standalone Queue bindings after another primitive replaces the Worker", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-queue-shared-worker-")
+    const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await writeFile(join(rootDir, "src", "welcome.queue.ts"), "export default null\n", "utf8")
+    await generateProviderOutputs({ clientOutDir: "dist", queue: { provider: "cloudflare" }, rootDir })
+    await writeFile(join(outputRoot, "index.js"), "// workflow worker\n", "utf8")
+
+    await generateProviderOutputs({ clientOutDir: "dist", cloudflareOwnedByNitro: true, queue: { provider: "cloudflare" }, rootDir })
+
+    await expect(readFile(join(outputRoot, "index.js"), "utf8")).resolves.toBe("// workflow worker\n")
+    expect(await readFile(join(outputRoot, "wrangler.json"), "utf8").then(JSON.parse)).not.toHaveProperty("queues")
+  })
+
   it("does not preload Vercel queue without queue definitions", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-queue-vite-no-definitions-")
     await mkdir(join(rootDir, "src"), { recursive: true })

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -300,7 +300,7 @@ describe("Vite provider outputs", () => {
     await expect(readFile(join(cloudflareOutputRoot, "index.js"), "utf8")).resolves.toBe(worker)
   })
 
-  it("cleans standalone Queue bindings after another primitive replaces the Worker", async () => {
+  it("preserves current Nitro Queue bindings after another primitive replaces the Worker", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-queue-shared-worker-")
     const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
     await mkdir(join(rootDir, "src"), { recursive: true })
@@ -311,7 +311,7 @@ describe("Vite provider outputs", () => {
     await generateProviderOutputs({ clientOutDir: "dist", cloudflareOwnedByNitro: true, queue: { provider: "cloudflare" }, rootDir })
 
     await expect(readFile(join(outputRoot, "index.js"), "utf8")).resolves.toBe("// workflow worker\n")
-    expect(await readFile(join(outputRoot, "wrangler.json"), "utf8").then(JSON.parse)).not.toHaveProperty("queues")
+    expect(await readFile(join(outputRoot, "wrangler.json"), "utf8").then(JSON.parse)).toHaveProperty("queues")
   })
 
   it("does not preload Vercel queue without queue definitions", async () => {

--- a/packages/queue/test/vite-output.test.ts
+++ b/packages/queue/test/vite-output.test.ts
@@ -135,6 +135,7 @@ describe("Vite provider outputs", () => {
 
     await generateProviderOutputs({
       clientOutDir: "dist",
+      cloudflareOwnedByNitro: true,
       queue: { provider: "vercel" },
       rootDir,
     })

--- a/packages/queue/test/vite.test.ts
+++ b/packages/queue/test/vite.test.ts
@@ -176,6 +176,18 @@ describe("hubQueue", () => {
     expect(existsSync(join(createDefaultCloudflareOutputRoot(root), "index.js"))).toBe(true)
   })
 
+  it("keeps standalone output when Queue targets Cloudflare but Nitro does not", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-queue-nitro-"))
+    roots.push(root)
+    await writeFile(join(root, "welcome.queue.ts"), "export default { handler: async () => undefined }\n")
+    const plugin = hubQueue({ provider: "cloudflare" })
+    const config = { build: { outDir: "dist" }, command: "build", nitro: { preset: "vercel" }, root }
+    ;(plugin.config as unknown as (config: Record<string, unknown>) => void)(config)
+    await (plugin.configResolved as (config: unknown) => Promise<void>)(config as never)
+    await (plugin.closeBundle as () => Promise<void>)()
+    expect(existsSync(join(createDefaultCloudflareOutputRoot(root), "index.js"))).toBe(true)
+  })
+
   it("rejects ambiguous and conflicting custom Cloudflare bindings", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-queue-nitro-"))
     roots.push(root)

--- a/packages/queue/test/vite.test.ts
+++ b/packages/queue/test/vite.test.ts
@@ -188,6 +188,27 @@ describe("hubQueue", () => {
     expect(existsSync(join(createDefaultCloudflareOutputRoot(root), "index.js"))).toBe(true)
   })
 
+  it.each(["NITRO_PRESET", "SERVER_PRESET", "VITEHUB_HOSTING"])("keeps standalone output for plain Vite selected by %s", async (environmentVariable) => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-queue-nitro-"))
+    roots.push(root)
+    await writeFile(join(root, "welcome.queue.ts"), "export default { handler: async () => undefined }\n")
+    const previous = process.env[environmentVariable]
+    process.env[environmentVariable] = "cloudflare_module"
+
+    try {
+      const plugin = hubQueue()
+      const config = { build: { outDir: "dist" }, command: "build", root }
+      ;(plugin.config as unknown as (config: Record<string, unknown>) => void)(config)
+      await (plugin.configResolved as (config: unknown) => Promise<void>)(config as never)
+      await (plugin.closeBundle as () => Promise<void>)()
+      expect(existsSync(join(createDefaultCloudflareOutputRoot(root), "index.js"))).toBe(true)
+    }
+    finally {
+      if (typeof previous === "undefined") delete process.env[environmentVariable]
+      else process.env[environmentVariable] = previous
+    }
+  })
+
   it("rejects ambiguous and conflicting custom Cloudflare bindings", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-queue-nitro-"))
     roots.push(root)

--- a/packages/queue/test/vite.test.ts
+++ b/packages/queue/test/vite.test.ts
@@ -24,16 +24,18 @@ describe("hubQueue", () => {
     const plugin = hubQueue({ provider: "cloudflare" })
     const config = plugin.config as unknown as (config: Record<string, unknown>) => unknown
     const configResolved = plugin.configResolved as (config: unknown) => Promise<void>
-    const userConfig = { nitro: { cloudflare: { wrangler: { compatibility_flags: ["custom"] } }, plugins: ["server/plugin.ts"] }, root }
+    const external = /^node:/
+    const userConfig = { nitro: { cloudflare: { wrangler: { compatibility_flags: ["custom"] } }, plugins: ["server/plugin.ts"], rollupConfig: { external } }, root }
 
     config(userConfig)
     expect(userConfig).toMatchObject({
       nitro: {
         cloudflare: { wrangler: { compatibility_flags: ["custom", "nodejs_compat"], queues: { consumers: [{ queue: "queue--77656c636f6d65" }], producers: [{ binding: "QUEUE_77656C636F6D65", queue: "queue--77656c636f6d65" }] } } },
         plugins: [".vitehub/nitro/queue/plugin.ts", "server/plugin.ts"],
-        rollupConfig: { external: ["cloudflare:workers"] },
+        rollupConfig: { external: [external, "cloudflare:workers"] },
       },
     })
+    expect((userConfig.nitro.rollupConfig.external as unknown as unknown[])[0]).toBe(external)
     config(userConfig)
     expect(userConfig).toMatchObject({
       nitro: { plugins: [".vitehub/nitro/queue/plugin.ts", "server/plugin.ts"] },
@@ -117,7 +119,7 @@ describe("hubQueue", () => {
     const initial = { nitro: {}, root }
     ;(plugin.config as unknown as (config: Record<string, unknown>) => void)(initial)
     expect(initial.nitro).not.toHaveProperty("cloudflare")
-    const resolved = { build: { outDir: "dist" }, command: "build", nitro: { ...initial.nitro, preset: "cloudflare_module" }, queue: undefined, root }
+    const resolved = { build: { outDir: "dist" }, command: "build", nitro: { ...initial.nitro, preset: "cloudflare_module" }, plugins: [{ name: "nitro:main" }], queue: undefined, root }
     await (plugin.configResolved as (config: unknown) => Promise<void>)(resolved as never)
     expect(resolved).toHaveProperty("nitro.cloudflare.wrangler.queues.producers")
     expect(resolved).toHaveProperty("nitro.rollupConfig.external", ["cloudflare:workers"])
@@ -188,7 +190,7 @@ describe("hubQueue", () => {
     expect(existsSync(join(createDefaultCloudflareOutputRoot(root), "index.js"))).toBe(true)
   })
 
-  it.each(["NITRO_PRESET", "SERVER_PRESET", "VITEHUB_HOSTING"])("keeps standalone output for plain Vite selected by %s", async (environmentVariable) => {
+  it.each(["NITRO_PRESET", "SERVER_PRESET", "VITEHUB_HOSTING"])("keeps standalone output after Blob's Nitro bridge when selected by %s", async (environmentVariable) => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-queue-nitro-"))
     roots.push(root)
     await writeFile(join(root, "welcome.queue.ts"), "export default { handler: async () => undefined }\n")
@@ -197,7 +199,7 @@ describe("hubQueue", () => {
 
     try {
       const plugin = hubQueue()
-      const config = { build: { outDir: "dist" }, command: "build", root }
+      const config = { build: { outDir: "dist" }, command: "build", nitro: { plugins: [".vitehub/nitro/blob/plugin.ts"] }, plugins: [{ name: "@vite-hub/blob/vite" }], root }
       ;(plugin.config as unknown as (config: Record<string, unknown>) => void)(config)
       await (plugin.configResolved as (config: unknown) => Promise<void>)(config as never)
       await (plugin.closeBundle as () => Promise<void>)()

--- a/packages/queue/test/vite.test.ts
+++ b/packages/queue/test/vite.test.ts
@@ -211,6 +211,40 @@ describe("hubQueue", () => {
     }
   })
 
+  it("rejects Queue Definitions generated after Nitro config resolution", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-queue-nitro-late-generated-"))
+    roots.push(root)
+    const plugin = hubQueue({ provider: "cloudflare" })
+    await (plugin.configResolved as (config: unknown) => Promise<void>)({
+      build: { outDir: "dist" },
+      command: "build",
+      nitro: { preset: "cloudflare_module" },
+      plugins: [{ name: "nitro:main" }],
+      root,
+    } as never)
+    await writeFile(join(root, "welcome.queue.ts"), "export default { handler: async () => undefined }\n")
+
+    await expect((plugin.closeBundle as () => Promise<void>)()).rejects.toThrow("changed after config resolution")
+  })
+
+  it("rejects Queue Definitions removed after Nitro config resolution", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-queue-nitro-late-removed-"))
+    roots.push(root)
+    const definition = join(root, "welcome.queue.ts")
+    await writeFile(definition, "export default { handler: async () => undefined }\n")
+    const plugin = hubQueue({ provider: "cloudflare" })
+    await (plugin.configResolved as (config: unknown) => Promise<void>)({
+      build: { outDir: "dist" },
+      command: "build",
+      nitro: { preset: "cloudflare_module" },
+      plugins: [{ name: "nitro:main" }],
+      root,
+    } as never)
+    await rm(definition)
+
+    await expect((plugin.closeBundle as () => Promise<void>)()).rejects.toThrow("changed after config resolution")
+  })
+
   it("rejects ambiguous and conflicting custom Cloudflare bindings", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-queue-nitro-"))
     roots.push(root)

--- a/packages/queue/test/vite.test.ts
+++ b/packages/queue/test/vite.test.ts
@@ -227,6 +227,28 @@ describe("hubQueue", () => {
     await expect((plugin.closeBundle as () => Promise<void>)()).rejects.toThrow("changed after config resolution")
   })
 
+  it("removes Queue bindings when final config discovery is empty", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-queue-nitro-empty-final-"))
+    roots.push(root)
+    const definition = join(root, "welcome.queue.ts")
+    await writeFile(definition, "export default { handler: async () => undefined }\n")
+    const plugin = hubQueue({ provider: "cloudflare" })
+    const config = { nitro: { preset: "cloudflare_module" }, root }
+    ;(plugin.config as unknown as (config: Record<string, unknown>) => void)(config)
+    expect(config).toHaveProperty("nitro.cloudflare.wrangler.queues")
+    await rm(definition)
+
+    const resolvedConfig = {
+      ...config,
+      build: { outDir: "dist" },
+      command: "build",
+      plugins: [{ name: "nitro:main" }],
+    }
+    await (plugin.configResolved as (config: unknown) => Promise<void>)(resolvedConfig as never)
+
+    expect(resolvedConfig.nitro).not.toHaveProperty("cloudflare.wrangler.queues")
+  })
+
   it("rejects Queue Definitions removed after Nitro config resolution", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-queue-nitro-late-removed-"))
     roots.push(root)

--- a/packages/queue/test/vite.test.ts
+++ b/packages/queue/test/vite.test.ts
@@ -1,8 +1,11 @@
+import { existsSync } from "node:fs"
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
+
+import { createDefaultCloudflareOutputRoot } from "@vite-hub/internal/build/deployment-output"
 
 import { hubQueue } from "../src/vite.ts"
 
@@ -114,10 +117,12 @@ describe("hubQueue", () => {
     const initial = { nitro: {}, root }
     ;(plugin.config as unknown as (config: Record<string, unknown>) => void)(initial)
     expect(initial.nitro).not.toHaveProperty("cloudflare")
-    const resolved = { nitro: { ...initial.nitro, preset: "cloudflare_module" }, queue: undefined, root }
+    const resolved = { build: { outDir: "dist" }, command: "build", nitro: { ...initial.nitro, preset: "cloudflare_module" }, queue: undefined, root }
     await (plugin.configResolved as (config: unknown) => Promise<void>)(resolved as never)
     expect(resolved).toHaveProperty("nitro.cloudflare.wrangler.queues.producers")
     expect(resolved).toHaveProperty("nitro.rollupConfig.external", ["cloudflare:workers"])
+    await (plugin.closeBundle as () => Promise<void>)()
+    expect(existsSync(join(createDefaultCloudflareOutputRoot(root), "index.js"))).toBe(false)
 
     const disabled = { nitro: { preset: "cloudflare_module", plugins: [".vitehub/nitro/queue/plugin.ts", "server/plugin.ts"] }, queue: false, root }
     ;(hubQueue(false).config as unknown as (config: Record<string, unknown>) => void)(disabled)
@@ -157,7 +162,7 @@ describe("hubQueue", () => {
 
     await (plugin.configResolved as (config: unknown) => Promise<void>)({
       build: { outDir: "dist" },
-      command: "serve",
+      command: "build",
       nitro: underscorePages.nitro,
       plugins: [],
       queue: { binding: "JOBS", provider: "cloudflare" },
@@ -167,6 +172,8 @@ describe("hubQueue", () => {
     const pagesPlugin = await readFile(join(root, ".vitehub", "nitro", "queue", "plugin.ts"), "utf8")
     expect(pagesPlugin).not.toContain("cloudflare:queue")
     expect(pagesPlugin).not.toContain("cloudflare:workers")
+    await (plugin.closeBundle as () => Promise<void>)()
+    expect(existsSync(join(createDefaultCloudflareOutputRoot(root), "index.js"))).toBe(true)
   })
 
   it("rejects ambiguous and conflicting custom Cloudflare bindings", async () => {

--- a/packages/rate-limit/src/internal/provider-output.ts
+++ b/packages/rate-limit/src/internal/provider-output.ts
@@ -36,7 +36,7 @@ async function readOutputState(rootDir: string): Promise<CloudflareRateLimitOutp
       bindings: Array.isArray(parsed.bindings)
         ? parsed.bindings.filter((value): value is string => typeof value === "string")
         : [],
-      standalone: parsed.standalone === true,
+      standalone: parsed.standalone !== false && Array.isArray(parsed.bindings) && parsed.bindings.length > 0,
     }
   }
   catch (error) {

--- a/packages/rate-limit/src/internal/provider-output.ts
+++ b/packages/rate-limit/src/internal/provider-output.ts
@@ -112,16 +112,6 @@ export async function writeRateLimitProviderOutput(options: {
     if (options.provider === "cloudflare" && options.declarations.length > 0 && !options.namespace) {
       throw new Error("[vitehub] Cloudflare Rate Limit requires rateLimit.namespace to isolate counters between deployments.")
     }
-    await writeProviderDeploymentOutputs({
-      clientOutDir: options.clientOutDir,
-      cleanup: {
-        cloudflare: {
-          outputRoot: createDefaultCloudflareOutputRoot(options.rootDir),
-          wranglerConfigOwnership: ownership,
-        },
-      },
-      rootDir: options.rootDir,
-    })
     await writeOutputState(options.rootDir, options.provider === "cloudflare" ? currentBindings : [])
     await writeRateLimitManifest(options.rootDir, options.declarations, options.provider)
     return

--- a/packages/rate-limit/src/internal/provider-output.ts
+++ b/packages/rate-limit/src/internal/provider-output.ts
@@ -52,7 +52,7 @@ async function writeOutputState(rootDir: string, bindings: string[], standalone 
     return
   }
   await mkdir(dirname(file), { recursive: true })
-  await writeFile(file, `${JSON.stringify({ bindings, ...(standalone ? { standalone: true } : {}) }, null, 2)}\n`, "utf8")
+  await writeFile(file, `${JSON.stringify({ bindings, standalone }, null, 2)}\n`, "utf8")
 }
 
 function namespaceId(namespace: string, rateLimitId: string): string {

--- a/packages/rate-limit/src/internal/provider-output.ts
+++ b/packages/rate-limit/src/internal/provider-output.ts
@@ -22,6 +22,7 @@ interface CloudflareRateLimitBindingConfig {
 
 interface CloudflareRateLimitOutputState {
   bindings: string[]
+  standalone: boolean
 }
 
 function outputStateFile(rootDir: string): string {
@@ -35,22 +36,23 @@ async function readOutputState(rootDir: string): Promise<CloudflareRateLimitOutp
       bindings: Array.isArray(parsed.bindings)
         ? parsed.bindings.filter((value): value is string => typeof value === "string")
         : [],
+      standalone: parsed.standalone === true,
     }
   }
   catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { bindings: [] }
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return { bindings: [], standalone: false }
     throw error
   }
 }
 
-async function writeOutputState(rootDir: string, bindings: string[]): Promise<void> {
+async function writeOutputState(rootDir: string, bindings: string[], standalone = false): Promise<void> {
   const file = outputStateFile(rootDir)
   if (bindings.length === 0) {
     await rm(file, { force: true })
     return
   }
   await mkdir(dirname(file), { recursive: true })
-  await writeFile(file, `${JSON.stringify({ bindings }, null, 2)}\n`, "utf8")
+  await writeFile(file, `${JSON.stringify({ bindings, ...(standalone ? { standalone: true } : {}) }, null, 2)}\n`, "utf8")
 }
 
 function namespaceId(namespace: string, rateLimitId: string): string {
@@ -112,7 +114,27 @@ export async function writeRateLimitProviderOutput(options: {
     if (options.provider === "cloudflare" && options.declarations.length > 0 && !options.namespace) {
       throw new Error("[vitehub] Cloudflare Rate Limit requires rateLimit.namespace to isolate counters between deployments.")
     }
-    await writeOutputState(options.rootDir, options.provider === "cloudflare" ? currentBindings : [])
+    const hasComposedBindings = options.provider === "cloudflare" && options.declarations.length > 0
+    if (!hasComposedBindings && state.standalone && state.bindings.length > 0) {
+      await writeProviderDeploymentOutputs({
+        clientOutDir: options.clientOutDir,
+        cleanup: {
+          cloudflare: {
+            outputRoot: createDefaultCloudflareOutputRoot(options.rootDir),
+            wranglerConfigOwnership: {
+              arrays: {
+                ratelimits: {
+                  key: "name",
+                  values: state.bindings,
+                },
+              },
+            },
+          },
+        },
+        rootDir: options.rootDir,
+      })
+    }
+    await writeOutputState(options.rootDir, hasComposedBindings ? currentBindings : [])
     await writeRateLimitManifest(options.rootDir, options.declarations, options.provider)
     return
   }
@@ -132,7 +154,7 @@ export async function writeRateLimitProviderOutput(options: {
       },
       rootDir: options.rootDir,
     })
-    await writeOutputState(options.rootDir, currentBindings)
+    await writeOutputState(options.rootDir, currentBindings, true)
     await writeRateLimitManifest(options.rootDir, options.declarations, options.provider)
     return
   }

--- a/packages/rate-limit/src/internal/provider-output.ts
+++ b/packages/rate-limit/src/internal/provider-output.ts
@@ -135,7 +135,7 @@ export async function writeRateLimitProviderOutput(options: {
         rootDir: options.rootDir,
       })
     }
-    await writeOutputState(options.rootDir, hasComposedBindings ? currentBindings : [])
+    await writeOutputState(options.rootDir, [])
     await writeRateLimitManifest(options.rootDir, options.declarations, options.provider)
     return
   }

--- a/packages/rate-limit/src/internal/provider-output.ts
+++ b/packages/rate-limit/src/internal/provider-output.ts
@@ -115,7 +115,7 @@ export async function writeRateLimitProviderOutput(options: {
       throw new Error("[vitehub] Cloudflare Rate Limit requires rateLimit.namespace to isolate counters between deployments.")
     }
     const hasComposedBindings = options.provider === "cloudflare" && options.declarations.length > 0
-    const staleBindings = state.bindings.filter(binding => !currentBindings.includes(binding))
+    const staleBindings = hasComposedBindings ? state.bindings.filter(binding => !currentBindings.includes(binding)) : state.bindings
     if (state.standalone && staleBindings.length > 0) {
       await writeProviderDeploymentOutputs({
         clientOutDir: options.clientOutDir,

--- a/packages/rate-limit/src/internal/provider-output.ts
+++ b/packages/rate-limit/src/internal/provider-output.ts
@@ -11,6 +11,7 @@ import type { ProviderOutputConfigOwnership } from "@vite-hub/internal/build/pro
 import type { RateLimitDeclaration } from "../types.ts"
 
 interface CloudflareRateLimitBindingConfig {
+  [key: string]: unknown
   name: string
   namespace_id: string
   simple: {
@@ -88,6 +89,7 @@ export function resolveRateLimitNamespace(configured?: string): string | undefin
 
 export async function writeRateLimitProviderOutput(options: {
   clientOutDir: string
+  cloudflareOwnedByNitro?: boolean
   declarations: RateLimitDeclaration[]
   namespace?: string
   previousDeclarations?: RateLimitDeclaration[]
@@ -105,6 +107,25 @@ export async function writeRateLimitProviderOutput(options: {
       },
     },
   } satisfies ProviderOutputConfigOwnership
+
+  if (options.cloudflareOwnedByNitro) {
+    if (options.provider === "cloudflare" && options.declarations.length > 0 && !options.namespace) {
+      throw new Error("[vitehub] Cloudflare Rate Limit requires rateLimit.namespace to isolate counters between deployments.")
+    }
+    await writeProviderDeploymentOutputs({
+      clientOutDir: options.clientOutDir,
+      cleanup: {
+        cloudflare: {
+          outputRoot: createDefaultCloudflareOutputRoot(options.rootDir),
+          wranglerConfigOwnership: ownership,
+        },
+      },
+      rootDir: options.rootDir,
+    })
+    await writeOutputState(options.rootDir, options.provider === "cloudflare" ? currentBindings : [])
+    await writeRateLimitManifest(options.rootDir, options.declarations, options.provider)
+    return
+  }
 
   if (options.provider === "cloudflare" && options.declarations.length > 0) {
     if (!options.namespace) {

--- a/packages/rate-limit/src/internal/provider-output.ts
+++ b/packages/rate-limit/src/internal/provider-output.ts
@@ -115,7 +115,8 @@ export async function writeRateLimitProviderOutput(options: {
       throw new Error("[vitehub] Cloudflare Rate Limit requires rateLimit.namespace to isolate counters between deployments.")
     }
     const hasComposedBindings = options.provider === "cloudflare" && options.declarations.length > 0
-    if (!hasComposedBindings && state.standalone && state.bindings.length > 0) {
+    const staleBindings = state.bindings.filter(binding => !currentBindings.includes(binding))
+    if (state.standalone && staleBindings.length > 0) {
       await writeProviderDeploymentOutputs({
         clientOutDir: options.clientOutDir,
         cleanup: {
@@ -125,7 +126,7 @@ export async function writeRateLimitProviderOutput(options: {
               arrays: {
                 ratelimits: {
                   key: "name",
-                  values: state.bindings,
+                  values: staleBindings,
                 },
               },
             },

--- a/packages/rate-limit/src/vite.ts
+++ b/packages/rate-limit/src/vite.ts
@@ -54,7 +54,7 @@ function mergeNitroConfig(
   const baseNitro = { ...nitro, plugins }
   if (!nitroCloudflare || provider !== "cloudflare" || declarations.length === 0) {
     registerCloudflareProviderOutput(config, "rate-limit", {})
-    return baseNitro
+    return composeNitroCloudflareProviderOutput(config, baseNitro)
   }
   if (!namespace) {
     throw new Error("[vitehub] Cloudflare Rate Limit requires rateLimit.namespace to isolate counters between deployments.")

--- a/packages/rate-limit/src/vite.ts
+++ b/packages/rate-limit/src/vite.ts
@@ -3,6 +3,8 @@ import { resolve } from "node:path"
 
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import {
+  composeNitroCloudflareProviderOutput,
+  registerCloudflareProviderOutput,
   registerProviderRuntimeModules,
   shouldSkipViteProviderBuild,
   useComposedProviderOutput,
@@ -14,7 +16,7 @@ import { normalizePath } from "vite"
 
 import { discoverRateLimitDeclarations } from "./discovery.ts"
 import { writeRateLimitManifest } from "./internal/manifest.ts"
-import { resolveRateLimitNamespace, writeRateLimitProviderOutput } from "./internal/provider-output.ts"
+import { createCloudflareRateLimitBindings, resolveRateLimitNamespace, writeRateLimitProviderOutput } from "./internal/provider-output.ts"
 
 import type { ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
 import type { Plugin, ResolvedConfig } from "vite"
@@ -38,11 +40,29 @@ function cloneNitroConfig(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {}
 }
 
-function mergeNitroConfig(value: unknown): Record<string, unknown> {
+function mergeNitroConfig(
+  config: object,
+  value: unknown,
+  declarations: RateLimitDeclaration[],
+  namespace: string | undefined,
+  provider: "cloudflare" | "memory" | undefined,
+  cloudflareOwnedByNitro: boolean,
+): Record<string, unknown> {
   const nitro = cloneNitroConfig(value)
   const plugins = Array.isArray(nitro.plugins) ? [...nitro.plugins] : []
   if (!plugins.includes(generatedNitroPlugin)) plugins.unshift(generatedNitroPlugin)
-  return { ...nitro, plugins }
+  const baseNitro = { ...nitro, plugins }
+  if (!cloudflareOwnedByNitro || provider !== "cloudflare" || declarations.length === 0) {
+    registerCloudflareProviderOutput(config, "rate-limit", {})
+    return baseNitro
+  }
+  if (!namespace) {
+    throw new Error("[vitehub] Cloudflare Rate Limit requires rateLimit.namespace to isolate counters between deployments.")
+  }
+  registerCloudflareProviderOutput(config, "rate-limit", {
+    rateLimits: createCloudflareRateLimitBindings(declarations, namespace),
+  })
+  return composeNitroCloudflareProviderOutput(config, baseNitro)
 }
 
 function renderRuntimeInstaller(
@@ -70,16 +90,23 @@ function renderRuntimeInstaller(
   ].join("\n")
 }
 
-function resolveProvider(options: RateLimitModuleOptions, config: ResolvedConfig): "cloudflare" | "memory" {
+function resolveProvider(options: RateLimitModuleOptions, command: "build" | "serve", nitro: unknown, deferUnknown = false): "cloudflare" | "memory" | undefined {
   if (options.provider && options.provider !== "auto") return options.provider
-  if (config.command === "serve") return "memory"
-  const nitroPreset = (config as { nitro?: { preset?: string } }).nitro?.preset
-  const hosting = getHostingProvider(nitroPreset || process.env.VITEHUB_HOSTING)
+  if (command === "serve") return "memory"
+  const nitroPreset = cloneNitroConfig(nitro).preset
+  const hosting = getHostingProvider(typeof nitroPreset === "string" ? nitroPreset : process.env.VITEHUB_HOSTING)
   if (hosting === "cloudflare") return "cloudflare"
   if (hosting) {
     throw new Error(`[vitehub] Rate Limit has no native ${hosting} driver. Configure a custom Rate Limiter instead of falling back to per-instance memory.`)
   }
+  if (deferUnknown) return
   throw new Error("[vitehub] Rate Limit provider cannot be inferred for a production build. Set rateLimit.provider to \"cloudflare\" or explicitly choose \"memory\" for a known single-process deployment.")
+}
+
+function isNitroCloudflareHost(nitro: unknown): boolean {
+  if (!nitro || typeof nitro !== "object" || Array.isArray(nitro)) return false
+  const preset = cloneNitroConfig(nitro).preset
+  return typeof preset === "string" && getHostingProvider(preset) === "cloudflare"
 }
 
 export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimitVitePlugin {
@@ -88,26 +115,45 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
   let composedOutput: ComposedProviderOutput | undefined
   let declarations: RateLimitDeclaration[] = []
   let declarationFiles = new Set<string>()
+  let cloudflareOwnedByNitro = false
   let previousDeclarations: RateLimitDeclaration[] = []
   let provider: "cloudflare" | "memory" = "memory"
   let projectRoot: string | undefined
   let resolved: ResolvedConfig | undefined
 
-  const refreshDeclarations = async (): Promise<void> => {
-    if (!projectRoot || !resolved) return
+  const collectDeclarations = (): void => {
+    if (!projectRoot) return
     declarations = discoverRateLimitDeclarations({
       rootDir: projectRoot,
       scanDirs: rateLimit.scanDirs,
     })
     declarationFiles = new Set(declarations.map(declaration => declaration.source.file))
+  }
+
+  const refreshDeclarations = async (): Promise<void> => {
+    if (!projectRoot || !resolved) return
+    collectDeclarations()
     await writeRateLimitManifest(resolved.root, declarations, provider)
   }
 
   return {
     name: pluginName,
-    config(config) {
+    config(config, env) {
       rateLimit = config.rateLimit ?? rateLimit
-      const nitro = mergeNitroConfig((config as { nitro?: unknown }).nitro)
+      const configuredNitro = (config as { nitro?: unknown }).nitro
+      cloudflareOwnedByNitro = isNitroCloudflareHost(configuredNitro)
+      projectRoot = resolveViteHubProjectRoot(config.root || process.cwd(), { projectRoot: rateLimit.projectRoot })
+      const configuredProvider = resolveProvider(rateLimit, env?.command ?? "serve", configuredNitro, true)
+      if (configuredProvider) provider = configuredProvider
+      collectDeclarations()
+      const nitro = mergeNitroConfig(
+        config,
+        configuredNitro,
+        declarations,
+        resolveRateLimitNamespace(rateLimit.namespace),
+        configuredProvider,
+        cloudflareOwnedByNitro,
+      )
       ;(config as { nitro?: unknown }).nitro = nitro
       return { nitro } as never
     },
@@ -116,8 +162,19 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
       rateLimit = config.rateLimit ?? rateLimit
       composedOutput = useComposedProviderOutput(config)
       projectRoot = resolveViteHubProjectRoot(config.root, { projectRoot: rateLimit.projectRoot })
-      provider = resolveProvider(rateLimit, config)
-      await refreshDeclarations()
+      const configuredNitro = (config as { nitro?: unknown }).nitro
+      cloudflareOwnedByNitro = isNitroCloudflareHost(configuredNitro)
+      provider = resolveProvider(rateLimit, config.command, configuredNitro)!
+      collectDeclarations()
+      ;(config as { nitro?: unknown }).nitro = mergeNitroConfig(
+        config,
+        configuredNitro,
+        declarations,
+        resolveRateLimitNamespace(rateLimit.namespace),
+        provider,
+        cloudflareOwnedByNitro,
+      )
+      await writeRateLimitManifest(config.root, declarations, provider)
       const pluginFile = resolve(config.root, generatedNitroPlugin)
       const runtimeFile = resolve(config.root, generatedRuntimeModule)
       const runtimeConfig = { provider } satisfies RateLimitRuntimeConfig
@@ -143,10 +200,21 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
     },
     async closeBundle() {
       if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
-      await refreshDeclarations()
+      if (cloudflareOwnedByNitro) {
+        const configuredDeclarations = declarations
+        collectDeclarations()
+        if (JSON.stringify(declarations) !== JSON.stringify(configuredDeclarations)) {
+          throw new Error("[vitehub] Nitro Cloudflare Rate Limit declarations changed after config resolution. Generate Rate Limit source files before Vite config resolves.")
+        }
+        await writeRateLimitManifest(resolved.root, declarations, provider)
+      }
+      else {
+        await refreshDeclarations()
+      }
       const namespace = resolveRateLimitNamespace(rateLimit.namespace)
       await writeRateLimitProviderOutput({
         clientOutDir: resolved.build.outDir,
+        cloudflareOwnedByNitro,
         declarations,
         namespace,
         previousDeclarations,

--- a/packages/rate-limit/src/vite.ts
+++ b/packages/rate-limit/src/vite.ts
@@ -79,7 +79,7 @@ function renderRuntimeInstaller(
       ? [
           "export default definePlugin((nitroApp) => {",
           "  setRateLimitRuntimeConfig(config)",
-          "  nitroApp.hooks.hook('request', (event) => enterRateLimitRuntimeEvent(event))",
+          "  nitroApp.hooks.hook('request', (event) => enterRateLimitRuntimeEvent(Object.assign(event, { env: event.env ?? event.context?.cloudflare?.env ?? event.context?._platform?.cloudflare?.env ?? event.req?.runtime?.cloudflare?.env ?? event.node?.req?.runtime?.cloudflare?.env })))",
           "})",
         ]
       : [

--- a/packages/rate-limit/src/vite.ts
+++ b/packages/rate-limit/src/vite.ts
@@ -198,7 +198,7 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
     },
     async closeBundle() {
       if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
-      if (cloudflareOwnedByNitro) {
+      if (cloudflareOwnedByNitro && provider === "cloudflare") {
         const configuredDeclarations = declarations
         collectDeclarations()
         if (JSON.stringify(declarations) !== JSON.stringify(configuredDeclarations)) {

--- a/packages/rate-limit/src/vite.ts
+++ b/packages/rate-limit/src/vite.ts
@@ -9,7 +9,7 @@ import {
   shouldSkipViteProviderBuild,
   useComposedProviderOutput,
 } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, isServerEnvironment, resolveViteHubProjectRoot } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, hasNitroVitePlugin, isServerEnvironment, resolveViteHubProjectRoot } from "@vite-hub/internal/build/vite"
 import { writeFileIfChanged } from "@vite-hub/internal/definition-catalog"
 import { getHostingProvider } from "@vite-hub/internal/hosting"
 import { normalizePath } from "vite"
@@ -46,13 +46,13 @@ function mergeNitroConfig(
   declarations: RateLimitDeclaration[],
   namespace: string | undefined,
   provider: "cloudflare" | "memory" | undefined,
-  cloudflareOwnedByNitro: boolean,
+  nitroCloudflare: boolean,
 ): Record<string, unknown> {
   const nitro = cloneNitroConfig(value)
   const plugins = Array.isArray(nitro.plugins) ? [...nitro.plugins] : []
   if (!plugins.includes(generatedNitroPlugin)) plugins.unshift(generatedNitroPlugin)
   const baseNitro = { ...nitro, plugins }
-  if (!cloudflareOwnedByNitro || provider !== "cloudflare" || declarations.length === 0) {
+  if (!nitroCloudflare || provider !== "cloudflare" || declarations.length === 0) {
     registerCloudflareProviderOutput(config, "rate-limit", {})
     return baseNitro
   }
@@ -141,7 +141,6 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
     config(config, env) {
       rateLimit = config.rateLimit ?? rateLimit
       const configuredNitro = (config as { nitro?: unknown }).nitro
-      cloudflareOwnedByNitro = isNitroCloudflareHost(configuredNitro)
       projectRoot = resolveViteHubProjectRoot(config.root || process.cwd(), { projectRoot: rateLimit.projectRoot })
       const configuredProvider = resolveProvider(rateLimit, env?.command ?? "serve", configuredNitro, true)
       if (configuredProvider) provider = configuredProvider
@@ -152,7 +151,7 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
         declarations,
         resolveRateLimitNamespace(rateLimit.namespace),
         configuredProvider,
-        cloudflareOwnedByNitro,
+        isNitroCloudflareHost(configuredNitro),
       )
       ;(config as { nitro?: unknown }).nitro = nitro
       return { nitro } as never
@@ -163,7 +162,8 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
       composedOutput = useComposedProviderOutput(config)
       projectRoot = resolveViteHubProjectRoot(config.root, { projectRoot: rateLimit.projectRoot })
       const configuredNitro = (config as { nitro?: unknown }).nitro
-      cloudflareOwnedByNitro = isNitroCloudflareHost(configuredNitro)
+      const nitroCloudflare = isNitroCloudflareHost(configuredNitro)
+      cloudflareOwnedByNitro = hasNitroVitePlugin(config) && nitroCloudflare
       provider = resolveProvider(rateLimit, config.command, configuredNitro)!
       collectDeclarations()
       ;(config as { nitro?: unknown }).nitro = mergeNitroConfig(
@@ -172,7 +172,7 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
         declarations,
         resolveRateLimitNamespace(rateLimit.namespace),
         provider,
-        cloudflareOwnedByNitro,
+        nitroCloudflare,
       )
       await writeRateLimitManifest(config.root, declarations, provider)
       const pluginFile = resolve(config.root, generatedNitroPlugin)

--- a/packages/rate-limit/src/vite.ts
+++ b/packages/rate-limit/src/vite.ts
@@ -93,8 +93,7 @@ function renderRuntimeInstaller(
 function resolveProvider(options: RateLimitModuleOptions, command: "build" | "serve", nitro: unknown, deferUnknown = false): "cloudflare" | "memory" | undefined {
   if (options.provider && options.provider !== "auto") return options.provider
   if (command === "serve") return "memory"
-  const nitroPreset = cloneNitroConfig(nitro).preset
-  const hosting = getHostingProvider(typeof nitroPreset === "string" ? nitroPreset : process.env.VITEHUB_HOSTING)
+  const hosting = resolveNitroHosting(nitro)
   if (hosting === "cloudflare") return "cloudflare"
   if (hosting) {
     throw new Error(`[vitehub] Rate Limit has no native ${hosting} driver. Configure a custom Rate Limiter instead of falling back to per-instance memory.`)
@@ -103,10 +102,9 @@ function resolveProvider(options: RateLimitModuleOptions, command: "build" | "se
   throw new Error("[vitehub] Rate Limit provider cannot be inferred for a production build. Set rateLimit.provider to \"cloudflare\" or explicitly choose \"memory\" for a known single-process deployment.")
 }
 
-function isNitroCloudflareHost(nitro: unknown): boolean {
-  if (!nitro || typeof nitro !== "object" || Array.isArray(nitro)) return false
+function resolveNitroHosting(nitro: unknown): string | undefined {
   const preset = cloneNitroConfig(nitro).preset
-  return typeof preset === "string" && getHostingProvider(preset) === "cloudflare"
+  return getHostingProvider(typeof preset === "string" ? preset : process.env.NITRO_PRESET || process.env.SERVER_PRESET || process.env.VITEHUB_HOSTING)
 }
 
 export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimitVitePlugin {
@@ -151,7 +149,7 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
         declarations,
         resolveRateLimitNamespace(rateLimit.namespace),
         configuredProvider,
-        isNitroCloudflareHost(configuredNitro),
+        resolveNitroHosting(configuredNitro) === "cloudflare",
       )
       ;(config as { nitro?: unknown }).nitro = nitro
       return { nitro } as never
@@ -162,7 +160,7 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
       composedOutput = useComposedProviderOutput(config)
       projectRoot = resolveViteHubProjectRoot(config.root, { projectRoot: rateLimit.projectRoot })
       const configuredNitro = (config as { nitro?: unknown }).nitro
-      const nitroCloudflare = isNitroCloudflareHost(configuredNitro)
+      const nitroCloudflare = resolveNitroHosting(configuredNitro) === "cloudflare"
       cloudflareOwnedByNitro = hasNitroVitePlugin(config) && nitroCloudflare
       provider = resolveProvider(rateLimit, config.command, configuredNitro)!
       collectDeclarations()

--- a/packages/rate-limit/test/provider-output.test.ts
+++ b/packages/rate-limit/test/provider-output.test.ts
@@ -111,6 +111,9 @@ describe("Rate Limit Provider Output", () => {
     const { declarations, root } = await projectWithDeclaration()
     const configFile = join(createDefaultCloudflareOutputRoot(root), "wrangler.json")
     await writeRateLimitProviderOutput({ clientOutDir: "dist", declarations, namespace: "acme-image-service", provider: "cloudflare", rootDir: root })
+    const stateFile = join(root, ".vitehub", "rate-limit", "cloudflare-output.json")
+    const legacyState = JSON.parse(await readFile(stateFile, "utf8")) as { bindings: string[] }
+    await writeFile(stateFile, `${JSON.stringify({ bindings: legacyState.bindings }, null, 2)}\n`)
     const standalone = JSON.parse(await readFile(configFile, "utf8"))
     await writeFile(configFile, `${JSON.stringify({ ...standalone, vars: { APP: "vitehub" } }, null, 2)}\n`)
     const renamed = [{ ...declarations[0]!, name: "renamed" }]

--- a/packages/rate-limit/test/provider-output.test.ts
+++ b/packages/rate-limit/test/provider-output.test.ts
@@ -71,6 +71,39 @@ describe("Rate Limit Provider Output", () => {
     })
   })
 
+  it("leaves Nitro-owned Cloudflare output untouched while persisting generated state", async () => {
+    const { declarations, root } = await projectWithDeclaration()
+    const outputRoot = createDefaultCloudflareOutputRoot(root)
+    const configFile = join(outputRoot, "wrangler.json")
+    const existingConfig = {
+      ratelimits: [
+        { name: "NITRO", namespace_id: "7", simple: { limit: 2, period: 10 } },
+        { name: getCloudflareRateLimitBindingName("upload"), namespace_id: "8", simple: { limit: 10, period: 60 } },
+      ],
+      vars: { APP: "vitehub" },
+    }
+    await mkdir(outputRoot, { recursive: true })
+    await writeFile(configFile, `${JSON.stringify(existingConfig, null, 2)}\n`)
+
+    await writeRateLimitProviderOutput({
+      clientOutDir: "dist",
+      cloudflareOwnedByNitro: true,
+      declarations,
+      namespace: "acme-image-service",
+      provider: "cloudflare",
+      rootDir: root,
+    })
+
+    await expect(readFile(configFile, "utf8").then(JSON.parse)).resolves.toEqual({
+      ratelimits: [{ name: "NITRO", namespace_id: "7", simple: { limit: 2, period: 10 } }],
+      vars: { APP: "vitehub" },
+    })
+    await expect(readFile(join(root, ".vitehub", "rate-limit", "cloudflare-output.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+      bindings: [getCloudflareRateLimitBindingName("upload")],
+    })
+    await expect(readFile(join(root, ".vitehub", "rate-limit", "manifest.json"), "utf8")).resolves.toContain('"provider": "cloudflare"')
+  })
+
   it("rejects unsupported Cloudflare guarantees", async () => {
     const strict = await projectWithDeclaration({ enforcement: "strict", limit: 10, window: "1m" })
     expect(() => createCloudflareRateLimitBindings(strict.declarations, "test")).toThrow("best-effort")

--- a/packages/rate-limit/test/provider-output.test.ts
+++ b/packages/rate-limit/test/provider-output.test.ts
@@ -75,6 +75,13 @@ describe("Rate Limit Provider Output", () => {
     const { declarations, root } = await projectWithDeclaration()
     const outputRoot = createDefaultCloudflareOutputRoot(root)
     const configFile = join(outputRoot, "wrangler.json")
+    await writeRateLimitProviderOutput({
+      clientOutDir: "dist",
+      declarations,
+      namespace: "acme-image-service",
+      provider: "cloudflare",
+      rootDir: root,
+    })
     const existingConfig = {
       ratelimits: [
         { name: "NITRO", namespace_id: "7", simple: { limit: 2, period: 10 } },
@@ -82,7 +89,6 @@ describe("Rate Limit Provider Output", () => {
       ],
       vars: { APP: "vitehub" },
     }
-    await mkdir(outputRoot, { recursive: true })
     await writeFile(configFile, `${JSON.stringify(existingConfig, null, 2)}\n`)
 
     await writeRateLimitProviderOutput({
@@ -94,10 +100,7 @@ describe("Rate Limit Provider Output", () => {
       rootDir: root,
     })
 
-    await expect(readFile(configFile, "utf8").then(JSON.parse)).resolves.toEqual({
-      ratelimits: [{ name: "NITRO", namespace_id: "7", simple: { limit: 2, period: 10 } }],
-      vars: { APP: "vitehub" },
-    })
+    await expect(readFile(configFile, "utf8").then(JSON.parse)).resolves.toEqual(existingConfig)
     await expect(readFile(join(root, ".vitehub", "rate-limit", "cloudflare-output.json"), "utf8").then(JSON.parse)).resolves.toEqual({
       bindings: [getCloudflareRateLimitBindingName("upload")],
     })

--- a/packages/rate-limit/test/provider-output.test.ts
+++ b/packages/rate-limit/test/provider-output.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -105,6 +105,40 @@ describe("Rate Limit Provider Output", () => {
       bindings: [getCloudflareRateLimitBindingName("upload")],
     })
     await expect(readFile(join(root, ".vitehub", "rate-limit", "manifest.json"), "utf8")).resolves.toContain('"provider": "cloudflare"')
+  })
+
+  it("cleans only marker-owned standalone bindings when Nitro transitions to memory", async () => {
+    const { declarations, root } = await projectWithDeclaration()
+    const outputRoot = createDefaultCloudflareOutputRoot(root)
+    const configFile = join(outputRoot, "wrangler.json")
+    await writeRateLimitProviderOutput({
+      clientOutDir: "dist",
+      declarations,
+      namespace: "acme-image-service",
+      provider: "cloudflare",
+      rootDir: root,
+    })
+    await writeFile(configFile, `${JSON.stringify({
+      ratelimits: [
+        { name: "MANUAL", namespace_id: "7", simple: { limit: 2, period: 10 } },
+        ...createCloudflareRateLimitBindings(declarations, "acme-image-service"),
+      ],
+      vars: { APP: "vitehub" },
+    }, null, 2)}\n`)
+
+    await writeRateLimitProviderOutput({
+      clientOutDir: "dist",
+      cloudflareOwnedByNitro: true,
+      declarations: [],
+      provider: "memory",
+      rootDir: root,
+    })
+
+    await expect(readFile(configFile, "utf8").then(JSON.parse)).resolves.toEqual({
+      ratelimits: [{ name: "MANUAL", namespace_id: "7", simple: { limit: 2, period: 10 } }],
+      vars: { APP: "vitehub" },
+    })
+    await expect(access(join(root, ".vitehub", "rate-limit", "cloudflare-output.json"))).rejects.toMatchObject({ code: "ENOENT" })
   })
 
   it("rejects unsupported Cloudflare guarantees", async () => {

--- a/packages/rate-limit/test/provider-output.test.ts
+++ b/packages/rate-limit/test/provider-output.test.ts
@@ -107,6 +107,26 @@ describe("Rate Limit Provider Output", () => {
     await expect(readFile(join(root, ".vitehub", "rate-limit", "manifest.json"), "utf8")).resolves.toContain('"provider": "cloudflare"')
   })
 
+  it("cleans renamed standalone bindings during Nitro takeover", async () => {
+    const { declarations, root } = await projectWithDeclaration()
+    const configFile = join(createDefaultCloudflareOutputRoot(root), "wrangler.json")
+    await writeRateLimitProviderOutput({ clientOutDir: "dist", declarations, namespace: "acme-image-service", provider: "cloudflare", rootDir: root })
+    const standalone = JSON.parse(await readFile(configFile, "utf8"))
+    await writeFile(configFile, `${JSON.stringify({ ...standalone, vars: { APP: "vitehub" } }, null, 2)}\n`)
+    const renamed = [{ ...declarations[0]!, name: "renamed" }]
+
+    await writeRateLimitProviderOutput({
+      clientOutDir: "dist",
+      cloudflareOwnedByNitro: true,
+      declarations: renamed,
+      namespace: "acme-image-service",
+      provider: "cloudflare",
+      rootDir: root,
+    })
+
+    await expect(readFile(configFile, "utf8").then(JSON.parse)).resolves.toEqual({ vars: { APP: "vitehub" } })
+  })
+
   it("cleans only marker-owned standalone bindings when Nitro transitions to memory", async () => {
     const { declarations, root } = await projectWithDeclaration()
     const outputRoot = createDefaultCloudflareOutputRoot(root)

--- a/packages/rate-limit/test/provider-output.test.ts
+++ b/packages/rate-limit/test/provider-output.test.ts
@@ -149,7 +149,7 @@ describe("Rate Limit Provider Output", () => {
     await writeRateLimitProviderOutput({
       clientOutDir: "dist",
       cloudflareOwnedByNitro: true,
-      declarations: [],
+      declarations,
       provider: "memory",
       rootDir: root,
     })

--- a/packages/rate-limit/test/provider-output.test.ts
+++ b/packages/rate-limit/test/provider-output.test.ts
@@ -103,6 +103,7 @@ describe("Rate Limit Provider Output", () => {
     await expect(readFile(configFile, "utf8").then(JSON.parse)).resolves.toEqual(existingConfig)
     await expect(readFile(join(root, ".vitehub", "rate-limit", "cloudflare-output.json"), "utf8").then(JSON.parse)).resolves.toEqual({
       bindings: [getCloudflareRateLimitBindingName("upload")],
+      standalone: false,
     })
     await expect(readFile(join(root, ".vitehub", "rate-limit", "manifest.json"), "utf8")).resolves.toContain('"provider": "cloudflare"')
   })

--- a/packages/rate-limit/test/provider-output.test.ts
+++ b/packages/rate-limit/test/provider-output.test.ts
@@ -71,7 +71,7 @@ describe("Rate Limit Provider Output", () => {
     })
   })
 
-  it("leaves Nitro-owned Cloudflare output untouched while persisting generated state", async () => {
+  it("leaves Nitro-owned Cloudflare output untouched without claiming standalone state", async () => {
     const { declarations, root } = await projectWithDeclaration()
     const outputRoot = createDefaultCloudflareOutputRoot(root)
     const configFile = join(outputRoot, "wrangler.json")
@@ -101,10 +101,7 @@ describe("Rate Limit Provider Output", () => {
     })
 
     await expect(readFile(configFile, "utf8").then(JSON.parse)).resolves.toEqual(existingConfig)
-    await expect(readFile(join(root, ".vitehub", "rate-limit", "cloudflare-output.json"), "utf8").then(JSON.parse)).resolves.toEqual({
-      bindings: [getCloudflareRateLimitBindingName("upload")],
-      standalone: false,
-    })
+    await expect(access(join(root, ".vitehub", "rate-limit", "cloudflare-output.json"))).rejects.toMatchObject({ code: "ENOENT" })
     await expect(readFile(join(root, ".vitehub", "rate-limit", "manifest.json"), "utf8")).resolves.toContain('"provider": "cloudflare"')
   })
 

--- a/packages/rate-limit/test/vite.test.ts
+++ b/packages/rate-limit/test/vite.test.ts
@@ -104,12 +104,12 @@ describe("hubRateLimit", () => {
     expect(vercelConfig({ nitro: { preset: "vercel" }, root }, { command: "build" }).nitro).not.toHaveProperty("cloudflare.wrangler.ratelimits")
   })
 
-  it("keeps standalone output when hosting inference has no Nitro preset", async () => {
+  it.each(["NITRO_PRESET", "SERVER_PRESET", "VITEHUB_HOSTING"])("keeps standalone output without Nitro when hosting is selected by %s", async (environmentVariable) => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-plain-cloudflare-"))
     roots.push(root)
     await writeCloudflareDeclaration(root)
-    const previousHosting = process.env.VITEHUB_HOSTING
-    process.env.VITEHUB_HOSTING = "cloudflare"
+    const previousHosting = process.env[environmentVariable]
+    process.env[environmentVariable] = "cloudflare"
     try {
       const plugin = hubRateLimit({ namespace: "vite-test" })
       const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => unknown
@@ -125,8 +125,35 @@ describe("hubRateLimit", () => {
       await expect(readFile(join(root, "dist", appOutput!, "wrangler.json"), "utf8")).resolves.toContain(getCloudflareRateLimitBindingName("upload"))
     }
     finally {
-      if (previousHosting === undefined) delete process.env.VITEHUB_HOSTING
-      else process.env.VITEHUB_HOSTING = previousHosting
+      if (previousHosting === undefined) delete process.env[environmentVariable]
+      else process.env[environmentVariable] = previousHosting
+    }
+  })
+
+  it.each(["NITRO_PRESET", "SERVER_PRESET", "VITEHUB_HOSTING"])("composes and suppresses output for real Nitro hosting selected by %s", async (environmentVariable) => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-nitro-cloudflare-env-"))
+    roots.push(root)
+    await writeCloudflareDeclaration(root)
+    const previousHosting = process.env[environmentVariable]
+    process.env[environmentVariable] = "cloudflare"
+    try {
+      const plugin = hubRateLimit({ namespace: "vite-test" })
+      const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => unknown
+      const configResolved = plugin.configResolved as (config: unknown) => Promise<void>
+      const userConfig = { nitro: {}, root }
+
+      config(userConfig, { command: "build" })
+      await configResolved({ ...userConfig, build: { outDir: "dist" }, command: "build", plugins: [{ name: "nitro:main" }], resolve: { alias: [] } } as never)
+      expect(userConfig).toHaveProperty("nitro.cloudflare.wrangler.ratelimits", [
+        expect.objectContaining({ name: getCloudflareRateLimitBindingName("upload") }),
+      ])
+      await (plugin.closeBundle as () => Promise<void>)()
+
+      await expect(access(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"))).rejects.toMatchObject({ code: "ENOENT" })
+    }
+    finally {
+      if (previousHosting === undefined) delete process.env[environmentVariable]
+      else process.env[environmentVariable] = previousHosting
     }
   })
 

--- a/packages/rate-limit/test/vite.test.ts
+++ b/packages/rate-limit/test/vite.test.ts
@@ -214,7 +214,7 @@ describe("hubRateLimit", () => {
     const installer = await readFile(join(root, ".vitehub", "nitro", "rate-limit", "plugin.ts"), "utf8")
     expect(installer).toContain('const config = {"provider":"memory"}')
     expect(installer).not.toContain("Registry")
-    expect(installer).toContain("enterRateLimitRuntimeEvent(event)")
+    expect(installer).toContain("enterRateLimitRuntimeEvent(Object.assign(event")
   })
 
   it("installs the Cloudflare runtime in plain Vite SSR modules", async () => {

--- a/packages/rate-limit/test/vite.test.ts
+++ b/packages/rate-limit/test/vite.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
 
+import { createDefaultCloudflareOutputRoot } from "@vite-hub/internal/build/deployment-output"
 import { getCloudflareRateLimitBindingName } from "../src/integrations/cloudflare.ts"
 import { hubRateLimit } from "../src/vite.ts"
 
@@ -50,9 +51,11 @@ describe("hubRateLimit", () => {
       },
     })
 
-    const resolvedConfig = { ...userConfig, build: { outDir: "dist" }, command: "build", plugins: [], resolve: { alias: [] } }
+    const resolvedConfig = { ...userConfig, build: { outDir: "dist" }, command: "build", plugins: [{ name: "nitro:main" }], resolve: { alias: [] } }
     await configResolved(resolvedConfig as never)
     expect(resolvedConfig.nitro.cloudflare.wrangler.ratelimits).toHaveLength(2)
+    await (plugin.closeBundle as () => Promise<void>)()
+    await expect(access(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"))).rejects.toMatchObject({ code: "ENOENT" })
   })
 
   it("requires a namespace for discovered Nitro Cloudflare Rate Limits", async () => {
@@ -78,7 +81,7 @@ describe("hubRateLimit", () => {
       build: { outDir: "dist" },
       command: "build",
       nitro: { preset: "cloudflare_module" },
-      plugins: [],
+      plugins: [{ name: "nitro:main" }],
       resolve: { alias: [] },
       root,
     }
@@ -127,6 +130,23 @@ describe("hubRateLimit", () => {
     }
   })
 
+  it("keeps standalone output when Cloudflare config has no Nitro plugin", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-plain-cloudflare-config-"))
+    roots.push(root)
+    await writeCloudflareDeclaration(root)
+    const plugin = hubRateLimit({ namespace: "vite-test" })
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => unknown
+    const configResolved = plugin.configResolved as (config: unknown) => Promise<void>
+    const closeBundle = plugin.closeBundle as () => Promise<void>
+    const userConfig = { nitro: { preset: "cloudflare-module" }, root }
+
+    config(userConfig, { command: "build" })
+    await configResolved({ ...userConfig, build: { outDir: "dist" }, command: "build", plugins: [], resolve: { alias: [] } } as never)
+    await closeBundle()
+
+    await expect(readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8")).resolves.toContain(getCloudflareRateLimitBindingName("upload"))
+  })
+
   it("rejects Nitro Rate Limit declarations generated after config resolution", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-nitro-late-declaration-"))
     roots.push(root)
@@ -137,7 +157,7 @@ describe("hubRateLimit", () => {
     const userConfig = { nitro: { preset: "cloudflare-module" }, root }
 
     config(userConfig, { command: "build" })
-    await configResolved({ ...userConfig, build: { outDir: "dist" }, command: "build", plugins: [], resolve: { alias: [] } } as never)
+    await configResolved({ ...userConfig, build: { outDir: "dist" }, command: "build", plugins: [{ name: "nitro:main" }], resolve: { alias: [] } } as never)
     await writeCloudflareDeclaration(root)
 
     await expect(closeBundle()).rejects.toThrow("changed after config resolution")

--- a/packages/rate-limit/test/vite.test.ts
+++ b/packages/rate-limit/test/vite.test.ts
@@ -271,6 +271,7 @@ describe("hubRateLimit", () => {
     } as never)
     const installer = await readFile(join(root, ".vitehub", "nitro", "rate-limit", "plugin.ts"), "utf8")
     expect(installer).toContain('from "vite-hub/_internal/rate-limit/runtime"')
+    expect(installer).toContain("event.node?.req?.runtime?.cloudflare?.env")
     expect(installer).not.toContain("@vite-hub/rate-limit/runtime")
   })
 

--- a/packages/rate-limit/test/vite.test.ts
+++ b/packages/rate-limit/test/vite.test.ts
@@ -1,9 +1,10 @@
-import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
 
+import { getCloudflareRateLimitBindingName } from "../src/integrations/cloudflare.ts"
 import { hubRateLimit } from "../src/vite.ts"
 
 const roots: string[] = []
@@ -12,7 +13,136 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map(root => rm(root, { force: true, recursive: true })))
 })
 
+async function writeCloudflareDeclaration(root: string): Promise<void> {
+  await writeFile(join(root, "upload.ts"), [
+    'import { defineRateLimit } from "@vite-hub/rate-limit"',
+    'const upload = defineRateLimit("upload", { enforcement: "best-effort", limit: 10, window: "1m" })',
+    "void upload",
+    "",
+  ].join("\n"))
+}
+
 describe("hubRateLimit", () => {
+  it("composes discovered Rate Limits into a Nitro Cloudflare Worker", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-nitro-cloudflare-"))
+    roots.push(root)
+    await writeCloudflareDeclaration(root)
+    const plugin = hubRateLimit({ namespace: "vite-test" })
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => { nitro: Record<string, unknown> }
+    const configResolved = plugin.configResolved as (config: unknown) => Promise<void>
+    const userConfig = {
+      nitro: {
+        cloudflare: { wrangler: { ratelimits: [{ name: "MANUAL", namespace_id: "9", simple: { limit: 1, period: 10 } }] } },
+        preset: "cloudflare-module",
+      },
+      root,
+    }
+
+    const configured = config(userConfig, { command: "build" })
+    expect(configured.nitro).toMatchObject({
+      cloudflare: {
+        wrangler: {
+          ratelimits: [
+            { name: "MANUAL" },
+            { name: getCloudflareRateLimitBindingName("upload"), simple: { limit: 10, period: 60 } },
+          ],
+        },
+      },
+    })
+
+    const resolvedConfig = { ...userConfig, build: { outDir: "dist" }, command: "build", plugins: [], resolve: { alias: [] } }
+    await configResolved(resolvedConfig as never)
+    expect(resolvedConfig.nitro.cloudflare.wrangler.ratelimits).toHaveLength(2)
+  })
+
+  it("requires a namespace for discovered Nitro Cloudflare Rate Limits", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-nitro-namespace-"))
+    roots.push(root)
+    await writeCloudflareDeclaration(root)
+    const plugin = hubRateLimit()
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => unknown
+
+    expect(() => config({ nitro: { preset: "cloudflare-module" }, root }, { command: "build" })).toThrow("requires rateLimit.namespace")
+  })
+
+  it("composes after a Cloudflare Nitro preset resolves late", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-nitro-late-preset-"))
+    roots.push(root)
+    await writeCloudflareDeclaration(root)
+    const plugin = hubRateLimit({ namespace: "vite-test", projectRoot: "." })
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => unknown
+    const configResolved = plugin.configResolved as (config: unknown) => Promise<void>
+
+    expect(() => config({ nitro: {}, root }, { command: "build" })).not.toThrow()
+    const resolvedConfig = {
+      build: { outDir: "dist" },
+      command: "build",
+      nitro: { preset: "cloudflare_module" },
+      plugins: [],
+      resolve: { alias: [] },
+      root,
+    }
+    await configResolved(resolvedConfig as never)
+    expect(resolvedConfig).toHaveProperty("nitro.cloudflare.wrangler.ratelimits", [
+      expect.objectContaining({ name: getCloudflareRateLimitBindingName("upload") }),
+    ])
+  })
+
+  it("does not compose bindings for memory or non-Cloudflare Nitro builds", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-nitro-other-"))
+    roots.push(root)
+    await writeCloudflareDeclaration(root)
+    const memoryPlugin = hubRateLimit({ provider: "memory" })
+    const memoryConfig = memoryPlugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => { nitro: Record<string, unknown> }
+    expect(memoryConfig({ nitro: { preset: "cloudflare-module" }, root }, { command: "build" }).nitro).not.toHaveProperty("cloudflare.wrangler.ratelimits")
+
+    const vercelPlugin = hubRateLimit({ namespace: "vite-test", provider: "cloudflare" })
+    const vercelConfig = vercelPlugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => { nitro: Record<string, unknown> }
+    expect(vercelConfig({ nitro: { preset: "vercel" }, root }, { command: "build" }).nitro).not.toHaveProperty("cloudflare.wrangler.ratelimits")
+  })
+
+  it("keeps standalone output when hosting inference has no Nitro preset", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-plain-cloudflare-"))
+    roots.push(root)
+    await writeCloudflareDeclaration(root)
+    const previousHosting = process.env.VITEHUB_HOSTING
+    process.env.VITEHUB_HOSTING = "cloudflare"
+    try {
+      const plugin = hubRateLimit({ namespace: "vite-test" })
+      const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => unknown
+      const configResolved = plugin.configResolved as (config: unknown) => Promise<void>
+      const closeBundle = plugin.closeBundle as () => Promise<void>
+      const userConfig = { root }
+
+      config(userConfig, { command: "build" })
+      await configResolved({ ...userConfig, build: { outDir: "dist" }, command: "build", plugins: [], resolve: { alias: [] } } as never)
+      await closeBundle()
+
+      const [appOutput] = await readdir(join(root, "dist"))
+      await expect(readFile(join(root, "dist", appOutput!, "wrangler.json"), "utf8")).resolves.toContain(getCloudflareRateLimitBindingName("upload"))
+    }
+    finally {
+      if (previousHosting === undefined) delete process.env.VITEHUB_HOSTING
+      else process.env.VITEHUB_HOSTING = previousHosting
+    }
+  })
+
+  it("rejects Nitro Rate Limit declarations generated after config resolution", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-nitro-late-declaration-"))
+    roots.push(root)
+    const plugin = hubRateLimit({ namespace: "vite-test" })
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => unknown
+    const configResolved = plugin.configResolved as (config: unknown) => Promise<void>
+    const closeBundle = plugin.closeBundle as () => Promise<void>
+    const userConfig = { nitro: { preset: "cloudflare-module" }, root }
+
+    config(userConfig, { command: "build" })
+    await configResolved({ ...userConfig, build: { outDir: "dist" }, command: "build", plugins: [], resolve: { alias: [] } } as never)
+    await writeCloudflareDeclaration(root)
+
+    await expect(closeBundle()).rejects.toThrow("changed after config resolution")
+  })
+
   it("registers generated Nitro runtime with config-key precedence", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-vite-"))
     roots.push(root)


### PR DESCRIPTION
## Summary

- add a private Cloudflare contribution catalog for Queue, R2, and Rate Limit resources
- merge contributions into Nitro's Wrangler config by resource identity while preserving compatible user entries
- let Nitro own the Cloudflare Worker artifact when Nitro was already configured, while retaining standalone Vite output otherwise

## Validation

- `pnpm --filter @vite-hub/internal typecheck`
- `pnpm --filter @vite-hub/queue typecheck`
- `vp test test/cloudflare-provider-output.test.ts` in `packages/internal` (3 tests)
- `vp test test/vite.test.ts test/vite-output.test.ts` in `packages/queue` (17 tests)
- targeted `oxlint`
- `git diff --check`

## Dependency

Stacked on `agent/queue-nitro-integration` / #689. Merge after #689.