### PR TITLE
fix(agent): use Box cwd as Harness workspace

### DIFF
--- a/packages/agent/src/harness/box-sandbox.ts
+++ b/packages/agent/src/harness/box-sandbox.ts
@@ -4,6 +4,8 @@ import type { HarnessV1NetworkSandboxSession, HarnessV1SandboxProvider } from "@
 import type { Box, BoxProcess, BoxSession } from "@vite-hub/box"
 import { openHarnessBox } from "./shared-box.ts"
 
+export const boxHarnessWorkDir = "workspace"
+
 function streamFromBytes(bytes: Uint8Array) {
   return new ReadableStream<Uint8Array>({
     start(controller) {
@@ -31,7 +33,13 @@ async function bytesFromStream(stream: ReadableStream<Uint8Array>) {
 }
 
 function resolvePath(session: BoxSession, path: string) {
-  return path.startsWith("/") ? posix.normalize(path) : posix.resolve(session.cwd, path)
+  const resolved = path.startsWith("/") ? posix.normalize(path) : posix.resolve(session.cwd, path)
+  const harnessWorkspace = posix.join(posix.dirname(session.cwd), boxHarnessWorkDir)
+  if (resolved === harnessWorkspace) return session.cwd
+  if (resolved.startsWith(`${harnessWorkspace}/`)) {
+    return posix.join(session.cwd, resolved.slice(harnessWorkspace.length + 1))
+  }
+  return resolved
 }
 
 function adaptProcess(process: BoxProcess) {
@@ -52,7 +60,7 @@ function adaptProcess(process: BoxProcess) {
 function adaptBoxSession(session: BoxSession): HarnessV1NetworkSandboxSession {
   if (!session.spawn) throw new Error("[vitehub] Harness Agent Drivers require a Box runtime with process spawning.")
   const adapted = {
-    defaultWorkingDirectory: session.cwd,
+    defaultWorkingDirectory: posix.dirname(session.cwd),
     description: `ViteHub Box ${session.id}`,
     id: session.id,
     ports: session.ports?.values || [],

--- a/packages/agent/src/harness/box-sandbox.ts
+++ b/packages/agent/src/harness/box-sandbox.ts
@@ -4,8 +4,6 @@ import type { HarnessV1NetworkSandboxSession, HarnessV1SandboxProvider } from "@
 import type { Box, BoxProcess, BoxSession } from "@vite-hub/box"
 import { openHarnessBox } from "./shared-box.ts"
 
-export const boxHarnessWorkDir = "workspace"
-
 function streamFromBytes(bytes: Uint8Array) {
   return new ReadableStream<Uint8Array>({
     start(controller) {
@@ -33,13 +31,7 @@ async function bytesFromStream(stream: ReadableStream<Uint8Array>) {
 }
 
 function resolvePath(session: BoxSession, path: string) {
-  const resolved = path.startsWith("/") ? posix.normalize(path) : posix.resolve(session.cwd, path)
-  const harnessWorkspace = posix.join(posix.dirname(session.cwd), boxHarnessWorkDir)
-  if (resolved === harnessWorkspace) return session.cwd
-  if (resolved.startsWith(`${harnessWorkspace}/`)) {
-    return posix.join(session.cwd, resolved.slice(harnessWorkspace.length + 1))
-  }
-  return resolved
+  return path.startsWith("/") ? posix.normalize(path) : posix.resolve(session.cwd, path)
 }
 
 function adaptProcess(process: BoxProcess) {
@@ -60,7 +52,7 @@ function adaptProcess(process: BoxProcess) {
 function adaptBoxSession(session: BoxSession): HarnessV1NetworkSandboxSession {
   if (!session.spawn) throw new Error("[vitehub] Harness Agent Drivers require a Box runtime with process spawning.")
   const adapted = {
-    defaultWorkingDirectory: posix.dirname(session.cwd),
+    defaultWorkingDirectory: session.cwd,
     description: `ViteHub Box ${session.id}`,
     id: session.id,
     ports: session.ports?.values || [],

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1543,9 +1543,8 @@ async function createAgentInvocationContext<
           requires: (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentBoxRequirements],
         }))
       : undefined
-    const boxHarness = box ? await import("./harness/box-sandbox.ts") : undefined
-    const harnessSandboxProvider = box && boxHarness
-      ? boxHarness.createBoxHarnessSandbox(box)
+    const harnessSandboxProvider = box
+      ? (await import("./harness/box-sandbox.ts")).createBoxHarnessSandbox(box)
       : undefined
     const workspaceName = workspaceOptions
       ? workspaceNameFromOptions(workspaceOptions, {}, context.agentIdentity)
@@ -1654,7 +1653,6 @@ async function createAgentInvocationContext<
       hasCapabilityCleanup: capabilities.hasCloseCallbacks,
       handledResponse: capabilities.response,
       harnessSandboxProvider,
-      harnessWorkDir: boxHarness?.boxHarnessWorkDir,
       hooks: definition?.hooks as AgentHookObserverHooks | undefined,
       input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
       instructions,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1543,8 +1543,9 @@ async function createAgentInvocationContext<
           requires: (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[baseAgentBoxRequirements],
         }))
       : undefined
-    const harnessSandboxProvider = box
-      ? (await import("./harness/box-sandbox.ts")).createBoxHarnessSandbox(box)
+    const boxHarness = box ? await import("./harness/box-sandbox.ts") : undefined
+    const harnessSandboxProvider = box && boxHarness
+      ? boxHarness.createBoxHarnessSandbox(box)
       : undefined
     const workspaceName = workspaceOptions
       ? workspaceNameFromOptions(workspaceOptions, {}, context.agentIdentity)
@@ -1653,7 +1654,7 @@ async function createAgentInvocationContext<
       hasCapabilityCleanup: capabilities.hasCloseCallbacks,
       handledResponse: capabilities.response,
       harnessSandboxProvider,
-      harnessWorkDir: box ? "." : undefined,
+      harnessWorkDir: boxHarness?.boxHarnessWorkDir,
       hooks: definition?.hooks as AgentHookObserverHooks | undefined,
       input: capabilities.input as AgentRunInput<CALL_OPTIONS>,
       instructions,

--- a/packages/agent/test/box-adapter.test.ts
+++ b/packages/agent/test/box-adapter.test.ts
@@ -1,11 +1,37 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { createBoxHarnessSandbox } from "../src/harness/box-sandbox.ts"
+import { HarnessAgent } from "@ai-sdk/harness/agent"
+import { boxHarnessWorkDir, createBoxHarnessSandbox } from "../src/harness/box-sandbox.ts"
 import { shareBoxSessions } from "../src/harness/shared-box.ts"
 
 import type { Box, BoxSession } from "@vite-hub/box"
 
 describe("Box harness adapter", () => {
+  it("uses a Harness-valid work directory for the Box workspace", () => {
+    const sandbox = createBoxHarnessSandbox({ plan: plan(), async open() { return boxSession() } })
+
+    expect(() => new HarnessAgent({
+      harness: { builtinTools: {}, harnessId: "fixture" } as never,
+      permissionMode: "allow-all",
+      sandbox,
+      sandboxConfig: { workDir: boxHarnessWorkDir },
+    })).not.toThrow()
+  })
+
+  it("maps the Harness workspace back to the authoritative Box cwd", async () => {
+    const exec = vi.fn(async () => ({ code: 0, ok: true, stderr: "", stdout: "" }))
+    const box: Box = {
+      plan: plan(),
+      async open() { return boxSession({ cwd: "/host/repository", exec }) },
+    }
+
+    const harness = await createBoxHarnessSandbox(box).createSession()
+    expect(harness.defaultWorkingDirectory).toBe("/host")
+    await harness.run({ command: "pwd", workingDirectory: "/host/workspace" })
+    expect(exec).toHaveBeenCalledWith("sh", ["-lc", "pwd"], expect.objectContaining({ cwd: "/host/repository" }))
+    await harness.destroy?.()
+  })
+
   it("opens a shared Box without a Harness driver", async () => {
     const session = boxSession()
     const open = vi.fn(async () => session)

--- a/packages/agent/test/box-adapter.test.ts
+++ b/packages/agent/test/box-adapter.test.ts
@@ -1,24 +1,12 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { HarnessAgent } from "@ai-sdk/harness/agent"
-import { boxHarnessWorkDir, createBoxHarnessSandbox } from "../src/harness/box-sandbox.ts"
+import { createBoxHarnessSandbox } from "../src/harness/box-sandbox.ts"
 import { shareBoxSessions } from "../src/harness/shared-box.ts"
 
 import type { Box, BoxSession } from "@vite-hub/box"
 
 describe("Box harness adapter", () => {
-  it("uses a Harness-valid work directory for the Box workspace", () => {
-    const sandbox = createBoxHarnessSandbox({ plan: plan(), async open() { return boxSession() } })
-
-    expect(() => new HarnessAgent({
-      harness: { builtinTools: {}, harnessId: "fixture" } as never,
-      permissionMode: "allow-all",
-      sandbox,
-      sandboxConfig: { workDir: boxHarnessWorkDir },
-    })).not.toThrow()
-  })
-
-  it("maps the Harness workspace back to the authoritative Box cwd", async () => {
+  it("preserves a provider-specific authoritative Box cwd", async () => {
     const exec = vi.fn(async () => ({ code: 0, ok: true, stderr: "", stdout: "" }))
     const box: Box = {
       plan: plan(),
@@ -26,8 +14,8 @@ describe("Box harness adapter", () => {
     }
 
     const harness = await createBoxHarnessSandbox(box).createSession()
-    expect(harness.defaultWorkingDirectory).toBe("/host")
-    await harness.run({ command: "pwd", workingDirectory: "/host/workspace" })
+    expect(harness.defaultWorkingDirectory).toBe("/host/repository")
+    await harness.run({ command: "pwd", workingDirectory: "/host/repository" })
     expect(exec).toHaveBeenCalledWith("sh", ["-lc", "pwd"], expect.objectContaining({ cwd: "/host/repository" }))
     await harness.destroy?.()
   })

--- a/packages/agent/test/box.test.ts
+++ b/packages/agent/test/box.test.ts
@@ -183,7 +183,7 @@ describe("Agent Box", () => {
 
       await expect(readFile(join(worktree, "changed.txt"), "utf8")).resolves.toBe("changed")
       expect(harnessSettings.at(-1)?.sandbox).toMatchObject({ providerId: "trusted-host" })
-      expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "workspace" })
+      expect(harnessSettings.at(-1)?.sandboxConfig.workDir).toBeUndefined()
     }
     finally {
       if (originalPath === undefined) delete process.env.PATH
@@ -259,7 +259,7 @@ describe("Agent Box", () => {
 
       expect(reportedCheckout).toMatch(/\/vitehub-box-[^/]+\/workspace$/)
       await expect(stat(join(reportedCheckout, ".."))).rejects.toMatchObject({ code: "ENOENT" })
-      expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "workspace" })
+      expect(harnessSettings.at(-1)?.sandboxConfig.workDir).toBeUndefined()
     }
     finally {
       if (originalPath === undefined) delete process.env.PATH
@@ -313,7 +313,7 @@ describe("Agent Box", () => {
       runtime: "unknown",
       waitUntil: vi.fn(),
     }, { prompt: "Repair the project." })).rejects.toThrow("stop after harness configuration")
-    expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "workspace" })
+    expect(harnessSettings.at(-1)?.sandboxConfig.workDir).toBeUndefined()
   })
 
   it("rejects Agent Workspace materialization over a Box-owned cwd", async () => {

--- a/packages/agent/test/box.test.ts
+++ b/packages/agent/test/box.test.ts
@@ -183,7 +183,7 @@ describe("Agent Box", () => {
 
       await expect(readFile(join(worktree, "changed.txt"), "utf8")).resolves.toBe("changed")
       expect(harnessSettings.at(-1)?.sandbox).toMatchObject({ providerId: "trusted-host" })
-      expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "." })
+      expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "workspace" })
     }
     finally {
       if (originalPath === undefined) delete process.env.PATH
@@ -259,7 +259,7 @@ describe("Agent Box", () => {
 
       expect(reportedCheckout).toMatch(/\/vitehub-box-[^/]+\/workspace$/)
       await expect(stat(join(reportedCheckout, ".."))).rejects.toMatchObject({ code: "ENOENT" })
-      expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "." })
+      expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "workspace" })
     }
     finally {
       if (originalPath === undefined) delete process.env.PATH
@@ -313,7 +313,7 @@ describe("Agent Box", () => {
       runtime: "unknown",
       waitUntil: vi.fn(),
     }, { prompt: "Repair the project." })).rejects.toThrow("stop after harness configuration")
-    expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "." })
+    expect(harnessSettings.at(-1)?.sandboxConfig).toMatchObject({ workDir: "workspace" })
   })
 
   it("rejects Agent Workspace materialization over a Box-owned cwd", async () => {

--- a/packages/box/test/trusted-host.test.ts
+++ b/packages/box/test/trusted-host.test.ts
@@ -413,7 +413,7 @@ describe("trustedHost", () => {
         settled,
         new Promise((resolvePromise) => setTimeout(resolvePromise, 1_500, "still-running")),
       ])).resolves.toBe(reason);
-      expect(() => process.kill(-child.pid!, 0)).toThrow();
+      await vi.waitFor(() => expect(() => process.kill(-child.pid!, 0)).toThrow());
     } finally {
       await session.destroy?.();
     }

--- a/packages/box/test/trusted-host.test.ts
+++ b/packages/box/test/trusted-host.test.ts
@@ -387,6 +387,38 @@ describe("trustedHost", () => {
     await session.destroy?.();
   });
 
+  it("force-kills commands that ignore abort termination", async () => {
+    if (process.platform === "win32") return;
+    const root = await temporaryRoot();
+    const marker = join(root, "ready");
+    const box = await resolveBox({ runtime: trustedHost() }, {});
+    const session = await boxProvider(box).createSession();
+    const controller = new AbortController();
+    const reason = new Error("cancelled");
+    const child = await session.spawn({
+      abortSignal: controller.signal,
+      command: `node -e "require('node:fs').writeFileSync(process.env.READY_MARKER, ''); process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)"`,
+      env: { READY_MARKER: marker },
+    });
+
+    try {
+      await vi.waitFor(() => expect(stat(marker)).resolves.toMatchObject({}));
+      const settled = child.wait().then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      controller.abort(reason);
+
+      await expect(Promise.race([
+        settled,
+        new Promise((resolvePromise) => setTimeout(resolvePromise, 1_500, "still-running")),
+      ])).resolves.toBe(reason);
+      expect(() => process.kill(-child.pid!, 0)).toThrow();
+    } finally {
+      await session.destroy?.();
+    }
+  });
+
   it("retries seed materialization after a later boot failure", async () => {
     const root = await temporaryRoot();
     let attempts = 0;


### PR DESCRIPTION
## Summary

- keep trusted-host abort cleanup covered when a worker ignores SIGTERM
- let Harness use the authoritative Box cwd as its default workspace instead of passing the invalid `.` workDir
- preserve provider-specific checkout paths during Harness workspace reset

## Verification

- Agent Box tests: 43 passed
- trusted-host Box tests: 25 passed
- `@vite-hub/agent` build
- Agent typecheck