### PR TITLE
fix(agent): expose completed tools to chat fallbacks

### DIFF
--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -967,6 +967,7 @@ function createChatTextStream(): ChatTextStreamController {
 
 function streamAgentOutputToChatText(
   result: Promise<unknown>,
+  onToolResult?: (result: AgentToolStepItem) => void,
 ): ChatTextStream {
   let collected = ""
   return {
@@ -990,6 +991,13 @@ function streamAgentOutputToChatText(
       }
 
       for await (const event of streamAgentOutputToEvents(output)) {
+        if (event.type === "tool-result" && !event.error) {
+          onToolResult?.({
+            output: event.output,
+            toolCallId: event.id,
+            toolName: event.name,
+          })
+        }
         if (event.type === "text-delta") {
           collected += event.text
           yield event.text
@@ -1009,6 +1017,7 @@ function streamAgentOutputToChatReplies(
     commentary: "hidden" | "message"
     onCommentary: (stream: ChatTextStream, discard: () => void) => void
     onFinal: (stream: ChatTextStream) => void
+    onToolResult?: (result: AgentToolStepItem) => void
   },
 ): { completion: Promise<void> } {
   const commentary = createChatTextStream()
@@ -1034,6 +1043,13 @@ function streamAgentOutputToChatReplies(
           })()
         : streamAgentOutputToEvents(output)
       for await (const event of events) {
+        if (event.type === "tool-result" && !event.error) {
+          options.onToolResult?.({
+            output: event.output,
+            toolCallId: event.id,
+            toolName: event.name,
+          })
+        }
         if (event.type === "error") throw new Error(event.error)
         if (event.type !== "text-delta" || !event.text) continue
         if (event.phase === undefined) {
@@ -2599,7 +2615,7 @@ async function handleChatSdkMessage(
           if (options?.stream === true || options?.commentary === undefined) {
             await postChatStream(
               thread,
-              streamAgentOutputToChatText(result),
+              streamAgentOutputToChatText(result, toolResult => toolResults.push(toolResult)),
               typeof thinkingFallback === "string" || thinkingFallback === null ? thinkingFallback : undefined,
               context.waitUntil,
               invocationDeadlineAbort?.signal,
@@ -2612,6 +2628,7 @@ async function handleChatSdkMessage(
             let finalDeliveryError: unknown
             const replies = streamAgentOutputToChatReplies(result, {
               commentary: options.commentary,
+              onToolResult: toolResult => toolResults.push(toolResult),
               onCommentary(response, discard) {
                 const delivery = postChatStream(thread, response, undefined, context.waitUntil, invocationDeadlineAbort?.signal, maximumInvocationDeadline)
                   .catch(() => discard())

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -43,6 +43,7 @@ import type {
   AgentMessageDeliveryKind,
   AgentRunInput,
   AgentRunMetadata,
+  AgentToolStepItem,
   AgentRuntimeConfig,
   AgentRuntimeContext,
   AgentRuntimeName,
@@ -712,6 +713,7 @@ function fallbackWebhookFromRequest(request: Request): string | undefined {
 async function collectAgentOutput(
   result: unknown,
   onProgress?: (summary: string) => void,
+  onToolResult?: (result: AgentToolStepItem) => void,
 ): Promise<string> {
   if (result instanceof Response) {
     if (result.headers.get("content-type")?.includes("application/json")) {
@@ -745,6 +747,13 @@ async function collectAgentOutput(
     }
     const summary = progressSummaryFromEvent(event)
     if (summary) onProgress?.(summary)
+    if (event.type === "tool-result" && !event.error) {
+      onToolResult?.({
+        output: event.output,
+        toolCallId: event.id,
+        toolName: event.name,
+      })
+    }
     if (event.type === "error") {
       throw new Error(event.error)
     }
@@ -2014,6 +2023,7 @@ function chatErrorHookArgs(
   input: AgentChatMessageTriggerInput | undefined,
   run: AgentRunMetadata | undefined,
   error: unknown,
+  toolResults: AgentToolStepItem[],
   abortSignal?: AbortSignal,
   onPost?: () => void,
 ): AgentChatErrorHookArgs<ViteAgentRouteRuntimeConfig> {
@@ -2030,6 +2040,7 @@ function chatErrorHookArgs(
       text: message.text,
     },
     run,
+    toolResults: [...toolResults],
     thread: {
       post: async (postedMessage) => {
         await postChatMessage(thread, postedMessage as AgentChatMessage, abortSignal)
@@ -2183,6 +2194,7 @@ async function postChatErrorFallback(
   options: AgentChatOptions | undefined,
   input: AgentChatMessageTriggerInput | undefined,
   run: AgentRunMetadata | undefined,
+  toolResults: AgentToolStepItem[],
   manualDelivery?: ManualChatDeliveryState,
   maximumInvocationDeadline?: number,
 ): Promise<void> {
@@ -2204,7 +2216,7 @@ async function postChatErrorFallback(
   const fallbackResolutionAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
   const fallbackResolution = resolveChatErrorFallbackText(
     options,
-    chatErrorHookArgs(thread, message, input, run, error, fallbackResolutionAbort?.signal, () => {
+    chatErrorHookArgs(thread, message, input, run, error, toolResults, fallbackResolutionAbort?.signal, () => {
       callbackDelivered = true
       resolveCallbackDelivery?.()
     }),
@@ -2445,6 +2457,7 @@ async function handleChatSdkMessage(
   let typing: ChatTypingRefresh | undefined
   let progress: ReturnType<typeof createManualDeliveryProgressUpdater> | undefined
   const manualDeliveryState: ManualChatDeliveryState = {}
+  const toolResults: AgentToolStepItem[] = []
   const invocationDeadlineAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
   try {
     input = createChatTriggerInput(chatRegistrationOrigin(registration), thread, message, [chatAuthorizationUiMessage(thread, message, messageContext)], messageContext, registration.channelId)
@@ -2542,7 +2555,7 @@ async function handleChatSdkMessage(
           const result = manualDelivery
             ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
             : await runAgentInline(agent as never, runContext as never, invocationInput as never)
-          const text = await collectAgentOutput(result, progress?.update)
+          const text = await collectAgentOutput(result, progress?.update, toolResult => toolResults.push(toolResult))
           if (!manualDelivery && text) {
             invocationDeadlineAbort?.signal.throwIfAborted()
             if (!await postDiscordSplitContent(thread, { markdown: text }, invocationDeadlineAbort?.signal)) {
@@ -2638,7 +2651,7 @@ async function handleChatSdkMessage(
   catch (error) {
     typing?.stop()
     await progress?.finish()
-    await postChatErrorFallback(error, thread, message, options, input, run, manualDeliveryState, maximumInvocationDeadline)
+    await postChatErrorFallback(error, thread, message, options, input, run, toolResults, manualDeliveryState, maximumInvocationDeadline)
     throw error
   }
   finally {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1442,6 +1442,7 @@ export interface AgentChatAgentHookArgs<TRuntimeConfig extends AgentRuntimeConfi
 
 export interface AgentChatErrorHookArgs<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> extends AgentChatAgentHookArgs<TRuntimeConfig> {
   error: unknown
+  toolResults: AgentToolStepItem[]
 }
 
 export interface AgentChatEventHookArgs<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> extends Record<string, unknown> {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7651,6 +7651,57 @@ describe("server helpers", () => {
     }
   })
 
+  it("exposes completed tool results to manual error fallbacks", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    let completedToolResults: unknown
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            errorFallbackText: ({ toolResults }) => {
+              completedToolResults = toolResults
+              return "Your meal was saved, but the final reply failed."
+            },
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield { input: { statement: "INSERT INTO meals VALUES (...)" }, toolCallId: "call-1", toolName: "db_exec", type: "tool-call" }
+            yield { output: { changes: 1 }, toolCallId: "call-1", toolName: "db_exec", type: "tool-result" }
+            yield { error: "model timeout", type: "error" }
+          })(),
+        }),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      await expect(handler(chatWebhookRequest(91_021), "telegram")).rejects.toThrow("model timeout")
+      expect(completedToolResults).toEqual([{
+        output: { changes: 1 },
+        toolCallId: "call-1",
+        toolName: "db_exec",
+      }])
+      expect(adapter.editMessage).toHaveBeenCalledWith(
+        "telegram:456",
+        "sent-1",
+        "Your meal was saved, but the final reply failed.",
+      )
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
   it("replaces a manual placeholder with the error fallback", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7685,7 +7685,7 @@ describe("server helpers", () => {
     const handler = createChannelWebhookRouteHandler(agent as never)
 
     try {
-      await expect(handler(chatWebhookRequest(91_021), "telegram")).rejects.toThrow("model timeout")
+      await expect(handler(chatWebhookRequest(91_035), "telegram")).rejects.toThrow("model timeout")
       expect(completedToolResults).toEqual([{
         output: { changes: 1 },
         toolCallId: "call-1",
@@ -7696,6 +7696,55 @@ describe("server helpers", () => {
         "sent-1",
         "Your meal was saved, but the final reply failed.",
       )
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
+  it.each([
+    ["streamed text", { stream: true }, 91_033],
+    ["phased replies", { commentary: "hidden" as const, stream: false }, 91_034],
+  ])("exposes completed tool results to automatic %s error fallbacks", async (_delivery, messages, messageId) => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    let completedToolResults: unknown
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: {
+            ...messages,
+            errorFallbackText: ({ toolResults }) => {
+              completedToolResults = toolResults
+              return "Your meal was saved, but the final reply failed."
+            },
+          },
+        }),
+      },
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield { output: { changes: 1 }, toolCallId: "call-1", toolName: "db_exec", type: "tool-result" }
+            yield { error: "model timeout", type: "error" }
+          })(),
+        }),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = handler(chatWebhookRequest(messageId), "telegram")
+      await expect(response).rejects.toThrow("model timeout")
+      expect(completedToolResults).toEqual([{
+        output: { changes: 1 },
+        toolCallId: "call-1",
+        toolName: "db_exec",
+      }])
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Your meal was saved, but the final reply failed.")
     }
     finally {
       consoleError.mockRestore()


### PR DESCRIPTION
## Summary

Expose successfully completed tool results to chat error fallback callbacks, so applications can distinguish a pre-effect model failure from a failure after a durable tool completed.

Keep ViteHub neutral about whether a tool result represents a committed product action; the consuming agent decides that from the tool contract.

## Verification

- Added a Telegram manual-delivery regression covering a successful db_exec followed by a model stream error
- Targeted provider tests pass: 2 passed, 208 skipped
- Consuming Calories app passes all 9 tests and Nuxt typecheck through pnpm patch