### PR TITLE
fix(vite-hub): resolve database runtime in Nuxt builds

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -50,7 +50,8 @@
     "./runtime/virtual-schema": "./dist/runtime/virtual-schema.js",
     "./virtual": "./dist/virtual.js",
     "./vite": "./dist/vite.js",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./runtime/cloudflare-env": "./dist/runtime/state.js"
   },
   "scripts": {
     "build": "vp pack",

--- a/packages/database/src/nuxt.ts
+++ b/packages/database/src/nuxt.ts
@@ -251,13 +251,12 @@ async function installNitroCloudflareEnvBridge(config: Record<string, unknown>, 
   config.rollupConfig = rollupConfig
   await writeFileIfChanged(resolve(root, generatedNitroDatabaseMiddleware), [
     "import { env as vitehubEnv } from 'cloudflare:workers'",
-    "import { defineMiddleware } from 'nitro'",
     "import { setActiveCloudflareEnv } from '@vite-hub/database/runtime/state'",
     "",
-    "export default defineMiddleware((event) => {",
+    "export default (event: unknown) => {",
     "  const target = event as { env?: Record<string, unknown>, context?: { cloudflare?: { env?: Record<string, unknown> }, _platform?: { cloudflare?: { env?: Record<string, unknown> } } }, req?: { runtime?: { cloudflare?: { env?: Record<string, unknown> } } } }",
     "  setActiveCloudflareEnv(target.env ?? target.context?.cloudflare?.env ?? target.context?._platform?.cloudflare?.env ?? target.req?.runtime?.cloudflare?.env ?? (vitehubEnv as unknown as Record<string, unknown>))",
-    "})",
+    "}",
     "",
   ].join("\n"))
 }

--- a/packages/database/vite.config.ts
+++ b/packages/database/vite.config.ts
@@ -33,9 +33,12 @@ export default defineConfig({
     ],
     exports: {
       customExports(exports) {
-        return Object.fromEntries(
-          Object.entries(exports).filter(([key]) => !key.startsWith("./runtime/definition-")),
-        )
+        return {
+          ...Object.fromEntries(
+            Object.entries(exports).filter(([key]) => !key.startsWith("./runtime/definition-")),
+          ),
+          "./runtime/cloudflare-env": "./dist/runtime/state.js",
+        }
       },
       inlinedDependencies: false,
     },

--- a/packages/vite-hub/package.json
+++ b/packages/vite-hub/package.json
@@ -43,6 +43,7 @@
     "./_internal/agent/state/sqlite": "./dist/_internal/agent/state/sqlite.js",
     "./_internal/blob": "./dist/_internal/blob.js",
     "./_internal/blob/runtime/state": "./dist/_internal/blob/runtime/state.js",
+    "./_internal/database/runtime/state": "./dist/_internal/database/runtime/state.js",
     "./_internal/kv": "./dist/_internal/kv.js",
     "./_internal/kv/runtime/disabled-upstash": "./dist/_internal/kv/runtime/disabled-upstash.js",
     "./_internal/markdown-template": "./dist/_internal/markdown-template.js",

--- a/packages/vite-hub/src/_internal/database/runtime/state.ts
+++ b/packages/vite-hub/src/_internal/database/runtime/state.ts
@@ -1,1 +1,1 @@
-export { setActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
+export { setActiveCloudflareEnv } from "@vite-hub/database/runtime/cloudflare-env"

--- a/packages/vite-hub/src/_internal/database/runtime/state.ts
+++ b/packages/vite-hub/src/_internal/database/runtime/state.ts
@@ -1,0 +1,1 @@
+export * from "@vite-hub/database/runtime/state"

--- a/packages/vite-hub/src/_internal/database/runtime/state.ts
+++ b/packages/vite-hub/src/_internal/database/runtime/state.ts
@@ -1,1 +1,1 @@
-export * from "@vite-hub/database/runtime/state"
+export { setActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -176,6 +176,14 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
   nuxt.hook?.("nitro:config", config => applyNitroConfig(installedPlugins, config, nuxt))
   if (options.database) {
     await hubDatabaseNuxt(options.database === true ? {} : options.database)(undefined, nuxt)
+    if (!nuxt.options.dev) {
+      nuxt.hook?.("nitro:config", async (config) => {
+        config.alias = {
+          ...(config.alias as Record<string, string> | undefined),
+          "@vite-hub/database/runtime/state": "vite-hub/_internal/database/runtime/state",
+        }
+      })
+    }
   }
 }
 

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -178,10 +178,9 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
     await hubDatabaseNuxt(options.database === true ? {} : options.database)(undefined, nuxt)
     if (!nuxt.options.dev) {
       nuxt.hook?.("nitro:config", async (config) => {
-        config.alias = {
-          ...(config.alias as Record<string, string> | undefined),
-          "@vite-hub/database/runtime/state": "vite-hub/_internal/database/runtime/state",
-        }
+        const alias = (config.alias ??= {}) as Record<string, string>
+        alias["@vite-hub/database/runtime/state"]
+          ??= "vite-hub/_internal/database/runtime/state"
       })
     }
   }

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -314,6 +314,20 @@ describe("ViteHub Nuxt integration", () => {
     expect(nitroConfig).not.toHaveProperty("alias.@vite-hub/database/runtime/state")
   })
 
+  it("preserves an explicitly configured Database runtime alias", async () => {
+    const { nuxt, runNitroConfigHook } = createNuxt()
+
+    await viteHubNuxtModule({ database: true, preset: "cloudflare" }, nuxt)
+    const nitroConfig = {
+      alias: {
+        "@vite-hub/database/runtime/state": "./custom-database-state.ts",
+      },
+    }
+    await runNitroConfigHook(nitroConfig)
+
+    expect(nitroConfig.alias["@vite-hub/database/runtime/state"]).toBe("./custom-database-state.ts")
+  })
+
   it("does not concatenate complete Nitro arrays returned by config hooks", async () => {
     mocks.vitehub.mockReturnValue([
       {

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -299,8 +299,19 @@ describe("ViteHub Nuxt integration", () => {
     expect(nitroConfig).toMatchObject({
       alias: {
         "@vite-hub/database/drizzle": "/tmp/vitehub-nuxt/custom-vite-root/.vitehub/database/cloudflare-runtime.mjs",
+        "@vite-hub/database/runtime/state": "vite-hub/_internal/database/runtime/state",
       },
     })
+  })
+
+  it("keeps the Database Nuxt runtime alias out of development", async () => {
+    const { nuxt, runNitroConfigHook } = createNuxt(true)
+
+    await viteHubNuxtModule({ database: true, preset: "cloudflare" }, nuxt)
+    const nitroConfig = {}
+    await runNitroConfigHook(nitroConfig)
+
+    expect(nitroConfig).not.toHaveProperty("alias.@vite-hub/database/runtime/state")
   })
 
   it("does not concatenate complete Nitro arrays returned by config hooks", async () => {

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -77,6 +77,10 @@ const generatedRuntimeOwnerExports = new Set([
   "@vite-hub/workflow/runtime/vercel-vite",
 ])
 
+const bundledFrameworkForwarders = new Map([
+  ["./_internal/database/runtime/state", "@vite-hub/internal/runtime/cloudflare-env"],
+])
+
 function sourceForwarderTargets(source: string): string[] | undefined {
   const lines = source.split(/\r?\n/).map(line => line.trim()).filter(Boolean)
   if (!lines.length) return
@@ -156,6 +160,11 @@ describe("framework package contract", () => {
 
     for (const { subpath, targets } of manifestForwarders) {
       const ownerSpecifier = ownerSpecifierForDistributionSubpath(subpath)
+      const bundledTarget = bundledFrameworkForwarders.get(subpath)
+      if (bundledTarget) {
+        expect([...new Set(targets)], subpath).toEqual([bundledTarget])
+        continue
+      }
       const ownerPackage = ownerSpecifier.split("/").slice(0, 2).join("/")
       expect([...new Set(targets)], subpath).toEqual([ownerSpecifier])
       expect(manifest.dependencies[ownerPackage], subpath).toBeDefined()

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -7,6 +7,8 @@ import * as ownerAgent from "@vite-hub/agent"
 import * as ownerCapabilities from "@vite-hub/agent/capabilities"
 import ownerAuthHandler from "@vite-hub/auth/server"
 import * as ownerBlobContentType from "@vite-hub/blob/content-type"
+import { setActiveCloudflareEnv as ownerCloudflareEnvSetter } from "@vite-hub/database/runtime/cloudflare-env"
+import { setActiveCloudflareEnv as ownerDatabaseStateSetter } from "@vite-hub/database/runtime/state"
 import * as ownerRateLimit from "@vite-hub/rate-limit"
 import * as framework from "vite-hub"
 import * as frameworkAgent from "vite-hub/agent"
@@ -14,6 +16,7 @@ import * as frameworkCapabilities from "vite-hub/agent/capabilities"
 import frameworkAuthHandler from "vite-hub/auth/server"
 import * as frameworkBlobContentType from "vite-hub/blob/content-type"
 import * as frameworkRateLimit from "vite-hub/rate-limit"
+import { setActiveCloudflareEnv as frameworkDatabaseStateSetter } from "vite-hub/_internal/database/runtime/state"
 import { distributionBinEntries, distributionEntriesFromManifest } from "../vite.config.ts"
 
 const packageRoot = fileURLToPath(new URL("..", import.meta.url))
@@ -53,6 +56,7 @@ const generatedRuntimeOwnerExports = new Set([
   "@vite-hub/blob/runtime/state",
   "@vite-hub/blob/runtime/vercel-vite",
   "@vite-hub/database/runtime/agent",
+  "@vite-hub/database/runtime/cloudflare-env",
   "@vite-hub/database/runtime/cloudflare-vite",
   "@vite-hub/database/runtime/hosted",
   "@vite-hub/database/runtime/state",
@@ -77,8 +81,8 @@ const generatedRuntimeOwnerExports = new Set([
   "@vite-hub/workflow/runtime/vercel-vite",
 ])
 
-const bundledFrameworkForwarders = new Map([
-  ["./_internal/database/runtime/state", "@vite-hub/internal/runtime/cloudflare-env"],
+const frameworkForwarderTargets = new Map([
+  ["./_internal/database/runtime/state", "@vite-hub/database/runtime/cloudflare-env"],
 ])
 
 function sourceForwarderTargets(source: string): string[] | undefined {
@@ -137,6 +141,11 @@ describe("framework package contract", () => {
     expect(frameworkRateLimit.createRateLimiter).toBe(ownerRateLimit.createRateLimiter)
   })
 
+  it("keeps the Database environment setter on its owner runtime instance", () => {
+    expect(ownerCloudflareEnvSetter).toBe(ownerDatabaseStateSetter)
+    expect(frameworkDatabaseStateSetter).toBe(ownerDatabaseStateSetter)
+  })
+
   it("keeps every source forwarder owned by its matching package export", () => {
     const manifestEntries = Object.entries(manifest.exports).flatMap(([subpath, target]) =>
       distributionEntriesFromManifest(target).map(source => ({ source, subpath })),
@@ -160,13 +169,9 @@ describe("framework package contract", () => {
 
     for (const { subpath, targets } of manifestForwarders) {
       const ownerSpecifier = ownerSpecifierForDistributionSubpath(subpath)
-      const bundledTarget = bundledFrameworkForwarders.get(subpath)
-      if (bundledTarget) {
-        expect([...new Set(targets)], subpath).toEqual([bundledTarget])
-        continue
-      }
-      const ownerPackage = ownerSpecifier.split("/").slice(0, 2).join("/")
-      expect([...new Set(targets)], subpath).toEqual([ownerSpecifier])
+      const expectedTarget = frameworkForwarderTargets.get(subpath) || ownerSpecifier
+      const ownerPackage = expectedTarget.split("/").slice(0, 2).join("/")
+      expect([...new Set(targets)], subpath).toEqual([expectedTarget])
       expect(manifest.dependencies[ownerPackage], subpath).toBeDefined()
     }
   })

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -434,8 +434,9 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
       expect(existsSync(join(appDir, "node_modules/@vite-hub")), "owner packages must not be visible at the consumer root").toBe(false)
       await run("pnpm", ["run", "build"], appDir)
 
-      await expect(readFile(join(appDir, ".vitehub/nitro/database/middleware.ts"), "utf8"))
-        .resolves.toContain("from '@vite-hub/database/runtime/state'")
+      const middleware = await readFile(join(appDir, ".vitehub/nitro/database/middleware.ts"), "utf8")
+      expect(middleware).toContain("from '@vite-hub/database/runtime/state'")
+      expect(middleware).not.toContain("from 'nitro'")
     }
     finally {
       await rm(root, { recursive: true, force: true })

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -188,8 +188,8 @@ async function packWorkspacePackages(packDir: string, packageNames?: Set<string>
   return specs
 }
 
-function workspaceConfig(specs: Record<string, string>) {
-  const overrides = Object.entries(specs)
+function workspaceConfig(specs: Record<string, string>, additionalOverrides: Record<string, string> = {}) {
+  const overrides = Object.entries({ ...specs, ...additionalOverrides })
     .sort(([left], [right]) => left.localeCompare(right))
     .map(([name, spec]) => `  ${JSON.stringify(name)}: ${JSON.stringify(spec)}`)
 
@@ -392,6 +392,56 @@ async function assertVercelRuntimeImportsResolveInside(
 }
 
 describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-hub consumer contract", () => {
+  it("builds Nuxt database middleware without exposing owner packages", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vite-hub-nuxt-consumer-"))
+    const appDir = join(root, "app")
+    const packDir = join(root, "packs")
+
+    try {
+      await Promise.all([
+        mkdir(appDir, { recursive: true }),
+        mkdir(packDir, { recursive: true }),
+      ])
+      const specs = await packWorkspacePackages(packDir)
+      await Promise.all([
+        writeFile(join(appDir, "app.vue"), "<template><main>ViteHub</main></template>\n", "utf8"),
+        writeFile(join(appDir, "nuxt.config.ts"), `
+          export default defineNuxtConfig({
+            modules: ["vite-hub/nuxt"],
+            nitro: { preset: "cloudflare_module" },
+            vitehub: { database: true, preset: "cloudflare" },
+          })
+        `, "utf8"),
+        writeFile(join(appDir, "package.json"), JSON.stringify({
+          dependencies: {
+            nuxt: "4.4.8",
+            vite: "8.0.8",
+            "vite-hub": specs["vite-hub"],
+          },
+          packageManager: "pnpm@10.33.0",
+          private: true,
+          scripts: { build: "nuxt build" },
+          type: "module",
+        }, null, 2), "utf8"),
+        writeFile(join(appDir, "pnpm-workspace.yaml"), workspaceConfig(specs, {
+          "oxc-parser": "0.140.0",
+          rolldown: "1.1.5",
+        }), "utf8"),
+      ])
+      await run("pnpm", ["install", "--no-hoist", "--strict-peer-dependencies"], appDir)
+
+      await assertOnlyViteHubDependencies(appDir, ["vite-hub"])
+      expect(existsSync(join(appDir, "node_modules/@vite-hub")), "owner packages must not be visible at the consumer root").toBe(false)
+      await run("pnpm", ["run", "build"], appDir)
+
+      await expect(readFile(join(appDir, ".vitehub/nitro/database/middleware.ts"), "utf8"))
+        .resolves.toContain("from '@vite-hub/database/runtime/state'")
+    }
+    finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  }, 300_000)
+
   it("publishes Browser types and Cloudflare adapter without consumer-owned Playwright", async () => {
     const root = await mkdtemp(join(tmpdir(), "vite-hub-browser-consumer-"))
     const appDir = join(root, "app")


### PR DESCRIPTION
Generated Nuxt database middleware imports `@vite-hub/database/runtime/state` from the application root. Under a strict pnpm graph, framework consumers only declare `vite-hub`, so that transitive owner package is not resolvable there and production Nitro builds fail.

This routes the generated state import through a private `vite-hub/_internal/database/runtime/state` facade during production Nitro configuration. An alias-safe database runtime export maps to the same built state module, so the facade cannot recurse and the setter stays on the database-owned request-scoped runtime instance. Generated middleware is a plain Nitro event handler, avoiding a second transitive application-root import. The framework alias is a default and preserves an explicitly configured Nitro alias. The database package still generates and owns the middleware and runtime state; local Nuxt development is unchanged.

## Verification

- full repository package build with publint
- `corepack pnpm vp test test/nuxt.test.ts` in `packages/database`: 14 passed, no type errors
- full `packages/vite-hub` suite: 91 passed, no type errors
- packed strict-pnpm Nuxt production consumer build: passed
- changed-file oxlint and `git diff --check`