### PR TITLE
fix(sandbox): make definition defaults configuration-free

### DIFF
--- a/docs/content/docs/server-primitives/sandbox.md
+++ b/docs/content/docs/server-primitives/sandbox.md
@@ -82,7 +82,7 @@ The Vite config key is `sandbox`.
 | `sandbox: false` | `false` | enabled | Disables Sandbox discovery and provider runtime output. |
 | `provider` | `SandboxProvider` | inferred from hosting | Selects `cloudflare` or `vercel`. Omit it only when hosting inference is enough. |
 | `name` | `string` | package default | Shared provider resource name hint. |
-| Cloudflare provider options | `CloudflareSandboxDefinitionProviderOptions` | provider defaults | `binding`, `className`, `migrationTag`, `sandboxId`, `sleepAfter`, `keepAlive`, and `normalizeId`. |
+| Cloudflare provider options | `CloudflareSandboxDefinitionProviderOptions` | `sandboxId`: Definition name; `sleepAfter`: `5m` | `binding`, `className`, `migrationTag`, `sandboxId`, `sleepAfter`, `keepAlive`, and `normalizeId`. |
 | Vercel provider options | `VercelSandboxProviderOptions` | provider defaults | `runtime`, `timeout`, `cpu`, `ports`, `source`, `networkPolicy`, `token`, `teamId`, and `projectId`. |
 
 Provider inference supports Cloudflare and Vercel hosting. Netlify cannot infer a Sandbox Provider; set `sandbox.provider` explicitly when a build target needs sandbox output.
@@ -91,10 +91,12 @@ Provider inference supports Cloudflare and Vercel hosting. Netlify cannot infer 
 
 | Provider | Configure with | Provider output | Nuance |
 | --- | --- | --- | --- |
-| Cloudflare | `sandbox: { provider: 'cloudflare' }` | Durable Object binding, migration, and runtime provider loader output. | Uses request environment bindings. `binding` defaults to `SANDBOX`; `sandboxId` can pin a reusable execution sandbox. |
+| Cloudflare | Inferred from hosting or `sandbox: { provider: 'cloudflare' }` | Durable Object binding, migration, and runtime provider loader output. | Uses request environment bindings. `binding` defaults to `SANDBOX`; the Definition name defaults `sandboxId`; `sleepAfter` defaults to `5m`. |
 | Vercel | `sandbox: { provider: 'vercel' }` | Vercel Sandbox runtime provider output. | Requires `@vercel/sandbox` at runtime. Supported runtimes are currently `node22` and `node24`. |
 
 Cloudflare and Vercel expose different lifecycle, credential, network, and file behavior. Keep provider credentials in Server Env or provider configuration, not in Sandbox Payloads.
+
+Successful Cloudflare runs remain available until their idle timeout so later runs of the same Definition can reuse them. Failed Cloudflare runs and Vercel runs are stopped immediately.
 
 ## Define sandbox work
 

