### PR TITLE
fix(blob): unpublish bundled Vercel driver

### DIFF
--- a/packages/blob/package.json
+++ b/packages/blob/package.json
@@ -51,7 +51,6 @@
     "./drivers/supabase": "./dist/drivers/supabase.js",
     "./drivers/uploadthing": "./dist/drivers/uploadthing.js",
     "./drivers/vercel": "./dist/drivers/vercel.js",
-    "./drivers/vercel-bundled": "./dist/drivers/vercel-bundled.js",
     "./ensure": "./dist/ensure.js",
     "./errors": "./dist/errors.js",
     "./runtime/cloudflare-vite": "./dist/runtime/cloudflare-vite.js",

--- a/packages/blob/test/optional-peer.test.ts
+++ b/packages/blob/test/optional-peer.test.ts
@@ -32,3 +32,14 @@ describe("optional peer imports", () => {
     expect(built).not.toContain("@aws-sdk/")
   })
 })
+
+describe("package exports", () => {
+  it("keeps the bundled Vercel runtime internal", async () => {
+    const manifest = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8")) as {
+      exports: Record<string, string>
+    }
+
+    expect(manifest.exports).toHaveProperty("./drivers/vercel")
+    expect(manifest.exports).not.toHaveProperty("./drivers/vercel-bundled")
+  })
+})

--- a/packages/blob/test/vite-output.test.ts
+++ b/packages/blob/test/vite-output.test.ts
@@ -11,7 +11,7 @@ import { getProviderRuntimeModule, writeProviderDeploymentOutputs, type Composed
 import { toSafeAppName } from "@vite-hub/internal/build/user-entry"
 
 import { normalizeBlobOptions } from "../src/config.ts"
-import { createBundledVercelBlobDriver } from "../src/drivers/vercel-bundled.ts"
+import { createBundledVercelBlobDriver, createDriver as createInternalVercelBlobDriver } from "../src/drivers/vercel-bundled.ts"
 import { generateProviderOutputs, prepareProviderOutputs } from "../src/internal/vite-build.ts"
 
 const execFileAsync = promisify(execFile)
@@ -196,7 +196,7 @@ describe("Vite provider outputs", () => {
       statusText: "Forbidden",
     }))
     vi.stubGlobal("fetch", anonymousFetch)
-    const driver = createBundledVercelBlobDriver({
+    const driver = createInternalVercelBlobDriver({
       access: storeAccess,
       driver: "vercel-blob",
       token: "vercel_blob_rw_test",

--- a/packages/blob/vite.config.ts
+++ b/packages/blob/vite.config.ts
@@ -46,6 +46,11 @@ export default defineConfig({
       "src/virtual.ts",
     ],
     exports: {
+      customExports(exports) {
+        return Object.fromEntries(
+          Object.entries(exports).filter(([key]) => key !== "./drivers/vercel-bundled"),
+        );
+      },
       inlinedDependencies: false,
     },
     outExtensions: () => ({


### PR DESCRIPTION
Removes `@vite-hub/blob/drivers/vercel-bundled` from the package export map so ViteHub no longer presents its hosted dependency-closure strategy as a selectable Blob Driver. The implementation remains built because ViteHub selects it internally when `vercel-blob` runs in hosted Vercel output; the playground E2E source import is unchanged.

Adds a focused manifest regression. The Blob build and publint, package typecheck, public-export test, Nitro selector tests, isolated Vercel output test, and the Vite E2E Vercel build pass.

A full Blob sweep reached 150 passing tests; three temporary-output path cases failed under the linked dependency worktree, and the clean-consumer install timed out without network. The affected bundled-runtime and Vercel output paths were rerun directly and pass.