### PR TITLE
feat(agent): deliver progress summaries during manual streaming

### DIFF
--- a/docs/content/docs/capabilities/progress-summary.md
+++ b/docs/content/docs/capabilities/progress-summary.md
@@ -52,7 +52,7 @@ The part is transient, so it does not become conversation history. Keep structur
 
 ## Understand the runtime behavior
 
-Reasoning deltas and tool start or completion events mark the current activity dirty. While new activity exists, the Capability generates at most one summary per interval and never overlaps generations. Raw reasoning, tool input, and tool output are excluded from the generated prompt; reasoning is represented only as an `Active` presence signal.
+The Capability generates an initial summary when the stream starts. Reasoning deltas and tool start or completion events then mark the current activity dirty. While new activity exists, the Capability generates at most one summary per interval and never overlaps generations. Raw reasoning, tool input, and tool output are excluded from the generated prompt; reasoning is represented only as an `Active` presence signal.
 
 The default prompt uses only reasoning presence, sanitized tool names, and the previous summary. It does not include user message text, code, commands, paths, traces, hidden instructions, credentials, raw tool details, or trusted `<context>` payloads.
 
@@ -60,7 +60,7 @@ The Capability stops pending timers when the parent invocation aborts. It also d
 
 ## Requirements
 
-The primary Agent Driver must emit reasoning or tool lifecycle events through a compatible async stream or UI message stream. The Capability remains silent when the stream has no new activity to summarize.
+The primary Agent Driver must expose a compatible async stream or UI message stream. After the initial summary, the Capability remains silent until reasoning or tool lifecycle events provide new activity to summarize.
 
 Configure a `driver`, `model`, or `execute` option for summary generation. Without one of those options, the Capability uses the Agent model when available.
 
@@ -74,7 +74,7 @@ Configure a `driver`, `model`, or `execute` option for summary generation. Witho
 
 ## Verify the result
 
