### PR TITLE
fix(agent): normalize raw JSON tool schemas

### DIFF
--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -54,6 +54,7 @@ import type {
 } from "./types.ts"
 import type { AttachmentData, AttachmentPart, Message, MessagePart } from "./messages.ts"
 import type { WorkspaceName } from "@vite-hub/workspace"
+import type { JSONSchema7 } from "json-schema"
 
 export interface AiSdkAdapterOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -741,15 +742,25 @@ const defaultToolInputSchemaJson = {
   type: "object",
 } as const
 
-function withDefaultToolInputSchemas<TTools extends Record<string, unknown> | undefined>(tools: TTools, createDefaultToolInputSchema: () => unknown): TTools {
+function withDefaultToolInputSchemas<TTools extends Record<string, unknown> | undefined>(tools: TTools, createJsonSchema: (schema: JSONSchema7) => unknown): TTools {
   if (!tools) return tools
   let defaultToolInputSchema: unknown
   return Object.fromEntries(Object.entries(tools).map(([name, tool]) => {
     const record = tool as { inputSchema?: unknown, type?: unknown } | undefined
-    if (!record || typeof record !== "object" || record.type === "provider" || record.type === "provider-defined" || record.inputSchema != null) {
+    if (!record || typeof record !== "object" || record.type === "provider" || record.type === "provider-defined") {
       return [name, tool]
     }
-    defaultToolInputSchema ??= createDefaultToolInputSchema()
+    if (record.inputSchema != null) {
+      const inputSchema = record.inputSchema
+      if (typeof inputSchema !== "object" || inputSchema === null || "~standard" in inputSchema || "jsonSchema" in inputSchema) {
+        return [name, tool]
+      }
+      return [name, {
+        ...record,
+        inputSchema: createJsonSchema(inputSchema as JSONSchema7),
+      }]
+    }
+    defaultToolInputSchema ??= createJsonSchema(defaultToolInputSchemaJson)
     return [name, {
       ...record,
       inputSchema: defaultToolInputSchema,
@@ -991,7 +1002,7 @@ async function createAgent(
   const resolvedTools = withDefaultToolInputSchemas(withWorkspaceFallbackToolEvidence(await applyCapabilityToolTransforms({
     ...context.tools,
     ...adapterTools,
-  }, []), fallbackCapture), () => jsonSchema(defaultToolInputSchemaJson))
+  }, []), fallbackCapture), jsonSchema)
   const providerTools = Object.fromEntries((context.providerTools || []).map(tool => [tool.name, {
     args: tool.args || {},
     id: tool.id,

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -3087,6 +3087,91 @@ describe("agent message protocol", () => {
     ])
   })
 
+  it("normalizes raw JSON Schema tool inputs for AI SDK agents", async () => {
+    const agentSettings: Record<string, unknown>[] = []
+    const rawJsonSchema = {
+      additionalProperties: false,
+      properties: { query: { type: "string" } },
+      required: ["query"],
+      type: "object",
+    } as const
+    const standardSchema = {
+      "~standard": {
+        jsonSchema: {
+          input: () => rawJsonSchema,
+          output: () => rawJsonSchema,
+        },
+        validate: (input: unknown) => ({ value: input }),
+        vendor: "test",
+        version: 1 as const,
+      },
+    }
+    const wrappedJsonSchema = { jsonSchema: rawJsonSchema }
+    const jsonSchema = vi.fn(schema => ({ jsonSchema: schema }))
+    loadAiSdk.mockResolvedValue({
+      isStepCount: vi.fn(count => ({ count })),
+      jsonSchema,
+      ToolLoopAgent: class {
+        constructor(settings: Record<string, unknown>) {
+          agentSettings.push(settings)
+        }
+
+        async generate() {
+          return { finishReason: "stop", text: "ok" }
+        }
+      },
+    })
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [
+        defineCapability({
+          id: "schema-tools",
+          tools: {
+            defaultSchema: {
+              execute: () => "ok",
+              name: "defaultSchema",
+            },
+            rawJsonSchema: {
+              execute: () => "ok",
+              inputSchema: rawJsonSchema,
+              name: "rawJsonSchema",
+            },
+            standardSchema: {
+              execute: () => "ok",
+              inputSchema: standardSchema,
+              name: "standardSchema",
+            },
+            wrappedJsonSchema: {
+              execute: () => "ok",
+              inputSchema: wrappedJsonSchema as never,
+              name: "wrappedJsonSchema",
+            },
+          },
+        }),
+      ],
+      driver: { model: {} as never },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, { prompt: "hello" })).resolves.toMatchObject({ text: "ok" })
+
+    const tools = agentSettings[0]!.tools as Record<string, { inputSchema: unknown }>
+    expect(tools.rawJsonSchema!.inputSchema).toEqual({ jsonSchema: rawJsonSchema })
+    expect(tools.standardSchema!.inputSchema).toBe(standardSchema)
+    expect(tools.wrappedJsonSchema!.inputSchema).toBe(wrappedJsonSchema)
+    expect(tools.defaultSchema!.inputSchema).toEqual({
+      jsonSchema: {
+        additionalProperties: false,
+        properties: {},
+        type: "object",
+      },
+    })
+    expect(jsonSchema).toHaveBeenCalledTimes(2)
+  })
+
   it("resolves provider callbacks only at model invocation with byte limits", async () => {
     const generate = vi.fn(async (_input: unknown) => ({ finishReason: "stop", text: "ok" }))
     loadAiSdk.mockResolvedValue({

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -4177,7 +4177,9 @@ describe("defineAgent workspace option", () => {
 
     expect(toolResolver).toHaveBeenCalledTimes(1)
     const resolvedShell = (agentSettings.at(-1)?.tools as { shell?: typeof shell } | undefined)?.shell
-    expect(resolvedShell).toEqual(expect.objectContaining({ inputSchema: {} }))
+    expect(resolvedShell).toEqual(expect.objectContaining({
+      inputSchema: { schema: {}, type: "json-schema" },
+    }))
     await resolvedShell?.execute({ command: "rg defineAgent" })
     expect(shell.execute).toHaveBeenCalledWith({ command: "rg defineAgent" })
   })


### PR DESCRIPTION
Normalizes raw JSON Schema tool inputs through the AI SDK jsonSchema wrapper before constructing the model agent. This makes the raw JSON Schema contract from #545 work at runtime while preserving Standard Schema and existing AI SDK schema wrappers; schema-less tools keep the shared empty-object default.

Adds a focused regression covering raw JSON Schema, Standard Schema, wrapped JSON Schema, and the default path. Validated with the full agent runtime test file, the package typecheck, and the package build/publint path.

Refs #545