### PR TITLE
fix(agent): type generated lazy chat state

### DIFF
--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -943,7 +943,7 @@ function generatedCloudflareChatStateHelper(): string[] {
   ]
 }
 
-function generatedLibsqlChatStateHelper(state: GeneratedLibsqlAgentStateOptions): string[] {
+function generatedLibsqlChatStateHelper(state: GeneratedLibsqlAgentStateOptions, typescript = false): string[] {
   const { authTokenEnvName, durableUrlRequired, ephemeralHosting, ...stateOptions } = state
   const configuredAuthTokenOption = authTokenEnvName
     ? [`  ...(typeof process === 'object' && process.env[${JSON.stringify(authTokenEnvName)}] ? { authToken: process.env[${JSON.stringify(authTokenEnvName)}] } : {}),`]
@@ -951,7 +951,7 @@ function generatedLibsqlChatStateHelper(state: GeneratedLibsqlAgentStateOptions)
   return [
     "",
     `const viteHubChatStateOptions = ${JSON.stringify(stateOptions)}`,
-    "let viteHubChatState",
+    `let viteHubChatState${typescript ? ": ReturnType<typeof createLibsqlAgentState> | undefined" : ""}`,
     "",
     "function chatStateFromLibsql() {",
     "  const runtimeUrl = typeof process === 'object' ? process.env.VITEHUB_AGENT_STATE_URL : undefined",
@@ -1200,7 +1200,7 @@ async function generateAgentWebhookRouteHandler(
     "",
     ...generatedRuntimeHelpers(),
     ...(options.cloudflareState ? generatedCloudflareChatStateHelper() : []),
-    ...(options.libsqlState ? generatedLibsqlChatStateHelper(options.libsqlState) : []),
+    ...(options.libsqlState ? generatedLibsqlChatStateHelper(options.libsqlState, true) : []),
     "",
     ...routeCapabilities.setup,
     `const chatRoutePattern = new RegExp(${JSON.stringify(routeRegexSource(options.chatRoute))})`,
@@ -1467,7 +1467,7 @@ async function generateAgentDenoServer(
     "})",
     "",
     ...deploymentCatalog.setup,
-    ...(options.libsqlState ? generatedLibsqlChatStateHelper(options.libsqlState) : []),
+    ...(options.libsqlState ? generatedLibsqlChatStateHelper(options.libsqlState, true) : []),
     ...routeCapabilities.setup,
     "function jsonError(status, message) {",
     "  return Response.json({ error: true, status, statusText: message, message }, { status })",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -674,6 +674,7 @@ describe("agent Vite plugin", () => {
       await closeBundle.handler()
 
       const wrapper = await readFile(join(root, ".vitehub/agent/netlify-function.mjs"), "utf8")
+      await execFileAsync(process.execPath, ["--check", join(root, ".vitehub/agent/netlify-function.mjs")])
       expect(wrapper).toContain("export default async function viteHubAgentNetlifyFunction(request, context)")
       expect(wrapper).toContain("import { setAgentWorkflowRuntimeLoaders as vitehubSetAgentWorkflowRuntimeLoaders } from \"@vite-hub/agent/server/internal\"")
       expect(wrapper).toContain("state: () => import(\"vite-hub/_internal/workflow/runtime/state\")")
@@ -695,6 +696,8 @@ describe("agent Vite plugin", () => {
       expect(wrapper).toContain("routePath(webhookRoute, { agent, webhook })")
       expect(wrapper).toContain("import { createLibsqlAgentState } from \"@vite-hub/agent/state/sqlite\"")
       expect(wrapper).toContain("const viteHubChatStateOptions = {\"tablePrefix\":\"agent_state_\",\"url\":\"libsql://state.example.test\"}")
+      expect(wrapper).toContain("let viteHubChatState\n")
+      expect(wrapper).not.toContain("let viteHubChatState:")
       expect(wrapper).not.toContain("build-token")
       expect(wrapper).toContain("function chatStateFromLibsql()")
       expect(wrapper).toContain("handler(request, webhook, { agentIdentity: agentIdentities[agent], state: viteHubChatStateResolver, webhookState: viteHubChatStateResolver, waitUntil })")
@@ -1509,21 +1512,28 @@ export default defineAgent({
         ],
       }, null, 2)}\n`, "utf8")
 
-      const plugin = hubAgent()
-      if (typeof plugin.configResolved === "function") {
-        await plugin.configResolved.call({} as never, { command: "build", preset: "cloudflare", root } as never)
-      }
+      for (const stateProvider of ["cloudflare", "libsql"] as const) {
+        const plugin = hubAgent(stateProvider === "libsql"
+          ? { providers: { state: { provider: "libsql", url: "libsql://state.example.test" } } }
+          : undefined)
+        if (typeof plugin.configResolved === "function") {
+          await plugin.configResolved.call({} as never, { command: "build", preset: "cloudflare", root } as never)
+        }
 
-      const generatedRoute = await readFile(join(root, ".vitehub/agent/chat-webhook-route.ts"), "utf8")
-      expect(generatedRoute).not.toContain("@ts-nocheck")
-      await execFileAsync(process.execPath, [
-        resolve(import.meta.dirname, "../../../node_modules/typescript/bin/tsc"),
-        "--noEmit",
-        "-p",
-        join(root, "tsconfig.json"),
-      ], { cwd: root }).catch((error: { stderr?: string, stdout?: string }) => {
-        throw new Error([error.stdout, error.stderr].filter(Boolean).join("\n"))
-      })
+        const generatedRoute = await readFile(join(root, ".vitehub/agent/chat-webhook-route.ts"), "utf8")
+        expect(generatedRoute).not.toContain("@ts-nocheck")
+        if (stateProvider === "libsql") {
+          expect(generatedRoute).toContain("let viteHubChatState: ReturnType<typeof createLibsqlAgentState> | undefined")
+        }
+        await execFileAsync(process.execPath, [
+          resolve(import.meta.dirname, "../../../node_modules/typescript/bin/tsc"),
+          "--noEmit",
+          "-p",
+          join(root, "tsconfig.json"),
+        ], { cwd: root }).catch((error: { stderr?: string, stdout?: string }) => {
+          throw new Error([error.stdout, error.stderr].filter(Boolean).join("\n"))
+        })
+      }
     }
     finally {
       await rm(root, { force: true, recursive: true })
@@ -1846,6 +1856,7 @@ export default defineAgent({
       expect(denoServer).toContain("const chatRoutePattern = new RegExp(\"^/api/_vitehub/agents/(?<agent>[^/]+)/chat$\")")
       expect(denoServer).toContain("const webhookRoutePattern = new RegExp(\"^/api/_vitehub/agents/(?<agent>[^/]+)/webhooks/(?<webhook>[^/]+)$\")")
       expect(denoServer).toContain("import { createLibsqlAgentState } from \"@vite-hub/agent/state/sqlite\"")
+      expect(denoServer).toContain("let viteHubChatState: ReturnType<typeof createLibsqlAgentState> | undefined")
       expect(denoServer).toContain("return isWebhookRoute ? await handler(request, webhook, { agentIdentity: agentIdentities[agent], state: viteHubChatStateResolver, webhookState: viteHubChatStateResolver }) : await handler(request, { agentIdentity: agentIdentities[agent], state: viteHubChatStateResolver })")
       expect(denoServer).not.toContain("@vite-hub/schedule/runtime")
       expect(denoServer).toContain("function resolveDenoServeOptions(args)")


### PR DESCRIPTION
Generated Nitro and Deno Agent routes now give lazily initialized libSQL Chat state an explicit `ReturnType<typeof createLibsqlAgentState> | undefined`. Netlify `.mjs` keeps the plain JavaScript declaration, so the shared generator remains valid across hosts.

The regression compiles Cloudflare-native and libSQL-backed Nitro output under strict TypeScript, asserts the typed Deno output, and syntax-checks generated Netlify JavaScript. Before the source fix, the libSQL case reproduced TS7034 and TS7005; after it, all 180 provider tests, Agent typecheck, and Agent build/publint pass.

This upstreams only the downstream generated-state typing hunk; unrelated runtime patch behavior remains out of scope.