### PR TITLE
fix(blob): keep Cloudflare R2 provider-native

### DIFF
--- a/packages/blob/fixtures/cloudflare-r2-consumer/vite.config.ts
+++ b/packages/blob/fixtures/cloudflare-r2-consumer/vite.config.ts
@@ -1,0 +1,18 @@
+import { hubBlob } from "@vite-hub/blob/vite"
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  build: {
+    outDir: "dist/cloudflare",
+    rollupOptions: {
+      external: ["cloudflare:workers"],
+      input: ".vitehub/nitro/blob/runtime.mjs",
+      output: { entryFileNames: "server.mjs" },
+    },
+  },
+  nitro: { preset: "cloudflare_module" },
+  plugins: [
+    { name: "nitro:main" },
+    hubBlob({ binding: "BLOB", bucketName: "assets", driver: "cloudflare-r2" }),
+  ],
+})

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -34,6 +34,7 @@
     "./drivers/azure": "./dist/drivers/azure.js",
     "./drivers/box": "./dist/drivers/box.js",
     "./drivers/cloudflare": "./dist/drivers/cloudflare.js",
+    "./drivers/cloudflare-native": "./dist/drivers/cloudflare-native.js",
     "./drivers/digitalocean-spaces": "./dist/drivers/digitalocean-spaces.js",
     "./drivers/dropbox": "./dist/drivers/dropbox.js",
     "./drivers/files": "./dist/drivers/files.js",
