### PR TITLE
fix(vite-hub): apply deployment Nitro presets only during build

### DIFF
--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -293,7 +293,8 @@ function deploymentPlugins(
           throw new Error("[vitehub] Blob is disabled but the application imports " + JSON.stringify(source) + ".")
         }
       },
-      config(config) {
+      config(config, environment) {
+        const building = environment.command === "build"
         for (const service of requestedServices) assertDeploymentService(plan, service)
         const identity = resolveDeploymentIdentity(
           typeof config.root === "string" ? config.root : undefined,
@@ -342,35 +343,38 @@ function deploymentPlugins(
           nitro.cloudflare = cloudflare
         }
         const configuredPreset = typeof nitro.preset === "string" ? nitro.preset : undefined
-        if (configuredPreset && normalizeNitroPreset(configuredPreset) !== plan.nitroPreset) {
-          throw new Error("[vitehub] vitehub preset " + JSON.stringify(plan.preset) + " conflicts with nitro.preset " + JSON.stringify(configuredPreset) + ".")
-        }
-        for (const name of ["NITRO_PRESET", "SERVER_PRESET"] as const) {
-          const value = process.env[name]
-          if (value && normalizeNitroPreset(value) !== plan.nitroPreset) {
-            throw new Error("[vitehub] vitehub preset " + JSON.stringify(plan.preset) + " conflicts with " + name + "=" + JSON.stringify(value) + ".")
-          }
-        }
         const configuredHosting = process.env.VITEHUB_HOSTING
         if (configuredHosting && deploymentPresetFromNitro(configuredHosting) !== plan.preset) {
           throw new Error("[vitehub] vitehub preset " + JSON.stringify(plan.preset) + " conflicts with VITEHUB_HOSTING=" + JSON.stringify(configuredHosting) + ".")
         }
-        nitro.modules = [
-          ...(Array.isArray(nitro.modules) ? nitro.modules : []),
-          deploymentNitroModule(plan, services, identity),
-        ]
-        if (plan.output.packaging === "deno-node-modules") {
-          nitro.commands = { ...cloneRecord(nitro.commands), deploy: "node ./deploy.mjs" }
-          const rollupConfig = cloneRecord(nitro.rollupConfig)
-          const output = Array.isArray(rollupConfig.output)
-            ? rollupConfig.output.map(options => ({ ...cloneRecord(options), entryFileNames: "index.mjs" }))
-            : { ...cloneRecord(rollupConfig.output), entryFileNames: "index.mjs" }
-          nitro.rollupConfig = {
-            ...rollupConfig,
-            output,
+        if (building) {
+          if (configuredPreset && normalizeNitroPreset(configuredPreset) !== plan.nitroPreset) {
+            throw new Error("[vitehub] vitehub preset " + JSON.stringify(plan.preset) + " conflicts with nitro.preset " + JSON.stringify(configuredPreset) + ".")
           }
+          for (const name of ["NITRO_PRESET", "SERVER_PRESET"] as const) {
+            const value = process.env[name]
+            if (value && normalizeNitroPreset(value) !== plan.nitroPreset) {
+              throw new Error("[vitehub] vitehub preset " + JSON.stringify(plan.preset) + " conflicts with " + name + "=" + JSON.stringify(value) + ".")
+            }
+          }
+          nitro.modules = [
+            ...(Array.isArray(nitro.modules) ? nitro.modules : []),
+            deploymentNitroModule(plan, services, identity),
+          ]
+          if (plan.output.packaging === "deno-node-modules") {
+            nitro.commands = { ...cloneRecord(nitro.commands), deploy: "node ./deploy.mjs" }
+            const rollupConfig = cloneRecord(nitro.rollupConfig)
+            const output = Array.isArray(rollupConfig.output)
+              ? rollupConfig.output.map(options => ({ ...cloneRecord(options), entryFileNames: "index.mjs" }))
+              : { ...cloneRecord(rollupConfig.output), entryFileNames: "index.mjs" }
+            nitro.rollupConfig = {
+              ...rollupConfig,
+              output,
+            }
+          }
+          nitro.preset = plan.nitroPreset
         }
-        ;(config as { nitro?: unknown }).nitro = { ...nitro, preset: plan.nitroPreset }
+        ;(config as { nitro?: unknown }).nitro = nitro
       },
     },
     {
@@ -378,7 +382,7 @@ function deploymentPlugins(
       enforce: "post",
       configResolved(config) {
         const nitro = cloneRecord((config as { nitro?: unknown }).nitro)
-        if (nitro.preset !== plan.nitroPreset) {
+        if (config.command === "build" && nitro.preset !== plan.nitroPreset) {
           throw new Error("[vitehub] The " + JSON.stringify(plan.preset) + " deployment plan requires Nitro preset " + JSON.stringify(plan.nitroPreset) + ".")
         }
       },

--- a/packages/vite-hub/test/deployment-integration.test.ts
+++ b/packages/vite-hub/test/deployment-integration.test.ts
@@ -24,6 +24,55 @@ describe("built-in deployment preset integration", () => {
     expect((config as typeof config & { nitro?: { preset?: string } }).nitro?.preset).toBeTruthy()
   })
 
+  it("applies deployment-owned Nitro configuration only during build", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-preset-command-"))
+    try {
+      const developmentConfig = {
+        nitro: {
+          modules: ["local-module"],
+          preset: "node-server",
+        },
+        root,
+        plugins: [vitehub({
+          preset: "cloudflare",
+          blob: false,
+          env: false,
+          queue: false,
+          rateLimit: false,
+        })],
+      } as Parameters<typeof resolveConfig>[0] & {
+        nitro: { modules: string[], preset: string }
+      }
+      const development = await resolveConfig(developmentConfig, "serve")
+      expect((development as typeof development & {
+        nitro?: { modules?: unknown[], preset?: string }
+      }).nitro).toMatchObject({
+        modules: ["local-module"],
+        preset: "node-server",
+      })
+
+      const production = await resolveConfig({
+        root,
+        plugins: [vitehub({
+          preset: "cloudflare",
+          blob: false,
+          env: false,
+          queue: false,
+          rateLimit: false,
+        })],
+      }, "build")
+      expect((production as typeof production & {
+        nitro?: { modules?: unknown[], preset?: string }
+      }).nitro).toMatchObject({
+        modules: [expect.any(Function)],
+        preset: "cloudflare-module",
+      })
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("preserves a Worker name configured through the Nitro plugin", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-worker-name-"))
     try {

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -441,6 +441,32 @@ describe("vitehub", () => {
     }
   })
 
+  it("keeps deployment-owned Nitro configuration out of development", async () => {
+    const config = {
+      nitro: {
+        commands: { preview: "node ./preview.mjs" },
+        modules: ["local-module"],
+        preset: "node-server",
+        rollupConfig: { output: { chunkFileNames: "chunks/[name].mjs" } },
+      },
+    } as Record<string, unknown>
+    const plugins = vitehub({ preset: "deno" })
+    const presetPlugin = plugins.find(candidate => (candidate as Plugin).name === "vite-hub/deployment-preset") as Plugin
+    const presetHook = presetPlugin.config as unknown as (
+      config: Record<string, unknown>,
+      env: { command: "serve", mode: string },
+    ) => void
+
+    await presetHook(config, { command: "serve", mode: "development" })
+
+    expect(config.nitro).toEqual({
+      commands: { preview: "node ./preview.mjs" },
+      modules: ["local-module"],
+      preset: "node-server",
+      rollupConfig: { output: { chunkFileNames: "chunks/[name].mjs" } },
+    })
+  })
+
   it("preserves array-valued Rollup outputs for Deno", async () => {
     const config = {
       nitro: {


### PR DESCRIPTION
Keeps deployment-owned Nitro configuration out of Vite's development server. `vitehub({ preset })` now preserves the application's local Nitro preset, modules, commands, and Rollup output during `serve`, while builds still enforce the selected deployment plan, append its output module, and apply Deno packaging. Plan-derived service configuration and explicit `VITEHUB_HOSTING` selection keep their existing behavior.

The root cause was the deployment preset config hooks applying their Nitro build mutations and final preset guard for both Vite commands. Regression coverage now resolves real `serve` and `build` configs side by side and directly proves Deno development configuration remains unchanged.

Validated with `pnpm --filter vite-hub test` (8 files, 73 tests, no type errors), `pnpm --filter vite-hub typecheck`, focused oxlint, and `git diff --check`.