### PR TITLE
feat(agent): support manual chat delivery controls

### DIFF
--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -216,6 +216,12 @@ function assertNoLegacyChatHistoryOption(options: AgentChatOptions): void {
   }
 }
 
+export function assertChatDeliveryOptions(options: AgentChatOptions): void {
+  if (options.delivery === "manual" && (options.stream === true || options.commentary !== undefined)) {
+    throw new TypeError("[vitehub] messages.delivery \"manual\" cannot be combined with messages.stream or messages.commentary.")
+  }
+}
+
 export function getChatCapabilityOptions<TRuntimeConfig extends AgentRuntimeConfig>(
   capabilities: AgentCapabilityDefinition[],
 ): AgentChatOptions<TRuntimeConfig> | undefined {
@@ -230,6 +236,7 @@ export function defineChatCapability<
   options: TOptions = {} as TOptions,
 ): AgentCapabilityDefinition<TRuntimeConfig, WorkspaceName, ChatCapabilityTypeContract<AgentChatOptionsOrigin<TOptions>>> {
   assertNoLegacyChatHistoryOption(options)
+  assertChatDeliveryOptions(options)
   return defineCapability({
     id: "chat",
     metadata: {

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -220,6 +220,9 @@ export function assertChatDeliveryOptions(options: AgentChatOptions): void {
   if (options.delivery === "manual" && (options.stream === true || options.commentary !== undefined)) {
     throw new TypeError("[vitehub] messages.delivery \"manual\" cannot be combined with messages.stream or messages.commentary.")
   }
+  if (options.timeout !== undefined && (!Number.isFinite(options.timeout) || options.timeout <= 0)) {
+    throw new TypeError("[vitehub] messages.timeout must be a positive finite number.")
+  }
 }
 
 export function getChatCapabilityOptions<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1913,7 +1913,10 @@ async function postChatErrorFallback(
     thread_id: message.threadId,
   })
   const fallback = await resolveChatErrorFallbackText(options, chatErrorHookArgs(thread, message, input, run, error))
-  if (!fallback) return
+  if (!fallback) {
+    if (manualDeliveryPlaceholder) await deleteManualDeliveryPlaceholder(manualDeliveryPlaceholder)
+    return
+  }
   if (await deliverToManualDeliveryPlaceholder(manualDeliveryPlaceholder, fallback)) return
   await thread.post(fallback).catch(() => undefined)
 }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1939,25 +1939,24 @@ function createChatFinishExtension(
 async function flushChatFinishExtensionMessages(
   thread: Thread,
   chat: AgentChatQueuedFinishExtension,
-  manualDeliveryPlaceholder?: unknown,
-): Promise<unknown> {
+  manualDelivery: { placeholder?: unknown },
+): Promise<void> {
   const messages = chat[chatFinishMessagesKey].splice(0)
   for (let message of messages) {
-    if (manualDeliveryPlaceholder) {
+    if (manualDelivery.placeholder) {
       if (isAsyncIterable(message)) {
         let markdown = ""
         for await (const chunk of message) markdown += chunk
         message = { markdown }
       }
-      if (await deliverToManualDeliveryPlaceholder(manualDeliveryPlaceholder, message)) {
-        manualDeliveryPlaceholder = undefined
+      if (await deliverToManualDeliveryPlaceholder(manualDelivery.placeholder, message)) {
+        manualDelivery.placeholder = undefined
         continue
       }
-      manualDeliveryPlaceholder = undefined
+      manualDelivery.placeholder = undefined
     }
     await postChatMessage(thread, message)
   }
-  return manualDeliveryPlaceholder
 }
 
 function withChatFinishExtension<CALL_OPTIONS>(
@@ -2020,7 +2019,7 @@ async function handleChatSdkMessage(
   let input: AgentChatMessageTriggerInput | undefined
   let run: AgentRunMetadata | undefined
   let typing: ChatTypingRefresh | undefined
-  let manualDeliveryPlaceholder: unknown
+  const manualDeliveryState: { placeholder?: unknown } = {}
   try {
     input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, [chatAuthorizationUiMessage(thread, message, messageContext)], messageContext, registration.channelId)
     if (typeof options?.timeout === "number" && Number.isFinite(options.timeout) && options.timeout > 0) {
@@ -2056,7 +2055,7 @@ async function handleChatSdkMessage(
     const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
     const thinkingFallback = invocation.metadata?.thinkingFallback
     if (manualDelivery && typeof thinkingFallback === "string") {
-      manualDeliveryPlaceholder = await thread.post(thinkingFallback)
+      manualDeliveryState.placeholder = await thread.post(thinkingFallback)
     }
     typing = streamsPhasedReplies ? startChatTypingRefresh(thread, context) : undefined
     run = invocation.run
@@ -2081,9 +2080,9 @@ async function handleChatSdkMessage(
           await thread.post({ markdown: text })
         }
       }
-      manualDeliveryPlaceholder = await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryPlaceholder)
-      if (manualDeliveryPlaceholder) await deleteManualDeliveryPlaceholder(manualDeliveryPlaceholder)
-      manualDeliveryPlaceholder = undefined
+      await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState)
+      if (manualDeliveryState.placeholder) await deleteManualDeliveryPlaceholder(manualDeliveryState.placeholder)
+      manualDeliveryState.placeholder = undefined
     }
     else {
       const result = streamAgent(agent as never, runContext as never, invocationInput as never, {
@@ -2131,12 +2130,12 @@ async function handleChatSdkMessage(
       finally {
         typing?.stop()
       }
-      await flushChatFinishExtensionMessages(thread, chatFinish)
+      await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState)
     }
   }
   catch (error) {
     typing?.stop()
-    await postChatErrorFallback(error, thread, message, options, input, run, manualDeliveryPlaceholder)
+    await postChatErrorFallback(error, thread, message, options, input, run, manualDeliveryState.placeholder)
     throw error
   }
   finally {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -7,7 +7,7 @@ import { resolveAgentTriggerInvocation, resolveAgentTriggers, runAgent, runAgent
 import { hasTraceableStreamResult, isAsyncIterable, streamAgentOutputToEvents } from "../agent-output.ts"
 import { toAgentPublicError } from "../agent-error.ts"
 import { getAccessCapabilityOptions } from "../capabilities/access-metadata.ts"
-import { CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCapabilityOptions } from "../chat-trigger.ts"
+import { assertChatDeliveryOptions, CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCapabilityOptions } from "../chat-trigger.ts"
 import { chatTriggerHistoryLimit, createChatMessageTriggerInput, resolveChatTriggerHistory, uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { normalizeCapabilities } from "../capability-runtime.ts"
 import { deliveryArtifactAttachments } from "../delivery-artifacts.ts"
@@ -1842,6 +1842,44 @@ async function postChatMessage(thread: Thread, message: AgentChatMessage): Promi
   } as AdapterPostableMessage)
 }
 
+async function replaceManualDeliveryPlaceholder(placeholder: unknown, message: AgentChatMessage): Promise<boolean> {
+  if (!placeholder || typeof placeholder !== "object" || !("edit" in placeholder) || typeof placeholder.edit !== "function") return false
+  const target = placeholder as { edit: (message: unknown) => Promise<unknown> }
+  if (isAsyncIterable(message)) {
+    let markdown = ""
+    for await (const chunk of message) markdown += chunk
+    await target.edit({ markdown })
+    return true
+  }
+  if (typeof message !== "object" || message === null) {
+    await target.edit(message)
+    return true
+  }
+  if (deliveryArtifactAttachments(chatMessageDeliveryArtifacts(message)).length) return false
+  await target.edit(isTextChatMessage(message) ? message.text : message)
+  return true
+}
+
+async function deleteManualDeliveryPlaceholder(placeholder: unknown): Promise<void> {
+  const message = "Manual chat delivery could not remove its placeholder."
+  if (!placeholder || typeof placeholder !== "object" || !("delete" in placeholder) || typeof placeholder.delete !== "function") {
+    throw new Error(message)
+  }
+  try {
+    await (placeholder as { delete: () => Promise<unknown> }).delete()
+  }
+  catch (cause) {
+    throw new Error(message, { cause })
+  }
+}
+
+async function deliverToManualDeliveryPlaceholder(placeholder: unknown, message: AgentChatMessage): Promise<boolean> {
+  if (!placeholder) return false
+  if (await replaceManualDeliveryPlaceholder(placeholder, message).catch(() => false)) return true
+  await deleteManualDeliveryPlaceholder(placeholder)
+  return false
+}
+
 async function resolveChatErrorFallbackText(
   options: AgentChatOptions | undefined,
   args: AgentChatErrorHookArgs<ViteAgentRouteRuntimeConfig>,
@@ -1865,6 +1903,7 @@ async function postChatErrorFallback(
   options: AgentChatOptions | undefined,
   input: AgentChatMessageTriggerInput | undefined,
   run: AgentRunMetadata | undefined,
+  manualDeliveryPlaceholder?: unknown,
 ): Promise<void> {
   console.error({
     component: "@vite-hub/agent",
@@ -1874,9 +1913,9 @@ async function postChatErrorFallback(
     thread_id: message.threadId,
   })
   const fallback = await resolveChatErrorFallbackText(options, chatErrorHookArgs(thread, message, input, run, error))
-  if (fallback) {
-    await thread.post(fallback).catch(() => undefined)
-  }
+  if (!fallback) return
+  if (await deliverToManualDeliveryPlaceholder(manualDeliveryPlaceholder, fallback)) return
+  await thread.post(fallback).catch(() => undefined)
 }
 
 function createChatFinishExtension(
@@ -1897,11 +1936,20 @@ function createChatFinishExtension(
 async function flushChatFinishExtensionMessages(
   thread: Thread,
   chat: AgentChatQueuedFinishExtension,
-): Promise<void> {
+  manualDeliveryPlaceholder?: unknown,
+): Promise<unknown> {
   const messages = chat[chatFinishMessagesKey].splice(0)
   for (const message of messages) {
+    if (manualDeliveryPlaceholder) {
+      if (await deliverToManualDeliveryPlaceholder(manualDeliveryPlaceholder, message)) {
+        manualDeliveryPlaceholder = undefined
+        continue
+      }
+      manualDeliveryPlaceholder = undefined
+    }
     await postChatMessage(thread, message)
   }
+  return manualDeliveryPlaceholder
 }
 
 function withChatFinishExtension<CALL_OPTIONS>(
@@ -1964,8 +2012,12 @@ async function handleChatSdkMessage(
   let input: AgentChatMessageTriggerInput | undefined
   let run: AgentRunMetadata | undefined
   let typing: ChatTypingRefresh | undefined
+  let manualDeliveryPlaceholder: unknown
   try {
     input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, [chatAuthorizationUiMessage(thread, message, messageContext)], messageContext, registration.channelId)
+    if (typeof options?.timeout === "number" && Number.isFinite(options.timeout) && options.timeout > 0) {
+      input.timeout = options.timeout
+    }
     const authorizationInput = createChatMessageTriggerInput(options || {}, input).input
     const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, authorizationInput, input.run, messageContext)
     if (!invoker) return
@@ -1991,7 +2043,13 @@ async function handleChatSdkMessage(
     const invocation = await resolveAgentTriggerInvocation(agent as never, context as never, "chat.message", input)
     if (isResolvedAgentTriggerHandledInvocation(invocation)) return
 
-    const streamsPhasedReplies = options?.stream !== false || options?.commentary !== undefined
+    assertChatDeliveryOptions(options || {})
+    const manualDelivery = options?.delivery === "manual"
+    const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
+    const thinkingFallback = invocation.metadata?.thinkingFallback
+    if (manualDelivery && typeof thinkingFallback === "string") {
+      manualDeliveryPlaceholder = await thread.post(thinkingFallback)
+    }
     typing = streamsPhasedReplies ? startChatTypingRefresh(thread, context) : undefined
     run = invocation.run
     const runContext = {
@@ -2004,24 +2062,25 @@ async function handleChatSdkMessage(
       context: {
         ...(invocation.input as AgentRunInput).context,
         [messageChannelStateContextKey]: state,
-        ...(options?.stream === false ? { [finalChannelOutputContextKey]: true } : {}),
+        ...(options?.stream === false || manualDelivery ? { [finalChannelOutputContextKey]: true } : {}),
       },
     }, invoker), chatFinish)
     if (!streamsPhasedReplies) {
       const result = await runAgentInline(agent as never, runContext as never, invocationInput as never)
       const text = await collectAgentOutput(result)
-      if (text) {
+      if (!manualDelivery && text) {
         if (!await postDiscordSplitContent(thread, { markdown: text })) {
           await thread.post({ markdown: text })
         }
       }
-      await flushChatFinishExtensionMessages(thread, chatFinish)
+      manualDeliveryPlaceholder = await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryPlaceholder)
+      if (manualDeliveryPlaceholder) await deleteManualDeliveryPlaceholder(manualDeliveryPlaceholder)
+      manualDeliveryPlaceholder = undefined
     }
     else {
       const result = streamAgent(agent as never, runContext as never, invocationInput as never, {
         output: "events",
       })
-      const thinkingFallback = invocation.metadata?.thinkingFallback
       try {
         if (options?.stream === true || options?.commentary === undefined) {
           await postChatStream(
@@ -2069,7 +2128,7 @@ async function handleChatSdkMessage(
   }
   catch (error) {
     typing?.stop()
-    await postChatErrorFallback(error, thread, message, options, input, run)
+    await postChatErrorFallback(error, thread, message, options, input, run, manualDeliveryPlaceholder)
     throw error
   }
   finally {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1942,8 +1942,13 @@ async function flushChatFinishExtensionMessages(
   manualDeliveryPlaceholder?: unknown,
 ): Promise<unknown> {
   const messages = chat[chatFinishMessagesKey].splice(0)
-  for (const message of messages) {
+  for (let message of messages) {
     if (manualDeliveryPlaceholder) {
+      if (isAsyncIterable(message)) {
+        let markdown = ""
+        for await (const chunk of message) markdown += chunk
+        message = { markdown }
+      }
       if (await deliverToManualDeliveryPlaceholder(manualDeliveryPlaceholder, message)) {
         manualDeliveryPlaceholder = undefined
         continue

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1489,6 +1489,7 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
   commentary?: "hidden" | "message"
   concurrency?: AgentMessageConcurrency
   dedupeTtlMs?: number
+  delivery?: "automatic" | "manual"
   errorFallbackText?: string | null | ((context: AgentChatErrorHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
   fallbackStreamingPlaceholderText?: string | readonly string[] | null | ((context: AgentChatAgentHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
   filter?: AgentMessageFilter<TRuntimeConfig>
@@ -1500,6 +1501,7 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
   stream?: boolean
   streamingUpdateIntervalMs?: number
   threadHistory?: unknown
+  timeout?: number
   transcripts?: TranscriptsConfig
   triggerHistory?: AgentChatTriggerHistory
   userName?: string

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -6942,6 +6942,48 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Streamed reply" })
   })
 
+  it("does not overwrite the first manual reply when a later reply fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.postMessage.mockImplementationOnce(async threadId => ({
+      id: "sent-1",
+      threadId,
+    })).mockRejectedValueOnce(new Error("post failed"))
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            errorFallbackText: "Delivery failed.",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: { run: () => "Private output" },
+      hooks: {
+        "agent:finish": event => [
+          event.reply("First reply"),
+          event.reply("Second reply"),
+        ],
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      await expect(handler(chatWebhookRequest(91_012), "telegram")).rejects.toThrow("post failed")
+      expect(adapter.editMessage).toHaveBeenCalledOnce()
+      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "First reply" })
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(3, "telegram:456", "Delivery failed.")
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
   it("replaces a manual placeholder with the error fallback", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -6941,6 +6941,38 @@ describe("server helpers", () => {
     }
   })
 
+  it("removes a manual placeholder when the error fallback is disabled", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            errorFallbackText: null,
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: { run: () => { throw new Error("model timeout") } },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      await expect(handler(chatWebhookRequest(91_010), "telegram")).rejects.toThrow("model timeout")
+      expect(adapter.postMessage).toHaveBeenCalledOnce()
+      expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+      expect(adapter.editMessage).not.toHaveBeenCalled()
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
   it("removes an unused manual placeholder", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -6841,6 +6841,230 @@ describe("server helpers", () => {
     }
   })
 
+  it("preserves automatic chat delivery", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: { delivery: "automatic" },
+        }),
+      },
+      driver: { run: () => "Agent output" },
+      hooks: {
+        "agent:finish": event => event.reply("Explicit reply"),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_004), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", { markdown: "Agent output" })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Explicit reply" })
+    expect(adapter.editMessage).not.toHaveBeenCalled()
+  })
+
+  it("delivers only explicit manual replies and replaces the placeholder once", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const run = vi.fn(({ input }) => {
+      expect(input.timeout).toBe(20)
+      return "{\"internal\":\"structured output\"}"
+    })
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+            timeout: 20,
+          },
+        }),
+      },
+      driver: { run },
+      hooks: {
+        "agent:finish": event => [
+          event.reply("Calories reply"),
+          event.reply("Dashboard reply"),
+        ],
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_005), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(run).toHaveBeenCalledOnce()
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Analyzing photo…")
+    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Calories reply" })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Dashboard reply" })
+    expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", { markdown: "{\"internal\":\"structured output\"}" })
+  })
+
+  it("replaces a manual placeholder with the error fallback", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            errorFallbackText: "Please send the photo again.",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: { run: () => { throw new Error("model timeout") } },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      await expect(handler(chatWebhookRequest(91_006), "telegram")).rejects.toThrow("model timeout")
+      expect(adapter.postMessage).toHaveBeenCalledOnce()
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Analyzing photo…")
+      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", "Please send the photo again.")
+      expect(adapter.deleteMessage).not.toHaveBeenCalled()
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it("removes an unused manual placeholder", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: { run: () => "Private output" },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_007), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.postMessage).toHaveBeenCalledOnce()
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Analyzing photo…")
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.editMessage).not.toHaveBeenCalled()
+  })
+
+  it("removes a manual placeholder before posting an artifact reply", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    let finishDelete!: () => void
+    adapter.deleteMessage.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      finishDelete = resolve
+    }))
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: { run: () => "Private output" },
+      hooks: {
+        async "agent:finish"(event) {
+          const chat = event.extensions.get("chat") as { sendMessage?: (message: unknown) => Promise<void> } | undefined
+          await chat?.sendMessage?.({
+            artifacts: [{
+              mediaType: "image/png",
+              path: "results/chart.png",
+              placement: "inline",
+              url: "https://assets.example/results/chart.png",
+            }],
+            markdown: "See the result.",
+          })
+        },
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const responsePromise = handler(chatWebhookRequest(91_008), "telegram")
+
+    await vi.waitFor(() => {
+      expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Analyzing photo…")
+    expect(adapter.postMessage).toHaveBeenCalledOnce()
+    finishDelete()
+
+    const response = await responsePromise
+    expect(response.status).toBe(200)
+    expect(adapter.editMessage).not.toHaveBeenCalled()
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", expect.objectContaining({
+      attachments: expect.any(Array),
+      markdown: "See the result.",
+    }))
+  })
+
+  it("fails clearly when an unreplaceable manual reply cannot remove its placeholder", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    ;(adapter as unknown as { deleteMessage?: unknown }).deleteMessage = undefined
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: { run: () => "Private output" },
+      hooks: {
+        async "agent:finish"(event) {
+          const chat = event.extensions.get("chat") as { sendMessage?: (message: unknown) => Promise<void> } | undefined
+          await chat?.sendMessage?.({
+            artifacts: [{
+              mediaType: "image/png",
+              path: "results/chart.png",
+              placement: "inline",
+              url: "https://assets.example/results/chart.png",
+            }],
+            markdown: "See the result.",
+          })
+        },
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    await expect(handler(chatWebhookRequest(91_009), "telegram")).rejects.toThrow(
+      "Manual chat delivery could not remove its placeholder.",
+    )
+    expect(adapter.postMessage).toHaveBeenCalledOnce()
+    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", "Sorry, I couldn't process that message.")
+  })
+
   it("lets chat webhooks opt out of streaming model execution", async () => {
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -6908,6 +6908,40 @@ describe("server helpers", () => {
     expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", { markdown: "{\"internal\":\"structured output\"}" })
   })
 
+  it("posts a buffered manual stream when placeholder editing fails", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.editMessage.mockRejectedValueOnce(new Error("edit failed"))
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: { run: () => "Private output" },
+      hooks: {
+        "agent:finish": event => event.reply((async function* () {
+          yield "Streamed "
+          yield "reply"
+        })()),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_011), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Streamed reply" })
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Streamed reply" })
+  })
+
   it("replaces a manual placeholder with the error fallback", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5675,6 +5675,36 @@ describe("agent message protocol", () => {
     })).toThrow("messages.history was replaced by messages.triggerHistory")
   })
 
