### PR TITLE
feat(vite-hub): add Nuxt integration

### DIFF
--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -41,6 +41,19 @@ export default defineConfig({
 })
 ```
 
+In Nuxt, register the framework module. It installs the same Vite integrations
+and carries their Nitro configuration through Nuxt's lifecycle.
+
+```ts [nuxt.config.ts]
+import viteHubNuxt from "vite-hub/nuxt"
+
+export default defineNuxtConfig({
+  modules: [
+    [viteHubNuxt, { preset: "node" }],
+  ],
+})
+```
+
 Import application APIs from explicit feature subpaths.
 
 ```ts [server/agents/support.ts]

--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -115,6 +115,7 @@ for libraries, focused integrations, and advanced composition.
 | Import path | Use |
 | --- | --- |
 | `vite-hub` | Canonical application import for `vitehub()`. |
+| `vite-hub/nuxt` | Register the framework Nuxt module and carry Vite integration configuration into Nitro. |
 | `@vite-hub/agent/vite` | Register the Agent Vite Integration. |
 | `@vite-hub/auth/vite` | Register the Auth Vite Integration. |
 | `@vite-hub/blob/vite` | Register the Blob Vite Integration. |

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -283,10 +283,10 @@ function isScheduleRegistryId(id: string): boolean {
   return id.replace(/\\/g, "/").split("?", 1)[0]!.endsWith(generatedScheduleRuntimeRegistrySuffix)
 }
 
