### PR TITLE
refactor(agent)!: remove pullRequestContext capability

### DIFF
--- a/docs/content/docs/capabilities/repository-host-context.md
+++ b/docs/content/docs/capabilities/repository-host-context.md
@@ -134,4 +134,4 @@ Call `resolveAll()` in tests when you need to assert the full resolved shape.
 
 - [Repository host](/docs/capabilities/repository-host)
 - [Agent invocations](/docs/agents/invocations)
-- Source: `packages/agent/src/capabilities/pull-request-context.ts`
+- Source: `packages/agent/src/capabilities/repository-host-context.ts`

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -47,8 +47,7 @@ export {
 } from "./repository-host.ts"
 export {
   repositoryHostContext,
-  pullRequestContext,
-} from "./pull-request-context.ts"
+} from "./repository-host-context.ts"
 export {
   llmRoute,
 } from "./llm-route.ts"
@@ -248,13 +247,10 @@ export type {
   JsonObject,
   JsonPrimitive,
   JsonValue,
-  PullRequestContextCapabilityFactory,
   PullRequestContextComment,
   PullRequestContextFile,
   PullRequestContextMetadata,
-  PullRequestContextOptions,
   PullRequestContextRef,
-  PullRequestContextResolver,
   PullRequestContextUser,
   PullRequestContextValue,
   RepositoryHostContextCapabilityFactory,
@@ -266,7 +262,7 @@ export type {
   RepositoryHostContextTargetValue,
   RepositoryHostContextValue,
   RepositoryHostIssueContext,
-} from "./pull-request-context.ts"
+} from "./repository-host-context.ts"
 export type {
   LlmRouteDecision,
   LlmRouteOptions,

--- a/packages/agent/src/capabilities/repository-host-context.ts
+++ b/packages/agent/src/capabilities/repository-host-context.ts
@@ -187,26 +187,10 @@ export interface RepositoryHostContextOptions<
   triggers?: Record<string, AgentTriggerDefinition<TRuntimeConfig, Name, any, any>>
 }
 
-export type PullRequestContextOptions<
-  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
-  Name extends WorkspaceName = WorkspaceName,
-> = RepositoryHostContextOptions<TRuntimeConfig, Name>
-
-export type PullRequestContextResolver<
-  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
-  Name extends WorkspaceName = WorkspaceName,
-> = RepositoryHostContextResolver<TRuntimeConfig, Name>
-
 type RepositoryHostContextCapabilityTypeContract<
   TContextKey extends string = "repositoryHost",
 > = AgentCapabilityTypeContract & {
   invocationContext: Record<TContextKey, AsyncRecord<RepositoryHostContextValue>>
-}
-
-type PullRequestContextCapabilityTypeContract<
-  TContextKey extends string = "pullRequest",
-> = AgentCapabilityTypeContract & {
-  invocationContext: Record<TContextKey, PullRequestContextValue>
 }
 
 const defaultRepositoryHostContextId = "repository-host-context"
@@ -593,12 +577,10 @@ function normalizeHostPullRequest(value: unknown, fallback: { issue?: Repository
 
 export function readPullRequestContext(context: unknown, contextKey = "pullRequest"): PullRequestContextValue | undefined {
   if (isRecord(context) && isRecord(context.context) && typeof context.context.get === "function") {
-    const value = context.context.get(contextKey)
-    return normalizePullRequestContext(value) || normalizePullRequestContext(isRecord(value) ? value.__pullRequestContext : undefined)
+    return normalizePullRequestContext(context.context.get(contextKey))
   }
   if (isRecord(context) && typeof context.get === "function") {
-    const value = context.get(contextKey)
-    return normalizePullRequestContext(value) || normalizePullRequestContext(isRecord(value) ? value.__pullRequestContext : undefined)
+    return normalizePullRequestContext(context.get(contextKey))
   }
   return normalizePullRequestContext(context)
 }
@@ -723,7 +705,7 @@ function repositoryHostContextValues(input: unknown): Partial<RepositoryHostCont
 
 function staticRepositoryHostRecord(input: unknown): AsyncRecord<RepositoryHostContextValue> {
   const values = repositoryHostContextValues(input)
-  return Object.assign(createAsyncRecord<RepositoryHostContextValue, RepositoryHostContextKey>(
+  return createAsyncRecord<RepositoryHostContextValue, RepositoryHostContextKey>(
     "repositoryHostContext()",
     repositoryHostContextKeys,
     () => repositoryHostContextKeys.filter(key => values[key] !== undefined),
@@ -735,7 +717,7 @@ function staticRepositoryHostRecord(input: unknown): AsyncRecord<RepositoryHostC
       labels: () => values.labels,
       pullRequest: () => values.pullRequest,
     },
-  ), values.pullRequest ? { __pullRequestContext: values.pullRequest } : {}) as AsyncRecord<RepositoryHostContextValue> & { __pullRequestContext?: PullRequestContextValue }
+  )
 }
 
 function repositoryParts(target: RepositoryHostContextTarget, nested?: Record<string, unknown>) {
@@ -899,17 +881,6 @@ export interface RepositoryHostContextCapabilityFactory {
   read(input: unknown, contextKey?: string): AsyncRecord<RepositoryHostContextValue>
 }
 
-export interface PullRequestContextCapabilityFactory {
-  <
-    TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
-    Name extends WorkspaceName = WorkspaceName,
-    const TContextKey extends string = "pullRequest",
-  >(
-    options?: PullRequestContextOptions<TRuntimeConfig, Name> & { contextKey?: TContextKey },
-  ): AgentCapabilityDefinition<TRuntimeConfig, Name, PullRequestContextCapabilityTypeContract<TContextKey>>
-  read(input: unknown, contextKey?: string): PullRequestContextValue | undefined
-}
-
 function createRepositoryHostContext<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
@@ -959,59 +930,6 @@ function createRepositoryHostContext<
   })
 }
 
