### PR TITLE
feat(agent): expose chat delivery kind to message filters

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -28,14 +28,14 @@ Built-in helpers include `discord()`, `github()`, `http()`, `slack()`, `teams()`
 
 Adapter-backed Channels deliver only the completed response by default. Set top-level `defineAgent({ messages: { stream: true } })` to opt every adapter Channel into draft and edit updates, or set `messages.stream` on an individual Channel to control progressive delivery for that destination. Web Chat routes return streaming HTTP responses independently of adapter delivery settings.
 
-Set `messages.filter` on an adapter-backed Channel to admit only supported incoming messages before Agent invocation. The filter receives the normalized current `Message` with the Channel callback context, run metadata, and thread controls; returning `false` ignores the delivery without starting the Agent or posting an error fallback.
+Set `messages.filter` on an adapter-backed Channel to admit only supported incoming messages before Agent invocation. The filter receives the normalized current `Message`, its `deliveryKind`, the Channel callback context, run metadata, and thread controls; returning `false` ignores the delivery without starting the Agent or posting an error fallback. `deliveryKind` is `direct`, `mention`, or `subscribed`; explicit mentions remain `mention` in threads the Agent already subscribes to.
 
 ```ts
-telegram({
+teams({
   adapter,
   messages: {
-    filter: ({ message }) =>
-      message.parts.length === 1 && message.parts[0]?.type === 'image',
+    filter: ({ deliveryKind }) =>
+      deliveryKind === 'direct' || deliveryKind === 'mention',
   },
 })
 ```

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -316,6 +316,7 @@ export type {
   AgentInvokerResolveContext,
   AgentMessageChannelSettings,
   AgentMessageConcurrency,
+  AgentMessageDeliveryKind,
   AgentMessageFilter,
   AgentMessageFilterContext,
   AgentMessageLockScope,

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -38,6 +38,7 @@ import type {
   AgentInput,
   AgentHostIdentity,
   AgentInvoker,
+  AgentMessageDeliveryKind,
   AgentRunInput,
   AgentRunMetadata,
   AgentRuntimeConfig,
@@ -2013,6 +2014,7 @@ async function handleChatSdkMessage(
   registration: AgentWebhookRegistrationDefinition,
   thread: Thread,
   message: ChatSdkMessage,
+  deliveryKind: AgentMessageDeliveryKind,
   options: AgentChatOptions | undefined,
   state: { keyPrefix: string, state: StateAdapter },
   messageContext?: MessageContext,
@@ -2040,6 +2042,7 @@ async function handleChatSdkMessage(
       const [current] = uiMessagesToAgentMessages([currentMessage])
       if (!current || !await filter({
         ...context,
+        deliveryKind,
         message: current,
         run: input.run,
         thread: {
@@ -2163,13 +2166,13 @@ async function createChatWebhookHandler(
   const state = { keyPrefix: resolvedState.titleKeyPrefix, state: resolvedState.state }
 
   chat.onDirectMessage((thread, message, _channel, messageContext) =>
-    handleChatSdkMessage(agent, context, registration, thread, message, options, state, messageContext))
+    handleChatSdkMessage(agent, context, registration, thread, message, "direct", options, state, messageContext))
   chat.onNewMention(async (thread, message, messageContext) => {
     await thread.subscribe().catch(() => undefined)
-    await handleChatSdkMessage(agent, context, registration, thread, message, options, state, messageContext)
+    await handleChatSdkMessage(agent, context, registration, thread, message, "mention", options, state, messageContext)
   })
   chat.onSubscribedMessage((thread, message, messageContext) =>
-    handleChatSdkMessage(agent, context, registration, thread, message, options, state, messageContext))
+    handleChatSdkMessage(agent, context, registration, thread, message, message.isMention ? "mention" : "subscribed", options, state, messageContext))
 
   const handler = chat.webhooks[adapterName]
   if (!handler) {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1466,10 +1466,13 @@ export type AgentChatSendMessage = (message: AgentChatMessage) => Promise<void>
 
 export type AgentMessageConcurrency = "drop" | "parallel" | "queue" | "reject" | (string & {})
 
+export type AgentMessageDeliveryKind = "direct" | "mention" | "subscribed"
+
 export type AgentMessageLockScope = "agent" | "channel" | "thread" | (string & {})
 
 export interface AgentMessageFilterContext<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>
   extends AgentCallbackContext<TRuntimeConfig> {
+  deliveryKind: AgentMessageDeliveryKind
   message: Message
   thread: {
     post: AgentChatSendMessage

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -14,6 +14,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { resolveAgentCapabilities } from "../src/capability-runtime.ts"
 
+import type { AgentMessageDeliveryKind } from "../src/index.ts"
 import type { AgentChannelChatRouteStandardSchemaV1 } from "../src/server.ts"
 import type { Adapter, ChatInstance, StreamChunk, WebhookOptions } from "chat"
 
@@ -41,7 +42,7 @@ const optionalMessageAdapterRuntimeExternals = [
 
 const hostedAgentRoot = join(import.meta.dirname, "../../../fixtures/tutorials/agents")
 
-function createTestChatAdapter(options: { attachmentFetchData?: () => Promise<Buffer>, deferMessageProcessing?: boolean, missingIncomingMessageId?: boolean, persistThreadHistory?: boolean, photoData?: Blob, secret?: string } = {}) {
+function createTestChatAdapter(options: { attachmentFetchData?: () => Promise<Buffer>, deferMessageProcessing?: boolean, isDM?: boolean, missingIncomingMessageId?: boolean, persistThreadHistory?: boolean, photoData?: Blob, secret?: string } = {}) {
   let chatInstance: ChatInstance | undefined
   let sentMessageId = 0
   const cachedMessages = new Map<string, Message[]>()
@@ -124,6 +125,7 @@ function createTestChatAdapter(options: { attachmentFetchData?: () => Promise<Bu
         },
         formatted: { children: [], type: "root" },
         id: options.missingIncomingMessageId ? undefined as unknown as string : String(rawMessage.message_id ?? "7"),
+        isMention: rawMessage.isMention === true,
         metadata: { dateSent: date, edited: false },
         raw: body,
         text: typeof rawMessage.text === "string" ? rawMessage.text : "",
@@ -143,7 +145,7 @@ function createTestChatAdapter(options: { attachmentFetchData?: () => Promise<Bu
     initialize: vi.fn(async (chat: ChatInstance) => {
       chatInstance = chat
     }),
-    isDM: vi.fn(() => true),
+    isDM: vi.fn(() => options.isDM ?? true),
     editMessage: vi.fn(async (threadId: string, messageId: string, message: unknown) => ({ id: messageId, raw: { message }, threadId })),
     fetchMessages: vi.fn(async (threadId: string) => ({ messages: cachedMessages.get(threadId) ?? [] })),
     name: "telegram",
@@ -3192,6 +3194,7 @@ describe("server helpers", () => {
 
     expect(filter).toHaveBeenCalledWith(expect.objectContaining({
       agentIdentity: { name: "support" },
+      deliveryKind: "direct",
       message: expect.objectContaining({
         parts: [expect.objectContaining({ text: "hello", type: "text" })],
       }),
@@ -3218,6 +3221,52 @@ describe("server helpers", () => {
     }))
     expect(run).toHaveBeenCalledOnce()
     expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "accepted" })
+  })
+
+  it("classifies direct, mention, and subscribed deliveries for message filters", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const deliveryKinds: AgentMessageDeliveryKind[] = []
+    const createHandler = (adapter: Adapter) => createChannelWebhookRouteHandler(defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter,
+          messages: {
+            filter: ({ deliveryKind }) => {
+              deliveryKinds.push(deliveryKind)
+              return false
+            },
+          },
+        }),
+      },
+      driver: { run: () => "unused" },
+    }) as never)
+    const request = (messageId: number, threadId: number, isMention = false) =>
+      new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+        body: JSON.stringify({
+          update_id: messageId,
+          message: {
+            chat: { id: threadId, type: "group" },
+            date: 1781092800,
+            from: { first_name: "Maxi", id: 123, username: "maxi" },
+            isMention,
+            message_id: messageId,
+            text: "hello",
+          },
+        }),
+        method: "POST",
+      })
+
+    const directHandler = createHandler(createTestChatAdapter())
+    await directHandler(request(2010, 456), "telegram")
+
+    const groupHandler = createHandler(createTestChatAdapter({ isDM: false }))
+    await groupHandler(request(2011, 789, true), "telegram")
+    await groupHandler(request(2012, 789), "telegram")
+    await groupHandler(request(2013, 789, true), "telegram")
+
+    expect(deliveryKinds).toEqual(["direct", "mention", "subscribed", "mention"])
   })
 
   it("defaults adapter-backed Channels to final-only delivery", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelDeliveryReplyStream, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUIMessageStreamProjection, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelDeliveryReplyStream, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentMessageDeliveryKind, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUIMessageStreamProjection, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, repositoryHost, repositoryHostContext, sandbox, schedule, skills, streamTranscription, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -1389,6 +1389,10 @@ describe("agent public types", () => {
         teams: teams({ adapter: teamsAdapter }),
       },
       messages: {
+        filter: ({ deliveryKind }) => {
+          expectTypeOf(deliveryKind).toEqualTypeOf<AgentMessageDeliveryKind>()
+          return deliveryKind === "direct" || deliveryKind === "mention"
+        },
         identity: ({ adapter, author }) => `${adapter}:${author.userId}`,
         transcripts: {
           maxPerUser: 50,


### PR DESCRIPTION
Adds `deliveryKind` to `messages.filter` so Agent Definitions can admit direct messages and explicit mentions while ignoring ordinary subscribed follow-ups without provider-specific parsing. ViteHub normalizes subscribed callbacks carrying `message.isMention` back to `mention`, which keeps the public contract semantic instead of exposing Chat SDK routing details.

The regression drives direct, new-mention, ordinary subscribed, and subscribed-mention paths through Chat SDK, while existing filters may continue reading only the normalized message. Teams adapter changes, conversation classification, attachments, authorization, and downstream Quiver policy are intentionally excluded.

Validated with the full `@vite-hub/agent` build and 1,496-test suite, its TypeScript check, the focused 184-test provider suite after the final rebase, and `git diff --check`.
