### PR TITLE
feat(rate-limit): compose Nitro Cloudflare bindings

### DIFF
--- a/docs/content/docs/frameworks-hosts/cloudflare.md
+++ b/docs/content/docs/frameworks-hosts/cloudflare.md
@@ -78,7 +78,7 @@ Agent routes should come from generated Provider Output. Raw Cloudflare Worker f
 
 ### Rate Limiting bindings
 
-Register the Rate Limit integration. A Cloudflare Nitro preset infers the provider, and each source-local `defineRateLimit()` call contributes one `ratelimits` entry to generated `wrangler.json`.
+Register the Rate Limit integration. A Cloudflare Nitro preset infers the provider, and each source-local `defineRateLimit()` call contributes one `ratelimits` entry to Nitro's Wrangler config. Do not repeat those bindings in `nitro.cloudflare.wrangler`; plain Vite builds continue to write them to generated `wrangler.json`.
 
 ```ts [vite.config.ts]
 import { hubRateLimit } from '@vite-hub/rate-limit/vite'

--- a/packages/rate-limit/src/internal/provider-output.ts
+++ b/packages/rate-limit/src/internal/provider-output.ts
@@ -11,6 +11,7 @@ import type { ProviderOutputConfigOwnership } from "@vite-hub/internal/build/pro
 import type { RateLimitDeclaration } from "../types.ts"
 
 interface CloudflareRateLimitBindingConfig {
+  [key: string]: unknown
   name: string
   namespace_id: string
   simple: {
@@ -88,6 +89,7 @@ export function resolveRateLimitNamespace(configured?: string): string | undefin
 
 export async function writeRateLimitProviderOutput(options: {
   clientOutDir: string
+  cloudflareOwnedByNitro?: boolean
   declarations: RateLimitDeclaration[]
   namespace?: string
   previousDeclarations?: RateLimitDeclaration[]
@@ -105,6 +107,25 @@ export async function writeRateLimitProviderOutput(options: {
       },
     },
   } satisfies ProviderOutputConfigOwnership
+
+  if (options.cloudflareOwnedByNitro) {
+    if (options.provider === "cloudflare" && options.declarations.length > 0 && !options.namespace) {
+      throw new Error("[vitehub] Cloudflare Rate Limit requires rateLimit.namespace to isolate counters between deployments.")
+    }
+    await writeProviderDeploymentOutputs({
+      clientOutDir: options.clientOutDir,
+      cleanup: {
+        cloudflare: {
+          outputRoot: createDefaultCloudflareOutputRoot(options.rootDir),
+          wranglerConfigOwnership: ownership,
+        },
+      },
+      rootDir: options.rootDir,
+    })
+    await writeOutputState(options.rootDir, options.provider === "cloudflare" ? currentBindings : [])
+    await writeRateLimitManifest(options.rootDir, options.declarations, options.provider)
+    return
+  }
 
   if (options.provider === "cloudflare" && options.declarations.length > 0) {
     if (!options.namespace) {

--- a/packages/rate-limit/src/vite.ts
+++ b/packages/rate-limit/src/vite.ts
@@ -106,7 +106,7 @@ function resolveProvider(options: RateLimitModuleOptions, command: "build" | "se
 function isNitroCloudflareHost(nitro: unknown): boolean {
   if (!nitro || typeof nitro !== "object" || Array.isArray(nitro)) return false
   const preset = cloneNitroConfig(nitro).preset
-  return getHostingProvider(typeof preset === "string" ? preset : process.env.VITEHUB_HOSTING) === "cloudflare"
+  return typeof preset === "string" && getHostingProvider(preset) === "cloudflare"
 }
 
 export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimitVitePlugin {
@@ -200,7 +200,17 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
     },
     async closeBundle() {
       if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
-      await refreshDeclarations()
+      if (cloudflareOwnedByNitro) {
+        const configuredDeclarations = declarations
+        collectDeclarations()
+        if (JSON.stringify(declarations) !== JSON.stringify(configuredDeclarations)) {
+          throw new Error("[vitehub] Nitro Cloudflare Rate Limit declarations changed after config resolution. Generate Rate Limit source files before Vite config resolves.")
+        }
+        await writeRateLimitManifest(resolved.root, declarations, provider)
+      }
+      else {
+        await refreshDeclarations()
+      }
       const namespace = resolveRateLimitNamespace(rateLimit.namespace)
       await writeRateLimitProviderOutput({
         clientOutDir: resolved.build.outDir,

--- a/packages/rate-limit/src/vite.ts
+++ b/packages/rate-limit/src/vite.ts
@@ -3,6 +3,8 @@ import { resolve } from "node:path"
 
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import {
+  composeNitroCloudflareProviderOutput,
+  registerCloudflareProviderOutput,
   registerProviderRuntimeModules,
   shouldSkipViteProviderBuild,
   useComposedProviderOutput,
@@ -14,7 +16,7 @@ import { normalizePath } from "vite"
 
 import { discoverRateLimitDeclarations } from "./discovery.ts"
 import { writeRateLimitManifest } from "./internal/manifest.ts"
-import { resolveRateLimitNamespace, writeRateLimitProviderOutput } from "./internal/provider-output.ts"
+import { createCloudflareRateLimitBindings, resolveRateLimitNamespace, writeRateLimitProviderOutput } from "./internal/provider-output.ts"
 
 import type { ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
 import type { Plugin, ResolvedConfig } from "vite"
@@ -38,11 +40,29 @@ function cloneNitroConfig(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {}
 }
 
-function mergeNitroConfig(value: unknown): Record<string, unknown> {
+function mergeNitroConfig(
+  config: object,
+  value: unknown,
+  declarations: RateLimitDeclaration[],
+  namespace: string | undefined,
+  provider: "cloudflare" | "memory" | undefined,
+  cloudflareOwnedByNitro: boolean,
+): Record<string, unknown> {
   const nitro = cloneNitroConfig(value)
   const plugins = Array.isArray(nitro.plugins) ? [...nitro.plugins] : []
   if (!plugins.includes(generatedNitroPlugin)) plugins.unshift(generatedNitroPlugin)
-  return { ...nitro, plugins }
+  const baseNitro = { ...nitro, plugins }
+  if (!cloudflareOwnedByNitro || provider !== "cloudflare" || declarations.length === 0) {
+    registerCloudflareProviderOutput(config, "rate-limit", {})
+    return baseNitro
+  }
+  if (!namespace) {
+    throw new Error("[vitehub] Cloudflare Rate Limit requires rateLimit.namespace to isolate counters between deployments.")
+  }
+  registerCloudflareProviderOutput(config, "rate-limit", {
+    rateLimits: createCloudflareRateLimitBindings(declarations, namespace),
+  })
+  return composeNitroCloudflareProviderOutput(config, baseNitro)
 }
 
 function renderRuntimeInstaller(
@@ -70,16 +90,23 @@ function renderRuntimeInstaller(
   ].join("\n")
 }
 
-function resolveProvider(options: RateLimitModuleOptions, config: ResolvedConfig): "cloudflare" | "memory" {
+function resolveProvider(options: RateLimitModuleOptions, command: "build" | "serve", nitro: unknown, deferUnknown = false): "cloudflare" | "memory" | undefined {
   if (options.provider && options.provider !== "auto") return options.provider
-  if (config.command === "serve") return "memory"
-  const nitroPreset = (config as { nitro?: { preset?: string } }).nitro?.preset
-  const hosting = getHostingProvider(nitroPreset || process.env.VITEHUB_HOSTING)
+  if (command === "serve") return "memory"
+  const nitroPreset = cloneNitroConfig(nitro).preset
+  const hosting = getHostingProvider(typeof nitroPreset === "string" ? nitroPreset : process.env.VITEHUB_HOSTING)
   if (hosting === "cloudflare") return "cloudflare"
   if (hosting) {
     throw new Error(`[vitehub] Rate Limit has no native ${hosting} driver. Configure a custom Rate Limiter instead of falling back to per-instance memory.`)
   }
+  if (deferUnknown) return
   throw new Error("[vitehub] Rate Limit provider cannot be inferred for a production build. Set rateLimit.provider to \"cloudflare\" or explicitly choose \"memory\" for a known single-process deployment.")
+}
+
+function isNitroCloudflareHost(nitro: unknown): boolean {
+  if (!nitro || typeof nitro !== "object" || Array.isArray(nitro)) return false
+  const preset = cloneNitroConfig(nitro).preset
+  return getHostingProvider(typeof preset === "string" ? preset : process.env.VITEHUB_HOSTING) === "cloudflare"
 }
 
 export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimitVitePlugin {
@@ -88,26 +115,45 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
   let composedOutput: ComposedProviderOutput | undefined
   let declarations: RateLimitDeclaration[] = []
   let declarationFiles = new Set<string>()
+  let cloudflareOwnedByNitro = false
   let previousDeclarations: RateLimitDeclaration[] = []
   let provider: "cloudflare" | "memory" = "memory"
   let projectRoot: string | undefined
   let resolved: ResolvedConfig | undefined
 
-  const refreshDeclarations = async (): Promise<void> => {
-    if (!projectRoot || !resolved) return
+  const collectDeclarations = (): void => {
+    if (!projectRoot) return
     declarations = discoverRateLimitDeclarations({
       rootDir: projectRoot,
       scanDirs: rateLimit.scanDirs,
     })
     declarationFiles = new Set(declarations.map(declaration => declaration.source.file))
+  }
+
+  const refreshDeclarations = async (): Promise<void> => {
+    if (!projectRoot || !resolved) return
+    collectDeclarations()
     await writeRateLimitManifest(resolved.root, declarations, provider)
   }
 
   return {
     name: pluginName,
-    config(config) {
+    config(config, env) {
       rateLimit = config.rateLimit ?? rateLimit
-      const nitro = mergeNitroConfig((config as { nitro?: unknown }).nitro)
+      const configuredNitro = (config as { nitro?: unknown }).nitro
+      cloudflareOwnedByNitro = isNitroCloudflareHost(configuredNitro)
+      projectRoot = resolveViteHubProjectRoot(config.root || process.cwd(), { projectRoot: rateLimit.projectRoot })
+      const configuredProvider = resolveProvider(rateLimit, env?.command ?? "serve", configuredNitro, true)
+      if (configuredProvider) provider = configuredProvider
+      collectDeclarations()
+      const nitro = mergeNitroConfig(
+        config,
+        configuredNitro,
+        declarations,
+        resolveRateLimitNamespace(rateLimit.namespace),
+        configuredProvider,
+        cloudflareOwnedByNitro,
+      )
       ;(config as { nitro?: unknown }).nitro = nitro
       return { nitro } as never
     },
@@ -116,8 +162,19 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
       rateLimit = config.rateLimit ?? rateLimit
       composedOutput = useComposedProviderOutput(config)
       projectRoot = resolveViteHubProjectRoot(config.root, { projectRoot: rateLimit.projectRoot })
-      provider = resolveProvider(rateLimit, config)
-      await refreshDeclarations()
+      const configuredNitro = (config as { nitro?: unknown }).nitro
+      cloudflareOwnedByNitro = isNitroCloudflareHost(configuredNitro)
+      provider = resolveProvider(rateLimit, config.command, configuredNitro)!
+      collectDeclarations()
+      ;(config as { nitro?: unknown }).nitro = mergeNitroConfig(
+        config,
+        configuredNitro,
+        declarations,
+        resolveRateLimitNamespace(rateLimit.namespace),
+        provider,
+        cloudflareOwnedByNitro,
+      )
+      await writeRateLimitManifest(config.root, declarations, provider)
       const pluginFile = resolve(config.root, generatedNitroPlugin)
       const runtimeFile = resolve(config.root, generatedRuntimeModule)
       const runtimeConfig = { provider } satisfies RateLimitRuntimeConfig
@@ -147,6 +204,7 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
       const namespace = resolveRateLimitNamespace(rateLimit.namespace)
       await writeRateLimitProviderOutput({
         clientOutDir: resolved.build.outDir,
+        cloudflareOwnedByNitro,
         declarations,
         namespace,
         previousDeclarations,

--- a/packages/rate-limit/test/provider-output.test.ts
+++ b/packages/rate-limit/test/provider-output.test.ts
@@ -71,6 +71,39 @@ describe("Rate Limit Provider Output", () => {
     })
   })
 
+  it("leaves Nitro-owned Cloudflare output untouched while persisting generated state", async () => {
+    const { declarations, root } = await projectWithDeclaration()
+    const outputRoot = createDefaultCloudflareOutputRoot(root)
+    const configFile = join(outputRoot, "wrangler.json")
+    const existingConfig = {
+      ratelimits: [
+        { name: "NITRO", namespace_id: "7", simple: { limit: 2, period: 10 } },
+        { name: getCloudflareRateLimitBindingName("upload"), namespace_id: "8", simple: { limit: 10, period: 60 } },
+      ],
+      vars: { APP: "vitehub" },
+    }
+    await mkdir(outputRoot, { recursive: true })
+    await writeFile(configFile, `${JSON.stringify(existingConfig, null, 2)}\n`)
+
+    await writeRateLimitProviderOutput({
+      clientOutDir: "dist",
+      cloudflareOwnedByNitro: true,
+      declarations,
+      namespace: "acme-image-service",
+      provider: "cloudflare",
+      rootDir: root,
+    })
+
+    await expect(readFile(configFile, "utf8").then(JSON.parse)).resolves.toEqual({
+      ratelimits: [{ name: "NITRO", namespace_id: "7", simple: { limit: 2, period: 10 } }],
+      vars: { APP: "vitehub" },
+    })
+    await expect(readFile(join(root, ".vitehub", "rate-limit", "cloudflare-output.json"), "utf8").then(JSON.parse)).resolves.toEqual({
+      bindings: [getCloudflareRateLimitBindingName("upload")],
+    })
+    await expect(readFile(join(root, ".vitehub", "rate-limit", "manifest.json"), "utf8")).resolves.toContain('"provider": "cloudflare"')
+  })
+
   it("rejects unsupported Cloudflare guarantees", async () => {
     const strict = await projectWithDeclaration({ enforcement: "strict", limit: 10, window: "1m" })
     expect(() => createCloudflareRateLimitBindings(strict.declarations, "test")).toThrow("best-effort")

--- a/packages/rate-limit/test/vite.test.ts
+++ b/packages/rate-limit/test/vite.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
 
+import { getCloudflareRateLimitBindingName } from "../src/integrations/cloudflare.ts"
 import { hubRateLimit } from "../src/vite.ts"
 
 const roots: string[] = []
@@ -12,7 +13,94 @@ afterEach(async () => {
   await Promise.all(roots.splice(0).map(root => rm(root, { force: true, recursive: true })))
 })
 
+async function writeCloudflareDeclaration(root: string): Promise<void> {
+  await writeFile(join(root, "upload.ts"), [
+    'import { defineRateLimit } from "@vite-hub/rate-limit"',
+    'const upload = defineRateLimit("upload", { enforcement: "best-effort", limit: 10, window: "1m" })',
+    "void upload",
+    "",
+  ].join("\n"))
+}
+
 describe("hubRateLimit", () => {
+  it("composes discovered Rate Limits into a Nitro Cloudflare Worker", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-nitro-cloudflare-"))
+    roots.push(root)
+    await writeCloudflareDeclaration(root)
+    const plugin = hubRateLimit({ namespace: "vite-test" })
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => { nitro: Record<string, unknown> }
+    const configResolved = plugin.configResolved as (config: unknown) => Promise<void>
+    const userConfig = {
+      nitro: {
+        cloudflare: { wrangler: { ratelimits: [{ name: "MANUAL", namespace_id: "9", simple: { limit: 1, period: 10 } }] } },
+        preset: "cloudflare-module",
+      },
+      root,
+    }
+
+    const configured = config(userConfig, { command: "build" })
+    expect(configured.nitro).toMatchObject({
+      cloudflare: {
+        wrangler: {
+          ratelimits: [
+            { name: "MANUAL" },
+            { name: getCloudflareRateLimitBindingName("upload"), simple: { limit: 10, period: 60 } },
+          ],
+        },
+      },
+    })
+
+    const resolvedConfig = { ...userConfig, build: { outDir: "dist" }, command: "build", plugins: [], resolve: { alias: [] } }
+    await configResolved(resolvedConfig as never)
+    expect(resolvedConfig.nitro.cloudflare.wrangler.ratelimits).toHaveLength(2)
+  })
+
+  it("requires a namespace for discovered Nitro Cloudflare Rate Limits", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-nitro-namespace-"))
+    roots.push(root)
+    await writeCloudflareDeclaration(root)
+    const plugin = hubRateLimit()
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => unknown
+
+    expect(() => config({ nitro: { preset: "cloudflare-module" }, root }, { command: "build" })).toThrow("requires rateLimit.namespace")
+  })
+
+  it("composes after a Cloudflare Nitro preset resolves late", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-nitro-late-preset-"))
+    roots.push(root)
+    await writeCloudflareDeclaration(root)
+    const plugin = hubRateLimit({ namespace: "vite-test", projectRoot: "." })
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => unknown
+    const configResolved = plugin.configResolved as (config: unknown) => Promise<void>
+
+    expect(() => config({ nitro: {}, root }, { command: "build" })).not.toThrow()
+    const resolvedConfig = {
+      build: { outDir: "dist" },
+      command: "build",
+      nitro: { preset: "cloudflare_module" },
+      plugins: [],
+      resolve: { alias: [] },
+      root,
+    }
+    await configResolved(resolvedConfig as never)
+    expect(resolvedConfig).toHaveProperty("nitro.cloudflare.wrangler.ratelimits", [
+      expect.objectContaining({ name: getCloudflareRateLimitBindingName("upload") }),
+    ])
+  })
+
+  it("does not compose bindings for memory or non-Cloudflare Nitro builds", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-nitro-other-"))
+    roots.push(root)
+    await writeCloudflareDeclaration(root)
+    const memoryPlugin = hubRateLimit({ provider: "memory" })
+    const memoryConfig = memoryPlugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => { nitro: Record<string, unknown> }
+    expect(memoryConfig({ nitro: { preset: "cloudflare-module" }, root }, { command: "build" }).nitro).not.toHaveProperty("cloudflare.wrangler.ratelimits")
+
+    const vercelPlugin = hubRateLimit({ namespace: "vite-test", provider: "cloudflare" })
+    const vercelConfig = vercelPlugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => { nitro: Record<string, unknown> }
+    expect(vercelConfig({ nitro: { preset: "vercel" }, root }, { command: "build" }).nitro).not.toHaveProperty("cloudflare.wrangler.ratelimits")
+  })
+
   it("registers generated Nitro runtime with config-key precedence", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-vite-"))
     roots.push(root)

--- a/packages/rate-limit/test/vite.test.ts
+++ b/packages/rate-limit/test/vite.test.ts
@@ -1,4 +1,4 @@
-import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -99,6 +99,48 @@ describe("hubRateLimit", () => {
     const vercelPlugin = hubRateLimit({ namespace: "vite-test", provider: "cloudflare" })
     const vercelConfig = vercelPlugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => { nitro: Record<string, unknown> }
     expect(vercelConfig({ nitro: { preset: "vercel" }, root }, { command: "build" }).nitro).not.toHaveProperty("cloudflare.wrangler.ratelimits")
+  })
+
+  it("keeps standalone output when hosting inference has no Nitro preset", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-plain-cloudflare-"))
+    roots.push(root)
+    await writeCloudflareDeclaration(root)
+    const previousHosting = process.env.VITEHUB_HOSTING
+    process.env.VITEHUB_HOSTING = "cloudflare"
+    try {
+      const plugin = hubRateLimit({ namespace: "vite-test" })
+      const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => unknown
+      const configResolved = plugin.configResolved as (config: unknown) => Promise<void>
+      const closeBundle = plugin.closeBundle as () => Promise<void>
+      const userConfig = { root }
+
+      config(userConfig, { command: "build" })
+      await configResolved({ ...userConfig, build: { outDir: "dist" }, command: "build", plugins: [], resolve: { alias: [] } } as never)
+      await closeBundle()
+
+      const [appOutput] = await readdir(join(root, "dist"))
+      await expect(readFile(join(root, "dist", appOutput!, "wrangler.json"), "utf8")).resolves.toContain(getCloudflareRateLimitBindingName("upload"))
+    }
+    finally {
+      if (previousHosting === undefined) delete process.env.VITEHUB_HOSTING
+      else process.env.VITEHUB_HOSTING = previousHosting
+    }
+  })
+
+  it("rejects Nitro Rate Limit declarations generated after config resolution", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-nitro-late-declaration-"))
+    roots.push(root)
+    const plugin = hubRateLimit({ namespace: "vite-test" })
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => unknown
+    const configResolved = plugin.configResolved as (config: unknown) => Promise<void>
+    const closeBundle = plugin.closeBundle as () => Promise<void>
+    const userConfig = { nitro: { preset: "cloudflare-module" }, root }
+
+    config(userConfig, { command: "build" })
+    await configResolved({ ...userConfig, build: { outDir: "dist" }, command: "build", plugins: [], resolve: { alias: [] } } as never)
+    await writeCloudflareDeclaration(root)
+
+    await expect(closeBundle()).rejects.toThrow("changed after config resolution")
   })
 
   it("registers generated Nitro runtime with config-key precedence", async () => {


### PR DESCRIPTION
Composes discovered Rate Limit declarations into Nitro’s Cloudflare Wrangler config, so applications no longer need to repeat generated `ratelimits` bindings manually.

The integration reuses the existing Cloudflare binding translator, preserves standalone output for plain Vite builds, and leaves Nitro-owned Wrangler files untouched while retaining Rate Limit manifest and ownership state. The package build, typecheck, and all 50 tests pass.

Depends on #705.