+  it("rejects streaming and commentary with manual message delivery", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const error = "messages.delivery \"manual\" cannot be combined with messages.stream or messages.commentary"
+
+    expect(() => defineAgent({
+      channels: {
+        telegram: telegram({ adapter: () => ({}) as never }),
+      },
+      driver: { run: () => "ok" },
+      messages: {
+        delivery: "manual",
+        stream: true,
+      },
+    })).toThrow(error)
+
+    expect(() => defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => ({}) as never,
+          messages: {
+            commentary: "hidden",
+            delivery: "manual",
+          },
+        }),
+      },
+      driver: { run: () => "ok" },
+    })).toThrow(error)
+  })
+
   it("preserves channel ids for same-kind webhook registrations", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { teams } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5705,6 +5705,22 @@ describe("agent message protocol", () => {
     })).toThrow(error)
   })
 
+  it("rejects invalid message timeouts", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const error = "messages.timeout must be a positive finite number"
+
+    for (const timeout of [0, -1, Number.POSITIVE_INFINITY, Number.NaN]) {
+      expect(() => defineAgent({
+        channels: {
+          telegram: telegram({ adapter: () => ({}) as never }),
+        },
+        driver: { run: () => "ok" },
+        messages: { timeout },
+      })).toThrow(error)
+    }
+  })
+
   it("preserves channel ids for same-kind webhook registrations", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { teams } = await import("../src/channels.ts")


### PR DESCRIPTION
`@vite-hub/agent` message Channels can now opt into `messages.delivery: "manual"` and set a positive `messages.timeout`. Manual delivery keeps collected Agent output private while still delivering explicit finish replies, and it rejects streaming or commentary settings because those modes would give both the framework and the app ownership of the same response.

ViteHub now owns the configured placeholder lifecycle: it posts the placeholder before invocation, edits it with the first replaceable explicit reply or error fallback, posts later replies normally, removes an unused placeholder (including when error fallback is disabled), and removes it before posting an unreplaceable artifact reply. If editing a streamed reply fails, the buffered reply is posted without losing content; failures in later replies cannot overwrite an already-delivered first reply. Automatic delivery remains unchanged, so downstream apps no longer need to post acknowledgements from filters or patch raw structured output handling.

Validated with all 497 Agent provider/runtime tests, the focused manual and automatic delivery matrix, Agent typecheck, Agent build and publint, `git diff --check`, and independent standards and behavior reviews.