### PR TITLE
refactor(agent)!: move structured output into drivers

### DIFF
--- a/docs/content/docs/agents/agent-definitions.md
+++ b/docs/content/docs/agents/agent-definitions.md
@@ -23,7 +23,7 @@ export default defineAgent({
 })
 ```
 
-Use a structural driver object when the application supplies a custom model, harness adapter, or run function. That object accepts exactly one concrete variant: `model`, `harness`, or `run`; driver-specific options stay beside the variant key.
+Use a structural driver object when the application supplies a custom model, harness adapter, or run function. That object accepts exactly one concrete variant: `model`, `harness`, or `run`; execution options such as `instructions` and `output` stay beside the variant key.
 
 ## Agent Definition options
 
@@ -41,7 +41,6 @@ Use a structural driver object when the application supplies a custom model, har
 | `invoker` | `AgentInvokerOptions` | None | Configures Agent Actor profiles and resolution through the current `invoker`-named API. |
 | `messages` | `AgentMessageChannelSettings` | Channel defaults | Applies shared commentary, delivery, concurrency, session, state, and transcript settings across adapter-backed Channels. |
 | `name` | `string` | Discovered identity | Supplies an explicit Definition name for direct metadata and Workspace naming. Discovered host identity still comes from the file or folder path. |
-| `output` | `AgentOutputDefinition` | None | Decodes and validates structured Agent output with a Standard Schema. |
 | `runtime` | `false \| workflow(name?)` | Discovered Workflow | Disables hosted Workflow execution or selects an explicit Workflow binding. Direct calls without discovered Agent identity remain inline. |
 | `runEvents` | `AgentRunEvents` | None | Publishes and reads durable events scoped to the current Agent Invocation run. |
 | `version` | `string` | None | Adds a Definition version to generated and Agent inspection metadata. |
@@ -51,7 +50,7 @@ The resolved `AgentDefinition` also exposes runtime-owned `resolve()` and, when 
 
 ## Declare structured output
 
-Set `output.schema` when server code needs a typed value instead of provider result plumbing. The schema uses [Standard Schema](https://standardschema.dev/), so the Agent Invocation decodes the final JSON, validates it once, and returns the inferred output value.
+Set `driver.output.schema` when server code needs a typed value instead of provider result plumbing. The schema uses [Standard Schema](https://standardschema.dev/), so the Agent Invocation decodes the selected Driver's final JSON, validates it once, and returns the inferred output value.
 
 ```ts [server/agents/summary.ts]
 import { defineAgent } from '@vite-hub/agent'
