### PR TITLE
fix(blob): isolate Nitro-owned Cloudflare provider output

### DIFF
--- a/packages/blob/src/internal/vite-build.ts
+++ b/packages/blob/src/internal/vite-build.ts
@@ -601,18 +601,30 @@ function registerSupportedProviderRuntimeModules(
   providerOutput: ComposedProviderOutput | undefined,
   artifacts: GeneratedBlobArtifacts,
   blob: BlobModuleOptions | ResolvedBlobModuleOptions | undefined,
+  cloudflareOwnedByNitro = false,
 ): void {
-  registerProviderRuntimeModules(providerOutput, productName, shouldCreateProviderOutput(blob) ? artifacts.runtimeModuleFiles : {})
-  registerVercelRuntimePackages(providerOutput, productName, shouldCreateProviderOutput(blob) ? getVercelBlobRuntimePackages(blob) : [])
+  const runtimeModuleFiles: Record<string, string> = shouldCreateProviderOutput(blob)
+    ? cloudflareOwnedByNitro
+      ? { cloudflare: artifacts.runtimeModuleFiles.cloudflare }
+      : artifacts.runtimeModuleFiles
+    : {}
+  registerProviderRuntimeModules(providerOutput, productName, runtimeModuleFiles)
+  if (cloudflareOwnedByNitro) {
+    if (providerOutput?.vercelRuntimePackagesByProduct) delete providerOutput.vercelRuntimePackagesByProduct[productName]
+  }
+  else {
+    registerVercelRuntimePackages(providerOutput, productName, shouldCreateProviderOutput(blob) ? getVercelBlobRuntimePackages(blob) : [])
+  }
 }
 
 export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedBlobArtifacts> {
   const artifacts = options.artifacts ?? await prepareProviderOutputs(options)
-  registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.blob)
+  registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.blob, options.cloudflareOwnedByNitro)
   const localOnly = !shouldCreateProviderOutput(options.blob)
   const createCloudflare = !localOnly && !options.cloudflareOwnedByNitro
   const createVercel = !localOnly && !options.cloudflareOwnedByNitro
-  const stageSharedVercelRuntime = (!options.serverFunctionName || options.serverFunctionName === "__server.func")
+  const stageSharedVercelRuntime = !options.cloudflareOwnedByNitro
+    && (!options.serverFunctionName || options.serverFunctionName === "__server.func")
     && hasSiblingVercelRuntime(options.providerOutput)
   const cleanupVercel = options.cloudflareOwnedByNitro ? getVercelBlobOutputCleanup(options) : undefined
   const hasCurrentCloudflareContribution = Boolean(createCloudflareR2Bindings(resolveBlobConfig(options.blob, "cloudflare"))?.length)
@@ -650,8 +662,8 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   return artifacts
 }
 
-export async function prepareProviderOutputs(options: Pick<GenerateProviderOutputsOptions, "blob" | "providerOutput" | "rootDir">): Promise<GeneratedBlobArtifacts> {
+export async function prepareProviderOutputs(options: Pick<GenerateProviderOutputsOptions, "blob" | "cloudflareOwnedByNitro" | "providerOutput" | "rootDir">): Promise<GeneratedBlobArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.blob)
-  registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.blob)
+  registerSupportedProviderRuntimeModules(options.providerOutput, artifacts, options.blob, options.cloudflareOwnedByNitro)
   return artifacts
 }

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -300,6 +300,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
 
       providerArtifacts = await prepareProviderOutputs({
         blob,
+        cloudflareOwnedByNitro,
         providerOutput,
         rootDir,
       })

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -390,7 +390,55 @@ describe("Vite provider outputs", () => {
     await expect(readFile(functionFile, "utf8")).resolves.toBe("// shared server\n")
   })
 
