### PR TITLE
feat(workspace): preserve untracked GitHub files when publishing

### DIFF
--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -228,6 +228,23 @@ export default defineWorkspace({
 
 Set `WORKSPACE_GITHUB_TOKEN`, `VITEHUB_WORKSPACE_GITHUB_TOKEN`, `GITHUB_TOKEN`, or a `GITHUB_TOKEN` runtime binding with permission to read and write the repository contents. Reads and snapshots call the GitHub API, so this Store trades provider independence for GitHub API latency and rate limits. `workspace.snapshot()` writes changed Workspace Store files as a GitHub commit. If the target branch moves after the Workspace Store loaded local changes, snapshot fails with a conflict so the caller can retry from a fresh Workspace Store.
 
+Publish a Workspace snapshot into an existing GitHub repository with the GitHub publisher:
+
+```ts
+import { github } from "@vite-hub/workspace/publish"
+
+export default defineWorkspace({
+  publish: [github({
+    repository: "owner/repo",
+    branch: "main",
+    root: "generated/docs",
+    deleteUntracked: false,
+  })],
+})
+```
+
+By default, the publisher treats `root` as an exact mirror and deletes remote paths that are absent from the Workspace snapshot. Set `deleteUntracked: false` when the publisher owns only part of `root`; Workspace files are still created and updated, while every remote-only path remains on GitHub, including files from earlier snapshots.
+
 Built on [`@vite-hub/source`](../source/README.md) and [isomorphic-git](https://isomorphic-git.org/). Shell-backed Workspace tools load `@vite-hub/shell` only when the shell tool executes.
 
 Learn more at [vitehub.dev](https://vitehub.dev).

--- a/packages/workspace/src/providers/github/shared.ts
+++ b/packages/workspace/src/providers/github/shared.ts
@@ -279,6 +279,7 @@ export function findGitHubRemoteFiles(
 export async function readGitHubBranchState(input: {
   branch: string;
   kind: "publisher" | "store";
+  paths?: string[];
   repository: string;
   root: string;
   token: string;
@@ -312,6 +313,32 @@ export async function readGitHubBranchState(input: {
     input.token,
     `/repos/${owner}/${repo}/git/commits/${ref.object.sha}`,
   );
+  if (input.paths) {
+    const entries = await Promise.all(input.paths.map(async (path) => {
+      const fullPath = joinGitPath(input.root, path);
+      const encodedPath = fullPath.split("/").map(encodeURIComponent).join("/");
+      try {
+        return await requestGitHubJson<GitHubTreeEntry>(
+          input.repository,
+          input.token,
+          `/repos/${owner}/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref.object.sha)}`,
+        );
+      }
+      catch (error) {
+        if (error instanceof GitHubRequestError && error.status === 404) return undefined;
+        throw error;
+      }
+    }));
+    return {
+      branchExists,
+      files: new Map(input.paths.flatMap((path, index) => {
+        const entry = entries[index];
+        return entry?.type === "file" && entry.sha ? [[path, entry] as const] : [];
+      })),
+      refSha: ref.object.sha,
+      treeSha: current.tree.sha,
+    };
+  }
   const tree = await requestGitHubJson<GitHubTreeResponse>(
     input.repository,
     input.token,

--- a/packages/workspace/src/providers/github/shared.ts
+++ b/packages/workspace/src/providers/github/shared.ts
@@ -322,6 +322,7 @@ export async function readGitHubBranchState(input: {
           input.repository,
           input.token,
           `/repos/${owner}/${repo}/contents/${encodedPath}?ref=${encodeURIComponent(ref.object.sha)}`,
+          { headers: { accept: "application/vnd.github.object+json" } },
         );
       }
       catch (error) {

--- a/packages/workspace/src/publishers/github.ts
+++ b/packages/workspace/src/publishers/github.ts
@@ -69,7 +69,14 @@ export function github(options: GitHubPublisherOptions = {}): WorkspacePublisher
       const files = await readFiles(ctx, root)
       const nextPaths = new Set(files.map(file => file.path))
 
-      const remote = await readGitHubBranchState({ branch, kind: "publisher", repository, root, token })
+      const remote = await readGitHubBranchState({
+        branch,
+        kind: "publisher",
+        paths: options.deleteUntracked === false ? files.map(file => file.path) : undefined,
+        repository,
+        root,
+        token,
+      })
       const changedFiles = files.filter(file => remote.files.get(file.path)?.sha !== file.gitSha)
       const deletePaths = options.deleteUntracked === false
         ? []

--- a/packages/workspace/src/publishers/github.ts
+++ b/packages/workspace/src/publishers/github.ts
@@ -24,6 +24,7 @@ export type GitHubPublisherOption = GitHubWorkspaceOption
 
 export interface GitHubPublisherOptions {
   branch?: GitHubPublisherOption
+  deleteUntracked?: boolean
   message?: GitHubPublisherOption
   repo?: GitHubPublisherOption
   repository?: GitHubPublisherOption
@@ -70,9 +71,11 @@ export function github(options: GitHubPublisherOptions = {}): WorkspacePublisher
 
       const remote = await readGitHubBranchState({ branch, kind: "publisher", repository, root, token })
       const changedFiles = files.filter(file => remote.files.get(file.path)?.sha !== file.gitSha)
-      const deletePaths = [...remote.files]
-        .filter(([path]) => !nextPaths.has(path))
-        .map(([, entry]) => entry.path)
+      const deletePaths = options.deleteUntracked === false
+        ? []
+        : [...remote.files]
+            .filter(([path]) => !nextPaths.has(path))
+            .map(([, entry]) => entry.path)
 
       if (!changedFiles.length && !deletePaths.length) return
 

--- a/packages/workspace/test/github-publisher.test.ts
+++ b/packages/workspace/test/github-publisher.test.ts
@@ -291,7 +291,8 @@ describe("GitHub workspace publisher", () => {
     await workspace.writeFile("inbox/audio.md", "hola", { mediaType: "text/markdown" })
     await workspace.snapshot()
 
-    expect(requests.map(request => request.path)).toContain("/repos/onmax/repo/contents/workspace/root/inbox/audio.md")
+    const contentsRequest = requests.find(request => request.path === "/repos/onmax/repo/contents/workspace/root/inbox/audio.md")
+    expect(contentsRequest?.headers.get("accept")).toBe("application/vnd.github.object+json")
     expect(requests.some(request => request.path.endsWith("/git/trees/base-tree"))).toBe(false)
     expect(requests.filter(request => request.method !== "GET")).toEqual([])
   })

--- a/packages/workspace/test/github-publisher.test.ts
+++ b/packages/workspace/test/github-publisher.test.ts
@@ -63,6 +63,13 @@ beforeEach(() => {
     if (url.pathname === "/repos/onmax/repo/git/ref/heads/main") return jsonResponse({ object: { sha: refSha } })
     if (url.pathname === "/repos/onmax/repo/git/ref/heads/feature/audio") return jsonResponse({ object: { sha: refSha } })
     if (url.pathname.startsWith("/repos/onmax/repo/git/commits/")) return jsonResponse({ tree: { sha: remoteTreeSha } })
+    if (url.pathname.startsWith("/repos/onmax/repo/contents/")) {
+      const path = decodeURIComponent(url.pathname.slice("/repos/onmax/repo/contents/".length))
+      const entry = remoteTree.find(item => item.path === path)
+      return entry
+        ? jsonResponse({ ...entry, type: "file" })
+        : new Response("missing file", { status: 404, statusText: "Not Found" })
+    }
     if (url.pathname === "/repos/onmax/repo/git/trees/base-tree" && method === "GET") return jsonResponse({ tree: remoteTree })
     if (url.pathname.startsWith("/repos/onmax/repo/git/trees/tree-sha-") && method === "GET") return jsonResponse({ tree: remoteTree })
     if (url.pathname === "/repos/onmax/repo/git/blobs" && method === "POST" && body?.content) {
@@ -264,6 +271,29 @@ describe("GitHub workspace publisher", () => {
         type: "blob",
       }],
     })
+  })
+
+  it("checks only workspace paths when untracked deletion is disabled", async () => {
+    remoteTree = [{ path: "workspace/root/inbox/audio.md", sha: textSha("hola"), type: "blob" }]
+
+    const workspace = createWorkspace({
+      name: "docs",
+      store: { provider: "memory" },
+      publish: [github({
+        branch: "feature/audio",
+        deleteUntracked: false,
+        repo: "onmax/repo",
+        root: "workspace/root",
+        token: "token",
+      })],
+    })
+
+    await workspace.writeFile("inbox/audio.md", "hola", { mediaType: "text/markdown" })
+    await workspace.snapshot()
+
+    expect(requests.map(request => request.path)).toContain("/repos/onmax/repo/contents/workspace/root/inbox/audio.md")
+    expect(requests.some(request => request.path.endsWith("/git/trees/base-tree"))).toBe(false)
+    expect(requests.filter(request => request.method !== "GET")).toEqual([])
   })
 
   it("skips publishing when deletion is disabled and only remote files are untracked", async () => {

--- a/packages/workspace/test/github-publisher.test.ts
+++ b/packages/workspace/test/github-publisher.test.ts
@@ -234,6 +234,58 @@ describe("GitHub workspace publisher", () => {
     })
   })
 
+  it("preserves remote-only files when untracked deletion is disabled", async () => {
+    remoteTree = [
+      { path: "workspace/root/assets/audio.mp3", sha: textSha("asset"), type: "blob" },
+      { path: "workspace/root/inbox/audio.md", sha: textSha("old"), type: "blob" },
+    ]
+
+    const workspace = createWorkspace({
+      name: "docs",
+      store: { provider: "memory" },
+      publish: [github({
+        branch: "feature/audio",
+        deleteUntracked: false,
+        repo: "onmax/repo",
+        root: "workspace/root",
+        token: "token",
+      })],
+    })
+
+    await workspace.writeFile("inbox/audio.md", "hola", { mediaType: "text/markdown" })
+    await workspace.snapshot({ name: "update transcript" })
+
+    expect(requests.find(request => request.path.endsWith("/git/trees"))?.body).toMatchObject({
+      base_tree: "base-tree",
+      tree: [{
+        mode: "100644",
+        path: "workspace/root/inbox/audio.md",
+        sha: textSha("hola"),
+        type: "blob",
+      }],
+    })
+  })
+
+  it("skips publishing when deletion is disabled and only remote files are untracked", async () => {
+    remoteTree = [{ path: "workspace/root/assets/audio.mp3", sha: textSha("asset"), type: "blob" }]
+
+    const workspace = createWorkspace({
+      name: "docs",
+      store: { provider: "memory" },
+      publish: [github({
+        branch: "feature/audio",
+        deleteUntracked: false,
+        repo: "onmax/repo",
+        root: "workspace/root",
+        token: "token",
+      })],
+    })
+
+    await workspace.snapshot()
+
+    expect(requests.filter(request => request.method !== "GET")).toEqual([])
+  })
+
   it("skips unchanged snapshots after comparing the remote tree", async () => {
     const workspace = createWorkspace({
       name: "docs",


### PR DESCRIPTION
Adds a `deleteUntracked` opt-out to the GitHub Workspace publisher. Existing exact-mirror behavior remains the default; setting it to `false` publishes changed Workspace files without deleting remote-only paths under the configured root, including files retained from earlier snapshots.

Reconstructs the Quiver partial-mirror fix in source and documents the ownership trade-off. Focused publisher regressions cover default deletion, preservation during a changed-file update, and no-op detection when only remote-only paths differ.
