### PR TITLE
feat(agent): auto-enable eval tooling from eval files

### DIFF
--- a/docs/content/docs/agents/evals.md
+++ b/docs/content/docs/agents/evals.md
@@ -145,7 +145,9 @@ The Agent Vite integration writes the Evalite configuration during local setup. 
 pnpm vitehub agent eval server/agents/support.eval.ts
 ```
 
-Configure the runner through `hubAgent({ eval })`. Set `eval: false` to disable Agent Evals and their CLI contribution.
+Executable `*.eval.ts`, `*.eval.mts`, `*.eval.tsx`, `eval.ts`, `eval.mts`, and `eval.tsx` files automatically enable the Agent Eval CLI and generated Evalite configuration. A fixture-only `evals/` directory remains inert.
+
+Configure the discovered runner through `hubAgent({ eval })`.
 
 ```ts [vite.config.ts]
 import { hubAgent } from '@vite-hub/agent/vite'

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path"
 import { readWorkspaceDevToken, workspaceDevTokenHeader } from "@vite-hub/workspace/server"
 
 import { formatAgentError } from "./agent-error.ts"
+import { discoverAgentEvalFiles } from "./discovery.ts"
 import { runAgentInfoCli } from "./internal/agent-info-cli.ts"
 import { vercelAiGatewayPricing, type AgentUsagePricing } from "./internal/usage-pricing.ts"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig, type ResolvedAgentEvalOptions } from "./internal/evalite-config.ts"
