### PR TITLE
fix(database): support Nuxt local runtime

### DIFF
--- a/packages/database/src/internal/runtime-module.ts
+++ b/packages/database/src/internal/runtime-module.ts
@@ -1,0 +1,28 @@
+interface RenderDatabaseRuntimeModuleOptions {
+  createAgentDatabaseImport: string
+  databaseEntries: string[]
+  imports: string[]
+}
+
+export function renderDatabaseRuntimeModule(options: RenderDatabaseRuntimeModuleOptions): string {
+  return [
+    `import { createAgentDatabase } from ${JSON.stringify(options.createAgentDatabaseImport)}`,
+    ...options.imports,
+    "",
+    "const configuredDatabases = {",
+    ...options.databaseEntries,
+    "}",
+    "const defaultDatabase = configuredDatabases.default || {",
+    "  db: new Proxy({}, {",
+    "    get() { throw new Error(\"[vitehub] Database \\\"default\\\" is not configured.\") },",
+    "  }),",
+    "  schema: {},",
+    "}",
+    "export const databases = { ...configuredDatabases, default: defaultDatabase }",
+    "export function useDatabase(name) { return databases[name] }",
+    "export const agentDb = createAgentDatabase(databases)",
+    "export const db = databases.default.db",
+    "export const schema = databases.default.schema",
+    "",
+  ].join("\n")
+}

--- a/packages/database/src/internal/vite-build.ts
+++ b/packages/database/src/internal/vite-build.ts
@@ -9,6 +9,7 @@ import { resolve } from "pathe"
 
 import { resolveConfigValue } from "../config-value.ts"
 import { resolveCloudflareD1Bindings } from "./cloudflare.ts"
+import { renderDatabaseRuntimeModule } from "./runtime-module.ts"
 import { renderDatabaseConfigExpression } from "./runtime-config-expression.ts"
 
 import type { ProvisionState } from "@vite-hub/internal/provision"
@@ -73,26 +74,15 @@ function renderRuntimeModule(file: string, runtimeConfig: ResolvedDBViteConfig) 
     "  },",
   ].join("\n"))
 
