### PR TITLE
refactor: share Effect boundary interpreter

### DIFF
--- a/packages/agent/src/internal/effect-runtime.ts
+++ b/packages/agent/src/internal/effect-runtime.ts
@@ -1,47 +1,11 @@
-import { Cause, Data, Effect, Exit } from "effect"
+import { createEffectBoundary, EffectBoundaryFailure } from "@vite-hub/internal/effect"
 
-export class AgentEffectFailure extends Data.TaggedError("AgentEffectFailure")<{
-  readonly cause: unknown
-  readonly operation: string
-}> {}
+const boundary = createEffectBoundary({
+  aggregateMessage: "[vitehub] Agent operation failed for multiple reasons.",
+  interruptionMessage: "[vitehub] Agent operation was interrupted.",
+})
 
-function interruptionError(signal?: AbortSignal): unknown {
-  if (signal?.aborted && signal.reason !== undefined) return signal.reason
-  const error = new Error("[vitehub] Agent operation was interrupted.")
-  error.name = "AbortError"
-  return error
-}
-
-export function agentEffectCauseValues(
-  cause: Cause.Cause<unknown>,
-  signal?: AbortSignal,
-): unknown[] {
-  return cause.reasons.map(reason => {
-    if (Cause.isFailReason(reason)) {
-      return reason.error instanceof AgentEffectFailure ? reason.error.cause : reason.error
-    }
-    if (Cause.isDieReason(reason)) return reason.defect
-    return interruptionError(signal)
-  })
-}
-
-export function tryAgentPromise<A>(
-  operation: string,
-  evaluate: (signal: AbortSignal) => PromiseLike<A> | A,
-): Effect.Effect<A, AgentEffectFailure> {
-  return Effect.tryPromise({
-    catch: cause => new AgentEffectFailure({ cause, operation }),
-    try: signal => Promise.resolve(evaluate(signal)),
-  })
-}
-
-export async function runAgentEffect<A, E>(
-  effect: Effect.Effect<A, E>,
-  options: { signal?: AbortSignal } = {},
-): Promise<A> {
-  const exit = await Effect.runPromiseExit(effect, options.signal ? { signal: options.signal } : undefined)
-  if (Exit.isSuccess(exit)) return exit.value
-  const causes = agentEffectCauseValues(exit.cause, options.signal)
-  if (causes.length === 1) throw causes[0]
-  throw new AggregateError(causes, "[vitehub] Agent operation failed for multiple reasons.")
-}
+export { EffectBoundaryFailure as AgentEffectFailure }
+export const agentEffectCauseValues = boundary.causeValues
+export const runAgentEffect = boundary.run
+export const tryAgentPromise = boundary.tryPromise

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -10,6 +10,7 @@
   "exports": {
     "./cli": "./dist/cli.js",
     "./env": "./dist/env.js",
+    "./effect": "./dist/effect.js",
     "./arrays": "./dist/arrays.js",
     "./definition-catalog": "./dist/definition-catalog.js",
     "./definition-discovery": "./dist/definition-discovery.js",
@@ -50,6 +51,7 @@
   "dependencies": {
     "@vercel/nft": "catalog:vercel",
     "@vite-hub/runtime": "workspace:*",
+    "effect": "catalog:effect",
     "esbuild": "catalog:esbuild-v27",
     "h3": "catalog:unjs",
     "pathe": "catalog:unjs"

--- a/packages/internal/src/effect.ts
+++ b/packages/internal/src/effect.ts
@@ -1,0 +1,56 @@
+import { Cause, Data, Effect, Exit } from "effect"
+
+export class EffectBoundaryFailure extends Data.TaggedError("EffectBoundaryFailure")<{
+  readonly cause: unknown
+  readonly operation: string
+}> {}
+
+interface EffectBoundaryOptions {
+  readonly aggregateMessage: string
+  readonly interruptionMessage: string
+}
+
+export function createEffectBoundary(options: EffectBoundaryOptions) {
+  function interruptionError(signal?: AbortSignal): unknown {
+    if (signal?.aborted && signal.reason !== undefined) return signal.reason
+    const error = new Error(options.interruptionMessage)
+    error.name = "AbortError"
+    return error
+  }
+
+  function causeValues(cause: Cause.Cause<unknown>, signal?: AbortSignal): unknown[] {
+    return cause.reasons.map((reason) => {
+      if (Cause.isFailReason(reason)) {
+        return reason.error instanceof EffectBoundaryFailure ? reason.error.cause : reason.error
+      }
+      if (Cause.isDieReason(reason)) return reason.defect
+      return interruptionError(signal)
+    })
+  }
+
+  function tryPromise<A>(
+    operation: string,
+    evaluate: (signal: AbortSignal) => PromiseLike<A> | A,
+  ): Effect.Effect<A, EffectBoundaryFailure> {
+    return Effect.tryPromise({
+      catch: cause => new EffectBoundaryFailure({ cause, operation }),
+      try: signal => Promise.resolve(evaluate(signal)),
+    })
+  }
+
+  async function run<A, E>(
+    effect: Effect.Effect<A, E>,
+    runOptions: { signal?: AbortSignal } = {},
+  ): Promise<A> {
+    const exit = await Effect.runPromiseExit(
+      effect,
+      runOptions.signal ? { signal: runOptions.signal } : undefined,
+    )
+    if (Exit.isSuccess(exit)) return exit.value
+    const causes = causeValues(exit.cause, runOptions.signal)
+    if (causes.length === 1) throw causes[0]
+    throw new AggregateError(causes, options.aggregateMessage)
+  }
+
+  return { causeValues, run, tryPromise }
+}

--- a/packages/internal/test/effect.test.ts
+++ b/packages/internal/test/effect.test.ts
@@ -1,0 +1,27 @@
+import { Effect } from "effect"
+import { describe, expect, it } from "vitest"
+
+import { createEffectBoundary } from "../src/effect.ts"
+
+const boundary = createEffectBoundary({
+  aggregateMessage: "aggregate",
+  interruptionMessage: "interrupted",
+})
+
+describe("Effect boundary", () => {
+  it("preserves the caller's abort reason", async () => {
+    const controller = new AbortController()
+    const reason = new Error("stop")
+    const result = boundary.run(Effect.never, { signal: controller.signal }).catch(error => error)
+    controller.abort(reason)
+    await expect(result).resolves.toBe(reason)
+  })
+
+  it("returns failures and defects by identity without FiberFailure", async () => {
+    const failure = new Error("failure")
+    const defect = new Error("defect")
+    await expect(boundary.run(boundary.tryPromise("test", () => Promise.reject(failure))).catch(error => error))
+      .resolves.toBe(failure)
+    await expect(boundary.run(Effect.die(defect)).catch(error => error)).resolves.toBe(defect)
+  })
+})

--- a/packages/internal/vite.config.ts
+++ b/packages/internal/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
       "src/definition-catalog.ts",
       "src/definition-discovery.ts",
       "src/env.ts",
+      "src/effect.ts",
       "src/http-request.ts",
       "src/object.ts",
       "src/provision.ts",

--- a/packages/workspace/src/internal/effect-runtime.ts
+++ b/packages/workspace/src/internal/effect-runtime.ts
@@ -1,47 +1,11 @@
-import { Cause, Data, Effect, Exit } from "effect"
+import { createEffectBoundary, EffectBoundaryFailure } from "@vite-hub/internal/effect"
 
-export class WorkspaceEffectFailure extends Data.TaggedError("WorkspaceEffectFailure")<{
-  readonly cause: unknown
-  readonly operation: string
-}> {}
+const boundary = createEffectBoundary({
+  aggregateMessage: "[vitehub] Workspace operation failed for multiple reasons.",
+  interruptionMessage: "[vitehub] Workspace operation was interrupted.",
+})
 
-function interruptionError(signal?: AbortSignal): unknown {
-  if (signal?.aborted && signal.reason !== undefined) return signal.reason
-  const error = new Error("[vitehub] Workspace operation was interrupted.")
-  error.name = "AbortError"
-  return error
-}
-
-export function workspaceEffectCauseValues(
-  cause: Cause.Cause<unknown>,
-  signal?: AbortSignal,
-): unknown[] {
-  return cause.reasons.map(reason => {
-    if (Cause.isFailReason(reason)) {
-      return reason.error instanceof WorkspaceEffectFailure ? reason.error.cause : reason.error
-    }
-    if (Cause.isDieReason(reason)) return reason.defect
-    return interruptionError(signal)
-  })
-}
-
-export function tryWorkspacePromise<A>(
-  operation: string,
-  evaluate: (signal: AbortSignal) => PromiseLike<A> | A,
-): Effect.Effect<A, WorkspaceEffectFailure> {
-  return Effect.tryPromise({
-    catch: cause => new WorkspaceEffectFailure({ cause, operation }),
-    try: signal => Promise.resolve(evaluate(signal)),
-  })
-}
-
-export async function runWorkspaceEffect<A, E>(
-  effect: Effect.Effect<A, E>,
-  options: { signal?: AbortSignal } = {},
-): Promise<A> {
-  const exit = await Effect.runPromiseExit(effect, options.signal ? { signal: options.signal } : undefined)
-  if (Exit.isSuccess(exit)) return exit.value
-  const causes = workspaceEffectCauseValues(exit.cause, options.signal)
-  if (causes.length === 1) throw causes[0]
-  throw new AggregateError(causes, "[vitehub] Workspace operation failed for multiple reasons.")
-}
+export { EffectBoundaryFailure as WorkspaceEffectFailure }
+export const runWorkspaceEffect = boundary.run
+export const tryWorkspacePromise = boundary.tryPromise
+export const workspaceEffectCauseValues = boundary.causeValues

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -833,6 +833,9 @@ importers:
       '@vite-hub/runtime':
         specifier: workspace:*
         version: link:../runtime
+      effect:
+        specifier: catalog:effect
+        version: 4.0.0-beta.99
       esbuild:
         specifier: catalog:esbuild-v27
         version: 0.27.7

--- a/test/effect-ownership.test.ts
+++ b/test/effect-ownership.test.ts
@@ -21,13 +21,14 @@ import { describe, expect, it } from "vitest"
 
 const repoRoot = resolve(import.meta.dirname, "..")
 const effectVersion = "4.0.0-beta.99"
-const expectedEffectOwners = ["agent", "schedule", "workspace"]
+const expectedEffectOwners = ["agent", "internal", "schedule", "workspace"]
 const allowedEffectOwners = new Set(expectedEffectOwners)
 
 type PackageEffectOwnership = {
   declaresEffect: boolean
   importsEffect: boolean
   name: string
+  private: boolean
 }
 
 async function readFiles(dir: string, predicate: (path: string) => boolean): Promise<string[]> {
@@ -79,6 +80,7 @@ async function packageEffectOwnership(): Promise<PackageEffectOwnership[]> {
       declaresEffect,
       importsEffect: sources.some(sourceImportsEffect),
       name: entry.name,
+      private: manifest.private === true,
     })
   }
   return packages
@@ -118,9 +120,10 @@ describe("Effect ownership", () => {
 
     const packages = await packageEffectOwnership()
     expect(effectOwnershipViolations(packages)).toEqual([])
-    const owners = packages.filter(pkg => pkg.importsEffect).map(pkg => pkg.name).sort()
-    expect(owners).toEqual(expectedEffectOwners)
-    for (const owner of owners) {
+    const owners = packages.filter(pkg => pkg.importsEffect).sort((a, b) => a.name.localeCompare(b.name))
+    expect(owners.map(owner => owner.name)).toEqual(expectedEffectOwners)
+    for (const pkg of owners) {
+      const owner = pkg.name
       const packageDir = join(repoRoot, "packages", owner)
       const manifestPath = join(packageDir, "package.json")
       const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { dependencies?: Record<string, string> }
@@ -131,11 +134,13 @@ describe("Effect ownership", () => {
       expect(resolved.version, packageDir).toBe(effectVersion)
 
       const declarations = await readFiles(join(packageDir, "dist"), path => path.endsWith(".d.ts"))
-      expect(declarations.some(sourceImportsEffect), packageDir).toBe(false)
-      expect(
-        declarations.some(source => /\bFiberFailure\b/.test(source)),
-        packageDir,
-      ).toBe(false)
+      if (!pkg.private) {
+        expect(declarations.some(sourceImportsEffect), packageDir).toBe(false)
+        expect(
+          declarations.some(source => /\bFiberFailure\b/.test(source)),
+          packageDir,
+        ).toBe(false)
+      }
 
       const bundles = (await readFiles(join(packageDir, "dist"), path => /\.[cm]?js$/.test(path))).join("\n")
       expect(bundles, packageDir).not.toMatch(/effect@3\.|3\.17\.7/)
@@ -144,15 +149,15 @@ describe("Effect ownership", () => {
 
   it.each([
     {
-      fixture: [{ declaresEffect: true, importsEffect: true, name: "queue" }],
+      fixture: [{ declaresEffect: true, importsEffect: true, name: "queue", private: false }],
       violation: "queue: unauthorized Effect importer",
     },
     {
-      fixture: [{ declaresEffect: true, importsEffect: false, name: "schedule" }],
+      fixture: [{ declaresEffect: true, importsEffect: false, name: "schedule", private: false }],
       violation: "schedule: Effect importer and dependency ownership differ",
     },
     {
-      fixture: [{ declaresEffect: false, importsEffect: true, name: "workspace" }],
+      fixture: [{ declaresEffect: false, importsEffect: true, name: "workspace", private: false }],
       violation: "workspace: Effect importer and dependency ownership differ",
     },
   ])("rejects invalid Effect ownership: $violation", ({ fixture, violation }) => {


### PR DESCRIPTION
Moves the duplicated Agent and Workspace Effect boundary interpreters into one private `@vite-hub/internal/effect` seam.

The shared boundary preserves caller abort reasons, original failure and defect identity, aggregate failures, and package-specific interruption messages. Agent and Workspace keep their existing Promise-facing helpers and public declarations remain free of Effect types.

This reduces duplicated production code while keeping Effect ownership explicit and covered by focused boundary and repository ownership tests.