### PR TITLE
fix(agent): resolve Codex bridge assets from installed packages

### DIFF
--- a/packages/agent/src/harness/codex.ts
+++ b/packages/agent/src/harness/codex.ts
@@ -1,6 +1,7 @@
 import { readFile } from "node:fs/promises"
+import { createRequire } from "node:module"
 import { join } from "node:path"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 import { createCodex } from "@ai-sdk/harness-codex"
 
@@ -98,8 +99,8 @@ function createViteHubCodex(settings: CodexHarnessSettings, preferOpenAI: boolea
 }
 
 async function readCodexBridgeAsset(name: string): Promise<string> {
-  const packageEntry = import.meta.resolve("@ai-sdk/harness-codex")
-  return await readFile(fileURLToPath(new URL(`./bridge/${name}`, packageEntry)), "utf8")
+  const packageEntry = createRequire(import.meta.url).resolve("@ai-sdk/harness-codex")
+  return await readFile(fileURLToPath(new URL(`./bridge/${name}`, pathToFileURL(packageEntry))), "utf8")
 }
 
 async function prepareCodexHome(session: object): Promise<void> {

--- a/packages/agent/test/harness-codex-patch.test.ts
+++ b/packages/agent/test/harness-codex-patch.test.ts
@@ -1,7 +1,7 @@
 import { createCodex } from "@ai-sdk/harness-codex"
 import { execFile } from "node:child_process"
 import { build } from "esbuild"
-import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
 import { pathToFileURL } from "node:url"
 import { promisify } from "node:util"
@@ -57,6 +57,41 @@ describe("ViteHub Codex harness", () => {
     finally {
       await rm(fixture, { force: true, recursive: true })
     }
+  })
+
+  it("loads bridge assets through package-scoped resolution in the built package", async () => {
+    const dist = new URL("../dist/", import.meta.url)
+    const chunks = await Promise.all(
+      (await readdir(dist))
+        .filter(file => file.endsWith(".js"))
+        .map(async file => ({ file, source: await readFile(new URL(file, dist), "utf8") })),
+    )
+    const codexChunk = chunks.find(chunk => chunk.source.includes("readCodexBridgeAsset"))
+
+    expect({
+      packageScopedResolver: codexChunk?.source.includes("createRequire(import.meta.url).resolve(\"@ai-sdk/harness-codex\")"),
+      pathConvertedToFileURL: codexChunk?.source.includes("pathToFileURL(packageEntry)"),
+      runtimeESMResolver: codexChunk?.source.includes("import.meta.resolve(\"@ai-sdk/harness-codex\")"),
+    }).toEqual({
+      packageScopedResolver: true,
+      pathConvertedToFileURL: true,
+      runtimeESMResolver: false,
+    })
+
+    const { stdout } = await exec(process.execPath, [
+      "--input-type=module",
+      "--eval",
+      `
+        const { createCodexDriver } = await import(process.argv[1])
+        const bootstrap = await createCodexDriver({ sandbox: false }).harness.getBootstrap()
+        process.stdout.write(bootstrap.files.find(file => file.path.endsWith("package.json")).content)
+      `,
+      new URL(codexChunk!.file, dist).href,
+    ])
+
+    expect(JSON.parse(stdout)).toMatchObject({
+      dependencies: { "@openai/codex-sdk": expect.any(String) },
+    })
   })
 
   it.each([


### PR DESCRIPTION
## Summary

- resolve the Codex harness dependency through Node's package-scoped resolver in the built Agent package
- convert the resolved filesystem path to a file URL before loading sibling bridge assets
- verify the generated Codex chunk keeps that resolver and loads the real bridge package content

## Verification

- `corepack pnpm --filter @vite-hub/agent exec vp test run test/harness-codex-patch.test.ts`
- `corepack pnpm --filter @vite-hub/agent typecheck`
- `corepack pnpm --filter @vite-hub/agent build`
- `corepack pnpm exec vp lint packages/agent/src/harness/codex.ts packages/agent/test/harness-codex-patch.test.ts`
- `git diff --check origin/main...HEAD`
- `corepack pnpm --filter @vite-hub/agent test` (1,464 tests passed; unrelated GitHub-channel timeouts and the tutorial fixture remained red)
