### PR TITLE
feat(agent): expose AI Gateway usage pricing

### DIFF
--- a/docs/content/docs/capabilities/usage-cost.md
+++ b/docs/content/docs/capabilities/usage-cost.md
@@ -27,6 +27,14 @@ The default pricing callback fetches Vercel AI Gateway's public model catalog. I
 
 Pricing is best-effort. A missing model match, unavailable catalog, timeout, invalid price, or pricing callback error leaves the usage record and successful Agent Invocation unchanged. A cost already reported by the provider remains authoritative.
 
+Import `vercelAiGatewayPricing()` when application-owned work adds usage after the Capability runs and must reprice the canonical record with the same catalog behavior.
+
+```ts
+import { usageCost, vercelAiGatewayPricing } from '@vite-hub/agent/capabilities'
+
+const pricing = vercelAiGatewayPricing()
+```
+
 ## Read the enriched record
 
 Finish Hooks read the canonical record from `event.invocation.usage`. The Capability also returns that same object from its typed finish extension.

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -84,11 +84,13 @@ export {
 } from "./transcription-elevenlabs.ts"
 export {
   usageCost,
+  vercelAiGatewayPricing,
 } from "./usage-cost.ts"
 export type {
   AgentUsagePricing,
   AgentUsagePricingContext,
   UsageCostOptions,
+  VercelAiGatewayPricingOptions,
 } from "./usage-cost.ts"
 export {
   workspaceShell,

--- a/packages/agent/src/capabilities/usage-cost.ts
+++ b/packages/agent/src/capabilities/usage-cost.ts
@@ -4,9 +4,13 @@ import { vercelAiGatewayPricing } from "../internal/usage-pricing.ts"
 import type { AgentCapabilityDefinition, AgentRuntimeConfig, AgentUsageRecord } from "../types.ts"
 import type { AgentUsagePricing } from "../internal/usage-pricing.ts"
 
+export {
+  vercelAiGatewayPricing,
+} from "../internal/usage-pricing.ts"
 export type {
   AgentUsagePricing,
   AgentUsagePricingContext,
+  VercelAiGatewayPricingOptions,
 } from "../internal/usage-pricing.ts"
 
 export interface UsageCostOptions {

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -23,7 +23,7 @@ interface StaticModelPrice {
   output?: string
 }
 
-interface VercelAiGatewayPricingOptions {
+export interface VercelAiGatewayPricingOptions {
   maxAge?: number
   fetch?: typeof fetch
   modelsUrl?: string

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from "vitest"
 
 import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelDeliveryReplyStream, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentMessageDeliveryKind, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUIMessageStreamProjection, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
-import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, repositoryHost, repositoryHostContext, sandbox, schedule, skills, streamTranscription, subagents, transcribe, usageCost, webSearch, workspaceShell, type AgentUsagePricing, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput, type UsageCostOptions } from "../src/capabilities.ts"
+import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, repositoryHost, repositoryHostContext, sandbox, schedule, skills, streamTranscription, subagents, transcribe, usageCost, vercelAiGatewayPricing, webSearch, workspaceShell, type AgentUsagePricing, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput, type UsageCostOptions, type VercelAiGatewayPricingOptions } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
 import { remoteMcpServer } from "../src/mcp.ts"
@@ -38,8 +38,10 @@ describe("agent public types", () => {
       }
     }) satisfies AgentUsagePricing
     const options = { pricing } satisfies UsageCostOptions
+    const gatewayPricingOptions = { timeout: 5_000 } satisfies VercelAiGatewayPricingOptions
 
     expectTypeOf(usageCost(options)).toMatchTypeOf<AgentCapabilityDefinition>()
+    expectTypeOf(vercelAiGatewayPricing(gatewayPricingOptions)).toMatchTypeOf<AgentUsagePricing>()
     defineAgent({
       capabilities: [usageCost(options)],
       driver: { run: () => "ok" },


### PR DESCRIPTION
Exports `vercelAiGatewayPricing()` and its options from the public Agent Capabilities surface so applications that add usage after `usageCost()` runs can reprice the canonical record without reproducing ViteHub's catalog logic.

The default Capability behavior is unchanged. Public type coverage pins the export, the docs show the reuse boundary, and the Agent test suite passes with 68 files and 1,574 tests.
