### PR TITLE
fix(agent): keep typing active for manual delivery

### DIFF
--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -851,6 +851,7 @@ function startChatTypingRefresh(thread: Thread, context: ViteAgentRouteRuntimeCo
   let stopped = false
   let timeout: ReturnType<typeof setTimeout> | undefined
   let wake: (() => void) | undefined
+  let cancelTypingWait: (() => void) | undefined
 
   const sleep = (ms: number) => new Promise<void>((resolve) => {
     wake = resolve
@@ -866,12 +867,14 @@ function startChatTypingRefresh(thread: Thread, context: ViteAgentRouteRuntimeCo
     try {
       await Promise.race([
         thread.startTyping().catch(() => undefined),
-        new Promise(resolve => {
+        new Promise<void>(resolve => {
+          cancelTypingWait = resolve
           limit = setTimeout(resolve, chatTypingRefreshTimeoutMs)
         }),
       ])
     }
     finally {
+      cancelTypingWait = undefined
       if (limit) {
         clearTimeout(limit)
       }
@@ -897,6 +900,7 @@ function startChatTypingRefresh(thread: Thread, context: ViteAgentRouteRuntimeCo
         clearTimeout(timeout)
         timeout = undefined
       }
+      cancelTypingWait?.()
       wake?.()
       wake = undefined
     },
@@ -2554,6 +2558,7 @@ async function handleChatSdkMessage(
     const authorizationInput = createChatMessageTriggerInput(options || {}, input).input
     const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, authorizationInput, input.run, messageContext)
     if (!invoker) return
+
     const messages = await chatTriggerMessages(thread, message, options, messageContext, historyThroughCurrent)
     const currentMessage = message.id
       ? messages.find(item => item.id === message.id)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2554,7 +2554,6 @@ async function handleChatSdkMessage(
     const authorizationInput = createChatMessageTriggerInput(options || {}, input).input
     const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, authorizationInput, input.run, messageContext)
     if (!invoker) return
-
     const messages = await chatTriggerMessages(thread, message, options, messageContext, historyThroughCurrent)
     const currentMessage = message.id
       ? messages.find(item => item.id === message.id)
@@ -2580,6 +2579,7 @@ async function handleChatSdkMessage(
     assertChatDeliveryOptions(options || {})
     const manualDelivery = options?.delivery === "manual"
     const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
+    typing = streamsPhasedReplies || manualDelivery ? startChatTypingRefresh(thread, context) : undefined
     const thinkingFallback = invocation.metadata?.thinkingFallback
     if (manualDelivery && typeof thinkingFallback === "string") {
       const placeholderDelivery = thread.post(thinkingFallback).then(async (placeholder) => {
@@ -2595,7 +2595,6 @@ async function handleChatSdkMessage(
         invocationDeadlineAbort,
       )
     }
-    typing = streamsPhasedReplies ? startChatTypingRefresh(thread, context) : undefined
     run = invocation.run
     const runContext = {
       ...context,

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7490,6 +7490,36 @@ describe("server helpers", () => {
     expect(typingOrder!).toBeLessThan(fallbackOrder!)
   })
 
+  it("does not delay manual non-streaming delivery on a hung typing request", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.startTyping.mockImplementation(() => new Promise(() => {}))
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: { delivery: "manual", stream: false },
+        }),
+      },
+      driver: { run: () => "internal output" },
+      hooks: {
+        "agent:finish": event => event.reply("Explicit reply"),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await Promise.race([
+      handler(chatWebhookRequest(91_099), "telegram"),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error("webhook blocked on typing status")), 100)),
+    ])
+
+    expect(response.status).toBe(200)
+    expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "Explicit reply" })
+  })
+
   it("uses generate for manual delivery without progress summaries", async () => {
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7482,57 +7482,12 @@ describe("server helpers", () => {
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Calories reply" })
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Dashboard reply" })
     expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", { markdown: "{\"internal\":\"structured output\"}" })
-  })
-
-  it("starts typing immediately for manual delivery while work continues", async () => {
-    const { defineAgent } = await import("../src/index.ts")
-    const { telegram } = await import("../src/channels.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
-    const adapter = createTestChatAdapter()
-    let runStarted!: () => void
-    let finishRun!: () => void
-    const runStartedPromise = new Promise<void>(resolve => {
-      runStarted = resolve
-    })
-    const finishRunPromise = new Promise<void>(resolve => {
-      finishRun = resolve
-    })
-    const agent = defineAgent({
-      channels: {
-        telegram: testTelegram(telegram, {
-          adapter: () => adapter as never,
-          messages: {
-            delivery: "manual",
-            fallbackStreamingPlaceholderText: "Analyzing request…",
-          },
-        }),
-      },
-      driver: { run: async () => {
-        runStarted()
-        await finishRunPromise
-        return "done"
-      } },
-      hooks: {
-        "agent:finish": event => event.reply("done"),
-      },
-    })
-    const handler = createChannelWebhookRouteHandler(agent as never)
-
-    const responsePromise = handler(chatWebhookRequest(91_018), "telegram")
-
-    await runStartedPromise
     expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
-    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Analyzing request…")
     const typingOrder = adapter.startTyping.mock.invocationCallOrder[0]
     const fallbackOrder = adapter.postMessage.mock.invocationCallOrder[0]
     expect(typingOrder).toBeDefined()
     expect(fallbackOrder).toBeDefined()
     expect(typingOrder!).toBeLessThan(fallbackOrder!)
-
-    finishRun()
-    const response = await responsePromise
-
-    expect(response.status).toBe(200)
   })
 
   it("uses generate for manual delivery without progress summaries", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7484,6 +7484,57 @@ describe("server helpers", () => {
     expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", { markdown: "{\"internal\":\"structured output\"}" })
   })
 
+  it("starts typing immediately for manual delivery while work continues", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    let runStarted!: () => void
+    let finishRun!: () => void
+    const runStartedPromise = new Promise<void>(resolve => {
+      runStarted = resolve
+    })
+    const finishRunPromise = new Promise<void>(resolve => {
+      finishRun = resolve
+    })
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            fallbackStreamingPlaceholderText: "Analyzing request…",
+          },
+        }),
+      },
+      driver: { run: async () => {
+        runStarted()
+        await finishRunPromise
+        return "done"
+      } },
+      hooks: {
+        "agent:finish": event => event.reply("done"),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const responsePromise = handler(chatWebhookRequest(91_018), "telegram")
+
+    await runStartedPromise
+    expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Analyzing request…")
+    const typingOrder = adapter.startTyping.mock.invocationCallOrder[0]
+    const fallbackOrder = adapter.postMessage.mock.invocationCallOrder[0]
+    expect(typingOrder).toBeDefined()
+    expect(fallbackOrder).toBeDefined()
+    expect(typingOrder!).toBeLessThan(fallbackOrder!)
+
+    finishRun()
+    const response = await responsePromise
+
+    expect(response.status).toBe(200)
+  })
+
   it("uses generate for manual delivery without progress summaries", async () => {
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")


### PR DESCRIPTION
## Summary

- start typing refreshes for manual chat delivery while the Agent Invocation runs
- preserve final-only adapter behavior when streaming and manual delivery are both disabled
- cover the ordering between typing and the manual placeholder

## Verification

- `vp pack` in `packages/agent`
- `vp test test/providers.test.ts -t "defaults adapter-backed Channels to final-only delivery|starts typing immediately for manual delivery while work continues|flushes deferred non-streaming chat webhook work before returning"`
- full `providers.test.ts`: 217 passed; one unrelated existing test was flaky in the full run and passed in isolation