### PR TITLE
fix(agent): compose channel instructions outside chat history

### DIFF
--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -5,7 +5,7 @@ import {
   teeingAsyncIterableStreamDescriptor,
 } from "./internal/stream-result.ts"
 import { loadAiSdk } from "./internal/ai-sdk-runtime.ts"
-import { resolveMessageChannelInstructions } from "./internal/channels.ts"
+import { markMessageChannelInstructionConsumer, resolveMessageChannelInstructions } from "./internal/channels.ts"
 import {
   applyCapabilityToolTransforms,
 } from "./capability-runtime.ts"
@@ -1087,7 +1087,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
   const staticTools = typeof options.tools === "object" && options.tools
     ? withAgentToolStepReporting(withJsonCompatibleToolOutputs(applyAgentToolPolicies(options.tools as AgentToolSet) || {}))
     : undefined
-  return {
+  return markMessageChannelInstructionConsumer({
     async generate(context) {
       const execution = options.execution
       const callInput = await getCallInput(context, execution?.attachments) as Record<string, unknown>
@@ -1159,7 +1159,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       } as never) as StreamTextResult<ToolSet, never, never>, usageCapture), model) as StreamTextResult<ToolSet, never, never>
       return withWorkspaceFallbackStreamResult(result, model as never, context, fallback, fallbackCapture?.evidence)
     },
