### PR TITLE
fix(browser): own Playwright public types

### DIFF
--- a/docs/content/docs/server-primitives/browser.md
+++ b/docs/content/docs/server-primitives/browser.md
@@ -18,7 +18,7 @@ Browser is a server primitive, not an Agent Capability. Server code invokes Brow
 ### Install
 
 ```bash [Terminal]
-pnpm add vite-hub @cloudflare/playwright playwright-core
+pnpm add vite-hub @cloudflare/playwright
 ```
 
 ### Configure

--- a/fixtures/consumer/vite-hub/src/type-contract.ts
+++ b/fixtures/consumer/vite-hub/src/type-contract.ts
@@ -13,6 +13,7 @@ import * as agentServer from "vite-hub/agent/server"
 import * as agentSqliteState from "vite-hub/agent/state/sqlite"
 import * as authAgent from "vite-hub/auth/agent"
 import { resolveBox } from "vite-hub/box"
+import type { BrowserDownload } from "vite-hub/browser"
 import * as smtp from "vite-hub/email/drivers/smtp"
 import { env } from "vite-hub/env"
 import * as markdownTemplate from "vite-hub/markdown-template"
@@ -61,6 +62,7 @@ export const contract = {
 }
 
 export const builtInAgentName = "codex" satisfies BuiltInAgentDriverName
+export type BrowserDownloadUrl = ReturnType<BrowserDownload["url"]>
 export const configuredCodex = { kind: "codex", reasoningEffort: "high" } satisfies BuiltInAgentDriver
 export const codexOptions = { model: "gpt-5.5" } satisfies CodexDriverOptions
 export const claudeCodeOptions = { maxTurns: 12 } satisfies ClaudeCodeDriverOptions

