### PR TITLE
fix: harden runtime and verification edges

### DIFF
--- a/docs/content/docs/server-primitives/queue.md
+++ b/docs/content/docs/server-primitives/queue.md
@@ -387,7 +387,7 @@ When migrating from the first structured Queue error contract, add `custom: true
 | `QUEUE_PROVIDER_RESPONSE_INVALID` | A successful Vercel send returned a missing or malformed `messageId`. |
 | `CLOUDFLARE_BINDING_RESOLUTION_REQUIRED` | A direct Cloudflare client was created without a concrete binding. |
 | `CLOUDFLARE_BINDING_INVALID` | The Cloudflare binding does not expose `send()` and `sendBatch()`. |
-| `CLOUDFLARE_UNSUPPORTED_ENQUEUE_OPTIONS` | Cloudflare received unsupported enqueue options such as `idempotencyKey` or `retentionSeconds`. |
+| `CLOUDFLARE_UNSUPPORTED_ENQUEUE_OPTIONS` | Cloudflare received unsupported enqueue options: `idempotencyKey`, `region`, or `retentionSeconds`. |
 | `VERCEL_QUEUE_SDK_LOAD_FAILED` | `@vercel/queue` could not be loaded. |
 | `VERCEL_QUEUE_SDK_INVALID` | `@vercel/queue` did not expose the expected client API. |
 | `VERCEL_QUEUE_REGION_REQUIRED` | Vercel region could not be resolved for the installed SDK shape. |

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
     "build": "NODE_OPTIONS='--max-old-space-size=8192' nuxi build",
     "deploy:cloudflare": "vp run build && vp dlx \"wrangler@4.112.0\" deploy --config .output/server/wrangler.json",
     "test": "vp test",
-    "typecheck": "nuxi prepare && ! vue-tsc --noEmit 2>&1 | grep 'error TS' | grep -Ev 'node_modules/.pnpm/docus@|docus/(app/pages/\\[\\[lang\\]\\]/\\[\\.\\.\\.slug\\]\\.vue\\(48,15\\): error TS2345|modules/config\\.ts\\(38,5\\): error TS2322)'",
+    "typecheck": "nuxi prepare && node scripts/typecheck.mjs",
     "generate": "NODE_OPTIONS='--max-old-space-size=8192' nuxi generate",
     "preview": "nuxi preview",
     "preview:cloudflare": "vp run build && vp dlx \"wrangler@4.112.0\" dev --config .output/server/wrangler.json"

--- a/docs/scripts/typecheck.mjs
+++ b/docs/scripts/typecheck.mjs
@@ -1,0 +1,66 @@
+import { spawnSync } from "node:child_process"
+import { createRequire } from "node:module"
+import { delimiter, dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const knownDocusDiagnostics = new Set([
+  "app/app.vue:43:25:TS2571",
+  "app/components/OgImage/Docs.takumi.vue:19:84:TS2731",
+  "app/components/OgImage/Landing.takumi.vue:62:73:TS2731",
+  "app/error.vue:39:25:TS2571",
+  "app/plugins/i18n.ts:52:77:TS2339",
+  "modules/assistant/runtime/components/AssistantPanel.vue:162:12:TS2322",
+  "modules/assistant/runtime/components/AssistantPanel.vue:204:39:TS2345",
+  "modules/assistant/runtime/components/AssistantPanel.vue:216:47:TS2345",
+  "modules/assistant/runtime/components/AssistantPanel.vue:231:39:TS2345",
+  "modules/assistant/runtime/composables/useAssistant.ts:59:49:TS2339",
+])
+
+const vueTsc = fileURLToPath(import.meta.resolve("vue-tsc/bin/vue-tsc.js"))
+const require = createRequire(import.meta.url)
+const nuxtRequire = createRequire(require.resolve("nuxt/package.json"))
+const vueRouterNodeModules = dirname(dirname(nuxtRequire.resolve("vue-router/package.json")))
+const result = spawnSync(process.execPath, [vueTsc, "--noEmit", "--pretty", "false"], {
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    NODE_PATH: [vueRouterNodeModules, process.env.NODE_PATH].filter(Boolean).join(delimiter),
+  },
+  maxBuffer: 10 * 1024 * 1024,
+})
+const stdout = result.stdout || ""
+const stderr = result.stderr || ""
+
+if (result.status === 0) {
+  process.stdout.write(stdout)
+  process.stderr.write(stderr)
+  process.exit(0)
+}
+
+const lines = `${stdout}${stderr}`.split(/\r?\n/)
+const diagnosticKeys = []
+let hasUnexpectedOutput = false
+for (const line of lines) {
+  if (!line) continue
+  const match = /^(.*)\((\d+),(\d+)\): error (TS\d+):/.exec(line)
+  if (match) {
+    const path = match[1].replaceAll("\\", "/")
+    const docusPath = path.split("/node_modules/docus/")[1]
+    diagnosticKeys.push(docusPath ? `${docusPath}:${match[2]}:${match[3]}:${match[4]}` : "")
+  }
+  else if (diagnosticKeys.length === 0 || !/^\s/.test(line)) {
+    hasUnexpectedOutput = true
+  }
+}
+
+if (
+  result.error
+  || result.signal
+  || diagnosticKeys.length === 0
+  || hasUnexpectedOutput
+  || diagnosticKeys.some(diagnostic => !knownDocusDiagnostics.has(diagnostic))
+) {
+  process.stdout.write(stdout)
+  process.stderr.write(stderr)
+  process.exit(result.status || 1)
+}

--- a/packages/agent/src/capabilities/transcribe.ts
+++ b/packages/agent/src/capabilities/transcribe.ts
@@ -164,7 +164,15 @@ function bytesFromAudioString(value: string): Uint8Array {
 
 async function responseBytes(response: Response, maxBytes: number): Promise<Uint8Array> {
   const contentLength = Number(response.headers.get("content-length"))
-  if (Number.isFinite(contentLength)) assertWithinMaxBytes(contentLength, maxBytes, "downloaded audio")
+  if (Number.isFinite(contentLength)) {
+    try {
+      assertWithinMaxBytes(contentLength, maxBytes, "downloaded audio")
+    }
+    catch (error) {
+      await response.body?.cancel(error).catch(() => undefined)
+      throw error
+    }
+  }
 
   if (!response.body) {
     const bytes = new Uint8Array(await response.arrayBuffer())
@@ -175,13 +183,22 @@ async function responseBytes(response: Response, maxBytes: number): Promise<Uint
   const reader = response.body.getReader()
   const chunks: Uint8Array[] = []
   let byteLength = 0
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-    const chunk = value instanceof Uint8Array ? value : new Uint8Array(value)
-    byteLength += chunk.byteLength
-    assertWithinMaxBytes(byteLength, maxBytes, "downloaded audio")
-    chunks.push(chunk)
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      const chunk = value instanceof Uint8Array ? value : new Uint8Array(value)
+      byteLength += chunk.byteLength
+      assertWithinMaxBytes(byteLength, maxBytes, "downloaded audio")
+      chunks.push(chunk)
+    }
+  }
+  catch (error) {
+    await reader.cancel(error).catch(() => undefined)
+    throw error
+  }
+  finally {
+    reader.releaseLock()
   }
 
   const bytes = new Uint8Array(byteLength)

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -61,6 +61,27 @@ function chatIdentity(user: Record<string, unknown> | undefined, run: AgentRunMe
   return run?.origin ? `${run.origin}:${identity}` : identity
 }
 
+export function resolveChatTriggerInvoker(triggerInput: AgentChatMessageTriggerInput | undefined): AgentInvoker | undefined {
+  const userMeta: Record<string, unknown> = {}
+  for (const key of ["id", "sub", "email", "username", "name", "customer"]) {
+    const value = firstString(triggerInput?.user?.[key])?.trim()
+    if (value) userMeta[key] = value
+  }
+  const meta = Object.keys(userMeta).length || triggerInput?.meta
+    ? { ...userMeta, ...triggerInput?.meta }
+    : undefined
+  const invokerId = chatIdentity(triggerInput?.user, triggerInput?.run)
+  return triggerInput?.invoker
+    ? normalizeAgentInvoker(triggerInput.invoker, "chat.message input.invoker")
+    : invokerId
+      ? normalizeAgentInvoker({
+          id: invokerId,
+          kind: triggerInput?.run?.origin === "devtools" ? "devtools" as const : "chat" as const,
+          ...(meta ? { meta } : {}),
+        }, "chat.message input.user")
+      : undefined
+}
+
 function uiToolName(part: Record<string, unknown>): string {
   if (part.type === "dynamic-tool") {
     return firstString(part.toolName, part.name) || "tool"
@@ -306,24 +327,7 @@ export function createChatMessageTriggerInput<TRuntimeConfig extends AgentRuntim
   const triggerHistory = resolveChatTriggerHistory(options, triggerInput?.triggerHistory)
   const selectedMessages = selectChatHistory(messages, triggerHistory, options.sessions, triggerInput?.session)
   const hookArgs = createChatTriggerHookArgs<TRuntimeConfig>(selectedMessages, triggerInput?.run, triggerInput?.session)
-  const userMeta: Record<string, unknown> = {}
-  for (const key of ["id", "sub", "email", "username", "name", "customer"]) {
-    const value = firstString(triggerInput?.user?.[key])?.trim()
-    if (value) userMeta[key] = value
-  }
-  const meta = Object.keys(userMeta).length || triggerInput?.meta
-    ? { ...userMeta, ...triggerInput?.meta }
-    : undefined
-  const invokerId = chatIdentity(triggerInput?.user, triggerInput?.run)
-  const invoker = triggerInput?.invoker
-    ? normalizeAgentInvoker(triggerInput.invoker, "chat.message input.invoker")
-    : invokerId
-      ? normalizeAgentInvoker({
-          id: invokerId,
-          kind: triggerInput?.run?.origin === "devtools" ? "devtools" as const : "chat" as const,
-          ...(meta ? { meta } : {}),
-        }, "chat.message input.user")
-      : undefined
+  const invoker = resolveChatTriggerInvoker(triggerInput)
   return {
     hookArgs,
     input: {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -8,7 +8,7 @@ import { streamAgentOutputToEvents } from "../agent-output.ts"
 import { getAccessCapabilityOptions } from "../capabilities/access-metadata.ts"
 import { RateLimitRejectedError } from "../capabilities/rate-limit.ts"
 import { CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCapabilityOptions } from "../chat-trigger.ts"
-import { chatTriggerHistoryLimit, resolveChatTriggerHistory, uiMessagesToAgentMessages } from "../chat-message-input.ts"
+import { chatTriggerHistoryLimit, resolveChatTriggerHistory, resolveChatTriggerInvoker, uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { normalizeCapabilities } from "../capability-runtime.ts"
 import { deliveryArtifactAttachments } from "../delivery-artifacts.ts"
 import { createAgentInvocationContextStore } from "../invocation-context.ts"
@@ -1725,16 +1725,23 @@ async function handleChatSdkMessage(
         return capability.chatAttachments?.audio === true || metadata?.chatAttachments?.audio === true
       }),
     }
+    input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, [], messageContext, registration.channelId)
+    const authorizationInvoker = resolveChatTriggerInvoker(input)
+    const authorizationInput: AgentRunInput = {
+      context: authorizationInvoker ? { invoker: authorizationInvoker } : {},
+      messages: [],
+    }
+    const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, authorizationInput, input.run, messageContext)
+    if (!invoker) return
+
     const messages = await chatTriggerMessages(thread, message, options, messageContext, messageOptions)
     const currentMessage = message.id
       ? messages.find(item => item.id === message.id)
       : messages.at(-1)
     if (!currentMessage || !Array.isArray(currentMessage.parts) || currentMessage.parts.length === 0) return
-    input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, messages, messageContext, registration.channelId)
+    input = { ...input, messages }
     const invocation = await resolveAgentTriggerInvocation(agent as never, context as never, "chat.message", input)
     if (isResolvedAgentTriggerHandledInvocation(invocation)) return
-    const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, invocation.input as AgentRunInput, invocation.run, messageContext)
-    if (!invoker) return
 
     typing = options?.stream !== false ? startChatTypingRefresh(thread, context) : undefined
     run = invocation.run

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -8,7 +8,7 @@ import { streamAgentOutputToEvents } from "../agent-output.ts"
 import { getAccessCapabilityOptions } from "../capabilities/access-metadata.ts"
 import { RateLimitRejectedError } from "../capabilities/rate-limit.ts"
 import { CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCapabilityOptions } from "../chat-trigger.ts"
-import { chatTriggerHistoryLimit, resolveChatTriggerHistory, resolveChatTriggerInvoker, uiMessagesToAgentMessages } from "../chat-message-input.ts"
+import { chatTriggerHistoryLimit, createChatMessageTriggerInput, resolveChatTriggerHistory, uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { normalizeCapabilities } from "../capability-runtime.ts"
 import { deliveryArtifactAttachments } from "../delivery-artifacts.ts"
 import { createAgentInvocationContextStore } from "../invocation-context.ts"
@@ -1411,6 +1411,17 @@ async function chatSdkMessageToUiMessage(
   }
 }
 
+function chatAuthorizationUiMessage(thread: Thread, message: ChatSdkMessage, messageContext?: MessageContext): UIMessageLike {
+  const metadata = chatMessageMetadata(thread, message, messageContext)
+  return {
+    createdAt: isoDate(message.metadata.dateSent),
+    id: message.id,
+    ...(metadata ? { metadata } : {}),
+    parts: message.text ? [{ id: "text-0", text: message.text, type: "text" }] : [],
+    role: message.author.isMe ? "assistant" : "user",
+  }
+}
+
 interface ChatThreadHistoryCache {
   getMessages(threadId: string, limit?: number): Promise<ChatSdkMessage[]>
 }
@@ -1725,12 +1736,8 @@ async function handleChatSdkMessage(
         return capability.chatAttachments?.audio === true || metadata?.chatAttachments?.audio === true
       }),
     }
-    input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, [], messageContext, registration.channelId)
-    const authorizationInvoker = resolveChatTriggerInvoker(input)
-    const authorizationInput: AgentRunInput = {
-      context: authorizationInvoker ? { invoker: authorizationInvoker } : {},
-      messages: [],
-    }
+    input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, [chatAuthorizationUiMessage(thread, message, messageContext)], messageContext, registration.channelId)
+    const authorizationInput = createChatMessageTriggerInput(options || {}, input).input
     const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, authorizationInput, input.run, messageContext)
     if (!invoker) return
 

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2825,6 +2825,19 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenCalledTimes(1)
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "echo: hello" })
     expect(invokerResolve).toHaveBeenCalledOnce()
+    expect(invokerResolve).toHaveBeenCalledWith(expect.objectContaining({
+      input: expect.objectContaining({
+        context: expect.objectContaining({
+          channel: expect.objectContaining({
+            message: expect.objectContaining({ id: "7", text: "hello" }),
+          }),
+          chat: expect.objectContaining({
+            message: expect.objectContaining({ id: "7", text: "hello" }),
+          }),
+        }),
+        messages: [expect.objectContaining({ role: "user" })],
+      }),
+    }))
     expect(admitChat).toHaveBeenCalledWith(expect.objectContaining({
       invoker: expect.objectContaining({
         id: "customer:acme",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -3648,6 +3648,33 @@ describe("server helpers", () => {
         })],
       }))
 
+      document = {
+        file_name: "denied.txt",
+        mime_type: "text/plain",
+        url: "https://cdn.example/denied.txt",
+      }
+      messageId = "msg-denied"
+      admitChat.mockClear()
+      admitChat.mockReturnValueOnce(false)
+      fetch.mockClear()
+      run.mockClear()
+
+      const deniedResponse = await webhookHandler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/discord-events", {
+        body: JSON.stringify({
+          message: {
+            chat: { id: "support" },
+            document,
+            from: { id: "42", username: "maxi" },
+            message_id: messageId,
+          },
+        }),
+        method: "POST",
+      }), "discord-events")
+      expect(deniedResponse.status).toBe(200)
+      expect(admitChat).toHaveBeenCalledOnce()
+      expect(fetch).not.toHaveBeenCalled()
+      expect(run).not.toHaveBeenCalled()
+
       fetch.mockResolvedValueOnce(new Response("too large", {
         headers: { "content-length": String(8 * 1024 * 1024 + 1), "content-type": "text/plain" },
       }))
@@ -3664,7 +3691,7 @@ describe("server helpers", () => {
         webhookUrl: webhook => `https://example.com/api/_vitehub/agents/support/webhooks/${webhook}`,
       })).rejects.toThrow("[vitehub] Chat text attachment exceeds 8388608 bytes.")
       expect(fetch).toHaveBeenCalledWith("https://cdn.example/large.log")
