### PR TITLE
feat(cli): inspect execution authority

### DIFF
--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -82,7 +82,7 @@ Use `--watch` to rerun affected evals after file changes and `--no-cache` to byp
 
 ## Inspect an Agent Definition
 
-Start the app's Vite Development Server, then inspect the resolved metadata for one chat-capable Agent Definition.
+Start the app's Vite Development Server, then inspect the resolved metadata for one Agent Definition.
 The command does not invoke the Agent Driver.
 
 ```bash [Terminal]
@@ -90,9 +90,10 @@ pnpm vitehub agent info --agent support
 pnpm vitehub agent info --agent support --json
 ```
 
-The default output summarizes the selected Driver, tools, visible Workspace files and Sources, instructions, Agent Invoker Profiles, warnings, and metadata status.
-Use `--json` for the structured inspection contract and `--url` when Vite is not listening on `http://localhost:5173`.
-When multiple chat-capable Agents are discovered, `--agent` is required.
+The default output summarizes the selected Driver, its execution authority, tools, visible Workspace files and Sources, instructions, Agent Invoker Profiles, warnings, and metadata status.
+Execution authority is a resolution-time snapshot of filesystem, network, environment, credential, process, and isolation authority. An `unknown` value means the runtime or provider cannot prove that dimension during inspection; it does not mean restricted or denied. The snapshot describes runtime truth for the inspected context, not an enforcement decision or proof of safety.
+Use `--json` for the structured inspection contract at `config.driver.executionAuthority`, and `--url` when Vite is not listening on `http://localhost:5173`.
+When multiple Agents are discovered, `--agent` is required.
 `agent info` reads resolved runtime metadata from the guarded Agent Dev Loop endpoint exposed by `hubAgent()`.
 
 ## Talk to an Agent during development

--- a/packages/agent/src/internal/agent-info-cli.ts
+++ b/packages/agent/src/internal/agent-info-cli.ts
@@ -1,3 +1,5 @@
+import { isExecutionAuthority, type ExecutionAuthority } from "@vite-hub/runtime"
+
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } from "../invocation-stream.ts"
 
 import type { AgentInspectionMetadata } from "../types.ts"
@@ -113,6 +115,21 @@ function agentInfoDriver(config: AgentInspectionMetadata["config"]): string {
   return "Unknown Agent Driver"
 }
 
