### PR TITLE
fix(sandbox): compile package TypeScript entrypoints

### DIFF
--- a/docs/content/docs/reference/file-conventions.md
+++ b/docs/content/docs/reference/file-conventions.md
@@ -29,7 +29,7 @@ Rate Limit deliberately has no file convention. Call `requireRateLimit(event, id
 
 Most discovered Definition files default-export the package-owned Definition Boundary Helper. This keeps Build-Extracted Definition Options limited to the direct discovered default export.
 
-Canonical Sandbox package projects are the exception: `server/sandboxes/<path>/index.ts` runs as top-level ESM and default-exports its result. The folder supplies the Definition identity, and optional static wall-clock policy comes from the adjacent `package.json` under `vitehub.sandbox.timeout`. Free-form `<path>.sandbox.ts` files still default-export `defineSandbox(...)`.
+Canonical Sandbox package projects are the exception: `server/sandboxes/<path>/index.ts` runs as top-level ESM and default-exports its result. The adjacent `package.json` must set `"type": "module"`. Local TypeScript uses explicit relative ESM imports, while bare dependencies must expose runtime-ready JavaScript; CommonJS source and package-local import aliases are not compiled. The folder supplies the Definition identity, and optional static wall-clock policy comes from `vitehub.sandbox.timeout`. Free-form `<path>.sandbox.ts` files still default-export `defineSandbox(...)`.
 
 ```ts [server/queues/welcome-email.ts]
 import { defineQueue } from '@vite-hub/queue'

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -35,6 +35,8 @@ ViteHub passes `{ payload, context }` through `process.argv[2]`, awaits the modu
 
 ViteHub uses the manifest's `packageManager`, then a lockfile at that package root, then npm. A matching `pnpm-workspace.yaml` selects pnpm, moves preparation to the pnpm workspace root, and carries the transitive `workspace:*` dependency closure into the Box while the entrypoint still runs from its package directory.
 
