### PR TITLE
fix(workflow): close public error boundaries

### DIFF
--- a/docs/content/docs/server-primitives/workflows.md
+++ b/docs/content/docs/server-primitives/workflows.md
@@ -58,7 +58,7 @@ export default defineEventHandler(async () => {
 | `runWorkflow`, `deferWorkflow`, `getWorkflowRun` from `@vite-hub/workflow` | Start, defer, or inspect Workflow Runs. |
 | `createWorkflow` from `@vite-hub/workflow` | Create an inline Workflow Handle for app-owned code. |
 | `normalizeWorkflowOptions` from `@vite-hub/workflow` | Resolve Integration Options to a concrete Workflow Provider. |
-| `WorkflowError` from `@vite-hub/workflow` | Throw or handle structured Workflow failures with stable codes. |
+| `ApplicationWorkflowError`, `WorkflowError` from `@vite-hub/workflow` | Throw or handle structured app-owned and ViteHub-owned Workflow failures with stable codes. |
 | `readRequestPayload`, `readValidatedPayload`, `validatePayload` from `@vite-hub/workflow` | Read provider request payloads in custom runtime entrypoints. |
 | `hubWorkflow` from `@vite-hub/workflow/vite` | Register Workflow discovery and provider output generation. |
 
@@ -162,17 +162,17 @@ The run id belongs to Invocation Options. Use a stable id when the provider shou
 
 ## Structured errors
 
-Throw `WorkflowError` when app code needs a stable failure contract across Workflow Providers.
+Throw `ApplicationWorkflowError` when app code needs a stable failure contract across Workflow Providers. `WorkflowError` is reserved for ViteHub-owned failures with fixed codes, messages, and detail shapes.
 
 ```ts [server/workflows/transcribe.ts]
-import { WorkflowError, defineWorkflow } from '@vite-hub/workflow'
+import { ApplicationWorkflowError, defineWorkflow } from '@vite-hub/workflow'
 
 export default defineWorkflow<{ recordingId: string }>(async ({ payload }) => {
   try {
     return await transcribeRecording(payload.recordingId)
   }
   catch (cause) {
-    throw new WorkflowError({
+    throw new ApplicationWorkflowError({
       cause,
       code: 'TRANSCRIPTION_FAILED',
       details: { recordingId: payload.recordingId },
@@ -182,7 +182,7 @@ export default defineWorkflow<{ recordingId: string }>(async ({ payload }) => {
 })
 ```
 
-Every `WorkflowError` requires a `code` and `message`. ViteHub's built-in codes are typed as `WorkflowErrorCode`, while app code can use its own stable strings. Calling `error.toJSON()` returns `code`, `message`, and JSON-safe `details`; it omits `cause`, which stays on the in-memory error for logging and debugging. Configure retries on the Workflow Step; throwing an error does not override the Step's retry policy.
+Every `ApplicationWorkflowError` requires a non-reserved SCREAMING_SNAKE_CASE `code` and a `message`. Calling `error.toJSON()` returns `code`, `message`, and JSON-safe `details`; it omits `cause`, which stays on the in-memory error for logging and debugging. ViteHub's built-in codes are typed as `WorkflowErrorCode` and use `WorkflowError` with code-derived messages and code-specific details. Configure retries on the Workflow Step; throwing an error does not override the Step's retry policy.
 
 ## Workflow Run shape
 

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -72,17 +72,17 @@ export default defineEventHandler(async (event) => {
 
 `getWorkflowRun()` normalizes provider run and step state, including timestamps, attempts, and failures. `cancelWorkflow()` cancels a durable run, and `resumeWorkflowSignal()` forwards an opaque signal token created inside the native workflow. Providers that cannot perform an operation fail explicitly instead of simulating it.
 
-Throw `WorkflowError` when callers need a stable, inspectable failure instead of parsing log output or provider-specific messages.
+Throw `ApplicationWorkflowError` when app callers need a stable, inspectable failure instead of parsing log output or provider-specific messages. `WorkflowError` is reserved for ViteHub-owned failures with fixed codes, messages, and detail shapes.
 
 ```ts
-import { WorkflowError } from "@vite-hub/workflow"
+import { ApplicationWorkflowError } from "@vite-hub/workflow"
 
 async function transcribe(recordingId: string) {
   try {
     return await transcribeRecording(recordingId)
   }
   catch (cause) {
-    throw new WorkflowError({
+    throw new ApplicationWorkflowError({
       cause,
       code: "TRANSCRIPTION_FAILED",
       details: { recordingId },
@@ -92,7 +92,7 @@ async function transcribe(recordingId: string) {
 }
 ```
 
-`code` is required and remains available through `error.toJSON()`. ViteHub's built-in codes are typed as `WorkflowErrorCode`, while app code can use its own stable strings. Keep `details` JSON-safe and free of secrets; `toJSON()` omits `cause`, which remains available only on the in-memory error. Workflow Step retry behavior belongs in the Step's retry options rather than the error.
+`code` and `message` are required and remain available through `error.toJSON()`. Application codes use non-reserved SCREAMING_SNAKE_CASE strings. Keep `details` JSON-safe and free of secrets; `toJSON()` omits `cause`, which remains available only on the in-memory error. ViteHub's built-in codes are typed as `WorkflowErrorCode` and use `WorkflowError` with code-derived messages and code-specific details. Workflow Step retry behavior belongs in the Step's retry options rather than the error.
 
 ```ts
 // vite.config.ts

--- a/packages/workflow/fixtures/published-types/consumer.ts
+++ b/packages/workflow/fixtures/published-types/consumer.ts
@@ -15,7 +15,12 @@ applicationError.code satisfies "TRANSCRIPTION_FAILED"
 applicationError.toJSON().details satisfies { attempt: number, provider: string } | undefined
 
 new WorkflowError({ code }) satisfies WorkflowError<"WORKFLOW_DEFINITION_NOT_FOUND">
-new WorkflowError({ code: dynamicCode }) satisfies WorkflowError<WorkflowErrorCode>
+new WorkflowError({
+  code: dynamicCode,
+  details: { operation: "start", provider: "vercel" },
+}) satisfies WorkflowError<WorkflowErrorCode>
+// @ts-expect-error Dynamic built-in codes must provide details for codes that require them.
+new WorkflowError({ code: dynamicCode })
 
 const providerOptions = {
   code: "WORKFLOW_PROVIDER_OPERATION_FAILED" as const,

--- a/packages/workflow/fixtures/published-types/consumer.ts
+++ b/packages/workflow/fixtures/published-types/consumer.ts
@@ -1,26 +1,45 @@
-import { WorkflowError } from "@vite-hub/workflow"
+import { ApplicationWorkflowError, WorkflowError } from "@vite-hub/workflow"
 
-import type { WorkflowErrorCode, WorkflowErrorOptions } from "@vite-hub/workflow"
+import type { ApplicationWorkflowErrorOptions, WorkflowErrorCode, WorkflowErrorOptions } from "@vite-hub/workflow"
 
 const code = "WORKFLOW_DEFINITION_NOT_FOUND" satisfies WorkflowErrorCode
 const options = {
   code: "TRANSCRIPTION_FAILED" as const,
   details: { attempt: 2, provider: "vercel" },
   message: "Transcription failed.",
-} satisfies WorkflowErrorOptions
-const error = new WorkflowError(options)
+} satisfies ApplicationWorkflowErrorOptions
+const applicationError = new ApplicationWorkflowError(options)
 
-error.code satisfies "TRANSCRIPTION_FAILED"
-error.toJSON().details satisfies { attempt: number, provider: string } | undefined
+applicationError.code satisfies "TRANSCRIPTION_FAILED"
+applicationError.toJSON().details satisfies { attempt: number, provider: string } | undefined
+
+new WorkflowError({ code }) satisfies WorkflowError<"WORKFLOW_DEFINITION_NOT_FOUND">
+
+const providerOptions = {
+  code: "WORKFLOW_PROVIDER_OPERATION_FAILED" as const,
+  details: { operation: "start", provider: "vercel" as const, status: 503 },
+} satisfies WorkflowErrorOptions<"WORKFLOW_PROVIDER_OPERATION_FAILED">
+const providerError = new WorkflowError(providerOptions)
+
+providerError.details?.operation satisfies string | undefined
+// @ts-expect-error Built-in Workflow error details do not expose arbitrary keys.
+void providerError.details?.token
 
 new WorkflowError({
-  code,
-  message: "Workflow definition not found.",
+  code: "WORKFLOW_PROVIDER_OPERATION_FAILED",
+  details: {
+    // @ts-expect-error Built-in Workflow operations use the closed ViteHub vocabulary.
+    operation: "publish-secret",
+    provider: "vercel",
+  },
 })
 
-new WorkflowError({
+// @ts-expect-error Application codes require the explicit ApplicationWorkflowError boundary.
+new WorkflowError({ code: "TRANSCRIPTION_FAILED", message: "Transcription failed." })
+
+new ApplicationWorkflowError({
   code: "INVALID_DETAILS",
-  // @ts-expect-error Workflow error details must be JSON-safe.
+  // @ts-expect-error Application Workflow error details must be JSON-safe.
   details: { failedAt: new Date() },
   message: "Invalid details.",
 })

--- a/packages/workflow/fixtures/published-types/consumer.ts
+++ b/packages/workflow/fixtures/published-types/consumer.ts
@@ -4,6 +4,7 @@ import type { ApplicationWorkflowErrorOptions, WorkflowErrorCode, WorkflowErrorO
 
 const code = "WORKFLOW_DEFINITION_NOT_FOUND" satisfies WorkflowErrorCode
 declare const dynamicCode: WorkflowErrorCode
+const disabledOptions: WorkflowErrorOptions = { code: "WORKFLOW_DISABLED" }
 const options = {
   code: "TRANSCRIPTION_FAILED" as const,
   details: { attempt: 2, provider: "vercel" },
@@ -15,6 +16,7 @@ applicationError.code satisfies "TRANSCRIPTION_FAILED"
 applicationError.toJSON().details satisfies { attempt: number, provider: string } | undefined
 
 new WorkflowError({ code }) satisfies WorkflowError<"WORKFLOW_DEFINITION_NOT_FOUND">
+new WorkflowError(disabledOptions)
 new WorkflowError({
   code: dynamicCode,
   details: { operation: "start", provider: "vercel" },

--- a/packages/workflow/fixtures/published-types/consumer.ts
+++ b/packages/workflow/fixtures/published-types/consumer.ts
@@ -3,6 +3,7 @@ import { ApplicationWorkflowError, WorkflowError } from "@vite-hub/workflow"
 import type { ApplicationWorkflowErrorOptions, WorkflowErrorCode, WorkflowErrorOptions } from "@vite-hub/workflow"
 
 const code = "WORKFLOW_DEFINITION_NOT_FOUND" satisfies WorkflowErrorCode
+declare const dynamicCode: WorkflowErrorCode
 const options = {
   code: "TRANSCRIPTION_FAILED" as const,
   details: { attempt: 2, provider: "vercel" },
@@ -14,6 +15,7 @@ applicationError.code satisfies "TRANSCRIPTION_FAILED"
 applicationError.toJSON().details satisfies { attempt: number, provider: string } | undefined
 
 new WorkflowError({ code }) satisfies WorkflowError<"WORKFLOW_DEFINITION_NOT_FOUND">
+new WorkflowError({ code: dynamicCode }) satisfies WorkflowError<WorkflowErrorCode>
 
 const providerOptions = {
   code: "WORKFLOW_PROVIDER_OPERATION_FAILED" as const,

--- a/packages/workflow/src/errors.ts
+++ b/packages/workflow/src/errors.ts
@@ -39,6 +39,7 @@ const maximumApplicationMessageLength = 512
 const maximumApplicationDetailDepth = 5
 const maximumApplicationDetailEntries = 64
 const applicationDetailAccessor = Symbol("application detail accessor")
+const trustedViteHubErrorToJSON = ViteHubError.prototype.toJSON
 
 export type WorkflowErrorCode = keyof typeof workflowErrorMessages
 export type WorkflowOperationName = typeof workflowOperationNames[number]
@@ -84,12 +85,15 @@ type WorkflowErrorOptionsFor<TCode extends WorkflowErrorCode> = ErrorOptions & {
     : { details: WorkflowErrorDetails<TCode> })
 
 export type WorkflowErrorOptions<TCode extends WorkflowErrorCode = WorkflowErrorCode> =
+  TCode extends WorkflowErrorCode ? WorkflowErrorOptionsFor<TCode> : never
+
+type WorkflowErrorConstructorOptions<TCode extends WorkflowErrorCode> =
   [WorkflowErrorCode] extends [TCode]
     ? ErrorOptions & { code: TCode, details: WorkflowErrorDetails<TCode> }
-    : TCode extends WorkflowErrorCode ? WorkflowErrorOptionsFor<TCode> : never
+    : WorkflowErrorOptions<TCode>
 
 export class WorkflowError<TCode extends WorkflowErrorCode = WorkflowErrorCode> extends ViteHubError<TCode, WorkflowErrorDetails<TCode>> {
-  constructor(options: WorkflowErrorOptions<TCode>) {
+  constructor(options: WorkflowErrorConstructorOptions<TCode>) {
     const code = readOption(options, "code")
     if (typeof code !== "string" || !Object.hasOwn(workflowErrorMessages, code)) {
       throw new TypeError("WorkflowError requires a known workflow error code.")
@@ -304,7 +308,7 @@ function sealPublicError(error: ViteHubError<string, ViteHubErrorDetails>): void
   deepFreeze(error.details)
   Object.defineProperty(error, "toJSON", {
     configurable: false,
-    value: () => ViteHubError.prototype.toJSON.call(error),
+    value: () => trustedViteHubErrorToJSON.call(error),
     writable: false,
   })
   for (const key of ["code", "details", "message", "name", "requestId", "retryable"] as const) {

--- a/packages/workflow/src/errors.ts
+++ b/packages/workflow/src/errors.ts
@@ -85,7 +85,7 @@ type WorkflowErrorOptionsFor<TCode extends WorkflowErrorCode> = ErrorOptions & {
 
 export type WorkflowErrorOptions<TCode extends WorkflowErrorCode = WorkflowErrorCode> =
   [WorkflowErrorCode] extends [TCode]
-    ? ErrorOptions & { code: TCode, details?: WorkflowErrorDetails<TCode> }
+    ? ErrorOptions & { code: TCode, details: WorkflowErrorDetails<TCode> }
     : TCode extends WorkflowErrorCode ? WorkflowErrorOptionsFor<TCode> : never
 
 export class WorkflowError<TCode extends WorkflowErrorCode = WorkflowErrorCode> extends ViteHubError<TCode, WorkflowErrorDetails<TCode>> {
@@ -234,10 +234,11 @@ function cloneApplicationDetailValue(value: unknown, depth: number, state: { ent
       throw new TypeError("ApplicationWorkflowError details must contain only plain objects and arrays.")
     }
 
-    const entries = safeApplicationKeys(value)
+    const keys = safeApplicationKeys(value)
+    countApplicationEntries(state, keys.length)
+    const entries = keys
       .map(key => [key, readApplicationValue(value, key)] as const)
       .filter(([, nested]) => nested !== undefined)
-    countApplicationEntries(state, entries.length)
     return Object.fromEntries(entries.map(([key, nested]) => [key, cloneApplicationDetailValue(nested, depth + 1, state)]))
   }
   finally {
@@ -312,7 +313,6 @@ function sealPublicError(error: ViteHubError<string, ViteHubErrorDetails>): void
       Object.defineProperty(error, key, { ...descriptor, configurable: false, writable: false })
     }
   }
-  Object.preventExtensions(error)
 }
 
 function deepFreeze(value: unknown): void {

--- a/packages/workflow/src/errors.ts
+++ b/packages/workflow/src/errors.ts
@@ -1,32 +1,309 @@
 import { ViteHubError } from "@vite-hub/runtime"
 
-import type { ViteHubErrorDetails, ViteHubErrorOptions } from "@vite-hub/runtime"
+import type { ViteHubErrorDetails } from "@vite-hub/runtime"
 
-export type WorkflowErrorCode =
-  | "VERCEL_WORKFLOW_SDK_LOAD_FAILED"
-  | "WORKFLOW_DEFINITION_NOT_FOUND"
-  | "WORKFLOW_DISABLED"
-  | "WORKFLOW_NATIVE_ENTRY_INVALID"
-  | "WORKFLOW_NATIVE_ENTRY_REQUIRED"
-  | "WORKFLOW_OPERATION_UNSUPPORTED"
-  | "WORKFLOW_PROVIDER_OPERATION_FAILED"
-  | "WORKFLOW_RUN_ID_UNSUPPORTED"
+const workflowErrorMessages = {
+  VERCEL_WORKFLOW_SDK_LOAD_FAILED: "Vercel Workflow DevKit load failed. Install the optional workflow peer dependency.",
+  WORKFLOW_DEFINITION_NOT_FOUND: "Workflow definition was not found.",
+  WORKFLOW_DISABLED: "Workflow is disabled.",
+  WORKFLOW_NATIVE_ENTRY_INVALID: "Workflow has no transformed native Vercel entry.",
+  WORKFLOW_NATIVE_ENTRY_REQUIRED: "Workflow has no native durable entry for Vercel.",
+  WORKFLOW_OPERATION_UNSUPPORTED: "Workflow provider operation is unsupported.",
+  WORKFLOW_PROVIDER_OPERATION_FAILED: "Workflow provider operation failed.",
+  WORKFLOW_RUN_ID_UNSUPPORTED: "Native Vercel workflows assign their own run IDs.",
+} as const
 
-export interface WorkflowErrorOptions<
+const workflowProviderNames = ["cloudflare", "openworkflow", "vercel"] as const
+const workflowOperationNames = [
+  "cancel",
+  "cancellation",
+  "connect",
+  "create",
+  "get",
+  "get-run",
+  "import",
+  "list-steps",
+  "resume-signal",
+  "run",
+  "signals",
+  "start",
+  "status",
+] as const
+
+const workflowProviders = new Set<string>(workflowProviderNames)
+const workflowOperations = new Set<string>(workflowOperationNames)
+
+const applicationCodePattern = /^[A-Z][A-Z0-9]*(?:_[A-Z0-9]+)*$/
+const safeWorkflowNamePattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
+const maximumApplicationMessageLength = 512
+const maximumApplicationDetailDepth = 5
+const maximumApplicationDetailEntries = 64
+
+export type WorkflowErrorCode = keyof typeof workflowErrorMessages
+export type WorkflowOperationName = typeof workflowOperationNames[number]
+export type WorkflowProviderName = typeof workflowProviderNames[number]
+
+type WorkflowNameDetails = {
+  name?: string
+}
+
+type VercelWorkflowDetails = {
+  name?: string
+  provider: "vercel"
+}
+
+type WorkflowOperationDetails = {
+  operation: WorkflowOperationName
+  provider: WorkflowProviderName
+}
+
+type WorkflowProviderOperationDetails = WorkflowOperationDetails & {
+  status?: number
+}
+
+type VercelSdkDetails = {
+  provider: "vercel"
+}
+
+export type WorkflowErrorDetails<TCode extends WorkflowErrorCode = WorkflowErrorCode> =
+  TCode extends "VERCEL_WORKFLOW_SDK_LOAD_FAILED" ? VercelSdkDetails
+    : TCode extends "WORKFLOW_DEFINITION_NOT_FOUND" ? WorkflowNameDetails
+      : TCode extends "WORKFLOW_DISABLED" ? never
+        : TCode extends "WORKFLOW_NATIVE_ENTRY_INVALID" | "WORKFLOW_NATIVE_ENTRY_REQUIRED" | "WORKFLOW_RUN_ID_UNSUPPORTED" ? VercelWorkflowDetails
+          : TCode extends "WORKFLOW_OPERATION_UNSUPPORTED" ? WorkflowOperationDetails
+            : TCode extends "WORKFLOW_PROVIDER_OPERATION_FAILED" ? WorkflowProviderOperationDetails
+              : never
+
+type WorkflowErrorOptionsFor<TCode extends WorkflowErrorCode> = ErrorOptions & {
+  code: TCode
+} & (TCode extends "WORKFLOW_DISABLED"
+  ? { details?: never }
+  : TCode extends "WORKFLOW_DEFINITION_NOT_FOUND"
+    ? { details?: WorkflowErrorDetails<TCode> }
+    : { details: WorkflowErrorDetails<TCode> })
+
+export type WorkflowErrorOptions<TCode extends WorkflowErrorCode = WorkflowErrorCode> =
+  TCode extends WorkflowErrorCode ? WorkflowErrorOptionsFor<TCode> : never
+
+export class WorkflowError<TCode extends WorkflowErrorCode = WorkflowErrorCode> extends ViteHubError<TCode, WorkflowErrorDetails<TCode>> {
+  constructor(options: WorkflowErrorOptions<TCode>) {
+    const code = readOption(options, "code")
+    if (typeof code !== "string" || !Object.hasOwn(workflowErrorMessages, code)) {
+      throw new TypeError("WorkflowError requires a known workflow error code.")
+    }
+
+    const details = safeWorkflowErrorDetails(code as WorkflowErrorCode, readOption(options, "details"))
+    const cause = readOption(options, "cause")
+    super(code as TCode, workflowErrorMessages[code as WorkflowErrorCode], {
+      ...(cause === undefined ? {} : { cause }),
+      ...(details === undefined ? {} : { details: details as WorkflowErrorDetails<TCode> }),
+    })
+    this.name = "WorkflowError"
+    sealPublicError(this)
+  }
+}
+
+export interface ApplicationWorkflowErrorOptions<
   TCode extends string = string,
   TDetails extends ViteHubErrorDetails = ViteHubErrorDetails,
-> extends Pick<ViteHubErrorOptions<TDetails>, "cause" | "details"> {
+> extends ErrorOptions {
   code: TCode
+  details?: TDetails
   message: string
 }
 
-export class WorkflowError<
+export class ApplicationWorkflowError<
   TCode extends string = string,
   TDetails extends ViteHubErrorDetails = ViteHubErrorDetails,
 > extends ViteHubError<TCode, TDetails> {
-  constructor(options: WorkflowErrorOptions<TCode, TDetails>) {
-    const { code, message, ...errorOptions } = options
-    super(code, message, errorOptions)
-    this.name = "WorkflowError"
+  constructor(options: ApplicationWorkflowErrorOptions<TCode, TDetails>) {
+    const code = readOption(options, "code")
+    if (typeof code !== "string" || code.length > 64 || !applicationCodePattern.test(code) || Object.hasOwn(workflowErrorMessages, code)) {
+      throw new TypeError("ApplicationWorkflowError requires a non-reserved SCREAMING_SNAKE_CASE code of at most 64 characters.")
+    }
+
+    const message = readOption(options, "message")
+    if (typeof message !== "string" || message.length === 0 || message.length > maximumApplicationMessageLength) {
+      throw new TypeError("ApplicationWorkflowError requires a message between 1 and 512 characters.")
+    }
+
+    const cause = readOption(options, "cause")
+    const rawDetails = readOption(options, "details")
+    const details = rawDetails === undefined ? undefined : cloneApplicationDetails(rawDetails)
+    super(code as TCode, message, {
+      ...(cause === undefined ? {} : { cause }),
+      ...(details === undefined ? {} : { details: details as TDetails }),
+    })
+    this.name = "ApplicationWorkflowError"
+    sealPublicError(this)
   }
+}
+
+function readOption(options: unknown, key: "cause" | "code" | "details" | "message"): unknown {
+  if ((typeof options !== "object" || options === null) && typeof options !== "function") return undefined
+  try {
+    return Reflect.get(options, key)
+  }
+  catch {
+    return undefined
+  }
+}
+
+function safeWorkflowErrorDetails(code: WorkflowErrorCode, details: unknown): ViteHubErrorDetails | undefined {
+  if (typeof details !== "object" || details === null) return undefined
+
+  const name = safeStringProperty(details, "name", value => safeWorkflowNamePattern.test(value))
+  const operation = safeStringProperty(details, "operation", value => workflowOperations.has(value))
+  const provider = safeStringProperty(details, "provider", value => workflowProviders.has(value)) as WorkflowProviderName | undefined
+  const status = safeNumberProperty(details, "status", value => Number.isInteger(value) && value >= 400 && value <= 599)
+
+  switch (code) {
+    case "VERCEL_WORKFLOW_SDK_LOAD_FAILED":
+      return provider === "vercel" ? { provider } : undefined
+    case "WORKFLOW_DEFINITION_NOT_FOUND":
+      return name ? { name } : undefined
+    case "WORKFLOW_DISABLED":
+      return undefined
+    case "WORKFLOW_NATIVE_ENTRY_INVALID":
+    case "WORKFLOW_NATIVE_ENTRY_REQUIRED":
+    case "WORKFLOW_RUN_ID_UNSUPPORTED":
+      return provider === "vercel" ? { ...(name ? { name } : {}), provider } : undefined
+    case "WORKFLOW_OPERATION_UNSUPPORTED":
+      return operation && provider ? { operation, provider } : undefined
+    case "WORKFLOW_PROVIDER_OPERATION_FAILED":
+      return operation && provider ? { operation, provider, ...(status === undefined ? {} : { status }) } : undefined
+  }
+}
+
+function safeStringProperty(value: object, key: string, accepts: (value: string) => boolean): string | undefined {
+  try {
+    const property = Reflect.get(value, key)
+    return typeof property === "string" && accepts(property) ? property : undefined
+  }
+  catch {
+    return undefined
+  }
+}
+
+function safeNumberProperty(value: object, key: string, accepts: (value: number) => boolean): number | undefined {
+  try {
+    const property = Reflect.get(value, key)
+    return typeof property === "number" && accepts(property) ? property : undefined
+  }
+  catch {
+    return undefined
+  }
+}
+
+function cloneApplicationDetails(value: unknown): ViteHubErrorDetails {
+  const state = { entries: 0, seen: new Set<object>() }
+  const result = cloneApplicationDetailValue(value, 0, state)
+  if (!isPlainObject(result)) {
+    throw new TypeError("ApplicationWorkflowError details must be a JSON-safe plain object.")
+  }
+  return result as ViteHubErrorDetails
+}
+
+function cloneApplicationDetailValue(value: unknown, depth: number, state: { entries: number, seen: Set<object> }): unknown {
+  if (value === null || typeof value === "boolean" || typeof value === "string") return value
+  if (typeof value === "number") {
+    if (Number.isFinite(value)) return value
+    throw new TypeError("ApplicationWorkflowError details must contain only finite numbers.")
+  }
+  if (typeof value !== "object") {
+    throw new TypeError("ApplicationWorkflowError details must be JSON-safe.")
+  }
+  if (depth >= maximumApplicationDetailDepth) {
+    throw new TypeError("ApplicationWorkflowError details exceed the maximum depth of 5.")
+  }
+  if (state.seen.has(value)) {
+    throw new TypeError("ApplicationWorkflowError details must not contain cycles.")
+  }
+
+  state.seen.add(value)
+  try {
+    if (Array.isArray(value)) {
+      const length = safeArrayLength(value)
+      countApplicationEntries(state, length)
+      return Array.from({ length }, (_, index) => cloneApplicationDetailValue(readApplicationValue(value, String(index)), depth + 1, state))
+    }
+    if (!isPlainObject(value)) {
+      throw new TypeError("ApplicationWorkflowError details must contain only plain objects and arrays.")
+    }
+
+    const keys = safeApplicationKeys(value)
+    countApplicationEntries(state, keys.length)
+    return Object.fromEntries(keys.map(key => [key, cloneApplicationDetailValue(readApplicationValue(value, key), depth + 1, state)]))
+  }
+  finally {
+    state.seen.delete(value)
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false
+  try {
+    const prototype = Object.getPrototypeOf(value)
+    return prototype === Object.prototype || prototype === null
+  }
+  catch {
+    return false
+  }
+}
+
+function safeArrayLength(value: readonly unknown[]): number {
+  try {
+    const length = Reflect.get(value, "length")
+    if (typeof length === "number" && Number.isSafeInteger(length) && length >= 0) return length
+  }
+  catch {
+    // Fall through to the fixed public error below.
+  }
+  throw new TypeError("ApplicationWorkflowError details contain an invalid array.")
+}
+
+function safeApplicationKeys(value: object): string[] {
+  try {
+    return Object.keys(value)
+  }
+  catch {
+    throw new TypeError("ApplicationWorkflowError details contain an unreadable object.")
+  }
+}
+
+function readApplicationValue(value: object, key: string): unknown {
+  try {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (!descriptor || !("value" in descriptor)) {
+      throw new TypeError("ApplicationWorkflowError details must not contain accessors.")
+    }
+    return descriptor.value
+  }
+  catch (error) {
+    if (error instanceof TypeError && error.message.startsWith("ApplicationWorkflowError")) throw error
+    throw new TypeError("ApplicationWorkflowError details contain an unreadable value.")
+  }
+}
+
+function countApplicationEntries(state: { entries: number }, count: number): void {
+  state.entries += count
+  if (state.entries > maximumApplicationDetailEntries) {
+    throw new TypeError("ApplicationWorkflowError details exceed the maximum of 64 entries.")
+  }
+}
+
+function sealPublicError(error: ViteHubError<string, ViteHubErrorDetails>): void {
+  deepFreeze(error.details)
+  for (const key of ["code", "details", "message", "name", "requestId", "retryable"] as const) {
+    const descriptor = Object.getOwnPropertyDescriptor(error, key)
+    if (descriptor && "writable" in descriptor) {
+      Object.defineProperty(error, key, { ...descriptor, configurable: false, writable: false })
+    }
+  }
+}
+
+function deepFreeze(value: unknown): void {
+  if (typeof value !== "object" || value === null || Object.isFrozen(value)) return
+  for (const nested of Object.values(value)) deepFreeze(nested)
+  Object.freeze(value)
 }

--- a/packages/workflow/src/errors.ts
+++ b/packages/workflow/src/errors.ts
@@ -231,9 +231,11 @@ function cloneApplicationDetailValue(value: unknown, depth: number, state: { ent
       throw new TypeError("ApplicationWorkflowError details must contain only plain objects and arrays.")
     }
 
-    const keys = safeApplicationKeys(value)
-    countApplicationEntries(state, keys.length)
-    return Object.fromEntries(keys.map(key => [key, cloneApplicationDetailValue(readApplicationValue(value, key), depth + 1, state)]))
+    const entries = safeApplicationKeys(value)
+      .map(key => [key, readApplicationValue(value, key)] as const)
+      .filter(([, nested]) => nested !== undefined)
+    countApplicationEntries(state, entries.length)
+    return Object.fromEntries(entries.map(([key, nested]) => [key, cloneApplicationDetailValue(nested, depth + 1, state)]))
   }
   finally {
     state.seen.delete(value)
@@ -300,6 +302,7 @@ function sealPublicError(error: ViteHubError<string, ViteHubErrorDetails>): void
       Object.defineProperty(error, key, { ...descriptor, configurable: false, writable: false })
     }
   }
+  Object.preventExtensions(error)
 }
 
 function deepFreeze(value: unknown): void {

--- a/packages/workflow/src/errors.ts
+++ b/packages/workflow/src/errors.ts
@@ -38,6 +38,7 @@ const safeWorkflowNamePattern = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/
 const maximumApplicationMessageLength = 512
 const maximumApplicationDetailDepth = 5
 const maximumApplicationDetailEntries = 64
+const applicationDetailAccessor = Symbol("application detail accessor")
 
 export type WorkflowErrorCode = keyof typeof workflowErrorMessages
 export type WorkflowOperationName = typeof workflowOperationNames[number]
@@ -83,7 +84,9 @@ type WorkflowErrorOptionsFor<TCode extends WorkflowErrorCode> = ErrorOptions & {
     : { details: WorkflowErrorDetails<TCode> })
 
 export type WorkflowErrorOptions<TCode extends WorkflowErrorCode = WorkflowErrorCode> =
-  TCode extends WorkflowErrorCode ? WorkflowErrorOptionsFor<TCode> : never
+  [WorkflowErrorCode] extends [TCode]
+    ? ErrorOptions & { code: TCode, details?: WorkflowErrorDetails<TCode> }
+    : TCode extends WorkflowErrorCode ? WorkflowErrorOptionsFor<TCode> : never
 
 export class WorkflowError<TCode extends WorkflowErrorCode = WorkflowErrorCode> extends ViteHubError<TCode, WorkflowErrorDetails<TCode>> {
   constructor(options: WorkflowErrorOptions<TCode>) {
@@ -277,12 +280,14 @@ function readApplicationValue(value: object, key: string): unknown {
   try {
     const descriptor = Object.getOwnPropertyDescriptor(value, key)
     if (!descriptor || !("value" in descriptor)) {
-      throw new TypeError("ApplicationWorkflowError details must not contain accessors.")
+      throw applicationDetailAccessor
     }
     return descriptor.value
   }
   catch (error) {
-    if (error instanceof TypeError && error.message.startsWith("ApplicationWorkflowError")) throw error
+    if (error === applicationDetailAccessor) {
+      throw new TypeError("ApplicationWorkflowError details must not contain accessors.")
+    }
     throw new TypeError("ApplicationWorkflowError details contain an unreadable value.")
   }
 }
@@ -296,6 +301,11 @@ function countApplicationEntries(state: { entries: number }, count: number): voi
 
 function sealPublicError(error: ViteHubError<string, ViteHubErrorDetails>): void {
   deepFreeze(error.details)
+  Object.defineProperty(error, "toJSON", {
+    configurable: false,
+    value: () => ViteHubError.prototype.toJSON.call(error),
+    writable: false,
+  })
   for (const key of ["code", "details", "message", "name", "requestId", "retryable"] as const) {
     const descriptor = Object.getOwnPropertyDescriptor(error, key)
     if (descriptor && "writable" in descriptor) {

--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -1,6 +1,15 @@
 export { normalizeWorkflowOptions } from "./config.ts"
 export { defineWorkflow } from "./definition.ts"
-export { WorkflowError, type WorkflowErrorCode, type WorkflowErrorOptions } from "./errors.ts"
+export {
+  ApplicationWorkflowError,
+  WorkflowError,
+  type ApplicationWorkflowErrorOptions,
+  type WorkflowErrorCode,
+  type WorkflowErrorDetails,
+  type WorkflowErrorOptions,
+  type WorkflowOperationName,
+  type WorkflowProviderName,
+} from "./errors.ts"
 export { getCloudflareWorkflowBindingName, getCloudflareWorkflowClassName, getCloudflareWorkflowName } from "./integrations/cloudflare.ts"
 export { getVercelWorkflowName } from "./integrations/vercel.ts"
 export { cancelWorkflow, createWorkflow, deferWorkflow, getWorkflowRun, resumeWorkflowSignal, runWorkflow } from "./runtime/client.ts"

--- a/packages/workflow/src/runtime/adapters.ts
+++ b/packages/workflow/src/runtime/adapters.ts
@@ -11,6 +11,7 @@ import { getWorkflowRunState, loadWorkflowDefinition, setWorkflowRun } from "./s
 import { cancelVercelWorkflow, inspectVercelWorkflowRun, resumeVercelWorkflowSignal, startVercelWorkflow } from "./vercel.ts"
 
 import type { CloudflareWorkflowBinding, ResolvedWorkflowOptions, WorkflowDefinition, WorkflowDeferOptions, WorkflowRun, WorkflowRunStatus, WorkflowSignalResult } from "../types.ts"
+import type { WorkflowOperationName } from "../errors.ts"
 
 interface RunWorkflowAdapterContext<TPayload = unknown, TResult = unknown> {
   definition: WorkflowDefinition<TPayload, TResult>
@@ -34,11 +35,10 @@ interface WorkflowRuntimeAdapter {
   run<TPayload = unknown, TResult = unknown>(context: RunWorkflowAdapterContext<TPayload, TResult>): Promise<WorkflowRun<TPayload, TResult>>
 }
 
-function unsupportedOperation(provider: string, operation: string): never {
+function unsupportedOperation(provider: "cloudflare" | "openworkflow" | "vercel", operation: WorkflowOperationName): never {
   throw new WorkflowError({
     code: "WORKFLOW_OPERATION_UNSUPPORTED",
     details: { operation, provider },
-    message: `Workflow provider ${JSON.stringify(provider)} does not support ${operation}.`,
   })
 }
 
@@ -195,7 +195,6 @@ function createVercelAdapter(config: ResolvedWorkflowOptions): WorkflowRuntimeAd
         throw new WorkflowError({
           code: "WORKFLOW_RUN_ID_UNSUPPORTED",
           details: { ...(safeWorkflowName(name) ? { name } : {}), provider: "vercel" },
-          message: "Native Vercel workflows assign their own run IDs.",
         })
       }
       return await startVercelWorkflow(name, definition, payload)

--- a/packages/workflow/src/runtime/client.ts
+++ b/packages/workflow/src/runtime/client.ts
@@ -24,7 +24,6 @@ async function loadRequiredWorkflowDefinition(name: string) {
     throw new WorkflowError({
       code: "WORKFLOW_DEFINITION_NOT_FOUND",
       details: safeWorkflowName(name) ? { name } : undefined,
-      message: "Workflow definition was not found.",
     })
   }
   return definition
@@ -170,7 +169,6 @@ export async function runWorkflow<TPayload = unknown, TResult = unknown>(
   if (config === false) {
     throw new WorkflowError({
       code: "WORKFLOW_DISABLED",
-      message: "Workflow is disabled.",
     })
   }
 
@@ -191,7 +189,6 @@ export async function getWorkflowRun<TPayload = unknown, TResult = unknown>(name
   if (config === false) {
     throw new WorkflowError({
       code: "WORKFLOW_DISABLED",
-      message: "Workflow is disabled.",
     })
   }
 
@@ -207,7 +204,6 @@ export async function cancelWorkflow<TPayload = unknown, TResult = unknown>(name
   if (config === false) {
     throw new WorkflowError({
       code: "WORKFLOW_DISABLED",
-      message: "Workflow is disabled.",
     })
   }
 
@@ -227,7 +223,6 @@ export async function resumeWorkflowSignal<TPayload = unknown>(token: string, pa
   if (config === false) {
     throw new WorkflowError({
       code: "WORKFLOW_DISABLED",
-      message: "Workflow is disabled.",
     })
   }
   return await getWorkflowRuntimeAdapter(config).resume(token, payload)

--- a/packages/workflow/src/runtime/provider-operation.ts
+++ b/packages/workflow/src/runtime/provider-operation.ts
@@ -1,4 +1,4 @@
-import { WorkflowError } from "../errors.ts"
+import { ApplicationWorkflowError, WorkflowError } from "../errors.ts"
 
 type WorkflowProvider = "cloudflare" | "openworkflow" | "vercel"
 
@@ -16,7 +16,7 @@ type WorkflowProviderOperation =
   | "status"
 
 export function isWorkflowBoundaryError(error: unknown): boolean {
-  if (error instanceof WorkflowError) return true
+  if (error instanceof WorkflowError || error instanceof ApplicationWorkflowError) return true
   if (typeof error !== "object" || error === null) return false
 
   try {
@@ -61,7 +61,6 @@ export async function runWorkflowProviderOperation<T>(
       cause: error,
       code: "WORKFLOW_PROVIDER_OPERATION_FAILED",
       details: { operation, provider, ...(status === undefined ? {} : { status }) },
-      message: "Workflow provider operation failed.",
     })
   }
 }

--- a/packages/workflow/src/runtime/vercel.ts
+++ b/packages/workflow/src/runtime/vercel.ts
@@ -105,7 +105,6 @@ async function getVercelWorkflowRuntime(): Promise<VercelWorkflowRuntime> {
       cause: error,
       code: "VERCEL_WORKFLOW_SDK_LOAD_FAILED",
       details: { provider: "vercel" },
-      message: "Vercel Workflow DevKit load failed. Install the optional workflow peer dependency.",
     })
   }
 }
@@ -197,7 +196,6 @@ function getNativeWorkflowName<TPayload, TResult>(name: string, definition: Work
     throw new WorkflowError({
       code: "WORKFLOW_NATIVE_ENTRY_INVALID",
       details: { ...(safeWorkflowName(name) ? { name } : {}), provider: "vercel" },
-      message: "Workflow has no transformed native Vercel entry.",
     })
   }
   return workflowName
@@ -251,7 +249,6 @@ export async function startVercelWorkflow<TPayload = unknown, TResult = unknown>
     throw new WorkflowError({
       code: "WORKFLOW_NATIVE_ENTRY_REQUIRED",
       details: { ...(safeWorkflowName(name) ? { name } : {}), provider: "vercel" },
-      message: "Workflow has no native durable entry for Vercel.",
     })
   }
   const context: WorkflowExecutionContext<TPayload> = {

--- a/packages/workflow/test/errors.test.ts
+++ b/packages/workflow/test/errors.test.ts
@@ -33,6 +33,7 @@ describe("WorkflowError", () => {
 
     expect(Reflect.set(error, "code", "SECRET_CODE")).toBe(false)
     expect(Reflect.set(error, "message", secret)).toBe(false)
+    expect(Reflect.set(error, "toJSON", () => ({ message: secret }))).toBe(false)
     expect(Reflect.set(error.details!, "operation", secret)).toBe(false)
     expect(JSON.stringify(error)).not.toContain(secret)
   })
@@ -70,6 +71,7 @@ describe("ApplicationWorkflowError", () => {
     const cause = new Error("private provider diagnostics")
     const details = {
       attempt: 2,
+      optional: undefined,
       provider: { name: "custom", regions: ["arn", "fra"] },
       reference: "https://user:token@example.com/private",
     }

--- a/packages/workflow/test/errors.test.ts
+++ b/packages/workflow/test/errors.test.ts
@@ -1,28 +1,166 @@
 import { ViteHubError } from "@vite-hub/runtime"
 import { describe, expect, it } from "vitest"
 
-import { WorkflowError } from "../src/index.ts"
+import { ApplicationWorkflowError, WorkflowError } from "../src/index.ts"
 
 describe("WorkflowError", () => {
-  it("serializes the public contract without exposing its cause", () => {
+  it("derives its public message and details from a known code", () => {
     const cause = new Error("provider token: secret")
     const error = new WorkflowError({
       cause,
-      code: "TRANSCRIPTION_FAILED",
-      details: { attempt: 2, provider: "vercel" },
-      message: "Transcription failed.",
+      code: "WORKFLOW_PROVIDER_OPERATION_FAILED",
+      details: { operation: "start", provider: "vercel", status: 503 },
     })
 
     expect(error).toBeInstanceOf(Error)
     expect(error).toBeInstanceOf(ViteHubError)
     expect(error.name).toBe("WorkflowError")
     expect(error.cause).toBe(cause)
-    expect(error.code).toBe("TRANSCRIPTION_FAILED")
     expect(JSON.parse(JSON.stringify(error))).toEqual({
-      code: "TRANSCRIPTION_FAILED",
-      details: { attempt: 2, provider: "vercel" },
-      message: "Transcription failed.",
+      code: "WORKFLOW_PROVIDER_OPERATION_FAILED",
+      details: { operation: "start", provider: "vercel", status: 503 },
+      message: "Workflow provider operation failed.",
     })
     expect(JSON.stringify(error)).not.toContain("secret")
+  })
+
+  it("keeps its trusted public shape immutable after construction", () => {
+    const error = new WorkflowError({
+      code: "WORKFLOW_PROVIDER_OPERATION_FAILED",
+      details: { operation: "start", provider: "vercel", status: 503 },
+    })
+    const secret = "https://user:token@example.com/private"
+
+    expect(Reflect.set(error, "code", "SECRET_CODE")).toBe(false)
+    expect(Reflect.set(error, "message", secret)).toBe(false)
+    expect(Reflect.set(error.details!, "operation", secret)).toBe(false)
+    expect(JSON.stringify(error)).not.toContain(secret)
+  })
+
+  it("does not publish cast-only details or messages for built-in codes", () => {
+    const secret = "https://user:token@example.com/private"
+    const error = new WorkflowError({
+      code: "WORKFLOW_DISABLED",
+      details: { token: secret, value: 1n },
+      message: secret,
+    } as never)
+
+    expect(error.toJSON()).toEqual({
+      code: "WORKFLOW_DISABLED",
+      message: "Workflow is disabled.",
+    })
+    expect(JSON.stringify(error)).not.toContain(secret)
+  })
+
+  it("fails hostile constructor options with a fixed public error", () => {
+    const secret = "https://user:token@example.com/private"
+    const options = new Proxy({}, {
+      get() {
+        throw new Error(secret)
+      },
+    })
+
+    expect(() => new WorkflowError(options as never)).toThrow("WorkflowError requires a known workflow error code.")
+    expect(() => new WorkflowError(options as never)).not.toThrow(secret)
+  })
+})
+
+describe("ApplicationWorkflowError", () => {
+  it("publishes explicit application messages and defensively cloned JSON details", () => {
+    const cause = new Error("private provider diagnostics")
+    const details = {
+      attempt: 2,
+      provider: { name: "custom", regions: ["arn", "fra"] },
+      reference: "https://user:token@example.com/private",
+    }
+    const error = new ApplicationWorkflowError({
+      cause,
+      code: "TRANSCRIPTION_FAILED",
+      details,
+      message: "Transcription failed for token=explicit-public-value.",
+    })
+    details.provider.name = "mutated"
+
+    expect(error.name).toBe("ApplicationWorkflowError")
+    expect(error.cause).toBe(cause)
+    expect(error.toJSON()).toEqual({
+      code: "TRANSCRIPTION_FAILED",
+      details: {
+        attempt: 2,
+        provider: { name: "custom", regions: ["arn", "fra"] },
+        reference: "https://user:token@example.com/private",
+      },
+      message: "Transcription failed for token=explicit-public-value.",
+    })
+    expect(JSON.stringify(error)).not.toContain("private provider diagnostics")
+  })
+
+  it("keeps cloned application details immutable after construction", () => {
+    const error = new ApplicationWorkflowError({
+      code: "CUSTOM_WORKFLOW_FAILURE",
+      details: { context: { operation: "start" } },
+      message: "Custom workflow failure.",
+    })
+    const secret = "https://user:token@example.com/private"
+
+    expect(Reflect.set(error, "message", secret)).toBe(false)
+    expect(Reflect.set(error.details!.context as object, "operation", secret)).toBe(false)
+    expect(JSON.stringify(error)).not.toContain(secret)
+  })
+
+  it.each([
+    ["BigInt", { value: 1n }],
+    ["cycles", (() => {
+      const value: Record<string, unknown> = {}
+      value.self = value
+      return value
+    })()],
+    ["class instances", { failedAt: new Date() }],
+    ["hostile getters", Object.defineProperty({}, "token", {
+      enumerable: true,
+      get() {
+        throw new Error("token=private")
+      },
+    })],
+    ["accessors", Object.defineProperty({}, "status", {
+      enumerable: true,
+      get() {
+        return 503
+      },
+    })],
+  ])("rejects %s in application details without publishing raw diagnostics", (_, details) => {
+    expect(() => new ApplicationWorkflowError({
+      code: "CUSTOM_WORKFLOW_FAILURE",
+      details: details as never,
+      message: "Custom workflow failure.",
+    })).toThrow(/^ApplicationWorkflowError details/)
+    expect(() => new ApplicationWorkflowError({
+      code: "CUSTOM_WORKFLOW_FAILURE",
+      details: details as never,
+      message: "Custom workflow failure.",
+    })).not.toThrow("token=private")
+  })
+
+  it("requires a bounded non-reserved application code and message", () => {
+    expect(() => new ApplicationWorkflowError({
+      code: "WORKFLOW_DISABLED",
+      message: "Custom message.",
+    })).toThrow("non-reserved SCREAMING_SNAKE_CASE code")
+    expect(() => new ApplicationWorkflowError({
+      code: "custom-code",
+      message: "Custom message.",
+    })).toThrow("non-reserved SCREAMING_SNAKE_CASE code")
+    expect(() => new ApplicationWorkflowError({
+      code: "CUSTOM__CODE",
+      message: "Custom message.",
+    })).toThrow("non-reserved SCREAMING_SNAKE_CASE code")
+    expect(() => new ApplicationWorkflowError({
+      code: "CUSTOM_CODE_",
+      message: "Custom message.",
+    })).toThrow("non-reserved SCREAMING_SNAKE_CASE code")
+    expect(() => new ApplicationWorkflowError({
+      code: "CUSTOM_CODE",
+      message: "x".repeat(513),
+    })).toThrow("message between 1 and 512 characters")
   })
 })

--- a/packages/workflow/test/errors.test.ts
+++ b/packages/workflow/test/errors.test.ts
@@ -64,6 +64,17 @@ describe("WorkflowError", () => {
     expect(() => new WorkflowError(options as never)).toThrow("WorkflowError requires a known workflow error code.")
     expect(() => new WorkflowError(options as never)).not.toThrow(secret)
   })
+
+  it("pins trusted serialization for subclasses", () => {
+    class CustomWorkflowError extends WorkflowError<"WORKFLOW_DISABLED"> {
+      override toJSON(): never {
+        throw new Error("private subclass diagnostics")
+      }
+    }
+
+    const error = new CustomWorkflowError({ code: "WORKFLOW_DISABLED" })
+    expect(error.toJSON()).toEqual({ code: "WORKFLOW_DISABLED", message: "Workflow is disabled." })
+  })
 })
 
 describe("ApplicationWorkflowError", () => {
@@ -128,6 +139,14 @@ describe("ApplicationWorkflowError", () => {
       enumerable: true,
       get() {
         return 503
+      },
+    })],
+    ["hostile descriptor traps", new Proxy({ token: true }, {
+      getOwnPropertyDescriptor() {
+        throw new TypeError("ApplicationWorkflowError token=private")
+      },
+      ownKeys() {
+        return ["token"]
       },
     })],
   ])("rejects %s in application details without publishing raw diagnostics", (_, details) => {

--- a/packages/workflow/test/errors.test.ts
+++ b/packages/workflow/test/errors.test.ts
@@ -78,6 +78,18 @@ describe("WorkflowError", () => {
     expect(error.metadata).toBe("consumer-owned")
     expect(error.toJSON()).toEqual({ code: "WORKFLOW_DISABLED", message: "Workflow is disabled." })
   })
+
+  it("captures trusted serialization before prototype instrumentation", () => {
+    const error = new WorkflowError({ code: "WORKFLOW_DISABLED" })
+    const original = ViteHubError.prototype.toJSON
+    try {
+      ViteHubError.prototype.toJSON = () => ({ message: "private patched diagnostics" }) as never
+      expect(error.toJSON()).toEqual({ code: "WORKFLOW_DISABLED", message: "Workflow is disabled." })
+    }
+    finally {
+      ViteHubError.prototype.toJSON = original
+    }
+  })
 })
 
 describe("ApplicationWorkflowError", () => {

--- a/packages/workflow/test/errors.test.ts
+++ b/packages/workflow/test/errors.test.ts
@@ -67,12 +67,15 @@ describe("WorkflowError", () => {
 
   it("pins trusted serialization for subclasses", () => {
     class CustomWorkflowError extends WorkflowError<"WORKFLOW_DISABLED"> {
+      readonly metadata = "consumer-owned"
+
       override toJSON(): never {
         throw new Error("private subclass diagnostics")
       }
     }
 
     const error = new CustomWorkflowError({ code: "WORKFLOW_DISABLED" })
+    expect(error.metadata).toBe("consumer-owned")
     expect(error.toJSON()).toEqual({ code: "WORKFLOW_DISABLED", message: "Workflow is disabled." })
   })
 })
@@ -183,5 +186,14 @@ describe("ApplicationWorkflowError", () => {
       code: "CUSTOM_CODE",
       message: "x".repeat(513),
     })).toThrow("message between 1 and 512 characters")
+  })
+
+  it("counts omitted undefined properties against the entry limit", () => {
+    const details = Object.fromEntries(Array.from({ length: 65 }, (_, index) => [`key${index}`, undefined]))
+    expect(() => new ApplicationWorkflowError({
+      code: "CUSTOM_WORKFLOW_FAILURE",
+      details,
+      message: "Custom workflow failure.",
+    })).toThrow("maximum of 64 entries")
   })
 })

--- a/packages/workflow/test/provider-operation.test.ts
+++ b/packages/workflow/test/provider-operation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { WorkflowError } from "../src/errors.ts"
+import { ApplicationWorkflowError, WorkflowError } from "../src/errors.ts"
 import { runWorkflowProviderOperation, safeWorkflowName } from "../src/runtime/provider-operation.ts"
 
 describe("Workflow provider operation errors", () => {
@@ -40,7 +40,7 @@ describe("Workflow provider operation errors", () => {
   })
 
   it("preserves Workflow and abort errors by exact identity", async () => {
-    const custom = new WorkflowError({ code: "CUSTOM_WORKFLOW_FAILURE", message: "Custom failure." })
+    const custom = new ApplicationWorkflowError({ code: "CUSTOM_WORKFLOW_FAILURE", message: "Custom failure." })
     const abort = new DOMException("cancelled", "AbortError")
 
     await expect(runWorkflowProviderOperation("vercel", "get-run", () => {

--- a/packages/workflow/test/published-types.test.ts
+++ b/packages/workflow/test/published-types.test.ts
@@ -46,3 +46,28 @@ it("keeps Effect internals out of published Workflow artifacts", async () => {
   expect(manifest.optionalDependencies?.effect).toBeUndefined()
   expect(manifest.peerDependencies?.effect).toBeUndefined()
 })
+
+it("keeps built Workflow error boundaries safe for hostile inputs and mutation", async () => {
+  const { ApplicationWorkflowError, WorkflowError } = await import("../dist/index.js")
+  const secret = "https://user:token@example.com/private"
+  const builtIn = new WorkflowError({
+    code: "WORKFLOW_DISABLED",
+    details: { token: secret, value: 1n },
+    message: secret,
+  } as never)
+  const application = new ApplicationWorkflowError({
+    code: "CUSTOM_WORKFLOW_FAILURE",
+    details: { context: { operation: "start" } },
+    message: "Custom workflow failure.",
+  })
+
+  expect(Reflect.set(builtIn, "message", secret)).toBe(false)
+  expect(Reflect.set(application.details!.context, "operation", secret)).toBe(false)
+  expect(JSON.stringify(builtIn)).not.toContain(secret)
+  expect(JSON.stringify(application)).not.toContain(secret)
+  expect(() => new ApplicationWorkflowError({
+    code: "CUSTOM_WORKFLOW_FAILURE",
+    details: { value: 1n } as never,
+    message: "Custom workflow failure.",
+  })).toThrow("ApplicationWorkflowError details")
+})

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { WorkflowProviderStep } from "../src/types.ts"
 import { getCloudflareWorkflowBindingName } from "../src/integrations/cloudflare.ts"
-import { WorkflowError } from "../src/errors.ts"
+import { ApplicationWorkflowError, WorkflowError } from "../src/errors.ts"
 import { resetOpenWorkflowRuntime, setOpenWorkflowImporter } from "../src/runtime/openworkflow.ts"
 import { createOpenWorkflowWorker } from "../src/runtime/openworkflow-worker.ts"
 import { runCloudflareWorkflow } from "../src/runtime/cloudflare-runner.ts"
@@ -1387,7 +1387,7 @@ describe("workflow runtime", () => {
   })
 
   it("preserves custom and abort errors from the Vercel runtime loader", async () => {
-    const custom = new WorkflowError({ code: "CUSTOM_RUNTIME_LOAD_FAILED", message: "Custom load failure." })
+    const custom = new ApplicationWorkflowError({ code: "CUSTOM_RUNTIME_LOAD_FAILED", message: "Custom load failure." })
     const abort = new DOMException("cancelled", "AbortError")
     setWorkflowRuntimeConfig({ provider: "vercel" })
     setWorkflowRuntimeRegistry({

--- a/playground/vite/build/vite-e2e.ts
+++ b/playground/vite/build/vite-e2e.ts
@@ -304,7 +304,7 @@ function renderSandboxRuntimeModule(file: string) {
 function renderWorkflowRuntimeModule(file: string) {
   return [
     `export { defineWorkflow } from ${JSON.stringify(createImportPath(file, resolve(workflowPackageDir, "src/definition.ts")))}`,
-    `export { WorkflowError } from ${JSON.stringify(createImportPath(file, resolve(workflowPackageDir, "src/errors.ts")))}`,
+    `export { ApplicationWorkflowError, WorkflowError } from ${JSON.stringify(createImportPath(file, resolve(workflowPackageDir, "src/errors.ts")))}`,
     `export { createWorkflow, deferWorkflow, getWorkflowRun, runWorkflow } from ${JSON.stringify(createImportPath(file, resolve(workflowPackageDir, "src/runtime/client.ts")))}`,
     `export { readRequestPayload, readValidatedPayload, validatePayload } from ${JSON.stringify(createImportPath(file, resolve(workflowPackageDir, "src/runtime/payload.ts")))}`,
     "",


### PR DESCRIPTION
## Summary

- closes `WorkflowError` to ViteHub-owned codes, fixed code-derived messages, and code-specific provider, operation, name, and status details
- moves application-owned codes to the explicit `ApplicationWorkflowError` boundary, which validates bounded codes and messages and defensively clones JSON-safe plain-object details with depth and entry limits
- rejects cycles, BigInt, class instances, accessors, hostile proxies, reserved codes, and malformed SCREAMING_SNAKE_CASE codes without echoing raw diagnostics
- freezes trusted details and public fields while preserving subclass field initialization
- installs the standalone trusted serializer only when Runtime has not already installed its final sealed serializer, so the branch composes with #670 without redefining a non-configurable property

## Public contract and migration

This deliberately breaks the generic constructor introduced by #694.

```ts
// Before: implicitly publishes every message and detail supplied by the caller.
new WorkflowError({ code: "TRANSCRIPTION_FAILED", message: "Transcription failed.", details })

// After: explicit application-owned publication boundary.
new ApplicationWorkflowError({ code: "TRANSCRIPTION_FAILED", message: "Transcription failed.", details })

// ViteHub-owned failures no longer accept a caller message.
new WorkflowError({ code: "WORKFLOW_DISABLED" })
```

`ApplicationWorkflowError` deliberately publishes its validated `message` and cloned `details`; raw provider diagnostics belong in `cause`, which remains available on the error instance but is excluded from JSON. Application codes are non-reserved SCREAMING_SNAKE_CASE values up to 64 characters, messages are 1–512 characters, and details allow at most five levels and 64 total entries.

## Validation

- Workflow typecheck — passed
- Workflow build and publint — passed
- current-base focused source, installed-consumer, built-artifact, provider-operation, runtime, hostile-input, mutation, and subclass-field suite: 4 files, 85 tests — passed
- exact no-conflict merge with final #670 `4332ff188b68748e435d446aae7ebc1d1aa094fc` — passed
- merged-foundation Runtime and Workflow build/publint, Workflow typecheck, and the same 4-file/85-test suite — passed
- source and built subclass-with-own-field regressions were not included in the merged head; tests-only follow-up #715 preserves them
- standalone trusted serializer remains pinned against later prototype instrumentation — passed
- oxlint on the compatibility correction — passed
- `git diff --check` — passed
- the prior full Workflow suite passed 114/119; five `vite-output` tests remain blocked locally by unrelated unbuilt workspace package entry points in the copied playground fixture
- merged head cd6cf755ad2b34617e8832f2898ec04566139c23 passed GitHub aggregate CI, consumer, docs, package preview, provider verification, Continuous Releases, Workers, and the Vercel deployment

## Exact accounting

- production: +330 / -34
- tests: +233 / -13
- installed consumer fixture: +38 / -10
- documentation: +9 / -9
- playground fixture: +1 / -1
- total: +611 / -67 across 14 files

## Stack

This pull request merged at exact head cd6cf755ad2b34617e8832f2898ec04566139c23 before the later correction head 6e0802775bd57e280d31b90e449cfde230c6cc3a reached the pull request. That later production correction is superseded by the current #694 design; its two missing subclass regressions are preserved in tests-only follow-up #715.

## EFFECT ADOPTION STATUS

No Effect dependency or public Effect type is added. This correction follows the migration rules: errors remain `ViteHubError` subclasses, published declarations expose closed vocabularies, causes retain diagnostics privately, subclass construction remains extensible, built artifacts contain no Effect imports or `FiberFailure`, and JSON behavior is verified from both the standalone built package and a merged final-foundation build.

<!-- babysitter:blocker:v1 -->

> [!WARNING]
> **Babysitter status:** this pull request is already merged at cd6cf755ad2b34617e8832f2898ec04566139c23.
>
> The unmerged 6e080277 correction is not part of this pull request; #694 owns the surviving production design and #715 owns the missing regressions.

<!-- /babysitter:blocker:v1 -->

