### PR TITLE
feat(agent): sync channel webhooks from CLI

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -122,7 +122,7 @@ Set `routes.discordGateway: true` on `hubAgent()` when the deployment needs a ge
 
 ## Telegram
 
-Use `telegram()` with Telegram credentials and admission settings. ViteHub creates the Chat SDK adapter, registers the webhook with Telegram's secret header, and keeps generic webhook plumbing out of the Agent Definition. Pass `adapter` as an escape hatch for an app-owned adapter.
+Use `telegram()` with Telegram credentials and admission settings. ViteHub creates the Chat SDK adapter and exposes a verified webhook route; the ViteHub CLI synchronizes that deployed route with Telegram. Pass `adapter` as an escape hatch when the application owns both the adapter and its provider lifecycle.
 
 ```ts [server/agents/support.ts]
 import { defineAgent } from '@vite-hub/agent'
@@ -139,6 +139,21 @@ export default defineAgent({
   driver: { run: () => 'ok' },
 })
 ```
+
+Deploy the target stage, then inspect its provider registration plan. The public URL must be an HTTPS origin, and ViteHub verifies the deployed route before it contacts Telegram for the current webhook state.
+
+```bash [Terminal]
+pnpm vitehub channels sync \
+  --stage staging \
+  --url https://staging.example.com \
+  --agent support \
+  --channel telegram \
+  --json
+```
+
+The dry run is the default. Apply the reviewed plan only with `--apply` and an exact `--confirm-origin https://staging.example.com`; this prevents a local default or stale preview URL from becoming the bot's production webhook. Keep `TELEGRAM_BOT_TOKEN` and `TELEGRAM_WEBHOOK_SECRET_TOKEN` in Server Env because the command never accepts or prints credentials.
+
+Telegram does not return the webhook secret or allowed update list from `getWebhookInfo`, so the plan reports those fields as unverifiable. Pass `--force` when you need to reapply them even though the registered URL matches. See [CLI](/docs/development/cli#synchronize-channel-webhooks) for apply and deletion safeguards.
 
 For a long-running host, set `mode: 'polling'` and mount `createTelegramPollingRouteHandler(agent)` on a protected `GET` route that the host calls once at startup. The handler initializes every polling Telegram Channel, starts the official adapter's long-poll loop, and is idempotent within the process. Polling disables the Telegram webhook route and is not suitable for request-isolated serverless workers.
 

--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -23,12 +23,13 @@ Libraries and advanced integrations that do not use the framework distribution
 can install `@vite-hub/cli` directly.
 
 Expected help lists available namespaces.
-The Agent Package contributes `agent` when `hubAgent()` is active, Database contributes `db` when `hubDb()` is active, Workspace contributes `workspace` when `hubWorkspace()` is active, and the CLI includes the built-in `provision` namespace.
+The Agent Package contributes `agent` and `channels` when `hubAgent()` is active, Database contributes `db` when `hubDb()` is active, Workspace contributes `workspace` when `hubWorkspace()` is active, and the CLI includes the built-in `provision` namespace.
 
 ```txt [Output]
 Usage: vitehub <namespace> <feature> [args...]
 Available namespaces:
   agent       Agent development workflows.
+  channels    External Channel registration workflows.
   db          Database development workflows.
   workspace   Workspace development workflows.
   provision   Idempotently create missing provider resources.
@@ -41,10 +42,42 @@ Available namespaces:
 | `vitehub agent eval` | Opt-in tooling | Agent Package | Run discovered Agent Evals through ViteHub defaults. |
 | `vitehub agent info` | Available | Agent Package | Inspect resolved Agent metadata through a running Vite Development Server. |
 | `vitehub agent dev` | Available | Agent Package | Talk to a discovered Agent through a running Vite Development Server. |
+| `vitehub channels sync` | Available | Agent Package | Inspect or apply provider-owned webhook registrations for a deployed stage. |
 | `vitehub db generate` | Available | Database Package | Refresh generated Database artifacts and generate Drizzle migrations. |
 | `vitehub db migrate` | Available | Database Package | Refresh generated Database artifacts and apply Drizzle migrations. |
 | `vitehub workspace dev` | Available | Workspace Package | Run commands through a Workspace Session exposed by a Compatible Vite Development Server. |
 | `vitehub provision run` | Available | ViteHub CLI plus package Provision Steps | Create missing provider resources idempotently. |
+
+## Synchronize Channel webhooks
+
+Deploy the application stage before registering its Channel webhooks. `channels sync` loads the discovered Agent Definitions with the selected Vite stage, checks that every desired webhook route is live at the exact public HTTPS origin, and then compares the provider state. Telegram is the first supported provider.
+
+The command is read-only by default. Start with sanitized JSON when an agent or another command needs to review the complete plan.
+
+```bash [Terminal]
+pnpm vitehub channels sync \
+  --stage staging \
+  --url https://staging.example.com \
+  --json
+```
+
+`--stage staging` loads Vite's stage-specific environment files, such as `.env.staging`; existing process environment values take precedence. Keep the Telegram bot token and webhook secret in Server Env. The command does not accept credentials as flags and does not include them in human or JSON output.
+
+Apply the reviewed plan by repeating the exact origin in `--confirm-origin`. The confirmation is non-interactive, so the same contract works for developers, CI, and coding agents without silently selecting a deployment.
+
+```bash [Terminal]
+pnpm vitehub channels sync \
+  --stage staging \
+  --url https://staging.example.com \
+  --apply \
+  --confirm-origin https://staging.example.com
+```
+
+Use `--agent <name>` or `--channel <id>` to narrow a multi-Agent application. Switching a Telegram Channel to polling, or setting `webhooks: false`, plans removal of an existing Telegram webhook; applying that plan also requires `--allow-delete`, and the current provider URL must belong to the confirmed origin. ViteHub preserves pending updates during registration and removal.
+
+Telegram exposes the registered URL and delivery errors through `getWebhookInfo`, but it does not return the configured secret token or allowed update list. The plan marks those fields as unverifiable. Use `--force` to reapply them when the URL already matches and credential or subscription configuration changed. Telegram accepts public webhook ports 443, 80, 88, and 8443; the CLI rejects other explicit ports before applying.
+
+`channels sync` owns only the provider's mechanical registration. The first Telegram synchronizer subscribes to message updates because that is the built-in Channel's supported inbound event. Admission rules, allowed users, secrets, and additional update types remain in the application. An app that needs a custom adapter, certificate, fixed IP, or connection policy must keep the provider lifecycle application-owned; an app-owned `adapter` is not a synchronization target.
 
 ## Manage Database migrations
 

--- a/docs/skills/vitehub/references/channels-triggers.md
+++ b/docs/skills/vitehub/references/channels-triggers.md
@@ -14,6 +14,10 @@ Use official Channel helpers when the installed contract provides them. Create a
 
 Treat webhook secrets and installation tokens as server-only Env. Keep generated routes inspectable and document the exact local or deployed URL used for proof.
 
+For initial setup of a built-in Telegram Channel, discover the installed contract with `pnpm vitehub channels sync --help` after the application stage is deployed. Run `pnpm vitehub channels sync --stage <stage> --url <https-origin> --json` first; it is read-only, loads the stage-specific Vite environment, and verifies the deployed webhook route before inspecting Telegram.
+
+Apply a reviewed registration only when the task explicitly authorizes provider mutation, using `--apply --confirm-origin <the-same-https-origin>`. Never infer the stage or origin, pass provider credentials as arguments, or expose Env values in output. A planned deletion also needs explicit intent and `--allow-delete`; switching Telegram to polling or `webhooks: false` can produce that plan. Keep custom adapter registration and product policy application-owned.
+
 ## Proof
 
 Exercise the generated or custom webhook with a verified event, observe the Agent Invocation, and confirm the expected external delivery or persisted message. A route existing in Provider Output is not proof that admission and delivery work.

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -2080,6 +2080,7 @@ export function telegram<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntim
   return withAgentChannelSyncDefinition<TRuntimeConfig>(channel, {
     provider: "telegram",
     async resolve(context, resolvedChannel) {
+      if (resolvedChannel.adapter !== channel.adapter) return
       const resolvedWebhooks = resolvedChannel.webhooks
       const registration = Array.isArray(resolvedWebhooks)
         ? resolvedWebhooks.length === 1 ? resolvedWebhooks[0] : undefined

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -43,6 +43,8 @@ import type {
   PublishedAgentDeliveryArtifact,
 } from "./types.ts"
 import { defineMessageChannelInstructions } from "./internal/channels.ts"
+import { withAgentChannelSyncDefinition } from "./internal/channel-sync.ts"
+import { createTelegramChannelSyncProvider } from "./internal/telegram-channel-sync.ts"
 import type { PullRequestContextValue } from "./capabilities/repository-host-context.ts"
 import type { AgentChannelChatRouteBody, AgentChannelChatRouteHandlerOptions } from "./server.ts"
 import type { TelegramAdapterConfig } from "@chat-adapter/telegram"
@@ -2066,7 +2068,7 @@ export function telegram<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntim
   const webhookOptions = webhookSecret !== undefined
     ? { secretToken: telegramWebhookSecretToken(webhookSecret) }
     : webhooks
-  return defineMessageChannelInstructions(defineChannel("telegram", {
+  const channel = defineMessageChannelInstructions(defineChannel("telegram", {
     ...channelOptions,
     adapter: telegramAdapterResolver(options),
     ...(mode === "polling" ? { listener: { kind: "telegram-polling" } } : {}),
@@ -2074,6 +2076,39 @@ export function telegram<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntim
       ? false
       : telegramWebhookDefaults(webhookOptions),
   }), "Write the final response for Telegram. Match the language of the user's latest message. Prefer short paragraphs or bullets and keep the answer concise. Do not use Markdown tables; express rows as bullets because Telegram fallback delivery exposes table syntax. Avoid decorative emoji, redundant restatement, and generic follow-up questions. Follow the Agent's own instructions when they require a different format.")
+  if (options.adapter) return channel
+  const syncMode = mode === "polling" || webhooks === false ? "disabled" : "webhook"
+  return withAgentChannelSyncDefinition<TRuntimeConfig>(channel, {
+    mode: syncMode,
+    provider: "telegram",
+    async resolve(context) {
+      const registration = Array.isArray(webhookOptions)
+        ? webhookOptions.length === 1 ? webhookOptions[0] : undefined
+        : webhookOptions && typeof webhookOptions === "object" ? webhookOptions : undefined
+      const secret = webhookSecret ?? (
+        registration?.secretToken
+      )
+      const [apiBaseUrl, apiUrl, botToken, secretToken] = await Promise.all([
+        options.apiBaseUrl === undefined ? undefined : resolveRuntimeValue(options.apiBaseUrl, context),
+        options.apiUrl === undefined ? undefined : resolveRuntimeValue(options.apiUrl, context),
+        options.botToken === undefined ? undefined : resolveRuntimeValue(options.botToken, context),
+        secret === undefined ? undefined : resolveRuntimeValue(secret, context),
+      ])
+      const resolvedBotToken = cleanSecret(botToken) || cleanSecret(process.env.TELEGRAM_BOT_TOKEN)
+      if (!resolvedBotToken) {
+        throw new TypeError("[vitehub] Telegram Channel synchronization requires telegram({ botToken }) or TELEGRAM_BOT_TOKEN.")
+      }
+      const resolvedSecretToken = secretToken === false
+        ? undefined
+        : cleanSecret(secretToken) || cleanSecret(process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN)
+      return createTelegramChannelSyncProvider({
+        apiBaseUrl: cleanSecret(apiUrl) || cleanSecret(apiBaseUrl) || cleanSecret(process.env.TELEGRAM_API_BASE_URL),
+        botToken: resolvedBotToken,
+        mode: syncMode,
+        ...(resolvedSecretToken ? { secretToken: resolvedSecretToken } : {}),
+      })
+    },
+  })
 }
 
 export function webChat<

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -2077,17 +2077,14 @@ export function telegram<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntim
       : telegramWebhookDefaults(webhookOptions),
   }), "Write the final response for Telegram. Match the language of the user's latest message. Prefer short paragraphs or bullets and keep the answer concise. Do not use Markdown tables; express rows as bullets because Telegram fallback delivery exposes table syntax. Avoid decorative emoji, redundant restatement, and generic follow-up questions. Follow the Agent's own instructions when they require a different format.")
   if (options.adapter) return channel
-  const syncMode = mode === "polling" || webhooks === false ? "disabled" : "webhook"
   return withAgentChannelSyncDefinition<TRuntimeConfig>(channel, {
-    mode: syncMode,
     provider: "telegram",
-    async resolve(context) {
-      const registration = Array.isArray(webhookOptions)
-        ? webhookOptions.length === 1 ? webhookOptions[0] : undefined
-        : webhookOptions && typeof webhookOptions === "object" ? webhookOptions : undefined
-      const secret = webhookSecret ?? (
-        registration?.secretToken
-      )
+    async resolve(context, resolvedChannel) {
+      const resolvedWebhooks = resolvedChannel.webhooks
+      const registration = Array.isArray(resolvedWebhooks)
+        ? resolvedWebhooks.length === 1 ? resolvedWebhooks[0] : undefined
+        : resolvedWebhooks && typeof resolvedWebhooks === "object" ? resolvedWebhooks : undefined
+      const secret = registration?.secretToken
       const [apiBaseUrl, apiUrl, botToken, secretToken] = await Promise.all([
         options.apiBaseUrl === undefined ? undefined : resolveRuntimeValue(options.apiBaseUrl, context),
         options.apiUrl === undefined ? undefined : resolveRuntimeValue(options.apiUrl, context),
@@ -2104,7 +2101,9 @@ export function telegram<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntim
       return createTelegramChannelSyncProvider({
         apiBaseUrl: cleanSecret(apiUrl) || cleanSecret(apiBaseUrl) || cleanSecret(process.env.TELEGRAM_API_BASE_URL),
         botToken: resolvedBotToken,
-        mode: syncMode,
+        mode: resolvedChannel.listener?.kind === "telegram-polling" || resolvedWebhooks === false
+          ? "disabled"
+          : "webhook",
         ...(resolvedSecretToken ? { secretToken: resolvedSecretToken } : {}),
       })
     },

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -54,7 +54,6 @@ interface AgentCliContributorOptions {
   eval?: AgentEvalOptions
   rootDir?: string
   serverDirs?: string[]
-  webhookRoute?: false | string
 }
 
 interface ParsedEvalArgs {
@@ -1331,7 +1330,6 @@ export function createAgentCliContributor(options?: false | AgentCliContributorO
           run: async (args, context) => await runAgentChannelSyncCli(args, context, {
             rootDir: options?.rootDir,
             serverDirs: options?.serverDirs,
-            webhookRoute: options?.webhookRoute,
           }),
           usage: "vitehub channels sync --stage <name> --url <https-origin> [--apply --confirm-origin <https-origin>]",
         }],

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -1329,7 +1329,6 @@ export function createAgentCliContributor(options?: false | AgentCliContributorO
           name: "sync",
           run: async (args, context) => await runAgentChannelSyncCli(args, context, {
             rootDir: options?.rootDir,
-            serverDirs: options?.serverDirs,
           }),
           usage: "vitehub channels sync --stage <name> --url <https-origin> [--apply --confirm-origin <https-origin>]",
         }],

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -6,6 +6,7 @@ import { readWorkspaceDevToken, workspaceDevTokenHeader } from "@vite-hub/worksp
 import { formatAgentError } from "./agent-error.ts"
 import { createAgentEvalInclude, discoverAgentEvalFiles } from "./discovery.ts"
 import { runAgentInfoCli } from "./internal/agent-info-cli.ts"
+import { runAgentChannelSyncCli } from "./internal/channel-sync-cli.ts"
 import { vercelAiGatewayPricing, type AgentUsagePricing } from "./internal/usage-pricing.ts"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig, type ResolvedAgentEvalOptions } from "./internal/evalite-config.ts"
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute, readAgentInvocationStream } from "./invocation-stream.ts"
@@ -53,6 +54,7 @@ interface AgentCliContributorOptions {
   eval?: AgentEvalOptions
   rootDir?: string
   serverDirs?: string[]
+  webhookRoute?: false | string
 }
 
 interface ParsedEvalArgs {
@@ -1315,11 +1317,27 @@ export function createAgentCliContributor(options?: false | AgentCliContributorO
     })
   }
   return {
-    namespaces: [{
-      description: "Agent development workflows.",
-      features,
-      name: "agent",
-    }],
+    namespaces: [
+      {
+        description: "Agent development workflows.",
+        features,
+        name: "agent",
+      },
+      {
+        description: "External Channel registration workflows.",
+        features: [{
+          description: "Inspect and synchronize provider-owned Channel webhooks for a deployed stage.",
+          name: "sync",
+          run: async (args, context) => await runAgentChannelSyncCli(args, context, {
+            rootDir: options?.rootDir,
+            serverDirs: options?.serverDirs,
+            webhookRoute: options?.webhookRoute,
+          }),
+          usage: "vitehub channels sync --stage <name> --url <https-origin> [--apply --confirm-origin <https-origin>]",
+        }],
+        name: "channels",
+      },
+    ],
   }
 }
 

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -251,7 +251,9 @@ async function loadChannelSyncTargets(
 ): Promise<LoadedChannelSyncTarget[]> {
   const { createServer, loadEnv } = await import("vite")
   let server: Awaited<ReturnType<typeof createServer>> | undefined
-  const previousEnvironment = new Map<string, string>()
+  const previousEnvironment = new Map(
+    Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  )
   try {
     server = await createServer({
       appType: "custom",
@@ -260,10 +262,7 @@ async function loadChannelSyncTargets(
       root: input.rootDir,
       server: { hmr: false, middlewareMode: true },
     })
-    for (const [key, value] of Object.entries(process.env)) {
-      if (value !== undefined) previousEnvironment.set(key, value)
-      delete process.env[key]
-    }
+    for (const key of Object.keys(process.env)) delete process.env[key]
     for (const [key, value] of Object.entries(input.env)) {
       if (value !== undefined) process.env[key] = value
     }
@@ -286,13 +285,14 @@ async function loadChannelSyncTargets(
         if (input.channel && channelId !== input.channel) continue
         const syncDefinition = getAgentChannelSyncDefinition(channel)
         if (!syncDefinition) continue
+        const sync = await syncDefinition.resolve(context, channel)
         targets.push({
           agent: loaded.identity.name,
           channel: channelId,
-          mode: syncDefinition.mode,
+          mode: sync.mode,
           provider: syncDefinition.provider,
           registration: channelRegistration(channelId, channel),
-          sync: await syncDefinition.resolve(context),
+          sync,
         })
       }
     }

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -272,6 +272,8 @@ async function loadChannelSyncTargets(
     Object.entries(input.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
   )
   try {
+    for (const key of Object.keys(process.env)) delete process.env[key]
+    for (const [key, value] of selectedEnvironment) process.env[key] = value
     server = await createServer({
       appType: "custom",
       logLevel: "silent",
@@ -279,8 +281,6 @@ async function loadChannelSyncTargets(
       root: input.rootDir,
       server: { hmr: false, middlewareMode: true },
     })
-    for (const key of Object.keys(process.env)) delete process.env[key]
-    for (const [key, value] of selectedEnvironment) process.env[key] = value
     const environment = {
       ...loadEnv(input.stage, server.config.envDir, ""),
       ...Object.fromEntries(selectedEnvironment),
@@ -482,7 +482,9 @@ export async function runAgentChannelSyncCli(
         channel: item.target.channel,
         current: sanitizedProviderState(item.plan.current),
         destructive: item.plan.destructive === true,
-        desired: item.plan.desired,
+        desired: item.target.registration?.url
+          ? sanitizedProviderState(item.plan.desired)
+          : item.plan.desired,
         preflight: item.preflight,
         provider: item.target.provider,
         ...(result ? { result: sanitizedProviderState(result) } : {}),

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -24,6 +24,8 @@ interface ChannelSyncCliOptions {
 }
 
 interface ChannelSyncLoadInput {
+  agent?: string
+  channel?: string
   rootDir: string
   serverDirs?: string[]
   stage: string
@@ -269,8 +271,10 @@ async function loadChannelSyncTargets(
     for (const definition of uniqueAgentDefinitions(input.rootDir, input.serverDirs)) {
       const loaded = await loadViteAgent(server, definition)
       if (!loaded?.agent.channels) continue
+      if (input.agent && loaded.identity.name !== input.agent) continue
       const context = createViteAgentDiscoveryContext(loaded.identity)
       for (const [channelId, channel] of Object.entries(loaded.agent.channels)) {
+        if (input.channel && channelId !== input.channel) continue
         const syncDefinition = getAgentChannelSyncDefinition(channel)
         if (!syncDefinition) continue
         targets.push({
@@ -376,6 +380,8 @@ export async function runAgentChannelSyncCli(
       options.webhookRoute === undefined ? defaultWebhookRoute : options.webhookRoute
     const loadTargets = options.loadTargets || loadChannelSyncTargets
     const allTargets = await loadTargets({
+      agent: parsed.agent,
+      channel: parsed.channel,
       rootDir: options.rootDir || context.rootDir,
       serverDirs: options.serverDirs,
       stage: parsed.stage,

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -1,5 +1,7 @@
 import { join } from "node:path"
 
+import { VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
+
 import { discoverAgentDefinitions } from "../discovery.ts"
 import { getAgentChannelSyncDefinition, agentChannelSyncProviderHeader } from "./channel-sync.ts"
 import { createViteAgentDiscoveryContext, loadViteAgent } from "../vite/runtime-adapter.ts"
@@ -19,7 +21,6 @@ interface ChannelSyncCliOptions {
   fetch?: typeof fetch
   loadTargets?: (input: ChannelSyncLoadInput) => Promise<LoadedChannelSyncTarget[]>
   rootDir?: string
-  serverDirs?: string[]
 }
 
 interface ChannelSyncLoadInput {
@@ -27,7 +28,6 @@ interface ChannelSyncLoadInput {
   channel?: string
   env: NodeJS.ProcessEnv
   rootDir: string
-  serverDirs?: string[]
   stage: string
 }
 
@@ -294,7 +294,11 @@ async function loadChannelSyncTargetsExclusive(
       process.env[key] = value
     }
     const targets: LoadedChannelSyncTarget[] = []
-    for (const definition of uniqueAgentDefinitions(input.rootDir, input.serverDirs)) {
+    const stageRoot = server.config.root
+    const stageServerDirs = (server.config as typeof server.config & {
+      [VITEHUB_SERVER_DIRS]?: string[]
+    })[VITEHUB_SERVER_DIRS]
+    for (const definition of uniqueAgentDefinitions(stageRoot, stageServerDirs)) {
       if (input.agent && definition.name !== input.agent) continue
       const loaded = await loadViteAgent(server, definition)
       if (!loaded?.agent.channels) continue
@@ -433,7 +437,6 @@ export async function runAgentChannelSyncCli(
       channel: parsed.channel,
       env: context.env,
       rootDir: options.rootDir || context.rootDir,
-      serverDirs: options.serverDirs,
       stage: parsed.stage,
     })
     const targets = allTargets.filter(

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -254,6 +254,9 @@ async function loadChannelSyncTargets(
   const previousEnvironment = new Map(
     Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
   )
+  const selectedEnvironment = new Map(
+    Object.entries(input.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+  )
   try {
     server = await createServer({
       appType: "custom",
@@ -263,12 +266,10 @@ async function loadChannelSyncTargets(
       server: { hmr: false, middlewareMode: true },
     })
     for (const key of Object.keys(process.env)) delete process.env[key]
-    for (const [key, value] of Object.entries(input.env)) {
-      if (value !== undefined) process.env[key] = value
-    }
+    for (const [key, value] of selectedEnvironment) process.env[key] = value
     const environment = {
       ...loadEnv(input.stage, server.config.envDir, ""),
-      ...input.env,
+      ...Object.fromEntries(selectedEnvironment),
     }
     for (const [key, value] of Object.entries(environment)) {
       if (value === undefined) continue

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -273,6 +273,7 @@ async function loadChannelSyncTargets(
     }
     const targets: LoadedChannelSyncTarget[] = []
     for (const definition of uniqueAgentDefinitions(input.rootDir, input.serverDirs)) {
+      if (input.agent && definition.name !== input.agent) continue
       const loaded = await loadViteAgent(server, definition)
       if (!loaded?.agent.channels) continue
       if (input.agent && loaded.identity.name !== input.agent) continue

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -20,7 +20,6 @@ interface ChannelSyncCliOptions {
   loadTargets?: (input: ChannelSyncLoadInput) => Promise<LoadedChannelSyncTarget[]>
   rootDir?: string
   serverDirs?: string[]
-  webhookRoute?: false | string
 }
 
 interface ChannelSyncLoadInput {
@@ -30,7 +29,6 @@ interface ChannelSyncLoadInput {
   rootDir: string
   serverDirs?: string[]
   stage: string
-  webhookRoute: false | string
 }
 
 export interface LoadedChannelSyncTarget {
@@ -390,8 +388,6 @@ export async function runAgentChannelSyncCli(
         throw new TypeError("--confirm-origin must exactly match --url.")
     }
 
-    const webhookRoute =
-      options.webhookRoute === undefined ? defaultWebhookRoute : options.webhookRoute
     const loadTargets = options.loadTargets || loadChannelSyncTargets
     const allTargets = await loadTargets({
       agent: parsed.agent,
@@ -400,7 +396,6 @@ export async function runAgentChannelSyncCli(
       rootDir: options.rootDir || context.rootDir,
       serverDirs: options.serverDirs,
       stage: parsed.stage,
-      webhookRoute,
     })
     const targets = allTargets.filter(
       (target) =>
@@ -425,7 +420,7 @@ export async function runAgentChannelSyncCli(
     const fetchImpl = options.fetch || globalThis.fetch
     const planned: PlannedChannelSyncTarget[] = []
     for (const target of targets) {
-      const desiredUrl = desiredWebhookUrl(target, origin, webhookRoute)
+      const desiredUrl = desiredWebhookUrl(target, origin, defaultWebhookRoute)
       if (desiredUrl) await verifyDeployedWebhook(desiredUrl, target.provider, fetchImpl)
       const plan = await target.sync.plan({ desiredUrl, fetch: fetchImpl, force: parsed.force })
       planned.push({ plan, preflight: desiredUrl ? "verified" : "not-required", target })

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -389,6 +389,18 @@ export async function runAgentChannelSyncCli(
     if (!targets.length)
       throw new Error("No synchronizable Channels matched the selected Agent and Channel filters.")
 
+    const providerResources = new Map<unknown, LoadedChannelSyncTarget>()
+    for (const target of targets) {
+      if (target.sync.resourceKey === undefined) continue
+      const existing = providerResources.get(target.sync.resourceKey)
+      if (existing) {
+        throw new Error(
+          `Channels ${existing.agent}/${existing.channel} and ${target.agent}/${target.channel} target the same ${target.provider} resource.`,
+        )
+      }
+      providerResources.set(target.sync.resourceKey, target)
+    }
+
     const fetchImpl = options.fetch || globalThis.fetch
     const planned: PlannedChannelSyncTarget[] = []
     for (const target of targets) {
@@ -397,8 +409,8 @@ export async function runAgentChannelSyncCli(
       const plan = await target.sync.plan({ desiredUrl, fetch: fetchImpl, force: parsed.force })
       planned.push({ plan, preflight: desiredUrl ? "verified" : "not-required", target })
     }
-    const deletion = planned.find((item) => item.plan.action === "delete")
-    if (parsed.apply && deletion) {
+    const deletions = planned.filter((item) => item.plan.action === "delete")
+    if (parsed.apply) for (const deletion of deletions) {
       const currentUrl =
         typeof deletion.plan.current.url === "string" ? deletion.plan.current.url : ""
       if (currentUrl) {
@@ -410,6 +422,7 @@ export async function runAgentChannelSyncCli(
         }
       }
     }
+    const deletion = deletions[0]
     if (parsed.apply && deletion && !parsed.allowDelete) {
       throw new Error(
         `Channel ${deletion.target.agent}/${deletion.target.channel} requires deletion; rerun with --allow-delete after reviewing the plan.`,

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -92,6 +92,10 @@ function sanitizedProviderState(state: Record<string, unknown>): Record<string, 
   }
 }
 
+function sanitizedUrl(url: string): string {
+  return String(sanitizedProviderState({ url }).url)
+}
+
 const defaultWebhookRoute = "/api/_vitehub/agents/[agent]/webhooks/[webhook]"
 
 function writeChannelSyncUsage(context: ChannelSyncCliContext): void {
@@ -341,11 +345,11 @@ async function verifyDeployedWebhook(
     })
   }
   catch {
-    throw new Error(`Deployed webhook preflight request failed for ${url}.`)
+    throw new Error(`Deployed webhook preflight request failed for ${sanitizedUrl(url)}.`)
   }
   if (!response.ok || response.headers.get(agentChannelSyncProviderHeader) !== provider) {
     throw new Error(
-      `Deployed webhook preflight failed for ${url}; expected ${agentChannelSyncProviderHeader}: ${provider}.`,
+      `Deployed webhook preflight failed for ${sanitizedUrl(url)}; expected ${agentChannelSyncProviderHeader}: ${provider}.`,
     )
   }
 }
@@ -482,7 +486,7 @@ export async function runAgentChannelSyncCli(
         channel: item.target.channel,
         current: sanitizedProviderState(item.plan.current),
         destructive: item.plan.destructive === true,
-        desired: item.target.registration?.url
+        desired: item.target.registration?.url || item.target.registration?.path
           ? sanitizedProviderState(item.plan.desired)
           : item.plan.desired,
         preflight: item.preflight,

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -494,7 +494,7 @@ export async function runAgentChannelSyncCli(
         const resultUrl = typeof result.url === "string" ? result.url : undefined
         if (expectedUrl !== undefined && resultUrl !== expectedUrl) {
           throw new Error(
-            `Provider verification failed for ${item.target.agent}/${item.target.channel}; expected webhook URL ${expectedUrl || "<empty>"}.`,
+            `Provider verification failed for ${item.target.agent}/${item.target.channel}; expected webhook URL ${expectedUrl ? sanitizedUrl(expectedUrl) : "<empty>"}.`,
           )
         }
       }

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -253,7 +253,7 @@ async function loadChannelSyncTargets(
 ): Promise<LoadedChannelSyncTarget[]> {
   const { createServer, loadEnv } = await import("vite")
   let server: Awaited<ReturnType<typeof createServer>> | undefined
-  const previousEnvironment = new Map<string, string | undefined>()
+  const previousEnvironment = new Map<string, string>()
   try {
     server = await createServer({
       appType: "custom",
@@ -262,13 +262,19 @@ async function loadChannelSyncTargets(
       root: input.rootDir,
       server: { hmr: false, middlewareMode: true },
     })
+    for (const [key, value] of Object.entries(process.env)) {
+      if (value !== undefined) previousEnvironment.set(key, value)
+      delete process.env[key]
+    }
+    for (const [key, value] of Object.entries(input.env)) {
+      if (value !== undefined) process.env[key] = value
+    }
     const environment = {
       ...loadEnv(input.stage, server.config.envDir, ""),
       ...input.env,
     }
     for (const [key, value] of Object.entries(environment)) {
       if (value === undefined) continue
-      previousEnvironment.set(key, process.env[key])
       process.env[key] = value
     }
     const targets: LoadedChannelSyncTarget[] = []
@@ -299,9 +305,9 @@ async function loadChannelSyncTargets(
       await server?.close()
     }
     finally {
+      for (const key of Object.keys(process.env)) delete process.env[key]
       for (const [key, value] of previousEnvironment) {
-        if (value === undefined) delete process.env[key]
-        else process.env[key] = value
+        process.env[key] = value
       }
     }
   }

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -416,14 +416,15 @@ export async function runAgentChannelSyncCli(
       planned.push({ plan, preflight: desiredUrl ? "verified" : "not-required", target })
     }
     const deletions = planned.filter((item) => item.plan.action === "delete")
-    if (parsed.apply) for (const deletion of deletions) {
+    if (parsed.apply) for (const item of planned) {
+      if (item.plan.action !== "delete" && item.plan.action !== "update") continue
       const currentUrl =
-        typeof deletion.plan.current.url === "string" ? deletion.plan.current.url : ""
+        typeof item.plan.current.url === "string" ? item.plan.current.url : ""
       if (currentUrl) {
         const currentOrigin = httpsUrlOrigin(currentUrl, "current provider webhook URL").origin
         if (currentOrigin !== origin) {
           throw new Error(
-            `Channel ${deletion.target.agent}/${deletion.target.channel} deletion targets ${currentOrigin}, which does not match the confirmed deployment origin ${origin}.`,
+            `Channel ${item.target.agent}/${item.target.channel} ${item.plan.action} targets ${currentOrigin}, which does not match the confirmed deployment origin ${origin}.`,
           )
         }
       }

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -264,7 +264,7 @@ function uniqueAgentDefinitions(
   return [...unique.values()]
 }
 
-async function loadChannelSyncTargets(
+async function loadChannelSyncTargetsExclusive(
   input: ChannelSyncLoadInput,
 ): Promise<LoadedChannelSyncTarget[]> {
   const { createServer, loadEnv } = await import("vite")
@@ -328,6 +328,25 @@ async function loadChannelSyncTargets(
         process.env[key] = value
       }
     }
+  }
+}
+
+let channelSyncTargetLoadQueue: Promise<void> = Promise.resolve()
+
+async function loadChannelSyncTargets(
+  input: ChannelSyncLoadInput,
+): Promise<LoadedChannelSyncTarget[]> {
+  const previous = channelSyncTargetLoadQueue
+  let release!: () => void
+  channelSyncTargetLoadQueue = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  await previous
+  try {
+    return await loadChannelSyncTargetsExclusive(input)
+  }
+  finally {
+    release()
   }
 }
 

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -1,0 +1,461 @@
+import { join } from "node:path"
+
+import { discoverAgentDefinitions } from "../discovery.ts"
+import { getAgentChannelSyncDefinition, agentChannelSyncProviderHeader } from "./channel-sync.ts"
+import { createViteAgentDiscoveryContext, loadViteAgent } from "../vite/runtime-adapter.ts"
+
+import type { AgentChannelDefinition, DiscoveredAgentDefinition } from "../types.ts"
+import type { AgentChannelSyncPlan, AgentChannelSyncProvider } from "./channel-sync.ts"
+
+interface ChannelSyncCliContext {
+  cwd: string
+  env: NodeJS.ProcessEnv
+  rootDir: string
+  stderr: { write: (chunk: string | Uint8Array) => unknown }
+  stdout: { write: (chunk: string | Uint8Array) => unknown }
+}
+
+interface ChannelSyncCliOptions {
+  fetch?: typeof fetch
+  loadTargets?: (input: ChannelSyncLoadInput) => Promise<LoadedChannelSyncTarget[]>
+  rootDir?: string
+  serverDirs?: string[]
+  webhookRoute?: false | string
+}
+
+interface ChannelSyncLoadInput {
+  rootDir: string
+  serverDirs?: string[]
+  stage: string
+  webhookRoute: false | string
+}
+
+export interface LoadedChannelSyncTarget {
+  agent: string
+  channel: string
+  mode: "disabled" | "webhook"
+  provider: string
+  registration?: {
+    id: string
+    path?: string
+    url?: string
+  }
+  sync: AgentChannelSyncProvider
+}
+
+interface ParsedChannelSyncArgs {
+  agent?: string
+  allowDelete: boolean
+  apply: boolean
+  channel?: string
+  confirmOrigin?: string
+  dryRun: boolean
+  force: boolean
+  help: boolean
+  json: boolean
+  origin?: string
+  stage?: string
+}
+
+interface ChannelSyncResultRegistration {
+  action: AgentChannelSyncPlan["action"]
+  agent: string
+  applied: boolean
+  channel: string
+  current: Record<string, unknown>
+  destructive: boolean
+  desired: Record<string, unknown>
+  preflight: "not-required" | "verified"
+  provider: string
+  result?: Record<string, unknown>
+  unverifiable: string[]
+}
+
+interface PlannedChannelSyncTarget {
+  plan: AgentChannelSyncPlan
+  preflight: ChannelSyncResultRegistration["preflight"]
+  target: LoadedChannelSyncTarget
+}
+
+const defaultWebhookRoute = "/api/_vitehub/agents/[agent]/webhooks/[webhook]"
+
+function writeChannelSyncUsage(context: ChannelSyncCliContext): void {
+  context.stdout.write(
+    [
+      "Usage: vitehub channels sync --stage <name> --url <https-origin> [--agent <name>] [--channel <id>] [--json]",
+      "       vitehub channels sync --stage <name> --url <https-origin> --apply --confirm-origin <https-origin> [--allow-delete]",
+      "",
+      "Inspect and synchronize provider-owned Channel webhooks for one deployed stage.",
+      "The command is a dry run unless --apply is present.",
+      "",
+      "Options:",
+      "  --stage <name>             Load stage-specific Vite environment files.",
+      "  --url <https-origin>       Public origin of the deployed application.",
+      "  --agent <name>             Limit synchronization to one Agent.",
+      "  --channel <id>             Limit synchronization to one Channel.",
+      "  --apply                    Apply the complete validated plan.",
+      "  --confirm-origin <origin>  Confirm the exact deployment origin for --apply.",
+      "  --allow-delete             Permit a planned provider webhook deletion.",
+      "  --force                    Reapply registrations whose URL already matches.",
+      "  --dry-run                  Explicitly select the default read-only mode.",
+      "  --json                     Print one sanitized JSON result to stdout.",
+      "  -h, --help                 Show this help.",
+      "",
+    ].join("\n"),
+  )
+}
+
+function takeValue(args: string[], index: number, flag: string): [string, number] {
+  const value = args[index + 1]
+  if (!value || value.startsWith("--")) throw new TypeError(`${flag} requires a value.`)
+  return [value, index + 1]
+}
+
+function parseChannelSyncArgs(args: string[]): ParsedChannelSyncArgs {
+  const parsed: ParsedChannelSyncArgs = {
+    allowDelete: false,
+    apply: false,
+    dryRun: false,
+    force: false,
+    help: false,
+    json: false,
+  }
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]!
+    if (arg === "-h" || arg === "--help") parsed.help = true
+    else if (arg === "--allow-delete") parsed.allowDelete = true
+    else if (arg === "--apply") parsed.apply = true
+    else if (arg === "--dry-run") parsed.dryRun = true
+    else if (arg === "--force") parsed.force = true
+    else if (arg === "--json") parsed.json = true
+    else if (["--agent", "--channel", "--confirm-origin", "--stage", "--url"].includes(arg)) {
+      const [value, next] = takeValue(args, index, arg)
+      index = next
+      if (arg === "--agent") parsed.agent = value
+      else if (arg === "--channel") parsed.channel = value
+      else if (arg === "--confirm-origin") parsed.confirmOrigin = value
+      else if (arg === "--stage") parsed.stage = value
+      else parsed.origin = value
+    } else throw new TypeError(`Unknown channels sync option: ${arg}`)
+  }
+  return parsed
+}
+
+function httpsUrlOrigin(value: string, label: string): { origin: string; url: URL } {
+  let url: URL
+  try {
+    url = new URL(value)
+  }
+  catch {
+    throw new TypeError(`${label} must be a valid HTTPS URL.`)
+  }
+  if (url.protocol !== "https:" || url.username || url.password) {
+    throw new TypeError(`${label} must use HTTPS without credentials.`)
+  }
+  return { origin: url.origin, url }
+}
+
+function normalizeOrigin(value: string, flag: string): string {
+  const { origin, url } = httpsUrlOrigin(value, flag)
+  if (url.search || url.hash || (url.pathname !== "/" && url.pathname !== "")) {
+    throw new TypeError(
+      `${flag} must be an HTTPS origin without credentials, a path, query, or fragment.`,
+    )
+  }
+  return origin
+}
+
+function replaceRouteParams(route: string, agent: string, webhook: string): string {
+  return route
+    .replaceAll("[agent]", encodeURIComponent(agent))
+    .replaceAll(":agent", encodeURIComponent(agent))
+    .replaceAll("[webhook]", encodeURIComponent(webhook))
+    .replaceAll(":webhook", encodeURIComponent(webhook))
+}
+
+function desiredWebhookUrl(
+  target: LoadedChannelSyncTarget,
+  origin: string,
+  webhookRoute: false | string,
+): string | undefined {
+  if (target.mode === "disabled") return
+  if (!target.registration)
+    throw new TypeError(`Channel ${target.agent}/${target.channel} has no webhook registration.`)
+  const configured = target.registration.url || target.registration.path
+  const route = configured || webhookRoute
+  if (!route)
+    throw new TypeError(`Channel ${target.agent}/${target.channel} has no deployed webhook route.`)
+  const url = new URL(replaceRouteParams(route, target.agent, target.registration.id), `${origin}/`)
+  if (url.origin !== origin) {
+    throw new TypeError(
+      `Channel ${target.agent}/${target.channel} resolves outside the confirmed deployment origin.`,
+    )
+  }
+  return url.toString()
+}
+
+function channelRegistration(
+  channelId: string,
+  channel: AgentChannelDefinition,
+): LoadedChannelSyncTarget["registration"] {
+  const webhooks = channel.webhooks
+  if (webhooks === false) return
+  if (Array.isArray(webhooks)) {
+    if (webhooks.length !== 1) {
+      throw new TypeError(
+        `Telegram Channel ${channelId} must declare exactly one webhook registration.`,
+      )
+    }
+    const registration = webhooks[0]!
+    return {
+      id: registration.id || channelId,
+      ...(registration.path ? { path: registration.path } : {}),
+      ...(registration.url ? { url: registration.url } : {}),
+    }
+  }
+  if (webhooks && webhooks !== true) {
+    return {
+      id: webhooks.id || channelId,
+      ...(webhooks.path ? { path: webhooks.path } : {}),
+      ...(webhooks.url ? { url: webhooks.url } : {}),
+    }
+  }
+  return { id: channelId }
+}
+
+function uniqueAgentDefinitions(
+  rootDir: string,
+  serverDirs?: string[],
+): DiscoveredAgentDefinition[] {
+  const definitions = [
+    ...discoverAgentDefinitions({ mode: "vite-suffix", rootDir }),
+    ...discoverAgentDefinitions({
+      mode: "server-agents",
+      scanDirs: serverDirs || [join(rootDir, "server")],
+    }),
+  ]
+  const unique = new Map<string, DiscoveredAgentDefinition>()
+  for (const definition of definitions) {
+    const existing = unique.get(definition.name)
+    if (existing && existing.handler !== definition.handler) {
+      throw new TypeError(`Duplicate Agent name "${definition.name}" cannot be synchronized.`)
+    }
+    unique.set(definition.name, definition)
+  }
+  return [...unique.values()]
+}
+
+async function loadChannelSyncTargets(
+  input: ChannelSyncLoadInput,
+): Promise<LoadedChannelSyncTarget[]> {
+  const { createServer, loadEnv } = await import("vite")
+  const stageEnv = loadEnv(input.stage, input.rootDir, "")
+  const addedEnvironmentKeys: string[] = []
+  for (const [key, value] of Object.entries(stageEnv)) {
+    if (process.env[key] !== undefined) continue
+    process.env[key] = value
+    addedEnvironmentKeys.push(key)
+  }
+  let server: Awaited<ReturnType<typeof createServer>> | undefined
+  try {
+    server = await createServer({
+      appType: "custom",
+      logLevel: "silent",
+      mode: input.stage,
+      root: input.rootDir,
+      server: { hmr: false, middlewareMode: true },
+    })
+    const targets: LoadedChannelSyncTarget[] = []
+    for (const definition of uniqueAgentDefinitions(input.rootDir, input.serverDirs)) {
+      const loaded = await loadViteAgent(server, definition)
+      if (!loaded?.agent.channels) continue
+      const context = createViteAgentDiscoveryContext(loaded.identity)
+      for (const [channelId, channel] of Object.entries(loaded.agent.channels)) {
+        const syncDefinition = getAgentChannelSyncDefinition(channel)
+        if (!syncDefinition) continue
+        targets.push({
+          agent: loaded.identity.name,
+          channel: channelId,
+          mode: syncDefinition.mode,
+          provider: syncDefinition.provider,
+          registration: channelRegistration(channelId, channel),
+          sync: await syncDefinition.resolve(context),
+        })
+      }
+    }
+    return targets
+  }
+  finally {
+    try {
+      await server?.close()
+    }
+    finally {
+      for (const key of addedEnvironmentKeys) delete process.env[key]
+    }
+  }
+}
+
+async function verifyDeployedWebhook(
+  url: string,
+  provider: string,
+  fetchImpl: typeof fetch,
+): Promise<void> {
+  let response: Response
+  try {
+    response = await fetchImpl(url, {
+      method: "HEAD",
+      redirect: "error",
+      signal: AbortSignal.timeout(30_000),
+    })
+  }
+  catch {
+    throw new Error(`Deployed webhook preflight request failed for ${url}.`)
+  }
+  if (!response.ok || response.headers.get(agentChannelSyncProviderHeader) !== provider) {
+    throw new Error(
+      `Deployed webhook preflight failed for ${url}; expected ${agentChannelSyncProviderHeader}: ${provider}.`,
+    )
+  }
+}
+
+function writeHumanResult(
+  result: {
+    mode: "apply" | "dry-run"
+    origin: string
+    registrations: ChannelSyncResultRegistration[]
+    stage: string
+  },
+  context: ChannelSyncCliContext,
+): void {
+  context.stdout.write(
+    `Channel sync ${result.mode} for stage ${result.stage} at ${result.origin}\n`,
+  )
+  for (const registration of result.registrations) {
+    context.stdout.write(
+      `  ${registration.agent}/${registration.channel} (${registration.provider}): ${registration.action}${registration.applied ? " applied" : ""}\n`,
+    )
+    context.stdout.write(
+      `    Current URL: ${typeof registration.current.url === "string" && registration.current.url ? registration.current.url : "<none>"}\n`,
+    )
+    context.stdout.write(
+      `    Desired URL: ${typeof registration.desired.url === "string" && registration.desired.url ? registration.desired.url : "<none>"}\n`,
+    )
+    context.stdout.write(`    Deployed route: ${registration.preflight}\n`)
+    if (registration.unverifiable.length) {
+      context.stdout.write(`    Provider cannot verify: ${registration.unverifiable.join(", ")}\n`)
+    }
+  }
+}
+
+export async function runAgentChannelSyncCli(
+  args: string[],
+  context: ChannelSyncCliContext,
+  options: ChannelSyncCliOptions = {},
+): Promise<number> {
+  let parsed: ParsedChannelSyncArgs
+  try {
+    parsed = parseChannelSyncArgs(args)
+    if (parsed.help) {
+      writeChannelSyncUsage(context)
+      return 0
+    }
+    if (!parsed.stage) throw new TypeError("channels sync requires --stage <name>.")
+    if (!parsed.origin) throw new TypeError("channels sync requires --url <https-origin>.")
+    if (parsed.apply && parsed.dryRun)
+      throw new TypeError("--apply and --dry-run cannot be used together.")
+    const origin = normalizeOrigin(parsed.origin, "--url")
+    if (parsed.apply) {
+      if (!parsed.confirmOrigin)
+        throw new TypeError("--apply requires --confirm-origin <https-origin>.")
+      const confirmedOrigin = normalizeOrigin(parsed.confirmOrigin, "--confirm-origin")
+      if (confirmedOrigin !== origin)
+        throw new TypeError("--confirm-origin must exactly match --url.")
+    }
+
+    const webhookRoute =
+      options.webhookRoute === undefined ? defaultWebhookRoute : options.webhookRoute
+    const loadTargets = options.loadTargets || loadChannelSyncTargets
+    const allTargets = await loadTargets({
+      rootDir: options.rootDir || context.rootDir,
+      serverDirs: options.serverDirs,
+      stage: parsed.stage,
+      webhookRoute,
+    })
+    const targets = allTargets.filter(
+      (target) =>
+        (!parsed.agent || target.agent === parsed.agent) &&
+        (!parsed.channel || target.channel === parsed.channel),
+    )
+    if (!targets.length)
+      throw new Error("No synchronizable Channels matched the selected Agent and Channel filters.")
+
+    const fetchImpl = options.fetch || globalThis.fetch
+    const planned: PlannedChannelSyncTarget[] = []
+    for (const target of targets) {
+      const desiredUrl = desiredWebhookUrl(target, origin, webhookRoute)
+      if (desiredUrl) await verifyDeployedWebhook(desiredUrl, target.provider, fetchImpl)
+      const plan = await target.sync.plan({ desiredUrl, fetch: fetchImpl, force: parsed.force })
+      planned.push({ plan, preflight: desiredUrl ? "verified" : "not-required", target })
+    }
+    const deletion = planned.find((item) => item.plan.action === "delete")
+    if (parsed.apply && deletion) {
+      const currentUrl =
+        typeof deletion.plan.current.url === "string" ? deletion.plan.current.url : ""
+      if (currentUrl) {
+        const currentOrigin = httpsUrlOrigin(currentUrl, "current provider webhook URL").origin
+        if (currentOrigin !== origin) {
+          throw new Error(
+            `Channel ${deletion.target.agent}/${deletion.target.channel} deletion targets ${currentOrigin}, which does not match the confirmed deployment origin ${origin}.`,
+          )
+        }
+      }
+    }
+    if (parsed.apply && deletion && !parsed.allowDelete) {
+      throw new Error(
+        `Channel ${deletion.target.agent}/${deletion.target.channel} requires deletion; rerun with --allow-delete after reviewing the plan.`,
+      )
+    }
+
+    const registrations: ChannelSyncResultRegistration[] = []
+    for (const item of planned) {
+      const result = parsed.apply ? await item.target.sync.apply(item.plan, fetchImpl) : undefined
+      if (result) {
+        const expectedUrl =
+          typeof item.plan.desired.url === "string" ? item.plan.desired.url : undefined
+        const resultUrl = typeof result.url === "string" ? result.url : undefined
+        if (expectedUrl !== undefined && resultUrl !== expectedUrl) {
+          throw new Error(
+            `Provider verification failed for ${item.target.agent}/${item.target.channel}; expected webhook URL ${expectedUrl || "<empty>"}.`,
+          )
+        }
+      }
+      registrations.push({
+        action: item.plan.action,
+        agent: item.target.agent,
+        applied: parsed.apply && item.plan.action !== "none",
+        channel: item.target.channel,
+        current: item.plan.current,
+        destructive: item.plan.destructive === true,
+        desired: item.plan.desired,
+        preflight: item.preflight,
+        provider: item.target.provider,
+        ...(result ? { result } : {}),
+        unverifiable: item.plan.unverifiable || [],
+      })
+    }
+    const output = {
+      mode: parsed.apply ? ("apply" as const) : ("dry-run" as const),
+      origin,
+      registrations,
+      schemaVersion: 1,
+      stage: parsed.stage,
+    }
+    if (parsed.json) context.stdout.write(`${JSON.stringify(output)}\n`)
+    else writeHumanResult(output, context)
+    return 0
+  }
+  catch (error) {
+    context.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    return 1
+  }
+}

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -26,6 +26,7 @@ interface ChannelSyncCliOptions {
 interface ChannelSyncLoadInput {
   agent?: string
   channel?: string
+  env: NodeJS.ProcessEnv
   rootDir: string
   serverDirs?: string[]
   stage: string
@@ -251,14 +252,8 @@ async function loadChannelSyncTargets(
   input: ChannelSyncLoadInput,
 ): Promise<LoadedChannelSyncTarget[]> {
   const { createServer, loadEnv } = await import("vite")
-  const stageEnv = loadEnv(input.stage, input.rootDir, "")
-  const addedEnvironmentKeys: string[] = []
-  for (const [key, value] of Object.entries(stageEnv)) {
-    if (process.env[key] !== undefined) continue
-    process.env[key] = value
-    addedEnvironmentKeys.push(key)
-  }
   let server: Awaited<ReturnType<typeof createServer>> | undefined
+  const previousEnvironment = new Map<string, string | undefined>()
   try {
     server = await createServer({
       appType: "custom",
@@ -267,6 +262,15 @@ async function loadChannelSyncTargets(
       root: input.rootDir,
       server: { hmr: false, middlewareMode: true },
     })
+    const environment = {
+      ...loadEnv(input.stage, server.config.envDir, ""),
+      ...input.env,
+    }
+    for (const [key, value] of Object.entries(environment)) {
+      if (value === undefined) continue
+      previousEnvironment.set(key, process.env[key])
+      process.env[key] = value
+    }
     const targets: LoadedChannelSyncTarget[] = []
     for (const definition of uniqueAgentDefinitions(input.rootDir, input.serverDirs)) {
       const loaded = await loadViteAgent(server, definition)
@@ -294,7 +298,10 @@ async function loadChannelSyncTargets(
       await server?.close()
     }
     finally {
-      for (const key of addedEnvironmentKeys) delete process.env[key]
+      for (const [key, value] of previousEnvironment) {
+        if (value === undefined) delete process.env[key]
+        else process.env[key] = value
+      }
     }
   }
 }
@@ -382,6 +389,7 @@ export async function runAgentChannelSyncCli(
     const allTargets = await loadTargets({
       agent: parsed.agent,
       channel: parsed.channel,
+      env: context.env,
       rootDir: options.rootDir || context.rootDir,
       serverDirs: options.serverDirs,
       stage: parsed.stage,

--- a/packages/agent/src/internal/channel-sync-cli.ts
+++ b/packages/agent/src/internal/channel-sync-cli.ts
@@ -78,6 +78,20 @@ interface PlannedChannelSyncTarget {
   target: LoadedChannelSyncTarget
 }
 
+function sanitizedProviderState(state: Record<string, unknown>): Record<string, unknown> {
+  if (typeof state.url !== "string" || !state.url) return state
+  try {
+    const url = new URL(state.url)
+    if (!url.username && !url.password && !url.search && !url.hash && url.pathname === "/") {
+      return state
+    }
+    return { ...state, url: `${url.origin}/[redacted]` }
+  }
+  catch {
+    return { ...state, url: "[redacted]" }
+  }
+}
+
 const defaultWebhookRoute = "/api/_vitehub/agents/[agent]/webhooks/[webhook]"
 
 function writeChannelSyncUsage(context: ChannelSyncCliContext): void {
@@ -287,6 +301,7 @@ async function loadChannelSyncTargets(
         const syncDefinition = getAgentChannelSyncDefinition(channel)
         if (!syncDefinition) continue
         const sync = await syncDefinition.resolve(context, channel)
+        if (!sync) continue
         targets.push({
           agent: loaded.identity.name,
           channel: channelId,
@@ -465,12 +480,12 @@ export async function runAgentChannelSyncCli(
         agent: item.target.agent,
         applied: parsed.apply && item.plan.action !== "none",
         channel: item.target.channel,
-        current: item.plan.current,
+        current: sanitizedProviderState(item.plan.current),
         destructive: item.plan.destructive === true,
         desired: item.plan.desired,
         preflight: item.preflight,
         provider: item.target.provider,
-        ...(result ? { result } : {}),
+        ...(result ? { result: sanitizedProviderState(result) } : {}),
         unverifiable: item.plan.unverifiable || [],
       })
     }

--- a/packages/agent/src/internal/channel-sync.ts
+++ b/packages/agent/src/internal/channel-sync.ts
@@ -44,6 +44,7 @@ export function withAgentChannelSyncDefinition<
 >(channel: TChannel, definition: AgentChannelSyncDefinition<TRuntimeConfig>): TChannel {
   Object.defineProperty(channel, agentChannelSyncDefinition, {
     configurable: true,
+    enumerable: true,
     value: definition,
   })
   return channel

--- a/packages/agent/src/internal/channel-sync.ts
+++ b/packages/agent/src/internal/channel-sync.ts
@@ -19,6 +19,7 @@ export interface AgentChannelSyncPlan {
 
 export interface AgentChannelSyncProvider {
   apply: (plan: AgentChannelSyncPlan, fetchImpl: typeof fetch) => Promise<Record<string, unknown>>
+  mode: "disabled" | "webhook"
   plan: (input: {
     desiredUrl?: string
     fetch: typeof fetch
@@ -31,9 +32,11 @@ export interface AgentChannelSyncProvider {
 export interface AgentChannelSyncDefinition<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
 > {
-  mode: "disabled" | "webhook"
   provider: string
-  resolve: (context: AgentCallbackContext<TRuntimeConfig>) => MaybePromise<AgentChannelSyncProvider>
+  resolve: (
+    context: AgentCallbackContext<TRuntimeConfig>,
+    channel: AgentChannelDefinition<TRuntimeConfig>,
+  ) => MaybePromise<AgentChannelSyncProvider>
 }
 
 const agentChannelSyncDefinition = Symbol.for("vitehub.agent.channelSyncDefinition")

--- a/packages/agent/src/internal/channel-sync.ts
+++ b/packages/agent/src/internal/channel-sync.ts
@@ -36,7 +36,7 @@ export interface AgentChannelSyncDefinition<
   resolve: (
     context: AgentCallbackContext<TRuntimeConfig>,
     channel: AgentChannelDefinition<TRuntimeConfig>,
-  ) => MaybePromise<AgentChannelSyncProvider>
+  ) => MaybePromise<AgentChannelSyncProvider | undefined>
 }
 
 const agentChannelSyncDefinition = Symbol.for("vitehub.agent.channelSyncDefinition")

--- a/packages/agent/src/internal/channel-sync.ts
+++ b/packages/agent/src/internal/channel-sync.ts
@@ -24,6 +24,8 @@ export interface AgentChannelSyncProvider {
     fetch: typeof fetch
     force: boolean
   }) => Promise<AgentChannelSyncPlan>
+  /** Opaque provider resource identity used only to reject conflicting local plans. */
+  resourceKey?: unknown
 }
 
 export interface AgentChannelSyncDefinition<

--- a/packages/agent/src/internal/channel-sync.ts
+++ b/packages/agent/src/internal/channel-sync.ts
@@ -1,0 +1,60 @@
+import type {
+  AgentCallbackContext,
+  AgentChannelDefinition,
+  AgentRuntimeConfig,
+  MaybePromise,
+} from "../types.ts"
+
+export const agentChannelSyncProviderHeader = "x-vitehub-channel-provider"
+
+export type AgentChannelSyncAction = "create" | "delete" | "none" | "update"
+
+export interface AgentChannelSyncPlan {
+  action: AgentChannelSyncAction
+  current: Record<string, unknown>
+  desired: Record<string, unknown>
+  destructive?: boolean
+  unverifiable?: string[]
+}
+
+export interface AgentChannelSyncProvider {
+  apply: (plan: AgentChannelSyncPlan, fetchImpl: typeof fetch) => Promise<Record<string, unknown>>
+  plan: (input: {
+    desiredUrl?: string
+    fetch: typeof fetch
+    force: boolean
+  }) => Promise<AgentChannelSyncPlan>
+}
+
+export interface AgentChannelSyncDefinition<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+> {
+  mode: "disabled" | "webhook"
+  provider: string
+  resolve: (context: AgentCallbackContext<TRuntimeConfig>) => MaybePromise<AgentChannelSyncProvider>
+}
+
+const agentChannelSyncDefinition = Symbol.for("vitehub.agent.channelSyncDefinition")
+
+export function withAgentChannelSyncDefinition<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  TChannel extends AgentChannelDefinition<TRuntimeConfig> = AgentChannelDefinition<TRuntimeConfig>,
+>(channel: TChannel, definition: AgentChannelSyncDefinition<TRuntimeConfig>): TChannel {
+  Object.defineProperty(channel, agentChannelSyncDefinition, {
+    configurable: true,
+    value: definition,
+  })
+  return channel
+}
+
+export function getAgentChannelSyncDefinition<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+>(
+  channel: AgentChannelDefinition<TRuntimeConfig>,
+): AgentChannelSyncDefinition<TRuntimeConfig> | undefined {
+  return (
+    channel as AgentChannelDefinition<TRuntimeConfig> & {
+      [agentChannelSyncDefinition]?: AgentChannelSyncDefinition<TRuntimeConfig>
+    }
+  )[agentChannelSyncDefinition]
+}

--- a/packages/agent/src/internal/telegram-channel-sync.ts
+++ b/packages/agent/src/internal/telegram-channel-sync.ts
@@ -104,6 +104,7 @@ export function createTelegramChannelSyncProvider(
     )
   }
   return {
+    resourceKey: options.botToken,
     async apply(plan, fetchImpl) {
       if (plan.action === "none") return plan.current
       if (plan.action === "delete") {

--- a/packages/agent/src/internal/telegram-channel-sync.ts
+++ b/packages/agent/src/internal/telegram-channel-sync.ts
@@ -1,0 +1,159 @@
+import type { AgentChannelSyncPlan, AgentChannelSyncProvider } from "./channel-sync.ts"
+
+interface TelegramApiResponse<T> {
+  description?: string
+  ok: boolean
+  result?: T
+}
+
+interface TelegramWebhookInfo {
+  has_custom_certificate?: boolean
+  ip_address?: string
+  last_error_date?: number
+  last_error_message?: string
+  max_connections?: number
+  pending_update_count?: number
+  url?: string
+}
+
+interface TelegramChannelSyncOptions {
+  apiBaseUrl?: string
+  botToken: string
+  mode: "disabled" | "webhook"
+  secretToken?: string
+}
+
+function telegramApiUrl(options: TelegramChannelSyncOptions, method: string): string {
+  const base = (options.apiBaseUrl || "https://api.telegram.org").replace(/\/+$/, "")
+  return `${base}/bot${options.botToken}/${method}`
+}
+
+function redactTelegramDescription(
+  description: string | undefined,
+  options: TelegramChannelSyncOptions,
+): string | undefined {
+  let redacted = description?.trim()
+  for (const secret of [options.botToken, options.secretToken]) {
+    if (secret) redacted = redacted?.split(secret).join("[redacted]")
+  }
+  return redacted
+}
+
+async function telegramApi<T>(
+  options: TelegramChannelSyncOptions,
+  fetchImpl: typeof fetch,
+  method: string,
+  body?: Record<string, unknown>,
+): Promise<T> {
+  let response: Response
+  try {
+    response = await fetchImpl(telegramApiUrl(options, method), {
+      ...(body ? { body: JSON.stringify(body) } : {}),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+      signal: AbortSignal.timeout(30_000),
+    })
+  }
+  catch (error) {
+    throw new Error(`Telegram ${method} request failed.`, { cause: error })
+  }
+  const result = (await response.json().catch(() => undefined)) as
+    | TelegramApiResponse<T>
+    | undefined
+  if (!response.ok || !result?.ok || result.result === undefined) {
+    const description = redactTelegramDescription(result?.description, options)
+    throw new Error(
+      `Telegram ${method} failed with HTTP ${response.status}${description ? `: ${description}` : ""}.`,
+    )
+  }
+  return result.result as T
+}
+
+function telegramRemoteState(info: TelegramWebhookInfo): Record<string, unknown> {
+  return {
+    customCertificate: info.has_custom_certificate === true,
+    ...(typeof info.ip_address === "string" ? { ipAddress: info.ip_address } : {}),
+    ...(typeof info.last_error_date === "number"
+      ? { lastErrorAt: new Date(info.last_error_date * 1000).toISOString() }
+      : {}),
+    ...(typeof info.last_error_message === "string"
+      ? { lastErrorMessage: info.last_error_message }
+      : {}),
+    ...(typeof info.max_connections === "number" ? { maxConnections: info.max_connections } : {}),
+    pendingUpdateCount:
+      typeof info.pending_update_count === "number" ? info.pending_update_count : 0,
+    url: typeof info.url === "string" ? info.url : "",
+  }
+}
+
+async function inspectTelegramWebhook(
+  options: TelegramChannelSyncOptions,
+  fetchImpl: typeof fetch,
+): Promise<Record<string, unknown>> {
+  return telegramRemoteState(
+    await telegramApi<TelegramWebhookInfo>(options, fetchImpl, "getWebhookInfo"),
+  )
+}
+
+export function createTelegramChannelSyncProvider(
+  options: TelegramChannelSyncOptions,
+): AgentChannelSyncProvider {
+  if (options.secretToken && !/^[A-Za-z0-9_-]{1,256}$/.test(options.secretToken)) {
+    throw new TypeError(
+      "Telegram webhookSecret must be 1-256 letters, numbers, underscores, or hyphens.",
+    )
+  }
+  return {
+    async apply(plan, fetchImpl) {
+      if (plan.action === "none") return plan.current
+      if (plan.action === "delete") {
+        await telegramApi<boolean>(options, fetchImpl, "deleteWebhook", {
+          drop_pending_updates: false,
+        })
+      } else {
+        const url = plan.desired.url
+        if (typeof url !== "string" || !url)
+          throw new TypeError("Telegram webhook synchronization requires a desired URL.")
+        await telegramApi<boolean>(options, fetchImpl, "setWebhook", {
+          allowed_updates: ["message"],
+          drop_pending_updates: false,
+          ...(options.secretToken ? { secret_token: options.secretToken } : {}),
+          url,
+        })
+      }
+      return await inspectTelegramWebhook(options, fetchImpl)
+    },
+    async plan({ desiredUrl, fetch, force }): Promise<AgentChannelSyncPlan> {
+      const current = await inspectTelegramWebhook(options, fetch)
+      const currentUrl = typeof current.url === "string" ? current.url : ""
+      if (options.mode === "disabled") {
+        return {
+          action: currentUrl ? "delete" : "none",
+          current,
+          desired: { url: "" },
+          ...(currentUrl ? { destructive: true } : {}),
+        }
+      }
+      if (!desiredUrl)
+        throw new TypeError("Telegram webhook synchronization requires a desired URL.")
+      const target = new URL(desiredUrl)
+      if (target.protocol !== "https:")
+        throw new TypeError("Telegram webhooks require an HTTPS URL.")
+      if (target.port && !["80", "88", "443", "8443"].includes(target.port)) {
+        throw new TypeError("Telegram webhook URLs support ports 443, 80, 88, and 8443.")
+      }
+      return {
+        action: force || currentUrl !== desiredUrl ? (currentUrl ? "update" : "create") : "none",
+        current,
+        desired: {
+          allowedUpdates: ["message"],
+          botToken: "configured",
+          dropPendingUpdates: false,
+          secretToken: options.secretToken ? "configured" : "not configured",
+          url: desiredUrl,
+        },
+        unverifiable: ["allowedUpdates", "secretToken"],
+      }
+    },
+  }
+}

--- a/packages/agent/src/internal/telegram-channel-sync.ts
+++ b/packages/agent/src/internal/telegram-channel-sync.ts
@@ -104,6 +104,7 @@ export function createTelegramChannelSyncProvider(
     )
   }
   return {
+    mode: options.mode,
     resourceKey: options.botToken,
     async apply(plan, fetchImpl) {
       if (plan.action === "none") return plan.current

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -13,6 +13,7 @@ import { normalizeCapabilities } from "../capability-runtime.ts"
 import { deliveryArtifactAttachments } from "../delivery-artifacts.ts"
 import { createAgentInvocationContextStore } from "../invocation-context.ts"
 import { finalChannelOutputContextKey } from "../internal/final-channel-output.ts"
+import { agentChannelSyncProviderHeader } from "../internal/channel-sync.ts"
 import { agentOutputEventObserverContextKey } from "../internal/agent-output-events.ts"
 import { isAttachmentData } from "../messages.ts"
 import { resolveAgentInvoker, withResolvedAgentInvokerInput } from "../invoker.ts"
@@ -2611,8 +2612,8 @@ export function createChannelWebhookRouteHandler(
   agent: AgentInput<ViteAgentRouteRuntimeContext>,
 ): (request: Request, webhook?: string, options?: AgentChannelWebhookRouteOptions) => Promise<Response> {
   return async (request, webhook, handlerOptions = {}) => {
-    if (request.method !== "POST") {
-      return createJsonErrorResponse(405, "Agent webhook route only accepts POST requests.")
+    if (request.method !== "HEAD" && request.method !== "POST") {
+      return createJsonErrorResponse(405, "Agent webhook route only accepts HEAD and POST requests.")
     }
 
     const webhookId = webhook === undefined ? fallbackWebhookFromRequest(request) : webhook
@@ -2637,6 +2638,15 @@ export function createChannelWebhookRouteHandler(
       }
 
       const { registration, trigger } = match
+      if (request.method === "HEAD") {
+        return new Response(null, {
+          headers: {
+            "cache-control": "no-store",
+            [agentChannelSyncProviderHeader]: registration.provider,
+          },
+          status: 204,
+        })
+      }
       if (await matchedWebhookRegistrationRequiresVerification(registration, context, trigger.id !== "chat.message")) {
         try {
           await verifyAgentWebhookRequest([registration], request, context, { requireSecretHeader: true })

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1803,10 +1803,12 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       cli: async () => {
         const { createAgentCliContributor } = await import(/* @vite-ignore */ "./cli.js")
         if (agent === false || agent?.cli === false) return createAgentCliContributor(false)
+        const normalized = normalizeAgentOptions(agent)
         return createAgentCliContributor({
           eval: agent?.eval,
           rootDir: resolved?.root ?? process.cwd(),
           serverDirs,
+          webhookRoute: normalized ? normalized.routes.webhooks : false,
         })
       },
     },

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1803,12 +1803,10 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       cli: async () => {
         const { createAgentCliContributor } = await import(/* @vite-ignore */ "./cli.js")
         if (agent === false || agent?.cli === false) return createAgentCliContributor(false)
-        const normalized = normalizeAgentOptions(agent)
         return createAgentCliContributor({
           eval: agent?.eval,
           rootDir: resolved?.root ?? process.cwd(),
           serverDirs,
-          webhookRoute: normalized ? normalized.routes.webhooks : false,
         })
       },
     },

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -82,12 +82,35 @@ describe("agent CLI", () => {
     expect(getAgentChannelSyncDefinition(channel)).toBeUndefined()
   })
 
-  it("preserves Telegram synchronization when a Channel is decorated", () => {
-    const channel = { ...telegram(), capabilities: [] }
-    expect(getAgentChannelSyncDefinition(channel)).toMatchObject({
+  it("preserves Telegram synchronization when a Channel is decorated", async () => {
+    const channel = { ...telegram({ botToken: "bot-token" }), capabilities: [] }
+    const definition = getAgentChannelSyncDefinition(channel)
+    expect(definition).toMatchObject({ provider: "telegram" })
+    await expect(definition!.resolve({} as never, channel)).resolves.toMatchObject({
       mode: "webhook",
-      provider: "telegram",
     })
+  })
+
+  it("resolves Telegram synchronization from decorated lifecycle fields", async () => {
+    const base = telegram({ botToken: "bot-token", webhookSecret: "old-secret" })
+    const channel = {
+      ...base,
+      webhooks: { ...base.webhooks as object, secretToken: "new-secret" },
+    }
+    const sync = await getAgentChannelSyncDefinition(channel)!.resolve({} as never, channel)
+    const bodies: Record<string, unknown>[] = []
+    const fetcher = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.body) bodies.push(JSON.parse(String(init.body)))
+      return Response.json({ ok: true, result: { pending_update_count: 0, url: "https://example.com/webhook" } })
+    })
+
+    await sync.apply({
+      action: "create",
+      current: { url: "" },
+      desired: { url: "https://example.com/webhook" },
+    }, fetcher as never)
+
+    expect(bodies[0]).toMatchObject({ secret_token: "new-secret" })
   })
 
   it("prints a sanitized Telegram webhook plan without applying it", async () => {
@@ -598,6 +621,34 @@ describe("agent CLI", () => {
       else process.env.TELEGRAM_BOT_TOKEN = previousBotToken
       if (previousWebhookToken === undefined) delete process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN
       else process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN = previousWebhookToken
+      await rm(rootDir, { force: true, recursive: true })
+    }
+  })
+
+  it("preserves the ambient environment when Vite server creation fails", async () => {
+    const rootDir = await mkdtemp(join(import.meta.dirname, "channel-sync-invalid-app-"))
+    const key = "VITEHUB_CHANNEL_SYNC_AMBIENT_TEST"
+    const previous = process.env[key]
+    process.env[key] = "preserved"
+    try {
+      await writeFile(join(rootDir, "vite.config.ts"), 'throw new Error("invalid stage config")\n', "utf8")
+      const exitCode = await runAgentChannelSyncCli([
+        "--stage", "production",
+        "--url", "https://example.com",
+      ], {
+        cwd: rootDir,
+        env: process.env,
+        rootDir,
+        stderr: stream(),
+        stdout: stream(),
+      })
+
+      expect(exitCode).toBe(1)
+      expect(process.env[key]).toBe("preserved")
+    }
+    finally {
+      if (previous === undefined) delete process.env[key]
+      else process.env[key] = previous
       await rm(rootDir, { force: true, recursive: true })
     }
   })

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -329,7 +329,7 @@ describe("agent CLI", () => {
     })
 
     expect(exitCode).toBe(1)
-    expect(stderr.output()).toContain("deletion targets https://production.example.com")
+    expect(stderr.output()).toContain("delete targets https://production.example.com")
     expect(fetcher).toHaveBeenCalledTimes(1)
   })
 
@@ -379,7 +379,48 @@ describe("agent CLI", () => {
     })
 
     expect(exitCode).toBe(1)
-    expect(stderr.output()).toContain("deletion targets https://production.example.com")
+    expect(stderr.output()).toContain("delete targets https://production.example.com")
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
+  it("binds webhook updates to the current provider origin", async () => {
+    const stderr = stream()
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      if (init?.method === "HEAD") {
+        return new Response(null, { headers: { "x-vitehub-channel-provider": "telegram" }, status: 204 })
+      }
+      if (url.endsWith("/getWebhookInfo")) {
+        return Response.json({ ok: true, result: { url: "https://production.example.com/hook" } })
+      }
+      throw new Error(`Unexpected mutation: ${url}`)
+    })
+
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "staging",
+      "--url", "https://staging.example.com",
+      "--apply",
+      "--confirm-origin", "https://staging.example.com",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr,
+      stdout: stream(),
+    }, {
+      fetch: fetcher as never,
+      loadTargets: async () => [{
+        agent: "support",
+        channel: "telegram",
+        mode: "webhook",
+        provider: "telegram",
+        registration: { id: "telegram" },
+        sync: createTelegramChannelSyncProvider({ botToken: "bot-token", mode: "webhook" }),
+      }],
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.output()).toContain("update targets https://production.example.com")
     expect(fetcher).toHaveBeenCalledTimes(2)
   })
 

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -313,6 +313,48 @@ describe("agent CLI", () => {
     expect(stderr.output()).not.toContain("query-secret")
   })
 
+  it("redacts credentials embedded in failed provider verification URLs", async () => {
+    const stderr = stream()
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "production",
+      "--url", "https://example.com",
+      "--apply",
+      "--confirm-origin", "https://example.com",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr,
+      stdout: stream(),
+    }, {
+      fetch: (async () => new Response(null, {
+        headers: { "x-vitehub-channel-provider": "telegram" },
+        status: 204,
+      })) as never,
+      loadTargets: async () => [{
+        agent: "support",
+        channel: "telegram",
+        mode: "webhook",
+        provider: "telegram",
+        registration: { id: "telegram", path: "/webhooks/admission-secret?key=query-secret" },
+        sync: {
+          apply: async () => ({ url: "https://example.com/normalized" }),
+          mode: "webhook",
+          plan: async ({ desiredUrl }) => ({
+            action: "create",
+            current: { url: "" },
+            desired: { url: desiredUrl },
+          }),
+        },
+      }],
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.output()).toContain("https://example.com/[redacted]")
+    expect(stderr.output()).not.toContain("admission-secret")
+    expect(stderr.output()).not.toContain("query-secret")
+  })
+
   it("requires exact origin confirmation before loading an apply plan", async () => {
     const stderr = stream()
     const loadTargets = vi.fn(async () => [])

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -104,13 +104,22 @@ describe("agent CLI", () => {
       return Response.json({ ok: true, result: { pending_update_count: 0, url: "https://example.com/webhook" } })
     })
 
-    await sync.apply({
+    await sync!.apply({
       action: "create",
       current: { url: "" },
       desired: { url: "https://example.com/webhook" },
     }, fetcher as never)
 
     expect(bodies[0]).toMatchObject({ secret_token: "new-secret" })
+  })
+
+  it("drops inherited Telegram synchronization when decoration replaces the adapter", async () => {
+    const base = telegram({ botToken: "bot-token" })
+    const channel = { ...base, adapter: () => ({}) as never }
+
+    await expect(
+      getAgentChannelSyncDefinition(channel)!.resolve({} as never, channel),
+    ).resolves.toBeUndefined()
   })
 
   it("prints a sanitized Telegram webhook plan without applying it", async () => {
@@ -209,6 +218,38 @@ describe("agent CLI", () => {
     expect(stderr.output()).toContain("[redacted]")
     expect(stderr.output()).not.toContain("bot-secret")
     expect(stderr.output()).not.toContain("webhook-secret")
+  })
+
+  it("redacts credentials embedded in provider webhook URLs", async () => {
+    const stdout = stream()
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "production",
+      "--url", "https://example.com",
+      "--json",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr: stream(),
+      stdout,
+    }, {
+      fetch: (async (_input: string | URL | Request, init?: RequestInit) => init?.method === "HEAD"
+        ? new Response(null, { headers: { "x-vitehub-channel-provider": "telegram" }, status: 204 })
+        : Response.json({ ok: true, result: { pending_update_count: 0, url: "https://example.com/legacy/secret-token?key=query-secret" } })) as never,
+      loadTargets: async () => [{
+        agent: "support",
+        channel: "telegram",
+        mode: "webhook",
+        provider: "telegram",
+        registration: { id: "telegram" },
+        sync: createTelegramChannelSyncProvider({ botToken: "bot-token", mode: "webhook" }),
+      }],
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stdout.output()).not.toContain("secret-token")
+    expect(stdout.output()).not.toContain("query-secret")
+    expect(JSON.parse(stdout.output()).registrations[0].current.url).toBe("https://example.com/[redacted]")
   })
 
   it("requires exact origin confirmation before loading an apply plan", async () => {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -273,7 +273,7 @@ describe("agent CLI", () => {
         channel: "telegram",
         mode: "webhook",
         provider: "telegram",
-        registration: { id: "telegram", url: "https://example.com/webhooks/admission-secret?key=query-secret" },
+        registration: { id: "telegram", path: "/webhooks/admission-secret?key=query-secret" },
         sync: createTelegramChannelSyncProvider({ botToken: "bot-token", mode: "webhook" }),
       }],
     })
@@ -282,6 +282,35 @@ describe("agent CLI", () => {
     expect(stdout.output()).not.toContain("admission-secret")
     expect(stdout.output()).not.toContain("query-secret")
     expect(JSON.parse(stdout.output()).registrations[0].desired.url).toBe("https://example.com/[redacted]")
+  })
+
+  it("redacts credentials embedded in failed preflight URLs", async () => {
+    const stderr = stream()
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "production",
+      "--url", "https://example.com",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr,
+      stdout: stream(),
+    }, {
+      fetch: (async () => new Response(null, { status: 404 })) as never,
+      loadTargets: async () => [{
+        agent: "support",
+        channel: "telegram",
+        mode: "webhook",
+        provider: "telegram",
+        registration: { id: "telegram", path: "/webhooks/admission-secret?key=query-secret" },
+        sync: createTelegramChannelSyncProvider({ botToken: "bot-token", mode: "webhook" }),
+      }],
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.output()).toContain("https://example.com/[redacted]")
+    expect(stderr.output()).not.toContain("admission-secret")
+    expect(stderr.output()).not.toContain("query-secret")
   })
 
   it("requires exact origin confirmation before loading an apply plan", async () => {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -333,6 +333,98 @@ describe("agent CLI", () => {
     expect(fetcher).toHaveBeenCalledTimes(1)
   })
 
+  it("validates every deletion against the confirmed origin before mutation", async () => {
+    const stderr = stream()
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.includes("/botstaging-bot/")) {
+        return Response.json({ ok: true, result: { url: "https://staging.example.com/hook" } })
+      }
+      if (url.includes("/botproduction-bot/")) {
+        return Response.json({ ok: true, result: { url: "https://production.example.com/hook" } })
+      }
+      throw new Error(`Unexpected mutation: ${url}`)
+    })
+
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "staging",
+      "--url", "https://staging.example.com",
+      "--apply",
+      "--allow-delete",
+      "--confirm-origin", "https://staging.example.com",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr,
+      stdout: stream(),
+    }, {
+      fetch: fetcher as never,
+      loadTargets: async () => [
+        {
+          agent: "support",
+          channel: "staging",
+          mode: "disabled",
+          provider: "telegram",
+          sync: createTelegramChannelSyncProvider({ botToken: "staging-bot", mode: "disabled" }),
+        },
+        {
+          agent: "support",
+          channel: "production",
+          mode: "disabled",
+          provider: "telegram",
+          sync: createTelegramChannelSyncProvider({ botToken: "production-bot", mode: "disabled" }),
+        },
+      ],
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.output()).toContain("deletion targets https://production.example.com")
+    expect(fetcher).toHaveBeenCalledTimes(2)
+  })
+
+  it("rejects Channels targeting the same provider resource before planning", async () => {
+    const stderr = stream()
+    const fetcher = vi.fn()
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "production",
+      "--url", "https://app.example.com",
+      "--apply",
+      "--confirm-origin", "https://app.example.com",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr,
+      stdout: stream(),
+    }, {
+      fetch: fetcher as never,
+      loadTargets: async () => [
+        {
+          agent: "support",
+          channel: "alerts",
+          mode: "webhook",
+          provider: "telegram",
+          registration: { id: "alerts" },
+          sync: createTelegramChannelSyncProvider({ botToken: "shared-bot", mode: "webhook" }),
+        },
+        {
+          agent: "support",
+          channel: "chat",
+          mode: "webhook",
+          provider: "telegram",
+          registration: { id: "chat" },
+          sync: createTelegramChannelSyncProvider({ botToken: "shared-bot", mode: "webhook" }),
+        },
+      ],
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.output()).toContain("target the same telegram resource")
+    expect(stderr.output()).not.toContain("shared-bot")
+    expect(fetcher).not.toHaveBeenCalled()
+  })
+
   it("deletes and verifies a Telegram webhook only with explicit permission", async () => {
     const stdout = stream()
     let registeredUrl = "https://app.example.com/hook"

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
+import { VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import { refreshWorkspaceDevToken, workspaceDevTokenHeader } from "@vite-hub/workspace/server"
 import { describe, expect, it, vi } from "vitest"
 
@@ -765,6 +766,52 @@ describe("agent CLI", () => {
       else process.env.TELEGRAM_BOT_TOKEN = previousBotToken
       if (previousWebhookToken === undefined) delete process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN
       else process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN = previousWebhookToken
+      await rm(rootDir, { force: true, recursive: true })
+    }
+  })
+
+  it("discovers Channels from the selected stage server directories", async () => {
+    const rootDir = await mkdtemp(join(import.meta.dirname, "channel-sync-stage-dirs-"))
+    const productionServerDir = join(rootDir, "production-server")
+    try {
+      await mkdir(join(productionServerDir, "agents"), { recursive: true })
+      await writeFile(join(rootDir, "vite.config.ts"), [
+        'import { defineConfig } from "vite"',
+        'import { VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"',
+        "export default defineConfig(({ mode }) => ({",
+        `  [VITEHUB_SERVER_DIRS]: mode === "production" ? [${JSON.stringify(productionServerDir)}] : [],`,
+        "}))",
+        "",
+      ].join("\n"), "utf8")
+      await writeFile(join(productionServerDir, "agents", "support.ts"), [
+        'import { defineAgent } from "@vite-hub/agent"',
+        'import { telegram } from "@vite-hub/agent/channels"',
+        'export default defineAgent({ channels: { telegram: telegram({ botToken: "bot-token" }) }, driver: { run: () => "ok" } })',
+        "",
+      ].join("\n"), "utf8")
+      const requests: string[] = []
+      const exitCode = await runAgentChannelSyncCli([
+        "--stage", "production",
+        "--url", "https://example.com",
+      ], {
+        cwd: rootDir,
+        env: {},
+        rootDir,
+        stderr: stream(),
+        stdout: stream(),
+      }, {
+        fetch: (async (input: string | URL | Request, init?: RequestInit) => {
+          requests.push(String(input))
+          return init?.method === "HEAD"
+            ? new Response(null, { headers: { "x-vitehub-channel-provider": "telegram" }, status: 204 })
+            : Response.json({ ok: true, result: { pending_update_count: 0, url: "" } })
+        }) as never,
+      })
+
+      expect(exitCode).toBe(0)
+      expect(requests).toContain("https://api.telegram.org/botbot-token/getWebhookInfo")
+    }
+    finally {
       await rm(rootDir, { force: true, recursive: true })
     }
   })

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -6,8 +6,12 @@ import { refreshWorkspaceDevToken, workspaceDevTokenHeader } from "@vite-hub/wor
 import { describe, expect, it, vi } from "vitest"
 
 import { createAgentCliContributor, runAgentDevCli, runAgentEvalCli, runAgentInfoCli } from "../src/cli.ts"
+import { runAgentChannelSyncCli } from "../src/internal/channel-sync-cli.ts"
+import { getAgentChannelSyncDefinition } from "../src/internal/channel-sync.ts"
 import { createAgentEvaliteConfigPath, writeAgentEvaliteConfig } from "../src/internal/evalite-config.ts"
+import { createTelegramChannelSyncProvider } from "../src/internal/telegram-channel-sync.ts"
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue } from "../src/invocation-stream.ts"
+import { telegram } from "../src/channels.ts"
 
 function stream() {
   let value = ""
@@ -46,6 +50,10 @@ describe("agent CLI", () => {
           expect.objectContaining({ name: "dev" }),
         ],
         name: "agent",
+      }, {
+        description: "External Channel registration workflows.",
+        features: [expect.objectContaining({ name: "sync" })],
+        name: "channels",
       }],
     })
   })
@@ -60,9 +68,390 @@ describe("agent CLI", () => {
           expect.objectContaining({ name: "dev" }),
         ],
         name: "agent",
+      }, {
+        description: "External Channel registration workflows.",
+        features: [expect.objectContaining({ name: "sync" })],
+        name: "channels",
       }],
     })
     await rm(rootDir, { force: true, recursive: true })
+  })
+
+  it("leaves custom Telegram adapter registration application-owned", () => {
+    const channel = telegram({ adapter: () => ({}) as never })
+    expect(getAgentChannelSyncDefinition(channel)).toBeUndefined()
+  })
+
+  it("prints a sanitized Telegram webhook plan without applying it", async () => {
+    const stdout = stream()
+    const stderr = stream()
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      if (init?.method === "HEAD") {
+        return new Response(null, { headers: { "x-vitehub-channel-provider": "telegram" }, status: 204 })
+      }
+      expect(url).toContain("/botsecret-bot-token/getWebhookInfo")
+      return Response.json({ ok: true, result: { pending_update_count: 2, url: "" } })
+    })
+
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "staging",
+      "--url", "https://staging.example.com",
+      "--json",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr,
+      stdout,
+    }, {
+      fetch: fetcher as never,
+      loadTargets: async () => [{
+        agent: "calories",
+        channel: "telegram",
+        mode: "webhook",
+        provider: "telegram",
+        registration: { id: "telegram" },
+        sync: createTelegramChannelSyncProvider({
+          botToken: "secret-bot-token",
+          mode: "webhook",
+          secretToken: "secret-webhook-token",
+        }),
+      }],
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stderr.output()).toBe("")
+    expect(fetcher).toHaveBeenCalledTimes(2)
+    expect(stdout.output()).not.toContain("secret-bot-token")
+    expect(stdout.output()).not.toContain("secret-webhook-token")
+    expect(JSON.parse(stdout.output())).toMatchObject({
+      mode: "dry-run",
+      origin: "https://staging.example.com",
+      registrations: [{
+        action: "create",
+        agent: "calories",
+        applied: false,
+        channel: "telegram",
+        desired: {
+          secretToken: "configured",
+          url: "https://staging.example.com/api/_vitehub/agents/calories/webhooks/telegram",
+        },
+        preflight: "verified",
+        provider: "telegram",
+      }],
+      schemaVersion: 1,
+      stage: "staging",
+    })
+  })
+
+  it("redacts Telegram credentials from provider errors", async () => {
+    const stderr = stream()
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "staging",
+      "--url", "https://staging.example.com",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr,
+      stdout: stream(),
+    }, {
+      fetch: (async (_input: string | URL | Request, init?: RequestInit) => init?.method === "HEAD"
+        ? new Response(null, { headers: { "x-vitehub-channel-provider": "telegram" }, status: 204 })
+        : Response.json({ description: "bot-secret and webhook-secret are invalid", ok: false }, { status: 401 })) as never,
+      loadTargets: async () => [{
+        agent: "support",
+        channel: "telegram",
+        mode: "webhook",
+        provider: "telegram",
+        registration: { id: "telegram" },
+        sync: createTelegramChannelSyncProvider({
+          botToken: "bot-secret",
+          mode: "webhook",
+          secretToken: "webhook-secret",
+        }),
+      }],
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.output()).toContain("[redacted]")
+    expect(stderr.output()).not.toContain("bot-secret")
+    expect(stderr.output()).not.toContain("webhook-secret")
+  })
+
+  it("requires exact origin confirmation before loading an apply plan", async () => {
+    const stderr = stream()
+    const loadTargets = vi.fn(async () => [])
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "production",
+      "--url", "https://app.example.com",
+      "--apply",
+      "--confirm-origin", "https://preview.example.com",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr,
+      stdout: stream(),
+    }, { loadTargets })
+
+    expect(exitCode).toBe(1)
+    expect(loadTargets).not.toHaveBeenCalled()
+    expect(stderr.output()).toContain("--confirm-origin must exactly match --url")
+  })
+
+  it("applies a validated Telegram webhook plan without exposing secrets", async () => {
+    const stdout = stream()
+    let registeredUrl = ""
+    const requests: Array<{ body?: string, method?: string, url: string }> = []
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      requests.push({ body: typeof init?.body === "string" ? init.body : undefined, method: init?.method, url })
+      if (init?.method === "HEAD") {
+        return new Response(null, { headers: { "x-vitehub-channel-provider": "telegram" }, status: 204 })
+      }
+      if (url.endsWith("/getWebhookInfo")) {
+        return Response.json({ ok: true, result: { pending_update_count: 0, url: registeredUrl } })
+      }
+      if (url.endsWith("/setWebhook")) {
+        registeredUrl = JSON.parse(String(init?.body)).url
+        return Response.json({ ok: true, result: true })
+      }
+      throw new Error(`Unexpected Telegram request: ${url}`)
+    })
+
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "production",
+      "--url", "https://app.example.com",
+      "--apply",
+      "--confirm-origin", "https://app.example.com",
+      "--json",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr: stream(),
+      stdout,
+    }, {
+      fetch: fetcher as never,
+      loadTargets: async () => [{
+        agent: "support",
+        channel: "telegram",
+        mode: "webhook",
+        provider: "telegram",
+        registration: { id: "telegram" },
+        sync: createTelegramChannelSyncProvider({ botToken: "bot-token", mode: "webhook", secretToken: "webhook-token" }),
+      }],
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stdout.output()).not.toContain("bot-token")
+    expect(stdout.output()).not.toContain("webhook-token")
+    expect(JSON.parse(stdout.output()).registrations[0]).toMatchObject({ action: "create", applied: true })
+    const setWebhook = requests.find(request => request.url.endsWith("/setWebhook"))
+    expect(JSON.parse(setWebhook?.body || "{}")).toEqual({
+      allowed_updates: ["message"],
+      drop_pending_updates: false,
+      secret_token: "webhook-token",
+      url: "https://app.example.com/api/_vitehub/agents/support/webhooks/telegram",
+    })
+  })
+
+  it("requires deletion permission before disabling a provider webhook", async () => {
+    const stderr = stream()
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.endsWith("/getWebhookInfo")) {
+        return Response.json({ ok: true, result: { pending_update_count: 0, url: "https://app.example.com/hook" } })
+      }
+      throw new Error(`Unexpected mutation: ${url}`)
+    })
+
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "production",
+      "--url", "https://app.example.com",
+      "--apply",
+      "--confirm-origin", "https://app.example.com",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr,
+      stdout: stream(),
+    }, {
+      fetch: fetcher as never,
+      loadTargets: async () => [{
+        agent: "support",
+        channel: "telegram",
+        mode: "disabled",
+        provider: "telegram",
+        sync: createTelegramChannelSyncProvider({ botToken: "bot-token", mode: "disabled" }),
+      }],
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.output()).toContain("requires deletion; rerun with --allow-delete")
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it("binds deletion confirmation to the current provider origin", async () => {
+    const stderr = stream()
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input)
+      if (url.endsWith("/getWebhookInfo")) {
+        return Response.json({ ok: true, result: { pending_update_count: 0, url: "https://production.example.com/hook" } })
+      }
+      throw new Error(`Unexpected mutation: ${url}`)
+    })
+
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "staging",
+      "--url", "https://staging.example.com",
+      "--apply",
+      "--allow-delete",
+      "--confirm-origin", "https://staging.example.com",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr,
+      stdout: stream(),
+    }, {
+      fetch: fetcher as never,
+      loadTargets: async () => [{
+        agent: "support",
+        channel: "telegram",
+        mode: "disabled",
+        provider: "telegram",
+        sync: createTelegramChannelSyncProvider({ botToken: "bot-token", mode: "disabled" }),
+      }],
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.output()).toContain("deletion targets https://production.example.com")
+    expect(fetcher).toHaveBeenCalledTimes(1)
+  })
+
+  it("deletes and verifies a Telegram webhook only with explicit permission", async () => {
+    const stdout = stream()
+    let registeredUrl = "https://app.example.com/hook"
+    const deleteBodies: string[] = []
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      if (url.endsWith("/getWebhookInfo")) {
+        return Response.json({ ok: true, result: { pending_update_count: 3, url: registeredUrl } })
+      }
+      if (url.endsWith("/deleteWebhook")) {
+        deleteBodies.push(String(init?.body))
+        registeredUrl = ""
+        return Response.json({ ok: true, result: true })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "production",
+      "--url", "https://app.example.com",
+      "--apply",
+      "--allow-delete",
+      "--confirm-origin", "https://app.example.com",
+      "--json",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr: stream(),
+      stdout,
+    }, {
+      fetch: fetcher as never,
+      loadTargets: async () => [{
+        agent: "support",
+        channel: "telegram",
+        mode: "disabled",
+        provider: "telegram",
+        sync: createTelegramChannelSyncProvider({ botToken: "bot-token", mode: "disabled" }),
+      }],
+    })
+
+    expect(exitCode).toBe(0)
+    expect(deleteBodies.map(body => JSON.parse(body))).toEqual([{ drop_pending_updates: false }])
+    expect(JSON.parse(stdout.output()).registrations[0]).toMatchObject({
+      action: "delete",
+      applied: true,
+      result: { url: "" },
+    })
+  })
+
+  it("discovers Telegram Channels with the selected stage environment", async () => {
+    const rootDir = await mkdtemp(join(import.meta.dirname, "channel-sync-app-"))
+    const stdout = stream()
+    const requests: string[] = []
+    const previousBotToken = process.env.TELEGRAM_BOT_TOKEN
+    const previousWebhookToken = process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN
+    delete process.env.TELEGRAM_BOT_TOKEN
+    delete process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN
+    try {
+      await mkdir(join(rootDir, "server", "agents"), { recursive: true })
+      await writeFile(join(rootDir, ".env.staging"), [
+        "TELEGRAM_BOT_TOKEN=stage-bot-token",
+        "TELEGRAM_WEBHOOK_SECRET_TOKEN=stage-webhook-token",
+        "",
+      ].join("\n"), "utf8")
+      await writeFile(join(rootDir, "server", "agents", "support.ts"), [
+        'import { defineAgent } from "@vite-hub/agent"',
+        'import { telegram } from "@vite-hub/agent/channels"',
+        "export default defineAgent({",
+        "  channels: {",
+        "    telegram: telegram({",
+        "      botToken: process.env.TELEGRAM_BOT_TOKEN,",
+        "      webhookSecret: process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN,",
+        "    }),",
+        "  },",
+        "  driver: { run: () => 'ok' },",
+        "})",
+        "",
+      ].join("\n"), "utf8")
+      const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input)
+        requests.push(url)
+        if (init?.method === "HEAD") {
+          return new Response(null, { headers: { "x-vitehub-channel-provider": "telegram" }, status: 204 })
+        }
+        return Response.json({ ok: true, result: { pending_update_count: 0, url: "" } })
+      })
+
+      const exitCode = await runAgentChannelSyncCli([
+        "--stage", "staging",
+        "--url", "https://staging.example.com",
+        "--json",
+      ], {
+        cwd: rootDir,
+        env: {},
+        rootDir,
+        stderr: stream(),
+        stdout,
+      }, { fetch: fetcher as never })
+
+      expect(exitCode).toBe(0)
+      expect(requests).toContain("https://api.telegram.org/botstage-bot-token/getWebhookInfo")
+      expect(stdout.output()).not.toContain("stage-bot-token")
+      expect(stdout.output()).not.toContain("stage-webhook-token")
+      expect(JSON.parse(stdout.output()).registrations).toMatchObject([{
+        agent: "support",
+        channel: "telegram",
+        desired: { secretToken: "configured" },
+      }])
+      expect(process.env.TELEGRAM_BOT_TOKEN).toBeUndefined()
+      expect(process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN).toBeUndefined()
+    }
+    finally {
+      if (previousBotToken === undefined) delete process.env.TELEGRAM_BOT_TOKEN
+      else process.env.TELEGRAM_BOT_TOKEN = previousBotToken
+      if (previousWebhookToken === undefined) delete process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN
+      else process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN = previousWebhookToken
+      await rm(rootDir, { force: true, recursive: true })
+    }
   })
 
   it("prints concise resolved Agent information from the running Vite server", async () => {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -82,6 +82,14 @@ describe("agent CLI", () => {
     expect(getAgentChannelSyncDefinition(channel)).toBeUndefined()
   })
 
+  it("preserves Telegram synchronization when a Channel is decorated", () => {
+    const channel = { ...telegram(), capabilities: [] }
+    expect(getAgentChannelSyncDefinition(channel)).toMatchObject({
+      mode: "webhook",
+      provider: "telegram",
+    })
+  })
+
   it("prints a sanitized Telegram webhook plan without applying it", async () => {
     const stdout = stream()
     const stderr = stream()

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -533,9 +533,15 @@ describe("agent CLI", () => {
     delete process.env.TELEGRAM_BOT_TOKEN
     delete process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN
     try {
+      await mkdir(join(rootDir, "config-env"), { recursive: true })
       await mkdir(join(rootDir, "server", "agents"), { recursive: true })
-      await writeFile(join(rootDir, ".env.staging"), [
-        "TELEGRAM_BOT_TOKEN=stage-bot-token",
+      await writeFile(join(rootDir, "vite.config.ts"), [
+        'import { defineConfig } from "vite"',
+        'export default defineConfig({ envDir: "config-env" })',
+        "",
+      ].join("\n"), "utf8")
+      await writeFile(join(rootDir, "config-env", ".env.staging"), [
+        "TELEGRAM_BOT_TOKEN=env-dir-bot-token",
         "TELEGRAM_WEBHOOK_SECRET_TOKEN=stage-webhook-token",
         "",
       ].join("\n"), "utf8")
@@ -568,15 +574,16 @@ describe("agent CLI", () => {
         "--json",
       ], {
         cwd: rootDir,
-        env: {},
+        env: { TELEGRAM_BOT_TOKEN: "context-bot-token" },
         rootDir,
         stderr: stream(),
         stdout,
       }, { fetch: fetcher as never })
 
       expect(exitCode).toBe(0)
-      expect(requests).toContain("https://api.telegram.org/botstage-bot-token/getWebhookInfo")
-      expect(stdout.output()).not.toContain("stage-bot-token")
+      expect(requests).toContain("https://api.telegram.org/botcontext-bot-token/getWebhookInfo")
+      expect(stdout.output()).not.toContain("context-bot-token")
+      expect(stdout.output()).not.toContain("env-dir-bot-token")
       expect(stdout.output()).not.toContain("stage-webhook-token")
       expect(JSON.parse(stdout.output()).registrations).toMatchObject([{
         agent: "support",

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -755,6 +755,53 @@ describe("agent CLI", () => {
     }
   })
 
+  it("serializes concurrent stage environment loading", async () => {
+    const firstRoot = await mkdtemp(join(import.meta.dirname, "channel-sync-concurrent-first-"))
+    const secondRoot = await mkdtemp(join(import.meta.dirname, "channel-sync-concurrent-second-"))
+    const key = "VITEHUB_CHANNEL_SYNC_CONCURRENT_TEST"
+    const config = (expected: string, delay: number) => [
+      "export default async function () {",
+      `  await new Promise(resolve => setTimeout(resolve, ${delay}))`,
+      `  if (process.env.${key} !== ${JSON.stringify(expected)}) throw new Error("wrong concurrent environment")`,
+      `  throw new Error(${JSON.stringify(`expected ${expected} failure`)})`,
+      "}",
+      "",
+    ].join("\n")
+    try {
+      await writeFile(join(firstRoot, "vite.config.ts"), config("first", 30), "utf8")
+      await writeFile(join(secondRoot, "vite.config.ts"), config("second", 80), "utf8")
+      const run = (rootDir: string, selected: string) => {
+        const stderr = stream()
+        return {
+          result: runAgentChannelSyncCli([
+            "--stage", "production",
+            "--url", "https://example.com",
+          ], {
+            cwd: rootDir,
+            env: { [key]: selected },
+            rootDir,
+            stderr,
+            stdout: stream(),
+          }),
+          stderr,
+        }
+      }
+
+      const first = run(firstRoot, "first")
+      await new Promise(resolve => setTimeout(resolve, 5))
+      const second = run(secondRoot, "second")
+      expect(await Promise.all([first.result, second.result])).toEqual([1, 1])
+      expect(first.stderr.output()).toContain("expected first failure")
+      expect(second.stderr.output()).toContain("expected second failure")
+      expect(first.stderr.output()).not.toContain("wrong concurrent environment")
+      expect(second.stderr.output()).not.toContain("wrong concurrent environment")
+    }
+    finally {
+      await rm(firstRoot, { force: true, recursive: true })
+      await rm(secondRoot, { force: true, recursive: true })
+    }
+  })
+
   it("exposes the selected environment while Vite resolves its config", async () => {
     const rootDir = await mkdtemp(join(import.meta.dirname, "channel-sync-config-env-app-"))
     const key = "VITEHUB_CHANNEL_SYNC_CONFIG_ENV_DIR"

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -252,6 +252,38 @@ describe("agent CLI", () => {
     expect(JSON.parse(stdout.output()).registrations[0].current.url).toBe("https://example.com/[redacted]")
   })
 
+  it("redacts credentials embedded in configured desired webhook URLs", async () => {
+    const stdout = stream()
+    const exitCode = await runAgentChannelSyncCli([
+      "--stage", "production",
+      "--url", "https://example.com",
+      "--json",
+    ], {
+      cwd: "/repo",
+      env: {},
+      rootDir: "/repo",
+      stderr: stream(),
+      stdout,
+    }, {
+      fetch: (async (_input: string | URL | Request, init?: RequestInit) => init?.method === "HEAD"
+        ? new Response(null, { headers: { "x-vitehub-channel-provider": "telegram" }, status: 204 })
+        : Response.json({ ok: true, result: { pending_update_count: 0, url: "" } })) as never,
+      loadTargets: async () => [{
+        agent: "support",
+        channel: "telegram",
+        mode: "webhook",
+        provider: "telegram",
+        registration: { id: "telegram", url: "https://example.com/webhooks/admission-secret?key=query-secret" },
+        sync: createTelegramChannelSyncProvider({ botToken: "bot-token", mode: "webhook" }),
+      }],
+    })
+
+    expect(exitCode).toBe(0)
+    expect(stdout.output()).not.toContain("admission-secret")
+    expect(stdout.output()).not.toContain("query-secret")
+    expect(JSON.parse(stdout.output()).registrations[0].desired.url).toBe("https://example.com/[redacted]")
+  })
+
   it("requires exact origin confirmation before loading an apply plan", async () => {
     const stderr = stream()
     const loadTargets = vi.fn(async () => [])
@@ -686,6 +718,56 @@ describe("agent CLI", () => {
 
       expect(exitCode).toBe(1)
       expect(process.env[key]).toBe("preserved")
+    }
+    finally {
+      if (previous === undefined) delete process.env[key]
+      else process.env[key] = previous
+      await rm(rootDir, { force: true, recursive: true })
+    }
+  })
+
+  it("exposes the selected environment while Vite resolves its config", async () => {
+    const rootDir = await mkdtemp(join(import.meta.dirname, "channel-sync-config-env-app-"))
+    const key = "VITEHUB_CHANNEL_SYNC_CONFIG_ENV_DIR"
+    const previous = process.env[key]
+    process.env[key] = "wrong-env"
+    try {
+      await mkdir(join(rootDir, "selected-env"), { recursive: true })
+      await mkdir(join(rootDir, "server", "agents"), { recursive: true })
+      await writeFile(join(rootDir, "vite.config.ts"), [
+        'import { defineConfig } from "vite"',
+        `export default defineConfig({ envDir: process.env.${key} })`,
+        "",
+      ].join("\n"), "utf8")
+      await writeFile(join(rootDir, "selected-env", ".env.production"), "TELEGRAM_BOT_TOKEN=selected-bot-token\n", "utf8")
+      await writeFile(join(rootDir, "server", "agents", "support.ts"), [
+        'import { defineAgent } from "@vite-hub/agent"',
+        'import { telegram } from "@vite-hub/agent/channels"',
+        "export default defineAgent({ channels: { telegram: telegram() }, driver: { run: () => 'ok' } })",
+        "",
+      ].join("\n"), "utf8")
+      const requests: string[] = []
+      const exitCode = await runAgentChannelSyncCli([
+        "--stage", "production",
+        "--url", "https://example.com",
+      ], {
+        cwd: rootDir,
+        env: { [key]: "selected-env" },
+        rootDir,
+        stderr: stream(),
+        stdout: stream(),
+      }, {
+        fetch: (async (input: string | URL | Request, init?: RequestInit) => {
+          requests.push(String(input))
+          return init?.method === "HEAD"
+            ? new Response(null, { headers: { "x-vitehub-channel-provider": "telegram" }, status: 204 })
+            : Response.json({ ok: true, result: { pending_update_count: 0, url: "" } })
+        }) as never,
+      })
+
+      expect(exitCode).toBe(0)
+      expect(requests).toContain("https://api.telegram.org/botselected-bot-token/getWebhookInfo")
+      expect(process.env[key]).toBe("wrong-env")
     }
     finally {
       if (previous === undefined) delete process.env[key]

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -553,7 +553,7 @@ describe("agent CLI", () => {
     const requests: string[] = []
     const previousBotToken = process.env.TELEGRAM_BOT_TOKEN
     const previousWebhookToken = process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN
-    delete process.env.TELEGRAM_BOT_TOKEN
+    process.env.TELEGRAM_BOT_TOKEN = "context-bot-token"
     delete process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN
     try {
       await mkdir(join(rootDir, "config-env"), { recursive: true })
@@ -597,7 +597,7 @@ describe("agent CLI", () => {
         "--json",
       ], {
         cwd: rootDir,
-        env: { TELEGRAM_BOT_TOKEN: "context-bot-token" },
+        env: process.env,
         rootDir,
         stderr: stream(),
         stdout,
@@ -613,7 +613,7 @@ describe("agent CLI", () => {
         channel: "telegram",
         desired: { secretToken: "configured" },
       }])
-      expect(process.env.TELEGRAM_BOT_TOKEN).toBeUndefined()
+      expect(process.env.TELEGRAM_BOT_TOKEN).toBe("context-bot-token")
       expect(process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN).toBeUndefined()
     }
     finally {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -4047,6 +4047,32 @@ describe("server helpers", () => {
     }))
   })
 
+  it("preflights a deployed Channel webhook without invoking or verifying it", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const run = vi.fn(() => "unexpected")
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => createTestChatAdapter() as never,
+          webhookSecret: "secret-token",
+        }),
+      },
+      driver: { run },
+    })
+
+    const response = await createChannelWebhookRouteHandler(agent as never)(new Request(
+      "https://example.com/api/_vitehub/agents/support/webhooks/telegram",
+      { method: "HEAD" },
+    ), "telegram")
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get("cache-control")).toBe("no-store")
+    expect(response.headers.get("x-vitehub-channel-provider")).toBe("telegram")
+    expect(run).not.toHaveBeenCalled()
+  })
+
   it("preserves generic attachment URLs as typed references", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")


### PR DESCRIPTION
## What changed

Adds a Telegram-first `vitehub channels sync` workflow. It discovers the declared channel, reads the remote webhook, prints a dry-run plan by default, and applies only after an explicit stage, URL, origin confirmation, and deployed-route preflight.

The public Channel adapter boundary keeps provider account choices, credentials, event policy, and destructive application behavior with the application. Telegram supplies inspect, set, and delete semantics; secrets are redacted and delete has a separate confirmation gate.

## Why

Applications should not need one-off webhook setup scripts for framework-owned callback mechanics. The CLI makes that lifecycle visible and safe without guessing a public origin or mutating a provider during planning.

## Validation

- Agent package typecheck
- 45 focused CLI tests
- 194 provider tests
- 4 documentation tests
- Compiled CLI help, lint, and `git diff --check`
