### PR TITLE
fix(deploy): upload native modules on Deno updates

### DIFF
--- a/packages/internal/src/build/deno-runtime-packages.ts
+++ b/packages/internal/src/build/deno-runtime-packages.ts
@@ -291,10 +291,10 @@ try {
   }
   await cp(sourceRoot, uploadRoot, { recursive: true })
 
-  const common = ["--org", organization, "--app", app]
+  const common = ["--allow-node-modules", "--org", organization, "--app", app]
   const deployment = await run(["deploy", ".", "--prod", ...common], uploadRoot)
   if (deployment.code !== 0) {
-    const creation = await run(["deploy", "create", ".", "--source", "local", "--do-not-use-detected-build-config", "--runtime-mode", "dynamic", "--allow-node-modules", "--entrypoint", "server/index.ts", "--working-directory", ".", "--region", region, ...common], uploadRoot)
+    const creation = await run(["deploy", "create", ".", "--source", "local", "--do-not-use-detected-build-config", "--runtime-mode", "dynamic", "--entrypoint", "server/index.ts", "--working-directory", ".", "--region", region, ...common], uploadRoot)
     if (creation.code !== 0) {
       throw new Error("deno deploy/create exited with " + (creation.signal || "code " + creation.code))
     }

--- a/packages/internal/test/deno-runtime-packages.test.ts
+++ b/packages/internal/test/deno-runtime-packages.test.ts
@@ -82,7 +82,7 @@ describe("Deno deployment output", () => {
       readFile(join(outputDir, "deno.json"), "utf8").then(JSON.parse),
     ).resolves.toMatchObject({ nodeModulesDir: "manual" })
     const deployRunner = await readFile(join(outputDir, "deploy.mjs"), "utf8")
-    for (const text of ["DENO_DEPLOY_ORG", '["deploy", "create"', "--do-not-use-detected-build-config", "--allow-node-modules", "server/index.ts", '["deploy", ".", "--prod"', 'const common = ["--org", organization, "--app", app]', "mkdtemp", "finally"]) expect(deployRunner).toContain(text)
+    for (const text of ["DENO_DEPLOY_ORG", '["deploy", "create"', "--do-not-use-detected-build-config", "--allow-node-modules", "server/index.ts", '["deploy", ".", "--prod"', 'const common = ["--allow-node-modules", "--org", organization, "--app", app]', "mkdtemp", "finally"]) expect(deployRunner).toContain(text)
   })
 
   it("uses the pnpm package from a bundle marker", async () => {
@@ -189,10 +189,9 @@ process.exit(process.env.VITEHUB_DENO_ALWAYS_FAIL === "1" || attempts === 0 ? 1 
       expect(invocations).toHaveLength(2)
       expect(invocations[0]!.args.slice(0, 2)).toEqual(["deploy", "."])
       expect(invocations[1]!.args.slice(0, 3)).toEqual(["deploy", "create", "."])
-      expect(invocations[0]!.args).not.toContain("--allow-node-modules")
-      expect(invocations[1]!.args).toContain("--allow-node-modules")
       for (const invocation of invocations) {
         expect(relative(root, invocation.cwd).startsWith("..")).toBe(true)
+        expect(invocation.args).toContain("--allow-node-modules")
         expect(invocation).toMatchObject({ entry: true, libvips: true, sharp: true })
         expect(existsSync(invocation.cwd)).toBe(false)
       }


### PR DESCRIPTION
Stacks on #747’s generated Deno runner. Keeps `--allow-node-modules` in the shared deploy arguments so an ordinary existing-app update uploads the staged `node_modules` tree just like the create path; without it, the external upload root fixes ignored `.output` files but silently drops Sharp’s native packages on subsequent deployments.

The generated-runner regression exercises both paths from a consumer whose `.gitignore` excludes `.output`, verifies the complete temporary stage includes the Linux x64 Sharp and libvips artifacts, and requires native-module upload semantics on update and create.
