### PR TITLE
feat(agent): validate unsafe invocation authority

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -91,7 +91,7 @@ export default defineAgent({
 });
 ```
 
-Harness Agents resolve their concrete sandbox or Box before invocation. If that execution authority differs from `noExecutionAuthority`, the invocation fails closed unless `authorizeExecution` returns `true`. The callback receives the invocation-scoped `executionAuthority` together with the resolved input and Agent Invoker; approve only the callers and inputs that may exercise that exact authority. Model and custom run drivers with `noExecutionAuthority` do not require approval.
+Harness Agents resolve their concrete sandbox or Box before execution. Function-valued `driver.sandbox` callbacks retain their capability-prepared invocation context; ViteHub authorizes their resolved provider after Capability preparation but before input hooks, harness adaptation, or Agent execution. If the execution authority differs from `noExecutionAuthority`, the invocation fails closed unless `authorizeExecution` returns `true`. The callback receives the invocation-scoped `executionAuthority` together with the resolved input and Agent Invoker; approve only the callers and inputs that may exercise that exact authority. Model and custom run drivers with `noExecutionAuthority` do not require approval.
 
 Put Agent-owned Skills under `server/agents/codex/skills/`; discovery materializes them into the Harness Workspace and the isolated Codex profile automatically. Use `skills()` for Workspace-backed or external Source Skills.
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -75,6 +75,7 @@ import { codexDriver } from "@vite-hub/agent/harness/codex";
 import { file } from "@vite-hub/workspace";
 
 export default defineAgent({
+  authorizeExecution: () => true,
   driver: codexDriver({
     instructions: "Review the exact pull request head before changing code.",
     model: "gpt-5.5",
@@ -89,6 +90,8 @@ export default defineAgent({
   },
 });
 ```
+
+Harness Agents resolve their concrete sandbox or Box before invocation. If that execution authority differs from `noExecutionAuthority`, the invocation fails closed unless `authorizeExecution` returns `true`. The callback receives the invocation-scoped `executionAuthority` together with the resolved input and Agent Invoker; approve only the callers and inputs that may exercise that exact authority. Model and custom run drivers with `noExecutionAuthority` do not require approval.
 
 Put Agent-owned Skills under `server/agents/codex/skills/`; discovery materializes them into the Harness Workspace and the isolated Codex profile automatically. Use `skills()` for Workspace-backed or external Source Skills.
 
