### PR TITLE
feat(agent): add ordered message processing

### DIFF
--- a/docs/content/docs/capabilities/chat.md
+++ b/docs/content/docs/capabilities/chat.md
@@ -79,7 +79,7 @@ For adapter-backed delivery, inspect the Channel-generated webhook registrations
 | `identity` | `IdentityResolver` | channel-qualified user id when transcripts are enabled | Resolve the identity used to partition transcripts. |
 | `stream` | `boolean` | inherited | Whether the chat trigger should stream output. |
 | `streamingUpdateIntervalMs` | `number` | inherited | Minimum interval between streamed Channel message updates. |
-| `concurrency` | `"drop" \| "parallel" \| "queue" \| "reject" \| string` | inherited | Message concurrency behavior. |
+| `concurrency` | `"drop" \| "parallel" \| "queue" \| "reject" \| "serial" \| string` | inherited | Overlapping message behavior. `serial` runs each retained message as a separate awaited Agent Invocation in queue order; `queue` coalesces retained messages into one invocation. Queue retention and failure guarantees come from the configured Chat State runtime. |
 | `lockScope` | `"agent" \| "channel" \| "thread" \| string` | inherited | Scope used for message locks. |
 | `dedupeTtlMs` | `number` | inherited | Time-to-live for Chat SDK duplicate-message keys. |
 | `userName` | `string` | `"vitehub"` | Agent username used by adapter-backed Chat SDK delivery. |

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1,7 +1,7 @@
 import { parseStandardSchema } from "@vite-hub/internal/http-request"
 import { runWithActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { createRuntimeWaitUntilController } from "@vite-hub/runtime"
-import { Chat, StreamingPlan, convertEmojiPlaceholders } from "chat"
+import { Chat, StreamingPlan, ThreadImpl, convertEmojiPlaceholders } from "chat"
 
 import { resolveAgentTriggerInvocation, resolveAgentTriggers, runAgent, runAgentInline, streamAgent, streamAgentTrigger } from "../index.ts"
 import { hasTraceableStreamResult, isAsyncIterable, streamAgentOutputToEvents } from "../agent-output.ts"
@@ -1623,6 +1623,71 @@ function chatSdkOption<T>(options: AgentChatOptions | undefined, key: string): T
   return isRecord(options) ? options[key] as T | undefined : undefined
 }
 
