### PR TITLE
fix(queue): preserve Nitro Cloudflare bindings

### DIFF
--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -117,7 +117,6 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
   let validatesNitroDefinitions = false
 
   return {
-    enforce: "post",
     name: "@vite-hub/queue/vite",
     vitehub: {
       cli: async () => {

--- a/test/consumer/deployment-presets.test.ts
+++ b/test/consumer/deployment-presets.test.ts
@@ -7,14 +7,8 @@ import { delimiter, dirname, join, resolve } from "node:path"
 import { promisify } from "node:util"
 
 import { build, copyPublicAssets, createNitro, prepare, prerender } from "nitropack/core"
-import {
-  build as buildNitro3,
-  copyPublicAssets as copyNitro3PublicAssets,
-  createNitro as createNitro3,
-  prepare as prepareNitro3,
-  prerender as prerenderNitro3,
-} from "nitro/builder"
-import { resolveConfig } from "vite"
+import { nitro } from "nitro/vite"
+import { createBuilder, resolveConfig } from "vite"
 import { vitehub } from "vite-hub"
 import { expect, it } from "vitest"
 
@@ -77,13 +71,22 @@ it("preserves Nitro Netlify output when emitting the ViteHub deployment manifest
   }
 })
 
-it("emits dynamically imported Rate Limits in Nitro Cloudflare output", async () => {
-  const root = await mkdtemp(join(tmpdir(), "vitehub-cloudflare-rate-limit-output-"))
+it("preserves Queue and Rate Limit bindings in Nitro Cloudflare output", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-cloudflare-provider-output-"))
+  const deploymentName = "vitehub-drop-pm-20260719"
+  const generatedQueue = `${deploymentName}-image-optimization`
+  const manualQueue = "manual-queue"
+  const manualBucket = { binding: "MANUAL_BUCKET", bucket_name: "manual-bucket" }
+  const manualContainer = { class_name: "ManualContainer", name: "manual-container" }
   const manualRateLimit = { name: "MANUAL", namespace_id: "9", simple: { limit: 1, period: 10 } }
-  let nitro: Awaited<ReturnType<typeof createNitro3>> | undefined
+  const previousDeploymentName = process.env.VITEHUB_DEPLOYMENT_NAME
   try {
+    process.env.VITEHUB_DEPLOYMENT_NAME = deploymentName
     await symlink(join(import.meta.dirname, "../../node_modules"), join(root, "node_modules"), "dir")
     await mkdir(join(root, "server/api"), { recursive: true })
+    await mkdir(join(root, "server/queues"), { recursive: true })
+    await writeFile(join(root, "index.html"), "<!doctype html><title>ViteHub</title>\n", "utf8")
+    await writeFile(join(root, "server/queues/image-optimization.ts"), "export default async () => undefined\n", "utf8")
     await writeFile(join(root, "server/api/upload.get.ts"), [
       "export default defineEventHandler(async (event) => {",
       '  const { requireRateLimit } = await import("vite-hub/rate-limit")',
@@ -92,47 +95,52 @@ it("emits dynamically imported Rate Limits in Nitro Cloudflare output", async ()
       "})",
       "",
     ].join("\n"), "utf8")
-    const config = await resolveConfig({
+    const builder = await createBuilder({
       nitro: {
         cloudflare: {
           wrangler: {
-            name: "vitehub-rate-limit-consumer",
+            containers: [manualContainer],
+            name: deploymentName,
+            queues: {
+              consumers: [{ queue: manualQueue }],
+              producers: [{ binding: "MANUAL_QUEUE", queue: manualQueue }],
+            },
             ratelimits: [manualRateLimit],
+            r2_buckets: [manualBucket],
           },
         },
         compatibilityDate: "2026-07-20",
         serverDir: true,
       },
-      plugins: [vitehub({
-        preset: "cloudflare",
-        agent: false,
-        blob: false,
-        database: false,
-        devtools: false,
-        env: false,
-        kv: false,
-        queue: false,
-        rateLimit: true,
-        sandbox: false,
-        workflow: false,
-        workspace: false,
-      })],
+      plugins: [
+        vitehub({
+          preset: "cloudflare",
+          agent: false,
+          blob: false,
+          database: false,
+          devtools: false,
+          env: false,
+          kv: false,
+          queue: true,
+          rateLimit: true,
+          sandbox: false,
+          workflow: false,
+          workspace: false,
+        }),
+        nitro(),
+      ],
       root,
-    }, "build")
-    const nitroConfig = (config as typeof config & { nitro?: Parameters<typeof createNitro3>[0] }).nitro
-    expect(nitroConfig).toBeDefined()
-
-    nitro = await createNitro3({ ...nitroConfig, dev: false, rootDir: root })
-    await prepareNitro3(nitro)
-    await copyNitro3PublicAssets(nitro)
-    await prerenderNitro3(nitro)
-    await buildNitro3(nitro)
+    })
+    await builder.buildApp()
 
     const bindingName = getCloudflareRateLimitBindingName("image-upload")
     await expect(readFile(join(root, ".vitehub/rate-limit/manifest.json"), "utf8").then(JSON.parse)).resolves.toMatchObject({
       rateLimits: [{ name: "image-upload", provider: "cloudflare" }],
     })
-    await expect(readFile(join(root, ".output/server/wrangler.json"), "utf8").then(JSON.parse)).resolves.toMatchObject({
+    const wrangler = JSON.parse(await readFile(join(root, ".output/server/wrangler.json"), "utf8"))
+    expect(wrangler).toMatchObject({
+      containers: [manualContainer],
+      name: deploymentName,
       ratelimits: [
         manualRateLimit,
         {
@@ -141,21 +149,36 @@ it("emits dynamically imported Rate Limits in Nitro Cloudflare output", async ()
           simple: { limit: 5, period: 60 },
         },
       ],
+      r2_buckets: [manualBucket],
     })
+    expect(wrangler.queues?.consumers).toEqual([
+      { queue: manualQueue },
+      { queue: generatedQueue },
+    ])
+    expect(wrangler.queues?.producers).toEqual([
+      { binding: "MANUAL_QUEUE", queue: manualQueue },
+      {
+        binding: "QUEUE_696D6167652D6F7074696D697A6174696F6E",
+        queue: generatedQueue,
+      },
+    ])
 
     const serverRoot = join(root, ".output/server")
     const runtime = (await readdir(serverRoot, { recursive: true }))
       .filter(file => file.endsWith(".mjs"))
       .map(file => readFile(join(serverRoot, file), "utf8"))
     const emittedSource = (await Promise.all(runtime)).join("\n")
+    expect(emittedSource).toContain("cloudflare:queue")
+    expect(emittedSource).toContain(generatedQueue)
     expect(emittedSource).toContain('requireRateLimit(event, "image-upload"')
     expect(emittedSource).toContain('bindingPrefix = "RATE_LIMIT"')
+    expect(emittedSource).not.toContain("@vercel/functions")
+    expect(emittedSource).not.toContain("@vercel/queue")
+    expect(existsSync(join(root, ".vercel/output"))).toBe(false)
   } finally {
-    try {
-      await nitro?.close()
-    } finally {
-      await rm(root, { force: true, recursive: true })
-    }
+    if (typeof previousDeploymentName === "undefined") delete process.env.VITEHUB_DEPLOYMENT_NAME
+    else process.env.VITEHUB_DEPLOYMENT_NAME = previousDeploymentName
+    await rm(root, { force: true, recursive: true })
   }
 }, 30_000)
 


### PR DESCRIPTION
Restores dynamically discovered Queue bindings in Nitro-owned Cloudflare output. Queue no longer runs its entire Vite Integration as a post plugin, so `nitro:init` snapshots the generated bindings while Queue provider-output closure still observes the shared catalog populated during `buildEnd`.

Expands the real Vite and Nitro consumer regression to prove the exact long Drop deployment Queue identity reaches final Wrangler output alongside manual Queue, Rate Limit, R2, container, and Worker-name configuration. The emitted server contains the Cloudflare Queue hook while Vercel Queue and Functions imports and Vercel output remain absent.