### PR TITLE
fix(agent): preserve image attachments without MIME

### DIFF
--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -322,6 +322,35 @@ function attachmentDataByteLength(data: AttachmentData | undefined): number | un
   if (typeof data === "string") return new TextEncoder().encode(data).byteLength
 }
 
+function resolvedImageMediaType(data: AttachmentData): string | undefined {
+  if (data instanceof Blob && data.type.startsWith("image/")) return data.type
+  if (typeof data === "string") {
+    const dataUrlMediaType = /^data:(image\/[^;,]+)[;,]/i.exec(data)?.[1]?.toLowerCase()
+    if (dataUrlMediaType) return dataUrlMediaType
+    if (!/^[A-Za-z0-9+/]+={0,2}$/.test(data) || data.length % 4 !== 0) return
+    try {
+      const decoded = atob(data.slice(0, Math.min(data.length, 24)))
+      return resolvedImageMediaType(Uint8Array.from(decoded, character => character.charCodeAt(0)))
+    }
+    catch {
+      return
+    }
+  }
+  const bytes = data instanceof ArrayBuffer
+    ? new Uint8Array(data)
+    : data instanceof Uint8Array ? data : undefined
+  if (!bytes) return
+  const startsWith = (signature: number[], offset = 0) =>
+    signature.every((byte, index) => bytes[offset + index] === byte)
+  if (startsWith([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])) return "image/png"
+  if (startsWith([0xFF, 0xD8, 0xFF])) return "image/jpeg"
+  if (startsWith([0x47, 0x49, 0x46, 0x38, 0x37, 0x61]) || startsWith([0x47, 0x49, 0x46, 0x38, 0x39, 0x61])) return "image/gif"
+  if (startsWith([0x42, 0x4D])) return "image/bmp"
+  if (startsWith([0x52, 0x49, 0x46, 0x46]) && startsWith([0x57, 0x45, 0x42, 0x50], 8)) return "image/webp"
+  if (startsWith([0x49, 0x49, 0x2A, 0x00]) || startsWith([0x4D, 0x4D, 0x00, 0x2A])) return "image/tiff"
+  if (startsWith([0x00, 0x00, 0x01, 0x00])) return "image/x-icon"
+}
+
 function assertAttachmentWithinLimit(part: AttachmentPart, byteLength: number | undefined, maxBytes: number): void {
   if (typeof byteLength === "number" && byteLength > maxBytes) {
     throw new Error(`[vitehub] ${part.type} attachment is ${byteLength} bytes, which exceeds maxBytes (${maxBytes}).`)
@@ -339,7 +368,10 @@ async function resolveModelAttachmentPart(part: AttachmentPart, maxBytes: number
   assertAttachmentWithinLimit(part, byteLength, maxBytes)
   const data = resolved instanceof Blob ? await resolved.arrayBuffer() : resolved
   const { fetchData: _fetchData, ...rest } = part
-  return { byteLength, part: { ...rest, data } }
+  const mediaType = part.type === "image"
+    ? resolvedImageMediaType(resolved) ?? resolvedImageMediaType(data)
+    : undefined
+  return { byteLength, part: { ...rest, data, ...(mediaType ? { mediaType } : {}) } }
 }
 
 function channelCurrentMessageId(context: AgentAdapterRunContext): string | null | undefined {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1395,6 +1395,23 @@ const chatTextAttachmentMaxBytes = 8 * 1024 * 1024
 const textAttachmentExtensions = new Set(["csv", "json", "log", "md", "txt", "yaml", "yml"])
 const textAttachmentMimeTypes = new Set(["application/json", "application/x-yaml", "application/yaml", "text/csv"])
 const chatTextAttachmentOversizeMessage = `[vitehub] Chat text attachment exceeds ${chatTextAttachmentMaxBytes} bytes.`
+const imageAttachmentMimeTypes: Record<string, string> = {
+  avif: "image/avif",
+  gif: "image/gif",
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  png: "image/png",
+  svg: "image/svg+xml",
+  webp: "image/webp",
+}
+
+function imageAttachmentMediaType(attachment: Attachment): string | undefined {
+  if (attachment.data instanceof Blob && attachment.data.type.startsWith("image/")) return attachment.data.type
+  for (const path of [attachment.name, attachment.url]) {
+    const extension = path?.split(/[?#]/)[0]?.split(".").pop()?.toLowerCase()
+    if (extension && imageAttachmentMimeTypes[extension]) return imageAttachmentMimeTypes[extension]
+  }
+}
 
 function isTextAttachment(attachment: Attachment): boolean {
   if (attachment.type !== "file") return false
@@ -1504,14 +1521,16 @@ async function textPartFromAttachment(attachment: Attachment, index: number, opt
 }
 
 function attachmentPartFromAttachment(attachment: Attachment, index: number): AttachmentPart | undefined {
-  const mediaType = typeof attachment.mimeType === "string" && attachment.mimeType
+  const declaredMediaType = typeof attachment.mimeType === "string" && attachment.mimeType
     ? attachment.mimeType
     : undefined
-  const type = mediaType?.startsWith("audio/") || (attachment.type === "audio" && !mediaType)
+  const type = declaredMediaType?.startsWith("audio/") || (attachment.type === "audio" && !declaredMediaType)
     ? "audio"
-    : mediaType?.startsWith("image/")
+    : declaredMediaType?.startsWith("image/") || (attachment.type === "image" && !declaredMediaType)
       ? "image"
       : "file"
+  const mediaType = declaredMediaType
+    ?? (type === "image" ? imageAttachmentMediaType(attachment) : undefined)
   const data = isAttachmentData(attachment.data) ? attachment.data : undefined
   const fetchData = typeof attachment.fetchData === "function"
     ? async () => {
@@ -1530,7 +1549,7 @@ function attachmentPartFromAttachment(attachment: Attachment, index: number): At
     fetchData,
     fetchMetadata: attachment.fetchMetadata,
     id: `attachment-${index + 1}`,
-    mediaType: mediaType ?? (type === "audio" ? "audio/ogg" : "application/octet-stream"),
+    mediaType: mediaType ?? (type === "audio" ? "audio/ogg" : type === "image" ? "image/jpeg" : "application/octet-stream"),
     name: attachment.name,
     size: attachment.size,
     type,

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -41,7 +41,7 @@ const optionalMessageAdapterRuntimeExternals = [
 
 const hostedAgentRoot = join(import.meta.dirname, "../../../fixtures/tutorials/agents")
 
-function createTestChatAdapter(options: { attachmentFetchData?: () => Promise<Buffer>, deferMessageProcessing?: boolean, missingIncomingMessageId?: boolean, persistThreadHistory?: boolean, secret?: string } = {}) {
+function createTestChatAdapter(options: { attachmentFetchData?: () => Promise<Buffer>, deferMessageProcessing?: boolean, missingIncomingMessageId?: boolean, persistThreadHistory?: boolean, photoData?: Blob, secret?: string } = {}) {
   let chatInstance: ChatInstance | undefined
   let sentMessageId = 0
   const cachedMessages = new Map<string, Message[]>()
@@ -63,7 +63,7 @@ function createTestChatAdapter(options: { attachmentFetchData?: () => Promise<Bu
       const chat = rawMessage.chat as { id?: number | string } | undefined
       const from = rawMessage.from as { email?: string, id?: number | string, is_bot?: boolean, mail?: string, userPrincipalName?: string, username?: string } | undefined
       const document = rawMessage.document as { content?: string, file_id?: string, file_name?: string, file_size?: number, mime_type?: string, url?: string } | undefined
-      const photos = rawMessage.photo as Array<{ file_id?: string, file_size?: number, height?: number, width?: number }> | undefined
+      const photos = rawMessage.photo as Array<{ file_id?: string, file_name?: string, file_size?: number, height?: number, url?: string, width?: number }> | undefined
       const photo = photos?.at(-1)
       const date = typeof rawMessage.date === "number"
         ? new Date(rawMessage.date * 1000)
@@ -100,11 +100,15 @@ function createTestChatAdapter(options: { attachmentFetchData?: () => Promise<Bu
               }]
           : typeof photo?.file_id === "string"
             ? [{
-                fetchData: options.attachmentFetchData ?? (async () => Buffer.from([1, 2, 3])),
+                ...(options.photoData
+                  ? { data: options.photoData }
+                  : { fetchData: options.attachmentFetchData ?? (async () => Buffer.from([1, 2, 3])) }),
                 fetchMetadata: { fileId: photo.file_id },
                 height: photo.height,
+                name: photo.file_name,
                 size: photo.file_size,
                 type: "image",
+                url: photo.url,
                 width: photo.width,
               }]
           : [],
@@ -3873,14 +3877,50 @@ describe("server helpers", () => {
           expect.objectContaining({
             fetchData: expect.any(Function),
             fetchMetadata: { fileId: "large-photo" },
-            mediaType: "application/octet-stream",
+            mediaType: "image/jpeg",
             size: 3,
-            type: "file",
+            type: "image",
           }),
         ],
       })],
     }))
     expect(attachmentFetchData).not.toHaveBeenCalled()
+  })
+
+  it("derives missing image MIME types from attachment metadata", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter({ photoData: new Blob(["image"], { type: "application/octet-stream" }) })
+    const run = vi.fn(() => "ok")
+    const agent = defineAgent({
+      channels: { telegram: telegram({ adapter: () => adapter as never }) },
+      driver: { run },
+    })
+
+    const response = await createChannelWebhookRouteHandler(agent as never)(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: 44,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 1014,
+          photo: [{ file_id: "image", file_name: "screenshot.png", url: "https://example.com/screenshot.png" }],
+        },
+      }),
+      method: "POST",
+    }), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({
+      messages: [expect.objectContaining({
+        parts: [expect.objectContaining({
+          mediaType: "image/png",
+          type: "image",
+        })],
+      })],
+    }))
   })
 
   it("preserves generic attachment URLs as typed references", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3273,6 +3273,41 @@ describe("agent message protocol", () => {
       }],
     }))
 
