### PR TITLE
fix(agent): preserve multimodal history for fresh harness sessions

### DIFF
--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -24,7 +24,7 @@ import {
   type ColocatedAgentSkills,
 } from "./internal/colocated-agent-skills.ts"
 import { toAiSdkModelMessages } from "./ai-sdk.ts"
-import { isAttachmentPart } from "./messages.ts"
+import { isAttachmentData, isAttachmentPart } from "./messages.ts"
 import { isAsyncIterable } from "./internal/stream-result.ts"
 import {
   applyAgentToolPolicies,
@@ -47,7 +47,8 @@ import type {
   AgentToolSet,
   MaybePromise,
 } from "./types.ts"
-import type { Message } from "./messages.ts"
+import type { AttachmentData, Message } from "./messages.ts"
+import type { UserContent, UserModelMessage } from "ai"
 
 type HarnessAgentLike = {
   createSession: (options?: Record<string, unknown>) => MaybePromise<HarnessAgentSessionLike>
@@ -77,10 +78,20 @@ type HarnessGlobalSkillsSandbox = {
   run(options: { abortSignal?: AbortSignal, command: string, workingDirectory?: string }): PromiseLike<{ exitCode: number, stderr?: string, stdout?: string }>
 }
 
+type HarnessAttachmentSandbox = HarnessInstructionSandbox & HarnessGlobalSkillsSandbox
+
+interface HarnessPreparedSandbox {
+  abortSignal?: AbortSignal
+  session: HarnessAttachmentSandbox
+  sessionWorkDir: string
+}
+
 type HarnessAgentConstructor = new (settings: Record<string, unknown>) => HarnessAgentLike
 const harnessResumeStates = new WeakMap<object, Map<string, unknown>>()
 const harnessGeneratedFiles = ["harness-tool.mjs"] as const
 const harnessInstructionFiles = ["AGENTS.md", "CLAUDE.md"] as const
+const harnessAttachmentDirectory = ".vitehub/attachments"
+const harnessAttachmentMaxBytes = 25 * 1024 * 1024
 const harnessAgentPackage = "@ai-sdk/harness/agent"
 const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
 const harnessGlobalSkillsDirectory = Symbol.for("vitehub.harnessGlobalSkillsDirectory")
@@ -304,14 +315,6 @@ async function composeHarnessInstructions(content: string, context: AgentAdapter
   return await composeInstructionDocument(content, compositionContext)
 }
 
-function renderHarnessModelMessageContent(content: unknown): string {
-  if (typeof content === "string") return content
-  if (Array.isArray(content) && content.every(part => part && typeof part === "object" && (part as { type?: unknown }).type === "text" && typeof (part as { text?: unknown }).text === "string")) {
-    return content.map(part => (part as { text: string }).text).join("")
-  }
-  return JSON.stringify(content)
-}
-
 function harnessSerializableMessages(messages: Message[]): Message[] {
   return messages.map(message => ({
     ...message,
@@ -324,16 +327,41 @@ function harnessSerializableMessages(messages: Message[]): Message[] {
   }))
 }
 
-function renderHarnessChatPrompt(messages: Message[]): string {
-  return [
-    "Conversation history:",
-    ...toAiSdkModelMessages(harnessSerializableMessages(messages)).map((message) => {
-      const role = message.role === "assistant" ? "Assistant" : message.role === "user" ? "User" : message.role
-      return `${role}: ${renderHarnessModelMessageContent(message.content)}`
-    }),
-    "",
-    "Respond to the latest user message.",
-  ].join("\n")
+type HarnessProjectedContentPart = Exclude<UserContent, string>[number]
+
+function projectHarnessChatMessages(messages: Message[]): UserModelMessage {
+  const modelMessages = toAiSdkModelMessages(messages)
+  const lastUserMessage = modelMessages.findLast((message): message is UserModelMessage => message.role === "user")
+  if (!lastUserMessage) {
+    throw new Error("[vitehub] Harness chat history must contain a user message.")
+  }
+  if (messages.length === 1) return lastUserMessage
+
+  const content: HarnessProjectedContentPart[] = []
+  for (const message of modelMessages) {
+    const projected: HarnessProjectedContentPart[] = []
+    if (typeof message.content === "string") {
+      projected.push({ text: message.content, type: "text" })
+    }
+    else {
+      for (const part of message.content) {
+        if (part.type === "text") {
+          projected.push({ text: part.text, type: "text" })
+        }
+        else if (message.role === "user" && part.type === "image") {
+          projected.push(part)
+        }
+        else {
+          projected.push({ text: JSON.stringify(part), type: "text" })
+        }
+      }
+    }
+    if (!projected.length) continue
+    content.push({ text: `<message role="${message.role}">\n`, type: "text" })
+    content.push(...projected)
+    content.push({ text: "\n</message>\n", type: "text" })
+  }
+  return { content, role: "user" }
 }
 
 function latestHarnessUserMessage(messages: Message[]): Message[] {
@@ -344,7 +372,182 @@ function latestHarnessUserMessage(messages: Message[]): Message[] {
   return messages.slice(-1)
 }
 
-async function toHarnessCallInput(context: AgentAdapterRunContext, resumesSession = false) {
+function harnessAttachmentExtension(mediaType: string): string {
+  return {
+    "application/pdf": "pdf",
+    "image/apng": "apng",
+    "image/avif": "avif",
+    "image/gif": "gif",
+    "image/jpeg": "jpg",
+    "image/png": "png",
+    "image/svg+xml": "svg",
+    "image/webp": "webp",
+    "text/plain": "txt",
+  }[mediaType.toLowerCase()] || "bin"
+}
+
+function harnessAttachmentStringBytes(value: string, mediaType: string): Uint8Array {
+  const dataUrl = /^data:([^,]*?),(.*)$/s.exec(value)
+  if (dataUrl) {
+    const encoded = dataUrl[2]!
+    return dataUrl[1]!.split(";").includes("base64")
+      ? new Uint8Array(Buffer.from(encoded, "base64"))
+      : new TextEncoder().encode(decodeURIComponent(encoded))
+  }
+  const normalizedMediaType = mediaType.toLowerCase()
+  if (
+    normalizedMediaType.startsWith("text/")
+    || normalizedMediaType === "application/json"
+    || normalizedMediaType.endsWith("+json")
+    || normalizedMediaType.endsWith("+xml")
+  ) {
+    return new TextEncoder().encode(value)
+  }
+  return new Uint8Array(Buffer.from(value, "base64"))
+}
+
+async function harnessAttachmentBytes(data: AttachmentData, mediaType: string): Promise<Uint8Array> {
+  if (data instanceof Blob) return new Uint8Array(await data.arrayBuffer())
+  if (data instanceof ArrayBuffer) return new Uint8Array(data)
+  if (data instanceof Uint8Array) return data
+  return harnessAttachmentStringBytes(data, mediaType)
+}
+
+async function resolveHarnessAttachmentData(part: Extract<Message["parts"][number], { type: "audio" | "file" | "image" }>): Promise<AttachmentData | undefined> {
+  if (typeof part.fetchData !== "function") return isAttachmentData(part.data) ? part.data : undefined
+  const fetched = await part.fetchData()
+  return isAttachmentData(fetched) ? fetched : undefined
+}
+
+function quoteHarnessShellValue(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+async function removeHarnessAttachmentDirectory(session: HarnessAttachmentSandbox, directory: string): Promise<void> {
+  const attachmentsDirectory = posix.dirname(directory)
+  const vitehubDirectory = posix.dirname(attachmentsDirectory)
+  const result = await session.run({
+    command: `rm -rf -- ${quoteHarnessShellValue(directory)} && { rmdir -- ${quoteHarnessShellValue(attachmentsDirectory)} ${quoteHarnessShellValue(vitehubDirectory)} 2>/dev/null || true; }`,
+  })
+  if (result.exitCode !== 0) {
+    throw new Error(`[vitehub] Failed to clean up Harness attachments: ${result.stderr || "sandbox command failed"}`)
+  }
+}
+
+async function materializeHarnessChatMessages(
+  messages: Message[],
+  prepared: HarnessPreparedSandbox,
+): Promise<{ directory?: string, messages: Message[] }> {
+  const hasAttachments = messages.some(message =>
+    message.role === "user" && message.parts.some(isAttachmentPart),
+  )
+  if (!hasAttachments) return { messages }
+
+  let remainingBytes = harnessAttachmentMaxBytes
+  let remainingDeclaredBytes = harnessAttachmentMaxBytes
+  const directory = joinHarnessSessionPath(
+    prepared.sessionWorkDir,
+    `${harnessAttachmentDirectory}/${globalThis.crypto.randomUUID()}`,
+  )
+  try {
+    const materialized: Message[] = []
+    for (const [messageIndex, message] of messages.entries()) {
+      if (message.role !== "user") {
+        materialized.push(message)
+        continue
+      }
+      const parts: Message["parts"] = []
+      for (const [partIndex, part] of message.parts.entries()) {
+        if (!isAttachmentPart(part)) {
+          parts.push(part)
+          continue
+        }
+        if (typeof part.size === "number" && part.size > remainingDeclaredBytes) {
+          throw new Error(`[vitehub] ${part.type} attachment exceeds the remaining Harness attachment limit (${remainingDeclaredBytes} bytes).`)
+        }
+        if (typeof part.size === "number") remainingDeclaredBytes -= part.size
+        const data = await resolveHarnessAttachmentData(part)
+        if (!data) {
+          if (part.url) {
+            throw new Error(`[vitehub] Harness ${part.type} attachment requires data or fetchData(); URL-only attachments must be resolved by the Channel adapter.`)
+          }
+          throw new TypeError(`[vitehub] Harness ${part.type} attachment fetchData() did not return supported attachment data.`)
+        }
+        const bytes = await harnessAttachmentBytes(data, part.mediaType)
+        if (bytes.byteLength > remainingBytes) {
+          throw new Error(`[vitehub] ${part.type} attachment is ${bytes.byteLength} bytes, which exceeds the remaining Harness attachment limit (${remainingBytes} bytes).`)
+        }
+        remainingBytes -= bytes.byteLength
+        const path = `${directory}/message-${messageIndex + 1}-attachment-${partIndex + 1}.${harnessAttachmentExtension(part.mediaType)}`
+        await prepared.session.writeBinaryFile({
+          abortSignal: prepared.abortSignal,
+          content: bytes,
+          path,
+        })
+        if (part.type === "image") {
+          const { fetchData: _fetchData, url: _url, ...image } = part
+          parts.push({ ...image, data: path })
+        }
+        else {
+          parts.push({
+            id: part.id,
+            text: `Attachment ${JSON.stringify(part.name || part.type)} (${JSON.stringify(part.mediaType)}) is available at ${path}.`,
+            type: "text" as const,
+          })
+        }
+      }
+      materialized.push({ ...message, parts })
+    }
+    return { directory, messages: materialized }
+  }
+  catch (error) {
+    try {
+      await removeHarnessAttachmentDirectory(prepared.session, directory)
+    }
+    catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], "[vitehub] Harness attachment preparation and cleanup failed.")
+    }
+    throw error
+  }
+}
+
+async function prepareHarnessChatPrompt(
+  context: AgentAdapterRunContext,
+  resumesSession: boolean,
+  prepared: HarnessPreparedSandbox | undefined,
+): Promise<{ directory?: string, prompt: UserModelMessage }> {
+  const selectedMessages = resumesSession ? latestHarnessUserMessage(context.messages) : context.messages
+  const hasAttachments = selectedMessages.some(message => message.role === "user" && message.parts.some(isAttachmentPart))
+  if (hasAttachments && !prepared) {
+    throw new Error("[vitehub] Harness attachment materialization requires a prepared sandbox session.")
+  }
+  const materialized = prepared
+    ? await materializeHarnessChatMessages(selectedMessages, prepared)
+    : { messages: selectedMessages }
+  try {
+    return {
+      ...(materialized.directory ? { directory: materialized.directory } : {}),
+      prompt: projectHarnessChatMessages(materialized.messages),
+    }
+  }
+  catch (error) {
+    if (materialized.directory && prepared) {
+      try {
+        await removeHarnessAttachmentDirectory(prepared.session, materialized.directory)
+      }
+      catch (cleanupError) {
+        throw new AggregateError([error, cleanupError], "[vitehub] Harness chat projection and attachment cleanup failed.")
+      }
+    }
+    throw error
+  }
+}
+
+async function toHarnessCallInput(
+  context: AgentAdapterRunContext,
+  resumesSession = false,
+  chatPrompt?: UserModelMessage,
+) {
   const base = {
     abortSignal: context.input.abortSignal,
     timeout: context.input.timeout,
@@ -355,7 +558,7 @@ async function toHarnessCallInput(context: AgentAdapterRunContext, resumesSessio
     if (context.context.has("chat")) {
       return {
         ...base,
-        prompt: renderHarnessChatPrompt(resumesSession ? latestHarnessUserMessage(context.messages) : context.messages),
+        messages: [chatPrompt || projectHarnessChatMessages(resumesSession ? latestHarnessUserMessage(context.messages) : context.messages)],
       }
     }
     return {
@@ -1057,8 +1260,15 @@ export function createHarnessAgentAdapter<
   async function createAgentAndSession(context: AgentAdapterRunContext<CALL_OPTIONS, TRuntimeConfig>) {
     let workspaceSession: { close: (error?: unknown) => MaybePromise<void>, refreshGitBaseline?: () => MaybePromise<void> } | undefined
     let globalSkillsSession: { close: (error?: unknown) => MaybePromise<void> } | undefined
+    let preparedSandbox: HarnessPreparedSandbox | undefined
+    let attachmentDirectory: string | undefined
     const colocatedSkillsWorkspace = await resolveHarnessColocatedSkills(context)
     const resolved = await createHarnessAgent(options, context, async (session, sessionWorkDir, abortSignal, globalSkillsDirectory, globalSkillsWorkspace, sessionPrepare) => {
+      preparedSandbox = {
+        abortSignal,
+        session: session as HarnessAttachmentSandbox,
+        sessionWorkDir,
+      }
       let globalSkillsWorkingDirectory: string | undefined
       if (context.box && isHarnessRelativeDirectory(globalSkillsDirectory)) {
         const home = await (session as HarnessGlobalSkillsSandbox).run({
@@ -1129,26 +1339,59 @@ export function createHarnessAgentAdapter<
     })
     const preparationSession = {
       async close(error?: unknown) {
+        let closeError = error
+        if (attachmentDirectory && preparedSandbox) {
+          try {
+            await removeHarnessAttachmentDirectory(preparedSandbox.session, attachmentDirectory)
+          }
+          catch (nextError) {
+            closeError = nextError
+          }
+          attachmentDirectory = undefined
+        }
         try {
-          await globalSkillsSession?.close(error)
+          await globalSkillsSession?.close(closeError)
+        }
+        catch (nextError) {
+          closeError = nextError
         }
         finally {
-          await workspaceSession?.close(error)
+          try {
+            await workspaceSession?.close(closeError)
+          }
+          catch (nextError) {
+            closeError = nextError
+          }
         }
+        if (closeError !== error) throw closeError
       },
+    }
+    const created = await createSession(resolved.agent, context, () => preparationSession, resolved)
+    let chatPrompt: UserModelMessage | undefined
+    try {
+      if (context.context.has("chat") && context.messages.length) {
+        const prepared = await prepareHarnessChatPrompt(context, created.resumesSession, preparedSandbox)
+        attachmentDirectory = prepared.directory
+        chatPrompt = prepared.prompt
+      }
+    }
+    catch (error) {
+      await created.cleanup(error)
+      throw error
     }
     return {
       agent: resolved.agent,
-      ...await createSession(resolved.agent, context, () => preparationSession, resolved),
+      chatPrompt,
+      ...created,
     }
   }
 
   return {
     async generate(context) {
-      const { agent, cleanup, session, resumesSession } = await createAgentAndSession(context)
+      const { agent, chatPrompt, cleanup, session, resumesSession } = await createAgentAndSession(context)
       try {
         const result = defineAgentUsageMetadata(await agent.generate({
-          ...await toHarnessCallInput(context, resumesSession),
+          ...await toHarnessCallInput(context, resumesSession, chatPrompt),
           session,
         }), usageMetadata)
         await cleanup()
@@ -1161,10 +1404,10 @@ export function createHarnessAgentAdapter<
     },
     name: "ai-sdk-harness",
     async stream(context) {
-      const { agent, cleanup, session, resumesSession } = await createAgentAndSession(context)
+      const { agent, chatPrompt, cleanup, session, resumesSession } = await createAgentAndSession(context)
       try {
         const result = defineAgentUsageMetadata(await agent.stream({
-          ...await toHarnessCallInput(context, resumesSession),
+          ...await toHarnessCallInput(context, resumesSession, chatPrompt),
           session,
         }), usageMetadata)
         return await withSessionCleanup(result, cleanup, context.input.abortSignal)

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -444,7 +444,6 @@ async function materializeHarnessChatMessages(
   if (!hasAttachments) return { messages }
 
   let remainingBytes = harnessAttachmentMaxBytes
-  let remainingDeclaredBytes = harnessAttachmentMaxBytes
   const directory = joinHarnessSessionPath(
     prepared.sessionWorkDir,
     `${harnessAttachmentDirectory}/${globalThis.crypto.randomUUID()}`,
@@ -462,10 +461,6 @@ async function materializeHarnessChatMessages(
           parts.push(part)
           continue
         }
-        if (typeof part.size === "number" && part.size > remainingDeclaredBytes) {
-          throw new Error(`[vitehub] ${part.type} attachment exceeds the remaining Harness attachment limit (${remainingDeclaredBytes} bytes).`)
-        }
-        if (typeof part.size === "number") remainingDeclaredBytes -= part.size
         const data = await resolveHarnessAttachmentData(part)
         if (!data) {
           if (part.url) {

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -17,7 +17,7 @@ import {
   resolveColocatedAgentInstructionDocument,
   workspaceDefinitionWithAutoCommitRules,
 } from "./workspace-agent.ts"
-import { nextWithAbort } from "./internal/abortable-stream.ts"
+import { abortSignalError, nextWithAbort } from "./internal/abortable-stream.ts"
 import { agentOutputInstructions } from "./internal/agent-structured-output.ts"
 import {
   colocatedAgentSkillsContextKey,
@@ -426,9 +426,22 @@ function harnessAttachmentStringBytes(value: string, mediaType: string, remainin
     if (encoded.length > remainingBytes * 3) {
       assertHarnessAttachmentSize(Math.ceil(encoded.length / 3), remainingBytes, type)
     }
-    const decoded = decodeURIComponent(encoded)
-    assertHarnessAttachmentSize(Buffer.byteLength(decoded), remainingBytes, type)
-    return new TextEncoder().encode(decoded)
+    const bytes = new TextEncoder().encode(encoded)
+    let readIndex = 0
+    let writeIndex = 0
+    while (readIndex < bytes.length) {
+      if (bytes[readIndex] === 37) {
+        const encodedByte = String.fromCharCode(bytes[readIndex + 1]!, bytes[readIndex + 2]!)
+        if (!/^[\da-f]{2}$/i.test(encodedByte)) throw new URIError("URI malformed")
+        bytes[writeIndex++] = Number.parseInt(encodedByte, 16)
+        readIndex += 3
+      }
+      else {
+        bytes[writeIndex++] = bytes[readIndex++]!
+      }
+    }
+    assertHarnessAttachmentSize(writeIndex, remainingBytes, type)
+    return bytes.slice(0, writeIndex)
   }
   const normalizedMediaType = mediaType.toLowerCase()
   if (
@@ -460,9 +473,26 @@ async function harnessAttachmentBytes(data: AttachmentData, mediaType: string, r
   return harnessAttachmentStringBytes(data, mediaType, remainingBytes, type)
 }
 
-async function resolveHarnessAttachmentData(part: Extract<Message["parts"][number], { type: "audio" | "file" | "image" }>): Promise<AttachmentData | undefined> {
+async function resolveHarnessAttachmentData(
+  part: Extract<Message["parts"][number], { type: "audio" | "file" | "image" }>,
+  abortSignal?: AbortSignal,
+): Promise<AttachmentData | undefined> {
   if (typeof part.fetchData !== "function") return isAttachmentData(part.data) ? part.data : undefined
-  const fetched = await part.fetchData()
+  if (abortSignal?.aborted) {
+    throw abortSignalError(abortSignal, "[vitehub] Harness attachment resolution aborted.")
+  }
+  const fetchedPromise = Promise.resolve(part.fetchData())
+  const fetched = abortSignal
+    ? await new Promise<AttachmentData>((resolve, reject) => {
+        const onAbort = () => {
+          abortSignal.removeEventListener("abort", onAbort)
+          reject(abortSignalError(abortSignal, "[vitehub] Harness attachment resolution aborted."))
+        }
+        if (abortSignal.aborted) return onAbort()
+        abortSignal.addEventListener("abort", onAbort, { once: true })
+        fetchedPromise.then(resolve, reject).finally(() => abortSignal.removeEventListener("abort", onAbort))
+      })
+    : await fetchedPromise
   return isAttachmentData(fetched) ? fetched : undefined
 }
 
@@ -502,7 +532,7 @@ async function materializeHarnessChatMessages(
           parts.push(part)
           continue
         }
-        const data = await resolveHarnessAttachmentData(part)
+        const data = await resolveHarnessAttachmentData(part, prepared.abortSignal)
         if (!data) {
           if (part.url) {
             throw new Error(`[vitehub] Harness ${part.type} attachment requires data or fetchData(); URL-only attachments must be resolved by the Channel adapter.`)

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -75,7 +75,7 @@ type HarnessFileSandbox = {
 }
 
 type HarnessGlobalSkillsSandbox = {
-  run(options: { abortSignal?: AbortSignal, command: string, workingDirectory?: string }): PromiseLike<{ exitCode: number, stderr?: string, stdout?: string }>
+  run(options: { abortSignal?: AbortSignal, command: string, env?: Record<string, string>, workingDirectory?: string }): PromiseLike<{ exitCode: number, stderr?: string, stdout?: string }>
 }
 
 type HarnessAttachmentSandbox = HarnessInstructionSandbox & HarnessGlobalSkillsSandbox
@@ -91,6 +91,7 @@ const harnessResumeStates = new WeakMap<object, Map<string, unknown>>()
 const harnessGeneratedFiles = ["harness-tool.mjs"] as const
 const harnessInstructionFiles = ["AGENTS.md", "CLAUDE.md"] as const
 const harnessAttachmentDirectory = ".vitehub/attachments"
+const harnessAttachmentCleanupCommand = `node -e "const fs=require('node:fs');const path=require('node:path');const directory=process.env.VITEHUB_ATTACHMENT_DIRECTORY;fs.rmSync(directory,{force:true,recursive:true});for(const parent of [path.dirname(directory),path.dirname(path.dirname(directory))]){try{fs.rmdirSync(parent)}catch(error){if(error.code!=='ENOENT'&&error.code!=='ENOTEMPTY')throw error}}"`
 const harnessAttachmentMaxBytes = 25 * 1024 * 1024
 const harnessAgentPackage = "@ai-sdk/harness/agent"
 const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
@@ -386,13 +387,46 @@ function harnessAttachmentExtension(mediaType: string): string {
   }[mediaType.toLowerCase()] || "bin"
 }
 
-function harnessAttachmentStringBytes(value: string, mediaType: string): Uint8Array {
+function assertHarnessAttachmentSize(byteLength: number, remainingBytes: number, type: string): void {
+  if (byteLength > remainingBytes) {
+    throw new Error(`[vitehub] ${type} attachment is ${byteLength} bytes, which exceeds the remaining Harness attachment limit (${remainingBytes} bytes).`)
+  }
+}
+
+function harnessBase64ByteLength(value: string): number {
+  let encodedCharacters = 0
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index)
+    if (code === 61) break
+    if (
+      (code >= 48 && code <= 57)
+      || (code >= 65 && code <= 90)
+      || (code >= 97 && code <= 122)
+      || code === 43
+      || code === 45
+      || code === 47
+      || code === 95
+    ) {
+      encodedCharacters++
+    }
+  }
+  return Math.floor(encodedCharacters * 6 / 8)
+}
+
+function harnessAttachmentStringBytes(value: string, mediaType: string, remainingBytes: number, type: string): Uint8Array {
   const dataUrl = /^data:([^,]*?),(.*)$/s.exec(value)
   if (dataUrl) {
     const encoded = dataUrl[2]!
-    return dataUrl[1]!.split(";").includes("base64")
-      ? new Uint8Array(Buffer.from(encoded, "base64"))
-      : new TextEncoder().encode(decodeURIComponent(encoded))
+    if (dataUrl[1]!.split(";").includes("base64")) {
+      assertHarnessAttachmentSize(harnessBase64ByteLength(encoded), remainingBytes, type)
+      return new Uint8Array(Buffer.from(encoded, "base64"))
+    }
+    if (encoded.length > remainingBytes * 3) {
+      assertHarnessAttachmentSize(Math.ceil(encoded.length / 3), remainingBytes, type)
+    }
+    const decoded = decodeURIComponent(encoded)
+    assertHarnessAttachmentSize(Buffer.byteLength(decoded), remainingBytes, type)
+    return new TextEncoder().encode(decoded)
   }
   const normalizedMediaType = mediaType.toLowerCase()
   if (
@@ -401,16 +435,27 @@ function harnessAttachmentStringBytes(value: string, mediaType: string): Uint8Ar
     || normalizedMediaType.endsWith("+json")
     || normalizedMediaType.endsWith("+xml")
   ) {
+    assertHarnessAttachmentSize(Buffer.byteLength(value), remainingBytes, type)
     return new TextEncoder().encode(value)
   }
+  assertHarnessAttachmentSize(harnessBase64ByteLength(value), remainingBytes, type)
   return new Uint8Array(Buffer.from(value, "base64"))
 }
 
-async function harnessAttachmentBytes(data: AttachmentData, mediaType: string): Promise<Uint8Array> {
-  if (data instanceof Blob) return new Uint8Array(await data.arrayBuffer())
-  if (data instanceof ArrayBuffer) return new Uint8Array(data)
-  if (data instanceof Uint8Array) return data
-  return harnessAttachmentStringBytes(data, mediaType)
+async function harnessAttachmentBytes(data: AttachmentData, mediaType: string, remainingBytes: number, type: string): Promise<Uint8Array> {
+  if (data instanceof Blob) {
+    assertHarnessAttachmentSize(data.size, remainingBytes, type)
+    return new Uint8Array(await data.arrayBuffer())
+  }
+  if (data instanceof ArrayBuffer) {
+    assertHarnessAttachmentSize(data.byteLength, remainingBytes, type)
+    return new Uint8Array(data)
+  }
+  if (data instanceof Uint8Array) {
+    assertHarnessAttachmentSize(data.byteLength, remainingBytes, type)
+    return data
+  }
+  return harnessAttachmentStringBytes(data, mediaType, remainingBytes, type)
 }
 
 async function resolveHarnessAttachmentData(part: Extract<Message["parts"][number], { type: "audio" | "file" | "image" }>): Promise<AttachmentData | undefined> {
@@ -419,15 +464,10 @@ async function resolveHarnessAttachmentData(part: Extract<Message["parts"][numbe
   return isAttachmentData(fetched) ? fetched : undefined
 }
 
-function quoteHarnessShellValue(value: string): string {
-  return `'${value.replace(/'/g, "'\\''")}'`
-}
-
 async function removeHarnessAttachmentDirectory(session: HarnessAttachmentSandbox, directory: string): Promise<void> {
-  const attachmentsDirectory = posix.dirname(directory)
-  const vitehubDirectory = posix.dirname(attachmentsDirectory)
   const result = await session.run({
-    command: `rm -rf -- ${quoteHarnessShellValue(directory)} && { rmdir -- ${quoteHarnessShellValue(attachmentsDirectory)} ${quoteHarnessShellValue(vitehubDirectory)} 2>/dev/null || true; }`,
+    command: harnessAttachmentCleanupCommand,
+    env: { VITEHUB_ATTACHMENT_DIRECTORY: directory },
   })
   if (result.exitCode !== 0) {
     throw new Error(`[vitehub] Failed to clean up Harness attachments: ${result.stderr || "sandbox command failed"}`)
@@ -468,10 +508,8 @@ async function materializeHarnessChatMessages(
           }
           throw new TypeError(`[vitehub] Harness ${part.type} attachment fetchData() did not return supported attachment data.`)
         }
-        const bytes = await harnessAttachmentBytes(data, part.mediaType)
-        if (bytes.byteLength > remainingBytes) {
-          throw new Error(`[vitehub] ${part.type} attachment is ${bytes.byteLength} bytes, which exceeds the remaining Harness attachment limit (${remainingBytes} bytes).`)
-        }
+        const bytes = await harnessAttachmentBytes(data, part.mediaType, remainingBytes, part.type)
+        assertHarnessAttachmentSize(bytes.byteLength, remainingBytes, part.type)
         remainingBytes -= bytes.byteLength
         const path = `${directory}/message-${messageIndex + 1}-attachment-${partIndex + 1}.${harnessAttachmentExtension(part.mediaType)}`
         await prepared.session.writeBinaryFile({

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -78,7 +78,9 @@ type HarnessGlobalSkillsSandbox = {
   run(options: { abortSignal?: AbortSignal, command: string, env?: Record<string, string>, workingDirectory?: string }): PromiseLike<{ exitCode: number, stderr?: string, stdout?: string }>
 }
 
-type HarnessAttachmentSandbox = HarnessInstructionSandbox & HarnessGlobalSkillsSandbox
+type HarnessAttachmentSandbox = HarnessInstructionSandbox & HarnessGlobalSkillsSandbox & {
+  [harnessRemoveDirectory]?: (directory: string) => MaybePromise<void>
+}
 
 interface HarnessPreparedSandbox {
   abortSignal?: AbortSignal
@@ -91,9 +93,9 @@ const harnessResumeStates = new WeakMap<object, Map<string, unknown>>()
 const harnessGeneratedFiles = ["harness-tool.mjs"] as const
 const harnessInstructionFiles = ["AGENTS.md", "CLAUDE.md"] as const
 const harnessAttachmentDirectory = ".vitehub/attachments"
-const harnessAttachmentCleanupCommand = `node -e "const fs=require('node:fs');const path=require('node:path');const directory=process.env.VITEHUB_ATTACHMENT_DIRECTORY;fs.rmSync(directory,{force:true,recursive:true});for(const parent of [path.dirname(directory),path.dirname(path.dirname(directory))]){try{fs.rmdirSync(parent)}catch(error){if(error.code!=='ENOENT'&&error.code!=='ENOTEMPTY')throw error}}"`
 const harnessAttachmentMaxBytes = 25 * 1024 * 1024
 const harnessAgentPackage = "@ai-sdk/harness/agent"
+const harnessRemoveDirectory = Symbol.for("vitehub.harnessRemoveDirectory")
 const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
 const harnessGlobalSkillsDirectory = Symbol.for("vitehub.harnessGlobalSkillsDirectory")
 const harnessSessionPrepare = Symbol.for("vitehub.harnessSessionPrepare")
@@ -465,13 +467,9 @@ async function resolveHarnessAttachmentData(part: Extract<Message["parts"][numbe
 }
 
 async function removeHarnessAttachmentDirectory(session: HarnessAttachmentSandbox, directory: string): Promise<void> {
-  const result = await session.run({
-    command: harnessAttachmentCleanupCommand,
-    env: { VITEHUB_ATTACHMENT_DIRECTORY: directory },
-  })
-  if (result.exitCode !== 0) {
-    throw new Error(`[vitehub] Failed to clean up Harness attachments: ${result.stderr || "sandbox command failed"}`)
-  }
+  const removeDirectory = session[harnessRemoveDirectory]
+  if (!removeDirectory) throw new Error("[vitehub] Harness attachment materialization requires sandbox directory removal support.")
+  await removeDirectory.call(session, directory)
 }
 
 async function materializeHarnessChatMessages(
@@ -482,6 +480,9 @@ async function materializeHarnessChatMessages(
     message.role === "user" && message.parts.some(isAttachmentPart),
   )
   if (!hasAttachments) return { messages }
+  if (!prepared.session[harnessRemoveDirectory]) {
+    throw new Error("[vitehub] Harness attachment materialization requires sandbox directory removal support.")
+  }
 
   let remainingBytes = harnessAttachmentMaxBytes
   const directory = joinHarnessSessionPath(

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -417,7 +417,7 @@ function harnessAttachmentStringBytes(value: string, mediaType: string, remainin
   const dataUrl = /^data:([^,]*?),(.*)$/s.exec(value)
   if (dataUrl) {
     const encoded = dataUrl[2]!
-    if (dataUrl[1]!.split(";").includes("base64")) {
+    if (dataUrl[1]!.split(";").some(parameter => parameter.toLowerCase() === "base64")) {
       assertHarnessAttachmentSize(harnessBase64ByteLength(encoded), remainingBytes, type)
       return new Uint8Array(Buffer.from(encoded, "base64"))
     }

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -414,7 +414,7 @@ function harnessBase64ByteLength(value: string): number {
 }
 
 function harnessAttachmentStringBytes(value: string, mediaType: string, remainingBytes: number, type: string): Uint8Array {
-  const dataUrl = /^data:([^,]*?),(.*)$/s.exec(value)
+  const dataUrl = /^data:([^,]*?),(.*)$/is.exec(value)
   if (dataUrl) {
     const encoded = dataUrl[2]!
     if (dataUrl[1]!.split(";").some(parameter => parameter.toLowerCase() === "base64")) {

--- a/packages/agent/src/harness/box-sandbox.ts
+++ b/packages/agent/src/harness/box-sandbox.ts
@@ -5,6 +5,12 @@ import type { Box, BoxProcess, BoxSession } from "@vite-hub/box"
 import type { ExecutionAuthority } from "@vite-hub/runtime"
 import { openHarnessBox } from "./shared-box.ts"
 
+const harnessRemoveDirectory = Symbol.for("vitehub.harnessRemoveDirectory")
+
+type BoxHarnessSandboxSession = HarnessV1NetworkSandboxSession & {
+  [harnessRemoveDirectory](path: string): Promise<void>
+}
+
 function streamFromBytes(bytes: Uint8Array) {
   return new ReadableStream<Uint8Array>({
     start(controller) {
@@ -50,9 +56,17 @@ function adaptProcess(process: BoxProcess) {
   }
 }
 
-function adaptBoxSession(session: BoxSession): HarnessV1NetworkSandboxSession {
+function adaptBoxSession(session: BoxSession): BoxHarnessSandboxSession {
   if (!session.spawn) throw new Error("[vitehub] Harness Agent Drivers require a Box runtime with process spawning.")
   const adapted = {
+    async [harnessRemoveDirectory](path: string) {
+      const directory = resolvePath(session, path)
+      await session.files.remove(directory, { recursive: true })
+      for (const parent of [posix.dirname(directory), posix.dirname(posix.dirname(directory))]) {
+        if (await session.files.list(parent).then(entries => entries.length > 0).catch(() => true)) break
+        await session.files.remove(parent)
+      }
+    },
     defaultWorkingDirectory: session.cwd,
     description: `ViteHub Box ${session.id}`,
     id: session.id,
@@ -110,7 +124,7 @@ function adaptBoxSession(session: BoxSession): HarnessV1NetworkSandboxSession {
     async writeTextFile({ content, encoding = "utf8", path }: { content: string, encoding?: string, path: string }) {
       await this.writeBinaryFile({ content: Buffer.from(content, encoding as BufferEncoding), path })
     },
-  } satisfies HarnessV1NetworkSandboxSession
+  } satisfies BoxHarnessSandboxSession
   return adapted
 }
 

--- a/packages/agent/src/harness/local-sandbox.ts
+++ b/packages/agent/src/harness/local-sandbox.ts
@@ -1,6 +1,6 @@
 import { spawn as spawnChildProcess, type ChildProcessWithoutNullStreams } from "node:child_process"
 import { once } from "node:events"
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, readdir, rm, rmdir, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, isAbsolute, join, relative, resolve } from "node:path"
 import { Readable } from "node:stream"
@@ -21,11 +21,14 @@ export interface LocalHarnessSandboxOptions {
 }
 
 interface LocalHarnessSandboxSession extends HarnessV1NetworkSandboxSession {
+  [harnessRemoveDirectory](path: string): Promise<void>
   readonly cleanup: boolean
   readonly env: Record<string, string>
   readonly processes: Set<LocalProcessOwner>
   readonly rootDir: string
 }
+
+const harnessRemoveDirectory = Symbol.for("vitehub.harnessRemoveDirectory")
 
 let localHarnessOwnerName: string | undefined
 const localHarnessOwnerPattern = /^owner-(\d+)-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
@@ -266,6 +269,15 @@ async function createSession(options: LocalHarnessSandboxOptions, sessionId: str
   await mkdir(rootDir, { recursive: true })
   const env = { ...stringEnv(options.env || process.env), INIT_CWD: rootDir, OLDPWD: rootDir, PWD: rootDir }
   const session = {
+    async [harnessRemoveDirectory](path: string) {
+      const directory = resolvePath(this, path)
+      await rm(directory, { force: true, recursive: true })
+      for (const parent of [dirname(directory), dirname(dirname(directory))]) {
+        await rmdir(parent).catch((error: NodeJS.ErrnoException) => {
+          if (error.code !== "ENOENT" && error.code !== "ENOTEMPTY") throw error
+        })
+      }
+    },
     cleanup,
     defaultWorkingDirectory: rootDir,
     description: "Workspace shell.",

--- a/packages/agent/test/harness-chat-history.test.ts
+++ b/packages/agent/test/harness-chat-history.test.ts
@@ -148,6 +148,7 @@ describe("Harness chat history", () => {
             { text: "Compare it with these.", type: "text" },
             { data: new Uint8Array([99]), fetchData: () => new Uint8Array([2]), mediaType: "image/jpeg", type: "image" },
             { data: new Uint8Array([3]), mediaType: "image/webp", type: "image" },
+            { data: "data:image/png;BASE64,BQ==", mediaType: "image/png", type: "image" },
             { data: new Uint8Array([4]), mediaType: "application/pdf", name: "report.pdf", type: "file" },
           ],
           role: "user" as const,
@@ -166,11 +167,13 @@ describe("Harness chat history", () => {
       [1],
       [2],
       [3],
+      [5],
     ])
     expect(turns[1]?.isResume).toBe(true)
     expect(turns[1]?.imageBytes).toEqual([
       [2],
       [3],
+      [5],
     ])
 
     const freshPrompt = turns[0]?.prompt
@@ -180,10 +183,11 @@ describe("Harness chat history", () => {
       expect.stringMatching(/\.vitehub\/attachments\/[^/]+\/message-1-attachment-2\.png$/),
       expect.stringMatching(/\.vitehub\/attachments\/[^/]+\/message-3-attachment-2\.jpg$/),
       expect.stringMatching(/\.vitehub\/attachments\/[^/]+\/message-3-attachment-3\.webp$/),
+      expect.stringMatching(/\.vitehub\/attachments\/[^/]+\/message-3-attachment-4\.png$/),
     ])
     expect(JSON.stringify(freshContent)).not.toContain("escape")
     expect(freshContent.filter(part => part.type === "text").map(part => part.text).join("")).toContain("I remember it.")
-    expect(freshContent.filter(part => part.type === "text").map(part => part.text).join("")).toMatch(/report\.pdf.*\.vitehub\/attachments\/[^/]+\/message-3-attachment-4\.pdf/)
+    expect(freshContent.filter(part => part.type === "text").map(part => part.text).join("")).toMatch(/report\.pdf.*\.vitehub\/attachments\/[^/]+\/message-3-attachment-5\.pdf/)
 
     const resumedPrompt = turns[1]?.prompt
     expect(resumedPrompt).toMatchObject({ role: "user" })

--- a/packages/agent/test/harness-chat-history.test.ts
+++ b/packages/agent/test/harness-chat-history.test.ts
@@ -1,0 +1,271 @@
+import { mkdtemp, readdir, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { afterEach, describe, expect, it } from "vitest"
+
+import { createMessage, defineAgent, runAgent } from "../src/index.ts"
+import { createLocalHarnessSandbox } from "../src/harness/local-sandbox.ts"
+
+import type {
+  HarnessV1,
+  HarnessV1Prompt,
+  HarnessV1PromptTurnOptions,
+  HarnessV1StartOptions,
+} from "@ai-sdk/harness"
+
+interface CapturedTurn {
+  imageBytes: number[][]
+  isResume: boolean
+  prompt: HarnessV1Prompt
+}
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(root => rm(root, { force: true, recursive: true })))
+})
+
+function lifecycleState<T extends "continue-turn" | "resume-session">(type: T) {
+  return {
+    data: {},
+    harnessId: "history-test",
+    specificationVersion: "harness-v1" as const,
+    type,
+  }
+}
+
+function createHistoryHarness(turns: CapturedTurn[]): HarnessV1 {
+  return {
+    builtinTools: {},
+    harnessId: "history-test",
+    specificationVersion: "harness-v1",
+    async doStart(options: HarnessV1StartOptions) {
+      return {
+        isResume: options.resumeFrom !== undefined,
+        sessionId: options.sessionId,
+        async doCompact() {},
+        async doContinueTurn() {
+          throw new Error("Unexpected continuation")
+        },
+        async doDestroy() {},
+        async doDetach() {
+          return lifecycleState("resume-session")
+        },
+        async doPromptTurn(turn: HarnessV1PromptTurnOptions) {
+          const imageParts = typeof turn.prompt === "object" && Array.isArray(turn.prompt.content)
+            ? turn.prompt.content.filter(part => part.type === "image")
+            : []
+          const imageBytes = await Promise.all(imageParts.map(async (part) => {
+            expect(typeof part.image).toBe("string")
+            const bytes = await options.sandboxSession.readBinaryFile({ path: part.image as string })
+            expect(bytes).not.toBeNull()
+            return Array.from(bytes!)
+          }))
+          turns.push({
+            imageBytes,
+            isResume: options.resumeFrom !== undefined,
+            prompt: turn.prompt,
+          })
+          const usage = {
+            inputTokens: { cacheRead: 0, cacheWrite: 0, noCache: 0, total: 0 },
+            outputTokens: { reasoning: 0, text: 0, total: 0 },
+          }
+          const finishReason = { raw: "stop", unified: "stop" as const }
+          turn.emit({ type: "stream-start" })
+          turn.emit({
+            finishReason,
+            type: "finish-step",
+            usage,
+          })
+          turn.emit({
+            finishReason,
+            totalUsage: usage,
+            type: "finish",
+          })
+          return {
+            done: Promise.resolve(),
+            async submitToolResult() {},
+          }
+        },
+        async doStop() {
+          return lifecycleState("resume-session")
+        },
+        async doSuspendTurn() {
+          return lifecycleState("continue-turn")
+        },
+      }
+    },
+  }
+}
+
+async function createRoot() {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-harness-chat-history-"))
+  roots.push(root)
+  return root
+}
+
+const runtime = {
+  memo<T>(_key: string, create: () => T) {
+    return create()
+  },
+  runtime: "unknown" as const,
+  waitUntil() {},
+}
+
+async function attachmentPaths(root: string) {
+  return (await readdir(root, { recursive: true })).filter(path =>
+    path.includes(".vitehub/attachments"),
+  )
+}
+
+describe("Harness chat history", () => {
+  it("projects ordered multimodal history for fresh sessions and only the latest turn when resumed", async () => {
+    const root = await createRoot()
+    const turns: CapturedTurn[] = []
+    const agent = defineAgent({
+      driver: {
+        harness: createHistoryHarness(turns),
+        sandbox: createLocalHarnessSandbox({ rootDir: root }),
+        sessionKey: "thread-1",
+      },
+    })
+    const input = {
+      context: { chat: {} },
+      messages: [
+        createMessage({
+          id: "historical-user",
+          parts: [
+            { text: "Remember the first image.", type: "text" },
+            { data: new Uint8Array([1]), mediaType: "image/png", name: "../../escape.png", type: "image" },
+          ],
+          role: "user" as const,
+        }),
+        createMessage({ id: "assistant", role: "assistant" as const, text: "I remember it." }),
+        createMessage({
+          id: "latest-user",
+          parts: [
+            { text: "Compare it with these.", type: "text" },
+            { data: new Uint8Array([99]), fetchData: () => new Uint8Array([2]), mediaType: "image/jpeg", type: "image" },
+            { data: new Uint8Array([3]), mediaType: "image/webp", type: "image" },
+            { data: new Uint8Array([4]), mediaType: "application/pdf", name: "report.pdf", type: "file" },
+          ],
+          role: "user" as const,
+        }),
+      ],
+    }
+
+    await runAgent(agent, runtime, input)
+    expect(await attachmentPaths(root)).toEqual([])
+    await runAgent(agent, runtime, input)
+    expect(await attachmentPaths(root)).toEqual([])
+
+    expect(turns).toHaveLength(2)
+    expect(turns[0]?.isResume).toBe(false)
+    expect(turns[0]?.imageBytes).toEqual([
+      [1],
+      [2],
+      [3],
+    ])
+    expect(turns[1]?.isResume).toBe(true)
+    expect(turns[1]?.imageBytes).toEqual([
+      [2],
+      [3],
+    ])
+
+    const freshPrompt = turns[0]?.prompt
+    expect(freshPrompt).toMatchObject({ role: "user" })
+    const freshContent = typeof freshPrompt === "object" && Array.isArray(freshPrompt.content) ? freshPrompt.content : []
+    expect(freshContent.filter(part => part.type === "image").map(part => part.image)).toEqual([
+      expect.stringMatching(/\.vitehub\/attachments\/[^/]+\/message-1-attachment-2\.png$/),
+      expect.stringMatching(/\.vitehub\/attachments\/[^/]+\/message-3-attachment-2\.jpg$/),
+      expect.stringMatching(/\.vitehub\/attachments\/[^/]+\/message-3-attachment-3\.webp$/),
+    ])
+    expect(JSON.stringify(freshContent)).not.toContain("escape")
+    expect(freshContent.filter(part => part.type === "text").map(part => part.text).join("")).toContain("I remember it.")
+    expect(freshContent.filter(part => part.type === "text").map(part => part.text).join("")).toMatch(/report\.pdf.*\.vitehub\/attachments\/[^/]+\/message-3-attachment-4\.pdf/)
+
+    const resumedPrompt = turns[1]?.prompt
+    expect(resumedPrompt).toMatchObject({ role: "user" })
+    const resumedText = typeof resumedPrompt === "object" && Array.isArray(resumedPrompt.content)
+      ? resumedPrompt.content.filter(part => part.type === "text").map(part => part.text).join("")
+      : ""
+    expect(resumedText).toContain("Compare it with these.")
+    expect(resumedText).not.toContain("Remember the first image.")
+    expect(resumedText).not.toContain("I remember it.")
+  })
+
+  it("enforces one aggregate attachment budget and removes partial materialization", async () => {
+    const root = await createRoot()
+    const turns: CapturedTurn[] = []
+    const agent = defineAgent({
+      driver: {
+        harness: createHistoryHarness(turns),
+        sandbox: createLocalHarnessSandbox({ rootDir: root }),
+      },
+    })
+    const thirteenMiB = new Uint8Array(13 * 1024 * 1024)
+
+    await expect(runAgent(agent, runtime, {
+      context: { chat: {} },
+      messages: [createMessage({
+        parts: [
+          { fetchData: () => thirteenMiB, mediaType: "application/pdf", type: "file" },
+          { fetchData: () => thirteenMiB, mediaType: "application/pdf", type: "file" },
+        ],
+        role: "user",
+      })],
+    })).rejects.toThrow("exceeds the remaining Harness attachment limit")
+
+    expect(turns).toEqual([])
+    expect(await attachmentPaths(root)).toEqual([])
+  })
+
+  it("rejects invalid Channel adapter data instead of using fallback attachment data", async () => {
+    const root = await createRoot()
+    const turns: CapturedTurn[] = []
+    const agent = defineAgent({
+      driver: {
+        harness: createHistoryHarness(turns),
+        sandbox: createLocalHarnessSandbox({ rootDir: root }),
+      },
+    })
+
+    await expect(runAgent(agent, runtime, {
+      context: { chat: {} },
+      messages: [createMessage({
+        parts: [{
+          data: new Uint8Array([1]),
+          fetchData: () => undefined as never,
+          mediaType: "image/png",
+          type: "image",
+        }],
+        role: "user",
+      })],
+    })).rejects.toThrow("fetchData() did not return supported attachment data")
+
+    expect(turns).toEqual([])
+    expect(await attachmentPaths(root)).toEqual([])
+  })
+
+  it("rejects URL-only attachments before invoking the Harness turn", async () => {
+    const root = await createRoot()
+    const turns: CapturedTurn[] = []
+    const agent = defineAgent({
+      driver: {
+        harness: createHistoryHarness(turns),
+        sandbox: createLocalHarnessSandbox({ rootDir: root }),
+      },
+    })
+
+    await expect(runAgent(agent, runtime, {
+      context: { chat: {} },
+      messages: [createMessage({
+        parts: [{ mediaType: "image/png", type: "image", url: "https://cdn.example.com/photo.png" }],
+        role: "user",
+      })],
+    })).rejects.toThrow("URL-only attachments must be resolved by the Channel adapter")
+
+    expect(turns).toEqual([])
+    expect(await attachmentPaths(root)).toEqual([])
+  })
+})

--- a/packages/agent/test/harness-chat-history.test.ts
+++ b/packages/agent/test/harness-chat-history.test.ts
@@ -333,4 +333,34 @@ describe("Harness chat history", () => {
     expect(turns).toEqual([])
     expect(await attachmentPaths(root)).toEqual([])
   })
+
+  it("rejects attachments before invocation when a custom sandbox cannot remove directories", async () => {
+    const root = await createRoot()
+    const turns: CapturedTurn[] = []
+    const sandbox = createLocalHarnessSandbox({ rootDir: root })
+    const agent = defineAgent({
+      driver: {
+        harness: createHistoryHarness(turns),
+        sandbox: {
+          ...sandbox,
+          async createSession(options: Parameters<typeof sandbox.createSession>[0]) {
+            const session = await sandbox.createSession(options)
+            delete (session as unknown as Record<symbol, unknown>)[Symbol.for("vitehub.harnessRemoveDirectory")]
+            return session
+          },
+        },
+      },
+    })
+
+    await expect(runAgent(agent, runtime, {
+      context: { chat: {} },
+      messages: [createMessage({
+        parts: [{ data: new Uint8Array([1]), mediaType: "image/png", type: "image" }],
+        role: "user",
+      })],
+    })).rejects.toThrow("requires sandbox directory removal support")
+
+    expect(turns).toEqual([])
+    expect(await attachmentPaths(root)).toEqual([])
+  })
 })

--- a/packages/agent/test/harness-chat-history.test.ts
+++ b/packages/agent/test/harness-chat-history.test.ts
@@ -285,6 +285,66 @@ describe("Harness chat history", () => {
     expect(await attachmentPaths(root)).toEqual([])
   })
 
+  it("percent-decodes arbitrary data URL bytes", async () => {
+    const root = await createRoot()
+    const turns: CapturedTurn[] = []
+    const agent = defineAgent({
+      driver: {
+        harness: createHistoryHarness(turns),
+        sandbox: createLocalHarnessSandbox({ rootDir: root }),
+      },
+    })
+
+    await runAgent(agent, runtime, {
+      context: { chat: {} },
+      messages: [createMessage({
+        parts: [{ data: "data:application/octet-stream,%FF%00A", mediaType: "image/png", type: "image" }],
+        role: "user",
+      })],
+    })
+
+    expect(turns[0]?.imageBytes).toEqual([[255, 0, 65]])
+    expect(await attachmentPaths(root)).toEqual([])
+  })
+
+  it("aborts stalled Channel attachment resolution before Harness invocation", async () => {
+    const root = await createRoot()
+    const turns: CapturedTurn[] = []
+    const controller = new AbortController()
+    let markFetchStarted!: () => void
+    const fetchStarted = new Promise<void>((resolve) => {
+      markFetchStarted = resolve
+    })
+    const agent = defineAgent({
+      driver: {
+        harness: createHistoryHarness(turns),
+        sandbox: createLocalHarnessSandbox({ rootDir: root }),
+      },
+    })
+
+    const invocation = runAgent(agent, runtime, {
+      abortSignal: controller.signal,
+      context: { chat: {} },
+      messages: [createMessage({
+        parts: [{
+          fetchData: () => {
+            markFetchStarted()
+            return new Promise<Uint8Array>(() => {})
+          },
+          mediaType: "image/png",
+          type: "image",
+        }],
+        role: "user",
+      })],
+    })
+    await fetchStarted
+    controller.abort(new Error("request closed"))
+
+    await expect(invocation).rejects.toThrow("request closed")
+    expect(turns).toEqual([])
+    expect(await attachmentPaths(root)).toEqual([])
+  })
+
   it("rejects invalid Channel adapter data instead of using fallback attachment data", async () => {
     const root = await createRoot()
     const turns: CapturedTurn[] = []

--- a/packages/agent/test/harness-chat-history.test.ts
+++ b/packages/agent/test/harness-chat-history.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, readdir, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { createMessage, defineAgent, runAgent } from "../src/index.ts"
 import { createLocalHarnessSandbox } from "../src/harness/local-sandbox.ts"
@@ -22,6 +22,7 @@ interface CapturedTurn {
 const roots: string[] = []
 
 afterEach(async () => {
+  vi.restoreAllMocks()
   await Promise.all(roots.splice(0).map(root => rm(root, { force: true, recursive: true })))
 })
 
@@ -204,6 +205,9 @@ describe("Harness chat history", () => {
       },
     })
     const thirteenMiB = new Uint8Array(13 * 1024 * 1024)
+    const oversizedBlob = new Blob([])
+    Object.defineProperty(oversizedBlob, "size", { value: 26 * 1024 * 1024 })
+    const arrayBuffer = vi.spyOn(Blob.prototype, "arrayBuffer")
 
     await expect(runAgent(agent, runtime, {
       context: { chat: {} },
@@ -216,6 +220,18 @@ describe("Harness chat history", () => {
       })],
     })).rejects.toThrow("exceeds the remaining Harness attachment limit")
 
+    expect(turns).toEqual([])
+    expect(await attachmentPaths(root)).toEqual([])
+
+    await expect(runAgent(agent, runtime, {
+      context: { chat: {} },
+      messages: [createMessage({
+        parts: [{ data: oversizedBlob, mediaType: "image/png", type: "image" }],
+        role: "user",
+      })],
+    })).rejects.toThrow("exceeds the remaining Harness attachment limit")
+
+    expect(arrayBuffer).not.toHaveBeenCalled()
     expect(turns).toEqual([])
     expect(await attachmentPaths(root)).toEqual([])
   })
@@ -245,6 +261,23 @@ describe("Harness chat history", () => {
 
     expect(turns).toHaveLength(1)
     expect(turns[0]?.imageBytes).toEqual([[1]])
+    expect(await attachmentPaths(root)).toEqual([])
+
+    const encoded = Buffer.alloc(25 * 1024 * 1024).toString("base64")
+    const wrappedBase64 = `${encoded.slice(0, 76)}\n${encoded.slice(76)}`
+    await runAgent(agent, runtime, {
+      context: { chat: {} },
+      messages: [createMessage({
+        parts: [{
+          fetchData: () => wrappedBase64,
+          mediaType: "application/pdf",
+          type: "file",
+        }],
+        role: "user",
+      })],
+    })
+
+    expect(turns).toHaveLength(2)
     expect(await attachmentPaths(root)).toEqual([])
   })
 

--- a/packages/agent/test/harness-chat-history.test.ts
+++ b/packages/agent/test/harness-chat-history.test.ts
@@ -148,7 +148,7 @@ describe("Harness chat history", () => {
             { text: "Compare it with these.", type: "text" },
             { data: new Uint8Array([99]), fetchData: () => new Uint8Array([2]), mediaType: "image/jpeg", type: "image" },
             { data: new Uint8Array([3]), mediaType: "image/webp", type: "image" },
-            { data: "data:image/png;BASE64,BQ==", mediaType: "image/png", type: "image" },
+            { data: "DATA:image/png;BASE64,BQ==", mediaType: "image/png", type: "image" },
             { data: new Uint8Array([4]), mediaType: "application/pdf", name: "report.pdf", type: "file" },
           ],
           role: "user" as const,

--- a/packages/agent/test/harness-chat-history.test.ts
+++ b/packages/agent/test/harness-chat-history.test.ts
@@ -220,6 +220,34 @@ describe("Harness chat history", () => {
     expect(await attachmentPaths(root)).toEqual([])
   })
 
+  it("enforces the attachment budget from fetched bytes instead of declared metadata", async () => {
+    const root = await createRoot()
+    const turns: CapturedTurn[] = []
+    const agent = defineAgent({
+      driver: {
+        harness: createHistoryHarness(turns),
+        sandbox: createLocalHarnessSandbox({ rootDir: root }),
+      },
+    })
+
+    await runAgent(agent, runtime, {
+      context: { chat: {} },
+      messages: [createMessage({
+        parts: [{
+          fetchData: () => new Uint8Array([1]),
+          mediaType: "image/png",
+          size: 26 * 1024 * 1024,
+          type: "image",
+        }],
+        role: "user",
+      })],
+    })
+
+    expect(turns).toHaveLength(1)
+    expect(turns[0]?.imageBytes).toEqual([[1]])
+    expect(await attachmentPaths(root)).toEqual([])
+  })
+
   it("rejects invalid Channel adapter data instead of using fallback attachment data", async () => {
     const root = await createRoot()
     const turns: CapturedTurn[] = []

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -935,15 +935,21 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
       { type: "finish" },
       { type: "done" },
     ])
-    expect(harnessStreamInputs[0]?.messages).toBeUndefined()
-    expect(harnessStreamInputs[0]?.prompt).toBe([
-      "Conversation history:",
-      "User: Remember the marker kiwi-714.",
-      "Assistant: stored kiwi-714",
-      "User: What marker did I ask you to remember?",
-      "",
-      "Respond to the latest user message.",
-    ].join("\n"))
+    expect(harnessStreamInputs[0]?.prompt).toBeUndefined()
+    expect(harnessStreamInputs[0]?.messages).toEqual([{
+      content: [
+        { text: "<message role=\"user\">\n", type: "text" },
+        { text: "Remember the marker kiwi-714.", type: "text" },
+        { text: "\n</message>\n", type: "text" },
+        { text: "<message role=\"assistant\">\n", type: "text" },
+        { text: "stored kiwi-714", type: "text" },
+        { text: "\n</message>\n", type: "text" },
+        { text: "<message role=\"user\">\n", type: "text" },
+        { text: "What marker did I ask you to remember?", type: "text" },
+        { text: "\n</message>\n", type: "text" },
+      ],
+      role: "user",
+    }])
   })
 
   it("closes harness workspace sessions when streams finish normally", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -53,6 +53,17 @@ afterEach(() => {
   loadAiSdk.mockImplementation(async () => await import("ai"))
 })
 
+function projectedHarnessMessages(entries: Array<["assistant" | "system" | "tool" | "user", string]>) {
+  return [{
+    content: entries.flatMap(([role, text]) => [
+      { text: `<message role="${role}">\n`, type: "text" },
+      { text, type: "text" },
+      { text: "\n</message>\n", type: "text" },
+    ]),
+    role: "user",
+  }]
+}
+
 async function failedTitleInvocation(options: {
   deliver?: (title: string) => Promise<void> | void
   execute: () => string
@@ -1804,8 +1815,6 @@ describe("agent message protocol", () => {
         }),
         createMessage({ id: "user-2", parts: [{ data: { scope: "kiwi-714" }, type: "data" }], role: "user" }),
         createMessage({ id: "user-3", parts: [{ error: "prior lookup warning", type: "error" }], role: "user" }),
-        createMessage({ id: "user-provider-only", parts: [{ fetchData: () => new Uint8Array([1]), mediaType: "application/pdf", type: "file" }], role: "user" }),
-        createMessage({ id: "user-url", parts: [{ fetchData: () => new Uint8Array([1]), mediaType: "application/pdf", type: "file", url: "https://cdn.example.com/report.pdf" }], role: "user" }),
         createMessage({ id: "user-4", role: "user", text: "What marker?" }),
       ],
     })).resolves.toMatchObject({ text: "ok" })
@@ -1814,19 +1823,15 @@ describe("agent message protocol", () => {
       sandbox: provider,
     })
     expect(harnessGenerate).toHaveBeenCalledWith(expect.objectContaining({
-      prompt: [
-        "Conversation history:",
-        "User: Remember kiwi-714.",
-        "Assistant: [{\"input\":{\"marker\":\"kiwi-714\"},\"toolCallId\":\"lookup-1\",\"toolName\":\"lookup\",\"type\":\"tool-call\"}]",
-        "tool: [{\"output\":{\"type\":\"json\",\"value\":{\"marker\":\"kiwi-714\"}},\"toolCallId\":\"lookup-1\",\"toolName\":\"lookup\",\"type\":\"tool-result\"}]",
-        "Assistant: Tool confirmed marker.",
-        "User: {\"scope\":\"kiwi-714\"}",
-        "User: prior lookup warning",
-        "User: [{\"data\":\"https://cdn.example.com/report.pdf\",\"mediaType\":\"application/pdf\",\"type\":\"file\"}]",
-        "User: What marker?",
-        "",
-        "Respond to the latest user message.",
-      ].join("\n"),
+      messages: projectedHarnessMessages([
+        ["user", "Remember kiwi-714."],
+        ["assistant", "{\"input\":{\"marker\":\"kiwi-714\"},\"toolCallId\":\"lookup-1\",\"toolName\":\"lookup\",\"type\":\"tool-call\"}"],
+        ["tool", "{\"output\":{\"type\":\"json\",\"value\":{\"marker\":\"kiwi-714\"}},\"toolCallId\":\"lookup-1\",\"toolName\":\"lookup\",\"type\":\"tool-result\"}"],
+        ["assistant", "Tool confirmed marker."],
+        ["user", "{\"scope\":\"kiwi-714\"}"],
+        ["user", "prior lookup warning"],
+        ["user", "What marker?"],
+      ]),
       session,
     }))
   })
@@ -2082,28 +2087,6 @@ describe("agent message protocol", () => {
       prompt: "Review this: checkout",
       session,
     }))
-    expect(session.destroy).toHaveBeenCalledOnce()
-  })
-
-  it("keeps remote attachment URLs visible to chat harnesses", async () => {
-    const { defineAgent, runAgent } = await import("../src/index.ts")
-    const session = { destroy: vi.fn() }
-    harnessCreateSession.mockResolvedValueOnce(session)
-    harnessGenerate.mockResolvedValueOnce({ text: "ok" })
-    const agent = defineAgent({
-      driver: { harness: { provider: "codex" } },
-    })
-
-    await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
-      context: { chat: {} },
-      messages: [createMessage({
-        parts: [{ mediaType: "image/png", name: "photo.png", type: "image", url: "https://cdn.example.com/photo.png" }],
-        role: "user",
-      })],
-    })
-
-    const prompt = (harnessGenerate.mock.calls[0]?.[0] as { prompt?: string }).prompt
-    expect(prompt).toContain("https://cdn.example.com/photo.png")
     expect(session.destroy).toHaveBeenCalledOnce()
   })
 
@@ -2483,23 +2466,15 @@ describe("agent message protocol", () => {
     expect(harnessCreateSession).toHaveBeenNthCalledWith(1, { sessionId: "thread-1" })
     expect(harnessCreateSession).toHaveBeenNthCalledWith(2, { resumeFrom: { token: "resume" }, sessionId: "thread-1" })
     expect(harnessGenerate).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      prompt: [
-        "Conversation history:",
-        "User: hello",
-        "Assistant: ok",
-        "User: again",
-        "",
-        "Respond to the latest user message.",
-      ].join("\n"),
+      messages: projectedHarnessMessages([
+        ["user", "hello"],
+        ["assistant", "ok"],
+        ["user", "again"],
+      ]),
       session: firstSession,
     }))
     expect(harnessGenerate).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      prompt: [
-        "Conversation history:",
-        "User: again",
-        "",
-        "Respond to the latest user message.",
-      ].join("\n"),
+      messages: [{ content: "again", role: "user" }],
       session: secondSession,
     }))
     expect(firstSession.detach).toHaveBeenCalledTimes(1)
@@ -2586,12 +2561,7 @@ describe("agent message protocol", () => {
     expect(harnessCreateSession).toHaveBeenNthCalledWith(1, { sessionId: "thread-1" })
     expect(harnessCreateSession).toHaveBeenNthCalledWith(2, { sessionId: "thread-1" })
     expect(harnessGenerate).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      prompt: [
-        "Conversation history:",
-        "User: again",
-        "",
-        "Respond to the latest user message.",
-      ].join("\n"),
+      messages: [{ content: "again", role: "user" }],
       session: secondSession,
     }))
     expect(firstSession.detach).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Fresh Harness-backed Agent Invocations now project the selected ordered chat history into a new session, including multimodal attachments and serialized tool-call/result context. Resumed Harness sessions still receive only the newest user turn, so ViteHub preserves the expected session boundary without changing core `@ai-sdk/harness` behavior.

Attachment materialization stays inside `@vite-hub/agent`: Channel adapter `fetchData()` is authoritative and abort-aware, actual decoded bytes enforce one 25 MiB budget, data URLs preserve arbitrary percent-encoded bytes, generated sandbox paths prevent traversal, and a private built-in sandbox capability physically removes each per-run directory plus empty reserved parents. Custom sandboxes without that cleanup capability reject attachments before writing or invocation. The change adds no Workspace exception and remains confined to six `packages/agent` files.

Validated under Node 24.15.0 with 346 focused Agent tests, Agent typecheck, the dependency build with publint clean, the repository’s exact CI `vp run lint` command, and `git diff --check`. Independent standards and spec reviews found no unresolved behavioral or scope findings.