### PR TITLE
fix(database): deduplicate Nuxt D1 bindings

### DIFF
--- a/packages/database/src/internal/cloudflare.ts
+++ b/packages/database/src/internal/cloudflare.ts
@@ -161,13 +161,23 @@ export function mergeCloudflareD1Bindings(
   current: unknown,
   generated: CloudflareD1WranglerBinding[],
 ): CloudflareD1WranglerBinding[] {
-  const bindings = Array.isArray(current)
-    ? current.filter(isCloudflareD1WranglerBinding).map(binding => ({ ...binding }))
-    : []
+  const bindings: CloudflareD1WranglerBinding[] = []
+  const bindingNames = new Set<string>()
+
+  if (Array.isArray(current)) {
+    for (const binding of current) {
+      if (isCloudflareD1WranglerBinding(binding) && !bindingNames.has(binding.binding)) {
+        bindings.push({ ...binding })
+        bindingNames.add(binding.binding)
+      }
+    }
+  }
 
   for (const binding of generated) {
     const index = bindings.findIndex(item => item.binding === binding.binding)
-    if (index === -1) bindings.push(binding)
+    if (index === -1) {
+      bindings.push(binding)
+    }
     else bindings[index] = { ...binding }
   }
 

--- a/packages/database/src/nuxt.ts
+++ b/packages/database/src/nuxt.ts
@@ -190,24 +190,14 @@ function mergeNitroCloudflareConfig(config: Record<string, unknown>, d1: Resolve
   const nitro = ensureRecord(config, "nitro")
   const cloudflare = ensureRecord(nitro, "cloudflare")
   const wrangler = ensureRecord(cloudflare, "wrangler")
-  wrangler.d1_databases = mergeD1BindingsOnce(wrangler.d1_databases, d1.d1Database)
+  wrangler.d1_databases = mergeCloudflareD1Bindings(wrangler.d1_databases, [d1.d1Database])
 }
 
 function mergeNitroConfigCloudflareConfig(config: Record<string, unknown>, d1: ResolvedDatabaseNuxtD1Options) {
   if (!d1.d1Database) return
   const cloudflare = ensureRecord(config, "cloudflare")
   const wrangler = ensureRecord(cloudflare, "wrangler")
-  wrangler.d1_databases = mergeD1BindingsOnce(wrangler.d1_databases, d1.d1Database)
-}
-
-function mergeD1BindingsOnce(current: unknown, binding: NonNullable<ResolvedDatabaseNuxtD1Options["d1Database"]>) {
-  return mergeCloudflareD1Bindings(current, [binding]).filter((candidate, index, bindings) =>
-    bindings.findIndex(existing =>
-      existing.binding === candidate.binding
-      && existing.database_id === candidate.database_id
-      && existing.database_name === candidate.database_name,
-    ) === index,
-  )
+  wrangler.d1_databases = mergeCloudflareD1Bindings(wrangler.d1_databases, [d1.d1Database])
 }
 
 function hasNuxtContentModule(modules: unknown[] | undefined) {

--- a/packages/database/src/nuxt.ts
+++ b/packages/database/src/nuxt.ts
@@ -190,14 +190,24 @@ function mergeNitroCloudflareConfig(config: Record<string, unknown>, d1: Resolve
   const nitro = ensureRecord(config, "nitro")
   const cloudflare = ensureRecord(nitro, "cloudflare")
   const wrangler = ensureRecord(cloudflare, "wrangler")
-  wrangler.d1_databases = mergeCloudflareD1Bindings(wrangler.d1_databases, [d1.d1Database])
+  wrangler.d1_databases = mergeD1BindingsOnce(wrangler.d1_databases, d1.d1Database)
 }
 
 function mergeNitroConfigCloudflareConfig(config: Record<string, unknown>, d1: ResolvedDatabaseNuxtD1Options) {
   if (!d1.d1Database) return
   const cloudflare = ensureRecord(config, "cloudflare")
   const wrangler = ensureRecord(cloudflare, "wrangler")
-  wrangler.d1_databases = mergeCloudflareD1Bindings(wrangler.d1_databases, [d1.d1Database])
+  wrangler.d1_databases = mergeD1BindingsOnce(wrangler.d1_databases, d1.d1Database)
+}
+
+function mergeD1BindingsOnce(current: unknown, binding: NonNullable<ResolvedDatabaseNuxtD1Options["d1Database"]>) {
+  return mergeCloudflareD1Bindings(current, [binding]).filter((candidate, index, bindings) =>
+    bindings.findIndex(existing =>
+      existing.binding === candidate.binding
+      && existing.database_id === candidate.database_id
+      && existing.database_name === candidate.database_name,
+    ) === index,
+  )
 }
 
 function hasNuxtContentModule(modules: unknown[] | undefined) {

--- a/packages/database/test/cloudflare.test.ts
+++ b/packages/database/test/cloudflare.test.ts
@@ -140,10 +140,20 @@ describe("Cloudflare D1 binding projections", () => {
   it("replaces generated D1 bindings by binding name when merging with host config", () => {
     expect(mergeCloudflareD1Bindings([
       {
+        binding: "BEFORE",
+        database_id: "before-id",
+        database_name: "before-db",
+      },
+      {
         binding: "DB",
         database_id: "old-id",
         database_name: "old-db",
         preview_database_id: "old-preview-id",
+      },
+      {
+        binding: "DB",
+        database_id: "duplicate-id",
+        database_name: "duplicate-db",
       },
       {
         binding: "OTHER",
@@ -157,6 +167,11 @@ describe("Cloudflare D1 binding projections", () => {
         database_name: "new-db",
       },
     ])).toEqual([
+      {
+        binding: "BEFORE",
+        database_id: "before-id",
+        database_name: "before-db",
+      },
       {
         binding: "DB",
         database_id: "new-id",

--- a/packages/database/test/nuxt.test.ts
+++ b/packages/database/test/nuxt.test.ts
@@ -167,6 +167,52 @@ describe("Database Nuxt integration", () => {
     })
   })
 
+  it("deduplicates D1 bindings already merged into Nuxt and Nitro config", async () => {
+    const binding = {
+      binding: "DB",
+      database_id: "content-id",
+      database_name: "content-db",
+    }
+    const { hooks, nuxt } = createNuxt({
+      database: {
+        driver: "d1",
+        databaseId: "content-id",
+        databaseName: "content-db",
+      },
+      dev: false,
+      nitro: {
+        cloudflare: {
+          wrangler: {
+            d1_databases: [binding, binding],
+          },
+        },
+      },
+      rootDir: "/tmp/vitehub-db-nuxt-deduplicated",
+      vite: {},
+    })
+
+    await hubDb()(undefined, nuxt)
+
+    expect(nuxt.options.nitro).toMatchObject({
+      cloudflare: {
+        wrangler: {
+          d1_databases: [binding],
+        },
+      },
+    })
+
+    const nitroConfig = {
+      cloudflare: {
+        wrangler: {
+          d1_databases: [binding, binding],
+        },
+      },
+    }
+    await callHook(hooks, "nitro:config", nitroConfig)
+
+    expect(nitroConfig.cloudflare.wrangler.d1_databases).toEqual([binding])
+  })
+
   it("does not emit an invalid Wrangler D1 binding when the resource is incomplete", async () => {
     const { nuxt } = createNuxt({
       database: {


### PR DESCRIPTION
Deduplicates identical Cloudflare D1 entries after both Nuxt option merging and the Nitro config hook. Nuxt and Nitro can carry the same generated binding through both phases; the previous merge replaced the first match but retained identical siblings, leaving duplicate entries in Wrangler config.

The regression covers both integration phases. Validated with the Database package build and publint, package typecheck, focused lint, the focused Nuxt suite, and the full Database suite (12 files, 79 tests).
