### PR TITLE
fix(sandbox): compose Cloudflare Nitro output

### DIFF
--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -43,11 +43,17 @@ export function isServerEnvironment(name: string, config: { consumer?: string })
 interface NitroVercelConfig {
   environments?: Record<string, { build?: { outDir?: string } }>
   nitro?: { preset?: string }
-  plugins?: readonly { name: string }[]
+  plugins?: unknown
 }
 
-export function hasNitroVitePlugin(config: { plugins?: readonly { name: string }[] }): boolean {
-  return config.plugins?.some(plugin => plugin.name === "nitro:main") === true
+function includesNitroVitePlugin(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(includesNitroVitePlugin)
+  if (!value || typeof value !== "object") return false
+  return "name" in value && value.name === "nitro:main"
+}
+
+export function hasNitroVitePlugin(config: { plugins?: unknown }): boolean {
+  return includesNitroVitePlugin(config.plugins)
 }
 
 export function resolveNitroVercelFunctionName(

--- a/packages/internal/test/vite-build.test.ts
+++ b/packages/internal/test/vite-build.test.ts
@@ -5,7 +5,9 @@ import { hasNitroVitePlugin, resolveNitroVercelFunctionName } from "../src/build
 describe("Vite provider builds", () => {
   it("distinguishes the Nitro host plugin from ViteHub bridge plugins", () => {
     expect(hasNitroVitePlugin({ plugins: [{ name: "nitro:main" }] })).toBe(true)
+    expect(hasNitroVitePlugin({ plugins: [[false, [{ name: "nitro:main" }]]] })).toBe(true)
     expect(hasNitroVitePlugin({ plugins: [{ name: "@vite-hub/blob/vite" }, { name: "@vite-hub/queue/vite" }] })).toBe(false)
+    expect(hasNitroVitePlugin({ plugins: [[{ name: "@vite-hub/blob/vite" }]] })).toBe(false)
   })
 
   it("isolates provider functions when Nitro owns the Vercel output", () => {

--- a/packages/sandbox/src/cloudflare.ts
+++ b/packages/sandbox/src/cloudflare.ts
@@ -133,8 +133,14 @@ function createCloudflareSandboxRollupPlugin(options: CloudflareSandboxEntrypoin
       if (!chunk.isEntry || chunk.fileName !== 'index.mjs')
         return null
       const escapedClassName = className.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      const namedExport = new RegExp(`\\bexport\\s+(?:class\\s+${escapedClassName}\\b|\\{[^}]*\\b${escapedClassName}\\b[^}]*\\})`)
-      if (namedExport.test(code))
+      const exportsClass = new RegExp(`\\bexport\\s+class\\s+${escapedClassName}\\b`).test(code)
+      const exportsName = [...code.matchAll(/\bexport\s*\{([^}]*)\}/g)].some(([, specifiers]) =>
+        specifiers!.split(',').some((specifier) => {
+          const names = specifier.trim().split(/\s+as\s+/)
+          return names.at(-1) === className
+        }),
+      )
+      if (exportsClass || exportsName)
         return null
 
       return {

--- a/packages/sandbox/src/cloudflare.ts
+++ b/packages/sandbox/src/cloudflare.ts
@@ -61,6 +61,10 @@ export function configureCloudflareSandbox(target: MutableCloudflareTarget, opti
   if (!classIsMigrated && existingMigrations?.some(entry => entry.tag === migrationTag)) {
     throw new Error(`[vitehub] Cloudflare migration tag ${JSON.stringify(migrationTag)} is already in use. Configure a unique sandbox migrationTag.`)
   }
+  const existingBindings = target.cloudflare?.wrangler?.durable_objects?.bindings
+  if (existingBindings?.some(entry => entry.name === binding && entry.class_name !== className)) {
+    throw new Error(`[vitehub] Cloudflare Durable Object binding ${JSON.stringify(binding)} is already in use. Configure a unique sandbox binding.`)
+  }
 
   target.cloudflare ||= {}
   target.cloudflare.wrangler ||= {}
@@ -141,7 +145,9 @@ function createCloudflareSandboxRollupPlugin(options: CloudflareSandboxEntrypoin
 export function installCloudflareSandboxEntrypoint(target: MutableRollupTarget, options: CloudflareSandboxEntrypointOptions = {}) {
   const { className } = resolveCloudflareSandboxEntrypointOptions(options)
   target.rollupConfig ||= {}
-  const plugins = Array.isArray(target.rollupConfig.plugins) ? target.rollupConfig.plugins : []
+  const plugins = Array.isArray(target.rollupConfig.plugins)
+    ? target.rollupConfig.plugins
+    : target.rollupConfig.plugins ? [target.rollupConfig.plugins] : []
   target.rollupConfig.plugins = plugins
   if (plugins.some((plugin: unknown) => typeof plugin === 'object' && plugin !== null && 'name' in plugin && (plugin as { name?: string }).name === `vitehub-sandbox-cloudflare-exports:${className}`))
     return
@@ -192,6 +198,7 @@ export async function configureCloudflareSandboxNitro(
   if (!wrangler.compatibility_flags.includes('nodejs_compat'))
     wrangler.compatibility_flags.push('nodejs_compat')
 
-  installCloudflareSandboxEntrypoint(target, resolvedOptions)
+  if (!existingContainer)
+    installCloudflareSandboxEntrypoint(target, resolvedOptions)
   return target
 }

--- a/packages/sandbox/src/cloudflare.ts
+++ b/packages/sandbox/src/cloudflare.ts
@@ -53,6 +53,9 @@ function resolveCloudflareSandboxEntrypointOptions(options: CloudflareSandboxEnt
 
 export function configureCloudflareSandbox(target: MutableCloudflareTarget, options: CloudflareSandboxEntrypointOptions = {}) {
   const { binding, className, migrationTag, name } = resolveCloudflareSandboxEntrypointOptions(options)
+  if (typeof target.cloudflare?.wrangler?.exports !== 'undefined') {
+    throw new Error('[vitehub] Cloudflare Sandbox cannot compose legacy migrations with an existing Wrangler exports configuration. Remove exports or configure the Sandbox Durable Object explicitly.')
+  }
   const existingMigrations = target.cloudflare?.wrangler?.migrations
   const classIsMigrated = existingMigrations?.some(entry => entry.new_sqlite_classes?.includes(className))
   if (!classIsMigrated && existingMigrations?.some(entry => entry.tag === migrationTag)) {

--- a/packages/sandbox/src/cloudflare.ts
+++ b/packages/sandbox/src/cloudflare.ts
@@ -99,6 +99,14 @@ export function configureCloudflareSandbox(target: MutableCloudflareTarget, opti
       ...(name ? { name } : {}),
     })
   }
+  else {
+    const container = containers.find(entry => entry.class_name === className)!
+    container.image ??= image
+    if (typeof container.max_instances !== 'number' || container.max_instances < defaultCloudflareSandboxMaxInstances)
+      container.max_instances = defaultCloudflareSandboxMaxInstances
+    if (name)
+      container.name ??= name
+  }
 
   const bindings = target.cloudflare.wrangler.durable_objects.bindings as WranglerDurableObjectBinding[]
   if (!bindings.some(entry => entry.name === binding && entry.class_name === className)) {
@@ -149,18 +157,8 @@ function createCloudflareSandboxRollupPlugin(options: CloudflareSandboxEntrypoin
     renderChunk(code, chunk) {
       if (!chunk.isEntry)
         return null
-      if (/\bexport\s*\*\s*from\b/.test(code))
-        return null
-      const exportLists = [...code.matchAll(/\bexport\s*\{([^}]*)\}/g)]
-      const hasNamedExport = (name: string) => {
-        const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-        return new RegExp(`\\bexport\\s+class\\s+${escapedName}\\b`).test(code)
-          || exportLists.some(([, specifiers]) => specifiers!.split(',').some((specifier) => {
-            const names = specifier.trim().split(/\s+as\s+/)
-            return names.at(-1) === name
-          }))
-      }
-      const missingExports = [className, 'ContainerProxy'].filter(name => !hasNamedExport(name))
+      const exportedNames = new Set(chunk.exports)
+      const missingExports = [className, 'ContainerProxy'].filter(name => !exportedNames.has(name))
       if (!missingExports.length)
         return null
       const exportsPath = relative(dirname(chunk.fileName), 'sandbox-cloudflare-exports.mjs').replace(/\\/g, '/')

--- a/packages/sandbox/src/cloudflare.ts
+++ b/packages/sandbox/src/cloudflare.ts
@@ -173,7 +173,7 @@ export async function configureCloudflareSandboxNitro(
   configureCloudflareSandbox(target, resolvedOptions)
   const container = target.cloudflare!.wrangler!.containers!
     .find(entry => entry.class_name === resolvedOptions.className)!
-  if (!existingContainer) {
+  if (typeof existingContainer?.image !== 'string') {
     const appDockerfile = resolve(rootDir, 'Dockerfile')
     const dockerfile = existsSync(appDockerfile)
       ? appDockerfile

--- a/packages/sandbox/src/cloudflare.ts
+++ b/packages/sandbox/src/cloudflare.ts
@@ -50,6 +50,20 @@ function resolveCloudflareSandboxEntrypointOptions(options: CloudflareSandboxEnt
   }
 }
 
+function mergeRollupExternal(value: unknown, addition: string): unknown {
+  if (typeof value === 'undefined')
+    return [addition]
+  if (Array.isArray(value))
+    return value.includes(addition) ? [...value] : [...value, addition]
+  if (typeof value === 'string' || value instanceof RegExp)
+    return [value, addition]
+  if (typeof value === 'function') {
+    return (source: string, importer?: string, isResolved?: boolean) =>
+      source === addition || Boolean(value(source, importer, isResolved))
+  }
+  return value
+}
+
 export function configureCloudflareSandbox(target: MutableCloudflareTarget, options: CloudflareSandboxEntrypointOptions = {}) {
   const { binding, className, migrationTag, name } = resolveCloudflareSandboxEntrypointOptions(options)
   if (typeof target.cloudflare?.wrangler?.exports !== 'undefined') {
@@ -123,6 +137,7 @@ function createCloudflareSandboxRollupPlugin(options: CloudflareSandboxEntrypoin
       if (id === resolvedModuleId) {
         return [
           `import { Sandbox as CloudflareSandbox } from '@cloudflare/sandbox'`,
+          `export { ContainerProxy } from '@cloudflare/sandbox'`,
           ``,
           `export class ${className} extends CloudflareSandbox {}`,
           ``,
@@ -130,21 +145,23 @@ function createCloudflareSandboxRollupPlugin(options: CloudflareSandboxEntrypoin
       }
     },
     renderChunk(code, chunk) {
-      if (!chunk.isEntry || chunk.fileName !== 'index.mjs')
+      if (!chunk.isEntry)
         return null
-      const escapedClassName = className.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      const exportsClass = new RegExp(`\\bexport\\s+class\\s+${escapedClassName}\\b`).test(code)
-      const exportsName = [...code.matchAll(/\bexport\s*\{([^}]*)\}/g)].some(([, specifiers]) =>
-        specifiers!.split(',').some((specifier) => {
-          const names = specifier.trim().split(/\s+as\s+/)
-          return names.at(-1) === className
-        }),
-      )
-      if (exportsClass || exportsName)
+      const exportLists = [...code.matchAll(/\bexport\s*\{([^}]*)\}/g)]
+      const hasNamedExport = (name: string) => {
+        const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+        return new RegExp(`\\bexport\\s+class\\s+${escapedName}\\b`).test(code)
+          || exportLists.some(([, specifiers]) => specifiers!.split(',').some((specifier) => {
+            const names = specifier.trim().split(/\s+as\s+/)
+            return names.at(-1) === name
+          }))
+      }
+      const missingExports = [className, 'ContainerProxy'].filter(name => !hasNamedExport(name))
+      if (!missingExports.length)
         return null
 
       return {
-        code: `${code}\nexport { ${className} } from './sandbox-cloudflare-exports.mjs'\n`,
+        code: `${code}\nexport { ${missingExports.join(', ')} } from './sandbox-cloudflare-exports.mjs'\n`,
         map: null,
       }
     },
@@ -204,6 +221,8 @@ export async function configureCloudflareSandboxNitro(
   if (!wrangler.compatibility_flags.includes('nodejs_compat'))
     wrangler.compatibility_flags.push('nodejs_compat')
 
+  target.rollupConfig ||= {}
+  target.rollupConfig.external = mergeRollupExternal(target.rollupConfig.external, 'cloudflare:workers')
   installCloudflareSandboxEntrypoint(target, resolvedOptions)
   return target
 }

--- a/packages/sandbox/src/cloudflare.ts
+++ b/packages/sandbox/src/cloudflare.ts
@@ -1,4 +1,3 @@
-import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { writeFileIfChanged } from '@vite-hub/internal/definition-catalog'
 import { join, relative, resolve } from 'pathe'
@@ -133,6 +132,10 @@ function createCloudflareSandboxRollupPlugin(options: CloudflareSandboxEntrypoin
     renderChunk(code, chunk) {
       if (!chunk.isEntry || chunk.fileName !== 'index.mjs')
         return null
+      const escapedClassName = className.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      const namedExport = new RegExp(`\\bexport\\s+(?:class\\s+${escapedClassName}\\b|\\{[^}]*\\b${escapedClassName}\\b[^}]*\\})`)
+      if (namedExport.test(code))
+        return null
 
       return {
         code: `${code}\nexport { ${className} } from './sandbox-cloudflare-exports.mjs'\n`,
@@ -183,10 +186,7 @@ export async function configureCloudflareSandboxNitro(
   const container = target.cloudflare!.wrangler!.containers!
     .find(entry => entry.class_name === resolvedOptions.className)!
   if (typeof existingContainer?.image !== 'string') {
-    const appDockerfile = resolve(rootDir, 'Dockerfile')
-    const dockerfile = existsSync(appDockerfile)
-      ? appDockerfile
-      : await writeCloudflareSandboxDockerfile(resolve(rootDir, '.vitehub/sandbox'))
+    const dockerfile = await writeCloudflareSandboxDockerfile(resolve(rootDir, '.vitehub/sandbox'))
     container.image = relativeWranglerPath(serverDir, dockerfile)
     container.image_build_context = relativeWranglerPath(serverDir, rootDir)
   }
@@ -198,7 +198,6 @@ export async function configureCloudflareSandboxNitro(
   if (!wrangler.compatibility_flags.includes('nodejs_compat'))
     wrangler.compatibility_flags.push('nodejs_compat')
 
-  if (!existingContainer)
-    installCloudflareSandboxEntrypoint(target, resolvedOptions)
+  installCloudflareSandboxEntrypoint(target, resolvedOptions)
   return target
 }

--- a/packages/sandbox/src/cloudflare.ts
+++ b/packages/sandbox/src/cloudflare.ts
@@ -53,6 +53,11 @@ function resolveCloudflareSandboxEntrypointOptions(options: CloudflareSandboxEnt
 
 export function configureCloudflareSandbox(target: MutableCloudflareTarget, options: CloudflareSandboxEntrypointOptions = {}) {
   const { binding, className, migrationTag, name } = resolveCloudflareSandboxEntrypointOptions(options)
+  const existingMigrations = target.cloudflare?.wrangler?.migrations
+  const classIsMigrated = existingMigrations?.some(entry => entry.new_sqlite_classes?.includes(className))
+  if (!classIsMigrated && existingMigrations?.some(entry => entry.tag === migrationTag)) {
+    throw new Error(`[vitehub] Cloudflare migration tag ${JSON.stringify(migrationTag)} is already in use. Configure a unique sandbox migrationTag.`)
+  }
 
   target.cloudflare ||= {}
   target.cloudflare.wrangler ||= {}
@@ -72,21 +77,6 @@ export function configureCloudflareSandbox(target: MutableCloudflareTarget, opti
       ...(name ? { name } : {}),
     })
   }
-  else {
-    for (const container of containers) {
-      if (container.class_name !== className)
-        continue
-
-      if (typeof container.image !== 'string')
-        container.image = image
-
-      if (typeof container.max_instances !== 'number' || container.max_instances < defaultCloudflareSandboxMaxInstances)
-        container.max_instances = defaultCloudflareSandboxMaxInstances
-
-      if (name && typeof container.name !== 'string')
-        container.name = name
-    }
-  }
 
   const bindings = target.cloudflare.wrangler.durable_objects.bindings as WranglerDurableObjectBinding[]
   if (!bindings.some(entry => entry.name === binding && entry.class_name === className)) {
@@ -98,13 +88,7 @@ export function configureCloudflareSandbox(target: MutableCloudflareTarget, opti
 
   const migrations = target.cloudflare.wrangler.migrations as WranglerMigration[]
   if (!migrations.some(entry => Array.isArray(entry.new_sqlite_classes) && entry.new_sqlite_classes.includes(className))) {
-    const migration = migrations.find(entry => entry.tag === migrationTag)
-    if (migration) {
-      migration.new_sqlite_classes ||= []
-      migration.new_sqlite_classes.push(className)
-    }
-    else
-      migrations.push({ tag: migrationTag, new_sqlite_classes: [className] })
+    migrations.push({ tag: migrationTag, new_sqlite_classes: [className] })
   }
 }
 
@@ -189,7 +173,7 @@ export async function configureCloudflareSandboxNitro(
   configureCloudflareSandbox(target, resolvedOptions)
   const container = target.cloudflare!.wrangler!.containers!
     .find(entry => entry.class_name === resolvedOptions.className)!
-  if (typeof existingContainer?.image !== 'string') {
+  if (!existingContainer) {
     const appDockerfile = resolve(rootDir, 'Dockerfile')
     const dockerfile = existsSync(appDockerfile)
       ? appDockerfile

--- a/packages/sandbox/src/cloudflare.ts
+++ b/packages/sandbox/src/cloudflare.ts
@@ -102,7 +102,7 @@ export function configureCloudflareSandbox(target: MutableCloudflareTarget, opti
   else {
     const container = containers.find(entry => entry.class_name === className)!
     container.image ??= image
-    if (typeof container.max_instances !== 'number' || container.max_instances < defaultCloudflareSandboxMaxInstances)
+    if (typeof container.max_instances !== 'number')
       container.max_instances = defaultCloudflareSandboxMaxInstances
     if (name)
       container.name ??= name

--- a/packages/sandbox/src/cloudflare.ts
+++ b/packages/sandbox/src/cloudflare.ts
@@ -1,9 +1,11 @@
-import { writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { join } from 'pathe'
+import { writeFileIfChanged } from '@vite-hub/internal/definition-catalog'
+import { join, relative, resolve } from 'pathe'
 import type { Plugin } from 'rollup'
 import type {
   MutableCloudflareTarget,
+  MutableNitroCloudflareTarget,
   MutableRollupTarget,
   WranglerContainer,
   WranglerDurableObjectBinding,
@@ -21,19 +23,16 @@ function resolveCloudflareSandboxEntrypoint() {
     return require.resolve('@cloudflare/sandbox')
   }
   catch {
-    return '@cloudflare/sandbox'
+    throw new Error('[vitehub] The Cloudflare Sandbox provider requires @cloudflare/sandbox. Install a supported version before building.')
   }
 }
 
 function resolveCloudflareSandboxVersion() {
-  try {
-    const entry = require.resolve('@cloudflare/sandbox')
-    const pkg = require(join(entry, '..', '..', 'package.json'))
-    return typeof pkg?.version === 'string' ? pkg.version : '0.7.0'
-  }
-  catch {
-    return '0.7.0'
-  }
+  const entry = resolveCloudflareSandboxEntrypoint()
+  const pkg = require(join(entry, '..', '..', 'package.json'))
+  if (typeof pkg?.version !== 'string')
+    throw new Error('[vitehub] Could not resolve the installed @cloudflare/sandbox version.')
+  return pkg.version
 }
 
 export type CloudflareSandboxEntrypointOptions = {
@@ -99,10 +98,13 @@ export function configureCloudflareSandbox(target: MutableCloudflareTarget, opti
 
   const migrations = target.cloudflare.wrangler.migrations as WranglerMigration[]
   if (!migrations.some(entry => Array.isArray(entry.new_sqlite_classes) && entry.new_sqlite_classes.includes(className))) {
-    migrations.push({
-      tag: migrationTag,
-      new_sqlite_classes: [className],
-    })
+    const migration = migrations.find(entry => entry.tag === migrationTag)
+    if (migration) {
+      migration.new_sqlite_classes ||= []
+      migration.new_sqlite_classes.push(className)
+    }
+    else
+      migrations.push({ tag: migrationTag, new_sqlite_classes: [className] })
   }
 }
 
@@ -164,5 +166,45 @@ export function installCloudflareSandboxEntrypoint(target: MutableRollupTarget, 
 
 export async function writeCloudflareSandboxDockerfile(serverDir: string) {
   const dockerfilePath = join(serverDir, 'Dockerfile')
-  await writeFile(dockerfilePath, `FROM docker.io/cloudflare/sandbox:${resolveCloudflareSandboxVersion()}\n`)
+  await writeFileIfChanged(dockerfilePath, `FROM docker.io/cloudflare/sandbox:${resolveCloudflareSandboxVersion()}\n`)
+  return dockerfilePath
+}
+
+function relativeWranglerPath(from: string, to: string) {
+  const path = relative(from, to).replace(/\\/g, '/')
+  return path.startsWith('.') ? path : `./${path}`
+}
+
+export async function configureCloudflareSandboxNitro(
+  targetValue: MutableNitroCloudflareTarget | undefined,
+  rootDir: string,
+  options: CloudflareSandboxEntrypointOptions = {},
+) {
+  const target = targetValue || {}
+  const serverDir = resolve(rootDir, target.output?.serverDir || '.output/server')
+  const resolvedOptions = resolveCloudflareSandboxEntrypointOptions(options)
+  const existingContainer = target.cloudflare?.wrangler?.containers
+    ?.find(entry => entry.class_name === resolvedOptions.className)
+
+  configureCloudflareSandbox(target, resolvedOptions)
+  const container = target.cloudflare!.wrangler!.containers!
+    .find(entry => entry.class_name === resolvedOptions.className)!
+  if (typeof existingContainer?.image !== 'string') {
+    const appDockerfile = resolve(rootDir, 'Dockerfile')
+    const dockerfile = existsSync(appDockerfile)
+      ? appDockerfile
+      : await writeCloudflareSandboxDockerfile(resolve(rootDir, '.vitehub/sandbox'))
+    container.image = relativeWranglerPath(serverDir, dockerfile)
+    container.image_build_context = relativeWranglerPath(serverDir, rootDir)
+  }
+
+  const wrangler = target.cloudflare!.wrangler!
+  wrangler.compatibility_flags = Array.isArray(wrangler.compatibility_flags)
+    ? [...wrangler.compatibility_flags]
+    : []
+  if (!wrangler.compatibility_flags.includes('nodejs_compat'))
+    wrangler.compatibility_flags.push('nodejs_compat')
+
+  installCloudflareSandboxEntrypoint(target, resolvedOptions)
+  return target
 }

--- a/packages/sandbox/src/cloudflare.ts
+++ b/packages/sandbox/src/cloudflare.ts
@@ -1,6 +1,6 @@
 import { createRequire } from 'node:module'
 import { writeFileIfChanged } from '@vite-hub/internal/definition-catalog'
-import { join, relative, resolve } from 'pathe'
+import { dirname, join, relative, resolve } from 'pathe'
 import type { Plugin } from 'rollup'
 import type {
   MutableCloudflareTarget,
@@ -42,6 +42,8 @@ export type CloudflareSandboxEntrypointOptions = {
 }
 
 function resolveCloudflareSandboxEntrypointOptions(options: CloudflareSandboxEntrypointOptions = {}) {
+  if (options.className === 'ContainerProxy')
+    throw new Error('[vitehub] Cloudflare Sandbox className "ContainerProxy" is reserved by @cloudflare/sandbox. Configure a different className.')
   return {
     binding: options.binding || defaultCloudflareSandboxBinding,
     className: options.className || defaultCloudflareSandboxClassName,
@@ -147,6 +149,8 @@ function createCloudflareSandboxRollupPlugin(options: CloudflareSandboxEntrypoin
     renderChunk(code, chunk) {
       if (!chunk.isEntry)
         return null
+      if (/\bexport\s*\*\s*from\b/.test(code))
+        return null
       const exportLists = [...code.matchAll(/\bexport\s*\{([^}]*)\}/g)]
       const hasNamedExport = (name: string) => {
         const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -159,9 +163,11 @@ function createCloudflareSandboxRollupPlugin(options: CloudflareSandboxEntrypoin
       const missingExports = [className, 'ContainerProxy'].filter(name => !hasNamedExport(name))
       if (!missingExports.length)
         return null
+      const exportsPath = relative(dirname(chunk.fileName), 'sandbox-cloudflare-exports.mjs').replace(/\\/g, '/')
+      const importPath = exportsPath.startsWith('.') ? exportsPath : `./${exportsPath}`
 
       return {
-        code: `${code}\nexport { ${missingExports.join(', ')} } from './sandbox-cloudflare-exports.mjs'\n`,
+        code: `${code}\nexport { ${missingExports.join(', ')} } from ${JSON.stringify(importPath)}\n`,
         map: null,
       }
     },
@@ -204,11 +210,12 @@ export async function configureCloudflareSandboxNitro(
   const resolvedOptions = resolveCloudflareSandboxEntrypointOptions(options)
   const existingContainer = target.cloudflare?.wrangler?.containers
     ?.find(entry => entry.class_name === resolvedOptions.className)
+  const existingImage = existingContainer?.image?.replace(/\\/g, '/')
 
   configureCloudflareSandbox(target, resolvedOptions)
   const container = target.cloudflare!.wrangler!.containers!
     .find(entry => entry.class_name === resolvedOptions.className)!
-  if (typeof existingContainer?.image !== 'string') {
+  if (typeof existingImage !== 'string' || existingImage.endsWith('/.vitehub/sandbox/Dockerfile')) {
     const dockerfile = await writeCloudflareSandboxDockerfile(resolve(rootDir, '.vitehub/sandbox'))
     container.image = relativeWranglerPath(serverDir, dockerfile)
     container.image_build_context = relativeWranglerPath(serverDir, rootDir)

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -144,7 +144,7 @@ function resolveStringAliases(alias: unknown): AliasMap {
     const find = entry.find.replace(/\/$/, '')
     if (!find || builtinModuleSet.has(find))
       continue
-    aliases[find] = entry.replacement.replace(/\/$/, '')
+    aliases[find] = entry.replacement
   }
   return aliases
 }
@@ -223,7 +223,12 @@ export async function prepareSandboxRuntime(options: {
   writeArtifacts?: boolean
 }) {
   const rootDir = options.resolvedConfig?.root || resolve(process.cwd(), typeof options.userConfig.root === 'string' ? options.userConfig.root : '.')
-  const context = await resolveSandboxViteContext(options.integrationOptions, { ...options.userConfig, root: rootDir }, options.env)
+  const resolvedNitro = (options.resolvedConfig as { nitro?: unknown } | undefined)?.nitro
+  const context = await resolveSandboxViteContext(options.integrationOptions, {
+    ...options.userConfig,
+    ...(isPlainObject(resolvedNitro) ? { nitro: resolvedNitro } : {}),
+    root: rootDir,
+  }, options.env)
   const stateModule = createSandboxStateModuleContents(context)
   if (!context.config) {
     return {

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -83,7 +83,11 @@ async function resolveSandboxViteContext(
   const options = normalizeSandboxOptions(
     typeof configOptions === 'undefined' ? integrationOptions ?? {} : configOptions,
   )
-  const hosting = detectHosting({ options: userConfig as { preset?: string | null } }) || undefined
+  const nitro = isPlainObject(userConfig.nitro) ? userConfig.nitro : {}
+  const preset = typeof userConfig.preset === 'string'
+    ? userConfig.preset
+    : typeof nitro.preset === 'string' ? nitro.preset : undefined
+  const hosting = detectHosting({ options: { preset } }) || undefined
   const config = options === false ? false : resolveSandboxFeatureConfig(options, hosting)
   const rootDir = resolve(process.cwd(), typeof userConfig.root === 'string' ? userConfig.root : '.')
 
@@ -137,8 +141,7 @@ function resolveStringAliases(alias: unknown): AliasMap {
   for (const entry of readAliasEntries(alias)) {
     if (
       typeof entry.find === 'string'
-      && !entry.find.endsWith('/')
-      && !builtinModuleSet.has(entry.find)
+      && !builtinModuleSet.has(entry.find.replace(/\/$/, ''))
       && typeof entry.replacement === 'string'
     )
       aliases[entry.find] = entry.replacement

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -145,8 +145,7 @@ function resolveStringAliases(alias: unknown): AliasMap {
       continue
     if (builtinModuleSet.has(entry.find))
       continue
-    const normalized = entry.find.replace(/\/$/, '')
-    const find = entry.find.endsWith('/') && builtinModuleSet.has(normalized) ? entry.find : normalized
+    const find = entry.find.replace(/\/$/, '')
     if (!find)
       continue
     aliases[find] = entry.replacement

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -235,6 +235,7 @@ export async function prepareSandboxRuntime(options: {
       aliases: {} as AliasMap,
       definitions: [],
       files: [],
+      hosting: context.hosting,
       stateModule,
     }
   }
@@ -261,6 +262,7 @@ export async function prepareSandboxRuntime(options: {
       cloudflare: plan.cloudflare,
       definitions,
       files: [],
+      hosting: context.hosting,
       stateModule,
     }
   }
@@ -279,6 +281,7 @@ export async function prepareSandboxRuntime(options: {
     cloudflare: plan.cloudflare,
     definitions,
     files: [facadeFile, ...Array.from(emitted.values(), artifact => artifact.dst)],
+    hosting: context.hosting,
     stateModule,
   }
 }

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -1,4 +1,5 @@
 import { readFile } from 'node:fs/promises'
+import { builtinModules } from 'node:module'
 
 import { createImportPath, ensureGeneratedDir } from '@vite-hub/internal/build/paths'
 import { writeFileIfChanged } from '@vite-hub/internal/definition-catalog'
@@ -16,6 +17,10 @@ import type { Alias, ConfigEnv, ResolvedConfig } from 'vite'
 
 const SANDBOX_PACKAGE_ID = '@vite-hub/sandbox'
 const SANDBOX_REGISTRY_ID = '#vitehub-sandbox-registry'
+const builtinModuleSet = new Set([
+  ...builtinModules,
+  ...builtinModules.map(name => `node:${name}`),
+])
 
 type AliasMap = Record<string, string>
 type SandboxPublicOptions = AgentSandboxConfig | false
@@ -130,7 +135,12 @@ function readAliasEntries(alias: unknown): Alias[] {
 function resolveStringAliases(alias: unknown): AliasMap {
   const aliases: AliasMap = {}
   for (const entry of readAliasEntries(alias)) {
-    if (typeof entry.find === 'string' && typeof entry.replacement === 'string')
+    if (
+      typeof entry.find === 'string'
+      && !entry.find.endsWith('/')
+      && !builtinModuleSet.has(entry.find)
+      && typeof entry.replacement === 'string'
+    )
       aliases[entry.find] = entry.replacement
   }
   return aliases
@@ -240,6 +250,7 @@ export async function prepareSandboxRuntime(options: {
   if (options.writeArtifacts === false) {
     return {
       aliases,
+      cloudflare: plan.cloudflare,
       definitions,
       files: [],
       stateModule,
@@ -257,6 +268,7 @@ export async function prepareSandboxRuntime(options: {
   )
   return {
     aliases,
+    cloudflare: plan.cloudflare,
     definitions,
     files: [facadeFile, ...Array.from(emitted.values(), artifact => artifact.dst)],
     stateModule,

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -143,9 +143,9 @@ function resolveStringAliases(alias: unknown): AliasMap {
   for (const entry of readAliasEntries(alias)) {
     if (typeof entry.find !== 'string' || typeof entry.replacement !== 'string')
       continue
-    if (builtinModuleSet.has(entry.find))
-      continue
     const find = entry.find.replace(/\/$/, '')
+    if (builtinModuleSet.has(entry.find) || builtinModuleSet.has(find))
+      continue
     if (!find)
       continue
     aliases[find] = entry.replacement

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -86,7 +86,9 @@ async function resolveSandboxViteContext(
   const nitro = isPlainObject(userConfig.nitro) ? userConfig.nitro : {}
   const preset = typeof userConfig.preset === 'string'
     ? userConfig.preset
-    : typeof nitro.preset === 'string' ? nitro.preset : undefined
+    : typeof nitro.preset === 'string'
+      ? nitro.preset
+      : process.env.NITRO_PRESET || process.env.SERVER_PRESET
   const hosting = detectHosting({ options: { preset } }) || undefined
   const config = options === false ? false : resolveSandboxFeatureConfig(options, hosting)
   const rootDir = resolve(process.cwd(), typeof userConfig.root === 'string' ? userConfig.root : '.')

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -139,12 +139,12 @@ function readAliasEntries(alias: unknown): Alias[] {
 function resolveStringAliases(alias: unknown): AliasMap {
   const aliases: AliasMap = {}
   for (const entry of readAliasEntries(alias)) {
-    if (
-      typeof entry.find === 'string'
-      && !builtinModuleSet.has(entry.find.replace(/\/$/, ''))
-      && typeof entry.replacement === 'string'
-    )
-      aliases[entry.find] = entry.replacement
+    if (typeof entry.find !== 'string' || typeof entry.replacement !== 'string')
+      continue
+    const find = entry.find.replace(/\/$/, '')
+    if (!find || builtinModuleSet.has(find))
+      continue
+    aliases[find] = entry.replacement.replace(/\/$/, '')
   }
   return aliases
 }

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -143,8 +143,11 @@ function resolveStringAliases(alias: unknown): AliasMap {
   for (const entry of readAliasEntries(alias)) {
     if (typeof entry.find !== 'string' || typeof entry.replacement !== 'string')
       continue
-    const find = entry.find.replace(/\/$/, '')
-    if (!find || builtinModuleSet.has(find))
+    if (builtinModuleSet.has(entry.find))
+      continue
+    const normalized = entry.find.replace(/\/$/, '')
+    const find = entry.find.endsWith('/') && builtinModuleSet.has(normalized) ? entry.find : normalized
+    if (!find)
       continue
     aliases[find] = entry.replacement
   }

--- a/packages/sandbox/src/internal/shared/cloudflare-target.ts
+++ b/packages/sandbox/src/internal/shared/cloudflare-target.ts
@@ -16,6 +16,7 @@ export interface WranglerR2Bucket {
 export interface WranglerContainer {
   class_name: string
   image?: string
+  image_build_context?: string
   instance_type?: string
   max_instances?: number
   name?: string
@@ -63,6 +64,7 @@ export interface WranglerHyperdriveBinding {
 }
 
 export interface MutableWranglerConfig {
+  compatibility_flags?: string[]
   kv_namespaces?: WranglerKVNamespace[]
   r2_buckets?: WranglerR2Bucket[]
   containers?: WranglerContainer[]
@@ -86,5 +88,11 @@ export interface MutableCloudflareTarget {
 export interface MutableRollupTarget {
   rollupConfig?: {
     plugins?: unknown
+  }
+}
+
+export interface MutableNitroCloudflareTarget extends MutableCloudflareTarget, MutableRollupTarget {
+  output?: {
+    serverDir?: string
   }
 }

--- a/packages/sandbox/src/internal/shared/cloudflare-target.ts
+++ b/packages/sandbox/src/internal/shared/cloudflare-target.ts
@@ -65,6 +65,7 @@ export interface WranglerHyperdriveBinding {
 
 export interface MutableWranglerConfig {
   compatibility_flags?: string[]
+  exports?: unknown
   kv_namespaces?: WranglerKVNamespace[]
   r2_buckets?: WranglerR2Bucket[]
   containers?: WranglerContainer[]

--- a/packages/sandbox/src/internal/shared/cloudflare-target.ts
+++ b/packages/sandbox/src/internal/shared/cloudflare-target.ts
@@ -88,6 +88,7 @@ export interface MutableCloudflareTarget {
 
 export interface MutableRollupTarget {
   rollupConfig?: {
+    external?: unknown
     plugins?: unknown
   }
 }

--- a/packages/sandbox/src/internal/shared/cloudflare-wrangler.ts
+++ b/packages/sandbox/src/internal/shared/cloudflare-wrangler.ts
@@ -28,6 +28,7 @@ function isSameKVNamespace(left: WranglerKVNamespace, right: WranglerKVNamespace
 function isSameContainer(left: WranglerContainer, right: WranglerContainer) {
   return left.class_name === right.class_name
     && left.image === right.image
+    && left.image_build_context === right.image_build_context
     && left.instance_type === right.instance_type
     && left.max_instances === right.max_instances
     && left.name === right.name

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -92,7 +92,6 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
   let rawConfig: Record<string, unknown> = {}
   let rawEnv: ConfigEnv = { command: 'serve', mode: 'development' }
   let resolvedConfig: ResolvedConfig | undefined
-  let composedCloudflareSandbox = false
 
   async function prepareCurrentSandboxRuntime(writeArtifacts = true) {
     const prepared = await prepareSandboxRuntime({
@@ -149,7 +148,7 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
       generatedAliases = prepared.aliases
       generatedFiles = prepared.files
       definitions = prepared.definitions
-      composedCloudflareSandbox = await composeCloudflareSandbox(config, prepared)
+      await composeCloudflareSandbox(config, prepared)
       return {
         resolve: {
           alias: toSandboxAliasEntries({
@@ -174,8 +173,7 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
     async configResolved(config) {
       resolvedConfig = config
       const prepared = await refreshSandboxRuntime()
-      if (!composedCloudflareSandbox)
-        composedCloudflareSandbox = await composeCloudflareSandbox(config, prepared)
+      await composeCloudflareSandbox(config, prepared)
     },
     async handleHotUpdate(context) {
       if (!isSandboxDefinitionUpdate(context.file, definitions, generatedFiles, resolvedConfig?.root))

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -123,6 +123,19 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
     return prepared
   }
 
+  async function composeCloudflareSandbox(
+    config: { nitro?: unknown, plugins?: unknown, root?: string },
+    prepared: Awaited<ReturnType<typeof prepareCurrentSandboxRuntime>>,
+  ) {
+    if (!prepared.cloudflare || !hasNitroVitePlugin(config))
+      return
+    config.nitro = await configureCloudflareSandboxNitro(
+      config.nitro as Parameters<typeof configureCloudflareSandboxNitro>[0],
+      typeof config.root === 'string' ? config.root : process.cwd(),
+      prepared.cloudflare,
+    )
+  }
+
   return {
     name: '@vite-hub/sandbox/vite',
     enforce: 'pre',
@@ -133,14 +146,7 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
       generatedAliases = prepared.aliases
       generatedFiles = prepared.files
       definitions = prepared.definitions
-      if (prepared.cloudflare && hasNitroVitePlugin(config)) {
-        const configWithNitro = config as typeof config & { nitro?: Parameters<typeof configureCloudflareSandboxNitro>[0] }
-        configWithNitro.nitro = await configureCloudflareSandboxNitro(
-          configWithNitro.nitro,
-          config.root || process.cwd(),
-          prepared.cloudflare,
-        )
-      }
+      await composeCloudflareSandbox(config, prepared)
       return {
         resolve: {
           alias: toSandboxAliasEntries({
@@ -164,7 +170,8 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
     },
     async configResolved(config) {
       resolvedConfig = config
-      await refreshSandboxRuntime()
+      const prepared = await refreshSandboxRuntime()
+      await composeCloudflareSandbox(config, prepared)
     },
     async handleHotUpdate(context) {
       if (!isSandboxDefinitionUpdate(context.file, definitions, generatedFiles, resolvedConfig?.root))

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -162,8 +162,9 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
       generatedAliases = prepared.aliases
       generatedFiles = prepared.files
       definitions = prepared.definitions
-      if (config.nitro && typeof config.nitro === 'object') {
-        earlyNitroTarget = config.nitro as Record<string, unknown>
+      const nitro = (config as { nitro?: unknown }).nitro
+      if (nitro && typeof nitro === 'object') {
+        earlyNitroTarget = nitro as Record<string, unknown>
         earlyNitroSnapshot = cloneConfigValue(earlyNitroTarget)
       }
       composedCloudflareEarly = await composeCloudflareSandbox(config, prepared)

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -1,4 +1,4 @@
-import { createNoExternalMerger, isServerEnvironment } from '@vite-hub/internal/build/vite'
+import { createNoExternalMerger, hasNitroVitePlugin, isServerEnvironment } from '@vite-hub/internal/build/vite'
 import { normalize, relative } from 'pathe'
 
 import { configureCloudflareSandboxNitro } from './cloudflare'
@@ -79,16 +79,6 @@ function invalidateGeneratedSandboxModules(files: string[], moduleGraph: { getMo
     if (module)
       moduleGraph.invalidateModule(module as never)
   }
-}
-
-function hasNitroVitePlugin(value: unknown): boolean {
-  if (Array.isArray(value))
-    return value.some(hasNitroVitePlugin)
-  if (!value || typeof value !== 'object')
-    return false
-  if ('name' in value && value.name === 'nitro:main')
-    return true
-  return 'plugins' in value && hasNitroVitePlugin(value.plugins)
 }
 
 export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -146,7 +146,6 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
       generatedAliases = prepared.aliases
       generatedFiles = prepared.files
       definitions = prepared.definitions
-      await composeCloudflareSandbox(config, prepared)
       return {
         resolve: {
           alias: toSandboxAliasEntries({

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -1,4 +1,5 @@
 import { createNoExternalMerger, hasNitroVitePlugin, isServerEnvironment } from '@vite-hub/internal/build/vite'
+import { getHostingProvider } from '@vite-hub/internal/hosting'
 import { normalize, relative } from 'pathe'
 
 import { configureCloudflareSandboxNitro } from './cloudflare'
@@ -91,6 +92,7 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
   let rawConfig: Record<string, unknown> = {}
   let rawEnv: ConfigEnv = { command: 'serve', mode: 'development' }
   let resolvedConfig: ResolvedConfig | undefined
+  let composedCloudflareSandbox = false
 
   async function prepareCurrentSandboxRuntime(writeArtifacts = true) {
     const prepared = await prepareSandboxRuntime({
@@ -127,13 +129,14 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
     config: { nitro?: unknown, plugins?: unknown, root?: string },
     prepared: Awaited<ReturnType<typeof prepareCurrentSandboxRuntime>>,
   ) {
-    if (!prepared.cloudflare || !hasNitroVitePlugin(config))
-      return
+    if (!prepared.cloudflare || !hasNitroVitePlugin(config) || getHostingProvider(prepared.hosting) !== 'cloudflare')
+      return false
     config.nitro = await configureCloudflareSandboxNitro(
       config.nitro as Parameters<typeof configureCloudflareSandboxNitro>[0],
       typeof config.root === 'string' ? config.root : process.cwd(),
       prepared.cloudflare,
     )
+    return true
   }
 
   return {
@@ -146,6 +149,7 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
       generatedAliases = prepared.aliases
       generatedFiles = prepared.files
       definitions = prepared.definitions
+      composedCloudflareSandbox = await composeCloudflareSandbox(config, prepared)
       return {
         resolve: {
           alias: toSandboxAliasEntries({
@@ -170,7 +174,8 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
     async configResolved(config) {
       resolvedConfig = config
       const prepared = await refreshSandboxRuntime()
-      await composeCloudflareSandbox(config, prepared)
+      if (!composedCloudflareSandbox)
+        composedCloudflareSandbox = await composeCloudflareSandbox(config, prepared)
     },
     async handleHotUpdate(context) {
       if (!isSandboxDefinitionUpdate(context.file, definitions, generatedFiles, resolvedConfig?.root))

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -1,6 +1,7 @@
 import { createNoExternalMerger, isServerEnvironment } from '@vite-hub/internal/build/vite'
 import { normalize, relative } from 'pathe'
 
+import { configureCloudflareSandboxNitro } from './cloudflare'
 import { resolveFeatureRuntimePath } from './internal/shared/feature-runtime-path'
 import { prepareSandboxRuntime } from './internal/runtime-preparation'
 import type { Alias, ConfigEnv, Plugin, ResolvedConfig } from 'vite'
@@ -80,6 +81,16 @@ function invalidateGeneratedSandboxModules(files: string[], moduleGraph: { getMo
   }
 }
 
+function hasNitroVitePlugin(value: unknown): boolean {
+  if (Array.isArray(value))
+    return value.some(hasNitroVitePlugin)
+  if (!value || typeof value !== 'object')
+    return false
+  if ('name' in value && value.name === 'nitro:main')
+    return true
+  return 'plugins' in value && hasNitroVitePlugin(value.plugins)
+}
+
 export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
   const internalOptions = options as SandboxPublicOptions & SandboxViteInternalOptions | undefined
   const mergeNoExternal = createNoExternalMerger('@vite-hub/sandbox')
@@ -132,6 +143,14 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
       generatedAliases = prepared.aliases
       generatedFiles = prepared.files
       definitions = prepared.definitions
+      if (prepared.cloudflare && hasNitroVitePlugin(config.plugins)) {
+        const configWithNitro = config as typeof config & { nitro?: Parameters<typeof configureCloudflareSandboxNitro>[0] }
+        configWithNitro.nitro = await configureCloudflareSandboxNitro(
+          configWithNitro.nitro,
+          config.root || process.cwd(),
+          prepared.cloudflare,
+        )
+      }
       return {
         resolve: {
           alias: toSandboxAliasEntries({

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -133,7 +133,7 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
       generatedAliases = prepared.aliases
       generatedFiles = prepared.files
       definitions = prepared.definitions
-      if (prepared.cloudflare && hasNitroVitePlugin(config.plugins)) {
+      if (prepared.cloudflare && hasNitroVitePlugin(config)) {
         const configWithNitro = config as typeof config & { nitro?: Parameters<typeof configureCloudflareSandboxNitro>[0] }
         configWithNitro.nitro = await configureCloudflareSandboxNitro(
           configWithNitro.nitro,

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -92,6 +92,20 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
   let rawConfig: Record<string, unknown> = {}
   let rawEnv: ConfigEnv = { command: 'serve', mode: 'development' }
   let resolvedConfig: ResolvedConfig | undefined
+  let earlyNitroTarget: Record<string, unknown> | undefined
+  let earlyNitroSnapshot: Record<string, unknown> | undefined
+  let composedCloudflareEarly = false
+
+  function cloneConfigValue<T>(value: T): T {
+    if (Array.isArray(value))
+      return value.map(cloneConfigValue) as T
+    if (value && typeof value === 'object' && Object.getPrototypeOf(value) === Object.prototype) {
+      return Object.fromEntries(
+        Object.entries(value).map(([key, entry]) => [key, cloneConfigValue(entry)]),
+      ) as T
+    }
+    return value
+  }
 
   async function prepareCurrentSandboxRuntime(writeArtifacts = true) {
     const prepared = await prepareSandboxRuntime({
@@ -148,7 +162,11 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
       generatedAliases = prepared.aliases
       generatedFiles = prepared.files
       definitions = prepared.definitions
-      await composeCloudflareSandbox(config, prepared)
+      if (config.nitro && typeof config.nitro === 'object') {
+        earlyNitroTarget = config.nitro as Record<string, unknown>
+        earlyNitroSnapshot = cloneConfigValue(earlyNitroTarget)
+      }
+      composedCloudflareEarly = await composeCloudflareSandbox(config, prepared)
       return {
         resolve: {
           alias: toSandboxAliasEntries({
@@ -173,7 +191,15 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
     async configResolved(config) {
       resolvedConfig = config
       const prepared = await refreshSandboxRuntime()
-      await composeCloudflareSandbox(config, prepared)
+      const composed = await composeCloudflareSandbox(config, prepared)
+      if (!composed && composedCloudflareEarly && earlyNitroTarget && earlyNitroSnapshot) {
+        for (const key of ['cloudflare', 'rollupConfig']) {
+          if (key in earlyNitroSnapshot)
+            earlyNitroTarget[key] = earlyNitroSnapshot[key]
+          else
+            delete earlyNitroTarget[key]
+        }
+      }
     },
     async handleHotUpdate(context) {
       if (!isSandboxDefinitionUpdate(context.file, definitions, generatedFiles, resolvedConfig?.root))

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -187,6 +187,98 @@ describe("hubSandbox", () => {
     await expect(readFile(join(rootDir, ".vitehub/sandbox/runtime/sandbox-definitions/tools__release-notes.mjs"), "utf8")).resolves.toContain("from alias")
   })
 
+  it("keeps Node built-ins out of definition bundle aliases", async () => {
+    const rootDir = await createViteRoot()
+    await writeFile(join(rootDir, "src/tools/release-notes.sandbox.ts"), [
+      `import { execFileSync } from "node:child_process"`,
+      ``,
+      `export default defineSandbox(async () => ({ version: execFileSync(process.execPath, ["--version"]).toString() }))`,
+      ``,
+    ].join("\n"))
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "vercel" })
+    const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: { root: string, resolve: { alias: AliasOptions } }) => unknown | Promise<unknown>
+
+    await configHook({ root: rootDir }, { command: "build", mode: "production" })
+    await configResolved({
+      root: rootDir,
+      resolve: {
+        alias: [
+          { find: "process/", replacement: "/virtual/process" },
+          { find: "node:child_process", replacement: "/virtual/child-process" },
+        ],
+      },
+    })
+
+    const definition = await readFile(join(rootDir, ".vitehub/sandbox/runtime/sandbox-definitions/tools__release-notes.mjs"), "utf8")
+    expect(definition).toContain("node:child_process")
+    expect(definition).not.toContain("/virtual/child-process")
+  })
+
+  it("composes Cloudflare Sandbox into Nitro output", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({
+      provider: "cloudflare",
+      name: "image-optimizer",
+    })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const userConfig = {
+      root: rootDir,
+      plugins: [[{ name: "nitro:main" }]],
+      nitro: {
+        cloudflare: {
+          wrangler: {
+            compatibility_flags: ["custom"],
+            migrations: [{ tag: "v1", new_sqlite_classes: ["Existing"] }],
+            routes: ["example.com/*"],
+          },
+        },
+        output: {
+          serverDir: ".output/server",
+        },
+      },
+    }
+
+    await configHook(userConfig, { command: "build", mode: "production" })
+
+    expect(userConfig.nitro.cloudflare.wrangler).toMatchObject({
+      compatibility_flags: ["custom", "nodejs_compat"],
+      containers: [{
+        class_name: "Sandbox",
+        image: "../../.vitehub/sandbox/Dockerfile",
+        image_build_context: "../..",
+        instance_type: "lite",
+        max_instances: 12,
+        name: "image-optimizer",
+      }],
+      durable_objects: {
+        bindings: [{ name: "SANDBOX", class_name: "Sandbox" }],
+      },
+      migrations: [{ tag: "v1", new_sqlite_classes: ["Existing", "Sandbox"] }],
+      routes: ["example.com/*"],
+    })
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
+      .resolves.toMatch(/^FROM docker\.io\/cloudflare\/sandbox:\d/)
+
+    const configuredNitro = userConfig.nitro as typeof userConfig.nitro & {
+      rollupConfig: {
+        plugins: Array<{
+          load: (id: string) => string
+          name: string
+          renderChunk: (code: string, chunk: { fileName: string, isEntry: boolean }) => { code: string }
+        }>
+      }
+    }
+    const [rollupPlugin] = configuredNitro.rollupConfig.plugins
+    expect(rollupPlugin.name).toBe("vitehub-sandbox-cloudflare-exports:Sandbox")
+    expect(rollupPlugin.load("\0virtual:vitehub-sandbox-cloudflare-exports"))
+      .toContain("export class Sandbox extends CloudflareSandbox")
+    expect(rollupPlugin.renderChunk("export default {}", { isEntry: true, fileName: "index.mjs" }).code)
+      .toContain(`export { Sandbox } from './sandbox-cloudflare-exports.mjs'`)
+  })
+
   it("defers generated definition bundling until Vite aliases are resolved", async () => {
     const rootDir = await createViteRoot()
     await mkdir(join(rootDir, "src/lib"), { recursive: true })

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -316,6 +316,39 @@ describe("hubSandbox", () => {
       .rejects.toMatchObject({ code: "ENOENT" })
   })
 
+  it("completes only the required image fields on a partial Cloudflare Sandbox container", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare", name: "generated-name" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const container = {
+      class_name: "Sandbox",
+      instance_type: "standard-1",
+      max_instances: 2,
+      name: "application-owned",
+    }
+    const userConfig = {
+      root: rootDir,
+      plugins: [{ name: "nitro:main" }],
+      nitro: {
+        cloudflare: { wrangler: { containers: [container] } },
+        output: { serverDir: ".output/server" },
+      },
+    }
+
+    await configHook(userConfig, { command: "build", mode: "production" })
+
+    expect(userConfig.nitro.cloudflare.wrangler.containers[0]).toBe(container)
+    expect(userConfig.nitro.cloudflare.wrangler.containers).toEqual([{
+      class_name: "Sandbox",
+      image: "../../.vitehub/sandbox/Dockerfile",
+      image_build_context: "../..",
+      instance_type: "standard-1",
+      max_instances: 2,
+      name: "application-owned",
+    }])
+  })
+
   it("rejects an existing Cloudflare migration tag without changing it", async () => {
     const rootDir = await createViteRoot()
     const { hubSandbox } = await import("../src/vite.ts")

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -210,6 +210,7 @@ describe("hubSandbox", () => {
         alias: [
           { find: "process/", replacement: "/virtual/process" },
           { find: "node:child_process", replacement: "/virtual/child-process" },
+          { find: "#root/", replacement: "/" },
           { find: "@/", replacement: `${join(rootDir, "src")}/` },
         ],
       },
@@ -227,11 +228,12 @@ describe("hubSandbox", () => {
     const plugin = hubSandbox()
     const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
     const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
-    const userConfig = { root: rootDir, nitro: { preset: "cloudflare-module" } }
+    const userConfig = { root: rootDir }
 
     await configHook(userConfig, { command: "build", mode: "production" })
     const resolvedConfig = {
       ...userConfig,
+      nitro: { preset: "cloudflare-module" },
       plugins: [{ name: "nitro:main" }],
       resolve: { alias: [] },
     }

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -250,9 +250,11 @@ describe("hubSandbox", () => {
       name: "image-optimizer",
     })
     const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
+    const existingPlugin = { name: "application-plugin" }
     const userConfig = {
       root: rootDir,
-      plugins: [[{ name: "nitro:main" }]],
+      plugins: [{ name: "nitro:main" }],
       nitro: {
         cloudflare: {
           wrangler: {
@@ -264,17 +266,20 @@ describe("hubSandbox", () => {
         output: {
           serverDir: ".output/server",
         },
+        rollupConfig: { plugins: existingPlugin },
       },
     }
 
     await configHook(userConfig, { command: "build", mode: "production" })
+    userConfig.nitro.output.serverDir = ".nitro/server/output"
+    await configResolved({ ...userConfig, resolve: { alias: [] } })
 
     expect(userConfig.nitro.cloudflare.wrangler).toMatchObject({
       compatibility_flags: ["custom", "nodejs_compat"],
       containers: [{
         class_name: "Sandbox",
-        image: "../../.vitehub/sandbox/Dockerfile",
-        image_build_context: "../..",
+        image: "../../../.vitehub/sandbox/Dockerfile",
+        image_build_context: "../../..",
         instance_type: "lite",
         max_instances: 12,
         name: "image-optimizer",
@@ -300,7 +305,8 @@ describe("hubSandbox", () => {
         }>
       }
     }
-    const [rollupPlugin] = configuredNitro.rollupConfig.plugins
+    expect(configuredNitro.rollupConfig.plugins[0]).toBe(existingPlugin)
+    const rollupPlugin = configuredNitro.rollupConfig.plugins[1]
     expect(rollupPlugin.name).toBe("vitehub-sandbox-cloudflare-exports:Sandbox")
     expect(rollupPlugin.load("\0virtual:vitehub-sandbox-cloudflare-exports"))
       .toContain("export class Sandbox extends CloudflareSandbox")
@@ -313,6 +319,7 @@ describe("hubSandbox", () => {
     const { hubSandbox } = await import("../src/vite.ts")
     const plugin = hubSandbox({ provider: "cloudflare", name: "generated-name" })
     const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
     const container = {
       class_name: "Sandbox",
       image: "./custom.Dockerfile",
@@ -329,6 +336,7 @@ describe("hubSandbox", () => {
     }
 
     await configHook(userConfig, { command: "build", mode: "production" })
+    await configResolved({ ...userConfig, resolve: { alias: [] } })
 
     expect(userConfig.nitro.cloudflare.wrangler.containers[0]).toBe(container)
     expect(userConfig.nitro.cloudflare.wrangler.containers).toEqual([{
@@ -340,6 +348,7 @@ describe("hubSandbox", () => {
     }])
     await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
       .rejects.toMatchObject({ code: "ENOENT" })
+    expect(userConfig.nitro).not.toHaveProperty("rollupConfig")
   })
 
   it("completes only the required image fields on a partial Cloudflare Sandbox container", async () => {
@@ -347,6 +356,7 @@ describe("hubSandbox", () => {
     const { hubSandbox } = await import("../src/vite.ts")
     const plugin = hubSandbox({ provider: "cloudflare", name: "generated-name" })
     const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
     const container = {
       class_name: "Sandbox",
       instance_type: "standard-1",
@@ -363,6 +373,7 @@ describe("hubSandbox", () => {
     }
 
     await configHook(userConfig, { command: "build", mode: "production" })
+    await configResolved({ ...userConfig, resolve: { alias: [] } })
 
     expect(userConfig.nitro.cloudflare.wrangler.containers[0]).toBe(container)
     expect(userConfig.nitro.cloudflare.wrangler.containers).toEqual([{
@@ -380,6 +391,7 @@ describe("hubSandbox", () => {
     const { hubSandbox } = await import("../src/vite.ts")
     const plugin = hubSandbox({ provider: "cloudflare" })
     const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
     const migrations = [{ tag: "v1", new_sqlite_classes: ["Existing"] }]
     const userConfig = {
       root: rootDir,
@@ -389,7 +401,8 @@ describe("hubSandbox", () => {
       },
     }
 
-    await expect(configHook(userConfig, { command: "build", mode: "production" }))
+    await configHook(userConfig, { command: "build", mode: "production" })
+    await expect(configResolved({ ...userConfig, resolve: { alias: [] } }))
       .rejects.toThrow('Cloudflare migration tag "v1" is already in use')
     expect(userConfig.nitro.cloudflare.wrangler).toEqual({
       migrations: [{ tag: "v1", new_sqlite_classes: ["Existing"] }],
@@ -401,6 +414,7 @@ describe("hubSandbox", () => {
     const { hubSandbox } = await import("../src/vite.ts")
     const plugin = hubSandbox({ provider: "cloudflare" })
     const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
     const wrangler = { exports: { Existing: "Existing" } }
     const userConfig = {
       root: rootDir,
@@ -408,9 +422,34 @@ describe("hubSandbox", () => {
       nitro: { cloudflare: { wrangler } },
     }
 
-    await expect(configHook(userConfig, { command: "build", mode: "production" }))
+    await configHook(userConfig, { command: "build", mode: "production" })
+    await expect(configResolved({ ...userConfig, resolve: { alias: [] } }))
       .rejects.toThrow("cannot compose legacy migrations")
     expect(userConfig.nitro.cloudflare.wrangler).toBe(wrangler)
+  })
+
+  it("rejects a colliding Cloudflare Durable Object binding before mutation", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
+    const wrangler = {
+      durable_objects: { bindings: [{ name: "SANDBOX", class_name: "Existing" }] },
+    }
+    const userConfig = {
+      root: rootDir,
+      plugins: [{ name: "nitro:main" }],
+      nitro: { cloudflare: { wrangler } },
+    }
+
+    await configHook(userConfig, { command: "build", mode: "production" })
+    await expect(configResolved({ ...userConfig, resolve: { alias: [] } }))
+      .rejects.toThrow('Cloudflare Durable Object binding "SANDBOX" is already in use')
+    expect(userConfig.nitro.cloudflare.wrangler).toBe(wrangler)
+    expect(wrangler).toEqual({
+      durable_objects: { bindings: [{ name: "SANDBOX", class_name: "Existing" }] },
+    })
   })
 
   it("defers generated definition bundling until Vite aliases are resolved", async () => {

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -242,6 +242,26 @@ describe("hubSandbox", () => {
     expect((resolvedConfig.nitro as any).cloudflare.wrangler.containers).toMatchObject([{ class_name: "Sandbox" }])
   })
 
+  it("infers Cloudflare from the Nitro preset environment", async () => {
+    const rootDir = await createViteRoot()
+    const previousPreset = process.env.NITRO_PRESET
+    process.env.NITRO_PRESET = "cloudflare-module"
+    try {
+      const { hubSandbox } = await import("../src/vite.ts")
+      const plugin = hubSandbox()
+      const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+      const userConfig = { root: rootDir, plugins: [{ name: "nitro:main" }], nitro: {} as Record<string, any> }
+
+      await configHook(userConfig, { command: "build", mode: "production" })
+
+      expect(userConfig.nitro.cloudflare.wrangler.containers).toMatchObject([{ class_name: "Sandbox" }])
+    }
+    finally {
+      if (typeof previousPreset === "undefined") delete process.env.NITRO_PRESET
+      else process.env.NITRO_PRESET = previousPreset
+    }
+  })
+
   it("composes Cloudflare Sandbox into Nitro output", async () => {
     const rootDir = await createViteRoot()
     const { hubSandbox } = await import("../src/vite.ts")
@@ -267,7 +287,7 @@ describe("hubSandbox", () => {
         output: {
           serverDir: ".nitro/server/output",
         },
-        rollupConfig: { plugins: existingPlugin },
+        rollupConfig: { external: "application-runtime", plugins: existingPlugin },
       },
     }
 
@@ -298,6 +318,7 @@ describe("hubSandbox", () => {
 
     const configuredNitro = userConfig.nitro as typeof userConfig.nitro & {
       rollupConfig: {
+        external: unknown
         plugins: Array<{
           load: (id: string) => string
           name: string
@@ -306,12 +327,15 @@ describe("hubSandbox", () => {
       }
     }
     expect(configuredNitro.rollupConfig.plugins[0]).toBe(existingPlugin)
+    expect(configuredNitro.rollupConfig.external).toEqual(["application-runtime", "cloudflare:workers"])
     const rollupPlugin = configuredNitro.rollupConfig.plugins[1]
     expect(rollupPlugin.name).toBe("vitehub-sandbox-cloudflare-exports:Sandbox")
     expect(rollupPlugin.load("\0virtual:vitehub-sandbox-cloudflare-exports"))
       .toContain("export class Sandbox extends CloudflareSandbox")
-    expect(rollupPlugin.renderChunk("export default {}", { isEntry: true, fileName: "index.mjs" }).code)
-      .toContain(`export { Sandbox } from './sandbox-cloudflare-exports.mjs'`)
+    expect(rollupPlugin.load("\0virtual:vitehub-sandbox-cloudflare-exports"))
+      .toContain("export { ContainerProxy } from '@cloudflare/sandbox'")
+    expect(rollupPlugin.renderChunk("export default {}", { isEntry: true, fileName: "server.js" }).code)
+      .toContain(`export { Sandbox, ContainerProxy } from './sandbox-cloudflare-exports.mjs'`)
   })
 
   it("preserves an application-owned Cloudflare Sandbox container", async () => {
@@ -352,10 +376,14 @@ describe("hubSandbox", () => {
     const [rollupPlugin] = (userConfig.nitro as typeof userConfig.nitro & {
       rollupConfig: { plugins: Array<{ renderChunk: (code: string, chunk: { fileName: string, isEntry: boolean }) => unknown }> }
     }).rollupConfig.plugins
-    expect(rollupPlugin.renderChunk("export class Sandbox {}", { isEntry: true, fileName: "index.mjs" })).toBeNull()
-    expect(rollupPlugin.renderChunk("class Worker {}; export { Worker as Sandbox }", { isEntry: true, fileName: "index.mjs" })).toBeNull()
+    expect(rollupPlugin.renderChunk("export class Sandbox {}", { isEntry: true, fileName: "index.mjs" }))
+      .toMatchObject({ code: expect.stringContaining(`export { ContainerProxy } from './sandbox-cloudflare-exports.mjs'`) })
+    expect(rollupPlugin.renderChunk("class Worker {}; export { Worker as Sandbox }", { isEntry: true, fileName: "index.mjs" }))
+      .toMatchObject({ code: expect.stringContaining(`export { ContainerProxy } from './sandbox-cloudflare-exports.mjs'`) })
     expect(rollupPlugin.renderChunk("class Sandbox {}; export { Sandbox as Worker }", { isEntry: true, fileName: "index.mjs" }))
-      .toMatchObject({ code: expect.stringContaining(`export { Sandbox } from './sandbox-cloudflare-exports.mjs'`) })
+      .toMatchObject({ code: expect.stringContaining(`export { Sandbox, ContainerProxy } from './sandbox-cloudflare-exports.mjs'`) })
+    expect(rollupPlugin.renderChunk("export class Sandbox {}; export { ContainerProxy }", { isEntry: true, fileName: "index.mjs" })).toBeNull()
+    expect(rollupPlugin.renderChunk("export default {}", { isEntry: false, fileName: "chunk.mjs" })).toBeNull()
   })
 
   it("rejects conflicting Cloudflare container build contexts", async () => {

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -191,11 +191,13 @@ describe("hubSandbox", () => {
     const rootDir = await createViteRoot()
     await mkdir(join(rootDir, "src/lib"), { recursive: true })
     await writeFile(join(rootDir, "src/lib/version.ts"), `export const version = "from slash alias"\n`)
+    await writeFile(join(rootDir, "src/lib/process.ts"), `export const processAlias = "from process slash alias"\n`)
     await writeFile(join(rootDir, "src/tools/release-notes.sandbox.ts"), [
       `import { execFileSync } from "node:child_process"`,
       `import { version } from "@/lib/version"`,
+      `import { processAlias } from "process/"`,
       ``,
-      `export default defineSandbox(async () => ({ version, node: execFileSync(process.execPath, ["--version"]).toString() }))`,
+      `export default defineSandbox(async () => ({ processAlias, version, node: execFileSync(process.execPath, ["--version"]).toString() }))`,
       ``,
     ].join("\n"))
     const { hubSandbox } = await import("../src/vite.ts")
@@ -208,7 +210,7 @@ describe("hubSandbox", () => {
       root: rootDir,
       resolve: {
         alias: [
-          { find: "process/", replacement: "/virtual/process" },
+          { find: "process/", replacement: join(rootDir, "src/lib/process.ts") },
           { find: "node:child_process", replacement: "/virtual/child-process" },
           { find: "#root/", replacement: "/" },
           { find: "@/", replacement: `${join(rootDir, "src")}/` },
@@ -220,6 +222,7 @@ describe("hubSandbox", () => {
     expect(definition).toContain("node:child_process")
     expect(definition).not.toContain("/virtual/child-process")
     expect(definition).toContain("from slash alias")
+    expect(definition).toContain("from process slash alias")
   })
 
   it("infers Cloudflare from a late-resolved Nitro preset", async () => {
@@ -292,14 +295,16 @@ describe("hubSandbox", () => {
     }
 
     await configHook(userConfig, { command: "build", mode: "production" })
+    expect(userConfig.nitro.cloudflare.wrangler.containers[0].image).toBe("../../../.vitehub/sandbox/Dockerfile")
+    userConfig.nitro.output.serverDir = ".nitro/server/final/output"
     await configResolved({ ...userConfig, resolve: { alias: [] } })
 
     expect(userConfig.nitro.cloudflare.wrangler).toMatchObject({
       compatibility_flags: ["custom", "nodejs_compat"],
       containers: [{
         class_name: "Sandbox",
-        image: "../../../.vitehub/sandbox/Dockerfile",
-        image_build_context: "../../..",
+        image: "../../../../.vitehub/sandbox/Dockerfile",
+        image_build_context: "../../../..",
         instance_type: "lite",
         max_instances: 12,
         name: "image-optimizer",
@@ -335,7 +340,9 @@ describe("hubSandbox", () => {
     expect(rollupPlugin.load("\0virtual:vitehub-sandbox-cloudflare-exports"))
       .toContain("export { ContainerProxy } from '@cloudflare/sandbox'")
     expect(rollupPlugin.renderChunk("export default {}", { isEntry: true, fileName: "server.js" }).code)
-      .toContain(`export { Sandbox, ContainerProxy } from './sandbox-cloudflare-exports.mjs'`)
+      .toContain(`export { Sandbox, ContainerProxy } from "./sandbox-cloudflare-exports.mjs"`)
+    expect(rollupPlugin.renderChunk("export default {}", { isEntry: true, fileName: "entries/server.js" }).code)
+      .toContain(`export { Sandbox, ContainerProxy } from "../sandbox-cloudflare-exports.mjs"`)
   })
 
   it("preserves an application-owned Cloudflare Sandbox container", async () => {
@@ -377,13 +384,25 @@ describe("hubSandbox", () => {
       rollupConfig: { plugins: Array<{ renderChunk: (code: string, chunk: { fileName: string, isEntry: boolean }) => unknown }> }
     }).rollupConfig.plugins
     expect(rollupPlugin.renderChunk("export class Sandbox {}", { isEntry: true, fileName: "index.mjs" }))
-      .toMatchObject({ code: expect.stringContaining(`export { ContainerProxy } from './sandbox-cloudflare-exports.mjs'`) })
+      .toMatchObject({ code: expect.stringContaining(`export { ContainerProxy } from "./sandbox-cloudflare-exports.mjs"`) })
     expect(rollupPlugin.renderChunk("class Worker {}; export { Worker as Sandbox }", { isEntry: true, fileName: "index.mjs" }))
-      .toMatchObject({ code: expect.stringContaining(`export { ContainerProxy } from './sandbox-cloudflare-exports.mjs'`) })
+      .toMatchObject({ code: expect.stringContaining(`export { ContainerProxy } from "./sandbox-cloudflare-exports.mjs"`) })
     expect(rollupPlugin.renderChunk("class Sandbox {}; export { Sandbox as Worker }", { isEntry: true, fileName: "index.mjs" }))
-      .toMatchObject({ code: expect.stringContaining(`export { Sandbox, ContainerProxy } from './sandbox-cloudflare-exports.mjs'`) })
+      .toMatchObject({ code: expect.stringContaining(`export { Sandbox, ContainerProxy } from "./sandbox-cloudflare-exports.mjs"`) })
     expect(rollupPlugin.renderChunk("export class Sandbox {}; export { ContainerProxy }", { isEntry: true, fileName: "index.mjs" })).toBeNull()
+    expect(rollupPlugin.renderChunk("export * from './sandbox.mjs'", { isEntry: true, fileName: "index.mjs" })).toBeNull()
     expect(rollupPlugin.renderChunk("export default {}", { isEntry: false, fileName: "chunk.mjs" })).toBeNull()
+  })
+
+  it("rejects ContainerProxy as the Cloudflare Sandbox class name", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare", className: "ContainerProxy" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const userConfig = { root: rootDir, plugins: [{ name: "nitro:main" }], nitro: { preset: "cloudflare-module" } }
+
+    await expect(configHook(userConfig, { command: "build", mode: "production" }))
+      .rejects.toThrow('className "ContainerProxy" is reserved')
   })
 
   it("rejects conflicting Cloudflare container build contexts", async () => {

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -354,6 +354,25 @@ describe("hubSandbox", () => {
     }).rollupConfig.plugins
     expect(rollupPlugin.renderChunk("export class Sandbox {}", { isEntry: true, fileName: "index.mjs" })).toBeNull()
     expect(rollupPlugin.renderChunk("class Worker {}; export { Worker as Sandbox }", { isEntry: true, fileName: "index.mjs" })).toBeNull()
+    expect(rollupPlugin.renderChunk("class Sandbox {}; export { Sandbox as Worker }", { isEntry: true, fileName: "index.mjs" }))
+      .toMatchObject({ code: expect.stringContaining(`export { Sandbox } from './sandbox-cloudflare-exports.mjs'`) })
+  })
+
+  it("rejects conflicting Cloudflare container build contexts", async () => {
+    const { finalizeCloudflareWranglerConfig } = await import("../src/internal/shared/cloudflare-wrangler.ts")
+    const target = {
+      cloudflare: {
+        wrangler: {
+          containers: [
+            { class_name: "Sandbox", image: "./Dockerfile", image_build_context: "../app" },
+            { class_name: "Sandbox", image: "./Dockerfile", image_build_context: "../sandbox" },
+          ],
+        },
+      },
+    }
+
+    expect(() => finalizeCloudflareWranglerConfig(target))
+      .toThrow('Conflicting Cloudflare container "Sandbox"')
   })
 
   it("completes only the required image fields on a partial Cloudflare Sandbox container", async () => {

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -189,10 +189,13 @@ describe("hubSandbox", () => {
 
   it("keeps Node built-ins out of definition bundle aliases", async () => {
     const rootDir = await createViteRoot()
+    await mkdir(join(rootDir, "src/lib"), { recursive: true })
+    await writeFile(join(rootDir, "src/lib/version.ts"), `export const version = "from slash alias"\n`)
     await writeFile(join(rootDir, "src/tools/release-notes.sandbox.ts"), [
       `import { execFileSync } from "node:child_process"`,
+      `import { version } from "@/lib/version"`,
       ``,
-      `export default defineSandbox(async () => ({ version: execFileSync(process.execPath, ["--version"]).toString() }))`,
+      `export default defineSandbox(async () => ({ version, node: execFileSync(process.execPath, ["--version"]).toString() }))`,
       ``,
     ].join("\n"))
     const { hubSandbox } = await import("../src/vite.ts")
@@ -207,6 +210,7 @@ describe("hubSandbox", () => {
         alias: [
           { find: "process/", replacement: "/virtual/process" },
           { find: "node:child_process", replacement: "/virtual/child-process" },
+          { find: "@/", replacement: `${join(rootDir, "src")}/` },
         ],
       },
     })
@@ -214,6 +218,26 @@ describe("hubSandbox", () => {
     const definition = await readFile(join(rootDir, ".vitehub/sandbox/runtime/sandbox-definitions/tools__release-notes.mjs"), "utf8")
     expect(definition).toContain("node:child_process")
     expect(definition).not.toContain("/virtual/child-process")
+    expect(definition).toContain("from slash alias")
+  })
+
+  it("infers Cloudflare from a late-resolved Nitro preset", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox()
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
+    const userConfig = { root: rootDir, nitro: { preset: "cloudflare-module" } }
+
+    await configHook(userConfig, { command: "build", mode: "production" })
+    const resolvedConfig = {
+      ...userConfig,
+      plugins: [{ name: "nitro:main" }],
+      resolve: { alias: [] },
+    }
+    await configResolved(resolvedConfig)
+
+    expect((resolvedConfig.nitro as any).cloudflare.wrangler.containers).toMatchObject([{ class_name: "Sandbox" }])
   })
 
   it("composes Cloudflare Sandbox into Nitro output", async () => {
@@ -368,6 +392,23 @@ describe("hubSandbox", () => {
     expect(userConfig.nitro.cloudflare.wrangler).toEqual({
       migrations: [{ tag: "v1", new_sqlite_classes: ["Existing"] }],
     })
+  })
+
+  it("rejects Wrangler exports before adding legacy migrations", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const wrangler = { exports: { Existing: "Existing" } }
+    const userConfig = {
+      root: rootDir,
+      plugins: [{ name: "nitro:main" }],
+      nitro: { cloudflare: { wrangler } },
+    }
+
+    await expect(configHook(userConfig, { command: "build", mode: "production" }))
+      .rejects.toThrow("cannot compose legacy migrations")
+    expect(userConfig.nitro.cloudflare.wrangler).toBe(wrangler)
   })
 
   it("defers generated definition bundling until Vite aliases are resolved", async () => {

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -295,7 +295,7 @@ describe("hubSandbox", () => {
     }
 
     await configHook(userConfig, { command: "build", mode: "production" })
-    expect(userConfig.nitro.cloudflare.wrangler.containers[0].image).toBe("../../../.vitehub/sandbox/Dockerfile")
+    expect((userConfig.nitro.cloudflare.wrangler as any).containers[0].image).toBe("../../../.vitehub/sandbox/Dockerfile")
     userConfig.nitro.output.serverDir = ".nitro/server/final/output"
     await configResolved({ ...userConfig, resolve: { alias: [] } })
 

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -231,7 +231,7 @@ describe("hubSandbox", () => {
         cloudflare: {
           wrangler: {
             compatibility_flags: ["custom"],
-            migrations: [{ tag: "v1", new_sqlite_classes: ["Existing"] }],
+            migrations: [{ tag: "existing", new_sqlite_classes: ["Existing"] }],
             routes: ["example.com/*"],
           },
         },
@@ -256,7 +256,10 @@ describe("hubSandbox", () => {
       durable_objects: {
         bindings: [{ name: "SANDBOX", class_name: "Sandbox" }],
       },
-      migrations: [{ tag: "v1", new_sqlite_classes: ["Existing", "Sandbox"] }],
+      migrations: [
+        { tag: "existing", new_sqlite_classes: ["Existing"] },
+        { tag: "v1", new_sqlite_classes: ["Sandbox"] },
+      ],
       routes: ["example.com/*"],
     })
     await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
@@ -277,6 +280,61 @@ describe("hubSandbox", () => {
       .toContain("export class Sandbox extends CloudflareSandbox")
     expect(rollupPlugin.renderChunk("export default {}", { isEntry: true, fileName: "index.mjs" }).code)
       .toContain(`export { Sandbox } from './sandbox-cloudflare-exports.mjs'`)
+  })
+
+  it("preserves an application-owned Cloudflare Sandbox container", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare", name: "generated-name" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const container = {
+      class_name: "Sandbox",
+      image: "./custom.Dockerfile",
+      instance_type: "standard-1",
+      max_instances: 2,
+      name: "application-owned",
+    }
+    const userConfig = {
+      root: rootDir,
+      plugins: [{ name: "nitro:main" }],
+      nitro: {
+        cloudflare: { wrangler: { containers: [container] } },
+      },
+    }
+
+    await configHook(userConfig, { command: "build", mode: "production" })
+
+    expect(userConfig.nitro.cloudflare.wrangler.containers[0]).toBe(container)
+    expect(userConfig.nitro.cloudflare.wrangler.containers).toEqual([{
+      class_name: "Sandbox",
+      image: "./custom.Dockerfile",
+      instance_type: "standard-1",
+      max_instances: 2,
+      name: "application-owned",
+    }])
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
+      .rejects.toMatchObject({ code: "ENOENT" })
+  })
+
+  it("rejects an existing Cloudflare migration tag without changing it", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const migrations = [{ tag: "v1", new_sqlite_classes: ["Existing"] }]
+    const userConfig = {
+      root: rootDir,
+      plugins: [{ name: "nitro:main" }],
+      nitro: {
+        cloudflare: { wrangler: { migrations } },
+      },
+    }
+
+    await expect(configHook(userConfig, { command: "build", mode: "production" }))
+      .rejects.toThrow('Cloudflare migration tag "v1" is already in use')
+    expect(userConfig.nitro.cloudflare.wrangler).toEqual({
+      migrations: [{ tag: "v1", new_sqlite_classes: ["Existing"] }],
+    })
   })
 
   it("defers generated definition bundling until Vite aliases are resolved", async () => {

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -222,7 +222,7 @@ describe("hubSandbox", () => {
     expect(definition).toContain("node:child_process")
     expect(definition).not.toContain("/virtual/child-process")
     expect(definition).toContain("from slash alias")
-    expect(definition).toContain("from process slash alias")
+    expect(definition).not.toContain("from process slash alias")
   })
 
   it("infers Cloudflare from a late-resolved Nitro preset", async () => {
@@ -327,7 +327,7 @@ describe("hubSandbox", () => {
         plugins: Array<{
           load: (id: string) => string
           name: string
-          renderChunk: (code: string, chunk: { fileName: string, isEntry: boolean }) => { code: string }
+          renderChunk: (code: string, chunk: { exports: string[], fileName: string, isEntry: boolean }) => { code: string }
         }>
       }
     }
@@ -339,9 +339,9 @@ describe("hubSandbox", () => {
       .toContain("export class Sandbox extends CloudflareSandbox")
     expect(rollupPlugin.load("\0virtual:vitehub-sandbox-cloudflare-exports"))
       .toContain("export { ContainerProxy } from '@cloudflare/sandbox'")
-    expect(rollupPlugin.renderChunk("export default {}", { isEntry: true, fileName: "server.js" }).code)
+    expect(rollupPlugin.renderChunk("export default {}", { exports: ["default"], isEntry: true, fileName: "server.js" }).code)
       .toContain(`export { Sandbox, ContainerProxy } from "./sandbox-cloudflare-exports.mjs"`)
-    expect(rollupPlugin.renderChunk("export default {}", { isEntry: true, fileName: "entries/server.js" }).code)
+    expect(rollupPlugin.renderChunk("export default {}", { exports: ["default"], isEntry: true, fileName: "entries/server.js" }).code)
       .toContain(`export { Sandbox, ContainerProxy } from "../sandbox-cloudflare-exports.mjs"`)
   })
 
@@ -381,17 +381,19 @@ describe("hubSandbox", () => {
     await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
       .rejects.toMatchObject({ code: "ENOENT" })
     const [rollupPlugin] = (userConfig.nitro as typeof userConfig.nitro & {
-      rollupConfig: { plugins: Array<{ renderChunk: (code: string, chunk: { fileName: string, isEntry: boolean }) => unknown }> }
+      rollupConfig: { plugins: Array<{ renderChunk: (code: string, chunk: { exports: string[], fileName: string, isEntry: boolean }) => unknown }> }
     }).rollupConfig.plugins
-    expect(rollupPlugin.renderChunk("export class Sandbox {}", { isEntry: true, fileName: "index.mjs" }))
+    expect(rollupPlugin.renderChunk("export class Sandbox {}", { exports: ["Sandbox"], isEntry: true, fileName: "index.mjs" }))
       .toMatchObject({ code: expect.stringContaining(`export { ContainerProxy } from "./sandbox-cloudflare-exports.mjs"`) })
-    expect(rollupPlugin.renderChunk("class Worker {}; export { Worker as Sandbox }", { isEntry: true, fileName: "index.mjs" }))
+    expect(rollupPlugin.renderChunk("class Worker {}; export { Worker as Sandbox }", { exports: ["Sandbox"], isEntry: true, fileName: "index.mjs" }))
       .toMatchObject({ code: expect.stringContaining(`export { ContainerProxy } from "./sandbox-cloudflare-exports.mjs"`) })
-    expect(rollupPlugin.renderChunk("class Sandbox {}; export { Sandbox as Worker }", { isEntry: true, fileName: "index.mjs" }))
+    expect(rollupPlugin.renderChunk("class Sandbox {}; export { Sandbox as Worker }", { exports: ["Worker"], isEntry: true, fileName: "index.mjs" }))
       .toMatchObject({ code: expect.stringContaining(`export { Sandbox, ContainerProxy } from "./sandbox-cloudflare-exports.mjs"`) })
-    expect(rollupPlugin.renderChunk("export class Sandbox {}; export { ContainerProxy }", { isEntry: true, fileName: "index.mjs" })).toBeNull()
-    expect(rollupPlugin.renderChunk("export * from './sandbox.mjs'", { isEntry: true, fileName: "index.mjs" })).toBeNull()
-    expect(rollupPlugin.renderChunk("export default {}", { isEntry: false, fileName: "chunk.mjs" })).toBeNull()
+    expect(rollupPlugin.renderChunk("export class Sandbox {}; export { ContainerProxy }", { exports: ["Sandbox", "ContainerProxy"], isEntry: true, fileName: "index.mjs" })).toBeNull()
+    expect(rollupPlugin.renderChunk("export * from './sandbox.mjs'", { exports: ["Other"], isEntry: true, fileName: "index.mjs" }))
+      .toMatchObject({ code: expect.stringContaining(`export { Sandbox, ContainerProxy }`) })
+    expect(rollupPlugin.renderChunk("export * from './sandbox.mjs'", { exports: ["Sandbox", "ContainerProxy"], isEntry: true, fileName: "index.mjs" })).toBeNull()
+    expect(rollupPlugin.renderChunk("export default {}", { exports: ["default"], isEntry: false, fileName: "chunk.mjs" })).toBeNull()
   })
 
   it("rejects ContainerProxy as the Cloudflare Sandbox class name", async () => {
@@ -456,6 +458,21 @@ describe("hubSandbox", () => {
       max_instances: 2,
       name: "application-owned",
     }])
+  })
+
+  it("completes partial containers configured without Nitro", async () => {
+    const { configureCloudflareSandbox } = await import("../src/cloudflare.ts")
+    const container = { class_name: "Sandbox", instance_type: "standard-1" }
+    const target = { cloudflare: { wrangler: { containers: [container] } } }
+
+    configureCloudflareSandbox(target)
+
+    expect(container).toEqual({
+      class_name: "Sandbox",
+      image: "./Dockerfile",
+      instance_type: "standard-1",
+      max_instances: 12,
+    })
   })
 
   it("rejects an existing Cloudflare migration tag without changing it", async () => {
@@ -554,6 +571,33 @@ describe("hubSandbox", () => {
     await configResolved(resolvedConfig)
 
     expect(resolvedConfig.nitro).toEqual({ preset: "vercel" })
+  })
+
+  it("removes early environment-selected Cloudflare output when Nitro resolves away", async () => {
+    const rootDir = await createViteRoot()
+    const previousPreset = process.env.NITRO_PRESET
+    process.env.NITRO_PRESET = "cloudflare-module"
+    try {
+      const { hubSandbox } = await import("../src/vite.ts")
+      const plugin = hubSandbox({ provider: "cloudflare" })
+      const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+      const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
+      const nitro: Record<string, any> = {}
+      const userConfig = { root: rootDir, plugins: [{ name: "nitro:main" }], nitro }
+
+      await configHook(userConfig, { command: "build", mode: "production" })
+      expect(nitro.cloudflare.wrangler.containers).toHaveLength(1)
+
+      const resolvedConfig = { ...userConfig, nitro: { preset: "vercel" }, resolve: { alias: [] } }
+      await configResolved(resolvedConfig)
+
+      expect(nitro).toEqual({})
+      expect(resolvedConfig.nitro).toEqual({ preset: "vercel" })
+    }
+    finally {
+      if (typeof previousPreset === "undefined") delete process.env.NITRO_PRESET
+      else process.env.NITRO_PRESET = previousPreset
+    }
   })
 
   it("does not reuse an application Dockerfile for the generated Sandbox image", async () => {

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -256,6 +256,7 @@ describe("hubSandbox", () => {
       root: rootDir,
       plugins: [{ name: "nitro:main" }],
       nitro: {
+        preset: "cloudflare-module",
         cloudflare: {
           wrangler: {
             compatibility_flags: ["custom"],
@@ -264,14 +265,13 @@ describe("hubSandbox", () => {
           },
         },
         output: {
-          serverDir: ".output/server",
+          serverDir: ".nitro/server/output",
         },
         rollupConfig: { plugins: existingPlugin },
       },
     }
 
     await configHook(userConfig, { command: "build", mode: "production" })
-    userConfig.nitro.output.serverDir = ".nitro/server/output"
     await configResolved({ ...userConfig, resolve: { alias: [] } })
 
     expect(userConfig.nitro.cloudflare.wrangler).toMatchObject({
@@ -331,6 +331,7 @@ describe("hubSandbox", () => {
       root: rootDir,
       plugins: [{ name: "nitro:main" }],
       nitro: {
+        preset: "cloudflare-module",
         cloudflare: { wrangler: { containers: [container] } },
       },
     }
@@ -348,7 +349,11 @@ describe("hubSandbox", () => {
     }])
     await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
       .rejects.toMatchObject({ code: "ENOENT" })
-    expect(userConfig.nitro).not.toHaveProperty("rollupConfig")
+    const [rollupPlugin] = (userConfig.nitro as typeof userConfig.nitro & {
+      rollupConfig: { plugins: Array<{ renderChunk: (code: string, chunk: { fileName: string, isEntry: boolean }) => unknown }> }
+    }).rollupConfig.plugins
+    expect(rollupPlugin.renderChunk("export class Sandbox {}", { isEntry: true, fileName: "index.mjs" })).toBeNull()
+    expect(rollupPlugin.renderChunk("class Worker {}; export { Worker as Sandbox }", { isEntry: true, fileName: "index.mjs" })).toBeNull()
   })
 
   it("completes only the required image fields on a partial Cloudflare Sandbox container", async () => {
@@ -367,6 +372,7 @@ describe("hubSandbox", () => {
       root: rootDir,
       plugins: [{ name: "nitro:main" }],
       nitro: {
+        preset: "cloudflare-module",
         cloudflare: { wrangler: { containers: [container] } },
         output: { serverDir: ".output/server" },
       },
@@ -391,18 +397,17 @@ describe("hubSandbox", () => {
     const { hubSandbox } = await import("../src/vite.ts")
     const plugin = hubSandbox({ provider: "cloudflare" })
     const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
-    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
     const migrations = [{ tag: "v1", new_sqlite_classes: ["Existing"] }]
     const userConfig = {
       root: rootDir,
       plugins: [{ name: "nitro:main" }],
       nitro: {
+        preset: "cloudflare-module",
         cloudflare: { wrangler: { migrations } },
       },
     }
 
-    await configHook(userConfig, { command: "build", mode: "production" })
-    await expect(configResolved({ ...userConfig, resolve: { alias: [] } }))
+    await expect(configHook(userConfig, { command: "build", mode: "production" }))
       .rejects.toThrow('Cloudflare migration tag "v1" is already in use')
     expect(userConfig.nitro.cloudflare.wrangler).toEqual({
       migrations: [{ tag: "v1", new_sqlite_classes: ["Existing"] }],
@@ -414,16 +419,14 @@ describe("hubSandbox", () => {
     const { hubSandbox } = await import("../src/vite.ts")
     const plugin = hubSandbox({ provider: "cloudflare" })
     const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
-    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
     const wrangler = { exports: { Existing: "Existing" } }
     const userConfig = {
       root: rootDir,
       plugins: [{ name: "nitro:main" }],
-      nitro: { cloudflare: { wrangler } },
+      nitro: { preset: "cloudflare-module", cloudflare: { wrangler } },
     }
 
-    await configHook(userConfig, { command: "build", mode: "production" })
-    await expect(configResolved({ ...userConfig, resolve: { alias: [] } }))
+    await expect(configHook(userConfig, { command: "build", mode: "production" }))
       .rejects.toThrow("cannot compose legacy migrations")
     expect(userConfig.nitro.cloudflare.wrangler).toBe(wrangler)
   })
@@ -433,23 +436,77 @@ describe("hubSandbox", () => {
     const { hubSandbox } = await import("../src/vite.ts")
     const plugin = hubSandbox({ provider: "cloudflare" })
     const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
-    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
     const wrangler = {
       durable_objects: { bindings: [{ name: "SANDBOX", class_name: "Existing" }] },
     }
     const userConfig = {
       root: rootDir,
       plugins: [{ name: "nitro:main" }],
-      nitro: { cloudflare: { wrangler } },
+      nitro: { preset: "cloudflare-module", cloudflare: { wrangler } },
     }
 
-    await configHook(userConfig, { command: "build", mode: "production" })
-    await expect(configResolved({ ...userConfig, resolve: { alias: [] } }))
+    await expect(configHook(userConfig, { command: "build", mode: "production" }))
       .rejects.toThrow('Cloudflare Durable Object binding "SANDBOX" is already in use')
     expect(userConfig.nitro.cloudflare.wrangler).toBe(wrangler)
     expect(wrangler).toEqual({
       durable_objects: { bindings: [{ name: "SANDBOX", class_name: "Existing" }] },
     })
+  })
+
+  it("does not compose Cloudflare output for a non-Cloudflare Nitro host", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const userConfig = {
+      root: rootDir,
+      plugins: [{ name: "nitro:main" }],
+      nitro: { preset: "vercel" },
+    }
+
+    await configHook(userConfig, { command: "build", mode: "production" })
+
+    expect(userConfig.nitro).toEqual({ preset: "vercel" })
+  })
+
+  it("keeps a late-resolved non-Cloudflare Nitro preset authoritative", async () => {
+    const rootDir = await createViteRoot()
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
+    const userConfig = {
+      root: rootDir,
+      plugins: [{ name: "nitro:main" }],
+      nitro: {},
+    }
+
+    await configHook(userConfig, { command: "build", mode: "production" })
+    expect(userConfig.nitro).toEqual({})
+
+    const resolvedConfig = { ...userConfig, nitro: { preset: "vercel" }, resolve: { alias: [] } }
+    await configResolved(resolvedConfig)
+
+    expect(resolvedConfig.nitro).toEqual({ preset: "vercel" })
+  })
+
+  it("does not reuse an application Dockerfile for the generated Sandbox image", async () => {
+    const rootDir = await createViteRoot()
+    await writeFile(join(rootDir, "Dockerfile"), "FROM node:24\n")
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const userConfig = {
+      root: rootDir,
+      plugins: [{ name: "nitro:main" }],
+      nitro: { preset: "cloudflare-module" },
+    }
+
+    await configHook(userConfig, { command: "build", mode: "production" })
+
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
+      .resolves.toMatch(/^FROM docker\.io\/cloudflare\/sandbox:/)
+    await expect(readFile(join(rootDir, "Dockerfile"), "utf8")).resolves.toBe("FROM node:24\n")
   })
 
   it("defers generated definition bundling until Vite aliases are resolved", async () => {


### PR DESCRIPTION
Composes the Cloudflare Sandbox plan into Nitro-owned Worker output, so `hubSandbox()` now uses the installed Sandbox SDK version for generated Dockerfiles, registers the container, Durable Object binding and migration, enables `nodejs_compat`, and exports the Sandbox class from the server entry. Application-owned container image fields remain authoritative; generated images never reuse an unrelated application Dockerfile, existing migration tags are never rewritten, and colliding Sandbox migration tags or Durable Object binding names fail with actionable configuration errors.

Known Cloudflare Nitro targets are composed before Nitro snapshots its config, while unresolved hosting is re-evaluated from the final resolved preset so a late non-Cloudflare preset remains authoritative. Existing single Rollup plugins are preserved, and an application-exported Sandbox class is not exported twice. Resolved aliases preserve replacement paths, while Node built-ins and builtin-shaped slash aliases stay out of definition bundling. The internal and Sandbox package verification covers the composed Cloudflare output and alias behavior.