### PR TITLE
fix(blob): resolve generated Nitro handlers from the project root

### DIFF
--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -112,21 +112,32 @@ function blobServeNitroRoute(serve: BlobServeConfig): string {
   return `${normalizeNitroRoute(serve.route).replace(/\/+$/, "")}/**`
 }
 
-function mergeNitroBlobConfig(value: unknown, serve: BlobServeConfig | undefined, cloudflare: boolean): Record<string, unknown> {
+function mergeNitroBlobConfig(value: unknown, serve: BlobServeConfig | undefined, cloudflare: boolean, root?: string): Record<string, unknown> {
   const nitro = cloneNitroConfig(value)
-  const plugins = Array.isArray(nitro.plugins) ? [...nitro.plugins] : []
-  if (!plugins.includes(generatedNitroBlobPlugin)) plugins.push(generatedNitroBlobPlugin)
-  const handlers = Array.isArray(nitro.handlers)
-    ? nitro.handlers.filter(handler => handler?.handler !== generatedNitroBlobMiddleware)
+  const plugin = root ? resolve(root, generatedNitroBlobPlugin) : generatedNitroBlobPlugin
+  const middleware = root ? resolve(root, generatedNitroBlobMiddleware) : generatedNitroBlobMiddleware
+  const serveHandler = root ? resolve(root, generatedBlobServeRouteHandler) : generatedBlobServeRouteHandler
+  const plugins = Array.isArray(nitro.plugins)
+    ? nitro.plugins.filter(entry => entry !== generatedNitroBlobPlugin && entry !== plugin)
     : []
-  if (cloudflare) handlers.unshift({ handler: generatedNitroBlobMiddleware, middleware: true, route: "/**" })
+  plugins.push(plugin)
+  const handlers = Array.isArray(nitro.handlers)
+    ? nitro.handlers.filter(handler =>
+        handler?.handler !== generatedNitroBlobMiddleware
+        && handler?.handler !== middleware,
+      )
+    : []
+  if (cloudflare) handlers.unshift({ handler: middleware, middleware: true, route: "/**" })
   if (!serve) return { ...nitro, handlers, plugins }
-  const existingHandlers = handlers.filter(handler => handler?.handler !== generatedBlobServeRouteHandler)
+  const existingHandlers = handlers.filter(handler =>
+    handler?.handler !== generatedBlobServeRouteHandler
+    && handler?.handler !== serveHandler,
+  )
   return {
     ...nitro,
     handlers: [
       ...existingHandlers,
-      { handler: generatedBlobServeRouteHandler, route: blobServeNitroRoute(serve) },
+      { handler: serveHandler, route: blobServeNitroRoute(serve) },
     ],
     plugins,
   }
@@ -274,6 +285,7 @@ export function hubBlob(options?: BlobModuleOptions): BlobVitePlugin {
         configuredNitro,
         blobConfig.blob ? blobConfig.blob.serve : undefined,
         cloudflareOwnedByNitro,
+        config.root,
       )
       ;(config as { nitro?: unknown }).nitro = mergeNitroCloudflareBlobOutput(config, nitro, blob, cloudflareOwnedByNitro)
       providerOutput = useComposedProviderOutput(config)

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -112,26 +112,29 @@ function blobServeNitroRoute(serve: BlobServeConfig): string {
   return `${normalizeNitroRoute(serve.route).replace(/\/+$/, "")}/**`
 }
 
+function isGeneratedNitroRegistration(value: unknown, generatedPath: string): boolean {
+  return typeof value === "string"
+    && (value === generatedPath || value.replaceAll("\\", "/").endsWith(`/${generatedPath}`))
+}
+
 function mergeNitroBlobConfig(value: unknown, serve: BlobServeConfig | undefined, cloudflare: boolean, root?: string): Record<string, unknown> {
   const nitro = cloneNitroConfig(value)
   const plugin = root ? resolve(root, generatedNitroBlobPlugin) : generatedNitroBlobPlugin
   const middleware = root ? resolve(root, generatedNitroBlobMiddleware) : generatedNitroBlobMiddleware
   const serveHandler = root ? resolve(root, generatedBlobServeRouteHandler) : generatedBlobServeRouteHandler
   const plugins = Array.isArray(nitro.plugins)
-    ? nitro.plugins.filter(entry => entry !== generatedNitroBlobPlugin && entry !== plugin)
+    ? nitro.plugins.filter(entry => !isGeneratedNitroRegistration(entry, generatedNitroBlobPlugin))
     : []
   plugins.push(plugin)
   const handlers = Array.isArray(nitro.handlers)
     ? nitro.handlers.filter(handler =>
-        handler?.handler !== generatedNitroBlobMiddleware
-        && handler?.handler !== middleware,
+        !isGeneratedNitroRegistration(handler?.handler, generatedNitroBlobMiddleware),
       )
     : []
   if (cloudflare) handlers.unshift({ handler: middleware, middleware: true, route: "/**" })
   if (!serve) return { ...nitro, handlers, plugins }
   const existingHandlers = handlers.filter(handler =>
-    handler?.handler !== generatedBlobServeRouteHandler
-    && handler?.handler !== serveHandler,
+    !isGeneratedNitroRegistration(handler?.handler, generatedBlobServeRouteHandler),
   )
   return {
     ...nitro,

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -153,6 +153,7 @@ describe("hubBlob", () => {
 
   it("resolves generated Nitro registrations from the final Vite root", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-blob-nitro-root-"))
+    const staleRoot = await mkdtemp(join(tmpdir(), "vitehub-blob-nitro-stale-root-"))
     const plugin = hubBlob({
       bucketName: "assets",
       driver: "cloudflare-r2",
@@ -188,11 +189,14 @@ describe("hubBlob", () => {
         ...userConfig.nitro,
         handlers: [
           ...(userConfig.nitro.handlers ?? []),
+          { handler: resolve(staleRoot, generatedMiddleware), middleware: true, route: "/**" },
+          { handler: resolve(staleRoot, generatedServeHandler), route: "/api/_vitehub/blob/**" },
           { handler: resolvedMiddleware, middleware: true, route: "/**" },
           { handler: resolvedServeHandler, route: "/api/_vitehub/blob/**" },
         ],
         plugins: [
           ...(userConfig.nitro.plugins ?? []),
+          resolve(staleRoot, generatedPlugin),
           resolvedPlugin,
         ],
       },
@@ -212,6 +216,7 @@ describe("hubBlob", () => {
     }
     finally {
       await rm(root, { force: true, recursive: true })
+      await rm(staleRoot, { force: true, recursive: true })
     }
   })
 

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -151,6 +151,70 @@ describe("hubBlob", () => {
     expect(driverImports(nitroRuntime)[0]).toContain("/drivers/fs")
   })
 
+  it("resolves generated Nitro registrations from the final Vite root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-nitro-root-"))
+    const plugin = hubBlob({
+      bucketName: "assets",
+      driver: "cloudflare-r2",
+      nitroOwned: true,
+      serve: true,
+    } as never)
+    const config = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build" }) => void
+    const configResolved = plugin.configResolved as (config: unknown) => void | Promise<void>
+    const generatedPlugin = ".vitehub/nitro/blob/plugin.ts"
+    const generatedMiddleware = ".vitehub/nitro/blob/middleware.ts"
+    const generatedServeHandler = ".vitehub/blob/serve-route.ts"
+    const resolvedPlugin = resolve(root, generatedPlugin)
+    const resolvedMiddleware = resolve(root, generatedMiddleware)
+    const resolvedServeHandler = resolve(root, generatedServeHandler)
+    const userConfig: {
+      nitro: {
+        handlers?: unknown[]
+        plugins?: string[]
+        preset: string
+      }
+    } = { nitro: { preset: "cloudflare_module" } }
+
+    config(userConfig, { command: "build" })
+    expect(userConfig).toHaveProperty("nitro.plugins", [generatedPlugin])
+    expect(userConfig).toHaveProperty("nitro.handlers", [
+      { handler: generatedMiddleware, middleware: true, route: "/**" },
+      { handler: generatedServeHandler, route: "/api/_vitehub/blob/**" },
+    ])
+
+    const resolvedConfig = {
+      build: { outDir: "dist" },
+      nitro: {
+        ...userConfig.nitro,
+        handlers: [
+          ...(userConfig.nitro.handlers ?? []),
+          { handler: resolvedMiddleware, middleware: true, route: "/**" },
+          { handler: resolvedServeHandler, route: "/api/_vitehub/blob/**" },
+        ],
+        plugins: [
+          ...(userConfig.nitro.plugins ?? []),
+          resolvedPlugin,
+        ],
+      },
+      root,
+    }
+
+    try {
+      await configResolved(resolvedConfig as never)
+      await configResolved(resolvedConfig as never)
+
+      expect(root).not.toBe(process.cwd())
+      expect(resolvedConfig).toHaveProperty("nitro.plugins", [resolvedPlugin])
+      expect(resolvedConfig).toHaveProperty("nitro.handlers", [
+        { handler: resolvedMiddleware, middleware: true, route: "/**" },
+        { handler: resolvedServeHandler, route: "/api/_vitehub/blob/**" },
+      ])
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("runs selected default and named Blob stores from a standalone Node artifact", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-blob-nitro-node-"))
     const artifactRoot = await mkdtemp(join(tmpdir(), "vitehub-blob-nitro-artifact-"))


### PR DESCRIPTION
## Summary

- resolve Blob's generated Nitro plugin, Cloudflare middleware, and serving handler from the final Vite project root
- replace relative or already-resolved registrations with one canonical path so repeated configuration stays idempotent
- cover a consuming root that differs from `cwd`, including mixed relative and absolute registrations

## Why

Nuxt can materialize both workspace-root and app-root `.vitehub` trees. Relative Nitro registrations can silently select the stale workspace runtime even after Blob generates the correct app-root runtime, so the final Vite hook now anchors every generated registration to `config.root`. The early `config` hook remains relative because its root is not final yet.

## Verification

- `pnpm --filter @vite-hub/blob exec vp test test/vite.test.ts -t 'registers Nitro runtime setup|resolves generated Nitro registrations|facade declare Nitro ownership|final Nitro ownership|does not yield Cloudflare output|removes an early R2 contribution|masks credentials'`
- `pnpm --filter @vite-hub/blob build`
- `pnpm --filter @vite-hub/blob typecheck`
- `pnpm exec vp exec oxlint packages/blob/src/vite.ts packages/blob/test/vite.test.ts --ignore-path .gitignore`
- `git diff --check`