### PR TITLE
feat(agent): add controllable child invocations

### DIFF
--- a/docs/content/docs/agents/controlled-child-invocations.md
+++ b/docs/content/docs/agents/controlled-child-invocations.md
@@ -1,0 +1,62 @@
+---
+title: Controlled child invocations
+description: Start, inspect, and cancel a child Agent Invocation without assuming durable runtime support.
+navigation.order: 23.5
+icon: i-lucide-workflow
+---
+
+Use `startAgentInvocation()` when trusted parent or host code needs to control a child after starting it. The call returns after the selected runtime accepts the start and establishes the child Agent Invocation id.
+
+```ts
+import { startAgentInvocation } from '@vite-hub/agent'
+import researcher from '../agents/researcher'
+
+const child = await startAgentInvocation(researcher, runtimeContext, {
+  prompt: 'Compare the two deployment options.',
+})
+
+const current = await child.inspect()
+if (current.outcome === 'available') {
+  console.log(current.invocation.id, current.invocation.status)
+}
+```
+
+Every start receives a fresh id. The id is stable for that logical invocation, but it does not promise that an inline or serverless runtime can resolve the child after the process ends. Workflow-backed children delegate inspection to their Workflow Run while the returned controller remains available; ViteHub does not add an invocation registry, persistence, or public lookup by id.
+
+## Inspect lifecycle
+
+`inspect()` returns either an available snapshot or an explicit unavailable outcome. Snapshots normalize the lifecycle to `pending`, `running`, `completed`, `failed`, or `cancelled`, and include terminal output or error only when the selected runtime owns it.
+
+An unavailable outcome is not another lifecycle state. It means the selected runtime cannot currently resolve the invocation.
+
+## Cancel active work
+
+```ts
+const cancellation = await child.cancel('The parent no longer needs this work.')
+
+if (cancellation.outcome === 'accepted') {
+  const latest = await child.inspect()
+}
+```
+
+Inline cancellation propagates through a child-owned `AbortSignal`. Workflow-backed cancellation delegates to the selected Workflow provider. `accepted` means the cancellation request was accepted; inspect again for the observed terminal state. Providers can return `unsupported`, and completed or failed invocations return `invalid-state` instead of pretending they were cancelled.
+
+## Discover input support
+
+Follow-up and active steering are separate operations. Follow-up continues explicit context in a later invocation, while steering changes active work. Check both before sending input, and still handle the operation result because support can depend on lifecycle state.
+
+```ts
+if (child.support.steer) {
+  const result = await child.sendInput({ prompt: 'Focus on the migration risk.' }, {
+    mode: 'steer',
+  })
+}
+```
+
+Current built-in runtimes report follow-up and steering as `unsupported`; ViteHub does not reinterpret Harness session reuse or generic Workflow signals as Agent input. A runtime adapter must provide real ordering and lifecycle semantics before either support flag becomes true.
+
+## Subagents
+
+The `subagents()` Capability uses the same lower Agent Invocation start seam, but keeps its model-facing tool result serializable. Each tool call receives a fresh trusted child id and awaits the same compatibility result that `runAgent()` returned previously; the model cannot choose or reuse the child id.
+
+Use `subagents()` for bounded model-selected delegation. Use `startAgentInvocation()` when trusted code needs the controller.

