### PR TITLE
fix(workspace): explain missing shell runtime

### DIFF
--- a/packages/workspace/src/runtime/dependency-loaders.ts
+++ b/packages/workspace/src/runtime/dependency-loaders.ts
@@ -1,3 +1,5 @@
+import { workspaceError } from "../core/errors.ts"
+
 const shellWorkspaceSpecifier = "@vite-hub/shell/workspace"
 
 export interface WorkspaceDependencyRuntimeLoaders {
@@ -28,6 +30,25 @@ export function getWorkspaceDependencyRuntimeLoaders(): WorkspaceDependencyRunti
   return workspaceDependencyRuntimeLoadersGlobal()[workspaceDependencyRuntimeLoadersKey()] ?? defaultWorkspaceDependencyRuntimeLoaders
 }
 
-export function loadWorkspaceShellModule(): Promise<unknown> {
-  return getWorkspaceDependencyRuntimeLoaders().shellWorkspace()
+export async function loadWorkspaceShellModule(): Promise<unknown> {
+  try {
+    return await getWorkspaceDependencyRuntimeLoaders().shellWorkspace()
+  }
+  catch (error) {
+    if (isMissingWorkspaceShellError(error)) {
+      throw workspaceError("[vitehub] Install @vite-hub/shell to use Workspace Tools shell commands.", { cause: error })
+    }
+    throw error
+  }
+}
+
+function isMissingWorkspaceShellError(error: unknown) {
+  if (!(error instanceof Error)) return false
+  const code = (error as { code?: unknown }).code
+  if (code !== "ERR_MODULE_NOT_FOUND" && code !== "MODULE_NOT_FOUND") return false
+  return error.message.includes("Cannot find package '@vite-hub/shell'")
+    || error.message.includes("Cannot find module '@vite-hub/shell'")
+    || error.message.includes("Cannot find module '@vite-hub/shell/workspace'")
+    || (error.message.includes("tried to access @vite-hub/shell")
+      && (error.message.includes("isn't declared") || error.message.includes("isn't provided")))
 }

--- a/packages/workspace/test/dependency-runtime-loaders.test.ts
+++ b/packages/workspace/test/dependency-runtime-loaders.test.ts
@@ -26,4 +26,52 @@ describe("workspace dependency runtime loaders", () => {
     expect(getWorkspaceDependencyRuntimeLoaders()).toEqual(loaders)
     await expect(loadWorkspaceShellModule()).resolves.toBe(shellWorkspace)
   })
+
+  it("directs consumers to install the missing shell runtime", async () => {
+    const cause = Object.assign(new Error("Cannot find package '@vite-hub/shell' imported from /consumer/node_modules/@vite-hub/workspace/dist/dependency-loaders.js"), {
+      code: "ERR_MODULE_NOT_FOUND",
+    })
+    setWorkspaceDependencyRuntimeLoaders({
+      shellWorkspace: async () => {
+        throw cause
+      },
+    })
+
+    await expect(loadWorkspaceShellModule()).rejects.toMatchObject({
+      cause,
+      code: "WORKSPACE_FAILED",
+      message: "[vitehub] Install @vite-hub/shell to use Workspace Tools shell commands.",
+      name: "ViteHubError",
+    })
+  })
+
+  it("recognizes a missing shell runtime under Yarn PnP", async () => {
+    const cause = Object.assign(new Error("@vite-hub/workspace tried to access @vite-hub/shell, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound."), {
+      code: "MODULE_NOT_FOUND",
+    })
+    setWorkspaceDependencyRuntimeLoaders({
+      shellWorkspace: async () => {
+        throw cause
+      },
+    })
+
+    await expect(loadWorkspaceShellModule()).rejects.toMatchObject({
+      cause,
+      code: "WORKSPACE_FAILED",
+      message: "[vitehub] Install @vite-hub/shell to use Workspace Tools shell commands.",
+    })
+  })
+
+  it("preserves shell runtime initialization failures", async () => {
+    const cause = Object.assign(new Error("Cannot find module '@vite-hub/shell-plugin' required by /consumer/node_modules/@vite-hub/shell/dist/workspace.js"), {
+      code: "ERR_MODULE_NOT_FOUND",
+    })
+    setWorkspaceDependencyRuntimeLoaders({
+      shellWorkspace: async () => {
+        throw cause
+      },
+    })
+
+    await expect(loadWorkspaceShellModule()).rejects.toBe(cause)
+  })
 })

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -170,9 +170,10 @@ async function assertPackedPackage(tarball: string, framework: boolean) {
   }
 }
 
