### PR TITLE
fix(blob): propagate Vercel runtime to Nitro

### DIFF
--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -73,10 +73,14 @@ function mergeNitroExternal(value: unknown, addition: string): unknown {
   return value
 }
 
-function isNitroCloudflareHost(value: unknown): boolean {
+function getNitroHostingProvider(value: unknown): ReturnType<typeof getHostingProvider> {
   const nitro = cloneNitroConfig(value)
   const preset = typeof nitro.preset === "string" ? nitro.preset : process.env.NITRO_PRESET || process.env.SERVER_PRESET || process.env.VITEHUB_HOSTING
-  return typeof preset === "string" && getHostingProvider(preset) === "cloudflare"
+  return typeof preset === "string" ? getHostingProvider(preset) : undefined
+}
+
+function isNitroCloudflareHost(value: unknown): boolean {
+  return getNitroHostingProvider(value) === "cloudflare"
 }
 
 function mergeNitroCloudflareBlobOutput(config: object, nitro: Record<string, unknown>, blob: BlobModuleOptions | undefined, cloudflareOwnedByNitro: boolean): Record<string, unknown> {
@@ -186,10 +190,10 @@ function renderBlobServeRouteHandler(serve: BlobServeConfig, importBase = blobPa
   ].join("\n")
 }
 
-async function refreshBlobGeneratedFiles(root: string, blob: BlobViteRuntimeConfig["blob"], cloudflare: boolean, importBase = blobPackageName): Promise<void> {
+async function refreshBlobGeneratedFiles(root: string, blob: BlobViteRuntimeConfig["blob"], cloudflare: boolean, importBase = blobPackageName, provider?: "cloudflare" | "vercel"): Promise<void> {
   const runtimeFile = resolve(root, generatedNitroBlobRuntime)
   await Promise.all([
-    writeFileIfChanged(runtimeFile, renderBlobRuntimeModule(runtimeFile, blob, cloudflare ? "cloudflare" : undefined)),
+    writeFileIfChanged(runtimeFile, renderBlobRuntimeModule(runtimeFile, blob, provider)),
     writeFileIfChanged(resolve(root, generatedNitroBlobPlugin), renderNitroBlobPlugin(blob, cloudflare, importBase)),
     writeFileIfChanged(resolve(root, generatedNitroBlobMiddleware), renderNitroBlobMiddleware(importBase)),
   ])
@@ -253,7 +257,15 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       ;(config as { nitro?: unknown }).nitro = mergeNitroCloudflareBlobOutput(config, nitro, blob, cloudflareOwnedByNitro)
       providerOutput = useComposedProviderOutput(config)
       runtimeConfig = blobConfig
-      await refreshBlobGeneratedFiles(config.root, runtimeConfig.blob, cloudflareOwnedByNitro, importBase)
+      const hosting = getNitroHostingProvider(configuredNitro)
+        ?? (resolveNitroVercelFunctionName(config, "blob") ? "vercel" : undefined)
+      await refreshBlobGeneratedFiles(
+        config.root,
+        runtimeConfig.blob,
+        cloudflareOwnedByNitro,
+        importBase,
+        hosting === "cloudflare" || hosting === "vercel" ? hosting : undefined,
+      )
     },
     configEnvironment(name, config) {
       if (!isServerEnvironment(name, config)) {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -11,7 +11,7 @@ import { getProviderRuntimeModule, type ComposedProviderOutput } from "@vite-hub
 import { toSafeAppName } from "@vite-hub/internal/build/user-entry"
 
 import { normalizeBlobOptions } from "../src/config.ts"
-import { generateProviderOutputs, prepareProviderOutputs } from "../src/internal/vite-build.ts"
+import { generateProviderOutputs, prepareProviderOutputs, renderBlobRuntimeModule } from "../src/internal/vite-build.ts"
 
 const execFileAsync = promisify(execFile)
 const playgroundDir = resolve(import.meta.dirname, "../../../playground/vite")
@@ -130,6 +130,18 @@ afterEach(() => {
 })
 
 describe("Vite provider outputs", () => {
+  it("stages the bundled Vercel driver in the Nitro shared runtime", () => {
+    const source = renderBlobRuntimeModule(
+      "/tmp/.vitehub/nitro/blob/runtime.mjs",
+      normalizeBlobOptions({ driver: "vercel-blob", access: "private" }, { hosting: "vercel" })!,
+      "vercel",
+    )
+
+    expect(source).toContain("/drivers/vercel-bundled")
+    expect(source).not.toContain("/drivers/vercel\"")
+    expect(source).not.toContain("files-sdk")
+  })
+
   it("rejects malformed resolved Blob config before rendering provider entries", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-invalid-resolved-config-")
 

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path"
 import { promisify } from "node:util"
 
 import { build as bundle } from "esbuild"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { toSafeAppName } from "@vite-hub/internal/build/user-entry"
 
 import { BLOB_VIRTUAL_CONFIG_ID, hubBlob } from "../src/vite.ts"
@@ -18,6 +18,46 @@ function driverImports(source: string) {
 }
 
 describe("hubBlob", () => {
+  it("uses the bundled driver in the Nitro Vercel shared runtime", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-nitro-vercel-runtime-"))
+    try {
+      const plugin = hubBlob({ access: "private", driver: "vercel-blob" })
+      await (plugin.configResolved as (config: unknown) => void | Promise<void>)({
+        build: { outDir: "dist" },
+        nitro: { preset: "vercel" },
+        plugins: [{ name: "nitro:main" }],
+        root,
+      } as never)
+
+      const runtime = await readFile(join(root, ".vitehub", "nitro", "blob", "runtime.mjs"), "utf8")
+      expect(runtime).toContain("/drivers/vercel-bundled")
+      expect(runtime).not.toContain('/drivers/vercel"')
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("uses the bundled driver when Vercel is detected from the environment", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-nitro-vercel-env-runtime-"))
+    vi.stubEnv("VERCEL", "1")
+    try {
+      const plugin = hubBlob({ access: "private", driver: "vercel-blob" })
+      await (plugin.configResolved as (config: unknown) => void | Promise<void>)({
+        build: { outDir: "dist" },
+        plugins: [{ name: "nitro:main" }],
+        root,
+      } as never)
+
+      const runtime = await readFile(join(root, ".vitehub", "nitro", "blob", "runtime.mjs"), "utf8")
+      expect(runtime).toContain("/drivers/vercel-bundled")
+    }
+    finally {
+      vi.unstubAllEnvs()
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("resolves Blob config from the Vite layer", () => {
     const plugin = hubBlob({ driver: "fs", base: ".cache/blob" })
 


### PR DESCRIPTION
Propagates the detected Vercel hosting provider into the Nitro shared Blob runtime so private Vercel Blob selects the statically bundled driver in the function that imports it. This keeps the generic optional-peer driver for plain Vite and non-Vercel runtimes while preserving the existing isolated provider output.

Refs #763