### PR TITLE
feat(agent): add progress summary capability

### DIFF
--- a/docs/content/docs/capabilities/official-capabilities.md
+++ b/docs/content/docs/capabilities/official-capabilities.md
@@ -30,6 +30,7 @@ import {
   memory,
   openapi,
   papercuts,
+  progressSummary,
   rateLimit,
   repositoryHost,
   repositoryHostContext,
@@ -96,6 +97,7 @@ import {
 | Rate limit | [`rateLimit()`](/docs/capabilities/rate-limit) | A trusted invocation budget should be consumed before the Agent runs. |
 | Title | [`title()`](/docs/capabilities/title) | Agent output, finish extensions, or compatible Channel threads should include a generated title. |
 | Chat summary | [`chatSummary()`](/docs/capabilities/chat-summary) | A summary command should replace explicit input with a conversation summary. |
+| Progress summary | [`progressSummary()`](/docs/capabilities/progress-summary) | A streaming Agent should explain its current reasoning and tool activity in one user-facing sentence. |
 | Papercut reports | [`papercuts()`](/docs/capabilities/papercuts) | An Agent should report small runtime or developer-experience friction to an application-owned sink. |
 
 ## Read capability pages first

--- a/docs/content/docs/capabilities/progress-summary.md
+++ b/docs/content/docs/capabilities/progress-summary.md
@@ -16,16 +16,16 @@ Import the Capability from `@vite-hub/agent/capabilities` and give it the indepe
 ```ts [server/agents/support.ts]
 import { defineAgent } from '@vite-hub/agent'
 import { progressSummary } from '@vite-hub/agent/capabilities'
-import { codexDriver } from '@vite-hub/agent/harness/codex'
 
 export default defineAgent({
   driver: primaryDriver,
   capabilities: [
     progressSummary({
-      driver: codexDriver({
+      driver: {
+        kind: 'codex',
         model: 'gpt-5.6-luna',
         reasoningEffort: 'low',
-      }),
+      },
     }),
   ],
 })

--- a/docs/content/docs/capabilities/progress-summary.md
+++ b/docs/content/docs/capabilities/progress-summary.md
@@ -1,0 +1,102 @@
+---
+title: Progress summary
+description: Stream a short user-facing summary of current Agent activity.
+navigation.title: Progress summary
+navigation.order: 210
+navigation.group: Decisions and output
+icon: i-lucide-message-circle-more
+---
+
+`progressSummary()` observes reasoning and tool lifecycle events while an Agent works, then emits a replaceable one-sentence status as transient `data-progress-summary` stream data.
+
+## Add progress summaries
+
+Import the Capability from `@vite-hub/agent/capabilities` and give it the independent Agent Driver that should write progress:
+
+```ts [server/agents/support.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { progressSummary } from '@vite-hub/agent/capabilities'
+import { codexDriver } from '@vite-hub/agent/harness/codex'
+
+export default defineAgent({
+  driver: primaryDriver,
+  capabilities: [
+    progressSummary({
+      driver: codexDriver({
+        model: 'gpt-5.6-luna',
+        reasoningEffort: 'low',
+      }),
+    }),
+  ],
+})
+```
+
+The Capability owns the summarizer instructions. The configured Driver selects the model and execution environment using the same contract as an Agent Definition or `title()`.
+
+## Render the current summary
+
+Listen for `data-progress-summary` parts and replace the currently displayed sentence when `revision` increases:
+
+```ts
+{
+  type: 'data-progress-summary',
+  data: {
+    type: 'progress-summary',
+    summary: 'Checking current SKU costs against the planning data.',
+    revision: 1,
+  },
+}
+```
+
+The part is transient, so it does not become conversation history. Keep structured reasoning and tool logs separate when your interface exposes them.
+
+## Understand the runtime behavior
+
+Reasoning deltas and tool start or completion events mark the current activity dirty. While new activity exists, the Capability generates at most one summary per interval and never overlaps generations. Tool input and output are excluded from the generated prompt.
+
+The default prompt preserves useful product concepts and names while translating internal tool identifiers into their purpose. It omits code, commands, paths, traces, hidden instructions, credentials, and raw tool details. Trusted `<context>` payloads embedded in user messages are also excluded.
+
+The Capability stops pending timers when the parent invocation aborts. A generation failure does not interrupt the primary response stream.
+
+## Requirements
+
+The primary Agent Driver must emit reasoning or tool lifecycle events through a compatible async stream or UI message stream. The Capability remains silent when the stream has no new activity to summarize.
+
+Configure a `driver`, `model`, or `execute` option for summary generation. Without one of those options, the Capability uses the Agent model when available.
+
+## Driver support
+
+| Agent Driver | Support |
+| --- | --- |
+| Model-backed | Uses an explicit summary model or the Agent model. |
+| Harness-backed | Uses an independent Harness Driver, including its model and reasoning settings. |
+| Custom-run-backed | Uses an independent custom Driver or the `execute` callback. |
+
+## Verify the result
+
+Run an invocation that performs at least one tool call or emits reasoning for longer than `intervalMs`. Confirm that the primary stream continues immediately and that a transient `data-progress-summary` part arrives with a higher `revision`.
+
+Stop the invocation before the next interval and confirm that no later progress part appears.
+
+## Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `driver` | `AgentDriver` | none | Independent Agent Driver used for progress generation. |
+| `execute` | `(input) => string \| { summary?: string }` | none | Custom progress generator. |
+| `id` | `string` | `"progress-summary"` | Capability id. |
+| `instructions` | `string` | Capability-owned instructions | System instructions for model-backed generation. |
+| `intervalMs` | `number` | `10000` | Minimum delay between dirty progress snapshots. |
+| `maxLength` | `number` | `180` | Maximum summary length. |
+| `model` | `AgentModelResolver` | Agent model | Model used when no independent Driver is configured. |
+| `template` | `string \| function` | generated | Markdown prompt template. |
+| `variables` | `Record<string, value \| function>` | none | Extra Markdown template variables. |
+
+String templates use `@vite-hub/markdown-template` and receive `userText`, `reasoning`, `activeTools`, `completedTools`, and `previous`.
+
+## Reference
+
+- [title()](/docs/capabilities/title)
+- [Agent Drivers](/docs/agents/agent-drivers)
+- [Markdown pages](/docs/ai-resources/markdown-pages)
+- Source: `packages/agent/src/capabilities/progress-summary.ts`

--- a/docs/content/docs/capabilities/progress-summary.md
+++ b/docs/content/docs/capabilities/progress-summary.md
@@ -52,11 +52,11 @@ The part is transient, so it does not become conversation history. Keep structur
 
 ## Understand the runtime behavior
 
-Reasoning deltas and tool start or completion events mark the current activity dirty. While new activity exists, the Capability generates at most one summary per interval and never overlaps generations. Tool input and output are excluded from the generated prompt.
+Reasoning deltas and tool start or completion events mark the current activity dirty. While new activity exists, the Capability generates at most one summary per interval and never overlaps generations. Raw reasoning, tool input, and tool output are excluded from the generated prompt; reasoning is represented only as an `Active` presence signal.
 
 The default prompt preserves useful product concepts and names while translating internal tool identifiers into their purpose. It omits code, commands, paths, traces, hidden instructions, credentials, and raw tool details. Trusted `<context>` payloads embedded in user messages are also excluded.
 
-The Capability stops pending timers when the parent invocation aborts. A generation failure does not interrupt the primary response stream.
+The Capability stops pending timers when the parent invocation aborts. It also discards pending or in-flight summaries when the primary stream finishes, so progress never delays completion or arrives after terminal output. A generation failure does not interrupt the primary response stream.
 
 ## Requirements
 
@@ -92,7 +92,7 @@ Stop the invocation before the next interval and confirm that no later progress 
 | `template` | `string \| function` | generated | Markdown prompt template. |
 | `variables` | `Record<string, value \| function>` | none | Extra Markdown template variables. |
 
-String templates use `@vite-hub/markdown-template` and receive `userText`, `reasoning`, `activeTools`, `completedTools`, and `previous`.
+String templates use `@vite-hub/markdown-template` and receive `userText`, the `reasoning` presence signal, `activeTools`, `completedTools`, and `previous`.
 
 ## Reference
 

--- a/docs/content/docs/capabilities/progress-summary.md
+++ b/docs/content/docs/capabilities/progress-summary.md
@@ -54,7 +54,7 @@ The part is transient, so it does not become conversation history. Keep structur
 
 Reasoning deltas and tool start or completion events mark the current activity dirty. While new activity exists, the Capability generates at most one summary per interval and never overlaps generations. Raw reasoning, tool input, and tool output are excluded from the generated prompt; reasoning is represented only as an `Active` presence signal.
 
-The default prompt preserves useful product concepts and names while translating internal tool identifiers into their purpose. It omits code, commands, paths, traces, hidden instructions, credentials, and raw tool details. Trusted `<context>` payloads embedded in user messages are also excluded.
+The default prompt uses only reasoning presence, sanitized tool names, and the previous summary. It does not include user message text, code, commands, paths, traces, hidden instructions, credentials, raw tool details, or trusted `<context>` payloads.
 
 The Capability stops pending timers when the parent invocation aborts. It also discards pending or in-flight summaries when the primary stream finishes, so progress never delays completion or arrives after terminal output. A generation failure does not interrupt the primary response stream.
 
@@ -92,7 +92,7 @@ Stop the invocation before the next interval and confirm that no later progress 
 | `template` | `string \| function` | generated | Markdown prompt template. |
 | `variables` | `Record<string, value \| function>` | none | Extra Markdown template variables. |
 
-String templates use `@vite-hub/markdown-template` and receive `userText`, the `reasoning` presence signal, `activeTools`, `completedTools`, and `previous`.
+String templates use `@vite-hub/markdown-template` and receive `userText`, the `reasoning` presence signal, `activeTools`, `completedTools`, and `previous`. Referencing `userText` opts a custom template into handling user message text; keep sensitive content out of prompts you construct.
 
 ## Reference
 

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -43,6 +43,9 @@ export {
   papercuts,
 } from "./papercuts.ts"
 export {
+  progressSummary,
+} from "./progress-summary.ts"
+export {
   repositoryHost,
 } from "./repository-host.ts"
 export {
@@ -211,6 +214,15 @@ export type {
   RateLimitLimiterResolver,
   RateLimitOptions,
 } from "./rate-limit.ts"
+export type {
+  ProgressSummaryExecuteInput,
+  ProgressSummaryExecuteResult,
+  ProgressSummaryOptions,
+  ProgressSummarySnapshot,
+  ProgressSummaryTemplate,
+  ProgressSummaryTemplateInput,
+  ProgressSummaryTemplateVariable,
+} from "./progress-summary.ts"
 export type {
   OpenAPICapabilityOptions,
   OpenAPICliOptions,

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -479,7 +479,7 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
     output(context) {
       context.output.render((result) => {
         const messages = context.input.messages()
-        if (!messages.some(message => message.role === "user")) return result
+        if (!messages.some(message => message.role === "user") && !context.input.get().prompt) return result
         if (isStreamResult(result)) {
           const wrapped = new WeakMap<object, AsyncIterable<unknown> & ReadableStream<unknown>>()
           const wrap = (stream: AsyncIterable<unknown> | ReadableStream<unknown>) => {

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -5,6 +5,7 @@ import { normalizeAgentDriver } from "../internal/agent-driver.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 import { isAsyncIterable, toReadableAsyncIterableStream } from "../internal/stream-result.ts"
 import { getMessageText } from "../messages.ts"
+import { normalizeUiMessageStreamChunk } from "../stream-output.ts"
 
 import type {
   AgentAdapterRunContext,
@@ -409,23 +410,24 @@ function withProgressSummaryStream(
   }
 
   const observe = (chunk: unknown) => {
-    const type = eventType(chunk)
-    const phasedReasoning = isRecord(chunk)
-      && chunk.phase === "reasoning"
+    const event = normalizeUiMessageStreamChunk(chunk)
+    const type = eventType(event)
+    const phasedReasoning = isRecord(event)
+      && event.phase === "reasoning"
       && (type === "text-start" || type === "text-delta")
     if (type === "reasoning-delta" || type === "reasoning-summary-text-delta" || phasedReasoning) {
       reasoningActive = true
       dirty = true
     }
     else if (type === "tool-input-start" || type === "tool-call" || type === "tool-input-available") {
-      const id = eventToolId(chunk)
-      const name = eventToolName(chunk)
+      const id = eventToolId(event)
+      const name = eventToolName(event)
       if (id && name) activeTools.set(id, name)
       dirty = true
     }
     else if (type === "tool-result" || type === "tool-output-available" || type === "tool-error" || type === "tool-output-error") {
-      const id = eventToolId(chunk)
-      const name = eventToolName(chunk) || activeTools.get(id)
+      const id = eventToolId(event)
+      const name = eventToolName(event) || activeTools.get(id)
       if (id) activeTools.delete(id)
       if (name) completedTools.push(name)
       dirty = true

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -223,8 +223,11 @@ async function generateWithDriver(
   const instructions = options.instructions ?? defaultProgressSummaryInstructions
   const runContext = progressSummaryAdapterRunContext(context, input, prompt)
   if (driver.kind === "harness") {
+    const resolvedDriver = driver.resolve
+      ? { ...driver, ...await driver.resolve(), kind: "harness" as const }
+      : driver
     const { createHarnessAgentAdapter } = await import("../harness-agent.ts")
-    return await resultText(await createHarnessAgentAdapter({ ...driver, instructions } as never).generate(runContext as never))
+    return await resultText(await createHarnessAgentAdapter({ ...resolvedDriver, instructions } as never).generate(runContext as never))
   }
   const { createAiSdkAdapter } = await import("../ai-sdk.ts")
   return await resultText(await createAiSdkAdapter({

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -1,4 +1,5 @@
 import { renderMarkdownTemplate } from "@vite-hub/markdown-template"
+import { createUIMessageStreamResponse } from "ai"
 import { streamAgentOutputToEvents, toAgentRunResult } from "../agent-output.ts"
 import { defineCapability } from "../capability-runtime.ts"
 import { normalizeAgentDriver } from "../internal/agent-driver.ts"
@@ -21,6 +22,7 @@ import type {
 import type { Message } from "../messages.ts"
 
 type ToUIMessageStream = (...args: unknown[]) => ReadableStream<unknown>
+type ToUIMessageStreamResponse = (...args: unknown[]) => Response
 
 export interface ProgressSummarySnapshot {
   activeTools: string[]
@@ -483,6 +485,7 @@ function isStreamResult(value: unknown): value is {
   fullStream?: AsyncIterable<unknown> | ReadableStream<unknown>
   stream?: AsyncIterable<unknown> | ReadableStream<unknown>
   toUIMessageStream?: ToUIMessageStream
+  toUIMessageStreamResponse?: ToUIMessageStreamResponse
 } {
   return isRecord(value)
     && (
@@ -511,6 +514,7 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
             return value
           }
           const toUIMessageStream = result.toUIMessageStream?.bind(result)
+          const toUIMessageStreamResponse = result.toUIMessageStreamResponse && toUIMessageStream
           return cloneResult(result, {
             ...progressSummaryStreamOverrides(result, wrap),
             ...(toUIMessageStream
@@ -518,6 +522,17 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
                   toUIMessageStream: {
                     value: (...args: unknown[]) =>
                       wrap(toUIMessageStream(...args)),
+                    writable: true,
+                  },
+                }
+              : {}),
+            ...(toUIMessageStreamResponse
+              ? {
+                  toUIMessageStreamResponse: {
+                    value: (...args: unknown[]) => createUIMessageStreamResponse({
+                      ...(isRecord(args[0]) ? args[0] : {}),
+                      stream: wrap(toUIMessageStream(...args)) as ReadableStream<never>,
+                    }),
                     writable: true,
                   },
                 }

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -340,6 +340,7 @@ function withProgressSummaryStream(
     : stream
   const activeTools = new Map<string, string>()
   const completedTools: string[] = []
+  const activeReasoning = new Set<string>()
   const startedAt = Date.now()
   const intervalMs = Math.max(0, options.intervalMs ?? 10_000)
   let reasoningActive = false
@@ -420,8 +421,19 @@ function withProgressSummaryStream(
       && event.phase === "reasoning"
       && (type === "text-start" || type === "text-delta")
     if (type === "reasoning-delta" || type === "reasoning-summary-text-delta" || phasedReasoning) {
+      const id = eventToolId(event)
+      if (id) activeReasoning.add(id)
       reasoningActive = true
       dirty = true
+    }
+    else if (type === "reasoning-end" || type === "reasoning-summary-text-end") {
+      const id = eventToolId(event)
+      if (id) activeReasoning.delete(id)
+      reasoningActive = activeReasoning.size > 0
+    }
+    else if (type === "text-end") {
+      const id = eventToolId(event)
+      if (id && activeReasoning.delete(id)) reasoningActive = activeReasoning.size > 0
     }
     else if (type === "tool-input-start" || type === "tool-call" || type === "tool-input-available") {
       const id = eventToolId(event)

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -74,9 +74,6 @@ const defaultProgressSummaryInstructions = [
 ].join("\n")
 
 const defaultProgressSummaryTemplate = [
-  "# User request",
-  "{{ userText }}",
-  "",
   "# Current activity",
   "Reasoning: {{ reasoning }}",
   "Active tools: {{ activeTools }}",

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -92,12 +92,6 @@ function eventType(value: unknown): string {
   return isRecord(value) ? String(value.type || "") : ""
 }
 
-function eventText(value: unknown): string {
-  if (!isRecord(value)) return ""
-  const text = value.text ?? value.textDelta ?? value.delta
-  return typeof text === "string" ? text : ""
-}
-
 function eventToolName(value: unknown): string {
   if (!isRecord(value)) return ""
   const name = value.toolName ?? value.name
@@ -113,7 +107,7 @@ function eventToolId(value: unknown): string {
 }
 
 function firstUserText(messages: Message[]): string {
-  const message = messages.find(message => message.role === "user")
+  const message = messages.findLast(message => message.role === "user")
   return message
     ? getMessageText(message)
         .replace(/<context>[\s\S]*?<\/context>/gi, "")
@@ -283,18 +277,43 @@ async function generateProgressSummary(
   return cleanSummary(result.text, maxLength)
 }
 
-function cloneResult<T extends object>(result: T, overrides: Record<string, unknown>): T {
+function cloneResult<T extends object>(result: T, overrides: Record<string, PropertyDescriptor>): T {
   const clone = Object.create(Object.getPrototypeOf(result))
-  Object.defineProperties(clone, Object.getOwnPropertyDescriptors(result))
-  for (const [key, value] of Object.entries(overrides)) {
+  const descriptors = Object.getOwnPropertyDescriptors(result)
+  for (const key of Object.keys(overrides)) delete descriptors[key]
+  Object.defineProperties(clone, descriptors)
+  for (const [key, descriptor] of Object.entries(overrides)) {
     Object.defineProperty(clone, key, {
       configurable: true,
       enumerable: true,
-      value,
-      writable: true,
+      ...descriptor,
     })
   }
   return clone
+}
+
+function isProgressSummaryStream(value: unknown): value is AsyncIterable<unknown> | ReadableStream<unknown> {
+  return isAsyncIterable(value) || value instanceof ReadableStream
+}
+
+function progressSummaryStreamOverrides(
+  result: {
+    fullStream?: AsyncIterable<unknown> | ReadableStream<unknown>
+    stream?: AsyncIterable<unknown> | ReadableStream<unknown>
+  },
+  wrap: (stream: AsyncIterable<unknown> | ReadableStream<unknown>) => AsyncIterable<unknown> & ReadableStream<unknown>,
+): Record<string, PropertyDescriptor> {
+  const descriptor = (key: "fullStream" | "stream"): PropertyDescriptor => ({
+    get() {
+      const stream = result[key]
+      if (!isProgressSummaryStream(stream)) return stream
+      return wrap(stream)
+    },
+  })
+  return {
+    ...("stream" in result ? { stream: descriptor("stream") } : {}),
+    ...("fullStream" in result ? { fullStream: descriptor("fullStream") } : {}),
+  }
 }
 
 function progressData(summary: string, revision: number) {
@@ -322,38 +341,54 @@ function withProgressSummaryStream(
   const completedTools: string[] = []
   const startedAt = Date.now()
   const intervalMs = Math.max(0, options.intervalMs ?? 10_000)
-  let reasoning = ""
+  let reasoningActive = false
   let previous: string | undefined
   let revision = 0
   let dirty = false
   let running = false
   let closed = false
+  let scheduled = false
   let timer: ReturnType<typeof setTimeout> | undefined
   let controller: TransformStreamDefaultController<unknown> | undefined
+  let generationAbortController: AbortController | undefined
   const abortSignal = context.abortSignal ?? context.input.get().abortSignal
   const close = () => {
+    // Progress is transient: never hold the primary stream open or emit stale
+    // activity after its terminal event while independent generation finishes.
     closed = true
     if (timer) clearTimeout(timer)
+    generationAbortController?.abort()
+    scheduled = false
     abortSignal?.removeEventListener("abort", close)
   }
   abortSignal?.addEventListener("abort", close, { once: true })
 
   const schedule = () => {
-    if (closed || running || timer || !dirty) return
-    timer = setTimeout(() => {
+    if (closed || running || scheduled || !dirty) return
+    scheduled = true
+    const run = () => {
+      scheduled = false
       timer = undefined
       if (closed || running || !dirty) return
       dirty = false
       running = true
       const currentRevision = ++revision
+      const inputValue = context.input.get()
+      const generationAbort = new AbortController()
+      generationAbortController = generationAbort
       const input: ProgressSummaryExecuteInput = {
         activeTools: [...activeTools.values()],
         completedTools: completedTools.slice(-5),
         elapsedMs: Date.now() - startedAt,
-        input: context.input.get(),
+        input: {
+          ...inputValue,
+          abortSignal: inputValue.abortSignal
+            ? AbortSignal.any([inputValue.abortSignal, generationAbort.signal])
+            : generationAbort.signal,
+        },
         messages,
         previous,
-        reasoning: reasoning.slice(-4_000).trim() || undefined,
+        reasoning: reasoningActive ? "Active" : undefined,
         userText: firstUserText(messages),
       }
       void generateProgressSummary(context, options, input)
@@ -364,16 +399,22 @@ function withProgressSummaryStream(
         })
         .catch(() => undefined)
         .finally(() => {
+          if (generationAbortController === generationAbort) generationAbortController = undefined
           running = false
           schedule()
         })
-    }, intervalMs)
+    }
+    if (intervalMs === 0) queueMicrotask(run)
+    else timer = setTimeout(run, intervalMs)
   }
 
   const observe = (chunk: unknown) => {
     const type = eventType(chunk)
-    if (type === "reasoning-delta" || type === "reasoning-summary-text-delta") {
-      reasoning += eventText(chunk)
+    const phasedReasoning = isRecord(chunk)
+      && chunk.phase === "reasoning"
+      && (type === "text-start" || type === "text-delta")
+    if (type === "reasoning-delta" || type === "reasoning-summary-text-delta" || phasedReasoning) {
+      reasoningActive = true
       dirty = true
     }
     else if (type === "tool-input-start" || type === "tool-call" || type === "tool-input-available") {
@@ -400,7 +441,24 @@ function withProgressSummaryStream(
       observe(chunk)
     },
   }))
-  return toReadableAsyncIterableStream(transformed)
+  const reader = transformed.getReader()
+  return toReadableAsyncIterableStream(new ReadableStream({
+    async cancel(reason) {
+      close()
+      await reader.cancel(reason)
+    },
+    async pull(outputController) {
+      try {
+        const { done, value } = await reader.read()
+        if (done) outputController.close()
+        else outputController.enqueue(value)
+      }
+      catch (error) {
+        close()
+        outputController.error(error)
+      }
+    },
+  }))
 }
 
 function isStreamResult(value: unknown): value is {
@@ -410,10 +468,8 @@ function isStreamResult(value: unknown): value is {
 } {
   return isRecord(value)
     && (
-      isAsyncIterable(value.fullStream)
-      || value.fullStream instanceof ReadableStream
-      || isAsyncIterable(value.stream)
-      || value.stream instanceof ReadableStream
+      "fullStream" in value
+      || "stream" in value
       || typeof value.toUIMessageStream === "function"
     )
 }
@@ -428,16 +484,24 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
         const messages = context.input.messages()
         if (!messages.some(message => message.role === "user")) return result
         if (isStreamResult(result)) {
-          const stream = result.stream
-          const fullStream = result.fullStream
+          const wrapped = new WeakMap<object, AsyncIterable<unknown> & ReadableStream<unknown>>()
+          const wrap = (stream: AsyncIterable<unknown> | ReadableStream<unknown>) => {
+            const existing = wrapped.get(stream)
+            if (existing) return existing
+            const value = withProgressSummaryStream(stream, context, options, messages)
+            wrapped.set(stream, value)
+            return value
+          }
           const toUIMessageStream = result.toUIMessageStream?.bind(result)
           return cloneResult(result, {
-            ...(stream ? { stream: withProgressSummaryStream(stream, context, options, messages) } : {}),
-            ...(fullStream ? { fullStream: withProgressSummaryStream(fullStream, context, options, messages) } : {}),
+            ...progressSummaryStreamOverrides(result, wrap),
             ...(toUIMessageStream
               ? {
-                  toUIMessageStream: (...args: unknown[]) =>
-                    withProgressSummaryStream(toUIMessageStream(...args), context, options, messages),
+                  toUIMessageStream: {
+                    value: (...args: unknown[]) =>
+                      wrap(toUIMessageStream(...args)),
+                    writable: true,
+                  },
                 }
               : {}),
           })

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -2,7 +2,7 @@ import { renderMarkdownTemplate } from "@vite-hub/markdown-template"
 import { streamAgentOutputToEvents, toAgentRunResult } from "../agent-output.ts"
 import { defineCapability } from "../capability-runtime.ts"
 import { toAgentUiMessageStreamResponse } from "../http-response.ts"
-import { normalizeAgentDriver } from "../internal/agent-driver.ts"
+import { normalizeAgentDriver, resolveNormalizedHarnessDriver } from "../internal/agent-driver.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 import { isAsyncIterable, toReadableAsyncIterableStream } from "../internal/stream-result.ts"
 import { getMessageText } from "../messages.ts"
@@ -223,9 +223,7 @@ async function generateWithDriver(
   const instructions = options.instructions ?? defaultProgressSummaryInstructions
   const runContext = progressSummaryAdapterRunContext(context, input, prompt)
   if (driver.kind === "harness") {
-    const resolvedDriver = driver.resolve
-      ? { ...driver, ...await driver.resolve(), kind: "harness" as const }
-      : driver
+    const resolvedDriver = await resolveNormalizedHarnessDriver(driver)
     const { createHarnessAgentAdapter } = await import("../harness-agent.ts")
     return await resultText(await createHarnessAgentAdapter({ ...resolvedDriver, instructions } as never).generate(runContext as never))
   }

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -1,7 +1,7 @@
 import { renderMarkdownTemplate } from "@vite-hub/markdown-template"
-import { createUIMessageStreamResponse } from "ai"
 import { streamAgentOutputToEvents, toAgentRunResult } from "../agent-output.ts"
 import { defineCapability } from "../capability-runtime.ts"
+import { toAgentUiMessageStreamResponse } from "../http-response.ts"
 import { normalizeAgentDriver } from "../internal/agent-driver.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 import { isAsyncIterable, toReadableAsyncIterableStream } from "../internal/stream-result.ts"
@@ -529,7 +529,7 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
             ...(toUIMessageStreamResponse
               ? {
                   toUIMessageStreamResponse: {
-                    value: (...args: unknown[]) => createUIMessageStreamResponse({
+                    value: (...args: unknown[]) => toAgentUiMessageStreamResponse({
                       ...(isRecord(args[0]) ? args[0] : {}),
                       stream: wrap(toUIMessageStream(...args)) as ReadableStream<never>,
                     }),

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -412,6 +412,10 @@ function withProgressSummaryStream(
   const observe = (chunk: unknown) => {
     const event = normalizeUiMessageStreamChunk(chunk)
     const type = eventType(event)
+    if (type === "finish") {
+      close()
+      return
+    }
     const phasedReasoning = isRecord(event)
       && event.phase === "reasoning"
       && (type === "text-start" || type === "text-delta")

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -103,13 +103,16 @@ function eventToolId(value: unknown): string {
   return typeof id === "string" ? id : ""
 }
 
-function firstUserText(messages: Message[]): string {
+function firstUserText(messages: Message[], input: AgentRunInput): string {
   const message = messages.findLast(message => message.role === "user")
-  return message
+  const text = message
     ? getMessageText(message)
-        .replace(/<context>[\s\S]*?<\/context>/gi, "")
-        .trim()
-    : ""
+    : typeof input.prompt === "string"
+      ? input.prompt
+      : ""
+  return text
+    .replace(/<context>[\s\S]*?<\/context>/gi, "")
+    .trim()
 }
 
 function cleanSummary(value: unknown, maxLength: number): string | undefined {
@@ -386,7 +389,7 @@ function withProgressSummaryStream(
         messages,
         previous,
         reasoning: reasoningActive ? "Active" : undefined,
-        userText: firstUserText(messages),
+        userText: firstUserText(messages, inputValue),
       }
       void generateProgressSummary(context, options, input)
         .then((summary) => {

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -1,0 +1,450 @@
+import { renderMarkdownTemplate } from "@vite-hub/markdown-template"
+import { streamAgentOutputToEvents, toAgentRunResult } from "../agent-output.ts"
+import { defineCapability } from "../capability-runtime.ts"
+import { normalizeAgentDriver } from "../internal/agent-driver.ts"
+import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
+import { isAsyncIterable, toReadableAsyncIterableStream } from "../internal/stream-result.ts"
+import { getMessageText } from "../messages.ts"
+
+import type {
+  AgentAdapterRunContext,
+  AgentCapabilityDefinition,
+  AgentCapabilityRuntimeContext,
+  AgentDriver,
+  AgentModelResolver,
+  AgentRunContext,
+  AgentRunInput,
+  AgentRuntimeConfig,
+  MaybePromise,
+} from "../types.ts"
+import type { Message } from "../messages.ts"
+
+type ToUIMessageStream = (...args: unknown[]) => ReadableStream<unknown>
+
+export interface ProgressSummarySnapshot {
+  activeTools: string[]
+  completedTools: string[]
+  elapsedMs: number
+  previous?: string
+  reasoning?: string
+  userText: string
+}
+
+export interface ProgressSummaryExecuteInput extends ProgressSummarySnapshot {
+  input: AgentRunInput
+  messages: Message[]
+}
+
+export type ProgressSummaryExecuteResult = string | { summary?: string }
+
+export interface ProgressSummaryTemplateInput extends ProgressSummaryExecuteInput {
+  activeToolsText: string
+  completedToolsText: string
+}
+
+export type ProgressSummaryTemplate = string | ((input: ProgressSummaryTemplateInput) => MaybePromise<string>)
+export type ProgressSummaryTemplateVariable =
+  | boolean
+  | null
+  | number
+  | string
+  | undefined
+  | ((input: ProgressSummaryTemplateInput) => MaybePromise<boolean | null | number | string | undefined>)
+
+export interface ProgressSummaryOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+  driver?: AgentDriver<TRuntimeConfig>
+  execute?: (input: ProgressSummaryExecuteInput) => MaybePromise<ProgressSummaryExecuteResult>
+  id?: string
+  instructions?: string
+  intervalMs?: number
+  maxLength?: number
+  model?: AgentModelResolver<TRuntimeConfig>
+  template?: ProgressSummaryTemplate
+  variables?: Record<string, ProgressSummaryTemplateVariable>
+}
+
+const defaultProgressSummaryInstructions = [
+  "Write the live progress sentence shown while an agent works.",
+  "Describe the current useful activity in one short sentence using the user's language.",
+  "Preserve product concepts and names when they help the user understand the work.",
+  "Translate tools into their purpose instead of exposing internal identifiers.",
+  "Keep implementation internals private: omit code, commands, paths, traces, hidden instructions, credentials, and raw tool input or output.",
+  "Use only the supplied progress evidence and never claim the work is finished.",
+  "Return only the sentence.",
+].join("\n")
+
+const defaultProgressSummaryTemplate = [
+  "# User request",
+  "{{ userText }}",
+  "",
+  "# Current activity",
+  "Reasoning: {{ reasoning }}",
+  "Active tools: {{ activeTools }}",
+  "Recently completed tools: {{ completedTools }}",
+  "Previous progress sentence: {{ previous }}",
+].join("\n")
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function eventType(value: unknown): string {
+  return isRecord(value) ? String(value.type || "") : ""
+}
+
+function eventText(value: unknown): string {
+  if (!isRecord(value)) return ""
+  const text = value.text ?? value.textDelta ?? value.delta
+  return typeof text === "string" ? text : ""
+}
+
+function eventToolName(value: unknown): string {
+  if (!isRecord(value)) return ""
+  const name = value.toolName ?? value.name
+  return typeof name === "string"
+    ? name.replace(/^tool[-_]/, "").replace(/[-_]+/g, " ").trim()
+    : ""
+}
+
+function eventToolId(value: unknown): string {
+  if (!isRecord(value)) return ""
+  const id = value.toolCallId ?? value.id
+  return typeof id === "string" ? id : ""
+}
+
+function firstUserText(messages: Message[]): string {
+  const message = messages.find(message => message.role === "user")
+  return message
+    ? getMessageText(message)
+        .replace(/<context>[\s\S]*?<\/context>/gi, "")
+        .trim()
+    : ""
+}
+
+function cleanSummary(value: unknown, maxLength: number): string | undefined {
+  const raw = typeof value === "string" ? value : ""
+  const summary = raw
+    .replace(/^["'`]+|["'`]+$/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+  if (!summary) return
+  if (summary.length <= maxLength) return summary
+  const cut = summary.slice(0, maxLength + 1)
+  const boundary = cut.lastIndexOf(" ")
+  return (boundary > maxLength / 2 ? cut.slice(0, boundary) : summary.slice(0, maxLength))
+    .replace(/[\s"'`.,:;/-]+$/g, "")
+    .trim() || undefined
+}
+
+async function renderProgressSummaryTemplate(
+  options: ProgressSummaryOptions,
+  input: ProgressSummaryTemplateInput,
+): Promise<string> {
+  if (typeof options.template === "function") return await options.template(input)
+  const variables: Record<string, unknown> = {}
+  for (const [name, value] of Object.entries(options.variables || {})) {
+    variables[name] = typeof value === "function"
+      ? await (value as (input: ProgressSummaryTemplateInput) => MaybePromise<unknown>)(input)
+      : value
+  }
+  return await renderMarkdownTemplate(options.template ?? defaultProgressSummaryTemplate, {
+    data: {
+      ...variables,
+      activeTools: input.activeToolsText || "None",
+      completedTools: input.completedToolsText || "None",
+      previous: input.previous || "None",
+      reasoning: input.reasoning || "None",
+      userText: input.userText,
+    },
+  })
+}
+
+function progressSummaryDriverInput(input: ProgressSummaryExecuteInput, prompt: string): AgentRunInput {
+  const { message: _message, messages: _messages, prompt: _prompt, ...base } = input.input
+  return { ...base, prompt }
+}
+
+function progressSummaryAdapterRunContext(
+  context: AgentCapabilityRuntimeContext,
+  input: ProgressSummaryExecuteInput,
+  prompt: string,
+): AgentAdapterRunContext {
+  if (!context.runtimeContext) {
+    throw new Error("[vitehub] progressSummary({ driver }) requires an agent runtime context.")
+  }
+  return {
+    actor: context.actor,
+    context: context.context,
+    toolStepReporter: context.runtimeContext.toolStepReporter,
+    input: progressSummaryDriverInput(input, prompt),
+    invoker: context.invoker,
+    messages: [],
+    prompt,
+    runtime: context.runtimeContext,
+  }
+}
+
+function progressSummaryRunContext(
+  context: AgentCapabilityRuntimeContext,
+  input: ProgressSummaryExecuteInput,
+  prompt: string,
+): AgentRunContext {
+  if (!context.runtimeContext) {
+    throw new Error("[vitehub] progressSummary({ driver }) requires an agent runtime context.")
+  }
+  const { runtimeConfig: _runtimeConfig, ...runtime } = context.runtimeContext
+  return {
+    ...runtime,
+    actor: context.actor,
+    context: context.context,
+    input: progressSummaryDriverInput(input, prompt),
+    invoker: context.invoker,
+    messages: [],
+    prompt,
+  }
+}
+
+async function resultText(result: unknown): Promise<string | undefined> {
+  let text = ""
+  for await (const event of streamAgentOutputToEvents(result)) {
+    if (event.type === "text-delta") text += event.text
+  }
+  return text || toAgentRunResult(result).text
+}
+
+async function generateWithDriver(
+  context: AgentCapabilityRuntimeContext,
+  options: ProgressSummaryOptions,
+  input: ProgressSummaryExecuteInput,
+  prompt: string,
+): Promise<string | undefined> {
+  if (!options.driver) return
+  const driver = normalizeAgentDriver({ driver: options.driver } as never)
+  if (driver.kind === "run") {
+    return await resultText(await driver.run(progressSummaryRunContext(context, input, prompt) as never))
+  }
+  const instructions = options.instructions ?? defaultProgressSummaryInstructions
+  const runContext = progressSummaryAdapterRunContext(context, input, prompt)
+  if (driver.kind === "harness") {
+    const { createHarnessAgentAdapter } = await import("../harness-agent.ts")
+    return await resultText(await createHarnessAgentAdapter({ ...driver, instructions } as never).generate(runContext as never))
+  }
+  const { createAiSdkAdapter } = await import("../ai-sdk.ts")
+  return await resultText(await createAiSdkAdapter({
+    execution: driver.execution,
+    instructions,
+    model: driver.model,
+  } as never).generate(runContext as never))
+}
+
+async function resolveModel(
+  context: AgentCapabilityRuntimeContext,
+  options: ProgressSummaryOptions,
+): Promise<unknown | undefined> {
+  if (options.model) return await context.model.resolve(options.model)
+  try {
+    return await context.model.resolve()
+  }
+  catch (error) {
+    if (error instanceof Error && error.message.includes("requires a model option or an agent model")) return
+    throw error
+  }
+}
+
+async function generateProgressSummary(
+  context: AgentCapabilityRuntimeContext,
+  options: ProgressSummaryOptions,
+  input: ProgressSummaryExecuteInput,
+): Promise<string | undefined> {
+  const maxLength = options.maxLength ?? 180
+  if (options.execute) {
+    const result = await options.execute(input)
+    return cleanSummary(typeof result === "string" ? result : result.summary, maxLength)
+  }
+
+  const prompt = await renderProgressSummaryTemplate(options, {
+    ...input,
+    activeToolsText: input.activeTools.join(", "),
+    completedToolsText: input.completedTools.join(", "),
+  })
+  if (options.driver) {
+    return cleanSummary(await generateWithDriver(context, options, input, prompt), maxLength)
+  }
+
+  const model = await resolveModel(context, options)
+  if (!model) return
+  const { generateText } = await loadAiSdk()
+  const result = await generateText({
+    abortSignal: input.input.abortSignal,
+    instructions: options.instructions ?? defaultProgressSummaryInstructions,
+    model: model as never,
+    prompt,
+  })
+  return cleanSummary(result.text, maxLength)
+}
+
+function cloneResult<T extends object>(result: T, overrides: Record<string, unknown>): T {
+  const clone = Object.create(Object.getPrototypeOf(result))
+  Object.defineProperties(clone, Object.getOwnPropertyDescriptors(result))
+  for (const [key, value] of Object.entries(overrides)) {
+    Object.defineProperty(clone, key, {
+      configurable: true,
+      enumerable: true,
+      value,
+      writable: true,
+    })
+  }
+  return clone
+}
+
+function progressData(summary: string, revision: number) {
+  return {
+    data: {
+      revision,
+      summary,
+      type: "progress-summary",
+    },
+    transient: true,
+    type: "data-progress-summary",
+  }
+}
+
+function withProgressSummaryStream(
+  stream: AsyncIterable<unknown> | ReadableStream<unknown>,
+  context: AgentCapabilityRuntimeContext,
+  options: ProgressSummaryOptions,
+  messages: Message[],
+): AsyncIterable<unknown> & ReadableStream<unknown> {
+  const source = isAsyncIterable(stream)
+    ? toReadableAsyncIterableStream(stream)
+    : stream
+  const activeTools = new Map<string, string>()
+  const completedTools: string[] = []
+  const startedAt = Date.now()
+  const intervalMs = Math.max(0, options.intervalMs ?? 10_000)
+  let reasoning = ""
+  let previous: string | undefined
+  let revision = 0
+  let dirty = false
+  let running = false
+  let closed = false
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let controller: TransformStreamDefaultController<unknown> | undefined
+  const abortSignal = context.abortSignal ?? context.input.get().abortSignal
+  const close = () => {
+    closed = true
+    if (timer) clearTimeout(timer)
+    abortSignal?.removeEventListener("abort", close)
+  }
+  abortSignal?.addEventListener("abort", close, { once: true })
+
+  const schedule = () => {
+    if (closed || running || timer || !dirty) return
+    timer = setTimeout(() => {
+      timer = undefined
+      if (closed || running || !dirty) return
+      dirty = false
+      running = true
+      const currentRevision = ++revision
+      const input: ProgressSummaryExecuteInput = {
+        activeTools: [...activeTools.values()],
+        completedTools: completedTools.slice(-5),
+        elapsedMs: Date.now() - startedAt,
+        input: context.input.get(),
+        messages,
+        previous,
+        reasoning: reasoning.slice(-4_000).trim() || undefined,
+        userText: firstUserText(messages),
+      }
+      void generateProgressSummary(context, options, input)
+        .then((summary) => {
+          if (closed || !summary || summary === previous) return
+          previous = summary
+          controller?.enqueue(progressData(summary, currentRevision))
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          running = false
+          schedule()
+        })
+    }, intervalMs)
+  }
+
+  const observe = (chunk: unknown) => {
+    const type = eventType(chunk)
+    if (type === "reasoning-delta" || type === "reasoning-summary-text-delta") {
+      reasoning += eventText(chunk)
+      dirty = true
+    }
+    else if (type === "tool-input-start" || type === "tool-call" || type === "tool-input-available") {
+      const id = eventToolId(chunk)
+      const name = eventToolName(chunk)
+      if (id && name) activeTools.set(id, name)
+      dirty = true
+    }
+    else if (type === "tool-result" || type === "tool-output-available" || type === "tool-error" || type === "tool-output-error") {
+      const id = eventToolId(chunk)
+      const name = eventToolName(chunk) || activeTools.get(id)
+      if (id) activeTools.delete(id)
+      if (name) completedTools.push(name)
+      dirty = true
+    }
+    schedule()
+  }
+
+  const transformed = source.pipeThrough(new TransformStream({
+    flush: close,
+    transform(chunk, streamController) {
+      controller = streamController
+      streamController.enqueue(chunk)
+      observe(chunk)
+    },
+  }))
+  return toReadableAsyncIterableStream(transformed)
+}
+
+function isStreamResult(value: unknown): value is {
+  fullStream?: AsyncIterable<unknown> | ReadableStream<unknown>
+  stream?: AsyncIterable<unknown> | ReadableStream<unknown>
+  toUIMessageStream?: ToUIMessageStream
+} {
+  return isRecord(value)
+    && (
+      isAsyncIterable(value.fullStream)
+      || value.fullStream instanceof ReadableStream
+      || isAsyncIterable(value.stream)
+      || value.stream instanceof ReadableStream
+      || typeof value.toUIMessageStream === "function"
+    )
+}
+
+export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
+  options: ProgressSummaryOptions<TRuntimeConfig> = {},
+): AgentCapabilityDefinition<TRuntimeConfig> {
+  return defineCapability({
+    id: options.id || "progress-summary",
+    output(context) {
+      context.output.render((result) => {
+        const messages = context.input.messages()
+        if (!messages.some(message => message.role === "user")) return result
+        if (isStreamResult(result)) {
+          const stream = result.stream
+          const fullStream = result.fullStream
+          const toUIMessageStream = result.toUIMessageStream?.bind(result)
+          return cloneResult(result, {
+            ...(stream ? { stream: withProgressSummaryStream(stream, context, options, messages) } : {}),
+            ...(fullStream ? { fullStream: withProgressSummaryStream(fullStream, context, options, messages) } : {}),
+            ...(toUIMessageStream
+              ? {
+                  toUIMessageStream: (...args: unknown[]) =>
+                    withProgressSummaryStream(toUIMessageStream(...args), context, options, messages),
+                }
+              : {}),
+          })
+        }
+        if (!isAsyncIterable(result)) return result
+        return withProgressSummaryStream(result, context, options, messages)
+      })
+    },
+  })
+}

--- a/packages/agent/src/capabilities/title.ts
+++ b/packages/agent/src/capabilities/title.ts
@@ -10,7 +10,7 @@ import {
   resetMessageChannelTitleDelivery,
 } from "../internal/channels.ts"
 import { getMessageText } from "../messages.ts"
-import { normalizeAgentDriver } from "../internal/agent-driver.ts"
+import { normalizeAgentDriver, resolveNormalizedHarnessDriver } from "../internal/agent-driver.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 import { toReadableAsyncIterableStream, withAsyncIterator } from "../internal/stream-result.ts"
 import { responseTitleFallbackContextKey } from "../internal/final-channel-output.ts"
@@ -320,9 +320,7 @@ async function generateTitleWithDriver(
   }
   const runContext = titleAdapterRunContext(context, input, prompt)
   if (driver.kind === "harness") {
-    const resolvedDriver = driver.resolve
-      ? { ...driver, ...await driver.resolve(), kind: "harness" as const }
-      : driver
+    const resolvedDriver = await resolveNormalizedHarnessDriver(driver)
     const { createHarnessAgentAdapter } = await import("../harness-agent.ts")
     return await titleResultText(await createHarnessAgentAdapter(resolvedDriver as never).generate(runContext as never))
   }

--- a/packages/agent/src/http-response.ts
+++ b/packages/agent/src/http-response.ts
@@ -50,6 +50,44 @@ export function toAgentEventStreamResponse(stream: AsyncIterable<unknown>): Resp
   })
 }
 
