### PR TITLE
fix(blob): make private Vercel storage runtime-complete

### DIFF
--- a/packages/blob/fixtures/private-vercel-consumer/src/server.ts
+++ b/packages/blob/fixtures/private-vercel-consumer/src/server.ts
@@ -1,0 +1,3 @@
+import { blob } from "@vite-hub/blob"
+
+export default async () => Response.json(await blob.list())

--- a/packages/blob/fixtures/private-vercel-consumer/vite.config.ts
+++ b/packages/blob/fixtures/private-vercel-consumer/vite.config.ts
@@ -1,0 +1,16 @@
+import { hubBlob } from "@vite-hub/blob/vite"
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  blob: {
+    access: "private",
+    driver: "vercel-blob",
+    token: "vercel_blob_rw_test",
+  },
+  build: {
+    outDir: "dist/client",
+    rollupOptions: { input: "src/server.ts" },
+    ssr: "src/server.ts",
+  },
+  plugins: [hubBlob()],
+})

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -68,6 +68,7 @@
     "test": "vp run -t @vite-hub/blob#build && vp test"
   },
   "dependencies": {
+    "@vercel/blob": "catalog:storage",
     "defu": "catalog:unjs",
     "esbuild": "catalog:esbuild-v27",
     "h3": "catalog:unjs",

--- a/packages/blob/src/drivers/vercel-bundled.ts
+++ b/packages/blob/src/drivers/vercel-bundled.ts
@@ -1,19 +1,146 @@
-import { Files } from "files-sdk"
-import { vercelBlob } from "files-sdk/vercel-blob"
+import { del, get, head, list, put } from "@vercel/blob"
 
-import { createFilesSdkDriver } from "./files-sdk.ts"
+import type { BlobDriverAdapter, BlobObject, BlobPutBody, BlobPutOptions, ResolvedVercelBlobStoreConfig } from "../types.ts"
 
-import type { BlobDriverAdapter, BlobPutOptions, ResolvedVercelBlobStoreConfig } from "../types.ts"
+function toBlobObject(blob: {
+  contentType?: string
+  etag?: string
+  pathname: string
+  size: number
+  uploadedAt: Date
+  url?: string
+}): BlobObject {
+  return {
+    contentType: blob.contentType,
+    customMetadata: {},
+    httpEtag: blob.etag,
+    httpMetadata: blob.contentType ? { contentType: blob.contentType } : {},
+    pathname: blob.pathname,
+    size: blob.size,
+    uploadedAt: blob.uploadedAt,
+    url: blob.url,
+  }
+}
 
-export function createBundledVercelBlobDriver(options: ResolvedVercelBlobStoreConfig): BlobDriverAdapter<ResolvedVercelBlobStoreConfig> {
-  return createFilesSdkDriver(
-    options,
-    async (options, putOptions: BlobPutOptions = {}) => vercelBlob({
-      ...options,
-      access: putOptions.access || options.access,
-      addRandomSuffix: false,
-      allowOverwrite: options.allowOverwrite ?? true,
-    }),
-    Files,
+function isMissingBlobError(error: unknown) {
+  return error instanceof Error && (
+    error.name === "BlobNotFoundError"
+    || /(?:requested )?blob (?:was )?not found|requested blob does not exist/i.test(error.message)
   )
 }
+
+export function createBundledVercelBlobDriver(options: ResolvedVercelBlobStoreConfig): BlobDriverAdapter<ResolvedVercelBlobStoreConfig> {
+  const auth = { token: options.token }
+
+  async function read(pathname: string) {
+    const abortSignal = options.downloadTimeoutMs && options.downloadTimeoutMs > 0
+      ? AbortSignal.timeout(options.downloadTimeoutMs)
+      : undefined
+    if (options.access === "private") {
+      const result = await get(pathname, { ...auth, abortSignal, access: "private" })
+      return result ? new Response(result.stream, { headers: result.blob.contentType ? { "content-type": result.blob.contentType } : undefined }) : null
+    }
+
+    try {
+      const metadata = await head(pathname, { ...auth, abortSignal })
+      const response = await fetch(metadata.url, { signal: abortSignal })
+      if (response.status === 404) return null
+      if (!response.ok) throw new Error(`Vercel Blob read failed: ${response.status} ${response.statusText}`)
+      return response
+    }
+    catch (error) {
+      if (isMissingBlobError(error)) return null
+      throw error
+    }
+  }
+
+  return {
+    name: options.driver,
+    options,
+    async delete(pathnames) {
+      await del(pathnames, auth)
+    },
+    async get(pathname) {
+      return await (await read(pathname))?.blob() || null
+    },
+    async getArrayBuffer(pathname) {
+      return await (await read(pathname))?.arrayBuffer() || null
+    },
+    async head(pathname) {
+      try {
+        return toBlobObject(await head(pathname, auth))
+      }
+      catch (error) {
+        if (isMissingBlobError(error)) return null
+        throw error
+      }
+    },
+    async list(listOptions = {}) {
+      if (listOptions.folded) {
+        const result = await list({
+          ...auth,
+          cursor: listOptions.cursor,
+          limit: listOptions.limit,
+          mode: "folded",
+          prefix: listOptions.prefix,
+        })
+        return {
+          blobs: result.blobs.map(toBlobObject),
+          cursor: result.cursor,
+          folders: result.folders,
+          hasMore: result.hasMore,
+        }
+      }
+      const result = await list({
+        ...auth,
+        cursor: listOptions.cursor,
+        limit: listOptions.limit,
+        prefix: listOptions.prefix,
+      })
+      return {
+        blobs: result.blobs.map(toBlobObject),
+        cursor: result.cursor,
+        hasMore: result.hasMore,
+      }
+    },
+    async put(pathname, body: BlobPutBody, putOptions: BlobPutOptions = {}) {
+      const result = await put(pathname, body as Parameters<typeof put>[1], {
+        ...auth,
+        access: putOptions.access || options.access,
+        addRandomSuffix: false,
+        allowOverwrite: options.allowOverwrite ?? true,
+        contentType: putOptions.contentType,
+      })
+      let size = typeof body === "string"
+        ? new TextEncoder().encode(body).byteLength
+        : body instanceof Blob
+          ? body.size
+          : body instanceof ArrayBuffer || ArrayBuffer.isView(body)
+            ? body.byteLength
+            : Number(putOptions.contentLength) || 0
+      let uploadedAt = new Date()
+      let httpEtag = (result as typeof result & { etag?: string }).etag
+      if (!size) {
+        const metadata = await head(result.url, auth)
+        size = metadata.size
+        uploadedAt = metadata.uploadedAt
+        httpEtag ||= metadata.etag
+      }
+      const contentType = result.contentType || putOptions.contentType
+      const httpMetadata: Record<string, string> = {}
+      if (contentType) httpMetadata.contentType = contentType
+      return {
+        contentType,
+        customMetadata: putOptions.customMetadata || {},
+        httpEtag,
+        httpMetadata,
+        pathname: result.pathname,
+        size,
+        uploadedAt,
+        url: result.url,
+      }
+    },
+  }
+}
+
+export { createBundledVercelBlobDriver as createDriver }

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -91,6 +91,11 @@ const driverModules = {
   "vercel-blob": "drivers/vercel",
 } satisfies Record<NonNullable<ResolvedBlobModuleOptions["store"]>["driver"], string>
 
+function getDriverModule(driver: NonNullable<ResolvedBlobModuleOptions["store"]>["driver"], provider?: BlobProvider) {
+  if (driver === "vercel-blob" && provider === "vercel") return "drivers/vercel-bundled"
+  return driverModules[driver]
+}
+
 function isResolvedBlobStore(store: unknown): store is ResolvedBlobModuleOptions["store"] {
   if (!isPlainObject(store) || typeof store.driver !== "string" || !Object.hasOwn(driverModules, store.driver)) return false
   switch (store.driver) {
@@ -174,7 +179,7 @@ function renderProviderEntry(
     `import { setBlobRuntimeConfig, setBlobRuntimeStorage } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule("runtime/state")))}`,
     `import { ${spec.factory} } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule(spec.runtimeModule)))}`,
   ]
-  const driverModule = blobConfig ? driverModules[blobConfig.store.driver] : undefined
+  const driverModule = blobConfig ? getDriverModule(blobConfig.store.driver, spec.name) : undefined
   if (driverModule) {
     imports.push(`import { createBlobStorage } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule("storage")))}`)
     imports.push(`import { createDriver } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule(driverModule)))}`)
@@ -208,9 +213,9 @@ function renderProviderEntry(
   return lines.filter(Boolean).join("\n")
 }
 
-export function renderBlobRuntimeModule(file: string, blobConfig: false | ResolvedBlobModuleOptions) {
+export function renderBlobRuntimeModule(file: string, blobConfig: false | ResolvedBlobModuleOptions, provider?: BlobProvider) {
   const stores = blobConfig ? Object.values(blobConfig.stores || { default: blobConfig.store }) : []
-  const selectedDriverModules = [...new Set(stores.map(store => driverModules[store.driver]))]
+  const selectedDriverModules = [...new Set(stores.map(store => getDriverModule(store.driver, provider)))]
   const driverImports = Object.fromEntries(selectedDriverModules.map((driverModule, index) => [driverModule, `createDriver${index}`]))
   const imports = [
     `import { ensureBlob } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule("ensure")))}`,
@@ -228,13 +233,14 @@ export function renderBlobRuntimeModule(file: string, blobConfig: false | Resolv
     imports.push(`import { ${runtimeStoreResolvers.join(", ")} } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule("config")))}`)
   }
 
-  const createDriverCases = Object.entries(driverModules).map(([driver, driverModule]) => {
-      const driverImport = driverImports[driverModule]
-      if (!driverImport) return undefined
-      const runtimeStoreResolver = getRuntimeBlobStoreResolver(driver)
-      const storeExpression = runtimeStoreResolver ? `${runtimeStoreResolver}(store, process.env)` : "store"
-      return `    case ${JSON.stringify(driver)}: return ${driverImport}(${storeExpression})`
-    }).filter(Boolean)
+  const createDriverCases = Object.keys(driverModules).map((driver) => {
+    const driverModule = getDriverModule(driver as keyof typeof driverModules, provider)
+    const driverImport = driverImports[driverModule]
+    if (!driverImport) return undefined
+    const runtimeStoreResolver = getRuntimeBlobStoreResolver(driver)
+    const storeExpression = runtimeStoreResolver ? `${runtimeStoreResolver}(store, process.env)` : "store"
+    return `    case ${JSON.stringify(driver)}: return ${driverImport}(${storeExpression})`
+  }).filter(Boolean)
 
   return [
     ...imports,
@@ -332,7 +338,7 @@ async function writeProviderEntries(rootDir: string, blob: BlobModuleOptions | R
     const runtimeModuleFile = resolve(generatedDir, `${spec.name}-runtime.mjs`)
     const blobConfig = resolveBlobConfig(blob, spec.hosting)
     await writeFile(entryFile, renderProviderEntry(spec, entryFile, userAppEntry, blobConfig), "utf8")
-    await writeFile(runtimeModuleFile, renderBlobRuntimeModule(runtimeModuleFile, blobConfig), "utf8")
+    await writeFile(runtimeModuleFile, renderBlobRuntimeModule(runtimeModuleFile, blobConfig, spec.name), "utf8")
     entryFiles[spec.name] = entryFile
     runtimeModuleFiles[spec.name] = runtimeModuleFile
   }
@@ -502,16 +508,22 @@ function hasCloudflareR2Store(blob: BlobModuleOptions | ResolvedBlobModuleOption
 }
 
 async function copyVercelBlobRuntimePackages(options: GenerateProviderOutputsOptions) {
-  if (!hasCloudflareR2Store(options.blob)) return
+  const packages = new Set<string>()
+  const resolved = resolveBlobConfig(options.blob, "vercel")
+  if (resolved !== false && Object.values(resolved.stores || { default: resolved.store }).some(store => store.driver === "vercel-blob")) {
+    packages.add("@vercel/blob")
+  }
+  if (hasCloudflareR2Store(options.blob)) {
+    packages.add("files-sdk")
+    packages.add("@aws-sdk/client-s3")
+    packages.add("@aws-sdk/lib-storage")
+    packages.add("@aws-sdk/s3-presigned-post")
+    packages.add("@aws-sdk/s3-request-presigner")
+  }
+  if (!packages.size) return
 
   await copyVercelFunctionRuntimePackages({
-    packages: [
-      { name: "files-sdk", resolveFrom: resolve(packageDir, "package.json") },
-      { name: "@aws-sdk/client-s3", resolveFrom: resolve(packageDir, "package.json") },
-      { name: "@aws-sdk/lib-storage", resolveFrom: resolve(packageDir, "package.json") },
-      { name: "@aws-sdk/s3-presigned-post", resolveFrom: resolve(packageDir, "package.json") },
-      { name: "@aws-sdk/s3-request-presigner", resolveFrom: resolve(packageDir, "package.json") },
-    ],
+    packages: [...packages].map(name => ({ name, resolveFrom: resolve(packageDir, "package.json") })),
     rootDir: options.rootDir,
     serverFunctionName: options.serverFunctionName,
   })

--- a/packages/blob/test/consumer-runtime.test.ts
+++ b/packages/blob/test/consumer-runtime.test.ts
@@ -1,0 +1,123 @@
+import { execFile } from "node:child_process"
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+import { describe, expect, it } from "vitest"
+
+import { probePrivateVercelFunction } from "./private-vercel-probe.ts"
+
+const execFileAsync = promisify(execFile)
+const packageRoot = resolve(import.meta.dirname, "..")
+const workspaceRoot = resolve(packageRoot, "../..")
+const fixtureRoot = resolve(packageRoot, "fixtures/private-vercel-consumer")
+
+async function run(command: string, args: string[], cwd: string) {
+  try {
+    return await execFileAsync(command, args, {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        CI: "true",
+        PNPM_CONFIG_CONFIRM_MODULES_PURGE: "false",
+      },
+    })
+  } catch (error) {
+    const failed = error as Error & { stderr?: string | Buffer, stdout?: string | Buffer }
+    throw new Error(
+      `${command} ${args.join(" ")} failed\n${failed.stdout || ""}${failed.stderr || ""}`,
+      { cause: error },
+    )
+  }
+}
+
+describe("private Vercel Blob consumer runtime", () => {
+  it(
+    "builds and executes without a consumer-owned files-sdk dependency",
+    { timeout: 120_000 },
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), "vitehub-blob-private-vercel-consumer-"))
+      const appDir = join(root, "app")
+      const packDir = join(root, "packs")
+      const stagedPackageRoot = join(root, "workspace/packages/blob")
+
+      try {
+        await Promise.all([
+          cp(fixtureRoot, appDir, { recursive: true }),
+          mkdir(packDir, { recursive: true }),
+          mkdir(stagedPackageRoot, { recursive: true }),
+        ])
+        const sourceManifest = JSON.parse(
+          await readFile(join(packageRoot, "package.json"), "utf8"),
+        ) as { devDependencies?: Record<string, string>, version: string }
+        delete sourceManifest.devDependencies
+        await Promise.all([
+          cp(join(packageRoot, "dist"), join(stagedPackageRoot, "dist"), { recursive: true }),
+          cp(join(workspaceRoot, "pnpm-workspace.yaml"), join(root, "workspace/pnpm-workspace.yaml")),
+          writeFile(
+            join(stagedPackageRoot, "package.json"),
+            `${JSON.stringify(sourceManifest, null, 2)}\n`,
+            "utf8",
+          ),
+        ])
+        await run("pnpm", ["--config.ignore-scripts=true", "pack", "--pack-destination", packDir], stagedPackageRoot)
+
+        const tarball = join(packDir, `vite-hub-blob-${sourceManifest.version}.tgz`)
+        const { stdout: packedManifestJson } = await run(
+          "tar",
+          ["-xOf", tarball, "package/package.json"],
+          appDir,
+        )
+        const packedManifest = JSON.parse(packedManifestJson) as {
+          peerDependencies?: Record<string, string>
+        }
+        const vite = packedManifest.peerDependencies?.vite
+        if (!vite) throw new Error("Packed @vite-hub/blob is missing its Vite peer range.")
+        await writeFile(
+          join(appDir, "package.json"),
+          `${JSON.stringify(
+            {
+              dependencies: {
+                "@vite-hub/blob": `file:${tarball}`,
+                vite,
+              },
+              name: "vitehub-blob-private-vercel-consumer",
+              packageManager: "pnpm@10.33.0",
+              private: true,
+              scripts: { build: "vite build" },
+              type: "module",
+            },
+            null,
+            2,
+          )}\n`,
+          "utf8",
+        )
+        await writeFile(
+          join(appDir, "pnpm-workspace.yaml"),
+          ["packages:", "  - .", "allowBuilds:", "  esbuild: true", ""].join("\n"),
+          "utf8",
+        )
+
+        await run("pnpm", ["install", "--prod", "--no-hoist", "--strict-peer-dependencies"], appDir)
+
+        const consumerManifest = JSON.parse(
+          await readFile(join(appDir, "package.json"), "utf8"),
+        ) as { dependencies: Record<string, string> }
+        expect(consumerManifest.dependencies).not.toHaveProperty("files-sdk")
+        expect(consumerManifest.dependencies).not.toHaveProperty("@vercel/blob")
+        await run("pnpm", ["run", "build"], appDir)
+
+        const runtimeModule = await readFile(
+          join(appDir, ".vitehub/blob/vercel-runtime.mjs"),
+          "utf8",
+        )
+        expect(runtimeModule).toContain("drivers/vercel-bundled")
+        await probePrivateVercelFunction(appDir)
+      } finally {
+        await rm(root, { force: true, recursive: true })
+      }
+    },
+  )
+})

--- a/packages/blob/test/optional-peer.test.ts
+++ b/packages/blob/test/optional-peer.test.ts
@@ -20,8 +20,8 @@ describe("optional peer imports", () => {
   it("keeps the bundled Vercel Blob driver statically reachable for selected Vercel outputs", async () => {
     const built = await readFile(new URL("../dist/drivers/vercel-bundled.js", import.meta.url), "utf8")
 
-    expect(built).toContain('from "files-sdk"')
-    expect(built).toContain('from "files-sdk/vercel-blob"')
-    expect(built).not.toContain('from "@vercel/blob"')
+    expect(built).not.toContain('from "files-sdk"')
+    expect(built).not.toContain('from "files-sdk/vercel-blob"')
+    expect(built).toContain('from "@vercel/blob"')
   })
 })

--- a/packages/blob/test/private-vercel-probe.ts
+++ b/packages/blob/test/private-vercel-probe.ts
@@ -1,0 +1,65 @@
+import { strict as assert } from "node:assert"
+import { createServer, get } from "node:http"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import type { IncomingMessage, Server, ServerResponse } from "node:http"
+
+async function listen(server: Server) {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  const address = server.address()
+  assert(address && typeof address === "object")
+  return address
+}
+
+async function close(server: Server) {
+  await new Promise<void>((resolve, reject) =>
+    server.close(error => error ? reject(error) : resolve()),
+  )
+}
+
+export async function probePrivateVercelFunction(appDir: string) {
+  const blobApi = createServer((_request, response) => {
+    response.setHeader("content-type", "application/json")
+    response.end(JSON.stringify({ blobs: [], hasMore: false }))
+  })
+  const blobApiAddress = await listen(blobApi)
+  const originalBlobApiUrl = process.env.VERCEL_BLOB_API_URL
+  process.env.VERCEL_BLOB_API_URL = `http://127.0.0.1:${blobApiAddress.port}`
+
+  const serverEntry = join(appDir, ".vercel/output/functions/__server.func/index.mjs")
+  const generated = await import(`${pathToFileURL(serverEntry).href}?t=${Date.now()}`) as {
+    default: (request: IncomingMessage, response: ServerResponse) => unknown
+  }
+  const server = createServer((request, response) => {
+    Promise.resolve(generated.default(request, response)).catch((error) => {
+      response.statusCode = 500
+      response.end(error instanceof Error ? error.stack : String(error))
+    })
+  })
+  const address = await listen(server)
+
+  try {
+    const result = await new Promise<{ body: string, status?: number }>((resolve, reject) => {
+      get(`http://127.0.0.1:${address.port}/api/stats`, (response) => {
+        const chunks: Buffer[] = []
+        response.on("data", chunk => chunks.push(chunk))
+        response.on("end", () => resolve({
+          body: Buffer.concat(chunks).toString("utf8"),
+          status: response.statusCode,
+        }))
+      }).once("error", reject)
+    })
+
+    assert.equal(result.status, 200, result.body)
+    assert.deepEqual(JSON.parse(result.body).blobs, [])
+  }
+  finally {
+    if (originalBlobApiUrl === undefined) delete process.env.VERCEL_BLOB_API_URL
+    else process.env.VERCEL_BLOB_API_URL = originalBlobApiUrl
+    await Promise.all([close(server), close(blobApi)])
+  }
+}

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -11,6 +11,7 @@ import { getProviderRuntimeModule, type ComposedProviderOutput } from "@vite-hub
 import { toSafeAppName } from "@vite-hub/internal/build/user-entry"
 
 import { normalizeBlobOptions } from "../src/config.ts"
+import { createBundledVercelBlobDriver } from "../src/drivers/vercel-bundled.ts"
 import { generateProviderOutputs, prepareProviderOutputs } from "../src/internal/vite-build.ts"
 
 const execFileAsync = promisify(execFile)
@@ -55,6 +56,8 @@ const vercelBlobMock = vi.hoisted(() => ({
 const filesSdkMock = vi.hoisted(() => ({
   minio: vi.fn((options: unknown) => ({ options, provider: "minio" })),
 }))
+
+vi.mock("@vercel/blob", () => vercelBlobMock)
 
 vi.mock("files-sdk", () => ({
   Files: class {
@@ -128,6 +131,23 @@ afterEach(() => {
 })
 
 describe("Vite provider outputs", () => {
+  it("maps Vercel missing-object errors to Blob misses", async () => {
+    const missing = new Error("Vercel Blob: The requested blob does not exist")
+    missing.name = "BlobNotFoundError"
+    vercelBlobMock.head.mockRejectedValueOnce(missing)
+    const driver = createBundledVercelBlobDriver({
+      access: "private",
+      driver: "vercel-blob",
+      token: "vercel_blob_rw_test",
+    })
+
+    await expect(driver.head("missing.txt")).resolves.toBeNull()
+
+    const missingStore = new Error("Vercel Blob: The requested store does not exist")
+    vercelBlobMock.head.mockRejectedValueOnce(missingStore)
+    await expect(driver.head("missing.txt")).rejects.toBe(missingStore)
+  })
+
   it("rejects malformed resolved Blob config before rendering provider entries", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-invalid-resolved-config-")
 
@@ -497,6 +517,34 @@ describe("Vite provider outputs", () => {
     await generateProviderOutputs({ blob: {}, clientOutDir: "dist/client", rootDir, serverFunctionName: "__blob.func" })
     expect(existsSync(staleFile)).toBe(false)
     await writeFile(runtimeProbe, runtimeProbeSource, "utf8")
+    await expect(execFileAsync(process.execPath, [runtimeProbe])).resolves.toMatchObject({ stderr: "", stdout: "" })
+  })
+
+  it("copies the private Vercel Blob runtime into isolated Vercel output", { timeout: 15_000 }, async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-vercel-blob-runtime-")
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await mkdir(join(rootDir, "dist", "client"), { recursive: true })
+    await writeFile(join(rootDir, "src", "server.ts"), "export default async () => new Response('ok')\n", "utf8")
+
+    await generateProviderOutputs({
+      blob: {
+        access: "private",
+        driver: "vercel-blob",
+        token: "vercel_blob_rw_test",
+      },
+      clientOutDir: "dist/client",
+      rootDir,
+      serverFunctionName: "__blob.func",
+    })
+
+    const runtimeModule = await readFile(join(rootDir, ".vitehub", "blob", "vercel-runtime.mjs"), "utf8")
+    expect(runtimeModule).toContain("drivers/vercel-bundled")
+
+    const serverEntry = join(rootDir, ".vercel", "output", "functions", "__blob.func", "index.mjs")
+    await expect(import(`${pathToFileURL(serverEntry).href}?t=${Date.now()}`)).resolves.toHaveProperty("default")
+
+    const runtimeProbe = join(dirname(serverEntry), "runtime-probe.mjs")
+    await writeFile(runtimeProbe, `await import("@vercel/blob")\n`, "utf8")
     await expect(execFileAsync(process.execPath, [runtimeProbe])).resolves.toMatchObject({ stderr: "", stdout: "" })
   })
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -601,6 +601,9 @@ importers:
       '@aws-sdk/s3-request-presigner':
         specifier: ^3.700.0
         version: 3.1088.0
+      '@vercel/blob':
+        specifier: catalog:storage
+        version: 2.6.1
       defu:
         specifier: catalog:unjs
         version: 6.1.7
@@ -933,12 +936,12 @@ importers:
 
   packages/queue:
     dependencies:
-      '@vite-hub/runtime':
-        specifier: workspace:*
-        version: link:../runtime
       '@vercel/queue':
         specifier: catalog:vercel
         version: 0.0.0-alpha.40
+      '@vite-hub/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       defu:
         specifier: catalog:unjs
         version: 6.1.7
@@ -1294,12 +1297,12 @@ importers:
       '@vercel/functions':
         specifier: catalog:vercel
         version: 3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1)
-      '@vite-hub/runtime':
-        specifier: workspace:*
-        version: link:../runtime
       '@vite-hub/database':
         specifier: workspace:*
         version: link:../database
+      '@vite-hub/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       '@workflow/builders':
         specifier: catalog:workflow
         version: 4.0.5(@opentelemetry/api@1.9.1)(@swc/helpers@0.5.23)(ws@8.21.1)
@@ -20027,7 +20030,7 @@ snapshots:
       structured-clone-es: 2.0.0
       tinyglobby: 0.2.17
       unconfig: 7.5.0
-      unstorage: 1.17.5(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@netlify/blobs@10.7.5)(@upstash/redis@1.38.0)(@vercel/blob@2.6.1)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.11.1)(uploadthing@7.7.4(express@5.2.1)(fastify@5.10.0)(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(tailwindcss@4.3.2))
+      unstorage: 1.17.5(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@netlify/blobs@10.7.5)(@upstash/redis@1.38.0)(@vercel/blob@2.6.1)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.11.1)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(tailwindcss@4.3.2))
       vue-virtual-scroller: 3.0.4(vue@3.5.40(typescript@6.0.3))
       ws: 8.21.1
     transitivePeerDependencies:
@@ -20090,7 +20093,7 @@ snapshots:
       publint: 0.3.21
       tinyglobby: 0.2.17
       unconfig: 7.5.0
-      unstorage: 1.17.5(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@netlify/blobs@10.7.5)(@upstash/redis@1.38.0)(@vercel/blob@2.6.1)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.11.1)(uploadthing@7.7.4(express@5.2.1)(fastify@5.10.0)(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(tailwindcss@4.3.2))
+      unstorage: 1.17.5(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@netlify/blobs@10.7.5)(@upstash/redis@1.38.0)(@vercel/blob@2.6.1)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.11.1)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(tailwindcss@4.3.2))
       vue-virtual-scroller: 3.0.4(vue@3.5.40(typescript@6.0.3))
       ws: 8.21.1
     transitivePeerDependencies:
@@ -29086,28 +29089,6 @@ snapshots:
       rolldown: 1.0.0-rc.16
     optional: true
 
-  unstorage@1.17.5(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@netlify/blobs@10.7.5)(@upstash/redis@1.38.0)(@vercel/blob@2.6.1)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.11.1)(uploadthing@7.7.4(express@5.2.1)(fastify@5.10.0)(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(tailwindcss@4.3.2)):
-    dependencies:
-      anymatch: 3.1.3
-      chokidar: 5.0.0
-      destr: 2.0.5
-      h3: 1.15.11
-      lru-cache: 11.5.2
-      node-fetch-native: 1.6.7
-      ofetch: 1.5.1
-      ufo: 1.6.4
-    optionalDependencies:
-      '@azure/identity': 4.13.1
-      '@azure/storage-blob': 12.31.0
-      '@netlify/blobs': 10.7.5
-      '@upstash/redis': 1.38.0
-      '@vercel/blob': 2.6.1
-      '@vercel/functions': 3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1)
-      aws4fetch: 1.0.20
-      db0: 0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1))
-      ioredis: 5.11.1
-      uploadthing: 7.7.4(express@5.2.1)(fastify@5.10.0)(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(tailwindcss@4.3.2)
-
   unstorage@1.17.5(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@netlify/blobs@10.7.5)(@upstash/redis@1.38.0)(@vercel/blob@2.6.1)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.11.1)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.2)):
     dependencies:
       anymatch: 3.1.3
@@ -29129,6 +29110,28 @@ snapshots:
       db0: 0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1))
       ioredis: 5.11.1
       uploadthing: 7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.2)
+
+  unstorage@1.17.5(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@netlify/blobs@10.7.5)(@upstash/redis@1.38.0)(@vercel/blob@2.6.1)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.11.1)(uploadthing@7.7.4(express@5.2.1)(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(tailwindcss@4.3.2)):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.11
+      lru-cache: 11.5.2
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.4
+    optionalDependencies:
+      '@azure/identity': 4.13.1
+      '@azure/storage-blob': 12.31.0
+      '@netlify/blobs': 10.7.5
+      '@upstash/redis': 1.38.0
+      '@vercel/blob': 2.6.1
+      '@vercel/functions': 3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1)
+      aws4fetch: 1.0.20
+      db0: 0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1))
+      ioredis: 5.11.1
+      uploadthing: 7.7.4(express@5.2.1)(fastify@5.10.0)(h3@2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22)))(tailwindcss@4.3.2)
 
   unstorage@2.0.0-alpha.7(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@netlify/blobs@10.7.5)(@upstash/redis@1.38.0)(@vercel/blob@2.6.1)(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.1))(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@libsql/client@0.17.4)(better-sqlite3@12.9.0)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1)))(ioredis@5.11.1)(lru-cache@11.5.2)(ofetch@1.5.1)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.2)):
     optionalDependencies:

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -306,12 +306,12 @@ async function resolveEsmSpecifiers(entries: Array<{ parent: string, specifier: 
   return JSON.parse(String(stdout)) as Array<{ error?: string, resolved?: string }>
 }
 
-async function assertVercelOwnerImportsResolveInside(
+async function assertVercelRuntimeImportsResolveInside(
   functionsRoot: string,
   sources: Record<string, string>,
   message: string,
 ) {
-  const ownerImports = Object.entries(sources).flatMap(([file, source]) =>
+  const runtimeImports = Object.entries(sources).flatMap(([file, source]) =>
     importSpecifierOccurrences(source)
       .filter(({ specifier }) => specifier.startsWith("@vite-hub/"))
       .map(occurrence => ({ file, ...occurrence })),
@@ -322,10 +322,10 @@ async function assertVercelOwnerImportsResolveInside(
     const importer = join(functionsRoot, occurrence.file)
     return { ...occurrence, functionDir, importer }
   })
-  const invalid = ownerImports
+  const invalid = runtimeImports
     .filter(entry => !("functionDir" in entry) || !("importer" in entry))
     .map(entry => ({ ...entry, reason: "importer is outside a Vercel function" }))
-  const contained = ownerImports.filter(
+  const contained = runtimeImports.filter(
     (entry): entry is typeof entry & { functionDir: string, importer: string } => "functionDir" in entry && "importer" in entry,
   )
   const resolutions = await resolveEsmSpecifiers(contained.map(entry => ({
@@ -425,10 +425,10 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
       const vercelOptionalImports = vercelImports.filter(({ specifier }) => isOptionalPackageSpecifier(specifier))
       expect(vercelOptionalImports, "Vercel functions must not ship opt-in packages").toEqual([])
 
-      await assertVercelOwnerImportsResolveInside(
+      await assertVercelRuntimeImportsResolveInside(
         vercelFunctionsRoot,
         vercelSources,
-        "Vercel owner imports must resolve inside their own function output",
+        "Vercel runtime imports must resolve inside their own function output",
       )
 
       const cloudflareExternalImports = Object.entries(cloudflareSources).flatMap(([file, source]) =>

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -127,15 +127,14 @@ describe("package manifest contracts", () => {
     }
   })
 
-  it("keeps blob adapter SDKs as optional peers", () => {
+  it("keeps the private Vercel Blob runtime owned by the blob package", () => {
     const manifest = readPackageManifest("blob")
 
-    for (const name of ["files-sdk"]) {
-      expect(manifest.dependencies?.[name], `${name} should not be installed with @vite-hub/blob by default`).toBeUndefined()
-      expect(manifest.peerDependencies?.[name], `${name} should be declared as an opt-in blob peer`).toEqual(expect.any(String))
-      expect(manifest.peerDependenciesMeta?.[name]?.optional, `${name} should be an optional blob peer`).toBe(true)
-      expect(manifest.devDependencies?.[name], `${name} should remain available for blob development and tests`).toEqual(expect.any(String))
-    }
+    expect(manifest.dependencies?.["files-sdk"]).toBeUndefined()
+    expect(manifest.peerDependencies?.["files-sdk"]).toEqual(expect.any(String))
+    expect(manifest.peerDependenciesMeta?.["files-sdk"]?.optional).toBe(true)
+    expect(manifest.devDependencies?.["files-sdk"]).toEqual(expect.any(String))
+    expect(manifest.dependencies?.["@vercel/blob"]).toEqual(expect.any(String))
   })
 })
 


### PR DESCRIPTION
Private Vercel Blob output selected the lazy optional-peer driver and externalized its implementation, so isolated functions omitted the runtime dependency even when `@vite-hub/blob` selected the store.

This makes `@vercel/blob` a Blob-owned runtime dependency, selects a direct Vercel driver only for Vercel output, and copies the SDK into the isolated function. `files-sdk` remains an optional peer for generic adapters, avoiding its incompatible optional `h3@^1` peer in normal Blob installs. The regression packs a clean consumer that installs only Blob and Vite with strict peer enforcement, builds the generated Vercel function, and executes `GET /api/stats` against a local Blob API while the existing optional-peer coverage preserves generic non-Vercel reachability.
