### PR TITLE
fix(deploy): emit JavaScript for Deno Deploy

### DIFF
--- a/packages/internal/src/build/deno-runtime-packages.ts
+++ b/packages/internal/src/build/deno-runtime-packages.ts
@@ -332,7 +332,7 @@ try {
   await cp(sourceRoot, uploadRoot, { recursive: true })
 
   const common = ["--allow-node-modules", "--org", organization, "--app", app]
-  const creation = await run(["deploy", "create", ".", "--source", "local", "--do-not-use-detected-build-config", "--runtime-mode", "dynamic", "--entrypoint", "server/index.ts", "--working-directory", ".", "--region", region, ...common], uploadRoot)
+  const creation = await run(["deploy", "create", ".", "--source", "local", "--do-not-use-detected-build-config", "--runtime-mode", "dynamic", "--entrypoint", "server/index.mjs", "--working-directory", ".", "--region", region, ...common], uploadRoot)
   if (creation.code !== 0) {
     const deployment = await run(["deploy", ".", "--prod", ...common], uploadRoot)
     if (deployment.code !== 0) {
@@ -360,8 +360,14 @@ export async function finalizeDenoDeploymentOutput(
 
   const denoConfig = {
     nodeModulesDir: "manual",
-    tasks: { start: "deno run -A ./server/index.ts" },
+    tasks: { start: "deno run -A ./server/index.mjs" },
   }
+  // Existing apps may retain this entrypoint; keep its import opaque to Deno's type checker.
+  await writeFile(
+    join(serverDir, "index.ts"),
+    'await import("./index." + "mjs")\n',
+    "utf8",
+  )
   await writeFile(join(outputDir, "deno.json"), `${JSON.stringify(denoConfig, null, 2)}\n`, "utf8")
   await writeFile(join(outputDir, "deploy.mjs"), denoDeployRunnerSource, "utf8")
 }

--- a/packages/internal/src/deployment.ts
+++ b/packages/internal/src/deployment.ts
@@ -58,7 +58,7 @@ const plans = {
   deno: {
     host: "deno-deploy",
     nitroPreset: "deno-deploy",
-    output: { directory: ".output", entry: "server/index.ts", packaging: "deno-node-modules" },
+    output: { directory: ".output", entry: "server/index.mjs", packaging: "deno-node-modules" },
     preset: "deno",
     runtime: "deno",
     services: {

--- a/packages/internal/test/deno-runtime-packages.test.ts
+++ b/packages/internal/test/deno-runtime-packages.test.ts
@@ -51,7 +51,7 @@ import "real"
 
     await mkdir(join(outputDir, "server"), { recursive: true })
     await writeFile(
-      join(outputDir, "server", "index.ts"),
+      join(outputDir, "server", "index.mjs"),
       '//#region node_modules/.pnpm/sharp@9.9.9/node_modules/sharp/index.js\nvoid 0\n',
       "utf8",
     )
@@ -91,7 +91,7 @@ import "real"
       readFile(join(outputDir, "deno.json"), "utf8").then(JSON.parse),
     ).resolves.toMatchObject({ nodeModulesDir: "manual" })
     const deployRunner = await readFile(join(outputDir, "deploy.mjs"), "utf8")
-    for (const text of ["DENO_DEPLOY_ORG", '["deploy", "create"', "--do-not-use-detected-build-config", "--allow-node-modules", "server/index.ts", '["deploy", ".", "--prod"', 'const common = ["--allow-node-modules", "--org", organization, "--app", app]', "mkdtemp", "finally"]) expect(deployRunner).toContain(text)
+    for (const text of ["DENO_DEPLOY_ORG", '["deploy", "create"', "--do-not-use-detected-build-config", "--allow-node-modules", "server/index.mjs", '["deploy", ".", "--prod"', 'const common = ["--allow-node-modules", "--org", organization, "--app", app]', "mkdtemp", "finally"]) expect(deployRunner).toContain(text)
     expect(deployRunner).not.toContain("DENO_DEPLOY_NODE_MODULES_ENABLED")
   })
 
@@ -188,14 +188,14 @@ import "plain"
       await mkdir(join(output, "node_modules/@img/sharp-libvips-linux-x64/lib"), { recursive: true })
       await writeFile(join(root, ".gitignore"), ".output/\n", "utf8")
       await writeFile(join(root, "package.json"), "{}\n", "utf8")
-      await writeFile(join(output, "server/index.ts"), "void 0\n", "utf8")
+      await writeFile(join(output, "server/index.mjs"), "void 0\n", "utf8")
       await writeFile(join(output, "node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node"), "native", "utf8")
       await writeFile(join(output, "node_modules/@img/sharp-libvips-linux-x64/lib/libvips-cpp.so.8.17.3"), "native", "utf8")
       await finalizeDenoDeploymentOutput({ rootDir: root })
 
       await execFile("git", ["init", "--quiet"], { cwd: root })
-      const ignored = await execFile("git", ["check-ignore", "--no-index", ".output/server/index.ts"], { cwd: root })
-      expect(ignored.stdout.trim()).toBe(".output/server/index.ts")
+      const ignored = await execFile("git", ["check-ignore", "--no-index", ".output/server/index.mjs"], { cwd: root })
+      expect(ignored.stdout.trim()).toBe(".output/server/index.mjs")
       const uploadable = await execFile("git", ["ls-files", "--cached", "--others", "--exclude-standard", "."], { cwd: output })
       expect(uploadable.stdout.trim()).toBe("")
 
@@ -210,7 +210,8 @@ const attempts = existsSync(log) ? (await readFile(log, "utf8")).trim().split("\
 await appendFile(log, JSON.stringify({
   args: process.argv.slice(2),
   cwd: process.cwd(),
-  entry: existsSync("server/index.ts"),
+  entry: existsSync("server/index.mjs"),
+  legacyEntry: existsSync("server/index.ts"),
   sharp: existsSync("node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node"),
   libvips: existsSync("node_modules/@img/sharp-libvips-linux-x64/lib/libvips-cpp.so.8.17.3"),
 }) + "\\n")
@@ -231,6 +232,7 @@ process.exit(process.env.VITEHUB_DENO_ALWAYS_FAIL === "1" || attempts === 0 ? 1 
         args: string[]
         cwd: string
         entry: boolean
+        legacyEntry: boolean
         libvips: boolean
         sharp: boolean
       })