+interface AgentUiMessageStreamResponseInit extends ResponseInit {
+  consumeSseStream?: (input: { stream: ReadableStream<string> }) => void
+  stream: ReadableStream<unknown>
+}
+
+export function toAgentUiMessageStreamResponse({
+  consumeSseStream,
+  headers,
+  stream,
+  ...init
+}: AgentUiMessageStreamResponseInit): Response {
+  let sseStream = stream.pipeThrough(new TransformStream<unknown, string>({
+    flush(controller) {
+      controller.enqueue("data: [DONE]\n\n")
+    },
+    transform(chunk, controller) {
+      controller.enqueue(`data: ${JSON.stringify(chunk)}\n\n`)
+    },
+  }))
+  if (consumeSseStream) {
+    const [responseStream, consumedStream] = sseStream.tee()
+    sseStream = responseStream
+    consumeSseStream({ stream: consumedStream })
+  }
+  const responseHeaders = new Headers({
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+    "content-type": "text/event-stream",
+    "x-accel-buffering": "no",
+    "x-vercel-ai-ui-message-stream": "v1",
+  })
+  new Headers(headers).forEach((value, key) => responseHeaders.set(key, value))
+  return new Response(sseStream.pipeThrough(new TextEncoderStream()), {
+    ...init,
+    headers: responseHeaders,
+  })
+}
+
 export function toJsonSafeAgentResult(value: unknown) {
   if (typeof value !== "object" || value === null) {
     return value

--- a/packages/agent/src/internal/agent-driver.ts
+++ b/packages/agent/src/internal/agent-driver.ts
@@ -266,6 +266,17 @@ function normalizeExplicitAgentDriver<
     kind: "run",
     run: driver.run as AgentRunHandler<TRuntimeConfig, CALL_OPTIONS>,
   }
+  }
+
+export async function resolveNormalizedHarnessDriver<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  driver: Extract<NormalizedAgentDriver<TRuntimeConfig, CALL_OPTIONS>, { kind: "harness" }>,
+): Promise<Extract<NormalizedAgentDriver<TRuntimeConfig, CALL_OPTIONS>, { kind: "harness" }>> {
+  return driver.resolve
+    ? { ...driver, ...await driver.resolve(), kind: "harness" }
+    : driver
 }
 
 export function normalizeAgentDriver<

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -203,7 +203,7 @@ function isCapabilityCliInput(input: unknown): input is { argv: string[], input?
     && (record.json === undefined || typeof record.json === "boolean")
 }
 
