### PR TITLE
fix(agent): enforce chat invocation deadlines

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -28,6 +28,8 @@ Built-in helpers include `discord()`, `github()`, `http()`, `slack()`, `teams()`
 
 Adapter-backed Channels deliver only the completed response by default. Set top-level `defineAgent({ messages: { stream: true } })` to opt every adapter Channel into draft and edit updates, or set `messages.stream` on an individual Channel to control progressive delivery for that destination. Web Chat routes return streaming HTTP responses independently of adapter delivery settings.
 
+On Cloudflare, ViteHub reserves the final five seconds of the 30-second background execution window for an adapter-backed Channel's configured error fallback and cleanup. Webhook setup, Agent Invocation, output consumption, progress updates, and normal delivery share the first 25 seconds. The deadline is absolute from webhook entry: late output is discarded, and ViteHub removes late messages when the adapter returns enough ownership to do so.
+
 Set `messages.filter` on an adapter-backed Channel to admit only supported incoming messages before Agent invocation. The filter receives the normalized current `Message`, its `deliveryKind`, the Channel callback context, run metadata, and thread controls; returning `false` ignores the delivery without starting the Agent or posting an error fallback. `deliveryKind` is `direct`, `mention`, or `subscribed`; explicit mentions remain `mention` in threads the Agent already subscribes to.
 
 ```ts

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -765,6 +765,7 @@ function progressSummaryFromEvent(event: unknown): string | undefined {
 function createManualDeliveryProgressUpdater(
   manualDelivery: { placeholder?: unknown },
   waitUntil: AgentWaitUntil,
+  abortSignal?: AbortSignal,
 ): {
   finish: () => Promise<void>
   update: (summary: string) => void
@@ -802,6 +803,7 @@ function createManualDeliveryProgressUpdater(
       ])
       if (timeout) clearTimeout(timeout)
       if (drained || !manualDelivery.placeholder) return
+      if (abortSignal) return
 
       const stalePlaceholder = manualDelivery.placeholder
       manualDelivery.placeholder = undefined
@@ -2487,7 +2489,7 @@ async function handleChatSdkMessage(
     }
     const chatFinish = createChatFinishExtension(input, registration)
     progress = manualDelivery
-      ? createManualDeliveryProgressUpdater(manualDeliveryState, context.waitUntil)
+      ? createManualDeliveryProgressUpdater(manualDeliveryState, context.waitUntil, invocationDeadlineAbort?.signal)
       : undefined
     const resolvedInvocationInput = invocation.input as AgentRunInput
     const remainingMaximumInvocationTimeout = maximumInvocationDeadline === undefined

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2249,27 +2249,46 @@ function createChatFinishExtension(
   }
 }
 
+async function* abortableChatMessage(
+  message: AsyncIterable<string>,
+  abortSignal: AbortSignal,
+): AsyncIterable<string> {
+  const iterator = message[Symbol.asyncIterator]()
+  let closed = false
+  const close = async () => {
+    if (closed) return
+    closed = true
+    await iterator.return?.().catch(() => undefined)
+  }
+  try {
+    while (true) {
+      abortSignal.throwIfAborted()
+      const next = await new Promise<IteratorResult<string>>((resolve, reject) => {
+        const onAbort = () => {
+          void close()
+          reject(abortSignal.reason)
+        }
+        abortSignal.addEventListener("abort", onAbort, { once: true })
+        iterator.next().then(resolve, reject).finally(() => {
+          abortSignal.removeEventListener("abort", onAbort)
+        })
+      })
+      if (next.done) return
+      yield next.value
+    }
+  }
+  finally {
+    await close()
+  }
+}
+
 async function collectAbortableChatMessage(
   message: AsyncIterable<string>,
   abortSignal: AbortSignal,
 ): Promise<{ markdown: string }> {
-  const iterator = message[Symbol.asyncIterator]()
   let markdown = ""
-  while (true) {
-    abortSignal.throwIfAborted()
-    const next = await new Promise<IteratorResult<string>>((resolve, reject) => {
-      const onAbort = () => {
-        void iterator.return?.().catch(() => undefined)
-        reject(abortSignal.reason)
-      }
-      abortSignal.addEventListener("abort", onAbort, { once: true })
-      iterator.next().then(resolve, reject).finally(() => {
-        abortSignal.removeEventListener("abort", onAbort)
-      })
-    })
-    if (next.done) return { markdown }
-    markdown += next.value
-  }
+  for await (const chunk of abortableChatMessage(message, abortSignal)) markdown += chunk
+  return { markdown }
 }
 
 async function flushChatFinishExtensionMessages(
@@ -2282,7 +2301,9 @@ async function flushChatFinishExtensionMessages(
   for (let message of messages) {
     abortSignal?.throwIfAborted()
     if (abortSignal && isAsyncIterable(message)) {
-      message = await collectAbortableChatMessage(message, abortSignal)
+      message = manualDelivery.placeholder
+        ? await collectAbortableChatMessage(message, abortSignal)
+        : abortableChatMessage(message, abortSignal)
     }
     if (manualDelivery.placeholder) {
       if (isAsyncIterable(message)) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2263,11 +2263,13 @@ async function handleChatSdkMessage(
       // Manual delivery disables Chat SDK reply streaming, but still consumes
       // normalized Agent events so transient Capability output can update the
       // framework-owned placeholder without exposing ordinary Agent text.
-      const result = manualDelivery
-        ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
-        : await runAgentInline(agent as never, runContext as never, invocationInput as never)
       const text = await enforceChatInvocationTimeout(
-        collectAgentOutput(result, progress?.update),
+        (async () => {
+          const result = manualDelivery
+            ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
+            : await runAgentInline(agent as never, runContext as never, invocationInput as never)
+          return await collectAgentOutput(result, progress?.update)
+        })(),
         maximumInvocationTimeout === undefined ? undefined : invocationInput.timeout,
       )
       if (!manualDelivery && text) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2282,6 +2282,7 @@ async function handleChatSdkMessage(
   let typing: ChatTypingRefresh | undefined
   let progress: ReturnType<typeof createManualDeliveryProgressUpdater> | undefined
   const manualDeliveryState: { errorFallback?: string, placeholder?: unknown } = {}
+  const invocationDeadlineAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
   try {
     input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, [chatAuthorizationUiMessage(thread, message, messageContext)], messageContext, registration.channelId)
     if (typeof options?.timeout === "number" && Number.isFinite(options.timeout) && options.timeout > 0) {
@@ -2318,7 +2319,11 @@ async function handleChatSdkMessage(
     const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
     const thinkingFallback = invocation.metadata?.thinkingFallback
     if (manualDelivery && typeof thinkingFallback === "string") {
-      manualDeliveryState.placeholder = await thread.post(thinkingFallback)
+      manualDeliveryState.placeholder = await enforceChatInvocationTimeout(
+        thread.post(thinkingFallback),
+        maximumInvocationDeadline === undefined ? undefined : Math.max(0, maximumInvocationDeadline - Date.now()),
+        invocationDeadlineAbort,
+      )
     }
     typing = streamsPhasedReplies ? startChatTypingRefresh(thread, context) : undefined
     run = invocation.run
@@ -2334,7 +2339,6 @@ async function handleChatSdkMessage(
     const remainingMaximumInvocationTimeout = maximumInvocationDeadline === undefined
       ? undefined
       : Math.max(0, maximumInvocationDeadline - Date.now())
-    const invocationDeadlineAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
     const invocationInput = withChatFinishExtension(withResolvedAgentInvokerInput({
       ...resolvedInvocationInput,
       ...(invocationDeadlineAbort

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1224,6 +1224,7 @@ async function postChatStream(
     const finishPlaceholder = () => {
       waitUntil(clearPlaceholder().then(() => cleared ? undefined : clearPlaceholder()))
     }
+    abortSignal?.addEventListener("abort", finishPlaceholder, { once: true })
     const nativeResponse: ChatTextStream = {
       getText: response.getText,
       async *[Symbol.asyncIterator]() {
@@ -1273,6 +1274,7 @@ async function postChatStream(
       await removeAbortedChatDelivery(sent, abortSignal)
     }
     finally {
+      abortSignal?.removeEventListener("abort", finishPlaceholder)
       chatThread._adapter = previousAdapter
       chatThread._fallbackStreamingPlaceholderText = previousFallback
       finishPlaceholder()
@@ -2360,6 +2362,7 @@ async function handleChatSdkMessage(
             )
           }
           else {
+            const commentaryDeliveries: Promise<void>[] = []
             let finalDelivery: Promise<void> | undefined
             let finalDeliveryError: unknown
             const replies = streamAgentOutputToChatReplies(result, {
@@ -2367,6 +2370,7 @@ async function handleChatSdkMessage(
               onCommentary(response, discard) {
                 const delivery = postChatStream(thread, response, undefined, context.waitUntil, invocationDeadlineAbort?.signal)
                   .catch(() => discard())
+                commentaryDeliveries.push(delivery)
                 context.waitUntil(delivery)
               },
               onFinal(response) {
@@ -2385,6 +2389,7 @@ async function handleChatSdkMessage(
             await replies.completion.catch((error) => {
               streamError = error
             })
+            await Promise.all(commentaryDeliveries)
             await finalDelivery
             if (streamError !== undefined) throw streamError
             if (finalDeliveryError !== undefined) throw finalDeliveryError

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1248,7 +1248,7 @@ async function postChatStream(
     const nativeStream = adapter.stream!.bind(adapter)
     const placeholder = fallback === null
       ? Promise.resolve(undefined)
-      : adapter.postMessage(thread.id, fallback).catch(() => undefined)
+      : adapter.postMessage(thread.id, fallback)
     let cleared = false
     let clearing: Promise<void> | undefined
     let clearRequested = false

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1973,6 +1973,7 @@ function chatErrorHookArgs(
   input: AgentChatMessageTriggerInput | undefined,
   run: AgentRunMetadata | undefined,
   error: unknown,
+  onPost?: () => void,
 ): AgentChatErrorHookArgs<ViteAgentRouteRuntimeConfig> {
   const inputMessage = input?.messages.at(-1)
   const metadata = inputMessage?.metadata && typeof inputMessage.metadata === "object"
@@ -1988,7 +1989,10 @@ function chatErrorHookArgs(
     },
     run,
     thread: {
-      post: async postedMessage => postChatMessage(thread, postedMessage as AgentChatMessage),
+      post: async (postedMessage) => {
+        await postChatMessage(thread, postedMessage as AgentChatMessage)
+        onPost?.()
+      },
     },
   }
 }
@@ -2099,6 +2103,7 @@ async function resolveChatErrorFallbackText(
   options: AgentChatOptions | undefined,
   args: AgentChatErrorHookArgs<ViteAgentRouteRuntimeConfig>,
   resolutionTimeout?: number,
+  callbackDelivered?: () => boolean,
 ): Promise<string | undefined> {
   const fallback = options?.errorFallbackText
   if (fallback === null) return undefined
@@ -2108,7 +2113,7 @@ async function resolveChatErrorFallbackText(
       return resolved || undefined
     }
     catch {
-      return defaultChatErrorFallbackText
+      return callbackDelivered?.() ? undefined : defaultChatErrorFallbackText
     }
   }
   if (typeof fallback === "string") return fallback
@@ -2137,10 +2142,14 @@ async function postChatErrorFallback(
   const fallbackResolutionTimeout = maximumInvocationDeadline === undefined
     ? undefined
     : Math.min(1_000, Math.max(0, maximumInvocationDeadline + 5_000 - Date.now()))
+  let callbackDelivered = false
   const fallback = await resolveChatErrorFallbackText(
     options,
-    chatErrorHookArgs(thread, message, input, run, error),
+    chatErrorHookArgs(thread, message, input, run, error, () => {
+      callbackDelivered = true
+    }),
     fallbackResolutionTimeout,
+    () => callbackDelivered,
   )
   if (fallback && manualDelivery) manualDelivery.errorFallback = fallback
   const fallbackDeliveryAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
@@ -2183,6 +2192,29 @@ function createChatFinishExtension(
   }
 }
 
+async function collectAbortableChatMessage(
+  message: AsyncIterable<string>,
+  abortSignal: AbortSignal,
+): Promise<{ markdown: string }> {
+  const iterator = message[Symbol.asyncIterator]()
+  let markdown = ""
+  while (true) {
+    abortSignal.throwIfAborted()
+    const next = await new Promise<IteratorResult<string>>((resolve, reject) => {
+      const onAbort = () => {
+        void iterator.return?.().catch(() => undefined)
+        reject(abortSignal.reason)
+      }
+      abortSignal.addEventListener("abort", onAbort, { once: true })
+      iterator.next().then(resolve, reject).finally(() => {
+        abortSignal.removeEventListener("abort", onAbort)
+      })
+    })
+    if (next.done) return { markdown }
+    markdown += next.value
+  }
+}
+
 async function flushChatFinishExtensionMessages(
   thread: Thread,
   chat: AgentChatQueuedFinishExtension,
@@ -2192,6 +2224,9 @@ async function flushChatFinishExtensionMessages(
   const messages = chat[chatFinishMessagesKey].splice(0)
   for (let message of messages) {
     abortSignal?.throwIfAborted()
+    if (abortSignal && isAsyncIterable(message)) {
+      message = await collectAbortableChatMessage(message, abortSignal)
+    }
     if (manualDelivery.placeholder) {
       if (isAsyncIterable(message)) {
         let markdown = ""

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2319,8 +2319,15 @@ async function handleChatSdkMessage(
     const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
     const thinkingFallback = invocation.metadata?.thinkingFallback
     if (manualDelivery && typeof thinkingFallback === "string") {
+      const placeholderDelivery = thread.post(thinkingFallback).then(async (placeholder) => {
+        if (invocationDeadlineAbort?.signal.aborted) {
+          await deleteManualDeliveryPlaceholder(placeholder)
+          invocationDeadlineAbort.signal.throwIfAborted()
+        }
+        return placeholder
+      })
       manualDeliveryState.placeholder = await enforceChatInvocationTimeout(
-        thread.post(thinkingFallback),
+        placeholderDelivery,
         maximumInvocationDeadline === undefined ? undefined : Math.max(0, maximumInvocationDeadline - Date.now()),
         invocationDeadlineAbort,
       )

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2593,7 +2593,7 @@ async function handleChatSdkMessage(
             )
           }
           else {
-            const commentaryDeliveries: Promise<void>[] = []
+            const commentaryDeliveries: Promise<void>[] | undefined = maximumInvocationDeadline === undefined ? undefined : []
             let finalDelivery: Promise<void> | undefined
             let finalDeliveryError: unknown
             const replies = streamAgentOutputToChatReplies(result, {
@@ -2601,7 +2601,7 @@ async function handleChatSdkMessage(
               onCommentary(response, discard) {
                 const delivery = postChatStream(thread, response, undefined, context.waitUntil, invocationDeadlineAbort?.signal, maximumInvocationDeadline)
                   .catch(() => discard())
-                commentaryDeliveries.push(delivery)
+                commentaryDeliveries?.push(delivery)
                 context.waitUntil(delivery)
               },
               onFinal(response) {
@@ -2621,7 +2621,7 @@ async function handleChatSdkMessage(
             await replies.completion.catch((error) => {
               streamError = error
             })
-            await Promise.all(commentaryDeliveries)
+            if (commentaryDeliveries) await Promise.all(commentaryDeliveries)
             await finalDelivery
             if (streamError !== undefined) throw streamError
             if (finalDeliveryError !== undefined) throw finalDeliveryError

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1165,7 +1165,12 @@ async function finishDiscordSplitStream(
   else if (first) {
     sentMessages.push(await thread.post({ raw: first }))
   }
+  if (abortSignal?.aborted) {
+    await Promise.allSettled(sentMessages.map(deleteManualDeliveryPlaceholder))
+    abortSignal.throwIfAborted()
+  }
   for (const part of rest) {
+    abortSignal?.throwIfAborted()
     sentMessages.push(await thread.post({ raw: part }))
     if (abortSignal?.aborted) {
       await Promise.allSettled(sentMessages.map(deleteManualDeliveryPlaceholder))

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -803,10 +803,13 @@ function createManualDeliveryProgressUpdater(
       ])
       if (timeout) clearTimeout(timeout)
       if (drained || !manualDelivery.placeholder) return
-      if (abortSignal?.aborted) return
 
       const stalePlaceholder = manualDelivery.placeholder
       manualDelivery.placeholder = undefined
+      if (abortSignal?.aborted) {
+        waitUntil(deleteManualDeliveryPlaceholder(stalePlaceholder).catch(() => undefined))
+        return
+      }
       const cleanup = draining.then(async () => {
         await deleteManualDeliveryPlaceholder(stalePlaceholder).catch(() => undefined)
       })

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1166,16 +1166,25 @@ function sentMessageText(sent: unknown): string {
   return sent && typeof sent === "object" && "text" in sent && typeof sent.text === "string" ? sent.text : ""
 }
 
+async function removeAbortedChatDelivery(sent: unknown, abortSignal?: AbortSignal): Promise<void> {
+  if (!abortSignal?.aborted) return
+  await deleteManualDeliveryPlaceholder(sent)
+  abortSignal.throwIfAborted()
+}
+
 async function postChatStream(
   thread: Thread,
   response: ChatTextStream,
   fallback: string | null | undefined,
   waitUntil: AgentWaitUntil,
+  abortSignal?: AbortSignal,
 ): Promise<void> {
   let sent: unknown
   if (fallback === undefined) {
     sent = await thread.post(chatStreamPostable(thread, response) as never)
+    await removeAbortedChatDelivery(sent, abortSignal)
     await finishDiscordSplitStream(thread, sent, response.getText() || sentMessageText(sent))
+    await removeAbortedChatDelivery(sent, abortSignal)
     return
   }
 
@@ -1247,7 +1256,9 @@ async function postChatStream(
     chatThread._fallbackStreamingPlaceholderText = fallback
     try {
       sent = await thread.post(chatStreamPostable(thread, nativeResponse) as never)
+      await removeAbortedChatDelivery(sent, abortSignal)
       await finishDiscordSplitStream(thread, sent, response.getText() || sentMessageText(sent))
+      await removeAbortedChatDelivery(sent, abortSignal)
     }
     finally {
       chatThread._adapter = previousAdapter
@@ -1263,7 +1274,9 @@ async function postChatStream(
   chatThread._fallbackStreamingPlaceholderText = fallback
   try {
     sent = await thread.post(chatStreamPostable(thread, response) as never)
+    await removeAbortedChatDelivery(sent, abortSignal)
     await finishDiscordSplitStream(thread, sent, response.getText() || sentMessageText(sent))
+    await removeAbortedChatDelivery(sent, abortSignal)
   }
   finally {
     chatThread._fallbackStreamingPlaceholderText = previous
@@ -2326,6 +2339,7 @@ async function handleChatSdkMessage(
               streamAgentOutputToChatText(result),
               typeof thinkingFallback === "string" || thinkingFallback === null ? thinkingFallback : undefined,
               context.waitUntil,
+              invocationDeadlineAbort?.signal,
             )
           }
           else {
@@ -2334,7 +2348,7 @@ async function handleChatSdkMessage(
             const replies = streamAgentOutputToChatReplies(result, {
               commentary: options.commentary,
               onCommentary(response, discard) {
-                const delivery = postChatStream(thread, response, undefined, context.waitUntil)
+                const delivery = postChatStream(thread, response, undefined, context.waitUntil, invocationDeadlineAbort?.signal)
                   .catch(() => discard())
                 context.waitUntil(delivery)
               },
@@ -2344,6 +2358,7 @@ async function handleChatSdkMessage(
                   response,
                   typeof thinkingFallback === "string" || thinkingFallback === null ? thinkingFallback : undefined,
                   context.waitUntil,
+                  invocationDeadlineAbort?.signal,
                 ).catch((error) => {
                   finalDeliveryError = error
                 })

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2382,6 +2382,7 @@ async function handleChatSdkMessage(
             : await runAgentInline(agent as never, runContext as never, invocationInput as never)
           const text = await collectAgentOutput(result, progress?.update)
           if (!manualDelivery && text) {
+            invocationDeadlineAbort?.signal.throwIfAborted()
             if (!await postDiscordSplitContent(thread, { markdown: text }, invocationDeadlineAbort?.signal)) {
               const sent = await thread.post({ markdown: text })
               if (invocationDeadlineAbort?.signal.aborted) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2171,6 +2171,8 @@ interface ManualChatDeliveryState {
   placeholderCleanup?: Promise<void>
 }
 
+const chatFallbackDeliveryReserveMs = 4_000
+
 async function postChatErrorFallback(
   error: unknown,
   thread: Thread,
@@ -2190,18 +2192,27 @@ async function postChatErrorFallback(
   })
   const fallbackResolutionTimeout = maximumInvocationDeadline === undefined
     ? undefined
-    : Math.min(1_000, Math.max(0, maximumInvocationDeadline + 5_000 - Date.now()))
+    : Math.max(0, maximumInvocationDeadline + 5_000 - chatFallbackDeliveryReserveMs - Date.now())
   let callbackDelivered = false
+  let resolveCallbackDelivery: (() => void) | undefined
+  const callbackDelivery = new Promise<void>((resolve) => {
+    resolveCallbackDelivery = resolve
+  })
   const fallbackResolutionAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
-  const fallback = await resolveChatErrorFallbackText(
+  const fallbackResolution = resolveChatErrorFallbackText(
     options,
     chatErrorHookArgs(thread, message, input, run, error, fallbackResolutionAbort?.signal, () => {
       callbackDelivered = true
+      resolveCallbackDelivery?.()
     }),
     fallbackResolutionTimeout,
     fallbackResolutionAbort,
     () => callbackDelivered,
   )
+  const fallback = typeof options?.errorFallbackText === "function"
+    ? await Promise.race([fallbackResolution, callbackDelivery.then(() => undefined)])
+    : await fallbackResolution
+  if (callbackDelivered) fallbackResolutionAbort?.abort()
   if (fallback && manualDelivery) manualDelivery.errorFallback = fallback
   if (manualDelivery?.placeholderCleanup) {
     const cleanup = manualDelivery.placeholderCleanup.catch(() => undefined)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1136,29 +1136,41 @@ async function postDiscordSplitContent(
   if (discordLongContentMode(thread.adapter) !== "split") return false
   const rendered = renderDiscordPostable(thread.adapter, postable)
   if (!rendered || rendered.length <= discordMaxContentLength) return false
+  const sentMessages: unknown[] = []
   for (const part of discordContentParts(rendered)) {
     const sent = await thread.post({ raw: part })
+    sentMessages.push(sent)
     if (abortSignal?.aborted) {
-      await deleteManualDeliveryPlaceholder(sent)
+      await Promise.allSettled(sentMessages.map(deleteManualDeliveryPlaceholder))
       abortSignal.throwIfAborted()
     }
   }
   return true
 }
 
-async function finishDiscordSplitStream(thread: Thread, sent: unknown, markdown: string): Promise<void> {
+async function finishDiscordSplitStream(
+  thread: Thread,
+  sent: unknown,
+  markdown: string,
+  abortSignal?: AbortSignal,
+): Promise<void> {
   if (!markdown || discordLongContentMode(thread.adapter) !== "split") return
   const rendered = renderDiscordPostable(thread.adapter, { markdown })
   if (!rendered || rendered.length <= discordMaxContentLength) return
   const [first, ...rest] = discordContentParts(rendered)
+  const sentMessages = sent ? [sent] : []
   if (first && sent && typeof sent === "object" && "edit" in sent && typeof sent.edit === "function") {
     await sent.edit({ attachments: [], raw: first })
   }
   else if (first) {
-    await thread.post({ raw: first })
+    sentMessages.push(await thread.post({ raw: first }))
   }
   for (const part of rest) {
-    await thread.post({ raw: part })
+    sentMessages.push(await thread.post({ raw: part }))
+    if (abortSignal?.aborted) {
+      await Promise.allSettled(sentMessages.map(deleteManualDeliveryPlaceholder))
+      abortSignal.throwIfAborted()
+    }
   }
 }
 
@@ -1183,7 +1195,7 @@ async function postChatStream(
   if (fallback === undefined) {
     sent = await thread.post(chatStreamPostable(thread, response) as never)
     await removeAbortedChatDelivery(sent, abortSignal)
-    await finishDiscordSplitStream(thread, sent, response.getText() || sentMessageText(sent))
+    await finishDiscordSplitStream(thread, sent, response.getText() || sentMessageText(sent), abortSignal)
     await removeAbortedChatDelivery(sent, abortSignal)
     return
   }
@@ -1257,7 +1269,7 @@ async function postChatStream(
     try {
       sent = await thread.post(chatStreamPostable(thread, nativeResponse) as never)
       await removeAbortedChatDelivery(sent, abortSignal)
-      await finishDiscordSplitStream(thread, sent, response.getText() || sentMessageText(sent))
+      await finishDiscordSplitStream(thread, sent, response.getText() || sentMessageText(sent), abortSignal)
       await removeAbortedChatDelivery(sent, abortSignal)
     }
     finally {
@@ -1275,7 +1287,7 @@ async function postChatStream(
   try {
     sent = await thread.post(chatStreamPostable(thread, response) as never)
     await removeAbortedChatDelivery(sent, abortSignal)
-    await finishDiscordSplitStream(thread, sent, response.getText() || sentMessageText(sent))
+    await finishDiscordSplitStream(thread, sent, response.getText() || sentMessageText(sent), abortSignal)
     await removeAbortedChatDelivery(sent, abortSignal)
   }
   finally {
@@ -1962,7 +1974,7 @@ function chatMessageDeliveryArtifacts(message: AgentChatMessage): readonly Publi
   return Array.isArray(artifacts) ? artifacts as readonly PublishedAgentDeliveryArtifact[] : []
 }
 
-async function postChatMessage(thread: Thread, message: AgentChatMessage): Promise<void> {
+async function postChatMessage(thread: Thread, message: AgentChatMessage, abortSignal?: AbortSignal): Promise<void> {
   if (isAsyncIterable(message)) {
     let markdown = ""
     const stream = (async function* () {
@@ -1972,25 +1984,27 @@ async function postChatMessage(thread: Thread, message: AgentChatMessage): Promi
       }
     })()
     const sent = await thread.post(thread.adapter.stream ? new StreamingPlan(stream) : stream)
-    await finishDiscordSplitStream(thread, sent, markdown || sentMessageText(sent))
+    await removeAbortedChatDelivery(sent, abortSignal)
+    await finishDiscordSplitStream(thread, sent, markdown || sentMessageText(sent), abortSignal)
+    await removeAbortedChatDelivery(sent, abortSignal)
     return
   }
   if (typeof message !== "object" || message === null) {
-    if (await postDiscordSplitContent(thread, message)) return
-    await thread.post(message)
+    if (await postDiscordSplitContent(thread, message, abortSignal)) return
+    await removeAbortedChatDelivery(await thread.post(message), abortSignal)
     return
   }
 
   const attachments = deliveryArtifactAttachments(chatMessageDeliveryArtifacts(message))
   if (!attachments.length) {
     const postable = isTextChatMessage(message) ? message.text : message as AdapterPostableMessage
-    if (await postDiscordSplitContent(thread, postable)) return
-    await thread.post(postable)
+    if (await postDiscordSplitContent(thread, postable, abortSignal)) return
+    await removeAbortedChatDelivery(await thread.post(postable), abortSignal)
     return
   }
 
   if (isTextChatMessage(message)) {
-    await thread.post({ attachments, raw: message.text })
+    await removeAbortedChatDelivery(await thread.post({ attachments, raw: message.text }), abortSignal)
     return
   }
 
@@ -1998,13 +2012,13 @@ async function postChatMessage(thread: Thread, message: AgentChatMessage): Promi
     artifacts?: readonly PublishedAgentDeliveryArtifact[]
     attachments?: unknown
   }
-  await thread.post({
+  await removeAbortedChatDelivery(await thread.post({
     ...postable,
     attachments: [
       ...(Array.isArray(postable.attachments) ? postable.attachments as Attachment[] : []),
       ...attachments,
     ],
-  } as AdapterPostableMessage)
+  } as AdapterPostableMessage), abortSignal)
 }
 
 async function replaceManualDeliveryPlaceholder(placeholder: unknown, message: AgentChatMessage): Promise<boolean> {
@@ -2105,6 +2119,7 @@ async function flushChatFinishExtensionMessages(
   thread: Thread,
   chat: AgentChatQueuedFinishExtension,
   manualDelivery: { placeholder?: unknown },
+  abortSignal?: AbortSignal,
 ): Promise<void> {
   const messages = chat[chatFinishMessagesKey].splice(0)
   for (let message of messages) {
@@ -2115,12 +2130,13 @@ async function flushChatFinishExtensionMessages(
         message = { markdown }
       }
       if (await deliverToManualDeliveryPlaceholder(manualDelivery.placeholder, message)) {
+        abortSignal?.throwIfAborted()
         manualDelivery.placeholder = undefined
         continue
       }
       manualDelivery.placeholder = undefined
     }
-    await postChatMessage(thread, message)
+    await postChatMessage(thread, message, abortSignal)
   }
 }
 
@@ -2319,7 +2335,8 @@ async function handleChatSdkMessage(
             }
           }
           await progress?.finish()
-          await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState)
+          await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState, invocationDeadlineAbort?.signal)
+          invocationDeadlineAbort?.signal.throwIfAborted()
           if (manualDeliveryState.placeholder) await deleteManualDeliveryPlaceholder(manualDeliveryState.placeholder)
           manualDeliveryState.placeholder = undefined
         })(),
@@ -2376,7 +2393,7 @@ async function handleChatSdkMessage(
         finally {
           typing?.stop()
         }
-        await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState)
+        await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState, invocationDeadlineAbort?.signal)
       })(), maximumInvocationDeadline === undefined ? undefined : invocationInput.timeout, invocationDeadlineAbort)
     }
   }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1191,6 +1191,7 @@ async function postChatStream(
   waitUntil: AgentWaitUntil,
   abortSignal?: AbortSignal,
 ): Promise<void> {
+  abortSignal?.throwIfAborted()
   let sent: unknown
   if (fallback === undefined) {
     sent = await thread.post(chatStreamPostable(thread, response) as never)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2931,9 +2931,11 @@ export function createChannelWebhookRouteHandler(
         }
       }
 
+      const webhookDeadlineAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
       const chatWebhookTask = (async () => {
         const baseChatOptions = getAgentChatOptions(agent)
         const adapters = await resolveChatAdapters(baseChatOptions, context)
+        webhookDeadlineAbort?.signal.throwIfAborted()
         const adapterName = resolveChatAdapterName(adapters, registration)
         const adapter = adapterName ? adapters[adapterName] : undefined
         if (!adapter) {
@@ -2943,6 +2945,7 @@ export function createChannelWebhookRouteHandler(
         try {
           const chatOptions = getChannelChatOptions(agent, registration.channelId, baseChatOptions)
           const handler = await createChatWebhookHandler(agent, context, registration, adapterName!, adapter, chatOptions, handlerOptions, maximumInvocationDeadline)
+          webhookDeadlineAbort?.signal.throwIfAborted()
           const response = await handler(request, { waitUntil: context.waitUntil })
           if (chatOptions?.stream === false && hasExplicitNonStreamingMessages(agent, registration.channelId)) {
             await context.flushWaitUntil?.()
@@ -2958,6 +2961,7 @@ export function createChannelWebhookRouteHandler(
       return await enforceChatInvocationTimeout(
         chatWebhookTask,
         maximumInvocationDeadline === undefined ? undefined : Math.max(0, maximumInvocationDeadline - Date.now()),
+        webhookDeadlineAbort,
       )
     })
   }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2160,14 +2160,22 @@ function chatInvocationTimeout(
   return timeout === undefined ? maximum : Math.min(timeout, maximum)
 }
 
-async function enforceChatInvocationTimeout<T>(task: Promise<T>, timeout: number | undefined): Promise<T> {
+async function enforceChatInvocationTimeout<T>(
+  task: Promise<T>,
+  timeout: number | undefined,
+  abortController?: AbortController,
+): Promise<T> {
   if (timeout === undefined) return await task
   let timeoutId: ReturnType<typeof setTimeout> | undefined
   try {
     return await Promise.race([
       task,
       new Promise<never>((_resolve, reject) => {
-        timeoutId = setTimeout(() => reject(new Error(`Chat invocation timed out after ${timeout}ms.`)), timeout)
+        timeoutId = setTimeout(() => {
+          const error = new Error(`Chat invocation timed out after ${timeout}ms.`)
+          abortController?.abort(error)
+          reject(error)
+        }, timeout)
       }),
     ])
   }
@@ -2246,8 +2254,16 @@ async function handleChatSdkMessage(
     const remainingMaximumInvocationTimeout = maximumInvocationTimeout === undefined
       ? undefined
       : Math.max(0, maximumInvocationTimeout - (Date.now() - invocationStartedAt))
+    const invocationDeadlineAbort = maximumInvocationTimeout === undefined ? undefined : new AbortController()
     const invocationInput = withChatFinishExtension(withResolvedAgentInvokerInput({
       ...resolvedInvocationInput,
+      ...(invocationDeadlineAbort
+        ? {
+            abortSignal: resolvedInvocationInput.abortSignal
+              ? AbortSignal.any([resolvedInvocationInput.abortSignal, invocationDeadlineAbort.signal])
+              : invocationDeadlineAbort.signal,
+          }
+        : {}),
       timeout: chatInvocationTimeout(resolvedInvocationInput.timeout, remainingMaximumInvocationTimeout),
       context: {
         ...resolvedInvocationInput.context,
@@ -2275,6 +2291,7 @@ async function handleChatSdkMessage(
           return await collectAgentOutput(result, progress?.update)
         })(),
         maximumInvocationTimeout === undefined ? undefined : invocationInput.timeout,
+        invocationDeadlineAbort,
       )
       if (!manualDelivery && text) {
         if (!await postDiscordSplitContent(thread, { markdown: text })) {
@@ -2334,7 +2351,7 @@ async function handleChatSdkMessage(
           typing?.stop()
         }
         await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState)
-      })(), maximumInvocationTimeout === undefined ? undefined : invocationInput.timeout)
+      })(), maximumInvocationTimeout === undefined ? undefined : invocationInput.timeout, invocationDeadlineAbort)
     }
   }
   catch (error) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -803,7 +803,7 @@ function createManualDeliveryProgressUpdater(
       ])
       if (timeout) clearTimeout(timeout)
       if (drained || !manualDelivery.placeholder) return
-      if (abortSignal) return
+      if (abortSignal?.aborted) return
 
       const stalePlaceholder = manualDelivery.placeholder
       manualDelivery.placeholder = undefined

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2282,25 +2282,25 @@ async function handleChatSdkMessage(
       // Manual delivery disables Chat SDK reply streaming, but still consumes
       // normalized Agent events so transient Capability output can update the
       // framework-owned placeholder without exposing ordinary Agent text.
-      const text = await enforceChatInvocationTimeout(
+      await enforceChatInvocationTimeout(
         (async () => {
           const result = manualDelivery
             ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
             : await runAgentInline(agent as never, runContext as never, invocationInput as never)
-          return await collectAgentOutput(result, progress?.update)
+          const text = await collectAgentOutput(result, progress?.update)
+          if (!manualDelivery && text) {
+            if (!await postDiscordSplitContent(thread, { markdown: text })) {
+              await thread.post({ markdown: text })
+            }
+          }
+          await progress?.finish()
+          await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState)
+          if (manualDeliveryState.placeholder) await deleteManualDeliveryPlaceholder(manualDeliveryState.placeholder)
+          manualDeliveryState.placeholder = undefined
         })(),
         maximumInvocationDeadline === undefined ? undefined : invocationInput.timeout,
         invocationDeadlineAbort,
       )
-      if (!manualDelivery && text) {
-        if (!await postDiscordSplitContent(thread, { markdown: text })) {
-          await thread.post({ markdown: text })
-        }
-      }
-      await progress?.finish()
-      await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState)
-      if (manualDeliveryState.placeholder) await deleteManualDeliveryPlaceholder(manualDeliveryState.placeholder)
-      manualDeliveryState.placeholder = undefined
     }
     else {
       await enforceChatInvocationTimeout((async () => {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2084,7 +2084,7 @@ async function postChatErrorFallback(
   options: AgentChatOptions | undefined,
   input: AgentChatMessageTriggerInput | undefined,
   run: AgentRunMetadata | undefined,
-  manualDeliveryPlaceholder?: unknown,
+  manualDelivery?: { errorFallback?: string, placeholder?: unknown },
 ): Promise<void> {
   console.error({
     component: "@vite-hub/agent",
@@ -2094,11 +2094,12 @@ async function postChatErrorFallback(
     thread_id: message.threadId,
   })
   const fallback = await resolveChatErrorFallbackText(options, chatErrorHookArgs(thread, message, input, run, error))
+  if (fallback && manualDelivery) manualDelivery.errorFallback = fallback
   if (!fallback) {
-    if (manualDeliveryPlaceholder) await deleteManualDeliveryPlaceholder(manualDeliveryPlaceholder)
+    if (manualDelivery?.placeholder) await deleteManualDeliveryPlaceholder(manualDelivery.placeholder)
     return
   }
-  if (await deliverToManualDeliveryPlaceholder(manualDeliveryPlaceholder, fallback)) return
+  if (await deliverToManualDeliveryPlaceholder(manualDelivery?.placeholder, fallback)) return
   await thread.post(fallback).catch(() => undefined)
 }
 
@@ -2120,7 +2121,7 @@ function createChatFinishExtension(
 async function flushChatFinishExtensionMessages(
   thread: Thread,
   chat: AgentChatQueuedFinishExtension,
-  manualDelivery: { placeholder?: unknown },
+  manualDelivery: { errorFallback?: string, placeholder?: unknown },
   abortSignal?: AbortSignal,
 ): Promise<void> {
   const messages = chat[chatFinishMessagesKey].splice(0)
@@ -2132,6 +2133,9 @@ async function flushChatFinishExtensionMessages(
         message = { markdown }
       }
       if (await deliverToManualDeliveryPlaceholder(manualDelivery.placeholder, message)) {
+        if (abortSignal?.aborted && manualDelivery.errorFallback) {
+          await replaceManualDeliveryPlaceholder(manualDelivery.placeholder, manualDelivery.errorFallback)
+        }
         abortSignal?.throwIfAborted()
         manualDelivery.placeholder = undefined
         continue
@@ -2239,7 +2243,7 @@ async function handleChatSdkMessage(
   let run: AgentRunMetadata | undefined
   let typing: ChatTypingRefresh | undefined
   let progress: ReturnType<typeof createManualDeliveryProgressUpdater> | undefined
-  const manualDeliveryState: { placeholder?: unknown } = {}
+  const manualDeliveryState: { errorFallback?: string, placeholder?: unknown } = {}
   try {
     input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, [chatAuthorizationUiMessage(thread, message, messageContext)], messageContext, registration.channelId)
     if (typeof options?.timeout === "number" && Number.isFinite(options.timeout) && options.timeout > 0) {
@@ -2339,8 +2343,9 @@ async function handleChatSdkMessage(
           await progress?.finish()
           await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState, invocationDeadlineAbort?.signal)
           invocationDeadlineAbort?.signal.throwIfAborted()
-          if (manualDeliveryState.placeholder) await deleteManualDeliveryPlaceholder(manualDeliveryState.placeholder)
+          const completedPlaceholder = manualDeliveryState.placeholder
           manualDeliveryState.placeholder = undefined
+          if (completedPlaceholder) await deleteManualDeliveryPlaceholder(completedPlaceholder)
         })(),
         maximumInvocationDeadline === undefined ? undefined : invocationInput.timeout,
         invocationDeadlineAbort,
@@ -2405,7 +2410,7 @@ async function handleChatSdkMessage(
   catch (error) {
     typing?.stop()
     await progress?.finish()
-    await postChatErrorFallback(error, thread, message, options, input, run, manualDeliveryState.placeholder)
+    await postChatErrorFallback(error, thread, message, options, input, run, manualDeliveryState)
     throw error
   }
   finally {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2191,11 +2191,13 @@ async function flushChatFinishExtensionMessages(
 ): Promise<void> {
   const messages = chat[chatFinishMessagesKey].splice(0)
   for (let message of messages) {
+    abortSignal?.throwIfAborted()
     if (manualDelivery.placeholder) {
       if (isAsyncIterable(message)) {
         let markdown = ""
         for await (const chunk of message) markdown += chunk
         message = { markdown }
+        abortSignal?.throwIfAborted()
       }
       const placeholder = manualDelivery.placeholder
       if (await deliverToManualDeliveryPlaceholder(placeholder, message, abortSignal

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2156,7 +2156,24 @@ function chatInvocationTimeout(
   timeout: number | undefined,
   maximum: number | undefined,
 ): number | undefined {
-  return timeout === undefined || maximum === undefined ? timeout : Math.min(timeout, maximum)
+  if (maximum === undefined) return timeout
+  return timeout === undefined ? maximum : Math.min(timeout, maximum)
+}
+
+async function enforceChatInvocationTimeout<T>(task: Promise<T>, timeout: number | undefined): Promise<T> {
+  if (timeout === undefined) return await task
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      task,
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => reject(new Error(`Chat invocation timed out after ${timeout}ms.`)), timeout)
+      }),
+    ])
+  }
+  finally {
+    if (timeoutId) clearTimeout(timeoutId)
+  }
 }
 
 async function handleChatSdkMessage(
@@ -2249,7 +2266,10 @@ async function handleChatSdkMessage(
       const result = manualDelivery
         ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
         : await runAgentInline(agent as never, runContext as never, invocationInput as never)
-      const text = await collectAgentOutput(result, progress?.update)
+      const text = await enforceChatInvocationTimeout(
+        collectAgentOutput(result, progress?.update),
+        maximumInvocationTimeout === undefined ? undefined : invocationInput.timeout,
+      )
       if (!manualDelivery && text) {
         if (!await postDiscordSplitContent(thread, { markdown: text })) {
           await thread.post({ markdown: text })

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1329,7 +1329,7 @@ async function postChatStream(
   const adapter = thread.adapter
   const placeholder = fallback === null
     ? Promise.resolve(undefined)
-    : adapter.postMessage(thread.id, fallback).catch(() => undefined)
+    : adapter.postMessage(thread.id, fallback)
   const clearPlaceholder = () => {
     waitUntil(settleChatCleanup(placeholder.then(async (message) => {
       if (message?.id) await adapter.deleteMessage(message.threadId || thread.id, message.id)
@@ -1344,8 +1344,7 @@ async function postChatStream(
       if (property === "postMessage" && fallback !== null) {
         return async (...args: Parameters<Adapter["postMessage"]>) => {
           if (args[0] === thread.id && args[1] === fallback) {
-            const message = await placeholder
-            if (message) return message
+            return await placeholder
           }
           return adapter.postMessage(...args)
         }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2931,28 +2931,34 @@ export function createChannelWebhookRouteHandler(
         }
       }
 
-      const baseChatOptions = getAgentChatOptions(agent)
-      const adapters = await resolveChatAdapters(baseChatOptions, context)
-      const adapterName = resolveChatAdapterName(adapters, registration)
-      const adapter = adapterName ? adapters[adapterName] : undefined
-      if (!adapter) {
-        return createJsonErrorResponse(500, `Agent chat webhook "${webhookId}" does not have a matching chat adapter.`)
-      }
-
-      try {
-        const chatOptions = getChannelChatOptions(agent, registration.channelId, baseChatOptions)
-        const handler = await createChatWebhookHandler(agent, context, registration, adapterName!, adapter, chatOptions, handlerOptions, maximumInvocationDeadline)
-        const response = await handler(request, { waitUntil: context.waitUntil })
-        if (chatOptions?.stream === false && hasExplicitNonStreamingMessages(agent, registration.channelId)) {
-          await context.flushWaitUntil?.()
+      const chatWebhookTask = (async () => {
+        const baseChatOptions = getAgentChatOptions(agent)
+        const adapters = await resolveChatAdapters(baseChatOptions, context)
+        const adapterName = resolveChatAdapterName(adapters, registration)
+        const adapter = adapterName ? adapters[adapterName] : undefined
+        if (!adapter) {
+          return createJsonErrorResponse(500, `Agent chat webhook "${webhookId}" does not have a matching chat adapter.`)
         }
-        return response
-      }
-      catch (error) {
-        const response = toHttpErrorResponse(error)
-        if (response) return response
-        throw error
-      }
+
+        try {
+          const chatOptions = getChannelChatOptions(agent, registration.channelId, baseChatOptions)
+          const handler = await createChatWebhookHandler(agent, context, registration, adapterName!, adapter, chatOptions, handlerOptions, maximumInvocationDeadline)
+          const response = await handler(request, { waitUntil: context.waitUntil })
+          if (chatOptions?.stream === false && hasExplicitNonStreamingMessages(agent, registration.channelId)) {
+            await context.flushWaitUntil?.()
+          }
+          return response
+        }
+        catch (error) {
+          const response = toHttpErrorResponse(error)
+          if (response) return response
+          throw error
+        }
+      })()
+      return await enforceChatInvocationTimeout(
+        chatWebhookTask,
+        maximumInvocationDeadline === undefined ? undefined : Math.max(0, maximumInvocationDeadline - Date.now()),
+      )
     })
   }
 }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2098,12 +2098,18 @@ async function deliverToManualDeliveryPlaceholder(
 async function resolveChatErrorFallbackText(
   options: AgentChatOptions | undefined,
   args: AgentChatErrorHookArgs<ViteAgentRouteRuntimeConfig>,
+  resolutionTimeout?: number,
 ): Promise<string | undefined> {
   const fallback = options?.errorFallbackText
   if (fallback === null) return undefined
   if (typeof fallback === "function") {
-    const resolved = await fallback(args)
-    return resolved || undefined
+    try {
+      const resolved = await enforceChatInvocationTimeout(Promise.resolve(fallback(args)), resolutionTimeout)
+      return resolved || undefined
+    }
+    catch {
+      return defaultChatErrorFallbackText
+    }
   }
   if (typeof fallback === "string") return fallback
   const publicError = toAgentPublicError(args.error, "http")
@@ -2119,6 +2125,7 @@ async function postChatErrorFallback(
   input: AgentChatMessageTriggerInput | undefined,
   run: AgentRunMetadata | undefined,
   manualDelivery?: { errorFallback?: string, placeholder?: unknown },
+  maximumInvocationDeadline?: number,
 ): Promise<void> {
   console.error({
     component: "@vite-hub/agent",
@@ -2127,7 +2134,14 @@ async function postChatErrorFallback(
     message_id: message.id,
     thread_id: message.threadId,
   })
-  const fallback = await resolveChatErrorFallbackText(options, chatErrorHookArgs(thread, message, input, run, error))
+  const fallbackResolutionTimeout = maximumInvocationDeadline === undefined
+    ? undefined
+    : Math.min(1_000, Math.max(0, maximumInvocationDeadline + 5_000 - Date.now()))
+  const fallback = await resolveChatErrorFallbackText(
+    options,
+    chatErrorHookArgs(thread, message, input, run, error),
+    fallbackResolutionTimeout,
+  )
   if (fallback && manualDelivery) manualDelivery.errorFallback = fallback
   if (!fallback) {
     if (manualDelivery?.placeholder) await deleteManualDeliveryPlaceholder(manualDelivery.placeholder)
@@ -2461,7 +2475,7 @@ async function handleChatSdkMessage(
   catch (error) {
     typing?.stop()
     await progress?.finish()
-    await postChatErrorFallback(error, thread, message, options, input, run, manualDeliveryState)
+    await postChatErrorFallback(error, thread, message, options, input, run, manualDeliveryState, maximumInvocationDeadline)
     throw error
   }
   finally {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2188,6 +2188,7 @@ async function handleChatSdkMessage(
   messageContext?: MessageContext,
   maximumInvocationTimeout?: number,
 ): Promise<void> {
+  const invocationStartedAt = Date.now()
   let input: AgentChatMessageTriggerInput | undefined
   let run: AgentRunMetadata | undefined
   let typing: ChatTypingRefresh | undefined
@@ -2242,9 +2243,12 @@ async function handleChatSdkMessage(
       ? createManualDeliveryProgressUpdater(manualDeliveryState, context.waitUntil)
       : undefined
     const resolvedInvocationInput = invocation.input as AgentRunInput
+    const remainingMaximumInvocationTimeout = maximumInvocationTimeout === undefined
+      ? undefined
+      : Math.max(0, maximumInvocationTimeout - (Date.now() - invocationStartedAt))
     const invocationInput = withChatFinishExtension(withResolvedAgentInvokerInput({
       ...resolvedInvocationInput,
-      timeout: chatInvocationTimeout(resolvedInvocationInput.timeout, maximumInvocationTimeout),
+      timeout: chatInvocationTimeout(resolvedInvocationInput.timeout, remainingMaximumInvocationTimeout),
       context: {
         ...resolvedInvocationInput.context,
         [messageChannelStateContextKey]: state,
@@ -2283,52 +2287,54 @@ async function handleChatSdkMessage(
       manualDeliveryState.placeholder = undefined
     }
     else {
-      const result = streamAgent(agent as never, runContext as never, invocationInput as never, {
-        output: "events",
-      })
-      try {
-        if (options?.stream === true || options?.commentary === undefined) {
-          await postChatStream(
-            thread,
-            streamAgentOutputToChatText(result),
-            typeof thinkingFallback === "string" || thinkingFallback === null ? thinkingFallback : undefined,
-            context.waitUntil,
-          )
+      await enforceChatInvocationTimeout((async () => {
+        const result = streamAgent(agent as never, runContext as never, invocationInput as never, {
+          output: "events",
+        })
+        try {
+          if (options?.stream === true || options?.commentary === undefined) {
+            await postChatStream(
+              thread,
+              streamAgentOutputToChatText(result),
+              typeof thinkingFallback === "string" || thinkingFallback === null ? thinkingFallback : undefined,
+              context.waitUntil,
+            )
+          }
+          else {
+            let finalDelivery: Promise<void> | undefined
+            let finalDeliveryError: unknown
+            const replies = streamAgentOutputToChatReplies(result, {
+              commentary: options.commentary,
+              onCommentary(response, discard) {
+                const delivery = postChatStream(thread, response, undefined, context.waitUntil)
+                  .catch(() => discard())
+                context.waitUntil(delivery)
+              },
+              onFinal(response) {
+                finalDelivery = postChatStream(
+                  thread,
+                  response,
+                  typeof thinkingFallback === "string" || thinkingFallback === null ? thinkingFallback : undefined,
+                  context.waitUntil,
+                ).catch((error) => {
+                  finalDeliveryError = error
+                })
+              },
+            })
+            let streamError: unknown
+            await replies.completion.catch((error) => {
+              streamError = error
+            })
+            await finalDelivery
+            if (streamError !== undefined) throw streamError
+            if (finalDeliveryError !== undefined) throw finalDeliveryError
+          }
         }
-        else {
-          let finalDelivery: Promise<void> | undefined
-          let finalDeliveryError: unknown
-          const replies = streamAgentOutputToChatReplies(result, {
-            commentary: options.commentary,
-            onCommentary(response, discard) {
-              const delivery = postChatStream(thread, response, undefined, context.waitUntil)
-                .catch(() => discard())
-              context.waitUntil(delivery)
-            },
-            onFinal(response) {
-              finalDelivery = postChatStream(
-                thread,
-                response,
-                typeof thinkingFallback === "string" || thinkingFallback === null ? thinkingFallback : undefined,
-                context.waitUntil,
-              ).catch((error) => {
-                finalDeliveryError = error
-              })
-            },
-          })
-          let streamError: unknown
-          await replies.completion.catch((error) => {
-            streamError = error
-          })
-          await finalDelivery
-          if (streamError !== undefined) throw streamError
-          if (finalDeliveryError !== undefined) throw finalDeliveryError
+        finally {
+          typing?.stop()
         }
-      }
-      finally {
-        typing?.stop()
-      }
-      await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState)
+        await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState)
+      })(), maximumInvocationTimeout === undefined ? undefined : invocationInput.timeout)
     }
   }
   catch (error) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2054,9 +2054,14 @@ async function deleteManualDeliveryPlaceholder(placeholder: unknown): Promise<vo
   }
 }
 
-async function deliverToManualDeliveryPlaceholder(placeholder: unknown, message: AgentChatMessage): Promise<boolean> {
+async function deliverToManualDeliveryPlaceholder(
+  placeholder: unknown,
+  message: AgentChatMessage,
+  beforeDelete?: () => void,
+): Promise<boolean> {
   if (!placeholder) return false
   if (await replaceManualDeliveryPlaceholder(placeholder, message).catch(() => false)) return true
+  beforeDelete?.()
   await deleteManualDeliveryPlaceholder(placeholder)
   return false
 }
@@ -2132,9 +2137,14 @@ async function flushChatFinishExtensionMessages(
         for await (const chunk of message) markdown += chunk
         message = { markdown }
       }
-      if (await deliverToManualDeliveryPlaceholder(manualDelivery.placeholder, message)) {
+      const placeholder = manualDelivery.placeholder
+      if (await deliverToManualDeliveryPlaceholder(placeholder, message, abortSignal
+        ? () => {
+            manualDelivery.placeholder = undefined
+          }
+        : undefined)) {
         if (abortSignal?.aborted && manualDelivery.errorFallback) {
-          await replaceManualDeliveryPlaceholder(manualDelivery.placeholder, manualDelivery.errorFallback)
+          await replaceManualDeliveryPlaceholder(placeholder, manualDelivery.errorFallback)
         }
         abortSignal?.throwIfAborted()
         manualDelivery.placeholder = undefined

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2143,12 +2143,29 @@ async function postChatErrorFallback(
     fallbackResolutionTimeout,
   )
   if (fallback && manualDelivery) manualDelivery.errorFallback = fallback
-  if (!fallback) {
-    if (manualDelivery?.placeholder) await deleteManualDeliveryPlaceholder(manualDelivery.placeholder)
-    return
+  const fallbackDeliveryAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
+  const fallbackDelivery = (async () => {
+    if (!fallback) {
+      if (manualDelivery?.placeholder) await deleteManualDeliveryPlaceholder(manualDelivery.placeholder)
+      return
+    }
+    if (await deliverToManualDeliveryPlaceholder(manualDelivery?.placeholder, fallback)) return
+    fallbackDeliveryAbort?.signal.throwIfAborted()
+    const sent = await thread.post(fallback).catch(() => undefined)
+    if (!sent) return
+    if (fallbackDeliveryAbort?.signal.aborted) {
+      await deleteManualDeliveryPlaceholder(sent)
+      fallbackDeliveryAbort.signal.throwIfAborted()
+    }
+  })()
+  if (maximumInvocationDeadline === undefined) await fallbackDelivery
+  else {
+    await enforceChatInvocationTimeout(
+      fallbackDelivery,
+      Math.max(0, maximumInvocationDeadline + 5_000 - Date.now()),
+      fallbackDeliveryAbort,
+    ).catch(() => undefined)
   }
-  if (await deliverToManualDeliveryPlaceholder(manualDelivery?.placeholder, fallback)) return
-  await thread.post(fallback).catch(() => undefined)
 }
 
 function createChatFinishExtension(

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2194,9 +2194,8 @@ async function handleChatSdkMessage(
   options: AgentChatOptions | undefined,
   state: { keyPrefix: string, state: StateAdapter },
   messageContext?: MessageContext,
-  maximumInvocationTimeout?: number,
+  maximumInvocationDeadline?: number,
 ): Promise<void> {
-  const invocationStartedAt = Date.now()
   let input: AgentChatMessageTriggerInput | undefined
   let run: AgentRunMetadata | undefined
   let typing: ChatTypingRefresh | undefined
@@ -2251,10 +2250,10 @@ async function handleChatSdkMessage(
       ? createManualDeliveryProgressUpdater(manualDeliveryState, context.waitUntil)
       : undefined
     const resolvedInvocationInput = invocation.input as AgentRunInput
-    const remainingMaximumInvocationTimeout = maximumInvocationTimeout === undefined
+    const remainingMaximumInvocationTimeout = maximumInvocationDeadline === undefined
       ? undefined
-      : Math.max(0, maximumInvocationTimeout - (Date.now() - invocationStartedAt))
-    const invocationDeadlineAbort = maximumInvocationTimeout === undefined ? undefined : new AbortController()
+      : Math.max(0, maximumInvocationDeadline - Date.now())
+    const invocationDeadlineAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
     const invocationInput = withChatFinishExtension(withResolvedAgentInvokerInput({
       ...resolvedInvocationInput,
       ...(invocationDeadlineAbort
@@ -2290,7 +2289,7 @@ async function handleChatSdkMessage(
             : await runAgentInline(agent as never, runContext as never, invocationInput as never)
           return await collectAgentOutput(result, progress?.update)
         })(),
-        maximumInvocationTimeout === undefined ? undefined : invocationInput.timeout,
+        maximumInvocationDeadline === undefined ? undefined : invocationInput.timeout,
         invocationDeadlineAbort,
       )
       if (!manualDelivery && text) {
@@ -2351,7 +2350,7 @@ async function handleChatSdkMessage(
           typing?.stop()
         }
         await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState)
-      })(), maximumInvocationTimeout === undefined ? undefined : invocationInput.timeout, invocationDeadlineAbort)
+      })(), maximumInvocationDeadline === undefined ? undefined : invocationInput.timeout, invocationDeadlineAbort)
     }
   }
   catch (error) {
@@ -2373,6 +2372,7 @@ async function createChannelChat(
   adapter: Adapter,
   options: AgentChatOptions | undefined,
   handlerOptions: AgentChannelWebhookRouteOptions,
+  maximumInvocationDeadline?: number,
 ): Promise<Chat> {
   const resolvedState = await resolveChatState(options, context, registration, handlerOptions)
   const chat = new Chat(createChatSdkConfig(
@@ -2382,19 +2382,14 @@ async function createChannelChat(
     options,
   ))
   const state = { keyPrefix: resolvedState.titleKeyPrefix, state: resolvedState.state }
-  // Cloudflare cancels waitUntil after 30 seconds, so fallback delivery needs its own time budget.
-  const maximumInvocationTimeout = context.runtime === "cloudflare-agents" && handlerOptions.waitUntil
-    ? cloudflareChatBackgroundTimeoutMs
-    : undefined
-
   chat.onDirectMessage((thread, message, _channel, messageContext) =>
-    handleChatSdkMessage(agent, context, registration, thread, message, "direct", options, state, messageContext, maximumInvocationTimeout))
+    handleChatSdkMessage(agent, context, registration, thread, message, "direct", options, state, messageContext, maximumInvocationDeadline))
   chat.onNewMention(async (thread, message, messageContext) => {
     await thread.subscribe().catch(() => undefined)
-    await handleChatSdkMessage(agent, context, registration, thread, message, "mention", options, state, messageContext, maximumInvocationTimeout)
+    await handleChatSdkMessage(agent, context, registration, thread, message, "mention", options, state, messageContext, maximumInvocationDeadline)
   })
   chat.onSubscribedMessage((thread, message, messageContext) =>
-    handleChatSdkMessage(agent, context, registration, thread, message, message.isMention ? "mention" : "subscribed", options, state, messageContext, maximumInvocationTimeout))
+    handleChatSdkMessage(agent, context, registration, thread, message, message.isMention ? "mention" : "subscribed", options, state, messageContext, maximumInvocationDeadline))
 
   return chat
 }
@@ -2407,8 +2402,9 @@ async function createChatWebhookHandler(
   adapter: Adapter,
   options: AgentChatOptions | undefined,
   handlerOptions: AgentChannelWebhookRouteOptions,
+  maximumInvocationDeadline?: number,
 ): Promise<(request: Request, webhookOptions: WebhookOptions) => Promise<Response>> {
-  const chat = await createChannelChat(agent, context, registration, adapterName, adapter, options, handlerOptions)
+  const chat = await createChannelChat(agent, context, registration, adapterName, adapter, options, handlerOptions, maximumInvocationDeadline)
   const handler = chat.webhooks[adapterName]
   if (!handler) {
     throw new Error(`[vitehub] Chat adapter "${adapterName}" did not expose a webhook handler.`)
@@ -2657,6 +2653,7 @@ export function createChannelWebhookRouteHandler(
   agent: AgentInput<ViteAgentRouteRuntimeContext>,
 ): (request: Request, webhook?: string, options?: AgentChannelWebhookRouteOptions) => Promise<Response> {
   return async (request, webhook, handlerOptions = {}) => {
+    const webhookStartedAt = Date.now()
     if (request.method !== "HEAD" && request.method !== "POST") {
       return createJsonErrorResponse(405, "Agent webhook route only accepts HEAD and POST requests.")
     }
@@ -2676,6 +2673,10 @@ export function createChannelWebhookRouteHandler(
       handlerOptions.capabilities,
       routeAgentIdentity(handlerOptions),
     )
+    // Cloudflare cancels waitUntil after 30 seconds, so fallback delivery needs its own time budget.
+    const maximumInvocationDeadline = context.runtime === "cloudflare-agents" && handlerOptions.waitUntil
+      ? webhookStartedAt + cloudflareChatBackgroundTimeoutMs
+      : undefined
     return await runWithRuntimeCloudflareEnv(context, async () => {
       const match = await findAgentWebhookRegistration(agent, context, request, webhookId)
       if (!match) {
@@ -2837,7 +2838,7 @@ export function createChannelWebhookRouteHandler(
 
       try {
         const chatOptions = getChannelChatOptions(agent, registration.channelId, baseChatOptions)
-        const handler = await createChatWebhookHandler(agent, context, registration, adapterName!, adapter, chatOptions, handlerOptions)
+        const handler = await createChatWebhookHandler(agent, context, registration, adapterName!, adapter, chatOptions, handlerOptions, maximumInvocationDeadline)
         const response = await handler(request, { waitUntil: context.waitUntil })
         if (chatOptions?.stream === false && hasExplicitNonStreamingMessages(agent, registration.channelId)) {
           await context.flushWaitUntil?.()

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2161,6 +2161,12 @@ async function resolveChatErrorFallbackText(
   return defaultChatErrorFallbackText
 }
 
+interface ManualChatDeliveryState {
+  errorFallback?: string
+  placeholder?: unknown
+  placeholderCleanup?: Promise<void>
+}
+
 async function postChatErrorFallback(
   error: unknown,
   thread: Thread,
@@ -2168,7 +2174,7 @@ async function postChatErrorFallback(
   options: AgentChatOptions | undefined,
   input: AgentChatMessageTriggerInput | undefined,
   run: AgentRunMetadata | undefined,
-  manualDelivery?: { errorFallback?: string, placeholder?: unknown },
+  manualDelivery?: ManualChatDeliveryState,
   maximumInvocationDeadline?: number,
 ): Promise<void> {
   console.error({
@@ -2193,6 +2199,16 @@ async function postChatErrorFallback(
     () => callbackDelivered,
   )
   if (fallback && manualDelivery) manualDelivery.errorFallback = fallback
+  if (manualDelivery?.placeholderCleanup) {
+    const cleanup = manualDelivery.placeholderCleanup.catch(() => undefined)
+    if (maximumInvocationDeadline === undefined) await cleanup
+    else {
+      await enforceChatInvocationTimeout(
+        cleanup,
+        Math.max(0, maximumInvocationDeadline + 5_000 - Date.now()),
+      ).catch(() => undefined)
+    }
+  }
   const fallbackDeliveryAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
   const fallbackDelivery = (async () => {
     if (!fallback) {
@@ -2259,7 +2275,7 @@ async function collectAbortableChatMessage(
 async function flushChatFinishExtensionMessages(
   thread: Thread,
   chat: AgentChatQueuedFinishExtension,
-  manualDelivery: { errorFallback?: string, placeholder?: unknown },
+  manualDelivery: ManualChatDeliveryState,
   abortSignal?: AbortSignal,
 ): Promise<void> {
   const messages = chat[chatFinishMessagesKey].splice(0)
@@ -2391,7 +2407,7 @@ async function handleChatSdkMessage(
   let run: AgentRunMetadata | undefined
   let typing: ChatTypingRefresh | undefined
   let progress: ReturnType<typeof createManualDeliveryProgressUpdater> | undefined
-  const manualDeliveryState: { errorFallback?: string, placeholder?: unknown } = {}
+  const manualDeliveryState: ManualChatDeliveryState = {}
   const invocationDeadlineAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
   try {
     input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, [chatAuthorizationUiMessage(thread, message, messageContext)], messageContext, registration.channelId)
@@ -2504,14 +2520,19 @@ async function handleChatSdkMessage(
           await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState, invocationDeadlineAbort?.signal)
           invocationDeadlineAbort?.signal.throwIfAborted()
           const completedPlaceholder = manualDeliveryState.placeholder
-          manualDeliveryState.placeholder = undefined
           if (completedPlaceholder) {
+            const placeholderCleanup = deleteManualDeliveryPlaceholder(completedPlaceholder)
+            manualDeliveryState.placeholderCleanup = placeholderCleanup
             try {
-              await deleteManualDeliveryPlaceholder(completedPlaceholder)
+              await placeholderCleanup
+              if (manualDeliveryState.placeholder === completedPlaceholder) {
+                manualDeliveryState.placeholder = undefined
+              }
             }
-            catch (error) {
-              if (!invocationDeadlineAbort?.signal.aborted) manualDeliveryState.placeholder = completedPlaceholder
-              throw error
+            finally {
+              if (manualDeliveryState.placeholderCleanup === placeholderCleanup) {
+                manualDeliveryState.placeholderCleanup = undefined
+              }
             }
           }
         })(),

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1189,12 +1189,44 @@ async function removeAbortedChatDelivery(sent: unknown, abortSignal?: AbortSigna
   abortSignal.throwIfAborted()
 }
 
+async function settleChatCleanup(
+  task: Promise<unknown>,
+  maximumDeadline?: number,
+  abortSignal?: AbortSignal,
+): Promise<void> {
+  const abortableTask = abortSignal
+    ? new Promise<unknown>((resolve, reject) => {
+        const onAbort = () => {
+          abortSignal.removeEventListener("abort", onAbort)
+          reject(abortSignal.reason)
+        }
+        abortSignal.addEventListener("abort", onAbort, { once: true })
+        task.then(
+          (value) => {
+            abortSignal.removeEventListener("abort", onAbort)
+            resolve(value)
+          },
+          (error) => {
+            abortSignal.removeEventListener("abort", onAbort)
+            reject(error)
+          },
+        )
+        if (abortSignal.aborted) onAbort()
+      })
+    : task
+  await enforceChatInvocationTimeout(
+    abortableTask,
+    maximumDeadline === undefined ? undefined : Math.max(0, maximumDeadline - Date.now()),
+  ).catch(() => undefined)
+}
+
 async function postChatStream(
   thread: Thread,
   response: ChatTextStream,
   fallback: string | null | undefined,
   waitUntil: AgentWaitUntil,
   abortSignal?: AbortSignal,
+  maximumDeadline?: number,
 ): Promise<void> {
   abortSignal?.throwIfAborted()
   let sent: unknown
@@ -1218,17 +1250,17 @@ async function postChatStream(
     const clearPlaceholder = async () => {
       if (cleared) return
       if (clearing) return clearing
-      clearing = placeholder.then(async (message) => {
+      clearing = settleChatCleanup(placeholder.then(async (message) => {
         if (!message?.id) return
         await adapter.deleteMessage(message.threadId || thread.id, message.id)
         cleared = true
-      }).catch(() => undefined).finally(() => {
+      }), maximumDeadline, abortSignal).finally(() => {
         clearing = undefined
       })
       return clearing
     }
     const finishPlaceholder = () => {
-      waitUntil(clearPlaceholder().then(() => cleared ? undefined : clearPlaceholder()))
+      waitUntil(clearPlaceholder().then(() => cleared || abortSignal?.aborted ? undefined : clearPlaceholder()))
     }
     abortSignal?.addEventListener("abort", finishPlaceholder, { once: true })
     const nativeResponse: ChatTextStream = {
@@ -1294,9 +1326,9 @@ async function postChatStream(
     ? Promise.resolve(undefined)
     : adapter.postMessage(thread.id, fallback).catch(() => undefined)
   const clearPlaceholder = () => {
-    waitUntil(placeholder.then(async (message) => {
+    waitUntil(settleChatCleanup(placeholder.then(async (message) => {
       if (message?.id) await adapter.deleteMessage(message.threadId || thread.id, message.id)
-    }).catch(() => undefined))
+    }), maximumDeadline, abortSignal))
   }
   abortSignal?.addEventListener("abort", clearPlaceholder, { once: true })
   const chatThread = thread as Thread & { _adapter?: Adapter, _fallbackStreamingPlaceholderText?: string | null }
@@ -1978,6 +2010,7 @@ function chatErrorHookArgs(
   input: AgentChatMessageTriggerInput | undefined,
   run: AgentRunMetadata | undefined,
   error: unknown,
+  abortSignal?: AbortSignal,
   onPost?: () => void,
 ): AgentChatErrorHookArgs<ViteAgentRouteRuntimeConfig> {
   const inputMessage = input?.messages.at(-1)
@@ -1995,7 +2028,7 @@ function chatErrorHookArgs(
     run,
     thread: {
       post: async (postedMessage) => {
-        await postChatMessage(thread, postedMessage as AgentChatMessage)
+        await postChatMessage(thread, postedMessage as AgentChatMessage, abortSignal)
         onPost?.()
       },
     },
@@ -2108,13 +2141,14 @@ async function resolveChatErrorFallbackText(
   options: AgentChatOptions | undefined,
   args: AgentChatErrorHookArgs<ViteAgentRouteRuntimeConfig>,
   resolutionTimeout?: number,
+  resolutionAbort?: AbortController,
   callbackDelivered?: () => boolean,
 ): Promise<string | undefined> {
   const fallback = options?.errorFallbackText
   if (fallback === null) return undefined
   if (typeof fallback === "function") {
     try {
-      const resolved = await enforceChatInvocationTimeout(Promise.resolve(fallback(args)), resolutionTimeout)
+      const resolved = await enforceChatInvocationTimeout(Promise.resolve(fallback(args)), resolutionTimeout, resolutionAbort)
       return resolved || undefined
     }
     catch {
@@ -2148,12 +2182,14 @@ async function postChatErrorFallback(
     ? undefined
     : Math.min(1_000, Math.max(0, maximumInvocationDeadline + 5_000 - Date.now()))
   let callbackDelivered = false
+  const fallbackResolutionAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
   const fallback = await resolveChatErrorFallbackText(
     options,
-    chatErrorHookArgs(thread, message, input, run, error, () => {
+    chatErrorHookArgs(thread, message, input, run, error, fallbackResolutionAbort?.signal, () => {
       callbackDelivered = true
     }),
     fallbackResolutionTimeout,
+    fallbackResolutionAbort,
     () => callbackDelivered,
   )
   if (fallback && manualDelivery) manualDelivery.errorFallback = fallback
@@ -2496,6 +2532,7 @@ async function handleChatSdkMessage(
               typeof thinkingFallback === "string" || thinkingFallback === null ? thinkingFallback : undefined,
               context.waitUntil,
               invocationDeadlineAbort?.signal,
+              maximumInvocationDeadline,
             )
           }
           else {
@@ -2505,7 +2542,7 @@ async function handleChatSdkMessage(
             const replies = streamAgentOutputToChatReplies(result, {
               commentary: options.commentary,
               onCommentary(response, discard) {
-                const delivery = postChatStream(thread, response, undefined, context.waitUntil, invocationDeadlineAbort?.signal)
+                const delivery = postChatStream(thread, response, undefined, context.waitUntil, invocationDeadlineAbort?.signal, maximumInvocationDeadline)
                   .catch(() => discard())
                 commentaryDeliveries.push(delivery)
                 context.waitUntil(delivery)
@@ -2517,6 +2554,7 @@ async function handleChatSdkMessage(
                   typeof thinkingFallback === "string" || thinkingFallback === null ? thinkingFallback : undefined,
                   context.waitUntil,
                   invocationDeadlineAbort?.signal,
+                  maximumInvocationDeadline,
                 ).catch((error) => {
                   finalDeliveryError = error
                 })

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2469,7 +2469,15 @@ async function handleChatSdkMessage(
           invocationDeadlineAbort?.signal.throwIfAborted()
           const completedPlaceholder = manualDeliveryState.placeholder
           manualDeliveryState.placeholder = undefined
-          if (completedPlaceholder) await deleteManualDeliveryPlaceholder(completedPlaceholder)
+          if (completedPlaceholder) {
+            try {
+              await deleteManualDeliveryPlaceholder(completedPlaceholder)
+            }
+            catch (error) {
+              if (!invocationDeadlineAbort?.signal.aborted) manualDeliveryState.placeholder = completedPlaceholder
+              throw error
+            }
+          }
         })(),
         maximumInvocationDeadline === undefined ? undefined : invocationInput.timeout,
         invocationDeadlineAbort,

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1283,8 +1283,34 @@ async function postChatStream(
   }
 
   // ponytail: Chat SDK has no per-stream fallback option; replace this when it exposes one.
-  const chatThread = thread as Thread & { _fallbackStreamingPlaceholderText?: string | null }
+  const adapter = thread.adapter
+  const placeholder = fallback === null
+    ? Promise.resolve(undefined)
+    : adapter.postMessage(thread.id, fallback).catch(() => undefined)
+  const clearPlaceholder = () => {
+    waitUntil(placeholder.then(async (message) => {
+      if (message?.id) await adapter.deleteMessage(message.threadId || thread.id, message.id)
+    }).catch(() => undefined))
+  }
+  abortSignal?.addEventListener("abort", clearPlaceholder, { once: true })
+  const chatThread = thread as Thread & { _adapter?: Adapter, _fallbackStreamingPlaceholderText?: string | null }
+  const previousAdapter = chatThread._adapter
   const previous = chatThread._fallbackStreamingPlaceholderText
+  chatThread._adapter = new Proxy(adapter, {
+    get(target, property) {
+      if (property === "postMessage" && fallback !== null) {
+        return async (...args: Parameters<Adapter["postMessage"]>) => {
+          if (args[0] === thread.id && args[1] === fallback) {
+            const message = await placeholder
+            if (message) return message
+          }
+          return adapter.postMessage(...args)
+        }
+      }
+      const value = Reflect.get(target, property, target)
+      return typeof value === "function" ? value.bind(target) : value
+    },
+  })
   chatThread._fallbackStreamingPlaceholderText = fallback
   try {
     sent = await thread.post(chatStreamPostable(thread, response) as never)
@@ -1293,6 +1319,8 @@ async function postChatStream(
     await removeAbortedChatDelivery(sent, abortSignal)
   }
   finally {
+    abortSignal?.removeEventListener("abort", clearPlaceholder)
+    chatThread._adapter = previousAdapter
     chatThread._fallbackStreamingPlaceholderText = previous
   }
 }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1128,12 +1128,20 @@ function renderDiscordPostable(adapter: Adapter, postable: AdapterPostableMessag
   if (typeof postable === "object" && postable !== null && "markdown" in postable && typeof postable.markdown === "string") return postable.markdown
 }
 
-async function postDiscordSplitContent(thread: Thread, postable: AdapterPostableMessage): Promise<boolean> {
+async function postDiscordSplitContent(
+  thread: Thread,
+  postable: AdapterPostableMessage,
+  abortSignal?: AbortSignal,
+): Promise<boolean> {
   if (discordLongContentMode(thread.adapter) !== "split") return false
   const rendered = renderDiscordPostable(thread.adapter, postable)
   if (!rendered || rendered.length <= discordMaxContentLength) return false
   for (const part of discordContentParts(rendered)) {
-    await thread.post({ raw: part })
+    const sent = await thread.post({ raw: part })
+    if (abortSignal?.aborted) {
+      await deleteManualDeliveryPlaceholder(sent)
+      abortSignal.throwIfAborted()
+    }
   }
   return true
 }
@@ -2289,8 +2297,12 @@ async function handleChatSdkMessage(
             : await runAgentInline(agent as never, runContext as never, invocationInput as never)
           const text = await collectAgentOutput(result, progress?.update)
           if (!manualDelivery && text) {
-            if (!await postDiscordSplitContent(thread, { markdown: text })) {
-              await thread.post({ markdown: text })
+            if (!await postDiscordSplitContent(thread, { markdown: text }, invocationDeadlineAbort?.signal)) {
+              const sent = await thread.post({ markdown: text })
+              if (invocationDeadlineAbort?.signal.aborted) {
+                await deleteManualDeliveryPlaceholder(sent)
+                invocationDeadlineAbort.signal.throwIfAborted()
+              }
             }
           }
           await progress?.finish()

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7718,6 +7718,60 @@ describe("server helpers", () => {
     }
   })
 
+  it("bounds stalled Cloudflare fallback delivery by the hard deadline", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.postMessage.mockImplementation(() => new Promise(() => undefined))
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            errorFallbackText: "Please try again.",
+            timeout: 50_000,
+          },
+          webhooks: { secretToken: false },
+        }),
+      },
+      driver: {
+        run: async () => ({
+          stream: (async function* () {
+            await new Promise(() => undefined)
+          })(),
+        }),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const responseError = handler(chatWebhookRequest(91_023), "telegram", {
+        cloudflare: { env: {} },
+        waitUntil: () => undefined,
+      }).catch(error => error)
+      await vi.advanceTimersByTimeAsync(0)
+
+      await vi.advanceTimersByTimeAsync(29_999)
+      await expect(Promise.race([
+        responseError.then(() => "settled"),
+        Promise.resolve("pending"),
+      ])).resolves.toBe("pending")
+
+      await vi.advanceTimersByTimeAsync(1)
+      await expect(responseError).resolves.toMatchObject({
+        message: "Chat invocation timed out after 25000ms.",
+      })
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Please try again.")
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("removes a manual placeholder when the error fallback is disabled", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -6760,6 +6760,41 @@ describe("server helpers", () => {
     }
   })
 
+  it("does not retry an ambiguously failed native streaming placeholder post", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.postMessage.mockRejectedValueOnce(new Error("provider response lost"))
+    adapter.stream = vi.fn(async () => null)
+    const agent = defineAgent({
+      capabilities: [
+        defineChatCapability({
+          errorFallbackText: null,
+          fallbackStreamingPlaceholderText: "Working on it...",
+          platforms: {
+            telegram: () => adapter as never,
+          },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      driver: { run: async () => "done" },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      await expect(handler(chatWebhookRequest(21051), "telegram")).rejects.toThrow("provider response lost")
+      expect(adapter.postMessage).toHaveBeenCalledOnce()
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Working on it...")
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
   it("does not block native output on slow fallback delivery or cleanup", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineChatCapability } = await import("../src/chat-trigger.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -3541,6 +3541,37 @@ describe("server helpers", () => {
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", expect.any(String), { markdown: "Final answer." })
   })
 
+  it("does not block non-Cloudflare webhooks on stalled commentary delivery", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { discord } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.postMessage.mockImplementationOnce(() => new Promise(() => undefined))
+    const agent = defineAgent({
+      channels: {
+        discord: discord({
+          adapter: () => adapter as never,
+          messages: { commentary: "message" },
+        }),
+      },
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield { phase: "commentary", text: "Checking the image.", type: "text-delta" }
+            yield { phase: "final", text: "Final answer.", type: "text-delta" }
+          })(),
+        }),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(2018, 999), "discord")
+
+    expect(response.status).toBe(200)
+    expect(adapter.postMessage).toHaveBeenCalledTimes(2)
+    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:999", expect.any(String), { markdown: "Final answer." })
+  })
+
   it("delivers unphased final output when commentary is configured", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { discord } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7933,6 +7933,65 @@ describe("server helpers", () => {
     }
   })
 
+  it("does not post Discord split fragments after the Cloudflare deadline", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { discord } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter() as ReturnType<typeof createTestChatAdapter> & {
+      formatConverter: { renderPostable: (message: unknown) => string }
+      name: string
+    }
+    adapter.formatConverter = {
+      renderPostable(message: unknown) {
+        if (typeof message === "string") return message
+        if (typeof message === "object" && message && "raw" in message && typeof message.raw === "string") return message.raw
+        if (typeof message === "object" && message && "markdown" in message && typeof message.markdown === "string") return message.markdown
+        return ""
+      },
+    }
+    adapter.name = "discord"
+    Object.defineProperty(adapter, Symbol.for("vitehub.discord.longContent.mode"), { value: "split" })
+    adapter.editMessage.mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 26_000))
+    })
+    const agent = defineAgent({
+      channels: {
+        discord: discord({
+          adapter: () => adapter as never,
+          messages: {
+            errorFallbackText: "Please try again.",
+            stream: true,
+            timeout: 50_000,
+          },
+        }),
+      },
+      driver: { run: () => ({ text: `${"word ".repeat(430)}done` }) },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const responseError = handler(chatWebhookRequest(91_027), "discord", {
+        cloudflare: { env: {} },
+        waitUntil: () => undefined,
+      }).catch(error => error)
+      await vi.advanceTimersByTimeAsync(25_000)
+
+      await expect(responseError).resolves.toMatchObject({
+        message: "Chat invocation timed out after 25000ms.",
+      })
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", {
+        raw: expect.stringMatching(/ \(2\/2\)$/),
+      })
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("removes a manual placeholder when the error fallback is disabled", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7827,6 +7827,112 @@ describe("server helpers", () => {
     }
   })
 
+  it("closes stalled finish iterators before opening Cloudflare delivery", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const iteratorReturn = vi.fn(async () => ({ done: true as const, value: undefined }))
+    const reply = {
+      [Symbol.asyncIterator]: () => {
+        let first = true
+        return {
+          next: async () => {
+            if (first) {
+              first = false
+              return { done: false as const, value: "partial" }
+            }
+            return await new Promise<IteratorResult<string>>(() => undefined)
+          },
+          return: iteratorReturn,
+        }
+      },
+    }
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            errorFallbackText: "Please try again.",
+            stream: false,
+            timeout: 50_000,
+          },
+          webhooks: { secretToken: false },
+        }),
+      },
+      driver: { run: () => ({ text: "" }) },
+      hooks: {
+        "agent:finish": async (event) => {
+          const chat = event.extensions.get("chat") as { sendMessage?: (message: AsyncIterable<string>) => Promise<void> } | undefined
+          await chat?.sendMessage?.(reply)
+        },
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const responseError = handler(chatWebhookRequest(91_025), "telegram", {
+        cloudflare: { env: {} },
+        waitUntil: () => undefined,
+      }).catch(error => error)
+      await vi.advanceTimersByTimeAsync(25_000)
+
+      await expect(responseError).resolves.toMatchObject({
+        message: "Chat invocation timed out after 25000ms.",
+      })
+      expect(iteratorReturn).toHaveBeenCalledOnce()
+      expect(adapter.postMessage).toHaveBeenCalledTimes(1)
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Please try again.")
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it("does not duplicate a fallback callback that delivered before timing out", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            errorFallbackText: async ({ thread }) => {
+              await thread.post("Tailored fallback.")
+              await new Promise(() => undefined)
+            },
+          },
+          webhooks: { secretToken: false },
+        }),
+      },
+      driver: { run: () => { throw new Error("model timeout") } },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const responseError = handler(chatWebhookRequest(91_026), "telegram", {
+        cloudflare: { env: {} },
+        waitUntil: () => undefined,
+      }).catch(error => error)
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      await expect(responseError).resolves.toMatchObject({ message: "model timeout" })
+      expect(adapter.postMessage).toHaveBeenCalledTimes(1)
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Tailored fallback.")
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("removes a manual placeholder when the error fallback is disabled", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -8086,7 +8086,6 @@ describe("server helpers", () => {
           messages: {
             errorFallbackText: async ({ thread }) => {
               await thread.post("Tailored fallback.")
-              await new Promise(() => undefined)
             },
           },
           webhooks: { secretToken: false },
@@ -8105,6 +8104,52 @@ describe("server helpers", () => {
 
       await expect(responseError).resolves.toMatchObject({ message: "model timeout" })
       expect(adapter.postMessage).toHaveBeenCalledTimes(1)
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Tailored fallback.")
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it("uses the available Cloudflare deadline to resolve an immediate error fallback", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    let resolveFallback: ((fallback: string) => void) | undefined
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            errorFallbackText: () => new Promise<string>((resolve) => {
+              resolveFallback = resolve
+            }),
+          },
+          webhooks: { secretToken: false },
+        }),
+      },
+      driver: { run: () => { throw new Error("model error") } },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = handler(chatWebhookRequest(91_032), "telegram", {
+        cloudflare: { env: {} },
+        waitUntil: () => undefined,
+      })
+      for (let index = 0; index < 100 && !resolveFallback; index++) {
+        await vi.advanceTimersByTimeAsync(1)
+      }
+      expect(resolveFallback).toBeTypeOf("function")
+      await vi.advanceTimersByTimeAsync(1_100)
+      resolveFallback?.("Tailored fallback.")
+      for (let index = 0; index < 20 && !adapter.postMessage.mock.calls.length; index++) await Promise.resolve()
+      await expect(response).rejects.toThrow("model error")
+      expect(adapter.postMessage).toHaveBeenCalledOnce()
       expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Tailored fallback.")
     }
     finally {
@@ -8139,7 +8184,7 @@ describe("server helpers", () => {
           webhooks: { secretToken: false },
         }),
       },
-      driver: { run: () => { throw new Error("model timeout") } },
+      driver: { run: () => new Promise(() => undefined) },
     })
     const handler = createChannelWebhookRouteHandler(agent as never)
 
@@ -8148,6 +8193,7 @@ describe("server helpers", () => {
         cloudflare: { env: {} },
         waitUntil: () => undefined,
       }).catch(error => error)
+      await vi.advanceTimersByTimeAsync(25_000)
       await vi.advanceTimersByTimeAsync(1_000)
 
       await responseError

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7772,6 +7772,61 @@ describe("server helpers", () => {
     }
   })
 
+  it("rejects queued finish messages before late Cloudflare delivery", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            errorFallbackText: "Please try again.",
+            stream: false,
+            timeout: 50_000,
+          },
+          webhooks: { secretToken: false },
+        }),
+      },
+      driver: {
+        run: async () => {
+          await new Promise(resolve => setTimeout(resolve, 30_000))
+          return { text: "" }
+        },
+      },
+      hooks: {
+        "agent:finish": async (event) => {
+          const chat = event.extensions.get("chat") as { sendMessage?: (message: string) => Promise<void> } | undefined
+          await chat?.sendMessage?.("late finish message")
+        },
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const responseError = handler(chatWebhookRequest(91_024), "telegram", {
+        cloudflare: { env: {} },
+        waitUntil: () => undefined,
+      }).catch(error => error)
+      await vi.advanceTimersByTimeAsync(25_000)
+
+      await expect(responseError).resolves.toMatchObject({
+        message: "Chat invocation timed out after 25000ms.",
+      })
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Please try again.")
+
+      await vi.advanceTimersByTimeAsync(5_000)
+      expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", "late finish message")
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("removes a manual placeholder when the error fallback is disabled", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -6726,6 +6726,40 @@ describe("server helpers", () => {
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "done" })
   })
 
+  it("does not retry an ambiguously failed streaming placeholder post", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.postMessage.mockRejectedValueOnce(new Error("provider response lost"))
+    const agent = defineAgent({
+      capabilities: [
+        defineChatCapability({
+          errorFallbackText: null,
+          fallbackStreamingPlaceholderText: "Working on it...",
+          platforms: {
+            telegram: () => adapter as never,
+          },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      driver: { run: async () => "done" },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      await expect(handler(chatWebhookRequest(21050), "telegram")).rejects.toThrow("provider response lost")
+      expect(adapter.postMessage).toHaveBeenCalledOnce()
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Working on it...")
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
   it("does not block native output on slow fallback delivery or cleanup", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineChatCapability } = await import("../src/chat-trigger.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7649,6 +7649,7 @@ describe("server helpers", () => {
     const { telegram } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
+    let invocationAbortSignal: AbortSignal | undefined
     const agent = defineAgent({
       channels: {
         telegram: telegram({
@@ -7662,6 +7663,7 @@ describe("server helpers", () => {
       driver: {
         run: async ({ input }) => {
           expect(input.timeout).toBe(25_000)
+          invocationAbortSignal = input.abortSignal
           await new Promise(resolve => setTimeout(resolve, 10_000))
           return {
             stream: (async function* () {
@@ -7685,6 +7687,10 @@ describe("server helpers", () => {
 
       await expect(responseError).resolves.toMatchObject({
         message: "Chat invocation timed out after 25000ms.",
+      })
+      expect(invocationAbortSignal).toMatchObject({
+        aborted: true,
+        reason: expect.objectContaining({ message: "Chat invocation timed out after 25000ms." }),
       })
       expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Please try again.")
     }

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7413,14 +7413,17 @@ describe("server helpers", () => {
     }
   })
 
-  it("retains a stalled progress placeholder for the Cloudflare timeout fallback", async () => {
+  it("removes a stalled progress placeholder before the Cloudflare timeout fallback", async () => {
     vi.useFakeTimers()
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
-    adapter.editMessage.mockImplementationOnce(async () => await new Promise(() => undefined))
+    let resolveProgressEdit: (() => void) | undefined
+    adapter.editMessage.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      resolveProgressEdit = resolve
+    }))
     const agent = defineAgent({
       channels: {
         telegram: testTelegram(telegram, {
@@ -7459,8 +7462,12 @@ describe("server helpers", () => {
       await expect(responseError).resolves.toMatchObject({
         message: "Chat invocation timed out after 25000ms.",
       })
-      expect(adapter.postMessage).toHaveBeenCalledOnce()
-      expect(adapter.editMessage).toHaveBeenLastCalledWith("telegram:456", "sent-1", "Please send the photo again.")
+      expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", "Please send the photo again.")
+      expect(adapter.deleteMessage.mock.invocationCallOrder[0]).toBeLessThan(adapter.postMessage.mock.invocationCallOrder[1]!)
+      resolveProgressEdit?.()
+      await vi.runAllTimersAsync()
+      expect(adapter.editMessage).toHaveBeenCalledOnce()
     }
     finally {
       consoleError.mockRestore()

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7588,6 +7588,59 @@ describe("server helpers", () => {
     }
   })
 
+  it("delivers the manual fallback when a stream ignores its Cloudflare timeout", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const run = vi.fn(({ input }) => {
+      expect(input.timeout).toBe(25_000)
+      return {
+        stream: (async function* () {
+          await new Promise(() => undefined)
+        })(),
+      }
+    })
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            errorFallbackText: "Please try again.",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+            timeout: 50_000,
+          },
+        }),
+      },
+      driver: { run },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = handler(chatWebhookRequest(91_021), "telegram", {
+        cloudflare: { env: {} },
+        waitUntil: () => undefined,
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(run).toHaveBeenCalledOnce()
+      const responseError = response.catch(error => error)
+
+      await vi.advanceTimersByTimeAsync(25_000)
+
+      await expect(responseError).resolves.toMatchObject({
+        message: "Chat invocation timed out after 25000ms.",
+      })
+      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", "Please try again.")
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("removes a manual placeholder when the error fallback is disabled", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7410,6 +7410,61 @@ describe("server helpers", () => {
     }
   })
 
+  it("retains a stalled progress placeholder for the Cloudflare timeout fallback", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.editMessage.mockImplementationOnce(async () => await new Promise(() => undefined))
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            errorFallbackText: "Please send the photo again.",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+            progress: true,
+            timeout: 50_000,
+          },
+        }),
+      },
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield {
+              data: { revision: 1, summary: "Reviewing the request.", type: "progress-summary" },
+              transient: true,
+              type: "data-progress-summary",
+            }
+            await new Promise(() => undefined)
+          })(),
+        }),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const responseError = handler(chatWebhookRequest(91_031), "telegram", {
+        cloudflare: { env: {} },
+        waitUntil: () => undefined,
+      }).catch(error => error)
+      await vi.advanceTimersByTimeAsync(25_100)
+
+      await expect(responseError).resolves.toMatchObject({
+        message: "Chat invocation timed out after 25000ms.",
+      })
+      expect(adapter.postMessage).toHaveBeenCalledOnce()
+      expect(adapter.editMessage).toHaveBeenLastCalledWith("telegram:456", "sent-1", "Please send the photo again.")
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("posts a buffered manual stream when placeholder editing fails", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -5625,7 +5625,10 @@ describe("server helpers", () => {
     const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/support", {
       body: "{}",
       method: "POST",
-    }), "support")
+    }), "support", {
+      cloudflare: { env: {} },
+      waitUntil: () => undefined,
+    })
 
     expect(response.status).toBe(404)
     await expect(response.json()).resolves.toMatchObject({ message: "Unknown ViteHub agent webhook.", status: 404 })
@@ -7905,7 +7908,7 @@ describe("server helpers", () => {
     }
   })
 
-  it("closes stalled finish iterators before opening Cloudflare delivery", async () => {
+  it("closes stalled finish iterators before timeout fallback delivery", async () => {
     vi.useFakeTimers()
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")
@@ -7961,7 +7964,7 @@ describe("server helpers", () => {
         message: "Chat invocation timed out after 25000ms.",
       })
       expect(iteratorReturn).toHaveBeenCalledOnce()
-      expect(adapter.postMessage).toHaveBeenCalledTimes(1)
+      expect(adapter.postMessage).toHaveBeenCalledTimes(2)
       expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Please try again.")
     }
     finally {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7548,6 +7548,52 @@ describe("server helpers", () => {
     }
   })
 
+  it("preserves manual placeholder ownership when cleanup fails after the deadline", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.deleteMessage.mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 26_000))
+      throw new Error("delete failed")
+    })
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            errorFallbackText: "Please try again.",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+            timeout: 50_000,
+          },
+        }),
+      },
+      driver: { run: () => ({ text: "" }) },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const responseError = handler(chatWebhookRequest(91_030), "telegram", {
+        cloudflare: { env: {} },
+        waitUntil: () => undefined,
+      }).catch(error => error)
+      await vi.advanceTimersByTimeAsync(26_000)
+
+      await expect(responseError).resolves.toMatchObject({
+        message: "Chat invocation timed out after 25000ms.",
+      })
+      expect(adapter.postMessage).toHaveBeenCalledOnce()
+      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", "Please try again.")
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("bounds provider error details in chat logs", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7689,7 +7689,7 @@ describe("server helpers", () => {
       await vi.advanceTimersByTimeAsync(25_000)
 
       await expect(responseError).resolves.toMatchObject({
-        message: "Chat invocation timed out after 15000ms.",
+        message: "Chat invocation timed out after 25000ms.",
       })
       expect(invocationAbortSignal).toMatchObject({
         aborted: true,

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7556,7 +7556,8 @@ describe("server helpers", () => {
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     const run = vi.fn(({ input }) => {
-      expect(input.timeout).toBe(25_000)
+      expect(input.timeout).toBeGreaterThan(24_000)
+      expect(input.timeout).toBeLessThanOrEqual(25_000)
       throw new Error("model timeout")
     })
     const agent = defineAgent({

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7965,6 +7965,55 @@ describe("server helpers", () => {
     }
   })
 
+  it("removes fallback callback delivery that completes after timing out", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.postMessage.mockImplementation(async (threadId: string, message: unknown) => {
+      if (message === "Tailored fallback.") {
+        await new Promise(resolve => setTimeout(resolve, 2_000))
+        return { id: "late-tailored", raw: { message }, threadId }
+      }
+      return { id: "default-fallback", raw: { message }, threadId }
+    })
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            errorFallbackText: async ({ thread }) => {
+              await thread.post("Tailored fallback.")
+            },
+          },
+          webhooks: { secretToken: false },
+        }),
+      },
+      driver: { run: () => { throw new Error("model timeout") } },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const responseError = handler(chatWebhookRequest(91_029), "telegram", {
+        cloudflare: { env: {} },
+        waitUntil: () => undefined,
+      }).catch(error => error)
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      await responseError
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Sorry, I couldn't process that message.")
+
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "late-tailored")
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("does not post Discord split fragments after the Cloudflare deadline", async () => {
     vi.useFakeTimers()
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7653,7 +7653,10 @@ describe("server helpers", () => {
     const agent = defineAgent({
       channels: {
         telegram: telegram({
-          adapter: () => adapter as never,
+          adapter: async () => {
+            await new Promise(resolve => setTimeout(resolve, 10_000))
+            return adapter as never
+          },
           messages: {
             errorFallbackText: "Please try again.",
             timeout: 50_000,
@@ -7662,9 +7665,8 @@ describe("server helpers", () => {
       },
       driver: {
         run: async ({ input }) => {
-          expect(input.timeout).toBe(25_000)
+          expect(input.timeout).toBe(15_000)
           invocationAbortSignal = input.abortSignal
-          await new Promise(resolve => setTimeout(resolve, 10_000))
           return {
             stream: (async function* () {
               await new Promise(() => undefined)
@@ -7686,11 +7688,11 @@ describe("server helpers", () => {
       await vi.advanceTimersByTimeAsync(25_000)
 
       await expect(responseError).resolves.toMatchObject({
-        message: "Chat invocation timed out after 25000ms.",
+        message: "Chat invocation timed out after 15000ms.",
       })
       expect(invocationAbortSignal).toMatchObject({
         aborted: true,
-        reason: expect.objectContaining({ message: "Chat invocation timed out after 25000ms." }),
+        reason: expect.objectContaining({ message: "Chat invocation timed out after 15000ms." }),
       })
       expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Please try again.")
     }

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7516,6 +7516,38 @@ describe("server helpers", () => {
     }
   })
 
+  it("restores manual placeholder ownership when completion cleanup fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.deleteMessage.mockRejectedValue(new Error("delete failed"))
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            errorFallbackText: "Please try again.",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: { run: () => ({ text: "" }) },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      await expect(handler(chatWebhookRequest(91_028), "telegram")).rejects.toThrow("Manual chat delivery could not remove its placeholder.")
+      expect(adapter.postMessage).toHaveBeenCalledOnce()
+      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", "Please try again.")
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
   it("bounds provider error details in chat logs", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7355,7 +7355,10 @@ describe("server helpers", () => {
     })
     const handler = createChannelWebhookRouteHandler(agent as never)
 
-    const response = await handler(chatWebhookRequest(91_014), "telegram")
+    const response = await handler(chatWebhookRequest(91_014), "telegram", {
+      cloudflare: { env: {} },
+      waitUntil: () => undefined,
+    })
 
     expect(response.status).toBe(200)
     expect(adapter.editMessage).toHaveBeenCalledOnce()

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7595,8 +7595,9 @@ describe("server helpers", () => {
     const { telegram } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
-    const run = vi.fn(({ input }) => {
+    const run = vi.fn(async ({ input }) => {
       expect(input.timeout).toBe(25_000)
+      await new Promise(resolve => setTimeout(resolve, 10_000))
       return {
         stream: (async function* () {
           await new Promise(() => undefined)

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7642,6 +7642,58 @@ describe("server helpers", () => {
     }
   })
 
+  it("delivers the streaming fallback when a stream ignores its Cloudflare timeout", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        telegram: telegram({
+          adapter: () => adapter as never,
+          messages: {
+            errorFallbackText: "Please try again.",
+            timeout: 50_000,
+          },
+        }),
+      },
+      driver: {
+        run: async ({ input }) => {
+          expect(input.timeout).toBe(25_000)
+          await new Promise(resolve => setTimeout(resolve, 10_000))
+          return {
+            stream: (async function* () {
+              await new Promise(() => undefined)
+            })(),
+          }
+        },
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = handler(chatWebhookRequest(91_022), "telegram", {
+        cloudflare: { env: {} },
+        waitUntil: () => undefined,
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      const responseError = response.catch(error => error)
+
+      await vi.advanceTimersByTimeAsync(25_000)
+
+      await expect(responseError).resolves.toMatchObject({
+        message: "Chat invocation timed out after 25000ms.",
+      })
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Please try again.")
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("removes a manual placeholder when the error fallback is disabled", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")


### PR DESCRIPTION
I enforce a hard Cloudflare deadline across the complete manually delivered chat lifecycle, starting at webhook entry and covering provider invocation, output consumption, placeholder updates, final delivery, and cleanup. A driver that ignores cooperative abort can no longer hold the request until Cloudflare cancels the remaining `waitUntil()` tasks, and late output cannot overwrite the configured timeout fallback.

This is broader than the original provider race because bounding only invocation and output collection still leaves delivery paths able to run past the deadline. `main` now contains that narrower timeout as part of [`86027262`](https://github.com/vite-hub/vitehub/commit/86027262f47ec5e686c836e7173c58fd6162855b), while this PR extends the same ownership across streaming and non-streaming delivery, late completion, placeholder removal, manual fallback preservation, and `waitUntil()` cleanup.

I understand this may be a larger lifecycle change than you want to merge, and I am completely fine if you decide not to take it. I am also happy for the preferred outcome to be a smaller seam or to leave the downstream patch in place; I am sharing the complete version because it is the behavior I could make internally consistent across every delivery path.

I verified all 209 provider tests, the Agent package typecheck, and the Agent package build with `publint` on the current head. The Channel documentation records Cloudflare’s 25-second normal-work window and five-second fallback/cleanup reserve.