### PR TITLE
fix(blob): restore hosted provider output contracts

### DIFF
--- a/packages/blob/fixtures/cloudflare-r2-consumer/vite.config.ts
+++ b/packages/blob/fixtures/cloudflare-r2-consumer/vite.config.ts
@@ -1,0 +1,18 @@
+import { hubBlob } from "@vite-hub/blob/vite"
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  build: {
+    outDir: "dist/cloudflare",
+    rollupOptions: {
+      external: ["cloudflare:workers"],
+      input: ".vitehub/nitro/blob/runtime.mjs",
+      output: { entryFileNames: "server.mjs" },
+    },
+  },
+  nitro: { preset: "cloudflare_module" },
+  plugins: [
+    { name: "nitro:main" },
+    hubBlob({ binding: "BLOB", bucketName: "assets", driver: "cloudflare-r2" }),
+  ],
+})

--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -34,6 +34,7 @@
     "./drivers/azure": "./dist/drivers/azure.js",
     "./drivers/box": "./dist/drivers/box.js",
     "./drivers/cloudflare": "./dist/drivers/cloudflare.js",
+    "./drivers/cloudflare-native": "./dist/drivers/cloudflare-native.js",
     "./drivers/digitalocean-spaces": "./dist/drivers/digitalocean-spaces.js",
     "./drivers/dropbox": "./dist/drivers/dropbox.js",
     "./drivers/files": "./dist/drivers/files.js",
