### PR TITLE
test(packages): verify built package exports

### DIFF
--- a/packages/auth/test/package.test.ts
+++ b/packages/auth/test/package.test.ts
@@ -2,6 +2,8 @@ import { readFileSync } from "node:fs"
 
 import { describe, expect, it } from "vitest"
 
+import { verifyBuiltPackageExports } from "../../internal/test-utils/built-package-exports.js"
+
 const packageJson = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as {
   exports: Record<string, unknown>
 }
@@ -12,6 +14,15 @@ describe("@vite-hub/auth package contract", () => {
       ".",
       "./agent",
       "./package.json",
+      "./server",
+      "./vite",
+    ])
+  })
+
+  it("loads documented exports from built package targets", async () => {
+    await verifyBuiltPackageExports(new URL("../", import.meta.url), "@vite-hub/auth", [
+      ".",
+      "./agent",
       "./server",
       "./vite",
     ])

--- a/packages/box/test/package.test.ts
+++ b/packages/box/test/package.test.ts
@@ -1,0 +1,13 @@
+import { describe, it } from "vitest"
+
+import { verifyBuiltPackageExports } from "../../internal/test-utils/built-package-exports.js"
+
+describe("@vite-hub/box package contract", () => {
+  it("loads documented exports from built package targets", async () => {
+    await verifyBuiltPackageExports(new URL("../", import.meta.url), "@vite-hub/box", [
+      ".",
+      "./_internal/cloudflare",
+      "./_internal/vercel",
+    ])
+  })
+})

--- a/packages/internal/package.json
+++ b/packages/internal/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@types/node": "catalog:tooling",
+    "exsolve": "catalog:unjs",
     "sharp": "0.34.5",
     "typescript": "catalog:tooling",
     "vite-plus": "catalog:tooling",

--- a/packages/internal/test-utils/built-package-exports.ts
+++ b/packages/internal/test-utils/built-package-exports.ts
@@ -1,0 +1,31 @@
+import { execFile } from "node:child_process"
+import { access } from "node:fs/promises"
+import { isAbsolute, join, relative, sep } from "node:path"
+import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
+
+import { resolveModuleURL } from "exsolve"
+
+const execFileAsync = promisify(execFile)
+
+export async function verifyBuiltPackageExports(
+  packageRootURL: URL,
+  packageName: string,
+  subpaths: readonly string[],
+): Promise<void> {
+  const packageRoot = fileURLToPath(packageRootURL)
+  const distRoot = join(packageRoot, "dist")
+  for (const subpath of subpaths) {
+    const specifier = subpath === "." ? packageName : `${packageName}/${subpath.replace(/^\.\//, "")}`
+    const resolved = resolveModuleURL(specifier, { from: packageRootURL })
+    const target = fileURLToPath(resolved)
+    const relativeTarget = relative(distRoot, target)
+
+    if (relativeTarget === ".." || relativeTarget.startsWith(`..${sep}`) || isAbsolute(relativeTarget)) {
+      throw new Error(`${specifier} resolved outside ${distRoot}: ${resolved}`)
+    }
+
+    await access(target)
+    await execFileAsync(process.execPath, ["--input-type=module", "--eval", `await import(${JSON.stringify(resolved)})`])
+  }
+}

--- a/packages/runtime/test/package.test.ts
+++ b/packages/runtime/test/package.test.ts
@@ -1,0 +1,9 @@
+import { describe, it } from "vitest"
+
+import { verifyBuiltPackageExports } from "../../internal/test-utils/built-package-exports.js"
+
+describe("@vite-hub/runtime package contract", () => {
+  it("loads documented exports from built package targets", async () => {
+    await verifyBuiltPackageExports(new URL("../", import.meta.url), "@vite-hub/runtime", ["."])
+  })
+})

--- a/packages/source/test/package.test.ts
+++ b/packages/source/test/package.test.ts
@@ -1,0 +1,18 @@
+import { describe, it } from "vitest"
+
+import { verifyBuiltPackageExports } from "../../internal/test-utils/built-package-exports.js"
+
+describe("@vite-hub/source package contract", () => {
+  it("loads documented exports from built package targets", async () => {
+    await verifyBuiltPackageExports(new URL("../", import.meta.url), "@vite-hub/source", [
+      ".",
+      "./sources",
+      "./sources/custom",
+      "./sources/file",
+      "./sources/github",
+      "./sources/glob",
+      "./sources/markdown",
+      "./sources/mcp-resources",
+    ])
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -921,6 +921,9 @@ importers:
       '@types/node':
         specifier: catalog:tooling
         version: 24.13.3
+      exsolve:
+        specifier: catalog:unjs
+        version: 1.1.0
       sharp:
         specifier: 0.34.5
         version: 0.34.5


### PR DESCRIPTION
## Summary

- add a shared built-package export resolution helper
- exercise Auth, Source, Box, and Runtime through their built package contracts
- fail when an export target is missing or resolves outside the package dist directory

## Verification

- five focused package tests
- Auth, Source, Box, and Runtime typechecks
- build and publint
- lint and diff checks
- deliberate missing-dist negative proof
- independent standards and specification reviews