### PR TITLE
fix(schedule): close public error serialization

### DIFF
--- a/packages/schedule/fixtures/published-types/consumer.ts
+++ b/packages/schedule/fixtures/published-types/consumer.ts
@@ -6,11 +6,11 @@ import registry from "#vitehub/schedule/registry"
 registry satisfies ScheduleDefinitionRegistry
 
 const code = "SCHEDULE_NOT_FOUND" satisfies ScheduleErrorCode
-const error = new ScheduleError("Runtime Schedule not found: daily", {
-  code,
-  details: { id: "daily" },
-  httpStatus: 404,
-})
+const error = new ScheduleError(code)
+new ScheduleError("SCHEDULE_INVALID_ID", { details: { field: "id", valueType: "string" } })
+
+// @ts-expect-error Schedule details use a closed field/valueType schema.
+new ScheduleError(code, { details: { field: "id", token: "private", valueType: "string" } })
 
 error.code satisfies ScheduleErrorCode
 error.toJSON().code satisfies ScheduleErrorCode

--- a/packages/schedule/fixtures/published-types/consumer.ts
+++ b/packages/schedule/fixtures/published-types/consumer.ts
@@ -10,7 +10,7 @@ const error = new ScheduleError(code)
 new ScheduleError("SCHEDULE_INVALID_ID", { details: { field: "id", valueType: "string" } })
 
 // @ts-expect-error Schedule details use a closed field/valueType schema.
-new ScheduleError(code, { details: { field: "id", token: "private", valueType: "string" } })
+new ScheduleError("SCHEDULE_INVALID_ID", { details: { field: "id", token: "private", valueType: "string" } })
 
 error.code satisfies ScheduleErrorCode
 error.toJSON().code satisfies ScheduleErrorCode

--- a/packages/schedule/src/errors.ts
+++ b/packages/schedule/src/errors.ts
@@ -173,7 +173,7 @@ function sealScheduleError(error: ScheduleError): void {
   const snapshot = Object.freeze(error.toJSON())
   Object.defineProperty(error, "toJSON", {
     configurable: false,
-    enumerable: true,
+    enumerable: false,
     value: () => snapshot,
     writable: false,
   })

--- a/packages/schedule/src/errors.ts
+++ b/packages/schedule/src/errors.ts
@@ -164,5 +164,16 @@ export class ScheduleError<TCode extends ScheduleErrorCode = ScheduleErrorCode> 
     super(normalizedCode as TCode, scheduleErrorMessages[normalizedCode], normalizedOptions)
     this.name = "ScheduleError"
     this.httpStatus = scheduleErrorHttpStatuses[normalizedCode]
+    sealScheduleError(this)
+  }
+}
+
+function sealScheduleError(error: ScheduleError): void {
+  if (error.details) Object.freeze(error.details)
+  for (const key of ["code", "details", "httpStatus", "message", "name", "requestId", "retryable"] as const) {
+    const descriptor = Object.getOwnPropertyDescriptor(error, key)
+    if (descriptor && "writable" in descriptor) {
+      Object.defineProperty(error, key, { ...descriptor, configurable: false, writable: false })
+    }
   }
 }

