### PR TITLE
fix(agent): measure invocation stream inactivity

### DIFF
--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -255,7 +255,7 @@ VERCEL_TOKEN=... VERCEL_PROJECT_ID=... pnpm vitehub provision run --provider ver
 | `No Compatible Vite Development Server found` | The app dev server is not running or `--url` points at the wrong port. | Start Vite separately, then pass the dev server URL. |
 | `Unknown Workspace Dev target` | The named Workspace is not discovered by the running Vite dev server. | Check the Workspace Definition name and make sure `hubWorkspace()` is active. |
 | `Agent Dev Loop command requires workspace.mode: "write"` | A `!` command targeted an Agent without writable Workspace access. | Configure the selected Agent with `workspace: { mode: 'write' }`, or send a normal Agent message instead. |
-| Agent Dev Loop request times out | The invocation stream emitted no events before the inactivity timeout. | Pass `--timeout <ms>` for the dev-loop command or inspect the stalled Agent work. |
+| Agent Dev Loop request times out | A streamed invocation emitted no events before the inactivity timeout, or a Capability CLI/Workspace command exceeded its wall-clock deadline. | Pass `--timeout <ms>` for the dev-loop operation or inspect the stalled work. |
 | `Agent Dev Loop payload file must contain a JSON object` | The `--payload` file is not a JSON object. | Replace the file contents with one object shaped for the selected Agent Trigger. |
 
 ## Next steps

--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -255,7 +255,7 @@ VERCEL_TOKEN=... VERCEL_PROJECT_ID=... pnpm vitehub provision run --provider ver
 | `No Compatible Vite Development Server found` | The app dev server is not running or `--url` points at the wrong port. | Start Vite separately, then pass the dev server URL. |
 | `Unknown Workspace Dev target` | The named Workspace is not discovered by the running Vite dev server. | Check the Workspace Definition name and make sure `hubWorkspace()` is active. |
 | `Agent Dev Loop command requires workspace.mode: "write"` | A `!` command targeted an Agent without writable Workspace access. | Configure the selected Agent with `workspace: { mode: 'write' }`, or send a normal Agent message instead. |
-| Agent Dev Loop request times out | The invocation exceeded the CLI request timeout. | Pass `--timeout <ms>` for the dev-loop command or shorten the Agent work. |
+| Agent Dev Loop request times out | The invocation stream emitted no events before the inactivity timeout. | Pass `--timeout <ms>` for the dev-loop command or inspect the stalled Agent work. |
 | `Agent Dev Loop payload file must contain a JSON object` | The `--payload` file is not a JSON object. | Replace the file contents with one object shaped for the selected Agent Trigger. |
 
 ## Next steps

