### PR TITLE
fix(vite-hub): align Nuxt generated handler roots

### DIFF
--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1808,25 +1808,26 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       agent = config.agent ?? agent
       const resolved = normalizeAgentOptions(agent)
       serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
-      const hasHostedAgents = Boolean(resolved && hasHostedAgentDefinitions(resolve(config.root || process.cwd()), serverDirs))
+      const root = resolve(config.root || process.cwd())
+      const hasHostedAgents = Boolean(resolved && hasHostedAgentDefinitions(root, serverDirs))
       const denoOutput = resolved && resolved.runtime === "deno"
       const installCloudflareState = hasHostedAgents && !denoOutput && shouldInstallCloudflareAgentState(resolved, config)
       const nitroHandlers = [
         ...(resolved && hasHostedAgents && !denoOutput && resolved.routes.chat
           ? [{
-              handler: generatedAgentWebhookRouteHandler,
+              handler: join(root, generatedAgentWebhookRouteHandler),
               route: normalizeNitroRoute(resolved.routes.chat),
             }]
           : []),
         ...(resolved && hasHostedAgents && !denoOutput
           ? [{
-              handler: generatedAgentWebhookRouteHandler,
+              handler: join(root, generatedAgentWebhookRouteHandler),
               route: normalizeNitroRoute(resolved.routes.webhooks),
             }]
           : []),
         ...(resolved && hasHostedAgents && !denoOutput && resolved.routes.discordGateway
           ? [{
-              handler: generatedAgentDiscordGatewayRouteHandler,
+              handler: join(root, generatedAgentDiscordGatewayRouteHandler),
               route: normalizeNitroRoute(resolved.routes.discordGateway),
             }]
           : []),

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -891,7 +891,7 @@ describe("agent Vite plugin", () => {
       return (result as { nitro?: { handlers?: unknown[] } } | undefined)?.nitro?.handlers
     }
     const webhook = {
-      handler: ".vitehub/agent/chat-webhook-route.ts",
+      handler: join(hostedAgentRoot, ".vitehub/agent/chat-webhook-route.ts"),
       route: "/api/_vitehub/agents/:agent/webhooks/:webhook",
     }
 
@@ -899,14 +899,14 @@ describe("agent Vite plugin", () => {
     await expect(handlers(false)).resolves.toEqual([webhook])
     await expect(handlers(true)).resolves.toEqual([
       {
-        handler: ".vitehub/agent/chat-webhook-route.ts",
+        handler: join(hostedAgentRoot, ".vitehub/agent/chat-webhook-route.ts"),
         route: "/api/_vitehub/agents/:agent/chat",
       },
       webhook,
     ])
     await expect(handlers("/chat/[agent]")).resolves.toEqual([
       {
-        handler: ".vitehub/agent/chat-webhook-route.ts",
+        handler: join(hostedAgentRoot, ".vitehub/agent/chat-webhook-route.ts"),
         route: "/chat/:agent",
       },
       webhook,
@@ -934,11 +934,11 @@ describe("agent Vite plugin", () => {
       nitro: {
         handlers: expect.arrayContaining([
           {
-            handler: ".vitehub/agent/chat-webhook-route.ts",
+            handler: join(hostedAgentRoot, ".vitehub/agent/chat-webhook-route.ts"),
             route: "/api/_vitehub/agents/:agent/webhooks/:webhook",
           },
           {
-            handler: ".vitehub/agent/discord-gateway-route.ts",
+            handler: join(hostedAgentRoot, ".vitehub/agent/discord-gateway-route.ts"),
             route: "/api/_vitehub/agents/:agent/discord/gateway",
           },
         ]),
@@ -1257,11 +1257,11 @@ describe("agent Vite plugin", () => {
     }
 
     expect(output.nitro?.handlers).toContainEqual({
-      handler: ".vitehub/agent/chat-webhook-route.ts",
+      handler: join(hostedAgentRoot, ".vitehub/agent/chat-webhook-route.ts"),
       route: "/api/_vitehub/agents/:agent/chat",
     })
     expect(output.nitro?.handlers).toContainEqual({
-      handler: ".vitehub/agent/chat-webhook-route.ts",
+      handler: join(hostedAgentRoot, ".vitehub/agent/chat-webhook-route.ts"),
       route: "/api/_vitehub/agents/:agent/webhooks/:webhook",
     })
     expect(output.nitro?.cloudflare).toBeUndefined()
@@ -1338,11 +1338,11 @@ describe("agent Vite plugin", () => {
     }
 
     expect(output.nitro?.handlers).toContainEqual({
-      handler: ".vitehub/agent/chat-webhook-route.ts",
+      handler: join(hostedAgentRoot, ".vitehub/agent/chat-webhook-route.ts"),
       route: "/api/_vitehub/agents/:agent/chat",
     })
     expect(output.nitro?.handlers).toContainEqual({
-      handler: ".vitehub/agent/chat-webhook-route.ts",
+      handler: join(hostedAgentRoot, ".vitehub/agent/chat-webhook-route.ts"),
       route: "/api/_vitehub/agents/:agent/webhooks/:webhook",
     })
     expect(output.nitro?.cloudflare).toBeUndefined()

--- a/packages/vite-hub/test/nuxt-agent.test.ts
+++ b/packages/vite-hub/test/nuxt-agent.test.ts
@@ -1,0 +1,49 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterEach, expect, it } from "vitest"
+
+import viteHubNuxtModule from "../src/nuxt.ts"
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(root => rm(root, { force: true, recursive: true })))
+})
+
+it("registers generated Agent handlers from the Nuxt source root", async () => {
+  const rootDir = await mkdtemp(join(tmpdir(), "vitehub-nuxt-agent-root-"))
+  roots.push(rootDir)
+  const srcDir = join(rootDir, "app")
+  const serverDir = join(rootDir, "server")
+  await mkdir(join(serverDir, "agents"), { recursive: true })
+  await writeFile(join(serverDir, "agents", "support.ts"), "export default {}\n", "utf8")
+  await writeFile(join(rootDir, "package.json"), JSON.stringify({ name: "vitehub-nuxt-agent-root" }), "utf8")
+
+  let nitroConfigHook: ((config: Record<string, unknown>) => Promise<void>) | undefined
+  const nuxt = {
+    hook(name: "nitro:config", callback: (config: Record<string, unknown>) => Promise<void>) {
+      if (name === "nitro:config") nitroConfigHook = callback
+    },
+    options: {
+      dev: false,
+      rootDir,
+      serverDir,
+      srcDir,
+      vite: {},
+    },
+  }
+
+  viteHubNuxtModule({ agent: true, preset: "node" }, nuxt)
+  if (!nitroConfigHook) throw new TypeError("Expected a Nitro config hook.")
+  const nitroConfig: Record<string, unknown> = {}
+  await nitroConfigHook(nitroConfig)
+
+  expect(nitroConfig).toMatchObject({
+    handlers: [{
+      handler: join(srcDir, ".vitehub/agent/chat-webhook-route.ts"),
+      route: "/api/_vitehub/agents/:agent/webhooks/:webhook",
+    }],
+  })
+})


### PR DESCRIPTION
Anchors Agent-generated Nitro handlers to the resolved Vite root that owns `.vitehub`. Nuxt projects with a separate `srcDir` now register `app/.vitehub/agent/chat-webhook-route.ts` instead of asking Nitro to resolve the same relative path from the project root.

Agent continues to own both generation and registration, so the Nuxt adapter does not rewrite consumer-defined or sibling ViteHub handlers. The regression runs the real `vite-hub/nuxt` and Agent config hooks with distinct `rootDir`, `srcDir`, and `serverDir`; it failed with the relative handler before this change and passes with the source-root-anchored path.

Validated with the full Agent suite (64 files, 1,469 tests), the full `vite-hub` suite (8 files, 71 tests), both package typechecks, build and publint through the package test pipelines, `git diff --check`, and independent standards/spec reviews. A disposable Nuxt 4.4.8 consumer on the established Vite 8.1.5 graph completed a production Nitro build, generated `app/.vitehub/agent/chat-webhook-route.ts`, and bundled its project-root Agent import successfully.