@@ -49,7 +50,8 @@ interface AgentCliContributor {
 }
 
 interface AgentCliContributorOptions {
-  eval?: false | AgentEvalOptions
+  eval?: AgentEvalOptions
+  rootDir?: string
 }
 
 interface ParsedEvalArgs {
@@ -571,15 +573,11 @@ async function loadEvaliteRunner(): Promise<EvaliteRunner> {
 export async function runAgentEvalCli(
   args: string[],
   context: AgentCliContext,
-  options: false | AgentEvalOptions | undefined,
+  options: AgentEvalOptions | undefined,
   runner?: EvaliteRunner,
   writeConfig: AgentEvaliteConfigWriter = writeAgentEvaliteConfig,
 ): Promise<number> {
   const resolvedOptions = resolveAgentEvalOptions(options)
-  if (resolvedOptions === false) {
-    context.stderr.write("Agent eval CLI is disabled by the Agent integration.\n")
-    return 1
-  }
 
   let parsed: ParsedEvalArgs
   try {
@@ -1279,6 +1277,7 @@ export async function runAgentDevCli(
 export function createAgentCliContributor(options?: false | AgentCliContributorOptions): AgentCliContributor | undefined {
   if (options === false) return
   const evalOptions = resolveAgentEvalOptions(options?.eval)
+  const hasEvalFiles = discoverAgentEvalFiles(options?.rootDir ?? process.cwd()).length > 0
   const features: AgentCliContributor["namespaces"][number]["features"] = [
     {
       description: "Inspect a discovered Agent through a running Vite Development Server.",
@@ -1293,7 +1292,7 @@ export function createAgentCliContributor(options?: false | AgentCliContributorO
       usage: "vitehub agent dev [message...] [--agent <name>]",
     },
   ]
-  if (evalOptions !== false) {
+  if (hasEvalFiles) {
     features.unshift({
       description: "Run ViteHub Agent Evals.",
       name: "eval",

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -52,6 +52,7 @@ interface AgentCliContributor {
 interface AgentCliContributorOptions {
   eval?: AgentEvalOptions
   rootDir?: string
+  serverDirs?: string[]
 }
 
 interface ParsedEvalArgs {
@@ -576,6 +577,7 @@ export async function runAgentEvalCli(
   options: AgentEvalOptions | undefined,
   runner?: EvaliteRunner,
   writeConfig: AgentEvaliteConfigWriter = writeAgentEvaliteConfig,
+  files?: string[],
 ): Promise<number> {
   const resolvedOptions = resolveAgentEvalOptions(options)
 
@@ -600,6 +602,7 @@ export async function runAgentEvalCli(
     cache: resolvedOptions.cache,
     cacheEnabled: parsed.noCache ? false : undefined,
     cwd: context.rootDir,
+    ...(files ? { files } : {}),
     forceRerunTriggers: resolvedOptions.forceRerunTriggers,
     hideTable: parsed.hideTable ?? resolvedOptions.hideTable,
     maxConcurrency: resolvedOptions.maxConcurrency,
@@ -1277,7 +1280,10 @@ export async function runAgentDevCli(
 export function createAgentCliContributor(options?: false | AgentCliContributorOptions): AgentCliContributor | undefined {
   if (options === false) return
   const evalOptions = resolveAgentEvalOptions(options?.eval)
-  const hasEvalFiles = discoverAgentEvalFiles(options?.rootDir ?? process.cwd()).length > 0
+  const evalFiles = discoverAgentEvalFiles([
+    options?.rootDir ?? process.cwd(),
+    ...(options?.serverDirs ?? []),
+  ])
   const features: AgentCliContributor["namespaces"][number]["features"] = [
     {
       description: "Inspect a discovered Agent through a running Vite Development Server.",
@@ -1292,11 +1298,11 @@ export function createAgentCliContributor(options?: false | AgentCliContributorO
       usage: "vitehub agent dev [message...] [--agent <name>]",
     },
   ]
-  if (hasEvalFiles) {
+  if (evalFiles.length) {
     features.unshift({
       description: "Run ViteHub Agent Evals.",
       name: "eval",
-      run: async (args, context) => await runAgentEvalCli(args, context, evalOptions),
+      run: async (args, context) => await runAgentEvalCli(args, context, evalOptions, undefined, writeAgentEvaliteConfig, evalFiles),
       usage: "vitehub agent eval [path] [--watch]",
     })
   }

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path"
 import { readWorkspaceDevToken, workspaceDevTokenHeader } from "@vite-hub/workspace/server"
 
 import { formatAgentError } from "./agent-error.ts"
-import { discoverAgentEvalFiles } from "./discovery.ts"
+import { createAgentEvalInclude, discoverAgentEvalFiles } from "./discovery.ts"
 import { runAgentInfoCli } from "./internal/agent-info-cli.ts"
 import { vercelAiGatewayPricing, type AgentUsagePricing } from "./internal/usage-pricing.ts"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig, type ResolvedAgentEvalOptions } from "./internal/evalite-config.ts"
@@ -577,7 +577,7 @@ export async function runAgentEvalCli(
   options: AgentEvalOptions | undefined,
   runner?: EvaliteRunner,
   writeConfig: AgentEvaliteConfigWriter = writeAgentEvaliteConfig,
-  files?: string[],
+  include?: string[],
 ): Promise<number> {
   const resolvedOptions = resolveAgentEvalOptions(options)
 
@@ -602,7 +602,7 @@ export async function runAgentEvalCli(
     cache: resolvedOptions.cache,
     cacheEnabled: parsed.noCache ? false : undefined,
     cwd: context.rootDir,
-    ...(files ? { files } : {}),
+    ...(include ? { include } : {}),
     forceRerunTriggers: resolvedOptions.forceRerunTriggers,
     hideTable: parsed.hideTable ?? resolvedOptions.hideTable,
     maxConcurrency: resolvedOptions.maxConcurrency,
@@ -1280,10 +1280,11 @@ export async function runAgentDevCli(
 export function createAgentCliContributor(options?: false | AgentCliContributorOptions): AgentCliContributor | undefined {
   if (options === false) return
   const evalOptions = resolveAgentEvalOptions(options?.eval)
-  const evalFiles = discoverAgentEvalFiles([
+  const evalRoots = [
     options?.rootDir ?? process.cwd(),
     ...(options?.serverDirs ?? []),
-  ])
+  ]
+  const evalFiles = discoverAgentEvalFiles(evalRoots)
   const features: AgentCliContributor["namespaces"][number]["features"] = [
     {
       description: "Inspect a discovered Agent through a running Vite Development Server.",
@@ -1302,7 +1303,14 @@ export function createAgentCliContributor(options?: false | AgentCliContributorO
     features.unshift({
       description: "Run ViteHub Agent Evals.",
       name: "eval",
-      run: async (args, context) => await runAgentEvalCli(args, context, evalOptions, undefined, writeAgentEvaliteConfig, evalFiles),
+      run: async (args, context) => await runAgentEvalCli(
+        args,
+        context,
+        evalOptions,
+        undefined,
+        writeAgentEvaliteConfig,
+        createAgentEvalInclude(evalRoots),
+      ),
       usage: "vitehub agent eval [path] [--watch]",
     })
   }

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -30,7 +30,9 @@ export const agentEvalFileConvention = {
 
 export function createAgentEvalInclude(rootDirs: string[]): string[] {
   return [...new Set(rootDirs.flatMap((rootDir) => {
-    const root = resolve(rootDir).replace(/\\/g, "/")
+    const root = resolve(rootDir)
+      .replace(/\\/g, "/")
+      .replace(/([*?[\]{}()!])/g, "\\$1")
     return agentEvalFileConvention.include.map(pattern => `${root}/${pattern}`)
   }))].sort()
 }

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -36,8 +36,10 @@ function isEvalDefinitionFile(file: string): boolean {
   return evalDefinitionPattern.test(basename(file))
 }
 
-export function discoverAgentEvalFiles(rootDir: string): string[] {
-  return listMatchingFiles(resolve(rootDir), file => agentEvalFileConvention.pattern.test(file))
+export function discoverAgentEvalFiles(rootDirs: string[]): string[] {
+  return [...new Set(rootDirs.flatMap(rootDir =>
+    listMatchingFiles(resolve(rootDir), file => agentEvalFileConvention.pattern.test(file)),
+  ))].sort()
 }
 
 function normalizeSuffixAgentName(rootDir: string, file: string) {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -4,6 +4,7 @@ import { basename, dirname, relative, resolve } from "node:path"
 import {
   createDirectoryDefinitionSource,
   discoverDefinitions,
+  listMatchingFiles,
   mergeDefinitions,
   normalizeSuffixDefinitionName,
 } from "@vite-hub/internal/definition-catalog"
@@ -17,12 +18,26 @@ const evalDefinitionPattern = /^(?:.+\.)?eval\.(?:c|m)?[jt]s$/i
 const indexDefinitionPattern = /^index\.(?:c|m)?[jt]s$/i
 const colocatedAgentResourceDirectories = new Set(["home", "skills"])
 
+export const agentEvalFileConvention = {
+  include: [
+    "**/*.eval.?(m)ts",
+    "**/eval.?(m)ts",
+    "**/*.eval.tsx",
+    "**/eval.tsx",
+  ],
+  pattern: /^(?:.+\.)?eval\.(?:m?ts|tsx)$/,
+}
+
 function isColocatedAgentResourcePath(path: string): boolean {
   return colocatedAgentResourceDirectories.has(path.split("/")[0] || "")
 }
 
 function isEvalDefinitionFile(file: string): boolean {
   return evalDefinitionPattern.test(basename(file))
+}
+
+export function discoverAgentEvalFiles(rootDir: string): string[] {
+  return listMatchingFiles(resolve(rootDir), file => agentEvalFileConvention.pattern.test(file))
 }
 
 function normalizeSuffixAgentName(rootDir: string, file: string) {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -28,6 +28,13 @@ export const agentEvalFileConvention = {
   pattern: /^(?:.+\.)?eval\.(?:m?ts|tsx)$/,
 }
 
+export function createAgentEvalInclude(rootDirs: string[]): string[] {
+  return [...new Set(rootDirs.flatMap((rootDir) => {
+    const root = resolve(rootDir).replace(/\\/g, "/")
+    return agentEvalFileConvention.include.map(pattern => `${root}/${pattern}`)
+  }))].sort()
+}
+
 function isColocatedAgentResourcePath(path: string): boolean {
   return colocatedAgentResourceDirectories.has(path.split("/")[0] || "")
 }

--- a/packages/agent/src/evalite-runner.ts
+++ b/packages/agent/src/evalite-runner.ts
@@ -3,6 +3,8 @@ import process from "node:process"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
 
+import { agentEvalFileConvention } from "./discovery.ts"
+
 import type { Writable } from "node:stream"
 import type { Evalite } from "evalite/types"
 import type { ResolvedAgentEvalOptions } from "./internal/evalite-config.ts"
@@ -163,7 +165,7 @@ export async function runAgentEvalite(options: RunAgentEvaliteOptions): Promise<
     browser: undefined,
     config: false,
     forceRerunTriggers,
-    include: ["**/*.eval.?(m)ts"],
+    include: agentEvalFileConvention.include,
     maxConcurrency: options.maxConcurrency,
     mode: "test",
     reporters,

--- a/packages/agent/src/evalite-runner.ts
+++ b/packages/agent/src/evalite-runner.ts
@@ -12,6 +12,7 @@ import type { ResolvedAgentEvalOptions } from "./internal/evalite-config.ts"
 export interface RunAgentEvaliteOptions extends ResolvedAgentEvalOptions {
   cacheEnabled?: boolean
   cwd: string
+  files?: string[]
   mode: Evalite.RunMode
   outputPath?: string
   path?: string
@@ -165,7 +166,7 @@ export async function runAgentEvalite(options: RunAgentEvaliteOptions): Promise<
     browser: undefined,
     config: false,
     forceRerunTriggers,
-    include: agentEvalFileConvention.include,
+    include: options.files ?? agentEvalFileConvention.include,
     maxConcurrency: options.maxConcurrency,
     mode: "test",
     reporters,

--- a/packages/agent/src/evalite-runner.ts
+++ b/packages/agent/src/evalite-runner.ts
@@ -12,7 +12,7 @@ import type { ResolvedAgentEvalOptions } from "./internal/evalite-config.ts"
 export interface RunAgentEvaliteOptions extends ResolvedAgentEvalOptions {
   cacheEnabled?: boolean
   cwd: string
-  files?: string[]
+  include?: string[]
   mode: Evalite.RunMode
   outputPath?: string
   path?: string
@@ -166,7 +166,7 @@ export async function runAgentEvalite(options: RunAgentEvaliteOptions): Promise<
     browser: undefined,
     config: false,
     forceRerunTriggers,
-    include: options.files ?? agentEvalFileConvention.include,
+    include: options.include ?? agentEvalFileConvention.include,
     maxConcurrency: options.maxConcurrency,
     mode: "test",
     reporters,

--- a/packages/agent/src/internal/evalite-config.ts
+++ b/packages/agent/src/internal/evalite-config.ts
@@ -1,3 +1,5 @@
+import { rm } from "node:fs/promises"
+
 import { createGeneratedDefinitionPath, writeFileIfChanged } from "@vite-hub/internal/definition-catalog"
 
 import type { AgentEvalOptions } from "../types.ts"
@@ -12,8 +14,7 @@ const defaultForceRerunTriggers = [
   "src/**/*.eval.*",
 ]
 
-export function resolveAgentEvalOptions(options: false | AgentEvalOptions | undefined): ResolvedAgentEvalOptions | false {
-  if (options === false) return false
+export function resolveAgentEvalOptions(options: AgentEvalOptions | undefined): ResolvedAgentEvalOptions {
   return {
     ...options,
     forceRerunTriggers: options?.forceRerunTriggers ?? defaultForceRerunTriggers,
@@ -56,4 +57,8 @@ export async function writeAgentEvaliteConfig(rootDir: string, options: Resolved
   const file = createAgentEvaliteConfigPath(rootDir)
   await writeFileIfChanged(file, renderAgentEvaliteConfig(options))
   return file
+}
+
+export async function removeAgentEvaliteConfig(rootDir: string): Promise<void> {
+  await rm(createAgentEvaliteConfigPath(rootDir), { force: true })
 }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1310,7 +1310,7 @@ export interface ResolvedAgentRoutesOptions {
 export interface AgentModuleOptions {
   cli?: false | AgentCliOptions
   execution?: AgentExecution
-  eval?: false | AgentEvalOptions
+  eval?: AgentEvalOptions
   imports?: boolean
   integrations?: AgentIntegrationsOptions
   providers?: AgentProvidersOptions

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1804,6 +1804,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
         return createAgentCliContributor({
           eval: agent?.eval,
           rootDir: resolved?.root ?? process.cwd(),
+          serverDirs,
         })
       },
     },
@@ -1864,13 +1865,14 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
     async configResolved(config) {
       resolved = config
       agent = config.agent ?? agent
+      serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
       runtimeCapabilities = await resolveGeneratedAgentRuntimeCapabilities(
         config,
         getInternalAgentOptions(agent)?.runtimeCapabilityImports ?? frameworkOptions?.runtimeCapabilityImports,
       )
       standaloneRuntimeCapabilities = await writeStandaloneAgentRuntimeCapabilities(config, runtimeCapabilities)
       await writeGeneratedAgentOutputs(config)
-      if (agent === false || !discoverAgentEvalFiles(config.root).length) {
+      if (agent === false || !discoverAgentEvalFiles([config.root, ...(serverDirs ?? [])]).length) {
         await removeAgentEvaliteConfig(config.root)
         return
       }

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -16,8 +16,8 @@ import {
   installCloudflareAgentStateEntrypoint,
 } from "./cloudflare.ts"
 import { normalizeAgentOptions } from "./config.ts"
-import { discoverAgentDefinitions } from "./discovery.ts"
-import { resolveAgentEvalOptions, writeAgentEvaliteConfig } from "./internal/evalite-config.ts"
+import { discoverAgentDefinitions, discoverAgentEvalFiles } from "./discovery.ts"
+import { removeAgentEvaliteConfig, resolveAgentEvalOptions, writeAgentEvaliteConfig } from "./internal/evalite-config.ts"
 import { readColocatedAgentHome } from "./vite/colocated-agent-home.ts"
 import { readColocatedAgentInstructions } from "./vite/colocated-agent-instructions.ts"
 import { readColocatedAgentSkills } from "./vite/colocated-agent-skills.ts"
@@ -1801,7 +1801,10 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       cli: async () => {
         const { createAgentCliContributor } = await import(/* @vite-ignore */ "./cli.js")
         if (agent === false || agent?.cli === false) return createAgentCliContributor(false)
-        return createAgentCliContributor({ eval: resolveAgentEvalOptions(agent?.eval) })
+        return createAgentCliContributor({
+          eval: agent?.eval,
+          rootDir: resolved?.root ?? process.cwd(),
+        })
       },
     },
     config(config) {
@@ -1867,14 +1870,12 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       )
       standaloneRuntimeCapabilities = await writeStandaloneAgentRuntimeCapabilities(config, runtimeCapabilities)
       await writeGeneratedAgentOutputs(config)
-      if (agent === false || agent?.eval === false) {
+      if (agent === false || !discoverAgentEvalFiles(config.root).length) {
+        await removeAgentEvaliteConfig(config.root)
         return
       }
 
       const evalOptions = resolveAgentEvalOptions(agent?.eval)
-      if (evalOptions === false) {
-        return
-      }
       await writeAgentEvaliteConfig(config.root, evalOptions)
     },
     configEnvironment(name, config) {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -1185,13 +1185,16 @@ describe("agent CLI", () => {
       spawn: vi.fn(),
       stderr: stream(),
       stdout: stream(),
-    }, undefined, runner, vi.fn(async () => "/repo/.vitehub/agent/evalite.config.ts"))
+    }, undefined, runner, vi.fn(async () => "/repo/.vitehub/agent/evalite.config.ts"), [
+      "/external/server/agents/support.eval.ts",
+    ])
 
     expect(exitCode).toBe(0)
     expect(runner).toHaveBeenCalledWith({
       cache: undefined,
       cacheEnabled: undefined,
       cwd: "/repo",
+      files: ["/external/server/agents/support.eval.ts"],
       forceRerunTriggers: [
         "server/agents/**",
         "src/**/*.agent.*",

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -1186,7 +1186,8 @@ describe("agent CLI", () => {
       stderr: stream(),
       stdout: stream(),
     }, undefined, runner, vi.fn(async () => "/repo/.vitehub/agent/evalite.config.ts"), [
-      "/external/server/agents/support.eval.ts",
+      "/external/server/**/*.eval.?(m)ts",
+      "/external/server/**/eval.?(m)ts",
     ])
 
     expect(exitCode).toBe(0)
@@ -1194,7 +1195,10 @@ describe("agent CLI", () => {
       cache: undefined,
       cacheEnabled: undefined,
       cwd: "/repo",
-      files: ["/external/server/agents/support.eval.ts"],
+      include: [
+        "/external/server/**/*.eval.?(m)ts",
+        "/external/server/**/eval.?(m)ts",
+      ],
       forceRerunTriggers: [
         "server/agents/**",
         "src/**/*.agent.*",

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -37,7 +37,7 @@ const unknownExecutionAuthorityFixture = {
 
 describe("agent CLI", () => {
   it("contributes the agent eval feature", () => {
-    expect(createAgentCliContributor()).toEqual({
+    expect(createAgentCliContributor({ rootDir: join(import.meta.dirname, "fixtures") })).toEqual({
       namespaces: [{
         description: "Agent development workflows.",
         features: [
@@ -50,8 +50,9 @@ describe("agent CLI", () => {
     })
   })
 
-  it("keeps the agent dev feature when eval is disabled", () => {
-    expect(createAgentCliContributor({ eval: false })).toEqual({
+  it("keeps the agent dev feature without executable eval files", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-cli-no-evals-"))
+    expect(createAgentCliContributor({ rootDir })).toEqual({
       namespaces: [{
         description: "Agent development workflows.",
         features: [
@@ -61,6 +62,7 @@ describe("agent CLI", () => {
         name: "agent",
       }],
     })
+    await rm(rootDir, { force: true, recursive: true })
   })
 
   it("prints concise resolved Agent information from the running Vite server", async () => {
@@ -1266,21 +1268,6 @@ describe("agent CLI", () => {
     expect(exitCode).toBe(0)
     expect(runner).not.toHaveBeenCalled()
     expect(stdout.output()).toContain("Usage: vitehub agent eval")
-  })
-
-  it("can disable agent eval CLI", async () => {
-    const stderr = stream()
-    const exitCode = await runAgentEvalCli([], {
-      cwd: "/repo",
-      env: {},
-      rootDir: "/repo",
-      spawn: vi.fn(),
-      stderr,
-      stdout: stream(),
-    }, false, vi.fn())
-
-    expect(exitCode).toBe(1)
-    expect(stderr.output()).toContain("disabled")
   })
 
   it("rejects unsupported options before running Evalite", async () => {

--- a/packages/agent/test/deployment-catalog.test.ts
+++ b/packages/agent/test/deployment-catalog.test.ts
@@ -143,7 +143,6 @@ async function createDeploymentRuntimeFixture(adapter: "deno" | "netlify" | "nit
     logLevel: "silent",
     plugins: [
       hubAgent({
-        eval: false,
         providers: {
           state: {
             provider: "sqlite",

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1,11 +1,11 @@
-import { mkdir, mkdtemp, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { Readable } from "node:stream"
 
 import { describe, expect, it, vi } from "vitest"
 
-import { discoverAgentDefinitions } from "../src/discovery.ts"
+import { discoverAgentDefinitions, discoverAgentEvalFiles } from "../src/discovery.ts"
 import { getMessageText } from "../src/messages.ts"
 
 import type { IncomingMessage, ServerResponse } from "node:http"
@@ -15,6 +15,31 @@ import type { AgentRunInput } from "../src/index.ts"
 async function createTempRoot(prefix: string) {
   return await mkdtemp(join(tmpdir(), prefix))
 }
+
+it("discovers executable Agent Eval files without treating fixture directories as evals", async () => {
+  const root = await createTempRoot("vitehub-agent-evals-")
+  try {
+    await mkdir(join(root, "evals"), { recursive: true })
+    await mkdir(join(root, "server", "agents", "support"), { recursive: true })
+    await writeFile(join(root, "evals", "cases.json"), "[]\n", "utf8")
+    await writeFile(join(root, "evals", "reference.xlsx"), "fixture", "utf8")
+    await writeFile(join(root, "server", "agents", "support", "EVAL.TS"), "export default defineEval({})", "utf8")
+
+    expect(discoverAgentEvalFiles(root)).toEqual([])
+
+    const suffixEval = join(root, "server", "agents", "support.eval.ts")
+    const folderEval = join(root, "server", "agents", "support", "eval.mts")
+    const tsxEval = join(root, "server", "agents", "support.eval.tsx")
+    await writeFile(suffixEval, "export default defineEval({})", "utf8")
+    await writeFile(folderEval, "export default defineEval({})", "utf8")
+    await writeFile(tsxEval, "export default defineEval({})", "utf8")
+
+    expect(discoverAgentEvalFiles(root)).toEqual([suffixEval, tsxEval, folderEval])
+  }
+  finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})
 
 function responseChunkText(chunk: unknown) {
   if (typeof chunk === "string") return chunk

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -25,7 +25,7 @@ it("discovers executable Agent Eval files without treating fixture directories a
     await writeFile(join(root, "evals", "reference.xlsx"), "fixture", "utf8")
     await writeFile(join(root, "server", "agents", "support", "EVAL.TS"), "export default defineEval({})", "utf8")
 
-    expect(discoverAgentEvalFiles(root)).toEqual([])
+    expect(discoverAgentEvalFiles([root])).toEqual([])
 
     const suffixEval = join(root, "server", "agents", "support.eval.ts")
     const folderEval = join(root, "server", "agents", "support", "eval.mts")
@@ -34,7 +34,7 @@ it("discovers executable Agent Eval files without treating fixture directories a
     await writeFile(folderEval, "export default defineEval({})", "utf8")
     await writeFile(tsxEval, "export default defineEval({})", "utf8")
 
-    expect(discoverAgentEvalFiles(root)).toEqual([suffixEval, tsxEval, folderEval])
+    expect(discoverAgentEvalFiles([root])).toEqual([suffixEval, tsxEval, folderEval])
   }
   finally {
     await rm(root, { force: true, recursive: true })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -5,7 +5,7 @@ import { Readable } from "node:stream"
 
 import { describe, expect, it, vi } from "vitest"
 
-import { discoverAgentDefinitions, discoverAgentEvalFiles } from "../src/discovery.ts"
+import { createAgentEvalInclude, discoverAgentDefinitions, discoverAgentEvalFiles } from "../src/discovery.ts"
 import { getMessageText } from "../src/messages.ts"
 
 import type { IncomingMessage, ServerResponse } from "node:http"
@@ -15,6 +15,11 @@ import type { AgentRunInput } from "../src/index.ts"
 async function createTempRoot(prefix: string) {
   return await mkdtemp(join(tmpdir(), prefix))
 }
+
+it("escapes glob syntax in Agent Eval roots", () => {
+  const include = createAgentEvalInclude(["/repo/app[1]/server?(external)"])
+  expect(include).toContain("/repo/app\\[1\\]/server\\?\\(external\\)/**/*.eval.?(m)ts")
+})
 
 it("discovers executable Agent Eval files without treating fixture directories as evals", async () => {
   const root = await createTempRoot("vitehub-agent-evals-")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -205,6 +205,43 @@ function chatWebhookRequest(messageId: number, threadId = 456, text = "hello") {
 }
 
 describe("agent Vite plugin", () => {
+  it("activates eval tooling only while executable eval files exist", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-eval-discovery-"))
+    const generatedConfig = join(root, ".vitehub", "agent", "evalite.config.ts")
+    try {
+      await mkdir(join(root, "evals"), { recursive: true })
+      await writeFile(join(root, "evals", "cases.json"), "[]\n", "utf8")
+      await writeFile(join(root, "evals", "reference.xlsx"), "fixture", "utf8")
+
+      const plugin = hubAgent()
+      const configResolved = plugin.configResolved as (config: { command: "serve", root: string }) => Promise<void>
+      const cli = plugin.vitehub?.cli as () => Promise<{
+        namespaces: Array<{ features: Array<{ name: string }> }>
+      }>
+      const featureNames = async () => (await cli()).namespaces[0]!.features.map(feature => feature.name)
+
+      await configResolved({ command: "serve", root })
+      await expect(readFile(generatedConfig, "utf8")).rejects.toMatchObject({ code: "ENOENT" })
+      await expect(featureNames()).resolves.not.toContain("eval")
+
+      const evalFile = join(root, "server", "agents", "support.eval.tsx")
+      await mkdir(join(root, "server", "agents"), { recursive: true })
+      await writeFile(evalFile, "export default defineEval({})", "utf8")
+      await configResolved({ command: "serve", root })
+      await expect(readFile(generatedConfig, "utf8")).resolves.toContain("forceRerunTriggers")
+      await expect(featureNames()).resolves.toContain("eval")
+
+      await rm(evalFile)
+      await configResolved({ command: "serve", root })
+      await expect(readFile(generatedConfig, "utf8")).rejects.toMatchObject({ code: "ENOENT" })
+      await expect(featureNames()).resolves.not.toContain("eval")
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("bundles repository context templates into Vite builds", async () => {
     const { hubAgent } = await import("../src/vite.ts")
     const root = await mkdtemp(join(import.meta.dirname, ".repository-context-template-"))
@@ -228,7 +265,7 @@ describe("agent Vite plugin", () => {
       ].join("\n"), "utf8")
 
       const runBuild = build as unknown as (config: unknown) => Promise<unknown>
-      const agentPlugin: unknown = hubAgent({ eval: false })
+      const agentPlugin: unknown = hubAgent()
       const markdownPlugin: unknown = hubMarkdownTemplate()
       await runBuild({
         [VITEHUB_SERVER_DIRS]: [serverDir],
@@ -475,7 +512,7 @@ describe("agent Vite plugin", () => {
 
   it("invalidates runtime Schedule modules when an Agent changes", async () => {
     const { hubAgent } = await import("../src/vite.ts")
-    const plugin = hubAgent({ eval: false })
+    const plugin = hubAgent()
     const registryModule = { id: "registry" }
     const targetsModule = { id: "targets" }
     const nitroRegistryModule = { id: "nitro-registry" }
@@ -536,7 +573,7 @@ describe("agent Vite plugin", () => {
       await writeFile(join(agentRoot, "instructions.md"), "@./tone.md\n", "utf8")
       await writeFile(join(agentRoot, "tone.md"), "Use a concise tone.\n", "utf8")
 
-      const plugin = hubAgent({ eval: false })
+      const plugin = hubAgent()
       const configResolved = plugin.configResolved as unknown as (config: { agent?: unknown, command: "serve", plugins: never[], root: string }) => Promise<void>
       await configResolved({ command: "serve", plugins: [], root })
       const generatedRouteModule = { id: "generated-route" }
@@ -570,7 +607,7 @@ describe("agent Vite plugin", () => {
   it("materializes the MCP runtime package for Vercel build output", async () => {
     const { copyVercelFunctionRuntimePackages } = await import("@vite-hub/internal/build/vercel-runtime-packages")
     const { hubAgent } = await import("../src/vite.ts")
-    const plugin = hubAgent({ eval: false })
+    const plugin = hubAgent()
     const configResolved = plugin.configResolved as (config: { agent?: unknown, command: "build", root: string }) => Promise<void>
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
     vi.mocked(copyVercelFunctionRuntimePackages).mockClear()
@@ -1373,12 +1410,12 @@ describe("agent Vite plugin", () => {
     try {
       await mkdir(join(root, "server", "agents"), { recursive: true })
       await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
-      const plugin = hubAgent({ eval: false, runtime: "deno" })
+      const plugin = hubAgent({ runtime: "deno" })
       const configResolved = plugin.configResolved as (config: { agent?: unknown, command: "build", root: string }) => Promise<void>
       const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
       vi.mocked(copyVercelFunctionRuntimePackages).mockClear()
 
-      await configResolved({ agent: { eval: false, runtime: "deno" }, command: "build", root })
+      await configResolved({ agent: { runtime: "deno" }, command: "build", root })
       await closeBundle.handler()
 
       expect(copyVercelFunctionRuntimePackages).not.toHaveBeenCalled()
@@ -1466,7 +1503,7 @@ export default defineAgent({
         ],
       }, null, 2)}\n`, "utf8")
 
-      const plugin = hubAgent({ eval: false })
+      const plugin = hubAgent()
       if (typeof plugin.configResolved === "function") {
         await plugin.configResolved.call({} as never, { command: "build", preset: "cloudflare", root } as never)
       }

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -208,6 +208,7 @@ describe("agent Vite plugin", () => {
   it("activates eval tooling only while executable eval files exist", async () => {
     const { hubAgent } = await import("../src/vite.ts")
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-eval-discovery-"))
+    const serverDir = await mkdtemp(join(tmpdir(), "vitehub-agent-eval-server-"))
     const generatedConfig = join(root, ".vitehub", "agent", "evalite.config.ts")
     try {
       await mkdir(join(root, "evals"), { recursive: true })
@@ -215,7 +216,11 @@ describe("agent Vite plugin", () => {
       await writeFile(join(root, "evals", "reference.xlsx"), "fixture", "utf8")
 
       const plugin = hubAgent()
-      const configResolved = plugin.configResolved as (config: { command: "serve", root: string }) => Promise<void>
+      const configResolved = plugin.configResolved as (config: {
+        [VITEHUB_SERVER_DIRS]?: string[]
+        command: "serve"
+        root: string
+      }) => Promise<void>
       const cli = plugin.vitehub?.cli as () => Promise<{
         namespaces: Array<{ features: Array<{ name: string }> }>
       }>
@@ -225,10 +230,10 @@ describe("agent Vite plugin", () => {
       await expect(readFile(generatedConfig, "utf8")).rejects.toMatchObject({ code: "ENOENT" })
       await expect(featureNames()).resolves.not.toContain("eval")
 
-      const evalFile = join(root, "server", "agents", "support.eval.tsx")
-      await mkdir(join(root, "server", "agents"), { recursive: true })
+      const evalFile = join(serverDir, "agents", "support.eval.tsx")
+      await mkdir(join(serverDir, "agents"), { recursive: true })
       await writeFile(evalFile, "export default defineEval({})", "utf8")
-      await configResolved({ command: "serve", root })
+      await configResolved({ [VITEHUB_SERVER_DIRS]: [serverDir], command: "serve", root })
       await expect(readFile(generatedConfig, "utf8")).resolves.toContain("forceRerunTriggers")
       await expect(featureNames()).resolves.toContain("eval")
 
@@ -239,6 +244,7 @@ describe("agent Vite plugin", () => {
     }
     finally {
       await rm(root, { force: true, recursive: true })
+      await rm(serverDir, { force: true, recursive: true })
     }
   })
 

--- a/packages/agent/test/schedule-process-integration.test.ts
+++ b/packages/agent/test/schedule-process-integration.test.ts
@@ -86,7 +86,6 @@ describe("Agent Process Schedule integration", () => {
       plugins: [
         schedulePlugin as never,
         hubAgent({
-          eval: false,
           providers: { state: { provider: "memory" } },
           routes: { chat: true },
         }),

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -164,6 +164,21 @@ describe("agent public types", () => {
     void webhookRoute
   })
 
+  it("keeps Agent Eval configuration as runner options rather than an activation toggle", () => {
+    const evalOptions: AgentModuleOptions = {
+      eval: {
+        maxConcurrency: 2,
+        testTimeout: 60_000,
+      },
+    }
+    const disabledEval: AgentModuleOptions = {
+      // @ts-expect-error Executable Eval files control activation.
+      eval: false,
+    }
+    void evalOptions
+    void disabledEval
+  })
+
   it("accepts zero-argument Channel factories and keeps configured Channels explicit", () => {
     interface RuntimeConfig extends AgentRuntimeConfig {
       token: string


### PR DESCRIPTION
Agent Eval tooling now follows executable eval files instead of defaulting on whenever the Agent integration is present. Adding a canonical `*.eval.ts`, `*.eval.mts`, `*.eval.tsx`, or folder-level equivalent exposes `vitehub agent eval` and writes the generated Evalite config; fixture-only `evals/` directories stay inert, and removing the final eval file removes stale generated config.

This keeps `agent.eval` as runner tuning only and removes the boolean activation toggle. Discovery and Evalite execution now share one case-sensitive filename convention, without changing eval execution or scoring behavior.

Validated with the focused Agent CLI, discovery, Vite plugin, and Evalite runner suites (264 tests), the Agent package typecheck and lint, the Agent dependency build with publint, and a representative consumer proving fixture-only, TSX activation, and removal behavior. The broader Agent suite also passed 1,488 tests; its remaining environment-bound cases require registry access or local listener permissions unavailable in the sandbox.