### PR TITLE
feat(agent): infer pull request workspaces

### DIFF
--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -436,7 +436,7 @@ async function preparePullRequestGitSession(
     'if [ -n "${VITEHUB_GIT_AUTH_HEADER:-}" ]; then git config --local http.https://github.com/.extraheader "$VITEHUB_GIT_AUTH_HEADER"; fi',
     `git fetch --depth=100 origin ${fetchRefspecs}`,
     `test "$(git rev-parse refs/vitehub/head)" = ${shellQuote(setup.headSha)} || { echo "[vitehub] fetched pull request head does not match the expected SHA." >&2; exit 1; }`,
-    "git checkout -q --detach refs/vitehub/head",
+    setup.mount ? "git checkout -q --detach refs/vitehub/head" : "git reset -q --mixed refs/vitehub/head",
     ...(baseTrackingRef ? [`git branch -f vitehub-base ${shellQuote(baseTrackingRef)} >/dev/null`] : []),
     "git branch -f vitehub-head HEAD >/dev/null",
   ].join("\n")

--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -436,7 +436,7 @@ async function preparePullRequestGitSession(
     'if [ -n "${VITEHUB_GIT_AUTH_HEADER:-}" ]; then git config --local http.https://github.com/.extraheader "$VITEHUB_GIT_AUTH_HEADER"; fi',
     `git fetch --depth=100 origin ${fetchRefspecs}`,
     `test "$(git rev-parse refs/vitehub/head)" = ${shellQuote(setup.headSha)} || { echo "[vitehub] fetched pull request head does not match the expected SHA." >&2; exit 1; }`,
-    setup.mount ? "git checkout -q --detach refs/vitehub/head" : "git reset -q --mixed refs/vitehub/head",
+    setup.mount ? "git checkout -q --detach refs/vitehub/head" : "git reset -q --hard refs/vitehub/head",
     ...(baseTrackingRef ? [`git branch -f vitehub-base ${shellQuote(baseTrackingRef)} >/dev/null`] : []),
     "git branch -f vitehub-head HEAD >/dev/null",
   ].join("\n")

--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -436,7 +436,7 @@ async function preparePullRequestGitSession(
     'if [ -n "${VITEHUB_GIT_AUTH_HEADER:-}" ]; then git config --local http.https://github.com/.extraheader "$VITEHUB_GIT_AUTH_HEADER"; fi',
     `git fetch --depth=100 origin ${fetchRefspecs}`,
     `test "$(git rev-parse refs/vitehub/head)" = ${shellQuote(setup.headSha)} || { echo "[vitehub] fetched pull request head does not match the expected SHA." >&2; exit 1; }`,
-    setup.mount ? "git checkout -q --detach refs/vitehub/head" : "git reset -q --mixed refs/vitehub/head",
+    "git checkout -q --detach refs/vitehub/head",
     ...(baseTrackingRef ? [`git branch -f vitehub-base ${shellQuote(baseTrackingRef)} >/dev/null`] : []),
     "git branch -f vitehub-head HEAD >/dev/null",
   ].join("\n")

--- a/packages/agent/src/capabilities/git.ts
+++ b/packages/agent/src/capabilities/git.ts
@@ -303,10 +303,11 @@ function safeGitSha(sha: unknown): string | undefined {
   return /^(?:[0-9a-f]{40}|[0-9a-f]{64})$/.test(normalized) ? normalized : undefined
 }
 
