### PR TITLE
Add typed named-database lookup

### DIFF
--- a/docs/content/docs/concepts/server-primitives-for-any-host.md
+++ b/docs/content/docs/concepts/server-primitives-for-any-host.md
@@ -129,16 +129,15 @@ Create a Database Definition file that ViteHub discovers automatically. Its file
 Import the generated Runtime Helper in a server route and query the named database. ViteHub connects that call to the provider configured for the current environment.
 
 ```ts [server/api/notes.get.ts]
-import { databases } from '@vite-hub/database/drizzle'
+import { useDatabase } from '@vite-hub/database/drizzle'
 
 export default defineEventHandler(() => {
-  return databases.notes.db.select().from(databases.notes.schema.notes)
+  const { db, schema } = useDatabase('notes')
+  return db.select().from(schema.notes)
 })
 ```
 
 ::
-
-ViteHub discovers the Database Definition, generates the Drizzle Runtime Surface, and adapts the provider output for development and deployment. Other primitives follow the same shape, but their Definition locations and Runtime Helpers differ.
 
 ## Inspect the boundary
 

--- a/docs/content/docs/server-primitives/database.md
+++ b/docs/content/docs/server-primitives/database.md
@@ -162,10 +162,11 @@ export default defineDatabase({
 Named databases should represent real ownership or operational boundaries, not folder organization.
 
 ```ts [server/api/events.get.ts]
-import { databases } from '@vite-hub/database/drizzle'
+import { useDatabase } from '@vite-hub/database/drizzle'
 
 export default defineEventHandler(() => {
-  return databases.analytics.db.select().from(databases.analytics.schema.events)
+  const { db, schema } = useDatabase('analytics')
+  return db.select().from(schema.events)
 })
 ```
 

--- a/packages/database/src/drizzle-subpath.d.ts
+++ b/packages/database/src/drizzle-subpath.d.ts
@@ -1,6 +1,7 @@
 import "./virtual-module.d.ts"
 
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core"
+import databaseEntries from "#vitehub/database/databases"
 import schema from "#vitehub/database/schema"
 import type { AgentDatabaseHandle } from "./runtime/agent.js"
 
@@ -11,12 +12,22 @@ export interface RuntimeDatabaseEntry<TSchema extends Record<string, unknown>> {
   schema: TSchema
 }
 
+type RuntimeDatabaseRegistry = {
+  [Name in keyof typeof databaseEntries]: RuntimeDatabaseEntry<typeof databaseEntries[Name]["schema"]>
+}
+
+type RuntimeDatabaseSurface = RuntimeDatabaseRegistry & {
+  default: RuntimeDatabaseEntry<typeof schema>
+}
+
+type RuntimeDatabaseLookup = RuntimeDatabaseSurface & Record<string, RuntimeDatabaseEntry<Record<string, unknown>>>
+
 export * from "#vitehub/database/schema"
 export { schema }
 
-export declare const databases: Record<string, RuntimeDatabaseEntry<Record<string, unknown>>> & {
-  default: RuntimeDatabaseEntry<typeof schema>
-}
+export declare const databases: RuntimeDatabaseLookup
+
+export declare function useDatabase<Name extends keyof RuntimeDatabaseSurface>(name: Name): RuntimeDatabaseSurface[Name]
 
 export declare const db: DrizzleRuntimeDatabase<typeof schema>
 

--- a/packages/database/src/drizzle.ts
+++ b/packages/database/src/drizzle.ts
@@ -1,4 +1,5 @@
 import schema from "#vitehub/database/schema"
+import databaseEntries from "#vitehub/database/databases"
 import { databases as runtimeDatabases, db as runtimeDb } from "./runtime/drizzle-runtime.ts"
 import { createAgentDatabase } from "./runtime/agent.ts"
 
@@ -11,11 +12,23 @@ export interface RuntimeDatabaseEntry<TSchema extends Record<string, unknown>> {
   schema: TSchema
 }
 
-export const databases = runtimeDatabases as Record<string, RuntimeDatabaseEntry<Record<string, unknown>>> & {
+type RuntimeDatabaseRegistry = {
+  [Name in keyof typeof databaseEntries]: RuntimeDatabaseEntry<typeof databaseEntries[Name]["schema"]>
+}
+
+type RuntimeDatabaseSurface = RuntimeDatabaseRegistry & {
   default: RuntimeDatabaseEntry<typeof schema>
 }
 
+type RuntimeDatabaseLookup = RuntimeDatabaseSurface & Record<string, RuntimeDatabaseEntry<Record<string, unknown>>>
+
+export const databases = runtimeDatabases as RuntimeDatabaseLookup
+
 export const db = runtimeDb as DrizzleRuntimeDatabase<typeof schema>
+
+export function useDatabase<Name extends keyof RuntimeDatabaseSurface>(name: Name): RuntimeDatabaseSurface[Name] {
+  return databases[name]
+}
 
 export const agentDb = createAgentDatabase(databases)
 

--- a/packages/database/src/internal/generated.ts
+++ b/packages/database/src/internal/generated.ts
@@ -1,7 +1,7 @@
 import { mkdir, writeFile } from "node:fs/promises"
 
 import { createImportPath } from "@vite-hub/internal/build/paths"
-import { dirname } from "pathe"
+import { dirname, join } from "pathe"
 
 import { renderConfigValueExpression } from "../config-value.ts"
 
@@ -62,7 +62,40 @@ function renderGeneratedDrizzleConfig(config: ResolvedDBViteConfig, databaseName
   ].join("\n")
 }
 
+function renderGeneratedDatabaseTypes(file: string, definitions: DiscoveredDatabaseDefinition[]) {
+  const imports = definitions.map((definition, index) =>
+    `import type database_${index} from ${JSON.stringify(createImportPath(file, definition.handler))}`)
+  const schemaDefinitionIndex = Math.max(0, definitions.findIndex(definition => definition.name === "default"))
+  const schemaDefinition = definitions[schemaDefinitionIndex]!
+  const schemaFields = schemaDefinition.tableNames.map(tableName =>
+    `  ${JSON.stringify(tableName)}: typeof database_${schemaDefinitionIndex}.schema[${JSON.stringify(tableName)}]`)
+  const namedEntries = definitions.flatMap((definition, index) => definition.name === "default" ? [] : [
+    `    ${JSON.stringify(definition.name)}: {`,
+    `      config: import("@vite-hub/database").ResolvedDrizzleDatabaseConfig`,
+    `      schema: typeof database_${index}.schema`,
+    "    },",
+  ])
+
+  return [
+    ...imports,
+    "",
+    'declare module "#vitehub/database/schema" {',
+    ...schemaFields,
+    "}",
+    "",
+    'declare module "#vitehub/database/databases" {',
+    "  interface DatabaseRegistry {",
+    ...namedEntries,
+    "  }",
+    "}",
+    "",
+    "export {}",
+    "",
+  ].join("\n")
+}
+
 export async function writeGeneratedDatabaseArtifacts(config: ResolvedDBViteConfig) {
+  const generatedTypesFile = join(config.rootDir, ".vitehub/types/database.d.ts")
   await Promise.all(config.definitions.map(async (definition) => {
     const file = config.generatedSchemaFilesByDatabase[definition.name]!
     await mkdir(dirname(file), { recursive: true })
@@ -71,6 +104,8 @@ export async function writeGeneratedDatabaseArtifacts(config: ResolvedDBViteConf
 
   await mkdir(dirname(config.generatedDrizzleConfigFile), { recursive: true })
   await writeFile(config.generatedDrizzleConfigFile, renderGeneratedDrizzleConfig(config), "utf8")
+  await mkdir(dirname(generatedTypesFile), { recursive: true })
+  await writeFile(generatedTypesFile, renderGeneratedDatabaseTypes(generatedTypesFile, config.definitions), "utf8")
   await Promise.all(config.databaseNames.map(async (name) => {
     const file = config.generatedDrizzleConfigFilesByDatabase[name]!
     await mkdir(dirname(file), { recursive: true })

--- a/packages/database/src/runtime/drizzle-runtime.ts
+++ b/packages/database/src/runtime/drizzle-runtime.ts
@@ -60,7 +60,7 @@ function createRuntimeDatabase<TSchema extends Record<string, unknown>>(
   })
 }
 
-const runtimeEntries = databaseEntries as Record<string, RuntimeDatabaseModule>
+const runtimeEntries = databaseEntries as unknown as Record<string, RuntimeDatabaseModule>
 
 const resolvedDatabases = Object.fromEntries(
   Object.entries(runtimeEntries).map(([name, entry]) => [

--- a/packages/database/src/virtual-module.d.ts
+++ b/packages/database/src/virtual-module.d.ts
@@ -1,13 +1,22 @@
 declare module "#vitehub/database/schema" {
-  const schema: Record<string, unknown>
+  export interface DatabaseSchema {
+    [name: string]: unknown
+  }
+
+  const schema: DatabaseSchema
   export default schema
 }
 
 declare module "#vitehub/database/databases" {
-  const databases: Record<string, {
-    config: import("./types.ts").ResolvedDrizzleDatabaseConfig
-    schema: Record<string, unknown>
-  }>
+  export interface DatabaseRegistry {
+    default: {
+      config: import("./types.ts").ResolvedDrizzleDatabaseConfig
+      schema: import("#vitehub/database/schema").DatabaseSchema
+    }
+  }
+
+  const databases: DatabaseRegistry
+  export { databases }
   export default databases
 }
 

--- a/packages/database/test/runtime.test.ts
+++ b/packages/database/test/runtime.test.ts
@@ -239,9 +239,10 @@ describe("drizzle runtime", () => {
     const fetchMock = vi.fn()
     vi.stubGlobal("fetch", fetchMock)
 
-    const { databases, db } = await import("../src/drizzle.ts")
+    const { databases, db, useDatabase } = await import("../src/drizzle.ts")
 
     expect(db).toBe(databases.default.db)
+    expect((useDatabase as (name: string) => unknown)("analytics")).toBe(databases.analytics)
 
     await databases.default.db.run(sql`
       create table if not exists notes (

--- a/packages/database/test/types-published.test-d.ts
+++ b/packages/database/test/types-published.test-d.ts
@@ -1,11 +1,24 @@
 import { defineDatabase } from "@vite-hub/database"
-import { agentDb, db, databases, schema } from "@vite-hub/database/drizzle"
+import { agentDb, db, databases, schema, useDatabase } from "@vite-hub/database/drizzle"
 import { hubDb } from "@vite-hub/database/nuxt"
 import { sqliteTable, text } from "drizzle-orm/sqlite-core"
 
 import { describe, expectTypeOf, it } from "vitest"
 
 import type { Database, DatabaseNuxtIntegrationOptions } from "@vite-hub/database"
+
+const analyticsSchema = {
+  events: sqliteTable("events", { name: text("name").notNull() }),
+}
+
+declare module "#vitehub/database/databases" {
+  interface DatabaseRegistry {
+    analytics: {
+      config: import("@vite-hub/database").ResolvedDrizzleDatabaseConfig
+      schema: typeof analyticsSchema
+    }
+  }
+}
 
 describe("published package types", () => {
   it("resolves virtual schema types from the drizzle subpath without manual ambient imports", () => {
@@ -15,6 +28,9 @@ describe("published package types", () => {
     expectTypeOf(db).toMatchTypeOf<typeof databases.default.db>()
     expectTypeOf(agentDb.query).toBeFunction()
     expectTypeOf(agentDb.database("analytics").exec).toBeFunction()
+    expectTypeOf(useDatabase("analytics").schema.events).toEqualTypeOf(analyticsSchema.events)
+    // @ts-expect-error Unknown database names must be rejected by the generated registry.
+    useDatabase("missing")
   })
 
   it("returns a typed runtime database from defineDatabase", () => {

--- a/packages/database/test/vite.test.ts
+++ b/packages/database/test/vite.test.ts
@@ -328,6 +328,7 @@ describe("hubDb", () => {
     expect(databasesCode).toContain(definition)
     expect(databasesCode).toContain("\"default\"")
     expect(databasesCode).toContain("\"server/databases/migrations\"")
+    await expect(readFile(join(rootDir, ".vitehub/types/database.d.ts"), "utf8")).resolves.toContain('declare module "#vitehub/database/databases"')
   })
 
   it("refreshes generated artifacts during definition hot updates", async () => {


### PR DESCRIPTION
## Summary

Adds `useDatabase(name)` to `@vite-hub/database/drizzle`. The helper derives valid names and the selected `db`/`schema` types from the generated database registry, while the existing `databases` lookup remains available.

The Vite database integration now emits the literal registry and schema declarations needed for that inference. The concept and database pages use the helper as the canonical named-database example.

## Verification

- `node_modules/typescript/bin/tsc --noEmit -p packages/database/tsconfig.json`
- Standalone TypeScript probe confirms `useDatabase("notes")` preserves the selected schema and rejects `useDatabase("missing")`.
- Runtime and package build tests were not run because this isolated worktree has no complete dependency install and the available ambient Vite cache is read-only; network installs were intentionally avoided.

## Review boundary

This PR is intentionally based on the WIP `docs/concepts-glossary-rewrite` branch and is separate from WIP #911 so the API/docs improvement can be reviewed independently.

