### PR TITLE
feat(agent): load colocated instructions for model drivers

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -129,6 +129,7 @@ import type {
   AgentInvoker,
   AgentInvokerOptions,
   AgentInvokerProfile,
+  AgentModelDriver,
   AgentOutputDefinition,
   AgentModelResolver,
   AgentRegistry,
@@ -436,6 +437,7 @@ const syntheticWorkspaceRun = Symbol.for("vitehub.syntheticWorkspaceRun")
 const baseAgentResolve = Symbol.for("vitehub.baseAgentResolve")
 const baseAgentModel = Symbol.for("vitehub.baseAgentModel")
 const baseAgentDriverKind = Symbol.for("vitehub.baseAgentDriverKind")
+const baseAgentDefinitionResolve = Symbol.for("vitehub.baseAgentDefinitionResolve")
 const baseAgentBoxRequirements = Symbol.for("vitehub.baseAgentBoxRequirements")
 const baseAgentCapabilitiesResolver = Symbol.for("vitehub.baseAgentCapabilitiesResolver")
 type WorkspaceSourceNames<TWorkspace> =
@@ -1111,6 +1113,9 @@ function defineBaseAgent<
   Object.defineProperty(definition, "__vitehubAgentSettings", {
     value: channels === options.channels ? options : { ...options, channels },
   })
+  Object.defineProperty(definition, baseAgentDefinitionResolve, {
+    value: definition.resolve,
+  })
   return definition
 }
 
@@ -1310,6 +1315,36 @@ export const defineAgent: DefineAgent = ((options: unknown) => {
       })
     : defineBaseAgent(normalizedOptions as never)
 }) as DefineAgent
+
+export function agentWithColocatedInstructions<Agent>(agent: Agent, instructions?: string): Agent {
+  if (!instructions || !hasAgentDefinition(agent)) return agent
+  const settings = (agent as AgentDefinition & { __vitehubAgentSettings?: AgentSettings }).__vitehubAgentSettings
+  if (!settings || settings.workspace) return agent
+  const driver = normalizeAgentDriver(settings)
+  if (driver.kind !== "model" || driver.instructions !== undefined) return agent
+  const definition = defineAgent({
+    ...settings,
+    driver: {
+      ...(settings.driver as AgentModelDriver),
+      instructions,
+    },
+  } as never) as Agent
+  const decorations = Object.getOwnPropertyDescriptors(agent as object)
+  delete decorations.__vitehubAgentSettings
+  Reflect.deleteProperty(decorations, baseAgentResolve)
+  Reflect.deleteProperty(decorations, baseAgentModel)
+  Reflect.deleteProperty(decorations, baseAgentDriverKind)
+  Reflect.deleteProperty(decorations, baseAgentDefinitionResolve)
+  if (
+    (agent as AgentDefinition & { [baseAgentDefinitionResolve]?: unknown }).resolve
+    === (agent as AgentDefinition & { [baseAgentDefinitionResolve]?: unknown })[baseAgentDefinitionResolve]
+  ) {
+    delete decorations.resolve
+  }
+  Object.setPrototypeOf(definition as object, Object.getPrototypeOf(agent as object))
+  Object.defineProperties(definition as object, decorations)
+  return definition
+}
 
 export async function resolveAgent<TContext extends AgentRuntimeContext>(
   agent: AgentInput<TContext>,

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync } from "node:fs"
+import { existsSync, statSync } from "node:fs"
 import { mkdir, rm, writeFile } from "node:fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
@@ -17,9 +17,9 @@ import {
 } from "./cloudflare.ts"
 import { normalizeAgentOptions } from "./config.ts"
 import { discoverAgentDefinitions } from "./discovery.ts"
-import { resolveInstructionImports } from "./instruction-composition.ts"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig } from "./internal/evalite-config.ts"
 import { readColocatedAgentHome } from "./vite/colocated-agent-home.ts"
