### PR TITLE
fix(agent): mark failed Channel titles

### DIFF
--- a/packages/agent/src/capabilities/title.ts
+++ b/packages/agent/src/capabilities/title.ts
@@ -7,6 +7,7 @@ import {
   finishMessageChannelTitleDelivery,
   messageChannelStateContextKey,
   messageChannelTitleDeliveredContextKey,
+  resetMessageChannelTitleDelivery,
 } from "../internal/channels.ts"
 import { getMessageText } from "../messages.ts"
 import { normalizeAgentDriver } from "../internal/agent-driver.ts"
@@ -573,6 +574,7 @@ export function title<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCo
         await finishMessageChannelTitleDelivery(await getChannelDeliveryAttempt(), false).catch(() => undefined)
       }
       let title: Promise<string | undefined> | undefined
+      let titleClaimed = false
       let titleSkipped = false
       const getTitle = () => {
         title ??= (async () => {
@@ -582,6 +584,7 @@ export function title<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCo
           const pendingAttempt = getChannelDeliveryAttempt()
           const attempt = pendingAttempt instanceof Promise ? await pendingAttempt : pendingAttempt
           if (!attempt.deliver) return
+          titleClaimed = true
           try {
             const resolvedTitle = await generateTitle(context, options as TitleOptions, {
               input: context.input.get(),
@@ -634,10 +637,13 @@ export function title<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCo
       const titleDeliveryEffect: AgentChannelDeliveryFinishEffectCallback = async (finish) => {
         if (Object.hasOwn(finish.event, "error")) {
           const resolvedTitle = await getTitle()
-          if (titleSkipped) return
+          if (!titleClaimed || titleSkipped) return
+          const attempt = await getChannelDeliveryAttempt()
+          await resetMessageChannelTitleDelivery(attempt).catch(() => undefined)
           const failureIntent = createMessageChannelTitleEffectIntent(
             errorTitle(resolvedTitle, options.maxLength ?? 80, options.fallback ?? "Untitled"),
             "always",
+            attempt,
           )
           if (!resolvedTitle || finish.context.get<boolean>(messageChannelTitleDeliveredContextKey) === true) {
             return failureIntent
@@ -645,8 +651,7 @@ export function title<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCo
           return [
             createMessageChannelTitleEffectIntent(
               resolvedTitle.trim(),
-              options.channelDelivery,
-              await getChannelDeliveryAttempt(),
+              "always",
             ),
             failureIntent,
           ]

--- a/packages/agent/src/capabilities/title.ts
+++ b/packages/agent/src/capabilities/title.ts
@@ -33,6 +33,7 @@ import type { MessageChannelTitleDeliveryAttempt, MessageChannelStateBinding } f
 
 type ToUIMessageStream = (...args: unknown[]) => ReadableStream<unknown>
 const titleApplied = Symbol("vitehub.title.applied")
+const skippedTitleGeneration = Symbol("vitehub.title.skipped")
 type TitleApplied = { [titleApplied]?: true }
 
 export interface TitleExecuteInput {
@@ -118,6 +119,13 @@ function cleanGeneratedTitle(value: unknown, maxLength: number, fallback: string
   return (boundary >= 20 ? cut.slice(0, boundary) : title.slice(0, maxLength))
     .replace(/[\s"'`.!?:;,/-]+$/g, "")
     .trim() || fallback
+}
+
+function errorTitle(value: string | undefined, maxLength: number, fallback: string): string {
+  const existingTitle = (value || fallback)
+    .replace(/^(?:ERROR:\s*)+/i, "")
+    .trim() || "Untitled"
+  return cleanGeneratedTitle(`ERROR: ${existingTitle}`, maxLength, "ERROR".slice(0, Math.max(0, maxLength)))
 }
 
 function heuristicTitle(text: string, maxLength: number, fallback: string): string {
@@ -276,7 +284,7 @@ async function generateTitleWithDriver(
   } as never).generate(runContext as never))
 }
 
-async function generateTitle(context: AgentCapabilityRuntimeContext, options: TitleOptions, input: TitleExecuteInput): Promise<string | undefined> {
+async function generateTitle(context: AgentCapabilityRuntimeContext, options: TitleOptions, input: TitleExecuteInput): Promise<string | typeof skippedTitleGeneration> {
   const fallback = options.fallback ?? "Untitled"
   const maxLength = options.maxLength ?? 80
   const templateInput = {
@@ -287,8 +295,8 @@ async function generateTitle(context: AgentCapabilityRuntimeContext, options: Ti
     trigger: agentTriggerId(context),
   }
 
-  if (!shouldRunForTrigger(options.trigger, templateInput.trigger)) return
-  if (options.when && !await options.when(templateInput)) return
+  if (!shouldRunForTrigger(options.trigger, templateInput.trigger)) return skippedTitleGeneration
+  if (options.when && !await options.when(templateInput)) return skippedTitleGeneration
 
   if (options.execute) {
     const result = await options.execute(input)
@@ -565,6 +573,7 @@ export function title<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCo
         await finishMessageChannelTitleDelivery(await getChannelDeliveryAttempt(), false).catch(() => undefined)
       }
       let title: Promise<string | undefined> | undefined
+      let titleSkipped = false
       const getTitle = () => {
         title ??= (async () => {
           const messages = context.input.messages()
@@ -580,6 +589,11 @@ export function title<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCo
               messages,
               text: getMessageText(message),
             })
+            if (resolvedTitle === skippedTitleGeneration) {
+              titleSkipped = true
+              await finishMessageChannelTitleDelivery(attempt, false).catch(() => undefined)
+              return
+            }
             if (!resolvedTitle) {
               await finishMessageChannelTitleDelivery(attempt, false).catch(() => undefined)
             }
@@ -618,6 +632,25 @@ export function title<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCo
         return resolvedTitle ? { title: resolvedTitle } : undefined
       })
       const titleDeliveryEffect: AgentChannelDeliveryFinishEffectCallback = async (finish) => {
+        if (Object.hasOwn(finish.event, "error")) {
+          const resolvedTitle = await getTitle()
+          if (titleSkipped) return
+          const failureIntent = createMessageChannelTitleEffectIntent(
+            errorTitle(resolvedTitle, options.maxLength ?? 80, options.fallback ?? "Untitled"),
+            "always",
+          )
+          if (!resolvedTitle || finish.context.get<boolean>(messageChannelTitleDeliveredContextKey) === true) {
+            return failureIntent
+          }
+          return [
+            createMessageChannelTitleEffectIntent(
+              resolvedTitle.trim(),
+              options.channelDelivery,
+              await getChannelDeliveryAttempt(),
+            ),
+            failureIntent,
+          ]
+        }
         const resolvedTitle = finish.extensions.get(capabilityId, "title")
         return typeof resolvedTitle === "string" && resolvedTitle.trim()
           ? createMessageChannelTitleEffectIntent(
@@ -631,7 +664,8 @@ export function title<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCo
         Boolean(finish.channel)
         && Boolean(firstUserMessage(context.input.messages()))
         && finish.context.get<boolean>(messageChannelTitleSupportContextKey) !== false
-        && finish.context.get<boolean>(messageChannelTitleDeliveredContextKey) !== true
+        && (Object.hasOwn(finish.event, "error")
+          || finish.context.get<boolean>(messageChannelTitleDeliveredContextKey) !== true)
       titleDeliveryEffect.kind = "title"
       context.delivery.finishEffect(titleDeliveryEffect)
       context.output.render((result) => {

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -34,6 +34,7 @@ export interface MessageChannelTitleDeliveryAttempt {
   claim?: MessageChannelTitleDeliveryClaim
   deliver: boolean
   error?: unknown
+  persist?: boolean
   reason?: "already-delivered" | "pending"
 }
 
@@ -121,11 +122,19 @@ export async function finishMessageChannelTitleDelivery(
   if (!delivered && !final) return
   attempt.claim.settled = true
   try {
-    if (delivered) await attempt.claim.state.set(attempt.claim.markerKey, true)
+    if (delivered && attempt.persist !== false) await attempt.claim.state.set(attempt.claim.markerKey, true)
   }
   finally {
     await attempt.claim.state.releaseLock(attempt.claim.lock)
   }
+}
+
+export async function resetMessageChannelTitleDelivery(
+  attempt: MessageChannelTitleDeliveryAttempt,
+): Promise<void> {
+  if (!attempt.claim) return
+  attempt.persist = false
+  if (attempt.claim.settled) await attempt.claim.state.delete(attempt.claim.markerKey)
 }
 
 function withChannelWebhookProvider<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -205,9 +205,19 @@ describe("agent channels", () => {
       expect(typeof resolved.setThreadTitle).toBe("function")
 
       await resolved.setThreadTitle?.("discord:guild:channel:thread-1", "  New   Thread   Title  ")
+      const longTitle = `ERROR: ${"x".repeat(120)}`
+      await resolved.setThreadTitle?.("discord:guild:channel:thread-1", longTitle)
 
-      expect(fetch).toHaveBeenCalledWith("https://discord.test/api/channels/thread-1", {
+      expect(fetch).toHaveBeenNthCalledWith(1, "https://discord.test/api/channels/thread-1", {
         body: JSON.stringify({ name: "New Thread Title" }),
+        headers: {
+          Authorization: "Bot bot-token",
+          "Content-Type": "application/json",
+        },
+        method: "PATCH",
+      })
+      expect(fetch).toHaveBeenNthCalledWith(2, "https://discord.test/api/channels/thread-1", {
+        body: JSON.stringify({ name: longTitle.slice(0, 100) }),
         headers: {
           Authorization: "Bot bot-token",
           "Content-Type": "application/json",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -4755,6 +4755,29 @@ describe("server helpers", () => {
     expect(state.releaseLock).toHaveBeenCalledWith(lock)
   })
 
+  it("clears a delivered Title claim before marking a failed Channel", async () => {
+    const {
+      finishMessageChannelTitleDelivery,
+      resetMessageChannelTitleDelivery,
+    } = await import("../src/internal/channels.ts")
+    const lock = { expiresAt: Date.now() + 60_000, threadId: "title:pending", token: "lock" }
+    const state = {
+      delete: vi.fn(async () => undefined),
+      releaseLock: vi.fn(async () => undefined),
+      set: vi.fn(async () => undefined),
+    }
+    const attempt = {
+      claim: { lock, markerKey: "channel-title:thread:delivered", state },
+      deliver: true,
+    }
+
+    await finishMessageChannelTitleDelivery(attempt as never, true)
+    await resetMessageChannelTitleDelivery(attempt as never)
+
+    expect(state.set).toHaveBeenCalledWith("channel-title:thread:delivered", true)
+    expect(state.delete).toHaveBeenCalledWith("channel-title:thread:delivered")
+  })
+
   it("does not redeliver a Title when marker observation succeeds but lock release fails", async () => {
     const {
       claimMessageChannelTitleDelivery,

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -52,6 +52,56 @@ afterEach(() => {
   loadAiSdk.mockImplementation(async () => await import("ai"))
 })
 
+async function failedTitleInvocation(options: {
+  deliver?: (title: string) => Promise<void> | void
+  execute: () => string
+  fallback?: string
+  maxLength?: number
+  trigger?: string
+  when?: () => boolean
+}) {
+  const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+  const { defineChannel } = await import("../src/channels.ts")
+  const failure = new Error("driver failed")
+  const delivered: string[] = []
+  const titleEffect = vi.fn(async (context: { effect: { payload?: unknown } }) => {
+    const value = (context.effect.payload as { title: string }).title
+    await options.deliver?.(value)
+    delivered.push(value)
+  })
+  const agent = defineAgent({
+    capabilities: [title({
+      execute: options.execute,
+      ...(options.fallback === undefined ? {} : { fallback: options.fallback }),
+      ...(options.maxLength === undefined ? {} : { maxLength: options.maxLength }),
+      ...(options.trigger === undefined ? {} : { trigger: options.trigger }),
+      ...(options.when === undefined ? {} : { when: options.when }),
+    })],
+    channels: {
+      portal: defineChannel("portal", {
+        effects: { title: titleEffect as never },
+        messages: false,
+        triggers: {
+          message: {
+            invoke: context => ({
+              input: { messages: [createMessage({ role: "user", text: "prepare title" })] },
+              run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
+            }),
+          },
+        },
+      }),
+    },
+    driver: { run: () => { throw failure } },
+  })
+
+  await expect(runAgentTrigger(agent, {
+    memo: vi.fn(),
+    runtime: "unknown" as const,
+    waitUntil: vi.fn(),
+  }, "portal.message", {})).rejects.toBe(failure)
+  return { delivered, titleEffect }
+}
+
 describe("agent message protocol", () => {
   it("normalizes undefined tool output to JSON null", () => {
     expect(toJsonCompatibleValue(undefined)).toBeNull()
@@ -3684,6 +3734,64 @@ describe("agent message protocol", () => {
     await Promise.all(waitUntilTasks)
     expect(execute).toHaveBeenCalledOnce()
     expect(titleEffect).toHaveBeenCalledTimes(2)
+  })
+
+  it("marks failed message Channel titles after applying the ordinary title", async () => {
+    const execute = vi.fn(() => "Useful existing title")
+    const { delivered } = await failedTitleInvocation({ execute })
+
+    expect(execute).toHaveBeenCalledOnce()
+    expect(delivered).toEqual([
+      "Useful existing title",
+      "ERROR: Useful existing title",
+    ])
+  })
+
+  it("retries the ordinary title before marking a failed message Channel", async () => {
+    const deliver = vi.fn()
+      .mockRejectedValueOnce(new Error("temporary title failure"))
+      .mockResolvedValue(undefined)
+    const { delivered, titleEffect } = await failedTitleInvocation({
+      deliver,
+      execute: () => "Useful existing title",
+    })
+
+    expect(titleEffect).toHaveBeenCalledTimes(3)
+    expect(delivered).toEqual([
+      "Useful existing title",
+      "ERROR: Useful existing title",
+    ])
+  })
+
+  it.each([
+    ["ERROR: ERROR: Existing title", 80, "ERROR: Existing title"],
+    ["Quarterly billing reconciliation", 20, "ERROR: Quarterly bil"],
+  ])("keeps failed title prefixes idempotent within maxLength", async (generatedTitle, maxLength, expectedTitle) => {
+    const { delivered } = await failedTitleInvocation({ execute: () => generatedTitle, maxLength })
+
+    expect(delivered.at(-1)).toBe(expectedTitle)
+    expect(delivered.at(-1)?.length).toBeLessThanOrEqual(maxLength)
+    expect(delivered.at(-1)?.match(/ERROR:/g)).toHaveLength(1)
+  })
+
+  it("uses the configured fallback when failed title generation produced no title", async () => {
+    const execute = vi.fn(() => { throw new Error("title failed") })
+    const { delivered } = await failedTitleInvocation({ execute, fallback: "Untitled" })
+
+    expect(execute).toHaveBeenCalledOnce()
+    expect(delivered).toEqual(["ERROR: Untitled"])
+  })
+
+  it.each([
+    ["trigger", { trigger: "schedule.tick" }],
+    ["when", { when: () => false }],
+  ])("does not mark failed titles skipped by the %s filter", async (_filter, options) => {
+    const execute = vi.fn(() => "Skipped title")
+    const { delivered, titleEffect } = await failedTitleInvocation({ execute, ...options })
+
+    expect(execute).not.toHaveBeenCalled()
+    expect(titleEffect).not.toHaveBeenCalled()
+    expect(delivered).toEqual([])
   })
 
   it("retries title delivery at finish when any early delivery handler fails", async () => {


### PR DESCRIPTION
Marks failed Agent Invocation titles through the existing Channel title effect. The normal title is still generated and applied first; terminal failures then reuse that cached title for one idempotent, max-length-safe `ERROR: ` rename, so Channel conversations expose the failure without another model call. If generation fails, the title falls back to `ERROR: Untitled`, while `trigger` and `when` opt-outs remain respected.

Keeps the successful path and generic Channel boundary unchanged, with Discord retaining its existing 100-character platform cap. Coverage exercises ordering, failed early-delivery retries, nested prefixes, configured length limits, fallback behavior, title filters, and the Discord adapter mutation.

The workspace quota failure remains separate. Its follow-up seam is trusted-host root allocation and file-by-file materialization in `packages/workspace/src/session/trusted-host.ts`, coordinated through `packages/workspace/src/session/harness.ts`; because #746 replaces that session model, the storage follow-up should reconcile with that PR instead of landing a speculative redesign here.