-  }
+  })
 }
 
 export function fromAiSdkAgent(agent: Agent): AgentAdapter {

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -507,7 +507,8 @@ async function synthesizeWorkspaceFallbackFromEvidence(
     instructions: [
       "Answer the user's last message using only the workspace tool results.",
       "If the tool results are insufficient, say what is missing.",
-    ].join("\n"),
+      resolveMessageChannelInstructions(context.context, context),
+    ].filter(Boolean).join("\n"),
     model,
     prompt: [
       `User message:\n${getPromptText(context)}`,
@@ -1031,7 +1032,7 @@ async function createAgent(
     joinInstructions(
       await resolveInstructions(options, metadataContext),
       context.instructions,
-      resolveMessageChannelInstructions(context.context),
+      resolveMessageChannelInstructions(context.context, context),
       agentOutputInstructions(context.output),
     ),
     metadataContext,

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -5,6 +5,7 @@ import {
   teeingAsyncIterableStreamDescriptor,
 } from "./internal/stream-result.ts"
 import { loadAiSdk } from "./internal/ai-sdk-runtime.ts"
+import { resolveMessageChannelInstructions } from "./internal/channels.ts"
 import {
   applyCapabilityToolTransforms,
 } from "./capability-runtime.ts"
@@ -1028,7 +1029,9 @@ async function createAgent(
     : model
   const instructions = await composeInstructions(
     joinInstructions(
-      context.instructions ?? await resolveInstructions(options, metadataContext),
+      await resolveInstructions(options, metadataContext),
+      context.instructions,
+      resolveMessageChannelInstructions(context.context),
       agentOutputInstructions(context.output),
     ),
     metadataContext,

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -5,6 +5,7 @@ import { toAgentUiMessageStreamResponse } from "../http-response.ts"
 import { normalizeAgentDriver, resolveNormalizedHarnessDriver } from "../internal/agent-driver.ts"
 import { progressSummaryOutputContextKey } from "../internal/agent-output-events.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
+import { markAuxiliaryMessageChannelInstructionContext } from "../internal/channels.ts"
 import { isAsyncIterable, toReadableAsyncIterableStream } from "../internal/stream-result.ts"
 import { getMessageText } from "../messages.ts"
 import { normalizeUiMessageStreamChunk } from "../stream-output.ts"
@@ -170,7 +171,7 @@ function progressSummaryAdapterRunContext(
   if (!context.runtimeContext) {
     throw new Error("[vitehub] progressSummary({ driver }) requires an agent runtime context.")
   }
-  return {
+  return markAuxiliaryMessageChannelInstructionContext({
     actor: context.actor,
     context: context.context,
     toolStepReporter: context.runtimeContext.toolStepReporter,
@@ -179,7 +180,7 @@ function progressSummaryAdapterRunContext(
     messages: [],
     prompt,
     runtime: context.runtimeContext,
-  }
+  })
 }
 
 function progressSummaryRunContext(

--- a/packages/agent/src/capabilities/title.ts
+++ b/packages/agent/src/capabilities/title.ts
@@ -5,6 +5,7 @@ import {
   claimMessageChannelTitleDelivery,
   createMessageChannelTitleEffectIntent,
   finishMessageChannelTitleDelivery,
+  markAuxiliaryMessageChannelInstructionContext,
   messageChannelStateContextKey,
   messageChannelTitleDeliveredContextKey,
   resetMessageChannelTitleDelivery,
@@ -266,7 +267,7 @@ function titleAdapterRunContext(
   if (!context.runtimeContext) {
     throw new Error("[vitehub] title({ driver }) requires an agent runtime context.")
   }
-  return {
+  return markAuxiliaryMessageChannelInstructionContext({
     actor: context.actor,
     context: context.context,
     toolStepReporter: context.runtimeContext.toolStepReporter,
@@ -275,7 +276,7 @@ function titleAdapterRunContext(
     messages: [],
     prompt,
     runtime: context.runtimeContext,
-  }
+  })
 }
 
 function titleRunContext(

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -42,6 +42,7 @@ import type {
   MaybeResolvable,
   PublishedAgentDeliveryArtifact,
 } from "./types.ts"
+import { defineMessageChannelInstructions } from "./internal/channels.ts"
 import type { PullRequestContextValue } from "./capabilities/repository-host-context.ts"
 import type { AgentChannelChatRouteBody, AgentChannelChatRouteHandlerOptions } from "./server.ts"
 import type { TelegramAdapterConfig } from "@chat-adapter/telegram"
@@ -2065,14 +2066,14 @@ export function telegram<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntim
   const webhookOptions = webhookSecret !== undefined
     ? { secretToken: telegramWebhookSecretToken(webhookSecret) }
     : webhooks
-  return defineChannel("telegram", {
+  return defineMessageChannelInstructions(defineChannel("telegram", {
     ...channelOptions,
     adapter: telegramAdapterResolver(options),
     ...(mode === "polling" ? { listener: { kind: "telegram-polling" } } : {}),
     webhooks: mode === "polling"
       ? false
       : telegramWebhookDefaults(webhookOptions),
-  })
+  }), "Write the final response for Telegram. Match the language of the user's latest message. Prefer short paragraphs or bullets and keep the answer concise. Do not use Markdown tables; express rows as bullets because Telegram fallback delivery exposes table syntax. Avoid decorative emoji, redundant restatement, and generic follow-up questions. Follow the Agent's own instructions when they require a different format.")
 }
 
 export function webChat<

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -712,7 +712,7 @@ async function resolveHarnessDriverInstructions<
   const configured = resolved ? await composeHarnessInstructions(resolved, context) : undefined
   return [
     configured,
-    resolveMessageChannelInstructions(context.context),
+    resolveMessageChannelInstructions(context.context, context),
     agentOutputInstructions(context.output),
   ].filter(Boolean).join("\n\n") || undefined
 }

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -19,7 +19,7 @@ import {
 } from "./workspace-agent.ts"
 import { abortSignalError, nextWithAbort } from "./internal/abortable-stream.ts"
 import { agentOutputInstructions } from "./internal/agent-structured-output.ts"
-import { resolveMessageChannelInstructions } from "./internal/channels.ts"
+import { markMessageChannelInstructionConsumer, resolveMessageChannelInstructions } from "./internal/channels.ts"
 import {
   colocatedAgentSkillsContextKey,
   type ColocatedAgentSkills,
@@ -1455,7 +1455,7 @@ export function createHarnessAgentAdapter<
     }
   }
 
-  return {
+  return markMessageChannelInstructionConsumer({
     async generate(context) {
       const { agent, chatPrompt, cleanup, session, resumesSession } = await createAgentAndSession(context)
       try {
@@ -1486,6 +1486,6 @@ export function createHarnessAgentAdapter<
         throw error
       }
     },
-  }
+  })
 }
 import { posix } from "node:path"

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -19,6 +19,7 @@ import {
 } from "./workspace-agent.ts"
 import { abortSignalError, nextWithAbort } from "./internal/abortable-stream.ts"
 import { agentOutputInstructions } from "./internal/agent-structured-output.ts"
+import { resolveMessageChannelInstructions } from "./internal/channels.ts"
 import {
   colocatedAgentSkillsContextKey,
   type ColocatedAgentSkills,
@@ -709,7 +710,11 @@ async function resolveHarnessDriverInstructions<
     throw new TypeError("[vitehub] defineAgent({ driver.instructions }) must resolve to a string.")
   }
   const configured = resolved ? await composeHarnessInstructions(resolved, context) : undefined
-  return [configured, agentOutputInstructions(context.output)].filter(Boolean).join("\n\n") || undefined
+  return [
+    configured,
+    resolveMessageChannelInstructions(context.context),
+    agentOutputInstructions(context.output),
+  ].filter(Boolean).join("\n\n") || undefined
 }
 
 async function resolveHarnessWorkDir<

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1656,7 +1656,10 @@ async function createAgentInvocationContext<
     : tracedRuntimeContext
   const callbackContext = createAgentCallbackContext(runtimeContext)
   const invocationContext = createAgentInvocationContextStore(input.context)
-  bindMessageChannelInstructions(invocationContext, context.run?.channelId ? definition?.channels?.[context.run.channelId] : undefined)
+  bindMessageChannelInstructions(
+    invocationContext,
+    activeAgentChannel(definition?.channels, invocationContext, context.run)?.channel,
+  )
   invocationContext.set(scheduledAgentChannelIdsContextKey, Object.keys(definition?.channels || {}), { overwrite: true })
   invocationContext.set(scheduledAgentNameContextKey, context.agentIdentity?.name, { overwrite: true })
   const colocatedSkills = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[colocatedAgentSkillsSymbol]

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -19,6 +19,7 @@ import { createTraceEventLog, getViteHubErrorShape, resolveRuntimeContext } from
 import { agentResultKind, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
 import { defineChatCapability, getChatCapabilityOptions } from "./chat-trigger.ts"
 import {
+  bindMessageChannelInstructions,
   finishMessageChannelTitleDelivery,
   isMessageChannelTitleEffectIntent,
   messageChannelTitleDeliveredContextKey,
@@ -1655,6 +1656,7 @@ async function createAgentInvocationContext<
     : tracedRuntimeContext
   const callbackContext = createAgentCallbackContext(runtimeContext)
   const invocationContext = createAgentInvocationContextStore(input.context)
+  bindMessageChannelInstructions(invocationContext, context.run?.channelId ? definition?.channels?.[context.run.channelId] : undefined)
   invocationContext.set(scheduledAgentChannelIdsContextKey, Object.keys(definition?.channels || {}), { overwrite: true })
   invocationContext.set(scheduledAgentNameContextKey, context.agentIdentity?.name, { overwrite: true })
   const colocatedSkills = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[colocatedAgentSkillsSymbol]

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -17,7 +17,7 @@ const messageChannelTitleClaimTtlMs = 5 * 60 * 1000
 const messageChannelInstructions = new WeakMap<object, string>()
 const messageChannelInvocationInstructions = new WeakMap<AgentInvocationContextStore, string>()
 const auxiliaryMessageChannelInstructionContexts = new WeakSet<object>()
-const messageChannelInstructionConsumers = new WeakSet<object>()
+const messageChannelInstructionConsumer = Symbol("vitehub.messageChannelInstructionConsumer")
 const messageChannelTitleEffectIntents = new WeakSet<AgentChannelDeliveryEffectIntent>()
 const messageChannelTitleDeliveryPolicies = new WeakMap<AgentChannelDeliveryEffectIntent, "always" | "once-per-thread">()
 const messageChannelTitleDeliveryAttempts = new WeakMap<AgentChannelDeliveryEffectIntent, MessageChannelTitleDeliveryAttempt>()
@@ -90,12 +90,15 @@ export function markAuxiliaryMessageChannelInstructionContext<TContext extends o
 export function markMessageChannelInstructionConsumer<TConsumer extends object>(
   consumer: TConsumer,
 ): TConsumer {
-  messageChannelInstructionConsumers.add(consumer)
+  Object.defineProperty(consumer, messageChannelInstructionConsumer, {
+    enumerable: true,
+    value: true,
+  })
   return consumer
 }
 
 export function consumesMessageChannelInstructions(consumer: object): boolean {
-  return messageChannelInstructionConsumers.has(consumer)
+  return (consumer as { [messageChannelInstructionConsumer]?: unknown })[messageChannelInstructionConsumer] === true
 }
 
 export function resolveMessageChannelInstructions(

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -59,6 +59,17 @@ export function inheritMessageChannelInstructions<
   return channel
 }
 
+export function inspectMessageChannelInstructions(
+  channels: Record<string, unknown> | undefined,
+): string[] {
+  return Object.entries(channels || {}).flatMap(([channelId, channel]) => {
+    const instructions = channel && typeof channel === "object"
+      ? messageChannelInstructions.get(channel)
+      : undefined
+    return instructions ? [`Channel "${channelId}" instructions:\n\n${instructions}`] : []
+  })
+}
+
 export function bindMessageChannelInstructions(
   context: AgentInvocationContextStore,
   channel: object | undefined,

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -51,6 +51,14 @@ export function defineMessageChannelInstructions<
   return channel
 }
 
+export function inheritMessageChannelInstructions<
+  TChannel extends object,
+>(channel: TChannel, source: object): TChannel {
+  const instructions = messageChannelInstructions.get(source)
+  if (instructions) messageChannelInstructions.set(channel, instructions)
+  return channel
+}
+
 export function bindMessageChannelInstructions(
   context: AgentInvocationContextStore,
   channel: object | undefined,

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -14,6 +14,8 @@ import type { Lock, StateAdapter } from "chat"
 export const messageChannelTitleDeliveredContextKey = "channel.delivery.titleDelivered"
 export const messageChannelStateContextKey = "chat.channelState"
 const messageChannelTitleClaimTtlMs = 5 * 60 * 1000
+const messageChannelInstructions = new WeakMap<object, string>()
+const messageChannelInvocationInstructions = new WeakMap<AgentInvocationContextStore, string>()
 const messageChannelTitleEffectIntents = new WeakSet<AgentChannelDeliveryEffectIntent>()
 const messageChannelTitleDeliveryPolicies = new WeakMap<AgentChannelDeliveryEffectIntent, "always" | "once-per-thread">()
 const messageChannelTitleDeliveryAttempts = new WeakMap<AgentChannelDeliveryEffectIntent, MessageChannelTitleDeliveryAttempt>()
@@ -36,6 +38,29 @@ export interface MessageChannelTitleDeliveryAttempt {
   error?: unknown
   persist?: boolean
   reason?: "already-delivered" | "pending"
+}
+
+export function defineMessageChannelInstructions<
+  TChannel extends object,
+>(channel: TChannel, instructions: string): TChannel {
+  const value = instructions.trim()
+  if (!value) {
+    throw new TypeError("[vitehub] Internal Channel instructions must be a non-empty string.")
+  }
+  messageChannelInstructions.set(channel, value)
+  return channel
+}
+
+export function bindMessageChannelInstructions(
+  context: AgentInvocationContextStore,
+  channel: object | undefined,
+): void {
+  const instructions = channel && messageChannelInstructions.get(channel)
+  if (instructions) messageChannelInvocationInstructions.set(context, instructions)
+}
+
+export function resolveMessageChannelInstructions(context: AgentInvocationContextStore): string | undefined {
+  return messageChannelInvocationInstructions.get(context)
 }
 
 export function createMessageChannelTitleEffectIntent(

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -16,6 +16,7 @@ export const messageChannelStateContextKey = "chat.channelState"
 const messageChannelTitleClaimTtlMs = 5 * 60 * 1000
 const messageChannelInstructions = new WeakMap<object, string>()
 const messageChannelInvocationInstructions = new WeakMap<AgentInvocationContextStore, string>()
+const auxiliaryMessageChannelInstructionContexts = new WeakSet<object>()
 const messageChannelTitleEffectIntents = new WeakSet<AgentChannelDeliveryEffectIntent>()
 const messageChannelTitleDeliveryPolicies = new WeakMap<AgentChannelDeliveryEffectIntent, "always" | "once-per-thread">()
 const messageChannelTitleDeliveryAttempts = new WeakMap<AgentChannelDeliveryEffectIntent, MessageChannelTitleDeliveryAttempt>()
@@ -78,7 +79,18 @@ export function bindMessageChannelInstructions(
   if (instructions) messageChannelInvocationInstructions.set(context, instructions)
 }
 
-export function resolveMessageChannelInstructions(context: AgentInvocationContextStore): string | undefined {
+export function markAuxiliaryMessageChannelInstructionContext<TContext extends object>(
+  context: TContext,
+): TContext {
+  auxiliaryMessageChannelInstructionContexts.add(context)
+  return context
+}
+
+export function resolveMessageChannelInstructions(
+  context: AgentInvocationContextStore,
+  adapterContext?: object,
+): string | undefined {
+  if (adapterContext && auxiliaryMessageChannelInstructionContexts.has(adapterContext)) return undefined
   return messageChannelInvocationInstructions.get(context)
 }
 

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -17,6 +17,7 @@ const messageChannelTitleClaimTtlMs = 5 * 60 * 1000
 const messageChannelInstructions = new WeakMap<object, string>()
 const messageChannelInvocationInstructions = new WeakMap<AgentInvocationContextStore, string>()
 const auxiliaryMessageChannelInstructionContexts = new WeakSet<object>()
+const messageChannelInstructionConsumers = new WeakSet<object>()
 const messageChannelTitleEffectIntents = new WeakSet<AgentChannelDeliveryEffectIntent>()
 const messageChannelTitleDeliveryPolicies = new WeakMap<AgentChannelDeliveryEffectIntent, "always" | "once-per-thread">()
 const messageChannelTitleDeliveryAttempts = new WeakMap<AgentChannelDeliveryEffectIntent, MessageChannelTitleDeliveryAttempt>()
@@ -84,6 +85,17 @@ export function markAuxiliaryMessageChannelInstructionContext<TContext extends o
 ): TContext {
   auxiliaryMessageChannelInstructionContexts.add(context)
   return context
+}
+
+export function markMessageChannelInstructionConsumer<TConsumer extends object>(
+  consumer: TConsumer,
+): TConsumer {
+  messageChannelInstructionConsumers.add(consumer)
+  return consumer
+}
+
+export function consumesMessageChannelInstructions(consumer: object): boolean {
+  return messageChannelInstructionConsumers.has(consumer)
 }
 
 export function resolveMessageChannelInstructions(

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -14,7 +14,7 @@ import type { Lock, StateAdapter } from "chat"
 export const messageChannelTitleDeliveredContextKey = "channel.delivery.titleDelivered"
 export const messageChannelStateContextKey = "chat.channelState"
 const messageChannelTitleClaimTtlMs = 5 * 60 * 1000
-const messageChannelInstructions = new WeakMap<object, string>()
+const messageChannelInstructions = Symbol("vitehub.messageChannelInstructions")
 const messageChannelInvocationInstructions = new WeakMap<AgentInvocationContextStore, string>()
 const auxiliaryMessageChannelInstructionContexts = new WeakSet<object>()
 const messageChannelInstructionConsumer = Symbol("vitehub.messageChannelInstructionConsumer")
@@ -49,15 +49,18 @@ export function defineMessageChannelInstructions<
   if (!value) {
     throw new TypeError("[vitehub] Internal Channel instructions must be a non-empty string.")
   }
-  messageChannelInstructions.set(channel, value)
+  Object.defineProperty(channel, messageChannelInstructions, {
+    enumerable: true,
+    value,
+  })
   return channel
 }
 
 export function inheritMessageChannelInstructions<
   TChannel extends object,
 >(channel: TChannel, source: object): TChannel {
-  const instructions = messageChannelInstructions.get(source)
-  if (instructions) messageChannelInstructions.set(channel, instructions)
+  const instructions = (source as { [messageChannelInstructions]?: string })[messageChannelInstructions]
+  if (instructions) defineMessageChannelInstructions(channel, instructions)
   return channel
 }
 
@@ -66,7 +69,7 @@ export function inspectMessageChannelInstructions(
 ): string[] {
   return Object.entries(channels || {}).flatMap(([channelId, channel]) => {
     const instructions = channel && typeof channel === "object"
-      ? messageChannelInstructions.get(channel)
+      ? (channel as { [messageChannelInstructions]?: string })[messageChannelInstructions]
       : undefined
     return instructions ? [`Channel "${channelId}" instructions:\n\n${instructions}`] : []
   })
@@ -76,7 +79,7 @@ export function bindMessageChannelInstructions(
   context: AgentInvocationContextStore,
   channel: object | undefined,
 ): void {
-  const instructions = channel && messageChannelInstructions.get(channel)
+  const instructions = channel && (channel as { [messageChannelInstructions]?: string })[messageChannelInstructions]
   if (instructions) messageChannelInvocationInstructions.set(context, instructions)
 }
 

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -12,6 +12,7 @@ import { streamAgentOutputToEvents } from "../agent-output.ts"
 import { uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { discoverAgentDefinitions } from "../discovery.ts"
 import { isResolvedAgentTriggerHandledInvocation, resolveAgentInspectionMetadata, resolveAgentTriggerInvocation, resolveAgentTriggers, runAgentInline, streamAgent } from "../index.ts"
+import { inheritMessageChannelInstructions } from "../internal/channels.ts"
 import { workspaceAgentOwnsWorkspaceDefinition, workspaceModeFromOptions, workspaceNameFromOptions } from "../workspace-agent.ts"
 import {
   createViteAgentDiscoveryContext,
@@ -153,7 +154,7 @@ function withDeliveryPreviewChannels(
         type: "delivery-preview",
       })
     }]))
-    return [channelId, { ...channel, effects }]
+    return [channelId, inheritMessageChannelInstructions({ ...channel, effects }, channel)]
   }))
   const clone = Object.create(Object.getPrototypeOf(agent)) as AgentInput<ViteAgentRuntimeContext>
   Object.defineProperties(clone, Object.getOwnPropertyDescriptors(agent))

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -26,7 +26,7 @@ import {
   resolveInstructionImports,
 } from "./instruction-composition.ts"
 import { normalizeAgentDriver, resolveNormalizedHarnessDriver } from "./internal/agent-driver.ts"
-import { inspectMessageChannelInstructions } from "./internal/channels.ts"
+import { consumesMessageChannelInstructions, inspectMessageChannelInstructions } from "./internal/channels.ts"
 
 import type {
   AgentAdapterMetadataContext,
@@ -772,7 +772,7 @@ function agentChannelMetadataInstructions<
   definition: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
 ): string[] {
   const settings = agentSettings(definition)
-  if (settings && normalizeAgentDriver(settings).kind === "run") return []
+  if (!settings || normalizeAgentDriver(settings).kind === "run") return []
   return inspectMessageChannelInstructions(definition.channels)
 }
 
@@ -1457,8 +1457,11 @@ async function resolveNonWorkspaceAgentInspectionMetadata<
   resolution: AgentInspectionMetadataResolutionOptions<TRuntimeConfig, Name>,
 ): Promise<AgentInspectionMetadata> {
   const settings = agentSettings(definition)
-  const channelInstructions = agentChannelMetadataInstructions(definition)
   if (!settings) {
+    const adapter = await definition.resolve(createInspectionMetadataRuntime(resolution))
+    const channelInstructions = consumesMessageChannelInstructions(adapter)
+      ? inspectMessageChannelInstructions(definition.channels)
+      : []
     return {
       files: [],
       ...(channelInstructions.length ? { instructions: channelInstructions } : {}),
@@ -1466,6 +1469,7 @@ async function resolveNonWorkspaceAgentInspectionMetadata<
       tools: [],
     }
   }
+  const channelInstructions = agentChannelMetadataInstructions(definition)
 
   const selection = await resolveMetadataCapabilitySelection(settings as never, resolution)
   validateAgentCapabilityComposition(selection.capabilities, { hasWorkspace: false })

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1458,9 +1458,13 @@ async function resolveNonWorkspaceAgentInspectionMetadata<
 ): Promise<AgentInspectionMetadata> {
   const settings = agentSettings(definition)
   if (!settings) {
+    const definedChannelInstructions = inspectMessageChannelInstructions(definition.channels)
+    if (!definedChannelInstructions.length) {
+      return { files: [], ...agentInspectionMetadata(definition as never), tools: [] }
+    }
     const adapter = await definition.resolve(createInspectionMetadataRuntime(resolution))
     const channelInstructions = consumesMessageChannelInstructions(adapter)
-      ? inspectMessageChannelInstructions(definition.channels)
+      ? definedChannelInstructions
       : []
     return {
       files: [],

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -766,6 +766,16 @@ function agentInspectionMetadata<
   }
 }
 
+function agentChannelMetadataInstructions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+>(
+  definition: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
+): string[] {
+  const settings = agentSettings(definition)
+  if (!settings || normalizeAgentDriver(settings).kind === "run") return []
+  return inspectMessageChannelInstructions(definition.channels)
+}
+
 function normalizedSourcesFromOptions<
   TRuntimeConfig extends AgentRuntimeConfig,
   Name extends WorkspaceName,
@@ -1447,7 +1457,7 @@ async function resolveNonWorkspaceAgentInspectionMetadata<
   resolution: AgentInspectionMetadataResolutionOptions<TRuntimeConfig, Name>,
 ): Promise<AgentInspectionMetadata> {
   const settings = agentSettings(definition)
-  const channelInstructions = inspectMessageChannelInstructions(definition.channels)
+  const channelInstructions = agentChannelMetadataInstructions(definition)
   if (!settings) {
     return {
       files: [],
@@ -1509,7 +1519,7 @@ export function createAgentInspectionMetadata<
   definition: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
 ): AgentInspectionMetadata {
   const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig, Name>>
-  const channelInstructions = inspectMessageChannelInstructions(definition.channels)
+  const channelInstructions = agentChannelMetadataInstructions(definition)
   if (!workspaceDefinition.__vitehubWorkspaceAgent || !workspaceDefinition.__vitehubWorkspaceAgentOptions) {
     return {
       files: [],
@@ -1574,7 +1584,7 @@ export async function resolveAgentInspectionMetadata<
       files: await resolveWorkspaceMetadataFiles(capabilityContext.options as never, capabilityContext.workspace as never),
       instructions: [
         ...instructionMetadata.instructions,
-        ...inspectMessageChannelInstructions(workspaceDefinition.channels),
+        ...agentChannelMetadataInstructions(workspaceDefinition as AgentInput<AgentRuntimeContext<TRuntimeConfig>>),
       ],
       ...agentInspectionMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
       ...(config ? { config } : {}),
@@ -1648,7 +1658,7 @@ export async function materializeAgentInspectionSourceMetadata<
       files: await resolveWorkspaceMetadataFiles(capabilityContext.options as never, capabilityContext.workspace as never),
       instructions: [
         ...instructionMetadata.instructions,
-        ...inspectMessageChannelInstructions(workspaceDefinition.channels),
+        ...agentChannelMetadataInstructions(workspaceDefinition as AgentInput<AgentRuntimeContext<TRuntimeConfig>>),
       ],
       ...agentInspectionMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
       ...(config ? { config } : {}),

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -26,6 +26,7 @@ import {
   resolveInstructionImports,
 } from "./instruction-composition.ts"
 import { normalizeAgentDriver, resolveNormalizedHarnessDriver } from "./internal/agent-driver.ts"
+import { inspectMessageChannelInstructions } from "./internal/channels.ts"
 
 import type {
   AgentAdapterMetadataContext,
@@ -1446,7 +1447,15 @@ async function resolveNonWorkspaceAgentInspectionMetadata<
   resolution: AgentInspectionMetadataResolutionOptions<TRuntimeConfig, Name>,
 ): Promise<AgentInspectionMetadata> {
   const settings = agentSettings(definition)
-  if (!settings) return { files: [], ...agentInspectionMetadata(definition as never), tools: [] }
+  const channelInstructions = inspectMessageChannelInstructions(definition.channels)
+  if (!settings) {
+    return {
+      files: [],
+      ...(channelInstructions.length ? { instructions: channelInstructions } : {}),
+      ...agentInspectionMetadata(definition as never),
+      tools: [],
+    }
+  }
 
   const selection = await resolveMetadataCapabilitySelection(settings as never, resolution)
   validateAgentCapabilityComposition(selection.capabilities, { hasWorkspace: false })
@@ -1485,6 +1494,7 @@ async function resolveNonWorkspaceAgentInspectionMetadata<
     }
     return {
       files: [],
+      ...(channelInstructions.length ? { instructions: channelInstructions } : {}),
       ...agentInspectionMetadata(definition as never),
       ...(config ? { config } : {}),
       tools: capabilityMetadataTools(selection.capabilities, { driverKind: selection.driverKind }),
@@ -1499,14 +1509,20 @@ export function createAgentInspectionMetadata<
   definition: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
 ): AgentInspectionMetadata {
   const workspaceDefinition = definition as Partial<WorkspaceAgentDefinition<TRuntimeConfig, Name>>
+  const channelInstructions = inspectMessageChannelInstructions(definition.channels)
   if (!workspaceDefinition.__vitehubWorkspaceAgent || !workspaceDefinition.__vitehubWorkspaceAgentOptions) {
-    return { files: [], ...agentInspectionMetadata(definition), tools: [] }
+    return {
+      files: [],
+      ...(channelInstructions.length ? { instructions: channelInstructions } : {}),
+      ...agentInspectionMetadata(definition),
+      tools: [],
+    }
   }
 
   const options = workspaceDefinition.__vitehubWorkspaceAgentOptions as unknown as WorkspaceAgentOptions<TRuntimeConfig, Name>
   return {
     files: workspaceMetadataFiles(options),
-    instructions: workspaceMetadataInstructions(options),
+    instructions: [...workspaceMetadataInstructions(options), ...channelInstructions],
     ...agentInspectionMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
     tools: workspaceMetadataTools(options),
   }
@@ -1556,7 +1572,10 @@ export async function resolveAgentInspectionMetadata<
 
     return {
       files: await resolveWorkspaceMetadataFiles(capabilityContext.options as never, capabilityContext.workspace as never),
-      instructions: instructionMetadata.instructions,
+      instructions: [
+        ...instructionMetadata.instructions,
+        ...inspectMessageChannelInstructions(workspaceDefinition.channels),
+      ],
       ...agentInspectionMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
       ...(config ? { config } : {}),
       tools: await resolveWorkspaceMetadataTools(capabilityContext.options as never, capabilityContext.workspace as never),

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -1646,7 +1646,10 @@ export async function materializeAgentInspectionSourceMetadata<
 
     return {
       files: await resolveWorkspaceMetadataFiles(capabilityContext.options as never, capabilityContext.workspace as never),
-      instructions: instructionMetadata.instructions,
+      instructions: [
+        ...instructionMetadata.instructions,
+        ...inspectMessageChannelInstructions(workspaceDefinition.channels),
+      ],
       ...agentInspectionMetadata(workspaceDefinition as AgentDefinition<TRuntimeConfig>),
       ...(config ? { config } : {}),
       tools: await resolveWorkspaceMetadataTools(capabilityContext.options as never, capabilityContext.workspace as never),

--- a/packages/agent/src/workspace-agent.ts
+++ b/packages/agent/src/workspace-agent.ts
@@ -772,7 +772,7 @@ function agentChannelMetadataInstructions<
   definition: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
 ): string[] {
   const settings = agentSettings(definition)
-  if (!settings || normalizeAgentDriver(settings).kind === "run") return []
+  if (settings && normalizeAgentDriver(settings).kind === "run") return []
   return inspectMessageChannelInstructions(definition.channels)
 }
 

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest"
 
 import { createAiSdkAdapter } from "../src/ai-sdk.ts"
 import { discord, telegram } from "../src/channels.ts"
-import { defineAgent, runAgentTrigger } from "../src/index.ts"
+import { createAgentInspectionMetadata, defineAgent, resolveAgentInspectionMetadata, runAgentTrigger } from "../src/index.ts"
 import { bindMessageChannelInstructions, inheritMessageChannelInstructions, resolveMessageChannelInstructions } from "../src/internal/channels.ts"
 import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
 import { createMessage } from "../src/messages.ts"
@@ -138,6 +138,20 @@ async function modelCallFor(channel: "discord" | "telegram", messages = history)
 }
 
 describe("Channel instructions", () => {
+  it("exposes private Channel guidance through Agent inspection", async () => {
+    const agent = defineAgent({
+      channels: {
+        discord: discord(),
+        support: telegram(),
+      },
+      driver: { model: {} as never },
+    })
+    const inspected = [`Channel "support" instructions:\n\n${telegramInstructions}`]
+
+    expect(createAgentInspectionMetadata(agent).instructions).toEqual(inspected)
+    expect((await resolveAgentInspectionMetadata(agent)).instructions).toEqual(inspected)
+  })
+
   it("preserves instructions when an internal runtime wraps a Channel", () => {
     const source = telegram()
     const wrapped = inheritMessageChannelInstructions({ ...source, effects: {} }, source)

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -152,6 +152,16 @@ describe("Channel instructions", () => {
     expect((await resolveAgentInspectionMetadata(agent)).instructions).toEqual(inspected)
   })
 
+  it("does not advertise Channel guidance for custom run Drivers", async () => {
+    const agent = defineAgent({
+      channels: { support: telegram() },
+      driver: { run: () => "ok" },
+    })
+
+    expect(createAgentInspectionMetadata(agent)).not.toHaveProperty("instructions")
+    expect(await resolveAgentInspectionMetadata(agent)).not.toHaveProperty("instructions")
+  })
+
   it("preserves instructions when an internal runtime wraps a Channel", () => {
     const source = telegram()
     const wrapped = inheritMessageChannelInstructions({ ...source, effects: {} }, source)

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -225,6 +225,15 @@ describe("Channel instructions", () => {
     expect(resolveMessageChannelInstructions(context)).toBe(telegramInstructions)
   })
 
+  it("preserves instructions when an app decorates a Channel", () => {
+    const decorated = { ...telegram(), capabilities: [] }
+    const context = createAgentInvocationContextStore()
+
+    bindMessageChannelInstructions(context, decorated)
+
+    expect(resolveMessageChannelInstructions(context)).toBe(telegramInstructions)
+  })
+
   it("reproduces the AI SDK rejection for synthetic system history", async () => {
     await expect(modelCallFor("telegram", [
       {

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import { createAiSdkAdapter } from "../src/ai-sdk.ts"
 import { discord, telegram } from "../src/channels.ts"
 import { defineAgent, runAgentTrigger } from "../src/index.ts"
+import { bindMessageChannelInstructions, inheritMessageChannelInstructions, resolveMessageChannelInstructions } from "../src/internal/channels.ts"
 import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
 import { createMessage } from "../src/messages.ts"
 
@@ -137,6 +138,16 @@ async function modelCallFor(channel: "discord" | "telegram", messages = history)
 }
 
 describe("Channel instructions", () => {
+  it("preserves instructions when an internal runtime wraps a Channel", () => {
+    const source = telegram()
+    const wrapped = inheritMessageChannelInstructions({ ...source, effects: {} }, source)
+    const context = createAgentInvocationContextStore()
+
+    bindMessageChannelInstructions(context, wrapped)
+
+    expect(resolveMessageChannelInstructions(context)).toBe(telegramInstructions)
+  })
+
   it("reproduces the AI SDK rejection for synthetic system history", async () => {
     await expect(modelCallFor("telegram", [
       {

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest"
 import { createAiSdkAdapter } from "../src/ai-sdk.ts"
 import { discord, telegram } from "../src/channels.ts"
 import { createAgentInspectionMetadata, defineAgent, resolveAgentInspectionMetadata, runAgentTrigger } from "../src/index.ts"
-import { bindMessageChannelInstructions, inheritMessageChannelInstructions, resolveMessageChannelInstructions } from "../src/internal/channels.ts"
+import { bindMessageChannelInstructions, inheritMessageChannelInstructions, markAuxiliaryMessageChannelInstructionContext, resolveMessageChannelInstructions } from "../src/internal/channels.ts"
 import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
 import { createMessage } from "../src/messages.ts"
 
@@ -254,5 +254,31 @@ describe("Channel instructions", () => {
       outputInstructions,
     ])
     expect(systemMessages[0]!.content).not.toContain("Injected Channel instructions.")
+  })
+
+  it("does not apply final-response guidance to auxiliary model calls", async () => {
+    const model = createModel()
+    const adapter = createAiSdkAdapter({
+      instructions: "Generate one short title.",
+      model: model as never,
+    })
+    const context = createAgentInvocationContextStore()
+    bindMessageChannelInstructions(context, telegram())
+    const invoker = { id: "channel-test", kind: "user" }
+
+    await adapter.generate(markAuxiliaryMessageChannelInstructionContext({
+      actor: invoker,
+      context,
+      input: {},
+      invoker,
+      messages: [],
+      prompt: "Dinner plans",
+      runtime,
+    }) as never)
+
+    const systemMessages = model.doGenerateCalls[0]!.prompt.filter(message => message.role === "system")
+    expect(systemMessages).toHaveLength(1)
+    expect(systemMessages[0]!.content).toContain("Generate one short title.")
+    expect(systemMessages[0]!.content).not.toContain(telegramInstructions)
   })
 })

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -162,6 +162,19 @@ describe("Channel instructions", () => {
     expect(await resolveAgentInspectionMetadata(agent)).not.toHaveProperty("instructions")
   })
 
+  it("retains Channel guidance for opaque adapter definitions", async () => {
+    const agent = {
+      channels: { support: telegram() },
+      async resolve() {
+        return createAiSdkAdapter({ model: createModel() as never })
+      },
+    } as never
+    const inspected = [`Channel "support" instructions:\n\n${telegramInstructions}`]
+
+    expect(createAgentInspectionMetadata(agent).instructions).toEqual(inspected)
+    expect((await resolveAgentInspectionMetadata(agent)).instructions).toEqual(inspected)
+  })
+
   it("preserves instructions when an internal runtime wraps a Channel", () => {
     const source = telegram()
     const wrapped = inheritMessageChannelInstructions({ ...source, effects: {} }, source)

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -175,6 +175,22 @@ describe("Channel instructions", () => {
     expect((await resolveAgentInspectionMetadata(agent)).instructions).toEqual(inspected)
   })
 
+  it("retains consumer classification when an opaque definition decorates an adapter", async () => {
+    const agent = {
+      channels: { support: telegram() },
+      async resolve() {
+        return {
+          ...createAiSdkAdapter({ model: createModel() as never }),
+          decorated: true,
+        }
+      },
+    } as never
+
+    expect((await resolveAgentInspectionMetadata(agent)).instructions).toEqual([
+      `Channel "support" instructions:\n\n${telegramInstructions}`,
+    ])
+  })
+
   it("omits guidance for opaque custom adapters that do not consume it", async () => {
     const agent = {
       channels: { support: telegram() },

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -196,6 +196,35 @@ describe("Channel instructions", () => {
     expect(systemMessages[0]!.content).not.toContain(telegramInstructions)
   })
 
+  it("selects guidance from trusted trigger context when run metadata is omitted", async () => {
+    const model = createModel()
+    const agent = defineAgent({
+      channels: {
+        support: telegram({
+          triggers: {
+            ping: {
+              invoke: () => ({
+                input: {
+                  messages: [createMessage({ role: "user", text: "Hello" })],
+                },
+              }),
+            },
+          },
+        }),
+      },
+      driver: {
+        instructions: agentInstructions,
+        model: model as never,
+      },
+    })
+
+    await runAgentTrigger(agent, runtime, "support.ping", {})
+
+    const systemMessages = model.doGenerateCalls[0]!.prompt.filter(message => message.role === "system")
+    expect(systemMessages).toHaveLength(1)
+    expectInstructionsOnceInOrder(systemMessages[0]!.content, [agentInstructions, telegramInstructions])
+  })
+
   it("composes configured and resolved instructions without trusting public context", async () => {
     const model = createModel()
     const adapter = createAiSdkAdapter({

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -171,8 +171,20 @@ describe("Channel instructions", () => {
     } as never
     const inspected = [`Channel "support" instructions:\n\n${telegramInstructions}`]
 
-    expect(createAgentInspectionMetadata(agent).instructions).toEqual(inspected)
+    expect(createAgentInspectionMetadata(agent)).not.toHaveProperty("instructions")
     expect((await resolveAgentInspectionMetadata(agent)).instructions).toEqual(inspected)
+  })
+
+  it("omits guidance for opaque custom adapters that do not consume it", async () => {
+    const agent = {
+      channels: { support: telegram() },
+      async resolve() {
+        return { generate: () => "ok" }
+      },
+    } as never
+
+    expect(createAgentInspectionMetadata(agent)).not.toHaveProperty("instructions")
+    expect(await resolveAgentInspectionMetadata(agent)).not.toHaveProperty("instructions")
   })
 
   it("preserves instructions when an internal runtime wraps a Channel", () => {

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -1,0 +1,204 @@
+import { describe, expect, it } from "vitest"
+
+import { createAiSdkAdapter } from "../src/ai-sdk.ts"
+import { discord, telegram } from "../src/channels.ts"
+import { defineAgent, runAgentTrigger } from "../src/index.ts"
+import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
+import { createMessage } from "../src/messages.ts"
+
+import type { AgentRuntimeContext } from "../src/index.ts"
+
+const generateResult = {
+  content: [{ text: "{\"title\":\"ok\"}", type: "text" }],
+  finishReason: { raw: "stop", unified: "stop" },
+  usage: {
+    inputTokens: {
+      cacheRead: 0,
+      cacheWrite: 0,
+      noCache: 3,
+      total: 3,
+    },
+    outputTokens: {
+      reasoning: 0,
+      text: 1,
+      total: 1,
+    },
+  },
+  warnings: [],
+}
+
+const outputSchema = {
+  "~standard": {
+    jsonSchema: {
+      input: () => ({
+        properties: { title: { type: "string" } },
+        required: ["title"],
+        type: "object",
+      }),
+      output: () => ({ type: "object" }),
+    },
+    validate: (value: unknown) => ({ value: value as { title: string } }),
+    vendor: "vitehub-test",
+    version: 1 as const,
+  },
+}
+
+function createModel() {
+  const doGenerateCalls: Array<{ prompt: Array<{ content: string, role: string }> }> = []
+  return {
+    doGenerate: async (options: { prompt: Array<{ content: string, role: string }> }) => {
+      doGenerateCalls.push(options)
+      return generateResult
+    },
+    doGenerateCalls,
+    doStream: async () => {
+      throw new Error("Unexpected streaming model call")
+    },
+    modelId: "channel-instructions-test",
+    provider: "test",
+    specificationVersion: "v3",
+    supportedUrls: {},
+  }
+}
+
+const runtime: AgentRuntimeContext = {
+  memo: (_key, create) => create(),
+  runtime: "unknown" as const,
+  waitUntil: () => undefined,
+}
+
+const history = [
+  {
+    id: "1",
+    parts: [{ text: "Did we save dinner?", type: "text" }],
+    role: "user",
+  },
+  {
+    id: "2",
+    parts: [{ text: "Yes.", type: "text" }],
+    role: "assistant",
+  },
+  {
+    id: "3",
+    parts: [{ text: "Show it again.", type: "text" }],
+    role: "user",
+  },
+]
+
+const agentInstructions = "Keep the calorie records accurate."
+const telegramInstructions = "Write the final response for Telegram. Match the language of the user's latest message. Prefer short paragraphs or bullets and keep the answer concise. Do not use Markdown tables; express rows as bullets because Telegram fallback delivery exposes table syntax. Avoid decorative emoji, redundant restatement, and generic follow-up questions. Follow the Agent's own instructions when they require a different format."
+const outputInstructions = "Return only one valid JSON value for the configured Agent output. Do not wrap it in Markdown or add commentary."
+
+function expectInstructionsOnceInOrder(document: string, instructions: string[]) {
+  let previousIndex = -1
+  for (const instruction of instructions) {
+    const index = document.indexOf(instruction)
+    expect(index).toBeGreaterThan(previousIndex)
+    expect(document.indexOf(instruction, index + instruction.length)).toBe(-1)
+    previousIndex = index
+  }
+}
+
+async function modelCallFor(channel: "discord" | "telegram", messages = history) {
+  const model = createModel()
+  let inputRoles: string[] = []
+  const agent = defineAgent({
+    channels: {
+      discord: discord(),
+      support: telegram(),
+    },
+    driver: {
+      instructions: agentInstructions,
+      model: model as never,
+      output: { schema: outputSchema },
+    },
+    hooks: {
+      "agent:input": ({ input }) => {
+        inputRoles = input.messages?.map(message => message.role) ?? []
+      },
+    },
+  })
+
+  const channelId = channel === "telegram" ? "support" : "discord"
+  await runAgentTrigger(agent, runtime, "chat.message", {
+    messages,
+    run: {
+      channelId,
+      origin: channelId,
+      runId: `${channelId}:1`,
+      threadId: `${channelId}:1`,
+    },
+  })
+
+  return {
+    inputRoles,
+    modelCall: model.doGenerateCalls[0]!,
+  }
+}
+
+describe("Channel instructions", () => {
+  it("reproduces the AI SDK rejection for synthetic system history", async () => {
+    await expect(modelCallFor("telegram", [
+      {
+        id: "system",
+        parts: [{ text: "Write the final response for Telegram.", type: "text" }],
+        role: "system",
+      },
+      ...history,
+    ])).rejects.toThrow("System messages are not allowed in the prompt or messages fields")
+  })
+
+  it("keeps Telegram history as messages and composes one instruction document", async () => {
+    const { inputRoles, modelCall } = await modelCallFor("telegram")
+    const systemMessages = modelCall.prompt.filter(message => message.role === "system")
+
+    expect(inputRoles).toEqual(["user", "assistant", "user"])
+    expect(systemMessages).toHaveLength(1)
+    expectInstructionsOnceInOrder(systemMessages[0]!.content, [
+      agentInstructions,
+      telegramInstructions,
+      outputInstructions,
+    ])
+    expect(modelCall.prompt.map(message => message.role)).toEqual(["system", "user", "assistant", "user"])
+  })
+
+  it("only adds Telegram response guidance to Telegram turns", async () => {
+    const { modelCall } = await modelCallFor("discord")
+    const systemMessages = modelCall.prompt.filter(message => message.role === "system")
+
+    expect(systemMessages).toHaveLength(1)
+    expectInstructionsOnceInOrder(systemMessages[0]!.content, [agentInstructions, outputInstructions])
+    expect(systemMessages[0]!.content).not.toContain(telegramInstructions)
+  })
+
+  it("composes configured and resolved instructions without trusting public context", async () => {
+    const model = createModel()
+    const adapter = createAiSdkAdapter({
+      instructions: "Configured Agent instructions.",
+      model: model as never,
+    })
+    const invoker = { id: "channel-test", kind: "user" }
+
+    await adapter.generate({
+      actor: invoker,
+      context: createAgentInvocationContextStore({
+        "agent.channelInstructions": "Injected Channel instructions.",
+      }),
+      input: {},
+      instructions: "Resolved invocation instructions.",
+      invoker,
+      messages: [createMessage({ role: "user", text: "Hello" })],
+      output: { schema: outputSchema },
+      runtime,
+    } as never)
+
+    const systemMessages = model.doGenerateCalls[0]!.prompt.filter(message => message.role === "system")
+    expect(systemMessages).toHaveLength(1)
+    expectInstructionsOnceInOrder(systemMessages[0]!.content, [
+      "Configured Agent instructions.",
+      "Resolved invocation instructions.",
+      outputInstructions,
+    ])
+    expect(systemMessages[0]!.content).not.toContain("Injected Channel instructions.")
+  })
+})

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -203,6 +203,18 @@ describe("Channel instructions", () => {
     expect(await resolveAgentInspectionMetadata(agent)).not.toHaveProperty("instructions")
   })
 
+  it("does not resolve opaque definitions without Channel guidance during inspection", async () => {
+    let resolved = false
+    const resolve = () => {
+      resolved = true
+      throw new Error("resolver must not run")
+    }
+    const agent = { channels: { discord: discord() }, resolve } as never
+
+    expect(await resolveAgentInspectionMetadata(agent)).not.toHaveProperty("instructions")
+    expect(resolved).toBe(false)
+  })
+
   it("preserves instructions when an internal runtime wraps a Channel", () => {
     const source = telegram()
     const wrapped = inheritMessageChannelInstructions({ ...source, effects: {} }, source)

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1478,6 +1478,46 @@ describe("agent message protocol", () => {
     expect(harnessAgentSettings.at(-1)?.instructions).toContain('"title"')
   })
 
+  it("guides Telegram harness turns without changing other Channels", async () => {
+    const { discord, telegram } = await import("../src/channels.ts")
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    harnessCreateSession.mockResolvedValue({ destroy: vi.fn() })
+    harnessGenerate.mockResolvedValue({ text: "ok" })
+    const agent = defineAgent({
+      channels: {
+        discord: discord(),
+        support: telegram(),
+      },
+      driver: {
+        harness: { provider: "codex" },
+        instructions: "Configured Agent instructions.",
+      },
+    })
+    const invoke = async (channelId: "discord" | "support") => {
+      await runAgentTrigger(agent, {
+        memo: vi.fn(),
+        runtime: "unknown",
+        waitUntil: vi.fn(),
+      }, "chat.message", {
+        messages: [createMessage({ role: "user", text: "Hello" })],
+        run: {
+          channelId,
+          origin: channelId,
+          runId: `${channelId}:1`,
+          threadId: `${channelId}:1`,
+        },
+      })
+      return harnessAgentSettings.at(-1)?.instructions as string
+    }
+
+    const telegramInstructions = await invoke("support")
+    const discordInstructions = await invoke("discord")
+
+    expect(telegramInstructions).toContain("Configured Agent instructions.")
+    expect(telegramInstructions).toContain("Write the final response for Telegram.")
+    expect(discordInstructions).toBe("Configured Agent instructions.")
+  })
+
   it("guides model Drivers with configured structured output", async () => {
     const agentSettings: Record<string, unknown>[] = []
     loadAiSdk.mockResolvedValue({

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2854,6 +2854,66 @@ describe("defineAgent workspace option", () => {
     expect(agentSettings.at(-1)?.instructions).toBe("Use colocated workspace instructions.")
   })
 
+  it("composes colocated, Channel, and output instructions", async () => {
+    const sourceRootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-"))
+    tempRoots.push(sourceRootDir)
+    await writeLocalFile(join(sourceRootDir, "instructions.md"), "Use colocated workspace instructions.\n")
+    readFile.mockResolvedValueOnce("Use colocated workspace instructions.\n")
+    agentGenerate.mockResolvedValueOnce({ finishReason: "stop", text: "{\"title\":\"ok\"}" })
+    const { telegram } = await import("../src/channels.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { createMessage } = await import("../src/messages.ts")
+    const schema = {
+      "~standard": {
+        jsonSchema: {
+          input: () => ({
+            properties: { title: { type: "string" } },
+            required: ["title"],
+            type: "object",
+          }),
+          output: () => ({ type: "object" }),
+        },
+        validate: (value: unknown) => ({ value: value as { title: string } }),
+        vendor: "vitehub-test",
+        version: 1 as const,
+      },
+    }
+    const agent = withExplicitWorkspaceName(defineAgent({
+      channels: { support: telegram() },
+      workspace: { sourceRootDir },
+      driver: {
+        model: {} as never,
+        output: { schema },
+      },
+    }), { workspace: "docs" })
+
+    await agent.run!(Object.assign(context() as object, {
+      input: {
+        messages: [createMessage({ role: "user", text: "Show dinner." })],
+      },
+      run: {
+        channelId: "support",
+        origin: "support",
+        runId: "support:1",
+        threadId: "support:1",
+      },
+    }) as never)
+
+    const instructions = agentSettings.at(-1)?.instructions as string
+    const ordered = [
+      "Use colocated workspace instructions.",
+      "Write the final response for Telegram.",
+      "Return only one valid JSON value for the configured Agent output.",
+    ]
+    let previousIndex = -1
+    for (const instruction of ordered) {
+      const index = instructions.indexOf(instruction)
+      expect(index).toBeGreaterThan(previousIndex)
+      expect(instructions.indexOf(instruction, index + instruction.length)).toBe(-1)
+      previousIndex = index
+    }
+  })
+
   it("applies discovered source roots to workspace agents", async () => {
     const sourceRootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-"))
     tempRoots.push(sourceRootDir)

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -4555,6 +4555,20 @@ describe("defineAgent workspace option", () => {
     ].join("\n")])
   })
 
+  it("keeps Channel guidance in materialized Agent inspection metadata", async () => {
+    const { telegram } = await import("../src/channels.ts")
+    const { defineAgent, materializeAgentInspectionSourceMetadata } = await import("../src/index.ts")
+    const agent = withExplicitWorkspaceName(defineAgent({
+      channels: { support: telegram() },
+      workspace: {},
+      driver: { model: {} as never },
+    }), { workspace: "support" })
+
+    expect((await materializeAgentInspectionSourceMetadata(agent)).instructions).toEqual(expect.arrayContaining([
+      expect.stringContaining('Channel "support" instructions:\n\nWrite the final response for Telegram.'),
+    ]))
+  })
+
   it("includes skill sources in Agent inspection file metadata", async () => {
     const { createAgentInspectionMetadata, defineAgent } = await import("../src/index.ts")
     const { skills } = await import("../src/capabilities.ts")

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -3363,6 +3363,7 @@ describe("defineAgent workspace option", () => {
   })
 
   it("synthesizes an answer when tool loop stops without text after tool results", async () => {
+    const { telegram } = await import("../src/channels.ts")
     const { defineAgent } = await import("../src/index.ts")
     agentGenerate.mockResolvedValueOnce({
       finishReason: "stop",
@@ -3377,12 +3378,21 @@ describe("defineAgent workspace option", () => {
     })
 
     const agent = withExplicitWorkspaceName(defineAgent({
+      channels: { support: telegram() },
       workspace: {},
       driver: { model: {} as never },
     }), { workspace: "docs" })
 
-    await expect(agent.run!(context())).resolves.toBe("fallback answer")
+    await expect(agent.run!(Object.assign(context() as object, {
+      run: {
+        channelId: "support",
+        origin: "support",
+        runId: "support:1",
+        threadId: "support:1",
+      },
+    }) as never)).resolves.toBe("fallback answer")
     expect(generateText).toHaveBeenCalledWith(expect.objectContaining({
+      instructions: expect.stringContaining("Write the final response for Telegram."),
       prompt: expect.stringContaining("client.py:7"),
     }))
   })


### PR DESCRIPTION
## What changed

- keep message-shaped Channel history as ordinary user and assistant messages
- attach Telegram response guidance to the `telegram()` Channel through private runtime metadata selected from the trusted run channel
- compose configured Agent, resolved invocation or Workspace, Channel, and structured-output instructions into one model-driver instruction document
- cover the real AI SDK `ToolLoopAgent` prompt path, custom Channel keys, non-Telegram turns, public-context rejection, and colocated Workspace instructions

## Why

AI SDK 7 rejects system-role entries passed through a `ToolLoopAgent` prompt or messages input when the Agent already uses its `instructions` option. Channel guidance belongs at ViteHub's model-driver boundary, so downstream apps should not inject synthetic system messages into chat history.

This keeps the contribution internal to `@vite-hub/agent`: there is no new public Channel instruction option, and callers cannot forge the system-level contribution through invocation context.

## Validation

- `corepack pnpm --filter @vite-hub/agent test` — 67 files and 1,515 tests passed; package build and publint passed
- `corepack pnpm --filter @vite-hub/agent typecheck`
- focused Channel, chat-input, Channel-definition, and Workspace regressions — 201 tests passed
- independent direction and implementation reviews completed with no remaining material findings