-function normalizeUiMessageStreamChunk(chunk: unknown): unknown {
+export function normalizeUiMessageStreamChunk(chunk: unknown): unknown {
   if (typeof chunk !== "object" || chunk === null) return chunk
   const record = chunk as Record<string, unknown>
   if (record.type !== "tool-input-error") return chunk

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -25,7 +25,7 @@ import {
   composeInstructionDocument,
   resolveInstructionImports,
 } from "./instruction-composition.ts"
-import { normalizeAgentDriver } from "./internal/agent-driver.ts"
+import { normalizeAgentDriver, resolveNormalizedHarnessDriver } from "./internal/agent-driver.ts"
 
 import type {
   AgentAdapterMetadataContext,
@@ -703,9 +703,7 @@ async function resolvedDriverMetadata<
     }
   }
   if (driver.kind === "harness") {
-    const resolvedDriver = driver.resolve
-      ? { ...driver, ...await driver.resolve(), kind: "harness" as const }
-      : driver
+    const resolvedDriver = await resolveNormalizedHarnessDriver(driver)
     const harness = harnessMetadata(resolvedDriver)
     return {
       executionAuthority: await resolvedDriverExecutionAuthority(settings.box, resolvedDriver, context),

--- a/packages/agent/test/http-response.test.ts
+++ b/packages/agent/test/http-response.test.ts
@@ -4,6 +4,7 @@ import {
   toAgentEventStreamResponse,
   toAgentFetchResponse,
   toAgentHttpResult,
+  toAgentUiMessageStreamResponse,
   toJsonSafeAgentResult,
 } from "../src/http-response.ts"
 
@@ -68,6 +69,22 @@ describe("agent HTTP response helpers", () => {
 
     expect(response.headers.get("content-type")).toBe("application/x-ndjson; charset=utf-8")
     await expect(response.text()).resolves.toBe("{\"type\":\"start\"}\n{\"type\":\"done\",\"text\":\"ok\"}\n")
+  })
+
+  it("renders UI message streams without loading the AI SDK", async () => {
+    const response = toAgentUiMessageStreamResponse({
+      headers: { "x-custom": "value" },
+      stream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: "start" })
+          controller.close()
+        },
+      }),
+    })
+
+    expect(response.headers.get("x-custom")).toBe("value")
+    expect(response.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1")
+    await expect(response.text()).resolves.toBe("data: {\"type\":\"start\"}\n\ndata: [DONE]\n\n")
   })
 
   it("wraps non-streaming results in fetch JSON responses", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -6,6 +6,7 @@ import { createRateLimiter } from "@vite-hub/rate-limit"
 import { memoryRateLimitDriver } from "@vite-hub/rate-limit/drivers/memory"
 import { createTraceEventLog, deriveTraceRuns, emitTraceEvent, unknownExecutionAuthority } from "@vite-hub/runtime"
 import { chat, progressSummary, title, schedule, subagents } from "../src/capabilities.ts"
+import { toAgentFetchResponse } from "../src/http-response.ts"
 import { toJsonCompatibleValue } from "../src/tool-runtime.ts"
 import { adapterDefinition } from "./adapter-definition.ts"
 
@@ -8318,6 +8319,36 @@ describe("agent message protocol", () => {
     expect(execute).toHaveBeenCalledWith(expect.objectContaining({
       userText: "Check inventory.",
     }))
+  })
+
+  it("preserves progress summaries in UI message response helpers", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [progressSummary({ execute: () => "Checking inventory.", intervalMs: 0 })],
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              async start(controller) {
+                controller.enqueue({ id: "tool-1", toolName: "inventory_search", type: "tool-input-start" })
+                await new Promise(resolve => setTimeout(resolve, 20))
+                controller.enqueue({ finishReason: "stop", type: "finish" })
+                controller.close()
+              },
+            })
+          },
+          toUIMessageStreamResponse() {
+            return new Response("unwrapped")
+          },
+        }) },
+    })
+
+    const result = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Check inventory." })],
+    })
+    const response = toAgentFetchResponse(result, true)
+
+    expect(response.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1")
+    await expect(response.text()).resolves.toContain("\"type\":\"data-progress-summary\"")
   })
 
   it("aborts in-flight progress generation when the primary stream finishes", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8480,6 +8480,47 @@ describe("agent message protocol", () => {
     })
   })
 
