### PR TITLE
fix(queue): exclude Cloudflare output from Vercel static

### DIFF
--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -218,7 +218,7 @@ async function copyVercelClientOutput(rootDir: string, clientDir: string, static
     && !isAbsolute(outputRelativePath)
 
   await copyClientOutput(clientDir, staticOutputDir)
-  if (!excludesCloudflareOutput) return
+  if (resolve(clientDir) === resolve(staticOutputDir) || !excludesCloudflareOutput) return
 
   try {
     await readFile(resolve(cloudflareOutputRoot, "wrangler.json"))

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -1,5 +1,5 @@
 import { mkdir, readFile, readdir, rm, rmdir, writeFile } from "node:fs/promises"
-import { dirname, resolve } from "node:path"
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path"
 
 import { copyClientOutput, hasStaticIndex } from "./client-output.ts"
 import { createDefaultCloudflareOutputRoot, writeCloudflareWranglerConfig } from "./cloudflare.ts"
@@ -209,6 +209,28 @@ async function writeCloudflareDeploymentOutput(options: CloudflareDeploymentOutp
   await Promise.all(writes)
 }
 
+async function copyVercelClientOutput(rootDir: string, clientDir: string, staticOutputDir: string): Promise<void> {
+  const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
+  const outputRelativePath = relative(clientDir, cloudflareOutputRoot)
+  const excludesCloudflareOutput = outputRelativePath
+    && outputRelativePath !== ".."
+    && !outputRelativePath.startsWith(`..${sep}`)
+    && !isAbsolute(outputRelativePath)
+
+  await copyClientOutput(clientDir, staticOutputDir)
+  if (!excludesCloudflareOutput) return
+
+  try {
+    await readFile(resolve(cloudflareOutputRoot, "wrangler.json"))
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
+    throw error
+  }
+
+  await rm(resolve(staticOutputDir, outputRelativePath), { force: true, recursive: true })
+}
+
 async function writeVercelDeploymentOutput(options: VercelDeploymentOutputOptions): Promise<void> {
   const { clientDir, staticIndex } = resolveClientOutput(options.rootDir, options.clientOutDir)
   const outputRoot = options.outputRoot ?? createDefaultVercelOutputRoot(options.rootDir)
@@ -231,7 +253,7 @@ async function writeVercelDeploymentOutput(options: VercelDeploymentOutputOption
     ),
     writeProviderOutputConfig(resolve(outputRoot, "config.json"), config, { keys: options.configKeys }),
     staticIndex
-      ? copyClientOutput(clientDir, options.staticOutputDir ?? resolve(outputRoot, "static"))
+      ? copyVercelClientOutput(options.rootDir, clientDir, options.staticOutputDir ?? resolve(outputRoot, "static"))
       : Promise.resolve(),
   ])
 }

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -1,6 +1,6 @@
 import { existsSync } from "node:fs"
 import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises"
-import { join } from "node:path"
+import { join, relative } from "node:path"
 import { tmpdir } from "node:os"
 
 import { afterEach, describe, expect, it, vi } from "vitest"
