### PR TITLE
refactor(workspace): deduplicate source adapters

### DIFF
--- a/docs/content/docs/server-primitives/source.md
+++ b/docs/content/docs/server-primitives/source.md
@@ -213,7 +213,7 @@ export default defineWorkspace({
 })
 ```
 
-The Source Package owns retrieval. The Workspace Package owns Mount placement, Source-Backed Paths, Source Sync Policy, low-level Source Instruction metadata, and Workspace Store reconciliation.
+`glob()` and the other shared loader names intentionally exist in both packages. Import them from `@vite-hub/source` for direct retrieval through `useSource()`; import them from `@vite-hub/workspace` when retrieved items should become Workspace Source Bindings governed by mount placement, materialization, sync, validation, resolution, views, fetches, and Workspace-scoped registries.
 
 ## Provider output
 

--- a/packages/workspace/src/sources/custom.ts
+++ b/packages/workspace/src/sources/custom.ts
@@ -3,15 +3,14 @@ import { lookup } from "mrmime"
 import { workspaceError } from "../core/errors.ts"
 import { normalizeSafeWorkspacePath } from "../core/path.ts"
 
+import type { ExactOptions, WorkspaceSourceRuntimeOptions } from "./runtime-options.ts"
 import type { MaybePromise, SourceContext, WorkspaceContent, WorkspaceSource, WorkspaceSourceItem } from "../core/types.ts"
 
-type ExactOptions<TInput, TShape> = TInput & Record<Exclude<keyof TInput, keyof TShape>, never>
-type WorkspaceSourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "materialize" | "mount" | "probeKeys" | "sync" | "validate">
 type CustomWorkspaceSourceFile = Omit<WorkspaceSourceItem, "content" | "contentStream" | "key" | "path"> & {
   content: WorkspaceContent | ((context: SourceContext) => MaybePromise<WorkspaceContent>)
   path: string
 }
-type CustomWorkspaceSourceFiles = WorkspaceSourceRuntimeOptions & {
+type CustomWorkspaceSourceFiles = WorkspaceSourceRuntimeOptions & Pick<WorkspaceSource, "probeKeys"> & {
   files: readonly CustomWorkspaceSourceFile[]
 }
 

--- a/packages/workspace/src/sources/file.ts
+++ b/packages/workspace/src/sources/file.ts
@@ -1,13 +1,14 @@
 import { file as createFileSource, type FileSourceOptions as SourcePackageFileSourceOptions } from "@vite-hub/source/sources/file"
 
 import { normalizeSafeWorkspacePath } from "../core/path.ts"
+import { withWorkspaceRuntimeOptions } from "./runtime-options.ts"
 
+import type { ExactOptions, WorkspaceSourceRuntimeOptions } from "./runtime-options.ts"
 import type { WorkspaceSource } from "../core/types.ts"
 
-type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "materialize" | "mount" | "probeKeys" | "sync" | "validate">
-type ExactOptions<TInput, TShape> = TInput & Record<Exclude<keyof TInput, keyof TShape>, never>
+type FileWorkspaceSourceRuntimeOptions = WorkspaceSourceRuntimeOptions & Pick<WorkspaceSource, "probeKeys">
 
-export type FileSourceOptions<TKey extends string = string> = SourcePackageFileSourceOptions<TKey> & SourceRuntimeOptions
+export type FileSourceOptions<TKey extends string = string> = SourcePackageFileSourceOptions<TKey> & FileWorkspaceSourceRuntimeOptions
 export type FileSourceInput<TKey extends string = string> = FileSourceOptions<TKey> | TKey
 
 export function file<const TKey extends string>(input: TKey): WorkspaceSource
@@ -20,12 +21,7 @@ export function file<const TKey extends string = string>(input: FileSourceInput<
     : options.mount ?? ""
   const source = createFileSource(options)
   return {
-    ...source,
-    cache: options.cache,
-    materialize: options.materialize,
-    mount,
+    ...withWorkspaceRuntimeOptions(source, { ...options, mount }),
     probeKeys: options.probeKeys || [key],
-    sync: options.sync,
-    validate: options.validate,
   }
 }

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -1,17 +1,17 @@
 import { getActiveCloudflareBinding } from "@vite-hub/internal/runtime/cloudflare-env"
 import { github as createGitHubSource, type GitHubSourceOptions as SourcePackageGitHubSourceOptions } from "@vite-hub/source/sources/github"
 
+import { withWorkspaceRuntimeOptions } from "./runtime-options.ts"
 import { resolveWorkspaceEnv } from "../env.ts"
 import { processEnv, resolveGitHubTokenOption } from "../providers/github/shared.ts"
+import type { ExactOptions, WorkspaceSourceRuntimeOptions } from "./runtime-options.ts"
 import type { MaybePromise, WorkspaceSource, WorkspaceSourceResolutionContext } from "../core/types.ts"
 
-type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "materialize" | "mount" | "sync" | "validate">
-type ExactOptions<TInput, TShape> = TInput & Record<Exclude<keyof TInput, keyof TShape>, never>
 type GitHubAuth = NonNullable<SourcePackageGitHubSourceOptions["auth"]>
 type GitHubResolvedSourceOptions = Omit<GitHubSourceOptions, "repo"> & Partial<Pick<GitHubSourceOptions, "repo">>
 const githubTokenEnvNames = ["WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"] as const
 
-export interface GitHubSourceOptions extends Omit<SourcePackageGitHubSourceOptions, "auth">, SourceRuntimeOptions {
+export interface GitHubSourceOptions extends Omit<SourcePackageGitHubSourceOptions, "auth">, WorkspaceSourceRuntimeOptions {
   auth?: GitHubAuth
 }
 
@@ -47,9 +47,8 @@ export function github(input: GitHubSourceInput): WorkspaceSource {
     return source
   }
 
-  return {
+  return withWorkspaceRuntimeOptions({
     ...baseSource,
-    cache: resolvedOptions.cache,
     fingerprint: {
       exclude: resolvedOptions.exclude,
       include: resolvedOptions.include,
@@ -57,10 +56,6 @@ export function github(input: GitHubSourceInput): WorkspaceSource {
       repo: resolvedOptions.repo,
       root: resolvedOptions.root,
     },
-    materialize: resolvedOptions.materialize,
-    mount: resolvedOptions.mount,
-    sync: resolvedOptions.sync,
-    validate: resolvedOptions.validate,
     async prepare(ctx) {
       const source = await getSourceForRoot(ctx.rootDir)
       await source.prepare?.(ctx)
@@ -85,7 +80,7 @@ export function github(input: GitHubSourceInput): WorkspaceSource {
       const source = await getSourceForRoot(ctx.rootDir)
       return await source.search?.(query, ctx) ?? []
     },
-  }
+  }, resolvedOptions)
 }
 
 function resolvableGitHubSource(resolve: GitHubSourceResolver): WorkspaceSource {

--- a/packages/workspace/src/sources/glob.ts
+++ b/packages/workspace/src/sources/glob.ts
@@ -1,25 +1,18 @@
 import { glob as createGlobSource, type GlobSourceOptions as SourcePackageGlobSourceOptions } from "@vite-hub/source/sources/glob"
 
+import { withWorkspaceRuntimeOptions } from "./runtime-options.ts"
+
+import type { ExactOptions, WorkspaceSourceRuntimeOptions } from "./runtime-options.ts"
 import type { WorkspaceSource } from "../core/types.ts"
 
-type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "materialize" | "mount" | "sync" | "validate">
-type ExactOptions<TInput, TShape> = TInput & Record<Exclude<keyof TInput, keyof TShape>, never>
-
-export type GlobSourceOptions = SourcePackageGlobSourceOptions & SourceRuntimeOptions
+export type GlobSourceOptions = SourcePackageGlobSourceOptions & WorkspaceSourceRuntimeOptions
 
 export function glob<const TOptions extends GlobSourceOptions>(options: ExactOptions<TOptions, GlobSourceOptions>): WorkspaceSource {
   const source = createGlobSource({
     ...options,
     keyCache: options.keyCache ?? !isLazySource(options),
   })
-  return {
-    ...source,
-    cache: options.cache,
-    materialize: options.materialize,
-    mount: options.mount,
-    sync: options.sync,
-    validate: options.validate,
-  }
+  return withWorkspaceRuntimeOptions(source, options)
 }
 
 function isLazySource(options: GlobSourceOptions) {

--- a/packages/workspace/src/sources/markdown.ts
+++ b/packages/workspace/src/sources/markdown.ts
@@ -1,6 +1,7 @@
 import { markdown as createMarkdownSource } from "@vite-hub/source/sources/markdown"
 
 import { normalizeSafeWorkspacePath } from "../core/path.ts"
+import { withWorkspaceRuntimeOptions } from "./runtime-options.ts"
 
 import type { FileSourceOptions } from "./file.ts"
 import type { WorkspaceSource } from "../core/types.ts"
@@ -9,12 +10,7 @@ export function markdown(options: FileSourceOptions): WorkspaceSource {
   const key = normalizeSafeWorkspacePath(options.workspacePath || options.path || "")
   const source = createMarkdownSource(options)
   return {
-    ...source,
-    cache: options.cache,
-    materialize: options.materialize,
-    mount: options.mount,
+    ...withWorkspaceRuntimeOptions(source, options),
     probeKeys: options.probeKeys || [key],
-    sync: options.sync,
-    validate: options.validate,
   }
 }

--- a/packages/workspace/src/sources/mcp-resources.ts
+++ b/packages/workspace/src/sources/mcp-resources.ts
@@ -3,15 +3,14 @@ import { mcpResources as createMcpResourcesSource } from "@vite-hub/source/sourc
 import { normalizeSafeWorkspacePath } from "../core/path.ts"
 import { markLiveWorkspaceSource } from "./live.ts"
 import { registerMcpResourcesSourceLoader } from "./mcp-resources-loader.ts"
+import { withWorkspaceRuntimeOptions } from "./runtime-options.ts"
 
+import type { ExactOptions, WorkspaceSourceRuntimeOptions } from "./runtime-options.ts"
 import type { WorkspaceSource } from "../core/types.ts"
 import type { McpResourcesSourceOptions as SourcePackageMcpResourcesSourceOptions } from "@vite-hub/source/sources/mcp-resources"
 
-type SourceRuntimeOptions = Pick<WorkspaceSource, "cache" | "materialize" | "mount" | "sync" | "validate">
-type ExactOptions<TInput, TShape> = TInput & Record<Exclude<keyof TInput, keyof TShape>, never>
-
 export interface McpResourcesSourceOptions<TKey extends string = string>
-  extends Omit<SourcePackageMcpResourcesSourceOptions<TKey>, "cache">, SourceRuntimeOptions {}
+  extends Omit<SourcePackageMcpResourcesSourceOptions<TKey>, "cache">, WorkspaceSourceRuntimeOptions {}
 
 export function mcpResources<const TKey extends string = string, const TOptions extends McpResourcesSourceOptions<TKey> = McpResourcesSourceOptions<TKey>>(options: ExactOptions<TOptions, McpResourcesSourceOptions<TKey>>): WorkspaceSource {
   const livePaths: Record<string, string> = {}
@@ -20,20 +19,20 @@ export function mcpResources<const TKey extends string = string, const TOptions 
     cache: options.cache,
   })
 
-  return markLiveWorkspaceSource({
+  const source = withWorkspaceRuntimeOptions({
     ...baseSource,
-    cache: options.cache,
-    materialize: options.materialize || (options.sync ? "none" : "lazy"),
-    mount: options.mount,
     async prepare(ctx) {
       await baseSource.prepare?.(ctx)
       const mountPath = resolveMountPath(options.mount, ctx)
       const keys = await baseSource.getKeys(ctx)
       resetLivePaths(livePaths, mountPath, keys)
     },
-    sync: options.sync,
-    validate: options.validate,
-  }, livePaths)
+  }, {
+    ...options,
+    materialize: options.materialize || (options.sync ? "none" : "lazy"),
+  })
+
+  return markLiveWorkspaceSource(source, livePaths)
 }
 
 registerMcpResourcesSourceLoader(input => mcpResources(input as never))

--- a/packages/workspace/src/sources/runtime-options.ts
+++ b/packages/workspace/src/sources/runtime-options.ts
@@ -1,0 +1,22 @@
+import type { WorkspaceSource } from "../core/types.ts"
+
+export type ExactOptions<TInput, TShape> = TInput & Record<Exclude<keyof TInput, keyof TShape>, never>
+
+export type WorkspaceSourceRuntimeOptions = Pick<
+  WorkspaceSource,
+  "cache" | "materialize" | "mount" | "sync" | "validate"
+>
+
+export function withWorkspaceRuntimeOptions(
+  source: WorkspaceSource,
+  options: WorkspaceSourceRuntimeOptions,
+): WorkspaceSource {
+  return {
+    ...source,
+    cache: options.cache,
+    materialize: options.materialize,
+    mount: options.mount,
+    sync: options.sync,
+    validate: options.validate,
+  }
+}

--- a/packages/workspace/test/source-metadata.test.ts
+++ b/packages/workspace/test/source-metadata.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { custom, fetch, file, github, mcpResources } from "../src/index.ts"
+import { custom, fetch, file, github, glob, markdown, mcpResources } from "../src/index.ts"
 import {
   normalizeWorkspaceSourceMetadata,
   normalizeWorkspaceSourcesMetadata,
@@ -48,6 +48,68 @@ afterEach(() => {
 })
 
 describe("Workspace Source metadata", () => {
+  it("preserves adapter-specific Workspace runtime options", () => {
+    const direct = {
+      async getKeys() {
+        return []
+      },
+      async getItem(key: string) {
+        return { content: "", key }
+      },
+    }
+
+    expect(custom(direct)).toBe(direct)
+    expect(file({
+      mount: { materialize: "lazy" },
+      path: "README.md",
+    })).toMatchObject({
+      mount: { materialize: "lazy", path: "" },
+      probeKeys: ["README.md"],
+    })
+    expect(markdown({
+      mount: { materialize: "lazy" },
+      path: "README.md",
+    })).toMatchObject({
+      mount: { materialize: "lazy" },
+      probeKeys: ["README.md"],
+    })
+    expect(glob({
+      cache: { maxAge: 60 },
+      include: "**/*.md",
+      materialize: "lazy",
+      mount: "docs",
+      sync: true,
+      validate: "request",
+    })).toMatchObject({
+      cache: { maxAge: 60 },
+      materialize: "lazy",
+      mount: "docs",
+      sync: true,
+      validate: "request",
+    })
+    expect(github({
+      cache: { maxAge: 60 },
+      materialize: "lazy",
+      mount: "repository",
+      repo: "vite-hub/vitehub",
+      sync: true,
+      validate: "request",
+    })).toMatchObject({
+      cache: { maxAge: 60 },
+      materialize: "lazy",
+      mount: "repository",
+      sync: true,
+      validate: "request",
+    })
+    expect(mcpResources({
+      server: mcpClient,
+      sync: true,
+    })).toMatchObject({
+      materialize: "none",
+      sync: true,
+    })
+  })
+
   it("projects canonical metadata for every Source form", () => {
     const sources = Object.fromEntries(normalizeWorkspaceSourcesMetadata({
       customDocs: custom({


### PR DESCRIPTION
## Summary

- share the equivalent Workspace source-adapter plumbing
- preserve each source-specific default and identity behavior
- keep custom and fetch outside the shared boundary

## Verification

- `git diff --check origin/main...HEAD`
- `env -u GH_TOKEN -u GITHUB_TOKEN -u WORKSPACE_GITHUB_TOKEN -u VITEHUB_WORKSPACE_GITHUB_TOKEN pnpm exec vp test` in `packages/workspace` (470 tests passed; type errors: none)
- independent direction and code review