### PR TITLE
fix(sandbox): make definition defaults configuration-free

### DIFF
--- a/docs/content/docs/server-primitives/sandbox.md
+++ b/docs/content/docs/server-primitives/sandbox.md
@@ -99,7 +99,7 @@ The Vite config key is `sandbox`.
 | `sandbox: false` | `false` | enabled | Disables Sandbox discovery and provider runtime output. |
 | `provider` | `SandboxProvider` | inferred from hosting | Selects `cloudflare` or `vercel`. Omit it only when hosting inference is enough. |
 | `name` | `string` | package default | Shared provider resource name hint. |
-| Cloudflare provider options | `CloudflareSandboxDefinitionProviderOptions` | `sandboxId`: Definition name; `sleepAfter`: `5m` | `binding`, `className`, `migrationTag`, `sandboxId`, `sleepAfter`, `keepAlive`, and `normalizeId`. |
+| Cloudflare provider options | `CloudflareSandboxDefinitionProviderOptions` | `sandboxId`: URL-encoded Definition name; `sleepAfter`: `5m` | `binding`, `className`, `migrationTag`, `sandboxId`, `sleepAfter`, `keepAlive`, and `normalizeId`. |
 | Vercel provider options | `VercelSandboxProviderOptions` | provider defaults | `runtime`, `timeout`, `cpu`, `ports`, `source`, `networkPolicy`, `token`, `teamId`, and `projectId`. |
 
 Provider inference supports Cloudflare and Vercel hosting. Netlify cannot infer a Sandbox Provider; set `sandbox.provider` explicitly when a build target needs sandbox output.
@@ -108,7 +108,7 @@ Provider inference supports Cloudflare and Vercel hosting. Netlify cannot infer 
 
 | Provider | Configure with | Provider output | Nuance |
 | --- | --- | --- | --- |
-| Cloudflare | Inferred from hosting or `sandbox: { provider: 'cloudflare' }` | Durable Object binding, migration, and runtime provider loader output. | Uses request environment bindings. `binding` defaults to `SANDBOX`; the Definition name defaults `sandboxId`; `sleepAfter` defaults to `5m`. |
+| Cloudflare | Inferred from hosting or `sandbox: { provider: 'cloudflare' }` | Durable Object binding, migration, and runtime provider loader output. | Uses request environment bindings. `binding` defaults to `SANDBOX`; the URL-encoded Definition name defaults `sandboxId`; `sleepAfter` defaults to `5m`. |
 | Vercel | `sandbox: { provider: 'vercel' }` | Vercel Sandbox runtime provider output. | Requires `@vercel/sandbox` at runtime. Supported runtimes are currently `node22` and `node24`. |
 
 Cloudflare and Vercel expose different lifecycle, credential, network, and file behavior. Keep provider credentials in Server Env or provider configuration, not in Sandbox Payloads.

--- a/docs/content/docs/server-primitives/sandbox.md
+++ b/docs/content/docs/server-primitives/sandbox.md
@@ -99,7 +99,7 @@ The Vite config key is `sandbox`.
 | `sandbox: false` | `false` | enabled | Disables Sandbox discovery and provider runtime output. |
 | `provider` | `SandboxProvider` | inferred from hosting | Selects `cloudflare` or `vercel`. Omit it only when hosting inference is enough. |
 | `name` | `string` | package default | Shared provider resource name hint. |
-| Cloudflare provider options | `CloudflareSandboxDefinitionProviderOptions` | provider defaults | `binding`, `className`, `migrationTag`, `sandboxId`, `sleepAfter`, `keepAlive`, and `normalizeId`. |
+| Cloudflare provider options | `CloudflareSandboxDefinitionProviderOptions` | `sandboxId`: Definition name; `sleepAfter`: `5m` | `binding`, `className`, `migrationTag`, `sandboxId`, `sleepAfter`, `keepAlive`, and `normalizeId`. |
 | Vercel provider options | `VercelSandboxProviderOptions` | provider defaults | `runtime`, `timeout`, `cpu`, `ports`, `source`, `networkPolicy`, `token`, `teamId`, and `projectId`. |
 
 Provider inference supports Cloudflare and Vercel hosting. Netlify cannot infer a Sandbox Provider; set `sandbox.provider` explicitly when a build target needs sandbox output.
@@ -108,10 +108,12 @@ Provider inference supports Cloudflare and Vercel hosting. Netlify cannot infer 
 
 | Provider | Configure with | Provider output | Nuance |
 | --- | --- | --- | --- |
-| Cloudflare | `sandbox: { provider: 'cloudflare' }` | Durable Object binding, migration, and runtime provider loader output. | Uses request environment bindings. `binding` defaults to `SANDBOX`; `sandboxId` can pin a reusable execution sandbox. |
+| Cloudflare | Inferred from hosting or `sandbox: { provider: 'cloudflare' }` | Durable Object binding, migration, and runtime provider loader output. | Uses request environment bindings. `binding` defaults to `SANDBOX`; the Definition name defaults `sandboxId`; `sleepAfter` defaults to `5m`. |
 | Vercel | `sandbox: { provider: 'vercel' }` | Vercel Sandbox runtime provider output. | Requires `@vercel/sandbox` at runtime. Supported runtimes are currently `node22` and `node24`. |
 
 Cloudflare and Vercel expose different lifecycle, credential, network, and file behavior. Keep provider credentials in Server Env or provider configuration, not in Sandbox Payloads.
+
+Successful Cloudflare runs remain available until their idle timeout so later runs of the same Definition can reuse them. Failed Cloudflare runs and Vercel runs are stopped immediately.
 
 ## Define sandbox work
 

--- a/docs/content/docs/server-primitives/sandbox.md
+++ b/docs/content/docs/server-primitives/sandbox.md
@@ -99,7 +99,7 @@ The Vite config key is `sandbox`.
 | `sandbox: false` | `false` | enabled | Disables Sandbox discovery and provider runtime output. |
 | `provider` | `SandboxProvider` | inferred from hosting | Selects `cloudflare` or `vercel`. Omit it only when hosting inference is enough. |
 | `name` | `string` | package default | Shared provider resource name hint. |
-| Cloudflare provider options | `CloudflareSandboxDefinitionProviderOptions` | `sandboxId`: safely prefixed, URL-encoded and hashed Definition name; `sleepAfter`: `5m` | `binding`, `className`, `migrationTag`, `sandboxId`, `sleepAfter`, `keepAlive`, and `normalizeId`. |
+| Cloudflare provider options | `CloudflareSandboxDefinitionProviderOptions` | `sandboxId`: safely prefixed, bounded, URL-encoded and hashed Definition name; `sleepAfter`: `5m` | `binding`, `className`, `migrationTag`, `sandboxId`, `sleepAfter`, `keepAlive`, and `normalizeId`. |
 | Vercel provider options | `VercelSandboxProviderOptions` | provider defaults | `runtime`, `timeout`, `cpu`, `ports`, `source`, `networkPolicy`, `token`, `teamId`, and `projectId`. |
 
 Provider inference supports Cloudflare and Vercel hosting. Netlify cannot infer a Sandbox Provider; set `sandbox.provider` explicitly when a build target needs sandbox output.
@@ -110,7 +110,7 @@ Hosting inference is activated by discovered Sandbox Definitions. Definition-fre
 
 | Provider | Configure with | Provider output | Nuance |
 | --- | --- | --- | --- |
-| Cloudflare | Inferred from hosting or `sandbox: { provider: 'cloudflare' }` | Durable Object binding, migration, and runtime provider loader output. | Uses request environment bindings. `binding` defaults to `SANDBOX`; a safely prefixed, URL-encoded and hashed Definition name defaults `sandboxId`; `sleepAfter` defaults to `5m`. |
+| Cloudflare | Inferred from hosting or `sandbox: { provider: 'cloudflare' }` | Durable Object binding, migration, and runtime provider loader output. | Uses request environment bindings. `binding` defaults to `SANDBOX`; a safely prefixed, bounded, URL-encoded and hashed Definition name defaults `sandboxId`; `sleepAfter` defaults to `5m`. |
 | Vercel | `sandbox: { provider: 'vercel' }` | Vercel Sandbox runtime provider output. | Requires `@vercel/sandbox` at runtime. Supported runtimes are currently `node22` and `node24`. |
 
 Cloudflare and Vercel expose different lifecycle, credential, network, and file behavior. Keep provider credentials in Server Env or provider configuration, not in Sandbox Payloads.

--- a/docs/content/docs/server-primitives/sandbox.md
+++ b/docs/content/docs/server-primitives/sandbox.md
@@ -113,7 +113,7 @@ Provider inference supports Cloudflare and Vercel hosting. Netlify cannot infer 
 
 Cloudflare and Vercel expose different lifecycle, credential, network, and file behavior. Keep provider credentials in Server Env or provider configuration, not in Sandbox Payloads.
 
-Successful Cloudflare runs remain available until their idle timeout so later runs of the same Definition can reuse them. Failed Cloudflare runs and Vercel runs are stopped immediately.
+Cloudflare runs remain available until their idle timeout so later runs of the same Definition can reuse them. Each invocation removes its isolated temporary files on success or failure. Vercel runs are stopped immediately.
 
 ## Define sandbox work
 

--- a/docs/content/docs/server-primitives/sandbox.md
+++ b/docs/content/docs/server-primitives/sandbox.md
@@ -99,7 +99,7 @@ The Vite config key is `sandbox`.
 | `sandbox: false` | `false` | enabled | Disables Sandbox discovery and provider runtime output. |
 | `provider` | `SandboxProvider` | inferred from hosting | Selects `cloudflare` or `vercel`. Omit it only when hosting inference is enough. |
 | `name` | `string` | package default | Shared provider resource name hint. |
-| Cloudflare provider options | `CloudflareSandboxDefinitionProviderOptions` | `sandboxId`: safely prefixed, URL-encoded Definition name; `sleepAfter`: `5m` | `binding`, `className`, `migrationTag`, `sandboxId`, `sleepAfter`, `keepAlive`, and `normalizeId`. |
+| Cloudflare provider options | `CloudflareSandboxDefinitionProviderOptions` | `sandboxId`: safely prefixed, URL-encoded and hashed Definition name; `sleepAfter`: `5m` | `binding`, `className`, `migrationTag`, `sandboxId`, `sleepAfter`, `keepAlive`, and `normalizeId`. |
 | Vercel provider options | `VercelSandboxProviderOptions` | provider defaults | `runtime`, `timeout`, `cpu`, `ports`, `source`, `networkPolicy`, `token`, `teamId`, and `projectId`. |
 
 Provider inference supports Cloudflare and Vercel hosting. Netlify cannot infer a Sandbox Provider; set `sandbox.provider` explicitly when a build target needs sandbox output.
@@ -110,12 +110,12 @@ Hosting inference is activated by discovered Sandbox Definitions. Definition-fre
 
 | Provider | Configure with | Provider output | Nuance |
 | --- | --- | --- | --- |
-| Cloudflare | Inferred from hosting or `sandbox: { provider: 'cloudflare' }` | Durable Object binding, migration, and runtime provider loader output. | Uses request environment bindings. `binding` defaults to `SANDBOX`; a safely prefixed, URL-encoded Definition name defaults `sandboxId`; `sleepAfter` defaults to `5m`. |
+| Cloudflare | Inferred from hosting or `sandbox: { provider: 'cloudflare' }` | Durable Object binding, migration, and runtime provider loader output. | Uses request environment bindings. `binding` defaults to `SANDBOX`; a safely prefixed, URL-encoded and hashed Definition name defaults `sandboxId`; `sleepAfter` defaults to `5m`. |
 | Vercel | `sandbox: { provider: 'vercel' }` | Vercel Sandbox runtime provider output. | Requires `@vercel/sandbox` at runtime. Supported runtimes are currently `node22` and `node24`. |
 
 Cloudflare and Vercel expose different lifecycle, credential, network, and file behavior. Keep provider credentials in Server Env or provider configuration, not in Sandbox Payloads.
 
-Cloudflare runs remain available until their idle timeout so later runs of the same Definition can reuse them. Each invocation removes its isolated temporary files on success or failure. Vercel runs are stopped immediately.
+Cloudflare runs remain available until their idle timeout so later runs of the same Definition can reuse them. Each invocation removes its isolated temporary files on success or failure. When `keepAlive: true` disables Cloudflare idle shutdown, ViteHub stops the sandbox after every run instead. Vercel runs are stopped immediately.
 
 ## Define sandbox work
 

--- a/docs/content/docs/server-primitives/sandbox.md
+++ b/docs/content/docs/server-primitives/sandbox.md
@@ -99,7 +99,7 @@ The Vite config key is `sandbox`.
 | `sandbox: false` | `false` | enabled | Disables Sandbox discovery and provider runtime output. |
 | `provider` | `SandboxProvider` | inferred from hosting | Selects `cloudflare` or `vercel`. Omit it only when hosting inference is enough. |
 | `name` | `string` | package default | Shared provider resource name hint. |
-| Cloudflare provider options | `CloudflareSandboxDefinitionProviderOptions` | `sandboxId`: URL-encoded Definition name; `sleepAfter`: `5m` | `binding`, `className`, `migrationTag`, `sandboxId`, `sleepAfter`, `keepAlive`, and `normalizeId`. |
+| Cloudflare provider options | `CloudflareSandboxDefinitionProviderOptions` | `sandboxId`: safely prefixed, URL-encoded Definition name; `sleepAfter`: `5m` | `binding`, `className`, `migrationTag`, `sandboxId`, `sleepAfter`, `keepAlive`, and `normalizeId`. |
 | Vercel provider options | `VercelSandboxProviderOptions` | provider defaults | `runtime`, `timeout`, `cpu`, `ports`, `source`, `networkPolicy`, `token`, `teamId`, and `projectId`. |
 
 Provider inference supports Cloudflare and Vercel hosting. Netlify cannot infer a Sandbox Provider; set `sandbox.provider` explicitly when a build target needs sandbox output.
