### PR TITLE
fix: release validation prerequisites

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,10 @@ jobs:
           node-version: "24"
           cache: true
 
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: 2.9.3
+
       - name: Validate npm trusted publishing support
         run: |
           node --version

--- a/packages/auth/test/published-types.test.ts
+++ b/packages/auth/test/published-types.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process"
-import { cp, mkdtemp, readFile, readdir, rm } from "node:fs/promises"
+import { cp, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -51,6 +51,15 @@ async function runPnpm(args: string[], cwd: string): Promise<void> {
 beforeAll(async () => {
   consumerRoot = await mkdtemp(join(tmpdir(), "vitehub-auth-types-"))
   await cp(fixtureRoot, consumerRoot, { recursive: true })
+  const consumerManifestPath = join(consumerRoot, "package.json")
+  const consumerManifest = JSON.parse(await readFile(consumerManifestPath, "utf8"))
+  for (const name of packedPackages) {
+    const packageName = `@vite-hub/${name}`
+    if (!(packageName in consumerManifest.dependencies)) continue
+    const version = JSON.parse(await readFile(join(workspaceRoot, "packages", name, "package.json"), "utf8")).version
+    consumerManifest.dependencies[packageName] = `file:./vite-hub-${name}-${version}.tgz`
+  }
+  await writeFile(consumerManifestPath, `${JSON.stringify(consumerManifest, null, 2)}\n`)
   const packResults = await Promise.allSettled(packedPackages.map(name => (
     runPnpm(["pack", "--pack-destination", consumerRoot!], join(workspaceRoot, "packages", name))
   )))

--- a/packages/auth/test/published-types.test.ts
+++ b/packages/auth/test/published-types.test.ts
@@ -1,11 +1,13 @@
 import { execFile } from "node:child_process"
-import { cp, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
+import { cp, mkdtemp, readFile, readdir, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
 
 import { afterAll, beforeAll, expect, it } from "vitest"
+
+import { syncPackedWorkspaceDependencies } from "../../internal/test-utils/published-types.js"
 
 const execFileAsync = promisify(execFile)
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
@@ -51,15 +53,11 @@ async function runPnpm(args: string[], cwd: string): Promise<void> {
 beforeAll(async () => {
   consumerRoot = await mkdtemp(join(tmpdir(), "vitehub-auth-types-"))
   await cp(fixtureRoot, consumerRoot, { recursive: true })
-  const consumerManifestPath = join(consumerRoot, "package.json")
-  const consumerManifest = JSON.parse(await readFile(consumerManifestPath, "utf8"))
-  for (const name of packedPackages) {
-    const packageName = `@vite-hub/${name}`
-    if (!(packageName in consumerManifest.dependencies)) continue
-    const version = JSON.parse(await readFile(join(workspaceRoot, "packages", name, "package.json"), "utf8")).version
-    consumerManifest.dependencies[packageName] = `file:./vite-hub-${name}-${version}.tgz`
-  }
-  await writeFile(consumerManifestPath, `${JSON.stringify(consumerManifest, null, 2)}\n`)
+  await syncPackedWorkspaceDependencies(
+    consumerRoot,
+    workspaceRoot,
+    packedPackages.map(name => `@vite-hub/${name}`),
+  )
   const packResults = await Promise.allSettled(packedPackages.map(name => (
     runPnpm(["pack", "--pack-destination", consumerRoot!], join(workspaceRoot, "packages", name))
   )))

--- a/packages/internal/test-utils/published-types.ts
+++ b/packages/internal/test-utils/published-types.ts
@@ -1,0 +1,21 @@
+import { readFile, writeFile } from "node:fs/promises"
+import { join } from "node:path"
+
+export async function syncPackedWorkspaceDependencies(
+  consumerRoot: string,
+  workspaceRoot: string,
+  packageNames: readonly string[],
+): Promise<void> {
+  const consumerManifestPath = join(consumerRoot, "package.json")
+  const consumerManifest = JSON.parse(await readFile(consumerManifestPath, "utf8"))
+
+  for (const packageName of packageNames) {
+    if (!(packageName in consumerManifest.dependencies)) continue
+    const name = packageName.replace(/^@vite-hub\//, "")
+    const packageManifestPath = join(workspaceRoot, "packages", name, "package.json")
+    const version = JSON.parse(await readFile(packageManifestPath, "utf8")).version
+    consumerManifest.dependencies[packageName] = `file:./vite-hub-${name}-${version}.tgz`
+  }
+
+  await writeFile(consumerManifestPath, `${JSON.stringify(consumerManifest, null, 2)}\n`)
+}

--- a/packages/internal/test-utils/published-types.ts
+++ b/packages/internal/test-utils/published-types.ts
@@ -8,14 +8,25 @@ export async function syncPackedWorkspaceDependencies(
 ): Promise<void> {
   const consumerManifestPath = join(consumerRoot, "package.json")
   const consumerManifest = JSON.parse(await readFile(consumerManifestPath, "utf8"))
+  const overrides: string[] = []
 
   for (const packageName of packageNames) {
-    if (!(packageName in consumerManifest.dependencies)) continue
     const name = packageName.replace(/^@vite-hub\//, "")
     const packageManifestPath = join(workspaceRoot, "packages", name, "package.json")
     const version = JSON.parse(await readFile(packageManifestPath, "utf8")).version
-    consumerManifest.dependencies[packageName] = `file:./vite-hub-${name}-${version}.tgz`
+    const dependency = `file:./vite-hub-${name}-${version}.tgz`
+    overrides.push(`  "${packageName}": "${dependency}"`)
+    if (packageName in consumerManifest.dependencies) consumerManifest.dependencies[packageName] = dependency
   }
 
   await writeFile(consumerManifestPath, `${JSON.stringify(consumerManifest, null, 2)}\n`)
+
+  const workspaceManifestPath = join(consumerRoot, "pnpm-workspace.yaml")
+  try {
+    await readFile(workspaceManifestPath)
+    await writeFile(workspaceManifestPath, `overrides:\n${overrides.join("\n")}\n`)
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
 }

--- a/packages/rate-limit/test/published-types.test.ts
+++ b/packages/rate-limit/test/published-types.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process"
-import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { cp, mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -7,8 +7,11 @@ import { promisify } from "node:util"
 
 import { it } from "vitest"
 
+import { syncPackedWorkspaceDependencies } from "../../internal/test-utils/published-types.js"
+
 const execFileAsync = promisify(execFile)
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const workspaceRoot = resolve(packageRoot, "../..")
 const fixtureRoot = join(packageRoot, "fixtures", "published-types")
 const tsc = resolve(packageRoot, "../../node_modules/typescript/bin/tsc")
 
@@ -25,11 +28,7 @@ it("publishes every documented Rate Limit entrypoint to a real consumer", { time
   const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-types-"))
   try {
     await cp(fixtureRoot, root, { recursive: true })
-    const version = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")).version
-    const consumerManifestPath = join(root, "package.json")
-    const consumerManifest = JSON.parse(await readFile(consumerManifestPath, "utf8"))
-    consumerManifest.dependencies["@vite-hub/rate-limit"] = `file:./vite-hub-rate-limit-${version}.tgz`
-    await writeFile(consumerManifestPath, `${JSON.stringify(consumerManifest, null, 2)}\n`)
+    await syncPackedWorkspaceDependencies(root, workspaceRoot, ["@vite-hub/rate-limit"])
     await runPnpm(["pack", "--pack-destination", root], packageRoot)
     await runPnpm(["install", "--ignore-scripts", "--no-frozen-lockfile"], root)
     try {

--- a/packages/rate-limit/test/published-types.test.ts
+++ b/packages/rate-limit/test/published-types.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process"
-import { cp, mkdtemp, rm } from "node:fs/promises"
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -25,6 +25,11 @@ it("publishes every documented Rate Limit entrypoint to a real consumer", { time
   const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-types-"))
   try {
     await cp(fixtureRoot, root, { recursive: true })
+    const version = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")).version
+    const consumerManifestPath = join(root, "package.json")
+    const consumerManifest = JSON.parse(await readFile(consumerManifestPath, "utf8"))
+    consumerManifest.dependencies["@vite-hub/rate-limit"] = `file:./vite-hub-rate-limit-${version}.tgz`
+    await writeFile(consumerManifestPath, `${JSON.stringify(consumerManifest, null, 2)}\n`)
     await runPnpm(["pack", "--pack-destination", root], packageRoot)
     await runPnpm(["install", "--ignore-scripts", "--no-frozen-lockfile"], root)
     try {

--- a/packages/runtime/test/published-types.test.ts
+++ b/packages/runtime/test/published-types.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process"
-import { cp, mkdtemp, rm } from "node:fs/promises"
+import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -33,6 +33,11 @@ async function runProcess(command: string, args: string[], cwd: string): Promise
 beforeAll(async () => {
   consumerRoot = await mkdtemp(join(tmpdir(), "vitehub-runtime-types-"))
   await cp(fixtureRoot, consumerRoot, { recursive: true })
+  const version = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")).version
+  const consumerManifestPath = join(consumerRoot, "package.json")
+  const consumerManifest = JSON.parse(await readFile(consumerManifestPath, "utf8"))
+  consumerManifest.dependencies["@vite-hub/runtime"] = `file:./vite-hub-runtime-${version}.tgz`
+  await writeFile(consumerManifestPath, `${JSON.stringify(consumerManifest, null, 2)}\n`)
   const packResults = await Promise.allSettled([runProcess("npm", [
     "pack",
     "--pack-destination",

--- a/packages/runtime/test/published-types.test.ts
+++ b/packages/runtime/test/published-types.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process"
-import { cp, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { cp, mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
@@ -7,8 +7,11 @@ import { promisify } from "node:util"
 
 import { afterAll, beforeAll, it } from "vitest"
 
+import { syncPackedWorkspaceDependencies } from "../../internal/test-utils/published-types.js"
+
 const execFileAsync = promisify(execFile)
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const workspaceRoot = resolve(packageRoot, "../..")
 const fixtureRoot = join(packageRoot, "fixtures", "published-types")
 const tsc = resolve(packageRoot, "../../node_modules/typescript/bin/tsc")
 const phaseTimeout = 15_000
@@ -33,11 +36,7 @@ async function runProcess(command: string, args: string[], cwd: string): Promise
 beforeAll(async () => {
   consumerRoot = await mkdtemp(join(tmpdir(), "vitehub-runtime-types-"))
   await cp(fixtureRoot, consumerRoot, { recursive: true })
-  const version = JSON.parse(await readFile(join(packageRoot, "package.json"), "utf8")).version
-  const consumerManifestPath = join(consumerRoot, "package.json")
-  const consumerManifest = JSON.parse(await readFile(consumerManifestPath, "utf8"))
-  consumerManifest.dependencies["@vite-hub/runtime"] = `file:./vite-hub-runtime-${version}.tgz`
-  await writeFile(consumerManifestPath, `${JSON.stringify(consumerManifest, null, 2)}\n`)
+  await syncPackedWorkspaceDependencies(consumerRoot, workspaceRoot, ["@vite-hub/runtime"])
   const packResults = await Promise.allSettled([runProcess("npm", [
     "pack",
     "--pack-destination",


### PR DESCRIPTION
The release workflow validates deployment and published-package contracts after rewriting package versions. Two repository-controlled prerequisites made the v0.0.2 dry run fail:

- the workflow ran the Deno deployment contract without installing Deno, causing `spawn deno ENOENT`;
- published-types fixture metadata still referenced `0.0.1` tarballs after packages received the release version.

This installs the same pinned Deno setup used by CI and synchronizes copied consumer dependencies and pnpm overrides to the package versions their tests actually pack.

Validation: release workflow YAML parses; affected package typechecks and published-types tests pass; `git diff --check` passes. Exact-head repository checks and review are required before merge; the full release dry run will be rerun after merge.