-async function packWorkspacePackages(packDir: string) {
+async function packWorkspacePackages(packDir: string, packageNames?: Set<string>) {
   const specs: Record<string, string> = {}
-  const infos = listWorkspacePackageInfos(repoRoot).filter(info => !info.private)
+  const infos = listWorkspacePackageInfos(repoRoot)
+    .filter(info => !info.private && (!packageNames || packageNames.has(info.packageName)))
 
   for (const info of infos) {
     const source = JSON.parse(await readFile(join(info.dir, "package.json"), "utf8")) as PackageManifest
@@ -388,6 +389,66 @@ async function assertVercelRuntimeImportsResolveInside(
 }
 
 describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-hub consumer contract", () => {
+  it("reports the missing Workspace shell runtime from a packed consumer", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vite-hub-workspace-consumer-"))
+    const appDir = join(root, "app")
+    const packDir = join(root, "packs")
+
+    try {
+      await Promise.all([
+        mkdir(appDir, { recursive: true }),
+        mkdir(packDir, { recursive: true }),
+      ])
+      const specs = await packWorkspacePackages(packDir, new Set([
+        "@vite-hub/box",
+        "@vite-hub/markdown-template",
+        "@vite-hub/runtime",
+        "@vite-hub/source",
+        "@vite-hub/workspace",
+      ]))
+      await Promise.all([
+        writeFile(join(appDir, "package.json"), JSON.stringify({
+          dependencies: {
+            "@vite-hub/workspace": specs["@vite-hub/workspace"],
+            ai: "7.0.19",
+          },
+          private: true,
+          type: "module",
+        }, null, 2), "utf8"),
+        writeFile(join(appDir, "pnpm-workspace.yaml"), workspaceConfig(specs), "utf8"),
+      ])
+      await run("pnpm", ["install", "--no-hoist", "--strict-peer-dependencies"], appDir)
+      const missingShell = await run("node", ["--input-type=module", "--eval", `
+        import { createWorkspaceTools } from "@vite-hub/workspace/ai"
+        let shellResolved = true
+        try { import.meta.resolve("@vite-hub/shell") } catch { shellResolved = false }
+        try {
+          await createWorkspaceTools({}).shell.execute({ command: "pwd" })
+          throw new Error("Workspace shell unexpectedly loaded")
+        }
+        catch (error) {
+          process.stdout.write(JSON.stringify({
+            causeCode: error.cause?.code,
+            code: error.code,
+            message: error.message,
+            name: error.name,
+            shellResolved,
+          }))
+        }
+      `], appDir)
+      expect(JSON.parse(missingShell.stdout)).toEqual({
+        causeCode: "ERR_MODULE_NOT_FOUND",
+        code: "WORKSPACE_FAILED",
+        message: "[vitehub] Install @vite-hub/shell to use Workspace Tools shell commands.",
+        name: "ViteHubError",
+        shellResolved: false,
+      })
+    }
+    finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  }, 120_000)
+
   it("installs, typechecks, builds, and runs without workspace or hoisting access", async () => {
     const root = await mkdtemp(join(tmpdir(), "vite-hub-consumer-"))
     const appDir = join(root, "app")


### PR DESCRIPTION
## Summary

- translate a missing optional Shell runtime into an actionable ViteHub error
- preserve the external dynamic-import boundary
- recognize Node and Yarn PnP missing-peer diagnostics
- cover the loader and packed Workspace consumer contract

## Verification

- Workspace build and typecheck
- 36 files and 473 tests
- packed-artifact runtime proof
- full consumer and provider CI