--- a/docs/content/docs/development/troubleshooting.md
+++ b/docs/content/docs/development/troubleshooting.md
@@ -59,7 +59,7 @@ If the proof is timing out before it reaches the interesting failure, increase t
 pnpm vitehub agent eval server/agents/support.eval.ts --output .vitehub/evals/support.json
 ```
 
-When the Agent Dev Loop reports `Agent Invocation Stream timed out after <ms> of inactivity`, first decide whether the invocation is expected to stay silent longer than the default timeout. If so, rerun with `vitehub agent dev --timeout <ms>`. If the timeout is surprising, inspect the Agent Driver boundary and any Workspace or harness session setup before changing prompts.
+When the Agent Dev Loop reports `Agent Invocation Stream timed out after <ms> of inactivity`, first decide whether the streamed invocation is expected to stay silent longer than the default timeout. If so, rerun with `vitehub agent dev --timeout <ms>`. If the timeout is surprising, inspect the Agent Driver boundary and any Workspace or harness session setup before changing prompts. For Capability CLI and `!` Workspace commands, the same option is a wall-clock command deadline because those operations do not emit Agent Invocation Stream events.
 
 ## When to escalate
 

--- a/docs/content/docs/development/troubleshooting.md
+++ b/docs/content/docs/development/troubleshooting.md
@@ -53,13 +53,13 @@ find dist -maxdepth 4 -type f | sort
 
 Separate Agent runtime failures from model behavior.
 Use `vitehub agent dev` to inspect one interactive Agent Invocation, then use Agent Evals when the failure is repeatable behavior.
-If the proof is timing out before it reaches the interesting failure, increase the dev-loop `--timeout` or the Agent Eval Runner `agent.eval.testTimeout` in `vite.config.ts`.
+If the proof is timing out before it reaches the interesting failure, increase the dev-loop inactivity `--timeout` or the Agent Eval Runner `agent.eval.testTimeout` in `vite.config.ts`.
 
 ```bash [Terminal]
 pnpm vitehub agent eval server/agents/support.eval.ts --output .vitehub/evals/support.json
 ```
 
-When the Agent Dev Loop reports `Agent Invocation Stream timed out after <ms>`, first decide whether the invocation is expected to run longer than the default timeout. If so, rerun with `vitehub agent dev --timeout <ms>`. If the timeout is surprising, inspect the Agent Driver boundary and any Workspace or harness session setup before changing prompts.
+When the Agent Dev Loop reports `Agent Invocation Stream timed out after <ms> of inactivity`, first decide whether the invocation is expected to stay silent longer than the default timeout. If so, rerun with `vitehub agent dev --timeout <ms>`. If the timeout is surprising, inspect the Agent Driver boundary and any Workspace or harness session setup before changing prompts.
 
 ## When to escalate
 

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -554,8 +554,11 @@ export async function* streamAgentOutputToEvents(value: unknown): AsyncIterable<
     return
   }
   if (value instanceof Response) {
-    const text = await value.text()
-    if (text) yield { text, type: "text-delta" }
+    if (value.body) {
+      for await (const text of value.body.pipeThrough(new TextDecoderStream())) {
+        if (text) yield { text, type: "text-delta" }
+      }
+    }
     yield { type: "finish" }
     return
   }

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -148,7 +148,7 @@ function writeDevUsage(context: AgentCliContext): void {
     "  --cli <name>      Run a Capability CLI command attached to the Agent.",
     "  --payload <path>  Agent Trigger payload JSON file.",
     "  --url <url>       Compatible Vite Development Server URL. Defaults to http://localhost:5173.",
-    "  --timeout <ms>    Agent Invocation Stream inactivity timeout. Defaults to 90000.",
+    "  --timeout <ms>    Stream inactivity timeout; command deadline. Defaults to 90000.",
     "  -h, --help        Show this help.",
     "",
   ].join("\n"))

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -148,7 +148,7 @@ function writeDevUsage(context: AgentCliContext): void {
     "  --cli <name>      Run a Capability CLI command attached to the Agent.",
     "  --payload <path>  Agent Trigger payload JSON file.",
     "  --url <url>       Compatible Vite Development Server URL. Defaults to http://localhost:5173.",
-    "  --timeout <ms>    Agent Invocation timeout. Defaults to 90000.",
+    "  --timeout <ms>    Agent Invocation Stream inactivity timeout. Defaults to 90000.",
     "  -h, --help        Show this help.",
     "",
   ].join("\n"))

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -76,7 +76,8 @@ export function createAgentInvocationStreamResponse(
     clearInactivityTimeout()
     if (options.timeout && options.timeout > 0) {
       timeout = setTimeout(() => {
-        fail(controller, new Error(`Agent Invocation Stream timed out after ${options.timeout}ms of inactivity.`), "invocation")
+        const error = `Agent Invocation Stream timed out after ${options.timeout}ms of inactivity.`
+        fail(controller, new Error(error), "invocation", { code: "INTERNAL", error })
       }, options.timeout)
     }
   }
@@ -107,13 +108,14 @@ export function createAgentInvocationStreamResponse(
     controller: ReadableStreamDefaultController<Uint8Array>,
     cause: unknown,
     context: "invocation" | "serialization" = "serialization",
+    publicError?: Omit<AgentInvocationStreamErrorEvent, "type">,
   ): void {
     if (closed) return
     clearInactivityTimeout()
     abort(cause)
     try {
       write(controller, {
-        ...toAgentPublicError(cause, context),
+        ...(publicError ?? toAgentPublicError(cause, context)),
         type: "error",
       })
       closeFailed(controller)

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -66,14 +66,14 @@ export function createAgentInvocationStreamResponse(
   let closed = false
   let timeout: ReturnType<typeof setTimeout> | undefined
 
-  function clearTimeoutSignal(): void {
+  function clearInactivityTimeout(): void {
     if (!timeout) return
     clearTimeout(timeout)
     timeout = undefined
   }
 
-  function armTimeoutSignal(controller: ReadableStreamDefaultController<Uint8Array>): void {
-    clearTimeoutSignal()
+  function resetInactivityTimeout(controller: ReadableStreamDefaultController<Uint8Array>): void {
+    clearInactivityTimeout()
     if (options.timeout && options.timeout > 0) {
       timeout = setTimeout(() => {
         fail(controller, new Error(`Agent Invocation Stream timed out after ${options.timeout}ms of inactivity.`), "invocation")
@@ -82,7 +82,7 @@ export function createAgentInvocationStreamResponse(
   }
 
   function close(controller: ReadableStreamDefaultController<Uint8Array>): void {
-    clearTimeoutSignal()
+    clearInactivityTimeout()
     closed = true
     controller.close()
   }
@@ -109,7 +109,7 @@ export function createAgentInvocationStreamResponse(
     context: "invocation" | "serialization" = "serialization",
   ): void {
     if (closed) return
-    clearTimeoutSignal()
+    clearInactivityTimeout()
     abort(cause)
     try {
       write(controller, {
@@ -137,7 +137,7 @@ export function createAgentInvocationStreamResponse(
     if (closed || abortController.signal.aborted) return false
     try {
       controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`))
