### PR TITLE
fix(agent): defer local sandbox owner creation

### DIFF
--- a/packages/agent/src/harness/local-sandbox.ts
+++ b/packages/agent/src/harness/local-sandbox.ts
@@ -27,8 +27,12 @@ interface LocalHarnessSandboxSession extends HarnessV1NetworkSandboxSession {
   readonly rootDir: string
 }
 
-const localHarnessOwnerName = `owner-${process.pid}-${randomUUID()}`
+let localHarnessOwnerName: string | undefined
 const localHarnessOwnerPattern = /^owner-(\d+)-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
+function getLocalHarnessOwnerName() {
+  return localHarnessOwnerName ??= `owner-${process.pid}-${randomUUID()}`
+}
 
 function stringEnv(env: Record<string, string | undefined>): Record<string, string> {
   return Object.fromEntries(Object.entries(env).filter((entry): entry is [string, string] => typeof entry[1] === "string"))
@@ -46,7 +50,7 @@ function isProcessAlive(pid: number) {
 
 async function managedRootDir(sessionId: string | undefined) {
   const parent = join(tmpdir(), "vitehub-harness")
-  const owner = join(parent, localHarnessOwnerName)
+  const owner = join(parent, getLocalHarnessOwnerName())
   await mkdir(owner, { recursive: true })
 
   const entries = await readdir(parent, { withFileTypes: true })

--- a/packages/agent/test/local-sandbox-import.test.ts
+++ b/packages/agent/test/local-sandbox-import.test.ts
@@ -1,0 +1,35 @@
+import { rm } from "node:fs/promises"
+import { basename, dirname } from "node:path"
+
+import { expect, it, vi } from "vitest"
+
+const { randomUUID } = vi.hoisted(() => ({
+  randomUUID: vi.fn(() => "123e4567-e89b-42d3-a456-426614174000"),
+}))
+
+vi.mock("node:crypto", async (importOriginal) => ({
+  ...await importOriginal<typeof import("node:crypto")>(),
+  randomUUID,
+}))
+
+it("creates and reuses the cleanup owner only when a session starts", async () => {
+  const { createLocalHarnessSandbox } = await import("../src/harness/local-sandbox.ts")
+
+  expect(randomUUID).not.toHaveBeenCalled()
+
+  const provider = createLocalHarnessSandbox()
+  const first = await provider.createSession({ sessionId: "first" })
+  const second = await provider.createSession({ sessionId: "second" })
+  const firstOwner = dirname((first as unknown as { rootDir: string }).rootDir)
+  const secondOwner = dirname((second as unknown as { rootDir: string }).rootDir)
+
+  try {
+    expect(randomUUID).toHaveBeenCalledOnce()
+    expect(basename(firstOwner)).toBe(`owner-${process.pid}-123e4567-e89b-42d3-a456-426614174000`)
+    expect(secondOwner).toBe(firstOwner)
+  }
+  finally {
+    await Promise.all([first.destroy?.(), second.destroy?.()])
+    await rm(firstOwner, { force: true, recursive: true })
+  }
+})


### PR DESCRIPTION
Defers the local harness cleanup-owner UUID until the first managed session starts, so importing `@vite-hub/agent/harness/local-sandbox` no longer performs random generation during module evaluation. The owner remains process-scoped and cached, so managed sessions still share one cleanup namespace.

The regression mocks `node:crypto` to prove the import consumes zero UUIDs, then starts two named sessions and proves they generate exactly one owner UUID and reuse its directory.

Validation:
- `pnpm exec vp test test/local-sandbox.test.ts test/local-sandbox-import.test.ts` — 30 passed
- `pnpm run typecheck`
- `pnpm exec oxlint packages/agent/src/harness/local-sandbox.ts packages/agent/test/local-sandbox-import.test.ts`
- `pnpm exec vp run -t @vite-hub/agent#build`
- `pnpm exec vp test` — 62 files and 1,449 tests passed after building the tutorial fixture prerequisite with `pnpm exec vp run -t vite-hub#build`
