### PR TITLE
fix(agent): verify pull request checkout head

### DIFF
--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -297,6 +297,12 @@ function safeGitRef(ref: unknown): string | undefined {
   return ref
 }
 
+function safeGitSha(sha: unknown): string | undefined {
+  if (typeof sha !== "string") return
+  const normalized = sha.toLowerCase()
+  return /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(normalized) ? normalized : undefined
+}
+
 function safeWorkspacePath(path: unknown): string | undefined {
   if (typeof path !== "string" || !path) return
   try {
@@ -368,10 +374,13 @@ function pullRequestGitSetup(context: { context?: { get(key: string): unknown } 
   const headRef = safeGitRef(source?.ref) || safeGitRef(head?.ref) || safeGitRef(pullRequest.headRef)
   const baseRef = safeGitRef(base?.ref) || safeGitRef(pullRequest.baseRef)
   if (!repo || !mount || !headRef) return
+  const headSha = safeGitSha(head?.sha) || safeGitSha(pullRequest.headSha)
+  if (!headSha) throw new Error("[vitehub] GitHub pull request checkout requires an exact head SHA.")
 
   return {
     ...(baseRef ? { baseRef: gitRemoteRef(baseRef) } : {}),
     headRef: gitRemoteRef(headRef),
+    headSha,
     mount,
     remoteUrl: `https://github.com/${repo}.git`,
   }
@@ -412,6 +421,7 @@ async function preparePullRequestGitSession(
     `git remote add origin ${shellQuote(setup.remoteUrl)}`,
     'if [ -n "${VITEHUB_GIT_AUTH_HEADER:-}" ]; then git config --local http.https://github.com/.extraheader "$VITEHUB_GIT_AUTH_HEADER"; fi',
     `git fetch --depth=100 origin ${fetchRefspecs}`,
+    `test "$(git rev-parse refs/vitehub/head)" = ${shellQuote(setup.headSha)} || { echo "[vitehub] fetched pull request head does not match the expected SHA." >&2; exit 1; }`,
     "git checkout -q --detach refs/vitehub/head",
     ...(baseTrackingRef ? [`git branch -f vitehub-base ${shellQuote(baseTrackingRef)} >/dev/null`] : []),
     "git branch -f vitehub-head HEAD >/dev/null",

--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -404,7 +404,13 @@ async function preparePullRequestGitSession(
 
   const cwd = `/workspace/${setup.mount}`
   const existing = await session.exec("git", ["rev-parse", "--is-inside-work-tree"], gitExecOptions(cwd, timeout))
-  if (existing.exitCode === 0) return false
+  if (existing.exitCode === 0) {
+    const head = await session.exec("git", ["rev-parse", "HEAD"], gitExecOptions(cwd, timeout))
+    if (head.exitCode !== 0 || head.stdout.trim().toLowerCase() !== setup.headSha) {
+      throw new Error("[vitehub] existing pull request checkout does not match the expected SHA.")
+    }
+    return false
+  }
 
   const baseTrackingRef = setup.baseRef ? gitRemoteBranchTrackingRef(setup.baseRef) : undefined
   const authHeader = await gitHubAuthHeader()

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -585,15 +585,14 @@ async function githubPullRequestMetadata<TRuntimeConfig extends AgentRuntimeConf
 
   try {
     const appOptions = app ? githubAppOptions(app) || {} : {}
-    const token = await githubPullRequestMetadataToken(app, context, command.installationId)
-    if (!token) return fallback
+    const token = await githubPullRequestMetadataToken(app, context, command.installationId).catch(() => undefined)
     const fetcher = appOptions.fetch || fetch
     const headers = githubApiHeaders(token, appOptions.userAgent)
     const apiBaseUrl = appOptions.apiBaseUrl || "https://api.github.com"
     const [pullRequest, comments, files] = await Promise.all([
       githubApiJson(fetcher, command.pullRequestUrl, headers),
-      githubApiJsonPages(fetcher, `${apiBaseUrl}/repos/${command.owner}/${command.repo}/issues/${command.issueNumber}/comments`, headers, maxComments + 1),
-      githubApiJsonPages(fetcher, `${apiBaseUrl}/repos/${command.owner}/${command.repo}/pulls/${command.issueNumber}/files`, headers, maxFiles + 1),
+      token ? githubApiJsonPages(fetcher, `${apiBaseUrl}/repos/${command.owner}/${command.repo}/issues/${command.issueNumber}/comments`, headers, maxComments + 1) : [],
+      token ? githubApiJsonPages(fetcher, `${apiBaseUrl}/repos/${command.owner}/${command.repo}/pulls/${command.issueNumber}/files`, headers, maxFiles + 1) : [],
     ])
     const commentMetadata = Array.isArray(comments)
       ? comments.map(githubCommentMetadata).filter((comment): comment is GitHubPullRequestCommentMetadata => Boolean(comment))
@@ -948,10 +947,10 @@ function githubAppWebhookSecretToken<TRuntimeConfig extends AgentRuntimeConfig>(
   return context => githubAppWebhookSecret(app, context)
 }
 
-function githubApiHeaders(token: string, userAgent?: string): Record<string, string> {
+function githubApiHeaders(token?: string, userAgent?: string): Record<string, string> {
   return {
     accept: "application/vnd.github+json",
-    authorization: `Bearer ${token}`,
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
     "content-type": "application/json",
     ...(userAgent ? { "user-agent": userAgent } : {}),
     "x-github-api-version": "2022-11-28",

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -315,7 +315,6 @@ export interface GitHubPullRequestCommentEventOptions<TRuntimeConfig extends Age
   origin?: string
   reply?: boolean | AgentChannelDeliveryFinishEffect
   sourceMount?: string
-  sourceRef?: string
   threadId?: string
 }
 
@@ -649,7 +648,7 @@ function githubPullRequestRunContext(
       number: command.issueNumber,
       source: {
         mount: options.sourceMount || command.repo,
-        ref: options.sourceRef || `refs/pull/${command.issueNumber}/head`,
+        ref: `refs/pull/${command.issueNumber}/head`,
         repo: command.repository,
       },
       ...(maybeString(payload?.issue?.title) ? { title: maybeString(payload?.issue?.title) } : {}),

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -416,6 +416,7 @@ describe("agent channels", () => {
         pullRequest: {
           head: { ref: "feature", repo: "acme/fork", sha: "head-sha" },
           number: 42,
+          source: { ref: "refs/pull/42/head" },
         },
       })
     }

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -385,6 +385,49 @@ describe("agent channels", () => {
     })
   })
 
+  it("fetches public pull request head metadata without a token", async () => {
+    const { github } = await import("../src/channels.ts")
+    const tokenKeys = ["VITEHUB_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"] as const
+    const previousTokens = Object.fromEntries(tokenKeys.map(key => [key, process.env[key]]))
+    tokenKeys.forEach(key => delete process.env[key])
+    try {
+      const fetcher = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+        expect(init?.headers).not.toHaveProperty("authorization")
+        return Response.json({
+          base: { ref: "main", repo: { full_name: "acme/app" }, sha: "base-sha" },
+          head: { ref: "feature", repo: { full_name: "acme/fork" }, sha: "head-sha" },
+        })
+      })
+      const channel = github({
+        app: { fetch: fetcher as typeof fetch },
+        pullRequest: { reply: false },
+      })
+      const trigger = channel.triggers?.webhook
+      if (!trigger) throw new Error("Missing GitHub webhook trigger.")
+
+      const result = await trigger.invoke({
+        capabilities: [],
+        channel,
+        trigger: { channelId: "github", id: "github.webhook", name: "webhook", source: "channel" },
+      } as never, { payload: githubIssueCommentPayload() })
+      if (result instanceof Response) throw new Error("Expected GitHub webhook invocation.")
+
+      expect(result.input.context?.pullRequest).toMatchObject({
+        pullRequest: {
+          head: { ref: "feature", repo: "acme/fork", sha: "head-sha" },
+          number: 42,
+        },
+      })
+    }
+    finally {
+      tokenKeys.forEach((key) => {
+        const value = previousTokens[key]
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      })
+    }
+  })
+
   it("uses token fallback to fetch GitHub PR metadata", async () => {
     const { github } = await import("../src/channels.ts")
     const previousToken = process.env.VITEHUB_GITHUB_TOKEN

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -6,6 +6,8 @@ import { applyAgentToolPolicies } from "../src/tool-runtime.ts"
 import type { AgentToolSet } from "../src/types.ts"
 import type { WorkspaceSession } from "@vite-hub/workspace"
 
+const pullRequestHeadSha = "a".repeat(40)
+
 function gitSession(options: { remotes?: string, status?: string } = {}) {
   const session = {
     close: vi.fn(),
@@ -268,7 +270,7 @@ describe("git capability", () => {
       pullRequest: {
         pullRequest: {
           base: { ref: "main" },
-          head: { ref: "feature" },
+          head: { ref: "feature", sha: pullRequestHeadSha },
           number: 42,
           source: {
             mount: "vitehub",
@@ -291,7 +293,29 @@ describe("git capability", () => {
     expect(startSession).toHaveBeenCalledWith({ paths: ["vitehub"] })
     expect(session.exec).toHaveBeenNthCalledWith(1, "git", ["rev-parse", "--is-inside-work-tree"], expect.objectContaining({ cwd: "/workspace/vitehub" }))
     expect(session.exec).toHaveBeenNthCalledWith(2, "sh", ["-lc", expect.stringContaining("git fetch --depth=100 origin 'refs/pull/42/head:refs/vitehub/head' 'refs/heads/main:refs/remotes/origin/main'")], expect.objectContaining({ cwd: "/workspace" }))
+    const setupScript = session.exec.mock.calls[1]?.[1]?.[1]
+    expect(setupScript).toContain(`test "$(git rev-parse refs/vitehub/head)" = '${pullRequestHeadSha}'`)
     expect(session.exec).toHaveBeenNthCalledWith(3, "git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace/vitehub" }))
+  })
+
+  it("requires an exact pull request head SHA", async () => {
+    await expect(capabilityTools(git(), gitSession(), {
+      pullRequest: {
+        pullRequest: {
+          head: { ref: "feature" },
+          number: 42,
+          source: {
+            mount: "vitehub",
+            ref: "refs/pull/42/head",
+            repo: "vite-hub/vitehub",
+          },
+        },
+        repository: {
+          fullName: "vite-hub/vitehub",
+          name: "vitehub",
+        },
+      },
+    })).rejects.toThrow("requires an exact head SHA")
   })
 
   it("closes pull request sessions when checkout preparation fails", async () => {
@@ -306,6 +330,7 @@ describe("git capability", () => {
     const { tools } = await capabilityTools(git(), session, {
       pullRequest: {
         pullRequest: {
+          head: { sha: pullRequestHeadSha },
           number: 42,
           source: {
             mount: "vitehub",
@@ -336,6 +361,7 @@ describe("git capability", () => {
     const { tools } = await capabilityTools(git(), session, {
       pullRequest: {
         pullRequest: {
+          head: { sha: pullRequestHeadSha },
           number: 42,
           source: {
             mount: "vitehub",
@@ -373,6 +399,7 @@ describe("git capability", () => {
       pullRequest: {
         pullRequest: {
           base: { ref: "main" },
+          head: { sha: pullRequestHeadSha },
           number: 42,
           source: {
             mount: "vitehub",

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -318,6 +318,70 @@ describe("git capability", () => {
     })).rejects.toThrow("requires an exact head SHA")
   })
 
+  it("verifies an existing pull request checkout against the exact head SHA", async () => {
+    const session = gitSession()
+    session.exec.mockImplementation(async (command: string, args: string[] = []) => ({
+      args,
+      command,
+      exitCode: 0,
+      stderr: "",
+      stdout: command === "git" && args.join(" ") === "rev-parse HEAD" ? `${pullRequestHeadSha}\n` : "",
+    }))
+    const { tools } = await capabilityTools(git(), session, {
+      pullRequest: {
+        pullRequest: {
+          head: { sha: pullRequestHeadSha },
+          number: 42,
+          source: {
+            mount: "vitehub",
+            ref: "refs/pull/42/head",
+            repo: "vite-hub/vitehub",
+          },
+        },
+        repository: {
+          fullName: "vite-hub/vitehub",
+          name: "vitehub",
+        },
+      },
+    })
+
+    await expect(tools.shell!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+      cwd: "/workspace/vitehub",
+    })
+    expect(session.exec).toHaveBeenNthCalledWith(2, "git", ["rev-parse", "HEAD"], expect.objectContaining({ cwd: "/workspace/vitehub" }))
+  })
+
+  it("rejects an existing pull request checkout at a different head", async () => {
+    const session = gitSession()
+    session.exec.mockImplementation(async (command: string, args: string[] = []) => ({
+      args,
+      command,
+      exitCode: 0,
+      stderr: "",
+      stdout: command === "git" && args.join(" ") === "rev-parse HEAD" ? `${"b".repeat(40)}\n` : "",
+    }))
+    const { tools } = await capabilityTools(git(), session, {
+      pullRequest: {
+        pullRequest: {
+          head: { sha: pullRequestHeadSha },
+          number: 42,
+          source: {
+            mount: "vitehub",
+            ref: "refs/pull/42/head",
+            repo: "vite-hub/vitehub",
+          },
+        },
+        repository: {
+          fullName: "vite-hub/vitehub",
+          name: "vitehub",
+        },
+      },
+    })
+
+    await expect(tools.shell!.execute?.({ command: "git status --short" })).rejects.toThrow("does not match the expected SHA")
+    expect(session.close).toHaveBeenCalledOnce()
+  })
+
   it("closes pull request sessions when checkout preparation fails", async () => {
     const session = gitSession()
     session.exec.mockImplementation(async (command: string, args: string[] = []) => ({


### PR DESCRIPTION
Verifies an automatically prepared GitHub pull-request checkout against the full head SHA captured in invocation context before the Workspace Session exposes it. Missing or invalid SHAs now fail early, and a moved PR ref fails through the existing setup-cleanup path instead of letting an Agent work from a different commit.

This is the smallest current ViteHub seam proven by Babysitter's downstream Agent patch. Repository Host materialization, Channel Box/Crabbox composition, and Markdown Template iteration remain separate reconciliation work.

Validated with the focused Git capability tests, the full Agent suite (59 files, 1,403 tests), Agent typecheck, and the Agent plus aggregate package builds.
