### PR TITLE
fix(agent): materialize lazy sources for harness sessions

### DIFF
--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -227,6 +227,9 @@ function workspaceSourceHarnessPaths(context: AgentAdapterRunContext): string[] 
   const sources = context.workspaceDefinition?.sources
   if (!sources) return []
   return normalizeWorkspaceSourcesMetadata(sources).flatMap((source) => {
+    if (source.materialize === "lazy" && !source.requestOnly) {
+      return [source.mountPath]
+    }
     if (source.probeKeys?.length) {
       return source.probeKeys.map(key => [source.mountPath, key].filter(Boolean).join("/"))
     }

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7504,7 +7504,7 @@ describe("server helpers", () => {
     const handler = createChannelWebhookRouteHandler(agent as never)
 
     try {
-      const response = await handler(chatWebhookRequest(91_018), "telegram")
+      const response = await handler(chatWebhookRequest(91_020), "telegram")
       expect(response.status).toBe(503)
       const logEntry = consoleError.mock.calls[0]?.[0] as { error?: unknown }
       const serializedLogEntry = JSON.stringify(logEntry)

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -1857,7 +1857,7 @@ describe("defineAgent workspace option", () => {
     })
   })
 
-  it("passes lazy source probe paths without mount roots into Harness Workspace Sessions", async () => {
+  it("passes complete lazy source mounts into Harness Workspace Sessions", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { custom } = await import("@vite-hub/workspace")
     const harnessWorkspaceSession = { close: vi.fn() }
@@ -1904,7 +1904,7 @@ describe("defineAgent workspace option", () => {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
       onWriteBack: expect.any(Function),
-      paths: ["AGENTS.md", "CLAUDE.md", "docs/context.md"],
+      paths: ["docs", "portal", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
     })
@@ -2067,7 +2067,7 @@ describe("defineAgent workspace option", () => {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
       onWriteBack: expect.any(Function),
-      paths: ["AGENTS.md", "CLAUDE.md"],
+      paths: ["docs", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
     }))


### PR DESCRIPTION
## What changed

Harness-backed agents now pass each filesystem-backed lazy source mount into workspace session preparation. Request-only sources remain excluded, while non-lazy sources retain their existing probe-path behavior. The new provider-error logging regression test also uses a unique chat delivery ID so full-suite deduplication cannot skip its error path.

## Why

Harness sessions receive a physical filesystem snapshot. Selecting only probe paths meant lazy sources without probe keys were omitted entirely, and lazy sources with probe keys exposed only those probes rather than the complete source. Codex therefore could not inspect repositories that the agent workspace declared as available.

The provider test isolation repair is required by the rebased base: its delivery ID duplicated an earlier manual-delivery test, so the Chat SDK correctly deduplicated it during the full suite and returned before exercising the provider error.

## Validation

- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm --filter @vite-hub/agent exec vp test test/workspace.test.ts` — 164 tests passed
- `pnpm --filter @vite-hub/agent exec vp test test/providers.test.ts` — 193 tests passed