### PR TITLE
fix(database): type Cloudflare environment bridge

### DIFF
--- a/packages/database/src/nuxt.ts
+++ b/packages/database/src/nuxt.ts
@@ -256,7 +256,7 @@ async function installNitroCloudflareEnvBridge(config: Record<string, unknown>, 
     "",
     "export default defineMiddleware((event) => {",
     "  const target = event as { env?: Record<string, unknown>, context?: { cloudflare?: { env?: Record<string, unknown> }, _platform?: { cloudflare?: { env?: Record<string, unknown> } } }, req?: { runtime?: { cloudflare?: { env?: Record<string, unknown> } } } }",
-    "  setActiveCloudflareEnv(target.env ?? target.context?.cloudflare?.env ?? target.context?._platform?.cloudflare?.env ?? target.req?.runtime?.cloudflare?.env ?? vitehubEnv)",
+    "  setActiveCloudflareEnv(target.env ?? target.context?.cloudflare?.env ?? target.context?._platform?.cloudflare?.env ?? target.req?.runtime?.cloudflare?.env ?? (vitehubEnv as unknown as Record<string, unknown>))",
     "})",
     "",
   ].join("\n"))

--- a/packages/database/test/nuxt.test.ts
+++ b/packages/database/test/nuxt.test.ts
@@ -148,8 +148,9 @@ describe("Database Nuxt integration", () => {
         },
       },
     })
-    await expect(readFile("/tmp/vitehub-db-nuxt/.vitehub/nitro/database/middleware.ts", "utf8"))
-      .resolves.toContain("setActiveCloudflareEnv")
+    const middleware = await readFile("/tmp/vitehub-db-nuxt/.vitehub/nitro/database/middleware.ts", "utf8")
+    expect(middleware).toContain("setActiveCloudflareEnv")
+    expect(middleware).toContain("vitehubEnv as unknown as Record<string, unknown>")
   })
 
   it("aliases the hosted runtime from the Nuxt source directory", async () => {


### PR DESCRIPTION
Narrows Cloudflare's generated Worker `Env` interface to ViteHub's record-shaped runtime environment at the generated Nuxt bridge. Without the explicit boundary, consuming Nuxt applications fail typecheck because Cloudflare's concrete interface intentionally has no string index signature.

Runtime behavior is unchanged. The Database suite passes with 12 files and 102 tests, including a regression assertion on the generated middleware.