@@ -134,6 +134,39 @@ describe("provider deployment outputs", () => {
     await expect(readFile(join(cloudflareDir, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
       kv_namespaces: [{ binding: "SETTINGS", id: "namespace-id" }],
     })
+  })
+
+  it("excludes nested Cloudflare output from every Vercel static copy", async () => {
+    const rootDir = await createTempProject()
+    const {
+      createDefaultCloudflareOutputRoot,
+      createDefaultVercelOutputRoot,
+      writeProviderDeploymentOutputs,
+    } = await import("../src/build/deployment-output.ts")
+    const clientDir = join(rootDir, "dist")
+    const cloudflareDir = createDefaultCloudflareOutputRoot(rootDir)
+    const vercelStaticDir = join(createDefaultVercelOutputRoot(rootDir), "static")
+    const copiedCloudflareDir = join(vercelStaticDir, relative(clientDir, cloudflareDir))
+    await mkdir(cloudflareDir, { recursive: true })
+    await writeFile(join(clientDir, "index.html"), "<!doctype html>\n")
+    await writeFile(join(cloudflareDir, "wrangler.json"), "{}\n")
+
+    const writeVercelOutput = () => writeProviderDeploymentOutputs({
+      clientOutDir: "dist",
+      rootDir,
+      vercel: {
+        bundleEntry: join(rootDir, "entry.mjs"),
+        bundleOptions: {},
+      },
+    })
+
+    await writeVercelOutput()
+    expect(existsSync(join(vercelStaticDir, "index.html"))).toBe(true)
+    expect(existsSync(copiedCloudflareDir)).toBe(false)
+
+    await writeVercelOutput()
+    expect(existsSync(join(cloudflareDir, "wrangler.json"))).toBe(true)
+    expect(existsSync(copiedCloudflareDir)).toBe(false)
   })
 
   it("forwards keyed array ownership through composed Cloudflare output", async () => {

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -167,6 +167,17 @@ describe("provider deployment outputs", () => {
     await writeVercelOutput()
     expect(existsSync(join(cloudflareDir, "wrangler.json"))).toBe(true)
     expect(existsSync(copiedCloudflareDir)).toBe(false)
+
+    await writeProviderDeploymentOutputs({
+      clientOutDir: "dist",
+      rootDir,
+      vercel: {
+        bundleEntry: join(rootDir, "entry.mjs"),
+        bundleOptions: {},
+        staticOutputDir: clientDir,
+      },
+    })
+    expect(existsSync(join(cloudflareDir, "wrangler.json"))).toBe(true)
   })
 
   it("forwards keyed array ownership through composed Cloudflare output", async () => {

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -1,7 +1,7 @@
 import { hash } from "node:crypto"
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { createRequire } from "node:module"
-import { dirname, isAbsolute, relative, resolve, sep } from "node:path"
+import { dirname, relative, resolve } from "node:path"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
 import { createDefaultCloudflareOutputRoot, createDefaultVercelOutputRoot, getProviderRuntimeModule, getVercelRuntimePackages, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
@@ -459,26 +459,6 @@ function createVercelOutput(
   }
 }
 
-async function removeCloudflareOutputFromVercelStatic(rootDir: string, clientOutDir: string) {
-  const clientDir = resolve(rootDir, clientOutDir)
-  const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
-  const outputRelativePath = relative(clientDir, cloudflareOutputRoot)
-  if (!outputRelativePath
-    || outputRelativePath === ".."
-    || outputRelativePath.startsWith(`..${sep}`)
-    || isAbsolute(outputRelativePath)) return
-
-  try {
-    await readFile(resolve(cloudflareOutputRoot, "wrangler.json"))
-  }
-  catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
-    throw error
-  }
-
-  await rm(resolve(createDefaultVercelOutputRoot(rootDir), "static", outputRelativePath), { force: true, recursive: true })
-}
-
 interface VercelQueueOutputState {
   digest: string
   serverFunctionName: string
@@ -604,7 +584,6 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
         .filter(serverFunctionName => !createVercel || serverFunctionName !== vercelFunctionName)
         .map(serverFunctionName => rm(resolve(createDefaultVercelOutputRoot(options.rootDir), "functions", serverFunctionName), { force: true, recursive: true })))
       if (createVercel) {
-        await removeCloudflareOutputFromVercelStatic(options.rootDir, options.clientOutDir)
         const functionRoot = resolve(createDefaultVercelOutputRoot(options.rootDir), "functions", vercelFunctionName)
         await copyVercelRuntimePackages({
           packages: getVercelRuntimePackages(options.providerOutput, "blob"),

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -1,7 +1,7 @@
 import { hash } from "node:crypto"
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { createRequire } from "node:module"
-import { dirname, relative, resolve } from "node:path"
+import { dirname, isAbsolute, relative, resolve, sep } from "node:path"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
 import { createDefaultCloudflareOutputRoot, createDefaultVercelOutputRoot, getProviderRuntimeModule, getVercelRuntimePackages, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
@@ -459,6 +459,26 @@ function createVercelOutput(
   }
 }
 
+async function removeCloudflareOutputFromVercelStatic(rootDir: string, clientOutDir: string) {
+  const clientDir = resolve(rootDir, clientOutDir)
+  const cloudflareOutputRoot = createDefaultCloudflareOutputRoot(rootDir)
+  const outputRelativePath = relative(clientDir, cloudflareOutputRoot)
+  if (!outputRelativePath
+    || outputRelativePath === ".."
+    || outputRelativePath.startsWith(`..${sep}`)
+    || isAbsolute(outputRelativePath)) return
+
+  try {
+    await readFile(resolve(cloudflareOutputRoot, "wrangler.json"))
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
+    throw error
+  }
+
+  await rm(resolve(createDefaultVercelOutputRoot(rootDir), "static", outputRelativePath), { force: true, recursive: true })
+}
+
 interface VercelQueueOutputState {
   digest: string
   serverFunctionName: string
@@ -584,6 +604,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
         .filter(serverFunctionName => !createVercel || serverFunctionName !== vercelFunctionName)
         .map(serverFunctionName => rm(resolve(createDefaultVercelOutputRoot(options.rootDir), "functions", serverFunctionName), { force: true, recursive: true })))
       if (createVercel) {
+        await removeCloudflareOutputFromVercelStatic(options.rootDir, options.clientOutDir)
         const functionRoot = resolve(createDefaultVercelOutputRoot(options.rootDir), "functions", vercelFunctionName)
         await copyVercelRuntimePackages({
           packages: getVercelRuntimePackages(options.providerOutput, "blob"),


### PR DESCRIPTION
Stops Queue Vercel output from copying the preserved default Cloudflare output subtree into `.vercel/output/static` when both outputs share `dist`. The cleanup is scoped to a nested output with a source `wrangler.json`, so shared Cloudflare config remains in its owner output and ordinary static assets still deploy.

The existing shared-output regression now passes, along with the full Queue and provider-output suites.