### PR TITLE
fix(docs): deploy Cloudflare with Vite+

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -83,10 +83,8 @@ jobs:
         run: vp run --filter vitehub-docs build
 
       - name: Deploy Worker
-        uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: docs
-          wranglerVersion: "4.112.0"
-          command: deploy --config .output/server/wrangler.json
+        working-directory: docs
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: vp dlx "wrangler@4.112.0" deploy --config .output/server/wrangler.json


### PR DESCRIPTION
Replaces `cloudflare/wrangler-action` with the pinned Wrangler CLI through Vite+, matching the existing pull-request verification path while keeping the Cloudflare credentials scoped to the deploy step.

The action tried to install Wrangler with npm inside the pnpm workspace and failed on its `catalog:` dependencies, so the production Worker and `vitehub.dev` custom domain were never deployed.