### PR TITLE
fix(blob): restore content type detection

### DIFF
--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -29,6 +29,7 @@ composition and explicit feature subpaths for application APIs.
 | `vite-hub/auth` and `vite-hub/auth/server` | Auth Definitions and server runtime helpers. |
 | `vite-hub/auth/agent` | Better Auth session mapping into Agent Invokers. |
 | `vite-hub/blob` | Blob Runtime Helpers and Blob Store access. |
+| `vite-hub/blob/content-type` | Detect common image and PDF signatures from leading bytes before upload. |
 | `vite-hub/box` | Box Definitions and trusted-host execution contracts. |
 | `vite-hub/box/crabbox` | Crabbox-backed Box runtime. |
 | `vite-hub/database` and `vite-hub/database/drizzle` | Database Definitions and generated Drizzle access. |
@@ -77,6 +78,7 @@ for libraries, focused integrations, and advanced composition.
 | `@vite-hub/auth` | Auth Package | Auth Definition helpers. |
 | `@vite-hub/auth/server` | Auth Package | Better Auth runtime creation, request handlers, and session access for manual host integration. |
 | `@vite-hub/blob` | Blob Package | Blob Runtime Helpers and Blob Store access. |
+| `@vite-hub/blob/content-type` | Blob Package | Detect common image and PDF signatures from leading bytes before upload. |
 | `@vite-hub/email` | Email Package | Email Definition, explicit clients, portable types, and normalized errors. |
 | `@vite-hub/email/server` | Email Runtime | Server-only discovered `email` Runtime Helper. |
 | `@vite-hub/email/drivers/smtp` | Email Package | Optional Node.js SMTP delivery through Nodemailer. |

