### PR TITLE
feat(agent): split success and error hooks

### DIFF
--- a/docs/content/docs/agents/agent-definitions.md
+++ b/docs/content/docs/agents/agent-definitions.md
@@ -37,7 +37,7 @@ Use a structural driver object when the application supplies a custom model, har
 | `channels` | `Record<string, AgentChannelInput>` | None | Declares named Channel factories or definitions for reachability and delivery. |
 | `cli.capabilities` | `boolean` | `true` | Enables or disables Capability-contributed Agent CLI commands for this Definition. |
 | `description` | `string` | None | Adds human-readable metadata for discovery and inspection. |
-| `hooks` | Agent, Capability, and observer hook map | None | Registers `agent:input`, `agent:finish`, Capability lifecycle, or `hook:observe` callbacks. |
+| `hooks` | Agent, Capability, and observer hook map | None | Registers `agent:input`, `agent:finish`, `agent:error`, Capability lifecycle, or `hook:observe` callbacks. |
 | `invoker` | `AgentInvokerOptions` | None | Configures Agent Actor profiles and resolution through the current `invoker`-named API. |
 | `messages` | `AgentMessageChannelSettings` | Channel defaults | Applies shared commentary, delivery, concurrency, session, state, and transcript settings across adapter-backed Channels. |
 | `name` | `string` | Discovered identity | Supplies an explicit Definition name for direct metadata and Workspace naming. Discovered host identity still comes from the file or folder path. |

--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -187,9 +187,9 @@ export default defineAgent({
 })
 ```
 
-## Finish lifecycle
+## Outcome hooks
 
-Use an Agent Finish Hook to observe the completed invocation. Finish hooks are appropriate for usage export, trace collection, cleanup, or product-side notifications. Read normalized usage directly from `event.invocation.usage`.
+Use an Agent Finish Hook to observe a successful invocation. Finish hooks are appropriate for usage export, trace collection, or product-side notifications; use an Agent Error Hook for failed invocations and Capability cleanup for work that must run after either outcome. Read normalized usage directly from `event.invocation.usage`.
 
 ```ts [server/agents/support.ts]
 import { gateway } from '@ai-sdk/gateway'
@@ -229,7 +229,7 @@ Finish hooks should not quietly grant new abilities. Capabilities and Agent Driv
 
 ### Handle failures
 
-When an Agent Invocation fails, the finish event keeps the original thrown value on `event.error` and exposes a normalized message on `event.errorMessage`.
+When Agent execution fails, its Agent Error Hook receives the original thrown value on `event.error` and a normalized message on `event.errorMessage`. Agent Finish Hooks run only after successful execution, so application hooks do not need to branch on `event.error`.
 
 Use `event.errorMessage` for status updates, logs, and delivery effects. Use `event.error` only when you need to inspect the original thrown value.
 
