### PR TITLE
fix(box): expose setup timeouts and command diagnostics

### DIFF
--- a/docs/content/docs/agents/boxes.md
+++ b/docs/content/docs/agents/boxes.md
@@ -105,7 +105,7 @@ A public repository may contain:
 
 It must not contain plaintext bearer credentials or the capability that decrypts committed ciphertext. Supply that root capability through Server Env, workload identity, an interactive unlock, or another deployment-owned source.
 
-Resolved env values, materialized file contents, mutable state, decryption capabilities, physical Home paths, and sandbox handles are excluded from serialized Box metadata and ViteHub-generated workspaces or artifacts. Requirement failures report bounded stderr or stdout diagnostics after redacting declared env values, and Crabbox sends materialization bytes over stdin instead of command arguments. Every process inside the Box remains trusted and can still read or log its credentials.
+Resolved env values, materialized file contents, mutable state, decryption capabilities, physical Home paths, and sandbox handles are excluded from serialized Box metadata and ViteHub-generated workspaces or artifacts. Requirement failures report bounded stderr or stdout diagnostics after redacting declared env and Home file values. When durable Home state is mounted, ViteHub omits command output because mutable state cannot be exhaustively redacted. Crabbox sends materialization bytes over stdin instead of command arguments. Every process inside the Box remains trusted and can still read or log its credentials.
 
 ## Understand fail-closed boot
 

--- a/docs/content/docs/agents/boxes.md
+++ b/docs/content/docs/agents/boxes.md
@@ -105,7 +105,7 @@ A public repository may contain:
 
 It must not contain plaintext bearer credentials or the capability that decrypts committed ciphertext. Supply that root capability through Server Env, workload identity, an interactive unlock, or another deployment-owned source.
 
-Resolved env values, materialized file contents, mutable state, decryption capabilities, physical Home paths, and sandbox handles are excluded from serialized Box metadata and ViteHub-generated workspaces or artifacts. Requirement failures discard command output, and Crabbox sends materialization bytes over stdin instead of command arguments. Every process inside the Box remains trusted and can still read or log its credentials.
+Resolved env values, materialized file contents, mutable state, decryption capabilities, physical Home paths, and sandbox handles are excluded from serialized Box metadata and ViteHub-generated workspaces or artifacts. Requirement failures report bounded stderr or stdout diagnostics after redacting declared env values, and Crabbox sends materialization bytes over stdin instead of command arguments. Every process inside the Box remains trusted and can still read or log its credentials.
 
 ## Understand fail-closed boot
 
