### PR TITLE
refactor(sandbox): unpublish provider internals

### DIFF
--- a/packages/sandbox/package.json
+++ b/packages/sandbox/package.json
@@ -48,14 +48,6 @@
       "types": "./dist/runtime/provider-loader.d.ts",
       "import": "./dist/runtime/provider-loader.js"
     },
-    "./runtime/providers/cloudflare": {
-      "types": "./dist/runtime/providers/cloudflare.d.ts",
-      "import": "./dist/runtime/providers/cloudflare.js"
-    },
-    "./runtime/providers/vercel": {
-      "types": "./dist/runtime/providers/vercel.d.ts",
-      "import": "./dist/runtime/providers/vercel.js"
-    },
     "./runtime/state": {
       "types": "./dist/runtime/state.d.ts",
       "import": "./dist/runtime/state.js"

--- a/packages/sandbox/src/feature.ts
+++ b/packages/sandbox/src/feature.ts
@@ -142,6 +142,9 @@ function createSandboxRegistryContents(
 export function createSandboxProviderLoaderContents(
   provider: SandboxProvider,
 ) {
+  const providerExport = provider === 'cloudflare'
+    ? 'resolveCloudflareSandboxBox'
+    : 'resolveVercelSandboxBox'
   const providerLoaderPath = resolveFeatureRuntimePath(
     import.meta.url,
     '@vite-hub/sandbox',
@@ -149,7 +152,7 @@ export function createSandboxProviderLoaderContents(
     `runtime/providers/${provider}.js`,
   )
   return [
-    `import { resolveSandboxBox } from ${JSON.stringify(providerLoaderPath)}`,
+    `import { ${providerExport} as resolveSandboxBox } from ${JSON.stringify(providerLoaderPath)}`,
     '',
     'export async function loadSandboxRuntimeProvider(selectedProvider) {',
     `  if (selectedProvider !== ${JSON.stringify(provider)})`,

--- a/packages/sandbox/src/feature.ts
+++ b/packages/sandbox/src/feature.ts
@@ -142,9 +142,7 @@ function createSandboxRegistryContents(
 export function createSandboxProviderLoaderContents(
   provider: SandboxProvider,
 ) {
-  const providerExport = provider === 'cloudflare'
-    ? 'resolveCloudflareSandboxBox'
-    : 'resolveVercelSandboxBox'
+  const providerExport = sandboxProviderRuntimeExport(provider)
   const providerLoaderPath = resolveFeatureRuntimePath(
     import.meta.url,
     '@vite-hub/sandbox',
@@ -163,6 +161,12 @@ export function createSandboxProviderLoaderContents(
     '}',
     '',
   ].join('\n')
+}
+
+export function sandboxProviderRuntimeExport(provider: SandboxProvider) {
+  return provider === 'cloudflare'
+    ? 'resolveCloudflareSandboxBox'
+    : 'resolveVercelSandboxBox'
 }
 
 export function resolveSandboxFeatureConfig(sandboxConfig: AgentSandboxConfig, hosting?: string): AgentSandboxConfig {

--- a/packages/sandbox/src/runtime/provider-loader.ts
+++ b/packages/sandbox/src/runtime/provider-loader.ts
@@ -23,13 +23,13 @@ const dynamicImport = new Function('specifier', 'return import(specifier)') as <
 
 export async function loadSandboxRuntimeProvider(provider: SandboxProvider): Promise<SandboxRuntimeProvider> {
   if (provider === 'cloudflare') {
-    const { resolveSandboxBox } = await dynamicImport<typeof import('./providers/cloudflare')>('./providers/cloudflare.js')
-    return { resolveSandboxBox }
+    const { resolveCloudflareSandboxBox } = await dynamicImport<typeof import('./providers/cloudflare')>('./providers/cloudflare.js')
+    return { resolveSandboxBox: resolveCloudflareSandboxBox }
   }
 
   if (provider === 'vercel') {
-    const { resolveSandboxBox } = await dynamicImport<typeof import('./providers/vercel')>('./providers/vercel.js')
-    return { resolveSandboxBox }
+    const { resolveVercelSandboxBox } = await dynamicImport<typeof import('./providers/vercel')>('./providers/vercel.js')
+    return { resolveSandboxBox: resolveVercelSandboxBox }
   }
 
   throw new Error(`[vitehub] Unsupported sandbox provider: ${provider}`)

--- a/packages/sandbox/src/runtime/providers/cloudflare.ts
+++ b/packages/sandbox/src/runtime/providers/cloudflare.ts
@@ -15,7 +15,7 @@ type SandboxEvent = {
   }
 }
 
-export async function resolveSandboxBox(options: SandboxOptions, context: { event?: SandboxEvent } = {}) {
+export async function resolveCloudflareSandboxBox(options: SandboxOptions, context: { event?: SandboxEvent } = {}) {
   const env = getCloudflareEnv(context.event)
   const bindingName = options.provider.binding || 'SANDBOX'
   const namespace = env?.[bindingName]

--- a/packages/sandbox/src/runtime/providers/vercel.ts
+++ b/packages/sandbox/src/runtime/providers/vercel.ts
@@ -41,7 +41,7 @@ function resolveCredentials(provider: VercelSandboxProviderOptions) {
   }
 }
 
-export async function resolveSandboxBox(options: SandboxOptions) {
+export async function resolveVercelSandboxBox(options: SandboxOptions) {
   const credentials = resolveCredentials(options.provider)
   const boxOptions = {
     runtime: options.provider.runtime || 'node24',

--- a/packages/sandbox/test/cloudflare-runtime-provider.test.ts
+++ b/packages/sandbox/test/cloudflare-runtime-provider.test.ts
@@ -6,7 +6,7 @@ const { resolveCloudflareBox } = vi.hoisted(() => ({
 
 vi.mock("@vite-hub/box/_internal/cloudflare", () => ({ resolveCloudflareBox }))
 
-import { resolveSandboxBox } from "../src/runtime/providers/cloudflare.ts"
+import { resolveCloudflareSandboxBox } from "../src/runtime/providers/cloudflare.ts"
 
 const namespace = {
   get: vi.fn(),
@@ -15,7 +15,7 @@ const namespace = {
 
 describe("Cloudflare Sandbox runtime provider", () => {
   it("defaults idle shutdown to five minutes", async () => {
-    const provider = await resolveSandboxBox({
+    const provider = await resolveCloudflareSandboxBox({
       local: {},
       provider: { provider: "cloudflare" },
     }, {
@@ -34,7 +34,7 @@ describe("Cloudflare Sandbox runtime provider", () => {
   })
 
   it("preserves an explicit idle shutdown override", async () => {
-    const provider = await resolveSandboxBox({
+    const provider = await resolveCloudflareSandboxBox({
       local: {},
       provider: { provider: "cloudflare", sleepAfter: "30s" },
     }, {
@@ -51,7 +51,7 @@ describe("Cloudflare Sandbox runtime provider", () => {
   })
 
   it("closes a Box session when keepAlive disables idle shutdown", async () => {
-    const provider = await resolveSandboxBox({
+    const provider = await resolveCloudflareSandboxBox({
       local: {},
       provider: { provider: "cloudflare", keepAlive: true },
     }, {

--- a/packages/sandbox/test/provider-detection.test.ts
+++ b/packages/sandbox/test/provider-detection.test.ts
@@ -46,9 +46,9 @@ describe("provider detection", () => {
   it("resolves the Cloudflare binding from the scoped environment", async () => {
     const namespace = {}
 
-    const { resolveSandboxBox } = await import("../src/runtime/providers/cloudflare.ts")
+    const { resolveCloudflareSandboxBox } = await import("../src/runtime/providers/cloudflare.ts")
     const provider = await runWithActiveCloudflareEnv({ SANDBOX: namespace }, () =>
-      resolveSandboxBox({ local: {}, provider: { provider: "cloudflare" } }))
+      resolveCloudflareSandboxBox({ local: {}, provider: { provider: "cloudflare" } }))
 
     expect(provider.resolveBox).toEqual(expect.any(Function))
   })

--- a/packages/sandbox/test/public-api.test.ts
+++ b/packages/sandbox/test/public-api.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises"
+import { access, readFile } from "node:fs/promises"
 import { join } from "node:path"
 
 import { describe, expect, it } from "vitest"
@@ -37,5 +37,14 @@ describe("sandbox public api", () => {
     expect(loader).not.toContain('"./providers/cloudflare"')
     expect(loader).not.toContain('"./providers/vercel"')
     expect(loader).not.toContain("createSandboxClient")
+  })
+
+  it("keeps provider implementations internal", async () => {
+    const manifest = JSON.parse(await readFile(join(import.meta.dirname, "../package.json"), "utf8"))
+
+    expect(manifest.exports).not.toHaveProperty("./runtime/providers/cloudflare")
+    expect(manifest.exports).not.toHaveProperty("./runtime/providers/vercel")
+    await expect(access(join(import.meta.dirname, "../dist/runtime/providers/cloudflare.js"))).resolves.toBeUndefined()
+    await expect(access(join(import.meta.dirname, "../dist/runtime/providers/vercel.js"))).resolves.toBeUndefined()
   })
 })

--- a/packages/sandbox/test/vercel-provider.test.ts
+++ b/packages/sandbox/test/vercel-provider.test.ts
@@ -6,7 +6,7 @@ const { resolveVercelBox } = vi.hoisted(() => ({
 
 vi.mock("@vite-hub/box/_internal/vercel", () => ({ resolveVercelBox }))
 
-import { resolveSandboxBox } from "../src/runtime/providers/vercel.ts"
+import { resolveVercelSandboxBox } from "../src/runtime/providers/vercel.ts"
 
 const envKeys = [
   "VERCEL_TOKEN",
@@ -26,7 +26,7 @@ describe("resolveSandboxBox", () => {
     process.env.VERCEL_TEAM_ID = "team-from-env"
     process.env.VERCEL_PROJECT_ID = "project-from-env"
 
-    const provider = await resolveSandboxBox({
+    const provider = await resolveVercelSandboxBox({
       local: {},
       provider: {
         provider: "vercel",
@@ -48,7 +48,7 @@ describe("resolveSandboxBox", () => {
   it("uses config credentials without process", async () => {
     vi.stubGlobal("process", undefined)
 
-    const provider = await resolveSandboxBox({
+    const provider = await resolveVercelSandboxBox({
       local: {},
       provider: {
         provider: "vercel",

--- a/packages/sandbox/vite.config.ts
+++ b/packages/sandbox/vite.config.ts
@@ -25,6 +25,10 @@ export default defineConfig({
       "src/runtime/state.ts",
     ],
     exports: {
+      exclude: [
+        "runtime/providers/cloudflare",
+        "runtime/providers/vercel",
+      ],
       customExports(exports) {
         return Object.fromEntries(
           Object.entries(exports).map(([key, value]) => {

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -75,8 +75,6 @@ const generatedRuntimeOwnerExports = new Set([
   "@vite-hub/rate-limit/runtime",
   "@vite-hub/sandbox/runtime/empty-registry",
   "@vite-hub/sandbox/runtime/provider-loader",
-  "@vite-hub/sandbox/runtime/providers/cloudflare",
-  "@vite-hub/sandbox/runtime/providers/vercel",
   "@vite-hub/sandbox/runtime/state",
   "@vite-hub/schedule/runtime/state",
   "@vite-hub/schedule/runtime/static",

--- a/playground/vite/build/vite-e2e.ts
+++ b/playground/vite/build/vite-e2e.ts
@@ -22,7 +22,7 @@ import { defaultCloudflareSandboxBinding, defaultCloudflareSandboxClassName, def
 import { resolveSandboxProject } from "../../../packages/sandbox/src/project.ts"
 import { discoverServerSandboxDefinitions } from "../../../packages/sandbox/src/discovery.ts"
 import { bundleSandboxDefinition } from "../../../packages/sandbox/src/bundle.ts"
-import { resolveSandboxFeatureConfig } from "../../../packages/sandbox/src/feature.ts"
+import { resolveSandboxFeatureConfig, sandboxProviderRuntimeExport } from "../../../packages/sandbox/src/feature.ts"
 import { finalizeCloudflareWranglerConfig } from "../../../packages/sandbox/src/internal/shared/cloudflare-wrangler.ts"
 import { normalizeWorkspaceOptions } from "../../../packages/workspace/src/config.ts"
 import { discoverViteWorkspaceDefinitions } from "../../../packages/workspace/src/build/discovery.ts"
@@ -664,10 +664,11 @@ function renderSandboxRegistryModule(definitions: Array<{ name: string, file: st
 }
 
 function renderSandboxProviderLoaderModule(file: string, provider: "cloudflare" | "vercel") {
+  const providerExport = sandboxProviderRuntimeExport(provider)
   const runtimeProviderFile = resolvePackageRuntime(sandboxPackageDir, `runtime/providers/${provider}`)
 
   return [
-    `import { resolveSandboxBox } from ${JSON.stringify(createImportPath(file, runtimeProviderFile))}`,
+    `import { ${providerExport} as resolveSandboxBox } from ${JSON.stringify(createImportPath(file, runtimeProviderFile))}`,
     "",
     "export async function loadSandboxRuntimeProvider(selectedProvider) {",
     `  if (selectedProvider !== ${JSON.stringify(provider)})`,


### PR DESCRIPTION
## Summary

- stop publishing `@vite-hub/sandbox/runtime/providers/cloudflare` and `@vite-hub/sandbox/runtime/providers/vercel`
- keep both provider artifacts in the internal runtime graph while preventing Vite Plus from regenerating their public exports
- remove the corresponding framework-distribution ownership exceptions without changing provider behavior

The older `sandbox/providers/*` duplicates were already removed in #746, so this stays at the remaining public-surface seam and does not add an adapter refactor.

## Verification

- `vp pack` in `packages/sandbox` (`publint` clean)
- `vp test` in `packages/sandbox` (15 files, 233 tests)
- `tsc --noEmit -p packages/sandbox/tsconfig.json`
- `vp run fallow:dead-code`
- built resolution proof: both public provider imports return `ERR_PACKAGE_PATH_NOT_EXPORTED`, while the provider artifacts and internal loader remain available