@@ -110,7 +110,7 @@ Hosting inference is activated by discovered Sandbox Definitions. Definition-fre
 
 | Provider | Configure with | Provider output | Nuance |
 | --- | --- | --- | --- |
-| Cloudflare | Inferred from hosting or `sandbox: { provider: 'cloudflare' }` | Durable Object binding, migration, and runtime provider loader output. | Uses request environment bindings. `binding` defaults to `SANDBOX`; the URL-encoded Definition name defaults `sandboxId`; `sleepAfter` defaults to `5m`. |
+| Cloudflare | Inferred from hosting or `sandbox: { provider: 'cloudflare' }` | Durable Object binding, migration, and runtime provider loader output. | Uses request environment bindings. `binding` defaults to `SANDBOX`; a safely prefixed, URL-encoded Definition name defaults `sandboxId`; `sleepAfter` defaults to `5m`. |
 | Vercel | `sandbox: { provider: 'vercel' }` | Vercel Sandbox runtime provider output. | Requires `@vercel/sandbox` at runtime. Supported runtimes are currently `node22` and `node24`. |
 
 Cloudflare and Vercel expose different lifecycle, credential, network, and file behavior. Keep provider credentials in Server Env or provider configuration, not in Sandbox Payloads.

--- a/docs/content/docs/server-primitives/sandbox.md
+++ b/docs/content/docs/server-primitives/sandbox.md
@@ -104,6 +104,8 @@ The Vite config key is `sandbox`.
 
 Provider inference supports Cloudflare and Vercel hosting. Netlify cannot infer a Sandbox Provider; set `sandbox.provider` explicitly when a build target needs sandbox output.
 
+Hosting inference is activated by discovered Sandbox Definitions. Definition-free consumers such as a Workspace using `runtime: 'sandbox'` must configure `sandbox.provider` explicitly so ViteHub knows to provision provider output.
+
 ## Providers
 
 | Provider | Configure with | Provider output | Nuance |

--- a/packages/sandbox/src/feature.ts
+++ b/packages/sandbox/src/feature.ts
@@ -197,7 +197,9 @@ export async function createSandboxFeaturePlan(
   deferUnresolvedHostingValidation = false,
 ): Promise<FeatureRuntimePlan> {
   const configuredProviderName = getSandboxFeatureProvider(sandboxConfig)?.provider
-  const resolvedConfig = resolveSandboxFeatureConfig(sandboxConfig, hosting)
+  const resolvedConfig = definitions.length > 0
+    ? resolveSandboxFeatureConfig(sandboxConfig, hosting)
+    : { ...sandboxConfig }
   const manifest = createSandboxManifest(paths.aliasPath, createSandboxTypeTemplateContents(definitions))
   const {
     bundleAlias,

--- a/packages/sandbox/src/feature.ts
+++ b/packages/sandbox/src/feature.ts
@@ -256,7 +256,7 @@ export async function createSandboxFeaturePlan(
     },
   }))
   const providerLoaderTarget = resolveSandboxProviderLoaderTarget(defaultProviderName, deps)
-  const cloudflareOptions = defaultProvider?.provider === 'cloudflare'
+  const cloudflareOptions = definitions.length > 0 && defaultProvider?.provider === 'cloudflare'
     ? {
         binding: typeof defaultProvider.binding === 'string' ? defaultProvider.binding : defaultCloudflareSandboxBinding,
         className: typeof defaultProvider.className === 'string' ? defaultProvider.className : defaultCloudflareSandboxClassName,

--- a/packages/sandbox/src/feature.ts
+++ b/packages/sandbox/src/feature.ts
@@ -258,7 +258,7 @@ export async function createSandboxFeaturePlan(
     },
   }))
   const providerLoaderTarget = resolveSandboxProviderLoaderTarget(defaultProviderName, deps)
