### PR TITLE
feat(agent): add a usage cost capability

### DIFF
--- a/docs/content/docs/capabilities/official-capabilities.md
+++ b/docs/content/docs/capabilities/official-capabilities.md
@@ -39,6 +39,7 @@ import {
   skills,
   subagents,
   transcribe,
+  usageCost,
   webSearch,
   workspaceShell,
 } from '@vite-hub/agent/capabilities'
@@ -99,6 +100,7 @@ import {
 | Chat summary | [`chatSummary()`](/docs/capabilities/chat-summary) | A summary command should replace explicit input with a conversation summary. |
 | Progress summary | [`progressSummary()`](/docs/capabilities/progress-summary) | A streaming Agent should explain its current reasoning and tool activity in one user-facing sentence. |
 | Papercut reports | [`papercuts()`](/docs/capabilities/papercuts) | An Agent should report small runtime or developer-experience friction to an application-owned sink. |
+| Usage cost | [`usageCost()`](/docs/capabilities/usage-cost) | Agent Usage Records should include a best-effort monetary cost before Finish Hooks and client usage emission. |
 
 ## Read capability pages first
 

--- a/docs/content/docs/capabilities/usage-cost.md
+++ b/docs/content/docs/capabilities/usage-cost.md
@@ -1,0 +1,91 @@
+---
+title: Usage cost
+description: Enrich Agent Usage Records with best-effort monetary cost.
+navigation.title: Usage cost
+navigation.order: 230
+navigation.group: Decisions and output
+icon: i-lucide-coins
+---
+
+`usageCost()` enriches ViteHub's canonical Agent Usage Record with monetary cost before Agent Finish Hooks run and before streamed usage is emitted to clients. Raw usage capture remains part of the Agent Invocation whether or not you install this Capability.
+
+## Add usage cost
+
+```ts [server/agents/support.ts]
+import { defineAgent } from '@vite-hub/agent'
+import { usageCost } from '@vite-hub/agent/capabilities'
+
+export default defineAgent({
+  driver: { model },
+  capabilities: [
+    usageCost(),
+  ],
+})
+```
+
+The default pricing callback fetches Vercel AI Gateway's public model catalog. It uses exact decimal arithmetic for regular input, cache-read, cache-write, and output tokens, caches successful catalog responses for five minutes, and bounds each catalog request to ten seconds.
+
+Pricing is best-effort. A missing model match, unavailable catalog, timeout, invalid price, or pricing callback error leaves the usage record and successful Agent Invocation unchanged. A cost already reported by the provider remains authoritative.
+
+## Read the enriched record
+
+Finish Hooks read the canonical record from `event.invocation.usage`. The Capability also returns that same object from its typed finish extension.
+
+```ts [server/agents/support.ts]
+defineAgent({
+  driver: { model },
+  capabilities: [usageCost()],
+  hooks: {
+    'agent:finish'(event) {
+      const usage = event.invocation.usage
+      const enrichedUsage = event.extensions.get('usage-cost')
+
+      console.log(usage?.cost, enrichedUsage?.cost)
+    },
+  },
+})
+```
+
+Agent output keeps its existing usage shape. For streams, ViteHub waits to resolve pricing until the usage record becomes available during consumption, then enriches it before client emission and Finish Hooks.
+
+## Provide application pricing
+
+Pass `pricing` when the application owns its catalog or provider mapping. The callback uses ViteHub types and does not require a provider SDK.
+
+```ts [server/agents/support.ts]
+import type { AgentUsagePricing } from '@vite-hub/agent/capabilities'
+
+const pricing: AgentUsagePricing = ({ model, usage }) => {
+  if (model?.id !== 'internal/support-model') return
+
+  return {
+    amount: String((usage.totalTokens ?? 0) / 1_000_000),
+    currency: 'USD',
+    estimated: true,
+    source: 'custom',
+  }
+}
+
+defineAgent({
+  driver: { model },
+  capabilities: [usageCost({ pricing })],
+})
+```
+
+Return `undefined` when pricing is unavailable. Keep the callback deterministic for the supplied model and usage record; ViteHub may call it while a stream is being consumed.
+
+## Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `pricing` | `AgentUsagePricing` | Vercel AI Gateway catalog pricing | Resolves a cost from the model, response metadata, Agent Run metadata, and token usage. |
+
+## Verify it
+
+Invoke the Agent with a model that reports token usage. Confirm that `event.invocation.usage` is present without the Capability, then install `usageCost()` and confirm a matched model adds `cost`. Test missing and failing pricing callbacks too: both must preserve the successful Agent Invocation and raw usage.
+
+## Related
+
+- [Agent Invocations](/docs/concepts/agent-invocations)
+- [Runtime events](/docs/reference/runtime-events)
+- [Custom capabilities](/docs/capabilities/custom-capabilities)

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -83,6 +83,14 @@ export {
   elevenLabsScribe,
 } from "./transcription-elevenlabs.ts"
 export {
+  usageCost,
+} from "./usage-cost.ts"
+export type {
+  AgentUsagePricing,
+  AgentUsagePricingContext,
+  UsageCostOptions,
+} from "./usage-cost.ts"
+export {
   workspaceShell,
 } from "./workspace-shell.ts"
 export type {

--- a/packages/agent/src/capabilities/usage-cost.ts
+++ b/packages/agent/src/capabilities/usage-cost.ts
@@ -1,4 +1,4 @@
-import { defineCapability } from "../capability-runtime.ts"
+import { defineCapability, eagerFinishExtensionSymbol } from "../capability-runtime.ts"
 import { vercelAiGatewayPricing } from "../internal/usage-pricing.ts"
 
 import type { AgentCapabilityDefinition, AgentRuntimeConfig, AgentUsageRecord } from "../types.ts"
@@ -24,7 +24,7 @@ export function usageCost<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
 ): AgentCapabilityDefinition<TRuntimeConfig> {
   const pricing = options.pricing || vercelAiGatewayPricing()
 
-  return defineCapability<TRuntimeConfig>({
+  return Object.assign(defineCapability<TRuntimeConfig>({
     id: "usage-cost",
     metadata: {
       kind: "usage-cost",
@@ -48,5 +48,7 @@ export function usageCost<TRuntimeConfig extends AgentRuntimeConfig = AgentRunti
 
       return record
     },
+  }), {
+    [eagerFinishExtensionSymbol]: true,
   })
 }

--- a/packages/agent/src/capabilities/usage-cost.ts
+++ b/packages/agent/src/capabilities/usage-cost.ts
@@ -1,0 +1,52 @@
+import { defineCapability } from "../capability-runtime.ts"
+import { vercelAiGatewayPricing } from "../internal/usage-pricing.ts"
+
+import type { AgentCapabilityDefinition, AgentRuntimeConfig, AgentUsageRecord } from "../types.ts"
+import type { AgentUsagePricing } from "../internal/usage-pricing.ts"
+
+export type {
+  AgentUsagePricing,
+  AgentUsagePricingContext,
+} from "../internal/usage-pricing.ts"
+
+export interface UsageCostOptions {
+  pricing?: AgentUsagePricing
+}
+
+declare global {
+  interface ViteHubAgentFinishExtensions {
+    "usage-cost": AgentUsageRecord
+  }
+}
+
+export function usageCost<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
+  options: UsageCostOptions = {},
+): AgentCapabilityDefinition<TRuntimeConfig> {
+  const pricing = options.pricing || vercelAiGatewayPricing()
+
+  return defineCapability<TRuntimeConfig>({
+    id: "usage-cost",
+    metadata: {
+      kind: "usage-cost",
+    },
+    async finish(event) {
+      const record = event.invocation.usage
+      if (!record || record.cost || !record.usage) return record
+
+      try {
+        const cost = await pricing({
+          model: record.model,
+          response: record.response,
+          run: record.run || event.invocation.run,
+          usage: record.usage,
+        })
+        if (cost) record.cost = cost
+      }
+      catch {
+        return record
+      }
+
+      return record
+    },
+  })
+}

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -69,11 +69,13 @@ type ResolvedAgentOutputRenderer = ((result: unknown, extensions?: AgentOutputEx
 export const workspaceMaterializationPathsSymbol: unique symbol = Symbol("vitehub.agent.workspaceMaterializationPaths")
 export const globalSkillsSymbol: unique symbol = Symbol.for("vitehub.agent.globalSkills")
 export const capabilityInvocationStartSymbol: unique symbol = Symbol("vitehub.agent.capabilityInvocationStart")
+export const eagerFinishExtensionSymbol: unique symbol = Symbol("vitehub.agent.eagerFinishExtension")
 type InternalAgentCapabilityDefinition<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 > = AgentCapabilityDefinition<TRuntimeConfig, Name> & {
   [capabilityInvocationStartSymbol]?: (context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>) => MaybePromise<void>
+  [eagerFinishExtensionSymbol]?: boolean
   [globalSkillsSymbol]?: AgentGlobalSkill
   [workspaceMaterializationPathsSymbol]?: readonly string[]
 }
@@ -91,6 +93,7 @@ type AgentCapabilityRuntimePhase = typeof defaultCapabilityRuntimePhases[number]
 export const optionalWorkspaceCapabilitySymbol: unique symbol = Symbol("vitehub.agent.optionalWorkspaceCapability")
 
 export interface ResolvedAgentFinishExtensionProvider {
+  eager?: boolean
   id: string
   resolve: AgentFinishExtensionProvider
 }
@@ -908,8 +911,9 @@ export async function resolveAgentCapabilities<
     })
   }
 
-  function addFinishExtensionProvider(capabilityId: string, value: unknown | AgentFinishExtensionProvider) {
+  function addFinishExtensionProvider(capabilityId: string, value: unknown | AgentFinishExtensionProvider, eager?: boolean) {
     registries.finishExtensionProviders.push({
+      ...(eager ? { eager: true } : {}),
       id: capabilityId,
       resolve: typeof value === "function"
         ? value as AgentFinishExtensionProvider
@@ -1116,7 +1120,13 @@ export async function resolveAgentCapabilities<
         workspace: currentWorkspace,
       } as AgentCapabilityRuntimeContext<TRuntimeConfig, Name> & WorkspaceOverrideRuntime<Name>
       capabilityContexts.push({ capability, context: capabilityContext })
-      if (capability.finish) addFinishExtensionProvider(capability.id, capability.finish)
+      if (capability.finish) {
+        addFinishExtensionProvider(
+          capability.id,
+          capability.finish,
+          (capability as InternalAgentCapabilityDefinition<TRuntimeConfig, Name>)[eagerFinishExtensionSymbol],
+        )
+      }
 
       for (const [name, trigger] of Object.entries(capability.triggers || {})) {
         assertTriggerName(name, capability.id)

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1385,7 +1385,7 @@ export async function createAgentInvocationExtensions(
 }
 
 type CapabilityCleanupOutcome =
-  | { failed: false }
+  | { completed?: boolean, failed: false }
   | { error: unknown, failed: true }
 
 async function closeCapabilityStreamIterator(
@@ -1418,7 +1418,7 @@ async function closeCapabilityStreamIterator(
       }
     }
   }
-  await close(outcome)
+  await close(outcome.failed ? outcome : { completed, failed: false })
 }
 
 export function withCapabilityCleanup<T extends AsyncIterable<unknown>>(

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1458,18 +1458,18 @@ export function withResponseCleanup(
   options: { onChunk?: (chunk: Uint8Array) => void } = {},
 ): Response | Promise<Response> {
   if (!response.body) {
-    return close({ failed: false }).then(() => response)
+    return close({ completed: true, failed: false }).then(() => response)
   }
   const reader = response.body.getReader()
   let closed = false
-  async function closeOnce(outcome: CapabilityCleanupOutcome = { failed: false }) {
+  async function closeOnce(outcome: CapabilityCleanupOutcome = { completed: true, failed: false }) {
     if (closed) return
     closed = true
     await close(outcome)
   }
   const wrapped = new Response(new ReadableStream({
     async cancel(reason) {
-      let cancelOutcome: CapabilityCleanupOutcome = reason === undefined ? { failed: false } : { error: reason, failed: true }
+      let cancelOutcome: CapabilityCleanupOutcome = reason === undefined ? { completed: false, failed: false } : { error: reason, failed: true }
       try {
         await reader.cancel(reason)
       }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1977,6 +1977,28 @@ function withEagerStreamUsageExtensions<
   })()
 }
 
+function withEagerUiMessageStreamUsageExtensions<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  rendered: unknown,
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+): unknown {
+  if (!isUIMessageStreamResult(rendered)) return rendered
+  const toUIMessageStream = rendered.toUIMessageStream as (...args: unknown[]) => ReadableStream<unknown>
+  return cloneWithPropertyDescriptors(rendered, {
+    toUIMessageStream: {
+      configurable: true,
+      enumerable: false,
+      value: (...args: unknown[]) => toReadableAsyncIterableStream(withEagerStreamUsageExtensions(
+        toReadableAsyncIterableStream(toUIMessageStream.apply(rendered, args)),
+        context,
+        rendered,
+      )),
+    },
+  })
+}
+
 function withStreamResultProperties<T extends AsyncIterable<StreamEvent>>(stream: T, result: unknown): T {
   if (typeof stream !== "object" || stream === null || typeof result !== "object" || result === null) return stream
   Object.defineProperties(stream, Object.fromEntries(["usage", "usageRecord"].map(key => [key, {
@@ -2755,7 +2777,9 @@ async function executeAgentInvocation<
 
   if (options.kind === "run") {
     return await finalizeAgentInvocationResult(invocation, lifecycle, result, async (result) => {
-      const driverUsageRecord = await resolveFinishUsageRecord(invocation, result)
+      const driverUsageRecord = hasTraceableStreamResult(result)
+        ? undefined
+        : await resolveFinishUsageRecord(invocation, result)
       const rendered = options.renderOutput
         ? renderedResult ? result : await applyOutputRenderers(result, invocation.outputRenderers, invocation.outputExtensionProviders, outputExtensions)
         : result
@@ -2891,7 +2915,9 @@ async function executeAgentInvocation<
   }
 
   return await finalizeAgentInvocationResult(invocation, lifecycle, result, async (result) => {
-    const driverUsageRecord = await resolveFinishUsageRecord(invocation, result)
+    const driverUsageRecord = hasTraceableStreamResult(result)
+      ? undefined
+      : await resolveFinishUsageRecord(invocation, result)
     const rendered = renderedResult ? result : await applyOutputRenderers(result, invocation.outputRenderers, invocation.outputExtensionProviders, outputExtensions)
     if (options.output === "ui-message-stream") {
       const projection = typeof definition?.uiMessageStream === "function"
@@ -2899,7 +2925,7 @@ async function executeAgentInvocation<
         : definition?.uiMessageStream
       const enrichedRendered = isAsyncIterable(rendered)
         ? withEagerStreamUsageExtensions(rendered, invocation, rendered)
-        : rendered
+        : withEagerUiMessageStreamUsageExtensions(rendered, invocation)
       return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(enrichedRendered, invocation), shouldWrapInvocationOutput(invocation), async (outcome, streamedText, streamedUsageRecord) => {
         await finishStreamAgentInvocation(invocation, lifecycle, resultWithStreamedTextAndUsage(rendered, streamedText || "", streamedUsageRecord, driverUsageRecord), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
       }, projection)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2843,7 +2843,17 @@ async function executeAgentInvocation<
                   if (finishTask) return await finishTask
                   const finishResult = resultWithStreamedTextAndUsage(preserved, streamedText, streamedUsageRecord, driverUsageRecord)
                   finishTask = (async () => {
-                    await finishStreamAgentInvocation(invocation, lifecycle, finishResult, finishOutcomeFromCleanup(outcome), runFailureMessage, outputExtensions)
+                    if (!outcome.failed && !outcome.completed) {
+                      await lifecycle.finish({
+                        result: finishResult,
+                        status: "success",
+                        ...(streamedUsageRecord ? { usage: streamedUsageRecord } : {}),
+                        usageResolved: true,
+                      })
+                    }
+                    else {
+                      await finishStreamAgentInvocation(invocation, lifecycle, finishResult, finishOutcomeFromCleanup(outcome), runFailureMessage, outputExtensions)
+                    }
                     const usageRecord = finishResult && typeof finishResult === "object"
                       ? (finishResult as { usageRecord?: AgentUsageRecord }).usageRecord
                       : undefined
@@ -2995,7 +3005,18 @@ async function executeAgentInvocation<
         ? withEagerStreamUsageExtensions(rendered, invocation, rendered)
         : withEagerUiMessageStreamUsageExtensions(rendered, invocation)
       return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(enrichedRendered, invocation), shouldWrapInvocationOutput(invocation), async (outcome, streamedText, streamedUsageRecord) => {
-        await finishStreamAgentInvocation(invocation, lifecycle, resultWithStreamedTextAndUsage(rendered, streamedText || "", streamedUsageRecord, driverUsageRecord), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
+        const finishResult = resultWithStreamedTextAndUsage(rendered, streamedText || "", streamedUsageRecord, driverUsageRecord)
+        if (!outcome.failed && !outcome.completed) {
+          await lifecycle.finish({
+            result: finishResult,
+            status: "success",
+            ...(streamedUsageRecord ? { usage: streamedUsageRecord } : {}),
+            usageResolved: true,
+          })
+        }
+        else {
+          await finishStreamAgentInvocation(invocation, lifecycle, finishResult, finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
+        }
       }, projection)
     }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3041,7 +3041,18 @@ async function executeAgentInvocation<
     const shouldWrapOutput = shouldWrapInvocationOutput(invocation)
     const value = shouldWrapOutput
       ? withCapabilityCleanup(tracedStream, async (outcome) => {
-          await finishStreamAgentInvocation(invocation, lifecycle, streamed.finishResult(), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
+          const finishResult = streamed.finishResult()
+          if (!outcome.failed && !outcome.completed) {
+            await lifecycle.finish({
+              result: finishResult,
+              status: "success",
+              ...(streamed.finishUsage() ? { usage: streamed.finishUsage() } : {}),
+              usageResolved: true,
+            })
+          }
+          else {
+            await finishStreamAgentInvocation(invocation, lifecycle, finishResult, finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
+          }
         }, { abortSignal: invocation.input.abortSignal }) as AsyncIterable<StreamEvent>
       : tracedStream
     return {
@@ -3060,8 +3071,18 @@ async function executeAgentInvocation<
             toUIMessageStream: () => uiMessageStreamFromResponse(response),
           }, invocation)
           const finalized = await finalizeUiMessageStreamOutput(enrichedResponseStream, shouldWrapInvocationOutput(invocation), async (outcome, streamedText, streamedUsageRecord) => {
-            const driverUsageRecord = await resolveFinishUsageRecord(invocation, response)
-            await finishStreamAgentInvocation(invocation, lifecycle, resultWithStreamedTextAndUsage(response, streamedText || "", streamedUsageRecord, driverUsageRecord), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
+            if (!outcome.failed && !outcome.completed) {
+              await lifecycle.finish({
+                result: resultWithStreamedTextAndUsage(response, streamedText || "", streamedUsageRecord),
+                status: "success",
+                ...(streamedUsageRecord ? { usage: streamedUsageRecord } : {}),
+                usageResolved: true,
+              })
+            }
+            else {
+              const driverUsageRecord = await resolveFinishUsageRecord(invocation, response)
+              await finishStreamAgentInvocation(invocation, lifecycle, resultWithStreamedTextAndUsage(response, streamedText || "", streamedUsageRecord, driverUsageRecord), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
+            }
           }, projection)
           const headers = new Headers(response.headers)
           headers.delete("content-encoding")

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2803,7 +2803,11 @@ async function executeAgentInvocation<
               configurable: true,
               enumerable: false,
               value: (...args: unknown[]) => withReadableStreamCleanup(
-                normalizeUiMessageStream(toUIMessageStream.apply(rendered, args)),
+                toReadableAsyncIterableStream(withEagerStreamUsageExtensions(
+                  toReadableAsyncIterableStream(normalizeUiMessageStream(toUIMessageStream.apply(rendered, args))),
+                  invocation,
+                  rendered,
+                )),
                 outcome => (finishTask ??= finishStreamAgentInvocation(invocation, lifecycle, resultWithStreamedTextAndUsage(rendered, streamedText, streamedUsageRecord, driverUsageRecord), finishOutcomeFromCleanup(outcome), runFailureMessage, outputExtensions)),
                 {
                   onChunk(chunk) {
@@ -2967,9 +2971,10 @@ async function executeAgentInvocation<
           const projection = typeof definition?.uiMessageStream === "function"
             ? await definition.uiMessageStream(invocation)
             : definition?.uiMessageStream
-          const finalized = await finalizeUiMessageStreamOutput({
+          const enrichedResponseStream = withEagerUiMessageStreamUsageExtensions({
             toUIMessageStream: () => uiMessageStreamFromResponse(response),
-          }, shouldWrapInvocationOutput(invocation), async (outcome, streamedText, streamedUsageRecord) => {
+          }, invocation)
+          const finalized = await finalizeUiMessageStreamOutput(enrichedResponseStream, shouldWrapInvocationOutput(invocation), async (outcome, streamedText, streamedUsageRecord) => {
             const driverUsageRecord = await resolveFinishUsageRecord(invocation, response)
             await finishStreamAgentInvocation(invocation, lifecycle, resultWithStreamedTextAndUsage(response, streamedText || "", streamedUsageRecord, driverUsageRecord), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
           }, projection)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1976,6 +1976,29 @@ function resultWithUsageRecord(result: unknown, usageRecord: Extract<StreamEvent
   return result
 }
 
+function resultWithResolvedUsageRecord(result: unknown, usageRecord: AgentUsageRecord | undefined): unknown {
+  if (!usageRecord || result instanceof Response) return result
+  if (!result || typeof result !== "object") return resultWithUsageRecord(result, usageRecord)
+  return cloneWithPropertyDescriptors(result, {
+    ...(usageRecord.usage
+      ? {
+          usage: {
+            configurable: true,
+            enumerable: true,
+            value: usageRecord.usage,
+            writable: true,
+          },
+        }
+      : {}),
+    usageRecord: {
+      configurable: true,
+      enumerable: true,
+      value: usageRecord,
+      writable: true,
+    },
+  })
+}
+
 function resultWithStreamedTextAndUsage(
   result: unknown,
   text: string,
@@ -2745,16 +2768,21 @@ async function executeAgentInvocation<
       const structuredUsageRecord = options.renderOutput && invocation.output
         ? await resolveFinishUsageRecord(invocation, structuredFinal) ?? driverUsageRecord
         : driverUsageRecord
+      const hasEagerFinishExtension = invocation.finishExtensionProviders.some(provider => provider.eager)
       const finishResult = invocation.output
         ? undefined
-        : hasFinishWork(invocation) ? resultWithUsageRecord(final, driverUsageRecord) : final
+        : hasEagerFinishExtension
+          ? resultWithResolvedUsageRecord(final, driverUsageRecord)
+          : hasFinishWork(invocation) ? resultWithUsageRecord(final, driverUsageRecord) : final
       const value = options.renderOutput && invocation.output
         ? await validateAgentOutput(invocation.output, structuredFinal, {
             allowMaterializedObject: customRun
               ? structuredFinal === final
               : structuredFinal === final && final !== result,
           })
-        : customRun ? final : options.renderOutput ? toAgentRunResult(finishResult) : final
+        : customRun
+          ? hasEagerFinishExtension ? finishResult : final
+          : options.renderOutput ? toAgentRunResult(finishResult) : final
       return {
         finishResult: invocation.output ? value : finishResult,
         finishUsage: structuredUsageRecord,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2134,8 +2134,8 @@ function withStreamedResult(
   let unphasedText = ""
   let usageRecord: Extract<StreamEvent, { type: "usage" }>["usageRecord"] | undefined
   return {
-    finishResult() {
-      return resultWithStreamedTextAndUsage(result, explicitTextPhaseSeen ? finalText : unphasedText, usageRecord, fallbackUsageRecord)
+    finishResult(resultOverride: unknown = result) {
+      return resultWithStreamedTextAndUsage(resultOverride, explicitTextPhaseSeen ? finalText : unphasedText, usageRecord, fallbackUsageRecord)
     },
     finishUsage() {
       return usageRecord ?? fallbackUsageRecord
@@ -2186,7 +2186,21 @@ async function finishStreamAgentInvocation<
   try {
     const usageRecord = await resolveFinishUsageRecord(context, result)
     finishUsage = usageRecord
-    finishResult = await applyFinalOutputRenderers(result, context, outputExtensions)
+    const resolvedResult = resultWithResolvedUsageRecord(result, usageRecord)
+    if (usageRecord && resolvedResult !== result && result && typeof result === "object" && Object.isExtensible(result)) {
+      try {
+        Object.defineProperty(result, "usageRecord", {
+          configurable: true,
+          enumerable: true,
+          value: usageRecord,
+          writable: true,
+        })
+      }
+      catch {
+        // The resolved wrapper still carries usage when the original result cannot.
+      }
+    }
+    finishResult = await applyFinalOutputRenderers(resolvedResult, context, outputExtensions)
     finishResult = context.output
       ? await validateAgentOutput(context.output, await materializeAgentStructuredOutput(finishResult, context.input.abortSignal), { allowMaterializedObject: finishResult !== result })
       : resultWithUsageRecord(finishResult, usageRecord)
@@ -2304,7 +2318,7 @@ async function resolveFinishUsageRecord<
 }
 
 type AgentInvocationFinishOutcome =
-  | { result?: unknown, status: "success", usage?: AgentUsageRecord }
+  | { result?: unknown, status: "success", usage?: AgentUsageRecord, usageResolved?: boolean }
   | { error: unknown, status: "error" }
 
 function finishOutcomeFromCleanup(outcome: { failed: false } | { error: unknown, failed: true }, result?: unknown): AgentInvocationFinishOutcome {
@@ -2529,7 +2543,7 @@ async function finishAgentInvocation<
     if (!failed) {
       try {
         resultKind = agentResultKind(result)
-        usage ??= await resolveAgentUsageRecord(result, context.run)
+        if (!outcome.usageResolved) usage ??= await resolveAgentUsageRecord(result, context.run)
       }
       catch {
         // Invocation data must not change Agent output or mask the original failure.
@@ -2844,11 +2858,28 @@ async function executeAgentInvocation<
         const streamProperties = (["stream", "fullStream"] as const)
           .filter(property => isAsyncIterable((rendered as { fullStream?: unknown, stream?: unknown })[property]))
         let finishTask: Promise<void> | undefined
+        let preserved: object
         const preserveStream = (renderedStream: AsyncIterable<unknown>) => {
           const enrichedStream = withEagerStreamUsageExtensions(renderedStream, invocation, rendered)
           const streamed = withStreamedResult(enrichedStream, rendered, driverUsageRecord)
-          const value = withCapabilityCleanup(streamed.stream, (outcome) => {
-            return finishTask ??= finishStreamAgentInvocation(invocation, lifecycle, streamed.finishResult(), finishOutcomeFromCleanup(outcome), runFailureMessage, outputExtensions)
+          const value = withCapabilityCleanup(streamed.stream, async (outcome) => {
+            if (finishTask) return await finishTask
+            const finishResult = streamed.finishResult(preserved)
+            finishTask = !outcome.failed && !outcome.completed
+              ? lifecycle.finish({
+                  result: finishResult,
+                  status: "success",
+                  ...(streamed.finishUsage() ? { usage: streamed.finishUsage() } : {}),
+                  usageResolved: true,
+                })
+              : (async () => {
+                  await finishStreamAgentInvocation(invocation, lifecycle, finishResult, finishOutcomeFromCleanup(outcome), runFailureMessage, outputExtensions)
+                  const usageRecord = finishResult && typeof finishResult === "object"
+                    ? (finishResult as { usageRecord?: AgentUsageRecord }).usageRecord
+                    : undefined
+                  if (usageRecord) resultWithUsageRecord(preserved, usageRecord)
+                })()
+            return await finishTask
           }, { abortSignal: invocation.input.abortSignal })
           const preservedStream = typeof (renderedStream as ReadableStream<unknown>).pipeThrough === "function"
             ? toReadableAsyncIterableStream(value)
@@ -2886,7 +2917,7 @@ async function executeAgentInvocation<
             },
           }
         }
-        const preserved = resultWithPreservedProperties(rendered as object, descriptors)
+        preserved = resultWithPreservedProperties(rendered as object, descriptors)
         return {
           deferFinish: true,
           finishResult: preserved,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2611,7 +2611,8 @@ async function finalizeAgentInvocationResult<
       return response
     }
     if (isAsyncIterable(result) && !hasTraceableStreamResult(result) && !options.finalizeRawStreams) {
-      const stream = options.wrapStream?.(result) || result
+      const wrappedStream = options.wrapStream?.(result) || result
+      const stream = withEagerStreamUsageExtensions(wrappedStream, context, result)
       if (shouldWrapOutput) {
         const streamed = withStreamedResult(stream, result)
         if (!context.finalOutputRenderers.length && (!context.output || !options.finalizeRawStreams)) {
@@ -2883,10 +2884,7 @@ async function executeAgentInvocation<
       outputExtensions,
       ...(customRun
         ? {
-            wrapStream: (stream: AsyncIterable<unknown>) => maybeTraceAgentStream(
-              withEagerStreamUsageExtensions(stream, invocation, result) as AsyncIterable<StreamEvent>,
-              invocation,
-            ),
+            wrapStream: (stream: AsyncIterable<unknown>) => maybeTraceAgentStream(stream as AsyncIterable<StreamEvent>, invocation),
           }
         : {}),
     })

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1970,9 +1970,32 @@ function withEagerStreamUsageExtensions<
         runtime: context.runtimeContext,
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
       await createAgentInvocationExtensions(eventBase as never, providers)
-      yield chunk && typeof chunk === "object"
-        ? { ...chunk, usageRecord: usage }
-        : { type: "usage", usageRecord: usage }
+      if (chunk && typeof chunk === "object") {
+        const prototype = Object.getPrototypeOf(chunk)
+        if (prototype !== Object.prototype && prototype !== null) {
+          if (Object.isExtensible(chunk)) {
+            try {
+              Object.defineProperty(chunk, "usageRecord", {
+                configurable: true,
+                enumerable: true,
+                value: usage,
+                writable: true,
+              })
+              yield chunk
+              continue
+            }
+            catch {
+              // Preserve the custom chunk and emit the canonical record separately.
+            }
+          }
+          yield chunk
+          yield { type: "usage", usageRecord: usage }
+          continue
+        }
+        yield { ...chunk, usageRecord: usage }
+        continue
+      }
+      yield { type: "usage", usageRecord: usage }
     }
   })()
 }
@@ -2014,7 +2037,10 @@ function resultWithStreamedText(result: unknown, text: string): unknown {
   if (result && typeof result === "object" && !(result instanceof Response)) {
     const descriptor = Object.getOwnPropertyDescriptor(result, "text")
     const current = descriptor && "value" in descriptor ? descriptor.value : undefined
-    return typeof current === "string" && current ? result : cloneWithPropertyDescriptors(result, {
+    if (typeof current === "string" && current) return result
+    const prototype = Object.getPrototypeOf(result)
+    if (prototype !== Object.prototype && prototype !== null && !Object.isExtensible(result)) return result
+    return resultWithPreservedProperties(result, {
       text: {
         configurable: true,
         enumerable: true,
@@ -2654,7 +2680,12 @@ async function finalizeAgentInvocationResult<
         const finishResult = responseText && !outcome.failed
           ? { raw: result, text: responseText }
           : result
-        await lifecycle.finish(finishOutcomeFromCleanup(outcome, finishResult))
+        if (!outcome.failed && !outcome.completed) {
+          await lifecycle.finish({ result: finishResult, status: "success", usageResolved: true })
+        }
+        else {
+          await lifecycle.finish(finishOutcomeFromCleanup(outcome, finishResult))
+        }
       }, {
         onChunk: chunk => responseText += responseDecoder?.decode(chunk, { stream: true }) ?? "",
       }) : result
@@ -2669,6 +2700,14 @@ async function finalizeAgentInvocationResult<
           return withCapabilityCleanup(streamed.stream, async (outcome) => {
             const finishOutcome = finishOutcomeFromCleanup(outcome, result)
             const usage = streamed.finishUsage()
+            if (!outcome.failed && !outcome.completed) {
+              return lifecycle.finish({
+                result,
+                status: "success",
+                ...(usage ? { usage: await resolveAgentUsageRecord({ usageRecord: usage }, context.run) } : {}),
+                usageResolved: true,
+              })
+            }
             return lifecycle.finish(finishOutcome.status === "success"
               ? { ...finishOutcome, usage: usage ? await resolveAgentUsageRecord({ usageRecord: usage }, context.run) : undefined }
               : finishOutcome)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1938,16 +1938,19 @@ function withEagerStreamUsageExtensions<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(
-  stream: AsyncIterable<StreamEvent>,
+  stream: AsyncIterable<unknown>,
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
   result: unknown,
-): AsyncIterable<StreamEvent> {
+): AsyncIterable<unknown> {
   const providers = context.finishExtensionProviders.filter(provider => provider.eager)
   if (!providers.length) return stream
   return (async function* () {
-    for await (const event of stream) {
-      if (event.type !== "usage") {
-        yield event
+    const toolNames = new Map<string, string>()
+    const textPhases = new Map<string, AgentMessagePhase | "hidden">()
+    for await (const chunk of stream) {
+      const event = toAgentStreamEvent(chunk, toolNames, textPhases)
+      if (event?.type !== "usage") {
+        yield chunk
         continue
       }
       const usage = { ...event.usageRecord }
@@ -1964,7 +1967,9 @@ function withEagerStreamUsageExtensions<
         runtime: context.runtimeContext,
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
       await createAgentInvocationExtensions(eventBase as never, providers)
-      yield { ...event, usageRecord: usage }
+      yield chunk && typeof chunk === "object"
+        ? { ...chunk, usageRecord: usage }
+        : { ...event, usageRecord: usage }
     }
   })()
 }
@@ -2786,7 +2791,8 @@ async function executeAgentInvocation<
           .filter(property => isAsyncIterable((rendered as { fullStream?: unknown, stream?: unknown })[property]))
         let finishTask: Promise<void> | undefined
         const preserveStream = (renderedStream: AsyncIterable<unknown>) => {
-          const streamed = withStreamedResult(renderedStream, rendered, driverUsageRecord)
+          const enrichedStream = withEagerStreamUsageExtensions(renderedStream, invocation, rendered)
+          const streamed = withStreamedResult(enrichedStream, rendered, driverUsageRecord)
           const value = withCapabilityCleanup(streamed.stream, (outcome) => {
             return finishTask ??= finishStreamAgentInvocation(invocation, lifecycle, streamed.finishResult(), finishOutcomeFromCleanup(outcome), runFailureMessage, outputExtensions)
           }, { abortSignal: invocation.input.abortSignal })
@@ -2868,7 +2874,12 @@ async function executeAgentInvocation<
       finalizeRawStreams: options.renderOutput && Boolean(invocation.output),
       outputExtensions,
       ...(customRun
-        ? { wrapStream: (stream: AsyncIterable<unknown>) => maybeTraceAgentStream(stream as AsyncIterable<StreamEvent>, invocation) }
+        ? {
+            wrapStream: (stream: AsyncIterable<unknown>) => maybeTraceAgentStream(
+              withEagerStreamUsageExtensions(stream, invocation, result) as AsyncIterable<StreamEvent>,
+              invocation,
+            ),
+          }
         : {}),
     })
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1979,6 +1979,15 @@ function resultWithUsageRecord(result: unknown, usageRecord: Extract<StreamEvent
 function resultWithResolvedUsageRecord(result: unknown, usageRecord: AgentUsageRecord | undefined): unknown {
   if (!usageRecord || result instanceof Response) return result
   if (!result || typeof result !== "object") return resultWithUsageRecord(result, usageRecord)
+  const prototype = Object.getPrototypeOf(result)
+  if (prototype !== Object.prototype && prototype !== null) {
+    return {
+      ...toAgentRunResult(result),
+      raw: result,
+      usage: usageRecord.usage,
+      usageRecord,
+    }
+  }
   return cloneWithPropertyDescriptors(result, {
     ...(usageRecord.usage
       ? {
@@ -2765,15 +2774,18 @@ async function executeAgentInvocation<
             invocation.context.get<AgentOutputEventObserver>(agentOutputEventObserverContextKey),
           )
         : final
-      const structuredUsageRecord = options.renderOutput && invocation.output
+      const resolvedUsageRecord = options.renderOutput && invocation.output
         ? await resolveFinishUsageRecord(invocation, structuredFinal) ?? driverUsageRecord
         : driverUsageRecord
       const hasEagerFinishExtension = invocation.finishExtensionProviders.some(provider => provider.eager)
+      const structuredUsageRecord = hasEagerFinishExtension && resolvedUsageRecord
+        ? { ...resolvedUsageRecord }
+        : resolvedUsageRecord
       const finishResult = invocation.output
         ? undefined
         : hasEagerFinishExtension
-          ? resultWithResolvedUsageRecord(final, driverUsageRecord)
-          : hasFinishWork(invocation) ? resultWithUsageRecord(final, driverUsageRecord) : final
+          ? resultWithResolvedUsageRecord(final, structuredUsageRecord)
+          : hasFinishWork(invocation) ? resultWithUsageRecord(final, structuredUsageRecord) : final
       const value = options.renderOutput && invocation.output
         ? await validateAgentOutput(invocation.output, structuredFinal, {
             allowMaterializedObject: customRun

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2897,7 +2897,10 @@ async function executeAgentInvocation<
       const projection = typeof definition?.uiMessageStream === "function"
         ? await definition.uiMessageStream(invocation)
         : definition?.uiMessageStream
-      return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(rendered, invocation), shouldWrapInvocationOutput(invocation), async (outcome, streamedText, streamedUsageRecord) => {
+      const enrichedRendered = isAsyncIterable(rendered)
+        ? withEagerStreamUsageExtensions(rendered, invocation, rendered)
+        : rendered
+      return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(enrichedRendered, invocation), shouldWrapInvocationOutput(invocation), async (outcome, streamedText, streamedUsageRecord) => {
         await finishStreamAgentInvocation(invocation, lifecycle, resultWithStreamedTextAndUsage(rendered, streamedText || "", streamedUsageRecord, driverUsageRecord), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
       }, projection)
     }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2884,7 +2884,9 @@ async function executeAgentInvocation<
                       await lifecycle.finish({
                         result: finishResult,
                         status: "success",
-                        ...(streamedUsageRecord ? { usage: streamedUsageRecord } : {}),
+                        ...(streamedUsageRecord
+                          ? { usage: await resolveAgentUsageRecord({ usageRecord: streamedUsageRecord }, invocation.run) }
+                          : {}),
                         usageResolved: true,
                       })
                     }
@@ -2927,7 +2929,9 @@ async function executeAgentInvocation<
               ? lifecycle.finish({
                   result: finishResult,
                   status: "success",
-                  ...(streamed.finishUsage() ? { usage: streamed.finishUsage() } : {}),
+                  ...(streamed.finishUsage()
+                    ? { usage: await resolveAgentUsageRecord({ usageRecord: streamed.finishUsage() }, invocation.run) }
+                    : {}),
                   usageResolved: true,
                 })
               : (async () => {
@@ -3047,7 +3051,9 @@ async function executeAgentInvocation<
           await lifecycle.finish({
             result: finishResult,
             status: "success",
-            ...(streamedUsageRecord ? { usage: streamedUsageRecord } : {}),
+            ...(streamedUsageRecord
+              ? { usage: await resolveAgentUsageRecord({ usageRecord: streamedUsageRecord }, invocation.run) }
+              : {}),
             usageResolved: true,
           })
         }
@@ -3083,7 +3089,9 @@ async function executeAgentInvocation<
             await lifecycle.finish({
               result: finishResult,
               status: "success",
-              ...(streamed.finishUsage() ? { usage: streamed.finishUsage() } : {}),
+              ...(streamed.finishUsage()
+                ? { usage: await resolveAgentUsageRecord({ usageRecord: streamed.finishUsage() }, invocation.run) }
+                : {}),
               usageResolved: true,
             })
           }
@@ -3112,7 +3120,9 @@ async function executeAgentInvocation<
               await lifecycle.finish({
                 result: resultWithStreamedTextAndUsage(response, streamedText || "", streamedUsageRecord),
                 status: "success",
-                ...(streamedUsageRecord ? { usage: streamedUsageRecord } : {}),
+                ...(streamedUsageRecord
+                  ? { usage: await resolveAgentUsageRecord({ usageRecord: streamedUsageRecord }, invocation.run) }
+                  : {}),
                 usageResolved: true,
               })
             }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1949,9 +1949,7 @@ function withEagerStreamUsageExtensions<
     const textPhases = new Map<string, AgentMessagePhase | "hidden">()
     for await (const chunk of stream) {
       const event = toAgentStreamEvent(chunk, toolNames, textPhases)
-      const usageRecord = event?.type === "usage"
-        ? event.usageRecord
-        : usageRecordFromStreamChunk(chunk, result)
+      const usageRecord = usageRecordFromStreamChunk(chunk, result)
       if (!usageRecord) {
         yield chunk
         continue

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1981,6 +1981,32 @@ function resultWithResolvedUsageRecord(result: unknown, usageRecord: AgentUsageR
   if (!result || typeof result !== "object") return resultWithUsageRecord(result, usageRecord)
   const prototype = Object.getPrototypeOf(result)
   if (prototype !== Object.prototype && prototype !== null) {
+    if (Object.isExtensible(result)) {
+      try {
+        Object.defineProperties(result, {
+          ...(usageRecord.usage
+            ? {
+                usage: {
+                  configurable: true,
+                  enumerable: true,
+                  value: usageRecord.usage,
+                  writable: true,
+                },
+              }
+            : {}),
+          usageRecord: {
+            configurable: true,
+            enumerable: true,
+            value: usageRecord,
+            writable: true,
+          },
+        })
+        return result
+      }
+      catch {
+        // Fall through to a wrapper when an existing property cannot be replaced.
+      }
+    }
     return {
       ...toAgentRunResult(result),
       raw: result,
@@ -2161,15 +2187,18 @@ function maybeTraceUiMessageStreamOutput<
   return isAsyncIterable(rendered) ? maybeTraceAgentStream(rendered as AsyncIterable<StreamEvent>, context) : rendered
 }
 
+function hasFinishConsumer<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>): boolean {
+  return Boolean(context.finishHook || context.finishDeliveryEffectProviders.length)
+}
+
 function hasFinishWork<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>): boolean {
-  return Boolean(
-    context.finishHook
-    || context.finishDeliveryEffectProviders.length
-    || context.finishExtensionProviders.some(provider => provider.eager),
-  )
+  return hasFinishConsumer(context) || context.finishExtensionProviders.some(provider => provider.eager)
 }
 
 async function resolveFinishUsageRecord<
@@ -2179,8 +2208,8 @@ async function resolveFinishUsageRecord<
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
   result: unknown,
 ): Promise<Extract<StreamEvent, { type: "usage" }>["usageRecord"] | undefined> {
-  if (hasFinishWork(context)) return await resolveAgentUsageRecord(result, context.run)
-  if (!context.runtimeContext.traceLog) return undefined
+  if (hasFinishConsumer(context)) return await resolveAgentUsageRecord(result, context.run)
+  if (!context.runtimeContext.traceLog && !context.finishExtensionProviders.some(provider => provider.eager)) return undefined
   try {
     return await resolveAgentUsageRecord(result, context.run)
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2783,14 +2783,17 @@ async function executeAgentInvocation<
       const rendered = options.renderOutput
         ? renderedResult ? result : await applyOutputRenderers(result, invocation.outputRenderers, invocation.outputExtensionProviders, outputExtensions)
         : result
-      if (options.renderOutput
+      const shouldPreserveEagerStreamResult = hasTraceableStreamResult(rendered)
+        && invocation.finishExtensionProviders.some(provider => provider.eager)
+        && shouldWrapInvocationOutput(invocation)
+      if (shouldPreserveEagerStreamResult || (options.renderOutput
         && !invocation.output
         && invocation.context.get<boolean>(responseTitleFallbackContextKey) === true
         && rendered !== result
         && (isAsyncIterable((rendered as { stream?: unknown }).stream)
           || isAsyncIterable((rendered as { fullStream?: unknown }).fullStream)
           || isUIMessageStreamResult(rendered))
-        && shouldWrapInvocationOutput(invocation)) {
+        && shouldWrapInvocationOutput(invocation))) {
         if (isUIMessageStreamResult(rendered)
           && !isAsyncIterable((rendered as { stream?: unknown }).stream)
           && !isAsyncIterable((rendered as { fullStream?: unknown }).fullStream)) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2922,7 +2922,7 @@ async function executeAgentInvocation<
   }
 
   return await finalizeAgentInvocationResult(invocation, lifecycle, result, async (result) => {
-    const driverUsageRecord = hasTraceableStreamResult(result)
+    const driverUsageRecord = hasTraceableStreamResult(result) || isUIMessageStreamResult(result)
       ? undefined
       : await resolveFinishUsageRecord(invocation, result)
     const rendered = renderedResult ? result : await applyOutputRenderers(result, invocation.outputRenderers, invocation.outputExtensionProviders, outputExtensions)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2868,6 +2868,9 @@ async function executeAgentInvocation<
         for (let owner: object | null = rendered as object; owner && !textStreamDescriptor; owner = Object.getPrototypeOf(owner))
           textStreamDescriptor = Object.getOwnPropertyDescriptor(owner, "textStream")
         if (textStreamDescriptor) {
+          const resolveTextStream = "get" in textStreamDescriptor
+            ? () => textStreamDescriptor.get?.call(rendered)
+            : () => textStreamDescriptor.value
           let preservedTextStream: unknown
           let initialized = false
           descriptors.textStream = {
@@ -2875,7 +2878,7 @@ async function executeAgentInvocation<
             enumerable: textStreamDescriptor.enumerable ?? false,
             get() {
               if (!initialized) {
-                const textStream = Reflect.get(rendered as object, "textStream")
+                const textStream = resolveTextStream()
                 preservedTextStream = isAsyncIterable(textStream) ? preserveStream(textStream) : textStream
                 initialized = true
               }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2839,7 +2839,18 @@ async function executeAgentInvocation<
                   invocation,
                   rendered,
                 )),
-                outcome => (finishTask ??= finishStreamAgentInvocation(invocation, lifecycle, resultWithStreamedTextAndUsage(rendered, streamedText, streamedUsageRecord, driverUsageRecord), finishOutcomeFromCleanup(outcome), runFailureMessage, outputExtensions)),
+                async (outcome) => {
+                  if (finishTask) return await finishTask
+                  const finishResult = resultWithStreamedTextAndUsage(preserved, streamedText, streamedUsageRecord, driverUsageRecord)
+                  finishTask = (async () => {
+                    await finishStreamAgentInvocation(invocation, lifecycle, finishResult, finishOutcomeFromCleanup(outcome), runFailureMessage, outputExtensions)
+                    const usageRecord = finishResult && typeof finishResult === "object"
+                      ? (finishResult as { usageRecord?: AgentUsageRecord }).usageRecord
+                      : undefined
+                    if (usageRecord) resultWithUsageRecord(preserved, usageRecord)
+                  })()
+                  return await finishTask
+                },
                 {
                   onChunk(chunk) {
                     streamedText += uiMessageTextDelta(chunk) || ""

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2409,8 +2409,12 @@ async function finishAgentInvocation<
         ...(text !== undefined ? { text } : {}),
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
       const provisionalActiveDeliveryProviders = await prepareProvisionalTitleDeliverySupport(context, eventBase)
-      if (context.finishHook || context.finishExtensionProviders.some(provider => provider.eager) || provisionalActiveDeliveryProviders.length || hasDeferredFinishDeliveryEffectProvider(context.finishDeliveryEffectProviders)) {
-        const extensions = await createAgentInvocationExtensions(eventBase as never, context.finishExtensionProviders)
+      const hasFinishConsumer = Boolean(context.finishHook || provisionalActiveDeliveryProviders.length || hasDeferredFinishDeliveryEffectProvider(context.finishDeliveryEffectProviders))
+      const finishExtensionProviders = hasFinishConsumer
+        ? context.finishExtensionProviders
+        : context.finishExtensionProviders.filter(provider => provider.eager)
+      if (hasFinishConsumer || finishExtensionProviders.length) {
+        const extensions = await createAgentInvocationExtensions(eventBase as never, finishExtensionProviders)
         const finishEvent = { ...eventBase, extensions }
         const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, finishEvent as never)
         await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(activeDeliveryProviders, finishEvent as never, context), finishEvent as never)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2118,7 +2118,12 @@ function withStreamedResult(
           if (event.phase === "final") finalText += event.text
           else if (!explicitTextPhaseSeen && event.phase === undefined) unphasedText += event.text
         }
-        if (event?.type === "usage") usageRecord = event.usageRecord
+        const attachedUsageRecord = chunk && typeof chunk === "object" && "usageRecord" in chunk
+          ? (chunk as { usageRecord?: AgentUsageRecord }).usageRecord
+          : undefined
+        usageRecord = event?.type === "usage"
+          ? event.usageRecord
+          : attachedUsageRecord ?? usageRecordFromStreamChunk(chunk, result) ?? usageRecord
         yield chunk
       }
     })(),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2745,15 +2745,18 @@ async function executeAgentInvocation<
       const structuredUsageRecord = options.renderOutput && invocation.output
         ? await resolveFinishUsageRecord(invocation, structuredFinal) ?? driverUsageRecord
         : driverUsageRecord
+      const finishResult = invocation.output
+        ? undefined
+        : hasFinishWork(invocation) ? resultWithUsageRecord(final, driverUsageRecord) : final
       const value = options.renderOutput && invocation.output
         ? await validateAgentOutput(invocation.output, structuredFinal, {
             allowMaterializedObject: customRun
               ? structuredFinal === final
               : structuredFinal === final && final !== result,
           })
-        : customRun ? final : options.renderOutput ? toAgentRunResult(final) : final
+        : customRun ? final : options.renderOutput ? toAgentRunResult(finishResult) : final
       return {
-        finishResult: invocation.output ? value : hasFinishWork(invocation) ? resultWithUsageRecord(final, driverUsageRecord) : final,
+        finishResult: invocation.output ? value : finishResult,
         finishUsage: structuredUsageRecord,
         value,
       }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1949,11 +1949,14 @@ function withEagerStreamUsageExtensions<
     const textPhases = new Map<string, AgentMessagePhase | "hidden">()
     for await (const chunk of stream) {
       const event = toAgentStreamEvent(chunk, toolNames, textPhases)
-      if (event?.type !== "usage") {
+      const usageRecord = event?.type === "usage"
+        ? event.usageRecord
+        : usageRecordFromStreamChunk(chunk, result)
+      if (!usageRecord) {
         yield chunk
         continue
       }
-      const usage = { ...event.usageRecord }
+      const usage = { ...usageRecord }
       const eventBase = {
         actor: context.actor,
         input: context.input,
@@ -1969,7 +1972,7 @@ function withEagerStreamUsageExtensions<
       await createAgentInvocationExtensions(eventBase as never, providers)
       yield chunk && typeof chunk === "object"
         ? { ...chunk, usageRecord: usage }
-        : { ...event, usageRecord: usage }
+        : { type: "usage", usageRecord: usage }
     }
   })()
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2777,13 +2777,13 @@ async function executeAgentInvocation<
 
   if (options.kind === "run") {
     return await finalizeAgentInvocationResult(invocation, lifecycle, result, async (result) => {
-      const driverUsageRecord = hasTraceableStreamResult(result)
+      const driverUsageRecord = hasTraceableStreamResult(result) || isUIMessageStreamResult(result)
         ? undefined
         : await resolveFinishUsageRecord(invocation, result)
       const rendered = options.renderOutput
         ? renderedResult ? result : await applyOutputRenderers(result, invocation.outputRenderers, invocation.outputExtensionProviders, outputExtensions)
         : result
-      const shouldPreserveEagerStreamResult = hasTraceableStreamResult(rendered)
+      const shouldPreserveEagerStreamResult = (hasTraceableStreamResult(rendered) || isUIMessageStreamResult(rendered))
         && invocation.finishExtensionProviders.some(provider => provider.eager)
         && shouldWrapInvocationOutput(invocation)
       if (shouldPreserveEagerStreamResult || (options.renderOutput

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2099,6 +2099,20 @@ function resultWithResolvedUsageRecord(result: unknown, usageRecord: AgentUsageR
   })
 }
 
+function resultWithPreservedProperties(result: object, descriptors: PropertyDescriptorMap): object {
+  const prototype = Object.getPrototypeOf(result)
+  if (prototype !== Object.prototype && prototype !== null && Object.isExtensible(result)) {
+    try {
+      Object.defineProperties(result, descriptors)
+      return result
+    }
+    catch {
+      // Fall through to descriptor cloning for plain result objects and immutable properties.
+    }
+  }
+  return cloneWithPropertyDescriptors(result, descriptors)
+}
+
 function resultWithStreamedTextAndUsage(
   result: unknown,
   text: string,
@@ -2801,7 +2815,7 @@ async function executeAgentInvocation<
           let finishTask: Promise<void> | undefined
           let streamedText = ""
           let streamedUsageRecord: Extract<StreamEvent, { type: "usage" }>["usageRecord"] | undefined
-          const preserved = cloneWithPropertyDescriptors(rendered, {
+          const preserved = resultWithPreservedProperties(rendered, {
             toUIMessageStream: {
               configurable: true,
               enumerable: false,
@@ -2869,7 +2883,7 @@ async function executeAgentInvocation<
             },
           }
         }
-        const preserved = cloneWithPropertyDescriptors(rendered as object, descriptors)
+        const preserved = resultWithPreservedProperties(rendered as object, descriptors)
         return {
           deferFinish: true,
           finishResult: preserved,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1984,7 +1984,7 @@ function resultWithResolvedUsageRecord(result: unknown, usageRecord: AgentUsageR
     if (Object.isExtensible(result)) {
       try {
         Object.defineProperties(result, {
-          ...(usageRecord.usage
+          ...(usageRecord.usage && !("usage" in result)
             ? {
                 usage: {
                   configurable: true,
@@ -2015,7 +2015,7 @@ function resultWithResolvedUsageRecord(result: unknown, usageRecord: AgentUsageR
     }
   }
   return cloneWithPropertyDescriptors(result, {
-    ...(usageRecord.usage
+    ...(usageRecord.usage && !("usage" in result)
       ? {
           usage: {
             configurable: true,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1934,6 +1934,41 @@ function maybeTraceAgentStream<
   return context.runtimeContext.traceLog ? traceAgentStreamEvents(stream, toTraceContext(context)) : stream
 }
 
+function withEagerStreamUsageExtensions<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  stream: AsyncIterable<StreamEvent>,
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+  result: unknown,
+): AsyncIterable<StreamEvent> {
+  const providers = context.finishExtensionProviders.filter(provider => provider.eager)
+  if (!providers.length) return stream
+  return (async function* () {
+    for await (const event of stream) {
+      if (event.type !== "usage") {
+        yield event
+        continue
+      }
+      const usage = { ...event.usageRecord }
+      const eventBase = {
+        actor: context.actor,
+        input: context.input,
+        invoker: context.invoker,
+        invocation: {
+          durationMs: Date.now() - context.startedAt,
+          ...(context.run ? { run: context.run } : {}),
+          usage,
+        },
+        result,
+        runtime: context.runtimeContext,
+      } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
+      await createAgentInvocationExtensions(eventBase as never, providers)
+      yield { ...event, usageRecord: usage }
+    }
+  })()
+}
+
 function withStreamResultProperties<T extends AsyncIterable<StreamEvent>>(stream: T, result: unknown): T {
   if (typeof stream !== "object" || stream === null || typeof result !== "object" || result === null) return stream
   Object.defineProperties(stream, Object.fromEntries(["usage", "usageRecord"].map(key => [key, {
@@ -2866,7 +2901,7 @@ async function executeAgentInvocation<
     const stream = isStreamResult
       ? streamAgentOutputToEvents(rendered)
       : customRun ? rendered as AsyncIterable<StreamEvent> : streamAgentOutputToEvents(rendered)
-    const streamed = withStreamedResult(stream, rendered, driverUsageRecord)
+    const streamed = withStreamedResult(withEagerStreamUsageExtensions(stream, invocation, rendered), rendered, driverUsageRecord)
     const tracedStream = maybeTraceAgentStream(streamed.stream as AsyncIterable<StreamEvent>, invocation)
     const shouldWrapOutput = shouldWrapInvocationOutput(invocation)
     const value = shouldWrapOutput

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2922,7 +2922,9 @@ async function executeAgentInvocation<
   }
 
   return await finalizeAgentInvocationResult(invocation, lifecycle, result, async (result) => {
-    const driverUsageRecord = hasTraceableStreamResult(result) || isUIMessageStreamResult(result)
+    const hasEagerFinishExtension = invocation.finishExtensionProviders.some(provider => provider.eager)
+    const driverUsageRecord = hasEagerFinishExtension
+      && (hasTraceableStreamResult(result) || isUIMessageStreamResult(result))
       ? undefined
       : await resolveFinishUsageRecord(invocation, result)
     const rendered = renderedResult ? result : await applyOutputRenderers(result, invocation.outputRenderers, invocation.outputExtensionProviders, outputExtensions)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2133,7 +2133,11 @@ function hasFinishWork<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>): boolean {
-  return Boolean(context.finishHook || context.finishDeliveryEffectProviders.length)
+  return Boolean(
+    context.finishHook
+    || context.finishDeliveryEffectProviders.length
+    || context.finishExtensionProviders.some(provider => provider.eager),
+  )
 }
 
 async function resolveFinishUsageRecord<
@@ -2405,7 +2409,7 @@ async function finishAgentInvocation<
         ...(text !== undefined ? { text } : {}),
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
       const provisionalActiveDeliveryProviders = await prepareProvisionalTitleDeliverySupport(context, eventBase)
-      if (context.finishHook || provisionalActiveDeliveryProviders.length || hasDeferredFinishDeliveryEffectProvider(context.finishDeliveryEffectProviders)) {
+      if (context.finishHook || context.finishExtensionProviders.some(provider => provider.eager) || provisionalActiveDeliveryProviders.length || hasDeferredFinishDeliveryEffectProvider(context.finishDeliveryEffectProviders)) {
         const extensions = await createAgentInvocationExtensions(eventBase as never, context.finishExtensionProviders)
         const finishEvent = { ...eventBase, extensions }
         const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, finishEvent as never)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2611,8 +2611,8 @@ async function finalizeAgentInvocationResult<
       return response
     }
     if (isAsyncIterable(result) && !hasTraceableStreamResult(result) && !options.finalizeRawStreams) {
-      const wrappedStream = options.wrapStream?.(result) || result
-      const stream = withEagerStreamUsageExtensions(wrappedStream, context, result)
+      const enrichedStream = withEagerStreamUsageExtensions(result, context, result)
+      const stream = options.wrapStream?.(enrichedStream) || enrichedStream
       if (shouldWrapOutput) {
         const streamed = withStreamedResult(stream, result)
         if (!context.finalOutputRenderers.length && (!context.output || !options.finalizeRawStreams)) {

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -24,12 +24,14 @@ interface StaticModelPrice {
 }
 
 interface VercelAiGatewayPricingOptions {
+  maxAge?: number
   fetch?: typeof fetch
   modelsUrl?: string
   timeout?: number
 }
 
 const vercelAiGatewayModelsUrl = "https://ai-gateway.vercel.sh/v1/models"
+const vercelAiGatewayPricingMaxAge = 5 * 60_000
 const vercelAiGatewayPricingTimeout = 10_000
 
 function hasTokenUsage(usage: AgentUsage): boolean {
@@ -123,30 +125,36 @@ function vercelGatewayModelIdCandidates(model: AgentUsageRecord["model"] | undef
 
 export function vercelAiGatewayPricing(options: VercelAiGatewayPricingOptions = {}): AgentUsagePricing {
   const fetcher = options.fetch || globalThis.fetch
+  const maxAge = options.maxAge ?? vercelAiGatewayPricingMaxAge
   const modelsUrl = options.modelsUrl || vercelAiGatewayModelsUrl
   const timeout = options.timeout ?? vercelAiGatewayPricingTimeout
   let prices: Promise<Record<string, StaticModelPrice>> | undefined
+  let pricesExpiresAt = 0
 
   async function loadPrices() {
-    prices ??= (async () => {
-      const response = await fetcher(modelsUrl, { signal: AbortSignal.timeout(timeout) })
-      if (!response.ok) throw new Error(`[vitehub] Vercel AI Gateway pricing request failed with ${response.status}.`)
-      const body = await response.json() as { data?: Array<{ id?: unknown, pricing?: Record<string, unknown> }> }
-      const result: Record<string, StaticModelPrice> = {}
-      for (const model of body.data || []) {
-        if (typeof model.id !== "string" || !model.pricing) continue
-        result[model.id] = {
-          input: normalizeVercelPrice(model.pricing.input),
-          inputCacheRead: normalizeVercelPrice(model.pricing.input_cache_read),
-          inputCacheWrite: normalizeVercelPrice(model.pricing.input_cache_write),
-          output: normalizeVercelPrice(model.pricing.output),
+    if (!prices || (pricesExpiresAt > 0 && Date.now() >= pricesExpiresAt)) {
+      prices = (async () => {
+        const response = await fetcher(modelsUrl, { signal: AbortSignal.timeout(timeout) })
+        if (!response.ok) throw new Error(`[vitehub] Vercel AI Gateway pricing request failed with ${response.status}.`)
+        const body = await response.json() as { data?: Array<{ id?: unknown, pricing?: Record<string, unknown> }> }
+        const result: Record<string, StaticModelPrice> = {}
+        for (const model of body.data || []) {
+          if (typeof model.id !== "string" || !model.pricing) continue
+          result[model.id] = {
+            input: normalizeVercelPrice(model.pricing.input),
+            inputCacheRead: normalizeVercelPrice(model.pricing.input_cache_read),
+            inputCacheWrite: normalizeVercelPrice(model.pricing.input_cache_write),
+            output: normalizeVercelPrice(model.pricing.output),
+          }
         }
-      }
-      return result
-    })().catch((error) => {
-      prices = undefined
-      throw error
-    })
+        pricesExpiresAt = Date.now() + maxAge
+        return result
+      })().catch((error) => {
+        prices = undefined
+        pricesExpiresAt = 0
+        throw error
+      })
+    }
     return await prices
   }
 

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -144,8 +144,10 @@ export function vercelAiGatewayPricing(options: VercelAiGatewayPricingOptions = 
 
   return async ({ model, usage }) => {
     if (!hasTokenUsage(usage)) return
+    const modelIds = vercelGatewayModelIdCandidates(model)
+    if (!modelIds.length) return
     const catalog = await loadPrices()
-    const price = vercelGatewayModelIdCandidates(model)
+    const price = modelIds
       .map(modelId => catalog[modelId])
       .find((item): item is StaticModelPrice => Boolean(item))
     if (!price) return

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -133,6 +133,7 @@ export function vercelAiGatewayPricing(options: VercelAiGatewayPricingOptions = 
 
   async function loadPrices() {
     if (!prices || (pricesExpiresAt > 0 && Date.now() >= pricesExpiresAt)) {
+      pricesExpiresAt = 0
       prices = (async () => {
         const response = await fetcher(modelsUrl, { signal: AbortSignal.timeout(timeout) })
         if (!response.ok) throw new Error(`[vitehub] Vercel AI Gateway pricing request failed with ${response.status}.`)

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -112,7 +112,6 @@ function vercelGatewayModelIdCandidates(model: AgentUsageRecord["model"] | undef
   if (!modelId.includes("/") && provider) {
     const providerScope = provider.split(".", 1)[0]!
     addModelIdCandidate(candidates, `${providerScope}/${unscoped}`)
-    addModelIdCandidate(candidates, `${providerScope.split("-", 1)[0]}/${unscoped}`)
   }
   const isAnthropic = modelId.startsWith("anthropic/") || unscoped.startsWith("claude-") || provider.includes("anthropic")
   if (isAnthropic) {

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -31,11 +31,12 @@ interface VercelAiGatewayPricingOptions {
 const vercelAiGatewayModelsUrl = "https://ai-gateway.vercel.sh/v1/models"
 
 function hasTokenUsage(usage: AgentUsage): boolean {
+  const inputDetails = usage.inputTokenDetails
   return usage.inputTokens !== undefined
     || usage.outputTokens !== undefined
-    || usage.totalTokens !== undefined
-    || usage.inputTokenDetails !== undefined
-    || usage.outputTokenDetails !== undefined
+    || Boolean(inputDetails?.cacheReadTokens)
+    || Boolean(inputDetails?.cachedTokens)
+    || Boolean(inputDetails?.cacheWriteTokens)
 }
 
 function decimalToParts(value: string): { scale: bigint, units: bigint } {

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -73,17 +73,21 @@ function multiplyDecimal(value: string | undefined, count: number | undefined): 
   }
 }
 
-function pricedTokens(usage: AgentUsage, price: StaticModelPrice): string {
+function pricedTokens(usage: AgentUsage, price: StaticModelPrice): string | undefined {
   const inputDetails = usage.inputTokenDetails || {}
   const cacheReadTokens = inputDetails.cacheReadTokens || inputDetails.cachedTokens || 0
   const cacheWriteTokens = inputDetails.cacheWriteTokens || 0
   const regularInputTokens = Math.max(0, (usage.inputTokens || 0) - cacheReadTokens - cacheWriteTokens)
-  return addDecimalParts([
-    multiplyDecimal(price.input, regularInputTokens),
-    multiplyDecimal(price.inputCacheRead || price.input, cacheReadTokens),
-    multiplyDecimal(price.inputCacheWrite || price.input, cacheWriteTokens),
-    multiplyDecimal(price.output, usage.outputTokens),
-  ].filter((item): item is { scale: bigint, units: bigint } => Boolean(item)))
+  const categories = [
+    [price.input, regularInputTokens],
+    [price.inputCacheRead || price.input, cacheReadTokens],
+    [price.inputCacheWrite || price.input, cacheWriteTokens],
+    [price.output, usage.outputTokens || 0],
+  ] as const
+  if (categories.some(([value, count]) => count > 0 && value === undefined)) return
+  return addDecimalParts(categories
+    .map(([value, count]) => multiplyDecimal(value, count))
+    .filter((item): item is { scale: bigint, units: bigint } => Boolean(item)))
 }
 
 function normalizeVercelPrice(value: unknown): string | undefined {
@@ -167,8 +171,10 @@ export function vercelAiGatewayPricing(options: VercelAiGatewayPricingOptions = 
       .map(modelId => catalog[modelId])
       .find((item): item is StaticModelPrice => Boolean(item))
     if (!price) return
+    const amount = pricedTokens(usage, price)
+    if (amount === undefined) return
     return {
-      amount: pricedTokens(usage, price),
+      amount,
       currency: price.currency || "USD",
       estimated: true,
       source: "vercel-ai-gateway",

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -107,6 +107,11 @@ function vercelGatewayModelIdCandidates(model: AgentUsageRecord["model"] | undef
 
   const unscoped = modelId.includes("/") ? modelId.slice(modelId.lastIndexOf("/") + 1) : modelId
   const provider = typeof model?.provider === "string" ? model.provider.toLowerCase() : ""
+  if (!modelId.includes("/") && provider) {
+    const providerScope = provider.split(".", 1)[0]!
+    addModelIdCandidate(candidates, `${providerScope}/${unscoped}`)
+    addModelIdCandidate(candidates, `${providerScope.split("-", 1)[0]}/${unscoped}`)
+  }
   const isAnthropic = modelId.startsWith("anthropic/") || unscoped.startsWith("claude-") || provider.includes("anthropic")
   if (isAnthropic) {
     addModelIdCandidate(candidates, `anthropic/${unscoped}`)

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -74,6 +74,7 @@ function multiplyDecimal(value: string | undefined, count: number | undefined): 
 }
 
 function pricedTokens(usage: AgentUsage, price: StaticModelPrice): string | undefined {
+  if (usage.inputTokens === undefined || usage.outputTokens === undefined) return
   const inputDetails = usage.inputTokenDetails || {}
   const cacheReadTokens = inputDetails.cacheReadTokens || inputDetails.cachedTokens || 0
   const cacheWriteTokens = inputDetails.cacheWriteTokens || 0
@@ -82,7 +83,7 @@ function pricedTokens(usage: AgentUsage, price: StaticModelPrice): string | unde
     [price.input, regularInputTokens],
     [price.inputCacheRead || price.input, cacheReadTokens],
     [price.inputCacheWrite || price.input, cacheWriteTokens],
-    [price.output, usage.outputTokens || 0],
+    [price.output, usage.outputTokens],
   ] as const
   if (categories.some(([value, count]) => count > 0 && value === undefined)) return
   return addDecimalParts(categories

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -135,7 +135,10 @@ export function vercelAiGatewayPricing(options: VercelAiGatewayPricingOptions = 
         }
       }
       return result
-    })()
+    })().catch((error) => {
+      prices = undefined
+      throw error
+    })
     return await prices
   }
 

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -34,15 +34,6 @@ const vercelAiGatewayModelsUrl = "https://ai-gateway.vercel.sh/v1/models"
 const vercelAiGatewayPricingMaxAge = 5 * 60_000
 const vercelAiGatewayPricingTimeout = 10_000
 
-function hasTokenUsage(usage: AgentUsage): boolean {
-  const inputDetails = usage.inputTokenDetails
-  return usage.inputTokens !== undefined
-    || usage.outputTokens !== undefined
-    || Boolean(inputDetails?.cacheReadTokens)
-    || Boolean(inputDetails?.cachedTokens)
-    || Boolean(inputDetails?.cacheWriteTokens)
-}
-
 function decimalToParts(value: string): { scale: bigint, units: bigint } {
   const trimmed = value.trim()
   if (!/^\d+(?:\.\d+)?$/.test(trimmed)) {
@@ -164,7 +155,7 @@ export function vercelAiGatewayPricing(options: VercelAiGatewayPricingOptions = 
   }
 
   return async ({ model, usage }) => {
-    if (!hasTokenUsage(usage)) return
+    if (usage.inputTokens === undefined || usage.outputTokens === undefined) return
     const modelIds = vercelGatewayModelIdCandidates(model)
     if (!modelIds.length) return
     const catalog = await loadPrices()

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -26,9 +26,11 @@ interface StaticModelPrice {
 interface VercelAiGatewayPricingOptions {
   fetch?: typeof fetch
   modelsUrl?: string
+  timeout?: number
 }
 
 const vercelAiGatewayModelsUrl = "https://ai-gateway.vercel.sh/v1/models"
+const vercelAiGatewayPricingTimeout = 10_000
 
 function hasTokenUsage(usage: AgentUsage): boolean {
   const inputDetails = usage.inputTokenDetails
@@ -117,11 +119,12 @@ function vercelGatewayModelIdCandidates(model: AgentUsageRecord["model"] | undef
 export function vercelAiGatewayPricing(options: VercelAiGatewayPricingOptions = {}): AgentUsagePricing {
   const fetcher = options.fetch || globalThis.fetch
   const modelsUrl = options.modelsUrl || vercelAiGatewayModelsUrl
+  const timeout = options.timeout ?? vercelAiGatewayPricingTimeout
   let prices: Promise<Record<string, StaticModelPrice>> | undefined
 
   async function loadPrices() {
     prices ??= (async () => {
-      const response = await fetcher(modelsUrl)
+      const response = await fetcher(modelsUrl, { signal: AbortSignal.timeout(timeout) })
       if (!response.ok) throw new Error(`[vitehub] Vercel AI Gateway pricing request failed with ${response.status}.`)
       const body = await response.json() as { data?: Array<{ id?: unknown, pricing?: Record<string, unknown> }> }
       const result: Record<string, StaticModelPrice> = {}

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -14,7 +14,7 @@ interface AgentUIMessageStreamWriter {
 }
 
 type StreamCleanupOutcome =
-  | { failed: false }
+  | { completed?: boolean, failed: false }
   | { error: unknown, failed: true }
 
 const uiMessageStreamHeaders = {
@@ -133,7 +133,7 @@ export function withReadableStreamCleanup<T>(
 ): ReadableStream<T> {
   const reader = stream.getReader()
   let cleaned = false
-  const runCleanup = async (outcome: StreamCleanupOutcome = { failed: false }) => {
+  const runCleanup = async (outcome: StreamCleanupOutcome = { completed: true, failed: false }) => {
     if (cleaned) return
     cleaned = true
     await cleanup(outcome)
@@ -156,7 +156,7 @@ export function withReadableStreamCleanup<T>(
       }
     },
     async cancel(reason) {
-      let outcome: StreamCleanupOutcome = reason === undefined ? { failed: false } : { error: reason, failed: true }
+      let outcome: StreamCleanupOutcome = reason === undefined ? { completed: false, failed: false } : { error: reason, failed: true }
       try {
         await reader.cancel(reason)
       }

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -1801,7 +1801,7 @@ describe("agent capability runtime", () => {
     for await (const _chunk of withCapabilityCleanup(stream, close)) break
 
     expect(iterator.return).toHaveBeenCalledTimes(1)
-    expect(close).toHaveBeenCalledWith({ failed: false })
+    expect(close).toHaveBeenCalledWith({ completed: false, failed: false })
   })
 
   it("closes streamed output as failed when source iterator return rejects", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -833,7 +833,7 @@ describe("agent message protocol", () => {
 
     await stream.cancel()
 
-    expect(outcomes).toEqual([{ failed: false }])
+    expect(outcomes).toEqual([{ completed: false, failed: false }])
   })
 
   it("propagates post-chunk UI message response read failures", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelDeliveryReplyStream, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentMessageDeliveryKind, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUIMessageStreamProjection, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
-import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, repositoryHost, repositoryHostContext, sandbox, schedule, skills, streamTranscription, subagents, transcribe, webSearch, workspaceShell, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput } from "../src/capabilities.ts"
+import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, repositoryHost, repositoryHostContext, sandbox, schedule, skills, streamTranscription, subagents, transcribe, usageCost, webSearch, workspaceShell, type AgentUsagePricing, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput, type UsageCostOptions } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -27,6 +27,30 @@ declare global {
 }
 
 describe("agent public types", () => {
+  it("types usage cost pricing and finish extensions", () => {
+    const pricing = ((context) => {
+      expectTypeOf(context.usage).toMatchTypeOf<NonNullable<AgentUsageRecord["usage"]>>()
+      return {
+        amount: "0.01",
+        currency: "USD",
+        estimated: true,
+        source: "custom",
+      }
+    }) satisfies AgentUsagePricing
+    const options = { pricing } satisfies UsageCostOptions
+
+    expectTypeOf(usageCost(options)).toMatchTypeOf<AgentCapabilityDefinition>()
+    defineAgent({
+      capabilities: [usageCost(options)],
+      driver: { run: () => "ok" },
+      hooks: {
+        "agent:finish"(event) {
+          expectTypeOf(event.extensions.get("usage-cost")).toEqualTypeOf<AgentUsageRecord | undefined>()
+        },
+      },
+    })
+  })
+
   it("types static and per-invocation UI message stream projection", () => {
     const projection = {
       reasoning: "visible",

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -69,6 +69,57 @@ describe("usageCost", () => {
     expect(fetch.mock.calls[0]![1]?.signal).toBeInstanceOf(AbortSignal)
   })
 
+  it.each([
+    {
+      name: "input",
+      pricing: { output: "0.000002" },
+    },
+    {
+      name: "output",
+      pricing: { input: "0.000001" },
+    },
+  ])("does not estimate partial cost when $name pricing is missing", async ({ pricing }) => {
+    const fetch = vi.fn(async () => Response.json({
+      data: [{
+        id: "custom/model",
+        pricing,
+      }],
+    }))
+    vi.stubGlobal("fetch", fetch)
+
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [usageCost()],
+      driver: {
+        run: () => ({
+          modelId: "custom/model",
+          text: "ok",
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            totalTokens: 12,
+          },
+        }),
+      },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    await runAgent(agent, runtime(), { prompt: "hello" })
+
+    expect(finish.mock.calls[0]![0].invocation.usage).toMatchObject({
+      usage: {
+        inputTokens: 10,
+        outputTokens: 2,
+        totalTokens: 12,
+      },
+    })
+    expect(finish.mock.calls[0]![0].invocation.usage?.cost).toBeUndefined()
+  })
+
   it("supports custom pricing without provider dependencies", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -118,25 +118,30 @@ describe("usageCost", () => {
       estimated: true,
       source: "custom" as const,
     }))
-    const usageRecord = {
-      usage: {
-        inputTokens: 10,
-        outputTokens: 2,
-        totalTokens: 12,
-      },
-    }
     const agent = defineAgent({
       capabilities: [usageCost({ pricing })],
       driver: {
         run: () => ({
           text: "ok",
-          usageRecord,
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            totalTokens: 12,
+          },
         }),
       },
     })
 
     await expect(runAgent(agent, runtime(), { prompt: "hello" })).resolves.toMatchObject({
       text: "ok",
+      usageRecord: {
+        cost: {
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        },
+      },
     })
     expect(pricing).toHaveBeenCalledOnce()
   })

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -229,6 +229,85 @@ describe("usageCost", () => {
     expect(result).not.toHaveProperty("usageRecord")
   })
 
+  it("enriches immutable usage records through a mutable canonical copy", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const usageRecord = Object.freeze({
+      usage: {
+        inputTokens: 10,
+        outputTokens: 2,
+        totalTokens: 12,
+      },
+    })
+    const agent = defineAgent({
+      capabilities: [usageCost({
+        pricing: () => ({
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        }),
+      })],
+      driver: {
+        run: () => ({
+          text: "ok",
+          usageRecord,
+        }),
+      },
+    })
+
+    await expect(runAgent(agent, runtime(), { prompt: "hello" })).resolves.toMatchObject({
+      usageRecord: {
+        cost: {
+          amount: "0.02",
+        },
+      },
+    })
+    expect(usageRecord).not.toHaveProperty("cost")
+  })
+
+  it("wraps class-backed results without cloning their private state", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    class DriverResult {
+      #value = "preserved"
+      text = "ok"
+      usage = {
+        inputTokens: 10,
+        outputTokens: 2,
+        totalTokens: 12,
+      }
+
+      value() {
+        return this.#value
+      }
+    }
+    const result = new DriverResult()
+    const agent = defineAgent({
+      capabilities: [usageCost({
+        pricing: () => ({
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        }),
+      })],
+      driver: {
+        run: () => result,
+      },
+    })
+
+    await expect(runAgent(agent, runtime(), { prompt: "hello" })).resolves.toMatchObject({
+      raw: result,
+      usageRecord: {
+        cost: {
+          amount: "0.02",
+        },
+      },
+    })
+    expect(result.value()).toBe("preserved")
+  })
+
   it("does not resolve unrelated lazy finish extensions during eager-only work", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -141,6 +141,45 @@ describe("usageCost", () => {
     expect(pricing).toHaveBeenCalledOnce()
   })
 
+  it("does not resolve unrelated lazy finish extensions during eager-only work", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const lazy = vi.fn(() => {
+      throw new Error("lazy extension should not run")
+    })
+    const pricing = vi.fn(() => ({
+      amount: "0.02",
+      currency: "USD" as const,
+      estimated: true,
+      source: "custom" as const,
+    }))
+    const agent = defineAgent({
+      capabilities: [
+        {
+          id: "lazy",
+          finish: lazy,
+        },
+        usageCost({ pricing }),
+      ],
+      driver: {
+        run: () => ({
+          text: "ok",
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            totalTokens: 12,
+          },
+        }),
+      },
+    })
+
+    await expect(runAgent(agent, runtime(), { prompt: "hello" })).resolves.toMatchObject({
+      text: "ok",
+    })
+    expect(pricing).toHaveBeenCalledOnce()
+    expect(lazy).not.toHaveBeenCalled()
+  })
+
   it("does not estimate cost from total-only token usage", async () => {
     const fetch = vi.fn(async () => Response.json({
       data: [{
@@ -179,6 +218,54 @@ describe("usageCost", () => {
       },
     })
     expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("retries catalog loading after a transient failure", async () => {
+    const fetch = vi.fn()
+      .mockRejectedValueOnce(new Error("temporarily unavailable"))
+      .mockResolvedValue(Response.json({
+        data: [{
+          id: "custom/model",
+          pricing: {
+            input: "0.000001",
+            output: "0.000002",
+          },
+        }],
+      }))
+    vi.stubGlobal("fetch", fetch)
+
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [usageCost()],
+      driver: {
+        run: () => ({
+          modelId: "custom/model",
+          text: "ok",
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            totalTokens: 12,
+          },
+        }),
+      },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    await runAgent(agent, runtime(), { prompt: "first" })
+    await runAgent(agent, runtime(), { prompt: "second" })
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(finish.mock.calls[0]![0].invocation.usage?.cost).toBeUndefined()
+    expect(finish.mock.calls[1]![0].invocation.usage?.cost).toEqual({
+      amount: "0.000014",
+      currency: "USD",
+      estimated: true,
+      source: "vercel-ai-gateway",
+    })
   })
 
   it.each([

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -146,6 +146,56 @@ describe("usageCost", () => {
     expect(pricing).toHaveBeenCalledOnce()
   })
 
+  it("prices usage records before yielding them from streamAgent", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const pricing = vi.fn(() => ({
+      amount: "0.02",
+      currency: "USD" as const,
+      estimated: true,
+      source: "custom" as const,
+    }))
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing })],
+      driver: {
+        run: () => (async function* () {
+          yield {
+            type: "usage" as const,
+            usageRecord: {
+              usage: {
+                inputTokens: 10,
+                outputTokens: 2,
+                totalTokens: 12,
+              },
+            },
+          }
+        })(),
+      },
+    })
+
+    const stream = await streamAgent(agent, runtime(), { prompt: "hello" })
+    const events = []
+    for await (const event of stream as AsyncIterable<unknown>) events.push(event)
+
+    expect(events).toEqual([{
+      type: "usage",
+      usageRecord: {
+        cost: {
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        },
+        usage: {
+          inputTokens: 10,
+          outputTokens: 2,
+          totalTokens: 12,
+        },
+      },
+    }])
+    expect(pricing).toHaveBeenCalledOnce()
+  })
+
   it("preserves richer raw usage while attaching the canonical record", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -285,6 +285,89 @@ describe("usageCost", () => {
     }))
   })
 
+  it("prices toUIMessageStream usage before tracing it", async () => {
+    const { createTraceEventLog } = await import("@vite-hub/runtime")
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const traceLog = createTraceEventLog()
+    const agent = defineAgent({
+      capabilities: [usageCost({
+        pricing: () => ({
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        }),
+      })],
+      driver: {
+        run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              start(controller) {
+                controller.enqueue({
+                  type: "usage",
+                  usageRecord: {
+                    usage: {
+                      inputTokens: 10,
+                      outputTokens: 2,
+                      totalTokens: 12,
+                    },
+                  },
+                })
+                controller.close()
+              },
+            })
+          },
+        }),
+      },
+    })
+
+    const stream = await streamAgent(agent, {
+      ...runtime(),
+      traceLog,
+    }, { prompt: "hello" }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    for await (const _chunk of stream) {}
+
+    expect(traceLog.entries()).toContainEqual(expect.objectContaining({
+      attributes: expect.objectContaining({
+        "usage.hasCost": true,
+        "usage.totalTokens": 12,
+      }),
+      name: "agent.usage.recorded",
+    }))
+  })
+
+  it("returns stream results before their usage promise settles", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    let resolveUsage!: (usage: { totalTokens: number }) => void
+    const usage = new Promise<{ totalTokens: number }>((resolve) => {
+      resolveUsage = resolve
+    })
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing: () => undefined })],
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield { type: "text-delta", text: "ok" }
+          })(),
+          usage,
+        }),
+      },
+    })
+
+    const pending = streamAgent(agent, runtime(), { prompt: "hello" })
+    const outcome = await Promise.race([
+      pending.then(() => "returned"),
+      new Promise<"blocked">(resolve => setTimeout(() => resolve("blocked"), 50)),
+    ])
+    resolveUsage({ totalTokens: 1 })
+
+    expect(outcome).toBe("returned")
+    const stream = await pending
+    for await (const _chunk of stream as AsyncIterable<unknown>) {}
+  })
+
   it("prices usage records before yielding runAgent streams", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -688,6 +688,42 @@ describe("usageCost", () => {
     expect(result.usageRecord?.cost?.amount).toBe("0.02")
   })
 
+  it("does not await unresolved UI usage when a streamAgent result is closed early", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing: () => undefined })],
+      driver: {
+        run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: "text-delta", delta: "ok" })
+              },
+            })
+          },
+          usage: new Promise(() => {}),
+        }),
+      },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    const stream = await streamAgent(agent, runtime(), { prompt: "hello" }, { output: "ui-message-stream" }) as AsyncIterable<unknown>
+    const consume = (async () => {
+      for await (const _chunk of stream) break
+    })()
+
+    await expect(Promise.race([
+      consume.then(() => "closed"),
+      new Promise<"blocked">(resolve => setTimeout(() => resolve("blocked"), 50)),
+    ])).resolves.toBe("closed")
+    expect(finish).toHaveBeenCalledOnce()
+    expect(finish.mock.calls[0]![0].invocation.usage).toBeUndefined()
+  })
+
   it("returns runAgent UI message results before their usage promise settles", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -241,6 +241,54 @@ describe("usageCost", () => {
     expect(pricing).toHaveBeenCalledOnce()
   })
 
+  it("prices usage carried by raw finish chunks before yielding", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const pricing = vi.fn(() => ({
+      amount: "0.02",
+      currency: "USD" as const,
+      estimated: true,
+      source: "custom" as const,
+    }))
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing })],
+      driver: {
+        run: () => (async function* () {
+          yield {
+            totalUsage: {
+              inputTokens: 10,
+              outputTokens: 2,
+              totalTokens: 12,
+            },
+            type: "finish" as const,
+          }
+        })(),
+      },
+    })
+
+    const stream = await runAgent(agent, runtime(), { prompt: "hello" })
+    const chunks = []
+    for await (const chunk of stream as AsyncIterable<unknown>) chunks.push(chunk)
+
+    expect(chunks).toEqual([{
+      totalUsage: {
+        inputTokens: 10,
+        outputTokens: 2,
+        totalTokens: 12,
+      },
+      type: "finish",
+      usageRecord: expect.objectContaining({
+        cost: {
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        },
+      }),
+    }])
+    expect(pricing).toHaveBeenCalledOnce()
+  })
+
   it("preserves richer raw usage while attaching the canonical record", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -120,6 +120,46 @@ describe("usageCost", () => {
     expect(finish.mock.calls[0]![0].invocation.usage?.cost).toBeUndefined()
   })
 
+  it.each([
+    {
+      name: "input",
+      usage: { inputTokens: 10 },
+    },
+    {
+      name: "output",
+      usage: { outputTokens: 2 },
+    },
+  ])("does not estimate cost when only $name token usage is reported", async ({ usage }) => {
+    const fetch = vi.fn(async () => Response.json({
+      data: [{
+        id: "custom/model",
+        pricing: {
+          input: "0.000001",
+          output: "0.000002",
+        },
+      }],
+    }))
+    vi.stubGlobal("fetch", fetch)
+
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [usageCost()],
+      driver: {
+        run: () => ({
+          modelId: "custom/model",
+          text: "ok",
+          usage,
+        }),
+      },
+    })
+
+    const result = await runAgent(agent, runtime(), { prompt: "hello" }) as {
+      usageRecord?: { cost?: unknown }
+    }
+    expect(result.usageRecord?.cost).toBeUndefined()
+  })
+
   it("supports custom pricing without provider dependencies", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")
@@ -535,6 +575,76 @@ describe("usageCost", () => {
     expect(outcome).toBe("returned")
     const result = await pending as { stream: AsyncIterable<unknown> }
     for await (const _chunk of result.stream) {}
+  })
+
+  it("does not await unresolved result usage when a runAgent stream is closed early", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const usage = new Promise(() => {})
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing: () => undefined })],
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield { type: "text-delta", text: "ok" }
+            await new Promise(() => {})
+          })(),
+          usage,
+        }),
+      },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    const result = await runAgent(agent, runtime(), { prompt: "hello" }) as { stream: AsyncIterable<unknown> }
+    const consume = (async () => {
+      for await (const _chunk of result.stream) break
+    })()
+
+    await expect(Promise.race([
+      consume.then(() => "closed"),
+      new Promise<"blocked">(resolve => setTimeout(() => resolve("blocked"), 50)),
+    ])).resolves.toBe("closed")
+    expect(finish).toHaveBeenCalledOnce()
+    expect(finish.mock.calls[0]![0].invocation.usage).toBeUndefined()
+  })
+
+  it("attaches deferred usage to returned plain stream results", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    let resolveUsage!: (usage: { inputTokens: number, outputTokens: number, totalTokens: number }) => void
+    const usage = new Promise<{ inputTokens: number, outputTokens: number, totalTokens: number }>((resolve) => {
+      resolveUsage = resolve
+    })
+    const agent = defineAgent({
+      capabilities: [usageCost({
+        pricing: () => ({
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        }),
+      })],
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield { type: "text-delta", text: "ok" }
+            resolveUsage({ inputTokens: 10, outputTokens: 2, totalTokens: 12 })
+          })(),
+          usage,
+        }),
+      },
+    })
+
+    const result = await runAgent(agent, runtime(), { prompt: "hello" }) as {
+      stream: AsyncIterable<unknown>
+      usageRecord?: { cost?: { amount: string } }
+    }
+    for await (const _chunk of result.stream) {}
+
+    expect(result.usageRecord?.cost?.amount).toBe("0.02")
   })
 
   it("returns runAgent UI message results before their usage promise settles", async () => {

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+const runtime = () => ({
+  memo: vi.fn(),
+  runtime: "unknown" as const,
+  runtimeConfig: {},
+  waitUntil: vi.fn(),
+})
+
+describe("usageCost", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("enriches canonical usage with cache-aware Vercel AI Gateway cost", async () => {
+    const fetch = vi.fn(async () => Response.json({
+      data: [{
+        id: "zai/glm-5v-turbo",
+        pricing: {
+          input: "0.0000012",
+          input_cache_read: "0.0000003",
+          input_cache_write: "0.0000015",
+          output: "0.000004",
+        },
+      }],
+    }))
+    vi.stubGlobal("fetch", fetch)
+
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [usageCost()],
+      driver: {
+        run: () => ({
+          modelId: "zai/glm-5v-turbo",
+          provider: "gateway",
+          text: "ok",
+          usage: {
+            inputTokenDetails: {
+              cacheReadTokens: 200,
+              cacheWriteTokens: 100,
+            },
+            inputTokens: 1_000,
+            outputTokens: 50,
+            totalTokens: 1_050,
+          },
+        }),
+      },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    await expect(runAgent(agent, runtime(), { prompt: "log breakfast" })).resolves.toMatchObject({
+      text: "ok",
+    })
+
+    const event = finish.mock.calls[0]![0]
+    expect(event.extensions.get("usage-cost")).toBe(event.invocation.usage)
+    expect(event.invocation.usage?.cost).toEqual({
+      amount: "0.00125",
+      currency: "USD",
+      estimated: true,
+      source: "vercel-ai-gateway",
+    })
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  it("supports custom pricing without provider dependencies", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const pricing = vi.fn(() => ({
+      amount: "0.42",
+      currency: "USD" as const,
+      estimated: false,
+      source: "custom" as const,
+    }))
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing })],
+      driver: {
+        run: () => ({
+          modelId: "custom/model",
+          text: "ok",
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            totalTokens: 12,
+          },
+        }),
+      },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    await runAgent(agent, runtime(), { prompt: "hello" })
+
+    expect(pricing).toHaveBeenCalledWith(expect.objectContaining({
+      model: expect.objectContaining({ id: "custom/model" }),
+      usage: expect.objectContaining({ totalTokens: 12 }),
+    }))
+    expect(finish.mock.calls[0]![0].invocation.usage?.cost).toEqual({
+      amount: "0.42",
+      currency: "USD",
+      estimated: false,
+      source: "custom",
+    })
+  })
+
+  it.each([
+    {
+      name: "throws",
+      pricing: () => {
+        throw new Error("pricing unavailable")
+      },
+    },
+    {
+      name: "returns no cost",
+      pricing: () => undefined,
+    },
+  ])("preserves usage and Agent success when pricing $name", async ({ pricing }) => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing })],
+      driver: {
+        run: () => ({
+          text: "ok",
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            totalTokens: 12,
+          },
+        }),
+      },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    await expect(runAgent(agent, runtime(), { prompt: "hello" })).resolves.toMatchObject({
+      text: "ok",
+    })
+
+    const event = finish.mock.calls[0]![0]
+    expect(event.extensions.get("usage-cost")).toBe(event.invocation.usage)
+    expect(event.invocation.usage).toEqual(expect.objectContaining({
+      usage: {
+        inputTokens: 10,
+        outputTokens: 2,
+        totalTokens: 12,
+      },
+    }))
+    expect(event.invocation.usage?.cost).toBeUndefined()
+  })
+
+  it("keeps provider-reported cost without resolving another price", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const pricing = vi.fn()
+    const finish = vi.fn()
+    const cost = {
+      amount: "0.01",
+      currency: "USD" as const,
+      estimated: false,
+      source: "provider" as const,
+    }
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing })],
+      driver: {
+        run: () => ({
+          text: "ok",
+          usageRecord: {
+            cost,
+            usage: {
+              inputTokens: 10,
+              outputTokens: 2,
+              totalTokens: 12,
+            },
+          },
+        }),
+      },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    await runAgent(agent, runtime(), { prompt: "hello" })
+
+    expect(pricing).not.toHaveBeenCalled()
+    expect(finish.mock.calls[0]![0].invocation.usage?.cost).toBe(cost)
+  })
+})

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -13,7 +13,7 @@ describe("usageCost", () => {
   })
 
   it("enriches canonical usage with cache-aware Vercel AI Gateway cost", async () => {
-    const fetch = vi.fn(async () => Response.json({
+    const fetch = vi.fn(async (_input: Parameters<typeof globalThis.fetch>[0], _init?: RequestInit) => Response.json({
       data: [{
         id: "zai/glm-5v-turbo",
         pricing: {
@@ -65,6 +65,7 @@ describe("usageCost", () => {
       source: "vercel-ai-gateway",
     })
     expect(fetch).toHaveBeenCalledOnce()
+    expect(fetch.mock.calls[0]![1]?.signal).toBeInstanceOf(AbortSignal)
   })
 
   it("supports custom pricing without provider dependencies", async () => {

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -9,6 +9,7 @@ const runtime = () => ({
 
 describe("usageCost", () => {
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
   })
 
@@ -472,6 +473,42 @@ describe("usageCost", () => {
     expect(outcome).toBe("returned")
     const result = await pending as { toUIMessageStream: () => ReadableStream<unknown> }
     for await (const _chunk of result.toUIMessageStream()) {}
+  })
+
+  it("returns streamAgent UI message results before their usage promise settles", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    let resolveUsage!: (usage: { totalTokens: number }) => void
+    const usage = new Promise<{ totalTokens: number }>((resolve) => {
+      resolveUsage = resolve
+    })
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing: () => undefined })],
+      driver: {
+        run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: "finish" })
+                controller.close()
+              },
+            })
+          },
+          usage,
+        }),
+      },
+    })
+
+    const pending = streamAgent(agent, runtime(), { prompt: "hello" }, { output: "ui-message-stream" })
+    const outcome = await Promise.race([
+      pending.then(() => "returned"),
+      new Promise<"blocked">(resolve => setTimeout(() => resolve("blocked"), 50)),
+    ])
+    resolveUsage({ totalTokens: 1 })
+
+    expect(outcome).toBe("returned")
+    const stream = await pending as ReadableStream<unknown>
+    for await (const _chunk of stream) {}
   })
 
   it("prices usage records before yielding runAgent streams", async () => {
@@ -969,6 +1006,56 @@ describe("usageCost", () => {
       estimated: true,
       source: "vercel-ai-gateway",
     })
+  })
+
+  it("refreshes cached catalog pricing after its freshness window", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(Response.json({
+        data: [{
+          id: "custom/model",
+          pricing: {
+            input: "0.000001",
+            output: "0.000002",
+          },
+        }],
+      }))
+      .mockResolvedValueOnce(Response.json({
+        data: [{
+          id: "custom/model",
+          pricing: {
+            input: "0.000002",
+            output: "0.000004",
+          },
+        }],
+      }))
+    vi.stubGlobal("fetch", fetch)
+
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [usageCost()],
+      driver: {
+        run: () => ({
+          modelId: "custom/model",
+          text: "ok",
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            totalTokens: 12,
+          },
+        }),
+      },
+    })
+
+    const first = await runAgent(agent, runtime(), { prompt: "first" })
+    vi.advanceTimersByTime(5 * 60_000)
+    const second = await runAgent(agent, runtime(), { prompt: "second" })
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+    expect(first).toMatchObject({ usageRecord: { cost: { amount: "0.000014" } } })
+    expect(second).toMatchObject({ usageRecord: { cost: { amount: "0.000028" } } })
   })
 
   it.each([

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -862,6 +862,57 @@ describe("usageCost", () => {
     expect(result.value()).toBe("preserved")
   })
 
+  it("preserves class-backed stream results while enriching their streams", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    class DriverStreamResult {
+      #value = "preserved"
+      stream = (async function* () {
+        yield {
+          type: "usage",
+          usageRecord: {
+            usage: {
+              inputTokens: 10,
+              outputTokens: 2,
+              totalTokens: 12,
+            },
+          },
+        }
+      })()
+
+      value() {
+        return this.#value
+      }
+    }
+    const result = new DriverStreamResult()
+    const agent = defineAgent({
+      capabilities: [usageCost({
+        pricing: () => ({
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        }),
+      })],
+      driver: {
+        run: () => result,
+      },
+    })
+
+    const enriched = await runAgent(agent, runtime(), { prompt: "hello" }) as DriverStreamResult
+    expect(enriched).toBe(result)
+    expect(enriched.value()).toBe("preserved")
+    const chunks = []
+    for await (const chunk of enriched.stream) chunks.push(chunk)
+    expect(chunks).toContainEqual(expect.objectContaining({
+      usageRecord: expect.objectContaining({
+        cost: expect.objectContaining({
+          amount: "0.02",
+        }),
+      }),
+    }))
+  })
+
   it("preserves Agent success when eager usage extraction fails", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -110,6 +110,49 @@ describe("usageCost", () => {
     })
   })
 
+  it("matches provider-scoped catalog entries for unscoped model IDs", async () => {
+    const fetch = vi.fn(async () => Response.json({
+      data: [{
+        id: "openai/gpt-5",
+        pricing: {
+          input: "0.000001",
+          output: "0.000002",
+        },
+      }],
+    }))
+    vi.stubGlobal("fetch", fetch)
+
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [usageCost()],
+      driver: {
+        run: () => ({
+          modelId: "gpt-5",
+          provider: "openai.responses",
+          text: "ok",
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            totalTokens: 12,
+          },
+        }),
+      },
+    })
+
+    await expect(runAgent(agent, runtime(), { prompt: "hello" })).resolves.toMatchObject({
+      usageRecord: {
+        cost: {
+          amount: "0.000014",
+          currency: "USD",
+          estimated: true,
+          source: "vercel-ai-gateway",
+        },
+      },
+    })
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
   it("enriches canonical usage without requiring a finish hook", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -146,6 +146,45 @@ describe("usageCost", () => {
     expect(pricing).toHaveBeenCalledOnce()
   })
 
+  it("preserves richer raw usage while attaching the canonical record", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const usage = {
+      inputTokens: 10,
+      outputTokens: 2,
+      providerMetadata: {
+        cacheTier: "ephemeral",
+      },
+      totalTokens: 12,
+    }
+    const agent = defineAgent({
+      capabilities: [usageCost({
+        pricing: () => ({
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        }),
+      })],
+      driver: {
+        run: () => ({
+          text: "ok",
+          usage,
+        }),
+      },
+    })
+
+    const result = await runAgent(agent, runtime(), { prompt: "hello" })
+    expect((result as { usage?: unknown }).usage).toBe(usage)
+    expect(result).toMatchObject({
+      usageRecord: {
+        cost: {
+          amount: "0.02",
+        },
+      },
+    })
+  })
+
   it("returns the enriched resolved record when usage metadata is added", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -154,6 +154,53 @@ describe("usageCost", () => {
     expect(fetch).toHaveBeenCalledOnce()
   })
 
+  it("does not map compatible providers to vendor catalog scopes", async () => {
+    const fetch = vi.fn(async () => Response.json({
+      data: [{
+        id: "openai/gpt-5",
+        pricing: {
+          input: "0.000001",
+          output: "0.000002",
+        },
+      }],
+    }))
+    vi.stubGlobal("fetch", fetch)
+
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [usageCost()],
+      driver: {
+        run: () => ({
+          modelId: "gpt-5",
+          provider: "openai-compatible",
+          text: "ok",
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            totalTokens: 12,
+          },
+        }),
+      },
+    })
+
+    const result = await runAgent(agent, runtime(), { prompt: "hello" })
+
+    expect(result).toMatchObject({
+      usageRecord: {
+        usage: {
+          totalTokens: 12,
+        },
+      },
+    })
+    expect(result).not.toMatchObject({
+      usageRecord: {
+        cost: expect.anything(),
+      },
+    })
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
   it("enriches canonical usage without requiring a finish hook", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -109,6 +109,78 @@ describe("usageCost", () => {
     })
   })
 
+  it("enriches canonical usage without requiring a finish hook", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const pricing = vi.fn(() => ({
+      amount: "0.02",
+      currency: "USD" as const,
+      estimated: true,
+      source: "custom" as const,
+    }))
+    const usageRecord = {
+      usage: {
+        inputTokens: 10,
+        outputTokens: 2,
+        totalTokens: 12,
+      },
+    }
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing })],
+      driver: {
+        run: () => ({
+          text: "ok",
+          usageRecord,
+        }),
+      },
+    })
+
+    await expect(runAgent(agent, runtime(), { prompt: "hello" })).resolves.toMatchObject({
+      text: "ok",
+    })
+    expect(pricing).toHaveBeenCalledOnce()
+  })
+
+  it("does not estimate cost from total-only token usage", async () => {
+    const fetch = vi.fn(async () => Response.json({
+      data: [{
+        id: "custom/model",
+        pricing: {
+          input: "0.000001",
+          output: "0.000002",
+        },
+      }],
+    }))
+    vi.stubGlobal("fetch", fetch)
+
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const usageRecord = {
+      usage: {
+        totalTokens: 12,
+      },
+    }
+    const agent = defineAgent({
+      capabilities: [usageCost()],
+      driver: {
+        run: () => ({
+          modelId: "custom/model",
+          text: "ok",
+          usageRecord,
+        }),
+      },
+    })
+
+    await expect(runAgent(agent, runtime(), { prompt: "hello" })).resolves.toMatchObject({
+      usageRecord: {
+        usage: {
+          totalTokens: 12,
+        },
+      },
+    })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
   it.each([
     {
       name: "throws",

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -724,6 +724,39 @@ describe("usageCost", () => {
     expect(finish.mock.calls[0]![0].invocation.usage).toBeUndefined()
   })
 
+  it("does not await unresolved event usage when a streamAgent result is closed early", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing: () => undefined })],
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield { type: "text-delta", text: "ok" }
+            await new Promise(() => {})
+          })(),
+          usage: new Promise(() => {}),
+        }),
+      },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    const stream = await streamAgent(agent, runtime(), { prompt: "hello" }) as AsyncIterable<unknown>
+    const consume = (async () => {
+      for await (const _chunk of stream) break
+    })()
+
+    await expect(Promise.race([
+      consume.then(() => "closed"),
+      new Promise<"blocked">(resolve => setTimeout(() => resolve("blocked"), 50)),
+    ])).resolves.toBe("closed")
+    expect(finish).toHaveBeenCalledOnce()
+    expect(finish.mock.calls[0]![0].invocation.usage).toBeUndefined()
+  })
+
   it("returns runAgent UI message results before their usage promise settles", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -158,6 +158,7 @@ describe("usageCost", () => {
       usageRecord?: { cost?: unknown }
     }
     expect(result.usageRecord?.cost).toBeUndefined()
+    expect(fetch).not.toHaveBeenCalled()
   })
 
   it("supports custom pricing without provider dependencies", async () => {
@@ -755,6 +756,50 @@ describe("usageCost", () => {
     ])).resolves.toBe("closed")
     expect(finish).toHaveBeenCalledOnce()
     expect(finish.mock.calls[0]![0].invocation.usage).toBeUndefined()
+  })
+
+  it("normalizes observed usage when a streamAgent result is closed early", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing: () => undefined })],
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield {
+              type: "usage" as const,
+              usageRecord: {
+                usage: {
+                  inputTokens: 10,
+                  outputTokens: 2,
+                  totalTokens: 12,
+                },
+              },
+            }
+            yield { type: "text-delta" as const, text: "unconsumed" }
+          })(),
+          usage: new Promise(() => {}),
+        }),
+      },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    const stream = await streamAgent(agent, {
+      ...runtime(),
+      run: { runId: "run-1" },
+    }, { prompt: "hello" }) as AsyncIterable<unknown>
+    for await (const chunk of stream) {
+      if ((chunk as { type?: string }).type === "usage") break
+    }
+
+    expect(finish).toHaveBeenCalledOnce()
+    expect(finish.mock.calls[0]![0].invocation.usage).toMatchObject({
+      run: { runId: "run-1" },
+      usage: { totalTokens: 12 },
+    })
   })
 
   it("returns runAgent UI message results before their usage promise settles", async () => {

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -647,6 +647,47 @@ describe("usageCost", () => {
     expect(result.usageRecord?.cost?.amount).toBe("0.02")
   })
 
+  it("attaches deferred usage to returned UI message stream results", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    let resolveUsage!: (usage: { inputTokens: number, outputTokens: number, totalTokens: number }) => void
+    const usage = new Promise<{ inputTokens: number, outputTokens: number, totalTokens: number }>((resolve) => {
+      resolveUsage = resolve
+    })
+    const agent = defineAgent({
+      capabilities: [usageCost({
+        pricing: () => ({
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        }),
+      })],
+      driver: {
+        run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: "text-delta", delta: "ok" })
+                resolveUsage({ inputTokens: 10, outputTokens: 2, totalTokens: 12 })
+                controller.close()
+              },
+            })
+          },
+          usage,
+        }),
+      },
+    })
+
+    const result = await runAgent(agent, runtime(), { prompt: "hello" }) as {
+      toUIMessageStream: () => ReadableStream<unknown>
+      usageRecord?: { cost?: { amount: string } }
+    }
+    for await (const _chunk of result.toUIMessageStream()) {}
+
+    expect(result.usageRecord?.cost?.amount).toBe("0.02")
+  })
+
   it("returns runAgent UI message results before their usage promise settles", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -407,6 +407,37 @@ describe("usageCost", () => {
     for await (const _chunk of stream as AsyncIterable<unknown>) {}
   })
 
+  it("returns runAgent stream results before their usage promise settles", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    let resolveUsage!: (usage: { totalTokens: number }) => void
+    const usage = new Promise<{ totalTokens: number }>((resolve) => {
+      resolveUsage = resolve
+    })
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing: () => undefined })],
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield { type: "text-delta", text: "ok" }
+          })(),
+          usage,
+        }),
+      },
+    })
+
+    const pending = runAgent(agent, runtime(), { prompt: "hello" })
+    const outcome = await Promise.race([
+      pending.then(() => "returned"),
+      new Promise<"blocked">(resolve => setTimeout(() => resolve("blocked"), 50)),
+    ])
+    resolveUsage({ totalTokens: 1 })
+
+    expect(outcome).toBe("returned")
+    const result = await pending as { stream: AsyncIterable<unknown> }
+    for await (const _chunk of result.stream) {}
+  })
+
   it("prices usage records before yielding runAgent streams", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -196,6 +196,51 @@ describe("usageCost", () => {
     expect(pricing).toHaveBeenCalledOnce()
   })
 
+  it("prices usage records before yielding runAgent streams", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const pricing = vi.fn(() => ({
+      amount: "0.02",
+      currency: "USD" as const,
+      estimated: true,
+      source: "custom" as const,
+    }))
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing })],
+      driver: {
+        run: () => (async function* () {
+          yield {
+            type: "usage" as const,
+            usageRecord: {
+              usage: {
+                inputTokens: 10,
+                outputTokens: 2,
+                totalTokens: 12,
+              },
+            },
+          }
+        })(),
+      },
+    })
+
+    const stream = await runAgent(agent, runtime(), { prompt: "hello" })
+    const events = []
+    for await (const event of stream as AsyncIterable<unknown>) events.push(event)
+
+    expect(events).toEqual([{
+      type: "usage",
+      usageRecord: expect.objectContaining({
+        cost: {
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        },
+      }),
+    }])
+    expect(pricing).toHaveBeenCalledOnce()
+  })
+
   it("preserves richer raw usage while attaching the canonical record", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")
@@ -488,6 +533,37 @@ describe("usageCost", () => {
     })
 
     await expect(runAgent(agent, runtime(), { prompt: "hello" })).resolves.toMatchObject({
+      usageRecord: {
+        usage: {
+          totalTokens: 12,
+        },
+      },
+    })
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
+  it("does not load pricing when usage has no model identity", async () => {
+    const fetch = vi.fn()
+    vi.stubGlobal("fetch", fetch)
+
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [usageCost()],
+      driver: {
+        run: () => ({
+          text: "ok",
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            totalTokens: 12,
+          },
+        }),
+      },
+    })
+
+    await expect(runAgent(agent, runtime(), { prompt: "hello" })).resolves.toMatchObject({
+      text: "ok",
       usageRecord: {
         usage: {
           totalTokens: 12,

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -146,6 +146,89 @@ describe("usageCost", () => {
     expect(pricing).toHaveBeenCalledOnce()
   })
 
+  it("returns the enriched resolved record when usage metadata is added", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [usageCost({
+        pricing: () => ({
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        }),
+      })],
+      driver: {
+        run: () => ({
+          modelId: "custom/model",
+          text: "ok",
+          usageRecord: {
+            usage: {
+              inputTokens: 10,
+              outputTokens: 2,
+              totalTokens: 12,
+            },
+          },
+        }),
+      },
+    })
+
+    await expect(runAgent(agent, {
+      ...runtime(),
+      run: { runId: "run-1" },
+    }, { prompt: "hello" })).resolves.toMatchObject({
+      usageRecord: {
+        cost: {
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        },
+        model: {
+          id: "custom/model",
+        },
+        run: {
+          runId: "run-1",
+        },
+      },
+    })
+  })
+
+  it("enriches immutable driver results without mutating them", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const result = Object.freeze({
+      text: "ok",
+      usage: {
+        inputTokens: 10,
+        outputTokens: 2,
+        totalTokens: 12,
+      },
+    })
+    const agent = defineAgent({
+      capabilities: [usageCost({
+        pricing: () => ({
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        }),
+      })],
+      driver: {
+        run: () => result,
+      },
+    })
+
+    await expect(runAgent(agent, runtime(), { prompt: "hello" })).resolves.toMatchObject({
+      usageRecord: {
+        cost: {
+          amount: "0.02",
+        },
+      },
+    })
+    expect(result).not.toHaveProperty("usageRecord")
+  })
+
   it("does not resolve unrelated lazy finish extensions during eager-only work", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -337,6 +337,45 @@ describe("usageCost", () => {
     }))
   })
 
