### PR TITLE
feat(source): preserve typed record data

### DIFF
--- a/packages/source/README.md
+++ b/packages/source/README.md
@@ -31,6 +31,38 @@ const keys = await docs.keys()
 const first = await docs.read(keys[0]!)
 ```
 
+Structured sources preserve record and metadata types through `useSource()`:
+
+```ts
+import type { Source } from "@vite-hub/source"
+
+interface Article {
+  author: string
+  cover: { key: string, mediaType: string }
+  title: string
+}
+
+interface ArticleMetadata {
+  revision: string
+}
+
+declare global {
+  interface ViteHubSourceMap {
+    articles: Source<`article_${string}`, Article, ArticleMetadata>
+  }
+}
+
+const article = await useSource("articles").get("article_123")
+article.data?.title
+article.metadata?.revision
+
+const articles = await useSource("articles").items()
+```
+
+Keep binary assets behind the Blob boundary and store a serializable reference in
+the record. This keeps ordinary record reads lazy while treating the structured
+data and its assets as one logical item.
+
 ## Used by
 
 [`@vite-hub/workspace`](../workspace/README.md) materializes Source output into workspace files. Use this package directly when you only need typed source loading and not a workspace file tree.

--- a/packages/source/src/core/registry.ts
+++ b/packages/source/src/core/registry.ts
@@ -6,9 +6,11 @@ import type {
   ReadSourceResult,
   Source,
   SourceContext,
+  SourceData,
   SourceItem,
   SourceKey,
   SourceListEntry,
+  SourceMetadata,
   SourceName,
   SourceReader,
 } from "./types.ts"
@@ -30,10 +32,12 @@ export function registerSources<const TSources extends Record<string, Source>>(s
   return sources
 }
 
-export function getRegisteredSource<TName extends SourceName>(name: TName): Source<SourceKey<TName>> {
+export function getRegisteredSource<TName extends SourceName>(
+  name: TName,
+): Source<SourceKey<TName>, SourceData<TName>, SourceMetadata<TName>> {
   const source = sourceRegistry.get(name)
   if (!source) throw sourceNotFoundError(name)
-  return source as Source<SourceKey<TName>>
+  return source as Source<SourceKey<TName>, SourceData<TName>, SourceMetadata<TName>>
 }
 
 export function clearSources(): void {
@@ -90,7 +94,9 @@ export function useSource<TName extends SourceName>(
     return await source.getKeys(ctx)
   }
 
-  async function get(key: SourceKey<TName>): Promise<SourceItem<SourceKey<TName>>> {
+  async function get(
+    key: SourceKey<TName>,
+  ): Promise<SourceItem<SourceKey<TName>, SourceData<TName>, SourceMetadata<TName>>> {
     await ensurePrepared()
     return await source.getItem(key, ctx)
   }
@@ -98,6 +104,11 @@ export function useSource<TName extends SourceName>(
   return {
     keys,
     get,
+    async items() {
+      await ensurePrepared()
+      if (source.getItems) return await source.getItems(ctx)
+      return await Promise.all((await keys()).map(get))
+    },
     async read<TOptions extends ReadSourceOptions | undefined = undefined>(
       key: SourceKey<TName>,
       options?: TOptions,

--- a/packages/source/src/core/types.ts
+++ b/packages/source/src/core/types.ts
@@ -35,24 +35,32 @@ export interface SourceSearchHit {
   text: string
 }
 
-export interface SourceItem<TKey extends string = string> {
+export interface SourceItem<
+  TKey extends string = string,
+  TData = unknown,
+  TMetadata extends object = Record<string, unknown>,
+> {
   key: TKey
   path?: string
   content?: SourceContent
-  data?: unknown
+  data?: TData
   mediaType?: string
-  metadata?: Record<string, unknown>
+  metadata?: TMetadata
 }
 
-export interface Source<TKey extends string = string> {
+export interface Source<
+  TKey extends string = string,
+  TData = unknown,
+  TMetadata extends object = Record<string, unknown>,
+> {
   name: string
   cache?: false | SourceCacheOptions
   fingerprint?: unknown
   prepare?(ctx: SourceContext): Promise<void>
   getKeys(ctx: SourceContext): Promise<TKey[]>
-  getItem(key: TKey, ctx: SourceContext): Promise<SourceItem<TKey>>
-  getItems?(ctx: SourceContext): Promise<SourceItem<TKey>[]>
-  getMeta?(key: TKey, ctx: SourceContext): Promise<Record<string, unknown> | undefined>
+  getItem(key: TKey, ctx: SourceContext): Promise<SourceItem<TKey, TData, TMetadata>>
+  getItems?(ctx: SourceContext): Promise<SourceItem<TKey, TData, TMetadata>[]>
+  getMeta?(key: TKey, ctx: SourceContext): Promise<TMetadata | undefined>
   search?(query: SourceSearchQuery, ctx: SourceContext): Promise<SourceSearchHit[]>
   watch?: unknown[]
 }
@@ -68,23 +76,32 @@ declare global {
 
 export interface SourceMap extends ViteHubSourceMap {}
 
-type SourceKeyOf<TSource> = TSource extends Source<infer TKey> ? TKey : string
+type SourceKeyOf<TSource> = TSource extends Source<infer TKey, any, any> ? TKey : string
+type SourceDataOf<TSource> = TSource extends Source<any, infer TData, any> ? TData : unknown
+type SourceMetadataOf<TSource> = TSource extends Source<any, any, infer TMetadata> ? TMetadata : Record<string, unknown>
+type RegisteredSource<TName extends SourceName> =
+  TName extends keyof ViteHubSourceMap ? ViteHubSourceMap[TName] : Source
 
 export type SourceName = [keyof ViteHubSourceMap] extends [never] ? string : Extract<keyof ViteHubSourceMap, string>
 
 export type SourceKey<TName extends SourceName = SourceName> =
-  TName extends keyof ViteHubSourceMap
-    ? Extract<SourceKeyOf<ViteHubSourceMap[TName]>, string>
-    : string
+  Extract<SourceKeyOf<RegisteredSource<TName>>, string>
+
+export type SourceData<TName extends SourceName = SourceName> =
+  SourceDataOf<RegisteredSource<TName>>
+
+export type SourceMetadata<TName extends SourceName = SourceName> =
+  SourceMetadataOf<RegisteredSource<TName>>
 
 export interface SourceReader<TName extends SourceName = SourceName> {
   keys(): Promise<SourceKey<TName>[]>
-  get(key: SourceKey<TName>): Promise<SourceItem<SourceKey<TName>>>
+  get(key: SourceKey<TName>): Promise<SourceItem<SourceKey<TName>, SourceData<TName>, SourceMetadata<TName>>>
+  items(): Promise<Array<SourceItem<SourceKey<TName>, SourceData<TName>, SourceMetadata<TName>>>>
   read<TOptions extends ReadSourceOptions | undefined = undefined>(
     key: SourceKey<TName>,
     options?: TOptions
   ): Promise<ReadSourceResult<TOptions>>
-  meta(key: SourceKey<TName>): Promise<Record<string, unknown> | undefined>
+  meta(key: SourceKey<TName>): Promise<SourceMetadata<TName> | undefined>
   exists(key: SourceKey<TName>): Promise<boolean>
   list(prefix?: SourceKey<TName> | (string & {}) | ""): Promise<SourceListEntry<SourceKey<TName>>[]>
 }

--- a/packages/source/test/registry.test.ts
+++ b/packages/source/test/registry.test.ts
@@ -1,10 +1,11 @@
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   clearSources,
   custom,
   defineSources,
   file,
+  registerSource,
   registerSources,
   useSource,
 } from "../src/index.ts"
@@ -43,7 +44,29 @@ describe("@vite-hub/source registry", () => {
     await expect(docs.exists("README.md")).resolves.toBe(true)
     await expect(docs.exists("missing.md" as any)).resolves.toBe(false)
     await expect(docs.list()).resolves.toEqual([{ key: "README.md", type: "file" }])
+    await expect(docs.items()).resolves.toMatchObject([{ key: "README.md" }])
     await expect(useSource("custom").get("data.json")).resolves.toMatchObject({ data: { ok: true } })
+  })
+
+  it("uses a source bulk reader when available", async () => {
+    const getItem = vi.fn()
+    const getItems = vi.fn(async () => [
+      { data: { title: "One" }, key: "one" },
+      { data: { title: "Two" }, key: "two" },
+    ])
+
+    registerSource("articles", custom({
+      name: "articles",
+      async getKeys() {
+        return ["one", "two"]
+      },
+      getItem,
+      getItems,
+    }))
+
+    await expect(useSource("articles").items()).resolves.toHaveLength(2)
+    expect(getItems).toHaveBeenCalledOnce()
+    expect(getItem).not.toHaveBeenCalled()
   })
 
   it("throws a source-specific error for missing registrations", () => {

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -10,17 +10,38 @@ import {
   registerSources,
   source,
   type Source,
+  type SourceData,
   type SourceItem,
+  type SourceMetadata,
   useSource,
 } from "../src/index.ts"
 
+interface Meal {
+  analysis: {
+    costUsd: number
+    model: string
+  }
+  calories: number
+  name: string
+  photo: {
+    key: string
+    mediaType: string
+  }
+}
+
+interface MealMetadata {
+  revision: string
+}
+
 declare global {
   interface ViteHubSourceMap {
+    articles: Source
     custom: Source
     dbt: Source
     docs: Source<"README.md" | "guide/setup.md">
     dynamic: Source
     github: Source
+    meals: Source<`meal_${string}`, Meal, MealMetadata>
     readme: Source<"README.md">
   }
 }
@@ -56,6 +77,16 @@ describe("@vite-hub/source types", () => {
     expectTypeOf(await docs.exists("guide/setup.md")).toEqualTypeOf<boolean>()
     expectTypeOf(await docs.meta("README.md")).toEqualTypeOf<Record<string, unknown> | undefined>()
     expectTypeOf(await dynamic.keys()).toEqualTypeOf<string[]>()
+    expectTypeOf<SourceData<"meals">>().toEqualTypeOf<Meal>()
+    expectTypeOf<SourceMetadata<"meals">>().toEqualTypeOf<MealMetadata>()
+
+    const meal = await useSource("meals").get("meal_123")
+    expectTypeOf(meal).toEqualTypeOf<SourceItem<`meal_${string}`, Meal, MealMetadata>>()
+    expectTypeOf(meal.data).toEqualTypeOf<Meal | undefined>()
+    expectTypeOf(meal.metadata).toEqualTypeOf<MealMetadata | undefined>()
+    expectTypeOf(await useSource("meals").meta("meal_123")).toEqualTypeOf<MealMetadata | undefined>()
+    expectTypeOf(await useSource("meals").items())
+      .toEqualTypeOf<Array<SourceItem<`meal_${string}`, Meal, MealMetadata>>>()
 
     // @ts-expect-error source names are inferred from the global source map
     useSource("missing")
@@ -75,5 +106,29 @@ describe("@vite-hub/source types", () => {
     } satisfies Source<"one.md" | "two.md">))
 
     expectTypeOf(source).toMatchTypeOf<Source<"one.md" | "two.md">>()
+  })
+
+  it("preserves record and metadata types from a custom source", async () => {
+    const source: Source<"meal_123", Meal, MealMetadata> = defineSource(custom({
+      name: "meals",
+      async getKeys() {
+        return ["meal_123"] as const
+      },
+      async getItem(key: "meal_123") {
+        return {
+          data: {
+            analysis: { costUsd: 0.002, model: "google/gemini-3-flash" },
+            calories: 720,
+            name: "Post-workout meal",
+            photo: { key: "meals/meal_123/original", mediaType: "image/png" },
+          },
+          key,
+          metadata: { revision: "1" },
+        }
+      },
+    } satisfies Source<"meal_123", Meal, MealMetadata>))
+
+    expectTypeOf(await source.getItem("meal_123", { rootDir: "." }))
+      .toEqualTypeOf<SourceItem<"meal_123", Meal, MealMetadata>>()
   })
 })


### PR DESCRIPTION
Structured Sources now carry their record data and metadata types through the public `Source`, registry, and `useSource()` contracts. `get()`, `meta()`, and the new `items()` reader preserve those types; `items()` uses a source's bulk reader when available and otherwise resolves its keys through `getItem()`.

The package README documents the typed record shape and keeps binary payloads behind the Blob boundary through serializable asset references.

Validated with the `@vite-hub/source` build and publint, all 55 package tests, package typechecking, focused lint, and `git diff --check`.