### PR TITLE
fix(schedule): emit executable Cloudflare schedule module

### DIFF
--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -21,7 +21,7 @@ const registryImportAnchor = ".vitehub/schedule/registry.js"
 const generatedNitroSchedulePlugin = ".vitehub/nitro/schedule/plugin.ts"
 const generatedNitroRuntimeRegistry = ".vitehub/nitro/schedule/runtime-registry.js"
 const generatedNitroStaticRegistry = ".vitehub/nitro/schedule/static-registry.js"
-const generatedNitroCloudflareModule = "./.vitehub/nitro/schedule/module.ts"
+const generatedNitroCloudflareModule = "./.vitehub/nitro/schedule/module.mjs"
 const mergeNoExternal = createNoExternalMerger(schedulePackageName)
 
 export interface ScheduleProcessRuntimeOptions {
@@ -274,17 +274,15 @@ function renderNitroSchedulePlugin(options: RenderNitroSchedulePluginOptions): s
 
 function renderNitroCloudflareModule(crons: string[]): string {
   return [
-    "import type { Nitro } from 'nitro/types'",
-    "",
     `const crons = ${JSON.stringify(crons)}`,
     "",
-    "function dedupeCloudflareCrons(nitro: Nitro): void {",
+    "function dedupeCloudflareCrons(nitro) {",
     "  const wrangler = nitro.options.cloudflare?.wrangler",
     "  if (!wrangler?.triggers || !Array.isArray(wrangler.triggers.crons)) return",
-    "  wrangler.triggers.crons = [...new Set(wrangler.triggers.crons.filter((cron): cron is string => typeof cron === 'string'))]",
+    "  wrangler.triggers.crons = [...new Set(wrangler.triggers.crons.filter((cron) => typeof cron === 'string'))]",
     "}",
     "",
-    "export default function vitehubScheduleModule(nitro: Nitro): void {",
+    "export default function vitehubScheduleModule(nitro) {",
     "  nitro.options.cloudflare ??= {}",
     "  nitro.options.cloudflare.wrangler ??= {}",
     "  nitro.options.cloudflare.wrangler.triggers ??= {}",
@@ -489,7 +487,6 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
       })
       if (!nitro) return null
       ;(config as ViteConfigWithNitro).nitro = nitro
-      return { nitro } as unknown as Omit<UserConfig, "plugins">
     },
     configResolved(config) {
       resolved = config

--- a/packages/schedule/test/vite.test.ts
+++ b/packages/schedule/test/vite.test.ts
@@ -121,17 +121,7 @@ describe("Vite schedule integration", () => {
       { command: "build", mode: "production" },
     )
 
-    expect(config).toMatchObject({
-      nitro: {
-        cloudflare: {
-          wrangler: {
-            triggers: { crons: ["0 0 * * *", "*/10 * * * *"] },
-          },
-        },
-        modules: ["./.vitehub/nitro/schedule/module.ts"],
-        plugins: [".vitehub/nitro/schedule/plugin.ts"],
-      },
-    })
+    expect(config).toBeUndefined()
     expect(userConfig).toMatchObject({
       nitro: {
         cloudflare: {
@@ -139,16 +129,21 @@ describe("Vite schedule integration", () => {
             triggers: { crons: ["0 0 * * *", "*/10 * * * *"] },
           },
         },
-        modules: ["./.vitehub/nitro/schedule/module.ts"],
+        modules: ["./.vitehub/nitro/schedule/module.mjs"],
         plugins: [".vitehub/nitro/schedule/plugin.ts"],
       },
     })
     await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "plugin.ts"), "utf8")).resolves.toContain("cloudflare:scheduled")
     await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "plugin.ts"), "utf8")).resolves.toContain("../../schedule/registry.js")
     await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "plugin.ts"), "utf8")).resolves.toContain("@vite-hub/schedule/runtime/static")
