### PR TITLE
refactor(source): remove redundant source subpaths

### DIFF
--- a/docs/content/docs/reference/index.md
+++ b/docs/content/docs/reference/index.md
@@ -38,7 +38,7 @@ instead of one root barrel.
 | `@vite-hub/sandbox` | Sandbox Definitions, Sandbox Runs, Sandbox Provider integration | `@vite-hub/sandbox`, `@vite-hub/sandbox/vite` |
 | `@vite-hub/schedule` | Static schedules, runtime schedules, Schedule Targets, cron Provider Output | `@vite-hub/schedule`, `@vite-hub/schedule/runtime`, `@vite-hub/schedule/vite` |
 | `@vite-hub/shell` | Shell-shaped runtime execution providers and Workspace shell integration helpers | `@vite-hub/shell`, `@vite-hub/shell/workspace` |
-| `@vite-hub/source` | Source Definitions and Source Loaders for file, glob, markdown, GitHub, custom, and MCP resource retrieval | `@vite-hub/source`, `@vite-hub/source/sources/*` |
+| `@vite-hub/source` | Source Definitions and Source Loaders for file, glob, markdown, GitHub, custom, and MCP resource retrieval | `@vite-hub/source` |
 | `@vite-hub/workflow` | Workflow Definitions, durable run state, step execution, provider workflow output | `@vite-hub/workflow`, `@vite-hub/workflow/vite` |
 | `@vite-hub/workspace` | Workspace Definitions, Workspace Stores, Source Bindings, Workspace runtime facades, Workspace extensions | `@vite-hub/workspace`, `@vite-hub/workspace/vite`, `@vite-hub/workspace/runtime` |
 

