### PR TITLE
refactor(cli): reuse shared contributor contract

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,7 +10,30 @@ import { resolve } from "pathe"
 import { runProvision } from "./provision.ts"
 
 import type { InlineConfig, ResolvedConfig } from "vite"
-import type { ViteHubCliCommandNamespace, ViteHubCliContext, ViteHubCliSpawn, ViteHubCliSpawnOptions } from "@vite-hub/internal/cli"
+import type { ViteHubCliCommandNamespace, ViteHubCliContext } from "@vite-hub/internal/cli"
+
+interface ViteHubCliSpawnResult {
+  exitCode: number | null
+  signal?: NodeJS.Signals | null
+}
+
+interface ViteHubCliSpawnOptions {
+  cwd?: string
+  env?: NodeJS.ProcessEnv
+  stderr?: "inherit" | "pipe"
+  stdout?: "inherit" | "pipe"
+}
+
+type ViteHubCliSpawn = (
+  command: string,
+  args: string[],
+  options?: ViteHubCliSpawnOptions,
+) => Promise<ViteHubCliSpawnResult>
+
+interface ViteHubCliStreams {
+  stderr: { write: (chunk: string | Uint8Array) => unknown }
+  stdout: { write: (chunk: string | Uint8Array) => unknown }
+}
 
 export interface RunViteHubCliOptions {
   args?: string[]
@@ -18,8 +41,8 @@ export interface RunViteHubCliOptions {
   env?: NodeJS.ProcessEnv
   loadConfig?: (rootDir: string) => Promise<Pick<ResolvedConfig, "plugins" | "root">>
   spawn?: ViteHubCliSpawn
-  stderr?: ViteHubCliContext["stderr"]
-  stdout?: ViteHubCliContext["stdout"]
+  stderr?: ViteHubCliStreams["stderr"]
+  stdout?: ViteHubCliStreams["stdout"]
 }
 
 function defaultSpawn(command: string, args: string[], options: ViteHubCliSpawnOptions = {}) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,66 +4,13 @@ import { realpathSync } from "node:fs"
 import process from "node:process"
 import { fileURLToPath } from "node:url"
 
-import { collectViteHubProvisionSteps } from "@vite-hub/internal/cli"
+import { collectViteHubCliNamespaces, collectViteHubProvisionSteps } from "@vite-hub/internal/cli"
 import { resolve } from "pathe"
 
 import { runProvision } from "./provision.ts"
 
 import type { InlineConfig, ResolvedConfig } from "vite"
-
-interface ViteHubCliSpawnResult {
-  exitCode: number | null
-  signal?: NodeJS.Signals | null
-}
-
-interface ViteHubCliSpawnOptions {
-  cwd?: string
-  env?: NodeJS.ProcessEnv
-  stderr?: "inherit" | "pipe"
-  stdout?: "inherit" | "pipe"
-}
-
-type ViteHubCliSpawn = (
-  command: string,
-  args: string[],
-  options?: ViteHubCliSpawnOptions,
-) => Promise<ViteHubCliSpawnResult>
-
-interface ViteHubCliContext {
-  cwd: string
-  env: NodeJS.ProcessEnv
-  rootDir: string
-  spawn: ViteHubCliSpawn
-  stderr: { write: (chunk: string | Uint8Array) => unknown }
-  stdout: { write: (chunk: string | Uint8Array) => unknown }
-}
-
-interface ViteHubCliFeature {
-  description?: string
-  name: string
-  run: (args: string[], context: ViteHubCliContext) => Promise<number | void> | number | void
-  usage?: string
-}
-
-interface ViteHubCliCommandNamespace {
-  description?: string
-  features: ViteHubCliFeature[]
-  name: string
-}
-
-interface ViteHubCliContributor {
-  namespaces: ViteHubCliCommandNamespace[]
-}
-
-type ViteHubCliContributorFactory = () => ViteHubCliContributor | undefined | Promise<ViteHubCliContributor | undefined>
-
-interface ViteHubCliPluginMetadata {
-  cli?: ViteHubCliContributor | ViteHubCliContributorFactory
-}
-
-interface ViteHubCliContributingPlugin {
-  vitehub?: ViteHubCliPluginMetadata
-}
+import type { ViteHubCliCommandNamespace, ViteHubCliContext, ViteHubCliSpawn, ViteHubCliSpawnOptions } from "@vite-hub/internal/cli"
 
 export interface RunViteHubCliOptions {
   args?: string[]
@@ -96,37 +43,6 @@ async function loadViteConfig(rootDir: string): Promise<Pick<ResolvedConfig, "pl
   const { resolveConfig } = await import("vite")
   const inlineConfig: InlineConfig = { root: rootDir }
   return await resolveConfig(inlineConfig, "serve", "development")
-}
-
-async function resolveContributor(value: ViteHubCliPluginMetadata["cli"]): Promise<ViteHubCliContributor | undefined> {
-  return typeof value === "function" ? await value() : value
-}
-
-async function collectViteHubCliNamespaces(plugins: readonly unknown[]): Promise<ViteHubCliCommandNamespace[]> {
-  const namespaces = new Map<string, ViteHubCliCommandNamespace>()
-
-  for (const plugin of plugins) {
-    if (!plugin || typeof plugin !== "object") continue
-    const metadata = (plugin as ViteHubCliContributingPlugin).vitehub
-    const contributor = await resolveContributor(metadata?.cli)
-    if (!contributor) continue
-
-    for (const namespace of contributor.namespaces) {
-      const existing = namespaces.get(namespace.name)
-      if (!existing) {
-        namespaces.set(namespace.name, { ...namespace, features: [...namespace.features] })
-        continue
-      }
-
-      const features = new Map(existing.features.map(feature => [feature.name, feature]))
-      for (const feature of namespace.features) {
-        features.set(feature.name, feature)
-      }
-      existing.features = [...features.values()]
-    }
-  }
-
-  return [...namespaces.values()]
 }
 
 // Built-in namespace that orchestrates package-contributed Provision Steps.

--- a/packages/cli/src/provision.ts
+++ b/packages/cli/src/provision.ts
@@ -1,6 +1,7 @@
 import { mergeProvisionState, writeProvisionState } from "@vite-hub/internal/provision-state"
 import { resolveCloudflareProvisionConfig, resolveVercelProvisionConfig } from "@vite-hub/internal/provision"
 
+import type { ViteHubCliContext } from "@vite-hub/internal/cli"
 import type {
   ProvisionAction,
   ProvisionContext,
@@ -9,13 +10,7 @@ import type {
   ProvisionStep,
 } from "@vite-hub/internal/provision"
 
-interface ProvisionFeatureContext {
-  cwd: string
-  env: NodeJS.ProcessEnv
-  rootDir: string
-  stderr: { write: (chunk: string | Uint8Array) => unknown }
-  stdout: { write: (chunk: string | Uint8Array) => unknown }
-}
+type ProvisionFeatureContext = Pick<ViteHubCliContext, "env" | "rootDir" | "stderr" | "stdout">
 
 interface ProvisionFeatureOptions {
   collectSteps: () => Promise<ProvisionStep[]>

--- a/packages/database/src/cli.ts
+++ b/packages/database/src/cli.ts
@@ -2,29 +2,9 @@ import { delimiter, join } from "node:path"
 
 import type { DBModulePublicOptions } from "./types.ts"
 import type { ResolvedDBViteConfig } from "./types.ts"
+import type { ViteHubCliContext, ViteHubCliContributor } from "@vite-hub/internal/cli"
 
 import { isAbsolute, relative } from "pathe"
-
-interface ViteHubCliContext {
-  env?: NodeJS.ProcessEnv
-  rootDir: string
-  spawn: (command: string, args: string[], options?: { cwd?: string, env?: NodeJS.ProcessEnv, stderr?: "inherit" | "pipe", stdout?: "inherit" | "pipe" }) => Promise<{ exitCode: number | null }>
-  stderr: { write: (chunk: string | Uint8Array) => unknown }
-  stdout: { write: (chunk: string | Uint8Array) => unknown }
-}
-
-interface ViteHubCliContributor {
-  namespaces: Array<{
-    description?: string
-    features: Array<{
-      description?: string
-      name: string
-      run: (args: string[], context: ViteHubCliContext) => Promise<number | void> | number | void
-      usage?: string
-    }>
-    name: string
-  }>
-}
 
 type ResolvedDBViteConfigProvider = () => MaybePromise<ResolvedDBViteConfig | undefined>
 type MaybePromise<T> = Promise<T> | T

--- a/packages/database/src/cli.ts
+++ b/packages/database/src/cli.ts
@@ -2,12 +2,33 @@ import { delimiter, join } from "node:path"
 
 import type { DBModulePublicOptions } from "./types.ts"
 import type { ResolvedDBViteConfig } from "./types.ts"
-import type { ViteHubCliContext, ViteHubCliContributor } from "@vite-hub/internal/cli"
+import type { ViteHubCliContributor as SharedViteHubCliContributor } from "@vite-hub/internal/cli"
 
 import { isAbsolute, relative } from "pathe"
 
 type ResolvedDBViteConfigProvider = () => MaybePromise<ResolvedDBViteConfig | undefined>
 type MaybePromise<T> = Promise<T> | T
+
+interface ViteHubCliContext {
+  env?: NodeJS.ProcessEnv
+  rootDir: string
+  spawn: (command: string, args: string[], options?: { cwd?: string, env?: NodeJS.ProcessEnv, stderr?: "inherit" | "pipe", stdout?: "inherit" | "pipe" }) => Promise<{ exitCode: number | null }>
+  stderr: { write: (chunk: string | Uint8Array) => unknown }
+  stdout: { write: (chunk: string | Uint8Array) => unknown }
+}
+
+interface ViteHubCliContributor {
+  namespaces: Array<{
+    description?: string
+    features: Array<{
+      description?: string
+      name: string
+      run: (args: string[], context: ViteHubCliContext) => Promise<number | void> | number | void
+      usage?: string
+    }>
+    name: string
+  }>
+}
 
 function writeGenerateUsage(context: ViteHubCliContext): void {
   context.stdout.write([
@@ -125,5 +146,5 @@ export function createDbCliContributor(
       features,
       name: "db",
     }],
-  }
+  } satisfies SharedViteHubCliContributor
 }


### PR DESCRIPTION
Reuses the single ViteHub CLI contributor contract and namespace collector from `@vite-hub/internal/cli` across the public CLI and Database package. This removes the duplicate contract declarations and collector implementation so contributor ordering and feature replacement semantics have one owner.

There is no public API or behavior change; the CLI build continues to inline the private internal declarations into `@vite-hub/cli`.