@@ -240,7 +242,7 @@ process.exit(process.env.VITEHUB_DENO_ALWAYS_FAIL === "1" || attempts === 0 ? 1 
       for (const invocation of invocations) {
         expect(relative(root, invocation.cwd).startsWith("..")).toBe(true)
         expect(invocation.args).toContain("--allow-node-modules")
-        expect(invocation).toMatchObject({ entry: true, libvips: true, sharp: true })
+        expect(invocation).toMatchObject({ entry: true, legacyEntry: true, libvips: true, sharp: true })
         expect(existsSync(invocation.cwd)).toBe(false)
       }
       expect(invocations[0]!.cwd).toBe(invocations[1]!.cwd)
@@ -278,7 +280,7 @@ const nativePath = require.resolve("@img/" + "sharp-linux-x64/sharp.node")
 if (!nativePath.endsWith("/sharp-linux-x64.node")) throw new Error("Sharp's x64 native package did not resolve from the output root")
 `
         : ""
-      await writeFile(join(output, "server/index.ts"), `//#region ${sharpMarker}/lib/index.js
+      await writeFile(join(output, "server/index.mjs"), `//#region ${sharpMarker}/lib/index.js
 import { createRequire } from "node:module"
 import sharp from "../node_modules/sharp/lib/index.js"
 
@@ -293,6 +295,9 @@ process.exit(0)
         expect(existsSync(join(output, "node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node"))).toBe(true)
         expect(existsSync(join(output, "node_modules/@img/sharp-libvips-linux-x64/lib/libvips-cpp.so.8.17.3"))).toBe(true)
       }
+      await execFile("deno", ["check", "server/index.mjs"], { cwd: output })
+      await execFile("deno", ["check", "server/index.ts"], { cwd: output })
+      await execFile("deno", ["run", "-A", join(output, "server/index.mjs")], { cwd: output })
       await execFile("deno", ["run", "-A", join(output, "server/index.ts")], { cwd: output })
     } finally {
       await rm(output, { force: true, recursive: true })

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -275,12 +275,12 @@ function deploymentPlugins(plan: DeploymentPlan, requestedServices: DeploymentSe
         if (plan.output.packaging === "deno-node-modules") {
           nitro.commands = { ...cloneRecord(nitro.commands), deploy: "node ./deploy.mjs" }
           const rollupConfig = cloneRecord(nitro.rollupConfig)
+          const output = Array.isArray(rollupConfig.output)
+            ? rollupConfig.output.map(options => ({ ...cloneRecord(options), entryFileNames: "index.mjs" }))
+            : { ...cloneRecord(rollupConfig.output), entryFileNames: "index.mjs" }
           nitro.rollupConfig = {
             ...rollupConfig,
-            output: {
-              ...cloneRecord(rollupConfig.output),
-              entryFileNames: "index.mjs",
-            },
+            output,
           }
         }
         ;(config as { nitro?: unknown }).nitro = { ...nitro, preset: plan.nitroPreset }

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -274,6 +274,14 @@ function deploymentPlugins(plan: DeploymentPlan, requestedServices: DeploymentSe
         ]
         if (plan.output.packaging === "deno-node-modules") {
           nitro.commands = { ...cloneRecord(nitro.commands), deploy: "node ./deploy.mjs" }
+          const rollupConfig = cloneRecord(nitro.rollupConfig)
+          nitro.rollupConfig = {
+            ...rollupConfig,
+            output: {
+              ...cloneRecord(rollupConfig.output),
+              entryFileNames: "index.mjs",
+            },
+          }
         }
         ;(config as { nitro?: unknown }).nitro = { ...nitro, preset: plan.nitroPreset }
       },

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -387,6 +387,32 @@ describe("vitehub", () => {
     }
   })
 
+  it("preserves array-valued Rollup outputs for Deno", async () => {
+    const config = {
+      nitro: {
+        rollupConfig: {
+          output: [
+            { chunkFileNames: "chunks/[name].mjs" },
+            { assetFileNames: "assets/[name][extname]" },
+          ],
+        },
+      },
+    } as Record<string, unknown>
+    const plugin = vitehub({ preset: "deno" }).find(candidate => (candidate as Plugin).name === "vite-hub/deployment-preset") as Plugin
+    const hook = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build", mode: string }) => void
+
+    await hook(config, { command: "build", mode: "production" })
+
+    expect(config.nitro).toMatchObject({
+      rollupConfig: {
+        output: [
+          { chunkFileNames: "chunks/[name].mjs", entryFileNames: "index.mjs" },
+          { assetFileNames: "assets/[name][extname]", entryFileNames: "index.mjs" },
+        ],
+      },
+    })
+  })
+
   it("composes deployment output through a Nitro module", async () => {
     const config = { nitro: { modules: ["existing-module"] } } as Record<string, unknown>
     const plugin = vitehub({ preset: "node" }).find(candidate => (candidate as Plugin).name === "vite-hub/deployment-preset") as Plugin

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -371,13 +371,19 @@ describe("vitehub", () => {
     ["deno", "deno-deploy"],
     ["node", "node-server"],
   ] as const)("maps the %s deployment plan to Nitro %s", async (preset, nitroPreset) => {
-    const config = {} as Record<string, unknown>
+    const config = preset === "deno"
+      ? { nitro: { rollupConfig: { output: { chunkFileNames: "chunks/[name].mjs" } } } }
+      : {} as Record<string, unknown>
     const plugin = vitehub({ preset }).find(candidate => (candidate as Plugin).name === "vite-hub/deployment-preset") as Plugin
     const hook = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build", mode: string }) => void
     await hook(config, { command: "build", mode: "production" })
     expect(config.nitro).toMatchObject({ preset: nitroPreset })
     if (preset === "deno") {
-      expect(config.nitro).toMatchObject({ commands: { deploy: "node ./deploy.mjs" }, modules: [expect.any(Function)] })
+      expect(config.nitro).toMatchObject({
+        commands: { deploy: "node ./deploy.mjs" },
+        modules: [expect.any(Function)],
+        rollupConfig: { output: { chunkFileNames: "chunks/[name].mjs", entryFileNames: "index.mjs" } },
+      })
     }
   })
 

--- a/test/consumer/deployment-presets.test.ts
+++ b/test/consumer/deployment-presets.test.ts
@@ -200,7 +200,7 @@ it.skipIf(process.platform !== "linux" || process.arch !== "x64")("uploads and e
 import { join } from "node:path"
 import sharp from "sharp"
 
-const require = createRequire(join(process.cwd(), "server/index.ts"))
+const require = createRequire(join(process.cwd(), "server/index.mjs"))
 
 export default defineEventHandler(async () => {
   const nativePath = require.resolve("@img/" + "sharp-linux-x64/sharp.node")
@@ -242,7 +242,11 @@ export default defineEventHandler(async () => {
 
     expect(existsSync(join(output, "node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node"))).toBe(true)
     expect(existsSync(join(output, "node_modules/@img/sharp-libvips-linux-x64/lib/libvips-cpp.so.8.17.3"))).toBe(true)
-    const entry = existsSync(join(output, "server/index.ts")) ? "server/index.ts" : "server/index.mjs"
+    const entry = "server/index.mjs"
+    expect(existsSync(join(output, entry))).toBe(true)
+    expect(existsSync(join(output, "server/index.ts"))).toBe(true)
+    await execFile("deno", ["check", entry], { cwd: output, timeout: 30_000 })
+    await execFile("deno", ["check", "server/index.ts"], { cwd: output, timeout: 30_000 })
     await mkdir(bin, { recursive: true })
     const fakeDeno = join(bin, "deno")
     await writeFile(fakeDeno, `#!/usr/bin/env node
@@ -292,7 +296,7 @@ process.exit(result.status ?? 1)
         DENO_DEPLOY_APP: "existing-native-app",
         DENO_DEPLOY_ORG: "vitehub",
         PATH: `${bin}${delimiter}${process.env.PATH || ""}`,
-        VITEHUB_DENO_ENTRY: entry,
+        VITEHUB_DENO_ENTRY: "server/index.ts",
         VITEHUB_DENO_INVOCATIONS: invocationsFile,
         VITEHUB_DENO_REMOTE: remote,
         VITEHUB_REAL_DENO: realDeno,


### PR DESCRIPTION
Nitro's Deno preset emits its server bundle with a `.ts` extension, so Deno Deploy type-checks generated JavaScript and fails on Sharp's undeclared `@types/node` dependency before the app starts. ViteHub now emits the generated bundle as `server/index.mjs`, aligns its deployment plan, task, and create runner, and keeps a tiny computed-import `server/index.ts` shim for existing apps that retain the old entrypoint.

The generated-artifact regression runs Deno 2.9 checks through both entrypoints, exercises a real Linux x64 Sharp PNG transform through each path, and simulates an existing-app upload from the ignore-independent staging root with the native Sharp/libvips tree intact. Existing Nitro Rollup output options remain composed.