+function agentInfoExecutionAuthority(authority: ExecutionAuthority): string[] {
+  const filesystem = authority.filesystem.scope === authority.filesystem.access
+    ? authority.filesystem.scope
+    : `${authority.filesystem.scope}, ${authority.filesystem.access}`
+  return [
+    "Execution authority:",
+    `  Filesystem: ${filesystem}`,
+    `  Network: ${authority.network}`,
+    `  Environment: ${authority.environment}`,
+    `  Credentials: ${authority.credentials}`,
+    `  Process execution: ${authority.processes}`,
+    `  Isolation: ${authority.isolation}`,
+  ]
+}
+
 function agentInfoNames(values: Array<{ name: string }>, fallback: string): string {
   if (!values.length) return fallback
   const names = values.slice(0, 5).map(value => value.name)
@@ -121,10 +138,12 @@ function agentInfoNames(values: Array<{ name: string }>, fallback: string): stri
 
 function writeAgentInfo(context: AgentInfoCliContext, metadata: AgentInspectionMetadata): void {
   const files = countAgentInfoFiles(metadata.files || [])
+  const authority = metadata.config?.driver?.executionAuthority
   context.stdout.write([
     `Agent: ${metadata.name || "unknown"}`,
     "Metadata: ready",
     `Driver: ${agentInfoDriver(metadata.config)}`,
+    ...(isExecutionAuthority(authority) ? agentInfoExecutionAuthority(authority) : ["Execution authority: unavailable"]),
     `Tools: ${plural(metadata.tools?.length || 0, "tool")} (${agentInfoNames(metadata.tools || [], "none")})`,
     `Workspace files: ${plural(files.files, "file")}, ${plural(files.directories, "directory", "directories")}, ${plural(files.sources, "source")}`,
     `Instructions: ${plural(metadata.instructions?.length || 0, "document")}`,

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -26,6 +26,15 @@ function ndjson(events: unknown[]): Response {
   })
 }
 
+const unknownExecutionAuthorityFixture = {
+  credentials: "unknown",
+  environment: "unknown",
+  filesystem: { access: "unknown", scope: "unknown" },
+  isolation: "unknown",
+  network: "unknown",
+  processes: "unknown",
+} as const
+
 describe("agent CLI", () => {
   it("contributes the agent eval feature", () => {
     expect(createAgentCliContributor()).toEqual({
@@ -58,7 +67,20 @@ describe("agent CLI", () => {
     const stdout = stream()
     const fetchAgentInfo = vi.fn(async () => Response.json({
       inspection: {
-        config: { driver: { kind: "model", model: { id: "openai/gpt-5" } } },
+        config: {
+          driver: {
+            executionAuthority: {
+              credentials: "ambient",
+              environment: "ambient",
+              filesystem: { access: "read-write", scope: "host" },
+              isolation: "none",
+              network: "unrestricted",
+              processes: "arbitrary",
+            },
+            kind: "model",
+            model: { id: "openai/gpt-5" },
+          },
+        },
         files: [
           {
             children: [{ kind: "file", path: "docs/AGENTS.md", source: "docs" }],
@@ -89,6 +111,13 @@ describe("agent CLI", () => {
       "Agent: support",
       "Metadata: ready",
       "Driver: Model-backed Agent Driver (openai/gpt-5)",
+      "Execution authority:",
+      "  Filesystem: host, read-write",
+      "  Network: unrestricted",
+      "  Environment: ambient",
+      "  Credentials: ambient",
+      "  Process execution: arbitrary",
+      "  Isolation: none",
       "Tools: 2 tools (search, shell)",
       "Workspace files: 1 file, 1 directory, 1 source",
       "Instructions: 1 document",
@@ -103,11 +132,11 @@ describe("agent CLI", () => {
     }))
   })
 
-  it("prints the existing Agent inspection contract as JSON", async () => {
+  it("prints execution authority in the existing Agent inspection contract as JSON", async () => {
     const stdout = stream()
     const fetchAgentInfo = vi.fn(async () => Response.json({
       inspection: {
-        config: { driver: { kind: "run" } },
+        config: { driver: { executionAuthority: unknownExecutionAuthorityFixture, kind: "unknown" } },
         files: [],
         instructions: [],
         invokerProfiles: [],
@@ -128,7 +157,7 @@ describe("agent CLI", () => {
 
     expect(exitCode).toBe(0)
     expect(JSON.parse(stdout.output())).toEqual({
-      config: { driver: { kind: "run" } },
+      config: { driver: { executionAuthority: unknownExecutionAuthorityFixture, kind: "unknown" } },
       files: [],
       instructions: [],
       invokerProfiles: [],
@@ -140,7 +169,77 @@ describe("agent CLI", () => {
     expect(fetchAgentInfo).toHaveBeenCalledWith("http://localhost:5173/__vitehub/agent/invocation-stream?inspect=1&agent=support", expect.anything())
   })
 
-  it("requires an Agent target when multiple chat-capable Agents are discovered", async () => {
+  it("prints unknown execution authority without inferring restrictions", async () => {
+    const stdout = stream()
+    const exitCode = await runAgentInfoCli([], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr: stream(),
+      stdout,
+    }, {
+      fetch: vi.fn(async () => Response.json({
+        inspection: {
+          config: { driver: { executionAuthority: unknownExecutionAuthorityFixture, kind: "unknown" } },
+          name: "opaque",
+        },
+      })) as never,
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stdout.output()).toContain([
+      "Execution authority:",
+      "  Filesystem: unknown",
+      "  Network: unknown",
+      "  Environment: unknown",
+      "  Credentials: unknown",
+      "  Process execution: unknown",
+      "  Isolation: unknown",
+    ].join("\n"))
+  })
+
+  it("reports unavailable execution authority without treating it as none", async () => {
+    const stdout = stream()
+    const exitCode = await runAgentInfoCli([], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr: stream(),
+      stdout,
+    }, {
+      fetch: vi.fn(async () => Response.json({ inspection: { name: "legacy" } })) as never,
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stdout.output()).toContain("Execution authority: unavailable\n")
+    expect(stdout.output()).not.toContain("Execution authority: none")
+  })
+
+  it.each([
+    { config: {}, label: "missing Driver metadata" },
+    { config: { driver: { executionAuthority: {}, kind: "unknown" } }, label: "malformed execution authority" },
+  ])("reports $label as unavailable", async ({ config }) => {
+    const stdout = stream()
+    const exitCode = await runAgentInfoCli([], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr: stream(),
+      stdout,
+    }, {
+      fetch: vi.fn(async () => Response.json({
+        inspection: {
+          config,
+          name: "legacy",
+        },
+      })) as never,
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stdout.output()).toContain("Execution authority: unavailable\n")
+  })
+
+  it("requires an Agent target when multiple Agents are discovered", async () => {
     const stderr = stream()
     const fetchAgentInfo = vi.fn(async () => new Response("Multiple Agents discovered. Pass --agent review|support.", { status: 400 }))
 


### PR DESCRIPTION
Extends `vitehub agent info` with the resolved execution-authority snapshot already carried by Agent inspection metadata. Human output now names filesystem, network, environment, credential, process, and isolation authority, while `--json` preserves the provider-neutral descriptor at `config.driver.executionAuthority`.

Unknown authority remains explicitly `unknown`, and metadata from an older or incompatible inspection seam renders as unavailable instead of being treated as restricted or safe. The CLI guide documents the snapshot semantics and makes clear that inspection is not an enforcement decision or proof of safety.