### PR TITLE
refactor(workspace): remove unreferenced package subpaths

### DIFF
--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -44,10 +44,6 @@
       "types": "./dist/ai.d.ts",
       "import": "./dist/ai.js"
     },
-    "./cli": {
-      "types": "./dist/cli.d.ts",
-      "import": "./dist/cli.js"
-    },
     "./cloudflare": {
       "types": "./dist/cloudflare.d.ts",
       "import": "./dist/cloudflare.js"
@@ -101,14 +97,6 @@
       "types": "./dist/runtime/assets.d.ts",
       "import": "./dist/runtime/assets.js"
     },
-    "./internal/runtime/empty-assets-registry": {
-      "types": "./dist/runtime/empty-assets-registry.d.ts",
-      "import": "./dist/runtime/empty-assets-registry.js"
-    },
-    "./internal/runtime/empty-registry": {
-      "types": "./dist/runtime/empty-registry.d.ts",
-      "import": "./dist/runtime/empty-registry.js"
-    },
     "./internal/runtime/hosted": {
       "types": "./dist/hosted.d.ts",
       "import": "./dist/hosted.js"
@@ -125,17 +113,9 @@
       "types": "./dist/runtime/workspace.d.ts",
       "import": "./dist/runtime/workspace.js"
     },
-    "./internal/stores/cloudflare-artifacts": {
-      "types": "./dist/providers/cloudflare/artifacts-store.d.ts",
-      "import": "./dist/providers/cloudflare/artifacts-store.js"
-    },
     "./internal/stores/github": {
       "types": "./dist/providers/github/store.d.ts",
       "import": "./dist/providers/github/store.js"
-    },
-    "./internal/stores/vercel-blob": {
-      "types": "./dist/providers/vercel/blob-store.d.ts",
-      "import": "./dist/providers/vercel/blob-store.js"
     }
   },
   "scripts": {

--- a/packages/workspace/test/package-exports.test.ts
+++ b/packages/workspace/test/package-exports.test.ts
@@ -1,0 +1,44 @@
+import { spawnSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+
+import { describe, expect, it } from "vitest"
+
+const workspaceRoot = fileURLToPath(new URL("..", import.meta.url))
+
+describe("workspace package exports", () => {
+  it("keeps generated registries private and removes unused public subpaths", () => {
+    const script = `
+      const removed = [
+        "@vite-hub/workspace/cli",
+        "@vite-hub/workspace/internal/runtime/empty-assets-registry",
+        "@vite-hub/workspace/internal/runtime/empty-registry",
+        "@vite-hub/workspace/internal/stores/cloudflare-artifacts",
+        "@vite-hub/workspace/internal/stores/vercel-blob",
+      ]
+
+      for (const specifier of removed) {
+        let error
+        try {
+          await import(specifier)
+        }
+        catch (cause) {
+          error = cause
+        }
+        if (error?.code !== "ERR_PACKAGE_PATH_NOT_EXPORTED") {
+          throw error || new Error(\`Expected \${specifier} to be private\`)
+        }
+      }
+
+      await import("#vitehub-workspace-assets-registry")
+      await import("#vitehub-workspace-registry")
+      await import("@vite-hub/workspace/cloudflare")
+      await import("@vite-hub/workspace/internal/runtime/hosted-vercel-blob")
+    `
+    const result = spawnSync(process.execPath, ["--input-type=module", "--eval", script], {
+      cwd: workspaceRoot,
+      encoding: "utf8",
+    })
+
+    expect(result.status, result.stderr).toBe(0)
+  })
+})

--- a/packages/workspace/test/public-api.test.ts
+++ b/packages/workspace/test/public-api.test.ts
@@ -111,7 +111,6 @@ describe("workspace public API", () => {
     const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"))
     const builtServer = await readFile(new URL("../dist/server.d.ts", import.meta.url), "utf8")
     const builtCollectionsClient = await readFile(new URL("../dist/collections/client.js", import.meta.url), "utf8")
-    const builtSandboxStore = await readFile(new URL("../dist/providers/vercel/blob-store.d.ts", import.meta.url), "utf8")
     const distDir = new URL("../dist/", import.meta.url)
     const distFiles = await readdir(distDir, { recursive: true })
     const declarations = (await Promise.all(distFiles
@@ -122,9 +121,7 @@ describe("workspace public API", () => {
       "source-metadata.js",
       "runtime/empty-assets-registry.js",
       "runtime/empty-registry.js",
-      "providers/cloudflare/artifacts-store.js",
       "providers/github/store.js",
-      "providers/vercel/blob-store.js",
     ].map(file => readFile(new URL(file, distDir), "utf8")))).join("\n")
     const effectImport = /(?:from\s*|import\s*(?:\(\s*)?)["']effect(?:\/[^"']*)?["']/
     const vueFreeBundles = (await Promise.all(["index.js", "server.js", "collections.js"]
@@ -148,7 +145,6 @@ describe("workspace public API", () => {
     expect(builtServer).toContain("from \"h3\"")
     expect(declarations).not.toContain("files-sdk")
     expect(declarations).not.toContain("@vercel/blob")
-    expect(builtSandboxStore).not.toContain("files-sdk")
     expect(declarations).not.toContain("@vite-hub/sandbox")
     expect(declarations).not.toMatch(effectImport)
     expect(effectFreeBundles).not.toMatch(effectImport)
@@ -159,7 +155,7 @@ describe("workspace public API", () => {
   it("keeps hosted runtime setup off the public Workspace surface", async () => {
     const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"))
     const hosted = await import("../src/hosted.ts")
-    const builtVercelBlobStore = await readFile(new URL("../dist/providers/vercel/blob-store.js", import.meta.url), "utf8")
+    const builtVercelBlobRuntime = await readFile(new URL("../dist/hosted-vercel-blob.js", import.meta.url), "utf8")
 
     expect(packageJson.exports).not.toHaveProperty("./hosted")
     expect(packageJson.exports).toHaveProperty("./internal/runtime/hosted")
@@ -169,10 +165,10 @@ describe("workspace public API", () => {
     expect(hosted).not.toHaveProperty("createCloudflareArtifactsWorkspaceStore")
     expect(hosted).not.toHaveProperty("createGitHubWorkspaceStore")
     expect(hosted).not.toHaveProperty("createVercelBlobWorkspaceStore")
-    expect(builtVercelBlobStore).not.toContain("files-sdk")
-    expect(builtVercelBlobStore).not.toContain('import("files-sdk/vercel-blob")')
-    expect(builtVercelBlobStore).not.toContain('import("@vercel/blob")')
-    expect(builtVercelBlobStore).not.toContain('from "@vercel/blob"')
+    expect(builtVercelBlobRuntime).not.toContain("files-sdk")
+    expect(builtVercelBlobRuntime).not.toContain('import("files-sdk/vercel-blob")')
+    expect(builtVercelBlobRuntime).not.toContain('import("@vercel/blob")')
+    expect(builtVercelBlobRuntime).not.toContain('from "@vercel/blob"')
   })
 
   it("uses the writable facade for synced reads and writes", async () => {

--- a/packages/workspace/test/public-api.test.ts
+++ b/packages/workspace/test/public-api.test.ts
@@ -14,6 +14,23 @@ import { setWorkspaceHostedStoreLoader, setWorkspaceRuntimeAssetsRegistry, setWo
 
 const tempDirs: string[] = []
 
+async function readBuiltSourceModule(sourcePath: string): Promise<string> {
+  const distDir = new URL("../dist/", import.meta.url)
+  const files = await readdir(distDir, { recursive: true })
+  const marker = `//#region ${sourcePath}`
+  const modules = await Promise.all(
+    files.filter(file => file.endsWith(".js"))
+      .map(file => readFile(new URL(file, distDir), "utf8")),
+  )
+  const matches = modules.filter(content => content.includes(marker))
+
+  if (matches.length !== 1) {
+    throw new Error(`Expected one built module for ${sourcePath}, found ${matches.length}`)
+  }
+
+  return matches[0]
+}
+
 async function createRoot() {
   const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-api-"))
   tempDirs.push(root)
@@ -111,6 +128,7 @@ describe("workspace public API", () => {
     const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"))
     const builtServer = await readFile(new URL("../dist/server.d.ts", import.meta.url), "utf8")
     const builtCollectionsClient = await readFile(new URL("../dist/collections/client.js", import.meta.url), "utf8")
+    const builtCloudflareArtifactsStore = await readBuiltSourceModule("src/providers/cloudflare/artifacts-store.ts")
     const distDir = new URL("../dist/", import.meta.url)
     const distFiles = await readdir(distDir, { recursive: true })
     const declarations = (await Promise.all(distFiles
@@ -148,6 +166,7 @@ describe("workspace public API", () => {
     expect(declarations).not.toContain("@vite-hub/sandbox")
     expect(declarations).not.toMatch(effectImport)
     expect(effectFreeBundles).not.toMatch(effectImport)
+    expect(builtCloudflareArtifactsStore).not.toMatch(effectImport)
     expect(vueFreeBundles).not.toMatch(/from\s*["']vue["']/)
     expect(builtCollectionsClient).toMatch(/from\s*["']vue["']/)
   })
@@ -155,7 +174,7 @@ describe("workspace public API", () => {
   it("keeps hosted runtime setup off the public Workspace surface", async () => {
     const packageJson = JSON.parse(await readFile(new URL("../package.json", import.meta.url), "utf8"))
     const hosted = await import("../src/hosted.ts")
-    const builtVercelBlobRuntime = await readFile(new URL("../dist/hosted-vercel-blob.js", import.meta.url), "utf8")
+    const builtVercelBlobStore = await readBuiltSourceModule("src/providers/vercel/blob-store.ts")
 
     expect(packageJson.exports).not.toHaveProperty("./hosted")
     expect(packageJson.exports).toHaveProperty("./internal/runtime/hosted")
@@ -165,10 +184,10 @@ describe("workspace public API", () => {
     expect(hosted).not.toHaveProperty("createCloudflareArtifactsWorkspaceStore")
     expect(hosted).not.toHaveProperty("createGitHubWorkspaceStore")
     expect(hosted).not.toHaveProperty("createVercelBlobWorkspaceStore")
-    expect(builtVercelBlobRuntime).not.toContain("files-sdk")
-    expect(builtVercelBlobRuntime).not.toContain('import("files-sdk/vercel-blob")')
-    expect(builtVercelBlobRuntime).not.toContain('import("@vercel/blob")')
-    expect(builtVercelBlobRuntime).not.toContain('from "@vercel/blob"')
+    expect(builtVercelBlobStore).not.toContain("files-sdk")
+    expect(builtVercelBlobStore).not.toContain('import("files-sdk/vercel-blob")')
+    expect(builtVercelBlobStore).not.toContain('import("@vercel/blob")')
+    expect(builtVercelBlobStore).not.toContain('from "@vercel/blob"')
   })
 
   it("uses the writable facade for synced reads and writes", async () => {

--- a/packages/workspace/vite.config.ts
+++ b/packages/workspace/vite.config.ts
@@ -19,7 +19,6 @@ export default defineConfig({
     entry: [
       "src/ai.ts",
       "src/cloudflare.ts",
-      "src/cli.ts",
       "src/collections.ts",
       "src/collections/client.ts",
       "src/hosted.ts",
@@ -37,9 +36,7 @@ export default defineConfig({
       "src/runtime/assets.ts",
       "src/runtime/state.ts",
       "src/server.ts",
-      "src/providers/cloudflare/artifacts-store.ts",
       "src/providers/github/store.ts",
-      "src/providers/vercel/blob-store.ts",
       "src/test.ts",
       "src/vite.ts",
     ],
@@ -52,23 +49,15 @@ export default defineConfig({
         "runtime/empty-registry",
         "runtime/state",
         "runtime/workspace",
-        "providers/cloudflare/artifacts-store",
         "providers/github/store",
-        "providers/vercel/blob-store",
       ],
       customExports(exports) {
         exports["./internal/runtime/assets"] = "./dist/runtime/assets.js";
-        exports["./internal/runtime/empty-assets-registry"] =
-          "./dist/runtime/empty-assets-registry.js";
-        exports["./internal/runtime/empty-registry"] = "./dist/runtime/empty-registry.js";
         exports["./internal/runtime/hosted"] = "./dist/hosted.js";
         exports["./internal/runtime/hosted-vercel-blob"] = "./dist/hosted-vercel-blob.js";
         exports["./internal/runtime/state"] = "./dist/runtime/state.js";
         exports["./internal/runtime/workspace"] = "./dist/runtime/workspace.js";
-        exports["./internal/stores/cloudflare-artifacts"] =
-          "./dist/providers/cloudflare/artifacts-store.js";
         exports["./internal/stores/github"] = "./dist/providers/github/store.js";
-        exports["./internal/stores/vercel-blob"] = "./dist/providers/vercel/blob-store.js";
 
         return Object.fromEntries(
           Object.entries(exports).map(([key, value]) => {


### PR DESCRIPTION
Removes five unreferenced `@vite-hub/workspace` package subpaths and their direct pack entries before 1.0. The CLI and provider stores remain internal relative dependencies, while the two generated registries keep their private `#vitehub-workspace-*` imports and built files without remaining publicly importable.

The broader audit was intentionally deferred where current main has live or generated consumers: Source subpaths are imported and documented, Sandbox paths are generated runtimes, the bundled Vercel Blob driver is resolved dynamically, and Internal is a separate package seam. Validated with Workspace pack/publint, package typecheck, the full 469-test runtime suite, and built package-resolution proof for both removed and retained paths.