+  it("prices serialized UI message response usage before returning it", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [usageCost({
+        pricing: () => ({
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        }),
+      })],
+      driver: {
+        run: () => new Response(`data: ${JSON.stringify({
+          type: "usage",
+          usageRecord: {
+            usage: {
+              inputTokens: 10,
+              outputTokens: 2,
+              totalTokens: 12,
+            },
+          },
+        })}\n\n`, {
+          headers: { "x-vercel-ai-ui-message-stream": "v1" },
+        }),
+      },
+    })
+
+    const response = await streamAgent(agent, runtime(), { prompt: "hello" }, {
+      output: "ui-message-stream",
+    }) as Response
+    const chunks = []
+    const body = response.body!
+      .pipeThrough(new TextDecoderStream())
+    for await (const chunk of body) chunks.push(chunk)
+
+    expect(chunks.join("")).toContain("\"amount\":\"0.02\"")
+  })
+
   it("returns stream results before their usage promise settles", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, streamAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -240,6 +240,51 @@ describe("usageCost", () => {
     expect(pricing).toHaveBeenCalledOnce()
   })
 
+  it("prices UI message stream usage before tracing it", async () => {
+    const { createTraceEventLog } = await import("@vite-hub/runtime")
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const traceLog = createTraceEventLog()
+    const agent = defineAgent({
+      capabilities: [usageCost({
+        pricing: () => ({
+          amount: "0.02",
+          currency: "USD",
+          estimated: true,
+          source: "custom",
+        }),
+      })],
+      driver: {
+        run: () => (async function* () {
+          yield {
+            type: "usage" as const,
+            usageRecord: {
+              usage: {
+                inputTokens: 10,
+                outputTokens: 2,
+                totalTokens: 12,
+              },
+            },
+          }
+        })(),
+      },
+    })
+
+    const stream = await streamAgent(agent, {
+      ...runtime(),
+      traceLog,
+    }, { prompt: "hello" }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    for await (const _chunk of stream) {}
+
+    expect(traceLog.entries()).toContainEqual(expect.objectContaining({
+      attributes: expect.objectContaining({
+        "usage.hasCost": true,
+        "usage.totalTokens": 12,
+      }),
+      name: "agent.usage.recorded",
+    }))
+  })
+
   it("prices usage records before yielding runAgent streams", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -511,6 +511,38 @@ describe("usageCost", () => {
     for await (const _chunk of stream) {}
   })
 
+  it("preserves resolved stream usage for finish hooks without eager extensions", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const agent = defineAgent({
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield { type: "text-delta", text: "ok" }
+          })(),
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            totalTokens: 12,
+          },
+        }),
+      },
+      hooks: {
+        "agent:finish": finish,
+      },
+    })
+
+    const stream = await streamAgent(agent, runtime(), { prompt: "hello" })
+    for await (const _chunk of stream as AsyncIterable<unknown>) {}
+
+    expect(finish).toHaveBeenCalledOnce()
+    expect(finish.mock.calls[0]![0].invocation.usage).toMatchObject({
+      usage: {
+        totalTokens: 12,
+      },
+    })
+  })
+
   it("prices usage records before yielding runAgent streams", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")
@@ -1056,6 +1088,62 @@ describe("usageCost", () => {
     expect(fetch).toHaveBeenCalledTimes(2)
     expect(first).toMatchObject({ usageRecord: { cost: { amount: "0.000014" } } })
     expect(second).toMatchObject({ usageRecord: { cost: { amount: "0.000028" } } })
+  })
+
+  it("shares one catalog refresh across concurrent invocations", async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"))
+    let resolveRefresh!: (response: Response) => void
+    const refresh = new Promise<Response>((resolve) => {
+      resolveRefresh = resolve
+    })
+    const fetch = vi.fn()
+      .mockResolvedValueOnce(Response.json({
+        data: [{
+          id: "custom/model",
+          pricing: {
+            input: "0.000001",
+            output: "0.000002",
+          },
+        }],
+      }))
+      .mockReturnValueOnce(refresh)
+    vi.stubGlobal("fetch", fetch)
+
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [usageCost()],
+      driver: {
+        run: () => ({
+          modelId: "custom/model",
+          text: "ok",
+          usage: {
+            inputTokens: 10,
+            outputTokens: 2,
+            totalTokens: 12,
+          },
+        }),
+      },
+    })
+
+    await runAgent(agent, runtime(), { prompt: "prime" })
+    vi.advanceTimersByTime(5 * 60_000)
+    const first = runAgent(agent, runtime(), { prompt: "first" })
+    const second = runAgent(agent, runtime(), { prompt: "second" })
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalledTimes(2))
+    resolveRefresh(Response.json({
+      data: [{
+        id: "custom/model",
+        pricing: {
+          input: "0.000002",
+          output: "0.000004",
+        },
+      }],
+    }))
+
+    await expect(Promise.all([first, second])).resolves.toHaveLength(2)
+    expect(fetch).toHaveBeenCalledTimes(2)
   })
 
   it.each([

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -834,6 +834,7 @@ describe("usageCost", () => {
       value() {
         return this.#value
       }
+
     }
     const result = new DriverResult()
     const agent = defineAgent({
@@ -883,6 +884,13 @@ describe("usageCost", () => {
       value() {
         return this.#value
       }
+
+      get textStream() {
+        const value = this.#value
+        return (async function* () {
+          yield value
+        })()
+      }
     }
     const result = new DriverStreamResult()
     const agent = defineAgent({
@@ -902,6 +910,9 @@ describe("usageCost", () => {
     const enriched = await runAgent(agent, runtime(), { prompt: "hello" }) as DriverStreamResult
     expect(enriched).toBe(result)
     expect(enriched.value()).toBe("preserved")
+    const text = []
+    for await (const chunk of enriched.textStream) text.push(chunk)
+    expect(text).toEqual(["preserved"])
     const chunks = []
     for await (const chunk of enriched.stream) chunks.push(chunk)
     expect(chunks).toContainEqual(expect.objectContaining({

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -438,6 +438,42 @@ describe("usageCost", () => {
     for await (const _chunk of result.stream) {}
   })
 
+  it("returns runAgent UI message results before their usage promise settles", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    let resolveUsage!: (usage: { totalTokens: number }) => void
+    const usage = new Promise<{ totalTokens: number }>((resolve) => {
+      resolveUsage = resolve
+    })
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing: () => undefined })],
+      driver: {
+        run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              start(controller) {
+                controller.enqueue({ type: "finish" })
+                controller.close()
+              },
+            })
+          },
+          usage,
+        }),
+      },
+    })
+
+    const pending = runAgent(agent, runtime(), { prompt: "hello" })
+    const outcome = await Promise.race([
+      pending.then(() => "returned"),
+      new Promise<"blocked">(resolve => setTimeout(() => resolve("blocked"), 50)),
+    ])
+    resolveUsage({ totalTokens: 1 })
+
+    expect(outcome).toBe("returned")
+    const result = await pending as { toUIMessageStream: () => ReadableStream<unknown> }
+    for await (const _chunk of result.toUIMessageStream()) {}
+  })
+
   it("prices usage records before yielding runAgent streams", async () => {
     const { usageCost } = await import("../src/capabilities.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -205,6 +205,7 @@ describe("usageCost", () => {
       estimated: true,
       source: "custom" as const,
     }))
+    const finish = vi.fn()
     const agent = defineAgent({
       capabilities: [usageCost({ pricing })],
       driver: {
@@ -220,6 +221,9 @@ describe("usageCost", () => {
             },
           }
         })(),
+      },
+      hooks: {
+        "agent:finish": finish,
       },
     })
 
