### PR TITLE
fix(workspace): create missing GitHub publish branches

### DIFF
--- a/packages/workspace/src/providers/github/shared.ts
+++ b/packages/workspace/src/providers/github/shared.ts
@@ -27,6 +27,7 @@ export interface GitHubTreeResponse {
 }
 
 export interface GitHubBranchState {
+  branchExists: boolean;
   files: Map<string, GitHubTreeEntry>;
   refSha: string;
   treeSha: string;
@@ -42,6 +43,12 @@ export interface GitHubFileUpdate {
 export interface GitHubCommitResult {
   commitSha: string;
   treeSha: string;
+}
+
+class GitHubRequestError extends WorkspaceError {
+  constructor(message: string, readonly status: number) {
+    super(message);
+  }
 }
 
 export function processEnv(
@@ -211,8 +218,9 @@ export async function requestGitHubJson<T>(
   });
 
   if (!response.ok) {
-    throw new WorkspaceError(
+    throw new GitHubRequestError(
       `[vitehub] GitHub workspace request failed for ${repository}: ${response.status} ${response.statusText} ${await response.text().catch(() => "")}`,
+      response.status,
     );
   }
   return (await response.json()) as T;
@@ -276,11 +284,29 @@ export async function readGitHubBranchState(input: {
   token: string;
 }): Promise<GitHubBranchState> {
   const { owner, repo } = splitGitHubRepository(input.repository, input.kind);
-  const ref = await requestGitHubJson<{ object: { sha: string } }>(
-    input.repository,
-    input.token,
-    `/repos/${owner}/${repo}/git/ref/heads/${input.branch}`,
-  );
+  let branchExists = true;
+  let ref: { object: { sha: string } };
+  try {
+    ref = await requestGitHubJson(
+      input.repository,
+      input.token,
+      `/repos/${owner}/${repo}/git/ref/heads/${input.branch}`,
+    );
+  }
+  catch (error) {
+    if (!(error instanceof GitHubRequestError) || error.status !== 404) throw error;
+    const repository = await requestGitHubJson<{ default_branch: string }>(
+      input.repository,
+      input.token,
+      `/repos/${owner}/${repo}`,
+    );
+    ref = await requestGitHubJson(
+      input.repository,
+      input.token,
+      `/repos/${owner}/${repo}/git/ref/heads/${repository.default_branch}`,
+    );
+    branchExists = false;
+  }
   const current = await requestGitHubJson<{ tree: { sha: string } }>(
     input.repository,
     input.token,
@@ -292,6 +318,7 @@ export async function readGitHubBranchState(input: {
     `/repos/${owner}/${repo}/git/trees/${current.tree.sha}?recursive=1`,
   );
   return {
+    branchExists,
     files: findGitHubRemoteFiles(tree, input.root, input.kind),
     refSha: ref.object.sha,
     treeSha: current.tree.sha,
@@ -315,6 +342,7 @@ export async function readGitHubBlob(input: {
 export async function commitGitHubChanges(input: {
   baseTreeSha: string;
   branch: string;
+  branchExists: boolean;
   deletePaths: string[];
   files: GitHubFileUpdate[];
   kind?: "publisher" | "store";
@@ -370,15 +398,28 @@ export async function commitGitHubChanges(input: {
       method: "POST",
     },
   );
-  await requestGitHubJson(
-    input.repository,
-    input.token,
-    `/repos/${owner}/${repo}/git/refs/heads/${input.branch}`,
-    {
-      body: JSON.stringify({ force: false, sha: commit.sha }),
-      method: "PATCH",
-    },
-  );
+  if (input.branchExists) {
+    await requestGitHubJson(
+      input.repository,
+      input.token,
+      `/repos/${owner}/${repo}/git/refs/heads/${input.branch}`,
+      {
+        body: JSON.stringify({ force: false, sha: commit.sha }),
+        method: "PATCH",
+      },
+    );
+  }
+  else {
+    await requestGitHubJson(
+      input.repository,
+      input.token,
+      `/repos/${owner}/${repo}/git/refs`,
+      {
+        body: JSON.stringify({ ref: `refs/heads/${input.branch}`, sha: commit.sha }),
+        method: "POST",
+      },
+    );
+  }
   return { commitSha: commit.sha, treeSha: tree.sha };
 }
 

--- a/packages/workspace/src/providers/github/store.ts
+++ b/packages/workspace/src/providers/github/store.ts
@@ -292,6 +292,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
     const commit = await commitGitHubChanges({
       baseTreeSha: this.#baselineTreeSha,
       branch: this.#branch,
+      branchExists: remote.branchExists,
       deletePaths,
       files,
       message: options.name || "chore: update workspace snapshot",

--- a/packages/workspace/src/publishers/github.ts
+++ b/packages/workspace/src/publishers/github.ts
@@ -79,6 +79,7 @@ export function github(options: GitHubPublisherOptions = {}): WorkspacePublisher
       await commitGitHubChanges({
         baseTreeSha: remote.treeSha,
         branch,
+        branchExists: remote.branchExists,
         deletePaths,
         files: changedFiles,
         kind: "publisher",

--- a/packages/workspace/test/github-publisher.test.ts
+++ b/packages/workspace/test/github-publisher.test.ts
@@ -10,6 +10,8 @@ let remoteTreeSha = "base-tree"
 let remoteTree: Array<{ path: string, sha: string, type: "blob" }> = []
 let commitIndex = 0
 let treeIndex = 0
+let mirrorRefSha: string | undefined
+let mirrorRefStatus = 404
 
 function gitBlobSha(bytes: Uint8Array): string {
   return createHash("sha1")
@@ -36,16 +38,29 @@ beforeEach(() => {
   remoteTree = []
   commitIndex = 0
   treeIndex = 0
+  mirrorRefSha = undefined
+  mirrorRefStatus = 404
   vi.stubGlobal("fetch", vi.fn(async (input: string | URL | Request, init: RequestInit = {}) => {
     const url = new URL(input instanceof Request ? input.url : String(input))
     const method = init.method || "GET"
     const body = typeof init.body === "string" ? JSON.parse(init.body) as {
       content?: string
+      force?: boolean
+      ref?: string
       sha?: string | null
       tree?: Array<{ path: string, sha: string | null, type: "blob" }>
     } : undefined
     requests.push({ body, headers: new Headers(init.headers), method, path: url.pathname })
 
+    if (url.pathname === "/repos/onmax/repo/git/ref/heads/mirror") {
+      if (mirrorRefSha) return jsonResponse({ object: { sha: mirrorRefSha } })
+      return new Response("missing mirror branch", {
+        status: mirrorRefStatus,
+        statusText: mirrorRefStatus === 404 ? "Not Found" : "Internal Server Error",
+      })
+    }
+    if (url.pathname === "/repos/onmax/repo") return jsonResponse({ default_branch: "main" })
+    if (url.pathname === "/repos/onmax/repo/git/ref/heads/main") return jsonResponse({ object: { sha: refSha } })
     if (url.pathname === "/repos/onmax/repo/git/ref/heads/feature/audio") return jsonResponse({ object: { sha: refSha } })
     if (url.pathname.startsWith("/repos/onmax/repo/git/commits/")) return jsonResponse({ tree: { sha: remoteTreeSha } })
     if (url.pathname === "/repos/onmax/repo/git/trees/base-tree" && method === "GET") return jsonResponse({ tree: remoteTree })
@@ -62,6 +77,14 @@ beforeEach(() => {
       return jsonResponse({ sha: remoteTreeSha })
     }
     if (url.pathname === "/repos/onmax/repo/git/commits" && method === "POST") return jsonResponse({ sha: `commit-sha-${++commitIndex}` })
+    if (url.pathname === "/repos/onmax/repo/git/refs" && method === "POST") {
+      if (body?.ref === "refs/heads/mirror" && body.sha) mirrorRefSha = body.sha
+      return jsonResponse({})
+    }
+    if (url.pathname === "/repos/onmax/repo/git/refs/heads/mirror" && method === "PATCH") {
+      if (body?.sha) mirrorRefSha = body.sha
+      return jsonResponse({})
+    }
     if (url.pathname === "/repos/onmax/repo/git/refs/heads/feature/audio" && method === "PATCH") {
       if (body?.sha) refSha = body.sha
       return jsonResponse({})
@@ -105,6 +128,62 @@ describe("GitHub workspace publisher", () => {
       tree: "tree-sha-1",
     })
     expect(requests.every(request => request.headers.get("user-agent") === "vitehub-workspace")).toBe(true)
+  })
+
+  it("creates a missing branch from the default branch before using non-forced updates", async () => {
+    const workspace = createWorkspace({
+      name: "docs",
+      store: { provider: "memory" },
+      publish: [github({
+        branch: "mirror",
+        repository: "onmax/repo",
+        root: "workspace/root",
+        token: "token",
+      })],
+    })
+
+    await workspace.writeFile("inbox/first.md", "first")
+    await workspace.snapshot({ name: "first publish" })
+
+    expect(requests.map(request => request.path)).toEqual(expect.arrayContaining([
+      "/repos/onmax/repo/git/ref/heads/mirror",
+      "/repos/onmax/repo",
+      "/repos/onmax/repo/git/ref/heads/main",
+    ]))
+    expect(requests.find(request => request.path.endsWith("/git/trees") && request.method === "POST")?.body)
+      .toMatchObject({ base_tree: "base-tree" })
+    expect(requests.find(request => request.path.endsWith("/git/commits") && request.method === "POST")?.body)
+      .toMatchObject({ parents: ["base-sha"] })
+    expect(requests.find(request => request.path === "/repos/onmax/repo/git/refs" && request.method === "POST")?.body)
+      .toEqual({ ref: "refs/heads/mirror", sha: "commit-sha-1" })
+    expect(requests.some(request => request.method === "PATCH")).toBe(false)
+
+    requests.length = 0
+    await workspace.writeFile("inbox/second.md", "second")
+    await workspace.snapshot({ name: "second publish" })
+
+    expect(requests.find(request => request.path.endsWith("/git/refs/heads/mirror") && request.method === "PATCH")?.body)
+      .toEqual({ force: false, sha: "commit-sha-2" })
+    expect(requests.some(request => request.path === "/repos/onmax/repo/git/refs" && request.method === "POST")).toBe(false)
+  })
+
+  it("does not treat non-404 branch failures as missing", async () => {
+    mirrorRefStatus = 500
+    const workspace = createWorkspace({
+      name: "docs",
+      store: { provider: "memory" },
+      publish: [github({
+        branch: "mirror",
+        repository: "onmax/repo",
+        token: "token",
+      })],
+    })
+
+    await workspace.writeFile("inbox/first.md", "first")
+    await expect(workspace.snapshot()).rejects.toThrow("500 Internal Server Error")
+    expect(requests.map(request => request.path)).toEqual([
+      "/repos/onmax/repo/git/ref/heads/mirror",
+    ])
   })
 
   it("publishes delete-only snapshots after the last workspace file is removed", async () => {
@@ -181,7 +260,7 @@ describe("GitHub workspace publisher", () => {
       name: "docs",
       store: { provider: "memory" },
       publish: [github({
-        branch: "feature/audio",
+        branch: "mirror",
         repo: "onmax/repo",
         root: "workspace/root",
         token: "token",

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -8,6 +8,8 @@ let remoteTreeSha = "base-tree";
 let remoteTree: Array<{ mode?: string; path: string; sha: string; size?: number; type: "blob" }> = [];
 let commitIndex = 0;
 let treeIndex = 0;
+let mirrorRefSha: string | undefined;
+let mirrorRefStatus = 404;
 const blobs = new Map<string, Uint8Array>();
 const jsonBlobResponses = new Set<string>();
 
@@ -44,6 +46,8 @@ beforeEach(() => {
   remoteTree = [];
   commitIndex = 0;
   treeIndex = 0;
+  mirrorRefSha = undefined;
+  mirrorRefStatus = 404;
   blobs.clear();
   jsonBlobResponses.clear();
   delete process.env.WORKSPACE_GITHUB_TOKEN;
@@ -58,12 +62,21 @@ beforeEach(() => {
           ? (JSON.parse(init.body) as {
               content?: string;
               force?: boolean;
+              ref?: string;
               sha?: string | null;
               tree?: Array<{ mode?: string; path: string; sha: string | null; type: "blob" }>;
             })
           : undefined;
       requests.push({ body, headers: new Headers(init.headers), method, path: url.pathname });
 
+      if (url.pathname === "/repos/onmax/repo/git/ref/heads/mirror") {
+        if (mirrorRefSha) return jsonResponse({ object: { sha: mirrorRefSha } });
+        return new Response("missing mirror branch", {
+          status: mirrorRefStatus,
+          statusText: mirrorRefStatus === 404 ? "Not Found" : "Forbidden",
+        });
+      }
+      if (url.pathname === "/repos/onmax/repo") return jsonResponse({ default_branch: "main" });
       if (url.pathname === "/repos/onmax/repo/git/ref/heads/main")
         return jsonResponse({ object: { sha: refSha } });
       if (url.pathname.startsWith("/repos/onmax/repo/git/commits/"))
@@ -111,6 +124,14 @@ beforeEach(() => {
       }
       if (url.pathname === "/repos/onmax/repo/git/commits" && method === "POST")
         return jsonResponse({ sha: `commit-sha-${++commitIndex}` });
+      if (url.pathname === "/repos/onmax/repo/git/refs" && method === "POST") {
+        if (body?.ref === "refs/heads/mirror" && body.sha) mirrorRefSha = body.sha;
+        return jsonResponse({});
+      }
+      if (url.pathname === "/repos/onmax/repo/git/refs/heads/mirror" && method === "PATCH") {
+        if (body?.sha) mirrorRefSha = body.sha;
+        return jsonResponse({});
+      }
       if (url.pathname === "/repos/onmax/repo/git/refs/heads/main" && method === "PATCH") {
         if (body?.sha) refSha = body.sha;
         return jsonResponse({});
@@ -284,6 +305,71 @@ describe("GitHub workspace store", () => {
     await expect(freshStore.getMeta!("loader")).resolves.toEqual({ digest: "abc" });
   });
 
+  it("creates a missing branch from the default branch before using non-forced updates", async () => {
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        branch: "mirror",
+        provider: "github",
+        repository: "onmax/repo",
+        root: ".vitehub/workspaces/<workspace>",
+        token: "token",
+      },
+      "docs",
+    );
+
+    await store.writeFile("tasks/first.md", { path: "tasks/first.md", content: "first\n" });
+    await store.snapshot({ name: "first publish" });
+
+    expect(requests.map(request => request.path)).toEqual(expect.arrayContaining([
+      "/repos/onmax/repo/git/ref/heads/mirror",
+      "/repos/onmax/repo",
+      "/repos/onmax/repo/git/ref/heads/main",
+    ]));
+    expect(
+      requests.find(request => request.path.endsWith("/git/trees") && request.method === "POST")
+        ?.body,
+    ).toMatchObject({ base_tree: "base-tree" });
+    expect(
+      requests.find(request => request.path.endsWith("/git/commits") && request.method === "POST")
+        ?.body,
+    ).toMatchObject({ parents: ["base-sha"] });
+    expect(
+      requests.find(request => request.path === "/repos/onmax/repo/git/refs" && request.method === "POST")
+        ?.body,
+    ).toEqual({ ref: "refs/heads/mirror", sha: "commit-sha-1" });
+    expect(requests.some(request => request.method === "PATCH")).toBe(false);
+
+    requests.length = 0;
+    await store.writeFile("tasks/second.md", { path: "tasks/second.md", content: "second\n" });
+    await store.snapshot({ name: "second publish" });
+
+    expect(
+      requests.find(request => request.path.endsWith("/git/refs/heads/mirror") && request.method === "PATCH")
+        ?.body,
+    ).toEqual({ force: false, sha: "commit-sha-2" });
+    expect(requests.some(request => request.path === "/repos/onmax/repo/git/refs" && request.method === "POST")).toBe(false);
+  });
+
+  it("does not treat non-404 branch failures as missing", async () => {
+    mirrorRefStatus = 403;
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        branch: "mirror",
+        provider: "github",
+        repository: "onmax/repo",
+        token: "token",
+      },
+      "docs",
+    );
+
+    await expect(store.list()).rejects.toThrow("403 Forbidden");
+    expect(requests.map(request => request.path)).toEqual([
+      "/repos/onmax/repo/git/ref/heads/mirror",
+    ]);
+  });
+
   it("decodes GitHub JSON blob responses when raw bytes are unavailable", async () => {
     const content = "fallback\n";
     const sha = textSha(content);
@@ -344,6 +430,7 @@ describe("GitHub workspace store", () => {
     const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
     const store = createGitHubWorkspaceStore(
       {
+        branch: "mirror",
         provider: "github",
         repository: "onmax/repo",
         root: ".vitehub/workspaces/<workspace>",


### PR DESCRIPTION
GitHub Workspace stores and publishers now treat only a configured-ref 404 as first-publication state, read the repository default branch for the parent commit and base tree, then create the configured ref after the commit exists. Existing branches keep their non-forced ref updates, while authorization, server, and missing-default-ref failures continue to surface.

Adds stateful mocked GitHub coverage for both paths: the first non-empty publish creates the branch, a subsequent publish updates it with `force: false`, and non-404 configured-ref failures never enter the fallback or write path. Empty and unchanged snapshots remain no-ops.