### PR TITLE
fix(vite-hub): expose the deployment preset to integrations

### DIFF
--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -191,6 +191,10 @@ export interface ViteHubOptions {
 
 export type DeploymentPreset = "cloudflare" | "deno" | "netlify" | "node" | "vercel"
 
+export interface ViteHubConfig {
+  preset?: DeploymentPreset
+}
+
 type DeploymentIdentitySource = "VITEHUB_DEPLOYMENT_NAME" | "package.json" | "root" | "vitehub.name"
 
 interface DeploymentIdentity {
@@ -295,6 +299,10 @@ function deploymentPlugins(
       },
       config(config, environment) {
         const building = environment.command === "build"
+        ;(config as { vitehub?: unknown }).vitehub = {
+          ...cloneRecord((config as { vitehub?: unknown }).vitehub),
+          preset: plan.preset,
+        }
         for (const service of requestedServices) assertDeploymentService(plan, service)
         const identity = resolveDeploymentIdentity(
           typeof config.root === "string" ? config.root : undefined,
@@ -545,4 +553,10 @@ export function vitehub(options: ViteHubOptions): PluginOption[] {
   }
   plugins.push(viteHubTypesPlugin())
   return plugins as PluginOption[]
+}
+
+declare module "vite" {
+  interface UserConfig {
+    vitehub?: ViteHubConfig
+  }
 }

--- a/packages/vite-hub/test/deployment-integration.test.ts
+++ b/packages/vite-hub/test/deployment-integration.test.ts
@@ -40,8 +40,12 @@ describe("built-in deployment preset integration", () => {
           queue: false,
           rateLimit: false,
         })],
+        vitehub: {
+          marker: "preserved",
+        },
       } as Parameters<typeof resolveConfig>[0] & {
         nitro: { modules: string[], preset: string }
+        vitehub: { marker: string }
       }
       const development = await resolveConfig(developmentConfig, "serve")
       expect((development as typeof development & {
@@ -49,6 +53,10 @@ describe("built-in deployment preset integration", () => {
       }).nitro).toMatchObject({
         modules: ["local-module"],
         preset: "node-server",
+      })
+      expect(development.vitehub).toEqual({
+        marker: "preserved",
+        preset: "cloudflare",
       })
 
       const production = await resolveConfig({
@@ -66,6 +74,9 @@ describe("built-in deployment preset integration", () => {
       }).nitro).toMatchObject({
         modules: [expect.any(Function)],
         preset: "cloudflare-module",
+      })
+      expect(production.vitehub).toEqual({
+        preset: "cloudflare",
       })
     }
     finally {


### PR DESCRIPTION
Exposes the selected built-in deployment preset as typed `config.vitehub.preset`, merging any existing ViteHub config fields so composed integrations can read one ViteHub-owned deployment identity during both serve and build. Nitro preset mutation remains build-only, preserving the local-development behavior established in #867.

Agent already prefers `config.vitehub.preset`; the inactive downstream patch instead added plugin-object metadata, which remains under `resolved.plugins` and does not satisfy that resolved-config contract. The real-config regression proves a Cloudflare deployment stays visible while serve retains local `nitro.preset: "node-server"` and build resolves `nitro.preset: "cloudflare-module"`.

Validated with the full `vite-hub` package suite (8 files, 74 tests, no type errors), package typecheck, focused oxlint, and `git diff --check`.