### PR TITLE
feat(agent): rehydrate queued webhook invocations

### DIFF
--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -793,17 +793,18 @@ async function executeQueuedWebhookDelivery(
   if (lifecycleSignal.aborted) stopForLifecycle()
   else lifecycleSignal.addEventListener("abort", stopForLifecycle, { once: true })
   try {
-    const match = await findAgentWebhookRegistration(agent, context, request, delivery.webhookId)
-    if (!match) throw new Error(`[vitehub] Persisted webhook registration "${delivery.webhookId}" no longer exists.`)
-    const input = await createAgentWebhookTriggerInput(request, match.registration)
-    let invocation = await resolveAgentTriggerInvocation(agent as never, context as never, match.trigger.id, input)
-    if (!isResolvedAgentTriggerHandledInvocation(invocation) && invocation.webhook?.rehydrate) {
-      invocation = resolveAgentTriggerInvocationResult(await invocation.webhook.rehydrate(), invocation.trigger)
-    }
-    if (isResolvedAgentTriggerHandledInvocation(invocation)) {
-      await context.flushWaitUntil?.()
-    }
-    else {
+    const invocation = await runWithRuntimeCloudflareEnv(context, async () => {
+      const match = await findAgentWebhookRegistration(agent, context, request, delivery.webhookId)
+      if (!match) throw new Error(`[vitehub] Persisted webhook registration "${delivery.webhookId}" no longer exists.`)
+      const input = await createAgentWebhookTriggerInput(request, match.registration)
+      let invocation = await resolveAgentTriggerInvocation(agent as never, context as never, match.trigger.id, input)
+      if (!isResolvedAgentTriggerHandledInvocation(invocation) && invocation.webhook?.rehydrate) {
+        invocation = resolveAgentTriggerInvocationResult(await invocation.webhook.rehydrate(), invocation.trigger)
+      }
+      if (isResolvedAgentTriggerHandledInvocation(invocation)) await context.flushWaitUntil?.()
+      return invocation
+    })
+    if (!isResolvedAgentTriggerHandledInvocation(invocation)) {
       if (!invocation.webhook || invocation.webhook.deliveryId !== delivery.deliveryId) {
         throw new Error("[vitehub] Persisted webhook delivery no longer resolves to the same deliveryId.")
       }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -19,7 +19,7 @@ import { isAttachmentData } from "../messages.ts"
 import { resolveAgentInvoker, withResolvedAgentInvokerInput } from "../invoker.ts"
 import { createAgentRuntimeContext } from "../runtime/context.ts"
 import { createAgentUIMessageStreamResponse } from "../stream-output.ts"
-import { isResolvedAgentTriggerHandledInvocation, verifyAgentWebhookRequest } from "../trigger-runtime.ts"
+import { isResolvedAgentTriggerHandledInvocation, resolveAgentTriggerInvocationResult, verifyAgentWebhookRequest } from "../trigger-runtime.ts"
 import { AgentHttpError, toHttpErrorResponse } from "../http-error.ts"
 import { isWorkflowRun } from "../http-response.ts"
 import { messageChannelStateContextKey } from "../internal/channels.ts"
@@ -796,8 +796,14 @@ async function executeQueuedWebhookDelivery(
     const match = await findAgentWebhookRegistration(agent, context, request, delivery.webhookId)
     if (!match) throw new Error(`[vitehub] Persisted webhook registration "${delivery.webhookId}" no longer exists.`)
     const input = await createAgentWebhookTriggerInput(request, match.registration)
-    const invocation = await resolveAgentTriggerInvocation(agent as never, context as never, match.trigger.id, input)
-    if (!isResolvedAgentTriggerHandledInvocation(invocation)) {
+    let invocation = await resolveAgentTriggerInvocation(agent as never, context as never, match.trigger.id, input)
+    if (!isResolvedAgentTriggerHandledInvocation(invocation) && invocation.webhook?.rehydrate) {
+      invocation = resolveAgentTriggerInvocationResult(await invocation.webhook.rehydrate(), invocation.trigger)
+    }
+    if (isResolvedAgentTriggerHandledInvocation(invocation)) {
+      await context.flushWaitUntil?.()
+    }
+    else {
       if (!invocation.webhook || invocation.webhook.deliveryId !== delivery.deliveryId) {
         throw new Error("[vitehub] Persisted webhook delivery no longer resolves to the same deliveryId.")
       }

--- a/packages/agent/src/trigger-runtime.ts
+++ b/packages/agent/src/trigger-runtime.ts
@@ -18,6 +18,7 @@ import type {
   AgentRunResult,
   AgentRuntimeConfig,
   AgentRuntimeContext,
+  AgentTriggerInvokeResult,
   AgentTriggerRunInvokeResult,
   AgentWebhookInvocationOwnership,
   AgentWebhookRegistrationDefinition,
@@ -198,7 +199,7 @@ export interface ResolvedAgentTriggerInvocation<
   metadata?: Record<string, unknown>
   run?: AgentRunMetadata
   trigger: ResolvedAgentTriggerDefinition<TRuntimeConfig, unknown, CALL_OPTIONS>
-  webhook?: AgentWebhookInvocationOwnership
+  webhook?: AgentWebhookInvocationOwnership<CALL_OPTIONS>
 }
 
 export interface ResolvedAgentTriggerHandledInvocation<
@@ -424,6 +425,17 @@ export async function resolveAgentTriggerInvocation<
     })
   }
   const invocation = await trigger.invoke(input)
+  return resolveAgentTriggerInvocationResult(invocation, trigger)
+}
+
+export function resolveAgentTriggerInvocationResult<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  TInput = unknown,
+  CALL_OPTIONS = unknown,
+>(
+  invocation: AgentTriggerInvokeResult<CALL_OPTIONS>,
+  trigger: ResolvedAgentTriggerDefinition<TRuntimeConfig, TInput, CALL_OPTIONS>,
+): ResolvedAgentTriggerInvocationResult<TRuntimeConfig, CALL_OPTIONS> {
   if (invocation instanceof Response) {
     return {
       response: invocation,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -343,15 +343,17 @@ export interface AgentTriggerRunInvokeResult<CALL_OPTIONS = unknown> {
   input: AgentRunInput<CALL_OPTIONS>
   metadata?: Record<string, unknown>
   run?: AgentRunMetadata
-  webhook?: AgentWebhookInvocationOwnership
+  webhook?: AgentWebhookInvocationOwnership<CALL_OPTIONS>
 }
 
-export interface AgentWebhookInvocationOwnership {
+export interface AgentWebhookInvocationOwnership<CALL_OPTIONS = unknown> {
   concurrencyGroup?: string
   concurrencyKey?: string
   concurrencyLimit?: number
   concurrencyTtlMs?: number
   deliveryId: string
+  /** Rebuilds a persistent webhook invocation from current source data after the delivery is claimed. */
+  rehydrate?: () => MaybePromise<AgentTriggerInvokeResult<CALL_OPTIONS>>
 }
 
 export type AgentTriggerInvokeResult<CALL_OPTIONS = unknown> =

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -5472,6 +5472,200 @@ describe("server helpers", () => {
     }
   })
 
+  it("rehydrates a claimed webhook delivery before running the agent", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { github } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-webhook-rehydrate-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const scope = "webhook:review:github:github:"
+    const deliveryId = "delivery-rehydrate"
+    const claim = vi.fn()
+      .mockResolvedValueOnce({
+        attempts: 1,
+        concurrencyGroup: "review:default",
+        concurrencyLimit: 1,
+        deliveryId,
+        enqueuedAt: Date.now(),
+        leaseExpiresAt: Date.now() + 1_000,
+        leaseToken: "lease-rehydrate",
+        leaseTtlMs: 1_000,
+        request: {
+          body: "{}",
+          headers: {
+            "content-type": "application/json",
+            "x-github-delivery": deliveryId,
+            "x-github-event": "pull_request",
+          },
+          method: "POST",
+          url: "https://example.com/api/github/webhook",
+        },
+        scope,
+        webhookId: "github",
+      })
+      .mockResolvedValue(null)
+    const complete = vi.fn(async () => true)
+    const queueState = new Proxy(state, {
+      get(target, property) {
+        if (property === "claimWebhookDelivery") return claim
+        if (property === "completeWebhookDelivery") return complete
+        if (property === "extendWebhookDeliveryLease") return vi.fn(async () => true)
+        if (property === "retryWebhookDelivery") return vi.fn(async () => true)
+        const value = Reflect.get(target, property)
+        return typeof value === "function" ? value.bind(target) : value
+      },
+    })
+    const run = vi.fn(() => "accepted")
+    const rehydrate = vi.fn(() => ({
+      input: { prompt: "fresh prompt" },
+      webhook: { concurrencyLimit: 1, deliveryId },
+    }))
+    const agent = defineAgent({
+      channels: {
+        github: github({
+          triggers: {
+            webhook: {
+              invoke: () => ({
+                input: { prompt: "stale prompt" },
+                webhook: { concurrencyLimit: 1, deliveryId, rehydrate },
+              }),
+            },
+          },
+          webhooks: { secretToken: false },
+        }),
+      },
+      driver: { run },
+    })
+    let stop: () => void = () => undefined
+
+    try {
+      await state.connect()
+      stop = createChannelWebhookRouteHandler(agent as never).resume({ agentName: "review", webhookState: queueState })
+
+      await vi.waitFor(() => expect(run).toHaveBeenCalledOnce())
+      await vi.waitFor(() => expect(complete).toHaveBeenCalledOnce())
+      expect(rehydrate).toHaveBeenCalledOnce()
+      expect(run).toHaveBeenCalledWith(expect.objectContaining({
+        input: expect.objectContaining({ prompt: "fresh prompt" }),
+      }))
+      expect(run).not.toHaveBeenCalledWith(expect.objectContaining({
+        input: expect.objectContaining({ prompt: "stale prompt" }),
+      }))
+    }
+    finally {
+      stop()
+      await state.disconnect()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
+  it("completes handled rehydration and retries changed delivery identity", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { github } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { createLibsqlAgentState } = await import("../src/state/sqlite.ts")
+    const stateDir = await mkdtemp(join(tmpdir(), "vitehub-webhook-rehydrate-outcomes-"))
+    const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
+    const scope = "webhook:review:github:github:"
+    const deliveries = ["delivery-handled", "delivery-changed"].map(deliveryId => ({
+      attempts: 1,
+      concurrencyGroup: "review:default",
+      concurrencyLimit: 2,
+      deliveryId,
+      enqueuedAt: Date.now(),
+      leaseExpiresAt: Date.now() + 1_000,
+      leaseToken: `lease-${deliveryId}`,
+      leaseTtlMs: 1_000,
+      request: {
+        body: "{}",
+        headers: {
+          "content-type": "application/json",
+          "x-github-delivery": deliveryId,
+          "x-github-event": "pull_request",
+        },
+        method: "POST",
+        url: "https://example.com/api/github/webhook",
+      },
+      scope,
+      webhookId: "github",
+    }))
+    const claim = vi.fn(async () => deliveries.shift() ?? null)
+    const complete = vi.fn(async () => true)
+    const retry = vi.fn(async () => true)
+    const queueState = new Proxy(state, {
+      get(target, property) {
+        if (property === "claimWebhookDelivery") return claim
+        if (property === "completeWebhookDelivery") return complete
+        if (property === "extendWebhookDeliveryLease") return vi.fn(async () => true)
+        if (property === "retryWebhookDelivery") return retry
+        const value = Reflect.get(target, property)
+        return typeof value === "function" ? value.bind(target) : value
+      },
+    })
+    const run = vi.fn(() => "accepted")
+    let handled = false
+    let releaseDeferred: () => void = () => undefined
+    const deferred = new Promise<void>((resolve) => {
+      releaseDeferred = resolve
+    })
+    const agent = defineAgent({
+      channels: {
+        github: github({
+          triggers: {
+            webhook: {
+              invoke: (context, input) => {
+                const deliveryId = (input as { github: { deliveryId: string } }).github.deliveryId
+                return {
+                  input: { prompt: "stale prompt" },
+                  webhook: {
+                    concurrencyLimit: 2,
+                    deliveryId,
+                    rehydrate: () => {
+                      if (deliveryId === "delivery-handled") {
+                        handled = true
+                        context.waitUntil(deferred)
+                        return new Response(null, { status: 202 })
+                      }
+                      return {
+                        input: { prompt: "wrong delivery" },
+                        webhook: { concurrencyLimit: 2, deliveryId: "different-delivery" },
+                      }
+                    },
+                  },
+                }
+              },
+            },
+          },
+          webhooks: { secretToken: false },
+        }),
+      },
+      driver: { run },
+    })
+    let stop: () => void = () => undefined
+
+    try {
+      await state.connect()
+      stop = createChannelWebhookRouteHandler(agent as never).resume({ agentName: "review", webhookState: queueState })
+
+      await vi.waitFor(() => expect(handled).toBe(true))
+      await vi.waitFor(() => expect(retry).toHaveBeenCalledWith(scope, "delivery-changed", expect.any(String), expect.any(Number)))
+      expect(complete).not.toHaveBeenCalled()
+      releaseDeferred()
+      await vi.waitFor(() => expect(complete).toHaveBeenCalledWith(scope, "delivery-handled", expect.any(String)))
+      expect(complete).not.toHaveBeenCalledWith(scope, "delivery-changed", expect.any(String))
+      expect(run).not.toHaveBeenCalled()
+    }
+    finally {
+      releaseDeferred()
+      stop()
+      consoleError.mockRestore()
+      await state.disconnect()
+      await rm(stateDir, { force: true, recursive: true })
+    }
+  })
+
   it("retries webhook queue discovery after a transient startup failure", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -5473,6 +5473,7 @@ describe("server helpers", () => {
   })
 
   it("rehydrates a claimed webhook delivery before running the agent", async () => {
+    const { getActiveCloudflareEnv } = await import("@vite-hub/internal/runtime/cloudflare-env")
     const { defineAgent } = await import("../src/index.ts")
     const { github } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
@@ -5517,10 +5518,13 @@ describe("server helpers", () => {
       },
     })
     const run = vi.fn(() => "accepted")
-    const rehydrate = vi.fn(() => ({
-      input: { prompt: "fresh prompt" },
-      webhook: { concurrencyLimit: 1, deliveryId },
-    }))
+    const rehydrate = vi.fn(() => {
+      expect(getActiveCloudflareEnv()?.SOURCE_TOKEN).toBe("runtime-source-token")
+      return {
+        input: { prompt: "fresh prompt" },
+        webhook: { concurrencyLimit: 1, deliveryId },
+      }
+    })
     const agent = defineAgent({
       channels: {
         github: github({
@@ -5541,7 +5545,11 @@ describe("server helpers", () => {
 
     try {
       await state.connect()
-      stop = createChannelWebhookRouteHandler(agent as never).resume({ agentName: "review", webhookState: queueState })
+      stop = createChannelWebhookRouteHandler(agent as never).resume({
+        agentName: "review",
+        cloudflare: { env: { SOURCE_TOKEN: "runtime-source-token" } },
+        webhookState: queueState,
+      })
 
       await vi.waitFor(() => expect(run).toHaveBeenCalledOnce())
       await vi.waitFor(() => expect(complete).toHaveBeenCalledOnce())

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,6 +1,6 @@
 import { describe, expectTypeOf, it } from "vitest"
 
-import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelDeliveryReplyStream, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentDriverCapacityOptions, type AgentDriverCapacityQueueOptions, type AgentErrorHookEvent, type AgentFinishEvent, type AgentFinishHookEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentMessageDeliveryKind, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentUIMessageStreamProjection, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
+import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelDeliveryReplyStream, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentDriverCapacityOptions, type AgentDriverCapacityQueueOptions, type AgentErrorHookEvent, type AgentFinishEvent, type AgentFinishHookEvent, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentMessageDeliveryKind, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentTriggerInvokeResult, type AgentTriggerRunInvokeResult, type AgentUIMessageStreamProjection, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
 import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, repositoryHost, repositoryHostContext, sandbox, schedule, skills, streamTranscription, subagents, transcribe, usageCost, vercelAiGatewayPricing, webSearch, workspaceShell, type AgentUsagePricing, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput, type UsageCostOptions, type VercelAiGatewayPricingOptions } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -27,6 +27,14 @@ declare global {
 }
 
 describe("agent public types", () => {
+  it("preserves call options through queued webhook rehydration", () => {
+    type Options = { mode: "fresh" }
+    type Webhook = NonNullable<AgentTriggerRunInvokeResult<Options>["webhook"]>
+    type Rehydrate = NonNullable<Webhook["rehydrate"]>
+
+    expectTypeOf<Awaited<ReturnType<Rehydrate>>>().toEqualTypeOf<AgentTriggerInvokeResult<Options>>()
+  })
+
   it("types bounded driver capacity", () => {
     const queue = { maxPending: 20, timeout: 300_000 } satisfies AgentDriverCapacityQueueOptions
     const capacity = { concurrency: 2, queue } satisfies AgentDriverCapacityOptions


### PR DESCRIPTION
## Summary

Persistent webhook queues currently replay the original request payload, so an editable source can still run stale data after waiting for capacity. This adds an optional typed `rehydrate` callback to webhook invocation ownership and resolves it immediately after claim, before the Agent runs, while retaining the original delivery identity as the authority.

This PR is stacked on #901. It deliberately excludes queue persistence, source-specific fetching, busy steering, and consumer changes.

## Behavior

- Normalizes a refreshed invocation through the existing trigger runtime before execution.
- Completes a handled `Response` normally after flushing deferred trigger work.
- Rejects a refreshed invocation whose `deliveryId` differs from the claimed delivery, preserving the queue's existing retry behavior.

## Verification

- `pnpm --filter @vite-hub/agent exec vp test test/providers.test.ts -t 'rehydrat'` — 2 passed.
- `pnpm --filter @vite-hub/agent typecheck` — passed.
- `pnpm exec vp run -t @vite-hub/agent#build` — passed.
- `pnpm oxlint packages/agent/src/server/routes.ts packages/agent/src/trigger-runtime.ts packages/agent/src/types.ts packages/agent/test/providers.test.ts packages/agent/test/types.test-d.ts` — passed with pre-existing warnings outside this diff.
- The complete provider test file passed 224 of 225 tests; one generated Nitro strict-TypeScript fixture timed out under full-suite load, and that fixture passed when run alone.
