### PR TITLE
fix(agent): preserve Nuxt chat route context

### DIFF
--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -105,6 +105,7 @@ export interface AgentTelegramPollingRouteOptions extends AgentRouteRuntimeOptio
 
 export interface AgentChannelChatRouteRequestOptions extends AgentRouteRuntimeOptions {
   agentName?: string
+  event?: unknown
 }
 
 export interface AgentChannelChatRouteStandardSchemaResultSuccess<T = unknown> {
@@ -125,6 +126,7 @@ export interface AgentChannelChatRouteStandardSchemaV1<T = unknown> {
 export interface AgentChannelChatRouteAdmissionContext<TBody extends AgentChannelChatRouteBody = AgentChannelChatRouteBody> {
   agentName: string
   body: TBody
+  event?: unknown
   rawBody: string
   request: Request
 }
@@ -203,7 +205,9 @@ function firstString(...values: unknown[]): string | undefined {
 
 function readableStreamFromResult(value: unknown): ReadableStream<unknown> {
   if (value instanceof ReadableStream) return value
+  if (isRecord(value) && typeof value.getReader === "function") return value as unknown as ReadableStream<unknown>
   if (value instanceof Response && value.body) return value.body
+  if (isRecord(value) && isRecord(value.body) && typeof value.body.getReader === "function") return value.body as unknown as ReadableStream<unknown>
   throw new Error("[vitehub] Agent chat trigger expected a UI message stream.")
 }
 
@@ -3513,7 +3517,9 @@ function mergeAgentChannelChatRouteInput(
 }
 
 async function toAgentChatFetchResponse(result: unknown): Promise<Response> {
-  if (result instanceof Response) return withCleanUiMessageStreamResponse(result)
+  if (result instanceof Response || (isRecord(result) && isRecord(result.body) && typeof result.body.getReader === "function" && isRecord(result.headers) && typeof result.headers.get === "function")) {
+    return withCleanUiMessageStreamResponse(result as Response)
+  }
   return createAgentUIMessageStreamResponse({ stream: readableStreamFromResult(result) })
 }
 
@@ -3537,7 +3543,7 @@ export function createChannelChatRouteHandler(
       const parsed = await parseAgentChannelChatRouteBody(request)
       const agentIdentity = routeAgentIdentity(handlerOptions)
       const agentName = agentIdentity?.name || "agent"
-      const auth = await routeOptions.admission?.authenticate?.({ agentName, body: parsed.body, rawBody: parsed.rawBody, request })
+      const auth = await routeOptions.admission?.authenticate?.({ agentName, body: parsed.body, event: handlerOptions.event, rawBody: parsed.rawBody, request })
       if (auth === false) throw createRouteError(401, "Agent chat route request was not admitted.")
       const body = await parseAgentChannelChatRouteAdmissionBody(parsed.body, routeOptions.admission?.body)
       const context = createRuntimeContext(
@@ -3555,7 +3561,7 @@ export function createChannelChatRouteHandler(
         baseInput,
         trustInput ? trustAgentChannelChatRouteInput(body, routeOptions.input) : undefined,
       )
-      const inputContext = { agentName, auth: auth as never, body, input: trustedInput, rawBody: parsed.rawBody, request }
+      const inputContext = { agentName, auth: auth as never, body, event: handlerOptions.event, input: trustedInput, rawBody: parsed.rawBody, request }
       const admittedInput = mergeAgentChannelChatRouteInput(
         trustedInput,
         await routeOptions.admission?.context?.(inputContext),

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -203,11 +203,30 @@ function firstString(...values: unknown[]): string | undefined {
   return values.find((value): value is string => typeof value === "string" && value.length > 0)
 }
 
+function isReadableStreamLike(value: unknown): value is ReadableStream<unknown> {
+  return isRecord(value)
+    && typeof value.getReader === "function"
+    && typeof value.pipeThrough === "function"
+}
+
+function isHeadersLike(value: unknown): value is Headers {
+  return isRecord(value)
+    && typeof value.entries === "function"
+    && typeof value.get === "function"
+}
+
+function isResponseLike(value: unknown): value is Response & { body: ReadableStream<unknown> } {
+  return isRecord(value)
+    && isReadableStreamLike(value.body)
+    && isHeadersLike(value.headers)
+    && typeof value.status === "number"
+    && typeof value.statusText === "string"
+}
+
 function readableStreamFromResult(value: unknown): ReadableStream<unknown> {
-  if (value instanceof ReadableStream) return value
-  if (isRecord(value) && typeof value.getReader === "function") return value as unknown as ReadableStream<unknown>
+  if (value instanceof ReadableStream || isReadableStreamLike(value)) return value
   if (value instanceof Response && value.body) return value.body
-  if (isRecord(value) && isRecord(value.body) && typeof value.body.getReader === "function") return value.body as unknown as ReadableStream<unknown>
+  if (isResponseLike(value)) return value.body
   throw new Error("[vitehub] Agent chat trigger expected a UI message stream.")
 }
 
@@ -222,7 +241,7 @@ function withCleanUiMessageStreamResponse(response: Response): Response {
   const decoder = new TextDecoder()
   const reader = response.body.getReader()
   let tail = ""
-  const headers = new Headers(response.headers)
+  const headers = new Headers([...response.headers.entries()])
   headers.delete("content-encoding")
   headers.delete("content-length")
 
@@ -3517,8 +3536,8 @@ function mergeAgentChannelChatRouteInput(
 }
 
 async function toAgentChatFetchResponse(result: unknown): Promise<Response> {
-  if (result instanceof Response || (isRecord(result) && isRecord(result.body) && typeof result.body.getReader === "function" && isRecord(result.headers) && typeof result.headers.get === "function")) {
-    return withCleanUiMessageStreamResponse(result as Response)
+  if (result instanceof Response || isResponseLike(result)) {
+    return withCleanUiMessageStreamResponse(result)
   }
   return createAgentUIMessageStreamResponse({ stream: readableStreamFromResult(result) })
 }

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1250,7 +1250,7 @@ async function generateAgentWebhookRouteHandler(
       ? [
           "  const handler = chatHandlers[agent]",
           "  if (!handler) throw createError({ statusCode: 404, statusMessage: 'Unknown ViteHub agent.' })",
-          `  return await handler(await toRequest(event), { agentIdentity: agentIdentities[agent], ${routeCapabilities.requestOption}cloudflare${runtimeRouteOption}, waitUntil: waitUntilFromEvent(event) })`,
+          `  return await handler(await toRequest(event), { agentIdentity: agentIdentities[agent], ${routeCapabilities.requestOption}cloudflare${runtimeRouteOption}, event, waitUntil: waitUntilFromEvent(event) })`,
         ]
       : [
           "  throw createError({ statusCode: 404, statusMessage: 'Unknown ViteHub agent.' })",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1491,6 +1491,7 @@ describe("agent Vite plugin", () => {
       expect(webhookRoute).toContain("const webhookRoutePattern")
       expect(webhookRoute).toContain("const agent = getRouterParam(event, 'agent') || (agentNames.length === 1 ? agentNames[0] : undefined)")
       expect(webhookRoute).toContain("return await handler(await toRequest(event), webhook")
+      expect(webhookRoute).toContain("return await handler(await toRequest(event), { agentIdentity: agentIdentities[agent], cloudflare, runtime: 'vite', event, waitUntil: waitUntilFromEvent(event) })")
       expect(webhookRoute).not.toContain("@vite-hub/schedule/runtime")
     }
     finally {
@@ -2376,6 +2377,55 @@ describe("server helpers", () => {
     await expect(response.text()).resolves.toBe("event: custom\ndata: ok\n\n")
   })
 
+  it("accepts UI message streams and Responses from another runtime realm", async () => {
+    const agentModule = await import("../src/index.ts")
+    const { defineAgent } = agentModule
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue({ textDelta: "hello", type: "text-delta" })
+        controller.close()
+      },
+    })
+    const foreignStream = {
+      getReader: stream.getReader.bind(stream),
+      pipeThrough: stream.pipeThrough.bind(stream),
+      [Symbol.asyncIterator]: stream[Symbol.asyncIterator].bind(stream),
+    }
+    const foreignResponse = {
+      body: new Response("data: {\"type\":\"finish\"}\n\n").body,
+      headers: new Headers({
+        "content-type": "text/event-stream",
+        "x-vercel-ai-ui-message-stream": "v1",
+      }),
+      status: 202,
+      statusText: "Accepted",
+    }
+    expect(foreignStream).not.toBeInstanceOf(ReadableStream)
+    expect(foreignResponse).not.toBeInstanceOf(Response)
+    const streamAgentTrigger = vi.spyOn(agentModule, "streamAgentTrigger")
+      .mockResolvedValueOnce(foreignStream as never)
+      .mockResolvedValueOnce(foreignResponse as never)
+    const handler = createChannelChatRouteHandler(defineAgent({
+      capabilities: [defineChatCapability()],
+      driver: { run: () => "unused" },
+    }) as never)
+    const request = () => new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({ messages: [{ parts: [{ text: "hello", type: "text" }], role: "user" }] }),
+      method: "POST",
+    })
+
+    const streamResponse = await handler(request(), { agentName: "support" })
+    expect(streamResponse.status).toBe(200)
+    await expect(streamResponse.text()).resolves.toContain('"textDelta":"hello"')
+
+    const response = await handler(request(), { agentName: "support" })
+    expect(response.status).toBe(202)
+    await expect(response.text()).resolves.toBe("data: {\"type\":\"finish\"}\n\ndata: [DONE]\n\n")
+    streamAgentTrigger.mockRestore()
+  })
+
   it("appends DONE to UI message chat Response bodies and drops stale body headers", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
@@ -2563,7 +2613,9 @@ describe("server helpers", () => {
         },
       },
     }
-    const authenticate = vi.fn(({ rawBody, request }) => {
+    const hostEvent = { context: { tenant: "acme" } }
+    const authenticate = vi.fn(({ event, rawBody, request }) => {
+      expect(event).toBe(hostEvent)
       expect(rawBody.length).toBeGreaterThan(0)
       return request.headers.get("x-quiver-chat-token") === "trusted"
         ? { invokerProfileId: "customer:acme" }
@@ -2580,7 +2632,8 @@ describe("server helpers", () => {
             admission: {
               body: bodySchema,
               authenticate,
-              context({ auth, body }) {
+              context({ auth, body, event }) {
+                expect(event).toBe(hostEvent)
                 return {
                   invokerProfileId: auth.invokerProfileId,
                   meta: body.meta,
@@ -2588,6 +2641,9 @@ describe("server helpers", () => {
                   user: body.user,
                 }
               },
+            },
+            mapInput({ event }) {
+              expect(event).toBe(hostEvent)
             },
           },
         }),
@@ -2620,7 +2676,7 @@ describe("server helpers", () => {
         "x-quiver-chat-token": "trusted",
       },
       method: "POST",
-    }), { agentName: "support" })
+    }), { agentName: "support", event: hostEvent })
 
     expect(response.status).toBe(200)
     expect(response.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1")
@@ -2642,7 +2698,7 @@ describe("server helpers", () => {
         "x-quiver-chat-token": "trusted",
       },
       method: "POST",
-    }), { agentName: "support" })
+    }), { agentName: "support", event: hostEvent })
 
     expect(malformedResponse.status).toBe(400)
     expect(authenticate).toHaveBeenCalledWith(expect.objectContaining({
@@ -2662,7 +2718,7 @@ describe("server helpers", () => {
       }),
       headers: { "x-quiver-chat-token": "nope" },
       method: "POST",
-    }), { agentName: "support" })
+    }), { agentName: "support", event: hostEvent })
 
     expect(rejectedResponse.status).toBe(401)
     await expect(rejectedResponse.json()).resolves.toMatchObject({

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2393,12 +2393,16 @@ describe("server helpers", () => {
       pipeThrough: stream.pipeThrough.bind(stream),
       [Symbol.asyncIterator]: stream[Symbol.asyncIterator].bind(stream),
     }
+    const responseHeaders = new Headers({
+      "content-type": "text/event-stream",
+      "x-vercel-ai-ui-message-stream": "v1",
+    })
     const foreignResponse = {
       body: new Response("data: {\"type\":\"finish\"}\n\n").body,
-      headers: new Headers({
-        "content-type": "text/event-stream",
-        "x-vercel-ai-ui-message-stream": "v1",
-      }),
+      headers: {
+        entries: responseHeaders.entries.bind(responseHeaders),
+        get: responseHeaders.get.bind(responseHeaders),
+      },
       status: 202,
       statusText: "Accepted",
     }

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1249,8 +1249,9 @@ describe("agent public types", () => {
         }),
         portalWeb: webChat({
           route: {
-            mapInput({ body, request }) {
+            mapInput({ body, event, request }) {
               expectTypeOf(body.messages).toEqualTypeOf<unknown>()
+              expectTypeOf(event).toEqualTypeOf<unknown>()
               expectTypeOf(request).toEqualTypeOf<Request>()
               return { meta: body.meta as Record<string, unknown> }
             },
@@ -1266,16 +1267,18 @@ describe("agent public types", () => {
                   }),
                 },
               },
-              authenticate({ body, rawBody, request }) {
+              authenticate({ body, event, rawBody, request }) {
                 expectTypeOf(body.messages).toEqualTypeOf<unknown>()
+                expectTypeOf(event).toEqualTypeOf<unknown>()
                 expectTypeOf(rawBody).toEqualTypeOf<string>()
                 expectTypeOf(request).toEqualTypeOf<Request>()
                 return { invokerProfileId: "customer:acme" }
               },
-              context({ auth, body, rawBody }) {
+              context({ auth, body, event, rawBody }) {
                 expectTypeOf(auth.invokerProfileId).toEqualTypeOf<string>()
                 expectTypeOf(body.meta.customer).toEqualTypeOf<string>()
                 expectTypeOf(body.user.email).toEqualTypeOf<string>()
+                expectTypeOf(event).toEqualTypeOf<unknown>()
                 expectTypeOf(rawBody).toEqualTypeOf<string>()
                 return {
                   invokerProfileId: auth.invokerProfileId,


### PR DESCRIPTION
## Summary

- forward the Nitro host event through generated chat handlers into authentication, admission context, and input mapping
- accept readable-stream and UI-message Response shapes across JavaScript realms without relying only on constructor identity
- keep native Web responses on the existing cleanup path, including stale body-header removal and the terminal `[DONE]` frame

## Why

Quiver Portal's Ask AI route crosses the Nuxt/Nitro runtime boundary. The converted Web `Request` preserves HTTP data, but admission also needs the original H3 event for host-owned context. The returned UI message stream can originate in a different runtime realm, where a valid `ReadableStream` or `Response` fails the local `instanceof` check.

This keeps both fixes in the shared Agent route boundary. PR #914 already owns request-envelope typing and validation, so this change leaves that behavior untouched.

## Boundary

The host event remains `unknown` and chat-specific, so H3 types do not leak into ViteHub's host-independent server API. Structural Response recognition requires both a readable body and Headers-compatible `get`; other route families, generated-root placement, and Harness/Codex bundling are unchanged.

## Verification

- focused Agent server-route tests for non-`instanceof` streams and Responses, plus event identity in authentication/context/mapInput
- focused generated Nitro handler assertion
- `corepack pnpm --filter @vite-hub/agent typecheck`
- `corepack pnpm --filter @vite-hub/agent build` (includes publint)
- changed-file `vp lint` passes with only existing warnings outside this diff

A disposable Portal rebuild was not repeated because the shared workspace was under disk pressure; the focused regressions cover the exact downstream patch seams.