### PR TITLE
feat(agent): filter channel messages before invocation

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -28,6 +28,18 @@ Built-in helpers include `discord()`, `github()`, `http()`, `slack()`, `teams()`
 
 Adapter-backed Channels deliver only the completed response by default. Set top-level `defineAgent({ messages: { stream: true } })` to opt every adapter Channel into draft and edit updates, or set `messages.stream` on an individual Channel to control progressive delivery for that destination. Web Chat routes return streaming HTTP responses independently of adapter delivery settings.
 
+Set `messages.filter` on an adapter-backed Channel to admit only supported incoming messages before Agent invocation. The filter receives the normalized current `Message` with the Channel callback context, run metadata, and thread controls; returning `false` ignores the delivery without starting the Agent or posting an error fallback.
+
+```ts
+telegram({
+  adapter,
+  messages: {
+    filter: ({ message }) =>
+      message.parts.length === 1 && message.parts[0]?.type === 'image',
+  },
+})
+```
+
 ## Deliver public commentary
 
 Adapter-backed Channels hide commentary by default. Set `messages.commentary` to `message` when an explicitly phased Agent stream should publish commentary as one best-effort progress message and deliver the final response as a separate message.

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -314,6 +314,8 @@ export type {
   AgentInvokerResolveContext,
   AgentMessageChannelSettings,
   AgentMessageConcurrency,
+  AgentMessageFilter,
+  AgentMessageFilterContext,
   AgentMessageLockScope,
   AgentOutputDefinition,
   AgentModelInput,

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -212,9 +212,9 @@ export function resolveAgentChannelChatOptions<TRuntimeConfig extends AgentRunti
   }
   if (channelMessageOverrides.length) {
     if (messageChannelCount > 1) {
-      const unsupportedOverrides = channelMessageOverrides.some(({ commentary: _commentary, stream: _stream, ...channelMessages }) => Object.keys(channelMessages).length > 0)
+      const unsupportedOverrides = channelMessageOverrides.some(({ commentary: _commentary, filter: _filter, stream: _stream, ...channelMessages }) => Object.keys(channelMessages).length > 0)
       if (unsupportedOverrides) {
-        throw new TypeError("[vitehub] Channel-local messages options other than commentary or stream are only supported when an Agent defines one message-shaped Channel. Move shared settings to defineAgent({ messages }) until Channel-scoped chat triggers land.")
+        throw new TypeError("[vitehub] Channel-local messages options other than commentary, filter, or stream are only supported when an Agent defines one message-shaped Channel. Move shared settings to defineAgent({ messages }) until Channel-scoped chat triggers land.")
       }
     }
     else {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1944,6 +1944,18 @@ async function handleChatSdkMessage(
       ? messages.find(item => item.id === message.id)
       : messages.at(-1)
     if (!currentMessage || !Array.isArray(currentMessage.parts) || currentMessage.parts.length === 0) return
+    const filter = options?.filter
+    if (filter) {
+      const [current] = uiMessagesToAgentMessages([currentMessage])
+      if (!current || !await filter({
+        ...context,
+        message: current,
+        run: input.run,
+        thread: {
+          post: async postedMessage => await postChatMessage(thread, postedMessage),
+        },
+      })) return
+    }
     input = { ...input, messages }
     const invocation = await resolveAgentTriggerInvocation(agent as never, context as never, "chat.message", input)
     if (isResolvedAgentTriggerHandledInvocation(invocation)) return

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1455,6 +1455,17 @@ export type AgentMessageConcurrency = "drop" | "parallel" | "queue" | "reject" |
 
 export type AgentMessageLockScope = "agent" | "channel" | "thread" | (string & {})
 
+export interface AgentMessageFilterContext<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>
+  extends AgentCallbackContext<TRuntimeConfig> {
+  message: Message
+  thread: {
+    post: AgentChatSendMessage
+  }
+}
+
+export type AgentMessageFilter<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> =
+  (context: AgentMessageFilterContext<TRuntimeConfig>) => MaybePromise<boolean>
+
 export interface AgentChatFinishExtension {
   provider?: string
   run?: Partial<AgentRunMetadata>
@@ -1467,6 +1478,7 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
   dedupeTtlMs?: number
   errorFallbackText?: string | null | ((context: AgentChatErrorHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
   fallbackStreamingPlaceholderText?: string | readonly string[] | null | ((context: AgentChatAgentHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
+  filter?: AgentMessageFilter<TRuntimeConfig>
   identity?: IdentityResolver
   lockScope?: AgentMessageLockScope
   messageHistory?: unknown

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -3096,6 +3096,72 @@ describe("server helpers", () => {
     }))
   })
 
+  it("filters adapter messages before Agent invocation", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const filter = vi.fn(async ({ message }) =>
+      message.parts.length === 1 && message.parts[0]?.type === "audio")
+    const run = vi.fn(() => "accepted")
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: { filter, stream: false },
+        }),
+      },
+      driver: { run },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+    const request = (message: Record<string, unknown>) => new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        update_id: message.message_id,
+        message: {
+          chat: { id: 456, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          ...message,
+        },
+      }),
+      method: "POST",
+    })
+
+    await handler(request({ message_id: 2006, text: "hello" }), "telegram", {
+      agentName: "support",
+      runtime: "vite",
+    })
+
+    expect(filter).toHaveBeenCalledWith(expect.objectContaining({
+      agentIdentity: { name: "support" },
+      message: expect.objectContaining({
+        parts: [expect.objectContaining({ text: "hello", type: "text" })],
+      }),
+      request: expect.any(Request),
+      run: expect.objectContaining({ messageId: "2006", origin: "telegram" }),
+      runtime: "vite",
+      thread: { post: expect.any(Function) },
+    }))
+    expect(run).not.toHaveBeenCalled()
+    expect(adapter.postMessage).not.toHaveBeenCalled()
+
+    await handler(request({
+      audio: { file_id: "audio-file" },
+      message_id: 2007,
+    }), "telegram", {
+      agentName: "support",
+      runtime: "vite",
+    })
+
+    expect(filter).toHaveBeenLastCalledWith(expect.objectContaining({
+      message: expect.objectContaining({
+        parts: [expect.objectContaining({ mediaType: "audio/ogg", type: "audio" })],
+      }),
+    }))
+    expect(run).toHaveBeenCalledOnce()
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "accepted" })
+  })
+
   it("defaults adapter-backed Channels to final-only delivery", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram, webChat } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5706,6 +5706,22 @@ describe("agent message protocol", () => {
     })).not.toThrow()
   })
 