-  const cloudflareOptions = definitions.length > 0 && defaultProvider?.provider === 'cloudflare'
+  const cloudflareOptions = defaultProvider?.provider === 'cloudflare'
     ? {
         binding: typeof defaultProvider.binding === 'string' ? defaultProvider.binding : defaultCloudflareSandboxBinding,
         className: typeof defaultProvider.className === 'string' ? defaultProvider.className : defaultCloudflareSandboxClassName,

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -101,7 +101,7 @@ async function resolveSandboxViteContext(
   return {
     rootDir,
     config,
-    deps: await readSandboxWorkspaceDeps(rootDir),
+    deps: hasDefinitions ? await readSandboxWorkspaceDeps(rootDir) : {},
     runtimeConfig: createSandboxRuntimeConfig(config, hosting),
     hosting,
     command: env.command,

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -78,6 +78,7 @@ async function resolveSandboxViteContext(
   integrationOptions: SandboxPublicOptions | undefined,
   userConfig: Record<string, unknown>,
   env: ConfigEnv,
+  hasDefinitions: boolean,
 ): Promise<SandboxViteContext> {
   const configOptions = userConfig.sandbox as SandboxPublicOptions | undefined
   const options = normalizeSandboxOptions(
@@ -90,7 +91,11 @@ async function resolveSandboxViteContext(
       ? nitro.preset
       : process.env.NITRO_PRESET || process.env.SERVER_PRESET
   const hosting = detectHosting({ options: { preset } }) || undefined
-  const config = options === false ? false : resolveSandboxFeatureConfig(options, hosting)
+  const config = options === false
+    ? false
+    : hasDefinitions
+      ? resolveSandboxFeatureConfig(options, hosting)
+      : { ...options }
   const rootDir = resolve(process.cwd(), typeof userConfig.root === 'string' ? userConfig.root : '.')
 
   return {
@@ -227,12 +232,13 @@ export async function prepareSandboxRuntime(options: {
   writeArtifacts?: boolean
 }) {
   const rootDir = options.resolvedConfig?.root || resolve(process.cwd(), typeof options.userConfig.root === 'string' ? options.userConfig.root : '.')
+  const definitions = discoverSandboxDefinitions({ rootDir })
   const resolvedNitro = (options.resolvedConfig as { nitro?: unknown } | undefined)?.nitro
   const context = await resolveSandboxViteContext(options.integrationOptions, {
     ...options.userConfig,
     ...(isPlainObject(resolvedNitro) ? { nitro: resolvedNitro } : {}),
     root: rootDir,
-  }, options.env)
+  }, options.env, definitions.length > 0)
   const stateModule = createSandboxStateModuleContents(context)
   if (!context.config) {
     return {
@@ -245,7 +251,6 @@ export async function prepareSandboxRuntime(options: {
   }
 
   const facadeFile = resolve(ensureGeneratedDir(rootDir, 'sandbox'), 'runtime/sandbox.mjs')
-  const definitions = discoverSandboxDefinitions({ rootDir })
   const plan = await createSandboxFeaturePlan(
     context.config,
     definitions,

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -96,13 +96,17 @@ async function resolveSandboxViteContext(
     : hasDefinitions
       ? resolveSandboxFeatureConfig(options, hosting)
       : { ...options }
+  const runtimeSandboxConfig = config !== false
+    && (hasDefinitions || getSandboxFeatureProvider(config)?.provider)
+    ? config
+    : false
   const rootDir = resolve(process.cwd(), typeof userConfig.root === 'string' ? userConfig.root : '.')
 
   return {
     rootDir,
     config,
     deps: hasDefinitions ? await readSandboxWorkspaceDeps(rootDir) : {},
-    runtimeConfig: createSandboxRuntimeConfig(config, hosting),
+    runtimeConfig: createSandboxRuntimeConfig(runtimeSandboxConfig, hosting),
     hosting,
     command: env.command,
     mode: env.mode,

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -232,7 +232,11 @@ export async function prepareSandboxRuntime(options: {
   writeArtifacts?: boolean
 }) {
   const rootDir = options.resolvedConfig?.root || resolve(process.cwd(), typeof options.userConfig.root === 'string' ? options.userConfig.root : '.')
-  const definitions = discoverSandboxDefinitions({ rootDir })
+  const configOptions = options.userConfig.sandbox as SandboxPublicOptions | undefined
+  const disabled = typeof configOptions === 'undefined'
+    ? options.integrationOptions === false
+    : configOptions === false
+  const definitions = disabled ? [] : discoverSandboxDefinitions({ rootDir })
   const resolvedNitro = (options.resolvedConfig as { nitro?: unknown } | undefined)?.nitro
   const context = await resolveSandboxViteContext(options.integrationOptions, {
     ...options.userConfig,

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -63,62 +63,65 @@ async function executeSandboxDefinitionOnce<TPayload, TResult>(
   const inputJson = toJson({ payload, context }, 'payload/context')
 
   await sandbox.mkdir(files.baseDir, { recursive: true })
-  await writeSandboxDefinitionBundle(sandbox, files.baseDir, bundle)
-  await Promise.all([
-    sandbox.writeFile(files.entryPath, createEntrySource(definitionPath)),
-    sandbox.writeFile(files.inputPath, inputJson),
-  ])
-
-  const launcher = resolveLauncher(sandbox.provider, definitionOptions?.runtime)
-  const execArgs = [...launcher.args, files.entryPath, files.inputPath, files.outputPath]
-
-  let outputRaw = ''
-  let execution: Awaited<ReturnType<SandboxClient['exec']>> | undefined
-
   try {
-    execution = await sandbox.exec(launcher.command, execArgs, {
-      env: definitionOptions?.env,
-      timeout: definitionOptions?.timeout,
-    })
-    outputRaw = await readExecOutputWithRecovery(sandbox, files.outputPath, execution, definitionOptions?.timeout, execution)
-  }
-  catch (error) {
-    if (execution) {
-      outputRaw = await readExecOutputWithRecovery(sandbox, files.outputPath, error, definitionOptions?.timeout, execution)
+    await writeSandboxDefinitionBundle(sandbox, files.baseDir, bundle)
+    await Promise.all([
+      sandbox.writeFile(files.entryPath, createEntrySource(definitionPath)),
+      sandbox.writeFile(files.inputPath, inputJson),
+    ])
+
+    const launcher = resolveLauncher(sandbox.provider, definitionOptions?.runtime)
+    const execArgs = [...launcher.args, files.entryPath, files.inputPath, files.outputPath]
+
+    let outputRaw = ''
+    let execution: Awaited<ReturnType<SandboxClient['exec']>> | undefined
+
+    try {
+      execution = await sandbox.exec(launcher.command, execArgs, {
+        env: definitionOptions?.env,
+        timeout: definitionOptions?.timeout,
+      })
+      outputRaw = await readExecOutputWithRecovery(sandbox, files.outputPath, execution, definitionOptions?.timeout, execution)
     }
-    else {
-      const recoveredOutput = await recoverExecOutput(sandbox, files.outputPath, error, definitionOptions?.timeout, execution)
-      if (recoveredOutput == null)
-        throw error
+    catch (error) {
+      if (execution) {
+        outputRaw = await readExecOutputWithRecovery(sandbox, files.outputPath, error, definitionOptions?.timeout, execution)
+      }
+      else {
+        const recoveredOutput = await recoverExecOutput(sandbox, files.outputPath, error, definitionOptions?.timeout, execution)
+        if (recoveredOutput == null)
+          throw error
 
-      outputRaw = recoveredOutput
+        outputRaw = recoveredOutput
+      }
     }
-  }
 
-  const output = tryParseSandboxOutput<TResult>(outputRaw)
-    || tryParseSandboxOutput(extractSandboxOutputFromExecution(execution) || '')
+    const output = tryParseSandboxOutput<TResult>(outputRaw)
+      || tryParseSandboxOutput(extractSandboxOutputFromExecution(execution) || '')
 
-  if (!output) {
-    throw createHandlerError('Sandbox definition output is not valid JSON.', sandbox.provider, {
-      output: outputRaw,
-      cause: 'Output file was empty or contained incomplete JSON.',
+    if (!output) {
+      throw createHandlerError('Sandbox definition output is not valid JSON.', sandbox.provider, {
+        output: outputRaw,
+        cause: 'Output file was empty or contained incomplete JSON.',
+      })
+    }
+
+    if (output.ok)
+      return output.result as TResult
+
+    throw createHandlerError(output.error?.message || 'Sandbox definition failed.', sandbox.provider, {
+      name: output.error?.name,
+      stack: output.error?.stack,
+      cause: output.error?.cause,
+      stdout: execution?.stdout,
+      stderr: execution?.stderr,
+      exitCode: execution?.code,
     })
   }
-
-  if (output.ok) {
+  finally {
     if (sandbox.provider === 'cloudflare')
-      await sandbox.deleteFile(files.baseDir)
-    return output.result as TResult
+      await sandbox.exec('rm', ['-rf', '--', files.baseDir]).catch(() => {})
   }
-
-  throw createHandlerError(output.error?.message || 'Sandbox definition failed.', sandbox.provider, {
-    name: output.error?.name,
-    stack: output.error?.stack,
-    cause: output.error?.cause,
-    stdout: execution?.stdout,
-    stderr: execution?.stderr,
-    exitCode: execution?.code,
-  })
 }
 
 export async function executeSandboxDefinition<TPayload, TResult>(

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -88,13 +88,21 @@ async function executeLauncher(
         throw createTimeoutError(sandbox.provider, options.timeout || 0)
       }
       options.signal?.addEventListener('abort', abortSession, { once: true })
-      const result = await withCloudflareDeadline('exec', timeout, async () => await session.exec(
-        [command, ...args].map(shellQuote).join(' '),
-        {
-          ...options,
-          timeout,
-        },
-      ))
+      let result: Awaited<ReturnType<typeof session.exec>>
+      try {
+        result = await withCloudflareDeadline('exec', timeout, async () => await session.exec(
+          [command, ...args].map(shellQuote).join(' '),
+          {
+            ...options,
+            timeout,
+          },
+        ))
+      }
+      catch (error) {
+        throw error instanceof SandboxError
+          ? error
+          : createCloudflareTransportError('exec', error)
+      }
       return {
         ok: result.exitCode === 0,
         stdout: result.stdout,

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -171,7 +171,7 @@ export async function executeSandboxDefinition<TPayload, TResult>(
   context?: Record<string, unknown>,
 ): Promise<TResult> {
   const timeout = definitionOptions?.timeout
-  if (typeof timeout !== 'number' || timeout <= 0 || sandbox.provider === 'cloudflare') {
+  if (typeof timeout !== 'number' || timeout <= 0) {
     return await executeSandboxDefinitionOnce(
       sandbox,
       definitionName,

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -1,3 +1,4 @@
+import { resolveExecRequestTimeout } from '../sandbox/adapters/cloudflare/transport'
 import { SandboxError } from '../sandbox/errors'
 import { shellQuote } from '../sandbox/utils'
 import { createEntrySource } from './entry-script'
@@ -60,12 +61,16 @@ async function executeLauncher(
     : undefined
   const nativeCloudflareSession = cloudflareSandbox?.native as { createSession?: unknown } | undefined
   if (cloudflareSandbox && typeof nativeCloudflareSession?.createSession === 'function') {
+    const timeout = resolveExecRequestTimeout(options.timeout)
     const session = await cloudflareSandbox.cloudflare.createSession({
       env: options.env,
-      timeout: options.timeout,
+      timeout,
     })
     try {
-      const result = await session.exec([command, ...args].map(shellQuote).join(' '), options)
+      const result = await session.exec([command, ...args].map(shellQuote).join(' '), {
+        ...options,
+        timeout,
+      })
       return {
         ok: result.exitCode === 0,
         stdout: result.stdout,

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -1,4 +1,4 @@
-import { resolveExecRequestTimeout, withCloudflareDeadline } from '../sandbox/adapters/cloudflare/transport'
+import { createCloudflareTransportError, resolveExecRequestTimeout, withCloudflareDeadline } from '../sandbox/adapters/cloudflare/transport'
 import { SandboxError } from '../sandbox/errors'
 import { shellQuote } from '../sandbox/utils'
 import { createEntrySource } from './entry-script'
@@ -76,7 +76,9 @@ async function executeLauncher(
       void sessionPromise.then(async lateSession => {
         await cloudflareSandbox.cloudflare.deleteSession(lateSession.id).catch(() => {})
       }).catch(() => {})
-      throw error
+      throw error instanceof SandboxError
+        ? error
+        : createCloudflareTransportError('createSession', error)
     }
     const deleteSession = async () => await cloudflareSandbox.cloudflare.deleteSession(session.id).catch(() => {})
     const abortSession = () => void deleteSession()

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -54,21 +54,38 @@ async function executeLauncher(
   sandbox: SandboxClient,
   command: string,
   args: string[],
-  options: { env?: Record<string, string>, timeout?: number },
+  options: { cwd?: string, deadline?: number, env?: Record<string, string>, signal?: AbortSignal, timeout?: number },
 ) {
   const cloudflareSandbox = sandbox.provider === 'cloudflare'
     ? sandbox as CloudflareSandboxClient
     : undefined
   const nativeCloudflareSession = cloudflareSandbox?.native as { createSession?: unknown } | undefined
   if (cloudflareSandbox && typeof nativeCloudflareSession?.createSession === 'function') {
-    const timeout = resolveExecRequestTimeout(options.timeout)
-    const session = await withCloudflareDeadline('createSession', timeout, async () => {
-      return await cloudflareSandbox.cloudflare.createSession({
-        env: options.env,
-        timeout,
-      })
+    const remaining = options.deadline ? Math.max(1, options.deadline - Date.now()) : undefined
+    const timeout = Math.min(resolveExecRequestTimeout(options.timeout), remaining ?? Number.POSITIVE_INFINITY)
+    const sessionPromise = cloudflareSandbox.cloudflare.createSession({
+      cwd: options.cwd,
+      env: options.env,
+      timeout,
     })
+    let session: Awaited<typeof sessionPromise>
     try {
+      session = await withCloudflareDeadline('createSession', timeout, async () => await sessionPromise)
+    }
+    catch (error) {
+      void sessionPromise.then(async lateSession => {
+        await cloudflareSandbox.cloudflare.deleteSession(lateSession.id).catch(() => {})
+      }).catch(() => {})
+      throw error
+    }
+    const deleteSession = async () => await cloudflareSandbox.cloudflare.deleteSession(session.id).catch(() => {})
+    const abortSession = () => void deleteSession()
+    try {
+      if (options.signal?.aborted) {
+        await deleteSession()
+        throw createTimeoutError(sandbox.provider, options.timeout || 0)
+      }
+      options.signal?.addEventListener('abort', abortSession, { once: true })
       const result = await session.exec([command, ...args].map(shellQuote).join(' '), {
         ...options,
         timeout,
@@ -81,11 +98,16 @@ async function executeLauncher(
       }
     }
     finally {
-      await cloudflareSandbox.cloudflare.deleteSession(session.id).catch(() => {})
+      options.signal?.removeEventListener('abort', abortSession)
+      await deleteSession()
     }
   }
 
-  return await sandbox.exec(command, args, options)
+  return await sandbox.exec(command, args, {
+    cwd: options.cwd,
+    env: options.env,
+    timeout: options.timeout,
+  })
 }
 
 async function executeSandboxDefinitionOnce<TPayload, TResult>(
@@ -96,6 +118,7 @@ async function executeSandboxDefinitionOnce<TPayload, TResult>(
   payload?: TPayload,
   context?: Record<string, unknown>,
   signal?: AbortSignal,
+  deadline?: number,
 ) {
   const bundle = normalizeSandboxDefinitionBundle(source)
 
@@ -126,7 +149,10 @@ async function executeSandboxDefinitionOnce<TPayload, TResult>(
 
     try {
       execution = await executeLauncher(sandbox, launcher.command, execArgs, {
+        cwd: files.baseDir,
+        deadline,
         env: definitionOptions?.env,
+        signal,
         timeout: definitionOptions?.timeout,
       })
       outputRaw = await readExecOutputWithRecovery(sandbox, files.outputPath, execution, definitionOptions?.timeout, execution)
@@ -197,6 +223,7 @@ export async function executeSandboxDefinition<TPayload, TResult>(
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined
   const abortController = new AbortController()
+  const deadline = Date.now() + timeout
 
   try {
     return await Promise.race([
@@ -208,6 +235,7 @@ export async function executeSandboxDefinition<TPayload, TResult>(
         payload,
         context,
         abortController.signal,
+        deadline,
       ),
       new Promise<never>((_, reject) => {
         timeoutId = setTimeout(() => {

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -105,8 +105,11 @@ async function executeSandboxDefinitionOnce<TPayload, TResult>(
     })
   }
 
-  if (output.ok)
+  if (output.ok) {
+    if (sandbox.provider === 'cloudflare')
+      await sandbox.deleteFile(files.baseDir)
     return output.result as TResult
+  }
 
   throw createHandlerError(output.error?.message || 'Sandbox definition failed.', sandbox.provider, {
     name: output.error?.name,

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -58,7 +58,8 @@ async function executeLauncher(
   const cloudflareSandbox = sandbox.provider === 'cloudflare'
     ? sandbox as CloudflareSandboxClient
     : undefined
-  if (cloudflareSandbox && typeof cloudflareSandbox.native.createSession === 'function') {
+  const nativeCloudflareSession = cloudflareSandbox?.native as { createSession?: unknown } | undefined
+  if (cloudflareSandbox && typeof nativeCloudflareSession?.createSession === 'function') {
     const session = await cloudflareSandbox.cloudflare.createSession({
       env: options.env,
       timeout: options.timeout,

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -93,20 +93,28 @@ async function executeSandboxDefinitionOnce<TPayload, TResult>(
   source: SandboxDefinitionSource,
   payload?: TPayload,
   context?: Record<string, unknown>,
+  signal?: AbortSignal,
 ) {
   const bundle = normalizeSandboxDefinitionBundle(source)
 
   const files = createExecutionFiles(definitionName)
   const definitionPath = resolveSandboxModulePath(files.baseDir, bundle.entry)
   const inputJson = toJson({ payload, context }, 'payload/context')
+  const throwIfAborted = () => {
+    if (signal?.aborted)
+      throw createTimeoutError(sandbox.provider, definitionOptions?.timeout || 0)
+  }
 
   await sandbox.mkdir(files.baseDir, { recursive: true })
   try {
+    throwIfAborted()
     await writeSandboxDefinitionBundle(sandbox, files.baseDir, bundle)
+    throwIfAborted()
     await Promise.all([
       sandbox.writeFile(files.entryPath, createEntrySource(definitionPath)),
       sandbox.writeFile(files.inputPath, inputJson),
     ])
+    throwIfAborted()
 
     const launcher = resolveLauncher(sandbox.provider, definitionOptions?.runtime)
     const execArgs = [...launcher.args, files.entryPath, files.inputPath, files.outputPath]
@@ -183,6 +191,7 @@ export async function executeSandboxDefinition<TPayload, TResult>(
   }
 
   let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const abortController = new AbortController()
 
   try {
     return await Promise.race([
@@ -193,9 +202,13 @@ export async function executeSandboxDefinition<TPayload, TResult>(
         source,
         payload,
         context,
+        abortController.signal,
       ),
       new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => reject(createTimeoutError(sandbox.provider, timeout)), timeout)
+        timeoutId = setTimeout(() => {
+          abortController.abort()
+          reject(createTimeoutError(sandbox.provider, timeout))
+        }, timeout)
       }),
     ]) as TResult
   }

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -1,4 +1,4 @@
-import { resolveExecRequestTimeout } from '../sandbox/adapters/cloudflare/transport'
+import { resolveExecRequestTimeout, withCloudflareDeadline } from '../sandbox/adapters/cloudflare/transport'
 import { SandboxError } from '../sandbox/errors'
 import { shellQuote } from '../sandbox/utils'
 import { createEntrySource } from './entry-script'
@@ -62,9 +62,11 @@ async function executeLauncher(
   const nativeCloudflareSession = cloudflareSandbox?.native as { createSession?: unknown } | undefined
   if (cloudflareSandbox && typeof nativeCloudflareSession?.createSession === 'function') {
     const timeout = resolveExecRequestTimeout(options.timeout)
-    const session = await cloudflareSandbox.cloudflare.createSession({
-      env: options.env,
-      timeout,
+    const session = await withCloudflareDeadline('createSession', timeout, async () => {
+      return await cloudflareSandbox.cloudflare.createSession({
+        env: options.env,
+        timeout,
+      })
     })
     try {
       const result = await session.exec([command, ...args].map(shellQuote).join(' '), {
@@ -130,6 +132,9 @@ async function executeSandboxDefinitionOnce<TPayload, TResult>(
       outputRaw = await readExecOutputWithRecovery(sandbox, files.outputPath, execution, definitionOptions?.timeout, execution)
     }
     catch (error) {
+      if (error instanceof SandboxError && error.details?.operation === 'createSession')
+        throw error
+
       if (execution) {
         outputRaw = await readExecOutputWithRecovery(sandbox, files.outputPath, error, definitionOptions?.timeout, execution)
       }

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -79,7 +79,7 @@ async function executeLauncher(
       }
     }
     finally {
-      await session.destroy().catch(() => {})
+      await cloudflareSandbox.cloudflare.deleteSession(session.id).catch(() => {})
     }
   }
 

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -106,7 +106,6 @@ async function executeLauncher(
   }
 
   return await sandbox.exec(command, args, {
-    cwd: options.cwd,
     env: options.env,
     timeout: options.timeout,
   })

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -1,4 +1,5 @@
 import { SandboxError } from '../sandbox/errors'
+import { shellQuote } from '../sandbox/utils'
 import { createEntrySource } from './entry-script'
 import {
   createExecutionFiles,
@@ -48,6 +49,34 @@ function resolveLauncher(_provider: SandboxClient['provider'], runtime?: Sandbox
   }
 }
 
+async function executeLauncher(
+  sandbox: SandboxClient,
+  command: string,
+  args: string[],
+  options: { env?: Record<string, string>, timeout?: number },
+) {
+  if (sandbox.provider === 'cloudflare' && typeof sandbox.native.createSession === 'function') {
+    const session = await sandbox.cloudflare.createSession({
+      env: options.env,
+      timeout: options.timeout,
+    })
+    try {
+      const result = await session.exec([command, ...args].map(shellQuote).join(' '), options)
+      return {
+        ok: result.exitCode === 0,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        code: result.exitCode,
+      }
+    }
+    finally {
+      await session.destroy().catch(() => {})
+    }
+  }
+
+  return await sandbox.exec(command, args, options)
+}
+
 async function executeSandboxDefinitionOnce<TPayload, TResult>(
   sandbox: SandboxClient,
   definitionName: string,
@@ -77,7 +106,7 @@ async function executeSandboxDefinitionOnce<TPayload, TResult>(
     let execution: Awaited<ReturnType<SandboxClient['exec']>> | undefined
 
     try {
-      execution = await sandbox.exec(launcher.command, execArgs, {
+      execution = await executeLauncher(sandbox, launcher.command, execArgs, {
         env: definitionOptions?.env,
         timeout: definitionOptions?.timeout,
       })

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -17,7 +17,7 @@ import {
   tryParseSandboxOutput,
 } from './output-recovery'
 
-import type { SandboxClient } from '../sandbox/types'
+import type { CloudflareSandboxClient, SandboxClient } from '../sandbox/types'
 import type { SandboxDefinitionOptions, SandboxDefinitionRuntime } from '../module-types'
 
 const defaultNodeLauncher = 'import(process.argv[1])'
@@ -55,8 +55,11 @@ async function executeLauncher(
   args: string[],
   options: { env?: Record<string, string>, timeout?: number },
 ) {
-  if (sandbox.provider === 'cloudflare' && typeof sandbox.native.createSession === 'function') {
-    const session = await sandbox.cloudflare.createSession({
+  const cloudflareSandbox = sandbox.provider === 'cloudflare'
+    ? sandbox as CloudflareSandboxClient
+    : undefined
+  if (cloudflareSandbox && typeof cloudflareSandbox.native.createSession === 'function') {
+    const session = await cloudflareSandbox.cloudflare.createSession({
       env: options.env,
       timeout: options.timeout,
     })

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -1,4 +1,4 @@
-import { createCloudflareTransportError, resolveExecRequestTimeout, withCloudflareDeadline } from '../sandbox/adapters/cloudflare/transport'
+import { CLOUDFLARE_CONTROL_PLANE_TIMEOUT_MS, createCloudflareTransportError, resolveExecRequestTimeout, withCloudflareDeadline } from '../sandbox/adapters/cloudflare/transport'
 import { SandboxError } from '../sandbox/errors'
 import { shellQuote } from '../sandbox/utils'
 import { createEntrySource } from './entry-script'
@@ -80,7 +80,15 @@ async function executeLauncher(
         ? error
         : createCloudflareTransportError('createSession', error)
     }
-    const deleteSession = async () => await cloudflareSandbox.cloudflare.deleteSession(session.id).catch(() => {})
+    const deleteSession = async () => {
+      const remaining = options.deadline ? Math.max(1, options.deadline - Date.now()) : undefined
+      const timeout = Math.min(CLOUDFLARE_CONTROL_PLANE_TIMEOUT_MS, remaining ?? Number.POSITIVE_INFINITY)
+      await withCloudflareDeadline(
+        'deleteSession',
+        timeout,
+        async () => await cloudflareSandbox.cloudflare.deleteSession(session.id),
+      ).catch(() => {})
+    }
     const abortSession = () => void deleteSession()
     try {
       if (options.signal?.aborted) {

--- a/packages/sandbox/src/runtime/execute.ts
+++ b/packages/sandbox/src/runtime/execute.ts
@@ -88,10 +88,13 @@ async function executeLauncher(
         throw createTimeoutError(sandbox.provider, options.timeout || 0)
       }
       options.signal?.addEventListener('abort', abortSession, { once: true })
-      const result = await session.exec([command, ...args].map(shellQuote).join(' '), {
-        ...options,
-        timeout,
-      })
+      const result = await withCloudflareDeadline('exec', timeout, async () => await session.exec(
+        [command, ...args].map(shellQuote).join(' '),
+        {
+          ...options,
+          timeout,
+        },
+      ))
       return {
         ok: result.exitCode === 0,
         stdout: result.stdout,

--- a/packages/sandbox/src/runtime/provider-resolution.ts
+++ b/packages/sandbox/src/runtime/provider-resolution.ts
@@ -22,7 +22,7 @@ export function createCloudflareExecutionSandboxId(name: string, sandboxId?: str
   if (sandboxId)
     return sandboxId
 
-  return encodeURIComponent(name)
+  return `vitehub-${encodeURIComponent(name)}-definition`
 }
 
 export function resolveRuntimeProvider(provider?: SandboxDefinitionProviderOptions, event?: SandboxEvent) {

--- a/packages/sandbox/src/runtime/provider-resolution.ts
+++ b/packages/sandbox/src/runtime/provider-resolution.ts
@@ -18,11 +18,18 @@ type SandboxEvent = {
 
 const allowedDefinitionKeys = new Set(['timeout', 'env', 'runtime'])
 
+function hashCloudflareSandboxName(name: string) {
+  let hash = 2166136261
+  for (let index = 0; index < name.length; index++)
+    hash = Math.imul(hash ^ name.charCodeAt(index), 16777619)
+  return (hash >>> 0).toString(36)
+}
+
 export function createCloudflareExecutionSandboxId(name: string, sandboxId?: string) {
   if (sandboxId)
     return sandboxId
 
-  return `vitehub-${encodeURIComponent(name)}-definition`
+  return `vitehub-${encodeURIComponent(name)}-${hashCloudflareSandboxName(name)}-definition`
 }
 
 export function resolveRuntimeProvider(provider?: SandboxDefinitionProviderOptions, event?: SandboxEvent) {

--- a/packages/sandbox/src/runtime/provider-resolution.ts
+++ b/packages/sandbox/src/runtime/provider-resolution.ts
@@ -29,7 +29,10 @@ export function createCloudflareExecutionSandboxId(name: string, sandboxId?: str
   if (sandboxId)
     return sandboxId
 
-  return `vitehub-${encodeURIComponent(name)}-${hashCloudflareSandboxName(name)}-definition`
+  const prefix = 'vitehub-'
+  const suffix = `-${hashCloudflareSandboxName(name)}-definition`
+  const slug = encodeURIComponent(name).slice(0, 256 - prefix.length - suffix.length)
+  return `${prefix}${slug}${suffix}`
 }
 
 export function resolveRuntimeProvider(provider?: SandboxDefinitionProviderOptions, event?: SandboxEvent) {

--- a/packages/sandbox/src/runtime/provider-resolution.ts
+++ b/packages/sandbox/src/runtime/provider-resolution.ts
@@ -22,9 +22,7 @@ export function createCloudflareExecutionSandboxId(name: string, sandboxId?: str
   if (sandboxId)
     return sandboxId
 
-  const hash = globalThis.crypto.randomUUID().replace(/-/g, '').slice(0, 24)
-
-  return `vitehub-${name.replace(/[^a-z0-9-]/gi, '-').toLowerCase()}-${hash}`
+  return name.replace(/[^a-z0-9-]/gi, '-').toLowerCase()
 }
 
 export function resolveRuntimeProvider(provider?: SandboxDefinitionProviderOptions, event?: SandboxEvent) {

--- a/packages/sandbox/src/runtime/provider-resolution.ts
+++ b/packages/sandbox/src/runtime/provider-resolution.ts
@@ -22,7 +22,7 @@ export function createCloudflareExecutionSandboxId(name: string, sandboxId?: str
   if (sandboxId)
     return sandboxId
 
-  return name.replace(/[^a-z0-9-]/gi, '-').toLowerCase()
+  return encodeURIComponent(name)
 }
 
 export function resolveRuntimeProvider(provider?: SandboxDefinitionProviderOptions, event?: SandboxEvent) {

--- a/packages/sandbox/src/runtime/providers/cloudflare.ts
+++ b/packages/sandbox/src/runtime/providers/cloudflare.ts
@@ -39,7 +39,7 @@ export async function resolveSandboxProvider(options: SandboxOptions, context: {
     namespace,
     sandboxId: options.provider.sandboxId,
     cloudflare: {
-      sleepAfter: options.provider.sleepAfter,
+      sleepAfter: options.provider.sleepAfter ?? '5m',
       keepAlive: options.provider.keepAlive,
       normalizeId: options.provider.normalizeId,
     },

--- a/packages/sandbox/src/runtime/runtime.ts
+++ b/packages/sandbox/src/runtime/runtime.ts
@@ -97,7 +97,7 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
 
     return {
       name: context.name,
-      async run(payload, options = {}) {
+      async run<TPayload = unknown, TResult = unknown>(payload?: TPayload, options: SandboxExecutionOptions = {}): Promise<TResult> {
         const cloudflareSandboxId = provider.provider === 'cloudflare'
           ? createCloudflareExecutionSandboxId(context.name, options.sandboxId || provider.sandboxId)
           : undefined
@@ -107,6 +107,7 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
 
         for (let attempt = 0; attempt < attempts; attempt++) {
           let sandbox: SandboxClient | undefined
+          let succeeded = false
 
           try {
             const createdSandbox = await runtimeProvider.createSandboxClient(
@@ -118,7 +119,7 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
                 : provider as SandboxProviderOptions,
             )
             sandbox = createdSandbox
-            return await executeSandboxDefinition(
+            const result = await executeSandboxDefinition<TPayload, TResult>(
               createdSandbox,
               context.name,
               context.definition.options,
@@ -126,6 +127,8 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
               payload,
               options.context,
             )
+            succeeded = true
+            return result
           }
           catch (error) {
             const sandboxError = toSandboxError(error)
@@ -139,7 +142,8 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
             await sleep(CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS[attempt])
           }
           finally {
-            await sandbox?.stop().catch(() => {})
+            if (provider.provider !== 'cloudflare' || !succeeded)
+              await sandbox?.stop().catch(() => {})
           }
         }
 

--- a/packages/sandbox/src/runtime/runtime.ts
+++ b/packages/sandbox/src/runtime/runtime.ts
@@ -107,8 +107,6 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
 
         for (let attempt = 0; attempt < attempts; attempt++) {
           let sandbox: SandboxClient | undefined
-          let succeeded = false
-
           try {
             const createdSandbox = await runtimeProvider.createSandboxClient(
               cloudflareSandboxId
@@ -127,7 +125,6 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
               payload,
               options.context,
             )
-            succeeded = true
             return result
           }
           catch (error) {
@@ -142,7 +139,7 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
             await sleep(CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS[attempt])
           }
           finally {
-            if (provider.provider !== 'cloudflare' || !succeeded)
+            if (provider.provider !== 'cloudflare')
               await sandbox?.stop().catch(() => {})
           }
         }

--- a/packages/sandbox/src/runtime/runtime.ts
+++ b/packages/sandbox/src/runtime/runtime.ts
@@ -139,7 +139,7 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
             await sleep(CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS[attempt])
           }
           finally {
-            if (provider.provider !== 'cloudflare')
+            if (provider.provider !== 'cloudflare' || provider.keepAlive === true)
               await sandbox?.stop().catch(() => {})
           }
         }

--- a/packages/sandbox/src/runtime/runtime.ts
+++ b/packages/sandbox/src/runtime/runtime.ts
@@ -139,7 +139,7 @@ const sandboxPort: ProviderPort<SandboxProviderOptions, SandboxRunner, SandboxRu
             await sleep(CLOUDFLARE_SANDBOX_RETRY_DELAYS_MS[attempt])
           }
           finally {
-            if (provider.provider !== 'cloudflare' || provider.keepAlive === true)
+            if (provider.provider !== 'cloudflare' || provider.cloudflare?.keepAlive === true)
               await sandbox?.stop().catch(() => {})
           }
         }

--- a/packages/sandbox/src/sandbox/types/cloudflare.ts
+++ b/packages/sandbox/src/sandbox/types/cloudflare.ts
@@ -23,7 +23,6 @@ export interface CloudflareSandboxSession {
   id: string
   exec: (cmd: string, opts?: { timeout?: number, env?: Record<string, string>, cwd?: string }) => Promise<{ stdout: string, stderr: string, exitCode: number }>
   startProcess: (cmd: string, args?: string[], opts?: { cwd?: string, env?: Record<string, string> }) => Promise<CloudflareSandboxSessionProcess>
-  destroy: () => Promise<void>
 }
 
 export interface CloudflareSandboxSessionProcess {

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -84,6 +84,9 @@ function invalidateGeneratedSandboxModules(files: string[], moduleGraph: { getMo
 
 export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
   const internalOptions = options as SandboxPublicOptions & SandboxViteInternalOptions | undefined
+  const integrationOptions = options && typeof options === 'object'
+    ? Object.fromEntries(Object.entries(options).filter(([key]) => key !== 'providerImportAliases' && key !== 'providerImportSpecifier')) as SandboxPublicOptions
+    : options
   const mergeNoExternal = createNoExternalMerger('@vite-hub/sandbox')
   let generatedAliases: AliasMap = {}
   let generatedFiles: string[] = []
@@ -109,7 +112,7 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
 
   async function prepareCurrentSandboxRuntime(writeArtifacts = true) {
     const prepared = await prepareSandboxRuntime({
-      integrationOptions: options,
+      integrationOptions,
       userConfig: rawConfig,
       env: rawEnv,
       resolvedConfig,

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -129,12 +129,11 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
     definitions = prepared.definitions
     if (internalOptions?.providerImportAliases && internalOptions.providerImportSpecifier) {
       const facade = generatedAliases[SANDBOX_PACKAGE_ID]
+      delete internalOptions.providerImportAliases[SANDBOX_PACKAGE_ID]
       if (facade) {
-        internalOptions.providerImportAliases[SANDBOX_PACKAGE_ID] = facade
         internalOptions.providerImportAliases[internalOptions.providerImportSpecifier] = facade
       }
       else {
-        delete internalOptions.providerImportAliases[SANDBOX_PACKAGE_ID]
         delete internalOptions.providerImportAliases[internalOptions.providerImportSpecifier]
       }
     }

--- a/packages/sandbox/test/cloudflare-runtime-provider.test.ts
+++ b/packages/sandbox/test/cloudflare-runtime-provider.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from "vitest"
+
+const { getSandbox } = vi.hoisted(() => ({ getSandbox: vi.fn() }))
+
+vi.mock("@cloudflare/sandbox", () => ({ getSandbox }))
+
+import { resolveSandboxProvider } from "../src/runtime/providers/cloudflare.ts"
+
+const namespace = {
+  get: vi.fn(),
+  idFromName: vi.fn(),
+}
+
+describe("Cloudflare Sandbox runtime provider", () => {
+  it("defaults idle shutdown to five minutes", async () => {
+    const provider = await resolveSandboxProvider({
+      local: {},
+      provider: { provider: "cloudflare" },
+    }, {
+      event: { context: { cloudflare: { env: { SANDBOX: namespace } } } },
+    })
+
+    expect(provider.cloudflare.sleepAfter).toBe("5m")
+  })
+
+  it("preserves an explicit idle shutdown override", async () => {
+    const provider = await resolveSandboxProvider({
+      local: {},
+      provider: { provider: "cloudflare", sleepAfter: "30s" },
+    }, {
+      event: { context: { cloudflare: { env: { SANDBOX: namespace } } } },
+    })
+
+    expect(provider.cloudflare.sleepAfter).toBe("30s")
+  })
+})

--- a/packages/sandbox/test/execute.test.ts
+++ b/packages/sandbox/test/execute.test.ts
@@ -146,18 +146,19 @@ describe("executeSandboxDefinition", () => {
   it("deletes Cloudflare execution sessions through the sandbox", async () => {
     const { sandbox, files } = createFakeSandbox({ provider: "cloudflare" })
     const deleteSession = vi.fn(async () => {})
+    const createSession = vi.fn(async () => ({
+      id: "execution-session",
+      exec: vi.fn(async (command: string) => {
+        const outputPath = command.trim().split(/\s+/).at(-1)?.replace(/^'|'$/g, "")
+        if (outputPath)
+          files.set(outputPath, JSON.stringify({ ok: true, result: { ok: true } }))
+        return { exitCode: 0, stdout: "", stderr: "" }
+      }),
+    }))
     Object.assign(sandbox, {
       native: { createSession: vi.fn() },
       cloudflare: {
-        createSession: vi.fn(async () => ({
-          id: "execution-session",
-          exec: vi.fn(async (command: string) => {
-            const outputPath = command.trim().split(/\s+/).at(-1)?.replace(/^'|'$/g, "")
-            if (outputPath)
-              files.set(outputPath, JSON.stringify({ ok: true, result: { ok: true } }))
-            return { exitCode: 0, stdout: "", stderr: "" }
-          }),
-        })),
+        createSession,
         deleteSession,
       } as unknown as typeof sandbox.cloudflare,
     })
@@ -175,6 +176,42 @@ describe("executeSandboxDefinition", () => {
     )).resolves.toEqual({ ok: true })
 
     expect(deleteSession).toHaveBeenCalledWith("execution-session")
+    expect(createSession).toHaveBeenCalledWith(expect.objectContaining({
+      cwd: expect.stringMatching(/^\/tmp\/vitehub-sandbox\/release-notes-/),
+    }))
+  })
+
+  it("deletes a Cloudflare session created after the definition timeout", async () => {
+    const { sandbox } = createFakeSandbox({ provider: "cloudflare" })
+    const sessionExec = vi.fn()
+    const deleteSession = vi.fn(async () => {})
+    let finishCreation: ((session: unknown) => void) | undefined
+    Object.assign(sandbox, {
+      native: { createSession: vi.fn() },
+      cloudflare: {
+        createSession: vi.fn(async () => await new Promise(resolve => {
+          finishCreation = resolve
+        })),
+        deleteSession,
+      } as unknown as typeof sandbox.cloudflare,
+    })
+
+    await expect(executeSandboxDefinition(
+      sandbox,
+      "release-notes",
+      { timeout: 10 },
+      {
+        entry: "definition.mjs",
+        modules: {
+          "definition.mjs": "export default { run() { return { ok: true } } }",
+        },
+      },
+    )).rejects.toMatchObject({ code: "TIMEOUT", provider: "cloudflare" })
+
+    finishCreation?.({ id: "late-session", exec: sessionExec })
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(sessionExec).not.toHaveBeenCalled()
+    expect(deleteSession).toHaveBeenCalledWith("late-session")
   })
 
   it("bounds Cloudflare session creation with the default exec deadline", async () => {

--- a/packages/sandbox/test/execute.test.ts
+++ b/packages/sandbox/test/execute.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { executeSandboxDefinition } from "../src/runtime/execute.ts"
 import type { SandboxError } from "../src/sandbox/errors.ts"
@@ -134,6 +134,40 @@ describe("executeSandboxDefinition", () => {
       cmd: "rm",
       args: ["-rf", "--", expect.stringMatching(/^\/tmp\/vitehub-sandbox\/release-notes-/)],
     })
+  })
+
+  it("deletes Cloudflare execution sessions through the sandbox", async () => {
+    const { sandbox, files } = createFakeSandbox({ provider: "cloudflare" })
+    const deleteSession = vi.fn(async () => {})
+    Object.assign(sandbox, {
+      native: { createSession: vi.fn() },
+      cloudflare: {
+        createSession: vi.fn(async () => ({
+          id: "execution-session",
+          exec: vi.fn(async (command: string) => {
+            const outputPath = command.trim().split(/\s+/).at(-1)?.replace(/^'|'$/g, "")
+            if (outputPath)
+              files.set(outputPath, JSON.stringify({ ok: true, result: { ok: true } }))
+            return { exitCode: 0, stdout: "", stderr: "" }
+          }),
+        })),
+        deleteSession,
+      } as unknown as typeof sandbox.cloudflare,
+    })
+
+    await expect(executeSandboxDefinition(
+      sandbox,
+      "release-notes",
+      undefined,
+      {
+        entry: "definition.mjs",
+        modules: {
+          "definition.mjs": "export default { run() { return { ok: true } } }",
+        },
+      },
+    )).resolves.toEqual({ ok: true })
+
+    expect(deleteSession).toHaveBeenCalledWith("execution-session")
   })
 
   it("rethrows unrecoverable exec errors instead of masking them as output parse failures", async () => {

--- a/packages/sandbox/test/execute.test.ts
+++ b/packages/sandbox/test/execute.test.ts
@@ -251,6 +251,35 @@ describe("executeSandboxDefinition", () => {
     }
   })
 
+  it("preserves Cloudflare session creation failures for runtime retry", async () => {
+    const { sandbox } = createFakeSandbox({ provider: "cloudflare" })
+    const creationError = new Error("network connection lost")
+    Object.assign(sandbox, {
+      native: { createSession: vi.fn() },
+      cloudflare: {
+        createSession: vi.fn(async () => { throw creationError }),
+      } as unknown as typeof sandbox.cloudflare,
+    })
+
+    await expect(executeSandboxDefinition(
+      sandbox,
+      "release-notes",
+      undefined,
+      {
+        entry: "definition.mjs",
+        modules: {
+          "definition.mjs": "export default { run() { return { ok: true } } }",
+        },
+      },
+    )).rejects.toMatchObject({
+      message: "network connection lost",
+      cause: creationError,
+      code: "SANDBOX_TRANSPORT_ERROR",
+      details: { operation: "createSession" },
+      provider: "cloudflare",
+    } satisfies Partial<SandboxError>)
+  })
+
   it("rethrows unrecoverable exec errors instead of masking them as output parse failures", async () => {
     const execError = new Error("vercel transport unavailable")
     const { sandbox } = createFakeSandbox({ execError })

--- a/packages/sandbox/test/execute.test.ts
+++ b/packages/sandbox/test/execute.test.ts
@@ -4,13 +4,14 @@ import { executeSandboxDefinition } from "../src/runtime/execute.ts"
 import type { SandboxError } from "../src/sandbox/errors.ts"
 import type { SandboxClient, SandboxExecResult } from "../src/sandbox/types.ts"
 
-function createFakeSandbox(options: { execError?: Error, execResult?: SandboxExecResult } = {}) {
+function createFakeSandbox(options: { execError?: Error, execResult?: SandboxExecResult, provider?: "cloudflare" | "vercel" } = {}) {
   const files = new Map<string, string>()
   const execCalls: Array<{ cmd: string, args: string[] }> = []
+  const deleteFileCalls: string[] = []
 
   const sandbox = {
     id: "fake",
-    provider: "vercel",
+    provider: options.provider ?? "vercel",
     supports: {
       execEnv: true,
       execCwd: false,
@@ -65,15 +66,19 @@ function createFakeSandbox(options: { execError?: Error, execResult?: SandboxExe
     async exists() {
       throw new Error("not implemented")
     },
-    async deleteFile() {
-      throw new Error("not implemented")
+    async deleteFile(path: string) {
+      deleteFileCalls.push(path)
+      for (const file of files.keys()) {
+        if (file === path || file.startsWith(`${path}/`))
+          files.delete(file)
+      }
     },
     async moveFile() {
       throw new Error("not implemented")
     },
   } as unknown as SandboxClient
 
-  return { sandbox, execCalls }
+  return { sandbox, deleteFileCalls, execCalls, files }
 }
 
 describe("executeSandboxDefinition", () => {
@@ -95,6 +100,26 @@ describe("executeSandboxDefinition", () => {
     expect(execCalls).toHaveLength(1)
     expect(execCalls[0]?.cmd).toBe("node")
     expect(execCalls[0]?.args.slice(0, 2)).toEqual(["-e", "import(process.argv[1])"])
+  })
+
+  it("deletes successful Cloudflare invocation files before reuse", async () => {
+    const { sandbox, deleteFileCalls, files } = createFakeSandbox({ provider: "cloudflare" })
+
+    await expect(executeSandboxDefinition(
+      sandbox,
+      "release-notes",
+      undefined,
+      {
+        entry: "definition.mjs",
+        modules: {
+          "definition.mjs": "export default { run() { return { ok: true } } }",
+        },
+      },
+    )).resolves.toEqual({ ok: true })
+
+    expect(deleteFileCalls).toHaveLength(1)
+    expect(deleteFileCalls[0]).toMatch(/^\/tmp\/vitehub-sandbox\/release-notes-/)
+    expect(files.size).toBe(0)
   })
 
   it("rethrows unrecoverable exec errors instead of masking them as output parse failures", async () => {

--- a/packages/sandbox/test/execute.test.ts
+++ b/packages/sandbox/test/execute.test.ts
@@ -76,8 +76,11 @@ function createFakeSandbox(options: { execError?: Error, execResult?: SandboxExe
 
 describe("executeSandboxDefinition", () => {
   it("bounds Cloudflare setup with the definition timeout", async () => {
-    const { sandbox } = createFakeSandbox({ provider: "cloudflare" })
-    sandbox.mkdir = async () => await new Promise(() => {})
+    const { sandbox, execCalls } = createFakeSandbox({ provider: "cloudflare" })
+    let finishSetup: (() => void) | undefined
+    sandbox.mkdir = async () => await new Promise<void>((resolve) => {
+      finishSetup = resolve
+    })
 
     await expect(executeSandboxDefinition(
       sandbox,
@@ -93,6 +96,10 @@ describe("executeSandboxDefinition", () => {
       code: "TIMEOUT",
       provider: "cloudflare",
     } satisfies Partial<SandboxError>)
+
+    finishSetup?.()
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(execCalls.some(call => call.cmd === "node")).toBe(false)
   })
 
   it("imports the generated entry once with the default Node launcher", async () => {

--- a/packages/sandbox/test/execute.test.ts
+++ b/packages/sandbox/test/execute.test.ts
@@ -7,7 +7,6 @@ import type { SandboxClient, SandboxExecResult } from "../src/sandbox/types.ts"
 function createFakeSandbox(options: { execError?: Error, execResult?: SandboxExecResult, provider?: "cloudflare" | "vercel" } = {}) {
   const files = new Map<string, string>()
   const execCalls: Array<{ cmd: string, args: string[] }> = []
-  const deleteFileCalls: string[] = []
 
   const sandbox = {
     id: "fake",
@@ -66,19 +65,13 @@ function createFakeSandbox(options: { execError?: Error, execResult?: SandboxExe
     async exists() {
       throw new Error("not implemented")
     },
-    async deleteFile(path: string) {
-      deleteFileCalls.push(path)
-      for (const file of files.keys()) {
-        if (file === path || file.startsWith(`${path}/`))
-          files.delete(file)
-      }
-    },
+    async deleteFile() {},
     async moveFile() {
       throw new Error("not implemented")
     },
   } as unknown as SandboxClient
 
-  return { sandbox, deleteFileCalls, execCalls, files }
+  return { sandbox, execCalls, files }
 }
 
 describe("executeSandboxDefinition", () => {
@@ -102,8 +95,8 @@ describe("executeSandboxDefinition", () => {
     expect(execCalls[0]?.args.slice(0, 2)).toEqual(["-e", "import(process.argv[1])"])
   })
 
-  it("deletes successful Cloudflare invocation files before reuse", async () => {
-    const { sandbox, deleteFileCalls, files } = createFakeSandbox({ provider: "cloudflare" })
+  it("recursively deletes successful Cloudflare invocation files before reuse", async () => {
+    const { sandbox, execCalls } = createFakeSandbox({ provider: "cloudflare" })
 
     await expect(executeSandboxDefinition(
       sandbox,
@@ -117,9 +110,10 @@ describe("executeSandboxDefinition", () => {
       },
     )).resolves.toEqual({ ok: true })
 
-    expect(deleteFileCalls).toHaveLength(1)
-    expect(deleteFileCalls[0]).toMatch(/^\/tmp\/vitehub-sandbox\/release-notes-/)
-    expect(files.size).toBe(0)
+    expect(execCalls.at(-1)).toMatchObject({
+      cmd: "rm",
+      args: ["-rf", "--", expect.stringMatching(/^\/tmp\/vitehub-sandbox\/release-notes-/)],
+    })
   })
 
   it("rethrows unrecoverable exec errors instead of masking them as output parse failures", async () => {

--- a/packages/sandbox/test/execute.test.ts
+++ b/packages/sandbox/test/execute.test.ts
@@ -6,7 +6,7 @@ import type { SandboxClient, SandboxExecResult } from "../src/sandbox/types.ts"
 
 function createFakeSandbox(options: { execError?: Error, execResult?: SandboxExecResult, provider?: "cloudflare" | "vercel" } = {}) {
   const files = new Map<string, string>()
-  const execCalls: Array<{ cmd: string, args: string[] }> = []
+  const execCalls: Array<{ cmd: string, args: string[], options?: { cwd?: string } }> = []
 
   const sandbox = {
     id: "fake",
@@ -23,8 +23,8 @@ function createFakeSandbox(options: { execError?: Error, execResult?: SandboxExe
       startProcess: false,
     },
     native: {},
-    async exec(cmd: string, args: string[] = []): Promise<SandboxExecResult> {
-      execCalls.push({ cmd, args })
+    async exec(cmd: string, args: string[] = [], execOptions?: { cwd?: string }): Promise<SandboxExecResult> {
+      execCalls.push({ cmd, args, options: execOptions })
       if (options.execError)
         throw options.execError
       if (options.execResult)
@@ -120,6 +120,7 @@ describe("executeSandboxDefinition", () => {
     expect(execCalls).toHaveLength(1)
     expect(execCalls[0]?.cmd).toBe("node")
     expect(execCalls[0]?.args.slice(0, 2)).toEqual(["-e", "import(process.argv[1])"])
+    expect(execCalls[0]?.options?.cwd).toBeUndefined()
   })
 
   it("recursively deletes successful Cloudflare invocation files before reuse", async () => {

--- a/packages/sandbox/test/execute.test.ts
+++ b/packages/sandbox/test/execute.test.ts
@@ -295,6 +295,47 @@ describe("executeSandboxDefinition", () => {
     }
   })
 
+  it("bounds Cloudflare session deletion with the control-plane deadline", async () => {
+    vi.useFakeTimers()
+    try {
+      const { sandbox, files } = createFakeSandbox({ provider: "cloudflare" })
+      Object.assign(sandbox, {
+        native: { createSession: vi.fn() },
+        cloudflare: {
+          createSession: vi.fn(async () => ({
+            id: "completed-session",
+            exec: vi.fn(async (command: string) => {
+              const outputPath = command.trim().split(/\s+/).at(-1)?.replace(/^'|'$/g, "")
+              if (outputPath)
+                files.set(outputPath, JSON.stringify({ ok: true, result: { ok: true } }))
+              return { exitCode: 0, stdout: "", stderr: "" }
+            }),
+          })),
+          deleteSession: vi.fn(async () => await new Promise(() => {})),
+        } as unknown as typeof sandbox.cloudflare,
+      })
+
+      const execution = executeSandboxDefinition(
+        sandbox,
+        "release-notes",
+        undefined,
+        {
+          entry: "definition.mjs",
+          modules: {
+            "definition.mjs": "export default { run() { return { ok: true } } }",
+          },
+        },
+      )
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(15_000)
+
+      await expect(execution).resolves.toEqual({ ok: true })
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("recovers output after raw Cloudflare session transport failures", async () => {
     const { sandbox, files } = createFakeSandbox({ provider: "cloudflare" })
     Object.assign(sandbox, {

--- a/packages/sandbox/test/execute.test.ts
+++ b/packages/sandbox/test/execute.test.ts
@@ -75,6 +75,26 @@ function createFakeSandbox(options: { execError?: Error, execResult?: SandboxExe
 }
 
 describe("executeSandboxDefinition", () => {
+  it("bounds Cloudflare setup with the definition timeout", async () => {
+    const { sandbox } = createFakeSandbox({ provider: "cloudflare" })
+    sandbox.mkdir = async () => await new Promise(() => {})
+
+    await expect(executeSandboxDefinition(
+      sandbox,
+      "release-notes",
+      { timeout: 10 },
+      {
+        entry: "definition.mjs",
+        modules: {
+          "definition.mjs": "export default { run() { return { ok: true } } }",
+        },
+      },
+    )).rejects.toMatchObject({
+      code: "TIMEOUT",
+      provider: "cloudflare",
+    } satisfies Partial<SandboxError>)
+  })
+
   it("imports the generated entry once with the default Node launcher", async () => {
     const { sandbox, execCalls } = createFakeSandbox()
 

--- a/packages/sandbox/test/execute.test.ts
+++ b/packages/sandbox/test/execute.test.ts
@@ -252,6 +252,49 @@ describe("executeSandboxDefinition", () => {
     }
   })
 
+  it("bounds Cloudflare session execution with the default exec deadline", async () => {
+    vi.useFakeTimers()
+    try {
+      const { sandbox } = createFakeSandbox({ provider: "cloudflare" })
+      const deleteSession = vi.fn(async () => {})
+      Object.assign(sandbox, {
+        native: { createSession: vi.fn() },
+        cloudflare: {
+          createSession: vi.fn(async () => ({
+            id: "stalled-session",
+            exec: vi.fn(async () => await new Promise(() => {})),
+          })),
+          deleteSession,
+        } as unknown as typeof sandbox.cloudflare,
+      })
+
+      const execution = executeSandboxDefinition(
+        sandbox,
+        "release-notes",
+        undefined,
+        {
+          entry: "definition.mjs",
+          modules: {
+            "definition.mjs": "export default { run() { return { ok: true } } }",
+          },
+        },
+      )
+      const rejection = expect(execution).rejects.toMatchObject({
+        code: "SANDBOX_HANDLER_ERROR",
+        provider: "cloudflare",
+        details: { cause: "Cloudflare sandbox exec timed out after 180000ms." },
+      } satisfies Partial<SandboxError>)
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(240_000)
+
+      await rejection
+      expect(deleteSession).toHaveBeenCalledWith("stalled-session")
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("preserves Cloudflare session creation failures for runtime retry", async () => {
     const { sandbox } = createFakeSandbox({ provider: "cloudflare" })
     const creationError = new Error("network connection lost")

--- a/packages/sandbox/test/execute.test.ts
+++ b/packages/sandbox/test/execute.test.ts
@@ -177,6 +177,43 @@ describe("executeSandboxDefinition", () => {
     expect(deleteSession).toHaveBeenCalledWith("execution-session")
   })
 
+  it("bounds Cloudflare session creation with the default exec deadline", async () => {
+    vi.useFakeTimers()
+    try {
+      const { sandbox } = createFakeSandbox({ provider: "cloudflare" })
+      Object.assign(sandbox, {
+        native: { createSession: vi.fn() },
+        cloudflare: {
+          createSession: vi.fn(async () => await new Promise(() => {})),
+        } as unknown as typeof sandbox.cloudflare,
+      })
+
+      const execution = executeSandboxDefinition(
+        sandbox,
+        "release-notes",
+        undefined,
+        {
+          entry: "definition.mjs",
+          modules: {
+            "definition.mjs": "export default { run() { return { ok: true } } }",
+          },
+        },
+      )
+      const rejection = expect(execution).rejects.toMatchObject({
+        code: "TIMEOUT",
+        provider: "cloudflare",
+        details: { operation: "createSession", timeout: 180_000 },
+      } satisfies Partial<SandboxError>)
+      await vi.advanceTimersByTimeAsync(0)
+      await vi.advanceTimersByTimeAsync(180_000)
+
+      await rejection
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("rethrows unrecoverable exec errors instead of masking them as output parse failures", async () => {
     const execError = new Error("vercel transport unavailable")
     const { sandbox } = createFakeSandbox({ execError })

--- a/packages/sandbox/test/execute.test.ts
+++ b/packages/sandbox/test/execute.test.ts
@@ -295,6 +295,37 @@ describe("executeSandboxDefinition", () => {
     }
   })
 
+  it("recovers output after raw Cloudflare session transport failures", async () => {
+    const { sandbox, files } = createFakeSandbox({ provider: "cloudflare" })
+    Object.assign(sandbox, {
+      native: { createSession: vi.fn() },
+      cloudflare: {
+        createSession: vi.fn(async () => ({
+          id: "failed-session",
+          exec: vi.fn(async (command: string) => {
+            const outputPath = command.trim().split(/\s+/).at(-1)?.replace(/^'|'$/g, "")
+            if (outputPath)
+              files.set(outputPath, JSON.stringify({ ok: true, result: { recovered: true } }))
+            throw new Error("rpc unavailable")
+          }),
+        })),
+        deleteSession: vi.fn(async () => {}),
+      } as unknown as typeof sandbox.cloudflare,
+    })
+
+    await expect(executeSandboxDefinition(
+      sandbox,
+      "release-notes",
+      undefined,
+      {
+        entry: "definition.mjs",
+        modules: {
+          "definition.mjs": "export default { run() { return { recovered: true } } }",
+        },
+      },
+    )).resolves.toEqual({ recovered: true })
+  })
+
   it("preserves Cloudflare session creation failures for runtime retry", async () => {
     const { sandbox } = createFakeSandbox({ provider: "cloudflare" })
     const creationError = new Error("network connection lost")

--- a/packages/sandbox/test/runtime-lifecycle.test.ts
+++ b/packages/sandbox/test/runtime-lifecycle.test.ts
@@ -55,6 +55,7 @@ describe("Sandbox runtime lifecycle", () => {
       .not.toBe(createCloudflareExecutionSandboxId("tools_release-notes"))
     expect(createCloudflareExecutionSandboxId("Example").toLowerCase())
       .not.toBe(createCloudflareExecutionSandboxId("example").toLowerCase())
+    expect(createCloudflareExecutionSandboxId(`tools/${"例/".repeat(100)}`)).toHaveLength(256)
   })
 
   it("uses the Definition name as the default Cloudflare identity and keeps successful runs idle", async () => {

--- a/packages/sandbox/test/runtime-lifecycle.test.ts
+++ b/packages/sandbox/test/runtime-lifecycle.test.ts
@@ -106,6 +106,10 @@ describe("Sandbox runtime lifecycle", () => {
     const sandbox = createSandbox("cloudflare")
     setSandboxRuntimeConfig({ provider: "cloudflare", keepAlive: true })
     setSandboxRuntimeRegistry({ example: definition })
+    runtimeMocks.resolveSandboxProvider.mockResolvedValue({
+      provider: "cloudflare",
+      cloudflare: { keepAlive: true },
+    })
     runtimeMocks.createSandboxClient.mockResolvedValue(sandbox)
     runtimeMocks.executeSandboxDefinition.mockResolvedValue({ ok: true })
 

--- a/packages/sandbox/test/runtime-lifecycle.test.ts
+++ b/packages/sandbox/test/runtime-lifecycle.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const runtimeMocks = vi.hoisted(() => ({
+  createSandboxClient: vi.fn(),
+  executeSandboxDefinition: vi.fn(),
+  resolveSandboxProvider: vi.fn(async ({ provider }: { provider: Record<string, unknown> }) => provider),
+}))
+
+vi.mock("../src/runtime/execute.ts", () => ({
+  executeSandboxDefinition: runtimeMocks.executeSandboxDefinition,
+}))
+
+vi.mock("vitehub-sandbox-provider-loader", () => ({
+  loadSandboxRuntimeProvider: async () => ({
+    createSandboxClient: runtimeMocks.createSandboxClient,
+    resolveSandboxProvider: runtimeMocks.resolveSandboxProvider,
+  }),
+}))
+
+import { runSandboxRuntime } from "../src/runtime/runtime.ts"
+import { resetSandboxRuntimeState, setSandboxRuntimeConfig, setSandboxRuntimeRegistry } from "../src/runtime/state.ts"
+
+const definition = {
+  bundle: {
+    entry: "index.mjs",
+    modules: { "index.mjs": "export default async () => ({ ok: true })" },
+  },
+}
+
+function createSandbox(provider: "cloudflare" | "vercel") {
+  return {
+    provider,
+    stop: vi.fn(async () => {}),
+  }
+}
+
+afterEach(() => {
+  resetSandboxRuntimeState()
+})
+
+beforeEach(() => {
+  runtimeMocks.createSandboxClient.mockReset()
+  runtimeMocks.executeSandboxDefinition.mockReset()
+  runtimeMocks.resolveSandboxProvider.mockReset()
+  runtimeMocks.resolveSandboxProvider.mockImplementation(async ({ provider }) => provider)
+})
+
+describe("Sandbox runtime lifecycle", () => {
+  it("uses the Definition name as the default Cloudflare identity and keeps successful runs idle", async () => {
+    const sandbox = createSandbox("cloudflare")
+    setSandboxRuntimeConfig({ provider: "cloudflare" })
+    setSandboxRuntimeRegistry({ example: definition })
+    runtimeMocks.createSandboxClient.mockResolvedValue(sandbox)
+    runtimeMocks.executeSandboxDefinition.mockResolvedValue({ ok: true })
+
+    const result = await runSandboxRuntime("example")
+
+    expect(result.isOk()).toBe(true)
+    expect(runtimeMocks.createSandboxClient).toHaveBeenCalledWith(expect.objectContaining({
+      provider: "cloudflare",
+      sandboxId: "example",
+    }))
+    expect(sandbox.stop).not.toHaveBeenCalled()
+  })
+
+  it("keeps configured and per-run Cloudflare identity overrides", async () => {
+    const sandbox = createSandbox("cloudflare")
+    setSandboxRuntimeConfig({ provider: "cloudflare", sandboxId: "configured" })
+    setSandboxRuntimeRegistry({ example: definition })
+    runtimeMocks.createSandboxClient.mockResolvedValue(sandbox)
+    runtimeMocks.executeSandboxDefinition.mockResolvedValue({ ok: true })
+
+    await runSandboxRuntime("example")
+    await runSandboxRuntime("example", undefined, { sandboxId: "per-run" })
+
+    expect(runtimeMocks.createSandboxClient).toHaveBeenNthCalledWith(1, expect.objectContaining({ sandboxId: "configured" }))
+    expect(runtimeMocks.createSandboxClient).toHaveBeenNthCalledWith(2, expect.objectContaining({ sandboxId: "per-run" }))
+  })
+
+  it("stops failed Cloudflare attempts", async () => {
+    const sandbox = createSandbox("cloudflare")
+    setSandboxRuntimeConfig({ provider: "cloudflare" })
+    setSandboxRuntimeRegistry({ example: definition })
+    runtimeMocks.createSandboxClient.mockResolvedValue(sandbox)
+    runtimeMocks.executeSandboxDefinition.mockRejectedValue(new Error("definition failed"))
+
+    const result = await runSandboxRuntime("example")
+
+    expect(result.isErr()).toBe(true)
+    expect(sandbox.stop).toHaveBeenCalledOnce()
+  })
+
+  it("keeps Vercel cleanup unchanged", async () => {
+    const sandbox = createSandbox("vercel")
+    setSandboxRuntimeConfig({ provider: "vercel" })
+    setSandboxRuntimeRegistry({ example: definition })
+    runtimeMocks.createSandboxClient.mockResolvedValue(sandbox)
+    runtimeMocks.executeSandboxDefinition.mockResolvedValue({ ok: true })
+
+    const result = await runSandboxRuntime("example")
+
+    expect(result.isOk()).toBe(true)
+    expect(sandbox.stop).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/sandbox/test/runtime-lifecycle.test.ts
+++ b/packages/sandbox/test/runtime-lifecycle.test.ts
@@ -48,13 +48,13 @@ beforeEach(() => {
 
 describe("Sandbox runtime lifecycle", () => {
   it("keeps distinct Definition names distinct in default Cloudflare identities", () => {
-    expect(createCloudflareExecutionSandboxId("tools/release-notes")).toBe("vitehub-tools%2Frelease-notes-definition")
-    expect(createCloudflareExecutionSandboxId("api")).toBe("vitehub-api-definition")
-    expect(createCloudflareExecutionSandboxId("-preview-")).toBe("vitehub--preview--definition")
+    expect(createCloudflareExecutionSandboxId("tools/release-notes")).toMatch(/^vitehub-tools%2Frelease-notes-[a-z0-9]+-definition$/)
+    expect(createCloudflareExecutionSandboxId("api")).toMatch(/^vitehub-api-[a-z0-9]+-definition$/)
+    expect(createCloudflareExecutionSandboxId("-preview-")).toMatch(/^vitehub--preview--[a-z0-9]+-definition$/)
     expect(createCloudflareExecutionSandboxId("tools/release-notes"))
       .not.toBe(createCloudflareExecutionSandboxId("tools_release-notes"))
-    expect(createCloudflareExecutionSandboxId("Example"))
-      .not.toBe(createCloudflareExecutionSandboxId("example"))
+    expect(createCloudflareExecutionSandboxId("Example").toLowerCase())
+      .not.toBe(createCloudflareExecutionSandboxId("example").toLowerCase())
   })
 
   it("uses the Definition name as the default Cloudflare identity and keeps successful runs idle", async () => {
@@ -69,7 +69,7 @@ describe("Sandbox runtime lifecycle", () => {
     expect(result.isOk()).toBe(true)
     expect(runtimeMocks.createSandboxClient).toHaveBeenCalledWith(expect.objectContaining({
       provider: "cloudflare",
-      sandboxId: "vitehub-example-definition",
+      sandboxId: expect.stringMatching(/^vitehub-example-[a-z0-9]+-definition$/),
     }))
     expect(sandbox.stop).not.toHaveBeenCalled()
   })
@@ -99,6 +99,19 @@ describe("Sandbox runtime lifecycle", () => {
 
     expect(result.isErr()).toBe(true)
     expect(sandbox.stop).not.toHaveBeenCalled()
+  })
+
+  it("stops Cloudflare sandboxes that explicitly disable idle shutdown", async () => {
+    const sandbox = createSandbox("cloudflare")
+    setSandboxRuntimeConfig({ provider: "cloudflare", keepAlive: true })
+    setSandboxRuntimeRegistry({ example: definition })
+    runtimeMocks.createSandboxClient.mockResolvedValue(sandbox)
+    runtimeMocks.executeSandboxDefinition.mockResolvedValue({ ok: true })
+
+    const result = await runSandboxRuntime("example")
+
+    expect(result.isOk()).toBe(true)
+    expect(sandbox.stop).toHaveBeenCalledOnce()
   })
 
   it("keeps Vercel cleanup unchanged", async () => {

--- a/packages/sandbox/test/runtime-lifecycle.test.ts
+++ b/packages/sandbox/test/runtime-lifecycle.test.ts
@@ -48,7 +48,9 @@ beforeEach(() => {
 
 describe("Sandbox runtime lifecycle", () => {
   it("keeps distinct Definition names distinct in default Cloudflare identities", () => {
-    expect(createCloudflareExecutionSandboxId("tools/release-notes")).toBe("tools%2Frelease-notes")
+    expect(createCloudflareExecutionSandboxId("tools/release-notes")).toBe("vitehub-tools%2Frelease-notes-definition")
+    expect(createCloudflareExecutionSandboxId("api")).toBe("vitehub-api-definition")
+    expect(createCloudflareExecutionSandboxId("-preview-")).toBe("vitehub--preview--definition")
     expect(createCloudflareExecutionSandboxId("tools/release-notes"))
       .not.toBe(createCloudflareExecutionSandboxId("tools_release-notes"))
     expect(createCloudflareExecutionSandboxId("Example"))
@@ -67,7 +69,7 @@ describe("Sandbox runtime lifecycle", () => {
     expect(result.isOk()).toBe(true)
     expect(runtimeMocks.createSandboxClient).toHaveBeenCalledWith(expect.objectContaining({
       provider: "cloudflare",
-      sandboxId: "example",
+      sandboxId: "vitehub-example-definition",
     }))
     expect(sandbox.stop).not.toHaveBeenCalled()
   })

--- a/packages/sandbox/test/runtime-lifecycle.test.ts
+++ b/packages/sandbox/test/runtime-lifecycle.test.ts
@@ -86,7 +86,7 @@ describe("Sandbox runtime lifecycle", () => {
     expect(runtimeMocks.createSandboxClient).toHaveBeenNthCalledWith(2, expect.objectContaining({ sandboxId: "per-run" }))
   })
 
-  it("stops failed Cloudflare attempts", async () => {
+  it("leaves failed shared Cloudflare sandboxes to the idle timeout", async () => {
     const sandbox = createSandbox("cloudflare")
     setSandboxRuntimeConfig({ provider: "cloudflare" })
     setSandboxRuntimeRegistry({ example: definition })
@@ -96,7 +96,7 @@ describe("Sandbox runtime lifecycle", () => {
     const result = await runSandboxRuntime("example")
 
     expect(result.isErr()).toBe(true)
-    expect(sandbox.stop).toHaveBeenCalledOnce()
+    expect(sandbox.stop).not.toHaveBeenCalled()
   })
 
   it("keeps Vercel cleanup unchanged", async () => {

--- a/packages/sandbox/test/runtime-lifecycle.test.ts
+++ b/packages/sandbox/test/runtime-lifecycle.test.ts
@@ -18,6 +18,7 @@ vi.mock("vitehub-sandbox-provider-loader", () => ({
 }))
 
 import { runSandboxRuntime } from "../src/runtime/runtime.ts"
+import { createCloudflareExecutionSandboxId } from "../src/runtime/provider-resolution.ts"
 import { resetSandboxRuntimeState, setSandboxRuntimeConfig, setSandboxRuntimeRegistry } from "../src/runtime/state.ts"
 
 const definition = {
@@ -46,6 +47,14 @@ beforeEach(() => {
 })
 
 describe("Sandbox runtime lifecycle", () => {
+  it("keeps distinct Definition names distinct in default Cloudflare identities", () => {
+    expect(createCloudflareExecutionSandboxId("tools/release-notes")).toBe("tools%2Frelease-notes")
+    expect(createCloudflareExecutionSandboxId("tools/release-notes"))
+      .not.toBe(createCloudflareExecutionSandboxId("tools_release-notes"))
+    expect(createCloudflareExecutionSandboxId("Example"))
+      .not.toBe(createCloudflareExecutionSandboxId("example"))
+  })
+
   it("uses the Definition name as the default Cloudflare identity and keeps successful runs idle", async () => {
     const sandbox = createSandbox("cloudflare")
     setSandboxRuntimeConfig({ provider: "cloudflare" })

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
-import type { AliasOptions } from "vite"
+import { build, type AliasOptions } from "vite"
 
 const tempDirs: string[] = []
 
@@ -240,24 +240,63 @@ describe("hubSandbox", () => {
     expect(definition).not.toContain("from process slash alias")
   })
 
-  it("infers Cloudflare from a late-resolved Nitro preset", async () => {
+  it("builds a configuration-free Definition for a Cloudflare Nitro host", async () => {
     const rootDir = await createViteRoot()
+    await rm(join(rootDir, "src/tools/release-notes.sandbox.ts"))
+    await mkdir(join(rootDir, "server/sandboxes"), { recursive: true })
+    await writeFile(join(rootDir, "src/server.ts"), `export const ready = true\n`)
+    await writeFile(join(rootDir, "server/sandboxes/example.ts"), [
+      `import { defineSandbox } from "@vite-hub/sandbox"`,
+      ``,
+      `export default defineSandbox(async () => ({ ok: true }))`,
+      ``,
+    ].join("\n"))
+    const { hubSandbox } = await import("../src/vite.ts")
+    let resolvedNitro: any
+
+    await build({
+      appType: "custom",
+      build: {
+        rollupOptions: { input: join(rootDir, "src/server.ts") },
+        write: false,
+      },
+      nitro: { preset: "cloudflare-module" },
+      plugins: [
+        hubSandbox(),
+        {
+          name: "nitro:main",
+          configResolved(config: { nitro?: unknown }) {
+            resolvedNitro = config.nitro
+          },
+        },
+      ],
+      root: rootDir,
+    } as never)
+
+    expect(resolvedNitro.cloudflare.wrangler.containers).toMatchObject([{ class_name: "Sandbox" }])
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/runtime/sandbox-registry.mjs"), "utf8")).resolves.toContain('"example"')
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/runtime/sandbox-provider-loader.mjs"), "utf8")).resolves.toContain("createCloudflareSandboxClient")
+  })
+
+  it("keeps Cloudflare output inert without Sandbox definitions", async () => {
+    const rootDir = await createViteRoot()
+    await rm(join(rootDir, "src/tools/release-notes.sandbox.ts"))
     const { hubSandbox } = await import("../src/vite.ts")
     const plugin = hubSandbox()
     const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
     const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
-    const userConfig = { root: rootDir }
-
-    await configHook(userConfig, { command: "build", mode: "production" })
-    const resolvedConfig = {
-      ...userConfig,
+    const userConfig = {
+      root: rootDir,
       nitro: { preset: "cloudflare-module" },
       plugins: [{ name: "nitro:main" }],
-      resolve: { alias: [] },
     }
-    await configResolved(resolvedConfig)
 
-    expect((resolvedConfig.nitro as any).cloudflare.wrangler.containers).toMatchObject([{ class_name: "Sandbox" }])
+    await configHook(userConfig, { command: "build", mode: "production" })
+    await configResolved({ ...userConfig, resolve: { alias: [] } })
+
+    expect(userConfig.nitro).toEqual({ preset: "cloudflare-module" })
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
+      .rejects.toMatchObject({ code: "ENOENT" })
   })
 
   it("infers Cloudflare from the Nitro preset environment", async () => {
@@ -952,18 +991,13 @@ describe("hubSandbox", () => {
     }, {})).rejects.toThrow("generate the same artifact path")
   })
 
-  it("passes explicit Cloudflare sandbox container names to Cloudflare targets", async () => {
+  it("keeps explicit Cloudflare targets inert without definitions", async () => {
     const { createSandboxFeaturePlan } = await import("../src/feature.ts")
     const plan = await createSandboxFeaturePlan({ provider: "cloudflare", name: "custom-sandbox" }, [], {
       aliasPath: "/tmp/vitehub-sandbox/index.js",
     }, {})
 
-    expect(plan.cloudflare).toEqual({
-      binding: "SANDBOX",
-      className: "Sandbox",
-      migrationTag: "v1",
-      name: "custom-sandbox",
-    })
+    expect(plan.cloudflare).toBeUndefined()
   })
 
   it("refreshes generated artifacts during sandbox definition hot updates", async () => {

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -325,7 +325,7 @@ describe("hubSandbox", () => {
 
     expect(userConfig.nitro).toEqual({ preset: "cloudflare-module" })
     const stateId = await resolveId("#vitehub/sandbox")
-    await expect(load(stateId as string)).resolves.toContain('"sandbox": false')
+    expect(await load(stateId as string)).toContain('"sandbox": false')
     await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
       .rejects.toMatchObject({ code: "ENOENT" })
   })

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -1021,13 +1021,18 @@ describe("hubSandbox", () => {
     }, {})).rejects.toThrow("generate the same artifact path")
   })
 
-  it("keeps explicit Cloudflare targets inert without definitions", async () => {
+  it("emits explicit Cloudflare targets without definitions", async () => {
     const { createSandboxFeaturePlan } = await import("../src/feature.ts")
     const plan = await createSandboxFeaturePlan({ provider: "cloudflare", name: "custom-sandbox" }, [], {
       aliasPath: "/tmp/vitehub-sandbox/index.js",
     }, {})
 
-    expect(plan.cloudflare).toBeUndefined()
+    expect(plan.cloudflare).toEqual({
+      binding: "SANDBOX",
+      className: "Sandbox",
+      migrationTag: "v1",
+      name: "custom-sandbox",
+    })
   })
 
   it("refreshes generated artifacts during sandbox definition hot updates", async () => {

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -114,6 +114,8 @@ describe("hubSandbox", () => {
     expect(facade).toContain("setSandboxRuntimeConfig")
     expect(facade).toContain("setSandboxRuntimeRegistry(sandboxRegistry)")
     expect(facade).toContain("export * from")
+    expect(facade).not.toContain("providerImportAliases")
+    expect(facade).not.toContain("@vite-hub/kv/runtime/upstash-driver")
     expect(registry).toContain('"tools/release-notes"')
     expect(providerLoader).toContain("createVercelSandboxClient")
     expect(providerLoader).not.toContain("import('./providers/vercel.js')")
@@ -297,6 +299,19 @@ describe("hubSandbox", () => {
     expect(userConfig.nitro).toEqual({ preset: "cloudflare-module" })
     await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
       .rejects.toMatchObject({ code: "ENOENT" })
+  })
+
+  it("keeps unsupported hosting inert without Sandbox definitions", async () => {
+    const rootDir = await createViteRoot()
+    await rm(join(rootDir, "src/tools/release-notes.sandbox.ts"))
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox()
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+
+    await expect(configHook({
+      root: rootDir,
+      nitro: { preset: "netlify" },
+    }, { command: "build", mode: "production" })).resolves.toBeDefined()
   })
 
   it("infers Cloudflare from the Nitro preset environment", async () => {

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -312,6 +312,8 @@ describe("hubSandbox", () => {
     const plugin = hubSandbox()
     const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
     const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
+    const resolveId = plugin.resolveId as (id: string) => string | undefined | Promise<string | undefined>
+    const load = plugin.load as (id: string) => string | undefined | Promise<string | undefined>
     const userConfig = {
       root: rootDir,
       nitro: { preset: "cloudflare-module" },
@@ -322,6 +324,8 @@ describe("hubSandbox", () => {
     await configResolved({ ...userConfig, resolve: { alias: [] } })
 
     expect(userConfig.nitro).toEqual({ preset: "cloudflare-module" })
+    const stateId = await resolveId("#vitehub/sandbox")
+    await expect(load(stateId as string)).resolves.toContain('"sandbox": false')
     await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
       .rejects.toMatchObject({ code: "ENOENT" })
   })

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -158,6 +158,16 @@ describe("hubSandbox", () => {
     await expect(configHook({ root: rootDir }, { command: "build", mode: "production" })).resolves.toBeDefined()
   })
 
+  it("keeps default Sandbox inert when the Vite root has no package manifest", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-sandbox-vite-"))
+    tempDirs.push(rootDir)
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox()
+    const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+
+    await expect(configHook({ root: rootDir }, { command: "build", mode: "production" })).resolves.toBeDefined()
+  })
+
   it("exposes hosting inference and normalized runtime config through sandbox state", async () => {
     const rootDir = await createViteRoot()
     const { hubSandbox } = await import("../src/vite.ts")

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -143,6 +143,21 @@ describe("hubSandbox", () => {
     expect(code).toContain('"provider": "vercel"')
   })
 
+  it("does not discover conflicting Definitions when Sandbox is disabled", async () => {
+    const rootDir = await createViteRoot()
+    await mkdir(join(rootDir, "server/sandboxes/tools"), { recursive: true })
+    await writeFile(join(rootDir, "server/sandboxes/tools/release-notes.ts"), [
+      `import { defineSandbox } from "@vite-hub/sandbox"`,
+      `export default defineSandbox(async () => ({ ok: true }))`,
+      ``,
+    ].join("\n"))
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox(false)
+    const configHook = plugin.config as (config: Record<string, unknown>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+
+    await expect(configHook({ root: rootDir }, { command: "build", mode: "production" })).resolves.toBeDefined()
+  })
+
   it("exposes hosting inference and normalized runtime config through sandbox state", async () => {
     const rootDir = await createViteRoot()
     const { hubSandbox } = await import("../src/vite.ts")

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -94,7 +94,7 @@ describe("hubSandbox", () => {
 
     expect(readAlias(alias, "@vite-hub/sandbox")).toBeUndefined()
     expect(sandboxAlias).toContain(".vitehub/sandbox/runtime/sandbox.mjs")
-    expect(providerImportAliases["@vite-hub/sandbox"]).toBe(sandboxAlias)
+    expect(providerImportAliases["@vite-hub/sandbox"]).toBeUndefined()
     expect(providerImportAliases["vite-hub/sandbox"]).toBe(sandboxAlias)
 
     await configHook({ root: rootDir, sandbox: false }, { command: "serve", mode: "development" })

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -79,7 +79,7 @@ function frameworkWorkspaceDependencyRuntimeImports(sandbox: boolean) {
   return {
     ...(sandbox
       ? {
-          sandbox: "@vite-hub/sandbox",
+          sandbox: "vite-hub/sandbox",
           sandboxRuntimeState: `${generatedImportBase}/sandbox/runtime/state`,
         }
       : {}),

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -176,7 +176,7 @@ export function vitehub(options: ViteHubPresetOptions = {}): PluginOption[] {
   const plugins: unknown[] = []
   const providerImportAliases: Record<string, string> = {}
   configureProviderOptionalImportAliases(providerImportAliases, options)
-  const workspaceDependencyRuntimeImports = frameworkWorkspaceDependencyRuntimeImports(Boolean(options.sandbox))
+  const workspaceDependencyRuntimeImports = frameworkWorkspaceDependencyRuntimeImports(options.sandbox !== false)
 
   plugins.push(frameworkDependencyResolver(options, providerImportAliases))
   plugins.push(hubMarkdownTemplate({ runtimeImport: `${generatedImportBase}/markdown-template` }))

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -199,9 +199,9 @@ export function vitehub(options: ViteHubPresetOptions = {}): PluginOption[] {
       importBase: "vite-hub/auth",
     } as unknown as AuthModuleOptions))
   }
-  if (options.sandbox) {
+  if (options.sandbox !== false) {
     plugins.push(hubSandbox({
-      ...(options.sandbox === true ? {} : options.sandbox),
+      ...(options.sandbox === true || options.sandbox === undefined ? {} : options.sandbox),
       providerImportAliases,
       providerImportSpecifier: "vite-hub/sandbox",
     } as unknown as SandboxPublicOptions))

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -125,6 +125,8 @@ describe("vitehub", () => {
       scheduleRuntimeImport: "vite-hub/_internal/schedule/runtime",
       workflowImportBase: "vite-hub/_internal/workflow",
       workspaceDependencyRuntimeImports: {
+        sandbox: "@vite-hub/sandbox",
+        sandboxRuntimeState: "vite-hub/_internal/sandbox/runtime/state",
         shellWorkspace: "vite-hub/shell/workspace",
       },
       workspaceImportBase: "vite-hub/_internal/workspace",
@@ -159,6 +161,8 @@ describe("vitehub", () => {
         "@vite-hub/kv/runtime/upstash-driver": expect.stringMatching(/packages\/vite-hub\/dist\/_internal\/kv\/runtime\/disabled-upstash\.js$/),
       },
       workspaceDependencyRuntimeImports: {
+        sandbox: "@vite-hub/sandbox",
+        sandboxRuntimeState: "vite-hub/_internal/sandbox/runtime/state",
         shellWorkspace: "vite-hub/shell/workspace",
       },
       workspaceImportBase: "vite-hub/_internal/workspace",
@@ -218,8 +222,25 @@ describe("vitehub", () => {
     })
   })
 
-  it("keeps Sandbox loaders out of the default provider graph", () => {
+  it("keeps Sandbox loaders aligned with preset enablement", () => {
     vitehub()
+
+    expect(integrationMocks.hubAgent).toHaveBeenLastCalledWith(expect.objectContaining({
+      workspaceDependencyRuntimeImports: {
+        sandbox: "@vite-hub/sandbox",
+        sandboxRuntimeState: "vite-hub/_internal/sandbox/runtime/state",
+        shellWorkspace: "vite-hub/shell/workspace",
+      },
+    }))
+    expect(integrationMocks.hubWorkflow).toHaveBeenLastCalledWith(expect.objectContaining({
+      workspaceDependencyRuntimeImports: {
+        sandbox: "@vite-hub/sandbox",
+        sandboxRuntimeState: "vite-hub/_internal/sandbox/runtime/state",
+        shellWorkspace: "vite-hub/shell/workspace",
+      },
+    }))
+
+    vitehub({ sandbox: false })
 
     expect(integrationMocks.hubAgent).toHaveBeenLastCalledWith(expect.objectContaining({
       workspaceDependencyRuntimeImports: {

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -125,7 +125,7 @@ describe("vitehub", () => {
       scheduleRuntimeImport: "vite-hub/_internal/schedule/runtime",
       workflowImportBase: "vite-hub/_internal/workflow",
       workspaceDependencyRuntimeImports: {
-        sandbox: "@vite-hub/sandbox",
+        sandbox: "vite-hub/sandbox",
         sandboxRuntimeState: "vite-hub/_internal/sandbox/runtime/state",
         shellWorkspace: "vite-hub/shell/workspace",
       },
@@ -133,7 +133,7 @@ describe("vitehub", () => {
     })
     expect(integrationMocks.hubAgent).toHaveBeenCalledWith(expect.objectContaining({
       workspaceDependencyRuntimeImports: {
-        sandbox: "@vite-hub/sandbox",
+      sandbox: "vite-hub/sandbox",
         sandboxRuntimeState: "vite-hub/_internal/sandbox/runtime/state",
         shellWorkspace: "vite-hub/shell/workspace",
       },
@@ -161,7 +161,7 @@ describe("vitehub", () => {
         "@vite-hub/kv/runtime/upstash-driver": expect.stringMatching(/packages\/vite-hub\/dist\/_internal\/kv\/runtime\/disabled-upstash\.js$/),
       },
       workspaceDependencyRuntimeImports: {
-        sandbox: "@vite-hub/sandbox",
+        sandbox: "vite-hub/sandbox",
         sandboxRuntimeState: "vite-hub/_internal/sandbox/runtime/state",
         shellWorkspace: "vite-hub/shell/workspace",
       },
@@ -169,7 +169,7 @@ describe("vitehub", () => {
     })
     expect(integrationMocks.hubWorkflow).toHaveBeenCalledWith(expect.objectContaining({
       workspaceDependencyRuntimeImports: {
-        sandbox: "@vite-hub/sandbox",
+      sandbox: "vite-hub/sandbox",
         sandboxRuntimeState: "vite-hub/_internal/sandbox/runtime/state",
         shellWorkspace: "vite-hub/shell/workspace",
       },
@@ -227,14 +227,14 @@ describe("vitehub", () => {
 
     expect(integrationMocks.hubAgent).toHaveBeenLastCalledWith(expect.objectContaining({
       workspaceDependencyRuntimeImports: {
-        sandbox: "@vite-hub/sandbox",
+        sandbox: "vite-hub/sandbox",
         sandboxRuntimeState: "vite-hub/_internal/sandbox/runtime/state",
         shellWorkspace: "vite-hub/shell/workspace",
       },
     }))
     expect(integrationMocks.hubWorkflow).toHaveBeenLastCalledWith(expect.objectContaining({
       workspaceDependencyRuntimeImports: {
-        sandbox: "@vite-hub/sandbox",
+        sandbox: "vite-hub/sandbox",
         sandboxRuntimeState: "vite-hub/_internal/sandbox/runtime/state",
         shellWorkspace: "vite-hub/shell/workspace",
       },

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -74,6 +74,7 @@ describe("vitehub", () => {
       "vite-hub/dependencies",
       "@vite-hub/markdown-template/vite",
       "@vite-hub/env/vite",
+      "@vite-hub/sandbox/vite",
       "@vite-hub/agent/vite",
       "@vite-hub/database/vite",
       "@vite-hub/blob/vite",
@@ -100,6 +101,7 @@ describe("vitehub", () => {
       "@vite-hub/workspace/vite",
       "@vite-hub/devtools",
     ])
+    expect(pluginNames(vitehub({ sandbox: false }))).not.toContain("@vite-hub/sandbox/vite")
 
     vitehub({ schedule: true })
 

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -409,7 +409,8 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
       expect(workflowRegistry).toContain("vite-hub/_internal/workflow/runtime/execute")
       expect(workflowRegistry).toContain("vite-hub/_internal/workflow/runtime/state")
       expect(workflowRegistry).toContain("setWorkspaceDependencyRuntimeLoaders")
-      expect(workflowRegistry).not.toContain("vite-hub/_internal/sandbox/runtime/state")
+      expect(workflowRegistry).toContain("vite-hub/_internal/sandbox/runtime/state")
+      expect(workflowRegistry).toContain("vite-hub/sandbox")
       expect(workflowRegistry).toContain("vite-hub/shell/workspace")
       expect(workspacePlugin).toContain("vite-hub/_internal/workspace/runtime")
 


### PR DESCRIPTION
Makes discovered Sandbox Definitions configuration-free: the ViteHub preset enables discovery unless explicitly disabled, supported hosting selects the provider, and Cloudflare uses the normalized Definition name as its default reusable identity. Explicit provider and `sandboxId` settings still win, and projects without definitions emit no inferred Sandbox container output.

Cloudflare runs now default to a five-minute idle timeout. Every invocation recursively removes its isolated temporary files, while the reusable Cloudflare container remains available until idle shutdown so a failed concurrent invocation cannot terminate another run. Vercel cleanup is unchanged.

Supersedes #728, which GitHub closed when its stacked base branch was deleted after #723 merged.