### PR TITLE
fix(workspace): avoid redundant source file reads

### DIFF
--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -191,11 +191,9 @@ async function readSyncedBuildSources(store: WorkspaceStore): Promise<SyncedBuil
 
 async function removeRootBuildSourceFiles(store: WorkspaceStore, source: SyncedBuildSource) {
   const entries = await store.list("", { recursive: true })
-  await Promise.all(entries.map(async (entry) => {
-    if (entry.type !== "file") return
-    const file = await store.readFile(entry.path)
-    if (file?.metadata?.source === source.key) await store.rm(entry.path, { force: true })
-  }))
+  await Promise.all(entries
+    .filter(entry => entry.type === "file" && entry.metadata?.source === source.key)
+    .map(entry => store.rm(entry.path, { force: true })))
 }
 
 function isSyncedBuildSource(value: unknown): value is SyncedBuildSource {

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -1289,6 +1289,26 @@ describe("sources, loaders, and publishers", () => {
     await expect(store.readFile("stale.md")).resolves.toBeUndefined()
   })
 
+  it("purges root-mounted build sources from list metadata without reading every file", async () => {
+    const store = createMemoryWorkspaceStore()
+    const rootSource = file({ content: "# Instructions\n", workspacePath: "AGENTS.md", mount: "" })
+    const definition: WorkspaceDefinition = {
+      name: "root-build-source-metadata",
+      sources: { instructions: rootSource },
+    }
+
+    await syncWorkspaceDefinition(definition, store)
+    const readFile = vi.spyOn(store, "readFile")
+
+    await syncWorkspaceDefinition({
+      ...definition,
+      sources: {},
+    }, store)
+
+    expect(readFile).not.toHaveBeenCalled()
+    await expect(store.readFile("AGENTS.md")).resolves.toBeUndefined()
+  })
+
   it("purges stale local build source files after store restarts", async () => {
     const root = await createRoot()
     const storeRoot = join(root, ".vitehub", "workspaces", "docs")


### PR DESCRIPTION
## Summary

- remove root-mounted build source files from metadata already returned by `WorkspaceStore.list()`
- avoid calling `readFile()` once per workspace entry during reconciliation
- prevent GitHub Workspace Store refresh storms and secondary rate limits in Box-backed Codex invocations

## Verification

- `corepack pnpm --filter @vite-hub/workspace test -- source-loader-publisher.test.ts` (54 passed)
- `corepack pnpm --filter @vite-hub/workspace typecheck`
- `git diff --check`

## Live reproduction

Bitácora materialized a root-mounted GitHub workspace with 500+ files. The previous loop called `readFile()` for every entry, and each GitHub store read refreshed branch state, producing a GitHub secondary-rate-limit 403 before Codex could run.