@@ -63,8 +62,10 @@ const summaryOutput = object({
 })
 
 export default defineAgent({
-  driver: 'codex',
-  output: { schema: summaryOutput },
+  driver: {
+    kind: 'codex',
+    output: { schema: summaryOutput },
+  },
 })
 ```
 

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -10,6 +10,7 @@ import {
 } from "./capability-runtime.ts"
 import { agentInvocationCallbackContextValues } from "./invocation-context.ts"
 import { composeInstructionDocument } from "./instruction-composition.ts"
+import { agentOutputInstructions } from "./internal/agent-structured-output.ts"
 import { synthesizedAgentOutputSymbol } from "./internal/synthesized-agent-output.ts"
 import {
   applyAgentToolPolicies,
@@ -994,7 +995,10 @@ async function createAgent(
     ? await instrumentModel(model, instrumentations, { ...runtime, actor: context.actor, context: context.context, invoker: context.invoker, model, run: context.runtime.run })
     : model
   const instructions = await composeInstructions(
-    context.instructions ?? await resolveInstructions(options, metadataContext),
+    joinInstructions(
+      context.instructions ?? await resolveInstructions(options, metadataContext),
+      agentOutputInstructions(context.output),
+    ),
     metadataContext,
     context.workspaceInstructionBindings,
   )

--- a/packages/agent/src/eval.ts
+++ b/packages/agent/src/eval.ts
@@ -158,10 +158,14 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
-function variantModelDriver(variant: AgentEvalVariant): Record<string, unknown> {
+function variantModelDriver(
+  variant: AgentEvalVariant,
+  output?: unknown,
+): Record<string, unknown> {
   return {
     ...(variant.instructions !== undefined ? { instructions: variant.instructions } : {}),
     model: variant.model,
+    ...(output !== undefined ? { output } : {}),
   }
 }
 
@@ -180,7 +184,7 @@ function applyVariantToExplicitDriver(
     }
   }
   if ("harness" in driver && variant.model !== undefined) {
-    return variantModelDriver(variant)
+    return variantModelDriver(variant, driver.output)
   }
   throw new Error("[vitehub] Agent Evaluation variants with model or instructions require a model-backed Agent Driver.")
 }

--- a/packages/agent/src/harness/claude-code.ts
+++ b/packages/agent/src/harness/claude-code.ts
@@ -10,14 +10,15 @@ import type {
   HarnessV1StreamPart,
 } from "@ai-sdk/harness"
 import type { ClaudeCodeHarnessSettings } from "@ai-sdk/harness-claude-code"
-import type { AgentHarnessDriver, ClaudeCodeDriverOptions } from "../types.ts"
+import type { AgentHarnessDriver, AgentInvocationContextValues, AgentRuntimeConfig, ClaudeCodeDriverOptions } from "../types.ts"
 
 const claudeCodePackage = "@ai-sdk/harness-claude-code"
 
-export async function createClaudeCodeDriver(options: ClaudeCodeDriverOptions = {}): Promise<AgentHarnessDriver> {
+export async function createClaudeCodeDriver<TOutput = unknown>(options: ClaudeCodeDriverOptions<TOutput> = {}): Promise<AgentHarnessDriver<AgentRuntimeConfig, unknown, AgentInvocationContextValues, TOutput>> {
   const {
     credentials,
     env,
+    output,
     sandbox,
     ...settings
   } = options
@@ -25,6 +26,7 @@ export async function createClaudeCodeDriver(options: ClaudeCodeDriverOptions = 
   return {
     credentials: credentials ?? { label: "Claude Code", source: "ambient" },
     harness: await createClaudeCode(settings as ClaudeCodeHarnessSettings),
+    ...(output !== undefined ? { output } : {}),
     ...(sandbox === false
       ? {}
       : {

--- a/packages/agent/src/harness/codex.ts
+++ b/packages/agent/src/harness/codex.ts
@@ -11,6 +11,7 @@ import type { CodexHarnessSettings } from "@ai-sdk/harness-codex"
 import type {
   AgentHarnessDriver,
   AgentHarnessSandboxProviderInput,
+  AgentInvocationContextValues,
   AgentRuntimeConfig,
   CodexDriverOptions,
   CodexDriverSandboxOptions,
@@ -20,11 +21,12 @@ const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
 const harnessGlobalSkillsDirectory = Symbol.for("vitehub.harnessGlobalSkillsDirectory")
 const harnessSessionPrepare = Symbol.for("vitehub.harnessSessionPrepare")
 
-export function createCodexDriver<CALL_OPTIONS = unknown>(options: CodexDriverOptions<CALL_OPTIONS> = {}): AgentHarnessDriver<AgentRuntimeConfig, CALL_OPTIONS> {
+export function createCodexDriver<CALL_OPTIONS = unknown, TOutput = unknown>(options: CodexDriverOptions<CALL_OPTIONS, TOutput> = {}): AgentHarnessDriver<AgentRuntimeConfig, CALL_OPTIONS, AgentInvocationContextValues, TOutput> {
   const {
     credentials,
     env,
     instructions,
+    output,
     sandbox,
     workDir,
     ...settings
@@ -43,6 +45,7 @@ export function createCodexDriver<CALL_OPTIONS = unknown>(options: CodexDriverOp
     credentials: credentials ?? { label: "Codex", source: "ambient" },
     harness: createViteHubCodex({ ...settings, auth, model }, defaultOpenAIAuth),
     ...(instructions !== undefined ? { instructions } : {}),
+    ...(output !== undefined ? { output } : {}),
     requires: [
       defaultOpenAIAuth ? { name: "Codex", command: "codex", args: ["login", "status"] } : "codex",
     ],

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -116,6 +116,7 @@ import type {
   AgentChannelDeliveryFinishEffectResult,
   AgentChannelDeliveryFinishEffectContext,
   AgentDefinition,
+  AgentDriver,
   AgentDriverContribution,
   AgentDriverKind,
   CustomAgentDriver,
@@ -438,6 +439,7 @@ const baseAgentResolve = Symbol.for("vitehub.baseAgentResolve")
 const baseAgentModel = Symbol.for("vitehub.baseAgentModel")
 const baseAgentDriverKind = Symbol.for("vitehub.baseAgentDriverKind")
 const baseAgentDefinitionResolve = Symbol.for("vitehub.baseAgentDefinitionResolve")
+const baseAgentOutput = Symbol.for("vitehub.baseAgentOutput")
 const baseAgentBoxRequirements = Symbol.for("vitehub.baseAgentBoxRequirements")
 const baseAgentCapabilitiesResolver = Symbol.for("vitehub.baseAgentCapabilitiesResolver")
 type WorkspaceSourceNames<TWorkspace> =
@@ -581,6 +583,7 @@ type AgentDefinitionWithBaseResolve<
   [baseAgentBoxRequirements]?: readonly BoxRequirement[]
   [baseAgentCapabilitiesResolver]?: AgentCapabilitiesResolver<TRuntimeConfig, WorkspaceName, CALL_OPTIONS>
   [baseAgentDriverKind]?: AgentDriverKind
+  [baseAgentOutput]?: AgentOutputDefinition<TOutput>
   [baseAgentResolve]?: BaseAgentResolver<TRuntimeConfig, CALL_OPTIONS>
   [baseAgentModel]?: AgentModelResolver<TRuntimeConfig>
   [colocatedAgentSkillsSymbol]?: ColocatedAgentSkills
@@ -1027,7 +1030,7 @@ function defineBaseAgent<
   options: AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentInvocationContextValues, AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined, TOutput>,
 ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentInvocationContextValues, TOutput> {
   const driver = normalizeAgentDriver(options)
-  const { box, capabilities, cli, description, hooks, messages, name, output, runtime = defaultAgentWorkflowRuntime(), runEvents, uiMessageStream, version, workspace } = options
+  const { box, capabilities, cli, description, hooks, messages, name, runtime = defaultAgentWorkflowRuntime(), runEvents, uiMessageStream, version, workspace } = options
   const channels = normalizeAgentChannels(options.channels)
   if (box && driver.kind !== "harness") {
     throw new Error("[vitehub] defineAgent({ box }) currently requires a harness Agent Driver.")
@@ -1076,6 +1079,7 @@ function defineBaseAgent<
     ...(driver.kind === "harness" && driver.requires?.length ? { [baseAgentBoxRequirements]: driver.requires } : {}),
     ...(driver.kind === "model" ? { [baseAgentModel]: driver.model } : {}),
     [baseAgentDriverKind]: driver.kind,
+    ...(driver.output ? { [baseAgentOutput]: driver.output } : {}),
     ...(capabilitiesResolver ? { [baseAgentCapabilitiesResolver]: capabilitiesResolver } : {}),
     [baseAgentResolve]: resolveBaseAgent,
     box,
@@ -1087,7 +1091,6 @@ function defineBaseAgent<
     invoker,
     messages,
     name,
-    output,
     runtime,
     runEvents,
     run,
@@ -1178,7 +1181,7 @@ export interface DefineAgent {
       AgentCapabilitiesInvocationContextValues<TCapabilities>,
       AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>,
       TOutput,
-      CustomAgentDriver<TRuntimeConfig, CALL_OPTIONS, AgentCapabilitiesInvocationContextValues<TCapabilities>>
+      CustomAgentDriver<TRuntimeConfig, CALL_OPTIONS, AgentCapabilitiesInvocationContextValues<TCapabilities>, TOutput>
     > = WorkspaceAgentOptions<
       TRuntimeConfig,
       Name,
@@ -1187,10 +1190,10 @@ export interface DefineAgent {
       AgentCapabilitiesInvocationContextValues<TCapabilities>,
       AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>,
       TOutput,
-      CustomAgentDriver<TRuntimeConfig, CALL_OPTIONS, AgentCapabilitiesInvocationContextValues<TCapabilities>>
+      CustomAgentDriver<TRuntimeConfig, CALL_OPTIONS, AgentCapabilitiesInvocationContextValues<TCapabilities>, TOutput>
     >,
   >(
-    options: TOptions & { capabilities?: AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>, output?: AgentOutputDefinition<TOutput> } & ValidateWorkspaceAgentOptions<TOptions>,
+    options: TOptions & { capabilities?: AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>, driver: CustomAgentDriver<TRuntimeConfig, CALL_OPTIONS, AgentCapabilitiesInvocationContextValues<TCapabilities>, TOutput> } & ValidateWorkspaceAgentOptions<TOptions>,
   ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>, AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>, TOutput>
   <
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -1215,7 +1218,7 @@ export interface DefineAgent {
       AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>
     >,
   >(
-    options: TOptions & { capabilities?: AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>, output?: AgentOutputDefinition<TOutput> } & ValidateWorkspaceAgentOptions<TOptions>,
+    options: TOptions & { capabilities?: AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>, driver: AgentDriver<TRuntimeConfig, CALL_OPTIONS, AgentCapabilitiesInvocationContextValues<TCapabilities>, TOutput> } & ValidateWorkspaceAgentOptions<TOptions>,
   ): WorkspaceAgentDefinition<TRuntimeConfig, Name, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>, AgentCapabilitiesOption<TRuntimeConfig, Name, CALL_OPTIONS, TCapabilities>, TOutput>
   <
     TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -1231,7 +1234,7 @@ export interface DefineAgent {
       AgentCapabilitiesInvocationContextValues<TCapabilities>,
       AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>,
       TOutput,
-      CustomAgentDriver<TRuntimeConfig, CALL_OPTIONS, AgentCapabilitiesInvocationContextValues<TCapabilities>>
+      CustomAgentDriver<TRuntimeConfig, CALL_OPTIONS, AgentCapabilitiesInvocationContextValues<TCapabilities>, TOutput>
     > & { capabilities?: AgentCapabilitiesOption<TRuntimeConfig, WorkspaceName, CALL_OPTIONS, TCapabilities>, workspace?: never },
   ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentCapabilitiesInvocationContextValues<TCapabilities>, TOutput>
   <
@@ -1815,7 +1818,7 @@ async function createAgentInvocationContext<
       messages: capabilities.messages,
       modelExecutionInstrumentation: capabilities.registries.modelExecutionInstrumentation,
       outputExtensionProviders: capabilities.registries.outputExtensionProviders,
-      output: definition?.output,
+      output: internalDefinition?.[baseAgentOutput],
       outputRenderers: capabilities.registries.outputRenderers,
       prompt: typeof capabilities.input.prompt === "string" ? capabilities.input.prompt : undefined,
       providerTools: capabilities.registries.providerTools,

--- a/packages/agent/src/internal/agent-driver.ts
+++ b/packages/agent/src/internal/agent-driver.ts
@@ -12,6 +12,7 @@ import type {
   AgentInvokerProfile,
   AgentModelExecutionOptions,
   AgentModelResolver,
+  AgentOutputDefinition,
   AgentRunHandler,
   AgentRuntimeConfig,
   AgentSettings,
@@ -23,12 +24,14 @@ import type { BoxRequirement } from "@vite-hub/box"
 type NormalizedAgentDriver<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
+  TOutput = unknown,
 > =
   | {
     execution?: AgentModelExecutionOptions<TRuntimeConfig, CALL_OPTIONS>
     instructions?: AgentAdapterInstructions<TRuntimeConfig>
     kind: "model"
     model: AgentModelResolver<TRuntimeConfig>
+    output?: AgentOutputDefinition<TOutput>
   }
   | {
     credentials?: AgentHarnessCredentialSource
@@ -36,6 +39,7 @@ type NormalizedAgentDriver<
     hasSandbox?: boolean
     instructions?: AgentHarnessInstructions<TRuntimeConfig, CALL_OPTIONS>
     kind: "harness"
+    output?: AgentOutputDefinition<TOutput>
     provider?: string
     requires?: readonly BoxRequirement[]
     resolve?: () => Promise<AgentHarnessDriver<TRuntimeConfig, CALL_OPTIONS>>
@@ -45,6 +49,7 @@ type NormalizedAgentDriver<
   }
   | {
     kind: "run"
+    output?: AgentOutputDefinition<TOutput>
     run: AgentRunHandler<TRuntimeConfig, CALL_OPTIONS>
   }
 
@@ -93,9 +98,9 @@ function normalizeHarnessCredentialSource(value: unknown): AgentHarnessCredentia
   }
 }
 
-const modelDriverKeys = new Set(["execution", "instructions", "model"])
-const harnessDriverKeys = new Set(["credentials", "harness", "instructions", "requires", "sandbox", "sessionKey", "workDir"])
-const runDriverKeys = new Set(["run"])
+const modelDriverKeys = new Set(["execution", "instructions", "model", "output"])
+const harnessDriverKeys = new Set(["credentials", "harness", "instructions", "output", "requires", "sandbox", "sessionKey", "workDir"])
+const runDriverKeys = new Set(["output", "run"])
 const codexDriverKeys = new Set([
   "auth",
   "credentials",
@@ -103,6 +108,7 @@ const codexDriverKeys = new Set([
   "instructions",
   "kind",
   "model",
+  "output",
   "port",
   "reasoningEffort",
   "sandbox",
@@ -117,6 +123,7 @@ const claudeCodeDriverKeys = new Set([
   "kind",
   "maxTurns",
   "model",
+  "output",
   "port",
   "sandbox",
   "startupTimeoutMs",
@@ -174,6 +181,7 @@ function normalizeBuiltInAgentDriver<
       credentials: options.credentials ?? { label: "Codex", source: "ambient" },
       hasSandbox: options.sandbox !== false && (options.sandbox !== undefined || options.env !== undefined),
       kind: "harness",
+      output: options.output,
       provider: "codex",
       requires: [
         options.auth === undefined
@@ -198,6 +206,7 @@ function normalizeBuiltInAgentDriver<
     credentials: options.credentials ?? { label: "Claude Code", source: "ambient" },
     hasSandbox: options.sandbox !== false,
     kind: "harness",
+    output: options.output,
     provider: "claude-code",
     resolve,
   }
@@ -238,6 +247,7 @@ function normalizeExplicitAgentDriver<
       instructions: driver.instructions as AgentAdapterInstructions<TRuntimeConfig> | undefined,
       kind: "model",
       model: driver.model as AgentModelResolver<TRuntimeConfig>,
+      output: driver.output as AgentOutputDefinition | undefined,
     }
   }
   if (keys[0] === "harness") {
@@ -251,6 +261,7 @@ function normalizeExplicitAgentDriver<
       harness: driver.harness as AgentHarnessDriverInput,
       instructions: driver.instructions as AgentHarnessInstructions<TRuntimeConfig, CALL_OPTIONS> | undefined,
       kind: "harness",
+      output: driver.output as AgentOutputDefinition | undefined,
       requires: driver.requires as readonly BoxRequirement[] | undefined,
       sandbox: driver.sandbox as AgentHarnessSandboxProviderInput<TRuntimeConfig, CALL_OPTIONS> | undefined,
       sessionKey: driver.sessionKey as AgentHarnessSessionKey<TRuntimeConfig, CALL_OPTIONS> | undefined,
@@ -264,6 +275,7 @@ function normalizeExplicitAgentDriver<
   }
   return {
     kind: "run",
+    output: driver.output as AgentOutputDefinition | undefined,
     run: driver.run as AgentRunHandler<TRuntimeConfig, CALL_OPTIONS>,
   }
   }
@@ -289,6 +301,9 @@ export function normalizeAgentDriver<
   const record = options as Record<string, unknown>
   if (hasOwnDefined(record, "harnessSandbox")) {
     throw new Error("[vitehub] defineAgent({ harnessSandbox }) is no longer supported. Move the provider to defineAgent({ driver: { harness, sandbox } }); sandbox({ commands }) remains the model-facing command execution Capability.")
+  }
+  if (hasOwnDefined(record, "output")) {
+    throw new Error("[vitehub] defineAgent({ output }) is no longer supported. Move it to defineAgent({ driver: { output } }).")
   }
   if (hasOwnDefined(record, "driver")) {
     return normalizeExplicitAgentDriver<TRuntimeConfig, CALL_OPTIONS>(record.driver)

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -971,12 +971,13 @@ export type CodexDriverSandboxOptions<CALL_OPTIONS = unknown> =
   | LocalHarnessSandboxOptions
   | AgentHarnessSandboxProviderInput<AgentRuntimeConfig, CALL_OPTIONS>
 
-export interface CodexDriverOptions<CALL_OPTIONS = unknown> {
+export interface CodexDriverOptions<CALL_OPTIONS = unknown, TOutput = unknown> {
   auth?: CodexAuthOptions
   credentials?: AgentHarnessCredentialSource
   env?: Record<string, string | undefined>
   instructions?: AgentHarnessInstructions<AgentRuntimeConfig, CALL_OPTIONS>
   model?: string
+  output?: AgentOutputDefinition<TOutput>
   port?: number
   reasoningEffort?: "low" | "medium" | "high"
   sandbox?: CodexDriverSandboxOptions<CALL_OPTIONS>
@@ -1006,12 +1007,13 @@ export type ClaudeCodeThinkingConfig =
     type: "disabled"
   }
 
-export interface ClaudeCodeDriverOptions {
+export interface ClaudeCodeDriverOptions<TOutput = unknown> {
   auth?: ClaudeCodeAuthOptions
   credentials?: AgentHarnessCredentialSource
   env?: Record<string, string | undefined>
   maxTurns?: number
   model?: string
+  output?: AgentOutputDefinition<TOutput>
   port?: number
   sandbox?: false | LocalHarnessSandboxOptions
   startupTimeoutMs?: number
@@ -1020,10 +1022,10 @@ export interface ClaudeCodeDriverOptions {
 
 export type BuiltInAgentDriverName = "claude-code" | "codex"
 
-export type BuiltInAgentDriver<CALL_OPTIONS = unknown> =
+export type BuiltInAgentDriver<CALL_OPTIONS = unknown, TOutput = unknown> =
   | BuiltInAgentDriverName
-  | ({ kind: "codex" } & CodexDriverOptions<CALL_OPTIONS>)
-  | ({ kind: "claude-code" } & ClaudeCodeDriverOptions)
+  | ({ kind: "codex" } & CodexDriverOptions<CALL_OPTIONS, TOutput>)
+  | ({ kind: "claude-code" } & ClaudeCodeDriverOptions<TOutput>)
 
 export type AgentHarnessSessionKey<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -1069,6 +1071,7 @@ export type AgentHarnessSandboxProviderInput<
 export interface AgentModelDriver<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
+  TOutput = unknown,
 > {
   credentials?: never
   execution?: AgentModelExecutionOptions<TRuntimeConfig, CALL_OPTIONS>
@@ -1076,6 +1079,7 @@ export interface AgentModelDriver<
   instructions?: AgentAdapterInstructions<TRuntimeConfig>
   kind?: never
   model: AgentModelResolver<TRuntimeConfig>
+  output?: AgentOutputDefinition<TOutput>
   permissionMode?: never
   permissions?: never
   run?: never
@@ -1088,6 +1092,7 @@ export interface AgentHarnessDriver<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
   TContextValues extends object = AgentInvocationContextValues,
+  TOutput = unknown,
 > {
   credentials?: AgentHarnessCredentialSource
   execution?: never
@@ -1095,6 +1100,7 @@ export interface AgentHarnessDriver<
   instructions?: AgentHarnessInstructions<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   kind?: never
   model?: never
+  output?: AgentOutputDefinition<TOutput>
   permissionMode?: never
   permissions?: never
   requires?: readonly BoxRequirement[]
@@ -1108,6 +1114,7 @@ export interface AgentRunDriver<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
   TContextValues extends object = AgentInvocationContextValues,
+  TOutput = unknown,
 > {
   credentials?: never
   execution?: never
@@ -1115,6 +1122,7 @@ export interface AgentRunDriver<
   instructions?: never
   kind?: never
   model?: never
+  output?: AgentOutputDefinition<TOutput>
   permissionMode?: never
   permissions?: never
   run: AgentRunHandler<TRuntimeConfig, CALL_OPTIONS, TContextValues>
@@ -1127,20 +1135,22 @@ export type AgentDriver<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
   TContextValues extends object = AgentInvocationContextValues,
+  TOutput = unknown,
 > =
-  | AgentModelDriver<TRuntimeConfig, CALL_OPTIONS>
-  | AgentHarnessDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues>
-  | AgentRunDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues>
-  | BuiltInAgentDriver<CALL_OPTIONS>
+  | AgentModelDriver<TRuntimeConfig, CALL_OPTIONS, TOutput>
+  | AgentHarnessDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues, TOutput>
+  | AgentRunDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues, TOutput>
+  | BuiltInAgentDriver<CALL_OPTIONS, TOutput>
 
 export type CustomAgentDriver<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
   TContextValues extends object = AgentInvocationContextValues,
+  TOutput = unknown,
 > =
-  | AgentModelDriver<TRuntimeConfig, CALL_OPTIONS>
-  | AgentHarnessDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues>
-  | AgentRunDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues>
+  | AgentModelDriver<TRuntimeConfig, CALL_OPTIONS, TOutput>
+  | AgentHarnessDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues, TOutput>
+  | AgentRunDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues, TOutput>
 
 export interface AgentDefinitionCliOptions {
   capabilities?: boolean
@@ -1169,7 +1179,6 @@ type AgentSharedSettings<
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
   TContextValues extends object = AgentInvocationContextValues,
   TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined,
-  TOutput = unknown,
 > = {
   box?: BoxDefinition<AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>>
   capabilities?: TCapabilities
@@ -1180,7 +1189,6 @@ type AgentSharedSettings<
   invoker?: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues>
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   name?: string
-  output?: AgentOutputDefinition<TOutput>
   runtime?: AgentRuntimeBinding
   runEvents?: AgentRunEvents
   uiMessageStream?: AgentUIMessageStreamProjectionResolver<TRuntimeConfig, CALL_OPTIONS, TContextValues>
@@ -1195,10 +1203,12 @@ export type AgentSettings<
   TContextValues extends object = AgentInvocationContextValues,
   TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined,
   TOutput = unknown,
-  TDriver extends AgentDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues> = AgentDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues>,
-> = AgentSharedSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities, TOutput> & {
+  TDriver extends AgentDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues, TOutput> = AgentDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues, TOutput>,
+> = AgentSharedSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities> & {
   driver: TDriver
 }
+
+declare const agentOutputType: unique symbol
 
 export interface AgentDefinition<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -1207,6 +1217,7 @@ export interface AgentDefinition<
   TContextValues extends object = AgentInvocationContextValues,
   TOutput = unknown,
 > {
+  [agentOutputType]?: TOutput
   box?: BoxDefinition<AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>>
   capabilities?: AgentCapabilityDefinition<TRuntimeConfig>[]
   channels?: AgentChannels<TRuntimeConfig>
@@ -1217,7 +1228,6 @@ export interface AgentDefinition<
   invoker?: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues>
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   name?: string
-  output?: AgentOutputDefinition<TOutput>
   runtime?: AgentRuntimeBinding
   runEvents?: AgentRunEvents
   resolve(context: AgentRuntimeContext<TRuntimeConfig>): Promise<AgentAdapter<CALL_OPTIONS>>

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -115,7 +115,7 @@ export type WorkspaceAgentOptions<
   TContextValues extends object = AgentInvocationContextValues,
   TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, _Name, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, _Name, CALL_OPTIONS> | undefined,
   TOutput = unknown,
-  TDriver extends AgentDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues> = AgentDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues>,
+  TDriver extends AgentDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues, TOutput> = AgentDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues, TOutput>,
 > = AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities, TOutput, TDriver> & {
   name?: string
   workspace: WorkspaceAgentWorkspaceConfig<_Name>

--- a/packages/agent/test/eval.test.ts
+++ b/packages/agent/test/eval.test.ts
@@ -438,12 +438,24 @@ describe("agent eval", () => {
   it("applies model variants by replacing harness drivers for workspace agents", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineEval } = await import("../src/eval.ts")
+    const validate = vi.fn((value: unknown) => ({ value }))
+    const output = {
+      schema: {
+        "~standard": {
+          validate,
+          vendor: "vitehub-test",
+          version: 1 as const,
+        },
+      },
+    }
     const variantModel = { id: "variant" }
+    agentGenerate.mockResolvedValue({ finishReason: "stop", text: "{\"ok\":true}" })
 
     defineEval({
       agent: defineAgent({
         driver: {
           harness: { provider: "codex" },
+          output,
         },
         workspace: {},
       }),
@@ -458,6 +470,7 @@ describe("agent eval", () => {
     expect(agentSettings.at(-1)).toMatchObject({
       model: variantModel,
     })
+    expect(validate).toHaveBeenCalledWith({ ok: true })
   })
 
   it("applies replacement instruction variants for base agents", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -288,6 +288,15 @@ describe("agent message protocol", () => {
     } as never)).toThrowError("defineAgent({ harnessSandbox }) is no longer supported")
   })
 
+  it("rejects structured output at the agent root", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+
+    expect(() => defineAgent({
+      driver: { run: () => "{}" },
+      output: { schema: {} },
+    } as never)).toThrowError("defineAgent({ output }) is no longer supported")
+  })
+
   it("runs agent input hooks once before driver execution and can abort", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const run = vi.fn(() => "ok")
@@ -1449,8 +1458,7 @@ describe("agent message protocol", () => {
       },
     }
     const agent = defineAgent({
-      driver: { harness: { provider: "codex" } },
-      output: { schema },
+      driver: { harness: { provider: "codex" }, output: { schema } },
       runtime: false,
     })
 
@@ -1459,19 +1467,58 @@ describe("agent message protocol", () => {
     expect(harnessAgentSettings.at(-1)?.instructions).toContain('"title"')
   })
 
+  it("guides model Drivers with configured structured output", async () => {
+    const agentSettings: Record<string, unknown>[] = []
+    loadAiSdk.mockResolvedValue({
+      isStepCount: () => () => false,
+      jsonSchema: vi.fn(schema => schema),
+      ToolLoopAgent: class {
+        constructor(settings: Record<string, unknown>) {
+          agentSettings.push(settings)
+        }
+
+        async generate() {
+          return { text: "{\"title\":\"Weekly sync\"}" }
+        }
+      },
+    })
+    const schema = {
+      "~standard": {
+        jsonSchema: {
+          input: () => ({ properties: { title: { type: "string" } }, required: ["title"], type: "object" }),
+          output: () => ({ type: "number" }),
+        },
+        validate: (value: unknown) => ({ value: value as { title: string } }),
+        vendor: "vitehub-test",
+        version: 1 as const,
+      },
+    }
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      driver: { model: {} as never, output: { schema } },
+      runtime: false,
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toEqual({ title: "Weekly sync" })
+    expect(agentSettings.at(-1)?.instructions).toContain("Return only one valid JSON value")
+    expect(agentSettings.at(-1)?.instructions).toContain('"title"')
+  })
+
   it("rejects malformed JSON from structured harness results", async () => {
     const { ViteHubError } = await import("@vite-hub/runtime")
     const { defineAgent, runAgent } = await import("../src/index.ts")
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
     harnessGenerate.mockResolvedValueOnce({ text: "hello" })
     const agent = defineAgent({
-      driver: { harness: { provider: "codex" } },
-      output: {
-        schema: {
-          "~standard": {
-            validate: (value: unknown) => ({ value: value as { text: string } }),
-            vendor: "vitehub-test",
-            version: 1,
+      driver: {
+        harness: { provider: "codex" },
+        output: {
+          schema: {
+            "~standard": {
+              validate: (value: unknown) => ({ value: value as { text: string } }),
+              vendor: "vitehub-test",
+              version: 1,
+            },
           },
         },
       },

--- a/packages/agent/test/structured-output.test.ts
+++ b/packages/agent/test/structured-output.test.ts
@@ -48,9 +48,8 @@ describe("Agent structured output", () => {
       }
     }
     const agent = defineAgent({
-      driver: { run: () => new HarnessResult() },
+      driver: { output: { schema: summarySchema() }, run: () => new HarnessResult() },
       hooks: { "agent:finish": finish },
-      output: { schema: summarySchema() },
       runtime: false,
     })
 
@@ -65,8 +64,7 @@ describe("Agent structured output", () => {
 
   it("reports malformed JSON with a stable ViteHub-owned error", async () => {
     const agent = defineAgent({
-      driver: { run: () => "not json" },
-      output: { schema: summarySchema() },
+      driver: { output: { schema: summarySchema() }, run: () => "not json" },
       runtime: false,
     })
 
@@ -87,15 +85,17 @@ describe("Agent structured output", () => {
   it("preserves custom schema failures exactly", async () => {
     const cause = new Error("private validator failure")
     const agent = defineAgent({
-      driver: { run: () => ({ summary: "Decisions", title: "Weekly sync" }) },
-      output: {
-        schema: {
-          "~standard": {
-            validate: () => Promise.reject(cause),
-            vendor: "vitehub-test",
-            version: 1,
+      driver: {
+        output: {
+          schema: {
+            "~standard": {
+              validate: () => Promise.reject(cause),
+              vendor: "vitehub-test",
+              version: 1,
+            },
           },
         },
+        run: () => ({ summary: "Decisions", title: "Weekly sync" }),
       },
       runtime: false,
     })
@@ -107,8 +107,7 @@ describe("Agent structured output", () => {
     const cause = new Error("private model getter")
     const result = new Proxy({}, { has: () => { throw cause } })
     const agent = defineAgent({
-      driver: { run: () => result },
-      output: { schema: summarySchema() },
+      driver: { output: { schema: summarySchema() }, run: () => result },
       runtime: false,
     })
 
@@ -121,15 +120,17 @@ describe("Agent structured output", () => {
     const cause = new Error("private issue getter")
     const issue = Object.defineProperty({}, "path", { get: () => { throw cause } })
     const agent = defineAgent({
-      driver: { run: () => "{}" },
-      output: {
-        schema: {
-          "~standard": {
-            validate: () => ({ issues: [issue as never] }),
-            vendor: "vitehub-test",
-            version: 1,
+      driver: {
+        output: {
+          schema: {
+            "~standard": {
+              validate: () => ({ issues: [issue as never] }),
+              vendor: "vitehub-test",
+              version: 1,
+            },
           },
         },
+        run: () => "{}",
       },
       runtime: false,
     })
@@ -152,8 +153,7 @@ describe("Agent structured output", () => {
       },
     }
     const agent = defineAgent({
-      driver: { run: () => ({ text: "hello" }) },
-      output: { schema },
+      driver: { output: { schema }, run: () => ({ text: "hello" }) },
       runtime: false,
     })
 
@@ -173,8 +173,7 @@ describe("Agent structured output", () => {
       },
     }
     const agent = defineAgent({
-      driver: { run: () => ({ text: "42" }) },
-      output: { schema },
+      driver: { output: { schema }, run: () => ({ text: "42" }) },
       runtime: false,
     })
 
@@ -183,8 +182,7 @@ describe("Agent structured output", () => {
 
   it("decodes AgentRunResult text from custom drivers", async () => {
     const agent = defineAgent({
-      driver: { run: () => ({ text: "{\"summary\":\"Decisions\",\"title\":\"Weekly sync\"}" }) },
-      output: { schema: summarySchema() },
+      driver: { output: { schema: summarySchema() }, run: () => ({ text: "{\"summary\":\"Decisions\",\"title\":\"Weekly sync\"}" }) },
       runtime: false,
     })
 
@@ -197,12 +195,12 @@ describe("Agent structured output", () => {
   it("materializes and validates structured custom driver streams", async () => {
     const agent = defineAgent({
       driver: {
+        output: { schema: summarySchema() },
         run: async function* () {
           yield { text: "{\"summary\":\"Dec", type: "text-delta" as const }
           yield { text: "isions\",\"title\":\"Weekly sync\"}", type: "text-delta" as const }
         },
       },
-      output: { schema: summarySchema() },
       runtime: false,
     })
 
@@ -221,8 +219,7 @@ describe("Agent structured output", () => {
       },
     }
     const agent = defineAgent({
-      driver: { run: () => stream },
-      output: { schema: summarySchema() },
+      driver: { output: { schema: summarySchema() }, run: () => stream },
       runtime: false,
     })
     const result = runAgentInline(agent, runtime(), { abortSignal: controller.signal })
@@ -235,13 +232,13 @@ describe("Agent structured output", () => {
   it("materializes structured stream-result wrappers", async () => {
     const agent = defineAgent({
       driver: {
+        output: { schema: summarySchema() },
         run: () => ({
           stream: (async function* () {
             yield { text: "{\"summary\":\"Decisions\",\"title\":\"Weekly sync\"}", type: "text-delta" as const }
           })(),
         }),
       },
-      output: { schema: summarySchema() },
       runtime: false,
     })
 
@@ -255,13 +252,13 @@ describe("Agent structured output", () => {
     const finish = vi.fn()
     const agent = defineAgent({
       driver: {
+        output: { schema: summarySchema() },
         run: async function* () {
           yield { text: "{\"summary\":\"Decisions\",\"title\":\"Weekly sync\"}", type: "text-delta" as const }
           yield { type: "usage" as const, usageRecord: { usage: { totalTokens: 3 } } }
         },
       },
       hooks: { "agent:finish": finish },
-      output: { schema: summarySchema() },
       runtime: false,
     })
 
@@ -274,11 +271,11 @@ describe("Agent structured output", () => {
   it("preserves raw custom driver streams", async () => {
     const agent = defineAgent({
       driver: {
+        output: { schema: summarySchema() },
         run: async function* () {
           yield { text: "not json", type: "text-delta" as const }
         },
       },
-      output: { schema: summarySchema() },
       runtime: false,
     })
 
@@ -296,8 +293,7 @@ describe("Agent structured output", () => {
     })()
     const wrapper = { stream }
     const agent = defineAgent({
-      driver: { run: () => wrapper },
-      output: { schema: summarySchema() },
+      driver: { output: { schema: summarySchema() }, run: () => wrapper },
       runtime: false,
     })
 
@@ -311,13 +307,13 @@ describe("Agent structured output", () => {
     const finish = vi.fn()
     const agent = defineAgent({
       driver: {
+        output: { schema: summarySchema() },
         run: () => ({
           text: "{\"summary\":\"Decisions\",\"title\":\"Weekly sync\"}",
           usageRecord: { usage: { totalTokens: 3 } },
         }),
       },
       hooks: { "agent:finish": finish },
-      output: { schema: summarySchema() },
       runtime: false,
     })
 
@@ -331,6 +327,7 @@ describe("Agent structured output", () => {
     const finish = vi.fn()
     const agent = defineAgent({
       driver: {
+        output: { schema: summarySchema() },
         run: async function* () {
           yield { text: "{\"summary\":\"Decisions\",", type: "text-delta" as const }
           yield { text: "\"title\":\"Weekly sync\"}", type: "text-delta" as const }
@@ -338,7 +335,6 @@ describe("Agent structured output", () => {
         },
       },
       hooks: { "agent:finish": finish },
-      output: { schema: summarySchema() },
       runtime: false,
     })
 
@@ -353,8 +349,7 @@ describe("Agent structured output", () => {
 
   it("reports Standard Schema failures separately from JSON decoding", async () => {
     const agent = defineAgent({
-      driver: { run: () => "{\"title\":42}" },
-      output: { schema: summarySchema() },
+      driver: { output: { schema: summarySchema() }, run: () => "{\"title\":42}" },
       runtime: false,
     })
 

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -119,8 +119,7 @@ describe("agent public types", () => {
       },
     } satisfies StandardSchemaV1<unknown, { summary: string, title: string }>
     const agent = defineAgent({
-      driver: { run: () => "{}" },
-      output: { schema },
+      driver: { output: { schema }, run: () => "{}" },
       runtime: false,
     })
     const result = runAgentInline(agent, {} as AgentRuntimeContext, {})


### PR DESCRIPTION
Moves typed structured output into the Agent Driver that produces it, including custom model, harness, and run Drivers plus the built-in Codex and Claude Code configurations. Model and harness execution now receive the configured JSON-only instruction and optional Standard JSON Schema from `driver.output`, while output validation and inferred finish-result types remain unchanged.

This removes the root `defineAgent({ output })` contract. Consumers should move it beside the selected implementation as `defineAgent({ driver: { ..., output } })`; the runtime reports that migration directly when the legacy shape is used.

Validated with the full Agent suite (1,450 tests), Agent and docs typechecks, focused lint, `git diff --check`, and the Agent plus aggregate `vite-hub` builds with publint.