@@ -69,6 +70,7 @@
   },
   "dependencies": {
     "@vercel/blob": "catalog:storage",
+    "aws4fetch": "catalog:storage",
     "defu": "catalog:unjs",
     "esbuild": "catalog:esbuild-v27",
     "h3": "catalog:unjs",

--- a/packages/blob/src/drivers/cloudflare-native.ts
+++ b/packages/blob/src/drivers/cloudflare-native.ts
@@ -1,0 +1,144 @@
+import { getActiveCloudflareBinding } from "../runtime/state.ts"
+import { runtimeValue } from "./cloudflare-runtime.ts"
+
+import { AwsClient } from "aws4fetch"
+
+import type { BlobDriverAdapter, BlobListOptions, BlobListResult, BlobObject, BlobPutBody, BlobPutOptions, BlobSignedRequest, BlobSignOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
+
+interface R2ObjectLike {
+  arrayBuffer?: () => Promise<ArrayBuffer>
+  body?: ReadableStream
+  customMetadata?: Record<string, string>
+  httpEtag?: string
+  httpMetadata?: { contentType?: string }
+  key: string
+  size?: number
+  uploaded?: Date
+}
+
+interface R2BucketLike {
+  delete(key: string): Promise<void>
+  get(key: string): Promise<R2ObjectLike | null>
+  head(key: string): Promise<R2ObjectLike | null>
+  list(options?: { cursor?: string, delimiter?: string, include?: string[], limit?: number, prefix?: string }): Promise<{ cursor?: string, delimitedPrefixes?: string[], objects: R2ObjectLike[], truncated?: boolean }>
+  put(key: string, value: BlobPutBody, options?: { customMetadata?: Record<string, string>, httpMetadata?: { contentType?: string } }): Promise<R2ObjectLike>
+}
+
+export function getOptionalBucket(options: ResolvedCloudflareR2BlobStoreConfig): R2BucketLike | undefined {
+  return getActiveCloudflareBinding<R2BucketLike>(options.binding)
+    || (globalThis as any)[options.binding]
+}
+
+function getBucket(options: ResolvedCloudflareR2BlobStoreConfig): R2BucketLike {
+  const binding = getOptionalBucket(options)
+  if (!binding) {
+    throw new Error(`R2 binding "${options.binding}" not found`)
+  }
+
+  return binding
+}
+
+function mapObject(object: R2ObjectLike): BlobObject {
+  const contentType = object.httpMetadata?.contentType
+  return {
+    contentType,
+    customMetadata: object.customMetadata || {},
+    httpEtag: object.httpEtag,
+    httpMetadata: contentType ? { contentType } : {},
+    pathname: object.key,
+    size: object.size,
+    uploadedAt: object.uploaded || new Date(),
+  }
+}
+
+async function readArrayBuffer(object: R2ObjectLike): Promise<ArrayBuffer> {
+  if (typeof object.arrayBuffer === "function") {
+    return await object.arrayBuffer()
+  }
+  if (object.body) {
+    return await new Response(object.body).arrayBuffer()
+  }
+  return new ArrayBuffer(0)
+}
+
+function encodePathname(pathname: string): string {
+  return pathname.split("/").map(encodeURIComponent).join("/")
+}
+
+async function signRequest(options: ResolvedCloudflareR2BlobStoreConfig, pathname: string, signOptions: BlobSignOptions): Promise<BlobSignedRequest> {
+  const accountId = runtimeValue(options.accountId, "R2_ACCOUNT_ID", "CLOUDFLARE_R2_ACCOUNT_ID", "CLOUDFLARE_ACCOUNT_ID")
+  const accessKeyId = runtimeValue(options.accessKeyId, "R2_ACCESS_KEY_ID", "CLOUDFLARE_R2_ACCESS_KEY_ID")
+  const secretAccessKey = runtimeValue(options.secretAccessKey, "R2_SECRET_ACCESS_KEY", "CLOUDFLARE_R2_SECRET_ACCESS_KEY")
+  const bucket = runtimeValue(options.bucketName, "BLOB_BUCKET_NAME", "CLOUDFLARE_R2_BUCKET_NAME", "R2_BUCKET_NAME")
+  if (!accountId || !accessKeyId || !secretAccessKey || !bucket) {
+    throw new Error("Cloudflare R2 signed requests require `accountId`, `accessKeyId`, `secretAccessKey`, and `bucketName` HTTP credentials.")
+  }
+
+  const headers: Record<string, string> = {}
+  if (signOptions.method === "PUT") {
+    if (signOptions.contentType) headers["Content-Type"] = signOptions.contentType
+    if (signOptions.createOnly) headers["If-None-Match"] = "*"
+  }
+  const url = new URL(`https://${accountId}.r2.cloudflarestorage.com/${encodeURIComponent(bucket)}/${encodePathname(pathname)}`)
+  url.searchParams.set("X-Amz-Expires", String(signOptions.expiresIn))
+  const client = new AwsClient({ accessKeyId, region: "auto", secretAccessKey, service: "s3" })
+  const signed = await client.sign(url, {
+    headers,
+    method: signOptions.method,
+    aws: { allHeaders: true, signQuery: true },
+  })
+  return {
+    headers,
+    method: signOptions.method,
+    url: signed.url.toString(),
+  }
+}
+
+export function createDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig> {
+  return {
+    name: "cloudflare-r2",
+    options,
+    async delete(pathnames) {
+      await Promise.all((Array.isArray(pathnames) ? pathnames : [pathnames]).map(pathname => getBucket(options).delete(pathname)))
+    },
+    async get(pathname) {
+      const object = await getBucket(options).get(pathname)
+      if (!object) return null
+      const bytes = await readArrayBuffer(object)
+      return new Blob([bytes], { type: object.httpMetadata?.contentType || "" })
+    },
+    async getArrayBuffer(pathname) {
+      const object = await getBucket(options).get(pathname)
+      return object ? await readArrayBuffer(object) : null
+    },
+    async head(pathname) {
+      const object = await getBucket(options).head(pathname)
+      return object ? mapObject(object) : null
+    },
+    async list(listOptions: BlobListOptions = {}): Promise<BlobListResult> {
+      const result = await getBucket(options).list({
+        cursor: listOptions.cursor,
+        delimiter: listOptions.folded ? "/" : undefined,
+        include: ["customMetadata", "httpMetadata"],
+        limit: listOptions.limit ?? 1000,
+        prefix: listOptions.prefix,
+      })
+      return {
+        blobs: result.objects.map(mapObject),
+        cursor: result.truncated ? result.cursor : undefined,
+        folders: listOptions.folded ? result.delimitedPrefixes?.sort((left, right) => left.localeCompare(right)) : undefined,
+        hasMore: Boolean(result.truncated || result.cursor),
+      }
+    },
+    async put(pathname: string, body: BlobPutBody, putOptions: BlobPutOptions = {}) {
+      const object = await getBucket(options).put(pathname, body, {
+        customMetadata: putOptions.customMetadata,
+        httpMetadata: {
+          contentType: putOptions.contentType || (body instanceof Blob ? body.type : undefined),
+        },
+      })
+      return mapObject(object)
+    },
+    sign: (pathname, signOptions) => signRequest(options, pathname, signOptions),
+  }
+}

--- a/packages/blob/src/drivers/cloudflare-runtime.ts
+++ b/packages/blob/src/drivers/cloudflare-runtime.ts
@@ -1,0 +1,11 @@
+import { readEnv, trimmed } from "@vite-hub/internal/env"
+
+import { isMaskedBlobRuntimeValue } from "../config.ts"
+import { getActiveCloudflareEnv } from "../runtime/state.ts"
+
+export function runtimeValue(value: string | undefined, ...envNames: string[]): string | undefined {
+  const current = trimmed(value)
+  const env = getActiveCloudflareEnv() as Record<string, string | undefined> | undefined
+    || (typeof process === "undefined" ? {} : process.env)
+  return isMaskedBlobRuntimeValue(current) ? readEnv(env, ...envNames) : current
+}

--- a/packages/blob/src/drivers/cloudflare.ts
+++ b/packages/blob/src/drivers/cloudflare.ts
@@ -1,53 +1,11 @@
-import { readEnv, trimmed } from "@vite-hub/internal/env"
-
-import { isMaskedBlobRuntimeValue } from "../config.ts"
 import { importOptionalPeer } from "../internal/optional-peer.ts"
-import { getActiveCloudflareBinding, getActiveCloudflareEnv } from "../runtime/state.ts"
+import { createDriver as createNativeDriver, getOptionalBucket } from "./cloudflare-native.ts"
+import { runtimeValue } from "./cloudflare-runtime.ts"
 import { createFilesSdkDriver } from "./files-sdk.ts"
 
-import type { BlobDriverAdapter, BlobListOptions, BlobListResult, BlobObject, BlobPutBody, BlobPutOptions, BlobSignedRequest, BlobSignOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
+import type { BlobDriverAdapter, BlobSignedRequest, BlobSignOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
 
 const s3PeerInstall = "files-sdk @aws-sdk/client-s3 @aws-sdk/lib-storage @aws-sdk/s3-presigned-post @aws-sdk/s3-request-presigner"
-
-interface R2ObjectLike {
-  arrayBuffer?: () => Promise<ArrayBuffer>
-  body?: ReadableStream
-  customMetadata?: Record<string, string>
-  httpEtag?: string
-  httpMetadata?: { contentType?: string }
-  key: string
-  size?: number
-  uploaded?: Date
-}
-
-interface R2BucketLike {
-  delete(key: string): Promise<void>
-  get(key: string): Promise<R2ObjectLike | null>
-  head(key: string): Promise<R2ObjectLike | null>
-  list(options?: { cursor?: string, delimiter?: string, include?: string[], limit?: number, prefix?: string }): Promise<{ cursor?: string, delimitedPrefixes?: string[], objects: R2ObjectLike[], truncated?: boolean }>
-  put(key: string, value: BlobPutBody, options?: { customMetadata?: Record<string, string>, httpMetadata?: { contentType?: string } }): Promise<R2ObjectLike>
-}
-
-function getOptionalBucket(options: ResolvedCloudflareR2BlobStoreConfig): R2BucketLike | undefined {
-  return getActiveCloudflareBinding<R2BucketLike>(options.binding)
-    || (globalThis as any)[options.binding]
-}
-
-function getBucket(options: ResolvedCloudflareR2BlobStoreConfig): R2BucketLike {
-  const binding = getOptionalBucket(options)
-  if (!binding) {
-    throw new Error(`R2 binding "${options.binding}" not found`)
-  }
-
-  return binding
-}
-
-function runtimeValue(value: string | undefined, ...envNames: string[]): string | undefined {
-  const current = trimmed(value)
-  const env = getActiveCloudflareEnv() as Record<string, string | undefined> | undefined
-    || (typeof process === "undefined" ? {} : process.env)
-  return isMaskedBlobRuntimeValue(current) ? readEnv(env, ...envNames) : current
-}
 
 function createHttpDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig> {
   const bucketName = runtimeValue(options.bucketName, "BLOB_BUCKET_NAME", "CLOUDFLARE_R2_BUCKET_NAME", "R2_BUCKET_NAME")
@@ -107,77 +65,6 @@ async function signRequest(options: ResolvedCloudflareR2BlobStoreConfig, pathnam
         ? new Set(["content-type"])
         : undefined,
     }),
-  }
-}
-
-function mapObject(object: R2ObjectLike): BlobObject {
-  const contentType = object.httpMetadata?.contentType
-  return {
-    contentType,
-    customMetadata: object.customMetadata || {},
-    httpEtag: object.httpEtag,
-    httpMetadata: contentType ? { contentType } : {},
-    pathname: object.key,
-    size: object.size,
-    uploadedAt: object.uploaded || new Date(),
-  }
-}
-
-async function readArrayBuffer(object: R2ObjectLike): Promise<ArrayBuffer> {
-  if (typeof object.arrayBuffer === "function") {
-    return await object.arrayBuffer()
-  }
-  if (object.body) {
-    return await new Response(object.body).arrayBuffer()
-  }
-  return new ArrayBuffer(0)
-}
-
-function createNativeDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig> {
-  return {
-    name: "cloudflare-r2",
-    options,
-    async delete(pathnames) {
-      await Promise.all((Array.isArray(pathnames) ? pathnames : [pathnames]).map(pathname => getBucket(options).delete(pathname)))
-    },
-    async get(pathname) {
-      const object = await getBucket(options).get(pathname)
-      if (!object) return null
-      const bytes = await readArrayBuffer(object)
-      return new Blob([bytes], { type: object.httpMetadata?.contentType || "" })
-    },
-    async getArrayBuffer(pathname) {
-      const object = await getBucket(options).get(pathname)
-      return object ? await readArrayBuffer(object) : null
-    },
-    async head(pathname) {
-      const object = await getBucket(options).head(pathname)
-      return object ? mapObject(object) : null
-    },
-    async list(listOptions: BlobListOptions = {}): Promise<BlobListResult> {
-      const result = await getBucket(options).list({
-        cursor: listOptions.cursor,
-        delimiter: listOptions.folded ? "/" : undefined,
-        include: ["customMetadata", "httpMetadata"],
-        limit: listOptions.limit ?? 1000,
-        prefix: listOptions.prefix,
-      })
-      return {
-        blobs: result.objects.map(mapObject),
-        cursor: result.truncated ? result.cursor : undefined,
-        folders: listOptions.folded ? result.delimitedPrefixes?.sort((left, right) => left.localeCompare(right)) : undefined,
-        hasMore: Boolean(result.truncated || result.cursor),
-      }
-    },
-    async put(pathname: string, body: BlobPutBody, putOptions: BlobPutOptions = {}) {
-      const object = await getBucket(options).put(pathname, body, {
-        customMetadata: putOptions.customMetadata,
-        httpMetadata: {
-          contentType: putOptions.contentType || (body instanceof Blob ? body.type : undefined),
-        },
-      })
-      return mapObject(object)
-    },
   }
 }
 

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -536,14 +536,17 @@ async function copyVercelBlobRuntimePackages(options: GenerateProviderOutputsOpt
   await writeFile(resolve(options.rootDir, ".vercel/output/functions", options.serverFunctionName ?? "__server.func", vercelBlobOutputMarker), "", "utf8")
 }
 
-async function hasVercelBlobOutput(options: GenerateProviderOutputsOptions) {
-  try {
-    await access(resolve(options.rootDir, ".vercel/output/functions", options.serverFunctionName ?? "__server.func", vercelBlobOutputMarker))
-    return true
+async function getVercelBlobOutputNames(options: GenerateProviderOutputsOptions) {
+  const names = [...new Set([options.serverFunctionName ?? "__server.func", "__blob.func"])]
+  const owned: string[] = []
+  for (const name of names) {
+    try {
+      await access(resolve(options.rootDir, ".vercel/output/functions", name, vercelBlobOutputMarker))
+      owned.push(name)
+    }
+    catch {}
   }
-  catch {
-    return false
-  }
+  return owned
 }
 
 function registerSupportedProviderRuntimeModules(
@@ -560,7 +563,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   const localOnly = !shouldCreateProviderOutput(options.blob)
   const createCloudflare = !localOnly && !options.cloudflareOwnedByNitro
   const createVercel = !localOnly && !options.cloudflareOwnedByNitro
-  const cleanupVercel = options.cloudflareOwnedByNitro && await hasVercelBlobOutput(options)
+  const cleanupVercel = options.cloudflareOwnedByNitro ? await getVercelBlobOutputNames(options) : []
   const hasCurrentCloudflareContribution = Boolean(createCloudflareR2Bindings(resolveBlobConfig(options.blob, "cloudflare"))?.length)
   if (options.cloudflareOwnedByNitro) {
     await writeProviderDeploymentOutputs({
@@ -569,11 +572,17 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
       rootDir: options.rootDir,
     })
   }
+  for (const serverFunctionName of cleanupVercel) {
+    await writeProviderDeploymentOutputs({
+      clientOutDir: options.clientOutDir,
+      cleanup: { vercel: { serverFunctionName } },
+      rootDir: options.rootDir,
+    })
+  }
   await writeProviderDeploymentOutputs({
     afterWrite: createVercel ? () => copyVercelBlobRuntimePackages(options) : undefined,
     clientOutDir: options.clientOutDir,
     cloudflare: createCloudflare ? createCloudflareOutput(options.blob, artifacts, options.providerOutput) : undefined,
-    cleanup: cleanupVercel ? { vercel: { serverFunctionName: options.serverFunctionName ?? "__server.func" } } : undefined,
     rootDir: options.rootDir,
     vercel: createVercel ? createVercelOutput(artifacts, options.providerOutput, options.serverFunctionName) : undefined,
   })

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -92,6 +92,7 @@ const driverModules = {
 } satisfies Record<NonNullable<ResolvedBlobModuleOptions["store"]>["driver"], string>
 
 function getDriverModule(driver: NonNullable<ResolvedBlobModuleOptions["store"]>["driver"], provider?: BlobProvider) {
+  if (driver === "cloudflare-r2" && provider === "cloudflare") return "drivers/cloudflare-native"
   if (driver === "vercel-blob" && provider === "vercel") return "drivers/vercel-bundled"
   return driverModules[driver]
 }
@@ -542,6 +543,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.blob)
   const localOnly = !shouldCreateProviderOutput(options.blob)
   const createCloudflare = !localOnly && !options.cloudflareOwnedByNitro
+  const createVercel = !localOnly && !options.cloudflareOwnedByNitro
   const hasCurrentCloudflareContribution = Boolean(createCloudflareR2Bindings(resolveBlobConfig(options.blob, "cloudflare"))?.length)
   if (options.cloudflareOwnedByNitro) {
     await writeProviderDeploymentOutputs({
@@ -551,11 +553,14 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     })
   }
   await writeProviderDeploymentOutputs({
-    afterWrite: localOnly ? undefined : () => copyVercelBlobRuntimePackages(options),
+    afterWrite: createVercel ? () => copyVercelBlobRuntimePackages(options) : undefined,
     clientOutDir: options.clientOutDir,
     cloudflare: createCloudflare ? createCloudflareOutput(options.blob, artifacts, options.providerOutput) : undefined,
+    cleanup: options.cloudflareOwnedByNitro
+      ? { vercel: { serverFunctionName: options.serverFunctionName ?? "__server.func" } }
+      : undefined,
     rootDir: options.rootDir,
-    vercel: localOnly ? undefined : createVercelOutput(artifacts, options.providerOutput, options.serverFunctionName),
+    vercel: createVercel ? createVercelOutput(artifacts, options.providerOutput, options.serverFunctionName) : undefined,
   })
   if (createCloudflare) {
     const r2Buckets = createCloudflareR2Bindings(resolveBlobConfig(options.blob, "cloudflare"))

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -534,7 +534,8 @@ async function copyVercelBlobRuntimePackages(options: GenerateProviderOutputsOpt
       serverFunctionName: options.serverFunctionName,
     })
   }
-  const shared = Object.entries(options.providerOutput?.runtimeModuleFilesByProduct || {})
+  const isolated = Boolean(options.serverFunctionName && options.serverFunctionName !== "__server.func")
+  const shared = !isolated && Object.entries(options.providerOutput?.runtimeModuleFilesByProduct || {})
     .some(([product, modules]) => product !== productName && modules?.vercel)
   if (!shared) {
     const outputName = options.serverFunctionName ?? "__server.func"

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -533,11 +533,13 @@ async function copyVercelBlobRuntimePackages(options: GenerateProviderOutputsOpt
       serverFunctionName: options.serverFunctionName,
     })
   }
-  await writeFile(resolve(options.rootDir, ".vercel/output/functions", options.serverFunctionName ?? "__server.func", vercelBlobOutputMarker), "", "utf8")
+  if (options.serverFunctionName && options.serverFunctionName !== "__server.func") {
+    await writeFile(resolve(options.rootDir, ".vercel/output/functions", options.serverFunctionName, vercelBlobOutputMarker), "", "utf8")
+  }
 }
 
 async function getVercelBlobOutputNames(options: GenerateProviderOutputsOptions) {
-  const names = [...new Set([options.serverFunctionName ?? "__server.func", "__blob.func"])]
+  const names = [...new Set([options.serverFunctionName, "__blob.func"].filter((name): name is string => Boolean(name && name !== "__server.func")))]
   const owned: string[] = []
   for (const name of names) {
     try {

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -560,9 +560,6 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     afterWrite: createVercel ? () => copyVercelBlobRuntimePackages(options) : undefined,
     clientOutDir: options.clientOutDir,
     cloudflare: createCloudflare ? createCloudflareOutput(options.blob, artifacts, options.providerOutput) : undefined,
-    cleanup: options.cloudflareOwnedByNitro
-      ? { vercel: { serverFunctionName: options.serverFunctionName ?? "__server.func" } }
-      : undefined,
     rootDir: options.rootDir,
     vercel: createVercel ? createVercelOutput(artifacts, options.providerOutput, options.serverFunctionName) : undefined,
   })

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -91,8 +91,8 @@ const driverModules = {
   "vercel-blob": "drivers/vercel",
 } satisfies Record<NonNullable<ResolvedBlobModuleOptions["store"]>["driver"], string>
 
-function getDriverModule(driver: NonNullable<ResolvedBlobModuleOptions["store"]>["driver"], provider?: BlobProvider) {
-  if (driver === "cloudflare-r2" && provider === "cloudflare") return "drivers/cloudflare-native"
+function getDriverModule(driver: NonNullable<ResolvedBlobModuleOptions["store"]>["driver"], provider?: BlobProvider, nativeCloudflareR2 = false) {
+  if (driver === "cloudflare-r2" && provider === "cloudflare" && nativeCloudflareR2) return "drivers/cloudflare-native"
   if (driver === "vercel-blob" && provider === "vercel") return "drivers/vercel-bundled"
   return driverModules[driver]
 }
@@ -180,7 +180,8 @@ function renderProviderEntry(
     `import { setBlobRuntimeConfig, setBlobRuntimeStorage } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule("runtime/state")))}`,
     `import { ${spec.factory} } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule(spec.runtimeModule)))}`,
   ]
-  const driverModule = blobConfig ? getDriverModule(blobConfig.store.driver, spec.name) : undefined
+  const nativeCloudflareR2 = Boolean(blobConfig && isCloudflareR2StoreWithBucket(blobConfig.store))
+  const driverModule = blobConfig ? getDriverModule(blobConfig.store.driver, spec.name, nativeCloudflareR2) : undefined
   if (driverModule) {
     imports.push(`import { createBlobStorage } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule("storage")))}`)
     imports.push(`import { createDriver } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule(driverModule)))}`)
@@ -216,7 +217,10 @@ function renderProviderEntry(
 
 export function renderBlobRuntimeModule(file: string, blobConfig: false | ResolvedBlobModuleOptions, provider?: BlobProvider) {
   const stores = blobConfig ? Object.values(blobConfig.stores || { default: blobConfig.store }) : []
-  const selectedDriverModules = [...new Set(stores.map(store => getDriverModule(store.driver, provider)))]
+  const nativeCloudflareR2 = stores
+    .filter(store => store.driver === "cloudflare-r2")
+    .every(isCloudflareR2StoreWithBucket)
+  const selectedDriverModules = [...new Set(stores.map(store => getDriverModule(store.driver, provider, nativeCloudflareR2)))]
   const driverImports = Object.fromEntries(selectedDriverModules.map((driverModule, index) => [driverModule, `createDriver${index}`]))
   const imports = [
     `import { ensureBlob } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule("ensure")))}`,
@@ -235,7 +239,7 @@ export function renderBlobRuntimeModule(file: string, blobConfig: false | Resolv
   }
 
   const createDriverCases = Object.keys(driverModules).map((driver) => {
-    const driverModule = getDriverModule(driver as keyof typeof driverModules, provider)
+    const driverModule = getDriverModule(driver as keyof typeof driverModules, provider, nativeCloudflareR2)
     const driverImport = driverImports[driverModule]
     if (!driverImport) return undefined
     const runtimeStoreResolver = getRuntimeBlobStoreResolver(driver)

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { dirname, resolve } from "pathe"
 
@@ -533,18 +534,26 @@ async function copyVercelBlobRuntimePackages(options: GenerateProviderOutputsOpt
       serverFunctionName: options.serverFunctionName,
     })
   }
-  if (options.serverFunctionName && options.serverFunctionName !== "__server.func") {
-    await writeFile(resolve(options.rootDir, ".vercel/output/functions", options.serverFunctionName, vercelBlobOutputMarker), "", "utf8")
+  const shared = Object.entries(options.providerOutput?.runtimeModuleFilesByProduct || {})
+    .some(([product, modules]) => product !== productName && modules?.vercel)
+  if (!shared) {
+    const outputName = options.serverFunctionName ?? "__server.func"
+    const entry = await readFile(resolve(options.rootDir, ".vercel/output/functions", outputName, "index.mjs"))
+    await writeFile(resolve(options.rootDir, ".vercel/output/functions", outputName, vercelBlobOutputMarker), createHash("sha256").update(entry).digest("hex"), "utf8")
   }
 }
 
 async function getVercelBlobOutputNames(options: GenerateProviderOutputsOptions) {
-  const names = [...new Set([options.serverFunctionName, "__blob.func"].filter((name): name is string => Boolean(name && name !== "__server.func")))]
+  const names = [...new Set([options.serverFunctionName ?? "__server.func", "__blob.func"])]
   const owned: string[] = []
   for (const name of names) {
     try {
-      await access(resolve(options.rootDir, ".vercel/output/functions", name, vercelBlobOutputMarker))
-      owned.push(name)
+      const outputRoot = resolve(options.rootDir, ".vercel/output/functions", name)
+      const [entry, marker] = await Promise.all([
+        readFile(resolve(outputRoot, "index.mjs")),
+        readFile(resolve(outputRoot, vercelBlobOutputMarker), "utf8"),
+      ])
+      if (createHash("sha256").update(entry).digest("hex") === marker) owned.push(name)
     }
     catch {}
   }

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { dirname, resolve } from "pathe"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
@@ -16,6 +16,7 @@ import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, Vercel
 export const blobPackageName = "@vite-hub/blob"
 const cloudflareBlobWorkerMarker = "vitehub-blob-worker"
 const cloudflareBlobOutputState = ".vitehub/blob/cloudflare-output.json"
+const vercelBlobOutputMarker = ".vitehub-blob-output"
 const productName = "blob"
 const packageDir = computePackageDir(import.meta.url)
 const resolveRuntimeModule = (modulePath: string) => resolveRuntimeFromPkg(packageDir, modulePath)
@@ -525,13 +526,24 @@ async function copyVercelBlobRuntimePackages(options: GenerateProviderOutputsOpt
     packages.add("@aws-sdk/s3-presigned-post")
     packages.add("@aws-sdk/s3-request-presigner")
   }
-  if (!packages.size) return
+  if (packages.size) {
+    await copyVercelFunctionRuntimePackages({
+      packages: [...packages].map(name => ({ name, resolveFrom: resolve(packageDir, "package.json") })),
+      rootDir: options.rootDir,
+      serverFunctionName: options.serverFunctionName,
+    })
+  }
+  await writeFile(resolve(options.rootDir, ".vercel/output/functions", options.serverFunctionName ?? "__server.func", vercelBlobOutputMarker), "", "utf8")
+}
 
-  await copyVercelFunctionRuntimePackages({
-    packages: [...packages].map(name => ({ name, resolveFrom: resolve(packageDir, "package.json") })),
-    rootDir: options.rootDir,
-    serverFunctionName: options.serverFunctionName,
-  })
+async function hasVercelBlobOutput(options: GenerateProviderOutputsOptions) {
+  try {
+    await access(resolve(options.rootDir, ".vercel/output/functions", options.serverFunctionName ?? "__server.func", vercelBlobOutputMarker))
+    return true
+  }
+  catch {
+    return false
+  }
 }
 
 function registerSupportedProviderRuntimeModules(
@@ -548,6 +560,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   const localOnly = !shouldCreateProviderOutput(options.blob)
   const createCloudflare = !localOnly && !options.cloudflareOwnedByNitro
   const createVercel = !localOnly && !options.cloudflareOwnedByNitro
+  const cleanupVercel = options.cloudflareOwnedByNitro && await hasVercelBlobOutput(options)
   const hasCurrentCloudflareContribution = Boolean(createCloudflareR2Bindings(resolveBlobConfig(options.blob, "cloudflare"))?.length)
   if (options.cloudflareOwnedByNitro) {
     await writeProviderDeploymentOutputs({
@@ -560,6 +573,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     afterWrite: createVercel ? () => copyVercelBlobRuntimePackages(options) : undefined,
     clientOutDir: options.clientOutDir,
     cloudflare: createCloudflare ? createCloudflareOutput(options.blob, artifacts, options.providerOutput) : undefined,
+    cleanup: cleanupVercel ? { vercel: { serverFunctionName: options.serverFunctionName ?? "__server.func" } } : undefined,
     rootDir: options.rootDir,
     vercel: createVercel ? createVercelOutput(artifacts, options.providerOutput, options.serverFunctionName) : undefined,
   })

--- a/packages/blob/src/runtime/storage.ts
+++ b/packages/blob/src/runtime/storage.ts
@@ -1,6 +1,6 @@
 import { createBlobStorage } from "../storage.ts"
 import { resolveRuntimeMinioBlobStore, resolveRuntimeVercelBlobStore } from "../config.ts"
-import { createDriver as createCloudflareR2Driver } from "../drivers/cloudflare.ts"
+import { createDriver as createCloudflareR2NativeDriver, getOptionalBucket } from "../drivers/cloudflare-native.ts"
 
 import { getBlobRuntimeConfig, getNamedBlobRuntimeStorage, setNamedBlobRuntimeStorage } from "./state.ts"
 
@@ -28,8 +28,8 @@ const driverModules = {
 } satisfies Record<ResolvedBlobStoreConfig["driver"], string>
 
 async function importRuntimeDriver(config: ResolvedBlobStoreConfig) {
-  if (config.driver === "cloudflare-r2") {
-    return createCloudflareR2Driver(config)
+  if (config.driver === "cloudflare-r2" && getOptionalBucket(config)) {
+    return createCloudflareR2NativeDriver(config)
   }
 
   const isSourceRuntime = typeof import.meta !== "undefined"

--- a/packages/blob/src/runtime/storage.ts
+++ b/packages/blob/src/runtime/storage.ts
@@ -4,7 +4,7 @@ import { createDriver as createCloudflareR2NativeDriver, getOptionalBucket } fro
 
 import { getBlobRuntimeConfig, getNamedBlobRuntimeStorage, setNamedBlobRuntimeStorage } from "./state.ts"
 
-import type { BlobObject, BlobStorage, BlobStoreName, ResolvedBlobModuleOptions, ResolvedBlobStoreConfig } from "../types.ts"
+import type { BlobDriverAdapter, BlobObject, BlobStorage, BlobStoreName, ResolvedBlobModuleOptions, ResolvedBlobStoreConfig, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
 
 const driverModules = {
   akamai: "akamai",
@@ -28,10 +28,31 @@ const driverModules = {
 } satisfies Record<ResolvedBlobStoreConfig["driver"], string>
 
 async function importRuntimeDriver(config: ResolvedBlobStoreConfig) {
-  if (config.driver === "cloudflare-r2" && getOptionalBucket(config)) {
-    return createCloudflareR2NativeDriver(config)
+  if (config.driver === "cloudflare-r2") {
+    const nativeDriver = createCloudflareR2NativeDriver(config)
+    let fallbackDriver: Promise<BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig>> | undefined
+    const activeDriver = async () => {
+      if (getOptionalBucket(config)) return nativeDriver
+      fallbackDriver ||= importRuntimeDriverModule(config)
+      return fallbackDriver
+    }
+    return {
+      name: config.driver,
+      options: config,
+      delete: async pathnames => (await activeDriver()).delete(pathnames),
+      get: async pathname => (await activeDriver()).get(pathname),
+      getArrayBuffer: async pathname => (await activeDriver()).getArrayBuffer(pathname),
+      head: async pathname => (await activeDriver()).head(pathname),
+      list: async options => (await activeDriver()).list(options),
+      put: async (pathname, body, options) => (await activeDriver()).put(pathname, body, options),
+      sign: (pathname, options) => nativeDriver.sign!(pathname, options),
+    } satisfies BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig>
   }
 
+  return importRuntimeDriverModule(config)
+}
+
+async function importRuntimeDriverModule(config: ResolvedBlobStoreConfig) {
   const isSourceRuntime = typeof import.meta !== "undefined"
     && typeof import.meta.url === "string"
     && import.meta.url.endsWith(".ts")

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -189,7 +189,7 @@ function renderBlobServeRouteHandler(serve: BlobServeConfig, importBase = blobPa
 async function refreshBlobGeneratedFiles(root: string, blob: BlobViteRuntimeConfig["blob"], cloudflare: boolean, importBase = blobPackageName): Promise<void> {
   const runtimeFile = resolve(root, generatedNitroBlobRuntime)
   await Promise.all([
-    writeFileIfChanged(runtimeFile, renderBlobRuntimeModule(runtimeFile, blob)),
+    writeFileIfChanged(runtimeFile, renderBlobRuntimeModule(runtimeFile, blob, cloudflare ? "cloudflare" : undefined)),
     writeFileIfChanged(resolve(root, generatedNitroBlobPlugin), renderNitroBlobPlugin(blob, cloudflare, importBase)),
     writeFileIfChanged(resolve(root, generatedNitroBlobMiddleware), renderNitroBlobMiddleware(importBase)),
   ])

--- a/packages/blob/test/consumer-runtime.test.ts
+++ b/packages/blob/test/consumer-runtime.test.ts
@@ -167,7 +167,7 @@ describe("hosted Blob consumer runtime", () => {
         await run("node", ["--input-type=module", "--eval", cloudflareSignProbe], appDir)
         await expect(
           readFile(join(appDir, ".vercel/output/functions/__server.func/index.mjs"), "utf8"),
-        ).rejects.toMatchObject({ code: "ENOENT" })
+        ).resolves.toContain("createBlobVercelServer")
       } finally {
         await rm(root, { force: true, recursive: true })
       }

--- a/packages/blob/test/consumer-runtime.test.ts
+++ b/packages/blob/test/consumer-runtime.test.ts
@@ -167,7 +167,7 @@ describe("hosted Blob consumer runtime", () => {
         await run("node", ["--input-type=module", "--eval", cloudflareSignProbe], appDir)
         await expect(
           readFile(join(appDir, ".vercel/output/functions/__server.func/index.mjs"), "utf8"),
-        ).resolves.toContain("createBlobVercelServer")
+        ).rejects.toMatchObject({ code: "ENOENT" })
       } finally {
         await rm(root, { force: true, recursive: true })
       }

--- a/packages/blob/test/consumer-runtime.test.ts
+++ b/packages/blob/test/consumer-runtime.test.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process"
 import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
 import { promisify } from "node:util"
 
 import { describe, expect, it } from "vitest"
@@ -12,6 +13,13 @@ const execFileAsync = promisify(execFile)
 const packageRoot = resolve(import.meta.dirname, "..")
 const workspaceRoot = resolve(packageRoot, "../..")
 const fixtureRoot = resolve(packageRoot, "fixtures/private-vercel-consumer")
+const cloudflareFixtureRoot = resolve(packageRoot, "fixtures/cloudflare-r2-consumer")
+const awsRuntimePackages = [
+  "@aws-sdk/client-s3",
+  "@aws-sdk/lib-storage",
+  "@aws-sdk/s3-presigned-post",
+  "@aws-sdk/s3-request-presigner",
+]
 
 async function run(command: string, args: string[], cwd: string) {
   try {
@@ -33,9 +41,9 @@ async function run(command: string, args: string[], cwd: string) {
   }
 }
 
-describe("private Vercel Blob consumer runtime", () => {
+describe("hosted Blob consumer runtime", () => {
   it(
-    "builds and executes without a consumer-owned files-sdk dependency",
+    "builds private Vercel Blob and Cloudflare R2 without consumer provider dependencies",
     { timeout: 120_000 },
     async () => {
       const root = await mkdtemp(join(tmpdir(), "vitehub-blob-private-vercel-consumer-"))
@@ -107,6 +115,7 @@ describe("private Vercel Blob consumer runtime", () => {
         ) as { dependencies: Record<string, string> }
         expect(consumerManifest.dependencies).not.toHaveProperty("files-sdk")
         expect(consumerManifest.dependencies).not.toHaveProperty("@vercel/blob")
+        for (const name of awsRuntimePackages) expect(consumerManifest.dependencies).not.toHaveProperty(name)
         await run("pnpm", ["run", "build"], appDir)
 
         const runtimeModule = await readFile(
@@ -115,6 +124,50 @@ describe("private Vercel Blob consumer runtime", () => {
         )
         expect(runtimeModule).toContain("drivers/vercel-bundled")
         await probePrivateVercelFunction(appDir)
+
+        await cp(
+          join(cloudflareFixtureRoot, "vite.config.ts"),
+          join(appDir, "vite.config.ts"),
+        )
+        const awsResolveProbe = [
+          `const blob = import.meta.resolve("@vite-hub/blob/package.json")`,
+          `const packages = ${JSON.stringify(awsRuntimePackages)}`,
+          `const reachable = packages.filter((specifier) => { try { import.meta.resolve(specifier, blob); return true } catch { return false } })`,
+          `if (reachable.length) throw new Error(\`AWS runtime packages unexpectedly resolved: \${reachable.join(", ")}\`)`,
+        ].join("\n")
+        await run(
+          "node",
+          ["--experimental-import-meta-resolve", "--input-type=module", "--eval", awsResolveProbe],
+          appDir,
+        )
+        await run("pnpm", ["run", "build"], appDir)
+
+        const cloudflareRuntime = await readFile(
+          join(appDir, ".vitehub/nitro/blob/runtime.mjs"),
+          "utf8",
+        )
+        expect(cloudflareRuntime).toContain("drivers/cloudflare-native")
+        const cloudflareOutput = await readFile(
+          join(appDir, "dist/cloudflare/server.mjs"),
+          "utf8",
+        )
+        expect(cloudflareOutput).not.toContain("files-sdk")
+        expect(cloudflareOutput).not.toContain("@aws-sdk/")
+        const cloudflareSignProbe = [
+          `process.env.R2_ACCOUNT_ID = "account"`,
+          `process.env.R2_ACCESS_KEY_ID = "access-key"`,
+          `process.env.R2_SECRET_ACCESS_KEY = "secret-key"`,
+          `const { blob } = await import(${JSON.stringify(pathToFileURL(join(appDir, ".vitehub/nitro/blob/runtime.mjs")).href)})`,
+          `const signed = await blob.sign("proof/private.txt", { expiresIn: 60, method: "GET" })`,
+          `const url = new URL(signed.url)`,
+          `if (url.hostname !== "account.r2.cloudflarestorage.com") throw new Error("Unexpected R2 signing host")`,
+          `if (url.searchParams.get("X-Amz-Expires") !== "60") throw new Error("Unexpected R2 signing expiry")`,
+          `if (!url.searchParams.get("X-Amz-Signature")) throw new Error("Missing R2 signature")`,
+        ].join("\n")
+        await run("node", ["--input-type=module", "--eval", cloudflareSignProbe], appDir)
+        await expect(
+          readFile(join(appDir, ".vercel/output/functions/__server.func/index.mjs"), "utf8"),
+        ).rejects.toMatchObject({ code: "ENOENT" })
       } finally {
         await rm(root, { force: true, recursive: true })
       }

--- a/packages/blob/test/optional-peer.test.ts
+++ b/packages/blob/test/optional-peer.test.ts
@@ -24,4 +24,11 @@ describe("optional peer imports", () => {
     expect(built).not.toContain('from "files-sdk/vercel-blob"')
     expect(built).toContain('from "@vercel/blob"')
   })
+
+  it("keeps the Cloudflare-native R2 driver free of HTTP fallback peers", async () => {
+    const built = await readFile(new URL("../dist/drivers/cloudflare-native.js", import.meta.url), "utf8")
+
+    expect(built).not.toContain("files-sdk")
+    expect(built).not.toContain("@aws-sdk/")
+  })
 })

--- a/packages/blob/test/runtime.test.ts
+++ b/packages/blob/test/runtime.test.ts
@@ -541,6 +541,33 @@ describe("blob runtime", () => {
     ])
   })
 
+  it("rechecks the active Cloudflare binding after runtime storage is cached", async () => {
+    process.env.CLOUDFLARE_R2_ACCOUNT_ID = "account"
+    process.env.CLOUDFLARE_R2_ACCESS_KEY_ID = "access-key"
+    process.env.CLOUDFLARE_R2_SECRET_ACCESS_KEY = "secret-key"
+    process.env.R2_BUCKET_NAME = "runtime-assets"
+    setBlobRuntimeConfig({
+      store: {
+        accountId: "********",
+        accessKeyId: "********",
+        binding: "BLOB",
+        bucketName: "********",
+        driver: "cloudflare-r2",
+        secretAccessKey: "********",
+      },
+    })
+    setActiveCloudflareEnv({ BLOB: createMemoryBucket() })
+    await blob.list()
+
+    setActiveCloudflareEnv(undefined)
+    await blob.list()
+
+    expect(filesSdkMock.r2).toHaveBeenCalledWith(expect.objectContaining({
+      accountId: "account",
+      bucket: "runtime-assets",
+    }))
+  })
+
   it("keeps Cloudflare binding mode when the binding appears after driver creation", async () => {
     const { createDriver } = await import("../src/drivers/cloudflare.ts")
     const storage = createBlobStorage(createDriver({

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -297,6 +297,7 @@ describe("Vite provider outputs", () => {
       blob: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
       clientOutDir: "dist",
       cloudflareOwnedByNitro: true,
+      providerOutput: { runtimeModuleFilesByProduct: { queue: { vercel: "unused" } } },
       rootDir,
       serverFunctionName: "__blob.func",
     } as const

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -406,7 +406,9 @@ describe("Vite provider outputs", () => {
       rootDir,
     })
 
-    expect(await readFile(join(rootDir, "dist", toSafeAppName(rootDir), "wrangler.json"), "utf8")).not.toContain("\"r2_buckets\"")
+    const outputRoot = join(rootDir, "dist", toSafeAppName(rootDir))
+    expect(await readFile(join(outputRoot, "wrangler.json"), "utf8")).not.toContain("\"r2_buckets\"")
+    expect(await readFile(join(outputRoot, "index.js"), "utf8")).toContain("files-sdk/r2")
   })
 
   it("emits Cloudflare bucket bindings for named R2 stores", { timeout: 15_000 }, async () => {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -336,6 +336,18 @@ describe("Vite provider outputs", () => {
     await expect(readFile(functionFile, "utf8")).resolves.toBe("// shared server\n")
   })
 
+  it("cleans unchanged root Vercel output owned by Blob during Cloudflare builds", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-root-vercel-")
+    const functionFile = join(rootDir, ".vercel/output/functions/__server.func/index.mjs")
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await writeFile(join(rootDir, "src/server.ts"), "export default async () => new Response('ok')\n", "utf8")
+    await generateProviderOutputs({ blob: { driver: "vercel-blob" }, clientOutDir: "dist", rootDir })
+
+    await generateProviderOutputs({ blob: { driver: "vercel-blob" }, clientOutDir: "dist", cloudflareOwnedByNitro: true, rootDir })
+
+    expect(existsSync(functionFile)).toBe(false)
+  })
+
   it("cleans legacy standalone workers without R2 runtime code when Nitro takes ownership", { timeout: 30_000 }, async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-nitro-non-r2-")
     const cloudflareOutput = join(rootDir, "dist", toSafeAppName(rootDir))

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -275,7 +275,7 @@ describe("Vite provider outputs", () => {
     expect(existsSync(join(outputRoot, "functions", "__blob.func", "index.mjs"))).toBe(true)
   })
 
-  it("leaves Cloudflare Worker output to Nitro while retaining Vercel output", { timeout: 45_000 }, async () => {
+  it("leaves provider output to Nitro for Cloudflare builds", { timeout: 45_000 }, async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-nitro-cloudflare-")
     const cloudflareOutput = join(rootDir, "dist", toSafeAppName(rootDir))
     await mkdir(join(rootDir, "src"), { recursive: true })
@@ -320,7 +320,7 @@ describe("Vite provider outputs", () => {
       triggers: { crons: ["0 0 * * *"] },
     })
     expect(existsSync(join(rootDir, ".vercel", "output", "static", toSafeAppName(rootDir), "index.js"))).toBe(false)
-    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__blob.func", "index.mjs"))).toBe(true)
+    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__blob.func", "index.mjs"))).toBe(false)
   })
 
   it("cleans legacy standalone workers without R2 runtime code when Nitro takes ownership", { timeout: 30_000 }, async () => {
@@ -462,8 +462,8 @@ describe("Vite provider outputs", () => {
     })
 
     const cloudflareWorker = await readFile(join(rootDir, "dist", toSafeAppName(rootDir), "index.js"), "utf8")
-    expect(cloudflareWorker).toContain("\"files-sdk\"")
-    expect(cloudflareWorker).toContain("files-sdk/r2")
+    expect(cloudflareWorker).not.toContain("files-sdk")
+    expect(cloudflareWorker).not.toContain("@aws-sdk/")
   })
 
   it("copies Cloudflare R2 runtime packages into isolated Vercel output", { timeout: 15_000 }, async () => {
@@ -589,7 +589,7 @@ describe("Vite provider outputs", () => {
     expect(stdout.trim()).toBe("ok")
   })
 
-  it("statically reaches the Cloudflare R2 driver from bundled SSR output", async () => {
+  it("statically reaches only the native Cloudflare R2 driver from bundled SSR output", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-bundled-r2-")
     const entryFile = join(rootDir, "entry.ts")
     const bundleFile = join(rootDir, "worker.mjs")
@@ -617,6 +617,8 @@ describe("Vite provider outputs", () => {
     expect(bundled).not.toContain("@vite-hub/blob/drivers/cloudflare")
     expect(bundled).toContain("config.driver === \"cloudflare-r2\"")
     expect(bundled).toContain("R2 binding")
+    expect(bundled).not.toContain("files-sdk")
+    expect(bundled).not.toContain("@aws-sdk/")
   })
 
   it("rehydrates masked Vercel tokens from generated runtime output", async () => {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -320,7 +320,18 @@ describe("Vite provider outputs", () => {
       triggers: { crons: ["0 0 * * *"] },
     })
     expect(existsSync(join(rootDir, ".vercel", "output", "static", toSafeAppName(rootDir), "index.js"))).toBe(false)
-    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__blob.func", "index.mjs"))).toBe(true)
+    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__blob.func", "index.mjs"))).toBe(false)
+  })
+
+  it("preserves Vercel functions not owned by Blob during Cloudflare builds", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-shared-vercel-")
+    const functionFile = join(rootDir, ".vercel/output/functions/__server.func/index.mjs")
+    await mkdir(dirname(functionFile), { recursive: true })
+    await writeFile(functionFile, "// database server\n", "utf8")
+
+    await generateProviderOutputs({ blob: { driver: "vercel-blob" }, clientOutDir: "dist", cloudflareOwnedByNitro: true, rootDir })
+
+    await expect(readFile(functionFile, "utf8")).resolves.toBe("// database server\n")
   })
 
   it("cleans legacy standalone workers without R2 runtime code when Nitro takes ownership", { timeout: 30_000 }, async () => {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -313,7 +313,7 @@ describe("Vite provider outputs", () => {
     expect(legacyWorker).toContain("setBlobRuntimeConfig(")
     expect(legacyWorker).toContain("R2 binding")
     await writeFile(join(cloudflareOutput, "index.js"), legacyWorker, "utf8")
-    await generateProviderOutputs(options)
+    await generateProviderOutputs({ ...options, serverFunctionName: undefined })
 
     expect(existsSync(join(cloudflareOutput, "index.js"))).toBe(false)
     await expect(readFile(join(cloudflareOutput, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -326,12 +326,14 @@ describe("Vite provider outputs", () => {
   it("preserves Vercel functions not owned by Blob during Cloudflare builds", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-shared-vercel-")
     const functionFile = join(rootDir, ".vercel/output/functions/__server.func/index.mjs")
-    await mkdir(dirname(functionFile), { recursive: true })
-    await writeFile(functionFile, "// database server\n", "utf8")
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await writeFile(join(rootDir, "src/server.ts"), "export default async () => new Response('ok')\n", "utf8")
+    await generateProviderOutputs({ blob: { driver: "vercel-blob" }, clientOutDir: "dist", rootDir })
+    await writeFile(functionFile, "// shared server\n", "utf8")
 
     await generateProviderOutputs({ blob: { driver: "vercel-blob" }, clientOutDir: "dist", cloudflareOwnedByNitro: true, rootDir })
 
-    await expect(readFile(functionFile, "utf8")).resolves.toBe("// database server\n")
+    await expect(readFile(functionFile, "utf8")).resolves.toBe("// shared server\n")
   })
 
   it("cleans legacy standalone workers without R2 runtime code when Nitro takes ownership", { timeout: 30_000 }, async () => {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -320,7 +320,7 @@ describe("Vite provider outputs", () => {
       triggers: { crons: ["0 0 * * *"] },
     })
     expect(existsSync(join(rootDir, ".vercel", "output", "static", toSafeAppName(rootDir), "index.js"))).toBe(false)
-    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__blob.func", "index.mjs"))).toBe(false)
+    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__blob.func", "index.mjs"))).toBe(true)
   })
 
   it("cleans legacy standalone workers without R2 runtime code when Nitro takes ownership", { timeout: 30_000 }, async () => {

--- a/packages/blob/vite.config.ts
+++ b/packages/blob/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       "src/drivers/azure.ts",
       "src/drivers/box.ts",
       "src/drivers/cloudflare.ts",
+      "src/drivers/cloudflare-native.ts",
       "src/drivers/digitalocean-spaces.ts",
       "src/drivers/dropbox.ts",
       "src/drivers/files.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,9 @@ catalogs:
     '@vercel/blob':
       specifier: ^2.6.1
       version: 2.6.1
+    aws4fetch:
+      specifier: ^1.0.20
+      version: 1.0.20
     files-sdk:
       specifier: ^2.1.0
       version: 2.1.0
@@ -600,6 +603,9 @@ importers:
       '@vercel/blob':
         specifier: catalog:storage
         version: 2.6.1
+      aws4fetch:
+        specifier: catalog:storage
+        version: 1.0.20
       defu:
         specifier: catalog:unjs
         version: 6.1.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -56,6 +56,7 @@ catalogs:
   storage:
     "@upstash/redis": ^1.38.0
     "@vercel/blob": ^2.6.1
+    aws4fetch: ^1.0.20
     files-sdk: ^2.1.0
     unstorage: ^2.0.0-alpha.7
   tooling:


### PR DESCRIPTION
Cloudflare Nitro builds still routed Blob through the mixed R2 fallback graph and Vercel package staging. Clean consumers therefore tried to copy absent AWS SDK peers after Nitro finished, while the Worker retained `files-sdk` and `files-sdk/r2` reachability it could never use with a native R2 binding.

This selects a dedicated binding-native R2 driver only for Cloudflare output, keeps Blob signing runtime-complete through the Blob-owned `aws4fetch` dependency, and skips and cleans Blob-owned Vercel function output when Nitro owns Cloudflare deployment output. Generic, bindingless, and cross-provider R2 use keeps the existing lazy HTTP fallback and optional peers.

The regression packs a production-only consumer with no direct Files SDK or AWS SDK dependencies, builds the generated Cloudflare runtime, executes native signing, and asserts that the output contains neither `files-sdk` nor AWS SDK reachability. The exact Drop `c42ec504` + Queue `8fcbc57` Cloudflare build also completes with no Blob Files/AWS reachability, no `.vercel` output, and unchanged Queue prefix, logical mapping, and R2 bucket identity.

Validated with `@vite-hub/blob` build/publint, typecheck, and all 133 package tests. This PR is stacked on #752 so its diff contains only the Cloudflare R2 provider-output correction.
