### PR TITLE
fix agent chat adapter version typing

### DIFF
--- a/fallow.toml
+++ b/fallow.toml
@@ -108,6 +108,8 @@ ignoreDependencies = [
   "@vercel/blob",
   "@vercel/queue",
   "chat-state-cloudflare-do",
+  # Installed only inside the packed Agent Chat Platform Adapter consumer fixture.
+  "@chat-adapter/telegram",
   # Package builds and generated provider output reference these without source imports.
   "@aws-sdk/client-s3",
   "@aws-sdk/lib-storage",

--- a/packages/agent/fixtures/published-chat-adapter-types/consumer.ts
+++ b/packages/agent/fixtures/published-chat-adapter-types/consumer.ts
@@ -1,0 +1,14 @@
+import { createTelegramAdapter } from "@chat-adapter/telegram"
+import { telegram } from "@vite-hub/agent/channels"
+import type { AgentChatPlatformAdapter } from "@vite-hub/agent"
+
+const adapter = createTelegramAdapter({
+  allowedUserIds: ["123"],
+  botToken: "typecheck-only",
+})
+
+adapter satisfies AgentChatPlatformAdapter
+
+telegram({
+  adapter: () => adapter,
+})

--- a/packages/agent/fixtures/published-chat-adapter-types/package.json
+++ b/packages/agent/fixtures/published-chat-adapter-types/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "agent-published-chat-adapter-types-consumer",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@chat-adapter/telegram": "4.35.0",
+    "@vite-hub/agent": "file:./vite-hub-agent-0.0.1.tgz"
+  },
+  "devDependencies": {
+    "@types/node": "24.13.3",
+    "typescript": "6.0.3"
+  }
+}

--- a/packages/agent/fixtures/published-chat-adapter-types/pnpm-workspace.yaml
+++ b/packages/agent/fixtures/published-chat-adapter-types/pnpm-workspace.yaml
@@ -1,0 +1,8 @@
+overrides:
+  "@vite-hub/agent": "file:./vite-hub-agent-0.0.1.tgz"
+  "@vite-hub/box": "file:./vite-hub-box-0.0.1.tgz"
+  "@vite-hub/markdown-template": "file:./vite-hub-markdown-template-0.0.1.tgz"
+  "@vite-hub/rate-limit": "file:./vite-hub-rate-limit-0.0.1.tgz"
+  "@vite-hub/runtime": "file:./vite-hub-runtime-0.0.1.tgz"
+  "@vite-hub/source": "file:./vite-hub-source-0.0.1.tgz"
+  "@vite-hub/workspace": "file:./vite-hub-workspace-0.0.1.tgz"

--- a/packages/agent/fixtures/published-chat-adapter-types/tsconfig.json
+++ b/packages/agent/fixtures/published-chat-adapter-types/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "strict": true,
+    "target": "ESNext",
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "consumer.ts"
+  ]
+}

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -145,6 +145,7 @@ export type {
   AgentChatMessage,
   AgentChatMessageHookArgs,
   AgentChatOptions,
+  AgentChatPlatformAdapter,
   AgentChatPlatformResolver,
   AgentChatPlatformsResolver,
   AgentChatSendMessage,

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -20,6 +20,7 @@ import type {
   AgentCapabilityDefinition,
   AgentChatFinishExtension,
   AgentChatMessage,
+  AgentChatPlatformAdapter,
   AgentChannelDefinition,
   AgentChannelTriggerContext,
   AgentChannelDeliveryEffectContext,
@@ -1673,11 +1674,11 @@ function addDiscordThreadTitleSupport(adapter: Adapter, options: DiscordAdapterO
   })
 }
 