@@ -107,6 +110,7 @@ import { trustedHost } from "@vite-hub/box";
 import { useServerEnv } from "#vitehub/env/server";
 
 export default defineAgent<any, { ref: string; remote: string; sha: string }>({
+  authorizeExecution: () => true,
   box: {
     runtime: trustedHost({ stateRoot: "/var/lib/vitehub/boxes" }),
     checkout: {

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -505,7 +505,7 @@ function sandboxExecutionAuthority(sandbox: object) {
   return isExecutionAuthority(authority) ? normalizeExecutionAuthority(authority) : unknownExecutionAuthority
 }
 
-function sameExecutionAuthority(left: ReturnType<typeof sandboxExecutionAuthority>, right: ReturnType<typeof sandboxExecutionAuthority>): boolean {
+export function executionAuthoritiesEqual(left: ReturnType<typeof sandboxExecutionAuthority>, right: ReturnType<typeof sandboxExecutionAuthority>): boolean {
   const matches = {
     credentials: left.credentials === right.credentials,
     environment: left.environment === right.environment,
@@ -640,7 +640,7 @@ async function createHarnessAgent<
       sandbox = adaptLocalHarnessSandbox(baseSandbox, bootstrap.bootstrapDir)!
     }
   }
-  if (!sameExecutionAuthority(authorizedExecutionAuthority, sandboxExecutionAuthority(sandbox))) {
+  if (!executionAuthoritiesEqual(authorizedExecutionAuthority, sandboxExecutionAuthority(sandbox))) {
     throw new Error("[vitehub] Harness sandbox adapters must preserve the executionAuthority authorized for this invocation.")
   }
   const instructions = await resolveHarnessDriverInstructions(options.instructions, context)

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -1,4 +1,5 @@
 import { normalizeWorkspaceSourcesMetadata } from "@vite-hub/workspace/source-metadata"
+import { isExecutionAuthority, normalizeExecutionAuthority, unknownExecutionAuthority } from "@vite-hub/runtime"
 
 import {
   createHarnessUsageMetadata,
@@ -79,6 +80,7 @@ type HarnessGlobalSkillsSandbox = {
 
 type HarnessAgentConstructor = new (settings: Record<string, unknown>) => HarnessAgentLike
 const harnessResumeStates = new WeakMap<object, Map<string, unknown>>()
+const defaultHarnessSandboxes = new WeakSet<object>()
 const harnessGeneratedFiles = ["harness-tool.mjs"] as const
 const harnessInstructionFiles = ["AGENTS.md", "CLAUDE.md"] as const
 const harnessAgentPackage = "@ai-sdk/harness/agent"
@@ -470,7 +472,7 @@ async function resolveHarnessWorkDir<
   return resolved
 }
 
-function isProcesslessHarnessRuntime(context: AgentAdapterRunContext): boolean {
+function isProcesslessHarnessRuntime(context: Pick<AgentAdapterRunContext, "runtime">): boolean {
   return context.runtime.runtime === "cloudflare-agents" || context.runtime.runtime === "deno"
 }
 
@@ -488,12 +490,31 @@ function defaultHarnessEnv(): Record<string, string> {
     .filter((entry): entry is [string, string] => entry[1] !== undefined))
 }
 
-async function createDefaultHarnessSandbox(context: AgentAdapterRunContext): Promise<object> {
+export async function createDefaultHarnessSandbox(context: Pick<AgentAdapterRunContext, "runtime">): Promise<object> {
   if (isProcesslessHarnessRuntime(context)) {
     throw new Error(`[vitehub] Harness Agent Drivers on ${context.runtime.runtime} require a process-capable driver.sandbox provider.`)
   }
   const { createLocalHarnessSandbox } = await import("./harness/local-sandbox.ts")
-  return createLocalHarnessSandbox({ env: defaultHarnessEnv() })
+  const sandbox = createLocalHarnessSandbox({ env: defaultHarnessEnv() })
+  defaultHarnessSandboxes.add(sandbox)
+  return sandbox
+}
+
+function sandboxExecutionAuthority(sandbox: object) {
+  const authority = (sandbox as { executionAuthority?: unknown }).executionAuthority
+  return isExecutionAuthority(authority) ? normalizeExecutionAuthority(authority) : unknownExecutionAuthority
+}
+
+function sameExecutionAuthority(left: ReturnType<typeof sandboxExecutionAuthority>, right: ReturnType<typeof sandboxExecutionAuthority>): boolean {
+  const matches = {
+    credentials: left.credentials === right.credentials,
+    environment: left.environment === right.environment,
+    filesystem: left.filesystem.access === right.filesystem.access && left.filesystem.scope === right.filesystem.scope,
+    isolation: left.isolation === right.isolation,
+    network: left.network === right.network,
+    processes: left.processes === right.processes,
+  } satisfies Record<keyof typeof left, boolean>
+  return Object.values(matches).every(Boolean)
 }
 
 function hasHarnessInstructionDocument(context: AgentAdapterRunContext): boolean {
@@ -554,15 +575,15 @@ function resolveHarnessGlobalSkillsDirectory(
     : directory
 }
 
-async function resolveHarnessSandboxProvider<
+export async function resolveHarnessSandboxProvider<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(
   sandbox: AgentHarnessSandboxProviderInput<TRuntimeConfig, CALL_OPTIONS> | undefined,
-  context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>,
+  context: AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>,
 ): Promise<object | undefined> {
   const provider = typeof sandbox === "function"
-    ? await sandbox(toRunCallbackContext(context))
+    ? await sandbox(context)
     : sandbox
   if (provider !== undefined && (!provider || typeof provider !== "object")) {
     throw new TypeError("[vitehub] defineAgent({ driver.sandbox }) must return a harness sandbox provider object.")
@@ -594,10 +615,10 @@ async function createHarnessAgent<
   }
   const globalSkillsWorkspace = await resolveHarnessGlobalSkills(context)
   const driverSandbox = context.harnessSandboxProvider === undefined
-    ? await resolveHarnessSandboxProvider(options.sandbox, context)
+    ? await resolveHarnessSandboxProvider(options.sandbox, toRunCallbackContext(context))
     : undefined
-  const defaultSandbox = context.harnessSandboxProvider === undefined && driverSandbox === undefined
   const baseSandbox = context.harnessSandboxProvider ?? driverSandbox ?? await createDefaultHarnessSandbox(context)
+  const defaultSandbox = defaultHarnessSandboxes.has(baseSandbox)
   assertHarnessSandboxRuntime(baseSandbox, context)
   const adaptSandbox = (harness as Record<PropertyKey, unknown>)[harnessSandboxAdapter]
   let sandbox = baseSandbox
@@ -617,6 +638,9 @@ async function createHarnessAgent<
       const { adaptLocalHarnessSandbox } = await import("./internal/local-sandbox.ts")
       sandbox = adaptLocalHarnessSandbox(baseSandbox, bootstrap.bootstrapDir)!
     }
+  }
+  if (!sameExecutionAuthority(sandboxExecutionAuthority(baseSandbox), sandboxExecutionAuthority(sandbox))) {
+    throw new Error("[vitehub] Harness sandbox adapters must preserve the executionAuthority authorized for this invocation.")
   }
   const instructions = await resolveHarnessDriverInstructions(options.instructions, context)
   const workDir = await resolveHarnessWorkDir(options.workDir, context) ?? context.harnessWorkDir

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -620,6 +620,7 @@ async function createHarnessAgent<
   const baseSandbox = context.harnessSandboxProvider ?? driverSandbox ?? await createDefaultHarnessSandbox(context)
   const defaultSandbox = defaultHarnessSandboxes.has(baseSandbox)
   assertHarnessSandboxRuntime(baseSandbox, context)
+  const authorizedExecutionAuthority = sandboxExecutionAuthority(baseSandbox)
   const adaptSandbox = (harness as Record<PropertyKey, unknown>)[harnessSandboxAdapter]
   let sandbox = baseSandbox
   if (typeof adaptSandbox === "function") {
@@ -639,7 +640,7 @@ async function createHarnessAgent<
       sandbox = adaptLocalHarnessSandbox(baseSandbox, bootstrap.bootstrapDir)!
     }
   }
-  if (!sameExecutionAuthority(sandboxExecutionAuthority(baseSandbox), sandboxExecutionAuthority(sandbox))) {
+  if (!sameExecutionAuthority(authorizedExecutionAuthority, sandboxExecutionAuthority(sandbox))) {
     throw new Error("[vitehub] Harness sandbox adapters must preserve the executionAuthority authorized for this invocation.")
   }
   const instructions = await resolveHarnessDriverInstructions(options.instructions, context)

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -620,7 +620,7 @@ async function createHarnessAgent<
   const baseSandbox = context.harnessSandboxProvider ?? driverSandbox ?? await createDefaultHarnessSandbox(context)
   const defaultSandbox = defaultHarnessSandboxes.has(baseSandbox)
   assertHarnessSandboxRuntime(baseSandbox, context)
-  const authorizedExecutionAuthority = sandboxExecutionAuthority(baseSandbox)
+  const authorizedExecutionAuthority = context.harnessSandboxExecutionAuthority ?? sandboxExecutionAuthority(baseSandbox)
   const adaptSandbox = (harness as Record<PropertyKey, unknown>)[harnessSandboxAdapter]
   let sandbox = baseSandbox
   if (typeof adaptSandbox === "function") {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1181,7 +1181,8 @@ export async function resolveAgent<TContext extends AgentRuntimeContext>(
   context: TContext,
 ): Promise<AgentAdapter> {
   if (hasAgentDefinition(agent)) {
-    return await agent.resolve(context as never)
+    const adapter = await agent.resolve(context as never)
+    return withResolvedAgentExecutionAuthorization(agent as never, adapter)
   }
 
   throw new TypeError("[vitehub] Invalid agent definition.")
@@ -1539,6 +1540,37 @@ async function authorizeAgentExecution<
   const name = definition?.name || context.agentIdentity?.name
   const target = name ? `Agent "${name}"` : "Agent"
   throw new Error(`[vitehub] ${target} requires execution authorization for its resolved authority (${executionAuthoritySummary(executionAuthority)}). Add defineAgent({ authorizeExecution }) and return true only when this invocation may exercise that authority.`)
+}
+
+function withResolvedAgentExecutionAuthorization<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS>,
+  adapter: AgentAdapter<CALL_OPTIONS>,
+): AgentAdapter<CALL_OPTIONS> {
+  const authorizeContext = async (context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>) => {
+    const { runtime: resolvedRuntime } = context
+    const settings = settingsFromAgentDefinition(definition)
+    const driver = settings ? normalizeAgentDriver(settings) : undefined
+    const internalDefinition = definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS>
+    const driverKind = internalDefinition[agentExecutionDriverKind] ?? internalDefinition[baseAgentDriverKind] ?? driver?.kind
+    const callbackContext = { ...resolvedRuntime, ...context, runtime: resolvedRuntime.runtime } as AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>
+    const executionSurface = await resolveAgentExecutionSurface(definition, driver, driverKind, callbackContext, resolvedRuntime)
+    await authorizeAgentExecution(definition, executionSurface.executionAuthority, callbackContext)
+    if (executionSurface.box) context.context.set("agent.execution.box", executionSurface.box, { overwrite: true })
+    return {
+      ...context,
+      box: executionSurface.box ?? context.box,
+      harnessSandboxExecutionAuthority: executionSurface.executionAuthority,
+      harnessSandboxProvider: executionSurface.harnessSandboxProvider ?? context.harnessSandboxProvider,
+    }
+  }
+  const clone = Object.create(Object.getPrototypeOf(adapter)) as AgentAdapter<CALL_OPTIONS>
+  Object.defineProperties(clone, Object.getOwnPropertyDescriptors(adapter))
+  clone.generate = async context => adapter.generate(await authorizeContext(context as never))
+  if (adapter.stream) clone.stream = async context => adapter.stream!(await authorizeContext(context as never))
+  return clone
 }
 
 async function createAgentInvocationContext<

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1597,9 +1597,16 @@ async function createAgentInvocationContext<
       invoker,
       run: context.run,
     } satisfies AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>
-    const executionSurface = await resolveAgentExecutionSurface(definition, driver, executionDriverKind, runCallbackContext, runtimeContext)
-    await authorizeAgentExecution(definition, executionSurface.executionAuthority, runCallbackContext)
-    const { box, harnessSandboxProvider } = executionSurface
+    const deferHarnessSandboxResolution = !definition?.box
+      && executionDriverKind === "harness"
+      && driver?.kind === "harness"
+      && typeof driver.sandbox === "function"
+    const executionSurface = deferHarnessSandboxResolution
+      ? undefined
+      : await resolveAgentExecutionSurface(definition, driver, executionDriverKind, runCallbackContext, runtimeContext)
+    if (executionSurface) await authorizeAgentExecution(definition, executionSurface.executionAuthority, runCallbackContext)
+    const box = executionSurface?.box
+    let harnessSandboxProvider = executionSurface?.harnessSandboxProvider
     if (box) invocationContext.set("agent.execution.box", box, { overwrite: true })
     const capabilitiesResolver = internalDefinition?.[baseAgentCapabilitiesResolver]
     const invocationResolvedCapabilities = capabilitiesResolver
@@ -1664,6 +1671,31 @@ async function createAgentInvocationContext<
       resolveCapabilityCli,
       workspaceDefinition: resolvedWorkspaceDefinition,
     })
+    if (deferHarnessSandboxResolution) {
+      const preparedRunCallbackContext = {
+        ...agentInvocationCallbackContextValues(invocationContext),
+        ...callbackContext,
+        actor: invoker,
+        context: invocationContext,
+        input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
+        invoker,
+        run: context.run,
+      } satisfies AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>
+      try {
+        const preparedExecutionSurface = await resolveAgentExecutionSurface(definition, driver, executionDriverKind, preparedRunCallbackContext, runtimeContext)
+        await authorizeAgentExecution(definition, preparedExecutionSurface.executionAuthority, preparedRunCallbackContext)
+        harnessSandboxProvider = preparedExecutionSurface.harnessSandboxProvider
+      }
+      catch (error) {
+        try {
+          await capabilities.close()
+        }
+        catch (closeError) {
+          throw new AggregateError([error, closeError], "[vitehub] Agent execution authorization failed and Capability cleanup also failed.")
+        }
+        throw error
+      }
+    }
     const inputHook = definition?.hooks?.["agent:input"]
     if (inputHook && !capabilities.response) {
       try {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -169,7 +169,7 @@ import type {
 import type { WorkflowHandle } from "@vite-hub/workflow"
 import type { Box } from "@vite-hub/box"
 import { isHarnessBoxActive, shareBoxSessions } from "./harness/shared-box.ts"
-import { createDefaultHarnessSandbox, resolveHarnessSandboxProvider } from "./harness-agent.ts"
+import { createDefaultHarnessSandbox, executionAuthoritiesEqual, resolveHarnessSandboxProvider } from "./harness-agent.ts"
 
 export type {
   AgentAccessInvocationContextValue,
@@ -1507,16 +1507,7 @@ async function resolveAgentExecutionSurface<
 }
 
 function isNoExecutionAuthority(authority: ExecutionAuthority): boolean {
-  const matches = {
-    credentials: authority.credentials === noExecutionAuthority.credentials,
-    environment: authority.environment === noExecutionAuthority.environment,
-    filesystem: authority.filesystem.access === noExecutionAuthority.filesystem.access
-      && authority.filesystem.scope === noExecutionAuthority.filesystem.scope,
-    isolation: authority.isolation === noExecutionAuthority.isolation,
-    network: authority.network === noExecutionAuthority.network,
-    processes: authority.processes === noExecutionAuthority.processes,
-  } satisfies Record<keyof ExecutionAuthority, boolean>
-  return Object.values(matches).every(Boolean)
+  return executionAuthoritiesEqual(authority, noExecutionAuthority)
 }
 
 function executionAuthoritySummary(authority: ExecutionAuthority): string {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -10,7 +10,15 @@ import {
   createReplyDeliveryEffectIntent,
   createStatusDeliveryEffectIntent,
 } from "./delivery-effects.ts"
-import { createTraceEventLog, resolveRuntimeContext } from "@vite-hub/runtime"
+import {
+  createTraceEventLog,
+  isExecutionAuthority,
+  noExecutionAuthority,
+  normalizeExecutionAuthority,
+  resolveRuntimeContext,
+  unknownExecutionAuthority,
+  type ExecutionAuthority,
+} from "@vite-hub/runtime"
 import { agentResultKind, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
 import { defineChatCapability, getChatCapabilityOptions } from "./chat-trigger.ts"
 import {
@@ -111,6 +119,8 @@ import type {
   AgentChannelDeliveryFinishEffectResult,
   AgentChannelDeliveryFinishEffectContext,
   AgentDefinition,
+  AgentExecutionAuthorizationContext,
+  AgentExecutionAuthorizer,
   AgentDriverContribution,
   AgentDriverKind,
   AgentFinishEvent,
@@ -127,6 +137,7 @@ import type {
   AgentModelResolver,
   AgentRegistry,
   AgentRegistryModule,
+  AgentRunCallbackContext,
   AgentRunContext,
   AgentRunInput,
   AgentRunMetadata,
@@ -156,8 +167,9 @@ import type {
   WorkspaceSessionOptions,
 } from "@vite-hub/workspace"
 import type { WorkflowHandle } from "@vite-hub/workflow"
-import type { Box, BoxRequirement } from "@vite-hub/box"
+import type { Box } from "@vite-hub/box"
 import { isHarnessBoxActive, shareBoxSessions } from "./harness/shared-box.ts"
+import { createDefaultHarnessSandbox, resolveHarnessSandboxProvider } from "./harness-agent.ts"
 
 export type {
   AgentAccessInvocationContextValue,
@@ -253,6 +265,8 @@ export type {
   AgentDriverContributionKind,
   AgentDriverKind,
   AgentExecution,
+  AgentExecutionAuthorizationContext,
+  AgentExecutionAuthorizer,
   AgentFinishEvent,
   AgentFinishExtensions,
   AgentFinishExtensionValues,
@@ -405,7 +419,6 @@ const syntheticWorkspaceRun = Symbol.for("vitehub.syntheticWorkspaceRun")
 const baseAgentResolve = Symbol.for("vitehub.baseAgentResolve")
 const baseAgentModel = Symbol.for("vitehub.baseAgentModel")
 const baseAgentDriverKind = Symbol.for("vitehub.baseAgentDriverKind")
-const baseAgentBoxRequirements = Symbol.for("vitehub.baseAgentBoxRequirements")
 const baseAgentCapabilitiesResolver = Symbol.for("vitehub.baseAgentCapabilitiesResolver")
 type WorkspaceSourceNames<TWorkspace> =
   TWorkspace extends { sources: infer TSources }
@@ -545,7 +558,6 @@ type AgentDefinitionWithBaseResolve<
   CALL_OPTIONS = unknown,
   TOutput = unknown,
 > = AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput> & {
-  [baseAgentBoxRequirements]?: readonly BoxRequirement[]
   [baseAgentCapabilitiesResolver]?: AgentCapabilitiesResolver<TRuntimeConfig, WorkspaceName, CALL_OPTIONS>
   [baseAgentDriverKind]?: AgentDriverKind
   [baseAgentResolve]?: BaseAgentResolver<TRuntimeConfig, CALL_OPTIONS>
@@ -945,7 +957,7 @@ function defineBaseAgent<
   options: AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentInvocationContextValues, AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined, TOutput>,
 ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentInvocationContextValues, TOutput> {
   const driver = normalizeAgentDriver(options)
-  const { box, capabilities, cli, description, hooks, messages, name, output, runtime = defaultAgentWorkflowRuntime(), runEvents, version, workspace } = options
+  const { authorizeExecution, box, capabilities, cli, description, hooks, messages, name, output, runtime = defaultAgentWorkflowRuntime(), runEvents, version, workspace } = options
   const channels = normalizeAgentChannels(options.channels)
   if (box && driver.kind !== "harness") {
     throw new Error("[vitehub] defineAgent({ box }) currently requires a harness Agent Driver.")
@@ -990,11 +1002,11 @@ function defineBaseAgent<
   }
 
   const definition = {
-    ...(driver.kind === "harness" && driver.requires?.length ? { [baseAgentBoxRequirements]: driver.requires } : {}),
     ...(driver.kind === "model" ? { [baseAgentModel]: driver.model } : {}),
     [baseAgentDriverKind]: driver.kind,
     ...(capabilitiesResolver ? { [baseAgentCapabilitiesResolver]: capabilitiesResolver } : {}),
     [baseAgentResolve]: resolveBaseAgent,
+    authorizeExecution,
     box,
     channels,
     chat,
@@ -1431,6 +1443,108 @@ async function registerResolvedAgentWorkspaceDefinition(name: string, definition
   registerWorkspace(name, workspace)
 }
 
+interface ResolvedAgentExecutionSurface {
+  executionAuthority: ExecutionAuthority
+  box?: Box
+  harnessSandboxProvider?: object
+}
+
+function settingsFromAgentDefinition<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined): AgentSettings<TRuntimeConfig, CALL_OPTIONS> | undefined {
+  return (definition as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> & {
+    __vitehubAgentSettings?: AgentSettings<TRuntimeConfig, CALL_OPTIONS>
+  } | undefined)?.__vitehubAgentSettings
+}
+
+function declaredExecutionAuthority(provider: object): ExecutionAuthority {
+  const authority = (provider as { executionAuthority?: unknown }).executionAuthority
+  return isExecutionAuthority(authority)
+    ? normalizeExecutionAuthority(authority)
+    : unknownExecutionAuthority
+}
+
+async function resolveAgentExecutionSurface<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
+  driver: ReturnType<typeof normalizeAgentDriver<TRuntimeConfig, CALL_OPTIONS>> | undefined,
+  driverKind: AgentDriverKind | undefined,
+  context: AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>,
+  runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>,
+): Promise<ResolvedAgentExecutionSurface> {
+  if (definition?.box) {
+    const box = shareBoxSessions(await (await import("@vite-hub/box")).resolveBox(definition.box, context, {
+      requires: driverKind === "harness" && driver?.kind === "harness" ? driver.requires : undefined,
+    }))
+    return {
+      box,
+      executionAuthority: box.plan.executionAuthority,
+      harnessSandboxProvider: (await import("./harness/box-sandbox.ts")).createBoxHarnessSandbox(box),
+    }
+  }
+  if (driverKind === "run") return { executionAuthority: noExecutionAuthority }
+  if (!driver) {
+    return {
+      executionAuthority: driverKind === "model"
+        ? noExecutionAuthority
+        : unknownExecutionAuthority,
+    }
+  }
+  if (driver.kind !== "harness") return { executionAuthority: noExecutionAuthority }
+
+  const configuredHarnessSandbox = await resolveHarnessSandboxProvider(driver.sandbox, context)
+  const harnessSandboxProvider = configuredHarnessSandbox
+    ?? await createDefaultHarnessSandbox({ runtime: runtimeContext })
+  return {
+    executionAuthority: declaredExecutionAuthority(harnessSandboxProvider),
+    harnessSandboxProvider,
+  }
+}
+
+function isNoExecutionAuthority(authority: ExecutionAuthority): boolean {
+  const matches = {
+    credentials: authority.credentials === noExecutionAuthority.credentials,
+    environment: authority.environment === noExecutionAuthority.environment,
+    filesystem: authority.filesystem.access === noExecutionAuthority.filesystem.access
+      && authority.filesystem.scope === noExecutionAuthority.filesystem.scope,
+    isolation: authority.isolation === noExecutionAuthority.isolation,
+    network: authority.network === noExecutionAuthority.network,
+    processes: authority.processes === noExecutionAuthority.processes,
+  } satisfies Record<keyof ExecutionAuthority, boolean>
+  return Object.values(matches).every(Boolean)
+}
+
+function executionAuthoritySummary(authority: ExecutionAuthority): string {
+  return [
+    `filesystem=${authority.filesystem.scope}:${authority.filesystem.access}`,
+    `network=${authority.network}`,
+    `environment=${authority.environment}`,
+    `credentials=${authority.credentials}`,
+    `processes=${authority.processes}`,
+    `isolation=${authority.isolation}`,
+  ].join(", ")
+}
+
+async function authorizeAgentExecution<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
+  executionAuthority: ExecutionAuthority,
+  context: AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>,
+): Promise<void> {
+  if (isNoExecutionAuthority(executionAuthority)) return
+  const authorizationContext = { ...context, executionAuthority } satisfies AgentExecutionAuthorizationContext<TRuntimeConfig, CALL_OPTIONS>
+  if (await definition?.authorizeExecution?.(authorizationContext) === true) return
+
+  const name = definition?.name || context.agentIdentity?.name
+  const target = name ? `Agent "${name}"` : "Agent"
+  throw new Error(`[vitehub] ${target} requires execution authorization for its resolved authority (${executionAuthoritySummary(executionAuthority)}). Add defineAgent({ authorizeExecution }) and return true only when this invocation may exercise that authority.`)
+}
+
 async function createAgentInvocationContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -1471,18 +1585,33 @@ async function createAgentInvocationContext<
     const internalDefinition = definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined
     const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig>> | undefined
     const workspaceOptions = workspaceDefinition?.__vitehubWorkspaceAgentOptions as WorkspaceAgentOptions<AgentRuntimeConfig> | undefined
-    const driverKind = internalDefinition?.[baseAgentDriverKind] || "model"
+    const settings = settingsFromAgentDefinition(definition)
+    const driver = settings ? normalizeAgentDriver(settings) : undefined
+    const declaredDriverKind = internalDefinition?.[baseAgentDriverKind] || driver?.kind
+    const driverKind = declaredDriverKind || "model"
+    const workspaceMode = workspaceOptions ? workspaceModeFromOptions(workspaceOptions) : "read"
+    const boxDefinition = definition?.box
+    if (boxDefinition && workspaceOptions && (boxDefinition.cwd !== undefined || boxDefinition.checkout !== undefined)) {
+      throw new Error("[vitehub] defineAgent({ box, workspace }) cannot combine a Workspace with Box cwd or checkout because both own the same working tree. Remove cwd/checkout and let Workspace materialize into the Box.")
+    }
+    const runCallbackContext = {
+      ...agentInvocationCallbackContextValues(invocationContext),
+      ...callbackContext,
+      actor: invoker,
+      context: invocationContext,
+      input,
+      invoker,
+      run: context.run,
+    } satisfies AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>
+    const executionSurface = await resolveAgentExecutionSurface(definition, driver, declaredDriverKind, runCallbackContext, runtimeContext)
+    await authorizeAgentExecution(definition, executionSurface.executionAuthority, runCallbackContext)
+    const { box, harnessSandboxProvider } = executionSurface
+    if (box) invocationContext.set("agent.execution.box", box, { overwrite: true })
     const capabilitiesResolver = internalDefinition?.[baseAgentCapabilitiesResolver]
     const invocationResolvedCapabilities = capabilitiesResolver
       ? await resolveAgentCapabilityDefinitions(capabilitiesResolver, {
-          ...agentInvocationCallbackContextValues(invocationContext),
-          ...callbackContext,
-          actor: invoker,
-          context: invocationContext,
+          ...runCallbackContext,
           driver: { kind: driverKind },
-          input,
-          invoker,
-          run: context.run,
         })
       : []
     const channelCapabilities = activeAgentChannel(definition?.channels, invocationContext, context.run)?.channel.capabilities || []
@@ -1491,31 +1620,11 @@ async function createAgentInvocationContext<
       ...(definition?.capabilities || []),
       ...channelCapabilities,
     ]) as AgentCapabilityDefinition<TRuntimeConfig>[]
-    const workspaceMode = workspaceOptions ? workspaceModeFromOptions(workspaceOptions) : "read"
     validateAgentCapabilityComposition(resolvedCapabilityDefinitions, {
       hasBox: Boolean(definition?.box),
       hasWorkspace: Boolean(workspaceOptions),
       ...(workspaceOptions ? { workspaceMode } : {}),
     })
-    const boxDefinition = definition?.box
-    if (boxDefinition && workspaceOptions && (boxDefinition.cwd !== undefined || boxDefinition.checkout !== undefined)) {
-      throw new Error("[vitehub] defineAgent({ box, workspace }) cannot combine a Workspace with Box cwd or checkout because both own the same working tree. Remove cwd/checkout and let Workspace materialize into the Box.")
-    }
-    const box = boxDefinition
-      ? shareBoxSessions(await (await import("@vite-hub/box")).resolveBox(boxDefinition, {
-          ...callbackContext,
-          actor: invoker,
-          context: invocationContext,
-          input,
-          invoker,
-          run: context.run,
-        }, {
-          requires: (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentBoxRequirements],
-        }))
-      : undefined
-    const harnessSandboxProvider = box
-      ? (await import("./harness/box-sandbox.ts")).createBoxHarnessSandbox(box)
-      : undefined
     const workspaceName = workspaceOptions
       ? workspaceNameFromOptions(workspaceOptions, {}, context.agentIdentity)
       : undefined
@@ -2320,7 +2429,6 @@ async function executeAgentInvocation<
   options: AgentInvocationExecutionOptions,
 ): Promise<Response | AsyncIterable<StreamEvent> | unknown> {
   const customRun = hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)
-  const adapter = customRun ? undefined : await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(agent, context)
   const definition = hasAgentDefinition(agent)
     ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput>
     : undefined
@@ -2337,8 +2445,10 @@ async function executeAgentInvocation<
   }
 
   const executionFailureMessage = options.kind === "run" || customRun ? runFailureMessage : streamFailureMessage
+  let adapter: AgentAdapter<CALL_OPTIONS> | undefined
   let result: unknown
   try {
+    if (!customRun) adapter = await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(agent, context)
     if (customRun) {
       result = await agent.run(invocation)
     }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -419,6 +419,7 @@ const syntheticWorkspaceRun = Symbol.for("vitehub.syntheticWorkspaceRun")
 const baseAgentResolve = Symbol.for("vitehub.baseAgentResolve")
 const baseAgentModel = Symbol.for("vitehub.baseAgentModel")
 const baseAgentDriverKind = Symbol.for("vitehub.baseAgentDriverKind")
+const agentExecutionDriverKind = Symbol.for("vitehub.agentExecutionDriverKind")
 const baseAgentCapabilitiesResolver = Symbol.for("vitehub.baseAgentCapabilitiesResolver")
 type WorkspaceSourceNames<TWorkspace> =
   TWorkspace extends { sources: infer TSources }
@@ -560,6 +561,7 @@ type AgentDefinitionWithBaseResolve<
 > = AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput> & {
   [baseAgentCapabilitiesResolver]?: AgentCapabilitiesResolver<TRuntimeConfig, WorkspaceName, CALL_OPTIONS>
   [baseAgentDriverKind]?: AgentDriverKind
+  [agentExecutionDriverKind]?: AgentDriverKind
   [baseAgentResolve]?: BaseAgentResolver<TRuntimeConfig, CALL_OPTIONS>
   [baseAgentModel]?: AgentModelResolver<TRuntimeConfig>
   [colocatedAgentSkillsSymbol]?: ColocatedAgentSkills
@@ -1589,6 +1591,7 @@ async function createAgentInvocationContext<
     const driver = settings ? normalizeAgentDriver(settings) : undefined
     const declaredDriverKind = internalDefinition?.[baseAgentDriverKind] || driver?.kind
     const driverKind = declaredDriverKind || "model"
+    const executionDriverKind = internalDefinition?.[agentExecutionDriverKind] || declaredDriverKind
     const workspaceMode = workspaceOptions ? workspaceModeFromOptions(workspaceOptions) : "read"
     const boxDefinition = definition?.box
     if (boxDefinition && workspaceOptions && (boxDefinition.cwd !== undefined || boxDefinition.checkout !== undefined)) {
@@ -1603,7 +1606,7 @@ async function createAgentInvocationContext<
       invoker,
       run: context.run,
     } satisfies AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>
-    const executionSurface = await resolveAgentExecutionSurface(definition, driver, declaredDriverKind, runCallbackContext, runtimeContext)
+    const executionSurface = await resolveAgentExecutionSurface(definition, driver, executionDriverKind, runCallbackContext, runtimeContext)
     await authorizeAgentExecution(definition, executionSurface.executionAuthority, runCallbackContext)
     const { box, harnessSandboxProvider } = executionSurface
     if (box) invocationContext.set("agent.execution.box", box, { overwrite: true })

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1302,6 +1302,7 @@ type AgentInvocationContext<
   finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
   finishHook?: (event: AgentFinishHookEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void | AgentChannelDeliveryFinishEffectResult>
   hasCapabilityCleanup: boolean
+  harnessSandboxExecutionAuthority?: ExecutionAuthority
   harnessSandboxProvider?: object
   harnessWorkDir?: string
   hooks?: AgentHookObserverHooks
@@ -1606,6 +1607,7 @@ async function createAgentInvocationContext<
       : await resolveAgentExecutionSurface(definition, driver, executionDriverKind, runCallbackContext, runtimeContext)
     if (executionSurface) await authorizeAgentExecution(definition, executionSurface.executionAuthority, runCallbackContext)
     const box = executionSurface?.box
+    let harnessSandboxExecutionAuthority = executionSurface?.executionAuthority
     let harnessSandboxProvider = executionSurface?.harnessSandboxProvider
     if (box) invocationContext.set("agent.execution.box", box, { overwrite: true })
     const capabilitiesResolver = internalDefinition?.[baseAgentCapabilitiesResolver]
@@ -1684,6 +1686,7 @@ async function createAgentInvocationContext<
       try {
         const preparedExecutionSurface = await resolveAgentExecutionSurface(definition, driver, executionDriverKind, preparedRunCallbackContext, runtimeContext)
         await authorizeAgentExecution(definition, preparedExecutionSurface.executionAuthority, preparedRunCallbackContext)
+        harnessSandboxExecutionAuthority = preparedExecutionSurface.executionAuthority
         harnessSandboxProvider = preparedExecutionSurface.harnessSandboxProvider
       }
       catch (error) {
@@ -1757,6 +1760,7 @@ async function createAgentInvocationContext<
       globalSkills: capabilities.globalSkills,
       hasCapabilityCleanup: capabilities.hasCloseCallbacks,
       handledResponse: capabilities.response,
+      harnessSandboxExecutionAuthority,
       harnessSandboxProvider,
       harnessWorkDir: box ? "." : undefined,
       hooks: definition?.hooks as AgentHookObserverHooks | undefined,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1456,9 +1456,11 @@ function settingsFromAgentDefinition<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined): AgentSettings<TRuntimeConfig, CALL_OPTIONS> | undefined {
-  return (definition as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> & {
+  const internalDefinition = definition as AgentDefinition<TRuntimeConfig, CALL_OPTIONS> & {
     __vitehubAgentSettings?: AgentSettings<TRuntimeConfig, CALL_OPTIONS>
-  } | undefined)?.__vitehubAgentSettings
+    __vitehubWorkspaceAgentOptions?: WorkspaceAgentOptions<TRuntimeConfig, WorkspaceName, CALL_OPTIONS>
+  } | undefined
+  return internalDefinition?.__vitehubAgentSettings ?? internalDefinition?.__vitehubWorkspaceAgentOptions
 }
 
 function declaredExecutionAuthority(provider: object): ExecutionAuthority {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1626,6 +1626,7 @@ export interface AgentAdapterRunContext<
   driverContributions?: AgentDriverContribution[]
   globalSkills?: readonly AgentGlobalSkill[]
   hasCapabilityCleanup?: boolean
+  harnessSandboxExecutionAuthority?: ExecutionAuthority
   harnessSandboxProvider?: object
   harnessWorkDir?: string
   input: AgentRunInput<TOptions>

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -434,6 +434,20 @@ export interface AgentRunCallbackContext<
   run?: AgentRunMetadata
 }
 
+export interface AgentExecutionAuthorizationContext<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+  TContextValues extends object = AgentInvocationContextValues,
+> extends AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues> {
+  executionAuthority: ExecutionAuthority
+}
+
+export type AgentExecutionAuthorizer<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+  TContextValues extends object = AgentInvocationContextValues,
+> = (context: AgentExecutionAuthorizationContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>) => MaybePromise<boolean>
+
 export interface AgentRunResult {
   artifacts?: readonly PublishedAgentDeliveryArtifact[]
   finishReason?: unknown
@@ -1066,6 +1080,7 @@ type AgentSharedSettings<
   TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined,
   TOutput = unknown,
 > = {
+  authorizeExecution?: AgentExecutionAuthorizer<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   box?: BoxDefinition<AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>>
   capabilities?: TCapabilities
   channels?: AgentChannelInputs<TRuntimeConfig>
@@ -1100,6 +1115,7 @@ export interface AgentDefinition<
   TContextValues extends object = AgentInvocationContextValues,
   TOutput = unknown,
 > {
+  authorizeExecution?: AgentExecutionAuthorizer<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   box?: BoxDefinition<AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>>
   capabilities?: AgentCapabilityDefinition<TRuntimeConfig>[]
   channels?: AgentChannels<TRuntimeConfig>

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -41,7 +41,7 @@ import type { WorkspaceDevTokenOptions } from "@vite-hub/workspace/server"
 import type { ViteAgentRuntimeContext } from "./runtime-adapter.ts"
 
 const capabilityCliRunSurface = Symbol.for("vitehub.capabilityCliRunSurface")
-const baseAgentDriverKind = Symbol.for("vitehub.baseAgentDriverKind")
+const agentExecutionDriverKind = Symbol.for("vitehub.agentExecutionDriverKind")
 const workspaceRegistryId = "#vitehub-workspace-registry"
 
 interface AgentInvocationStreamBody {
@@ -491,7 +491,7 @@ function exposesCapabilityCli(agent: AgentInput): boolean {
 function withCapabilityCliRun(agent: AgentInput, cli: string, execution: AgentCapabilityCliExecutionInput): AgentInput {
   const clone = Object.create(Object.getPrototypeOf(agent)) as AgentInput
   Object.defineProperties(clone, Object.getOwnPropertyDescriptors(agent))
-  Object.defineProperty(clone, baseAgentDriverKind, { configurable: true, value: "run" })
+  Object.defineProperty(clone, agentExecutionDriverKind, { configurable: true, value: "run" })
   if (exposesCapabilityCli(agent)) Object.defineProperty(clone, capabilityCliRunSurface, { value: true })
   clone.run = async (context) => {
     const tool = context.tools?.[cli]
@@ -507,7 +507,7 @@ async function withWorkspaceCommandRun(agent: AgentInput, command: { abortSignal
   const clone = Object.create(Object.getPrototypeOf(agent)) as AgentInput
   Object.defineProperties(clone, Object.getOwnPropertyDescriptors(agent))
   const { trustedHost } = await import("@vite-hub/box")
-  Object.defineProperty(clone, baseAgentDriverKind, { configurable: true, value: "run" })
+  Object.defineProperty(clone, agentExecutionDriverKind, { configurable: true, value: "run" })
   clone.box = { runtime: trustedHost() }
   clone.run = async (context) => {
     if (!context.workspace) throw new Error("[vitehub] Agent Dev Loop command requires an Agent with a Workspace.")

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -22,6 +22,7 @@ import {
 
 import type { IncomingMessage, ServerResponse } from "node:http"
 import type { ViteDevServer } from "vite"
+import type { Box } from "@vite-hub/box"
 import type { AgentChatMessageTriggerInput } from "../chat-trigger.ts"
 import type { AgentDevLoopDiscoveryResponse, AgentInvocationStreamEvent } from "../invocation-stream.ts"
 import type {
@@ -40,6 +41,7 @@ import type { WorkspaceDevTokenOptions } from "@vite-hub/workspace/server"
 import type { ViteAgentRuntimeContext } from "./runtime-adapter.ts"
 
 const capabilityCliRunSurface = Symbol.for("vitehub.capabilityCliRunSurface")
+const baseAgentDriverKind = Symbol.for("vitehub.baseAgentDriverKind")
 const workspaceRegistryId = "#vitehub-workspace-registry"
 
 interface AgentInvocationStreamBody {
@@ -489,6 +491,7 @@ function exposesCapabilityCli(agent: AgentInput): boolean {
 function withCapabilityCliRun(agent: AgentInput, cli: string, execution: AgentCapabilityCliExecutionInput): AgentInput {
   const clone = Object.create(Object.getPrototypeOf(agent)) as AgentInput
   Object.defineProperties(clone, Object.getOwnPropertyDescriptors(agent))
+  Object.defineProperty(clone, baseAgentDriverKind, { configurable: true, value: "run" })
   if (exposesCapabilityCli(agent)) Object.defineProperty(clone, capabilityCliRunSurface, { value: true })
   clone.run = async (context) => {
     const tool = context.tools?.[cli]
@@ -500,13 +503,17 @@ function withCapabilityCliRun(agent: AgentInput, cli: string, execution: AgentCa
   return clone
 }
 
-function withWorkspaceCommandRun(agent: AgentInput, command: { abortSignal?: AbortSignal, args?: string[], command: string, timeout?: number }): AgentInput {
+async function withWorkspaceCommandRun(agent: AgentInput, command: { abortSignal?: AbortSignal, args?: string[], command: string, timeout?: number }): Promise<AgentInput> {
   const clone = Object.create(Object.getPrototypeOf(agent)) as AgentInput
   Object.defineProperties(clone, Object.getOwnPropertyDescriptors(agent))
+  const { trustedHost } = await import("@vite-hub/box")
+  Object.defineProperty(clone, baseAgentDriverKind, { configurable: true, value: "run" })
+  clone.box = { runtime: trustedHost() }
   clone.run = async (context) => {
     if (!context.workspace) throw new Error("[vitehub] Agent Dev Loop command requires an Agent with a Workspace.")
-    const { resolveBox, trustedHost } = await import("@vite-hub/" + "box") as typeof import("@vite-hub/box")
-    const host = await (await resolveBox({ runtime: trustedHost() }, {})).open({ signal: command.abortSignal })
+    const box = context.context.get<Box>("agent.execution.box")
+    if (!box) throw new Error("[vitehub] Agent Dev Loop command requires its authorized Box execution surface.")
+    const host = await box.open({ signal: command.abortSignal })
     try {
       return await runWorkspaceDevCommand({
         abortSignal: command.abortSignal,
@@ -634,7 +641,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
       : timeout
     const commandAbort = createWorkspaceCommandAbortSignal(req, abortSignal)
     try {
-      const result = await runAgentInline(withWorkspaceCommandRun(entry.agent, {
+      const result = await runAgentInline(await withWorkspaceCommandRun(entry.agent, {
         abortSignal: commandAbort.signal,
         ...(args ? { args } : {}),
         command: body.workspaceCommand.command,

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -504,8 +504,7 @@ async function resolvedDriverExecutionAuthority<
   driver: ReturnType<typeof normalizeAgentDriver<TRuntimeConfig, CALL_OPTIONS>>,
   context: AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS>,
 ): Promise<ExecutionAuthority> {
-  if (driver.kind === "model") return noExecutionAuthority
-  if (driver.kind !== "harness") return unknownExecutionAuthority
+  if (driver.kind !== "harness") return noExecutionAuthority
   if (box) {
     const { resolveBox } = await import("@vite-hub/box")
     const resolvedBox = await resolveBox(box, context, { requires: driver.requires })
@@ -653,7 +652,7 @@ function staticDriverMetadata<
       kind: "harness",
     }
   }
-  return { executionAuthority: unknownExecutionAuthority, kind: "run" }
+  return { executionAuthority: noExecutionAuthority, kind: "run" }
 }
 
 async function resolvedDriverMetadata<
@@ -687,7 +686,7 @@ async function resolvedDriverMetadata<
       kind: "harness",
     }
   }
-  return { executionAuthority: unknownExecutionAuthority, kind: "run" }
+  return { executionAuthority: noExecutionAuthority, kind: "run" }
 }
 
 function staticConfigMetadata<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(

--- a/packages/agent/test/adapter-definition.ts
+++ b/packages/agent/test/adapter-definition.ts
@@ -2,6 +2,7 @@ import type { AgentAdapter, AgentDefinition } from "../src/index.ts"
 
 export function adapterDefinition<T extends Pick<AgentAdapter, "generate"> & Partial<Pick<AgentAdapter, "name" | "stream">>>(adapter: T): AgentDefinition {
   return {
+    authorizeExecution: () => true,
     resolve: async () => ({ ...adapter, name: adapter.name || "test" }),
   }
 }

--- a/packages/agent/test/box.test.ts
+++ b/packages/agent/test/box.test.ts
@@ -86,6 +86,7 @@ describe("Agent Box", () => {
       const { codexDriver } = await import("../src/harness/codex.ts")
       const workspaceName = `box-live-${Date.now()}`
       const agent = defineAgent({
+        authorizeExecution: () => true,
         name: workspaceName,
         box: { runtime: trustedHost({ stateRoot }) },
         capabilities: [workspaceShell({ commands: ["sh"], mode: "write" })],
@@ -139,6 +140,7 @@ describe("Agent Box", () => {
       const { skills } = await import("../src/capabilities.ts")
       const { codexDriver } = await import("../src/harness/codex.ts")
       const agent = defineAgent<any, { worktreePath: string }>({
+        authorizeExecution: () => true,
         box: {
           cwd: ({ input }) => input.options?.worktreePath,
           env: { GH_TOKEN: "box-token" },
@@ -223,6 +225,7 @@ describe("Agent Box", () => {
       const { skills } = await import("../src/capabilities.ts")
       const { codexDriver } = await import("../src/harness/codex.ts")
       const agent = defineAgent({
+        authorizeExecution: () => true,
         box: {
           checkout: { ref: "refs/heads/main", remote: repository, sha },
           home: {
@@ -286,6 +289,7 @@ describe("Agent Box", () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { codexDriver } = await import("../src/harness/codex.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       box: {
         cwd: "/workspace",
         runtime: {
@@ -356,6 +360,7 @@ describe("Agent Box", () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { codexDriver } = await import("../src/harness/codex.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       box: {
         runtime: {
           name: "workspace-host",

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -644,6 +644,7 @@ describe("agent chat capability discovery", () => {
     const { defineAgent, defineCapability } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         defineCapability({
           cli: {
@@ -693,6 +694,7 @@ describe("agent chat capability discovery", () => {
     const { defineAgent, defineCapability } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         defineCapability({
           cli: {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -686,6 +686,55 @@ describe("agent chat capability discovery", () => {
     })
   })
 
+  it("preserves harness driver context for invocation-resolved Capability CLI commands", async () => {
+    const root = await createTempRoot("vitehub-agent-invocation-stream-dynamic-harness-cli-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "chat.ts"), "export default {}", "utf8")
+
+    const { defineAgent, defineCapability } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const inventory = defineCapability({
+      cli: {
+        commands: {
+          list: {
+            output: { format: "json" },
+            run: () => [{ id: "item_1" }],
+          },
+        },
+        name: "inventory",
+      },
+      id: "inventory-runtime",
+    })
+    const agent = defineAgent({
+      authorizeExecution: () => true,
+      capabilities: context => context.driver.kind === "harness" ? [inventory] : [],
+      driver: { harness: {} as never },
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent()
+
+    await configurePluginServer(plugin, server)
+
+    const response = await invokeMiddleware(handlers[0]!, {
+      agent: "chat",
+      cli: {
+        argv: ["list", "--json"],
+        name: "inventory",
+      },
+    }, agentInvocationStreamRoute, {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(JSON.parse(response.body)).toMatchObject({
+      capability: "inventory-runtime",
+      cli: "inventory",
+      exitCode: 0,
+      json: [{ id: "item_1" }],
+    })
+  })
+
   it("respects Capability CLI opt-out through the Vite endpoint", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-cli-opt-out-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -442,6 +442,7 @@ describe("agent eval", () => {
 
     defineEval({
       agent: defineAgent({
+        authorizeExecution: () => true,
         driver: {
           harness: { provider: "codex" },
         },

--- a/packages/agent/test/fixtures/quiver-sku-runtime.ts
+++ b/packages/agent/test/fixtures/quiver-sku-runtime.ts
@@ -21,6 +21,7 @@ export interface QuiverPortalRuntimeConfig {
 }
 
 const agent: AgentDefinition<QuiverPortalRuntimeConfig> = {
+  authorizeExecution: () => true,
   name: "quiver-sku-runtime",
   async resolve(runtime) {
     const portal = runtime.runtimeConfig?.portal

--- a/packages/agent/test/invocation-lifecycle.test.ts
+++ b/packages/agent/test/invocation-lifecycle.test.ts
@@ -98,6 +98,7 @@ async function createLifecycleProbe(
   })
   driver.execute.mockImplementation(() => scenario.execute?.(events))
   const agent = defineAgent({
+    authorizeExecution: () => true,
     capabilities: [defineCapability({
       close,
       id: "lifecycle",

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import type { IncomingMessage, ServerResponse } from "node:http"
 import type { Connect } from "vite"
+import type { AgentCapabilitiesResolverContext } from "../src/index.ts"
 
 const order = vi.hoisted(() => [] as string[])
 const diff = vi.hoisted(() => vi.fn(async () => {
@@ -522,6 +523,42 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
         processes: "arbitrary",
       },
     }))
+  })
+
+  it("preserves harness driver context while preparing Agent Workspace commands", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-workspace-command-harness-context-"))
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
+
+    const { readWorkspaceDevToken, workspaceDevTokenHeader, workspaceDevTokenServerId } = await import("@vite-hub/workspace/server")
+    const { defineAgent } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const capabilityDriverKinds: string[] = []
+    const agent = defineAgent({
+      authorizeExecution: () => true,
+      capabilities: (context: AgentCapabilitiesResolverContext) => {
+        capabilityDriverKinds.push(context.driver.kind)
+        return []
+      },
+      driver: { harness: {} as never },
+      workspace: { mode: "write", name: "shared" },
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent()
+
+    await configurePluginServer(plugin, server)
+    const token = await readWorkspaceDevToken(root, { serverId: workspaceDevTokenServerId(3000) })
+    const response = await invokeMiddleware(handlers[0]!, {
+      agent: "support",
+      workspaceCommand: { command: "ls" },
+    }, agentInvocationStreamRoute, {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+      [workspaceDevTokenHeader]: token,
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(capabilityDriverKinds).toEqual(["harness"])
   })
 
   it("installs hosted workspace runtime before hosted Agent Workspace commands", async () => {

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -388,6 +388,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: { run: () => "unused" },
       workspace: {
         mode: "write",
@@ -454,7 +455,9 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     const { readWorkspaceDevToken, workspaceDevTokenHeader, workspaceDevTokenServerId } = await import("@vite-hub/workspace/server")
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const authorizeExecution = vi.fn(() => true)
     const agent = defineAgent({
+      authorizeExecution,
       capabilities: [{
         id: "support-files",
         workspaceSources: {
@@ -509,6 +512,16 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     expect(workspaceSessionDiff).toHaveBeenCalled()
     expect(workspaceSessionCommit).toHaveBeenCalledWith({ message: "workspace dev command" })
     expect(workspaceSessionClose).toHaveBeenCalled()
+    expect(authorizeExecution).toHaveBeenCalledWith(expect.objectContaining({
+      executionAuthority: {
+        credentials: "unknown",
+        environment: "selected",
+        filesystem: { access: "read-write", scope: "host" },
+        isolation: "none",
+        network: "unrestricted",
+        processes: "arbitrary",
+      },
+    }))
   })
 
   it("installs hosted workspace runtime before hosted Agent Workspace commands", async () => {
@@ -520,6 +533,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: { run: () => "unused" },
       workspace: {
         mode: "write",
@@ -558,6 +572,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: { run: () => "unused" },
       workspace: { mode: "write" },
     })
@@ -626,6 +641,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: { run: () => "unused" },
       workspace: { mode: "write", name: "shared" },
     })
@@ -697,6 +713,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
       order.push("agent-finish")
     })
     const agent = defineAgent({
+      authorizeExecution: () => true,
       channels: {
         github: defineChannel("github", {
           effects: {},
@@ -807,6 +824,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         access({
           workspace: {
@@ -890,6 +908,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       channels: {
         web: defineChannel("web-chat", {}),
       },
@@ -962,6 +981,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       channels: {
         github: defineChannel("github", {
           effects: {},
@@ -1029,6 +1049,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     const { chat } = await import("../src/capabilities.ts")
     const { defineAgent, streamAgentTrigger } = await import("../src/index.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [chat()],
       driver: {
         harness: { provider: "codex" },

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -6077,6 +6077,7 @@ describe("server helpers", () => {
       version: "agent-v1",
     }
     const agent = {
+      authorizeExecution: () => true,
       capabilities: [
         defineChatCapability({
           platforms: {
@@ -6512,6 +6513,7 @@ describe("server helpers", () => {
       version: "agent-v1",
     }
     const agent = {
+      authorizeExecution: () => true,
       capabilities: [
         defineChatCapability({
           platforms: {
@@ -6587,6 +6589,7 @@ describe("server helpers", () => {
       version: "agent-v1",
     }
     const agent = {
+      authorizeExecution: () => true,
       capabilities: [
         defineChatCapability({
           platforms: {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1913,6 +1913,30 @@ describe("agent message protocol", () => {
     })
   })
 
+  it("rejects unsafe harness adapters used without invocation authorization", async () => {
+    const { defineAgent, resolveAgent } = await import("../src/index.ts")
+    const { createAgentInvocationContextStore } = await import("../src/invocation-context.ts")
+    const invoker = { id: "anonymous:test", kind: "anonymous", label: "Anonymous" }
+    const agent = defineAgent({
+      driver: {
+        harness: { provider: "codex" },
+        sandbox: { executionAuthority: unknownExecutionAuthority, providerId: "unsafe" },
+      },
+    })
+    const adapter = await resolveAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() })
+
+    await expect(adapter.generate({
+      actor: invoker,
+      context: createAgentInvocationContextStore(),
+      input: { prompt: "hello" },
+      invoker,
+      messages: [],
+      prompt: "hello",
+      runtime: { memo: vi.fn(), runtime: "unknown", runtimeConfig: {}, waitUntil: vi.fn() },
+    })).rejects.toThrow("requires execution authorization")
+    expect(harnessCreateSession).not.toHaveBeenCalled()
+  })
+
   it("preserves non-text chat history in harness prompts", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const session = { destroy: vi.fn() }

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -116,11 +116,11 @@ describe("agent message protocol", () => {
     expect(run).toHaveBeenCalledOnce()
   })
 
-  it("rejects unresolved execution authority before Agent-controlled work", async () => {
+  it("rejects unresolved static execution authority before Agent-controlled work", async () => {
     const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
     const capabilityResolver = vi.fn(() => [defineCapability({ id: "unsafe", prepare: vi.fn() })])
     const inputHook = vi.fn()
-    const sandbox = vi.fn(() => ({ executionAuthority: unknownExecutionAuthority, providerId: "unsafe" }))
+    const sandbox = { executionAuthority: unknownExecutionAuthority, providerId: "unsafe" }
     const agent = defineAgent({
       capabilities: capabilityResolver,
       driver: { harness: { harnessId: "fixture" }, sandbox },
@@ -135,7 +135,6 @@ describe("agent message protocol", () => {
     }, {
       context: { authorizeExecution: true },
     })).rejects.toThrow('Agent "public-shell" requires execution authorization')
-    expect(sandbox).toHaveBeenCalledOnce()
     expect(capabilityResolver).not.toHaveBeenCalled()
     expect(inputHook).not.toHaveBeenCalled()
     expect(harnessGenerate).not.toHaveBeenCalled()
@@ -1800,15 +1799,24 @@ describe("agent message protocol", () => {
   })
 
   it("resolves function-valued driver.sandbox for each invocation", async () => {
-    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
     const session = { destroy: vi.fn() }
     const provider = { providerId: "local-test", runId: "run-1" }
-    const sandbox = vi.fn(() => provider)
+    const sandbox = vi.fn(({ context }) => {
+      expect(context.get("sandbox-selection")).toBe("prepared")
+      return provider
+    })
     harnessCreateSession.mockResolvedValueOnce(session)
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
 
     const agent = defineAgent({
       authorizeExecution: () => true,
+      capabilities: [defineCapability({
+        id: "sandbox-selection",
+        prepare({ context }) {
+          context.set("sandbox-selection", "prepared")
+        },
+      })],
       driver: {
         harness: { provider: "codex" },
         sandbox,

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -188,6 +188,32 @@ describe("agent message protocol", () => {
     expect(harnessCreateSession).not.toHaveBeenCalled()
   })
 
+  it("rejects harness adapters that mutate the authorized execution authority", async () => {
+    const { defineAgent, runAgentInline } = await import("../src/index.ts")
+    const provider: {
+      executionAuthority: typeof noExecutionAuthority | typeof unknownExecutionAuthority
+      providerId: string
+    } = { executionAuthority: noExecutionAuthority, providerId: "unsafe" }
+    const adaptSandbox = vi.fn(() => {
+      provider.executionAuthority = unknownExecutionAuthority
+      return provider
+    })
+    const agent = defineAgent({
+      driver: {
+        harness: { [Symbol.for("vitehub.harnessSandboxAdapter")]: adaptSandbox, harnessId: "fixture" },
+        sandbox: provider,
+      },
+    })
+
+    await expect(runAgentInline(agent, {
+      memo: vi.fn(),
+      runtime: "vite",
+      waitUntil: vi.fn(),
+    }, {})).rejects.toThrow("Harness sandbox adapters must preserve the executionAuthority")
+    expect(adaptSandbox).toHaveBeenCalledWith(provider, { box: false, defaultSandbox: false })
+    expect(harnessCreateSession).not.toHaveBeenCalled()
+  })
+
   it("rejects opaque Agent resolution until unknown authority is authorized", async () => {
     const { runAgentInline } = await import("../src/index.ts")
     const resolve = vi.fn(async () => ({ generate: vi.fn(), name: "opaque" }))

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -213,6 +213,31 @@ describe("agent message protocol", () => {
     expect(harnessCreateSession).not.toHaveBeenCalled()
   })
 
+  it("rejects sandbox authority mutated after invocation authorization", async () => {
+    const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
+    const provider: {
+      executionAuthority: typeof noExecutionAuthority | typeof unknownExecutionAuthority
+      providerId: string
+    } = { executionAuthority: noExecutionAuthority, providerId: "unsafe" }
+    const mutateAuthority = defineCapability({
+      id: "mutate-authority",
+      prepare: () => {
+        provider.executionAuthority = unknownExecutionAuthority
+      },
+    })
+    const agent = defineAgent({
+      capabilities: [mutateAuthority],
+      driver: { harness: { harnessId: "fixture" }, sandbox: provider },
+    })
+
+    await expect(runAgentInline(agent, {
+      memo: vi.fn(),
+      runtime: "vite",
+      waitUntil: vi.fn(),
+    }, {})).rejects.toThrow("Harness sandbox adapters must preserve the executionAuthority")
+    expect(harnessCreateSession).not.toHaveBeenCalled()
+  })
+
   it("rejects opaque Agent resolution until unknown authority is authorized", async () => {
     const { runAgentInline } = await import("../src/index.ts")
     const resolve = vi.fn(async () => ({ generate: vi.fn(), name: "opaque" }))

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -166,6 +166,25 @@ describe("agent message protocol", () => {
     expect(harnessAgentSettings.at(-1)?.sandbox).toBe(provider)
   })
 
+  it("preserves sandbox settings on source-root workspace Agent clones", async () => {
+    const { defineAgent, runAgentInline } = await import("../src/index.ts")
+    const { workspaceAgentWithSourceRoot } = await import("../src/workspace-agent.ts")
+    const provider = { executionAuthority: noExecutionAuthority, providerId: "source-root" }
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    harnessGenerate.mockResolvedValue({ text: "cloned" })
+    const agent = workspaceAgentWithSourceRoot(defineAgent({
+      driver: { harness: { harnessId: "fixture" }, sandbox: provider },
+      workspace: {},
+    }), "/workspace")
+
+    await expect(runAgentInline(agent, {
+      memo: vi.fn(),
+      runtime: "vite",
+      waitUntil: vi.fn(),
+    }, {}, { output: "raw" })).resolves.toEqual({ text: "cloned" })
+    expect(harnessAgentSettings.at(-1)?.sandbox).toBe(provider)
+  })
+
   it("rejects harness adapters that change the authorized execution authority", async () => {
     const { defineAgent, runAgentInline } = await import("../src/index.ts")
     const provider = { executionAuthority: unknownExecutionAuthority, providerId: "unsafe" }

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { createMessage, getMessageText } from "@vite-hub/agent"
 import { createRateLimiter } from "@vite-hub/rate-limit"
 import { memoryRateLimitDriver } from "@vite-hub/rate-limit/drivers/memory"
-import { createTraceEventLog, deriveTraceRuns, emitTraceEvent, unknownExecutionAuthority } from "@vite-hub/runtime"
+import { createTraceEventLog, deriveTraceRuns, emitTraceEvent, noExecutionAuthority, unknownExecutionAuthority } from "@vite-hub/runtime"
 import { chat, title, schedule, subagents } from "../src/capabilities.ts"
 import { toJsonCompatibleValue } from "../src/tool-runtime.ts"
 import { adapterDefinition } from "./adapter-definition.ts"
@@ -103,6 +103,104 @@ async function failedTitleInvocation(options: {
 }
 
 describe("agent message protocol", () => {
+  it("keeps no-authority Agent Drivers anonymously invocable", async () => {
+    const { defineAgent, runAgentInline } = await import("../src/index.ts")
+    const run = vi.fn(() => "public")
+    const agent = defineAgent({ driver: { run } })
+
+    await expect(runAgentInline(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).resolves.toBe("public")
+    expect(run).toHaveBeenCalledOnce()
+  })
+
+  it("rejects unresolved execution authority before Agent-controlled work", async () => {
+    const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
+    const capabilityResolver = vi.fn(() => [defineCapability({ id: "unsafe", prepare: vi.fn() })])
+    const inputHook = vi.fn()
+    const sandbox = vi.fn(() => ({ executionAuthority: unknownExecutionAuthority, providerId: "unsafe" }))
+    const agent = defineAgent({
+      capabilities: capabilityResolver,
+      driver: { harness: { harnessId: "fixture" }, sandbox },
+      hooks: { "agent:input": inputHook },
+      name: "public-shell",
+    })
+
+    await expect(runAgentInline(agent, {
+      memo: vi.fn(),
+      runtime: "vite",
+      waitUntil: vi.fn(),
+    }, {
+      context: { authorizeExecution: true },
+    })).rejects.toThrow('Agent "public-shell" requires execution authorization')
+    expect(sandbox).toHaveBeenCalledOnce()
+    expect(capabilityResolver).not.toHaveBeenCalled()
+    expect(inputHook).not.toHaveBeenCalled()
+    expect(harnessGenerate).not.toHaveBeenCalled()
+  })
+
+  it("authorizes and reuses the exact resolved execution surface", async () => {
+    const { defineAgent, runAgentInline } = await import("../src/index.ts")
+    const provider = { executionAuthority: unknownExecutionAuthority, providerId: "authorized" }
+    const sandbox = vi.fn(() => provider)
+    const authorizeExecution = vi.fn(() => true)
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    harnessGenerate.mockResolvedValue({ text: "authorized" })
+    const agent = defineAgent({
+      authorizeExecution,
+      driver: { harness: { harnessId: "fixture" }, sandbox },
+      name: "private-shell",
+    })
+
+    await expect(runAgentInline(agent, {
+      memo: vi.fn(),
+      runtime: "vite",
+      waitUntil: vi.fn(),
+    }, {}, { output: "raw" })).resolves.toEqual({ text: "authorized" })
+    expect(sandbox).toHaveBeenCalledOnce()
+    expect(authorizeExecution).toHaveBeenCalledWith(expect.objectContaining({
+      executionAuthority: unknownExecutionAuthority,
+      input: {},
+    }))
+    expect(harnessAgentSettings.at(-1)?.sandbox).toBe(provider)
+  })
+
+  it("rejects harness adapters that change the authorized execution authority", async () => {
+    const { defineAgent, runAgentInline } = await import("../src/index.ts")
+    const provider = { executionAuthority: unknownExecutionAuthority, providerId: "unsafe" }
+    const adaptSandbox = vi.fn(() => ({ ...provider, executionAuthority: noExecutionAuthority }))
+    const agent = defineAgent({
+      authorizeExecution: () => true,
+      driver: {
+        harness: { [Symbol.for("vitehub.harnessSandboxAdapter")]: adaptSandbox, harnessId: "fixture" },
+        sandbox: provider,
+      },
+    })
+
+    await expect(runAgentInline(agent, {
+      memo: vi.fn(),
+      runtime: "vite",
+      waitUntil: vi.fn(),
+    }, {})).rejects.toThrow("Harness sandbox adapters must preserve the executionAuthority")
+    expect(adaptSandbox).toHaveBeenCalledWith(provider, { box: false, defaultSandbox: false })
+    expect(harnessCreateSession).not.toHaveBeenCalled()
+  })
+
+  it("rejects opaque Agent resolution until unknown authority is authorized", async () => {
+    const { runAgentInline } = await import("../src/index.ts")
+    const resolve = vi.fn(async () => ({ generate: vi.fn(), name: "opaque" }))
+    const agent = { name: "opaque", resolve }
+
+    await expect(runAgentInline(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).rejects.toThrow('Agent "opaque" requires execution authorization')
+    expect(resolve).not.toHaveBeenCalled()
+  })
+
   it("normalizes undefined tool output to JSON null", () => {
     expect(toJsonCompatibleValue(undefined)).toBeNull()
   })
@@ -201,6 +299,7 @@ describe("agent message protocol", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
     const harnessAgent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: context => context.driver.kind === "harness" ? [selected] : [],
       driver: { harness: { provider: "codex" } },
     })
@@ -1339,6 +1438,7 @@ describe("agent message protocol", () => {
   it("runs subagent tools with the resolved parent runtime context", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const browserAgent = {
+      authorizeExecution: () => true,
       async resolve(context) {
         return {
           async generate({ invoker, runtime }) {
@@ -1405,6 +1505,7 @@ describe("agent message protocol", () => {
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness,
       },
@@ -1448,6 +1549,7 @@ describe("agent message protocol", () => {
       },
     }
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: { harness: { provider: "codex" } },
       output: { schema },
       runtime: false,
@@ -1463,6 +1565,7 @@ describe("agent message protocol", () => {
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     harnessGenerate.mockResolvedValueOnce({ text: "hello" })
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: { harness: { provider: "codex" } },
       output: {
         schema: {
@@ -1481,7 +1584,7 @@ describe("agent message protocol", () => {
 
   it("requires explicit harness sandboxes on runtimes without local processes", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
-    const agent = defineAgent({ driver: { harness: { provider: "codex" } } })
+    const agent = defineAgent({ authorizeExecution: () => true, driver: { harness: { provider: "codex" } } })
 
     await expect(runAgent(agent, {
       memo: vi.fn(),
@@ -1490,6 +1593,7 @@ describe("agent message protocol", () => {
     }, { prompt: "hello" })).rejects.toThrow("require a process-capable driver.sandbox provider")
 
     const configuredAgent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
         sandbox: { providerId: "local" },
@@ -1509,7 +1613,7 @@ describe("agent message protocol", () => {
     harnessCreateSession.mockResolvedValueOnce(session)
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
 
-    const agent = defineAgent({ driver: { harness } })
+    const agent = defineAgent({ authorizeExecution: () => true, driver: { harness } })
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "hello" })).resolves.toMatchObject({ text: "ok" })
 
     expect(harnessAgentSettings.at(-1)?.sandbox).toMatchObject({ providerId: "local" })
@@ -1521,7 +1625,7 @@ describe("agent message protocol", () => {
     }, { prompt: "hello" })).rejects.toThrow("require a process-capable driver.sandbox provider")
 
     const provider = { providerId: "remote" }
-    const configuredAgent = defineAgent({ driver: { harness, sandbox: provider } })
+    const configuredAgent = defineAgent({ authorizeExecution: () => true, driver: { harness, sandbox: provider } })
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
     await expect(runAgent(configuredAgent, {
@@ -1537,7 +1641,7 @@ describe("agent message protocol", () => {
     const session = { destroy: vi.fn() }
     harnessCreateSession.mockResolvedValueOnce(session)
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
-    const agent = defineAgent({ driver: { harness: { builtinTools: {}, harnessId: "codex" } } })
+    const agent = defineAgent({ authorizeExecution: () => true, driver: { harness: { builtinTools: {}, harnessId: "codex" } } })
 
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "hello" })).resolves.toMatchObject({ text: "ok" })
 
@@ -1563,6 +1667,7 @@ describe("agent message protocol", () => {
     })
 
     const agent = indexA.defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         access({
           workspace: {
@@ -1604,6 +1709,7 @@ describe("agent message protocol", () => {
       harnessGenerate.mockResolvedValueOnce({ text: "ok" })
 
       const agent = defineAgent({
+        authorizeExecution: () => true,
         driver: {
           harness,
         },
@@ -1629,6 +1735,7 @@ describe("agent message protocol", () => {
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness,
         sandbox: provider,
@@ -1656,8 +1763,8 @@ describe("agent message protocol", () => {
       .mockResolvedValueOnce({ destroy: vi.fn() })
     harnessGenerate.mockResolvedValue({ text: "ok" })
 
-    const defaultAgent = defineAgent({ driver: { harness } })
-    const configuredAgent = defineAgent({ driver: { harness, sandbox: provider } })
+    const defaultAgent = defineAgent({ authorizeExecution: () => true, driver: { harness } })
+    const configuredAgent = defineAgent({ authorizeExecution: () => true, driver: { harness, sandbox: provider } })
 
     await runAgent(defaultAgent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "default" })
     await runAgent(configuredAgent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "configured" })
@@ -1675,6 +1782,7 @@ describe("agent message protocol", () => {
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
         sandbox,
@@ -1702,6 +1810,7 @@ describe("agent message protocol", () => {
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
         sandbox,
@@ -1734,6 +1843,7 @@ describe("agent message protocol", () => {
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
         sandbox: provider,
@@ -1796,6 +1906,7 @@ describe("agent message protocol", () => {
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness,
         sessionKey,
@@ -1836,6 +1947,7 @@ describe("agent message protocol", () => {
     harnessGenerate.mockResolvedValue({ text: "ok" })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
         instructions,
@@ -1894,6 +2006,7 @@ describe("agent message protocol", () => {
     })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
         instructions: "Review the exact pull request head.",
@@ -1919,6 +2032,7 @@ describe("agent message protocol", () => {
 
     for (const workDir of ["", "   ", "../repo", "repo/../../tmp", "/tmp/repo", "repo\\nested", () => 42] as const) {
       const agent = defineAgent({
+        authorizeExecution: () => true,
         driver: {
           harness: { provider: "codex" },
           workDir: workDir as never,
@@ -1935,6 +2049,7 @@ describe("agent message protocol", () => {
   it("rejects non-string harness instructions before creating a session", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
         instructions: (() => 42) as never,
@@ -1959,6 +2074,7 @@ describe("agent message protocol", () => {
     })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         credentials: { label: "local Codex", source: "ambient" },
         harness: { provider: "codex" },
@@ -1995,6 +2111,7 @@ describe("agent message protocol", () => {
     })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         inputCommands({
           commands: {
@@ -2042,6 +2159,7 @@ describe("agent message protocol", () => {
     harnessCreateSession.mockResolvedValueOnce(session)
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: { harness: { provider: "codex" } },
     })
 
@@ -2068,6 +2186,7 @@ describe("agent message protocol", () => {
     })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -2095,6 +2214,7 @@ describe("agent message protocol", () => {
     })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -2140,6 +2260,7 @@ describe("agent message protocol", () => {
     })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -2206,6 +2327,7 @@ describe("agent message protocol", () => {
     })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -2253,6 +2375,7 @@ describe("agent message protocol", () => {
     })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
         sandbox: { provider: "sandbox" },
@@ -2290,6 +2413,7 @@ describe("agent message protocol", () => {
     })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -2317,6 +2441,7 @@ describe("agent message protocol", () => {
     harnessGenerate.mockResolvedValueOnce({ text: "ok" })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         defineCapability({
           id: "model-tools",
@@ -2354,6 +2479,7 @@ describe("agent message protocol", () => {
     }))
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         defineCapability({
           id: "model-tools",
@@ -2376,6 +2502,7 @@ describe("agent message protocol", () => {
     const { webSearch } = await import("../src/capabilities.ts")
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [webSearch({ mode: "model" })],
       driver: {
         harness: { provider: "codex" },
@@ -2408,6 +2535,7 @@ describe("agent message protocol", () => {
     harnessGenerate.mockResolvedValue({ text: "ok" })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
         sessionKey: "thread-1",
@@ -2465,6 +2593,7 @@ describe("agent message protocol", () => {
     harnessGenerate.mockResolvedValue({ text: "ok" })
 
     const agent = defineAgent<any, { workspace: string }>({
+      authorizeExecution: () => true,
       box: {
         cwd: ({ input }) => input.options?.workspace,
         runtime: {
@@ -2516,6 +2645,7 @@ describe("agent message protocol", () => {
     harnessGenerate.mockResolvedValue({ text: "ok" })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
         sandbox: { provider: "sandbox" },
@@ -2569,6 +2699,7 @@ describe("agent message protocol", () => {
     } as never)).toThrow("driver.credentials.value")
 
     expect(() => defineAgent({
+      authorizeExecution: () => true,
       driver: { harness: { provider: "codex" }, instructions: "used" },
     })).not.toThrow()
 
@@ -9178,6 +9309,7 @@ describe("agent message protocol", () => {
   it("resolves static subagent tools with the resolved runtime context", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const browserAgent = {
+      authorizeExecution: () => true,
       async resolve(context) {
         expect(context.agentIdentity).toEqual({ name: "reviewer" })
         return {
@@ -9444,6 +9576,35 @@ describe("agent message protocol", () => {
       })
     })
 
+    it("recomputes execution authorization inside queued Workflow Runs", async () => {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const authorizeExecution = vi.fn(() => false)
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+      const agent = defineAgent({
+        authorizeExecution,
+        driver: {
+          harness: { harnessId: "fixture" },
+          sandbox: { executionAuthority: unknownExecutionAuthority, providerId: "workflow-unsafe" },
+        },
+      })
+
+      const run = await runAgent(agent, {
+        agentIdentity: { name: "private-workflow-agent" },
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, {}) as { id: string }
+
+      expect(authorizeExecution).not.toHaveBeenCalled()
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("private-workflow-agent", run.id)).resolves.toMatchObject({ status: "failed" })
+      expect(authorizeExecution).toHaveBeenCalledOnce()
+      expect(harnessCreateSession).not.toHaveBeenCalled()
+    })
+
     it("does not serialize abort signals into Agent Workflow payloads", async () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")
@@ -9669,6 +9830,24 @@ describe("agent message protocol", () => {
         runtime: "vercel",
         waitUntil: vi.fn(),
       }, {})).resolves.toBe("child")
+    })
+
+    it("authorizes manually composed child Agents independently", async () => {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const resolve = vi.fn(async () => ({ generate: vi.fn(), name: "opaque-child" }))
+      const child = { name: "opaque-child", resolve }
+      const parent = defineAgent({
+        runtime: false,
+        driver: { run: context => runAgent(child, context, {}) },
+      })
+
+      await expect(runAgent(parent, {
+        agentIdentity: { name: "parent" },
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: vi.fn(),
+      }, {})).rejects.toThrow('Agent "opaque-child" requires execution authorization')
+      expect(resolve).not.toHaveBeenCalled()
     })
 
     it("does not persist discovered identity ownership on caller contexts", async () => {
@@ -9967,6 +10146,7 @@ describe("agent message protocol", () => {
       setWorkflowRuntimeConfig({ provider: "vercel" })
 
       const agent = {
+        authorizeExecution: () => true,
         runtime: workflow("configured-agent"),
         async resolve(context) {
           return {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -11,6 +11,7 @@ import { defineAgentRunEvents, type AgentRunEventPublisher } from "../src/server
 import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentOutputExtensionProvider, AgentToolDefinition, AgentToolSchema, StreamEvent } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
 import type { StandardSchemaV1 } from "@standard-schema/spec"
+import type { ExecutionAuthority } from "@vite-hub/runtime"
 import { file, github as githubSource, type ReadonlyWorkspaceFacade } from "@vite-hub/workspace"
 import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatRunContext, FetchCapabilityToolOptions, PullRequestContextValue, RepositoryHostClient, RepositoryHostContextValue, TranscriptionResult } from "../src/capabilities.ts"
 
@@ -448,6 +449,12 @@ describe("agent public types", () => {
     })
 
     defineAgent({
+      authorizeExecution({ executionAuthority, input, invoker }) {
+        expectTypeOf(executionAuthority).toEqualTypeOf<ExecutionAuthority>()
+        expectTypeOf(input.prompt).toEqualTypeOf<AgentRunInput["prompt"]>()
+        expectTypeOf(invoker).toEqualTypeOf<AgentInvoker>()
+        return true
+      },
       driver: {
         harness: { provider: "codex" },
         sandbox: ({ input }) => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -323,6 +323,7 @@ describe("defineAgent workspace option", () => {
     exists.mockResolvedValue(true)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       capabilities: [skills({ path: "skills/agent-browser", shellExecution: "write" })],
       driver: {
         harness: { provider: "codex" },
@@ -387,6 +388,7 @@ describe("defineAgent workspace option", () => {
     })
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       capabilities: [blob({ mode: "write" })],
       driver: {
         harness: { provider: "codex" },
@@ -488,6 +490,7 @@ describe("defineAgent workspace option", () => {
     ))
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         blob({ assetPaths: ["artifacts"], mode: "write", policy: "deny" }),
         defineCapability({
@@ -574,6 +577,7 @@ describe("defineAgent workspace option", () => {
     } as unknown as WritableWorkspaceFacade)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         access({
           workspace: {
@@ -631,6 +635,7 @@ describe("defineAgent workspace option", () => {
     } as never)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -658,6 +663,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -689,6 +695,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -781,6 +788,7 @@ describe("defineAgent workspace option", () => {
     exists.mockResolvedValue(true)
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         skills({ path: "skills/ponytail", scope: "global", source: { resolve: resolvePonytail } as never }),
         skills({ path: "skills/code-review", scope: "global", source: codeReviewSource }),
@@ -820,6 +828,7 @@ describe("defineAgent workspace option", () => {
       .mockResolvedValueOnce({ exitCode: 1, stderr: "copy failed", stdout: "" })
       .mockRejectedValueOnce(new Error("cleanup failed"))
     const agent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [skills({ path: "skills/review", scope: "global", source: globalSkillSource() })],
       driver: {
         harness: {
@@ -847,6 +856,7 @@ describe("defineAgent workspace option", () => {
       .mockResolvedValueOnce({ close: workspaceClose })
       .mockResolvedValueOnce({ close: profileClose })
     const agent = Object.assign(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: {
           provider: "codex",
@@ -901,7 +911,7 @@ describe("defineAgent workspace option", () => {
 
   it("does not install caller-provided colocated skills", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
-    const agent = defineAgent({ driver: { harness: { provider: "codex" } } })
+    const agent = defineAgent({ authorizeExecution: () => true, driver: { harness: { provider: "codex" } } })
 
     await expect(runAgent(agent, context(), {
       context: {
@@ -924,6 +934,7 @@ describe("defineAgent workspace option", () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [skills({ path: "skills/review", scope: "global", source: globalSkillSource() })],
       driver: { harness: { provider: "custom" } },
     })
@@ -932,6 +943,7 @@ describe("defineAgent workspace option", () => {
     expect(harnessCreateSession).not.toHaveBeenCalled()
 
     const unsafeAgent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [skills({ path: "skills/review", scope: "global", source: globalSkillSource() })],
       driver: {
         harness: {
@@ -948,6 +960,7 @@ describe("defineAgent workspace option", () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [skills({ path: "skills/review", scope: "global", source: globalSkillSource() })],
       driver: {
         harness: {
@@ -964,6 +977,7 @@ describe("defineAgent workspace option", () => {
   it("preserves unmanaged Skills when no global Skills are configured", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: {
           provider: "codex",
@@ -988,6 +1002,7 @@ describe("defineAgent workspace option", () => {
     exists.mockResolvedValue(true)
     prepareHarnessWorkspaceSession.mockResolvedValueOnce({ close })
     const agent = defineAgent({
+      authorizeExecution: () => true,
       capabilities: [skills({ path: "skills/review", scope: "global", source: globalSkillSource() })],
       driver: {
         harness: {
@@ -1547,6 +1562,7 @@ describe("defineAgent workspace option", () => {
     exists.mockResolvedValue(true)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -1596,6 +1612,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       capabilities: [{
         id: "support-tools",
         tools: {
@@ -1632,6 +1649,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -1672,6 +1690,7 @@ describe("defineAgent workspace option", () => {
     exists.mockResolvedValue(true)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -1706,6 +1725,7 @@ describe("defineAgent workspace option", () => {
     readFile.mockResolvedValueOnce(document)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -1750,6 +1770,7 @@ describe("defineAgent workspace option", () => {
     harnessFileSession.writeBinaryFile.mockRejectedValueOnce(error)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -1768,6 +1789,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -1811,6 +1833,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -1863,6 +1886,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -1892,6 +1916,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -1937,6 +1962,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -1980,6 +2006,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -2029,6 +2056,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -2066,6 +2094,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -2106,6 +2135,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         access({
           workspace: {
@@ -2154,6 +2184,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         access({
           workspace: {
@@ -2199,6 +2230,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         access({
           workspace: {
@@ -2246,6 +2278,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         access({
           workspace: {
@@ -2294,6 +2327,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         access({
           workspace: {
@@ -2344,6 +2378,7 @@ describe("defineAgent workspace option", () => {
     exists.mockImplementation(async path => path === "README.md")
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         {
           id: "workspace-scope",
@@ -2394,6 +2429,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       capabilities: [
         access({
           workspace: {
@@ -2436,6 +2472,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -2472,6 +2509,7 @@ describe("defineAgent workspace option", () => {
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -2514,6 +2552,7 @@ describe("defineAgent workspace option", () => {
     })
 
     const agent = defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
       },
@@ -4334,6 +4373,7 @@ describe("defineAgent workspace option", () => {
     const { workspaceShell } = await import("../src/capabilities.ts")
     const { trustedHost } = await import("@vite-hub/box")
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       box: { runtime: trustedHost() },
       capabilities: [workspaceShell({ commands: "all", mode: "write" })],
       driver: { harness: {} },
@@ -4425,6 +4465,7 @@ describe("defineAgent workspace option", () => {
     exists.mockResolvedValue(true)
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       capabilities: [skills({ path: "skills/agent-browser", shellExecution: "write" })],
       driver: {
         harness: { provider: "codex" },
@@ -4449,6 +4490,7 @@ describe("defineAgent workspace option", () => {
   it("includes explicit driver.sandbox in harness Agent inspection metadata", async () => {
     const { defineAgent, resolveAgentInspectionMetadata } = await import("../src/index.ts")
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       driver: {
         harness: { provider: "codex" },
         sandbox: { providerId: "local-test", specificationVersion: "harness-sandbox-v1" },
@@ -4467,7 +4509,7 @@ describe("defineAgent workspace option", () => {
 
   it("reports the resolved default local harness authority", async () => {
     const { defineAgent, resolveAgentInspectionMetadata } = await import("../src/index.ts")
-    const agent = defineAgent({ driver: { harness: { provider: "codex" } } })
+    const agent = defineAgent({ authorizeExecution: () => true, driver: { harness: { provider: "codex" } } })
 
     expect((await resolveAgentInspectionMetadata(agent, {
       runtime: { runtime: "vite" },
@@ -4787,6 +4829,7 @@ describe("defineAgent workspace option", () => {
     const { resolveAgentInspectionMetadata, defineAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")
     const agent = withExplicitWorkspaceName(defineAgent({
+      authorizeExecution: () => true,
       workspace: {},
       driver: {
         harness: { provider: "codex" },

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -4649,16 +4649,16 @@ describe("defineAgent workspace option", () => {
       .toBe(unknownExecutionAuthority)
   })
 
-  it("reports unknown authority for custom run drivers", async () => {
+  it("reports no authority for custom run drivers", async () => {
     const { createAgentInspectionMetadata, defineAgent, resolveAgentInspectionMetadata } = await import("../src/index.ts")
     const agent = defineAgent({ driver: { run: () => "ok" } })
 
     expect(createAgentInspectionMetadata(agent).config?.driver).toEqual({
-      executionAuthority: unknownExecutionAuthority,
+      executionAuthority: noExecutionAuthority,
       kind: "run",
     })
     expect((await resolveAgentInspectionMetadata(agent)).config?.driver).toEqual({
-      executionAuthority: unknownExecutionAuthority,
+      executionAuthority: noExecutionAuthority,
       kind: "run",
     })
   })


### PR DESCRIPTION
Rejects Agent Invocations whose resolved Agent Driver authority differs from `noExecutionAuthority` unless the Agent Definition's `authorizeExecution` callback approves that invocation. The guard resolves the concrete Box or harness sandbox once after invoker resolution and fails before hooks, adapter resolution, or Agent execution; static execution surfaces fail before Capabilities, while function-valued sandbox resolvers retain their capability-prepared invocation context. Low-authority public Agents remain anonymously invocable.

Harness adapters must preserve the authority that was approved, opaque Agent Definitions fail closed, and Agent Dev Loop workspace commands authorize and execute through the same resolved `trustedHost()` Box. Regression coverage proves both sides of the boundary, exact provider reuse, adapter substitution and mutation rejection, and independent checks inside queued Workflow Runs and child invocations.

## Stack

This PR is stacked on #796 (`feat/execution-authority`) at `127f0b8aad1740bd8e9746b29098080340f50099` and should remain based on `feat/execution-authority` until that foundation lands.