-    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.toContain("build:before")
-    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.toContain("dedupeCloudflareCrons")
-    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.toContain("\"*/10 * * * *\"")
+    const moduleSource = await readFile(join(root, ".vitehub", "nitro", "schedule", "module.mjs"), "utf8")
+    expect(moduleSource).toContain("build:before")
+    expect(moduleSource).toContain("dedupeCloudflareCrons")
+    expect(moduleSource).toContain("\"*/10 * * * *\"")
+    expect(moduleSource).not.toContain("import type")
+    expect(moduleSource).not.toContain(": Nitro")
+    expect(moduleSource).not.toContain(": void")
+    expect(moduleSource).not.toContain("cron is string")
     await expect(readFile(join(root, ".vitehub", "schedule", "registry.js"), "utf8")).resolves.toContain("\"mirror\": async () => import(")
     await expect(readFile(join(root, ".vitehub", "schedule", "registry.d.ts"), "utf8")).resolves.toContain("ScheduleRegistryDefinition")
   })
@@ -177,12 +172,12 @@ describe("Vite schedule integration", () => {
       { command: "serve", mode: "development" },
     )
 
-    expect(config).toEqual({
+    expect(config).toBeUndefined()
+    expect(userConfig).toMatchObject({
       nitro: {
         plugins: [".vitehub/nitro/schedule/plugin.ts"],
       },
     })
-    expect(userConfig).toMatchObject(config as Record<string, unknown>)
     expect(userConfig).not.toHaveProperty("nitro.cloudflare")
     expect(userConfig).not.toHaveProperty("nitro.modules")
 
@@ -231,7 +226,8 @@ describe("Vite schedule integration", () => {
       { command: "serve", mode: "development" },
     )
 
-    expect(config).toEqual({
+    expect(config).toBeUndefined()
+    expect(userConfig).toMatchObject({
       nitro: {
         plugins: [".vitehub/nitro/schedule/plugin.ts"],
       },
@@ -321,7 +317,7 @@ describe("Vite schedule integration", () => {
 
     await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "plugin.ts"), "utf8")).resolves.toContain("cloudflare:scheduled")
     await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "static-registry.js"), "utf8")).resolves.not.toContain("src/cleanup.schedule.ts")
-    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.toContain("\"0 0 * * *\"")
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.mjs"), "utf8")).resolves.toContain("\"0 0 * * *\"")
   })
 
   it("honors explicit standalone Provider Wake output with the Process Runtime", async () => {
@@ -459,11 +455,11 @@ describe("Vite schedule integration", () => {
           triggers: { crons: ["0 0 * * *", "*/15 * * * *"] },
         },
       },
-      modules: ["existing-module", "./.vitehub/nitro/schedule/module.ts"],
+      modules: ["existing-module", "./.vitehub/nitro/schedule/module.mjs"],
       plugins: [".vitehub/nitro/schedule/plugin.ts"],
     })
     await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "plugin.ts"), "utf8")).resolves.toContain("cloudflare:scheduled")
