### PR TITLE
fix(agent): preserve channel attachment references by default

### DIFF
--- a/docs/content/docs/agents/agent-definitions.md
+++ b/docs/content/docs/agents/agent-definitions.md
@@ -113,7 +113,7 @@ export default defineAgent({
 })
 ```
 
-The callback also receives the invocation input and runtime handles. Capabilities that contribute Agent Triggers, chat admission or attachments, or static Workspace Sources must stay in a static array because ViteHub registers those contributions before an invocation starts.
+The callback also receives the invocation input and runtime handles. Capabilities that contribute Agent Triggers, chat admission, or static Workspace Sources must stay in a static array because ViteHub registers those contributions before an invocation starts.
 
 ## Add Workspace context
 

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -147,7 +147,7 @@ export default defineAgent({
 })
 ```
 
-Model-backed Agents pass inline data and HTTPS references as typed model input. When a part has `fetchData`, the model driver prefers that adapter-owned callback immediately before invocation and checks both the declared and resolved byte size. The default limit is 25 MiB; change the real resource policy with `driver.execution.attachments.maxBytes`.
+Model-backed Agents pass inline data and HTTPS references as typed model input. For the current user turn, the model driver prefers an attachment's adapter-owned `fetchData` callback immediately before invocation. Historical callbacks are not replayed; history retains only serializable data and URL references. The driver resolves attachments sequentially and checks both the declared and resolved byte size against one invocation-wide budget. The default limit is 25 MiB; change the real resource policy with `driver.execution.attachments.maxBytes`.
 
 ```ts [server/agents/vision.ts]
 export default defineAgent({

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -147,7 +147,7 @@ export default defineAgent({
 })
 ```
 
-Model-backed Agents pass inline data and HTTPS references as typed model input. For the current user turn, the model driver prefers an attachment's adapter-owned `fetchData` callback immediately before invocation. Historical callbacks are not replayed; history retains only serializable data and URL references. The driver resolves attachments sequentially and checks both the declared and resolved byte size against one invocation-wide budget. The default limit is 25 MiB; change the real resource policy with `driver.execution.attachments.maxBytes`.
+Model-backed Agents pass inline data and HTTPS references as typed model input. For the current Channel turn, the model driver prefers an attachment's adapter-owned `fetchData` callback immediately before invocation. Channel history callbacks are not replayed; history retains only serializable data and URL references. The driver resolves attachments sequentially and checks both the declared and resolved byte size against one invocation-wide budget. The default limit is 25 MiB; change the real resource policy with `driver.execution.attachments.maxBytes`.
 
 ```ts [server/agents/vision.ts]
 export default defineAgent({

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -164,7 +164,7 @@ Only HTTPS attachment URLs are forwarded as remote model input. ViteHub does not
 
 The byte limit checks a declared `size` before resolving provider data, then checks the resolved value using UTF-8 bytes for strings, `byteLength` for buffers and typed-array views, and `size` for Blobs. Invalid and non-HTTPS URLs are omitted from model input.
 
-Harness-backed Agents retain URL-bearing parts in their input, but a function callback cannot cross a serialized harness boundary. A private callback-only attachment needs a Capability that consumes it or an explicit future asset/persistence contract; ViteHub does not materialize it in `/tmp`. `serializeMessages()` similarly rejects unresolved attachment callbacks. The pure synchronous `toAiSdkModelMessages()` converter rejects callback- and Blob-only inputs; use the model-backed Agent Driver for its asynchronous invocation-time conversion, or provide an HTTPS URL.
+Harness-backed Agents retain URL-bearing parts in their input, but callbacks and binary objects cannot cross a serialized harness boundary. A private callback-only attachment needs a Capability that consumes it or an explicit future asset/persistence contract; ViteHub does not materialize it in `/tmp`. `serializeMessages()` rejects unresolved attachment callbacks and non-string binary data. The pure synchronous `toAiSdkModelMessages()` converter rejects callback- and Blob-only inputs; use the model-backed Agent Driver for its asynchronous invocation-time conversion, or provide an HTTPS URL.
 
 Text-like files keep the existing bounded prompt behavior: ViteHub decodes recognized text attachments up to 8 MiB and emits a text part instead of a duplicate file part. Other attachment normalization is inert.
 

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -162,7 +162,9 @@ export default defineAgent({
 
 Only HTTPS attachment URLs are forwarded as remote model input. ViteHub does not download arbitrary URLs on the server, because that would create an SSRF surface. Forwarding a signed URL also discloses its temporary access to the model provider, and provider URLs may expire; use `fetchData` for authenticated or refreshable access and treat durable persistence as a separate application decision.
 
-Harness-backed Agents retain URL-bearing parts in their input, but a function callback cannot cross a serialized harness boundary. A private callback-only attachment needs a Capability that consumes it or an explicit future asset/persistence contract; ViteHub does not materialize it in `/tmp`. `serializeMessages()` similarly rejects unresolved attachment callbacks. The pure synchronous `toAiSdkModelMessages()` converter does not invoke callbacks or convert Blob-only data; use the model-backed Agent Driver for its asynchronous invocation-time conversion, or provide an HTTPS URL.
+The byte limit checks a declared `size` before resolving provider data, then checks the resolved value using UTF-8 bytes for strings, `byteLength` for buffers and typed-array views, and `size` for Blobs. Invalid and non-HTTPS URLs are omitted from model input.
+
+Harness-backed Agents retain URL-bearing parts in their input, but a function callback cannot cross a serialized harness boundary. A private callback-only attachment needs a Capability that consumes it or an explicit future asset/persistence contract; ViteHub does not materialize it in `/tmp`. `serializeMessages()` similarly rejects unresolved attachment callbacks. The pure synchronous `toAiSdkModelMessages()` converter rejects callback- and Blob-only inputs; use the model-backed Agent Driver for its asynchronous invocation-time conversion, or provide an HTTPS URL.
 
 Text-like files keep the existing bounded prompt behavior: ViteHub decodes recognized text attachments up to 8 MiB and emits a text part instead of a duplicate file part. Other attachment normalization is inert.
 

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -123,6 +123,49 @@ Message-shaped Channels also record a canonical `channel` Agent Invocation Conte
 
 Augment `ViteHubAgentChannelMeta` and `ViteHubAgentChannelUser` in application code to type app-owned metadata and user fields.
 
+### Receive attachments as references
+
+Adapter-backed Channels preserve incoming images, audio, and generic files as typed Agent Message parts by default. No Capability or Channel option enables this. Each part keeps every handle supplied by the adapter: inline `data`, lazy `fetchData`, adapter-owned `fetchMetadata`, `url`, `mediaType`, `name`, and `size`.
+
+Normalization does not call `fetchData`, fetch a generic attachment URL, write a local file, or persist a blob. A Capability or Agent Driver chooses how to consume the reference. This keeps authenticated and expiring provider access inside the adapter while letting a consumer pass an HTTPS URL, resolve bytes, or explicitly persist the attachment only when needed.
+
+```ts [server/agents/support.ts]
+import { defineAgent } from '@vite-hub/agent'
+
+export default defineAgent({
+  driver: {
+    run({ messages }) {
+      const attachments = messages.flatMap(message =>
+        message.parts.filter(part =>
+          part.type === 'image' || part.type === 'audio' || part.type === 'file',
+        ),
+      )
+
+      return `Received ${attachments.length} attachment references.`
+    },
+  },
+})
+```
+
+Model-backed Agents pass inline data and HTTPS references as typed model input. When a part has `fetchData`, the model driver prefers that adapter-owned callback immediately before invocation and checks both the declared and resolved byte size. The default limit is 25 MiB; change the real resource policy with `driver.execution.attachments.maxBytes`.
+
+```ts [server/agents/vision.ts]
+export default defineAgent({
+  driver: {
+    model,
+    execution: {
+      attachments: { maxBytes: 10 * 1024 * 1024 },
+    },
+  },
+})
+```
+
+Only HTTPS attachment URLs are forwarded as remote model input. ViteHub does not download arbitrary URLs on the server, because that would create an SSRF surface. Forwarding a signed URL also discloses its temporary access to the model provider, and provider URLs may expire; use `fetchData` for authenticated or refreshable access and treat durable persistence as a separate application decision.
+
+Harness-backed Agents retain URL-bearing parts in their input, but a function callback cannot cross a serialized harness boundary. A private callback-only attachment needs a Capability that consumes it or an explicit future asset/persistence contract; ViteHub does not materialize it in `/tmp`. `serializeMessages()` similarly rejects unresolved attachment callbacks. The pure synchronous `toAiSdkModelMessages()` converter does not invoke callbacks or convert Blob-only data; use the model-backed Agent Driver for its asynchronous invocation-time conversion, or provide an HTTPS URL.
+
+Text-like files keep the existing bounded prompt behavior: ViteHub decodes recognized text attachments up to 8 MiB and emits a text part instead of a duplicate file part. Other attachment normalization is inert.
+
 ## Admit web chat requests
 
 Use `webChat()` when a web destination should expose the generated AI SDK UI-message route. Pass `route` options when the route needs authentication or product context, or set `route: false` when application code invokes the Channel from its own handler.

--- a/docs/content/docs/capabilities/index.md
+++ b/docs/content/docs/capabilities/index.md
@@ -54,7 +54,7 @@ export default defineAgent({
 })
 ```
 
-Return only invocation-scoped behavior from the callback. Capabilities that contribute Agent Triggers, chat admission or attachments, or static Workspace Sources must stay in a static list because ViteHub registers those contributions before an invocation exists.
+Return only invocation-scoped behavior from the callback. Capabilities that contribute Agent Triggers, chat admission, or static Workspace Sources must stay in a static list because ViteHub registers those contributions before an invocation exists.
 
 ## What Capabilities can contribute
 

