### PR TITLE
test(env): isolate release tag metadata

### DIFF
--- a/packages/env/test/vite.test.ts
+++ b/packages/env/test/vite.test.ts
@@ -11,7 +11,7 @@ import {
   ScriptTarget,
 } from "typescript"
 import { build } from "vite"
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { createRuntimeRegistry } from "../src/core/resolve.ts"
 import { resolveServerEnv } from "../src/server.ts"
@@ -19,8 +19,12 @@ import { createEnvImportAliases, createEnvTypeScriptPaths, env, hubEnv } from ".
 
 import { booleanSchema, stringSchema } from "./helpers.ts"
 
+afterEach(() => vi.unstubAllEnvs())
+
 describe("Vite plugin", () => {
   it("loads Vite env, validates build values, injects define, and serves virtual config", async () => {
+    vi.stubEnv("GITHUB_REF_TYPE", "")
+
     const root = await mkdtemp(join(tmpdir(), "vitehub-env-vite-"))
     await writeFile(join(root, "package.json"), JSON.stringify({ name: "quiver-chat", version: "1.2.3" }), "utf8")
     await writeFile(join(root, ".env.production"), "PUBLIC_APP_NAME=Quiver\nDEFINE_SENTRY_DEBUG=true\n", "utf8")


### PR DESCRIPTION
## Summary

- isolate the Vite env fixture from GitHub tag metadata
- keep the release test deterministic on tag-triggered workflows

## Validation

- `GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v0.0.2 vp test test/vite.test.ts`
- `vp run lint`
- `vp run typecheck` in `packages/env`