--- a/docs/content/docs/capabilities/subagents.md
+++ b/docs/content/docs/capabilities/subagents.md
@@ -45,7 +45,7 @@ export default defineAgent({
 ## Runtime behavior
 
 `subagents()` validates the configured names and tool names before the Agent runs.
-At invocation time, each subagent tool calls `runAgent()` with the parent runtime context and a child run id derived from the parent run id when available.
+At invocation time, each subagent tool starts a fresh child Agent Invocation with the parent runtime context, then awaits the existing serializable Agent result. The model cannot select or reuse the child invocation id.
 
 ## Requirements
 
@@ -76,6 +76,7 @@ Cover delegation guidance in Agent Driver Instructions with explicit Capability 
 
 Open Agent DevTools and confirm each subagent appears as a tool with the expected name and description.
 Run one delegated task and verify the child invocation id and inherited invoker metadata.
+Use [`startAgentInvocation()`](/docs/agents/controlled-child-invocations) from trusted code when the caller needs to inspect or cancel the child after start.
 
 ## Reference
 

--- a/packages/agent/src/agent-invocation.ts
+++ b/packages/agent/src/agent-invocation.ts
@@ -1,0 +1,220 @@
+import type { AgentRunInput } from "./types.ts"
+
+export type AgentInvocationStatus = "pending" | "running" | "completed" | "failed" | "cancelled"
+
+export interface AgentInvocationSnapshot<TOutput = unknown> {
+  error?: unknown
+  id: string
+  output?: TOutput
+  status: AgentInvocationStatus
+}
+
+export type AgentInvocationInspection<TOutput = unknown> =
+  | { invocation: AgentInvocationSnapshot<TOutput>, outcome: "available" }
+  | { id: string, outcome: "unavailable" }
+
+export type AgentInvocationControlOutcome = "accepted" | "unsupported" | "unavailable" | "invalid-state"
+
+export interface AgentInvocationControlResult<TOutput = unknown> {
+  id: string
+  invocation?: AgentInvocationSnapshot<TOutput>
+  outcome: AgentInvocationControlOutcome
+}
+
+export type AgentInvocationInputMode = "follow-up" | "steer"
+
+export interface AgentInvocationInputSupport {
+  followUp: boolean
+  steer: boolean
+}
+
+export interface AgentInvocationController<
+  TOutput = unknown,
+  CALL_OPTIONS = unknown,
+> {
+  cancel: (reason?: unknown) => Promise<AgentInvocationControlResult<TOutput>>
+  id: string
+  inspect: () => Promise<AgentInvocationInspection<TOutput>>
+  sendInput: (
+    input: AgentRunInput<CALL_OPTIONS>,
+    options: { mode: AgentInvocationInputMode },
+  ) => Promise<AgentInvocationControlResult<TOutput>>
+  support: AgentInvocationInputSupport
+}
+
+export interface AgentInvocationControllerAdapter<
+  TOutput = unknown,
+  CALL_OPTIONS = unknown,
+> {
+  cancel: (reason?: unknown) => Promise<AgentInvocationControlResult<TOutput>>
+  inspect: () => Promise<AgentInvocationInspection<TOutput>>
+  sendInput?: (
+    input: AgentRunInput<CALL_OPTIONS>,
+    options: { mode: AgentInvocationInputMode },
+  ) => Promise<AgentInvocationControlResult<TOutput>>
+  support?: Partial<AgentInvocationInputSupport>
+}
+
+export type AgentInvocationFinishOutcome<TOutput = unknown> =
+  | { output?: TOutput, status: "completed" }
+  | { error: unknown, status: "failed" }
+
+export interface LiveAgentInvocationOptions<TOutput = unknown> {
+  parentAbortSignal?: AbortSignal
+  start: (context: {
+    abortSignal: AbortSignal
+    id: string
+    onFinish: (outcome: AgentInvocationFinishOutcome<TOutput>) => void
+  }) => Promise<unknown>
+}
+
+export interface BackedAgentInvocationOptions<TOutput = unknown> {
+  cancel: () => Promise<AgentInvocationSnapshot<TOutput> | undefined>
+  errorOutcome: (error: unknown) => "unsupported" | "unavailable"
+  id: string
+  inspect: () => Promise<AgentInvocationSnapshot<TOutput> | undefined>
+  parentAbortSignal?: AbortSignal
+  result: Promise<unknown>
+}
+
+const agentInvocationResult = Symbol.for("vitehub.agentInvocationResult")
+
+type InternalAgentInvocationController = AgentInvocationController & {
+  [agentInvocationResult]: Promise<unknown>
+}
+
+export function createAgentInvocationController<
+  TOutput = unknown,
+  CALL_OPTIONS = unknown,
+>(
+  id: string,
+  adapter: AgentInvocationControllerAdapter<TOutput, CALL_OPTIONS>,
+  result: Promise<unknown>,
+): AgentInvocationController<TOutput, CALL_OPTIONS> {
+  const support: AgentInvocationInputSupport = Object.freeze({
+    followUp: adapter.support?.followUp === true,
+    steer: adapter.support?.steer === true,
+  })
+  const controller = {
+    cancel: adapter.cancel,
+    id,
+    inspect: adapter.inspect,
+    sendInput: adapter.sendInput || (async () => ({ id, outcome: "unsupported" })),
+    support,
+  }
+  Object.defineProperty(controller, agentInvocationResult, { value: result })
+  return Object.freeze(controller)
+}
+
+export function awaitAgentInvocationResult(controller: AgentInvocationController): Promise<unknown> {
+  return (controller as InternalAgentInvocationController)[agentInvocationResult]
+}
+
+function randomAgentInvocationId(): string {
+  return `ainv_${globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)}`
+}
+
+function isTerminalAgentInvocationStatus(status: AgentInvocationStatus): boolean {
+  return status === "completed" || status === "failed" || status === "cancelled"
+}
+
+export function startLiveAgentInvocation<TOutput = unknown, CALL_OPTIONS = unknown>(
+  options: LiveAgentInvocationOptions<TOutput>,
+): AgentInvocationController<TOutput, CALL_OPTIONS> {
+  const id = randomAgentInvocationId()
+  const abortController = new AbortController()
+  const abortSignal = options.parentAbortSignal
+    ? AbortSignal.any([options.parentAbortSignal, abortController.signal])
+    : abortController.signal
+  let snapshot: AgentInvocationSnapshot<TOutput> = { id, status: "running" }
+  let observedFinish = false
+  const result = options.start({
+    abortSignal,
+    id,
+    onFinish(outcome) {
+      observedFinish = true
+      snapshot = outcome.status === "completed"
+        ? { id, ...(outcome.output !== undefined ? { output: outcome.output } : {}), status: "completed" }
+        : abortSignal.aborted
+          ? { id, status: "cancelled" }
+          : { error: outcome.error, id, status: "failed" }
+    },
+  })
+  void result.catch((error) => {
+    if (observedFinish) return
+    snapshot = abortSignal.aborted
+      ? { id, status: "cancelled" }
+      : { error, id, status: "failed" }
+  })
+  return createAgentInvocationController<TOutput, CALL_OPTIONS>(id, {
+    async cancel(reason) {
+      if (isTerminalAgentInvocationStatus(snapshot.status)) {
+        return { id, invocation: { ...snapshot }, outcome: "invalid-state" }
+      }
+      abortController.abort(reason)
+      return { id, invocation: { ...snapshot }, outcome: "accepted" }
+    },
+    async inspect() {
+      return { invocation: { ...snapshot }, outcome: "available" }
+    },
+    async sendInput() {
+      return { id, invocation: { ...snapshot }, outcome: "unsupported" }
+    },
+  }, result)
+}
+
+export function createBackedAgentInvocationController<TOutput = unknown, CALL_OPTIONS = unknown>(
+  options: BackedAgentInvocationOptions<TOutput>,
+): AgentInvocationController<TOutput, CALL_OPTIONS> {
+  let removeParentAbortListener: (() => void) | undefined
+  const observeTerminalSnapshot = (snapshot: AgentInvocationSnapshot<TOutput> | undefined) => {
+    if (snapshot && isTerminalAgentInvocationStatus(snapshot.status)) {
+      removeParentAbortListener?.()
+      removeParentAbortListener = undefined
+    }
+    return snapshot
+  }
+  const inspect = async (): Promise<AgentInvocationInspection<TOutput>> => {
+    try {
+      const snapshot = observeTerminalSnapshot(await options.inspect())
+      return snapshot
+        ? { invocation: snapshot, outcome: "available" }
+        : { id: options.id, outcome: "unavailable" }
+    }
+    catch {
+      return { id: options.id, outcome: "unavailable" }
+    }
+  }
+  const controller = createAgentInvocationController<TOutput, CALL_OPTIONS>(options.id, {
+    async cancel() {
+      try {
+        const snapshot = observeTerminalSnapshot(await options.cancel())
+        if (!snapshot) return { id: options.id, outcome: "unavailable" }
+        return {
+          id: options.id,
+          invocation: snapshot,
+          outcome: isTerminalAgentInvocationStatus(snapshot.status) && snapshot.status !== "cancelled"
+            ? "invalid-state"
+            : "accepted",
+        }
+      }
+      catch (error) {
+        return { id: options.id, outcome: options.errorOutcome(error) }
+      }
+    },
+    inspect,
+    async sendInput() {
+      return { id: options.id, outcome: "unsupported" }
+    },
+  }, options.result)
+  if (options.parentAbortSignal) {
+    const parentAbortSignal = options.parentAbortSignal
+    const cancel = () => void controller.cancel(parentAbortSignal.reason)
+    if (options.parentAbortSignal.aborted) cancel()
+    else {
+      parentAbortSignal.addEventListener("abort", cancel, { once: true })
+      removeParentAbortListener = () => parentAbortSignal.removeEventListener("abort", cancel)
+    }
+  }
+  return controller
+}

--- a/packages/agent/src/capabilities/subagents.ts
+++ b/packages/agent/src/capabilities/subagents.ts
@@ -1,4 +1,5 @@
 import { capabilityWorkspaceSources, defineCapability } from "../capability-runtime.ts"
+import { awaitAgentInvocationResult } from "../agent-invocation.ts"
 import { withResolvedAgentInvokerInput } from "../invoker.ts"
 
 import type {
@@ -22,7 +23,6 @@ export interface SubagentToolInput<
   context?: TContext
   message: string | Message
   options?: CALL_OPTIONS
-  runId?: string
   timeout?: number
 }
 
@@ -65,7 +65,6 @@ function inputSchema(description: string): JSONSchema7 {
       context: { additionalProperties: true, description: "Structured task context for the subagent.", type: "object" },
       message: { description, type: "string" },
       options: { additionalProperties: true, description: "Agent call options for the subagent.", type: "object" },
-      runId: { description: "Optional run id for this subagent invocation.", type: "string" },
       timeout: { description: "Optional timeout in milliseconds.", type: "number" },
     },
     required: ["message"],
@@ -118,14 +117,6 @@ function subagentWorkspaceSources(
   return Object.keys(sources).length ? sources : undefined
 }
 
-function randomToken(): string {
-  return globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)
-}
-
-function childRunId(parentRunId: string | undefined, name: string, runId: string | undefined): string | undefined {
-  return runId || (parentRunId ? `${parentRunId}:${name}:${randomToken()}` : undefined)
-}
-
 function createTool<TRuntimeConfig extends AgentRuntimeConfig>(
   definition: SubagentDefinition<TRuntimeConfig>,
   name: string,
@@ -134,14 +125,14 @@ function createTool<TRuntimeConfig extends AgentRuntimeConfig>(
   return {
     description: definition.description,
     async execute(input: unknown) {
-      const { runAgent } = await import("../index.ts")
-      const { runId, ...agentInput } = input as SubagentToolInput
+      const { startAgentInvocation } = await import("../index.ts")
       const runtimeContext = (parentContext.runtimeContext || parentContext) as AgentRuntimeContext<TRuntimeConfig>
-      const nextRunId = childRunId(runtimeContext.run?.runId, name, runId)
-      return await runAgent(definition.agent, {
-        ...runtimeContext,
-        ...(nextRunId ? { run: { ...runtimeContext.run, runId: nextRunId } } : {}),
-      }, withResolvedAgentInvokerInput(agentInput as AgentRunInput, parentContext.invoker))
+      const controller = await startAgentInvocation(
+        definition.agent,
+        runtimeContext,
+        withResolvedAgentInvokerInput(input as AgentRunInput, parentContext.invoker),
+      )
+      return await awaitAgentInvocationResult(controller)
     },
     inputSchema: inputSchema(definition.description),
     name,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,6 +6,10 @@ import { AgentOutputValidationError, validateAgentOutput } from "./internal/agen
 import { loadAgentWorkflowModule, loadAgentWorkflowRuntimeStateModule } from "./internal/workflow-runtime-loaders.ts"
 import { agentErrorDetails, agentErrorMessage } from "./agent-error.ts"
 import {
+  createBackedAgentInvocationController,
+  startLiveAgentInvocation,
+} from "./agent-invocation.ts"
+import {
   createReactionDeliveryEffectIntent,
   createReplyDeliveryEffectIntent,
   createStatusDeliveryEffectIntent,
@@ -140,6 +144,10 @@ import type {
   ResolvedAgentTriggerDefinition,
   ResolvedAgentRuntimeContext,
 } from "./types.ts"
+import type {
+  AgentInvocationController,
+  AgentInvocationSnapshot,
+} from "./agent-invocation.ts"
 import type { StreamEvent } from "./messages.ts"
 import type { AgentTraceContext } from "./trace.ts"
 import type { ResolvedAgentTriggerInvocation, ResolvedAgentTriggerInvocationResult } from "./trigger-runtime.ts"
@@ -158,6 +166,17 @@ import type {
 import type { WorkflowHandle } from "@vite-hub/workflow"
 import type { Box, BoxRequirement } from "@vite-hub/box"
 import { isHarnessBoxActive, shareBoxSessions } from "./harness/shared-box.ts"
+
+export type {
+  AgentInvocationControlOutcome,
+  AgentInvocationControlResult,
+  AgentInvocationController,
+  AgentInvocationInputMode,
+  AgentInvocationInputSupport,
+  AgentInvocationInspection,
+  AgentInvocationSnapshot,
+  AgentInvocationStatus,
+} from "./agent-invocation.ts"
 
 export type {
   AgentAccessInvocationContextValue,
@@ -554,7 +573,7 @@ type AgentDefinitionWithBaseResolve<
 }
 interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
   input: AgentRunInput<CALL_OPTIONS>
-  run?: AgentRunMetadata
+  run?: Partial<AgentRunMetadata>
   runtime?: AgentRuntimeContext["runtime"]
   runtimeConfig?: AgentRuntimeConfig
 }
@@ -565,6 +584,10 @@ interface AgentWorkflowRun<TOutput = unknown> {
   provider: string
   result?: TOutput
   status: "cancelled" | "completed" | "failed" | "queued" | "running" | "unknown"
+}
+interface StartedAgentWorkflow<CALL_OPTIONS = unknown, TOutput = unknown> {
+  handle: WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, TOutput>
+  run: AgentWorkflowRun<TOutput>
 }
 interface ScheduleRunContextLike {
   attemptId?: string
@@ -656,7 +679,8 @@ async function runAgentAsWorkflow<
   agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>, TOutput>,
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
-) {
+  options: { fresh?: boolean } = {},
+): Promise<StartedAgentWorkflow<CALL_OPTIONS, TOutput> | undefined> {
   const binding = resolveAgentWorkflowRuntimeBinding<TRuntimeConfig>(agent)
   if (!binding || ("discoveryDefault" in binding && !context.agentIdentity)) return undefined
   if ("discoveryDefault" in binding) {
@@ -676,12 +700,15 @@ async function runAgentAsWorkflow<
   const workflowInput = { ...input }
   // ponytail: AbortSignal is live process state and cannot cross a durable Workflow payload.
   delete workflowInput.abortSignal
+  const inheritedRun = options.fresh && context.run
+    ? Object.fromEntries(Object.entries(context.run).filter(([key]) => key !== "runId"))
+    : context.run
   const payload: AgentWorkflowInvocationPayload<CALL_OPTIONS> = {
     ...(context.agentIdentity ? { agentIdentity: context.agentIdentity } : {}),
     input: workflowInput,
     runtime: context.runtime,
     runtimeConfig: resolvedContext.runtimeConfig,
-    ...(context.run ? { run: context.run } : {}),
+    ...(inheritedRun ? { run: inheritedRun } : {}),
   }
   const workflowEvent = {
     ...(context.cloudflare?.env ? { env: context.cloudflare.env } : {}),
@@ -692,7 +719,11 @@ async function runAgentAsWorkflow<
     },
   }
   const { runWithWorkflowRuntimeEvent } = await loadAgentWorkflowRuntimeStateModule()
-  return await runWithWorkflowRuntimeEvent(workflowEvent, () => handle.run(payload, context.run?.runId ? { id: context.run.runId } : {}))
+  const run = await runWithWorkflowRuntimeEvent(workflowEvent, () => handle.run(
+    payload,
+    !options.fresh && context.run?.runId ? { id: context.run.runId } : {},
+  ))
+  return { handle, run }
 }
 
 function resolveRegistryModule<TContext extends AgentRuntimeContext>(
@@ -2305,8 +2336,11 @@ async function materializeAgentStructuredOutput(result: unknown, abortSignal?: A
 }
 
 type AgentInvocationExecutionOptions =
-  | { kind: "run", renderOutput: boolean }
-  | { kind: "stream", output: "events" | "ui-message-stream" }
+  & (
+    | { kind: "run", renderOutput: boolean }
+    | { kind: "stream", output: "events" | "ui-message-stream" }
+  )
+  & { onFinish?: (outcome: AgentInvocationFinishOutcome) => void }
 
 async function executeAgentInvocation<
   TRuntimeConfig extends AgentRuntimeConfig,
@@ -2325,7 +2359,16 @@ async function executeAgentInvocation<
     : undefined
   const invocation = await createAgentInvocationContext(definition, context, input)
   const lifecycle = await openAgentInvocationLifecycle<AgentInvocationFinishOutcome>(
-    outcome => finishAgentInvocation(invocation, outcome),
+    async (outcome) => {
+      try {
+        await finishAgentInvocation(invocation, outcome)
+        options.onFinish?.(outcome)
+      }
+      catch (error) {
+        options.onFinish?.({ error, status: "error" })
+        throw error
+      }
+    },
   )
 
   const runFailureMessage = "[vitehub] Agent run failed and finish lifecycle also failed."
@@ -2583,6 +2626,94 @@ export async function runAgentInline<
   }) as TOutput
 }
 
+function agentInvocationSnapshotFromWorkflow<TOutput>(
+  run: AgentWorkflowRun<TOutput>,
+): AgentInvocationSnapshot<TOutput> | undefined {
+  const status = run.status === "queued"
+    ? "pending"
+    : run.status === "unknown"
+      ? undefined
+      : run.status
+  if (!status) return undefined
+  return {
+    ...(run.status === "failed" && run.metadata !== undefined ? { error: run.metadata } : {}),
+    id: run.id,
+    ...(run.result !== undefined ? { output: run.result } : {}),
+    status,
+  }
+}
+
+function workflowOperationOutcome(error: unknown): "unsupported" | "unavailable" {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && (error as { code?: unknown }).code === "WORKFLOW_OPERATION_UNSUPPORTED"
+    ? "unsupported"
+    : "unavailable"
+}
+
+function createWorkflowAgentInvocationController<CALL_OPTIONS, TOutput>(
+  started: StartedAgentWorkflow<CALL_OPTIONS, TOutput>,
+  parentAbortSignal?: AbortSignal,
+): AgentInvocationController<TOutput | Response, CALL_OPTIONS> {
+  const { handle, run } = started
+  return createBackedAgentInvocationController<TOutput | Response, CALL_OPTIONS>({
+    cancel: async () => agentInvocationSnapshotFromWorkflow(await handle.cancel(run.id) as AgentWorkflowRun<TOutput>),
+    errorOutcome: workflowOperationOutcome,
+    id: run.id,
+    inspect: async () => agentInvocationSnapshotFromWorkflow(await handle.getRun(run.id) as AgentWorkflowRun<TOutput>),
+    parentAbortSignal,
+    result: Promise.resolve(run),
+  })
+}
+
+function createInlineAgentInvocationController<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+  TOutput,
+>(
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>, TOutput>,
+  context: AgentRuntimeContext<TRuntimeConfig>,
+  input: AgentRunInput<CALL_OPTIONS>,
+): AgentInvocationController<TOutput | Response, CALL_OPTIONS> {
+  return startLiveAgentInvocation<TOutput | Response, CALL_OPTIONS>({
+    parentAbortSignal: input.abortSignal,
+    start: ({ abortSignal, id, onFinish }) => executeAgentInvocation(agent, {
+      ...context,
+      run: { ...context.run, runId: id },
+    }, { ...input, abortSignal }, {
+      kind: "run",
+      onFinish(outcome) {
+        onFinish(outcome.status === "success"
+          ? { ...(outcome.result !== undefined ? { output: outcome.result as TOutput | Response } : {}), status: "completed" }
+          : { error: outcome.error, status: "failed" })
+      },
+      renderOutput: true,
+    }),
+  })
+}
+
+export async function startAgentInvocation<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+  TOutput = unknown,
+>(
+  agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>, TOutput>,
+  context: AgentRuntimeContext<TRuntimeConfig>,
+  input: AgentRunInput<CALL_OPTIONS>,
+): Promise<AgentInvocationController<TOutput | Response, CALL_OPTIONS>> {
+  const invocationContext = withAgentIdentityOwner(agent, context)
+  const workflow = await runAgentAsWorkflow<TRuntimeConfig, CALL_OPTIONS, TOutput>(
+    agent,
+    invocationContext,
+    input,
+    { fresh: true },
+  )
+  return workflow
+    ? createWorkflowAgentInvocationController(workflow, input.abortSignal)
+    : createInlineAgentInvocationController(agent, invocationContext, input)
+}
+
 export async function runAgent<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
@@ -2593,8 +2724,8 @@ export async function runAgent<
   input: AgentRunInput<CALL_OPTIONS>,
 ): Promise<TOutput | Response | AgentWorkflowRun<TOutput>> {
   const invocationContext = withAgentIdentityOwner(agent, context)
-  const workflowRun = await runAgentAsWorkflow<TRuntimeConfig, CALL_OPTIONS, TOutput>(agent, invocationContext, input)
-  if (workflowRun) return workflowRun
+  const workflow = await runAgentAsWorkflow<TRuntimeConfig, CALL_OPTIONS, TOutput>(agent, invocationContext, input)
+  if (workflow) return workflow.run
   return await runAgentInline(agent, invocationContext, input)
 }
 

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -26,7 +26,7 @@ export function agentWithColocatedSkills<Agent>(agent: Agent, sources: Parameter
 export interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
   agentIdentity?: AgentHostIdentity
   input?: AgentRunInput<CALL_OPTIONS>
-  run?: AgentRunMetadata
+  run?: Partial<AgentRunMetadata>
   runtime?: AgentRuntimeName
   runtimeConfig?: AgentRuntimeConfig
 }
@@ -63,11 +63,12 @@ export async function runAgentWorkflowDefinition<
   const cloudflareEnv = context.provider === "cloudflare"
     ? getActiveCloudflareEnv() || getCloudflareEnv(getWorkflowRuntimeEvent())
     : undefined
+  const runId = context.id || payload.run?.runId
   const runtimeContext = createAgentRuntimeContext<TRuntimeConfig>({
     ...(payload.agentIdentity ? { agentIdentity: payload.agentIdentity } : {}),
     ...(cloudflareEnv ? { cloudflare: { env: cloudflareEnv } } : {}),
-    ...(payload.run || context.id
-      ? { run: payload.run || { origin: `workflow:${context.provider}`, runId: context.id! } }
+    ...(runId
+      ? { run: { origin: `workflow:${context.provider}`, ...payload.run, runId } }
       : {}),
     runtime: payload.runtime || agentRuntimeFromWorkflowProvider(context.provider),
     runtimeConfig: (payload.runtimeConfig || {}) as TRuntimeConfig,

--- a/packages/agent/test/agent-invocation.test.ts
+++ b/packages/agent/test/agent-invocation.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createBackedAgentInvocationController } from "../src/agent-invocation.ts"
+import { subagents } from "../src/capabilities.ts"
+import { defineAgent, startAgentInvocation, workflow } from "../src/index.ts"
+
+import type { AgentRuntimeContext, AgentToolDefinition } from "../src/index.ts"
+
+function runtime(overrides: Partial<AgentRuntimeContext> = {}): AgentRuntimeContext {
+  return {
+    memo: (_key, create) => create(),
+    runtime: "unknown",
+    waitUntil: promise => void Promise.resolve(promise).catch(() => {}),
+    ...overrides,
+  }
+}
+
+describe("Agent Invocation controllers", () => {
+  it("starts fresh inline invocations and inspects their authoritative lifecycle", async () => {
+    const completions: Array<(value: string) => void> = []
+    const agent = defineAgent({
+      driver: {
+        run: () => new Promise<string>((resolve) => {
+          completions.push(resolve)
+        }),
+      },
+      runtime: false,
+    })
+
+    const first = await startAgentInvocation(agent, runtime({ run: { runId: "parent" } }), {})
+    const second = await startAgentInvocation(agent, runtime({ run: { runId: "parent" } }), {})
+
+    expect(first.id).toMatch(/^ainv_/)
+    expect(second.id).toMatch(/^ainv_/)
+    expect(second.id).not.toBe(first.id)
+    await expect(first.inspect()).resolves.toEqual({
+      invocation: { id: first.id, status: "running" },
+      outcome: "available",
+    })
+
+    await vi.waitFor(() => expect(completions).toHaveLength(2))
+    completions[1]!("done")
+    await vi.waitFor(async () => {
+      await expect(second.inspect()).resolves.toEqual({
+        invocation: { id: second.id, output: "done", status: "completed" },
+        outcome: "available",
+      })
+    })
+  })
+
+  it("propagates controller and parent cancellation without claiming synchronous termination", async () => {
+    const agent = defineAgent({
+      driver: {
+        run: ({ input }) => new Promise((_resolve, reject) => {
+          if (input.abortSignal?.aborted) reject(input.abortSignal.reason)
+          else input.abortSignal?.addEventListener("abort", () => reject(input.abortSignal?.reason), { once: true })
+        }),
+      },
+      runtime: false,
+    })
+    const parent = new AbortController()
+    const controlled = await startAgentInvocation(agent, runtime(), {})
+    const inherited = await startAgentInvocation(agent, runtime(), { abortSignal: parent.signal })
+
+    await expect(controlled.cancel("stop")).resolves.toMatchObject({
+      id: controlled.id,
+      outcome: "accepted",
+    })
+    parent.abort("parent stopped")
+
+    await vi.waitFor(async () => {
+      await expect(controlled.inspect()).resolves.toMatchObject({
+        invocation: { status: "cancelled" },
+        outcome: "available",
+      })
+      await expect(inherited.inspect()).resolves.toMatchObject({
+        invocation: { status: "cancelled" },
+        outcome: "available",
+      })
+    })
+    await expect(controlled.cancel()).resolves.toMatchObject({ outcome: "invalid-state" })
+  })
+
+  it("reports follow-up and steering as unsupported without simulating input", async () => {
+    const agent = defineAgent({ driver: { run: () => "done" }, runtime: false })
+    const controller = await startAgentInvocation(agent, runtime(), {})
+
+    expect(controller.support).toEqual({ followUp: false, steer: false })
+    await expect(controller.sendInput({ prompt: "continue" }, { mode: "follow-up" })).resolves.toMatchObject({
+      id: controller.id,
+      outcome: "unsupported",
+    })
+    await expect(controller.sendInput({ prompt: "change course" }, { mode: "steer" })).resolves.toMatchObject({
+      id: controller.id,
+      outcome: "unsupported",
+    })
+  })
+
+  it("maps Workflow-backed identity and lifecycle without promising cancellation support", async () => {
+    const waitUntilTasks: Array<Promise<unknown>> = []
+    const agent = defineAgent({
+      driver: { run: ({ run }) => run?.runId },
+      runtime: workflow("controlled-child"),
+    })
+    const controller = await startAgentInvocation(agent, runtime({
+      run: { origin: "parent", runId: "parent-run", threadId: "thread-1" },
+      runtime: "vercel",
+      waitUntil: promise => waitUntilTasks.push(Promise.resolve(promise)),
+    }), {})
+
+    expect(controller.id).not.toBe("parent-run")
+    await expect(controller.inspect()).resolves.toMatchObject({ outcome: "available" })
+    await expect(controller.cancel()).resolves.toMatchObject({
+      id: controller.id,
+      outcome: "unsupported",
+    })
+    await Promise.all(waitUntilTasks)
+    await expect(controller.inspect()).resolves.toEqual({
+      invocation: { id: controller.id, output: controller.id, status: "completed" },
+      outcome: "available",
+    })
+  })
+
+  it("attempts backed cancellation independently of inspection availability", async () => {
+    const cancel = vi.fn(async () => ({ id: "child", status: "cancelled" as const }))
+    const controller = createBackedAgentInvocationController({
+      cancel,
+      errorOutcome: () => "unavailable",
+      id: "child",
+      inspect: async () => { throw new Error("inspection unavailable") },
+      result: Promise.resolve(),
+    })
+
+    await expect(controller.cancel()).resolves.toEqual({
+      id: "child",
+      invocation: { id: "child", status: "cancelled" },
+      outcome: "accepted",
+    })
+    expect(cancel).toHaveBeenCalledOnce()
+  })
+
+  it("stops observing parent cancellation after a backed invocation reaches a terminal state", async () => {
+    const parent = new AbortController()
+    const removeEventListener = vi.spyOn(parent.signal, "removeEventListener")
+    const cancel = vi.fn(async () => ({ id: "child", status: "cancelled" as const }))
+    const controller = createBackedAgentInvocationController({
+      cancel,
+      errorOutcome: () => "unavailable",
+      id: "child",
+      inspect: async () => ({ id: "child", status: "completed" }),
+      parentAbortSignal: parent.signal,
+      result: Promise.resolve(),
+    })
+
+    await expect(controller.inspect()).resolves.toMatchObject({
+      invocation: { status: "completed" },
+      outcome: "available",
+    })
+    expect(removeEventListener).toHaveBeenCalledOnce()
+    parent.abort("too late")
+    expect(cancel).not.toHaveBeenCalled()
+  })
+
+  it("keeps subagents serializable while assigning fresh trusted identities", async () => {
+    const child = defineAgent({ driver: { run: ({ run }) => run?.runId }, runtime: false })
+    const parent = defineAgent({
+      capabilities: [subagents({
+        agents: {
+          researcher: { agent: child, description: "Research one question." },
+        },
+      })],
+      driver: { model: {} as never },
+    })
+    const resolved = await parent.resolve(runtime()) as unknown as {
+      tools: Record<string, AgentToolDefinition>
+    }
+    const tool = resolved.tools.run_researcher!
+    const first = await tool.execute?.({ message: "one" })
+    const second = await tool.execute?.({ message: "two" })
+
+    expect(first).toMatch(/^ainv_/)
+    expect(second).toMatch(/^ainv_/)
+    expect(second).not.toBe(first)
+    expect((tool.inputSchema as { properties?: Record<string, unknown> }).properties).not.toHaveProperty("runId")
+  })
+})

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1273,7 +1273,7 @@ describe("agent message protocol", () => {
         context: expect.objectContaining({ previewUrl: "https://preview.local" }),
         invokerId: "github:onmax",
         message: "Check the product card.",
-        runId: expect.stringMatching(/^review-run:run_browser:/),
+        runId: expect.stringMatching(/^ainv_/),
       },
       text: "browser report",
     })

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -99,10 +99,13 @@ describe("agent public types", () => {
     const result = runAgentInline(agent, {} as AgentRuntimeContext, {})
     const rawResult = runAgentInline(agent, {} as AgentRuntimeContext, {}, { output: "raw" })
     const workflowResult = runAgent(agent, {} as AgentRuntimeContext, {})
+    const controlled = startAgentInvocation(agent, {} as AgentRuntimeContext, {})
 
     expectTypeOf(result).toEqualTypeOf<Promise<Response | { summary: string, title: string }>>()
     expectTypeOf(rawResult).toEqualTypeOf<Promise<unknown>>()
     expectTypeOf<Extract<Awaited<typeof workflowResult>, { id: string }>["result"]>().toEqualTypeOf<{ summary: string, title: string } | undefined>()
+    expectTypeOf<Awaited<typeof controlled>["support"]>().toEqualTypeOf<{ followUp: boolean, steer: boolean }>()
+    expectTypeOf<Extract<Awaited<ReturnType<Awaited<typeof controlled>["inspect"]>>, { outcome: "available" }>["invocation"]["output"]>().toEqualTypeOf<Response | { summary: string, title: string } | undefined>()
   })
 
   it("accepts literal false as the inline runtime opt-out", () => {
@@ -1378,9 +1381,10 @@ describe("agent public types", () => {
       context: { previewUrl: "https://preview.local" },
       message: "Check the product card.",
       options: { mode: "fast" },
-      runId: "review-run:browser",
     }
-    expectTypeOf(browserToolInput.runId).toEqualTypeOf<string | undefined>()
+    // @ts-expect-error Child invocation identity is assigned below the model tool input.
+    const legacyBrowserToolInput: SubagentToolInput = { message: "Check the product card.", runId: "review-run:browser" }
+    expectTypeOf(legacyBrowserToolInput).toMatchTypeOf<SubagentToolInput>()
     subagents({
       agents: {
         browser: {


### PR DESCRIPTION
Adds `startAgentInvocation()` as the trusted control surface for starting a fresh child Agent Invocation, inspecting its normalized lifecycle, and requesting cancellation without assuming persistence. Inline children own an abortable live controller, while Workflow-backed children keep the provider-canonical Workflow Run identity and delegate inspection and cancellation to the selected provider; follow-up and active steering remain explicit unsupported operations until a runtime provides truthful ordering and lifecycle semantics.

Moves `subagents()` onto the same lower start seam while preserving its serializable synchronous result, and removes model-selected child run ids so every delegation receives a fresh trusted identity. Focused coverage exercises inline lifecycle and cancellation propagation, Workflow identity and control behavior, provider-operation independence, split-module compatibility, public output types, and the subagent migration; the new guide makes the controller's durability and capability boundaries explicit.