### PR TITLE
feat(database): support remote D1 during development

### DIFF
--- a/docs/content/docs/server-primitives/database.md
+++ b/docs/content/docs/server-primitives/database.md
@@ -120,7 +120,7 @@ A project uses either one Default Database or a set of Named Databases. Do not m
 | `connection.authToken` | `DatabaseConfigValue` | No | Hosted database auth token. |
 | `cloudflare.binding` | `string` | No | D1 binding. Defaults to `DB` for Default Database and `DB_<NAME>` for Named Databases. |
 | `cloudflare.databaseId` | `DatabaseConfigValue` | No | D1 database id. |
-| `cloudflare.http` | `true \| { url, authToken }` | No | Explicitly selects authenticated D1 raw HTTP access for hosted runtimes. `true` uses Cloudflare's API; an object selects a compatible proxy. |
+| `cloudflare.http` | `true \| { url, authToken }` | No | Explicitly selects authenticated D1 raw HTTP access for local and hosted runtimes. `true` uses Cloudflare's API; an object selects a compatible proxy. |
 | `cloudflare.previewDatabaseId` | `DatabaseConfigValue` | No | D1 preview database id. |
 | `cloudflare.databaseName` | `DatabaseConfigValue` | No | D1 database name. |
 | `cloudflare.migrationsTable` | `string` | No | D1 migrations table. |
