### PR TITLE
feat(agent): trigger on GitHub pull request labels

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -262,6 +262,33 @@ export default defineAgent({
 
 The GitHub channel renders inline image artifacts as markdown in `reply` and `review` effects. It does not attach local files directly to GitHub comments.
 
+## Update GitHub pull request labels
+
+GitHub pull request channels support a `labels` delivery effect with `add`, `remove`, and `replace` actions. The channel always applies the effect to the pull request admitted by the current invocation; effect payloads cannot select another repository or pull request.
+
+```ts [server/agents/review.ts]
+import { defineAgent, defineCapability } from '@vite-hub/agent'
+import { github } from '@vite-hub/agent/channels'
+
+const reviewLifecycle = defineCapability({
+  id: 'review-lifecycle',
+  prepare(context) {
+    context.delivery.effect({
+      kind: 'labels',
+      payload: { action: 'add', labels: ['agent:working'] },
+    })
+  },
+})
+
+export default defineAgent({
+  capabilities: [reviewLifecycle],
+  channels: { github: github({ app: true, pullRequest: true }) },
+  driver: { run: () => 'Review complete.' },
+})
+```
+
+Use `add` or `remove` to preserve unrelated labels. `replace` sends the complete desired label set, including an empty array when the pull request should have no labels.
+
 GitHub Pull Request Context enrichment is bounded before it reaches the Agent Invocation Context. By default, `github({ pullRequest: true })` records up to 30 comments, 200 changed files, 12,000 pull request body characters, and 2,000 characters per comment body. Override those with `maxComments`, `maxFiles`, `maxBodyLength`, and `maxCommentBodyLength` on the `pullRequest` option. Rendered comments are labeled as untrusted user content, and failed metadata enrichment is recorded at `pullRequest.metadata.unavailable`.
 
 Use a labeled event when an Agent Invocation should start only after a trusted GitHub actor applies a specific label:

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -264,6 +264,27 @@ The GitHub channel renders inline image artifacts as markdown in `reply` and `re
 
 GitHub Pull Request Context enrichment is bounded before it reaches the Agent Invocation Context. By default, `github({ pullRequest: true })` records up to 30 comments, 200 changed files, 12,000 pull request body characters, and 2,000 characters per comment body. Override those with `maxComments`, `maxFiles`, `maxBodyLength`, and `maxCommentBodyLength` on the `pullRequest` option. Rendered comments are labeled as untrusted user content, and failed metadata enrichment is recorded at `pullRequest.metadata.unavailable`.
 
+Use a labeled event when an Agent Invocation should start only after a trusted GitHub actor applies a specific label:
+
+```ts [server/agents/triage.ts]
+export default defineAgent({
+  channels: {
+    github: github({
+      app: true,
+      pullRequest: {
+        labeled: {
+          label: 'agent:triage',
+          allowedSenders: [{ id: 583231, login: 'octocat' }],
+        },
+      },
+    }),
+  },
+  driver: { run: () => 'Triage this pull request.' },
+})
+```
+
+`allowedSenders` uses GitHub's stable numeric account ID for admission. An optional `login` is a case-insensitive assertion for reviewable configuration; a mismatch is rejected. Labeled events require a valid GitHub SHA-256 webhook signature. Admitted invocations include the label and sender, repository identity, GitHub App installation identity when present, delivery ID, and the exact base and head refs and SHAs in the Pull Request Context. Repeated deliveries share a delivery identity, while invocations for the same pull request head share an exact-head concurrency identity. The dev trigger also accepts a raw GitHub `pull_request` payload for local fixture replay and derives a deterministic development delivery ID from it.
+
 ## Next steps
 
 - Read [Triggers](/docs/agents/triggers) for `chat.message` and app-owned trigger consumers.

--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -308,7 +308,7 @@ function safeWorkspacePath(path: unknown): string | undefined {
 }
 
 function gitRemoteRef(ref: string): string {
-  return ref.startsWith("refs/") ? ref : `refs/heads/${ref}`
+  return ref.startsWith("refs/") || /^[0-9a-f]{40}$/i.test(ref) ? ref : `refs/heads/${ref}`
 }
 
 function gitRemoteBranchRef(ref: string): string {

--- a/packages/agent/src/capabilities/pull-request-context.ts
+++ b/packages/agent/src/capabilities/pull-request-context.ts
@@ -108,6 +108,7 @@ export interface PullRequestContextValue extends JsonObject {
     deliveryId?: string
     event?: string
     installationId?: number | string
+    label?: JsonObject & { name: string }
     sender?: PullRequestContextUser
   }
 }
@@ -394,8 +395,9 @@ function normalizedTrigger(value: unknown): PullRequestContextValue["trigger"] |
   const deliveryId = maybeString(value.deliveryId)
   const event = maybeString(value.event)
   const installationId = maybeContextValue(value.installationId)
+  const label = isRecord(value.label) ? maybeString(value.label.name) : undefined
   const sender = normalizedUser(value.sender)
-  if (!action && !actor && !args && !command && !comment && !deliveryId && !event && installationId === undefined && !sender) return
+  if (!action && !actor && !args && !command && !comment && !deliveryId && !event && installationId === undefined && !label && !sender) return
   return {
     ...(action ? { action } : {}),
     ...(actor ? { actor } : {}),
@@ -405,6 +407,7 @@ function normalizedTrigger(value: unknown): PullRequestContextValue["trigger"] |
     ...(deliveryId ? { deliveryId } : {}),
     ...(event ? { event } : {}),
     ...(installationId !== undefined ? { installationId } : {}),
+    ...(label ? { label: { name: label } } : {}),
     ...(sender ? { sender } : {}),
   }
 }

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -158,6 +158,43 @@ export type GitHubIssueCommentPayload = {
   sender?: { id?: unknown, login?: unknown, type?: unknown }
 }
 
+export type GitHubPullRequestLabeledPayload = {
+  action?: unknown
+  installation?: { id?: unknown }
+  label?: { name?: unknown }
+  number?: unknown
+  pull_request?: {
+    base?: { ref?: unknown, repo?: { full_name?: unknown } | null, sha?: unknown }
+    body?: unknown
+    html_url?: unknown
+    labels?: unknown
+    number?: unknown
+    head?: { ref?: unknown, repo?: { full_name?: unknown } | null, sha?: unknown }
+    title?: unknown
+    url?: unknown
+  }
+  repository?: {
+    full_name?: unknown
+    id?: unknown
+    name?: unknown
+    node_id?: unknown
+    owner?: { login?: unknown }
+  }
+  sender?: { id?: unknown, login?: unknown, node_id?: unknown, type?: unknown }
+}
+
+export interface GitHubSenderSelector {
+  id: number
+  login?: string
+}
+
+export interface GitHubSender {
+  id: number
+  login: string
+  nodeId?: string
+  type?: string
+}
+
 export interface GitHubPullRequestCommand {
   action: "created"
   actor: {
@@ -240,7 +277,9 @@ export interface GitHubPullRequestRunContext {
   }
   repository: {
     fullName: string
+    id?: number
     name: string
+    nodeId?: string
     owner: string
   }
   run: {
@@ -249,7 +288,10 @@ export interface GitHubPullRequestRunContext {
     runId: string
     threadId: string
   }
-  trigger: {
+  trigger: GitHubPullRequestCommentRunTrigger | GitHubPullRequestLabeledRunTrigger
+}
+
+export interface GitHubPullRequestCommentRunTrigger {
     action: GitHubPullRequestCommand["action"]
     actor: GitHubPullRequestCommand["actor"]
     args: string
@@ -271,7 +313,17 @@ export interface GitHubPullRequestRunContext {
       login?: string
       type?: string
     }
+}
+
+export interface GitHubPullRequestLabeledRunTrigger {
+  action: "labeled"
+  deliveryId: string
+  event: "pull_request"
+  installationId?: number
+  label: {
+    name: string
   }
+  sender: GitHubSender
 }
 
 export interface GitHubPullRequestReadInvocation {
@@ -319,10 +371,23 @@ export interface GitHubPullRequestCommentEventOptions<TRuntimeConfig extends Age
   threadId?: string
 }
 
+export interface GitHubPullRequestLabeledEventOptions {
+  allowedSenders: readonly GitHubSenderSelector[]
+  ignored?: (reason: string) => Response
+  label: string
+  origin?: string
+  sourceMount?: string
+}
+
+export interface GitHubPullRequestEventOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+  comment?: boolean | GitHubPullRequestCommentEventOptions<TRuntimeConfig>
+  labeled?: GitHubPullRequestLabeledEventOptions
+}
+
 export interface GitHubChannelOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>
   extends AgentChannelOptions<TRuntimeConfig> {
   app?: true | GitHubAppOptions<TRuntimeConfig>
-  pullRequest?: boolean | GitHubPullRequestCommentEventOptions<TRuntimeConfig>
+  pullRequest?: boolean | GitHubPullRequestCommentEventOptions<TRuntimeConfig> | GitHubPullRequestEventOptions<TRuntimeConfig>
 }
 
 export interface DiscordAdapterOptions {
@@ -567,6 +632,183 @@ function githubPullRequestCommandFromInput(input: unknown): GitHubPullRequestCom
   }
 }
 
+interface GitHubPullRequestLabeledEvent {
+  base: Required<GitHubPullRequestRefMetadata>
+  body?: string
+  deliveryId: string
+  head: Required<GitHubPullRequestRefMetadata>
+  htmlUrl: string
+  installationId?: number
+  label: string
+  labels?: string[]
+  number: number
+  pullRequestUrl: string
+  repository: {
+    fullName: string
+    id: number
+    name: string
+    nodeId?: string
+    owner: string
+  }
+  sender: GitHubSender
+  title?: string
+}
+
+function githubPositiveInteger(value: unknown): number | undefined {
+  const number = maybeNumber(value)
+  return number !== undefined && Number.isSafeInteger(number) && number > 0 ? number : undefined
+}
+
+function githubPullRequestLabeledFromInput(input: unknown): GitHubPullRequestLabeledEvent | undefined {
+  const payload = inputPayloadOrBody(input) as GitHubPullRequestLabeledPayload | undefined
+  const facts = inputGithubFacts(input)
+  if (!payload || maybeString(facts?.event) !== "pull_request" || payload.action !== "labeled") return
+  const pullRequest = payload.pull_request
+  const base = githubRefMetadata(pullRequest?.base)
+  const head = githubRefMetadata(pullRequest?.head)
+  const repository = maybeString(payload.repository?.full_name)
+  const repositoryId = githubPositiveInteger(payload.repository?.id)
+  const [owner, repo] = repository?.split("/") || []
+  const number = githubPositiveInteger(payload.number) ?? githubPositiveInteger(pullRequest?.number)
+  const senderId = githubPositiveInteger(payload.sender?.id)
+  const senderLogin = maybeString(payload.sender?.login)
+  const deliveryId = maybeString(facts?.deliveryId)
+  const installationId = githubPositiveInteger(facts?.installationId) ?? githubPositiveInteger(payload.installation?.id)
+  const label = maybeString(payload.label?.name)
+  const pullRequestUrl = maybeString(pullRequest?.url)
+  const htmlUrl = maybeString(pullRequest?.html_url)
+  if (
+    !base?.ref || !base.repo || !base.sha
+    || !head?.ref || !head.repo || !head.sha
+    || !repository || !repositoryId || !owner || !repo || !number
+    || !senderId || !senderLogin || !deliveryId || !label
+    || !pullRequestUrl || !htmlUrl
+  ) return
+  const labels = maybeStrings(Array.isArray(pullRequest?.labels)
+    ? pullRequest.labels.map(value => isRecord(value) ? maybeString(value.name) : undefined)
+    : undefined)
+  return {
+    base: { ref: base.ref, repo: base.repo, sha: base.sha },
+    ...(maybeString(pullRequest?.body) ? { body: maybeString(pullRequest?.body) } : {}),
+    deliveryId,
+    head: { ref: head.ref, repo: head.repo, sha: head.sha },
+    htmlUrl,
+    ...(installationId ? { installationId } : {}),
+    label,
+    ...(labels ? { labels } : {}),
+    number,
+    pullRequestUrl,
+    repository: {
+      fullName: repository,
+      id: repositoryId,
+      name: repo,
+      ...(maybeString(payload.repository?.node_id) ? { nodeId: maybeString(payload.repository?.node_id) } : {}),
+      owner,
+    },
+    sender: {
+      id: senderId,
+      login: senderLogin,
+      ...(maybeString(payload.sender?.node_id) ? { nodeId: maybeString(payload.sender?.node_id) } : {}),
+      ...(maybeString(payload.sender?.type) ? { type: maybeString(payload.sender?.type) } : {}),
+    },
+    ...(maybeString(pullRequest?.title) ? { title: maybeString(pullRequest?.title) } : {}),
+  }
+}
+
+function githubSenderAdmissionReason(
+  sender: GitHubSender,
+  allowedSenders: readonly GitHubSenderSelector[],
+): "sender_login_mismatch" | "sender_not_allowed" | undefined {
+  const matchingIds = allowedSenders.filter(allowed => allowed.id === sender.id)
+  if (!matchingIds.length) return "sender_not_allowed"
+  if (matchingIds.some(allowed => allowed.login === undefined || allowed.login.toLowerCase() === sender.login.toLowerCase())) return
+  return "sender_login_mismatch"
+}
+
+function githubWebhookVerified(input: unknown): boolean {
+  return isRecord(input) && isRecord(input.webhook) && input.webhook.signatureVerified === true
+}
+
+function githubAppHost<TRuntimeConfig extends AgentRuntimeConfig>(app: true | GitHubAppOptions<TRuntimeConfig> | undefined): string {
+  const apiBaseUrl = app && app !== true ? app.apiBaseUrl : undefined
+  if (!apiBaseUrl) return "github.com"
+  try {
+    const url = new URL(apiBaseUrl)
+    if ((url.protocol !== "https:" && url.protocol !== "http:") || !url.hostname) throw new TypeError()
+    return url.origin === "https://api.github.com" ? "github.com" : url.origin
+  }
+  catch {
+    throw new TypeError("[vitehub] GitHub App apiBaseUrl must be a valid HTTP URL.")
+  }
+}
+
+function githubPullRequestLabeledRunContext(
+  event: GitHubPullRequestLabeledEvent,
+  options: GitHubPullRequestLabeledEventOptions,
+  host: string,
+): GitHubPullRequestRunContext {
+  const executionKey = `github:${host}:repository:${event.repository.id}:pull:${event.number}:head:${event.head.sha}`
+  return {
+    pullRequest: {
+      apiUrl: event.pullRequestUrl,
+      base: event.base,
+      ...(event.body ? { body: event.body } : {}),
+      head: event.head,
+      htmlUrl: event.htmlUrl,
+      ...(event.labels ? { labels: event.labels } : {}),
+      number: event.number,
+      source: {
+        mount: options.sourceMount || event.repository.name,
+        ref: `refs/pull/${event.number}/head`,
+        repo: event.repository.fullName,
+      },
+      ...(event.title ? { title: event.title } : {}),
+    },
+    repository: event.repository,
+    run: {
+      messageId: event.deliveryId,
+      origin: options.origin || "github-pull-request-labeled",
+      runId: `github:${host}:delivery:${event.deliveryId}`,
+      threadId: executionKey,
+    },
+    trigger: {
+      action: "labeled",
+      deliveryId: event.deliveryId,
+      event: "pull_request",
+      ...(event.installationId ? { installationId: event.installationId } : {}),
+      label: { name: event.label },
+      sender: event.sender,
+    },
+  }
+}
+
+function githubSenderActor(sender: GitHubSender, host: string) {
+  return {
+    id: `github:${host}:${sender.id}`,
+    kind: "github",
+    label: `@${sender.login}`,
+    meta: {
+      github: sender,
+    },
+  }
+}
+
+function githubPullRequestLabeledInput(
+  event: GitHubPullRequestLabeledEvent,
+  pullRequest: GitHubPullRequestRunContext,
+  host: string,
+): AgentRunInput {
+  const actor = githubSenderActor(event.sender, host)
+  return {
+    context: {
+      actor,
+      invoker: actor,
+      pullRequest,
+    },
+    prompt: `Pull request #${event.number} was labeled ${event.label} by @${event.sender.login}.`,
+  }
+}
+
 async function githubPullRequestMetadata<TRuntimeConfig extends AgentRuntimeConfig>(
   app: true | GitHubAppOptions<TRuntimeConfig> | undefined,
   context: AgentCallbackContext<TRuntimeConfig>,
@@ -751,6 +993,9 @@ function githubCommandFromEffect<TRuntimeConfig extends AgentRuntimeConfig>(
   return githubCommandFromUnknown(effectPayload?.github)
     || githubCommandFromUnknown(effectMetadata?.github)
     || githubCommandFromUnknown(isRecord(context.input.context) ? context.input.context.github : undefined)
+    || githubCommandFromRunContext(githubPullRequestRunContextFromUnknown(
+      isRecord(context.input.context) ? context.input.context.pullRequest : undefined,
+    ))
 }
 
 async function resolveEffectOption<T, TRuntimeConfig extends AgentRuntimeConfig>(
@@ -1452,7 +1697,7 @@ function githubPullRequestEffects<TRuntimeConfig extends AgentRuntimeConfig = Ag
   return {
     async reaction(context) {
       const command = githubCommandFromEffect(context)
-      if (!command) return
+      if (!command?.commentId) return
       const fetcher = options.fetch || fetch
       const token = await resolveEffectOption(options.token, context)
       const url = `${options.apiBaseUrl || "https://api.github.com"}/repos/${command.owner}/${command.repo}/issues/comments/${command.commentId}/reactions`
@@ -1493,7 +1738,7 @@ function githubPullRequestEffects<TRuntimeConfig extends AgentRuntimeConfig = Ag
     },
     async update(context) {
       const command = githubCommandFromEffect(context)
-      if (!command) return
+      if (!command?.commentId) return
       const fetcher = options.fetch || fetch
       const token = await resolveEffectOption(options.token, context)
       const headers = githubApiHeaders(token, options.userAgent)
@@ -1547,6 +1792,7 @@ function githubPullRequestEffects<TRuntimeConfig extends AgentRuntimeConfig = Ag
 function githubWebhookDefaults<TRuntimeConfig extends AgentRuntimeConfig>(
   webhooks: AgentChannelDefinition<TRuntimeConfig>["webhooks"],
   app?: true | GitHubAppOptions<TRuntimeConfig>,
+  requireGitHubSignature = false,
 ): AgentChannelDefinition<TRuntimeConfig>["webhooks"] {
   const defaults = {
     secretHeader: "x-hub-signature-256",
@@ -1555,7 +1801,13 @@ function githubWebhookDefaults<TRuntimeConfig extends AgentRuntimeConfig>(
   }
   if (webhooks === undefined || webhooks === true) return defaults
   if (webhooks === false) return false
-  const apply = (webhook: AgentChannelWebhookRegistrationDefinition<TRuntimeConfig>) => ({ ...defaults, ...webhook })
+  const apply = (webhook: AgentChannelWebhookRegistrationDefinition<TRuntimeConfig>) => ({
+    ...defaults,
+    ...webhook,
+    ...(requireGitHubSignature
+      ? { secretHeader: "x-hub-signature-256", signature: "github-sha256" as const }
+      : {}),
+  })
   return Array.isArray(webhooks) ? webhooks.map(apply) : apply(webhooks)
 }
 
@@ -1650,16 +1902,41 @@ function githubPullRequestRunContextFromInput(input: unknown): GitHubPullRequest
   return githubPullRequestRunContextFromUnknown(input)
 }
 
-function githubCommandFromRunContext(value: GitHubPullRequestRunContext): GitHubPullRequestCommand | undefined {
+function githubCommandFromRunContext(value: GitHubPullRequestRunContext | undefined): GitHubPullRequestCommand | undefined {
+  if (!value) return
   const repository = maybeString(value.repository.fullName)
   const [fallbackOwner, fallbackRepo] = repository?.split("/") || []
   const owner = maybeString(value.repository.owner) || fallbackOwner
   const repo = maybeString(value.repository.name) || fallbackRepo
   const issueNumber = maybeNumber(value.pullRequest.number)
-  const commentId = maybeNumber(value.trigger.comment.id)
   const pullRequestUrl = maybeString(value.pullRequest.apiUrl)
+  if (!repository || !owner || !repo || !issueNumber || !pullRequestUrl) return
+  if (value.trigger.event === "pull_request") {
+    const login = maybeString(value.trigger.sender.login)
+    if (!login) return
+    return {
+      action: "created",
+      actor: {
+        id: value.trigger.sender.id,
+        login,
+        ...(value.trigger.sender.type ? { type: value.trigger.sender.type } : {}),
+      },
+      args: "",
+      body: "",
+      command: "",
+      commentId: 0,
+      deliveryId: value.trigger.deliveryId,
+      ...(value.trigger.installationId ? { installationId: value.trigger.installationId } : {}),
+      issueNumber,
+      owner,
+      pullRequestUrl,
+      repo,
+      repository,
+    }
+  }
+  const commentId = maybeNumber(value.trigger.comment.id)
   const login = maybeString(value.trigger.actor.login)
-  if (!repository || !owner || !repo || !issueNumber || !commentId || !pullRequestUrl || !login) return
+  if (!commentId || !login) return
   return {
     action: value.trigger.action,
     actor: value.trigger.actor,
@@ -1679,6 +1956,10 @@ function githubCommandFromRunContext(value: GitHubPullRequestRunContext): GitHub
 }
 
 function githubPullRequestDevPrompt(input: Record<string, unknown>, pullRequest: GitHubPullRequestRunContext): string {
+  if (pullRequest.trigger.event === "pull_request") {
+    return maybeString(input.prompt)
+      || `Pull request #${pullRequest.pullRequest.number} was labeled ${pullRequest.trigger.label.name} by @${pullRequest.trigger.sender.login}.`
+  }
   const command = maybeString(pullRequest.trigger.command)
   const args = maybeString(pullRequest.trigger.args)
   return maybeString(input.prompt) || maybeString(pullRequest.trigger.comment.body) || (command && args ? `${command} ${args}` : command) || "/review"
@@ -1691,15 +1972,117 @@ function githubDevPayload(input: unknown): GitHubIssueCommentPayload | undefined
   return input as GitHubIssueCommentPayload
 }
 
+function githubPullRequestDevInput(input: unknown): unknown {
+  if (!isRecord(input) || !isRecord(input.pull_request)) return input
+  const repositoryId = githubPositiveInteger(isRecord(input.repository) ? input.repository.id : undefined)
+  const number = githubPositiveInteger(input.number) ?? githubPositiveInteger(input.pull_request.number)
+  const head = isRecord(input.pull_request.head) ? maybeString(input.pull_request.head.sha) : undefined
+  const label = isRecord(input.label) ? maybeString(input.label.name) : undefined
+  const deliveryId = `dev:${repositoryId || "repository"}:${number || "pull"}:${head || "head"}:${label || "label"}`
+  return {
+    ...input,
+    github: {
+      deliveryId,
+      event: "pull_request",
+      ...(isRecord(input.installation) && githubPositiveInteger(input.installation.id)
+        ? { installationId: githubPositiveInteger(input.installation.id) }
+        : {}),
+    },
+    payload: input,
+  }
+}
+
+function githubPullRequestEventOptions<TRuntimeConfig extends AgentRuntimeConfig>(
+  pullRequest: boolean | GitHubPullRequestCommentEventOptions<TRuntimeConfig> | GitHubPullRequestEventOptions<TRuntimeConfig> | undefined,
+): {
+  comment?: GitHubPullRequestCommentEventOptions<TRuntimeConfig>
+  labeled?: GitHubPullRequestLabeledEventOptions
+} {
+  if (!pullRequest) return {}
+  if (pullRequest === true) return { comment: {} }
+  const grouped = pullRequest as GitHubPullRequestEventOptions<TRuntimeConfig>
+  if (grouped.comment !== undefined || grouped.labeled !== undefined) {
+    const comment = grouped.comment
+    return {
+      ...(comment ? { comment: comment === true ? {} : comment } : {}),
+      ...(grouped.labeled ? { labeled: grouped.labeled } : {}),
+    }
+  }
+  return { comment: pullRequest as GitHubPullRequestCommentEventOptions<TRuntimeConfig> }
+}
+
+function validateGitHubPullRequestLabeledOptions(options: GitHubPullRequestLabeledEventOptions): void {
+  if (!options.label.trim()) {
+    throw new TypeError("[vitehub] github({ pullRequest: { labeled } }) requires a non-empty label.")
+  }
+  if (!Array.isArray(options.allowedSenders) || !options.allowedSenders.length) {
+    throw new TypeError("[vitehub] github({ pullRequest: { labeled } }) requires at least one allowed sender.")
+  }
+  for (const sender of options.allowedSenders) {
+    if (!Number.isSafeInteger(sender.id) || sender.id <= 0) {
+      throw new TypeError("[vitehub] GitHub allowed sender ids must be positive safe integers.")
+    }
+    if (sender.login !== undefined && !sender.login.trim()) {
+      throw new TypeError("[vitehub] GitHub allowed sender logins must be non-empty when provided.")
+    }
+  }
+}
+
+function githubPullRequestLabeledInvocation<TRuntimeConfig extends AgentRuntimeConfig>(
+  input: unknown,
+  options: GitHubPullRequestLabeledEventOptions,
+  app: true | GitHubAppOptions<TRuntimeConfig> | undefined,
+  channelId: string,
+  requireVerified: boolean,
+  controls: Pick<AgentRunInput, "abortSignal" | "timeout"> = {},
+): AgentTriggerInvokeResult {
+  if (requireVerified && !githubWebhookVerified(input)) {
+    return options.ignored?.("unverified") || Response.json({ accepted: false, ok: true, reason: "unverified" }, { status: 401 })
+  }
+  const payload = inputPayloadOrBody(input) as GitHubPullRequestLabeledPayload | undefined
+  if (!payload) return options.ignored?.("missing_payload") || ignored("missing_payload")
+  if (payload.action !== "labeled") return options.ignored?.("not_labeled") || ignored("not_labeled")
+  const event = githubPullRequestLabeledFromInput(input)
+  if (!event) return options.ignored?.("invalid_payload") || ignored("invalid_payload")
+  if (event.label !== options.label) return options.ignored?.("wrong_label") || ignored("wrong_label")
+  const senderAdmissionReason = githubSenderAdmissionReason(event.sender, options.allowedSenders)
+  if (senderAdmissionReason) {
+    return options.ignored?.(senderAdmissionReason) || ignored(senderAdmissionReason)
+  }
+  const host = githubAppHost(app)
+  const pullRequest = githubPullRequestLabeledRunContext(event, options, host)
+  return {
+    input: {
+      ...githubPullRequestLabeledInput(event, pullRequest, host),
+      ...controls,
+    },
+    run: {
+      ...pullRequest.run,
+      channelId,
+    },
+    webhook: {
+      concurrencyKey: pullRequest.run.threadId,
+      deliveryId: event.deliveryId,
+    },
+  }
+}
+
 function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
-  pullRequest: boolean | GitHubPullRequestCommentEventOptions<TRuntimeConfig> | undefined,
+  pullRequest: boolean | GitHubPullRequestCommentEventOptions<TRuntimeConfig> | GitHubPullRequestEventOptions<TRuntimeConfig> | undefined,
   app?: true | GitHubAppOptions<TRuntimeConfig>,
 ): AgentChannelDefinition<TRuntimeConfig>["triggers"] {
-  if (!pullRequest) return undefined
-  const options = pullRequest === true ? {} : pullRequest
+  const { comment: options, labeled } = githubPullRequestEventOptions(pullRequest)
+  if (!options && !labeled) return undefined
+  if (labeled) validateGitHubPullRequestLabeledOptions(labeled)
   return {
     webhook: {
       async invoke(context, input): Promise<AgentTriggerInvokeResult> {
+        if (maybeString(inputGithubFacts(input)?.event) === "pull_request") {
+          return labeled
+            ? githubPullRequestLabeledInvocation(input, labeled, app, context.trigger.channelId, true)
+            : ignored("not_configured")
+        }
+        if (!options) return labeled?.ignored?.("wrong_event") || ignored("wrong_event")
         const payload = inputPayloadOrBody(input)
         const command = githubPullRequestCommandFromInput(isRecord(input) ? { ...input, payload } : { payload })
         if (!payload && !command) return options.ignored?.("missing_payload") || ignored("missing_payload")
@@ -1725,13 +2108,64 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
       webhooks: [],
       async invoke(context, input): Promise<AgentTriggerInvokeResult> {
         const inputRecord = isRecord(input) ? input : {}
-        const finishEffects = githubPullRequestCommentFinishEffects(options)
+        const devInput = githubPullRequestDevInput(input)
         const existingPullRequest = githubPullRequestRunContextFromInput(input)
         const controls = {
           ...(inputRecord.abortSignal ? { abortSignal: inputRecord.abortSignal as AbortSignal } : {}),
           ...(typeof inputRecord.timeout === "number" ? { timeout: inputRecord.timeout } : {}),
         }
         if (existingPullRequest) {
+          if (existingPullRequest.trigger.event === "pull_request") {
+            if (!labeled) return ignored("not_configured")
+            if (existingPullRequest.trigger.action !== "labeled") {
+              return labeled.ignored?.("not_labeled") || ignored("not_labeled")
+            }
+            const sender = existingPullRequest.trigger.sender
+            if (existingPullRequest.trigger.label.name !== labeled.label) {
+              return labeled.ignored?.("wrong_label") || ignored("wrong_label")
+            }
+            const senderAdmissionReason = githubSenderAdmissionReason(sender, labeled.allowedSenders)
+            if (senderAdmissionReason) {
+              return labeled.ignored?.(senderAdmissionReason) || ignored(senderAdmissionReason)
+            }
+            const repositoryId = githubPositiveInteger(existingPullRequest.repository.id)
+            const headSha = maybeString(existingPullRequest.pullRequest.head?.sha)
+            if (!repositoryId || !headSha) return labeled.ignored?.("invalid_payload") || ignored("invalid_payload")
+            const host = githubAppHost(app)
+            const actor = githubSenderActor(sender, host)
+            const executionKey = `github:${host}:repository:${repositoryId}:pull:${existingPullRequest.pullRequest.number}:head:${headSha}`
+            const run = {
+              messageId: existingPullRequest.trigger.deliveryId,
+              origin: labeled.origin || "github-pull-request-labeled",
+              runId: `github:${host}:delivery:${existingPullRequest.trigger.deliveryId}`,
+              threadId: executionKey,
+            }
+            const canonicalPullRequest = {
+              ...existingPullRequest,
+              run,
+            }
+            return {
+              input: {
+                ...controls,
+                context: {
+                  actor,
+                  invoker: actor,
+                  pullRequest: canonicalPullRequest,
+                },
+                prompt: githubPullRequestDevPrompt(inputRecord, canonicalPullRequest),
+              },
+              run: {
+                ...run,
+                channelId: context.trigger.channelId,
+              },
+              webhook: {
+                concurrencyKey: executionKey,
+                deliveryId: existingPullRequest.trigger.deliveryId,
+              },
+            }
+          }
+          if (!options) return labeled?.ignored?.("wrong_event") || ignored("wrong_event")
+          const finishEffects = githubPullRequestCommentFinishEffects(options)
           const command = githubCommandFromUnknown(inputRecord.github) || githubCommandFromRunContext(existingPullRequest)
           if (command && declaredInputCommand(context, command.command) === false) return options.ignored?.("not_command") || ignored("not_command")
           return {
@@ -1751,6 +2185,13 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
           }
         }
 
+        if (maybeString(inputGithubFacts(devInput)?.event) === "pull_request") {
+          return labeled
+            ? githubPullRequestLabeledInvocation(devInput, labeled, app, context.trigger.channelId, false, controls)
+            : ignored("not_configured")
+        }
+        if (!options) return labeled?.ignored?.("wrong_event") || ignored("wrong_event")
+
         const payload = githubDevPayload(input)
         const command = githubPullRequestCommandFromInput(isRecord(input) ? { ...input, payload } : { payload })
         if (!payload && !command) return options.ignored?.("missing_payload") || ignored("missing_payload")
@@ -1761,6 +2202,7 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
           ...options,
           threadId: options.threadId || maybeString(payload?.issue?.pull_request?.html_url) || maybeString(payload?.issue?.html_url) || command.pullRequestUrl,
         }, payload, metadata)
+        const finishEffects = githubPullRequestCommentFinishEffects(options)
         return {
           ...(finishEffects ? { delivery: { finishEffects } } : {}),
           input: {
@@ -1816,6 +2258,8 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
   options: GitHubChannelOptions<TRuntimeConfig> = {},
 ): AgentChannelDefinition<TRuntimeConfig> {
   const { app: appOptions, pullRequest, ...channelOptions } = options
+  const requiresGitHubSignature = Boolean(githubPullRequestEventOptions(pullRequest).labeled)
+  if (requiresGitHubSignature) githubAppHost(appOptions)
   const app = githubAppOptions(appOptions)
   const appEffects: AgentChannelDeliveryEffects<TRuntimeConfig> | undefined = appOptions
     ? githubPullRequestEffects<TRuntimeConfig>({
@@ -1835,7 +2279,7 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
       ...githubEventTriggers(pullRequest, appOptions),
       ...options.triggers,
     },
-    webhooks: githubWebhookDefaults(options.webhooks, appOptions),
+    webhooks: githubWebhookDefaults(options.webhooks, appOptions, requiresGitHubSignature),
   })
 }
 

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -765,7 +765,7 @@ function githubPullRequestLabeledRunContext(
       source: {
         mount: options.sourceMount || event.repository.name,
         ref: event.head.sha,
-        repo: event.repository.fullName,
+        repo: event.head.repo,
       },
       ...(event.title ? { title: event.title } : {}),
     },
@@ -2131,7 +2131,7 @@ function githubPullRequestLabeledInvocation<TRuntimeConfig extends AgentRuntimeC
   if (payload.action !== "labeled") return options.ignored?.("not_labeled") || ignored("not_labeled")
   const event = githubPullRequestLabeledFromInput(input)
   if (!event) return options.ignored?.("invalid_payload") || ignored("invalid_payload")
-  if (event.label !== options.label) return options.ignored?.("wrong_label") || ignored("wrong_label")
+  if (event.label.toLowerCase() !== options.label.toLowerCase()) return options.ignored?.("wrong_label") || ignored("wrong_label")
   const senderAdmissionReason = githubSenderAdmissionReason(event.sender, options.allowedSenders)
   if (senderAdmissionReason) {
     return options.ignored?.(senderAdmissionReason) || ignored(senderAdmissionReason)
@@ -2208,7 +2208,7 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
               return labeled.ignored?.("not_labeled") || ignored("not_labeled")
             }
             const sender = existingPullRequest.trigger.sender
-            if (existingPullRequest.trigger.label.name !== labeled.label) {
+            if (existingPullRequest.trigger.label.name.toLowerCase() !== labeled.label.toLowerCase()) {
               return labeled.ignored?.("wrong_label") || ignored("wrong_label")
             }
             const senderAdmissionReason = githubSenderAdmissionReason(sender, labeled.allowedSenders)

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -24,6 +24,7 @@ import type {
   AgentChannelDeliveryEffectContext,
   AgentChannelDeliveryEffectIntent,
   AgentChannelDeliveryEffects,
+  AgentChannelDeliveryLabelsPayload,
   AgentChannelDeliveryFinishEffect,
   AgentChannelDeliveryFinishEffectContext,
   AgentChannelWebhookRegistrationDefinition,
@@ -65,6 +66,7 @@ export type {
   AgentChannelDeliveryEffectPayload,
   AgentChannelDeliveryEffectKind,
   AgentChannelDeliveryEffects,
+  AgentChannelDeliveryLabelsPayload,
   AgentChannelDeliveryFinishEffect,
   AgentChannelDeliveryFinishEffectCallback,
   AgentChannelDeliveryFinishEffectResult,
@@ -194,6 +196,8 @@ export interface GitHubSender {
   nodeId?: string
   type?: string
 }
+
+export type GitHubPullRequestLabelsEffectPayload = AgentChannelDeliveryLabelsPayload
 
 export interface GitHubPullRequestCommand {
   action: "created"
@@ -998,6 +1002,42 @@ function githubCommandFromEffect<TRuntimeConfig extends AgentRuntimeConfig>(
     ))
 }
 
+interface GitHubPullRequestEffectTarget {
+  installationId?: number
+  issueNumber: number
+  owner: string
+  repo: string
+}
+
+function githubPullRequestTargetFromEffect<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
+): GitHubPullRequestEffectTarget | undefined {
+  const inputContext = isRecord(context.input.context) ? context.input.context : undefined
+  const command = githubCommandFromUnknown(inputContext?.github)
+  if (command) {
+    return {
+      ...(command.installationId ? { installationId: command.installationId } : {}),
+      issueNumber: command.issueNumber,
+      owner: command.owner,
+      repo: command.repo,
+    }
+  }
+  const pullRequest = githubPullRequestRunContextFromUnknown(context.input.context)
+  if (!pullRequest) return
+  const [fallbackOwner, fallbackRepo] = pullRequest.repository.fullName.split("/")
+  const owner = maybeString(pullRequest.repository.owner) || fallbackOwner
+  const repo = maybeString(pullRequest.repository.name) || fallbackRepo
+  const issueNumber = githubPositiveInteger(pullRequest.pullRequest.number)
+  const installationId = githubPositiveInteger(pullRequest.trigger.installationId)
+  if (!owner || !repo || !issueNumber) return
+  return {
+    ...(installationId ? { installationId } : {}),
+    issueNumber,
+    owner,
+    repo,
+  }
+}
+
 async function resolveEffectOption<T, TRuntimeConfig extends AgentRuntimeConfig>(
   value: MaybeResolvable<T, AgentChannelDeliveryEffectContext<TRuntimeConfig>>,
   context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
@@ -1128,7 +1168,11 @@ async function githubAppInstallationToken<TRuntimeConfig extends AgentRuntimeCon
   const env = await githubEnv(context)
   const appId = requiredString(await githubAppSetting(options, env, "appId", "appId", context), "appId")
   const installationId = installation
-    ?? ("effect" in context ? githubCommandFromEffect(context as AgentChannelDeliveryEffectContext<TRuntimeConfig>)?.installationId : undefined)
+    ?? ("effect" in context
+      ? context.effect.kind === "labels"
+        ? githubPullRequestTargetFromEffect(context)?.installationId
+        : githubCommandFromEffect(context)?.installationId
+      : undefined)
     ?? requiredNumber(await githubAppSetting(options, env, "installationId", "appInstallationId", context), "installationId")
   const apiBaseUrl = options.apiBaseUrl || "https://api.github.com"
   const cacheKey = `${apiBaseUrl}:${appId}:${installationId}`
@@ -1664,6 +1708,17 @@ function statusPayload<TRuntimeConfig extends AgentRuntimeConfig>(
   }
 }
 
+function githubLabelsEffectPayload(value: unknown): GitHubPullRequestLabelsEffectPayload {
+  if (!isRecord(value) || (value.action !== "add" && value.action !== "remove" && value.action !== "replace") || !Array.isArray(value.labels)) {
+    throw new TypeError("[vitehub] GitHub labels effect requires an add, remove, or replace action and a labels array.")
+  }
+  const labels = [...new Set(value.labels.map(label => typeof label === "string" ? label : ""))]
+  if (labels.some(label => !label.trim())) {
+    throw new TypeError("[vitehub] GitHub labels effect labels must be non-empty strings.")
+  }
+  return { action: value.action, labels }
+}
+
 async function githubPullRequestSha(
   fetcher: typeof fetch,
   command: GitHubPullRequestCommand,
@@ -1695,6 +1750,35 @@ function githubPullRequestEffects<TRuntimeConfig extends AgentRuntimeConfig = Ag
   options: GitHubPullRequestEffectsOptions<TRuntimeConfig>,
 ): AgentChannelDeliveryEffects<TRuntimeConfig> {
   return {
+    async labels(context) {
+      const target = githubPullRequestTargetFromEffect(context)
+      if (!target) return
+      const payload = githubLabelsEffectPayload(context.effect.payload)
+      if (payload.action !== "replace" && !payload.labels.length) return
+      const fetcher = options.fetch || fetch
+      const token = await resolveEffectOption(options.token, context)
+      const headers = githubApiHeaders(token, options.userAgent)
+      const url = `${options.apiBaseUrl || "https://api.github.com"}/repos/${target.owner}/${target.repo}/issues/${target.issueNumber}/labels`
+      if (payload.action === "remove") {
+        for (const label of payload.labels) {
+          const response = await fetcher(`${url}/${encodeURIComponent(label)}`, {
+            headers,
+            method: "DELETE",
+          })
+          const body = response.status === 404 ? await response.json().catch(() => undefined) : undefined
+          const missingLabel = isRecord(body) && body.message === "Label does not exist"
+          if (!response.ok && !missingLabel) {
+            throw new Error(`[vitehub] GitHub delivery effect failed with ${response.status}.`)
+          }
+        }
+        return
+      }
+      await githubApi(fetcher, url, {
+        body: JSON.stringify({ labels: payload.labels }),
+        headers,
+        method: payload.action === "add" ? "POST" : "PUT",
+      })
+    },
     async reaction(context) {
       const command = githubCommandFromEffect(context)
       if (!command?.commentId) return

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -213,6 +213,7 @@ export interface GitHubPullRequestCommand {
   commentId: number
   commentNodeId?: string
   deliveryId?: string
+  headSha?: string
   installationId?: number
   issueNumber: number
   owner: string
@@ -763,7 +764,7 @@ function githubPullRequestLabeledRunContext(
       number: event.number,
       source: {
         mount: options.sourceMount || event.repository.name,
-        ref: `refs/pull/${event.number}/head`,
+        ref: event.head.sha,
         repo: event.repository.fullName,
       },
       ...(event.title ? { title: event.title } : {}),
@@ -980,6 +981,7 @@ function githubCommandFromUnknown(value: unknown): GitHubPullRequestCommand | un
     commentId,
     ...(maybeString(value.commentNodeId) ? { commentNodeId: maybeString(value.commentNodeId) } : {}),
     ...(maybeString(value.deliveryId) ? { deliveryId: maybeString(value.deliveryId) } : {}),
+    ...(maybeString(value.headSha) ? { headSha: maybeString(value.headSha) } : {}),
     ...(maybeNumber(value.installationId) ? { installationId: maybeNumber(value.installationId) } : {}),
     issueNumber,
     owner,
@@ -1861,7 +1863,7 @@ function githubPullRequestEffects<TRuntimeConfig extends AgentRuntimeConfig = Ag
       const token = await resolveEffectOption(options.token, context)
       const headers = githubApiHeaders(token, options.userAgent)
       const payload = statusPayload(context, options.statusContext || "ViteHub Agent")
-      const sha = maybeString(payload.sha) || await githubPullRequestHeadSha(fetcher, command, headers)
+      const sha = maybeString(payload.sha) || command.headSha || await githubPullRequestHeadSha(fetcher, command, headers)
       if (!sha) return
       const url = `${options.apiBaseUrl || "https://api.github.com"}/repos/${command.owner}/${command.repo}/statuses/${sha}`
       await githubApi(fetcher, url, {
@@ -2010,6 +2012,7 @@ function githubCommandFromRunContext(value: GitHubPullRequestRunContext | undefi
       command: "",
       commentId: 0,
       deliveryId: value.trigger.deliveryId,
+      ...(value.pullRequest.head?.sha ? { headSha: value.pullRequest.head.sha } : {}),
       ...(value.trigger.installationId ? { installationId: value.trigger.installationId } : {}),
       issueNumber,
       owner,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -203,6 +203,7 @@ export type {
   AgentChannelDeliveryEffectPayload,
   AgentChannelDeliveryEffectKind,
   AgentChannelDeliveryEffects,
+  AgentChannelDeliveryLabelsPayload,
   AgentChannelDeliveryFinishEffectCallback,
   AgentChannelDeliveryFinishEffectResult,
   AgentChannelDeliveryFinishEffectContext,

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -493,7 +493,11 @@ function githubInstallationId(payload: unknown): number | undefined {
   return typeof id === "number" ? id : undefined
 }
 
-async function createAgentWebhookTriggerInput(request: Request, registration: AgentWebhookRegistrationDefinition): Promise<Record<string, unknown>> {
+async function createAgentWebhookTriggerInput(
+  request: Request,
+  registration: AgentWebhookRegistrationDefinition,
+  verified: boolean,
+): Promise<Record<string, unknown>> {
   const body = await request.clone().text()
   const payload = parseWebhookPayload(body)
   const headers = requestHeaders(request)
@@ -502,6 +506,7 @@ async function createAgentWebhookTriggerInput(request: Request, registration: Ag
     ...(registration.id ? { id: registration.id } : {}),
     ...(registration.path ? { path: registration.path } : {}),
     provider: registration.provider,
+    signatureVerified: verified,
   }
   return {
     body,
@@ -2584,20 +2589,25 @@ export function createChannelWebhookRouteHandler(
       }
 
       const { registration, trigger } = match
-      if (await matchedWebhookRegistrationRequiresVerification(registration, context, trigger.id !== "chat.message")) {
-        try {
+      let signatureVerified = false
+      try {
+        if (trigger.id !== "chat.message") {
+          const verification = await verifyAgentWebhookRequest([registration], request, context, { requireSecretHeader: true })
+          signatureVerified = verification.method === "github-sha256"
+        }
+        else if (await matchedWebhookRegistrationRequiresVerification(registration, context, false)) {
           await verifyAgentWebhookRequest([registration], request, context, { requireSecretHeader: true })
         }
-        catch (error) {
-          const response = toHttpErrorResponse(error)
-          if (response) return response
-          throw error
-        }
+      }
+      catch (error) {
+        const response = toHttpErrorResponse(error)
+        if (response) return response
+        throw error
       }
 
       if (trigger.id !== "chat.message") {
         try {
-          const input = await createAgentWebhookTriggerInput(request, registration)
+          const input = await createAgentWebhookTriggerInput(request, registration, signatureVerified)
           const invocation = await resolveAgentTriggerInvocation(agent as never, context as never, trigger.id, input)
           if (isResolvedAgentTriggerHandledInvocation(invocation)) {
             await context.flushWaitUntil?.()

--- a/packages/agent/src/trigger-runtime.ts
+++ b/packages/agent/src/trigger-runtime.ts
@@ -228,6 +228,7 @@ export function isResolvedAgentTriggerHandledInvocation<
 }
 
 export interface AgentWebhookVerificationResult {
+  method: "disabled" | "github-sha256" | "none" | "secret-token"
   registration?: AgentWebhookRegistrationDefinition
   verified: boolean
 }
@@ -297,21 +298,21 @@ async function verifyRequiredWebhookHeaders<TRuntimeConfig extends AgentRuntimeC
   for (const registration of registrations) {
     const secretToken = await resolveMaybe(registration.secretToken, context)
     if (!registration.secretHeader) {
-      if (secretToken === false) return { registration, verified: true }
+      if (secretToken === false) return { method: "disabled", registration, verified: true }
       if (secretToken) {
         throw webhookVerificationError(`[vitehub] Webhook registration "${registration.id || registration.provider}" declares secretToken but no secretHeader is configured. Verification requires secretHeader; secretToken: false explicitly disables verification.`)
       }
       continue
     }
     if (secretToken === false) {
-      return { registration, verified: true }
+      return { method: "disabled", registration, verified: true }
     }
     if (!secretToken) {
       throw webhookVerificationError(`[vitehub] Webhook registration "${registration.id || registration.provider}" declares secretHeader "${registration.secretHeader}" but no secretToken is configured. Verification requires secretToken from Server Env; secretToken: false explicitly disables verification.`)
     }
     throw webhookVerificationError(`[vitehub] Webhook secret header "${registration.secretHeader}" is required.`)
   }
-  return { verified: true }
+  return { method: "none", verified: true }
 }
 
 export async function verifyAgentWebhookRequest<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
@@ -331,13 +332,13 @@ export async function verifyAgentWebhookRequest<TRuntimeConfig extends AgentRunt
   if (!targeted.length) {
     return options.requireSecretHeader
       ? await verifyRequiredWebhookHeaders(registrations, verificationContext)
-      : { verified: true }
+      : { method: "none", verified: true }
   }
 
   for (const { headerValue, registration } of targeted) {
     const secretToken = await resolveMaybe(registration.secretToken, verificationContext)
     if (secretToken === false) {
-      return { registration, verified: true }
+      return { method: "disabled", registration, verified: true }
     }
     if (!secretToken) {
       throw webhookVerificationError(`[vitehub] Webhook registration "${registration.id || registration.provider}" declares secretHeader "${registration.secretHeader}" but no secretToken is configured. Verification requires secretToken from Server Env; secretToken: false explicitly disables verification.`)
@@ -345,12 +346,12 @@ export async function verifyAgentWebhookRequest<TRuntimeConfig extends AgentRunt
     if (registration.signature === "github-sha256") {
       const expected = `sha256=${await hmacSha256(secretToken, await request.clone().text())}`
       if (await constantTimeEqual(expected, headerValue)) {
-        return { registration, verified: true }
+        return { method: "github-sha256", registration, verified: true }
       }
       continue
     }
     if (await constantTimeEqual(secretToken, headerValue)) {
-      return { registration, verified: true }
+      return { method: "secret-token", registration, verified: true }
     }
   }
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -195,7 +195,7 @@ export interface AgentRunMetadata<TOrigin extends string = string> {
   threadId?: string
 }
 
-export type AgentChannelDeliveryEffectKind = "reaction" | "reply" | "status" | (string & {})
+export type AgentChannelDeliveryEffectKind = "labels" | "reaction" | "reply" | "status" | (string & {})
 
 export type AgentDeliveryArtifactPlacement = "inline" | "attachment" | "link"
 
@@ -244,6 +244,11 @@ export interface AgentChannelDeliveryReactionPayload {
 
 export type AgentChannelDeliveryReactionInput = string | AgentChannelDeliveryReactionPayload
 
+export interface AgentChannelDeliveryLabelsPayload {
+  action: "add" | "remove" | "replace"
+  labels: readonly string[]
+}
+
 export type AgentChannelDeliveryStatusState = "error" | "failure" | "pending" | "success" | (string & {})
 
 export interface AgentChannelDeliveryStatusPayload {
@@ -257,7 +262,8 @@ export interface AgentChannelDeliveryStatusPayload {
 export type AgentChannelDeliveryStatusInput = AgentChannelDeliveryStatusState | AgentChannelDeliveryStatusPayload
 
 export type AgentChannelDeliveryEffectPayload<TKind extends AgentChannelDeliveryEffectKind> =
-  TKind extends "reaction" ? AgentChannelDeliveryReactionInput
+  TKind extends "labels" ? AgentChannelDeliveryLabelsPayload
+    : TKind extends "reaction" ? AgentChannelDeliveryReactionInput
     : TKind extends "reply" ? AgentChannelDeliveryReplyInput
       : TKind extends "status" ? AgentChannelDeliveryStatusInput
         : unknown

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -30,6 +30,33 @@ function githubIssueCommentPayload(body = "/review please") {
   }
 }
 
+function githubPullRequestLabeledPayload() {
+  return {
+    action: "labeled",
+    installation: { id: 123 },
+    label: { name: "agent:ready" },
+    number: 42,
+    pull_request: {
+      base: { ref: "main", repo: { full_name: "acme/app" }, sha: "base-sha" },
+      body: "Keep this pull request moving.",
+      head: { ref: "feature", repo: { full_name: "acme/fork" }, sha: "head-sha" },
+      html_url: "https://github.test/acme/app/pull/42",
+      labels: [{ name: "agent:ready" }, { name: "bug" }],
+      number: 42,
+      title: "Improve app",
+      url: "https://api.github.test/repos/acme/app/pulls/42",
+    },
+    repository: {
+      full_name: "acme/app",
+      id: 1001,
+      name: "app",
+      node_id: "repo-node",
+      owner: { login: "acme" },
+    },
+    sender: { id: 1, login: "mona", node_id: "sender-node", type: "User" },
+  }
+}
+
 describe("agent channels", () => {
   it("uses normalized finish context text for default GitHub PR replies", async () => {
     const { github } = await import("../src/channels.ts")
@@ -383,6 +410,264 @@ describe("agent channels", () => {
       installationId: 123,
       repository: "acme/app",
     })
+  })
+
+  it("admits configured GitHub pull_request labeled senders with exact head context", async () => {
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs1" }).toString()
+    const fetcher = vi.fn(async (url: string | URL | Request) => {
+      if (String(url).endsWith("/app/installations/123/access_tokens")) {
+        return Response.json({ expires_at: new Date(Date.now() + 600_000).toISOString(), token: "installation-token" })
+      }
+      return Response.json({ ok: true }, { status: 201 })
+    })
+    const channel = github({
+      app: {
+        apiBaseUrl: "https://api.github.test",
+        appId: "1",
+        fetch: fetcher as typeof fetch,
+        privateKey: privateKeyPem,
+      },
+      pullRequest: {
+        comment: { reply: false },
+        labeled: {
+          allowedSenders: [{ id: 1, login: "Mona" }],
+          label: "agent:ready",
+        },
+      },
+    })
+    const trigger = channel.triggers?.webhook
+    if (!trigger) throw new Error("Missing GitHub webhook trigger.")
+    const context = {
+      capabilities: [],
+      channel,
+      trigger: { channelId: "github", id: "github.webhook", name: "webhook", source: "channel" },
+    }
+    const result = await trigger.invoke(context as never, {
+      github: { deliveryId: "delivery-1", event: "pull_request", installationId: 123 },
+      payload: githubPullRequestLabeledPayload(),
+      webhook: { signatureVerified: true },
+    })
+    if (result instanceof Response) throw new Error("Expected GitHub labeled invocation.")
+
+    expect(result.webhook).toEqual({
+      concurrencyKey: "github:https://api.github.test:repository:1001:pull:42:head:head-sha",
+      deliveryId: "delivery-1",
+    })
+    expect(result.run).toEqual({
+      channelId: "github",
+      messageId: "delivery-1",
+      origin: "github-pull-request-labeled",
+      runId: "github:https://api.github.test:delivery:delivery-1",
+      threadId: "github:https://api.github.test:repository:1001:pull:42:head:head-sha",
+    })
+    expect(result.input).toMatchObject({
+      context: {
+        actor: {
+          id: "github:https://api.github.test:1",
+          kind: "github",
+          label: "@mona",
+          meta: { github: { id: 1, login: "mona", nodeId: "sender-node", type: "User" } },
+        },
+        pullRequest: {
+          pullRequest: {
+            base: { ref: "main", repo: "acme/app", sha: "base-sha" },
+            head: { ref: "feature", repo: "acme/fork", sha: "head-sha" },
+            labels: ["agent:ready", "bug"],
+            number: 42,
+            source: { mount: "app", ref: "refs/pull/42/head", repo: "acme/app" },
+          },
+          repository: { fullName: "acme/app", id: 1001, name: "app", nodeId: "repo-node", owner: "acme" },
+          trigger: {
+            action: "labeled",
+            deliveryId: "delivery-1",
+            event: "pull_request",
+            installationId: 123,
+            label: { name: "agent:ready" },
+            sender: { id: 1, login: "mona", nodeId: "sender-node", type: "User" },
+          },
+        },
+      },
+    })
+
+    const replyEffect = channel.effects?.reply
+    if (typeof replyEffect !== "function") throw new Error("Missing GitHub reply effect.")
+    await replyEffect({
+      channel,
+      effect: { kind: "reply", payload: { body: "Label run complete." } },
+      input: result.input,
+      memo: vi.fn(),
+      run: result.run,
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    } as never)
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.github.test/repos/acme/app/issues/42/comments",
+      expect.objectContaining({ body: JSON.stringify({ body: "Label run complete." }), method: "POST" }),
+    )
+
+    const comment = await trigger.invoke(context as never, {
+      payload: githubIssueCommentPayload(),
+    })
+    if (comment instanceof Response) throw new Error("Expected compatible GitHub issue comment invocation.")
+    expect(comment.input.context?.github).toMatchObject({ command: "/review" })
+
+    const dev = channel.triggers?.dev
+    if (!dev) throw new Error("Missing GitHub dev trigger.")
+    const labeledContext = result.input.context?.pullRequest
+    const fromContext = await dev.invoke({
+      ...context,
+      trigger: { ...context.trigger, id: "github.dev", name: "dev" },
+    } as never, { pullRequest: labeledContext })
+    if (fromContext instanceof Response) throw new Error("Expected admitted GitHub labeled dev context.")
+    expect(fromContext.webhook?.concurrencyKey).toBe("github:https://api.github.test:repository:1001:pull:42:head:head-sha")
+
+    const rawPayload = githubPullRequestLabeledPayload() as Omit<ReturnType<typeof githubPullRequestLabeledPayload>, "installation"> & {
+      installation?: { id: number }
+    }
+    delete rawPayload.installation
+    const fromRawPayload = await dev.invoke({
+      ...context,
+      trigger: { ...context.trigger, id: "github.dev", name: "dev" },
+    } as never, rawPayload)
+    if (fromRawPayload instanceof Response) throw new Error("Expected raw GitHub labeled dev payload.")
+    expect(fromRawPayload.input.context?.pullRequest).toMatchObject({
+      trigger: {
+        deliveryId: "dev:1001:42:head-sha:agent:ready",
+        label: { name: "agent:ready" },
+      },
+    })
+    expect((fromRawPayload.input.context?.pullRequest as { trigger?: { installationId?: number } }).trigger?.installationId).toBeUndefined()
+
+    const callerControlled = structuredClone(labeledContext) as {
+      run: { runId: string, threadId: string }
+      trigger: { action: string }
+    }
+    callerControlled.run.runId = "attacker-run"
+    callerControlled.run.threadId = "attacker-thread"
+    const canonical = await dev.invoke({
+      ...context,
+      trigger: { ...context.trigger, id: "github.dev", name: "dev" },
+    } as never, { pullRequest: callerControlled })
+    if (canonical instanceof Response) throw new Error("Expected canonical GitHub labeled dev context.")
+    expect(canonical.run?.runId).toBe("github:https://api.github.test:delivery:delivery-1")
+    expect(canonical.run?.threadId).toBe("github:https://api.github.test:repository:1001:pull:42:head:head-sha")
+    expect(canonical.input.context?.pullRequest?.run).toEqual({
+      messageId: "delivery-1",
+      origin: "github-pull-request-labeled",
+      runId: "github:https://api.github.test:delivery:delivery-1",
+      threadId: "github:https://api.github.test:repository:1001:pull:42:head:head-sha",
+    })
+
+    callerControlled.trigger.action = "unlabeled"
+    const wrongAction = await dev.invoke({
+      ...context,
+      trigger: { ...context.trigger, id: "github.dev", name: "dev" },
+    } as never, { pullRequest: callerControlled })
+    if (!(wrongAction instanceof Response)) throw new Error("Expected rejected GitHub labeled dev action.")
+    await expect(wrongAction.json()).resolves.toMatchObject({ reason: "not_labeled" })
+
+    const staleContext = structuredClone(labeledContext) as { trigger: { sender: { login: string } } }
+    staleContext.trigger.sender.login = "octocat"
+    const rejectedContext = await dev.invoke({
+      ...context,
+      trigger: { ...context.trigger, id: "github.dev", name: "dev" },
+    } as never, { pullRequest: staleContext })
+    if (!(rejectedContext instanceof Response)) throw new Error("Expected rejected GitHub labeled dev context.")
+    await expect(rejectedContext.json()).resolves.toMatchObject({ reason: "sender_login_mismatch" })
+  })
+
+  it("handles unverified, wrong-label, wrong-action, and disallowed-sender GitHub events", async () => {
+    const { github } = await import("../src/channels.ts")
+    const channel = github({
+      pullRequest: {
+        labeled: {
+          allowedSenders: [{ id: 1, login: "mona" }],
+          label: "agent:ready",
+        },
+      },
+    })
+    const trigger = channel.triggers?.webhook
+    if (!trigger) throw new Error("Missing GitHub webhook trigger.")
+    const context = {
+      capabilities: [],
+      channel,
+      trigger: { channelId: "github", id: "github.webhook", name: "webhook", source: "channel" },
+    }
+    const invoke = async (payload: ReturnType<typeof githubPullRequestLabeledPayload>, verified = true) => {
+      const result = await trigger.invoke(context as never, {
+        github: { deliveryId: "delivery-1", event: "pull_request", installationId: 123 },
+        payload,
+        webhook: { signatureVerified: verified },
+      })
+      if (!(result instanceof Response)) throw new Error("Expected handled GitHub event.")
+      return result
+    }
+
+    const unverified = await invoke(githubPullRequestLabeledPayload(), false)
+    expect(unverified.status).toBe(401)
+    await expect(unverified.json()).resolves.toMatchObject({ reason: "unverified" })
+
+    const wrongLabel = githubPullRequestLabeledPayload()
+    wrongLabel.label.name = "agent:done"
+    await expect((await invoke(wrongLabel)).json()).resolves.toMatchObject({ reason: "wrong_label" })
+
+    const wrongAction = githubPullRequestLabeledPayload()
+    wrongAction.action = "unlabeled"
+    await expect((await invoke(wrongAction)).json()).resolves.toMatchObject({ reason: "not_labeled" })
+
+    const wrongSender = githubPullRequestLabeledPayload()
+    wrongSender.sender.id = 2
+    await expect((await invoke(wrongSender)).json()).resolves.toMatchObject({ reason: "sender_not_allowed" })
+
+    const renamedSender = githubPullRequestLabeledPayload()
+    renamedSender.sender.login = "octocat"
+    await expect((await invoke(renamedSender)).json()).resolves.toMatchObject({ reason: "sender_login_mismatch" })
+  })
+
+  it("requires stable GitHub sender selectors for labeled pull request admission", async () => {
+    const { github } = await import("../src/channels.ts")
+
+    expect(() => github({
+      pullRequest: { labeled: { allowedSenders: [], label: "agent:ready" } },
+    })).toThrow("requires at least one allowed sender")
+    expect(() => github({
+      pullRequest: { labeled: { allowedSenders: [{ id: 0 }], label: "agent:ready" } },
+    })).toThrow("positive safe integers")
+    expect(() => github({
+      pullRequest: { labeled: { allowedSenders: [{ id: 1, login: "" }], label: "agent:ready" } },
+    })).toThrow("logins must be non-empty")
+    expect(() => github({
+      app: { apiBaseUrl: "not a url" },
+      pullRequest: { labeled: { allowedSenders: [{ id: 1 }], label: "agent:ready" } },
+    })).toThrow("apiBaseUrl must be a valid HTTP URL")
+
+    const signed = github({
+      app: { webhookSecret: "secret-token" },
+      pullRequest: { labeled: { allowedSenders: [{ id: 1 }], label: "agent:ready" } },
+      webhooks: {
+        secretHeader: "x-insecure-token",
+        signature: "plain-token",
+      },
+    })
+    expect(signed.webhooks).toMatchObject({
+      secretHeader: "x-hub-signature-256",
+      signature: "github-sha256",
+    })
+  })
+
+  it("preserves legacy GitHub pull request comment options with an undefined labeled flag", async () => {
+    const { github } = await import("../src/channels.ts")
+    const channel = github({
+      pullRequest: {
+        labeled: undefined,
+        reply: false,
+      } as { labeled?: undefined, reply: false },
+    })
+
+    expect(channel.triggers?.webhook).toBeDefined()
+    expect(channel.triggers?.dev).toBeDefined()
   })
 
   it("uses token fallback to fetch GitHub PR metadata", async () => {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -476,7 +476,7 @@ describe("agent channels", () => {
             head: { ref: "feature", repo: "acme/fork", sha: "head-sha" },
             labels: ["agent:ready", "bug"],
             number: 42,
-            source: { mount: "app", ref: "refs/pull/42/head", repo: "acme/app" },
+            source: { mount: "app", ref: "head-sha", repo: "acme/app" },
           },
           repository: { fullName: "acme/app", id: 1001, name: "app", nodeId: "repo-node", owner: "acme" },
           trigger: {
@@ -1308,6 +1308,69 @@ describe("agent channels", () => {
     finally {
       await rm(rootDir, { force: true, recursive: true })
     }
+  })
+
+  it("posts labeled pull request statuses to the webhook head SHA", async () => {
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const fetcher = vi.fn(async (url: string | URL | Request) => {
+      const href = String(url)
+      if (href.endsWith("/app/installations/789/access_tokens")) {
+        return Response.json({ expires_at: new Date(Date.now() + 600_000).toISOString(), token: "installation-token" })
+      }
+      if (href.endsWith("/statuses/webhook-head-sha")) return Response.json({ ok: true }, { status: 201 })
+      throw new Error(`Unexpected GitHub API call: ${href}`)
+    })
+    const channel = github({
+      app: {
+        apiBaseUrl: "https://api.github.test",
+        appId: "4",
+        fetch: fetcher as typeof fetch,
+        installationId: 789,
+        privateKey: privateKey.export({ format: "pem", type: "pkcs1" }).toString(),
+      },
+    })
+    const statusEffect = channel.effects?.status
+    if (typeof statusEffect !== "function") throw new Error("Missing GitHub status effect.")
+
+    await statusEffect({
+      channel,
+      effect: { kind: "status", payload: "success" },
+      input: {
+        context: {
+          pullRequest: {
+            pullRequest: {
+              apiUrl: "https://api.github.test/repos/vite-hub/vitehub/pulls/42",
+              head: { sha: "webhook-head-sha" },
+              number: 42,
+            },
+            repository: { fullName: "vite-hub/vitehub", name: "vitehub", owner: "vite-hub" },
+            run: { messageId: "delivery-1", origin: "github-pull-request-labeled", runId: "run-1", threadId: "thread-1" },
+            trigger: {
+              action: "labeled",
+              deliveryId: "delivery-1",
+              event: "pull_request",
+              installationId: 789,
+              label: { name: "agent:ready" },
+              sender: { id: 1, login: "mona" },
+            },
+          },
+        },
+        prompt: "Maintain this pull request.",
+      },
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    } as never)
+
+    expect(fetcher).not.toHaveBeenCalledWith(
+      "https://api.github.test/repos/vite-hub/vitehub/pulls/42",
+      expect.anything(),
+    )
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://api.github.test/repos/vite-hub/vitehub/statuses/webhook-head-sha",
+      expect.objectContaining({ method: "POST" }),
+    )
   })
 
   it("ignores GitHub PR delivery effects without pull request context", async () => {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -433,7 +433,7 @@ describe("agent channels", () => {
         comment: { reply: false },
         labeled: {
           allowedSenders: [{ id: 1, login: "Mona" }],
-          label: "agent:ready",
+          label: "Agent:Ready",
         },
       },
     })
@@ -476,7 +476,7 @@ describe("agent channels", () => {
             head: { ref: "feature", repo: "acme/fork", sha: "head-sha" },
             labels: ["agent:ready", "bug"],
             number: 42,
-            source: { mount: "app", ref: "head-sha", repo: "acme/app" },
+            source: { mount: "app", ref: "head-sha", repo: "acme/fork" },
           },
           repository: { fullName: "acme/app", id: 1001, name: "app", nodeId: "repo-node", owner: "acme" },
           trigger: {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -825,7 +825,6 @@ describe("agent channels", () => {
         apiBaseUrl: "https://api.github.test",
         appId: "1",
         fetch: fetcher as typeof fetch,
-        installationId: 123,
         privateKey: privateKeyPem,
       },
     })
@@ -843,6 +842,22 @@ describe("agent channels", () => {
           url: "https://assets.example/review/screenshots/login.png",
         }],
         kind: "review",
+        metadata: {
+          github: {
+            action: "created",
+            actor: { login: "onmax" },
+            args: "",
+            body: "/review",
+            command: "/review",
+            commentId: 99,
+            installationId: 123,
+            issueNumber: 42,
+            owner: "vite-hub",
+            pullRequestUrl: "https://api.github.test/repos/vite-hub/vitehub/pulls/42",
+            repo: "vitehub",
+            repository: "vite-hub/vitehub",
+          },
+        },
         payload: { body: "Review body\n\n![Login badge](/workspace/codex-session/screenshots/login.png)" },
       },
       input: {
@@ -854,7 +869,6 @@ describe("agent channels", () => {
             body: "/review",
             command: "/review",
             commentId: 99,
-            installationId: 123,
             issueNumber: 42,
             owner: "vite-hub",
             pullRequestUrl: "https://api.github.test/repos/vite-hub/vitehub/pulls/42",
@@ -880,6 +894,237 @@ describe("agent channels", () => {
         method: "POST",
       }),
     )
+  })
+
+  it("changes pull request labels through the triggering GitHub App installation", async () => {
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs1" }).toString()
+    const fetcher = vi.fn(async (url: string | URL | Request) => {
+      if (String(url).endsWith("/app/installations/123/access_tokens")) {
+        return Response.json({ expires_at: new Date(Date.now() + 600_000).toISOString(), token: "installation-token" })
+      }
+      if (String(url).endsWith("/labels/agent%3Aready")) {
+        return Response.json({ message: "Label does not exist" }, { status: 404 })
+      }
+      return Response.json({ ok: true })
+    })
+    const channel = github({
+      app: {
+        apiBaseUrl: "https://api.github.test",
+        appId: "label-effects",
+        fetch: fetcher as typeof fetch,
+        privateKey: privateKeyPem,
+      },
+    })
+    const labelsEffect = channel.effects?.labels
+    if (typeof labelsEffect !== "function") throw new Error("Missing GitHub labels effect.")
+    const input = {
+      context: {
+        pullRequest: {
+          pullRequest: { number: 42 },
+          repository: { fullName: "vite-hub/vitehub", id: 1001, name: "vitehub", owner: "vite-hub" },
+          run: { messageId: "delivery-1", origin: "github-pull-request-labeled", runId: "run-1", threadId: "thread-1" },
+          trigger: {
+            action: "labeled",
+            deliveryId: "delivery-1",
+            event: "pull_request",
+            installationId: 123,
+            label: { name: "agent:ready" },
+            sender: { id: 1, login: "mona" },
+          },
+        },
+      },
+      prompt: "Maintain this pull request.",
+    }
+    const invoke = async (
+      payload: { action: "add" | "remove" | "replace", github?: Record<string, unknown>, labels: string[] },
+      metadata?: Record<string, unknown>,
+    ) => await labelsEffect({
+      channel,
+      effect: { kind: "labels", ...(metadata ? { metadata } : {}), payload },
+      input,
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    } as never)
+
+    const attackerTarget = {
+      commentId: 1,
+      installationId: 999,
+      issueNumber: 1,
+      owner: "attacker",
+      pullRequestUrl: "https://api.github.test/repos/attacker/repo/pulls/1",
+      repo: "repo",
+      repository: "attacker/repo",
+    }
+    await invoke({ action: "add", github: attackerTarget, labels: ["agent:working"] }, { github: attackerTarget })
+    await invoke({ action: "remove", labels: ["agent:ready", "needs review"] })
+    await invoke({ action: "replace", labels: ["agent:done", "bug"] })
+
+    const calls = fetcher.mock.calls.slice(1)
+    expect(calls).toEqual([
+      ["https://api.github.test/repos/vite-hub/vitehub/issues/42/labels", expect.objectContaining({
+        body: JSON.stringify({ labels: ["agent:working"] }),
+        headers: expect.objectContaining({ authorization: "Bearer installation-token" }),
+        method: "POST",
+      })],
+      ["https://api.github.test/repos/vite-hub/vitehub/issues/42/labels/agent%3Aready", expect.objectContaining({
+        headers: expect.objectContaining({ authorization: "Bearer installation-token" }),
+        method: "DELETE",
+      })],
+      ["https://api.github.test/repos/vite-hub/vitehub/issues/42/labels/needs%20review", expect.objectContaining({
+        headers: expect.objectContaining({ authorization: "Bearer installation-token" }),
+        method: "DELETE",
+      })],
+      ["https://api.github.test/repos/vite-hub/vitehub/issues/42/labels", expect.objectContaining({
+        body: JSON.stringify({ labels: ["agent:done", "bug"] }),
+        headers: expect.objectContaining({ authorization: "Bearer installation-token" }),
+        method: "PUT",
+      })],
+    ])
+  })
+
+  it("surfaces GitHub pull request label API failures", async () => {
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const fetcher = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).endsWith("/access_tokens")) {
+        return Response.json({ token: "installation-token" })
+      }
+      if (init?.method === "DELETE") {
+        return Response.json({ message: "Not Found" }, { status: 404 })
+      }
+      return Response.json({ message: "unprocessable" }, { status: 422 })
+    })
+    const channel = github({
+      app: {
+        apiBaseUrl: "https://api.github.test",
+        appId: "label-effects-failure",
+        fetch: fetcher as typeof fetch,
+        privateKey: privateKey.export({ format: "pem", type: "pkcs1" }).toString(),
+      },
+    })
+    const labelsEffect = channel.effects?.labels
+    if (typeof labelsEffect !== "function") throw new Error("Missing GitHub labels effect.")
+
+    await expect(labelsEffect({
+      channel,
+      effect: { kind: "labels", payload: { action: "add", labels: ["agent:working"] } },
+      input: {
+        context: {
+          pullRequest: {
+            pullRequest: { number: 42 },
+            repository: { fullName: "vite-hub/vitehub", name: "vitehub", owner: "vite-hub" },
+            run: { runId: "run-1" },
+            trigger: {
+              action: "labeled",
+              deliveryId: "delivery-1",
+              event: "pull_request",
+              installationId: 456,
+              label: { name: "agent:ready" },
+              sender: { id: 1, login: "mona" },
+            },
+          },
+        },
+        prompt: "Maintain this pull request.",
+      },
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    } as never)).rejects.toThrow("GitHub delivery effect failed with 422")
+
+    await expect(labelsEffect({
+      channel,
+      effect: { kind: "labels", payload: { action: "remove", labels: ["agent:working"] } },
+      input: {
+        context: {
+          pullRequest: {
+            pullRequest: { number: 42 },
+            repository: { fullName: "vite-hub/vitehub", name: "vitehub", owner: "vite-hub" },
+            run: { runId: "run-1" },
+            trigger: {
+              action: "labeled",
+              deliveryId: "delivery-1",
+              event: "pull_request",
+              installationId: 456,
+              label: { name: "agent:ready" },
+              sender: { id: 1, login: "mona" },
+            },
+          },
+        },
+        prompt: "Maintain this pull request.",
+      },
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    } as never)).rejects.toThrow("GitHub delivery effect failed with 404")
+  })
+
+  it("uses admitted issue-comment context as the only GitHub label target", async () => {
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const fetcher = vi.fn(async (url: string | URL | Request) => {
+      if (String(url).endsWith("/app/installations/321/access_tokens")) {
+        return Response.json({ token: "installation-token" })
+      }
+      return Response.json({ ok: true })
+    })
+    const channel = github({
+      app: {
+        apiBaseUrl: "https://api.github.test",
+        appId: "comment-label-effects",
+        fetch: fetcher as typeof fetch,
+        privateKey: privateKey.export({ format: "pem", type: "pkcs1" }).toString(),
+      },
+    })
+    const labelsEffect = channel.effects?.labels
+    if (typeof labelsEffect !== "function") throw new Error("Missing GitHub labels effect.")
+    const attackerTarget = {
+      commentId: 1,
+      installationId: 999,
+      issueNumber: 1,
+      owner: "attacker",
+      pullRequestUrl: "https://api.github.test/repos/attacker/repo/pulls/1",
+      repo: "repo",
+      repository: "attacker/repo",
+    }
+
+    await labelsEffect({
+      channel,
+      effect: {
+        kind: "labels",
+        metadata: { github: attackerTarget },
+        payload: { action: "add", github: attackerTarget, labels: ["agent:working"] },
+      },
+      input: {
+        context: {
+          github: {
+            action: "created",
+            actor: { login: "mona" },
+            args: "",
+            body: "/review",
+            command: "/review",
+            commentId: 99,
+            installationId: 321,
+            issueNumber: 42,
+            owner: "vite-hub",
+            pullRequestUrl: "https://api.github.test/repos/vite-hub/vitehub/pulls/42",
+            repo: "vitehub",
+            repository: "vite-hub/vitehub",
+          },
+        },
+        prompt: "/review",
+      },
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    } as never)
+
+    expect(fetcher.mock.calls.map(([url]) => String(url))).toEqual([
+      "https://api.github.test/app/installations/321/access_tokens",
+      "https://api.github.test/repos/vite-hub/vitehub/issues/42/labels",
+    ])
   })
 
   it("publishes Workspace image paths before posting GitHub PR replies", async () => {

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -360,6 +360,33 @@ describe("git capability", () => {
     expect(setupScript).not.toContain("vitehub-base")
   })
 
+  it("fetches an exact pull request head SHA without treating it as a branch", async () => {
+    const session = gitSession()
+    session.exec.mockImplementation(async (command: string, args: string[] = []) => ({
+      args,
+      command,
+      exitCode: command === "git" && args.join(" ") === "rev-parse --is-inside-work-tree" ? 1 : 0,
+      stderr: "",
+      stdout: "",
+    }))
+    const headSha = "0123456789abcdef0123456789abcdef01234567"
+    const { tools } = await capabilityTools(git(), session, {
+      pullRequest: {
+        pullRequest: {
+          number: 42,
+          source: { mount: "vitehub", ref: headSha, repo: "vite-hub/vitehub" },
+        },
+        repository: { fullName: "vite-hub/vitehub", name: "vitehub" },
+      },
+    })
+
+    await tools.shell!.execute?.({ command: "git status --short" })
+
+    const setupScript = session.exec.mock.calls.find(([command]) => command === "sh")?.[1]?.[1]
+    expect(setupScript).toContain(`git fetch --depth=100 origin '${headSha}:refs/vitehub/head'`)
+    expect(setupScript).not.toContain(`refs/heads/${headSha}`)
+  })
+
   it("keeps internally prepared pull request checkouts out of write commits", async () => {
     const session = gitSession()
     session.exec.mockImplementation(async (command: string, args: string[] = []) => ({

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -4533,7 +4533,7 @@ describe("server helpers", () => {
               pullRequest: {
                 base: { ref: "main", repo: "acme/app", sha: "base-sha" },
                 head: { ref: "feature", repo: "acme/fork", sha: "head-sha" },
-                source: { ref: "refs/pull/42/head", repo: "acme/app" },
+              source: { ref: "head-sha", repo: "acme/app" },
               },
               trigger: {
                 deliveryId: "delivery-1",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -4533,7 +4533,7 @@ describe("server helpers", () => {
               pullRequest: {
                 base: { ref: "main", repo: "acme/app", sha: "base-sha" },
                 head: { ref: "feature", repo: "acme/fork", sha: "head-sha" },
-              source: { ref: "head-sha", repo: "acme/app" },
+                source: { ref: "head-sha", repo: "acme/fork" },
               },
               trigger: {
                 deliveryId: "delivery-1",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -24,6 +24,32 @@ function githubSignature(secret: string, body: string) {
   return `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`
 }
 
+function githubPullRequestLabeledPayload() {
+  return {
+    action: "labeled",
+    installation: { id: 123 },
+    label: { name: "agent:ready" },
+    number: 42,
+    pull_request: {
+      base: { ref: "main", repo: { full_name: "acme/app" }, sha: "base-sha" },
+      head: { ref: "feature", repo: { full_name: "acme/fork" }, sha: "head-sha" },
+      html_url: "https://github.com/acme/app/pull/42",
+      labels: [{ name: "agent:ready" }],
+      number: 42,
+      title: "Improve app",
+      url: "https://api.github.com/repos/acme/app/pulls/42",
+    },
+    repository: {
+      full_name: "acme/app",
+      id: 1001,
+      name: "app",
+      node_id: "repo-node",
+      owner: { login: "acme" },
+    },
+    sender: { id: 1, login: "mona", node_id: "sender-node", type: "User" },
+  }
+}
+
 const optionalMessageAdapterRuntimeExternals = [
   "bufferutil",
   "utf-8-validate",
@@ -4421,6 +4447,195 @@ describe("server helpers", () => {
 
     expect(rejected.status).toBe(401)
     await expect(rejected.json()).resolves.toEqual({ error: "[vitehub] Webhook secret verification failed." })
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it("runs only admitted signed GitHub pull request label deliveries", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { github } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-github-labeled-trigger-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const run = vi.fn((_context: unknown) => "accepted")
+    const agent = defineAgent({
+      channels: {
+        github: github({
+          app: { webhookSecret: "secret-token" },
+          pullRequest: {
+            labeled: {
+              allowedSenders: [{ id: 1, login: "Mona" }],
+              label: "agent:ready",
+            },
+          },
+        }),
+      },
+      driver: { run },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+    const waitUntilTasks: Promise<unknown>[] = []
+    const request = (
+      deliveryId: string,
+      payload: ReturnType<typeof githubPullRequestLabeledPayload>,
+      event = "pull_request",
+      signature = githubSignature("secret-token", JSON.stringify(payload)),
+    ) => {
+      const body = JSON.stringify(payload)
+      return new Request("https://example.com/api/github/webhook", {
+        body,
+        headers: {
+          "content-type": "application/json",
+          "x-github-delivery": deliveryId,
+          "x-github-event": event,
+          "x-hub-signature-256": signature,
+        },
+        method: "POST",
+      })
+    }
+    const options = {
+      agentName: "review",
+      webhookState: state,
+      waitUntil: (task: Promise<unknown>) => waitUntilTasks.push(task),
+    }
+
+    try {
+      const wrongLabel = githubPullRequestLabeledPayload()
+      wrongLabel.label.name = "agent:done"
+      await expect((await handler(request("wrong-label", wrongLabel), "github", options)).json()).resolves.toMatchObject({ reason: "wrong_label" })
+
+      const wrongSender = githubPullRequestLabeledPayload()
+      wrongSender.sender.id = 2
+      await expect((await handler(request("wrong-sender", wrongSender), "github", options)).json()).resolves.toMatchObject({ reason: "sender_not_allowed" })
+
+      const wrongAction = githubPullRequestLabeledPayload()
+      wrongAction.action = "synchronize"
+      await expect((await handler(request("wrong-action", wrongAction), "github", options)).json()).resolves.toMatchObject({ reason: "not_labeled" })
+
+      for (const event of ["issue_comment", "pull_request_review", "check_suite"]) {
+        const ignoredEvent = await handler(request(`wrong-event-${event}`, githubPullRequestLabeledPayload(), event), "github", options)
+        await expect(ignoredEvent.json()).resolves.toMatchObject({ reason: "wrong_event" })
+      }
+      expect(run).not.toHaveBeenCalled()
+
+      const invalidSignature = await handler(request("bad-signature", githubPullRequestLabeledPayload(), "pull_request", "sha256=wrong"), "github", options)
+      expect(invalidSignature.status).toBe(401)
+      expect(run).not.toHaveBeenCalled()
+
+      const accepted = await handler(request("delivery-1", githubPullRequestLabeledPayload()), "github", options)
+      await expect(accepted.json()).resolves.toEqual({ accepted: true, ok: true })
+      await Promise.all(waitUntilTasks.splice(0))
+      expect(run).toHaveBeenCalledOnce()
+      expect(run.mock.calls[0]?.[0]).toMatchObject({
+        input: {
+          context: {
+            actor: { id: "github:github.com:1", label: "@mona" },
+            pullRequest: {
+              pullRequest: {
+                base: { ref: "main", repo: "acme/app", sha: "base-sha" },
+                head: { ref: "feature", repo: "acme/fork", sha: "head-sha" },
+                source: { ref: "refs/pull/42/head", repo: "acme/app" },
+              },
+              trigger: {
+                deliveryId: "delivery-1",
+                installationId: 123,
+                label: { name: "agent:ready" },
+                sender: { id: 1, login: "mona", nodeId: "sender-node" },
+              },
+            },
+          },
+        },
+        run: {
+          runId: "github:github.com:delivery:delivery-1",
+          threadId: "github:github.com:repository:1001:pull:42:head:head-sha",
+        },
+      })
+
+      const duplicate = await handler(request("delivery-1", githubPullRequestLabeledPayload()), "github", options)
+      await expect(duplicate.json()).resolves.toEqual({ accepted: false, duplicate: true, ok: true })
+      expect(run).toHaveBeenCalledOnce()
+
+      const reapplied = await handler(request("delivery-2", githubPullRequestLabeledPayload()), "github", options)
+      await expect(reapplied.json()).resolves.toEqual({ accepted: true, ok: true })
+      await Promise.all(waitUntilTasks)
+      expect(run).toHaveBeenCalledTimes(2)
+    }
+    finally {
+      await state.disconnect()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
+  it("fails closed when GitHub label admission disables webhook verification", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { github } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const run = vi.fn(() => "unexpected")
+    const agent = defineAgent({
+      channels: {
+        github: github({
+          app: { webhookSecret: false },
+          pullRequest: {
+            labeled: {
+              allowedSenders: [{ id: 1 }],
+              label: "agent:ready",
+            },
+          },
+        }),
+      },
+      driver: { run },
+    })
+    const payload = githubPullRequestLabeledPayload()
+    const response = await createChannelWebhookRouteHandler(agent as never)(new Request("https://example.com/api/github/webhook", {
+      body: JSON.stringify(payload),
+      headers: {
+        "content-type": "application/json",
+        "x-github-delivery": "delivery-1",
+        "x-github-event": "pull_request",
+      },
+      method: "POST",
+    }), "github")
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toMatchObject({ reason: "unverified" })
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it("uses one resolved GitHub App secret for label signature verification", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { github } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const run = vi.fn(() => "unexpected")
+    let resolutions = 0
+    const agent = defineAgent({
+      channels: {
+        github: github({
+          app: {
+            webhookSecret: () => ++resolutions === 1 ? "secret-token" : false,
+          },
+          pullRequest: {
+            labeled: {
+              allowedSenders: [{ id: 1 }],
+              label: "agent:ready",
+            },
+          },
+        }),
+      },
+      driver: { run },
+    })
+    const payload = githubPullRequestLabeledPayload()
+    const response = await createChannelWebhookRouteHandler(agent as never)(new Request("https://example.com/api/github/webhook", {
+      body: JSON.stringify(payload),
+      headers: {
+        "content-type": "application/json",
+        "x-github-delivery": "delivery-1",
+        "x-github-event": "pull_request",
+        "x-hub-signature-256": "sha256=wrong",
+      },
+      method: "POST",
+    }), "github")
+
+    expect(response.status).toBe(401)
+    expect(resolutions).toBe(1)
     expect(run).not.toHaveBeenCalled()
   })
 

--- a/packages/agent/test/repository-host-context.test.ts
+++ b/packages/agent/test/repository-host-context.test.ts
@@ -402,6 +402,7 @@ describe("repositoryHostContext", () => {
       trigger: {
         actor: { login: "mona" },
         deliveryId: "delivery-1",
+        label: { name: "agent:triage" },
       },
     } as const
 
@@ -412,6 +413,7 @@ describe("repositoryHostContext", () => {
       number: 42,
       repository: "acme/app",
       source: { mount: "vitehub" },
+      trigger: { label: { name: "agent:triage" } },
     })
     await expect(repositoryHostContext.read({
       context: { get: (key: string) => key === "pullRequest" ? rawPullRequestContext : undefined },

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
-import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
+import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestLabelsEffectPayload, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
@@ -1050,6 +1050,13 @@ describe("agent public types", () => {
         id: "feedback",
         prepare(context) {
           context.delivery.effect({ intent: "started", kind: "reaction" })
+          context.delivery.effect({
+            kind: "labels",
+            payload: {
+              action: "replace",
+              labels: ["agent:done"],
+            } satisfies GitHubPullRequestLabelsEffectPayload,
+          })
           context.delivery.finishEffect(context => context.reply(String(context.output)))
         },
       }, inputCommands({

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1639,6 +1639,26 @@ describe("agent public types", () => {
     // @ts-expect-error GitHub Channel PR comments are configured through pullRequest, not legacy events.
     github({ events: { pullRequestComments: true } })
 
+    github({
+      pullRequest: {
+        comment: { reply: false },
+        labeled: {
+          allowedSenders: [{ id: 583231, login: "octocat" }],
+          label: "agent:ready",
+        },
+      },
+    })
+
+    github({
+      pullRequest: {
+        labeled: {
+          // @ts-expect-error GitHub label admission requires the stable numeric account id.
+          allowedSenders: [{ login: "octocat" }],
+          label: "agent:ready",
+        },
+      },
+    })
+
     const broadCapabilities: AgentCapabilityDefinition[] = [
       access({
         workspace: {


### PR DESCRIPTION
Adds a GitHub-native `pull_request.labeled` trigger with declarative label and `allowedSenders` admission before invocation. Sender selectors require the stable numeric GitHub account id and may include a case-insensitive login assertion for reviewable, fail-closed configuration.

Admitted runs receive the exact base and head refs and SHAs, repository and installation identity, delivery id, label, sender, and stable delivery and exact-head execution identities. The generated webhook route records actual GitHub HMAC verification, rejects every unauthorized event without running the driver, and preserves issue-comment command behavior. This stacks on #754 for durable delivery deduplication and exact-head concurrency ownership.

The public Channel configuration and Pull Request Context reader are documented and covered. The focused channel, provider, context, and webhook-verification suites pass all 206 tests; package typecheck and build pass; `git diff --check` passes.