### PR TITLE
feat(agent): support streaming transcription replies

### DIFF
--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -223,6 +223,8 @@ export default defineAgent({
 })
 ```
 
+`event.reply()` also accepts `AsyncIterable<string>`. Chat-backed Channels stream it through the adapter when available and use Chat SDK's post-and-edit fallback otherwise.
+
 Finish hooks should not quietly grant new abilities. Capabilities and Agent Drivers remain the authority boundaries.
 
 ### Handle failures

--- a/docs/content/docs/capabilities/transcribe.md
+++ b/docs/content/docs/capabilities/transcribe.md
@@ -59,6 +59,35 @@ transcribe({
 })
 ```
 
+## Streaming transcription
+
+Use `streamTranscription()` for live raw audio. It wraps AI SDK streaming transcription and exposes `textStream`, an append-only text stream that can be passed directly to `event.reply()`.
+
+```ts
+import type { AgentFinishHookEvent } from '@vite-hub/agent'
+import { streamTranscription } from '@vite-hub/agent/capabilities'
+
+export async function liveTranscriptReply(
+  event: AgentFinishHookEvent,
+  audio: ReadableStream<Uint8Array>,
+) {
+  const transcription = await streamTranscription({
+    model: 'openai/gpt-realtime-whisper',
+    audio,
+    inputAudioFormat: {
+      type: 'audio/pcm',
+      rate: 24_000,
+    },
+  })
+
+  return event.reply(transcription.textStream)
+}
+```
+
+Return the reply intent without awaiting `transcription.text`; consuming the reply drives the provider stream and resolves the final text promise. Chat-backed Channels use native streaming when the adapter supports it and Chat SDK's post-and-edit fallback otherwise. Other message Channels use their native stream method when available and fall back to one final reply.
+
+`streamTranscription()` emits provider `transcript-delta` events as reply chunks. Providers that only emit partial and final snapshots produce one final reply, which avoids duplicating corrected partial text.
+
 ## Asynchronous remote transcription
 
 Use `createTranscription()` when a durable workflow should submit a private remote object and resume after the provider completes it.
@@ -104,6 +133,8 @@ Failed completions contain a `ViteHubError` with a fixed `TRANSCRIPTION_*` code 
 
 Basic transcription requires a model or custom executor.
 Artifact persistence requires an explicit writable Workspace.
+
+Streaming transcription requires an AI SDK streaming transcription model, a `ReadableStream<Uint8Array | string>` of raw audio, and its input audio format.
 
 Asynchronous remote transcription requires a `TranscriptionDriver`.
 The built-in ElevenLabs Scribe driver requires an API key and an explicitly configured speech-to-text webhook ID.
@@ -164,11 +195,13 @@ Import these helpers from `@vite-hub/agent/capabilities` when custom hooks or ex
 | --- | --- | --- |
 | `audioBytes(audio, { maxBytes? })` | `Promise<Uint8Array>` | Resolves direct data, `fetchData`, or an audio URL and enforces a `26214400` byte default limit. |
 | `getTranscriptionResults(context)` | `TranscriptionResult[]` | Reads the current invocation's results from an invocation context store or an object containing one. Returns an empty array when none exist. |
+| `streamTranscription(options)` | `Promise<StreamingTranscription>` | Starts AI SDK streaming transcription and exposes `textStream` for streamed replies, `text` for the final transcript, and the underlying `result` metadata. |
 
 Each `TranscriptionResult` contains `createdAt`, `date`, `messageId`, `stem`, and `transcript`, plus `audioPath` or `transcriptPath` when those artifacts were written.
 
 ## Reference
 
