### PR TITLE
fix(agent): clean up abandoned Harness sessions

### DIFF
--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -1173,11 +1173,18 @@ async function withSessionCleanup(
   waitUntil: AgentWaitUntil,
 ): Promise<unknown> {
   let cleanupTask: Promise<void> | undefined
+  let markCleanupStarted!: () => void
+  const cleanupStarted = new Promise<void>((resolve) => {
+    markCleanupStarted = resolve
+  })
   let onAbort: (() => void) | undefined
   const cleanupOnce = (error?: unknown) => {
-    cleanupTask ||= cleanup(error).finally(() => {
-      if (onAbort) abortSignal?.removeEventListener("abort", onAbort)
-    })
+    if (!cleanupTask) {
+      cleanupTask = cleanup(error).finally(() => {
+        if (onAbort) abortSignal?.removeEventListener("abort", onAbort)
+      })
+      markCleanupStarted()
+    }
     return cleanupTask
   }
   const observeAbort = () => {
@@ -1256,10 +1263,14 @@ async function withSessionCleanup(
     const then = (responseMessages as { then?: unknown }).then
     if (typeof then === "function") {
       // Harness closes its eagerly produced streams before this terminal promise settles.
-      waitUntil(Promise.resolve(responseMessages).then(
+      const producerCleanup = Promise.resolve(responseMessages).then(
         () => cleanupOnce(),
         error => cleanupOnce(error),
-      ))
+      )
+      waitUntil(Promise.race([
+        producerCleanup,
+        cleanupStarted.then(() => cleanupTask),
+      ]))
     }
   }
   return clone

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -46,6 +46,7 @@ import type {
   AgentRunCallbackContext,
   AgentRuntimeConfig,
   AgentToolSet,
+  AgentWaitUntil,
   MaybePromise,
 } from "./types.ts"
 import type { AttachmentData, Message } from "./messages.ts"
@@ -1165,15 +1166,31 @@ function createSharedCleanupIterableWrapper(cleanup: (error?: unknown) => Promis
   }
 }
 
-async function withSessionCleanup(result: unknown, cleanup: (error?: unknown) => Promise<void>, abortSignal?: AbortSignal): Promise<unknown> {
-  let cleanupCalled = false
-  const cleanupOnce = async (error?: unknown) => {
-    if (cleanupCalled) return
-    cleanupCalled = true
-    await cleanup(error)
+async function withSessionCleanup(
+  result: unknown,
+  cleanup: (error?: unknown) => Promise<void>,
+  abortSignal: AbortSignal | undefined,
+  waitUntil: AgentWaitUntil,
+): Promise<unknown> {
+  let cleanupTask: Promise<void> | undefined
+  let onAbort: (() => void) | undefined
+  const cleanupOnce = (error?: unknown) => {
+    cleanupTask ||= cleanup(error).finally(() => {
+      if (onAbort) abortSignal?.removeEventListener("abort", onAbort)
+    })
+    return cleanupTask
+  }
+  const observeAbort = () => {
+    if (!abortSignal) return
+    onAbort = () => {
+      waitUntil(cleanupOnce(abortSignal.reason))
+    }
+    if (abortSignal.aborted) onAbort()
+    else abortSignal.addEventListener("abort", onAbort, { once: true })
   }
 
   if (isAsyncIterable(result)) {
+    observeAbort()
     return withCleanup(result, cleanupOnce, abortSignal)
   }
   if (!result || typeof result !== "object") {
@@ -1230,6 +1247,21 @@ async function withSessionCleanup(result: unknown, cleanup: (error?: unknown) =>
     configurable: true,
     value: () => streamAgentOutputToEvents(clone)[Symbol.asyncIterator](),
   })
+  observeAbort()
+  const responseMessages = (result as { responseMessages?: unknown }).responseMessages
+  if (
+    (typeof responseMessages === "object" && responseMessages !== null)
+    || typeof responseMessages === "function"
+  ) {
+    const then = (responseMessages as { then?: unknown }).then
+    if (typeof then === "function") {
+      // Harness closes its eagerly produced streams before this terminal promise settles.
+      waitUntil(Promise.resolve(responseMessages).then(
+        () => cleanupOnce(),
+        error => cleanupOnce(error),
+      ))
+    }
+  }
   return clone
 }
 
@@ -1482,7 +1514,7 @@ export function createHarnessAgentAdapter<
           ...await toHarnessCallInput(context, resumesSession, chatPrompt),
           session,
         }), usageMetadata)