-Run an invocation that performs at least one tool call or emits reasoning for longer than `intervalMs`. Confirm that the primary stream continues immediately and that a transient `data-progress-summary` part arrives with a higher `revision`.
+Run an invocation and confirm that the primary stream continues immediately while an initial transient `data-progress-summary` part arrives. Perform at least one tool call or emit reasoning for longer than `intervalMs`, then confirm that a later part arrives with a higher `revision`.
 
 Stop the invocation before the next interval and confirm that no later progress part appears.
 

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -507,7 +507,7 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
   return defineCapability({
     id: options.id || "progress-summary",
     output(context) {
-      context.context.set(progressSummaryOutputContextKey, true)
+      context.context.set(progressSummaryOutputContextKey, true, { overwrite: true })
       context.output.render((result) => {
         const messages = context.input.messages()
         if (!messages.some(message => message.role === "user") && !context.input.get().prompt) return result

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -368,7 +368,7 @@ function withProgressSummaryStream(
   }
   abortSignal?.addEventListener("abort", close, { once: true })
 
-  const schedule = () => {
+  const schedule = (immediate = false) => {
     if (closed || running || scheduled || !dirty) return
     scheduled = true
     const run = () => {
@@ -409,7 +409,7 @@ function withProgressSummaryStream(
           schedule()
         })
     }
-    if (intervalMs === 0) queueMicrotask(run)
+    if (immediate || intervalMs === 0) queueMicrotask(run)
     else timer = setTimeout(run, intervalMs)
   }
 
@@ -457,7 +457,7 @@ function withProgressSummaryStream(
   const transformed = source.pipeThrough(new TransformStream({
     start(streamController) {
       controller = streamController
-      schedule()
+      schedule(true)
     },
     flush: close,
     transform(chunk, streamController) {

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -3,6 +3,7 @@ import { streamAgentOutputToEvents, toAgentRunResult } from "../agent-output.ts"
 import { defineCapability } from "../capability-runtime.ts"
 import { toAgentUiMessageStreamResponse } from "../http-response.ts"
 import { normalizeAgentDriver, resolveNormalizedHarnessDriver } from "../internal/agent-driver.ts"
+import { progressSummaryOutputContextKey } from "../internal/agent-output-events.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 import { isAsyncIterable, toReadableAsyncIterableStream } from "../internal/stream-result.ts"
 import { getMessageText } from "../messages.ts"
@@ -503,9 +504,10 @@ function isStreamResult(value: unknown): value is {
 export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
   options: ProgressSummaryOptions<TRuntimeConfig> = {},
 ): AgentCapabilityDefinition<TRuntimeConfig> {
-  const capability = defineCapability({
+  return defineCapability({
     id: options.id || "progress-summary",
     output(context) {
+      context.context.set(progressSummaryOutputContextKey, true)
       context.output.render((result) => {
         const messages = context.input.messages()
         if (!messages.some(message => message.role === "user") && !context.input.get().prompt) return result
@@ -549,6 +551,4 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
       })
     },
   })
-  Object.defineProperty(capability, Symbol.for("vitehub.progressSummaryCapability"), { value: true })
-  return capability
 }

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -503,7 +503,7 @@ function isStreamResult(value: unknown): value is {
 export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
   options: ProgressSummaryOptions<TRuntimeConfig> = {},
 ): AgentCapabilityDefinition<TRuntimeConfig> {
-  return defineCapability({
+  const capability = defineCapability({
     id: options.id || "progress-summary",
     output(context) {
       context.output.render((result) => {
@@ -549,4 +549,6 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
       })
     },
   })
+  Object.defineProperty(capability, Symbol.for("vitehub.progressSummaryCapability"), { value: true })
+  return capability
 }

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -349,7 +349,7 @@ function withProgressSummaryStream(
   let reasoningActive = false
   let previous: string | undefined
   let revision = 0
-  let dirty = false
+  let dirty = true
   let running = false
   let closed = false
   let scheduled = false
@@ -455,6 +455,10 @@ function withProgressSummaryStream(
   }
 
   const transformed = source.pipeThrough(new TransformStream({
+    start(streamController) {
+      controller = streamController
+      schedule()
+    },
     flush: close,
     transform(chunk, streamController) {
       controller = streamController

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,5 +1,6 @@
 import agentRegistry from "#vitehub/agent/registry"
 import { normalizeAgentDriver } from "./internal/agent-driver.ts"
+import { agentOutputEventObserverContextKey, type AgentOutputEventObserver } from "./internal/agent-output-events.ts"
 import { openAgentInvocationLifecycle, type AgentInvocationLifecycle } from "./internal/invocation-lifecycle.ts"
 import { cloneWithPropertyDescriptors, toReadableAsyncIterableStream } from "./internal/stream-result.ts"
 import { validateAgentOutput } from "./internal/agent-structured-output.ts"
@@ -2506,13 +2507,18 @@ async function finalizeAgentInvocationResult<
   }
 }
 
-async function materializeAgentStructuredOutput(result: unknown, abortSignal?: AbortSignal): Promise<unknown> {
+async function materializeAgentStructuredOutput(
+  result: unknown,
+  abortSignal?: AbortSignal,
+  onEvent?: AgentOutputEventObserver,
+): Promise<unknown> {
   if (!isAsyncIterable(result) && !hasTraceableStreamResult(result)) return result
   if (toAgentRunResult(result).text !== undefined) return result
   let text = ""
   let usageRecord: Extract<StreamEvent, { type: "usage" }>["usageRecord"] | undefined
   const events = withCapabilityCleanup(streamAgentOutputToEvents(result), async () => {}, { abortSignal }) as AsyncIterable<StreamEvent>
   for await (const event of events) {
+    onEvent?.(event)
     if (event.type === "error") throw new Error(event.error)
     if (event.type === "text-delta") text += event.text
     if (event.type === "usage") usageRecord = event.usageRecord
@@ -2702,7 +2708,13 @@ async function executeAgentInvocation<
         }
       }
       const final = options.renderOutput ? await applyFinalOutputRenderers(rendered, invocation, outputExtensions) : rendered
-      const structuredFinal = options.renderOutput && invocation.output ? await materializeAgentStructuredOutput(final, invocation.input.abortSignal) : final
+      const structuredFinal = options.renderOutput && invocation.output
+        ? await materializeAgentStructuredOutput(
+            final,
+            invocation.input.abortSignal,
+            invocation.context.get<AgentOutputEventObserver>(agentOutputEventObserverContextKey),
+          )
+        : final
       const structuredUsageRecord = options.renderOutput && invocation.output
         ? await resolveFinishUsageRecord(invocation, structuredFinal) ?? driverUsageRecord
         : driverUsageRecord

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1,6 +1,6 @@
 import agentRegistry from "#vitehub/agent/registry"
 import { normalizeAgentDriver } from "./internal/agent-driver.ts"
-import { agentOutputEventObserverContextKey, type AgentOutputEventObserver } from "./internal/agent-output-events.ts"
+import { agentOutputEventObserverContextKey, progressSummaryOutputContextKey, type AgentOutputEventObserver } from "./internal/agent-output-events.ts"
 import { openAgentInvocationLifecycle, type AgentInvocationLifecycle } from "./internal/invocation-lifecycle.ts"
 import { cloneWithPropertyDescriptors, toReadableAsyncIterableStream } from "./internal/stream-result.ts"
 import { validateAgentOutput } from "./internal/agent-structured-output.ts"
@@ -2575,7 +2575,12 @@ async function executeAgentInvocation<
     if (customRun) {
       result = await agent.run(invocation)
     }
-    else if (options.kind === "stream" && adapter?.stream) {
+    else if (options.kind === "stream"
+      && adapter?.stream
+      && (
+        invocation.context.get<boolean>(finalChannelOutputContextKey) !== true
+        || invocation.context.get<boolean>(progressSummaryOutputContextKey) === true
+      )) {
       result = await adapter.stream(toAgentAdapterRunContext(invocation) as never)
     }
     else {

--- a/packages/agent/src/internal/agent-output-events.ts
+++ b/packages/agent/src/internal/agent-output-events.ts
@@ -1,5 +1,6 @@
 import type { StreamEvent } from "../messages.ts"
 
 export const agentOutputEventObserverContextKey = "agent.output.eventObserver"
+export const progressSummaryOutputContextKey = "agent.output.progressSummary"
 
 export type AgentOutputEventObserver = (event: StreamEvent) => void

--- a/packages/agent/src/internal/agent-output-events.ts
+++ b/packages/agent/src/internal/agent-output-events.ts
@@ -1,0 +1,5 @@
+import type { StreamEvent } from "../messages.ts"
+
+export const agentOutputEventObserverContextKey = "agent.output.eventObserver"
+
+export type AgentOutputEventObserver = (event: StreamEvent) => void

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -683,7 +683,6 @@ async function collectAgentOutput(
 }
 
 const manualDeliveryProgressDrainTimeoutMs = 100
-const baseAgentOutputSymbol = Symbol.for("vitehub.baseAgentOutput")
 
 function progressSummaryFromEvent(event: unknown): string | undefined {
   if (!isRecord(event) || event.type !== "data-progress-summary") return
@@ -691,12 +690,6 @@ function progressSummaryFromEvent(event: unknown): string | undefined {
     ? event.data.summary.trim()
     : ""
   return summary || undefined
-}
-
-function hasAgentStructuredOutput(agent: AgentInput<ViteAgentRouteRuntimeContext>): boolean {
-  return typeof agent === "object"
-    && agent !== null
-    && Object.getOwnPropertyDescriptor(agent, baseAgentOutputSymbol)?.value !== undefined
 }
 
 function createManualDeliveryProgressUpdater(
@@ -2171,7 +2164,7 @@ async function handleChatSdkMessage(
       // Manual delivery disables Chat SDK reply streaming, but still consumes
       // normalized Agent events so transient Capability output can update the
       // framework-owned placeholder without exposing ordinary Agent text.
-      const result = manualDelivery && !hasAgentStructuredOutput(agent)
+      const result = manualDelivery
         ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
         : await runAgentInline(agent as never, runContext as never, invocationInput as never)
       const text = await collectAgentOutput(result, progress?.update)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -640,7 +640,7 @@ function fallbackWebhookFromRequest(request: Request): string | undefined {
 
 async function collectAgentOutput(
   result: unknown,
-  onProgress?: (summary: string) => MaybePromise<void>,
+  onProgress?: (summary: string) => void,
 ): Promise<string> {
   if (result instanceof Response) {
     if (result.headers.get("content-type")?.includes("application/json")) {
@@ -676,13 +676,74 @@ async function collectAgentOutput(
       const summary = isRecord(event.data) && typeof event.data.summary === "string"
         ? event.data.summary.trim()
         : ""
-      if (summary) await onProgress?.(summary)
+      if (summary) onProgress?.(summary)
     }
     if (event.type === "error") {
       throw new Error(event.error)
     }
   }
   return (explicitPhaseSeen ? finalText : unphasedText).trim()
+}
+
+const manualDeliveryProgressDrainTimeoutMs = 100
+
+function createManualDeliveryProgressUpdater(
+  manualDelivery: { placeholder?: unknown },
+  waitUntil: AgentWaitUntil,
+): {
+  finish: () => Promise<void>
+  update: (summary: string) => void
+} {
+  let latest: string | undefined
+  let active = true
+  let draining: Promise<void> | undefined
+
+  const drain = async () => {
+    while (active && latest && manualDelivery.placeholder) {
+      const summary = latest
+      latest = undefined
+      await replaceManualDeliveryPlaceholder(manualDelivery.placeholder, { markdown: summary }).catch(() => false)
+    }
+  }
+  const startDrain = () => {
+    if (draining) return
+    draining = drain().finally(() => {
+      draining = undefined
+      if (active && latest && manualDelivery.placeholder) startDrain()
+    })
+  }
+
+  return {
+    async finish() {
+      active = false
+      if (!draining) return
+
+      let timeout: ReturnType<typeof setTimeout> | undefined
+      const drained = await Promise.race([
+        draining.then(() => true),
+        new Promise<false>((resolve) => {
+          timeout = setTimeout(() => resolve(false), manualDeliveryProgressDrainTimeoutMs)
+        }),
+      ])
+      if (timeout) clearTimeout(timeout)
+      if (drained || !manualDelivery.placeholder) return
+
+      const stalePlaceholder = manualDelivery.placeholder
+      manualDelivery.placeholder = undefined
+      const cleanup = draining.then(async () => {
+        await deleteManualDeliveryPlaceholder(stalePlaceholder).catch(() => undefined)
+      })
+      waitUntil(Promise.race([
+        cleanup,
+        new Promise<void>(resolve => setTimeout(resolve, manualDeliveryProgressDrainTimeoutMs)),
+      ]))
+    },
+    update(summary) {
+      if (!manualDelivery.placeholder) return
+      latest = summary
+      startDrain()
+    },
+  }
 }
 
 type ChatTextStream = AsyncIterable<string> & {
@@ -2077,6 +2138,9 @@ async function handleChatSdkMessage(
       ...(invocation.run ? { run: invocation.run } : {}),
     }
     const chatFinish = createChatFinishExtension(input, registration)
+    const progress = manualDelivery
+      ? createManualDeliveryProgressUpdater(manualDeliveryState, context.waitUntil)
+      : undefined
     const invocationInput = withChatFinishExtension(withResolvedAgentInvokerInput({
       ...(invocation.input as AgentRunInput),
       context: {
@@ -2089,18 +2153,13 @@ async function handleChatSdkMessage(
       const result = manualDelivery
         ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
         : await runAgentInline(agent as never, runContext as never, invocationInput as never)
-      const text = await collectAgentOutput(result, manualDelivery
-        ? async (summary) => {
-            if (manualDeliveryState.placeholder) {
-              await replaceManualDeliveryPlaceholder(manualDeliveryState.placeholder, { markdown: summary }).catch(() => false)
-            }
-          }
-        : undefined)
+      const text = await collectAgentOutput(result, progress?.update)
       if (!manualDelivery && text) {
         if (!await postDiscordSplitContent(thread, { markdown: text })) {
           await thread.post({ markdown: text })
         }
       }
+      await progress?.finish()
       await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState)
       if (manualDeliveryState.placeholder) await deleteManualDeliveryPlaceholder(manualDeliveryState.placeholder)
       manualDeliveryState.placeholder = undefined

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -684,6 +684,7 @@ async function collectAgentOutput(
 
 const manualDeliveryProgressDrainTimeoutMs = 100
 const baseAgentOutputSymbol = Symbol.for("vitehub.baseAgentOutput")
+const progressSummaryCapabilitySymbol = Symbol.for("vitehub.progressSummaryCapability")
 
 function progressSummaryFromEvent(event: unknown): string | undefined {
   if (!isRecord(event) || event.type !== "data-progress-summary") return
@@ -697,6 +698,16 @@ function hasAgentStructuredOutput(agent: AgentInput<ViteAgentRouteRuntimeContext
   return typeof agent === "object"
     && agent !== null
     && Object.getOwnPropertyDescriptor(agent, baseAgentOutputSymbol)?.value !== undefined
+}
+
+function hasAgentProgressSummaryCapability(agent: AgentInput<ViteAgentRouteRuntimeContext>): boolean {
+  if (typeof agent !== "object" || agent === null || !("capabilities" in agent)) return false
+  const capabilities = agent.capabilities
+  return Array.isArray(capabilities) && capabilities.some(capability =>
+    typeof capability === "object"
+    && capability !== null
+    && progressSummaryCapabilitySymbol in capability
+  )
 }
 
 function createManualDeliveryProgressUpdater(
@@ -2139,6 +2150,8 @@ async function handleChatSdkMessage(
 
     assertChatDeliveryOptions(options || {})
     const manualDelivery = options?.delivery === "manual"
+    const observesManualProgress = manualDelivery
+      && (typeof agent.run === "function" || hasAgentProgressSummaryCapability(agent))
     const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
     const thinkingFallback = invocation.metadata?.thinkingFallback
     if (manualDelivery && typeof thinkingFallback === "string") {
@@ -2151,7 +2164,7 @@ async function handleChatSdkMessage(
       ...(invocation.run ? { run: invocation.run } : {}),
     }
     const chatFinish = createChatFinishExtension(input, registration)
-    progress = manualDelivery
+    progress = observesManualProgress
       ? createManualDeliveryProgressUpdater(manualDeliveryState, context.waitUntil)
       : undefined
     const invocationInput = withChatFinishExtension(withResolvedAgentInvokerInput({
@@ -2174,7 +2187,7 @@ async function handleChatSdkMessage(
       // Manual delivery disables Chat SDK reply streaming, but still consumes
       // normalized Agent events so transient Capability output can update the
       // framework-owned placeholder without exposing ordinary Agent text.
-      const result = manualDelivery && !hasAgentStructuredOutput(agent)
+      const result = observesManualProgress && !hasAgentStructuredOutput(agent)
         ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
         : await runAgentInline(agent as never, runContext as never, invocationInput as never)
       const text = await collectAgentOutput(result, progress?.update)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2092,6 +2092,7 @@ async function handleChatSdkMessage(
   let input: AgentChatMessageTriggerInput | undefined
   let run: AgentRunMetadata | undefined
   let typing: ChatTypingRefresh | undefined
+  let progress: ReturnType<typeof createManualDeliveryProgressUpdater> | undefined
   const manualDeliveryState: { placeholder?: unknown } = {}
   try {
     input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, [chatAuthorizationUiMessage(thread, message, messageContext)], messageContext, registration.channelId)
@@ -2138,7 +2139,7 @@ async function handleChatSdkMessage(
       ...(invocation.run ? { run: invocation.run } : {}),
     }
     const chatFinish = createChatFinishExtension(input, registration)
-    const progress = manualDelivery
+    progress = manualDelivery
       ? createManualDeliveryProgressUpdater(manualDeliveryState, context.waitUntil)
       : undefined
     const invocationInput = withChatFinishExtension(withResolvedAgentInvokerInput({
@@ -2215,6 +2216,7 @@ async function handleChatSdkMessage(
   }
   catch (error) {
     typing?.stop()
+    await progress?.finish()
     await postChatErrorFallback(error, thread, message, options, input, run, manualDeliveryState.placeholder)
     throw error
   }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2171,6 +2171,9 @@ async function handleChatSdkMessage(
       },
     }, invoker), chatFinish)
     if (!streamsPhasedReplies) {
+      // Manual delivery disables Chat SDK reply streaming, but still consumes
+      // normalized Agent events so transient Capability output can update the
+      // framework-owned placeholder without exposing ordinary Agent text.
       const result = manualDelivery && !hasAgentStructuredOutput(agent)
         ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
         : await runAgentInline(agent as never, runContext as never, invocationInput as never)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -13,6 +13,7 @@ import { normalizeCapabilities } from "../capability-runtime.ts"
 import { deliveryArtifactAttachments } from "../delivery-artifacts.ts"
 import { createAgentInvocationContextStore } from "../invocation-context.ts"
 import { finalChannelOutputContextKey } from "../internal/final-channel-output.ts"
+import { agentOutputEventObserverContextKey } from "../internal/agent-output-events.ts"
 import { isAttachmentData } from "../messages.ts"
 import { resolveAgentInvoker, withResolvedAgentInvokerInput } from "../invoker.ts"
 import { createAgentRuntimeContext } from "../runtime/context.ts"
@@ -672,12 +673,8 @@ async function collectAgentOutput(
         if (event.phase === "final") finalText += event.text
       }
     }
-    if (event.type === "data-progress-summary") {
-      const summary = isRecord(event.data) && typeof event.data.summary === "string"
-        ? event.data.summary.trim()
-        : ""
-      if (summary) onProgress?.(summary)
-    }
+    const summary = progressSummaryFromEvent(event)
+    if (summary) onProgress?.(summary)
     if (event.type === "error") {
       throw new Error(event.error)
     }
@@ -687,6 +684,14 @@ async function collectAgentOutput(
 
 const manualDeliveryProgressDrainTimeoutMs = 100
 const baseAgentOutputSymbol = Symbol.for("vitehub.baseAgentOutput")
+
+function progressSummaryFromEvent(event: unknown): string | undefined {
+  if (!isRecord(event) || event.type !== "data-progress-summary") return
+  const summary = isRecord(event.data) && typeof event.data.summary === "string"
+    ? event.data.summary.trim()
+    : ""
+  return summary || undefined
+}
 
 function hasAgentStructuredOutput(agent: AgentInput<ViteAgentRouteRuntimeContext>): boolean {
   return typeof agent === "object"
@@ -2154,6 +2159,14 @@ async function handleChatSdkMessage(
       context: {
         ...(invocation.input as AgentRunInput).context,
         [messageChannelStateContextKey]: state,
+        ...(progress
+          ? {
+              [agentOutputEventObserverContextKey]: (event: unknown) => {
+                const summary = progressSummaryFromEvent(event)
+                if (summary) progress?.update(summary)
+              },
+            }
+          : {}),
         ...(options?.stream === false || manualDelivery ? { [finalChannelOutputContextKey]: true } : {}),
       },
     }, invoker), chatFinish)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -686,6 +686,13 @@ async function collectAgentOutput(
 }
 
 const manualDeliveryProgressDrainTimeoutMs = 100
+const baseAgentOutputSymbol = Symbol.for("vitehub.baseAgentOutput")
+
+function hasAgentStructuredOutput(agent: AgentInput<ViteAgentRouteRuntimeContext>): boolean {
+  return typeof agent === "object"
+    && agent !== null
+    && Object.getOwnPropertyDescriptor(agent, baseAgentOutputSymbol)?.value !== undefined
+}
 
 function createManualDeliveryProgressUpdater(
   manualDelivery: { placeholder?: unknown },
@@ -2151,7 +2158,7 @@ async function handleChatSdkMessage(
       },
     }, invoker), chatFinish)
     if (!streamsPhasedReplies) {
-      const result = manualDelivery
+      const result = manualDelivery && !hasAgentStructuredOutput(agent)
         ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
         : await runAgentInline(agent as never, runContext as never, invocationInput as never)
       const text = await collectAgentOutput(result, progress?.update)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -684,7 +684,6 @@ async function collectAgentOutput(
 
 const manualDeliveryProgressDrainTimeoutMs = 100
 const baseAgentOutputSymbol = Symbol.for("vitehub.baseAgentOutput")
-const progressSummaryCapabilitySymbol = Symbol.for("vitehub.progressSummaryCapability")
 
 function progressSummaryFromEvent(event: unknown): string | undefined {
   if (!isRecord(event) || event.type !== "data-progress-summary") return
@@ -698,16 +697,6 @@ function hasAgentStructuredOutput(agent: AgentInput<ViteAgentRouteRuntimeContext
   return typeof agent === "object"
     && agent !== null
     && Object.getOwnPropertyDescriptor(agent, baseAgentOutputSymbol)?.value !== undefined
-}
-
-function hasAgentProgressSummaryCapability(agent: AgentInput<ViteAgentRouteRuntimeContext>): boolean {
-  if (typeof agent !== "object" || agent === null || !("capabilities" in agent)) return false
-  const capabilities = agent.capabilities
-  return Array.isArray(capabilities) && capabilities.some(capability =>
-    typeof capability === "object"
-    && capability !== null
-    && progressSummaryCapabilitySymbol in capability
-  )
 }
 
 function createManualDeliveryProgressUpdater(
@@ -2150,8 +2139,6 @@ async function handleChatSdkMessage(
 
     assertChatDeliveryOptions(options || {})
     const manualDelivery = options?.delivery === "manual"
-    const observesManualProgress = manualDelivery
-      && (typeof agent.run === "function" || hasAgentProgressSummaryCapability(agent))
     const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
     const thinkingFallback = invocation.metadata?.thinkingFallback
     if (manualDelivery && typeof thinkingFallback === "string") {
@@ -2164,7 +2151,7 @@ async function handleChatSdkMessage(
       ...(invocation.run ? { run: invocation.run } : {}),
     }
     const chatFinish = createChatFinishExtension(input, registration)
-    progress = observesManualProgress
+    progress = manualDelivery
       ? createManualDeliveryProgressUpdater(manualDeliveryState, context.waitUntil)
       : undefined
     const invocationInput = withChatFinishExtension(withResolvedAgentInvokerInput({
@@ -2187,7 +2174,7 @@ async function handleChatSdkMessage(
       // Manual delivery disables Chat SDK reply streaming, but still consumes
       // normalized Agent events so transient Capability output can update the
       // framework-owned placeholder without exposing ordinary Agent text.
-      const result = observesManualProgress && !hasAgentStructuredOutput(agent)
+      const result = manualDelivery && !hasAgentStructuredOutput(agent)
         ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
         : await runAgentInline(agent as never, runContext as never, invocationInput as never)
       const text = await collectAgentOutput(result, progress?.update)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -745,10 +745,7 @@ function createManualDeliveryProgressUpdater(
       const cleanup = draining.then(async () => {
         await deleteManualDeliveryPlaceholder(stalePlaceholder).catch(() => undefined)
       })
-      waitUntil(Promise.race([
-        cleanup,
-        new Promise<void>(resolve => setTimeout(resolve, manualDeliveryProgressDrainTimeoutMs)),
-      ]))
+      waitUntil(cleanup)
     },
     update(summary) {
       if (!manualDelivery.placeholder) return

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -638,7 +638,10 @@ function fallbackWebhookFromRequest(request: Request): string | undefined {
   return new URL(request.url).pathname.split("/").filter(Boolean).at(-1) || undefined
 }
 
-async function collectAgentOutput(result: unknown): Promise<string> {
+async function collectAgentOutput(
+  result: unknown,
+  onProgress?: (summary: string) => MaybePromise<void>,
+): Promise<string> {
   if (result instanceof Response) {
     if (result.headers.get("content-type")?.includes("application/json")) {
       const body = await result.clone().json().catch(() => undefined)
@@ -668,6 +671,12 @@ async function collectAgentOutput(result: unknown): Promise<string> {
         unphasedText = ""
         if (event.phase === "final") finalText += event.text
       }
+    }
+    if (event.type === "data-progress-summary") {
+      const summary = isRecord(event.data) && typeof event.data.summary === "string"
+        ? event.data.summary.trim()
+        : ""
+      if (summary) await onProgress?.(summary)
     }
     if (event.type === "error") {
       throw new Error(event.error)
@@ -2077,8 +2086,16 @@ async function handleChatSdkMessage(
       },
     }, invoker), chatFinish)
     if (!streamsPhasedReplies) {
-      const result = await runAgentInline(agent as never, runContext as never, invocationInput as never)
-      const text = await collectAgentOutput(result)
+      const result = manualDelivery
+        ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
+        : await runAgentInline(agent as never, runContext as never, invocationInput as never)
+      const text = await collectAgentOutput(result, manualDelivery
+        ? async (summary) => {
+            if (manualDeliveryState.placeholder) {
+              await replaceManualDeliveryPlaceholder(manualDeliveryState.placeholder, { markdown: summary }).catch(() => false)
+            }
+          }
+        : undefined)
       if (!manualDelivery && text) {
         if (!await postDiscordSplitContent(thread, { markdown: text })) {
           await thread.post({ markdown: text })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7079,6 +7079,49 @@ describe("server helpers", () => {
     expect(model.stream).not.toHaveBeenCalled()
   })
 
+  it("streams manual progress summaries from invocation-resolved Capabilities", async () => {
+    const { progressSummary } = await import("../src/capabilities/progress-summary.ts")
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const model = {
+      generate: vi.fn(),
+      stream: vi.fn(async () => ({
+        fullStream: (async function* () {
+          yield { delta: "Private result", type: "text-delta" }
+          yield { finishReason: "stop", type: "finish" }
+        })(),
+      })),
+      tools: {},
+      version: "agent-v1",
+    }
+    const agent = {
+      [Symbol.for("vitehub.baseAgentCapabilitiesResolver")]: () => [
+        progressSummary({ driver: { run: () => "Reviewing the request." }, intervalMs: 0 }),
+      ],
+      capabilities: [
+        defineChatCapability({
+          delivery: "manual",
+          fallbackStreamingPlaceholderText: "Analyzing…",
+          platforms: {
+            telegram: () => adapter as never,
+          },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      resolve: vi.fn(async () => model),
+    }
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_018), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(model.generate).not.toHaveBeenCalled()
+    expect(model.stream).toHaveBeenCalledOnce()
+  })
+
   it("preserves validated structured output for explicit manual replies", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7087,6 +7087,51 @@ describe("server helpers", () => {
     expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", { markdown: "Private model output" })
   })
 
+  it("does not block manual completion on a hanging progress edit", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    let resolveProgressEdit: (() => void) | undefined
+    adapter.editMessage.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      resolveProgressEdit = resolve
+    }))
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield {
+              data: { revision: 1, summary: "Reviewing the request.", type: "progress-summary" },
+              transient: true,
+              type: "data-progress-summary",
+            }
+            yield { finishReason: "stop", type: "finish" }
+          })(),
+        }),
+      },
+      hooks: {
+        "agent:finish": event => event.reply("Final customer reply"),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_014), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.editMessage).toHaveBeenCalledOnce()
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Final customer reply" })
+    resolveProgressEdit?.()
+  })
+
   it("posts a buffered manual stream when placeholder editing fails", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7103,6 +7103,7 @@ describe("server helpers", () => {
           messages: {
             delivery: "manual",
             fallbackStreamingPlaceholderText: "Analyzing photo…",
+            stream: false,
           },
         }),
       },

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7037,6 +7037,56 @@ describe("server helpers", () => {
     expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", { markdown: "{\"internal\":\"structured output\"}" })
   })
 
+  it("updates a manual placeholder with progress summaries before the final reply", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield {
+              data: { revision: 1, summary: "Reviewing the request.", type: "progress-summary" },
+              transient: true,
+              type: "data-progress-summary",
+            }
+            yield {
+              data: { revision: 2, summary: "Checking current inventory.", type: "progress-summary" },
+              transient: true,
+              type: "data-progress-summary",
+            }
+            yield { delta: "Private model output", type: "text-delta" }
+            yield { finishReason: "stop", type: "finish" }
+          })(),
+        }),
+      },
+      hooks: {
+        "agent:finish": event => event.reply("Final customer reply"),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_013), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.postMessage).toHaveBeenCalledOnce()
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Analyzing photo…")
+    expect(adapter.editMessage).toHaveBeenNthCalledWith(1, "telegram:456", "sent-1", { markdown: "Reviewing the request." })
+    expect(adapter.editMessage).toHaveBeenNthCalledWith(2, "telegram:456", "sent-1", { markdown: "Checking current inventory." })
+    expect(adapter.editMessage).toHaveBeenNthCalledWith(3, "telegram:456", "sent-1", { markdown: "Final customer reply" })
+    expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", { markdown: "Private model output" })
+  })
+
   it("posts a buffered manual stream when placeholder editing fails", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7132,6 +7132,53 @@ describe("server helpers", () => {
     resolveProgressEdit?.()
   })
 
+  it("quiesces a hanging progress edit before manual error delivery", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    let resolveProgressEdit: (() => void) | undefined
+    adapter.editMessage.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      resolveProgressEdit = resolve
+    }))
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            errorFallbackText: "Please send the photo again.",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield {
+              data: { revision: 1, summary: "Reviewing the request.", type: "progress-summary" },
+              transient: true,
+              type: "data-progress-summary",
+            }
+            yield { error: "model timeout", type: "error" }
+          })(),
+        }),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      await expect(handler(chatWebhookRequest(91_015), "telegram")).rejects.toThrow("model timeout")
+      expect(adapter.editMessage).toHaveBeenCalledOnce()
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", "Please send the photo again.")
+      resolveProgressEdit?.()
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
   it("posts a buffered manual stream when placeholder editing fails", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7084,11 +7084,20 @@ describe("server helpers", () => {
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
+    const schema = {
+      "~standard": {
+        validate: (value: unknown) => typeof value === "object" && value !== null && "title" in value
+          ? { value }
+          : { issues: [{ message: "Expected a title." }] },
+        vendor: "vitehub-test",
+        version: 1 as const,
+      },
+    }
     const model = {
       generate: vi.fn(),
       stream: vi.fn(async () => ({
         fullStream: (async function* () {
-          yield { delta: "Private result", type: "text-delta" }
+          yield { delta: "{\"title\":\"Private result\"}", type: "text-delta" }
           yield { finishReason: "stop", type: "finish" }
         })(),
       })),
@@ -7097,8 +7106,10 @@ describe("server helpers", () => {
     }
     const agent = {
       [Symbol.for("vitehub.baseAgentCapabilitiesResolver")]: () => [
-        progressSummary({ driver: { run: () => "Reviewing the request." }, intervalMs: 0 }),
+        progressSummary({ driver: { run: () => "Reviewing the request." }, id: "progress-primary", intervalMs: 0 }),
+        progressSummary({ driver: { run: () => "Still reviewing." }, id: "progress-secondary", intervalMs: 0 }),
       ],
+      [Symbol.for("vitehub.baseAgentOutput")]: { schema },
       capabilities: [
         defineChatCapability({
           delivery: "manual",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7037,6 +7037,48 @@ describe("server helpers", () => {
     expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", { markdown: "{\"internal\":\"structured output\"}" })
   })
 
+  it("uses generate for manual delivery without progress summaries", async () => {
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const model = {
+      generate: vi.fn(async () => ({ finishReason: "stop", text: "Generated result" })),
+      stream: vi.fn(async () => ({
+        fullStream: (async function* () {
+          yield { delta: "Streamed result", type: "text-delta" }
+          yield { finishReason: "stop", type: "finish" }
+        })(),
+      })),
+      tools: {},
+      version: "agent-v1",
+    }
+    const agent = {
+      capabilities: [
+        defineChatCapability({
+          delivery: "manual",
+          platforms: {
+            telegram: () => adapter as never,
+          },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      hooks: {
+        "agent:finish": (event: { reply: (message: string) => unknown, result: { text: string } }) =>
+          event.reply(event.result.text),
+      },
+      resolve: vi.fn(async () => model),
+    }
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_017), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(model.generate).toHaveBeenCalledOnce()
+    expect(model.stream).not.toHaveBeenCalled()
+  })
+
   it("preserves validated structured output for explicit manual replies", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7037,6 +7037,54 @@ describe("server helpers", () => {
     expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", { markdown: "{\"internal\":\"structured output\"}" })
   })
 
+  it("preserves validated structured output for explicit manual replies", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const schema = {
+      "~standard": {
+        validate: (value: unknown) => typeof value === "object"
+          && value !== null
+          && "title" in value
+          && typeof value.title === "string"
+          ? { value: value as { title: string } }
+          : { issues: [{ message: "Expected a title." }] },
+        vendor: "vitehub-test",
+        version: 1 as const,
+      },
+    }
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: {
+        output: { schema },
+        run: () => ({
+          stream: (async function* () {
+            yield { delta: "{\"title\":\"Validated reply\"}", type: "text-delta" }
+            yield { finishReason: "stop", type: "finish" }
+          })(),
+        }),
+      },
+      hooks: {
+        "agent:finish": event => event.reply((event.result as { title: string }).title),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_016), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Validated reply" })
+  })
+
   it("updates a manual placeholder with progress summaries before the final reply", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7068,6 +7068,11 @@ describe("server helpers", () => {
         output: { schema },
         run: () => ({
           stream: (async function* () {
+            yield {
+              data: { revision: 1, summary: "Validating the result.", type: "progress-summary" },
+              transient: true,
+              type: "data-progress-summary",
+            }
             yield { delta: "{\"title\":\"Validated reply\"}", type: "text-delta" }
             yield { finishReason: "stop", type: "finish" }
           })(),
@@ -7082,7 +7087,8 @@ describe("server helpers", () => {
     const response = await handler(chatWebhookRequest(91_016), "telegram")
 
     expect(response.status).toBe(200)
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Validated reply" })
+    expect(adapter.editMessage).toHaveBeenNthCalledWith(1, "telegram:456", "sent-1", { markdown: "Validating the result." })
+    expect(adapter.editMessage).toHaveBeenNthCalledWith(2, "telegram:456", "sent-1", { markdown: "Validated reply" })
   })
 
   it("updates a manual placeholder with progress summaries before the final reply", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8532,6 +8532,39 @@ describe("agent message protocol", () => {
     expect(execute).toHaveBeenNthCalledWith(2, expect.objectContaining({ activeTools: ["inventory search"] }))
   })
 
+  it("generates the initial progress summary without waiting for the revision interval", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const execute = vi.fn(() => "Preparing your request.")
+    const agent = defineAgent({
+      capabilities: [progressSummary({ execute, intervalMs: 60_000 })],
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream()
+          },
+        }) },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Check inventory." })],
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    const reader = stream.getReader()
+
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: {
+        data: {
+          revision: 1,
+          summary: "Preparing your request.",
+          type: "progress-summary",
+        },
+        transient: true,
+        type: "data-progress-summary",
+      },
+    })
+    await reader.cancel()
+    expect(execute).toHaveBeenCalledOnce()
+  })
+
   it("does not lock alternate progress stream representations before one is consumed", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const execute = vi.fn(() => "Checking inventory.")
@@ -8676,7 +8709,7 @@ describe("agent message protocol", () => {
     await reader.cancel()
     await new Promise(resolve => setTimeout(resolve, 30))
 
-    expect(execute).not.toHaveBeenCalled()
+    expect(execute).toHaveBeenCalledOnce()
   })
 
   it("cleans up scheduled progress generation when the source errors", async () => {
@@ -8704,7 +8737,7 @@ describe("agent message protocol", () => {
     })()).rejects.toThrow("stream failed")
     await new Promise(resolve => setTimeout(resolve, 30))
 
-    expect(execute).not.toHaveBeenCalled()
+    expect(execute).toHaveBeenCalledOnce()
   })
 
   it("observes phased reasoning text without exposing its contents", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8470,6 +8470,68 @@ describe("agent message protocol", () => {
     }))
   })
 
+  it("emits an initial progress summary before revising it for later activity", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    let sourceController!: ReadableStreamDefaultController<unknown>
+    const execute = vi.fn((input: { activeTools: string[] }) =>
+      input.activeTools.length ? "Checking inventory." : "Preparing your request.")
+    const agent = defineAgent({
+      capabilities: [progressSummary({ execute, intervalMs: 0 })],
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              start(controller) {
+                sourceController = controller
+              },
+            })
+          },
+        }) },
+    })
+
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      messages: [createMessage({ role: "user", text: "Check inventory." })],
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    const reader = stream.getReader()
+
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: {
+        data: {
+          revision: 1,
+          summary: "Preparing your request.",
+          type: "progress-summary",
+        },
+        transient: true,
+        type: "data-progress-summary",
+      },
+    })
+
+    sourceController.enqueue({ id: "tool-1", toolName: "inventory_search", type: "tool-input-start" })
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: { id: "tool-1", toolName: "inventory_search", type: "tool-input-start" },
+    })
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: {
+        data: {
+          revision: 2,
+          summary: "Checking inventory.",
+          type: "progress-summary",
+        },
+        transient: true,
+        type: "data-progress-summary",
+      },
+    })
+
+    sourceController.enqueue({ finishReason: "stop", type: "finish" })
+    sourceController.close()
+    await reader.cancel()
+
+    expect(execute).toHaveBeenNthCalledWith(1, expect.objectContaining({ activeTools: [] }))
+    expect(execute).toHaveBeenNthCalledWith(2, expect.objectContaining({ activeTools: ["inventory search"] }))
+  })
+
   it("does not lock alternate progress stream representations before one is consumed", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const execute = vi.fn(() => "Checking inventory.")
@@ -8705,11 +8767,15 @@ describe("agent message protocol", () => {
     }, { output: "ui-message-stream" }) as ReadableStream<unknown>
     for await (const _chunk of stream) {}
 
-    expect(execute).toHaveBeenCalledTimes(2)
+    expect(execute).toHaveBeenCalledTimes(3)
     expect(execute.mock.calls[0]?.[0]).toEqual(expect.objectContaining({
-      reasoning: "Active",
+      activeTools: [],
+      reasoning: undefined,
     }))
     expect(execute.mock.calls[1]?.[0]).toEqual(expect.objectContaining({
+      reasoning: "Active",
+    }))
+    expect(execute.mock.calls[2]?.[0]).toEqual(expect.objectContaining({
       activeTools: ["inventory search"],
       reasoning: undefined,
     }))
@@ -8719,7 +8785,7 @@ describe("agent message protocol", () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const session = { destroy: vi.fn() }
     harnessCreateSession.mockResolvedValueOnce(session)
-    harnessGenerate.mockResolvedValueOnce({ text: "Reviewing availability for Acme." })
+    harnessGenerate.mockResolvedValue({ text: "Reviewing availability for Acme." })
     const agent = defineAgent({
       capabilities: [
         progressSummary({
@@ -8756,6 +8822,11 @@ describe("agent message protocol", () => {
     expect((harnessGenerate.mock.calls[0]![0] as { prompt: string }).prompt).toBe([
       "Customer: Acme",
       "Request: Why did availability change?",
+      "Tools: None",
+    ].join("\n"))
+    expect((harnessGenerate.mock.calls[1]![0] as { prompt: string }).prompt).toBe([
+      "Customer: Acme",
+      "Request: Why did availability change?",
       "Tools: inventory search",
     ].join("\n"))
     expect(harnessAgentSettings.at(-1)).toMatchObject({
@@ -8766,7 +8837,7 @@ describe("agent message protocol", () => {
   it("resolves built-in progress summary drivers", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
-    harnessGenerate.mockResolvedValueOnce({ text: "Checking inventory." })
+    harnessGenerate.mockResolvedValue({ text: "Checking inventory." })
     const agent = defineAgent({
       capabilities: [
         progressSummary({
@@ -8793,7 +8864,7 @@ describe("agent message protocol", () => {
     const chunks = []
     for await (const chunk of stream) chunks.push(chunk)
 
-    expect(harnessGenerate).toHaveBeenCalledOnce()
+    expect(harnessGenerate).toHaveBeenCalledTimes(2)
     expect(chunks).toContainEqual(expect.objectContaining({
       type: "data-progress-summary",
     }))
@@ -8803,7 +8874,7 @@ describe("agent message protocol", () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const session = { destroy: vi.fn() }
     harnessCreateSession.mockResolvedValueOnce(session)
-    harnessGenerate.mockResolvedValueOnce({ text: "Checking inventory." })
+    harnessGenerate.mockResolvedValue({ text: "Checking inventory." })
     const agent = defineAgent({
       capabilities: [
         progressSummary({
@@ -8835,9 +8906,12 @@ describe("agent message protocol", () => {
     }, { output: "ui-message-stream" }) as ReadableStream<unknown>
     for await (const _chunk of stream) {}
 
-    const prompt = (harnessGenerate.mock.calls[0]![0] as { prompt: string }).prompt
-    expect(prompt).toContain("Active tools: inventory search")
-    expect(prompt).not.toMatch(/rm private|private\/path|sk-secret|hidden instructions/)
+    const prompts = harnessGenerate.mock.calls.map(call => (call[0] as { prompt: string }).prompt)
+    expect(prompts[0]).toContain("Active tools: None")
+    expect(prompts[1]).toContain("Active tools: inventory search")
+    for (const prompt of prompts) {
+      expect(prompt).not.toMatch(/rm private|private\/path|sk-secret|hidden instructions/)
+    }
   })
 
   it("does not read text getters when streaming native UI message results", async () => {


### PR DESCRIPTION
Manual Channel delivery now edits its existing placeholder with transient `data-progress-summary` updates while an Agent runs. It requests normalized events only for manual delivery with `progressSummary()`, keeps ordinary Agent text private, and leaves explicit finish replies in charge of final delivery, so the final reply replaces the progress state without duplicate posts. Automatic delivery and manual runs without summaries keep the behavior established in #858.

`progressSummary()` now generates an initial sanitized snapshot when its stream starts, then revises that snapshot after reasoning or tool activity. This keeps generation in the Capability introduced by #819 while Chat SDK adapters continue to own platform presentation, and removes the need for downstream apps to patch generated Agent runtime code.

Validated with 509 focused Agent provider/runtime tests, Agent typecheck, Agent build and publint, docs typecheck, `git diff --check`, and an independent scope and simplification review.