### PR TITLE
feat(sandbox): colocate Cloudflare image layers with definitions

### DIFF
--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -44,6 +44,7 @@ composition and explicit feature subpaths for application APIs.
 | `vite-hub/rate-limit` | Source-local managed Rate Limit handles and direct Rate Limiters. |
 | `vite-hub/runtime` | Runtime Host Context, policy, approval, trace, and capability APIs. |
 | `vite-hub/sandbox` | Sandbox Definitions and Sandbox Run helpers. |
+| `vite-hub/sandbox/cloudflare` | Cloudflare-only build layers for the generated Sandbox image. |
 | `vite-hub/schedule` and `vite-hub/schedule/runtime` | Static and runtime Schedule APIs. |
 | `vite-hub/schedule/runtime/driver` and `vite-hub/schedule/runtime/process` | Host wake registration and process-backed runtime Schedule controls. |
 | `vite-hub/shell` | Shell runtime and command analysis APIs. |
@@ -96,6 +97,7 @@ for libraries, focused integrations, and advanced composition.
 | `@vite-hub/rate-limit/drivers/memory` | Rate Limit Package | Local, test, and single-process fixed-window enforcement. |
 | `@vite-hub/rate-limit/drivers/cloudflare` | Rate Limit Package | Direct access to a Cloudflare Rate Limiting binding. |
 | `@vite-hub/sandbox` | Sandbox Package | Sandbox Definition and Sandbox Run helpers. |
+| `@vite-hub/sandbox/cloudflare` | Sandbox Package | Cloudflare-only build layers for the generated Sandbox image. |
 | `@vite-hub/schedule/runtime` | Schedule Package | Runtime schedule helpers. |
 | `@vite-hub/schedule/runtime/driver` | Schedule Package | Host integration boundary for reconciling stored Runtime Schedules with native wake registrations. |
 | `#vitehub/schedule/registry` | Schedule Package | Generated static schedule registry for host bridges. |