+interface ChatLockTracker {
+  refresh(lockKey: string): () => void
+  state: StateAdapter
+}
+
+function createChatLockTracker(state: StateAdapter): ChatLockTracker {
+  const locks = new Map<string, { lock: Lock, ttlMs: number }>()
+  const trackedState = new Proxy(state, {
+    get(target, property) {
+      if (property === "acquireLock") {
+        return async (lockKey: string, ttlMs: number) => {
+          const lock = await target.acquireLock(lockKey, ttlMs)
+          if (lock) locks.set(lockKey, { lock, ttlMs })
+          return lock
+        }
+      }
+      if (property === "forceReleaseLock") {
+        return async (lockKey: string) => {
+          try {
+            await target.forceReleaseLock(lockKey)
+          }
+          finally {
+            locks.delete(lockKey)
+          }
+        }
+      }
+      if (property === "releaseLock") {
+        return async (lock: Lock) => {
+          try {
+            await target.releaseLock(lock)
+          }
+          finally {
+            if (locks.get(lock.threadId)?.lock.token === lock.token) locks.delete(lock.threadId)
+          }
+        }
+      }
+      const value = Reflect.get(target, property)
+      return typeof value === "function" ? value.bind(target) : value
+    },
+  })
+
+  return {
+    refresh(lockKey) {
+      const tracked = locks.get(lockKey)
+      if (!tracked) return () => undefined
+      const interval = setInterval(() => {
+        void state.extendLock(tracked.lock, tracked.ttlMs).then((extended) => {
+          if (!extended) clearInterval(interval)
+        }, () => clearInterval(interval))
+      }, Math.max(1, Math.floor(tracked.ttlMs / 3)))
+      return () => clearInterval(interval)
+    },
+    state: trackedState,
+  }
+}
+
+async function chatSdkLockKey(adapter: Adapter, threadId: string, options: AgentChatOptions | undefined): Promise<string> {
+  const channelId = adapter.channelIdFromThreadId(threadId)
+  const configuredScope = chatSdkOption<ChatConfig["lockScope"]>(options, "lockScope")
+  const scope = typeof configuredScope === "function"
+    ? await configuredScope({ adapter, channelId, isDM: adapter.isDM?.(threadId) ?? false, threadId })
+    : configuredScope ?? adapter.lockScope ?? "thread"
+  return scope === "channel" ? channelId : threadId
+}
+
 function createChatSdkConfig(
   adapterName: string,
   adapter: Adapter,
@@ -1635,10 +1700,10 @@ function createChatSdkConfig(
   const identity: ChatConfig["identity"] = options?.identity ?? (options?.transcripts
     ? ({ author }) => author.isBot === true ? null : `${adapterName}:${author.userId}`
     : undefined)
-  const concurrency = chatSdkOption<ChatConfig["concurrency"] | "parallel">(options, "concurrency")
+  const concurrency = chatSdkOption<ChatConfig["concurrency"] | "parallel" | "serial">(options, "concurrency")
   return objectWithoutUndefined({
     adapters: { [adapterName]: adapter },
-    concurrency: concurrency === "parallel" ? "concurrent" : concurrency,
+    concurrency: concurrency === "parallel" ? "concurrent" : concurrency === "serial" ? "queue" : concurrency,
     dedupeTtlMs: chatSdkOption<number>(options, "dedupeTtlMs"),
     fallbackStreamingPlaceholderText,
     identity,
@@ -1946,6 +2011,7 @@ async function chatTriggerMessages(
   message: ChatSdkMessage,
   options: AgentChatOptions | undefined,
   messageContext?: MessageContext,
+  historyThroughCurrent = false,
 ): Promise<UIMessageLike[]> {
   const current = await chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext), {
     rejectOversizedTextAttachments: true,
@@ -1962,7 +2028,7 @@ async function chatTriggerMessages(
   } catch {}
 
   const durable = await durableChatThreadMessages(thread, limit)
-  const messages = [
+  let messages = [
     ...(await Promise.all(durable.map(item => item.id && message.id && item.id === message.id ? current : chatSdkMessageToUiMessage(item)))),
     ...fetchedNewestFirst.slice().reverse(),
   ].reduce<UIMessageLike[]>((deduped, item) => {
@@ -1976,7 +2042,11 @@ async function chatTriggerMessages(
     return deduped
   }, [])
 
-  if (!current.id || !messages.some(item => item.id === current.id)) {
+  if (historyThroughCurrent && current.id) {
+    const currentIndex = messages.findIndex(item => item.id === current.id)
+    messages = currentIndex >= 0 ? messages.slice(0, currentIndex + 1) : [current]
+  }
+  else if (!current.id || !messages.some(item => item.id === current.id)) {
     messages.push(current)
   }
   return messages.slice(-limit)
@@ -2467,6 +2537,7 @@ async function handleChatSdkMessage(
   state: { keyPrefix: string, state: StateAdapter },
   messageContext?: MessageContext,
   maximumInvocationDeadline?: number,
+  historyThroughCurrent = false,
 ): Promise<void> {
   let input: AgentChatMessageTriggerInput | undefined
   let run: AgentRunMetadata | undefined
@@ -2484,7 +2555,7 @@ async function handleChatSdkMessage(
     const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, authorizationInput, input.run, messageContext)
     if (!invoker) return
 
-    const messages = await chatTriggerMessages(thread, message, options, messageContext)
+    const messages = await chatTriggerMessages(thread, message, options, messageContext, historyThroughCurrent)
     const currentMessage = message.id
       ? messages.find(item => item.id === message.id)
       : messages.at(-1)
@@ -2676,6 +2747,99 @@ async function handleChatSdkMessage(
   }
 }
 
+type AgentMessageDeliveryKindResolver =
+  (message: ChatSdkMessage) => MaybePromise<AgentMessageDeliveryKind | undefined>
+
+function createChatSdkMessageThread(
+  chat: Chat,
+  adapter: Adapter,
+  state: StateAdapter,
+  source: Thread,
+  message: ChatSdkMessage,
+  options: AgentChatOptions | undefined,
+): Thread {
+  const fallbackStreamingPlaceholderText = typeof options?.fallbackStreamingPlaceholderText === "string"
+    ? options.fallbackStreamingPlaceholderText
+    : options?.fallbackStreamingPlaceholderText === null ? null : undefined
+  return new ThreadImpl({
+    adapter,
+    channelId: adapter.channelIdFromThreadId(message.threadId),
+    channelVisibility: adapter.getChannelVisibility?.(message.threadId),
+    currentMessage: message,
+    fallbackStreamingPlaceholderText,
+    id: message.threadId,
+    initialMessage: message,
+    isDM: adapter.isDM?.(message.threadId) ?? false,
+    logger: chat.getLogger(),
+    stateAdapter: state,
+    streamingUpdateIntervalMs: chatSdkOption<number>(options, "streamingUpdateIntervalMs"),
+    threadHistory: chatThreadHistoryCache(source) as never,
+  })
+}
+
+async function serialMessageDeliveryKind(thread: Thread, message: ChatSdkMessage): Promise<AgentMessageDeliveryKind | undefined> {
+  if (thread.isDM) return "direct"
+  if (await thread.isSubscribed()) return message.isMention ? "mention" : "subscribed"
+  if (!message.isMention) return
+  await thread.subscribe().catch(() => undefined)
+  return "mention"
+}
+
+async function handleChatSdkMessages(
+  agent: AgentInput<ViteAgentRouteRuntimeContext>,
+  context: ViteAgentRouteRuntimeContext,
+  registration: AgentWebhookRegistrationDefinition,
+  thread: Thread,
+  message: ChatSdkMessage,
+  resolveDeliveryKind: AgentMessageDeliveryKindResolver,
+  options: AgentChatOptions | undefined,
+  state: { keyPrefix: string, state: StateAdapter },
+  adapter: Adapter,
+  chat: Chat,
+  lockTracker: ChatLockTracker,
+  messageContext?: MessageContext,
+  maximumInvocationDeadline?: number,
+): Promise<void> {
+  const serial = chatSdkOption<string>(options, "concurrency") === "serial"
+  const messages = serial ? [...messageContext?.skipped ?? [], message] : [message]
+  const stopRefreshingLock = serial
+    ? lockTracker.refresh(await chatSdkLockKey(adapter, thread.id, options))
+    : () => undefined
+
+  try {
+    for (const queuedMessage of messages) {
+      try {
+        const queuedThread = serial
+          ? createChatSdkMessageThread(chat, adapter, state.state, thread, queuedMessage, options)
+          : thread
+        const deliveryKind = serial
+          ? await serialMessageDeliveryKind(queuedThread, queuedMessage)
+          : await resolveDeliveryKind(queuedMessage)
+        if (!deliveryKind) continue
+        await handleChatSdkMessage(
+          agent,
+          context,
+          registration,
+          queuedThread,
+          queuedMessage,
+          deliveryKind,
+          options,
+          state,
+          serial ? undefined : messageContext,
+          maximumInvocationDeadline,
+          serial,
+        )
+      }
+      catch (error) {
+        if (!serial) throw error
+      }
+    }
+  }
+  finally {
+    stopRefreshingLock()
+  }
+}
+
 async function createChannelChat(
   agent: AgentInput<ViteAgentRouteRuntimeContext>,
   context: ViteAgentRouteRuntimeContext,
@@ -2687,21 +2851,26 @@ async function createChannelChat(
   maximumInvocationDeadline?: number,
 ): Promise<Chat> {
   const resolvedState = await resolveChatState(options, context, registration, handlerOptions)
+  const lockTracker = createChatLockTracker(resolvedState.state)
   const chat = new Chat(createChatSdkConfig(
     adapterName,
     adapter,
-    resolvedState.state,
+    lockTracker.state,
     options,
   ))
   const state = { keyPrefix: resolvedState.titleKeyPrefix, state: resolvedState.state }
   chat.onDirectMessage((thread, message, _channel, messageContext) =>
-    handleChatSdkMessage(agent, context, registration, thread, message, "direct", options, state, messageContext, maximumInvocationDeadline))
+    handleChatSdkMessages(agent, context, registration, thread, message, () => "direct", options, state, adapter, chat, lockTracker, messageContext, maximumInvocationDeadline))
   chat.onNewMention(async (thread, message, messageContext) => {
-    await thread.subscribe().catch(() => undefined)
-    await handleChatSdkMessage(agent, context, registration, thread, message, "mention", options, state, messageContext, maximumInvocationDeadline)
+    if (chatSdkOption<string>(options, "concurrency") !== "serial") {
+      await thread.subscribe().catch(() => undefined)
+      await handleChatSdkMessages(agent, context, registration, thread, message, () => "mention", options, state, adapter, chat, lockTracker, messageContext, maximumInvocationDeadline)
+      return
+    }
+    await handleChatSdkMessages(agent, context, registration, thread, message, () => "mention", options, state, adapter, chat, lockTracker, messageContext, maximumInvocationDeadline)
   })
   chat.onSubscribedMessage((thread, message, messageContext) =>
-    handleChatSdkMessage(agent, context, registration, thread, message, message.isMention ? "mention" : "subscribed", options, state, messageContext, maximumInvocationDeadline))
+    handleChatSdkMessages(agent, context, registration, thread, message, queuedMessage => queuedMessage.isMention ? "mention" : "subscribed", options, state, adapter, chat, lockTracker, messageContext, maximumInvocationDeadline))
 
   return chat
 }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1510,7 +1510,7 @@ export type AgentChatMessage =
 
 export type AgentChatSendMessage = (message: AgentChatMessage) => Promise<void>
 
-export type AgentMessageConcurrency = "drop" | "parallel" | "queue" | "reject" | (string & {})
+export type AgentMessageConcurrency = "drop" | "parallel" | "queue" | "reject" | "serial" | (string & {})
 
 export type AgentMessageDeliveryKind = "direct" | "mention" | "subscribed"
 

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7128,6 +7128,7 @@ describe("server helpers", () => {
     ["parallel", "concurrent"],
     ["drop", "drop"],
     ["queue", "queue"],
+    ["serial", "queue"],
   ] as const)("maps ViteHub %s message concurrency to Chat SDK %s", async (concurrency, expectedConcurrency) => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
@@ -7148,6 +7149,272 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(200)
     expect((adapter._chatInstance() as unknown as { _concurrencyStrategy: string })._concurrencyStrategy).toBe(expectedConcurrency)
+  })
+
+  it("processes retained serial messages in queue order after an earlier failure", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-serial-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const extendLock = vi.spyOn(state, "extendLock")
+    const adapter = createTestChatAdapter()
+    const order: string[] = []
+    const histories: string[][] = []
+    let firstStarted!: () => void
+    let releaseFirst!: () => void
+    const firstStartedPromise = new Promise<void>(resolve => {
+      firstStarted = resolve
+    })
+    const firstPending = new Promise<void>(resolve => {
+      releaseFirst = resolve
+    })
+    const run = vi.fn(async ({ messages }) => {
+      const texts = messages.map((message: { parts: Array<{ text?: string, type?: string }> }) =>
+        message.parts.find(part => part.type === "text")?.text || "")
+      const text = texts.at(-1) || ""
+      histories.push(texts)
+      order.push(text)
+      if (text === "A") {
+        firstStarted()
+        await firstPending
+        throw new Error("A failed")
+      }
+      return "ok"
+    })
+    const handler = createChannelWebhookRouteHandler(defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: {
+            concurrency: "serial",
+            errorFallbackText: null,
+            state,
+            stream: false,
+            triggerHistory: { maxMessages: 2, source: "thread" },
+          },
+        }),
+      },
+      driver: { run },
+    }) as never)
+
+    try {
+      vi.useFakeTimers()
+      await state.connect()
+      const firstResponse = handler(chatWebhookRequest(91_010, 456, "A"), "telegram", { agentName: "support" })
+      await firstStartedPromise
+      await expect(handler(chatWebhookRequest(91_011, 456, "B"), "telegram", { agentName: "support" })).resolves.toMatchObject({ status: 200 })
+      await vi.advanceTimersByTimeAsync(31_000)
+      expect(extendLock).toHaveBeenCalled()
+      await expect(handler(chatWebhookRequest(91_012, 456, "C"), "telegram", { agentName: "support" })).resolves.toMatchObject({ status: 200 })
+      await expect(handler(chatWebhookRequest(91_013, 456, "D"), "telegram", { agentName: "support" })).resolves.toMatchObject({ status: 200 })
+      expect(order).toEqual(["A"])
+
+      releaseFirst()
+      await expect(firstResponse).resolves.toMatchObject({ status: 200 })
+      expect(order).toEqual(["A", "B", "C", "D"])
+      expect(run).toHaveBeenCalledTimes(4)
+      expect(histories).toEqual([["A"], ["B"], ["C"], ["D"]])
+    }
+    finally {
+      releaseFirst()
+      consoleError.mockRestore()
+      vi.useRealTimers()
+      await state.disconnect()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
+  it("preserves queued message threads with channel-scoped serial processing", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-serial-threads-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const adapter = createTestChatAdapter({ isDM: false })
+    vi.spyOn(adapter, "channelIdFromThreadId").mockReturnValue("telegram:channel")
+    let firstStarted!: () => void
+    let releaseFirst!: () => void
+    const firstStartedPromise = new Promise<void>(resolve => {
+      firstStarted = resolve
+    })
+    const firstPending = new Promise<void>(resolve => {
+      releaseFirst = resolve
+    })
+    const run = vi.fn(async () => {
+      if (run.mock.calls.length === 1) {
+        firstStarted()
+        await firstPending
+      }
+      return "ok"
+    })
+    const handler = createChannelWebhookRouteHandler(defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: {
+            concurrency: "serial",
+            lockScope: "channel",
+            state,
+            stream: false,
+            triggerHistory: "none",
+          },
+        }),
+      },
+      driver: { run },
+    }) as never)
+    const request = (messageId: number, threadId: number, text: string) => new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        message: {
+          chat: { id: threadId, type: "group" },
+          from: { id: messageId, username: `user-${messageId}` },
+          isMention: true,
+          message_id: messageId,
+          text,
+        },
+      }),
+      method: "POST",
+    })
+
+    try {
+      await state.connect()
+      const firstResponse = handler(request(91_015, 456, "A"), "telegram", { agentName: "support" })
+      await firstStartedPromise
+      await expect(handler(request(91_016, 789, "B"), "telegram", { agentName: "support" })).resolves.toMatchObject({ status: 200 })
+      releaseFirst()
+      await expect(firstResponse).resolves.toMatchObject({ status: 200 })
+
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", { markdown: "ok" })
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:789", { markdown: "ok" })
+    }
+    finally {
+      releaseFirst()
+      await state.disconnect()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
+  it("keeps queue concurrency coalesced", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-queue-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const adapter = createTestChatAdapter()
+    const order: string[] = []
+    let firstStarted!: () => void
+    let releaseFirst!: () => void
+    const firstStartedPromise = new Promise<void>(resolve => {
+      firstStarted = resolve
+    })
+    const firstPending = new Promise<void>(resolve => {
+      releaseFirst = resolve
+    })
+    const run = vi.fn(async ({ messages }) => {
+      const text = messages[0]?.parts.find((part: { type?: string }) => part.type === "text") as { text?: string } | undefined
+      order.push(text?.text || "")
+      if (text?.text === "A") {
+        firstStarted()
+        await firstPending
+      }
+      return "ok"
+    })
+    const handler = createChannelWebhookRouteHandler(defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: { concurrency: "queue", state, stream: false, triggerHistory: "none" },
+        }),
+      },
+      driver: { run },
+    }) as never)
+
+    try {
+      await state.connect()
+      const firstResponse = handler(chatWebhookRequest(91_020, 456, "A"), "telegram", { agentName: "support" })
+      await firstStartedPromise
+      await expect(handler(chatWebhookRequest(91_021, 456, "B"), "telegram", { agentName: "support" })).resolves.toMatchObject({ status: 200 })
+      await expect(handler(chatWebhookRequest(91_022, 456, "C"), "telegram", { agentName: "support" })).resolves.toMatchObject({ status: 200 })
+
+      releaseFirst()
+      await expect(firstResponse).resolves.toMatchObject({ status: 200 })
+      await vi.waitFor(() => expect(order).toEqual(["A", "C"]))
+      expect(run).toHaveBeenCalledTimes(2)
+    }
+    finally {
+      releaseFirst()
+      await state.disconnect()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
+  it("preserves mention and subscription eligibility for serial batches", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-serial-routing-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const adapter = createTestChatAdapter({ isDM: false })
+    const routed: Array<{ deliveryKind: string, text: string }> = []
+    const request = (messageId: number, text: string, isMention = false) => new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({
+        message: {
+          chat: { id: 456, type: "group" },
+          from: { id: 123, username: "maxi" },
+          isMention,
+          message_id: messageId,
+          text,
+        },
+      }),
+      method: "POST",
+    })
+    const handler = createChannelWebhookRouteHandler(defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: {
+            concurrency: "serial",
+            filter: ({ deliveryKind, message }) => {
+              const text = message.parts.find(part => part.type === "text")
+              routed.push({ deliveryKind, text: text?.type === "text" ? text.text : "" })
+              return true
+            },
+            lockScope: "thread",
+            state,
+            stream: false,
+            triggerHistory: "none",
+          },
+        }),
+      },
+      driver: { run: () => "ok" },
+    }) as never)
+
+    try {
+      await state.connect()
+      const lock = await state.acquireLock("telegram:456", 60_000)
+      if (!lock) throw new Error("Expected the test lock to be acquired.")
+      await expect(handler(request(91_030, "before mention"), "telegram", { agentName: "support" })).resolves.toMatchObject({ status: 200 })
+      await expect(handler(request(91_031, "mention", true), "telegram", { agentName: "support" })).resolves.toMatchObject({ status: 200 })
+      await expect(handler(request(91_032, "after mention"), "telegram", { agentName: "support" })).resolves.toMatchObject({ status: 200 })
+      expect(routed).toEqual([])
+
+      await state.releaseLock(lock)
+      await expect(handler(request(91_033, "drain"), "telegram", { agentName: "support" })).resolves.toMatchObject({ status: 200 })
+
+      expect(routed).toEqual([
+        { deliveryKind: "mention", text: "mention" },
+        { deliveryKind: "subscribed", text: "after mention" },
+      ])
+    }
+    finally {
+      await state.disconnect()
+      await rm(stateDir, { force: true, recursive: true })
+    }
   })
 
   it("preserves automatic chat delivery", async () => {


### PR DESCRIPTION
Adds `messages.concurrency: "serial"` for adapter-backed Channels. Each retained overlapping message receives a separate awaited Agent Invocation in queue order, while the existing `queue` value keeps Chat SDK's coalescing behavior.

The runtime renews the state-backed queue lock while Agent Invocations run, reconstructs each retained message's own thread and sender context, and prevents later queued messages from entering an earlier invocation through Chat History. Per-message failures still deliver the configured fallback and don't stop later retained messages.

This keeps the contract honest at the Chat State boundary: queue capacity, retention, and state failures still follow the configured state runtime, so this does not claim durable exactly-once delivery.

Verified with the complete Agent package suite: package build and publint pass, typecheck passes, and all 1,730 tests pass. Focused coverage proves ordered A/B/C/D execution after an earlier failure, lock renewal past 30 seconds, bounded history without future-message leakage, channel-scoped routing across threads, mention/subscription transitions, and preserved `queue` coalescing.
