### PR TITLE
fix(agent): align Codex bootstrap file paths

### DIFF
--- a/packages/agent/src/internal/codex-sandbox.ts
+++ b/packages/agent/src/internal/codex-sandbox.ts
@@ -1,6 +1,7 @@
 import type { AgentHarnessDriver, AgentHarnessSandboxProviderInput } from "../types.ts"
 
 const codexSandboxAdapterApplied = Symbol("vitehub.codexSandboxAdapterApplied")
+const absoluteCodexBootstrapDir = "/tmp/harness/codex"
 const localCodexBootstrapDir = "tmp/harness/codex"
 
 function relativeCodexSandboxSession<T extends object>(session: T, isolateHome: boolean, bootstrapDir?: string, codexHome?: string): T {
@@ -17,8 +18,14 @@ function relativeCodexSandboxSession<T extends object>(session: T, isolateHome: 
       if (property === "run" || property === "spawn") {
         return (options: { command: string, env?: Record<string, string | undefined> }) => (target as T & Record<"run" | "spawn", (options: never) => unknown>)[property]({
           ...options,
-          command: options.command.replaceAll("/tmp/harness/codex", anchoredBootstrapDir),
+          command: options.command.replaceAll(absoluteCodexBootstrapDir, anchoredBootstrapDir),
           ...(isolateHome ? { env: { ...options.env, CODEX_HOME: anchoredCodexHome } } : {}),
+        } as never)
+      }
+      if (property === "readTextFile" || property === "writeTextFile") {
+        return (options: { path: string }) => (target as T & Record<"readTextFile" | "writeTextFile", (options: never) => unknown>)[property]({
+          ...options,
+          path: options.path.replaceAll(absoluteCodexBootstrapDir, anchoredBootstrapDir),
         } as never)
       }
       const value = Reflect.get(target, property, receiver)

--- a/packages/agent/test/harness-codex-patch.test.ts
+++ b/packages/agent/test/harness-codex-patch.test.ts
@@ -5,7 +5,7 @@ import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises
 import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 import { promisify } from "node:util"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { createCodexDriver } from "../src/harness/codex.ts"
 import { createLocalHarnessSandbox } from "../src/harness/local-sandbox.ts"
@@ -106,6 +106,44 @@ describe("ViteHub Codex harness", () => {
     finally {
       await rm(root, { force: true, recursive: true })
     }
+  })
+
+  it("maps Codex bootstrap text files into the sandbox workspace", async () => {
+    const readTextFile = vi.fn(async () => "ready")
+    const run = vi.fn(async () => ({ exitCode: 0, stderr: "", stdout: "ready" }))
+    const writeTextFile = vi.fn(async () => undefined)
+    const rawSession = {
+      defaultWorkingDirectory: "/workspace",
+      readTextFile,
+      restricted: () => rawSession,
+      run,
+      writeTextFile,
+    }
+    const harness = createCodexDriver({ sandbox: false }).harness as Record<PropertyKey, unknown>
+    const adapt = harness[Symbol.for("vitehub.harnessSandboxAdapter")] as (
+      provider: HarnessV1SandboxProvider,
+    ) => HarnessV1SandboxProvider
+    const provider = adapt({
+      createSession: async () => rawSession,
+      specificationVersion: "harness-sandbox-v1",
+    } as unknown as HarnessV1SandboxProvider)
+    const session = await provider.createSession()
+
+    await session.writeTextFile({ content: "ready", path: "/tmp/harness/codex/marker" })
+    await session.restricted().readTextFile({ path: "/tmp/harness/codex/marker" })
+    await session.run({ command: "cat /tmp/harness/codex/marker" })
+
+    expect(writeTextFile).toHaveBeenCalledWith({
+      content: "ready",
+      path: "/workspace/tmp/harness/codex/marker",
+    })
+    expect(readTextFile).toHaveBeenCalledWith({
+      path: "/workspace/tmp/harness/codex/marker",
+    })
+    expect(run).toHaveBeenCalledWith({
+      command: "cat /workspace/tmp/harness/codex/marker",
+      env: { CODEX_HOME: "/workspace/tmp/harness/codex-home" },
+    })
   })
 
   it("adapts a Box sandbox for Codex paths and direct OpenAI auth", async () => {


### PR DESCRIPTION
Maps Codex bootstrap `readTextFile` and `writeTextFile` paths through the same sandbox-relative directory already used by `run` and `spawn`. Without this, harness bootstrap files and markers can stay at host `/tmp/harness/codex` while install commands run inside a disposable sandbox workspace.

A focused regression covers create/restricted-session text-file projection alongside command projection. UI message projection and bundle-safe bridge asset lookup are intentionally excluded because they already shipped in #817, #571, and #792.

Validation: Agent dependency-graph build, Agent typecheck, focused Codex harness tests (7/7), focused lint, and `git diff --check`.