--- a/docs/content/docs/server-primitives/source.md
+++ b/docs/content/docs/server-primitives/source.md
@@ -53,7 +53,6 @@ export default defineEventHandler(() => {
 | `useSource` from `@vite-hub/source` | Read from a registered Source at runtime. |
 | `file`, `glob`, `github`, `markdown`, `mcpResources`, `custom` from `@vite-hub/source` | Create built-in Source loaders. |
 | `getViteHubErrorShape` from `@vite-hub/runtime` | Inspect registry, path, and loader failures by `SOURCE_*` code. |
-| `@vite-hub/source/sources/*` subpaths | Import one loader directly when you want narrower dependencies. |
 
 Source, Source Reader, Source Item, loader option, cache, search, and error types are exported from `@vite-hub/source`.
 

--- a/packages/source/package.json
+++ b/packages/source/package.json
@@ -30,34 +30,6 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
-    "./sources": {
-      "types": "./dist/sources/index.d.ts",
-      "import": "./dist/sources/index.js"
-    },
-    "./sources/custom": {
-      "types": "./dist/sources/custom.d.ts",
-      "import": "./dist/sources/custom.js"
-    },
-    "./sources/file": {
-      "types": "./dist/sources/file.d.ts",
-      "import": "./dist/sources/file.js"
-    },
-    "./sources/github": {
-      "types": "./dist/sources/github.d.ts",
-      "import": "./dist/sources/github.js"
-    },
-    "./sources/glob": {
-      "types": "./dist/sources/glob.d.ts",
-      "import": "./dist/sources/glob.js"
-    },
-    "./sources/markdown": {
-      "types": "./dist/sources/markdown.d.ts",
-      "import": "./dist/sources/markdown.js"
-    },
-    "./sources/mcp-resources": {
-      "types": "./dist/sources/mcp-resources.d.ts",
-      "import": "./dist/sources/mcp-resources.js"
-    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/source/src/index.ts
+++ b/packages/source/src/index.ts
@@ -17,7 +17,9 @@ export {
   mcpResources,
 } from "./sources/index.ts"
 export type {
+  FileSourceInlineOptions,
   FileSourceOptions,
+  FileSourcePathOptions,
   GitHubSourceOptions,
   GlobSourceOptions,
   McpResourceContent,
@@ -27,4 +29,5 @@ export type {
   McpResourcesRequestOptions,
   McpResourcesServer,
   McpResourcesSourceOptions,
+  McpResourcesTransportConfig,
 } from "./sources/index.ts"

--- a/packages/source/src/index.ts
+++ b/packages/source/src/index.ts
@@ -16,7 +16,6 @@ export {
   markdown,
   mcpResources,
 } from "./sources/index.ts"
-export * as source from "./sources/index.ts"
 export type {
   FileSourceOptions,
   GitHubSourceOptions,

--- a/packages/source/src/sources/github.ts
+++ b/packages/source/src/sources/github.ts
@@ -1,2 +1,0 @@
-export { github } from "./github/index.ts"
-export type { GitHubSourceOptions } from "./github/types.ts"

--- a/packages/source/src/sources/index.ts
+++ b/packages/source/src/sources/index.ts
@@ -1,6 +1,10 @@
 export { custom } from "./custom.ts"
 export { file } from "./file.ts"
-export type { FileSourceOptions } from "./file.ts"
+export type {
+  FileSourceInlineOptions,
+  FileSourceOptions,
+  FileSourcePathOptions,
+} from "./file.ts"
 export { github } from "./github/index.ts"
 export type { GitHubSourceOptions } from "./github/types.ts"
 export { glob } from "./glob.ts"
@@ -15,4 +19,5 @@ export type {
   McpResourcesRequestOptions,
   McpResourcesServer,
   McpResourcesSourceOptions,
+  McpResourcesTransportConfig,
 } from "./mcp-resources.ts"

--- a/packages/source/test/package.test.ts
+++ b/packages/source/test/package.test.ts
@@ -4,15 +4,6 @@ import { verifyBuiltPackageExports } from "../../internal/test-utils/built-packa
 
 describe("@vite-hub/source package contract", () => {
   it("loads documented exports from built package targets", async () => {
-    await verifyBuiltPackageExports(new URL("../", import.meta.url), "@vite-hub/source", [
-      ".",
-      "./sources",
-      "./sources/custom",
-      "./sources/file",
-      "./sources/github",
-      "./sources/glob",
-      "./sources/markdown",
-      "./sources/mcp-resources",
-    ])
+    await verifyBuiltPackageExports(new URL("../", import.meta.url), "@vite-hub/source", ["."])
   })
 })

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -8,7 +8,6 @@ import {
   github,
   mcpResources,
   registerSources,
-  source,
   type Source,
   type SourceData,
   type SourceItem,
@@ -50,7 +49,7 @@ describe("@vite-hub/source types", () => {
   it("types registered source names and keys", async () => {
     const staticSource = file({ content: "# Docs\n", workspacePath: "README.md" })
     expectTypeOf(file({ content: "# Docs\n", workspacePath: "README.md" })).toMatchTypeOf<Source<"README.md">>()
-    expectTypeOf(source.github({ auth: false, repo: "acme/app" })).toMatchTypeOf<Source>()
+    expectTypeOf(github({ auth: false, repo: "acme/app" })).toMatchTypeOf<Source>()
     expectTypeOf(mcpResources({ server: {
       async listResources() {
         return { resources: [] }

--- a/packages/source/vite.config.ts
+++ b/packages/source/vite.config.ts
@@ -6,16 +6,7 @@ export default defineConfig({
     deps: {
       alwaysBundle: [/^@vite-hub\/internal/],
     },
-    entry: [
-      "src/index.ts",
-      "src/sources/custom.ts",
-      "src/sources/file.ts",
-      "src/sources/github.ts",
-      "src/sources/glob.ts",
-      "src/sources/index.ts",
-      "src/sources/markdown.ts",
-      "src/sources/mcp-resources.ts",
-    ],
+    entry: ["src/index.ts"],
     exports: {
       customExports(exports) {
         return Object.fromEntries(

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -28,13 +28,6 @@ const forwarderExportLine = /^export (?:type )?(?:\*|\{[^}]+\}) from "([^"]+)"$/
 
 const consolidatedOwnerExports = new Set([
   "@vite-hub/blob/ensure",
-  "@vite-hub/source/sources",
-  "@vite-hub/source/sources/custom",
-  "@vite-hub/source/sources/file",
-  "@vite-hub/source/sources/github",
-  "@vite-hub/source/sources/glob",
-  "@vite-hub/source/sources/markdown",
-  "@vite-hub/source/sources/mcp-resources",
   "@vite-hub/workspace/ai",
 ])
 

--- a/packages/workspace/src/sources/file.ts
+++ b/packages/workspace/src/sources/file.ts
@@ -1,4 +1,4 @@
-import { file as createFileSource, type FileSourceOptions as SourcePackageFileSourceOptions } from "@vite-hub/source/sources/file"
+import { file as createFileSource, type FileSourceOptions as SourcePackageFileSourceOptions } from "@vite-hub/source"
 
 import { normalizeSafeWorkspacePath } from "../core/path.ts"
 import { withWorkspaceRuntimeOptions } from "./runtime-options.ts"

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -1,5 +1,5 @@
 import { getActiveCloudflareBinding } from "@vite-hub/internal/runtime/cloudflare-env"
-import { github as createGitHubSource, type GitHubSourceOptions as SourcePackageGitHubSourceOptions } from "@vite-hub/source/sources/github"
+import { github as createGitHubSource, type GitHubSourceOptions as SourcePackageGitHubSourceOptions } from "@vite-hub/source"
 
 import { withWorkspaceRuntimeOptions } from "./runtime-options.ts"
 import { resolveWorkspaceEnv } from "../env.ts"

--- a/packages/workspace/src/sources/glob.ts
+++ b/packages/workspace/src/sources/glob.ts
@@ -1,4 +1,4 @@
-import { glob as createGlobSource, type GlobSourceOptions as SourcePackageGlobSourceOptions } from "@vite-hub/source/sources/glob"
+import { glob as createGlobSource, type GlobSourceOptions as SourcePackageGlobSourceOptions } from "@vite-hub/source"
 
 import { withWorkspaceRuntimeOptions } from "./runtime-options.ts"
 

--- a/packages/workspace/src/sources/markdown.ts
+++ b/packages/workspace/src/sources/markdown.ts
@@ -1,4 +1,4 @@
-import { markdown as createMarkdownSource } from "@vite-hub/source/sources/markdown"
+import { markdown as createMarkdownSource } from "@vite-hub/source"
 
 import { normalizeSafeWorkspacePath } from "../core/path.ts"
 import { withWorkspaceRuntimeOptions } from "./runtime-options.ts"

--- a/packages/workspace/src/sources/mcp-resources.ts
+++ b/packages/workspace/src/sources/mcp-resources.ts
@@ -1,4 +1,4 @@
-import { mcpResources as createMcpResourcesSource } from "@vite-hub/source/sources/mcp-resources"
+import { mcpResources as createMcpResourcesSource, type McpResourcesSourceOptions as SourcePackageMcpResourcesSourceOptions } from "@vite-hub/source"
 
 import { normalizeSafeWorkspacePath } from "../core/path.ts"
 import { markLiveWorkspaceSource } from "./live.ts"
@@ -7,7 +7,6 @@ import { withWorkspaceRuntimeOptions } from "./runtime-options.ts"
 
 import type { ExactOptions, WorkspaceSourceRuntimeOptions } from "./runtime-options.ts"
 import type { WorkspaceSource } from "../core/types.ts"
-import type { McpResourcesSourceOptions as SourcePackageMcpResourcesSourceOptions } from "@vite-hub/source/sources/mcp-resources"
 
 export interface McpResourcesSourceOptions<TKey extends string = string>
   extends Omit<SourcePackageMcpResourcesSourceOptions<TKey>, "cache">, WorkspaceSourceRuntimeOptions {}
@@ -57,4 +56,4 @@ export type {
   McpResourcesClientConfig,
   McpResourcesRequestOptions,
   McpResourcesServer,
-} from "@vite-hub/source/sources/mcp-resources"
+} from "@vite-hub/source"


### PR DESCRIPTION
## Summary

- make the Source root export the single supported factory import surface
- migrate remaining Workspace imports and remove the redundant namespace
- update package classification and documentation without changing retrieval behavior

## Verification

- Source, Workspace, and aggregate builds with publint
- Source and Workspace typechecks
- 463 Workspace tests and 54 Source tests
- built-artifact export inspection
- independent review