-    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.toContain("\"*/15 * * * *\"")
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.mjs"), "utf8")).resolves.toContain("\"*/15 * * * *\"")
   })
 
   it("discovers project server schedules when the Vite root is nested", async () => {
@@ -491,17 +487,7 @@ describe("Vite schedule integration", () => {
     resolvePluginConfig(plugin, appRoot)
     const registry = await loadScheduleRegistry(plugin)
 
-    expect(config).toMatchObject({
-      nitro: {
-        cloudflare: {
-          wrangler: {
-            triggers: { crons: ["0 4 * * *"] },
-          },
-        },
-        modules: ["./.vitehub/nitro/schedule/module.ts"],
-        plugins: [".vitehub/nitro/schedule/plugin.ts"],
-      },
-    })
+    expect(config).toBeUndefined()
     expect(userConfig).toMatchObject({
       nitro: {
         cloudflare: {
@@ -509,13 +495,13 @@ describe("Vite schedule integration", () => {
             triggers: { crons: ["0 4 * * *"] },
           },
         },
-        modules: ["./.vitehub/nitro/schedule/module.ts"],
+        modules: ["./.vitehub/nitro/schedule/module.mjs"],
         plugins: [".vitehub/nitro/schedule/plugin.ts"],
       },
     })
     await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "plugin.ts"), "utf8")).resolves.toContain("cloudflare:scheduled")
-    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.toContain("\"0 4 * * *\"")
-    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.not.toContain("\"0 0 * * *\"")
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.mjs"), "utf8")).resolves.toContain("\"0 4 * * *\"")
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.mjs"), "utf8")).resolves.not.toContain("\"0 0 * * *\"")
     await expect(readFile(join(appRoot, ".vitehub", "nitro", "schedule", "plugin.ts"), "utf8")).rejects.toThrow()
     expect(registry).toContain("\"cleanup\": async () => import(")
     expect(registry).toContain("\"sync\": async () => import(")
@@ -539,7 +525,7 @@ describe("Vite schedule integration", () => {
 
     expect(config).toBeNull()
     await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "plugin.ts"), "utf8")).rejects.toThrow()
