### PR TITLE
fix(deploy): prune incompatible Deno native packages

### DIFF
--- a/packages/internal/src/build/deno-runtime-packages.ts
+++ b/packages/internal/src/build/deno-runtime-packages.ts
@@ -200,7 +200,7 @@ async function copyPackageToNodeModules(name: string, resolver: NodeJS.Require, 
       ? outputNodeModules
       : join(targetDir, "node_modules")
     await copyPackageToNodeModules(dependencyName, packageRequire, packageDir, dependencyNodeModules, copied, staged, {
-      hoistOptionalDependencies: options.hoistOptionalDependencies,
+      hoistOptionalDependencies: options.hoistOptionalDependencies && Boolean(packageJson.optionalDependencies?.[dependencyName]),
       includeOptionalDependencies: options.includeOptionalDependencies,
       includePeerDependencies: options.includePeerDependencies,
       name: dependencyName,

--- a/packages/internal/src/build/deno-runtime-packages.ts
+++ b/packages/internal/src/build/deno-runtime-packages.ts
@@ -8,6 +8,10 @@ const builtinModuleNames = new Set([
   ...builtinModules.map((name) => `node:${name}`),
 ])
 const runtimeExtensions = new Set([".cjs", ".js", ".mjs", ".ts"])
+const denoRuntimeTargets = [
+  { cpu: "arm64", libc: "glibc", os: "linux" },
+  { cpu: "x64", libc: "glibc", os: "linux" },
+] as const
 
 interface FinalizeDenoDeploymentOutputOptions {
   outputDir?: string
@@ -122,15 +126,26 @@ interface RuntimePackage {
   packageJsonPath?: string
 }
 
+interface RuntimePackageJson {
+  cpu?: string[]
+  dependencies?: Record<string, string>
+  libc?: string[]
+  optionalDependencies?: Record<string, string>
+  os?: string[]
+  peerDependencies?: Record<string, string>
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>
+}
+
 async function copyRuntimePackagesToNodeModules(options: { outputNodeModules: string, packages: RuntimePackage[], rootDir: string }): Promise<void> {
   const copied = new Set<string>()
+  const staged = new Set<string>()
   const resolver = createRequire(join(options.rootDir, "package.json"))
   for (const runtimePackage of options.packages) {
-    await copyPackageToNodeModules(runtimePackage.name, resolver, options.rootDir, options.outputNodeModules, copied, runtimePackage)
+    await copyPackageToNodeModules(runtimePackage.name, resolver, options.rootDir, options.outputNodeModules, copied, staged, runtimePackage)
   }
 }
 
-async function copyPackageToNodeModules(name: string, resolver: NodeJS.Require, fromDir: string, outputNodeModules: string, copied: Set<string>, options: RuntimePackage): Promise<void> {
+async function copyPackageToNodeModules(name: string, resolver: NodeJS.Require, fromDir: string, outputNodeModules: string, copied: Set<string>, staged: Set<string>, options: RuntimePackage): Promise<void> {
   let packageJsonPath = options.packageJsonPath
   if (packageJsonPath) {
     try {
@@ -147,27 +162,33 @@ async function copyPackageToNodeModules(name: string, resolver: NodeJS.Require, 
   }
   const resolvedPackageJsonPath = await realpath(packageJsonPath)
   const packageDir = dirname(resolvedPackageJsonPath)
-  const packageJson = JSON.parse(await readFile(resolvedPackageJsonPath, "utf8")) as {
-    dependencies?: Record<string, string>
-    optionalDependencies?: Record<string, string>
-    peerDependencies?: Record<string, string>
-    peerDependenciesMeta?: Record<string, { optional?: boolean }>
-  }
+  const packageJson = JSON.parse(await readFile(resolvedPackageJsonPath, "utf8")) as RuntimePackageJson
   if (options.onlyIfOptionalDependencies && !Object.keys(packageJson.optionalDependencies || {}).length) return
   const packageKey = name + "\0" + resolvedPackageJsonPath
   if (copied.has(packageKey)) return
-  copied.add(packageKey)
   const targetDir = join(outputNodeModules, ...name.split("/"))
+  const stagedKey = packageKey + "\0" + targetDir
+  if (staged.has(stagedKey)) return
+  copied.add(packageKey)
   await rm(targetDir, { force: true, recursive: true })
   await cp(packageDir, targetDir, {
     dereference: true,
     filter: source => relative(packageDir, source).split(sep)[0] !== "node_modules",
     recursive: true,
   })
+  staged.add(stagedKey)
   const packageRequire = createRequire(resolvedPackageJsonPath)
-  const dependencyNames = new Set(Object.keys(packageJson.dependencies || {}))
+  const optionalDependencyNames = new Set(Object.keys(packageJson.optionalDependencies || {}))
+  const dependencyNames = new Set(
+    Object.keys(packageJson.dependencies || {}).filter(dependencyName => !optionalDependencyNames.has(dependencyName)),
+  )
   if (options.includeOptionalDependencies) {
-    for (const dependencyName of Object.keys(packageJson.optionalDependencies || {})) dependencyNames.add(dependencyName)
+    for (const dependencyName of Object.keys(packageJson.optionalDependencies || {})) {
+      const dependencyPackageJsonPath = await resolvePackageJson(dependencyName, packageRequire, packageDir)
+      if (!dependencyPackageJsonPath) continue
+      const dependencyPackageJson = JSON.parse(await readFile(dependencyPackageJsonPath, "utf8")) as RuntimePackageJson
+      if (supportsDenoRuntime(dependencyPackageJson)) dependencyNames.add(dependencyName)
+    }
   }
   if (options.includePeerDependencies) {
     for (const dependencyName of Object.keys(packageJson.peerDependencies || {})) {
@@ -178,7 +199,8 @@ async function copyPackageToNodeModules(name: string, resolver: NodeJS.Require, 
     const dependencyNodeModules = options.hoistOptionalDependencies && packageJson.optionalDependencies?.[dependencyName]
       ? outputNodeModules
       : join(targetDir, "node_modules")
-    await copyPackageToNodeModules(dependencyName, packageRequire, packageDir, dependencyNodeModules, copied, {
+    await copyPackageToNodeModules(dependencyName, packageRequire, packageDir, dependencyNodeModules, copied, staged, {
+      hoistOptionalDependencies: options.hoistOptionalDependencies,
       includeOptionalDependencies: options.includeOptionalDependencies,
       includePeerDependencies: options.includePeerDependencies,
       name: dependencyName,
@@ -186,6 +208,22 @@ async function copyPackageToNodeModules(name: string, resolver: NodeJS.Require, 
     })
   }
   copied.delete(packageKey)
+}
+
+function supportsDenoRuntime(packageJson: RuntimePackageJson): boolean {
+  return denoRuntimeTargets.some(target =>
+    supportsConstraint(packageJson.os, target.os)
+    && supportsConstraint(packageJson.cpu, target.cpu)
+    && supportsConstraint(packageJson.libc, target.libc),
+  )
+}
+
+function supportsConstraint(values: string[] | undefined, target: string): boolean {
+  if (!values?.length) return true
+  if (values.length === 1 && values[0] === "any") return true
+  if (values.includes(`!${target}`)) return false
+  const included = values.filter(value => !value.startsWith("!"))
+  return included.length === 0 || included.includes(target)
 }
 
 async function resolvePackageJson(name: string, resolver: NodeJS.Require, fromDir: string): Promise<string | undefined> {

--- a/packages/internal/test/deno-runtime-packages.test.ts
+++ b/packages/internal/test/deno-runtime-packages.test.ts
@@ -64,6 +64,7 @@ import "real"
     await writeRuntimePackage(root, "runtime-root", {
       dependencies: {
         "native-duplicate-darwin": "9.9.9",
+        "regular-parent": "9.9.9",
       },
       optionalDependencies: {
         "native-any": "9.9.9",
@@ -82,6 +83,8 @@ import "real"
       },
     })
     await writeRuntimePackage(root, "required-darwin", { cpu: ["x64"], os: ["darwin"] })
+    await writeRuntimePackage(root, "regular-parent", { optionalDependencies: { "regular-native": "9.9.9" } })
+    await writeRuntimePackage(root, "regular-native", { cpu: ["x64"], os: ["linux"] })
     await writeRuntimePackage(root, "native-any", { os: ["any"] })
     await writeRuntimePackage(root, "native-duplicate-darwin", { cpu: ["x64"], os: ["darwin"] })
     await writeRuntimePackage(root, "native-lib-linux-arm64", { cpu: ["arm64"], libc: ["glibc"], os: ["linux"] })
@@ -138,6 +141,8 @@ import "real"
     ]) expect(existsSync(join(outputNodeModules, name, "package.json"))).toBe(false)
     expect(existsSync(join(outputNodeModules, "native-linux-x64/node_modules/native-lib-linux-x64"))).toBe(false)
     expect(existsSync(join(outputNodeModules, "native-linux-arm64/node_modules/native-lib-linux-arm64"))).toBe(false)
+    expect(existsSync(join(outputNodeModules, "runtime-root/node_modules/regular-parent/node_modules/regular-native/package.json"))).toBe(true)
+    expect(existsSync(join(outputNodeModules, "runtime-root/node_modules/regular-native"))).toBe(false)
   })
 
   it("stages reachable packages and their installed optional native dependencies", async () => {

--- a/packages/internal/test/deno-runtime-packages.test.ts
+++ b/packages/internal/test/deno-runtime-packages.test.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs"
 import { execFile as execFileCallback } from "node:child_process"
-import { chmod, mkdir, mkdtemp, readFile, realpath, rm, symlink, writeFile } from "node:fs/promises"
+import { chmod, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat, symlink, writeFile } from "node:fs/promises"
 import { createRequire } from "node:module"
 import { tmpdir } from "node:os"
 import { delimiter, dirname, join, relative, resolve } from "node:path"
@@ -18,6 +18,21 @@ const execFile = promisify(execFileCallback)
 async function writeJson(file: string, value: unknown): Promise<void> {
   await mkdir(dirname(file), { recursive: true })
   await writeFile(file, JSON.stringify(value), "utf8")
+}
+
+async function writeRuntimePackage(root: string, name: string, packageJson: Record<string, unknown> = {}): Promise<void> {
+  const packageDir = join(root, "node_modules", ...name.split("/"))
+  await writeJson(join(packageDir, "package.json"), { name, version: "9.9.9", ...packageJson })
+  await writeFile(join(packageDir, "marker"), name, "utf8")
+}
+
+async function directorySize(directory: string): Promise<number> {
+  let size = 0
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const path = join(directory, entry.name)
+    size += entry.isDirectory() ? await directorySize(path) : (await stat(path)).size
+  }
+  return size
 }
 
 describe("Deno deployment output", () => {
@@ -40,6 +55,89 @@ const importText = \`import("missing-import")\`
 doThing() // import("missing-comment")
 import "real"
 `)).toEqual(["real"])
+  })
+
+  it("filters optional packages for Deno runtimes and hoists the selected closure once", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-deno-platforms-"))
+    const outputNodeModules = join(root, ".output/node_modules")
+    await writeJson(join(root, "package.json"), {})
+    await writeRuntimePackage(root, "runtime-root", {
+      dependencies: {
+        "native-duplicate-darwin": "9.9.9",
+      },
+      optionalDependencies: {
+        "native-any": "9.9.9",
+        "native-darwin-x64": "9.9.9",
+        "native-duplicate-darwin": "9.9.9",
+        "native-lib-linux-arm64": "9.9.9",
+        "native-lib-linux-x64": "9.9.9",
+        "native-lib-linuxmusl-x64": "9.9.9",
+        "native-linux-arm": "9.9.9",
+        "native-linux-arm64": "9.9.9",
+        "native-linux-x64": "9.9.9",
+        "native-linuxmusl-x64": "9.9.9",
+        "native-not-darwin": "9.9.9",
+        "native-wasm32": "9.9.9",
+        "native-win32-x64": "9.9.9",
+      },
+    })
+    await writeRuntimePackage(root, "required-darwin", { cpu: ["x64"], os: ["darwin"] })
+    await writeRuntimePackage(root, "native-any", { os: ["any"] })
+    await writeRuntimePackage(root, "native-duplicate-darwin", { cpu: ["x64"], os: ["darwin"] })
+    await writeRuntimePackage(root, "native-lib-linux-arm64", { cpu: ["arm64"], libc: ["glibc"], os: ["linux"] })
+    await writeRuntimePackage(root, "native-lib-linux-x64", { cpu: ["x64"], libc: ["glibc"], os: ["linux"] })
+    await writeRuntimePackage(root, "native-lib-linuxmusl-x64", { cpu: ["x64"], libc: ["musl"], os: ["linux"] })
+    await writeRuntimePackage(root, "native-linux-arm64", {
+      cpu: ["arm64"],
+      libc: ["glibc"],
+      optionalDependencies: { "native-lib-linux-arm64": "9.9.9" },
+      os: ["linux"],
+    })
+    await writeRuntimePackage(root, "native-linux-x64", {
+      cpu: ["x64"],
+      libc: ["glibc"],
+      optionalDependencies: { "native-lib-linux-x64": "9.9.9" },
+      os: ["linux"],
+    })
+    await writeRuntimePackage(root, "native-linuxmusl-x64", {
+      cpu: ["x64"],
+      libc: ["musl"],
+      optionalDependencies: { "native-lib-linuxmusl-x64": "9.9.9" },
+      os: ["linux"],
+    })
+    await writeRuntimePackage(root, "native-darwin-x64", { cpu: ["x64"], os: ["darwin"] })
+    await writeRuntimePackage(root, "native-linux-arm", { cpu: ["arm"], os: ["linux"] })
+    await writeRuntimePackage(root, "native-not-darwin", { os: ["!darwin"] })
+    await writeRuntimePackage(root, "native-wasm32", { cpu: ["wasm32"] })
+    await writeRuntimePackage(root, "native-win32-x64", { cpu: ["x64"], os: ["win32"] })
+    await mkdir(join(root, ".output/server"), { recursive: true })
+    await writeFile(
+      join(root, ".output/server/index.mjs"),
+      '//#region node_modules/runtime-root/index.js\nimport "required-darwin"\n',
+    )
+
+    await finalizeDenoDeploymentOutput({ rootDir: root })
+
+    for (const name of [
+      "native-any",
+      "native-lib-linux-arm64",
+      "native-lib-linux-x64",
+      "native-linux-arm64",
+      "native-linux-x64",
+      "native-not-darwin",
+      "required-darwin",
+    ]) expect(existsSync(join(outputNodeModules, name, "package.json"))).toBe(true)
+    for (const name of [
+      "native-darwin-x64",
+      "native-duplicate-darwin",
+      "native-lib-linuxmusl-x64",
+      "native-linux-arm",
+      "native-linuxmusl-x64",
+      "native-wasm32",
+      "native-win32-x64",
+    ]) expect(existsSync(join(outputNodeModules, name, "package.json"))).toBe(false)
+    expect(existsSync(join(outputNodeModules, "native-linux-x64/node_modules/native-lib-linux-x64"))).toBe(false)
+    expect(existsSync(join(outputNodeModules, "native-linux-arm64/node_modules/native-lib-linux-arm64"))).toBe(false)
   })
 
   it("stages reachable packages and their installed optional native dependencies", async () => {
@@ -290,6 +388,8 @@ if (png[0] !== 0x89 || png[1] !== 0x50 || png[2] !== 0x4e || png[3] !== 0x47) th
 process.exit(0)
 `, "utf8")
       await finalizeDenoDeploymentOutput({ outputDir: output, rootDir: workspaceRoot })
+      expect(await directorySize(join(output, "node_modules"))).toBeLessThan(64 * 1024 * 1024)
+      expect(existsSync(join(output, "node_modules/@img/sharp-linux-x64/node_modules/@img/sharp-libvips-linux-x64"))).toBe(false)
 
       if (process.platform === "linux" && process.arch === "x64") {
         expect(existsSync(join(output, "node_modules/@img/sharp-linux-x64/lib/sharp-linux-x64.node"))).toBe(true)


### PR DESCRIPTION
Deno deployment output currently copies every installed optional native package and can recursively duplicate selected native closures. A Drop consumer with multiple supported architectures produced a 383 MB artifact that failed during Deno Deploy artifact preparation. An intermediate Linux build still retained both GNU and musl variants at 71 MB; hosted revision `mz5dpst907gm` uploaded successfully but failed during artifact preparation before user code ran.

Filter only optional package edges with npm-compatible os, cpu, and libc metadata for Deno Deploy's documented Linux x64/ARM64 GNU runtimes, hoist each selected native closure once, and preserve directly imported or required dependencies. The resulting exact Drop artifact is 36.8 MB, hosted revision `zjr47ymhm5eq` deployed successfully, and its full upload/optimization/stats E2E passed. The regression covers platform metadata semantics, generated artifact size and layout, and a real Deno Sharp transform.

Observed while validating vite-hub/drop#1.