### PR TITLE
refactor(schedule): extract provider output bookkeeping

### DIFF
--- a/packages/internal/src/definition-catalog.ts
+++ b/packages/internal/src/definition-catalog.ts
@@ -337,6 +337,13 @@ export function createRuntimeRegistryContents(registryFile: string, definitions:
   ].join("\n")
 }
 
+export async function writeRuntimeRegistryFile<TDefinition extends Pick<DiscoveredDefinition, "handler" | "name">>(
+  registryFile: string,
+  definitions: TDefinition[],
+): Promise<void> {
+  await writeFileIfChanged(registryFile, createRuntimeRegistryContents(registryFile, definitions))
+}
+
 export function createGeneratedDefinitionPath(
   rootDir: string,
   options: {
@@ -368,7 +375,7 @@ export async function writeRuntimeRegistryFiles<TDefinition extends Pick<Discove
   },
 ): Promise<RuntimeRegistryFiles<TDefinition>> {
   await Promise.all([
-    writeFileIfChanged(options.registryFile, createRuntimeRegistryContents(options.registryFile, options.definitions)),
+    writeRuntimeRegistryFile(options.registryFile, options.definitions),
     writeFileIfChanged(options.pluginFile, options.createPluginContents(options.pluginFile, options.registryFile)),
   ])
 

--- a/packages/internal/test/definition-discovery.test.ts
+++ b/packages/internal/test/definition-discovery.test.ts
@@ -12,6 +12,7 @@ import {
   registerDefinition,
   sanitizeDefinitionFilename,
   writeFileIfChanged,
+  writeRuntimeRegistryFile,
   writeRuntimeRegistryFiles,
 } from "../src/definition-discovery.ts"
 
@@ -134,6 +135,20 @@ describe("writeRuntimeRegistryFiles", () => {
 
     await expect(readFile(registryFile, "utf8")).resolves.toContain('"welcome": async () => import("../../server/queues/welcome.ts")')
     await expect(readFile(pluginFile, "utf8")).resolves.toContain('import registry from "./registry.mjs"')
+  })
+})
+
+describe("writeRuntimeRegistryFile", () => {
+  it("writes a generated registry and creates its parent directory", async () => {
+    const root = await createTempDir("vitehub-internal-runtime-registry-")
+    const registryFile = join(root, ".vitehub", "schedule", "registry.mjs")
+
+    await writeRuntimeRegistryFile(registryFile, [{
+      handler: join(root, "src", "cleanup.schedule.ts"),
+      name: "cleanup",
+    }])
+
+    await expect(readFile(registryFile, "utf8")).resolves.toContain('"cleanup": async () => import("../../src/cleanup.schedule.ts")')
   })
 })
 

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -9,7 +9,7 @@ import { createDefaultCloudflareOutputRoot, createDefaultNetlifyOutputRoot, crea
 import { bundleEsmEntry } from "@vite-hub/internal/build/esbuild"
 import { createImportPath, ensureGeneratedDir } from "@vite-hub/internal/build/paths"
 import { createNodeFunctionConfig, createVercelConfigJson } from "@vite-hub/internal/build/vercel-config"
-import { createRuntimeRegistryContents } from "@vite-hub/internal/definition-catalog"
+import { writeRuntimeRegistryFile } from "@vite-hub/internal/definition-catalog"
 import { findDefaultExportCall, readObjectProperty } from "@vite-hub/internal/source-scanner"
 
 import { discoverScheduleDefinitions } from "../discovery.ts"
@@ -25,32 +25,15 @@ const cloudflareOutputStateFileName = "cloudflare-output.json"
 const denoCronFileName = "deno-cron.mjs"
 const generatedRegistryFileName = "registry.mjs"
 
-export function resolveScheduleRuntimeEntry(metaUrl = import.meta.url) {
-  const file = fileURLToPath(metaUrl)
-  const normalizedFile = file.replace(/\\/g, "/")
-  if (normalizedFile.endsWith("/src/internal/provider-output.ts")) {
-    return resolve(dirname(file), "../runtime/static.ts")
-  }
-  if (normalizedFile.endsWith("/dist/internal/provider-output.js")) {
-    return resolve(dirname(file), "../runtime/static.js")
-  }
-  return normalizedFile.includes("/dist/")
-    ? resolve(dirname(file), "runtime/static.js")
-    : resolve(dirname(file), "dist/runtime/static.js")
+type ImportResolver = (specifier: string) => string
+
+export function resolveScheduleRuntimeEntry(resolveImport: ImportResolver = specifier => import.meta.resolve(specifier)) {
+  return fileURLToPath(resolveImport(scheduleStaticRuntimeImport))
 }
 
-export function resolveScheduleDefinitionEntry(metaUrl = import.meta.url) {
-  const file = fileURLToPath(metaUrl)
-  const normalizedFile = file.replace(/\\/g, "/")
-  if (normalizedFile.endsWith("/src/internal/provider-output.ts")) {
-    return resolve(dirname(file), "../definition.ts")
-  }
-  if (normalizedFile.endsWith("/dist/internal/provider-output.js")) {
-    return resolve(dirname(file), "../definition.js")
-  }
-  return normalizedFile.includes("/dist/")
-    ? resolve(dirname(file), "definition.js")
-    : resolve(dirname(file), "dist/definition.js")
+export function resolveScheduleDefinitionEntry(resolveImport: ImportResolver = specifier => import.meta.resolve(specifier)) {
+  const packageRoot = dirname(fileURLToPath(resolveImport(`${schedulePackageName}/package.json`)))
+  return resolve(packageRoot, "dist/definition.js")
 }
 
 const scheduleRuntimeEntry = resolveScheduleRuntimeEntry()
@@ -280,13 +263,11 @@ async function writeProviderEntries(
   providedDefinitions?: DiscoveredScheduleDefinition[],
 ): Promise<GeneratedScheduleArtifacts> {
   const generatedDir = ensureGeneratedDir(rootDir, productName)
-  await mkdir(generatedDir, { recursive: true })
-
   const registryFile = resolve(generatedDir, generatedRegistryFileName)
   const definitions = (providedDefinitions ?? discoverScheduleDefinitions({ rootDir }))
     .filter(definition => !source || definition.source === source)
     .filter(definition => definition.runtimeOnly !== true)
-  await writeFile(registryFile, createRuntimeRegistryContents(registryFile, definitions), "utf8")
+  await writeRuntimeRegistryFile(registryFile, definitions)
 
   const cloudflareWorkerFile = resolve(generatedDir, "cloudflare-worker.mjs")
   const denoCronFile = resolve(generatedDir, denoCronFileName)

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -327,22 +327,18 @@ describe("schedule provider output", () => {
     expect(() => validateProviderCron("0 0 1 * 1", "cleanup")).toThrow(/provider wake output only supports five-field UTC cron syntax/)
   })
 
-  it("resolves the static schedule runtime entry from package source and dist layouts", () => {
-    expect(resolveScheduleRuntimeEntry("file:///repo/packages/schedule/src/internal/provider-output.ts")).toBe("/repo/packages/schedule/src/runtime/static.ts")
-    expect(resolveScheduleRuntimeEntry("file:///C:/repo/packages/schedule/src/internal/provider-output.ts")).toBe("/C:/repo/packages/schedule/src/runtime/static.ts")
-    expect(resolveScheduleRuntimeEntry("file:///repo/packages/schedule/dist/internal/provider-output.js")).toBe("/repo/packages/schedule/dist/runtime/static.js")
-    expect(resolveScheduleRuntimeEntry("file:///repo/packages/schedule/dist/vite.js")).toBe("/repo/packages/schedule/dist/runtime/static.js")
-    expect(resolveScheduleRuntimeEntry("file:///repo/packages/schedule/vite.js")).toBe("/repo/packages/schedule/dist/runtime/static.js")
-    expect(resolveScheduleRuntimeEntry("file:///home/user/src/app/node_modules/@vite-hub/schedule/dist/internal/provider-output.js")).toBe("/home/user/src/app/node_modules/@vite-hub/schedule/dist/runtime/static.js")
+  it("resolves the static schedule runtime from its declared package export", () => {
+    expect(resolveScheduleRuntimeEntry((specifier) => {
+      expect(specifier).toBe("@vite-hub/schedule/runtime/static")
+      return "file:///repo/node_modules/@vite-hub/schedule/dist/runtime/static.js"
+    })).toBe("/repo/node_modules/@vite-hub/schedule/dist/runtime/static.js")
   })
 
-  it("resolves the static schedule definition entry from package source and dist layouts", () => {
-    expect(resolveScheduleDefinitionEntry("file:///repo/packages/schedule/src/internal/provider-output.ts")).toBe("/repo/packages/schedule/src/definition.ts")
-    expect(resolveScheduleDefinitionEntry("file:///C:/repo/packages/schedule/src/internal/provider-output.ts")).toBe("/C:/repo/packages/schedule/src/definition.ts")
-    expect(resolveScheduleDefinitionEntry("file:///repo/packages/schedule/dist/internal/provider-output.js")).toBe("/repo/packages/schedule/dist/definition.js")
-    expect(resolveScheduleDefinitionEntry("file:///repo/packages/schedule/dist/vite.js")).toBe("/repo/packages/schedule/dist/definition.js")
-    expect(resolveScheduleDefinitionEntry("file:///repo/packages/schedule/vite.js")).toBe("/repo/packages/schedule/dist/definition.js")
-    expect(resolveScheduleDefinitionEntry("file:///home/user/src/app/node_modules/@vite-hub/schedule/dist/internal/provider-output.js")).toBe("/home/user/src/app/node_modules/@vite-hub/schedule/dist/definition.js")
+  it("resolves the private schedule definition from the declared package root", () => {
+    expect(resolveScheduleDefinitionEntry((specifier) => {
+      expect(specifier).toBe("@vite-hub/schedule/package.json")
+      return "file:///repo/node_modules/@vite-hub/schedule/package.json"
+    })).toBe("/repo/node_modules/@vite-hub/schedule/dist/definition.js")
   })
 
   it("writes Cloudflare schedule output to an existing Wrangler main", async () => {


### PR DESCRIPTION
## Summary

- extract reusable provider-output bookkeeping into the Internal build seam
- adopt it in Schedule without attempting a six-package rewrite
- resolve the Schedule runtime through its declared package export

## Verification

- 19 Internal tests
- 37 Schedule provider-output tests
- Internal and Schedule builds
- built-artifact resolution proof
- Vercel provider-output E2E
- independent review