+Package entrypoints are ESM projects. Keep `"type": "module"`, use explicit relative ESM imports for local `.ts` and `.mts` source, and depend on packages that expose runtime-ready JavaScript. ViteHub compiles the reachable local TypeScript graph without bundling package dependencies or moving relative assets. It rejects CommonJS/CTS, package import aliases and self-references for local source, imports that escape the selected package, and workspace dependencies that expose TypeScript runtime entries.
+
 Use `<path>.sandbox.ts` with `defineSandbox()` for free-form Definitions outside `server/sandboxes`.
 
 ```ts

--- a/packages/sandbox/src/bundle.ts
+++ b/packages/sandbox/src/bundle.ts
@@ -1,42 +1,11 @@
 import { createHash } from 'node:crypto'
 import { basename } from 'pathe'
-import { dirname, join, normalize } from 'node:path/posix'
+import { prepareExecutablePackageProject } from './internal/package-entry'
 import { bundleDiscoveredDefinitionModuleGraph } from './internal/shared/discovered-definition'
-import { findRuntimeRelativeModuleSpecifiers } from './internal/shared/discovered-definition/ast'
 import type { SandboxDefinitionBundle } from './module-types'
 import type { SandboxProject } from './project'
 
 const SHIM_NAMESPACE = 'vitehub-sandbox-runtime-shim'
-
-function validatePackageModuleSpecifiers(project: SandboxProject, entry: string) {
-  const pending = [entry]
-  const visited = new Set<string>()
-  while (pending.length) {
-    const path = pending.shift()!
-    if (visited.has(path))
-      continue
-    visited.add(path)
-    const file = project.files[path]
-    if (!file)
-      throw new Error(`[vitehub] Sandbox package entry is missing from project files: ${entry}`)
-    const source = Buffer.from(file.contents, file.encoding).toString()
-    for (const specifier of findRuntimeRelativeModuleSpecifiers(source, path)) {
-      const target = normalize(join(dirname(path), specifier.replace(/[?#].*$/, '')))
-      if (!Object.hasOwn(project.files, target)) {
-        throw new Error(
-          `[vitehub] Sandbox package module "${path}" imports "${specifier}", which is not an executable package file. Use an explicit extension that resolves to a package file.`,
-        )
-      }
-      if (/\.[cm]?[jt]sx$/.test(target)) {
-        throw new Error(
-          `[vitehub] Sandbox package module "${path}" imports "${specifier}", but Node cannot execute JSX package files directly. Use a JavaScript or type-strippable TypeScript module.`,
-        )
-      }
-      if (/\.(?:c|m)?[jt]sx?$/.test(target) && !/\.d\.(?:c|m)?tsx?$/.test(target))
-        pending.push(target)
-    }
-  }
-}
 
 export async function bundleSandboxDefinition(
   source: string,
@@ -50,12 +19,12 @@ export async function bundleSandboxDefinition(
   if (options.execution === 'module' && options.project) {
     const prefix = options.project.packagePath === '.' ? '' : `${options.project.packagePath}/`
     const entry = `${prefix}${basename(file)}`
-    validatePackageModuleSpecifiers(options.project, entry)
+    const executable = prepareExecutablePackageProject(options.project, entry)
     return {
-      entry,
+      entry: executable.entry,
       execution: 'module',
       modules: {},
-      project: options.project,
+      project: executable.project,
     }
   }
 

--- a/packages/sandbox/src/internal/package-entry.ts
+++ b/packages/sandbox/src/internal/package-entry.ts
@@ -1,0 +1,430 @@
+import { createHash } from 'node:crypto'
+import { createRequire } from 'node:module'
+import { dirname, join, normalize } from 'node:path/posix'
+import {
+  findCommonJSModuleSpecifiers,
+  findRuntimeModuleSpecifiers,
+  hasNonLiteralDynamicImport,
+  rewriteRuntimeRelativeModuleSpecifiers,
+} from './shared/discovered-definition/ast'
+import { isWorkspacePackage, parsePnpmWorkspacePackages } from '../project'
+import type { SandboxProject } from '../project'
+import type ts from 'typescript'
+
+const require = createRequire(import.meta.url)
+const typescript = require('typescript') as typeof import('typescript')
+const runtimeExportConditions = new Set(['default', 'import', 'node', 'node-addons'])
+
+type PackageRuntimeManifest = {
+  dependencies?: Record<string, string>
+  devDependencies?: Record<string, string>
+  exports?: unknown
+  main?: unknown
+  name?: unknown
+  optionalDependencies?: Record<string, string>
+  peerDependencies?: Record<string, string>
+  type?: unknown
+}
+
+function isExecutableTypeScriptModule(path: string) {
+  return /\.(?:ts|mts)$/.test(path) && !/\.d\.(?:ts|mts)$/.test(path)
+}
+
+function executablePackageModulePath(path: string) {
+  const suffixIndex = path.search(/[?#]/)
+  const modulePath = suffixIndex === -1 ? path : path.slice(0, suffixIndex)
+  const suffix = suffixIndex === -1 ? '' : path.slice(suffixIndex)
+  return isExecutableTypeScriptModule(modulePath) ? `${modulePath}.mjs${suffix}` : path
+}
+
+function projectFileSource(project: SandboxProject, path: string) {
+  const file = project.files[path]
+  if (!file) throw new Error(`[vitehub] Sandbox package project is missing required file: ${path}`)
+  return Buffer.from(file.contents, file.encoding).toString()
+}
+
+function parseRuntimeManifest(project: SandboxProject, path: string) {
+  try {
+    return JSON.parse(projectFileSource(project, path)) as PackageRuntimeManifest
+  } catch (error) {
+    throw new Error(`[vitehub] Sandbox package manifest is invalid JSON: ${path}`, {
+      cause: error,
+    })
+  }
+}
+
+function selectedPackageManifest(project: SandboxProject) {
+  const path = project.packagePath === '.' ? 'package.json' : `${project.packagePath}/package.json`
+  const manifest = parseRuntimeManifest(project, path)
+  if (manifest.type !== 'module') {
+    throw new Error(
+      `[vitehub] Sandbox package manifest "${path}" must set "type" to "module". Canonical Sandbox package entrypoints are ESM.`,
+    )
+  }
+  return manifest
+}
+
+function runtimeWorkspaceDependencyNames(manifest: PackageRuntimeManifest) {
+  const sections = [manifest.dependencies, manifest.optionalDependencies, manifest.peerDependencies]
+  return [
+    ...new Set(
+      sections
+        .flatMap((section) => Object.entries(section || {}))
+        .filter(([, specifier]) => specifier.startsWith('workspace:'))
+        .map(([name]) => name),
+    ),
+  ]
+}
+
+function runtimeExportTargets(value: unknown, patternMatch?: string): string[] {
+  if (typeof value === 'string')
+    return [patternMatch === undefined ? value : value.replaceAll('*', patternMatch)]
+  if (Array.isArray(value)) {
+    for (const target of value) {
+      const targets = runtimeExportTargets(target, patternMatch)
+      if (targets.length) return targets
+    }
+    return []
+  }
+  if (!value || typeof value !== 'object') return []
+  for (const [condition, target] of Object.entries(value)) {
+    if (runtimeExportConditions.has(condition)) {
+      const targets = runtimeExportTargets(target, patternMatch)
+      if (targets.length) return targets
+    }
+  }
+  return []
+}
+
+function runtimeTargetsForPackageSpecifier(
+  manifest: PackageRuntimeManifest,
+  packageName: string,
+  specifier: string,
+) {
+  if (manifest.exports !== undefined) {
+    let selected: unknown = manifest.exports
+    let patternMatch: string | undefined
+    if (selected && typeof selected === 'object' && !Array.isArray(selected)) {
+      const entries = selected as Record<string, unknown>
+      const hasSubpaths = Object.keys(entries).some((key) => key.startsWith('.'))
+      if (hasSubpaths) {
+        const subpath = specifier === packageName ? '.' : `.${specifier.slice(packageName.length)}`
+        if (Object.hasOwn(entries, subpath)) {
+          selected = entries[subpath]
+        } else {
+          const pattern = Object.keys(entries)
+            .filter((key) => {
+              const star = key.indexOf('*')
+              if (star === -1) return false
+              return subpath.startsWith(key.slice(0, star))
+                && subpath.endsWith(key.slice(star + 1))
+            })
+            .sort((left, right) => {
+              const leftStar = left.indexOf('*')
+              const rightStar = right.indexOf('*')
+              return rightStar - leftStar || right.length - left.length
+            })[0]
+          if (pattern) {
+            const star = pattern.indexOf('*')
+            patternMatch = subpath.slice(star, subpath.length - (pattern.length - star - 1))
+            selected = entries[pattern]
+          } else {
+            selected = undefined
+          }
+        }
+      } else if (specifier !== packageName) {
+        selected = undefined
+      }
+    } else if (specifier !== packageName) {
+      selected = undefined
+    }
+    return runtimeExportTargets(selected, patternMatch)
+  }
+  if (specifier !== packageName) return [`.${specifier.slice(packageName.length)}`]
+  return typeof manifest.main === 'string' ? [manifest.main] : []
+}
+
+function isTypeScriptRuntimeTarget(path: string) {
+  const target = path.replace(/[?#].*$/, '')
+  return /\.[cm]?tsx?$/.test(target) && !/\.d\.[cm]?ts$/.test(target)
+}
+
+function validateWorkspaceRuntimeExports(
+  project: SandboxProject,
+  runtimePackages: Iterable<string>,
+  declaredWorkspacePackages: Iterable<string>,
+) {
+  const pending = [...runtimePackages]
+  if (!pending.length) return
+  const workspacePackages = new Set(declaredWorkspacePackages)
+  if (!workspacePackages.size) return
+  const workspaceFile = project.files['pnpm-workspace.yaml']
+  if (!workspaceFile) return
+  const workspacePatterns = parsePnpmWorkspacePackages(
+    Buffer.from(workspaceFile.contents, workspaceFile.encoding).toString(),
+  )
+  const manifests = new Map<string, { manifest: PackageRuntimeManifest; path: string }>()
+  for (const path of Object.keys(project.files).filter(
+    (path) => path === 'package.json'
+      || (path.endsWith('/package.json')
+        && isWorkspacePackage(dirname(path), workspacePatterns)),
+  )) {
+    let manifest: PackageRuntimeManifest
+    try {
+      const value: unknown = JSON.parse(projectFileSource(project, path))
+      if (!value || typeof value !== 'object' || Array.isArray(value)) continue
+      manifest = value as PackageRuntimeManifest
+    } catch {
+      continue
+    }
+    if (typeof manifest.name === 'string') manifests.set(manifest.name, { manifest, path })
+  }
+
+  const visited = new Set<string>()
+  while (pending.length) {
+    const specifier = pending.shift()!
+    if (visited.has(specifier)) continue
+    visited.add(specifier)
+    const packageName = barePackageName(specifier)
+    if (!workspacePackages.has(packageName)) continue
+    const dependency = manifests.get(packageName)
+    if (!dependency) continue
+    const targets = runtimeTargetsForPackageSpecifier(
+      dependency.manifest,
+      packageName,
+      specifier,
+    )
+    const target = targets.find(isTypeScriptRuntimeTarget)
+    if (target) {
+      throw new Error(
+        `[vitehub] Sandbox workspace dependency "${packageName}" exposes TypeScript runtime target "${target}" in "${dependency.path}". Build dependencies to JavaScript before Sandbox execution.`,
+      )
+    }
+    const transitiveWorkspacePackages = runtimeWorkspaceDependencyNames(dependency.manifest)
+    for (const name of transitiveWorkspacePackages) workspacePackages.add(name)
+    pending.push(...transitiveWorkspacePackages)
+  }
+}
+
+function isInsideSelectedPackage(project: SandboxProject, path: string) {
+  if (project.packagePath === '.') return path !== '..' && !path.startsWith('../')
+  return path.startsWith(`${project.packagePath}/`)
+}
+
+function removeTypeOnlyModuleDeclarations(context: ts.TransformationContext) {
+  return (sourceFile: ts.SourceFile) =>
+    context.factory.updateSourceFile(
+      sourceFile,
+      sourceFile.statements.filter((statement) => {
+        if (typescript.isImportDeclaration(statement)) {
+          const clause = statement.importClause
+          const bindings = clause?.namedBindings
+          return !(
+            clause &&
+            !clause.name &&
+            bindings &&
+            typescript.isNamedImports(bindings) &&
+            bindings.elements.length > 0 &&
+            bindings.elements.every((element) => element.isTypeOnly)
+          )
+        }
+        if (typescript.isExportDeclaration(statement)) {
+          const clause = statement.exportClause
+          return !(
+            clause &&
+            typescript.isNamedExports(clause) &&
+            clause.elements.length > 0 &&
+            clause.elements.every((element) => element.isTypeOnly)
+          )
+        }
+        return true
+      }),
+    )
+}
+
+function transpilePackageModule(source: string, path: string) {
+  const result = typescript.transpileModule(source, {
+    compilerOptions: {
+      module: typescript.ModuleKind.ESNext,
+      target: typescript.ScriptTarget.ES2022,
+      verbatimModuleSyntax: true,
+    },
+    fileName: path,
+    reportDiagnostics: true,
+    transformers: { before: [removeTypeOnlyModuleDeclarations] },
+  })
+  const errors =
+    result.diagnostics?.filter(
+      (diagnostic) => diagnostic.category === typescript.DiagnosticCategory.Error,
+    ) || []
+  if (errors.length) {
+    const details = errors
+      .map((diagnostic) => typescript.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+      .join('\n')
+    throw new Error(
+      `[vitehub] Sandbox package module "${path}" could not be transpiled:\n${details}`,
+    )
+  }
+  return result.outputText
+}
+
+function barePackageName(specifier: string) {
+  const [scopeOrName, name] = specifier.split('/')
+  return scopeOrName.startsWith('@') && name ? `${scopeOrName}/${name}` : scopeOrName
+}
+
+function isUnsupportedExternalModuleSpecifier(specifier: string) {
+  return (
+    specifier.startsWith('/') ||
+    specifier.startsWith('\\') ||
+    (/^[A-Za-z][A-Za-z\d+.-]*:/.test(specifier) && !specifier.startsWith('node:'))
+  )
+}
+
+function validatePackageModuleSpecifiers(
+  project: SandboxProject,
+  entry: string,
+  packageName?: string,
+) {
+  const pending = [entry]
+  const runtimePackages = new Set<string>()
+  const visited = new Set<string>()
+  while (pending.length) {
+    const path = pending.shift()!
+    if (visited.has(path)) continue
+    visited.add(path)
+    const source = projectFileSource(project, path)
+    if (hasNonLiteralDynamicImport(source, path)) {
+      throw new Error(
+        `[vitehub] Sandbox package module "${path}" uses a non-literal dynamic import. Canonical Sandbox package entrypoints require literal import() specifiers.`,
+      )
+    }
+    const commonJS = findCommonJSModuleSpecifiers(source, path)[0]
+    if (commonJS) {
+      const syntax = {
+        'exports-assignment': 'exports assignment',
+        'exports-reference': 'exports reference',
+        'import-equals': 'import = require()',
+        'module-exports-assignment': 'module.exports assignment',
+        'module-reference': 'module reference',
+        require: 'require()',
+        'require-property': commonJS.specifier
+          ? `require.${commonJS.specifier}`
+          : 'require property access',
+      }[commonJS.syntax]
+      const target =
+        commonJS.specifier && commonJS.syntax !== 'require-property'
+          ? ` for "${commonJS.specifier}"`
+          : ''
+      throw new Error(
+        `[vitehub] Sandbox package module "${path}" uses CommonJS ${syntax}${target}. Canonical Sandbox package entrypoints are ESM; use import or export syntax.`,
+      )
+    }
+    const moduleSpecifiers = findRuntimeModuleSpecifiers(source, path)
+    for (const specifier of moduleSpecifiers) {
+      if (specifier.startsWith('#')) {
+        throw new Error(
+          `[vitehub] Sandbox package module "${path}" imports package alias "${specifier}". Use an explicit relative ESM import for local Sandbox source.`,
+        )
+      }
+      if (packageName && (specifier === packageName || specifier.startsWith(`${packageName}/`))) {
+        throw new Error(
+          `[vitehub] Sandbox package module "${path}" self-imports "${specifier}". Use an explicit relative ESM import for local Sandbox source.`,
+        )
+      }
+      if (isUnsupportedExternalModuleSpecifier(specifier)) {
+        throw new Error(
+          `[vitehub] Sandbox package module "${path}" imports absolute or URL module "${specifier}". Use a relative module inside the package or a runtime-ready package dependency.`,
+        )
+      }
+      if (!/^\.\.?\//.test(specifier) && !specifier.startsWith('node:')) {
+        runtimePackages.add(specifier)
+      }
+    }
+    for (const specifier of moduleSpecifiers.filter((specifier) => /^\.\.?\//.test(specifier))) {
+      const target = normalize(join(dirname(path), specifier.replace(/[?#].*$/, '')))
+      if (!isInsideSelectedPackage(project, target)) {
+        throw new Error(
+          `[vitehub] Sandbox package module "${path}" imports "${specifier}" outside its package. Declare runtime-ready JavaScript as a package dependency instead.`,
+        )
+      }
+      if (!Object.hasOwn(project.files, target)) {
+        throw new Error(
+          `[vitehub] Sandbox package module "${path}" imports "${specifier}", which is not an executable package file. Use an explicit extension that resolves to a package file.`,
+        )
+      }
+      if (/\.(?:cjs|cts)$/.test(target)) {
+        throw new Error(
+          `[vitehub] Sandbox package module "${path}" imports CommonJS module "${specifier}". Canonical Sandbox package source must use ESM JavaScript or TypeScript modules.`,
+        )
+      }
+      if (/\.[cm]?[jt]sx$/.test(target)) {
+        throw new Error(
+          `[vitehub] Sandbox package module "${path}" imports JSX module "${specifier}". Canonical Sandbox package source does not compile JSX.`,
+        )
+      }
+      if (/\.d\.[cm]?ts$/.test(target)) {
+        throw new Error(
+          `[vitehub] Sandbox package module "${path}" imports declaration file "${specifier}" at runtime. Use an import type declaration instead.`,
+        )
+      }
+      if (/\.(?:js|mjs|ts|mts)$/.test(target)) pending.push(target)
+    }
+  }
+  return { modulePaths: visited, runtimePackages }
+}
+
+export function prepareExecutablePackageProject(project: SandboxProject, entry: string) {
+  const manifest = selectedPackageManifest(project)
+  const packageName = typeof manifest.name === 'string' ? manifest.name : undefined
+  const { modulePaths, runtimePackages } = validatePackageModuleSpecifiers(
+    project,
+    entry,
+    packageName,
+  )
+  validateWorkspaceRuntimeExports(
+    project,
+    runtimePackages,
+    runtimeWorkspaceDependencyNames(manifest),
+  )
+  const generatedFiles: SandboxProject['files'] = {}
+  const files = { ...project.files }
+
+  for (const path of modulePaths) {
+    const file = project.files[path]!
+    const source = Buffer.from(file.contents, file.encoding).toString()
+    const rewritten = rewriteRuntimeRelativeModuleSpecifiers(
+      source,
+      path,
+      executablePackageModulePath,
+    )
+    if (isExecutableTypeScriptModule(path)) {
+      const executablePath = executablePackageModulePath(path)
+      if (Object.hasOwn(project.files, executablePath)) {
+        throw new Error(
+          `[vitehub] Sandbox package module "${path}" conflicts with generated executable "${executablePath}". Rename the existing file.`,
+        )
+      }
+      generatedFiles[executablePath] = {
+        contents: Buffer.from(transpilePackageModule(rewritten, path)).toString('base64'),
+        encoding: 'base64',
+      }
+    } else if (rewritten !== source) {
+      generatedFiles[path] = {
+        ...file,
+        contents: Buffer.from(rewritten).toString('base64'),
+      }
+    }
+  }
+
+  if (!Object.keys(generatedFiles).length) return { entry, project }
+
+  Object.assign(files, generatedFiles)
+  const digest = createHash('sha256')
+    .update(JSON.stringify({ generatedFiles, project: project.digest }))
+    .digest('hex')
+  return {
+    entry: executablePackageModulePath(entry),
+    project: { ...project, digest, files },
+  }
+}

--- a/packages/sandbox/src/internal/package-entry.ts
+++ b/packages/sandbox/src/internal/package-entry.ts
@@ -167,6 +167,34 @@ function isTypeScriptRuntimeTarget(path: string) {
   return /\.[cm]?tsx?$/.test(target) && !/\.d\.[cm]?ts$/.test(target)
 }
 
+function validateWorkspaceJavaScriptGraph(
+  project: SandboxProject,
+  packageName: string,
+  manifestPath: string,
+  targets: string[],
+) {
+  const pending = targets
+    .filter((target) => /\.(?:js|mjs)$/.test(target.replace(/[?#].*$/, '')))
+    .map((target) => normalize(join(dirname(manifestPath), target.replace(/[?#].*$/, ''))))
+  const visited = new Set<string>()
+  while (pending.length) {
+    const path = pending.shift()!
+    if (visited.has(path) || !Object.hasOwn(project.files, path)) continue
+    visited.add(path)
+    const source = projectFileSource(project, path)
+    for (const specifier of findRuntimeModuleSpecifiers(source, path)) {
+      if (!/^\.\.?\//.test(specifier)) continue
+      const target = normalize(join(dirname(path), specifier.replace(/[?#].*$/, '')))
+      if (isTypeScriptRuntimeTarget(target)) {
+        throw new Error(
+          `[vitehub] Sandbox workspace dependency "${packageName}" exposes TypeScript runtime target "${specifier}" from "${path}". Build dependencies to JavaScript before Sandbox execution.`,
+        )
+      }
+      if (/\.(?:js|mjs)$/.test(target)) pending.push(target)
+    }
+  }
+}
+
 function validateWorkspaceRuntimeExports(
   project: SandboxProject,
   runtimePackages: Iterable<string>,
@@ -218,6 +246,12 @@ function validateWorkspaceRuntimeExports(
         `[vitehub] Sandbox workspace dependency "${packageName}" exposes TypeScript runtime target "${target}" in "${dependency.path}". Build dependencies to JavaScript before Sandbox execution.`,
       )
     }
+    validateWorkspaceJavaScriptGraph(
+      project,
+      packageName,
+      dependency.path,
+      targets,
+    )
     const transitiveWorkspacePackages = runtimeWorkspaceDependencyNames(dependency.manifest)
     for (const name of transitiveWorkspacePackages) workspacePackages.add(name)
     pending.push(...transitiveWorkspacePackages)

--- a/packages/sandbox/src/internal/package-entry.ts
+++ b/packages/sandbox/src/internal/package-entry.ts
@@ -2,7 +2,8 @@ import { createHash } from 'node:crypto'
 import { createRequire } from 'node:module'
 import { dirname, join, normalize } from 'node:path/posix'
 import {
-  findCommonJSModuleSpecifiers,
+  findCommonJSImportEqualsSpecifiers,
+  findExecutableCommonJSModuleSpecifiers,
   findRuntimeModuleSpecifiers,
   hasNonLiteralDynamicImport,
   rewriteRuntimeRelativeModuleSpecifiers,
@@ -333,6 +334,30 @@ function isUnsupportedExternalModuleSpecifier(specifier: string) {
   )
 }
 
+function throwCommonJSSyntax(
+  path: string,
+  commonJS: ReturnType<typeof findExecutableCommonJSModuleSpecifiers>[number],
+): never {
+  const syntax = {
+    'exports-assignment': 'exports assignment',
+    'exports-reference': 'exports reference',
+    'import-equals': 'import = require()',
+    'module-exports-assignment': 'module.exports assignment',
+    'module-reference': 'module reference',
+    require: 'require()',
+    'require-property': commonJS.specifier
+      ? `require.${commonJS.specifier}`
+      : 'require property access',
+  }[commonJS.syntax]
+  const target =
+    commonJS.specifier && commonJS.syntax !== 'require-property'
+      ? ` for "${commonJS.specifier}"`
+      : ''
+  throw new Error(
+    `[vitehub] Sandbox package module "${path}" uses CommonJS ${syntax}${target}. Canonical Sandbox package entrypoints are ESM; use import or export syntax.`,
+  )
+}
+
 function validatePackageModuleSpecifiers(
   project: SandboxProject,
   entry: string,
@@ -351,27 +376,9 @@ function validatePackageModuleSpecifiers(
         `[vitehub] Sandbox package module "${path}" uses a non-literal dynamic import. Canonical Sandbox package entrypoints require literal import() specifiers.`,
       )
     }
-    const commonJS = findCommonJSModuleSpecifiers(source, path)[0]
-    if (commonJS) {
-      const syntax = {
-        'exports-assignment': 'exports assignment',
-        'exports-reference': 'exports reference',
-        'import-equals': 'import = require()',
-        'module-exports-assignment': 'module.exports assignment',
-        'module-reference': 'module reference',
-        require: 'require()',
-        'require-property': commonJS.specifier
-          ? `require.${commonJS.specifier}`
-          : 'require property access',
-      }[commonJS.syntax]
-      const target =
-        commonJS.specifier && commonJS.syntax !== 'require-property'
-          ? ` for "${commonJS.specifier}"`
-          : ''
-      throw new Error(
-        `[vitehub] Sandbox package module "${path}" uses CommonJS ${syntax}${target}. Canonical Sandbox package entrypoints are ESM; use import or export syntax.`,
-      )
-    }
+    const importEquals = findCommonJSImportEqualsSpecifiers(source, path)[0]
+    if (importEquals)
+      throwCommonJSSyntax(path, importEquals)
     const moduleSpecifiers = findRuntimeModuleSpecifiers(source, path)
     for (const specifier of moduleSpecifiers) {
       if (specifier.startsWith('#')) {
@@ -440,6 +447,8 @@ export function prepareExecutablePackageProject(project: SandboxProject, entry: 
     declaredWorkspaceDependencyNames(manifest),
   )
   const generatedFiles: SandboxProject['files'] = {}
+  const executableSources = new Map<string, string>()
+  const originalPaths = new Map<string, string>()
   const files = { ...project.files }
 
   for (const path of modulePaths) {
@@ -457,17 +466,28 @@ export function prepareExecutablePackageProject(project: SandboxProject, entry: 
           `[vitehub] Sandbox package module "${path}" conflicts with generated executable "${executablePath}". Rename the existing file.`,
         )
       }
+      const executableSource = transpilePackageModule(rewritten, path)
+      executableSources.set(executablePath, executableSource)
+      originalPaths.set(executablePath, path)
       generatedFiles[executablePath] = {
-        contents: Buffer.from(transpilePackageModule(rewritten, path)).toString('base64'),
+        contents: Buffer.from(executableSource).toString('base64'),
         encoding: 'base64',
       }
-    } else if (rewritten !== source) {
-      generatedFiles[path] = {
-        ...file,
-        contents: Buffer.from(rewritten).toString('base64'),
+    } else {
+      executableSources.set(path, rewritten)
+      originalPaths.set(path, path)
+      if (rewritten !== source) {
+        generatedFiles[path] = {
+          ...file,
+          contents: Buffer.from(rewritten).toString('base64'),
+        }
       }
     }
   }
+
+  const commonJS = findExecutableCommonJSModuleSpecifiers(executableSources)[0]
+  if (commonJS)
+    throwCommonJSSyntax(originalPaths.get(commonJS.path) || commonJS.path, commonJS)
 
   if (!Object.keys(generatedFiles).length) return { entry, project }
 

--- a/packages/sandbox/src/internal/package-entry.ts
+++ b/packages/sandbox/src/internal/package-entry.ts
@@ -13,7 +13,7 @@ import type ts from 'typescript'
 
 const require = createRequire(import.meta.url)
 const typescript = require('typescript') as typeof import('typescript')
-const runtimeExportConditions = new Set(['default', 'import', 'node', 'node-addons'])
+const runtimeExportConditions = new Set(['default', 'import', 'module-sync', 'node', 'node-addons'])
 
 type PackageRuntimeManifest = {
   dependencies?: Record<string, string>
@@ -69,6 +69,22 @@ function runtimeWorkspaceDependencyNames(manifest: PackageRuntimeManifest) {
   return [
     ...new Set(
       sections
+        .flatMap((section) => Object.entries(section || {}))
+        .filter(([, specifier]) => specifier.startsWith('workspace:'))
+        .map(([name]) => name),
+    ),
+  ]
+}
+
+function declaredWorkspaceDependencyNames(manifest: PackageRuntimeManifest) {
+  return [
+    ...new Set(
+      [
+        manifest.dependencies,
+        manifest.devDependencies,
+        manifest.optionalDependencies,
+        manifest.peerDependencies,
+      ]
         .flatMap((section) => Object.entries(section || {}))
         .filter(([, specifier]) => specifier.startsWith('workspace:'))
         .map(([name]) => name),
@@ -387,7 +403,7 @@ export function prepareExecutablePackageProject(project: SandboxProject, entry: 
   validateWorkspaceRuntimeExports(
     project,
     runtimePackages,
-    runtimeWorkspaceDependencyNames(manifest),
+    declaredWorkspaceDependencyNames(manifest),
   )
   const generatedFiles: SandboxProject['files'] = {}
   const files = { ...project.files }

--- a/packages/sandbox/src/internal/package-entry.ts
+++ b/packages/sandbox/src/internal/package-entry.ts
@@ -20,6 +20,7 @@ type PackageRuntimeManifest = {
   dependencies?: Record<string, string>
   devDependencies?: Record<string, string>
   exports?: unknown
+  imports?: unknown
   main?: unknown
   name?: unknown
   optionalDependencies?: Record<string, string>
@@ -81,14 +82,18 @@ function declaredWorkspaceDependencyNames(manifest: PackageRuntimeManifest) {
   ]
 }
 
-function runtimeExportTargets(value: unknown, patternMatch?: string): string[] {
+function runtimeExportTargets(
+  value: unknown,
+  patternMatch?: string,
+  allowPackageTarget = false,
+): string[] {
   if (typeof value === 'string') {
     const target = patternMatch === undefined ? value : value.replaceAll('*', patternMatch)
-    return target.startsWith('./') ? [target] : []
+    return target.startsWith('./') || allowPackageTarget ? [target] : []
   }
   if (Array.isArray(value)) {
     for (const target of value) {
-      const targets = runtimeExportTargets(target, patternMatch)
+      const targets = runtimeExportTargets(target, patternMatch, allowPackageTarget)
       if (targets.length) return targets
     }
     return []
@@ -96,7 +101,7 @@ function runtimeExportTargets(value: unknown, patternMatch?: string): string[] {
   if (!value || typeof value !== 'object') return []
   for (const [condition, target] of Object.entries(value)) {
     if (runtimeExportConditions.has(condition)) {
-      const targets = runtimeExportTargets(target, patternMatch)
+      const targets = runtimeExportTargets(target, patternMatch, allowPackageTarget)
       if (targets.length) return targets
     }
   }
@@ -151,6 +156,34 @@ function runtimeTargetsForPackageSpecifier(
   return typeof manifest.main === 'string' ? [manifest.main] : ['./index.js']
 }
 
+function runtimeTargetsForPackageImport(manifest: PackageRuntimeManifest, specifier: string) {
+  if (!manifest.imports || typeof manifest.imports !== 'object' || Array.isArray(manifest.imports)) {
+    return []
+  }
+  const entries = manifest.imports as Record<string, unknown>
+  let selected = entries[specifier]
+  let patternMatch: string | undefined
+  if (selected === undefined) {
+    const pattern = Object.keys(entries)
+      .filter((key) => {
+        const star = key.indexOf('*')
+        if (star === -1) return false
+        return specifier.startsWith(key.slice(0, star))
+          && specifier.endsWith(key.slice(star + 1))
+      })
+      .sort((left, right) => {
+        const leftStar = left.indexOf('*')
+        const rightStar = right.indexOf('*')
+        return rightStar - leftStar || right.length - left.length
+      })[0]
+    if (!pattern) return []
+    const star = pattern.indexOf('*')
+    patternMatch = specifier.slice(star, specifier.length - (pattern.length - star - 1))
+    selected = entries[pattern]
+  }
+  return runtimeExportTargets(selected, patternMatch, true)
+}
+
 function isTypeScriptRuntimeTarget(path: string) {
   const target = path.replace(/[?#].*$/, '')
   return /\.[cm]?tsx?$/.test(target) && !/\.d\.[cm]?ts$/.test(target)
@@ -159,6 +192,7 @@ function isTypeScriptRuntimeTarget(path: string) {
 function validateWorkspaceJavaScriptGraph(
   project: SandboxProject,
   packageName: string,
+  manifest: PackageRuntimeManifest,
   manifestPath: string,
   targets: string[],
 ) {
@@ -173,6 +207,22 @@ function validateWorkspaceJavaScriptGraph(
     visited.add(path)
     const source = projectFileSource(project, path)
     for (const specifier of findRuntimeModuleSpecifiers(source, path)) {
+      if (specifier.startsWith('#')) {
+        for (const aliasTarget of runtimeTargetsForPackageImport(manifest, specifier)) {
+          if (!/^\.\.?\//.test(aliasTarget)) {
+            runtimePackages.add(aliasTarget)
+            continue
+          }
+          const target = normalize(join(dirname(manifestPath), aliasTarget.replace(/[?#].*$/, '')))
+          if (isTypeScriptRuntimeTarget(target)) {
+            throw new Error(
+              `[vitehub] Sandbox workspace dependency "${packageName}" exposes TypeScript runtime target "${aliasTarget}" through package import "${specifier}". Build dependencies to JavaScript before Sandbox execution.`,
+            )
+          }
+          if (/\.(?:js|mjs)$/.test(target)) pending.push(target)
+        }
+        continue
+      }
       if (!/^\.\.?\//.test(specifier)) {
         if (!specifier.startsWith('node:')) runtimePackages.add(specifier)
         continue
@@ -243,6 +293,7 @@ function validateWorkspaceRuntimeExports(
     const runtimePackageEdges = validateWorkspaceJavaScriptGraph(
       project,
       packageName,
+      dependency.manifest,
       dependency.path,
       targets,
     )

--- a/packages/sandbox/src/internal/package-entry.ts
+++ b/packages/sandbox/src/internal/package-entry.ts
@@ -65,18 +65,6 @@ function selectedPackageManifest(project: SandboxProject) {
   return manifest
 }
 
-function runtimeWorkspaceDependencyNames(manifest: PackageRuntimeManifest) {
-  const sections = [manifest.dependencies, manifest.optionalDependencies, manifest.peerDependencies]
-  return [
-    ...new Set(
-      sections
-        .flatMap((section) => Object.entries(section || {}))
-        .filter(([, specifier]) => specifier.startsWith('workspace:'))
-        .map(([name]) => name),
-    ),
-  ]
-}
-
 function declaredWorkspaceDependencyNames(manifest: PackageRuntimeManifest) {
   return [
     ...new Set(
@@ -160,7 +148,7 @@ function runtimeTargetsForPackageSpecifier(
     return runtimeExportTargets(selected, patternMatch)
   }
   if (specifier !== packageName) return [`.${specifier.slice(packageName.length)}`]
-  return typeof manifest.main === 'string' ? [manifest.main] : []
+  return typeof manifest.main === 'string' ? [manifest.main] : ['./index.js']
 }
 
 function isTypeScriptRuntimeTarget(path: string) {
@@ -178,13 +166,17 @@ function validateWorkspaceJavaScriptGraph(
     .filter((target) => /\.(?:js|mjs)$/.test(target.replace(/[?#].*$/, '')))
     .map((target) => normalize(join(dirname(manifestPath), target.replace(/[?#].*$/, ''))))
   const visited = new Set<string>()
+  const runtimePackages = new Set<string>()
   while (pending.length) {
     const path = pending.shift()!
     if (visited.has(path) || !Object.hasOwn(project.files, path)) continue
     visited.add(path)
     const source = projectFileSource(project, path)
     for (const specifier of findRuntimeModuleSpecifiers(source, path)) {
-      if (!/^\.\.?\//.test(specifier)) continue
+      if (!/^\.\.?\//.test(specifier)) {
+        if (!specifier.startsWith('node:')) runtimePackages.add(specifier)
+        continue
+      }
       const target = normalize(join(dirname(path), specifier.replace(/[?#].*$/, '')))
       if (isTypeScriptRuntimeTarget(target)) {
         throw new Error(
@@ -194,6 +186,7 @@ function validateWorkspaceJavaScriptGraph(
       if (/\.(?:js|mjs)$/.test(target)) pending.push(target)
     }
   }
+  return runtimePackages
 }
 
 function validateWorkspaceRuntimeExports(
@@ -247,15 +240,16 @@ function validateWorkspaceRuntimeExports(
         `[vitehub] Sandbox workspace dependency "${packageName}" exposes TypeScript runtime target "${target}" in "${dependency.path}". Build dependencies to JavaScript before Sandbox execution.`,
       )
     }
-    validateWorkspaceJavaScriptGraph(
+    const runtimePackageEdges = validateWorkspaceJavaScriptGraph(
       project,
       packageName,
       dependency.path,
       targets,
     )
-    const transitiveWorkspacePackages = runtimeWorkspaceDependencyNames(dependency.manifest)
-    for (const name of transitiveWorkspacePackages) workspacePackages.add(name)
-    pending.push(...transitiveWorkspacePackages)
+    for (const name of declaredWorkspaceDependencyNames(dependency.manifest)) {
+      workspacePackages.add(name)
+    }
+    pending.push(...runtimePackageEdges)
   }
 }
 

--- a/packages/sandbox/src/internal/package-entry.ts
+++ b/packages/sandbox/src/internal/package-entry.ts
@@ -77,8 +77,10 @@ function runtimeWorkspaceDependencyNames(manifest: PackageRuntimeManifest) {
 }
 
 function runtimeExportTargets(value: unknown, patternMatch?: string): string[] {
-  if (typeof value === 'string')
-    return [patternMatch === undefined ? value : value.replaceAll('*', patternMatch)]
+  if (typeof value === 'string') {
+    const target = patternMatch === undefined ? value : value.replaceAll('*', patternMatch)
+    return target.startsWith('./') ? [target] : []
+  }
   if (Array.isArray(value)) {
     for (const target of value) {
       const targets = runtimeExportTargets(target, patternMatch)

--- a/packages/sandbox/src/internal/shared/discovered-definition/ast.ts
+++ b/packages/sandbox/src/internal/shared/discovered-definition/ast.ts
@@ -135,65 +135,36 @@ function propertyAccessRoot(expression: ts.Expression) {
   return { current, properties }
 }
 
-export function findCommonJSModuleSpecifiers(source: string, id: string) {
-  const sourceFile = createSourceFile(id, source)
-  const bindings = collectLexicalBindings(sourceFile)
-  const specifiers: Array<{
-    specifier?: string
-    syntax: 'exports-assignment' | 'exports-reference' | 'import-equals' | 'module-exports-assignment' | 'module-reference' | 'require' | 'require-property'
-  }> = []
+type CommonJSModuleSpecifier = {
+  path: string
+  specifier?: string
+  syntax:
+    | 'exports-assignment'
+    | 'exports-reference'
+    | 'import-equals'
+    | 'module-exports-assignment'
+    | 'module-reference'
+    | 'require'
+    | 'require-property'
+}
 
-  function isBound(node: ts.Identifier) {
-    for (let current: ts.Node | undefined = node; current; current = current.parent) {
-      if (bindings.get(current)?.has(node.text))
-        return true
-    }
-    return false
-  }
+export function findCommonJSImportEqualsSpecifiers(source: string, id: string) {
+  const sourceFile = createSourceFile(id, source)
+  const specifiers: CommonJSModuleSpecifier[] = []
 
   function visit(node: ts.Node) {
-    if (typescript.isImportEqualsDeclaration(node)
-      && !node.isTypeOnly
-      && typescript.isExternalModuleReference(node.moduleReference)) {
+    if (
+      typescript.isImportEqualsDeclaration(node) &&
+      !node.isTypeOnly &&
+      typescript.isExternalModuleReference(node.moduleReference)
+    ) {
       const expression = node.moduleReference.expression
       specifiers.push({
-        specifier: expression && typescript.isStringLiteralLike(expression) ? expression.text : undefined,
+        path: id,
+        specifier:
+          expression && typescript.isStringLiteralLike(expression) ? expression.text : undefined,
         syntax: 'import-equals',
       })
-    }
-    else if (typescript.isCallExpression(node)
-      && typescript.isIdentifier(node.expression)
-      && node.expression.text === 'require'
-      && !isBound(node.expression)) {
-      const argument = node.arguments[0]
-      specifiers.push({
-        specifier: argument && typescript.isStringLiteralLike(argument) ? argument.text : undefined,
-        syntax: 'require',
-      })
-    }
-    else if (typescript.isPropertyAccessExpression(node) || typescript.isElementAccessExpression(node)) {
-      const { current, properties } = propertyAccessRoot(node)
-      if (typescript.isIdentifier(current) && current.text === 'require' && !isBound(current)) {
-        specifiers.push({
-          specifier: properties.join('.'),
-          syntax: 'require-property',
-        })
-      }
-    }
-    else if (typescript.isBinaryExpression(node)
-      && node.operatorToken.kind >= typescript.SyntaxKind.FirstAssignment
-      && node.operatorToken.kind <= typescript.SyntaxKind.LastAssignment) {
-      const { current, properties } = propertyAccessRoot(node.left)
-      if (typescript.isIdentifier(current) && current.text === 'module' && !isBound(current) && properties[0] === 'exports')
-        specifiers.push({ syntax: 'module-exports-assignment' })
-      else if (typescript.isIdentifier(current) && current.text === 'exports' && !isBound(current) && properties.length)
-        specifiers.push({ syntax: 'exports-assignment' })
-    }
-    else if (typescript.isIdentifier(node)
-      && (node.text === 'module' || node.text === 'exports')
-      && isRuntimeIdentifierReference(node)
-      && !isBound(node)) {
-      specifiers.push({ syntax: node.text === 'module' ? 'module-reference' : 'exports-reference' })
     }
     typescript.forEachChild(node, visit)
   }
@@ -202,115 +173,174 @@ export function findCommonJSModuleSpecifiers(source: string, id: string) {
   return specifiers
 }
 
-function collectLexicalBindings(sourceFile: ts.SourceFile) {
-  const bindings = new Map<ts.Node, Set<string>>()
-
-  function add(scope: ts.Node | undefined, name: ts.BindingName | ts.Identifier | undefined) {
-    if (!scope || !name)
-      return
-    if (typescript.isIdentifier(name)) {
-      const names = bindings.get(scope) || new Set<string>()
-      names.add(name.text)
-      bindings.set(scope, names)
-      return
-    }
-    for (const element of name.elements) {
-      if (!typescript.isOmittedExpression(element))
-        add(scope, element.name)
-    }
-  }
-
-  function lexicalScope(node: ts.Node | undefined) {
-    for (let current = node; current; current = current.parent) {
-      if (typescript.isSourceFile(current)
-        || typescript.isBlock(current)
-        || typescript.isFunctionLike(current)
-        || typescript.isCatchClause(current))
-        return current
-    }
-  }
-
-  function functionScope(node: ts.Node | undefined) {
-    for (let current = node; current; current = current.parent) {
-      if (typescript.isSourceFile(current) || typescript.isFunctionLike(current))
-        return current
-    }
-  }
-
-  function visit(node: ts.Node) {
-    if (typescript.isImportClause(node) && !node.isTypeOnly) {
-      add(sourceFile, node.name)
-    }
-    else if (typescript.isImportSpecifier(node)
-      && !node.isTypeOnly
-      && !node.parent.parent.isTypeOnly) {
-      add(sourceFile, node.name)
-    }
-    else if (typescript.isNamespaceImport(node) && !node.parent.isTypeOnly) {
-      add(sourceFile, node.name)
-    }
-    else if (typescript.isVariableDeclaration(node)) {
-      const declarationList = node.parent
-      if (isAmbientDeclaration(node)) {
-        typescript.forEachChild(node, visit)
-        return
-      }
-      const scope = typescript.isVariableDeclarationList(declarationList)
-        && !(declarationList.flags & typescript.NodeFlags.BlockScoped)
-        ? functionScope(declarationList.parent)
-        : lexicalScope(declarationList.parent)
-      add(scope, node.name)
-    }
-    else if (typescript.isParameter(node)) {
-      add(functionScope(node.parent), node.name)
-    }
-    else if ((typescript.isFunctionDeclaration(node) || typescript.isClassDeclaration(node))
-      && !isAmbientDeclaration(node)) {
-      add(lexicalScope(node.parent), node.name)
-    }
-    else if (typescript.isFunctionExpression(node)) {
-      add(node, node.name)
-    }
-    else if (typescript.isCatchClause(node)) {
-      add(node, node.variableDeclaration?.name)
-    }
-    typescript.forEachChild(node, visit)
-  }
-
-  visit(sourceFile)
-  return bindings
-}
-
-function isAmbientDeclaration(node: ts.Node) {
-  for (let current: ts.Node | undefined = node; current; current = current.parent) {
-    if (typescript.isSourceFile(current))
-      return current.isDeclarationFile
-    if (hasModifier(current, typescript.SyntaxKind.DeclareKeyword))
-      return true
-  }
-  return false
-}
-
-function isRuntimeIdentifierReference(node: ts.Identifier) {
-  for (let current: ts.Node | undefined = node.parent; current; current = current.parent) {
-    if (typescript.isTypeNode(current))
-      return false
-    if (typescript.isExpression(current) || typescript.isStatement(current))
-      break
-  }
+function isExecutableIdentifierReference(node: ts.Identifier) {
   const parent = node.parent
-  if (typescript.isPropertyAccessExpression(parent) && parent.name === node)
+  if (
+    typescript.isImportClause(parent) ||
+    typescript.isImportSpecifier(parent) ||
+    typescript.isNamespaceImport(parent) ||
+    typescript.isNamespaceExport(parent)
+  )
+    return false
+  if (typescript.isExportSpecifier(parent)) {
+    const declaration = parent.parent.parent
+    if (declaration.moduleSpecifier) return false
+    return parent.propertyName ? parent.propertyName === node : parent.name === node
+  }
+  if (
+    typescript.isBindingElement(parent)
+    && (parent.name === node || parent.propertyName === node)
+  )
+    return false
+  if (typescript.isPropertyAccessExpression(parent) && parent.name === node) return false
+  if (
+    typescript.isLabeledStatement(parent) ||
+    typescript.isBreakStatement(parent) ||
+    typescript.isContinueStatement(parent)
+  )
     return false
   const namedParent = parent as ts.Node & { name?: ts.Node }
-  if (!typescript.isShorthandPropertyAssignment(parent) && namedParent.name === node)
-    return false
+  if (!typescript.isShorthandPropertyAssignment(parent) && namedParent.name === node) return false
   const propertyParent = parent as ts.Node & { propertyName?: ts.Node }
-  if (propertyParent.propertyName === node)
-    return false
-  const labeledParent = parent as ts.Node & { label?: ts.Node }
-  if (labeledParent.label === node)
-    return false
-  return true
+  return propertyParent.propertyName !== node
+}
+
+export function findExecutableCommonJSModuleSpecifiers(sources: ReadonlyMap<string, string>) {
+  const executableSources = new Map(
+    [...sources].map(([path, source]) => [`/${path.replace(/^[/]+/, '')}`, source]),
+  )
+  const options: ts.CompilerOptions = {
+    allowJs: true,
+    checkJs: false,
+    module: typescript.ModuleKind.ESNext,
+    moduleDetection: typescript.ModuleDetectionKind.Force,
+    noLib: true,
+    noResolve: true,
+    target: typescript.ScriptTarget.ES2022,
+    types: [],
+  }
+  const sourceFiles = new Map<string, ts.SourceFile>()
+  const host: ts.CompilerHost = {
+    fileExists: (fileName) => executableSources.has(fileName),
+    getCanonicalFileName: (fileName) => fileName,
+    getCurrentDirectory: () => '/',
+    getDefaultLibFileName: () => '',
+    getNewLine: () => '\n',
+    getSourceFile(fileName, languageVersion) {
+      const source = executableSources.get(fileName)
+      if (source === undefined) return undefined
+      let sourceFile = sourceFiles.get(fileName)
+      if (!sourceFile) {
+        sourceFile = typescript.createSourceFile(
+          fileName,
+          source,
+          languageVersion,
+          true,
+          typescript.ScriptKind.JS,
+        )
+        sourceFiles.set(fileName, sourceFile)
+      }
+      return sourceFile
+    },
+    readFile: (fileName) => executableSources.get(fileName),
+    useCaseSensitiveFileNames: () => true,
+    writeFile: () => {},
+  }
+  const program = typescript.createProgram({
+    host,
+    options,
+    rootNames: [...executableSources.keys()],
+  })
+  const checker = program.getTypeChecker()
+  const specifiers: CommonJSModuleSpecifier[] = []
+
+  function isRuntimeBindingDeclaration(node: ts.Declaration) {
+    return (
+      typescript.isBindingElement(node) ||
+      typescript.isClassDeclaration(node) ||
+      typescript.isClassExpression(node) ||
+      typescript.isFunctionDeclaration(node) ||
+      typescript.isFunctionExpression(node) ||
+      typescript.isImportClause(node) ||
+      typescript.isImportSpecifier(node) ||
+      typescript.isNamespaceImport(node) ||
+      typescript.isParameter(node) ||
+      typescript.isVariableDeclaration(node)
+    )
+  }
+
+  function isBound(node: ts.Identifier) {
+    const symbol = typescript.isShorthandPropertyAssignment(node.parent)
+      ? checker.getShorthandAssignmentValueSymbol(node.parent)
+      : checker.getSymbolAtLocation(node)
+    return symbol?.declarations?.some(isRuntimeBindingDeclaration) ?? false
+  }
+
+  function visit(sourceFile: ts.SourceFile, node: ts.Node) {
+    if (
+      typescript.isCallExpression(node) &&
+      typescript.isIdentifier(node.expression) &&
+      node.expression.text === 'require' &&
+      !isBound(node.expression)
+    ) {
+      const argument = node.arguments[0]
+      specifiers.push({
+        path: sourceFile.fileName.slice(1),
+        specifier: argument && typescript.isStringLiteralLike(argument) ? argument.text : undefined,
+        syntax: 'require',
+      })
+    } else if (
+      typescript.isPropertyAccessExpression(node) ||
+      typescript.isElementAccessExpression(node)
+    ) {
+      const { current, properties } = propertyAccessRoot(node)
+      if (typescript.isIdentifier(current) && current.text === 'require' && !isBound(current)) {
+        specifiers.push({
+          path: sourceFile.fileName.slice(1),
+          specifier: properties.join('.'),
+          syntax: 'require-property',
+        })
+      }
+    } else if (
+      typescript.isBinaryExpression(node) &&
+      node.operatorToken.kind >= typescript.SyntaxKind.FirstAssignment &&
+      node.operatorToken.kind <= typescript.SyntaxKind.LastAssignment
+    ) {
+      const { current, properties } = propertyAccessRoot(node.left)
+      if (
+        typescript.isIdentifier(current) &&
+        current.text === 'module' &&
+        !isBound(current) &&
+        properties[0] === 'exports'
+      ) {
+        specifiers.push({
+          path: sourceFile.fileName.slice(1),
+          syntax: 'module-exports-assignment',
+        })
+      } else if (
+        typescript.isIdentifier(current) &&
+        current.text === 'exports' &&
+        !isBound(current) &&
+        properties.length
+      ) {
+        specifiers.push({ path: sourceFile.fileName.slice(1), syntax: 'exports-assignment' })
+      }
+    } else if (
+      typescript.isIdentifier(node) &&
+      (node.text === 'module' || node.text === 'exports') &&
+      isExecutableIdentifierReference(node) &&
+      !isBound(node)
+    ) {
+      specifiers.push({
+        path: sourceFile.fileName.slice(1),
+        syntax: node.text === 'module' ? 'module-reference' : 'exports-reference',
+      })
+    }
+    typescript.forEachChild(node, (child) => visit(sourceFile, child))
+  }
+
+  for (const sourceFile of program.getSourceFiles()) visit(sourceFile, sourceFile)
+  return specifiers
 }
 
 export function rewriteRuntimeRelativeModuleSpecifiers(

--- a/packages/sandbox/src/internal/shared/discovered-definition/ast.ts
+++ b/packages/sandbox/src/internal/shared/discovered-definition/ast.ts
@@ -56,33 +56,290 @@ export function hasExportedType(source: string, id: string, name: string) {
   })
 }
 
-export function findRuntimeRelativeModuleSpecifiers(source: string, id: string) {
+function collectRuntimeModuleSpecifiers(source: string, id: string) {
   const sourceFile = createSourceFile(id, source)
-  const specifiers: string[] = []
+  const specifiers: Array<{ node: ts.StringLiteralLike, specifier: string }> = []
+  let hasNonLiteralDynamicImport = false
 
   function addSpecifier(node: ts.Expression | undefined) {
-    if (node && typescript.isStringLiteralLike(node) && /^\.\.?\//.test(node.text))
-      specifiers.push(node.text)
+    if (node && typescript.isStringLiteralLike(node))
+      specifiers.push({ node, specifier: node.text })
   }
 
   function visit(node: ts.Node) {
     if (typescript.isImportDeclaration(node)) {
-      if (!node.importClause?.isTypeOnly)
+      const clause = node.importClause
+      const bindings = clause?.namedBindings
+      const hasRuntimeBinding = !clause
+        || (!clause.isTypeOnly && (
+          Boolean(clause.name)
+          || !bindings
+          || typescript.isNamespaceImport(bindings)
+          || bindings.elements.length === 0
+          || bindings.elements.some(element => !element.isTypeOnly)
+        ))
+      if (hasRuntimeBinding)
         addSpecifier(node.moduleSpecifier)
     }
     else if (typescript.isExportDeclaration(node)) {
-      if (!node.isTypeOnly)
+      const clause = node.exportClause
+      const hasRuntimeExport = !node.isTypeOnly && (
+        !clause
+        || typescript.isNamespaceExport(clause)
+        || clause.elements.length === 0
+        || clause.elements.some(element => !element.isTypeOnly)
+      )
+      if (hasRuntimeExport)
         addSpecifier(node.moduleSpecifier)
     }
     else if (typescript.isCallExpression(node)
       && node.expression.kind === typescript.SyntaxKind.ImportKeyword) {
-      addSpecifier(node.arguments[0])
+      const argument = node.arguments[0]
+      if (argument && typescript.isStringLiteralLike(argument))
+        addSpecifier(argument)
+      else
+        hasNonLiteralDynamicImport = true
+    }
+    typescript.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return { hasNonLiteralDynamicImport, sourceFile, specifiers }
+}
+
+export function findRuntimeModuleSpecifiers(source: string, id: string) {
+  return collectRuntimeModuleSpecifiers(source, id).specifiers.map(entry => entry.specifier)
+}
+
+export function findRuntimeRelativeModuleSpecifiers(source: string, id: string) {
+  return findRuntimeModuleSpecifiers(source, id).filter(specifier => /^\.\.?\//.test(specifier))
+}
+
+export function hasNonLiteralDynamicImport(source: string, id: string) {
+  return collectRuntimeModuleSpecifiers(source, id).hasNonLiteralDynamicImport
+}
+
+function propertyAccessRoot(expression: ts.Expression) {
+  const properties: string[] = []
+  let current = expression
+  while (typescript.isPropertyAccessExpression(current) || typescript.isElementAccessExpression(current)) {
+    if (typescript.isPropertyAccessExpression(current)) {
+      properties.unshift(current.name.text)
+      current = current.expression
+      continue
+    }
+    const argument = current.argumentExpression
+    properties.unshift(argument && typescript.isStringLiteralLike(argument) ? argument.text : '*')
+    current = current.expression
+  }
+  return { current, properties }
+}
+
+export function findCommonJSModuleSpecifiers(source: string, id: string) {
+  const sourceFile = createSourceFile(id, source)
+  const bindings = collectLexicalBindings(sourceFile)
+  const specifiers: Array<{
+    specifier?: string
+    syntax: 'exports-assignment' | 'exports-reference' | 'import-equals' | 'module-exports-assignment' | 'module-reference' | 'require' | 'require-property'
+  }> = []
+
+  function isBound(node: ts.Identifier) {
+    for (let current: ts.Node | undefined = node; current; current = current.parent) {
+      if (bindings.get(current)?.has(node.text))
+        return true
+    }
+    return false
+  }
+
+  function visit(node: ts.Node) {
+    if (typescript.isImportEqualsDeclaration(node)
+      && !node.isTypeOnly
+      && typescript.isExternalModuleReference(node.moduleReference)) {
+      const expression = node.moduleReference.expression
+      specifiers.push({
+        specifier: expression && typescript.isStringLiteralLike(expression) ? expression.text : undefined,
+        syntax: 'import-equals',
+      })
+    }
+    else if (typescript.isCallExpression(node)
+      && typescript.isIdentifier(node.expression)
+      && node.expression.text === 'require'
+      && !isBound(node.expression)) {
+      const argument = node.arguments[0]
+      specifiers.push({
+        specifier: argument && typescript.isStringLiteralLike(argument) ? argument.text : undefined,
+        syntax: 'require',
+      })
+    }
+    else if (typescript.isPropertyAccessExpression(node) || typescript.isElementAccessExpression(node)) {
+      const { current, properties } = propertyAccessRoot(node)
+      if (typescript.isIdentifier(current) && current.text === 'require' && !isBound(current)) {
+        specifiers.push({
+          specifier: properties.join('.'),
+          syntax: 'require-property',
+        })
+      }
+    }
+    else if (typescript.isBinaryExpression(node)
+      && node.operatorToken.kind >= typescript.SyntaxKind.FirstAssignment
+      && node.operatorToken.kind <= typescript.SyntaxKind.LastAssignment) {
+      const { current, properties } = propertyAccessRoot(node.left)
+      if (typescript.isIdentifier(current) && current.text === 'module' && !isBound(current) && properties[0] === 'exports')
+        specifiers.push({ syntax: 'module-exports-assignment' })
+      else if (typescript.isIdentifier(current) && current.text === 'exports' && !isBound(current) && properties.length)
+        specifiers.push({ syntax: 'exports-assignment' })
+    }
+    else if (typescript.isIdentifier(node)
+      && (node.text === 'module' || node.text === 'exports')
+      && isRuntimeIdentifierReference(node)
+      && !isBound(node)) {
+      specifiers.push({ syntax: node.text === 'module' ? 'module-reference' : 'exports-reference' })
     }
     typescript.forEachChild(node, visit)
   }
 
   visit(sourceFile)
   return specifiers
+}
+
+function collectLexicalBindings(sourceFile: ts.SourceFile) {
+  const bindings = new Map<ts.Node, Set<string>>()
+
+  function add(scope: ts.Node | undefined, name: ts.BindingName | ts.Identifier | undefined) {
+    if (!scope || !name)
+      return
+    if (typescript.isIdentifier(name)) {
+      const names = bindings.get(scope) || new Set<string>()
+      names.add(name.text)
+      bindings.set(scope, names)
+      return
+    }
+    for (const element of name.elements) {
+      if (!typescript.isOmittedExpression(element))
+        add(scope, element.name)
+    }
+  }
+
+  function lexicalScope(node: ts.Node | undefined) {
+    for (let current = node; current; current = current.parent) {
+      if (typescript.isSourceFile(current)
+        || typescript.isBlock(current)
+        || typescript.isFunctionLike(current)
+        || typescript.isCatchClause(current))
+        return current
+    }
+  }
+
+  function functionScope(node: ts.Node | undefined) {
+    for (let current = node; current; current = current.parent) {
+      if (typescript.isSourceFile(current) || typescript.isFunctionLike(current))
+        return current
+    }
+  }
+
+  function visit(node: ts.Node) {
+    if (typescript.isImportClause(node) && !node.isTypeOnly) {
+      add(sourceFile, node.name)
+    }
+    else if (typescript.isImportSpecifier(node)
+      && !node.isTypeOnly
+      && !node.parent.parent.isTypeOnly) {
+      add(sourceFile, node.name)
+    }
+    else if (typescript.isNamespaceImport(node) && !node.parent.isTypeOnly) {
+      add(sourceFile, node.name)
+    }
+    else if (typescript.isVariableDeclaration(node)) {
+      const declarationList = node.parent
+      if (isAmbientDeclaration(node)) {
+        typescript.forEachChild(node, visit)
+        return
+      }
+      const scope = typescript.isVariableDeclarationList(declarationList)
+        && !(declarationList.flags & typescript.NodeFlags.BlockScoped)
+        ? functionScope(declarationList.parent)
+        : lexicalScope(declarationList.parent)
+      add(scope, node.name)
+    }
+    else if (typescript.isParameter(node)) {
+      add(functionScope(node.parent), node.name)
+    }
+    else if ((typescript.isFunctionDeclaration(node) || typescript.isClassDeclaration(node))
+      && !isAmbientDeclaration(node)) {
+      add(lexicalScope(node.parent), node.name)
+    }
+    else if (typescript.isFunctionExpression(node)) {
+      add(node, node.name)
+    }
+    else if (typescript.isCatchClause(node)) {
+      add(node, node.variableDeclaration?.name)
+    }
+    typescript.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return bindings
+}
+
+function isAmbientDeclaration(node: ts.Node) {
+  for (let current: ts.Node | undefined = node; current; current = current.parent) {
+    if (typescript.isSourceFile(current))
+      return current.isDeclarationFile
+    if (hasModifier(current, typescript.SyntaxKind.DeclareKeyword))
+      return true
+  }
+  return false
+}
+
+function isRuntimeIdentifierReference(node: ts.Identifier) {
+  for (let current: ts.Node | undefined = node.parent; current; current = current.parent) {
+    if (typescript.isTypeNode(current))
+      return false
+    if (typescript.isExpression(current) || typescript.isStatement(current))
+      break
+  }
+  const parent = node.parent
+  if (typescript.isPropertyAccessExpression(parent) && parent.name === node)
+    return false
+  const namedParent = parent as ts.Node & { name?: ts.Node }
+  if (!typescript.isShorthandPropertyAssignment(parent) && namedParent.name === node)
+    return false
+  const propertyParent = parent as ts.Node & { propertyName?: ts.Node }
+  if (propertyParent.propertyName === node)
+    return false
+  const labeledParent = parent as ts.Node & { label?: ts.Node }
+  if (labeledParent.label === node)
+    return false
+  return true
+}
+
+export function rewriteRuntimeRelativeModuleSpecifiers(
+  source: string,
+  id: string,
+  rewrite: (specifier: string) => string,
+) {
+  const { sourceFile, specifiers } = collectRuntimeModuleSpecifiers(source, id)
+  const edits: Array<{ end: number, replacement: string, start: number }> = []
+
+  for (const { node, specifier } of specifiers) {
+    if (!/^\.\.?\//.test(specifier))
+      continue
+    const replacement = rewrite(specifier)
+    if (replacement !== specifier) {
+      edits.push({
+        start: node.getStart(sourceFile),
+        end: node.getEnd(),
+        replacement: JSON.stringify(replacement),
+      })
+    }
+  }
+
+  return edits
+    .sort((left, right) => right.start - left.start)
+    .reduce(
+      (contents, edit) => `${contents.slice(0, edit.start)}${edit.replacement}${contents.slice(edit.end)}`,
+      source,
+    )
 }
 
 function collectExplicitImportNames(sourceFile: ts.SourceFile) {

--- a/packages/sandbox/src/project.ts
+++ b/packages/sandbox/src/project.ts
@@ -144,7 +144,7 @@ function parseSandboxProjectOptions(manifest: PackageManifest, path: string): Sa
   return { timeout }
 }
 
-function parsePnpmWorkspacePackages(source: string) {
+export function parsePnpmWorkspacePackages(source: string) {
   const patterns: string[] = []
   let packagesIndent: number | undefined
   for (const line of source.split(/\r?\n/)) {
@@ -170,7 +170,7 @@ function parsePnpmWorkspacePackages(source: string) {
   return patterns
 }
 
-function isWorkspacePackage(path: string, patterns: readonly string[]) {
+export function isWorkspacePackage(path: string, patterns: readonly string[]) {
   const included = patterns.filter(pattern => !pattern.startsWith('!')).some(pattern => matchesGlob(path, pattern))
   return included && !patterns.filter(pattern => pattern.startsWith('!')).some(pattern => matchesGlob(path, pattern.slice(1)))
 }

--- a/packages/sandbox/test/project.test.ts
+++ b/packages/sandbox/test/project.test.ts
@@ -37,10 +37,451 @@ describe("resolveSandboxProject", () => {
     expect(project.options).toEqual({ timeout: 60_000 })
   })
 
-  it("rejects package imports that Node cannot resolve directly", async () => {
+  it("requires canonical package entrypoints to declare ESM semantics", async () => {
     const root = await createRoot()
     const entry = join(root, "index.ts")
     await writeFile(join(root, "package.json"), JSON.stringify({ private: true }))
+    await writeFile(entry, "export default null\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('must set "type" to "module"')
+  })
+
+  it.each(["cjs", "cts"])("rejects local CommonJS .%s modules", async (extension) => {
+    const root = await createRoot()
+    const entry = join(root, "index.ts")
+    await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module" }))
+    await writeFile(join(root, `helper.${extension}`), "export default true\n")
+    await writeFile(entry, `import helper from './helper.${extension}'\nexport default helper\n`)
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow(`imports CommonJS module "./helper.${extension}"`)
+  })
+
+  it.each([
+    ["const helper = require('./helper.js')\nexport default helper\n", "require()"],
+    ["const target = './helper.js'\nconst helper = require(target)\nexport default helper\n", "require()"],
+    ["const path = require.resolve('./helper.js')\nexport default path\n", "require.resolve"],
+    ["module.exports = { helper: true }\n", "module.exports assignment"],
+    ["exports.helper = true\n", "exports assignment"],
+    ["Object.defineProperty(exports, '__esModule', { value: true })\n", "exports reference"],
+    ["Object.assign(module.exports, { helper: true })\n", "module reference"],
+    ["import type { exports } from './types.d.ts'\nObject.assign(exports, { helper: true })\n", "exports reference"],
+    ["declare const module: { exports: unknown }\nObject.assign(module.exports, { helper: true })\n", "module reference"],
+    ["declare function require(id: string): unknown\nexport default require('helper')\n", "require()"],
+    ["import helper = require('./helper.js')\nexport default helper\n", "import = require()"],
+  ])("rejects CommonJS package syntax", async (contents, syntax) => {
+    const root = await createRoot()
+    const entry = join(root, "index.ts")
+    await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module" }))
+    await writeFile(join(root, "helper.js"), "export default true\n")
+    await writeFile(join(root, "types.d.ts"), "export interface exports {}\n")
+    await writeFile(entry, contents)
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow(`uses CommonJS ${syntax}`)
+  })
+
+  it("allows locally bound CommonJS-like identifiers", async () => {
+    const root = await createRoot()
+    const entry = join(root, "index.ts")
+    await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module" }))
+    await writeFile(entry, [
+      "const require = (value: string) => value",
+      "const module = { exports: true }",
+      "const exports = { helper: true }",
+      "export default { exports, module: module.exports, value: require('ok') }",
+      "",
+    ].join("\n"))
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).resolves.toMatchObject({ entry: "index.ts.mjs" })
+  })
+
+  it("allows CommonJS-like type and class property names", async () => {
+    const root = await createRoot()
+    const entry = join(root, "index.ts")
+    await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module" }))
+    await writeFile(entry, [
+      "interface SandboxPayload { module: string; exports: string }",
+      "class Result { module = 'esm'; exports = 'value' }",
+      "const { module: kind, exports: value } = new Result()",
+      "module: { if (kind) break module }",
+      "export default { module: kind, exports: value } satisfies SandboxPayload",
+      "",
+    ].join("\n"))
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).resolves.toMatchObject({ entry: "index.ts.mjs" })
+  })
+
+  it("rejects non-literal dynamic imports", async () => {
+    const root = await createRoot()
+    const entry = join(root, "index.ts")
+    await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module" }))
+    await writeFile(join(root, "helper.ts"), "export default true\n")
+    await writeFile(entry, "const extension = 'ts'\nexport default await import('./helper.' + extension)\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow("uses a non-literal dynamic import")
+  })
+
+  it("rejects zero-argument dynamic imports with the package diagnostic", async () => {
+    const root = await createRoot()
+    const entry = join(root, "index.ts")
+    await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module" }))
+    await writeFile(entry, "export default import()\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow("uses a non-literal dynamic import")
+  })
+
+  it.each([
+    ["/tmp/outside.mjs"],
+    ["file:///tmp/outside.mjs"],
+    ["data:text/javascript,export default true"],
+  ])("rejects absolute and URL package imports from %s", async (specifier) => {
+    const root = await createRoot()
+    const entry = join(root, "index.ts")
+    await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module" }))
+    await writeFile(entry, `import value from ${JSON.stringify(specifier)}\nexport default value\n`)
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow(`imports absolute or URL module "${specifier}"`)
+  })
+
+  it.each([
+    ["#helper", "imports package alias"],
+    ["@fixture/sandbox/helper", "self-imports"],
+  ])("rejects project-local package indirection through %s", async (specifier, message) => {
+    const root = await createRoot()
+    const entry = join(root, "index.ts")
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      imports: { "#helper": "./helper.ts" },
+      name: "@fixture/sandbox",
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(root, "helper.ts"), "export default true\n")
+    await writeFile(entry, `import helper from ${JSON.stringify(specifier)}\nexport default helper\n`)
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow(message)
+  })
+
+  it("rejects relative imports that escape the selected package", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(helper, { recursive: true })])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({ exports: "./index.js", name: "@fixture/helper", type: "module" }))
+    await writeFile(join(helper, "index.js"), "export default true\n")
+    await writeFile(join(helper, "index.ts"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '../../packages/helper/index.ts'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('imports "../../packages/helper/index.ts" outside its package')
+  })
+
+  it("rejects TypeScript runtime exports from captured workspace dependencies", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    const fixture = join(sandbox, "fixtures/helper")
+    await Promise.all([
+      mkdir(fixture, { recursive: true }),
+      mkdir(helper, { recursive: true }),
+    ])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({
+      exports: { import: { types: "./index.d.ts" }, default: "./index.ts" },
+      name: "@fixture/helper",
+      type: "module",
+    }))
+    await writeFile(join(helper, "index.d.ts"), "declare const value: true\nexport default value\n")
+    await writeFile(join(helper, "index.ts"), "export default true\n")
+    await writeFile(join(fixture, "package.json"), JSON.stringify({
+      exports: "./index.js",
+      name: "@fixture/helper",
+      type: "module",
+    }))
+    await writeFile(join(fixture, "index.js"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/helper'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('workspace dependency "@fixture/helper" exposes TypeScript runtime target "./index.ts"')
+  })
+
+  it("rejects TypeScript runtime exports from the pnpm workspace root", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    await mkdir(sandbox, { recursive: true })
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['.', 'sandboxes/*']\n")
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      exports: "./index.ts",
+      name: "@fixture/root",
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(root, "index.ts"), "export default true\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/root": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/root'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('workspace dependency "@fixture/root" exposes TypeScript runtime target "./index.ts"')
+  })
+
+  it("rejects TypeScript package subpath imports", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(helper, { recursive: true })])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({ name: "@fixture/helper", type: "module" }))
+    await writeFile(join(helper, "index.ts"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/helper/index.ts'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('workspace dependency "@fixture/helper" exposes TypeScript runtime target "./index.ts"')
+  })
+
+  it("allows TypeScript-named package subpaths that export runtime JavaScript", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(helper, { recursive: true })])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({
+      exports: { "./*.ts": "./dist/*.js" },
+      name: "@fixture/helper",
+      type: "module",
+    }))
+    await mkdir(join(helper, "dist"))
+    await writeFile(join(helper, "dist/index.js"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/helper/index.ts'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).resolves.toMatchObject({ entry: "sandboxes/image/index.ts.mjs" })
+  })
+
+  it("rejects TypeScript runtime targets selected by workspace export patterns", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(helper, { recursive: true })])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({
+      exports: { "./*": "./src/*.ts" },
+      name: "@fixture/helper",
+      type: "module",
+    }))
+    await mkdir(join(helper, "src"))
+    await writeFile(join(helper, "src/value.ts"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/helper/value'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('workspace dependency "@fixture/helper" exposes TypeScript runtime target "./src/value.ts"')
+  })
+
+  it("erases named type-only imports and exports without treating them as runtime edges", async () => {
+    const root = await createRoot()
+    const entry = join(root, "index.ts")
+    await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module" }))
+    await writeFile(join(root, "types.d.ts"), "export interface Input { ok: boolean }\n")
+    await writeFile(entry, [
+      "import { type Input } from './types.d.ts'",
+      "export { type Input as Output } from './types.d.ts'",
+      "const value: Input = { ok: true }",
+      "export default value",
+      "",
+    ].join("\n"))
+    const project = await resolveSandboxProject(entry, root)
+    const bundle = await bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })
+    const output = Buffer.from(bundle.project!.files["index.ts.mjs"]!.contents, "base64").toString()
+    expect(output).not.toContain("types.d.ts")
+    expect(output).toContain("export default value")
+  })
+
+  it("does not reject unused workspace development dependencies with TypeScript exports", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(helper, { recursive: true })])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      devDependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({ exports: "./index.ts", name: "@fixture/helper", type: "module" }))
+    await writeFile(join(helper, "index.ts"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "export default true\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).resolves.toMatchObject({ entry: "sandboxes/image/index.ts.mjs" })
+  })
+
+  it("ignores unrelated package manifests outside the runtime dependency graph", async () => {
+    const root = await createRoot()
+    const entry = join(root, "index.ts")
+    await Promise.all([
+      mkdir(join(root, "fixtures/invalid"), { recursive: true }),
+      mkdir(join(root, "fixtures/null"), { recursive: true }),
+      mkdir(join(root, "fixtures/sharp"), { recursive: true }),
+    ])
+    await writeFile(join(root, "package.json"), JSON.stringify({
+      dependencies: { sharp: "^0.34.0" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(root, "fixtures/invalid/package.json"), "not json")
+    await writeFile(join(root, "fixtures/null/package.json"), "null")
+    await writeFile(join(root, "fixtures/sharp/package.json"), JSON.stringify({
+      exports: "./index.ts",
+      name: "sharp",
+      type: "module",
+    }))
+    await writeFile(entry, "import sharp from 'sharp'\nexport default sharp\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).resolves.toMatchObject({ entry: "index.ts.mjs" })
+  })
+
+  it("prefers workspace exports over an ignored TypeScript main field", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(helper, { recursive: true })])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({
+      exports: "./dist/index.js",
+      main: "./src/index.ts",
+      name: "@fixture/helper",
+      type: "module",
+    }))
+    await mkdir(join(helper, "dist"))
+    await writeFile(join(helper, "dist/index.js"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/helper'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).resolves.toMatchObject({ entry: "sandboxes/image/index.ts.mjs" })
+  })
+
+  it("ignores inactive TypeScript workspace export conditions", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(helper, { recursive: true })])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({
+      exports: { development: "./src/index.ts", default: "./dist/index.js" },
+      name: "@fixture/helper",
+      type: "module",
+    }))
+    await mkdir(join(helper, "dist"))
+    await mkdir(join(helper, "src"))
+    await writeFile(join(helper, "dist/index.js"), "export default true\n")
+    await writeFile(join(helper, "src/index.ts"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/helper'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).resolves.toMatchObject({ entry: "sandboxes/image/index.ts.mjs" })
+  })
+
+  it("rejects package imports that Node cannot resolve directly", async () => {
+    const root = await createRoot()
+    const entry = join(root, "index.ts")
+    await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module" }))
     await writeFile(join(root, "helper.ts"), "export const ok = true\n")
     await writeFile(join(root, "unused.ts"), "export { missing } from './missing'\n")
     await writeFile(entry, "import { ok } from './helper'\nexport default { ok }\n")
@@ -56,7 +497,7 @@ describe("resolveSandboxProject", () => {
   it.each(["jsx", "tsx"])("rejects package %s imports that Node cannot execute directly", async (extension) => {
     const root = await createRoot()
     const entry = join(root, "index.ts")
-    await writeFile(join(root, "package.json"), JSON.stringify({ private: true }))
+    await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module" }))
     await writeFile(join(root, `helper.${extension}`), "export const element = <div />\n")
     await writeFile(entry, `import { element } from './helper.${extension}'\nexport default element\n`)
 
@@ -65,13 +506,26 @@ describe("resolveSandboxProject", () => {
     await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
       execution: "module",
       project,
-    })).rejects.toThrow(`imports "./helper.${extension}", but Node cannot execute JSX package files directly`)
+    })).rejects.toThrow(`imports JSX module "./helper.${extension}"`)
+  })
+
+  it("rejects package files that conflict with generated executables", async () => {
+    const root = await createRoot()
+    const entry = join(root, "index.ts")
+    await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module" }))
+    await writeFile(join(root, "index.ts.mjs"), "export default 'existing'\n")
+    await writeFile(entry, "export default 'source'\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('module "index.ts" conflicts with generated executable "index.ts.mjs"')
   })
 
   it("ignores invalid imports outside the executable package graph", async () => {
     const root = await createRoot()
     const entry = join(root, "index.ts")
-    await writeFile(join(root, "package.json"), JSON.stringify({ private: true }))
+    await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module" }))
     await writeFile(join(root, "unused.ts"), "export { missing } from './missing'\n")
     await writeFile(entry, "export default { ok: true }\n")
 
@@ -80,7 +534,7 @@ describe("resolveSandboxProject", () => {
     await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
       execution: "module",
       project,
-    })).resolves.toMatchObject({ entry: "index.ts", execution: "module" })
+    })).resolves.toMatchObject({ entry: "index.ts.mjs", execution: "module" })
   })
 
   it.each([
@@ -166,17 +620,17 @@ describe("resolveSandboxProject", () => {
     expect(project.files).toHaveProperty("packages/second/index.js")
   })
 
-  it("installs and executes a transitive workspace dependency", { timeout: 30_000 }, async () => {
+  it("executes TypeScript package projects without runtime type stripping", { timeout: 30_000 }, async () => {
     const root = await createRoot()
     const sandbox = join(root, "sandboxes/image")
     const first = join(root, "packages/first")
     const second = join(root, "packages/second")
     await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(first, { recursive: true }), mkdir(second, { recursive: true })])
     await writeFile(join(root, "pnpm-workspace.yaml"), "packages:\n  - sandboxes/*\n  - packages/*\n")
-    await writeFile(join(sandbox, "package.json"), JSON.stringify({ dependencies: { "@fixture/first": "workspace:*" }, private: true }))
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({ dependencies: { "@fixture/first": "workspace:*" }, private: true, type: "module" }))
     await mkdir(join(sandbox, "lib"))
     await writeFile(join(sandbox, "lib/prompt.md"), "relative helper asset")
-    await writeFile(join(sandbox, "lib/helper.ts"), [
+    await writeFile(join(sandbox, "lib/helper.mts"), [
       "import { readFile } from 'node:fs/promises'",
       "export const asset = await readFile(new URL('./prompt.md', import.meta.url), 'utf8')",
       "",
@@ -190,31 +644,39 @@ describe("resolveSandboxProject", () => {
     await writeFile(definitionFile, [
       "import { readFile } from 'node:fs/promises'",
       "import { value } from '@fixture/first'",
-      "import { asset } from './lib/helper.ts'",
-      "const { payload, context } = JSON.parse(await readFile(process.argv[2], 'utf8'))",
+      "import { asset } from './lib/helper.mts'",
+      "interface SandboxPayload { nested: boolean }",
+      "const { payload, context } = JSON.parse(await readFile(process.argv[2], 'utf8')) as { context: unknown, payload: SandboxPayload }",
       "await Promise.resolve()",
       "export default { asset, context, payload, value }",
       "",
     ].join("\n"))
-
     const project = await resolveSandboxProject(definitionFile, root)
     expect(project.files).toHaveProperty("sandboxes/image/lib/prompt.md")
     const bundle = await bundleSandboxDefinition(await readFile(definitionFile, "utf8"), definitionFile, {
       execution: "module",
       project,
     })
+    expect(bundle.entry).toBe("sandboxes/image/index.ts.mjs")
+    expect(bundle.project?.files).toHaveProperty("sandboxes/image/lib/helper.mts.mjs")
     const box = await resolveBox({ runtime: trustedHost() }, {}, { requires: ["node", "pnpm"] })
     const session = await box.open()
     try {
-      const execution = createSandboxExecutionBox(session, "vercel")
+      const execution = createSandboxExecutionBox(session, "cloudflare")
       const root = dirname(session.cwd)
       const physical = (path: string) => path.startsWith('/') ? join(root, path) : path
       const exec = execution.exec
       const writeFile = execution.writeFile
-      execution.exec = async (command, args = [], options) => await exec(command, args.map(physical), {
-        ...options,
-        cwd: options?.cwd && physical(options.cwd),
-      })
+      execution.exec = async (command, args = [], options) => {
+        const physicalArgs = args.map(physical)
+        const runtimeArgs = command === "node" && args[0] === "-e" && args[1] === "import(process.argv[1])"
+          ? ["--no-experimental-strip-types", ...physicalArgs]
+          : physicalArgs
+        return await exec(command, runtimeArgs, {
+          ...options,
+          cwd: options?.cwd && physical(options.cwd),
+        })
+      }
       execution.writeFile = async (path, contents) => await writeFile(path, contents.replaceAll('/tmp/vitehub-sandbox', `${root}/tmp/vitehub-sandbox`))
       await expect(executeSandboxDefinition(
         execution,

--- a/packages/sandbox/test/project.test.ts
+++ b/packages/sandbox/test/project.test.ts
@@ -419,6 +419,32 @@ describe("resolveSandboxProject", () => {
     })).resolves.toMatchObject({ entry: "sandboxes/image/index.ts.mjs" })
   })
 
+  it("rejects imported workspace development dependencies with TypeScript exports", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(helper, { recursive: true })])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      devDependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({
+      exports: "./index.ts",
+      name: "@fixture/helper",
+      type: "module",
+    }))
+    await writeFile(join(helper, "index.ts"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/helper'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('workspace dependency "@fixture/helper" exposes TypeScript runtime target "./index.ts"')
+  })
+
   it("ignores unrelated package manifests outside the runtime dependency graph", async () => {
     const root = await createRoot()
     const entry = join(root, "index.ts")
@@ -502,6 +528,34 @@ describe("resolveSandboxProject", () => {
       execution: "module",
       project,
     })).resolves.toMatchObject({ entry: "sandboxes/image/index.ts.mjs" })
+  })
+
+  it("rejects TypeScript workspace exports selected by module-sync", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(helper, { recursive: true })])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({
+      exports: { "module-sync": "./index.ts", default: "./dist/index.js" },
+      name: "@fixture/helper",
+      type: "module",
+    }))
+    await writeFile(join(helper, "index.ts"), "export default true\n")
+    await mkdir(join(helper, "dist"))
+    await writeFile(join(helper, "dist/index.js"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/helper'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('workspace dependency "@fixture/helper" exposes TypeScript runtime target "./index.ts"')
   })
 
   it("rejects package imports that Node cannot resolve directly", async () => {

--- a/packages/sandbox/test/project.test.ts
+++ b/packages/sandbox/test/project.test.ts
@@ -247,6 +247,32 @@ describe("resolveSandboxProject", () => {
     })).rejects.toThrow('workspace dependency "@fixture/helper" exposes TypeScript runtime target "./index.ts"')
   })
 
+  it("continues past invalid workspace export array targets", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(helper, { recursive: true })])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({
+      exports: ["invalid-target", "./index.ts"],
+      name: "@fixture/helper",
+      type: "module",
+    }))
+    await writeFile(join(helper, "index.ts"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/helper'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('workspace dependency "@fixture/helper" exposes TypeScript runtime target "./index.ts"')
+  })
+
   it("rejects TypeScript runtime exports from the pnpm workspace root", async () => {
     const root = await createRoot()
     const sandbox = join(root, "sandboxes/image")

--- a/packages/sandbox/test/project.test.ts
+++ b/packages/sandbox/test/project.test.ts
@@ -247,6 +247,33 @@ describe("resolveSandboxProject", () => {
     })).rejects.toThrow('workspace dependency "@fixture/helper" exposes TypeScript runtime target "./index.ts"')
   })
 
+  it("rejects TypeScript edges behind workspace JavaScript exports", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(helper, { recursive: true })])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({
+      exports: "./index.js",
+      name: "@fixture/helper",
+      type: "module",
+    }))
+    await writeFile(join(helper, "index.js"), "import value from './helper.ts'\nexport default value\n")
+    await writeFile(join(helper, "helper.ts"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/helper'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('workspace dependency "@fixture/helper" exposes TypeScript runtime target "./helper.ts"')
+  })
+
   it("continues past invalid workspace export array targets", async () => {
     const root = await createRoot()
     const sandbox = join(root, "sandboxes/image")

--- a/packages/sandbox/test/project.test.ts
+++ b/packages/sandbox/test/project.test.ts
@@ -74,6 +74,17 @@ describe("resolveSandboxProject", () => {
     ["declare const module: { exports: unknown }\nObject.assign(module.exports, { helper: true })\n", "module reference"],
     ["declare function require(id: string): unknown\nexport default require('helper')\n", "require()"],
     ["import helper = require('./helper.js')\nexport default helper\n", "import = require()"],
+    ["for (const require of []) void require\nexport default require('helper')\n", "require()"],
+    ["for (const key in {}) { const exports = key; void exports }\nexport default exports\n", "exports reference"],
+    ["for (let module = 0; module < 1; module++) {}\nexport default module\n", "module reference"],
+    ["switch (true) { case true: { const exports = true; void exports; break } }\nexport default exports\n", "exports reference"],
+    ["class Value { static { var require = (value: string) => value; require('ok') } }\nexport default require('helper')\n", "require()"],
+    ["export default { module }\n", "module reference"],
+    ["export { module as value }\n", "module reference"],
+    ["const Value = class module { static self = module }\nexport default module\n", "module reference"],
+    ["const { value = module } = {}\nexport default value\n", "module reference"],
+    ["const [value = exports] = []\nexport default value\n", "exports reference"],
+    ["const { value: { nested = module } = {} } = {}\nexport default nested\n", "module reference"],
   ])("rejects CommonJS package syntax", async (contents, syntax) => {
     const root = await createRoot()
     const entry = join(root, "index.ts")
@@ -118,6 +129,76 @@ describe("resolveSandboxProject", () => {
       "export default { module: kind, exports: value } satisfies SandboxPayload",
       "",
     ].join("\n"))
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).resolves.toMatchObject({ entry: "index.ts.mjs" })
+  })
+
+  it.each([
+    [
+      "class expression self binding",
+      "const Value = class module { static self = module }\nexport default Value\n",
+    ],
+    [
+      "enum runtime binding",
+      "enum module { value = 'esm' }\nexport default module.value\n",
+    ],
+    [
+      "namespace runtime binding",
+      "namespace module { export const value = 'esm' }\nexport default module.value\n",
+    ],
+    [
+      "erased type export",
+      "type module = string\nexport type { module }\nexport default true\n",
+    ],
+    [
+      "erased inline type export",
+      "type module = string\nexport { type module }\nexport default true\n",
+    ],
+    [
+      "runtime import alias",
+      "import { module as value } from './source.js'\nexport default value\n",
+    ],
+    [
+      "runtime re-export alias",
+      "export { module as value } from './source.js'\nexport default true\n",
+    ],
+    [
+      "exported name alias",
+      "const value = true\nexport { value as module }\nexport default value\n",
+    ],
+    [
+      "destructuring property names",
+      "const { module: value, exports: other } = { module: true, exports: true }\nexport default value && other\n",
+    ],
+    [
+      "statement labels",
+      "module: { break module }\nexport default true\n",
+    ],
+    [
+      "loop-local binding",
+      "for (const require of ['ok']) require.toUpperCase()\nexport default true\n",
+    ],
+    [
+      "switch-local binding",
+      "switch (true) { case true: { const exports = true; void exports; break } }\nexport default true\n",
+    ],
+    [
+      "class static block binding",
+      "class Value { static { var require = (value: string) => value; require('ok') } }\nexport default Value\n",
+    ],
+    [
+      "delayed destructuring self-capture",
+      "const { module = () => module } = {}\nexport default module()\n",
+    ],
+  ])("allows %s in emitted package modules", async (_name, contents) => {
+    const root = await createRoot()
+    const entry = join(root, "index.ts")
+    await writeFile(join(root, "package.json"), JSON.stringify({ private: true, type: "module" }))
+    await writeFile(join(root, "source.js"), "export const module = 'esm'\n")
+    await writeFile(entry, contents)
     const project = await resolveSandboxProject(entry, root)
     await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
       execution: "module",

--- a/packages/sandbox/test/project.test.ts
+++ b/packages/sandbox/test/project.test.ts
@@ -355,6 +355,70 @@ describe("resolveSandboxProject", () => {
     })).rejects.toThrow('workspace dependency "@fixture/helper" exposes TypeScript runtime target "./helper.ts"')
   })
 
+  it("rejects TypeScript workspace subpaths imported by dependency JavaScript", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const first = join(root, "packages/first")
+    const second = join(root, "packages/second")
+    await Promise.all([
+      mkdir(sandbox, { recursive: true }),
+      mkdir(first, { recursive: true }),
+      mkdir(join(second, "src"), { recursive: true }),
+    ])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/first": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(first, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/second": "workspace:*" },
+      exports: "./index.js",
+      name: "@fixture/first",
+      type: "module",
+    }))
+    await writeFile(join(first, "index.js"), "export { default } from '@fixture/second/source'\n")
+    await writeFile(join(second, "package.json"), JSON.stringify({
+      exports: { "./source": "./src/source.ts" },
+      name: "@fixture/second",
+      type: "module",
+    }))
+    await writeFile(join(second, "src/source.ts"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/first'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('workspace dependency "@fixture/second" exposes TypeScript runtime target "./src/source.ts"')
+  })
+
+  it("validates the default index.js workspace entry", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(helper, { recursive: true })])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({
+      name: "@fixture/helper",
+      type: "module",
+    }))
+    await writeFile(join(helper, "index.js"), "export { default } from './helper.ts'\n")
+    await writeFile(join(helper, "helper.ts"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/helper'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('workspace dependency "@fixture/helper" exposes TypeScript runtime target "./helper.ts"')
+  })
+
   it("continues past invalid workspace export array targets", async () => {
     const root = await createRoot()
     const sandbox = join(root, "sandboxes/image")

--- a/packages/sandbox/test/project.test.ts
+++ b/packages/sandbox/test/project.test.ts
@@ -355,6 +355,34 @@ describe("resolveSandboxProject", () => {
     })).rejects.toThrow('workspace dependency "@fixture/helper" exposes TypeScript runtime target "./helper.ts"')
   })
 
+  it("rejects TypeScript workspace package import aliases", async () => {
+    const root = await createRoot()
+    const sandbox = join(root, "sandboxes/image")
+    const helper = join(root, "packages/helper")
+    await Promise.all([mkdir(sandbox, { recursive: true }), mkdir(helper, { recursive: true })])
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages: ['sandboxes/*', 'packages/*']\n")
+    await writeFile(join(sandbox, "package.json"), JSON.stringify({
+      dependencies: { "@fixture/helper": "workspace:*" },
+      private: true,
+      type: "module",
+    }))
+    await writeFile(join(helper, "package.json"), JSON.stringify({
+      exports: "./index.js",
+      imports: { "#internal": "./helper.ts" },
+      name: "@fixture/helper",
+      type: "module",
+    }))
+    await writeFile(join(helper, "index.js"), "export { default } from '#internal'\n")
+    await writeFile(join(helper, "helper.ts"), "export default true\n")
+    const entry = join(sandbox, "index.ts")
+    await writeFile(entry, "import helper from '@fixture/helper'\nexport default helper\n")
+    const project = await resolveSandboxProject(entry, root)
+    await expect(bundleSandboxDefinition(await readFile(entry, "utf8"), entry, {
+      execution: "module",
+      project,
+    })).rejects.toThrow('workspace dependency "@fixture/helper" exposes TypeScript runtime target "./helper.ts" through package import "#internal"')
+  })
+
   it("rejects TypeScript workspace subpaths imported by dependency JavaScript", async () => {
     const root = await createRoot()
     const sandbox = join(root, "sandboxes/image")

--- a/packages/sandbox/test/vite.test.ts
+++ b/packages/sandbox/test/vite.test.ts
@@ -331,6 +331,7 @@ describe("hubSandbox", () => {
     await writeFile(join(rootDir, "src/server.ts"), `export const ready = true\n`)
     await writeFile(join(packageRoot, "package.json"), JSON.stringify({
       private: true,
+      type: "module",
       vitehub: { sandbox: { timeout: 30_000 } },
     }))
     await writeFile(join(packageRoot, "helper.ts"), `export const ok = true\n`)
@@ -1085,6 +1086,7 @@ describe("hubSandbox", () => {
     await mkdir(projectDir, { recursive: true })
     await writeFile(manifest, JSON.stringify({
       private: true,
+      type: "module",
       vitehub: { sandbox: { timeout: 30_000 } },
     }))
     await writeFile(definition, "export default { ok: true }\n")
@@ -1129,6 +1131,7 @@ describe("hubSandbox", () => {
     await expect(readTimeout()).resolves.toBe(30_000)
     await writeFile(manifest, JSON.stringify({
       private: true,
+      type: "module",
       vitehub: { sandbox: { timeout: 60_000 } },
     }))
     await handleHotUpdate({
@@ -1180,7 +1183,7 @@ describe("hubSandbox", () => {
 
     const registry = join(rootDir, ".vitehub/sandbox/runtime/sandbox-registry.mjs")
     await expect(readFile(registry, "utf8")).resolves.not.toContain('"example"')
-    await writeFile(manifest, JSON.stringify({ private: true }))
+    await writeFile(manifest, JSON.stringify({ private: true, type: "module" }))
 
     const handleHotUpdate = plugin.handleHotUpdate as unknown as (context: {
       file: string


### PR DESCRIPTION
Canonical Sandbox package projects now run top-level `index.ts` without importing `defineSandbox`. ViteHub compiles the reachable local `.ts` and `.mts` ESM graph to sibling `.mjs` files while preserving package layout, relative assets, `import.meta.url`, and bare runtime dependencies. Static policy remains in the adjacent `package.json` under `vitehub.sandbox`.

The package boundary now requires `"type": "module"` and rejects CommonJS syntax, non-literal imports, package-local aliases and self-references, path escapes, JSX, generated-file collisions, and reachable workspace dependencies that expose TypeScript runtime entries. Regression coverage executes the generated project with Node type stripping disabled and exercises the packed Drop image optimizer with native Sharp.

Refs #776 and #788.