-function discoverScheduledAgentDefinitions(root: string): DiscoveredAgentDefinition[] {
+function discoverScheduledAgentDefinitions(root: string, serverDirs = [join(root, "server")]): DiscoveredAgentDefinition[] {
   const definitions = [
     ...discoverAgentDefinitions({ mode: "vite-suffix", rootDir: root }),
-    ...discoverAgentDefinitions({ mode: "server-agents", scanDirs: [join(root, "server")] }),
+    ...discoverAgentDefinitions({ mode: "server-agents", scanDirs: serverDirs }),
   ]
   const unique = new Map<string, DiscoveredAgentDefinition>()
   for (const definition of definitions) {
@@ -1770,7 +1770,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
         if (materialization) return materialization
       }
       if (!isScheduleRegistryId(id) && id !== resolvedScheduleTargetsId) return
-      const definitions = discoverScheduledAgentDefinitions(resolved.root)
+      const definitions = discoverScheduledAgentDefinitions(resolved.root, serverDirs)
       return isScheduleRegistryId(id)
         ? await transformScheduleRegistry(
             code,

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1326,11 +1326,12 @@ async function generateAgentNetlifyFunctionRouteHandler(
 async function writeAgentWebhookRouteHandler(
   root: string,
   options: { chatRoute?: false | string, cloudflareState?: boolean, libsqlState?: GeneratedLibsqlAgentStateOptions, runtime?: "vite", webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
+  serverDirs = [join(root, "server")],
 ): Promise<void> {
   const handlerPath = join(root, generatedAgentWebhookRouteHandler)
   const definitions = discoverAgentDefinitions({
     mode: "server-agents",
-    scanDirs: [join(root, "server")],
+    scanDirs: serverDirs,
   })
   await mkdir(dirname(handlerPath), { recursive: true })
   await writeFile(handlerPath, await generateAgentWebhookRouteHandler(definitions, handlerPath, options), "utf8")
@@ -1420,11 +1421,12 @@ async function generateAgentDiscordGatewayRouteHandler(
 async function writeAgentDiscordGatewayRouteHandler(
   root: string,
   options: { discordGatewayRoute?: false | string, runtime?: "vite", webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
+  serverDirs = [join(root, "server")],
 ): Promise<void> {
   const handlerPath = join(root, generatedAgentDiscordGatewayRouteHandler)
   const definitions = discoverAgentDefinitions({
     mode: "server-agents",
-    scanDirs: [join(root, "server")],
+    scanDirs: serverDirs,
   })
   await mkdir(dirname(handlerPath), { recursive: true })
   await writeFile(handlerPath, await generateAgentDiscordGatewayRouteHandler(definitions, handlerPath, options), "utf8")
@@ -1527,11 +1529,12 @@ async function generateAgentDenoServer(
 async function writeAgentDenoServer(
   root: string,
   options: { chatRoute?: false | string, libsqlState?: GeneratedLibsqlAgentStateOptions, webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
+  serverDirs = [join(root, "server")],
 ): Promise<void> {
   const handlerPath = join(root, generatedAgentDenoServer)
   const definitions = discoverAgentDefinitions({
     mode: "server-agents",
-    scanDirs: [join(root, "server")],
+    scanDirs: serverDirs,
   })
   const scheduleRegistryImport = options.schedule
     ? moduleImportSpecifier(handlerPath, await writeStandaloneAgentScheduleRegistry(
@@ -1553,11 +1556,12 @@ async function writeAgentDenoServer(
 async function writeAgentNetlifyFunctionRouteHandler(
   root: string,
   options: { chatRoute?: false | string, discordGatewayRoute?: false | string, libsqlState?: GeneratedLibsqlAgentStateOptions, runtime?: "vite", webhookRoute?: false | string } & AgentGeneratedImportOptions = {},
+  serverDirs = [join(root, "server")],
 ): Promise<string> {
   const handlerPath = join(root, generatedAgentNetlifyFunction)
   const definitions = discoverAgentDefinitions({
     mode: "server-agents",
-    scanDirs: [join(root, "server")],
+    scanDirs: serverDirs,
   })
   const scheduleRegistryImport = options.schedule
     ? moduleImportSpecifier(handlerPath, await writeStandaloneAgentScheduleRegistry(
@@ -1595,6 +1599,7 @@ async function writeNetlifyAgentProviderOutput(
   config: ResolvedConfig,
   options: ResolvedAgentModuleOptions,
   generatedOptions: AgentGeneratedImportOptions & { libsqlState?: GeneratedLibsqlAgentStateOptions, runtime?: "vite" } = {},
+  serverDirs?: string[],
 ): Promise<void> {
   const handlerPath = await writeAgentNetlifyFunctionRouteHandler(config.root, {
     ...generatedOptions,
@@ -1602,7 +1607,7 @@ async function writeNetlifyAgentProviderOutput(
     discordGatewayRoute: options.routes.discordGateway,
     libsqlState: generatedOptions.libsqlState ?? resolveLibsqlAgentState(options, config),
     webhookRoute: options.routes.webhooks,
-  })
+  }, serverDirs)
   await writeProviderDeploymentOutputs({
     clientOutDir: config.build?.outDir ?? "dist",
     netlify: {
@@ -1647,11 +1652,12 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
   let runtimeCapabilities: GeneratedAgentRuntimeCapability[] = []
   let standaloneRuntimeCapabilities: GeneratedAgentRuntimeCapability[] = []
   let resolved: ResolvedConfig | undefined
+  let serverDirs: string[] | undefined
 
   async function writeGeneratedAgentOutputs(config: ResolvedConfig) {
     const normalized = normalizeAgentOptions(agent)
     const schedule = hasScheduleVitePlugin(config)
-    const hasHostedAgents = hasHostedAgentDefinitions(config.root)
+    const hasHostedAgents = hasHostedAgentDefinitions(config.root, serverDirs)
     if (normalized && hasHostedAgents) {
       if (normalized.runtime === "deno") {
         await writeAgentDenoServer(config.root, {
@@ -1665,7 +1671,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
           workspaceDependencyRuntimeImports: getWorkspaceDependencyRuntimeImports(agent, frameworkOptions),
           workspaceImportBase: getWorkspaceImportBase(agent, frameworkOptions),
           webhookRoute: normalized.routes.webhooks,
-        })
+        }, serverDirs)
       }
       else {
         await writeAgentWebhookRouteHandler(config.root, {
@@ -1681,7 +1687,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
           workspaceDependencyRuntimeImports: getWorkspaceDependencyRuntimeImports(agent, frameworkOptions),
           workspaceImportBase: getWorkspaceImportBase(agent, frameworkOptions),
           webhookRoute: normalized.routes.webhooks,
-        })
+        }, serverDirs)
         if (normalized.routes.discordGateway) {
           await writeAgentDiscordGatewayRouteHandler(config.root, {
             agentImportBase: getAgentImportBase(agent, frameworkOptions),
@@ -1694,7 +1700,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
             workspaceDependencyRuntimeImports: getWorkspaceDependencyRuntimeImports(agent, frameworkOptions),
             workspaceImportBase: getWorkspaceImportBase(agent, frameworkOptions),
             webhookRoute: normalized.routes.webhooks,
-          })
+          }, serverDirs)
         }
         if (config.command === "serve" && isNetlifyHosting(config)) {
           await writeNetlifyAgentProviderOutput(config, normalized, {
@@ -1708,7 +1714,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
             workflowImportBase: getWorkflowImportBase(agent, frameworkOptions),
             workspaceDependencyRuntimeImports: getWorkspaceDependencyRuntimeImports(agent, frameworkOptions),
             workspaceImportBase: getWorkspaceImportBase(agent, frameworkOptions),
-          })
+          }, serverDirs)
         }
       }
     }
@@ -1791,7 +1797,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
     config(config) {
       agent = config.agent ?? agent
       const resolved = normalizeAgentOptions(agent)
-      const serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS]
+      serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
       const hasHostedAgents = Boolean(resolved && hasHostedAgentDefinitions(resolve(config.root || process.cwd()), serverDirs))
       const denoOutput = resolved && resolved.runtime === "deno"
       const installCloudflareState = hasHostedAgents && !denoOutput && shouldInstallCloudflareAgentState(resolved, config)
@@ -1877,7 +1883,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
         if (!resolved || resolved.command !== "build") return
         const normalized = normalizeAgentOptions(agent)
         if (normalized && normalized.runtime === "deno") return
-        if (normalized && hasHostedAgentDefinitions(resolved.root) && isNetlifyHosting(resolved)) {
+        if (normalized && hasHostedAgentDefinitions(resolved.root, serverDirs) && isNetlifyHosting(resolved)) {
           await writeNetlifyAgentProviderOutput(resolved, normalized, {
             agentImportBase: getAgentImportBase(agent, frameworkOptions),
             libsqlState: resolveLibsqlAgentState(normalized, resolved),
@@ -1888,7 +1894,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
             workflowImportBase: getWorkflowImportBase(agent, frameworkOptions),
             workspaceDependencyRuntimeImports: getWorkspaceDependencyRuntimeImports(agent, frameworkOptions),
             workspaceImportBase: getWorkspaceImportBase(agent, frameworkOptions),
-          })
+          }, serverDirs)
         } else if (isNetlifyHosting(resolved)) {
           await cleanupNetlifyAgentProviderOutput(resolved)
         }

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from "node:url"
 
 import { writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
-import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import { getHostingProvider } from "@vite-hub/internal/hosting"
 import { markdownTemplateMaterializationPath } from "@vite-hub/markdown-template/vite"
 
@@ -309,10 +309,10 @@ async function isColocatedAgentInstructionDependency(root: string, file: string)
   return false
 }
 
-function hasHostedAgentDefinitions(root: string): boolean {
+function hasHostedAgentDefinitions(root: string, serverDirs = [join(root, "server")]): boolean {
   return discoverAgentDefinitions({
     mode: "server-agents",
-    scanDirs: [join(root, "server")],
+    scanDirs: serverDirs,
   }).length > 0
 }
 
@@ -1791,7 +1791,8 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
     config(config) {
       agent = config.agent ?? agent
       const resolved = normalizeAgentOptions(agent)
-      const hasHostedAgents = Boolean(resolved && hasHostedAgentDefinitions(resolve(config.root || process.cwd())))
+      const serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS]
+      const hasHostedAgents = Boolean(resolved && hasHostedAgentDefinitions(resolve(config.root || process.cwd()), serverDirs))
       const denoOutput = resolved && resolved.runtime === "deno"
       const installCloudflareState = hasHostedAgents && !denoOutput && shouldInstallCloudflareAgentState(resolved, config)
       const nitroHandlers = [

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1769,8 +1769,12 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
     async transform(code, id) {
       if (agent === false || !resolved?.root) return
       const normalizedId = id.split(/[?#]/, 1)[0]!.replace(/\\/g, "/")
+      const serverAgentDefinition = (serverDirs ?? [join(resolved.root, "server")]).some((directory) => {
+        const agentRoot = `${resolve(directory, "agents").replace(/\\/g, "/")}/`
+        return normalizedId.startsWith(agentRoot) && /\.(?:c|m)?[jt]s$/i.test(normalizedId.slice(agentRoot.length))
+      })
       const agentDefinition = /\.agent\.(?:c|m)?[jt]s$/i.test(normalizedId)
-        || /\/server\/agents\/.*\.(?:c|m)?[jt]s$/i.test(normalizedId)
+        || serverAgentDefinition
       if (agentDefinition) {
         const materialization = transformRepositoryHostContextMaterialization(code, value => this.parse(value))
         if (materialization) return materialization

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -299,9 +299,9 @@ function discoverScheduledAgentDefinitions(root: string, serverDirs = [join(root
   return [...unique.values()]
 }
 
-async function isColocatedAgentInstructionDependency(root: string, file: string): Promise<boolean> {
+async function isColocatedAgentInstructionDependency(root: string, file: string, serverDirs?: string[]): Promise<boolean> {
   const target = resolve(file)
-  for (const definition of discoverScheduledAgentDefinitions(root)) {
+  for (const definition of discoverScheduledAgentDefinitions(root, serverDirs)) {
     const dependencies = new Set<string>()
     await readColocatedAgentInstructions(definition.handler, { dependencies })
     if (dependencies.has(target)) return true
@@ -1732,13 +1732,19 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
     },
     async handleHotUpdate(context) {
       const file = context.file.replace(/\\/g, "/")
+      const agentRoots = (serverDirs ?? [join(resolved?.root ?? context.server.config.root, "server")])
+        .map(directory => `${resolve(directory).replace(/\\/g, "/")}/agents/`)
+      const relativeAgentPath = agentRoots
+        .filter(directory => file.startsWith(directory))
+        .map(directory => file.slice(directory.length))
+        .find(path => /\.(?:c|m)?[jt]s$/i.test(path) || /\/(?:home|skills)\/.*$/i.test(path))
       const instructionUpdate = Boolean(
         resolved?.root
         && /\.md$/i.test(file)
-        && await isColocatedAgentInstructionDependency(resolved.root, file),
+        && await isColocatedAgentInstructionDependency(resolved.root, file, serverDirs),
       )
-      if (!instructionUpdate && !/\.agent\.(?:c|m)?[jt]s$/i.test(file) && !/\/server\/agents\/.*(?:\.(?:c|m)?[jt]s|\/(?:home|skills)\/.*)$/i.test(file)) return
-      const colocatedResourceUpdate = instructionUpdate || /\/server\/agents\/.*\/(?:home|skills)\/.*$/i.test(file)
+      if (!instructionUpdate && !/\.agent\.(?:c|m)?[jt]s$/i.test(file) && !relativeAgentPath) return
+      const colocatedResourceUpdate = instructionUpdate || Boolean(relativeAgentPath && /\/(?:home|skills)\/.*$/i.test(relativeAgentPath))
       if (resolved && colocatedResourceUpdate) {
         await writeGeneratedAgentOutputs(resolved)
       }

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path"
 
 import { createGitHubWorkspaceStore } from "@vite-hub/workspace/internal/stores/github"
+import { VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import { installHostedWorkspaceRuntime } from "@vite-hub/workspace/internal/runtime/hosted"
 import { installHostedVercelBlobWorkspaceRuntime } from "@vite-hub/workspace/internal/runtime/hosted-vercel-blob"
 import { getWorkspaceHostedStoreLoader, setWorkspaceHostedStoreLoader, setWorkspaceRuntimeRegistry } from "@vite-hub/workspace/runtime"
@@ -278,9 +279,12 @@ async function installServerAgentWorkspaceRegistry(
 }
 
 async function discoverStreamAgents(server: ViteDevServer): Promise<AgentInvocationStreamEntry[]> {
+  const serverDirs = (server.config as typeof server.config & {
+    [VITEHUB_SERVER_DIRS]?: string[]
+  })[VITEHUB_SERVER_DIRS] ?? [join(server.config.root, "server")]
   const definitions = discoverAgentDefinitions({
     mode: "server-agents",
-    scanDirs: [join(server.config.root, "server")],
+    scanDirs: serverDirs,
   })
   const loaded = []
   for (const definition of definitions) {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url"
 import { promisify } from "node:util"
 
 import { Message } from "chat"
+import { VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import { hubMarkdownTemplate } from "@vite-hub/markdown-template/vite"
 import { build } from "vite"
 import { describe, expect, it, vi } from "vitest"
@@ -203,7 +204,8 @@ describe("agent Vite plugin", () => {
   it("bundles repository context templates into Vite builds", async () => {
     const { hubAgent } = await import("../src/vite.ts")
     const root = await mkdtemp(join(import.meta.dirname, ".repository-context-template-"))
-    const agents = join(root, "server", "agents")
+    const serverDir = join(root, "backend")
+    const agents = join(serverDir, "agents")
     const entry = join(agents, "reviewer.ts")
     const template = join(agents, "PULL_REQUEST.template.md")
     const outfile = join(root, "dist", "agent.mjs")
@@ -225,6 +227,7 @@ describe("agent Vite plugin", () => {
       const agentPlugin: unknown = hubAgent({ eval: false })
       const markdownPlugin: unknown = hubMarkdownTemplate()
       await runBuild({
+        [VITEHUB_SERVER_DIRS]: [serverDir],
         build: {
           emptyOutDir: true,
           lib: { entry, fileName: () => "agent.mjs", formats: ["es"] },

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -474,6 +474,8 @@ describe("agent Vite plugin", () => {
     const nitroRegistryModule = { id: "nitro-registry" }
     const generatedRouteModule = { id: "generated-route" }
     const configResolved = plugin.configResolved as unknown as (config: { agent?: unknown, command: "serve", plugins: never[], root: string }) => Promise<void>
+    const config = plugin.config as unknown as (config: Record<string, unknown>) => void
+    config({ __vitehubServerDirs: ["/app/backend"] })
     await configResolved({ command: "serve", plugins: [], root: "/app" })
     const modules = new Map<string, object>([
       ["\0#vitehub/schedule/registry", registryModule],
@@ -486,8 +488,8 @@ describe("agent Vite plugin", () => {
     const handleHotUpdate = plugin.handleHotUpdate as (context: unknown) => Promise<void>
 
     await handleHotUpdate({
-      file: "/app/server/agents/digest.ts",
-      server: { moduleGraph: { getModuleById, invalidateModule } },
+      file: "/app/backend/agents/digest.ts",
+      server: { config: { root: "/app" }, moduleGraph: { getModuleById, invalidateModule } },
     })
 
     expect(invalidateModule).toHaveBeenCalledWith(registryModule)
@@ -496,8 +498,8 @@ describe("agent Vite plugin", () => {
 
     invalidateModule.mockClear()
     await handleHotUpdate({
-      file: "/app/server/agents/digest/skills/review/SKILL.md",
-      server: { moduleGraph: { getModuleById, invalidateModule } },
+      file: "/app/backend/agents/digest/skills/review/SKILL.md",
+      server: { config: { root: "/app" }, moduleGraph: { getModuleById, invalidateModule } },
     })
 
     expect(invalidateModule).toHaveBeenCalledWith(registryModule)
@@ -507,8 +509,8 @@ describe("agent Vite plugin", () => {
 
     invalidateModule.mockClear()
     await handleHotUpdate({
-      file: "/app/server/agents/digest/home/.codex/config.toml",
-      server: { moduleGraph: { getModuleById, invalidateModule } },
+      file: "/app/backend/agents/digest/home/.codex/config.toml",
+      server: { config: { root: "/app" }, moduleGraph: { getModuleById, invalidateModule } },
     })
 
     expect(invalidateModule).toHaveBeenCalledWith(registryModule)

--- a/packages/auth/src/config.ts
+++ b/packages/auth/src/config.ts
@@ -262,10 +262,14 @@ function readAuthSecondaryStorageConfig(body: string | undefined, allowRuntimeVa
   }
 }
 
-export function resolveAuthViteConfig(options?: AuthModuleOptions, rootDir: string = process.cwd()): ResolvedAuthViteConfig | undefined {
+export function resolveAuthViteConfig(
+  options?: AuthModuleOptions,
+  rootDir: string = process.cwd(),
+  discovery: { serverDirs?: string[] } = {},
+): ResolvedAuthViteConfig | undefined {
   if (options === false) return
 
-  const definition = discoverAuthDefinition(rootDir)
+  const definition = discoverAuthDefinition(rootDir, discovery)
   if (!definition) return
 
   const definitionObject = readDefinitionObjectBody(definition.handler)

--- a/packages/auth/src/discovery.ts
+++ b/packages/auth/src/discovery.ts
@@ -5,13 +5,13 @@ import type { DiscoveredAuthDefinition } from "./types.ts"
 
 const authDefinitionExtensions = [".ts", ".mts", ".cts", ".js", ".mjs", ".cjs"]
 
-function authDefinitionCandidates(rootDir: string): DiscoveredAuthDefinition[] {
+function authDefinitionCandidates(rootDir: string, serverDirs = [resolve(rootDir, "server")]): DiscoveredAuthDefinition[] {
   return authDefinitionExtensions.flatMap((extension) => [
-    {
-      handler: resolve(rootDir, "server", `auth${extension}`),
+    ...serverDirs.map(serverDir => ({
+      handler: resolve(serverDir, `auth${extension}`),
       name: "default" as const,
       source: "server-auth" as const,
-    },
+    })),
     {
       handler: resolve(rootDir, `server.auth${extension}`),
       name: "default" as const,
@@ -20,8 +20,8 @@ function authDefinitionCandidates(rootDir: string): DiscoveredAuthDefinition[] {
   ])
 }
 
-export function discoverAuthDefinitions(rootDir: string): DiscoveredAuthDefinition[] {
-  const definitions = authDefinitionCandidates(rootDir).filter(definition => existsSync(definition.handler))
+export function discoverAuthDefinitions(rootDir: string, options: { serverDirs?: string[] } = {}): DiscoveredAuthDefinition[] {
+  const definitions = authDefinitionCandidates(rootDir, options.serverDirs).filter(definition => existsSync(definition.handler))
   if (definitions.length > 1) {
     throw new Error([
       "[vitehub] Only one Auth Definition is allowed. Found:",
@@ -31,6 +31,6 @@ export function discoverAuthDefinitions(rootDir: string): DiscoveredAuthDefiniti
   return definitions
 }
 
-export function discoverAuthDefinition(rootDir: string): DiscoveredAuthDefinition | undefined {
-  return discoverAuthDefinitions(rootDir)[0]
+export function discoverAuthDefinition(rootDir: string, options: { serverDirs?: string[] } = {}): DiscoveredAuthDefinition | undefined {
+  return discoverAuthDefinitions(rootDir, options)[0]
 }

--- a/packages/auth/src/vite.ts
+++ b/packages/auth/src/vite.ts
@@ -1,7 +1,7 @@
 import { resolve } from "node:path"
 import { Readable } from "node:stream"
 
-import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import { writeFileIfChanged } from "@vite-hub/internal/definition-catalog"
 
 import { resolveAuthViteConfig } from "./config.ts"
@@ -261,6 +261,7 @@ export function hubAuth(options?: AuthModuleOptions): AuthVitePlugin {
   const importBase = (options as InternalAuthModuleOptions | undefined)?.importBase ?? authPackageName
   let resolved: ResolvedConfig | undefined
   let runtimeConfig: ResolvedAuthViteConfig | undefined
+  let serverDirs: string[] | undefined
   let serverEnv = false
 
   function resolvedOptions(): AuthModuleOptions | undefined {
@@ -269,7 +270,7 @@ export function hubAuth(options?: AuthModuleOptions): AuthVitePlugin {
 
   function refreshRuntimeConfig(): ResolvedAuthViteConfig | undefined {
     if (!resolved) return
-    runtimeConfig = resolveAuthViteConfig(resolvedOptions(), resolved.root)
+    runtimeConfig = resolveAuthViteConfig(resolvedOptions(), resolved.root, { serverDirs })
     resetAuth()
     return runtimeConfig
   }
@@ -283,7 +284,8 @@ export function hubAuth(options?: AuthModuleOptions): AuthVitePlugin {
     },
     config(config) {
       const configRoot = config.root || process.cwd()
-      const authConfig = resolveAuthViteConfig((config as { auth?: AuthModuleOptions }).auth ?? options, configRoot)
+      serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
+      const authConfig = resolveAuthViteConfig((config as { auth?: AuthModuleOptions }).auth ?? options, configRoot, { serverDirs })
       const nitro = mergeNitroAuthHandler((config as { nitro?: unknown }).nitro, authConfig)
       const hasNitroHandlers = Boolean(authConfig && (authConfig.route !== false || authConfig.access.routes.length > 0))
       return {

--- a/packages/auth/test/config.test.ts
+++ b/packages/auth/test/config.test.ts
@@ -62,6 +62,18 @@ describe("discoverAuthDefinition", () => {
     })
   })
 
+  it("discovers Auth from an explicit framework server directory", async () => {
+    const rootDir = await createTempProject()
+    const serverDir = join(rootDir, "backend")
+    const file = await writeAuth(rootDir, "backend/auth.ts", [])
+
+    expect(discoverAuthDefinition(join(rootDir, "app"), { serverDirs: [serverDir] })).toEqual({
+      handler: file,
+      name: "default",
+      source: "server-auth",
+    })
+  })
+
   it("rejects duplicate Auth Definitions", async () => {
     const rootDir = await createTempProject()
     await writeAuth(rootDir, "server/auth.ts", [])

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -1,7 +1,7 @@
 import { writeFileIfChanged } from "@vite-hub/internal/definition-catalog"
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { composeNitroCloudflareProviderOutput, registerCloudflareProviderOutput, resetComposedProviderOutput, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, hasNitroVitePlugin, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, hasNitroConfigContext, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
 import { getHostingProvider } from "@vite-hub/internal/hosting"
 import { resolve } from "pathe"
 
@@ -61,7 +61,7 @@ function hasNitroVitePluginOption(value: unknown): boolean {
   if (Array.isArray(value)) return value.some(hasNitroVitePluginOption)
   return Boolean(value)
     && typeof value === "object"
-    && hasNitroVitePlugin({ plugins: [value as { name: string }] })
+    && hasNitroConfigContext({ plugins: [value as { name: string }] })
 }
 
 function mergeNitroExternal(value: unknown, addition: string): unknown {
@@ -268,7 +268,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
       rootDir = config.root
       blob = config.blob ?? blob
       const configuredNitro = (config as { nitro?: unknown }).nitro
-      cloudflareOwnedByNitro = (nitroOwned || hasNitroVitePlugin(config)) && isNitroCloudflareHost(configuredNitro)
+      cloudflareOwnedByNitro = (nitroOwned || hasNitroConfigContext(config)) && isNitroCloudflareHost(configuredNitro)
       const blobConfig = resolveBlobViteConfig(blob, cloudflareOwnedByNitro ? { hosting: "cloudflare" } : undefined)
       const nitro = mergeNitroBlobConfig(
         configuredNitro,

--- a/packages/database/src/config.ts
+++ b/packages/database/src/config.ts
@@ -237,12 +237,6 @@ function getDefaultCloudflareBindingName(name: string) {
 }
 
 function getDefaultMigrationsDir(rootDir: string, definition: DiscoveredDatabaseDefinition) {
-  if (definition.source === "server-database-default") {
-    return relative(rootDir, resolve(rootDir, "server", "databases", "migrations"))
-  }
-  if (definition.source === "server-databases-named") {
-    return relative(rootDir, resolve(dirname(definition.handler), "migrations"))
-  }
   return relative(rootDir, resolve(dirname(definition.handler), "migrations"))
 }
 

--- a/packages/database/src/config.ts
+++ b/packages/database/src/config.ts
@@ -176,17 +176,16 @@ function createDatabaseDefinition(source: string, file: string, name: string, mo
   }
 }
 
-function discoverServerDatabases(rootDir: string) {
-  const serverDir = resolve(rootDir, "server")
+function discoverServerDatabases(rootDir: string, serverDirs = [resolve(rootDir, "server")]) {
   return discoverDefinitions<DiscoveredDatabaseDefinition>("database", [
-    createDirectoryDefinitionSource("server-database-default", [serverDir], "databases", {
+    createDirectoryDefinitionSource("server-database-default", serverDirs, "databases", {
       normalizeName(directory, file) {
         if (!configFilePattern.test(file.split(/[\\/]/).pop() || "")) return
         return dirname(file).replace(/\\/g, "/") === directory.replace(/\\/g, "/") ? "default" : undefined
       },
       createDefinition: ({ file, name }) => createDatabaseDefinition("server-database-default", file, name, "default"),
     }),
-    createDirectoryDefinitionSource("server-databases-named", [serverDir], "databases", {
+    createDirectoryDefinitionSource("server-databases-named", serverDirs, "databases", {
       normalizeName(directory, file) {
         if (!configFilePattern.test(file.split(/[\\/]/).pop() || "")) return
         const name = relative(directory, dirname(file)).replace(/\\/g, "/")
@@ -213,8 +212,8 @@ function discoverViteDatabases(rootDir: string) {
   return [...defaultDefinitions, ...suffixDefinitions]
 }
 
-export function discoverDatabaseDefinitions(rootDir: string): DiscoveredDatabaseDefinition[] {
-  const definitions = [...discoverServerDatabases(rootDir), ...discoverViteDatabases(rootDir)]
+export function discoverDatabaseDefinitions(rootDir: string, options: { serverDirs?: string[] } = {}): DiscoveredDatabaseDefinition[] {
+  const definitions = [...discoverServerDatabases(rootDir, options.serverDirs), ...discoverViteDatabases(rootDir)]
     .filter((definition, index, all) => all.findIndex(item => item.handler === definition.handler) === index)
   const hasDefault = definitions.some(definition => definition.mode === "default")
   const hasNamed = definitions.some(definition => definition.mode === "named")
@@ -305,10 +304,14 @@ function createGeneratedDrizzleConfigFile(rootDir: string, name: string) {
   })
 }
 
-export function resolveDBViteConfig(options?: DBModulePublicOptions, rootDir = process.cwd()): ResolvedDBViteConfig | undefined {
+export function resolveDBViteConfig(
+  options?: DBModulePublicOptions,
+  rootDir = process.cwd(),
+  discovery: { serverDirs?: string[] } = {},
+): ResolvedDBViteConfig | undefined {
   if (options === false) return
 
-  const definitions = discoverDatabaseDefinitions(rootDir)
+  const definitions = discoverDatabaseDefinitions(rootDir, discovery)
   if (!definitions.length) return
 
   const databases: Record<string, ResolvedDrizzleDatabaseConfig> = {}

--- a/packages/database/src/vite.ts
+++ b/packages/database/src/vite.ts
@@ -1,6 +1,6 @@
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { resetComposedProviderOutput, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import { normalize } from "pathe"
 
 import { createDbCliContributor } from "./cli.ts"
@@ -95,6 +95,7 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
   let providerOutput: ComposedProviderOutput | undefined
   let resolved: ResolvedConfig | undefined
   let runtimeConfig: ResolvedDBViteConfig | undefined
+  let serverDirs: string[] | undefined
 
   function resolvedOptions() {
     return resolved?.database ?? options
@@ -102,7 +103,7 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
 
   async function refreshRuntimeConfig() {
     if (!resolved) return
-    runtimeConfig = resolveDBViteConfig(resolvedOptions(), resolved.root)
+    runtimeConfig = resolveDBViteConfig(resolvedOptions(), resolved.root, { serverDirs })
     if (runtimeConfig) {
       await writeGeneratedDatabaseArtifacts(runtimeConfig)
     }
@@ -123,6 +124,9 @@ export function hubDb(options?: DBModulePublicOptions): DBVitePlugin {
         const provision = [createDatabaseProvisionStep(() => resolved?.root ?? process.cwd(), db)]
         return contributor ? { ...contributor, provision } : { namespaces: [], provision }
       },
+    },
+    config(config) {
+      serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
     },
     async configResolved(config) {
       resolved = config

--- a/packages/database/test/config.test.ts
+++ b/packages/database/test/config.test.ts
@@ -140,6 +140,16 @@ describe("resolveDBViteConfig", () => {
     })
   })
 
+  it("resolves default migrations from a forwarded server directory", async () => {
+    const rootDir = await createTempProject()
+    const serverDir = join(rootDir, "backend")
+    await writeDefinition(rootDir, "backend/databases/config.ts")
+
+    const resolved = resolveDBViteConfig(undefined, rootDir, { serverDirs: [serverDir] })
+
+    expect(resolved?.databases.default.migrationsDir).toBe("backend/databases/migrations")
+  })
+
   it("uses the integration connection when the definition does not select a host", async () => {
     const rootDir = await createTempProject()
     await writeDefinition(rootDir, "server/databases/config.ts")

--- a/packages/email/src/discovery.ts
+++ b/packages/email/src/discovery.ts
@@ -9,13 +9,14 @@ export interface DiscoveredEmailDefinition {
 
 const emailDefinitionExtensions = [".ts", ".mts", ".cts", ".js", ".mjs", ".cjs"]
 
-export function discoverEmailDefinition(root: string): DiscoveredEmailDefinition | undefined {
+export function discoverEmailDefinition(root: string, options: { serverDirs?: string[] } = {}): DiscoveredEmailDefinition | undefined {
+  const serverDirs = options.serverDirs ?? [resolve(root, "server")]
   const definitions = emailDefinitionExtensions.flatMap(extension => [
-    {
-      handler: resolve(root, "server", `email${extension}`),
+    ...serverDirs.map(serverDir => ({
+      handler: resolve(serverDir, `email${extension}`),
       name: "default" as const,
       source: "server-email" as const,
-    },
+    })),
     {
       handler: resolve(root, `server.email${extension}`),
       name: "default" as const,

--- a/packages/email/src/vite.ts
+++ b/packages/email/src/vite.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path"
 
-import { createNoExternalMerger, isServerEnvironment, resolveViteHubProjectRoot } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, isServerEnvironment, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import { discoverEmailDefinition } from "./discovery.ts"
 
@@ -43,11 +43,12 @@ function isEmailDefinitionFile(file: string): boolean {
 export function hubEmail(options: EmailVitePluginOptions = {}): EmailVitePlugin {
   let resolved: ResolvedConfig | undefined
   let definition: DiscoveredEmailDefinition | undefined
+  let serverDirs: string[] | undefined
 
   function refresh(): DiscoveredEmailDefinition | undefined {
     const viteRoot = resolve(resolved?.root ?? process.cwd())
     const projectRoot = resolveViteHubProjectRoot(viteRoot, { projectRoot: options.projectRoot })
-    definition = discoverEmailDefinition(projectRoot)
+    definition = discoverEmailDefinition(projectRoot, { serverDirs })
     return definition
   }
 
@@ -59,6 +60,7 @@ export function hubEmail(options: EmailVitePluginOptions = {}): EmailVitePlugin 
       refresh,
     },
     config(config) {
+      serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
       return {
         ssr: { noExternal: mergeNoExternal(config.ssr?.noExternal) },
       }

--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -46,14 +46,19 @@ interface NitroVercelConfig {
   plugins?: unknown
 }
 
+export const VITEHUB_NITRO_CONFIG_CONTEXT: unique symbol = Symbol.for("@vite-hub/internal/nitro-config-context")
+
 function includesNitroVitePlugin(value: unknown): boolean {
   if (Array.isArray(value)) return value.some(includesNitroVitePlugin)
   if (!value || typeof value !== "object") return false
   return "name" in value && value.name === "nitro:main"
 }
 
-export function hasNitroVitePlugin(config: { plugins?: unknown }): boolean {
-  return includesNitroVitePlugin(config.plugins)
+export function hasNitroConfigContext(config: {
+  [VITEHUB_NITRO_CONFIG_CONTEXT]?: boolean
+  plugins?: unknown
+}): boolean {
+  return config[VITEHUB_NITRO_CONFIG_CONTEXT] === true || includesNitroVitePlugin(config.plugins)
 }
 
 export function resolveNitroVercelFunctionName(
@@ -62,7 +67,7 @@ export function resolveNitroVercelFunctionName(
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
   const preset = config.nitro?.preset || env.NITRO_PRESET || env.SERVER_PRESET
-  const nitro = Boolean(preset) || hasNitroVitePlugin(config)
+  const nitro = Boolean(preset) || hasNitroConfigContext(config)
   const clientOutDir = config.environments?.client?.build?.outDir
   const vercel = preset
     ? preset.startsWith("vercel")

--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -47,6 +47,7 @@ interface NitroVercelConfig {
 }
 
 export const VITEHUB_NITRO_CONFIG_CONTEXT: unique symbol = Symbol.for("@vite-hub/internal/nitro-config-context")
+export const VITEHUB_SERVER_DIRS: unique symbol = Symbol.for("@vite-hub/internal/server-dirs")
 
 function includesNitroVitePlugin(value: unknown): boolean {
   if (Array.isArray(value)) return value.some(includesNitroVitePlugin)

--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -46,8 +46,8 @@ interface NitroVercelConfig {
   plugins?: unknown
 }
 
-export const VITEHUB_NITRO_CONFIG_CONTEXT: unique symbol = Symbol.for("@vite-hub/internal/nitro-config-context")
-export const VITEHUB_SERVER_DIRS: unique symbol = Symbol.for("@vite-hub/internal/server-dirs")
+export const VITEHUB_NITRO_CONFIG_CONTEXT = "__vitehubNitroConfigContext" as const
+export const VITEHUB_SERVER_DIRS = "__vitehubServerDirs" as const
 
 function includesNitroVitePlugin(value: unknown): boolean {
   if (Array.isArray(value)) return value.some(includesNitroVitePlugin)

--- a/packages/internal/test/vite-build.test.ts
+++ b/packages/internal/test/vite-build.test.ts
@@ -1,13 +1,18 @@
 import { describe, expect, it } from "vitest"
 
-import { hasNitroVitePlugin, resolveNitroVercelFunctionName } from "../src/build/vite.ts"
+import {
+  hasNitroConfigContext,
+  resolveNitroVercelFunctionName,
+  VITEHUB_NITRO_CONFIG_CONTEXT,
+} from "../src/build/vite.ts"
 
 describe("Vite provider builds", () => {
   it("distinguishes the Nitro host plugin from ViteHub bridge plugins", () => {
-    expect(hasNitroVitePlugin({ plugins: [{ name: "nitro:main" }] })).toBe(true)
-    expect(hasNitroVitePlugin({ plugins: [[false, [{ name: "nitro:main" }]]] })).toBe(true)
-    expect(hasNitroVitePlugin({ plugins: [{ name: "@vite-hub/blob/vite" }, { name: "@vite-hub/queue/vite" }] })).toBe(false)
-    expect(hasNitroVitePlugin({ plugins: [[{ name: "@vite-hub/blob/vite" }]] })).toBe(false)
+    expect(hasNitroConfigContext({ plugins: [{ name: "nitro:main" }] })).toBe(true)
+    expect(hasNitroConfigContext({ plugins: [[false, [{ name: "nitro:main" }]]] })).toBe(true)
+    expect(hasNitroConfigContext({ [VITEHUB_NITRO_CONFIG_CONTEXT]: true })).toBe(true)
+    expect(hasNitroConfigContext({ plugins: [{ name: "@vite-hub/blob/vite" }, { name: "@vite-hub/queue/vite" }] })).toBe(false)
+    expect(hasNitroConfigContext({ plugins: [[{ name: "@vite-hub/blob/vite" }]] })).toBe(false)
   })
 
   it("isolates provider functions when Nitro owns the Vercel output", () => {

--- a/packages/markdown-template/src/vite.ts
+++ b/packages/markdown-template/src/vite.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, readdir, writeFile } from "node:fs/promises"
 import { dirname, isAbsolute, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
-import { resolveViteHubProjectRoot } from "@vite-hub/internal/build/vite"
+import { resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import {
   markdownTemplateFileSuffix,
@@ -76,8 +76,7 @@ async function loadBundledMarkdownTemplate(path: string): Promise<BundledMarkdow
   }
 }
 
-async function createMarkdownTemplateCatalog(root: string, runtimeImport: string): Promise<MarkdownTemplateCatalogState> {
-  const templatesRoot = resolve(root, "server", "templates")
+async function createMarkdownTemplateCatalog(templatesRoot: string, runtimeImport: string): Promise<MarkdownTemplateCatalogState> {
   const entries: Record<string, BundledMarkdownTemplateCatalogEntry> = Object.create(null)
   const watchFiles = new Set<string>()
 
@@ -125,6 +124,7 @@ export function hubMarkdownTemplate(options: HubMarkdownTemplateOptions = {}): P
   const runtimeImport = options.runtimeImport || markdownTemplateRuntimeSpecifier
   const runtimeAlias = options.runtimeImport ? undefined : fileURLToPath(import.meta.resolve(markdownTemplateRuntimeSpecifier))
   let root = process.cwd()
+  let serverDirs: string[] | undefined
   let templatesRoot = resolve(root, "server", "templates")
   let registryPath = resolve(root, markdownTemplateRegistryPath)
   let catalogTypesPath = resolve(root, ".vitehub", "types", "templates.d.ts")
@@ -135,7 +135,7 @@ export function hubMarkdownTemplate(options: HubMarkdownTemplateOptions = {}): P
   }
 
   const refreshCatalog = async () => {
-    catalog = await createMarkdownTemplateCatalog(root, runtimeImport)
+    catalog = await createMarkdownTemplateCatalog(templatesRoot, runtimeImport)
     await Promise.all([
       writeFileIfChanged(registryPath, catalog.code),
       writeFileIfChanged(catalogTypesPath, renderMarkdownTemplateCatalogTypes(catalog.names)),
@@ -145,7 +145,8 @@ export function hubMarkdownTemplate(options: HubMarkdownTemplateOptions = {}): P
   return {
     name: "@vite-hub/markdown-template/vite",
     enforce: "pre",
-    config() {
+    config(config) {
+      serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
       if (!runtimeAlias) return
       return {
         resolve: {
@@ -183,7 +184,7 @@ export function hubMarkdownTemplate(options: HubMarkdownTemplateOptions = {}): P
     },
     async configResolved(config) {
       root = resolveViteHubProjectRoot(config.root)
-      templatesRoot = resolve(root, "server", "templates")
+      templatesRoot = resolve(serverDirs?.[0] ?? resolve(root, "server"), "templates")
       registryPath = resolve(root, markdownTemplateRegistryPath)
       catalogTypesPath = resolve(root, ".vitehub", "types", "templates.d.ts")
       const typesPath = resolve(root, ".vitehub", "types", "markdown-template.d.ts")

--- a/packages/markdown-template/test/vite.test.ts
+++ b/packages/markdown-template/test/vite.test.ts
@@ -164,6 +164,30 @@ describe("hubMarkdownTemplate", () => {
     await expect(bundled.default()).resolves.toBe("Review ViteHub.")
   }, 15_000)
 
+  it("discovers named templates from a forwarded server directory", async () => {
+    const root = await createRoot()
+    const templates = join(root, "backend", "templates")
+    const entry = join(root, "entry.ts")
+    await mkdir(templates, { recursive: true })
+    await writeFile(join(templates, "prompt.md"), "Custom server directory.\n", "utf8")
+    await writeFile(entry, 'export { renderTemplate } from "#vitehub/templates"\n', "utf8")
+
+    await build({
+      __vitehubServerDirs: [join(root, "backend")],
+      build: {
+        emptyOutDir: true,
+        lib: { entry, fileName: () => "entry.mjs", formats: ["es"] },
+        outDir: join(root, "dist"),
+      },
+      logLevel: "silent",
+      plugins: [hubMarkdownTemplate()],
+      root,
+    } as Parameters<typeof build>[0])
+
+    await expect(readFile(join(root, ".vitehub", "markdown-template", "templates.mjs"), "utf8"))
+      .resolves.toContain("Custom server directory.")
+  }, 15_000)
+
   it("uses the project root when Vite runs from app", async () => {
     const root = await createRoot()
     const app = join(root, "app")

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -1,6 +1,6 @@
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { composeNitroCloudflareProviderOutput, registerCloudflareProviderOutput, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, hasNitroVitePlugin, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, hasNitroConfigContext, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
 import { getHostingProvider } from "@vite-hub/internal/hosting"
 import { resolve } from "pathe"
 
@@ -200,7 +200,7 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
       queue = config.queue ?? queue
       const configuredNitro = (config as { nitro?: unknown }).nitro
       const configuredNitroConfig = cloneNitroConfig(configuredNitro)
-      nitroOwnsCloudflareWorker = hasNitroVitePlugin(config) && resolveNitroHosting(configuredNitroConfig) === "cloudflare" && supportsCloudflareQueues(configuredNitroConfig)
+      nitroOwnsCloudflareWorker = hasNitroConfigContext(config) && resolveNitroHosting(configuredNitroConfig) === "cloudflare" && supportsCloudflareQueues(configuredNitroConfig)
       configuredDefinitions = discoverQueueDefinitions({ rootDir: config.root })
       const nitro = mergeNitroConfig(config, configuredNitro, queue, config.root, configuredDefinitions)
       ;(config as { nitro?: unknown }).nitro = nitro
@@ -209,7 +209,7 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
       cloudflareQueues = supportsCloudflareQueues(nitro)
       const nitroHosting = resolveNitroHosting(nitro)
       nitroQueue = queue !== false && queue?.provider && nitroHosting && queue.provider !== nitroHosting ? false : queue
-      validatesNitroDefinitions = hasNitroVitePlugin(config) && nitroQueue !== false
+      validatesNitroDefinitions = hasNitroConfigContext(config) && nitroQueue !== false
       await writeQueueNitroIntegration(config.root, nitroQueue, hosting, cloudflareQueues, configuredDefinitions)
     },
     configEnvironment(name, config) {

--- a/packages/rate-limit/src/vite.ts
+++ b/packages/rate-limit/src/vite.ts
@@ -9,7 +9,7 @@ import {
   shouldSkipViteProviderBuild,
   useComposedProviderOutput,
 } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, hasNitroVitePlugin, isServerEnvironment, resolveViteHubProjectRoot } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, hasNitroConfigContext, isServerEnvironment, resolveViteHubProjectRoot } from "@vite-hub/internal/build/vite"
 import { writeFileIfChanged } from "@vite-hub/internal/definition-catalog"
 import { getHostingProvider } from "@vite-hub/internal/hosting"
 import { normalizePath } from "vite"
@@ -161,7 +161,7 @@ export function hubRateLimit(options: RateLimitVitePluginOptions = {}): RateLimi
       projectRoot = resolveViteHubProjectRoot(config.root, { projectRoot: rateLimit.projectRoot })
       const configuredNitro = (config as { nitro?: unknown }).nitro
       const nitroCloudflare = resolveNitroHosting(configuredNitro) === "cloudflare"
-      cloudflareOwnedByNitro = hasNitroVitePlugin(config) && nitroCloudflare
+      cloudflareOwnedByNitro = hasNitroConfigContext(config) && nitroCloudflare
       provider = resolveProvider(rateLimit, config.command, configuredNitro)!
       collectDeclarations()
       ;(config as { nitro?: unknown }).nitro = mergeNitroConfig(

--- a/packages/sandbox/src/vite.ts
+++ b/packages/sandbox/src/vite.ts
@@ -1,4 +1,4 @@
-import { createNoExternalMerger, hasNitroVitePlugin, isServerEnvironment } from '@vite-hub/internal/build/vite'
+import { createNoExternalMerger, hasNitroConfigContext, isServerEnvironment } from '@vite-hub/internal/build/vite'
 import { getHostingProvider } from '@vite-hub/internal/hosting'
 import { basename, dirname, normalize, relative } from 'pathe'
 
@@ -243,7 +243,7 @@ export function hubSandbox(options?: SandboxPublicOptions): SandboxVitePlugin {
     config: { nitro?: unknown, plugins?: unknown, root?: string },
     prepared: Awaited<ReturnType<typeof prepareCurrentSandboxRuntime>>,
   ) {
-    if (!prepared.cloudflare || !hasNitroVitePlugin(config) || getHostingProvider(prepared.hosting) !== 'cloudflare')
+    if (!prepared.cloudflare || !hasNitroConfigContext(config) || getHostingProvider(prepared.hosting) !== 'cloudflare')
       return false
     config.nitro = await configureCloudflareSandboxNitro(
       config.nitro as Parameters<typeof configureCloudflareSandboxNitro>[0],

--- a/packages/schedule/src/discovery.ts
+++ b/packages/schedule/src/discovery.ts
@@ -46,7 +46,7 @@ function normalizeDirectoryScheduleName(directory: string, file: string) {
 }
 
 export function discoverScheduleDefinitions(options:
-  | { mode?: "vite-suffix", rootDir: string, scanDirs?: string[], serverRootDir?: string }
+  | { mode?: "vite-suffix", rootDir: string, scanDirs?: string[], serverDirs?: string[], serverRootDir?: string }
   | { mode: "server-schedules", scanDirs: string[] }
 ): DiscoveredScheduleDefinition[] {
   if (options.mode === "server-schedules") {
@@ -60,7 +60,7 @@ export function discoverScheduleDefinitions(options:
 
   const roots = resolveDefinitionScanRoots(options.rootDir, options.scanDirs)
   const serverRoots = resolveDefinitionScanRoots(options.serverRootDir || options.rootDir, options.scanDirs)
-  const serverScanDirs = serverRoots.map(root => resolve(root, "server"))
+  const serverScanDirs = options.serverDirs ?? serverRoots.map(root => resolve(root, "server"))
 
   return mergeDefinitions(
     "schedule",

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -4,7 +4,7 @@ import { dirname, relative, resolve, normalize } from "node:path"
 import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { createRuntimeRegistryContents } from "@vite-hub/internal/definition-catalog"
-import { createNoExternalMerger, isServerEnvironment, resolveViteHubProjectRoot } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, isServerEnvironment, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import { discoverScheduleDefinitions } from "./discovery.ts"
 import { generateProviderOutputs, readDefinitionCrons, schedulePackageName } from "./internal/provider-output.ts"
@@ -41,6 +41,8 @@ export interface ScheduleNitroConfigOptions extends ScheduleVitePluginOptions {
   command?: "build" | "serve"
   nitro?: unknown
   root?: string
+  /** @internal Framework-resolved server definition directories. */
+  serverDirs?: string[]
 }
 
 interface InternalScheduleVitePluginOptions extends ScheduleVitePluginOptions {
@@ -386,6 +388,7 @@ export async function createScheduleNitroConfig(options: ScheduleNitroConfigOpti
   const roots = resolveSchedulePluginRoots(options.root || process.cwd(), options)
   const definitions = discoverScheduleDefinitions({
     rootDir: roots.viteRoot,
+    serverDirs: options.serverDirs,
     serverRootDir: roots.projectRoot,
   })
   if (!shouldInstallNitroSchedulePlugin(definitions, options)) {
@@ -423,6 +426,7 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
   let emitStandaloneProviderOutput = true
   let projectRoot: string | undefined
   let standaloneProviderSource: DiscoveredScheduleDefinition["source"] | undefined
+  let serverDirs: string[] | undefined
   let viteRoot: string | undefined
 
   function discoverViteSchedules() {
@@ -433,6 +437,7 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
     return discoverScheduleDefinitions({
       mode: "vite-suffix",
       rootDir: viteRoot,
+      serverDirs,
       serverRootDir: projectRoot,
     })
   }
@@ -444,6 +449,7 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
 
     return discoverScheduleDefinitions({
       rootDir: viteRoot,
+      serverDirs,
       serverRootDir: projectRoot,
     })
   }
@@ -462,9 +468,11 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
     name: SCHEDULE_VITE_PLUGIN_NAME,
     enforce: "pre",
     async config(config, env) {
+      serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
       const roots = resolveSchedulePluginRoots(config.root || process.cwd(), options)
       const definitions = discoverScheduleDefinitions({
         rootDir: roots.viteRoot,
+        serverDirs,
         serverRootDir: roots.projectRoot,
       })
       emitStandaloneProviderOutput = (options.runtime === undefined || options.providerOutput === "standalone") && shouldEmitStandaloneProviderOutput(definitions, options)
@@ -477,6 +485,7 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
         command: env.command,
         nitro: (config as { nitro?: unknown }).nitro,
         root: config.root || process.cwd(),
+        serverDirs,
       })
       if (!nitro) return null
       ;(config as ViteConfigWithNitro).nitro = nitro

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -507,7 +507,12 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
     },
     handleHotUpdate(context) {
       const file = normalize(context.file).replace(/\\/g, "/")
-      if (!/\.schedule\.(?:c|m)?[jt]s$/i.test(file) && !/\/server\/schedules\/.*\.(?:c|m)?[jt]s$/i.test(file)) {
+      const scheduleRoots = (serverDirs ?? [resolve(projectRoot ?? resolved?.root ?? context.server.config.root, "server")])
+        .map(directory => `${resolve(directory, "schedules").replace(/\\/g, "/")}/`)
+      const serverSchedule = scheduleRoots.some(directory =>
+        file.startsWith(directory) && /\.(?:c|m)?[jt]s$/i.test(file.slice(directory.length)),
+      )
+      if (!/\.schedule\.(?:c|m)?[jt]s$/i.test(file) && !serverSchedule) {
         return
       }
 

--- a/packages/schedule/test/vite.test.ts
+++ b/packages/schedule/test/vite.test.ts
@@ -3,9 +3,10 @@ import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { createDefaultCloudflareOutputRoot, createDefaultNetlifyOutputRoot } from "@vite-hub/internal/build/deployment-output"
+import { VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import { createScheduleNitroConfig, hubSchedule } from "../src/vite.ts"
 
 function resolveScheduleRegistry(plugin: ReturnType<typeof hubSchedule>) {
@@ -33,6 +34,34 @@ describe("Vite schedule integration", () => {
     const plugin = hubSchedule()
 
     expect(plugin.enforce).toBe("pre")
+  })
+
+  it("invalidates registries for updates under a forwarded server directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-hmr-"))
+    const serverDir = join(root, "backend")
+    const plugin = hubSchedule()
+    await (plugin.config as (config: Record<PropertyKey, unknown>, env: { command: "serve", mode: string }) => unknown)({
+      [VITEHUB_SERVER_DIRS]: [serverDir],
+      root,
+    }, { command: "serve", mode: "development" })
+    resolvePluginConfig(plugin, root)
+    const registry = {}
+    const targets = {}
+    const invalidateModule = vi.fn()
+
+    ;(plugin.handleHotUpdate as (context: Record<string, unknown>) => unknown)({
+      file: join(serverDir, "schedules", "daily.ts"),
+      server: {
+        config: { root },
+        moduleGraph: {
+          getModuleById: (id: string) => id.includes("targets") ? targets : registry,
+          invalidateModule,
+        },
+      },
+    })
+
+    expect(invalidateModule).toHaveBeenCalledWith(registry)
+    expect(invalidateModule).toHaveBeenCalledWith(targets)
   })
 
   it("registers runtime-only targets without emitting static provider output", async () => {

--- a/packages/vite-hub/fixtures/published-types/consumer.ts
+++ b/packages/vite-hub/fixtures/published-types/consumer.ts
@@ -17,6 +17,7 @@ import type { BoxDefinition } from "vite-hub/box"
 import * as smtp from "vite-hub/email/drivers/smtp"
 import { env } from "vite-hub/env"
 import * as markdownTemplate from "vite-hub/markdown-template"
+import viteHubNuxtModule from "vite-hub/nuxt"
 import * as scheduleDriver from "vite-hub/schedule/runtime/driver"
 import * as scheduleProcess from "vite-hub/schedule/runtime/process"
 import * as cloudflareShell from "vite-hub/shell/providers/cloudflare"
@@ -45,6 +46,7 @@ export const appFacingModules = [
   workspaceServer,
 ]
 
+export const nuxtModule = viteHubNuxtModule
 export const builtInAgent = defineAgent({ driver: "codex", runtime: false })
 export const builtInBox = { runtime: "trusted-host" } satisfies BoxDefinition
 export const builtInAgentName = "codex" satisfies BuiltInAgentDriverName

--- a/packages/vite-hub/package.json
+++ b/packages/vite-hub/package.json
@@ -93,6 +93,7 @@
     "./env/server": "./dist/env/server.js",
     "./kv": "./dist/kv.js",
     "./markdown-template": "./dist/markdown-template.js",
+    "./nuxt": "./dist/nuxt.js",
     "./queue": "./dist/queue.js",
     "./rate-limit": "./dist/rate-limit.js",
     "./runtime": "./dist/runtime.js",

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -1,4 +1,4 @@
-import { VITEHUB_NITRO_CONFIG_CONTEXT } from "@vite-hub/internal/build/vite"
+import { VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import { mergeConfig } from "vite"
 
 import { vitehub } from "./index.ts"
@@ -64,11 +64,14 @@ async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, u
     isSsrBuild: true,
     mode: nuxt.options.dev ? "development" : "production",
   } as const
+  const serverDirs = nuxt.options.serverDir ? [nuxt.options.serverDir] : undefined
   let config: UserConfig & {
     [VITEHUB_NITRO_CONFIG_CONTEXT]?: true
+    [VITEHUB_SERVER_DIRS]?: string[]
     nitro?: Record<string, unknown>
   } = {
     [VITEHUB_NITRO_CONFIG_CONTEXT]: true,
+    ...(serverDirs ? { [VITEHUB_SERVER_DIRS]: serverDirs } : {}),
     build: {},
     nitro: nitroConfig,
     root: nuxt.options.srcDir || nuxt.options.rootDir || process.cwd(),
@@ -80,8 +83,11 @@ async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, u
     if (handler) {
       const result = await handler.call({} as never, config, environment)
       if (result) {
-        config = mergeConfig(config, result)
+        const { nitro, ...viteConfig } = result as UserConfig & { nitro?: Record<string, unknown> }
+        config = mergeConfig(config, viteConfig)
+        if (nitro) config.nitro = nitro as Record<string, unknown>
         config[VITEHUB_NITRO_CONFIG_CONTEXT] = true
+        if (serverDirs) config[VITEHUB_SERVER_DIRS] = serverDirs
       }
     }
 

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -66,21 +66,21 @@ async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, u
     mode: nuxt.options.dev ? "development" : "production",
   } as const
   const serverDirs = nuxt.options.serverDir ? [nuxt.options.serverDir] : undefined
-  let config: UserConfig & {
-    [VITEHUB_NITRO_CONFIG_CONTEXT]?: true
-    [VITEHUB_SERVER_DIRS]?: string[]
-    nitro?: Record<string, unknown>
-  } = {
-    [VITEHUB_NITRO_CONFIG_CONTEXT]: true,
-    ...(serverDirs ? { [VITEHUB_SERVER_DIRS]: serverDirs } : {}),
-    build: {},
-    nitro: nitroConfig,
+  let config = mergeConfig({
     resolve: {
       alias: nuxt.options.alias,
     },
     root: nuxt.options.srcDir || nuxt.options.rootDir || process.cwd(),
-    server: {},
+  }, nuxt.options.vite ?? {}) as UserConfig & {
+    [VITEHUB_NITRO_CONFIG_CONTEXT]?: true
+    [VITEHUB_SERVER_DIRS]?: string[]
+    nitro?: Record<string, unknown>
   }
+  config[VITEHUB_NITRO_CONFIG_CONTEXT] = true
+  if (serverDirs) config[VITEHUB_SERVER_DIRS] = serverDirs
+  config.build ??= {}
+  config.nitro = nitroConfig
+  config.server ??= {}
 
   for (const plugin of plugins) {
     const handler = configHandler(plugin)

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -128,8 +128,10 @@ export default function viteHubNuxtModule(options: Parameters<typeof vitehub>[0]
 
   nuxt.options.vite ??= {}
   const viteConfig = nuxt.options.vite as UserConfig & {
+    [VITEHUB_NITRO_CONFIG_CONTEXT]?: true
     [VITEHUB_SERVER_DIRS]?: string[]
   }
+  viteConfig[VITEHUB_NITRO_CONFIG_CONTEXT] = true
   if (nuxt.options.serverDir) viteConfig[VITEHUB_SERVER_DIRS] = [nuxt.options.serverDir]
   nuxt.options.vite.plugins = [
     ...plugins.filter(plugin => !existingNames.has(plugin.name)),

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -1,0 +1,84 @@
+import { mergeConfig } from "vite"
+
+import { vitehub } from "./index.ts"
+
+import type { Plugin, PluginOption, UserConfig } from "vite"
+
+type NuxtLike = {
+  hook?: (name: "nitro:config", callback: (config: Record<string, unknown>) => Promise<void>) => void
+  options: {
+    dev?: boolean
+    rootDir?: string
+    vite?: UserConfig
+  }
+}
+
+function flattenPlugins(options: readonly unknown[]): Plugin[] {
+  const plugins: Plugin[] = []
+  for (const option of options) {
+    if (Array.isArray(option)) plugins.push(...flattenPlugins(option))
+    else if (option && typeof option === "object" && "name" in option) plugins.push(option as Plugin)
+  }
+  return plugins
+}
+
+function configHandler(plugin: Plugin) {
+  if (typeof plugin.config === "function") return plugin.config
+  return plugin.config?.handler
+}
+
+function withoutDeploymentOutput(options: readonly unknown[]): unknown[] {
+  return options.flatMap((option) => {
+    if (Array.isArray(option)) return [withoutDeploymentOutput(option)]
+    if (option && typeof option === "object" && "name" in option && option.name === "vite-hub/deployment-output") {
+      return []
+    }
+    return [option]
+  })
+}
+
+async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, unknown>, nuxt: NuxtLike) {
+  const environment = {
+    command: nuxt.options.dev ? "serve" : "build",
+    isPreview: false,
+    isSsrBuild: true,
+    mode: nuxt.options.dev ? "development" : "production",
+  } as const
+  let config: UserConfig & { nitro?: Record<string, unknown> } = {
+    build: {},
+    nitro: nitroConfig,
+    root: nuxt.options.rootDir || process.cwd(),
+    server: {},
+  }
+
+  for (const plugin of plugins) {
+    const handler = configHandler(plugin)
+    if (!handler) continue
+    const result = await handler.call({} as never, config, environment)
+    if (result) config = mergeConfig(config, result)
+  }
+
+  if (config.nitro) Object.assign(nitroConfig, config.nitro)
+}
+
+export default function viteHubNuxtModule(options: Parameters<typeof vitehub>[0], nuxt?: NuxtLike): void {
+  if (!nuxt) return
+
+  const plugins = flattenPlugins(vitehub(options))
+    .filter(plugin => plugin.name !== "vite-hub/deployment-output")
+  const existing = withoutDeploymentOutput(
+    Array.isArray(nuxt.options.vite?.plugins) ? nuxt.options.vite.plugins : [],
+  )
+  const existingNames = new Set(
+    flattenPlugins(existing)
+      .map(plugin => plugin.name)
+      .filter(Boolean),
+  )
+
+  nuxt.options.vite ??= {}
+  nuxt.options.vite.plugins = [
+    ...plugins.filter(plugin => !existingNames.has(plugin.name)),
+    ...existing,
+  ] as PluginOption[]
+  nuxt.hook?.("nitro:config", config => applyNitroConfig(plugins, config, nuxt))
+}

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -8,6 +8,7 @@ import type { Plugin, PluginOption, UserConfig } from "vite"
 type NuxtLike = {
   hook?: (name: "nitro:config", callback: (config: Record<string, unknown>) => Promise<void>) => void
   options: {
+    alias?: Record<string, string>
     dev?: boolean
     rootDir?: string
     serverDir?: string
@@ -74,6 +75,9 @@ async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, u
     ...(serverDirs ? { [VITEHUB_SERVER_DIRS]: serverDirs } : {}),
     build: {},
     nitro: nitroConfig,
+    resolve: {
+      alias: nuxt.options.alias,
+    },
     root: nuxt.options.srcDir || nuxt.options.rootDir || process.cwd(),
     server: {},
   }

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -9,9 +9,18 @@ type NuxtLike = {
   options: {
     dev?: boolean
     rootDir?: string
+    serverDir?: string
+    srcDir?: string
     vite?: UserConfig
   }
 }
+
+type QueueNitroConfigHandler = (options: {
+  nitro: Record<string, unknown>
+  projectRoot: string
+  root: string
+  serverDirs?: string[]
+}) => Promise<Record<string, unknown>>
 
 function flattenPlugins(options: readonly unknown[]): Plugin[] {
   const plugins: Plugin[] = []
@@ -25,6 +34,16 @@ function flattenPlugins(options: readonly unknown[]): Plugin[] {
 function configHandler(plugin: Plugin) {
   if (typeof plugin.config === "function") return plugin.config
   return plugin.config?.handler
+}
+
+function queueNitroConfigHandler(plugin: Plugin): QueueNitroConfigHandler | undefined {
+  return (plugin as Plugin & {
+    vitehub?: {
+      queue?: {
+        createNitroConfig?: QueueNitroConfigHandler
+      }
+    }
+  }).vitehub?.queue?.createNitroConfig
 }
 
 function withoutDeploymentOutput(options: readonly unknown[]): unknown[] {
@@ -47,11 +66,23 @@ async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, u
   let config: UserConfig & { nitro?: Record<string, unknown> } = {
     build: {},
     nitro: nitroConfig,
-    root: nuxt.options.rootDir || process.cwd(),
+    root: nuxt.options.srcDir || nuxt.options.rootDir || process.cwd(),
     server: {},
   }
 
   for (const plugin of plugins) {
+    const createQueueNitroConfig = queueNitroConfigHandler(plugin)
+    if (createQueueNitroConfig) {
+      const projectRoot = nuxt.options.rootDir || process.cwd()
+      config.nitro = await createQueueNitroConfig({
+        nitro: config.nitro || {},
+        projectRoot,
+        root: nuxt.options.srcDir || projectRoot,
+        serverDirs: nuxt.options.serverDir ? [nuxt.options.serverDir] : undefined,
+      })
+      continue
+    }
+
     const handler = configHandler(plugin)
     if (!handler) continue
     const result = await handler.call({} as never, config, environment)

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -127,6 +127,10 @@ export default function viteHubNuxtModule(options: Parameters<typeof vitehub>[0]
   const installedPlugins = plugins.map(plugin => existingPluginsByName.get(plugin.name) || plugin)
 
   nuxt.options.vite ??= {}
+  const viteConfig = nuxt.options.vite as UserConfig & {
+    [VITEHUB_SERVER_DIRS]?: string[]
+  }
+  if (nuxt.options.serverDir) viteConfig[VITEHUB_SERVER_DIRS] = [nuxt.options.serverDir]
   nuxt.options.vite.plugins = [
     ...plugins.filter(plugin => !existingNames.has(plugin.name)),
     ...existing,

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -128,7 +128,13 @@ export default function viteHubNuxtModule(options: Parameters<typeof vitehub>[0]
       .filter(plugin => plugin.name)
       .map(plugin => [plugin.name, plugin]),
   )
-  const installedPlugins = plugins.map(plugin => existingPluginsByName.get(plugin.name) || plugin)
+  const installedPlugins = [
+    ...plugins.map(plugin => existingPluginsByName.get(plugin.name) || plugin),
+    ...flattenPlugins(existing).filter(plugin =>
+      (plugin.name.startsWith("@vite-hub/") || plugin.name.startsWith("vite-hub/"))
+      && !plugins.some(candidate => candidate.name === plugin.name),
+    ),
+  ]
 
   nuxt.options.vite ??= {}
   const viteConfig = nuxt.options.vite as UserConfig & {

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -1,3 +1,4 @@
+import { VITEHUB_NITRO_CONFIG_CONTEXT } from "@vite-hub/internal/build/vite"
 import { mergeConfig } from "vite"
 
 import { vitehub } from "./index.ts"
@@ -63,7 +64,11 @@ async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, u
     isSsrBuild: true,
     mode: nuxt.options.dev ? "development" : "production",
   } as const
-  let config: UserConfig & { nitro?: Record<string, unknown> } = {
+  let config: UserConfig & {
+    [VITEHUB_NITRO_CONFIG_CONTEXT]?: true
+    nitro?: Record<string, unknown>
+  } = {
+    [VITEHUB_NITRO_CONFIG_CONTEXT]: true,
     build: {},
     nitro: nitroConfig,
     root: nuxt.options.srcDir || nuxt.options.rootDir || process.cwd(),
@@ -71,6 +76,15 @@ async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, u
   }
 
   for (const plugin of plugins) {
+    const handler = configHandler(plugin)
+    if (handler) {
+      const result = await handler.call({} as never, config, environment)
+      if (result) {
+        config = mergeConfig(config, result)
+        config[VITEHUB_NITRO_CONFIG_CONTEXT] = true
+      }
+    }
+
     const createQueueNitroConfig = queueNitroConfigHandler(plugin)
     if (createQueueNitroConfig) {
       const projectRoot = nuxt.options.rootDir || process.cwd()
@@ -80,13 +94,7 @@ async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, u
         root: nuxt.options.srcDir || projectRoot,
         serverDirs: nuxt.options.serverDir ? [nuxt.options.serverDir] : undefined,
       })
-      continue
     }
-
-    const handler = configHandler(plugin)
-    if (!handler) continue
-    const result = await handler.call({} as never, config, environment)
-    if (result) config = mergeConfig(config, result)
   }
 
   if (config.nitro) Object.assign(nitroConfig, config.nitro)
@@ -105,11 +113,17 @@ export default function viteHubNuxtModule(options: Parameters<typeof vitehub>[0]
       .map(plugin => plugin.name)
       .filter(Boolean),
   )
+  const existingPluginsByName = new Map(
+    flattenPlugins(existing)
+      .filter(plugin => plugin.name)
+      .map(plugin => [plugin.name, plugin]),
+  )
+  const installedPlugins = plugins.map(plugin => existingPluginsByName.get(plugin.name) || plugin)
 
   nuxt.options.vite ??= {}
   nuxt.options.vite.plugins = [
     ...plugins.filter(plugin => !existingNames.has(plugin.name)),
     ...existing,
   ] as PluginOption[]
-  nuxt.hook?.("nitro:config", config => applyNitroConfig(plugins, config, nuxt))
+  nuxt.hook?.("nitro:config", config => applyNitroConfig(installedPlugins, config, nuxt))
 }

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+import type { PluginOption } from "vite"
+
+const mocks = vi.hoisted(() => ({
+  objectHook: vi.fn(() => ({
+    nitro: {
+      handlers: [{ handler: "server/handler.ts", route: "/api/example" }],
+    },
+  })),
+  outputHook: vi.fn(),
+  vitehub: vi.fn(),
+}))
+
+vi.mock("../src/index.ts", () => ({ vitehub: mocks.vitehub }))
+
+import viteHubNuxtModule from "../src/nuxt.ts"
+
+function createNuxt(dev = false, plugins: PluginOption[] = []) {
+  let nitroConfigHook: ((config: Record<string, unknown>) => Promise<void>) | undefined
+  const nuxt = {
+    hook(name: "nitro:config", callback: (config: Record<string, unknown>) => Promise<void>) {
+      if (name === "nitro:config") nitroConfigHook = callback
+    },
+    options: {
+      dev,
+      rootDir: "/tmp/vitehub-nuxt",
+      vite: { plugins },
+    },
+  }
+  return {
+    nuxt,
+    runNitroConfigHook(config: Record<string, unknown>) {
+      if (!nitroConfigHook) throw new TypeError("Expected a Nitro config hook.")
+      return nitroConfigHook(config)
+    },
+  }
+}
+
+describe("ViteHub Nuxt integration", () => {
+  beforeEach(() => {
+    mocks.objectHook.mockClear()
+    mocks.outputHook.mockClear()
+    mocks.vitehub.mockReset()
+    mocks.vitehub.mockReturnValue([
+      false,
+      [{
+        name: "vite-hub/deployment-preset",
+        config(config: { nitro?: Record<string, unknown> }) {
+          const cloudflare = config.nitro?.cloudflare as Record<string, unknown> | undefined
+          const wrangler = cloudflare?.wrangler as Record<string, unknown> | undefined
+          config.nitro = {
+            ...config.nitro,
+            cloudflare: {
+              ...cloudflare,
+              wrangler: {
+                ...wrangler,
+                name: "vitehub-nuxt",
+              },
+            },
+            preset: "cloudflare_module",
+          }
+        },
+      }],
+      {
+        name: "vite-hub/object-hook",
+        config: {
+          handler: mocks.objectHook,
+        },
+      },
+      {
+        name: "vite-hub/deployment-output",
+        config: mocks.outputHook,
+      },
+    ])
+  })
+
+  it("installs flattened ViteHub plugins and applies their config hooks to Nitro", async () => {
+    const existingPlugin = { name: "vite-hub/object-hook" }
+    const { nuxt, runNitroConfigHook } = createNuxt(true, [[
+      existingPlugin,
+      { name: "vite-hub/deployment-output" },
+    ]])
+
+    viteHubNuxtModule({ preset: "cloudflare" }, nuxt)
+
+    expect((nuxt.options.vite.plugins as unknown[]).flat(Infinity)).toEqual([
+      expect.objectContaining({ name: "vite-hub/deployment-preset" }),
+      existingPlugin,
+    ])
+
+    const d1Binding = {
+      binding: "DB",
+      database_id: "database-id",
+      database_name: "database-name",
+    }
+    const nitroConfig = {
+      cloudflare: {
+        wrangler: {
+          d1_databases: [d1Binding, d1Binding],
+          observability: { enabled: true },
+        },
+      },
+    }
+    await runNitroConfigHook(nitroConfig)
+
+    expect(mocks.objectHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nitro: expect.objectContaining({ preset: "cloudflare_module" }),
+        root: "/tmp/vitehub-nuxt",
+      }),
+      {
+        command: "serve",
+        isPreview: false,
+        isSsrBuild: true,
+        mode: "development",
+      },
+    )
+    expect(mocks.outputHook).not.toHaveBeenCalled()
+    expect(nitroConfig).toEqual({
+      cloudflare: {
+        wrangler: {
+          d1_databases: [d1Binding, d1Binding],
+          name: "vitehub-nuxt",
+          observability: { enabled: true },
+        },
+      },
+      handlers: [{ handler: "server/handler.ts", route: "/api/example" }],
+      preset: "cloudflare_module",
+    })
+  })
+
+  it("does nothing when Nuxt has not initialized", () => {
+    expect(() => viteHubNuxtModule({ preset: "node" })).not.toThrow()
+    expect(mocks.vitehub).not.toHaveBeenCalled()
+  })
+})

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -9,6 +9,12 @@ const mocks = vi.hoisted(() => ({
     },
   })),
   outputHook: vi.fn(),
+  queueNitroConfig: vi.fn(async ({ nitro }: { nitro: Record<string, unknown> }) => ({
+    ...nitro,
+    queues: {
+      handlers: [{ handler: "custom-server/queues/email.ts" }],
+    },
+  })),
   vitehub: vi.fn(),
 }))
 
@@ -25,6 +31,8 @@ function createNuxt(dev = false, plugins: PluginOption[] = []) {
     options: {
       dev,
       rootDir: "/tmp/vitehub-nuxt",
+      serverDir: "/tmp/vitehub-nuxt/custom-server",
+      srcDir: "/tmp/vitehub-nuxt/app",
       vite: { plugins },
     },
   }
@@ -41,6 +49,7 @@ describe("ViteHub Nuxt integration", () => {
   beforeEach(() => {
     mocks.objectHook.mockClear()
     mocks.outputHook.mockClear()
+    mocks.queueNitroConfig.mockClear()
     mocks.vitehub.mockReset()
     mocks.vitehub.mockReturnValue([
       false,
@@ -62,6 +71,15 @@ describe("ViteHub Nuxt integration", () => {
           }
         },
       }],
+      {
+        name: "@vite-hub/queue/vite",
+        config: vi.fn(),
+        vitehub: {
+          queue: {
+            createNitroConfig: mocks.queueNitroConfig,
+          },
+        },
+      },
       {
         name: "vite-hub/object-hook",
         config: {
@@ -86,6 +104,7 @@ describe("ViteHub Nuxt integration", () => {
 
     expect((nuxt.options.vite.plugins as unknown[]).flat(Infinity)).toEqual([
       expect.objectContaining({ name: "vite-hub/deployment-preset" }),
+      expect.objectContaining({ name: "@vite-hub/queue/vite" }),
       existingPlugin,
     ])
 
@@ -104,10 +123,16 @@ describe("ViteHub Nuxt integration", () => {
     }
     await runNitroConfigHook(nitroConfig)
 
+    expect(mocks.queueNitroConfig).toHaveBeenCalledWith({
+      nitro: expect.objectContaining({ preset: "cloudflare_module" }),
+      projectRoot: "/tmp/vitehub-nuxt",
+      root: "/tmp/vitehub-nuxt/app",
+      serverDirs: ["/tmp/vitehub-nuxt/custom-server"],
+    })
     expect(mocks.objectHook).toHaveBeenCalledWith(
       expect.objectContaining({
         nitro: expect.objectContaining({ preset: "cloudflare_module" }),
-        root: "/tmp/vitehub-nuxt",
+        root: "/tmp/vitehub-nuxt/app",
       }),
       {
         command: "serve",
@@ -127,6 +152,9 @@ describe("ViteHub Nuxt integration", () => {
       },
       handlers: [{ handler: "server/handler.ts", route: "/api/example" }],
       preset: "cloudflare_module",
+      queues: {
+        handlers: [{ handler: "custom-server/queues/email.ts" }],
+      },
     })
   })
 

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
+import { VITEHUB_NITRO_CONFIG_CONTEXT } from "@vite-hub/internal/build/vite"
+
 import type { PluginOption } from "vite"
 
 const mocks = vi.hoisted(() => ({
@@ -8,11 +10,21 @@ const mocks = vi.hoisted(() => ({
       handlers: [{ handler: "server/handler.ts", route: "/api/example" }],
     },
   })),
-  outputHook: vi.fn(),
-  queueNitroConfig: vi.fn(async ({ nitro }: { nitro: Record<string, unknown> }) => ({
+  existingQueueConfig: vi.fn(),
+  existingQueueNitroConfig: vi.fn(async ({ nitro }: { nitro: Record<string, unknown> }) => ({
     ...nitro,
     queues: {
       handlers: [{ handler: "custom-server/queues/email.ts" }],
+    },
+  })),
+  outputHook: vi.fn(),
+  queueNitroConfig: vi.fn(async ({ nitro }: { nitro: Record<string, unknown> }) => ({
+    ...nitro,
+    unexpectedQueue: true,
+  })),
+  sandboxHook: vi.fn((config: { [VITEHUB_NITRO_CONFIG_CONTEXT]?: boolean }) => ({
+    nitro: {
+      sandbox: config[VITEHUB_NITRO_CONFIG_CONTEXT],
     },
   })),
   vitehub: vi.fn(),
@@ -48,8 +60,11 @@ function createNuxt(dev = false, plugins: PluginOption[] = []) {
 describe("ViteHub Nuxt integration", () => {
   beforeEach(() => {
     mocks.objectHook.mockClear()
+    mocks.existingQueueConfig.mockClear()
+    mocks.existingQueueNitroConfig.mockClear()
     mocks.outputHook.mockClear()
     mocks.queueNitroConfig.mockClear()
+    mocks.sandboxHook.mockClear()
     mocks.vitehub.mockReset()
     mocks.vitehub.mockReturnValue([
       false,
@@ -69,6 +84,9 @@ describe("ViteHub Nuxt integration", () => {
             },
             preset: "cloudflare_module",
           }
+          ;(config as Record<string, unknown>).queue = {
+            namePrefix: "vitehub-nuxt-",
+          }
         },
       }],
       {
@@ -79,6 +97,10 @@ describe("ViteHub Nuxt integration", () => {
             createNitroConfig: mocks.queueNitroConfig,
           },
         },
+      },
+      {
+        name: "@vite-hub/sandbox/vite",
+        config: mocks.sandboxHook,
       },
       {
         name: "vite-hub/object-hook",
@@ -94,8 +116,23 @@ describe("ViteHub Nuxt integration", () => {
   })
 
   it("installs flattened ViteHub plugins and applies their config hooks to Nitro", async () => {
-    const existingPlugin = { name: "vite-hub/object-hook" }
+    const existingPlugin = {
+      name: "vite-hub/object-hook",
+      config: {
+        handler: mocks.objectHook,
+      },
+    }
+    const existingQueuePlugin = {
+      name: "@vite-hub/queue/vite",
+      config: mocks.existingQueueConfig,
+      vitehub: {
+        queue: {
+          createNitroConfig: mocks.existingQueueNitroConfig,
+        },
+      },
+    }
     const { nuxt, runNitroConfigHook } = createNuxt(true, [[
+      existingQueuePlugin,
       existingPlugin,
       { name: "vite-hub/deployment-output" },
     ]])
@@ -104,7 +141,8 @@ describe("ViteHub Nuxt integration", () => {
 
     expect((nuxt.options.vite.plugins as unknown[]).flat(Infinity)).toEqual([
       expect.objectContaining({ name: "vite-hub/deployment-preset" }),
-      expect.objectContaining({ name: "@vite-hub/queue/vite" }),
+      expect.objectContaining({ name: "@vite-hub/sandbox/vite" }),
+      existingQueuePlugin,
       existingPlugin,
     ])
 
@@ -123,12 +161,25 @@ describe("ViteHub Nuxt integration", () => {
     }
     await runNitroConfigHook(nitroConfig)
 
-    expect(mocks.queueNitroConfig).toHaveBeenCalledWith({
+    expect(mocks.existingQueueConfig).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queue: { namePrefix: "vitehub-nuxt-" },
+      }),
+      expect.anything(),
+    )
+    expect(mocks.existingQueueNitroConfig).toHaveBeenCalledWith({
       nitro: expect.objectContaining({ preset: "cloudflare_module" }),
       projectRoot: "/tmp/vitehub-nuxt",
       root: "/tmp/vitehub-nuxt/app",
       serverDirs: ["/tmp/vitehub-nuxt/custom-server"],
     })
+    expect(mocks.queueNitroConfig).not.toHaveBeenCalled()
+    expect(mocks.sandboxHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        [VITEHUB_NITRO_CONFIG_CONTEXT]: true,
+      }),
+      expect.anything(),
+    )
     expect(mocks.objectHook).toHaveBeenCalledWith(
       expect.objectContaining({
         nitro: expect.objectContaining({ preset: "cloudflare_module" }),
@@ -155,6 +206,7 @@ describe("ViteHub Nuxt integration", () => {
       queues: {
         handlers: [{ handler: "custom-server/queues/email.ts" }],
       },
+      sandbox: true,
     })
   })
 

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -153,6 +153,9 @@ describe("ViteHub Nuxt integration", () => {
 
     viteHubNuxtModule({ preset: "cloudflare" }, nuxt)
 
+    expect((nuxt.options.vite as typeof nuxt.options.vite & {
+      [VITEHUB_SERVER_DIRS]?: string[]
+    })[VITEHUB_SERVER_DIRS]).toEqual(["/tmp/vitehub-nuxt/custom-server"])
     expect((nuxt.options.vite.plugins as unknown[]).flat(Infinity)).toEqual([
       expect.objectContaining({ name: "vite-hub/deployment-preset" }),
       expect.objectContaining({ name: "@vite-hub/agent/vite" }),

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -258,6 +258,25 @@ describe("ViteHub Nuxt integration", () => {
     })
   })
 
+  it("replays configured Nuxt Vite options into Nitro hooks", async () => {
+    const { nuxt, runNitroConfigHook } = createNuxt()
+    Object.assign(nuxt.options.vite, {
+      root: "/tmp/vitehub-nuxt/custom-vite-root",
+      workspace: false,
+    })
+
+    viteHubNuxtModule({ preset: "cloudflare" }, nuxt)
+    await runNitroConfigHook({})
+
+    expect(mocks.agentHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        root: "/tmp/vitehub-nuxt/custom-vite-root",
+        workspace: false,
+      }),
+      expect.anything(),
+    )
+  })
+
   it("does not concatenate complete Nitro arrays returned by config hooks", async () => {
     mocks.vitehub.mockReturnValue([
       {

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -18,6 +18,12 @@ const mocks = vi.hoisted(() => ({
       handlers: [{ handler: "custom-server/queues/email.ts" }],
     },
   })),
+  existingOwnerConfig: vi.fn((config: { nitro?: Record<string, unknown> }) => ({
+    nitro: {
+      ...config.nitro,
+      ownerPlugin: true,
+    },
+  })),
   outputHook: vi.fn(),
   agentHook: vi.fn((config: { [VITEHUB_SERVER_DIRS]?: string[], nitro?: Record<string, unknown> }) => ({
     nitro: {
@@ -75,6 +81,7 @@ describe("ViteHub Nuxt integration", () => {
     mocks.agentHook.mockClear()
     mocks.existingQueueConfig.mockClear()
     mocks.existingQueueNitroConfig.mockClear()
+    mocks.existingOwnerConfig.mockClear()
     mocks.outputHook.mockClear()
     mocks.queueNitroConfig.mockClear()
     mocks.sandboxHook.mockClear()
@@ -148,8 +155,13 @@ describe("ViteHub Nuxt integration", () => {
         },
       },
     }
+    const existingOwnerPlugin = {
+      name: "@vite-hub/auth/vite",
+      config: mocks.existingOwnerConfig,
+    }
     const { nuxt, runNitroConfigHook } = createNuxt(true, [[
       existingQueuePlugin,
+      existingOwnerPlugin,
       existingPlugin,
       { name: "vite-hub/deployment-output" },
     ]])
@@ -164,6 +176,7 @@ describe("ViteHub Nuxt integration", () => {
       expect.objectContaining({ name: "@vite-hub/agent/vite" }),
       expect.objectContaining({ name: "@vite-hub/sandbox/vite" }),
       existingQueuePlugin,
+      existingOwnerPlugin,
       existingPlugin,
     ])
 
@@ -195,6 +208,7 @@ describe("ViteHub Nuxt integration", () => {
       serverDirs: ["/tmp/vitehub-nuxt/custom-server"],
     })
     expect(mocks.queueNitroConfig).not.toHaveBeenCalled()
+    expect(mocks.existingOwnerConfig).toHaveBeenCalledOnce()
     expect(mocks.agentHook).toHaveBeenCalledWith(
       expect.objectContaining({
         [VITEHUB_SERVER_DIRS]: ["/tmp/vitehub-nuxt/custom-server"],
@@ -233,6 +247,7 @@ describe("ViteHub Nuxt integration", () => {
           observability: { enabled: true },
         },
       },
+      ownerPlugin: true,
       handlers: [{ handler: "server/handler.ts", route: "/api/example" }],
       modules: ["agent-module"],
       preset: "cloudflare_module",

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { VITEHUB_NITRO_CONFIG_CONTEXT } from "@vite-hub/internal/build/vite"
+import { VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import type { PluginOption } from "vite"
 
 const mocks = vi.hoisted(() => ({
-  objectHook: vi.fn(() => ({
+  objectHook: vi.fn((config: { nitro?: Record<string, unknown> }) => ({
     nitro: {
+      ...config.nitro,
       handlers: [{ handler: "server/handler.ts", route: "/api/example" }],
     },
   })),
@@ -18,12 +19,20 @@ const mocks = vi.hoisted(() => ({
     },
   })),
   outputHook: vi.fn(),
+  agentHook: vi.fn((config: { [VITEHUB_SERVER_DIRS]?: string[], nitro?: Record<string, unknown> }) => ({
+    nitro: {
+      ...config.nitro,
+      handlers: config[VITEHUB_SERVER_DIRS]?.map(serverDir => ({ handler: `${serverDir}/agents/support.ts` })),
+      modules: ["agent-module"],
+    },
+  })),
   queueNitroConfig: vi.fn(async ({ nitro }: { nitro: Record<string, unknown> }) => ({
     ...nitro,
     unexpectedQueue: true,
   })),
-  sandboxHook: vi.fn((config: { [VITEHUB_NITRO_CONFIG_CONTEXT]?: boolean }) => ({
+  sandboxHook: vi.fn((config: { [VITEHUB_NITRO_CONFIG_CONTEXT]?: boolean, nitro?: Record<string, unknown> }) => ({
     nitro: {
+      ...config.nitro,
       sandbox: config[VITEHUB_NITRO_CONFIG_CONTEXT],
     },
   })),
@@ -60,6 +69,7 @@ function createNuxt(dev = false, plugins: PluginOption[] = []) {
 describe("ViteHub Nuxt integration", () => {
   beforeEach(() => {
     mocks.objectHook.mockClear()
+    mocks.agentHook.mockClear()
     mocks.existingQueueConfig.mockClear()
     mocks.existingQueueNitroConfig.mockClear()
     mocks.outputHook.mockClear()
@@ -89,6 +99,10 @@ describe("ViteHub Nuxt integration", () => {
           }
         },
       }],
+      {
+        name: "@vite-hub/agent/vite",
+        config: mocks.agentHook,
+      },
       {
         name: "@vite-hub/queue/vite",
         config: vi.fn(),
@@ -141,6 +155,7 @@ describe("ViteHub Nuxt integration", () => {
 
     expect((nuxt.options.vite.plugins as unknown[]).flat(Infinity)).toEqual([
       expect.objectContaining({ name: "vite-hub/deployment-preset" }),
+      expect.objectContaining({ name: "@vite-hub/agent/vite" }),
       expect.objectContaining({ name: "@vite-hub/sandbox/vite" }),
       existingQueuePlugin,
       existingPlugin,
@@ -174,6 +189,12 @@ describe("ViteHub Nuxt integration", () => {
       serverDirs: ["/tmp/vitehub-nuxt/custom-server"],
     })
     expect(mocks.queueNitroConfig).not.toHaveBeenCalled()
+    expect(mocks.agentHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        [VITEHUB_SERVER_DIRS]: ["/tmp/vitehub-nuxt/custom-server"],
+      }),
+      expect.anything(),
+    )
     expect(mocks.sandboxHook).toHaveBeenCalledWith(
       expect.objectContaining({
         [VITEHUB_NITRO_CONFIG_CONTEXT]: true,
@@ -202,11 +223,43 @@ describe("ViteHub Nuxt integration", () => {
         },
       },
       handlers: [{ handler: "server/handler.ts", route: "/api/example" }],
+      modules: ["agent-module"],
       preset: "cloudflare_module",
       queues: {
         handlers: [{ handler: "custom-server/queues/email.ts" }],
       },
       sandbox: true,
+    })
+  })
+
+  it("does not concatenate complete Nitro arrays returned by config hooks", async () => {
+    mocks.vitehub.mockReturnValue([
+      {
+        name: "vite-hub/first",
+        config: () => ({
+          nitro: {
+            modules: ["first"],
+          },
+        }),
+      },
+      {
+        name: "vite-hub/second",
+        config: (config: { nitro?: Record<string, unknown> }) => ({
+          nitro: {
+            ...config.nitro,
+            modules: [...((config.nitro?.modules as string[] | undefined) ?? []), "second"],
+          },
+        }),
+      },
+    ])
+    const { nuxt, runNitroConfigHook } = createNuxt()
+    const nitroConfig = {}
+
+    viteHubNuxtModule({ preset: "node" }, nuxt)
+    await runNitroConfigHook(nitroConfig)
+
+    expect(nitroConfig).toEqual({
+      modules: ["first", "second"],
     })
   })
 

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -50,6 +50,9 @@ function createNuxt(dev = false, plugins: PluginOption[] = []) {
       if (name === "nitro:config") nitroConfigHook = callback
     },
     options: {
+      alias: {
+        "~": "/tmp/vitehub-nuxt/app",
+      },
       dev,
       rootDir: "/tmp/vitehub-nuxt",
       serverDir: "/tmp/vitehub-nuxt/custom-server",
@@ -207,6 +210,11 @@ describe("ViteHub Nuxt integration", () => {
     expect(mocks.objectHook).toHaveBeenCalledWith(
       expect.objectContaining({
         nitro: expect.objectContaining({ preset: "cloudflare_module" }),
+        resolve: {
+          alias: {
+            "~": "/tmp/vitehub-nuxt/app",
+          },
+        },
         root: "/tmp/vitehub-nuxt/app",
       }),
       {

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -164,7 +164,7 @@ describe("framework package contract", () => {
       .filter(({ source }) => !exportedForwarders.has(source))
       .map(({ subpath }) => subpath)
       .sort(),
-    ).toEqual([".", "./_internal/kv/runtime/disabled-upstash"])
+    ).toEqual([".", "./_internal/kv/runtime/disabled-upstash", "./nuxt"])
 
     for (const { subpath, targets } of manifestForwarders) {
       const ownerSpecifier = ownerSpecifierForDistributionSubpath(subpath)

--- a/packages/workflow/src/discovery.ts
+++ b/packages/workflow/src/discovery.ts
@@ -412,7 +412,7 @@ function discoverFlatServerWorkflowDefinitions(scanDirs: string[], source: NonNu
 }
 
 export function discoverWorkflowDefinitions(options:
-  | { mode?: "vite-suffix", rootDir: string, scanDirs?: string[] }
+  | { mode?: "vite-suffix", rootDir: string, scanDirs?: string[], serverDirs?: string[] }
   | { mode: "server-workflows", scanDirs: string[] }
 ): DiscoveredWorkflowDefinition[] {
   if (options.mode === "server-workflows") {
@@ -424,7 +424,7 @@ export function discoverWorkflowDefinitions(options:
   }
 
   const roots = resolveDefinitionScanRoots(options.rootDir, options.scanDirs)
-  const serverScanDirs = roots.map(root => resolve(root, "server"))
+  const serverScanDirs = options.serverDirs ?? roots.map(root => resolve(root, "server"))
   const folderDefinitions = discoverWorkflowFolders(serverScanDirs, "server-workflows")
 
   return mergeDefinitions(

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -202,6 +202,7 @@ interface GenerateProviderOutputsOptions {
   importBase?: string
   providerImportAliases?: Record<string, string>
   rootDir: string
+  serverDirs?: string[]
   serverFunctionName?: string
   workflow: WorkflowModuleOptions | undefined
   workspaceDependencyRuntimeImports?: WorkspaceDependencyRuntimeImports
@@ -511,12 +512,13 @@ async function writeProviderEntries(
   rootDir: string,
   workflow: WorkflowModuleOptions | undefined,
   importBases: WorkflowImportBases = {},
+  serverDirs?: string[],
 ) {
   const generatedDir = ensureGeneratedDir(rootDir, productName)
   await mkdir(generatedDir, { recursive: true })
 
   const registryFile = resolve(generatedDir, generatedRegistryFileName)
-  const definitions = discoverWorkflowDefinitions({ rootDir })
+  const definitions = discoverWorkflowDefinitions({ rootDir, serverDirs })
   const providerDefinitions = definitions
   const userAppEntry = resolveWorkflowUserAppEntry(rootDir)
   const cloudflareWorkflowConfig = resolveWorkflowConfig(workflow, "cloudflare")
@@ -650,7 +652,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     workflow: options.importBase,
     workspace: options.workspaceImportBase,
     workspaceDependencies: options.workspaceDependencyRuntimeImports,
-  })
+  }, options.serverDirs)
   const cloudflareWorkflowConfig = resolveWorkflowConfig(options.workflow, "cloudflare")
   const vercelWorkflowConfig = resolveWorkflowConfig(options.workflow, "vercel")
   const cloudflareOutput = cloudflareWorkflowConfig && cloudflareWorkflowConfig.provider === "cloudflare"

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -1,6 +1,6 @@
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import { generateProviderOutputs, workflowPackageName } from "./internal/vite-build.ts"
 
@@ -37,11 +37,13 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
   const internalOptions = options as InternalWorkflowModuleOptions | undefined
   let resolved: ResolvedConfig | undefined
   let workflow: WorkflowModuleOptions | undefined = options
+  let serverDirs: string[] | undefined
 
   return {
     name: "@vite-hub/workflow/vite",
     config(config) {
       workflow = config.workflow ?? workflow
+      serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
     },
     configResolved(config) {
       resolved = config
@@ -68,6 +70,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
           ...internalOptions?.providerImportAliases,
         },
         rootDir: resolved.root,
+        serverDirs,
         serverFunctionName: resolveNitroVercelFunctionName(resolved, "workflow"),
         workflow,
         workspaceDependencyRuntimeImports: internalOptions?.workspaceDependencyRuntimeImports,

--- a/packages/workspace/src/build/discovery.ts
+++ b/packages/workspace/src/build/discovery.ts
@@ -82,9 +82,9 @@ function createWorkspaceDefinition(source: string, file: string, name: string): 
   return { handler: file, name, path: file, source, sourceRootDir: resolveWorkspaceSourceRoot(file) }
 }
 
-function serverWorkspaceSource(rootDir: string): WorkspaceDefinitionCatalogSource[] {
-  const workspacesDir = resolve(rootDir, "server", "workspaces")
-  const agentsDir = resolve(rootDir, "server", "agents")
+function serverWorkspaceSource(rootDir: string, serverDir = resolve(rootDir, "server")): WorkspaceDefinitionCatalogSource[] {
+  const workspacesDir = resolve(serverDir, "workspaces")
+  const agentsDir = resolve(serverDir, "agents")
   const directoryWorkspaceDirs = collectDirectoriesWithConfig(workspacesDir)
 
   const normalizeDirectoryName = (workspacesRoot: string, file: string) => {
@@ -149,11 +149,14 @@ export function discoverServerWorkspaceDefinitions(rootDir: string): DiscoveredW
   return discoverDefinitions("workspace", [...serverWorkspaceSource(rootDir)])
 }
 
-export function discoverViteWorkspaceDefinitions(rootDir: string, options: { serverRootDir?: string } = {}): DiscoveredWorkspaceDefinition[] {
+export function discoverViteWorkspaceDefinitions(rootDir: string, options: { serverDirs?: string[], serverRootDir?: string } = {}): DiscoveredWorkspaceDefinition[] {
+  const serverRoot = options.serverRootDir || rootDir
+  const serverSources = options.serverDirs?.flatMap(serverDir => serverWorkspaceSource(serverRoot, serverDir))
+    ?? serverWorkspaceSource(serverRoot)
   return mergeDefinitions(
     "workspace",
     discoverDefinitions("workspace", [...viteWorkspaceSource(rootDir)]),
-    discoverDefinitions("workspace", [...serverWorkspaceSource(options.serverRootDir || rootDir)]),
+    discoverDefinitions("workspace", serverSources),
   )
 }
 

--- a/packages/workspace/src/build/discovery.ts
+++ b/packages/workspace/src/build/discovery.ts
@@ -110,7 +110,7 @@ function serverWorkspaceSource(rootDir: string, serverDir = resolve(rootDir, "se
   }
 
   return [
-    createDirectoryDefinitionSource("server-workspaces-directory-config", [resolve(rootDir, "server")], "workspaces", {
+    createDirectoryDefinitionSource("server-workspaces-directory-config", [serverDir], "workspaces", {
       includeHidden: true,
       normalizeName: normalizeDirectoryName,
       createDefinition: ({ file, name }) => {
@@ -120,7 +120,7 @@ function serverWorkspaceSource(rootDir: string, serverDir = resolve(rootDir, "se
         return createWorkspaceDefinition("server-workspaces-directory-config", file, name)
       },
     }),
-    createDirectoryDefinitionSource("server-agent-workspaces", [resolve(rootDir, "server")], "agents", {
+    createDirectoryDefinitionSource("server-agent-workspaces", [serverDir], "agents", {
       includeHidden: true,
       normalizeName(_agentsRoot, file) {
         if (!workspaceAgentPattern.test(basename(file))) return
@@ -130,7 +130,7 @@ function serverWorkspaceSource(rootDir: string, serverDir = resolve(rootDir, "se
       },
       createDefinition: ({ file, name }) => createWorkspaceDefinition("server-agent-workspaces", file, name),
     }),
-    createDirectoryDefinitionSource("server-workspaces", [resolve(rootDir, "server")], "workspaces", {
+    createDirectoryDefinitionSource("server-workspaces", [serverDir], "workspaces", {
       normalizeName: normalizeFlatName,
       createDefinition: ({ file, name }) => createWorkspaceDefinition("server-workspaces", file, name),
     }),

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -5,7 +5,7 @@ import { createDefaultCloudflareOutputRoot, writeCloudflareWranglerConfig } from
 import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
-import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored, resolveViteHubProjectRoot } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import { createWorkspaceDefinitionLoader, loadDiscoveredWorkspaceDefinition, shouldBundleWorkspaceAssets } from "../../build/assets.ts"
 import { createWorkspaceRegistryContents, discoverViteWorkspaceDefinitions } from "../../build/discovery.ts"
@@ -394,8 +394,8 @@ function resolveWorkspacePluginRoots(root: string, workspaceOptions: false | Wor
   return { projectRoot: resolvedProjectRoot, viteRoot: resolvedViteRoot }
 }
 
-function discoverDefinitions(roots: WorkspacePluginRoots) {
-  return discoverViteWorkspaceDefinitions(roots.viteRoot, { serverRootDir: roots.projectRoot })
+function discoverDefinitions(roots: WorkspacePluginRoots, serverDirs?: string[]) {
+  return discoverViteWorkspaceDefinitions(roots.viteRoot, { serverDirs, serverRootDir: roots.projectRoot })
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -825,9 +825,10 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
   let manifest: WorkspaceBuildState["manifest"] = { workspaces: [] }
   let registryContents = "export default {}\n"
   let server: ViteDevServer | undefined
+  let serverDirs: string[] | undefined
 
   async function refreshManifest(roots: WorkspacePluginRoots) {
-    const definitions = discoverDefinitions(roots)
+    const definitions = discoverDefinitions(roots, serverDirs)
     const state = await refreshWorkspaceBuildState(roots.projectRoot, definitions)
     manifest = state.manifest
     registryContents = state.registryContents
@@ -856,6 +857,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       getWorkspaces: () => manifest.workspaces,
     },
     async config(config, env) {
+      serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
       const workspaceOptions = stripWorkspaceInternalOptions(
         (config as UserConfig & { workspace?: false | WorkspaceModuleOptions }).workspace ?? publicOptions,
       )
@@ -876,7 +878,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
           },
         },
       }
-      const definitions = normalized ? discoverDefinitions(roots) : []
+      const definitions = normalized ? discoverDefinitions(roots, serverDirs) : []
       if (normalized && shouldInstallNitroWorkspacePlugin(config, runtimeOptions, normalized, definitions)) {
         const runtimeConfig = shouldConfigureRuntime(runtimeOptions, normalized) ? normalized : false
         const definitionOverrides = new Map<string, ResolvedWorkspaceModuleOptions>()
@@ -936,7 +938,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       await refreshManifest(roots)
       if (resolved.command !== "build" || !assetsRegistryFile) return
 
-      const definitions = discoverDefinitions(roots)
+      const definitions = discoverDefinitions(roots, serverDirs)
       await syncWorkspaceBuildAssets(definitions, roots.projectRoot, resolvedOptions, assetsRegistryFile)
     },
     closeBundle: {
@@ -948,7 +950,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
           projectRoot: projectRoot || resolveViteHubProjectRoot(resolved.root),
           viteRoot: viteRoot || resolve(resolved.root),
         }
-        const definitions = discoverDefinitions(roots)
+        const definitions = discoverDefinitions(roots, serverDirs)
         await Promise.all(definitions.map(async (definition) => {
           definition.source = await readFile(definition.path, "utf8")
         }))

--- a/packages/workspace/test/discovery.test.ts
+++ b/packages/workspace/test/discovery.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
 
-import { createWorkspaceRegistryContents, discoverServerWorkspaceDefinitions } from "../src/build/discovery.ts"
+import { createWorkspaceRegistryContents, discoverServerWorkspaceDefinitions, discoverViteWorkspaceDefinitions } from "../src/build/discovery.ts"
 
 const tempDirs: string[] = []
 
@@ -20,6 +20,20 @@ afterEach(async () => {
 })
 
 describe("discoverServerWorkspaceDefinitions", () => {
+  it("uses forwarded server directories for Vite discovery", async () => {
+    const root = await createRoot()
+    const serverDir = join(root, "backend")
+    await mkdir(join(serverDir, "workspaces"), { recursive: true })
+    await writeFile(join(serverDir, "workspaces", "docs.ts"), "export default {}\n", "utf8")
+
+    expect(discoverViteWorkspaceDefinitions(root, { serverDirs: [serverDir] })).toEqual([
+      expect.objectContaining({
+        handler: join(serverDir, "workspaces", "docs.ts"),
+        name: "docs",
+      }),
+    ])
+  })
+
   it("discovers directory workspaces from config files and ignores nested source files inside them", async () => {
     const root = await createRoot()
     await mkdir(join(root, "server", "workspaces", "data-sources"), { recursive: true })


### PR DESCRIPTION
Adds `vite-hub/nuxt` as the framework-owned Nuxt module. It installs the flattened ViteHub plugins once, removes `vite-hub/deployment-output` even when an existing `vitehub()` collection is nested in Nuxt's Vite config, and applies ViteHub config hooks to Nitro so deployment preset and service configuration reach the server build.

D1 binding idempotency remains owned by the Database Nuxt integration in #825; this adapter deliberately preserves Database config instead of adding a second generic dedupe policy. The published export, generated declaration, and package contract are covered.

Validated with `pnpm --filter vite-hub typecheck`, `pnpm --filter vite-hub test` (7 files, 69 tests), focused Workspace, Markdown Template, and Agent tests, and `git diff --check`.