@@ -175,11 +175,11 @@ export default defineEventHandler(() => {
 | --- | --- | --- |
 | Local SQLite | `connection.url` or no connection config | Default for local development and generated Drizzle artifacts. |
 | Hosted SQLite/libSQL-style connection | `connection.url` and optional `connection.authToken` | Keep URLs and tokens in Server Env when they are secrets. |
-| Cloudflare D1 | `cloudflare` Definition options or integration-level `database.driver: 'd1'` | Uses a D1 binding on Cloudflare. Hosted Vercel output uses D1 only when `cloudflare.http` is selected explicitly. |
+| Cloudflare D1 | `cloudflare` Definition options or integration-level `database.driver: 'd1'` | Uses a D1 binding on Cloudflare. Local development and hosted Vercel output use D1 only when `cloudflare.http` is selected explicitly. |
 
-### Use Cloudflare D1 from Vercel
+### Use Cloudflare D1 over HTTP
 
-A Database Definition can use the same D1 database from Cloudflare and Vercel. Cloudflare output prefers the configured binding. Set `cloudflare.http: true` to make Vercel call Cloudflare's D1 raw API with `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` from Server Env.
+A Database Definition can use the same D1 database during local development and from hosted providers. Cloudflare output prefers the configured binding. Set `cloudflare.http: true` to call Cloudflare's D1 raw API with `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN` from Server Env.
 
 ```ts [server/databases/config.ts]
 import { defineDatabase } from '@vite-hub/database'
@@ -221,7 +221,7 @@ Selecting D1 HTTP also generates Drizzle Kit's `d1-http` credentials. Migration 
 Cloudflare describes its built-in D1 REST API as best suited to administrative use because the global Cloudflare API rate limit applies. For sustained application traffic, use a narrowly authenticated proxy Worker and validate which queries or tables it may access. See Cloudflare's [D1 proxy Worker guide](https://developers.cloudflare.com/d1/tutorials/build-an-api-to-access-d1/).
 ::
 
-Omitting `cloudflare.http` preserves the existing hosted libSQL selection even when `cloudflare.databaseId` is present.
+Omitting `cloudflare.http` preserves local SQLite and the existing hosted libSQL selection even when `cloudflare.databaseId` is present.
 
 ### Select a hosted database for Vercel
 

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -61,6 +61,22 @@ Use `src/database.ts` or `server/databases/config.ts` for one default database. 
 
 `defineDatabase()` also returns the typed Drizzle database, so application code can import a definition directly and query it without another runtime factory.
 
+## Remote D1 development
+
+Set `cloudflare.http` on a Database Definition to query remote D1 during local development. `true` uses Cloudflare's API with `CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`; an object selects an authenticated D1-compatible proxy.
+
+```ts
+export default defineDatabase({
+  cloudflare: {
+    databaseId: process.env.CLOUDFLARE_D1_DATABASE_ID,
+    http: true,
+  },
+  schema,
+})
+```
+
+Remote access is explicit. Omitting `cloudflare.http` keeps the local SQLite default, and a Cloudflare deployment still prefers its D1 binding.
+
 ## Nuxt D1 host wiring
 
 Nuxt apps can declare one D1 database resource and let the Database Nuxt bridge wire framework consumers and Cloudflare output.

--- a/packages/database/src/runtime/definition-hosted.ts
+++ b/packages/database/src/runtime/definition-hosted.ts
@@ -10,7 +10,6 @@ export function createDefinitionRuntime<TSchema extends Record<string, unknown>>
   definition: DatabaseDefinition<TSchema>,
 ): RuntimeDrizzleDatabase<TSchema> {
   return createDrizzleSqliteAdapter(runtimeConfig(definition), definition.schema, {
-    cloudflareD1Http: true,
     libsql: { createClient, drizzle: drizzleLibsql as never },
     missingConnectionMessage: config => `[vitehub] Hosted database "${config.name}" requires a Cloudflare D1 binding, D1 HTTP configuration, or remote libSQL URL.`,
     requireRemoteUrl: true,

--- a/packages/database/src/runtime/drizzle-adapter.ts
+++ b/packages/database/src/runtime/drizzle-adapter.ts
@@ -25,7 +25,6 @@ interface LibsqlClientFactory {
 }
 
 interface DrizzleSqliteAdapterOptions {
-  cloudflareD1Http?: boolean
   libsql: LibsqlClientFactory
   requireRemoteUrl: boolean
   resolveLocalUrl?: (url: string) => string
@@ -76,7 +75,7 @@ function validateD1HttpUrl(value: string, name: string) {
     if (url.protocol === "http:" || url.protocol === "https:") return value
   }
   catch {}
-  throw new Error(`[vitehub] Hosted Cloudflare D1 database "${name}" requires cloudflare.http.url to be an HTTP(S) URL.`)
+  throw new Error(`[vitehub] Cloudflare D1 database "${name}" requires cloudflare.http.url to be an HTTP(S) URL.`)
 }
 
 function isD1HttpPayload(value: unknown): value is D1HttpPayload {
@@ -94,7 +93,7 @@ function resolveCloudflareD1HttpConnection(config: RuntimeDrizzleDatabaseConfig,
     const accountId = process.env.CLOUDFLARE_ACCOUNT_ID?.trim()
     const token = process.env.CLOUDFLARE_API_TOKEN?.trim()
     if (!accountId || !token) {
-      throw new Error(`[vitehub] Hosted Cloudflare D1 database "${config.name}" requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN when cloudflare.http is true.`)
+      throw new Error(`[vitehub] Cloudflare D1 database "${config.name}" requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN when cloudflare.http is true.`)
     }
     return {
       token,
@@ -105,7 +104,7 @@ function resolveCloudflareD1HttpConnection(config: RuntimeDrizzleDatabaseConfig,
   const token = resolveConfigValue(http.authToken)?.trim()
   const url = resolveConfigValue(http.url)?.trim()
   if (!token || !url) {
-    throw new Error(`[vitehub] Hosted Cloudflare D1 database "${config.name}" requires cloudflare.http.url and cloudflare.http.authToken at runtime.`)
+    throw new Error(`[vitehub] Cloudflare D1 database "${config.name}" requires cloudflare.http.url and cloudflare.http.authToken at runtime.`)
   }
   return { token, url: validateD1HttpUrl(url, config.name) }
 }
@@ -197,10 +196,11 @@ export function createDrizzleSqliteAdapter<TSchema extends Record<string, unknow
       return instance
     }
 
-    const databaseId = options.cloudflareD1Http && config.cloudflare?.http
-      ? resolveConfigValue(config.cloudflare?.databaseId)?.trim()
-      : undefined
-    if (databaseId) {
+    if (config.cloudflare?.http) {
+      const databaseId = resolveConfigValue(config.cloudflare.databaseId)?.trim()
+      if (!databaseId) {
+        throw new Error(`[vitehub] Cloudflare D1 database "${config.name}" requires cloudflare.databaseId when cloudflare.http is configured.`)
+      }
       const http = resolveCloudflareD1HttpConnection(config, databaseId)!
       if (d1HttpInstance && d1HttpInstanceUrl === http.url && d1HttpInstanceToken === http.token) {
         return d1HttpInstance

--- a/packages/database/src/runtime/hosted.ts
+++ b/packages/database/src/runtime/hosted.ts
@@ -12,7 +12,6 @@ export function createHostedDrizzleDb<TSchema extends Record<string, unknown>>(
   schema: TSchema,
 ) {
   return createDrizzleSqliteAdapter(dbConfig, schema, {
-    cloudflareD1Http: true,
     libsql: { createClient, drizzle: drizzleLibsql as never },
     missingConnectionMessage: config => `[vitehub] Hosted DB "${config.name}" requires an active Cloudflare D1 binding, cloudflare.http with databaseId, or a remote libSQL URL.`,
     requireRemoteUrl: true,

--- a/packages/database/test/runtime.test.ts
+++ b/packages/database/test/runtime.test.ts
@@ -70,6 +70,21 @@ async function createHostedAnalyticsDb(http: true | { authToken: string, url: st
   return { db }
 }
 
+async function createLocalAnalyticsDb(http: true | { authToken: string, url: string } = true) {
+  const { createDefinitionRuntime } = await import("../src/runtime/definition-local.ts")
+  const db = createDefinitionRuntime({
+    cloudflare: {
+      binding: "DB_ANALYTICS",
+      databaseId: "analytics-d1-id",
+      http,
+    },
+    drizzle: {},
+    name: "analytics",
+    schema: analyticsSchema,
+  })
+  return { db }
+}
+
 function createD1Response(...rows: unknown[][][]) {
   return new Response(JSON.stringify({
     result: rows.map(resultRows => ({ results: { rows: resultRows }, success: true })),
@@ -78,6 +93,15 @@ function createD1Response(...rows: unknown[][][]) {
     headers: { "Content-Type": "application/json" },
     status: 200,
   })
+}
+
+function expectD1HttpRequest(
+  [url, request]: [Parameters<typeof fetch>[0], Parameters<typeof fetch>[1]?],
+  options: { authToken: string, table: string, url: string },
+) {
+  expect(url).toBe(options.url)
+  expect(request?.headers).toMatchObject({ Authorization: `Bearer ${options.authToken}` })
+  expect(JSON.parse(String(request?.body))).toMatchObject({ params: [], sql: expect.stringContaining(options.table) })
 }
 
 ;(vi.mock as any)("#vitehub/database/schema", () => ({
@@ -212,6 +236,8 @@ describe("drizzle runtime", () => {
     tempDir = await mkdtemp(join(tmpdir(), "vitehub-db-runtime-"))
     runtimeState.dbPath = `file:${join(tempDir, "db.sqlite")}`
     runtimeState.analyticsDbPath = `file:${join(tempDir, "analytics.sqlite")}`
+    const fetchMock = vi.fn()
+    vi.stubGlobal("fetch", fetchMock)
 
     const { databases, db } = await import("../src/drizzle.ts")
 
@@ -235,6 +261,46 @@ describe("drizzle runtime", () => {
 
     expect(await databases.default.db.select().from(defaultSchema.notes)).toEqual([{ id: 1, title: "runtime note" }])
     expect(await databases.analytics.db.select().from(analyticsSchema.analyticsEvents)).toEqual([{ id: 1, name: "page-view" }])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it("queries configured Cloudflare D1 over HTTP from the generated local runtime", async () => {
+    runtimeDatabaseEntriesFactory = () => ({
+      analytics: {
+        config: {
+          cloudflare: {
+            binding: "DB_ANALYTICS",
+            databaseId: "analytics-d1-id",
+            http: {
+              authToken: "proxy-token",
+              url: "https://d1.example.com/raw",
+            },
+            migrationsDir: "src/database/analytics/migrations",
+          },
+          dialect: "sqlite",
+          drizzle: {},
+          generatedSchemaFile: ".vitehub/database/schema/analytics.ts",
+          migrationsDir: "src/database/analytics/migrations",
+          mode: "named",
+          name: "analytics",
+          orm: "drizzle",
+        },
+        schema: analyticsSchema,
+      },
+    })
+    vi.resetModules()
+    const fetchMock = vi.fn(async (_input: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) => createD1Response([[1, "page-view"]]))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { databases } = await import("../src/runtime/drizzle-runtime.ts")
+    await expect(databases.analytics.db.select().from(analyticsSchema.analyticsEvents)).resolves.toEqual([{ id: 1, name: "page-view" }])
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expectD1HttpRequest(fetchMock.mock.calls[0]!, {
+      authToken: "proxy-token",
+      table: "analytics_events",
+      url: "https://d1.example.com/raw",
+    })
   })
 
   it("prefers an active Cloudflare D1 binding over the configured fallback URL", async () => {
@@ -275,6 +341,42 @@ describe("database definition runtime", () => {
     expect(database.schema).toBe(defaultSchema)
     expect((database as unknown as { dialect: unknown }).dialect).not.toBe("sqlite")
     expect(await database.select().from(defaultSchema.notes)).toEqual([{ id: 1, title: "definition note" }])
+  })
+
+  it("queries configured Cloudflare D1 over HTTP from a local definition", async () => {
+    const fetchMock = vi.fn(async (_input: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) => createD1Response([[1, "page-view"]]))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const { db } = await createLocalAnalyticsDb({
+      authToken: "proxy-token",
+      url: "https://d1.example.com/raw",
+    })
+    await expect(db.select().from(analyticsSchema.analyticsEvents)).resolves.toEqual([{ id: 1, name: "page-view" }])
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    expectD1HttpRequest(fetchMock.mock.calls[0]!, {
+      authToken: "proxy-token",
+      table: "analytics_events",
+      url: "https://d1.example.com/raw",
+    })
+  })
+
+  it("requires a database id when local D1 HTTP is selected", async () => {
+    const { createDefinitionRuntime } = await import("../src/runtime/definition-local.ts")
+    const db = createDefinitionRuntime({
+      cloudflare: {
+        http: {
+          authToken: "proxy-token",
+          url: "https://d1.example.com/raw",
+        },
+      },
+      connection: { url: "file:.data/analytics.sqlite" },
+      drizzle: {},
+      name: "analytics",
+      schema: analyticsSchema,
+    })
+
+    expect(() => db.run).toThrow("Cloudflare D1 database \"analytics\" requires cloudflare.databaseId when cloudflare.http is configured.")
   })
 
   it("accepts normalized nested database names", async () => {
@@ -496,7 +598,7 @@ describe("hosted drizzle runtime", () => {
     vi.stubEnv("CLOUDFLARE_ACCOUNT_ID", "")
     vi.stubEnv("CLOUDFLARE_API_TOKEN", "")
     const { db } = await createHostedAnalyticsDb()
-    expect(() => db.run).toThrow("Hosted Cloudflare D1 database \"analytics\" requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN when cloudflare.http is true.")
+    expect(() => db.run).toThrow("Cloudflare D1 database \"analytics\" requires CLOUDFLARE_ACCOUNT_ID and CLOUDFLARE_API_TOKEN when cloudflare.http is true.")
   })
 
   it("requires both configured proxy values without falling back to Cloudflare credentials", async () => {

--- a/packages/database/test/vite.test.ts
+++ b/packages/database/test/vite.test.ts
@@ -1,8 +1,10 @@
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
-import { dirname, join } from "node:path"
+import { createServer as createHttpServer, type Server } from "node:http"
+import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises"
+import { dirname, join, resolve } from "node:path"
 import { tmpdir } from "node:os"
 
 import { afterEach, describe, expect, it } from "vitest"
+import { createServer as createViteServer } from "vite"
 
 import {
   DB_VIRTUAL_DATABASES_ID,
@@ -44,11 +46,90 @@ async function resolveCliContributor(plugin: ReturnType<typeof hubDb>) {
   return typeof cli === "function" ? await cli() : cli
 }
 
+async function listenHttpServer(server: Server) {
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", resolve)
+  })
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("Expected TCP server address.")
+  return `http://127.0.0.1:${address.port}`
+}
+
+async function closeHttpServer(server: Server) {
+  if (!server.listening) return
+  await new Promise<void>((resolve, reject) => server.close(error => error ? reject(error) : resolve()))
+}
+
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
 })
 
 describe("hubDb", () => {
+  it("routes Vite development queries through configured Cloudflare D1 HTTP", async () => {
+    const rootDir = await createTempProject()
+    await symlink(resolve(import.meta.dirname, "../../../node_modules"), join(rootDir, "node_modules"), "dir")
+    let proxyRequest: { authorization?: string, body?: unknown, method?: string, path?: string } = {}
+    const proxy = createHttpServer(async (request, response) => {
+      let body = ""
+      for await (const chunk of request) body += chunk
+      proxyRequest = {
+        authorization: request.headers.authorization,
+        body: JSON.parse(body),
+        method: request.method,
+        path: request.url,
+      }
+      response.setHeader("Content-Type", "application/json")
+      response.end(JSON.stringify({
+        result: [{ results: { rows: [["remote note"]] }, success: true }],
+        success: true,
+      }))
+    })
+    const proxyUrl = await listenHttpServer(proxy)
+
+    await writeDefinition(rootDir, "server/databases/config.ts", "notes", {
+      cloudflare: [
+        "    databaseId: 'dev-database-id',",
+        "    http: {",
+        "      authToken: 'dev-proxy-token',",
+        `      url: ${JSON.stringify(`${proxyUrl}/raw`)},`,
+        "    },",
+      ].join("\n"),
+    })
+    await mkdir(join(rootDir, "server"), { recursive: true })
+    await writeFile(join(rootDir, "server", "query.ts"), [
+      "import { db, schema } from '@vite-hub/database/drizzle'",
+      "export const query = () => db.select().from(schema.notes)",
+      "",
+    ].join("\n"))
+    await writeFile(join(rootDir, "index.html"), "<div>ViteHub Database</div>")
+
+    const server = await createViteServer({
+      configFile: false,
+      plugins: [hubDb()],
+      root: rootDir,
+      server: { host: "127.0.0.1", port: 0 },
+    })
+
+    try {
+      await server.listen()
+      const module = await server.ssrLoadModule(join(rootDir, "server", "query.ts")) as {
+        query: () => Promise<Array<{ title: string }>>
+      }
+
+      await expect(module.query()).resolves.toEqual([{ title: "remote note" }])
+      expect(proxyRequest).toMatchObject({
+        authorization: "Bearer dev-proxy-token",
+        body: { params: [], sql: expect.stringContaining("notes") },
+        method: "POST",
+        path: "/raw",
+      })
+    }
+    finally {
+      await Promise.all([server.close(), closeHttpServer(proxy)])
+    }
+  }, 30_000)
+
   it("exposes integration connection defaults to direct definitions", async () => {
     const plugin = hubDb({
       connection: {


### PR DESCRIPTION
Local Database Definitions now honor the existing `cloudflare.http` transport during development, so both direct `defineDatabase()` use and generated `@vite-hub/database/drizzle` queries can reach remote Cloudflare D1. The active binding still wins on Cloudflare, omitting `cloudflare.http` keeps local SQLite unchanged, and selecting HTTP without a database id fails before any local fallback.

This keeps provider selection inside the Database Definition instead of adding `database.remote` or a process-global mode flag. The shared adapter now treats explicit `cloudflare.http` as the single transport gate across runtimes, which lets Calories remove its downstream patch after moving the opt-in beside its Cloudflare database id.

A Vite development regression loads the generated Drizzle runtime and proves a query reaches an authenticated D1-compatible HTTP endpoint with the expected URL, authorization, SQL body, and returned rows. Direct-definition, missing-id, and local-SQLite regressions cover the other runtime paths. The full Database suite passes 96 tests with no type errors; Database typecheck, focused lint, docs typecheck, package build/publint, and diff checks also pass.
