### PR TITLE
fix(queue): start Cloudflare Queue apps in Node development

### DIFF
--- a/packages/internal/src/runtime/cloudflare-env.ts
+++ b/packages/internal/src/runtime/cloudflare-env.ts
@@ -42,6 +42,7 @@ export function getActiveCloudflareBinding<T>(name: string): T | undefined {
 interface CloudflareEnvCarrier {
   context?: { cloudflare?: { env?: CloudflareWorkerEnv }, _platform?: { cloudflare?: { env?: CloudflareWorkerEnv } } }
   env?: CloudflareWorkerEnv
+  node?: { req?: { runtime?: { cloudflare?: { env?: CloudflareWorkerEnv } } } }
   req?: { runtime?: { cloudflare?: { env?: CloudflareWorkerEnv } } }
 }
 
@@ -51,6 +52,7 @@ export function getCloudflareEnv(event: unknown): CloudflareWorkerEnv | undefine
     || target?.context?.cloudflare?.env
     || target?.context?._platform?.cloudflare?.env
     || target?.req?.runtime?.cloudflare?.env
+    || target?.node?.req?.runtime?.cloudflare?.env
     || getActiveCloudflareEnv()
 }
 
@@ -67,6 +69,12 @@ interface WaitUntilCarrier {
     waitUntil?: WaitUntilFn
     runtime?: { cloudflare?: { context?: { waitUntil?: WaitUntilFn }, waitUntil?: WaitUntilFn } }
   }
