### PR TITLE
fix(box): remove completed disposable sessions

### DIFF
--- a/packages/box/src/internal/crabbox.ts
+++ b/packages/box/src/internal/crabbox.ts
@@ -287,7 +287,7 @@ function createCrabboxProvider(options: CrabboxSandboxOptions) {
         }
         if (leaseId && remoteRoot) {
           await runCrabbox(sessionOptions, leaseId, {
-            command: `rm -rf -- ${shellQuote(remoteRoot)}`,
+            command: removeDisposableRootCommand(remoteRoot),
           }).catch(() => undefined);
         }
         releaseWorkspace()
@@ -679,7 +679,7 @@ function createCrabboxSession(state: CrabboxSessionState, sessionId: string | un
       }
       finally {
         let cleanupFailure: unknown
-        const result = await runCrabbox(state.options, state.leaseId, { command: `rm -rf -- ${shellQuote(state.root)}` }).catch((error) => {
+        const result = await runCrabbox(state.options, state.leaseId, { command: removeDisposableRootCommand(state.root) }).catch((error) => {
           cleanupFailure = error
           return undefined
         })
@@ -859,6 +859,10 @@ function createCrabboxSession(state: CrabboxSessionState, sessionId: string | un
     },
   } satisfies RuntimeSession
   return session
+}
+
+function removeDisposableRootCommand(root: string) {
+  return `chmod -R u+w -- ${shellQuote(root)} 2>/dev/null || true; rm -rf -- ${shellQuote(root)}`
 }
 
 async function warmup(options: CrabboxSessionOptions, abortSignal: AbortSignal | undefined) {

--- a/packages/box/test/crabbox.test.ts
+++ b/packages/box/test/crabbox.test.ts
@@ -115,6 +115,39 @@ describe("createCrabboxRuntime", () => {
     )
   }, 30_000)
 
+  it("removes a disposable checkout with read-only nested content when closed", async () => {
+    const root = await temporaryRoot()
+    const repository = join(root, "repository")
+    const bin = join(root, "bin")
+    await Promise.all([mkdir(repository), mkdir(bin)])
+    await fakeCrabbox(bin)
+    await runGit(repository, ["init", "--initial-branch=main"])
+    await writeFile(join(repository, "README.md"), "checkout\n")
+    await runGit(repository, ["add", "README.md"])
+    await runGit(repository, [
+      "-c", "user.name=Fixture",
+      "-c", "user.email=fixture@example.com",
+      "commit", "-m", "initial",
+    ])
+    const sha = (await execFileAsync("git", ["-C", repository, "rev-parse", "HEAD"])).stdout.trim()
+
+    await withEnvironment({ PATH: `${bin}:${process.env.PATH || ""}` }, async () => {
+      const box = await resolveBox({
+        checkout: { ref: "refs/heads/main", remote: repository, sha },
+        runtime: createCrabboxRuntime({ profile: "babysitter" }),
+      }, {})
+      const session = await box.open()
+      const sessionRoot = dirname(session.cwd)
+      await expect(session.exec("sh", ["-c", "mkdir read-only && touch read-only/file && chmod 400 read-only/file && chmod 500 read-only"], {
+        cwd: session.cwd,
+      })).resolves.toMatchObject({ code: 0 })
+
+      await session.close()
+
+      await expect(stat(sessionRoot)).rejects.toMatchObject({ code: "ENOENT" })
+    })
+  }, 30_000)
+
   it("removes a partial disposable checkout when revision verification fails", async () => {
     const root = await temporaryRoot()
     const repository = join(root, "repository")


### PR DESCRIPTION
## Summary

- make each validated disposable Crabbox root owner-writable before removing it after normal close or failed bootstrap
- cover the public Box session lifecycle with an exact Git checkout containing read-only nested content

## Why

Read-only reference checkout content can make rm -rf leave a multi-gigabyte /tmp/vitehub-box.* root behind after an agent finishes. Box creates, validates, and owns that disposable root, so consumers should not need package patches to make teardown reliable. The existing exact-root validation and workspace/state safety boundaries remain unchanged; consumer-owned browser session cleanup stays outside this change.

## Validation

- regression proof with the pre-fix cleanup command: public session.close() fails with Permission denied and leaves the disposable root
- pnpm --filter @vite-hub/box exec vp test test/crabbox.test.ts — 26 passed
- tsc --noEmit -p packages/box/tsconfig.json
- vp check --no-fmt packages/box/src/internal/crabbox.ts packages/box/test/crabbox.test.ts
- git diff --check