-function createPullRequestContext<
-  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
-  Name extends WorkspaceName = WorkspaceName,
-  const TContextKey extends string = "pullRequest",
->(
-  options: PullRequestContextOptions<TRuntimeConfig, Name> & { contextKey?: TContextKey } = {},
-): AgentCapabilityDefinition<TRuntimeConfig, Name, PullRequestContextCapabilityTypeContract<TContextKey>> {
-  const capabilityId = options.id || "pull-request-context"
-  const contextKey = options.contextKey || "pullRequest"
-  const recordedContexts = new WeakSet<AgentCapabilityContext<TRuntimeConfig, Name>["context"]>()
-
-  async function recordContext(context: AgentCapabilityContext<TRuntimeConfig, Name>) {
-    if (recordedContexts.has(context.context)) return
-    const hasContextOption = "context" in options
-    const hasTargetOption = "target" in options
-    const input = await resolveMaybeFunction(options.context, context)
-    const target = await resolveMaybeFunction(options.target, context)
-    const existing = context.context.get(contextKey)
-    if (existing !== undefined) {
-      recordedContexts.add(context.context)
-      return
-    }
-    if (target === false || target === null || target === undefined) {
-      if (hasTargetOption && (input === false || input === null || input === undefined)) {
-        return
-      }
-    }
-    if (!target && hasContextOption && (input === false || input === null || input === undefined)) {
-      return
-    }
-    const value = target
-      ? await targetRepositoryHostRecord(await resolveRepositoryHostContextClient(options, context), target).get("pullRequest")
-      : repositoryHostContextValues(input ?? context).pullRequest
-    if (value) context.context.set(contextKey, value)
-    recordedContexts.add(context.context)
-  }
-
-  return defineCapability({
-    id: capabilityId,
-    metadata: {
-      contextKey,
-      kind: "pull-request-context",
-    },
-    prepare: recordContext,
-    requires: options.target && !options.client ? [{ primitive: "repository-host" }] : undefined,
-    triggers: options.triggers,
-  })
-}
-
 export const repositoryHostContext = Object.assign(createRepositoryHostContext, {
   read: readRepositoryHostContext,
 }) as RepositoryHostContextCapabilityFactory
-
-export const pullRequestContext = Object.assign(createPullRequestContext, {
-  read: readPullRequestContext,
-}) as PullRequestContextCapabilityFactory

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1,6 +1,6 @@
 import { createHash, createSign } from "node:crypto"
 import { CHAT_FINISH_EXTENSION_CONTEXT_KEY } from "./chat-trigger.ts"