-        return await withSessionCleanup(result, cleanup, context.input.abortSignal)
+        return await withSessionCleanup(result, cleanup, context.input.abortSignal, context.runtime.waitUntil)
       }
       catch (error) {
         await cleanup(error)

--- a/packages/agent/test/invocation-lifecycle.test.ts
+++ b/packages/agent/test/invocation-lifecycle.test.ts
@@ -385,7 +385,7 @@ describe("Harness Agent Driver session cleanup", () => {
     const abort = new AbortController()
     const { destroy, tasks } = await createHarnessCleanupProbe({ abortSignal: abort.signal })
     abort.abort(new Error("abandoned"))
-    await tasks.at(-1)
+    await Promise.all(tasks)
 
     expect(destroy).toHaveBeenCalledOnce()
   })

--- a/packages/agent/test/invocation-lifecycle.test.ts
+++ b/packages/agent/test/invocation-lifecycle.test.ts
@@ -57,6 +57,87 @@ function createInvocationRuntime() {
   }
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function createHarnessAdapterContext(options: {
+  abortSignal?: AbortSignal
+  waitUntil: (task: Promise<unknown>) => void
+}) {
+  const values = new Map<string, unknown>()
+  return {
+    actor: { id: "actor" },
+    context: {
+      entries: () => values.entries(),
+      get: (key: string) => values.get(key),
+      has: (key: string) => values.has(key),
+      set: (key: string, value: unknown) => {
+        values.set(key, value)
+      },
+      toJSON: () => Object.fromEntries(values),
+    },
+    input: {
+      ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
+      prompt: "hello",
+    },
+    invoker: { id: "invoker" },
+    messages: [],
+    prompt: "hello",
+    runtime: {
+      memo: vi.fn(),
+      runtime: "unknown",
+      runtimeConfig: {},
+      waitUntil: options.waitUntil,
+    },
+  }
+}
+
+function streamOf<T>(values: T[]) {
+  return new ReadableStream<T>({
+    start(controller) {
+      for (const value of values) controller.enqueue(value)
+      controller.close()
+    },
+  })
+}
+
+async function createHarnessCleanupProbe(options: { abortSignal?: AbortSignal } = {}) {
+  const { createHarnessAgentAdapter } = await import("../src/harness-agent.ts")
+  const completion = deferred<unknown[]>()
+  const destroy = vi.fn()
+  const tasks: Promise<unknown>[] = []
+  const eventStream = streamOf([
+    { text: "first", type: "text-delta" },
+    { text: "second", type: "text-delta" },
+  ])
+  harnessCreateSession.mockResolvedValueOnce({ destroy })
+  harnessStream.mockResolvedValueOnce({
+    fullStream: eventStream,
+    responseMessages: completion.promise,
+    stream: eventStream,
+    textStream: streamOf(["first", "second"]),
+  })
+  const adapter = createHarnessAgentAdapter({
+    harness: { harnessId: "test" },
+    sandbox: { providerId: "test" },
+  } as never)
+  const result = await adapter.stream?.(createHarnessAdapterContext({
+    abortSignal: options.abortSignal,
+    waitUntil(task) {
+      tasks.push(task)
+    },
+  }) as never) as {
+    stream: AsyncIterable<{ text: string }>
+    textStream: AsyncIterable<string>
+  }
+  return { completion, destroy, result, tasks }
+}
+
 function createInvocationDriverFixture(
   kind: DriverKind,
   form: InvocationForm,
@@ -286,6 +367,47 @@ describe("Agent Invocation Interface lifecycle", () => {
 
     await expect(response.text()).resolves.toBe("handled")
     probe.expectFinished(["input", "close", "finish"])
+  })
+})
+
+describe("Harness Agent Driver session cleanup", () => {
+  it("cleans an unconsumed multi-stream result when production settles", async () => {
+    const { completion, destroy, tasks } = await createHarnessCleanupProbe()
+    expect(destroy).not.toHaveBeenCalled()
+
+    completion.resolve([])
+    await Promise.all(tasks)
+
+    expect(destroy).toHaveBeenCalledOnce()
+  })
+
+  it("cleans an unconsumed result when its invocation is aborted", async () => {
+    const abort = new AbortController()
+    const { destroy, tasks } = await createHarnessCleanupProbe({ abortSignal: abort.signal })
+    abort.abort(new Error("abandoned"))
+    await tasks.at(-1)
+
+    expect(destroy).toHaveBeenCalledOnce()
+  })
+
+  it("keeps buffered sibling streams readable after producer cleanup", async () => {
+    const { completion, destroy, result, tasks } = await createHarnessCleanupProbe()
+    const events = result.stream[Symbol.asyncIterator]()
+    const text = result.textStream[Symbol.asyncIterator]()
+
+    await expect(events.next()).resolves.toMatchObject({ done: false, value: { text: "first" } })
+    await expect(text.next()).resolves.toEqual({ done: false, value: "first" })
+    expect(destroy).not.toHaveBeenCalled()
+
+    completion.resolve([])
+    await Promise.all(tasks)
+    expect(destroy).toHaveBeenCalledOnce()
+
+    await expect(events.next()).resolves.toMatchObject({ done: false, value: { text: "second" } })
+    await expect(text.next()).resolves.toEqual({ done: false, value: "second" })
+    await expect(events.next()).resolves.toMatchObject({ done: true })
+    await expect(text.next()).resolves.toMatchObject({ done: true })
+    expect(destroy).toHaveBeenCalledOnce()
   })
 })
 


### PR DESCRIPTION
## Summary

- clean up Harness sessions when eager multi-stream production settles, even if no returned stream is consumed
- route abort cleanup through the runtime lifecycle and share one cleanup task across every result surface
- keep buffered sibling streams readable without imposing a fixed abandonment timeout

## Why

ViteHub creates the Harness session and wraps the returned result, but the existing cleanup wrappers only run after a consumer starts and finishes, returns, throws, or aborts an iterator. A result that is never consumed can therefore leave its session open indefinitely.

Harness exposes producer completion through `responseMessages` and closes its streams before that promise's reactions run. Following that terminal signal lets ViteHub reclaim the session after production finishes while preserving already-buffered output for partial or later consumption.

## Validation

- regression proof on `origin/main`: the three new lifecycle cases failed before the source fix
- `pnpm --filter @vite-hub/agent exec vp test test/invocation-lifecycle.test.ts` — 23 passed
- `pnpm --filter @vite-hub/agent exec vp test --maxWorkers=1` — 68 files and 1,574 tests passed
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm exec vp check --no-fmt packages/agent/src/harness-agent.ts packages/agent/test/invocation-lifecycle.test.ts`
- `git diff --check`