--- a/packages/schedule/src/errors.ts
+++ b/packages/schedule/src/errors.ts
@@ -170,13 +170,15 @@ export class ScheduleError<TCode extends ScheduleErrorCode = ScheduleErrorCode> 
 
 function sealScheduleError(error: ScheduleError): void {
   if (error.details) Object.freeze(error.details)
-  const snapshot = Object.freeze(error.toJSON())
-  Object.defineProperty(error, "toJSON", {
-    configurable: false,
-    enumerable: false,
-    value: () => snapshot,
-    writable: false,
-  })
+  if (!Object.getOwnPropertyDescriptor(error, "toJSON")) {
+    const snapshot = Object.freeze(error.toJSON())
+    Object.defineProperty(error, "toJSON", {
+      configurable: false,
+      enumerable: false,
+      value: () => snapshot,
+      writable: false,
+    })
+  }
   for (const key of ["code", "details", "httpStatus", "message", "name", "requestId", "retryable"] as const) {
     const descriptor = Object.getOwnPropertyDescriptor(error, key)
     if (descriptor && "writable" in descriptor) {

--- a/packages/schedule/src/errors.ts
+++ b/packages/schedule/src/errors.ts
@@ -1,65 +1,168 @@
 import { ViteHubError } from "@vite-hub/runtime"
 
-import type { ViteHubErrorDetails, ViteHubErrorOptions } from "@vite-hub/runtime"
+const scheduleErrorCodes = [
+  "SCHEDULE_ALREADY_EXISTS",
+  "SCHEDULE_DISABLED",
+  "SCHEDULE_INVALID_CRON",
+  "SCHEDULE_INVALID_ENABLED",
+  "SCHEDULE_INVALID_ID",
+  "SCHEDULE_INVALID_INPUT",
+  "SCHEDULE_INVALID_SCHEDULED_AT",
+  "SCHEDULE_INVALID_TARGET",
+  "SCHEDULE_INVALID_TIME_ZONE",
+  "SCHEDULE_NOT_DUE",
+  "SCHEDULE_NOT_FOUND",
+  "SCHEDULE_RUN_NOT_FOUND",
+  "SCHEDULE_TARGET_NOT_ELIGIBLE",
+  "SCHEDULE_TARGET_NOT_FOUND",
+] as const
 
-export type ScheduleErrorCode =
-  | "SCHEDULE_ALREADY_EXISTS"
-  | "SCHEDULE_DISABLED"
-  | "SCHEDULE_INVALID_CRON"
-  | "SCHEDULE_INVALID_ENABLED"
-  | "SCHEDULE_INVALID_ID"
-  | "SCHEDULE_INVALID_INPUT"
-  | "SCHEDULE_INVALID_SCHEDULED_AT"
-  | "SCHEDULE_INVALID_TARGET"
-  | "SCHEDULE_INVALID_TIME_ZONE"
-  | "SCHEDULE_NOT_DUE"
-  | "SCHEDULE_NOT_FOUND"
-  | "SCHEDULE_RUN_NOT_FOUND"
-  | "SCHEDULE_TARGET_NOT_ELIGIBLE"
-  | "SCHEDULE_TARGET_NOT_FOUND"
+const scheduleErrorFields = [
+  "cron",
+  "enabled",
+  "id",
+  "input",
+  "options",
+  "scheduledAt",
+  "target",
+  "timeZone",
+] as const
 
-export interface ScheduleErrorOptions<TCode extends ScheduleErrorCode = ScheduleErrorCode> extends ViteHubErrorOptions {
-  code: TCode
-  httpStatus?: number
+const scheduleErrorValueTypes = [
+  "array",
+  "bigint",
+  "boolean",
+  "date",
+  "function",
+  "null",
+  "number",
+  "object",
+  "string",
+  "symbol",
+  "undefined",
+  "unknown",
+] as const
+
+export type ScheduleErrorCode = typeof scheduleErrorCodes[number]
+export type ScheduleErrorField = typeof scheduleErrorFields[number]
+export type ScheduleErrorValueType = typeof scheduleErrorValueTypes[number]
+export type ScheduleValidationErrorCode = Extract<ScheduleErrorCode, `SCHEDULE_INVALID_${string}`>
+
+export type ScheduleErrorDetails = {
+  field: ScheduleErrorField
+  valueType: ScheduleErrorValueType
 }
 
-export type ScheduleErrorField =
-  | "cron"
-  | "enabled"
-  | "id"
-  | "input"
-  | "options"
-  | "scheduledAt"
-  | "target"
-  | "timeZone"
+export type ScheduleErrorOptions<TCode extends ScheduleErrorCode = ScheduleErrorCode> = ErrorOptions & {
+  requestId?: string
+} & (TCode extends ScheduleValidationErrorCode ? { details?: ScheduleErrorDetails } : { details?: never })
 
-export function invalidScheduleValueDetails(field: ScheduleErrorField, value: unknown): ViteHubErrorDetails {
-  const valueType = value === null
-    ? "null"
-    : Array.isArray(value)
-      ? "array"
-      : value instanceof Date
-        ? "date"
-        : typeof value
+const scheduleErrorMessages: Record<ScheduleErrorCode, string> = {
+  SCHEDULE_ALREADY_EXISTS: "Runtime Schedule already exists.",
+  SCHEDULE_DISABLED: "Runtime Schedule is disabled.",
+  SCHEDULE_INVALID_CRON: "Runtime Schedule cron is invalid.",
+  SCHEDULE_INVALID_ENABLED: "Runtime Schedule enabled value is invalid.",
+  SCHEDULE_INVALID_ID: "Runtime Schedule id is invalid.",
+  SCHEDULE_INVALID_INPUT: "Runtime Schedule input is invalid.",
+  SCHEDULE_INVALID_SCHEDULED_AT: "Runtime Schedule scheduledAt value is invalid.",
+  SCHEDULE_INVALID_TARGET: "Runtime Schedule target is invalid.",
+  SCHEDULE_INVALID_TIME_ZONE: "Runtime Schedule time zone is invalid.",
+  SCHEDULE_NOT_DUE: "Runtime Schedule is not due.",
+  SCHEDULE_NOT_FOUND: "Runtime Schedule was not found.",
+  SCHEDULE_RUN_NOT_FOUND: "Schedule Run was not found.",
+  SCHEDULE_TARGET_NOT_ELIGIBLE: "Runtime Schedule target is not eligible.",
+  SCHEDULE_TARGET_NOT_FOUND: "Runtime Schedule target was not found.",
+}
+
+const scheduleErrorHttpStatuses: Record<ScheduleErrorCode, number> = {
+  SCHEDULE_ALREADY_EXISTS: 409,
+  SCHEDULE_DISABLED: 409,
+  SCHEDULE_INVALID_CRON: 400,
+  SCHEDULE_INVALID_ENABLED: 400,
+  SCHEDULE_INVALID_ID: 400,
+  SCHEDULE_INVALID_INPUT: 400,
+  SCHEDULE_INVALID_SCHEDULED_AT: 400,
+  SCHEDULE_INVALID_TARGET: 400,
+  SCHEDULE_INVALID_TIME_ZONE: 400,
+  SCHEDULE_NOT_DUE: 409,
+  SCHEDULE_NOT_FOUND: 404,
+  SCHEDULE_RUN_NOT_FOUND: 500,
+  SCHEDULE_TARGET_NOT_ELIGIBLE: 400,
+  SCHEDULE_TARGET_NOT_FOUND: 404,
+}
+
+const scheduleErrorCodeSet = new Set<string>(scheduleErrorCodes)
+const scheduleErrorFieldSet = new Set<string>(scheduleErrorFields)
+const scheduleErrorValueTypeSet = new Set<string>(scheduleErrorValueTypes)
+
+function readProperty(value: object, key: PropertyKey): unknown {
+  try {
+    return Reflect.get(value, key)
+  }
+  catch {
+    return undefined
+  }
+}
+
+function normalizeScheduleErrorCode(code: unknown): ScheduleErrorCode {
+  if (typeof code !== "string" || !scheduleErrorCodeSet.has(code)) {
+    throw new TypeError("[vitehub] ScheduleError requires a supported Schedule error code.")
+  }
+  return code as ScheduleErrorCode
+}
+
+function normalizeScheduleErrorDetails(value: unknown): ScheduleErrorDetails | undefined {
+  if (typeof value !== "object" || value === null) return undefined
+  const field = readProperty(value, "field")
+  const valueType = readProperty(value, "valueType")
+  if (typeof field !== "string" || !scheduleErrorFieldSet.has(field)) return undefined
+  if (typeof valueType !== "string" || !scheduleErrorValueTypeSet.has(valueType)) return undefined
+  return { field: field as ScheduleErrorField, valueType: valueType as ScheduleErrorValueType }
+}
+
+function normalizeScheduleErrorOptions(code: ScheduleErrorCode, value: unknown): Required<Pick<ErrorOptions, "cause">> & { details?: ScheduleErrorDetails, requestId?: string } {
+  if (typeof value !== "object" || value === null) return { cause: undefined }
+  const requestId = readProperty(value, "requestId")
+  return {
+    cause: readProperty(value, "cause"),
+    ...(code.startsWith("SCHEDULE_INVALID_") ? { details: normalizeScheduleErrorDetails(readProperty(value, "details")) } : {}),
+    ...(typeof requestId === "string" && /^[A-Za-z0-9._:-]{1,128}$/.test(requestId) ? { requestId } : {}),
+  }
+}
+
+export function invalidScheduleValueDetails(field: ScheduleErrorField, value: unknown): ScheduleErrorDetails {
+  let valueType: ScheduleErrorValueType
+  try {
+    valueType = value === null
+      ? "null"
+      : Array.isArray(value)
+        ? "array"
+        : value instanceof Date
+          ? "date"
+          : typeof value
+  }
+  catch {
+    valueType = "unknown"
+  }
   return { field, valueType }
 }
 
 export function assertRuntimeScheduleId(id: unknown): asserts id is string {
   if (typeof id !== "string" || !id.trim()) {
-    throw new ScheduleError("Runtime Schedule id must be a non-empty string.", {
-      code: "SCHEDULE_INVALID_ID",
+    throw new ScheduleError("SCHEDULE_INVALID_ID", {
       details: invalidScheduleValueDetails("id", id),
-      httpStatus: 400,
     })
   }
 }
 
-export class ScheduleError<TCode extends ScheduleErrorCode = ScheduleErrorCode> extends ViteHubError<TCode> {
-  readonly httpStatus?: number
+export class ScheduleError<TCode extends ScheduleErrorCode = ScheduleErrorCode> extends ViteHubError<TCode, ScheduleErrorDetails> {
+  readonly httpStatus: number
 
-  constructor(message: string, options: ScheduleErrorOptions<TCode>) {
-    super(options.code, message, options)
+  constructor(code: TCode, options?: ScheduleErrorOptions<TCode>) {
+    const normalizedCode = normalizeScheduleErrorCode(code)
+    const normalizedOptions = normalizeScheduleErrorOptions(normalizedCode, options)
+    super(normalizedCode as TCode, scheduleErrorMessages[normalizedCode], normalizedOptions)
     this.name = "ScheduleError"
-    this.httpStatus = options.httpStatus
+    this.httpStatus = scheduleErrorHttpStatuses[normalizedCode]
   }
 }

--- a/packages/schedule/src/errors.ts
+++ b/packages/schedule/src/errors.ts
@@ -55,6 +55,7 @@ export type ScheduleErrorDetails = {
 
 export type ScheduleErrorOptions<TCode extends ScheduleErrorCode = ScheduleErrorCode> = ErrorOptions & {
   requestId?: string
+  retryable?: boolean
 } & (TCode extends ScheduleValidationErrorCode ? { details?: ScheduleErrorDetails } : { details?: never })
 
 const scheduleErrorMessages: Record<ScheduleErrorCode, string> = {
@@ -67,7 +68,7 @@ const scheduleErrorMessages: Record<ScheduleErrorCode, string> = {
   SCHEDULE_INVALID_SCHEDULED_AT: "Runtime Schedule scheduledAt value is invalid.",
   SCHEDULE_INVALID_TARGET: "Runtime Schedule target is invalid.",
   SCHEDULE_INVALID_TIME_ZONE: "Runtime Schedule time zone is invalid.",
-  SCHEDULE_NOT_DUE: "Runtime Schedule is not due.",
+  SCHEDULE_NOT_DUE: "Schedule is not due.",
   SCHEDULE_NOT_FOUND: "Runtime Schedule was not found.",
   SCHEDULE_RUN_NOT_FOUND: "Schedule Run was not found.",
   SCHEDULE_TARGET_NOT_ELIGIBLE: "Runtime Schedule target is not eligible.",
@@ -120,13 +121,15 @@ function normalizeScheduleErrorDetails(value: unknown): ScheduleErrorDetails | u
   return { field: field as ScheduleErrorField, valueType: valueType as ScheduleErrorValueType }
 }
 
-function normalizeScheduleErrorOptions(code: ScheduleErrorCode, value: unknown): Required<Pick<ErrorOptions, "cause">> & { details?: ScheduleErrorDetails, requestId?: string } {
+function normalizeScheduleErrorOptions(code: ScheduleErrorCode, value: unknown): Required<Pick<ErrorOptions, "cause">> & { details?: ScheduleErrorDetails, requestId?: string, retryable?: boolean } {
   if (typeof value !== "object" || value === null) return { cause: undefined }
   const requestId = readProperty(value, "requestId")
+  const retryable = readProperty(value, "retryable")
   return {
     cause: readProperty(value, "cause"),
     ...(code.startsWith("SCHEDULE_INVALID_") ? { details: normalizeScheduleErrorDetails(readProperty(value, "details")) } : {}),
     ...(typeof requestId === "string" && /^[A-Za-z0-9._:-]{1,128}$/.test(requestId) ? { requestId } : {}),
+    ...(typeof retryable === "boolean" ? { retryable } : {}),
   }
 }
 

--- a/packages/schedule/src/errors.ts
+++ b/packages/schedule/src/errors.ts
@@ -170,6 +170,13 @@ export class ScheduleError<TCode extends ScheduleErrorCode = ScheduleErrorCode> 
 
 function sealScheduleError(error: ScheduleError): void {
   if (error.details) Object.freeze(error.details)
+  const snapshot = Object.freeze(error.toJSON())
+  Object.defineProperty(error, "toJSON", {
+    configurable: false,
+    enumerable: true,
+    value: () => snapshot,
+    writable: false,
+  })
   for (const key of ["code", "details", "httpStatus", "message", "name", "requestId", "retryable"] as const) {
     const descriptor = Object.getOwnPropertyDescriptor(error, key)
     if (descriptor && "writable" in descriptor) {

--- a/packages/schedule/src/index.ts
+++ b/packages/schedule/src/index.ts
@@ -18,8 +18,11 @@ export {
 
 export type {
   ScheduleErrorCode,
+  ScheduleErrorDetails,
   ScheduleErrorField,
   ScheduleErrorOptions,
+  ScheduleErrorValueType,
+  ScheduleValidationErrorCode,
 } from "./errors.ts"
 
 export type {

--- a/packages/schedule/src/runtime/client.ts
+++ b/packages/schedule/src/runtime/client.ts
@@ -69,19 +69,15 @@ function validateCronPart(part: string, range: { min: number, max: number }): vo
 
 export function validateRuntimeScheduleCron(cron: unknown): void {
   if (typeof cron !== "string" || cron.trim() !== cron || cron.length === 0) {
-    throw new ScheduleError("Runtime Schedule cron must be a five-field cron expression.", {
-      code: "SCHEDULE_INVALID_CRON",
+    throw new ScheduleError("SCHEDULE_INVALID_CRON", {
       details: invalidScheduleValueDetails("cron", cron),
-      httpStatus: 400,
     })
   }
 
   const fields = cron.split(/\s+/)
   if (fields.length !== 5) {
-    throw new ScheduleError("Runtime Schedule cron must be a five-field cron expression.", {
-      code: "SCHEDULE_INVALID_CRON",
+    throw new ScheduleError("SCHEDULE_INVALID_CRON", {
       details: invalidScheduleValueDetails("cron", cron),
-      httpStatus: 400,
     })
   }
 
@@ -96,85 +92,65 @@ export function validateRuntimeScheduleCron(cron: unknown): void {
     })
   }
   catch {
-    throw new ScheduleError("Runtime Schedule cron must be a valid five-field cron expression.", {
-      code: "SCHEDULE_INVALID_CRON",
+    throw new ScheduleError("SCHEDULE_INVALID_CRON", {
       details: invalidScheduleValueDetails("cron", cron),
-      httpStatus: 400,
     })
   }
 }
 
 function validateRuntimeScheduleTimeZone(timeZone: unknown): void {
   if (!isIanaTimeZone(timeZone)) {
-    throw new ScheduleError("Runtime Schedule timeZone must be a valid IANA time zone.", {
-      code: "SCHEDULE_INVALID_TIME_ZONE",
+    throw new ScheduleError("SCHEDULE_INVALID_TIME_ZONE", {
       details: invalidScheduleValueDetails("timeZone", timeZone),
-      httpStatus: 400,
     })
   }
 }
 
 async function assertRuntimeTarget(target: unknown): Promise<void> {
   if (typeof target !== "string" || !target.trim()) {
-    throw new ScheduleError("Runtime Schedule target must be a non-empty string.", {
-      code: "SCHEDULE_INVALID_TARGET",
+    throw new ScheduleError("SCHEDULE_INVALID_TARGET", {
       details: invalidScheduleValueDetails("target", target),
-      httpStatus: 400,
     })
   }
 
   const definition = await loadScheduleDefinition(target)
   if (!definition) {
-    throw new ScheduleError(`Unknown Runtime Schedule target: ${target}`, {
-      code: "SCHEDULE_TARGET_NOT_FOUND",
-      details: { target },
-      httpStatus: 404,
-    })
+    throw new ScheduleError("SCHEDULE_TARGET_NOT_FOUND")
   }
 
   if (definition.options?.allowRuntimeSchedules !== true) {
-    throw new ScheduleError(`Schedule target is not runtime-schedule eligible: ${target}`, {
-      code: "SCHEDULE_TARGET_NOT_ELIGIBLE",
-      details: { target },
-      httpStatus: 400,
-    })
+    throw new ScheduleError("SCHEDULE_TARGET_NOT_ELIGIBLE")
   }
 }
 
-function assertRuntimeScheduleInputObject(input: unknown, operation: "create" | "update"): asserts input is Record<string, unknown> {
+function assertRuntimeScheduleInputObject(input: unknown): asserts input is Record<string, unknown> {
   if (typeof input !== "object" || input === null || Array.isArray(input)) {
-    throw new ScheduleError(`Runtime Schedule ${operation} input must be an object.`, {
-      code: "SCHEDULE_INVALID_INPUT",
+    throw new ScheduleError("SCHEDULE_INVALID_INPUT", {
       details: invalidScheduleValueDetails("input", input),
-      httpStatus: 400,
     })
   }
 }
 
-function assertRuntimeScheduleInputKeys(input: Record<string, unknown>, allowed: Set<string>, operation: "create" | "update"): void {
+function assertRuntimeScheduleInputKeys(input: Record<string, unknown>, allowed: Set<string>): void {
   const unknownKey = Object.keys(input).find(key => !allowed.has(key))
   if (unknownKey) {
-    throw new ScheduleError(`Runtime Schedule ${operation} contains an unsupported field.`, {
-      code: "SCHEDULE_INVALID_INPUT",
+    throw new ScheduleError("SCHEDULE_INVALID_INPUT", {
       details: invalidScheduleValueDetails("input", input),
-      httpStatus: 400,
     })
   }
 }
 
 async function validateCreateInput(input: RuntimeScheduleCreateInput): Promise<void> {
-  assertRuntimeScheduleInputObject(input, "create")
-  assertRuntimeScheduleInputKeys(input, runtimeScheduleCreateInputKeys, "create")
+  assertRuntimeScheduleInputObject(input)
+  assertRuntimeScheduleInputKeys(input, runtimeScheduleCreateInputKeys)
   await assertRuntimeTarget(input.target)
   validateRuntimeScheduleCron(input.cron)
   if (input.id !== undefined) {
     assertRuntimeScheduleId(input.id)
   }
   if (input.enabled !== undefined && typeof input.enabled !== "boolean") {
-    throw new ScheduleError("Runtime Schedule enabled must be a boolean when provided.", {
-      code: "SCHEDULE_INVALID_ENABLED",
+    throw new ScheduleError("SCHEDULE_INVALID_ENABLED", {
       details: invalidScheduleValueDetails("enabled", input.enabled),
-      httpStatus: 400,
     })
   }
   if (input.timeZone !== undefined) {
@@ -183,8 +159,8 @@ async function validateCreateInput(input: RuntimeScheduleCreateInput): Promise<v
 }
 
 async function validateUpdateInput(input: RuntimeScheduleUpdateInput): Promise<void> {
-  assertRuntimeScheduleInputObject(input, "update")
-  assertRuntimeScheduleInputKeys(input, runtimeScheduleUpdateInputKeys, "update")
+  assertRuntimeScheduleInputObject(input)
+  assertRuntimeScheduleInputKeys(input, runtimeScheduleUpdateInputKeys)
   if (input.target !== undefined) {
     await assertRuntimeTarget(input.target)
   }
@@ -192,10 +168,8 @@ async function validateUpdateInput(input: RuntimeScheduleUpdateInput): Promise<v
     validateRuntimeScheduleCron(input.cron)
   }
   if (input.enabled !== undefined && typeof input.enabled !== "boolean") {
-    throw new ScheduleError("Runtime Schedule enabled must be a boolean when provided.", {
-      code: "SCHEDULE_INVALID_ENABLED",
+    throw new ScheduleError("SCHEDULE_INVALID_ENABLED", {
       details: invalidScheduleValueDetails("enabled", input.enabled),
-      httpStatus: 400,
     })
   }
   if (input.timeZone !== undefined) {
@@ -211,11 +185,7 @@ async function updateRuntimeSchedule<TTarget extends ScheduleTargetName, TInput>
     updatedAt: new Date(),
   })
   if (!updated) {
-    throw new ScheduleError(`Runtime Schedule not found: ${id}`, {
-      code: "SCHEDULE_NOT_FOUND",
-      details: { id },
-      httpStatus: 404,
-    })
+    throw new ScheduleError("SCHEDULE_NOT_FOUND")
   }
   return updated as RuntimeScheduleRecord<TInput>
 }

--- a/packages/schedule/src/runtime/driver.ts
+++ b/packages/schedule/src/runtime/driver.ts
@@ -393,11 +393,7 @@ export async function installScheduleRuntime(options: InstallScheduleRuntimeOpti
             const staticSchedule = staticSchedules.byId.get(input.scheduleId)
             if (staticSchedule) {
               if (!isRuntimeScheduleDue(staticSchedule.record, input.scheduledAt)) {
-                throw new ScheduleError(`Static Schedule is not due: ${staticSchedule.name}`, {
-                  code: "SCHEDULE_NOT_DUE",
-                  details: { id: input.scheduleId, scheduledAt: input.scheduledAt.toISOString() },
-                  httpStatus: 409,
-                })
+                throw new ScheduleError("SCHEDULE_NOT_DUE")
               }
               await executeStaticSchedule({
                 cron: staticSchedule.definition.cron,

--- a/packages/schedule/src/runtime/execute.ts
+++ b/packages/schedule/src/runtime/execute.ts
@@ -43,10 +43,8 @@ interface ExecuteRuntimeScheduleWakeOptions {
 
 function assertRuntimeExecuteOptionsObject(options: unknown): asserts options is ExecuteRuntimeScheduleOptions {
   if (typeof options !== "object" || options === null || Array.isArray(options)) {
-    throw new ScheduleError("Runtime Schedule execute options must be a schedule id or options object.", {
-      code: "SCHEDULE_INVALID_INPUT",
+    throw new ScheduleError("SCHEDULE_INVALID_INPUT", {
       details: invalidScheduleValueDetails("options", options),
-      httpStatus: 400,
     })
   }
 }
@@ -61,10 +59,8 @@ function toRunId(source: ExecuteScheduleOptions["source"], scheduleId: string, s
 
 function validateScheduledAt(scheduledAt: Date): Date {
   if (!(scheduledAt instanceof Date) || Number.isNaN(scheduledAt.getTime())) {
-    throw new ScheduleError("Schedule Run scheduledAt must be a valid Date.", {
-      code: "SCHEDULE_INVALID_SCHEDULED_AT",
+    throw new ScheduleError("SCHEDULE_INVALID_SCHEDULED_AT", {
       details: invalidScheduleValueDetails("scheduledAt", scheduledAt),
-      httpStatus: 400,
     })
   }
   return scheduledAt
@@ -83,10 +79,7 @@ function toRunError(error: unknown): ScheduleRunError {
 
 function requireUpdatedRun(run: ScheduleRunRecord | undefined): ScheduleRunRecord {
   if (!run) {
-    throw new ScheduleError("Schedule Run bookkeeping update failed.", {
-      code: "SCHEDULE_RUN_NOT_FOUND",
-      httpStatus: 500,
-    })
+    throw new ScheduleError("SCHEDULE_RUN_NOT_FOUND")
   }
   return run
 }
@@ -246,11 +239,7 @@ export async function executeStaticSchedule(options: ExecuteStaticScheduleOption
 async function loadRequiredRuntimeSchedule(id: string, store: RuntimeScheduleStore = getRuntimeScheduleStore()): Promise<RuntimeScheduleRecord> {
   const schedule = await store.get(id)
   if (!schedule) {
-    throw new ScheduleError(`Runtime Schedule not found: ${id}`, {
-      code: "SCHEDULE_NOT_FOUND",
-      details: { id },
-      httpStatus: 404,
-    })
+    throw new ScheduleError("SCHEDULE_NOT_FOUND")
   }
   return schedule
 }
@@ -270,33 +259,17 @@ export async function executeRuntimeSchedule(options: ExecuteRuntimeScheduleOpti
 
   const schedule = await loadRequiredRuntimeSchedule(id, runtimeScheduleStore)
   if (!schedule.enabled) {
-    throw new ScheduleError(`Runtime Schedule is disabled: ${id}`, {
-      code: "SCHEDULE_DISABLED",
-      details: { id },
-      httpStatus: 409,
-    })
+    throw new ScheduleError("SCHEDULE_DISABLED")
   }
   if (runtimeOptions.requireDue && !isRuntimeScheduleDue(schedule, scheduledAt)) {
-    throw new ScheduleError(`Runtime Schedule is not due: ${id}`, {
-      code: "SCHEDULE_NOT_DUE",
-      details: { id, scheduledAt: scheduledAt.toISOString() },
-      httpStatus: 409,
-    })
+    throw new ScheduleError("SCHEDULE_NOT_DUE")
   }
   const definition = await loadScheduleDefinition(schedule.target)
   if (!definition) {
-    throw new ScheduleError(`Unknown Runtime Schedule target: ${schedule.target}`, {
-      code: "SCHEDULE_TARGET_NOT_FOUND",
-      details: { target: schedule.target },
-      httpStatus: 404,
-    })
+    throw new ScheduleError("SCHEDULE_TARGET_NOT_FOUND")
   }
   if (definition.options?.allowRuntimeSchedules !== true) {
-    throw new ScheduleError(`Runtime Schedule target is not eligible: ${schedule.target}`, {
-      code: "SCHEDULE_TARGET_NOT_ELIGIBLE",
-      details: { target: schedule.target },
-      httpStatus: 400,
-    })
+    throw new ScheduleError("SCHEDULE_TARGET_NOT_ELIGIBLE")
   }
 
   return await executeSchedule({

--- a/packages/schedule/src/runtime/store.ts
+++ b/packages/schedule/src/runtime/store.ts
@@ -141,11 +141,7 @@ export function createMemoryRuntimeScheduleStore(): RuntimeScheduleStore {
     create(record) {
       assertRuntimeScheduleId(record.id)
       if (records.has(record.id)) {
-        throw new ScheduleError(`Runtime Schedule already exists: ${record.id}`, {
-          code: "SCHEDULE_ALREADY_EXISTS",
-          details: { id: record.id },
-          httpStatus: 409,
-        })
+        throw new ScheduleError("SCHEDULE_ALREADY_EXISTS")
       }
       records.set(record.id, cloneRuntimeSchedule(record))
       return cloneRuntimeSchedule(record)
@@ -191,11 +187,7 @@ export function createKVRuntimeScheduleStore(options: KVScheduleStoreOptions = {
       const key = runtimeScheduleKey(prefix, record.id)
       return await withKVKeyLock(key, async () => {
         if (await store.has(key)) {
-          throw new ScheduleError(`Runtime Schedule already exists: ${record.id}`, {
-            code: "SCHEDULE_ALREADY_EXISTS",
-            details: { id: record.id },
-            httpStatus: 409,
-          })
+          throw new ScheduleError("SCHEDULE_ALREADY_EXISTS")
         }
         await store.set(key, serializeRuntimeSchedule(record))
         return cloneRuntimeSchedule(record)

--- a/packages/schedule/test/errors.test.ts
+++ b/packages/schedule/test/errors.test.ts
@@ -77,6 +77,7 @@ describe("ScheduleError", () => {
     expect(Reflect.set(error, "retryable", true)).toBe(false)
     expect(Reflect.set(error.details!, "field", secret)).toBe(false)
     expect(Reflect.set(error, "toJSON", () => ({ message: secret }))).toBe(false)
+    expect(Object.keys(error)).not.toContain("toJSON")
     expect(JSON.stringify(error)).not.toContain(secret)
   })
 
@@ -92,6 +93,7 @@ describe("ScheduleError", () => {
     expect(Reflect.set(error, "message", secret)).toBe(false)
     expect(Reflect.set(error.details!, "field", secret)).toBe(false)
     expect(Reflect.set(error, "toJSON", () => ({ message: secret }))).toBe(false)
+    expect(Object.keys(error)).not.toContain("toJSON")
     expect(JSON.stringify(error)).not.toContain(secret)
   })
 

--- a/packages/schedule/test/errors.test.ts
+++ b/packages/schedule/test/errors.test.ts
@@ -76,6 +76,7 @@ describe("ScheduleError", () => {
     expect(Reflect.set(error, "requestId", secret)).toBe(false)
     expect(Reflect.set(error, "retryable", true)).toBe(false)
     expect(Reflect.set(error.details!, "field", secret)).toBe(false)
+    expect(Reflect.set(error, "toJSON", () => ({ message: secret }))).toBe(false)
     expect(JSON.stringify(error)).not.toContain(secret)
   })
 
@@ -90,6 +91,7 @@ describe("ScheduleError", () => {
     expect(Reflect.set(error, "code", "PROVIDER_SECRET")).toBe(false)
     expect(Reflect.set(error, "message", secret)).toBe(false)
     expect(Reflect.set(error.details!, "field", secret)).toBe(false)
+    expect(Reflect.set(error, "toJSON", () => ({ message: secret }))).toBe(false)
     expect(JSON.stringify(error)).not.toContain(secret)
   })
 

--- a/packages/schedule/test/errors.test.ts
+++ b/packages/schedule/test/errors.test.ts
@@ -9,6 +9,7 @@ describe("ScheduleError", () => {
     const error = new ScheduleError("SCHEDULE_NOT_FOUND", {
       cause,
       requestId: "request-1",
+      retryable: false,
     })
 
     expect(error).toBeInstanceOf(Error)
@@ -21,6 +22,7 @@ describe("ScheduleError", () => {
       code: "SCHEDULE_NOT_FOUND",
       message: "Runtime Schedule was not found.",
       requestId: "request-1",
+      retryable: false,
     })
 
     const json = JSON.stringify(error)

--- a/packages/schedule/test/errors.test.ts
+++ b/packages/schedule/test/errors.test.ts
@@ -5,26 +5,22 @@ import { createMemoryRuntimeScheduleStore, ScheduleError, schedules, validateRun
 
 describe("ScheduleError", () => {
   it("preserves its public identity and serializes only stable ViteHub fields", () => {
-    const error = new ScheduleError("Runtime Schedule not found: daily", {
-      cause: new Error("private-provider-cause"),
-      code: "SCHEDULE_NOT_FOUND",
-      details: { id: "daily" },
-      httpStatus: 404,
+    const cause = new Error("private-provider-cause")
+    const error = new ScheduleError("SCHEDULE_NOT_FOUND", {
+      cause,
       requestId: "request-1",
-      retryable: false,
     })
 
     expect(error).toBeInstanceOf(Error)
     expect(error).toBeInstanceOf(ViteHubError)
     expect(error).toBeInstanceOf(ScheduleError)
     expect(error.name).toBe("ScheduleError")
+    expect(error.cause).toBe(cause)
     expect(error.httpStatus).toBe(404)
     expect(error.toJSON()).toEqual({
       code: "SCHEDULE_NOT_FOUND",
-      details: { id: "daily" },
-      message: "Runtime Schedule not found: daily",
+      message: "Runtime Schedule was not found.",
       requestId: "request-1",
-      retryable: false,
     })
 
     const json = JSON.stringify(error)
@@ -32,6 +28,40 @@ describe("ScheduleError", () => {
     expect(json).not.toContain("cause")
     expect(json).not.toContain("httpStatus")
     expect(json).not.toContain("stack")
+  })
+
+  it("rejects unknown codes without echoing them", () => {
+    const secret = "PROVIDER_TOKEN_private-secret"
+    let error: unknown
+    try {
+      new ScheduleError(secret as never)
+    }
+    catch (cause) {
+      error = cause
+    }
+
+    expect(error).toBeInstanceOf(TypeError)
+    expect(String(error)).not.toContain(secret)
+  })
+
+  it("normalizes hostile options to fixed JSON-safe output", () => {
+    const secret = "https://example.test/path?token=private-token"
+    const details = {
+      get field() {
+        throw new Error(secret)
+      },
+      value: 1n,
+    }
+    const error = new ScheduleError("SCHEDULE_NOT_FOUND", {
+      details,
+      requestId: secret,
+    } as never)
+
+    expect(error.toJSON()).toEqual({
+      code: "SCHEDULE_NOT_FOUND",
+      message: "Runtime Schedule was not found.",
+    })
+    expect(JSON.stringify(error)).not.toContain(secret)
   })
 
   it("redacts invalid cron values from messages, details, and JSON", () => {

--- a/packages/schedule/test/errors.test.ts
+++ b/packages/schedule/test/errors.test.ts
@@ -64,6 +64,35 @@ describe("ScheduleError", () => {
     expect(JSON.stringify(error)).not.toContain(secret)
   })
 
+  it("keeps its trusted public shape immutable after construction", () => {
+    const error = new ScheduleError("SCHEDULE_INVALID_CRON", {
+      details: { field: "cron", valueType: "string" },
+      requestId: "request-1",
+    })
+    const secret = "https://user:token@example.com/private"
+
+    expect(Reflect.set(error, "code", "PROVIDER_SECRET")).toBe(false)
+    expect(Reflect.set(error, "message", secret)).toBe(false)
+    expect(Reflect.set(error, "requestId", secret)).toBe(false)
+    expect(Reflect.set(error, "retryable", true)).toBe(false)
+    expect(Reflect.set(error.details!, "field", secret)).toBe(false)
+    expect(JSON.stringify(error)).not.toContain(secret)
+  })
+
+  it("keeps the built Schedule error shape immutable", async () => {
+    const { ScheduleError: BuiltScheduleError } = await import("../dist/index.js")
+    const error = new BuiltScheduleError("SCHEDULE_INVALID_CRON", {
+      details: { field: "cron", valueType: "string" },
+      requestId: "request-1",
+    } as never)
+    const secret = "https://user:token@example.com/private"
+
+    expect(Reflect.set(error, "code", "PROVIDER_SECRET")).toBe(false)
+    expect(Reflect.set(error, "message", secret)).toBe(false)
+    expect(Reflect.set(error.details!, "field", secret)).toBe(false)
+    expect(JSON.stringify(error)).not.toContain(secret)
+  })
+
   it("redacts invalid cron values from messages, details, and JSON", () => {
     const secret = "private-cron-value"
 

--- a/packages/schedule/test/runtime.test.ts
+++ b/packages/schedule/test/runtime.test.ts
@@ -231,13 +231,13 @@ describe("Runtime Schedule helper", () => {
 
     await expect(schedules.create({ cron: "0 9 * * *", target: "report", timezone: "UTC" } as never)).rejects.toMatchObject({
       code: "SCHEDULE_INVALID_INPUT",
-      message: "Runtime Schedule create contains an unsupported field.",
+      message: "Runtime Schedule input is invalid.",
     })
 
     await schedules.create({ cron: "0 9 * * *", id: "schedule-1", target: "report" })
     await expect(schedules.update("schedule-1", { timezone: "UTC" } as never)).rejects.toMatchObject({
       code: "SCHEDULE_INVALID_INPUT",
-      message: "Runtime Schedule update contains an unsupported field.",
+      message: "Runtime Schedule input is invalid.",
     })
   })
 


### PR DESCRIPTION
## Summary

- replaces caller-authored Schedule error codes and messages with a closed 14-code vocabulary and fixed code-derived messages/statuses
- exposes only code-owned validation details (`field` and `valueType`) plus a bounded request ID and boolean retryability, while retaining raw diagnostics in `cause`
- tolerates hostile cast-only constructor inputs, including throwing getters and BigInt, without serializing secrets or throwing during JSON conversion
- freezes details, binds a sealed own `toJSON` snapshot, and makes every trusted public serialization field non-writable so post-construction casts cannot mutate or shadow codes, messages, request IDs, retryability, details, or serialization into secret-bearing output
- closes the installed declaration surface and includes negative consumer coverage for arbitrary fields

## Public contract

This deliberately changes construction from `new ScheduleError(message, { code, ... })` to `new ScheduleError(code, { cause?, details?, requestId?, retryable? })`. The break removes arbitrary caller-authored public output; callers should choose the matching exported `ScheduleErrorCode`, keep provider diagnostics in `cause`, and use `invalidScheduleValueDetails()` for validation failures.

## Validation

- full Schedule suite: 14 files, 212 tests — passed with no type errors
- focused source and built mutation suite: 1 file, 9 tests — passed
- Schedule typecheck — passed
- Schedule build and publint — passed
- built hostile-input and post-construction mutation probes — passed
- oxlint on changed correction files — passed
- `git diff --check` — passed
- merged exact-head GitHub aggregate CI, consumer, docs, provider verification, package preview, Continuous Releases, and Workers checks — passed; the separate Vercel deployment was blocked only by its account build-rate quota

## Stack

This PR targets `refactor/effect-schedule-process-driver` at `8736569d67cdecce138c3c2ab7266a0bc6d47904`. Its current correction head is `f5c1cd93568d6fdc59c2d2a8cf4d4253092ccf00`. The serializer installation is conditional, so this branch composes with the base branch’s sealed serializer while remaining independently safe.

## EFFECT ADOPTION STATUS

No additional Effect usage is introduced. This correction keeps Effect implementation-only behind the Schedule boundary, preserves ordinary cause identity, prevents `FiberFailure` or Effect declarations from escaping, and verifies the public `ViteHubError` JSON contract from the built package.