-      armTimeoutSignal(controller)
+      resetInactivityTimeout(controller)
       return true
     }
     catch (cause) {
@@ -148,7 +148,7 @@ export function createAgentInvocationStreamResponse(
 
   return new Response(new ReadableStream({
     start(controller) {
-      armTimeoutSignal(controller)
+      resetInactivityTimeout(controller)
       run(event => emit(controller, event), abortController.signal)
         .then(() => {
           if (closed || abortController.signal.aborted) return
@@ -156,7 +156,7 @@ export function createAgentInvocationStreamResponse(
         })
         .catch((cause) => {
           if (closed || abortController.signal.aborted) return
-          clearTimeoutSignal()
+          clearInactivityTimeout()
           emit(controller, {
             ...toAgentPublicError(cause, "invocation"),
             type: "error",
@@ -165,7 +165,7 @@ export function createAgentInvocationStreamResponse(
         })
     },
     cancel() {
-      clearTimeoutSignal()
+      clearInactivityTimeout()
       closed = true
       abort()
     },

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -72,6 +72,15 @@ export function createAgentInvocationStreamResponse(
     timeout = undefined
   }
 
+  function armTimeoutSignal(controller: ReadableStreamDefaultController<Uint8Array>): void {
+    clearTimeoutSignal()
+    if (options.timeout && options.timeout > 0) {
+      timeout = setTimeout(() => {
+        fail(controller, new Error(`Agent Invocation Stream timed out after ${options.timeout}ms of inactivity.`), "invocation")
+      }, options.timeout)
+    }
+  }
+
   function close(controller: ReadableStreamDefaultController<Uint8Array>): void {
     clearTimeoutSignal()
     closed = true
@@ -128,6 +137,7 @@ export function createAgentInvocationStreamResponse(
     if (closed || abortController.signal.aborted) return false
     try {
       controller.enqueue(encoder.encode(`${JSON.stringify(event)}\n`))
+      armTimeoutSignal(controller)
       return true
     }
     catch (cause) {
@@ -138,11 +148,7 @@ export function createAgentInvocationStreamResponse(
 
   return new Response(new ReadableStream({
     start(controller) {
-      if (options.timeout && options.timeout > 0) {
-        timeout = setTimeout(() => {
-          fail(controller, new Error(`Agent Invocation Stream timed out after ${options.timeout}ms.`), "invocation")
-        }, options.timeout)
-      }
+      armTimeoutSignal(controller)
       run(event => emit(controller, event), abortController.signal)
         .then(() => {
           if (closed || abortController.signal.aborted) return

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -87,15 +87,13 @@ function payloadFromBody(body: AgentInvocationStreamBody): Record<string, unknow
   return body.payload
 }
 
-function withDevLoopControls<TInput extends object>(
+function withDevLoopAbortSignal<TInput extends object>(
   input: TInput,
   signal: AbortSignal,
-  timeout: number,
-): TInput & { abortSignal: AbortSignal, timeout: number } {
+): TInput & { abortSignal: AbortSignal } {
   return {
     ...input,
     abortSignal: signal,
-    timeout,
   }
 }
 
@@ -381,24 +379,23 @@ function selectedTrigger(entry: AgentInvocationStreamEntry, body: AgentInvocatio
   return entry.triggers["chat.message"]
 }
 
-function triggerInput(trigger: ResolvedAgentTriggerDefinition, body: AgentInvocationStreamBody, signal: AbortSignal, run: AgentRunMetadata, timeout: number): unknown {
+function triggerInput(trigger: ResolvedAgentTriggerDefinition, body: AgentInvocationStreamBody, signal: AbortSignal, run: AgentRunMetadata): unknown {
   const payload = payloadFromBody(body)
   if (trigger.id !== "chat.message") {
     const prompt = promptFromBody(body)
     if (payload) {
-      return withDevLoopControls(withPayloadDefaults(payload, {
+      return withDevLoopAbortSignal(withPayloadDefaults(payload, {
         ...(prompt ? { prompt } : {}),
         ...(typeof body.invokerProfileId === "string" ? { invokerProfileId: body.invokerProfileId } : {}),
         ...(isRecord(body.meta) ? { meta: body.meta } : {}),
         run,
-      }) as AgentRunInput<unknown>, signal, timeout)
+      }) as AgentRunInput<unknown>, signal)
     }
     if (!prompt) throw new Response("Missing Agent Trigger payload. Pass --payload or prompt.", { status: 400 })
     return {
       abortSignal: signal,
       prompt,
       run,
-      timeout,
       ...(typeof body.invokerProfileId === "string" ? { invokerProfileId: body.invokerProfileId } : {}),
       ...(isRecord(body.meta) ? { meta: body.meta } : {}),
     }
@@ -417,10 +414,10 @@ function triggerInput(trigger: ResolvedAgentTriggerDefinition, body: AgentInvoca
       name: "ViteHub Dev Loop",
     },
   })
-  return withDevLoopControls({
+  return withDevLoopAbortSignal({
     ...input,
     ...(messages ? { messages } : {}),
-  } as unknown as AgentChatMessageTriggerInput, signal, timeout)
+  } as unknown as AgentChatMessageTriggerInput, signal)
 }
 
 function parseBody(rawBody: string): AgentInvocationStreamBody {
@@ -667,7 +664,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
     const trigger = selectedTrigger(entry, body)
     if (trigger) {
       const triggerContext = { ...context, request: undefined }
-      const invocation = await resolveAgentTriggerInvocation(entry.agent as never, triggerContext as never, trigger.id, triggerInput(trigger, body, signal, run, timeout))
+      const invocation = await resolveAgentTriggerInvocation(entry.agent as never, triggerContext as never, trigger.id, triggerInput(trigger, body, signal, run))
       if (isResolvedAgentTriggerHandledInvocation(invocation)) {
         output = invocation.response
       }
@@ -676,7 +673,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
         const previewAgent = withDeliveryPreviewChannels(entry.agent, event => {
           if (!signal.aborted) emit(event)
         })
-        output = await streamAgentWithWorkspaceProgress(entry, emit, signal, async () => await streamAgent(previewAgent as never, { ...context, ...(invocation.run ? { run: invocation.run } : {}) } as never, withDevLoopControls(invocation.input, signal, timeout) as never, {
+        output = await streamAgentWithWorkspaceProgress(entry, emit, signal, async () => await streamAgent(previewAgent as never, { ...context, ...(invocation.run ? { run: invocation.run } : {}) } as never, withDevLoopAbortSignal(invocation.input, signal) as never, {
           output: "events",
         }))
       }
@@ -694,7 +691,6 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
           ? { context: { ...(isRecord(payload?.context) ? payload.context : {}), invokerProfileId: body.invokerProfileId } }
           : {}),
         messages: uiMessagesToAgentMessages(messages),
-        timeout,
       }, { output: "events" }))
     }
     for await (const event of streamAgentOutputToEvents(output)) {

--- a/packages/agent/test/agent-output.test.ts
+++ b/packages/agent/test/agent-output.test.ts
@@ -860,6 +860,23 @@ describe("agent output helpers", () => {
     ])
   })
 
+  it("emits handled Response body chunks as they arrive", async () => {
+    const response = new Response(new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("first"))
+        controller.enqueue(new TextEncoder().encode("second"))
+        controller.close()
+      },
+    }))
+    const events = []
+    for await (const event of streamAgentOutputToEvents(response)) events.push(event)
+    expect(events).toEqual([
+      { text: "first", type: "text-delta" },
+      { text: "second", type: "text-delta" },
+      { type: "finish" },
+    ])
+  })
+
   it("emits usage from promise-backed textStream results", async () => {
     const output = {
       textStream: (async function* () {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1621,7 +1621,7 @@ describe("agent chat capability discovery", () => {
     expect(reactionEffect).not.toHaveBeenCalled()
     expect(replyEffect).not.toHaveBeenCalled()
     expect(abortSignal).toBeInstanceOf(AbortSignal)
-    expect(timeout).toBe(1234)
+    expect(timeout).toBeUndefined()
   })
 
   it("serves plain Agent Definitions from the Agent Invocation Stream endpoint", async () => {

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -762,7 +762,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
       expect.objectContaining({ agent: "review", trigger: "github.webhook", type: "start" }),
       expect.objectContaining({ id: "workspace.prepare:review", phase: "workspace.prepare", status: "started", type: "progress" }),
       expect.objectContaining({ durationMs: expect.any(Number), id: "workspace.prepare:review", phase: "workspace.prepare", status: "completed", type: "progress" }),
-      { code: "INTERNAL", error: "Agent Invocation Stream failed.", type: "error" },
+      { code: "INTERNAL", error: "Agent Invocation Stream timed out after 100ms of inactivity.", type: "error" },
       { type: "done" },
     ])
     expect(harnessCreateSessionOptions[0]?.abortSignal).toBeInstanceOf(AbortSignal)

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -766,9 +766,9 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
       { type: "done" },
     ])
     expect(harnessCreateSessionOptions[0]?.abortSignal).toBeInstanceOf(AbortSignal)
-    expect(harnessCreateSessionOptions[0]?.timeout).toBe(100)
+    expect(harnessCreateSessionOptions[0]?.timeout).toBeUndefined()
     expect(harnessStreamInputs[0]?.abortSignal).toBeInstanceOf(AbortSignal)
-    expect(harnessStreamInputs[0]?.timeout).toBe(100)
+    expect(harnessStreamInputs[0]?.timeout).toBeUndefined()
     await waitFor(() => {
       expect(workspaceClose).toHaveBeenCalledOnce()
       expect(harnessSessionDestroy).toHaveBeenCalledOnce()
@@ -797,7 +797,9 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
 
     harnessStreamResult.mockReturnValueOnce({
       fullStream: (async function* () {
+        await new Promise(resolve => setTimeout(resolve, 60))
         yield { text: "Scoped review completed.", type: "text-delta" }
+        await new Promise(resolve => setTimeout(resolve, 60))
         yield { type: "finish" }
       })(),
     })
@@ -843,6 +845,7 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
     const response = await invokeMiddleware(handlers[0]!, {
       agent: "review",
       payload: { prompt: "review" },
+      timeout: 100,
       trigger: "github.webhook",
     }, agentInvocationStreamRoute, {
       "content-type": "application/json",
@@ -861,6 +864,8 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
       { type: "finish" },
       { type: "done" },
     ])
+    expect(harnessCreateSessionOptions[0]?.timeout).toBeUndefined()
+    expect(harnessStreamInputs[0]?.timeout).toBeUndefined()
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       paths: ["public", "AGENTS.md", "CLAUDE.md"],
     }))

--- a/packages/agent/test/invocation-stream.test.ts
+++ b/packages/agent/test/invocation-stream.test.ts
@@ -28,6 +28,32 @@ describe("Agent Invocation Stream", () => {
     expect(aborted).toBe(true)
   })
 
+  it("keeps active streams open beyond the inactivity timeout", async () => {
+    vi.useFakeTimers()
+    try {
+      const response = createAgentInvocationStreamResponse(async (emit) => {
+        for (const text of ["first", "second", "third"]) {
+          await new Promise(resolve => setTimeout(resolve, 20))
+          emit({ text, type: "text-delta" })
+        }
+      }, { timeout: 30 })
+
+      const text = response.text()
+      await vi.advanceTimersByTimeAsync(60)
+
+      await expect(text).resolves.toBe([
+        JSON.stringify({ text: "first", type: "text-delta" }),
+        JSON.stringify({ text: "second", type: "text-delta" }),
+        JSON.stringify({ text: "third", type: "text-delta" }),
+        JSON.stringify({ type: "done" }),
+        "",
+      ].join("\n"))
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("treats AbortError from cancellation aborts as cleanup", async () => {
     const NativeAbortController = globalThis.AbortController
 

--- a/packages/agent/test/invocation-stream.test.ts
+++ b/packages/agent/test/invocation-stream.test.ts
@@ -22,7 +22,7 @@ describe("Agent Invocation Stream", () => {
     ])
 
     expect(text.trim().split("\n").map(line => JSON.parse(line))).toEqual([
-      { code: "INTERNAL", error: "Agent Invocation Stream failed.", type: "error" },
+      { code: "INTERNAL", error: "Agent Invocation Stream timed out after 10ms of inactivity.", type: "error" },
       { type: "done" },
     ])
     expect(aborted).toBe(true)


### PR DESCRIPTION
## Summary

Rearm the Agent Invocation Stream timeout after every emitted event, so active runs can continue beyond the configured window while stalled runs still abort after that much inactivity.

This is the remaining upstream lifecycle gap from the Babysitter reliability patch. Current main already owns unconsumed Harness cleanup through #884, and the value-selection API from #821 deliberately keeps built-in Codex and Crabbox factories private, so this PR does not duplicate or reverse those changes.

## Verification

- Agent Invocation Stream regression: 7 passed
- Adjacent invocation lifecycle suites: 37 passed
- Agent package typecheck
- Agent package build with publint
- Changed-file lint and git diff check
