### PR TITLE
refactor!: standardize explicit results as error-first tuples

### DIFF
--- a/docs/content/docs/server-primitives/rate-limit.md
+++ b/docs/content/docs/server-primitives/rate-limit.md
@@ -138,7 +138,7 @@ const decision = await limiter.consume({ key: 'demo' })
 
 Every direct limiter exposes its resolved `policy` and the provider capabilities that affect enforcement and deployment. The memory driver is process-local and intended for development, tests, and known single-process hosts.
 
-Custom drivers return `{ unavailable: true, cause }` only for expected operational outages that the declared failure policy should govern. Configuration, provider-contract, and implementation defects should throw normally.
+Custom drivers return `[null, result]` after consuming the counter and `[error, undefined]` only for expected operational outages that the declared failure policy should govern. Configuration, provider-contract, and implementation defects should throw normally.
 
 ## Deploy to Cloudflare
 

--- a/docs/content/docs/server-primitives/sandbox.md
+++ b/docs/content/docs/server-primitives/sandbox.md
@@ -56,7 +56,9 @@ export default { text: payload?.notes?.toUpperCase() || 'No notes' }
 import { runSandbox } from '@vite-hub/sandbox'
 
 export default defineEventHandler(async () => {
-  return runSandbox('release-notes', { notes: 'ship it' })
+  const [error, result] = await runSandbox('release-notes', { notes: 'ship it' })
+  if (error) throw error
+  return result
 })
 ```
 

--- a/fixtures/consumer/vite-hub/server/queues/welcome.ts
+++ b/fixtures/consumer/vite-hub/server/queues/welcome.ts
@@ -2,10 +2,10 @@ import { defineQueue } from "vite-hub/queue"
 import { runSandbox } from "vite-hub/sandbox"
 
 export default defineQueue(async () => {
-  const result = await runSandbox("image-optimizer", { queued: true })
-  if (result.error?.message.includes('Unknown sandbox "image-optimizer"'))
-    throw result.error
-  ;(globalThis as Record<string, unknown>).__vitehubQueueSandboxResult = result.error
-    ? { code: result.error.code, message: result.error.message }
-    : result.value
+  const [error, result] = await runSandbox("image-optimizer", { queued: true })
+  if (error?.message.includes('Unknown sandbox "image-optimizer"'))
+    throw error
+  ;(globalThis as Record<string, unknown>).__vitehubQueueSandboxResult = error
+    ? { code: error.code, message: error.message }
+    : result
 })

--- a/packages/rate-limit/README.md
+++ b/packages/rate-limit/README.md
@@ -63,6 +63,6 @@ const decision = await limiter.consume({ key: authenticatedUser.id })
 
 The memory driver is process-local and intended for development, tests, and single-process hosts. Production drivers must implement atomic `consume()`; generic KV `get()` and `set()` operations are insufficient.
 
-Custom drivers return `{ unavailable: true, cause }` only for expected operational outages that the declared failure policy should govern. Invalid configuration, malformed provider responses, and implementation defects should throw normally.
+Custom drivers return `[null, result]` after consuming the counter and `[error, undefined]` only for expected operational outages that the declared failure policy should govern. Invalid configuration, malformed provider responses, and implementation defects should throw normally.
 
 Every direct limiter exposes its enforcement, counter scope, rejected-attempt behavior, and supported windows. The Vite integration writes those capabilities to `.vitehub/rate-limit/manifest.json` for agents and tooling to inspect.

--- a/packages/rate-limit/src/drivers/cloudflare.ts
+++ b/packages/rate-limit/src/drivers/cloudflare.ts
@@ -31,12 +31,12 @@ export function cloudflareRateLimitDriver(options: CloudflareRateLimitDriverOpti
         result = await options.binding.limit({ key: input.key })
       }
       catch (cause) {
-        return { cause, unavailable: true }
+        return [new Error("[vitehub] Cloudflare Rate Limit binding failed.", { cause }), undefined]
       }
       if (!result || typeof result.success !== "boolean") {
         throw new TypeError("[vitehub] Cloudflare Rate Limit binding returned an invalid result.")
       }
-      return { allowed: result.success }
+      return [null, { allowed: result.success }]
     },
     name: "cloudflare",
   }

--- a/packages/rate-limit/src/drivers/memory.ts
+++ b/packages/rate-limit/src/drivers/memory.ts
@@ -51,22 +51,22 @@ export function memoryRateLimitDriver(options: MemoryRateLimitDriverOptions = {}
       }
       const entry = current && current.resetAt > timestamp ? current : { count: 0, resetAt }
       if (entry.count >= input.limit) {
-        return {
+        return [null, {
           allowed: false,
           remaining: 0,
           resetAt: entry.resetAt,
           retryAfter: Math.max(1, Math.ceil((entry.resetAt - timestamp) / 1_000)),
           used: entry.count,
-        }
+        }]
       }
       entry.count += 1
       entries.set(key, entry)
-      return {
+      return [null, {
         allowed: true,
         remaining: input.limit - entry.count,
         resetAt: entry.resetAt,
         used: entry.count,
-      }
+      }]
     },
     name: "memory",
     size() {

--- a/packages/rate-limit/src/index.ts
+++ b/packages/rate-limit/src/index.ts
@@ -11,7 +11,6 @@ export type {
   RateLimitDriverInput,
   RateLimitDriverOutcome,
   RateLimitDriverResult,
-  RateLimitDriverUnavailable,
   RateLimitEnforcement,
   RateLimitFailurePolicy,
   RateLimiter,

--- a/packages/rate-limit/src/limiter.ts
+++ b/packages/rate-limit/src/limiter.ts
@@ -86,19 +86,16 @@ export function createRateLimiter(options: CreateRateLimiterOptions): RateLimite
       if (!input || typeof input.key !== "string" || input.key.length === 0) {
         throw new TypeError("[vitehub] Rate Limiter consume() requires a non-empty key.")
       }
-      const result = await options.driver.consume({
+      const [error, result] = await options.driver.consume({
         key: input.key,
         limit: policy.limit,
         name: options.name,
         windowMs: policy.windowMs,
       })
-      if ("unavailable" in result) {
-        if (result.unavailable !== true) {
-          throw new TypeError("[vitehub] Rate Limit driver unavailable outcome must set unavailable to true.")
-        }
+      if (error) {
         return {
           allowed: policy.failure === "allow",
-          cause: result.cause,
+          cause: error.cause ?? error,
           limit: policy.limit,
           reason: "unavailable",
           windowMs: policy.windowMs,

--- a/packages/rate-limit/src/types.ts
+++ b/packages/rate-limit/src/types.ts
@@ -57,12 +57,9 @@ export interface RateLimitDriverResult {
   used?: number
 }
 
-export interface RateLimitDriverUnavailable {
-  readonly cause: unknown
-  readonly unavailable: true
-}
-
-export type RateLimitDriverOutcome = RateLimitDriverResult | RateLimitDriverUnavailable
+export type RateLimitDriverOutcome =
+  | [error: null, value: RateLimitDriverResult]
+  | [error: Error, value: undefined]
 
 interface RateLimitDecisionBase extends RateLimitDriverResult {
   limit: number

--- a/packages/rate-limit/test/core.test.ts
+++ b/packages/rate-limit/test/core.test.ts
@@ -65,20 +65,20 @@ describe("Rate Limit core", () => {
 
   it("validates driver guarantees before consumption", () => {
     expect(() => createRateLimiter({
-      driver: { capabilities: { ...strictCapabilities, enforcement: "best-effort" }, consume: () => ({ allowed: true }), name: "edge" },
+      driver: { capabilities: { ...strictCapabilities, enforcement: "best-effort" }, consume: () => [null, { allowed: true }], name: "edge" },
       enforcement: "strict",
       limit: 1,
       window: "1m",
     })).toThrow("requires strict enforcement")
 
     expect(() => createRateLimiter({
-      driver: { capabilities: { ...strictCapabilities, windows: [10_000] }, consume: () => ({ allowed: true }), name: "narrow" },
+      driver: { capabilities: { ...strictCapabilities, windows: [10_000] }, consume: () => [null, { allowed: true }], name: "narrow" },
       limit: 1,
       window: "1m",
     })).toThrow("does not support")
 
     expect(() => createRateLimiter({
-      driver: { capabilities: {} as never, consume: () => ({ allowed: true }), name: "opaque" },
+      driver: { capabilities: {} as never, consume: () => [null, { allowed: true }], name: "opaque" },
       limit: 1,
       window: "1m",
     })).toThrow("valid enforcement")
@@ -95,7 +95,7 @@ describe("Rate Limit core", () => {
 
   it("applies explicit failure policy", async () => {
     const cause = new Error("offline")
-    const consume = vi.fn(() => ({ cause, unavailable: true } as const))
+    const consume = vi.fn((): import("../src/index.ts").RateLimitDriverOutcome => [cause, undefined])
     const driver = { capabilities: strictCapabilities, consume, name: "offline" }
     const allow = createRateLimiter({ driver, failure: "allow", limit: 1, window: "1m" })
     const deny = createRateLimiter({ driver, failure: "deny", limit: 1, window: "1m" })

--- a/packages/rate-limit/test/types.test-d.ts
+++ b/packages/rate-limit/test/types.test-d.ts
@@ -6,7 +6,7 @@ import { memoryRateLimitDriver } from "../src/drivers/memory.ts"
 import { hubRateLimit } from "../src/vite.ts"
 
 import type { HTTPEvent } from "h3"
-import type { RateLimitDecision, RateLimitDriver, RateLimitDriverOutcome, RateLimiter } from "../src/index.ts"
+import type { RateLimitDecision, RateLimitDriver, RateLimitDriverOutcome, RateLimitDriverResult, RateLimiter } from "../src/index.ts"
 
 it("types the portable Rate Limit contract", async () => {
   const event = {} as HTTPEvent
@@ -27,18 +27,21 @@ it("types the portable Rate Limit contract", async () => {
   limiter.consume({ event: {}, key: "user" })
 })
 
-it("types custom and provider drivers", () => {
-  const unavailable = { cause: new Error("offline"), unavailable: true } satisfies RateLimitDriverOutcome
-  const custom = {
+it("types custom and provider drivers", async () => {
+  const unavailable = [new Error("offline"), undefined] satisfies RateLimitDriverOutcome
+  const custom: RateLimitDriver = {
     capabilities: {
       enforcement: "strict",
       rejectedAttempts: "not-counted",
       scope: "global",
     },
-    consume: async () => ({ allowed: true, remaining: 1 }),
+    consume: async () => [null, { allowed: true, remaining: 1 }],
     name: "custom",
-  } satisfies RateLimitDriver
+  }
   createRateLimiter({ driver: custom, limit: 2, window: "10s" })
+  const [error, value] = await custom.consume({ key: "user", limit: 2, windowMs: 10_000 })
+  if (error) throw error
+  expectTypeOf(value).toEqualTypeOf<RateLimitDriverResult>()
   void unavailable
   createRateLimiter({ driver: cloudflareRateLimitDriver({ binding: { limit: async () => ({ success: true }) } }), limit: 2, window: "10s" })
   hubRateLimit({ namespace: "types-test", provider: "cloudflare", projectRoot: "../", scanDirs: ["shared"] })

--- a/packages/sandbox/README.md
+++ b/packages/sandbox/README.md
@@ -42,7 +42,8 @@ Use `<path>.sandbox.ts` with `defineSandbox()` for free-form Definitions outside
 ```ts
 import { runSandbox } from "@vite-hub/sandbox"
 
