### PR TITLE
fix(workspace): reopen persisted Cloudflare Artifacts workspaces

### DIFF
--- a/packages/workspace/src/providers/cloudflare/artifacts-store.ts
+++ b/packages/workspace/src/providers/cloudflare/artifacts-store.ts
@@ -21,25 +21,28 @@ import type {
   WorkspaceStore,
 } from "../../core/types.ts"
 
-interface ArtifactsCreateTokenResult {
+interface DisposableRpcValue {
+  [Symbol.dispose]?: () => void
+}
+
+interface ArtifactsCreateTokenResult extends DisposableRpcValue {
   expiresAt: string
   plaintext: string
 }
 
-interface ArtifactsCreateRepoResult {
+interface ArtifactsRepoInfo extends DisposableRpcValue {
   defaultBranch: string
-  name: string
   remote: string
+}
+
+interface ArtifactsCreateRepoResult extends ArtifactsRepoInfo {
+  name: string
   token: string
 }
 
-interface ArtifactsRepo {
+interface ArtifactsRepo extends DisposableRpcValue {
   createToken(scope?: "read" | "write", ttl?: number): Promise<ArtifactsCreateTokenResult>
-  defaultBranch: string
-  lastPushAt: string | null
-  name: string
-  remote: string
-  source: string | null
+  info(): Promise<ArtifactsRepoInfo>
 }
 
 interface ArtifactsBinding {
@@ -60,6 +63,10 @@ function tokenSecret(token: string) {
 function tokenExpiresAt(token: string) {
   const expires = token.match(/[?&]expires=(\d+)(?:&|$)/)?.[1]
   return expires ? Number(expires) * 1000 : 0
+}
+
+function disposeRpc(value: DisposableRpcValue | undefined) {
+  value?.[Symbol.dispose]?.()
 }
 
 function encodeWorkspaceRepoName(workspaceName: string) {
@@ -106,7 +113,7 @@ class CloudflareArtifactsWorkspaceStore implements WorkspaceStore {
   #fs: MemoryFS | undefined
   #head: string | undefined
   #pendingCommit: string | undefined
-  #repo: ArtifactsRepo | undefined
+  #remote: string | undefined
   #ready: Promise<void> | undefined
   #mutationQueue: Promise<void> = Promise.resolve()
   #token: { expiresAt: number, value: string } | undefined
@@ -275,7 +282,7 @@ class CloudflareArtifactsWorkspaceStore implements WorkspaceStore {
           http,
           onAuth: () => ({ password: token, username: "x" }),
           ref: this.#branch,
-          url: this.#repo!.remote,
+          url: this.#remote!,
         })
       }
       catch (error) {
@@ -354,11 +361,19 @@ class CloudflareArtifactsWorkspaceStore implements WorkspaceStore {
     }
   }
 
-  async #writeToken(): Promise<string> {
+  async #writeToken(repo?: ArtifactsRepo): Promise<string> {
     if (this.#token && this.#token.expiresAt > Date.now() + tokenRefreshWindow) return this.#token.value
-    const token = await this.#repo!.createToken("write", 3600)
-    this.#rememberToken(token.plaintext, token.expiresAt)
-    return this.#token!.value
+    const tokenRepo = repo || await this.#getBinding().get(repoName(this.options, this.workspaceName))
+    let token: ArtifactsCreateTokenResult | undefined
+    try {
+      token = await tokenRepo.createToken("write", 3600)
+      this.#rememberToken(token.plaintext, token.expiresAt)
+      return this.#token!.value
+    }
+    finally {
+      disposeRpc(token)
+      if (!repo) disposeRpc(tokenRepo)
+    }
   }
 
   #getBinding(): ArtifactsBinding {
@@ -389,46 +404,68 @@ class CloudflareArtifactsWorkspaceStore implements WorkspaceStore {
     const binding = this.#getBinding()
     const name = repoName(this.options, this.workspaceName)
     let created: ArtifactsCreateRepoResult | undefined
-    let repo: ArtifactsRepo
+    let repo: ArtifactsRepo | undefined
+    let repoInfo: ArtifactsCreateRepoResult | ArtifactsRepoInfo | undefined
     try {
-      repo = await binding.get(name)
-    }
-    catch (error) {
-      if (!hasArtifactsErrorCode(error, "NOT_FOUND", 10200)) throw error
       try {
-        created = await binding.create(name, {
-          description: `ViteHub workspace ${this.workspaceName}`,
-          readOnly: false,
-          setDefaultBranch: this.options.branch || "main",
-        })
+        repo = await binding.get(name)
       }
-      catch (createError) {
-        if (!hasArtifactsErrorCode(createError, "ALREADY_EXISTS", 10201)) throw createError
+      catch (error) {
+        if (!hasArtifactsErrorCode(error, "NOT_FOUND", 10200)) throw error
+        try {
+          created = await binding.create(name, {
+            description: `ViteHub workspace ${this.workspaceName}`,
+            readOnly: false,
+            setDefaultBranch: this.options.branch || "main",
+          })
+        }
+        catch (createError) {
+          if (!hasArtifactsErrorCode(createError, "ALREADY_EXISTS", 10201)) throw createError
+        }
+        repo = await binding.get(name)
       }
-      repo = await binding.get(name)
-    }
 
-    this.#repo = repo
-    this.#branch = this.options.branch || repo.defaultBranch || "main"
-    if (created) this.#rememberToken(created.token)
-    this.#fs = new MemoryFS()
-    await this.#fs.promises.mkdir(dir, { recursive: true })
-    if (created || (repo.lastPushAt === null && repo.source === null)) {
-      await git.init({ defaultBranch: this.#branch, dir, fs: this.#fs as never })
+      repoInfo = created || await repo.info()
+      this.#remote = repoInfo.remote
+      this.#branch = this.options.branch || repoInfo.defaultBranch || "main"
+      if (created) this.#rememberToken(created.token)
+      this.#fs = new MemoryFS()
+      await this.#fs.promises.mkdir(dir, { recursive: true })
+      const token = await this.#writeToken(repo)
+      const branchRef = `refs/heads/${this.#branch}`
+      const hasBranch = (
+        await git.listServerRefs({
+          http,
+          onAuth: () => ({ password: token, username: "x" }),
+          prefix: branchRef,
+          url: this.#remote,
+        })
+      ).some(ref => ref.ref === branchRef)
+      if (!hasBranch) {
+        await git.init({ defaultBranch: this.#branch, dir, fs: this.#fs as never })
+      }
+      else {
+        await git.clone({
+          depth: 1,
+          dir,
+          fs: this.#fs as never,
+          http,
+          onAuth: () => ({ password: token, username: "x" }),
+          ref: this.#branch,
+          singleBranch: true,
+          url: this.#remote,
+        })
+        this.#head = await git.resolveRef({ dir, fs: this.#fs as never, ref: this.#branch })
+      }
     }
-    else {
-      const token = await this.#writeToken()
-      await git.clone({
-        depth: 1,
-        dir,
-        fs: this.#fs as never,
-        http,
-        onAuth: () => ({ password: token, username: "x" }),
-        ref: this.#branch,
-        singleBranch: true,
-        url: repo.remote,
-      })
-      this.#head = await git.resolveRef({ dir, fs: this.#fs as never, ref: this.#branch })
+    finally {
+      try {
+        disposeRpc(repoInfo)
+        if (created !== repoInfo) disposeRpc(created)
+      }
+      finally {
+        disposeRpc(repo)
+      }
     }
     await this.#loadFileMetadata()
     const baseline = await createSnapshotFromEntries(await this.#listEntries("", { recursive: true }))

--- a/packages/workspace/src/storage/memory-fs.ts
+++ b/packages/workspace/src/storage/memory-fs.ts
@@ -45,9 +45,11 @@ export class MemoryFS {
     lstat: this.lstat.bind(this),
     mkdir: this.mkdir.bind(this),
     readFile: this.readFile.bind(this),
+    readlink: this.readlink.bind(this),
     readdir: this.readdir.bind(this),
     rmdir: this.rmdir.bind(this),
     stat: this.stat.bind(this),
+    symlink: this.symlink.bind(this),
     unlink: this.unlink.bind(this),
     writeFile: this.writeFile.bind(this),
   }
@@ -135,6 +137,15 @@ export class MemoryFS {
     return this.stat(path)
   }
 
+  async readlink(path: string) {
+    this.#requireEntry(path)
+    throw memoryFsError("EINVAL", path)
+  }
+
+  async symlink(_target: string, path: string) {
+    throw memoryFsError("ENOTSUP", path)
+  }
+
   deleteTree(path: string) {
     const target = this.normalize(path)
     const removed = [...this.entries.keys()].filter(key => key === target || key.startsWith(`${target}/`))
@@ -150,7 +161,7 @@ export class MemoryFS {
 
   #requireEntry(path: string) {
     const entry = this.entries.get(this.normalize(path))
-    if (!entry) throw new Error(`ENOENT: ${path}`)
+    if (!entry) throw memoryFsError("ENOENT", path)
     return entry
   }
 
@@ -159,4 +170,8 @@ export class MemoryFS {
     if (entry.kind !== "dir") throw new Error(`ENOTDIR: ${path}`)
     return entry
   }
+}
+
+function memoryFsError(code: string, path: string) {
+  return Object.assign(new Error(`${code}: ${path}`), { code })
 }

--- a/packages/workspace/test/cloudflare-artifacts-store.test.ts
+++ b/packages/workspace/test/cloudflare-artifacts-store.test.ts
@@ -14,6 +14,7 @@ const gitMock = vi.hoisted(() => ({
   }),
   commit: vi.fn(async () => "commit-1"),
   init: vi.fn(async () => {}),
+  listServerRefs: vi.fn(async () => [] as Array<{ oid: string; ref: string }>),
   push: vi.fn(async (_options?: unknown) => ({ refs: { main: "commit-1" } })),
   remove: vi.fn(async () => {}),
   resolveRef: vi.fn(async () => "remote-sha"),
@@ -39,27 +40,58 @@ function legacyArtifactsError(code: number, message: string) {
   return Object.assign(new Error(message), { code })
 }
 
-function artifactsRepo(options: { defaultBranch?: string, lastPushAt?: string | null, source?: string | null, token?: string } = {}) {
-  return {
-    createToken: vi.fn(async () => ({
-      expiresAt: expiresIn(3_600_000),
-      plaintext: options.token || "art_v1_fresh?expires=999",
-    })),
-    defaultBranch: options.defaultBranch || "main",
-    lastPushAt: options.lastPushAt ?? null,
-    name: "vitehub-workspace-docs",
-    remote,
-    source: options.source ?? null,
-  }
+function disposable<T extends object>(value: T) {
+  const dispose = vi.fn()
+  return Object.assign(value, { [Symbol.dispose]: dispose, dispose })
 }
 
-function createdRepo(token = `art_v1_created?expires=${Math.floor((Date.now() + 3_600_000) / 1000)}`) {
-  return {
+function artifactsRepo(
+  options: {
+    defaultBranch?: string
+    infoError?: Error
+    lastPushAt?: string | null
+    source?: string | null
+    token?: string
+    tokenError?: Error
+    tokenExpiresIn?: number
+  } = {},
+) {
+  const infoResult = disposable({
+    defaultBranch: options.defaultBranch || "main",
+    remote,
+  })
+  const tokenResults: Array<
+    ReturnType<typeof disposable<{ expiresAt: string; plaintext: string }>>
+  > = []
+  const repo = disposable({
+    createToken: vi.fn(async () => {
+      if (options.tokenError) throw options.tokenError
+      const token = disposable({
+        expiresAt: expiresIn(options.tokenExpiresIn ?? 3_600_000),
+        plaintext: options.token || "art_v1_fresh?expires=999",
+      })
+      tokenResults.push(token)
+      return token
+    }),
+    info: vi.fn(async () => {
+      if (options.infoError) throw options.infoError
+      return infoResult
+    }),
+    lastPushAt: options.lastPushAt ?? null,
+    source: options.source ?? null,
+  })
+  return Object.assign(repo, { infoResult, tokenResults })
+}
+
+function createdRepo(
+  token = `art_v1_created?expires=${Math.floor((Date.now() + 3_600_000) / 1000)}`,
+) {
+  return disposable({
     defaultBranch: "main",
     name: "vitehub-workspace-docs",
     remote,
     token,
-  }
+  })
 }
 
 async function createStore(binding: unknown, options: { branch?: string } = {}) {
@@ -84,6 +116,7 @@ afterEach(() => {
   gitMock.clone.mockClear()
   gitMock.commit.mockClear()
   gitMock.init.mockClear()
+  gitMock.listServerRefs.mockClear()
   gitMock.push.mockClear()
   gitMock.remove.mockClear()
   gitMock.resolveRef.mockClear()
@@ -123,9 +156,11 @@ describe("Cloudflare Artifacts workspace store", () => {
 
   it("uses the Artifacts binding and commits snapshots", async () => {
     const repo = artifactsRepo()
+    const created = createdRepo()
     const binding = {
-      create: vi.fn(async () => createdRepo()),
-      get: vi.fn()
+      create: vi.fn(async () => created),
+      get: vi
+        .fn()
         .mockRejectedValueOnce(artifactsError("NOT_FOUND", 10200, "missing"))
         .mockResolvedValueOnce(repo),
     }
@@ -138,17 +173,24 @@ describe("Cloudflare Artifacts workspace store", () => {
     await store.writeFile("README.md", { path: "README.md", content: "changed" })
 
     expect(snapshot.id).toBe("commit-1")
-    expect(binding.create).toHaveBeenCalledWith("vitehub-workspace-docs", expect.objectContaining({
-      setDefaultBranch: "main",
-    }))
+    expect(binding.create).toHaveBeenCalledWith(
+      "vitehub-workspace-docs",
+      expect.objectContaining({
+        setDefaultBranch: "main",
+      }),
+    )
     expect(binding.get).toHaveBeenCalledTimes(2)
     expect(gitMock.clone).not.toHaveBeenCalled()
     expect(gitMock.init).toHaveBeenCalledOnce()
-    expect(gitMock.push).toHaveBeenCalledWith(expect.objectContaining({
-      ref: "main",
-      url: repo.remote,
-    }))
+    expect(gitMock.push).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ref: "main",
+        url: remote,
+      }),
+    )
     expect(repo.createToken).not.toHaveBeenCalled()
+    expect(created.dispose).toHaveBeenCalledOnce()
+    expect(repo.dispose).toHaveBeenCalledOnce()
     const pushOptions = gitMock.push.mock.calls[0]?.[0] as { onAuth(): { password: string } }
     expect(pushOptions.onAuth().password).toBe("art_v1_created")
     expect((await store.diff({ from: snapshot })).entries).toEqual([
@@ -364,8 +406,22 @@ describe("Cloudflare Artifacts workspace store", () => {
     expect(binding.create).not.toHaveBeenCalled()
   })
 
+  it("disposes the repository handle when reading its info fails", async () => {
+    const infoError = new Error("repository info unavailable")
+    const repo = artifactsRepo({ infoError })
+    const store = await createStore({
+      create: vi.fn(),
+      get: vi.fn(async () => repo),
+    })
+
+    await expect(store.readFile("README.md")).rejects.toBe(infoError)
+    expect(repo.dispose).toHaveBeenCalledOnce()
+    expect(repo.infoResult.dispose).not.toHaveBeenCalled()
+    expect(repo.createToken).not.toHaveBeenCalled()
+  })
+
   it("gets the repository created by a concurrent request", async () => {
-    const repo = artifactsRepo({ lastPushAt: "2026-07-11T00:00:00.000Z" })
+    const repo = artifactsRepo()
     const binding = {
       create: vi.fn(async () => {
         throw artifactsError("ALREADY_EXISTS", 10201, "already exists")
@@ -374,6 +430,7 @@ describe("Cloudflare Artifacts workspace store", () => {
         .mockRejectedValueOnce(artifactsError("NOT_FOUND", 10200, "missing"))
         .mockResolvedValueOnce(repo),
     }
+    gitMock.listServerRefs.mockResolvedValueOnce([{ oid: "remote-sha", ref: "refs/heads/main" }])
     gitMock.clone.mockResolvedValueOnce(undefined)
     const store = await createStore(binding)
 
@@ -383,7 +440,22 @@ describe("Cloudflare Artifacts workspace store", () => {
     expect(gitMock.init).not.toHaveBeenCalled()
   })
 
-  it("initializes known-empty repositories but propagates clone failures for non-empty repositories", async () => {
+  it("disposes a creation result when the repository cannot be loaded", async () => {
+    const created = createdRepo()
+    const lookupError = new Error("created repository is not ready")
+    const store = await createStore({
+      create: vi.fn(async () => created),
+      get: vi
+        .fn()
+        .mockRejectedValueOnce(artifactsError("NOT_FOUND", 10200, "missing"))
+        .mockRejectedValueOnce(lookupError),
+    })
+
+    await expect(store.readFile("README.md")).rejects.toBe(lookupError)
+    expect(created.dispose).toHaveBeenCalledOnce()
+  })
+
+  it("initializes repositories without a branch but propagates clone failures for existing branches", async () => {
     const empty = artifactsRepo()
     const emptyStore = await createStore({
       create: vi.fn(),
@@ -394,8 +466,9 @@ describe("Cloudflare Artifacts workspace store", () => {
     expect(gitMock.clone).not.toHaveBeenCalled()
     expect(gitMock.init).toHaveBeenCalledOnce()
 
-    const nonEmpty = artifactsRepo({ lastPushAt: "2026-07-11T00:00:00.000Z" })
+    const nonEmpty = artifactsRepo()
     const cloneError = new Error("clone authentication failed")
+    gitMock.listServerRefs.mockResolvedValueOnce([{ oid: "remote-sha", ref: "refs/heads/main" }])
     gitMock.clone.mockRejectedValueOnce(cloneError)
     const nonEmptyStore = await createStore({
       create: vi.fn(),
@@ -404,6 +477,24 @@ describe("Cloudflare Artifacts workspace store", () => {
 
     await expect(nonEmptyStore.readFile("README.md")).rejects.toBe(cloneError)
     expect(gitMock.init).toHaveBeenCalledOnce()
+    expect(nonEmpty.dispose).toHaveBeenCalledOnce()
+    expect(nonEmpty.infoResult.dispose).toHaveBeenCalledOnce()
+    expect(nonEmpty.tokenResults[0]?.dispose).toHaveBeenCalledOnce()
+  })
+
+  it("disposes repository RPC results when remote inspection fails", async () => {
+    const repo = artifactsRepo()
+    const inspectionError = new Error("remote inspection failed")
+    gitMock.listServerRefs.mockRejectedValueOnce(inspectionError)
+    const store = await createStore({
+      create: vi.fn(),
+      get: vi.fn(async () => repo),
+    })
+
+    await expect(store.readFile("README.md")).rejects.toBe(inspectionError)
+    expect(repo.dispose).toHaveBeenCalledOnce()
+    expect(repo.infoResult.dispose).toHaveBeenCalledOnce()
+    expect(repo.tokenResults[0]?.dispose).toHaveBeenCalledOnce()
   })
 
   it("renews a short-lived creation token through the repository handle before Git auth", async () => {
@@ -424,8 +515,52 @@ describe("Cloudflare Artifacts workspace store", () => {
     expect(pushOptions.onAuth().password).toBe("art_v1_renewed")
   })
 
+  it("reacquires and disposes a repository handle when its cached token expires", async () => {
+    const loadedRepo = artifactsRepo({ tokenExpiresIn: 30_000 })
+    const refreshRepo = artifactsRepo({ token: "art_v1_refreshed?expires=999" })
+    const binding = {
+      create: vi.fn(),
+      get: vi.fn().mockResolvedValueOnce(loadedRepo).mockResolvedValueOnce(refreshRepo),
+    }
+    const store = await createStore(binding)
+
+    await store.writeFile("README.md", { content: "hello", path: "README.md" })
+    await store.snapshot()
+
+    expect(binding.get).toHaveBeenCalledTimes(2)
+    expect(loadedRepo.dispose).toHaveBeenCalledOnce()
+    expect(loadedRepo.tokenResults[0]?.dispose).toHaveBeenCalledOnce()
+    expect(refreshRepo.dispose).toHaveBeenCalledOnce()
+    expect(refreshRepo.tokenResults[0]?.dispose).toHaveBeenCalledOnce()
+    const pushOptions = gitMock.push.mock.calls[0]?.[0] as { onAuth(): { password: string } }
+    expect(pushOptions.onAuth().password).toBe("art_v1_refreshed")
+  })
+
+  it("disposes a reacquired repository handle when token minting fails", async () => {
+    const loadedRepo = artifactsRepo({ tokenExpiresIn: 30_000 })
+    const tokenError = new Error("token minting failed")
+    const refreshRepo = artifactsRepo({ tokenError })
+    const binding = {
+      create: vi.fn(),
+      get: vi.fn().mockResolvedValueOnce(loadedRepo).mockResolvedValueOnce(refreshRepo),
+    }
+    const store = await createStore(binding)
+
+    await store.writeFile("README.md", { content: "hello", path: "README.md" })
+    await expect(store.snapshot()).rejects.toBe(tokenError)
+
+    expect(loadedRepo.dispose).toHaveBeenCalledOnce()
+    expect(loadedRepo.tokenResults[0]?.dispose).toHaveBeenCalledOnce()
+    expect(refreshRepo.dispose).toHaveBeenCalledOnce()
+    expect(refreshRepo.tokenResults).toEqual([])
+    expect(gitMock.push).not.toHaveBeenCalled()
+  })
+
   it("uses the loaded branch head and repository entries as the initial baseline", async () => {
-    const repo = artifactsRepo({ lastPushAt: "2026-07-11T00:00:00.000Z" })
+    const repo = artifactsRepo()
+    gitMock.listServerRefs.mockResolvedValueOnce([
+      { oid: "remote-commit", ref: "refs/heads/main" },
+    ])
     gitMock.resolveRef.mockResolvedValueOnce("remote-commit")
     gitMock.clone.mockImplementationOnce(async (options?: unknown) => {
       const { fs } = options as {
@@ -447,15 +582,18 @@ describe("Cloudflare Artifacts workspace store", () => {
   it("snapshots an existing repository to its default branch", async () => {
     const repo = artifactsRepo({
       defaultBranch: "trunk",
-      lastPushAt: "2026-07-11T00:00:00.000Z",
     })
+    gitMock.listServerRefs.mockResolvedValueOnce([{ oid: "remote-sha", ref: "refs/heads/trunk" }])
     gitMock.clone.mockResolvedValueOnce(undefined)
     const { resolveCloudflareArtifactsStore } = await import("../src/config.ts")
     const options = resolveCloudflareArtifactsStore({}, {})
-    const store = await createStore({
-      create: vi.fn(),
-      get: vi.fn(async () => repo),
-    }, options)
+    const store = await createStore(
+      {
+        create: vi.fn(),
+        get: vi.fn(async () => repo),
+      },
+      options,
+    )
 
     await store.writeFile("README.md", { content: "hello", path: "README.md" })
     await store.snapshot()
@@ -486,7 +624,7 @@ describe("Cloudflare Artifacts workspace store", () => {
     type FileEntry = { data: Uint8Array; kind: "file"; mtimeMs: number }
     let committed = new Map<string, FileEntry>()
     const emptyRepo = artifactsRepo()
-    const nonEmptyRepo = artifactsRepo({ lastPushAt: "2026-07-11T00:00:00.000Z" })
+    const nonEmptyRepo = artifactsRepo()
     const binding = {
       create: vi.fn(async () => createdRepo()),
       get: vi.fn()
@@ -494,6 +632,9 @@ describe("Cloudflare Artifacts workspace store", () => {
         .mockResolvedValueOnce(emptyRepo)
         .mockResolvedValueOnce(nonEmptyRepo),
     }
+    gitMock.listServerRefs
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ oid: "commit-1", ref: "refs/heads/main" }])
     gitMock.push.mockImplementationOnce(async (options?: unknown) => {
       const { fs } = options as { fs: { entries: Map<string, FileEntry | { kind: "dir" }> } }
       committed = new Map(
@@ -643,19 +784,54 @@ describe("Cloudflare Artifacts workspace store", () => {
     expect(gitMock.push).toHaveBeenCalledTimes(2)
   })
 
-  it("clones existing fork history that has not received a direct push", async () => {
+  it("reopens an existing branch before committing and pushing its next snapshot", async () => {
     const repo = artifactsRepo({
       lastPushAt: null,
-      source: "artifacts:namespace/base",
+      source: null,
     })
-    gitMock.clone.mockResolvedValueOnce(undefined)
+    let head: string | undefined
+    gitMock.listServerRefs.mockResolvedValueOnce([
+      { oid: "remote-commit", ref: "refs/heads/main" },
+    ])
+    gitMock.clone.mockImplementationOnce(async () => {
+      head = "remote-commit"
+    })
+    gitMock.resolveRef.mockImplementationOnce(async () => head || "")
+    gitMock.commit.mockImplementationOnce(async () => {
+      if (head !== "remote-commit") throw new Error("commit did not extend the remote head")
+      head = "next-commit"
+      return head
+    })
+    gitMock.push.mockImplementationOnce(async () => {
+      if (head !== "next-commit") throw new Error("push was not fast-forward")
+      return { refs: { main: head } }
+    })
     const store = await createStore({
       create: vi.fn(),
       get: vi.fn(async () => repo),
     })
 
-    await expect(store.readFile("README.md")).resolves.toBeUndefined()
+    await store.writeFile("README.md", { content: "next", path: "README.md" })
+    await expect(store.snapshot()).resolves.toMatchObject({ id: "next-commit" })
+    expect(gitMock.listServerRefs).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prefix: "refs/heads/main",
+        url: remote,
+      }),
+    )
     expect(gitMock.clone).toHaveBeenCalledOnce()
     expect(gitMock.init).not.toHaveBeenCalled()
+    expect(gitMock.clone.mock.invocationCallOrder[0]).toBeLessThan(
+      gitMock.commit.mock.invocationCallOrder[0]!,
+    )
+    expect(gitMock.commit.mock.invocationCallOrder[0]).toBeLessThan(
+      gitMock.push.mock.invocationCallOrder[0]!,
+    )
+    expect(gitMock.push).toHaveBeenCalledWith(
+      expect.objectContaining({ ref: "main", url: remote }),
+    )
+    expect(repo.dispose).toHaveBeenCalledOnce()
+    expect(repo.infoResult.dispose).toHaveBeenCalledOnce()
+    expect(repo.tokenResults[0]?.dispose).toHaveBeenCalledOnce()
   })
 })

--- a/packages/workspace/test/cloudflare-artifacts-store.test.ts
+++ b/packages/workspace/test/cloudflare-artifacts-store.test.ts
@@ -49,8 +49,6 @@ function artifactsRepo(
   options: {
     defaultBranch?: string
     infoError?: Error
-    lastPushAt?: string | null
-    source?: string | null
     token?: string
     tokenError?: Error
     tokenExpiresIn?: number
@@ -77,8 +75,6 @@ function artifactsRepo(
       if (options.infoError) throw options.infoError
       return infoResult
     }),
-    lastPushAt: options.lastPushAt ?? null,
-    source: options.source ?? null,
   })
   return Object.assign(repo, { infoResult, tokenResults })
 }
@@ -785,10 +781,7 @@ describe("Cloudflare Artifacts workspace store", () => {
   })
 
   it("reopens an existing branch before committing and pushing its next snapshot", async () => {
-    const repo = artifactsRepo({
-      lastPushAt: null,
-      source: null,
-    })
+    const repo = artifactsRepo()
     let head: string | undefined
     gitMock.listServerRefs.mockResolvedValueOnce([
       { oid: "remote-commit", ref: "refs/heads/main" },

--- a/packages/workspace/test/memory-fs.test.ts
+++ b/packages/workspace/test/memory-fs.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest"
+
+import { MemoryFS } from "../src/storage/memory-fs.ts"
+
+describe("Workspace MemoryFS", () => {
+  it("exposes Node-style clone errors and symlink methods", async () => {
+    const fs = new MemoryFS()
+
+    await expect(fs.promises.readFile("/missing")).rejects.toMatchObject({ code: "ENOENT" })
+    await fs.promises.writeFile("/file", "content")
+    await expect(fs.promises.readlink("/file")).rejects.toMatchObject({ code: "EINVAL" })
+    await expect(fs.promises.symlink("/target", "/link")).rejects.toMatchObject({
+      code: "ENOTSUP",
+    })
+  })
+})


### PR DESCRIPTION
Reopens Cloudflare Artifacts-backed Workspaces from the configured remote branch instead of inferring repository emptiness from Artifacts metadata. Existing branches are cloned before snapshots are committed and pushed, so persisted repositories keep fast-forward history.

The store now retains only plain remote and token data while releasing repository, info, and token RPC results on success and failure. MemoryFS also exposes the Node-style error codes and symlink methods isomorphic-git needs during clone.