### PR TITLE
fix(blob): provision matching Vercel stores

### DIFF
--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -6,6 +6,7 @@ import { createDefaultCloudflareOutputRoot, getProviderRuntimeModule, registerPr
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vite-hub/internal/build/paths"
 import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
 import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
+import { isPlainObject } from "@vite-hub/internal/object"
 
 import { normalizeBlobOptions } from "../config.ts"
 
@@ -90,6 +91,31 @@ const driverModules = {
   "vercel-blob": "drivers/vercel",
 } satisfies Record<NonNullable<ResolvedBlobModuleOptions["store"]>["driver"], string>
 
+function isResolvedBlobStore(store: unknown): store is ResolvedBlobModuleOptions["store"] {
+  if (!isPlainObject(store) || typeof store.driver !== "string" || !Object.hasOwn(driverModules, store.driver)) return false
+  switch (store.driver) {
+    case "cloudflare-r2":
+      return typeof store.binding === "string"
+    case "fs":
+      return typeof store.base === "string"
+    case "minio":
+      return typeof store.bucket === "string"
+        && typeof store.endpoint === "string"
+        && typeof store.forcePathStyle === "boolean"
+        && typeof store.region === "string"
+    case "vercel-blob":
+      return (store.access === "private" || store.access === "public") && typeof store.token === "string"
+    default:
+      return true
+  }
+}
+
+function isResolvedBlobConfig(blob: object): blob is ResolvedBlobModuleOptions {
+  if (!("store" in blob) || !isResolvedBlobStore(blob.store)) return false
+  if (!("stores" in blob) || typeof blob.stores === "undefined") return true
+  return isPlainObject(blob.stores) && Object.values(blob.stores).every(isResolvedBlobStore)
+}
+
 function getRuntimeBlobStoreResolver(driver: string | undefined) {
   switch (driver) {
     case "minio":
@@ -129,9 +155,13 @@ function resolveBlobConfig(
   blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined,
   hosting: string,
 ): false | ResolvedBlobModuleOptions {
-  return blob && typeof blob === "object" && "store" in blob
-    ? blob
-    : normalizeBlobOptions(blob, { hosting }) || false
+  if (blob && typeof blob === "object" && "store" in blob) {
+    if (!isResolvedBlobConfig(blob)) {
+      throw new TypeError("`blob.store` must contain a fully resolved Blob store with a supported `driver`.")
+    }
+    return blob
+  }
+  return normalizeBlobOptions(blob, { hosting }) || false
 }
 
 function renderProviderEntry(

--- a/packages/blob/src/provision.ts
+++ b/packages/blob/src/provision.ts
@@ -16,8 +16,10 @@ interface CloudflareR2Bucket {
 }
 
 interface VercelBlobStore {
+  access?: "private" | "public"
   id?: string
   name?: string
+  projectsMetadata?: Array<{ projectId?: string }>
   type?: string
 }
 
@@ -26,13 +28,12 @@ interface VercelBlobStoresResponse {
 }
 
 interface VercelBlobStoreCreateResponse {
-  store?: { id?: string }
-  // Token returned on creation; treated as a secret, never persisted to disk or logged.
-  token?: string
-  BLOB_READ_WRITE_TOKEN?: string
+  store?: VercelBlobStore
 }
 
 const VERCEL_BLOB_STORE_NAME = "vitehub-blob"
+const VERCEL_BLOB_STORE_REGION = "iad1"
+const VERCEL_PROJECT_ENVIRONMENTS = ["production", "preview", "development"] as const
 
 function resolvedStores(options: BlobModuleOptions | undefined, env: Record<string, string | undefined>): ResolvedBlobStoreConfig[] {
   const config = resolveBlobViteConfig(options, { env })
@@ -79,8 +80,8 @@ export function createBlobVercelProvisionStep(resolveOptions: () => BlobModuleOp
     id: "blob:vercel-blob",
     provider: "vercel",
     async plan(context) {
-      const usesVercelBlob = resolvedStores(resolveOptions(), context.env).some(store => store.driver === "vercel-blob")
-      if (!usesVercelBlob) return []
+      const requested = resolvedStores(resolveOptions(), context.env).find(store => store.driver === "vercel-blob")
+      if (!requested || requested.driver !== "vercel-blob") return []
 
       const config = resolveVercelProvisionConfig(context.env)
       const projectId = readEnv(context.env, "VERCEL_PROJECT_ID")
@@ -91,43 +92,40 @@ export function createBlobVercelProvisionStep(resolveOptions: () => BlobModuleOp
 
       const request = createVercelProvisionClient(config, context.fetch)
       const listed = await request<VercelBlobStoresResponse>("/v1/storage/stores")
-      const existing = (listed.stores ?? []).find(store => store.type === "blob")
+      const existing = (listed.stores ?? []).find(store =>
+        (!store.type || store.type === "blob")
+        && (store.access ?? "public") === requested.access,
+      )
 
       return [{
         kind: "vercel-blob-store",
         name: existing?.name ?? VERCEL_BLOB_STORE_NAME,
         exists: Boolean(existing),
         apply: async () => {
-          const token = existing
-            ? readEnv(context.env, "BLOB_READ_WRITE_TOKEN")
-            : extractToken(await request<VercelBlobStoreCreateResponse>("/v1/storage/stores", {
-                method: "POST",
-                body: { type: "blob", name: VERCEL_BLOB_STORE_NAME },
-              }))
-          if (token) {
-            await pushVercelProjectEnv(request, projectId, "BLOB_READ_WRITE_TOKEN", token)
+          const store = existing ?? (await request<VercelBlobStoreCreateResponse>("/v1/storage/stores/blob", {
+            method: "POST",
+            body: {
+              access: requested.access,
+              name: VERCEL_BLOB_STORE_NAME,
+              region: VERCEL_BLOB_STORE_REGION,
+            },
+          })).store
+          if (!store?.id) {
+            throw new Error("Vercel Blob provisioning did not return a store id.")
+          }
+          if (!store.projectsMetadata?.some(project => project.projectId === projectId)) {
+            await request(`/v1/storage/stores/${store.id}/connections`, {
+              method: "POST",
+              body: {
+                envVarEnvironments: VERCEL_PROJECT_ENVIRONMENTS,
+                projectId,
+                type: "integration",
+              },
+            })
           }
           return {}
         },
       }]
     },
   }
-}
-
-function extractToken(response: VercelBlobStoreCreateResponse): string | undefined {
-  return response.token ?? response.BLOB_READ_WRITE_TOKEN
-}
-
-// Pushes a secret to the Vercel project env store. The value is never written to disk or logged.
-async function pushVercelProjectEnv(
-  request: ReturnType<typeof createVercelProvisionClient>,
-  projectId: string,
-  key: string,
-  value: string,
-): Promise<void> {
-  await request(`/v10/projects/${projectId}/env`, {
-    method: "POST",
-    query: { upsert: "true" },
-    body: { key, value, type: "encrypted", target: ["production", "preview", "development"] },
-  })
 }

--- a/packages/blob/test/provision.test.ts
+++ b/packages/blob/test/provision.test.ts
@@ -46,7 +46,7 @@ describe("blob cloudflare provision step", () => {
 describe("blob vercel provision step", () => {
   const env = { VERCEL_TOKEN: "vtoken", VERCEL_PROJECT_ID: "prj_1", BLOB_READ_WRITE_TOKEN: "secret-token" }
 
-  it("pushes the blob token to project env without ever returning it as a non-secret id", async () => {
+  it("reuses a public Blob store and connects it without exposing its token", async () => {
     const requests: Array<{ url: string, body: unknown }> = []
     const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = String(input)
@@ -54,20 +54,86 @@ describe("blob vercel provision step", () => {
         requests.push({ url, body: init.body ? JSON.parse(String(init.body)) : undefined })
         return jsonResponse({})
       }
-      // existing blob store so no creation happens
       return jsonResponse({ stores: [{ id: "store_1", name: "vitehub-blob", type: "blob" }] })
     }) as unknown as typeof globalThis.fetch
 
     const context: ProvisionContext = { env, fetch: fetchImpl, logger: { log: () => {}, warn: () => {} } }
     const actions = await createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" })).plan(context)
     expect(actions).toHaveLength(1)
+    expect(actions[0]!.exists).toBe(true)
     const result = await actions[0]!.apply()
 
-    // Secret must never be written to Provision State.
     expect(result.ids).toBeUndefined()
     expect(JSON.stringify(result)).not.toContain("secret-token")
+    expect(JSON.stringify(requests)).not.toContain("secret-token")
+    expect(requests).toEqual([{
+      body: {
+        envVarEnvironments: ["production", "preview", "development"],
+        projectId: "prj_1",
+        type: "integration",
+      },
+      url: expect.stringContaining("/v1/storage/stores/store_1/connections"),
+    }])
+  })
 
-    const envPush = requests.find(request => request.url.includes("/env"))
-    expect(envPush?.body).toMatchObject({ key: "BLOB_READ_WRITE_TOKEN", value: "secret-token" })
+  it("does not reconnect an already connected private Blob store", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      stores: [{
+        access: "private",
+        id: "store_private",
+        name: "vitehub-blob",
+        projectsMetadata: [{ projectId: "prj_1" }],
+        type: "blob",
+      }],
+    })) as unknown as typeof globalThis.fetch
+
+    const context: ProvisionContext = { env, fetch: fetchImpl, logger: { log: () => {}, warn: () => {} } }
+    const actions = await createBlobVercelProvisionStep(() => ({ access: "private", driver: "vercel-blob" })).plan(context)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]!.exists).toBe(true)
+    await actions[0]!.apply()
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it("creates and connects a private Blob store instead of selecting an existing public store", async () => {
+    const requests: Array<{ method: string | undefined, url: string, body: unknown }> = []
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      requests.push({
+        body: init?.body ? JSON.parse(String(init.body)) : undefined,
+        method: init?.method,
+        url,
+      })
+      if (url.includes("/v1/storage/stores/blob")) {
+        return jsonResponse({ store: { access: "private", id: "store_private", name: "vitehub-blob", type: "blob" } })
+      }
+      if (init?.method === "POST") return jsonResponse({})
+      return jsonResponse({ stores: [{ access: "public", id: "store_public", name: "existing-public", type: "blob" }] })
+    }) as unknown as typeof globalThis.fetch
+
+    const context: ProvisionContext = { env, fetch: fetchImpl, logger: { log: () => {}, warn: () => {} } }
+    const actions = await createBlobVercelProvisionStep(() => ({ access: "private", driver: "vercel-blob" })).plan(context)
+    expect(actions).toHaveLength(1)
+    expect(actions[0]!.exists).toBe(false)
+    await actions[0]!.apply()
+
+    expect(requests).toEqual([
+      { body: undefined, method: "GET", url: expect.stringContaining("/v1/storage/stores") },
+      {
+        body: { access: "private", name: "vitehub-blob", region: "iad1" },
+        method: "POST",
+        url: expect.stringContaining("/v1/storage/stores/blob"),
+      },
+      {
+        body: {
+          envVarEnvironments: ["production", "preview", "development"],
+          projectId: "prj_1",
+          type: "integration",
+        },
+        method: "POST",
+        url: expect.stringContaining("/v1/storage/stores/store_private/connections"),
+      },
+    ])
   })
 })

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -128,6 +128,16 @@ afterEach(() => {
 })
 
 describe("Vite provider outputs", () => {
+  it("rejects malformed resolved Blob config before rendering provider entries", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-invalid-resolved-config-")
+
+    await expect(generateProviderOutputs({
+      blob: { store: { access: "private" } } as never,
+      clientOutDir: "dist",
+      rootDir,
+    })).rejects.toThrow("`blob.store` must contain a fully resolved Blob store with a supported `driver`.")
+  })
+
   it("hydrates configured Blob options in bundled server output", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-runtime-config-")
     const entry = join(rootDir, "src", "server.ts")


### PR DESCRIPTION
Provisions Vercel Blob stores through the current Blob create and project-connection APIs, matching the configured public or private access mode instead of attaching the first account store. Project connections now let Vercel manage `BLOB_READ_WRITE_TOKEN`, so provisioning no longer copies that secret through ViteHub.

Also validates resolved Blob provider output before rendering runtime entries, preventing malformed `blob.store` objects from producing driverless bundles. Regression coverage exercises public-store reuse, private-store creation, existing project connections, secret isolation, and malformed resolved config.