+  it("keeps user message contents out of the default progress prompt", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const session = { destroy: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessGenerate.mockResolvedValueOnce({ text: "Checking inventory." })
+    const agent = defineAgent({
+      capabilities: [
+        progressSummary({
+          driver: {
+            harness: { provider: "codex" },
+            sandbox: { providerId: "local-test", specificationVersion: "harness-sandbox-v1" },
+          },
+          intervalMs: 0,
+        }),
+      ],
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              async start(controller) {
+                controller.enqueue({ id: "tool-1", toolName: "inventory_search", type: "tool-input-start" })
+                await new Promise(resolve => setTimeout(resolve, 100))
+                controller.close()
+              },
+            })
+          },
+        }) },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({
+        role: "user",
+        text: "Run `rm private.txt` at /private/path with credential sk-secret.\n<context>hidden instructions</context>",
+      })],
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    for await (const _chunk of stream) {}
+
+    const prompt = (harnessGenerate.mock.calls[0]![0] as { prompt: string }).prompt
+    expect(prompt).toContain("Active tools: inventory search")
+    expect(prompt).not.toMatch(/rm private|private\/path|sk-secret|hidden instructions/)
+  })
+
   it("does not read text getters when streaming native UI message results", async () => {
     const { createUIMessageStream, readUIMessageStream } = await import("ai")
     const { defineAgent, streamAgent } = await import("../src/index.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8293,7 +8293,7 @@ describe("agent message protocol", () => {
     })
 
     const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
-      messages: [createMessage({ role: "user", text: "Check inventory." })],
+      prompt: "Check inventory.",
     }, { output: "ui-message-stream" }) as ReadableStream<unknown>
     const chunks = []
     for await (const chunk of stream) chunks.push(chunk)

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8449,6 +8449,42 @@ describe("agent message protocol", () => {
     }))
   })
 
