### PR TITLE
feat(box): add ASCII Box runtime

### DIFF
--- a/fallow.toml
+++ b/fallow.toml
@@ -123,6 +123,8 @@ ignoreDependencies = [
   "@azure/storage-blob",
   # The umbrella package owns the AI SDK 6 peer required by files-sdk.
   "ai",
+  # Box provider adapters load these only from runtime-selected chunks.
+  "@asciidev/box-sdk",
   "@cloudflare/sandbox",
   "@google-cloud/storage",
   "@googleapis/drive",
@@ -140,6 +142,7 @@ ignoreDependencies = [
   "files-sdk",
   "google-auth-library",
   "publint",
+  "ssh2",
   "uploadthing",
   "workflow",
 ]

--- a/packages/box/README.md
+++ b/packages/box/README.md
@@ -97,7 +97,7 @@ Use `runtime: "vercel"` for the default Vercel Sandbox configuration. Cloudflare
 ASCII is selected through the same Box API. Install its optional control-plane SDK, then use either the default environment-backed selection or a tagged configuration:
 
 ```sh
-pnpm add @vite-hub/box @asciidev/box-sdk
+pnpm add @vite-hub/box @asciidev/box-sdk ssh2
 ```
 
 ```ts

--- a/packages/box/README.md
+++ b/packages/box/README.md
@@ -94,6 +94,28 @@ const vercel = await resolveBox({
 
 Use `runtime: "vercel"` for the default Vercel Sandbox configuration. Cloudflare remains tag-only because its Durable Objects namespace is required.
 
+ASCII is selected through the same Box API. Install its optional control-plane SDK, then use either the default environment-backed selection or a tagged configuration:
+
+```sh
+pnpm add @vite-hub/box @asciidev/box-sdk
+```
+
+```ts
+const ascii = await resolveBox(
+  {
+    runtime: "ascii",
+    checkout: {
+      ref: "refs/pull/123/head",
+      remote: "https://github.com/acme/project.git",
+      sha: "0123456789abcdef0123456789abcdef01234567",
+    },
+  },
+  {},
+);
+```
+
+`runtime: "ascii"` reads `BOX_API_KEY` and uses a two-hour disposable TTL, which leaves room for an hour-long Agent Invocation plus preparation and cleanup. Use `{ kind: "ascii", apiKey, baseUrl, ttlSeconds }` for explicit server configuration. ViteHub creates the machine without account secrets, authorizes a session-only SSH key, materializes Home and the exact Git commit through the shared Box path, and deletes the Box when the session closes. It does not use caller-owned SSH keys or introduce a separate remote-Box abstraction.
+
 The Cloudflare runtime preserves Durable Object idle reuse and bounds transient transport operations with retries and deadlines. The Vercel runtime exposes only the ports declared when the microVM is created. Both reject host `cwd`; materialize a Workspace into their disposable working tree instead.
 
 `box.open({ initialize })` runs initialization inside runtime preparation. If initialization fails, a runtime must tear down the session and roll back state created for that failed boot.

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -36,9 +36,11 @@
     "test": "vp run -t @vite-hub/box#build && vp test"
   },
   "dependencies": {
-    "@vite-hub/runtime": "workspace:*"
+    "@vite-hub/runtime": "workspace:*",
+    "ssh2": "^1.17.0"
   },
   "devDependencies": {
+    "@asciidev/box-sdk": "^0.0.24",
     "@cloudflare/sandbox": "catalog:sandbox",
     "@types/node": "catalog:tooling",
     "@vercel/sandbox": "catalog:sandbox",
@@ -48,10 +50,14 @@
     "vitest": "catalog:tooling"
   },
   "peerDependencies": {
+    "@asciidev/box-sdk": "^0.0.24",
     "@cloudflare/sandbox": "catalog:sandbox",
     "@vercel/sandbox": "catalog:sandbox"
   },
   "peerDependenciesMeta": {
+    "@asciidev/box-sdk": {
+      "optional": true
+    },
     "@cloudflare/sandbox": {
       "optional": true
     },

--- a/packages/box/package.json
+++ b/packages/box/package.json
@@ -36,8 +36,7 @@
     "test": "vp run -t @vite-hub/box#build && vp test"
   },
   "dependencies": {
-    "@vite-hub/runtime": "workspace:*",
-    "ssh2": "^1.17.0"
+    "@vite-hub/runtime": "workspace:*"
   },
   "devDependencies": {
     "@asciidev/box-sdk": "^0.0.24",
@@ -45,6 +44,7 @@
     "@types/node": "catalog:tooling",
     "@vercel/sandbox": "catalog:sandbox",
     "publint": "catalog:tooling",
+    "ssh2": "^1.17.0",
     "typescript": "catalog:tooling",
     "vite-plus": "catalog:tooling",
     "vitest": "catalog:tooling"
@@ -52,6 +52,7 @@
   "peerDependencies": {
     "@asciidev/box-sdk": "^0.0.24",
     "@cloudflare/sandbox": "catalog:sandbox",
+    "ssh2": "^1.17.0",
     "@vercel/sandbox": "catalog:sandbox"
   },
   "peerDependenciesMeta": {
@@ -59,6 +60,9 @@
       "optional": true
     },
     "@cloudflare/sandbox": {
+      "optional": true
+    },
+    "ssh2": {
       "optional": true
     },
     "@vercel/sandbox": {

--- a/packages/box/src/ascii.ts
+++ b/packages/box/src/ascii.ts
@@ -117,6 +117,7 @@ export function createAsciiRuntime(
         const transport = await connectAsciiSsh(
           dependencies.openSsh ?? openAsciiSshSession,
           {
+            abortSignal: openOptions.signal,
             destroyBox: async () => await removeAsciiBox(client, boxId),
             host: box.ip!,
             hostKeys,

--- a/packages/box/src/ascii.ts
+++ b/packages/box/src/ascii.ts
@@ -25,6 +25,7 @@ interface AsciiRuntimeDependencies {
   createClient?: (options: { apiKey: string; baseUrl: string }) => Promise<AsciiClient>;
   createIdentity?: () => Promise<AsciiSshIdentity>;
   openSsh?: (options: AsciiSshOptions) => Promise<RuntimeSession>;
+  provisioningTimeoutMs?: number;
 }
 
 interface AsciiClient {
@@ -107,7 +108,12 @@ export function createAsciiRuntime(
       let runtimeSession: RuntimeSession | undefined;
       try {
         openOptions.signal?.throwIfAborted();
-        const box = await waitForAsciiBox(client, boxId, openOptions.signal);
+        const box = await waitForAsciiBox(
+          client,
+          boxId,
+          openOptions.signal,
+          dependencies.provisioningTimeoutMs ?? 300_000,
+        );
         const identity = await (dependencies.createIdentity ?? createAsciiSshIdentity)();
         await client.sshKey(
           { boxId, sshKeyRequest: { key: identity.publicKey } },
@@ -125,7 +131,12 @@ export function createAsciiRuntime(
           },
           openOptions.signal,
         );
-        runtimeSession = withAsciiLifecycle(transport, client, boxId);
+        runtimeSession = withAsciiLifecycle(
+          transport,
+          client,
+          boxId,
+          openOptions.id ?? boxId,
+        );
         await probeAsciiTransport(runtimeSession, openOptions.signal);
         const env = await resolveRemoteEnvironment(input, {
           home: "/home/user/.vitehub/home",
@@ -185,16 +196,19 @@ async function waitForAsciiBox(
   client: AsciiClient,
   boxId: string,
   signal: AbortSignal | undefined,
+  timeoutMs: number,
 ) {
+  const deadline = AbortSignal.timeout(timeoutMs);
+  const provisioningSignal = signal ? AbortSignal.any([signal, deadline]) : deadline;
   for (let attempt = 0; attempt < 150; attempt++) {
-    signal?.throwIfAborted();
-    const { box } = await client.get({ boxId }, requestInit(signal));
+    provisioningSignal.throwIfAborted();
+    const { box } = await client.get({ boxId }, requestInit(provisioningSignal));
     if (["ready", "idle", "running"].includes(box.state) && box.ip) return box;
     if (box.state === "error")
       throw new Error(`[vitehub] ASCII Box ${boxId} entered the error state.`);
     if (box.state === "archived")
       throw new Error(`[vitehub] ASCII Box ${boxId} was archived during provisioning.`);
-    await abortableDelay(2_000, signal);
+    await abortableDelay(2_000, provisioningSignal);
   }
   throw new Error(`[vitehub] ASCII Box ${boxId} did not become ready within five minutes.`);
 }
@@ -322,11 +336,12 @@ function withAsciiLifecycle(
   transport: RuntimeSession,
   client: AsciiClient,
   boxId: string,
+  sessionId: string,
 ): RuntimeSession {
   let destroyPromise: Promise<void> | undefined;
   return {
     ...transport,
-    id: boxId,
+    id: sessionId,
     async destroy() {
       destroyPromise ??= closeAsciiBox(transport, client, boxId);
       return await destroyPromise;

--- a/packages/box/src/ascii.ts
+++ b/packages/box/src/ascii.ts
@@ -1,0 +1,462 @@
+import type { ExecutionAuthority } from "@vite-hub/runtime";
+import type { BoxRuntime } from "./index.ts";
+import {
+  createAsciiSshIdentity,
+  openAsciiSshSession,
+  parseAsciiSshHostKeys,
+  type AsciiSshIdentity,
+  type AsciiSshOptions,
+} from "./internal/ascii-ssh.ts";
+import { openRemoteBox, remoteBoxPlan, resolveRemoteEnvironment } from "./internal/remote.ts";
+import { markBuiltInBoxRuntime } from "./internal/runtime.ts";
+import type { RuntimeSession } from "./internal/session.ts";
+
+const asciiSdkPackage = "@asciidev/box-sdk";
+const defaultAsciiBaseUrl = "https://ascii.dev/api/box/v1";
+const defaultAsciiTtlSeconds = 7200;
+
+export interface AsciiBoxOptions {
+  apiKey?: string;
+  baseUrl?: string;
+  ttlSeconds?: number;
+}
+
+interface AsciiRuntimeDependencies {
+  createClient?: (options: { apiKey: string; baseUrl: string }) => Promise<AsciiClient>;
+  createIdentity?: () => Promise<AsciiSshIdentity>;
+  openSsh?: (options: AsciiSshOptions) => Promise<RuntimeSession>;
+}
+
+interface AsciiClient {
+  command(
+    input: {
+      boxId: string;
+      commandRequest: { command: string; timeoutSeconds?: number };
+    },
+    init?: RequestInit,
+  ): Promise<{
+    exitCode: number | null;
+    stderr: string;
+    stderrTruncated?: boolean;
+    stdout: string;
+    stdoutTruncated?: boolean;
+    timedOut: boolean;
+  }>;
+  create(
+    input: {
+      createBoxRequest: {
+        noEnv: true;
+        ttlSeconds: number;
+      };
+    },
+    init?: RequestInit,
+  ): Promise<{ box: AsciiBoxInfo }>;
+  get(input: { boxId: string }, init?: RequestInit): Promise<{ box: AsciiBoxInfo }>;
+  remove(input: { boxId: string }, init?: RequestInit): Promise<unknown>;
+  sshKey(
+    input: { boxId: string; sshKeyRequest: { key: string } },
+    init?: RequestInit,
+  ): Promise<unknown>;
+  stop(input: { boxId: string }, init?: RequestInit): Promise<unknown>;
+}
+
+interface AsciiBoxInfo {
+  id: string;
+  ip?: string | null;
+  state: string;
+}
+
+const asciiExecutionAuthority = {
+  credentials: "unknown",
+  environment: "selected",
+  filesystem: { access: "read-write", scope: "sandbox" },
+  isolation: "unknown",
+  network: "unknown",
+  processes: "arbitrary",
+} as const satisfies ExecutionAuthority;
+
+export function createAsciiRuntime(
+  options: AsciiBoxOptions = {},
+  dependencies: AsciiRuntimeDependencies = {},
+): BoxRuntime {
+  const ttlSeconds = options.ttlSeconds ?? defaultAsciiTtlSeconds;
+  if (!Number.isInteger(ttlSeconds) || ttlSeconds < 7200 || ttlSeconds > 2_592_000)
+    throw new TypeError("[vitehub] ASCII ttlSeconds must be an integer between 7200 and 2592000.");
+  return markBuiltInBoxRuntime({
+    name: "ascii",
+    async prepare(input) {
+      return remoteBoxPlan(input, {
+        executionAuthority: asciiExecutionAuthority,
+        runtime: "ascii",
+      });
+    },
+    async open(input, openOptions) {
+      openOptions.signal?.throwIfAborted();
+      const apiKey = options.apiKey ?? process.env.BOX_API_KEY;
+      if (!apiKey)
+        throw new Error("[vitehub] The ASCII Box runtime requires apiKey or BOX_API_KEY.");
+      const client = await (dependencies.createClient ?? loadAsciiClient)({
+        apiKey,
+        baseUrl: options.baseUrl ?? process.env.BOX_BASE_URL ?? defaultAsciiBaseUrl,
+      });
+      const created = await client.create(
+        { createBoxRequest: { noEnv: true, ttlSeconds } },
+        requestInit(AbortSignal.timeout(300_000)),
+      );
+      const boxId = created.box.id;
+      let runtimeSession: RuntimeSession | undefined;
+      try {
+        openOptions.signal?.throwIfAborted();
+        const box = await waitForAsciiBox(client, boxId, openOptions.signal);
+        const identity = await (dependencies.createIdentity ?? createAsciiSshIdentity)();
+        await client.sshKey(
+          { boxId, sshKeyRequest: { key: identity.publicKey } },
+          requestInit(openOptions.signal),
+        );
+        const hostKeys = await readAsciiHostKeys(client, boxId, openOptions.signal);
+        const transport = await connectAsciiSsh(
+          dependencies.openSsh ?? openAsciiSshSession,
+          {
+            destroyBox: async () => await removeAsciiBox(client, boxId),
+            host: box.ip!,
+            hostKeys,
+            identity,
+          },
+          openOptions.signal,
+        );
+        runtimeSession = withAsciiLifecycle(transport, client, boxId);
+        await probeAsciiTransport(runtimeSession, openOptions.signal);
+        const env = await resolveRemoteEnvironment(input, {
+          home: "/home/user/.vitehub/home",
+          workspace: "/home/user/.vitehub/workspace",
+        });
+        return await openRemoteBox(input, withBaseEnvironment(runtimeSession, env), {
+          executionAuthority: openOptions.executionAuthority,
+          home: "/home/user/.vitehub/home",
+          initialize: openOptions.initialize,
+          runtime: "ascii",
+          signal: openOptions.signal,
+          workspace: "/home/user/.vitehub/workspace",
+        });
+      } catch (error) {
+        if (runtimeSession) {
+          try {
+            await runtimeSession.destroy?.();
+          } catch (cleanupError) {
+            throw new AggregateError(
+              [error, cleanupError],
+              "[vitehub] ASCII Box initialization and cleanup failed.",
+            );
+          }
+          throw error;
+        }
+        try {
+          await removeAsciiBox(client, boxId);
+        } catch (cleanupError) {
+          throw new AggregateError(
+            [error, cleanupError],
+            "[vitehub] ASCII Box initialization and cleanup failed.",
+          );
+        }
+        throw error;
+      }
+    },
+  });
+}
+
+async function loadAsciiClient(options: { apiKey: string; baseUrl: string }): Promise<AsciiClient> {
+  try {
+    const { BoxApi, Configuration } = await import(/* @vite-ignore */ asciiSdkPackage);
+    return new BoxApi(
+      new Configuration({
+        accessToken: options.apiKey,
+        basePath: options.baseUrl,
+      }),
+    ) as unknown as AsciiClient;
+  } catch (error) {
+    throw new Error(
+      `[vitehub] The ASCII Box runtime requires @asciidev/box-sdk: ${error instanceof Error ? error.message : error}`,
+    );
+  }
+}
+
+async function waitForAsciiBox(
+  client: AsciiClient,
+  boxId: string,
+  signal: AbortSignal | undefined,
+) {
+  for (let attempt = 0; attempt < 150; attempt++) {
+    signal?.throwIfAborted();
+    const { box } = await client.get({ boxId }, requestInit(signal));
+    if (["ready", "idle", "running"].includes(box.state) && box.ip) return box;
+    if (box.state === "error")
+      throw new Error(`[vitehub] ASCII Box ${boxId} entered the error state.`);
+    if (box.state === "archived")
+      throw new Error(`[vitehub] ASCII Box ${boxId} was archived during provisioning.`);
+    await abortableDelay(2_000, signal);
+  }
+  throw new Error(`[vitehub] ASCII Box ${boxId} did not become ready within five minutes.`);
+}
+
+async function readAsciiHostKeys(
+  client: AsciiClient,
+  boxId: string,
+  signal: AbortSignal | undefined,
+) {
+  const result = await client.command(
+    {
+      boxId,
+      commandRequest: {
+        command: "sudo -n sh -c 'cat /etc/ssh/ssh_host_*_key.pub'",
+        timeoutSeconds: 30,
+      },
+    },
+    requestInit(signal),
+  );
+  if (
+    result.timedOut ||
+    result.exitCode !== 0 ||
+    result.stdoutTruncated ||
+    result.stderrTruncated
+  ) {
+    throw new Error(`[vitehub] ASCII could not retrieve complete SSH host keys: ${result.stderr}`);
+  }
+  return parseAsciiSshHostKeys(result.stdout);
+}
+
+async function connectAsciiSsh(
+  open: (options: AsciiSshOptions) => Promise<RuntimeSession>,
+  options: AsciiSshOptions,
+  signal: AbortSignal | undefined,
+) {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 30; attempt++) {
+    signal?.throwIfAborted();
+    try {
+      return await open(options);
+    } catch (error) {
+      lastError = error;
+      if (!isRetryableSshError(error)) throw error;
+      await abortableDelay(2_000, signal);
+    }
+  }
+  throw new Error(
+    `[vitehub] ASCII SSH did not become ready: ${lastError instanceof Error ? lastError.message : lastError}`,
+  );
+}
+
+async function probeAsciiTransport(session: RuntimeSession, signal: AbortSignal | undefined) {
+  const directory = `/home/user/.vitehub-probe-${crypto.randomUUID()}`;
+  await session.makeDirectory({ abortSignal: signal, path: directory, recursive: false });
+  try {
+    const path = `${directory}/binary`;
+    const expected = new Uint8Array([0, 1, 127, 128, 255]);
+    await session.writeBinaryFile({ abortSignal: signal, content: expected, path });
+    const actual = await session.readBinaryFile({ abortSignal: signal, path });
+    if (
+      !actual ||
+      actual.length !== expected.length ||
+      actual.some((value, index) => value !== expected[index])
+    ) {
+      throw new Error("[vitehub] ASCII SFTP binary probe failed.");
+    }
+    const success = await session.run({
+      abortSignal: signal,
+      command: "printf vitehub-ascii",
+      workingDirectory: directory,
+    });
+    if (success.exitCode !== 0 || success.stdout !== "vitehub-ascii")
+      throw new Error("[vitehub] ASCII streamed command probe failed.");
+    const failure = await session.run({
+      abortSignal: signal,
+      command: "exit 37",
+      workingDirectory: directory,
+    });
+    if (failure.exitCode !== 37)
+      throw new Error("[vitehub] ASCII command exit-status probe failed.");
+    if (!session.spawn)
+      throw new Error("[vitehub] ASCII SSH transport does not support long-running processes.");
+    const process = await session.spawn({
+      abortSignal: signal,
+      command: "sleep 3600",
+      workingDirectory: directory,
+    });
+    await process.kill("KILL");
+    await process.wait();
+  } finally {
+    await session.removeFile({
+      abortSignal: signal,
+      path: directory,
+      recursive: true,
+    });
+  }
+}
+
+function withBaseEnvironment(
+  session: RuntimeSession,
+  baseEnv: Record<string, string>,
+): RuntimeSession {
+  return {
+    ...session,
+    async run(options) {
+      return await session.run({
+        ...options,
+        env: { ...baseEnv, ...options.env },
+      });
+    },
+    ...(session.spawn
+      ? {
+          async spawn(options: Parameters<NonNullable<RuntimeSession["spawn"]>>[0]) {
+            return await session.spawn!({
+              ...options,
+              env: { ...baseEnv, ...options.env },
+            });
+          },
+        }
+      : {}),
+  };
+}
+
+function withAsciiLifecycle(
+  transport: RuntimeSession,
+  client: AsciiClient,
+  boxId: string,
+): RuntimeSession {
+  let destroyPromise: Promise<void> | undefined;
+  return {
+    ...transport,
+    id: boxId,
+    async destroy() {
+      destroyPromise ??= closeAsciiBox(transport, client, boxId);
+      return await destroyPromise;
+    },
+  };
+}
+
+async function closeAsciiBox(transport: RuntimeSession, client: AsciiClient, boxId: string) {
+  const failures: unknown[] = [];
+  try {
+    await withTimeout(
+      transport.stop(),
+      10_000,
+      `[vitehub] ASCII Box ${boxId} SSH teardown timed out.`,
+    );
+  } catch (error) {
+    failures.push(error);
+  }
+  try {
+    await removeAsciiBox(client, boxId);
+  } catch (error) {
+    failures.push(error);
+  }
+  if (failures.length)
+    throw new AggregateError(failures, `[vitehub] ASCII Box ${boxId} teardown failed.`);
+}
+
+async function removeAsciiBox(client: AsciiClient, boxId: string) {
+  const removalSignal = AbortSignal.timeout(20_000);
+  let removalError: unknown;
+  try {
+    await client.remove({ boxId }, requestInit(removalSignal));
+    for (let attempt = 0; attempt < 20; attempt++) {
+      try {
+        await client.get({ boxId }, requestInit(removalSignal));
+      } catch (error) {
+        if (isNotFound(error)) return;
+        throw error;
+      }
+      await abortableDelay(500, removalSignal);
+    }
+    removalError = new Error(`[vitehub] ASCII Box ${boxId} still exists after deletion.`);
+  } catch (error) {
+    if (isNotFound(error)) return;
+    removalError = error;
+  }
+
+  let containmentError: unknown;
+  const containmentSignal = AbortSignal.timeout(10_000);
+  try {
+    await client.stop({ boxId }, requestInit(containmentSignal));
+    await waitForArchived(client, boxId, containmentSignal);
+  } catch (error) {
+    containmentError = error;
+  }
+  throw new AggregateError(
+    containmentError ? [removalError, containmentError] : [removalError],
+    `[vitehub] ASCII Box ${boxId} could not be verified as deleted.`,
+  );
+}
+
+async function waitForArchived(client: AsciiClient, boxId: string, signal: AbortSignal) {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    try {
+      const { box } = await client.get({ boxId }, requestInit(signal));
+      if (box.state === "archived") return;
+    } catch (error) {
+      if (isNotFound(error)) return;
+      throw error;
+    }
+    await abortableDelay(500, signal);
+  }
+  throw new Error(`[vitehub] ASCII Box ${boxId} was not archived after deletion failed.`);
+}
+
+function isNotFound(error: unknown) {
+  if (!error || typeof error !== "object") return false;
+  if ("status" in error && error.status === 404) return true;
+  return (
+    "response" in error &&
+    !!error.response &&
+    typeof error.response === "object" &&
+    "status" in error.response &&
+    error.response.status === 404
+  );
+}
+
+function isRetryableSshError(error: unknown) {
+  if (!error || typeof error !== "object") return false;
+  if (
+    "code" in error &&
+    ["ECONNREFUSED", "ECONNRESET", "EHOSTUNREACH", "ETIMEDOUT"].includes(String(error.code))
+  ) {
+    return true;
+  }
+  return error instanceof Error && error.message.includes("box_restoring");
+}
+
+function requestInit(signal: AbortSignal | undefined): RequestInit | undefined {
+  return signal ? { signal } : undefined;
+}
+
+async function abortableDelay(milliseconds: number, signal: AbortSignal | undefined) {
+  await new Promise<void>((resolve, reject) => {
+    const finish = () => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    };
+    const timer = setTimeout(finish, milliseconds);
+    const onAbort = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+      reject(signal!.reason);
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) onAbort();
+  });
+}
+
+async function withTimeout<T>(promise: Promise<T>, milliseconds: number, message: string) {
+  return await new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(message)), milliseconds);
+    void promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}

--- a/packages/box/src/index.ts
+++ b/packages/box/src/index.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { readFile, realpath } from "node:fs/promises";
 import { isAbsolute, posix, relative, resolve } from "node:path";
 import { normalizeExecutionAuthority, type ExecutionAuthority } from "@vite-hub/runtime";
+import type { AsciiBoxOptions } from "./ascii.ts";
 import type { CloudflareBoxOptions, CloudflareDurableObjectNamespace, CloudflareSandboxStub } from "./cloudflare.ts";
 import type { CrabboxOptions } from "./internal/crabbox.ts";
 import type { TrustedHostOptions } from "./internal/trusted-host.ts";
@@ -17,6 +18,7 @@ import type {
 import { isBuiltInBoxRuntime } from "./internal/runtime.ts";
 
 export type {
+  AsciiBoxOptions,
   CloudflareBoxOptions,
   CloudflareDurableObjectNamespace,
   CloudflareSandboxStub,
@@ -75,10 +77,11 @@ export interface BoxDefinition<Context = unknown> {
   runtime: BoxRuntimeDefinition;
 }
 
-export type BuiltInBoxRuntimeName = "crabbox" | "trusted-host" | "vercel";
+export type BuiltInBoxRuntimeName = "ascii" | "crabbox" | "trusted-host" | "vercel";
 
 export type BuiltInBoxRuntime =
   | BuiltInBoxRuntimeName
+  | ({ kind: "ascii" } & AsciiBoxOptions)
   | ({ kind: "crabbox" } & CrabboxOptions)
   | ({ kind: "trusted-host" } & TrustedHostOptions)
   | ({ kind: "cloudflare" } & CloudflareBoxOptions)
@@ -255,6 +258,7 @@ export interface ResolveBoxOptions {
 }
 
 const reservedRuntimeNames = new Set([
+  "ascii",
   "cloudflare",
   "crabbox",
   "trusted-host",
@@ -269,6 +273,10 @@ async function resolveBoxRuntime(value: unknown): Promise<BoxRuntime> {
     return value;
   }
   if (typeof value === "string") {
+    if (value === "ascii") {
+      const { createAsciiRuntime } = await import("./ascii.ts");
+      return createAsciiRuntime();
+    }
     if (value === "crabbox") {
       const { createCrabboxRuntime } = await import("./internal/crabbox.ts");
       return createCrabboxRuntime();
@@ -281,13 +289,17 @@ async function resolveBoxRuntime(value: unknown): Promise<BoxRuntime> {
       const { createVercelRuntime } = await import("./vercel.ts");
       return createVercelRuntime();
     }
-    throw new Error(`[vitehub] Unknown Box runtime "${value}". Expected "crabbox", "trusted-host", "vercel", a tagged built-in configuration, or a custom runtime.`);
+    throw new Error(`[vitehub] Unknown Box runtime "${value}". Expected "ascii", "crabbox", "trusted-host", "vercel", a tagged built-in configuration, or a custom runtime.`);
   }
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new TypeError("[vitehub] Box requires an explicit built-in runtime value or custom runtime object.");
   }
 
   const { kind, ...options } = value as Record<string, unknown>;
+  if (kind === "ascii") {
+    const { createAsciiRuntime } = await import("./ascii.ts");
+    return createAsciiRuntime(options as AsciiBoxOptions);
+  }
   if (kind === "crabbox") {
     const { createCrabboxRuntime } = await import("./internal/crabbox.ts");
     return createCrabboxRuntime(options as CrabboxOptions);
@@ -304,7 +316,7 @@ async function resolveBoxRuntime(value: unknown): Promise<BoxRuntime> {
     const { createVercelRuntime } = await import("./vercel.ts");
     return createVercelRuntime(options as VercelBoxOptions);
   }
-  throw new Error(`[vitehub] Unknown Box runtime kind "${String(kind)}". Expected "crabbox", "trusted-host", "cloudflare", or "vercel".`);
+  throw new Error(`[vitehub] Unknown Box runtime kind "${String(kind)}". Expected "ascii", "crabbox", "trusted-host", "cloudflare", or "vercel".`);
 }
 
 function isBoxRuntime(value: unknown): value is BoxRuntime {

--- a/packages/box/src/internal/ascii-ssh.ts
+++ b/packages/box/src/internal/ascii-ssh.ts
@@ -21,6 +21,7 @@ export interface AsciiSshIdentity {
 }
 
 export interface AsciiSshOptions {
+  readonly abortSignal?: AbortSignal;
   readonly destroyBox: () => Promise<void>;
   readonly host: string;
   readonly hostKeys: readonly Uint8Array[];
@@ -80,7 +81,12 @@ export async function openAsciiSshSession(
   const fault = createTransportFault(options.destroyBox);
   await connect(client, options, fault.record);
   try {
-    const sftp = await openSftp(client);
+    const sftp = await waitWithTimeout(
+      openSftp(client),
+      20_000,
+      "[vitehub] ASCII SFTP negotiation timed out.",
+      options.abortSignal,
+    );
     return createAsciiSshSession(client, sftp, options.destroyBox, fault);
   } catch (error) {
     client.destroy();

--- a/packages/box/src/internal/ascii-ssh.ts
+++ b/packages/box/src/internal/ascii-ssh.ts
@@ -114,11 +114,19 @@ async function connect(
   onTransportError: (error: Error) => void,
 ) {
   const expectedKeys = options.hostKeys.map((key) => Buffer.from(key));
+  options.abortSignal?.throwIfAborted();
   await new Promise<void>((resolve, reject) => {
     let ready = false;
+    const onAbort = () => {
+      client.removeListener("ready", onReady);
+      client.removeListener("error", onError);
+      client.destroy();
+      reject(options.abortSignal!.reason);
+    };
     const onReady = () => {
       ready = true;
       client.removeListener("ready", onReady);
+      options.abortSignal?.removeEventListener("abort", onAbort);
       resolve();
     };
     const onError = (error: Error) => {
@@ -126,12 +134,19 @@ async function connect(
         onTransportError(error);
       } else {
         client.removeListener("ready", onReady);
+        client.removeListener("error", onError);
+        options.abortSignal?.removeEventListener("abort", onAbort);
         client.destroy();
         reject(error);
       }
     };
     client.on("ready", onReady);
     client.on("error", onError);
+    options.abortSignal?.addEventListener("abort", onAbort, { once: true });
+    if (options.abortSignal?.aborted) {
+      onAbort();
+      return;
+    }
     client.connect({
       host: options.host,
       hostVerifier(key) {
@@ -257,7 +272,7 @@ function createAsciiSshSession(
         workingDirectory: "/home/user",
       });
       if (result.exitCode !== 0) throw new Error(result.stderr);
-      return parseFileList(result.stdout);
+      return parseAsciiFileList(result.stdout);
     },
     async makeDirectory({ abortSignal, path, recursive }) {
       const result = await run({
@@ -664,12 +679,16 @@ function createTransportFault(destroyBox: () => Promise<void>): TransportFault {
   };
 }
 
-function parseFileList(output: string): BoxFileEntry[] {
+export function parseAsciiFileList(output: string): BoxFileEntry[] {
   return output
     .split("\0")
     .filter(Boolean)
     .map((line) => {
-      const [kind, size, path] = line.split("\t");
+      const kindSeparator = line.indexOf("\t");
+      const sizeSeparator = line.indexOf("\t", kindSeparator + 1);
+      const kind = line.slice(0, kindSeparator);
+      const size = line.slice(kindSeparator + 1, sizeSeparator);
+      const path = line.slice(sizeSeparator + 1);
       return {
         path,
         size: kind === "f" ? Number(size) : undefined,

--- a/packages/box/src/internal/ascii-ssh.ts
+++ b/packages/box/src/internal/ascii-ssh.ts
@@ -1,0 +1,795 @@
+import { randomUUID } from "node:crypto";
+import { posix } from "node:path";
+import { Readable } from "node:stream";
+import type { BoxFileEntry } from "../index.ts";
+import { shellQuote } from "./remote.ts";
+import type { RuntimeProcess, RuntimeSession } from "./session.ts";
+
+const ssh2Package = "ssh2";
+const allowedSignals = new Set(["HUP", "INT", "KILL", "QUIT", "TERM"]);
+const signalExitCodes: Readonly<Record<string, number>> = {
+  HUP: 129,
+  INT: 130,
+  KILL: 137,
+  QUIT: 131,
+  TERM: 143,
+};
+
+export interface AsciiSshIdentity {
+  readonly privateKey: string;
+  readonly publicKey: string;
+}
+
+export interface AsciiSshOptions {
+  readonly destroyBox: () => Promise<void>;
+  readonly host: string;
+  readonly hostKeys: readonly Uint8Array[];
+  readonly identity: AsciiSshIdentity;
+  readonly port?: number;
+}
+
+export async function createAsciiSshIdentity(): Promise<AsciiSshIdentity> {
+  const ssh2 = await loadSsh2();
+  const generated = ssh2.utils.generateKeyPairSync("rsa", {
+    bits: 3072,
+    comment: `vitehub-${randomUUID()}`,
+  });
+  return {
+    privateKey: generated.private,
+    publicKey: generated.public,
+  };
+}
+
+export function parseAsciiSshHostKeys(output: string): readonly Uint8Array[] {
+  const keys = output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [type, encoded] = line.split(/\s+/);
+      if (!type || !/^[A-Za-z0-9@._+-]+$/.test(type) || !encoded)
+        throw new Error("[vitehub] ASCII returned an invalid SSH host public key.");
+      const key = Buffer.from(encoded, "base64");
+      if (
+        key.length === 0 ||
+        key.toString("base64").replace(/=+$/, "") !== encoded.replace(/=+$/, "")
+      )
+        throw new Error("[vitehub] ASCII returned an invalid SSH host public key.");
+      if (key.length < 5)
+        throw new Error("[vitehub] ASCII returned an invalid SSH host public key.");
+      const typeLength = key.readUInt32BE(0);
+      if (
+        typeLength <= 0 ||
+        typeLength + 4 >= key.length ||
+        key.subarray(4, 4 + typeLength).toString() !== type
+      ) {
+        throw new Error("[vitehub] ASCII returned an invalid SSH host public key.");
+      }
+      return new Uint8Array(key);
+    });
+  if (keys.length === 0) throw new Error("[vitehub] ASCII returned no SSH host public keys.");
+  return keys;
+}
+
+export async function openAsciiSshSession(
+  options: AsciiSshOptions,
+  loadModule: () => Promise<Ssh2Module> = loadSsh2,
+): Promise<RuntimeSession> {
+  const ssh2 = await loadModule();
+  const client = new ssh2.Client();
+  const fault = createTransportFault(options.destroyBox);
+  await connect(client, options, fault.record);
+  try {
+    const sftp = await openSftp(client);
+    return createAsciiSshSession(client, sftp, options.destroyBox, fault);
+  } catch (error) {
+    client.destroy();
+    throw error;
+  }
+}
+
+async function loadSsh2(): Promise<Ssh2Module> {
+  try {
+    const imported = await import(/* @vite-ignore */ ssh2Package);
+    return {
+      Client: imported.Client,
+      utils: imported.default.utils,
+    } as unknown as Ssh2Module;
+  } catch (error) {
+    throw new Error(
+      `[vitehub] The ASCII Box runtime requires ssh2: ${error instanceof Error ? error.message : error}`,
+    );
+  }
+}
+
+async function connect(
+  client: SshClient,
+  options: AsciiSshOptions,
+  onTransportError: (error: Error) => void,
+) {
+  const expectedKeys = options.hostKeys.map((key) => Buffer.from(key));
+  await new Promise<void>((resolve, reject) => {
+    let ready = false;
+    const onReady = () => {
+      ready = true;
+      client.removeListener("ready", onReady);
+      resolve();
+    };
+    const onError = (error: Error) => {
+      if (ready) {
+        onTransportError(error);
+      } else {
+        client.removeListener("ready", onReady);
+        client.destroy();
+        reject(error);
+      }
+    };
+    client.on("ready", onReady);
+    client.on("error", onError);
+    client.connect({
+      host: options.host,
+      hostVerifier(key) {
+        return expectedKeys.some(
+          (expected) => expected.length === key.length && expected.equals(key),
+        );
+      },
+      keepaliveCountMax: 6,
+      keepaliveInterval: 10_000,
+      port: options.port ?? 22,
+      privateKey: options.identity.privateKey,
+      readyTimeout: 20_000,
+      username: "user",
+    });
+  });
+}
+
+async function openSftp(client: SshClient) {
+  return await new Promise<SftpClient>((resolve, reject) => {
+    client.sftp((error, sftp) => {
+      if (error) reject(error);
+      else resolve(sftp);
+    });
+  });
+}
+
+function createAsciiSshSession(
+  client: SshClient,
+  sftp: SftpClient,
+  destroyBox: () => Promise<void>,
+  fault: TransportFault,
+): RuntimeSession {
+  const workspace = "/home/user/.vitehub/workspace";
+  const processes = new Set<ReturnType<typeof createRuntimeProcess>>();
+  let closed = false;
+
+  const assertOpen = () => {
+    fault.throwIfFailed();
+    if (closed) throw new Error("[vitehub] ASCII SSH transport is closed.");
+  };
+  const exec = async (command: string) => {
+    assertOpen();
+    return await openChannel(client, command);
+  };
+  const spawn = async (options: {
+    abortSignal?: AbortSignal;
+    command: string;
+    env?: Record<string, string>;
+    workingDirectory?: string;
+  }) => {
+    assertOpen();
+    options.abortSignal?.throwIfAborted();
+    const unit = `vitehub-${randomUUID()}.service`;
+    let channel: SshChannel;
+    try {
+      channel = await waitWithTimeout(
+        exec(systemdRunCommand(unit, options)),
+        10_000,
+        `[vitehub] ASCII process ${unit} launch timed out.`,
+        options.abortSignal,
+      );
+    } catch (error) {
+      return await failClosed(error, destroyBox, `[vitehub] ASCII process ${unit} launch failed.`);
+    }
+    const process = createRuntimeProcess(
+      unit,
+      channel,
+      async (command) =>
+        await waitWithTimeout(
+          exec(command).then(async (channel) => await collectChannel(channel)),
+          10_000,
+          `[vitehub] ASCII SSH control command timed out for ${unit}.`,
+        ),
+      destroyBox,
+    );
+    processes.add(process);
+    void process.settled.finally(() => processes.delete(process));
+    if (options.abortSignal) {
+      const onAbort = () => void process.kill("KILL").catch(() => undefined);
+      options.abortSignal.addEventListener("abort", onAbort, { once: true });
+      void process.settled.finally(() =>
+        options.abortSignal?.removeEventListener("abort", onAbort),
+      );
+    }
+    await process.ready;
+    options.abortSignal?.throwIfAborted();
+    return process;
+  };
+  const run = async (options: {
+    abortSignal?: AbortSignal;
+    command: string;
+    env?: Record<string, string>;
+    workingDirectory?: string;
+  }) => {
+    const process = await spawn(options);
+    const [result, stdout, stderr] = await Promise.all([
+      process.wait(),
+      readStream(process.stdout),
+      readStream(process.stderr),
+    ]);
+    options.abortSignal?.throwIfAborted();
+    return { exitCode: result.exitCode, stderr, stdout };
+  };
+
+  return {
+    defaultWorkingDirectory: workspace,
+    id: `ascii-ssh-${randomUUID()}`,
+    async existsFile({ abortSignal, path }) {
+      return (
+        (
+          await run({
+            abortSignal,
+            command: `test -e ${shellQuote(path)}`,
+            workingDirectory: "/home/user",
+          })
+        ).exitCode === 0
+      );
+    },
+    async listFiles({ abortSignal, path, recursive }) {
+      const result = await run({
+        abortSignal,
+        command: `find ${shellQuote(path)} -mindepth 1 ${recursive ? "" : "-maxdepth 1 "}-printf '%y\\t%s\\t%p\\0'`,
+        workingDirectory: "/home/user",
+      });
+      if (result.exitCode !== 0) throw new Error(result.stderr);
+      return parseFileList(result.stdout);
+    },
+    async makeDirectory({ abortSignal, path, recursive }) {
+      const result = await run({
+        abortSignal,
+        command: `mkdir ${recursive ? "-p " : ""}-- ${shellQuote(path)}`,
+        workingDirectory: "/home/user",
+      });
+      if (result.exitCode !== 0) throw new Error(result.stderr);
+    },
+    async moveFile({ abortSignal, destination, source }) {
+      const result = await run({
+        abortSignal,
+        command: `mv -- ${shellQuote(source)} ${shellQuote(destination)}`,
+        workingDirectory: "/home/user",
+      });
+      if (result.exitCode !== 0) throw new Error(result.stderr);
+    },
+    async readBinaryFile({ abortSignal, path }) {
+      assertOpen();
+      try {
+        return new Uint8Array(
+          await sftpCall<Buffer>(abortSignal, client, fault.record, (callback) =>
+            sftp.readFile(path, callback),
+          ),
+        );
+      } catch (error) {
+        if (isMissingFile(error)) return null;
+        throw error;
+      }
+    },
+    async removeFile({ abortSignal, path, recursive }) {
+      const result = await run({
+        abortSignal,
+        command: recursive
+          ? `rm -rf -- ${shellQuote(path)}`
+          : `if test -d ${shellQuote(path)}; then rmdir -- ${shellQuote(path)}; else rm -f -- ${shellQuote(path)}; fi`,
+        workingDirectory: "/home/user",
+      });
+      if (result.exitCode !== 0) throw new Error(result.stderr);
+    },
+    run,
+    spawn,
+    async stop() {
+      if (closed) return;
+      const failures: unknown[] = [];
+      const stopped = await Promise.allSettled(
+        Array.from(processes, (process) => process.kill("KILL")),
+      );
+      failures.push(
+        ...stopped
+          .filter((result): result is PromiseRejectedResult => result.status === "rejected")
+          .map((result) => result.reason),
+      );
+      closed = true;
+      await fault.cleanup;
+      if (fault.error) failures.push(fault.error);
+      try {
+        sftp.end?.();
+        client.end();
+      } catch (error) {
+        failures.push(error);
+      }
+      if (failures.length)
+        throw new AggregateError(failures, "[vitehub] ASCII SSH teardown failed.");
+    },
+    async writeBinaryFile({ abortSignal, content, path }) {
+      assertOpen();
+      await sftpCall<void>(abortSignal, client, fault.record, (callback) =>
+        sftp.writeFile(path, Buffer.from(content), callback),
+      );
+    },
+  };
+}
+
+function systemdRunCommand(
+  unit: string,
+  options: {
+    command: string;
+    env?: Record<string, string>;
+    workingDirectory?: string;
+  },
+) {
+  const args = [
+    "sudo",
+    "-n",
+    "systemd-run",
+    "--quiet",
+    "--pipe",
+    "--wait",
+    "--collect",
+    "--service-type=exec",
+    `--unit=${unit}`,
+    "--uid=user",
+    "--gid=user",
+    `--working-directory=${options.workingDirectory ?? "/home/user/.vitehub/workspace"}`,
+    "--property=KillMode=control-group",
+    "--property=TimeoutStopSec=10s",
+    ...Object.entries(options.env ?? {}).map(([name, value]) => `--setenv=${name}=${value}`),
+    "--",
+    "/bin/sh",
+    "-lc",
+    options.command,
+  ];
+  return args.map(shellQuote).join(" ");
+}
+
+function createRuntimeProcess(
+  unit: string,
+  channel: SshChannel,
+  executeControl: (
+    command: string,
+  ) => Promise<{ exitCode: number; stderr: string; stdout: string }>,
+  destroyBox: () => Promise<void>,
+) {
+  let state: "launching" | "observed" | "terminal" = "launching";
+  let exitCode: number | undefined;
+  let killedExitCode: number | undefined;
+  let closeError: Error | undefined;
+  const settled = new Promise<void>((resolve) => {
+    channel.once("exit", (code: number | undefined) => {
+      if (typeof code === "number") exitCode = code;
+    });
+    channel.once("error", (error) => {
+      closeError = error;
+    });
+    channel.once("close", (code: number | undefined) => {
+      if (typeof code === "number") exitCode = code;
+      state = "terminal";
+      resolve();
+    });
+  });
+  const observed = observeUnit(unit, executeControl, () => state === "terminal").then((active) => {
+    if (state === "launching" && active) state = "observed";
+    return active;
+  });
+  const isTerminal = () => state === "terminal";
+  const ready = observed
+    .then(async (active) => {
+      if (active || isTerminal()) return;
+      throw new Error(`[vitehub] ASCII process ${unit} could not be observed after launch.`);
+    })
+    .catch(async (error) => {
+      await failClosed(error, destroyBox, `[vitehub] ASCII process ${unit} launch failed.`);
+    });
+
+  const process = {
+    ready,
+    settled,
+    stderr: toReadableStream(channel.stderr),
+    stdout: toReadableStream(channel),
+    async kill(signal?: string) {
+      const normalized = normalizeSignal(signal);
+      await observed;
+      if (isTerminal()) return;
+      let result: { exitCode: number; stderr: string; stdout: string };
+      try {
+        result = await executeControl(
+          [
+            "sudo -n systemctl kill",
+            "--kill-whom=all",
+            `--signal=SIG${normalized}`,
+            shellQuote(unit),
+          ].join(" "),
+        );
+      } catch (error) {
+        return await failClosed(error, destroyBox, `[vitehub] ASCII could not kill ${unit}.`);
+      }
+      if (result.exitCode !== 0) {
+        await Promise.race([settled, delay(250)]);
+        if (!isTerminal()) {
+          await destroyBox();
+          throw new Error(`[vitehub] ASCII could not kill ${unit}: ${result.stderr}`);
+        }
+      }
+      killedExitCode = signalExitCodes[normalized];
+      await waitWithTimeout(
+        settled,
+        10_000,
+        `[vitehub] ASCII process ${unit} did not terminate.`,
+      ).catch(async (error) => {
+        await destroyBox();
+        throw error;
+      });
+      try {
+        await verifyUnitStopped(unit, executeControl);
+      } catch (error) {
+        await destroyBox();
+        throw error;
+      }
+    },
+    async wait() {
+      await settled;
+      if (closeError) throw closeError;
+      if (exitCode === undefined)
+        throw new Error(`[vitehub] ASCII process ${unit} closed without an exit status.`);
+      return { exitCode: killedExitCode ?? exitCode };
+    },
+  } satisfies RuntimeProcess & { ready: Promise<void>; settled: Promise<void> };
+  return process;
+}
+
+async function observeUnit(
+  unit: string,
+  executeControl: (
+    command: string,
+  ) => Promise<{ exitCode: number; stderr: string; stdout: string }>,
+  terminal: () => boolean,
+) {
+  for (let attempt = 0; attempt < 20; attempt++) {
+    if (terminal()) return false;
+    const result = await executeControl(
+      `sudo -n systemctl show --property=LoadState --property=ActiveState --value ${shellQuote(unit)}`,
+    );
+    if (result.exitCode === 0 && !result.stdout.includes("not-found")) return true;
+    await delay(25);
+  }
+  return false;
+}
+
+async function verifyUnitStopped(
+  unit: string,
+  executeControl: (
+    command: string,
+  ) => Promise<{ exitCode: number; stderr: string; stdout: string }>,
+) {
+  const result = await executeControl(
+    [
+      "sudo -n systemctl show",
+      "--property=LoadState",
+      "--property=ActiveState",
+      "--property=ControlGroup",
+      shellQuote(unit),
+    ].join(" "),
+  );
+  if (result.exitCode !== 0)
+    throw new Error(`[vitehub] ASCII could not verify ${unit}: ${result.stderr}`);
+  const properties = new Map(
+    result.stdout
+      .trim()
+      .split(/\r?\n/)
+      .map((line) => {
+        const separator = line.indexOf("=");
+        return separator === -1
+          ? [line, ""]
+          : [line.slice(0, separator), line.slice(separator + 1)];
+      }),
+  );
+  if (properties.get("LoadState") === "not-found") return;
+  if (properties.get("LoadState") !== "loaded")
+    throw new Error(`[vitehub] ASCII process ${unit} has an unknown systemd load state.`);
+  const activeState = properties.get("ActiveState");
+  const controlGroup = properties.get("ControlGroup");
+  if (activeState && !["failed", "inactive"].includes(activeState))
+    throw new Error(`[vitehub] ASCII process ${unit} remains ${activeState}.`);
+  if (controlGroup) {
+    const processes = posix.join("/sys/fs/cgroup", controlGroup, "cgroup.procs");
+    const check = await executeControl(
+      `test ! -e ${shellQuote(processes)} || test -z "$(cat ${shellQuote(processes)})"`,
+    );
+    if (check.exitCode !== 0)
+      throw new Error(`[vitehub] ASCII process ${unit} left a non-empty cgroup.`);
+  }
+}
+
+async function openChannel(client: SshClient, command: string) {
+  return await new Promise<SshChannel>((resolve, reject) => {
+    client.exec(command, (error, channel) => {
+      if (error) reject(error);
+      else resolve(channel);
+    });
+  });
+}
+
+async function collectChannel(channel: SshChannel) {
+  let exitCode: number | undefined;
+  const [stdout, stderr] = await Promise.all([
+    readStream(toReadableStream(channel)),
+    readStream(toReadableStream(channel.stderr)),
+    new Promise<void>((resolve, reject) => {
+      channel.once("exit", (code: number | undefined) => {
+        if (typeof code === "number") exitCode = code;
+      });
+      channel.once("error", reject);
+      channel.once("close", (code: number | undefined) => {
+        if (typeof code === "number") exitCode = code;
+        resolve();
+      });
+    }),
+  ]);
+  if (exitCode === undefined)
+    throw new Error("[vitehub] ASCII SSH command closed without an exit status.");
+  return { exitCode, stderr, stdout };
+}
+
+async function readStream(stream: ReadableStream<Uint8Array>) {
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of stream) chunks.push(chunk);
+  return new TextDecoder().decode(Buffer.concat(chunks));
+}
+
+function toReadableStream(stream: Readable): ReadableStream<Uint8Array> {
+  let cancel: (() => void) | undefined;
+  let resume: (() => void) | undefined;
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      let closed = false;
+      const cleanup = () => {
+        stream.removeListener("close", onClose);
+        stream.removeListener("data", onData);
+        stream.removeListener("end", onClose);
+        stream.removeListener("error", onError);
+      };
+      const onClose = () => {
+        if (closed) return;
+        closed = true;
+        cleanup();
+        controller.close();
+      };
+      const onData = (chunk: Buffer | string) => {
+        controller.enqueue(typeof chunk === "string" ? Buffer.from(chunk) : new Uint8Array(chunk));
+        if ((controller.desiredSize ?? 1) <= 0) stream.pause();
+      };
+      const onError = (error: Error) => {
+        if (closed) return;
+        closed = true;
+        cleanup();
+        controller.error(error);
+      };
+      cancel = () => {
+        if (closed) return;
+        closed = true;
+        cleanup();
+        stream.resume();
+      };
+      resume = () => stream.resume();
+      stream.on("close", onClose);
+      stream.on("data", onData);
+      stream.on("end", onClose);
+      stream.on("error", onError);
+    },
+    pull() {
+      resume?.();
+    },
+    cancel() {
+      cancel?.();
+    },
+  });
+}
+
+async function sftpCall<T>(
+  signal: AbortSignal | undefined,
+  client: SshClient,
+  onTransportError: (error: unknown) => void,
+  start: (callback: (error: NodeJS.ErrnoException | null, value: T) => void) => void,
+) {
+  signal?.throwIfAborted();
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      onTransportError(signal!.reason);
+      client.destroy();
+      reject(signal!.reason);
+    };
+    signal?.addEventListener("abort", onAbort, { once: true });
+    start((error, value) => {
+      signal?.removeEventListener("abort", onAbort);
+      if (error) reject(error);
+      else resolve(value);
+    });
+  });
+}
+
+interface TransportFault {
+  readonly cleanup: Promise<void>;
+  readonly error: unknown;
+  record(error: unknown): void;
+  throwIfFailed(): void;
+}
+
+function createTransportFault(destroyBox: () => Promise<void>): TransportFault {
+  let cleanup = Promise.resolve();
+  let error: unknown;
+  return {
+    get cleanup() {
+      return cleanup;
+    },
+    get error() {
+      return error;
+    },
+    record(failure) {
+      if (error !== undefined) return;
+      const transportError =
+        failure ?? new Error("[vitehub] ASCII SSH transport failed without an error.");
+      error = transportError;
+      cleanup = destroyBox().catch((cleanupError) => {
+        error = new AggregateError(
+          [transportError, cleanupError],
+          "[vitehub] ASCII SSH transport and provider cleanup failed.",
+        );
+      });
+    },
+    throwIfFailed() {
+      if (error !== undefined) throw error;
+    },
+  };
+}
+
+function parseFileList(output: string): BoxFileEntry[] {
+  return output
+    .split("\0")
+    .filter(Boolean)
+    .map((line) => {
+      const [kind, size, path] = line.split("\t");
+      return {
+        path,
+        size: kind === "f" ? Number(size) : undefined,
+        type:
+          kind === "d"
+            ? ("directory" as const)
+            : kind === "l"
+              ? ("symlink" as const)
+              : ("file" as const),
+      };
+    })
+    .sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function normalizeSignal(signal = "TERM") {
+  const normalized = signal.toUpperCase().replace(/^SIG/, "");
+  if (!allowedSignals.has(normalized))
+    throw new TypeError(`[vitehub] Unsupported ASCII process signal: ${signal}`);
+  return normalized;
+}
+
+function isMissingFile(error: unknown) {
+  return (
+    !!error &&
+    typeof error === "object" &&
+    "code" in error &&
+    (error.code === "ENOENT" || error.code === 2)
+  );
+}
+
+function delay(milliseconds: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitWithTimeout<T>(
+  promise: Promise<T>,
+  milliseconds: number,
+  message: string,
+  signal?: AbortSignal,
+) {
+  signal?.throwIfAborted();
+  return await new Promise<T>((resolve, reject) => {
+    const finish = () => {
+      clearTimeout(timer);
+      signal?.removeEventListener("abort", onAbort);
+    };
+    const onAbort = () => {
+      finish();
+      reject(signal!.reason);
+    };
+    const timer = setTimeout(() => {
+      finish();
+      reject(new Error(message));
+    }, milliseconds);
+    signal?.addEventListener("abort", onAbort, { once: true });
+    if (signal?.aborted) onAbort();
+    void promise.then(
+      (value) => {
+        finish();
+        resolve(value);
+      },
+      (error) => {
+        finish();
+        reject(error);
+      },
+    );
+  });
+}
+
+async function failClosed(
+  error: unknown,
+  destroyBox: () => Promise<void>,
+  message: string,
+): Promise<never> {
+  try {
+    await destroyBox();
+  } catch (cleanupError) {
+    throw new AggregateError([error, cleanupError], message);
+  }
+  throw error;
+}
+
+interface Ssh2Module {
+  Client: new () => SshClient;
+  utils: {
+    generateKeyPairSync(
+      type: "rsa",
+      options: { bits: 3072; comment: string },
+    ): { private: string; public: string };
+  };
+}
+
+interface SshClient {
+  connect(options: {
+    host: string;
+    hostVerifier: (key: Buffer) => boolean;
+    keepaliveCountMax: number;
+    keepaliveInterval: number;
+    port: number;
+    privateKey: string;
+    readyTimeout: number;
+    username: string;
+  }): void;
+  destroy(): void;
+  end(): void;
+  exec(command: string, callback: (error: Error | null, channel: SshChannel) => void): void;
+  on(event: "error", listener: (error: Error) => void): this;
+  on(event: "ready", listener: () => void): this;
+  removeListener(event: "error", listener: (error: Error) => void): this;
+  removeListener(event: "ready", listener: () => void): this;
+  sftp(callback: (error: Error | null, sftp: SftpClient) => void): void;
+}
+
+interface SshChannel extends Readable {
+  readonly stderr: Readable;
+}
+
+interface SftpClient {
+  end?(): void;
+  readFile(
+    path: string,
+    callback: (error: NodeJS.ErrnoException | null, contents: Buffer) => void,
+  ): void;
+  writeFile(
+    path: string,
+    contents: Buffer,
+    callback: (error: NodeJS.ErrnoException | null, value: void) => void,
+  ): void;
+}

--- a/packages/box/src/internal/ascii-ssh.ts
+++ b/packages/box/src/internal/ascii-ssh.ts
@@ -200,10 +200,19 @@ function createAsciiSshSession(
     assertOpen();
     options.abortSignal?.throwIfAborted();
     const unit = `vitehub-${randomUUID()}.service`;
+    const launchScript = `/home/user/.vitehub-launch-${randomUUID()}`;
     let channel: SshChannel;
     try {
+      await sftpCall<void>(options.abortSignal, client, fault.record, (callback) =>
+        sftp.writeFile(
+          launchScript,
+          Buffer.from(launchScriptContents(launchScript, options)),
+          { mode: 0o700 },
+          callback,
+        ),
+      );
       channel = await waitWithTimeout(
-        exec(systemdRunCommand(unit, options)),
+        exec(systemdRunCommand(unit, launchScript, options.workingDirectory)),
         10_000,
         `[vitehub] ASCII process ${unit} launch timed out.`,
         options.abortSignal,
@@ -349,11 +358,8 @@ function createAsciiSshSession(
 
 function systemdRunCommand(
   unit: string,
-  options: {
-    command: string;
-    env?: Record<string, string>;
-    workingDirectory?: string;
-  },
+  launchScript: string,
+  workingDirectory?: string,
 ) {
   const args = [
     "sudo",
@@ -367,16 +373,30 @@ function systemdRunCommand(
     `--unit=${unit}`,
     "--uid=user",
     "--gid=user",
-    `--working-directory=${options.workingDirectory ?? "/home/user/.vitehub/workspace"}`,
+    `--working-directory=${workingDirectory ?? "/home/user/.vitehub/workspace"}`,
     "--property=KillMode=control-group",
     "--property=TimeoutStopSec=10s",
-    ...Object.entries(options.env ?? {}).map(([name, value]) => `--setenv=${name}=${value}`),
     "--",
     "/bin/sh",
-    "-lc",
-    options.command,
+    launchScript,
   ];
   return args.map(shellQuote).join(" ");
+}
+
+function launchScriptContents(
+  path: string,
+  options: { command: string; env?: Record<string, string> },
+) {
+  const exports = Object.entries(options.env ?? {}).map(
+    ([name, value]) => `export ${name}=${shellQuote(value)}`,
+  );
+  return [
+    "#!/bin/sh",
+    ...exports,
+    `rm -f -- ${shellQuote(path)}`,
+    `exec /bin/sh -lc ${shellQuote(options.command)}`,
+    "",
+  ].join("\n");
 }
 
 function createRuntimeProcess(
@@ -811,6 +831,12 @@ interface SftpClient {
   readFile(
     path: string,
     callback: (error: NodeJS.ErrnoException | null, contents: Buffer) => void,
+  ): void;
+  writeFile(
+    path: string,
+    contents: Buffer,
+    options: { mode: number },
+    callback: (error: NodeJS.ErrnoException | null, value: void) => void,
   ): void;
   writeFile(
     path: string,

--- a/packages/box/src/internal/ascii-ssh.ts
+++ b/packages/box/src/internal/ascii-ssh.ts
@@ -387,9 +387,11 @@ function launchScriptContents(
   path: string,
   options: { command: string; env?: Record<string, string> },
 ) {
-  const exports = Object.entries(options.env ?? {}).map(
-    ([name, value]) => `export ${name}=${shellQuote(value)}`,
-  );
+  const exports = Object.entries(options.env ?? {}).map(([name, value]) => {
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name))
+      throw new TypeError(`[vitehub] Invalid Box environment variable: ${name}`);
+    return `export ${name}=${shellQuote(value)}`;
+  });
   return [
     "#!/bin/sh",
     ...exports,

--- a/packages/box/src/internal/remote.ts
+++ b/packages/box/src/internal/remote.ts
@@ -97,7 +97,14 @@ export async function openRemoteBox(
     await options.initialize?.(session, { signal: options.signal });
     return session;
   } catch (error) {
-    await session.close().catch(() => undefined);
+    try {
+      await session.close();
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        `[vitehub] ${options.runtime} Box initialization and cleanup failed.`,
+      );
+    }
     throw error;
   }
 }

--- a/packages/box/src/internal/session.ts
+++ b/packages/box/src/internal/session.ts
@@ -96,7 +96,7 @@ interface RuntimeCommandOptions {
 export function createBoxSession(
   runtime: RuntimeSession,
   openOptions: BoxRuntimeOpenOptions,
-  cwd = runtime.defaultWorkingDirectory,
+  cwd: string = runtime.defaultWorkingDirectory,
 ): BoxSession {
   let closePromise: Promise<void> | undefined;
   let closed = false;

--- a/packages/box/test/ascii-ssh.test.ts
+++ b/packages/box/test/ascii-ssh.test.ts
@@ -25,6 +25,22 @@ describe("ASCII SSH transport", () => {
     expect(server.client.destroyed).toBe(true);
   });
 
+  it("closes an authenticated connection when SFTP negotiation is cancelled", async () => {
+    const server = new FakeSshServer();
+    server.holdSftpOpen = true;
+    const controller = new AbortController();
+    const opening = openSession(server, {
+      ...sshOptions(server),
+      abortSignal: controller.signal,
+    });
+
+    await vi.waitFor(() => expect(server.sftpOpens).toBe(1));
+    controller.abort(new Error("cancel SFTP negotiation"));
+
+    await expect(opening).rejects.toThrow("cancel SFTP negotiation");
+    expect(server.client.destroyed).toBe(true);
+  });
+
   it("fails closed when the authenticated SSH client reports a transport error", async () => {
     const server = new FakeSshServer();
     const session = await openSession(server);
@@ -221,12 +237,14 @@ class FakeSshServer {
   boxDestroys = 0;
   holdObservation = false;
   holdExec = false;
+  holdSftpOpen = false;
   holdSftpRead = false;
   observation: FakeChannel | undefined;
   process: FakeChannel | undefined;
   processStderr = [] as string[];
   processStdout = ["started"] as string[];
   sftpError: Error | undefined;
+  sftpOpens = 0;
   sftpReads = 0;
   verificationExitCode = 0;
   unitCollected = false;
@@ -308,6 +326,8 @@ class FakeSshClient extends EventEmitter {
   }
 
   sftp(callback: (error: Error | null, sftp: FakeSftp) => void) {
+    this.server.sftpOpens++;
+    if (this.server.holdSftpOpen) return;
     callback(this.server.sftpError ?? null, new FakeSftp(this.server));
   }
 }

--- a/packages/box/test/ascii-ssh.test.ts
+++ b/packages/box/test/ascii-ssh.test.ts
@@ -174,6 +174,25 @@ describe("ASCII SSH transport", () => {
     await session.stop();
   });
 
+  it("keeps environment values out of process arguments", async () => {
+    const server = new FakeSshServer();
+    const session = await openSession(server);
+    const process = await session.spawn!({
+      command: "sleep 3600",
+      env: { GH_TOKEN: "secret-value" },
+    });
+
+    expect(server.commands.join("\n")).not.toContain("secret-value");
+    expect(server.writtenFiles).toEqual([
+      expect.objectContaining({
+        contents: expect.stringContaining("secret-value"),
+        mode: 0o700,
+      }),
+    ]);
+    await process.kill();
+    await session.stop();
+  });
+
   it("accepts a transient unit that systemd already collected", async () => {
     const server = new FakeSshServer();
     server.unitCollected = true;
@@ -275,6 +294,7 @@ class FakeSshServer {
   sftpOpens = 0;
   sftpReads = 0;
   verificationExitCode = 0;
+  readonly writtenFiles: Array<{ contents: string; mode?: number; path: string }> = [];
   unitCollected = false;
 
   constructor() {
@@ -377,11 +397,19 @@ class FakeSftp {
   }
 
   writeFile(
-    _path: string,
-    _contents: Buffer,
-    callback: (error: NodeJS.ErrnoException | null, value: void) => void,
+    path: string,
+    contents: Buffer,
+    options:
+      | { mode: number }
+      | ((error: NodeJS.ErrnoException | null, value: void) => void),
+    callback?: (error: NodeJS.ErrnoException | null, value: void) => void,
   ) {
-    callback(null, undefined);
+    this.server.writtenFiles.push({
+      contents: contents.toString(),
+      mode: typeof options === "function" ? undefined : options.mode,
+      path,
+    });
+    (typeof options === "function" ? options : callback!)(null, undefined);
   }
 }
 

--- a/packages/box/test/ascii-ssh.test.ts
+++ b/packages/box/test/ascii-ssh.test.ts
@@ -1,0 +1,358 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { openAsciiSshSession, type AsciiSshOptions } from "../src/internal/ascii-ssh.ts";
+
+describe("ASCII SSH transport", () => {
+  it("pins the provider-reported host key and closes a rejected connection", async () => {
+    const server = new FakeSshServer();
+    const options = {
+      ...sshOptions(server),
+      hostKeys: [new Uint8Array([9, 9, 9])],
+    };
+
+    await expect(openSession(server, options)).rejects.toThrow("host key");
+    expect(server.client.destroyed).toBe(true);
+  });
+
+  it("closes an authenticated connection when SFTP negotiation fails", async () => {
+    const server = new FakeSshServer();
+    server.sftpError = new Error("SFTP unavailable");
+
+    await expect(openSession(server)).rejects.toThrow("SFTP unavailable");
+    expect(server.client.destroyed).toBe(true);
+  });
+
+  it("fails closed when the authenticated SSH client reports a transport error", async () => {
+    const server = new FakeSshServer();
+    const session = await openSession(server);
+
+    server.client.emit("error", new Error("SSH connection lost"));
+
+    await vi.waitFor(() => expect(server.boxDestroys).toBe(1));
+    await expect(session.existsFile({ path: "/home/user/.vitehub/workspace" })).rejects.toThrow(
+      "SSH connection lost",
+    );
+    await expect(session.stop()).rejects.toThrow();
+  });
+
+  it("fails closed when cancellation interrupts an in-flight SFTP operation", async () => {
+    const server = new FakeSshServer();
+    server.holdSftpRead = true;
+    const session = await openSession(server);
+    const controller = new AbortController();
+    const reading = session.readBinaryFile({
+      abortSignal: controller.signal,
+      path: "/home/user/proof.bin",
+    });
+
+    expect(server.sftpReads).toBe(1);
+    controller.abort(new Error("cancel SFTP read"));
+
+    await expect(reading).rejects.toThrow("cancel SFTP read");
+    await vi.waitFor(() => expect(server.boxDestroys).toBe(1));
+    expect(server.client.destroyed).toBe(true);
+    await expect(
+      session.writeBinaryFile({
+        content: new Uint8Array(),
+        path: "/home/user/another.bin",
+      }),
+    ).rejects.toThrow("cancel SFTP read");
+    await expect(session.stop()).rejects.toThrow();
+  });
+
+  it("kills a process when cancellation arrives during launch observation", async () => {
+    const server = new FakeSshServer();
+    server.holdObservation = true;
+    const session = await openSession(server);
+    const controller = new AbortController();
+    const spawned = session.spawn!({
+      abortSignal: controller.signal,
+      command: "sleep 3600",
+    });
+
+    await vi.waitFor(() => expect(server.observation).toBeDefined());
+    controller.abort(new Error("cancel launch"));
+    server.releaseObservation();
+
+    await expect(spawned).rejects.toThrow("cancel launch");
+    await vi.waitFor(() => expect(server.killSignals).toEqual(["KILL"]));
+    await session.stop();
+  });
+
+  it("destroys the Box when cancellation races the SSH exec callback", async () => {
+    const server = new FakeSshServer();
+    server.holdExec = true;
+    const session = await openSession(server);
+    const controller = new AbortController();
+    const spawned = session.spawn!({
+      abortSignal: controller.signal,
+      command: "sleep 3600",
+    });
+
+    controller.abort(new Error("cancel SSH launch"));
+
+    await expect(spawned).rejects.toThrow("cancel SSH launch");
+    expect(server.boxDestroys).toBe(1);
+    await session.stop();
+  });
+
+  it("destroys the Box when launch observation times out", async () => {
+    const server = new FakeSshServer();
+    server.holdObservation = true;
+    const session = await openSession(server);
+
+    vi.useFakeTimers();
+    try {
+      const spawned = session.spawn!({ command: "sleep 3600" }).catch((error) => error);
+      await vi.advanceTimersByTimeAsync(10_000);
+
+      const failure = await spawned;
+      expect(failure).toBeInstanceOf(Error);
+      expect(failure.message).toContain("control command timed out");
+      expect(server.boxDestroys).toBe(1);
+      await expect(session.stop()).rejects.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("maps requested signals and proves the systemd cgroup is empty", async () => {
+    const server = new FakeSshServer();
+    const session = await openSession(server);
+    const process = await session.spawn!({ command: "sleep 3600" });
+
+    await process.kill("TERM");
+
+    await expect(process.wait()).resolves.toEqual({ exitCode: 143 });
+    expect(server.killSignals).toEqual(["TERM"]);
+    expect(server.commands.some((command) => command.includes("cgroup.procs"))).toBe(true);
+    await session.stop();
+  });
+
+  it("accepts a transient unit that systemd already collected", async () => {
+    const server = new FakeSshServer();
+    server.unitCollected = true;
+    const session = await openSession(server);
+    const process = await session.spawn!({ command: "exit 0" });
+
+    await process.kill();
+
+    expect(server.boxDestroys).toBe(0);
+    await session.stop();
+  });
+
+  it("streams multiple stdout and stderr chunks and supports consumer cancellation", async () => {
+    const server = new FakeSshServer();
+    server.processStderr = ["error-one", "error-two"];
+    server.processStdout = ["output-one", "output-two", "output-three"];
+    const session = await openSession(server);
+    const process = await session.spawn!({ command: "sleep 3600" });
+    const stdout = process.stdout.getReader();
+    const stderr = process.stderr.getReader();
+
+    await expect(stdout.read()).resolves.toMatchObject({
+      done: false,
+      value: new Uint8Array(Buffer.from("output-one")),
+    });
+    await expect(stdout.read()).resolves.toMatchObject({
+      done: false,
+      value: new Uint8Array(Buffer.from("output-two")),
+    });
+    await expect(stderr.read()).resolves.toMatchObject({
+      done: false,
+      value: new Uint8Array(Buffer.from("error-one")),
+    });
+    await stdout.cancel();
+    await stderr.cancel();
+    await process.kill();
+    await session.stop();
+  });
+
+  it("destroys the Box when process termination cannot be verified", async () => {
+    const server = new FakeSshServer();
+    server.verificationExitCode = 1;
+    const session = await openSession(server);
+    const process = await session.spawn!({ command: "sleep 3600" });
+
+    await expect(process.kill()).rejects.toThrow("could not verify");
+    expect(server.boxDestroys).toBe(1);
+    await session.stop();
+  });
+});
+
+async function openSession(server: FakeSshServer, options: AsciiSshOptions = sshOptions(server)) {
+  return await openAsciiSshSession(options, async () => server.module as never);
+}
+
+function sshOptions(server: FakeSshServer): AsciiSshOptions {
+  return {
+    destroyBox: async () => {
+      server.boxDestroys++;
+    },
+    host: "192.0.2.1",
+    hostKeys: [server.hostKey],
+    identity: {
+      privateKey: "private",
+      publicKey: "ssh-ed25519 public",
+    },
+  };
+}
+
+class FakeSshServer {
+  readonly client = new FakeSshClient(this);
+  readonly commands: string[] = [];
+  readonly hostKey = new Uint8Array([1, 2, 3]);
+  readonly killSignals: string[] = [];
+  readonly module = {
+    Client: class {
+      constructor() {
+        return fakeServer!.client;
+      }
+    },
+    utils: {
+      generateKeyPairSync() {
+        return { private: "private", public: "public" };
+      },
+    },
+  };
+  boxDestroys = 0;
+  holdObservation = false;
+  holdExec = false;
+  holdSftpRead = false;
+  observation: FakeChannel | undefined;
+  process: FakeChannel | undefined;
+  processStderr = [] as string[];
+  processStdout = ["started"] as string[];
+  sftpError: Error | undefined;
+  sftpReads = 0;
+  verificationExitCode = 0;
+  unitCollected = false;
+
+  constructor() {
+    fakeServer = this;
+  }
+
+  execute(command: string) {
+    this.commands.push(command);
+    const channel = new FakeChannel();
+    if (command.includes("systemd-run")) {
+      this.process = channel;
+      for (const chunk of this.processStdout) channel.write(chunk);
+      for (const chunk of this.processStderr) channel.stderr.write(chunk);
+    } else if (command.includes("systemctl kill")) {
+      const signal = command.match(/--signal=SIG([A-Z]+)/)?.[1] ?? "TERM";
+      this.killSignals.push(signal);
+      setImmediate(() => {
+        channel.finish(0);
+        this.process?.finish(0);
+      });
+    } else if (command.includes("ControlGroup")) {
+      setImmediate(() =>
+        channel.finish(
+          this.verificationExitCode,
+          this.verificationExitCode === 0
+            ? this.unitCollected
+              ? "LoadState=not-found\nActiveState=inactive\nControlGroup=\n"
+              : "LoadState=loaded\nActiveState=inactive\nControlGroup=/system.slice/vitehub-test.service\n"
+            : "",
+          this.verificationExitCode === 0 ? "" : "systemctl unavailable",
+        ),
+      );
+    } else if (command.includes("LoadState") && command.includes("ActiveState")) {
+      if (this.holdObservation) this.observation = channel;
+      else setImmediate(() => channel.finish(0, "loaded\nactive\n"));
+    } else if (command.includes("cgroup.procs")) {
+      setImmediate(() => channel.finish(0));
+    } else {
+      setImmediate(() => channel.finish(0));
+    }
+    return channel;
+  }
+
+  releaseObservation() {
+    this.observation?.finish(0, "loaded\nactive\n");
+  }
+}
+
+let fakeServer: FakeSshServer | undefined;
+
+class FakeSshClient extends EventEmitter {
+  destroyed = false;
+  ended = false;
+
+  constructor(private readonly server: FakeSshServer) {
+    super();
+  }
+
+  connect(options: { hostVerifier: (key: Buffer) => boolean }) {
+    queueMicrotask(() => {
+      if (options.hostVerifier(Buffer.from(this.server.hostKey))) this.emit("ready");
+      else this.emit("error", new Error("host key rejected"));
+    });
+  }
+
+  destroy() {
+    this.destroyed = true;
+  }
+
+  end() {
+    this.ended = true;
+  }
+
+  exec(command: string, callback: (error: Error | null, channel: FakeChannel) => void) {
+    if (this.server.holdExec) return;
+    callback(null, this.server.execute(command));
+  }
+
+  sftp(callback: (error: Error | null, sftp: FakeSftp) => void) {
+    callback(this.server.sftpError ?? null, new FakeSftp(this.server));
+  }
+}
+
+class FakeSftp {
+  constructor(private readonly server: FakeSshServer) {}
+
+  end() {}
+
+  readFile(
+    _path: string,
+    callback: (error: NodeJS.ErrnoException | null, contents: Buffer) => void,
+  ) {
+    this.server.sftpReads++;
+    if (this.server.holdSftpRead) return;
+    callback(null, Buffer.alloc(0));
+  }
+
+  writeFile(
+    _path: string,
+    _contents: Buffer,
+    callback: (error: NodeJS.ErrnoException | null, value: void) => void,
+  ) {
+    callback(null, undefined);
+  }
+}
+
+class FakeChannel extends PassThrough {
+  readonly stderr = new PassThrough();
+  private finished = false;
+
+  constructor() {
+    super({ autoDestroy: false });
+  }
+
+  finish(code: number, stdout = "", stderr = "") {
+    if (this.finished) return;
+    this.finished = true;
+    if (stdout) this.write(stdout);
+    if (stderr) this.stderr.write(stderr);
+    this.end();
+    this.stderr.end();
+    queueMicrotask(() => {
+      this.emit("exit", code);
+      this.emit("close", code);
+    });
+  }
+}

--- a/packages/box/test/ascii-ssh.test.ts
+++ b/packages/box/test/ascii-ssh.test.ts
@@ -3,7 +3,11 @@ import { PassThrough } from "node:stream";
 
 import { describe, expect, it, vi } from "vitest";
 
-import { openAsciiSshSession, type AsciiSshOptions } from "../src/internal/ascii-ssh.ts";
+import {
+  openAsciiSshSession,
+  parseAsciiFileList,
+  type AsciiSshOptions,
+} from "../src/internal/ascii-ssh.ts";
 
 describe("ASCII SSH transport", () => {
   it("pins the provider-reported host key and closes a rejected connection", async () => {
@@ -39,6 +43,28 @@ describe("ASCII SSH transport", () => {
 
     await expect(opening).rejects.toThrow("cancel SFTP negotiation");
     expect(server.client.destroyed).toBe(true);
+  });
+
+  it("closes a connection when SSH authentication is cancelled", async () => {
+    const server = new FakeSshServer();
+    server.holdConnect = true;
+    const controller = new AbortController();
+    const opening = openSession(server, {
+      ...sshOptions(server),
+      abortSignal: controller.signal,
+    });
+
+    await vi.waitFor(() => expect(server.connects).toBe(1));
+    controller.abort(new Error("cancel SSH authentication"));
+
+    await expect(opening).rejects.toThrow("cancel SSH authentication");
+    expect(server.client.destroyed).toBe(true);
+  });
+
+  it("preserves tabs in listed file paths", async () => {
+    expect(parseAsciiFileList("f\t7\t/home/user/with\ttab\0")).toEqual([
+      { path: "/home/user/with\ttab", size: 7, type: "file" },
+    ]);
   });
 
   it("fails closed when the authenticated SSH client reports a transport error", async () => {
@@ -235,6 +261,8 @@ class FakeSshServer {
     },
   };
   boxDestroys = 0;
+  connects = 0;
+  holdConnect = false;
   holdObservation = false;
   holdExec = false;
   holdSftpOpen = false;
@@ -306,6 +334,8 @@ class FakeSshClient extends EventEmitter {
   }
 
   connect(options: { hostVerifier: (key: Buffer) => boolean }) {
+    this.server.connects++;
+    if (this.server.holdConnect) return;
     queueMicrotask(() => {
       if (options.hostVerifier(Buffer.from(this.server.hostKey))) this.emit("ready");
       else this.emit("error", new Error("host key rejected"));

--- a/packages/box/test/ascii-ssh.test.ts
+++ b/packages/box/test/ascii-ssh.test.ts
@@ -193,6 +193,17 @@ describe("ASCII SSH transport", () => {
     await session.stop();
   });
 
+  it("rejects invalid environment names before launching", async () => {
+    const server = new FakeSshServer();
+    const session = await openSession(server);
+
+    await expect(
+      session.spawn!({ command: "true", env: { "SAFE; touch /tmp/injected; #": "value" } }),
+    ).rejects.toThrow("Invalid Box environment variable");
+    expect(server.commands.join("\n")).not.toContain("touch /tmp/injected");
+    expect(server.boxDestroys).toBe(1);
+  });
+
   it("accepts a transient unit that systemd already collected", async () => {
     const server = new FakeSshServer();
     server.unitCollected = true;

--- a/packages/box/test/ascii.test.ts
+++ b/packages/box/test/ascii.test.ts
@@ -66,6 +66,15 @@ describe("ASCII Box runtime", () => {
     expect(fixture.machine.stops).toBe(1);
   });
 
+  it("preserves a caller-supplied session ID", async () => {
+    const fixture = asciiFixture();
+    const box = await resolveBox({ runtime: fixture.runtime }, {});
+    const session = await box.open({ id: "invocation-session" });
+
+    expect(session.id).toBe("invocation-session");
+    await session.close();
+  });
+
   it("uses a fresh cleanup signal when provisioning is cancelled", async () => {
     const fixture = asciiFixture();
     const controller = new AbortController();
@@ -82,6 +91,20 @@ describe("ASCII Box runtime", () => {
     await expect(opened).rejects.toThrow("cancel ASCII provisioning");
     expect(fixture.control.removes).toBe(1);
     expect(fixture.control.cleanupSignal?.aborted).toBe(false);
+  });
+
+  it("bounds a stalled provisioning request without a caller signal", async () => {
+    const fixture = asciiFixture({ provisioningTimeoutMs: 5 });
+    fixture.control.waitForReady = async (signal) =>
+      await new Promise((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    const box = await resolveBox({ runtime: fixture.runtime }, {});
+
+    const failure = await box.open().catch((error) => error);
+    expect(failure).toBeInstanceOf(Error);
+    expect(fixture.control.gets).toBeGreaterThanOrEqual(1);
+    expect(fixture.control.removes).toBe(1);
   });
 
   it("finishes create before honoring cancellation so the new Box can be deleted", async () => {
@@ -165,7 +188,7 @@ describe("ASCII Box runtime", () => {
   });
 });
 
-function asciiFixture() {
+function asciiFixture(options: { provisioningTimeoutMs?: number } = {}) {
   const machine = new FakeAsciiMachine();
   const control = {
     archiveAfterStop: true,
@@ -246,6 +269,7 @@ function asciiFixture() {
         async openSsh() {
           return machine.session;
         },
+        provisioningTimeoutMs: options.provisioningTimeoutMs,
       },
     ),
   };

--- a/packages/box/test/ascii.test.ts
+++ b/packages/box/test/ascii.test.ts
@@ -1,0 +1,361 @@
+import { posix } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { createAsciiRuntime } from "../src/ascii.ts";
+import { resolveBox, type BoxFileEntry } from "../src/index.ts";
+import type { RuntimeSession } from "../src/internal/session.ts";
+
+describe("ASCII Box runtime", () => {
+  it("selects ASCII without loading its optional SDK during preparation", async () => {
+    const direct = await resolveBox({ runtime: "ascii" }, {});
+    const configured = await resolveBox(
+      {
+        runtime: { apiKey: "test", kind: "ascii", ttlSeconds: 7200 },
+      },
+      {},
+    );
+
+    expect(direct.plan.runtime).toBe("ascii");
+    expect(configured.plan.runtime).toBe("ascii");
+    expect(configured.plan.executionAuthority).toMatchObject({
+      filesystem: { access: "read-write", scope: "sandbox" },
+      processes: "arbitrary",
+    });
+  });
+
+  it("materializes Home, environment, requirements, and closes provider resources once", async () => {
+    const fixture = asciiFixture();
+    const box = await resolveBox(
+      {
+        env: { DECLARED: "ready" },
+        home: {
+          files: {
+            ".config/vitehub.bin": { contents: new Uint8Array([0, 255]) },
+          },
+        },
+        requires: ["node"],
+        runtime: fixture.runtime,
+      },
+      {},
+    );
+    const session = await box.open();
+
+    expect(session.id).toBe("bx_test");
+    expect(session.spawn).toBeTypeOf("function");
+    expect(await session.files.read("/home/user/.vitehub/home/.config/vitehub.bin")).toEqual(
+      new Uint8Array([0, 255]),
+    );
+    await expect(session.exec("env-probe")).resolves.toMatchObject({
+      code: 0,
+      stdout: "/home/user/.vitehub/home|ready",
+    });
+
+    const process = await session.spawn!("sleep", ["3600"]);
+    await process.kill("TERM");
+    await expect(process.wait()).resolves.toEqual({ code: 137 });
+    await session.close();
+    await session.close();
+
+    expect(fixture.control.created).toEqual({
+      noEnv: true,
+      ttlSeconds: 7200,
+    });
+    expect(fixture.control.authorizedKey).toBe("ssh-ed25519 test");
+    expect(fixture.control.removes).toBe(1);
+    expect(fixture.machine.stops).toBe(1);
+  });
+
+  it("uses a fresh cleanup signal when provisioning is cancelled", async () => {
+    const fixture = asciiFixture();
+    const controller = new AbortController();
+    fixture.control.waitForReady = async (signal) =>
+      await new Promise((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    const box = await resolveBox({ runtime: fixture.runtime }, {});
+
+    const opened = box.open({ signal: controller.signal });
+    await vi.waitFor(() => expect(fixture.control.gets).toBe(1));
+    controller.abort(new Error("cancel ASCII provisioning"));
+
+    await expect(opened).rejects.toThrow("cancel ASCII provisioning");
+    expect(fixture.control.removes).toBe(1);
+    expect(fixture.control.cleanupSignal?.aborted).toBe(false);
+  });
+
+  it("finishes create before honoring cancellation so the new Box can be deleted", async () => {
+    const fixture = asciiFixture();
+    let finishCreate!: () => void;
+    fixture.control.waitForCreate = new Promise((resolve) => {
+      finishCreate = resolve;
+    });
+    const controller = new AbortController();
+    const box = await resolveBox({ runtime: fixture.runtime }, {});
+
+    const opened = box.open({ signal: controller.signal });
+    await vi.waitFor(() => expect(fixture.control.creates).toBe(1));
+    controller.abort(new Error("cancel ASCII creation"));
+    expect(fixture.control.removes).toBe(0);
+    const rejected = expect(opened).rejects.toThrow("cancel ASCII creation");
+    finishCreate();
+
+    await rejected;
+    expect(fixture.control.createSignal).not.toBe(controller.signal);
+    expect(fixture.control.createSignal?.aborted).toBe(false);
+    expect(fixture.control.removes).toBe(1);
+  });
+
+  it("attempts provider deletion after SSH teardown times out", async () => {
+    const fixture = asciiFixture();
+    fixture.machine.stopNever = true;
+    const box = await resolveBox({ runtime: fixture.runtime }, {});
+    const session = await box.open();
+
+    vi.useFakeTimers();
+    try {
+      const closing = session.close().catch((error) => error);
+      await vi.advanceTimersByTimeAsync(10_000);
+      const failure = await closing;
+      expect(flattenMessages(failure)).toContain(
+        "[vitehub] ASCII Box bx_test SSH teardown timed out.",
+      );
+      expect(fixture.machine.stops).toBe(1);
+      expect(fixture.control.removes).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("preserves initialization and verified-deletion failures", async () => {
+    const fixture = asciiFixture();
+    fixture.control.removeError = new Error("DELETE unavailable");
+    fixture.control.stopError = new Error("stop unavailable");
+    const box = await resolveBox({ runtime: fixture.runtime }, {});
+
+    let failure: unknown;
+    try {
+      await box.open({
+        async initialize() {
+          throw new Error("initialization failed");
+        },
+      });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect(flattenMessages(failure)).toEqual(
+      expect.arrayContaining([
+        "initialization failed",
+        expect.stringContaining("could not be verified as deleted"),
+      ]),
+    );
+    expect(fixture.control.stops).toBeGreaterThan(0);
+    expect(fixture.machine.stops).toBe(1);
+  });
+
+  it("rejects incomplete host-key bootstrap data", async () => {
+    const fixture = asciiFixture();
+    fixture.control.hostKey = "ssh-ed25519 bm90LWFuLXNzaC1rZXk=";
+    const box = await resolveBox({ runtime: fixture.runtime }, {});
+
+    await expect(box.open()).rejects.toThrow("invalid SSH host public key");
+    expect(fixture.control.removes).toBe(1);
+  });
+});
+
+function asciiFixture() {
+  const machine = new FakeAsciiMachine();
+  const control = {
+    archiveAfterStop: true,
+    authorizedKey: "",
+    cleanupSignal: undefined as AbortSignal | undefined,
+    creates: 0,
+    createSignal: undefined as AbortSignal | undefined,
+    created: undefined as { noEnv: true; ttlSeconds: number } | undefined,
+    gets: 0,
+    hostKey: hostPublicKey(),
+    removeError: undefined as Error | undefined,
+    removed: false,
+    removes: 0,
+    state: "ready",
+    stopError: undefined as Error | undefined,
+    stops: 0,
+    waitForReady: undefined as undefined | ((signal: AbortSignal | undefined) => Promise<never>),
+    waitForCreate: undefined as Promise<void> | undefined,
+  };
+  const client = {
+    async command() {
+      return {
+        exitCode: 0,
+        stderr: "",
+        stdout: control.hostKey,
+        timedOut: false,
+      };
+    },
+    async create(
+      input: { createBoxRequest: { noEnv: true; ttlSeconds: number } },
+      init?: RequestInit,
+    ) {
+      control.creates++;
+      control.createSignal = init?.signal ?? undefined;
+      control.created = input.createBoxRequest;
+      await control.waitForCreate;
+      return { box: { id: "bx_test", ip: "192.0.2.1", state: "provisioning" } };
+    },
+    async get(_input: unknown, init?: RequestInit) {
+      control.gets++;
+      if (control.removed) throw Object.assign(new Error("missing"), { response: { status: 404 } });
+      if (control.waitForReady) await control.waitForReady(init?.signal ?? undefined);
+      return {
+        box: {
+          id: "bx_test",
+          ip: "192.0.2.1",
+          state: control.state,
+        },
+      };
+    },
+    async remove(_input: unknown, init?: RequestInit) {
+      control.removes++;
+      control.cleanupSignal = init?.signal ?? undefined;
+      if (control.removeError) throw control.removeError;
+      control.removed = true;
+    },
+    async sshKey(input: { sshKeyRequest: { key: string } }) {
+      control.authorizedKey = input.sshKeyRequest.key;
+    },
+    async stop() {
+      control.stops++;
+      if (control.stopError) throw control.stopError;
+      if (control.archiveAfterStop) control.state = "archived";
+    },
+  };
+  return {
+    control,
+    machine,
+    runtime: createAsciiRuntime(
+      { apiKey: "test" },
+      {
+        async createClient() {
+          return client;
+        },
+        async createIdentity() {
+          return { privateKey: "private", publicKey: "ssh-ed25519 test" };
+        },
+        async openSsh() {
+          return machine.session;
+        },
+      },
+    ),
+  };
+}
+
+class FakeAsciiMachine {
+  readonly directories = new Set(["/home/user"]);
+  readonly files = new Map<string, Uint8Array>();
+  stops = 0;
+  stopError: Error | undefined;
+  stopNever = false;
+
+  readonly session: RuntimeSession = {
+    defaultWorkingDirectory: "/home/user/.vitehub/workspace",
+    id: "transport",
+    existsFile: async ({ path }) => this.directories.has(path) || this.files.has(path),
+    listFiles: async ({ path, recursive }) => this.list(path, recursive),
+    makeDirectory: async ({ path }) => {
+      this.directories.add(path);
+    },
+    moveFile: async ({ destination, source }) => {
+      const contents = this.files.get(source);
+      if (!contents) throw new Error(`missing ${source}`);
+      this.files.delete(source);
+      this.files.set(destination, contents);
+    },
+    readBinaryFile: async ({ path }) => this.files.get(path) ?? null,
+    removeFile: async ({ path, recursive }) => {
+      this.files.delete(path);
+      this.directories.delete(path);
+      if (recursive) {
+        for (const value of [...this.files.keys()])
+          if (value.startsWith(`${path}/`)) this.files.delete(value);
+        for (const value of [...this.directories])
+          if (value.startsWith(`${path}/`)) this.directories.delete(value);
+      }
+    },
+    run: async ({ command, env }) => {
+      if (command === "exit 37") return result(37);
+      if (command === "printf vitehub-ascii") return result(0, "vitehub-ascii");
+      if (command === "env-probe") return result(0, `${env?.HOME}|${env?.DECLARED}`);
+      return result(0);
+    },
+    spawn: async () => {
+      let killed = false;
+      return {
+        stderr: new ReadableStream({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        stdout: new ReadableStream({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        async kill() {
+          killed = true;
+        },
+        async wait() {
+          return { exitCode: killed ? 137 : 0 };
+        },
+      };
+    },
+    stop: async () => {
+      this.stops++;
+      if (this.stopNever) await new Promise(() => {});
+      if (this.stopError) throw this.stopError;
+    },
+    writeBinaryFile: async ({ content, path }) => {
+      this.files.set(path, new Uint8Array(content));
+    },
+  };
+
+  private list(path: string, recursive: boolean | undefined): BoxFileEntry[] {
+    const entries: BoxFileEntry[] = [];
+    for (const directory of this.directories) {
+      if (directory !== path && isChild(path, directory, recursive))
+        entries.push({ path: directory, type: "directory" });
+    }
+    for (const [file, contents] of this.files) {
+      if (isChild(path, file, recursive))
+        entries.push({ path: file, size: contents.length, type: "file" });
+    }
+    return entries.sort((left, right) => left.path.localeCompare(right.path));
+  }
+}
+
+function isChild(parent: string, child: string, recursive: boolean | undefined) {
+  if (!child.startsWith(`${parent}/`)) return false;
+  return recursive || posix.dirname(child) === parent;
+}
+
+function hostPublicKey() {
+  const type = Buffer.from("ssh-ed25519");
+  const key = Buffer.alloc(32, 7);
+  const blob = Buffer.alloc(4 + type.length + 4 + key.length);
+  blob.writeUInt32BE(type.length, 0);
+  type.copy(blob, 4);
+  blob.writeUInt32BE(key.length, 4 + type.length);
+  key.copy(blob, 8 + type.length);
+  return `ssh-ed25519 ${blob.toString("base64")} ascii-host`;
+}
+
+function result(exitCode: number, stdout = "") {
+  return { exitCode, stderr: "", stdout };
+}
+
+function flattenMessages(error: unknown): string[] {
+  if (error instanceof AggregateError)
+    return [error.message, ...error.errors.flatMap(flattenMessages)];
+  return [error instanceof Error ? error.message : String(error)];
+}

--- a/packages/box/test/remote-providers.test.ts
+++ b/packages/box/test/remote-providers.test.ts
@@ -108,6 +108,33 @@ describe("remote Box providers", () => {
     expect(received).toBe(controller.signal);
   });
 
+  it("preserves initialization and cleanup failures", async () => {
+    const instance = vercelInstance();
+    instance.stop = async () => {
+      throw new Error("provider cleanup failed");
+    };
+    const box = await resolveBox({
+      runtime: createVercelRuntime({ create: async () => instance }),
+    }, {});
+
+    let failure: unknown;
+    try {
+      await box.open({
+        async initialize() {
+          throw new Error("initialization failed");
+        },
+      });
+    } catch (error) {
+      failure = error;
+    }
+
+    expect(failure).toBeInstanceOf(AggregateError);
+    expect((failure as AggregateError).errors).toEqual([
+      expect.objectContaining({ message: "initialization failed" }),
+      expect.objectContaining({ message: "provider cleanup failed" }),
+    ]);
+  });
+
   it.each([
     [undefined, "unrestricted"],
     ["allow-all" as const, "unrestricted"],

--- a/packages/box/test/runtime-selection.test.ts
+++ b/packages/box/test/runtime-selection.test.ts
@@ -1,4 +1,4 @@
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 
 import { describe, expect, it } from "vitest";
 
@@ -6,10 +6,12 @@ import { resolveBox, type BoxDefinition, type BoxRuntime } from "../src/index.ts
 
 describe("Box runtime selection", () => {
   it("accepts default built-ins by literal name", async () => {
+    const ascii = await resolveBox({ runtime: "ascii" }, {});
     const trusted = await resolveBox({ runtime: "trusted-host" }, {});
     const crabbox = await resolveBox({ cwd: process.cwd(), runtime: "crabbox" }, {});
     const vercel = await resolveBox({ runtime: "vercel" }, {});
 
+    expect(ascii.plan.runtime).toBe("ascii");
     expect(trusted.plan.runtime).toBe("trusted-host");
     expect(crabbox.plan.runtime).toBe("crabbox");
     expect(vercel.plan.runtime).toBe("vercel");
@@ -19,8 +21,12 @@ describe("Box runtime selection", () => {
     const box = await resolveBox({
       runtime: { kind: "trusted-host", stateRoot: process.cwd() },
     }, {});
+    const ascii = await resolveBox({
+      runtime: { apiKey: "test", kind: "ascii", ttlSeconds: 7200 },
+    }, {});
 
     expect(box.plan.runtime).toBe("trusted-host");
+    expect(ascii.plan.runtime).toBe("ascii");
   });
 
   it("rejects unknown built-ins and reserved custom runtime names", async () => {
@@ -45,9 +51,11 @@ describe("Box runtime selection", () => {
   it("keeps built-in names closed while allowing custom runtimes", () => {
     const custom = {} as BoxRuntime;
     const definitions = [
+      { runtime: "ascii" },
       { runtime: "crabbox" },
       { runtime: "trusted-host" },
       { runtime: "vercel" },
+      { runtime: { kind: "ascii", ttlSeconds: 7200 } },
       { runtime: { kind: "crabbox", profile: "worker" } },
       { runtime: { kind: "trusted-host", stateRoot: "/var/lib/vitehub" } },
       { runtime: { kind: "cloudflare", namespace: {} as never } },
@@ -63,14 +71,22 @@ describe("Box runtime selection", () => {
 
   it("loads optional provider peers only after their built-in runtime is opened", async () => {
     const dist = new URL("../dist/", import.meta.url);
-    const [index, cloudflare, vercel] = await Promise.all([
+    const asciiFile = (await readdir(dist)).find(file => /^ascii-.*\.js$/.test(file));
+    expect(asciiFile).toBeDefined();
+    const [index, ascii, cloudflare, vercel] = await Promise.all([
       readFile(new URL("index.js", dist), "utf8"),
+      readFile(new URL(asciiFile!, dist), "utf8"),
       readFile(new URL("internal/cloudflare.js", dist), "utf8"),
       readFile(new URL("internal/vercel.js", dist), "utf8"),
     ]);
 
+    expect(index).not.toContain("@asciidev/box-sdk");
     expect(index).not.toContain("@cloudflare/sandbox");
     expect(index).not.toContain("@vercel/sandbox");
+    expect(ascii).toContain("@asciidev/box-sdk");
+    expect(ascii).toMatch(/\bimport\(/);
+    expect(ascii).not.toContain("@cloudflare/sandbox");
+    expect(ascii).not.toContain("@vercel/sandbox");
     expect(cloudflare).toMatch(/\bimport\(["']@cloudflare\/sandbox["']\)/);
     expect(cloudflare).not.toContain("@vercel/sandbox");
     expect(vercel).toMatch(/\bimport\(["']@vercel\/sandbox["']\)/);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -707,9 +707,6 @@ importers:
       '@vite-hub/runtime':
         specifier: workspace:*
         version: link:../runtime
-      ssh2:
-        specifier: ^1.17.0
-        version: 1.17.0
     devDependencies:
       '@asciidev/box-sdk':
         specifier: ^0.0.24
@@ -726,6 +723,9 @@ importers:
       publint:
         specifier: catalog:tooling
         version: 0.3.21
+      ssh2:
+        specifier: ^1.17.0
+        version: 1.17.0
       typescript:
         specifier: catalog:tooling
         version: 6.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -707,7 +707,13 @@ importers:
       '@vite-hub/runtime':
         specifier: workspace:*
         version: link:../runtime
+      ssh2:
+        specifier: ^1.17.0
+        version: 1.17.0
     devDependencies:
+      '@asciidev/box-sdk':
+        specifier: ^0.0.24
+        version: 0.0.24
       '@cloudflare/sandbox':
         specifier: catalog:sandbox
         version: 0.8.14
@@ -1671,6 +1677,9 @@ packages:
     engines: {node: '>= 20'}
     peerDependencies:
       '@types/json-schema': ^7.0.15
+
+  '@asciidev/box-sdk@0.0.24':
+    resolution: {integrity: sha512-w77vTWA+yrJ5O+FmchCkurjux1UZkQ5yeurnzX/FJTlQulEtj1xp0g/2cSh/GZWLXrgCV0exU99E+NyiilBeHA==}
 
   '@aws-crypto/sha1-browser@5.2.0':
     resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
@@ -7944,6 +7953,9 @@ packages:
       zod:
         optional: true
 
+  asn1@0.2.6:
+    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -8070,6 +8082,9 @@ packages:
   basic-ftp@5.3.1:
     resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
     engines: {node: '>=10.0.0'}
+
+  bcrypt-pbkdf@1.0.2:
+    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
 
   better-auth@1.6.23:
     resolution: {integrity: sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==}
@@ -8223,6 +8238,10 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  buildcheck@0.0.7:
+    resolution: {integrity: sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA==}
+    engines: {node: '>=10.0.0'}
 
   builtin-modules@5.0.0:
     resolution: {integrity: sha512-bkXY9WsVpY7CvMhKSR6pZilZu9Ln5WDrKVBUXf2S443etkmEO4V58heTecXcUIsNsi4Rx8JUO4NfX1IcQl4deg==}
@@ -8543,6 +8562,10 @@ packages:
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
+
+  cpu-features@0.0.10:
+    resolution: {integrity: sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==}
+    engines: {node: '>=10.0.0'}
 
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
@@ -10975,6 +10998,9 @@ packages:
   multipasta@0.2.8:
     resolution: {integrity: sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==}
 
+  nan@2.28.0:
+    resolution: {integrity: sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==}
+
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -12454,6 +12480,10 @@ packages:
     engines: {node: '>=20.16.0'}
     hasBin: true
 
+  ssh2@1.17.0:
+    resolution: {integrity: sha512-wPldCk3asibAjQ/kziWQQt1Wh3PgDFpC0XpwclzKcdT1vql6KeYxf5LIt4nlFkUeR8WuphYMKqUA56X4rjbfgQ==}
+    engines: {node: '>=10.16.0'}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
@@ -12785,6 +12815,9 @@ packages:
   turndown@7.2.4:
     resolution: {integrity: sha512-I8yFsfRzmzK0WV1pNNOA4A7y4RDfFxPRxb3t+e3ui14qSGOxGtiSP6GjeX+Y6CHb7HYaFj7ECUD7VE5kQMZWGQ==}
     engines: {node: '>=18', npm: '>=9'}
+
+  tweetnacl@0.14.5:
+    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -13796,6 +13829,8 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
       js-yaml: 4.3.0
+
+  '@asciidev/box-sdk@0.0.24': {}
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
@@ -20720,6 +20755,10 @@ snapshots:
       ai: 7.0.19(zod@4.4.3)
       zod: 4.4.3
 
+  asn1@0.2.6:
+    dependencies:
+      safer-buffer: 2.1.2
+
   assertion-error@2.0.1: {}
 
   ast-kit@2.2.0:
@@ -20817,6 +20856,10 @@ snapshots:
   baseline-browser-mapping@2.10.43: {}
 
   basic-ftp@5.3.1: {}
+
+  bcrypt-pbkdf@1.0.2:
+    dependencies:
+      tweetnacl: 0.14.5
 
   better-auth@1.6.23(@cloudflare/workers-types@4.20260509.1)(@opentelemetry/api@1.9.1)(@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0))(better-sqlite3@12.9.0)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1))(react@19.2.6)(vue@3.5.40(typescript@6.0.3)):
     dependencies:
@@ -20978,6 +21021,9 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  buildcheck@0.0.7:
+    optional: true
 
   builtin-modules@5.0.0: {}
 
@@ -21286,6 +21332,12 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
+
+  cpu-features@0.0.10:
+    dependencies:
+      buildcheck: 0.0.7
+      nan: 2.28.0
+    optional: true
 
   crc-32@1.2.2: {}
 
@@ -24408,6 +24460,9 @@ snapshots:
 
   multipasta@0.2.8: {}
 
+  nan@2.28.0:
+    optional: true
+
   nanoid@3.3.16: {}
 
   nanoid@5.1.16: {}
@@ -27341,6 +27396,14 @@ snapshots:
 
   srvx@0.11.22: {}
 
+  ssh2@1.17.0:
+    dependencies:
+      asn1: 0.2.6
+      bcrypt-pbkdf: 1.0.2
+    optionalDependencies:
+      cpu-features: 0.0.10
+      nan: 2.28.0
+
   standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
@@ -27687,6 +27750,8 @@ snapshots:
   turndown@7.2.4:
     dependencies:
       '@mixmark-io/domino': 2.2.0
+
+  tweetnacl@0.14.5: {}
 
   type-check@0.4.0:
     dependencies:


### PR DESCRIPTION
`@vite-hub/box` now accepts `runtime: "ascii"` and `{ kind: "ascii", ... }`, while Home files, environment, requirements, and exact-SHA Git checkout continue through the shared Box materialization path. The ASCII SDK remains an optional, lazily loaded control-plane peer, and `vite-hub/box` forwards the same public types.

ASCII's command endpoint buffers output and caps execution at 60 seconds, so this adapter uses the SDK only to provision and delete the machine. A session-unique in-memory SSH key, control-plane-retrieved host-key pins, binary SFTP, and transient systemd services provide streamed stdout/stderr, numeric exit status, process-scoped cgroup kill, and cancellation. The public abstraction remains Box with an ASCII provider selection; this does not add a public remote-Box or generic transport API. A two-hour minimum TTL, bounded teardown, verified deletion, and fail-closed transport faults contain ambiguous lifecycle failures.

Validated with all 113 Box tests, Box build/publint and typecheck, the consolidated `vite-hub` build and package/publication tests, and independent spec and standards reviews. A disposable OpenSSH 9.6/systemd 255 proof rejected a wrong host pin, round-tripped binary SFTP, propagated `exit 37`, streamed output before completion, kept `sleep 3600` active past 65 seconds, and terminated its cgroup with `SIGTERM`/143. No ASCII credentials were available, so the provider control plane was not exercised live; injected lifecycle tests cover provisioning, cancellation, cleanup, deletion fallback, and repeated close, while each real Box probes the required image capabilities and fails closed.