-import { readPullRequestContext } from "./capabilities/pull-request-context.ts"
+import { readPullRequestContext } from "./capabilities/repository-host-context.ts"
 import {
   deliveryArtifactAttachments,
   deliveryArtifactMarkdownReferencePaths,
@@ -38,7 +38,7 @@ import type {
   MaybeResolvable,
   PublishedAgentDeliveryArtifact,
 } from "./types.ts"
-import type { PullRequestContextValue } from "./capabilities/pull-request-context.ts"
+import type { PullRequestContextValue } from "./capabilities/repository-host-context.ts"
 import type { AgentChannelChatRouteBody, AgentChannelChatRouteHandlerOptions } from "./server.ts"
 import type { Adapter, FileUpload } from "chat"
 

--- a/packages/agent/test/repository-host-context.test.ts
+++ b/packages/agent/test/repository-host-context.test.ts
@@ -380,8 +380,8 @@ describe("repositoryHostContext", () => {
     await expect(host.get("labels")).resolves.toEqual([])
   })
 
-  it("keeps the old synchronous pull request reader for source and git consumers", async () => {
-    const { pullRequestContext, repositoryHostContext } = await import("../src/capabilities.ts")
+  it("normalizes pull request data in static repository host context", async () => {
+    const { repositoryHostContext } = await import("../src/capabilities.ts")
     const rawPullRequestContext = {
       number: 999,
       pull_request: {
@@ -405,14 +405,6 @@ describe("repositoryHostContext", () => {
       },
     } as const
 
-    expect(pullRequestContext.read({
-      context: { get: (key: string) => key === "pullRequest" ? rawPullRequestContext : undefined },
-    })).toMatchObject({
-      headRef: "refs/pull/42/head",
-      number: 42,
-      repository: "acme/app",
-      source: { mount: "vitehub" },
-    })
     await expect(repositoryHostContext.read({
       context: { get: (key: string) => key === "pullRequest" ? rawPullRequestContext : undefined },
     }).get("issue")).resolves.toMatchObject({
@@ -421,121 +413,6 @@ describe("repositoryHostContext", () => {
       repository: "acme/app",
       title: "Review me",
     })
-  })
-
-  it("honors pullRequestContext targets", async () => {
-    const { pullRequestContext } = await import("../src/capabilities.ts")
-    const read = vi.fn<RepositoryHostClient["read"]>(async request => {
-      if (request.operation === "issue") {
-        return {
-          number: 42,
-          pull_request: { url: "https://api.github.test/repos/acme/app/pulls/42" },
-          title: "Review me",
-        }
-      }
-      if (request.operation === "changeRequest") {
-        return {
-          base: { ref: "main" },
-          head: { ref: "feature", repo: { full_name: "contributor/app" } },
-          number: 42,
-          title: "Review me",
-        }
-      }
-      throw new Error(`Unexpected operation: ${request.operation}`)
-    })
-    const context = createAgentInvocationContextStore()
-
-    await resolveAgentCapabilities({
-      capabilities: [
-        pullRequestContext({
-          client: { provider: "github", read },
-          target: { pullRequest: 42, repo: "acme/app" },
-        }),
-      ],
-    }, runtime(), {}, undefined, "read", { context })
-
-    expect(context.get("pullRequest")).toMatchObject({
-      apiUrl: "https://api.github.test/repos/acme/app/pulls/42",
-      baseRef: "main",
-      headRef: "feature",
-      number: 42,
-      repository: "acme/app",
-      source: {
-        ref: "feature",
-        repo: "contributor/app",
-      },
-      title: "Review me",
-    })
-    expect(read).toHaveBeenCalledWith({
-      operation: "issue",
-      target: { id: 42, kind: "issue", owner: "acme", repository: "app" },
-    })
-    expect(read).toHaveBeenCalledWith({
-      operation: "changeRequest",
-      target: { id: 42, kind: "changeRequest", owner: "acme", repository: "app" },
-    })
-  })
-
-  it("declares repository-host requirements for pullRequestContext targets without explicit clients", async () => {
-    const { pullRequestContext } = await import("../src/capabilities.ts")
-
-    expect(pullRequestContext({
-      target: { pullRequest: 42, repo: "acme/app" },
-    }).requires).toEqual([{ primitive: "repository-host" }])
-    expect(pullRequestContext({
-      client: { provider: "github", read: vi.fn() },
-      target: { pullRequest: 42, repo: "acme/app" },
-    }).requires).toBeUndefined()
-  })
-
-  it("records pullRequestContext under the legacy pullRequest key by default", async () => {
-    const { pullRequestContext } = await import("../src/capabilities.ts")
-    const context = createAgentInvocationContextStore()
-
-    await resolveAgentCapabilities({
-      capabilities: [
-        pullRequestContext({
-          context: {
-            pullRequest: {
-              base: { ref: "main" },
-              number: 42,
-              repository: "acme/app",
-              source: {
-                mount: "vitehub",
-                ref: "refs/pull/42/head",
-                repo: "acme/app",
-              },
-              title: "Review me",
-            },
-          },
-        }),
-      ],
-    }, runtime(), {}, emptyWorkspace() as never, "read", {
-      context,
-      workspaceDefinition: {
-        name: "review",
-        sources: {},
-      },
-    })
-
-    expect(pullRequestContext.read({ context })).toMatchObject({
-      number: 42,
-      repository: "acme/app",
-      title: "Review me",
-    })
-    expect(context.get("pullRequest")).toMatchObject({
-      headRef: "refs/pull/42/head",
-      number: 42,
-      repository: "acme/app",
-      source: {
-        mount: "vitehub",
-        ref: "refs/pull/42/head",
-        repo: "acme/app",
-      },
-      title: "Review me",
-    })
-    expect(context.get<{ get?: unknown }>("pullRequest")?.get).toBeUndefined()
-    expect(context.get("repositoryHost")).toBeUndefined()
   })
 
   it("does not add repository host context when configured resolvers opt out", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
-import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, pullRequestContext, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
+import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -12,7 +12,7 @@ import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvoke
 import type { MCPClient } from "@ai-sdk/mcp"
 import type { StandardSchemaV1 } from "@standard-schema/spec"
 import { file, github as githubSource, type ReadonlyWorkspaceFacade } from "@vite-hub/workspace"
-import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatRunContext, FetchCapabilityToolOptions, PullRequestContextValue, RepositoryHostClient, RepositoryHostContextValue, TranscriptionResult } from "../src/capabilities.ts"
+import type { AccessInvocationContextValue, AccessWorkspaceOptionsFor, AgentChatRunContext, FetchCapabilityToolOptions, RepositoryHostClient, RepositoryHostContextValue, TranscriptionResult } from "../src/capabilities.ts"
 
 declare global {
   interface ViteHubAgentInvocationContextValues {
@@ -392,12 +392,6 @@ describe("agent public types", () => {
               repository: "acme/app",
             },
           } satisfies RepositoryHostContextValue,
-        }),
-        pullRequestContext({
-          context: {
-            number: 12,
-            repository: "acme/app",
-          } satisfies PullRequestContextValue,
         }),
         skills(),
         skills({ path: "skills/agent-browser", source: githubSource({ repo: "vercel/vercel-plugin", root: "skills/agent-browser" }) }),
@@ -820,6 +814,8 @@ describe("agent public types", () => {
 
     type CapabilityExports = typeof import("../src/capabilities.ts")
     type _PublicAudioBytes = CapabilityExports["audioBytes"]
+    // @ts-expect-error pull request context belongs to the GitHub Channel
+    type _PublicPullRequestContext = CapabilityExports["pullRequestContext"]
     // @ts-expect-error app-owned ingress belongs to Channels, not entry()
     type _PublicEntry = CapabilityExports["entry"]
     // @ts-expect-error Access Capability Type Contract is internal to access() inference
@@ -848,21 +844,6 @@ describe("agent public types", () => {
         return context.context.get<boolean>("enabled") ? [conditional] : []
       },
       driver: { run: () => "ok" },
-    })
-
-    defineAgent({
-      capabilities: async () => [
-        pullRequestContext({
-          context: { number: 42, repository: "acme/app" },
-        }),
-      ] as const,
-      driver: {
-        run({ context }) {
-          const pullRequest: PullRequestContextValue | undefined = context.get("pullRequest")
-          expectTypeOf(pullRequest).toEqualTypeOf<PullRequestContextValue | undefined>()
-          return "ok"
-        },
-      },
     })
   })
 


### PR DESCRIPTION
## What changed

- remove only the duplicated `pullRequestContext()` Capability factory and its factory-specific public types
- delete the legacy capability tests and type-inference coverage
- rename its shared implementation file to `repository-host-context.ts`
- keep `repositoryHostContext()` exported, documented, and fully tested
- keep the GitHub Channel's `pullRequest.read()` context reader unchanged

## Why

The GitHub Channel already owns normalized pull-request invocation context, so `pullRequestContext()` duplicates that ingress. `repositoryHostContext()` remains useful for lazy typed issue and Change Request data through a Repository Host client and is intentionally preserved.

This is a breaking removal for `pullRequestContext()` consumers. Use `github({ pullRequest: true })` with `pullRequest.read(invocation)` for Channel-provided pull-request context.

Replaces the over-broad closed PR #812.

## Validation

- `vp run -t @vite-hub/agent#build`
- Agent tests: 1,402 passed
- `pnpm --filter @vite-hub/agent typecheck`
- focused docs tests: 12 passed
- `git diff --check`