### PR TITLE
fix(agent): type and validate chat routes

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -28,6 +28,8 @@ export default defineAgent({
 
 Built-in helpers include `discord()`, `github()`, `http()`, `slack()`, `teams()`, `telegram()`, and `webChat()`. Under a canonical built-in key, pass options directly, such as `channels: { telegram: { messages: { delivery: 'manual' } } }`. A custom Channel id still uses a definition or synchronous factory, so `channels: { portal: webChat }` is equivalent to `channels: { portal: webChat() }`. Use `defineChannel(kind, options)` for an app-owned Channel Kind.
 
+Use `webChat()` for a generated AI SDK chat route; it enables `route` by default and records the `web-chat` Channel Kind. Use `http()` for a generic HTTP Channel; it keeps `route` disabled unless you pass `http({ route: true })` or route options explicitly. Both route-enabled forms use the same request and streaming-response contract, while their distinct Channel Kinds keep invocation origin and delivery semantics honest.
+
 Adapter-backed Channels deliver only the completed response by default. Set top-level `defineAgent({ messages: { stream: true } })` to opt every adapter Channel into draft and edit updates, or set `messages.stream` on an individual Channel to control progressive delivery for that destination. Web Chat routes return streaming HTTP responses independently of adapter delivery settings.
 
 On Cloudflare, ViteHub reserves the final two seconds of the 30-second background execution window for an adapter-backed Channel's configured error fallback and cleanup. Webhook setup, Agent Invocation, output consumption, progress updates, and normal delivery share the first 28 seconds. The deadline is absolute from webhook entry: late output is discarded, and ViteHub removes late messages when the adapter returns enough ownership to do so.
@@ -278,7 +280,9 @@ export default defineAgent({
 })
 ```
 
-ViteHub reads the raw request body once, parses the JSON object, runs `authenticate` with `rawBody`, then validates `admission.body` when a Standard Schema is provided. `input.trust` lists request body fields that may be copied after authentication. Add `timeout` only when authenticated callers may control Agent Invocation duration; ViteHub forwards positive, finite numeric values and ignores invalid timeouts. Use `admission.context` only when the route needs to derive or validate different `chat.message` input.
+ViteHub reads the raw request body once and runs `authenticate` with `rawBody`. It then requires a non-empty `messages` array containing `user` or `assistant` messages, accepts optional string `id`, `messageId`, and `trigger` fields, and passes additional AI SDK fields unchanged to admission validation. An `admission.body` Standard Schema adds product-specific validation to that shared contract instead of recreating it.
+
+`input.trust` lists request body fields that may be copied after authentication. Add `timeout` only when authenticated callers may control Agent Invocation duration; ViteHub forwards positive, finite numeric values and ignores invalid timeouts. Use `admission.context` only when the route needs to derive or validate different `chat.message` input.
 
 ## Add identity separately
 

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -96,12 +96,17 @@ export type {
   AgentMessageChannelSettings,
   PublishedAgentDeliveryArtifact,
 } from "./types.ts"
-export interface AgentChannelOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+export interface AgentChannelOptions<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody,
+  TAuth = unknown,
+> {
   adapter?: AgentChannelDefinition<TRuntimeConfig>["adapter"]
   capabilities?: AgentChannelDefinition<TRuntimeConfig>["capabilities"]
   effects?: AgentChannelDefinition<TRuntimeConfig>["effects"]
   identity?: AgentChannelDefinition<TRuntimeConfig>["identity"]
   messages?: false | AgentMessageChannelSettings<TRuntimeConfig>
+  route?: boolean | AgentChannelChatRouteHandlerOptions<TBody, TAuth>
   triggers?: AgentChannelDefinition<TRuntimeConfig>["triggers"]
   webhooks?: AgentChannelDefinition<TRuntimeConfig>["webhooks"]
 }
@@ -113,9 +118,7 @@ export interface AgentWebChatChannelOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody,
   TAuth = unknown,
-> extends AgentChannelOptions<TRuntimeConfig> {
-  route?: boolean | AgentChannelChatRouteHandlerOptions<TBody, TAuth>
-}
+> extends AgentChannelOptions<TRuntimeConfig, TBody, TAuth> {}
 
 type GitHubAppValue<T, TRuntimeConfig extends AgentRuntimeConfig> =
   MaybeResolvable<T, AgentCallbackContext<TRuntimeConfig> | AgentChannelDeliveryEffectContext<TRuntimeConfig>>
@@ -2037,8 +2040,12 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
   })
 }
 
-export function http<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
-  options: AgentChannelOptions<TRuntimeConfig> = {},
+export function http<
+  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
+  TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody,
+  TAuth = unknown,
+>(
+  options: AgentChannelOptions<TRuntimeConfig, TBody, TAuth> = {},
 ): AgentChannelDefinition<TRuntimeConfig> {
   if ("path" in options) {
     throw new TypeError("[vitehub] http({ path }) is not wired yet. Webhook routes are configured with webhooks.path.")

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2936,25 +2936,12 @@ async function parseAgentChannelChatRouteBody(request: Request): Promise<{ body:
   if (!raw.trim()) throw createRouteBodyError("Missing agent chat payload.")
   try {
     const body = JSON.parse(raw) as AgentChannelChatRouteBody
-    if (!isRecord(body)) throw createRouteBodyError("Agent chat payload must be a JSON object.")
+    if (!isRecord(body) || Array.isArray(body)) throw createRouteBodyError("Agent chat payload must be a JSON object.")
     return { body, rawBody: raw }
   }
   catch (error) {
     if (error instanceof Error && "statusCode" in error) throw error
     throw createRouteBodyError("Malformed agent chat payload.")
-  }
-}
-
-async function parseAgentChannelChatRouteAdmissionBody<TBody extends AgentChannelChatRouteBody>(
-  body: AgentChannelChatRouteBody,
-  schema: AgentChannelChatRouteStandardSchemaV1<TBody> | undefined,
-): Promise<TBody> {
-  if (!schema) return body as TBody
-  try {
-    return await parseStandardSchema(schema, body, "agent chat route body")
-  }
-  catch (error) {
-    throw createRouteBodyError(error instanceof Error ? error.message : "Invalid agent chat route body.")
   }
 }
 
@@ -2971,19 +2958,51 @@ function optionalBodyString(value: unknown, label: string): string | undefined {
   return trimmed || undefined
 }
 
+function validateAgentChannelChatRouteBody(body: AgentChannelChatRouteBody): AgentChannelChatRouteBody & { messages: UIMessage[] } {
+  optionalBodyString(body.id, "id")
+  optionalBodyString(body.messageId, "messageId")
+  optionalBodyString(body.trigger, "trigger")
+  if (!Array.isArray(body.messages)) {
+    throw createRouteBodyError("Agent chat payload requires a messages array.")
+  }
+  if (!body.messages.length) {
+    throw createRouteBodyError("Agent chat payload requires at least one message.")
+  }
+  for (const [index, message] of body.messages.entries()) {
+    if (!isRecord(message) || Array.isArray(message)) {
+      throw createRouteBodyError(`Agent chat payload message ${index + 1} must be an object.`)
+    }
+    if (message.role !== "user" && message.role !== "assistant") {
+      throw createRouteBodyError(`Agent chat payload message ${index + 1} role must be "user" or "assistant".`)
+    }
+  }
+  return body as AgentChannelChatRouteBody & { messages: UIMessage[] }
+}
+
+async function parseAgentChannelChatRouteAdmissionBody<TBody extends AgentChannelChatRouteBody>(
+  body: AgentChannelChatRouteBody,
+  schema: AgentChannelChatRouteStandardSchemaV1<TBody> | undefined,
+): Promise<TBody> {
+  const validatedBody = validateAgentChannelChatRouteBody(body)
+  if (!schema) return validatedBody as TBody
+  try {
+    return await parseStandardSchema(schema, validatedBody, "agent chat route body")
+  }
+  catch (error) {
+    throw createRouteBodyError(error instanceof Error ? error.message : "Invalid agent chat route body.")
+  }
+}
+
 function agentChannelChatRouteInput(
   body: AgentChannelChatRouteBody,
   agentName: string,
   allowTrustedInput = false,
   options: Pick<AgentChannelChatRouteHandlerOptions, "channelId" | "origin"> = {},
 ): AgentChatMessageTriggerInput {
-  if (!Array.isArray(body.messages)) {
-    throw createRouteBodyError("Agent chat payload requires a messages array.")
-  }
+  const { messages } = validateAgentChannelChatRouteBody(body)
   if (!allowTrustedInput && ("invoker" in body || "invokerProfileId" in body || "meta" in body || "run" in body || "session" in body || "timeout" in body || "user" in body)) {
     throw createRouteBodyError("Agent chat route identity must be derived server-side with defineAgent({ invoker }).")
   }
-  const messages = body.messages as UIMessage[]
   return {
     messages,
     run: createHttpChatRunMetadata(agentName, body, messages, options),

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2660,7 +2660,7 @@ describe("server helpers", () => {
     }))
   })
 
-  it("returns a validation error for malformed AI SDK chat requests", async () => {
+  it("validates the standard AI SDK chat request envelope", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
@@ -2669,15 +2669,82 @@ describe("server helpers", () => {
       driver: { run: () => "unused" },
     }) as never)
 
-    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
-      body: JSON.stringify({ text: "hello" }),
-      method: "POST",
-    }))
+    const invalidBodies = [
+      [[], "Agent chat payload must be a JSON object."],
+      [{ text: "hello" }, "Agent chat payload requires a messages array."],
+      [{ messages: [] }, "Agent chat payload requires at least one message."],
+      [{ messages: [null] }, "Agent chat payload message 1 must be an object."],
+      [{ messages: [{ role: "system" }] }, 'Agent chat payload message 1 role must be "user" or "assistant".'],
+      [{ id: 1, messages: [{ role: "user" }] }, "id must be a string when provided."],
+      [{ messageId: 1, messages: [{ role: "user" }] }, "messageId must be a string when provided."],
+      [{ messages: [{ role: "user" }], trigger: 1 }, "trigger must be a string when provided."],
+    ] as const
 
-    expect(response.status).toBe(400)
-    await expect(response.json()).resolves.toMatchObject({
-      error: "Agent chat payload requires a messages array.",
+    for (const [body, error] of invalidBodies) {
+      const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+        body: JSON.stringify(body),
+        method: "POST",
+      }))
+
+      expect(response.status).toBe(400)
+      await expect(response.json()).resolves.toMatchObject({ error })
+    }
+  })
+
+  it("serves explicit HTTP chat routes and preserves request extensions for admission", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { http } = await import("../src/channels.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
+    const message = {
+      custom: { source: "portal" },
+      id: "user-1",
+      metadata: { customer: "acme" },
+      parts: [{ text: "hello", type: "text" }],
+      role: "user",
+    }
+    const authenticate = vi.fn(({ body, rawBody }) => {
+      expect(body).toMatchObject({ extension: { requestId: "request-1" }, messages: [message] })
+      expect(rawBody).toContain('"requestId":"request-1"')
+      return true
     })
+    const validate = vi.fn((input: unknown) => {
+      expect(input).toMatchObject({ extension: { requestId: "request-1" }, messages: [message] })
+      return { value: input as { messages: unknown[] } }
+    })
+    const run = vi.fn(({ messages, run }) => `${run.messageId} ${run.threadId} ${JSON.stringify(messages)}`)
+    const handler = createChannelChatRouteHandler(defineAgent({
+      channels: {
+        portal: http({
+          route: {
+            admission: {
+              authenticate,
+              body: { "~standard": { validate } },
+            },
+          },
+        }),
+      },
+      driver: { run },
+    }) as never)
+
+    const response = await handler(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        extension: { requestId: "request-1" },
+        id: "portal-thread",
+        messageId: "request-message",
+        messages: [message],
+        trigger: "submit-message",
+      }),
+      method: "POST",
+    }), { agentName: "support" })
+
+    expect(response.status).toBe(200)
+    await expect(response.text()).resolves.toContain("request-message portal:portal-thread")
+    expect(authenticate).toHaveBeenCalledOnce()
+    expect(validate).toHaveBeenCalledOnce()
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({
+      messages: [expect.objectContaining({ id: "user-1", metadata: { customer: "acme" }, role: "user" })],
+      run: expect.objectContaining({ messageId: "request-message", origin: "http", threadId: "portal:portal-thread" }),
+    }))
   })
 
   it("rejects client-provided protected input on generated AI SDK chat routes", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1218,6 +1218,24 @@ describe("agent public types", () => {
         }),
         portal: http({
           adapter: () => ({}) as never,
+          route: {
+            admission: {
+              body: {
+                "~standard": {
+                  validate: (input: unknown) => ({
+                    value: input as { messages: unknown[], tenant: string },
+                  }),
+                },
+              },
+              authenticate() {
+                return { subject: "customer:acme" }
+              },
+              context({ auth, body }) {
+                expectTypeOf(auth.subject).toEqualTypeOf<string>()
+                expectTypeOf(body.tenant).toEqualTypeOf<string>()
+              },
+            },
+          },
           webhooks: { path: "/api/support/chat" },
         }),
         teams: teams({


### PR DESCRIPTION
## Summary

- expose the existing generated chat `route` option through generic `AgentChannelOptions`, so explicit `http({ route })` callers retain admission body and authentication inference
- validate the shared chat envelope after raw-body authentication: optional `id`, `messageId`, and `trigger` strings, a non-empty `messages` array, and public `user` or `assistant` roles
- keep extra request fields intact for additive Standard Schema validation, and document why `http()` and `webChat()` remain distinct Channel Kinds with different route defaults

## Why

`http()` and `webChat()` reach the same generated UI-message route handler, but repository history and current behavior do not support treating them as aliases. `webChat()` deliberately enables the route by default and records the `web-chat` origin, while `http()` remains a generic HTTP Channel whose route is explicit. Those Kinds flow into invocation origin, identity, rate-limit, and webhook behavior, so this preserves the distinction established in [#598](https://github.com/vite-hub/vitehub/pull/598).

The request envelope is common ViteHub protocol rather than application policy. Applications can now remove duplicate loose schemas for the standard AI SDK body and keep admission focused on authentication, trusted context, and any product-specific validation.

## Verification

Passed:

- `pnpm exec vp run -t @vite-hub/agent#build`
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm exec vp test test/providers.test.ts` (219 tests)
- `pnpm exec vp test test/tutorial-fixture.test.ts`
- full Agent run: 1,734 tests passed before isolating its two unrelated failures; the tutorial fixture passed after building its separate `vite-hub` dependency

`test/box.test.ts` still fails at the existing concurrent colocated-skill installation assertion. The same failure reproduces from the untouched `origin/main` commit `9cc43afb` in a separate worktree, so it is not caused by this diff.
