### PR TITLE
fix(database): bind hosted agent databases

### DIFF
--- a/docs/content/docs/capabilities/db.md
+++ b/docs/content/docs/capabilities/db.md
@@ -9,7 +9,7 @@ icon: i-lucide-database
 
 `db()` adds model-facing tools for a configured ViteHub Database primitive.
 It exposes read-only query and schema inspection by default, then adds SQL mutation only when write modes allow it.
-Hosted Agent routes receive the Database primitive automatically when the app configures `hubDb()`.
+Cloudflare and Vercel hosted Agent routes receive the Database primitive automatically when the app configures `hubDb()`.
 
 ## Installation
 

--- a/docs/content/docs/capabilities/db.md
+++ b/docs/content/docs/capabilities/db.md
@@ -9,6 +9,7 @@ icon: i-lucide-database
 
 `db()` adds model-facing tools for a configured ViteHub Database primitive.
 It exposes read-only query and schema inspection by default, then adds SQL mutation only when write modes allow it.
+Hosted Agent routes receive the Database primitive automatically when the app configures `hubDb()`.
 
 ## Installation
 

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -127,6 +127,7 @@ interface GeneratedAgentRuntimeCapability {
 
 const generatedAgentRuntimeCapabilityDefinitions: GeneratedAgentRuntimeCapability[] = [
   { importName: "blob", name: "blob", packageName: "@vite-hub/blob", pluginName: "@vite-hub/blob/vite" },
+  { importName: "agentDb", name: "db", packageName: "@vite-hub/database/drizzle", pluginName: "@vite-hub/database/vite" },
   { importName: "email", name: "email", packageName: "@vite-hub/email/server", pluginName: "@vite-hub/email/vite" },
   { importName: "kv", name: "kv", packageName: "@vite-hub/kv", pluginName: "@vite-hub/kv/vite" },
 ]

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -184,7 +184,8 @@ async function writeStandaloneAgentRuntimeCapabilities(
   config: Pick<ResolvedConfig, "plugins" | "root">,
   capabilities: GeneratedAgentRuntimeCapability[],
 ): Promise<GeneratedAgentRuntimeCapability[]> {
-  const emailCapability = capabilities.find(capability =>
+  const standaloneCapabilities = capabilities.filter(capability => capability.name !== "db")
+  const emailCapability = standaloneCapabilities.find(capability =>
     capability.name === "email" && capability.packageName !== false
   )
   const emailPlugin = config.plugins?.find(plugin => plugin.name === "@vite-hub/email/vite") as Plugin & {
@@ -194,11 +195,11 @@ async function writeStandaloneAgentRuntimeCapabilities(
   const runtimePath = join(config.root, generatedAgentEmailRuntime)
   if (!emailCapability || !definition) {
     await rm(runtimePath, { force: true })
-    return capabilities
+    return standaloneCapabilities
   }
 
   const emailPackageName = emailCapability.packageName
-  if (emailPackageName === false) return capabilities
+  if (emailPackageName === false) return standaloneCapabilities
   const emailImport = emailPackageName.endsWith("/server")
     ? emailPackageName.slice(0, -"/server".length)
     : "@vite-hub/email"
@@ -209,7 +210,7 @@ async function writeStandaloneAgentRuntimeCapabilities(
     "export const email = createEmail(definition)",
     "",
   ].join("\n"), "utf8")
-  return capabilities.map(capability => capability === emailCapability
+  return standaloneCapabilities.map(capability => capability === emailCapability
     ? { ...capability, packageName: "./email-runtime.js" }
     : capability)
 }

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1121,7 +1121,7 @@ describe("agent Vite plugin", () => {
       if (typeof denoPlugin.configResolved === "function") {
         await denoPlugin.configResolved.call({} as never, {
           command: "build",
-          plugins: [emailPlugin],
+          plugins: [emailPlugin, { name: "@vite-hub/database/vite" }],
           root,
         } as never)
       }
@@ -1131,6 +1131,7 @@ describe("agent Vite plugin", () => {
       expect(emailRuntime).toContain('import definition from "../../server/email.ts"')
       expect(emailRuntime).toContain("export const email = createEmail(definition)")
       expect(denoServer).toContain('import { email as vitehubEmail } from "./email-runtime.js"')
+      expect(denoServer).not.toContain("@vite-hub/database/drizzle")
 
       process.env.VITEHUB_HOSTING = "netlify"
       const netlifyPlugin = hubAgent()
@@ -1138,7 +1139,7 @@ describe("agent Vite plugin", () => {
         await netlifyPlugin.configResolved.call({} as never, {
           build: { outDir: "dist/client" },
           command: "build",
-          plugins: [emailPlugin],
+          plugins: [emailPlugin, { name: "@vite-hub/database/vite" }],
           resolve: { alias: [] },
           root,
         } as never)
@@ -1148,6 +1149,7 @@ describe("agent Vite plugin", () => {
       }
       const netlifyFunction = await readFile(join(root, ".vitehub/agent/netlify-function.mjs"), "utf8")
       expect(netlifyFunction).toContain('import { email as vitehubEmail } from "./email-runtime.js"')
+      expect(netlifyFunction).not.toContain("@vite-hub/database/drizzle")
     }
     finally {
       if (typeof previousHosting === "string") process.env.VITEHUB_HOSTING = previousHosting

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -415,7 +415,7 @@ describe("agent Vite plugin", () => {
       await configResolved({
         command: "serve",
         createResolver: () => async id => `/app/node_modules/${id}`,
-        plugins: [{ name: "@vite-hub/blob/vite" }, { name: "@vite-hub/email/vite" }, { name: "@vite-hub/kv/vite" }],
+        plugins: [{ name: "@vite-hub/blob/vite" }, { name: "@vite-hub/database/vite" }, { name: "@vite-hub/email/vite" }, { name: "@vite-hub/kv/vite" }],
         root,
       })
 
@@ -424,10 +424,11 @@ describe("agent Vite plugin", () => {
 
       expect(registry).toContain("defineScheduledAgentTarget")
       expect(registry).toContain('import { blob as vitehubBlob } from "@vite-hub/blob"')
+      expect(registry).toContain('import { agentDb as vitehubDb } from "@vite-hub/database/drizzle"')
       expect(registry).toContain('import { email as vitehubEmail } from "@vite-hub/email/server"')
       expect(registry).toContain('import { kv as vitehubKv } from "@vite-hub/kv"')
       expect(registry).toContain('import { schedules as vitehubSchedules } from "@vite-hub/schedule/runtime"')
-      expect(registry).toContain('{ agentIdentity: {"name":"digest"}, capabilities: { blob: vitehubBlob, email: vitehubEmail, kv: vitehubKv, schedule: { schedules: vitehubSchedules } } }')
+      expect(registry).toContain('{ agentIdentity: {"name":"digest"}, capabilities: { blob: vitehubBlob, db: vitehubDb, email: vitehubEmail, kv: vitehubKv, schedule: { schedules: vitehubSchedules } } }')
       expect(registry).toContain('registry["agent/digest"]')
       expect(registry).toContain('vitehubAgentWithColocatedInstructions(vitehubResolveScheduledAgentModule(module), "Use digest instructions.\\n")')
       expect(registry).not.toContain("withAgentDefaults")

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -41,6 +41,7 @@
     "./config": "./dist/config.js",
     "./drizzle": "./dist/drizzle.js",
     "./nuxt": "./dist/nuxt.js",
+    "./runtime/agent": "./dist/runtime/agent.js",
     "./runtime/cloudflare-vite": "./dist/runtime/cloudflare-vite.js",
     "./runtime/hosted": "./dist/runtime/hosted.js",
     "./runtime/state": "./dist/runtime/state.js",

--- a/packages/database/src/definition.ts
+++ b/packages/database/src/definition.ts
@@ -58,7 +58,9 @@ export function defineDatabase<TSchema extends Record<string, unknown>>(
 
   return new Proxy(definition as Database<TSchema>, {
     get(target, property, receiver) {
-      return Reflect.has(target, property) ? Reflect.get(target, property, receiver) : Reflect.get(runtime, property)
+      return Reflect.has(target, property) || (typeof property === "string" && allowedDefinitionKeys.has(property))
+        ? Reflect.get(target, property, receiver)
+        : Reflect.get(runtime, property)
     },
   })
 }

--- a/packages/database/src/drizzle-subpath.d.ts
+++ b/packages/database/src/drizzle-subpath.d.ts
@@ -2,6 +2,7 @@ import "./virtual-module.d.ts"
 
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core"
 import schema from "#vitehub/database/schema"
+import type { AgentDatabaseHandle } from "./runtime/agent.js"
 
 type DrizzleRuntimeDatabase<TSchema extends Record<string, unknown>> = BaseSQLiteDatabase<"async", unknown, TSchema>
 
@@ -18,3 +19,7 @@ export declare const databases: Record<string, RuntimeDatabaseEntry<Record<strin
 }
 
 export declare const db: DrizzleRuntimeDatabase<typeof schema>
+
+export declare const agentDb: AgentDatabaseHandle & {
+  database(name: string): AgentDatabaseHandle
+}

--- a/packages/database/src/drizzle.ts
+++ b/packages/database/src/drizzle.ts
@@ -1,5 +1,6 @@
 import schema from "#vitehub/database/schema"
 import { databases as runtimeDatabases, db as runtimeDb } from "./runtime/drizzle-runtime.ts"
+import { createAgentDatabase } from "./runtime/agent.ts"
 
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core"
 
@@ -15,5 +16,8 @@ export const databases = runtimeDatabases as Record<string, RuntimeDatabaseEntry
 }
 
 export const db = runtimeDb as DrizzleRuntimeDatabase<typeof schema>
+
+export const agentDb = createAgentDatabase(databases)
+
 export { schema }
 export * from "#vitehub/database/schema"

--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -74,6 +74,7 @@ function renderRuntimeModule(file: string, runtimeConfig: ResolvedDBViteConfig) 
   ].join("\n"))
 
   return [
+    `import { createAgentDatabase } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule("runtime/agent")))}`,
     `import { createHostedDrizzleDb } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule("runtime/hosted")))}`,
     "",
     ...imports,
@@ -81,6 +82,7 @@ function renderRuntimeModule(file: string, runtimeConfig: ResolvedDBViteConfig) 
     "export const databases = {",
     ...databaseEntries,
     "}",
+    "export const agentDb = createAgentDatabase(databases)",
     "",
     ...(runtimeConfig.databaseNames.includes("default")
       ? [

--- a/packages/database/src/nuxt.ts
+++ b/packages/database/src/nuxt.ts
@@ -78,7 +78,8 @@ export function hubDb(options: DatabaseNuxtIntegrationOptions = {}): DatabaseNux
         const provider = resolveNitroHostingProvider(config, nuxtOptions)
         if (!nuxtOptions.dev && (provider || d1)) mergeNitroHostedCondition(config)
         if (!nuxtOptions.dev) {
-          mergeNitroDatabaseRuntimeAlias(config, nuxtOptions.srcDir || root, provider ?? (d1 ? "cloudflare" : undefined))
+          const runtimeRoot = typeof viteConfig.root === "string" ? viteConfig.root : nuxtOptions.srcDir || root
+          mergeNitroDatabaseRuntimeAlias(config, runtimeRoot, provider ?? (d1 ? "cloudflare" : undefined))
         }
         if (!nuxtOptions.dev && provider === "cloudflare") {
           await installNitroCloudflareEnvBridge(config, root)

--- a/packages/database/src/nuxt.ts
+++ b/packages/database/src/nuxt.ts
@@ -13,6 +13,7 @@ import type { Plugin } from "vite"
 
 type ResolvedDatabaseNuxtIntegrationOptions = Exclude<DatabaseNuxtIntegrationOptions, false>
 const generatedNitroDatabaseMiddleware = ".vitehub/nitro/database/middleware.ts"
+const databaseDrizzleImport = "@vite-hub/database/drizzle"
 
 type NuxtModuleDependencies = Record<string, {
   defaults?: Record<string, unknown>
@@ -75,6 +76,9 @@ export function hubDb(options: DatabaseNuxtIntegrationOptions = {}): DatabaseNux
       hook("nitro:config", async (config) => {
         const provider = resolveNitroHostingProvider(config, nuxtOptions)
         if (!nuxtOptions.dev && (provider || d1)) mergeNitroHostedCondition(config)
+        if (!nuxtOptions.dev) {
+          mergeNitroDatabaseRuntimeAlias(config, root, provider ?? (d1 ? "cloudflare" : undefined))
+        }
         if (!nuxtOptions.dev && provider === "cloudflare") {
           await installNitroCloudflareEnvBridge(config, root)
         }
@@ -210,6 +214,18 @@ function mergeNitroHostedCondition(config: Record<string, unknown>) {
   const conditions = Array.isArray(config.exportConditions) ? config.exportConditions : []
   if (!conditions.includes("vitehub-hosted")) {
     config.exportConditions = ["vitehub-hosted", ...conditions]
+  }
+}
+
+function mergeNitroDatabaseRuntimeAlias(
+  config: Record<string, unknown>,
+  root: string,
+  provider: string | undefined,
+) {
+  if (provider !== "cloudflare" && provider !== "vercel") return
+  const alias = ensureRecord(config, "alias")
+  if (!(databaseDrizzleImport in alias)) {
+    alias[databaseDrizzleImport] = resolve(root, `.vitehub/database/${provider}-runtime.mjs`)
   }
 }
 

--- a/packages/database/src/nuxt.ts
+++ b/packages/database/src/nuxt.ts
@@ -41,6 +41,7 @@ type NuxtLike = {
     modules?: unknown[]
     nitro?: Record<string, unknown>
     rootDir?: string
+    srcDir?: string
     vite?: Record<string, unknown>
   }
 }
@@ -77,7 +78,7 @@ export function hubDb(options: DatabaseNuxtIntegrationOptions = {}): DatabaseNux
         const provider = resolveNitroHostingProvider(config, nuxtOptions)
         if (!nuxtOptions.dev && (provider || d1)) mergeNitroHostedCondition(config)
         if (!nuxtOptions.dev) {
-          mergeNitroDatabaseRuntimeAlias(config, root, provider ?? (d1 ? "cloudflare" : undefined))
+          mergeNitroDatabaseRuntimeAlias(config, nuxtOptions.srcDir || root, provider ?? (d1 ? "cloudflare" : undefined))
         }
         if (!nuxtOptions.dev && provider === "cloudflare") {
           await installNitroCloudflareEnvBridge(config, root)

--- a/packages/database/src/runtime/agent.ts
+++ b/packages/database/src/runtime/agent.ts
@@ -1,0 +1,43 @@
+import { sql } from "drizzle-orm"
+
+export interface AgentDatabaseHandle {
+  exec(statement: string): Promise<unknown>
+  query(statement: string): Promise<unknown>
+  schema(): Promise<unknown>
+}
+
+interface AgentDatabaseEntry {
+  db: {
+    all(query: unknown): Promise<unknown>
+    run(query: unknown): Promise<unknown>
+  }
+}
+
+function requireDatabase(databases: Record<string, AgentDatabaseEntry>, name: string) {
+  const entry = databases[name]
+  if (!entry) throw new Error(`[vitehub] Database "${name}" is not configured.`)
+  return entry
+}
+
+function createAgentDatabaseHandle(
+  databases: Record<string, AgentDatabaseEntry>,
+  name: string,
+): AgentDatabaseHandle {
+  return {
+    exec: statement => requireDatabase(databases, name).db.run(sql.raw(statement)),
+    query: statement => requireDatabase(databases, name).db.all(sql.raw(statement)),
+    schema: () => requireDatabase(databases, name).db.all(sql.raw(
+      "SELECT name, type, sql FROM sqlite_schema WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name",
+    )),
+  }
+}
+
+export function createAgentDatabase(databases: Record<string, AgentDatabaseEntry>) {
+  return {
+    ...createAgentDatabaseHandle(databases, "default"),
+    database(name: string) {
+      requireDatabase(databases, name)
+      return createAgentDatabaseHandle(databases, name)
+    },
+  }
+}

--- a/packages/database/test/nuxt.test.ts
+++ b/packages/database/test/nuxt.test.ts
@@ -152,6 +152,34 @@ describe("Database Nuxt integration", () => {
       .resolves.toContain("setActiveCloudflareEnv")
   })
 
+  it("aliases the hosted runtime from the Nuxt source directory", async () => {
+    const { hooks, nuxt } = createNuxt({
+      database: {
+        driver: "d1",
+        databaseId: "content-id",
+        databaseName: "content-db",
+      },
+      dev: false,
+      nitro: {
+        preset: "cloudflare_module",
+      },
+      rootDir: "/tmp/vitehub-db-nuxt",
+      srcDir: "/tmp/vitehub-db-nuxt/app",
+      vite: {},
+    })
+
+    await hubDb()(undefined, nuxt)
+
+    const nitroConfig = {}
+    await callHook(hooks, "nitro:config", nitroConfig)
+
+    expect(nitroConfig).toMatchObject({
+      alias: {
+        "@vite-hub/database/drizzle": "/tmp/vitehub-db-nuxt/app/.vitehub/database/cloudflare-runtime.mjs",
+      },
+    })
+  })
+
   it("uses local sqlite for Nuxt Content during dev without changing the D1 provider binding", async () => {
     const { nuxt } = createNuxt({
       database: {

--- a/packages/database/test/nuxt.test.ts
+++ b/packages/database/test/nuxt.test.ts
@@ -180,6 +180,27 @@ describe("Database Nuxt integration", () => {
     })
   })
 
+  it("aliases the hosted runtime from a custom Vite root", async () => {
+    const { hooks, nuxt } = createNuxt({
+      dev: false,
+      nitro: { preset: "vercel" },
+      rootDir: "/tmp/vitehub-db-nuxt",
+      srcDir: "/tmp/vitehub-db-nuxt/app",
+      vite: { root: "/tmp/vitehub-db-nuxt/custom-vite-root" },
+    })
+
+    await hubDb()(undefined, nuxt)
+
+    const nitroConfig = {}
+    await callHook(hooks, "nitro:config", nitroConfig)
+
+    expect(nitroConfig).toMatchObject({
+      alias: {
+        "@vite-hub/database/drizzle": "/tmp/vitehub-db-nuxt/custom-vite-root/.vitehub/database/vercel-runtime.mjs",
+      },
+    })
+  })
+
   it("uses local sqlite for Nuxt Content during dev without changing the D1 provider binding", async () => {
     const { nuxt } = createNuxt({
       database: {

--- a/packages/database/test/nuxt.test.ts
+++ b/packages/database/test/nuxt.test.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises"
+import { join } from "node:path"
 
 import { describe, expect, it } from "vitest"
 
@@ -113,6 +114,9 @@ describe("Database Nuxt integration", () => {
     await callHook(hooks, "nitro:config", nitroConfig)
 
     expect(nitroConfig).toEqual({
+      alias: {
+        "@vite-hub/database/drizzle": "/tmp/vitehub-db-nuxt/.vitehub/database/cloudflare-runtime.mjs",
+      },
       cloudflare: {
         wrangler: {
           d1_databases: [
@@ -291,6 +295,28 @@ describe("Database Nuxt integration", () => {
     await callHook(hooks, "nitro:config", nitroConfig)
 
     expect(nitroConfig.exportConditions).toEqual(["vitehub-hosted", "node"])
+  })
+
+  it.each([
+    ["cloudflare-module", "cloudflare"],
+    ["vercel", "vercel"],
+  ])("aliases the Drizzle runtime to the generated %s database module", async (preset, provider) => {
+    const rootDir = `/tmp/vitehub-db-nuxt-${provider}-runtime`
+    const { hooks, nuxt } = createNuxt({
+      dev: false,
+      nitro: { preset },
+      rootDir,
+      vite: {},
+    })
+
+    await hubDb()(undefined, nuxt)
+
+    const nitroConfig: Record<string, unknown> = { preset }
+    await callHook(hooks, "nitro:config", nitroConfig)
+
+    expect(nitroConfig.alias).toEqual({
+      "@vite-hub/database/drizzle": join(rootDir, `.vitehub/database/${provider}-runtime.mjs`),
+    })
   })
 
   it("selects the hosted definition runtime for Deno deployments", async () => {

--- a/packages/database/test/runtime.test.ts
+++ b/packages/database/test/runtime.test.ts
@@ -264,6 +264,27 @@ describe("drizzle runtime", () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it("exposes guarded raw SQL handles for hosted Agents", async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "vitehub-db-agent-runtime-"))
+    runtimeState.dbPath = `file:${join(tempDir, "db.sqlite")}`
+    runtimeState.analyticsDbPath = `file:${join(tempDir, "analytics.sqlite")}`
+
+    const { agentDb } = await import("../src/drizzle.ts")
+
+    await agentDb.exec("create table notes (id integer primary key, title text not null)")
+    await agentDb.exec("insert into notes (id, title) values (1, 'agent note')")
+    await expect(agentDb.query("select id, title from notes")).resolves.toEqual([{ id: 1, title: "agent note" }])
+    await expect(agentDb.schema()).resolves.toEqual([
+      expect.objectContaining({ name: "notes", type: "table" }),
+    ])
+
+    const analytics = agentDb.database("analytics")
+    await analytics.exec("create table analytics_events (id integer primary key, name text not null)")
+    await analytics.exec("insert into analytics_events (id, name) values (1, 'page-view')")
+    await expect(analytics.query("select id, name from analytics_events")).resolves.toEqual([{ id: 1, name: "page-view" }])
+    expect(() => agentDb.database("missing")).toThrow('Database "missing" is not configured.')
+  })
+
   it("queries configured Cloudflare D1 over HTTP from the generated local runtime", async () => {
     runtimeDatabaseEntriesFactory = () => ({
       analytics: {

--- a/packages/database/test/runtime.test.ts
+++ b/packages/database/test/runtime.test.ts
@@ -448,6 +448,21 @@ describe("database definition runtime", () => {
     expect(output).not.toContain("node:fs")
     expect(output).not.toContain("node:path")
   })
+
+  it("reads omitted definition options without opening the hosted database", async () => {
+    const script = [
+      "import { defineDatabase } from './dist/index.js'",
+      "const database = defineDatabase({ cloudflare: { binding: 'DB' }, schema: {} })",
+      "if (database.connection !== undefined) throw new Error('Expected an omitted connection')",
+    ].join(";")
+
+    await expect(execFileAsync(process.execPath, [
+      "--conditions=vitehub-hosted",
+      "--input-type=module",
+      "-e",
+      script,
+    ], { cwd: process.cwd() })).resolves.toBeDefined()
+  })
 })
 
 describe("hosted drizzle runtime", () => {

--- a/packages/database/test/types-published.test-d.ts
+++ b/packages/database/test/types-published.test-d.ts
@@ -1,5 +1,5 @@
 import { defineDatabase } from "@vite-hub/database"
-import { db, databases, schema } from "@vite-hub/database/drizzle"
+import { agentDb, db, databases, schema } from "@vite-hub/database/drizzle"
 import { hubDb } from "@vite-hub/database/nuxt"
 import { sqliteTable, text } from "drizzle-orm/sqlite-core"
 
@@ -13,6 +13,8 @@ describe("published package types", () => {
     expectTypeOf(schema.notes).toEqualTypeOf<unknown>()
     expectTypeOf(databases.default.schema).toMatchTypeOf<typeof schema>()
     expectTypeOf(db).toMatchTypeOf<typeof databases.default.db>()
+    expectTypeOf(agentDb.query).toBeFunction()
+    expectTypeOf(agentDb.database("analytics").exec).toBeFunction()
   })
 
   it("returns a typed runtime database from defineDatabase", () => {

--- a/packages/database/test/vite-output.test.ts
+++ b/packages/database/test/vite-output.test.ts
@@ -433,6 +433,9 @@ describe("Vite db provider outputs", () => {
     expect(bundledServerCode.includes("runtime/virtual-databases.js")).toBe(false)
     expect(bundledServerCode.includes("var databases$1 = {};")).toBe(false)
 
+    const cloudflareRuntime = await readFile(join(rootDir, ".vitehub/database/cloudflare-runtime.mjs"), "utf8")
+    expect(cloudflareRuntime).toContain("export const agentDb = createAgentDatabase(databases)")
+
     const vercelServerCode = await readFile(vercelServer, "utf8")
     expect(vercelServerCode).toContain("process.env.TURSO_ANALYTICS_DATABASE_URL || process.env.TURSO_DATABASE_URL")
     expect(vercelServerCode).toContain("process.env.TURSO_DATABASE_URL")

--- a/packages/database/vite.config.ts
+++ b/packages/database/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
       "src/nuxt.ts",
       "src/virtual.ts",
       "src/vite.ts",
+      "src/runtime/agent.ts",
       "src/runtime/cloudflare-vite.ts",
       "src/runtime/definition-defaults.ts",
       "src/runtime/definition-hosted.ts",

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -114,9 +114,6 @@ async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, u
 export default async function viteHubNuxtModule(options: Parameters<typeof vitehub>[0], nuxt?: NuxtLike): Promise<void> {
   if (!nuxt) return
 
-  if (options.database) {
-    await hubDatabaseNuxt(options.database === true ? {} : options.database)(undefined, nuxt)
-  }
   const plugins = flattenPlugins(vitehub(options))
     .filter(plugin => plugin.name !== "vite-hub/deployment-output")
   const existing = withoutDeploymentOutput(
@@ -152,4 +149,7 @@ export default async function viteHubNuxtModule(options: Parameters<typeof viteh
     ...existing,
   ] as PluginOption[]
   nuxt.hook?.("nitro:config", config => applyNitroConfig(installedPlugins, config, nuxt))
+  if (options.database) {
+    await hubDatabaseNuxt(options.database === true ? {} : options.database)(undefined, nuxt)
+  }
 }

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -1,4 +1,5 @@
 import { VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
+import { hubDb as hubDatabaseNuxt } from "@vite-hub/database/nuxt"
 import { mergeConfig } from "vite"
 
 import { vitehub } from "./index.ts"
@@ -110,9 +111,12 @@ async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, u
   if (config.nitro) Object.assign(nitroConfig, config.nitro)
 }
 
-export default function viteHubNuxtModule(options: Parameters<typeof vitehub>[0], nuxt?: NuxtLike): void {
+export default async function viteHubNuxtModule(options: Parameters<typeof vitehub>[0], nuxt?: NuxtLike): Promise<void> {
   if (!nuxt) return
 
+  if (options.database) {
+    await hubDatabaseNuxt(options.database === true ? {} : options.database)(undefined, nuxt)
+  }
   const plugins = flattenPlugins(vitehub(options))
     .filter(plugin => plugin.name !== "vite-hub/deployment-output")
   const existing = withoutDeploymentOutput(

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -279,6 +279,9 @@ describe("ViteHub Nuxt integration", () => {
 
   it("installs the Database Nuxt runtime alias through the framework module", async () => {
     const { nuxt, runNitroConfigHook } = createNuxt()
+    Object.assign(nuxt.options.vite, {
+      root: "/tmp/vitehub-nuxt/custom-vite-root",
+    })
 
     await viteHubNuxtModule({ database: true, preset: "cloudflare" }, nuxt)
     const nitroConfig = { preset: "cloudflare_module" }
@@ -289,7 +292,7 @@ describe("ViteHub Nuxt integration", () => {
     )
     expect(nitroConfig).toMatchObject({
       alias: {
-        "@vite-hub/database/drizzle": "/tmp/vitehub-nuxt/app/.vitehub/database/cloudflare-runtime.mjs",
+        "@vite-hub/database/drizzle": "/tmp/vitehub-nuxt/custom-vite-root/.vitehub/database/cloudflare-runtime.mjs",
       },
     })
   })

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -284,7 +284,7 @@ describe("ViteHub Nuxt integration", () => {
     })
 
     await viteHubNuxtModule({ database: true, preset: "cloudflare" }, nuxt)
-    const nitroConfig = { preset: "cloudflare_module" }
+    const nitroConfig = {}
     await runNitroConfigHook(nitroConfig)
 
     expect((nuxt.options.vite.plugins as unknown[]).flat(Infinity)).toContainEqual(

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -50,10 +50,10 @@ vi.mock("../src/index.ts", () => ({ vitehub: mocks.vitehub }))
 import viteHubNuxtModule from "../src/nuxt.ts"
 
 function createNuxt(dev = false, plugins: PluginOption[] = []) {
-  let nitroConfigHook: ((config: Record<string, unknown>) => Promise<void>) | undefined
+  const nitroConfigHooks: Array<(config: Record<string, unknown>) => Promise<void>> = []
   const nuxt = {
     hook(name: "nitro:config", callback: (config: Record<string, unknown>) => Promise<void>) {
-      if (name === "nitro:config") nitroConfigHook = callback
+      if (name === "nitro:config") nitroConfigHooks.push(callback)
     },
     options: {
       alias: {
@@ -68,9 +68,9 @@ function createNuxt(dev = false, plugins: PluginOption[] = []) {
   }
   return {
     nuxt,
-    runNitroConfigHook(config: Record<string, unknown>) {
-      if (!nitroConfigHook) throw new TypeError("Expected a Nitro config hook.")
-      return nitroConfigHook(config)
+    async runNitroConfigHook(config: Record<string, unknown>) {
+      if (!nitroConfigHooks.length) throw new TypeError("Expected a Nitro config hook.")
+      for (const hook of nitroConfigHooks) await hook(config)
     },
   }
 }
@@ -166,7 +166,7 @@ describe("ViteHub Nuxt integration", () => {
       { name: "vite-hub/deployment-output" },
     ]])
 
-    viteHubNuxtModule({ preset: "cloudflare" }, nuxt)
+    await viteHubNuxtModule({ preset: "cloudflare" }, nuxt)
 
     expect((nuxt.options.vite as typeof nuxt.options.vite & {
       [VITEHUB_SERVER_DIRS]?: string[]
@@ -265,7 +265,7 @@ describe("ViteHub Nuxt integration", () => {
       workspace: false,
     })
 
-    viteHubNuxtModule({ preset: "cloudflare" }, nuxt)
+    await viteHubNuxtModule({ preset: "cloudflare" }, nuxt)
     await runNitroConfigHook({})
 
     expect(mocks.agentHook).toHaveBeenCalledWith(
@@ -275,6 +275,23 @@ describe("ViteHub Nuxt integration", () => {
       }),
       expect.anything(),
     )
+  })
+
+  it("installs the Database Nuxt runtime alias through the framework module", async () => {
+    const { nuxt, runNitroConfigHook } = createNuxt()
+
+    await viteHubNuxtModule({ database: true, preset: "cloudflare" }, nuxt)
+    const nitroConfig = { preset: "cloudflare_module" }
+    await runNitroConfigHook(nitroConfig)
+
+    expect((nuxt.options.vite.plugins as unknown[]).flat(Infinity)).toContainEqual(
+      expect.objectContaining({ name: "@vite-hub/database/vite" }),
+    )
+    expect(nitroConfig).toMatchObject({
+      alias: {
+        "@vite-hub/database/drizzle": "/tmp/vitehub-nuxt/app/.vitehub/database/cloudflare-runtime.mjs",
+      },
+    })
   })
 
   it("does not concatenate complete Nitro arrays returned by config hooks", async () => {
@@ -300,7 +317,7 @@ describe("ViteHub Nuxt integration", () => {
     const { nuxt, runNitroConfigHook } = createNuxt()
     const nitroConfig = {}
 
-    viteHubNuxtModule({ preset: "node" }, nuxt)
+    await viteHubNuxtModule({ preset: "node" }, nuxt)
     await runNitroConfigHook(nitroConfig)
 
     expect(nitroConfig).toEqual({
@@ -308,8 +325,8 @@ describe("ViteHub Nuxt integration", () => {
     })
   })
 
-  it("does nothing when Nuxt has not initialized", () => {
-    expect(() => viteHubNuxtModule({ preset: "node" })).not.toThrow()
+  it("does nothing when Nuxt has not initialized", async () => {
+    await expect(viteHubNuxtModule({ preset: "node" })).resolves.toBeUndefined()
     expect(mocks.vitehub).not.toHaveBeenCalled()
   })
 })

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -52,6 +52,7 @@ const generatedRuntimeOwnerExports = new Set([
   "@vite-hub/blob/runtime/cloudflare-vite",
   "@vite-hub/blob/runtime/state",
   "@vite-hub/blob/runtime/vercel-vite",
+  "@vite-hub/database/runtime/agent",
   "@vite-hub/database/runtime/cloudflare-vite",
   "@vite-hub/database/runtime/hosted",
   "@vite-hub/database/runtime/state",


### PR DESCRIPTION
## What changed

- automatically register the configured ViteHub Database primitive in generated hosted Agent routes
- expose the Agent SQL adapter from generated Cloudflare and Vercel database runtimes
- alias `@vite-hub/database/drizzle` to that generated runtime during Nuxt/Nitro production builds

## Why

Hosted Agent routes could advertise the `db()` capability while bundling the package fallback registry, which is empty outside Vite's transform pipeline. Database tools then failed even though the app's D1 binding and normal Drizzle client were healthy.

This keeps the ownership inside ViteHub: apps configure `hubDb()` once, and hosted Agents receive that same database runtime without app-local adapter wiring.

## Validation

- `pnpm --filter @vite-hub/database test -- run test/runtime.test.ts test/nuxt.test.ts test/vite-output.test.ts` — 47 tests passed
- `pnpm --filter @vite-hub/database typecheck`
- `pnpm --filter @vite-hub/agent test -- run test/providers.test.ts` — 191 tests passed