### PR TITLE
fix: make Cloudflare preview container deployment reliable

### DIFF
--- a/docs/content/docs/frameworks-hosts/cloudflare.md
+++ b/docs/content/docs/frameworks-hosts/cloudflare.md
@@ -76,6 +76,16 @@ find dist -maxdepth 4 -type f | sort
 
 Agent routes should come from generated Provider Output. Raw Cloudflare Worker fetch handlers are not a public Agent API.
 
+### Workers Builds
+
+Use Nitro's generated deployment command for production and non-production Workers Builds:
+
+```bash [Deploy command]
+pnpm exec nitro deploy --prebuilt
+```
+
+When Sandbox is enabled, ViteHub writes an explicit gradual Container rollout into `.output/nitro.json`. This deploys the Worker and its Container application through the same generated contract. A direct Wrangler command with `--containers-rollout=none` bypasses ViteHub's deployment command and can leave a newly scoped Sandbox binding without a Container application to run.
+
 ### Rate Limiting bindings
 
 Register the Rate Limit integration. A Cloudflare Nitro preset infers the provider, and each handler-local `requireRateLimit()` policy contributes one `ratelimits` entry to Nitro's Wrangler config. Do not repeat those bindings in `nitro.cloudflare.wrangler`; plain Vite builds continue to write them to generated `wrangler.json`.

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -282,13 +282,17 @@ function deploymentNitroModule(
   services: object,
   identity: DeploymentIdentity,
   sandboxRequested: boolean,
-  deployCommandOwned: boolean,
 ) {
   return (nitro: {
     hooks: { hook: (name: "compiled", callback: () => Promise<void>) => void }
     options: { commands: Record<string, unknown>, output: { dir: string, serverDir: string }, rootDir: string }
   }) => {
-    if (plan.preset === "cloudflare" && sandboxRequested && !deployCommandOwned) {
+    const deployCommand = nitro.options.commands.deploy
+    if (
+      plan.preset === "cloudflare"
+      && sandboxRequested
+      && (deployCommand === undefined || deployCommand === "npx wrangler --cwd ./ deploy")
+    ) {
       const serverDir = relative(nitro.options.output.dir, nitro.options.output.serverDir).replaceAll("\\", "/")
       nitro.options.commands.deploy = `npx wrangler --cwd ./${serverDir} deploy --containers-rollout=gradual`
     }
@@ -357,7 +361,6 @@ function deploymentPlugins(
           }
         }
         const nitro = cloneRecord((config as { nitro?: unknown }).nitro)
-        const deployCommandOwned = typeof cloneRecord(nitro.commands).deploy === "string"
         if (blobEnabled && plan.services.blob.supported && plan.services.blob.adapter === "cloudflare-r2") {
           const optionBlob = options.blob === true ? undefined : options.blob
           const configuredBlob = (config as { blob?: BlobModuleOptions }).blob
@@ -392,7 +395,7 @@ function deploymentPlugins(
           }
           nitro.modules = [
             ...(Array.isArray(nitro.modules) ? nitro.modules : []),
-            deploymentNitroModule(plan, services, identity, requestedServices.includes("sandbox"), deployCommandOwned),
+            deploymentNitroModule(plan, services, identity, requestedServices.includes("sandbox")),
           ]
           if (plan.output.packaging === "deno-node-modules") {
             nitro.commands = { ...cloneRecord(nitro.commands), deploy: "node ./deploy.mjs" }

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -277,6 +277,10 @@ function normalizeNitroPreset(value: string): string {
   return value.trim().toLowerCase().replaceAll("_", "-")
 }
 
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
 function deploymentNitroModule(
   plan: DeploymentPlan,
   services: object,
@@ -289,8 +293,11 @@ function deploymentNitroModule(
     options: { commands: Record<string, unknown>, output: { dir: string, serverDir: string }, rootDir: string }
   }) => {
     if (plan.preset === "cloudflare" && sandboxRequested && !isDeployCommandOwned()) {
-      const serverDir = relative(nitro.options.output.dir, nitro.options.output.serverDir).replaceAll("\\", "/")
-      nitro.options.commands.deploy = `npx wrangler --cwd ./${serverDir} deploy --containers-rollout=gradual`
+      const outputRelative = relative(nitro.options.output.dir, nitro.options.output.serverDir).replaceAll("\\", "/")
+      const serverDir = /^[\w./-]+$/.test(outputRelative)
+        ? `./${outputRelative}`
+        : shellQuote(`./${relative(nitro.options.rootDir, nitro.options.output.serverDir).replaceAll("\\", "/")}`)
+      nitro.options.commands.deploy = `npx wrangler --cwd ${serverDir} deploy --containers-rollout=gradual`
     }
     nitro.hooks.hook("compiled", async () => {
       const outputDir = nitro.options.output.dir
@@ -391,8 +398,8 @@ function deploymentPlugins(
             }
           }
           nitro.modules = [
-            ...(Array.isArray(nitro.modules) ? nitro.modules : []),
             deploymentNitroModule(plan, services, identity, requestedServices.includes("sandbox"), () => deployCommandOwned),
+            ...(Array.isArray(nitro.modules) ? nitro.modules : []),
           ]
           if (plan.output.packaging === "deno-node-modules") {
             nitro.commands = { ...cloneRecord(nitro.commands), deploy: "node ./deploy.mjs" }

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -386,7 +386,7 @@ function deploymentPlugins(
           if (plan.preset === "cloudflare" && requestedServices.includes("sandbox")) {
             const commands = cloneRecord(nitro.commands)
             if (typeof commands.deploy !== "string") {
-              commands.deploy = "npx wrangler --cwd ./ deploy --containers-rollout=gradual"
+              commands.deploy = "npx wrangler --cwd ./server deploy --containers-rollout=gradual"
             }
             nitro.commands = commands
           }

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -282,17 +282,13 @@ function deploymentNitroModule(
   services: object,
   identity: DeploymentIdentity,
   sandboxRequested: boolean,
+  isDeployCommandOwned: () => boolean,
 ) {
   return (nitro: {
     hooks: { hook: (name: "compiled", callback: () => Promise<void>) => void }
     options: { commands: Record<string, unknown>, output: { dir: string, serverDir: string }, rootDir: string }
   }) => {
-    const deployCommand = nitro.options.commands.deploy
-    if (
-      plan.preset === "cloudflare"
-      && sandboxRequested
-      && (deployCommand === undefined || deployCommand === "npx wrangler --cwd ./ deploy")
-    ) {
+    if (plan.preset === "cloudflare" && sandboxRequested && !isDeployCommandOwned()) {
       const serverDir = relative(nitro.options.output.dir, nitro.options.output.serverDir).replaceAll("\\", "/")
       nitro.options.commands.deploy = `npx wrangler --cwd ./${serverDir} deploy --containers-rollout=gradual`
     }
@@ -314,6 +310,7 @@ function deploymentPlugins(
   services: object,
   options: ViteHubOptions,
 ): Plugin[] {
+  let deployCommandOwned = false
   return [
     {
       name: "vite-hub/deployment-preset",
@@ -395,7 +392,7 @@ function deploymentPlugins(
           }
           nitro.modules = [
             ...(Array.isArray(nitro.modules) ? nitro.modules : []),
-            deploymentNitroModule(plan, services, identity, requestedServices.includes("sandbox")),
+            deploymentNitroModule(plan, services, identity, requestedServices.includes("sandbox"), () => deployCommandOwned),
           ]
           if (plan.output.packaging === "deno-node-modules") {
             nitro.commands = { ...cloneRecord(nitro.commands), deploy: "node ./deploy.mjs" }
@@ -418,6 +415,7 @@ function deploymentPlugins(
       enforce: "post",
       configResolved(config) {
         const nitro = cloneRecord((config as { nitro?: unknown }).nitro)
+        deployCommandOwned = typeof cloneRecord(nitro.commands).deploy === "string"
         if (config.command === "build" && nitro.preset !== plan.nitroPreset) {
           throw new Error("[vitehub] The " + JSON.stringify(plan.preset) + " deployment plan requires Nitro preset " + JSON.stringify(plan.nitroPreset) + ".")
         }

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs"
-import { basename, dirname, join, resolve } from "node:path"
+import { basename, dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import frameworkPackageManifest from "../package.json" with { type: "json" }
@@ -277,11 +277,21 @@ function normalizeNitroPreset(value: string): string {
   return value.trim().toLowerCase().replaceAll("_", "-")
 }
 
-function deploymentNitroModule(plan: DeploymentPlan, services: object, identity: DeploymentIdentity) {
+function deploymentNitroModule(
+  plan: DeploymentPlan,
+  services: object,
+  identity: DeploymentIdentity,
+  sandboxRequested: boolean,
+  deployCommandOwned: boolean,
+) {
   return (nitro: {
     hooks: { hook: (name: "compiled", callback: () => Promise<void>) => void }
-    options: { output: { dir: string }, rootDir: string }
+    options: { commands: Record<string, unknown>, output: { dir: string, serverDir: string }, rootDir: string }
   }) => {
+    if (plan.preset === "cloudflare" && sandboxRequested && !deployCommandOwned) {
+      const serverDir = relative(nitro.options.output.dir, nitro.options.output.serverDir).replaceAll("\\", "/")
+      nitro.options.commands.deploy = `npx wrangler --cwd ./${serverDir} deploy --containers-rollout=gradual`
+    }
     nitro.hooks.hook("compiled", async () => {
       const outputDir = nitro.options.output.dir
       const rootDir = nitro.options.rootDir
@@ -347,6 +357,7 @@ function deploymentPlugins(
           }
         }
         const nitro = cloneRecord((config as { nitro?: unknown }).nitro)
+        const deployCommandOwned = typeof cloneRecord(nitro.commands).deploy === "string"
         if (blobEnabled && plan.services.blob.supported && plan.services.blob.adapter === "cloudflare-r2") {
           const optionBlob = options.blob === true ? undefined : options.blob
           const configuredBlob = (config as { blob?: BlobModuleOptions }).blob
@@ -381,15 +392,8 @@ function deploymentPlugins(
           }
           nitro.modules = [
             ...(Array.isArray(nitro.modules) ? nitro.modules : []),
-            deploymentNitroModule(plan, services, identity),
+            deploymentNitroModule(plan, services, identity, requestedServices.includes("sandbox"), deployCommandOwned),
           ]
-          if (plan.preset === "cloudflare" && requestedServices.includes("sandbox")) {
-            const commands = cloneRecord(nitro.commands)
-            if (typeof commands.deploy !== "string") {
-              commands.deploy = "npx wrangler --cwd ./server deploy --containers-rollout=gradual"
-            }
-            nitro.commands = commands
-          }
           if (plan.output.packaging === "deno-node-modules") {
             nitro.commands = { ...cloneRecord(nitro.commands), deploy: "node ./deploy.mjs" }
             const rollupConfig = cloneRecord(nitro.rollupConfig)

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -296,7 +296,7 @@ function deploymentNitroModule(
       const outputRelative = relative(nitro.options.output.dir, nitro.options.output.serverDir).replaceAll("\\", "/")
       const serverDir = /^[\w./-]+$/.test(outputRelative)
         ? `./${outputRelative}`
-        : shellQuote(`./${relative(nitro.options.rootDir, nitro.options.output.serverDir).replaceAll("\\", "/")}`)
+        : shellQuote(`./${outputRelative}`)
       nitro.options.commands.deploy = `npx wrangler --cwd ${serverDir} deploy --containers-rollout=gradual`
     }
     nitro.hooks.hook("compiled", async () => {

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -383,6 +383,13 @@ function deploymentPlugins(
             ...(Array.isArray(nitro.modules) ? nitro.modules : []),
             deploymentNitroModule(plan, services, identity),
           ]
+          if (plan.preset === "cloudflare" && requestedServices.includes("sandbox")) {
+            const commands = cloneRecord(nitro.commands)
+            if (typeof commands.deploy !== "string") {
+              commands.deploy = "npx wrangler --cwd ./ deploy --containers-rollout=gradual"
+            }
+            nitro.commands = commands
+          }
           if (plan.output.packaging === "deno-node-modules") {
             nitro.commands = { ...cloneRecord(nitro.commands), deploy: "node ./deploy.mjs" }
             const rollupConfig = cloneRecord(nitro.rollupConfig)

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -475,16 +475,24 @@ describe("vitehub", () => {
   })
 
   it("preserves an explicit Cloudflare Sandbox deploy command", async () => {
-    const config = await applyDeploymentConfig(
-      { preset: "cloudflare", sandbox: true },
-      { nitro: { commands: { deploy: "node ./deploy.mjs" } } },
-    )
+    const plugins = vitehub({ preset: "cloudflare", sandbox: true })
+    const preset = plugins.find(candidate => (candidate as Plugin).name === "vite-hub/deployment-preset") as Plugin
+    const output = plugins.find(candidate => (candidate as Plugin).name === "vite-hub/deployment-output") as Plugin
+    const config = { nitro: { commands: { deploy: "node ./deploy.mjs" } } } as Record<string, unknown>
+    const configure = preset.config as unknown as (
+      config: Record<string, unknown>,
+      env: { command: "build", mode: string },
+    ) => void
+    await configure(config, { command: "build", mode: "production" })
 
     const nitroConfig = config.nitro as { commands: Record<string, unknown>, modules: unknown[] }
+    nitroConfig.commands.deploy = "npx wrangler --cwd ./ deploy"
+    const resolveConfig = output.configResolved as unknown as (config: Record<string, unknown>) => void
+    resolveConfig({ command: "build", nitro: nitroConfig })
     const nitro = {
       hooks: { hook: vi.fn() },
       options: {
-        commands: { deploy: "node ./later-deploy.mjs" },
+        commands: nitroConfig.commands,
         output: { dir: "/app/.output", serverDir: "/app/.output/server" },
         rootDir: "/app",
       },
@@ -492,7 +500,7 @@ describe("vitehub", () => {
     const module = nitroConfig.modules.at(-1) as (target: typeof nitro) => void
     module(nitro)
 
-    expect(nitro.options).toMatchObject({ commands: { deploy: "node ./later-deploy.mjs" } })
+    expect(nitro.options).toMatchObject({ commands: { deploy: "npx wrangler --cwd ./ deploy" } })
   })
 
   it("keeps deployment-owned Nitro configuration out of development", async () => {

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -471,7 +471,7 @@ describe("vitehub", () => {
 
     expect(nitro.options).toMatchObject({
       commands: {
-        deploy: "npx wrangler --cwd './.output/cloudflare worker' deploy --containers-rollout=gradual",
+        deploy: "npx wrangler --cwd './cloudflare worker' deploy --containers-rollout=gradual",
         preview: "node ./preview.mjs",
       },
     })

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -447,9 +447,28 @@ describe("vitehub", () => {
       { nitro: { commands: { preview: "node ./preview.mjs" } } },
     )
 
-    expect(config.nitro).toMatchObject({
+    const nitroConfig = config.nitro as { commands: Record<string, unknown>, modules: unknown[] }
+    const module = nitroConfig.modules.at(-1) as (nitro: {
+      hooks: { hook: ReturnType<typeof vi.fn> }
+      options: {
+        commands: Record<string, unknown>
+        output: { dir: string, serverDir: string }
+        rootDir: string
+      }
+    }) => void
+    const nitro = {
+      hooks: { hook: vi.fn() },
+      options: {
+        commands: nitroConfig.commands,
+        output: { dir: "/app/.output", serverDir: "/app/.output/worker" },
+        rootDir: "/app",
+      },
+    }
+    module(nitro)
+
+    expect(nitro.options).toMatchObject({
       commands: {
-        deploy: "npx wrangler --cwd ./server deploy --containers-rollout=gradual",
+        deploy: "npx wrangler --cwd ./worker deploy --containers-rollout=gradual",
         preview: "node ./preview.mjs",
       },
     })

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -480,7 +480,19 @@ describe("vitehub", () => {
       { nitro: { commands: { deploy: "node ./deploy.mjs" } } },
     )
 
-    expect(config.nitro).toMatchObject({ commands: { deploy: "node ./deploy.mjs" } })
+    const nitroConfig = config.nitro as { commands: Record<string, unknown>, modules: unknown[] }
+    const nitro = {
+      hooks: { hook: vi.fn() },
+      options: {
+        commands: { deploy: "node ./later-deploy.mjs" },
+        output: { dir: "/app/.output", serverDir: "/app/.output/server" },
+        rootDir: "/app",
+      },
+    }
+    const module = nitroConfig.modules.at(-1) as (target: typeof nitro) => void
+    module(nitro)
+
+    expect(nitro.options).toMatchObject({ commands: { deploy: "node ./later-deploy.mjs" } })
   })
 
   it("keeps deployment-owned Nitro configuration out of development", async () => {

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -442,13 +442,16 @@ describe("vitehub", () => {
   })
 
   it("deploys Cloudflare Sandbox containers through the generated Nitro command", async () => {
+    const userModule = (nitro: { options: { commands: Record<string, unknown> } }) => {
+      nitro.options.commands.deploy = "node ./deploy.mjs"
+    }
     const config = await applyDeploymentConfig(
       { preset: "cloudflare", sandbox: true },
-      { nitro: { commands: { preview: "node ./preview.mjs" } } },
+      { nitro: { commands: { preview: "node ./preview.mjs" }, modules: [userModule] } },
     )
 
     const nitroConfig = config.nitro as { commands: Record<string, unknown>, modules: unknown[] }
-    const module = nitroConfig.modules.at(-1) as (nitro: {
+    const module = nitroConfig.modules[0] as (nitro: {
       hooks: { hook: ReturnType<typeof vi.fn> }
       options: {
         commands: Record<string, unknown>
@@ -460,7 +463,7 @@ describe("vitehub", () => {
       hooks: { hook: vi.fn() },
       options: {
         commands: nitroConfig.commands,
-        output: { dir: "/app/.output", serverDir: "/app/.output/worker" },
+        output: { dir: "/app/.output", serverDir: "/app/.output/cloudflare worker" },
         rootDir: "/app",
       },
     }
@@ -468,10 +471,13 @@ describe("vitehub", () => {
 
     expect(nitro.options).toMatchObject({
       commands: {
-        deploy: "npx wrangler --cwd ./worker deploy --containers-rollout=gradual",
+        deploy: "npx wrangler --cwd './.output/cloudflare worker' deploy --containers-rollout=gradual",
         preview: "node ./preview.mjs",
       },
     })
+    expect(nitroConfig.modules[1]).toBe(userModule)
+    userModule(nitro)
+    expect(nitro.options.commands.deploy).toBe("node ./deploy.mjs")
   })
 
   it("preserves an explicit Cloudflare Sandbox deploy command", async () => {
@@ -497,7 +503,7 @@ describe("vitehub", () => {
         rootDir: "/app",
       },
     }
-    const module = nitroConfig.modules.at(-1) as (target: typeof nitro) => void
+    const module = nitroConfig.modules[0] as (target: typeof nitro) => void
     module(nitro)
 
     expect(nitro.options).toMatchObject({ commands: { deploy: "npx wrangler --cwd ./ deploy" } })
@@ -560,7 +566,7 @@ describe("vitehub", () => {
     const plugin = vitehub({ preset: "node" }).find(candidate => (candidate as Plugin).name === "vite-hub/deployment-preset") as Plugin
     const hook = plugin.config as unknown as (config: Record<string, unknown>, env: { command: "build", mode: string }) => void
     await hook(config, { command: "build", mode: "production" })
-    expect(config.nitro).toMatchObject({ modules: ["existing-module", expect.any(Function)] })
+    expect(config.nitro).toMatchObject({ modules: [expect.any(Function), "existing-module"] })
   })
 
   it.each([

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -449,7 +449,7 @@ describe("vitehub", () => {
 
     expect(config.nitro).toMatchObject({
       commands: {
-        deploy: "npx wrangler --cwd ./ deploy --containers-rollout=gradual",
+        deploy: "npx wrangler --cwd ./server deploy --containers-rollout=gradual",
         preview: "node ./preview.mjs",
       },
     })

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -441,6 +441,29 @@ describe("vitehub", () => {
     }
   })
 
+  it("deploys Cloudflare Sandbox containers through the generated Nitro command", async () => {
+    const config = await applyDeploymentConfig(
+      { preset: "cloudflare", sandbox: true },
+      { nitro: { commands: { preview: "node ./preview.mjs" } } },
+    )
+
+    expect(config.nitro).toMatchObject({
+      commands: {
+        deploy: "npx wrangler --cwd ./ deploy --containers-rollout=gradual",
+        preview: "node ./preview.mjs",
+      },
+    })
+  })
+
+  it("preserves an explicit Cloudflare Sandbox deploy command", async () => {
+    const config = await applyDeploymentConfig(
+      { preset: "cloudflare", sandbox: true },
+      { nitro: { commands: { deploy: "node ./deploy.mjs" } } },
+    )
+
+    expect(config.nitro).toMatchObject({ commands: { deploy: "node ./deploy.mjs" } })
+  })
+
   it("keeps deployment-owned Nitro configuration out of development", async () => {
     const config = {
       nitro: {

--- a/test/consumer/deployment-presets.test.ts
+++ b/test/consumer/deployment-presets.test.ts
@@ -204,6 +204,11 @@ it("derives Cloudflare provider output from the Workers Builds target", async ()
         source: "WRANGLER_CI_OVERRIDE_NAME",
       },
     })
+    await expect(readFile(join(root, ".output/nitro.json"), "utf8").then(JSON.parse)).resolves.toMatchObject({
+      commands: {
+        deploy: "npx wrangler --cwd ./ deploy --containers-rollout=gradual",
+      },
+    })
     const wrangler = JSON.parse(await readFile(join(root, ".output/server/wrangler.json"), "utf8"))
     expect(wrangler).toMatchObject({
       containers: expect.arrayContaining([

--- a/test/consumer/deployment-presets.test.ts
+++ b/test/consumer/deployment-presets.test.ts
@@ -206,7 +206,7 @@ it("derives Cloudflare provider output from the Workers Builds target", async ()
     })
     await expect(readFile(join(root, ".output/nitro.json"), "utf8").then(JSON.parse)).resolves.toMatchObject({
       commands: {
-        deploy: "npx wrangler --cwd ./ deploy --containers-rollout=gradual",
+        deploy: "npx wrangler --cwd ./server deploy --containers-rollout=gradual",
       },
     })
     const wrangler = JSON.parse(await readFile(join(root, ".output/server/wrangler.json"), "utf8"))


### PR DESCRIPTION
## Summary

- generate an explicit gradual Container rollout for Cloudflare deployments with Sandbox enabled
- preserve application-owned Nitro deploy commands and keep the rollout scoped to ViteHub's generated deployment path
- document the supported Workers Builds command and cover unit plus consumer Provider Output

## Why

Cloudflare Workers Builds can invoke Wrangler with `--containers-rollout=none`, which uploads the Worker without provisioning a newly scoped Container application. The generated Sandbox Durable Object binding can then point at no application and fail when it receives work.

ViteHub now makes the safe deployment contract inspectable in `.output/nitro.json`: `pnpm exec nitro deploy --prebuilt` runs Wrangler with a gradual Container rollout, so the Worker and its Sandbox Container application are deployed together without weakening production rollout safety. Direct raw Wrangler commands remain outside this generated contract.

## Verification

- `pnpm exec vp run -t vite-hub#build`
- `pnpm --filter vite-hub typecheck`
- `pnpm --filter vite-hub exec vp test test/vite.test.ts` — 58 tests and type checks pass
- `TMPDIR=<worktree>/.tmp-test pnpm exec vp test test/consumer/deployment-presets.test.ts -t "derives Cloudflare provider output from the Workers Builds target"`
- `pnpm exec oxlint packages/vite-hub/src/index.ts packages/vite-hub/test/vite.test.ts test/consumer/deployment-presets.test.ts`
- `git diff --check`
- patched `vite-hub@0.0.3` into Drop PR #3 at `2e1ad8c`, then verified the preview build emitted `--containers-rollout=gradual` and `vitehub-drop-preview-sandbox`; no deployment was invoked