+import { readColocatedAgentInstructions } from "./vite/colocated-agent-instructions.ts"
 import { readColocatedAgentSkills } from "./vite/colocated-agent-skills.ts"
 
 import type { Plugin, ResolvedConfig } from "vite"
@@ -299,6 +299,16 @@ function discoverScheduledAgentDefinitions(root: string): DiscoveredAgentDefinit
   return [...unique.values()]
 }
 
+async function isColocatedAgentInstructionDependency(root: string, file: string): Promise<boolean> {
+  const target = resolve(file)
+  for (const definition of discoverScheduledAgentDefinitions(root)) {
+    const dependencies = new Set<string>()
+    await readColocatedAgentInstructions(definition.handler, { dependencies })
+    if (dependencies.has(target)) return true
+  }
+  return false
+}
+
 function hasHostedAgentDefinitions(root: string): boolean {
   return discoverAgentDefinitions({
     mode: "server-agents",
@@ -323,12 +333,13 @@ async function transformScheduleRegistry(
     const sourceRootDir = resolveWorkspaceSourceRoot(definition.handler)
     const agentIdentity = { name: definition.name, ...(definition.workspace ? { workspace: definition.workspace } : {}) }
     const handlerImport = importAnchor ? moduleImportSpecifier(importAnchor, definition.handler) : definition.handler
+    const colocatedInstructions = await readColocatedAgentInstructions(definition.handler)
     const colocatedHome = readColocatedAgentHome(definition.handler)
     return [
       `if (Object.prototype.hasOwnProperty.call(registry, ${JSON.stringify(`agent/${definition.name}`)})) throw new Error(${JSON.stringify(`[vitehub] Duplicate Runtime Schedule target: agent/${definition.name}`)})`,
       `registry[${JSON.stringify(`agent/${definition.name}`)}] = async () => {`,
       `  const module = await import(${JSON.stringify(handlerImport)})`,
-      `  return vitehubDefineScheduledAgentTarget(vitehubAgentWithColocatedHome(vitehubWithWorkspaceSourceRoot(vitehubResolveScheduledAgentModule(module), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(await readColocatedAgentInstructions(definition.handler))}, ${JSON.stringify(readColocatedAgentSkills(definition.handler))}), ${JSON.stringify(colocatedHome)}), { agentIdentity: ${JSON.stringify(agentIdentity)}, capabilities: ${generatedAgentRuntimeCapabilities(runtimeCapabilities, true)} })`,
+      `  return vitehubDefineScheduledAgentTarget(vitehubAgentWithColocatedHome(vitehubWithWorkspaceSourceRoot(vitehubAgentWithColocatedInstructions(vitehubResolveScheduledAgentModule(module), ${JSON.stringify(colocatedInstructions)}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(colocatedInstructions)}, ${JSON.stringify(readColocatedAgentSkills(definition.handler))}), ${JSON.stringify(colocatedHome)}), { agentIdentity: ${JSON.stringify(agentIdentity)}, capabilities: ${generatedAgentRuntimeCapabilities(runtimeCapabilities, true)} })`,
       "}",
     ]
   }))).flat()