+    const pngBytes = new Uint8Array([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+    const detectedImageFetch = vi.fn(async () => new Blob([pngBytes], { type: "application/octet-stream" }))
+    const imageDetectionAgent = defineAgent({
+      driver: {
+        execution: { attachments: { maxBytes: 12 } },
+        model: "attachment-model" as never,
+      },
+    })
+    await runAgent(imageDetectionAgent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({
+        parts: [{ fetchData: detectedImageFetch, mediaType: "image/jpeg", type: "image" }],
+        role: "user",
+      })],
+    })
+    expect(generate).toHaveBeenLastCalledWith(expect.objectContaining({
+      messages: [{
+        content: [{ image: pngBytes.buffer, mediaType: "image/png", type: "image" }],
+        role: "user",
+      }],
+    }))
+
+    const rawBase64Image = btoa(String.fromCharCode(...pngBytes))
+    await runAgent(imageDetectionAgent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({
+        parts: [{ data: rawBase64Image, mediaType: "image/jpeg", type: "image" }],
+        role: "user",
+      })],
+    })
+    expect(generate).toHaveBeenLastCalledWith(expect.objectContaining({
+      messages: [{
+        content: [{ image: rawBase64Image, mediaType: "image/png", type: "image" }],
+        role: "user",
+      }],
+    }))
+
     const currentIdlessFetchData = vi.fn(async () => new Uint8Array([1, 2, 3]))
     const staleIdlessFetchData = vi.fn(async () => new Uint8Array([4, 5, 6]))
     await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {


### PR DESCRIPTION
Preserves Chat SDK attachments explicitly typed as images when adapters omit MIME metadata. ViteHub normalizes them to Agent image parts without eager fetching, deriving types from Blob metadata, filenames, URLs, data URLs, raw base64, or resolved byte signatures before model invocation.

This covers Telegram photos, whose adapter supplies an image type, file ID, and lazy fetch callback without a MIME type. Metadata-free photos retain the JPEG compatibility fallback until their bytes are resolved, while PNG, GIF, WebP, and other recognized image data are forwarded with their actual media type.

Validation: pnpm --filter @vite-hub/agent test -- providers.test.ts runtime.test.ts (545 passed; package build and publint clean), pnpm --filter @vite-hub/agent typecheck, and git diff --check.