### PR TITLE
fix(database): merge Cloudflare runtime bindings

### DIFF
--- a/packages/database/src/nuxt.ts
+++ b/packages/database/src/nuxt.ts
@@ -327,7 +327,7 @@ async function installNitroCloudflareEnvBridge(config: Record<string, unknown>, 
     "",
     "export default (event: unknown) => {",
     "  const target = event as { env?: Record<string, unknown>, context?: { cloudflare?: { env?: Record<string, unknown> }, _platform?: { cloudflare?: { env?: Record<string, unknown> } } }, req?: { runtime?: { cloudflare?: { env?: Record<string, unknown> } } } }",
-    "  setActiveCloudflareEnv(target.env ?? target.context?.cloudflare?.env ?? target.context?._platform?.cloudflare?.env ?? target.req?.runtime?.cloudflare?.env ?? (vitehubEnv as unknown as Record<string, unknown>))",
+    "  setActiveCloudflareEnv({ ...(vitehubEnv as unknown as Record<string, unknown>), ...target.req?.runtime?.cloudflare?.env, ...target.context?._platform?.cloudflare?.env, ...target.context?.cloudflare?.env, ...target.env })",
     "}",
     "",
   ].join("\n"))

--- a/packages/database/test/nuxt.test.ts
+++ b/packages/database/test/nuxt.test.ts
@@ -1,12 +1,25 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
+import { pathToFileURL } from "node:url"
 
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { hubDb } from "../src/nuxt.ts"
 
 import type { Plugin } from "vite"
+
+const cloudflareBridgeState = vi.hoisted(() => ({
+  activeEnv: undefined as Record<string, unknown> | undefined,
+  fallbackEnv: { FALLBACK: "fallback", SHARED: "fallback" },
+}))
+
+vi.mock("cloudflare:workers", () => ({ env: cloudflareBridgeState.fallbackEnv }))
+vi.mock("@vite-hub/database/runtime/state", () => ({
+  setActiveCloudflareEnv: (env: Record<string, unknown>) => {
+    cloudflareBridgeState.activeEnv = env
+  },
+}))
 
 function createNuxt(options: Record<string, unknown>) {
   const hooks: Record<string, ((value: Record<string, unknown>) => Promise<void> | void)[]> = {}
@@ -152,6 +165,44 @@ describe("Database Nuxt integration", () => {
     const middleware = await readFile("/tmp/vitehub-db-nuxt/.vitehub/nitro/database/middleware.ts", "utf8")
     expect(middleware).toContain("setActiveCloudflareEnv")
     expect(middleware).toContain("vitehubEnv as unknown as Record<string, unknown>")
+  })
+
+  it("merges split Cloudflare bindings with request-local precedence", async () => {
+    const rootDir = process.cwd()
+    const middlewarePath = join(rootDir, ".vitehub/nitro/database/middleware.ts")
+    try {
+      const { hooks, nuxt } = createNuxt({
+        dev: false,
+        nitro: { preset: "cloudflare_module" },
+        rootDir,
+        vite: {},
+      })
+
+      await hubDb()(undefined, nuxt)
+      await callHook(hooks, "nitro:config", {})
+
+      const middleware = (await import(`${pathToFileURL(middlewarePath).href}?t=${Date.now()}`)).default
+      middleware({
+        context: {
+          _platform: { cloudflare: { env: { PLATFORM: "platform", SHARED: "platform" } } },
+          cloudflare: { env: { CONTEXT: "context", SHARED: "context" } },
+        },
+        env: { EVENT: "event", SHARED: "event" },
+        req: { runtime: { cloudflare: { env: { REQUEST: "request", SHARED: "request" } } } },
+      })
+
+      expect(cloudflareBridgeState.activeEnv).toEqual({
+        CONTEXT: "context",
+        EVENT: "event",
+        FALLBACK: "fallback",
+        PLATFORM: "platform",
+        REQUEST: "request",
+        SHARED: "event",
+      })
+    }
+    finally {
+      await rm(middlewarePath, { force: true })
+    }
   })
 
   it("aliases the hosted runtime from the Nuxt source directory", async () => {


### PR DESCRIPTION
## What changed

The generated Nitro Cloudflare database middleware now merges bindings from `cloudflare:workers`, `req.runtime.cloudflare.env`, `context._platform.cloudflare.env`, `context.cloudflare.env`, and `event.env`. Later request-specific sources override fallback values, so partial carriers no longer hide bindings supplied elsewhere.

This is a narrow follow-up to #888: it preserves that PR’s typed environment bridge and changes only how the existing bridge composes runtime bindings.

## Boundary

This PR does not change Auth Vue, local database development, D1 migration discovery, generated-root placement, or the shared Cloudflare environment helper.

## Verification

- Generated-middleware runtime regression proving split bindings survive and `event.env` wins collisions
- `@vite-hub/database` tests: 104 passed
- `@vite-hub/database` typecheck
- Database build and publint
- Changed-file oxlint and `git diff --check`
- Independent base-vs-head code review: no actionable findings