@@ -132,14 +132,14 @@ A string checks only that an executable exists. An object supplies a fixed comma
 requires: [
   "git",
   "kubectl",
-  { name: "GitHub CLI", command: "gh", args: ["auth", "status"] },
+  { name: "GitHub CLI", command: "gh", args: ["auth", "status"], timeout: 10_000 },
   { name: "Acme CLI", command: "acme", args: ["auth", "status"] },
 ];
 ```
 
 An arbitrary CLI can consume a declared env value, a native file such as `.kube/config`, or both. If it later refreshes files, move its writable directory to `home.state`; the Box API does not change.
 
-Requirement names, commands, and argv are inspectable declaration metadata, so keep credentials in `env` or Home files rather than arguments.
+Requirement names, commands, argv, and optional millisecond timeouts are inspectable declaration metadata, so keep credentials in `env` or Home files rather than arguments. Direct command checks use the declared `timeout`; trusted-host checks default to 10 seconds when it is omitted.
 
 ## Run through Crabbox
 

--- a/packages/box/src/ascii.ts
+++ b/packages/box/src/ascii.ts
@@ -146,7 +146,7 @@ export function createAsciiRuntime(
           runtime: "ascii",
           signal: openOptions.signal,
           workspace: "/home/user/.vitehub/workspace",
-        });
+        }, Object.keys(input.plan.env).map(name => env[name]));
       } catch (error) {
         if (runtimeSession) {
           try {

--- a/packages/box/src/ascii.ts
+++ b/packages/box/src/ascii.ts
@@ -146,7 +146,7 @@ export function createAsciiRuntime(
           runtime: "ascii",
           signal: openOptions.signal,
           workspace: "/home/user/.vitehub/workspace",
-        }, Object.keys(input.plan.env).map(name => env[name]));
+        }, env);
       } catch (error) {
         if (runtimeSession) {
           try {

--- a/packages/box/src/cloudflare-computer.ts
+++ b/packages/box/src/cloudflare-computer.ts
@@ -102,7 +102,7 @@ export function createCloudflareComputerRuntime(options: CloudflareComputerBoxOp
         initialize: openOptions.initialize,
         runtime: "cloudflare-computer",
         signal: openOptions.signal,
-      });
+      }, env);
     },
   });
 }

--- a/packages/box/src/cloudflare.ts
+++ b/packages/box/src/cloudflare.ts
@@ -119,7 +119,7 @@ export function createCloudflareRuntime(options: CloudflareBoxOptions): BoxRunti
         initialize: openOptions?.initialize,
         runtime: "cloudflare",
         signal: openOptions?.signal,
-      }, Object.keys(input.plan.env).map(name => env[name]));
+      }, env);
     },
   });
 }

--- a/packages/box/src/cloudflare.ts
+++ b/packages/box/src/cloudflare.ts
@@ -119,7 +119,7 @@ export function createCloudflareRuntime(options: CloudflareBoxOptions): BoxRunti
         initialize: openOptions?.initialize,
         runtime: "cloudflare",
         signal: openOptions?.signal,
-      });
+      }, Object.keys(input.plan.env).map(name => env[name]));
     },
   });
 }

--- a/packages/box/src/index.ts
+++ b/packages/box/src/index.ts
@@ -53,6 +53,7 @@ export type BoxRequirement =
       args?: readonly string[];
       command: string;
       name?: string;
+      timeout?: number;
     };
 
 export type BoxValue<T, Context> =
@@ -222,6 +223,7 @@ export interface ResolvedBoxRequirementInput {
   readonly args: readonly string[];
   readonly command: string;
   readonly name: string;
+  readonly timeout?: number;
 }
 
 export interface BoxRuntimeInput {
@@ -245,6 +247,7 @@ export interface BoxEnvironment {
 export interface BoxResolvedRequirement {
   readonly command: string;
   readonly name: string;
+  readonly timeout?: number;
 }
 
 export interface BoxPlan {
@@ -662,7 +665,16 @@ function normalizeRequirements(
     if (command.includes("\0") || args.some((argument) => argument.includes("\0")))
       throw new TypeError("[vitehub] Box requirement commands and arguments cannot contain NUL.");
     const name = value.name?.trim() || [command, ...args].join(" ");
-    return { args, command, name };
+    const timeout = value.timeout;
+    if (
+      timeout !== undefined
+      && (!Number.isInteger(timeout) || timeout <= 0 || timeout > 2 ** 32 - 1)
+    ) {
+      throw new TypeError(
+        "[vitehub] Box requirement timeout must be a positive integer no greater than 4294967295ms.",
+      );
+    }
+    return { args, command, name, ...(timeout === undefined ? {} : { timeout }) };
   });
   return [...new Map(requirements.map((value) => [JSON.stringify(value), value])).values()];
 }

--- a/packages/box/src/index.ts
+++ b/packages/box/src/index.ts
@@ -668,10 +668,10 @@ function normalizeRequirements(
     const timeout = value.timeout;
     if (
       timeout !== undefined
-      && (!Number.isInteger(timeout) || timeout <= 0 || timeout > 2 ** 32 - 1)
+      && (!Number.isInteger(timeout) || timeout <= 0 || timeout > 2 ** 31 - 1)
     ) {
       throw new TypeError(
-        "[vitehub] Box requirement timeout must be a positive integer no greater than 4294967295ms.",
+        "[vitehub] Box requirement timeout must be a positive integer no greater than 2147483647ms.",
       );
     }
     return { args, command, name, ...(timeout === undefined ? {} : { timeout }) };

--- a/packages/box/src/internal/crabbox.ts
+++ b/packages/box/src/internal/crabbox.ts
@@ -16,7 +16,12 @@ import type {
   ResolvedBoxRequirementInput,
 } from "../index.ts"
 import { materializeGitCheckout } from "./git-checkout.ts"
-import { boxRequirementError, boxRequirementPlan, boxRequirementSignal } from "./requirements.ts"
+import {
+  boxRequirementError,
+  boxRequirementPlan,
+  boxRequirementSecrets,
+  boxRequirementSignal,
+} from "./requirements.ts"
 import { markBuiltInBoxRuntime } from "./runtime.ts"
 import { createBoxSession, type RuntimeSession } from "./session.ts"
 
@@ -414,7 +419,11 @@ async function materializePlan(
     initializedState: [...missingState].map((index) =>
       remoteStatePath(options.stateRoot!, options.plan.state[index].key)
     ),
-    secrets: Object.values(environment),
+    secrets: boxRequirementSecrets([
+      ...Object.values(environment),
+      ...files.map(file => file.contents),
+      ...[...seeds.values()].flatMap(seed => seed.map(file => file.contents)),
+    ]),
   };
 }
 

--- a/packages/box/src/internal/crabbox.ts
+++ b/packages/box/src/internal/crabbox.ts
@@ -272,6 +272,7 @@ function createCrabboxProvider(options: CrabboxSandboxOptions) {
             options.requirements,
             createOptions.abortSignal,
             materialized.secrets,
+            options.plan.state.length === 0,
           )
           await createOptions.initialize?.(session)
           return session
@@ -1003,6 +1004,7 @@ async function validateRequirements(
   requirements: readonly ResolvedBoxRequirementInput[],
   abortSignal: AbortSignal | undefined,
   secrets: readonly string[],
+  includeDiagnosticOutput: boolean,
 ) {
   for (const requirement of requirements) {
     const command = ["command -v", shellQuote(requirement.command), ">/dev/null"]
@@ -1016,10 +1018,23 @@ async function validateRequirements(
       })
     }
     catch (cause) {
-      throw boxRequirementError(requirement, cause, secrets)
+      if (abortSignal?.aborted) throw abortSignal.reason
+      throw boxRequirementError(
+        requirement,
+        cause,
+        secrets,
+        requirement.timeout,
+        includeDiagnosticOutput,
+      )
     }
     if (result.exitCode !== 0) {
-      throw boxRequirementError(requirement, result, secrets)
+      throw boxRequirementError(
+        requirement,
+        result,
+        secrets,
+        requirement.timeout,
+        includeDiagnosticOutput,
+      )
     }
   }
 }

--- a/packages/box/src/internal/crabbox.ts
+++ b/packages/box/src/internal/crabbox.ts
@@ -16,6 +16,7 @@ import type {
   ResolvedBoxRequirementInput,
 } from "../index.ts"
 import { materializeGitCheckout } from "./git-checkout.ts"
+import { boxRequirementError, boxRequirementPlan, boxRequirementSignal } from "./requirements.ts"
 import { markBuiltInBoxRuntime } from "./runtime.ts"
 import { createBoxSession, type RuntimeSession } from "./session.ts"
 
@@ -104,7 +105,7 @@ export function createCrabboxRuntime(options: CrabboxOptions = {}): BoxRuntime {
         environment: { env: {} },
         executionAuthority: crabboxExecutionAuthority,
         identity: input.identity,
-        requirements: input.requirements.map(({ command, name }) => ({ command, name })),
+        requirements: boxRequirementPlan(input.requirements),
         runtime: "crabbox",
         workspace: workspace
           ? { path: workspace, state: "authoritative" as const, workDir: "workspace" as const }
@@ -261,7 +262,12 @@ function createCrabboxProvider(options: CrabboxSandboxOptions) {
           const probeCleanup = await session.run({ abortSignal: createOptions.abortSignal,
             command: `rm -- ${shellQuote(posix.join(root, ".vitehub-copy-probe"))}` })
           if (probeCleanup.exitCode !== 0) throw crabboxError("remove Crabbox copy probe", probeCleanup)
-          await validateRequirements(session, options.requirements, createOptions.abortSignal)
+          await validateRequirements(
+            session,
+            options.requirements,
+            createOptions.abortSignal,
+            materialized.secrets,
+          )
           await createOptions.initialize?.(session)
           return session
         }
@@ -408,6 +414,7 @@ async function materializePlan(
     initializedState: [...missingState].map((index) =>
       remoteStatePath(options.stateRoot!, options.plan.state[index].key)
     ),
+    secrets: Object.values(environment),
   };
 }
 
@@ -982,17 +989,28 @@ function startTunnel(state: CrabboxSessionState, remotePort: number) {
   return tunnel
 }
 
-async function validateRequirements(session: RuntimeSession, requirements: readonly ResolvedBoxRequirementInput[], abortSignal: AbortSignal | undefined) {
+async function validateRequirements(
+  session: RuntimeSession,
+  requirements: readonly ResolvedBoxRequirementInput[],
+  abortSignal: AbortSignal | undefined,
+  secrets: readonly string[],
+) {
   for (const requirement of requirements) {
     const command = ["command -v", shellQuote(requirement.command), ">/dev/null"]
     if (requirement.args.length) command.push("&&", shellQuote(requirement.command), ...requirement.args.map(shellQuote))
-    const result = await session.run({
-      abortSignal,
-      command: command.join(" "),
-      workingDirectory: posix.join(session.defaultWorkingDirectory, "workspace"),
-    })
+    let result: Awaited<ReturnType<RuntimeSession["run"]>>
+    try {
+      result = await session.run({
+        abortSignal: boxRequirementSignal(requirement, abortSignal),
+        command: command.join(" "),
+        workingDirectory: posix.join(session.defaultWorkingDirectory, "workspace"),
+      })
+    }
+    catch (cause) {
+      throw boxRequirementError(requirement, cause, secrets)
+    }
     if (result.exitCode !== 0) {
-      throw new Error(`[vitehub] Box requirement "${requirement.name}" failed.`);
+      throw boxRequirementError(requirement, result, secrets)
     }
   }
 }

--- a/packages/box/src/internal/remote.ts
+++ b/packages/box/src/internal/remote.ts
@@ -12,6 +12,7 @@ import { materializeGitCheckout } from "./git-checkout.ts";
 import {
   boxRequirementError,
   boxRequirementPlan,
+  boxRequirementSecrets,
   boxRequirementSignal,
 } from "./requirements.ts";
 import { createBoxSession, type RuntimeSession } from "./session.ts";
@@ -143,6 +144,7 @@ async function materializeRemotePlan(
   const home = options.home ?? "/home/vitehub";
   const workspace = options.workspace ?? "/workspace";
   const abortSignal = options.signal;
+  const diagnosticSecrets = [...secrets];
   for (const path of new Set([home, ...(options.preserveWorkspace ? [] : [workspace])])) {
     if (await session.existsFile({ abortSignal, path }))
       await session.removeFile({ abortSignal, path, recursive: true });
@@ -150,6 +152,8 @@ async function materializeRemotePlan(
   await session.makeDirectory({ abortSignal, path: home, recursive: true });
   await session.makeDirectory({ abortSignal, path: workspace, recursive: true });
   for (const [path, file] of Object.entries(input.plan.files)) {
+    const content = await file.resolve();
+    diagnosticSecrets.push(...boxRequirementSecrets([content]));
     await session.makeDirectory({
       abortSignal,
       path: dirnameRemotePath(joinRemotePath(home, path)),
@@ -157,7 +161,7 @@ async function materializeRemotePlan(
     });
     await session.writeBinaryFile({
       abortSignal,
-      content: await file.resolve(),
+      content,
       path: joinRemotePath(home, path),
     });
   }
@@ -175,7 +179,13 @@ async function materializeRemotePlan(
       },
     });
   }
-  await validateRequirements(session, input.requirements, workspace, abortSignal, secrets);
+  await validateRequirements(
+    session,
+    input.requirements,
+    workspace,
+    abortSignal,
+    diagnosticSecrets,
+  );
 }
 
 function joinRemotePath(...parts: string[]) {

--- a/packages/box/src/internal/remote.ts
+++ b/packages/box/src/internal/remote.ts
@@ -9,6 +9,11 @@ import type {
 } from "../index.ts";
 import { normalizeExecutionAuthority, type ExecutionAuthority } from "@vite-hub/runtime";
 import { materializeGitCheckout } from "./git-checkout.ts";
+import {
+  boxRequirementError,
+  boxRequirementPlan,
+  boxRequirementSignal,
+} from "./requirements.ts";
 import { createBoxSession, type RuntimeSession } from "./session.ts";
 
 interface RemoteRuntimeOptions {
@@ -69,7 +74,7 @@ export function remoteBoxPlan(
     environment: { env: {} },
     executionAuthority: options.executionAuthority,
     identity: input.identity,
-    requirements: input.requirements.map(({ command, name }) => ({ command, name })),
+    requirements: boxRequirementPlan(input.requirements),
     runtime: options.runtime,
     workspace: {
       state: "disposable",
@@ -85,6 +90,7 @@ export async function openRemoteBox(
     initialize?: (session: BoxSession, context: { signal?: AbortSignal }) => Promise<void>;
     signal?: AbortSignal;
   },
+  secrets: readonly string[],
 ) {
   assertRemoteInput(input, options.runtime);
   const session = createBoxSession(runtimeSession, {
@@ -93,7 +99,7 @@ export async function openRemoteBox(
     signal: options.signal,
   });
   try {
-    await materializeRemotePlan(input, runtimeSession, options);
+    await materializeRemotePlan(input, runtimeSession, options, secrets);
     await options.initialize?.(session, { signal: options.signal });
     return session;
   } catch (error) {
@@ -132,6 +138,7 @@ async function materializeRemotePlan(
   input: BoxRuntimeInput,
   session: RuntimeSession,
   options: Pick<RemoteRuntimeOptions, "home" | "workspace" | "preserveWorkspace"> & { signal?: AbortSignal },
+  secrets: readonly string[],
 ) {
   const home = options.home ?? "/home/vitehub";
   const workspace = options.workspace ?? "/workspace";
@@ -168,7 +175,7 @@ async function materializeRemotePlan(
       },
     });
   }
-  await validateRequirements(session, input.requirements, workspace, abortSignal);
+  await validateRequirements(session, input.requirements, workspace, abortSignal, secrets);
 }
 
 function joinRemotePath(...parts: string[]) {
@@ -185,18 +192,24 @@ async function validateRequirements(
   requirements: readonly ResolvedBoxRequirementInput[],
   workspace: string,
   abortSignal: AbortSignal | undefined,
+  secrets: readonly string[],
 ) {
   for (const requirement of requirements) {
     const command = ["command -v", shellQuote(requirement.command), ">/dev/null"];
     if (requirement.args.length)
       command.push("&&", shellQuote(requirement.command), ...requirement.args.map(shellQuote));
-    const result = await session.run({
-      abortSignal,
-      command: command.join(" "),
-      workingDirectory: workspace,
-    });
+    let result: Awaited<ReturnType<RuntimeSession["run"]>>;
+    try {
+      result = await session.run({
+        abortSignal: boxRequirementSignal(requirement, abortSignal),
+        command: command.join(" "),
+        workingDirectory: workspace,
+      });
+    } catch (cause) {
+      throw boxRequirementError(requirement, cause, secrets);
+    }
     if (result.exitCode !== 0)
-      throw new Error(`[vitehub] Box requirement "${requirement.name}" failed.`);
+      throw boxRequirementError(requirement, result, secrets);
   }
 }
 

--- a/packages/box/src/internal/remote.ts
+++ b/packages/box/src/internal/remote.ts
@@ -216,6 +216,7 @@ async function validateRequirements(
         workingDirectory: workspace,
       });
     } catch (cause) {
+      if (abortSignal?.aborted) throw abortSignal.reason;
       throw boxRequirementError(requirement, cause, secrets);
     }
     if (result.exitCode !== 0)

--- a/packages/box/src/internal/remote.ts
+++ b/packages/box/src/internal/remote.ts
@@ -91,7 +91,7 @@ export async function openRemoteBox(
     initialize?: (session: BoxSession, context: { signal?: AbortSignal }) => Promise<void>;
     signal?: AbortSignal;
   },
-  secrets: readonly string[],
+  environment: Readonly<Record<string, string>>,
 ) {
   assertRemoteInput(input, options.runtime);
   const session = createBoxSession(runtimeSession, {
@@ -100,7 +100,7 @@ export async function openRemoteBox(
     signal: options.signal,
   });
   try {
-    await materializeRemotePlan(input, runtimeSession, options, secrets);
+    await materializeRemotePlan(input, runtimeSession, options, environment);
     await options.initialize?.(session, { signal: options.signal });
     return session;
   } catch (error) {
@@ -139,12 +139,14 @@ async function materializeRemotePlan(
   input: BoxRuntimeInput,
   session: RuntimeSession,
   options: Pick<RemoteRuntimeOptions, "home" | "workspace" | "preserveWorkspace"> & { signal?: AbortSignal },
-  secrets: readonly string[],
+  environment: Readonly<Record<string, string>>,
 ) {
   const home = options.home ?? "/home/vitehub";
   const workspace = options.workspace ?? "/workspace";
   const abortSignal = options.signal;
-  const diagnosticSecrets = [...secrets];
+  const diagnosticSecrets = [...boxRequirementSecrets(
+    Object.keys(input.plan.env).map(name => environment[name]!),
+  )];
   for (const path of new Set([home, ...(options.preserveWorkspace ? [] : [workspace])])) {
     if (await session.existsFile({ abortSignal, path }))
       await session.removeFile({ abortSignal, path, recursive: true });

--- a/packages/box/src/internal/requirements.ts
+++ b/packages/box/src/internal/requirements.ts
@@ -1,0 +1,69 @@
+import type { BoxResolvedRequirement, ResolvedBoxRequirementInput } from "../index.ts";
+
+const maximumDiagnosticLength = 4_000;
+
+export function boxRequirementPlan(
+  requirements: readonly ResolvedBoxRequirementInput[],
+): readonly BoxResolvedRequirement[] {
+  return requirements.map(({ command, name, timeout }) => ({
+    command,
+    name,
+    ...(timeout === undefined ? {} : { timeout }),
+  }));
+}
+
+export function boxRequirementSignal(
+  requirement: ResolvedBoxRequirementInput,
+  signal: AbortSignal | undefined,
+): AbortSignal | undefined {
+  if (requirement.timeout === undefined) return signal;
+  const timeout = AbortSignal.timeout(requirement.timeout);
+  return signal ? AbortSignal.any([signal, timeout]) : timeout;
+}
+
+export function boxRequirementError(
+  requirement: ResolvedBoxRequirementInput,
+  failure: unknown,
+  secrets: readonly string[] = [],
+  timeout: number | undefined = requirement.timeout,
+): Error {
+  const details = commandFailureDetails(failure, secrets, timeout);
+  const name = diagnosticText(requirement.name, secrets);
+  return new Error(`[vitehub] Box requirement "${name}" failed${details ? `: ${details}` : "."}`);
+}
+
+function commandFailureDetails(
+  failure: unknown,
+  secrets: readonly string[],
+  timeout: number | undefined,
+) {
+  const error =
+    failure && typeof failure === "object" ? (failure as Record<string, unknown>) : undefined;
+  const timedOut =
+    error?.name === "TimeoutError" || error?.code === "ETIMEDOUT" || error?.killed === true;
+  const status =
+    timedOut && timeout !== undefined
+      ? `timed out after ${timeout}ms`
+      : typeof error?.exitCode === "number"
+        ? `exit code ${error.exitCode}`
+        : typeof error?.code === "number"
+          ? `exit code ${error.code}`
+          : typeof error?.signal === "string"
+            ? `terminated by ${error.signal}`
+            : error?.name === "AbortError"
+              ? "aborted"
+              : "";
+  const output = diagnosticText(error?.stderr, secrets) || diagnosticText(error?.stdout, secrets);
+  const message = status || output ? "" : diagnosticText(error?.message ?? failure, secrets);
+  return [status, output || message].filter(Boolean).join(": ");
+}
+
+function diagnosticText(value: unknown, secrets: readonly string[]) {
+  if (value === undefined || value === null) return "";
+  let text = String(value).trim();
+  for (const secret of [...new Set(secrets)].sort((left, right) => right.length - left.length)) {
+    if (secret) text = text.replaceAll(secret, "[redacted]");
+  }
+  if (text.length > maximumDiagnosticLength) text = `${text.slice(0, maximumDiagnosticLength)}…`;
+  return text;
+}

--- a/packages/box/src/internal/requirements.ts
+++ b/packages/box/src/internal/requirements.ts
@@ -21,6 +21,14 @@ export function boxRequirementSignal(
   return signal ? AbortSignal.any([signal, timeout]) : timeout;
 }
 
+export function boxRequirementSecrets(
+  values: readonly (string | Uint8Array)[],
+): readonly string[] {
+  return values.map((value) =>
+    typeof value === "string" ? value : new TextDecoder().decode(value)
+  ).filter(Boolean);
+}
+
 export function boxRequirementError(
   requirement: ResolvedBoxRequirementInput,
   failure: unknown,
@@ -60,10 +68,11 @@ function commandFailureDetails(
 
 function diagnosticText(value: unknown, secrets: readonly string[]) {
   if (value === undefined || value === null) return "";
-  let text = String(value).trim();
+  let text = String(value);
   for (const secret of [...new Set(secrets)].sort((left, right) => right.length - left.length)) {
     if (secret) text = text.replaceAll(secret, "[redacted]");
   }
+  text = text.trim();
   if (text.length > maximumDiagnosticLength) text = `${text.slice(0, maximumDiagnosticLength)}…`;
   return text;
 }

--- a/packages/box/src/internal/requirements.ts
+++ b/packages/box/src/internal/requirements.ts
@@ -34,8 +34,9 @@ export function boxRequirementError(
   failure: unknown,
   secrets: readonly string[] = [],
   timeout: number | undefined = requirement.timeout,
+  includeDiagnosticOutput = true,
 ): Error {
-  const details = commandFailureDetails(failure, secrets, timeout);
+  const details = commandFailureDetails(failure, secrets, timeout, includeDiagnosticOutput);
   const name = diagnosticText(requirement.name, secrets);
   return new Error(`[vitehub] Box requirement "${name}" failed${details ? `: ${details}` : "."}`);
 }
@@ -44,6 +45,7 @@ function commandFailureDetails(
   failure: unknown,
   secrets: readonly string[],
   timeout: number | undefined,
+  includeDiagnosticOutput: boolean,
 ) {
   const error =
     failure && typeof failure === "object" ? (failure as Record<string, unknown>) : undefined;
@@ -61,8 +63,12 @@ function commandFailureDetails(
             : error?.name === "AbortError"
               ? "aborted"
               : "";
-  const output = diagnosticText(error?.stderr, secrets) || diagnosticText(error?.stdout, secrets);
-  const message = status || output ? "" : diagnosticText(error?.message ?? failure, secrets);
+  const output = includeDiagnosticOutput
+    ? diagnosticText(error?.stderr, secrets) || diagnosticText(error?.stdout, secrets)
+    : "";
+  const message = includeDiagnosticOutput && !status && !output
+    ? diagnosticText(error?.message ?? failure, secrets)
+    : "";
   return [status, output || message].filter(Boolean).join(": ");
 }
 

--- a/packages/box/src/internal/requirements.ts
+++ b/packages/box/src/internal/requirements.ts
@@ -29,6 +29,54 @@ export function boxRequirementSecrets(
   ).filter(Boolean);
 }
 
+export async function collectBoxRequirementOutput(
+  stream: ReadableStream<Uint8Array>,
+  secrets: readonly string[],
+): Promise<string> {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  const patterns = [...new Set(secrets)].filter(Boolean).sort((left, right) => right.length - left.length);
+  const maximumSecretLength = Math.max(1, ...patterns.map(value => value.length));
+  let pending = "";
+  let output = "";
+  let truncated = false;
+
+  const append = (value: string) => {
+    if (!value || truncated) return;
+    if (output.length + value.length <= maximumDiagnosticLength) {
+      output += value;
+      return;
+    }
+    output = `${(output + value).slice(0, maximumDiagnosticLength - 1)}…`;
+    truncated = true;
+  };
+  const flush = (final: boolean) => {
+    while (pending && (final || pending.length >= maximumSecretLength)) {
+      const secret = patterns.find(value => pending.startsWith(value));
+      if (secret) {
+        append("[redacted]");
+        pending = pending.slice(secret.length);
+      }
+      else {
+        append(pending[0]!);
+        pending = pending.slice(1);
+      }
+    }
+  };
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      pending += decoder.decode(value, { stream: !done });
+      flush(done);
+      if (done) return output;
+    }
+  }
+  finally {
+    reader.releaseLock();
+  }
+}
+
 export function boxRequirementError(
   requirement: ResolvedBoxRequirementInput,
   failure: unknown,
@@ -66,7 +114,7 @@ function commandFailureDetails(
   const output = includeDiagnosticOutput
     ? diagnosticText(error?.stderr, secrets) || diagnosticText(error?.stdout, secrets)
     : "";
-  const message = includeDiagnosticOutput && !status && !output
+  const message = includeDiagnosticOutput && !output
     ? diagnosticText(error?.message ?? failure, secrets)
     : "";
   return [status, output || message].filter(Boolean).join(": ");
@@ -79,6 +127,7 @@ function diagnosticText(value: unknown, secrets: readonly string[]) {
     if (secret) text = text.replaceAll(secret, "[redacted]");
   }
   text = text.trim();
-  if (text.length > maximumDiagnosticLength) text = `${text.slice(0, maximumDiagnosticLength)}…`;
+  if (text.length > maximumDiagnosticLength)
+    text = `${text.slice(0, maximumDiagnosticLength - 1)}…`;
   return text;
 }

--- a/packages/box/src/internal/trusted-host.ts
+++ b/packages/box/src/internal/trusted-host.ts
@@ -37,6 +37,7 @@ import type {
   ResolvedBoxState,
 } from "../index.ts";
 import { materializeGitCheckout } from "./git-checkout.ts";
+import { boxRequirementError, boxRequirementPlan } from "./requirements.ts";
 import { markBuiltInBoxRuntime } from "./runtime.ts";
 import { createBoxSession, type RuntimeSession } from "./session.ts";
 
@@ -111,7 +112,7 @@ export function createTrustedHostRuntime(options: TrustedHostOptions = {}): BoxR
         environment: { env: {} },
         executionAuthority: trustedHostExecutionAuthority,
         identity: input.identity,
-        requirements: input.requirements.map(({ command, name }) => ({ command, name })),
+        requirements: boxRequirementPlan(input.requirements),
         runtime: "trusted-host",
         workspace: cwd
           ? { path: cwd, state: "authoritative" as const, workDir: "workspace" as const }
@@ -222,7 +223,13 @@ async function createSession(
       sessionId: createOptions.sessionId,
       workspace: input.cwd,
     });
-    await validateRequirements(input.requirements, env, checkout ?? input.cwd ?? root);
+    await validateRequirements(
+      input.requirements,
+      env,
+      checkout ?? input.cwd ?? root,
+      createOptions.abortSignal,
+      Object.keys(input.plan.env).map(name => env[name]),
+    );
     await createOptions.initialize?.(session);
     return session;
   } catch (error) {
@@ -616,6 +623,8 @@ async function validateRequirements(
   requirements: readonly ResolvedBoxRequirementInput[],
   env: Record<string, string>,
   cwd: string | undefined,
+  abortSignal: AbortSignal | undefined,
+  secrets: readonly string[],
 ) {
   for (const requirement of requirements) {
     const executable = await findExecutable(
@@ -625,19 +634,22 @@ async function validateRequirements(
       cwd,
     );
     if (!executable)
-      throw new Error(
-        `[vitehub] Box requirement "${requirement.name}" is unavailable: ${requirement.command} is not on PATH.`,
+      throw boxRequirementError(
+        requirement,
+        { message: `${requirement.command} is not on PATH.` },
+        secrets,
       );
     if (!requirement.args.length) continue;
     try {
       await promisify(execFile)(executable, requirement.args, {
         cwd,
         env,
+        signal: abortSignal,
         shell: isWindowsCommandShim(executable),
-        timeout: 10_000,
+        timeout: requirement.timeout ?? 10_000,
       });
-    } catch {
-      throw new Error(`[vitehub] Box requirement "${requirement.name}" failed.`);
+    } catch (cause) {
+      throw boxRequirementError(requirement, cause, secrets, requirement.timeout ?? 10_000);
     }
   }
 }

--- a/packages/box/src/internal/trusted-host.ts
+++ b/packages/box/src/internal/trusted-host.ts
@@ -37,7 +37,7 @@ import type {
   ResolvedBoxState,
 } from "../index.ts";
 import { materializeGitCheckout } from "./git-checkout.ts";
-import { boxRequirementError, boxRequirementPlan } from "./requirements.ts";
+import { boxRequirementError, boxRequirementPlan, boxRequirementSecrets } from "./requirements.ts";
 import { markBuiltInBoxRuntime } from "./runtime.ts";
 import { createBoxSession, type RuntimeSession } from "./session.ts";
 
@@ -228,7 +228,11 @@ async function createSession(
       env,
       checkout ?? input.cwd ?? root,
       createOptions.abortSignal,
-      Object.keys(input.plan.env).map(name => env[name]),
+      boxRequirementSecrets([
+        ...Object.keys(input.plan.env).map(name => env[name]),
+        ...files.map(file => file.contents),
+        ...states.flatMap(state => state.seed.map(file => file.contents)),
+      ]),
     );
     await createOptions.initialize?.(session);
     return session;

--- a/packages/box/src/internal/trusted-host.ts
+++ b/packages/box/src/internal/trusted-host.ts
@@ -37,7 +37,12 @@ import type {
   ResolvedBoxState,
 } from "../index.ts";
 import { materializeGitCheckout } from "./git-checkout.ts";
-import { boxRequirementError, boxRequirementPlan, boxRequirementSecrets } from "./requirements.ts";
+import {
+  boxRequirementError,
+  boxRequirementPlan,
+  boxRequirementSecrets,
+  boxRequirementSignal,
+} from "./requirements.ts";
 import { markBuiltInBoxRuntime } from "./runtime.ts";
 import { createBoxSession, type RuntimeSession } from "./session.ts";
 
@@ -233,6 +238,7 @@ async function createSession(
         ...files.map(file => file.contents),
         ...states.flatMap(state => state.seed.map(file => file.contents)),
       ]),
+      input.plan.state.length === 0,
     );
     await createOptions.initialize?.(session);
     return session;
@@ -629,6 +635,7 @@ async function validateRequirements(
   cwd: string | undefined,
   abortSignal: AbortSignal | undefined,
   secrets: readonly string[],
+  includeDiagnosticOutput: boolean,
 ) {
   for (const requirement of requirements) {
     const executable = await findExecutable(
@@ -642,18 +649,47 @@ async function validateRequirements(
         requirement,
         { message: `${requirement.command} is not on PATH.` },
         secrets,
+        requirement.timeout,
+        includeDiagnosticOutput,
       );
     if (!requirement.args.length) continue;
+    const timeout = requirement.timeout ?? 10_000;
+    let result: { exitCode: number; stderr: string; stdout: string };
     try {
-      await promisify(execFile)(executable, requirement.args, {
+      const child = spawnChildProcess(executable, requirement.args, {
         cwd,
+        detached: process.platform !== "win32",
         env,
-        signal: abortSignal,
         shell: isWindowsCommandShim(executable),
-        timeout: requirement.timeout ?? 10_000,
       });
+      const handle = processHandle(
+        child,
+        boxRequirementSignal({ ...requirement, timeout }, abortSignal),
+      );
+      const [stderr, stdout, { exitCode }] = await Promise.all([
+        collect(handle.stderr),
+        collect(handle.stdout),
+        handle.wait(),
+      ]);
+      result = { exitCode, stderr, stdout };
     } catch (cause) {
-      throw boxRequirementError(requirement, cause, secrets, requirement.timeout ?? 10_000);
+      if (abortSignal?.aborted) throw abortSignal.reason;
+      throw boxRequirementError(
+        requirement,
+        cause,
+        secrets,
+        timeout,
+        includeDiagnosticOutput,
+      );
+    }
+    if (result.exitCode !== 0) {
+      throw boxRequirementError(
+        requirement,
+        result,
+        secrets,
+        timeout,
+        includeDiagnosticOutput,
+      );
     }
   }
 }

--- a/packages/box/src/internal/trusted-host.ts
+++ b/packages/box/src/internal/trusted-host.ts
@@ -42,6 +42,7 @@ import {
   boxRequirementPlan,
   boxRequirementSecrets,
   boxRequirementSignal,
+  collectBoxRequirementOutput,
 } from "./requirements.ts";
 import { markBuiltInBoxRuntime } from "./runtime.ts";
 import { createBoxSession, type RuntimeSession } from "./session.ts";
@@ -667,8 +668,8 @@ async function validateRequirements(
         boxRequirementSignal({ ...requirement, timeout }, abortSignal),
       );
       const [stderr, stdout, { exitCode }] = await Promise.all([
-        collect(handle.stderr),
-        collect(handle.stdout),
+        collectBoxRequirementOutput(handle.stderr, secrets),
+        collectBoxRequirementOutput(handle.stdout, secrets),
         handle.wait(),
       ]);
       result = { exitCode, stderr, stdout };

--- a/packages/box/src/vercel.ts
+++ b/packages/box/src/vercel.ts
@@ -142,7 +142,7 @@ export function createVercelRuntime(options: VercelBoxOptions = {}): BoxRuntime 
         workspace,
         preserveWorkspace: Boolean(options.source),
         signal: openOptions?.signal,
-      });
+      }, Object.keys(input.plan.env).map(name => env[name]));
     },
   });
 }

--- a/packages/box/src/vercel.ts
+++ b/packages/box/src/vercel.ts
@@ -142,7 +142,7 @@ export function createVercelRuntime(options: VercelBoxOptions = {}): BoxRuntime 
         workspace,
         preserveWorkspace: Boolean(options.source),
         signal: openOptions?.signal,
-      }, Object.keys(input.plan.env).map(name => env[name]));
+      }, env);
     },
   });
 }

--- a/packages/box/test/crabbox.test.ts
+++ b/packages/box/test/crabbox.test.ts
@@ -25,11 +25,11 @@ describe("createCrabboxRuntime", () => {
 
     const box = await resolveBox({
       runtime: createCrabboxRuntime({ profile: "babysitter" }),
-      requires: [{ command: "gh", args: ["auth", "status"] }, "pnpm"],
+      requires: [{ command: "gh", args: ["auth", "status"], timeout: 5_000 }, "pnpm"],
       cwd: ({ worktree }: { worktree: string }) => worktree,
     }, { worktree: workspace }, { requires: [
           { command: "codex", args: ["login", "status"] },
-          { command: "gh", args: ["auth", "status"] },
+          { command: "gh", args: ["auth", "status"], timeout: 5_000 },
         ],
       },
     );
@@ -47,7 +47,7 @@ describe("createCrabboxRuntime", () => {
       },
       runtime: "crabbox",
       requirements: [
-        { command: "gh", name: "gh auth status" },
+        { command: "gh", name: "gh auth status", timeout: 5_000 },
         { command: "pnpm", name: "pnpm" },
         { command: "codex", name: "codex login status" },
       ],
@@ -208,6 +208,13 @@ describe("createCrabboxRuntime", () => {
       requires: [null as never],
       cwd: workspace,
     }, {})).rejects.toThrow("Box requirements must be commands or direct command checks");
+    for (const timeout of [0, -1, 1.5, Number.NaN, 2 ** 32]) {
+      await expect(resolveBox({
+        runtime: createCrabboxRuntime(),
+        requires: [{ command: "gh", timeout }],
+        cwd: workspace,
+      }, {})).rejects.toThrow("Box requirement timeout must be a positive integer");
+    }
   })
 
   it("materializes environment, files, and writable state before validation", async () => {
@@ -812,22 +819,25 @@ describe("createCrabboxRuntime", () => {
     const stateLog = join(root, "state.log")
     await Promise.all([mkdir(workspace), mkdir(bin)])
     await fakeCrabbox(bin)
-    await executable(bin, "gh", 'echo "not logged in" >&2\nexit 1')
+    await executable(bin, "gh", 'echo "token=$GH_TOKEN not logged in" >&2\nexit 1')
 
     await withEnvironment({ CRABBOX_TEST_STATE_LOG: stateLog, PATH: `${bin}:${process.env.PATH || ""}` }, async () => {
       const box = await resolveBox({
+        env: { GH_TOKEN: "crabbox-secret" },
         runtime: createCrabboxRuntime({ profile: "babysitter" }),
         requires: [{ name: "GitHub CLI", command: "gh", args: ["auth", "status"] }],
             cwd: workspace,
       }, {})
       const sandbox = boxProvider(box)
-      await expect(sandbox.createSession()).rejects.toThrow(
-          'Box requirement "GitHub CLI" failed',
-        );
+      const failure = await sandbox.createSession().catch((error: unknown) => error as Error) as Error
+      expect(failure.message).toContain('Box requirement "GitHub CLI" failed: exit code 1')
+      expect(failure.message).toContain("token=[redacted] not logged in")
+      expect(failure.message).not.toContain("crabbox-secret")
         const [stateHome] = [...new Set((await readFile(stateLog, "utf8")).trim().split("\n"))]
       await expect(stat(stateHome)).rejects.toMatchObject({ code: "ENOENT" })
     })
   }, 30_000)
+
 })
 
 async function temporaryRoot() {

--- a/packages/box/test/crabbox.test.ts
+++ b/packages/box/test/crabbox.test.ts
@@ -208,7 +208,7 @@ describe("createCrabboxRuntime", () => {
       requires: [null as never],
       cwd: workspace,
     }, {})).rejects.toThrow("Box requirements must be commands or direct command checks");
-    for (const timeout of [0, -1, 1.5, Number.NaN, 2 ** 32]) {
+    for (const timeout of [0, -1, 1.5, Number.NaN, 2 ** 31]) {
       await expect(resolveBox({
         runtime: createCrabboxRuntime(),
         requires: [{ command: "gh", timeout }],

--- a/packages/box/test/remote-providers.test.ts
+++ b/packages/box/test/remote-providers.test.ts
@@ -22,6 +22,37 @@ describe("remote Box providers", () => {
     await session.close();
   });
 
+  it("reports remote requirement output without exposing Box environment values", async () => {
+    const stub = cloudflareStub(async () => ({
+      exitCode: 2,
+      stderr: "",
+      stdout: "credential remote-secret was rejected",
+      success: false,
+    }));
+    const box = await resolveBox({
+      env: { ACCESS_TOKEN: "remote-secret" },
+      requires: [{ command: "node", args: ["--version"], timeout: 5_000 }],
+      runtime: { getSandbox: () => stub, kind: "cloudflare", namespace: namespace(stub) },
+    }, {});
+
+    expect(box.plan.requirements).toEqual([
+      { command: "node", name: "node --version", timeout: 5_000 },
+    ]);
+    const failure = await box.open().catch((error: unknown) => error as Error) as Error;
+    expect(failure.message).toContain("exit code 2: credential [redacted] was rejected");
+    expect(failure.message).not.toContain("remote-secret");
+  });
+
+  it("bounds remote requirement checks with their configured timeout", async () => {
+    const stub = cloudflareStub(async () => await new Promise<never>(() => {}));
+    const box = await resolveBox({
+      requires: [{ command: "node", timeout: 20 }],
+      runtime: { getSandbox: () => stub, kind: "cloudflare", namespace: namespace(stub) },
+    }, {});
+
+    await expect(box.open()).rejects.toThrow("timed out after 20ms");
+  });
+
   it("normalizes authority from tagged remote runtimes", async () => {
     const stub = cloudflareStub(async () => ({ exitCode: 0, stderr: "", stdout: "", success: true }));
     const cloudflare = await resolveBox({

--- a/packages/box/test/remote-providers.test.ts
+++ b/packages/box/test/remote-providers.test.ts
@@ -53,6 +53,21 @@ describe("remote Box providers", () => {
     await expect(box.open()).rejects.toThrow("timed out after 20ms");
   });
 
+  it("preserves caller cancellation during remote requirement checks", async () => {
+    const stub = cloudflareStub(async () => await new Promise<never>(() => {}));
+    const box = await resolveBox({
+      requires: ["node"],
+      runtime: { getSandbox: () => stub, kind: "cloudflare", namespace: namespace(stub) },
+    }, {});
+    const controller = new AbortController();
+    const reason = new Error("cancel requirement setup");
+
+    const opening = box.open({ signal: controller.signal });
+    controller.abort(reason);
+
+    await expect(opening).rejects.toBe(reason);
+  });
+
   it("normalizes authority from tagged remote runtimes", async () => {
     const stub = cloudflareStub(async () => ({ exitCode: 0, stderr: "", stdout: "", success: true }));
     const cloudflare = await resolveBox({

--- a/packages/box/test/requirements.test.ts
+++ b/packages/box/test/requirements.test.ts
@@ -1,0 +1,31 @@
+import { inspect } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+import { boxRequirementError } from "../src/internal/requirements.ts";
+
+describe("Box requirement failures", () => {
+  it("reports an effective timeout without retaining raw failure details", () => {
+    const failure = Object.assign(new Error("token setup-secret failed"), {
+      killed: true,
+      signal: "SIGTERM",
+      stderr: "token setup-secret failed",
+    });
+    const error = boxRequirementError(
+      {
+        args: [],
+        command: "setup",
+        name: "setup setup-secret",
+      },
+      failure,
+      ["setup-secret"],
+      10_000,
+    );
+
+    expect(error.message).toBe(
+      '[vitehub] Box requirement "setup [redacted]" failed: timed out after 10000ms: token [redacted] failed',
+    );
+    expect(error).not.toHaveProperty("cause");
+    expect(inspect(error, { depth: null })).not.toContain("setup-secret");
+  });
+});

--- a/packages/box/test/requirements.test.ts
+++ b/packages/box/test/requirements.test.ts
@@ -28,4 +28,15 @@ describe("Box requirement failures", () => {
     expect(error).not.toHaveProperty("cause");
     expect(inspect(error, { depth: null })).not.toContain("setup-secret");
   });
+
+  it("redacts whitespace-bearing secrets before trimming diagnostics", () => {
+    const error = boxRequirementError(
+      { args: [], command: "setup", name: "setup" },
+      { stderr: "token setup-secret\n" },
+      ["setup-secret\n"],
+    );
+
+    expect(error.message).toBe('[vitehub] Box requirement "setup" failed: token [redacted]');
+    expect(error.message).not.toContain("setup-secret");
+  });
 });

--- a/packages/box/test/requirements.test.ts
+++ b/packages/box/test/requirements.test.ts
@@ -2,7 +2,10 @@ import { inspect } from "node:util";
 
 import { describe, expect, it } from "vitest";
 
-import { boxRequirementError } from "../src/internal/requirements.ts";
+import {
+  boxRequirementError,
+  collectBoxRequirementOutput,
+} from "../src/internal/requirements.ts";
 
 describe("Box requirement failures", () => {
   it("reports an effective timeout without retaining raw failure details", () => {
@@ -51,5 +54,45 @@ describe("Box requirement failures", () => {
 
     expect(error.message).toBe('[vitehub] Box requirement "setup" failed: exit code 1');
     expect(error.message).not.toContain("refreshed-state-secret");
+  });
+
+  it("includes structured details alongside an exit status", () => {
+    const error = boxRequirementError(
+      { args: [], command: "setup", name: "setup" },
+      { exitCode: 1, message: "provider rejected the credential" },
+    );
+
+    expect(error.message).toBe(
+      '[vitehub] Box requirement "setup" failed: exit code 1: provider rejected the credential',
+    );
+  });
+
+  it("caps diagnostics at 4,000 characters including the ellipsis", () => {
+    const error = boxRequirementError(
+      { args: [], command: "setup", name: "setup" },
+      { stderr: "x".repeat(4_001) },
+    );
+    const diagnostic = error.message.split("failed: ")[1]!;
+
+    expect(diagnostic).toHaveLength(4_000);
+    expect(diagnostic.endsWith("…")).toBe(true);
+  });
+
+  it("bounds collected output while redacting secrets across chunks", async () => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("credential setup-"));
+        controller.enqueue(encoder.encode(`secret\n${"x".repeat(5_000)}`));
+        controller.close();
+      },
+    });
+
+    const output = await collectBoxRequirementOutput(stream, ["setup-secret"]);
+
+    expect(output).toHaveLength(4_000);
+    expect(output.startsWith("credential [redacted]")).toBe(true);
+    expect(output.endsWith("…")).toBe(true);
+    expect(output).not.toContain("setup-secret");
   });
 });

--- a/packages/box/test/requirements.test.ts
+++ b/packages/box/test/requirements.test.ts
@@ -39,4 +39,17 @@ describe("Box requirement failures", () => {
     expect(error.message).toBe('[vitehub] Box requirement "setup" failed: token [redacted]');
     expect(error.message).not.toContain("setup-secret");
   });
+
+  it("suppresses diagnostic output when it cannot be exhaustively redacted", () => {
+    const error = boxRequirementError(
+      { args: [], command: "setup", name: "setup" },
+      { exitCode: 1, stderr: "refreshed-state-secret" },
+      [],
+      undefined,
+      false,
+    );
+
+    expect(error.message).toBe('[vitehub] Box requirement "setup" failed: exit code 1');
+    expect(error.message).not.toContain("refreshed-state-secret");
+  });
 });

--- a/packages/box/test/trusted-host.test.ts
+++ b/packages/box/test/trusted-host.test.ts
@@ -569,6 +569,43 @@ describe("createTrustedHostRuntime", () => {
     );
   });
 
+  it("reports trusted-host requirement errors without exposing Box environment values", async () => {
+    const box = await resolveBox(
+      {
+        env: { ACCESS_TOKEN: "trusted-host-secret" },
+        requires: [{
+          command: "sh",
+          args: [
+            "-c",
+            'printf "credential %s was rejected\\n" "$ACCESS_TOKEN" >&2; exit 3',
+            "trusted-host-secret",
+          ],
+        }],
+        runtime: createTrustedHostRuntime(),
+      },
+      {},
+    );
+
+    const failure = await boxProvider(box).createSession()
+      .catch((error: unknown) => error as Error) as Error;
+    expect(failure.message).toContain('Box requirement "sh -c');
+    expect(failure.message).toContain('[redacted]" failed');
+    expect(failure.message).toContain("exit code 3: credential [redacted] was rejected");
+    expect(failure.message).not.toContain("trusted-host-secret");
+  });
+
+  it("bounds trusted-host requirement checks with their configured timeout", async () => {
+    const box = await resolveBox(
+      {
+        requires: [{ command: "sh", args: ["-c", "sleep 60"], timeout: 20 }],
+        runtime: createTrustedHostRuntime(),
+      },
+      {},
+    );
+
+    await expect(boxProvider(box).createSession()).rejects.toThrow("timed out after 20ms");
+  });
+
   it("resolves relative requirement executables from the Box workspace", async () => {
     const root = await temporaryRoot();
     const workspace = join(root, "workspace");

--- a/packages/box/test/trusted-host.test.ts
+++ b/packages/box/test/trusted-host.test.ts
@@ -594,6 +594,25 @@ describe("createTrustedHostRuntime", () => {
     expect(failure.message).not.toContain("trusted-host-secret");
   });
 
+  it("reports trusted-host requirement errors without exposing Home file contents", async () => {
+    const box = await resolveBox(
+      {
+        home: { files: { ".acme/token": { contents: "file-backed-secret\n" } } },
+        requires: [{
+          command: "sh",
+          args: ["-c", 'cat "$HOME/.acme/token" >&2; exit 3'],
+        }],
+        runtime: createTrustedHostRuntime(),
+      },
+      {},
+    );
+
+    const failure = await boxProvider(box).createSession()
+      .catch((error: unknown) => error as Error) as Error;
+    expect(failure.message).toContain("exit code 3: [redacted]");
+    expect(failure.message).not.toContain("file-backed-secret");
+  });
+
   it("bounds trusted-host requirement checks with their configured timeout", async () => {
     const box = await resolveBox(
       {

--- a/packages/box/test/trusted-host.test.ts
+++ b/packages/box/test/trusted-host.test.ts
@@ -616,13 +616,47 @@ describe("createTrustedHostRuntime", () => {
   it("bounds trusted-host requirement checks with their configured timeout", async () => {
     const box = await resolveBox(
       {
-        requires: [{ command: "sh", args: ["-c", "sleep 60"], timeout: 20 }],
+        requires: [{
+          command: process.execPath,
+          args: [
+            "-e",
+            "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)",
+          ],
+          timeout: 20,
+        }],
         runtime: createTrustedHostRuntime(),
       },
       {},
     );
 
     await expect(boxProvider(box).createSession()).rejects.toThrow("timed out after 20ms");
+  });
+
+  it("suppresses requirement output when durable Home state is mounted", async () => {
+    const root = await temporaryRoot();
+    const box = await resolveBox(
+      {
+        home: {
+          state: {
+            ".acme": {
+              key: "requirement-diagnostic-state",
+              seed: { token: { contents: "durable-state-secret" } },
+            },
+          },
+        },
+        requires: [{
+          command: "sh",
+          args: ["-c", 'cat "$HOME/.acme/token" >&2; exit 3'],
+        }],
+        runtime: createTrustedHostRuntime({ stateRoot: join(root, "state") }),
+      },
+      {},
+    );
+
+    const failure = await boxProvider(box).createSession()
+      .catch((error: unknown) => error as Error) as Error;
+    expect(failure.message).toContain("exit code 3");
+    expect(failure.message).not.toContain("durable-state-secret");
   });
 
   it("resolves relative requirement executables from the Box workspace", async () => {


### PR DESCRIPTION
Box requirements can now declare an execution timeout, and that value stays visible in the resolved Box plan while reaching ASCII, Cloudflare, Crabbox, Vercel, and trusted-host setup checks. Trusted-host checks keep a 10-second default when no timeout is configured.

Requirement failures now share one diagnostic path that prefers stderr, falls back to stdout or structured error details, and caps the output at 4,000 characters. Values declared through the Box environment are redacted from both the requirement label and diagnostic text, and unsanitized provider errors are not retained as causes.

This PR only changes Box requirement setup. Agent webhook rehydration, skills, and Harness behavior remain outside the boundary.

## Validation

- `vp run -t @vite-hub/box#build` — build and publint pass
- `tsc --noEmit -p packages/box/tsconfig.json`
- `vp check --no-fmt` on the 12 changed source and test files
- 92 focused timeout, plan, validation, failure-output, redaction, and bounded-diagnostic tests across the shared, remote, Crabbox, and trusted-host paths
- `git diff --check`

The complete Box run also passed 129 tests before two unrelated desktop-sandbox restrictions failed existing process/network tests: loopback `listen` and process-group `kill` both returned `EPERM`.