### PR TITLE
Accept H3 events in requireRateLimit

### DIFF
--- a/packages/rate-limit/src/types.ts
+++ b/packages/rate-limit/src/types.ts
@@ -25,9 +25,7 @@ export interface RequireRateLimitOptions extends RateLimitPolicy {
 
 export interface RateLimitRequestEvent {
   readonly req: {
-    readonly context?: { clientAddress?: string }
     readonly headers: { get: (name: string) => string | null }
-    readonly ip?: string
   }
 }
 

--- a/packages/rate-limit/test/types.test-d.ts
+++ b/packages/rate-limit/test/types.test-d.ts
@@ -5,11 +5,17 @@ import { cloudflareRateLimitDriver } from "../src/drivers/cloudflare.ts"
 import { memoryRateLimitDriver } from "../src/drivers/memory.ts"
 import { hubRateLimit } from "../src/vite.ts"
 
-import type { HTTPEvent } from "h3"
+import type { H3Event } from "h3"
 import type { RateLimitDecision, RateLimitDriver, RateLimitDriverOutcome, RateLimitDriverResult, RateLimiter } from "../src/index.ts"
 
+type H3EventWithHostContext = Omit<H3Event, "req"> & {
+  readonly req: Omit<H3Event["req"], "context"> & {
+    readonly context?: { readonly platform?: unknown }
+  }
+}
+
 it("types the portable Rate Limit contract", async () => {
-  const event = {} as HTTPEvent
+  const event = {} as H3EventWithHostContext
   expectTypeOf(await requireRateLimit(event, "uploads", { enforcement: "strict", failure: "deny", limit: 10, window: "1m" })).toEqualTypeOf<void>()
   expectTypeOf(await requireRateLimit(event, "uploads", { key: "user", limit: 10, window: "1m" })).toEqualTypeOf<void>()
   const limiter = createRateLimiter({ driver: memoryRateLimitDriver(), limit: 10, window: "1m" })


### PR DESCRIPTION
Narrows `RateLimitRequestEvent` to the `req.headers.get` surface that every accepted event must provide, so H3 events with host-owned request contexts can pass directly to `requireRateLimit`. H3's `getRequestIP()` still owns optional client-address fallbacks at runtime; this removes ViteHub's incompatible redeclaration of those shapes without changing enforcement or provider behavior.

Adds focused type coverage derived from the current `H3Event` with a host-specific request context. The full Rate Limit package passes all 71 tests with zero type errors, including build, publint, and the published-types consumer; package typecheck, focused lint, and `git diff --check` also pass.