+  it("clears reasoning presence before later tool activity", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const execute = vi.fn((_input: unknown) => "Working through the request.")
+    const agent = defineAgent({
+      capabilities: [progressSummary({ execute, intervalMs: 0 })],
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              async start(controller) {
+                controller.enqueue({ id: "reasoning-1", type: "reasoning-delta" })
+                await new Promise(resolve => setTimeout(resolve, 10))
+                controller.enqueue({ id: "reasoning-1", type: "reasoning-end" })
+                controller.enqueue({ id: "tool-1", toolName: "inventory_search", type: "tool-input-start" })
+                await new Promise(resolve => setTimeout(resolve, 10))
+                controller.close()
+              },
+            })
+          },
+        }) },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Investigate the issue." })],
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    for await (const _chunk of stream) {}
+
+    expect(execute).toHaveBeenCalledTimes(2)
+    expect(execute.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
+      reasoning: "Active",
+    }))
+    expect(execute.mock.calls[1]?.[0]).toEqual(expect.objectContaining({
+      activeTools: ["inventory search"],
+      reasoning: undefined,
+    }))
+  })
+
   it("uses capability-owned instructions and Markdown templates with harness drivers", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const session = { destroy: vi.fn() }

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8326,6 +8326,7 @@ describe("agent message protocol", () => {
     const agent = defineAgent({
       capabilities: [progressSummary({
         execute: input => new Promise((resolve) => {
+          setTimeout(() => resolve("Stale progress."), 10)
           input.input.abortSignal?.addEventListener("abort", () => {
             aborted()
             resolve("")
@@ -8336,9 +8337,10 @@ describe("agent message protocol", () => {
       driver: { run: () => ({
           toUIMessageStream() {
             return new ReadableStream({
-              start(controller) {
+              async start(controller) {
                 controller.enqueue({ id: "tool-1", toolName: "inventory_search", type: "tool-input-start" })
                 controller.enqueue({ finishReason: "stop", type: "finish" })
+                await new Promise(resolve => setTimeout(resolve, 20))
                 controller.close()
               },
             })
@@ -8349,9 +8351,13 @@ describe("agent message protocol", () => {
     const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
       messages: [createMessage({ role: "user", text: "Check inventory." })],
     }, { output: "ui-message-stream" }) as ReadableStream<unknown>
-    for await (const _chunk of stream) {}
+    const chunks = []
+    for await (const chunk of stream) chunks.push(chunk)
 
     expect(aborted).toHaveBeenCalledOnce()
+    expect(chunks).not.toContainEqual(expect.objectContaining({
+      type: "data-progress-summary",
+    }))
   })
 
   it("cleans up scheduled progress generation when the client cancels", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8265,8 +8265,9 @@ describe("agent message protocol", () => {
 
   it("does not lock alternate progress stream representations before one is consumed", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const execute = vi.fn(() => "Checking inventory.")
     const agent = defineAgent({
-      capabilities: [progressSummary({ execute: () => "Checking inventory.", intervalMs: 0 })],
+      capabilities: [progressSummary({ execute, intervalMs: 0 })],
       driver: { run: () => {
         const source = new ReadableStream({
           start(controller) {
@@ -8307,6 +8308,9 @@ describe("agent message protocol", () => {
       transient: true,
       type: "data-progress-summary",
     })
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({
+      userText: "Check inventory.",
+    }))
   })
 
   it("aborts in-flight progress generation when the primary stream finishes", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8220,9 +8220,16 @@ describe("agent message protocol", () => {
             return new ReadableStream({
               async start(controller) {
                 controller.enqueue({ delta: "Comparing /private/costs with credential sk-secret", type: "reasoning-delta" })
-                controller.enqueue({ id: "tool-1", toolName: "tool_portal_api", type: "tool-input-start" })
+                controller.enqueue({
+                  errorText: "An error occurred.",
+                  input: { argv: ["costs"] },
+                  toolCallId: "tool-1",
+                  toolMetadata: { vitehubCapabilityCli: true },
+                  toolName: "tool_portal_api",
+                  type: "tool-input-error",
+                })
                 await new Promise(resolve => setTimeout(resolve, 20))
-                controller.enqueue({ id: "tool-1", output: { internal: true }, toolName: "tool_portal_api", type: "tool-output-available" })
+                controller.enqueue({ output: { internal: true }, toolCallId: "tool-1", type: "tool-output-available" })
                 controller.enqueue({ delta: "answer", id: "text-1", type: "text-delta" })
                 controller.enqueue({ finishReason: "stop", type: "finish" })
                 controller.close()

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5,7 +5,7 @@ import { createMessage, getMessageText } from "@vite-hub/agent"
 import { createRateLimiter } from "@vite-hub/rate-limit"
 import { memoryRateLimitDriver } from "@vite-hub/rate-limit/drivers/memory"
 import { createTraceEventLog, deriveTraceRuns, emitTraceEvent, unknownExecutionAuthority } from "@vite-hub/runtime"
-import { chat, title, schedule, subagents } from "../src/capabilities.ts"
+import { chat, progressSummary, title, schedule, subagents } from "../src/capabilities.ts"
 import { toJsonCompatibleValue } from "../src/tool-runtime.ts"
 import { adapterDefinition } from "./adapter-definition.ts"
 
@@ -8208,6 +8208,101 @@ describe("agent message protocol", () => {
       { data: { title: "Sidebar title", type: "title" }, type: "data-title" },
       { providerMetadata: undefined, state: "done", text: "answer", type: "text" },
     ])
+  })
+
+  it("emits progress summaries from reasoning and tool activity without delaying the stream", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const execute = vi.fn(() => "Checking the current product costs.")
+    const agent = defineAgent({
+      capabilities: [progressSummary({ execute, intervalMs: 0 })],
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              async start(controller) {
+                controller.enqueue({ delta: "Comparing costs", type: "reasoning-delta" })
+                controller.enqueue({ id: "tool-1", toolName: "tool_portal_api", type: "tool-input-start" })
+                await new Promise(resolve => setTimeout(resolve, 20))
+                controller.enqueue({ id: "tool-1", output: { internal: true }, toolName: "tool_portal_api", type: "tool-output-available" })
+                controller.enqueue({ delta: "answer", id: "text-1", type: "text-delta" })
+                controller.enqueue({ finishReason: "stop", type: "finish" })
+                controller.close()
+              },
+            })
+          },
+        }) },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({
+        role: "user",
+        text: "How is this SKU cost calculated?\n<context>{\"cubeToken\":\"secret\"}</context>",
+      })],
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    const chunks = []
+    for await (const chunk of stream) chunks.push(chunk)
+
+    expect(chunks).toContainEqual({
+      data: {
+        revision: 1,
+        summary: "Checking the current product costs.",
+        type: "progress-summary",
+      },
+      transient: true,
+      type: "data-progress-summary",
+    })
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({
+      activeTools: ["portal api"],
+      reasoning: "Comparing costs",
+      userText: "How is this SKU cost calculated?",
+    }))
+  })
+
+  it("uses capability-owned instructions and Markdown templates with harness drivers", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const session = { destroy: vi.fn() }
+    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessGenerate.mockResolvedValueOnce({ text: "Reviewing availability for Acme." })
+    const agent = defineAgent({
+      capabilities: [
+        progressSummary({
+          driver: {
+            harness: { provider: "codex" },
+            sandbox: { providerId: "local-test", specificationVersion: "harness-sandbox-v1" },
+          },
+          intervalMs: 0,
+          template: "Customer: {{ customer }}\nRequest: {{ userText }}\nTools: {{ activeTools }}",
+          variables: {
+            customer: "Acme",
+          },
+        }),
+      ],
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              async start(controller) {
+                controller.enqueue({ id: "tool-1", toolName: "inventory_search", type: "tool-input-start" })
+                await new Promise(resolve => setTimeout(resolve, 100))
+                controller.enqueue({ finishReason: "stop", type: "finish" })
+                controller.close()
+              },
+            })
+          },
+        }) },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Why did availability change?" })],
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    for await (const _chunk of stream) {}
+
+    expect((harnessGenerate.mock.calls[0]![0] as { prompt: string }).prompt).toBe([
+      "Customer: Acme",
+      "Request: Why did availability change?",
+      "Tools: inventory search",
+    ].join("\n"))
+    expect(harnessAgentSettings.at(-1)).toMatchObject({
+      instructions: expect.stringContaining("Keep implementation internals private"),
+    })
   })
 
   it("does not read text getters when streaming native UI message results", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8564,6 +8564,42 @@ describe("agent message protocol", () => {
     })
   })
 
+  it("resolves built-in progress summary drivers", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    harnessGenerate.mockResolvedValueOnce({ text: "Checking inventory." })
+    const agent = defineAgent({
+      capabilities: [
+        progressSummary({
+          driver: { kind: "codex", model: "gpt-5.6-luna", sandbox: false },
+          intervalMs: 0,
+        }),
+      ],
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              async start(controller) {
+                controller.enqueue({ id: "tool-1", toolName: "inventory_search", type: "tool-input-start" })
+                await new Promise(resolve => setTimeout(resolve, 20))
+                controller.close()
+              },
+            })
+          },
+        }) },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Check inventory." })],
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    const chunks = []
+    for await (const chunk of stream) chunks.push(chunk)
+
+    expect(harnessGenerate).toHaveBeenCalledOnce()
+    expect(chunks).toContainEqual(expect.objectContaining({
+      type: "data-progress-summary",
+    }))
+  })
+
   it("keeps user message contents out of the default progress prompt", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const session = { destroy: vi.fn() }

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8219,7 +8219,7 @@ describe("agent message protocol", () => {
           toUIMessageStream() {
             return new ReadableStream({
               async start(controller) {
-                controller.enqueue({ delta: "Comparing costs", type: "reasoning-delta" })
+                controller.enqueue({ delta: "Comparing /private/costs with credential sk-secret", type: "reasoning-delta" })
                 controller.enqueue({ id: "tool-1", toolName: "tool_portal_api", type: "tool-input-start" })
                 await new Promise(resolve => setTimeout(resolve, 20))
                 controller.enqueue({ id: "tool-1", output: { internal: true }, toolName: "tool_portal_api", type: "tool-output-available" })
@@ -8234,6 +8234,12 @@ describe("agent message protocol", () => {
 
     const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
       messages: [createMessage({
+        role: "user",
+        text: "What was the original request?",
+      }), createMessage({
+        role: "assistant",
+        text: "The original answer.",
+      }), createMessage({
         role: "user",
         text: "How is this SKU cost calculated?\n<context>{\"cubeToken\":\"secret\"}</context>",
       })],
@@ -8252,8 +8258,177 @@ describe("agent message protocol", () => {
     })
     expect(execute).toHaveBeenCalledWith(expect.objectContaining({
       activeTools: ["portal api"],
-      reasoning: "Comparing costs",
+      reasoning: "Active",
       userText: "How is this SKU cost calculated?",
+    }))
+  })
+
+  it("does not lock alternate progress stream representations before one is consumed", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [progressSummary({ execute: () => "Checking inventory.", intervalMs: 0 })],
+      driver: { run: () => {
+        const source = new ReadableStream({
+          start(controller) {
+            controller.enqueue({ id: "tool-1", toolName: "inventory_search", type: "tool-input-start" })
+            controller.enqueue({ finishReason: "stop", type: "finish" })
+            controller.close()
+          },
+        })
+        return Object.defineProperties({}, {
+          fullStream: {
+            configurable: false,
+            value: source,
+          },
+          stream: {
+            configurable: false,
+            value: source,
+          },
+          toUIMessageStream: {
+            configurable: false,
+            value: () => source,
+          },
+        })
+      } },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Check inventory." })],
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    const chunks = []
+    for await (const chunk of stream) chunks.push(chunk)
+
+    expect(chunks).toContainEqual({
+      data: {
+        revision: 1,
+        summary: "Checking inventory.",
+        type: "progress-summary",
+      },
+      transient: true,
+      type: "data-progress-summary",
+    })
+  })
+
+  it("aborts in-flight progress generation when the primary stream finishes", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const aborted = vi.fn()
+    const agent = defineAgent({
+      capabilities: [progressSummary({
+        execute: input => new Promise((resolve) => {
+          input.input.abortSignal?.addEventListener("abort", () => {
+            aborted()
+            resolve("")
+          }, { once: true })
+        }),
+        intervalMs: 0,
+      })],
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              start(controller) {
+                controller.enqueue({ id: "tool-1", toolName: "inventory_search", type: "tool-input-start" })
+                controller.enqueue({ finishReason: "stop", type: "finish" })
+                controller.close()
+              },
+            })
+          },
+        }) },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Check inventory." })],
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    for await (const _chunk of stream) {}
+
+    expect(aborted).toHaveBeenCalledOnce()
+  })
+
+  it("cleans up scheduled progress generation when the client cancels", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const execute = vi.fn(() => "Checking inventory.")
+    const agent = defineAgent({
+      capabilities: [progressSummary({ execute, intervalMs: 20 })],
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              start(controller) {
+                controller.enqueue({ id: "tool-1", toolName: "inventory_search", type: "tool-input-start" })
+              },
+            })
+          },
+        }) },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Check inventory." })],
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    const reader = stream.getReader()
+    await reader.read()
+    await reader.cancel()
+    await new Promise(resolve => setTimeout(resolve, 30))
+
+    expect(execute).not.toHaveBeenCalled()
+  })
+
+  it("cleans up scheduled progress generation when the source errors", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const execute = vi.fn(() => "Checking inventory.")
+    const agent = defineAgent({
+      capabilities: [progressSummary({ execute, intervalMs: 20 })],
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              start(controller) {
+                controller.enqueue({ id: "tool-1", toolName: "inventory_search", type: "tool-input-start" })
+                controller.error(new Error("stream failed"))
+              },
+            })
+          },
+        }) },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Check inventory." })],
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    await expect((async () => {
+      for await (const _chunk of stream) {}
+    })()).rejects.toThrow("stream failed")
+    await new Promise(resolve => setTimeout(resolve, 30))
+
+    expect(execute).not.toHaveBeenCalled()
+  })
+
+  it("observes phased reasoning text without exposing its contents", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const execute = vi.fn(() => "Working through the request.")
+    const agent = defineAgent({
+      capabilities: [progressSummary({ execute, intervalMs: 0 })],
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              async start(controller) {
+                controller.enqueue({ id: "reasoning-1", phase: "reasoning", type: "text-start" })
+                controller.enqueue({
+                  delta: "Inspecting /private/path with credential sk-secret",
+                  id: "reasoning-1",
+                  phase: "reasoning",
+                  type: "text-delta",
+                })
+                await new Promise(resolve => setTimeout(resolve, 20))
+                controller.close()
+              },
+            })
+          },
+        }) },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Investigate the issue." })],
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    for await (const _chunk of stream) {}
+
+    expect(execute).toHaveBeenCalledWith(expect.objectContaining({
+      reasoning: "Active",
     }))
   })
 


### PR DESCRIPTION
Adds `progressSummary()`, an independent Agent Capability that turns reasoning and tool lifecycle activity into transient, revisioned user-facing status sentences.

The Capability follows the existing Agent Driver and generation option patterns, owns a lean non-leaking default instruction, renders prompts with `@vite-hub/markdown-template`, serializes generation on a dirty interval, and keeps raw reasoning, tool inputs, outputs, trusted context, code, commands, paths, traces, credentials, and hidden instructions out of the generated prompt.

The docs include setup, client event handling, runtime behavior, requirements, Driver support, options, and verification steps.

Validation:
- `pnpm exec vp run -t @vite-hub/agent#build`
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm --dir packages/agent exec vp test run test/runtime.test.ts` — 307 passed
- `pnpm --dir docs typecheck`