### PR TITLE
refactor(blob): compose Nitro Cloudflare output

### DIFF
--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -345,7 +345,6 @@ function isLegacyCloudflareBlobWorker(worker: string, wrangler: unknown): boolea
     : {}
   return worker.includes("function createBlobCloudflareWorker(")
     && worker.includes("setBlobRuntimeConfig(")
-    && worker.includes("R2 binding")
     && config.main === "index.js"
     && compatibilityFlags.includes("nodejs_compat")
     && observability.enabled === true

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -348,7 +348,9 @@ async function createNitroCloudflareCleanup(rootDir: string) {
   return {
     fileNames: ownsWorker ? ["index.js"] : [],
     outputRoot,
-    wranglerConfigOwnership: { keys: ownsWorker ? ["r2_buckets"] : [] },
+    wranglerConfigOwnership: {
+      keys: ownsWorker ? ["compatibility_date", "compatibility_flags", "main", "observability", "r2_buckets"] : [],
+    },
   }
 }
 

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -441,15 +441,17 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.blob)
   const localOnly = !shouldCreateProviderOutput(options.blob)
   const createCloudflare = !localOnly && !options.cloudflareOwnedByNitro
+  if (options.cloudflareOwnedByNitro && !localOnly) {
+    await writeProviderDeploymentOutputs({
+      clientOutDir: options.clientOutDir,
+      cleanup: { cloudflare: () => createNitroCloudflareCleanup(options.rootDir) },
+      rootDir: options.rootDir,
+    })
+  }
   await writeProviderDeploymentOutputs({
     afterWrite: localOnly ? undefined : () => copyVercelBlobRuntimePackages(options),
     clientOutDir: options.clientOutDir,
     cloudflare: createCloudflare ? createCloudflareOutput(options.blob, artifacts, options.providerOutput) : undefined,
-    cleanup: {
-      cloudflare: options.cloudflareOwnedByNitro && !localOnly
-        ? () => createNitroCloudflareCleanup(options.rootDir)
-        : undefined,
-    },
     rootDir: options.rootDir,
     vercel: localOnly ? undefined : createVercelOutput(artifacts, options.providerOutput, options.serverFunctionName),
   })

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -1,8 +1,8 @@
-import { mkdir, writeFile } from "node:fs/promises"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { resolve } from "pathe"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
-import { getProviderRuntimeModule, registerProviderRuntimeModules, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
+import { createDefaultCloudflareOutputRoot, getProviderRuntimeModule, registerProviderRuntimeModules, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vite-hub/internal/build/paths"
 import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
 import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
@@ -13,6 +13,7 @@ import type { BlobModuleOptions, ResolvedBlobModuleOptions, ResolvedCloudflareR2
 import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 
 export const blobPackageName = "@vite-hub/blob"
+const cloudflareBlobWorkerMarker = "vitehub-blob-worker"
 const productName = "blob"
 const packageDir = computePackageDir(import.meta.url)
 const resolveRuntimeModule = (modulePath: string) => resolveRuntimeFromPkg(packageDir, modulePath)
@@ -44,6 +45,7 @@ interface GenerateProviderOutputsOptions {
   artifacts?: GeneratedBlobArtifacts
   blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined
   clientOutDir: string
+  cloudflareOwnedByNitro?: boolean
   providerOutput?: ComposedProviderOutput
   rootDir: string
   serverFunctionName?: string
@@ -102,7 +104,7 @@ function isCloudflareR2StoreWithBucket(store: ResolvedBlobModuleOptions["store"]
   return store.driver === "cloudflare-r2" && Boolean(store.bucketName)
 }
 
-function createCloudflareR2Bindings(config: false | ResolvedBlobModuleOptions | undefined): Array<{ binding: string, bucket_name: string }> | undefined {
+export function createCloudflareR2Bindings(config: false | ResolvedBlobModuleOptions | undefined): Array<{ binding: string, bucket_name: string }> | undefined {
   if (!config) {
     return undefined
   }
@@ -315,6 +317,7 @@ function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOpti
         "@vite-hub/blob": artifacts.runtimeModuleFiles.cloudflare,
         ...(databaseRuntime ? { "@vite-hub/database/drizzle": databaseRuntime } : {}),
       },
+      banner: `// ${cloudflareBlobWorkerMarker}`,
       conditions: ["workerd", "worker", "browser", "default"],
       external: [
         "@aws-sdk/client-s3",
@@ -330,6 +333,22 @@ function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOpti
     },
     wranglerConfigKeys: ["r2_buckets"],
     wranglerConfig,
+  }
+}
+
+async function createNitroCloudflareCleanup(rootDir: string) {
+  const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
+  let ownsWorker = false
+  try {
+    ownsWorker = (await readFile(resolve(outputRoot, "index.js"), "utf8")).includes(cloudflareBlobWorkerMarker)
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
+  return {
+    fileNames: ownsWorker ? ["index.js"] : [],
+    outputRoot,
+    wranglerConfigOwnership: { keys: ownsWorker ? ["r2_buckets"] : [] },
   }
 }
 
@@ -421,10 +440,16 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   const artifacts = options.artifacts ?? await prepareProviderOutputs(options)
   registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.blob)
   const localOnly = !shouldCreateProviderOutput(options.blob)
+  const createCloudflare = !localOnly && !options.cloudflareOwnedByNitro
   await writeProviderDeploymentOutputs({
     afterWrite: localOnly ? undefined : () => copyVercelBlobRuntimePackages(options),
     clientOutDir: options.clientOutDir,
-    cloudflare: localOnly ? undefined : createCloudflareOutput(options.blob, artifacts, options.providerOutput),
+    cloudflare: createCloudflare ? createCloudflareOutput(options.blob, artifacts, options.providerOutput) : undefined,
+    cleanup: {
+      cloudflare: options.cloudflareOwnedByNitro && !localOnly
+        ? () => createNitroCloudflareCleanup(options.rootDir)
+        : undefined,
+    },
     rootDir: options.rootDir,
     vercel: localOnly ? undefined : createVercelOutput(artifacts, options.providerOutput, options.serverFunctionName),
   })

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -336,11 +336,35 @@ function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOpti
   }
 }
 
+function isLegacyCloudflareBlobWorker(worker: string, wrangler: unknown): boolean {
+  if (!wrangler || typeof wrangler !== "object" || Array.isArray(wrangler)) return false
+  const config = wrangler as Record<string, unknown>
+  const compatibilityFlags = Array.isArray(config.compatibility_flags) ? config.compatibility_flags : []
+  const observability = config.observability && typeof config.observability === "object" && !Array.isArray(config.observability)
+    ? config.observability as Record<string, unknown>
+    : {}
+  return worker.includes("function createBlobCloudflareWorker(")
+    && worker.includes("setBlobRuntimeConfig(")
+    && worker.includes("R2 binding")
+    && config.main === "index.js"
+    && compatibilityFlags.includes("nodejs_compat")
+    && observability.enabled === true
+}
+
 async function createNitroCloudflareCleanup(rootDir: string) {
   const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
   let ownsWorker = false
   try {
-    ownsWorker = (await readFile(resolve(outputRoot, "index.js"), "utf8")).includes(cloudflareBlobWorkerMarker)
+    const worker = await readFile(resolve(outputRoot, "index.js"), "utf8")
+    ownsWorker = worker.includes(cloudflareBlobWorkerMarker)
+    if (!ownsWorker) {
+      try {
+        ownsWorker = isLegacyCloudflareBlobWorker(worker, JSON.parse(await readFile(resolve(outputRoot, "wrangler.json"), "utf8")))
+      }
+      catch (error) {
+        if (!(error instanceof SyntaxError) && (error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+      }
+    }
   }
   catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -1,7 +1,7 @@
 import { writeFileIfChanged } from "@vite-hub/internal/definition-catalog"
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { composeNitroCloudflareProviderOutput, registerCloudflareProviderOutput, resetComposedProviderOutput, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, hasNitroVitePlugin, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
 import { getHostingProvider } from "@vite-hub/internal/hosting"
 import { resolve } from "pathe"
 
@@ -52,6 +52,13 @@ function serializeVirtualConfig(config: BlobViteRuntimeConfig): string {
 
 function cloneNitroConfig(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {}
+}
+
+function hasNitroVitePluginOption(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(hasNitroVitePluginOption)
+  return Boolean(value)
+    && typeof value === "object"
+    && hasNitroVitePlugin({ plugins: [value as { name: string }] })
 }
 
 function mergeNitroExternal(value: unknown, addition: string): unknown {
@@ -159,8 +166,6 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
   let clientOutDir = "dist"
   let command: "build" | "serve" = "serve"
   let cloudflareOwnedByNitro = false
-  let configHookRan = false
-  let hasNitroIntegration = false
   let providerArtifacts: Awaited<ReturnType<typeof prepareProviderOutputs>> | undefined
   let providerOutput: ComposedProviderOutput | undefined
   let rootDir = process.cwd()
@@ -183,11 +188,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       command = env.command
       blob = config.blob ?? blob
       const configuredNitro = (config as { nitro?: unknown }).nitro
-      if (!configHookRan) {
-        configHookRan = true
-        hasNitroIntegration = Boolean(configuredNitro)
-      }
-      cloudflareOwnedByNitro = hasNitroIntegration && isNitroCloudflareHost(configuredNitro)
+      cloudflareOwnedByNitro = hasNitroVitePluginOption(config.plugins) && isNitroCloudflareHost(configuredNitro)
       const blobConfig = resolveBlobViteConfig(blob, cloudflareOwnedByNitro ? { hosting: "cloudflare" } : undefined)
       const nitro = mergeNitroBlobConfig(
         configuredNitro,
@@ -203,8 +204,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       rootDir = config.root
       blob = config.blob ?? blob
       const configuredNitro = (config as { nitro?: unknown }).nitro
-      const nitroOwnsOutput = configHookRan ? hasNitroIntegration : Boolean(configuredNitro)
-      cloudflareOwnedByNitro = nitroOwnsOutput && isNitroCloudflareHost(configuredNitro)
+      cloudflareOwnedByNitro = hasNitroVitePlugin(config) && isNitroCloudflareHost(configuredNitro)
       ;(config as { nitro?: unknown }).nitro = mergeNitroCloudflareBlobOutput(config, cloneNitroConfig(configuredNitro), blob, cloudflareOwnedByNitro)
       providerOutput = useComposedProviderOutput(config)
       runtimeConfig = resolveBlobViteConfig(blob, cloudflareOwnedByNitro ? { hosting: "cloudflare" } : undefined)

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -1,10 +1,11 @@
 import { writeFileIfChanged } from "@vite-hub/internal/definition-catalog"
 import { getViteMode } from "@vite-hub/internal/build/mode"
-import { resetComposedProviderOutput, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
+import { composeNitroCloudflareProviderOutput, registerCloudflareProviderOutput, resetComposedProviderOutput, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
 import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
+import { getHostingProvider } from "@vite-hub/internal/hosting"
 import { resolve } from "pathe"
 
-import { generateProviderOutputs, prepareProviderOutputs, blobPackageName } from "./internal/vite-build.ts"
+import { createCloudflareR2Bindings, generateProviderOutputs, prepareProviderOutputs, blobPackageName } from "./internal/vite-build.ts"
 import { createBlobCloudflareProvisionStep, createBlobVercelProvisionStep } from "./provision.ts"
 import {
   BLOB_VIRTUAL_CONFIG_ID,
@@ -51,6 +52,20 @@ function serializeVirtualConfig(config: BlobViteRuntimeConfig): string {
 
 function cloneNitroConfig(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {}
+}
+
+function isNitroCloudflareHost(value: unknown): boolean {
+  const nitro = cloneNitroConfig(value)
+  const preset = typeof nitro.preset === "string" ? nitro.preset : process.env.NITRO_PRESET || process.env.SERVER_PRESET
+  return getHostingProvider(preset) === "cloudflare" || Object.hasOwn(nitro, "cloudflare")
+}
+
+function mergeNitroCloudflareBlobOutput(config: object, nitro: Record<string, unknown>, blob: BlobModuleOptions | undefined, cloudflareOwnedByNitro: boolean): Record<string, unknown> {
+  const bindings = cloudflareOwnedByNitro
+    ? createCloudflareR2Bindings(resolveBlobViteConfig(blob, { hosting: "cloudflare" }).blob)
+    : undefined
+  registerCloudflareProviderOutput(config, "blob", bindings ? { r2Buckets: bindings } : {})
+  return bindings ? composeNitroCloudflareProviderOutput(config, nitro) : nitro
 }
 
 function normalizeNitroRoute(route: string): string {
@@ -119,6 +134,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
   let blob: BlobModuleOptions | undefined = options
   let clientOutDir = "dist"
   let command: "build" | "serve" = "serve"
+  let cloudflareOwnedByNitro = false
   let providerArtifacts: Awaited<ReturnType<typeof prepareProviderOutputs>> | undefined
   let providerOutput: ComposedProviderOutput | undefined
   let rootDir = process.cwd()
@@ -141,18 +157,24 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       command = env.command
       blob = config.blob ?? blob
       const blobConfig = resolveBlobViteConfig(blob)
+      const configuredNitro = (config as { nitro?: unknown }).nitro
+      cloudflareOwnedByNitro = isNitroCloudflareHost(configuredNitro)
       const nitro = mergeNitroBlobConfig(
-        (config as { nitro?: unknown }).nitro,
+        configuredNitro,
         blobConfig.blob ? blobConfig.blob.serve : undefined,
       )
-      ;(config as { nitro?: unknown }).nitro = nitro
-      return { nitro } as never
+      const composedNitro = mergeNitroCloudflareBlobOutput(config, nitro, blob, cloudflareOwnedByNitro)
+      ;(config as { nitro?: unknown }).nitro = composedNitro
+      return { nitro: composedNitro } as never
     },
     async configResolved(config) {
       resolved = config
       clientOutDir = config.build.outDir
       rootDir = config.root
       blob = config.blob ?? blob
+      const configuredNitro = (config as { nitro?: unknown }).nitro
+      cloudflareOwnedByNitro ||= isNitroCloudflareHost(configuredNitro)
+      ;(config as { nitro?: unknown }).nitro = mergeNitroCloudflareBlobOutput(config, cloneNitroConfig(configuredNitro), blob, cloudflareOwnedByNitro)
       providerOutput = useComposedProviderOutput(config)
       runtimeConfig = resolveBlobViteConfig(blob)
       await refreshBlobGeneratedFiles(config.root, runtimeConfig.blob, importBase)
@@ -190,6 +212,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       await generateProviderOutputs({
         blob,
         clientOutDir,
+        cloudflareOwnedByNitro,
         artifacts: providerArtifacts,
         providerOutput,
         rootDir,

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -128,9 +128,10 @@ function renderNitroBlobPlugin(blob: BlobViteRuntimeConfig["blob"], cloudflare: 
     "",
     `const blobConfig = ${JSON.stringify(blob)}`,
     "",
-    "export default function vitehubBlobPlugin() {",
+    `export default function vitehubBlobPlugin(${cloudflare ? "nitro" : ""}) {`,
     cloudflare ? "  setActiveCloudflareEnv(vitehubEnv)" : undefined,
     "  setBlobRuntimeConfig(blobConfig)",
+    cloudflare ? "  nitro.hooks.hook('request', (event) => setActiveCloudflareEnv(event.env ?? event.context?.cloudflare?.env ?? event.context?._platform?.cloudflare?.env ?? event.req?.runtime?.cloudflare?.env ?? event.node?.req?.runtime?.cloudflare?.env ?? vitehubEnv))" : undefined,
     "}",
     "",
   ].filter(line => typeof line === "string").join("\n")

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -54,18 +54,40 @@ function cloneNitroConfig(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {}
 }
 
+function mergeNitroExternal(value: unknown, addition: string): unknown {
+  if (typeof value === "undefined") return [addition]
+  if (Array.isArray(value)) return value.includes(addition) ? [...value] : [...value, addition]
+  if (typeof value === "string" || value instanceof RegExp) return [value, addition]
+  if (typeof value === "function") {
+    return (source: string, importer?: string, isResolved?: boolean) => source === addition || Boolean(value(source, importer, isResolved))
+  }
+  return value
+}
+
 function isNitroCloudflareHost(value: unknown): boolean {
   const nitro = cloneNitroConfig(value)
   const preset = typeof nitro.preset === "string" ? nitro.preset : process.env.NITRO_PRESET || process.env.SERVER_PRESET || process.env.VITEHUB_HOSTING
-  return getHostingProvider(preset) === "cloudflare" || Object.hasOwn(nitro, "cloudflare")
+  return typeof preset === "string" ? getHostingProvider(preset) === "cloudflare" : Object.hasOwn(nitro, "cloudflare")
 }
 
 function mergeNitroCloudflareBlobOutput(config: object, nitro: Record<string, unknown>, blob: BlobModuleOptions | undefined, cloudflareOwnedByNitro: boolean): Record<string, unknown> {
-  const bindings = cloudflareOwnedByNitro
-    ? createCloudflareR2Bindings(resolveBlobViteConfig(blob, { hosting: "cloudflare" }).blob)
-    : undefined
+  if (!cloudflareOwnedByNitro) {
+    registerCloudflareProviderOutput(config, "blob", {})
+    return nitro
+  }
+  const bindings = createCloudflareR2Bindings(resolveBlobViteConfig(blob, { hosting: "cloudflare" }).blob)
+  const cloudflare = cloneNitroConfig(nitro.cloudflare)
+  const wrangler = cloneNitroConfig(cloudflare.wrangler)
+  const compatibilityFlags = Array.isArray(wrangler.compatibility_flags) ? [...wrangler.compatibility_flags] : []
+  if (!compatibilityFlags.includes("nodejs_compat")) compatibilityFlags.push("nodejs_compat")
+  const rollupConfig = cloneNitroConfig(nitro.rollupConfig)
+  const baseNitro = {
+    ...nitro,
+    cloudflare: { ...cloudflare, wrangler: { ...wrangler, compatibility_flags: compatibilityFlags } },
+    rollupConfig: { ...rollupConfig, external: mergeNitroExternal(rollupConfig.external, "cloudflare:workers") },
+  }
   registerCloudflareProviderOutput(config, "blob", bindings ? { r2Buckets: bindings } : {})
-  return bindings ? composeNitroCloudflareProviderOutput(config, nitro) : nitro
+  return composeNitroCloudflareProviderOutput(config, baseNitro)
 }
 
 function normalizeNitroRoute(route: string): string {
@@ -92,17 +114,19 @@ function mergeNitroBlobConfig(value: unknown, serve?: BlobServeConfig): Record<s
   }
 }
 
-function renderNitroBlobPlugin(blob: BlobViteRuntimeConfig["blob"], importBase = blobPackageName): string {
+function renderNitroBlobPlugin(blob: BlobViteRuntimeConfig["blob"], cloudflare: boolean, importBase = blobPackageName): string {
   return [
-    `import { setBlobRuntimeConfig } from '${importBase}/runtime/state'`,
+    cloudflare ? "import { env as vitehubEnv } from 'cloudflare:workers'" : undefined,
+    `import { ${cloudflare ? "setActiveCloudflareEnv, " : ""}setBlobRuntimeConfig } from '${importBase}/runtime/state'`,
     "",
     `const blobConfig = ${JSON.stringify(blob)}`,
     "",
     "export default function vitehubBlobPlugin() {",
+    cloudflare ? "  setActiveCloudflareEnv(vitehubEnv)" : undefined,
     "  setBlobRuntimeConfig(blobConfig)",
     "}",
     "",
-  ].join("\n")
+  ].filter(line => typeof line === "string").join("\n")
 }
 
 function renderBlobServeRouteHandler(serve: BlobServeConfig, importBase = blobPackageName): string {
@@ -121,8 +145,8 @@ function renderBlobServeRouteHandler(serve: BlobServeConfig, importBase = blobPa
   ].join("\n")
 }
 
-async function refreshBlobGeneratedFiles(root: string, blob: BlobViteRuntimeConfig["blob"], importBase = blobPackageName): Promise<void> {
-  await writeFileIfChanged(resolve(root, generatedNitroBlobPlugin), renderNitroBlobPlugin(blob, importBase))
+async function refreshBlobGeneratedFiles(root: string, blob: BlobViteRuntimeConfig["blob"], cloudflare: boolean, importBase = blobPackageName): Promise<void> {
+  await writeFileIfChanged(resolve(root, generatedNitroBlobPlugin), renderNitroBlobPlugin(blob, cloudflare, importBase))
   const serve = blob ? blob.serve : undefined
   if (!serve) return
   const file = resolve(root, generatedBlobServeRouteHandler)
@@ -184,7 +208,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       ;(config as { nitro?: unknown }).nitro = mergeNitroCloudflareBlobOutput(config, cloneNitroConfig(configuredNitro), blob, cloudflareOwnedByNitro)
       providerOutput = useComposedProviderOutput(config)
       runtimeConfig = resolveBlobViteConfig(blob, cloudflareOwnedByNitro ? { hosting: "cloudflare" } : undefined)
-      await refreshBlobGeneratedFiles(config.root, runtimeConfig.blob, importBase)
+      await refreshBlobGeneratedFiles(config.root, runtimeConfig.blob, cloudflareOwnedByNitro, importBase)
     },
     configEnvironment(name, config) {
       if (!isServerEnvironment(name, config)) {

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -56,7 +56,7 @@ function cloneNitroConfig(value: unknown): Record<string, unknown> {
 
 function isNitroCloudflareHost(value: unknown): boolean {
   const nitro = cloneNitroConfig(value)
-  const preset = typeof nitro.preset === "string" ? nitro.preset : process.env.NITRO_PRESET || process.env.SERVER_PRESET
+  const preset = typeof nitro.preset === "string" ? nitro.preset : process.env.NITRO_PRESET || process.env.SERVER_PRESET || process.env.VITEHUB_HOSTING
   return getHostingProvider(preset) === "cloudflare" || Object.hasOwn(nitro, "cloudflare")
 }
 
@@ -135,6 +135,8 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
   let clientOutDir = "dist"
   let command: "build" | "serve" = "serve"
   let cloudflareOwnedByNitro = false
+  let configHookRan = false
+  let hasNitroIntegration = false
   let providerArtifacts: Awaited<ReturnType<typeof prepareProviderOutputs>> | undefined
   let providerOutput: ComposedProviderOutput | undefined
   let rootDir = process.cwd()
@@ -156,9 +158,13 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
     config(config, env) {
       command = env.command
       blob = config.blob ?? blob
-      const blobConfig = resolveBlobViteConfig(blob)
       const configuredNitro = (config as { nitro?: unknown }).nitro
-      cloudflareOwnedByNitro = isNitroCloudflareHost(configuredNitro)
+      if (!configHookRan) {
+        configHookRan = true
+        hasNitroIntegration = Boolean(configuredNitro)
+      }
+      cloudflareOwnedByNitro = hasNitroIntegration && isNitroCloudflareHost(configuredNitro)
+      const blobConfig = resolveBlobViteConfig(blob, cloudflareOwnedByNitro ? { hosting: "cloudflare" } : undefined)
       const nitro = mergeNitroBlobConfig(
         configuredNitro,
         blobConfig.blob ? blobConfig.blob.serve : undefined,
@@ -173,10 +179,11 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       rootDir = config.root
       blob = config.blob ?? blob
       const configuredNitro = (config as { nitro?: unknown }).nitro
-      cloudflareOwnedByNitro ||= isNitroCloudflareHost(configuredNitro)
+      const nitroOwnsOutput = configHookRan ? hasNitroIntegration : Boolean(configuredNitro)
+      cloudflareOwnedByNitro = nitroOwnsOutput && isNitroCloudflareHost(configuredNitro)
       ;(config as { nitro?: unknown }).nitro = mergeNitroCloudflareBlobOutput(config, cloneNitroConfig(configuredNitro), blob, cloudflareOwnedByNitro)
       providerOutput = useComposedProviderOutput(config)
-      runtimeConfig = resolveBlobViteConfig(blob)
+      runtimeConfig = resolveBlobViteConfig(blob, cloudflareOwnedByNitro ? { hosting: "cloudflare" } : undefined)
       await refreshBlobGeneratedFiles(config.root, runtimeConfig.blob, importBase)
     },
     configEnvironment(name, config) {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -274,6 +274,14 @@ describe("Vite provider outputs", () => {
     })
 
     await writeFile(join(cloudflareOutput, "index.js"), "// vitehub-blob-worker\nexport default 'standalone blob'\n", "utf8")
+    await writeFile(join(cloudflareOutput, "wrangler.json"), `${JSON.stringify({
+      compatibility_date: "2026-06-01",
+      compatibility_flags: ["nodejs_compat"],
+      main: "index.js",
+      observability: { enabled: true },
+      r2_buckets: [{ binding: "ASSETS", bucket_name: "assets" }],
+      triggers: { crons: ["0 0 * * *"] },
+    }, null, 2)}\n`, "utf8")
     await generateProviderOutputs(options)
 
     expect(existsSync(join(cloudflareOutput, "index.js"))).toBe(false)

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -195,6 +195,7 @@ describe("Vite provider outputs", () => {
     const vercelServerContents = await readFile(vercelServer, "utf8")
 
     expect(existsSync(cloudflareWorker)).toBe(true)
+    expect(await readFile(cloudflareWorker, "utf8")).toContain("vitehub-blob-worker")
     expect(await readFile(cloudflareConfig, "utf8")).toContain("\"bucket_name\": \"assets\"")
     expect(await readFile(vercelConfig, "utf8")).toContain("\"/__server\"")
     expect(existsSync(vercelServer)).toBe(true)
@@ -242,6 +243,44 @@ describe("Vite provider outputs", () => {
     await expect(readFile(nitroFunction, "utf8")).resolves.toBe("export default 'nitro'\n")
     await expect(readFile(join(outputRoot, "config.json"), "utf8").then(JSON.parse)).resolves.toEqual(nitroConfig)
     expect(existsSync(join(outputRoot, "functions", "__blob.func", "index.mjs"))).toBe(true)
+  })
+
+  it("leaves Cloudflare Worker output to Nitro while retaining Vercel output", { timeout: 45_000 }, async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-nitro-cloudflare-")
+    const cloudflareOutput = join(rootDir, "dist", toSafeAppName(rootDir))
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist", "client"), { recursive: true })
+    await mkdir(cloudflareOutput, { recursive: true })
+    await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
+    await writeFile(join(cloudflareOutput, "index.js"), "// workflow worker\nexport default {}\n", "utf8")
+    await writeFile(join(cloudflareOutput, "wrangler.json"), `${JSON.stringify({
+      r2_buckets: [{ binding: "ASSETS", bucket_name: "assets", jurisdiction: "eu" }],
+      triggers: { crons: ["0 0 * * *"] },
+    }, null, 2)}\n`, "utf8")
+
+    const options = {
+      blob: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+      clientOutDir: "dist/client",
+      cloudflareOwnedByNitro: true,
+      rootDir,
+      serverFunctionName: "__blob.func",
+    } as const
+    await generateProviderOutputs(options)
+
+    await expect(readFile(join(cloudflareOutput, "index.js"), "utf8")).resolves.toBe("// workflow worker\nexport default {}\n")
+    await expect(readFile(join(cloudflareOutput, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+      r2_buckets: [{ binding: "ASSETS", bucket_name: "assets", jurisdiction: "eu" }],
+      triggers: { crons: ["0 0 * * *"] },
+    })
+
+    await writeFile(join(cloudflareOutput, "index.js"), "// vitehub-blob-worker\nexport default 'standalone blob'\n", "utf8")
+    await generateProviderOutputs(options)
+
+    expect(existsSync(join(cloudflareOutput, "index.js"))).toBe(false)
+    await expect(readFile(join(cloudflareOutput, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+      triggers: { crons: ["0 0 * * *"] },
+    })
+    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__blob.func", "index.mjs"))).toBe(true)
   })
 
   it("omits Cloudflare bucket bindings when none are configured", { timeout: 15_000 }, async () => {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -260,7 +260,7 @@ describe("Vite provider outputs", () => {
 
     const options = {
       blob: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
-      clientOutDir: "dist/client",
+      clientOutDir: "dist",
       cloudflareOwnedByNitro: true,
       rootDir,
       serverFunctionName: "__blob.func",
@@ -280,6 +280,7 @@ describe("Vite provider outputs", () => {
     await expect(readFile(join(cloudflareOutput, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
       triggers: { crons: ["0 0 * * *"] },
     })
+    expect(existsSync(join(rootDir, ".vercel", "output", "static", toSafeAppName(rootDir), "index.js"))).toBe(false)
     expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__blob.func", "index.mjs"))).toBe(true)
   })
 

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -293,6 +293,32 @@ describe("Vite provider outputs", () => {
     expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__blob.func", "index.mjs"))).toBe(true)
   })
 
+  it("cleans legacy standalone workers without R2 runtime code when Nitro takes ownership", { timeout: 30_000 }, async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-nitro-non-r2-")
+    const cloudflareOutput = join(rootDir, "dist", toSafeAppName(rootDir))
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist", "client"), { recursive: true })
+    await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
+
+    const options = {
+      blob: { driver: "vercel-blob", token: "test-token" },
+      clientOutDir: "dist/client",
+      rootDir,
+    } as const
+    await generateProviderOutputs(options)
+    const workerPath = join(cloudflareOutput, "index.js")
+    const legacyWorker = (await readFile(workerPath, "utf8")).replace("// vitehub-blob-worker\n", "")
+    expect(legacyWorker).toContain("function createBlobCloudflareWorker(")
+    expect(legacyWorker).toContain("setBlobRuntimeConfig(")
+    expect(legacyWorker).not.toContain("R2 binding")
+    await writeFile(workerPath, legacyWorker, "utf8")
+
+    await generateProviderOutputs({ ...options, cloudflareOwnedByNitro: true })
+
+    expect(existsSync(workerPath)).toBe(false)
+    expect(existsSync(join(cloudflareOutput, "wrangler.json"))).toBe(false)
+  })
+
   it("omits Cloudflare bucket bindings when none are configured", { timeout: 15_000 }, async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-no-bucket-")
     await mkdir(join(rootDir, "src"), { recursive: true })

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -253,10 +253,15 @@ describe("Vite provider outputs", () => {
     await mkdir(cloudflareOutput, { recursive: true })
     await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
     await writeFile(join(cloudflareOutput, "index.js"), "// workflow worker\nexport default {}\n", "utf8")
-    await writeFile(join(cloudflareOutput, "wrangler.json"), `${JSON.stringify({
+    const foreignWrangler = {
+      compatibility_date: "2026-06-01",
+      compatibility_flags: ["nodejs_compat"],
+      main: "index.js",
+      observability: { enabled: true },
       r2_buckets: [{ binding: "ASSETS", bucket_name: "assets", jurisdiction: "eu" }],
       triggers: { crons: ["0 0 * * *"] },
-    }, null, 2)}\n`, "utf8")
+    }
+    await writeFile(join(cloudflareOutput, "wrangler.json"), `${JSON.stringify(foreignWrangler, null, 2)}\n`, "utf8")
 
     const options = {
       blob: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
@@ -268,20 +273,16 @@ describe("Vite provider outputs", () => {
     await generateProviderOutputs(options)
 
     await expect(readFile(join(cloudflareOutput, "index.js"), "utf8")).resolves.toBe("// workflow worker\nexport default {}\n")
-    await expect(readFile(join(cloudflareOutput, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
-      r2_buckets: [{ binding: "ASSETS", bucket_name: "assets", jurisdiction: "eu" }],
-      triggers: { crons: ["0 0 * * *"] },
-    })
+    await expect(readFile(join(cloudflareOutput, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual(foreignWrangler)
 
-    await writeFile(join(cloudflareOutput, "index.js"), "// vitehub-blob-worker\nexport default 'standalone blob'\n", "utf8")
-    await writeFile(join(cloudflareOutput, "wrangler.json"), `${JSON.stringify({
-      compatibility_date: "2026-06-01",
-      compatibility_flags: ["nodejs_compat"],
-      main: "index.js",
-      observability: { enabled: true },
-      r2_buckets: [{ binding: "ASSETS", bucket_name: "assets" }],
-      triggers: { crons: ["0 0 * * *"] },
-    }, null, 2)}\n`, "utf8")
+    await generateProviderOutputs({ ...options, cloudflareOwnedByNitro: false })
+    const currentWorker = await readFile(join(cloudflareOutput, "index.js"), "utf8")
+    const legacyWorker = currentWorker.replace("// vitehub-blob-worker\n", "")
+    expect(currentWorker).toBe(`// vitehub-blob-worker\n${legacyWorker}`)
+    expect(legacyWorker).toContain("function createBlobCloudflareWorker(")
+    expect(legacyWorker).toContain("setBlobRuntimeConfig(")
+    expect(legacyWorker).toContain("R2 binding")
+    await writeFile(join(cloudflareOutput, "index.js"), legacyWorker, "utf8")
     await generateProviderOutputs(options)
 
     expect(existsSync(join(cloudflareOutput, "index.js"))).toBe(false)

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -90,6 +90,64 @@ describe("hubBlob", () => {
     expect(nitroPlugin).toContain("setBlobRuntimeConfig(blobConfig)")
   })
 
+  it("contributes deduplicated R2 bindings when Nitro owns Cloudflare output", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-nitro-r2-"))
+    const plugin = hubBlob({
+      stores: {
+        default: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+        assets: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+        assetsAlias: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+      },
+    })
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown
+    const configResolved = plugin.configResolved as (config: unknown) => void | Promise<void>
+    const userConfig = {}
+
+    config(userConfig, { command: "build" })
+    expect(userConfig).not.toHaveProperty("nitro.cloudflare.wrangler.r2_buckets")
+
+    const resolved = {
+      blob: {
+        stores: {
+          default: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+          assets: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+          assetsAlias: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
+        },
+      },
+      build: { outDir: "dist" },
+      nitro: {
+        ...(userConfig as { nitro?: object }).nitro,
+        cloudflare: {
+          wrangler: {
+            r2_buckets: [{ binding: "ASSETS", bucket_name: "assets", jurisdiction: "eu" }],
+            routes: ["example.com/*"],
+          },
+        },
+        preset: "cloudflare_module",
+      },
+      root,
+    }
+    await configResolved(resolved as never)
+
+    expect(resolved).toHaveProperty("nitro.cloudflare.wrangler.r2_buckets", [
+      { binding: "ASSETS", bucket_name: "assets", jurisdiction: "eu" },
+    ])
+    expect(resolved).toHaveProperty("nitro.cloudflare.wrangler.routes", ["example.com/*"])
+    expect(resolved).not.toHaveProperty("nitro.cloudflare.wrangler.observability")
+  })
+
+  it("does not contribute Cloudflare config for plain Vite or non-R2 stores", () => {
+    const config = (plugin: ReturnType<typeof hubBlob>, value: Record<string, unknown>) =>
+      (plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown)(value, { command: "build" })
+    const plainVite = {}
+    config(hubBlob({ binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" }), plainVite)
+    expect(plainVite).not.toHaveProperty("nitro.cloudflare")
+
+    const fsOnCloudflare = { nitro: { preset: "cloudflare_module" } }
+    config(hubBlob({ base: ".data/blob", driver: "fs" }), fsOnCloudflare)
+    expect(fsOnCloudflare).not.toHaveProperty("nitro.cloudflare")
+  })
+
   it("masks credentials embedded in Nitro runtime setup", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-blob-nitro-masked-"))
     const previousToken = process.env.BLOB_READ_WRITE_TOKEN

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -103,10 +103,12 @@ describe("hubBlob", () => {
     })
     const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown
     const configResolved = plugin.configResolved as (config: unknown) => void | Promise<void>
-    const userConfig = {}
+    const userConfig = { nitro: { preset: "cloudflare_module" } }
 
     config(userConfig, { command: "build" })
-    expect(userConfig).not.toHaveProperty("nitro.cloudflare.wrangler.r2_buckets")
+    expect(userConfig).toHaveProperty("nitro.cloudflare.wrangler.r2_buckets", [
+      { binding: "ASSETS", bucket_name: "assets" },
+    ])
 
     const resolved = {
       blob: {
@@ -135,6 +137,8 @@ describe("hubBlob", () => {
       { binding: "ASSETS", bucket_name: "assets", jurisdiction: "eu" },
     ])
     expect(resolved).toHaveProperty("nitro.cloudflare.wrangler.routes", ["example.com/*"])
+    expect(resolved).toHaveProperty("nitro.cloudflare.wrangler.compatibility_flags", ["nodejs_compat"])
+    expect(resolved).toHaveProperty("nitro.rollupConfig.external", ["cloudflare:workers"])
     expect(resolved).not.toHaveProperty("nitro.cloudflare.wrangler.observability")
   })
 
@@ -159,6 +163,8 @@ describe("hubBlob", () => {
       const nitroPlugin = await readFile(join(root, ".vitehub", "nitro", "blob", "plugin.ts"), "utf8")
       expect(nitroPlugin).toContain('"driver":"cloudflare-r2"')
       expect(nitroPlugin).toContain('"bucketName":"assets"')
+      expect(nitroPlugin).toContain("import { env as vitehubEnv } from 'cloudflare:workers'")
+      expect(nitroPlugin).toContain("setActiveCloudflareEnv(vitehubEnv)")
     }
     finally {
       if (typeof previousBucket === "undefined") delete process.env.BLOB_BUCKET_NAME
@@ -177,7 +183,11 @@ describe("hubBlob", () => {
     const value = { nitro: { preset: "cloudflare_module" } }
 
     config(value, { command: "build" })
-    await configResolved({ build: { outDir: "dist/client" }, nitro: { preset: "vercel" }, root } as never)
+    await configResolved({
+      build: { outDir: "dist/client" },
+      nitro: { cloudflare: { wrangler: { routes: ["inactive.example/*"] } }, preset: "vercel" },
+      root,
+    } as never)
     await closeBundle()
 
     expect(existsSync(join(root, "dist", toSafeAppName(root), "index.js"))).toBe(true)
@@ -205,7 +215,8 @@ describe("hubBlob", () => {
 
     const fsOnCloudflare = { nitro: { preset: "cloudflare_module" } }
     config(hubBlob({ base: ".data/blob", driver: "fs" }), fsOnCloudflare)
-    expect(fsOnCloudflare).not.toHaveProperty("nitro.cloudflare")
+    expect(fsOnCloudflare).not.toHaveProperty("nitro.cloudflare.wrangler.r2_buckets")
+    expect(fsOnCloudflare).toHaveProperty("nitro.cloudflare.wrangler.compatibility_flags", ["nodejs_compat"])
   })
 
   it("masks credentials embedded in Nitro runtime setup", async () => {

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -1,8 +1,10 @@
+import { existsSync } from "node:fs"
 import { mkdtemp, readFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { describe, expect, it } from "vitest"
+import { toSafeAppName } from "@vite-hub/internal/build/user-entry"
 
 import { BLOB_VIRTUAL_CONFIG_ID, hubBlob } from "../src/vite.ts"
 
@@ -136,12 +138,70 @@ describe("hubBlob", () => {
     expect(resolved).not.toHaveProperty("nitro.cloudflare.wrangler.observability")
   })
 
-  it("does not contribute Cloudflare config for plain Vite or non-R2 stores", () => {
+  it("uses Cloudflare defaults for the Nitro runtime when hosting is inferred", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-inferred-cloudflare-"))
+    const previousBucket = process.env.BLOB_BUCKET_NAME
+    const previousHosting = process.env.VITEHUB_HOSTING
+    process.env.BLOB_BUCKET_NAME = "assets"
+    process.env.VITEHUB_HOSTING = "cloudflare"
+    try {
+      const plugin = hubBlob()
+      const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown
+      const configResolved = plugin.configResolved as (config: unknown) => void | Promise<void>
+      const value = { nitro: {}, build: { outDir: "dist" }, root }
+
+      config(value, { command: "build" })
+      await configResolved(value as never)
+
+      expect(value).toHaveProperty("nitro.cloudflare.wrangler.r2_buckets", [
+        { binding: "BLOB", bucket_name: "assets" },
+      ])
+      const nitroPlugin = await readFile(join(root, ".vitehub", "nitro", "blob", "plugin.ts"), "utf8")
+      expect(nitroPlugin).toContain('"driver":"cloudflare-r2"')
+      expect(nitroPlugin).toContain('"bucketName":"assets"')
+    }
+    finally {
+      if (typeof previousBucket === "undefined") delete process.env.BLOB_BUCKET_NAME
+      else process.env.BLOB_BUCKET_NAME = previousBucket
+      if (typeof previousHosting === "undefined") delete process.env.VITEHUB_HOSTING
+      else process.env.VITEHUB_HOSTING = previousHosting
+    }
+  })
+
+  it("uses final Nitro ownership when the resolved preset changes", { timeout: 30_000 }, async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-final-nitro-host-"))
+    const plugin = hubBlob({ binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" })
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown
+    const configResolved = plugin.configResolved as (config: unknown) => void | Promise<void>
+    const closeBundle = plugin.closeBundle as () => void | Promise<void>
+    const value = { nitro: { preset: "cloudflare_module" } }
+
+    config(value, { command: "build" })
+    await configResolved({ build: { outDir: "dist/client" }, nitro: { preset: "vercel" }, root } as never)
+    await closeBundle()
+
+    expect(existsSync(join(root, "dist", toSafeAppName(root), "index.js"))).toBe(true)
+  })
+
+  it("does not contribute Cloudflare config for plain Vite or non-R2 stores", async () => {
     const config = (plugin: ReturnType<typeof hubBlob>, value: Record<string, unknown>) =>
       (plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown)(value, { command: "build" })
-    const plainVite = {}
-    config(hubBlob({ binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" }), plainVite)
-    expect(plainVite).not.toHaveProperty("nitro.cloudflare")
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-plain-vite-"))
+    const previousPreset = process.env.NITRO_PRESET
+    process.env.NITRO_PRESET = "cloudflare_module"
+    try {
+      const plugin = hubBlob({ binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" })
+      const plainVite = { build: { outDir: "dist" }, root }
+      config(plugin, plainVite)
+      expect(plainVite).not.toHaveProperty("nitro.cloudflare")
+      await (plugin.configResolved as (config: unknown) => void | Promise<void>)(plainVite as never)
+      await (plugin.closeBundle as () => void | Promise<void>)()
+      expect(existsSync(join(root, "dist", toSafeAppName(root), "index.js"))).toBe(true)
+    }
+    finally {
+      if (typeof previousPreset === "undefined") delete process.env.NITRO_PRESET
+      else process.env.NITRO_PRESET = previousPreset
+    }
 
     const fsOnCloudflare = { nitro: { preset: "cloudflare_module" } }
     config(hubBlob({ base: ".data/blob", driver: "fs" }), fsOnCloudflare)

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -167,6 +167,9 @@ describe("hubBlob", () => {
       expect(nitroPlugin).toContain('"bucketName":"assets"')
       expect(nitroPlugin).toContain("import { env as vitehubEnv } from 'cloudflare:workers'")
       expect(nitroPlugin).toContain("setActiveCloudflareEnv(vitehubEnv)")
+      expect(nitroPlugin).toContain("hooks.hook('request'")
+      expect(nitroPlugin).toContain("event.context?._platform?.cloudflare?.env")
+      expect(nitroPlugin).toContain("event.node?.req?.runtime?.cloudflare?.env ?? vitehubEnv")
     }
     finally {
       if (typeof previousBucket === "undefined") delete process.env.BLOB_BUCKET_NAME

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -103,7 +103,7 @@ describe("hubBlob", () => {
     })
     const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown
     const configResolved = plugin.configResolved as (config: unknown) => void | Promise<void>
-    const userConfig = { nitro: { preset: "cloudflare_module" } }
+    const userConfig = { nitro: { preset: "cloudflare_module" }, plugins: [{ name: "nitro:main" }] }
 
     config(userConfig, { command: "build" })
     expect(userConfig).toHaveProperty("nitro.cloudflare.wrangler.r2_buckets", [
@@ -123,12 +123,14 @@ describe("hubBlob", () => {
         ...(userConfig as { nitro?: object }).nitro,
         cloudflare: {
           wrangler: {
+            compatibility_flags: ["custom"],
             r2_buckets: [{ binding: "ASSETS", bucket_name: "assets", jurisdiction: "eu" }],
             routes: ["example.com/*"],
           },
         },
         preset: "cloudflare_module",
       },
+      plugins: [{ name: "nitro:main" }],
       root,
     }
     await configResolved(resolved as never)
@@ -137,7 +139,7 @@ describe("hubBlob", () => {
       { binding: "ASSETS", bucket_name: "assets", jurisdiction: "eu" },
     ])
     expect(resolved).toHaveProperty("nitro.cloudflare.wrangler.routes", ["example.com/*"])
-    expect(resolved).toHaveProperty("nitro.cloudflare.wrangler.compatibility_flags", ["nodejs_compat"])
+    expect(resolved).toHaveProperty("nitro.cloudflare.wrangler.compatibility_flags", ["custom", "nodejs_compat"])
     expect(resolved).toHaveProperty("nitro.rollupConfig.external", ["cloudflare:workers"])
     expect(resolved).not.toHaveProperty("nitro.cloudflare.wrangler.observability")
   })
@@ -152,7 +154,7 @@ describe("hubBlob", () => {
       const plugin = hubBlob()
       const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown
       const configResolved = plugin.configResolved as (config: unknown) => void | Promise<void>
-      const value = { nitro: {}, build: { outDir: "dist" }, root }
+      const value = { nitro: {}, build: { outDir: "dist" }, plugins: [{ name: "nitro:main" }], root }
 
       config(value, { command: "build" })
       await configResolved(value as never)
@@ -180,17 +182,20 @@ describe("hubBlob", () => {
     const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown
     const configResolved = plugin.configResolved as (config: unknown) => void | Promise<void>
     const closeBundle = plugin.closeBundle as () => void | Promise<void>
-    const value = { nitro: { preset: "cloudflare_module" } }
+    const value = { nitro: { preset: "cloudflare_module" }, plugins: [{ name: "nitro:main" }] }
 
     config(value, { command: "build" })
     await configResolved({
       build: { outDir: "dist/client" },
       nitro: { cloudflare: { wrangler: { routes: ["inactive.example/*"] } }, preset: "vercel" },
+      plugins: [{ name: "nitro:main" }],
       root,
     } as never)
     await closeBundle()
 
     expect(existsSync(join(root, "dist", toSafeAppName(root), "index.js"))).toBe(true)
+    const nitroPlugin = await readFile(join(root, ".vitehub", "nitro", "blob", "plugin.ts"), "utf8")
+    expect(nitroPlugin).not.toContain("cloudflare:workers")
   })
 
   it("does not contribute Cloudflare config for plain Vite or non-R2 stores", { timeout: 30_000 }, async () => {
@@ -213,7 +218,7 @@ describe("hubBlob", () => {
       else process.env.NITRO_PRESET = previousPreset
     }
 
-    const fsOnCloudflare = { nitro: { preset: "cloudflare_module" } }
+    const fsOnCloudflare = { nitro: { preset: "cloudflare_module" }, plugins: [{ name: "nitro:main" }] }
     config(hubBlob({ base: ".data/blob", driver: "fs" }), fsOnCloudflare)
     expect(fsOnCloudflare).not.toHaveProperty("nitro.cloudflare.wrangler.r2_buckets")
     expect(fsOnCloudflare).toHaveProperty("nitro.cloudflare.wrangler.compatibility_flags", ["nodejs_compat"])

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -183,7 +183,7 @@ describe("hubBlob", () => {
     expect(existsSync(join(root, "dist", toSafeAppName(root), "index.js"))).toBe(true)
   })
 
-  it("does not contribute Cloudflare config for plain Vite or non-R2 stores", async () => {
+  it("does not contribute Cloudflare config for plain Vite or non-R2 stores", { timeout: 30_000 }, async () => {
     const config = (plugin: ReturnType<typeof hubBlob>, value: Record<string, unknown>) =>
       (plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" | "serve" }) => unknown)(value, { command: "build" })
     const root = await mkdtemp(join(tmpdir(), "vitehub-blob-plain-vite-"))


### PR DESCRIPTION
## Summary

- compose discovered R2 bindings into Nitro's Cloudflare Wrangler output when Nitro owns the Worker
- preserve compatible explicit bindings and leave policy fields under application ownership
- suppress the competing standalone Blob Cloudflare worker/config without changing plain Vite Cloudflare or Vercel output

## Validation

- Blob typecheck
- 27/27 focused tests
- package build
- targeted oxlint (no new errors)
- `git diff --check`

## Dependency

Stacked on #705. Merge after #705.