### PR TITLE
refactor(workspace)!: remove placeholder mount contract

### DIFF
--- a/docs/content/docs/server-primitives/workspace.md
+++ b/docs/content/docs/server-primitives/workspace.md
@@ -408,19 +408,6 @@ export async function testDocs() {
 | `close()` | none | Rolls an uncommitted host tree back to authoritative Workspace state and releases Session resources. |
 | `tools?.aiSdk()` | none | Returns runtime-provided AI SDK tools when the Session supports them. |
 
-### Mount method options
-
-The exported `Workspace` contract also exposes `mount()` for integrations that hold the full Workspace implementation.
-
-| Surface | Options or result | Behavior |
-| --- | --- | --- |
-| `mount(options?)` | `mode: 'read-only' \| 'read-write' \| 'copy-on-write'`, `target?: string` | Declares the mount mode and target. With no options, mode defaults to `read-only` and target defaults to `/workspace`. |
-| `mount.diff()` | none | Returns changes made through the mount. |
-| `mount.commit(options?)` | `message?: string` | Commits mounted changes with an optional message. |
-| `mount.export()` | none | Exports the mounted Workspace as a snapshot. |
-
-The returned `WorkspaceMount` also exposes its `workspace`, resolved `mode`, and resolved `target`.
-
 Workspace owns the file tree and commit behavior. Box owns execution and provider adapters. Sandbox composes both for discovered named work, while Agent Definitions compose them for harness execution.
 
 ### Run sessions from the CLI

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -175,22 +175,6 @@ export interface WorkspaceSessionHost {
   ): Promise<{ code: number, stderr: string, stdout: string }>
 }
 