+  node?: {
+    req?: {
+      waitUntil?: WaitUntilFn
+      runtime?: { cloudflare?: { context?: { waitUntil?: WaitUntilFn }, waitUntil?: WaitUntilFn } }
+    }
+  }
 }
 
 export function resolveWaitUntil(event: unknown): WaitUntilFn | undefined {
@@ -81,6 +89,9 @@ export function resolveWaitUntil(event: unknown): WaitUntilFn | undefined {
     target?.req,
     target?.req?.runtime?.cloudflare,
     target?.req?.runtime?.cloudflare?.context,
+    target?.node?.req,
+    target?.node?.req?.runtime?.cloudflare,
+    target?.node?.req?.runtime?.cloudflare?.context,
   ]
   for (const owner of owners) {
     if (typeof owner?.waitUntil === "function") {

--- a/packages/queue/src/internal/runtime/state.ts
+++ b/packages/queue/src/internal/runtime/state.ts
@@ -38,7 +38,8 @@ export function enterQueueRuntimeEvent(event: unknown): void {
     queueEventStorage.enterWith(event)
   }
   catch {}
-  setActiveCloudflareEnv(getCloudflareEnv(event))
+  const explicitEnv = event && typeof event === "object" && Object.hasOwn(event, "env")
+  setActiveCloudflareEnv(explicitEnv ? (event as { env?: Record<string, unknown> }).env : getCloudflareEnv(event))
 }
 
 export function getQueueRuntimeEvent(): unknown {

--- a/packages/queue/src/internal/vite-build.ts
+++ b/packages/queue/src/internal/vite-build.ts
@@ -202,10 +202,11 @@ export function createCloudflareQueueBindings(definitions: DiscoveredQueueDefini
   }
 }
 
-function renderNitroPlugin(pluginFile: string, registryFile: string, queueConfig: NormalizedQueueOptions, cloudflareQueues: boolean, queueDefinitions: Record<string, string>) {
+function renderNitroPlugin(pluginFile: string, registryFile: string, queueConfig: NormalizedQueueOptions, cloudflareQueues: boolean, queueDefinitions: Record<string, string>, development: boolean) {
   const cloudflareRuntime = queueConfig !== false && queueConfig.provider === "cloudflare"
   const vercelRuntime = queueConfig !== false && queueConfig.provider === "vercel"
   const cloudflare = cloudflareQueues && cloudflareRuntime
+  const cloudflareGlobals = cloudflareRuntime && !development
   const runtimeClientFactory = cloudflareRuntime
     ? "createCloudflareQueueRuntimeClient"
     : vercelRuntime
@@ -214,7 +215,7 @@ function renderNitroPlugin(pluginFile: string, registryFile: string, queueConfig
   return [
     "import { definePlugin } from 'nitro'",
     ...(vercelRuntime ? [`import * as __vitehubVercelQueue from ${JSON.stringify(createImportPath(pluginFile, resolvePackageDependency("@vercel/queue")))}`] : []),
-    ...(cloudflareRuntime ? ["import { env as vitehubEnv, waitUntil as vitehubWaitUntil } from 'cloudflare:workers'"] : []),
+    ...(cloudflareGlobals ? ["import { env as vitehubEnv, waitUntil as vitehubWaitUntil } from 'cloudflare:workers'"] : []),
     ...(cloudflare ? [`import { createQueueCloudflareWorker } from ${JSON.stringify(createImportPath(pluginFile, resolveRuntimeModule("internal/runtime/cloudflare-vite")))}`] : []),
     ...(cloudflareRuntime ? [`import { createCloudflareQueueRuntimeClient } from ${JSON.stringify(createImportPath(pluginFile, resolveRuntimeModule("internal/runtime/cloudflare-client")))}`] : []),
     ...(vercelRuntime ? [`import { createVercelQueueRuntimeClient } from ${JSON.stringify(createImportPath(pluginFile, resolveRuntimeModule("internal/runtime/vercel-client")))}`] : []),
@@ -228,33 +229,34 @@ function renderNitroPlugin(pluginFile: string, registryFile: string, queueConfig
     `export default definePlugin((${cloudflare ? "nitro" : ""}) => {`,
     `  setQueueRuntimeConfig(queueConfig${runtimeClientFactory ? `, ${runtimeClientFactory}` : ""})`,
     "  setQueueRuntimeRegistry(queueRegistry)",
-    ...(cloudflareRuntime ? ["  setQueueRuntimeEventDefaults({ env: vitehubEnv, waitUntil: vitehubWaitUntil })"] : []),
+    ...(cloudflareGlobals ? ["  setQueueRuntimeEventDefaults({ env: vitehubEnv, waitUntil: vitehubWaitUntil })"] : []),
     ...(cloudflare ? ["  nitro.hooks.hook('cloudflare:queue', ({ batch, context, env }) => queueWorker.queue(batch, env, context))"] : []),
     "})",
     "",
   ].join("\n")
 }
 
-function renderNitroMiddleware(middlewareFile: string, queueConfig: NormalizedQueueOptions, hasDefinitions: boolean) {
+function renderNitroMiddleware(middlewareFile: string, queueConfig: NormalizedQueueOptions, hasDefinitions: boolean, development: boolean) {
   const cloudflare = queueConfig !== false && queueConfig.provider === "cloudflare"
+  const cloudflareGlobals = cloudflare && !development
   const vercel = hasDefinitions && queueConfig !== false && queueConfig.provider === "vercel"
   return [
     "import { defineMiddleware } from 'nitro'",
     ...(vercel ? [`import { waitUntil as vitehubWaitUntil } from ${JSON.stringify(createImportPath(middlewareFile, resolvePackageDependency("@vercel/functions")))}`] : []),
-    ...(cloudflare ? ["import { env as vitehubEnv, waitUntil as vitehubWaitUntil } from 'cloudflare:workers'"] : []),
+    ...(cloudflareGlobals ? ["import { env as vitehubEnv, waitUntil as vitehubWaitUntil } from 'cloudflare:workers'"] : []),
     `import { enterQueueRuntimeEvent } from ${JSON.stringify(createImportPath(middlewareFile, resolveRuntimeModule("internal/runtime/state")))}`,
     "",
     "export default defineMiddleware((event) => {",
     ...(cloudflare ? ["  const runtimeEvent = event as any"] : []),
     ...(vercel ? ["  Object.assign(event, { waitUntil: vitehubWaitUntil })"] : []),
-    ...(cloudflare ? ["  Object.assign(event, { env: runtimeEvent.env ?? runtimeEvent.context?.cloudflare?.env ?? runtimeEvent.context?._platform?.cloudflare?.env ?? runtimeEvent.req?.runtime?.cloudflare?.env ?? runtimeEvent.node?.req?.runtime?.cloudflare?.env ?? vitehubEnv, waitUntil: vitehubWaitUntil })"] : []),
+    ...(cloudflare ? [`  Object.assign(event, { env: runtimeEvent.env ?? runtimeEvent.context?.cloudflare?.env ?? runtimeEvent.context?._platform?.cloudflare?.env ?? runtimeEvent.req?.runtime?.cloudflare?.env ?? runtimeEvent.node?.req?.runtime?.cloudflare?.env${cloudflareGlobals ? " ?? vitehubEnv, waitUntil: vitehubWaitUntil" : ""} })`] : []),
     "  enterQueueRuntimeEvent(event)",
     "})",
     "",
   ].join("\n")
 }
 
-export async function writeQueueNitroIntegration(rootDir: string, queue: QueueModuleOptions | undefined, hosting: string, cloudflareQueues = true, definitions: DiscoveredQueueDefinition[] = discoverQueueDefinitions({ rootDir })): Promise<void> {
+export async function writeQueueNitroIntegration(rootDir: string, queue: QueueModuleOptions | undefined, hosting: string, cloudflareQueues = true, definitions: DiscoveredQueueDefinition[] = discoverQueueDefinitions({ rootDir }), development = false): Promise<void> {
   const generatedDir = ensureGeneratedDir(rootDir, productName)
   const registryFile = resolve(generatedDir, generatedRegistryFileName)
   const pluginFile = resolve(rootDir, generatedQueueNitroPlugin)
@@ -269,8 +271,8 @@ export async function writeQueueNitroIntegration(rootDir: string, queue: QueueMo
   ])
   await Promise.all([
     writeFile(registryFile, createRuntimeRegistryContents(registryFile, definitions), "utf8"),
-    writeFile(pluginFile, renderNitroPlugin(pluginFile, registryFile, queueConfig, cloudflareQueues, queueDefinitions), "utf8"),
-    writeFile(middlewareFile, renderNitroMiddleware(middlewareFile, queueConfig, definitions.length > 0), "utf8"),
+    writeFile(pluginFile, renderNitroPlugin(pluginFile, registryFile, queueConfig, cloudflareQueues, queueDefinitions, development), "utf8"),
+    writeFile(middlewareFile, renderNitroMiddleware(middlewareFile, queueConfig, definitions.length > 0, development), "utf8"),
   ])
 }
 

--- a/packages/queue/src/nuxt.ts
+++ b/packages/queue/src/nuxt.ts
@@ -39,6 +39,7 @@ export default function viteHubQueueNuxtModule(options: QueueNuxtModuleOptions =
   nuxt.hook?.("nitro:config", async (nitroConfig) => {
     const projectRoot = nuxt.options.rootDir || process.cwd()
     const nitro = await createQueueNitroConfig(plugin, {
+      development: nuxt.options.dev,
       nitro: nitroConfig,
       projectRoot,
       root: nuxt.options.srcDir || projectRoot,

--- a/packages/queue/src/vite.ts
+++ b/packages/queue/src/vite.ts
@@ -26,6 +26,7 @@ interface QueueProvisionContributingPlugin {
 export type QueueVitePlugin = Plugin & QueueProvisionContributingPlugin
 
 export interface QueueNitroConfigOptions {
+  development?: boolean
   nitro: Record<string, unknown>
   projectRoot: string
   root: string
@@ -145,6 +146,7 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
   let hosting = "vercel"
   let cloudflareQueues = true
   let configuredDefinitions: DiscoveredQueueDefinition[] = []
+  let localDevelopment = false
   let nitroOwnsCloudflareWorker = false
   let nitroQueue: QueueModuleOptions | undefined = queue
   let nuxtConfiguredDefinitions: DiscoveredQueueDefinition[] | undefined
@@ -171,7 +173,7 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
         }
       },
       queue: {
-        async createNitroConfig({ nitro, projectRoot, root, serverDirs }) {
+        async createNitroConfig({ development = false, nitro, projectRoot, root, serverDirs }) {
           const config = { nitro }
           nuxtProjectRoot = projectRoot
           nuxtServerQueueDirs = [...new Set(serverDirs || [resolve(projectRoot, "server"), resolve(root, "server")])]
@@ -185,7 +187,8 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
           nitroQueue = queue !== false && queue?.provider && nitroHosting && queue.provider !== nitroHosting ? false : queue
           cloudflareQueues = supportsCloudflareQueues(configuredNitro)
           nuxtOwnsCloudflareWorker = nitroQueue !== false && nitroHosting === "cloudflare" && cloudflareQueues
-          await writeQueueNitroIntegration(projectRoot, nitroQueue, hosting, cloudflareQueues, definitions)
+          localDevelopment = development
+          await writeQueueNitroIntegration(projectRoot, nitroQueue, hosting, cloudflareQueues, definitions, localDevelopment)
           return configuredNitro
         },
       },
@@ -210,7 +213,8 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
       const nitroHosting = resolveNitroHosting(nitro)
       nitroQueue = queue !== false && queue?.provider && nitroHosting && queue.provider !== nitroHosting ? false : queue
       validatesNitroDefinitions = hasNitroConfigContext(config) && nitroQueue !== false
-      await writeQueueNitroIntegration(config.root, nitroQueue, hosting, cloudflareQueues, configuredDefinitions)
+      localDevelopment = config.command === "serve"
+      await writeQueueNitroIntegration(config.root, nitroQueue, hosting, cloudflareQueues, configuredDefinitions, localDevelopment)
     },
     configEnvironment(name, config) {
       if (!isServerEnvironment(name, config)) {
@@ -226,7 +230,7 @@ export function hubQueue(options?: QueueModuleOptions): QueueVitePlugin {
         && (/\/server\/queues\//.test(file) || nuxtServerQueueDirs.some(dir => file.startsWith(dir)))
       if (!/\.queue\.(?:c|m)?[jt]s$/i.test(file) && !isDirectoryDefinition) return
       resolved = context.server.config
-      await writeQueueNitroIntegration(nuxtProjectRoot || resolved.root, nitroQueue, hosting, cloudflareQueues, resolveNuxtDefinitions?.())
+      await writeQueueNitroIntegration(nuxtProjectRoot || resolved.root, nitroQueue, hosting, cloudflareQueues, resolveNuxtDefinitions?.(), localDevelopment)
     },
     async closeBundle() {
       if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) {

--- a/packages/queue/test/nuxt.test.ts
+++ b/packages/queue/test/nuxt.test.ts
@@ -36,7 +36,7 @@ describe("Queue Nuxt integration", () => {
       "",
     ].join("\n"))
 
-    const nuxt = await loadNuxt({ cwd: root, dev, ready: true })
+    const nuxt = await loadNuxt({ cwd: root, overrides: { dev }, ready: true })
     try {
       expect((nuxt.options.vite.plugins as unknown[]).flat(Infinity)).toEqual([
         expect.objectContaining({ name: "@vite-hub/queue/vite" }),
@@ -86,8 +86,21 @@ describe("Queue Nuxt integration", () => {
         rollupConfig: directNitro.rollupConfig,
       })
 
-      await expect(readFile(join(root, ".vitehub", "nitro", "queue", "plugin.ts"), "utf8")).resolves.toContain("cloudflare:queue")
-      await expect(readFile(join(root, ".vitehub", "nitro", "queue", "middleware.ts"), "utf8")).resolves.toContain("enterQueueRuntimeEvent(event)")
+      const generatedPlugin = await readFile(join(root, ".vitehub", "nitro", "queue", "plugin.ts"), "utf8")
+      const generatedMiddleware = await readFile(join(root, ".vitehub", "nitro", "queue", "middleware.ts"), "utf8")
+      expect(generatedPlugin).toContain("cloudflare:queue")
+      expect(generatedMiddleware).toContain("enterQueueRuntimeEvent(event)")
+      if (dev) {
+        expect(`${generatedPlugin}\n${generatedMiddleware}`).not.toContain("cloudflare:workers")
+        expect(generatedPlugin).not.toContain("setQueueRuntimeEventDefaults({")
+        expect(generatedMiddleware).toContain("runtimeEvent.node?.req?.runtime?.cloudflare?.env")
+        expect(generatedMiddleware).not.toContain("?? vitehubEnv")
+      }
+      else {
+        expect(`${generatedPlugin}\n${generatedMiddleware}`).toContain("cloudflare:workers")
+        expect(generatedPlugin).toContain("setQueueRuntimeEventDefaults({")
+        expect(generatedMiddleware).toContain("Object.assign(event")
+      }
     }
     finally {
       await nuxt.close()
@@ -113,7 +126,7 @@ describe("Queue Nuxt integration", () => {
       "})",
       "",
     ].join("\n"))
-    const nuxt = await loadNuxt({ cwd: root, dev: false, ready: true })
+    const nuxt = await loadNuxt({ cwd: root, overrides: { dev: false }, ready: true })
     try {
       const nitroConfig: Record<string, unknown> = {
         alias: {},

--- a/packages/queue/test/runtime.test.ts
+++ b/packages/queue/test/runtime.test.ts
@@ -281,6 +281,20 @@ describe("cloudflare queue runtime", () => {
     expect(vercelQueueMock.send).not.toHaveBeenCalled()
   })
 
+  it("reports a missing Cloudflare binding without deployment runtime defaults", async () => {
+    setQueueRuntimeConfig({ cache: true, namePrefix: "", provider: "cloudflare" }, createCloudflareQueueRuntimeClient)
+    setQueueRuntimeRegistry({
+      welcome: async () => ({
+        default: { handler: async () => {} },
+      }),
+    })
+
+    await expect(runQueue("welcome", { email: "ava@example.com" })).rejects.toMatchObject({
+      code: "CLOUDFLARE_BINDING_RESOLUTION_REQUIRED",
+      details: { provider: "cloudflare" },
+    })
+  })
+
   it("isolates overlapping Cloudflare fetch environments", async () => {
     let arrivals = 0
     let release!: () => void

--- a/packages/queue/test/runtime.test.ts
+++ b/packages/queue/test/runtime.test.ts
@@ -554,6 +554,53 @@ describe("cloudflare queue runtime", () => {
     await waitUntil.mock.calls[0]?.[0]
     expect(send).toHaveBeenCalledTimes(1)
   })
+
+  it("uses Node request Cloudflare context for deferred dispatch", async () => {
+    const send = vi.fn(async () => {})
+    const waitUntil = vi.fn()
+
+    setQueueRuntimeConfig({ provider: "cloudflare" }, createCloudflareQueueRuntimeClient)
+    setQueueRuntimeRegistry({
+      welcome: async () => ({ default: { handler: async () => {} } }),
+    })
+
+    await runWithQueueRuntimeEvent({
+      node: {
+        req: {
+          runtime: {
+            cloudflare: {
+              context: { waitUntil },
+              env: { [getCloudflareQueueBindingName("welcome")]: { send, sendBatch: vi.fn() } },
+            },
+          },
+        },
+      },
+    }, async () => {
+      deferQueue("welcome", { email: "ava@example.com" })
+      await Promise.resolve()
+    })
+
+    expect(waitUntil).toHaveBeenCalledTimes(1)
+    await waitUntil.mock.calls[0]?.[0]
+    expect(send).toHaveBeenCalledTimes(1)
+  })
+
+  it("clears the active Cloudflare env for an explicitly unbound request", async () => {
+    const send = vi.fn(async () => {})
+    setQueueRuntimeConfig({ provider: "cloudflare" }, createCloudflareQueueRuntimeClient)
+    setQueueRuntimeRegistry({
+      welcome: async () => ({ default: { handler: async () => {} } }),
+    })
+
+    enterQueueRuntimeEvent({ env: { [getCloudflareQueueBindingName("welcome")]: { send, sendBatch: vi.fn() } } })
+    await runQueue("welcome", { email: "first@example.com" })
+    enterQueueRuntimeEvent({ env: undefined })
+
+    await expect(runQueue("welcome", { email: "second@example.com" })).rejects.toMatchObject({
+      code: "CLOUDFLARE_BINDING_RESOLUTION_REQUIRED",
+    })
+    expect(send).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe("vercel provider", () => {

--- a/packages/queue/test/vite.test.ts
+++ b/packages/queue/test/vite.test.ts
@@ -46,14 +46,15 @@ describe("hubQueue", () => {
       nitro: { plugins: [".vitehub/nitro/queue/plugin.ts", "server/plugin.ts"] },
     })
 
-    await configResolved({
+    const resolved = {
       build: { outDir: "dist" },
       command: "serve",
       plugins: [],
       queue: { provider: "cloudflare" },
       resolve: { alias: [] },
       root,
-    } as never)
+    }
+    await configResolved(resolved as never)
 
     const nitroPlugin = await readFile(join(root, ".vitehub", "nitro", "queue", "plugin.ts"), "utf8")
     const nitroMiddleware = await readFile(join(root, ".vitehub", "nitro", "queue", "middleware.ts"), "utf8")
@@ -62,14 +63,17 @@ describe("hubQueue", () => {
     expect(nitroPlugin).toContain("setQueueRuntimeRegistry(queueRegistry)")
     expect(nitroPlugin).not.toContain("enterQueueRuntimeEvent")
     expect(nitroPlugin).not.toContain("hooks.hook('request'")
+    expect(nitroPlugin).not.toContain("cloudflare:workers")
+    expect(nitroPlugin).not.toContain("setQueueRuntimeEventDefaults({")
     expect(nitroMiddleware).toContain("defineMiddleware((event) =>")
+    expect(nitroMiddleware).not.toContain("cloudflare:workers")
     expect(nitroMiddleware).toContain("const runtimeEvent = event as any")
-    expect(nitroMiddleware).toContain("Object.assign(event, { env: runtimeEvent.env ?? runtimeEvent.context?.cloudflare?.env ?? runtimeEvent.context?._platform?.cloudflare?.env ?? runtimeEvent.req?.runtime?.cloudflare?.env ?? runtimeEvent.node?.req?.runtime?.cloudflare?.env ?? vitehubEnv, waitUntil: vitehubWaitUntil })")
+    expect(nitroMiddleware).toContain("runtimeEvent.node?.req?.runtime?.cloudflare?.env")
+    expect(nitroMiddleware).not.toContain("?? vitehubEnv")
+    expect(nitroMiddleware).not.toContain("waitUntil: vitehubWaitUntil")
     expect(nitroMiddleware).toContain("enterQueueRuntimeEvent(event)")
     expect(nitroMiddleware).not.toContain("enterQueueRuntimeEvent(runtimeEvent)")
-    expect(nitroMiddleware).toContain("waitUntil: vitehubWaitUntil")
     expect(nitroMiddleware).not.toContain("next")
-    expect(nitroPlugin).toContain("setQueueRuntimeEventDefaults({ env: vitehubEnv, waitUntil: vitehubWaitUntil })")
     expect(nitroPlugin).toContain("cloudflare:queue")
     expect(nitroPlugin).toContain("queueWorker.queue(batch, env, context)")
     expect(registry).toContain("welcome.queue.ts")
@@ -94,6 +98,39 @@ describe("hubQueue", () => {
       files: ["runtime-types.d.ts", ".vitehub/nitro/queue/middleware.ts"],
     }, null, 2)}\n`)
     await execFileAsync(process.execPath, [join(workspaceRoot, "node_modules/typescript/bin/tsc"), "-p", root], { cwd: root })
+
+    const addedDefinition = join(root, "follow-up.queue.ts")
+    await writeFile(addedDefinition, "export default { handler: async () => undefined }\n")
+    await (plugin.handleHotUpdate as (context: unknown) => Promise<void>)({
+      file: addedDefinition,
+      server: { config: resolved },
+    })
+    expect(await readFile(join(root, ".vitehub", "nitro", "queue", "plugin.ts"), "utf8")).not.toContain("cloudflare:workers")
+    expect(await readFile(join(root, ".vitehub", "nitro", "queue", "middleware.ts"), "utf8")).not.toContain("cloudflare:workers")
+  }, 15_000)
+
+  it("keeps Cloudflare globals in generated production runtime", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-queue-nitro-production-"))
+    roots.push(root)
+    await writeFile(join(root, "welcome.queue.ts"), "export default { handler: async () => undefined }\n")
+
+    const plugin = hubQueue({ provider: "cloudflare" })
+    await (plugin.configResolved as (config: unknown) => Promise<void>)({
+      build: { outDir: "dist" },
+      command: "build",
+      nitro: { preset: "cloudflare_module" },
+      plugins: [{ name: "nitro:main" }],
+      queue: { provider: "cloudflare" },
+      resolve: { alias: [] },
+      root,
+    } as never)
+
+    const nitroPlugin = await readFile(join(root, ".vitehub", "nitro", "queue", "plugin.ts"), "utf8")
+    const nitroMiddleware = await readFile(join(root, ".vitehub", "nitro", "queue", "middleware.ts"), "utf8")
+    expect(nitroPlugin).toContain("import { env as vitehubEnv, waitUntil as vitehubWaitUntil } from 'cloudflare:workers'")
+    expect(nitroPlugin).toContain("setQueueRuntimeEventDefaults({ env: vitehubEnv, waitUntil: vitehubWaitUntil })")
+    expect(nitroMiddleware).toContain("import { env as vitehubEnv, waitUntil as vitehubWaitUntil } from 'cloudflare:workers'")
+    expect(nitroMiddleware).toContain("Object.assign(event, { env: runtimeEvent.env")
   })
 
   it("keeps inferred Cloudflare queue prefixes aligned across bindings and runtime definitions", async () => {

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -20,6 +20,7 @@ type NuxtLike = {
 }
 
 type QueueNitroConfigHandler = (options: {
+  development?: boolean
   nitro: Record<string, unknown>
   projectRoot: string
   root: string
@@ -101,6 +102,7 @@ async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, u
     if (createQueueNitroConfig) {
       const projectRoot = nuxt.options.rootDir || process.cwd()
       config.nitro = await createQueueNitroConfig({
+        development: nuxt.options.dev,
         nitro: config.nitro || {},
         projectRoot,
         root: projectRoot,

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -202,6 +202,7 @@ describe("ViteHub Nuxt integration", () => {
       expect.anything(),
     )
     expect(mocks.existingQueueNitroConfig).toHaveBeenCalledWith({
+      development: true,
       nitro: expect.objectContaining({ preset: "cloudflare_module" }),
       projectRoot: "/tmp/vitehub-nuxt",
       root: "/tmp/vitehub-nuxt",


### PR DESCRIPTION
Cloudflare-targeted Queue apps generated deployment-only `cloudflare:workers` imports during ordinary Node development, so Nuxt/Nitro could not start outside the Cloudflare runtime.

This threads the framework's explicit development mode into Queue runtime generation. Development output keeps the Queue registry, consumer hook, and request-scoped H3 binding normalization, but omits Cloudflare global defaults. Production output is unchanged and still imports real Cloudflare bindings; a local enqueue without a real binding retains the existing `CLOUDFLARE_BINDING_RESOLUTION_REQUIRED` error.

## Validation

- `pnpm exec vp run build`
- `pnpm --filter @vite-hub/queue test` (134 tests)
- Queue and `vite-hub` typechecks
- `packages/vite-hub/test/nuxt.test.ts` (7 tests)
- Nuxt 5 nightly consumer through `vite-hub/nuxt`: Node dev server built, returned HTTP 200, and generated Queue runtime contained no `cloudflare:workers` import