+- [AI Gateway streaming transcription](https://vercel.com/changelog/ai-gateway-now-supports-streaming-transcription)
 - [Workspace primitive](/docs/server-primitives/workspace)
 - [Agent invocations](/docs/agents/invocations)
 - Source: `packages/agent/src/capabilities/transcribe.ts`

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -73,6 +73,7 @@ export type {
 export {
   audioBytes,
   getTranscriptionResults,
+  streamTranscription,
   transcribe,
 } from "./transcribe.ts"
 export {
@@ -294,6 +295,8 @@ export type {
   SubagentToolInput,
 } from "./subagents.ts"
 export type {
+  StreamTranscriptionOptions,
+  StreamingTranscription,
   TranscribeArtifactTemplateInput,
   TranscribeArtifactsOptions,
   TranscribeAudioArtifactOptions,

--- a/packages/agent/src/capabilities/transcribe.ts
+++ b/packages/agent/src/capabilities/transcribe.ts
@@ -15,6 +15,8 @@ import type { WritableWorkspaceFacade, WorkspaceContent, WorkspaceName } from "@
 type AiSdkTranscribe = typeof import("ai")["transcribe"]
 type AiSdkTranscribeOptions = Omit<Parameters<AiSdkTranscribe>[0], "abortSignal" | "audio">
 type AiSdkTranscriptionResult = Awaited<ReturnType<AiSdkTranscribe>>
+type AiSdkStreamTranscribe = typeof import("ai")["experimental_streamTranscribe"]
+type AiSdkStreamTranscriptionResult = ReturnType<AiSdkStreamTranscribe>
 type TranscribeArtifactValue<T, TInput> = T | ((input: TInput) => MaybePromise<T>)
 const DEFAULT_TRANSCRIBE_MAX_BYTES = 25 * 1024 * 1024
 const resolvedAudioData = new WeakMap<AudioPart, Promise<AudioData>>()
@@ -24,6 +26,14 @@ export interface TranscribeExecuteInput {
 }
 
 export type TranscribeExecuteResult = AiSdkTranscriptionResult | string
+
+export type StreamTranscriptionOptions = Omit<Parameters<AiSdkStreamTranscribe>[0], "_internal">
+
+export interface StreamingTranscription {
+  result: AiSdkStreamTranscriptionResult
+  text: AiSdkStreamTranscriptionResult["text"]
+  textStream: AsyncIterable<string>
+}
 
 export interface TranscriptionResult {
   audioPath?: string
@@ -77,6 +87,39 @@ type StaticTranscribeOptions =
   }
 
 export type TranscribeOptions = StaticTranscribeOptions | (() => MaybePromise<StaticTranscribeOptions>)
+
+async function* transcriptionTextStream(
+  stream: AiSdkStreamTranscriptionResult["fullStream"],
+  text: AiSdkStreamTranscriptionResult["text"],
+): AsyncIterable<string> {
+  let streamedText = ""
+  for await (const part of stream) {
+    if (part.type === "error") throw part.error
+    if (part.type === "transcript-delta" && part.delta) {
+      streamedText += part.delta
+      yield part.delta
+    }
+  }
+  const finalText = await text
+  const suffix = finalText.startsWith(streamedText) ? finalText.slice(streamedText.length) : ""
+  if (suffix) yield suffix
+  else if (!streamedText && finalText) yield finalText
+}
+
+export async function streamTranscription(options: StreamTranscriptionOptions): Promise<StreamingTranscription> {
+  const aiSdk = await loadAiSdk() as typeof import("ai") & {
+    experimental_streamTranscribe?: AiSdkStreamTranscribe
+  }
+  if (!aiSdk.experimental_streamTranscribe) {
+    throw new TypeError("[vitehub] streamTranscription() requires ai.experimental_streamTranscribe.")
+  }
+  const result = aiSdk.experimental_streamTranscribe(options)
+  return {
+    result,
+    text: result.text,
+    textStream: transcriptionTextStream(result.fullStream, result.text),
+  }
+}
 
 function isAudioPart(part: unknown): part is AudioPart {
   return !!part

--- a/packages/agent/src/capabilities/transcribe.ts
+++ b/packages/agent/src/capabilities/transcribe.ts
@@ -114,6 +114,7 @@ export async function streamTranscription(options: StreamTranscriptionOptions): 
     throw new TypeError("[vitehub] streamTranscription() requires ai.experimental_streamTranscribe.")
   }
   const result = aiSdk.experimental_streamTranscribe(options)
+  void result.text.then(undefined, () => {})
   return {
     result,
     text: result.text,

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1182,10 +1182,11 @@ async function messageChannelReplyEffect<TRuntimeConfig extends AgentRuntimeConf
     }
     return
   }
-  let body = rewriteDeliveryArtifactMarkdown(replyBodyWithLinkArtifacts(replyBody(context), artifacts), artifacts)
+  let body = replyBody(context)
   if (stream) {
     for await (const chunk of stream) body = `${body || ""}${chunk}`
   }
+  body = rewriteDeliveryArtifactMarkdown(replyBodyWithLinkArtifacts(body, artifacts), artifacts)
   if (!body && !attachments.length && !files.length) return
   const message: AgentChatMessage = {
     markdown: body || "",

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -2,6 +2,7 @@ import { createHash, createSign } from "node:crypto"
 import { CHAT_FINISH_EXTENSION_CONTEXT_KEY } from "./chat-trigger.ts"
 import { readPullRequestContext } from "./capabilities/repository-host-context.ts"
 import { defineCapability } from "./capability-runtime.ts"
+import { isAsyncIterable } from "./internal/stream-result.ts"
 import {
   deliveryArtifactAttachments,
   deliveryArtifactMarkdownReferencePaths,
@@ -28,6 +29,7 @@ import type {
   AgentChannelDeliveryEffects,
   AgentChannelDeliveryFinishEffect,
   AgentChannelDeliveryFinishEffectContext,
+  AgentChannelDeliveryReplyStream,
   AgentChannelWebhookRegistrationDefinition,
   AgentFinishEvent,
   AgentRunInput,
@@ -75,6 +77,7 @@ export type {
   AgentChannelDeliveryReactionPayload,
   AgentChannelDeliveryReplyInput,
   AgentChannelDeliveryReplyPayload,
+  AgentChannelDeliveryReplyStream,
   AgentChannelDeliveryStatusInput,
   AgentChannelDeliveryStatusPayload,
   AgentChannelDeliveryStatusState,
@@ -1154,9 +1157,35 @@ async function messageChannelReplyEffect<TRuntimeConfig extends AgentRuntimeConf
   context: AgentChannelDeliveryEffectContext<TRuntimeConfig>,
 ): Promise<void> {
   const artifacts = deliveryArtifacts(context)
-  const body = rewriteDeliveryArtifactMarkdown(replyBodyWithLinkArtifacts(replyBody(context), artifacts), artifacts)
   const attachments = deliveryArtifactAttachments(artifacts)
   const files = await deliveryArtifactFiles(context, artifacts)
+  const stream = isAsyncIterable(context.effect.payload)
+    ? context.effect.payload as AgentChannelDeliveryReplyStream
+    : undefined
+  if (stream && !artifacts.length) {
+    const chat = context.finish
+      ? chatFinishExtensionFromUnknown(context.finish.extensions.get("chat")) || chatFinishExtension(context.input)
+      : undefined
+    if (chat) {
+      await chat.sendMessage(stream)
+      return
+    }
+    const adapter = context.channel.adapter
+      ? await resolveEffectOption(context.channel.adapter as MaybeResolvable<Adapter, AgentChannelDeliveryEffectContext<TRuntimeConfig>>, context)
+      : undefined
+    if (adapter && context.run?.threadId) {
+      const threadId = adapter.channelIdFromThreadId(context.run.threadId)
+      if (adapter.stream && await adapter.stream(threadId, stream) !== null) return
+      let body = ""
+      for await (const chunk of stream) body += chunk
+      if (body) await adapter.postMessage(threadId, { markdown: body })
+    }
+    return
+  }
+  let body = rewriteDeliveryArtifactMarkdown(replyBodyWithLinkArtifacts(replyBody(context), artifacts), artifacts)
+  if (stream) {
+    for await (const chunk of stream) body = `${body || ""}${chunk}`
+  }
   if (!body && !attachments.length && !files.length) return
   const message: AgentChatMessage = {
     markdown: body || "",

--- a/packages/agent/src/delivery-effects.ts
+++ b/packages/agent/src/delivery-effects.ts
@@ -1,3 +1,5 @@
+import { isAsyncIterable } from "./internal/stream-result.ts"
+
 import type {
   AgentChannelDeliveryEffectIntentOptions,
   AgentChannelDeliveryEffectIntent,
@@ -35,7 +37,7 @@ export function createReplyDeliveryEffectIntent(
   input: AgentChannelDeliveryReplyInput,
   options: AgentChannelDeliveryEffectIntentOptions = {},
 ): AgentChannelDeliveryEffectIntent<"reply"> {
-  if (typeof input === "string") return intent("reply", input, options)
+  if (typeof input === "string" || isAsyncIterable(input)) return intent("reply", input, options)
   const { artifacts, ...payload } = input
   return intent("reply", payload, { ...options, artifacts: options.artifacts ?? artifacts })
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -238,6 +238,7 @@ export type {
   AgentChannelDeliveryReactionPayload,
   AgentChannelDeliveryReplyInput,
   AgentChannelDeliveryReplyPayload,
+  AgentChannelDeliveryReplyStream,
   AgentChannelDeliveryStatusInput,
   AgentChannelDeliveryStatusPayload,
   AgentChannelDeliveryStatusState,
@@ -2241,7 +2242,9 @@ function createFinishDeliveryEffectContext<
   const result = event.result === undefined ? undefined : toAgentRunResult(event.result)
   const active = activeAgentChannel(context.channels, context.context, context.run)
   const reply: AgentChannelDeliveryFinishEffectContext<TRuntimeConfig, CALL_OPTIONS>["reply"] = (input, options = {}) => {
-    const inputArtifacts = typeof input === "object" && input !== null ? input.artifacts : undefined
+    const inputArtifacts = typeof input === "object" && input !== null && "artifacts" in input
+      ? input.artifacts
+      : undefined
     return createReplyDeliveryEffectIntent(input, {
       ...options,
       artifacts: options.artifacts ?? inputArtifacts ?? result?.artifacts,

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1798,6 +1798,10 @@ function chatMessageDeliveryArtifacts(message: AgentChatMessage): readonly Publi
 }
 
 async function postChatMessage(thread: Thread, message: AgentChatMessage): Promise<void> {
+  if (isAsyncIterable(message)) {
+    await thread.post(thread.adapter.stream ? new StreamingPlan(message) : message)
+    return
+  }
   if (typeof message !== "object" || message === null) {
     if (await postDiscordSplitContent(thread, message)) return
     await thread.post(message)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1799,7 +1799,15 @@ function chatMessageDeliveryArtifacts(message: AgentChatMessage): readonly Publi
 
 async function postChatMessage(thread: Thread, message: AgentChatMessage): Promise<void> {
   if (isAsyncIterable(message)) {
-    await thread.post(thread.adapter.stream ? new StreamingPlan(message) : message)
+    let markdown = ""
+    const stream = (async function* () {
+      for await (const chunk of message) {
+        markdown += chunk
+        yield chunk
+      }
+    })()
+    const sent = await thread.post(thread.adapter.stream ? new StreamingPlan(stream) : stream)
+    await finishDiscordSplitStream(thread, sent, markdown || sentMessageText(sent))
     return
   }
   if (typeof message !== "object" || message === null) {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -234,7 +234,9 @@ export interface AgentChannelDeliveryReplyPayload {
   markdown?: string
 }
 
-export type AgentChannelDeliveryReplyInput = string | AgentChannelDeliveryReplyPayload
+export type AgentChannelDeliveryReplyStream = AsyncIterable<string>
+
+export type AgentChannelDeliveryReplyInput = string | AgentChannelDeliveryReplyPayload | AgentChannelDeliveryReplyStream
 
 export interface AgentChannelDeliveryReactionPayload {
   action?: "remove" | (string & {})
@@ -1454,6 +1456,7 @@ export type AgentWebhookStateResolver<TRuntimeConfig extends AgentRuntimeConfig 
 
 export type AgentChatMessage =
   | AdapterPostableMessage
+  | AgentChannelDeliveryReplyStream
   | { text: string }
   | ((Exclude<AdapterPostableMessage, string> | { text: string }) & {
     artifacts?: readonly PublishedAgentDeliveryArtifact[]

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7449,6 +7449,65 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:888", { markdown: "side message via telegram" })
   })
 
+  it("streams event.reply through the Chat SDK transport", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const stream = vi.fn(async (threadId: string, textStream: AsyncIterable<string | StreamChunk>) => {
+      let text = ""
+      for await (const chunk of textStream) {
+        if (typeof chunk === "string") text += chunk
+        else if (chunk.type === "markdown_text") text += chunk.text
+      }
+      return { id: "stream-1", raw: { text }, threadId }
+    })
+    adapter.stream = stream
+    const agent = defineAgent({
+      channels: {
+        support: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            stream: false,
+          },
+        }),
+      },
+      driver: { run: () => ({ text: "agent answer" }) },
+      hooks: {
+        "agent:finish"(event) {
+          return event.reply((async function* () {
+            yield "live "
+            yield "transcript"
+          })())
+        },
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/support", {
+      body: JSON.stringify({
+        update_id: 89,
+        message: {
+          chat: { id: 889, type: "private" },
+          date: 1781092800,
+          from: { first_name: "Maxi", id: 123, username: "maxi" },
+          message_id: 89,
+          text: "hello",
+        },
+      }),
+      method: "POST",
+    }), "support")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true })
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:889", { markdown: "agent answer" })
+    expect(stream).toHaveBeenCalledOnce()
+    await expect(stream.mock.results[0]?.value).resolves.toMatchObject({
+      raw: { text: "live transcript" },
+      threadId: "telegram:889",
+    })
+  })
+
   it("maps finish hook delivery artifacts to Chat SDK attachments", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineChatCapability } = await import("../src/chat-trigger.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -3670,6 +3670,7 @@ describe("server helpers", () => {
     adapter.name = "discord"
     Object.defineProperty(adapter, Symbol.for("vitehub.discord.longContent.mode"), { value: "split" })
     let replyText = "short reply"
+    let finishReply: string | undefined
     const agent = defineAgent({
       channels: {
         discord: discord({
@@ -3679,6 +3680,14 @@ describe("server helpers", () => {
       },
       driver: {
         run: () => ({ text: replyText }),
+      },
+      hooks: {
+        "agent:finish"(event) {
+          if (!finishReply) return
+          return event.reply((async function* () {
+            yield finishReply
+          })())
+        },
       },
     })
     const handler = createChannelWebhookRouteHandler(agent as never)
@@ -3705,6 +3714,7 @@ describe("server helpers", () => {
     adapter.postMessage.mockClear()
     adapter.editMessage.mockClear()
     replyText = `${"word ".repeat(430)}done`
+    finishReply = `${"side ".repeat(430)}done`
 
     const longResponse = await handler(request(8), "discord")
 
@@ -3716,6 +3726,14 @@ describe("server helpers", () => {
       raw: expect.stringMatching(/ \(1\/2\)$/),
     })
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", {
+      raw: expect.stringMatching(/ \(2\/2\)$/),
+    })
+    expect(adapter.editMessage).toHaveBeenNthCalledWith(3, "telegram:456", "sent-4", { markdown: finishReply })
+    expect(adapter.editMessage).toHaveBeenNthCalledWith(4, "telegram:456", "sent-4", {
+      attachments: [],
+      raw: expect.stringMatching(/ \(1\/2\)$/),
+    })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(4, "telegram:456", {
       raw: expect.stringMatching(/ \(2\/2\)$/),
     })
   })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7633,7 +7633,7 @@ describe("server helpers", () => {
     expect(adapter.editMessage).not.toHaveBeenCalled()
   })
 
-  it("posts finish channel delivery replies after input replacement and appends link artifacts", async () => {
+  it("posts finish channel delivery replies after input replacement and rewrites streamed link artifacts", async () => {
     const { defineAgent, defineCapability } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
@@ -7652,7 +7652,9 @@ describe("server helpers", () => {
                 url: "https://assets.example/reports/result.md",
               }],
               kind: "reply",
-              payload: { body: "See the report." },
+              payload: (async function* () {
+                yield "See [Result report](reports/result.md)."
+              })(),
             }))
           },
         }),
@@ -7685,7 +7687,7 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:987", { markdown: "agent answer" })
     expect(adapter.editMessage).not.toHaveBeenCalled()
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:987", {
-      markdown: "See the report.\n\n[Result report](<https://assets.example/reports/result.md>)",
+      markdown: "See [Result report](<https://assets.example/reports/result.md>).",
     })
   })
 

--- a/packages/agent/test/transcription.test.ts
+++ b/packages/agent/test/transcription.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { getTranscriptionResults, title, transcribe } from "../src/capabilities.ts"
+import { getTranscriptionResults, streamTranscription, title, transcribe } from "../src/capabilities.ts"
 import { audioBytes, audioExtensionFor } from "../src/capabilities/transcribe.ts"
 import { createMessage, defineAgent, runAgent, serializeMessages } from "../src/index.ts"
 
@@ -55,6 +55,65 @@ function createTranscriptionCapabilityContext(
 }
 
 describe("agent transcription", () => {
+  it("normalizes streaming transcription events into reply text", async () => {
+    const experimentalStreamTranscribe = vi.fn(() => ({
+      fullStream: (async function* () {
+        yield { delta: "hello ", type: "transcript-delta" as const }
+        yield { text: "hello world", type: "transcript-final" as const }
+      })(),
+      text: Promise.resolve("hello world"),
+    }))
+    vi.doMock("ai", () => ({
+      experimental_streamTranscribe: experimentalStreamTranscribe,
+    }))
+    try {
+      const audio = new ReadableStream<Uint8Array>()
+      const transcription = await streamTranscription({
+        audio,
+        inputAudioFormat: { rate: 24_000, type: "audio/pcm" },
+        model: "openai/gpt-realtime-whisper",
+      })
+      let reply = ""
+      for await (const chunk of transcription.textStream) reply += chunk
+
+      expect(reply).toBe("hello world")
+      await expect(transcription.text).resolves.toBe("hello world")
+      expect(experimentalStreamTranscribe).toHaveBeenCalledWith({
+        audio,
+        inputAudioFormat: { rate: 24_000, type: "audio/pcm" },
+        model: "openai/gpt-realtime-whisper",
+      })
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
+
+  it("uses the final streaming transcript when a provider emits no deltas", async () => {
+    vi.doMock("ai", () => ({
+      experimental_streamTranscribe: () => ({
+        fullStream: (async function* () {
+          yield { text: "hello", type: "transcript-partial" as const }
+          yield { text: "hello world", type: "transcript-final" as const }
+        })(),
+        text: Promise.resolve("hello world"),
+      }),
+    }))
+    try {
+      const transcription = await streamTranscription({
+        audio: new ReadableStream<Uint8Array>(),
+        inputAudioFormat: { rate: 24_000, type: "audio/pcm" },
+        model: "openai/gpt-realtime-whisper",
+      })
+      let reply = ""
+      for await (const chunk of transcription.textStream) reply += chunk
+      expect(reply).toBe("hello world")
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
+
   it("normalizes audio extensions and bytes", async () => {
     expect(audioExtensionFor("audio/mpeg; codecs=mp3")).toBe("mp3")
     expect(audioExtensionFor("audio/opus")).toBe("ogg")

--- a/packages/agent/test/transcription.test.ts
+++ b/packages/agent/test/transcription.test.ts
@@ -114,6 +114,39 @@ describe("agent transcription", () => {
     }
   })
 
+  it("handles the final text rejection when the provider stream fails", async () => {
+    const error = new Error("provider failed")
+    let rejectText!: (reason?: unknown) => void
+    const text = new Promise<string>((_resolve, reject) => {
+      rejectText = reject
+    })
+    const thenSpy = vi.spyOn(text, "then")
+    vi.doMock("ai", () => ({
+      experimental_streamTranscribe: () => ({
+        fullStream: (async function* () {
+          rejectText(error)
+          yield { error, type: "error" as const }
+        })(),
+        text,
+      }),
+    }))
+    try {
+      const transcription = await streamTranscription({
+        audio: new ReadableStream<Uint8Array>(),
+        inputAudioFormat: { rate: 24_000, type: "audio/pcm" },
+        model: "openai/gpt-realtime-whisper",
+      })
+      await expect(async () => {
+        for await (const _chunk of transcription.textStream) {}
+      }).rejects.toThrow(error)
+      expect(thenSpy).toHaveBeenCalledOnce()
+      await expect(transcription.text).rejects.toThrow(error)
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
+
   it("normalizes audio extensions and bytes", async () => {
     expect(audioExtensionFor("audio/mpeg; codecs=mp3")).toBe("mp3")
     expect(audioExtensionFor("audio/opus")).toBe("ogg")

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUIMessageStreamProjection, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
-import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, repositoryHost, repositoryHostContext, sandbox, schedule, skills, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelDeliveryReplyStream, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUIMessageStreamProjection, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, repositoryHost, repositoryHostContext, sandbox, schedule, skills, streamTranscription, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -620,9 +620,22 @@ describe("agent public types", () => {
           expectTypeOf(event.extensions.get("missing")).toEqualTypeOf<unknown>()
           expectTypeOf(event.invocation.usage).toEqualTypeOf<AgentUsageRecord | undefined>()
           expectTypeOf(event.errorMessage).toEqualTypeOf<string | undefined>()
+          return event.reply((async function* () {
+            yield "streamed reply"
+          })())
         },
       },
     })
+
+    const streamingTranscription = streamTranscription({
+      audio: new ReadableStream<Uint8Array>(),
+      inputAudioFormat: { rate: 24_000, type: "audio/pcm" },
+      model: "openai/gpt-realtime-whisper",
+    })
+    expectTypeOf(streamingTranscription).toMatchTypeOf<Promise<{
+      text: PromiseLike<string>
+      textStream: AsyncIterable<string>
+    }>>()
 
     defineAgent({
       capabilities: [{
@@ -1032,7 +1045,7 @@ describe("agent public types", () => {
       expectTypeOf(context.reply("done")).toEqualTypeOf<AgentChannelDeliveryEffectIntent<"reply">>()
       expectTypeOf(context.reaction("eyes")).toEqualTypeOf<AgentChannelDeliveryEffectIntent<"reaction">>()
       expectTypeOf(context.status("pending")).toEqualTypeOf<AgentChannelDeliveryEffectIntent<"status">>()
-      expectTypeOf(context.reply({ markdown: "done" }).payload).toEqualTypeOf<AgentChannelDeliveryReplyPayload | string | undefined>()
+      expectTypeOf(context.reply({ markdown: "done" }).payload).toEqualTypeOf<AgentChannelDeliveryReplyPayload | AgentChannelDeliveryReplyStream | string | undefined>()
     })
     // @ts-expect-error Development samples belong in CLI payload files, not Channel options.
     teams({ dev: { samples: {} } })


### PR DESCRIPTION
## Summary

- add `streamTranscription()` over AI SDK streaming transcription with an append-only `textStream`
- let `event.reply()` and Chat finish messages accept `AsyncIterable<string>`
- reuse Chat SDK native streaming and post/edit fallback, with final-message and long Discord reply handling
- preserve streamed artifact rewriting and document the public API and live transcription flow

## Verification

- `tsc --noEmit -p packages/agent/tsconfig.json`
- `vp test run test/transcription.test.ts test/public-api.test.ts --reporter=dot` (37 tests)
- `vp test run test/providers.test.ts --testTimeout=10000` (170 tests)
- `vp pack` (publint clean)