### PR TITLE
fix(docs): keep search results below viewport top

### DIFF
--- a/docs/app/assets/main.css
+++ b/docs/app/assets/main.css
@@ -209,6 +209,7 @@ body {
   position: fixed !important;
   top: 248px !important;
   left: 50vw !important;
+  translate: -50% 0 !important;
   width: min(640px, calc(100vw - 1rem)) !important;
   margin: 0 !important;
   overflow: hidden;

--- a/docs/test/search-overlay.test.ts
+++ b/docs/test/search-overlay.test.ts
@@ -1,0 +1,13 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("docs search overlay", () => {
+  it("anchors expanding desktop results below the viewport top", async () => {
+    const css = await readFile(new URL("../app/assets/main.css", import.meta.url), "utf8");
+    const desktopRule = css.match(/\.vitehub-content-search-modal \{(?<body>[^}]+)\}/)?.groups
+      ?.body;
+
+    expect(desktopRule).toContain("top: 248px !important;");
+    expect(desktopRule).toContain("translate: -50% 0 !important;");
+  });
+});


### PR DESCRIPTION
Pins the desktop docs search to its configured top edge by cancelling Nuxt UI’s inherited vertical translation while preserving horizontal centering. The previous combination of `top: 248px` and `-translate-y-1/2` moved the dialog upward as search results increased its height, clipping the query and header above the viewport.

Adds a focused regression for the desktop positioning contract. The full docs test suite passes with 39 tests, the docs typecheck passes, and the locally served Nuxt stylesheet emits the fixed `translate: -50% 0` rule.