@@ -241,14 +241,14 @@ export default defineAgent({
     },
   },
   hooks: {
-    'agent:finish'(event) {
-      if (event.errorMessage) {
-        event.runtime.waitUntil(reportFailure(event.errorMessage))
-      }
+    'agent:error'(event) {
+      event.runtime.waitUntil(reportFailure(event.errorMessage))
     },
   },
 })
 ```
+
+These are top-level Agent Definition hooks. Command-scoped `inputCommands(...).hooks['agent:finish']` remains outcome-agnostic, and cleanup or outcome-hook failures are propagated without dispatching the opposite hook.
 
 ## Next steps
 

--- a/packages/agent/src/capabilities/title.ts
+++ b/packages/agent/src/capabilities/title.ts
@@ -211,6 +211,10 @@ function shouldProvideTitleFinishExtension(context: AgentCapabilityRuntimeContex
   return supportsTitleDelivery(context) || context.context.get<boolean>("agent.finishHook") === true
 }
 
+function shouldResolveTitleFinishExtension(context: AgentCapabilityRuntimeContext, event: AgentFinishEvent): boolean {
+  return supportsTitleDelivery(context) || context.context.get<boolean>(Object.hasOwn(event, "error") ? "agent.errorHook" : "agent.finishHook") === true
+}
+
 async function resolveTemplateVariables(options: TitleOptions, input: TitleTemplateInput): Promise<Record<string, unknown>> {
   const variables: Record<string, unknown> = {}
   for (const [name, value] of Object.entries(options.variables || {})) {
@@ -823,7 +827,7 @@ export function title<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCo
         ))
       })
       context.finish.provide(async (finish: AgentFinishEvent) => {
-        if (!shouldProvideTitleFinishExtension(context)) return
+        if (!shouldResolveTitleFinishExtension(context, finish)) return
         const resolvedTitle = await getTitle(finish.text)
         return resolvedTitle ? { title: resolvedTitle } : undefined
       })

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -122,6 +122,7 @@ import type {
   AgentDriverContribution,
   AgentDriverKind,
   CustomAgentDriver,
+  AgentErrorHookEvent,
   AgentFinishEvent,
   AgentFinishHookEvent,
   AgentFinishExtensions,
@@ -282,6 +283,8 @@ export type {
   AgentDriverContributionKind,
   AgentDriverKind,
   AgentExecution,
+  AgentErrorHook,
+  AgentErrorHookEvent,
   AgentFinishEvent,
   AgentFinishExtensions,
   AgentFinishExtensionValues,
@@ -1488,6 +1491,7 @@ type AgentInvocationContext<
   finalOutputRenderers: AgentCapabilityRegistries["finalOutputRenderers"]
   finishDeliveryEffectProviders: AgentChannelDeliveryFinishEffect[]
   finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
+  errorHook?: (event: AgentErrorHookEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void | AgentChannelDeliveryFinishEffectResult>
   finishHook?: (event: AgentFinishHookEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void | AgentChannelDeliveryFinishEffectResult>
   hasCapabilityCleanup: boolean
   harnessSandboxProvider?: object
@@ -1825,6 +1829,7 @@ async function createAgentInvocationContext<
       finalOutputRenderers: capabilities.registries.finalOutputRenderers,
       finishDeliveryEffectProviders: capabilities.registries.finishDeliveryEffectProviders,
       finishExtensionProviders: capabilities.registries.finishExtensionProviders,
+      errorHook: definition?.hooks?.["agent:error"] as never,
       finishHook: definition?.hooks?.["agent:finish"] as never,
       globalSkills: capabilities.globalSkills,
       hasCapabilityCleanup: capabilities.hasCloseCallbacks,
@@ -1854,6 +1859,7 @@ async function createAgentInvocationContext<
       workspaceMaterializationPaths: capabilities.workspaceMaterializationPaths,
       workspaceMode,
     }
+    invocationContext.set("agent.errorHook", Boolean(invocation.errorHook), { overwrite: true })
     invocationContext.set("agent.finishHook", Boolean(invocation.finishHook), { overwrite: true })
     await traceAgentInvocationStart(toTraceContext(invocation))
     await applyChannelDeliveryEffectIntents(invocation, invocation.deliveryEffectIntents)
@@ -1897,6 +1903,7 @@ type InvocationRunContext<
   finishDeliveryEffectProviders: AgentChannelDeliveryFinishEffect[]
   finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
   finalOutputRenderers: AgentCapabilityRegistries["finalOutputRenderers"]
+  errorHook?: (event: AgentErrorHookEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void | AgentChannelDeliveryFinishEffectResult>
   finishHook?: (event: AgentFinishHookEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void | AgentChannelDeliveryFinishEffectResult>
   hooks?: AgentHookObserverHooks
   input: AgentRunInput<CALL_OPTIONS>
@@ -2320,7 +2327,7 @@ function hasFinishWork<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>): boolean {
-  return hasFinishConsumer(context) || context.finishExtensionProviders.some(provider => provider.eager)
+  return Boolean(context.errorHook) || hasFinishConsumer(context) || context.finishExtensionProviders.some(provider => provider.eager)
 }
 
 async function resolveFinishUsageRecord<
@@ -2485,8 +2492,28 @@ function createAgentFinishHookEvent<
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
 ): AgentFinishHookEvent<TRuntimeConfig, CALL_OPTIONS> {
   const delivery = createFinishDeliveryEffectContext(event, context)
+  const { error: _error, errorMessage: _errorMessage, ...finishEvent } = event
   return {
-    ...event,
+    ...finishEvent,
+    reaction: delivery.reaction,
+    reply: delivery.reply,
+    status: delivery.status,
+  }
+}
+
+function createAgentErrorHookEvent<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>,
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+): AgentErrorHookEvent<TRuntimeConfig, CALL_OPTIONS> {
+  const delivery = createFinishDeliveryEffectContext(event, context)
+  const { result: _result, text: _text, ...errorEvent } = event
+  return {
+    ...errorEvent,
+    error: errorEvent.error,
+    errorMessage: errorEvent.errorMessage ?? agentErrorDetails(errorEvent.error).message,
     reaction: delivery.reaction,
     reply: delivery.reply,
     status: delivery.status,
@@ -2592,28 +2619,32 @@ async function finishAgentInvocation<
         ...(text !== undefined ? { text } : {}),
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
       const provisionalActiveDeliveryProviders = await prepareProvisionalTitleDeliverySupport(context, eventBase)
-      const hasFinishConsumer = Boolean(context.finishHook || provisionalActiveDeliveryProviders.length || hasDeferredFinishDeliveryEffectProvider(context.finishDeliveryEffectProviders))
-      const finishExtensionProviders = hasFinishConsumer
+      const outcomeHook = failed ? context.errorHook : context.finishHook
+      const hookName = failed ? "agent:error" : "agent:finish"
+      const hasOutcomeConsumer = Boolean(outcomeHook || provisionalActiveDeliveryProviders.length || hasDeferredFinishDeliveryEffectProvider(context.finishDeliveryEffectProviders))
+      const finishExtensionProviders = hasOutcomeConsumer
         ? context.finishExtensionProviders
         : context.finishExtensionProviders.filter(provider => provider.eager)
-      if (hasFinishConsumer || finishExtensionProviders.length) {
+      if (hasOutcomeConsumer || finishExtensionProviders.length) {
         const extensions = await createAgentInvocationExtensions(eventBase as never, finishExtensionProviders)
         const finishEvent = { ...eventBase, extensions }
         const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, finishEvent as never)
         await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(activeDeliveryProviders, finishEvent as never, context), finishEvent as never)
-        let finishHookResult: void | AgentChannelDeliveryFinishEffectResult
+        let outcomeHookResult: void | AgentChannelDeliveryFinishEffectResult
         await runObservedAgentHook(context.hooks, {
           ids: { runId: context.run?.runId },
-          name: "agent:finish",
+          name: hookName,
           owner: "agent",
-          phase: "finish",
+          phase: failed ? "error" : "finish",
         }, async () => {
-          finishHookResult = await context.finishHook?.(createAgentFinishHookEvent(finishEvent, context))
+          outcomeHookResult = failed
+            ? await context.errorHook?.(createAgentErrorHookEvent(finishEvent, context))
+            : await context.finishHook?.(createAgentFinishHookEvent(finishEvent, context))
         })
-        if (finishHookResult) {
-          const finishHookIntents: AgentChannelDeliveryEffectIntent[] = []
-          appendDeliveryEffectIntent(finishHookIntents, finishHookResult)
-          await applyChannelDeliveryEffectIntents(context, finishHookIntents, finishEvent)
+        if (outcomeHookResult) {
+          const outcomeHookIntents: AgentChannelDeliveryEffectIntent[] = []
+          appendDeliveryEffectIntent(outcomeHookIntents, outcomeHookResult)
+          await applyChannelDeliveryEffectIntents(context, outcomeHookIntents, finishEvent)
         }
       }
     }

--- a/packages/agent/src/test.ts
+++ b/packages/agent/src/test.ts
@@ -8,6 +8,8 @@ import { createTraceEventLog, deriveTraceRuns } from "@vite-hub/runtime"
 import { registerWorkspace } from "@vite-hub/workspace/test"
 
 import type {
+  AgentErrorHook,
+  AgentErrorHookEvent,
   AgentInput,
   AgentFinishEvent,
   AgentFinishHook,
@@ -125,7 +127,7 @@ function createDefaultRun(name: string | undefined): AgentRunMetadata {
   }
 }
 
-function withTestFinishCapture<TRuntimeConfig extends AgentRuntimeConfig>(
+function withTestOutcomeCapture<TRuntimeConfig extends AgentRuntimeConfig>(
   agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
   capture: (event: AgentFinishEvent<TRuntimeConfig>) => void,
 ): AgentInput<AgentRuntimeContext<TRuntimeConfig>> {
@@ -134,9 +136,14 @@ function withTestFinishCapture<TRuntimeConfig extends AgentRuntimeConfig>(
   const clone = Object.create(Object.getPrototypeOf(agent)) as AgentInput<AgentRuntimeContext<TRuntimeConfig>> & { hooks?: Record<string, unknown> }
   Object.defineProperties(clone, Object.getOwnPropertyDescriptors(agent))
   const hooks = clone.hooks || {}
+  const errorHook = hooks["agent:error"] as AgentErrorHook<TRuntimeConfig> | undefined
   const finishHook = hooks["agent:finish"] as AgentFinishHook<TRuntimeConfig> | undefined
   clone.hooks = {
     ...hooks,
+    async "agent:error"(event: AgentErrorHookEvent<TRuntimeConfig>) {
+      capture(event)
+      return await errorHook?.(event)
+    },
     async "agent:finish"(event: AgentFinishHookEvent<TRuntimeConfig>) {
       capture(event)
       return await finishHook?.(event)
@@ -398,7 +405,7 @@ export function createAgentTestRunner<
       })
 
       const raw = await runAgentInline<TRuntimeConfig, CALL_OPTIONS>(
-        withTestFinishCapture(instrumentedAgent, value => {
+        withTestOutcomeCapture(instrumentedAgent, value => {
           finishEvent = value as AgentFinishEvent
         }),
         context,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -106,6 +106,7 @@ declare global {
 export interface AgentInvocationContextValues extends ViteHubAgentInvocationContextValues {
   access: AgentAccessInvocationContextValue
   actor: AgentActor
+  "agent.errorHook": boolean
   "agent.finishHook": boolean
   "channel.delivery.effects": AgentChannelDeliveryEffectIntent[]
   "channel.delivery.finishEffects": AgentChannelDeliveryFinishEffect[]
@@ -491,14 +492,30 @@ export interface AgentFinishEvent<
   text?: string
 }
 
-export interface AgentFinishHookEvent<
+export type AgentFinishHookEvent<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
-> extends AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS> {
+> = Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "error" | "errorMessage"> & {
   reaction: (input: AgentChannelDeliveryReactionInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"reaction">
   reply: (input: AgentChannelDeliveryReplyInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"reply">
   status: (input: AgentChannelDeliveryStatusInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"status">
 }
+
+export type AgentErrorHookEvent<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> = Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "error" | "errorMessage" | "result" | "text"> & {
+  error: unknown
+  errorMessage: string
+  reaction: (input: AgentChannelDeliveryReactionInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"reaction">
+  reply: (input: AgentChannelDeliveryReplyInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"reply">
+  status: (input: AgentChannelDeliveryStatusInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"status">
+}
+
+export type AgentErrorHook<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  CALL_OPTIONS = unknown,
+> = (event: AgentErrorHookEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void | AgentChannelDeliveryFinishEffectResult>
 
 export type AgentFinishHook<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -516,6 +533,7 @@ export interface AgentInvocationHooks<
   CALL_OPTIONS = unknown,
   TContextValues extends object = AgentInvocationContextValues,
 > {
+  "agent:error"?: AgentErrorHook<TRuntimeConfig, CALL_OPTIONS>
   "agent:finish"?: AgentFinishHook<TRuntimeConfig, CALL_OPTIONS>
   "agent:input"?: AgentInputHook<TRuntimeConfig, CALL_OPTIONS, TContextValues>
 }

--- a/packages/agent/test/invocation-lifecycle.test.ts
+++ b/packages/agent/test/invocation-lifecycle.test.ts
@@ -171,9 +171,13 @@ async function createLifecycleProbe(
     events.push("close")
     return scenario.close?.()
   })
-  let finishError: unknown
-  const finish = vi.fn((event) => {
-    finishError = event.error
+  let hookError: unknown
+  const error = vi.fn((event) => {
+    hookError = event.error
+    events.push("error")
+    return scenario.finish?.()
+  })
+  const finish = vi.fn(() => {
     events.push("finish")
     return scenario.finish?.()
   })
@@ -185,28 +189,33 @@ async function createLifecycleProbe(
       ...(scenario.input ? { input: () => scenario.input!(events) } : {}),
     })],
     driver: driver.driver as never,
-    hooks: { "agent:finish": finish },
+    hooks: {
+      "agent:error": error,
+      "agent:finish": finish,
+    },
   })
 
   return {
     agent,
     execute: driver.execute,
-    get finishError() {
-      return finishError
+    get hookError() {
+      return hookError
     },
     expectCloseFailed(expectedEvents: string[]) {
       expect(events).toEqual(expectedEvents)
       expect(close).toHaveBeenCalledOnce()
+      expect(error).not.toHaveBeenCalled()
       expect(finish).not.toHaveBeenCalled()
     },
     expectFinished(expectedEvents: string[]) {
       expect(events).toEqual(expectedEvents)
       expect(close).toHaveBeenCalledOnce()
-      expect(finish).toHaveBeenCalledOnce()
+      expect(error.mock.calls.length + finish.mock.calls.length).toBe(1)
     },
     expectPending(expectedEvents: string[]) {
       expect(events).toEqual(expectedEvents)
       expect(close).not.toHaveBeenCalled()
+      expect(error).not.toHaveBeenCalled()
       expect(finish).not.toHaveBeenCalled()
     },
   }
@@ -234,7 +243,7 @@ describe("Agent Invocation Interface lifecycle", () => {
     probe.expectFinished(["driver", "close", "finish"])
   })
 
-  it.each(driverKinds)("closes %s capabilities before failed finish exactly once", async (kind) => {
+  it.each(driverKinds)("closes %s capabilities before Agent Error Hooks exactly once", async (kind) => {
     const { runAgent } = await import("../src/index.ts")
     const failure = new Error(`${kind} failed`)
     const probe = await createLifecycleProbe(kind, "run", {
@@ -245,8 +254,8 @@ describe("Agent Invocation Interface lifecycle", () => {
     })
 
     await expect(runAgent(probe.agent, createInvocationRuntime(), { prompt: "hello" })).rejects.toBe(failure)
-    probe.expectFinished(["driver", "close", "finish"])
-    expect(probe.finishError).toBe(failure)
+    probe.expectFinished(["driver", "close", "error"])
+    expect(probe.hookError).toBe(failure)
   })
 
   it.each(driverKinds)("preserves the %s finish failure identity after successful execution", async (kind) => {
@@ -284,8 +293,8 @@ describe("Agent Invocation Interface lifecycle", () => {
     expect(error).toBeInstanceOf(AggregateError)
     expect(error.message).toBe("[vitehub] Agent run failed and finish lifecycle also failed.")
     expect(error.errors).toEqual([executionFailure, finishFailure])
-    probe.expectFinished(["driver", "close", "finish"])
-    expect(probe.finishError).toBe(executionFailure)
+    probe.expectFinished(["driver", "close", "error"])
+    expect(probe.hookError).toBe(executionFailure)
   })
 
   it("preserves a close failure instead of aggregating it with itself", async () => {

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -691,10 +691,10 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     const { defineChannel } = await import("../src/channels.ts")
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
-    const finishEvents: unknown[] = []
-    const finishHook = vi.fn((event: unknown) => {
-      finishEvents.push(event)
-      order.push("agent-finish")
+    const errorEvents: unknown[] = []
+    const errorHook = vi.fn((event: unknown) => {
+      errorEvents.push(event)
+      order.push("agent-error")
     })
     const agent = defineAgent({
       channels: {
@@ -714,7 +714,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
       driver: {
         harness: { provider: "codex" },
       },
-      hooks: { "agent:finish": finishHook },
+      hooks: { "agent:error": errorHook },
       workspace: { mode: "write" },
     })
 
@@ -772,10 +772,10 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     await waitFor(() => {
       expect(workspaceClose).toHaveBeenCalledOnce()
       expect(harnessSessionDestroy).toHaveBeenCalledOnce()
-      expect(finishHook).toHaveBeenCalledOnce()
+      expect(errorHook).toHaveBeenCalledOnce()
     })
     expect(workspaceCloseErrors[0]).toBeInstanceOf(Error)
-    expect(finishEvents[0]).toEqual(expect.objectContaining({
+    expect(errorEvents[0]).toEqual(expect.objectContaining({
       error: expect.any(Error),
       invocation: expect.objectContaining({
         run: { channelId: "github", origin: "github-pull-request-comment", runId: "github-run" },
@@ -785,7 +785,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
       "prepare-harness-workspace",
       "workspace-session-close",
       "harness-session-destroy",
-      "agent-finish",
+      "agent-error",
     ]))
   })
 

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -471,8 +471,11 @@ describe("agent message protocol", () => {
         "agent:input"(context) {
           events.push(`agent-input:${context.input.prompt}`)
         },
+        "agent:error"(context) {
+          events.push(`agent-error:${context.errorMessage}`)
+        },
         "agent:finish"(context) {
-          events.push(context.error ? `agent-finish:error:${(context.error as Error).message}` : `agent-finish:${context.result}`)
+          events.push(`agent-finish:${context.result}`)
         },
       },
     })
@@ -491,7 +494,7 @@ describe("agent message protocol", () => {
       "agent-input:review:fail",
       "run:review:fail",
       "command-finish:error:boom",
-      "agent-finish:error:boom",
+      "agent-error:boom",
     ])
   })
 
@@ -778,7 +781,7 @@ describe("agent message protocol", () => {
     })
   })
 
-  it("exposes normalized error messages on failed finish events", async () => {
+  it("routes failed invocations through Agent Error Hooks", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const throwingGetterError = Object.defineProperty({}, "message", {
       get() {
@@ -803,11 +806,15 @@ describe("agent message protocol", () => {
 
     for (const { error, message } of cases) {
       const finish = vi.fn()
+      const agentError = vi.fn()
       const agent = defineAgent({
         driver: { run: () => {
             throw error
           }, },
-        hooks: { "agent:finish": finish },
+        hooks: {
+          "agent:error": agentError,
+          "agent:finish": finish,
+        },
       })
 
       await runAgent(agent, {
@@ -816,10 +823,62 @@ describe("agent message protocol", () => {
         waitUntil: vi.fn(),
       }, {}).catch(() => {})
 
-      const finishEvent = finish.mock.calls[0]?.[0]
-      expect(finishEvent?.error).toBe(error)
-      expect(finishEvent).toMatchObject({ errorMessage: message })
+      expect(finish).not.toHaveBeenCalled()
+      const errorEvent = agentError.mock.calls[0]?.[0]
+      expect(errorEvent?.error).toBe(error)
+      expect(errorEvent).toMatchObject({ errorMessage: message })
+      expect(errorEvent).not.toHaveProperty("result")
+      expect(errorEvent).not.toHaveProperty("text")
     }
+  })
+
+  it("observes disjoint outcome hooks and delivers Agent Error Hook effects", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const failure = new Error("boom")
+    const finish = vi.fn()
+    const agentError = vi.fn(event => event.reply(`failed:${event.errorMessage}`))
+    const observe = vi.fn()
+    const reply = vi.fn()
+    const agent = defineAgent({
+      channels: {
+        portal: defineChannel("portal", {
+          effects: { reply },
+          messages: false,
+        }),
+      },
+      driver: { run: (context) => {
+          if (context.prompt === "fail") throw failure
+          return "ok"
+        }, },
+      hooks: {
+        "agent:error": agentError,
+        "agent:finish": finish,
+        "hook:observe": observe,
+      },
+    })
+    const runtime = {
+      memo: vi.fn(),
+      run: { channelId: "portal", runId: "outcome-hooks" },
+      runtime: "unknown" as const,
+      waitUntil: vi.fn(),
+    }
+
+    await expect(runAgent(agent, runtime, { prompt: "pass" })).resolves.toBe("ok")
+    expect(finish).toHaveBeenCalledOnce()
+    expect(agentError).not.toHaveBeenCalled()
+
+    await expect(runAgent(agent, runtime, { prompt: "fail" })).rejects.toBe(failure)
+    expect(finish).toHaveBeenCalledOnce()
+    expect(agentError).toHaveBeenCalledOnce()
+    expect(agentError.mock.calls[0]![0].error).toBe(failure)
+    expect(reply).toHaveBeenCalledWith(expect.objectContaining({
+      effect: { kind: "reply", payload: "failed:boom" },
+    }))
+    expect(observe.mock.calls.map(([event]) => event).filter(event => event.owner === "agent")).toEqual([
+      expect.objectContaining({ name: "agent:finish", outcome: "success", phase: "finish" }),
+      expect.objectContaining({ name: "agent:error", outcome: "success", phase: "error" }),
+    ])
   })
 
   it("treats stream cancellation without reason as successful cleanup", async () => {
@@ -859,10 +918,10 @@ describe("agent message protocol", () => {
     const agent = defineAgent({
       driver: { run: () => {
           throw new Error("run failed")
-        }, },
+      }, },
       hooks: {
-        "agent:finish": () => {
-          throw new Error("finish failed")
+        "agent:error": () => {
+          throw new Error("error hook failed")
         },
       },
     })
@@ -4445,6 +4504,50 @@ describe("agent message protocol", () => {
     expect(finish.mock.calls[0]![0].extensions.get("title")).toEqual({ title: "Prepared title" })
   })
 
+  it("resolves title extensions only when an error-only hook runs", async () => {
+    const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const execute = vi.fn(() => "Prepared title")
+    const failure = new Error("failed")
+    const run = vi.fn()
+      .mockReturnValueOnce("ok")
+      .mockImplementationOnce(() => { throw failure })
+    const agentError = vi.fn()
+    const agent = defineAgent({
+      capabilities: [title({ execute })],
+      channels: {
+        portal: defineChannel("portal", {
+          adapter: {
+            channelIdFromThreadId: (threadId: string) => threadId,
+            postMessage: vi.fn(),
+          } as never,
+          triggers: {
+            message: {
+              invoke: context => ({
+                input: { messages: [createMessage({ role: "user", text: "prepare title" })] },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run", threadId: "thread-1" },
+              }),
+            },
+          },
+        }),
+      },
+      driver: { run },
+      hooks: {
+        "agent:error": agentError,
+      },
+    })
+    const runtime = { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }
+
+    await expect(runAgentTrigger(agent, runtime, "portal.message", {})).resolves.toBe("ok")
+    expect(execute).not.toHaveBeenCalled()
+    expect(agentError).not.toHaveBeenCalled()
+
+    await expect(runAgentTrigger(agent, runtime, "portal.message", {})).rejects.toBe(failure)
+    expect(execute).toHaveBeenCalledOnce()
+    expect(agentError).toHaveBeenCalledOnce()
+    expect(agentError.mock.calls[0]![0].extensions.get("title")).toEqual({ title: "Prepared title" })
+  })
+
   it("delivers titles through custom message Channel title effects", async () => {
     const { defineAgent, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
@@ -6389,6 +6492,28 @@ describe("agent message protocol", () => {
     }, {})).resolves.toMatchObject({ text: "ok" })
   })
 
+  it("does not make error-only hooks consume successful usage", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agentError = vi.fn()
+    const usage = {
+      // eslint-disable-next-line unicorn/no-thenable -- verifies successful invocations do not await unused usage
+      then() {
+        throw new Error("usage should be unused")
+      },
+    }
+    const agent = defineAgent({
+      driver: { run: () => ({ text: "ok", usage }), },
+      hooks: { "agent:error": agentError },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).resolves.toMatchObject({ text: "ok" })
+    expect(agentError).not.toHaveBeenCalled()
+  })
+
   it("runs final output renderers before finish delivery effects", async () => {
     const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
@@ -6705,10 +6830,10 @@ describe("agent message protocol", () => {
     expect(delivered).toHaveBeenCalledWith("raw review:15")
   })
 
-  it("routes stream final output renderer failures through finish lifecycle", async () => {
+  it("routes stream final output renderer failures through Agent Error Hooks", async () => {
     const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
     const finalError = new Error("final failed")
-    const finish = vi.fn()
+    const agentError = vi.fn()
     const agent = defineAgent({
       capabilities: [
         defineCapability({
@@ -6721,7 +6846,7 @@ describe("agent message protocol", () => {
         }),
       ],
       hooks: {
-        "agent:finish": finish,
+        "agent:error": agentError,
       },
       driver: { run: () => ({
           fullStream: (async function* () {
@@ -6736,7 +6861,7 @@ describe("agent message protocol", () => {
     await expect((async () => {
       for await (const _event of stream as AsyncIterable<unknown>) {}
     })()).rejects.toThrow("final failed")
-    expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+    expect(agentError).toHaveBeenCalledWith(expect.objectContaining({
       error: finalError,
     }))
   })
@@ -7009,9 +7134,9 @@ describe("agent message protocol", () => {
     ])
   })
 
-  it("runs finish lifecycle when async stream output renderer setup fails", async () => {
+  it("runs Agent Error Hooks when async stream output renderer setup fails", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
-    const finish = vi.fn()
+    const agentError = vi.fn()
     const renderError = new Error("render failed")
     const agent = defineAgent({
       capabilities: [{
@@ -7023,7 +7148,7 @@ describe("agent message protocol", () => {
         },
       }],
       hooks: {
-        "agent:finish": finish,
+        "agent:error": agentError,
       },
       driver: { run: () => (async function* () {
           yield "hello"
@@ -7031,7 +7156,7 @@ describe("agent message protocol", () => {
     })
 
     await expect(streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).rejects.toThrow("render failed")
-    expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+    expect(agentError).toHaveBeenCalledWith(expect.objectContaining({
       error: renderError,
     }))
   })
@@ -9639,13 +9764,13 @@ describe("agent message protocol", () => {
     expect(finish).toHaveBeenCalledTimes(1)
   })
 
-  it("runs agent finish hooks with Response body read errors", async () => {
+  it("runs Agent Error Hooks with Response body read errors", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
-    const finish = vi.fn()
+    const agentError = vi.fn()
     const error = new Error("upstream failed")
     const agent = defineAgent({
       hooks: {
-        "agent:finish": finish,
+        "agent:error": agentError,
       },
       driver: { run: () => new Response(new ReadableStream({
           pull() {
@@ -9656,11 +9781,11 @@ describe("agent message protocol", () => {
 
     const response = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}) as Response
     await expect(response.text()).rejects.toThrow("upstream failed")
-    expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+    expect(agentError).toHaveBeenCalledWith(expect.objectContaining({
       error,
     }))
-    expect(finish.mock.calls[0]![0]).not.toHaveProperty("result")
-    expect(deriveTraceRuns(finish.mock.calls[0]![0].runtime.traceLog.entries())).toMatchObject([{ status: "failed" }])
+    expect(agentError.mock.calls[0]![0]).not.toHaveProperty("result")
+    expect(deriveTraceRuns(agentError.mock.calls[0]![0].runtime.traceLog.entries())).toMatchObject([{ status: "failed" }])
   })
 
   it("runs agent finish hooks when Response bodies are canceled", async () => {
@@ -9683,23 +9808,23 @@ describe("agent message protocol", () => {
     expect(deriveTraceRuns(finish.mock.calls[0]![0].runtime.traceLog.entries())).toMatchObject([{ status: "completed" }])
   })
 
-  it("runs agent finish hooks when Response wrapping fails", async () => {
+  it("runs Agent Error Hooks when Response wrapping fails", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
-    const finish = vi.fn()
+    const agentError = vi.fn()
     const body = new ReadableStream()
     body.getReader()
     const agent = defineAgent({
       hooks: {
-        "agent:finish": finish,
+        "agent:error": agentError,
       },
       driver: { run: () => new Response(body) },
     })
 
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).rejects.toThrow()
-    expect(finish).toHaveBeenCalledWith(expect.objectContaining({
+    expect(agentError).toHaveBeenCalledWith(expect.objectContaining({
       error: expect.any(TypeError),
     }))
-    expect(finish.mock.calls[0]![0]).not.toHaveProperty("result")
+    expect(agentError.mock.calls[0]![0]).not.toHaveProperty("result")
   })
 
   it("preserves generated Response payload and metadata while tracing completion", async () => {

--- a/packages/agent/test/test-runner.test.ts
+++ b/packages/agent/test/test-runner.test.ts
@@ -245,6 +245,37 @@ describe("agent test runner", () => {
     }))
   })
 
+  it("preserves error hook delivery effects while capturing failed test runs", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const { createAgentTestRunner } = await import("../src/test.ts")
+    const failure = new Error("failed")
+    const agentError = vi.fn(event => event.reply(event.errorMessage))
+    const reply = vi.fn()
+    const runner = createAgentTestRunner(defineAgent({
+      channels: {
+        portal: defineChannel("portal", {
+          effects: { reply },
+          messages: false,
+        }),
+      },
+      driver: { run: () => { throw failure }, },
+      hooks: {
+        "agent:error": agentError,
+      },
+    }), {
+      run: { channelId: "portal", runId: "test-run" },
+      runtimeConfig: {},
+    })
+
+    await expect(runner.run({ prompt: "hello" })).rejects.toBe(failure)
+    expect(agentError).toHaveBeenCalledOnce()
+    expect(agentError.mock.calls[0]![0].error).toBe(failure)
+    expect(reply).toHaveBeenCalledWith(expect.objectContaining({
+      effect: expect.objectContaining({ kind: "reply", payload: "failed" }),
+    }))
+  })
+
   it("applies workspace defaults and collects workspace tool steps", async () => {
     const { registerWorkspace } = await import("@vite-hub/workspace/test")
     const execute = vi.fn(async () => "workspace result")

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelDeliveryReplyStream, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentFinishEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentMessageDeliveryKind, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUIMessageStreamProjection, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelDeliveryReplyStream, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentErrorHookEvent, type AgentFinishEvent, type AgentFinishHookEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentMessageDeliveryKind, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUIMessageStreamProjection, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, repositoryHost, repositoryHostContext, sandbox, schedule, skills, streamTranscription, subagents, transcribe, usageCost, vercelAiGatewayPricing, webSearch, workspaceShell, type AgentUsagePricing, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput, type UsageCostOptions, type VercelAiGatewayPricingOptions } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -46,7 +46,22 @@ describe("agent public types", () => {
       capabilities: [usageCost(options)],
       driver: { run: () => "ok" },
       hooks: {
+        "agent:error"(event) {
+          expectTypeOf(event).toMatchTypeOf<AgentErrorHookEvent>()
+          expectTypeOf<AgentErrorHookEvent>().toMatchTypeOf<{ error: unknown }>()
+          expectTypeOf(event.error).toEqualTypeOf<unknown>()
+          expectTypeOf(event.errorMessage).toEqualTypeOf<string>()
+          // @ts-expect-error Agent Error Hooks do not receive successful results.
+          void event.result
+          // @ts-expect-error Agent Error Hooks do not receive successful text.
+          void event.text
+        },
         "agent:finish"(event) {
+          expectTypeOf(event).toMatchTypeOf<AgentFinishHookEvent>()
+          // @ts-expect-error Agent Finish Hooks do not receive failed outcomes.
+          void event.error
+          // @ts-expect-error Agent Finish Hooks do not receive normalized error messages.
+          void event.errorMessage
           expectTypeOf(event.extensions.get("usage-cost")).toEqualTypeOf<AgentUsageRecord | undefined>()
         },
       },
@@ -660,7 +675,8 @@ describe("agent public types", () => {
           expectTypeOf(event.extensions.get<TranscriptionResult[]>("transcribe")).toEqualTypeOf<TranscriptionResult[] | undefined>()
           expectTypeOf(event.extensions.get("missing")).toEqualTypeOf<unknown>()
           expectTypeOf(event.invocation.usage).toEqualTypeOf<AgentUsageRecord | undefined>()
-          expectTypeOf(event.errorMessage).toEqualTypeOf<string | undefined>()
+          // @ts-expect-error Agent Finish Hooks exclude normalized error messages.
+          void event.errorMessage
           return event.reply((async function* () {
             yield "streamed reply"
           })())


### PR DESCRIPTION
Splits top-level Agent Definition outcome hooks so `agent:finish` receives only successful Agent Invocations and `agent:error` receives failures with the original thrown value and a normalized message. Both hooks keep delivery helpers and outcome extensions, while Capability cleanup and command-scoped `inputCommands(...).hooks["agent:finish"]` remain outcome-agnostic.

Verified with the `@vite-hub/agent` build and typecheck, 379 focused lifecycle/runtime/test-runner tests, and the complete 1,578-test Agent suite, including run, stream, `Response`, delivery, observation, tracing, and public type coverage.