### PR TITLE
fix(agent): translate message concurrency for Chat SDK

### DIFF
--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1362,9 +1362,10 @@ function createChatSdkConfig(
   const identity: ChatConfig["identity"] = options?.identity ?? (options?.transcripts
     ? ({ author }) => author.isBot === true ? null : `${adapterName}:${author.userId}`
     : undefined)
+  const concurrency = chatSdkOption<ChatConfig["concurrency"] | "parallel">(options, "concurrency")
   return objectWithoutUndefined({
     adapters: { [adapterName]: adapter },
-    concurrency: chatSdkOption<ChatConfig["concurrency"]>(options, "concurrency"),
+    concurrency: concurrency === "parallel" ? "concurrent" : concurrency,
     dedupeTtlMs: chatSdkOption<number>(options, "dedupeTtlMs"),
     fallbackStreamingPlaceholderText,
     identity,

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -6895,6 +6895,32 @@ describe("server helpers", () => {
     }
   })
 
+  it.each([
+    ["parallel", "concurrent"],
+    ["drop", "drop"],
+    ["queue", "queue"],
+  ] as const)("maps ViteHub %s message concurrency to Chat SDK %s", async (concurrency, expectedConcurrency) => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: { concurrency, stream: false },
+        }),
+      },
+      driver: { run: () => "Agent output" },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_003), "telegram")
+
+    expect(response.status).toBe(200)
+    expect((adapter._chatInstance() as unknown as { _concurrencyStrategy: string })._concurrencyStrategy).toBe(expectedConcurrency)
+  })
+
   it("preserves automatic chat delivery", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")


### PR DESCRIPTION
Translates ViteHub's public `messages.concurrency: "parallel"` value to Chat SDK's equivalent `"concurrent"` strategy when constructing the route runtime. The shared `"drop"` and `"queue"` values continue to pass through unchanged, so Agent Definitions keep ViteHub vocabulary and consumers no longer need a package patch for this boundary.

Adds regression coverage through the real channel route and Chat SDK instance. The Agent package build and publint pass, all 1,495 Agent tests pass, and the package typecheck passes.