@@ -239,6 +243,14 @@ describe("usageCost", () => {
       }),
     }])
     expect(pricing).toHaveBeenCalledOnce()
+    expect(finish.mock.calls[0]![0].invocation.usage).toEqual(expect.objectContaining({
+      cost: {
+        amount: "0.02",
+        currency: "USD",
+        estimated: true,
+        source: "custom",
+      },
+    }))
   })
 
   it("prices usage carried by raw finish chunks before yielding", async () => {
@@ -250,6 +262,7 @@ describe("usageCost", () => {
       estimated: true,
       source: "custom" as const,
     }))
+    const finish = vi.fn()
     const agent = defineAgent({
       capabilities: [usageCost({ pricing })],
       driver: {
@@ -263,6 +276,9 @@ describe("usageCost", () => {
             type: "finish" as const,
           }
         })(),
+      },
+      hooks: {
+        "agent:finish": finish,
       },
     })
 
@@ -287,6 +303,14 @@ describe("usageCost", () => {
       }),
     }])
     expect(pricing).toHaveBeenCalledOnce()
+    expect(finish.mock.calls[0]![0].invocation.usage).toEqual(expect.objectContaining({
+      cost: {
+        amount: "0.02",
+        currency: "USD",
+        estimated: true,
+        source: "custom",
+      },
+    }))
   })
 
   it("preserves richer raw usage while attaching the canonical record", async () => {

--- a/packages/agent/test/usage-cost.test.ts
+++ b/packages/agent/test/usage-cost.test.ts
@@ -297,8 +297,9 @@ describe("usageCost", () => {
       },
     })
 
-    await expect(runAgent(agent, runtime(), { prompt: "hello" })).resolves.toMatchObject({
-      raw: result,
+    const enriched = await runAgent(agent, runtime(), { prompt: "hello" })
+    expect(enriched).toBe(result)
+    expect(enriched).toMatchObject({
       usageRecord: {
         cost: {
           amount: "0.02",
@@ -306,6 +307,26 @@ describe("usageCost", () => {
       },
     })
     expect(result.value()).toBe("preserved")
+  })
+
+  it("preserves Agent success when eager usage extraction fails", async () => {
+    const { usageCost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const pricing = vi.fn()
+    const agent = defineAgent({
+      capabilities: [usageCost({ pricing })],
+      driver: {
+        run: () => ({
+          text: "ok",
+          usage: Promise.reject(new Error("usage unavailable")),
+        }),
+      },
+    })
+
+    await expect(runAgent(agent, runtime(), { prompt: "hello" })).resolves.toMatchObject({
+      text: "ok",
+    })
+    expect(pricing).not.toHaveBeenCalled()
   })
 
   it("does not resolve unrelated lazy finish extensions during eager-only work", async () => {


### PR DESCRIPTION
Adds opt-in `usageCost()` enrichment to ViteHub's canonical Agent Usage Record before Agent Finish Hooks run, and exposes that same record through `event.extensions.get("usage-cost")`. Raw usage capture remains unconditional, preserving the direct `event.invocation.usage` contract established when the legacy telemetry Capability was removed.

The default reuses ViteHub's existing Vercel AI Gateway catalog resolver with exact decimal arithmetic for regular input, cache read, cache write, and output tokens. Applications can provide an `AgentUsagePricing` callback without importing provider SDKs; provider-reported cost remains authoritative, while missing or failed pricing leaves the usage record and successful Agent Invocation unchanged.

Validated with the generated `vite-hub` distribution build and publint, the complete `@vite-hub/agent` suite (68 files, 1,568 tests), Agent typecheck, focused usage-cost and stream lifecycle regressions, docs typecheck, and `git diff --check`.
