### PR TITLE
fix(browser): own Cloudflare Playwright adapter

### DIFF
--- a/docs/content/docs/server-primitives/browser.md
+++ b/docs/content/docs/server-primitives/browser.md
@@ -18,7 +18,7 @@ Browser is a server primitive, not an Agent Capability. Server code invokes Brow
 ### Install
 
 ```bash [Terminal]
-pnpm add vite-hub @cloudflare/playwright
+pnpm add vite-hub
 ```
 
 ### Configure

--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -53,11 +53,11 @@
     "test": "vp run -t @vite-hub/browser#build && vp test"
   },
   "dependencies": {
+    "@cloudflare/playwright": "catalog:browser",
     "@vite-hub/runtime": "workspace:*",
     "playwright-core": "catalog:browser"
   },
   "devDependencies": {
-    "@cloudflare/playwright": "catalog:browser",
     "@types/node": "catalog:tooling",
     "@vite-hub/internal": "workspace:*",
     "publint": "catalog:tooling",
@@ -67,13 +67,9 @@
     "vitest": "catalog:tooling"
   },
   "peerDependencies": {
-    "@cloudflare/playwright": "catalog:browser",
     "vite": "catalog:vite-compat"
   },
   "peerDependenciesMeta": {
-    "@cloudflare/playwright": {
-      "optional": true
-    },
     "vite": {
       "optional": true
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -753,6 +753,9 @@ importers:
 
   packages/browser:
     dependencies:
+      '@cloudflare/playwright':
+        specifier: catalog:browser
+        version: 1.3.0
       '@vite-hub/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -763,9 +766,6 @@ importers:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
         version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
     devDependencies:
-      '@cloudflare/playwright':
-        specifier: catalog:browser
-        version: 1.3.0
       '@types/node':
         specifier: catalog:tooling
         version: 24.13.3

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -392,7 +392,7 @@ async function assertVercelRuntimeImportsResolveInside(
 }
 
 describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-hub consumer contract", () => {
-  it("publishes Browser types without consumer-owned Playwright", async () => {
+  it("publishes Browser types and Cloudflare adapter without consumer-owned Playwright", async () => {
     const root = await mkdtemp(join(tmpdir(), "vite-hub-browser-consumer-"))
     const appDir = join(root, "app")
     const packDir = join(root, "packs")
@@ -426,6 +426,11 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
       ])
       await run("pnpm", ["install", "--no-hoist", "--strict-peer-dependencies"], appDir)
       await assertOnlyViteHubDependencies(appDir, ["@vite-hub/browser"])
+      await run(process.execPath, ["--input-type=module", "--eval", `
+        import { createRequire } from "node:module"
+        const browserRequire = createRequire(import.meta.resolve("@vite-hub/browser/package.json"))
+        browserRequire.resolve("@cloudflare/playwright")
+      `], appDir)
       await run(process.execPath, [
         resolve(repoRoot, "node_modules/typescript/bin/tsc"),
         "--module",


### PR DESCRIPTION
## Summary

- make `@cloudflare/playwright` a direct `@vite-hub/browser` dependency instead of a consumer-owned optional peer
- preserve the existing lazy provider imports and provider error paths
- update the Browser install guide and verify adapter resolution from a packed, isolated consumer

## Why

`@vite-hub/browser` already dynamically loads the Cloudflare Playwright adapter from its provider and controller implementations, so applications should not declare that implementation dependency themselves. [Drop PR #2](https://github.com/vite-hub/drop/pull/2) proved the package-owned manifest through a frozen offline install, Cloudflare builds, and the deployed Browser flow; this upstream change moves that ownership to the package that uses it.

## Verification

- `pnpm --filter @vite-hub/browser test` — 42 tests pass, package build and type checks included
- `pnpm --filter @vite-hub/browser typecheck`
- `VITEHUB_CONSUMER_CONTRACT=1 pnpm exec vp test run test/consumer/vite-hub.test.ts -t "publishes Browser types and Cloudflare adapter"`
- `pnpm exec vp test run test/contracts.test.ts` — 12 tests pass
- packed manifest contains `@cloudflare/playwright: ^1.3.0` under dependencies, with `vite` as the only optional peer