### PR TITLE
Add per-invocation UI message stream projection

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -66,7 +66,7 @@ import {
 } from "./capability-runtime.ts"
 import type { AgentCapabilityRegistries, ResolvedAgentFinishExtensionProvider, ResolvedAgentOutputExtensionProvider } from "./capability-runtime.ts"
 import { formatUnknownAgentMessage } from "./registry-error.ts"
-import { finalizeUiMessageStreamOutput, isUIMessageStreamResult, normalizeUiMessageStream, uiMessageTextDelta, withReadableStreamCleanup } from "./stream-output.ts"
+import { createAgentUIMessageStreamResponse, finalizeUiMessageStreamOutput, isUIMessageStreamResponse, isUIMessageStreamResult, normalizeUiMessageStream, uiMessageStreamFromResponse, uiMessageTextDelta, withReadableStreamCleanup } from "./stream-output.ts"
 import {
   applyAgentToolPolicies,
   withAgentToolStepReporting,
@@ -2287,6 +2287,7 @@ async function finalizeAgentInvocationResult<
   finalizeObject: (result: unknown) => MaybePromise<{ deferFinish?: boolean, finishResult: unknown, finishUsage?: AgentUsageRecord, value: TResult }>,
   failureMessage: string,
   options: {
+    finalizeResponse?: (response: Response) => MaybePromise<{ deferFinish?: boolean, finishResult: unknown, finishUsage?: AgentUsageRecord, value: Response | TResult } | undefined>
     finalizeRawStreams?: boolean
     outputExtensions?: Map<string, unknown>
     wrapStream?: (stream: AsyncIterable<unknown>) => AsyncIterable<unknown>
@@ -2295,6 +2296,13 @@ async function finalizeAgentInvocationResult<
   const shouldWrapOutput = shouldWrapInvocationOutput(context)
   try {
     if (result instanceof Response) {
+      const finalized = await options.finalizeResponse?.(result)
+      if (finalized) {
+        if (!finalized.deferFinish) {
+          await lifecycle.finish({ result: finalized.finishResult, status: "success", usage: finalized.finishUsage })
+        }
+        return finalized.value
+      }
       const responseMediaType = result.headers.get("content-type")?.split(";", 1)[0]?.trim().toLowerCase()
       const responseIsText = responseMediaType !== "text/event-stream" && (responseMediaType?.startsWith("text/")
         || responseMediaType === "application/json"
@@ -2607,6 +2615,33 @@ async function executeAgentInvocation<
       value: customRun ? withStreamResultProperties(value, rendered) : value,
     }
   }, executionFailureMessage, {
+    finalizeResponse: options.output === "ui-message-stream"
+      ? async (response) => {
+          if (!isUIMessageStreamResponse(response)) return
+          const projection = typeof definition?.uiMessageStream === "function"
+            ? await definition.uiMessageStream(invocation)
+            : definition?.uiMessageStream
+          const finalized = await finalizeUiMessageStreamOutput({
+            toUIMessageStream: () => uiMessageStreamFromResponse(response),
+          }, shouldWrapInvocationOutput(invocation), async (outcome, streamedText, streamedUsageRecord) => {
+            const driverUsageRecord = await resolveFinishUsageRecord(invocation, response)
+            await finishStreamAgentInvocation(invocation, lifecycle, resultWithStreamedTextAndUsage(response, streamedText || "", streamedUsageRecord, driverUsageRecord), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
+          }, projection)
+          const headers = new Headers(response.headers)
+          headers.delete("content-encoding")
+          headers.delete("content-length")
+          return {
+            ...finalized,
+            finishResult: response,
+            value: createAgentUIMessageStreamResponse({
+              headers,
+              status: response.status,
+              statusText: response.statusText,
+              stream: finalized.value,
+            }),
+          }
+        }
+      : undefined,
     finalizeRawStreams: options.output === "ui-message-stream" || Boolean(invocation.finalOutputRenderers.length) || Boolean(invocation.output),
     outputExtensions,
     ...(customRun

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -344,6 +344,8 @@ export type {
   AgentUsageCredentialSource,
   AgentUsageCost,
   AgentUsageRecord,
+  AgentUIMessageStreamProjection,
+  AgentUIMessageStreamProjectionResolver,
   AgentWebhookRegistrationDefinition,
   AgentChannelWebhookRegistrationDefinition,
   AgentWorkflowRuntimeBinding,
@@ -982,7 +984,7 @@ function defineBaseAgent<
   options: AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentInvocationContextValues, AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined, TOutput>,
 ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentInvocationContextValues, TOutput> {
   const driver = normalizeAgentDriver(options)
-  const { box, capabilities, cli, description, hooks, messages, name, output, runtime = defaultAgentWorkflowRuntime(), runEvents, version, workspace } = options
+  const { box, capabilities, cli, description, hooks, messages, name, output, runtime = defaultAgentWorkflowRuntime(), runEvents, uiMessageStream, version, workspace } = options
   const channels = normalizeAgentChannels(options.channels)
   if (box && driver.kind !== "harness") {
     throw new Error("[vitehub] defineAgent({ box }) currently requires a harness Agent Driver.")
@@ -1045,6 +1047,7 @@ function defineBaseAgent<
     runtime,
     runEvents,
     run,
+    uiMessageStream,
     version,
     workspace,
     ...(normalizedCapabilities.length ? { capabilities: normalizedCapabilities } : {}),
@@ -2566,9 +2569,12 @@ async function executeAgentInvocation<
     const driverUsageRecord = await resolveFinishUsageRecord(invocation, result)
     const rendered = renderedResult ? result : await applyOutputRenderers(result, invocation.outputRenderers, invocation.outputExtensionProviders, outputExtensions)
     if (options.output === "ui-message-stream") {
+      const projection = typeof definition?.uiMessageStream === "function"
+        ? await definition.uiMessageStream(invocation)
+        : definition?.uiMessageStream
       return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, invocation), shouldWrapInvocationOutput(invocation), async (outcome, streamedText, streamedUsageRecord) => {
         await finishStreamAgentInvocation(invocation, lifecycle, resultWithStreamedTextAndUsage(rendered, streamedText || "", streamedUsageRecord, driverUsageRecord), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
-      })
+      }, projection)
     }
 
     const isStreamResult = hasTraceableStreamResult(rendered)

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -229,8 +229,12 @@ function projectUiMessageStream(
   projection: AgentUIMessageStreamProjection | undefined,
 ): ReadableStream<unknown> {
   if (!projection) return stream
+  const pendingTextStarts = new Map<string, unknown>()
   const reasoningTextIds = new Set<string>()
   return stream.pipeThrough(new TransformStream<unknown, unknown>({
+    flush(controller) {
+      for (const start of pendingTextStarts.values()) controller.enqueue(start)
+    },
     transform(chunk, controller) {
       const type = streamEventType(chunk)
       if (projection.reasoning === "hidden") {
@@ -239,11 +243,25 @@ function projectUiMessageStream(
         const id = typeof text.id === "string" ? text.id : undefined
         if (type === "text-start" && id) {
           reasoningTextIds.delete(id)
-          if (text.phase === "reasoning") reasoningTextIds.add(id)
+          pendingTextStarts.delete(id)
+          if (text.phase === "reasoning") {
+            reasoningTextIds.add(id)
+            return
+          }
+          pendingTextStarts.set(id, chunk)
+          return
+        }
+        if (text.phase === "reasoning" && id) {
+          pendingTextStarts.delete(id)
+          reasoningTextIds.add(id)
         }
         const reasoning = text.phase === "reasoning" || Boolean(id && reasoningTextIds.has(id))
         if (type === "text-end" && id) reasoningTextIds.delete(id)
         if (reasoning) return
+        if (id && pendingTextStarts.has(id)) {
+          controller.enqueue(pendingTextStarts.get(id))
+          pendingTextStarts.delete(id)
+        }
       }
       if (projection.tools === "hidden" && type?.startsWith("tool-")) return
       controller.enqueue(chunk)
@@ -282,8 +300,8 @@ async function writeEventsToUiMessageStream(
       const id = typeof text.id === "string" ? text.id : undefined
       if (type === "text-start" && id) {
         reasoningTextIds.delete(id)
-        if (text.phase === "reasoning") reasoningTextIds.add(id)
       }
+      if (text.phase === "reasoning" && id) reasoningTextIds.add(id)
       const reasoning = type.startsWith("reasoning-")
         || text.phase === "reasoning"
         || Boolean(id && reasoningTextIds.has(id))

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -195,10 +195,22 @@ function projectUiMessageStream(
   projection: AgentUIMessageStreamProjection | undefined,
 ): ReadableStream<unknown> {
   if (!projection) return stream
+  const reasoningTextIds = new Set<string>()
   return stream.pipeThrough(new TransformStream<unknown, unknown>({
     transform(chunk, controller) {
       const type = streamEventType(chunk)
-      if (projection.reasoning === "hidden" && type?.startsWith("reasoning-")) return
+      if (projection.reasoning === "hidden") {
+        if (type?.startsWith("reasoning-")) return
+        const text = chunk as { id?: unknown, phase?: unknown }
+        const id = typeof text.id === "string" ? text.id : undefined
+        if (type === "text-start" && id) {
+          reasoningTextIds.delete(id)
+          if (text.phase === "reasoning") reasoningTextIds.add(id)
+        }
+        const reasoning = text.phase === "reasoning" || Boolean(id && reasoningTextIds.has(id))
+        if (type === "text-end" && id) reasoningTextIds.delete(id)
+        if (reasoning) return
+      }
       if (projection.tools === "hidden" && type?.startsWith("tool-")) return
       controller.enqueue(chunk)
     },
@@ -216,17 +228,34 @@ function uiDataType(data: unknown): `data-${string}` {
 async function writeEventsToUiMessageStream(
   writer: AgentUIMessageStreamWriter,
   events: AsyncIterable<unknown>,
-  options: { onUsageRecord?: (usageRecord: AgentUsageRecord) => void } = {},
+  options: {
+    onUsageRecord?: (usageRecord: AgentUsageRecord) => void
+    projection?: AgentUIMessageStreamProjection
+  } = {},
 ) {
   const messageId = crypto.randomUUID()
   let textStarted = false
   let finished = false
+  const reasoningTextIds = new Set<string>()
   writer.write({ type: "start", messageId })
   for await (const event of events) {
     const usageRecord = usageRecordFromStreamChunk(event, events)
     if (usageRecord) options.onUsageRecord?.(usageRecord)
     const type = streamEventType(event)
     if (!type) continue
+    if (options.projection?.reasoning === "hidden") {
+      const text = event as { id?: unknown, phase?: unknown }
+      const id = typeof text.id === "string" ? text.id : undefined
+      if (type === "text-start" && id) {
+        reasoningTextIds.delete(id)
+        if (text.phase === "reasoning") reasoningTextIds.add(id)
+      }
+      const reasoning = type.startsWith("reasoning-")
+        || text.phase === "reasoning"
+        || Boolean(id && reasoningTextIds.has(id))
+      if (type === "text-end" && id) reasoningTextIds.delete(id)
+      if (reasoning) continue
+    }
     if (type === "text-delta") {
       const text = (event as { delta?: unknown, text?: unknown }).text ?? (event as { delta?: unknown }).delta
       if (typeof text !== "string" || !text) continue
@@ -288,6 +317,7 @@ export async function finalizeUiMessageStreamOutput(
       ? createAgentUIMessageStream({
           execute: async ({ writer }) => await writeEventsToUiMessageStream(writer, rendered, {
             onUsageRecord: usageRecord => { streamedUsageRecord = usageRecord },
+            projection,
           }),
         })
       : createAgentUIMessageStream({

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -1,7 +1,7 @@
 import { isAsyncIterable } from "./internal/stream-result.ts"
 import { usageRecordFromStreamChunk } from "./agent-output.ts"
 
-import type { AgentUsageRecord, MaybePromise } from "./types.ts"
+import type { AgentUIMessageStreamProjection, AgentUsageRecord, MaybePromise } from "./types.ts"
 
 interface FinalizedStreamOutput<T> {
   deferFinish: boolean
@@ -190,6 +190,21 @@ export function normalizeUiMessageStream(stream: ReadableStream<unknown>): Reada
   }))
 }
 
+function projectUiMessageStream(
+  stream: ReadableStream<unknown>,
+  projection: AgentUIMessageStreamProjection | undefined,
+): ReadableStream<unknown> {
+  if (!projection) return stream
+  return stream.pipeThrough(new TransformStream<unknown, unknown>({
+    transform(chunk, controller) {
+      const type = streamEventType(chunk)
+      if (projection.reasoning === "hidden" && type?.startsWith("reasoning-")) return
+      if (projection.tools === "hidden" && type?.startsWith("tool-")) return
+      controller.enqueue(chunk)
+    },
+  }))
+}
+
 function uiDataType(data: unknown): `data-${string}` {
   const rawType = typeof data === "object" && data !== null && typeof (data as { type?: unknown }).type === "string"
     ? (data as { type: string }).type
@@ -258,6 +273,7 @@ export async function finalizeUiMessageStreamOutput(
   rendered: unknown,
   shouldWrapOutput: boolean,
   finish: (outcome: StreamCleanupOutcome, streamedText?: string, streamedUsageRecord?: AgentUsageRecord) => MaybePromise<void>,
+  projection?: AgentUIMessageStreamProjection,
 ): Promise<FinalizedStreamOutput<unknown>> {
   const hasUiMessageStream = isUIMessageStreamResult(rendered)
   const hasAsyncIterable = isAsyncIterable(rendered)
@@ -266,7 +282,7 @@ export async function finalizeUiMessageStreamOutput(
     throw new Error("[vitehub] Agent stream output \"ui-message-stream\" requires a result with toUIMessageStream().")
   }
   let streamedUsageRecord: AgentUsageRecord | undefined
-  const stream = normalizeUiMessageStream(hasUiMessageStream
+  const stream = projectUiMessageStream(normalizeUiMessageStream(hasUiMessageStream
     ? rendered.toUIMessageStream()
     : hasAsyncIterable
       ? createAgentUIMessageStream({
@@ -283,7 +299,7 @@ export async function finalizeUiMessageStreamOutput(
           writer.write({ type: "text-end", id: messageId })
           writer.write({ type: "finish", finishReason: "stop" })
         },
-  }))
+  })), projection)
   let streamedText = ""
   return {
     deferFinish: shouldWrapOutput,

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -31,6 +31,40 @@ export function isUIMessageStreamResult(value: unknown): value is { toUIMessageS
     && typeof (value as { toUIMessageStream?: unknown }).toUIMessageStream === "function"
 }
 
+export function isUIMessageStreamResponse(value: unknown): value is Response & { body: ReadableStream<Uint8Array> } {
+  return value instanceof Response
+    && value.body !== null
+    && value.headers.get("x-vercel-ai-ui-message-stream") === "v1"
+}
+
+export function uiMessageStreamFromResponse(response: Response & { body: ReadableStream<Uint8Array> }): ReadableStream<unknown> {
+  const decoder = new TextDecoder()
+  let buffer = ""
+  const enqueueFrames = (controller: TransformStreamDefaultController<unknown>, flush = false) => {
+    const frames = buffer.split(/\r?\n\r?\n/)
+    buffer = flush ? "" : frames.pop() || ""
+    for (const frame of frames) {
+      const data = frame.split(/\r?\n/)
+        .filter(line => line.startsWith("data:"))
+        .map(line => line.slice(5).trimStart())
+        .join("\n")
+      if (!data || data === "[DONE]") continue
+      controller.enqueue(JSON.parse(data))
+    }
+  }
+  return response.body.pipeThrough(new TransformStream<Uint8Array, unknown>({
+    flush(controller) {
+      buffer += decoder.decode()
+      if (buffer.trim()) buffer += "\n\n"
+      enqueueFrames(controller, true)
+    },
+    transform(chunk, controller) {
+      buffer += decoder.decode(chunk, { stream: true })
+      enqueueFrames(controller)
+    },
+  }))
+}
+
 export function createAgentUIMessageStream(options: {
   execute: (context: { writer: AgentUIMessageStreamWriter }) => MaybePromise<void>
 }): ReadableStream<unknown> {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1520,6 +1520,7 @@ export interface AgentInspectionDriverMetadata {
 
 export interface AgentInspectionConfigMetadata {
   driver: AgentInspectionDriverMetadata
+  uiMessageStream?: AgentUIMessageStreamProjection
 }
 
 export interface AgentInspectionMetadata {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1058,6 +1058,19 @@ export interface AgentOutputDefinition<TOutput = unknown> {
   schema: StandardSchemaV1<unknown, TOutput>
 }
 
+export interface AgentUIMessageStreamProjection {
+  reasoning?: "hidden" | "visible"
+  tools?: "hidden" | "full"
+}
+
+export type AgentUIMessageStreamProjectionResolver<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+  TContextValues extends object = AgentInvocationContextValues,
+> =
+  | AgentUIMessageStreamProjection
+  | ((context: AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>) => MaybePromise<AgentUIMessageStreamProjection>)
+
 type AgentSharedSettings<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
@@ -1078,6 +1091,7 @@ type AgentSharedSettings<
   output?: AgentOutputDefinition<TOutput>
   runtime?: AgentRuntimeBinding
   runEvents?: AgentRunEvents
+  uiMessageStream?: AgentUIMessageStreamProjectionResolver<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   version?: string
   workspace?: WorkspaceAgentWorkspaceConfig
 }
@@ -1115,6 +1129,7 @@ export interface AgentDefinition<
   runEvents?: AgentRunEvents
   resolve(context: AgentRuntimeContext<TRuntimeConfig>): Promise<AgentAdapter<CALL_OPTIONS>>
   run?(context: AgentRunContext<TRuntimeConfig, CALL_OPTIONS, WorkspaceName, TContextValues>): MaybePromise<Response | AgentRunResult | AsyncIterable<StreamEvent> | unknown>
+  uiMessageStream?: AgentUIMessageStreamProjectionResolver<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   version?: string
   workspace?: WorkspaceAgentWorkspaceConfig
 }

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -57,6 +57,7 @@ import type {
   AgentRuntimeConfig,
   AgentRuntimeContext,
   AgentSettings,
+  AgentUIMessageStreamProjection,
   ResolvedAgentRuntimeContext,
   WorkspaceAgentWorkspaceConfig,
   WorkspaceAgentWorkspaceOptions,
@@ -711,8 +712,25 @@ async function resolvedDriverMetadata<
 function staticConfigMetadata<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
   definition: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
 ): AgentInspectionConfigMetadata | undefined {
-  const driver = staticDriverMetadata(agentSettings(definition))
-  return driver ? { driver } : undefined
+  const settings = agentSettings(definition)
+  const driver = staticDriverMetadata(settings)
+  const uiMessageStream = typeof settings?.uiMessageStream === "function"
+    ? undefined
+    : settings?.uiMessageStream
+  return driver ? { driver, ...(uiMessageStream ? { uiMessageStream } : {}) } : undefined
+}
+
+async function resolvedUiMessageStreamProjection<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  Name extends WorkspaceName,
+>(
+  definition: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+  context: AgentAdapterMetadataContext<TRuntimeConfig, Name> & AgentRunCallbackContext<TRuntimeConfig>,
+): Promise<AgentUIMessageStreamProjection | undefined> {
+  const uiMessageStream = agentSettings(definition)?.uiMessageStream
+  return typeof uiMessageStream === "function"
+    ? await uiMessageStream(context)
+    : uiMessageStream
 }
 
 async function resolvedConfigMetadata<
@@ -723,7 +741,8 @@ async function resolvedConfigMetadata<
   context: AgentAdapterMetadataContext<TRuntimeConfig, Name> & AgentRunCallbackContext<TRuntimeConfig>,
 ): Promise<AgentInspectionConfigMetadata | undefined> {
   const driver = await resolvedDriverMetadata(agentSettings(definition), context)
-  return driver ? { driver } : undefined
+  const uiMessageStream = await resolvedUiMessageStreamProjection(definition, context)
+  return driver ? { driver, ...(uiMessageStream ? { uiMessageStream } : {}) } : undefined
 }
 
 function agentInspectionMetadata<
@@ -1447,6 +1466,7 @@ async function resolveNonWorkspaceAgentInspectionMetadata<
       invoker: selection.invoker,
     } as AgentAdapterMetadataContext<TRuntimeConfig, Name> & AgentRunCallbackContext<TRuntimeConfig>
     const staticConfig = staticConfigMetadata(definition)
+    const uiMessageStream = await resolvedUiMessageStreamProjection(definition, context)
     const config = staticConfig && {
       driver: {
         ...staticConfig.driver,
@@ -1456,6 +1476,7 @@ async function resolveNonWorkspaceAgentInspectionMetadata<
           context,
         ),
       },
+      ...(uiMessageStream ? { uiMessageStream } : {}),
     }
     return {
       files: [],

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8229,8 +8229,9 @@ describe("agent message protocol", () => {
       { id: "reasoning-1", type: "reasoning-start" },
       { delta: "private reasoning", id: "reasoning-1", type: "reasoning-delta" },
       { id: "reasoning-1", type: "reasoning-end" },
-      { id: "reasoning-2", phase: "reasoning", type: "text-start" },
-      { delta: "private phased reasoning", id: "reasoning-2", type: "text-delta" },
+      { id: "reasoning-2", type: "text-start" },
+      { delta: "private phased reasoning", id: "reasoning-2", phase: "reasoning", type: "text-delta" },
+      { delta: "private phased suffix", id: "reasoning-2", type: "text-delta" },
       { id: "reasoning-2", type: "text-end" },
       { id: "text-1", type: "text-start" },
       { delta: "public answer", id: "text-1", type: "text-delta" },
@@ -8285,6 +8286,32 @@ describe("agent message protocol", () => {
       "hide-reasoning",
       "hide-tools",
     ])
+  })
+
+  it("tracks phased reasoning IDs before converting async iterable UI output", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      driver: {
+        run: async function* () {
+          yield { id: "reasoning-1", type: "text-start" }
+          yield { delta: "private", id: "reasoning-1", phase: "reasoning", type: "text-delta" }
+          yield { delta: " suffix", id: "reasoning-1", type: "text-delta" }
+          yield { id: "reasoning-1", type: "text-end" }
+          yield { delta: "public", id: "final-1", phase: "final", type: "text-delta" }
+          yield { type: "finish" }
+        },
+      },
+      uiMessageStream: { reasoning: "hidden" },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}, {
+      output: "ui-message-stream",
+    }) as ReadableStream<unknown>
+    const chunks = []
+    for await (const chunk of stream) chunks.push(chunk)
+    expect(chunks).not.toContainEqual(expect.objectContaining({ delta: expect.stringContaining("private") }))
+    expect(chunks).not.toContainEqual(expect.objectContaining({ delta: expect.stringContaining("suffix") }))
+    expect(chunks).toContainEqual(expect.objectContaining({ delta: "public" }))
   })
 
   it("projects an already-framed UI message stream Response", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8229,6 +8229,9 @@ describe("agent message protocol", () => {
       { id: "reasoning-1", type: "reasoning-start" },
       { delta: "private reasoning", id: "reasoning-1", type: "reasoning-delta" },
       { id: "reasoning-1", type: "reasoning-end" },
+      { id: "reasoning-2", phase: "reasoning", type: "text-start" },
+      { delta: "private phased reasoning", id: "reasoning-2", type: "text-delta" },
+      { id: "reasoning-2", type: "text-end" },
       { id: "text-1", type: "text-start" },
       { delta: "public answer", id: "text-1", type: "text-delta" },
       { id: "text-1", type: "text-end" },
@@ -8272,7 +8275,10 @@ describe("agent message protocol", () => {
 
     expect(omitted).toEqual(chunks)
     expect(visible).toEqual(chunks)
-    expect(hiddenReasoning).toEqual(chunks.filter(chunk => !chunk.type.startsWith("reasoning-")))
+    expect(hiddenReasoning).toEqual(chunks.filter(chunk =>
+      !chunk.type.startsWith("reasoning-")
+      && chunk.id !== "reasoning-2",
+    ))
     expect(hiddenTools).toEqual(chunks.filter(chunk => !chunk.type.startsWith("tool-")))
     expect(resolveProjection.mock.calls.map(([context]) => context.input.prompt)).toEqual([
       "visible",

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8222,6 +8222,65 @@ describe("agent message protocol", () => {
     ])
   })
 
+  it("projects reasoning and tool details per UI message stream invocation", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const chunks = [
+      { messageId: "assistant-1", type: "start" },
+      { id: "reasoning-1", type: "reasoning-start" },
+      { delta: "private reasoning", id: "reasoning-1", type: "reasoning-delta" },
+      { id: "reasoning-1", type: "reasoning-end" },
+      { id: "text-1", type: "text-start" },
+      { delta: "public answer", id: "text-1", type: "text-delta" },
+      { id: "text-1", type: "text-end" },
+      { input: { query: "users" }, toolCallId: "tool-1", toolName: "search", type: "tool-input-available" },
+      { output: "42", toolCallId: "tool-1", type: "tool-output-available" },
+      { finishReason: "stop", type: "finish" },
+    ]
+    const driver = {
+      run: () => ({
+        toUIMessageStream() {
+          return new ReadableStream<unknown>({
+            start(controller) {
+              for (const chunk of chunks) controller.enqueue(chunk)
+              controller.close()
+            },
+          })
+        },
+      }),
+    }
+    const resolveProjection = vi.fn(({ input }) => {
+      if (input.prompt === "hide-reasoning") return { reasoning: "hidden" as const, tools: "full" as const }
+      if (input.prompt === "hide-tools") return { reasoning: "visible" as const, tools: "hidden" as const }
+      return { reasoning: "visible" as const, tools: "full" as const }
+    })
+    const agent = defineAgent({
+      driver,
+      uiMessageStream: resolveProjection,
+    })
+    const defaultAgent = defineAgent({ driver })
+    const collect = async (target: typeof agent, prompt: string) => {
+      const stream = await streamAgent(target, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+      const projected = []
+      for await (const chunk of stream) projected.push(chunk)
+      return projected
+    }
+
+    const omitted = await collect(defaultAgent, "omitted")
+    const visible = await collect(agent, "visible")
+    const hiddenReasoning = await collect(agent, "hide-reasoning")
+    const hiddenTools = await collect(agent, "hide-tools")
+
+    expect(omitted).toEqual(chunks)
+    expect(visible).toEqual(chunks)
+    expect(hiddenReasoning).toEqual(chunks.filter(chunk => !chunk.type.startsWith("reasoning-")))
+    expect(hiddenTools).toEqual(chunks.filter(chunk => !chunk.type.startsWith("tool-")))
+    expect(resolveProjection.mock.calls.map(([context]) => context.input.prompt)).toEqual([
+      "visible",
+      "hide-reasoning",
+      "hide-tools",
+    ])
+  })
+
   it("normalizes valid capability CLI input errors in native UI message streams", async () => {
     const { createUIMessageStream } = await import("ai")
     const { defineAgent, streamAgent } = await import("../src/index.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8287,6 +8287,48 @@ describe("agent message protocol", () => {
     ])
   })
 
+  it("projects an already-framed UI message stream Response", async () => {
+    const { createAgentUIMessageStreamResponse } = await import("../src/stream-output.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      driver: {
+        run: () => createAgentUIMessageStreamResponse({
+          headers: { "content-length": "999", "x-agent": "custom" },
+          status: 201,
+          statusText: "Created",
+          stream: new ReadableStream({
+            start(controller) {
+              controller.enqueue({ id: "reasoning-1", type: "reasoning-start" })
+              controller.enqueue({ delta: "private", id: "reasoning-1", type: "reasoning-delta" })
+              controller.enqueue({ id: "reasoning-1", type: "reasoning-end" })
+              controller.enqueue({ id: "text-1", type: "text-start" })
+              controller.enqueue({ delta: "public", id: "text-1", type: "text-delta" })
+              controller.enqueue({ id: "text-1", type: "text-end" })
+              controller.enqueue({ finishReason: "stop", type: "finish" })
+              controller.close()
+            },
+          }),
+        }),
+      },
+      hooks: { "agent:finish": finish },
+      uiMessageStream: { reasoning: "hidden" },
+    })
+
+    const response = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}, {
+      output: "ui-message-stream",
+    }) as Response
+    expect(response.status).toBe(201)
+    expect(response.statusText).toBe("Created")
+    expect(response.headers.get("x-agent")).toBe("custom")
+    expect(response.headers.has("content-length")).toBe(false)
+    expect(finish).not.toHaveBeenCalled()
+    const body = await response.text()
+    expect(body).not.toContain("private")
+    expect(body).toContain("public")
+    expect(finish).toHaveBeenCalledOnce()
+  })
+
   it("normalizes valid capability CLI input errors in native UI message streams", async () => {
     const { createUIMessageStream } = await import("ai")
     const { defineAgent, streamAgent } = await import("../src/index.ts")

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUIMessageStreamProjection, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -27,6 +27,33 @@ declare global {
 }
 
 describe("agent public types", () => {
+  it("types static and per-invocation UI message stream projection", () => {
+    const projection = {
+      reasoning: "visible",
+      tools: "full",
+    } satisfies AgentUIMessageStreamProjection
+
+    defineAgent({
+      driver: { run: () => "ok" },
+      uiMessageStream: projection,
+    })
+    defineAgent({
+      driver: { run: () => "ok" },
+      uiMessageStream(context) {
+        expectTypeOf(context.input).toEqualTypeOf<AgentRunInput>()
+        expectTypeOf(context.context.get("chat.secret")).toEqualTypeOf<string | undefined>()
+        return context.input.prompt === "private"
+          ? { reasoning: "hidden", tools: "hidden" }
+          : projection
+      },
+    })
+    defineAgent({
+      driver: { run: () => "ok" },
+      // @ts-expect-error Reasoning projection has no full mode.
+      uiMessageStream: { reasoning: "full" },
+    })
+  })
+
   it("types the Email capability as one explicit send grant", () => {
     const policy: EmailCapabilityToolPolicy = "require-approval"
     const options = { from: "agent@example.com", policy, recipients: ["owner@example.com"] as const } satisfies EmailCapabilityOptions

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -4362,6 +4362,32 @@ describe("defineAgent workspace option", () => {
     })
   })
 
+  it("inspects static and resolved UI message stream projection", async () => {
+    const { createAgentInspectionMetadata, defineAgent, resolveAgentInspectionMetadata } = await import("../src/index.ts")
+    const staticAgent = defineAgent({
+      driver: { run: () => "ok" },
+      uiMessageStream: { reasoning: "hidden", tools: "full" },
+    })
+    const dynamicAgent = defineAgent({
+      driver: { run: () => "ok" },
+      uiMessageStream: ({ input }) => input.prompt === "private"
+        ? { reasoning: "hidden", tools: "hidden" }
+        : { reasoning: "visible", tools: "full" },
+    })
+
+    expect(createAgentInspectionMetadata(staticAgent).config?.uiMessageStream).toEqual({
+      reasoning: "hidden",
+      tools: "full",
+    })
+    expect(createAgentInspectionMetadata(dynamicAgent).config).not.toHaveProperty("uiMessageStream")
+    expect((await resolveAgentInspectionMetadata(dynamicAgent, {
+      input: { prompt: "private" },
+    })).config?.uiMessageStream).toEqual({
+      reasoning: "hidden",
+      tools: "hidden",
+    })
+  })
+
   it("reports unknown authority when a dynamic Box cannot resolve inspection input", async () => {
     const { defineAgent, resolveAgentInspectionMetadata } = await import("../src/index.ts")
     const { trustedHost } = await import("@vite-hub/box")


### PR DESCRIPTION
## Summary

- add `defineAgent({ uiMessageStream })` as a static or per-invocation projection for reasoning and tool UI chunks
- hide native and phased reasoning across generated streams and already-framed UI message stream Responses while preserving usage, metadata, and lifecycle behavior
- expose static and resolved UI message stream projection through Agent inspection metadata
- cover omitted, visible/full, hidden reasoning, hidden tools, resolver context, inspection, Response projection, and public types

## Validation

- `corepack pnpm vp run -t @vite-hub/agent#build`
- `corepack pnpm vp run -t vite-hub#build`
- `corepack pnpm --filter @vite-hub/agent typecheck`
- `corepack pnpm --filter @vite-hub/agent exec vp test run` — 59 files, 1,410 tests
- focused lint on the changed Agent files
- `git diff --check`