@@ -69,6 +70,7 @@
   },
   "dependencies": {
     "@vercel/blob": "catalog:storage",
+    "aws4fetch": "catalog:storage",
     "defu": "catalog:unjs",
     "esbuild": "catalog:esbuild-v27",
     "h3": "catalog:unjs",

--- a/packages/blob/src/drivers/cloudflare-native.ts
+++ b/packages/blob/src/drivers/cloudflare-native.ts
@@ -1,0 +1,144 @@
+import { getActiveCloudflareBinding } from "../runtime/state.ts"
+import { runtimeValue } from "./cloudflare-runtime.ts"
+
+import { AwsClient } from "aws4fetch"
+
+import type { BlobDriverAdapter, BlobListOptions, BlobListResult, BlobObject, BlobPutBody, BlobPutOptions, BlobSignedRequest, BlobSignOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
+
+interface R2ObjectLike {
+  arrayBuffer?: () => Promise<ArrayBuffer>
+  body?: ReadableStream
+  customMetadata?: Record<string, string>
+  httpEtag?: string
+  httpMetadata?: { contentType?: string }
+  key: string
+  size?: number
+  uploaded?: Date
+}
+
+interface R2BucketLike {
+  delete(key: string): Promise<void>
+  get(key: string): Promise<R2ObjectLike | null>
+  head(key: string): Promise<R2ObjectLike | null>
+  list(options?: { cursor?: string, delimiter?: string, include?: string[], limit?: number, prefix?: string }): Promise<{ cursor?: string, delimitedPrefixes?: string[], objects: R2ObjectLike[], truncated?: boolean }>
+  put(key: string, value: BlobPutBody, options?: { customMetadata?: Record<string, string>, httpMetadata?: { contentType?: string } }): Promise<R2ObjectLike>
+}
+
+export function getOptionalBucket(options: ResolvedCloudflareR2BlobStoreConfig): R2BucketLike | undefined {
+  return getActiveCloudflareBinding<R2BucketLike>(options.binding)
+    || (globalThis as any)[options.binding]
+}
+
+function getBucket(options: ResolvedCloudflareR2BlobStoreConfig): R2BucketLike {
+  const binding = getOptionalBucket(options)
+  if (!binding) {
+    throw new Error(`R2 binding "${options.binding}" not found`)
+  }
+
+  return binding
+}
+
+function mapObject(object: R2ObjectLike): BlobObject {
+  const contentType = object.httpMetadata?.contentType
+  return {
+    contentType,
+    customMetadata: object.customMetadata || {},
+    httpEtag: object.httpEtag,
+    httpMetadata: contentType ? { contentType } : {},
+    pathname: object.key,
+    size: object.size,
+    uploadedAt: object.uploaded || new Date(),
+  }
+}
+
+async function readArrayBuffer(object: R2ObjectLike): Promise<ArrayBuffer> {
+  if (typeof object.arrayBuffer === "function") {
+    return await object.arrayBuffer()
+  }
+  if (object.body) {
+    return await new Response(object.body).arrayBuffer()
+  }
+  return new ArrayBuffer(0)
+}
+
+function encodePathname(pathname: string): string {
+  return pathname.split("/").map(encodeURIComponent).join("/")
+}
+
+async function signRequest(options: ResolvedCloudflareR2BlobStoreConfig, pathname: string, signOptions: BlobSignOptions): Promise<BlobSignedRequest> {
+  const accountId = runtimeValue(options.accountId, "R2_ACCOUNT_ID", "CLOUDFLARE_R2_ACCOUNT_ID", "CLOUDFLARE_ACCOUNT_ID")
+  const accessKeyId = runtimeValue(options.accessKeyId, "R2_ACCESS_KEY_ID", "CLOUDFLARE_R2_ACCESS_KEY_ID")
+  const secretAccessKey = runtimeValue(options.secretAccessKey, "R2_SECRET_ACCESS_KEY", "CLOUDFLARE_R2_SECRET_ACCESS_KEY")
+  const bucket = runtimeValue(options.bucketName, "BLOB_BUCKET_NAME", "CLOUDFLARE_R2_BUCKET_NAME", "R2_BUCKET_NAME")
+  if (!accountId || !accessKeyId || !secretAccessKey || !bucket) {
+    throw new Error("Cloudflare R2 signed requests require `accountId`, `accessKeyId`, `secretAccessKey`, and `bucketName` HTTP credentials.")
+  }
+
+  const headers: Record<string, string> = {}
+  if (signOptions.method === "PUT") {
+    if (signOptions.contentType) headers["Content-Type"] = signOptions.contentType
+    if (signOptions.createOnly) headers["If-None-Match"] = "*"
+  }
+  const url = new URL(`https://${accountId}.r2.cloudflarestorage.com/${encodeURIComponent(bucket)}/${encodePathname(pathname)}`)
+  url.searchParams.set("X-Amz-Expires", String(signOptions.expiresIn))
+  const client = new AwsClient({ accessKeyId, region: "auto", secretAccessKey, service: "s3" })
+  const signed = await client.sign(url, {
+    headers,
+    method: signOptions.method,
+    aws: { allHeaders: true, signQuery: true },
+  })
+  return {
+    headers,
+    method: signOptions.method,
+    url: signed.url.toString(),
+  }
+}
+
+export function createDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig> {
+  return {
+    name: "cloudflare-r2",
+    options,
+    async delete(pathnames) {
+      await Promise.all((Array.isArray(pathnames) ? pathnames : [pathnames]).map(pathname => getBucket(options).delete(pathname)))
+    },
+    async get(pathname) {
+      const object = await getBucket(options).get(pathname)
+      if (!object) return null
+      const bytes = await readArrayBuffer(object)
+      return new Blob([bytes], { type: object.httpMetadata?.contentType || "" })
+    },
+    async getArrayBuffer(pathname) {
+      const object = await getBucket(options).get(pathname)
+      return object ? await readArrayBuffer(object) : null
+    },
+    async head(pathname) {
+      const object = await getBucket(options).head(pathname)
+      return object ? mapObject(object) : null
+    },
+    async list(listOptions: BlobListOptions = {}): Promise<BlobListResult> {
+      const result = await getBucket(options).list({
+        cursor: listOptions.cursor,
+        delimiter: listOptions.folded ? "/" : undefined,
+        include: ["customMetadata", "httpMetadata"],
+        limit: listOptions.limit ?? 1000,
+        prefix: listOptions.prefix,
+      })
+      return {
+        blobs: result.objects.map(mapObject),
+        cursor: result.truncated ? result.cursor : undefined,
+        folders: listOptions.folded ? result.delimitedPrefixes?.sort((left, right) => left.localeCompare(right)) : undefined,
+        hasMore: Boolean(result.truncated || result.cursor),
+      }
+    },
+    async put(pathname: string, body: BlobPutBody, putOptions: BlobPutOptions = {}) {
+      const object = await getBucket(options).put(pathname, body, {
+        customMetadata: putOptions.customMetadata,
+        httpMetadata: {
+          contentType: putOptions.contentType || (body instanceof Blob ? body.type : undefined),
+        },
+      })
+      return mapObject(object)
+    },
+    sign: (pathname, signOptions) => signRequest(options, pathname, signOptions),
+  }
+}

--- a/packages/blob/src/drivers/cloudflare-runtime.ts
+++ b/packages/blob/src/drivers/cloudflare-runtime.ts
@@ -1,0 +1,11 @@
+import { readEnv, trimmed } from "@vite-hub/internal/env"
+
+import { isMaskedBlobRuntimeValue } from "../config.ts"
+import { getActiveCloudflareEnv } from "../runtime/state.ts"
+
+export function runtimeValue(value: string | undefined, ...envNames: string[]): string | undefined {
+  const current = trimmed(value)
+  const env = getActiveCloudflareEnv() as Record<string, string | undefined> | undefined
+    || (typeof process === "undefined" ? {} : process.env)
+  return isMaskedBlobRuntimeValue(current) ? readEnv(env, ...envNames) : current
+}

--- a/packages/blob/src/drivers/cloudflare.ts
+++ b/packages/blob/src/drivers/cloudflare.ts
@@ -1,53 +1,11 @@
-import { readEnv, trimmed } from "@vite-hub/internal/env"
-
-import { isMaskedBlobRuntimeValue } from "../config.ts"
 import { importOptionalPeer } from "../internal/optional-peer.ts"
-import { getActiveCloudflareBinding, getActiveCloudflareEnv } from "../runtime/state.ts"
+import { createDriver as createNativeDriver, getOptionalBucket } from "./cloudflare-native.ts"
+import { runtimeValue } from "./cloudflare-runtime.ts"
 import { createFilesSdkDriver } from "./files-sdk.ts"
 
-import type { BlobDriverAdapter, BlobListOptions, BlobListResult, BlobObject, BlobPutBody, BlobPutOptions, BlobSignedRequest, BlobSignOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
+import type { BlobDriverAdapter, BlobSignedRequest, BlobSignOptions, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
 
 const s3PeerInstall = "files-sdk @aws-sdk/client-s3 @aws-sdk/lib-storage @aws-sdk/s3-presigned-post @aws-sdk/s3-request-presigner"
-
-interface R2ObjectLike {
-  arrayBuffer?: () => Promise<ArrayBuffer>
-  body?: ReadableStream
-  customMetadata?: Record<string, string>
-  httpEtag?: string
-  httpMetadata?: { contentType?: string }
-  key: string
-  size?: number
-  uploaded?: Date
-}
-
-interface R2BucketLike {
-  delete(key: string): Promise<void>
-  get(key: string): Promise<R2ObjectLike | null>
-  head(key: string): Promise<R2ObjectLike | null>
-  list(options?: { cursor?: string, delimiter?: string, include?: string[], limit?: number, prefix?: string }): Promise<{ cursor?: string, delimitedPrefixes?: string[], objects: R2ObjectLike[], truncated?: boolean }>
-  put(key: string, value: BlobPutBody, options?: { customMetadata?: Record<string, string>, httpMetadata?: { contentType?: string } }): Promise<R2ObjectLike>
-}
-
-function getOptionalBucket(options: ResolvedCloudflareR2BlobStoreConfig): R2BucketLike | undefined {
-  return getActiveCloudflareBinding<R2BucketLike>(options.binding)
-    || (globalThis as any)[options.binding]
-}
-
-function getBucket(options: ResolvedCloudflareR2BlobStoreConfig): R2BucketLike {
-  const binding = getOptionalBucket(options)
-  if (!binding) {
-    throw new Error(`R2 binding "${options.binding}" not found`)
-  }
-
-  return binding
-}
-
-function runtimeValue(value: string | undefined, ...envNames: string[]): string | undefined {
-  const current = trimmed(value)
-  const env = getActiveCloudflareEnv() as Record<string, string | undefined> | undefined
-    || (typeof process === "undefined" ? {} : process.env)
-  return isMaskedBlobRuntimeValue(current) ? readEnv(env, ...envNames) : current
-}
 
 function createHttpDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig> {
   const bucketName = runtimeValue(options.bucketName, "BLOB_BUCKET_NAME", "CLOUDFLARE_R2_BUCKET_NAME", "R2_BUCKET_NAME")
@@ -107,77 +65,6 @@ async function signRequest(options: ResolvedCloudflareR2BlobStoreConfig, pathnam
         ? new Set(["content-type"])
         : undefined,
     }),
-  }
-}
-
-function mapObject(object: R2ObjectLike): BlobObject {
-  const contentType = object.httpMetadata?.contentType
-  return {
-    contentType,
-    customMetadata: object.customMetadata || {},
-    httpEtag: object.httpEtag,
-    httpMetadata: contentType ? { contentType } : {},
-    pathname: object.key,
-    size: object.size,
-    uploadedAt: object.uploaded || new Date(),
-  }
-}
-
-async function readArrayBuffer(object: R2ObjectLike): Promise<ArrayBuffer> {
-  if (typeof object.arrayBuffer === "function") {
-    return await object.arrayBuffer()
-  }
-  if (object.body) {
-    return await new Response(object.body).arrayBuffer()
-  }
-  return new ArrayBuffer(0)
-}
-
-function createNativeDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig> {
-  return {
-    name: "cloudflare-r2",
-    options,
-    async delete(pathnames) {
-      await Promise.all((Array.isArray(pathnames) ? pathnames : [pathnames]).map(pathname => getBucket(options).delete(pathname)))
-    },
-    async get(pathname) {
-      const object = await getBucket(options).get(pathname)
-      if (!object) return null
-      const bytes = await readArrayBuffer(object)
-      return new Blob([bytes], { type: object.httpMetadata?.contentType || "" })
-    },
-    async getArrayBuffer(pathname) {
-      const object = await getBucket(options).get(pathname)
-      return object ? await readArrayBuffer(object) : null
-    },
-    async head(pathname) {
-      const object = await getBucket(options).head(pathname)
-      return object ? mapObject(object) : null
-    },
-    async list(listOptions: BlobListOptions = {}): Promise<BlobListResult> {
-      const result = await getBucket(options).list({
-        cursor: listOptions.cursor,
-        delimiter: listOptions.folded ? "/" : undefined,
-        include: ["customMetadata", "httpMetadata"],
-        limit: listOptions.limit ?? 1000,
-        prefix: listOptions.prefix,
-      })
-      return {
-        blobs: result.objects.map(mapObject),
-        cursor: result.truncated ? result.cursor : undefined,
-        folders: listOptions.folded ? result.delimitedPrefixes?.sort((left, right) => left.localeCompare(right)) : undefined,
-        hasMore: Boolean(result.truncated || result.cursor),
-      }
-    },
-    async put(pathname: string, body: BlobPutBody, putOptions: BlobPutOptions = {}) {
-      const object = await getBucket(options).put(pathname, body, {
-        customMetadata: putOptions.customMetadata,
-        httpMetadata: {
-          contentType: putOptions.contentType || (body instanceof Blob ? body.type : undefined),
-        },
-      })
-      return mapObject(object)
-    },
   }
 }
 

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { dirname, resolve } from "pathe"
 
@@ -16,6 +17,7 @@ import type { CloudflareProviderDeploymentOutput, ComposedProviderOutput, Vercel
 export const blobPackageName = "@vite-hub/blob"
 const cloudflareBlobWorkerMarker = "vitehub-blob-worker"
 const cloudflareBlobOutputState = ".vitehub/blob/cloudflare-output.json"
+const vercelBlobOutputMarker = ".vitehub-blob-output"
 const productName = "blob"
 const packageDir = computePackageDir(import.meta.url)
 const resolveRuntimeModule = (modulePath: string) => resolveRuntimeFromPkg(packageDir, modulePath)
@@ -91,7 +93,8 @@ const driverModules = {
   "vercel-blob": "drivers/vercel",
 } satisfies Record<NonNullable<ResolvedBlobModuleOptions["store"]>["driver"], string>
 
-function getDriverModule(driver: NonNullable<ResolvedBlobModuleOptions["store"]>["driver"], provider?: BlobProvider) {
+function getDriverModule(driver: NonNullable<ResolvedBlobModuleOptions["store"]>["driver"], provider?: BlobProvider, nativeCloudflareR2 = false) {
+  if (driver === "cloudflare-r2" && provider === "cloudflare" && nativeCloudflareR2) return "drivers/cloudflare-native"
   if (driver === "vercel-blob" && provider === "vercel") return "drivers/vercel-bundled"
   return driverModules[driver]
 }
@@ -179,7 +182,8 @@ function renderProviderEntry(
     `import { setBlobRuntimeConfig, setBlobRuntimeStorage } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule("runtime/state")))}`,
     `import { ${spec.factory} } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule(spec.runtimeModule)))}`,
   ]
-  const driverModule = blobConfig ? getDriverModule(blobConfig.store.driver, spec.name) : undefined
+  const nativeCloudflareR2 = Boolean(blobConfig && isCloudflareR2StoreWithBucket(blobConfig.store))
+  const driverModule = blobConfig ? getDriverModule(blobConfig.store.driver, spec.name, nativeCloudflareR2) : undefined
   if (driverModule) {
     imports.push(`import { createBlobStorage } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule("storage")))}`)
     imports.push(`import { createDriver } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule(driverModule)))}`)
@@ -215,7 +219,10 @@ function renderProviderEntry(
 
 export function renderBlobRuntimeModule(file: string, blobConfig: false | ResolvedBlobModuleOptions, provider?: BlobProvider) {
   const stores = blobConfig ? Object.values(blobConfig.stores || { default: blobConfig.store }) : []
-  const selectedDriverModules = [...new Set(stores.map(store => getDriverModule(store.driver, provider)))]
+  const nativeCloudflareR2 = stores
+    .filter(store => store.driver === "cloudflare-r2")
+    .every(isCloudflareR2StoreWithBucket)
+  const selectedDriverModules = [...new Set(stores.map(store => getDriverModule(store.driver, provider, nativeCloudflareR2)))]
   const driverImports = Object.fromEntries(selectedDriverModules.map((driverModule, index) => [driverModule, `createDriver${index}`]))
   const imports = [
     `import { ensureBlob } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule("ensure")))}`,
@@ -234,7 +241,7 @@ export function renderBlobRuntimeModule(file: string, blobConfig: false | Resolv
   }
 
   const createDriverCases = Object.keys(driverModules).map((driver) => {
-    const driverModule = getDriverModule(driver as keyof typeof driverModules, provider)
+    const driverModule = getDriverModule(driver as keyof typeof driverModules, provider, nativeCloudflareR2)
     const driverImport = driverImports[driverModule]
     if (!driverImport) return undefined
     const runtimeStoreResolver = getRuntimeBlobStoreResolver(driver)
@@ -520,13 +527,39 @@ async function copyVercelBlobRuntimePackages(options: GenerateProviderOutputsOpt
     packages.add("@aws-sdk/s3-presigned-post")
     packages.add("@aws-sdk/s3-request-presigner")
   }
-  if (!packages.size) return
+  if (packages.size) {
+    await copyVercelFunctionRuntimePackages({
+      packages: [...packages].map(name => ({ name, resolveFrom: resolve(packageDir, "package.json") })),
+      rootDir: options.rootDir,
+      serverFunctionName: options.serverFunctionName,
+    })
+  }
+  const isolated = Boolean(options.serverFunctionName && options.serverFunctionName !== "__server.func")
+  const shared = !isolated && Object.entries(options.providerOutput?.runtimeModuleFilesByProduct || {})
+    .some(([product, modules]) => product !== productName && modules?.vercel)
+  if (!shared) {
+    const outputName = options.serverFunctionName ?? "__server.func"
+    const entry = await readFile(resolve(options.rootDir, ".vercel/output/functions", outputName, "index.mjs"))
+    await writeFile(resolve(options.rootDir, ".vercel/output/functions", outputName, vercelBlobOutputMarker), createHash("sha256").update(entry).digest("hex"), "utf8")
+  }
+}
 
-  await copyVercelFunctionRuntimePackages({
-    packages: [...packages].map(name => ({ name, resolveFrom: resolve(packageDir, "package.json") })),
-    rootDir: options.rootDir,
-    serverFunctionName: options.serverFunctionName,
-  })
+function getVercelBlobOutputCleanup(options: GenerateProviderOutputsOptions) {
+  return async () => {
+    const cleanup: Array<{ serverFunctionName: string }> = []
+    for (const name of new Set([options.serverFunctionName, "__blob.func"].filter((name): name is string => Boolean(name && name !== "__server.func")))) {
+      try {
+        const outputRoot = resolve(options.rootDir, ".vercel/output/functions", name)
+        const [entry, marker] = await Promise.all([
+          readFile(resolve(outputRoot, "index.mjs")),
+          readFile(resolve(outputRoot, vercelBlobOutputMarker), "utf8"),
+        ])
+        if (createHash("sha256").update(entry).digest("hex") === marker) cleanup.push({ serverFunctionName: name })
+      }
+      catch {}
+    }
+    return cleanup
+  }
 }
 
 function registerSupportedProviderRuntimeModules(
@@ -542,6 +575,8 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.blob)
   const localOnly = !shouldCreateProviderOutput(options.blob)
   const createCloudflare = !localOnly && !options.cloudflareOwnedByNitro
+  const createVercel = !localOnly && !options.cloudflareOwnedByNitro
+  const cleanupVercel = options.cloudflareOwnedByNitro ? getVercelBlobOutputCleanup(options) : undefined
   const hasCurrentCloudflareContribution = Boolean(createCloudflareR2Bindings(resolveBlobConfig(options.blob, "cloudflare"))?.length)
   if (options.cloudflareOwnedByNitro) {
     await writeProviderDeploymentOutputs({
@@ -550,12 +585,19 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
       rootDir: options.rootDir,
     })
   }
+  if (cleanupVercel) {
+    await writeProviderDeploymentOutputs({
+      clientOutDir: options.clientOutDir,
+      cleanup: { vercel: cleanupVercel },
+      rootDir: options.rootDir,
+    })
+  }
   await writeProviderDeploymentOutputs({
-    afterWrite: localOnly ? undefined : () => copyVercelBlobRuntimePackages(options),
+    afterWrite: createVercel ? () => copyVercelBlobRuntimePackages(options) : undefined,
     clientOutDir: options.clientOutDir,
     cloudflare: createCloudflare ? createCloudflareOutput(options.blob, artifacts, options.providerOutput) : undefined,
     rootDir: options.rootDir,
-    vercel: localOnly ? undefined : createVercelOutput(artifacts, options.providerOutput, options.serverFunctionName),
+    vercel: createVercel ? createVercelOutput(artifacts, options.providerOutput, options.serverFunctionName) : undefined,
   })
   if (createCloudflare) {
     const r2Buckets = createCloudflareR2Bindings(resolveBlobConfig(options.blob, "cloudflare"))

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -514,6 +514,11 @@ function hasCloudflareR2Store(blob: BlobModuleOptions | ResolvedBlobModuleOption
     .some(store => store.driver === "cloudflare-r2")
 }
 
+function hasSiblingVercelRuntime(providerOutput: ComposedProviderOutput | undefined): boolean {
+  return Object.entries(providerOutput?.runtimeModuleFilesByProduct || {})
+    .some(([product, modules]) => product !== productName && Boolean(modules?.vercel))
+}
+
 async function copyVercelBlobRuntimePackages(options: GenerateProviderOutputsOptions) {
   const packages = new Set<string>()
   const resolved = resolveBlobConfig(options.blob, "vercel")
@@ -535,8 +540,7 @@ async function copyVercelBlobRuntimePackages(options: GenerateProviderOutputsOpt
     })
   }
   const isolated = Boolean(options.serverFunctionName && options.serverFunctionName !== "__server.func")
-  const shared = !isolated && Object.entries(options.providerOutput?.runtimeModuleFilesByProduct || {})
-    .some(([product, modules]) => product !== productName && modules?.vercel)
+  const shared = !isolated && hasSiblingVercelRuntime(options.providerOutput)
   if (!shared) {
     const outputName = options.serverFunctionName ?? "__server.func"
     const entry = await readFile(resolve(options.rootDir, ".vercel/output/functions", outputName, "index.mjs"))
@@ -593,7 +597,9 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     })
   }
   await writeProviderDeploymentOutputs({
-    afterWrite: createVercel ? () => copyVercelBlobRuntimePackages(options) : undefined,
+    afterWrite: createVercel || hasSiblingVercelRuntime(options.providerOutput)
+      ? () => copyVercelBlobRuntimePackages(options)
+      : undefined,
     clientOutDir: options.clientOutDir,
     cloudflare: createCloudflare ? createCloudflareOutput(options.blob, artifacts, options.providerOutput) : undefined,
     rootDir: options.rootDir,

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -521,6 +521,9 @@ function hasSiblingVercelRuntime(providerOutput: ComposedProviderOutput | undefi
 
 async function copyVercelBlobRuntimePackages(options: GenerateProviderOutputsOptions) {
   const packages = new Set<string>()
+  const isolated = Boolean(options.serverFunctionName && options.serverFunctionName !== "__server.func")
+  const shared = !isolated && hasSiblingVercelRuntime(options.providerOutput)
+  const outputName = options.serverFunctionName ?? "__server.func"
   const resolved = resolveBlobConfig(options.blob, "vercel")
   if (resolved !== false && Object.values(resolved.stores || { default: resolved.store }).some(store => store.driver === "vercel-blob")) {
     packages.add("@vercel/blob")
@@ -533,16 +536,14 @@ async function copyVercelBlobRuntimePackages(options: GenerateProviderOutputsOpt
     packages.add("@aws-sdk/s3-request-presigner")
   }
   if (packages.size) {
+    if (shared) await mkdir(resolve(options.rootDir, ".vercel/output/functions", outputName), { recursive: true })
     await copyVercelFunctionRuntimePackages({
       packages: [...packages].map(name => ({ name, resolveFrom: resolve(packageDir, "package.json") })),
       rootDir: options.rootDir,
       serverFunctionName: options.serverFunctionName,
     })
   }
-  const isolated = Boolean(options.serverFunctionName && options.serverFunctionName !== "__server.func")
-  const shared = !isolated && hasSiblingVercelRuntime(options.providerOutput)
   if (!shared) {
-    const outputName = options.serverFunctionName ?? "__server.func"
     const entry = await readFile(resolve(options.rootDir, ".vercel/output/functions", outputName, "index.mjs"))
     await writeFile(resolve(options.rootDir, ".vercel/output/functions", outputName, vercelBlobOutputMarker), createHash("sha256").update(entry).digest("hex"), "utf8")
   }

--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -580,6 +580,8 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   const localOnly = !shouldCreateProviderOutput(options.blob)
   const createCloudflare = !localOnly && !options.cloudflareOwnedByNitro
   const createVercel = !localOnly && !options.cloudflareOwnedByNitro
+  const stageSharedVercelRuntime = (!options.serverFunctionName || options.serverFunctionName === "__server.func")
+    && hasSiblingVercelRuntime(options.providerOutput)
   const cleanupVercel = options.cloudflareOwnedByNitro ? getVercelBlobOutputCleanup(options) : undefined
   const hasCurrentCloudflareContribution = Boolean(createCloudflareR2Bindings(resolveBlobConfig(options.blob, "cloudflare"))?.length)
   if (options.cloudflareOwnedByNitro) {
@@ -597,7 +599,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     })
   }
   await writeProviderDeploymentOutputs({
-    afterWrite: createVercel || hasSiblingVercelRuntime(options.providerOutput)
+    afterWrite: createVercel || stageSharedVercelRuntime
       ? () => copyVercelBlobRuntimePackages(options)
       : undefined,
     clientOutDir: options.clientOutDir,

--- a/packages/blob/src/runtime/storage.ts
+++ b/packages/blob/src/runtime/storage.ts
@@ -1,10 +1,10 @@
 import { createBlobStorage } from "../storage.ts"
 import { resolveRuntimeMinioBlobStore, resolveRuntimeVercelBlobStore } from "../config.ts"
-import { createDriver as createCloudflareR2Driver } from "../drivers/cloudflare.ts"
+import { createDriver as createCloudflareR2NativeDriver, getOptionalBucket } from "../drivers/cloudflare-native.ts"
 
 import { getBlobRuntimeConfig, getNamedBlobRuntimeStorage, setNamedBlobRuntimeStorage } from "./state.ts"
 
-import type { BlobObject, BlobStorage, BlobStoreName, ResolvedBlobModuleOptions, ResolvedBlobStoreConfig } from "../types.ts"
+import type { BlobDriverAdapter, BlobObject, BlobStorage, BlobStoreName, ResolvedBlobModuleOptions, ResolvedBlobStoreConfig, ResolvedCloudflareR2BlobStoreConfig } from "../types.ts"
 
 const driverModules = {
   akamai: "akamai",
@@ -29,9 +29,30 @@ const driverModules = {
 
 async function importRuntimeDriver(config: ResolvedBlobStoreConfig) {
   if (config.driver === "cloudflare-r2") {
-    return createCloudflareR2Driver(config)
+    const nativeDriver = createCloudflareR2NativeDriver(config)
+    let fallbackDriver: Promise<BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig>> | undefined
+    const activeDriver = async () => {
+      if (getOptionalBucket(config)) return nativeDriver
+      fallbackDriver ||= importRuntimeDriverModule(config)
+      return fallbackDriver
+    }
+    return {
+      name: config.driver,
+      options: config,
+      delete: async pathnames => (await activeDriver()).delete(pathnames),
+      get: async pathname => (await activeDriver()).get(pathname),
+      getArrayBuffer: async pathname => (await activeDriver()).getArrayBuffer(pathname),
+      head: async pathname => (await activeDriver()).head(pathname),
+      list: async options => (await activeDriver()).list(options),
+      put: async (pathname, body, options) => (await activeDriver()).put(pathname, body, options),
+      sign: (pathname, options) => nativeDriver.sign!(pathname, options),
+    } satisfies BlobDriverAdapter<ResolvedCloudflareR2BlobStoreConfig>
   }
 
+  return importRuntimeDriverModule(config)
+}
+
+async function importRuntimeDriverModule(config: ResolvedBlobStoreConfig) {
   const isSourceRuntime = typeof import.meta !== "undefined"
     && typeof import.meta.url === "string"
     && import.meta.url.endsWith(".ts")

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -74,10 +74,14 @@ function mergeNitroExternal(value: unknown, addition: string): unknown {
   return value
 }
 
-function isNitroCloudflareHost(value: unknown): boolean {
+function getNitroHostingProvider(value: unknown): ReturnType<typeof getHostingProvider> {
   const nitro = cloneNitroConfig(value)
   const preset = typeof nitro.preset === "string" ? nitro.preset : process.env.NITRO_PRESET || process.env.SERVER_PRESET || process.env.VITEHUB_HOSTING
-  return typeof preset === "string" && getHostingProvider(preset) === "cloudflare"
+  return typeof preset === "string" ? getHostingProvider(preset) : undefined
+}
+
+function isNitroCloudflareHost(value: unknown): boolean {
+  return getNitroHostingProvider(value) === "cloudflare"
 }
 
 function mergeNitroCloudflareBlobOutput(config: object, nitro: Record<string, unknown>, blob: BlobModuleOptions | undefined, cloudflareOwnedByNitro: boolean): Record<string, unknown> {
@@ -187,10 +191,10 @@ function renderBlobServeRouteHandler(serve: BlobServeConfig, importBase = blobPa
   ].join("\n")
 }
 
-async function refreshBlobGeneratedFiles(root: string, blob: BlobViteRuntimeConfig["blob"], cloudflare: boolean, importBase = blobPackageName): Promise<void> {
+async function refreshBlobGeneratedFiles(root: string, blob: BlobViteRuntimeConfig["blob"], cloudflare: boolean, importBase = blobPackageName, provider?: "cloudflare" | "vercel"): Promise<void> {
   const runtimeFile = resolve(root, generatedNitroBlobRuntime)
   await Promise.all([
-    writeFileIfChanged(runtimeFile, renderBlobRuntimeModule(runtimeFile, blob)),
+    writeFileIfChanged(runtimeFile, renderBlobRuntimeModule(runtimeFile, blob, provider)),
     writeFileIfChanged(resolve(root, generatedNitroBlobPlugin), renderNitroBlobPlugin(blob, cloudflare, importBase)),
     writeFileIfChanged(resolve(root, generatedNitroBlobMiddleware), renderNitroBlobMiddleware(importBase)),
   ])
@@ -256,7 +260,15 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       ;(config as { nitro?: unknown }).nitro = mergeNitroCloudflareBlobOutput(config, nitro, blob, cloudflareOwnedByNitro)
       providerOutput = useComposedProviderOutput(config)
       runtimeConfig = blobConfig
-      await refreshBlobGeneratedFiles(config.root, runtimeConfig.blob, cloudflareOwnedByNitro, importBase)
+      const hosting = getNitroHostingProvider(configuredNitro)
+        ?? (resolveNitroVercelFunctionName(config, "blob") ? "vercel" : undefined)
+      await refreshBlobGeneratedFiles(
+        config.root,
+        runtimeConfig.blob,
+        cloudflareOwnedByNitro,
+        importBase,
+        hosting === "cloudflare" || hosting === "vercel" ? hosting : undefined,
+      )
     },
     configEnvironment(name, config) {
       if (!isServerEnvironment(name, config)) {

--- a/packages/blob/test/consumer-runtime.test.ts
+++ b/packages/blob/test/consumer-runtime.test.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process"
 import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
 import { promisify } from "node:util"
 
 import { describe, expect, it } from "vitest"
@@ -12,6 +13,13 @@ const execFileAsync = promisify(execFile)
 const packageRoot = resolve(import.meta.dirname, "..")
 const workspaceRoot = resolve(packageRoot, "../..")
 const fixtureRoot = resolve(packageRoot, "fixtures/private-vercel-consumer")
+const cloudflareFixtureRoot = resolve(packageRoot, "fixtures/cloudflare-r2-consumer")
+const awsRuntimePackages = [
+  "@aws-sdk/client-s3",
+  "@aws-sdk/lib-storage",
+  "@aws-sdk/s3-presigned-post",
+  "@aws-sdk/s3-request-presigner",
+]
 
 async function run(command: string, args: string[], cwd: string) {
   try {
@@ -33,9 +41,9 @@ async function run(command: string, args: string[], cwd: string) {
   }
 }
 
-describe("private Vercel Blob consumer runtime", () => {
+describe("hosted Blob consumer runtime", () => {
   it(
-    "builds and executes without a consumer-owned files-sdk dependency",
+    "builds private Vercel Blob and Cloudflare R2 without consumer provider dependencies",
     { timeout: 120_000 },
     async () => {
       const root = await mkdtemp(join(tmpdir(), "vitehub-blob-private-vercel-consumer-"))
@@ -107,6 +115,7 @@ describe("private Vercel Blob consumer runtime", () => {
         ) as { dependencies: Record<string, string> }
         expect(consumerManifest.dependencies).not.toHaveProperty("files-sdk")
         expect(consumerManifest.dependencies).not.toHaveProperty("@vercel/blob")
+        for (const name of awsRuntimePackages) expect(consumerManifest.dependencies).not.toHaveProperty(name)
         await run("pnpm", ["run", "build"], appDir)
 
         const runtimeModule = await readFile(
@@ -115,6 +124,50 @@ describe("private Vercel Blob consumer runtime", () => {
         )
         expect(runtimeModule).toContain("drivers/vercel-bundled")
         await probePrivateVercelFunction(appDir)
+
+        await cp(
+          join(cloudflareFixtureRoot, "vite.config.ts"),
+          join(appDir, "vite.config.ts"),
+        )
+        const awsResolveProbe = [
+          `const blob = import.meta.resolve("@vite-hub/blob/package.json")`,
+          `const packages = ${JSON.stringify(awsRuntimePackages)}`,
+          `const reachable = packages.filter((specifier) => { try { import.meta.resolve(specifier, blob); return true } catch { return false } })`,
+          `if (reachable.length) throw new Error("AWS runtime packages unexpectedly resolved: " + reachable.join(", "))`,
+        ].join("\n")
+        await run(
+          "node",
+          ["--experimental-import-meta-resolve", "--input-type=module", "--eval", awsResolveProbe],
+          appDir,
+        )
+        await run("pnpm", ["run", "build"], appDir)
+
+        const cloudflareRuntime = await readFile(
+          join(appDir, ".vitehub/nitro/blob/runtime.mjs"),
+          "utf8",
+        )
+        expect(cloudflareRuntime).toContain("drivers/cloudflare-native")
+        const cloudflareOutput = await readFile(
+          join(appDir, "dist/cloudflare/server.mjs"),
+          "utf8",
+        )
+        expect(cloudflareOutput).not.toContain("files-sdk")
+        expect(cloudflareOutput).not.toContain("@aws-sdk/")
+        const cloudflareSignProbe = [
+          `process.env.R2_ACCOUNT_ID = "account"`,
+          `process.env.R2_ACCESS_KEY_ID = "access-key"`,
+          `process.env.R2_SECRET_ACCESS_KEY = "secret-key"`,
+          `const { blob } = await import(${JSON.stringify(pathToFileURL(join(appDir, ".vitehub/nitro/blob/runtime.mjs")).href)})`,
+          `const signed = await blob.sign("proof/private.txt", { expiresIn: 60, method: "GET" })`,
+          `const url = new URL(signed.url)`,
+          `if (url.hostname !== "account.r2.cloudflarestorage.com") throw new Error("Unexpected R2 signing host")`,
+          `if (url.searchParams.get("X-Amz-Expires") !== "60") throw new Error("Unexpected R2 signing expiry")`,
+          `if (!url.searchParams.get("X-Amz-Signature")) throw new Error("Missing R2 signature")`,
+        ].join("\n")
+        await run("node", ["--input-type=module", "--eval", cloudflareSignProbe], appDir)
+        await expect(
+          readFile(join(appDir, ".vercel/output/functions/__server.func/index.mjs"), "utf8"),
+        ).resolves.toContain("createBlobVercelServer")
       } finally {
         await rm(root, { force: true, recursive: true })
       }

--- a/packages/blob/test/optional-peer.test.ts
+++ b/packages/blob/test/optional-peer.test.ts
@@ -24,4 +24,11 @@ describe("optional peer imports", () => {
     expect(built).not.toContain('from "files-sdk/vercel-blob"')
     expect(built).toContain('from "@vercel/blob"')
   })
+
+  it("keeps the Cloudflare-native R2 driver free of HTTP fallback peers", async () => {
+    const built = await readFile(new URL("../dist/drivers/cloudflare-native.js", import.meta.url), "utf8")
+
+    expect(built).not.toContain("files-sdk")
+    expect(built).not.toContain("@aws-sdk/")
+  })
 })

--- a/packages/blob/test/runtime.test.ts
+++ b/packages/blob/test/runtime.test.ts
@@ -541,6 +541,33 @@ describe("blob runtime", () => {
     ])
   })
 
+  it("rechecks the active Cloudflare binding after runtime storage is cached", async () => {
+    process.env.CLOUDFLARE_R2_ACCOUNT_ID = "account"
+    process.env.CLOUDFLARE_R2_ACCESS_KEY_ID = "access-key"
+    process.env.CLOUDFLARE_R2_SECRET_ACCESS_KEY = "secret-key"
+    process.env.R2_BUCKET_NAME = "runtime-assets"
+    setBlobRuntimeConfig({
+      store: {
+        accountId: "********",
+        accessKeyId: "********",
+        binding: "BLOB",
+        bucketName: "********",
+        driver: "cloudflare-r2",
+        secretAccessKey: "********",
+      },
+    })
+    setActiveCloudflareEnv({ BLOB: createMemoryBucket() })
+    await blob.list()
+
+    setActiveCloudflareEnv(undefined)
+    await blob.list()
+
+    expect(filesSdkMock.r2).toHaveBeenCalledWith(expect.objectContaining({
+      accountId: "account",
+      bucket: "runtime-assets",
+    }))
+  })
+
   it("keeps Cloudflare binding mode when the binding appears after driver creation", async () => {
     const { createDriver } = await import("../src/drivers/cloudflare.ts")
     const storage = createBlobStorage(createDriver({

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -7,7 +7,7 @@ import { promisify } from "node:util"
 
 import { build as bundle } from "esbuild"
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest"
-import { getProviderRuntimeModule, type ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
+import { getProviderRuntimeModule, writeProviderDeploymentOutputs, type ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
 import { toSafeAppName } from "@vite-hub/internal/build/user-entry"
 
 import { normalizeBlobOptions } from "../src/config.ts"
@@ -358,8 +358,8 @@ describe("Vite provider outputs", () => {
   it("copies Blob dependencies for sibling Vercel output during Cloudflare builds", { timeout: 30_000 }, async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-shared-vercel-runtime-")
     const functionDir = join(rootDir, ".vercel/output/functions/__server.func")
-    await mkdir(functionDir, { recursive: true })
-    await writeFile(join(functionDir, "index.mjs"), "// sibling server\n", "utf8")
+    const siblingEntry = join(rootDir, "sibling.mjs")
+    await writeFile(siblingEntry, "export default 'sibling'\n", "utf8")
 
     await generateProviderOutputs({
       blob: { bucketName: "assets", driver: "cloudflare-r2" },
@@ -367,6 +367,12 @@ describe("Vite provider outputs", () => {
       cloudflareOwnedByNitro: true,
       providerOutput: { runtimeModuleFilesByProduct: { database: { vercel: "database-runtime.mjs" } } },
       rootDir,
+    })
+
+    await writeProviderDeploymentOutputs({
+      clientOutDir: "dist",
+      rootDir,
+      vercel: { bundleEntry: siblingEntry, bundleOptions: {} },
     })
 
     const runtimeProbe = join(functionDir, "runtime-probe.mjs")

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -293,7 +293,7 @@ describe("Vite provider outputs", () => {
     expect(existsSync(join(outputRoot, "functions", "__blob.func", "index.mjs"))).toBe(true)
   })
 
-  it("leaves Cloudflare Worker output to Nitro while retaining Vercel output", { timeout: 45_000 }, async () => {
+  it("leaves provider output to Nitro for Cloudflare builds", { timeout: 45_000 }, async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-nitro-cloudflare-")
     const cloudflareOutput = join(rootDir, "dist", toSafeAppName(rootDir))
     await mkdir(join(rootDir, "src"), { recursive: true })
@@ -315,10 +315,11 @@ describe("Vite provider outputs", () => {
       blob: { binding: "ASSETS", bucketName: "assets", driver: "cloudflare-r2" },
       clientOutDir: "dist",
       cloudflareOwnedByNitro: true,
+      providerOutput: { runtimeModuleFilesByProduct: { queue: { vercel: "unused" } } },
       rootDir,
       serverFunctionName: "__blob.func",
     } as const
-    await generateProviderOutputs(options)
+    await generateProviderOutputs({ ...options, serverFunctionName: undefined })
 
     await expect(readFile(join(cloudflareOutput, "index.js"), "utf8")).resolves.toBe("// workflow worker\nexport default {}\n")
     await expect(readFile(join(cloudflareOutput, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual(foreignWrangler)
@@ -338,7 +339,33 @@ describe("Vite provider outputs", () => {
       triggers: { crons: ["0 0 * * *"] },
     })
     expect(existsSync(join(rootDir, ".vercel", "output", "static", toSafeAppName(rootDir), "index.js"))).toBe(false)
-    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__blob.func", "index.mjs"))).toBe(true)
+    expect(existsSync(join(rootDir, ".vercel", "output", "functions", "__blob.func", "index.mjs"))).toBe(false)
+  })
+
+  it("preserves Vercel functions not owned by Blob during Cloudflare builds", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-shared-vercel-")
+    const functionFile = join(rootDir, ".vercel/output/functions/__server.func/index.mjs")
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await writeFile(join(rootDir, "src/server.ts"), "export default async () => new Response('ok')\n", "utf8")
+    await generateProviderOutputs({ blob: { driver: "vercel-blob" }, clientOutDir: "dist", rootDir })
+    await writeFile(functionFile, "// shared server\n", "utf8")
+
+    await generateProviderOutputs({ blob: { driver: "vercel-blob" }, clientOutDir: "dist", cloudflareOwnedByNitro: true, rootDir })
+
+    await expect(readFile(functionFile, "utf8")).resolves.toBe("// shared server\n")
+  })
+
+  it("preserves the shared root Vercel output during Cloudflare builds", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-root-vercel-")
+    const functionFile = join(rootDir, ".vercel/output/functions/__server.func/index.mjs")
+    await mkdir(join(rootDir, "src"), { recursive: true })
+    await writeFile(join(rootDir, "src/server.ts"), "export default async () => new Response('ok')\n", "utf8")
+    await generateProviderOutputs({ blob: { driver: "vercel-blob" }, clientOutDir: "dist", rootDir })
+
+    await generateProviderOutputs({ blob: { driver: "vercel-blob" }, clientOutDir: "dist", cloudflareOwnedByNitro: true, rootDir })
+
+    expect(existsSync(functionFile)).toBe(true)
+    await expect(readFile(functionFile, "utf8")).resolves.toContain("createBlobVercelServer")
   })
 
   it("cleans legacy standalone workers without R2 runtime code when Nitro takes ownership", { timeout: 30_000 }, async () => {
@@ -480,8 +507,8 @@ describe("Vite provider outputs", () => {
     })
 
     const cloudflareWorker = await readFile(join(rootDir, "dist", toSafeAppName(rootDir), "index.js"), "utf8")
-    expect(cloudflareWorker).toContain("\"files-sdk\"")
-    expect(cloudflareWorker).toContain("files-sdk/r2")
+    expect(cloudflareWorker).not.toContain("files-sdk")
+    expect(cloudflareWorker).not.toContain("@aws-sdk/")
   })
 
   it("copies Cloudflare R2 runtime packages into isolated Vercel output", { timeout: 15_000 }, async () => {
@@ -607,7 +634,7 @@ describe("Vite provider outputs", () => {
     expect(stdout.trim()).toBe("ok")
   })
 
-  it("statically reaches the Cloudflare R2 driver from bundled SSR output", async () => {
+  it("statically reaches only the native Cloudflare R2 driver from bundled SSR output", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-vite-bundled-r2-")
     const entryFile = join(rootDir, "entry.ts")
     const bundleFile = join(rootDir, "worker.mjs")
@@ -635,6 +662,8 @@ describe("Vite provider outputs", () => {
     expect(bundled).not.toContain("@vite-hub/blob/drivers/cloudflare")
     expect(bundled).toContain("config.driver === \"cloudflare-r2\"")
     expect(bundled).toContain("R2 binding")
+    expect(bundled).not.toContain("files-sdk")
+    expect(bundled).not.toContain("@aws-sdk/")
   })
 
   it("rehydrates masked Vercel tokens from generated runtime output", async () => {

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -355,6 +355,32 @@ describe("Vite provider outputs", () => {
     await expect(readFile(functionFile, "utf8")).resolves.toBe("// shared server\n")
   })
 
+  it("copies Blob dependencies for sibling Vercel output during Cloudflare builds", { timeout: 30_000 }, async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-shared-vercel-runtime-")
+    const functionDir = join(rootDir, ".vercel/output/functions/__server.func")
+    await mkdir(functionDir, { recursive: true })
+    await writeFile(join(functionDir, "index.mjs"), "// sibling server\n", "utf8")
+
+    await generateProviderOutputs({
+      blob: { bucketName: "assets", driver: "cloudflare-r2" },
+      clientOutDir: "dist",
+      cloudflareOwnedByNitro: true,
+      providerOutput: { runtimeModuleFilesByProduct: { database: { vercel: "database-runtime.mjs" } } },
+      rootDir,
+    })
+
+    const runtimeProbe = join(functionDir, "runtime-probe.mjs")
+    await writeFile(runtimeProbe, [
+      `await import("files-sdk/r2")`,
+      `await import("@aws-sdk/client-s3")`,
+      `await import("@aws-sdk/lib-storage")`,
+      `await import("@aws-sdk/s3-presigned-post")`,
+      `await import("@aws-sdk/s3-request-presigner")`,
+      "",
+    ].join("\n"), "utf8")
+    await expect(execFileAsync(process.execPath, [runtimeProbe])).resolves.toMatchObject({ stderr: "", stdout: "" })
+  })
+
   it("preserves the shared root Vercel output during Cloudflare builds", async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-root-vercel-")
     const functionFile = join(rootDir, ".vercel/output/functions/__server.func/index.mjs")

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path"
 import { promisify } from "node:util"
 
 import { build as bundle } from "esbuild"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { toSafeAppName } from "@vite-hub/internal/build/user-entry"
 
 import { BLOB_VIRTUAL_CONFIG_ID, hubBlob } from "../src/vite.ts"
@@ -18,6 +18,46 @@ function driverImports(source: string) {
 }
 
 describe("hubBlob", () => {
+  it("uses the bundled driver in the Nitro Vercel shared runtime", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-nitro-vercel-runtime-"))
+    try {
+      const plugin = hubBlob({ access: "private", driver: "vercel-blob" })
+      await (plugin.configResolved as (config: unknown) => void | Promise<void>)({
+        build: { outDir: "dist" },
+        nitro: { preset: "vercel" },
+        plugins: [{ name: "nitro:main" }],
+        root,
+      } as never)
+
+      const runtime = await readFile(join(root, ".vitehub", "nitro", "blob", "runtime.mjs"), "utf8")
+      expect(runtime).toContain("/drivers/vercel-bundled")
+      expect(runtime).not.toContain('/drivers/vercel"')
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("uses the bundled driver when Vercel is detected from the environment", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-nitro-vercel-env-runtime-"))
+    vi.stubEnv("VERCEL", "1")
+    try {
+      const plugin = hubBlob({ access: "private", driver: "vercel-blob" })
+      await (plugin.configResolved as (config: unknown) => void | Promise<void>)({
+        build: { outDir: "dist" },
+        plugins: [{ name: "nitro:main" }],
+        root,
+      } as never)
+
+      const runtime = await readFile(join(root, ".vitehub", "nitro", "blob", "runtime.mjs"), "utf8")
+      expect(runtime).toContain("/drivers/vercel-bundled")
+    }
+    finally {
+      vi.unstubAllEnvs()
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("resolves Blob config from the Vite layer", () => {
     const plugin = hubBlob({ driver: "fs", base: ".cache/blob" })
 

--- a/packages/blob/vite.config.ts
+++ b/packages/blob/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       "src/drivers/azure.ts",
       "src/drivers/box.ts",
       "src/drivers/cloudflare.ts",
+      "src/drivers/cloudflare-native.ts",
       "src/drivers/digitalocean-spaces.ts",
       "src/drivers/dropbox.ts",
       "src/drivers/files.ts",

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -77,6 +77,8 @@ interface VercelProviderDeploymentCleanup {
   serverFunctionName?: string
 }
 
+type VercelProviderDeploymentCleanupInput = VercelProviderDeploymentCleanup | VercelProviderDeploymentCleanup[] | (() => VercelProviderDeploymentCleanup | VercelProviderDeploymentCleanup[] | undefined | Promise<VercelProviderDeploymentCleanup | VercelProviderDeploymentCleanup[] | undefined>)
+
 interface NetlifyProviderDeploymentCleanup {
   configKeys?: string[]
   functionNames?: string[]
@@ -89,7 +91,7 @@ interface ProviderDeploymentOutputOptions extends SharedDeploymentOptions {
   cleanup?: {
     cloudflare?: CloudflareProviderDeploymentCleanup | (() => CloudflareProviderDeploymentCleanup | Promise<CloudflareProviderDeploymentCleanup>)
     netlify?: NetlifyProviderDeploymentCleanup
-    vercel?: VercelProviderDeploymentCleanup
+    vercel?: VercelProviderDeploymentCleanupInput
   }
   netlify?: NetlifyProviderDeploymentOutput
   vercel?: VercelProviderDeploymentOutput
@@ -274,6 +276,10 @@ async function cleanupVercelDeploymentOutput(rootDir: string, cleanup: VercelPro
   await Promise.all(writes)
 }
 
+async function cleanupVercelDeploymentOutputs(rootDir: string, cleanup: VercelProviderDeploymentCleanup | VercelProviderDeploymentCleanup[]): Promise<void> {
+  await Promise.all((Array.isArray(cleanup) ? cleanup : [cleanup]).map(item => cleanupVercelDeploymentOutput(rootDir, item)))
+}
+
 async function cleanupNetlifyDeploymentOutput(rootDir: string, cleanup: NetlifyProviderDeploymentCleanup): Promise<void> {
   const outputRoot = cleanup.outputRoot ?? createDefaultNetlifyOutputRoot(rootDir)
   const functionsRoot = resolve(outputRoot, "functions")
@@ -310,7 +316,8 @@ async function writeProviderDeploymentOutputsNow(options: ProviderDeploymentOutp
       rootDir: options.rootDir,
     }))
   } else if (options.cleanup?.vercel) {
-    writes.push(cleanupVercelDeploymentOutput(options.rootDir, options.cleanup.vercel))
+    const cleanup = typeof options.cleanup.vercel === "function" ? await options.cleanup.vercel() : options.cleanup.vercel
+    if (cleanup) writes.push(cleanupVercelDeploymentOutputs(options.rootDir, cleanup))
   }
   await Promise.all(writes)
   await options.afterWrite?.()

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -706,6 +706,40 @@ describe("provider deployment outputs", () => {
     expect(existsSync(cloudflareDir)).toBe(false)
   })
 
+  it("resolves Vercel cleanup ownership after preceding provider writes", async () => {
+    const rootDir = await createTempProject()
+    const {
+      createDefaultVercelOutputRoot,
+      writeProviderDeploymentOutputs,
+    } = await import("../src/build/deployment-output.ts")
+    const functionDir = join(createDefaultVercelOutputRoot(rootDir), "functions", "blob.func")
+    const providerWrite = writeProviderDeploymentOutputs({
+      clientOutDir: "dist/client",
+      rootDir,
+      vercel: {
+        bundleEntry: join(rootDir, "blob.mjs"),
+        bundleOptions: {},
+        function: { kind: "isolated", name: "blob.func" },
+      },
+    })
+    let observedFunction = false
+    const cleanup = writeProviderDeploymentOutputs({
+      cleanup: {
+        vercel: async () => {
+          observedFunction = existsSync(functionDir)
+          return [{ serverFunctionName: "blob.func" }]
+        },
+      },
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+
+    await Promise.all([providerWrite, cleanup])
+
+    expect(observedFunction).toBe(true)
+    expect(existsSync(functionDir)).toBe(false)
+  })
+
   it("rejects Cloudflare companion files that conflict with the bundle outfile", async () => {
     const rootDir = await createTempProject()
     const { writeProviderDeploymentOutputs } = await import("../src/build/deployment-output.ts")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ catalogs:
     '@vercel/blob':
       specifier: ^2.6.1
       version: 2.6.1
+    aws4fetch:
+      specifier: ^1.0.20
+      version: 1.0.20
     files-sdk:
       specifier: ^2.1.0
       version: 2.1.0
@@ -609,6 +612,9 @@ importers:
       '@vercel/blob':
         specifier: catalog:storage
         version: 2.6.1
+      aws4fetch:
+        specifier: catalog:storage
+        version: 1.0.20
       defu:
         specifier: catalog:unjs
         version: 6.1.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,6 +59,7 @@ catalogs:
     "@netlify/blobs": ^10.7.5
     "@upstash/redis": ^1.38.0
     "@vercel/blob": ^2.6.1
+    aws4fetch: ^1.0.20
     files-sdk: ^2.1.0
     unstorage: ^2.0.0-alpha.7
   tooling:


### PR DESCRIPTION
Restores the hosted Blob provider behavior that was proven in #759 and #764 but did not reach `main` when their stacked branches closed after #747 merged.

Private Vercel Blob now propagates the hosting provider into Nitro's shared runtime and selects the statically bundled `@vercel/blob` driver. Cloudflare Nitro output selects a binding-native R2 driver, owns signing through `aws4fetch`, and excludes Files SDK and AWS SDK fallback reachability while generic and bindingless R2 use keeps the existing lazy fallback.

Provider-output cleanup is serialized and ownership-marked. Blob removes only unchanged isolated functions it created, preserves shared Nitro `__server.func` output, and re-evaluates ownership inside the shared output queue so concurrent writers cannot be deleted from a stale marker read.

Shared sibling Vercel output stages Blob provider dependencies before the serialized function writer, so plugin order cannot drop runtime packages. The packed consumer regression builds and executes private Vercel Blob without consumer provider dependencies, then builds Cloudflare R2 in the same root and verifies native reachability plus preservation of the prior shared Vercel function. The exact Drop `c42ec504` composition with Queue `4ad1e19` passes fresh-store install, typecheck, standalone Vercel `/api/stats`, subsequent Cloudflare build, resource identity checks, and negative Files SDK, AWS SDK, MCP, and PKCE reachability. Blob passes 141 tests with no type errors; Internal passes 157 tests; repository lint, full typecheck, and 24 contract tests pass.