-  it("copies Blob dependencies for sibling Vercel output during Cloudflare builds", { timeout: 30_000 }, async () => {
+  it("does not register Blob Vercel runtime or packages when Nitro owns Cloudflare output", async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-nitro-cloudflare-registry-")
+    const providerOutput: ComposedProviderOutput = {
+      runtimeModuleFilesByProduct: { database: { vercel: "database-runtime.mjs" } },
+      vercelRuntimePackagesByProduct: { blob: [{ name: "stale-package", resolveFrom: rootDir }] },
+    }
+    const blob = { bucketName: "assets", driver: "cloudflare-r2" as const }
+
+    const artifacts = await prepareProviderOutputs({
+      blob,
+      cloudflareOwnedByNitro: true,
+      providerOutput,
+      rootDir,
+    })
+    expect(providerOutput.vercelRuntimePackagesByProduct?.blob).toBeUndefined()
+    expect(getProviderRuntimeModule(providerOutput, "blob", "cloudflare")).toBeDefined()
+    expect(getProviderRuntimeModule(providerOutput, "blob", "vercel")).toBeUndefined()
+    expect(getProviderRuntimeModule(providerOutput, "database", "vercel")).toBe("database-runtime.mjs")
+
+    await generateProviderOutputs({
+      artifacts,
+      blob,
+      clientOutDir: "dist",
+      cloudflareOwnedByNitro: true,
+      providerOutput,
+      rootDir,
+    })
+    expect(providerOutput.vercelRuntimePackagesByProduct?.blob).toBeUndefined()
+  })
+
+  it("does not copy Blob dependencies when Nitro owns Cloudflare output", { timeout: 30_000 }, async () => {
+    const rootDir = await createWorkspaceTempDir("vitehub-blob-nitro-cloudflare-packages-")
+    const functionDir = join(rootDir, ".vercel/output/functions/__server.func")
+    await mkdir(functionDir, { recursive: true })
+    await writeFile(join(functionDir, "index.mjs"), "export default 'sibling'\n", "utf8")
+
+    await generateProviderOutputs({
+      blob: { bucketName: "assets", driver: "cloudflare-r2" },
+      clientOutDir: "dist",
+      cloudflareOwnedByNitro: true,
+      providerOutput: { runtimeModuleFilesByProduct: { database: { vercel: "database-runtime.mjs" } } },
+      rootDir,
+    })
+
+    expect(existsSync(join(functionDir, "node_modules/files-sdk"))).toBe(false)
+    expect(existsSync(join(functionDir, "node_modules/@aws-sdk/client-s3"))).toBe(false)
+  })
+
+  it("copies Blob dependencies for sibling Vercel output", { timeout: 30_000 }, async () => {
     const rootDir = await createWorkspaceTempDir("vitehub-blob-shared-vercel-runtime-")
     const functionDir = join(rootDir, ".vercel/output/functions/__server.func")
     const siblingEntry = join(rootDir, "sibling.mjs")
@@ -399,7 +447,6 @@ describe("Vite provider outputs", () => {
     await generateProviderOutputs({
       blob: { bucketName: "assets", driver: "cloudflare-r2" },
       clientOutDir: "dist",
-      cloudflareOwnedByNitro: true,
       providerOutput: { runtimeModuleFilesByProduct: { database: { vercel: "database-runtime.mjs" } } },
       rootDir,
     })


### PR DESCRIPTION
When Nitro owns Cloudflare deployment output, Blob now keeps registering its Cloudflare runtime modules and bindings but skips Blob-owned Vercel package registration and shared function staging during both provider preparation and final generation. Ordinary Vercel and Nitro/Vercel output keep their existing runtime propagation, and ownership-aware cleanup from #767 remains unchanged.

The regression replaces #767's mixed-target Cloudflare staging case with explicit negative coverage for registry and copied package artifacts while retaining positive sibling Vercel staging. Before the fix, preparation registered `files-sdk` plus four AWS SDK packages and generation copied them into `__server.func/node_modules`; after it, the Blob registry entry and copied packages are absent.