-function safeWorkspacePath(path: unknown): string | undefined {
-  if (typeof path !== "string" || !path) return
+function safeWorkspacePath(path: unknown, allowRoot = false): string | undefined {
+  if (typeof path !== "string" || (!path && !allowRoot)) return
   try {
-    return workspacePathFromGitCwd(normalizeCwd(path)) || undefined
+    const workspacePath = workspacePathFromGitCwd(normalizeCwd(path))
+    return workspacePath || (allowRoot ? "" : undefined)
   }
   catch {
     return
@@ -364,16 +365,19 @@ function pullRequestGitSetup(context: { context?: { get(key: string): unknown } 
   if (typeof provider === "string" && provider !== "github") return
 
   const source = isGitRecord(pullRequest.source) ? pullRequest.source : undefined
+  if (source?.checkout === false) return
   const base = isGitRecord(pullRequest.base) ? pullRequest.base : undefined
   const head = isGitRecord(pullRequest.head) ? pullRequest.head : undefined
   const repository = isGitRecord(raw) && isGitRecord(raw.repository) ? raw.repository : undefined
   const repo = safeGitHubRepository(source?.repo)
     || safeGitHubRepository(isGitRecord(raw) ? raw.repository : undefined)
     || safeGitHubRepository(repository?.fullName)
-  const mount = safeWorkspacePath(source?.mount) || safeWorkspacePath(repository?.name)
+  const mount = source && "mount" in source
+    ? safeWorkspacePath(source.mount, true)
+    : safeWorkspacePath(repository?.name)
   const headRef = safeGitRef(source?.ref) || safeGitRef(head?.ref) || safeGitRef(pullRequest.headRef)
   const baseRef = safeGitRef(base?.ref) || safeGitRef(pullRequest.baseRef)
-  if (!repo || !mount || !headRef) return
+  if (!repo || mount === undefined || !headRef) return
   const headSha = safeGitSha(head?.sha) || safeGitSha(pullRequest.headSha)
   if (!headSha) throw new Error("[vitehub] GitHub pull request checkout requires an exact head SHA.")
 
@@ -402,7 +406,7 @@ async function preparePullRequestGitSession(
   const setup = pullRequestGitSetup(context)
   if (!setup || workspacePath !== setup.mount) return false
 
-  const cwd = `/workspace/${setup.mount}`
+  const cwd = setup.mount ? `/workspace/${setup.mount}` : "/workspace"
   const existing = await session.exec("git", ["rev-parse", "--is-inside-work-tree"], gitExecOptions(cwd, timeout))
   if (existing.exitCode === 0) {
     const head = await session.exec("git", ["rev-parse", "HEAD"], gitExecOptions(cwd, timeout))
@@ -420,15 +424,19 @@ async function preparePullRequestGitSession(
   ].map(shellQuote).join(" ")
   const script = [
     "set -eu",
-    `rm -rf -- ${shellQuote(setup.mount)}`,
-    `mkdir -p -- ${shellQuote(setup.mount)}`,
-    `cd -- ${shellQuote(setup.mount)}`,
+    ...(setup.mount
+      ? [
+          `rm -rf -- ${shellQuote(setup.mount)}`,
+          `mkdir -p -- ${shellQuote(setup.mount)}`,
+          `cd -- ${shellQuote(setup.mount)}`,
+        ]
+      : ["cd -- ."]),
     "git init -q",
     `git remote add origin ${shellQuote(setup.remoteUrl)}`,
     'if [ -n "${VITEHUB_GIT_AUTH_HEADER:-}" ]; then git config --local http.https://github.com/.extraheader "$VITEHUB_GIT_AUTH_HEADER"; fi',
     `git fetch --depth=100 origin ${fetchRefspecs}`,
     `test "$(git rev-parse refs/vitehub/head)" = ${shellQuote(setup.headSha)} || { echo "[vitehub] fetched pull request head does not match the expected SHA." >&2; exit 1; }`,
-    "git checkout -q --detach refs/vitehub/head",
+    setup.mount ? "git checkout -q --detach refs/vitehub/head" : "git reset -q --mixed refs/vitehub/head",
     ...(baseTrackingRef ? [`git branch -f vitehub-base ${shellQuote(baseTrackingRef)} >/dev/null`] : []),
     "git branch -f vitehub-head HEAD >/dev/null",
   ].join("\n")

--- a/packages/agent/src/capabilities/repository-host-context.ts
+++ b/packages/agent/src/capabilities/repository-host-context.ts
@@ -99,6 +99,7 @@ export interface PullRequestContextValue extends JsonObject {
     threadId?: string
   }
   source?: JsonObject & {
+    checkout?: boolean
     mount?: string
     ref?: string
     repo?: string

--- a/packages/agent/src/capabilities/repository-host-context.ts
+++ b/packages/agent/src/capabilities/repository-host-context.ts
@@ -364,12 +364,14 @@ function normalizedRun(value: unknown): PullRequestContextValue["run"] | undefin
 
 function normalizedSource(value: unknown): PullRequestContextValue["source"] | undefined {
   if (!isRecord(value)) return
-  const mount = maybeString(value.mount)
+  const checkout = typeof value.checkout === "boolean" ? value.checkout : undefined
+  const mount = typeof value.mount === "string" ? value.mount : undefined
   const ref = maybeString(value.ref)
   const repo = maybeString(value.repo)
-  if (!mount && !ref && !repo) return
+  if (checkout === undefined && mount === undefined && !ref && !repo) return
   return {
-    ...(mount ? { mount } : {}),
+    ...(checkout !== undefined ? { checkout } : {}),
+    ...(mount !== undefined ? { mount } : {}),
     ...(ref ? { ref } : {}),
     ...(repo ? { repo } : {}),
   }

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1866,7 +1866,9 @@ const githubPullRequestCheckout = `set -eu
 mkdir -p -- "$PR_WORKSPACE_PATH"
 cd -- "$PR_WORKSPACE_PATH"
 git init --quiet
-git config credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f'
+if [ -n "\${GH_TOKEN:-}" ]; then
+  git config credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f'
+fi
 git remote remove origin 2>/dev/null || true
 git remote add origin "https://github.com/$PR_REPOSITORY.git"
 git fetch --quiet --no-tags origin "$PR_SOURCE_REF"
@@ -1883,12 +1885,12 @@ function githubPullRequestBox<TRuntimeConfig extends AgentRuntimeConfig>(
     env: {
       GH_TOKEN: async (context) => {
         const value = githubPullRequestContextValue(context)
-        return await githubPullRequestMetadataToken(app, context, githubPullRequestInstallationId(value))
+        return await githubPullRequestMetadataToken(app, context, githubPullRequestInstallationId(value)) || ""
       },
       PR_HEAD_SHA: context => String(githubPullRequestContextValue(context).head!.sha),
       PR_REPOSITORY: context => String(githubPullRequestContextValue(context).source!.repo),
       PR_SOURCE_REF: context => String(githubPullRequestContextValue(context).source!.ref),
-      PR_WORKSPACE_PATH: workspace.mount || ".",
+      PR_WORKSPACE_PATH: workspace.mount ? `workspace/${workspace.mount}` : "workspace",
     },
     requires: [{
       args: ["-c", githubPullRequestCheckout],

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1,6 +1,7 @@
 import { createHash, createSign } from "node:crypto"
 import { CHAT_FINISH_EXTENSION_CONTEXT_KEY } from "./chat-trigger.ts"
 import { readPullRequestContext } from "./capabilities/repository-host-context.ts"
+import { defineCapability } from "./capability-runtime.ts"
 import {
   deliveryArtifactAttachments,
   deliveryArtifactMarkdownReferencePaths,
@@ -232,6 +233,7 @@ export interface GitHubPullRequestRunContext {
     metadata?: GitHubPullRequestMetadata
     number: number
     source: {
+      checkout?: boolean
       mount: string
       ref: string
       repo: string
@@ -316,6 +318,9 @@ export interface GitHubPullRequestCommentEventOptions<TRuntimeConfig extends Age
   reply?: boolean | AgentChannelDeliveryFinishEffect
   sourceMount?: string
   threadId?: string
+  workspace?: boolean | {
+    mount?: string
+  }
 }
 
 export interface GitHubChannelOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>
@@ -368,6 +373,40 @@ function maybeString(value: unknown): string | undefined {
 
 function maybeNumber(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+interface GitHubPullRequestWorkspacePolicy {
+  enabled: boolean
+  mount: string
+}
+
+function normalizeGitHubPullRequestWorkspaceMount(mount: string): string {
+  const normalized = mount.replace(/\\/g, "/").replace(/^\/+|\/+$/g, "")
+  const parts = normalized.split("/").filter(Boolean)
+  if (mount.startsWith("/") || /^[A-Za-z]:[\\/]/.test(mount) || parts.some(part => part === "." || part === "..") || parts[0] === ".git" || parts[0] === ".vitehub") {
+    throw new TypeError("[vitehub] GitHub pull request workspace mount must stay inside the Workspace.")
+  }
+  return parts.join("/")
+}
+
+function githubPullRequestWorkspacePolicy(
+  options: GitHubPullRequestCommentEventOptions,
+): GitHubPullRequestWorkspacePolicy {
+  if (options.workspace === false) {
+    return {
+      enabled: false,
+      mount: options.sourceMount ?? "",
+    }
+  }
+  const mount = options.workspace === true
+    ? ""
+    : typeof options.workspace === "object"
+      ? options.workspace.mount ?? ""
+      : options.sourceMount ?? "portal"
+  return {
+    enabled: true,
+    mount: normalizeGitHubPullRequestWorkspaceMount(mount),
+  }
 }
 
 function maybeStrings(value: unknown): string[] | undefined {
@@ -634,6 +673,7 @@ function githubPullRequestRunContext(
   metadata: GitHubPullRequestMetadataFields = {},
 ): GitHubPullRequestRunContext {
   const runId = command.deliveryId || `github:${command.repository}#${command.issueNumber}:comment:${command.commentId}`
+  const workspace = githubPullRequestWorkspacePolicy(options)
   const labels = maybeStrings(Array.isArray(payload?.issue?.labels)
     ? payload.issue.labels.map(label => isRecord(label) ? maybeString(label.name) : undefined)
     : undefined)
@@ -647,7 +687,8 @@ function githubPullRequestRunContext(
       ...(labels ? { labels } : {}),
       number: command.issueNumber,
       source: {
-        mount: options.sourceMount || command.repo,
+        ...(!workspace.enabled ? { checkout: false } : {}),
+        mount: workspace.enabled ? workspace.mount : options.sourceMount ?? command.repo,
         ref: `refs/pull/${command.issueNumber}/head`,
         repo: command.repository,
       },
@@ -1779,6 +1820,84 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
   }
 }
 
+function githubPullRequestContextValue(input: GitHubPullRequestReadInvocation): PullRequestContextValue {
+  const value = pullRequest.read(input)
+  if (!value.source?.repo) throw new Error("[vitehub] GitHub pull request workspace requires a repository source.")
+  if (!value.source.ref) throw new Error("[vitehub] GitHub pull request workspace requires a source ref.")
+  if (!value.head?.sha) throw new Error("[vitehub] GitHub pull request workspace requires the exact head SHA.")
+  return value
+}
+
+function githubPullRequestInstallationId(value: PullRequestContextValue): number | undefined {
+  const installationId = value.trigger?.installationId
+  if (typeof installationId === "number") return installationId
+  if (typeof installationId !== "string" || !installationId) return
+  const parsed = Number(installationId)
+  return Number.isFinite(parsed) ? parsed : undefined
+}
+
+function githubPullRequestWorkspaceCapability<TRuntimeConfig extends AgentRuntimeConfig>(
+  workspace: GitHubPullRequestWorkspacePolicy | undefined,
+  app: true | GitHubAppOptions<TRuntimeConfig> | undefined,
+): AgentCapabilityDefinition<TRuntimeConfig> | undefined {
+  if (!workspace?.enabled) return
+  return defineCapability({
+    id: "github-pull-request-workspace",
+    async workspace(context) {
+      const value = githubPullRequestContextValue(context)
+      const token = await githubPullRequestMetadataToken(app, context, githubPullRequestInstallationId(value))
+      const { github: githubSource } = await import("@vite-hub/workspace")
+      return {
+        sources: {
+          github: githubSource({
+            ...(token ? { auth: token } : {}),
+            materialize: "build",
+            mount: { path: workspace.mount },
+            ref: value.head!.sha!,
+            repo: value.source!.repo!,
+          }),
+        },
+      }
+    },
+  })
+}
+
+const githubPullRequestCheckout = `set -eu
+mkdir -p -- "$PR_WORKSPACE_PATH"
+cd -- "$PR_WORKSPACE_PATH"
+git init --quiet
+git config credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f'
+git remote remove origin 2>/dev/null || true
+git remote add origin "https://github.com/$PR_REPOSITORY.git"
+git fetch --quiet --no-tags origin "$PR_SOURCE_REF"
+test "$(git rev-parse FETCH_HEAD)" = "$PR_HEAD_SHA"
+git reset --mixed "$PR_HEAD_SHA"
+`
+
+function githubPullRequestBox<TRuntimeConfig extends AgentRuntimeConfig>(
+  workspace: GitHubPullRequestWorkspacePolicy | undefined,
+  app: true | GitHubAppOptions<TRuntimeConfig> | undefined,
+): AgentChannelDefinition<TRuntimeConfig>["box"] | undefined {
+  if (!workspace?.enabled) return
+  return {
+    env: {
+      GH_TOKEN: async (context) => {
+        const value = githubPullRequestContextValue(context)
+        return await githubPullRequestMetadataToken(app, context, githubPullRequestInstallationId(value))
+      },
+      PR_HEAD_SHA: context => String(githubPullRequestContextValue(context).head!.sha),
+      PR_REPOSITORY: context => String(githubPullRequestContextValue(context).source!.repo),
+      PR_SOURCE_REF: context => String(githubPullRequestContextValue(context).source!.ref),
+      PR_WORKSPACE_PATH: workspace.mount || ".",
+    },
+    requires: [{
+      args: ["-c", githubPullRequestCheckout],
+      command: "sh",
+      name: "GitHub pull request checkout",
+    }],
+  }
+}
+
 export function defineChannel<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
   kind: string,
   options: AgentChannelDefinitionOptions<TRuntimeConfig> = {},
@@ -1815,6 +1934,10 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
 ): AgentChannelDefinition<TRuntimeConfig> {
   const { app: appOptions, pullRequest, ...channelOptions } = options
   const app = githubAppOptions(appOptions)
+  const pullRequestOptions = pullRequest === true ? {} : pullRequest || {}
+  const workspace = pullRequest ? githubPullRequestWorkspacePolicy(pullRequestOptions) : undefined
+  const workspaceCapability = githubPullRequestWorkspaceCapability(workspace, appOptions)
+  const box = githubPullRequestBox(workspace, appOptions)
   const appEffects: AgentChannelDeliveryEffects<TRuntimeConfig> | undefined = appOptions
     ? githubPullRequestEffects<TRuntimeConfig>({
         apiBaseUrl: app?.apiBaseUrl,
@@ -1827,6 +1950,11 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
     : undefined
   return defineChannel("github", {
     ...channelOptions,
+    ...(box ? { box } : {}),
+    capabilities: [
+      ...(workspaceCapability ? [workspaceCapability] : []),
+      ...channelOptions.capabilities || [],
+    ],
     effects: appEffects ? { ...appEffects, ...options.effects } as AgentChannelDeliveryEffects<TRuntimeConfig> : options.effects,
     messages: false,
     triggers: {

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1851,7 +1851,7 @@ function githubPullRequestWorkspaceCapability<TRuntimeConfig extends AgentRuntim
         sources: {
           vitehubGitHubPullRequest: githubSource({
             ...(token ? { auth: token } : {}),
-            materialize: "build",
+            materialize: "lazy",
             mount: { path: workspace.mount },
             ref: value.head!.sha!,
             repo: value.source!.repo!,

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1862,44 +1862,6 @@ function githubPullRequestWorkspaceCapability<TRuntimeConfig extends AgentRuntim
   })
 }
 
-const githubPullRequestCheckout = `set -eu
-mkdir -p -- "$PR_WORKSPACE_PATH"
-cd -- "$PR_WORKSPACE_PATH"
-git init --quiet
-if [ -n "\${GH_TOKEN:-}" ]; then
-  git config credential.helper '!f() { echo username=x-access-token; echo "password=$GH_TOKEN"; }; f'
-fi
-git remote remove origin 2>/dev/null || true
-git remote add origin "https://github.com/$PR_REPOSITORY.git"
-git fetch --quiet --no-tags origin "$PR_SOURCE_REF"
-test "$(git rev-parse FETCH_HEAD)" = "$PR_HEAD_SHA"
-git reset --mixed "$PR_HEAD_SHA"
-`
-
-function githubPullRequestBox<TRuntimeConfig extends AgentRuntimeConfig>(
-  workspace: GitHubPullRequestWorkspacePolicy | undefined,
-  app: true | GitHubAppOptions<TRuntimeConfig> | undefined,
-): AgentChannelDefinition<TRuntimeConfig>["box"] | undefined {
-  if (!workspace?.enabled) return
-  return {
-    env: {
-      GH_TOKEN: async (context) => {
-        const value = githubPullRequestContextValue(context)
-        return await githubPullRequestMetadataToken(app, context, githubPullRequestInstallationId(value)) || ""
-      },
-      PR_HEAD_SHA: context => String(githubPullRequestContextValue(context).head!.sha),
-      PR_REPOSITORY: context => String(githubPullRequestContextValue(context).source!.repo),
-      PR_SOURCE_REF: context => String(githubPullRequestContextValue(context).source!.ref),
-      PR_WORKSPACE_PATH: workspace.mount ? `workspace/${workspace.mount}` : "workspace",
-    },
-    requires: [{
-      args: ["-c", githubPullRequestCheckout],
-      command: "sh",
-      name: "GitHub pull request checkout",
-    }],
-  }
-}
-
 export function defineChannel<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
   kind: string,
   options: AgentChannelDefinitionOptions<TRuntimeConfig> = {},
@@ -1939,7 +1901,6 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
   const pullRequestOptions = pullRequest === true ? {} : pullRequest || {}
   const workspace = pullRequest ? githubPullRequestWorkspacePolicy(pullRequestOptions) : undefined
   const workspaceCapability = githubPullRequestWorkspaceCapability(workspace, appOptions)
-  const box = githubPullRequestBox(workspace, appOptions)
   const appEffects: AgentChannelDeliveryEffects<TRuntimeConfig> | undefined = appOptions
     ? githubPullRequestEffects<TRuntimeConfig>({
         apiBaseUrl: app?.apiBaseUrl,
@@ -1952,7 +1913,6 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
     : undefined
   return defineChannel("github", {
     ...channelOptions,
-    ...(box ? { box } : {}),
     capabilities: [
       ...(workspaceCapability ? [workspaceCapability] : []),
       ...channelOptions.capabilities || [],

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1849,7 +1849,7 @@ function githubPullRequestWorkspaceCapability<TRuntimeConfig extends AgentRuntim
       const { github: githubSource } = await import("@vite-hub/workspace")
       return {
         sources: {
-          github: githubSource({
+          vitehubGitHubPullRequest: githubSource({
             ...(token ? { auth: token } : {}),
             materialize: "build",
             mount: { path: workspace.mount },

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -975,6 +975,20 @@ function normalizeAgentChannels<TRuntimeConfig extends AgentRuntimeConfig>(
   return channels || (inputs as AgentChannels<TRuntimeConfig>)
 }
 
+function capabilitiesContributeWorkspace(capabilities: unknown): boolean {
+  return Array.isArray(capabilities)
+    && normalizeCapabilities(capabilities).some(capability => Boolean(capability.workspace))
+}
+
+function agentContributesWorkspace(options: {
+  capabilities?: unknown
+  channels?: AgentChannels
+}): boolean {
+  if (capabilitiesContributeWorkspace(options.capabilities)) return true
+  return Object.values(options.channels || {})
+    .some(channel => capabilitiesContributeWorkspace(channel.capabilities))
+}
+
 function defineBaseAgent<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
@@ -1197,9 +1211,20 @@ function createWorkspaceAgentDefinition<
 }
 
 export const defineAgent: DefineAgent = ((options: unknown) => {
-  return isWorkspaceAgentOptions(options)
-    ? createWorkspaceAgentDefinition(options)
-    : defineBaseAgent(options as never)
+  const agentOptions = options as AgentSettings
+  const channels = normalizeAgentChannels(agentOptions.channels)
+  const normalizedOptions = channels === agentOptions.channels
+    ? agentOptions
+    : { ...agentOptions, channels }
+  if (isWorkspaceAgentOptions(normalizedOptions)) {
+    return createWorkspaceAgentDefinition(normalizedOptions)
+  }
+  return agentContributesWorkspace({
+    capabilities: normalizedOptions.capabilities,
+    channels,
+  })
+    ? createWorkspaceAgentDefinition({ ...normalizedOptions, workspace: {} })
+    : defineBaseAgent(normalizedOptions as never)
 }) as DefineAgent
 
 export async function resolveAgent<TContext extends AgentRuntimeContext>(
@@ -1525,7 +1550,8 @@ async function createAgentInvocationContext<
           run: context.run,
         })
       : []
-    const channelCapabilities = activeAgentChannel(definition?.channels, invocationContext, context.run)?.channel.capabilities || []
+    const activeChannel = activeAgentChannel(definition?.channels, invocationContext, context.run)?.channel
+    const channelCapabilities = activeChannel?.capabilities || []
     const resolvedCapabilityDefinitions = normalizeCapabilities([
       ...invocationResolvedCapabilities,
       ...(definition?.capabilities || []),
@@ -1537,7 +1563,20 @@ async function createAgentInvocationContext<
       hasWorkspace: Boolean(workspaceOptions),
       ...(workspaceOptions ? { workspaceMode } : {}),
     })
-    const boxDefinition = definition?.box
+    const channelBox = activeChannel?.box
+    const boxDefinition = definition?.box && channelBox
+      ? {
+          ...definition.box,
+          env: {
+            ...channelBox.env,
+            ...definition.box.env,
+          },
+          requires: [
+            ...(channelBox.requires || []),
+            ...(definition.box.requires || []),
+          ],
+        }
+      : definition?.box
     if (boxDefinition && workspaceOptions && (boxDefinition.cwd !== undefined || boxDefinition.checkout !== undefined)) {
       throw new Error("[vitehub] defineAgent({ box, workspace }) cannot combine a Workspace with Box cwd or checkout because both own the same working tree. Remove cwd/checkout and let Workspace materialize into the Box.")
     }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1563,20 +1563,7 @@ async function createAgentInvocationContext<
       hasWorkspace: Boolean(workspaceOptions),
       ...(workspaceOptions ? { workspaceMode } : {}),
     })
-    const channelBox = activeChannel?.box
-    const boxDefinition = definition?.box && channelBox
-      ? {
-          ...definition.box,
-          env: {
-            ...channelBox.env,
-            ...definition.box.env,
-          },
-          requires: [
-            ...(channelBox.requires || []),
-            ...(definition.box.requires || []),
-          ],
-        }
-      : definition?.box
+    const boxDefinition = definition?.box
     if (boxDefinition && workspaceOptions && (boxDefinition.cwd !== undefined || boxDefinition.checkout !== undefined)) {
       throw new Error("[vitehub] defineAgent({ box, workspace }) cannot combine a Workspace with Box cwd or checkout because both own the same working tree. Remove cwd/checkout and let Workspace materialize into the Box.")
     }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -980,6 +980,13 @@ function capabilitiesContributeWorkspace(capabilities: unknown): boolean {
     && normalizeCapabilities(capabilities).some(capability => Boolean(capability.workspace))
 }
 
+function capabilitiesRequireWritableWorkspace(capabilities: unknown): boolean {
+  return Array.isArray(capabilities)
+    && normalizeCapabilities(capabilities).some(capability =>
+      capability.requires?.some(requirement => requirement.workspace?.mode === "write"),
+    )
+}
+
 function agentContributesWorkspace(options: {
   capabilities?: unknown
   channels?: AgentChannels
@@ -987,6 +994,15 @@ function agentContributesWorkspace(options: {
   if (capabilitiesContributeWorkspace(options.capabilities)) return true
   return Object.values(options.channels || {})
     .some(channel => capabilitiesContributeWorkspace(channel.capabilities))
+}
+
+function agentRequiresWritableWorkspace(options: {
+  capabilities?: unknown
+  channels?: AgentChannels
+}): boolean {
+  if (capabilitiesRequireWritableWorkspace(options.capabilities)) return true
+  return Object.values(options.channels || {})
+    .some(channel => capabilitiesRequireWritableWorkspace(channel.capabilities))
 }
 
 function defineBaseAgent<
@@ -1223,7 +1239,17 @@ export const defineAgent: DefineAgent = ((options: unknown) => {
     capabilities: normalizedOptions.capabilities,
     channels,
   })
-    ? createWorkspaceAgentDefinition({ ...normalizedOptions, workspace: {} })
+    ? createWorkspaceAgentDefinition({
+        ...normalizedOptions,
+        workspace: {
+          mode: agentRequiresWritableWorkspace({
+            capabilities: normalizedOptions.capabilities,
+            channels,
+          })
+            ? "write"
+            : "read",
+        },
+      })
     : defineBaseAgent(normalizedOptions as never)
 }) as DefineAgent
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1372,7 +1372,6 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
 
 export interface AgentChannelDefinition<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   adapter?: AgentChatPlatformResolver<TRuntimeConfig>
-  box?: Pick<BoxDefinition<AgentRunCallbackContext<TRuntimeConfig>>, "env" | "requires">
   capabilities?: readonly AgentCapabilityDefinition<TRuntimeConfig>[]
   effects?: AgentChannelDeliveryEffects<TRuntimeConfig>
   identity?: IdentityResolver

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1372,6 +1372,7 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
 
 export interface AgentChannelDefinition<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   adapter?: AgentChatPlatformResolver<TRuntimeConfig>
+  box?: Pick<BoxDefinition<AgentRunCallbackContext<TRuntimeConfig>>, "env" | "requires">
   capabilities?: readonly AgentCapabilityDefinition<TRuntimeConfig>[]
   effects?: AgentChannelDeliveryEffects<TRuntimeConfig>
   identity?: IdentityResolver

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -154,29 +154,30 @@ describe("agent channels", () => {
     if (typeof defaultWorkspace !== "function") throw new Error("Missing default pull request Workspace contribution.")
     const contribution = await defaultWorkspace(context as never)
     if (!contribution) throw new Error("Missing default pull request Workspace source.")
-    expect(contribution.sources?.github).toMatchObject({
+    expect(contribution.sources?.vitehubGitHubPullRequest).toMatchObject({
       materialize: "build",
       mount: { path: "portal" },
     })
+    expect(contribution.sources).not.toHaveProperty("github")
     const rootChannel = github({ pullRequest: { workspace: true } })
     const rootWorkspace = rootChannel.capabilities?.find(capability => capability.id === "github-pull-request-workspace")?.workspace
     if (typeof rootWorkspace !== "function") throw new Error("Missing root pull request Workspace contribution.")
     await expect(rootWorkspace(context as never)).resolves.toMatchObject({
-      sources: { github: { mount: { path: "" } } },
+      sources: { vitehubGitHubPullRequest: { mount: { path: "" } } },
     })
 
     const customChannel = github({ pullRequest: { workspace: { mount: "repository" } } })
     const customWorkspace = customChannel.capabilities?.find(capability => capability.id === "github-pull-request-workspace")?.workspace
     if (typeof customWorkspace !== "function") throw new Error("Missing custom pull request Workspace contribution.")
     await expect(customWorkspace(context as never)).resolves.toMatchObject({
-      sources: { github: { mount: { path: "repository" } } },
+      sources: { vitehubGitHubPullRequest: { mount: { path: "repository" } } },
     })
 
     const sourceMountChannel = github({ pullRequest: { sourceMount: "legacy-repository" } })
     const sourceMountWorkspace = sourceMountChannel.capabilities?.find(capability => capability.id === "github-pull-request-workspace")?.workspace
     if (typeof sourceMountWorkspace !== "function") throw new Error("Missing source-mount pull request Workspace contribution.")
     await expect(sourceMountWorkspace(context as never)).resolves.toMatchObject({
-      sources: { github: { mount: { path: "legacy-repository" } } },
+      sources: { vitehubGitHubPullRequest: { mount: { path: "legacy-repository" } } },
     })
 
     const disabledChannel = github({ pullRequest: { workspace: false } })

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -158,32 +158,32 @@ describe("agent channels", () => {
       materialize: "build",
       mount: { path: "portal" },
     })
-    expect(defaultChannel.box?.env?.PR_WORKSPACE_PATH).toBe("workspace/portal")
-    expect(defaultChannel.box?.requires).toEqual([expect.objectContaining({
-      args: ["-c", expect.stringContaining('if [ -n "${GH_TOKEN:-}" ]; then')],
-      command: "sh",
-      name: "GitHub pull request checkout",
-    })])
-    expect(defaultChannel.box?.requires).toEqual([expect.objectContaining({
-      args: ["-c", expect.stringContaining('test "$(git rev-parse FETCH_HEAD)" = "$PR_HEAD_SHA"')],
-    })])
-
     const rootChannel = github({ pullRequest: { workspace: true } })
-    expect(rootChannel.box?.env?.PR_WORKSPACE_PATH).toBe("workspace")
+    const rootWorkspace = rootChannel.capabilities?.find(capability => capability.id === "github-pull-request-workspace")?.workspace
+    if (typeof rootWorkspace !== "function") throw new Error("Missing root pull request Workspace contribution.")
+    await expect(rootWorkspace(context as never)).resolves.toMatchObject({
+      sources: { github: { mount: { path: "" } } },
+    })
 
     const customChannel = github({ pullRequest: { workspace: { mount: "repository" } } })
-    expect(customChannel.box?.env?.PR_WORKSPACE_PATH).toBe("workspace/repository")
+    const customWorkspace = customChannel.capabilities?.find(capability => capability.id === "github-pull-request-workspace")?.workspace
+    if (typeof customWorkspace !== "function") throw new Error("Missing custom pull request Workspace contribution.")
+    await expect(customWorkspace(context as never)).resolves.toMatchObject({
+      sources: { github: { mount: { path: "repository" } } },
+    })
 
     const sourceMountChannel = github({ pullRequest: { sourceMount: "legacy-repository" } })
-    expect(sourceMountChannel.box?.env?.PR_WORKSPACE_PATH).toBe("workspace/legacy-repository")
+    const sourceMountWorkspace = sourceMountChannel.capabilities?.find(capability => capability.id === "github-pull-request-workspace")?.workspace
+    if (typeof sourceMountWorkspace !== "function") throw new Error("Missing source-mount pull request Workspace contribution.")
+    await expect(sourceMountWorkspace(context as never)).resolves.toMatchObject({
+      sources: { github: { mount: { path: "legacy-repository" } } },
+    })
 
     const disabledChannel = github({ pullRequest: { workspace: false } })
     expect(disabledChannel.capabilities).toEqual([])
-    expect(disabledChannel.box).toBeUndefined()
 
     const nonPullRequestChannel = github()
     expect(nonPullRequestChannel.capabilities).toEqual([])
-    expect(nonPullRequestChannel.box).toBeUndefined()
   })
 
   it("rejects pull request workspace mounts outside the Workspace", async () => {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -123,6 +123,74 @@ describe("agent channels", () => {
     expect(() => pullRequest.read({ context: { get: () => undefined } })).toThrow("requires pull request invocation context")
   })
 
+  it("configures pull request workspaces with portal, root, custom, and disabled policies", async () => {
+    const { github } = await import("../src/channels.ts")
+    const pullRequestContext = {
+      pullRequest: {
+        apiUrl: "https://api.github.test/repos/acme/app/pulls/42",
+        head: { ref: "feature", sha: "a".repeat(40) },
+        number: 42,
+        source: { mount: "portal", ref: "refs/pull/42/head", repo: "acme/app" },
+      },
+      repository: { fullName: "acme/app", name: "app", owner: "acme" },
+      run: { messageId: "99", origin: "github-pull-request-comment", runId: "github:acme/app#42:comment:99", threadId: "pr-42" },
+      trigger: {
+        action: "created",
+        actor: { login: "mona" },
+        args: "",
+        command: "/review",
+        comment: { id: 99 },
+        event: "issue_comment",
+      },
+    }
+    const context = {
+      context: {
+        get: (key: string) => key === "pullRequest" ? pullRequestContext : undefined,
+      },
+    }
+
+    const defaultChannel = github({ pullRequest: true })
+    const defaultWorkspace = defaultChannel.capabilities?.find(capability => capability.id === "github-pull-request-workspace")?.workspace
+    if (typeof defaultWorkspace !== "function") throw new Error("Missing default pull request Workspace contribution.")
+    const contribution = await defaultWorkspace(context as never)
+    if (!contribution) throw new Error("Missing default pull request Workspace source.")
+    expect(contribution.sources?.github).toMatchObject({
+      materialize: "build",
+      mount: { path: "portal" },
+    })
+    expect(defaultChannel.box?.env?.PR_WORKSPACE_PATH).toBe("portal")
+    expect(defaultChannel.box?.requires).toEqual([expect.objectContaining({
+      args: ["-c", expect.stringContaining('test "$(git rev-parse FETCH_HEAD)" = "$PR_HEAD_SHA"')],
+      command: "sh",
+      name: "GitHub pull request checkout",
+    })])
+
+    const rootChannel = github({ pullRequest: { workspace: true } })
+    expect(rootChannel.box?.env?.PR_WORKSPACE_PATH).toBe(".")
+
+    const customChannel = github({ pullRequest: { workspace: { mount: "repository" } } })
+    expect(customChannel.box?.env?.PR_WORKSPACE_PATH).toBe("repository")
+
+    const sourceMountChannel = github({ pullRequest: { sourceMount: "legacy-repository" } })
+    expect(sourceMountChannel.box?.env?.PR_WORKSPACE_PATH).toBe("legacy-repository")
+
+    const disabledChannel = github({ pullRequest: { workspace: false } })
+    expect(disabledChannel.capabilities).toEqual([])
+    expect(disabledChannel.box).toBeUndefined()
+
+    const nonPullRequestChannel = github()
+    expect(nonPullRequestChannel.capabilities).toEqual([])
+    expect(nonPullRequestChannel.box).toBeUndefined()
+  })
+
+  it("rejects pull request workspace mounts outside the Workspace", async () => {
+    const { github } = await import("../src/channels.ts")
+    expect(() => github({ pullRequest: { workspace: { mount: "../portal" } } }))
+      .toThrow("workspace mount must stay inside the Workspace")
+    expect(() => github({ pullRequest: { workspace: { mount: "C:\\portal" } } }))
+      .toThrow("workspace mount must stay inside the Workspace")
+  })
+
   it("creates Discord adapters from provider defaults", async () => {
     vi.resetModules()
     const createDiscordAdapter = vi.fn(() => ({ name: "discord" }))
@@ -479,6 +547,7 @@ describe("agent channels", () => {
           files: [{ filename: "src/app.ts", status: "modified" }],
           head: { ref: "feature", repo: "acme/fork", sha: "head-sha" },
           number: 42,
+          source: { mount: "portal", ref: "refs/pull/42/head", repo: "acme/app" },
         },
       })
       expect(fetcher.mock.calls.map(([url]) => String(url))).not.toContain("https://api.github.test/app/installations/123/access_tokens")
@@ -487,6 +556,37 @@ describe("agent channels", () => {
       if (previousToken === undefined) delete process.env.VITEHUB_GITHUB_TOKEN
       else process.env.VITEHUB_GITHUB_TOKEN = previousToken
     }
+  })
+
+  it("marks disabled pull request workspaces in invocation context", async () => {
+    const { github } = await import("../src/channels.ts")
+    const channel = github({
+      app: {
+        fetch: (async () => Response.json({
+          base: { ref: "main", repo: { full_name: "acme/app" }, sha: "base-sha" },
+          head: { ref: "feature", repo: { full_name: "acme/fork" }, sha: "head-sha" },
+        })) as typeof fetch,
+      },
+      pullRequest: { workspace: false },
+    })
+    const trigger = channel.triggers?.webhook
+    if (!trigger) throw new Error("Missing GitHub webhook trigger.")
+
+    const result = await trigger.invoke({
+      capabilities: [],
+      channel,
+      trigger: { channelId: "github", id: "github.webhook", name: "webhook", source: "channel" },
+    } as never, { payload: githubIssueCommentPayload() })
+    if (result instanceof Response) throw new Error("Expected GitHub webhook invocation.")
+
+    expect(result.input.context?.pullRequest).toMatchObject({
+      pullRequest: {
+        source: {
+          checkout: false,
+          mount: "app",
+        },
+      },
+    })
   })
 
   it("invokes GitHub PR dev trigger from context and raw payload", async () => {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -158,21 +158,24 @@ describe("agent channels", () => {
       materialize: "build",
       mount: { path: "portal" },
     })
-    expect(defaultChannel.box?.env?.PR_WORKSPACE_PATH).toBe("portal")
+    expect(defaultChannel.box?.env?.PR_WORKSPACE_PATH).toBe("workspace/portal")
     expect(defaultChannel.box?.requires).toEqual([expect.objectContaining({
-      args: ["-c", expect.stringContaining('test "$(git rev-parse FETCH_HEAD)" = "$PR_HEAD_SHA"')],
+      args: ["-c", expect.stringContaining('if [ -n "${GH_TOKEN:-}" ]; then')],
       command: "sh",
       name: "GitHub pull request checkout",
     })])
+    expect(defaultChannel.box?.requires).toEqual([expect.objectContaining({
+      args: ["-c", expect.stringContaining('test "$(git rev-parse FETCH_HEAD)" = "$PR_HEAD_SHA"')],
+    })])
 
     const rootChannel = github({ pullRequest: { workspace: true } })
-    expect(rootChannel.box?.env?.PR_WORKSPACE_PATH).toBe(".")
+    expect(rootChannel.box?.env?.PR_WORKSPACE_PATH).toBe("workspace")
 
     const customChannel = github({ pullRequest: { workspace: { mount: "repository" } } })
-    expect(customChannel.box?.env?.PR_WORKSPACE_PATH).toBe("repository")
+    expect(customChannel.box?.env?.PR_WORKSPACE_PATH).toBe("workspace/repository")
 
     const sourceMountChannel = github({ pullRequest: { sourceMount: "legacy-repository" } })
-    expect(sourceMountChannel.box?.env?.PR_WORKSPACE_PATH).toBe("legacy-repository")
+    expect(sourceMountChannel.box?.env?.PR_WORKSPACE_PATH).toBe("workspace/legacy-repository")
 
     const disabledChannel = github({ pullRequest: { workspace: false } })
     expect(disabledChannel.capabilities).toEqual([])

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -155,7 +155,7 @@ describe("agent channels", () => {
     const contribution = await defaultWorkspace(context as never)
     if (!contribution) throw new Error("Missing default pull request Workspace source.")
     expect(contribution.sources?.vitehubGitHubPullRequest).toMatchObject({
-      materialize: "build",
+      materialize: "lazy",
       mount: { path: "portal" },
     })
     expect(contribution.sources).not.toHaveProperty("github")

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -89,7 +89,7 @@ describe("agent channels", () => {
           files: [{ additions: 5, deletions: 2, filename: "src/app.ts", status: "modified" }],
           labels: ["review"],
           number: 42,
-          source: { mount: "app", ref: "refs/pull/42/head", repo: "acme/app" },
+          source: { checkout: false, mount: "", ref: "refs/pull/42/head", repo: "acme/app" },
           title: "Improve app",
         },
         repository: { fullName: "acme/app", name: "app", owner: "acme" },
@@ -117,7 +117,7 @@ describe("agent channels", () => {
       number: 42,
       provider: "github",
       repository: "acme/app",
-      source: { mount: "app", ref: "refs/pull/42/head", repo: "acme/app" },
+      source: { checkout: false, mount: "", ref: "refs/pull/42/head", repo: "acme/app" },
       title: "Improve app",
     })
     expect(() => pullRequest.read({ context: { get: () => undefined } })).toThrow("requires pull request invocation context")

--- a/packages/agent/test/config.test.ts
+++ b/packages/agent/test/config.test.ts
@@ -221,10 +221,10 @@ describe("agent config", () => {
     }
   })
 
-  it("does not let custom capabilities bypass explicit workspace with public metadata", async () => {
+  it("infers workspaces from custom contributions regardless of public metadata", async () => {
     const { defineAgent, defineCapability } = await import("../src/index.ts")
 
-    expect(() => defineAgent({
+    expect(defineAgent({
       capabilities: [
         defineCapability({
           id: "custom",
@@ -244,7 +244,10 @@ describe("agent config", () => {
         }),
       ],
       driver: { run: () => "ok" },
-    })).toThrow("custom() requires an explicit workspace")
+    })).toMatchObject({
+      __vitehubWorkspaceAgent: true,
+      __vitehubWorkspaceAgentOptions: { workspace: {} },
+    })
   })
 
 })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1351,7 +1351,7 @@ describe("agent chat capability discovery", () => {
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
     const agent = defineAgent({
       channels: {
-        github: github({ pullRequest: { reply: false }, webhooks: { secretToken: "secret-token" } }),
+        github: github({ pullRequest: { reply: false, workspace: false }, webhooks: { secretToken: "secret-token" } }),
       },
       driver: { run: ({ context, input }) => {
           const github = context.get<{ command: string, repository: string }>("github")

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -298,6 +298,77 @@ describe("git capability", () => {
     expect(session.exec).toHaveBeenNthCalledWith(3, "git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace/vitehub" }))
   })
 
+  it("prepares explicit root pull request checkouts without deleting Workspace artifacts", async () => {
+    const session = gitSession()
+    session.exec.mockImplementation(async (command: string, args: string[] = []) => ({
+      args,
+      command,
+      exitCode: command === "git" && args.join(" ") === "rev-parse --is-inside-work-tree" ? 1 : 0,
+      stderr: "",
+      stdout: command === "git" && args.join(" ") === "status --short" ? "ok\n" : "",
+    }))
+    const { startSession, tools } = await capabilityTools(git(), session, {
+      pullRequest: {
+        pullRequest: {
+          head: { sha: pullRequestHeadSha },
+          number: 42,
+          source: {
+            mount: "",
+            ref: "refs/pull/42/head",
+            repo: "vite-hub/vitehub",
+          },
+        },
+        repository: {
+          fullName: "vite-hub/vitehub",
+          name: "vitehub",
+        },
+      },
+    })
+
+    await expect(tools.shell!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+      cwd: "/workspace",
+      stdout: "ok\n",
+    })
+
+    expect(startSession).toHaveBeenCalledWith(undefined)
+    expect(session.exec).toHaveBeenNthCalledWith(1, "git", ["rev-parse", "--is-inside-work-tree"], expect.objectContaining({ cwd: "/workspace" }))
+    const setupScript = session.exec.mock.calls[1]?.[1]?.[1]
+    expect(setupScript).toContain("cd -- .")
+    expect(setupScript).toContain("git reset -q --mixed refs/vitehub/head")
+    expect(setupScript).not.toContain("rm -rf")
+  })
+
+  it("does not prepare a pull request checkout when the channel disables it", async () => {
+    const session = gitSession()
+    const { startSession, tools } = await capabilityTools(git(), session, {
+      pullRequest: {
+        pullRequest: {
+          head: { ref: "feature", sha: pullRequestHeadSha },
+          number: 42,
+          source: {
+            checkout: false,
+            mount: "vitehub",
+            ref: "refs/pull/42/head",
+            repo: "vite-hub/vitehub",
+          },
+        },
+        repository: {
+          fullName: "vite-hub/vitehub",
+          name: "vitehub",
+        },
+      },
+    })
+
+    await expect(tools.shell!.execute?.({ command: "git status --short" })).resolves.toMatchObject({
+      cwd: "/workspace",
+      stdout: "ok\n",
+    })
+
+    expect(startSession).toHaveBeenCalledWith(undefined)
+    expect(session.exec).toHaveBeenCalledOnce()
+    expect(session.exec).toHaveBeenCalledWith("git", ["status", "--short"], expect.objectContaining({ cwd: "/workspace" }))
+  })
+
   it("requires an exact pull request head SHA", async () => {
     await expect(capabilityTools(git(), gitSession(), {
       pullRequest: {

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -340,7 +340,7 @@ describe("git capability", () => {
     expect(session.exec).toHaveBeenNthCalledWith(1, "git", ["rev-parse", "--is-inside-work-tree"], expect.objectContaining({ cwd: "/workspace" }))
     const setupScript = session.exec.mock.calls[1]?.[1]?.[1]
     expect(setupScript).toContain("cd -- .")
-    expect(setupScript).toContain("git reset -q --mixed refs/vitehub/head")
+    expect(setupScript).toContain("git reset -q --hard refs/vitehub/head")
     expect(setupScript).not.toContain("rm -rf")
   })
 
@@ -362,7 +362,7 @@ describe("git capability", () => {
       await execFileAsync("git", ["init", "-q"], { cwd: workspace })
       await execFileAsync("git", ["remote", "add", "origin", source], { cwd: workspace })
       await execFileAsync("git", ["fetch", "-q", "origin", `${headSha.trim()}:refs/vitehub/head`], { cwd: workspace })
-      await execFileAsync("git", ["reset", "-q", "--mixed", "refs/vitehub/head"], { cwd: workspace })
+      await execFileAsync("git", ["reset", "-q", "--hard", "refs/vitehub/head"], { cwd: workspace })
 
       expect(await readFile(join(workspace, "README.md"), "utf8")).toBe("exact head\n")
       expect(await readFile(join(workspace, "PULL_REQUEST.md"), "utf8")).toBe("workspace artifact\n")

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -334,7 +334,7 @@ describe("git capability", () => {
     expect(session.exec).toHaveBeenNthCalledWith(1, "git", ["rev-parse", "--is-inside-work-tree"], expect.objectContaining({ cwd: "/workspace" }))
     const setupScript = session.exec.mock.calls[1]?.[1]?.[1]
     expect(setupScript).toContain("cd -- .")
-    expect(setupScript).toContain("git reset -q --mixed refs/vitehub/head")
+    expect(setupScript).toContain("git checkout -q --detach refs/vitehub/head")
     expect(setupScript).not.toContain("rm -rf")
   })
 

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -1,3 +1,8 @@
+import { execFile } from "node:child_process"
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
 import { describe, expect, it, vi } from "vitest"
 
 import { git } from "../src/capabilities.ts"
@@ -7,6 +12,7 @@ import type { AgentToolSet } from "../src/types.ts"
 import type { WorkspaceSession } from "@vite-hub/workspace"
 
 const pullRequestHeadSha = "a".repeat(40)
+const execFileAsync = promisify(execFile)
 
 function gitSession(options: { remotes?: string, status?: string } = {}) {
   const session = {
@@ -336,6 +342,36 @@ describe("git capability", () => {
     expect(setupScript).toContain("cd -- .")
     expect(setupScript).toContain("git reset -q --mixed refs/vitehub/head")
     expect(setupScript).not.toContain("rm -rf")
+  })
+
+  it("attaches root Git metadata to an already materialized exact-head tree", async () => {
+    const fixture = await mkdtemp(join(tmpdir(), "vitehub-root-pr-"))
+    const source = join(fixture, "source")
+    const workspace = join(fixture, "workspace")
+    try {
+      await mkdir(source)
+      await mkdir(workspace)
+      await execFileAsync("git", ["init", "-q"], { cwd: source })
+      await writeFile(join(source, "README.md"), "exact head\n")
+      await execFileAsync("git", ["add", "README.md"], { cwd: source })
+      await execFileAsync("git", ["-c", "user.name=ViteHub", "-c", "user.email=vitehub@example.com", "commit", "-qm", "fixture"], { cwd: source })
+      const { stdout: headSha } = await execFileAsync("git", ["rev-parse", "HEAD"], { cwd: source })
+
+      await copyFile(join(source, "README.md"), join(workspace, "README.md"))
+      await writeFile(join(workspace, "PULL_REQUEST.md"), "workspace artifact\n")
+      await execFileAsync("git", ["init", "-q"], { cwd: workspace })
+      await execFileAsync("git", ["remote", "add", "origin", source], { cwd: workspace })
+      await execFileAsync("git", ["fetch", "-q", "origin", `${headSha.trim()}:refs/vitehub/head`], { cwd: workspace })
+      await execFileAsync("git", ["reset", "-q", "--mixed", "refs/vitehub/head"], { cwd: workspace })
+
+      expect(await readFile(join(workspace, "README.md"), "utf8")).toBe("exact head\n")
+      expect(await readFile(join(workspace, "PULL_REQUEST.md"), "utf8")).toBe("workspace artifact\n")
+      const { stdout: status } = await execFileAsync("git", ["status", "--porcelain"], { cwd: workspace })
+      expect(status).toBe("?? PULL_REQUEST.md\n")
+    }
+    finally {
+      await rm(fixture, { force: true, recursive: true })
+    }
   })
 
   it("does not prepare a pull request checkout when the channel disables it", async () => {

--- a/packages/agent/test/git-capability.test.ts
+++ b/packages/agent/test/git-capability.test.ts
@@ -334,7 +334,7 @@ describe("git capability", () => {
     expect(session.exec).toHaveBeenNthCalledWith(1, "git", ["rev-parse", "--is-inside-work-tree"], expect.objectContaining({ cwd: "/workspace" }))
     const setupScript = session.exec.mock.calls[1]?.[1]?.[1]
     expect(setupScript).toContain("cd -- .")
-    expect(setupScript).toContain("git checkout -q --detach refs/vitehub/head")
+    expect(setupScript).toContain("git reset -q --mixed refs/vitehub/head")
     expect(setupScript).not.toContain("rm -rf")
   })
 

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4856,7 +4856,7 @@ describe("agent message protocol", () => {
                   labels: ["agent"],
                   number: 42,
                   source: {
-                    mount: "vitehub",
+                    mount: "portal",
                     ref: "refs/pull/42/head",
                     repo: "vite-hub/vitehub",
                   },
@@ -5113,6 +5113,7 @@ describe("agent message protocol", () => {
             maxComments: 100,
             maxFiles: 100,
             reply: false,
+            workspace: false,
           },
         }),
       },
@@ -5182,7 +5183,7 @@ describe("agent message protocol", () => {
             installationId: 321,
             privateKey: privateKeyPem,
           },
-          pullRequest: { reply: false },
+          pullRequest: { reply: false, workspace: false },
         }),
       },
       driver: { run: () => "ok" },
@@ -5354,11 +5355,11 @@ describe("agent message protocol", () => {
       channels: {
         github: github({
           app: { webhookSecret: false },
-          pullRequest: true,
+          pullRequest: { workspace: false },
         }),
         triage: github({
           app: { webhookSecret: false },
-          pullRequest: true,
+          pullRequest: { workspace: false },
         }),
       },
       driver: { run: context => `ran:${context.prompt}` },

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1655,6 +1655,29 @@ describe("agent public types", () => {
     // @ts-expect-error GitHub Channel PR comments are configured through pullRequest, not legacy events.
     github({ events: { pullRequestComments: true } })
 
+    defineAgent({
+      channels: {
+        github: () => github({ app: true, pullRequest: true }),
+      },
+      driver: { run: () => "ok" },
+    })
+    github({ pullRequest: { workspace: true } })
+    github({ pullRequest: { workspace: false } })
+    github({ pullRequest: { workspace: { mount: "portal" } } })
+
+    const inferredWorkspace = defineCapability({
+      id: "inferred-workspace",
+      workspace: {
+        sources: {
+          docs: file("README.md"),
+        },
+      },
+    })
+    defineAgent({
+      capabilities: [inferredWorkspace],
+      driver: { run: () => "ok" },
+    })
+
     const broadCapabilities: AgentCapabilityDefinition[] = [
       access({
         workspace: {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -241,6 +241,47 @@ describe("defineAgent workspace option", () => {
     workspaceSourceRequestDescriptorPath.mockImplementation((source: string) => `.vitehub/sources/${source}.json`)
   })
 
+  it("infers Workspace Agents from static and normalized channel capabilities", async () => {
+    const { defineAgent, defineCapability } = await import("../src/index.ts")
+    const workspaceCapability = defineCapability({
+      id: "review-workspace",
+      workspace: { sources: {} },
+    })
+    const channelFactory = vi.fn(() => ({
+      capabilities: [workspaceCapability],
+      kind: "review",
+    }))
+
+    const staticAgent = defineAgent({
+      capabilities: [workspaceCapability],
+      driver: { run: () => "ok" },
+    })
+    const channelAgent = defineAgent({
+      channels: { review: channelFactory },
+      driver: { run: () => "ok" },
+    })
+    const baseAgent = defineAgent({
+      driver: { run: () => "ok" },
+    })
+
+    expect(staticAgent).toMatchObject({
+      __vitehubWorkspaceAgent: true,
+      __vitehubWorkspaceAgentOptions: { workspace: {} },
+    })
+    expect(channelAgent).toMatchObject({
+      __vitehubWorkspaceAgent: true,
+      __vitehubWorkspaceAgentOptions: { workspace: {} },
+      channels: {
+        review: {
+          capabilities: [workspaceCapability],
+          kind: "review",
+        },
+      },
+    })
+    expect(channelFactory).toHaveBeenCalledOnce()
+    expect(baseAgent).not.toHaveProperty("__vitehubWorkspaceAgent")
+  })
+
   it("fails when a capability-required workspace path is missing", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -247,6 +247,11 @@ describe("defineAgent workspace option", () => {
       id: "review-workspace",
       workspace: { sources: {} },
     })
+    const writeWorkspaceCapability = defineCapability({
+      id: "write-review-workspace",
+      requires: [{ primitive: "workspace", workspace: { mode: "write", required: true } }],
+      workspace: { sources: {} },
+    })
     const channelFactory = vi.fn(() => ({
       capabilities: [workspaceCapability],
       kind: "review",
@@ -260,23 +265,31 @@ describe("defineAgent workspace option", () => {
       channels: { review: channelFactory },
       driver: { run: () => "ok" },
     })
+    const writeAgent = defineAgent({
+      capabilities: [workspaceCapability, writeWorkspaceCapability],
+      driver: { run: () => "ok" },
+    })
     const baseAgent = defineAgent({
       driver: { run: () => "ok" },
     })
 
     expect(staticAgent).toMatchObject({
       __vitehubWorkspaceAgent: true,
-      __vitehubWorkspaceAgentOptions: { workspace: {} },
+      __vitehubWorkspaceAgentOptions: { workspace: { mode: "read" } },
     })
     expect(channelAgent).toMatchObject({
       __vitehubWorkspaceAgent: true,
-      __vitehubWorkspaceAgentOptions: { workspace: {} },
+      __vitehubWorkspaceAgentOptions: { workspace: { mode: "read" } },
       channels: {
         review: {
           capabilities: [workspaceCapability],
           kind: "review",
         },
       },
+    })
+    expect(writeAgent).toMatchObject({
+      __vitehubWorkspaceAgent: true,
+      __vitehubWorkspaceAgentOptions: { workspace: { mode: "write" } },
     })
     expect(channelFactory).toHaveBeenCalledOnce()
     expect(baseAgent).not.toHaveProperty("__vitehubWorkspaceAgent")


### PR DESCRIPTION
GitHub pull-request Channels now contribute a Workspace automatically and materialize the exact pull-request head under `portal/` by default. Consumers can omit `workspace: {}`; static and normalized Channel Capabilities that contribute a Workspace now promote the definition to a Workspace Agent.

`pullRequest: { workspace: true }` keeps materialization at the Workspace root, while `workspace: false` disables both materialization and lazy Git setup. The existing Git Capability initializes exact-head metadata lazily at the resolved mount, so root artifacts such as `PULL_REQUEST.md` remain outside the default repository checkout without exposing checkout credentials to Agent commands.

Validated with the full `@vite-hub/agent` build and 1,427-test suite, package typechecking, repository lint, and live default/root checkout proofs against an exact remote SHA.