### PR TITLE
test(workflow): cover derived error serialization

### DIFF
--- a/packages/workflow/test/errors.test.ts
+++ b/packages/workflow/test/errors.test.ts
@@ -65,6 +65,21 @@ describe("WorkflowError", () => {
     expect(() => new WorkflowError(options as never)).not.toThrow(secret)
   })
 
+  it("keeps subclass fields compatible with trusted serialization", () => {
+    class CustomWorkflowError extends WorkflowError<"WORKFLOW_DISABLED"> {
+      readonly metadata = "consumer-owned"
+    }
+
+    const error = new CustomWorkflowError({ code: "WORKFLOW_DISABLED" })
+    expect(error.metadata).toBe("consumer-owned")
+    expect(error.toJSON()).toEqual({ code: "WORKFLOW_DISABLED", message: "Workflow is disabled." })
+    expect(Object.getOwnPropertyDescriptor(error, "toJSON")).toMatchObject({
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    })
+  })
+
   it("captures trusted serialization before prototype instrumentation", () => {
     const error = new WorkflowError({ code: "WORKFLOW_DISABLED" })
     const original = ViteHubError.prototype.toJSON

--- a/packages/workflow/test/published-types.test.ts
+++ b/packages/workflow/test/published-types.test.ts
@@ -60,9 +60,20 @@ it("keeps built Workflow error boundaries safe for hostile inputs and mutation",
     details: { context: { operation: "start" } },
     message: "Custom workflow failure.",
   })
+  class DerivedWorkflowError extends WorkflowError<"WORKFLOW_DISABLED"> {
+    readonly metadata = "consumer-owned"
+  }
+  const derived = new DerivedWorkflowError({ code: "WORKFLOW_DISABLED" })
 
   expect(Reflect.set(builtIn, "message", secret)).toBe(false)
   expect(Reflect.set(application.details!.context, "operation", secret)).toBe(false)
+  expect(derived.metadata).toBe("consumer-owned")
+  expect(derived.toJSON()).toEqual({ code: "WORKFLOW_DISABLED", message: "Workflow is disabled." })
+  expect(Object.getOwnPropertyDescriptor(derived, "toJSON")).toMatchObject({
+    configurable: false,
+    enumerable: false,
+    writable: false,
+  })
   expect(JSON.stringify(builtIn)).not.toContain(secret)
   expect(JSON.stringify(application)).not.toContain(secret)
   expect(() => new ApplicationWorkflowError({


### PR DESCRIPTION
#714 merged before its final compatibility regressions reached the pull request. The current #694 branch correctly removes Workflow's redundant serializer and relies on the Runtime foundation's sealed construction-time snapshot, so this follow-up carries only the two missing regressions and adds no production serializer code.

The source test proves a consumer subclass can initialize its own field after `WorkflowError` construction while inheriting the trusted, non-writable serializer. The built-artifact test proves the same behavior from the published JavaScript boundary, including the exact safe JSON shape.

## Hard dependency

This draft targets `feat/workflow-error-contract` at exact base `6a980f6f0bbb9be3c979c01dfc2e3e19a0f9ba16` and must merge after #694. If that base advances, revalidate these tests against its final Runtime foundation before merging.

At exact head `bbf8881b`, Workflow build, typecheck, focused source and built-artifact tests, changed-file Oxlint, and `git diff --check` pass.

## EFFECT ADOPTION STATUS

- Seam: Workflow public error serialization compatibility.
- Public API: unchanged; this is tests only.
- Boundary: source and built `WorkflowError` subclass behavior.
- Typed failures: unchanged closed Workflow and application error contracts.
- Resources/fibers: none.
- Deleted: no production code is added; the Runtime-owned serializer remains the single implementation.
- Retained: derived consumer fields and sealed safe JSON serialization.
- TODOs: merge after #694 and revalidate if its base advances.
- Confidence: high at the exact head.

<!-- babysitter:blocker:v1 -->

> [!WARNING]
> **Babysitter is blocked:** prerequisite pull request #694 is still open.
>
> Merge #694 into its target branch, then revalidate and merge this tests-only follow-up.

<!-- /babysitter:blocker:v1 -->
