### PR TITLE
fix(blob): keep R2 fallback in HTTP mode

### DIFF
--- a/packages/blob/src/drivers/cloudflare.ts
+++ b/packages/blob/src/drivers/cloudflare.ts
@@ -19,8 +19,12 @@ function createHttpDriver(options: ResolvedCloudflareR2BlobStoreConfig): BlobDri
     bucketName,
     secretAccessKey: runtimeValue(options.secretAccessKey, "R2_SECRET_ACCESS_KEY", "CLOUDFLARE_R2_SECRET_ACCESS_KEY"),
   }, async resolved => (await importOptionalPeer<typeof import("files-sdk/r2")>("files-sdk/r2", resolved.driver, s3PeerInstall)).r2({
-    ...resolved,
+    accountId: resolved.accountId,
+    accessKeyId: resolved.accessKeyId,
     bucket: resolved.bucketName,
+    defaultUrlExpiresIn: resolved.defaultUrlExpiresIn,
+    publicBaseUrl: resolved.publicBaseUrl,
+    secretAccessKey: resolved.secretAccessKey,
   }))
 }
 

--- a/packages/blob/test/runtime.test.ts
+++ b/packages/blob/test/runtime.test.ts
@@ -588,20 +588,23 @@ describe("blob runtime", () => {
         accessKeyId: "********",
         binding: "BLOB",
         bucketName: "********",
+        defaultUrlExpiresIn: 900,
         driver: "cloudflare-r2",
+        publicBaseUrl: "https://assets.example.com",
         secretAccessKey: "********",
       },
     })
 
     const list = expectBlobSuccess(await blob.list())
 
-    expect(filesSdkMock.r2).toHaveBeenCalledWith(expect.objectContaining({
+    expect(filesSdkMock.r2).toHaveBeenCalledWith({
       accountId: "account",
       accessKeyId: "access-key",
       bucket: "runtime-assets",
-      bucketName: "runtime-assets",
+      defaultUrlExpiresIn: 900,
+      publicBaseUrl: "https://assets.example.com",
       secretAccessKey: "secret-key",
-    }))
+    })
     expect(list.blobs).toEqual([
       expect.objectContaining({ pathname: "notes/hello.txt" }),
     ])
@@ -840,7 +843,6 @@ describe("blob runtime", () => {
       accountId: "worker-account",
       accessKeyId: "worker-access-key",
       bucket: "worker-assets",
-      bucketName: "worker-assets",
       secretAccessKey: "worker-secret-key",
     }))
   })
@@ -877,14 +879,12 @@ describe("blob runtime", () => {
       accountId: "first-account",
       accessKeyId: "first-access-key",
       bucket: "first-assets",
-      bucketName: "first-assets",
       secretAccessKey: "first-secret-key",
     }))
     expect(filesSdkMock.r2).toHaveBeenNthCalledWith(2, expect.objectContaining({
       accountId: "second-account",
       accessKeyId: "second-access-key",
       bucket: "second-assets",
-      bucketName: "second-assets",
       secretAccessKey: "second-secret-key",
     }))
   })


### PR DESCRIPTION
Cloudflare R2 fallback now passes only HTTP adapter options to Files SDK, so a configured binding name cannot select binding mode when the runtime binding is absent. Supported `defaultUrlExpiresIn` and `publicBaseUrl` values remain intact.

This fixes the residual fallback mismatch after #767, where native-versus-HTTP selection moved into ViteHub but the HTTP call still received ViteHub’s `binding`, `driver`, and `bucketName` fields. The runtime regression asserts the exact provider option object and keeps the worker-environment credential cases aligned.