-export type WorkspaceMountMode = "read-only" | "read-write" | "copy-on-write"
-
-export interface WorkspaceMountOptions {
-  mode: WorkspaceMountMode
-  target?: string
-}
-
-export interface WorkspaceMount {
-  workspace: Workspace
-  mode: WorkspaceMountMode
-  target: string
-  diff(): Promise<WorkspaceDiff>
-  commit(options?: { message?: string }): Promise<void>
-  export(): Promise<WorkspaceSnapshot>
-}
-
 export interface ExecOptions {
   abortSignal?: AbortSignal
   cwd?: string
@@ -679,7 +663,6 @@ export interface Workspace {
   snapshot(options?: SnapshotOptions): Promise<WorkspaceSnapshot>
   diff(options?: DiffOptions): Promise<WorkspaceDiff>
   startSession(options?: WorkspaceSessionOptions): Promise<WorkspaceSession>
-  mount(options?: WorkspaceMountOptions): WorkspaceMount
 }
 
 export interface WorkspaceSourceSyncCounts {

--- a/packages/workspace/src/core/use.ts
+++ b/packages/workspace/src/core/use.ts
@@ -250,23 +250,6 @@ function createLazyWorkspace(name: WorkspaceName, definition?: WorkspaceDefiniti
     async startSession(options) {
       return await (await resolveSyncedWorkspace()).startSession(options)
     },
-    mount(options) {
-      const mode = options?.mode || "read-only"
-      return {
-        workspace,
-        mode,
-        target: options?.target || "/workspace",
-        async diff() {
-          return await (await resolveSyncedWorkspace()).mount(options).diff()
-        },
-        async commit(commitOptions) {
-          await (await resolveSyncedWorkspace()).mount(options).commit(commitOptions)
-        },
-        async export() {
-          return await (await resolveSyncedWorkspace()).mount(options).export()
-        },
-      }
-    },
   } as Workspace
 
   return attachWorkspaceSourceRequestExecution(workspace, {

--- a/packages/workspace/src/core/workspace.ts
+++ b/packages/workspace/src/core/workspace.ts
@@ -7,8 +7,6 @@ import { getCachedWorkspaceStore } from "./workspace-cache.ts"
 import type {
   Workspace,
   WorkspaceDefinition,
-  WorkspaceMount,
-  WorkspaceMountOptions,
   WorkspaceSession,
 } from "./types.ts"
 
@@ -87,23 +85,6 @@ export function createWorkspace(definition: WorkspaceDefinition): Workspace {
       }
 
       return await createBasicWorkspaceSession(workspace, options)
-    },
-    mount(options?: WorkspaceMountOptions): WorkspaceMount {
-      const mode = options?.mode || "read-only"
-      return {
-        workspace,
-        mode,
-        target: options?.target || "/workspace",
-        async diff() {
-          return await workspace.diff()
-        },
-        async commit() {
-          await workspace.snapshot({ name: "mount-commit" })
-        },
-        async export() {
-          return await workspace.snapshot({ name: "mount-export" })
-        },
-      }
     },
   }
 

--- a/packages/workspace/src/sources/resolution.ts
+++ b/packages/workspace/src/sources/resolution.ts
@@ -477,23 +477,6 @@ export async function createWorkspaceSourceResolutionFacade<Name extends Workspa
         return await syncWorkspaceSources(resolvedDefinition, syncStore, options)
       },
       writeFile: writeFs.writeFile,
-      mount(options) {
-        const mode = options?.mode || "read-only"
-        return {
-          workspace: writeWorkspace,
-          mode,
-          target: options?.target || "/workspace",
-          async diff() {
-            return await writeWorkspace.diff()
-          },
-          async commit() {
-            await writeWorkspace.snapshot({ name: "mount-commit" })
-          },
-          async export() {
-            return await writeWorkspace.snapshot({ name: "mount-export" })
-          },
-        }
-      },
     }, sourceRequestExecution)
     const createWriteTools = (options?: WritableWorkspaceFacadeToolOptions) => createWorkspaceTools(writeWorkspace as never, {
       broadSearchPaths: options?.broadSearchPaths,

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -70,6 +70,12 @@ describe("workspace types", () => {
     expectTypeOf(source.github(githubOptions)).toMatchTypeOf(github(githubOptions))
   })
 
+  it("does not expose a placeholder mount contract", () => {
+    const workspace = {} as Workspace
+    // @ts-expect-error Workspace mounts require a real host projection contract.
+    workspace.mount()
+  })
+
   it("types the facade helpers", async () => {
     const definition = defineWorkspace({
       sources: {


### PR DESCRIPTION
## What changed

- remove the public `Workspace.mount()` API and its mount types
- remove the duplicate core, lazy, and Source-resolution façade implementations
- remove documentation for the placeholder surface
- add a type regression proving the contract stays absent until a real host projection exists

This is 83 deletions with no replacement wrapper or dependency.

## Why

Evidence research supports converging Workspace file I/O on one proven Node-compatible VFS while ViteHub keeps Source composition, authorization and write policy, history/persistence boundaries, transactional Sessions, and provider glue.

`mountx@0.0.1` is not ready to be that substrate: it is alpha and unaudited, and its current [correctness review](https://github.com/pithings/mountx/issues/1) contains reproduced P0 corruption/data-loss defects. It also does not provide ViteHub's Source overlay, policy, history, or remote Box transport contracts.

The existing `mount()` method does not create a host mount; it only returns `mode` and `target` metadata while forwarding `diff()` and `snapshot()`. Removing that false abstraction now leaves room for a future real VFS/projection contract without freezing compatibility glue. `startSession({ host })` remains the honest execution and materialization surface.

## Breaking change

`Workspace.mount()`, `WorkspaceMount`, `WorkspaceMountOptions`, and `WorkspaceMountMode` are removed.

## Validation

- `pnpm --filter @vite-hub/workspace test` — 36 files, 474 tests, no type errors
- `pnpm --filter @vite-hub/workspace typecheck`
- `pnpm --filter vitehub-docs test` — 10 files, 39 tests
- `pnpm exec oxlint` on the changed TypeScript files
- `git diff --check`