-const result = await runSandbox("release-notes", { notes: "ship it" })
+const [error, result] = await runSandbox("release-notes", { notes: "ship it" })
+if (error) throw error
 ```
 
 Add `hubSandbox()` to Vite for discovery, typed registry generation, package preparation plans, and host output. Provider images and full Dockerfile overrides belong to the selected Box adapter or host configuration; Sandbox Definitions stay portable.

--- a/packages/sandbox/examples/vite/src/server.ts
+++ b/packages/sandbox/examples/vite/src/server.ts
@@ -6,13 +6,13 @@ const app = new H3()
 
 app.post("/api/release-notes", async (event) => {
   const payload = await readRequestPayload<ReleaseNotesPayload>(event, { notes: "" }) as ReleaseNotesPayload
-  const result = await runSandbox("release-notes", payload)
+  const [error, result] = await runSandbox("release-notes", payload)
 
-  if (result.isErr()) {
-    throw createError({ statusCode: 500, statusMessage: result.error.message })
+  if (error) {
+    throw createError({ statusCode: 500, statusMessage: error.message })
   }
 
-  return { result: result.value }
+  return { result }
 })
 
 export default app

--- a/packages/sandbox/src/internal/shared/feature-runtime-path.ts
+++ b/packages/sandbox/src/internal/shared/feature-runtime-path.ts
@@ -32,9 +32,9 @@ export function resolveFeatureRuntimePath(
   if ((!importerUsesDist || !targetsSourceTree) && resolvedSourcePath)
     return resolvedSourcePath
 
-  const resolvedPackageJson = tryResolveModule(`${packageId}/package.json`)
-  if (resolvedPackageJson.ok) {
-    const packageRoot = dirname(resolvedPackageJson.path)
+  const [packageJsonError, packageJsonPath] = tryResolveModule(`${packageId}/package.json`)
+  if (!packageJsonError) {
+    const packageRoot = dirname(packageJsonPath)
     const packageSourcePath = join(
       packageRoot,
       'src',
@@ -45,12 +45,12 @@ export function resolveFeatureRuntimePath(
     const resolvedPackageSourcePath = resolveExistingModulePath(packageSourcePath)
     if ((!importerUsesDist || !targetsSourceTree) && resolvedPackageSourcePath)
       return resolvedPackageSourcePath
-    return join(dirname(resolvedPackageJson.path), 'dist', distRelativePath)
+    return join(dirname(packageJsonPath), 'dist', distRelativePath)
   }
 
-  const resolvedPackage = tryResolveModule(packageId)
-  if (resolvedPackage.ok)
-    return join(dirname(resolvedPackage.path), distRelativePath)
+  const [packageError, packagePath] = tryResolveModule(packageId)
+  if (!packageError)
+    return join(dirname(packagePath), distRelativePath)
 
   return sourcePath
 }

--- a/packages/sandbox/src/internal/shared/module-resolve.ts
+++ b/packages/sandbox/src/internal/shared/module-resolve.ts
@@ -1,15 +1,9 @@
 import { resolveModule } from 'local-pkg'
 import { resolvePathSync } from 'mlly'
 
-export interface ResolvedModuleResult {
-  ok: true
-  path: string
-}
-
-export interface MissingModuleResult {
-  ok: false
-  error: string
-}
+export type ModuleResolveResult =
+  | [error: null, path: string]
+  | [error: Error, path: undefined]
 
 function normalizePaths(paths?: string[]) {
   if (paths?.length)
@@ -34,34 +28,33 @@ function tryResolveFromRuntime(id: string): string | false | undefined {
   }
 }
 
-export function tryResolveModule(id: string, options: { paths?: string[] } = {}): ResolvedModuleResult | MissingModuleResult {
+export function tryResolveModule(id: string, options: { paths?: string[] } = {}): ModuleResolveResult {
   const paths = normalizePaths(options.paths)
 
   const runtimeResolved = tryResolveFromRuntime(id)
   if (runtimeResolved === false)
-    return { ok: false, error: `Unable to resolve module "${id}" using the active runtime resolver` }
+    return [new Error(`Unable to resolve module "${id}" using the active runtime resolver`), undefined]
   if (runtimeResolved)
-    return { ok: true, path: runtimeResolved }
+    return [null, runtimeResolved]
 
   const resolved = resolveModule(id, { paths })
   if (resolved)
-    return { ok: true, path: resolved }
+    return [null, resolved]
 
   for (const url of paths) {
     try {
-      return { ok: true, path: resolvePathSync(id, { url }) }
+      return [null, resolvePathSync(id, { url })]
     }
     catch {
       continue
     }
   }
 
-  return {
-    ok: false,
-    error: paths.length > 0
+  return [new Error(
+    paths.length > 0
       ? `Unable to resolve module "${id}" from ${paths.join(', ')}`
       : `Unable to resolve module "${id}" without explicit resolution paths`,
-  }
+  ), undefined]
 }
 
 const resolveCache = new Map<string, boolean>()
@@ -71,9 +64,10 @@ export function canResolveModule(moduleName: string, options?: { paths?: string[
   const cached = resolveCache.get(key)
   if (cached !== undefined)
     return cached
-  const result = tryResolveModule(moduleName, options).ok
-  resolveCache.set(key, result)
-  return result
+  const [error] = tryResolveModule(moduleName, options)
+  const resolved = error === null
+  resolveCache.set(key, resolved)
+  return resolved
 }
 
 export function clearResolveCache(): void {

--- a/packages/sandbox/src/module-types.ts
+++ b/packages/sandbox/src/module-types.ts
@@ -90,21 +90,9 @@ export type SandboxDefinitionFromHandler<THandler extends (...args: any[]) => an
     run: THandler
   }
 
-export interface SandboxOkResult<TResult = unknown> {
-  isOk: () => true
-  isErr: () => false
-  value: TResult
-  error?: never
-}
-
-export interface SandboxErrResult {
-  isOk: () => false
-  isErr: () => true
-  value?: never
-  error: SandboxError
-}
-
-export type SandboxRunResult<TResult = unknown> = SandboxOkResult<TResult> | SandboxErrResult
+export type SandboxRunResult<TResult = unknown> =
+  | [error: null, value: TResult]
+  | [error: SandboxError, value: undefined]
 
 export type {
   SandboxError,

--- a/packages/sandbox/src/runtime/result.ts
+++ b/packages/sandbox/src/runtime/result.ts
@@ -2,17 +2,9 @@ import type { SandboxRunResult } from "../module-types"
 import type { SandboxError } from "../sandbox/errors"
 
 export function ok<TResult>(value: TResult): SandboxRunResult<TResult> {
-  return {
-    isOk: () => true,
-    isErr: () => false,
-    value,
-  }
+  return [null, value]
 }
 
 export function err<TResult = never>(error: SandboxError): SandboxRunResult<TResult> {
-  return {
-    isOk: () => false,
-    isErr: () => true,
-    error,
-  }
+  return [error, undefined]
 }

--- a/packages/sandbox/test/module-resolve.test.ts
+++ b/packages/sandbox/test/module-resolve.test.ts
@@ -14,12 +14,11 @@ describe("module resolve", () => {
     expect(canResolveModule("@vite-hub/does-not-exist")).toBe(false)
   })
 
-  it("returns a missing-module result instead of throwing when process is unavailable", () => {
+  it("returns a missing-module tuple instead of throwing when process is unavailable", () => {
     vi.stubGlobal("process", undefined)
 
-    expect(tryResolveModule("@vite-hub/does-not-exist")).toEqual({
-      ok: false,
-      error: 'Unable to resolve module "@vite-hub/does-not-exist" without explicit resolution paths',
-    })
+    const [error, path] = tryResolveModule("@vite-hub/does-not-exist")
+    expect(error?.message).toBe('Unable to resolve module "@vite-hub/does-not-exist" without explicit resolution paths')
+    expect(path).toBeUndefined()
   })
 })

--- a/packages/sandbox/test/public-api.test.ts
+++ b/packages/sandbox/test/public-api.test.ts
@@ -22,14 +22,11 @@ describe("sandbox public api", () => {
     })
   })
 
-  it("returns a result wrapper instead of throwing", async () => {
-    const result = await runSandbox("missing")
+  it("returns an error-first tuple instead of throwing", async () => {
+    const [error, value] = await runSandbox("missing")
 
-    expect(result.isErr()).toBe(true)
-    expect(result.isOk()).toBe(false)
-    if (result.isErr()) {
-      expect(result.error!.message).toContain("missing")
-    }
+    expect(error?.message).toContain("missing")
+    expect(value).toBeUndefined()
   })
 
   it("emits extensioned provider loader imports for published ESM", async () => {

--- a/packages/sandbox/test/runtime-lifecycle.test.ts
+++ b/packages/sandbox/test/runtime-lifecycle.test.ts
@@ -86,7 +86,7 @@ describe("Sandbox runtime lifecycle", () => {
 
     const result = await runSandboxRuntime("example")
 
-    expect(result.isOk()).toBe(true)
+    expect(result[0]).toBeNull()
     expect(runtimeMocks.resolveProviderBox).toHaveBeenCalledWith(["node"])
     expect(runtimeMocks.open).toHaveBeenCalledWith({
       id: expect.stringMatching(/^vitehub-example-[a-z0-9]+-definition$/),
@@ -105,7 +105,7 @@ describe("Sandbox runtime lifecycle", () => {
 
     const result = await runSandboxRuntime("example")
 
-    expect(result.isErr()).toBe(true)
+    expect(result[0]).toBeInstanceOf(Error)
     expect(runtimeMocks.resolveSandboxBox).not.toHaveBeenCalled()
   })
 
@@ -149,7 +149,7 @@ describe("Sandbox runtime lifecycle", () => {
 
     const result = await runSandboxRuntime("example")
 
-    expect(result.isErr()).toBe(true)
+    expect(result[0]).toBeInstanceOf(Error)
     expect(runtimeMocks.close).toHaveBeenCalledOnce()
   })
 
@@ -160,7 +160,7 @@ describe("Sandbox runtime lifecycle", () => {
 
     const result = await runSandboxRuntime("example")
 
-    expect(result.isOk()).toBe(true)
+    expect(result[0]).toBeNull()
     expect(runtimeMocks.close).toHaveBeenCalledOnce()
   })
 
@@ -211,7 +211,7 @@ describe("Sandbox runtime lifecycle", () => {
 
     const result = await runSandboxRuntime("example")
 
-    expect(result.isOk()).toBe(true)
+    expect(result[0]).toBeNull()
     expect(runtimeMocks.executeSandboxDefinition).toHaveBeenCalledWith(
       expect.anything(),
       "example",

--- a/packages/sandbox/test/types.test-d.ts
+++ b/packages/sandbox/test/types.test-d.ts
@@ -37,7 +37,7 @@ describe("types", () => {
     expectTypeOf(config.sandbox).toMatchTypeOf<AgentSandboxConfig | false | undefined>()
   })
 
-  it("types sandbox definitions and run results", () => {
+  it("types sandbox definitions and run results", async () => {
     const definition = defineSandbox({
       run: async (payload?: { value: string }) => ({ value: payload?.value || "" }),
     })
@@ -46,6 +46,10 @@ describe("types", () => {
     expectTypeOf(runSandbox("release-notes", { value: "ok" })).resolves.toMatchTypeOf<SandboxRunResult>()
     expectTypeOf(runSandbox("package-entry", { value: "ok" })).resolves.toEqualTypeOf<SandboxRunResult<{ length: number }>>()
     expectTypeOf(runSandbox("unknown-package-entry", { anything: true })).resolves.toEqualTypeOf<SandboxRunResult<string>>()
+
+    const [error, result] = await runSandbox("package-entry", { value: "ok" })
+    if (error) throw error
+    expectTypeOf(result).toEqualTypeOf<{ length: number }>()
   })
 
   it("returns a Vite plugin", () => {

--- a/packages/shell/src/providers/just-bash.ts
+++ b/packages/shell/src/providers/just-bash.ts
@@ -111,8 +111,8 @@ async function runControlledCurlCommand(
 ): Promise<ShellObservation | undefined> {
   if (!mentionsCurlCommand(command)) return undefined
 
-  const parsed = parseControlledCurlCommand(command)
-  if (!parsed.ok) return policyDeniedCurl(command, options.cwd, parsed.error)
+  const [parseError, parsed] = parseControlledCurlCommand(command)
+  if (parseError) return policyDeniedCurl(command, options.cwd, parseError.message)
   if (!options.networkGrants) {
     return policyDeniedCurl(command, options.cwd, "No API-backed Source request descriptors are visible in this workspace.")
   }
@@ -146,13 +146,23 @@ async function runControlledCurlCommand(
   }
 }
 
-type ParsedControlledCurl =
-  | { body?: unknown, method: "GET" | "HEAD" | "POST", ok: true, url: string }
-  | { error: string, ok: false }
+type ParsedValue<T> =
+  | [error: null, value: T]
+  | [error: Error, value: undefined]
+
+type ParsedControlledCurl = ParsedValue<{
+  body?: unknown
+  method: "GET" | "HEAD" | "POST"
+  url: string
+}>
+
+function parseFailure<T>(message: string): ParsedValue<T> {
+  return [new Error(message), undefined]
+}
 
 function parseControlledCurlCommand(command: string): ParsedControlledCurl {
   if (hasUnsupportedCurlShellSyntax(command)) {
-    return { error: "Controlled curl must be a single command without pipes, redirects, chaining, command substitution, or heredocs.", ok: false }
+    return parseFailure("Controlled curl must be a single command without pipes, redirects, chaining, command substitution, or heredocs.")
   }
 
   let words: string[]
@@ -160,10 +170,10 @@ function parseControlledCurlCommand(command: string): ParsedControlledCurl {
     words = parseShellCommand(command)
   }
   catch (error) {
-    return { error: error instanceof Error ? error.message : String(error), ok: false }
+    return [error instanceof Error ? error : new Error(String(error)), undefined]
   }
 
-  if (words[0] !== "curl") return { error: "Controlled curl command must start with curl.", ok: false }
+  if (words[0] !== "curl") return parseFailure("Controlled curl command must start with curl.")
 
   let body: unknown
   let method: "GET" | "HEAD" | "POST" | undefined
@@ -177,19 +187,19 @@ function parseControlledCurlCommand(command: string): ParsedControlledCurl {
       }
       if (word === "-X" || word === "--request") {
         const value = words[++index]
-        if (!value) return { error: `${word} requires a method.`, ok: false }
+        if (!value) return parseFailure(`${word} requires a method.`)
         method = parseCurlMethod(value)
-        if (!method) return { error: `Unsupported curl request method: ${value}.`, ok: false }
+        if (!method) return parseFailure(`Unsupported curl request method: ${value}.`)
         continue
       }
       if (word.startsWith("--request=")) {
         method = parseCurlMethod(word.slice("--request=".length))
-        if (!method) return { error: `Unsupported curl request method: ${word.slice("--request=".length)}.`, ok: false }
+        if (!method) return parseFailure(`Unsupported curl request method: ${word.slice("--request=".length)}.`)
         continue
       }
       if (word === "--url") {
         const value = words[++index]
-        if (!value) return { error: "--url requires a URL.", ok: false }
+        if (!value) return parseFailure("--url requires a URL.")
         url = setCurlUrl(url, value)
         continue
       }
@@ -199,23 +209,23 @@ function parseControlledCurlCommand(command: string): ParsedControlledCurl {
       }
       if (word === "--json") {
         const value = words[++index]
-        if (!value) return { error: "--json requires a JSON body.", ok: false }
-        const parsed = parseJsonCurlBody(value)
-        if (!parsed.ok) return parsed
-        body = parsed.body
+        if (!value) return parseFailure("--json requires a JSON body.")
+        const [error, parsedBody] = parseJsonCurlBody(value)
+        if (error) return [error, undefined]
+        body = parsedBody
         method ??= "POST"
         continue
       }
       if (word.startsWith("--json=")) {
-        const parsed = parseJsonCurlBody(word.slice("--json=".length))
-        if (!parsed.ok) return parsed
-        body = parsed.body
+        const [error, parsedBody] = parseJsonCurlBody(word.slice("--json=".length))
+        if (error) return [error, undefined]
+        body = parsedBody
         method ??= "POST"
         continue
       }
       if (word === "-d" || word === "--data" || word === "--data-raw" || word === "--data-binary") {
         const value = words[++index]
-        if (!value) return { error: `${word} requires a body.`, ok: false }
+        if (!value) return parseFailure(`${word} requires a body.`)
         body = parseCurlDataBody(value)
         method ??= "POST"
         continue
@@ -231,30 +241,29 @@ function parseControlledCurlCommand(command: string): ParsedControlledCurl {
         continue
       }
       if (word === "-H" || word === "--header" || word === "-b" || word === "--cookie" || word.startsWith("--header=") || word.startsWith("--cookie=")) {
-        return { error: "Controlled curl injects Source credentials itself; do not pass headers or cookies in the command.", ok: false }
+        return parseFailure("Controlled curl injects Source credentials itself; do not pass headers or cookies in the command.")
       }
-      if (word.startsWith("-")) return { error: `Unsupported curl flag: ${word}.`, ok: false }
+      if (word.startsWith("-")) return parseFailure(`Unsupported curl flag: ${word}.`)
       url = setCurlUrl(url, word)
     }
   }
   catch (error) {
-    return { error: error instanceof Error ? error.message : String(error), ok: false }
+    return [error instanceof Error ? error : new Error(String(error)), undefined]
   }
 
-  if (!url) return { error: "Controlled curl requires a URL.", ok: false }
+  if (!url) return parseFailure("Controlled curl requires a URL.")
   try {
     url = new URL(url).toString()
   }
   catch {
-    return { error: `Controlled curl URL is invalid: ${url}.`, ok: false }
+    return parseFailure(`Controlled curl URL is invalid: ${url}.`)
   }
 
-  return {
+  return [null, {
     body,
     method: method ?? "GET",
-    ok: true,
     url,
-  }
+  }]
 }
 
 function mentionsCurlCommand(command: string): boolean {
@@ -299,8 +308,8 @@ function parseShellCommandLenient(command: string): string[] {
 }
 
 function parseCurlDataBody(value: string): unknown {
-  const parsed = parseJsonCurlBody(value)
-  return parsed.ok ? parsed.body : value
+  const [error, body] = parseJsonCurlBody(value)
+  return error ? value : body
 }
 
 function parseCurlMethod(value: string): "GET" | "HEAD" | "POST" | undefined {
@@ -308,12 +317,12 @@ function parseCurlMethod(value: string): "GET" | "HEAD" | "POST" | undefined {
   return method === "GET" || method === "HEAD" || method === "POST" ? method : undefined
 }
 
-function parseJsonCurlBody(value: string): { body: unknown, ok: true } | { error: string, ok: false } {
+function parseJsonCurlBody(value: string): ParsedValue<unknown> {
   try {
-    return { body: JSON.parse(value), ok: true }
+    return [null, JSON.parse(value)]
   }
   catch {
-    return { error: "--json body must be valid JSON.", ok: false }
+    return parseFailure("--json body must be valid JSON.")
   }
 }
 

--- a/playground/vite/server/api/sandboxes/release-notes.post.ts
+++ b/playground/vite/server/api/sandboxes/release-notes.post.ts
@@ -3,18 +3,18 @@ import { createError, defineEventHandler, readBody } from "h3"
 import { runSandbox } from "@vite-hub/sandbox"
 
 export default defineEventHandler(async (event) => {
-  const result = await runSandbox("release-notes", await readBody(event))
+  const [error, result] = await runSandbox("release-notes", await readBody(event))
 
-  if (result.isErr()) {
+  if (error) {
     throw createError({
       statusCode: 500,
-      statusMessage: result.error.message,
+      statusMessage: error.message,
       data: {
-        code: result.error.code,
-        provider: result.error.provider,
+        code: error.code,
+        provider: error.provider,
       },
     })
   }
 
-  return { result: result.value }
+  return { result }
 })

--- a/playground/vite/src/server.e2e.ts
+++ b/playground/vite/src/server.e2e.ts
@@ -319,20 +319,20 @@ app.get("/api/workspace/read-fresh", async (event) => {
 })
 
 app.post("/api/sandboxes/release-notes", async (event) => {
-  const result = await runSandbox("release-notes", await readBody(event))
+  const [error, result] = await runSandbox("release-notes", await readBody(event))
 
-  if (result.isErr()) {
+  if (error) {
     throw createError({
       statusCode: 500,
-      statusMessage: result.error.message,
+      statusMessage: error.message,
       data: {
-        code: result.error.code,
-        provider: result.error.provider,
+        code: error.code,
+        provider: error.provider,
       },
     })
   }
 
-  return { result: result.value }
+  return { result }
 })
 
 app.get("/api/workflows/welcome", () => ({ ok: true, workflow: workflowName }))


### PR DESCRIPTION
Standardizes ViteHub’s deliberate non-throwing operation results on error-first tuples. Sandbox now returns `[SandboxError | null, value | undefined]`, Rate Limit drivers return `[Error | null, decision | undefined]`, and the local Sandbox resolver and controlled-curl parsers use the same ordering. Wrapper methods and object discriminants are removed, and public examples, playground callers, consumer fixtures, and type tests now destructure the error first.

Domain observations and externally owned records remain unchanged: `ShellAnalyzeResult` preserves command metadata for both allowed and rejected observations; command outputs, Standard Schema and AI SDK validation, lifecycle/status records, aggregate outputs, and Sandbox’s serialized subprocess envelope are ordinary domain or wire records rather than explicit operation results. Tuple aliases stay feature-owned instead of introducing a shared generic while Runtime and Sandbox dependency ownership is active in #796. #798 independently changes Sandbox entry transport and may require a small docs/test rebase.

Validated with Sandbox, Rate Limit, and Shell builds, typechecks, and full package suites. The Sandbox type test proves an `if (error)` guard narrows the destructured value, while the consumer fixture and Rate Limit published-package fixture validate the public contracts.