### PR TITLE
fix(box): stream ASCII launch input over SSH

### DIFF
--- a/packages/box/src/ascii.ts
+++ b/packages/box/src/ascii.ts
@@ -105,6 +105,8 @@ export function createAsciiRuntime(
         requestInit(AbortSignal.timeout(300_000)),
       );
       const boxId = created.box.id;
+      let removePromise: Promise<void> | undefined;
+      const removeBox = () => (removePromise ??= removeAsciiBox(client, boxId));
       let runtimeSession: RuntimeSession | undefined;
       try {
         openOptions.signal?.throwIfAborted();
@@ -124,19 +126,14 @@ export function createAsciiRuntime(
           dependencies.openSsh ?? openAsciiSshSession,
           {
             abortSignal: openOptions.signal,
-            destroyBox: async () => await removeAsciiBox(client, boxId),
+            destroyBox: removeBox,
             host: box.ip!,
             hostKeys,
             identity,
           },
           openOptions.signal,
         );
-        runtimeSession = withAsciiLifecycle(
-          transport,
-          client,
-          boxId,
-          openOptions.id ?? boxId,
-        );
+        runtimeSession = withAsciiLifecycle(transport, boxId, removeBox, openOptions.id ?? boxId);
         await probeAsciiTransport(runtimeSession, openOptions.signal);
         const env = await resolveRemoteEnvironment(input, {
           home: "/home/user/.vitehub/home",
@@ -163,7 +160,7 @@ export function createAsciiRuntime(
           throw error;
         }
         try {
-          await removeAsciiBox(client, boxId);
+          await removeBox();
         } catch (cleanupError) {
           throw new AggregateError(
             [error, cleanupError],
@@ -334,8 +331,8 @@ function withBaseEnvironment(
 
 function withAsciiLifecycle(
   transport: RuntimeSession,
-  client: AsciiClient,
   boxId: string,
+  removeBox: () => Promise<void>,
   sessionId: string,
 ): RuntimeSession {
   let destroyPromise: Promise<void> | undefined;
@@ -343,13 +340,17 @@ function withAsciiLifecycle(
     ...transport,
     id: sessionId,
     async destroy() {
-      destroyPromise ??= closeAsciiBox(transport, client, boxId);
+      destroyPromise ??= closeAsciiBox(transport, boxId, removeBox);
       return await destroyPromise;
     },
   };
 }
 
-async function closeAsciiBox(transport: RuntimeSession, client: AsciiClient, boxId: string) {
+async function closeAsciiBox(
+  transport: RuntimeSession,
+  boxId: string,
+  removeBox: () => Promise<void>,
+) {
   const failures: unknown[] = [];
   try {
     await withTimeout(
@@ -361,7 +362,7 @@ async function closeAsciiBox(transport: RuntimeSession, client: AsciiClient, box
     failures.push(error);
   }
   try {
-    await removeAsciiBox(client, boxId);
+    await removeBox();
   } catch (error) {
     failures.push(error);
   }

--- a/packages/box/src/internal/ascii-ssh.ts
+++ b/packages/box/src/internal/ascii-ssh.ts
@@ -228,12 +228,15 @@ function createAsciiSshSession(
     processes.add(process);
     void process.settled.finally(() => processes.delete(process));
     try {
-      await waitWithTimeout(
-        endChannel(channel, launchScript),
-        10_000,
-        `[vitehub] ASCII process ${unit} launch input timed out.`,
-        options.abortSignal,
-      );
+      await Promise.all([
+        waitWithTimeout(
+          endChannel(channel, launchScript),
+          10_000,
+          `[vitehub] ASCII process ${unit} launch input timed out.`,
+          options.abortSignal,
+        ),
+        process.ready,
+      ]);
     } catch (error) {
       return await failClosed(error, destroyBox, `[vitehub] ASCII process ${unit} launch failed.`);
     }
@@ -245,7 +248,6 @@ function createAsciiSshSession(
         options.abortSignal?.removeEventListener("abort", onAbort),
       );
     }
-    await process.ready;
     options.abortSignal?.throwIfAborted();
     return process;
   };

--- a/packages/box/src/internal/ascii-ssh.ts
+++ b/packages/box/src/internal/ascii-ssh.ts
@@ -78,7 +78,9 @@ export async function openAsciiSshSession(
 ): Promise<RuntimeSession> {
   const ssh2 = await loadModule();
   const client = new ssh2.Client();
-  const fault = createTransportFault(options.destroyBox);
+  let destroyPromise: Promise<void> | undefined;
+  const destroyBox = () => (destroyPromise ??= options.destroyBox());
+  const fault = createTransportFault(destroyBox);
   await connect(client, options, fault.record);
   try {
     const sftp = await waitWithTimeout(
@@ -87,7 +89,7 @@ export async function openAsciiSshSession(
       "[vitehub] ASCII SFTP negotiation timed out.",
       options.abortSignal,
     );
-    return createAsciiSshSession(client, sftp, options.destroyBox, fault);
+    return createAsciiSshSession(client, sftp, destroyBox, fault);
   } catch (error) {
     client.destroy();
     throw error;
@@ -199,20 +201,12 @@ function createAsciiSshSession(
   }) => {
     assertOpen();
     options.abortSignal?.throwIfAborted();
+    const launchScript = launchScriptContents(options);
     const unit = `vitehub-${randomUUID()}.service`;
-    const launchScript = `/home/user/.vitehub-launch-${randomUUID()}`;
     let channel: SshChannel;
     try {
-      await sftpCall<void>(options.abortSignal, client, fault.record, (callback) =>
-        sftp.writeFile(
-          launchScript,
-          Buffer.from(launchScriptContents(launchScript, options)),
-          { mode: 0o700 },
-          callback,
-        ),
-      );
       channel = await waitWithTimeout(
-        exec(systemdRunCommand(unit, launchScript, options.workingDirectory)),
+        exec(systemdRunCommand(unit, options.workingDirectory)),
         10_000,
         `[vitehub] ASCII process ${unit} launch timed out.`,
         options.abortSignal,
@@ -233,9 +227,20 @@ function createAsciiSshSession(
     );
     processes.add(process);
     void process.settled.finally(() => processes.delete(process));
+    try {
+      await waitWithTimeout(
+        endChannel(channel, launchScript),
+        10_000,
+        `[vitehub] ASCII process ${unit} launch input timed out.`,
+        options.abortSignal,
+      );
+    } catch (error) {
+      return await failClosed(error, destroyBox, `[vitehub] ASCII process ${unit} launch failed.`);
+    }
     if (options.abortSignal) {
       const onAbort = () => void process.kill("KILL").catch(() => undefined);
       options.abortSignal.addEventListener("abort", onAbort, { once: true });
+      if (options.abortSignal.aborted) onAbort();
       void process.settled.finally(() =>
         options.abortSignal?.removeEventListener("abort", onAbort),
       );
@@ -356,11 +361,7 @@ function createAsciiSshSession(
   };
 }
 
-function systemdRunCommand(
-  unit: string,
-  launchScript: string,
-  workingDirectory?: string,
-) {
+function systemdRunCommand(unit: string, workingDirectory?: string) {
   const args = [
     "sudo",
     "-n",
@@ -378,27 +379,19 @@ function systemdRunCommand(
     "--property=TimeoutStopSec=10s",
     "--",
     "/bin/sh",
-    launchScript,
+    "-s",
   ];
   return args.map(shellQuote).join(" ");
 }
 
-function launchScriptContents(
-  path: string,
-  options: { command: string; env?: Record<string, string> },
-) {
+function launchScriptContents(options: { command: string; env?: Record<string, string> }) {
   const exports = Object.entries(options.env ?? {}).map(([name, value]) => {
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name))
-      throw new TypeError(`[vitehub] Invalid Box environment variable: ${name}`);
-    return `export ${name}=${shellQuote(value)}`;
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(name)) {
+      throw new Error(`[vitehub] Invalid environment variable name: ${JSON.stringify(name)}.`);
+    }
+    return `export ${shellQuote(`${name}=${value}`)}`;
   });
-  return [
-    "#!/bin/sh",
-    ...exports,
-    `rm -f -- ${shellQuote(path)}`,
-    `exec /bin/sh -lc ${shellQuote(options.command)}`,
-    "",
-  ].join("\n");
+  return [...exports, `exec /bin/sh -lc ${shellQuote(options.command)}`, ""].join("\n");
 }
 
 function createRuntimeProcess(
@@ -564,6 +557,21 @@ async function openChannel(client: SshClient, command: string) {
     client.exec(command, (error, channel) => {
       if (error) reject(error);
       else resolve(channel);
+    });
+  });
+}
+
+async function endChannel(channel: SshChannel, contents: string) {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      channel.removeListener("error", onError);
+      reject(error);
+    };
+    channel.once("error", onError);
+    channel.end(contents, (error) => {
+      channel.removeListener("error", onError);
+      if (error) reject(error);
+      else resolve();
     });
   });
 }
@@ -826,6 +834,7 @@ interface SshClient {
 
 interface SshChannel extends Readable {
   readonly stderr: Readable;
+  end(contents: string, callback: (error?: Error | null) => void): this;
 }
 
 interface SftpClient {
@@ -833,12 +842,6 @@ interface SftpClient {
   readFile(
     path: string,
     callback: (error: NodeJS.ErrnoException | null, contents: Buffer) => void,
-  ): void;
-  writeFile(
-    path: string,
-    contents: Buffer,
-    options: { mode: number },
-    callback: (error: NodeJS.ErrnoException | null, value: void) => void,
   ): void;
   writeFile(
     path: string,

--- a/packages/box/test/ascii-ssh.test.ts
+++ b/packages/box/test/ascii-ssh.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { PassThrough } from "node:stream";
+import { Duplex, PassThrough } from "node:stream";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -183,25 +183,88 @@ describe("ASCII SSH transport", () => {
     });
 
     expect(server.commands.join("\n")).not.toContain("secret-value");
-    expect(server.writtenFiles).toEqual([
-      expect.objectContaining({
-        contents: expect.stringContaining("secret-value"),
-        mode: 0o700,
-      }),
-    ]);
+    expect(server.process?.input).toContain("export 'GH_TOKEN=secret-value'");
+    expect(server.writtenFiles).toEqual([]);
     await process.kill();
     await session.stop();
   });
 
-  it("rejects invalid environment names before launching", async () => {
+  it("waits for the launch input to flush before returning the process", async () => {
+    const server = new FakeSshServer();
+    server.holdProcessInput = true;
+    const session = await openSession(server);
+    let opened = false;
+    const opening = session.spawn!({ command: "sleep 3600" }).then((process) => {
+      opened = true;
+      return process;
+    });
+
+    await vi.waitFor(() => expect(server.process?.input).toContain("sleep 3600"));
+    expect(opened).toBe(false);
+    server.releaseProcessInput();
+
+    const process = await opening;
+    await process.kill();
+    await session.stop();
+  });
+
+  it("destroys the Box once when launch input delivery is cancelled", async () => {
+    const server = new FakeSshServer();
+    server.holdProcessInput = true;
+    const session = await openSession(server);
+    const controller = new AbortController();
+    const opening = session.spawn!({
+      abortSignal: controller.signal,
+      command: "sleep 3600",
+    });
+
+    await vi.waitFor(() => expect(server.process?.input).toContain("sleep 3600"));
+    controller.abort(new Error("cancel launch input"));
+
+    await expect(opening).rejects.toThrow("cancel launch input");
+    expect(server.boxDestroys).toBe(1);
+    await session.stop();
+  });
+
+  it("destroys the Box once when launch input delivery fails", async () => {
+    const server = new FakeSshServer();
+    server.processInputError = new Error("SSH write failed");
+    const session = await openSession(server);
+
+    await expect(session.spawn!({ command: "sleep 3600" })).rejects.toThrow("SSH write failed");
+    expect(server.boxDestroys).toBe(1);
+    await session.stop();
+  });
+
+  it("coalesces client and channel failures into one provider deletion", async () => {
+    const server = new FakeSshServer();
+    server.holdProcessInput = true;
+    const session = await openSession(server);
+    const opening = session.spawn!({ command: "sleep 3600" });
+
+    await vi.waitFor(() => expect(server.process?.input).toContain("sleep 3600"));
+    server.client.emit("error", new Error("SSH connection lost"));
+    server.process?.failInput(new Error("SSH channel closed"));
+
+    await expect(opening).rejects.toThrow("SSH channel closed");
+    await vi.waitFor(() => expect(server.boxDestroys).toBe(1));
+    await expect(session.stop()).rejects.toThrow();
+  });
+
+  it("rejects invalid environment variable names without launching a process", async () => {
     const server = new FakeSshServer();
     const session = await openSession(server);
 
     await expect(
-      session.spawn!({ command: "true", env: { "SAFE; touch /tmp/injected; #": "value" } }),
-    ).rejects.toThrow("Invalid Box environment variable");
-    expect(server.commands.join("\n")).not.toContain("touch /tmp/injected");
-    expect(server.boxDestroys).toBe(1);
+      session.spawn!({
+        command: "sleep 3600",
+        env: { "X; touch /tmp/pwned; #": "value" },
+      }),
+    ).rejects.toThrow("Invalid environment variable name");
+
+    expect(server.commands.some((command) => command.includes("systemd-run"))).toBe(false);
+    expect(server.boxDestroys).toBe(0);
+    await session.stop();
   });
 
   it("accepts a transient unit that systemd already collected", async () => {
@@ -295,17 +358,19 @@ class FakeSshServer {
   holdConnect = false;
   holdObservation = false;
   holdExec = false;
+  holdProcessInput = false;
   holdSftpOpen = false;
   holdSftpRead = false;
   observation: FakeChannel | undefined;
   process: FakeChannel | undefined;
+  processInputError: Error | undefined;
   processStderr = [] as string[];
   processStdout = ["started"] as string[];
   sftpError: Error | undefined;
   sftpOpens = 0;
   sftpReads = 0;
   verificationExitCode = 0;
-  readonly writtenFiles: Array<{ contents: string; mode?: number; path: string }> = [];
+  readonly writtenFiles: Array<{ contents: string; path: string }> = [];
   unitCollected = false;
 
   constructor() {
@@ -317,8 +382,12 @@ class FakeSshServer {
     const channel = new FakeChannel();
     if (command.includes("systemd-run")) {
       this.process = channel;
-      for (const chunk of this.processStdout) channel.write(chunk);
-      for (const chunk of this.processStderr) channel.stderr.write(chunk);
+      channel.holdInput = this.holdProcessInput;
+      channel.inputError = this.processInputError;
+      channel.once("finish", () => {
+        for (const chunk of this.processStdout) channel.output(chunk);
+        for (const chunk of this.processStderr) channel.stderr.write(chunk);
+      });
     } else if (command.includes("systemctl kill")) {
       const signal = command.match(/--signal=SIG([A-Z]+)/)?.[1] ?? "TERM";
       this.killSignals.push(signal);
@@ -351,6 +420,10 @@ class FakeSshServer {
 
   releaseObservation() {
     this.observation?.finish(0, "loaded\nactive\n");
+  }
+
+  releaseProcessInput() {
+    this.process?.releaseInput();
   }
 }
 
@@ -410,34 +483,58 @@ class FakeSftp {
   writeFile(
     path: string,
     contents: Buffer,
-    options:
-      | { mode: number }
-      | ((error: NodeJS.ErrnoException | null, value: void) => void),
-    callback?: (error: NodeJS.ErrnoException | null, value: void) => void,
+    callback: (error: NodeJS.ErrnoException | null, value: void) => void,
   ) {
     this.server.writtenFiles.push({
       contents: contents.toString(),
-      mode: typeof options === "function" ? undefined : options.mode,
       path,
     });
-    (typeof options === "function" ? options : callback!)(null, undefined);
+    callback(null, undefined);
   }
 }
 
-class FakeChannel extends PassThrough {
+class FakeChannel extends Duplex {
+  holdInput = false;
+  inputError: Error | undefined;
   readonly stderr = new PassThrough();
+  input = "";
   private finished = false;
+  private inputCallback: ((error?: Error | null) => void) | undefined;
 
   constructor() {
     super({ autoDestroy: false });
   }
 
+  _read() {}
+
+  _write(chunk: Buffer, _encoding: BufferEncoding, callback: (error?: Error | null) => void) {
+    this.input += chunk.toString();
+    if (this.inputError) callback(this.inputError);
+    else if (this.holdInput) this.inputCallback = callback;
+    else callback();
+  }
+
+  output(contents: string) {
+    this.push(contents);
+  }
+
+  releaseInput() {
+    this.holdInput = false;
+    this.inputCallback?.();
+    this.inputCallback = undefined;
+  }
+
+  failInput(error: Error) {
+    this.inputCallback?.(error);
+    this.inputCallback = undefined;
+  }
+
   finish(code: number, stdout = "", stderr = "") {
     if (this.finished) return;
     this.finished = true;
-    if (stdout) this.write(stdout);
+    if (stdout) this.output(stdout);
     if (stderr) this.stderr.write(stderr);
-    this.end();
+    this.push(null);
     this.stderr.end();
     queueMicrotask(() => {
       this.emit("exit", code);

--- a/packages/box/test/ascii-ssh.test.ts
+++ b/packages/box/test/ascii-ssh.test.ts
@@ -236,6 +236,23 @@ describe("ASCII SSH transport", () => {
     await session.stop();
   });
 
+  it("observes readiness failures while launch input delivery is blocked", async () => {
+    const server = new FakeSshServer();
+    server.holdProcessInput = true;
+    server.observationExitCode = 1;
+    const session = await openSession(server);
+    const opening = session.spawn!({ command: "sleep 3600" });
+    const openingError = opening.catch((error: unknown) => error);
+
+    await vi.waitFor(() => expect(server.process?.input).toContain("sleep 3600"));
+
+    await expect(openingError).resolves.toEqual(
+      expect.objectContaining({ message: expect.stringContaining("could not be observed") }),
+    );
+    expect(server.boxDestroys).toBe(1);
+    await session.stop();
+  });
+
   it("coalesces client and channel failures into one provider deletion", async () => {
     const server = new FakeSshServer();
     server.holdProcessInput = true;
@@ -362,6 +379,7 @@ class FakeSshServer {
   holdSftpOpen = false;
   holdSftpRead = false;
   observation: FakeChannel | undefined;
+  observationExitCode = 0;
   process: FakeChannel | undefined;
   processInputError: Error | undefined;
   processStderr = [] as string[];
@@ -409,7 +427,13 @@ class FakeSshServer {
       );
     } else if (command.includes("LoadState") && command.includes("ActiveState")) {
       if (this.holdObservation) this.observation = channel;
-      else setImmediate(() => channel.finish(0, "loaded\nactive\n"));
+      else
+        setImmediate(() =>
+          channel.finish(
+            this.observationExitCode,
+            this.observationExitCode === 0 ? "loaded\nactive\n" : "",
+          ),
+        );
     } else if (command.includes("cgroup.procs")) {
       setImmediate(() => channel.finish(0));
     } else {

--- a/packages/box/test/ascii.test.ts
+++ b/packages/box/test/ascii.test.ts
@@ -107,6 +107,14 @@ describe("ASCII Box runtime", () => {
     expect(fixture.control.removes).toBe(1);
   });
 
+  it("coalesces transport cleanup with outer open cleanup", async () => {
+    const fixture = asciiFixture({ destroyDuringOpen: true });
+    const box = await resolveBox({ runtime: fixture.runtime }, {});
+
+    await expect(box.open()).rejects.toThrow("transport setup failed");
+    expect(fixture.control.removes).toBe(1);
+  });
+
   it("finishes create before honoring cancellation so the new Box can be deleted", async () => {
     const fixture = asciiFixture();
     let finishCreate!: () => void;
@@ -188,7 +196,9 @@ describe("ASCII Box runtime", () => {
   });
 });
 
-function asciiFixture(options: { provisioningTimeoutMs?: number } = {}) {
+function asciiFixture(
+  options: { destroyDuringOpen?: boolean; provisioningTimeoutMs?: number } = {},
+) {
   const machine = new FakeAsciiMachine();
   const control = {
     archiveAfterStop: true,
@@ -266,7 +276,11 @@ function asciiFixture(options: { provisioningTimeoutMs?: number } = {}) {
         async createIdentity() {
           return { privateKey: "private", publicKey: "ssh-ed25519 test" };
         },
-        async openSsh() {
+        async openSsh(input) {
+          if (options.destroyDuringOpen) {
+            await input.destroyBox();
+            throw new Error("transport setup failed");
+          }
           return machine.session;
         },
         provisioningTimeoutMs: options.provisioningTimeoutMs,


### PR DESCRIPTION
ASCII process launches now deliver the command and environment over bounded SSH stdin to `systemd-run`, so secret-bearing launch files are never persisted in the Box. Environment names are rejected before any remote process action, and ViteHub waits for ssh2's channel-end callback before exposing the process, which makes cancellation, timeout, and write failures fail closed.

Provider deletion now shares one promise across SSH client and channel faults, transport teardown, lifecycle close, and outer initialization rollback. This is the reviewed follow-up to #859 and prevents concurrent cleanup paths from issuing duplicate provider deletes without changing the public ASCII selector or Box contract.

Validated with 30 focused ASCII tests, 75 relevant Box tests, Box typecheck, build and publint, formatting and diff checks, and an independent security/lifecycle review. A fresh OpenSSH 9.6/systemd 255 proof streamed output, round-tripped binary SFTP, kept the process active for 65 seconds, found zero persisted launch files, and terminated the process cgroup with `SIGTERM`/143. The full Box suite passed 124 of 125 tests locally; the remaining unchanged trusted-host process-group test is blocked by host `kill EPERM`.