--- a/docs/content/docs/server-primitives/blob.md
+++ b/docs/content/docs/server-primitives/blob.md
@@ -47,12 +47,15 @@ export default defineEventHandler(async () => {
 | Import | Use |
 | --- | --- |
 | `blob` from `@vite-hub/blob` | Read and write the Default Blob Store or named Blob Stores. |
+| `detectContentType` from `vite-hub/blob/content-type` or `@vite-hub/blob/content-type` | Classify common image and PDF signatures before storage. |
 | `ensureBlob` from `@vite-hub/blob` or `@vite-hub/blob/ensure` | Validate upload size and content type. |
 | `hubBlob` from `@vite-hub/blob/vite` | Register Blob runtime configuration and Provider Output. |
 | `resolveBlobViteConfig` from `@vite-hub/blob/vite` | Resolve Blob Vite runtime config manually. |
 | `@vite-hub/blob/drivers/*` | Import provider-specific Blob Driver Modules. |
 
 All Blob driver, object, list, put, store, and module types are exported from `@vite-hub/blob`.
+
+Content detection is explicit: Blob writes preserve caller-provided metadata, and recognizing a leading signature does not prove that the complete file is valid or safe.
 
 ## Store configuration
 

--- a/packages/blob/README.md
+++ b/packages/blob/README.md
@@ -58,6 +58,15 @@ Set `blob.serve` to generate a Nitro route for serving Blob-backed assets. `serv
 Objects from the served store receive an absolute URL when `serve.publicBaseUrl` is configured, or a route-relative URL otherwise.
 Use `serve.headers` for static cache and security headers. Blob metadata remains authoritative for content headers such as `Content-Type`, `Content-Length`, and `ETag`.
 
+Use `detectContentType()` when an application needs to classify leading bytes before storage. It returns a detected MIME type for common images and PDFs, or `undefined` when the signature is unknown. Storage `contentType` remains caller-provided metadata, and recognizing a signature does not prove that a complete file is valid or safe.
+
+```ts
+import { detectContentType } from "@vite-hub/blob/content-type"
+
+const detected = detectContentType(new Uint8Array(await file.arrayBuffer()))
+if (detected !== file.type) throw new Error("File content does not match its declared type")
+```
+
 ```ts
 // vite.config.ts
 export default defineConfig({

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -29,6 +29,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./config": "./dist/config.js",
+    "./content-type": "./dist/content-type.js",
     "./drivers/akamai": "./dist/drivers/akamai.js",
     "./drivers/azure": "./dist/drivers/azure.js",
     "./drivers/box": "./dist/drivers/box.js",

--- a/packages/blob/src/content-type.ts
+++ b/packages/blob/src/content-type.ts
@@ -1,0 +1,28 @@
+interface ContentTypeSignature {
+  segments: Array<[offset: number, bytes: number[]]>
+  type: string
+}
+
+const signatures: ContentTypeSignature[] = [
+  { segments: [[0, [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]]], type: "image/png" },
+  { segments: [[0, [0xFF, 0xD8, 0xFF]]], type: "image/jpeg" },
+  { segments: [[0, [0x47, 0x49, 0x46, 0x38, 0x37, 0x61]]], type: "image/gif" },
+  { segments: [[0, [0x47, 0x49, 0x46, 0x38, 0x39, 0x61]]], type: "image/gif" },
+  { segments: [[0, [0x42, 0x4D]]], type: "image/bmp" },
+  { segments: [[0, [0x52, 0x49, 0x46, 0x46]], [8, [0x57, 0x45, 0x42, 0x50]]], type: "image/webp" },
+  { segments: [[0, [0x49, 0x49, 0x2A, 0x00]]], type: "image/tiff" },
+  { segments: [[0, [0x4D, 0x4D, 0x00, 0x2A]]], type: "image/tiff" },
+  { segments: [[0, [0x00, 0x00, 0x01, 0x00]]], type: "image/x-icon" },
+  { segments: [[0, [0x25, 0x50, 0x44, 0x46, 0x2D]]], type: "application/pdf" },
+]
+
+function matchesAt(bytes: Uint8Array, offset: number, signature: number[]): boolean {
+  if (offset + signature.length > bytes.length) return false
+  return signature.every((byte, index) => bytes[offset + index] === byte)
+}
+
+export function detectContentType(bytes: Uint8Array): string | undefined {
+  return signatures.find(signature => signature.segments.every(
+    ([offset, segment]) => matchesAt(bytes, offset, segment),
+  ))?.type
+}

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -315,6 +315,7 @@ function createCloudflareOutput(blob: BlobModuleOptions | ResolvedBlobModuleOpti
     bundleEntry: artifacts.cloudflareWorkerFile,
     bundleOptions: {
       alias: {
+        "@vite-hub/blob/content-type": resolveRuntimeModule("content-type"),
         "@vite-hub/blob": artifacts.runtimeModuleFiles.cloudflare,
         ...(databaseRuntime ? { "@vite-hub/database/drizzle": databaseRuntime } : {}),
       },
@@ -404,6 +405,7 @@ function createVercelOutput(
     bundleEntry: artifacts.vercelServerFile,
     bundleOptions: {
       alias: {
+        "@vite-hub/blob/content-type": resolveRuntimeModule("content-type"),
         "@vite-hub/blob": artifacts.runtimeModuleFiles.vercel,
         ...(databaseRuntime ? { "@vite-hub/database/drizzle": databaseRuntime } : {}),
       },

--- a/packages/blob/test/content-type.test.ts
+++ b/packages/blob/test/content-type.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest"
+
+import { detectContentType } from "../src/content-type.ts"
+
+describe("detectContentType", () => {
+  it.each([
+    ["PNG", [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A], "image/png"],
+    ["JPEG", [0xFF, 0xD8, 0xFF], "image/jpeg"],
+    ["GIF87a", [0x47, 0x49, 0x46, 0x38, 0x37, 0x61], "image/gif"],
+    ["GIF89a", [0x47, 0x49, 0x46, 0x38, 0x39, 0x61], "image/gif"],
+    ["BMP", [0x42, 0x4D], "image/bmp"],
+    ["WebP", [0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x45, 0x42, 0x50], "image/webp"],
+    ["little-endian TIFF", [0x49, 0x49, 0x2A, 0x00], "image/tiff"],
+    ["big-endian TIFF", [0x4D, 0x4D, 0x00, 0x2A], "image/tiff"],
+    ["ICO", [0x00, 0x00, 0x01, 0x00], "image/x-icon"],
+    ["PDF", [0x25, 0x50, 0x44, 0x46, 0x2D], "application/pdf"],
+  ])("detects %s", (_, input, expected) => {
+    expect(detectContentType(Uint8Array.from(input))).toBe(expected)
+  })
+
+  it("returns undefined for unknown or truncated content", () => {
+    expect(detectContentType(Uint8Array.from([0x89, 0x50]))).toBeUndefined()
+    expect(detectContentType(new TextEncoder().encode("<svg></svg>"))).toBeUndefined()
+  })
+})

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -203,6 +203,24 @@ describe("Vite provider outputs", () => {
     expect(existsSync(vercelStatic)).toBe(false)
   }, 20_000)
 
+  it("bundles the content-type subpath in provider output", { timeout: 15_000 }, async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-content-type-")
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist"), { recursive: true })
+    await writeFile(join(rootDir, "src", "server.ts"), [
+      'import { detectContentType } from "@vite-hub/blob/content-type"',
+      "export default async () => new Response(detectContentType(Uint8Array.from([0xFF, 0xD8, 0xFF])) || 'unknown')",
+      "",
+    ].join("\n"), "utf8")
+
+    await generateProviderOutputs({ blob: {}, clientOutDir: "dist", rootDir })
+
+    const cloudflareWorker = await readFile(join(rootDir, "dist", toSafeAppName(rootDir), "index.js"), "utf8")
+    const vercelServer = await readFile(join(rootDir, ".vercel", "output", "functions", "__server.func", "index.mjs"), "utf8")
+    expect(cloudflareWorker).toContain("image/jpeg")
+    expect(vercelServer).toContain("image/jpeg")
+  })
+
   it("copies Vercel static output from Vite's default dist directory", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-default-dist-")
     await mkdir(join(rootDir, "src"), { recursive: true })

--- a/packages/blob/vite.config.ts
+++ b/packages/blob/vite.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     },
     entry: [
       "src/config.ts",
+      "src/content-type.ts",
       "src/ensure.ts",
       "src/storage.ts",
       "src/drivers/akamai.ts",

--- a/packages/vite-hub/package.json
+++ b/packages/vite-hub/package.json
@@ -73,6 +73,7 @@
     "./auth/agent": "./dist/auth/agent.js",
     "./auth/server": "./dist/auth/server.js",
     "./blob": "./dist/blob.js",
+    "./blob/content-type": "./dist/blob/content-type.js",
     "./box": "./dist/box.js",
     "./box/crabbox": "./dist/box/crabbox.js",
     "./database": "./dist/database.js",

--- a/packages/vite-hub/src/blob/content-type.ts
+++ b/packages/vite-hub/src/blob/content-type.ts
@@ -1,0 +1,1 @@
+export * from "@vite-hub/blob/content-type"

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -6,11 +6,13 @@ import { describe, expect, it } from "vitest"
 import * as ownerAgent from "@vite-hub/agent"
 import * as ownerCapabilities from "@vite-hub/agent/capabilities"
 import ownerAuthHandler from "@vite-hub/auth/server"
+import * as ownerBlobContentType from "@vite-hub/blob/content-type"
 import * as ownerRateLimit from "@vite-hub/rate-limit"
 import * as framework from "vite-hub"
 import * as frameworkAgent from "vite-hub/agent"
 import * as frameworkCapabilities from "vite-hub/agent/capabilities"
 import frameworkAuthHandler from "vite-hub/auth/server"
+import * as frameworkBlobContentType from "vite-hub/blob/content-type"
 import * as frameworkRateLimit from "vite-hub/rate-limit"
 import { distributionBinEntries, distributionEntriesFromManifest } from "../vite.config.ts"
 
@@ -136,6 +138,7 @@ describe("framework package contract", () => {
     expect(frameworkCapabilities.email).toBe(ownerCapabilities.email)
     expect(frameworkCapabilities.workspaceShell).toBe(ownerCapabilities.workspaceShell)
     expect(frameworkAuthHandler).toBe(ownerAuthHandler)
+    expect(frameworkBlobContentType.detectContentType).toBe(ownerBlobContentType.detectContentType)
     expect(frameworkRateLimit.defineRateLimit).toBe(ownerRateLimit.defineRateLimit)
     expect(frameworkRateLimit.createRateLimiter).toBe(ownerRateLimit.createRateLimiter)
   })


### PR DESCRIPTION
Restores `detectContentType` as an explicit `@vite-hub/blob/content-type` API and forwards it through `vite-hub/blob/content-type`. The helper previously landed through a stacked base but is absent from current `main`, leaving consumers to duplicate common image and PDF signature detection.

Adds the package exports, build entries, and provider-output aliases required for the subpath to work in published packages and bundled Cloudflare and Vercel outputs. Detection remains signature classification only, so callers still own Blob `contentType` metadata and complete-file validation.