--- a/packages/sandbox/src/feature.ts
+++ b/packages/sandbox/src/feature.ts
@@ -233,7 +233,7 @@ export async function createSandboxFeaturePlan(
   const defaultProvider = getSandboxFeatureProvider(resolvedConfig)
   const defaultProviderName = defaultProvider?.provider
   const providerLoaderTarget = resolveSandboxProviderLoaderTarget(defaultProviderName, deps)
-  const cloudflareOptions = defaultProvider?.provider === 'cloudflare'
+  const cloudflareOptions = definitions.length > 0 && defaultProvider?.provider === 'cloudflare'
     ? {
         binding: typeof defaultProvider.binding === 'string' ? defaultProvider.binding : defaultCloudflareSandboxBinding,
         className: typeof defaultProvider.className === 'string' ? defaultProvider.className : defaultCloudflareSandboxClassName,

--- a/packages/sandbox/src/runtime/provider-resolution.ts
+++ b/packages/sandbox/src/runtime/provider-resolution.ts
@@ -22,9 +22,7 @@ export function createCloudflareExecutionSandboxId(name: string, sandboxId?: str
   if (sandboxId)
     return sandboxId
 
-  const hash = globalThis.crypto.randomUUID().replace(/-/g, '').slice(0, 24)
-
-  return `vitehub-${name.replace(/[^a-z0-9-]/gi, '-').toLowerCase()}-${hash}`
+  return name.replace(/[^a-z0-9-]/gi, '-').toLowerCase()
 }
 
 export function resolveRuntimeProvider(provider?: SandboxDefinitionProviderOptions, event?: SandboxEvent) {

--- a/packages/sandbox/src/runtime/providers/cloudflare.ts
+++ b/packages/sandbox/src/runtime/providers/cloudflare.ts
@@ -39,7 +39,7 @@ export async function resolveSandboxProvider(options: SandboxOptions, context: {
     namespace,
     sandboxId: options.provider.sandboxId,
     cloudflare: {
-      sleepAfter: options.provider.sleepAfter,
+      sleepAfter: options.provider.sleepAfter ?? '5m',
       keepAlive: options.provider.keepAlive,
       normalizeId: options.provider.normalizeId,
     },

--- a/packages/sandbox/src/runtime/runtime.ts
+++ b/packages/sandbox/src/runtime/runtime.ts
@@ -97,7 +97,7 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
 
     return {
       name: context.name,
-      async run(payload, options = {}) {
+      async run<TPayload = unknown, TResult = unknown>(payload?: TPayload, options: SandboxExecutionOptions = {}): Promise<TResult> {
         const cloudflareSandboxId = provider.provider === 'cloudflare'
           ? createCloudflareExecutionSandboxId(context.name, options.sandboxId || provider.sandboxId)
           : undefined
@@ -107,6 +107,7 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
 
         for (let attempt = 0; attempt < attempts; attempt++) {
           let sandbox: SandboxClient | undefined
+          let succeeded = false
 
           try {
             const createdSandbox = await runtimeProvider.createSandboxClient(
@@ -118,7 +119,7 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
                 : provider as SandboxProviderOptions,
             )
             sandbox = createdSandbox
-            return await executeSandboxDefinition(
+            const result = await executeSandboxDefinition<TPayload, TResult>(
               createdSandbox,
               context.name,
               context.definition.options,
@@ -126,6 +127,8 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
               payload,
               options.context,
             )
+            succeeded = true
+            return result
           }
           catch (error) {
             const sandboxError = toSandboxError(error)
@@ -139,7 +142,8 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
             await sleep(CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS[attempt])
           }
           finally {
-            await sandbox?.stop().catch(() => {})
+            if (provider.provider !== 'cloudflare' || !succeeded)
+              await sandbox?.stop().catch(() => {})
           }
         }
 

--- a/packages/sandbox/test/cloudflare-runtime-provider.test.ts
+++ b/packages/sandbox/test/cloudflare-runtime-provider.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest"
+
+const { getSandbox } = vi.hoisted(() => ({ getSandbox: vi.fn() }))
+
+vi.mock("@cloudflare/sandbox", () => ({ getSandbox }))
+
+import { resolveSandboxProvider } from "../src/runtime/providers/cloudflare.ts"
+
+const namespace = {
+  get: vi.fn(),
+  idFromName: vi.fn(),
+}
+
+describe("Cloudflare Sandbox runtime provider", () => {
+  it("defaults idle shutdown to five minutes", async () => {
+    const provider = await resolveSandboxProvider({
+      local: {},
+      provider: { provider: "cloudflare" },
+    }, {
+      event: { context: { cloudflare: { env: { SANDBOX: namespace } } } },
+    })
+
+    expect(provider.cloudflare.sleepAfter).toBe("5m")
+  })
+
+  it("preserves an explicit idle shutdown override", async () => {
+    const provider = await resolveSandboxProvider({
+      local: {},
+      provider: { provider: "cloudflare", sleepAfter: "30s" },
+    }, {
+      event: { context: { cloudflare: { env: { SANDBOX: namespace } } } },
+    })
+
+    expect(provider.cloudflare.sleepAfter).toBe("30s")
+  })
+})

--- a/packages/sandbox/test/runtime-lifecycle.test.ts
+++ b/packages/sandbox/test/runtime-lifecycle.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const runtimeMocks = vi.hoisted(() => ({
+  createSandboxClient: vi.fn(),
+  executeSandboxDefinition: vi.fn(),
+  resolveSandboxProvider: vi.fn(async ({ provider }: { provider: Record<string, unknown> }) => provider),
+}))
+
+vi.mock("../src/runtime/execute.ts", () => ({
+  executeSandboxDefinition: runtimeMocks.executeSandboxDefinition,
+}))
+
+vi.mock("vitehub-sandbox-provider-loader", () => ({
+  loadSandboxRuntimeProvider: async () => ({
+    createSandboxClient: runtimeMocks.createSandboxClient,
+    resolveSandboxProvider: runtimeMocks.resolveSandboxProvider,
+  }),
+}))
+
+import { runSandboxRuntime } from "../src/runtime/runtime.ts"
+import { resetSandboxRuntimeState, setSandboxRuntimeConfig, setSandboxRuntimeRegistry } from "../src/runtime/state.ts"
+
+const definition = {
+  bundle: {
+    entry: "index.mjs",
+    modules: { "index.mjs": "export default async () => ({ ok: true })" },
+  },
+}
+
+function createSandbox(provider: "cloudflare" | "vercel") {
+  return {
+    provider,
+    stop: vi.fn(async () => {}),
+  }
+}
+
+afterEach(() => {
+  resetSandboxRuntimeState()
+})
+
+beforeEach(() => {
+  runtimeMocks.createSandboxClient.mockReset()
+  runtimeMocks.executeSandboxDefinition.mockReset()
+  runtimeMocks.resolveSandboxProvider.mockReset()
+  runtimeMocks.resolveSandboxProvider.mockImplementation(async ({ provider }) => provider)
+})
+
+describe("Sandbox runtime lifecycle", () => {
+  it("uses the Definition name as the default Cloudflare identity and keeps successful runs idle", async () => {
+    const sandbox = createSandbox("cloudflare")
+    setSandboxRuntimeConfig({ provider: "cloudflare" })
+    setSandboxRuntimeRegistry({ example: definition })
+    runtimeMocks.createSandboxClient.mockResolvedValue(sandbox)
+    runtimeMocks.executeSandboxDefinition.mockResolvedValue({ ok: true })
+
+    const result = await runSandboxRuntime("example")
+
+    expect(result.isOk()).toBe(true)
+    expect(runtimeMocks.createSandboxClient).toHaveBeenCalledWith(expect.objectContaining({
+      provider: "cloudflare",
+      sandboxId: "example",
+    }))
+    expect(sandbox.stop).not.toHaveBeenCalled()
+  })
+
+  it("keeps configured and per-run Cloudflare identity overrides", async () => {
+    const sandbox = createSandbox("cloudflare")
+    setSandboxRuntimeConfig({ provider: "cloudflare", sandboxId: "configured" })
+    setSandboxRuntimeRegistry({ example: definition })
+    runtimeMocks.createSandboxClient.mockResolvedValue(sandbox)
+    runtimeMocks.executeSandboxDefinition.mockResolvedValue({ ok: true })
+
+    await runSandboxRuntime("example")
+    await runSandboxRuntime("example", undefined, { sandboxId: "per-run" })
+
+    expect(runtimeMocks.createSandboxClient).toHaveBeenNthCalledWith(1, expect.objectContaining({ sandboxId: "configured" }))
+    expect(runtimeMocks.createSandboxClient).toHaveBeenNthCalledWith(2, expect.objectContaining({ sandboxId: "per-run" }))
+  })
+
+  it("stops failed Cloudflare attempts", async () => {
+    const sandbox = createSandbox("cloudflare")
+    setSandboxRuntimeConfig({ provider: "cloudflare" })
+    setSandboxRuntimeRegistry({ example: definition })
+    runtimeMocks.createSandboxClient.mockResolvedValue(sandbox)
+    runtimeMocks.executeSandboxDefinition.mockRejectedValue(new Error("definition failed"))
+
+    const result = await runSandboxRuntime("example")
+
+    expect(result.isErr()).toBe(true)
+    expect(sandbox.stop).toHaveBeenCalledOnce()
+  })
+
+  it("keeps Vercel cleanup unchanged", async () => {
+    const sandbox = createSandbox("vercel")
+    setSandboxRuntimeConfig({ provider: "vercel" })
+    setSandboxRuntimeRegistry({ example: definition })
+    runtimeMocks.createSandboxClient.mockResolvedValue(sandbox)
+    runtimeMocks.executeSandboxDefinition.mockResolvedValue({ ok: true })
+
+    const result = await runSandboxRuntime("example")
+
+    expect(result.isOk()).toBe(true)
+    expect(sandbox.stop).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
-import type { AliasOptions } from "vite"
+import { build, type AliasOptions } from "vite"
 
 const tempDirs: string[] = []
 
@@ -225,24 +225,63 @@ describe("hubSandbox", () => {
     expect(definition).not.toContain("from process slash alias")
   })
 
-  it("infers Cloudflare from a late-resolved Nitro preset", async () => {
+  it("builds a configuration-free Definition for a Cloudflare Nitro host", async () => {
     const rootDir = await createViteRoot()
+    await rm(join(rootDir, "src/tools/release-notes.sandbox.ts"))
+    await mkdir(join(rootDir, "server/sandboxes"), { recursive: true })
+    await writeFile(join(rootDir, "src/server.ts"), `export const ready = true\n`)
+    await writeFile(join(rootDir, "server/sandboxes/example.ts"), [
+      `import { defineSandbox } from "@vite-hub/sandbox"`,
+      ``,
+      `export default defineSandbox(async () => ({ ok: true }))`,
+      ``,
+    ].join("\n"))
+    const { hubSandbox } = await import("../src/vite.ts")
+    let resolvedNitro: any
+
+    await build({
+      appType: "custom",
+      build: {
+        rollupOptions: { input: join(rootDir, "src/server.ts") },
+        write: false,
+      },
+      nitro: { preset: "cloudflare-module" },
+      plugins: [
+        hubSandbox(),
+        {
+          name: "nitro:main",
+          configResolved(config: { nitro?: unknown }) {
+            resolvedNitro = config.nitro
+          },
+        },
+      ],
+      root: rootDir,
+    } as never)
+
+    expect(resolvedNitro.cloudflare.wrangler.containers).toMatchObject([{ class_name: "Sandbox" }])
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/runtime/sandbox-registry.mjs"), "utf8")).resolves.toContain('"example"')
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/runtime/sandbox-provider-loader.mjs"), "utf8")).resolves.toContain("createCloudflareSandboxClient")
+  })
+
+  it("keeps Cloudflare output inert without Sandbox definitions", async () => {
+    const rootDir = await createViteRoot()
+    await rm(join(rootDir, "src/tools/release-notes.sandbox.ts"))
     const { hubSandbox } = await import("../src/vite.ts")
     const plugin = hubSandbox()
     const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
     const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
-    const userConfig = { root: rootDir }
-
-    await configHook(userConfig, { command: "build", mode: "production" })
-    const resolvedConfig = {
-      ...userConfig,
+    const userConfig = {
+      root: rootDir,
       nitro: { preset: "cloudflare-module" },
       plugins: [{ name: "nitro:main" }],
-      resolve: { alias: [] },
     }
-    await configResolved(resolvedConfig)
 
-    expect((resolvedConfig.nitro as any).cloudflare.wrangler.containers).toMatchObject([{ class_name: "Sandbox" }])
+    await configHook(userConfig, { command: "build", mode: "production" })
+    await configResolved({ ...userConfig, resolve: { alias: [] } })
+
+    expect(userConfig.nitro).toEqual({ preset: "cloudflare-module" })
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
+      .rejects.toMatchObject({ code: "ENOENT" })
   })
 
   it("infers Cloudflare from the Nitro preset environment", async () => {
@@ -781,18 +820,13 @@ describe("hubSandbox", () => {
     }, {})).rejects.toThrow("generate the same artifact path")
   })
 
-  it("passes explicit Cloudflare sandbox container names to Cloudflare targets", async () => {
+  it("keeps explicit Cloudflare targets inert without definitions", async () => {
     const { createSandboxFeaturePlan } = await import("../src/feature.ts")
     const plan = await createSandboxFeaturePlan({ provider: "cloudflare", name: "custom-sandbox" }, [], {
       aliasPath: "/tmp/vitehub-sandbox/index.js",
     }, {})
 
-    expect(plan.cloudflare).toEqual({
-      binding: "SANDBOX",
-      className: "Sandbox",
-      migrationTag: "v1",
-      name: "custom-sandbox",
-    })
+    expect(plan.cloudflare).toBeUndefined()
   })
 
   it("refreshes generated artifacts during sandbox definition hot updates", async () => {

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -193,9 +193,9 @@ export function vitehub(options: ViteHubPresetOptions = {}): PluginOption[] {
       importBase: "vite-hub/auth",
     } as unknown as AuthModuleOptions))
   }
-  if (options.sandbox) {
+  if (options.sandbox !== false) {
     plugins.push(hubSandbox({
-      ...(options.sandbox === true ? {} : options.sandbox),
+      ...(options.sandbox === true || options.sandbox === undefined ? {} : options.sandbox),
       providerImportAliases,
       providerImportSpecifier: "vite-hub/sandbox",
     } as unknown as SandboxPublicOptions))

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -74,6 +74,7 @@ describe("vitehub", () => {
       "vite-hub/dependencies",
       "@vite-hub/markdown-template/vite",
       "@vite-hub/env/vite",
+      "@vite-hub/sandbox/vite",
       "@vite-hub/agent/vite",
       "@vite-hub/database/vite",
       "@vite-hub/blob/vite",
@@ -100,6 +101,7 @@ describe("vitehub", () => {
       "@vite-hub/workspace/vite",
       "@vite-hub/devtools",
     ])
+    expect(pluginNames(vitehub({ sandbox: false }))).not.toContain("@vite-hub/sandbox/vite")
 
     vitehub({ schedule: true })
 


### PR DESCRIPTION
Makes discovered Sandbox Definitions configuration-free: the ViteHub preset enables discovery unless explicitly disabled, supported hosting selects the provider, and Cloudflare uses the normalized Definition name as its default reusable identity. Explicit provider and `sandboxId` settings still win, and projects without definitions emit no Sandbox container output.

Cloudflare runs now default to a five-minute idle timeout. Successful runs remain available for reuse, failed Cloudflare attempts still clean up, and Vercel cleanup is unchanged.