### PR TITLE
fix(rate-limit): discover auto-imported and shadowed bindings

### DIFF
--- a/packages/rate-limit/README.md
+++ b/packages/rate-limit/README.md
@@ -26,6 +26,8 @@ export async function handleImageUpload(event): Promise<Response> {
 
 `requireRateLimit()` can live inside any ordinary H3 handler. Its stable ID and provider policy must use static literals so the Vite integration can generate infrastructure; `event` and an optional dynamic `key` are runtime inputs. The guard defaults to the request's client address and throws an `HTTPError` with status `429` when the budget is exhausted. Pass `key: authenticatedUser.id` when a user or tenant is the correct budget boundary.
 
+A framework may auto-import the canonical `requireRateLimit` name from this package instead. Discovery recognizes that bare call only when no local runtime binding owns the name.
+
 Provider unavailability follows the declared `failure` policy: fail-open guards continue, while fail-closed guards throw status `503` and preserve the provider cause. Invalid configuration and provider contract violations still throw normally. Use `createRateLimiter()` when the application needs a decision for a custom response or another transport.
 
 Add the build integration:

--- a/packages/rate-limit/src/discovery.ts
+++ b/packages/rate-limit/src/discovery.ts
@@ -43,9 +43,9 @@ interface RateLimitScope extends RateLimitBindings {
 function requireRateLimitBindings(program: ESTree.Program): RateLimitBindings {
   const bindings: RateLimitBindings = { direct: new Set(), namespaces: new Set() }
   for (const statement of program.body) {
-    if (statement.type !== "ImportDeclaration" || !rateLimitImports.has(statement.source.value)) continue
+    if (statement.type !== "ImportDeclaration" || statement.importKind === "type" || !rateLimitImports.has(statement.source.value)) continue
     for (const specifier of statement.specifiers) {
-      if (specifier.type === "ImportSpecifier" && specifier.imported.type === "Identifier" && specifier.imported.name === "requireRateLimit") {
+      if (specifier.type === "ImportSpecifier" && specifier.importKind !== "type" && specifier.imported.type === "Identifier" && specifier.imported.name === "requireRateLimit") {
         bindings.direct.add(specifier.local.name)
       }
       if (specifier.type === "ImportNamespaceSpecifier") bindings.namespaces.add(specifier.local.name)
@@ -86,7 +86,6 @@ function addDynamicRateLimitBindings(declaration: ESTree.VariableDeclaration, sc
   for (const declarator of declaration.declarations) {
     if (!rateLimitDynamicImport(declarator.init)) continue
     if (declarator.id.type === "Identifier") {
-      scope.shadows.delete(declarator.id.name)
       scope.namespaces.add(declarator.id.name)
       continue
     }
@@ -99,15 +98,14 @@ function addDynamicRateLimitBindings(declaration: ESTree.VariableDeclaration, sc
       if (name !== "requireRateLimit") continue
       const value = property.value.type === "AssignmentPattern" ? property.value.left : property.value
       if (value.type !== "Identifier") continue
-      scope.shadows.delete(value.name)
       scope.direct.add(value.name)
     }
   }
 }
 
 function variableDeclaration(statement: ESTree.Statement | ESTree.ModuleDeclaration): ESTree.VariableDeclaration | undefined {
-  if (statement.type === "VariableDeclaration") return statement
-  if (statement.type === "ExportNamedDeclaration" && statement.declaration?.type === "VariableDeclaration") return statement.declaration
+  const declaration = runtimeDeclaration(statement)
+  return declaration?.type === "VariableDeclaration" ? declaration : undefined
 }
 
 function addDynamicRateLimitBindingsFromStatements(statements: (ESTree.Statement | ESTree.ModuleDeclaration)[], scope: RateLimitScope): void {
@@ -145,10 +143,90 @@ function addBindingNames(pattern: ESTree.BindingPattern | ESTree.ParamPattern, n
   }
 }
 
-function functionBindings(params: ESTree.ParamPattern[]): Set<string> {
+function hoistedVariableBindings(root: ESTree.Program | ESTree.FunctionBody): Set<string> {
   const names = new Set<string>()
-  for (const parameter of params) addBindingNames(parameter, names)
+  let nestedScopeDepth = 0
+  const enterNestedScope = (): void => {
+    nestedScopeDepth += 1
+  }
+  const exitNestedScope = (): void => {
+    nestedScopeDepth -= 1
+  }
+  const program: ESTree.Program = root.type === "Program"
+    ? root
+    : { ...root, type: "Program", sourceType: "module", hashbang: null, parent: null }
+  new Visitor({
+    ArrowFunctionExpression: enterNestedScope,
+    "ArrowFunctionExpression:exit": exitNestedScope,
+    ClassDeclaration: enterNestedScope,
+    "ClassDeclaration:exit": exitNestedScope,
+    ClassExpression: enterNestedScope,
+    "ClassExpression:exit": exitNestedScope,
+    FunctionDeclaration: enterNestedScope,
+    "FunctionDeclaration:exit": exitNestedScope,
+    FunctionExpression: enterNestedScope,
+    "FunctionExpression:exit": exitNestedScope,
+    VariableDeclaration(declaration) {
+      if (nestedScopeDepth === 0 && declaration.kind === "var" && !declaration.declare) {
+        for (const declarator of declaration.declarations) addBindingNames(declarator.id, names)
+      }
+    },
+  }).visit(program)
   return names
+}
+
+function functionBindings(node: ESTree.Function | ESTree.ArrowFunctionExpression): Set<string> {
+  const names = node.body?.type === "BlockStatement" ? hoistedVariableBindings(node.body) : new Set<string>()
+  if (node.type === "FunctionExpression" && node.id) names.add(node.id.name)
+  for (const parameter of node.params) addBindingNames(parameter, names)
+  return names
+}
+
+function runtimeDeclaration(statement: ESTree.Statement | ESTree.ModuleDeclaration): ESTree.Declaration | undefined {
+  if (statement.type === "ExportNamedDeclaration") return statement.declaration ?? undefined
+  if (statement.type === "ExportDefaultDeclaration") {
+    const declaration = statement.declaration
+    if (declaration.type === "FunctionDeclaration" || declaration.type === "ClassDeclaration") return declaration
+  }
+  if (statement.type === "VariableDeclaration"
+    || statement.type === "FunctionDeclaration"
+    || statement.type === "ClassDeclaration"
+    || statement.type === "TSEnumDeclaration"
+    || statement.type === "TSModuleDeclaration"
+    || statement.type === "TSImportEqualsDeclaration") return statement
+}
+
+function lexicalBindings(statements: (ESTree.Statement | ESTree.ModuleDeclaration)[]): Set<string> {
+  const names = new Set<string>()
+  for (const statement of statements) {
+    const declaration = runtimeDeclaration(statement)
+    if ((declaration?.type === "FunctionDeclaration" || declaration?.type === "ClassDeclaration") && declaration.id) {
+      if (!declaration.declare) names.add(declaration.id.name)
+    }
+    if (declaration?.type === "VariableDeclaration" && declaration.kind !== "var" && !declaration.declare) {
+      for (const declarator of declaration.declarations) addBindingNames(declarator.id, names)
+    }
+    if (declaration?.type === "TSEnumDeclaration" && !declaration.declare) names.add(declaration.id.name)
+    if (declaration?.type === "TSModuleDeclaration" && !declaration.declare && !declaration.global && declaration.id.type === "Identifier") names.add(declaration.id.name)
+    if (declaration?.type === "TSImportEqualsDeclaration" && declaration.importKind !== "type") names.add(declaration.id.name)
+  }
+  return names
+}
+
+function programBindings(program: ESTree.Program): Set<string> {
+  const names = lexicalBindings(program.body)
+  for (const name of hoistedVariableBindings(program)) names.add(name)
+  for (const statement of program.body) {
+    if (statement.type !== "ImportDeclaration" || statement.importKind === "type") continue
+    for (const specifier of statement.specifiers) {
+      if (specifier.type !== "ImportSpecifier" || specifier.importKind !== "type") names.add(specifier.local.name)
+    }
+  }
+  return names
+}
+
+function blockBindings(block: ESTree.BlockStatement): Set<string> {
+  return lexicalBindings(block.body)
 }
 
 function variableBindings(declaration: ESTree.VariableDeclaration | null | undefined): Set<string> {
@@ -157,33 +235,13 @@ function variableBindings(declaration: ESTree.VariableDeclaration | null | undef
   return names
 }
 
-function blockBindings(block: ESTree.BlockStatement): Set<string> {
-  const names = new Set<string>()
-  for (const statement of block.body) {
-    if ((statement.type === "FunctionDeclaration" || statement.type === "ClassDeclaration") && statement.id) {
-      names.add(statement.id.name)
-    }
-    const declaration = statement.type === "VariableDeclaration"
-      ? statement
-      : statement.type === "ExportNamedDeclaration" && statement.declaration?.type === "VariableDeclaration"
-        ? statement.declaration
-        : undefined
-    for (const declarator of declaration?.declarations ?? []) addBindingNames(declarator.id, names)
-  }
-  return names
+function loopBindings(declaration: ESTree.VariableDeclaration | null | undefined): Set<string> {
+  if (declaration?.kind === "var") return new Set()
+  return variableBindings(declaration)
 }
 
 function switchBindings(statement: ESTree.SwitchStatement): Set<string> {
-  const names = new Set<string>()
-  for (const switchCase of statement.cases) {
-    for (const child of switchCase.consequent) {
-      if ((child.type === "FunctionDeclaration" || child.type === "ClassDeclaration") && child.id) names.add(child.id.name)
-      if (child.type === "VariableDeclaration") {
-        for (const name of variableBindings(child)) names.add(name)
-      }
-    }
-  }
-  return names
+  return lexicalBindings(statement.cases.flatMap(switchCase => switchCase.consequent))
 }
 
 function staticPropertyName(property: ESTree.ObjectProperty): string | undefined {
@@ -252,17 +310,17 @@ export function extractRateLimitDeclarations(file: string, source: string): Rate
     throw new Error(`[vitehub] Could not parse ${file} while collecting Rate Limits: ${parsed.errors[0]?.message}`)
   }
 
+  const rootShadows = programBindings(parsed.program)
   const bindings = requireRateLimitBindings(parsed.program)
+  if (!rootShadows.has("requireRateLimit")) bindings.direct.add("requireRateLimit")
   const declarations: RateLimitDeclaration[] = []
-  const scopes: RateLimitScope[] = [{ ...bindings, shadows: new Set() }]
+  const scopes: RateLimitScope[] = [{ ...bindings, shadows: rootShadows }]
   addDynamicRateLimitBindingsFromStatements(parsed.program.body, scopes[0]!)
   const enterScope = (shadows: Set<string>): void => {
     scopes.push({ direct: new Set(), namespaces: new Set(), shadows })
   }
   const enterFunction = (node: ESTree.Function | ESTree.ArrowFunctionExpression): void => {
-    const shadows = functionBindings(node.params)
-    if (node.type === "FunctionExpression" && node.id) shadows.add(node.id.name)
-    enterScope(shadows)
+    enterScope(functionBindings(node))
   }
   const exitScope = (): void => {
     scopes.pop()
@@ -309,15 +367,15 @@ export function extractRateLimitDeclarations(file: string, source: string): Rate
     FunctionExpression: enterFunction,
     "FunctionExpression:exit": exitScope,
     ForInStatement(node) {
-      enterScope(node.left.type === "VariableDeclaration" ? variableBindings(node.left) : new Set())
+      enterScope(node.left.type === "VariableDeclaration" ? loopBindings(node.left) : new Set())
     },
     "ForInStatement:exit": exitScope,
     ForOfStatement(node) {
-      enterScope(node.left.type === "VariableDeclaration" ? variableBindings(node.left) : new Set())
+      enterScope(node.left.type === "VariableDeclaration" ? loopBindings(node.left) : new Set())
     },
     "ForOfStatement:exit": exitScope,
     ForStatement(node) {
-      enterScope(node.init?.type === "VariableDeclaration" ? variableBindings(node.init) : new Set())
+      enterScope(node.init?.type === "VariableDeclaration" ? loopBindings(node.init) : new Set())
     },
     "ForStatement:exit": exitScope,
     SwitchStatement(node) {

--- a/packages/rate-limit/src/discovery.ts
+++ b/packages/rate-limit/src/discovery.ts
@@ -166,6 +166,10 @@ function hoistedVariableBindings(root: ESTree.Program | ESTree.FunctionBody): Se
     "FunctionDeclaration:exit": exitNestedScope,
     FunctionExpression: enterNestedScope,
     "FunctionExpression:exit": exitNestedScope,
+    StaticBlock: enterNestedScope,
+    "StaticBlock:exit": exitNestedScope,
+    TSModuleDeclaration: enterNestedScope,
+    "TSModuleDeclaration:exit": exitNestedScope,
     VariableDeclaration(declaration) {
       if (nestedScopeDepth === 0 && declaration.kind === "var" && !declaration.declare) {
         for (const declarator of declaration.declarations) addBindingNames(declarator.id, names)
@@ -176,7 +180,7 @@ function hoistedVariableBindings(root: ESTree.Program | ESTree.FunctionBody): Se
 }
 
 function functionBindings(node: ESTree.Function | ESTree.ArrowFunctionExpression): Set<string> {
-  const names = node.body?.type === "BlockStatement" ? hoistedVariableBindings(node.body) : new Set<string>()
+  const names = new Set<string>()
   if (node.type === "FunctionExpression" && node.id) names.add(node.id.name)
   for (const parameter of node.params) addBindingNames(parameter, names)
   return names
@@ -227,6 +231,13 @@ function programBindings(program: ESTree.Program): Set<string> {
 
 function blockBindings(block: ESTree.BlockStatement): Set<string> {
   return lexicalBindings(block.body)
+}
+
+function scopedStatementBindings(statements: (ESTree.Statement | ESTree.ModuleDeclaration)[]): Set<string> {
+  const names = lexicalBindings(statements)
+  const program: ESTree.Program = { type: "Program", body: statements, sourceType: "module", hashbang: null, parent: null, start: 0, end: 0 }
+  for (const name of hoistedVariableBindings(program)) names.add(name)
+  return names
 }
 
 function variableBindings(declaration: ESTree.VariableDeclaration | null | undefined): Set<string> {
@@ -315,12 +326,14 @@ export function extractRateLimitDeclarations(file: string, source: string): Rate
   if (!rootShadows.has("requireRateLimit")) bindings.direct.add("requireRateLimit")
   const declarations: RateLimitDeclaration[] = []
   const scopes: RateLimitScope[] = [{ ...bindings, shadows: rootShadows }]
+  const functionBodies = new WeakSet<ESTree.BlockStatement>()
   addDynamicRateLimitBindingsFromStatements(parsed.program.body, scopes[0]!)
   const enterScope = (shadows: Set<string>): void => {
     scopes.push({ direct: new Set(), namespaces: new Set(), shadows })
   }
   const enterFunction = (node: ESTree.Function | ESTree.ArrowFunctionExpression): void => {
     enterScope(functionBindings(node))
+    if (node.body?.type === "BlockStatement") functionBodies.add(node.body)
   }
   const exitScope = (): void => {
     scopes.pop()
@@ -329,7 +342,7 @@ export function extractRateLimitDeclarations(file: string, source: string): Rate
     ArrowFunctionExpression: enterFunction,
     "ArrowFunctionExpression:exit": exitScope,
     BlockStatement(block) {
-      enterScope(blockBindings(block))
+      enterScope(functionBodies.has(block) ? scopedStatementBindings(block.body) : blockBindings(block))
       addDynamicRateLimitBindingsFromStatements(block.body, scopes.at(-1)!)
     },
     "BlockStatement:exit": exitScope,
@@ -383,6 +396,16 @@ export function extractRateLimitDeclarations(file: string, source: string): Rate
       for (const switchCase of node.cases) addDynamicRateLimitBindingsFromStatements(switchCase.consequent, scopes.at(-1)!)
     },
     "SwitchStatement:exit": exitScope,
+    StaticBlock(node) {
+      enterScope(scopedStatementBindings(node.body))
+      addDynamicRateLimitBindingsFromStatements(node.body, scopes.at(-1)!)
+    },
+    "StaticBlock:exit": exitScope,
+    TSModuleBlock(node) {
+      enterScope(scopedStatementBindings(node.body))
+      addDynamicRateLimitBindingsFromStatements(node.body, scopes.at(-1)!)
+    },
+    "TSModuleBlock:exit": exitScope,
   })
   visitor.visit(parsed.program)
   return declarations

--- a/packages/rate-limit/test/discovery.test.ts
+++ b/packages/rate-limit/test/discovery.test.ts
@@ -246,6 +246,38 @@ describe("Rate Limit declarations", () => {
     expect(extractRateLimitDeclarations("program-var.ts", programSource)).toEqual([])
   })
 
+  it("keeps namespace and static-block bindings in their own scopes", () => {
+    const source = [
+      "namespace Helpers {",
+      "  var requireRateLimit = local",
+      '  requireRateLimit(event, "namespace-local", { limit: 1, window: "1m" })',
+      "}",
+      "class HelpersClass {",
+      "  static {",
+      "    var requireRateLimit = local",
+      '    requireRateLimit(event, "static-local", { limit: 1, window: "1m" })',
+      "  }",
+      "}",
+      'requireRateLimit(event, "module", { limit: 2, window: "1m" })',
+    ].join("\n")
+
+    expect(extractRateLimitDeclarations("nested-var-scopes.ts", source)).toMatchObject([{ name: "module" }])
+  })
+
+  it("resolves default parameters outside body var bindings", () => {
+    const source = [
+      "function route(",
+      "  event,",
+      '  limited = requireRateLimit(event, "default-parameter", { limit: 1, window: "1m" }),',
+      ") {",
+      "  var requireRateLimit = local",
+      '  requireRateLimit(event, "body-local", { limit: 1, window: "1m" })',
+      "}",
+    ].join("\n")
+
+    expect(extractRateLimitDeclarations("default-parameter.ts", source)).toMatchObject([{ name: "default-parameter" }])
+  })
+
   it("deduplicates identical IDs and policies", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-declarations-"))
     roots.push(root)

--- a/packages/rate-limit/test/discovery.test.ts
+++ b/packages/rate-limit/test/discovery.test.ts
@@ -29,6 +29,19 @@ describe("Rate Limit declarations", () => {
     }])
   })
 
+  it("collects framework auto-imported guards", () => {
+    const source = [
+      "export default defineEventHandler(async (event) => {",
+      '  await requireRateLimit(event, "code-image", { failure: "deny", limit: 5, window: "1m" })',
+      "})",
+    ].join("\n")
+
+    expect(extractRateLimitDeclarations("/project/server/api/code.post.ts", source)).toMatchObject([{
+      name: "code-image",
+      policy: { failure: "deny", limit: 5, window: "1m" },
+    }])
+  })
+
   it("collects guards through namespace imports", () => {
     const source = [
       'import * as rateLimit from "vite-hub/rate-limit"',
@@ -50,11 +63,17 @@ describe("Rate Limit declarations", () => {
       '  const rateLimit = await import("@vite-hub/rate-limit")',
       '  await rateLimit.requireRateLimit(event, "search", { limit: 10, window: "10s" })',
       "}",
+      "export async function canonicalNamespace(event) {",
+      '  const requireRateLimit = await import("vite-hub/rate-limit")',
+      '  await requireRateLimit.requireRateLimit(event, "canonical-namespace", { limit: 3, window: "1m" })',
+      '  await requireRateLimit(event, "not-a-guard", { limit: 1, window: "1m" })',
+      "}",
     ].join("\n")
 
     expect(extractRateLimitDeclarations("/project/limits.ts", source)).toMatchObject([
       { name: "image-upload", policy: { failure: "deny", limit: 5, window: "1m" } },
       { name: "search", policy: { limit: 10, window: "10s" } },
+      { name: "canonical-namespace", policy: { limit: 3, window: "1m" } },
     ])
   })
 
@@ -149,6 +168,82 @@ describe("Rate Limit declarations", () => {
       'try {} catch (requireLimit) { requireLimit(event, "local", { limit: 2, window: "1m" }) }',
     ].join("\n")
     expect(extractRateLimitDeclarations("declaration-shadow.ts", declarations)).toEqual([])
+  })
+
+  it("ignores top-level bindings that own the auto-import name", () => {
+    const sources = [
+      [
+        'import { requireRateLimit } from "other-package"',
+        'requireRateLimit(event, "unrelated-import", { limit: 1, window: "1m" })',
+      ],
+      [
+        "export function requireRateLimit() {}",
+        'requireRateLimit(event, "exported-function", { limit: 1, window: "1m" })',
+      ],
+      [
+        "export default class requireRateLimit {}",
+        'requireRateLimit(event, "exported-class", { limit: 1, window: "1m" })',
+      ],
+      [
+        "const requireRateLimit = local",
+        'requireRateLimit(event, "local-variable", { limit: 1, window: "1m" })',
+      ],
+      [
+        "enum requireRateLimit { Local }",
+        'requireRateLimit(event, "local-enum", { limit: 1, window: "1m" })',
+      ],
+      [
+        "namespace requireRateLimit { export const local = true }",
+        'requireRateLimit(event, "local-namespace", { limit: 1, window: "1m" })',
+      ],
+      [
+        'import requireRateLimit = require("other-package")',
+        'requireRateLimit(event, "import-equals", { limit: 1, window: "1m" })',
+      ],
+    ]
+
+    for (const [index, source] of sources.entries()) {
+      expect(extractRateLimitDeclarations(`top-level-shadow-${index}.ts`, source.join("\n"))).toEqual([])
+    }
+  })
+
+  it("ignores parameter and block bindings that shadow an auto-import", () => {
+    const source = [
+      "async function parameter(event, requireRateLimit) {",
+      '  await requireRateLimit(event, "parameter", { limit: 1, window: "1m" })',
+      "}",
+      "async function route(event) {",
+      '  await requireRateLimit(event, "before-block", { limit: 2, window: "1m" })',
+      "  {",
+      "    const requireRateLimit = local",
+      '    await requireRateLimit(event, "block", { limit: 1, window: "1m" })',
+      "  }",
+      '  await requireRateLimit(event, "after-block", { limit: 3, window: "1m" })',
+      "}",
+    ].join("\n")
+
+    expect(extractRateLimitDeclarations("nested-shadow.ts", source)).toMatchObject([
+      { name: "before-block" },
+      { name: "after-block" },
+    ])
+  })
+
+  it("respects var hoisting across nested statements", () => {
+    const functionSource = [
+      'requireRateLimit(event, "module", { limit: 1, window: "1m" })',
+      "async function route(event) {",
+      '  await requireRateLimit(event, "before-var", { limit: 1, window: "1m" })',
+      "  if (enabled) { var requireRateLimit = local }",
+      '  await requireRateLimit(event, "after-var", { limit: 1, window: "1m" })',
+      "}",
+    ].join("\n")
+    expect(extractRateLimitDeclarations("function-var.ts", functionSource)).toMatchObject([{ name: "module" }])
+
+    const programSource = [
+      "if (enabled) { var requireRateLimit = local }",
+      'requireRateLimit(event, "program-var", { limit: 1, window: "1m" })',
+    ].join("\n")
+    expect(extractRateLimitDeclarations("program-var.ts", programSource)).toEqual([])
   })
 
   it("deduplicates identical IDs and policies", async () => {

--- a/packages/rate-limit/test/provider-output.test.ts
+++ b/packages/rate-limit/test/provider-output.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path"
 import { afterEach, describe, expect, it } from "vitest"
 
 import { createDefaultCloudflareOutputRoot } from "@vite-hub/internal/build/deployment-output"
+import { discoverRateLimitDeclarations } from "../src/discovery.ts"
 import { getCloudflareRateLimitBindingName } from "../src/drivers/cloudflare.ts"
 import { createCloudflareRateLimitBindings, resolveRateLimitNamespace, writeRateLimitProviderOutput } from "../src/internal/provider-output.ts"
 
@@ -33,6 +34,30 @@ describe("Rate Limit Provider Output", () => {
       namespace_id: expect.stringMatching(/^\d+$/),
       simple: { limit: 10, period: 60 },
     }])
+  })
+
+  it("emits bindings only for discovered ViteHub guards", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-rate-limit-discovered-output-"))
+    roots.push(root)
+    const routes = join(root, "server", "api")
+    await mkdir(routes, { recursive: true })
+    await writeFile(join(routes, "code.post.ts"), 'requireRateLimit(event, "code-image", { limit: 5, window: "1m" })\n')
+    await writeFile(join(routes, "files.post.ts"), [
+      'import { requireRateLimit as requireUploadLimit } from "vite-hub/rate-limit"',
+      'requireUploadLimit(event, "file-upload", { limit: 10, window: "1m" })',
+      "",
+    ].join("\n"))
+    await writeFile(join(routes, "local.post.ts"), [
+      "const requireRateLimit = local",
+      'requireRateLimit(event, "lookalike", { limit: 1, window: "1m" })',
+      "",
+    ].join("\n"))
+
+    const declarations = discoverRateLimitDeclarations({ rootDir: root })
+    expect(createCloudflareRateLimitBindings(declarations, "drop-production").map(binding => binding.name)).toEqual([
+      getCloudflareRateLimitBindingName("code-image"),
+      getCloudflareRateLimitBindingName("file-upload"),
+    ])
   })
 
   it("requires a project-unique Cloudflare namespace", async () => {


### PR DESCRIPTION
## Summary

- discover bare `requireRateLimit()` calls supplied by framework auto-imports
- preserve explicit, aliased, namespace, and dynamic Rate Limit bindings while excluding lexical lookalikes
- prove only real declarations contribute Cloudflare Rate Limit bindings

## Why

Nitro can register `requireRateLimit` as an auto-import, but Rate Limit discovery previously required a source import. The runtime guard worked while Provider Output silently omitted its native binding.

Discovery now treats the canonical bare name as a framework binding only when the module has no local runtime owner. Static imports, exported declarations, block bindings, function parameters, hoisted `var`, and TypeScript runtime declarations keep normal lexical precedence, so locally redefined lookalikes do not generate infrastructure.

## Verification

- `pnpm --filter @vite-hub/rate-limit typecheck`
- `pnpm exec vp check --no-fmt packages/rate-limit/src/discovery.ts packages/rate-limit/test/discovery.test.ts packages/rate-limit/test/provider-output.test.ts`
- `pnpm --filter @vite-hub/rate-limit test` — 8 test files and 78 tests pass with no type errors
