### PR TITLE
fix(blob): serialize Vercel output ownership cleanup

### DIFF
--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -543,21 +543,22 @@ async function copyVercelBlobRuntimePackages(options: GenerateProviderOutputsOpt
   }
 }
 
-async function getVercelBlobOutputNames(options: GenerateProviderOutputsOptions) {
-  const names = [...new Set([options.serverFunctionName ?? "__server.func", "__blob.func"])]
-  const owned: string[] = []
-  for (const name of names) {
-    try {
-      const outputRoot = resolve(options.rootDir, ".vercel/output/functions", name)
-      const [entry, marker] = await Promise.all([
-        readFile(resolve(outputRoot, "index.mjs")),
-        readFile(resolve(outputRoot, vercelBlobOutputMarker), "utf8"),
-      ])
-      if (createHash("sha256").update(entry).digest("hex") === marker) owned.push(name)
+function getVercelBlobOutputCleanup(options: GenerateProviderOutputsOptions) {
+  return async () => {
+    const cleanup: Array<{ serverFunctionName: string }> = []
+    for (const name of new Set([options.serverFunctionName, "__blob.func"].filter((name): name is string => Boolean(name && name !== "__server.func")))) {
+      try {
+        const outputRoot = resolve(options.rootDir, ".vercel/output/functions", name)
+        const [entry, marker] = await Promise.all([
+          readFile(resolve(outputRoot, "index.mjs")),
+          readFile(resolve(outputRoot, vercelBlobOutputMarker), "utf8"),
+        ])
+        if (createHash("sha256").update(entry).digest("hex") === marker) cleanup.push({ serverFunctionName: name })
+      }
+      catch {}
     }
-    catch {}
+    return cleanup
   }
-  return owned
 }
 
 function registerSupportedProviderRuntimeModules(
@@ -574,7 +575,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   const localOnly = !shouldCreateProviderOutput(options.blob)
   const createCloudflare = !localOnly && !options.cloudflareOwnedByNitro
   const createVercel = !localOnly && !options.cloudflareOwnedByNitro
-  const cleanupVercel = options.cloudflareOwnedByNitro ? await getVercelBlobOutputNames(options) : []
+  const cleanupVercel = options.cloudflareOwnedByNitro ? getVercelBlobOutputCleanup(options) : undefined
   const hasCurrentCloudflareContribution = Boolean(createCloudflareR2Bindings(resolveBlobConfig(options.blob, "cloudflare"))?.length)
   if (options.cloudflareOwnedByNitro) {
     await writeProviderDeploymentOutputs({
@@ -583,10 +584,10 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
       rootDir: options.rootDir,
     })
   }
-  for (const serverFunctionName of cleanupVercel) {
+  if (cleanupVercel) {
     await writeProviderDeploymentOutputs({
       clientOutDir: options.clientOutDir,
-      cleanup: { vercel: { serverFunctionName } },
+      cleanup: { vercel: cleanupVercel },
       rootDir: options.rootDir,
     })
   }

--- a/packages/blob/test/consumer-runtime.test.ts
+++ b/packages/blob/test/consumer-runtime.test.ts
@@ -167,7 +167,7 @@ describe("hosted Blob consumer runtime", () => {
         await run("node", ["--input-type=module", "--eval", cloudflareSignProbe], appDir)
         await expect(
           readFile(join(appDir, ".vercel/output/functions/__server.func/index.mjs"), "utf8"),
-        ).rejects.toMatchObject({ code: "ENOENT" })
+        ).resolves.toContain("createBlobVercelServer")
       } finally {
         await rm(root, { force: true, recursive: true })
       }

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -336,7 +336,7 @@ describe("Vite provider outputs", () => {
     await expect(readFile(functionFile, "utf8")).resolves.toBe("// shared server\n")
   })
 
-  it("cleans unchanged root Vercel output owned by Blob during Cloudflare builds", async () => {
+  it("preserves the shared root Vercel output during Cloudflare builds", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-root-vercel-")
     const functionFile = join(rootDir, ".vercel/output/functions/__server.func/index.mjs")
     await mkdir(join(rootDir, "src"), { recursive: true })
@@ -345,7 +345,8 @@ describe("Vite provider outputs", () => {
 
     await generateProviderOutputs({ blob: { driver: "vercel-blob" }, clientOutDir: "dist", cloudflareOwnedByNitro: true, rootDir })
 
-    expect(existsSync(functionFile)).toBe(false)
+    expect(existsSync(functionFile)).toBe(true)
+    await expect(readFile(functionFile, "utf8")).resolves.toContain("createBlobVercelServer")
   })
 
   it("cleans legacy standalone workers without R2 runtime code when Nitro takes ownership", { timeout: 30_000 }, async () => {

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -77,6 +77,8 @@ interface VercelProviderDeploymentCleanup {
   serverFunctionName?: string
 }
 
+type VercelProviderDeploymentCleanupInput = VercelProviderDeploymentCleanup | VercelProviderDeploymentCleanup[] | (() => VercelProviderDeploymentCleanup | VercelProviderDeploymentCleanup[] | undefined | Promise<VercelProviderDeploymentCleanup | VercelProviderDeploymentCleanup[] | undefined>)
+
 interface NetlifyProviderDeploymentCleanup {
   configKeys?: string[]
   functionNames?: string[]
@@ -89,7 +91,7 @@ interface ProviderDeploymentOutputOptions extends SharedDeploymentOptions {
   cleanup?: {
     cloudflare?: CloudflareProviderDeploymentCleanup | (() => CloudflareProviderDeploymentCleanup | Promise<CloudflareProviderDeploymentCleanup>)
     netlify?: NetlifyProviderDeploymentCleanup
-    vercel?: VercelProviderDeploymentCleanup
+    vercel?: VercelProviderDeploymentCleanupInput
   }
   netlify?: NetlifyProviderDeploymentOutput
   vercel?: VercelProviderDeploymentOutput
@@ -274,6 +276,10 @@ async function cleanupVercelDeploymentOutput(rootDir: string, cleanup: VercelPro
   await Promise.all(writes)
 }
 
+async function cleanupVercelDeploymentOutputs(rootDir: string, cleanup: VercelProviderDeploymentCleanup | VercelProviderDeploymentCleanup[]): Promise<void> {
+  await Promise.all((Array.isArray(cleanup) ? cleanup : [cleanup]).map(item => cleanupVercelDeploymentOutput(rootDir, item)))
+}
+
 async function cleanupNetlifyDeploymentOutput(rootDir: string, cleanup: NetlifyProviderDeploymentCleanup): Promise<void> {
   const outputRoot = cleanup.outputRoot ?? createDefaultNetlifyOutputRoot(rootDir)
   const functionsRoot = resolve(outputRoot, "functions")
@@ -310,7 +316,8 @@ async function writeProviderDeploymentOutputsNow(options: ProviderDeploymentOutp
       rootDir: options.rootDir,
     }))
   } else if (options.cleanup?.vercel) {
-    writes.push(cleanupVercelDeploymentOutput(options.rootDir, options.cleanup.vercel))
+    const cleanup = typeof options.cleanup.vercel === "function" ? await options.cleanup.vercel() : options.cleanup.vercel
+    if (cleanup) writes.push(cleanupVercelDeploymentOutputs(options.rootDir, cleanup))
   }
   await Promise.all(writes)
   await options.afterWrite?.()


### PR DESCRIPTION
Moves Blob Vercel ownership discovery into the existing per-root deployment-output queue and evaluates all candidate function markers in one critical section, so a concurrent capability cannot be deleted from stale ownership state. Adds a regression covering concurrent Vercel output writing during Blob cleanup.

Refs #759