@@ -338,7 +349,7 @@ async function transformScheduleRegistry(
     generatedImportOptions.workspaceImportBase ?? workspacePackageName,
   )
   return [
-    `import { workspaceDefinitionFromOptions as vitehubWorkspaceDefinitionFromOptions } from ${JSON.stringify(agentImportBase)}`,
+    `import { agentWithColocatedInstructions as vitehubAgentWithColocatedInstructions, workspaceDefinitionFromOptions as vitehubWorkspaceDefinitionFromOptions } from ${JSON.stringify(agentImportBase)}`,
     `import { agentWithColocatedHome as vitehubAgentWithColocatedHome } from ${JSON.stringify(subpath(agentImportBase, "runtime/workflow"))}`,
     `import { defineScheduledAgentTarget as vitehubDefineScheduledAgentTarget } from ${JSON.stringify(subpath(agentImportBase, "server/internal"))}`,
     ...workflowRuntime.imports,
@@ -661,21 +672,6 @@ function resolveWorkspaceSourceRoot(file: string): string {
   return existsSync(workspaceDirectory) && statSync(workspaceDirectory).isDirectory()
     ? workspaceDirectory
     : dirname(file)
-}
-
-async function readColocatedAgentInstructions(handler: string): Promise<string | undefined> {
-  const file = join(dirname(handler), "instructions.md")
-  if (!existsSync(file) || !statSync(file).isFile()) return
-  return await resolveInstructionImports(readFileSync(file, "utf8"), {
-    file,
-    read(specifier, importer) {
-      const imported = resolve(dirname(importer), specifier)
-      return {
-        content: readFileSync(imported, "utf8"),
-        file: imported,
-      }
-    },
-  })
 }
 
 function generatedWorkspaceSourceRootHelper(name: string, workspaceDefinitionFromOptions: string, typescript = false): string[] {
@@ -1064,7 +1060,7 @@ async function generateAgentDeploymentCatalog(
     const colocatedInstructions = await readColocatedAgentInstructions(definition.handler)
     const colocatedSkills = readColocatedAgentSkills(definition.handler)
     const colocatedHome = readColocatedAgentHome(definition.handler)
-    const agentExpression = `agentWithColocatedHome(withWorkspaceSourceRoot(resolveAgentModule(${moduleName}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(colocatedInstructions)}, ${JSON.stringify(colocatedSkills)}), ${JSON.stringify(colocatedHome)})`
+    const agentExpression = `agentWithColocatedHome(withWorkspaceSourceRoot(agentWithColocatedInstructions(resolveAgentModule(${moduleName}), ${JSON.stringify(colocatedInstructions)}), ${JSON.stringify(sourceRootDir)}, ${JSON.stringify(colocatedInstructions)}, ${JSON.stringify(colocatedSkills)}), ${JSON.stringify(colocatedHome)})`
     return {
       agentEntry: `${JSON.stringify(definition.name)}: ${agentExpression}`,
       import: `import * as ${moduleName} from ${JSON.stringify(moduleImportSpecifier(handlerPath, definition.handler))}`,
@@ -1085,7 +1081,7 @@ async function generateAgentDeploymentCatalog(
 
   return {
     imports: [
-      `import { ${typescript ? "type AgentHostIdentity, type AgentInput, type AgentRegistryModule, type AgentWaitUntil, type WorkspaceAgentDefinition, type WorkspaceAgentOptions, " : ""}workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(options.agentImportBase)}`,
+      `import { ${typescript ? "type AgentHostIdentity, type AgentInput, type AgentRegistryModule, type AgentWaitUntil, type WorkspaceAgentDefinition, type WorkspaceAgentOptions, " : ""}agentWithColocatedInstructions, workspaceAgentOwnsWorkspaceDefinition, workspaceDefinitionFromOptions } from ${JSON.stringify(options.agentImportBase)}`,
       `import { agentWithColocatedHome } from ${JSON.stringify(subpath(options.agentImportBase, "runtime/workflow"))}`,
       ...(channelHandlers
         ? [`import { ${chatHandlers ? "createChannelChatRouteHandler, " : ""}createChannelWebhookRouteHandler${chatHandlers ? ", hasChannelChatRoute" : ""} } from ${JSON.stringify(subpath(options.agentImportBase, "server/internal"))}`]
@@ -1123,7 +1119,7 @@ async function generateAgentDeploymentCatalog(
       ...generatedWorkspaceSourceRootHelper("withWorkspaceSourceRoot", "workspaceDefinitionFromOptions", typescript),
       "",
       `function workspaceRegistryEntry(name${typescript ? ": string" : ""}, module${typescript ? ": AgentRegistryModule" : ""}, sourceRootDir${typescript ? ": string" : ""}, colocatedInstructions${typescript ? ": string | undefined" : ""}, colocatedSkills${typescript ? ": ViteHubEncodedColocatedSkills | undefined" : ""}, colocatedHome${typescript ? ": Parameters<typeof agentWithColocatedHome>[1]" : ""}) {`,
-      "  const agent = agentWithColocatedHome(withWorkspaceSourceRoot(resolveAgentModule(module), sourceRootDir, colocatedInstructions, colocatedSkills), colocatedHome)",
+      "  const agent = agentWithColocatedHome(withWorkspaceSourceRoot(agentWithColocatedInstructions(resolveAgentModule(module), colocatedInstructions), sourceRootDir, colocatedInstructions, colocatedSkills), colocatedHome)",
       "  if (!workspaceAgentOwnsWorkspaceDefinition(agent)) return",
       "  return [name, async () => ({ ...module, default: agent })]",
       "}",
@@ -1730,8 +1726,13 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
     },
     async handleHotUpdate(context) {
       const file = context.file.replace(/\\/g, "/")
-      if (!/\.agent\.(?:c|m)?[jt]s$/i.test(file) && !/\/server\/agents\/.*(?:\.(?:c|m)?[jt]s|\/(?:home|skills)\/.*)$/i.test(file)) return
-      const colocatedResourceUpdate = /\/server\/agents\/.*\/(?:home|skills)\/.*$/i.test(file)
+      const instructionUpdate = Boolean(
+        resolved?.root
+        && /\.md$/i.test(file)
+        && await isColocatedAgentInstructionDependency(resolved.root, file),
+      )
+      if (!instructionUpdate && !/\.agent\.(?:c|m)?[jt]s$/i.test(file) && !/\/server\/agents\/.*(?:\.(?:c|m)?[jt]s|\/(?:home|skills)\/.*)$/i.test(file)) return
+      const colocatedResourceUpdate = instructionUpdate || /\/server\/agents\/.*\/(?:home|skills)\/.*$/i.test(file)
       if (resolved && colocatedResourceUpdate) {
         await writeGeneratedAgentOutputs(resolved)
       }

--- a/packages/agent/src/vite/colocated-agent-instructions.ts
+++ b/packages/agent/src/vite/colocated-agent-instructions.ts
@@ -1,0 +1,24 @@
+import { existsSync, readFileSync, statSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+
+import { resolveInstructionImports } from "../instruction-composition.ts"
+
+export async function readColocatedAgentInstructions(
+  handler: string,
+  options: { dependencies?: Set<string> } = {},
+): Promise<string | undefined> {
+  const file = join(dirname(handler), "instructions.md")
+  options.dependencies?.add(file)
+  if (!existsSync(file) || !statSync(file).isFile()) return
+  return await resolveInstructionImports(readFileSync(file, "utf8"), {
+    file,
+    read(specifier, importer) {
+      const imported = resolve(dirname(importer), specifier)
+      options.dependencies?.add(imported)
+      return {
+        content: readFileSync(imported, "utf8"),
+        file: imported,
+      }
+    },
+  })
+}

--- a/packages/agent/src/vite/runtime-adapter.ts
+++ b/packages/agent/src/vite/runtime-adapter.ts
@@ -2,11 +2,13 @@ import { existsSync, statSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { pathToFileURL } from "node:url"
 
+import { agentWithColocatedInstructions } from "../index.ts"
 import { createAgentRuntimeContext } from "../runtime/context.ts"
 import { workspaceAgentWithSourceRoot } from "../workspace-agent.ts"
 import { decodeColocatedAgentHome, withColocatedAgentHome } from "../internal/colocated-agent-home.ts"
 import { decodeColocatedAgentSkills, withColocatedAgentSkills } from "../internal/colocated-agent-skills.ts"
 import { readColocatedAgentHome } from "./colocated-agent-home.ts"
+import { readColocatedAgentInstructions } from "./colocated-agent-instructions.ts"
 import { readColocatedAgentSkills } from "./colocated-agent-skills.ts"
 
 import type { IncomingHttpHeaders, IncomingMessage, ServerResponse } from "node:http"
@@ -64,7 +66,13 @@ export async function loadViteAgent(
 ): Promise<LoadedViteAgent | undefined> {
   const module = await server.ssrLoadModule(pathToFileURL(definition.handler).href)
   const agent = withColocatedAgentHome(
-    withColocatedAgentSkills(resolveAgentModule(module), colocatedSkills(definition.handler)),
+    withColocatedAgentSkills(
+      agentWithColocatedInstructions(
+        resolveAgentModule(module),
+        await readColocatedAgentInstructions(definition.handler),
+      ),
+      colocatedSkills(definition.handler),
+    ),
     colocatedHome(definition.handler),
   )
   if (!agent) return

--- a/packages/agent/test/colocated-agent-instructions.test.ts
+++ b/packages/agent/test/colocated-agent-instructions.test.ts
@@ -1,0 +1,109 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import { agentWithColocatedInstructions, defineAgent } from "../src/index.ts"
+import { loadViteAgent } from "../src/vite/runtime-adapter.ts"
+
+import type { ViteDevServer } from "vite"
+import type { DiscoveredAgentDefinition } from "../src/index.ts"
+
+function settings(agent: unknown) {
+  return (agent as { __vitehubAgentSettings?: { driver?: { instructions?: unknown } } }).__vitehubAgentSettings
+}
+
+describe("colocated Agent instructions", () => {
+  const model = {} as never
+
+  it("adds instructions to model Agents without a Workspace", () => {
+    const agent = defineAgent({ driver: { model }, runtime: false })
+    const resolved = agentWithColocatedInstructions(agent, "Estimate the meal.")
+
+    expect(resolved).not.toBe(agent)
+    expect(settings(resolved)?.driver?.instructions).toBe("Estimate the meal.")
+  })
+
+  it("keeps explicit model Driver instructions", () => {
+    const agent = defineAgent({
+      driver: { instructions: "Use explicit instructions.", model },
+      runtime: false,
+    })
+
+    expect(agentWithColocatedInstructions(agent, "Use colocated instructions.")).toBe(agent)
+  })
+
+  it("preserves properties and descriptors added to an Agent Definition", () => {
+    const agent = defineAgent({ driver: { model }, runtime: false })
+    const resolve = async () => ({ generate: async () => ({ text: "decorated" }) })
+    const prototype = {
+      get pluginName() {
+        return "review"
+      },
+    }
+    Object.setPrototypeOf(agent, prototype)
+    Object.defineProperties(agent, {
+      pluginMetadata: {
+        configurable: false,
+        enumerable: false,
+        value: { plugin: "review" },
+        writable: false,
+      },
+      resolve: {
+        configurable: true,
+        enumerable: true,
+        value: resolve,
+        writable: true,
+      },
+    })
+
+    const decorated = agentWithColocatedInstructions(agent, "Use colocated instructions.") as typeof agent & {
+      pluginMetadata: { plugin: string }
+      pluginName: string
+    }
+
+    expect(Object.getPrototypeOf(decorated)).toBe(prototype)
+    expect(decorated.pluginName).toBe("review")
+    expect(decorated.resolve).toBe(resolve)
+    expect(decorated.pluginMetadata).toEqual({ plugin: "review" })
+    expect(Object.getOwnPropertyDescriptor(decorated, "pluginMetadata")).toMatchObject({
+      configurable: false,
+      enumerable: false,
+      writable: false,
+    })
+    expect(settings(decorated)?.driver?.instructions).toBe("Use colocated instructions.")
+  })
+
+  it("leaves Workspace and custom-run Agents to their existing instruction surfaces", () => {
+    const workspaceAgent = defineAgent({ driver: { model }, runtime: false, workspace: {} })
+    const runAgent = defineAgent({ driver: { run: () => "done" }, runtime: false })
+
+    expect(agentWithColocatedInstructions(workspaceAgent, "Workspace instructions.")).toBe(workspaceAgent)
+    expect(agentWithColocatedInstructions(runAgent, "Run instructions.")).toBe(runAgent)
+  })
+
+  it("loads instructions in the Vite Agent Dev Loop", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-colocated-instructions-"))
+    const handler = join(root, "reviewer", "agent.ts")
+    try {
+      await mkdir(join(root, "reviewer"), { recursive: true })
+      await writeFile(handler, "export default {}", "utf8")
+      await writeFile(join(root, "reviewer", "instructions.md"), "Review the local invocation.\n", "utf8")
+      const agent = defineAgent({ driver: { model }, runtime: false })
+      const server = {
+        ssrLoadModule: async () => ({ default: agent }),
+      } as unknown as ViteDevServer
+
+      const loaded = await loadViteAgent(server, {
+        handler,
+        name: "reviewer",
+      } as DiscoveredAgentDefinition)
+
+      expect(settings(loaded?.agent)?.driver?.instructions).toBe("Review the local invocation.\n")
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+})

--- a/packages/agent/test/deployment-catalog.test.ts
+++ b/packages/agent/test/deployment-catalog.test.ts
@@ -43,6 +43,7 @@ function deploymentRuntimeModules(): Map<string, string> {
       "  return Response.json({",
       "    agent: agent.description,",
       "    agentIdentity: options.agentIdentity,",
+      "    driverInstructions: agent.__vitehubAgentSettings?.driver?.instructions,",
       "    hasState: Boolean(state),",
       "    instructions: agent.sources?.__vitehubAgentInstructions?.content,",
       "    kind,",
@@ -123,11 +124,12 @@ async function createDeploymentRuntimeFixture(adapter: "deno" | "netlify" | "nit
       "import { defineAgent } from '@vite-hub/agent'",
       "export default defineAgent({",
       "  description: 'reviewer',",
-      "  driver: { run: async () => ({ text: 'reviewer' }) },",
+      "  driver: { model: {} },",
       "  runtime: false,",
       "})",
       "",
     ].join("\n"), "utf8")
+    await writeFile(join(reviewerRoot, "instructions.md"), "Review the deployment catalog.\n", "utf8")
   }
   if (adapter === "deno") {
     await mkdir(join(root, ".vitehub", "schedule"), { recursive: true })
@@ -276,6 +278,7 @@ describe("generated Agent deployment catalog", () => {
     await expect((await runtime!.request("reviewer", "chat")).json()).resolves.toMatchObject({
       agent: "reviewer",
       agentIdentity: { name: "reviewer" },
+      driverInstructions: "Review the deployment catalog.\n",
       kind: "chat",
       runtime: "vite",
     })
@@ -309,7 +312,10 @@ describe("generated Agent deployment catalog", () => {
     const sources = workspace.sources as Record<string, { content: string }> | undefined
     const skills = workspace[Symbol.for("vitehub.agent.colocatedSkills")] as Record<string, { content: Uint8Array }> | undefined
     const box = workspace.box as { home?: { files?: Record<string, { contents: Uint8Array }> } } | undefined
-    const settings = Object.getOwnPropertyDescriptor(workspace, "__vitehubAgentSettings")?.value as { box?: unknown } | undefined
+    const settings = Object.getOwnPropertyDescriptor(workspace, "__vitehubAgentSettings")?.value as {
+      box?: unknown
+      driver?: { instructions?: unknown }
+    } | undefined
 
     expect(workspace.sourceRootDir).toBe(join(runtime!.supportRoot, "workspace"))
     expect(sources?.__vitehubAgentInstructions).toMatchObject({
@@ -320,6 +326,7 @@ describe("generated Agent deployment catalog", () => {
     expect(new TextDecoder().decode(skills?.["__vitehubAgentSkill:skills/review/SKILL.md"]?.content)).toBe("# Review\n")
     expect(box?.home?.files?.[".codex/config.bin"]?.contents).toEqual(Uint8Array.from([0, 255, 42]))
     expect(settings?.box).toBe(box)
+    expect(settings?.driver?.instructions).toBeUndefined()
     await expect((await runtime!.request("support", "webhooks/channel")).json()).resolves.toMatchObject({
       instructions: "Support the deployment catalog.\n",
       skill: "# Review\n",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -351,7 +351,9 @@ describe("agent Vite plugin", () => {
     try {
       await mkdir(join(root, "server", "agents", "support", "workspace"), { recursive: true })
       await mkdir(join(root, "server", "agents", "support", "home", ".codex"), { recursive: true })
-      await writeFile(join(root, "server", "agents", "digest.ts"), "export default {}", "utf8")
+      await mkdir(join(root, "server", "agents", "digest"), { recursive: true })
+      await writeFile(join(root, "server", "agents", "digest", "agent.ts"), "export default {}", "utf8")
+      await writeFile(join(root, "server", "agents", "digest", "instructions.md"), "Use digest instructions.\n", "utf8")
       await writeFile(join(root, "server", "agents", "support", "agent.ts"), "export default defineAgent({ workspace: {} })", "utf8")
       await writeFile(join(root, "server", "agents", "support", "instructions.md"), "Use support instructions.\n", "utf8")
       await writeFile(join(root, "server", "agents", "support", "home", ".codex", "config.toml"), "model = 'codex'\n", "utf8")
@@ -375,6 +377,7 @@ describe("agent Vite plugin", () => {
       expect(registry).toContain('import { schedules as vitehubSchedules } from "@vite-hub/schedule/runtime"')
       expect(registry).toContain('{ agentIdentity: {"name":"digest"}, capabilities: { blob: vitehubBlob, email: vitehubEmail, kv: vitehubKv, schedule: { schedules: vitehubSchedules } } }')
       expect(registry).toContain('registry["agent/digest"]')
+      expect(registry).toContain('vitehubAgentWithColocatedInstructions(vitehubResolveScheduledAgentModule(module), "Use digest instructions.\\n")')
       expect(registry).not.toContain("withAgentDefaults")
       expect(registry).toContain('registry["agent/support"]')
       expect(registry).toContain('agentIdentity: {"name":"support","workspace":"support"}')
@@ -512,6 +515,47 @@ describe("agent Vite plugin", () => {
     expect(invalidateModule).toHaveBeenCalledWith(targetsModule)
     expect(invalidateModule).toHaveBeenCalledWith(nitroRegistryModule)
     expect(invalidateModule).toHaveBeenCalledWith(generatedRouteModule)
+  })
+
+  it("regenerates Agent outputs when an imported instruction document changes", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-instruction-update-"))
+    try {
+      const agentRoot = join(root, "server", "agents", "digest")
+      await mkdir(agentRoot, { recursive: true })
+      await writeFile(join(agentRoot, "agent.ts"), "export default {}", "utf8")
+      await writeFile(join(agentRoot, "instructions.md"), "@./tone.md\n", "utf8")
+      await writeFile(join(agentRoot, "tone.md"), "Use a concise tone.\n", "utf8")
+
+      const plugin = hubAgent({ eval: false })
+      const configResolved = plugin.configResolved as unknown as (config: { agent?: unknown, command: "serve", plugins: never[], root: string }) => Promise<void>
+      await configResolved({ command: "serve", plugins: [], root })
+      const generatedRouteModule = { id: "generated-route" }
+      const getModuleById = vi.fn((id: string) => id === join(root, ".vitehub/agent/chat-webhook-route.ts")
+        ? generatedRouteModule
+        : undefined)
+      const invalidateModule = vi.fn()
+      const handleHotUpdate = plugin.handleHotUpdate as (context: unknown) => Promise<void>
+
+      await handleHotUpdate({
+        file: join(agentRoot, "tone.md"),
+        server: { moduleGraph: { getModuleById, invalidateModule } },
+      })
+
+      expect(invalidateModule).toHaveBeenCalledWith(generatedRouteModule)
+
+      invalidateModule.mockClear()
+      await rm(join(agentRoot, "instructions.md"))
+      await handleHotUpdate({
+        file: join(agentRoot, "instructions.md"),
+        server: { moduleGraph: { getModuleById, invalidateModule } },
+      })
+
+      expect(invalidateModule).toHaveBeenCalledWith(generatedRouteModule)
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
   })
 
   it("materializes the MCP runtime package for Vercel build output", async () => {
@@ -1339,8 +1383,9 @@ describe("agent Vite plugin", () => {
     const { hubAgent } = await import("../src/vite.ts")
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-routes-"))
     try {
-      await mkdir(join(root, "server", "agents"), { recursive: true })
-      await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
+      await mkdir(join(root, "server", "agents", "support"), { recursive: true })
+      await writeFile(join(root, "server", "agents", "support", "agent.ts"), "export default {}", "utf8")
+      await writeFile(join(root, "server", "agents", "support", "instructions.md"), "Use support instructions.\n", "utf8")
       const plugin = hubAgent({ routes: { chat: true } })
       if (typeof plugin.configResolved === "function") {
         await plugin.configResolved.call({} as never, { command: "serve", root } as never)
@@ -1349,7 +1394,8 @@ describe("agent Vite plugin", () => {
       const webhookRoute = await readFile(join(root, ".vitehub/agent/chat-webhook-route.ts"), "utf8")
 
       expect(webhookRoute).toContain("createChannelChatRouteHandler")
-      expect(webhookRoute).toContain("withWorkspaceSourceRoot(resolveAgentModule")
+      expect(webhookRoute).toContain("withWorkspaceSourceRoot(agentWithColocatedInstructions(resolveAgentModule")
+      expect(webhookRoute).toContain('agentWithColocatedInstructions(resolveAgentModule(agent0), "Use support instructions.\\n")')
       expect(webhookRoute).not.toContain("withAgentDefaults")
       expect(webhookRoute).toContain("const agentIdentities")
       expect(webhookRoute).toContain('"support": {"name":"support"}')
@@ -1791,7 +1837,7 @@ export default defineAgent({
 
       expect(denoServer).toContain("import { setWorkspaceRuntimeRegistry } from \"@vite-hub/workspace/runtime\"")
       expect(denoServer).toContain("workspaceAgentOwnsWorkspaceDefinition")
-      expect(denoServer).toContain("withWorkspaceSourceRoot(resolveAgentModule(agent0)")
+      expect(denoServer).toContain("withWorkspaceSourceRoot(agentWithColocatedInstructions(resolveAgentModule(agent0)")
       expect(denoServer).toContain("workspaceRegistryEntry(\"support\", agent0")
       expect(denoServer).toContain("__vitehubAgentInstructions")
       expect(denoServer).toContain("content: colocatedInstructions")


### PR DESCRIPTION
Loads sibling `instructions.md` into plain model Agent Drivers across typed generated deployment catalogs, Runtime Schedule targets, and the Vite Agent Dev Loop. Generated outputs regenerate when the instruction document or one of its resolved Markdown imports changes, including when the sibling document is removed. Workspace-owned Agents keep their existing source materialization path, so colocated instructions continue to become the synthetic `AGENTS.md` source once rather than also being copied into `driver.instructions`; explicit Driver instructions and non-model Agents remain unchanged. Post-definition plugin properties, descriptors, and prototypes are preserved when the default instructions are applied.

Focused runtime coverage proves generated and local plain model Agents receive the adjacent document, instruction changes and removal invalidate generated outputs, decorated Agent Definitions retain their plugin-owned behavior, and a Workspace Agent retains `__vitehubAgentInstructions` with no Driver-level duplicate. The generated Schedule registry is also covered, alongside the package typecheck, build, and 177 focused passing tests.