### PR TITLE
fix(workspace): register Cloudflare Artifacts bindings in Nuxt

### DIFF
--- a/packages/vite-hub/package.json
+++ b/packages/vite-hub/package.json
@@ -58,6 +58,7 @@
     "./_internal/workspace": "./dist/_internal/workspace.js",
     "./_internal/workspace/internal/runtime/hosted": "./dist/_internal/workspace/internal/runtime/hosted.js",
     "./_internal/workspace/internal/runtime/hosted-vercel-blob": "./dist/_internal/workspace/internal/runtime/hosted-vercel-blob.js",
+    "./_internal/workspace/internal/runtime/state": "./dist/_internal/workspace/internal/runtime/state.js",
     "./_internal/workspace/runtime": "./dist/_internal/workspace/runtime.js",
     "./agent": "./dist/agent.js",
     "./agent/capabilities": "./dist/agent/capabilities.js",

--- a/packages/vite-hub/src/_internal/workspace/internal/runtime/state.ts
+++ b/packages/vite-hub/src/_internal/workspace/internal/runtime/state.ts
@@ -1,0 +1,1 @@
+export * from "@vite-hub/workspace/internal/runtime/state"

--- a/packages/workspace/src/build/discovery.ts
+++ b/packages/workspace/src/build/discovery.ts
@@ -158,10 +158,16 @@ export function discoverViteWorkspaceDefinitions(rootDir: string, options: { ser
 }
 
 function createWorkspaceRegistryEntry(definition: DiscoveredWorkspaceDefinition, importExpression: string, override?: { store: unknown }): string {
+  const renderedStore = override ? JSON.stringify(override.store) : undefined
   const defaultValue = [
     "...mod.default",
     ...(definition.sourceRootDir ? [`sourceRootDir: mod.default.sourceRootDir ?? ${JSON.stringify(definition.sourceRootDir)}`] : []),
-    ...(override ? [`store: ${JSON.stringify(override.store)}`] : []),
+    ...(renderedStore
+      ? [
+          `store: ${renderedStore}`,
+          `__vitehubWorkspaceAgentOptions: mod.default.__vitehubWorkspaceAgentOptions && typeof mod.default.__vitehubWorkspaceAgentOptions.workspace === "object" ? { ...mod.default.__vitehubWorkspaceAgentOptions, workspace: { ...mod.default.__vitehubWorkspaceAgentOptions.workspace, store: ${renderedStore} } } : mod.default.__vitehubWorkspaceAgentOptions`,
+        ]
+      : []),
   ].join(", ")
   return [
     `  ${JSON.stringify(definition.name)}: async () => {`,

--- a/packages/workspace/src/build/discovery.ts
+++ b/packages/workspace/src/build/discovery.ts
@@ -157,25 +157,28 @@ export function discoverViteWorkspaceDefinitions(rootDir: string, options: { ser
   )
 }
 
-function createWorkspaceRegistryEntry(definition: DiscoveredWorkspaceDefinition, importExpression: string): string {
+function createWorkspaceRegistryEntry(definition: DiscoveredWorkspaceDefinition, importExpression: string, override?: { store: unknown }): string {
+  const defaultValue = [
+    "...mod.default",
+    ...(definition.sourceRootDir ? [`sourceRootDir: mod.default.sourceRootDir ?? ${JSON.stringify(definition.sourceRootDir)}`] : []),
+    ...(override ? [`store: ${JSON.stringify(override.store)}`] : []),
+  ].join(", ")
   return [
     `  ${JSON.stringify(definition.name)}: async () => {`,
     `    const mod = await ${importExpression}`,
-    definition.sourceRootDir
-      ? `    return { ...mod, default: { ...mod.default, sourceRootDir: mod.default.sourceRootDir ?? ${JSON.stringify(definition.sourceRootDir)} } }`
-      : "    return mod",
+    definition.sourceRootDir || override ? `    return { ...mod, default: { ${defaultValue} } }` : "    return mod",
     "  },",
   ].join("\n")
 }
 
-export function createWorkspaceRegistryContents(registryFile: string, definitions: DiscoveredWorkspaceDefinition[]): string {
+export function createWorkspaceRegistryContents(registryFile: string, definitions: DiscoveredWorkspaceDefinition[], overrides?: Map<string, { store: unknown }>): string {
   const importExpression = (file: string) => {
     const importPath = relative(resolve(registryFile, ".."), file)
     return `import(${JSON.stringify(importPath.startsWith(".") ? importPath : `./${importPath}`)})`
   }
   return [
     "const registry = {",
-    ...definitions.map(definition => createWorkspaceRegistryEntry(definition, importExpression(definition.handler))),
+    ...definitions.map(definition => createWorkspaceRegistryEntry(definition, importExpression(definition.handler), overrides?.get(definition.name))),
     "}",
     "export default registry",
     "",

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -20,7 +20,7 @@ import { installHostedVercelBlobWorkspaceRuntime } from "../../hosted-vercel-blo
 import { configureCloudflareArtifacts } from "../../integrations/cloudflare.ts"
 import { ensureWorkspaceDevToken, refreshWorkspaceDevToken, runWorkspaceDevCommand, validateWorkspaceDevToken, workspaceDevHeader, workspaceDevHeaderValue, workspaceDevRoute, workspaceDevTokenServerId } from "../../server.ts"
 
-import type { HmrContext, Plugin, ResolvedConfig, UserConfig, ViteDevServer } from "vite"
+import type { AliasOptions, HmrContext, Plugin, ResolvedConfig, UserConfig, ViteDevServer } from "vite"
 import type { DiscoveredWorkspaceDefinition } from "../../build/discovery.ts"
 import type { IncomingMessage, ServerResponse } from "node:http"
 import type { WorkspaceBuildState } from "../../build/integration.ts"
@@ -345,8 +345,9 @@ function isWorkspaceRegistry(value: unknown): value is Record<string, () => Prom
   return isRecord(value) && Object.values(value).every(item => typeof item === "function")
 }
 
-function workspaceDefinitionLoaderAliases(config: ResolvedConfig): Record<string, string> {
-  return Object.fromEntries(config.resolve.alias.flatMap(alias =>
+function workspaceDefinitionLoaderAliases(aliases: AliasOptions): Record<string, string> {
+  if (!Array.isArray(aliases)) return aliases as Record<string, string>
+  return Object.fromEntries(aliases.flatMap(alias =>
     typeof alias.find === "string" ? [[alias.find, alias.replacement]] : [],
   ))
 }
@@ -815,7 +816,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       if (normalized && shouldInstallNitroWorkspacePlugin(config, runtimeOptions, normalized, definitions)) {
         const runtimeConfig = shouldConfigureRuntime(runtimeOptions, normalized) ? normalized : false
         const artifacts = await resolveCloudflareArtifactsConfigs(normalized, definitions, roots.projectRoot, {
-          aliases: config.resolve?.alias && !Array.isArray(config.resolve.alias) ? config.resolve.alias as Record<string, string> : undefined,
+          aliases: config.resolve?.alias ? workspaceDefinitionLoaderAliases(config.resolve.alias) : undefined,
           artifactsOnly: true,
           hosting,
         })
@@ -895,7 +896,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
             resolvedOptions,
             definitions,
             resolved.createResolver?.(),
-            resolved.resolve ? workspaceDefinitionLoaderAliases(resolved) : undefined,
+            resolved.resolve ? workspaceDefinitionLoaderAliases(resolved.resolve.alias) : undefined,
           ),
         ])
       },

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -79,7 +79,7 @@ async function sourceModuleUsesCloudflareArtifacts(
   visited.add(loaded.file)
   if (/\bprovider\s*:\s*["']cloudflare-artifacts["']/.test(loaded.source)) return true
 
-  const staticModuleSpecifier = /\b(?:import|export)\s+(?:[^"']*?\s+from\s+)?["']([^"']+)["']/g
+  const staticModuleSpecifier = /\b(?:import|export)\s+(?!type\b)(?:[^"']*?\s+from\s+)?["']([^"']+)["']/g
   for (const match of loaded.source.matchAll(staticModuleSpecifier)) {
     const specifier = match[1]!
     const resolvedModule = specifier.startsWith(".")

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -1,6 +1,5 @@
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { dirname, extname, isAbsolute, relative, resolve } from "node:path"
-import { fileURLToPath, pathToFileURL } from "node:url"
 
 import { createDefaultCloudflareOutputRoot, writeCloudflareWranglerConfig } from "@vite-hub/internal/build/cloudflare"
 import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
@@ -68,6 +67,71 @@ async function readSourceModule(file: string): Promise<{ file: string, source: s
 }
 
 type SourceModuleResolver = (id: string, importer: string) => Promise<string | undefined>
+
+interface BabelNode {
+  expression?: BabelNode
+  key?: { name?: unknown, type?: string, value?: unknown }
+  type?: string
+  value?: BabelNode | unknown
+}
+
+interface BabelObjectPropertyPath {
+  node: BabelNode
+  parentPath?: BabelObjectPropertyPath
+}
+
+function babelPropertyName(path: BabelObjectPropertyPath): unknown {
+  return path.node.key?.name ?? path.node.key?.value
+}
+
+function babelStringValue(node: BabelNode | undefined): unknown {
+  if (node?.type === "StringLiteral") return node.value
+  if (node?.type === "TSAsExpression" || node?.type === "TSSatisfiesExpression" || node?.type === "TSTypeAssertion") {
+    return babelStringValue(node.expression)
+  }
+}
+
+function isExportedWorkspaceStoreProperty(path: BabelObjectPropertyPath): boolean {
+  let exported = false
+  let store = false
+  for (let current = path.parentPath; current; current = current.parentPath) {
+    if (current.node.type === "ObjectProperty" && babelPropertyName(current) === "store") store = true
+    if (current.node.type === "ExportDefaultDeclaration") exported = true
+  }
+  return exported && store
+}
+
+async function sourceModuleDeclaresCloudflareArtifacts(
+  file: string,
+  loader: ReturnType<typeof createWorkspaceDefinitionLoader>,
+): Promise<boolean> {
+  const loaded = await readSourceModule(file)
+  if (!loaded) return false
+  let declaresCloudflareArtifacts = false
+  loader.transform({
+    filename: loaded.file,
+    jsx: /x$/.test(extname(loaded.file)),
+    source: loaded.source,
+    ts: /\.[cm]?tsx?$/.test(loaded.file),
+    babel: {
+      plugins: [() => ({
+        visitor: {
+          ObjectProperty(path: BabelObjectPropertyPath) {
+            const value = path.node.value as BabelNode | undefined
+            if (
+              babelPropertyName(path) === "provider"
+              && babelStringValue(value) === "cloudflare-artifacts"
+              && isExportedWorkspaceStoreProperty(path)
+            ) {
+              declaresCloudflareArtifacts = true
+            }
+          },
+        },
+      })],
+    },
+  })
+  return declaresCloudflareArtifacts
+}
 
 async function sourceModuleUsesCloudflareArtifacts(
   file: string,
@@ -187,19 +251,8 @@ async function resolveDefinitionCloudflareArtifactsConfigs(
   definitionOverrides?: Map<string, ResolvedWorkspaceModuleOptions>,
 ): Promise<ResolvedWorkspaceModuleOptions[]> {
   const loader = createWorkspaceDefinitionLoader(rootDir, aliases)
-  const resolveSourceModule = resolveModule || (async (id: string, importer: string) => {
-    try {
-      return fileURLToPath(loader.esmResolve(id, pathToFileURL(importer).href))
-    }
-    catch {
-      return undefined
-    }
-  })
   const configs: ResolvedWorkspaceModuleOptions[] = []
   for (const definition of definitions) {
-    const declaresCloudflareArtifacts = inspection?.artifactsOnly
-      ? await sourceModuleUsesCloudflareArtifacts(definition.path, resolveSourceModule)
-      : false
     const bundlesAssets = shouldBundleWorkspaceAssets(options.assets, definition.name)
     let loaded: WorkspaceDefinitionInput
     try {
@@ -207,7 +260,7 @@ async function resolveDefinitionCloudflareArtifactsConfigs(
     }
     catch (error) {
       if (inspection?.artifactsOnly) {
-        if (declaresCloudflareArtifacts) throw error
+        if (await sourceModuleDeclaresCloudflareArtifacts(definition.path, loader)) throw error
         continue
       }
       if (bundlesAssets || await sourceModuleUsesCloudflareArtifacts(definition.path, resolveModule)) throw error

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -79,9 +79,11 @@ async function sourceModuleUsesCloudflareArtifacts(
   visited.add(loaded.file)
   if (/\bprovider\s*:\s*["']cloudflare-artifacts["']/.test(loaded.source)) return true
 
-  const staticModuleSpecifier = /\b(?:import|export)\s+(?!type\b)(?:[^"']*?\s+from\s+)?["']([^"']+)["']/g
+  const staticModuleSpecifier = /\b(?:import|export)\s+(?!type\b)(?:([^"']*?)\s+from\s+)?["']([^"']+)["']/g
   for (const match of loaded.source.matchAll(staticModuleSpecifier)) {
-    const specifier = match[1]!
+    const imports = match[1]?.trim()
+    if (imports?.startsWith("{") && imports.endsWith("}") && imports.slice(1, -1).split(",").every(entry => /^type\b/.test(entry.trim()))) continue
+    const specifier = match[2]!
     const resolvedModule = specifier.startsWith(".")
       ? resolve(dirname(loaded.file), specifier)
       : await resolveModule?.(specifier, loaded.file)
@@ -182,6 +184,7 @@ async function resolveDefinitionCloudflareArtifactsConfigs(
   aliases?: Record<string, string>,
   inspection?: { artifactsOnly?: boolean },
   resolution?: { env?: Record<string, string | undefined>, hosting?: string },
+  definitionOverrides?: Map<string, ResolvedWorkspaceModuleOptions>,
 ): Promise<ResolvedWorkspaceModuleOptions[]> {
   const loader = createWorkspaceDefinitionLoader(rootDir, aliases)
   const resolveSourceModule = resolveModule || (async (id: string, importer: string) => {
@@ -218,7 +221,10 @@ async function resolveDefinitionCloudflareArtifactsConfigs(
       hosting: resolution?.hosting ?? process.env.VITEHUB_HOSTING,
       rootDir: workspace.rootDir || rootDir,
     })
-    if (config && config.store.provider === "cloudflare-artifacts") configs.push(config)
+    if (config && config.store.provider === "cloudflare-artifacts") {
+      configs.push(config)
+      definitionOverrides?.set(definition.name, config)
+    }
   }
   return configs
 }
@@ -233,6 +239,7 @@ async function resolveCloudflareArtifactsConfigs(
     env?: Record<string, string | undefined>
     hosting?: string
     resolveModule?: SourceModuleResolver
+    definitionOverrides?: Map<string, ResolvedWorkspaceModuleOptions>
   } = {},
 ): Promise<ResolvedWorkspaceModuleOptions[]> {
   return [
@@ -245,6 +252,7 @@ async function resolveCloudflareArtifactsConfigs(
       options.aliases,
       { artifactsOnly: options.artifactsOnly },
       { env: options.env, hosting: options.hosting },
+      options.definitionOverrides,
     ),
   ]
 }
@@ -676,6 +684,7 @@ async function writeNitroWorkspacePlugin(
   definitions: DiscoveredWorkspaceDefinition[],
   cloudflareArtifacts = false,
   importBase = WORKSPACE_PACKAGE_NAME,
+  definitionOverrides?: Map<string, ResolvedWorkspaceModuleOptions>,
 ): Promise<void> {
   const pluginFile = resolve(root, generatedNitroWorkspacePlugin)
   const registryFile = resolve(root, generatedNitroWorkspaceRegistry)
@@ -684,7 +693,7 @@ async function writeNitroWorkspacePlugin(
     mkdir(dirname(pluginFile), { recursive: true }),
     mkdir(dirname(registryFile), { recursive: true }),
   ])
-  await writeFile(registryFile, createWorkspaceRegistryContents(registryFile, definitions), "utf8")
+  await writeFile(registryFile, createWorkspaceRegistryContents(registryFile, definitions, definitionOverrides), "utf8")
   await writeFile(
     pluginFile,
     renderNitroWorkspacePlugin(
@@ -712,14 +721,16 @@ export async function createWorkspaceNitroConfig(options: WorkspaceNitroConfigOp
   const definitions = discoverDefinitions(roots)
   if (!isHostedWorkspaceStore(normalized.store) && !hasExplicitWorkspaceRuntimeOptions(workspaceOptions) && definitions.length === 0) return null
 
+  const definitionOverrides = new Map<string, ResolvedWorkspaceModuleOptions>()
   const cloudflareArtifactsConfigs = await resolveCloudflareArtifactsConfigs(normalized, definitions, roots.projectRoot, {
     aliases: options.aliases,
     artifactsOnly: true,
     env: options.env,
     hosting: options.hosting,
+    definitionOverrides,
   })
   const runtimeConfig = shouldConfigureRuntime(workspaceOptions, normalized) ? normalized : false
-  await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, workspaceOptions, definitions, cloudflareArtifactsConfigs.length > 0)
+  await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, workspaceOptions, definitions, cloudflareArtifactsConfigs.length > 0, WORKSPACE_PACKAGE_NAME, definitionOverrides)
   const nitro = mergeNitroWorkspaceConfig(options.nitro)
   for (const config of cloudflareArtifactsConfigs) configureCloudflareArtifacts(nitro, config)
   if (cloudflareArtifactsConfigs.length > 0) configureCloudflareArtifactsNitroRuntime(nitro)

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -82,7 +82,7 @@ async function sourceModuleUsesCloudflareArtifacts(
   const staticModuleSpecifier = /\b(?:import|export)\s+(?!type\b)(?:([^"']*?)\s+from\s+)?["']([^"']+)["']/g
   for (const match of loaded.source.matchAll(staticModuleSpecifier)) {
     const imports = match[1]?.trim()
-    if (imports?.startsWith("{") && imports.endsWith("}") && imports.slice(1, -1).split(",").every(entry => /^type\b/.test(entry.trim()))) continue
+    if (imports?.startsWith("{") && imports.endsWith("}") && imports.slice(1, -1).split(",").map(entry => entry.trim()).filter(Boolean).every(entry => /^type\b/.test(entry))) continue
     const specifier = match[2]!
     const resolvedModule = specifier.startsWith(".")
       ? resolve(dirname(loaded.file), specifier)

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -1,5 +1,6 @@
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { dirname, extname, isAbsolute, relative, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 import { createDefaultCloudflareOutputRoot, writeCloudflareWranglerConfig } from "@vite-hub/internal/build/cloudflare"
 import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
@@ -179,16 +180,33 @@ async function resolveDefinitionCloudflareArtifactsConfigs(
   options: ResolvedWorkspaceModuleOptions,
   resolveModule?: SourceModuleResolver,
   aliases?: Record<string, string>,
+  inspection?: { artifactsOnly?: boolean },
+  resolution?: { env?: Record<string, string | undefined>, hosting?: string },
 ): Promise<ResolvedWorkspaceModuleOptions[]> {
   const loader = createWorkspaceDefinitionLoader(rootDir, aliases)
+  const resolveSourceModule = resolveModule || (async (id: string, importer: string) => {
+    try {
+      return fileURLToPath(loader.esmResolve(id, pathToFileURL(importer).href))
+    }
+    catch {
+      return undefined
+    }
+  })
   const configs: ResolvedWorkspaceModuleOptions[] = []
   for (const definition of definitions) {
+    const declaresCloudflareArtifacts = inspection?.artifactsOnly
+      ? await sourceModuleUsesCloudflareArtifacts(definition.path, resolveSourceModule)
+      : false
     const bundlesAssets = shouldBundleWorkspaceAssets(options.assets, definition.name)
     let loaded: WorkspaceDefinitionInput
     try {
       loaded = await loadDiscoveredWorkspaceDefinition(loader, definition)
     }
     catch (error) {
+      if (inspection?.artifactsOnly) {
+        if (declaresCloudflareArtifacts) throw error
+        continue
+      }
       if (bundlesAssets || await sourceModuleUsesCloudflareArtifacts(definition.path, resolveModule)) throw error
       continue
     }
@@ -196,13 +214,39 @@ async function resolveDefinitionCloudflareArtifactsConfigs(
     if (!workspace.store || "readFile" in workspace.store) continue
     const config = normalizeWorkspaceOptions({ store: workspace.store }, {
       dev: false,
-      env: process.env,
-      hosting: process.env.VITEHUB_HOSTING,
+      env: resolution?.env || process.env,
+      hosting: resolution?.hosting ?? process.env.VITEHUB_HOSTING,
       rootDir: workspace.rootDir || rootDir,
     })
     if (config && config.store.provider === "cloudflare-artifacts") configs.push(config)
   }
   return configs
+}
+
+async function resolveCloudflareArtifactsConfigs(
+  config: ResolvedWorkspaceModuleOptions,
+  definitions: DiscoveredWorkspaceDefinition[],
+  rootDir: string,
+  options: {
+    aliases?: Record<string, string>
+    artifactsOnly?: boolean
+    env?: Record<string, string | undefined>
+    hosting?: string
+    resolveModule?: SourceModuleResolver
+  } = {},
+): Promise<ResolvedWorkspaceModuleOptions[]> {
+  return [
+    ...(config.store.provider === "cloudflare-artifacts" ? [config] : []),
+    ...await resolveDefinitionCloudflareArtifactsConfigs(
+      definitions,
+      rootDir,
+      config,
+      options.resolveModule,
+      options.aliases,
+      { artifactsOnly: options.artifactsOnly },
+      { env: options.env, hosting: options.hosting },
+    ),
+  ]
 }
 
 async function writeCloudflareArtifactsProviderOutput(
@@ -213,10 +257,7 @@ async function writeCloudflareArtifactsProviderOutput(
   aliases?: Record<string, string>,
 ): Promise<void> {
   const configs = config
-    ? [
-        ...(config.store.provider === "cloudflare-artifacts" ? [config] : []),
-        ...await resolveDefinitionCloudflareArtifactsConfigs(definitions, rootDir, config, resolveModule, aliases),
-      ]
+    ? await resolveCloudflareArtifactsConfigs(config, definitions, rootDir, { aliases, resolveModule })
     : []
   const requestedConfig = createCloudflareArtifactsWranglerConfig(configs)
   const [configuredArtifacts, previousBindings] = await Promise.all([
@@ -244,6 +285,7 @@ async function writeCloudflareArtifactsProviderOutput(
 }
 
 export interface WorkspaceNitroConfigOptions {
+  aliases?: Record<string, string>
   command?: "build" | "serve"
   env?: Record<string, string | undefined>
   hosting?: string
@@ -253,7 +295,16 @@ export interface WorkspaceNitroConfigOptions {
 }
 
 export type NitroConfig = {
+  cloudflare?: {
+    wrangler?: {
+      artifacts?: Array<{ binding: string, namespace: string }>
+      compatibility_flags?: string[]
+    } & Record<string, unknown>
+  } & Record<string, unknown>
   plugins?: unknown[]
+  rollupConfig?: {
+    external?: unknown
+  } & Record<string, unknown>
 } & Record<string, unknown>
 
 type ViteConfigWithWorkspaceNitro = Omit<UserConfig, "plugins"> & {
@@ -500,6 +551,26 @@ function mergeNitroWorkspaceConfig(value: unknown): NitroConfig {
   return { ...nitro, plugins }
 }
 
+function mergeNitroExternal(value: unknown, addition: string): unknown {
+  if (typeof value === "undefined") return [addition]
+  if (Array.isArray(value)) return value.includes(addition) ? [...value] : [...value, addition]
+  if (typeof value === "string" || value instanceof RegExp) return [value, addition]
+  if (typeof value === "function") {
+    return (source: string, importer?: string, isResolved?: boolean) => source === addition || Boolean(value(source, importer, isResolved))
+  }
+  return value
+}
+
+function configureCloudflareArtifactsNitroRuntime(nitro: NitroConfig): void {
+  nitro.cloudflare ??= {}
+  nitro.cloudflare.wrangler ??= {}
+  const compatibilityFlags = nitro.cloudflare.wrangler.compatibility_flags || []
+  if (!compatibilityFlags.includes("nodejs_compat")) compatibilityFlags.push("nodejs_compat")
+  nitro.cloudflare.wrangler.compatibility_flags = compatibilityFlags
+  const rollupConfig = isRecord(nitro.rollupConfig) ? { ...nitro.rollupConfig } : {}
+  nitro.rollupConfig = { ...rollupConfig, external: mergeNitroExternal(rollupConfig.external, "cloudflare:workers") }
+}
+
 function moduleImportSpecifier(fromFile: string, targetFile: string): string {
   const specifier = relative(dirname(fromFile), targetFile).replace(/\\/g, "/")
   return specifier.startsWith(".") ? specifier : `./${specifier}`
@@ -544,6 +615,7 @@ function renderNitroWorkspacePlugin(
   config: false | ResolvedWorkspaceModuleOptions,
   registryImport: string,
   installHostedRuntime: boolean,
+  cloudflareArtifacts: boolean,
   importBase = WORKSPACE_PACKAGE_NAME,
 ): string {
   const hostedRuntimeImport = `${importBase}/internal/runtime/hosted`
@@ -566,6 +638,12 @@ function renderNitroWorkspacePlugin(
         ...(installHostedRuntime ? [`import { installHostedVercelBlobWorkspaceRuntime } from '${hostedVercelBlobRuntimeImport}'`] : []),
         `import { ${config ? "setWorkspaceRuntimeConfig, " : ""}setWorkspaceRuntimeRegistry } from '${runtimeImport}'`,
       ]
+  if (cloudflareArtifacts) {
+    runtimeImports.unshift(
+      "import { env as vitehubEnv } from 'cloudflare:workers'",
+      `import { setActiveCloudflareEnv } from '${importBase}/internal/runtime/state'`,
+    )
+  }
   const runtimeSetup = hostedConfig
     ? [
         `  ${isVercelBlobStore ? "configureHostedVercelBlobWorkspaceRuntime" : "configureHostedWorkspaceRuntime"}(${renderRuntimeValue({ root: hostedConfig.root, store: hostedConfig.store })})`,
@@ -582,6 +660,7 @@ function renderNitroWorkspacePlugin(
     `import registry from ${JSON.stringify(registryImport)}`,
     "",
     "export default function vitehubWorkspacePlugin() {",
+    ...(cloudflareArtifacts ? ["  setActiveCloudflareEnv(vitehubEnv)"] : []),
     "  setWorkspaceRuntimeRegistry(registry)",
     ...runtimeSetup,
     "}",
@@ -594,6 +673,7 @@ async function writeNitroWorkspacePlugin(
   config: false | ResolvedWorkspaceModuleOptions,
   options: false | WorkspaceModuleOptions | undefined,
   definitions: DiscoveredWorkspaceDefinition[],
+  cloudflareArtifacts = false,
   importBase = WORKSPACE_PACKAGE_NAME,
 ): Promise<void> {
   const pluginFile = resolve(root, generatedNitroWorkspacePlugin)
@@ -610,6 +690,7 @@ async function writeNitroWorkspacePlugin(
       runtimeConfig,
       moduleImportSpecifier(pluginFile, registryFile),
       definitions.length > 0 && !(runtimeConfig && isHostedWorkspaceStore(runtimeConfig.store)),
+      cloudflareArtifacts,
       importBase,
     ),
     "utf8",
@@ -630,9 +711,18 @@ export async function createWorkspaceNitroConfig(options: WorkspaceNitroConfigOp
   const definitions = discoverDefinitions(roots)
   if (!isHostedWorkspaceStore(normalized.store) && !hasExplicitWorkspaceRuntimeOptions(workspaceOptions) && definitions.length === 0) return null
 
+  const cloudflareArtifactsConfigs = await resolveCloudflareArtifactsConfigs(normalized, definitions, roots.projectRoot, {
+    aliases: options.aliases,
+    artifactsOnly: true,
+    env: options.env,
+    hosting: options.hosting,
+  })
   const runtimeConfig = shouldConfigureRuntime(workspaceOptions, normalized) ? normalized : false
-  await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, workspaceOptions, definitions)
-  return mergeNitroWorkspaceConfig(options.nitro)
+  await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, workspaceOptions, definitions, cloudflareArtifactsConfigs.length > 0)
+  const nitro = mergeNitroWorkspaceConfig(options.nitro)
+  for (const config of cloudflareArtifactsConfigs) configureCloudflareArtifacts(nitro, config)
+  if (cloudflareArtifactsConfigs.length > 0) configureCloudflareArtifactsNitroRuntime(nitro)
+  return nitro
 }
 
 export interface WorkspaceVitePluginAPI {
@@ -724,8 +814,16 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       const definitions = normalized ? discoverDefinitions(roots) : []
       if (normalized && shouldInstallNitroWorkspacePlugin(config, runtimeOptions, normalized, definitions)) {
         const runtimeConfig = shouldConfigureRuntime(runtimeOptions, normalized) ? normalized : false
-        await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, runtimeOptions, definitions, importBase)
+        const artifacts = await resolveCloudflareArtifactsConfigs(normalized, definitions, roots.projectRoot, {
+          aliases: config.resolve?.alias && !Array.isArray(config.resolve.alias) ? config.resolve.alias as Record<string, string> : undefined,
+          artifactsOnly: true,
+          hosting,
+        })
+        const usesCloudflareArtifacts = artifacts.length > 0
+        await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, runtimeOptions, definitions, usesCloudflareArtifacts, importBase)
         const nitro = mergeNitroWorkspaceConfig((config as ViteConfigWithWorkspaceNitro).nitro)
+        for (const artifactConfig of artifacts) configureCloudflareArtifacts(nitro, artifactConfig)
+        if (usesCloudflareArtifacts) configureCloudflareArtifactsNitroRuntime(nitro)
         ;(config as ViteConfigWithWorkspaceNitro).nitro = nitro
         viteConfig.nitro = nitro
       }

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -826,13 +826,15 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       const definitions = normalized ? discoverDefinitions(roots) : []
       if (normalized && shouldInstallNitroWorkspacePlugin(config, runtimeOptions, normalized, definitions)) {
         const runtimeConfig = shouldConfigureRuntime(runtimeOptions, normalized) ? normalized : false
+        const definitionOverrides = new Map<string, ResolvedWorkspaceModuleOptions>()
         const artifacts = await resolveCloudflareArtifactsConfigs(normalized, definitions, roots.projectRoot, {
           aliases: config.resolve?.alias ? workspaceDefinitionLoaderAliases(config.resolve.alias) : undefined,
           artifactsOnly: true,
           hosting,
+          definitionOverrides,
         })
         const usesCloudflareArtifacts = artifacts.length > 0
-        await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, runtimeOptions, definitions, usesCloudflareArtifacts, importBase)
+        await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, runtimeOptions, definitions, usesCloudflareArtifacts, importBase, definitionOverrides)
         const nitro = mergeNitroWorkspaceConfig((config as ViteConfigWithWorkspaceNitro).nitro)
         for (const artifactConfig of artifacts) configureCloudflareArtifacts(nitro, artifactConfig)
         if (usesCloudflareArtifacts) configureCloudflareArtifactsNitroRuntime(nitro)

--- a/packages/workspace/src/nuxt.ts
+++ b/packages/workspace/src/nuxt.ts
@@ -7,6 +7,7 @@ export interface WorkspaceNuxtModuleOptions extends WorkspaceModuleOptions {}
 type NuxtLike = {
   hook?: (name: "nitro:config", handler: (nitroConfig: Record<string, unknown>) => void | Promise<void>) => void
   options: {
+    alias?: Record<string, string>
     dev?: boolean
     imports?: {
       imports?: Array<{ from: string, name: string }>
@@ -51,6 +52,7 @@ export default function viteHubWorkspaceNuxtModule(options: WorkspaceNuxtModuleO
   nuxt.hook?.("nitro:config", async (nitroConfig) => {
     const rootDir = nuxt.options.rootDir || process.cwd()
     const nitro = await createWorkspaceNitroConfig({
+      aliases: nuxt.options.alias,
       command: nuxt.options.dev ? "serve" : "build",
       nitro: nitroConfig,
       viteRoot: nuxt.options.srcDir || rootDir,

--- a/packages/workspace/src/runtime/state.ts
+++ b/packages/workspace/src/runtime/state.ts
@@ -1,6 +1,7 @@
 import { registerWorkspace, resolveRegisteredWorkspaceDefinition, setWorkspaceRegistry, type WorkspaceRegistry } from "../core/registry.ts"
 import { setWorkspaceAssetsRegistry } from "../asset-registry.ts"
 import type { WorkspaceAssetsRegistry } from "../core/types.ts"
+export { setActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 export { useWorkspace } from "../core/use.ts"
 export type { ReadonlyWorkspaceFacade, UseWorkspaceOptions, WritableWorkspaceFacade } from "../core/use.ts"
 export { resetWorkspaceStoreCache } from "../core/workspace-cache.ts"

--- a/packages/workspace/test/discovery.test.ts
+++ b/packages/workspace/test/discovery.test.ts
@@ -68,6 +68,20 @@ describe("discoverServerWorkspaceDefinitions", () => {
     expect(contents).toContain("sourceRootDir: mod.default.sourceRootDir ??")
   })
 
+  it("applies resolved store overrides to Workspace Agent options", async () => {
+    const root = await createRoot()
+    const registryFile = join(root, ".vitehub", "workspace", "registry.mjs")
+    await mkdir(join(root, "server", "agents", "docs"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "docs", "agent.ts"), "export default defineAgent({ workspace: { store: { provider: 'cloudflare-artifacts' } } })\n", "utf8")
+    const definitions = discoverServerWorkspaceDefinitions(root)
+    const store = { binding: "ENV_ARTIFACTS", namespace: "environment", provider: "cloudflare-artifacts" }
+
+    const contents = createWorkspaceRegistryContents(registryFile, definitions, new Map([["docs", { store }]]))
+
+    expect(contents).toContain("workspace: { ...mod.default.__vitehubWorkspaceAgentOptions.workspace, store:")
+    expect(contents).toContain('"binding":"ENV_ARTIFACTS"')
+  })
+
   it("uses config directory when sibling workspace path is not a directory", async () => {
     const root = await createRoot()
     const directory = join(root, "server", "workspaces", "docs")

--- a/packages/workspace/test/nuxt-types.test-d.ts
+++ b/packages/workspace/test/nuxt-types.test-d.ts
@@ -3,15 +3,32 @@ import { describe, expectTypeOf, it } from "vitest"
 
 import workspaceNuxt from "../src/nuxt.ts"
 
+import type { NitroConfig } from "../src/nitro.ts"
+
 describe("workspace nuxt types", () => {
   it("loads Workspace Vite config types through the Nuxt entrypoint", () => {
     const config: UserConfig = {
       workspace: {
-        store: { provider: "memory" },
+        store: {
+          binding: "WORKSPACE_FILES",
+          namespace: "project-workspaces",
+          provider: "cloudflare-artifacts",
+        },
+      },
+    }
+    expectTypeOf(workspaceNuxt).toBeFunction()
+    expectTypeOf(config.workspace).toMatchTypeOf<UserConfig["workspace"]>()
+  })
+
+  it("types Cloudflare Artifacts in generated Nitro config", () => {
+    const config: NitroConfig = {
+      cloudflare: {
+        wrangler: {
+          artifacts: [{ binding: "WORKSPACE_FILES", namespace: "project-workspaces" }],
+        },
       },
     }
 
-    expectTypeOf(workspaceNuxt).toBeFunction()
-    expectTypeOf(config.workspace).toMatchTypeOf<UserConfig["workspace"]>()
+    expectTypeOf(config.cloudflare?.wrangler?.artifacts).toMatchTypeOf<Array<{ binding: string, namespace: string }> | undefined>()
   })
 })

--- a/packages/workspace/test/nuxt.test.ts
+++ b/packages/workspace/test/nuxt.test.ts
@@ -150,7 +150,7 @@ describe("Workspace Nuxt module", () => {
     await mkdir(definitionRoot, { recursive: true })
     await writeFile(join(definitionRoot, "artifact-options.ts"), "export type ArtifactOptions = { provider: 'cloudflare-artifacts' }\n")
     await writeFile(join(definitionRoot, "typed.ts"), [
-      "import { type ArtifactOptions } from './artifact-options'",
+      "import { type ArtifactOptions, } from './artifact-options'",
       "import { workspaceRoot } from '#imports'",
       "export default { root: workspaceRoot, store: { provider: 'memory' } } satisfies { store: ArtifactOptions | { provider: 'memory' } }",
       "",

--- a/packages/workspace/test/nuxt.test.ts
+++ b/packages/workspace/test/nuxt.test.ts
@@ -159,6 +159,39 @@ describe("Workspace Nuxt module", () => {
     await expect(nitroConfigHook({})).resolves.toBeUndefined()
   })
 
+  it("ignores non-runtime Artifact provider references in Workspace Definitions", async () => {
+    const { nitroConfigHook, root } = await createNuxtHook()
+    const definitionRoot = join(root, "server", "workspaces")
+    await mkdir(definitionRoot, { recursive: true })
+    await writeFile(join(definitionRoot, "typed.ts"), [
+      "type ArtifactStore = {",
+      "  provider: 'cloudflare-artifacts'",
+      "}",
+      "interface NestedStore { store: { provider: 'cloudflare-artifacts' } }",
+      "// provider: 'cloudflare-artifacts'",
+      "const example = \"provider: 'cloudflare-artifacts'\"",
+      "const unrelated = { provider: 'cloudflare-artifacts' }",
+      "import { workspaceRoot } from '#imports'",
+      "export default { root: workspaceRoot, example, unrelated, store: { provider: 'memory' } } satisfies NestedStore | { store: ArtifactStore | { provider: 'memory' } }",
+      "",
+    ].join("\n"))
+
+    await expect(nitroConfigHook({})).resolves.toBeUndefined()
+  })
+
+  it("surfaces unresolved runtime Artifact Workspace Definitions", async () => {
+    const { nitroConfigHook, root } = await createNuxtHook()
+    const definitionRoot = join(root, "server", "workspaces")
+    await mkdir(definitionRoot, { recursive: true })
+    await writeFile(join(definitionRoot, "artifacts.ts"), [
+      "import { workspaceRoot } from '#imports'",
+      "export default { root: workspaceRoot, store: { provider: 'cloudflare-artifacts' as const } }",
+      "",
+    ].join("\n"))
+
+    await expect(nitroConfigHook({})).rejects.toThrow("Cannot find module '#imports'")
+  })
+
   it("registers a Definition binding configured through a Nuxt alias", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-nuxt-alias-"))
     tempDirs.push(root)

--- a/packages/workspace/test/nuxt.test.ts
+++ b/packages/workspace/test/nuxt.test.ts
@@ -1,6 +1,41 @@
-import { describe, expect, it } from "vitest"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterEach, describe, expect, it } from "vitest"
 
 import workspaceNuxt from "../src/nuxt.ts"
+import { createWorkspaceNitroConfig } from "../src/vite.ts"
+
+import type { WorkspaceModuleOptions } from "../src/core/types.ts"
+
+const tempDirs: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
+})
+
+async function createNuxtHook(store: WorkspaceModuleOptions["store"] = { provider: "memory" }, aliases?: Record<string, string>) {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-nuxt-artifacts-"))
+  tempDirs.push(root)
+  let nitroConfigHook: ((nitroConfig: Record<string, unknown>) => void | Promise<void>) | undefined
+  const nuxt = {
+    hook(name: "nitro:config", handler: (nitroConfig: Record<string, unknown>) => void | Promise<void>) {
+      if (name === "nitro:config") nitroConfigHook = handler
+    },
+    options: {
+      alias: aliases,
+      dev: false,
+      rootDir: root,
+      srcDir: root,
+      vite: {},
+    },
+  }
+
+  workspaceNuxt({ store }, nuxt)
+  expect(nitroConfigHook).toBeDefined()
+  return { nitroConfigHook: nitroConfigHook!, root }
+}
 
 describe("Workspace Nuxt module", () => {
   it("registers collection composables once", () => {
@@ -20,5 +55,170 @@ describe("Workspace Nuxt module", () => {
       { from: "@vite-hub/workspace/collections/client", name: "useWorkspaceCollection" },
       { from: "@vite-hub/workspace/collections/client", name: "useWorkspaceCollectionItem" },
     ])
+  })
+
+  it("registers the default Cloudflare Artifacts binding and runtime in generated Nitro config", async () => {
+    const { nitroConfigHook, root } = await createNuxtHook({ provider: "cloudflare-artifacts" })
+    const nitroConfig: Record<string, unknown> = {
+      cloudflare: {
+        wrangler: {
+          artifacts: [{ binding: "EXISTING_ARTIFACTS", namespace: "existing" }],
+          observability: { enabled: true },
+        },
+      },
+    }
+
+    await nitroConfigHook(nitroConfig)
+
+    expect(nitroConfig).toMatchObject({
+      cloudflare: {
+        wrangler: {
+          artifacts: [
+            { binding: "EXISTING_ARTIFACTS", namespace: "existing" },
+            { binding: "WORKSPACE_ARTIFACTS", namespace: "vitehub" },
+          ],
+          compatibility_flags: ["nodejs_compat"],
+          observability: { enabled: true },
+        },
+      },
+      plugins: [".vitehub/nitro/workspace/plugin.ts"],
+      rollupConfig: { external: ["cloudflare:workers"] },
+    })
+    const plugin = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
+    expect(plugin).toContain("import { env as vitehubEnv } from 'cloudflare:workers'")
+    expect(plugin).toContain("setActiveCloudflareEnv(vitehubEnv)")
+  })
+
+  it("registers Cloudflare Artifacts bindings from Workspace Definitions", async () => {
+    const { nitroConfigHook, root } = await createNuxtHook()
+    await mkdir(join(root, "server", "workspaces"), { recursive: true })
+    await writeFile(join(root, "server", "workspaces", "reports.ts"), [
+      "export default {",
+      "  store: { binding: 'REPORT_ARTIFACTS', namespace: 'reports', provider: 'cloudflare-artifacts' },",
+      "}",
+      "",
+    ].join("\n"))
+
+    const nitroConfig: Record<string, unknown> = {}
+    await nitroConfigHook(nitroConfig)
+
+    expect(nitroConfig).toMatchObject({
+      cloudflare: {
+        wrangler: {
+          artifacts: [
+            { binding: "REPORT_ARTIFACTS", namespace: "reports" },
+          ],
+        },
+      },
+    })
+  })
+
+  it("resolves Definition bindings from the Nitro environment", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-nuxt-env-"))
+    tempDirs.push(root)
+    await mkdir(join(root, "server", "workspaces"), { recursive: true })
+    await writeFile(join(root, "server", "workspaces", "reports.ts"), [
+      "export default { store: { provider: 'cloudflare-artifacts' } }",
+      "",
+    ].join("\n"))
+
+    await expect(createWorkspaceNitroConfig({
+      env: { WORKSPACE_ARTIFACTS_BINDING: "ENV_ARTIFACTS", WORKSPACE_ARTIFACTS_NAMESPACE: "environment" },
+      viteRoot: root,
+    })).resolves.toMatchObject({
+      cloudflare: { wrangler: { artifacts: [{ binding: "ENV_ARTIFACTS", namespace: "environment" }] } },
+    })
+  })
+
+  it("does not load non-Artifact Workspace Definitions before Nuxt aliases are available", async () => {
+    const { nitroConfigHook, root } = await createNuxtHook()
+    await mkdir(join(root, "server", "workspaces"), { recursive: true })
+    await writeFile(join(root, "server", "workspaces", "aliased.ts"), [
+      "import { workspaceRoot } from '~/workspace-options'",
+      "export default { root: workspaceRoot, store: { provider: 'memory' } }",
+      "",
+    ].join("\n"))
+
+    await expect(nitroConfigHook({})).resolves.toBeUndefined()
+  })
+
+  it("registers a Definition binding configured through a Nuxt alias", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-nuxt-alias-"))
+    tempDirs.push(root)
+    const optionsFile = join(root, "workspace-options.ts")
+    const { nitroConfigHook, root: nuxtRoot } = await createNuxtHook({ provider: "memory" }, { "#workspace-options": optionsFile })
+    const definitionRoot = join(nuxtRoot, "server", "workspaces")
+    await mkdir(definitionRoot, { recursive: true })
+    await writeFile(optionsFile, "export const store = { binding: 'ALIAS_ARTIFACTS', namespace: 'alias', provider: 'cloudflare-artifacts' } as const\n")
+    await writeFile(join(definitionRoot, "aliased-artifacts.ts"), [
+      "import { store } from '#workspace-options'",
+      "export default { store }",
+      "",
+    ].join("\n"))
+
+    const nitroConfig: Record<string, unknown> = {}
+    await nitroConfigHook(nitroConfig)
+    expect(nitroConfig).toMatchObject({
+      cloudflare: { wrangler: { artifacts: [{ binding: "ALIAS_ARTIFACTS", namespace: "alias" }] } },
+    })
+  })
+
+  it("registers a Definition binding with a computed provider", async () => {
+    const { nitroConfigHook, root } = await createNuxtHook()
+    const definitionRoot = join(root, "server", "workspaces")
+    await mkdir(definitionRoot, { recursive: true })
+    await writeFile(join(definitionRoot, "computed-artifacts.ts"), [
+      "const provider = ['cloudflare', 'artifacts'].join('-')",
+      "export default { store: { binding: 'COMPUTED_ARTIFACTS', namespace: 'computed', provider } }",
+      "",
+    ].join("\n"))
+
+    const nitroConfig: Record<string, unknown> = {}
+    await nitroConfigHook(nitroConfig)
+    expect(nitroConfig).toMatchObject({
+      cloudflare: { wrangler: { artifacts: [{ binding: "COMPUTED_ARTIFACTS", namespace: "computed" }] } },
+    })
+  })
+
+  it("deduplicates an existing custom Cloudflare Artifacts binding", async () => {
+    const { nitroConfigHook } = await createNuxtHook({
+      binding: "CUSTOM_ARTIFACTS",
+      namespace: "custom-workspaces",
+      provider: "cloudflare-artifacts",
+    })
+    const nitroConfig: Record<string, unknown> = {
+      cloudflare: {
+        wrangler: {
+          artifacts: [{ binding: "CUSTOM_ARTIFACTS", namespace: "custom-workspaces" }],
+        },
+      },
+    }
+
+    await nitroConfigHook(nitroConfig)
+
+    expect(nitroConfig).toMatchObject({
+      cloudflare: {
+        wrangler: {
+          artifacts: [{ binding: "CUSTOM_ARTIFACTS", namespace: "custom-workspaces" }],
+        },
+      },
+      plugins: [".vitehub/nitro/workspace/plugin.ts"],
+    })
+  })
+
+  it("rejects a custom binding already assigned to another namespace", async () => {
+    const { nitroConfigHook } = await createNuxtHook({
+      binding: "CUSTOM_ARTIFACTS",
+      namespace: "workspace",
+      provider: "cloudflare-artifacts",
+    })
+
+    await expect(nitroConfigHook({
+      cloudflare: {
+        wrangler: {
+          artifacts: [{ binding: "CUSTOM_ARTIFACTS", namespace: "application" }],
+        },
+      },
+    })).rejects.toThrow("cannot use both namespace")
   })
 })

--- a/packages/workspace/test/nuxt.test.ts
+++ b/packages/workspace/test/nuxt.test.ts
@@ -128,6 +128,8 @@ describe("Workspace Nuxt module", () => {
     })).resolves.toMatchObject({
       cloudflare: { wrangler: { artifacts: [{ binding: "ENV_ARTIFACTS", namespace: "environment" }] } },
     })
+    const registry = await readFile(join(root, ".vitehub", "nitro", "workspace", "registry.js"), "utf8")
+    expect(registry).toContain('store: {"binding":"ENV_ARTIFACTS","namespace":"environment","provider":"cloudflare-artifacts"')
   })
 
   it("does not load non-Artifact Workspace Definitions before Nuxt aliases are available", async () => {
@@ -148,7 +150,7 @@ describe("Workspace Nuxt module", () => {
     await mkdir(definitionRoot, { recursive: true })
     await writeFile(join(definitionRoot, "artifact-options.ts"), "export type ArtifactOptions = { provider: 'cloudflare-artifacts' }\n")
     await writeFile(join(definitionRoot, "typed.ts"), [
-      "import type { ArtifactOptions } from './artifact-options'",
+      "import { type ArtifactOptions } from './artifact-options'",
       "import { workspaceRoot } from '#imports'",
       "export default { root: workspaceRoot, store: { provider: 'memory' } } satisfies { store: ArtifactOptions | { provider: 'memory' } }",
       "",

--- a/packages/workspace/test/nuxt.test.ts
+++ b/packages/workspace/test/nuxt.test.ts
@@ -142,6 +142,21 @@ describe("Workspace Nuxt module", () => {
     await expect(nitroConfigHook({})).resolves.toBeUndefined()
   })
 
+  it("ignores type-only imports when detecting Artifact Workspace Definitions", async () => {
+    const { nitroConfigHook, root } = await createNuxtHook()
+    const definitionRoot = join(root, "server", "workspaces")
+    await mkdir(definitionRoot, { recursive: true })
+    await writeFile(join(definitionRoot, "artifact-options.ts"), "export type ArtifactOptions = { provider: 'cloudflare-artifacts' }\n")
+    await writeFile(join(definitionRoot, "typed.ts"), [
+      "import type { ArtifactOptions } from './artifact-options'",
+      "import { workspaceRoot } from '#imports'",
+      "export default { root: workspaceRoot, store: { provider: 'memory' } } satisfies { store: ArtifactOptions | { provider: 'memory' } }",
+      "",
+    ].join("\n"))
+
+    await expect(nitroConfigHook({})).resolves.toBeUndefined()
+  })
+
   it("registers a Definition binding configured through a Nuxt alias", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-nuxt-alias-"))
     tempDirs.push(root)

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -869,6 +869,32 @@ describe("hubWorkspace", () => {
     expect(registrySource).toContain('"docs": async () => {')
   })
 
+  it("activates Cloudflare Artifacts bindings in the Vite-generated Nitro runtime", async () => {
+    const root = await createViteRoot()
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace({ store: { provider: "cloudflare-artifacts" } })
+    const config = plugin.config as (
+      config: { plugins?: unknown[], root: string },
+      env: { command: "build", mode: string },
+    ) => Promise<{ nitro?: { plugins?: string[] } }>
+
+    await expect(config({ plugins: [{ name: "nitro:main" }], root }, { command: "build", mode: "production" })).resolves.toMatchObject({
+      nitro: {
+        cloudflare: {
+          wrangler: {
+            artifacts: [{ binding: "WORKSPACE_ARTIFACTS", namespace: "vitehub" }],
+            compatibility_flags: ["nodejs_compat"],
+          },
+        },
+        rollupConfig: { external: ["cloudflare:workers"] },
+      },
+    })
+
+    const pluginSource = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
+    expect(pluginSource).toContain("import { env as vitehubEnv } from 'cloudflare:workers'")
+    expect(pluginSource).toContain("setActiveCloudflareEnv(vitehubEnv)")
+  })
+
   it("does not discover Nitro workspaces when workspace is disabled", async () => {
     const root = await createViteRoot()
     const { createWorkspaceNitroConfig } = await import("../src/vite.ts")

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -895,6 +895,23 @@ describe("hubWorkspace", () => {
     expect(pluginSource).toContain("setActiveCloudflareEnv(vitehubEnv)")
   })
 
+  it("preserves env-resolved Definition bindings in the Vite-generated registry", async () => {
+    vi.stubEnv("WORKSPACE_ARTIFACTS_BINDING", "ENV_ARTIFACTS")
+    const root = await createViteRoot()
+    await writeFile(join(root, "src", "docs.workspace.ts"), "export default { store: { provider: 'cloudflare-artifacts' } }\n")
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace()
+    const config = plugin.config as (
+      config: { plugins?: unknown[], root: string },
+      env: { command: "build", mode: string },
+    ) => Promise<unknown>
+
+    await config({ plugins: [{ name: "nitro:main" }], root }, { command: "build", mode: "production" })
+
+    const registry = await readFile(join(root, ".vitehub", "nitro", "workspace", "registry.js"), "utf8")
+    expect(registry).toContain('store: {"binding":"ENV_ARTIFACTS"')
+  })
+
   it("does not discover Nitro workspaces when workspace is disabled", async () => {
     const root = await createViteRoot()
     const { createWorkspaceNitroConfig } = await import("../src/vite.ts")


### PR DESCRIPTION
Projects normalized `cloudflare-artifacts` Workspace stores into generated Nitro Cloudflare Wrangler config when `@vite-hub/workspace/nuxt` runs its `nitro:config` hook. This covers both module-level configuration and discovered Workspace Definitions, closing the Nitro Vite gap where Workspace runtime configuration existed without its Artifacts binding.

The Nitro config creator reuses Workspace’s binding defaults, deduplication, and namespace collision checks, preserves unrelated Wrangler configuration, and wires the active Cloudflare environment used by the Artifacts runtime. Focused Nuxt coverage exercises defaults, Definition bindings, custom deduplication, conflicts, generated runtime setup, config preservation, and the emitted Nitro config type.