--- a/docs/content/docs/capabilities/transcribe.md
+++ b/docs/content/docs/capabilities/transcribe.md
@@ -42,7 +42,7 @@ export default defineAgent({
 ## Runtime behavior
 
 `transcribe()` runs before model execution.
-It enforces the configured maximum audio size, resolves audio data from direct data, `fetchData`, or URL, and appends transcript text to the user message.
+It enforces the configured maximum audio size, resolves audio data from direct data, `fetchData`, or URL, and replaces the consumed audio parts with transcript text in the user message.
 
 When artifacts are enabled, it writes sanitized transcript and optional audio files to the Agent's writable Workspace and exposes results as a finish extension.
 

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1,4 +1,4 @@
-import { getMessageText } from "./messages.ts"
+import { getMessageText, isAttachmentPart } from "./messages.ts"
 import {
   cloneWithPropertyDescriptors,
   isAsyncIterable,
@@ -33,6 +33,7 @@ import type {
   ToolLoopAgentSettings,
   ToolResultPart,
   ToolSet,
+  UserContent,
 } from "ai"
 import type {
   AgentAdapter,
@@ -42,6 +43,7 @@ import type {
   AgentAdapterRunContext,
   AgentAdapterResult,
   AgentCallSettingsInstrumentationContext,
+  AgentAttachmentExecutionOptions,
   AgentModelExecutionInstrumentation,
   AgentModelExecutionOptions,
   AgentModelInstrumentationContext,
@@ -50,7 +52,7 @@ import type {
   AgentToolResolverWithWorkspace,
   MaybePromise,
 } from "./types.ts"
-import type { Message, MessagePart } from "./messages.ts"
+import type { AttachmentData, AttachmentPart, Message, MessagePart } from "./messages.ts"
 import type { WorkspaceName } from "@vite-hub/workspace"
 
 export interface AiSdkAdapterOptions<
@@ -74,10 +76,13 @@ export type AiSdkModelExecutionOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   TCallOptions = unknown,
   TTools extends ToolSet = ToolSet,
-> = Omit<AgentModelExecutionOptions<TRuntimeConfig, TCallOptions>, "callSettings" | "workspaceFallback"> & {
+> = Omit<AgentModelExecutionOptions<TRuntimeConfig, TCallOptions>, "attachments" | "callSettings" | "workspaceFallback"> & {
+  attachments?: AiSdkAttachmentOptions
   callSettings?: AiSdkModelCallSettings<TCallOptions, TTools>
   workspaceFallback?: boolean | AiSdkWorkspaceFallbackOptions
 }
+
+export type AiSdkAttachmentOptions = AgentAttachmentExecutionOptions
 
 export interface AiSdkWorkspaceFallbackOptions {
   enabled?: boolean
@@ -86,6 +91,56 @@ export interface AiSdkWorkspaceFallbackOptions {
 
 function isDataMessagePart(part: MessagePart): part is Extract<MessagePart, { type: "data" | `data-${string}` }> {
   return part.type === "data" || part.type.startsWith("data-")
+}
+
+type UserContentPart = Exclude<UserContent, string>[number]
+
+function attachmentModelData(part: AttachmentPart): Exclude<AttachmentData, Blob> | URL | undefined {
+  if (part.data && !(part.data instanceof Blob)) return part.data
+  if (part.data instanceof Blob && !part.url) {
+    throw new TypeError("[vitehub] toAiSdkModelMessages() cannot convert a Blob synchronously. Pass the message through a model-backed Agent Driver or provide an HTTPS URL.")
+  }
+  if (!part.url) return
+  try {
+    const url = new URL(part.url)
+    return url.protocol === "https:" ? url : undefined
+  }
+  catch {
+    return undefined
+  }
+}
+
+function toAttachmentModelPart(part: AttachmentPart): UserContentPart | undefined {
+  const data = attachmentModelData(part)
+  if (!data) return
+  if (part.type === "image") {
+    return { image: data, mediaType: part.mediaType, type: "image" }
+  }
+  return {
+    data,
+    filename: part.name,
+    mediaType: part.mediaType,
+    type: "file",
+  }
+}
+
+function toUserModelMessageContent(parts: MessagePart[]): UserContent | undefined {
+  const attachments = parts.flatMap(part => isAttachmentPart(part) ? [toAttachmentModelPart(part)] : []).filter((part): part is UserContentPart => !!part)
+  if (!attachments.length) {
+    const text = toTextModelMessageContent(parts)
+    return text || undefined
+  }
+  const content: UserContentPart[] = []
+  for (const part of parts) {
+    if (isAttachmentPart(part)) {
+      const attachment = toAttachmentModelPart(part)
+      if (attachment) content.push(attachment)
+      continue
+    }
+    const text = toTextModelMessageContent([part])
+    if (text) content.push({ text, type: "text" })
+  }
+  return content.length ? content : undefined
 }
 
 function toTextModelMessageContent(parts: MessagePart[]): string {
@@ -230,7 +285,9 @@ export function toAiSdkModelMessages(messages: Message[]): ModelMessage[] {
           ? [{ content, role: message.role } as ModelMessage]
           : []
       }
-      const content = getMessageText(message) || toTextModelMessageContent(message.parts)
+      const content = message.role === "user"
+        ? toUserModelMessageContent(message.parts)
+        : getMessageText(message) || toTextModelMessageContent(message.parts)
       return hasModelMessageContent(content)
         ? [{ content, role: message.role } as ModelMessage]
         : []
@@ -242,7 +299,51 @@ function hasModelMessageContent(content: unknown): boolean {
   return Array.isArray(content) ? content.length > 0 : content != null
 }
 
-function getCallInput(context: AgentAdapterRunContext) {
+const defaultAiSdkAttachmentMaxBytes = 25 * 1024 * 1024
+
+function aiSdkAttachmentMaxBytes(options: AiSdkAttachmentOptions | undefined): number {
+  const maxBytes = options?.maxBytes ?? defaultAiSdkAttachmentMaxBytes
+  if (!Number.isFinite(maxBytes) || maxBytes <= 0) {
+    throw new TypeError("[vitehub] aiSdk({ execution: { attachments: { maxBytes } } }) must be a positive finite number.")
+  }
+  return maxBytes
+}
+
+function attachmentDataByteLength(data: AttachmentData | undefined): number | undefined {
+  if (data instanceof Blob) return data.size
+  if (data instanceof ArrayBuffer) return data.byteLength
+  if (ArrayBuffer.isView(data)) return data.byteLength
+  if (typeof data === "string") return new TextEncoder().encode(data).byteLength
+}
+
+function assertAttachmentWithinLimit(part: AttachmentPart, byteLength: number | undefined, maxBytes: number): void {
+  if (typeof byteLength === "number" && byteLength > maxBytes) {
+    throw new Error(`[vitehub] ${part.type} attachment is ${byteLength} bytes, which exceeds maxBytes (${maxBytes}).`)
+  }
+}
+
+async function resolveModelAttachmentPart(part: AttachmentPart, maxBytes: number): Promise<AttachmentPart> {
+  assertAttachmentWithinLimit(part, part.size, maxBytes)
+  const resolved = typeof part.fetchData === "function" ? await part.fetchData() : part.data
+  if (!resolved) return part
+  assertAttachmentWithinLimit(part, attachmentDataByteLength(resolved), maxBytes)
+  const data = resolved instanceof Blob ? await resolved.arrayBuffer() : resolved
+  const { fetchData: _fetchData, ...rest } = part
+  return { ...rest, data }
+}
+
+async function resolveModelAttachments(messages: Message[], options: AiSdkAttachmentOptions | undefined): Promise<Message[]> {
+  const maxBytes = aiSdkAttachmentMaxBytes(options)
+  return await Promise.all(messages.map(async (message) => {
+    if (message.role !== "user") return message
+    return {
+      ...message,
+      parts: await Promise.all(message.parts.map(part => isAttachmentPart(part) ? resolveModelAttachmentPart(part, maxBytes) : part)),
+    }
+  }))
+}
+
+async function getCallInput(context: AgentAdapterRunContext, attachments?: AiSdkAttachmentOptions) {
   const base = {
     abortSignal: context.input.abortSignal,
     timeout: context.input.timeout,
@@ -252,7 +353,7 @@ function getCallInput(context: AgentAdapterRunContext) {
   if (context.messages.length) {
     return {
       ...base,
-      messages: toAiSdkModelMessages(context.messages),
+      messages: toAiSdkModelMessages(await resolveModelAttachments(context.messages, attachments)),
     }
   }
   if (context.prompt) {
@@ -890,8 +991,8 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
     : undefined
   return {
     async generate(context) {
-      const callInput = getCallInput(context) as Record<string, unknown>
       const execution = options.execution
+      const callInput = await getCallInput(context, execution?.attachments) as Record<string, unknown>
       const fallback = getFallbackOptions(execution?.workspaceFallback)
       const fallbackCapture = fallback.enabled
         ? createWorkspaceFallbackEvidenceCapture(fallback.maxToolResults)
@@ -951,7 +1052,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
         await usageCapture.onStepEnd(event)
         fallbackCapture?.collect(event)
       }
-      const callInput = getCallInput(context) as Record<string, unknown>
+      const callInput = await getCallInput(context, execution?.attachments) as Record<string, unknown>
       const result = withResolvedModelMetadata(withCapturedUsage(await agent.stream({
         ...callInput,
         onEnd: usageCapture.onEnd,
@@ -966,11 +1067,11 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
 export function fromAiSdkAgent(agent: Agent): AgentAdapter {
   return {
     async generate(context) {
-      return await agent.generate(getCallInput(context) as never)
+      return await agent.generate(await getCallInput(context) as never)
     },
     name: "ai-sdk",
     async stream(context) {
-      return await agent.stream(getCallInput(context) as never)
+      return await agent.stream(await getCallInput(context) as never)
     },
   }
 }

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1,4 +1,4 @@
-import { getMessageText, isAttachmentPart } from "./messages.ts"
+import { getMessageText, isAttachmentData, isAttachmentPart } from "./messages.ts"
 import {
   cloneWithPropertyDescriptors,
   isAsyncIterable,
@@ -97,16 +97,20 @@ type UserContentPart = Exclude<UserContent, string>[number]
 
 function attachmentModelData(part: AttachmentPart): Exclude<AttachmentData, Blob> | URL | undefined {
   if (part.data && !(part.data instanceof Blob)) return part.data
-  if (part.data instanceof Blob && !part.url) {
+  if (part.url) {
+    try {
+      const url = new URL(part.url)
+      if (url.protocol === "https:") return url
+    }
+    catch {
+      // Invalid URLs are not model input.
+    }
+  }
+  if (part.data instanceof Blob) {
     throw new TypeError("[vitehub] toAiSdkModelMessages() cannot convert a Blob synchronously. Pass the message through a model-backed Agent Driver or provide an HTTPS URL.")
   }
-  if (!part.url) return
-  try {
-    const url = new URL(part.url)
-    return url.protocol === "https:" ? url : undefined
-  }
-  catch {
-    return undefined
+  if (part.fetchData) {
+    throw new TypeError("[vitehub] toAiSdkModelMessages() cannot resolve attachment callbacks synchronously. Pass the message through a model-backed Agent Driver or provide an HTTPS URL.")
   }
 }
 
@@ -325,6 +329,9 @@ function assertAttachmentWithinLimit(part: AttachmentPart, byteLength: number | 
 async function resolveModelAttachmentPart(part: AttachmentPart, maxBytes: number): Promise<AttachmentPart> {
   assertAttachmentWithinLimit(part, part.size, maxBytes)
   const resolved = typeof part.fetchData === "function" ? await part.fetchData() : part.data
+  if (typeof part.fetchData === "function" && !isAttachmentData(resolved)) {
+    throw new TypeError(`[vitehub] ${part.type} attachment fetchData() did not return supported attachment data.`)
+  }
   if (!resolved) return part
   assertAttachmentWithinLimit(part, attachmentDataByteLength(resolved), maxBytes)
   const data = resolved instanceof Blob ? await resolved.arrayBuffer() : resolved

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -340,7 +340,7 @@ async function resolveModelAttachmentPart(part: AttachmentPart, maxBytes: number
   return { byteLength, part: { ...rest, data } }
 }
 
-function channelCurrentMessageId(context: AgentAdapterRunContext): string | undefined {
+function channelCurrentMessageId(context: AgentAdapterRunContext): string | null | undefined {
   const inputContext = context.input.context
   if (!inputContext || typeof inputContext !== "object") return
   const channel = "channel" in inputContext && inputContext.channel && typeof inputContext.channel === "object"
@@ -349,14 +349,17 @@ function channelCurrentMessageId(context: AgentAdapterRunContext): string | unde
   const message = channel?.message && typeof channel.message === "object"
     ? channel.message as Record<string, unknown>
     : undefined
-  return typeof message?.id === "string" && message.id ? message.id : undefined
+  return typeof message?.id === "string" && message.id ? message.id : null
 }
 
-async function resolveModelAttachments(messages: Message[], options: AiSdkAttachmentOptions | undefined, currentMessageId?: string): Promise<Message[]> {
+async function resolveModelAttachments(messages: Message[], options: AiSdkAttachmentOptions | undefined, currentMessageId?: string | null): Promise<Message[]> {
   const maxBytes = aiSdkAttachmentMaxBytes(options)
   let remainingBytes = maxBytes
   const resolvedMessages: Message[] = []
-  for (const message of messages) {
+  const currentMessageIndex = currentMessageId === null
+    ? messages.findLastIndex(message => message.role === "user")
+    : undefined
+  for (const [messageIndex, message] of messages.entries()) {
     if (message.role !== "user") {
       resolvedMessages.push(message)
       continue
@@ -367,7 +370,9 @@ async function resolveModelAttachments(messages: Message[], options: AiSdkAttach
         parts.push(part)
         continue
       }
-      if (currentMessageId && message.id !== currentMessageId) {
+      const isHistoricalChannelMessage = currentMessageId !== undefined
+        && (currentMessageId === null ? messageIndex !== currentMessageIndex : message.id !== currentMessageId)
+      if (isHistoricalChannelMessage) {
         const { fetchData: _fetchData, ...reference } = part
         if (reference.data || reference.url) {
           const resolved = await resolveModelAttachmentPart(reference, remainingBytes)

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -340,12 +340,23 @@ async function resolveModelAttachmentPart(part: AttachmentPart, maxBytes: number
   return { byteLength, part: { ...rest, data } }
 }
 
-async function resolveModelAttachments(messages: Message[], options: AiSdkAttachmentOptions | undefined): Promise<Message[]> {
+function channelCurrentMessageId(context: AgentAdapterRunContext): string | undefined {
+  const inputContext = context.input.context
+  if (!inputContext || typeof inputContext !== "object") return
+  const channel = "channel" in inputContext && inputContext.channel && typeof inputContext.channel === "object"
+    ? inputContext.channel as Record<string, unknown>
+    : undefined
+  const message = channel?.message && typeof channel.message === "object"
+    ? channel.message as Record<string, unknown>
+    : undefined
+  return typeof message?.id === "string" && message.id ? message.id : undefined
+}
+
+async function resolveModelAttachments(messages: Message[], options: AiSdkAttachmentOptions | undefined, currentMessageId?: string): Promise<Message[]> {
   const maxBytes = aiSdkAttachmentMaxBytes(options)
-  const currentUserIndex = messages.findLastIndex(message => message.role === "user")
   let remainingBytes = maxBytes
   const resolvedMessages: Message[] = []
-  for (const [messageIndex, message] of messages.entries()) {
+  for (const message of messages) {
     if (message.role !== "user") {
       resolvedMessages.push(message)
       continue
@@ -356,13 +367,12 @@ async function resolveModelAttachments(messages: Message[], options: AiSdkAttach
         parts.push(part)
         continue
       }
-      if (messageIndex !== currentUserIndex) {
+      if (currentMessageId && message.id !== currentMessageId) {
         const { fetchData: _fetchData, ...reference } = part
         if (reference.data || reference.url) {
-          const byteLength = attachmentDataByteLength(reference.data) ?? reference.size ?? 0
-          assertAttachmentWithinLimit(reference, byteLength, remainingBytes)
-          remainingBytes -= byteLength
-          parts.push(reference)
+          const resolved = await resolveModelAttachmentPart(reference, remainingBytes)
+          remainingBytes -= resolved.byteLength
+          parts.push(resolved.part)
         }
         continue
       }
@@ -385,7 +395,7 @@ async function getCallInput(context: AgentAdapterRunContext, attachments?: AiSdk
   if (context.messages.length) {
     return {
       ...base,
-      messages: toAiSdkModelMessages(await resolveModelAttachments(context.messages, attachments)),
+      messages: toAiSdkModelMessages(await resolveModelAttachments(context.messages, attachments, channelCurrentMessageId(context))),
     }
   }
   if (context.prompt) {

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -326,28 +326,53 @@ function assertAttachmentWithinLimit(part: AttachmentPart, byteLength: number | 
   }
 }
 
-async function resolveModelAttachmentPart(part: AttachmentPart, maxBytes: number): Promise<AttachmentPart> {
+async function resolveModelAttachmentPart(part: AttachmentPart, maxBytes: number): Promise<{ byteLength: number, part: AttachmentPart }> {
   assertAttachmentWithinLimit(part, part.size, maxBytes)
   const resolved = typeof part.fetchData === "function" ? await part.fetchData() : part.data
   if (typeof part.fetchData === "function" && !isAttachmentData(resolved)) {
     throw new TypeError(`[vitehub] ${part.type} attachment fetchData() did not return supported attachment data.`)
   }
-  if (!resolved) return part
-  assertAttachmentWithinLimit(part, attachmentDataByteLength(resolved), maxBytes)
+  if (!resolved) return { byteLength: part.size ?? 0, part }
+  const byteLength = attachmentDataByteLength(resolved) ?? 0
+  assertAttachmentWithinLimit(part, byteLength, maxBytes)
   const data = resolved instanceof Blob ? await resolved.arrayBuffer() : resolved
   const { fetchData: _fetchData, ...rest } = part
-  return { ...rest, data }
+  return { byteLength, part: { ...rest, data } }
 }
 
 async function resolveModelAttachments(messages: Message[], options: AiSdkAttachmentOptions | undefined): Promise<Message[]> {
   const maxBytes = aiSdkAttachmentMaxBytes(options)
-  return await Promise.all(messages.map(async (message) => {
-    if (message.role !== "user") return message
-    return {
-      ...message,
-      parts: await Promise.all(message.parts.map(part => isAttachmentPart(part) ? resolveModelAttachmentPart(part, maxBytes) : part)),
+  const currentUserIndex = messages.findLastIndex(message => message.role === "user")
+  let remainingBytes = maxBytes
+  const resolvedMessages: Message[] = []
+  for (const [messageIndex, message] of messages.entries()) {
+    if (message.role !== "user") {
+      resolvedMessages.push(message)
+      continue
     }
-  }))
+    const parts: MessagePart[] = []
+    for (const part of message.parts) {
+      if (!isAttachmentPart(part)) {
+        parts.push(part)
+        continue
+      }
+      if (messageIndex !== currentUserIndex) {
+        const { fetchData: _fetchData, ...reference } = part
+        if (reference.data || reference.url) {
+          const byteLength = attachmentDataByteLength(reference.data) ?? reference.size ?? 0
+          assertAttachmentWithinLimit(reference, byteLength, remainingBytes)
+          remainingBytes -= byteLength
+          parts.push(reference)
+        }
+        continue
+      }
+      const resolved = await resolveModelAttachmentPart(part, remainingBytes)
+      remainingBytes -= resolved.byteLength
+      parts.push(resolved.part)
+    }
+    resolvedMessages.push({ ...message, parts })
+  }
+  return resolvedMessages
 }
 
 async function getCallInput(context: AgentAdapterRunContext, attachments?: AiSdkAttachmentOptions) {

--- a/packages/agent/src/capabilities/transcribe.ts
+++ b/packages/agent/src/capabilities/transcribe.ts
@@ -482,7 +482,6 @@ export function getTranscriptionResults(context: AgentInvocationContextStore | {
 
 export function transcribe(options: TranscribeOptions): AgentCapabilityDefinition {
   return defineCapability({
-    chatAttachments: { audio: true },
     id: "transcribe",
     metadata: {
       kind: "transcribe",

--- a/packages/agent/src/capabilities/transcribe.ts
+++ b/packages/agent/src/capabilities/transcribe.ts
@@ -524,7 +524,10 @@ export function transcribe(options: TranscribeOptions): AgentCapabilityDefinitio
         results.push(...messageResults)
         const text = transcripts.filter(Boolean).join("\n")
         const separator = text && message.parts.some(part => part.type === "text" && part.text.length > 0) ? "\n" : ""
-        messages.push(appendMessageText(message, `${separator}${text}`))
+        messages.push(appendMessageText({
+          ...message,
+          parts: message.parts.filter(part => !isAudioPart(part)),
+        }, `${separator}${text}`))
       }
       context.input.setMessages(messages)
       appendTranscriptionResults(context.context, results)

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -277,7 +277,6 @@ export async function resolveAgentCapabilityDefinitions<
     const unsupported = [
       capability.triggers ? "triggers" : undefined,
       capability.workspaceSources ? "workspaceSources" : undefined,
-      capability.chatAttachments ? "chatAttachments" : undefined,
       accessMetadata?.chat === true ? "chat access" : undefined,
     ].filter((value): value is string => Boolean(value))
     if (unsupported.length) {

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -1,4 +1,4 @@
-import { createMessage } from "./messages.ts"
+import { createMessage, isAttachmentData, isAttachmentPart } from "./messages.ts"
 import { normalizeAgentInvoker } from "./invoker.ts"
 
 import type {
@@ -11,7 +11,7 @@ import type {
   AgentRunMetadata,
   AgentRuntimeConfig,
 } from "./types.ts"
-import type { AudioData, Message, MessagePart } from "./messages.ts"
+import type { AttachmentData, AttachmentPart, Message, MessagePart } from "./messages.ts"
 
 export type UIMessageLike = {
   createdAt?: Date | string
@@ -95,39 +95,36 @@ function uiToolId(part: Record<string, unknown>, name: string, index: number): s
   return firstString(part.toolCallId, part.id) || `${name}-${index + 1}`
 }
 
-function isAudioData(value: unknown): value is AudioData {
-  if (typeof value === "string") return value.length > 0
-  if (!value || typeof value !== "object") return false
-  if ("byteLength" in value && typeof (value as { byteLength?: unknown }).byteLength === "number") return (value as { byteLength: number }).byteLength > 0
-  if ("size" in value && typeof (value as { size?: unknown }).size === "number") return (value as { size: number }).size > 0
-  return false
-}
-
-function uiAudioPartToAgentPart(part: Record<string, unknown>): MessagePart[] {
-  const mediaType = typeof part.mediaType === "string" && part.mediaType.startsWith("audio/")
-    ? part.mediaType
-    : undefined
-  if (!mediaType) return []
+function uiAttachmentPartToAgentPart(part: Record<string, unknown>): MessagePart[] {
+  const mediaType = typeof part.mediaType === "string" && part.mediaType ? part.mediaType : undefined
+  const inputType = isAttachmentPart(part) ? part.type : undefined
+  const type = mediaType?.startsWith("audio/")
+    ? "audio"
+    : mediaType?.startsWith("image/")
+      ? "image"
+      : inputType
+  if (!type || !mediaType) return []
 
   const id = firstString(part.id)
-  const base = {
+  const data = isAttachmentData(part.data) ? part.data : undefined
+  const fetchData = typeof part.fetchData === "function"
+    ? part.fetchData as () => AttachmentData | Promise<AttachmentData>
+    : undefined
+  const name = firstString(part.name, part.filename)
+  const url = typeof part.url === "string" && part.url ? part.url : undefined
+  if (!data && !fetchData && !url) return []
+  const attachment = {
+    ...(data ? { data } : {}),
+    ...(fetchData ? { fetchData } : {}),
     ...(id ? { id } : {}),
-    ...(typeof part.name === "string" ? { name: part.name } : {}),
+    ...(name ? { name } : {}),
     ...(typeof part.size === "number" && Number.isFinite(part.size) ? { size: part.size } : {}),
     ...(typeof part.fetchMetadata === "object" && part.fetchMetadata !== null ? { fetchMetadata: part.fetchMetadata as Record<string, string> } : {}),
     mediaType,
-    type: "audio" as const,
-  }
-  if (typeof part.fetchData === "function") {
-    return [{ ...base, fetchData: part.fetchData as () => AudioData | Promise<AudioData> }]
-  }
-  if (typeof part.url === "string" && part.url) {
-    return [{ ...base, url: part.url }]
-  }
-  if (isAudioData(part.data)) {
-    return [{ ...base, data: part.data }]
-  }
-  return []
+    type,
+    ...(url ? { url } : {}),
+  } satisfies AttachmentPart
+  return [attachment]
 }
 
 function uiMessagePartsToAgentParts(message: UIMessageLike): Array<MessagePart | string> {
@@ -143,7 +140,9 @@ function uiMessagePartsToAgentParts(message: UIMessageLike): Array<MessagePart |
         type: record.type as "data" | `data-${string}`,
       }]
     }
-    if (record.type === "audio") return uiAudioPartToAgentPart(record)
+    if (record.type === "audio" || record.type === "file" || record.type === "image") {
+      return uiAttachmentPartToAgentPart(record)
+    }
     if (record.type === "dynamic-tool" || (typeof record.type === "string" && record.type.startsWith("tool-"))) {
       const state = typeof record.state === "string" ? record.state : undefined
       const errorText = typeof record.errorText === "string" ? record.errorText : undefined

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -24,6 +24,7 @@ import {
   type ColocatedAgentSkills,
 } from "./internal/colocated-agent-skills.ts"
 import { toAiSdkModelMessages } from "./ai-sdk.ts"
+import { isAttachmentPart } from "./messages.ts"
 import { isAsyncIterable } from "./internal/stream-result.ts"
 import {
   applyAgentToolPolicies,
@@ -311,10 +312,22 @@ function renderHarnessModelMessageContent(content: unknown): string {
   return JSON.stringify(content)
 }
 
+function harnessSerializableMessages(messages: Message[]): Message[] {
+  return messages.map(message => ({
+    ...message,
+    parts: message.parts.flatMap((part) => {
+      if (!isAttachmentPart(part) || (!part.fetchData && !(part.data instanceof Blob))) return [part]
+      const { fetchData: _fetchData, ...reference } = part
+      if (reference.data instanceof Blob) delete reference.data
+      return reference.data || reference.url ? [reference] : []
+    }),
+  }))
+}
+
 function renderHarnessChatPrompt(messages: Message[]): string {
   return [
     "Conversation history:",
-    ...toAiSdkModelMessages(messages).map((message) => {
+    ...toAiSdkModelMessages(harnessSerializableMessages(messages)).map((message) => {
       const role = message.role === "assistant" ? "Assistant" : message.role === "user" ? "User" : message.role
       return `${role}: ${renderHarnessModelMessageContent(message.content)}`
     }),
@@ -347,7 +360,7 @@ async function toHarnessCallInput(context: AgentAdapterRunContext, resumesSessio
     }
     return {
       ...base,
-      messages: toAiSdkModelMessages(context.messages),
+      messages: toAiSdkModelMessages(harnessSerializableMessages(context.messages)),
     }
   }
   if (context.prompt) {

--- a/packages/agent/src/messages.ts
+++ b/packages/agent/src/messages.ts
@@ -120,7 +120,11 @@ export type MessagePart =
 export function isAttachmentData(value: unknown): value is AttachmentData {
   return typeof value === "string"
     ? value.length > 0
-    : value instanceof ArrayBuffer || value instanceof Blob || value instanceof Uint8Array
+    : value instanceof ArrayBuffer
+      ? value.byteLength > 0
+      : value instanceof Blob
+        ? value.size > 0
+        : value instanceof Uint8Array && value.byteLength > 0
 }
 
 export function isAttachmentPart(value: unknown): value is AttachmentPart {

--- a/packages/agent/src/messages.ts
+++ b/packages/agent/src/messages.ts
@@ -18,18 +18,31 @@ export interface DataPart {
   type: "data" | `data-${string}`
 }
 
-export type AudioData = ArrayBuffer | Blob | string | Uint8Array
+export type AttachmentData = ArrayBuffer | Blob | string | Uint8Array
+export type AudioData = AttachmentData
 
-export interface AudioPart {
-  data?: AudioData
-  fetchData?: () => Promise<AudioData> | AudioData
+export interface AttachmentPart {
+  data?: AttachmentData
+  fetchData?: () => Promise<AttachmentData> | AttachmentData
   fetchMetadata?: Record<string, string>
   id?: string
   mediaType: string
   name?: string
   size?: number
-  type: "audio"
+  type: "audio" | "file" | "image"
   url?: string
+}
+
+export interface AudioPart extends AttachmentPart {
+  type: "audio"
+}
+
+export interface FilePart extends AttachmentPart {
+  type: "file"
+}
+
+export interface ImagePart extends AttachmentPart {
+  type: "image"
 }
 
 export type ToolInvocationState = "approval-required" | "failed" | "proposed" | "running" | "completed"
@@ -97,10 +110,24 @@ export type MessagePart =
   | AudioPart
   | DataPart
   | ErrorPart
+  | FilePart
+  | ImagePart
   | SourcePart
   | TextPart
   | ToolCallPart
   | ToolResultPart
+
+export function isAttachmentData(value: unknown): value is AttachmentData {
+  return typeof value === "string"
+    ? value.length > 0
+    : value instanceof ArrayBuffer || value instanceof Blob || value instanceof Uint8Array
+}
+
+export function isAttachmentPart(value: unknown): value is AttachmentPart {
+  if (!value || typeof value !== "object") return false
+  const type = (value as { type?: unknown }).type
+  return type === "audio" || type === "file" || type === "image"
+}
 
 export interface Message {
   createdAt?: string
@@ -262,14 +289,6 @@ function assertSerializable(value: unknown, field: string): void {
   }
 }
 
-function hasAudioData(value: unknown): boolean {
-  if (typeof value === "string") return value.length > 0
-  if (!value || typeof value !== "object") return false
-  if ("byteLength" in value && typeof value.byteLength === "number") return value.byteLength > 0
-  if ("size" in value && typeof value.size === "number") return value.size > 0
-  return false
-}
-
 export function validateMessage(message: Message): void {
   assertString(message.id, "message.id")
   assertSerializable(message.id, "message.id")
@@ -284,7 +303,9 @@ export function validateMessage(message: Message): void {
 
   const openToolCalls = new Map<string, ToolCallPart | ApprovalRequestPart>()
   for (const [index, part] of message.parts.entries()) {
-    if (part.type !== "audio") assertSerializable(part, `message.parts[${index}]`)
+    if (!isAttachmentPart(part)) {
+      assertSerializable(part, `message.parts[${index}]`)
+    }
     switch (part.type) {
       case "text":
         if (typeof part.text !== "string") throw new TypeError("[vitehub:messages] text part requires text.")
@@ -317,19 +338,27 @@ export function validateMessage(message: Message): void {
       case "data":
         if (!("data" in part)) throw new TypeError("[vitehub:messages] data part requires data.")
         break
-      case "audio": {
+      case "audio":
+      case "file":
+      case "image": {
         const { fetchData: _fetchData, ...serializablePart } = part
         assertSerializable(serializablePart, `message.parts[${index}]`)
-        if (typeof part.mediaType !== "string" || !part.mediaType.startsWith("audio/")) {
+        if (typeof part.mediaType !== "string" || !part.mediaType) {
+          throw new TypeError(`[vitehub:messages] ${part.type} part requires a mediaType.`)
+        }
+        if (part.type === "audio" && !part.mediaType.startsWith("audio/")) {
           throw new TypeError("[vitehub:messages] audio part requires an audio/* mediaType.")
         }
-        const hasData = hasAudioData(part.data)
+        if (part.type === "image" && !part.mediaType.startsWith("image/")) {
+          throw new TypeError("[vitehub:messages] image part requires an image/* mediaType.")
+        }
+        const hasData = isAttachmentData(part.data)
         const hasFetchData = typeof part.fetchData === "function"
         const hasUrl = typeof part.url === "string" && part.url.length > 0
-        if ([hasData, hasFetchData, hasUrl].filter(Boolean).length !== 1) {
-          throw new TypeError("[vitehub:messages] audio part requires exactly one of data, fetchData, or url.")
+        if (!hasData && !hasFetchData && !hasUrl) {
+          throw new TypeError(`[vitehub:messages] ${part.type} part requires data, fetchData, or url.`)
         }
-        if (part.id !== undefined) assertString(part.id, "audio.id")
+        if (part.id !== undefined) assertString(part.id, `${part.type}.id`)
         break
       }
       case "source":
@@ -418,8 +447,8 @@ export function serializeMessages(messages: Message[]): string {
   for (const [messageIndex, message] of messages.entries()) {
     validateMessage(message)
     for (const [partIndex, part] of message.parts.entries()) {
-      if (part.type === "audio" && typeof part.fetchData === "function") {
-        throw new TypeError(`[vitehub:messages] serializeMessages() cannot serialize message[${messageIndex}].parts[${partIndex}].fetchData. Provide audio data or a URL before serializing.`)
+      if (isAttachmentPart(part) && typeof part.fetchData === "function") {
+        throw new TypeError(`[vitehub:messages] serializeMessages() cannot serialize message[${messageIndex}].parts[${partIndex}].fetchData. Resolve or remove the attachment callback before serializing.`)
       }
     }
   }

--- a/packages/agent/src/messages.ts
+++ b/packages/agent/src/messages.ts
@@ -454,6 +454,9 @@ export function serializeMessages(messages: Message[]): string {
       if (isAttachmentPart(part) && typeof part.fetchData === "function") {
         throw new TypeError(`[vitehub:messages] serializeMessages() cannot serialize message[${messageIndex}].parts[${partIndex}].fetchData. Resolve or remove the attachment callback before serializing.`)
       }
+      if (isAttachmentPart(part) && part.data !== undefined && typeof part.data !== "string") {
+        throw new TypeError(`[vitehub:messages] serializeMessages() cannot serialize binary data in message[${messageIndex}].parts[${partIndex}]. Resolve it to a string or URL before serializing.`)
+      }
     }
   }
   return JSON.stringify({ messages, version: 1 } satisfies SerializedMessages)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1304,7 +1304,7 @@ function attachmentPartFromAttachment(attachment: Attachment, index: number): At
     : undefined
   const type = attachment.type === "audio" || mediaType?.startsWith("audio/")
     ? "audio"
-    : attachment.type === "image" || mediaType?.startsWith("image/")
+    : mediaType?.startsWith("image/")
       ? "image"
       : "file"
   const data = isAttachmentData(attachment.data) ? attachment.data : undefined
@@ -1325,7 +1325,7 @@ function attachmentPartFromAttachment(attachment: Attachment, index: number): At
     fetchData,
     fetchMetadata: attachment.fetchMetadata,
     id: `attachment-${index + 1}`,
-    mediaType: mediaType ?? (type === "audio" ? "audio/ogg" : type === "image" ? "image/*" : "application/octet-stream"),
+    mediaType: mediaType ?? (type === "audio" ? "audio/ogg" : "application/octet-stream"),
     name: attachment.name,
     size: attachment.size,
     type,

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -13,6 +13,7 @@ import { normalizeCapabilities } from "../capability-runtime.ts"
 import { deliveryArtifactAttachments } from "../delivery-artifacts.ts"
 import { createAgentInvocationContextStore } from "../invocation-context.ts"
 import { finalChannelOutputContextKey } from "../internal/final-channel-output.ts"
+import { isAttachmentData } from "../messages.ts"
 import { normalizeAgentInvokerProfiles, resolveAgentInvoker, withResolvedAgentInvokerInput } from "../invoker.ts"
 import { createAgentRuntimeContext } from "../runtime/context.ts"
 import { createAgentUIMessageStreamResponse } from "../stream-output.ts"
@@ -66,7 +67,7 @@ import type {
   MaybeResolvable,
   ResolvedAgentTriggerDefinition,
 } from "../types.ts"
-import type { AudioData, MessagePart } from "../messages.ts"
+import type { AttachmentPart, MessagePart } from "../messages.ts"
 import type {
   ChatDevtoolsConversation,
   ChatDevtoolsMetadata,
@@ -1185,14 +1186,6 @@ function chatMessageAuthorEmail(message: ChatSdkMessage): string | undefined {
   )
 }
 
-function audioData(value: unknown): AudioData | undefined {
-  if (typeof value === "string") return value
-  if (value instanceof ArrayBuffer) return value
-  if (value instanceof Blob) return value
-  if (value instanceof Uint8Array) return value
-  return undefined
-}
-
 const chatTextAttachmentMaxBytes = 8 * 1024 * 1024
 const textAttachmentExtensions = new Set(["csv", "json", "log", "md", "txt", "yaml", "yml"])
 const textAttachmentMimeTypes = new Set(["application/json", "application/x-yaml", "application/yaml", "text/csv"])
@@ -1305,39 +1298,40 @@ async function textPartFromAttachment(attachment: Attachment, index: number, opt
   }
 }
 
-function audioPartFromAttachment(attachment: Attachment, index: number): MessagePart | undefined {
-  const mediaType = typeof attachment.mimeType === "string" && attachment.mimeType.startsWith("audio/")
+function attachmentPartFromAttachment(attachment: Attachment, index: number): AttachmentPart | undefined {
+  const mediaType = typeof attachment.mimeType === "string" && attachment.mimeType
     ? attachment.mimeType
     : undefined
-  if (attachment.type !== "audio" && !mediaType) return undefined
-  const base = objectWithoutUndefined({
+  const type = attachment.type === "audio" || mediaType?.startsWith("audio/")
+    ? "audio"
+    : attachment.type === "image" || mediaType?.startsWith("image/")
+      ? "image"
+      : "file"
+  const data = isAttachmentData(attachment.data) ? attachment.data : undefined
+  const fetchData = typeof attachment.fetchData === "function"
+    ? async () => {
+        const value = await attachment.fetchData?.()
+        const resolved = isAttachmentData(value) ? value : undefined
+        if (!resolved) {
+          throw new Error("[vitehub] Chat attachment fetchData() did not return supported attachment data.")
+        }
+        return resolved
+      }
+    : undefined
+  const url = typeof attachment.url === "string" && attachment.url ? attachment.url : undefined
+  if (!data && !fetchData && !url) return undefined
+  const part = objectWithoutUndefined({
+    data,
+    fetchData,
     fetchMetadata: attachment.fetchMetadata,
-    id: `audio-${index + 1}`,
-    mediaType: mediaType ?? "audio/ogg",
+    id: `attachment-${index + 1}`,
+    mediaType: mediaType ?? (type === "audio" ? "audio/ogg" : type === "image" ? "image/*" : "application/octet-stream"),
     name: attachment.name,
     size: attachment.size,
-    type: "audio" as const,
+    type,
+    url,
   })
-  if (typeof attachment.fetchData === "function") {
-    return {
-      ...base,
-      fetchData: async () => {
-        const data = audioData(await attachment.fetchData?.())
-        if (!data) {
-          throw new Error("[vitehub] Chat attachment fetchData() did not return supported audio data.")
-        }
-        return data
-      },
-    }
-  }
-  if (typeof attachment.url === "string" && attachment.url) {
-    return { ...base, url: attachment.url }
-  }
-  const data = audioData(attachment.data)
-  if (data) {
-    return { ...base, data }
-  }
-  return undefined
+  return part as AttachmentPart
 }
 
 function attachmentFallbackLabel(attachment: Attachment): string {
@@ -1363,20 +1357,19 @@ function attachmentFallbackText(attachments: Attachment[]): string {
   return `Sent attachments: ${summary}.`
 }
 
-async function chatMessageParts(message: ChatSdkMessage, options: { includeAudioAttachments?: boolean, rejectOversizedTextAttachments?: boolean } = {}): Promise<MessagePart[]> {
+async function chatMessageParts(message: ChatSdkMessage, options: { rejectOversizedTextAttachments?: boolean } = {}): Promise<MessagePart[]> {
   const parts: MessagePart[] = []
   if (message.text) {
     parts.push({ id: "text-0", text: message.text, type: "text" })
   }
   for (const [index, attachment] of message.attachments.entries()) {
-    const part = await textPartFromAttachment(attachment, index, options)
-    if (part) parts.push(part)
-  }
-  if (options.includeAudioAttachments) {
-    for (const [index, attachment] of message.attachments.entries()) {
-      const part = audioPartFromAttachment(attachment, index)
-      if (part) parts.push(part)
+    const textPart = await textPartFromAttachment(attachment, index, options)
+    if (textPart) {
+      parts.push(textPart)
+      continue
     }
+    const attachmentPart = attachmentPartFromAttachment(attachment, index)
+    if (attachmentPart) parts.push(attachmentPart)
   }
   if (!parts.length) {
     const text = attachmentFallbackText(message.attachments)
@@ -1407,7 +1400,7 @@ function chatMessageMetadata(thread: Thread, message: ChatSdkMessage, messageCon
 async function chatSdkMessageToUiMessage(
   message: ChatSdkMessage,
   metadata?: Record<string, unknown>,
-  options?: { includeAudioAttachments?: boolean, rejectOversizedTextAttachments?: boolean },
+  options?: { rejectOversizedTextAttachments?: boolean },
 ): Promise<UIMessageLike> {
   return {
     createdAt: isoDate(message.metadata.dateSent),
@@ -1455,10 +1448,8 @@ async function chatTriggerMessages(
   message: ChatSdkMessage,
   options: AgentChatOptions | undefined,
   messageContext?: MessageContext,
-  messageOptions?: { includeAudioAttachments?: boolean },
 ): Promise<UIMessageLike[]> {
   const current = await chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext), {
-    ...messageOptions,
     rejectOversizedTextAttachments: true,
   })
   const limit = chatTriggerHistoryLimit(resolveChatTriggerHistory(options))
@@ -1467,14 +1458,14 @@ async function chatTriggerMessages(
   const fetchedNewestFirst: UIMessageLike[] = []
   try {
     for await (const item of thread.messages) {
-      fetchedNewestFirst.push(item.id && message.id && item.id === message.id ? current : await chatSdkMessageToUiMessage(item, undefined, messageOptions))
+      fetchedNewestFirst.push(item.id && message.id && item.id === message.id ? current : await chatSdkMessageToUiMessage(item))
       if (fetchedNewestFirst.length >= limit) break
     }
   } catch {}
 
   const durable = await durableChatThreadMessages(thread, limit)
   const messages = [
-    ...(await Promise.all(durable.map(item => item.id && message.id && item.id === message.id ? current : chatSdkMessageToUiMessage(item, undefined, messageOptions)))),
+    ...(await Promise.all(durable.map(item => item.id && message.id && item.id === message.id ? current : chatSdkMessageToUiMessage(item)))),
     ...fetchedNewestFirst.slice().reverse(),
   ].reduce<UIMessageLike[]>((deduped, item) => {
     if (!item.id) {
@@ -1737,18 +1728,12 @@ async function handleChatSdkMessage(
   let run: AgentRunMetadata | undefined
   let typing: ChatTypingRefresh | undefined
   try {
-    const messageOptions = {
-      includeAudioAttachments: getAgentCapabilities(agent).some((capability) => {
-        const metadata = capability.metadata as { chatAttachments?: { audio?: unknown } } | undefined
-        return capability.chatAttachments?.audio === true || metadata?.chatAttachments?.audio === true
-      }),
-    }
     input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, [chatAuthorizationUiMessage(thread, message, messageContext)], messageContext, registration.channelId)
     const authorizationInput = createChatMessageTriggerInput(options || {}, input).input
     const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, authorizationInput, input.run, messageContext)
     if (!invoker) return
 
-    const messages = await chatTriggerMessages(thread, message, options, messageContext, messageOptions)
+    const messages = await chatTriggerMessages(thread, message, options, messageContext)
     const currentMessage = message.id
       ? messages.find(item => item.id === message.id)
       : messages.at(-1)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1304,7 +1304,7 @@ function attachmentPartFromAttachment(attachment: Attachment, index: number): At
     : undefined
   const type = attachment.type === "audio" || mediaType?.startsWith("audio/")
     ? "audio"
-    : mediaType?.startsWith("image/")
+    : attachment.type === "image" || mediaType?.startsWith("image/")
       ? "image"
       : "file"
   const data = isAttachmentData(attachment.data) ? attachment.data : undefined
@@ -1325,7 +1325,7 @@ function attachmentPartFromAttachment(attachment: Attachment, index: number): At
     fetchData,
     fetchMetadata: attachment.fetchMetadata,
     id: `attachment-${index + 1}`,
-    mediaType: mediaType ?? (type === "audio" ? "audio/ogg" : "application/octet-stream"),
+    mediaType: mediaType ?? (type === "audio" ? "audio/ogg" : type === "image" ? "image/jpeg" : "application/octet-stream"),
     name: attachment.name,
     size: attachment.size,
     type,

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1302,9 +1302,9 @@ function attachmentPartFromAttachment(attachment: Attachment, index: number): At
   const mediaType = typeof attachment.mimeType === "string" && attachment.mimeType
     ? attachment.mimeType
     : undefined
-  const type = attachment.type === "audio" || mediaType?.startsWith("audio/")
+  const type = mediaType?.startsWith("audio/") || (attachment.type === "audio" && !mediaType)
     ? "audio"
-    : attachment.type === "image" || mediaType?.startsWith("image/")
+    : mediaType?.startsWith("image/")
       ? "image"
       : "file"
   const data = isAttachmentData(attachment.data) ? attachment.data : undefined
@@ -1325,7 +1325,7 @@ function attachmentPartFromAttachment(attachment: Attachment, index: number): At
     fetchData,
     fetchMetadata: attachment.fetchMetadata,
     id: `attachment-${index + 1}`,
-    mediaType: mediaType ?? (type === "audio" ? "audio/ogg" : type === "image" ? "image/jpeg" : "application/octet-stream"),
+    mediaType: mediaType ?? (type === "audio" ? "audio/ogg" : "application/octet-stream"),
     name: attachment.name,
     size: attachment.size,
     type,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -803,9 +803,6 @@ export interface AgentCapabilityDefinition<
   bash?: readonly AgentCapabilityBashCommand[]
   bind?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   capabilities?: readonly AgentCapabilityDefinition<TRuntimeConfig, Name>[]
-  chatAttachments?: {
-    audio?: boolean
-  }
   cli?: AgentCapabilityCliResolver<TRuntimeConfig, Name>
   close?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
   configure?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
@@ -922,10 +919,15 @@ export interface AgentModelExecutionInstrumentation<
   model?: AgentModelInstrumentation<TRuntimeConfig>
 }
 
+export interface AgentAttachmentExecutionOptions {
+  maxBytes?: number
+}
+
 export interface AgentModelExecutionOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
 > {
+  attachments?: AgentAttachmentExecutionOptions
   callSettings?: Record<string, unknown>
   instrumentation?: AgentModelExecutionInstrumentation<TRuntimeConfig, CALL_OPTIONS>
   stepLimit?: number

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -32,7 +32,7 @@ const optionalMessageAdapterRuntimeExternals = [
 
 const hostedAgentRoot = join(import.meta.dirname, "../../../fixtures/tutorials/agents")
 
-function createTestChatAdapter(options: { deferMessageProcessing?: boolean, missingIncomingMessageId?: boolean, persistThreadHistory?: boolean, secret?: string } = {}) {
+function createTestChatAdapter(options: { attachmentFetchData?: () => Promise<Buffer>, deferMessageProcessing?: boolean, missingIncomingMessageId?: boolean, persistThreadHistory?: boolean, secret?: string } = {}) {
   let chatInstance: ChatInstance | undefined
   let sentMessageId = 0
   const cachedMessages = new Map<string, Message[]>()
@@ -62,7 +62,7 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, miss
       const message = new Message({
         attachments: rawMessage.audio
           ? [{
-              fetchData: async () => Buffer.from([1, 2, 3]),
+              fetchData: options.attachmentFetchData ?? (async () => Buffer.from([1, 2, 3])),
               fetchMetadata: { fileId: "audio-file" },
               mimeType: "audio/ogg",
               name: "voice.ogg",
@@ -71,16 +71,17 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, miss
             }]
           : typeof document?.file_id === "string" && typeof document.mime_type === "string" && document.mime_type.startsWith("audio/")
             ? [{
-                fetchData: async () => Buffer.from([1, 2, 3]),
+                fetchData: options.attachmentFetchData ?? (async () => Buffer.from([1, 2, 3])),
                 fetchMetadata: { fileId: document.file_id },
                 mimeType: document.mime_type,
                 name: document.file_name,
                 size: document.file_size,
                 type: "file",
+                ...(typeof document.url === "string" ? { url: document.url } : {}),
               }]
           : document && (typeof document.file_id === "string" || typeof document.url === "string" || typeof document.content === "string")
             ? [{
-                ...(typeof document.content === "string" ? { fetchData: async () => Buffer.from(document.content ?? "") } : {}),
+                ...(typeof document.content === "string" ? { fetchData: options.attachmentFetchData ?? (async () => Buffer.from(document.content ?? "")) } : {}),
                 ...(typeof document.file_id === "string" ? { fetchMetadata: { fileId: document.file_id } } : {}),
                 ...(document.mime_type ? { mimeType: document.mime_type } : {}),
                 name: document.file_name,
@@ -90,7 +91,7 @@ function createTestChatAdapter(options: { deferMessageProcessing?: boolean, miss
               }]
           : typeof photo?.file_id === "string"
             ? [{
-                fetchData: async () => Buffer.from([1, 2, 3]),
+                fetchData: options.attachmentFetchData ?? (async () => Buffer.from([1, 2, 3])),
                 fetchMetadata: { fileId: photo.file_id },
                 height: photo.height,
                 size: photo.file_size,
@@ -2880,6 +2881,12 @@ describe("server helpers", () => {
         }),
         parts: [
           expect.objectContaining({ text: "hello", type: "text" }),
+          expect.objectContaining({
+            fetchData: expect.any(Function),
+            fetchMetadata: { fileId: "audio-file" },
+            mediaType: "audio/ogg",
+            type: "audio",
+          }),
         ],
       })],
       run: expect.objectContaining({
@@ -3226,11 +3233,12 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenCalledTimes(2)
   })
 
-  it("does not map audio mime file attachments without transcribe()", async () => {
+  it("maps audio mime file attachments by default without resolving bytes", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
-    const adapter = createTestChatAdapter()
+    const attachmentFetchData = vi.fn(async () => Buffer.from([1, 2, 3]))
+    const adapter = createTestChatAdapter({ attachmentFetchData })
     const run = vi.fn(() => "ok")
     const agent = defineAgent({
       channels: {
@@ -3251,6 +3259,7 @@ describe("server helpers", () => {
             file_name: "forwarded.ogg",
             file_size: 3,
             mime_type: "audio/ogg",
+            url: "https://cdn.example.com/forwarded.ogg",
           },
           from: { first_name: "Maxi", id: 123, username: "maxi" },
           message_id: 108,
@@ -3266,16 +3275,27 @@ describe("server helpers", () => {
       messages: [expect.objectContaining({
         parts: [
           expect.objectContaining({ text: "reenviado", type: "text" }),
+          expect.objectContaining({
+            fetchData: expect.any(Function),
+            fetchMetadata: { fileId: "forwarded-audio-file" },
+            mediaType: "audio/ogg",
+            name: "forwarded.ogg",
+            size: 3,
+            type: "audio",
+            url: "https://cdn.example.com/forwarded.ogg",
+          }),
         ],
       })],
     }))
+    expect(attachmentFetchData).not.toHaveBeenCalled()
   })
 
   it("invokes chat agents for attachment-only image messages", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
-    const adapter = createTestChatAdapter()
+    const attachmentFetchData = vi.fn(async () => Buffer.from([1, 2, 3]))
+    const adapter = createTestChatAdapter({ attachmentFetchData })
     const hostIdentity = { name: "support", workspace: "support-workspace" }
     const run = vi.fn(({ agentIdentity }) => {
       expect(agentIdentity).toEqual(hostIdentity)
@@ -3312,10 +3332,58 @@ describe("server helpers", () => {
       messages: [expect.objectContaining({
         parts: [
           expect.objectContaining({
-            text: "Sent an image attachment.",
-            type: "text",
+            fetchData: expect.any(Function),
+            fetchMetadata: { fileId: "large-photo" },
+            mediaType: "image/*",
+            size: 3,
+            type: "image",
           }),
         ],
+      })],
+    }))
+    expect(attachmentFetchData).not.toHaveBeenCalled()
+  })
+
+  it("preserves generic attachment URLs as typed references", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const run = vi.fn(() => "ok")
+    const agent = defineAgent({
+      channels: { telegram: telegram({ adapter: () => adapter as never }) },
+      driver: { run },
+    })
+
+    const response = await createChannelWebhookRouteHandler(agent as never)(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 43,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          document: {
+            file_name: "report.pdf",
+            file_size: 2048,
+            mime_type: "application/pdf",
+            url: "https://cdn.discordapp.com/attachments/channel/message/report.pdf",
+          },
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 1013,
+        },
+      }),
+      method: "POST",
+    }), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({
+      messages: [expect.objectContaining({
+        parts: [expect.objectContaining({
+          mediaType: "application/pdf",
+          name: "report.pdf",
+          size: 2048,
+          type: "file",
+          url: "https://cdn.discordapp.com/attachments/channel/message/report.pdf",
+        })],
       })],
     }))
   })
@@ -3415,7 +3483,6 @@ describe("server helpers", () => {
     const agent = defineAgent({
       capabilities: [
         defineCapability({
-          chatAttachments: { audio: true },
           id: "custom-audio",
           input,
         }),
@@ -3479,7 +3546,6 @@ describe("server helpers", () => {
         defineCapability({
           capabilities: [
             defineCapability({
-              chatAttachments: { audio: true },
               id: "nested-audio",
               input,
             }),
@@ -6110,7 +6176,7 @@ describe("server helpers", () => {
     }
   })
 
-  it("falls back when durable thread history text attachment URLs fail", async () => {
+  it("preserves typed references when durable text attachment URL decoding fails", async () => {
     const { telegram } = await import("../src/channels.ts")
     const { defineAgent } = await import("../src/index.ts")
     const { getMessageText } = await import("../src/messages.ts")
@@ -6120,6 +6186,7 @@ describe("server helpers", () => {
     const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-history-stale-attachment-"))
     const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
     const runs: string[][] = []
+    let receivedMessages: Array<{ parts: Array<Record<string, unknown>> }> = []
     try {
       await state.connect?.()
       await state.appendToList("msg-history:telegram:456", new Message({
@@ -6151,6 +6218,7 @@ describe("server helpers", () => {
         },
         driver: {
           run: ({ messages }) => {
+            receivedMessages = messages as unknown as Array<{ parts: Array<Record<string, unknown>> }>
             runs.push(messages.map(getMessageText))
             return "ok"
           },
@@ -6181,7 +6249,15 @@ describe("server helpers", () => {
       expect(response.status).toBe(200)
       await expect(response.json()).resolves.toEqual({ ok: true })
       expect(fetch).toHaveBeenCalledWith("https://cdn.example/old.txt")
-      expect(runs).toEqual([["Sent a file attachment.", "current after stale history"]])
+      expect(runs).toEqual([["", "current after stale history"]])
+      expect(receivedMessages[0]?.parts).toEqual([
+        expect.objectContaining({
+          mediaType: "text/plain",
+          name: "old.txt",
+          type: "file",
+          url: "https://cdn.example/old.txt",
+        }),
+      ])
     }
     finally {
       fetch.mockRestore()

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -3334,9 +3334,9 @@ describe("server helpers", () => {
           expect.objectContaining({
             fetchData: expect.any(Function),
             fetchMetadata: { fileId: "large-photo" },
-            mediaType: "application/octet-stream",
+            mediaType: "image/jpeg",
             size: 3,
-            type: "file",
+            type: "image",
           }),
         ],
       })],

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -3334,9 +3334,9 @@ describe("server helpers", () => {
           expect.objectContaining({
             fetchData: expect.any(Function),
             fetchMetadata: { fileId: "large-photo" },
-            mediaType: "image/jpeg",
+            mediaType: "application/octet-stream",
             size: 3,
-            type: "image",
+            type: "file",
           }),
         ],
       })],

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -3334,9 +3334,9 @@ describe("server helpers", () => {
           expect.objectContaining({
             fetchData: expect.any(Function),
             fetchMetadata: { fileId: "large-photo" },
-            mediaType: "image/*",
+            mediaType: "application/octet-stream",
             size: 3,
-            type: "image",
+            type: "file",
           }),
         ],
       })],

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2974,6 +2974,7 @@ describe("agent message protocol", () => {
   it("preserves remote attachment parts without invoking provider callbacks", async () => {
     const { toAiSdkModelMessages } = await import("../src/ai-sdk.ts")
     const fetchData = vi.fn(async () => new Uint8Array([1, 2, 3]))
+    const staleFetchData = vi.fn(async () => new Uint8Array([7, 8, 9]))
 
     expect(toAiSdkModelMessages([
       createMessage({
@@ -3056,6 +3057,10 @@ describe("agent message protocol", () => {
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
       messages: [
         createMessage({
+          parts: [{ fetchData: staleFetchData, mediaType: "application/pdf", type: "file" }],
+          role: "user",
+        }),
+        createMessage({
           parts: [{ fetchData: ignoredAssistantFetchData, mediaType: "image/png", size: 3, type: "image" }],
           role: "assistant",
         }),
@@ -3066,6 +3071,7 @@ describe("agent message protocol", () => {
       ],
     })).resolves.toMatchObject({ text: "ok" })
     expect(fetchData).toHaveBeenCalledOnce()
+    expect(staleFetchData).not.toHaveBeenCalled()
     expect(ignoredAssistantFetchData).not.toHaveBeenCalled()
     expect(generate).toHaveBeenCalledWith(expect.objectContaining({
       messages: [{
@@ -3103,6 +3109,20 @@ describe("agent message protocol", () => {
       })],
     })).rejects.toThrow("exceeds maxBytes")
     expect(oversizedFetchData).not.toHaveBeenCalled()
+
+    const firstAggregateFetch = vi.fn(async () => new Uint8Array([1, 2]))
+    const secondAggregateFetch = vi.fn(async () => new Uint8Array([3, 4]))
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({
+        parts: [
+          { fetchData: firstAggregateFetch, mediaType: "application/pdf", size: 2, type: "file" },
+          { fetchData: secondAggregateFetch, mediaType: "application/pdf", size: 2, type: "file" },
+        ],
+        role: "user",
+      })],
+    })).rejects.toThrow("exceeds maxBytes")
+    expect(firstAggregateFetch).toHaveBeenCalledOnce()
+    expect(secondAggregateFetch).not.toHaveBeenCalled()
 
     const emptyFetchData = vi.fn(async () => "")
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3002,6 +3002,13 @@ describe("agent message protocol", () => {
         role: "user",
       }),
     ])).toThrow("cannot convert a Blob synchronously")
+
+    expect(() => toAiSdkModelMessages([
+      createMessage({
+        parts: [{ fetchData, mediaType: "image/png", type: "image" }],
+        role: "user",
+      }),
+    ])).toThrow("cannot resolve attachment callbacks synchronously")
   })
 
   it("maps Web Chat file parts to typed attachment references", async () => {
@@ -3096,6 +3103,14 @@ describe("agent message protocol", () => {
       })],
     })).rejects.toThrow("exceeds maxBytes")
     expect(oversizedFetchData).not.toHaveBeenCalled()
+
+    const emptyFetchData = vi.fn(async () => "")
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({
+        parts: [{ fetchData: emptyFetchData, mediaType: "application/pdf", type: "file" }],
+        role: "user",
+      })],
+    })).rejects.toThrow("did not return supported attachment data")
   })
 
   it("preserves prefixed data parts during model conversion", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1705,6 +1705,8 @@ describe("agent message protocol", () => {
         }),
         createMessage({ id: "user-2", parts: [{ data: { scope: "kiwi-714" }, type: "data" }], role: "user" }),
         createMessage({ id: "user-3", parts: [{ error: "prior lookup warning", type: "error" }], role: "user" }),
+        createMessage({ id: "user-provider-only", parts: [{ fetchData: () => new Uint8Array([1]), mediaType: "application/pdf", type: "file" }], role: "user" }),
+        createMessage({ id: "user-url", parts: [{ fetchData: () => new Uint8Array([1]), mediaType: "application/pdf", type: "file", url: "https://cdn.example.com/report.pdf" }], role: "user" }),
         createMessage({ id: "user-4", role: "user", text: "What marker?" }),
       ],
     })).resolves.toMatchObject({ text: "ok" })
@@ -1721,6 +1723,7 @@ describe("agent message protocol", () => {
         "Assistant: Tool confirmed marker.",
         "User: {\"scope\":\"kiwi-714\"}",
         "User: prior lookup warning",
+        "User: [{\"data\":\"https://cdn.example.com/report.pdf\",\"mediaType\":\"application/pdf\",\"type\":\"file\"}]",
         "User: What marker?",
         "",
         "Respond to the latest user message.",

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3057,6 +3057,7 @@ describe("agent message protocol", () => {
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
       messages: [
         createMessage({
+          id: "historical-attachment",
           parts: [{ fetchData: staleFetchData, mediaType: "application/pdf", type: "file" }],
           role: "user",
         }),
@@ -3065,10 +3066,12 @@ describe("agent message protocol", () => {
           role: "assistant",
         }),
         createMessage({
+          id: "current-attachment",
           parts: [{ fetchData, mediaType: "image/png", size: 3, type: "image", url: "https://cdn.example.com/photo.png" }],
           role: "user",
         }),
       ],
+      context: { channel: { message: { id: "current-attachment" } } },
     })).resolves.toMatchObject({ text: "ok" })
     expect(fetchData).toHaveBeenCalledOnce()
     expect(staleFetchData).not.toHaveBeenCalled()
@@ -3079,6 +3082,20 @@ describe("agent message protocol", () => {
         role: "user",
       }],
     }))
+
+    await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      context: { channel: { message: { id: "current-text" } } },
+      messages: [
+        createMessage({
+          id: "historical-blob",
+          parts: [{ data: new Blob([new Uint8Array([1, 2, 3])]), mediaType: "application/pdf", type: "file" }],
+          role: "user",
+        }),
+        createMessage({ id: "current-text", role: "user", text: "continue" }),
+      ],
+    })
+    const historyCall = generate.mock.calls.at(-1)?.[0] as { messages?: Array<{ content?: Array<{ data?: unknown }> }> }
+    expect(historyCall.messages?.[0]?.content?.[0]?.data).toBeInstanceOf(ArrayBuffer)
 
     const blobAgent = defineAgent({
       driver: {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2974,7 +2974,6 @@ describe("agent message protocol", () => {
   it("preserves remote attachment parts without invoking provider callbacks", async () => {
     const { toAiSdkModelMessages } = await import("../src/ai-sdk.ts")
     const fetchData = vi.fn(async () => new Uint8Array([1, 2, 3]))
-    const staleFetchData = vi.fn(async () => new Uint8Array([7, 8, 9]))
 
     expect(toAiSdkModelMessages([
       createMessage({
@@ -3045,6 +3044,7 @@ describe("agent message protocol", () => {
     })
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const fetchData = vi.fn(async () => new Uint8Array([1, 2, 3]))
+    const staleFetchData = vi.fn(async () => new Uint8Array([7, 8, 9]))
     const ignoredAssistantFetchData = vi.fn(async () => new Uint8Array([4, 5, 6]))
     const agent = defineAgent({
       driver: {
@@ -3071,7 +3071,7 @@ describe("agent message protocol", () => {
           role: "user",
         }),
       ],
-      context: { channel: { message: { id: "current-attachment" } } },
+      context: { channel: { message: { id: "current-attachment", text: "" } } },
     })).resolves.toMatchObject({ text: "ok" })
     expect(fetchData).toHaveBeenCalledOnce()
     expect(staleFetchData).not.toHaveBeenCalled()
@@ -3084,7 +3084,7 @@ describe("agent message protocol", () => {
     }))
 
     await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
-      context: { channel: { message: { id: "current-text" } } },
+      context: { channel: { message: { id: "current-text", text: "continue" } } },
       messages: [
         createMessage({
           id: "historical-blob",

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3083,6 +3083,18 @@ describe("agent message protocol", () => {
       }],
     }))
 
+    const currentIdlessFetchData = vi.fn(async () => new Uint8Array([1, 2, 3]))
+    const staleIdlessFetchData = vi.fn(async () => new Uint8Array([4, 5, 6]))
+    await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      context: { channel: { message: { text: "" } } },
+      messages: [
+        createMessage({ parts: [{ fetchData: staleIdlessFetchData, mediaType: "application/pdf", type: "file" }], role: "user" }),
+        createMessage({ parts: [{ fetchData: currentIdlessFetchData, mediaType: "image/png", type: "image" }], role: "user" }),
+      ],
+    })
+    expect(staleIdlessFetchData).not.toHaveBeenCalled()
+    expect(currentIdlessFetchData).toHaveBeenCalledOnce()
+
     await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
       context: { channel: { message: { id: "current-text", text: "continue" } } },
       messages: [

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1983,6 +1983,28 @@ describe("agent message protocol", () => {
     expect(session.destroy).toHaveBeenCalledOnce()
   })
 
+  it("keeps remote attachment URLs visible to chat harnesses", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const session = { destroy: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessGenerate.mockResolvedValueOnce({ text: "ok" })
+    const agent = defineAgent({
+      driver: { harness: { provider: "codex" } },
+    })
+
+    await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      context: { chat: {} },
+      messages: [createMessage({
+        parts: [{ mediaType: "image/png", name: "photo.png", type: "image", url: "https://cdn.example.com/photo.png" }],
+        role: "user",
+      })],
+    })
+
+    const prompt = (harnessGenerate.mock.calls[0]?.[0] as { prompt?: string }).prompt
+    expect(prompt).toContain("https://cdn.example.com/photo.png")
+    expect(session.destroy).toHaveBeenCalledOnce()
+  })
+
   it("destroys harness sessions created after abort before running the harness", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const controller = new AbortController()
@@ -2947,6 +2969,133 @@ describe("agent message protocol", () => {
     ])).toEqual([
       { content: "hello", role: "user" },
     ])
+  })
+
+  it("preserves remote attachment parts without invoking provider callbacks", async () => {
+    const { toAiSdkModelMessages } = await import("../src/ai-sdk.ts")
+    const fetchData = vi.fn(async () => new Uint8Array([1, 2, 3]))
+
+    expect(toAiSdkModelMessages([
+      createMessage({
+        id: "m1",
+        parts: [
+          { text: "inspect these", type: "text" },
+          { fetchData, mediaType: "image/png", name: "photo.png", type: "image", url: "https://cdn.example.com/photo.png" },
+          { mediaType: "application/pdf", name: "report.pdf", type: "file", url: "https://cdn.example.com/report.pdf" },
+          { mediaType: "application/octet-stream", type: "file", url: "http://internal.example.test/private" },
+        ],
+        role: "user",
+      }),
+    ])).toEqual([{
+      content: [
+        { text: "inspect these", type: "text" },
+        { image: new URL("https://cdn.example.com/photo.png"), mediaType: "image/png", type: "image" },
+        { data: new URL("https://cdn.example.com/report.pdf"), filename: "report.pdf", mediaType: "application/pdf", type: "file" },
+      ],
+      role: "user",
+    }])
+    expect(fetchData).not.toHaveBeenCalled()
+
+    expect(() => toAiSdkModelMessages([
+      createMessage({
+        parts: [{ data: new Blob([new Uint8Array([1])], { type: "image/png" }), mediaType: "image/png", type: "image" }],
+        role: "user",
+      }),
+    ])).toThrow("cannot convert a Blob synchronously")
+  })
+
+  it("maps Web Chat file parts to typed attachment references", async () => {
+    const { uiMessagesToAgentMessages } = await import("../src/chat-message-input.ts")
+
+    expect(uiMessagesToAgentMessages([{
+      id: "web-1",
+      parts: [
+        { filename: "photo.png", mediaType: "image/png", type: "file", url: "https://cdn.example.com/photo.png" },
+        { filename: "voice.ogg", mediaType: "audio/ogg", type: "file", url: "https://cdn.example.com/voice.ogg" },
+        { filename: "report.pdf", mediaType: "application/pdf", type: "file", url: "https://cdn.example.com/report.pdf" },
+      ],
+      role: "user",
+    }])[0]?.parts).toEqual([
+      { mediaType: "image/png", name: "photo.png", type: "image", url: "https://cdn.example.com/photo.png" },
+      { mediaType: "audio/ogg", name: "voice.ogg", type: "audio", url: "https://cdn.example.com/voice.ogg" },
+      { mediaType: "application/pdf", name: "report.pdf", type: "file", url: "https://cdn.example.com/report.pdf" },
+    ])
+  })
+
+  it("resolves provider callbacks only at model invocation with byte limits", async () => {
+    const generate = vi.fn(async (_input: unknown) => ({ finishReason: "stop", text: "ok" }))
+    loadAiSdk.mockResolvedValue({
+      isStepCount: vi.fn(count => ({ count })),
+      jsonSchema: vi.fn(schema => schema),
+      ToolLoopAgent: class {
+        constructor(_settings: unknown) {}
+
+        async generate(input: unknown) {
+          return await generate(input)
+        }
+      },
+    })
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const fetchData = vi.fn(async () => new Uint8Array([1, 2, 3]))
+    const ignoredAssistantFetchData = vi.fn(async () => new Uint8Array([4, 5, 6]))
+    const agent = defineAgent({
+      driver: {
+        execution: { attachments: { maxBytes: 3 } },
+        model: "attachment-model" as never,
+      },
+    })
+
+    expect(fetchData).not.toHaveBeenCalled()
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [
+        createMessage({
+          parts: [{ fetchData: ignoredAssistantFetchData, mediaType: "image/png", size: 3, type: "image" }],
+          role: "assistant",
+        }),
+        createMessage({
+          parts: [{ fetchData, mediaType: "image/png", size: 3, type: "image", url: "https://cdn.example.com/photo.png" }],
+          role: "user",
+        }),
+      ],
+    })).resolves.toMatchObject({ text: "ok" })
+    expect(fetchData).toHaveBeenCalledOnce()
+    expect(ignoredAssistantFetchData).not.toHaveBeenCalled()
+    expect(generate).toHaveBeenCalledWith(expect.objectContaining({
+      messages: [{
+        content: [{ image: new Uint8Array([1, 2, 3]), mediaType: "image/png", type: "image" }],
+        role: "user",
+      }],
+    }))
+
+    const blobAgent = defineAgent({
+      driver: {
+        execution: { attachments: { maxBytes: 3 } },
+        model: "attachment-model" as never,
+      },
+    })
+    await runAgent(blobAgent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({
+        parts: [{ data: new Blob([new Uint8Array([1, 2, 3])]), mediaType: "application/pdf", type: "file" }],
+        role: "user",
+      })],
+    })
+    const blobCall = generate.mock.calls.at(-1)?.[0] as { messages?: Array<{ content?: Array<{ data?: unknown }> }> }
+    expect(blobCall.messages?.[0]?.content?.[0]?.data).toBeInstanceOf(ArrayBuffer)
+
+    const oversizedFetchData = vi.fn(async () => new Uint8Array([1, 2, 3]))
+    const oversizedAgent = defineAgent({
+      driver: {
+        execution: { attachments: { maxBytes: 2 } },
+        model: "attachment-model" as never,
+      },
+    })
+    await expect(runAgent(oversizedAgent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({
+        parts: [{ fetchData: oversizedFetchData, mediaType: "application/pdf", size: 3, type: "file" }],
+        role: "user",
+      })],
+    })).rejects.toThrow("exceeds maxBytes")
+    expect(oversizedFetchData).not.toHaveBeenCalled()
   })
 
   it("preserves prefixed data parts during model conversion", async () => {

--- a/packages/agent/test/transcription.test.ts
+++ b/packages/agent/test/transcription.test.ts
@@ -205,6 +205,11 @@ describe("agent transcription", () => {
       parts: [{ fetchData: () => new Uint8Array([1]), mediaType: "image/png", type: "image" }],
       role: "user",
     })])).toThrow("cannot serialize")
+
+    expect(() => serializeMessages([createMessage({
+      parts: [{ data: new Uint8Array([1]), mediaType: "image/png", type: "image" }],
+      role: "user",
+    })])).toThrow("cannot serialize binary data")
   })
 
   it("rejects invalid audio message parts", () => {

--- a/packages/agent/test/transcription.test.ts
+++ b/packages/agent/test/transcription.test.ts
@@ -267,7 +267,7 @@ describe("agent transcription", () => {
       audio: { data: "AAAA", mediaType: "audio/wav", type: "audio" },
     })
     expect(finish.mock.calls[0]![0].input.messages.at(-1)?.parts).toEqual([
-      { text: "voice transcript", type: "text" },
+      { id: "text-0", text: "voice transcript", type: "text" },
     ])
     expect(finish.mock.calls[0]![0].extensions.get("transcribe")).toEqual([{
       createdAt: expect.any(String),

--- a/packages/agent/test/transcription.test.ts
+++ b/packages/agent/test/transcription.test.ts
@@ -162,7 +162,7 @@ describe("agent transcription", () => {
     )
   })
 
-  it("accepts audio message parts", () => {
+  it("accepts typed attachment message parts and preserves multiple handles", () => {
     expect(createMessage({
       parts: [{ data: "AAAA", mediaType: "audio/wav", type: "audio" }],
       role: "user",
@@ -171,21 +171,40 @@ describe("agent transcription", () => {
     ])
 
     expect(createMessage({
-      parts: [{ fetchData: () => new Uint8Array([1]), mediaType: "audio/ogg", type: "audio" }],
+      parts: [{ fetchData: () => new Uint8Array([1]), fetchMetadata: { fileId: "audio-1" }, mediaType: "audio/ogg", type: "audio", url: "https://example.com/audio.ogg" }],
       role: "user",
     }).parts[0]).toMatchObject({
+      fetchData: expect.any(Function),
+      fetchMetadata: { fileId: "audio-1" },
       mediaType: "audio/ogg",
       type: "audio",
+      url: "https://example.com/audio.ogg",
     })
+
+    expect(createMessage({
+      parts: [
+        { mediaType: "image/png", type: "image", url: "https://example.com/photo.png" },
+        { mediaType: "application/pdf", name: "report.pdf", type: "file", url: "https://example.com/report.pdf" },
+      ],
+      role: "user",
+    }).parts).toMatchObject([
+      { type: "image", url: "https://example.com/photo.png" },
+      { name: "report.pdf", type: "file", url: "https://example.com/report.pdf" },
+    ])
   })
 
-  it("rejects serializing lazy audio message parts", () => {
+  it("rejects serializing lazy attachment message parts", () => {
     const message = createMessage({
       parts: [{ fetchData: () => new Uint8Array([1]), mediaType: "audio/ogg", type: "audio" }],
       role: "user",
     })
 
     expect(() => serializeMessages([message])).toThrow("cannot serialize")
+
+    expect(() => serializeMessages([createMessage({
+      parts: [{ fetchData: () => new Uint8Array([1]), mediaType: "image/png", type: "image" }],
+      role: "user",
+    })])).toThrow("cannot serialize")
   })
 
   it("rejects invalid audio message parts", () => {
@@ -195,9 +214,14 @@ describe("agent transcription", () => {
     })).toThrow("audio/* mediaType")
 
     expect(() => createMessage({
-      parts: [{ data: "AAAA", mediaType: "audio/wav", type: "audio", url: "https://example.com/audio.wav" }],
+      parts: [{ mediaType: "audio/wav", type: "audio" }],
       role: "user",
-    })).toThrow("exactly one of data, fetchData, or url")
+    })).toThrow("requires data, fetchData, or url")
+
+    expect(() => createMessage({
+      parts: [{ mediaType: "application/octet-stream", type: "image", url: "https://example.com/image" }],
+      role: "user",
+    })).toThrow("image/* mediaType")
   })
 
   it("transcribes audio input with custom execution before agent execution", async () => {

--- a/packages/agent/test/transcription.test.ts
+++ b/packages/agent/test/transcription.test.ts
@@ -222,6 +222,11 @@ describe("agent transcription", () => {
       parts: [{ mediaType: "application/octet-stream", type: "image", url: "https://example.com/image" }],
       role: "user",
     })).toThrow("image/* mediaType")
+
+    expect(() => createMessage({
+      parts: [{ data: new Uint8Array(), mediaType: "audio/wav", type: "audio" }],
+      role: "user",
+    })).toThrow("requires data, fetchData, or url")
   })
 
   it("transcribes audio input with custom execution before agent execution", async () => {
@@ -256,6 +261,9 @@ describe("agent transcription", () => {
     expect(execute).toHaveBeenCalledWith({
       audio: { data: "AAAA", mediaType: "audio/wav", type: "audio" },
     })
+    expect(finish.mock.calls[0]![0].input.messages.at(-1)?.parts).toEqual([
+      { text: "voice transcript", type: "text" },
+    ])
     expect(finish.mock.calls[0]![0].extensions.get("transcribe")).toEqual([{
       createdAt: expect.any(String),
       date: expect.any(String),

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -930,11 +930,22 @@ describe("agent public types", () => {
     })
 
     expectTypeOf(inventoryRuntime.cli).toMatchTypeOf<AgentCapabilityCliResolver | undefined>()
-    const audioRuntime = defineCapability({
+    const image: ImagePart = {
+      fetchData: () => new Uint8Array([1]),
+      fetchMetadata: { fileId: "provider-file" },
+      mediaType: "image/png",
+      name: "photo.png",
+      size: 1,
+      type: "image",
+      url: "https://example.com/photo.png",
+    }
+    expectTypeOf(image.fetchData).toMatchTypeOf<(() => ArrayBuffer | Blob | string | Uint8Array | Promise<ArrayBuffer | Blob | string | Uint8Array>) | undefined>()
+
+    defineCapability({
+      // @ts-expect-error Attachments are normalized by default rather than enabled by a Capability.
       chatAttachments: { audio: true },
-      id: "audio-runtime",
+      id: "legacy-audio-runtime",
     })
-    expectTypeOf(audioRuntime.chatAttachments).toMatchTypeOf<{ audio?: boolean } | undefined>()
 
     defineCapability({
       id: "legacy-instructions",


### PR DESCRIPTION
Preserves Channel-hosted image, audio, and generic file attachments as typed `AttachmentPart` references by default. Shared message normalization now carries every provider handle together—URL, lazy `fetchData`, stable `fetchMetadata`, media type, name, and size—while bounded text attachments keep their existing decoded-text behavior. This removes the capability opt-in and avoids duplicate audio-plus-prose fallbacks.

The AI SDK converter passes inline data and validated HTTPS references directly to supported model inputs, and model-backed Agent Drivers resolve provider callbacks only when the model invocation needs bytes. Resolution is bounded to 25 MiB by default through `execution.attachments.maxBytes`; synchronous conversion fails explicitly for callback- or Blob-only inputs, while harness consumers omit callback/Blob-only references and retain safe URLs without implicit server fetches or temporary-file materialization. The Channel docs describe expiry, authentication, serialization, model-disclosure, protocol, and byte boundaries.

Validation: exact-head CI passes; 425 focused provider/runtime tests and 274 focused runtime tests pass locally; `pnpm --filter @vite-hub/agent typecheck` passes; and the agent package build passes with publint clean. Exact-head Codex review found no major issues after Web Chat metadata classification, user-role/current-turn callback resolution, safe media-type handling, Blob handling, and harness callback boundaries were corrected.