### PR TITLE
feat(agent): deliver GitHub pull request labels

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -275,7 +275,7 @@ const reviewLifecycle = defineCapability({
   prepare(context) {
     context.delivery.effect({
       kind: 'labels',
-      payload: { action: 'replace', labels: ['agent:working'] },
+      payload: { action: 'add', labels: ['agent:working'] },
     })
   },
 })

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -275,7 +275,7 @@ const reviewLifecycle = defineCapability({
   prepare(context) {
     context.delivery.effect({
       kind: 'labels',
-      payload: { action: 'replace', labels: ['agent:done'] },
+      payload: { action: 'replace', labels: ['agent:working'] },
     })
   },
 })

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -262,6 +262,33 @@ export default defineAgent({
 
 The GitHub channel renders inline image artifacts as markdown in `reply` and `review` effects. It does not attach local files directly to GitHub comments.
 
+## Update GitHub pull request labels
+
+GitHub pull request channels support a `labels` delivery effect with `add`, `remove`, and `replace` actions. The channel always applies the effect to the pull request admitted by the current invocation; effect payloads cannot select another repository or pull request.
+
+```ts [server/agents/review.ts]
+import { defineAgent, defineCapability } from '@vite-hub/agent'
+import { github } from '@vite-hub/agent/channels'
+
+const reviewLifecycle = defineCapability({
+  id: 'review-lifecycle',
+  prepare(context) {
+    context.delivery.effect({
+      kind: 'labels',
+      payload: { action: 'replace', labels: ['agent:done'] },
+    })
+  },
+})
+
+export default defineAgent({
+  capabilities: [reviewLifecycle],
+  channels: { github: github({ app: true, pullRequest: true }) },
+  driver: { run: () => 'Review complete.' },
+})
+```
+
+Use `add` or `remove` to preserve unrelated labels. `replace` sends the complete desired label set, including an empty array when the pull request should have no labels.
+
 GitHub Pull Request Context enrichment is bounded before it reaches the Agent Invocation Context. By default, `github({ pullRequest: true })` records up to 30 comments, 200 changed files, 12,000 pull request body characters, and 2,000 characters per comment body. Override those with `maxComments`, `maxFiles`, `maxBodyLength`, and `maxCommentBodyLength` on the `pullRequest` option. Rendered comments are labeled as untrusted user content, and failed metadata enrichment is recorded at `pullRequest.metadata.unavailable`.
 
 Use a labeled event when an Agent Invocation should start only after a trusted GitHub actor applies a specific label:

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -24,6 +24,7 @@ import type {
   AgentChannelDeliveryEffectContext,
   AgentChannelDeliveryEffectIntent,
   AgentChannelDeliveryEffects,
+  AgentChannelDeliveryLabelsPayload,
   AgentChannelDeliveryFinishEffect,
   AgentChannelDeliveryFinishEffectContext,
   AgentChannelWebhookRegistrationDefinition,
@@ -65,6 +66,7 @@ export type {
   AgentChannelDeliveryEffectPayload,
   AgentChannelDeliveryEffectKind,
   AgentChannelDeliveryEffects,
+  AgentChannelDeliveryLabelsPayload,
   AgentChannelDeliveryFinishEffect,
   AgentChannelDeliveryFinishEffectCallback,
   AgentChannelDeliveryFinishEffectResult,
@@ -194,6 +196,8 @@ export interface GitHubSender {
   nodeId?: string
   type?: string
 }
+
+export type GitHubPullRequestLabelsEffectPayload = AgentChannelDeliveryLabelsPayload
 
 export interface GitHubPullRequestCommand {
   action: "created"
@@ -998,6 +1002,42 @@ function githubCommandFromEffect<TRuntimeConfig extends AgentRuntimeConfig>(
     ))
 }
 
+interface GitHubPullRequestEffectTarget {
+  installationId?: number
+  issueNumber: number
+  owner: string
+  repo: string
+}
+
+function githubPullRequestTargetFromEffect<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
+): GitHubPullRequestEffectTarget | undefined {
+  const inputContext = isRecord(context.input.context) ? context.input.context : undefined
+  const command = githubCommandFromUnknown(inputContext?.github)
+  if (command) {
+    return {
+      ...(command.installationId ? { installationId: command.installationId } : {}),
+      issueNumber: command.issueNumber,
+      owner: command.owner,
+      repo: command.repo,
+    }
+  }
+  const pullRequest = githubPullRequestRunContextFromUnknown(context.input.context)
+  if (!pullRequest) return
+  const [fallbackOwner, fallbackRepo] = pullRequest.repository.fullName.split("/")
+  const owner = maybeString(pullRequest.repository.owner) || fallbackOwner
+  const repo = maybeString(pullRequest.repository.name) || fallbackRepo
+  const issueNumber = githubPositiveInteger(pullRequest.pullRequest.number)
+  const installationId = githubPositiveInteger(pullRequest.trigger.installationId)
+  if (!owner || !repo || !issueNumber) return
+  return {
+    ...(installationId ? { installationId } : {}),
+    issueNumber,
+    owner,
+    repo,
+  }
+}
+
 async function resolveEffectOption<T, TRuntimeConfig extends AgentRuntimeConfig>(
   value: MaybeResolvable<T, AgentChannelDeliveryEffectContext<TRuntimeConfig>>,
   context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
@@ -1128,7 +1168,7 @@ async function githubAppInstallationToken<TRuntimeConfig extends AgentRuntimeCon
   const env = await githubEnv(context)
   const appId = requiredString(await githubAppSetting(options, env, "appId", "appId", context), "appId")
   const installationId = installation
-    ?? ("effect" in context ? githubCommandFromEffect(context as AgentChannelDeliveryEffectContext<TRuntimeConfig>)?.installationId : undefined)
+    ?? ("effect" in context ? githubPullRequestTargetFromEffect(context as AgentChannelDeliveryEffectContext<TRuntimeConfig>)?.installationId : undefined)
     ?? requiredNumber(await githubAppSetting(options, env, "installationId", "appInstallationId", context), "installationId")
   const apiBaseUrl = options.apiBaseUrl || "https://api.github.com"
   const cacheKey = `${apiBaseUrl}:${appId}:${installationId}`
@@ -1664,6 +1704,17 @@ function statusPayload<TRuntimeConfig extends AgentRuntimeConfig>(
   }
 }
 
+function githubLabelsEffectPayload(value: unknown): GitHubPullRequestLabelsEffectPayload {
+  if (!isRecord(value) || (value.action !== "add" && value.action !== "remove" && value.action !== "replace") || !Array.isArray(value.labels)) {
+    throw new TypeError("[vitehub] GitHub labels effect requires an add, remove, or replace action and a labels array.")
+  }
+  const labels = [...new Set(value.labels.map(label => typeof label === "string" ? label : ""))]
+  if (labels.some(label => !label.trim())) {
+    throw new TypeError("[vitehub] GitHub labels effect labels must be non-empty strings.")
+  }
+  return { action: value.action, labels }
+}
+
 async function githubPullRequestSha(
   fetcher: typeof fetch,
   command: GitHubPullRequestCommand,
@@ -1695,6 +1746,30 @@ function githubPullRequestEffects<TRuntimeConfig extends AgentRuntimeConfig = Ag
   options: GitHubPullRequestEffectsOptions<TRuntimeConfig>,
 ): AgentChannelDeliveryEffects<TRuntimeConfig> {
   return {
+    async labels(context) {
+      const target = githubPullRequestTargetFromEffect(context)
+      if (!target) return
+      const payload = githubLabelsEffectPayload(context.effect.payload)
+      if (payload.action !== "replace" && !payload.labels.length) return
+      const fetcher = options.fetch || fetch
+      const token = await resolveEffectOption(options.token, context)
+      const headers = githubApiHeaders(token, options.userAgent)
+      const url = `${options.apiBaseUrl || "https://api.github.com"}/repos/${target.owner}/${target.repo}/issues/${target.issueNumber}/labels`
+      if (payload.action === "remove") {
+        for (const label of payload.labels) {
+          await githubApi(fetcher, `${url}/${encodeURIComponent(label)}`, {
+            headers,
+            method: "DELETE",
+          })
+        }
+        return
+      }
+      await githubApi(fetcher, url, {
+        body: JSON.stringify({ labels: payload.labels }),
+        headers,
+        method: payload.action === "add" ? "POST" : "PUT",
+      })
+    },
     async reaction(context) {
       const command = githubCommandFromEffect(context)
       if (!command?.commentId) return

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1765,7 +1765,9 @@ function githubPullRequestEffects<TRuntimeConfig extends AgentRuntimeConfig = Ag
             headers,
             method: "DELETE",
           })
-          if (!response.ok && response.status !== 404) {
+          const body = response.status === 404 ? await response.json().catch(() => undefined) : undefined
+          const missingLabel = isRecord(body) && body.message === "Label does not exist"
+          if (!response.ok && !missingLabel) {
             throw new Error(`[vitehub] GitHub delivery effect failed with ${response.status}.`)
           }
         }

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1168,7 +1168,11 @@ async function githubAppInstallationToken<TRuntimeConfig extends AgentRuntimeCon
   const env = await githubEnv(context)
   const appId = requiredString(await githubAppSetting(options, env, "appId", "appId", context), "appId")
   const installationId = installation
-    ?? ("effect" in context ? githubPullRequestTargetFromEffect(context as AgentChannelDeliveryEffectContext<TRuntimeConfig>)?.installationId : undefined)
+    ?? ("effect" in context
+      ? context.effect.kind === "labels"
+        ? githubPullRequestTargetFromEffect(context)?.installationId
+        : githubCommandFromEffect(context)?.installationId
+      : undefined)
     ?? requiredNumber(await githubAppSetting(options, env, "installationId", "appInstallationId", context), "installationId")
   const apiBaseUrl = options.apiBaseUrl || "https://api.github.com"
   const cacheKey = `${apiBaseUrl}:${appId}:${installationId}`
@@ -1757,10 +1761,13 @@ function githubPullRequestEffects<TRuntimeConfig extends AgentRuntimeConfig = Ag
       const url = `${options.apiBaseUrl || "https://api.github.com"}/repos/${target.owner}/${target.repo}/issues/${target.issueNumber}/labels`
       if (payload.action === "remove") {
         for (const label of payload.labels) {
-          await githubApi(fetcher, `${url}/${encodeURIComponent(label)}`, {
+          const response = await fetcher(`${url}/${encodeURIComponent(label)}`, {
             headers,
             method: "DELETE",
           })
+          if (!response.ok && response.status !== 404) {
+            throw new Error(`[vitehub] GitHub delivery effect failed with ${response.status}.`)
+          }
         }
         return
       }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -203,6 +203,7 @@ export type {
   AgentChannelDeliveryEffectPayload,
   AgentChannelDeliveryEffectKind,
   AgentChannelDeliveryEffects,
+  AgentChannelDeliveryLabelsPayload,
   AgentChannelDeliveryFinishEffectCallback,
   AgentChannelDeliveryFinishEffectResult,
   AgentChannelDeliveryFinishEffectContext,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -195,7 +195,7 @@ export interface AgentRunMetadata<TOrigin extends string = string> {
   threadId?: string
 }
 
-export type AgentChannelDeliveryEffectKind = "reaction" | "reply" | "status" | (string & {})
+export type AgentChannelDeliveryEffectKind = "labels" | "reaction" | "reply" | "status" | (string & {})
 
 export type AgentDeliveryArtifactPlacement = "inline" | "attachment" | "link"
 
@@ -244,6 +244,11 @@ export interface AgentChannelDeliveryReactionPayload {
 
 export type AgentChannelDeliveryReactionInput = string | AgentChannelDeliveryReactionPayload
 
+export interface AgentChannelDeliveryLabelsPayload {
+  action: "add" | "remove" | "replace"
+  labels: readonly string[]
+}
+
 export type AgentChannelDeliveryStatusState = "error" | "failure" | "pending" | "success" | (string & {})
 
 export interface AgentChannelDeliveryStatusPayload {
@@ -257,7 +262,8 @@ export interface AgentChannelDeliveryStatusPayload {
 export type AgentChannelDeliveryStatusInput = AgentChannelDeliveryStatusState | AgentChannelDeliveryStatusPayload
 
 export type AgentChannelDeliveryEffectPayload<TKind extends AgentChannelDeliveryEffectKind> =
-  TKind extends "reaction" ? AgentChannelDeliveryReactionInput
+  TKind extends "labels" ? AgentChannelDeliveryLabelsPayload
+    : TKind extends "reaction" ? AgentChannelDeliveryReactionInput
     : TKind extends "reply" ? AgentChannelDeliveryReplyInput
       : TKind extends "status" ? AgentChannelDeliveryStatusInput
         : unknown

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -988,9 +988,12 @@ describe("agent channels", () => {
   it("surfaces GitHub pull request label API failures", async () => {
     const { github } = await import("../src/channels.ts")
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
-    const fetcher = vi.fn(async (url: string | URL | Request) => {
+    const fetcher = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
       if (String(url).endsWith("/access_tokens")) {
         return Response.json({ token: "installation-token" })
+      }
+      if (init?.method === "DELETE") {
+        return Response.json({ message: "Not Found" }, { status: 404 })
       }
       return Response.json({ message: "unprocessable" }, { status: 422 })
     })
@@ -1030,6 +1033,32 @@ describe("agent channels", () => {
       runtime: "unknown",
       waitUntil: vi.fn(),
     } as never)).rejects.toThrow("GitHub delivery effect failed with 422")
+
+    await expect(labelsEffect({
+      channel,
+      effect: { kind: "labels", payload: { action: "remove", labels: ["agent:working"] } },
+      input: {
+        context: {
+          pullRequest: {
+            pullRequest: { number: 42 },
+            repository: { fullName: "vite-hub/vitehub", name: "vitehub", owner: "vite-hub" },
+            run: { runId: "run-1" },
+            trigger: {
+              action: "labeled",
+              deliveryId: "delivery-1",
+              event: "pull_request",
+              installationId: 456,
+              label: { name: "agent:ready" },
+              sender: { id: 1, login: "mona" },
+            },
+          },
+        },
+        prompt: "Maintain this pull request.",
+      },
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    } as never)).rejects.toThrow("GitHub delivery effect failed with 404")
   })
 
   it("uses admitted issue-comment context as the only GitHub label target", async () => {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -882,6 +882,205 @@ describe("agent channels", () => {
     )
   })
 
+  it("changes pull request labels through the triggering GitHub App installation", async () => {
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs1" }).toString()
+    const fetcher = vi.fn(async (url: string | URL | Request) => {
+      if (String(url).endsWith("/app/installations/123/access_tokens")) {
+        return Response.json({ expires_at: new Date(Date.now() + 600_000).toISOString(), token: "installation-token" })
+      }
+      return Response.json({ ok: true })
+    })
+    const channel = github({
+      app: {
+        apiBaseUrl: "https://api.github.test",
+        appId: "label-effects",
+        fetch: fetcher as typeof fetch,
+        privateKey: privateKeyPem,
+      },
+    })
+    const labelsEffect = channel.effects?.labels
+    if (typeof labelsEffect !== "function") throw new Error("Missing GitHub labels effect.")
+    const input = {
+      context: {
+        pullRequest: {
+          pullRequest: { number: 42 },
+          repository: { fullName: "vite-hub/vitehub", id: 1001, name: "vitehub", owner: "vite-hub" },
+          run: { messageId: "delivery-1", origin: "github-pull-request-labeled", runId: "run-1", threadId: "thread-1" },
+          trigger: {
+            action: "labeled",
+            deliveryId: "delivery-1",
+            event: "pull_request",
+            installationId: 123,
+            label: { name: "agent:ready" },
+            sender: { id: 1, login: "mona" },
+          },
+        },
+      },
+      prompt: "Maintain this pull request.",
+    }
+    const invoke = async (
+      payload: { action: "add" | "remove" | "replace", github?: Record<string, unknown>, labels: string[] },
+      metadata?: Record<string, unknown>,
+    ) => await labelsEffect({
+      channel,
+      effect: { kind: "labels", ...(metadata ? { metadata } : {}), payload },
+      input,
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    } as never)
+
+    const attackerTarget = {
+      commentId: 1,
+      installationId: 999,
+      issueNumber: 1,
+      owner: "attacker",
+      pullRequestUrl: "https://api.github.test/repos/attacker/repo/pulls/1",
+      repo: "repo",
+      repository: "attacker/repo",
+    }
+    await invoke({ action: "add", github: attackerTarget, labels: ["agent:working"] }, { github: attackerTarget })
+    await invoke({ action: "remove", labels: ["agent:ready", "needs review"] })
+    await invoke({ action: "replace", labels: ["agent:done", "bug"] })
+
+    const calls = fetcher.mock.calls.slice(1)
+    expect(calls).toEqual([
+      ["https://api.github.test/repos/vite-hub/vitehub/issues/42/labels", expect.objectContaining({
+        body: JSON.stringify({ labels: ["agent:working"] }),
+        headers: expect.objectContaining({ authorization: "Bearer installation-token" }),
+        method: "POST",
+      })],
+      ["https://api.github.test/repos/vite-hub/vitehub/issues/42/labels/agent%3Aready", expect.objectContaining({
+        headers: expect.objectContaining({ authorization: "Bearer installation-token" }),
+        method: "DELETE",
+      })],
+      ["https://api.github.test/repos/vite-hub/vitehub/issues/42/labels/needs%20review", expect.objectContaining({
+        headers: expect.objectContaining({ authorization: "Bearer installation-token" }),
+        method: "DELETE",
+      })],
+      ["https://api.github.test/repos/vite-hub/vitehub/issues/42/labels", expect.objectContaining({
+        body: JSON.stringify({ labels: ["agent:done", "bug"] }),
+        headers: expect.objectContaining({ authorization: "Bearer installation-token" }),
+        method: "PUT",
+      })],
+    ])
+  })
+
+  it("surfaces GitHub pull request label API failures", async () => {
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const fetcher = vi.fn(async (url: string | URL | Request) => {
+      if (String(url).endsWith("/access_tokens")) {
+        return Response.json({ token: "installation-token" })
+      }
+      return Response.json({ message: "unprocessable" }, { status: 422 })
+    })
+    const channel = github({
+      app: {
+        apiBaseUrl: "https://api.github.test",
+        appId: "label-effects-failure",
+        fetch: fetcher as typeof fetch,
+        privateKey: privateKey.export({ format: "pem", type: "pkcs1" }).toString(),
+      },
+    })
+    const labelsEffect = channel.effects?.labels
+    if (typeof labelsEffect !== "function") throw new Error("Missing GitHub labels effect.")
+
+    await expect(labelsEffect({
+      channel,
+      effect: { kind: "labels", payload: { action: "add", labels: ["agent:working"] } },
+      input: {
+        context: {
+          pullRequest: {
+            pullRequest: { number: 42 },
+            repository: { fullName: "vite-hub/vitehub", name: "vitehub", owner: "vite-hub" },
+            run: { runId: "run-1" },
+            trigger: {
+              action: "labeled",
+              deliveryId: "delivery-1",
+              event: "pull_request",
+              installationId: 456,
+              label: { name: "agent:ready" },
+              sender: { id: 1, login: "mona" },
+            },
+          },
+        },
+        prompt: "Maintain this pull request.",
+      },
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    } as never)).rejects.toThrow("GitHub delivery effect failed with 422")
+  })
+
+  it("uses admitted issue-comment context as the only GitHub label target", async () => {
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const fetcher = vi.fn(async (url: string | URL | Request) => {
+      if (String(url).endsWith("/app/installations/321/access_tokens")) {
+        return Response.json({ token: "installation-token" })
+      }
+      return Response.json({ ok: true })
+    })
+    const channel = github({
+      app: {
+        apiBaseUrl: "https://api.github.test",
+        appId: "comment-label-effects",
+        fetch: fetcher as typeof fetch,
+        privateKey: privateKey.export({ format: "pem", type: "pkcs1" }).toString(),
+      },
+    })
+    const labelsEffect = channel.effects?.labels
+    if (typeof labelsEffect !== "function") throw new Error("Missing GitHub labels effect.")
+    const attackerTarget = {
+      commentId: 1,
+      installationId: 999,
+      issueNumber: 1,
+      owner: "attacker",
+      pullRequestUrl: "https://api.github.test/repos/attacker/repo/pulls/1",
+      repo: "repo",
+      repository: "attacker/repo",
+    }
+
+    await labelsEffect({
+      channel,
+      effect: {
+        kind: "labels",
+        metadata: { github: attackerTarget },
+        payload: { action: "add", github: attackerTarget, labels: ["agent:working"] },
+      },
+      input: {
+        context: {
+          github: {
+            action: "created",
+            actor: { login: "mona" },
+            args: "",
+            body: "/review",
+            command: "/review",
+            commentId: 99,
+            installationId: 321,
+            issueNumber: 42,
+            owner: "vite-hub",
+            pullRequestUrl: "https://api.github.test/repos/vite-hub/vitehub/pulls/42",
+            repo: "vitehub",
+            repository: "vite-hub/vitehub",
+          },
+        },
+        prompt: "/review",
+      },
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    } as never)
+
+    expect(fetcher.mock.calls.map(([url]) => String(url))).toEqual([
+      "https://api.github.test/app/installations/321/access_tokens",
+      "https://api.github.test/repos/vite-hub/vitehub/issues/42/labels",
+    ])
+  })
+
   it("publishes Workspace image paths before posting GitHub PR replies", async () => {
     const { github } = await import("../src/channels.ts")
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -825,7 +825,6 @@ describe("agent channels", () => {
         apiBaseUrl: "https://api.github.test",
         appId: "1",
         fetch: fetcher as typeof fetch,
-        installationId: 123,
         privateKey: privateKeyPem,
       },
     })
@@ -843,6 +842,22 @@ describe("agent channels", () => {
           url: "https://assets.example/review/screenshots/login.png",
         }],
         kind: "review",
+        metadata: {
+          github: {
+            action: "created",
+            actor: { login: "onmax" },
+            args: "",
+            body: "/review",
+            command: "/review",
+            commentId: 99,
+            installationId: 123,
+            issueNumber: 42,
+            owner: "vite-hub",
+            pullRequestUrl: "https://api.github.test/repos/vite-hub/vitehub/pulls/42",
+            repo: "vitehub",
+            repository: "vite-hub/vitehub",
+          },
+        },
         payload: { body: "Review body\n\n![Login badge](/workspace/codex-session/screenshots/login.png)" },
       },
       input: {
@@ -854,7 +869,6 @@ describe("agent channels", () => {
             body: "/review",
             command: "/review",
             commentId: 99,
-            installationId: 123,
             issueNumber: 42,
             owner: "vite-hub",
             pullRequestUrl: "https://api.github.test/repos/vite-hub/vitehub/pulls/42",
@@ -889,6 +903,9 @@ describe("agent channels", () => {
     const fetcher = vi.fn(async (url: string | URL | Request) => {
       if (String(url).endsWith("/app/installations/123/access_tokens")) {
         return Response.json({ expires_at: new Date(Date.now() + 600_000).toISOString(), token: "installation-token" })
+      }
+      if (String(url).endsWith("/labels/agent%3Aready")) {
+        return Response.json({ message: "Label does not exist" }, { status: 404 })
       }
       return Response.json({ ok: true })
     })

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -2,7 +2,7 @@ import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
-import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
+import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestLabelsEffectPayload, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
@@ -1050,6 +1050,13 @@ describe("agent public types", () => {
         id: "feedback",
         prepare(context) {
           context.delivery.effect({ intent: "started", kind: "reaction" })
+          context.delivery.effect({
+            kind: "labels",
+            payload: {
+              action: "replace",
+              labels: ["agent:done"],
+            } satisfies GitHubPullRequestLabelsEffectPayload,
+          })
           context.delivery.finishEffect(context => context.reply(String(context.output)))
         },
       }, inputCommands({


### PR DESCRIPTION
Adds a first-class `labels` delivery effect for GitHub pull requests with generic `add`, `remove`, and `replace` actions. It uses the existing GitHub App installation-token path and targets the admitted pull request context, so applications can compose ready, working, done, or blocked lifecycle policy without ViteHub hard-coding those labels.

The effect maps to GitHub's POST, DELETE, and PUT issue-label endpoints, surfaces API failures, and supports both issue-comment and labeled-event runs. Effect payload or metadata cannot override the admitted repository, pull request, or installation; hostile-override tests cover both context shapes. Public channel documentation includes the effect contract and an Agent Definition example. This stacks on #756.

Verification: focused channel suite (23 tests), dependency and package builds, package typecheck, and `git diff --check`. A base-branch diff review found no actionable correctness, maintainability, security, or documentation issues.