-function isAdapter(value: unknown): value is Adapter {
+function isAdapter(value: unknown): value is AgentChatPlatformAdapter {
   return isRecord(value) && typeof value.postMessage === "function"
 }
 
-function isResolver(value: unknown): value is { resolve: (context: AgentCallbackContext) => MaybePromise<Adapter> } {
+function isResolver(value: unknown): value is { resolve: (context: AgentCallbackContext) => MaybePromise<AgentChatPlatformAdapter> } {
   return isRecord(value) && typeof value.resolve === "function"
 }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -247,6 +247,7 @@ export type {
   AgentChatMessage,
   AgentChatMessageHookArgs,
   AgentChatOptions,
+  AgentChatPlatformAdapter,
   AgentChatPlatformResolver,
   AgentChatPlatformsResolver,
   AgentChatSendMessage,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1394,8 +1394,26 @@ export interface AgentChatEventHooks<TRuntimeConfig extends AgentRuntimeConfig =
   onDirectMessage?: (args: { message: { text: string } } & AgentChatEventHookArgs<TRuntimeConfig>) => MaybePromise<void>
 }
 
+type AgentChatVersionBoundAdapterMethod =
+  | "fetchChannelMessages"
+  | "fetchMessage"
+  | "fetchMessages"
+  | "initialize"
+  | "listThreads"
+  | "parseMessage"
+
+// Chat SDK messages and instances carry private state, so keep version-bound values opaque at this boundary.
+export type AgentChatPlatformAdapter = Omit<Adapter, AgentChatVersionBoundAdapterMethod> & {
+  fetchChannelMessages?: (...args: Parameters<NonNullable<Adapter["fetchChannelMessages"]>>) => Promise<unknown>
+  fetchMessage?: (...args: Parameters<NonNullable<Adapter["fetchMessage"]>>) => Promise<unknown>
+  fetchMessages: (...args: Parameters<Adapter["fetchMessages"]>) => Promise<unknown>
+  initialize: (chat: never) => Promise<void>
+  listThreads?: (...args: Parameters<NonNullable<Adapter["listThreads"]>>) => Promise<unknown>
+  parseMessage: (raw: never) => unknown
+}
+
 export type AgentChatPlatformResolver<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> =
-  MaybeResolvable<Adapter, AgentCallbackContext<TRuntimeConfig>>
+  MaybeResolvable<AgentChatPlatformAdapter, AgentCallbackContext<TRuntimeConfig>>
 
 export type AgentChatPlatformsResolver<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> =
   MaybeResolvable<Record<string, AgentChatPlatformResolver<TRuntimeConfig>>, AgentCallbackContext<TRuntimeConfig>>

--- a/packages/agent/test/published-chat-adapter-types.test.ts
+++ b/packages/agent/test/published-chat-adapter-types.test.ts
@@ -1,0 +1,89 @@
+import { execFile } from "node:child_process"
+import { cp, mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+import { afterAll, beforeAll, it } from "vitest"
+
+import { syncPackedWorkspaceDependencies } from "../../internal/test-utils/published-types.js"
+
+const execFileAsync = promisify(execFile)
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const workspaceRoot = resolve(packageRoot, "../..")
+const fixtureRoot = join(packageRoot, "fixtures", "published-chat-adapter-types")
+const tsc = resolve(workspaceRoot, "node_modules/typescript/bin/tsc")
+const childProcessTimeout = 20_000
+const packedPackages = [
+  "agent",
+  "box",
+  "markdown-template",
+  "rate-limit",
+  "runtime",
+  "source",
+  "workspace",
+] as const
+let consumerRoot: string | undefined
+
+async function runPnpm(args: string[], cwd: string): Promise<void> {
+  try {
+    const npmExecPath = process.env.npm_execpath
+    if (npmExecPath?.includes("pnpm")) {
+      await execFileAsync(process.execPath, [npmExecPath, ...args], {
+        cwd,
+        killSignal: "SIGKILL",
+        timeout: childProcessTimeout,
+      })
+      return
+    }
+    await execFileAsync("corepack", ["pnpm", ...args], {
+      cwd,
+      killSignal: "SIGKILL",
+      timeout: childProcessTimeout,
+    })
+  }
+  catch (error) {
+    const output = error as Error & { stderr?: string, stdout?: string }
+    throw new Error([output.message, output.stdout, output.stderr].filter(Boolean).join("\n"), { cause: error })
+  }
+}
+
+beforeAll(async () => {
+  consumerRoot = await mkdtemp(join(tmpdir(), "vitehub-agent-chat-types-"))
+  await cp(fixtureRoot, consumerRoot, { recursive: true })
+  await syncPackedWorkspaceDependencies(
+    consumerRoot,
+    workspaceRoot,
+    packedPackages.map(name => `@vite-hub/${name}`),
+  )
+  const packs = await Promise.allSettled(packedPackages.map(name =>
+    runPnpm(["pack", "--pack-destination", consumerRoot!], join(workspaceRoot, "packages", name))))
+  const failedPack = packs.find(result => result.status === "rejected")
+  if (failedPack) throw failedPack.reason
+  await runPnpm([
+    "install",
+    "--prefer-offline",
+    "--ignore-scripts",
+    "--no-frozen-lockfile",
+    "--strict-peer-dependencies",
+  ], consumerRoot)
+}, 60_000)
+
+afterAll(async () => {
+  if (consumerRoot) await rm(consumerRoot, { force: true, recursive: true })
+})
+
+it("accepts a newer Chat SDK adapter from the published package", { timeout: 25_000 }, async () => {
+  try {
+    await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", consumerRoot!], {
+      cwd: packageRoot,
+      killSignal: "SIGKILL",
+      timeout: childProcessTimeout,
+    })
+  }
+  catch (error) {
+    const output = error as Error & { stderr?: string, stdout?: string }
+    throw new Error([output.message, output.stdout, output.stderr].filter(Boolean).join("\n"), { cause: error })
+  }
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ catalogs:
       specifier: ^4.34.0
       version: 4.34.0
     chat:
-      specifier: ^4.34.0
+      specifier: 4.34.0
       version: 4.34.0
     chat-state-cloudflare-do:
       specifier: ^0.2.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -29,7 +29,7 @@ catalogs:
     better-auth: ^1.6.23
   chat:
     "@chat-adapter/discord": ^4.34.0
-    chat: ^4.34.0
+    chat: 4.34.0
     chat-state-cloudflare-do: ^0.2.0
   database:
     "@libsql/client": ^0.17.4


### PR DESCRIPTION
## What changed

- Add a structural `AgentChatPlatformAdapter` boundary that preserves the adapter methods ViteHub uses while keeping Chat SDK version-bound `Message` and `ChatInstance` values opaque.
- Pin ViteHub's owned `chat` dependency to 4.34.0 so the compatibility test exercises a real cross-version install.
- Add a packed consumer test with `@chat-adapter/telegram@4.35.0`, including `allowedUserIds`, under strict peer checking.

## Why

Chat SDK adapters own an exact `chat` dependency. A 4.35 adapter was rejected by ViteHub's 4.34 `Adapter` type because `Message` contains private state, even though the runtime adapter surface is compatible. Weakening the whole resolver to `any` hides too much; this keeps the stable adapter surface typed and isolates only the version-bound values.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm --filter @vite-hub/agent test` — 62 files, 1,449 tests
- packed Telegram 4.35 published-type consumer under `--strict-peer-dependencies`
- `pnpm exec vp run test:consumer`

## Dependency boundary

A consumer that also installs Workflow 4 still cannot use Telegram 4.35 with strict peer checking because Chat 4.35 requires `workflow@^5.0.0-beta.35`. That Workflow 5/provider-output migration is a separate dependency seam; this PR does not suppress or weaken that peer contract.