### PR TITLE
fix(agent): harden exported error constructors

### DIFF
--- a/packages/agent/src/capabilities/transcription.ts
+++ b/packages/agent/src/capabilities/transcription.ts
@@ -1,7 +1,7 @@
 import { ViteHubError } from "@vite-hub/runtime"
 
 import type { MaybePromise } from "../types.ts"
-import type { ViteHubErrorDetails, ViteHubErrorShape } from "@vite-hub/runtime"
+import type { ViteHubErrorShape } from "@vite-hub/runtime"
 
 const transcriptionErrorMessages = {
   TRANSCRIPTION_AUTHENTICATION_FAILED: "[vitehub] Transcription authentication failed.",
@@ -102,7 +102,7 @@ export interface CreateTranscriptionOptions {
   driver: TranscriptionDriver
 }
 
-export interface TranscriptionErrorDetails extends ViteHubErrorDetails {
+export type TranscriptionErrorDetails = {
   provider?: string
   status?: number
 }
@@ -115,14 +115,15 @@ export interface TranscriptionErrorOptions extends ErrorOptions {
 }
 
 export class TranscriptionError extends ViteHubError<TranscriptionErrorCode, TranscriptionErrorDetails> {
-  constructor(code: TranscriptionErrorCode, options: TranscriptionErrorOptions = {}) {
-    if (!Object.hasOwn(transcriptionErrorMessages, code)) {
+  constructor(code: TranscriptionErrorCode, options?: TranscriptionErrorOptions) {
+    if (typeof code !== "string" || !Object.hasOwn(transcriptionErrorMessages, code)) {
       throw new TypeError("[vitehub] TranscriptionError requires a known transcription error code.")
     }
     const details = safeErrorDetails(options)
     const retryable = transcriptionErrorRetryability[code]
+    const cause = readErrorOption(options, "cause")
     super(code, transcriptionErrorMessages[code], {
-      ...(options.cause === undefined ? {} : { cause: options.cause }),
+      ...(cause === undefined ? {} : { cause }),
       ...(details ? { details } : {}),
       ...(retryable === undefined ? {} : { retryable }),
     })
@@ -276,13 +277,24 @@ export function isTranscriptionAbortError(value: unknown): boolean {
   }
 }
 
-function safeErrorDetails(options: TranscriptionErrorOptions): TranscriptionErrorDetails | undefined {
-  const provider = safeProvider(options.provider)
-  const status = typeof options.status === "number"
-    && Number.isInteger(options.status)
-    && options.status >= 100
-    && options.status <= 599
-    ? options.status
+function readErrorOption(options: unknown, key: "cause" | "provider" | "status"): unknown {
+  if ((typeof options !== "object" || options === null) && typeof options !== "function") return undefined
+  try {
+    return Reflect.get(options, key)
+  }
+  catch {
+    return undefined
+  }
+}
+
+function safeErrorDetails(options: unknown): TranscriptionErrorDetails | undefined {
+  const provider = safeProvider(readErrorOption(options, "provider"))
+  const rawStatus = readErrorOption(options, "status")
+  const status = typeof rawStatus === "number"
+    && Number.isInteger(rawStatus)
+    && rawStatus >= 100
+    && rawStatus <= 599
+    ? rawStatus
     : undefined
   return provider || status ? { ...(provider ? { provider } : {}), ...(status ? { status } : {}) } : undefined
 }

--- a/packages/agent/src/internal/agent-structured-output.ts
+++ b/packages/agent/src/internal/agent-structured-output.ts
@@ -14,12 +14,22 @@ export type AgentOutputValidationErrorCode = keyof typeof agentOutputErrorMessag
 export type AgentOutputValidationErrorOptions = ErrorOptions
 
 export class AgentOutputValidationError extends ViteHubError<AgentOutputValidationErrorCode> {
-  constructor(code: AgentOutputValidationErrorCode, options: AgentOutputValidationErrorOptions = {}) {
-    if (!Object.hasOwn(agentOutputErrorMessages, code)) {
+  constructor(code: AgentOutputValidationErrorCode, options?: AgentOutputValidationErrorOptions) {
+    if (typeof code !== "string" || !Object.hasOwn(agentOutputErrorMessages, code)) {
       throw new TypeError("[vitehub] AgentOutputValidationError requires a known agent output error code.")
     }
-    super(code, agentOutputErrorMessages[code], { cause: options.cause, retryable: false })
+    super(code, agentOutputErrorMessages[code], { cause: readErrorCause(options), retryable: false })
     this.name = "AgentOutputValidationError"
+  }
+}
+
+function readErrorCause(options: unknown): unknown {
+  if ((typeof options !== "object" || options === null) && typeof options !== "function") return undefined
+  try {
+    return Reflect.get(options, "cause")
+  }
+  catch {
+    return undefined
   }
 }
 

--- a/packages/agent/test/async-transcription.test-d.ts
+++ b/packages/agent/test/async-transcription.test-d.ts
@@ -14,12 +14,19 @@ import {
 declare const driver: TranscriptionDriver
 declare const payload: unknown
 declare const submitInput: TranscriptionSubmitInput
+declare const transcriptionError: TranscriptionError
 
 it("exports the asynchronous transcription contract", () => {
   expectTypeOf(createTranscription({ driver })).toEqualTypeOf<TranscriptionClient>()
   expectTypeOf(createTranscription({ driver }).submit(submitInput)).toEqualTypeOf<Promise<TranscriptionSubmission>>()
   expectTypeOf(createTranscription({ driver }).receive(payload)).toEqualTypeOf<Promise<TranscriptionCompletion>>()
   expectTypeOf(elevenLabsScribe({ apiKey: "secret", webhookId: "webhook-1" })).toEqualTypeOf<TranscriptionDriver>()
+})
+
+it("keeps transcription error details closed", () => {
+  transcriptionError.details?.provider satisfies string | undefined
+  // @ts-expect-error Transcription details do not expose arbitrary keys.
+  transcriptionError.details?.token
 })
 
 it("keeps provider completion handling exhaustive", async () => {

--- a/packages/agent/test/async-transcription.test.ts
+++ b/packages/agent/test/async-transcription.test.ts
@@ -123,6 +123,22 @@ describe("createTranscription", () => {
     })
   })
 
+  it("handles hostile error constructor options", () => {
+    const secret = "https://user:token@example.com/private"
+    const options = new Proxy({}, {
+      get() {
+        throw new Error(secret)
+      },
+    })
+    const error = new TranscriptionError("TRANSCRIPTION_PROVIDER_FAILED", options as never)
+
+    expect(error.toJSON()).toEqual({
+      code: "TRANSCRIPTION_PROVIDER_FAILED",
+      message: "[vitehub] Transcription provider failed.",
+    })
+    expect(JSON.stringify(error)).not.toContain(secret)
+  })
+
   it.each([
     ["TRANSCRIPTION_AUTHENTICATION_FAILED", false],
     ["TRANSCRIPTION_INVALID_PAYLOAD", false],

--- a/packages/agent/test/public-api.test.ts
+++ b/packages/agent/test/public-api.test.ts
@@ -42,6 +42,22 @@ it("keeps Effect out of published Agent declarations", async () => {
   expect(output).toContain("class TranscriptionError extends ViteHubError")
 })
 
+it("keeps built Agent error constructors safe for hostile options", async () => {
+  const { AgentOutputValidationError } = await import("../dist/index.js")
+  const { TranscriptionError } = await import("../dist/capabilities.js")
+  const secret = "https://user:token@example.com/private"
+  const options = new Proxy({}, {
+    get() {
+      throw new Error(secret)
+    },
+  })
+
+  const transcription = new TranscriptionError("TRANSCRIPTION_PROVIDER_FAILED", options)
+  const output = new AgentOutputValidationError("AGENT_OUTPUT_INVALID_JSON", options)
+  expect(JSON.stringify(transcription)).not.toContain(secret)
+  expect(JSON.stringify(output)).not.toContain(secret)
+})
+
 it("pins Effect to the Agent implementation dependency without leaking runtime failures", async () => {
   const dist = new URL("../dist/", import.meta.url)
   const javascript = (await Promise.all(

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -84,6 +84,23 @@ describe("Agent structured output", () => {
     })
   })
 
+  it("handles hostile output-error constructor options", () => {
+    const secret = "https://user:token@example.com/private"
+    const options = new Proxy({}, {
+      get() {
+        throw new Error(secret)
+      },
+    })
+    const error = new AgentOutputValidationError("AGENT_OUTPUT_INVALID_JSON", options as never)
+
+    expect(error.toJSON()).toEqual({
+      code: "AGENT_OUTPUT_INVALID_JSON",
+      message: "[vitehub] Agent output is not valid JSON.",
+      retryable: false,
+    })
+    expect(JSON.stringify(error)).not.toContain(secret)
+  })
+
   it("preserves custom schema failures exactly", async () => {
     const cause = new Error("private validator failure")
     const agent = defineAgent({


### PR DESCRIPTION
## Summary

This closes the final exported Agent constructor gaps left after #706. `TranscriptionErrorDetails` is now a closed public type, and both `TranscriptionError` and `AgentOutputValidationError` read constructor options through hostile-safe accessors so a throwing Proxy/getter cannot escape raw diagnostics or break serialization.

## Public contract

This intentionally tightens the Transcription declaration: consumers can read only `provider` and `status`; arbitrary detail keys are no longer published. Supported constructor call shapes, fixed code-derived messages, code-owned retryability, and ordinary cause identity remain unchanged. Hostile cast inputs now omit unreadable optional metadata instead of throwing or serializing getter failures.

## Accounting and validation

At exact head `dd76d19d8e82692a25ee2cb536862c672aaa9bc2`, the diff from #706 is production +37/-15 and tests/declaration fixtures +56, for +93/-15 across 6 files. The full Agent suite, build, publint, typecheck, focused source and built-artifact probes (3 files, 52 tests), declaration negative test, changed-file lint, and diff validation pass. GitHub CI, consumer, docs, preview, provider verification, and Workers checks are green; the separate Vercel deployment is externally rate-limited.

## Dependency

This draft targets exact #706 head b0849ce9b533acdad527c5a8ad8139a6aa8c6d00. #706 is now closed, so this stack cannot land as written; reopen and land #706 or retarget #713 onto its intended surviving base, then revalidate this exact feature delta.

## EFFECT ADOPTION STATUS

- Seam: exported Agent transcription and structured-output error constructors.
- Public API: closed Transcription details declaration; supported constructors and Promise/Web shapes remain.
- Boundary: hostile-safe constructor option reads and inherited `ViteHubError` serialization.
- Typed failures: closed codes, fixed messages, derived retryability, exact ordinary causes, and omitted unreadable optional metadata.
- Resources/fibers: none; this error-only correction adds no Effect runtime.
- Deleted: open detail index signature and raw hostile getter escape paths.
- TODOs: no code TODOs; merge remains blocked on #706.
- Confidence: high after source, built artifact, declaration, full package, lint, and diff proof.

<!-- babysitter:blocker:v1 -->

> [!WARNING]
> **Babysitter is blocked:** prerequisite #706 is closed, so this draft has no mergeable dependency path yet.
>
> Reopen and land #706, or retarget this draft onto the intended surviving base and revalidate it before merge.

<!-- /babysitter:blocker:v1 -->