-  return [
-    `import { createAgentDatabase } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule("runtime/agent")))}`,
-    `import { createHostedDrizzleDb } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule("runtime/hosted")))}`,
-    "",
-    ...imports,
-    "",
-    "export const databases = {",
-    ...databaseEntries,
-    "}",
-    "export function useDatabase(name) { return databases[name] }",
-    "export const agentDb = createAgentDatabase(databases)",
-    "",
-    ...(runtimeConfig.databaseNames.includes("default")
-      ? [
-          "export const db = databases.default.db",
-          "export const schema = databases.default.schema",
-        ]
-      : []),
-    "",
-  ].join("\n")
+  return renderDatabaseRuntimeModule({
+    createAgentDatabaseImport: createImportPath(file, resolveRuntimeModule("runtime/agent")),
+    databaseEntries,
+    imports: [
+      `import { createHostedDrizzleDb } from ${JSON.stringify(createImportPath(file, resolveRuntimeModule("runtime/hosted")))}`,
+      "",
+      ...imports,
+    ],
+  })
 }
 
 function renderProviderEntry(spec: ProviderEntrySpec, entryFile: string, userAppEntry: string | undefined) {

--- a/packages/database/src/nuxt.ts
+++ b/packages/database/src/nuxt.ts
@@ -1,11 +1,15 @@
+import { rm } from "node:fs/promises"
 import { resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 import { writeFileIfChanged } from "@vite-hub/internal/definition-catalog"
-import { resolveViteHubProjectRoot } from "@vite-hub/internal/build/vite"
+import { resolveViteHubGeneratedRoot, resolveViteHubProjectRoot, VITEHUB_GENERATED_ROOT } from "@vite-hub/internal/build/vite"
 import { getHostingProvider } from "@vite-hub/internal/hosting"
 import { isPlainObject as isRecord } from "@vite-hub/internal/object"
 
 import { mergeCloudflareD1Bindings, resolveCloudflareD1Binding } from "./internal/cloudflare.ts"
+import { renderDatabaseRuntimeModule } from "./internal/runtime-module.ts"
+import { resolveDBViteConfig } from "./config.ts"
 import { hubDb as hubDbVite } from "./vite.ts"
 
 import type { DatabaseNuxtIntegrationOptions, DBModulePublicOptions } from "./types.ts"
@@ -13,7 +17,9 @@ import type { Plugin } from "vite"
 
 type ResolvedDatabaseNuxtIntegrationOptions = Exclude<DatabaseNuxtIntegrationOptions, false>
 const generatedNitroDatabaseMiddleware = ".vitehub/nitro/database/middleware.ts"
+const generatedNitroLocalDatabaseRuntime = "database/local-runtime.mjs"
 const databaseDrizzleImport = "@vite-hub/database/drizzle"
+const databaseRuntimeDir = fileURLToPath(new URL("./runtime/", import.meta.url))
 
 type NuxtModuleDependencies = Record<string, {
   defaults?: Record<string, unknown>
@@ -37,10 +43,12 @@ type DatabaseNuxtModule = {
 type NuxtLike = {
   hook?: (name: string, callback: (value: Record<string, unknown>) => Promise<void> | void) => void
   options: Record<string, unknown> & {
+    buildDir?: string
     dev?: boolean
     modules?: unknown[]
     nitro?: Record<string, unknown>
     rootDir?: string
+    serverDir?: string
     srcDir?: string
     vite?: Record<string, unknown>
   }
@@ -65,6 +73,14 @@ export function hubDb(options: DatabaseNuxtIntegrationOptions = {}): DatabaseNux
       projectRoot: resolvedOptions.projectRoot,
     })
     const viteConfig = ensureRecord(nuxtOptions, "vite")
+    const generatedRoot = resolveViteHubGeneratedRoot({
+      [VITEHUB_GENERATED_ROOT]: typeof viteConfig[VITEHUB_GENERATED_ROOT] === "string"
+        ? viteConfig[VITEHUB_GENERATED_ROOT]
+        : nuxtOptions.buildDir
+          ? resolve(nuxtOptions.buildDir, "vitehub")
+          : undefined,
+      root,
+    })
     const viteOptions = resolveDatabaseViteOptions(resolvedOptions)
     if (viteOptions) {
       viteConfig.database = { ...(isRecord(viteConfig.database) ? viteConfig.database : {}), ...viteOptions }
@@ -77,6 +93,15 @@ export function hubDb(options: DatabaseNuxtIntegrationOptions = {}): DatabaseNux
       hook("nitro:config", async (config) => {
         const provider = resolveNitroHostingProvider(config, nuxtOptions)
         if (!nuxtOptions.dev && (provider || d1)) mergeNitroHostedCondition(config)
+        if (nuxtOptions.dev) {
+          await installNitroLocalDatabaseRuntime(
+            config,
+            root,
+            generatedRoot,
+            resolvedOptions,
+            nuxtOptions.serverDir ? [nuxtOptions.serverDir] : undefined,
+          )
+        }
         if (!nuxtOptions.dev) {
           const runtimeRoot = typeof viteConfig.root === "string" ? viteConfig.root : nuxtOptions.srcDir || root
           mergeNitroDatabaseRuntimeAlias(config, runtimeRoot, provider ?? (d1 ? "cloudflare" : undefined))
@@ -108,6 +133,53 @@ export function hubDb(options: DatabaseNuxtIntegrationOptions = {}): DatabaseNux
 const nuxtModule: DatabaseNuxtModule = hubDb()
 
 export default nuxtModule
+
+async function installNitroLocalDatabaseRuntime(
+  config: Record<string, unknown>,
+  root: string,
+  generatedRoot: string,
+  options: ResolvedDatabaseNuxtIntegrationOptions,
+  serverDirs?: string[],
+) {
+  const file = resolve(generatedRoot, generatedNitroLocalDatabaseRuntime)
+  const alias = isRecord(config.alias) ? config.alias : undefined
+  const existingAlias = alias?.[databaseDrizzleImport]
+  if (existingAlias && existingAlias !== file) {
+    await rm(file, { force: true })
+    return
+  }
+
+  const runtime = resolveDBViteConfig(options, root, { serverDirs })
+  if (!runtime?.definitions.length) {
+    await rm(file, { force: true })
+    if (alias && existingAlias === file) {
+      delete alias[databaseDrizzleImport]
+      if (!Object.keys(alias).length) delete config.alias
+    }
+    return
+  }
+
+  const imports = runtime.definitions.map((definition, index) =>
+    `import definition_${index} from ${JSON.stringify(pathToFileURL(definition.handler).href)}`)
+  const entries = runtime.definitions.map((definition, index) => [
+    `  ${JSON.stringify(definition.name)}: {`,
+    `    db: createDefinitionRuntime(definition_${index}, definitionDefaults),`,
+    `    schema: definition_${index}.schema,`,
+    "  },",
+  ].join("\n"))
+  await writeFileIfChanged(file, renderDatabaseRuntimeModule({
+    createAgentDatabaseImport: pathToFileURL(resolve(databaseRuntimeDir, "agent.js")).href,
+    databaseEntries: entries,
+    imports: [
+      `import { createDefinitionRuntime } from ${JSON.stringify(pathToFileURL(resolve(databaseRuntimeDir, "definition-local.js")).href)}`,
+      ...imports,
+      "",
+      `const definitionDefaults = ${JSON.stringify(runtime.definitionDefaults)}`,
+    ],
+  }))
+  if (alias) alias[databaseDrizzleImport] = file
+  else config.alias = { [databaseDrizzleImport]: file }
+}
 
 function resolveNuxtContentModuleDependencies(options: DatabaseNuxtIntegrationOptions, nuxt: unknown): NuxtModuleDependencies {
   const nuxtOptions = (nuxt as NuxtLike).options

--- a/packages/database/src/runtime/definition-config.ts
+++ b/packages/database/src/runtime/definition-config.ts
@@ -2,6 +2,11 @@ import definitionDefaults from "#vitehub/database/definition-defaults"
 
 import type { DatabaseDefinition, RuntimeDrizzleDatabaseConfig } from "../types.ts"
 
+interface DatabaseDefinitionDefaults {
+  cloudflare?: DatabaseDefinition["cloudflare"]
+  connection?: DatabaseDefinition["connection"]
+}
+
 function defaultBinding(name: string) {
   if (name === "default") return "DB"
   const suffix = name.replace(/[^a-z0-9]+/gi, "_").replace(/^_+|_+$/g, "").replace(/_+/g, "_").toUpperCase()
@@ -13,15 +18,18 @@ function defaultUrl(name: string) {
   return `file:.vitehub/data/database/${name}.sqlite.db`
 }
 
-export function runtimeConfig(definition: DatabaseDefinition): RuntimeDrizzleDatabaseConfig {
-  const cloudflare = definition.cloudflare ?? definitionDefaults.cloudflare
+export function runtimeConfig(
+  definition: DatabaseDefinition,
+  defaults: DatabaseDefinitionDefaults = definitionDefaults,
+): RuntimeDrizzleDatabaseConfig {
+  const cloudflare = definition.cloudflare ?? defaults.cloudflare
   return {
     ...(cloudflare
       ? { cloudflare: { ...cloudflare, binding: cloudflare.binding || defaultBinding(definition.name) } }
       : {}),
     connection: {
-      authToken: definition.connection?.authToken ?? definitionDefaults.connection?.authToken,
-      url: definition.connection?.url ?? definitionDefaults.connection?.url ?? defaultUrl(definition.name),
+      authToken: definition.connection?.authToken ?? defaults.connection?.authToken,
+      url: definition.connection?.url ?? defaults.connection?.url ?? defaultUrl(definition.name),
     },
     drizzle: definition.drizzle,
     name: definition.name,

--- a/packages/database/src/runtime/definition-local.ts
+++ b/packages/database/src/runtime/definition-local.ts
@@ -18,8 +18,9 @@ function resolveLocalUrl(url: string) {
 
 export function createDefinitionRuntime<TSchema extends Record<string, unknown>>(
   definition: DatabaseDefinition<TSchema>,
+  defaults?: Pick<DatabaseDefinition, "cloudflare" | "connection">,
 ): RuntimeDrizzleDatabase<TSchema> {
-  return createDrizzleSqliteAdapter(runtimeConfig(definition), definition.schema, {
+  return createDrizzleSqliteAdapter(runtimeConfig(definition, defaults), definition.schema, {
     libsql: { createClient, drizzle: drizzleLibsql as never },
     missingConnectionMessage: config => `[vitehub] Database "${config.name}" requires a Cloudflare D1 binding or database connection URL.`,
     requireRemoteUrl: false,

--- a/packages/database/test/nuxt.test.ts
+++ b/packages/database/test/nuxt.test.ts
@@ -1,5 +1,6 @@
-import { readFile } from "node:fs/promises"
-import { join } from "node:path"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
 
 import { describe, expect, it } from "vitest"
 
@@ -239,6 +240,56 @@ describe("Database Nuxt integration", () => {
         },
       },
     })
+  })
+
+  it("maintains the discovered database runtime for Nitro development", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-db-nuxt-local-"))
+    const buildDir = join(rootDir, ".nuxt")
+    const serverDir = join(rootDir, "app/server")
+    const runtimeFile = join(buildDir, "vitehub/database/local-runtime.mjs")
+    const writeDefinition = async (name: string) => {
+      const file = join(serverDir, `databases/${name}/config.ts`)
+      await mkdir(dirname(file), { recursive: true })
+      await writeFile(file, [
+        'import { defineDatabase } from "@vite-hub/database"',
+        `export default defineDatabase({ name: ${JSON.stringify(name)}, schema: {} })`,
+        "",
+      ].join("\n"))
+    }
+
+    try {
+      await writeDefinition("analytics")
+      const { hooks, nuxt } = createNuxt({ buildDir, dev: true, rootDir, serverDir, vite: {} })
+      await hubDb({ connection: { authToken: "dev-token", url: "libsql://dev.example.com" } })(undefined, nuxt)
+
+      const nitroConfig: Record<string, unknown> = {}
+      await callHook(hooks, "nitro:config", nitroConfig)
+      expect(nitroConfig.alias).toEqual({ "@vite-hub/database/drizzle": runtimeFile })
+      await expect(readFile(runtimeFile, "utf8")).resolves.toMatch(
+        /databases\/analytics\/config\.ts[\s\S]+"connection":\{"authToken":"dev-token","url":"libsql:\/\/dev\.example\.com"\}[\s\S]+"analytics":[\s\S]+export const databases[\s\S]+export const db[\s\S]+export const schema/,
+      )
+
+      await rm(join(serverDir, "databases/analytics"), { force: true, recursive: true })
+      await writeDefinition("reports")
+      await callHook(hooks, "nitro:config", nitroConfig)
+      const updatedRuntime = await readFile(runtimeFile, "utf8")
+      expect(updatedRuntime).toContain("databases/reports/config.ts")
+      expect(updatedRuntime).not.toContain("databases/analytics/config.ts")
+
+      const customAlias = { alias: { "@vite-hub/database/drizzle": "#custom-database" } }
+      await callHook(hooks, "nitro:config", customAlias)
+      expect(customAlias.alias).toEqual({ "@vite-hub/database/drizzle": "#custom-database" })
+      await expect(readFile(runtimeFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" })
+
+      await callHook(hooks, "nitro:config", nitroConfig)
+      await rm(serverDir, { force: true, recursive: true })
+      await callHook(hooks, "nitro:config", nitroConfig)
+      expect(nitroConfig.alias).toBeUndefined()
+      await expect(readFile(runtimeFile, "utf8")).rejects.toMatchObject({ code: "ENOENT" })
+    }
+    finally {
+      await rm(rootDir, { force: true, recursive: true })
+    }
   })
 
   it("deduplicates D1 bindings already merged into Nuxt and Nitro config", async () => {


### PR DESCRIPTION
Nuxt development now discovers Database Definitions through the resolved ViteHub project root and Nuxt server directory, writes a local Nitro runtime module under Nuxt’s generated-artifact root, and aliases `@vite-hub/database/drizzle` to it. The generated module preserves the public `databases`, `useDatabase`, `agentDb`, `db`, and `schema` runtime surface.

Each Nitro configuration run refreshes the module from the discovered definition set, removes stale output and its owned alias when definitions disappear, and preserves an explicit user alias. Production runtime selection is unchanged.

## Verification

- `corepack pnpm --filter @vite-hub/database test` — build and publint passed; 103 tests passed
- `corepack pnpm --filter @vite-hub/database typecheck`
- `corepack pnpm exec vp lint packages/database/src/nuxt.ts packages/database/test/nuxt.test.ts`
- focused Nuxt suite — 15 tests passed
- disposable Calories checkout without the database patch — emitted the local runtime from `server/databases/config.ts` and cleared database/Nuxt compilation; the full dev request and production prerender remain blocked later by the separate Blob source-root mismatch between `.vitehub/blob` and `app/.vitehub/blob`