--- a/packages/blob/test/consumer-runtime.test.ts
+++ b/packages/blob/test/consumer-runtime.test.ts
@@ -104,13 +104,6 @@ describe("hosted Blob consumer runtime", () => {
               },
               name: "vitehub-blob-private-vercel-consumer",
               packageManager: "pnpm@10.33.0",
-              pnpm: {
-                overrides: {
-                  "@vite-hub/runtime": `file:${runtimeTarball}`,
-                  // Rolldown 1.1.5 pins @emnapi/* 1.x, while wasm-runtime 1.2 requires 2.x peers.
-                  "@napi-rs/wasm-runtime": "1.1.6",
-                },
-              },
               private: true,
               scripts: { build: "vite build" },
               type: "module",
@@ -122,7 +115,15 @@ describe("hosted Blob consumer runtime", () => {
         )
         await writeFile(
           join(appDir, "pnpm-workspace.yaml"),
-          ["packages:", "  - .", "allowBuilds:", "  esbuild: true", ""].join("\n"),
+          [
+            "packages:",
+            "  - .",
+            "allowBuilds:",
+            "  esbuild: true",
+            "overrides:",
+            `  "@vite-hub/runtime": "file:${runtimeTarball}"`,
+            "",
+          ].join("\n"),
           "utf8",
         )
 

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -53,13 +53,13 @@
     "test": "vp run -t @vite-hub/browser#build && vp test"
   },
   "dependencies": {
-    "@vite-hub/runtime": "workspace:*"
+    "@vite-hub/runtime": "workspace:*",
+    "playwright-core": "catalog:browser"
   },
   "devDependencies": {
     "@cloudflare/playwright": "catalog:browser",
     "@types/node": "catalog:tooling",
     "@vite-hub/internal": "workspace:*",
-    "playwright-core": "catalog:browser",
     "publint": "catalog:tooling",
     "typescript": "catalog:tooling",
     "vite": "catalog:vite",
@@ -68,7 +68,6 @@
   },
   "peerDependencies": {
     "@cloudflare/playwright": "catalog:browser",
-    "playwright-core": "catalog:browser",
     "vite": "catalog:vite-compat"
   },
   "peerDependenciesMeta": {

--- a/packages/browser/src/client.ts
+++ b/packages/browser/src/client.ts
@@ -47,6 +47,7 @@ export type {
   BrowserDefinitionContext,
   BrowserDefinitionHandler,
   BrowserDefinitionRegistry,
+  BrowserDownload,
   BrowserPageSession,
   BrowserRunResult,
 } from "./types.ts"

--- a/packages/browser/src/types.ts
+++ b/packages/browser/src/types.ts
@@ -7,8 +7,11 @@ import type {
 import type {
   Browser as PlaywrightBrowser,
   BrowserContext,
+  Download as PlaywrightDownload,
   Page,
 } from "playwright-core"
+
+export type BrowserDownload = PlaywrightDownload
 
 export interface BrowserFeatures {
   liveHandoff: boolean

--- a/packages/browser/test/types.test-d.ts
+++ b/packages/browser/test/types.test-d.ts
@@ -3,6 +3,7 @@ import { describe, expectTypeOf, it } from "vitest"
 import {
   createBrowser,
   defineBrowser,
+  type BrowserDownload,
   type BrowserPageSession,
   type BrowserRunResult,
   type BrowserSessionRef,
@@ -28,6 +29,10 @@ describe("published Browser types", () => {
       expectTypeOf(browser.open()).resolves.toEqualTypeOf<BrowserPageSession>()
       return input.url
     })
+  })
+
+  it("exports the complete Browser Download event type", () => {
+    expectTypeOf<BrowserDownload>().toEqualTypeOf<import("playwright-core").Download>()
   })
 
   it("types error-first Browser Definition results", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -756,6 +756,9 @@ importers:
       '@vite-hub/runtime':
         specifier: workspace:*
         version: link:../runtime
+      playwright-core:
+        specifier: catalog:browser
+        version: 1.61.1
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
         version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
@@ -769,9 +772,6 @@ importers:
       '@vite-hub/internal':
         specifier: workspace:*
         version: link:../internal
-      playwright-core:
-        specifier: catalog:browser
-        version: 1.61.1
       publint:
         specifier: catalog:tooling
         version: 0.3.21

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -392,6 +392,60 @@ async function assertVercelRuntimeImportsResolveInside(
 }
 
 describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-hub consumer contract", () => {
+  it("publishes Browser types without consumer-owned Playwright", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vite-hub-browser-consumer-"))
+    const appDir = join(root, "app")
+    const packDir = join(root, "packs")
+
+    try {
+      await Promise.all([
+        mkdir(appDir, { recursive: true }),
+        mkdir(packDir, { recursive: true }),
+      ])
+      const specs = await packWorkspacePackages(packDir, new Set([
+        "@vite-hub/browser",
+        "@vite-hub/runtime",
+      ]))
+      await Promise.all([
+        writeFile(join(appDir, "index.ts"), `
+          import type { BrowserDownload } from "@vite-hub/browser"
+          declare const download: BrowserDownload
+          download.url()
+        `, "utf8"),
+        writeFile(join(appDir, "package.json"), JSON.stringify({
+          dependencies: {
+            "@vite-hub/browser": specs["@vite-hub/browser"],
+          },
+          devDependencies: {
+            "@types/node": "24.13.3",
+          },
+          private: true,
+          type: "module",
+        }, null, 2), "utf8"),
+        writeFile(join(appDir, "pnpm-workspace.yaml"), workspaceConfig(specs), "utf8"),
+      ])
+      await run("pnpm", ["install", "--no-hoist", "--strict-peer-dependencies"], appDir)
+      await assertOnlyViteHubDependencies(appDir, ["@vite-hub/browser"])
+      await run(process.execPath, [
+        resolve(repoRoot, "node_modules/typescript/bin/tsc"),
+        "--module",
+        "NodeNext",
+        "--moduleResolution",
+        "NodeNext",
+        "--noEmit",
+        "--strict",
+        "--target",
+        "ESNext",
+        "--types",
+        "node",
+        "index.ts",
+      ], appDir)
+    }
+    finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  }, 120_000)
+
   it("reports the missing Workspace shell runtime from a packed consumer", async () => {
     const root = await mkdtemp(join(tmpdir(), "vite-hub-workspace-consumer-"))
     const appDir = join(root, "app")


### PR DESCRIPTION
## Summary

- export `BrowserDownload` from `@vite-hub/browser` and `vite-hub/browser`
- make `playwright-core` an `@vite-hub/browser` dependency instead of a consumer-owned peer
- verify direct and facade consumers through packed, isolated installs

## Why

Browser Definitions create and return the Playwright-backed session, but the public declarations required applications to install and import `playwright-core` themselves. That exposed ViteHub's controller dependency without preserving any application-owned host identity.

The Browser package now owns the compatible engine dependency, so consumers can name values returned by Browser Definitions through the ViteHub entry point. Private helpers can still accept smaller structural capabilities where appropriate.

## Verification

- `pnpm --filter @vite-hub/browser test` — 42 tests and type checks pass
- packed `@vite-hub/browser` consumer installs with strict peers and compiles `BrowserDownload` without a direct Playwright dependency
- packed `vite-hub` consumer installs with no hoisting, typechecks `vite-hub/browser`, builds, and runs
- Drop `pnpm patch` proof removes its direct `playwright-core` dependency and passes `pnpm typecheck`