### PR TITLE
fix(vite-hub): resolve provider facade aliases

### DIFF
--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -140,8 +140,11 @@ function frameworkDependencyResolver(
       )
     },
     resolveId(id, importer) {
-      const providerImportAlias = providerImportAliases[id]
-        ?? Object.entries(providerImportAliases).find(([specifier]) => frameworkProviderImportAliases[specifier] === id)?.[1]
+      const providerFacadeAliases = Object.entries(providerImportAliases)
+        .filter(([specifier]) => frameworkProviderImportAliases[specifier])
+      const providerFacadeTargets = new Set(providerFacadeAliases.map(([, target]) => target))
+      const providerImportAlias = providerFacadeAliases.find(([specifier]) => frameworkProviderImportAliases[specifier] === id)?.[1]
+        ?? (providerFacadeTargets.has(providerImportAliases[id]) ? providerImportAliases[id] : undefined)
       if (providerImportAlias) return providerImportAlias
       if (!isGeneratedImporter(importer)) return
       const isFrameworkPackageImport = id === frameworkPackageName || id.startsWith(`${frameworkPackageName}/`)

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -140,12 +140,12 @@ function frameworkDependencyResolver(
       )
     },
     resolveId(id, importer) {
-      const providerFacadeAliases = Object.entries(providerImportAliases)
-        .filter(([specifier]) => frameworkProviderImportAliases[specifier])
-      const providerFacadeTargets = new Set(providerFacadeAliases.map(([, target]) => target))
-      const providerImportAlias = providerFacadeAliases.find(([specifier]) => frameworkProviderImportAliases[specifier] === id)?.[1]
-        ?? (providerFacadeTargets.has(providerImportAliases[id]) ? providerImportAliases[id] : undefined)
-      if (providerImportAlias) return providerImportAlias
+      for (const specifier in providerImportAliases) {
+        const frameworkFacade = frameworkProviderImportAliases[specifier]
+        if (!frameworkFacade) continue
+        const providerFacade = providerImportAliases[specifier]
+        if (id === frameworkFacade || providerImportAliases[id] === providerFacade) return providerFacade
+      }
       if (!isGeneratedImporter(importer)) return
       const isFrameworkPackageImport = id === frameworkPackageName || id.startsWith(`${frameworkPackageName}/`)
       const isOwnerPackageImport = generatedOwnerPackageNames.some(name => id === name || id.startsWith(`${name}/`))

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -140,6 +140,9 @@ function frameworkDependencyResolver(
       )
     },
     resolveId(id, importer) {
+      const providerImportAlias = providerImportAliases[id]
+        ?? Object.entries(providerImportAliases).find(([specifier]) => frameworkProviderImportAliases[specifier] === id)?.[1]
+      if (providerImportAlias) return providerImportAlias
       if (!isGeneratedImporter(importer)) return
       const isFrameworkPackageImport = id === frameworkPackageName || id.startsWith(`${frameworkPackageName}/`)
       const isOwnerPackageImport = generatedOwnerPackageNames.some(name => id === name || id.startsWith(`${name}/`))

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -296,6 +296,7 @@ describe("vitehub", () => {
     const resolveId = plugin.resolveId
     if (typeof resolveId !== "function") throw new TypeError("Expected the framework dependency resolver.")
     expect(await resolveId.call({} as never, "vite-hub/sandbox", "/app/server.ts", {} as never)).toBe(providerSandboxFacade)
+    expect(await resolveId.call({} as never, "@vite-hub/sandbox", "/app/server.ts", {} as never)).toBe(providerSandboxFacade)
     expect(await resolveId.call({} as never, frameworkSandboxFacade, "/app/server.ts", {} as never)).toBe(providerSandboxFacade)
     expect(await resolveId.call({} as never, "@vite-hub/kv/runtime/upstash-driver", "/app/server.ts", {} as never)).toBeUndefined()
   })

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -297,6 +297,7 @@ describe("vitehub", () => {
     if (typeof resolveId !== "function") throw new TypeError("Expected the framework dependency resolver.")
     expect(await resolveId.call({} as never, "vite-hub/sandbox", "/app/server.ts", {} as never)).toBe(providerSandboxFacade)
     expect(await resolveId.call({} as never, frameworkSandboxFacade, "/app/server.ts", {} as never)).toBe(providerSandboxFacade)
+    expect(await resolveId.call({} as never, "@vite-hub/kv/runtime/upstash-driver", "/app/server.ts", {} as never)).toBeUndefined()
   })
 
   it.each(generatedOwnerPackageCases)("classifies generated import %s as %s", async (name, access) => {

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -283,6 +283,22 @@ describe("vitehub", () => {
     )).toMatch(/\/vite-hub\/dist\/_internal\/blob\/runtime\/state\.js$/)
   })
 
+  it("resolves provider facades after framework aliasing", async () => {
+    const plugin = dependencyPlugin({ sandbox: true })
+    const config = plugin.config as unknown as (config: object) => { resolve: { alias: Record<string, string> } }
+    const frameworkSandboxFacade = config({}).resolve.alias["vite-hub/sandbox"]
+    const sandboxCall = integrationMocks.hubSandbox.mock.calls.at(-1) as unknown as [{ providerImportAliases: Record<string, string> }]
+    const providerSandboxFacade = "/app/.vitehub/sandbox/provider.mjs"
+
+    sandboxCall[0].providerImportAliases["@vite-hub/sandbox"] = providerSandboxFacade
+    sandboxCall[0].providerImportAliases["vite-hub/sandbox"] = providerSandboxFacade
+
+    const resolveId = plugin.resolveId
+    if (typeof resolveId !== "function") throw new TypeError("Expected the framework dependency resolver.")
+    expect(await resolveId.call({} as never, "vite-hub/sandbox", "/app/server.ts", {} as never)).toBe(providerSandboxFacade)
+    expect(await resolveId.call({} as never, frameworkSandboxFacade, "/app/server.ts", {} as never)).toBe(providerSandboxFacade)
+  })
+
   it.each(generatedOwnerPackageCases)("classifies generated import %s as %s", async (name, access) => {
     const resolved = await dependencyResolver().call({} as never, name, "\0#vitehub/templates", {} as never)
     if (access === "deny") expect(resolved).toBeUndefined()


### PR DESCRIPTION
Provider builds can redirect a ViteHub feature facade to a generated runtime implementation, but Vite may rewrite the `vite-hub/*` specifier to the framework distribution path before the dependency resolver sees it. The resolver now recognizes both forms and preserves the generated provider facade, which keeps discovered Sandbox definitions in the provider registry.

Adds focused contract coverage for direct and Vite-rewritten facade resolution. This can merge independently of #720, though both branches touch `frameworkDependencyResolver` and the later branch may need a small rebase.