### PR TITLE
feat(agent): simplify dynamic Markdown materialization

### DIFF
--- a/docs/content/docs/capabilities/repository-host-context.md
+++ b/docs/content/docs/capabilities/repository-host-context.md
@@ -38,6 +38,7 @@ export default defineAgent({
   capabilities: [
     repositoryHostContext({
       client: githubRepositoryHostClient,
+      materialize: './PULL_REQUEST.template.md',
       target: {
         repo: 'acme/app',
         number: 42,
@@ -94,8 +95,9 @@ Node ids, discussions, actions, and non-GitHub providers are not part of this co
 
 ## Runtime behavior
 
-`repositoryHostContext()` does not generate Workspace files.
-It does not render `context.md`, create `context.json`, or format provider data for the Agent.
+`repositoryHostContext()` keeps context data-only unless `materialize` is configured.
+With `materialize: './PULL_REQUEST.template.md'`, ViteHub bundles the colocated Markdown renderer and writes the resolved context to `PULL_REQUEST.md` in the Agent Workspace.
+The generated path preserves directories and case while removing only the final `.template`.
 
 Use `repositoryHost()` separately when a model-backed Agent needs repository-host tools such as `repository_host_read`.
 Use `repositoryHostContext()` when trusted runtime code needs a typed invocation context value.
@@ -110,7 +112,7 @@ Target-based context requires a client option or a configured `repository-host` 
 | Agent Driver | Support |
 | --- | --- |
 | Model-backed | Does not receive rendered context automatically. Caller code must render selected values into instructions, input, or another model-facing surface. |
-| Harness-backed | Does not receive generated Workspace context files. Caller code must materialize any files it wants the harness to inspect. |
+| Harness-backed | Receives the configured materialized Markdown file in its Agent Workspace. |
 | Custom-run-backed | Can read the async record directly through `repositoryHostContext.read(ctx)`. |
 
 ## Options
@@ -121,6 +123,7 @@ Target-based context requires a client option or a configured `repository-host` 
 | `context` | `RepositoryHostContextInput \| function` | invocation context | Static issue, Change Request, or selected key values. |
 | `contextKey` | `string` | `"repositoryHost"` | Agent Invocation Context key used to store the async record. |
 | `id` | `string` | `"repository-host-context"` | Capability id. |
+| `materialize` | relative `*.template.md` path | none | Renders resolved context into the matching Workspace `.md` path. |
 | `provider` | `"github" \| string` | client provider | Provider guard. V1 accepts GitHub targets. |
 | `target` | `RepositoryHostContextTarget \| function` | none | Repository host target such as `{ repo, number }`, `{ repo, issue }`, or `{ repo, pullRequest }`. |
 | `triggers` | `Record<string, AgentTriggerDefinition>` | none | Trigger contributions tied to this context. |

--- a/docs/content/docs/reference/markdown-templates.md
+++ b/docs/content/docs/reference/markdown-templates.md
@@ -64,6 +64,8 @@ Relative template imports work with both forms. Imported fragments can remain or
 
 Files ending in `.template.md` remain direct-import modules and do not enter the named catalog, even when they are under `server/templates`. The legacy `?markdown-template` import query remains supported for existing applications, but new code should use the `.template.md` suffix.
 
+`repositoryHostContext({ materialize })` uses the same path convention. Pass a caller-relative `.template.md` path; ViteHub bundles its renderer and derives the generated `.md` path by removing only the final `.template`, preserving directories and case.
+
 ## Render a template string
 
 Pass the template string and the complete data available to it. Scalar bindings are escaped as Markdown text, while triple bindings insert an intentional Markdown fragment.

--- a/packages/agent/src/capabilities/repository-host-context.ts
+++ b/packages/agent/src/capabilities/repository-host-context.ts
@@ -1,4 +1,4 @@
-import { defineCapability } from "../capability-runtime.ts"
+import { defineCapability, workspaceMaterializationPathsSymbol } from "../capability-runtime.ts"
 import { requirePrimitive } from "./storage/shared.ts"
 
 import type {
@@ -925,7 +925,7 @@ function createRepositoryHostContext<
     recordedContexts.add(context.context)
   }
 
-  return defineCapability({
+  return Object.assign(defineCapability({
     id: capabilityId,
     metadata: {
       contextKey,
@@ -942,6 +942,7 @@ function createRepositoryHostContext<
             }
             await recordContext(context)
             const value = context.context.get(contextKey)
+            if (value === undefined) return
             if (!isAsyncRecord(value)) {
               throw new Error("[vitehub] repositoryHostContext() could not resolve materialization data.")
             }
@@ -958,7 +959,9 @@ function createRepositoryHostContext<
           },
         }
       : {},
-  })
+  }), typeof materialization === "object"
+    ? { [workspaceMaterializationPathsSymbol]: [materialization.path] }
+    : {})
 }
 
 export const repositoryHostContext = Object.assign(createRepositoryHostContext, {

--- a/packages/agent/src/capabilities/repository-host-context.ts
+++ b/packages/agent/src/capabilities/repository-host-context.ts
@@ -12,6 +12,11 @@ import type {
 import type { RepositoryHostClient, RepositoryHostProvider, RepositoryHostTarget } from "./repository-host.ts"
 import type { WorkspaceName } from "@vite-hub/workspace"
 
+interface RepositoryHostContextMaterialization {
+  path: string
+  template: (context: Record<string, unknown>) => MaybePromise<string>
+}
+
 export type JsonPrimitive = string | number | boolean | null
 export type JsonValue = JsonPrimitive | JsonObject | JsonValue[]
 
@@ -182,6 +187,7 @@ export interface RepositoryHostContextOptions<
   context?: RepositoryHostContextInput | RepositoryHostContextResolver<TRuntimeConfig, Name>
   contextKey?: string
   id?: string
+  materialize?: string
   provider?: RepositoryHostProvider
   target?: RepositoryHostContextTarget | RepositoryHostContextTargetResolver<TRuntimeConfig, Name>
   triggers?: Record<string, AgentTriggerDefinition<TRuntimeConfig, Name, any, any>>
@@ -888,6 +894,7 @@ function createRepositoryHostContext<
 >(
   options: RepositoryHostContextOptions<TRuntimeConfig, Name> & { contextKey?: TContextKey } = {},
 ): AgentCapabilityDefinition<TRuntimeConfig, Name, RepositoryHostContextCapabilityTypeContract<TContextKey>> {
+  const materialization = options.materialize as string | RepositoryHostContextMaterialization | undefined
   const capabilityId = options.id || defaultRepositoryHostContextId
   const contextKey = options.contextKey || defaultRepositoryHostContextKey
   const recordedContexts = new WeakSet<AgentCapabilityContext<TRuntimeConfig, Name>["context"]>()
@@ -927,6 +934,30 @@ function createRepositoryHostContext<
     prepare: recordContext,
     requires: options.target && !options.client ? [{ primitive: "repository-host" }] : undefined,
     triggers: options.triggers,
+    ...materialization
+      ? {
+          async workspace(context) {
+            if (typeof materialization === "string") {
+              throw new TypeError("[vitehub] repositoryHostContext() materialize paths require the ViteHub Agent plugin.")
+            }
+            await recordContext(context)
+            const value = context.context.get(contextKey)
+            if (!isAsyncRecord(value)) {
+              throw new Error("[vitehub] repositoryHostContext() could not resolve materialization data.")
+            }
+            return {
+              sources: {
+                [capabilityId]: {
+                  content: await materialization.template(await value.resolveAll()),
+                  materialize: "build",
+                  mount: "",
+                  workspacePath: materialization.path,
+                },
+              },
+            }
+          },
+        }
+      : {},
   })
 }
 

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -7,6 +7,7 @@ import { writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deploym
 import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
 import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored } from "@vite-hub/internal/build/vite"
 import { getHostingProvider } from "@vite-hub/internal/hosting"
+import { markdownTemplateMaterializationPath } from "@vite-hub/markdown-template/vite"
 
 import { registerAgentInvocationStreamEndpoint } from "./vite/invocation-stream-endpoint.ts"
 import {
@@ -701,6 +702,134 @@ function generatedWorkspaceSourceRootHelper(name: string, workspaceDefinitionFro
 function moduleImportSpecifier(fromFile: string, targetFile: string): string {
   const specifier = relative(dirname(fromFile), targetFile).replace(/\\/g, "/")
   return specifier.startsWith(".") ? specifier : `./${specifier}`
+}
+
+interface PositionedNode {
+  end: number
+  start: number
+  type: string
+  [key: string]: unknown
+}
+
+function isPositionedNode(value: unknown): value is PositionedNode {
+  return Boolean(
+    value
+    && typeof value === "object"
+    && typeof (value as PositionedNode).type === "string"
+    && typeof (value as PositionedNode).start === "number"
+    && typeof (value as PositionedNode).end === "number",
+  )
+}
+
+function visitNodes(node: PositionedNode, visit: (node: PositionedNode) => void): void {
+  visit(node)
+  if (node.type.includes("Function")) return
+  for (const value of Object.values(node)) {
+    if (isPositionedNode(value)) visitNodes(value, visit)
+    else if (Array.isArray(value)) {
+      for (const item of value) {
+        if (isPositionedNode(item)) visitNodes(item, visit)
+      }
+    }
+  }
+}
+
+export function transformRepositoryHostContextMaterialization(
+  code: string,
+  parse: (code: string) => unknown,
+): string | undefined {
+  const program = parse(code)
+  if (!isPositionedNode(program)) return
+  const replacements: Array<{ end: number, start: number, value: string }> = []
+  const imports: string[] = []
+  const identifiers = new Set<string>()
+  const namedImports = new Set<string>()
+  const namespaceImports = new Set<string>()
+  let importPosition: number | undefined
+
+  visitNodes(program, (node) => {
+    if (node.type === "Identifier" && typeof node.name === "string") identifiers.add(node.name)
+    if (node.type !== "ImportDeclaration") return
+    const source = node.source
+    if (
+      !isPositionedNode(source)
+      || source.type !== "Literal"
+      || source.value !== "@vite-hub/agent/capabilities"
+      && source.value !== "vite-hub/agent/capabilities"
+    ) return
+    importPosition = Math.min(importPosition ?? node.start, node.start)
+    const specifiers = Array.isArray(node.specifiers) ? node.specifiers : []
+    for (const specifier of specifiers) {
+      if (!isPositionedNode(specifier)) continue
+      const local = specifier.local
+      if (!isPositionedNode(local) || local.type !== "Identifier" || typeof local.name !== "string") continue
+      if (specifier.type === "ImportNamespaceSpecifier") namespaceImports.add(local.name)
+      const imported = specifier.imported
+      if (
+        specifier.type === "ImportSpecifier"
+        && isPositionedNode(imported)
+        && imported.type === "Identifier"
+        && imported.name === "repositoryHostContext"
+      ) namedImports.add(local.name)
+    }
+  })
+  if (!namedImports.size && !namespaceImports.size) return
+
+  visitNodes(program, (node) => {
+    if (node.type !== "CallExpression") return
+    const callee = node.callee
+    const namedCall = isPositionedNode(callee)
+      && callee.type === "Identifier"
+      && typeof callee.name === "string"
+      && namedImports.has(callee.name)
+    const memberCall = isPositionedNode(callee)
+      && callee.type === "MemberExpression"
+      && callee.computed !== true
+      && isPositionedNode(callee.object)
+      && callee.object.type === "Identifier"
+      && typeof callee.object.name === "string"
+      && namespaceImports.has(callee.object.name)
+      && isPositionedNode(callee.property)
+      && callee.property.type === "Identifier"
+      && callee.property.name === "repositoryHostContext"
+    if (!namedCall && !memberCall) return
+    const argument = Array.isArray(node.arguments) ? node.arguments[0] : undefined
+    if (!isPositionedNode(argument) || argument.type !== "ObjectExpression") return
+    const properties = Array.isArray(argument.properties) ? argument.properties : []
+    for (const property of properties) {
+      if (!isPositionedNode(property) || property.type !== "Property" || property.computed === true) continue
+      const key = property.key
+      const name = isPositionedNode(key) && key.type === "Identifier"
+        ? key.name
+        : isPositionedNode(key) && key.type === "Literal"
+          ? key.value
+          : undefined
+      const value = property.value
+      if (name !== "materialize" || !isPositionedNode(value) || value.type !== "Literal" || typeof value.value !== "string") continue
+      let templateName = `__vitehubRepositoryHostContextTemplate${imports.length}`
+      while (identifiers.has(templateName)) templateName += "_"
+      identifiers.add(templateName)
+      const path = markdownTemplateMaterializationPath(value.value)
+      imports.push(`import ${templateName} from ${JSON.stringify(value.value)};`)
+      replacements.push({
+        end: value.end,
+        start: value.start,
+        value: `{ path: ${JSON.stringify(path)}, template: ${templateName} }`,
+      })
+    }
+  })
+
+  if (!replacements.length) return
+  replacements.push({
+    end: importPosition!,
+    start: importPosition!,
+    value: `${imports.join("\n")}\n`,
+  })
+  let transformed = code
+  for (const replacement of replacements.sort((left, right) => right.start - left.start)) {
+    transformed = transformed.slice(0, replacement.start) + replacement.value + transformed.slice(replacement.end)
+  }
+  return transformed
 }
 
 function generatedRuntimeHelpers(): string[] {
@@ -1507,6 +1636,13 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
     },
     async transform(code, id) {
       if (agent === false || !resolved?.root) return
+      const normalizedId = id.split(/[?#]/, 1)[0]!.replace(/\\/g, "/")
+      const agentDefinition = /\.agent\.(?:c|m)?[jt]s$/i.test(normalizedId)
+        || /\/server\/agents\/.*\.(?:c|m)?[jt]s$/i.test(normalizedId)
+      if (agentDefinition) {
+        const materialization = transformRepositoryHostContextMaterialization(code, value => this.parse(value))
+        if (materialization) return materialization
+      }
       if (!isScheduleRegistryId(id) && id !== resolvedScheduleTargetsId) return
       const definitions = discoverScheduledAgentDefinitions(resolved.root)
       return isScheduleRegistryId(id)

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -723,7 +723,6 @@ function isPositionedNode(value: unknown): value is PositionedNode {
 
 function visitNodes(node: PositionedNode, visit: (node: PositionedNode) => void): void {
   visit(node)
-  if (node.type.includes("Function")) return
   for (const value of Object.values(node)) {
     if (isPositionedNode(value)) visitNodes(value, visit)
     else if (Array.isArray(value)) {

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -733,6 +733,69 @@ function visitNodes(node: PositionedNode, visit: (node: PositionedNode) => void)
   }
 }
 
+function addBindingIdentifiers(value: unknown, bindings: Set<string>): void {
+  if (!isPositionedNode(value)) return
+  if (value.type === "Identifier" && typeof value.name === "string") {
+    bindings.add(value.name)
+    return
+  }
+  if (value.type === "Property") {
+    addBindingIdentifiers(value.value, bindings)
+    return
+  }
+  if (value.type === "RestElement") {
+    addBindingIdentifiers(value.argument, bindings)
+    return
+  }
+  if (value.type === "AssignmentPattern") {
+    addBindingIdentifiers(value.left, bindings)
+    return
+  }
+  for (const item of Array.isArray(value.elements) ? value.elements : []) addBindingIdentifiers(item, bindings)
+  for (const property of Array.isArray(value.properties) ? value.properties : []) addBindingIdentifiers(property, bindings)
+}
+
+function scopedBindings(node: PositionedNode): Set<string> {
+  const bindings = new Set<string>()
+  if (node.type.includes("Function")) {
+    addBindingIdentifiers(node.id, bindings)
+    for (const parameter of Array.isArray(node.params) ? node.params : []) addBindingIdentifiers(parameter, bindings)
+  }
+  if (node.type === "CatchClause") addBindingIdentifiers(node.param, bindings)
+  if (node.type === "Program" || node.type === "BlockStatement") {
+    for (const statement of Array.isArray(node.body) ? node.body : []) {
+      if (!isPositionedNode(statement)) continue
+      if (statement.type === "VariableDeclaration") {
+        for (const declaration of Array.isArray(statement.declarations) ? statement.declarations : []) {
+          if (isPositionedNode(declaration)) addBindingIdentifiers(declaration.id, bindings)
+        }
+      }
+      else if (statement.type === "FunctionDeclaration" || statement.type === "ClassDeclaration") {
+        addBindingIdentifiers(statement.id, bindings)
+      }
+    }
+  }
+  return bindings
+}
+
+function visitScopedNodes(
+  node: PositionedNode,
+  shadows: ReadonlySet<string>,
+  visit: (node: PositionedNode, shadows: ReadonlySet<string>) => void,
+): void {
+  const bindings = scopedBindings(node)
+  const nestedShadows = bindings.size ? new Set([...shadows, ...bindings]) : shadows
+  visit(node, nestedShadows)
+  for (const value of Object.values(node)) {
+    if (isPositionedNode(value)) visitScopedNodes(value, nestedShadows, visit)
+    else if (Array.isArray(value)) {
+      for (const item of value) {
+        if (isPositionedNode(item)) visitScopedNodes(item, nestedShadows, visit)
+      }
+    }
+  }
+}
+
 export function transformRepositoryHostContextMaterialization(
   code: string,
   parse: (code: string) => unknown,
@@ -774,13 +837,14 @@ export function transformRepositoryHostContextMaterialization(
   })
   if (!namedImports.size && !namespaceImports.size) return
 
-  visitNodes(program, (node) => {
+  visitScopedNodes(program, new Set(), (node, shadows) => {
     if (node.type !== "CallExpression") return
     const callee = node.callee
     const namedCall = isPositionedNode(callee)
       && callee.type === "Identifier"
       && typeof callee.name === "string"
       && namedImports.has(callee.name)
+      && !shadows.has(callee.name)
     const memberCall = isPositionedNode(callee)
       && callee.type === "MemberExpression"
       && callee.computed !== true
@@ -788,6 +852,7 @@ export function transformRepositoryHostContextMaterialization(
       && callee.object.type === "Identifier"
       && typeof callee.object.name === "string"
       && namespaceImports.has(callee.object.name)
+      && !shadows.has(callee.object.name)
       && isPositionedNode(callee.property)
       && callee.property.type === "Identifier"
       && callee.property.name === "repositoryHostContext"

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -5,7 +5,11 @@ import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { Message } from "chat"
+import { hubMarkdownTemplate } from "@vite-hub/markdown-template/vite"
+import { build } from "vite"
 import { describe, expect, it, vi } from "vitest"
+
+import { resolveAgentCapabilities } from "../src/capability-runtime.ts"
 
 import type { AgentChannelChatRouteStandardSchemaV1 } from "../src/server.ts"
 import type { Adapter, ChatInstance, StreamChunk, WebhookOptions } from "chat"
@@ -192,6 +196,94 @@ function chatWebhookRequest(messageId: number, threadId = 456, text = "hello") {
 }
 
 describe("agent Vite plugin", () => {
+  it("bundles repository context templates into Vite builds", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const root = await mkdtemp(join(import.meta.dirname, ".repository-context-template-"))
+    const agents = join(root, "server", "agents")
+    const entry = join(agents, "reviewer.ts")
+    const template = join(agents, "PULL_REQUEST.template.md")
+    const outfile = join(root, "dist", "agent.mjs")
+    try {
+      await mkdir(agents, { recursive: true })
+      await writeFile(join(root, "package.json"), "{}", "utf8")
+      await writeFile(template, "# Pull request {{ pullRequest.number }}\n", "utf8")
+      await writeFile(entry, [
+        `"use server"`,
+        `import { repositoryHostContext as context } from "@vite-hub/agent/capabilities"`,
+        `const __vitehubRepositoryHostContextTemplate0 = "caller"`,
+        `void __vitehubRepositoryHostContextTemplate0`,
+        `export default context({ materialize: "./PULL_REQUEST.template.md" })`,
+        ``,
+      ].join("\n"), "utf8")
+
+      await build({
+        build: {
+          emptyOutDir: true,
+          lib: { entry, fileName: () => "agent.mjs", formats: ["es"] },
+          minify: false,
+          outDir: join(root, "dist"),
+          rollupOptions: {
+            external: ["@vite-hub/agent/capabilities", "@vite-hub/markdown-template"],
+          },
+        },
+        logLevel: "silent",
+        plugins: [hubAgent({ eval: false }), hubMarkdownTemplate()],
+        root,
+      })
+
+      await rm(template)
+      const output = await readFile(outfile, "utf8")
+      expect(output).toContain("# Pull request {{ pullRequest.number }}")
+      expect(output).toContain('path: "PULL_REQUEST.md"')
+      expect(output).toMatch(/^"use server";/)
+      expect(output).not.toContain("readFile")
+      const bundled = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: unknown }
+      const resolved = await resolveAgentCapabilities({
+        capabilities: [bundled.default as never],
+      }, {
+        capabilities: {},
+        memo: vi.fn(),
+        runtime: "unknown",
+        runtimeConfig: {},
+        waitUntil: vi.fn(),
+      }, {
+        context: {
+          pullRequest: {
+            number: 42,
+            repository: "acme/app",
+          },
+        },
+      }, {
+        fs: {
+          exists: vi.fn(async () => false),
+          glob: vi.fn(async () => []),
+          list: vi.fn(async () => []),
+          materializeSources: vi.fn(async () => ({ bytes: 0, directories: 0, durationMs: 0, files: 0, path: "", sources: [] })),
+          readFile: vi.fn(async () => { throw new Error("missing") }),
+          search: vi.fn(async () => []),
+          stat: vi.fn(async () => { throw new Error("missing") }),
+        },
+        tools: {
+          inspect: vi.fn(() => ({})),
+          none: vi.fn(() => ({})),
+        },
+      } as never, "read", {
+        workspaceDefinition: {
+          name: "review",
+          sources: {},
+        },
+      })
+      expect(resolved.workspaceDefinition?.sources?.["repository-host-context"]).toMatchObject({
+        content: "# Pull request 42",
+        materialize: "build",
+        workspacePath: "PULL_REQUEST.md",
+      })
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  }, 15_000)
+
   it("ignores generated ViteHub files in the Vite dev watcher", async () => {
     const { hubAgent } = await import("../src/vite.ts")
     const plugin = hubAgent()

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -216,7 +216,10 @@ describe("agent Vite plugin", () => {
         ``,
       ].join("\n"), "utf8")
 
-      await build({
+      const runBuild = build as unknown as (config: unknown) => Promise<unknown>
+      const agentPlugin: unknown = hubAgent({ eval: false })
+      const markdownPlugin: unknown = hubMarkdownTemplate()
+      await runBuild({
         build: {
           emptyOutDir: true,
           lib: { entry, fileName: () => "agent.mjs", formats: ["es"] },
@@ -227,7 +230,7 @@ describe("agent Vite plugin", () => {
           },
         },
         logLevel: "silent",
-        plugins: [hubAgent({ eval: false }), hubMarkdownTemplate()],
+        plugins: [agentPlugin, markdownPlugin],
         root,
       })
 
@@ -249,10 +252,22 @@ describe("agent Vite plugin", () => {
       }, {
         context: {
           pullRequest: {
-            number: 42,
-            repository: "acme/app",
+            pullRequest: {
+              apiUrl: "https://api.github.com/repos/acme/app/pulls/42",
+              number: 42,
+              source: {
+                mount: "app",
+                ref: "refs/pull/42/head",
+                repo: "acme/app",
+              },
+            },
+            repository: {
+              fullName: "acme/app",
+              name: "app",
+              owner: "acme",
+            },
           },
-        },
+        } as never,
       }, {
         fs: {
           exists: vi.fn(async () => false),

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -212,6 +212,7 @@ describe("agent Vite plugin", () => {
         `import { repositoryHostContext as context } from "@vite-hub/agent/capabilities"`,
         `const __vitehubRepositoryHostContextTemplate0 = "caller"`,
         `void __vitehubRepositoryHostContextTemplate0`,
+        `export const local = (context: (options: unknown) => unknown) => context({ materialize: "./IGNORED.template.md" })`,
         `export default () => [context({ materialize: "./PULL_REQUEST.template.md" })]`,
         ``,
       ].join("\n"), "utf8")
@@ -238,6 +239,7 @@ describe("agent Vite plugin", () => {
       const output = await readFile(outfile, "utf8")
       expect(output).toContain("# Pull request {{ pullRequest.number }}")
       expect(output).toContain('path: "PULL_REQUEST.md"')
+      expect(output).toContain('materialize: "./IGNORED.template.md"')
       expect(output).toMatch(/^"use server";/)
       expect(output).not.toContain("readFile")
       const bundled = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: () => [unknown] }

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -212,7 +212,7 @@ describe("agent Vite plugin", () => {
         `import { repositoryHostContext as context } from "@vite-hub/agent/capabilities"`,
         `const __vitehubRepositoryHostContextTemplate0 = "caller"`,
         `void __vitehubRepositoryHostContextTemplate0`,
-        `export default context({ materialize: "./PULL_REQUEST.template.md" })`,
+        `export default () => [context({ materialize: "./PULL_REQUEST.template.md" })]`,
         ``,
       ].join("\n"), "utf8")
 
@@ -240,9 +240,9 @@ describe("agent Vite plugin", () => {
       expect(output).toContain('path: "PULL_REQUEST.md"')
       expect(output).toMatch(/^"use server";/)
       expect(output).not.toContain("readFile")
-      const bundled = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: unknown }
+      const bundled = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: () => [unknown] }
       const resolved = await resolveAgentCapabilities({
-        capabilities: [bundled.default as never],
+        capabilities: [bundled.default()[0] as never],
       }, {
         capabilities: {},
         memo: vi.fn(),

--- a/packages/agent/test/repository-host-context.test.ts
+++ b/packages/agent/test/repository-host-context.test.ts
@@ -30,6 +30,24 @@ const emptyWorkspace = () => ({
 })
 
 describe("repositoryHostContext", () => {
+  it("requires the Vite plugin to compile materialization path strings", async () => {
+    const { repositoryHostContext } = await import("../src/capabilities.ts")
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [
+        repositoryHostContext({
+          materialize: "./PULL_REQUEST.template.md",
+        }),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      context: createAgentInvocationContextStore(),
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })).rejects.toThrow("materialize paths require the ViteHub Agent plugin")
+  })
+
   it("records a data-only async record without workspace context files", async () => {
     const { repositoryHostContext } = await import("../src/capabilities.ts")
     const context = createAgentInvocationContextStore()

--- a/packages/agent/test/repository-host-context.test.ts
+++ b/packages/agent/test/repository-host-context.test.ts
@@ -48,6 +48,33 @@ describe("repositoryHostContext", () => {
     })).rejects.toThrow("materialize paths require the ViteHub Agent plugin")
   })
 
+  it("omits materialization when configured resolvers opt out", async () => {
+    const { repositoryHostContext } = await import("../src/capabilities.ts")
+    const workspaceDefinition = {
+      name: "review",
+      sources: {},
+    }
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        repositoryHostContext({
+          materialize: {
+            path: "PULL_REQUEST.md",
+            template: () => "# Pull request",
+          },
+          target: () => false,
+        } as never),
+      ],
+    }, runtime(), {}, emptyWorkspace() as never, "read", {
+      context: createAgentInvocationContextStore(),
+      driverKind: "harness",
+      workspaceDefinition,
+    })
+
+    expect(resolved.workspaceDefinition).toEqual(workspaceDefinition)
+    expect(resolved.workspaceMaterializationPaths).toEqual(["PULL_REQUEST.md"])
+  })
+
   it("records a data-only async record without workspace context files", async () => {
     const { repositoryHostContext } = await import("../src/capabilities.ts")
     const context = createAgentInvocationContextStore()

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -419,6 +419,7 @@ describe("agent public types", () => {
               repository: "acme/app",
             },
           } satisfies RepositoryHostContextValue,
+          materialize: "./PULL_REQUEST.template.md",
         }),
         skills(),
         skills({ path: "skills/agent-browser", source: githubSource({ repo: "vercel/vercel-plugin", root: "skills/agent-browser" }) }),

--- a/packages/markdown-template/src/internal/vite.ts
+++ b/packages/markdown-template/src/internal/vite.ts
@@ -22,6 +22,17 @@ export interface BundledMarkdownTemplateCatalogEntry extends BundledMarkdownTemp
   imports: Record<string, BundledMarkdownTemplate>
 }
 
+export function markdownTemplateMaterializationPath(templatePath: string): string {
+  if (!templatePath.startsWith("./") || !templatePath.endsWith(markdownTemplateFileSuffix) || templatePath.includes("\\")) {
+    throw new TypeError(`[vitehub] Markdown materialization requires a relative ${markdownTemplateFileSuffix} path, received ${JSON.stringify(templatePath)}.`)
+  }
+  const segments = templatePath.slice(2).split("/")
+  if (segments.some(segment => !segment || segment === "." || segment === "..")) {
+    throw new TypeError(`[vitehub] Markdown materialization paths cannot escape or contain ambiguous segments, received ${JSON.stringify(templatePath)}.`)
+  }
+  return templatePath.slice(2, -markdownTemplateFileSuffix.length) + ".md"
+}
+
 function stripMarkdownCode(template: string): string {
   let fence: { marker: string, length: number, listIndented: boolean } | undefined
   let inList = false

--- a/packages/markdown-template/src/vite.ts
+++ b/packages/markdown-template/src/vite.ts
@@ -10,6 +10,7 @@ import {
   markdownTemplateRegistryId,
   markdownTemplateRegistryPath,
   markdownTemplateRuntimeSpecifier,
+  markdownTemplateMaterializationPath,
   bundleMarkdownTemplateImports,
   parseMarkdownTemplateRequest,
   renderMarkdownTemplateCatalogModule,
@@ -17,6 +18,8 @@ import {
   renderMarkdownTemplateModule,
   renderMarkdownTemplateTypes,
 } from "./internal/vite.ts"
+
+export { markdownTemplateMaterializationPath }
 
 import type { BundledMarkdownTemplate, BundledMarkdownTemplateCatalogEntry } from "./internal/vite.ts"
 import type { Plugin } from "vite"

--- a/packages/markdown-template/test/vite.test.ts
+++ b/packages/markdown-template/test/vite.test.ts
@@ -14,7 +14,7 @@ import {
 import { build } from "vite"
 import { afterEach, describe, expect, it } from "vitest"
 
-import { extractMarkdownTemplateImportSpecifiers, parseMarkdownTemplateRequest } from "../src/internal/vite.ts"
+import { extractMarkdownTemplateImportSpecifiers, markdownTemplateMaterializationPath, parseMarkdownTemplateRequest } from "../src/internal/vite.ts"
 import { hubMarkdownTemplate } from "../src/vite.ts"
 
 const tempDirs: string[] = []
@@ -31,6 +31,20 @@ afterEach(async () => {
 })
 
 describe("hubMarkdownTemplate", () => {
+  it("derives safe materialization paths from template names", () => {
+    expect(markdownTemplateMaterializationPath("./PULL_REQUEST.template.md")).toBe("PULL_REQUEST.md")
+    expect(markdownTemplateMaterializationPath("./review/PULL_REQUEST.template.md")).toBe("review/PULL_REQUEST.md")
+    for (const path of [
+      "/PULL_REQUEST.template.md",
+      "../PULL_REQUEST.template.md",
+      "./review/../PULL_REQUEST.template.md",
+      "./PULL_REQUEST.md",
+      ".\\PULL_REQUEST.template.md",
+    ]) {
+      expect(() => markdownTemplateMaterializationPath(path)).toThrow("Markdown materialization")
+    }
+  })
+
   it("leaves explicit Vite queries on direct templates untouched", () => {
     expect(parseMarkdownTemplateRequest("./prompt.template.md?raw")).toBeUndefined()
     expect(parseMarkdownTemplateRequest("./prompt.template.md?url")).toBeUndefined()


### PR DESCRIPTION
Adds a caller-relative Markdown shorthand for repository-host context materialization:

```ts
repositoryHostContext({
  materialize: './PULL_REQUEST.template.md',
})
```

ViteHub now bundles the colocated renderer and materializes `PULL_REQUEST.md`, preserving directories and case while removing only the final `.template`. The public option remains a string; the compiled renderer shape stays internal.

The Vite proof covers an aliased capability import, directive preservation, binding collision avoidance, source-template removal, bundle execution, and the rendered Workspace source. Path tests reject absolute, escaping, ambiguous, and non-template inputs.