--- a/docs/content/docs/server-primitives/sandbox.md
+++ b/docs/content/docs/server-primitives/sandbox.md
@@ -56,6 +56,7 @@ export default defineEventHandler(async () => {
 | --- | --- |
 | `defineSandbox` from `@vite-hub/sandbox` | Declare a Sandbox Definition. |
 | `runSandbox` from `@vite-hub/sandbox` | Execute a named Sandbox Definition. |
+| `defineDockerfileFragment` from `@vite-hub/sandbox/cloudflare` | Add Cloudflare-only build layers to the generated Sandbox image. |
 | `hubSandbox` from `@vite-hub/sandbox/vite` | Register Sandbox discovery, generated types, and provider runtime wiring. |
 | `@vite-hub/sandbox/runtime/providers/cloudflare` | Cloudflare runtime provider loader entry. |
 | `@vite-hub/sandbox/runtime/providers/vercel` | Vercel runtime provider loader entry. |
@@ -63,6 +64,22 @@ export default defineEventHandler(async () => {
 | `@vite-hub/sandbox/sandbox/providers/vercel` | Vercel direct Sandbox client provider. |
 
 Sandbox Definition, Provider, Execution Options, and Run Result types are exported from `@vite-hub/sandbox`.
+
+When a Cloudflare build discovers exactly one Sandbox Definition, it can colocate static image layers beside that definition. Use `defineDockerfileFragment` as a top-level tagged template; ViteHub supplies the installed Cloudflare Sandbox base image and keeps this build-only statement out of the runtime bundle.
+
+```ts [src/tools/image.sandbox.ts]
+import { defineSandbox } from '@vite-hub/sandbox'
+import { defineDockerfileFragment } from '@vite-hub/sandbox/cloudflare'
+
+defineDockerfileFragment`
+RUN apt-get update \
+  && apt-get install -y imagemagick
+`
+
+export default defineSandbox(async () => null)
+```
+
+This surface belongs to Cloudflare's current app-level Sandbox image. Multiple definitions, interpolation, `FROM`, other hosts, and an application-owned container image are rejected instead of implying per-definition or provider-neutral image support.
 
 ## Configure the Vite Integration
 

--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -40,6 +40,10 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
+    "./cloudflare": {
+      "types": "./dist/cloudflare-public.d.ts",
+      "import": "./dist/cloudflare-public.js"
+    },
     "./runtime/empty-registry": {
       "types": "./dist/runtime/empty-registry.d.ts",
       "import": "./dist/runtime/empty-registry.js"

--- a/packages/sandbox/src/cloudflare-public.ts
+++ b/packages/sandbox/src/cloudflare-public.ts
@@ -1,0 +1,4 @@
+export function defineDockerfileFragment(strings: TemplateStringsArray, ...values: unknown[]): void {
+  if (!Array.isArray(strings?.raw) || values.length > 0)
+    throw new TypeError('[vitehub] `defineDockerfileFragment` must be used as a static tagged template without interpolations.')
+}

--- a/packages/sandbox/src/cloudflare.ts
+++ b/packages/sandbox/src/cloudflare.ts
@@ -37,6 +37,7 @@ function resolveCloudflareSandboxVersion() {
 export type CloudflareSandboxEntrypointOptions = {
   binding?: string
   className?: string
+  dockerfileFragment?: string
   migrationTag?: string
   name?: string
 }
@@ -47,6 +48,7 @@ function resolveCloudflareSandboxEntrypointOptions(options: CloudflareSandboxEnt
   return {
     binding: options.binding || defaultCloudflareSandboxBinding,
     className: options.className || defaultCloudflareSandboxClassName,
+    dockerfileFragment: typeof options.dockerfileFragment === 'string' ? options.dockerfileFragment : undefined,
     migrationTag: options.migrationTag || defaultCloudflareSandboxMigrationTag,
     name: options.name || undefined,
   }
@@ -187,9 +189,12 @@ export function installCloudflareSandboxEntrypoint(target: MutableRollupTarget, 
   plugins.push(plugin)
 }
 
-export async function writeCloudflareSandboxDockerfile(serverDir: string) {
+export async function writeCloudflareSandboxDockerfile(serverDir: string, fragment = '') {
   const dockerfilePath = join(serverDir, 'Dockerfile')
-  await writeFileIfChanged(dockerfilePath, `FROM docker.io/cloudflare/sandbox:${resolveCloudflareSandboxVersion()}\n`)
+  await writeFileIfChanged(
+    dockerfilePath,
+    `FROM docker.io/cloudflare/sandbox:${resolveCloudflareSandboxVersion()}\n${fragment}`,
+  )
   return dockerfilePath
 }
 
@@ -209,12 +214,20 @@ export async function configureCloudflareSandboxNitro(
   const existingContainer = target.cloudflare?.wrangler?.containers
     ?.find(entry => entry.class_name === resolvedOptions.className)
   const existingImage = existingContainer?.image?.replace(/\\/g, '/')
+  if (typeof resolvedOptions.dockerfileFragment === 'string'
+    && typeof existingImage === 'string'
+    && !existingImage.endsWith('/.vitehub/sandbox/Dockerfile')) {
+    throw new Error('[vitehub] A colocated Cloudflare Dockerfile fragment cannot be combined with an application-owned Sandbox container image. Remove the fragment or the explicit image.')
+  }
 
   configureCloudflareSandbox(target, resolvedOptions)
   const container = target.cloudflare!.wrangler!.containers!
     .find(entry => entry.class_name === resolvedOptions.className)!
   if (typeof existingImage !== 'string' || existingImage.endsWith('/.vitehub/sandbox/Dockerfile')) {
-    const dockerfile = await writeCloudflareSandboxDockerfile(resolve(rootDir, '.vitehub/sandbox'))
+    const dockerfile = await writeCloudflareSandboxDockerfile(
+      resolve(rootDir, '.vitehub/sandbox'),
+      resolvedOptions.dockerfileFragment,
+    )
     container.image = relativeWranglerPath(serverDir, dockerfile)
     container.image_build_context = relativeWranglerPath(serverDir, rootDir)
   }

--- a/packages/sandbox/src/definition-options.ts
+++ b/packages/sandbox/src/definition-options.ts
@@ -117,8 +117,9 @@ function findCloudflareDockerfileFragmentImport(sourceFile: ts.SourceFile): Clou
 
     const importClause = statement.importClause
     const bindings = importClause?.namedBindings
-    if (!bindings || !ts.isNamedImports(bindings))
-      continue
+    if (!bindings || !ts.isNamedImports(bindings)) {
+      throw new Error('[vitehub] `defineDockerfileFragment` must be imported as a named import from `vite-hub/sandbox/cloudflare`.')
+    }
 
     const specifier = bindings.elements.find((specifier) => {
       return (specifier.propertyName?.text || specifier.name.text) === cloudflareDockerfileFragmentHelper

--- a/packages/sandbox/src/definition-options.ts
+++ b/packages/sandbox/src/definition-options.ts
@@ -9,6 +9,21 @@ type TypeScript = typeof import('typescript')
 type OptionsExpression = ts.Expression | null | undefined
 
 const sandboxDefinitionSyntax = '`defineSandbox()`'
+const cloudflareDockerfileFragmentHelper = 'defineDockerfileFragment'
+const cloudflareDockerfileFragmentImports = new Set([
+  '@vite-hub/sandbox/cloudflare',
+  'vite-hub/sandbox/cloudflare',
+])
+type CloudflareDockerfileFragmentMatch = {
+  fragment: string
+  importDeclaration: ts.ImportDeclaration
+  expressionStatement: ts.ExpressionStatement
+}
+
+type CloudflareDockerfileFragmentImport = {
+  declaration: ts.ImportDeclaration
+  localName: string
+}
 
 function getTypeScript(): TypeScript {
   return require('typescript') as TypeScript
@@ -87,6 +102,102 @@ function readStaticValue(node: ts.Expression): unknown {
   }
 
   throw new Error(`[vitehub] ${sandboxDefinitionSyntax} options must use static JSON-serializable values.`)
+}
+
+function findCloudflareDockerfileFragmentImport(sourceFile: ts.SourceFile): CloudflareDockerfileFragmentImport | undefined {
+  const ts = getTypeScript()
+  let match: CloudflareDockerfileFragmentImport | undefined
+
+  for (const statement of sourceFile.statements) {
+    if (!ts.isImportDeclaration(statement)
+      || !ts.isStringLiteral(statement.moduleSpecifier)
+      || !cloudflareDockerfileFragmentImports.has(statement.moduleSpecifier.text)) {
+      continue
+    }
+
+    const importClause = statement.importClause
+    const bindings = importClause?.namedBindings
+    if (!bindings || !ts.isNamedImports(bindings))
+      continue
+
+    const specifier = bindings.elements.find((specifier) => {
+      return (specifier.propertyName?.text || specifier.name.text) === cloudflareDockerfileFragmentHelper
+    })
+    if (!specifier)
+      continue
+    if (importClause?.name || bindings.elements.length !== 1)
+      throw new Error('[vitehub] `defineDockerfileFragment` must be imported by itself from `vite-hub/sandbox/cloudflare`.')
+    if (match)
+      throw new Error('[vitehub] `defineDockerfileFragment` may be imported only once per Sandbox Definition.')
+
+    match = { declaration: statement, localName: specifier.name.text }
+  }
+
+  return match
+}
+
+function readCloudflareDockerfileFragment(sourceFile: ts.SourceFile): CloudflareDockerfileFragmentMatch | undefined {
+  const ts = getTypeScript()
+  const helperImport = findCloudflareDockerfileFragmentImport(sourceFile)
+  if (!helperImport)
+    return
+  const { declaration: importDeclaration, localName } = helperImport
+
+  let match: CloudflareDockerfileFragmentMatch | undefined
+
+  function visit(node: ts.Node) {
+    if (!ts.isTaggedTemplateExpression(node)
+      || !ts.isIdentifier(node.tag)
+      || node.tag.text !== localName) {
+      ts.forEachChild(node, visit)
+      return
+    }
+    const statement = node.parent
+    if (!ts.isExpressionStatement(statement) || statement.parent !== sourceFile)
+      throw new Error('[vitehub] `defineDockerfileFragment` must appear once as a top-level tagged-template statement.')
+    if (match)
+      throw new Error('[vitehub] `defineDockerfileFragment` may appear only once per Sandbox Definition.')
+    if (!ts.isNoSubstitutionTemplateLiteral(node.template)) {
+      throw new Error('[vitehub] `defineDockerfileFragment` requires one static template without interpolations.')
+    }
+
+    const fragment = node.template.getText(sourceFile).slice(1, -1)
+    if (/^[ \t]*FROM(?:[ \t]|$)/im.test(fragment)) {
+      throw new Error('[vitehub] `defineDockerfileFragment` extends ViteHub\'s version-matched Cloudflare Sandbox base and cannot contain FROM. Configure an application-owned Dockerfile for a custom base image.')
+    }
+
+    match = { fragment, importDeclaration, expressionStatement: statement }
+  }
+
+  ts.forEachChild(sourceFile, visit)
+  if (!match)
+    throw new Error('[vitehub] `defineDockerfileFragment` must appear once as a top-level tagged-template statement.')
+
+  return match
+}
+
+export async function extractCloudflareDockerfileFragment(file: string): Promise<string | undefined> {
+  const source = await readFile(file, 'utf8')
+  const ts = getTypeScript()
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+  return readCloudflareDockerfileFragment(sourceFile)?.fragment
+}
+
+export function stripCloudflareDockerfileFragment(source: string, file: string): string {
+  const ts = getTypeScript()
+  const sourceFile = ts.createSourceFile(file, source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS)
+  const match = readCloudflareDockerfileFragment(sourceFile)
+  if (!match)
+    return source
+
+  const ranges = [match.importDeclaration, match.expressionStatement]
+    .map(node => ({ start: node.getStart(sourceFile), end: node.getEnd() }))
+    .sort((left, right) => right.start - left.start)
+
+  return ranges.reduce(
+    (result, range) => `${result.slice(0, range.start)}${result.slice(range.end)}`,
+    source,
+  )
 }
 
 export async function extractSandboxDefinitionOptions(file: string): Promise<SandboxDefinitionOptions | undefined> {

--- a/packages/sandbox/src/feature.ts
+++ b/packages/sandbox/src/feature.ts
@@ -194,6 +194,7 @@ export async function createSandboxFeaturePlan(
   deps: Record<string, string>,
   hosting?: string,
   discoveredDefinitionOptions: SandboxDefinitionCompilerOptions = {},
+  deferUnresolvedHostingValidation = false,
 ): Promise<FeatureRuntimePlan> {
   const resolvedConfig = resolveSandboxFeatureConfig(sandboxConfig, hosting)
   const manifest = createSandboxManifest(paths.aliasPath, createSandboxTypeTemplateContents(definitions))
@@ -229,7 +230,8 @@ export async function createSandboxFeaturePlan(
     throw new Error('[vitehub] A colocated Cloudflare Dockerfile fragment currently requires exactly one discovered Sandbox Definition because Cloudflare provider output owns one app-level Sandbox image. Configure an application-owned Dockerfile until ViteHub can route definitions to distinct images.')
   }
   if (fragmentDefinitions.length
-    && (defaultProviderName !== 'cloudflare' || hostingProvider !== 'cloudflare')) {
+    && (defaultProviderName !== 'cloudflare'
+      || (hostingProvider !== 'cloudflare' && (!deferUnresolvedHostingValidation || typeof hosting === 'string')))) {
     throw new Error('[vitehub] A colocated Cloudflare Dockerfile fragment requires Cloudflare hosting and the Cloudflare Sandbox provider. Other hosts use different image build and routing models.')
   }
   const sandboxArtifacts: GeneratedArtifact[] = sandboxDefinitions.map(definition => ({

--- a/packages/sandbox/src/feature.ts
+++ b/packages/sandbox/src/feature.ts
@@ -196,6 +196,7 @@ export async function createSandboxFeaturePlan(
   discoveredDefinitionOptions: SandboxDefinitionCompilerOptions = {},
   deferUnresolvedHostingValidation = false,
 ): Promise<FeatureRuntimePlan> {
+  const configuredProviderName = getSandboxFeatureProvider(sandboxConfig)?.provider
   const resolvedConfig = resolveSandboxFeatureConfig(sandboxConfig, hosting)
   const manifest = createSandboxManifest(paths.aliasPath, createSandboxTypeTemplateContents(definitions))
   const {
@@ -227,12 +228,13 @@ export async function createSandboxFeaturePlan(
   const hostingProvider = getHostingProvider(hosting)
   const fragmentDefinitions = definitionMetadata.filter(definition => typeof definition.cloudflareDockerfileFragment === 'string')
   const deferFragmentHostingValidation = deferUnresolvedHostingValidation && typeof hosting === 'undefined'
+  const deferFragmentProviderValidation = deferFragmentHostingValidation && typeof configuredProviderName === 'undefined'
   if (fragmentDefinitions.length && definitions.length !== 1) {
     throw new Error('[vitehub] A colocated Cloudflare Dockerfile fragment currently requires exactly one discovered Sandbox Definition because Cloudflare provider output owns one app-level Sandbox image. Configure an application-owned Dockerfile until ViteHub can route definitions to distinct images.')
   }
   if (fragmentDefinitions.length
-    && !deferFragmentHostingValidation
-    && (defaultProviderName !== 'cloudflare' || hostingProvider !== 'cloudflare')) {
+    && ((!deferFragmentProviderValidation && defaultProviderName !== 'cloudflare')
+      || (!deferFragmentHostingValidation && hostingProvider !== 'cloudflare'))) {
     throw new Error('[vitehub] A colocated Cloudflare Dockerfile fragment requires Cloudflare hosting and the Cloudflare Sandbox provider. Other hosts use different image build and routing models.')
   }
   const sandboxArtifacts: GeneratedArtifact[] = sandboxDefinitions.map(definition => ({

--- a/packages/sandbox/src/feature.ts
+++ b/packages/sandbox/src/feature.ts
@@ -12,7 +12,11 @@ import {
   defaultCloudflareSandboxClassName,
   defaultCloudflareSandboxMigrationTag,
 } from './cloudflare'
-import { extractSandboxDefinitionOptions } from './definition-options'
+import {
+  extractCloudflareDockerfileFragment,
+  extractSandboxDefinitionOptions,
+  stripCloudflareDockerfileFragment,
+} from './definition-options'
 import { getSandboxFeatureProvider } from './module-types'
 import type { AgentSandboxConfig, SandboxDefinitionOptions } from './module-types'
 import { createSandboxTypeTemplateContents } from './type-template'
@@ -82,6 +86,7 @@ export function createSandboxManifest(aliasPath: string, typeTemplate: string): 
 }
 
 type SandboxDefinitionMetadata = {
+  cloudflareDockerfileFragment?: string
   name: string
   options?: SandboxDefinitionOptions
 }
@@ -107,6 +112,7 @@ function normalizeSandboxDefinitionOptions(name: string, options: SandboxDefinit
 async function loadSandboxDefinitionMetadata(definitions: ScannedDefinition[]) {
   return await Promise.all(definitions.map(async (definition) => {
     return {
+      cloudflareDockerfileFragment: await extractCloudflareDockerfileFragment(definition.handler),
       name: definition.name,
       options: normalizeSandboxDefinitionOptions(definition.name, await extractSandboxDefinitionOptions(definition.handler)),
     } satisfies SandboxDefinitionMetadata
@@ -215,11 +221,25 @@ export async function createSandboxFeaturePlan(
   })
   const definitionMetadata = await loadSandboxDefinitionMetadata(definitions)
   const metadataByName = new Map(definitionMetadata.map(definition => [definition.name, definition] as const))
+  const defaultProvider = getSandboxFeatureProvider(resolvedConfig)
+  const defaultProviderName = defaultProvider?.provider
+  const hostingProvider = getHostingProvider(hosting)
+  const fragmentDefinitions = definitionMetadata.filter(definition => typeof definition.cloudflareDockerfileFragment === 'string')
+  if (fragmentDefinitions.length && definitions.length !== 1) {
+    throw new Error('[vitehub] A colocated Cloudflare Dockerfile fragment currently requires exactly one discovered Sandbox Definition because Cloudflare provider output owns one app-level Sandbox image. Configure an application-owned Dockerfile until ViteHub can route definitions to distinct images.')
+  }
+  if (fragmentDefinitions.length
+    && (defaultProviderName !== 'cloudflare' || hostingProvider !== 'cloudflare')) {
+    throw new Error('[vitehub] A colocated Cloudflare Dockerfile fragment requires Cloudflare hosting and the Cloudflare Sandbox provider. Other hosts use different image build and routing models.')
+  }
   const sandboxArtifacts: GeneratedArtifact[] = sandboxDefinitions.map(definition => ({
     key: definition.definitionArtifactKey,
     filename: definition.definitionFilename,
     async getContents() {
-      const source = await definitionCompiler.readSource(definition._meta.sourcePath)
+      const source = stripCloudflareDockerfileFragment(
+        await definitionCompiler.readSource(definition._meta.sourcePath),
+        definition._meta.sourcePath,
+      )
       const bundle = await bundleSandboxDefinition(source, definition._meta.sourcePath, {
         alias: bundleAlias,
       })
@@ -230,8 +250,6 @@ export async function createSandboxFeaturePlan(
       })}\n`
     },
   }))
-  const defaultProvider = getSandboxFeatureProvider(resolvedConfig)
-  const defaultProviderName = defaultProvider?.provider
   const providerLoaderTarget = resolveSandboxProviderLoaderTarget(defaultProviderName, deps)
   const cloudflareOptions = defaultProvider?.provider === 'cloudflare'
     ? {
@@ -239,6 +257,7 @@ export async function createSandboxFeaturePlan(
         className: typeof defaultProvider.className === 'string' ? defaultProvider.className : defaultCloudflareSandboxClassName,
         migrationTag: typeof defaultProvider.migrationTag === 'string' ? defaultProvider.migrationTag : defaultCloudflareSandboxMigrationTag,
         name: typeof defaultProvider.name === 'string' ? defaultProvider.name : undefined,
+        dockerfileFragment: fragmentDefinitions[0]?.cloudflareDockerfileFragment,
       }
     : undefined
 

--- a/packages/sandbox/src/feature.ts
+++ b/packages/sandbox/src/feature.ts
@@ -226,12 +226,13 @@ export async function createSandboxFeaturePlan(
   const defaultProviderName = defaultProvider?.provider
   const hostingProvider = getHostingProvider(hosting)
   const fragmentDefinitions = definitionMetadata.filter(definition => typeof definition.cloudflareDockerfileFragment === 'string')
+  const deferFragmentHostingValidation = deferUnresolvedHostingValidation && typeof hosting === 'undefined'
   if (fragmentDefinitions.length && definitions.length !== 1) {
     throw new Error('[vitehub] A colocated Cloudflare Dockerfile fragment currently requires exactly one discovered Sandbox Definition because Cloudflare provider output owns one app-level Sandbox image. Configure an application-owned Dockerfile until ViteHub can route definitions to distinct images.')
   }
   if (fragmentDefinitions.length
-    && (defaultProviderName !== 'cloudflare'
-      || (hostingProvider !== 'cloudflare' && (!deferUnresolvedHostingValidation || typeof hosting === 'string')))) {
+    && !deferFragmentHostingValidation
+    && (defaultProviderName !== 'cloudflare' || hostingProvider !== 'cloudflare')) {
     throw new Error('[vitehub] A colocated Cloudflare Dockerfile fragment requires Cloudflare hosting and the Cloudflare Sandbox provider. Other hosts use different image build and routing models.')
   }
   const sandboxArtifacts: GeneratedArtifact[] = sandboxDefinitions.map(definition => ({

--- a/packages/sandbox/src/internal/runtime-preparation.ts
+++ b/packages/sandbox/src/internal/runtime-preparation.ts
@@ -258,6 +258,7 @@ export async function prepareSandboxRuntime(options: {
       scanRoots: [rootDir],
       serverImports: { presets: [] },
     },
+    !options.resolvedConfig,
   )
   const aliases = createGeneratedAliasMap(rootDir, plan)
   if (options.writeArtifacts === false) {

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -207,7 +207,9 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
         return
 
       const previousFiles = [...generatedFiles, ...Object.values(generatedAliases)]
-      await refreshSandboxRuntime()
+      const prepared = await refreshSandboxRuntime()
+      if (resolvedConfig)
+        await composeCloudflareSandbox(resolvedConfig, prepared)
       invalidateGeneratedSandboxModules([...previousFiles, ...generatedFiles, ...Object.values(generatedAliases)], context.server.moduleGraph)
     },
     configEnvironment(name, config) {

--- a/packages/sandbox/test/definition-options.test.ts
+++ b/packages/sandbox/test/definition-options.test.ts
@@ -176,4 +176,13 @@ describe("Cloudflare Dockerfile fragment extraction", () => {
 
     await expect(extractCloudflareDockerfileFragment(file)).resolves.toBeUndefined()
   })
+
+  it("rejects namespace imports from the fragment marker module", async () => {
+    const file = await writeDefinition([
+      `import * as cloudflare from "vite-hub/sandbox/cloudflare"`,
+      `cloudflare.defineDockerfileFragment\`RUN true\``,
+    ].join("\n"))
+
+    await expect(extractCloudflareDockerfileFragment(file)).rejects.toThrow("named import")
+  })
 })

--- a/packages/sandbox/test/definition-options.test.ts
+++ b/packages/sandbox/test/definition-options.test.ts
@@ -1,10 +1,14 @@
-import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
 
-import { extractSandboxDefinitionOptions } from "../src/definition-options.ts"
+import {
+  extractCloudflareDockerfileFragment,
+  extractSandboxDefinitionOptions,
+  stripCloudflareDockerfileFragment,
+} from "../src/definition-options.ts"
 
 const tempDirs: string[] = []
 
@@ -98,5 +102,78 @@ describe("extractSandboxDefinitionOptions", () => {
       runtime: { command: "node", args: ["worker.mjs"] },
       timeout: 30000,
     })
+  })
+})
+
+describe("Cloudflare Dockerfile fragment extraction", () => {
+  it("preserves raw template text and strips build-only source", async () => {
+    const file = await writeDefinition([
+      `import { defineDockerfileFragment } from "vite-hub/sandbox/cloudflare"`,
+      `import { defineSandbox } from "vite-hub/sandbox"`,
+      ``,
+      `defineDockerfileFragment\``,
+      `RUN apt-get update \\`,
+      `  && apt-get install -y imagemagick`,
+      `\``,
+      ``,
+      `export default defineSandbox(async () => null)`,
+      ``,
+    ].join("\n"))
+
+    const fragment = await extractCloudflareDockerfileFragment(file)
+    expect(fragment).toBe("\nRUN apt-get update \\\n  && apt-get install -y imagemagick\n")
+
+    const source = await readFile(file, "utf8")
+    const stripped = stripCloudflareDockerfileFragment(source, file)
+    expect(stripped).not.toContain("defineDockerfileFragment")
+    expect(stripped).not.toContain("imagemagick")
+    expect(stripped).toContain("export default defineSandbox")
+  })
+
+  it("rejects interpolated fragments", async () => {
+    const file = await writeDefinition([
+      `import { defineDockerfileFragment } from "vite-hub/sandbox/cloudflare"`,
+      `const packageName = "imagemagick"`,
+      'defineDockerfileFragment`RUN apt-get install ${packageName}`',
+    ].join("\n"))
+
+    await expect(extractCloudflareDockerfileFragment(file)).rejects.toThrow("without interpolations")
+  })
+
+  it("rejects the former exported fragment shape", async () => {
+    const file = await writeDefinition([
+      `import { defineDockerfileFragment } from "vite-hub/sandbox/cloudflare"`,
+      `export const cloudflareDockerfileFragment = defineDockerfileFragment\`RUN true\``,
+    ].join("\n"))
+
+    await expect(extractCloudflareDockerfileFragment(file)).rejects.toThrow("top-level")
+  })
+
+  it("rejects interpolated fragments assigned to a variable", async () => {
+    const file = await writeDefinition([
+      `import { defineDockerfileFragment } from "vite-hub/sandbox/cloudflare"`,
+      `const packageName = "imagemagick"`,
+      'const fragment = defineDockerfileFragment`RUN apt-get install ${packageName}`',
+    ].join("\n"))
+
+    await expect(extractCloudflareDockerfileFragment(file)).rejects.toThrow("top-level")
+  })
+
+  it("rejects FROM instructions", async () => {
+    const file = await writeDefinition([
+      `import { defineDockerfileFragment } from "vite-hub/sandbox/cloudflare"`,
+      `defineDockerfileFragment\`FROM alpine\``,
+    ].join("\n"))
+
+    await expect(extractCloudflareDockerfileFragment(file)).rejects.toThrow("cannot contain FROM")
+  })
+
+  it("ignores a local helper with the same name", async () => {
+    const file = await writeDefinition([
+      `const defineDockerfileFragment = String.raw`,
+      `defineDockerfileFragment\`RUN true\``,
+    ].join("\n"))
+
+    await expect(extractCloudflareDockerfileFragment(file)).resolves.toBeUndefined()
   })
 })

--- a/packages/sandbox/test/public-api.test.ts
+++ b/packages/sandbox/test/public-api.test.ts
@@ -3,6 +3,7 @@ import { join } from "node:path"
 
 import { describe, expect, it } from "vitest"
 
+import { defineDockerfileFragment } from "../src/cloudflare-public.ts"
 import { defineSandbox, runSandbox } from "../src/index.ts"
 
 describe("sandbox public api", () => {
@@ -15,11 +16,20 @@ describe("sandbox public api", () => {
     })
 
     expect("createSandbox" in sandboxPackage).toBe(false)
+    expect("defineDockerfileFragment" in sandboxPackage).toBe(false)
     expect(definition.options).toEqual({
       env: { FOO: "bar" },
       runtime: { command: "node", args: ["--trace-warnings"] },
       timeout: 1_000,
     })
+  })
+
+  it("keeps Cloudflare Dockerfile fragments static", () => {
+    expect(defineDockerfileFragment`RUN true`).toBeUndefined()
+    expect(() => (defineDockerfileFragment as (...args: any[]) => void)(
+      { raw: ["RUN echo ", ""] },
+      "dynamic",
+    )).toThrow("without interpolations")
   })
 
   it("returns a result wrapper instead of throwing", async () => {

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -440,7 +440,7 @@ describe("hubSandbox", () => {
     const rootDir = await createViteRoot()
     await writeCloudflareFragmentDefinition(rootDir)
     const { hubSandbox } = await import("../src/vite.ts")
-    const plugin = hubSandbox({ provider: "cloudflare" })
+    const plugin = hubSandbox()
     const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
     const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
     const userConfig = {

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -457,6 +457,38 @@ describe("hubSandbox", () => {
       .resolves.toContain("&& apt-get install -y imagemagick")
   })
 
+  it("refreshes the generated Cloudflare Dockerfile when its colocated fragment changes", async () => {
+    const rootDir = await createViteRoot()
+    await writeCloudflareFragmentDefinition(rootDir)
+    const definition = join(rootDir, "src/tools/release-notes.sandbox.ts")
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
+    const handleHotUpdate = plugin.handleHotUpdate as unknown as (context: {
+      file: string
+      server: { moduleGraph: { getModuleById: () => undefined, invalidateModule: () => void } }
+    }) => Promise<void>
+    const config = {
+      root: rootDir,
+      plugins: [{ name: "nitro:main" }],
+      nitro: { preset: "cloudflare-module" },
+      resolve: { alias: [] },
+    }
+
+    await configHook(config, { command: "serve", mode: "development" })
+    await configResolved(config)
+    await writeFile(definition, (await readFile(definition, "utf8")).replace("imagemagick", "ffmpeg"))
+    await handleHotUpdate({
+      file: definition,
+      server: { moduleGraph: { getModuleById: () => undefined, invalidateModule: () => {} } },
+    })
+
+    const dockerfile = await readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8")
+    expect(dockerfile).toContain("ffmpeg")
+    expect(dockerfile).not.toContain("imagemagick")
+  })
+
   it("rejects a colocated fragment without changing an application-owned image", async () => {
     const rootDir = await createViteRoot()
     await writeCloudflareFragmentDefinition(rootDir)

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -36,6 +36,21 @@ async function createViteRoot() {
   return rootDir
 }
 
+async function writeCloudflareFragmentDefinition(rootDir: string) {
+  await writeFile(join(rootDir, "src/tools/release-notes.sandbox.ts"), [
+    `import { defineDockerfileFragment } from "vite-hub/sandbox/cloudflare"`,
+    `import { defineSandbox } from "@vite-hub/sandbox"`,
+    ``,
+    `defineDockerfileFragment\``,
+    `RUN apt-get update \\`,
+    `  && apt-get install -y imagemagick`,
+    `\``,
+    ``,
+    `export default defineSandbox(async () => ({ ok: true }))`,
+    ``,
+  ].join("\n"))
+}
+
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map(root => rm(root, { recursive: true, force: true })))
 })
@@ -343,6 +358,109 @@ describe("hubSandbox", () => {
       .toContain(`export { Sandbox, ContainerProxy } from "./sandbox-cloudflare-exports.mjs"`)
     expect(rollupPlugin.renderChunk("export default {}", { exports: ["default"], isEntry: true, fileName: "entries/server.js" }).code)
       .toContain(`export { Sandbox, ContainerProxy } from "../sandbox-cloudflare-exports.mjs"`)
+  })
+
+  it("appends a colocated Cloudflare Dockerfile fragment without bundling build metadata", async () => {
+    const rootDir = await createViteRoot()
+    await writeCloudflareFragmentDefinition(rootDir)
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
+    const userConfig = {
+      root: rootDir,
+      plugins: [{ name: "nitro:main" }],
+      nitro: { preset: "cloudflare-module" },
+    }
+
+    await configHook(userConfig, { command: "build", mode: "production" })
+    await configResolved({ ...userConfig, resolve: { alias: [] } })
+
+    const dockerfile = await readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8")
+    expect(dockerfile).toMatch(/^FROM docker\.io\/cloudflare\/sandbox:\d/)
+    expect(dockerfile).toContain("RUN apt-get update \\\n  && apt-get install -y imagemagick")
+
+    const definition = await readFile(
+      join(rootDir, ".vitehub/sandbox/runtime/sandbox-definitions/tools__release-notes.mjs"),
+      "utf8",
+    )
+    expect(definition).not.toContain("defineDockerfileFragment")
+    expect(definition).not.toContain("imagemagick")
+  })
+
+  it("rejects a colocated Cloudflare fragment with multiple Sandbox Definitions", async () => {
+    const rootDir = await createViteRoot()
+    await writeCloudflareFragmentDefinition(rootDir)
+    await writeFile(join(rootDir, "src/tools/second.sandbox.ts"), [
+      `import { defineSandbox } from "@vite-hub/sandbox"`,
+      `export default defineSandbox(async () => null)`,
+    ].join("\n"))
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+
+    await expect(configHook({ root: rootDir }, { command: "build", mode: "production" }))
+      .rejects.toThrow("requires exactly one discovered Sandbox Definition")
+  })
+
+  it("rejects a colocated Cloudflare fragment for non-Cloudflare providers", async () => {
+    const rootDir = await createViteRoot()
+    await writeCloudflareFragmentDefinition(rootDir)
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "vercel" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+
+    await expect(configHook({ root: rootDir }, { command: "build", mode: "production" }))
+      .rejects.toThrow("requires Cloudflare hosting and the Cloudflare Sandbox provider")
+  })
+
+  it("rejects a colocated Cloudflare fragment on non-Cloudflare hosting", async () => {
+    const rootDir = await createViteRoot()
+    await writeCloudflareFragmentDefinition(rootDir)
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+
+    await expect(configHook({ root: rootDir, preset: "vercel" }, { command: "build", mode: "production" }))
+      .rejects.toThrow("requires Cloudflare hosting and the Cloudflare Sandbox provider")
+  })
+
+  it("rejects a colocated Cloudflare fragment when hosting is unknown", async () => {
+    const rootDir = await createViteRoot()
+    await writeCloudflareFragmentDefinition(rootDir)
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+
+    await expect(configHook({ root: rootDir, preset: "node-server" }, { command: "build", mode: "production" }))
+      .rejects.toThrow("requires Cloudflare hosting and the Cloudflare Sandbox provider")
+  })
+
+  it("rejects a colocated fragment without changing an application-owned image", async () => {
+    const rootDir = await createViteRoot()
+    await writeCloudflareFragmentDefinition(rootDir)
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const container = {
+      class_name: "Sandbox",
+      image: "./application.Dockerfile",
+      max_instances: 3,
+    }
+    const userConfig = {
+      root: rootDir,
+      plugins: [{ name: "nitro:main" }],
+      nitro: {
+        preset: "cloudflare-module",
+        cloudflare: { wrangler: { containers: [container] } },
+      },
+    }
+
+    await expect(configHook(userConfig, { command: "build", mode: "production" }))
+      .rejects.toThrow("cannot be combined with an application-owned Sandbox container image")
+    expect(userConfig.nitro.cloudflare.wrangler.containers).toEqual([container])
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
+      .rejects.toMatchObject({ code: "ENOENT" })
   })
 
   it("preserves an application-owned Cloudflare Sandbox container", async () => {

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -436,6 +436,27 @@ describe("hubSandbox", () => {
       .rejects.toThrow("requires Cloudflare hosting and the Cloudflare Sandbox provider")
   })
 
+  it("accepts a colocated Cloudflare fragment when Nitro resolves Cloudflare hosting late", async () => {
+    const rootDir = await createViteRoot()
+    await writeCloudflareFragmentDefinition(rootDir)
+    const { hubSandbox } = await import("../src/vite.ts")
+    const plugin = hubSandbox({ provider: "cloudflare" })
+    const configHook = plugin.config as (config: Record<string, any>, env: { command: "serve" | "build", mode: string }) => unknown | Promise<unknown>
+    const configResolved = plugin.configResolved as unknown as (config: Record<string, any>) => unknown | Promise<unknown>
+    const userConfig = {
+      root: rootDir,
+      plugins: [{ name: "nitro:main" }],
+      nitro: {},
+    }
+
+    await configHook(userConfig, { command: "build", mode: "production" })
+    const resolvedConfig = { ...userConfig, nitro: { preset: "cloudflare-module" }, resolve: { alias: [] } }
+    await configResolved(resolvedConfig)
+
+    await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
+      .resolves.toContain("RUN apt-get install -y imagemagick")
+  })
+
   it("rejects a colocated fragment without changing an application-owned image", async () => {
     const rootDir = await createViteRoot()
     await writeCloudflareFragmentDefinition(rootDir)

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -454,7 +454,7 @@ describe("hubSandbox", () => {
     await configResolved(resolvedConfig)
 
     await expect(readFile(join(rootDir, ".vitehub/sandbox/Dockerfile"), "utf8"))
-      .resolves.toContain("RUN apt-get install -y imagemagick")
+      .resolves.toContain("&& apt-get install -y imagemagick")
   })
 
   it("rejects a colocated fragment without changing an application-owned image", async () => {

--- a/packages/sandbox/vite.config.ts
+++ b/packages/sandbox/vite.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       onlyBundle: false,
     },
     entry: [
+      "src/cloudflare-public.ts",
       "src/index.ts",
       "src/vite.ts",
       "src/runtime/empty-registry.ts",
@@ -30,11 +31,12 @@ export default defineConfig({
       customExports(exports) {
         return Object.fromEntries(
           Object.entries(exports).map(([key, value]) => {
+            const exportKey = key === "./cloudflare-public" ? "./cloudflare" : key;
             if (typeof value !== "string" || !value.endsWith(".js")) {
-              return [key, value];
+              return [exportKey, value];
             }
             return [
-              key,
+              exportKey,
               {
                 types: value.replace(/\.js$/, ".d.ts"),
                 import: value,

--- a/packages/vite-hub/package.json
+++ b/packages/vite-hub/package.json
@@ -93,6 +93,7 @@
     "./rate-limit": "./dist/rate-limit.js",
     "./runtime": "./dist/runtime.js",
     "./sandbox": "./dist/sandbox.js",
+    "./sandbox/cloudflare": "./dist/sandbox/cloudflare.js",
     "./schedule": "./dist/schedule.js",
     "./schedule/runtime": "./dist/schedule/runtime.js",
     "./schedule/runtime/driver": "./dist/schedule/runtime/driver.js",

--- a/packages/vite-hub/src/sandbox/cloudflare.ts
+++ b/packages/vite-hub/src/sandbox/cloudflare.ts
@@ -1,0 +1,1 @@
+export * from "@vite-hub/sandbox/cloudflare"


### PR DESCRIPTION
Adds a Cloudflare-only build fragment beside a single Sandbox Definition. `defineDockerfileFragment` is exposed from `@vite-hub/sandbox/cloudflare` and `vite-hub/sandbox/cloudflare`; ViteHub discovers the exact imported top-level tagged template, preserves its raw text, removes the build-only statement and import from the runtime bundle, and appends the fragment after the installed-version `cloudflare/sandbox` base in `.vitehub/sandbox/Dockerfile`.

This keeps the image at the existing app/provider boundary introduced by #723: more than one discovered definition, a non-Cloudflare or unknown host, interpolation, unsupported marker placement, and `FROM` fail clearly. An application-owned container image remains authoritative and conflicts with the fragment instead of being rewritten.