+  it("accepts channel-local message filters across multiple message-shaped channels", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram, webChat } = await import("../src/channels.ts")
+
+    expect(() => defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => ({}) as never,
+          messages: { filter: () => false },
+        }),
+        web: webChat(),
+      },
+      driver: { run: () => "ok" },
+    })).not.toThrow()
+  })
+
   it("applies channel-local message settings for one message-shaped channel", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { webChat } = await import("../src/channels.ts")
@@ -5738,7 +5754,7 @@ describe("agent message protocol", () => {
         web: webChat({ messages: { triggerHistory: "none" } }),
       },
       driver: { run: () => "ok" },
-    })).toThrow("Channel-local messages options other than commentary or stream are only supported when an Agent defines one message-shaped Channel")
+    })).toThrow("Channel-local messages options other than commentary, filter, or stream are only supported when an Agent defines one message-shaped Channel")
   })
 
   it("rejects channel-local identity across multiple message-shaped channels", async () => {


### PR DESCRIPTION
Adds `messages.filter` to adapter-backed Channels so they can reject unsupported normalized messages before Agent invocation. The callback receives the current Agent `Message`, Channel callback context, run metadata, and thread controls; returning `false` exits without invoking the driver or posting an error fallback.

The focused regression covers async rejection and acceptance, the complete callback context, normalized attachment input, and the absence of delivery on rejection. The separate missing-MIME image fallback from the downstream Calories patch is intentionally excluded from this PR.

Validated with the full `@vite-hub/agent` package build and 1,449-test suite, its TypeScript check, and `git diff --check`.