-    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).rejects.toThrow()
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.mjs"), "utf8")).rejects.toThrow()
   })
 
   it("can force Nitro plugin output for suffix schedules", async () => {
@@ -560,17 +546,7 @@ describe("Vite schedule integration", () => {
       { command: "build", mode: "production" },
     )
 
-    expect(config).toMatchObject({
-      nitro: {
-        cloudflare: {
-          wrangler: {
-            triggers: { crons: ["0 0 * * *"] },
-          },
-        },
-        modules: ["./.vitehub/nitro/schedule/module.ts"],
-        plugins: [".vitehub/nitro/schedule/plugin.ts"],
-      },
-    })
+    expect(config).toBeUndefined()
     expect(userConfig).toMatchObject({
       nitro: {
         cloudflare: {
@@ -578,7 +554,7 @@ describe("Vite schedule integration", () => {
             triggers: { crons: ["0 0 * * *"] },
           },
         },
-        modules: ["./.vitehub/nitro/schedule/module.ts"],
+        modules: ["./.vitehub/nitro/schedule/module.mjs"],
         plugins: [".vitehub/nitro/schedule/plugin.ts"],
       },
     })
@@ -607,13 +583,7 @@ describe("Vite schedule integration", () => {
       { command: "build", mode: "production" },
     )
 
-    expect(config).toMatchObject({
-      nitro: {
-        hooks: { "build:before": expect.any(Function) },
-        modules: ["./.vitehub/nitro/schedule/module.ts"],
-        plugins: [".vitehub/nitro/schedule/plugin.ts"],
-      },
-    })
+    expect(config).toBeUndefined()
     const buildBefore = ((userConfig.nitro as { hooks?: Record<string, unknown> }).hooks?.["build:before"]) as () => void
     buildBefore()
 
@@ -621,7 +591,7 @@ describe("Vite schedule integration", () => {
     expect(userConfig).toMatchObject({
       nitro: {
         hooks: { "build:before": buildBefore },
-        modules: ["./.vitehub/nitro/schedule/module.ts"],
+        modules: ["./.vitehub/nitro/schedule/module.mjs"],
         plugins: [".vitehub/nitro/schedule/plugin.ts"],
       },
     })
@@ -693,8 +663,8 @@ describe("Vite schedule integration", () => {
         },
       },
     })
-    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.toContain("\"0 4 * * *\"")
-    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.ts"), "utf8")).resolves.not.toContain("\"0 0 * * *\"")
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.mjs"), "utf8")).resolves.toContain("\"0 4 * * *\"")
+    await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.mjs"), "utf8")).resolves.not.toContain("\"0 0 * * *\"")
     await expect(readFile(join(root, ".vitehub", "schedule", "registry.mjs"), "utf8")).resolves.toContain("\"cleanup\"")
     await expect(readFile(join(root, ".vitehub", "schedule", "registry.mjs"), "utf8")).resolves.not.toContain("\"sync\"")
     await expect(readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8")).resolves.toContain("\"0 0 * * *\"")

--- a/test/consumer/deployment-presets.test.ts
+++ b/test/consumer/deployment-presets.test.ts
@@ -243,6 +243,58 @@ it("preserves Queue and Rate Limit bindings in Nitro Cloudflare output", async (
   }
 }, 30_000)
 
+it("loads the generated Schedule module and emits each Cloudflare cron once", async () => {
+  const root = await realpath(await mkdtemp(join(tmpdir(), "vitehub-cloudflare-schedule-output-")))
+  const cron = "0 * * * *"
+  try {
+    await symlink(join(import.meta.dirname, "../../node_modules"), join(root, "node_modules"), "dir")
+    await mkdir(join(root, "server/schedules"), { recursive: true })
+    await writeFile(join(root, "package.json"), JSON.stringify({ name: "schedule-cloudflare-fixture" }), "utf8")
+    await writeFile(join(root, "index.html"), "<!doctype html><title>ViteHub</title>\n", "utf8")
+    await writeFile(join(root, "server/schedules/cleanup.ts"), [
+      'import { defineSchedule } from "vite-hub/schedule"',
+      `export default defineSchedule({ cron: ${JSON.stringify(cron)}, handler: () => undefined })`,
+      "",
+    ].join("\n"), "utf8")
+
+    const builder = await createBuilder({
+      nitro: {
+        cloudflare: {
+          wrangler: {
+            triggers: { crons: [cron] },
+          },
+        },
+        compatibilityDate: "2026-07-20",
+        serverDir: true,
+      },
+      plugins: [
+        vitehub({
+          preset: "cloudflare",
+          agent: false,
+          blob: false,
+          database: false,
+          env: false,
+          kv: false,
+          queue: false,
+          rateLimit: false,
+          schedule: true,
+          workflow: false,
+          workspace: false,
+        }),
+        nitro(),
+      ],
+      root,
+    })
+    await builder.buildApp()
+
+    expect(existsSync(join(root, ".vitehub/nitro/schedule/module.mjs"))).toBe(true)
+    const wrangler = JSON.parse(await readFile(join(root, ".output/server/wrangler.json"), "utf8"))
+    expect(wrangler.triggers?.crons).toEqual([cron])
+  } finally {
+    await rm(root, { force: true, recursive: true })
+  }
+}, 30_000)
+
 it.skipIf(process.platform !== "linux" || process.arch !== "x64")("uploads and executes native packages when updating an existing Deno app", async () => {
   const root = await mkdtemp(join(tmpdir(), "vitehub-deno-native-update-"))
   const workspaceRoot = resolve(import.meta.dirname, "../..")


### PR DESCRIPTION
## Summary

- generate the Schedule Cloudflare Nitro module as executable `.mjs`
- contribute Nitro config through the shared Vite config mutation without returning a competing partial config
- cover JavaScript-only module output, config composition, and a production-style Cloudflare build that emits each cron once

## Why

Schedule registered a generated `.ts` module containing TypeScript-only syntax, but Nitro loads that module as JavaScript during Cloudflare production builds. The Vite hook also mutated the complete in-flight Nitro config and returned the same contribution again, creating a second composition path.

This stays independent from #851's provider-output bookkeeping and does not change Schedule runtime semantics.

## Verification

- `pnpm --filter @vite-hub/schedule test` — 197 tests and type checks pass
- `pnpm --filter @vite-hub/schedule typecheck`
- focused `createBuilder()` + Nitro Cloudflare build — generated module loads and `0 * * * *` appears once in `.output/server/wrangler.json`
- lint and diff checks pass
- independent standards and spec reviews found no issues