### PR TITLE
fix(blob): authenticate Vercel object reads

### DIFF
--- a/packages/blob/src/drivers/vercel-bundled.ts
+++ b/packages/blob/src/drivers/vercel-bundled.ts
@@ -29,6 +29,16 @@ function isMissingBlobError(error: unknown) {
   )
 }
 
+function resolveBlobAccess(url: string, fallback: "private" | "public") {
+  try {
+    const hostname = new URL(url).hostname
+    if (hostname.endsWith(".private.blob.vercel-storage.com")) return "private"
+    if (hostname.endsWith(".public.blob.vercel-storage.com")) return "public"
+  }
+  catch {}
+  return fallback
+}
+
 export function createBundledVercelBlobDriver(options: ResolvedVercelBlobStoreConfig): BlobDriverAdapter<ResolvedVercelBlobStoreConfig> {
   const auth = { token: options.token }
 
@@ -36,17 +46,14 @@ export function createBundledVercelBlobDriver(options: ResolvedVercelBlobStoreCo
     const abortSignal = options.downloadTimeoutMs && options.downloadTimeoutMs > 0
       ? AbortSignal.timeout(options.downloadTimeoutMs)
       : undefined
-    if (options.access === "private") {
-      const result = await get(pathname, { ...auth, abortSignal, access: "private" })
-      return result ? new Response(result.stream, { headers: result.blob.contentType ? { "content-type": result.blob.contentType } : undefined }) : null
-    }
-
     try {
       const metadata = await head(pathname, { ...auth, abortSignal })
-      const response = await fetch(metadata.url, { signal: abortSignal })
-      if (response.status === 404) return null
-      if (!response.ok) throw new Error(`Vercel Blob read failed: ${response.status} ${response.statusText}`)
-      return response
+      const result = await get(metadata.url, {
+        ...auth,
+        abortSignal,
+        access: resolveBlobAccess(metadata.url, options.access),
+      })
+      return result ? new Response(result.stream, { headers: result.blob.contentType ? { "content-type": result.blob.contentType } : undefined }) : null
     }
     catch (error) {
       if (isMissingBlobError(error)) return null

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -128,9 +128,44 @@ afterEach(() => {
   vercelBlobMock.head.mockClear()
   vercelBlobMock.list.mockClear()
   vercelBlobMock.put.mockClear()
+  vi.unstubAllGlobals()
 })
 
 describe("Vite provider outputs", () => {
+  it.each([
+    { objectAccess: "private" as const, storeAccess: "public" as const },
+    { objectAccess: "public" as const, storeAccess: "private" as const },
+  ])("reads a $objectAccess Vercel object when per-put access differs from the $storeAccess store default", async ({ objectAccess, storeAccess }) => {
+    const pathname = "images/private.txt"
+    const canonicalUrl = `https://store.${objectAccess}.blob.vercel-storage.com/${pathname}`
+    vercelBlobMock.head.mockResolvedValueOnce({
+      pathname,
+      size: 5,
+      uploadedAt: new Date("2026-01-01T00:00:00.000Z"),
+      url: canonicalUrl,
+    })
+    const anonymousFetch = vi.fn(async () => new Response(null, {
+      status: 403,
+      statusText: "Forbidden",
+    }))
+    vi.stubGlobal("fetch", anonymousFetch)
+    const driver = createBundledVercelBlobDriver({
+      access: storeAccess,
+      driver: "vercel-blob",
+      token: "vercel_blob_rw_test",
+    })
+
+    await driver.put(pathname, "value", { access: objectAccess })
+    const value = await driver.getArrayBuffer(pathname)
+    expect(new TextDecoder().decode(value || undefined)).toBe("value")
+    expect(vercelBlobMock.put).toHaveBeenCalledWith(pathname, "value", expect.objectContaining({ access: objectAccess }))
+    expect(vercelBlobMock.get).toHaveBeenCalledWith(canonicalUrl, expect.objectContaining({
+      access: objectAccess,
+      token: "vercel_blob_rw_test",
+    }))
+    expect(anonymousFetch).not.toHaveBeenCalled()
+  })
+
   it("maps Vercel missing-object errors to Blob misses", async () => {
     const missing = new Error("Vercel Blob: The requested blob does not exist")
     missing.name = "BlobNotFoundError"


### PR DESCRIPTION
Reads Vercel Blob objects through the authenticated SDK using the canonical URL returned by metadata lookup. This prevents private objects from being fetched anonymously when a per-write access override differs from the normalized store default, while keeping the application and provider configuration unchanged.

Adds bidirectional coverage for public/private access mismatches and explicitly guards against the anonymous fetch path that produced the hosted 403. The stateless access recovery costs one metadata request, which is the provider-authoritative way to select the immutable Vercel store access mode.