-      expect(admitChat).not.toHaveBeenCalled()
+      expect(admitChat).toHaveBeenCalledOnce()
       expect(run).not.toHaveBeenCalled()
     }
     finally {

--- a/packages/agent/test/transcription.test.ts
+++ b/packages/agent/test/transcription.test.ts
@@ -80,6 +80,56 @@ describe("agent transcription", () => {
     }, { maxBytes: 3 })).rejects.toThrow("exceeds maxBytes")
   })
 
+  it("cancels oversized and erroring audio responses and releases readers", async () => {
+    const headerCancel = vi.fn()
+    const headerOversized = new ReadableStream<Uint8Array>({ cancel: headerCancel })
+    const cancel = vi.fn()
+    const oversized = new ReadableStream<Uint8Array>({
+      cancel,
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]))
+        controller.enqueue(new Uint8Array([3, 4]))
+      },
+    })
+    const readError = new Error("audio stream failed")
+    const erroring = new ReadableStream<Uint8Array>({
+      pull() {
+        throw readError
+      },
+    })
+    const successful = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array([1, 2]))
+        controller.enqueue(new Uint8Array([3]))
+        controller.close()
+      },
+    })
+    const fetch = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response(headerOversized, { headers: { "content-length": "4" } }))
+      .mockResolvedValueOnce(new Response(oversized))
+      .mockResolvedValueOnce(new Response(erroring))
+      .mockResolvedValueOnce(new Response(successful))
+    const audio = { mediaType: "audio/ogg", type: "audio" as const, url: "https://example.com/audio.ogg" }
+
+    try {
+      await expect(audioBytes(audio, { maxBytes: 3 })).rejects.toThrow("exceeds maxBytes")
+      expect(headerCancel).toHaveBeenCalledOnce()
+
+      await expect(audioBytes(audio, { maxBytes: 3 })).rejects.toThrow("exceeds maxBytes")
+      expect(cancel).toHaveBeenCalledOnce()
+      expect(oversized.locked).toBe(false)
+
+      await expect(audioBytes(audio, { maxBytes: 3 })).rejects.toBe(readError)
+      expect(erroring.locked).toBe(false)
+
+      await expect(audioBytes(audio, { maxBytes: 3 })).resolves.toEqual(new Uint8Array([1, 2, 3]))
+      expect(successful.locked).toBe(false)
+    }
+    finally {
+      fetch.mockRestore()
+    }
+  })
+
   it("reuses lazy audio bytes between transcription and audio artifacts", async () => {
     const fetchData = vi.fn(async () => new Uint8Array([1, 2, 3]))
     const capability = transcribe({

--- a/packages/queue/src/errors.ts
+++ b/packages/queue/src/errors.ts
@@ -5,6 +5,8 @@ import type { QueueProvider } from "./types.ts"
 
 export type QueueProviderOperation = "create-client" | "load-sdk" | "send" | "send-batch"
 
+export const cloudflareUnsupportedEnqueueOptions = ["idempotencyKey", "region", "retentionSeconds"] as const
+
 export type QueueErrorCode =
   | "CLOUDFLARE_BINDING_INVALID"
   | "CLOUDFLARE_BINDING_RESOLUTION_REQUIRED"
@@ -24,7 +26,7 @@ export type QueueErrorCode =
 type QueueErrorDetailMap = {
   CLOUDFLARE_BINDING_INVALID: { readonly provider: "cloudflare" }
   CLOUDFLARE_BINDING_RESOLUTION_REQUIRED: { readonly provider: "cloudflare" }
-  CLOUDFLARE_UNSUPPORTED_ENQUEUE_OPTIONS: { readonly provider: "cloudflare", readonly unsupported: readonly ("idempotencyKey" | "retentionSeconds")[] }
+  CLOUDFLARE_UNSUPPORTED_ENQUEUE_OPTIONS: { readonly provider: "cloudflare", readonly unsupported: readonly (typeof cloudflareUnsupportedEnqueueOptions)[number][] }
   QUEUE_DEFINITION_LOAD_FAILED: { readonly queue?: string }
   QUEUE_DEFINITION_NOT_FOUND: { readonly queue?: string }
   QUEUE_DISABLED: never
@@ -139,7 +141,7 @@ function normalizeBuiltInDetails(code: QueueErrorCode, value: unknown): ViteHubE
       validateFixedDetail(details?.provider, "cloudflare")
       return Object.freeze({
         provider: "cloudflare",
-        unsupported: parseUnsupportedOptions(details?.unsupported, ["idempotencyKey", "retentionSeconds"]),
+        unsupported: parseUnsupportedOptions(details?.unsupported, cloudflareUnsupportedEnqueueOptions),
       })
     case "QUEUE_DEFINITION_LOAD_FAILED":
     case "QUEUE_DEFINITION_NOT_FOUND": {

--- a/packages/queue/src/providers/cloudflare.ts
+++ b/packages/queue/src/providers/cloudflare.ts
@@ -1,5 +1,5 @@
 import { normalizeQueueEnqueueInput } from "../enqueue.ts"
-import { QueueError, runQueueProviderOperation } from "../errors.ts"
+import { cloudflareUnsupportedEnqueueOptions, QueueError, runQueueProviderOperation } from "../errors.ts"
 import { getCloudflareQueueDefinitionName } from "../integrations/cloudflare.ts"
 import { isNonRetryableQueueError, reportQueueDeliveryError } from "../internal/delivery-error.ts"
 
@@ -10,10 +10,7 @@ function isCloudflareQueueBinding(binding: unknown): binding is CloudflareQueueB
 }
 
 function toSendOptions(options: QueueEnqueueOptions = {}) {
-  const unsupported = [
-    options.idempotencyKey !== undefined ? "idempotencyKey" as const : undefined,
-    options.retentionSeconds !== undefined ? "retentionSeconds" as const : undefined,
-  ].filter((option): option is "idempotencyKey" | "retentionSeconds" => typeof option === "string")
+  const unsupported = cloudflareUnsupportedEnqueueOptions.filter(option => options[option] !== undefined)
 
   if (unsupported.length) {
     throw new QueueError<"CLOUDFLARE_UNSUPPORTED_ENQUEUE_OPTIONS">({

--- a/packages/queue/test/runtime.test.ts
+++ b/packages/queue/test/runtime.test.ts
@@ -61,6 +61,29 @@ afterEach(() => {
 })
 
 describe("cloudflare queue runtime", () => {
+  it("rejects region for single and batch sends while forwarding supported options", async () => {
+    const send = vi.fn(async () => {})
+    const sendBatch = vi.fn(async () => {})
+    const client = createCloudflareQueueClient({
+      binding: { send, sendBatch },
+      provider: "cloudflare",
+    })
+
+    const unsupportedRegion = {
+      code: "CLOUDFLARE_UNSUPPORTED_ENQUEUE_OPTIONS",
+      details: { provider: "cloudflare", unsupported: ["region"] },
+    }
+    await expect(client.send({ payload: { id: 1 }, region: "weur" })).rejects.toMatchObject(unsupportedRegion)
+    await expect(client.sendBatch([{ body: { id: 2 } }], { region: "weur" })).rejects.toMatchObject(unsupportedRegion)
+    expect(send).not.toHaveBeenCalled()
+    expect(sendBatch).not.toHaveBeenCalled()
+
+    await client.send({ contentType: "json", delaySeconds: 1, payload: { id: 3 } })
+    await client.sendBatch([{ body: { id: 4 }, contentType: "json" }], { delaySeconds: 2 })
+    expect(send).toHaveBeenCalledWith({ id: 3 }, { contentType: "json", delaySeconds: 1 })
+    expect(sendBatch).toHaveBeenCalledWith([{ body: { id: 4 }, contentType: "json", delaySeconds: 2 }])
+  })
+
   it("sets the Cloudflare environment when enterWith is unavailable", () => {
     const env = { QUEUE_WELCOME: {} }
     vi.spyOn(AsyncLocalStorage.prototype, "enterWith").mockImplementation(() => {


### PR DESCRIPTION
Hardens four existing runtime and verification boundaries. Chat senders are now authorized from minimal identity metadata before attachment URLs are fetched, transcription downloads cancel and release oversized or erroring streams, and Cloudflare Queue rejects unsupported `region` options for single sends and batches.

The docs typecheck now runs `vue-tsc` through an exact Docus 5.12.3 diagnostic allowlist, so compiler crashes, changed dependency diagnostics, and application type errors remain failures instead of disappearing through a grep pipeline. The Queue change is integrated with the structured error contract from #739, including typed and normalized unsupported-option details.
