### PR TITLE
feat(agent): upload current input attachments with Blob

### DIFF
--- a/docs/content/docs/capabilities/blob.md
+++ b/docs/content/docs/capabilities/blob.md
@@ -19,7 +19,7 @@ Use the configuration example below as the starting point, then tighten modes, p
 
 The Capability contributes `blob_read` for get, head, and list operations.
 When configured with write mode, it also contributes `blob_edit` for putting or deleting objects.
-`blob_edit` can upload inline content or a Workspace file through `workspacePath`.
+`blob_edit` can upload inline content, a current input attachment through `attachmentId`, or a Workspace file through `workspacePath`.
 For Harness Agents, `assetPaths` also turns final-answer Markdown references into published delivery artifacts.
 
 ## Configuration

--- a/docs/content/docs/capabilities/blob.md
+++ b/docs/content/docs/capabilities/blob.md
@@ -44,7 +44,7 @@ export default defineAgent({
 ViteHub selects the configured Blob store and exposes a small Storage Capability Tool Surface.
 Read mode supports one object read, metadata read, or prefix list operation per tool call.
 Write mode adds put/delete operations and allows them by default.
-Put operations accept either `body` or `workspacePath`, not both.
+Put operations accept exactly one of `attachmentId`, `body`, or `workspacePath`.
 Delete operations return `{ pathname, deleted: true }`.
 
 ## Requirements

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1,4 +1,4 @@
-import { getMessageText, isAttachmentData, isAttachmentPart } from "./messages.ts"
+import { getMessageText, isAttachmentData, isAttachmentPart, resolveAttachmentData } from "./messages.ts"
 import {
   cloneWithPropertyDescriptors,
   isAsyncIterable,
@@ -360,7 +360,7 @@ function assertAttachmentWithinLimit(part: AttachmentPart, byteLength: number | 
 
 async function resolveModelAttachmentPart(part: AttachmentPart, maxBytes: number): Promise<{ byteLength: number, part: AttachmentPart }> {
   assertAttachmentWithinLimit(part, part.size, maxBytes)
-  const resolved = typeof part.fetchData === "function" ? await part.fetchData() : part.data
+  const resolved = await resolveAttachmentData(part)
   if (typeof part.fetchData === "function" && !isAttachmentData(resolved)) {
     throw new TypeError(`[vitehub] ${part.type} attachment fetchData() did not return supported attachment data.`)
   }

--- a/packages/agent/src/capabilities/storage/blob.ts
+++ b/packages/agent/src/capabilities/storage/blob.ts
@@ -7,6 +7,7 @@ import {
   readHarnessWorkspaceDiff,
 } from "../../harness-runtime.ts"
 import { cloneWithPropertyDescriptors } from "../../internal/stream-result.ts"
+import { isAttachmentData, isAttachmentPart } from "../../messages.ts"
 import {
   assertString,
   createTool,
@@ -21,9 +22,11 @@ import type {
   AgentCapabilityDefinition,
   AgentCapabilityContext,
   AgentCapabilityMode,
+  AgentCapabilityRuntimeContext,
   AgentToolSet,
   MaybePromise,
 } from "../../types.ts"
+import type { AttachmentPart } from "../../messages.ts"
 import type { PrimitiveStorageCapabilityOptions } from "./shared.ts"
 
 export interface BlobCapabilityOptions extends PrimitiveStorageCapabilityOptions {
@@ -60,6 +63,7 @@ interface BlobReadInput {
 }
 
 interface BlobEditInput {
+  attachmentId?: string
   body?: unknown
   operation: "delete" | "put"
   options?: Record<string, unknown>
@@ -81,6 +85,10 @@ const blobReadInputSchema = jsonObjectSchema({
 }, ["operation"])
 
 const blobEditInputSchema = jsonObjectSchema({
+  attachmentId: {
+    description: "Upload a current input attachment instead of inline body or a Workspace file.",
+    type: "string",
+  },
   body: {},
   operation: { enum: ["delete", "put"], type: "string" },
   options: { additionalProperties: true, type: "object" },
@@ -245,8 +253,33 @@ async function readWorkspaceBlobBody(context: AgentCapabilityContext, path: stri
   return await context.fs.readFile(path as never, { encoding: "binary" })
 }
 
+function currentInputAttachments(context: AgentCapabilityRuntimeContext): AttachmentPart[] {
+  const messages = context.input.messages()
+  const current = context.run?.messageId
+    ? messages.find(message => message.id === context.run?.messageId)
+    : [...messages].reverse().find(message => message.role === "user")
+  return current?.parts.filter(isAttachmentPart) ?? []
+}
+
+async function readInputAttachment(context: AgentCapabilityRuntimeContext, id: string) {
+  const attachments = currentInputAttachments(context)
+  const matches = attachments.filter(part => part.id === id)
+  if (matches.length !== 1) {
+    const available = attachments.flatMap(part => part.id ? [part.id] : [])
+    throw new Error(`[vitehub] blob_edit attachmentId ${JSON.stringify(id)} must identify one current input attachment.${available.length ? ` Available: ${available.join(", ")}.` : ""}`)
+  }
+  const attachment = matches[0]!
+  const body = typeof attachment.fetchData === "function" ? await attachment.fetchData() : attachment.data
+  if (!isAttachmentData(body)) {
+    throw new Error(`[vitehub] blob_edit attachmentId ${JSON.stringify(id)} did not resolve to supported attachment data.`)
+  }
+  return { body, mediaType: attachment.mediaType }
+}
+
 function blobTools(mode: AgentCapabilityMode, options: BlobCapabilityOptions): AgentCapabilityDefinition["tools"] {
   return (context) => {
+    const attachments = currentInputAttachments(context)
+      .flatMap(part => part.id ? [`${part.id} (${part.mediaType})`] : [])
     const tools: AgentToolSet = {
       blob_read: createTool<BlobReadInput>({
         description: "Read one Blob object, read object metadata, or list objects under a developer-provided prefix.",
@@ -266,17 +299,30 @@ function blobTools(mode: AgentCapabilityMode, options: BlobCapabilityOptions): A
     }
     if (mode === "write") {
       tools.blob_edit = createTool<BlobEditInput>({
-        description: "Put or delete Blob objects. Use workspacePath to upload a Workspace file.",
-        execute: async ({ body, operation, options: putOptions, pathname, workspacePath }) => {
+        description: [
+          "Put or delete Blob objects. Use attachmentId for a current input attachment or workspacePath for a Workspace file.",
+          ...(attachments.length ? [`Current input attachments: ${attachments.join(", ")}.`] : []),
+        ].join(" "),
+        execute: async ({ attachmentId, body, operation, options: putOptions, pathname, workspacePath }) => {
           const store = await resolveBlobStore(context, options)
           if (operation === "put") {
             const path = assertString(pathname, "blob_edit pathname")
             const sourcePath = typeof workspacePath === "string" && workspacePath.trim() ? workspacePath : undefined
-            if (sourcePath && body !== undefined) throw new Error("[vitehub] blob_edit put accepts body or workspacePath, not both.")
+            const sourceAttachment = typeof attachmentId === "string" && attachmentId.trim() ? attachmentId : undefined
+            const sources = Number(body !== undefined) + Number(Boolean(sourcePath)) + Number(Boolean(sourceAttachment))
+            if (sources > 1) throw new Error("[vitehub] blob_edit put accepts exactly one of attachmentId, body, or workspacePath.")
+            if (sourceAttachment) {
+              const attachment = await readInputAttachment(context, sourceAttachment)
+              return storageValue(method<(pathname: string, body: unknown, options?: unknown) => MaybePromise<unknown>>(store, "blob", "put")(
+                path,
+                attachment.body,
+                { ...(attachment.mediaType ? { contentType: attachment.mediaType } : {}), ...putOptions },
+              ))
+            }
             if (sourcePath) {
               return storageValue(method<(pathname: string, body: unknown, options?: unknown) => MaybePromise<unknown>>(store, "blob", "put")(path, await readWorkspaceBlobBody(context, sourcePath), putOptions))
             }
-            if (body === undefined) throw new Error("[vitehub] blob_edit put requires body or workspacePath.")
+            if (body === undefined) throw new Error("[vitehub] blob_edit put requires attachmentId, body, or workspacePath.")
             return storageValue(method<(pathname: string, body: unknown, options?: unknown) => MaybePromise<unknown>>(store, "blob", "put")(path, body, putOptions))
           }
           if (operation === "delete") {

--- a/packages/agent/src/capabilities/storage/blob.ts
+++ b/packages/agent/src/capabilities/storage/blob.ts
@@ -7,7 +7,7 @@ import {
   readHarnessWorkspaceDiff,
 } from "../../harness-runtime.ts"
 import { cloneWithPropertyDescriptors } from "../../internal/stream-result.ts"
-import { isAttachmentData, isAttachmentPart } from "../../messages.ts"
+import { attachmentStringBytes, currentInputAttachments, isAttachmentData, resolveAttachmentData } from "../../messages.ts"
 import {
   assertString,
   createTool,
@@ -22,7 +22,6 @@ import type {
   AgentCapabilityDefinition,
   AgentCapabilityContext,
   AgentCapabilityMode,
-  AgentCapabilityRuntimeContext,
   AgentToolSet,
   MaybePromise,
 } from "../../types.ts"
@@ -253,52 +252,30 @@ async function readWorkspaceBlobBody(context: AgentCapabilityContext, path: stri
   return await context.fs.readFile(path as never, { encoding: "binary" })
 }
 
-function currentInputAttachments(context: AgentCapabilityRuntimeContext): AttachmentPart[] {
-  if (!context.input) return []
-  const messages = context.input.messages()
-  const current = context.run?.messageId
-    ? messages.find(message => message.id === context.run?.messageId)
-    : [...messages].reverse().find(message => message.role === "user")
-  return current?.parts.filter((part): part is AttachmentPart =>
-    isAttachmentPart(part)
-    && (isAttachmentData(part.data) || typeof part.fetchData === "function"),
-  ) ?? []
+function resolvableInputAttachments(context: AgentCapabilityContext): AttachmentPart[] {
+  if (!context.invocation) return []
+  return currentInputAttachments(context.invocation.input.messages(), context.run?.messageId)
+    .filter(part => isAttachmentData(part.data) || typeof part.fetchData === "function")
 }
 
-async function readInputAttachment(context: AgentCapabilityRuntimeContext, id: string) {
-  const attachments = currentInputAttachments(context)
+async function readInputAttachment(context: AgentCapabilityContext, id: string) {
+  const attachments = resolvableInputAttachments(context)
   const matches = attachments.filter(part => part.id === id)
   if (matches.length !== 1) {
     const available = attachments.flatMap(part => part.id ? [part.id] : [])
     throw new Error(`[vitehub] blob_edit attachmentId ${JSON.stringify(id)} must identify one current input attachment.${available.length ? ` Available: ${available.join(", ")}.` : ""}`)
   }
   const attachment = matches[0]!
-  const body = typeof attachment.fetchData === "function" ? await attachment.fetchData() : attachment.data
+  const body = await resolveAttachmentData(attachment)
   if (!isAttachmentData(body)) {
     throw new Error(`[vitehub] blob_edit attachmentId ${JSON.stringify(id)} did not resolve to supported attachment data.`)
   }
-  return { body: decodeAttachmentString(body, attachment.mediaType), mediaType: attachment.mediaType }
-}
-
-function decodeAttachmentString(body: AttachmentPart["data"], mediaType: string) {
-  if (typeof body !== "string") return body
-  const dataUrl = /^data:[^,]*?(;base64)?,(.*)$/is.exec(body)
-  if (dataUrl) {
-    return dataUrl[1]
-      ? Uint8Array.from(atob(dataUrl[2]!), character => character.charCodeAt(0))
-      : new TextEncoder().encode(decodeURIComponent(dataUrl[2]!))
-  }
-  const normalizedMediaType = mediaType.split(";", 1)[0]!.trim().toLowerCase()
-  if (normalizedMediaType.startsWith("text/") || normalizedMediaType === "application/json" || normalizedMediaType === "application/xml" || normalizedMediaType.endsWith("+json") || normalizedMediaType.endsWith("+xml")) {
-    return body
-  }
-  return Uint8Array.from(atob(body), character => character.charCodeAt(0))
+  return { body: typeof body === "string" ? attachmentStringBytes(body, attachment.mediaType) : body, mediaType: attachment.mediaType }
 }
 
 function blobTools(mode: AgentCapabilityMode, options: BlobCapabilityOptions): AgentCapabilityDefinition["tools"] {
   return (context) => {
-    const runtimeContext = context as AgentCapabilityRuntimeContext
-    const attachments = currentInputAttachments(runtimeContext)
+    const attachments = resolvableInputAttachments(context)
       .flatMap(part => part.id ? [`${part.id} (${part.mediaType})`] : [])
     const tools: AgentToolSet = {
       blob_read: createTool<BlobReadInput>({
@@ -332,11 +309,11 @@ function blobTools(mode: AgentCapabilityMode, options: BlobCapabilityOptions): A
             const sources = Number(body !== undefined) + Number(Boolean(sourcePath)) + Number(Boolean(sourceAttachment))
             if (sources > 1) throw new Error("[vitehub] blob_edit put accepts exactly one of attachmentId, body, or workspacePath.")
             if (sourceAttachment) {
-              const attachment = await readInputAttachment(runtimeContext, sourceAttachment)
+              const attachment = await readInputAttachment(context, sourceAttachment)
               return storageValue(method<(pathname: string, body: unknown, options?: unknown) => MaybePromise<unknown>>(store, "blob", "put")(
                 path,
                 attachment.body,
-                { ...(attachment.mediaType ? { contentType: attachment.mediaType } : {}), ...putOptions },
+                { ...putOptions, ...(attachment.mediaType ? { contentType: attachment.mediaType } : {}) },
               ))
             }
             if (sourcePath) {

--- a/packages/agent/src/capabilities/storage/blob.ts
+++ b/packages/agent/src/capabilities/storage/blob.ts
@@ -278,7 +278,8 @@ async function readInputAttachment(context: AgentCapabilityRuntimeContext, id: s
 
 function blobTools(mode: AgentCapabilityMode, options: BlobCapabilityOptions): AgentCapabilityDefinition["tools"] {
   return (context) => {
-    const attachments = currentInputAttachments(context)
+    const runtimeContext = context as AgentCapabilityRuntimeContext
+    const attachments = currentInputAttachments(runtimeContext)
       .flatMap(part => part.id ? [`${part.id} (${part.mediaType})`] : [])
     const tools: AgentToolSet = {
       blob_read: createTool<BlobReadInput>({
@@ -312,7 +313,7 @@ function blobTools(mode: AgentCapabilityMode, options: BlobCapabilityOptions): A
             const sources = Number(body !== undefined) + Number(Boolean(sourcePath)) + Number(Boolean(sourceAttachment))
             if (sources > 1) throw new Error("[vitehub] blob_edit put accepts exactly one of attachmentId, body, or workspacePath.")
             if (sourceAttachment) {
-              const attachment = await readInputAttachment(context, sourceAttachment)
+              const attachment = await readInputAttachment(runtimeContext, sourceAttachment)
               return storageValue(method<(pathname: string, body: unknown, options?: unknown) => MaybePromise<unknown>>(store, "blob", "put")(
                 path,
                 attachment.body,

--- a/packages/agent/src/capabilities/storage/blob.ts
+++ b/packages/agent/src/capabilities/storage/blob.ts
@@ -288,8 +288,8 @@ function decodeAttachmentString(body: AttachmentPart["data"], mediaType: string)
       ? Uint8Array.from(atob(dataUrl[2]!), character => character.charCodeAt(0))
       : new TextEncoder().encode(decodeURIComponent(dataUrl[2]!))
   }
-  const normalizedMediaType = mediaType.toLowerCase()
-  if (normalizedMediaType.startsWith("text/") || normalizedMediaType === "application/json" || normalizedMediaType.endsWith("+json") || normalizedMediaType.endsWith("+xml")) {
+  const normalizedMediaType = mediaType.split(";", 1)[0]!.trim().toLowerCase()
+  if (normalizedMediaType.startsWith("text/") || normalizedMediaType === "application/json" || normalizedMediaType === "application/xml" || normalizedMediaType.endsWith("+json") || normalizedMediaType.endsWith("+xml")) {
     return body
   }
   return Uint8Array.from(atob(body), character => character.charCodeAt(0))

--- a/packages/agent/src/capabilities/storage/blob.ts
+++ b/packages/agent/src/capabilities/storage/blob.ts
@@ -269,11 +269,34 @@ async function readInputAttachment(context: AgentCapabilityRuntimeContext, id: s
     throw new Error(`[vitehub] blob_edit attachmentId ${JSON.stringify(id)} must identify one current input attachment.${available.length ? ` Available: ${available.join(", ")}.` : ""}`)
   }
   const attachment = matches[0]!
-  const body = typeof attachment.fetchData === "function" ? await attachment.fetchData() : attachment.data
+  const body = typeof attachment.fetchData === "function"
+    ? await attachment.fetchData()
+    : attachment.data ?? (attachment.url ? await fetchAttachmentUrl(attachment.url) : undefined)
   if (!isAttachmentData(body)) {
     throw new Error(`[vitehub] blob_edit attachmentId ${JSON.stringify(id)} did not resolve to supported attachment data.`)
   }
-  return { body, mediaType: attachment.mediaType }
+  return { body: decodeAttachmentString(body, attachment.mediaType), mediaType: attachment.mediaType }
+}
+
+async function fetchAttachmentUrl(url: string): Promise<ArrayBuffer> {
+  const response = await fetch(url)
+  if (!response.ok) throw new Error(`[vitehub] blob_edit attachment request failed with ${response.status}.`)
+  return await response.arrayBuffer()
+}
+
+function decodeAttachmentString(body: AttachmentPart["data"], mediaType: string) {
+  if (typeof body !== "string") return body
+  const dataUrl = /^data:[^,]*?(;base64)?,(.*)$/is.exec(body)
+  if (dataUrl) {
+    return dataUrl[1]
+      ? Uint8Array.from(atob(dataUrl[2]!), character => character.charCodeAt(0))
+      : new TextEncoder().encode(decodeURIComponent(dataUrl[2]!))
+  }
+  const normalizedMediaType = mediaType.toLowerCase()
+  if (normalizedMediaType.startsWith("text/") || normalizedMediaType === "application/json" || normalizedMediaType.endsWith("+json") || normalizedMediaType.endsWith("+xml")) {
+    return body
+  }
+  return Uint8Array.from(atob(body), character => character.charCodeAt(0))
 }
 
 function blobTools(mode: AgentCapabilityMode, options: BlobCapabilityOptions): AgentCapabilityDefinition["tools"] {

--- a/packages/agent/src/capabilities/storage/blob.ts
+++ b/packages/agent/src/capabilities/storage/blob.ts
@@ -254,11 +254,15 @@ async function readWorkspaceBlobBody(context: AgentCapabilityContext, path: stri
 }
 
 function currentInputAttachments(context: AgentCapabilityRuntimeContext): AttachmentPart[] {
+  if (!context.input) return []
   const messages = context.input.messages()
   const current = context.run?.messageId
     ? messages.find(message => message.id === context.run?.messageId)
     : [...messages].reverse().find(message => message.role === "user")
-  return current?.parts.filter(isAttachmentPart) ?? []
+  return current?.parts.filter((part): part is AttachmentPart =>
+    isAttachmentPart(part)
+    && (isAttachmentData(part.data) || typeof part.fetchData === "function"),
+  ) ?? []
 }
 
 async function readInputAttachment(context: AgentCapabilityRuntimeContext, id: string) {
@@ -269,19 +273,11 @@ async function readInputAttachment(context: AgentCapabilityRuntimeContext, id: s
     throw new Error(`[vitehub] blob_edit attachmentId ${JSON.stringify(id)} must identify one current input attachment.${available.length ? ` Available: ${available.join(", ")}.` : ""}`)
   }
   const attachment = matches[0]!
-  const body = typeof attachment.fetchData === "function"
-    ? await attachment.fetchData()
-    : attachment.data ?? (attachment.url ? await fetchAttachmentUrl(attachment.url) : undefined)
+  const body = typeof attachment.fetchData === "function" ? await attachment.fetchData() : attachment.data
   if (!isAttachmentData(body)) {
     throw new Error(`[vitehub] blob_edit attachmentId ${JSON.stringify(id)} did not resolve to supported attachment data.`)
   }
   return { body: decodeAttachmentString(body, attachment.mediaType), mediaType: attachment.mediaType }
-}
-
-async function fetchAttachmentUrl(url: string): Promise<ArrayBuffer> {
-  const response = await fetch(url)
-  if (!response.ok) throw new Error(`[vitehub] blob_edit attachment request failed with ${response.status}.`)
-  return await response.arrayBuffer()
 }
 
 function decodeAttachmentString(body: AttachmentPart["data"], mediaType: string) {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -6,7 +6,7 @@ import {
   createCapabilityCliTool,
 } from "./capability-cli.ts"
 import { normalizeWorkspaceCommandEntries, workspaceCommandTools } from "./capabilities/workspace-command.ts"
-import { createMessage } from "./messages.ts"
+import { createMessage, memoizeMessageAttachmentData } from "./messages.ts"
 import { agentInvocationCallbackContextValues, agentInvocationSourceContext, createAgentInvocationContextStore } from "./invocation-context.ts"
 import {
   createFallbackAgentInvoker,
@@ -878,7 +878,9 @@ export async function resolveAgentCapabilities<
   let currentInput = normalizeRunInput(input)
   let currentWorkspace = workspace as ReadonlyWorkspaceFacade<Name> | undefined
   let currentWorkspaceDefinition = invocationOptions.workspaceDefinition
-  let messages = getRunMessages(currentInput)
+  const inputMessages = getRunMessages(currentInput)
+  let messages = memoizeMessageAttachmentData(inputMessages)
+  if (messages !== inputMessages) currentInput = withMessages(currentInput, messages)
   let tools: AgentToolSet | undefined
   const driverContributions: AgentDriverContribution[] = []
   let capabilityScope: Awaited<ReturnType<typeof openAgentCapabilityScope>> | undefined
@@ -1003,10 +1005,12 @@ export async function resolveAgentCapabilities<
         messages: () => messages,
         set(value) {
           currentInput = normalizeRunInput(value)
-          messages = getRunMessages(currentInput)
+          const inputMessages = getRunMessages(currentInput)
+          messages = memoizeMessageAttachmentData(inputMessages)
+          if (messages !== inputMessages) currentInput = withMessages(currentInput, messages)
         },
         setMessages(value) {
-          messages = value
+          messages = memoizeMessageAttachmentData(value)
           currentInput = withMessages(currentInput, messages)
         },
       }

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -28,6 +28,7 @@ import type {
   AgentCapabilityTypeContract,
   AgentCapabilityHookName,
   AgentCapabilityHooks,
+  AgentCapabilityInputContext,
   AgentCapabilityMode,
   AgentCapabilityRuntimeContext,
   AgentChannelDeliveryEffectIntent,
@@ -997,6 +998,18 @@ export async function resolveAgentCapabilities<
         workspaceMaterializationPaths,
       }
       let capabilityContext: AgentCapabilityRuntimeContext<TRuntimeConfig, Name> & WorkspaceOverrideRuntime<Name>
+      const input: AgentCapabilityInputContext = {
+        get: () => currentInput,
+        messages: () => messages,
+        set(value) {
+          currentInput = normalizeRunInput(value)
+          messages = getRunMessages(currentInput)
+        },
+        setMessages(value) {
+          messages = value
+          currentInput = withMessages(currentInput, messages)
+        },
+      }
       capabilityContext = {
         ...metadataContext,
         [workspaceOverrideSymbol](nextWorkspace: ReadonlyWorkspaceFacade<Name>) {
@@ -1005,18 +1018,8 @@ export async function resolveAgentCapabilities<
         },
         capability,
         mode: capability.mode,
-        input: {
-          get: () => currentInput,
-          messages: () => messages,
-          set(value) {
-            currentInput = normalizeRunInput(value)
-            messages = getRunMessages(currentInput)
-          },
-          setMessages(value) {
-            messages = value
-            currentInput = withMessages(currentInput, messages)
-          },
-        },
+        input,
+        invocation: { input },
         delivery: {
           effect(intent) {
             if (!intent || typeof intent !== "object" || typeof intent.kind !== "string" || !intent.kind.trim()) {

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -25,7 +25,7 @@ import {
   type ColocatedAgentSkills,
 } from "./internal/colocated-agent-skills.ts"
 import { toAiSdkModelMessages } from "./ai-sdk.ts"
-import { isAttachmentData, isAttachmentPart } from "./messages.ts"
+import { attachmentStringBytes, isAttachmentData, isAttachmentPart, resolveAttachmentData } from "./messages.ts"
 import { isAsyncIterable } from "./internal/stream-result.ts"
 import {
   applyAgentToolPolicies,
@@ -426,40 +426,18 @@ function harnessAttachmentStringBytes(value: string, mediaType: string, remainin
     const encoded = dataUrl[2]!
     if (dataUrl[1]!.split(";").some(parameter => parameter.toLowerCase() === "base64")) {
       assertHarnessAttachmentSize(harnessBase64ByteLength(encoded), remainingBytes, type)
-      return new Uint8Array(Buffer.from(encoded, "base64"))
+      return attachmentStringBytes(value, mediaType)
     }
     if (encoded.length > remainingBytes * 3) {
       assertHarnessAttachmentSize(Math.ceil(encoded.length / 3), remainingBytes, type)
     }
-    const bytes = new TextEncoder().encode(encoded)
-    let readIndex = 0
-    let writeIndex = 0
-    while (readIndex < bytes.length) {
-      if (bytes[readIndex] === 37) {
-        const encodedByte = String.fromCharCode(bytes[readIndex + 1]!, bytes[readIndex + 2]!)
-        if (!/^[\da-f]{2}$/i.test(encodedByte)) throw new URIError("URI malformed")
-        bytes[writeIndex++] = Number.parseInt(encodedByte, 16)
-        readIndex += 3
-      }
-      else {
-        bytes[writeIndex++] = bytes[readIndex++]!
-      }
-    }
-    assertHarnessAttachmentSize(writeIndex, remainingBytes, type)
-    return bytes.slice(0, writeIndex)
+    const bytes = attachmentStringBytes(value, mediaType)
+    assertHarnessAttachmentSize(bytes.byteLength, remainingBytes, type)
+    return bytes
   }
-  const normalizedMediaType = mediaType.toLowerCase()
-  if (
-    normalizedMediaType.startsWith("text/")
-    || normalizedMediaType === "application/json"
-    || normalizedMediaType.endsWith("+json")
-    || normalizedMediaType.endsWith("+xml")
-  ) {
-    assertHarnessAttachmentSize(Buffer.byteLength(value), remainingBytes, type)
-    return new TextEncoder().encode(value)
-  }
-  assertHarnessAttachmentSize(harnessBase64ByteLength(value), remainingBytes, type)
-  return new Uint8Array(Buffer.from(value, "base64"))
+  const bytes = attachmentStringBytes(value, mediaType)
+  assertHarnessAttachmentSize(bytes.byteLength, remainingBytes, type)
+  return bytes
 }
 
 async function harnessAttachmentBytes(data: AttachmentData, mediaType: string, remainingBytes: number, type: string): Promise<Uint8Array> {
@@ -482,13 +460,12 @@ async function resolveHarnessAttachmentData(
   part: Extract<Message["parts"][number], { type: "audio" | "file" | "image" }>,
   abortSignal?: AbortSignal,
 ): Promise<AttachmentData | undefined> {
-  if (typeof part.fetchData !== "function") return isAttachmentData(part.data) ? part.data : undefined
   if (abortSignal?.aborted) {
     throw abortSignalError(abortSignal, "[vitehub] Harness attachment resolution aborted.")
   }
-  const fetchedPromise = Promise.resolve(part.fetchData())
+  const fetchedPromise = resolveAttachmentData(part)
   const fetched = abortSignal
-    ? await new Promise<AttachmentData>((resolve, reject) => {
+    ? await new Promise<AttachmentData | undefined>((resolve, reject) => {
         const onAbort = () => {
           abortSignal.removeEventListener("abort", onAbort)
           reject(abortSignalError(abortSignal, "[vitehub] Harness attachment resolution aborted."))

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -25,7 +25,7 @@ import {
   type ColocatedAgentSkills,
 } from "./internal/colocated-agent-skills.ts"
 import { toAiSdkModelMessages } from "./ai-sdk.ts"
-import { attachmentStringBytes, isAttachmentData, isAttachmentPart, resolveAttachmentData } from "./messages.ts"
+import { attachmentStringBytes, isAttachmentData, isAttachmentPart, isTextAttachmentMediaType, resolveAttachmentData } from "./messages.ts"
 import { isAsyncIterable } from "./internal/stream-result.ts"
 import {
   applyAgentToolPolicies,
@@ -434,6 +434,12 @@ function harnessAttachmentStringBytes(value: string, mediaType: string, remainin
     const bytes = attachmentStringBytes(value, mediaType)
     assertHarnessAttachmentSize(bytes.byteLength, remainingBytes, type)
     return bytes
+  }
+  if (!isTextAttachmentMediaType(mediaType)) {
+    assertHarnessAttachmentSize(harnessBase64ByteLength(value), remainingBytes, type)
+  }
+  else {
+    assertHarnessAttachmentSize(Buffer.byteLength(value), remainingBytes, type)
   }
   const bytes = attachmentStringBytes(value, mediaType)
   assertHarnessAttachmentSize(bytes.byteLength, remainingBytes, type)

--- a/packages/agent/src/messages.ts
+++ b/packages/agent/src/messages.ts
@@ -133,6 +133,54 @@ export function isAttachmentPart(value: unknown): value is AttachmentPart {
   return type === "audio" || type === "file" || type === "image"
 }
 
+export function currentInputAttachments(messages: Message[], messageId?: string): AttachmentPart[] {
+  const current = messageId
+    ? messages.find(message => message.id === messageId)
+    : [...messages].reverse().find(message => message.role === "user")
+  return current?.parts.filter(isAttachmentPart) ?? []
+}
+
+const attachmentDataResolutions = new WeakMap<AttachmentPart, Promise<AttachmentData | undefined>>()
+
+export function resolveAttachmentData(part: AttachmentPart): Promise<AttachmentData | undefined> {
+  if (typeof part.fetchData !== "function") return Promise.resolve(isAttachmentData(part.data) ? part.data : undefined)
+  const existing = attachmentDataResolutions.get(part)
+  if (existing) return existing
+  const resolution = Promise.resolve().then(() => part.fetchData!()).then(data => isAttachmentData(data) ? data : undefined)
+  attachmentDataResolutions.set(part, resolution)
+  return resolution
+}
+
+export function attachmentStringBytes(value: string, mediaType: string): Uint8Array {
+  const dataUrl = /^data:([^,]*?),(.*)$/is.exec(value)
+  if (dataUrl) {
+    const encoded = dataUrl[2]!
+    if (dataUrl[1]!.split(";").some(parameter => parameter.toLowerCase() === "base64")) {
+      return Uint8Array.from(atob(encoded), character => character.charCodeAt(0))
+    }
+    const bytes = new TextEncoder().encode(encoded)
+    let readIndex = 0
+    let writeIndex = 0
+    while (readIndex < bytes.length) {
+      if (bytes[readIndex] === 37) {
+        const encodedByte = String.fromCharCode(bytes[readIndex + 1]!, bytes[readIndex + 2]!)
+        if (!/^[\da-f]{2}$/i.test(encodedByte)) throw new URIError("URI malformed")
+        bytes[writeIndex++] = Number.parseInt(encodedByte, 16)
+        readIndex += 3
+      }
+      else {
+        bytes[writeIndex++] = bytes[readIndex++]!
+      }
+    }
+    return bytes.slice(0, writeIndex)
+  }
+  const normalizedMediaType = mediaType.split(";", 1)[0]!.trim().toLowerCase()
+  if (normalizedMediaType.startsWith("text/") || normalizedMediaType === "application/json" || normalizedMediaType === "application/xml" || normalizedMediaType.endsWith("+json") || normalizedMediaType.endsWith("+xml")) {
+    return new TextEncoder().encode(value)
+  }
+  return Uint8Array.from(atob(value), character => character.charCodeAt(0))
+}
+
 export interface Message {
   createdAt?: string
   id: string

--- a/packages/agent/src/messages.ts
+++ b/packages/agent/src/messages.ts
@@ -140,15 +140,29 @@ export function currentInputAttachments(messages: Message[], messageId?: string)
   return current?.parts.filter(isAttachmentPart) ?? []
 }
 
-const attachmentDataResolutions = new WeakMap<AttachmentPart, Promise<AttachmentData | undefined>>()
-
 export function resolveAttachmentData(part: AttachmentPart): Promise<AttachmentData | undefined> {
   if (typeof part.fetchData !== "function") return Promise.resolve(isAttachmentData(part.data) ? part.data : undefined)
-  const existing = attachmentDataResolutions.get(part)
-  if (existing) return existing
-  const resolution = Promise.resolve().then(() => part.fetchData!()).then(data => isAttachmentData(data) ? data : undefined)
-  attachmentDataResolutions.set(part, resolution)
-  return resolution
+  return Promise.resolve().then(() => part.fetchData!()).then(data => isAttachmentData(data) ? data : undefined)
+}
+
+export function memoizeMessageAttachmentData(messages: Message[]): Message[] {
+  let changed = false
+  const memoized = messages.map((message) => {
+    let messageChanged = false
+    const parts = message.parts.map((part) => {
+      if (!isAttachmentPart(part) || typeof part.fetchData !== "function") return part
+      changed = true
+      messageChanged = true
+      const fetchData = part.fetchData
+      let resolution: Promise<AttachmentData> | undefined
+      return {
+        ...part,
+        fetchData: () => resolution ??= Promise.resolve().then(() => fetchData.call(part)),
+      }
+    })
+    return messageChanged ? { ...message, parts } : message
+  })
+  return changed ? memoized : messages
 }
 
 export function attachmentStringBytes(value: string, mediaType: string): Uint8Array {

--- a/packages/agent/src/messages.ts
+++ b/packages/agent/src/messages.ts
@@ -170,7 +170,7 @@ export function attachmentStringBytes(value: string, mediaType: string): Uint8Ar
   if (dataUrl) {
     const encoded = dataUrl[2]!
     if (dataUrl[1]!.split(";").some(parameter => parameter.toLowerCase() === "base64")) {
-      return Uint8Array.from(atob(encoded), character => character.charCodeAt(0))
+      return base64Bytes(encoded)
     }
     const bytes = new TextEncoder().encode(encoded)
     let readIndex = 0
@@ -188,11 +188,21 @@ export function attachmentStringBytes(value: string, mediaType: string): Uint8Ar
     }
     return bytes.slice(0, writeIndex)
   }
-  const normalizedMediaType = mediaType.split(";", 1)[0]!.trim().toLowerCase()
-  if (normalizedMediaType.startsWith("text/") || normalizedMediaType === "application/json" || normalizedMediaType === "application/xml" || normalizedMediaType.endsWith("+json") || normalizedMediaType.endsWith("+xml")) {
+  if (isTextAttachmentMediaType(mediaType)) {
     return new TextEncoder().encode(value)
   }
-  return Uint8Array.from(atob(value), character => character.charCodeAt(0))
+  return base64Bytes(value)
+}
+
+function base64Bytes(value: string): Uint8Array {
+  const normalized = value.replaceAll(/\s/g, "").replaceAll("-", "+").replaceAll("_", "/")
+  const padded = normalized.padEnd(normalized.length + (4 - normalized.length % 4) % 4, "=")
+  return Uint8Array.from(atob(padded), character => character.charCodeAt(0))
+}
+
+export function isTextAttachmentMediaType(mediaType: string): boolean {
+  const normalized = mediaType.split(";", 1)[0]!.trim().toLowerCase()
+  return normalized.startsWith("text/") || normalized === "application/json" || normalized === "application/xml" || normalized.endsWith("+json") || normalized.endsWith("+xml")
 }
 
 export interface Message {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -700,9 +700,17 @@ export interface AgentCapabilityContext<
   Name extends WorkspaceName = WorkspaceName,
 > extends AgentAdapterMetadataContext<TRuntimeConfig, Name> {
   abortSignal?: AbortSignal
+  invocation?: { input: AgentCapabilityInputContext }
   mode?: AgentCapabilityMode
   runtimeContext?: ResolvedAgentRuntimeContext
   workspaceDefinition?: WorkspaceDefinition
+}
+
+export interface AgentCapabilityInputContext {
+  get: () => AgentRunInput
+  messages: () => Message[]
+  set: (input: AgentRunInput) => void
+  setMessages: (messages: Message[]) => void
 }
 
 export type AgentCapabilityToolResolver<
@@ -776,12 +784,8 @@ export interface AgentCapabilityRuntimeContext<
   Name extends WorkspaceName = WorkspaceName,
 > extends AgentCapabilityContext<TRuntimeConfig, Name> {
   capability: AgentCapabilityDefinition<TRuntimeConfig, Name>
-  input: {
-    get: () => AgentRunInput
-    messages: () => Message[]
-    set: (input: AgentRunInput) => void
-    setMessages: (messages: Message[]) => void
-  }
+  input: AgentCapabilityInputContext
+  invocation: { input: AgentCapabilityInputContext }
   delivery: {
     effect: (intent: AgentChannelDeliveryEffectIntent) => void
     finishEffect: (effect: AgentChannelDeliveryFinishEffect) => void

--- a/packages/agent/test/harness-chat-history.test.ts
+++ b/packages/agent/test/harness-chat-history.test.ts
@@ -298,12 +298,15 @@ describe("Harness chat history", () => {
     await runAgent(agent, runtime, {
       context: { chat: {} },
       messages: [createMessage({
-        parts: [{ data: "data:application/octet-stream,%FF%00A", mediaType: "image/png", type: "image" }],
+        parts: [
+          { data: "data:application/octet-stream,%FF%00A", mediaType: "image/png", type: "image" },
+          { data: "-_8=", mediaType: "image/png", type: "image" },
+        ],
         role: "user",
       })],
     })
 
-    expect(turns[0]?.imageBytes).toEqual([[255, 0, 65]])
+    expect(turns[0]?.imageBytes).toEqual([[255, 0, 65], [251, 255]])
     expect(await attachmentPaths(root)).toEqual([])
   })
 

--- a/packages/agent/test/storage-capabilities.test.ts
+++ b/packages/agent/test/storage-capabilities.test.ts
@@ -545,13 +545,46 @@ describe("storage capabilities", () => {
     const body = new Blob(["data"], { type: "image/png" })
     await tools.blob_edit!.execute?.({ body, operation: "put", options: { contentType: "image/png" }, pathname: "images/a.png" })
     await tools.blob_edit!.execute?.({ operation: "put", pathname: "images/from-workspace.png", workspacePath: "screenshots/result.png" })
-    await expect(Promise.resolve().then(() => tools.blob_edit!.execute?.({ body: "inline", operation: "put", pathname: "images/a.png", workspacePath: "screenshots/result.png" }))).rejects.toThrow("body or workspacePath")
-    await expect(Promise.resolve().then(() => tools.blob_edit!.execute?.({ operation: "put", pathname: "images/a.png" }))).rejects.toThrow("body or workspacePath")
+    await expect(Promise.resolve().then(() => tools.blob_edit!.execute?.({ body: "inline", operation: "put", pathname: "images/a.png", workspacePath: "screenshots/result.png" }))).rejects.toThrow("exactly one")
+    await expect(Promise.resolve().then(() => tools.blob_edit!.execute?.({ operation: "put", pathname: "images/a.png" }))).rejects.toThrow("attachmentId, body, or workspacePath")
     await expect(tools.blob_edit!.execute?.({ operation: "delete", pathname: "images/a.png" })).resolves.toEqual({ pathname: "images/a.png", deleted: true })
     expect(store.put).toHaveBeenCalledWith("images/a.png", body, { contentType: "image/png" })
     expect(workspace.fs.readFile).toHaveBeenCalledWith("screenshots/result.png", { encoding: "binary" })
     expect(store.put).toHaveBeenCalledWith("images/from-workspace.png", workspaceBytes, undefined)
     expect(store.del).toHaveBeenCalledWith("images/a.png")
+  })
+
+  it("uploads a current input attachment by id", async () => {
+    const { blob } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const bytes = new Uint8Array([1, 2, 3])
+    const store = {
+      del: vi.fn(),
+      get: vi.fn(),
+      head: vi.fn(),
+      list: vi.fn(),
+      put: vi.fn(async pathname => ({ pathname })),
+    }
+    const resolved = await resolveAgentCapabilities(
+      { capabilities: [blob({ mode: "write" })] },
+      {
+        ...runtime({ blob: store }),
+        run: { messageId: "message-2", runId: "run-1" },
+      },
+      {
+        messages: [
+          { id: "message-1", parts: [{ id: "attachment-1", mediaType: "image/png", type: "image", data: "old" }], role: "user" },
+          { id: "message-2", parts: [{ id: "attachment-1", mediaType: "image/jpeg", type: "image", fetchData: vi.fn(async () => bytes) }], role: "user" },
+        ],
+      },
+    )
+
+    await expect(resolved.tools!.blob_edit!.execute?.({
+      attachmentId: "attachment-1",
+      operation: "put",
+      pathname: "meals/current/original",
+    })).resolves.toEqual({ pathname: "meals/current/original" })
+    expect(store.put).toHaveBeenCalledWith("meals/current/original", bytes, { contentType: "image/jpeg" })
   })
 
   it("uploads workspacePath from the active Harness workspace when available", async () => {

--- a/packages/agent/test/storage-capabilities.test.ts
+++ b/packages/agent/test/storage-capabilities.test.ts
@@ -563,7 +563,7 @@ describe("storage capabilities", () => {
       get: vi.fn(),
       head: vi.fn(),
       list: vi.fn(),
-      put: vi.fn(async pathname => ({ pathname })),
+      put: vi.fn(async (pathname: string, _body: unknown, _options?: unknown) => ({ pathname })),
     }
     const resolved = await resolveAgentCapabilities(
       { capabilities: [blob({ mode: "write" })] },
@@ -585,6 +585,45 @@ describe("storage capabilities", () => {
       pathname: "meals/current/original",
     })).resolves.toEqual({ pathname: "meals/current/original" })
     expect(store.put).toHaveBeenCalledWith("meals/current/original", bytes, { contentType: "image/jpeg" })
+  })
+
+  it("resolves encoded and URL-backed input attachments", async () => {
+    const { blob } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const store = {
+      del: vi.fn(),
+      get: vi.fn(),
+      head: vi.fn(),
+      list: vi.fn(),
+      put: vi.fn(async (pathname: string, _body: unknown, _options?: unknown) => ({ pathname })),
+    }
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(new Uint8Array([4, 5, 6])))
+    const resolved = await resolveAgentCapabilities(
+      { capabilities: [blob({ mode: "write" })] },
+      { ...runtime({ blob: store }), run: { messageId: "message-1", runId: "run-1" } },
+      {
+        messages: [{
+          id: "message-1",
+          parts: [
+            { data: "data:image/png;base64,AQID", id: "encoded", mediaType: "image/png", type: "image" },
+            { data: "BAUG", id: "base64", mediaType: "image/jpeg", type: "image" },
+            { id: "remote", mediaType: "image/jpeg", type: "image", url: "https://example.com/photo.jpg" },
+          ],
+          role: "user",
+        }],
+      },
+    )
+
+    await resolved.tools!.blob_edit!.execute?.({ attachmentId: "encoded", operation: "put", pathname: "encoded.png" })
+    await resolved.tools!.blob_edit!.execute?.({ attachmentId: "base64", operation: "put", pathname: "base64.jpg" })
+    await resolved.tools!.blob_edit!.execute?.({ attachmentId: "remote", operation: "put", pathname: "remote.jpg" })
+
+    expect(store.put).toHaveBeenNthCalledWith(1, "encoded.png", new Uint8Array([1, 2, 3]), { contentType: "image/png" })
+    expect(store.put).toHaveBeenNthCalledWith(2, "base64.jpg", new Uint8Array([4, 5, 6]), { contentType: "image/jpeg" })
+    expect(store.put).toHaveBeenNthCalledWith(3, "remote.jpg", expect.any(ArrayBuffer), { contentType: "image/jpeg" })
+    expect(new Uint8Array(store.put.mock.calls[2]![1] as ArrayBuffer)).toEqual(new Uint8Array([4, 5, 6]))
+    expect(fetchMock).toHaveBeenCalledWith("https://example.com/photo.jpg")
+    fetchMock.mockRestore()
   })
 
   it("uploads workspacePath from the active Harness workspace when available", async () => {

--- a/packages/agent/test/storage-capabilities.test.ts
+++ b/packages/agent/test/storage-capabilities.test.ts
@@ -587,7 +587,7 @@ describe("storage capabilities", () => {
     expect(store.put).toHaveBeenCalledWith("meals/current/original", bytes, { contentType: "image/jpeg" })
   })
 
-  it("resolves encoded and URL-backed input attachments", async () => {
+  it("resolves encoded input attachments without advertising unresolved URLs", async () => {
     const { blob } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const store = {
@@ -597,7 +597,6 @@ describe("storage capabilities", () => {
       list: vi.fn(),
       put: vi.fn(async (pathname: string, _body: unknown, _options?: unknown) => ({ pathname })),
     }
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(new Uint8Array([4, 5, 6])))
     const resolved = await resolveAgentCapabilities(
       { capabilities: [blob({ mode: "write" })] },
       { ...runtime({ blob: store }), run: { messageId: "message-1", runId: "run-1" } },
@@ -616,14 +615,27 @@ describe("storage capabilities", () => {
 
     await resolved.tools!.blob_edit!.execute?.({ attachmentId: "encoded", operation: "put", pathname: "encoded.png" })
     await resolved.tools!.blob_edit!.execute?.({ attachmentId: "base64", operation: "put", pathname: "base64.jpg" })
-    await resolved.tools!.blob_edit!.execute?.({ attachmentId: "remote", operation: "put", pathname: "remote.jpg" })
+    await expect(resolved.tools!.blob_edit!.execute?.({ attachmentId: "remote", operation: "put", pathname: "remote.jpg" })).rejects.toThrow("must identify one current input attachment")
 
     expect(store.put).toHaveBeenNthCalledWith(1, "encoded.png", new Uint8Array([1, 2, 3]), { contentType: "image/png" })
     expect(store.put).toHaveBeenNthCalledWith(2, "base64.jpg", new Uint8Array([4, 5, 6]), { contentType: "image/jpeg" })
-    expect(store.put).toHaveBeenNthCalledWith(3, "remote.jpg", expect.any(ArrayBuffer), { contentType: "image/jpeg" })
-    expect(new Uint8Array(store.put.mock.calls[2]![1] as ArrayBuffer)).toEqual(new Uint8Array([4, 5, 6]))
-    expect(fetchMock).toHaveBeenCalledWith("https://example.com/photo.jpg")
-    fetchMock.mockRestore()
+    expect(resolved.tools!.blob_edit!.description).not.toContain("remote")
+  })
+
+  it("resolves Blob tools for static Agent inspection without invocation input", async () => {
+    const { blob } = await import("../src/capabilities.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [blob({ mode: "write" })],
+      driver: { model: {} as never },
+    })
+
+    await expect(agent.resolve({
+      capabilities: { blob: {} },
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    })).resolves.toMatchObject({ tools: { blob_edit: expect.any(Object) } })
   })
 
   it("uploads workspacePath from the active Harness workspace when available", async () => {

--- a/packages/agent/test/storage-capabilities.test.ts
+++ b/packages/agent/test/storage-capabilities.test.ts
@@ -557,7 +557,10 @@ describe("storage capabilities", () => {
   it("uploads a current input attachment by id", async () => {
     const { blob } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { resolveAttachmentData } = await import("../src/messages.ts")
     const bytes = new Uint8Array([1, 2, 3])
+    const fetchData = vi.fn(async () => bytes)
+    const attachment = { id: "attachment-1", mediaType: "image/jpeg", type: "image" as const, fetchData }
     const store = {
       del: vi.fn(),
       get: vi.fn(),
@@ -574,17 +577,20 @@ describe("storage capabilities", () => {
       {
         messages: [
           { id: "message-1", parts: [{ id: "attachment-1", mediaType: "image/png", type: "image", data: "old" }], role: "user" },
-          { id: "message-2", parts: [{ id: "attachment-1", mediaType: "image/jpeg", type: "image", fetchData: vi.fn(async () => bytes) }], role: "user" },
+          { id: "message-2", parts: [attachment], role: "user" },
         ],
       },
     )
 
+    await resolveAttachmentData(attachment)
     await expect(resolved.tools!.blob_edit!.execute?.({
       attachmentId: "attachment-1",
       operation: "put",
+      options: { contentType: "application/octet-stream" },
       pathname: "meals/current/original",
     })).resolves.toEqual({ pathname: "meals/current/original" })
     expect(store.put).toHaveBeenCalledWith("meals/current/original", bytes, { contentType: "image/jpeg" })
+    expect(fetchData).toHaveBeenCalledOnce()
   })
 
   it("resolves encoded input attachments without advertising unresolved URLs", async () => {
@@ -606,6 +612,7 @@ describe("storage capabilities", () => {
           parts: [
             { data: "data:image/png;base64,AQID", id: "encoded", mediaType: "image/png", type: "image" },
             { data: "BAUG", id: "base64", mediaType: "image/jpeg", type: "image" },
+            { data: "data:image/jpeg,%FF%D8%FF", id: "percent", mediaType: "image/jpeg", type: "image" },
             { data: "{\"meal\":true}", id: "json", mediaType: "application/json; charset=utf-8", type: "file" },
             { id: "remote", mediaType: "image/jpeg", type: "image", url: "https://example.com/photo.jpg" },
           ],
@@ -616,12 +623,14 @@ describe("storage capabilities", () => {
 
     await resolved.tools!.blob_edit!.execute?.({ attachmentId: "encoded", operation: "put", pathname: "encoded.png" })
     await resolved.tools!.blob_edit!.execute?.({ attachmentId: "base64", operation: "put", pathname: "base64.jpg" })
+    await resolved.tools!.blob_edit!.execute?.({ attachmentId: "percent", operation: "put", pathname: "percent.jpg" })
     await resolved.tools!.blob_edit!.execute?.({ attachmentId: "json", operation: "put", pathname: "meal.json" })
     await expect(resolved.tools!.blob_edit!.execute?.({ attachmentId: "remote", operation: "put", pathname: "remote.jpg" })).rejects.toThrow("must identify one current input attachment")
 
     expect(store.put).toHaveBeenNthCalledWith(1, "encoded.png", new Uint8Array([1, 2, 3]), { contentType: "image/png" })
     expect(store.put).toHaveBeenNthCalledWith(2, "base64.jpg", new Uint8Array([4, 5, 6]), { contentType: "image/jpeg" })
-    expect(store.put).toHaveBeenNthCalledWith(3, "meal.json", "{\"meal\":true}", { contentType: "application/json; charset=utf-8" })
+    expect(store.put).toHaveBeenNthCalledWith(3, "percent.jpg", new Uint8Array([255, 216, 255]), { contentType: "image/jpeg" })
+    expect(store.put).toHaveBeenNthCalledWith(4, "meal.json", new TextEncoder().encode("{\"meal\":true}"), { contentType: "application/json; charset=utf-8" })
     expect(resolved.tools!.blob_edit!.description).not.toContain("remote")
   })
 

--- a/packages/agent/test/storage-capabilities.test.ts
+++ b/packages/agent/test/storage-capabilities.test.ts
@@ -582,7 +582,9 @@ describe("storage capabilities", () => {
       },
     )
 
-    await resolveAttachmentData(attachment)
+    const invocationAttachment = resolved.messages[1]!.parts[0]!
+    if (invocationAttachment.type !== "image") throw new Error("Expected image attachment")
+    await resolveAttachmentData(invocationAttachment)
     await expect(resolved.tools!.blob_edit!.execute?.({
       attachmentId: "attachment-1",
       operation: "put",
@@ -591,6 +593,14 @@ describe("storage capabilities", () => {
     })).resolves.toEqual({ pathname: "meals/current/original" })
     expect(store.put).toHaveBeenCalledWith("meals/current/original", bytes, { contentType: "image/jpeg" })
     expect(fetchData).toHaveBeenCalledOnce()
+
+    const retried = await resolveAgentCapabilities(
+      { capabilities: [blob({ mode: "write" })] },
+      { ...runtime({ blob: store }), run: { messageId: "message-2", runId: "run-2" } },
+      { messages: [{ id: "message-2", parts: [attachment], role: "user" }] },
+    )
+    await retried.tools!.blob_edit!.execute?.({ attachmentId: "attachment-1", operation: "put", pathname: "meals/retry/original" })
+    expect(fetchData).toHaveBeenCalledTimes(2)
   })
 
   it("resolves encoded input attachments without advertising unresolved URLs", async () => {

--- a/packages/agent/test/storage-capabilities.test.ts
+++ b/packages/agent/test/storage-capabilities.test.ts
@@ -606,6 +606,7 @@ describe("storage capabilities", () => {
           parts: [
             { data: "data:image/png;base64,AQID", id: "encoded", mediaType: "image/png", type: "image" },
             { data: "BAUG", id: "base64", mediaType: "image/jpeg", type: "image" },
+            { data: "{\"meal\":true}", id: "json", mediaType: "application/json; charset=utf-8", type: "file" },
             { id: "remote", mediaType: "image/jpeg", type: "image", url: "https://example.com/photo.jpg" },
           ],
           role: "user",
@@ -615,10 +616,12 @@ describe("storage capabilities", () => {
 
     await resolved.tools!.blob_edit!.execute?.({ attachmentId: "encoded", operation: "put", pathname: "encoded.png" })
     await resolved.tools!.blob_edit!.execute?.({ attachmentId: "base64", operation: "put", pathname: "base64.jpg" })
+    await resolved.tools!.blob_edit!.execute?.({ attachmentId: "json", operation: "put", pathname: "meal.json" })
     await expect(resolved.tools!.blob_edit!.execute?.({ attachmentId: "remote", operation: "put", pathname: "remote.jpg" })).rejects.toThrow("must identify one current input attachment")
 
     expect(store.put).toHaveBeenNthCalledWith(1, "encoded.png", new Uint8Array([1, 2, 3]), { contentType: "image/png" })
     expect(store.put).toHaveBeenNthCalledWith(2, "base64.jpg", new Uint8Array([4, 5, 6]), { contentType: "image/jpeg" })
+    expect(store.put).toHaveBeenNthCalledWith(3, "meal.json", "{\"meal\":true}", { contentType: "application/json; charset=utf-8" })
     expect(resolved.tools!.blob_edit!.description).not.toContain("remote")
   })
 


### PR DESCRIPTION
## What changed

- add `attachmentId` as a `blob_edit` upload source for attachments on the current input message
- expose available attachment IDs and media types in the tool description
- preserve the attachment media type as Blob `contentType`
- document the new Blob Capability input

## Why

Consumers could inspect image attachments but could not persist them with the generic Blob Capability. Calories therefore lost meal photos after removing its domain-specific upload hook.

This makes the obvious composition work: an Agent Definition can combine `blob({ mode: "write" })` with its database Capability and store the current input attachment without app-local plumbing.

## Validation

- `pnpm exec tsc --noEmit -p packages/agent/tsconfig.json`
- `pnpm exec vp lint src/capabilities/storage/blob.ts test/storage-capabilities.test.ts`
- `pnpm exec vp test test/storage-capabilities.test.ts` (24 tests)
- downstream Calories `pnpm patch` deployed and verified against live R2/D1 state