### PR TITLE
fix(deploy): upload native modules on Deno updates

### DIFF
--- a/packages/internal/src/build/deno-runtime-packages.ts
+++ b/packages/internal/src/build/deno-runtime-packages.ts
@@ -331,12 +331,9 @@ try {
   }
   await cp(sourceRoot, uploadRoot, { recursive: true })
 
-  const common = ["--org", organization, "--app", app]
-  const creation = await run(["deploy", "create", ".", "--source", "local", "--do-not-use-detected-build-config", "--runtime-mode", "dynamic", "--allow-node-modules", "--entrypoint", "server/index.ts", "--working-directory", ".", "--region", region, ...common], uploadRoot)
+  const common = ["--allow-node-modules", "--org", organization, "--app", app]
+  const creation = await run(["deploy", "create", ".", "--source", "local", "--do-not-use-detected-build-config", "--runtime-mode", "dynamic", "--entrypoint", "server/index.ts", "--working-directory", ".", "--region", region, ...common], uploadRoot)
   if (creation.code !== 0) {
-    if (process.env.DENO_DEPLOY_NODE_MODULES_ENABLED !== "1") {
-      throw new Error("Deno Deploy could not create the app with node_modules uploads enabled. If this app already exists with that policy enabled, set DENO_DEPLOY_NODE_MODULES_ENABLED=1 before redeploying.")
-    }
     const deployment = await run(["deploy", ".", "--prod", ...common], uploadRoot)
     if (deployment.code !== 0) {
       throw new Error("deno deploy exited with " + (deployment.signal || "code " + deployment.code))

--- a/packages/internal/test/deno-runtime-packages.test.ts
+++ b/packages/internal/test/deno-runtime-packages.test.ts
@@ -91,7 +91,8 @@ import "real"
       readFile(join(outputDir, "deno.json"), "utf8").then(JSON.parse),
     ).resolves.toMatchObject({ nodeModulesDir: "manual" })
     const deployRunner = await readFile(join(outputDir, "deploy.mjs"), "utf8")
-    for (const text of ["DENO_DEPLOY_ORG", "DENO_DEPLOY_NODE_MODULES_ENABLED", '["deploy", "create"', "--do-not-use-detected-build-config", "--allow-node-modules", "server/index.ts", '["deploy", ".", "--prod"', 'const common = ["--org", organization, "--app", app]', "mkdtemp", "finally"]) expect(deployRunner).toContain(text)
+    for (const text of ["DENO_DEPLOY_ORG", '["deploy", "create"', "--do-not-use-detected-build-config", "--allow-node-modules", "server/index.ts", '["deploy", ".", "--prod"', 'const common = ["--allow-node-modules", "--org", organization, "--app", app]', "mkdtemp", "finally"]) expect(deployRunner).toContain(text)
+    expect(deployRunner).not.toContain("DENO_DEPLOY_NODE_MODULES_ENABLED")
   })
 
   it("uses the pnpm package from a bundle marker", async () => {
@@ -224,9 +225,7 @@ process.exit(process.env.VITEHUB_DENO_ALWAYS_FAIL === "1" || attempts === 0 ? 1 
         PATH: `${bin}${delimiter}${process.env.PATH || ""}`,
         VITEHUB_DENO_INVOCATIONS: invocationsFile,
       }
-      await execFile(process.execPath, [join(output, "deploy.mjs")], {
-        env: { ...env, DENO_DEPLOY_NODE_MODULES_ENABLED: "1" },
-      })
+      await execFile(process.execPath, [join(output, "deploy.mjs")], { env })
 
       const invocations = (await readFile(invocationsFile, "utf8")).trim().split("\n").map(line => JSON.parse(line) as {
         args: string[]
@@ -238,10 +237,9 @@ process.exit(process.env.VITEHUB_DENO_ALWAYS_FAIL === "1" || attempts === 0 ? 1 
       expect(invocations).toHaveLength(2)
       expect(invocations[0]!.args.slice(0, 3)).toEqual(["deploy", "create", "."])
       expect(invocations[1]!.args.slice(0, 2)).toEqual(["deploy", "."])
-      expect(invocations[0]!.args).toContain("--allow-node-modules")
-      expect(invocations[1]!.args).not.toContain("--allow-node-modules")
       for (const invocation of invocations) {
         expect(relative(root, invocation.cwd).startsWith("..")).toBe(true)
+        expect(invocation.args).toContain("--allow-node-modules")
         expect(invocation).toMatchObject({ entry: true, libvips: true, sharp: true })
         expect(existsSync(invocation.cwd)).toBe(false)
       }
@@ -255,8 +253,11 @@ process.exit(process.env.VITEHUB_DENO_ALWAYS_FAIL === "1" || attempts === 0 ? 1 
         },
       })).rejects.toThrow()
       const failedInvocations = (await readFile(failedInvocationsFile, "utf8")).trim().split("\n")
-      expect(failedInvocations).toHaveLength(1)
-      const failedStage = JSON.parse(failedInvocations[0]!) as { cwd: string }
+      expect(failedInvocations).toHaveLength(2)
+      const failedStages = failedInvocations.map(line => JSON.parse(line) as { args: string[], cwd: string })
+      expect(failedStages[0]!.cwd).toBe(failedStages[1]!.cwd)
+      for (const invocation of failedStages) expect(invocation.args).toContain("--allow-node-modules")
+      const failedStage = failedStages[1]!
       expect(existsSync(failedStage.cwd)).toBe(false)
     } finally {
       await rm(root, { force: true, recursive: true })

--- a/packages/vite-hub/README.md
+++ b/packages/vite-hub/README.md
@@ -51,7 +51,7 @@ Selecting an unsupported opt-in capability fails the build with the preset polic
 
 The Deno preset uses Nitro's Deno entrypoint, so it rejects Schedule and `agent.runtime: "deno"`; those owner-package outputs require an explicit deployment integration.
 
-The Deno preset emits `.output/deno.json`, stages emitted runtime packages and installed optional native dependencies under `.output/node_modules`, and writes `.output/deploy.mjs`, a non-interactive create-or-update runner used by the `node ./deploy.mjs` command in `.output/nitro.json`; set `DENO_DEPLOY_ORG` plus `DENO_DEPLOY_APP` or `VITEHUB_DEPLOYMENT_NAME` before deployment. The runner creates new apps with node-module uploads enabled. For an existing app that already has that policy enabled, also set `DENO_DEPLOY_NODE_MODULES_ENABLED=1`; otherwise the runner stops instead of silently omitting staged packages. The Node preset emits a plain Node server artifact suitable for a VPS or container image; Docker is not a hosting preset.
+The Deno preset emits `.output/deno.json`, stages emitted runtime packages and installed optional native dependencies under `.output/node_modules`, and writes `.output/deploy.mjs`, a non-interactive create-or-update runner used by the `node ./deploy.mjs` command in `.output/nitro.json`; set `DENO_DEPLOY_ORG` plus `DENO_DEPLOY_APP` or `VITEHUB_DEPLOYMENT_NAME` before deployment. The runner uploads node modules when it creates or updates an app. The Node preset emits a plain Node server artifact suitable for a VPS or container image; Docker is not a hosting preset.
 
 ## Use feature APIs
 

--- a/test/consumer/deployment-presets.test.ts
+++ b/test/consumer/deployment-presets.test.ts
@@ -1,12 +1,17 @@
 import { existsSync } from "node:fs"
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { execFile as execFileCallback } from "node:child_process"
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises"
+import { createRequire } from "node:module"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { delimiter, dirname, join, resolve } from "node:path"
+import { promisify } from "node:util"
 
 import { build, copyPublicAssets, createNitro, prepare, prerender } from "nitropack/core"
 import { resolveConfig } from "vite"
 import { vitehub } from "vite-hub"
 import { expect, it } from "vitest"
+
+const execFile = promisify(execFileCallback)
 
 it("preserves Nitro Netlify output when emitting the ViteHub deployment manifest", async () => {
   const root = await mkdtemp(join(tmpdir(), "vitehub-netlify-output-"))
@@ -62,3 +67,140 @@ it("preserves Nitro Netlify output when emitting the ViteHub deployment manifest
     }
   }
 })
+
+it("uploads and executes native packages when updating an existing Deno app", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-deno-native-update-"))
+  const workspaceRoot = resolve(import.meta.dirname, "../..")
+  const require = createRequire(join(workspaceRoot, "packages/internal/package.json"))
+  const sharpPackageJson = await realpath(require.resolve("sharp/package.json"))
+  const output = join(root, ".output")
+  const remote = await mkdtemp(join(tmpdir(), "vitehub-deno-native-remote-"))
+  const bin = join(root, "bin")
+  const invocationsFile = join(root, "invocations.jsonl")
+  let nitro: Awaited<ReturnType<typeof createNitro>> | undefined
+  try {
+    await mkdir(join(root, "node_modules"), { recursive: true })
+    await mkdir(join(root, "server/api"), { recursive: true })
+    await symlink(dirname(sharpPackageJson), join(root, "node_modules/sharp"), "dir")
+    await writeFile(join(root, "server/api/optimize.get.ts"), `import { createRequire } from "node:module"
+import { join } from "node:path"
+import sharp from "sharp"
+
+const require = createRequire(join(process.cwd(), "server/index.ts"))
+
+export default defineEventHandler(async () => {
+  const nativePath = require.resolve("@img/" + "sharp-linux-x64/sharp.node")
+  if (!nativePath.startsWith(join(process.cwd(), "node_modules"))) throw new Error("Sharp did not resolve from the uploaded Deno artifact")
+  const png = await sharp({ create: { background: "#123456", channels: 4, height: 2, width: 2 } }).png().toBuffer()
+  return [...png.subarray(0, 4)]
+})
+`, "utf8")
+    const config = await resolveConfig({
+      root,
+      plugins: [vitehub({
+        preset: "deno",
+        agent: false,
+        blob: false,
+        database: false,
+        devtools: false,
+        env: false,
+        queue: false,
+        rateLimit: false,
+        workflow: false,
+        workspace: false,
+      })],
+    }, "build")
+    const nitroConfig = (config as typeof config & { nitro?: Parameters<typeof createNitro>[0] }).nitro
+    expect(nitroConfig).toBeDefined()
+
+    nitro = await createNitro({
+      ...nitroConfig,
+      dev: false,
+      externals: { trace: false },
+      noExternals: false,
+      rootDir: root,
+      srcDir: join(root, "server"),
+    })
+    await prepare(nitro)
+    await copyPublicAssets(nitro)
+    await prerender(nitro)
+    await build(nitro)
+
+    expect(existsSync(join(output, "node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node"))).toBe(true)
+    expect(existsSync(join(output, "node_modules/@img/sharp-libvips-linux-x64/lib/libvips-cpp.so.8.17.3"))).toBe(true)
+    const entry = existsSync(join(output, "server/index.ts")) ? "server/index.ts" : "server/index.mjs"
+    await mkdir(bin, { recursive: true })
+    const fakeDeno = join(bin, "deno")
+    await writeFile(fakeDeno, `#!/usr/bin/env node
+import { appendFile, cp, mkdir, readdir, rm } from "node:fs/promises"
+import { spawnSync } from "node:child_process"
+import { join, relative, sep } from "node:path"
+
+const args = process.argv.slice(2)
+await appendFile(process.env.VITEHUB_DENO_INVOCATIONS, JSON.stringify(args) + "\\n")
+if (args[0] === "deploy" && args[1] === "create") process.exit(1)
+
+const source = process.cwd()
+const remote = process.env.VITEHUB_DENO_REMOTE
+const includeNodeModules = args.includes("--allow-node-modules")
+await rm(remote, { force: true, recursive: true })
+await mkdir(remote, { recursive: true })
+for (const entry of await readdir(source)) {
+  await cp(join(source, entry), join(remote, entry), {
+    dereference: true,
+    filter: path => includeNodeModules || !relative(source, path).split(sep).includes("node_modules"),
+    recursive: true,
+  })
+}
+
+const probe = ${JSON.stringify(`let handler
+Object.defineProperty(Deno, "serve", {
+  configurable: true,
+  value: (...args) => {
+    handler = args.at(-1)
+    return { addr: { hostname: "127.0.0.1", port: 0, transport: "tcp" }, finished: Promise.resolve(), ref() {}, shutdown: async () => {}, unref() {} }
+  },
+})
+await import("./" + Deno.env.get("VITEHUB_DENO_ENTRY"))
+const response = await handler(new Request("http://localhost/api/optimize"), { remoteAddr: { hostname: "127.0.0.1", port: 1234, transport: "tcp" } })
+const signature = await response.json()
+if (response.status !== 200 || JSON.stringify(signature) !== "[137,80,78,71]") throw new Error("Generated Deno output did not execute Sharp: " + response.status + " " + JSON.stringify(signature))
+Deno.exit(0)
+`)}
+const result = spawnSync(process.env.VITEHUB_REAL_DENO, ["eval", probe], { cwd: remote, env: process.env, stdio: "inherit" })
+process.exit(result.status ?? 1)
+`, "utf8")
+    await chmod(fakeDeno, 0o755)
+    const realDeno = (await execFile("which", ["deno"])).stdout.trim()
+    await execFile(process.execPath, [join(output, "deploy.mjs")], {
+      env: {
+        ...process.env,
+        DENO_DEPLOY_APP: "existing-native-app",
+        DENO_DEPLOY_ORG: "vitehub",
+        PATH: `${bin}${delimiter}${process.env.PATH || ""}`,
+        VITEHUB_DENO_ENTRY: entry,
+        VITEHUB_DENO_INVOCATIONS: invocationsFile,
+        VITEHUB_DENO_REMOTE: remote,
+        VITEHUB_REAL_DENO: realDeno,
+      },
+      timeout: 30_000,
+    })
+
+    const invocations = (await readFile(invocationsFile, "utf8")).trim().split("\n").map(line => JSON.parse(line) as string[])
+    expect(invocations).toHaveLength(2)
+    expect(invocations[0]!.slice(0, 3)).toEqual(["deploy", "create", "."])
+    expect(invocations[1]!.slice(0, 2)).toEqual(["deploy", "."])
+    for (const invocation of invocations) expect(invocation).toContain("--allow-node-modules")
+    expect(existsSync(join(remote, "node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node"))).toBe(true)
+    expect(existsSync(join(remote, "node_modules/@img/sharp-libvips-linux-x64/lib/libvips-cpp.so.8.17.3"))).toBe(true)
+  } finally {
+    try {
+      await nitro?.close()
+    } finally {
+      await Promise.all([
+        rm(root, { force: true, recursive: true }),
+        rm(remote, { force: true, recursive: true }),
+      ])
+    }
+  }
+}, 60_000)

--- a/test/consumer/deployment-presets.test.ts
+++ b/test/consumer/deployment-presets.test.ts
@@ -68,7 +68,7 @@ it("preserves Nitro Netlify output when emitting the ViteHub deployment manifest
   }
 })
 
-it("uploads and executes native packages when updating an existing Deno app", async () => {
+it.skipIf(process.platform !== "linux" || process.arch !== "x64")("uploads and executes native packages when updating an existing Deno app", async () => {
   const root = await mkdtemp(join(tmpdir(), "vitehub-deno-native-update-"))
   const workspaceRoot = resolve(import.meta.dirname, "../..")
   const require = createRequire(join(workspaceRoot, "packages/internal/package.json"))


### PR DESCRIPTION
Existing Deno app deployments used the ordinary update command without `--allow-node-modules`, so ViteHub's staged native dependencies were omitted from uploads and Sharp failed at runtime. Apply the upload flag to both create and update, and remove the manual `DENO_DEPLOY_NODE_MODULES_ENABLED` assertion that exposed provider policy to users.\n\nCover the generated runner directly and through a real Nitro/ViteHub Deno consumer. The consumer simulates an existing app and uploader filtering, copies the generated artifact, then executes it with Deno and performs a real Sharp PNG transform.