### PR TITLE
feat(auth): integrate Vue clients with Nuxt

### DIFF
--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -27,6 +27,7 @@ composition and explicit feature subpaths for application APIs.
 | `vite-hub/agent/server` and `vite-hub/agent/state/sqlite` | Manual server integration and libSQL-compatible durable Agent state. |
 | `vite-hub/auth` and `vite-hub/auth/server` | Auth Definitions and server runtime helpers. |
 | `vite-hub/auth/agent` | Better Auth session mapping into Agent Invokers. |
+| `vite-hub/auth/vue` | Better Auth Vue client and normalized session composables. |
 | `vite-hub/blob` | Blob Runtime Helpers and Blob Store access. |
 | `vite-hub/blob/content-type` | Detect common image and PDF signatures from leading bytes before upload. |
 | `vite-hub/browser` | Browser Definitions, invocation-scoped Playwright sessions, and named Browser runs. |

--- a/docs/content/docs/server-primitives/auth.md
+++ b/docs/content/docs/server-primitives/auth.md
@@ -7,7 +7,7 @@ icon: i-lucide-shield-check
 
 Auth is the server primitive for application user identity and sessions. ViteHub owns the Auth Definition, Auth Route Exposure, storage placement metadata, and server runtime helpers. Storage placement metadata is inspectable configuration; it does not create Better Auth storage adapters.
 
-Better Auth owns client packages, sign-in UI, session hooks, client plugins, and provider-specific client behavior. Use ViteHub to expose and configure the server route, then use Better Auth clients in the browser.
+Better Auth owns sign-in UI, client plugins, and provider-specific client behavior. ViteHub exposes its Vue client and normalized session composables; other framework clients remain available from Better Auth.
 
 ## Quick start
 
@@ -91,13 +91,15 @@ Better Auth-compatible options stay top-level. ViteHub reserves Auth fields such
 
 The Canonical Auth Route Path is `/api/auth/**`. Auth Route Exposure is enabled by default, so apps do not need to create a manual route file for the common same-origin case.
 
-Use Better Auth's client package from browser code.
+Vue apps can use the same-origin ViteHub Auth client and normalized session state directly.
 
 ```ts [lib/auth-client.ts]
-import { createAuthClient } from 'better-auth/client'
+import { useUserSession } from '@vite-hub/auth/vue'
 
-export const authClient = createAuthClient()
+export const userSession = useUserSession()
 ```
+
+Import `createAuthClient` from the same entry when a custom base path or Better Auth client plugins are required.
 
 Server code can read the discovered Auth instance or require a session for a request.
 

--- a/fallow.toml
+++ b/fallow.toml
@@ -26,6 +26,8 @@ dynamicallyLoaded = [
   "packages/database/src/runtime/definition-defaults.ts",
   "packages/env/test/**/*.test-d.ts",
   "packages/auth/test/**/*.test-d.ts",
+  # Registered by the Auth Nuxt module as a Nitro runtime plugin.
+  "packages/auth/src/runtime/nuxt.ts",
   "packages/email/test/**/*.test-d.ts",
   "packages/database/examples/**/server/**",
   "packages/database/examples/**/src/server.ts",

--- a/packages/auth/README.md
+++ b/packages/auth/README.md
@@ -122,13 +122,13 @@ export default defineAuth({
 
 ## Client-side Auth
 
-Use Better Auth's client libraries from application code. ViteHub exposes the Auth route in local Vite development and provides the handler for hosts that mount it manually; Better Auth owns framework clients, hooks, client plugins, sign-in actions, and session state.
+Vue apps can use ViteHub's Better Auth client and normalized session composable directly. `useUserSession()` exposes the current `user` and `session`, sign-in and sign-out actions, and `loggedIn`, `pending`, and `ready` computed refs.
 
 ```ts
 // lib/auth-client.ts
-import { createAuthClient } from "better-auth/client"
+import { useUserSession } from "@vite-hub/auth/vue"
 
-export const authClient = createAuthClient()
+export const session = useUserSession()
 ```
 
 That default talks to `/api/auth` on the same origin. If the Auth Definition uses a custom `basePath`, pass the same path to the Better Auth client.
@@ -145,14 +145,15 @@ export default defineAuth({
 
 ```ts
 // lib/auth-client.ts
-import { createAuthClient } from "better-auth/client"
+import { createAuthClient, useUserSession } from "@vite-hub/auth/vue"
 
 export const authClient = createAuthClient({
   basePath: "/auth",
 })
+export const userSession = useUserSession(authClient)
 ```
 
-Use Better Auth's framework entrypoints when you want React, Vue, Svelte, Solid, or other framework-specific client behavior. ViteHub does not provide `@vite-hub/auth/client` or a separate Auth Client Definition.
+The exported `createAuthClient` keeps Better Auth's option and plugin inference for custom base paths and client plugins. The zero-config composables use ViteHub's shared default client. React, Svelte, Solid, and other framework clients remain available from Better Auth's framework entrypoints.
 
 Read [Better Auth's client docs](https://www.better-auth.com/docs/concepts/client) for framework entrypoints and session helpers.
 

--- a/packages/auth/fixtures/published-types/consumer.ts
+++ b/packages/auth/fixtures/published-types/consumer.ts
@@ -1,4 +1,5 @@
 import { ViteHubError, type ViteHubErrorShape } from "@vite-hub/runtime"
+import { createAuthClient, useSession, useUserSession } from "@vite-hub/auth/vue"
 
 const required = new ViteHubError("AUTHENTICATION_REQUIRED", "Sign in required.")
 required.toJSON() satisfies ViteHubErrorShape<"AUTHENTICATION_REQUIRED">
@@ -9,3 +10,9 @@ const provider = new ViteHubError<"AUTH_PROVIDER_OPERATION_FAILED", { operation:
   { details: { operation: "get-session", provider: "better-auth" } },
 )
 provider.toJSON() satisfies ViteHubErrorShape<"AUTH_PROVIDER_OPERATION_FAILED", { operation: "get-session", provider: "better-auth" }>
+
+const customClient = createAuthClient({ basePath: "/auth" })
+customClient.useSession().value.data?.user.id satisfies string | undefined
+useSession(customClient).value.data?.user.id satisfies string | undefined
+useSession().value.data?.user.id satisfies string | undefined
+useUserSession(customClient).loggedIn.value satisfies boolean

--- a/packages/auth/fixtures/published-types/package.json
+++ b/packages/auth/fixtures/published-types/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@vite-hub/agent": "file:./vite-hub-agent-0.0.1.tgz",
     "@vite-hub/auth": "file:./vite-hub-auth-0.0.1.tgz",
-    "@vite-hub/runtime": "file:./vite-hub-runtime-0.0.1.tgz"
+    "@vite-hub/runtime": "file:./vite-hub-runtime-0.0.1.tgz",
+    "vue": "^3.5.0"
   },
   "devDependencies": {
     "@types/node": "^24.13.3"

--- a/packages/auth/fixtures/published-types/tsconfig.json
+++ b/packages/auth/fixtures/published-types/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "noEmit": true,
+    "skipLibCheck": true,
     "strict": true,
     "types": ["node"]
   },

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -34,8 +34,10 @@
   "exports": {
     ".": "./dist/index.js",
     "./agent": "./dist/agent.js",
+    "./nuxt": "./dist/nuxt.js",
     "./server": "./dist/server.js",
     "./vite": "./dist/vite.js",
+    "./vue": "./dist/vue.js",
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -45,6 +47,7 @@
     "test": "vp run -t @vite-hub/auth#build && vp test"
   },
   "dependencies": {
+    "@vite-hub/env": "workspace:*",
     "@vite-hub/runtime": "workspace:*",
     "better-auth": "catalog:auth"
   },
@@ -56,17 +59,22 @@
     "typescript": "catalog:tooling",
     "vite": "catalog:vite",
     "vite-plus": "catalog:tooling",
-    "vitest": "catalog:tooling"
+    "vitest": "catalog:tooling",
+    "vue": "catalog:ui"
   },
   "peerDependencies": {
     "@vite-hub/agent": "workspace:*",
-    "vite": "catalog:vite-compat"
+    "vite": "catalog:vite-compat",
+    "vue": "catalog:ui"
   },
   "peerDependenciesMeta": {
     "@vite-hub/agent": {
       "optional": true
     },
     "vite": {
+      "optional": true
+    },
+    "vue": {
       "optional": true
     }
   },

--- a/packages/auth/src/nuxt.ts
+++ b/packages/auth/src/nuxt.ts
@@ -1,0 +1,87 @@
+import { fileURLToPath } from "node:url"
+
+import { createEnvImportAliases, hubEnv } from "@vite-hub/env/vite"
+
+import { AUTH_VITE_PLUGIN_NAME, createAuthNitroConfig, hubAuth } from "./vite.ts"
+
+import type { AuthModuleOptions } from "./types.ts"
+
+export interface AuthNuxtModuleOptions {
+  auth?: AuthModuleOptions
+  env?: false | { projectRoot?: string }
+  importsFrom?: string
+  nitro?: boolean
+}
+
+type NuxtLike = {
+  hook?: (name: "nitro:config", handler: (nitroConfig: Record<string, unknown>) => Promise<void>) => void
+  options: {
+    alias?: Record<string, string>
+    imports?: {
+      imports?: Array<{ from: string, name: string }>
+    }
+    nitro?: {
+      alias?: Record<string, string>
+      plugins?: string[]
+    }
+    rootDir?: string
+    serverDir?: string
+    vite?: {
+      plugins?: unknown[]
+      root?: string
+    }
+  }
+}
+
+const composables = ["useAuthClient", "useSession", "useSignIn", "useSignUp", "useUserSession"]
+const nitroRegistered = new WeakSet<object>()
+
+export default function hubAuthNuxt(options: AuthNuxtModuleOptions = {}, nuxt?: NuxtLike): void {
+  if (!nuxt) return
+
+  nuxt.options.vite ??= {}
+  nuxt.options.vite.plugins ??= []
+  const vitePlugins = nuxt.options.vite.plugins.flat(Infinity) as Array<{ name?: string }>
+  const viteRoot = nuxt.options.vite.root || nuxt.options.rootDir || process.cwd()
+  const envProjectRoot = options.env === false ? viteRoot : options.env?.projectRoot || viteRoot
+  if (options.env !== false && !vitePlugins.some(plugin => plugin?.name === "@vite-hub/env/vite")) {
+    nuxt.options.vite.plugins.push(hubEnv({ ...options.env, projectRoot: envProjectRoot }))
+  }
+  const authPlugin = vitePlugins.find(plugin => plugin?.name === AUTH_VITE_PLUGIN_NAME) || hubAuth(options.auth)
+  if (!vitePlugins.some(plugin => plugin?.name === AUTH_VITE_PLUGIN_NAME)) nuxt.options.vite.plugins.push(authPlugin)
+
+  if (options.nitro !== false && !nitroRegistered.has(nuxt)) {
+    nitroRegistered.add(nuxt)
+    nuxt.hook?.("nitro:config", async (nitroConfig) => {
+      Object.assign(nitroConfig, createAuthNitroConfig(authPlugin as ReturnType<typeof hubAuth>, {
+        nitro: nitroConfig,
+        projectRoot: viteRoot,
+        serverDirs: nuxt.options.serverDir ? [nuxt.options.serverDir] : undefined,
+      }))
+    })
+  }
+
+  nuxt.options.imports ??= {}
+  nuxt.options.imports.imports ??= []
+  for (const name of composables) {
+    if (!nuxt.options.imports.imports.some((entry) => entry.name === name)) {
+      nuxt.options.imports.imports.push({
+        from: options.importsFrom || "@vite-hub/auth/vue",
+        name,
+      })
+    }
+  }
+
+  if (options.env === false) return
+
+  const envAliases = createEnvImportAliases({ projectRoot: envProjectRoot })
+  const runtimePlugin = fileURLToPath(new URL("./runtime/nuxt.js", import.meta.url))
+
+  nuxt.options.alias = { ...envAliases, ...nuxt.options.alias }
+  nuxt.options.nitro ??= {}
+  nuxt.options.nitro.alias = { ...envAliases, ...nuxt.options.nitro.alias }
+  nuxt.options.nitro.plugins ??= []
+  if (!nuxt.options.nitro.plugins.includes(runtimePlugin)) {
+    nuxt.options.nitro.plugins.push(runtimePlugin)
+  }
+}

--- a/packages/auth/src/nuxt.ts
+++ b/packages/auth/src/nuxt.ts
@@ -1,3 +1,4 @@
+import { resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { createEnvImportAliases, hubEnv } from "@vite-hub/env/vite"
@@ -27,6 +28,7 @@ type NuxtLike = {
     rootDir?: string
     serverDir?: string
     vite?: {
+      auth?: AuthModuleOptions
       plugins?: unknown[]
       root?: string
     }
@@ -43,7 +45,7 @@ export default function hubAuthNuxt(options: AuthNuxtModuleOptions = {}, nuxt?: 
   nuxt.options.vite.plugins ??= []
   const vitePlugins = nuxt.options.vite.plugins.flat(Infinity) as Array<{ name?: string }>
   const viteRoot = nuxt.options.vite.root || nuxt.options.rootDir || process.cwd()
-  const envProjectRoot = options.env === false ? viteRoot : options.env?.projectRoot || viteRoot
+  const envProjectRoot = options.env === false ? viteRoot : resolve(viteRoot, options.env?.projectRoot || ".")
   if (options.env !== false && !vitePlugins.some(plugin => plugin?.name === "@vite-hub/env/vite")) {
     nuxt.options.vite.plugins.push(hubEnv({ ...options.env, projectRoot: envProjectRoot }))
   }
@@ -57,6 +59,7 @@ export default function hubAuthNuxt(options: AuthNuxtModuleOptions = {}, nuxt?: 
         nitro: nitroConfig,
         projectRoot: viteRoot,
         serverDirs: nuxt.options.serverDir ? [nuxt.options.serverDir] : undefined,
+        viteAuth: nuxt.options.vite?.auth,
       }))
     })
   }

--- a/packages/auth/src/nuxt.ts
+++ b/packages/auth/src/nuxt.ts
@@ -48,12 +48,13 @@ export default function hubAuthNuxt(options: AuthNuxtModuleOptions = {}, nuxt?: 
   const viteRoot = nuxt.options.vite.root || nuxt.options.rootDir || process.cwd()
   const configuredEnvProjectRoot = resolve(viteRoot, options.env === false ? "." : options.env?.projectRoot || ".")
   const existingEnvPlugin = vitePlugins.find(plugin => plugin?.name === "@vite-hub/env/vite") as EnvVitePlugin | undefined
-  const envProjectRoot = existingEnvPlugin?.api.resolveProjectRoot(viteRoot) || configuredEnvProjectRoot
+  const envPlugin = existingEnvPlugin || (options.env === false ? undefined : hubEnv(options.env))
+  const envProjectRoot = envPlugin?.api.resolveProjectRoot(viteRoot) || configuredEnvProjectRoot
   if (options.env !== false && options.env?.projectRoot && existingEnvPlugin && envProjectRoot !== configuredEnvProjectRoot) {
     throw new TypeError("`@vite-hub/auth/nuxt` env.projectRoot must match the installed `@vite-hub/env/vite` plugin.")
   }
   if (options.env !== false && !existingEnvPlugin) {
-    nuxt.options.vite.plugins.push(hubEnv({ ...options.env, projectRoot: envProjectRoot }))
+    nuxt.options.vite.plugins.push(envPlugin!)
   }
   const authPlugin = vitePlugins.find(plugin => plugin?.name === AUTH_VITE_PLUGIN_NAME) || hubAuth(options.auth)
   if (!vitePlugins.some(plugin => plugin?.name === AUTH_VITE_PLUGIN_NAME)) nuxt.options.vite.plugins.push(authPlugin)

--- a/packages/auth/src/nuxt.ts
+++ b/packages/auth/src/nuxt.ts
@@ -6,6 +6,7 @@ import { createEnvImportAliases, hubEnv } from "@vite-hub/env/vite"
 import { AUTH_VITE_PLUGIN_NAME, createAuthNitroConfig, hubAuth } from "./vite.ts"
 
 import type { AuthModuleOptions } from "./types.ts"
+import type { EnvVitePlugin } from "@vite-hub/env/vite"
 
 export interface AuthNuxtModuleOptions {
   auth?: AuthModuleOptions
@@ -45,8 +46,13 @@ export default function hubAuthNuxt(options: AuthNuxtModuleOptions = {}, nuxt?: 
   nuxt.options.vite.plugins ??= []
   const vitePlugins = nuxt.options.vite.plugins.flat(Infinity) as Array<{ name?: string }>
   const viteRoot = nuxt.options.vite.root || nuxt.options.rootDir || process.cwd()
-  const envProjectRoot = options.env === false ? viteRoot : resolve(viteRoot, options.env?.projectRoot || ".")
-  if (options.env !== false && !vitePlugins.some(plugin => plugin?.name === "@vite-hub/env/vite")) {
+  const configuredEnvProjectRoot = resolve(viteRoot, options.env === false ? "." : options.env?.projectRoot || ".")
+  const existingEnvPlugin = vitePlugins.find(plugin => plugin?.name === "@vite-hub/env/vite") as EnvVitePlugin | undefined
+  const envProjectRoot = existingEnvPlugin?.api.resolveProjectRoot(viteRoot) || configuredEnvProjectRoot
+  if (options.env !== false && options.env?.projectRoot && existingEnvPlugin && envProjectRoot !== configuredEnvProjectRoot) {
+    throw new TypeError("`@vite-hub/auth/nuxt` env.projectRoot must match the installed `@vite-hub/env/vite` plugin.")
+  }
+  if (options.env !== false && !existingEnvPlugin) {
     nuxt.options.vite.plugins.push(hubEnv({ ...options.env, projectRoot: envProjectRoot }))
   }
   const authPlugin = vitePlugins.find(plugin => plugin?.name === AUTH_VITE_PLUGIN_NAME) || hubAuth(options.auth)

--- a/packages/auth/src/runtime/env.d.ts
+++ b/packages/auth/src/runtime/env.d.ts
@@ -1,0 +1,3 @@
+import type { ServerEnv } from "@vite-hub/env"
+
+export function useServerEnv(event?: unknown): ServerEnv

--- a/packages/auth/src/runtime/nuxt.ts
+++ b/packages/auth/src/runtime/nuxt.ts
@@ -1,0 +1,6 @@
+import { useServerEnv } from "#vitehub/env/server"
+import { setAuthRuntimeEnvResolver } from "@vite-hub/auth/server"
+
+export default function viteHubAuthNuxtRuntime(): void {
+  setAuthRuntimeEnvResolver(useServerEnv)
+}

--- a/packages/auth/src/vite.ts
+++ b/packages/auth/src/vite.ts
@@ -43,15 +43,17 @@ export function createAuthNitroConfig(plugin: AuthVitePlugin, options: {
   nitro: Record<string, unknown>
   projectRoot: string
   serverDirs?: string[]
+  viteAuth?: AuthModuleOptions
 }): Record<string, unknown> {
-  const result = plugin.config && typeof plugin.config === "function"
+  const viteConfigResult = plugin.config && typeof plugin.config === "function"
     ? plugin.config.call({} as never, {
         root: options.projectRoot,
         nitro: options.nitro,
+        auth: options.viteAuth,
         ...(options.serverDirs ? { [VITEHUB_SERVER_DIRS]: options.serverDirs } : {}),
       } as UserConfig & { nitro: Record<string, unknown> }, { command: "build", isPreview: false, isSsrBuild: true, mode: "production" })
     : undefined
-  return (result && typeof result === "object" && "nitro" in result ? result.nitro : options.nitro) as Record<string, unknown>
+  return (viteConfigResult && typeof viteConfigResult === "object" && "nitro" in viteConfigResult ? viteConfigResult.nitro : options.nitro) as Record<string, unknown>
 }
 
 type InternalAuthModuleOptions = AuthModuleOptions & {

--- a/packages/auth/src/vite.ts
+++ b/packages/auth/src/vite.ts
@@ -9,7 +9,7 @@ import { getAuthForDefinition, handleAuthRequest, resetAuth } from "./server.ts"
 import { isAuthRequestPath } from "./shared.ts"
 
 import type { IncomingMessage, ServerResponse } from "node:http"
-import type { Plugin, ResolvedConfig } from "vite"
+import type { Plugin, ResolvedConfig, UserConfig } from "vite"
 import type {
   AuthDefinition,
   AuthModuleOptions,
@@ -38,6 +38,21 @@ export interface AuthVitePluginAPI {
 }
 
 export type AuthVitePlugin = Plugin & { api: AuthVitePluginAPI }
+
+export function createAuthNitroConfig(plugin: AuthVitePlugin, options: {
+  nitro: Record<string, unknown>
+  projectRoot: string
+  serverDirs?: string[]
+}): Record<string, unknown> {
+  const result = plugin.config && typeof plugin.config === "function"
+    ? plugin.config.call({} as never, {
+        root: options.projectRoot,
+        nitro: options.nitro,
+        ...(options.serverDirs ? { [VITEHUB_SERVER_DIRS]: options.serverDirs } : {}),
+      } as UserConfig & { nitro: Record<string, unknown> }, { command: "build", isPreview: false, isSsrBuild: true, mode: "production" })
+    : undefined
+  return (result && typeof result === "object" && "nitro" in result ? result.nitro : options.nitro) as Record<string, unknown>
+}
 
 type InternalAuthModuleOptions = AuthModuleOptions & {
   importBase?: string

--- a/packages/auth/src/vite.ts
+++ b/packages/auth/src/vite.ts
@@ -187,12 +187,12 @@ function mergeNitroAuthHandler(value: unknown, config: ResolvedAuthViteConfig | 
     ...(config.route === false
       ? []
       : [{
-          handler: generatedAuthRouteHandler,
+          handler: resolve(config.rootDir, generatedAuthRouteHandler),
           route: authRoutePattern(config.route),
         }]),
     ...(config.access.routes.length > 0
       ? [{
-          handler: generatedAuthAccessMiddlewareHandler,
+          handler: resolve(config.rootDir, generatedAuthAccessMiddlewareHandler),
           middleware: true,
           route: "/**",
         }]

--- a/packages/auth/src/vue.ts
+++ b/packages/auth/src/vue.ts
@@ -1,0 +1,70 @@
+import { createAuthClient } from "better-auth/vue"
+import { computed } from "vue"
+
+import type { SessionQueryParams } from "better-auth"
+import type { BetterFetchError, VueAuthClient } from "better-auth/vue"
+import type { ComputedRef, DeepReadonly, Ref } from "vue"
+
+export { createAuthClient }
+export type { VueAuthClient } from "better-auth/vue"
+
+export const authClient: VueAuthClient<{}> = createAuthClient()
+
+export function useAuthClient(): typeof authClient {
+  return authClient
+}
+
+export interface AuthSessionState<Client extends VueAuthClient<any> = typeof authClient> {
+  data: Client["$Infer"]["Session"] | null
+  error: BetterFetchError | null
+  isPending: boolean
+  isRefetching: boolean
+  refetch: (queryParams?: { query?: SessionQueryParams }) => Promise<void>
+}
+
+type AuthSessionRef<Client extends VueAuthClient<any> = typeof authClient> = DeepReadonly<Ref<AuthSessionState<Client>>>
+
+export function useSession<Client extends VueAuthClient<any> = typeof authClient>(client: Client = authClient as Client): AuthSessionRef<Client> {
+  return client.useSession() as AuthSessionRef<Client>
+}
+
+type ClientSession<Client extends VueAuthClient<any>> = Client["$Infer"]["Session"]
+
+export interface UserSession<Client extends VueAuthClient<any> = typeof authClient> {
+  data: ComputedRef<ClientSession<Client> | null>
+  error: ComputedRef<BetterFetchError | null>
+  loggedIn: ComputedRef<boolean>
+  pending: ComputedRef<boolean>
+  ready: ComputedRef<boolean>
+  refresh: () => Promise<void>
+  session: ComputedRef<ClientSession<Client>["session"] | null>
+  signIn: Client["signIn"]
+  signOut: Client["signOut"]
+  signUp: Client["signUp"]
+  user: ComputedRef<ClientSession<Client>["user"] | null>
+}
+
+export function useUserSession<Client extends VueAuthClient<any> = typeof authClient>(client: Client = authClient as Client): UserSession<Client> {
+  const state = client.useSession() as AuthSessionRef<Client>
+  return {
+    data: computed(() => state.value.data),
+    error: computed(() => state.value.error),
+    loggedIn: computed(() => Boolean(state.value.data?.session && state.value.data?.user)),
+    pending: computed(() => state.value.isPending || state.value.isRefetching),
+    ready: computed(() => !state.value.isPending),
+    refresh: () => state.value.refetch(),
+    session: computed(() => state.value.data?.session ?? null),
+    signIn: client.signIn,
+    signOut: client.signOut,
+    signUp: client.signUp,
+    user: computed(() => state.value.data?.user ?? null),
+  }
+}
+
+export function useSignIn(): typeof authClient.signIn {
+  return authClient.signIn
+}
+
+export function useSignUp(): typeof authClient.signUp {
+  return authClient.signUp
+}

--- a/packages/auth/test/nuxt.test.ts
+++ b/packages/auth/test/nuxt.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
+import { hubEnv } from "@vite-hub/env/vite"
+
 import hubAuthNuxt from "../src/nuxt.ts"
 
 function createNuxt() {
@@ -106,6 +108,34 @@ describe("Auth Nuxt integration", () => {
     hubAuthNuxt({ env: { projectRoot: "../shared" } }, nuxt)
 
     expect((nuxt.options.alias as Record<string, string>)["#vitehub/env/server"]).toBe("/tmp/workspace/apps/shared/.vitehub/env/server.mjs")
+  })
+
+  it("reuses the installed Env plugin project root", () => {
+    const nuxt = createNuxt()
+    ;(nuxt.options as typeof nuxt.options & { vite: { plugins: unknown[], root: string } }).vite = {
+      plugins: [hubEnv({ projectRoot: "../shared" })],
+      root: "/tmp/workspace/apps/site",
+    }
+
+    hubAuthNuxt({}, nuxt)
+
+    expect((nuxt.options.alias as Record<string, string>)["#vitehub/env/server"]).toBe("/tmp/workspace/apps/shared/.vitehub/env/server.mjs")
+  })
+
+  it("validates an explicit Env root against the installed plugin", () => {
+    function createNuxtWithEnv() {
+      const nuxt = createNuxt()
+      ;(nuxt.options as typeof nuxt.options & { vite: { plugins: unknown[], root: string } }).vite = {
+        plugins: [hubEnv({ projectRoot: "../shared" })],
+        root: "/tmp/workspace/apps/site",
+      }
+      return nuxt
+    }
+
+    expect(() => hubAuthNuxt({ env: { projectRoot: "../shared" } }, createNuxtWithEnv())).not.toThrow()
+    expect(() => hubAuthNuxt({ env: { projectRoot: "../other" } }, createNuxtWithEnv())).toThrow(
+      "env.projectRoot must match the installed `@vite-hub/env/vite` plugin",
+    )
   })
 
   it("preserves the Vite Auth switch during Nitro replay", async () => {

--- a/packages/auth/test/nuxt.test.ts
+++ b/packages/auth/test/nuxt.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest"
+
+import hubAuthNuxt from "../src/nuxt.ts"
+
+function createNuxt() {
+  const hooks: Array<(config: Record<string, unknown>) => Promise<void>> = []
+  return {
+    hook(name: "nitro:config", handler: (config: Record<string, unknown>) => Promise<void>) {
+      expect(name).toBe("nitro:config")
+      hooks.push(handler)
+    },
+    hooks,
+    options: {
+      alias: { "#existing": "/tmp/existing.mjs" },
+      imports: {
+        imports: [{ from: "app/composables", name: "useSession" }],
+      },
+      nitro: {
+        alias: { "#nitro-existing": "/tmp/nitro-existing.mjs" },
+        plugins: ["/tmp/existing-plugin.mjs"],
+      },
+      rootDir: "/tmp/vitehub-auth-nuxt",
+    },
+  }
+}
+
+describe("Auth Nuxt integration", () => {
+  it("installs Vue composables and the server Env runtime once", () => {
+    const nuxt = createNuxt()
+
+    hubAuthNuxt({ importsFrom: "vite-hub/auth/vue" }, nuxt)
+    hubAuthNuxt({ importsFrom: "vite-hub/auth/vue" }, nuxt)
+    const vite = (nuxt.options as typeof nuxt.options & {
+      vite: { plugins: Array<{ name?: string }> }
+    }).vite
+
+    expect(nuxt.options.imports.imports).toEqual([
+      { from: "app/composables", name: "useSession" },
+      { from: "vite-hub/auth/vue", name: "useAuthClient" },
+      { from: "vite-hub/auth/vue", name: "useSignIn" },
+      { from: "vite-hub/auth/vue", name: "useSignUp" },
+      { from: "vite-hub/auth/vue", name: "useUserSession" },
+    ])
+    expect(nuxt.options.alias).toEqual({
+      "#existing": "/tmp/existing.mjs",
+      "#vitehub/env/public": "/tmp/vitehub-auth-nuxt/.vitehub/env/public.mjs",
+      "#vitehub/env/server": "/tmp/vitehub-auth-nuxt/.vitehub/env/server.mjs",
+    })
+    expect(nuxt.options.nitro.alias).toEqual({
+      "#nitro-existing": "/tmp/nitro-existing.mjs",
+      "#vitehub/env/public": "/tmp/vitehub-auth-nuxt/.vitehub/env/public.mjs",
+      "#vitehub/env/server": "/tmp/vitehub-auth-nuxt/.vitehub/env/server.mjs",
+    })
+    expect(nuxt.options.nitro.plugins).toHaveLength(2)
+    expect(nuxt.options.nitro.plugins[1]).toMatch(/\/runtime\/nuxt\.js$/)
+    expect(vite.plugins).toHaveLength(2)
+    expect(vite.plugins).toEqual([
+      expect.objectContaining({ name: "@vite-hub/env/vite" }),
+      expect.objectContaining({ name: "@vite-hub/auth/vite" }),
+    ])
+    expect(nuxt.hooks).toHaveLength(1)
+  })
+
+  it("keeps Auth enabled when Env is disabled", () => {
+    const nuxt = {
+      options: {
+        rootDir: "/tmp/vitehub-auth-nuxt",
+      },
+    }
+
+    hubAuthNuxt({ env: false }, nuxt)
+    const options = nuxt.options as typeof nuxt.options & {
+      imports: { imports: Array<{ from: string, name: string }> }
+      vite: { plugins: Array<{ name?: string }> }
+    }
+
+    expect(options.vite.plugins).toContainEqual(
+      expect.objectContaining({ name: "@vite-hub/auth/vite" }),
+    )
+    expect(options.imports.imports).toHaveLength(5)
+    expect(options).not.toHaveProperty("alias")
+    expect(options).not.toHaveProperty("nitro")
+  })
+
+  it("uses the configured roots for Auth discovery and Env imports", async () => {
+    const nuxt = createNuxt()
+    ;(nuxt.options as typeof nuxt.options & { vite: { root: string } }).vite = { root: "/tmp/vite-root" }
+
+    hubAuthNuxt({ env: { projectRoot: "/tmp/env-root" } }, nuxt)
+
+    expect((nuxt.options.alias as Record<string, string>)["#vitehub/env/server"]).toBe("/tmp/env-root/.vitehub/env/server.mjs")
+    const plugins = (nuxt.options as typeof nuxt.options & { vite: { plugins: Array<{ config?: (config: { root?: string }) => unknown, name?: string }> } }).vite.plugins
+    expect(plugins).toHaveLength(2)
+    const authPlugin = plugins.find(plugin => plugin.name === "@vite-hub/auth/vite")!
+    const authConfig = vi.fn(() => ({ nitro: {} }))
+    authPlugin.config = authConfig
+    await nuxt.hooks[0]({})
+    expect(authConfig).toHaveBeenCalledWith(expect.objectContaining({ root: "/tmp/vite-root" }), expect.anything())
+    expect(nuxt.hooks).toHaveLength(1)
+  })
+
+  it("does nothing before Nuxt initializes", () => {
+    expect(hubAuthNuxt()).toBeUndefined()
+  })
+})

--- a/packages/auth/test/nuxt.test.ts
+++ b/packages/auth/test/nuxt.test.ts
@@ -1,3 +1,7 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
 import { describe, expect, it, vi } from "vitest"
 
 import { hubEnv } from "@vite-hub/env/vite"
@@ -108,6 +112,24 @@ describe("Auth Nuxt integration", () => {
     hubAuthNuxt({ env: { projectRoot: "../shared" } }, nuxt)
 
     expect((nuxt.options.alias as Record<string, string>)["#vitehub/env/server"]).toBe("/tmp/workspace/apps/shared/.vitehub/env/server.mjs")
+  })
+
+  it("preserves automatic Env project-root detection", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-auth-nuxt-root-"))
+    const appRoot = join(root, "app")
+    await mkdir(appRoot)
+    await writeFile(join(root, "package.json"), JSON.stringify({ name: "auth-nuxt-root" }))
+    try {
+      const nuxt = createNuxt()
+      ;(nuxt.options as typeof nuxt.options & { vite: { root: string } }).vite = { root: appRoot }
+
+      hubAuthNuxt({}, nuxt)
+
+      expect((nuxt.options.alias as Record<string, string>)["#vitehub/env/server"]).toBe(join(root, ".vitehub/env/server.mjs"))
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
   })
 
   it("reuses the installed Env plugin project root", () => {

--- a/packages/auth/test/nuxt.test.ts
+++ b/packages/auth/test/nuxt.test.ts
@@ -99,6 +99,29 @@ describe("Auth Nuxt integration", () => {
     expect(nuxt.hooks).toHaveLength(1)
   })
 
+  it("resolves relative Env roots from the Vite root", () => {
+    const nuxt = createNuxt()
+    ;(nuxt.options as typeof nuxt.options & { vite: { root: string } }).vite = { root: "/tmp/workspace/apps/site" }
+
+    hubAuthNuxt({ env: { projectRoot: "../shared" } }, nuxt)
+
+    expect((nuxt.options.alias as Record<string, string>)["#vitehub/env/server"]).toBe("/tmp/workspace/apps/shared/.vitehub/env/server.mjs")
+  })
+
+  it("preserves the Vite Auth switch during Nitro replay", async () => {
+    const nuxt = createNuxt()
+    ;(nuxt.options as typeof nuxt.options & { vite: { auth: false } }).vite = { auth: false }
+
+    hubAuthNuxt({}, nuxt)
+
+    const plugins = (nuxt.options as typeof nuxt.options & { vite: { plugins: Array<{ config?: (config: { auth?: false }) => unknown, name?: string }> } }).vite.plugins
+    const authPlugin = plugins.find(plugin => plugin.name === "@vite-hub/auth/vite")!
+    const authConfig = vi.fn(() => ({ nitro: {} }))
+    authPlugin.config = authConfig
+    await nuxt.hooks[0]({})
+    expect(authConfig).toHaveBeenCalledWith(expect.objectContaining({ auth: false }), expect.anything())
+  })
+
   it("does nothing before Nuxt initializes", () => {
     expect(hubAuthNuxt()).toBeUndefined()
   })

--- a/packages/auth/test/package.test.ts
+++ b/packages/auth/test/package.test.ts
@@ -13,9 +13,11 @@ describe("@vite-hub/auth package contract", () => {
     expect(Object.keys(packageJson.exports).sort()).toEqual([
       ".",
       "./agent",
+      "./nuxt",
       "./package.json",
       "./server",
       "./vite",
+      "./vue",
     ])
   })
 
@@ -23,7 +25,9 @@ describe("@vite-hub/auth package contract", () => {
     await verifyBuiltPackageExports(new URL("../", import.meta.url), "@vite-hub/auth", [
       ".",
       "./agent",
+      "./nuxt",
       "./server",
+      "./vue",
       "./vite",
     ])
   })

--- a/packages/auth/test/published-types.test.ts
+++ b/packages/auth/test/published-types.test.ts
@@ -19,6 +19,7 @@ const packedPackages = [
   "agent",
   "auth",
   "box",
+  "env",
   "markdown-template",
   "rate-limit",
   "runtime",

--- a/packages/auth/test/vite.test.ts
+++ b/packages/auth/test/vite.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { dirname, join } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { afterEach, describe, expect, it } from "vitest"
@@ -169,7 +169,7 @@ describe("hubAuth", () => {
     expect(config({ root })).toMatchObject({
       nitro: {
         handlers: [{
-          handler: ".vitehub/auth/route.ts",
+          handler: resolve(root, ".vitehub/auth/route.ts"),
           route: "/api/auth/**",
         }],
       },
@@ -195,11 +195,11 @@ describe("hubAuth", () => {
       nitro: {
         handlers: [
           {
-            handler: ".vitehub/auth/route.ts",
+            handler: resolve(root, ".vitehub/auth/route.ts"),
             route: "/api/auth/**",
           },
           {
-            handler: ".vitehub/auth/access-middleware.ts",
+            handler: resolve(root, ".vitehub/auth/access-middleware.ts"),
             middleware: true,
             route: "/**",
           },
@@ -220,7 +220,7 @@ describe("hubAuth", () => {
     expect(config({ root })).toMatchObject({
       nitro: {
         handlers: [{
-          handler: ".vitehub/auth/route.ts",
+          handler: resolve(root, ".vitehub/auth/route.ts"),
           route: "/auth/**",
         }],
       },

--- a/packages/auth/test/vue.test.ts
+++ b/packages/auth/test/vue.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest"
+
+import { authClient, createAuthClient, useAuthClient, useSession, useSignIn, useSignUp, useUserSession } from "../src/vue.ts"
+
+describe("Vue Auth composables", () => {
+  it("projects the shared Better Auth Vue client", () => {
+    expect(useAuthClient() === authClient).toBe(true)
+    expect(useSession()).toBeDefined()
+    expect(typeof useSignIn()).toBe("function")
+    expect(typeof useSignUp()).toBe("function")
+  })
+
+  it("keeps Better Auth client configuration available", () => {
+    const client = createAuthClient({ basePath: "/auth" })
+    const session = useUserSession(client)
+
+    expect(client.useSession).toBeTypeOf("function")
+    expect(session.loggedIn.value).toBe(false)
+  })
+})

--- a/packages/auth/tsconfig.json
+++ b/packages/auth/tsconfig.json
@@ -14,6 +14,12 @@
       "#vitehub/auth/server": [
         "packages/auth/src/server.ts"
       ],
+      "#vitehub/env/server": [
+        "packages/auth/src/runtime/env.d.ts"
+      ],
+      "@vite-hub/auth/server": [
+        "packages/auth/src/server.ts"
+      ],
       "@vite-hub/internal/*": [
         "packages/internal/src/*.ts"
       ],

--- a/packages/auth/vite.config.ts
+++ b/packages/auth/vite.config.ts
@@ -4,7 +4,15 @@ export default defineConfig({
   pack: {
     tsconfig: "tsconfig.build.json",
     deps: {
-      neverBundle: ["better-auth", "vite", "#vitehub/auth/definition"],
+      neverBundle: [
+        "better-auth",
+        "vue",
+        "vite",
+        "#vitehub/auth/definition",
+        "#vitehub/env/server",
+        "@vite-hub/auth/server",
+        /^@vite-hub\/env(?:\/|$)/,
+      ],
       alwaysBundle: [/^@vite-hub\/internal/],
       onlyBundle: false,
     },
@@ -12,13 +20,16 @@ export default defineConfig({
       "src/agent.ts",
       "src/index.ts",
       "src/runtime/empty-definition.ts",
+      "src/runtime/nuxt.ts",
       "src/server.ts",
+      "src/nuxt.ts",
+      "src/vue.ts",
       "src/vite.ts",
     ],
     exports: {
       customExports(exports) {
         return Object.fromEntries(
-          Object.entries(exports).filter(([key]) => key !== "./runtime/empty-definition"),
+          Object.entries(exports).filter(([key]) => !["./runtime/empty-definition", "./runtime/nuxt"].includes(key)),
         )
       },
       inlinedDependencies: false,

--- a/packages/env/src/vite.ts
+++ b/packages/env/src/vite.ts
@@ -45,6 +45,7 @@ export { env }
 export interface EnvVitePluginAPI {
   getPublicEnv: () => Record<string, unknown>
   getServerEnvRegistry: () => EnvRuntimeRegistry
+  resolveProjectRoot: (viteRoot: string) => string
 }
 
 export type EnvVitePlugin = Plugin & { api: EnvVitePluginAPI }
@@ -73,11 +74,12 @@ export function hubEnv(options: EnvIntegrationOptions = {}): EnvVitePlugin {
   let diagnosticsText: string | undefined
   const getPublicEnv = () => buildPublicConfig
   const getServerEnvRegistry = () => serverRegistry
+  const resolveProjectRoot = (viteRoot: string) => resolveViteHubProjectRoot(resolve(viteRoot), { projectRoot: options.projectRoot })
   const runtimeImports = resolveRuntimeImports(options.runtimeImports)
 
   return {
     name: ENV_VITE_PLUGIN_NAME,
-    api: { getPublicEnv, getServerEnvRegistry },
+    api: { getPublicEnv, getServerEnvRegistry, resolveProjectRoot },
     async config(config, env) {
       const envConfig = (config as UserConfig & EnvViteUserConfig).env
       validateEnvConfigShape(envConfig, "vite")
@@ -85,7 +87,7 @@ export function hubEnv(options: EnvIntegrationOptions = {}): EnvVitePlugin {
         return
       }
 
-      const root = resolveViteHubProjectRoot(resolve(config.root || process.cwd()), { projectRoot: options.projectRoot })
+      const root = resolveProjectRoot(config.root || process.cwd())
       const loadedEnv = loadEnv(env.mode, root, "")
       const context = createSourceContext({
         env: { ...loadedEnv, ...process.env },
@@ -125,7 +127,7 @@ export function hubEnv(options: EnvIntegrationOptions = {}): EnvVitePlugin {
       if (diagnosticsText) {
         config.logger.info(diagnosticsText)
       }
-      const projectRoot = resolveViteHubProjectRoot(config.root, { projectRoot: options.projectRoot })
+      const projectRoot = resolveProjectRoot(config.root)
       const packageRoot = await resolvePackageRoot(config.root, projectRoot)
       await refreshEnvGeneratedFiles(projectRoot, packageRoot, buildPublicConfig, serverRegistry, runtimeImports)
     },

--- a/packages/env/test/vite.test.ts
+++ b/packages/env/test/vite.test.ts
@@ -22,6 +22,10 @@ import { booleanSchema, stringSchema } from "./helpers.ts"
 afterEach(() => vi.unstubAllEnvs())
 
 describe("Vite plugin", () => {
+  it("exposes its resolved project root", () => {
+    expect(hubEnv({ projectRoot: "../shared" }).api.resolveProjectRoot("/tmp/workspace/apps/site")).toBe("/tmp/workspace/apps/shared")
+  })
+
   it("loads Vite env, validates build values, injects define, and serves virtual config", async () => {
     vi.stubEnv("GITHUB_REF_TYPE", "")
 

--- a/packages/vite-hub/fixtures/published-types/consumer.ts
+++ b/packages/vite-hub/fixtures/published-types/consumer.ts
@@ -13,6 +13,7 @@ import * as localHarnessSandbox from "vite-hub/agent/harness/local-sandbox"
 import * as agentServer from "vite-hub/agent/server"
 import * as agentSqliteState from "vite-hub/agent/state/sqlite"
 import * as authAgent from "vite-hub/auth/agent"
+import { createAuthClient, useUserSession } from "vite-hub/auth/vue"
 import type { BoxDefinition } from "vite-hub/box"
 import * as smtp from "vite-hub/email/drivers/smtp"
 import { env } from "vite-hub/env"
@@ -47,6 +48,8 @@ export const appFacingModules = [
 ]
 
 export const nuxtModule = viteHubNuxtModule
+export const customAuthClient = createAuthClient({ basePath: "/auth" })
+export const userSession = useUserSession(customAuthClient)
 export const builtInAgent = defineAgent({ driver: "codex", runtime: false })
 export const builtInBox = { runtime: "trusted-host" } satisfies BoxDefinition
 export const builtInAgentName = "codex" satisfies BuiltInAgentDriverName

--- a/packages/vite-hub/package.json
+++ b/packages/vite-hub/package.json
@@ -73,6 +73,7 @@
     "./auth": "./dist/auth.js",
     "./auth/agent": "./dist/auth/agent.js",
     "./auth/server": "./dist/auth/server.js",
+    "./auth/vue": "./dist/auth/vue.js",
     "./blob": "./dist/blob.js",
     "./blob/content-type": "./dist/blob/content-type.js",
     "./box": "./dist/box.js",

--- a/packages/vite-hub/src/auth/vue.ts
+++ b/packages/vite-hub/src/auth/vue.ts
@@ -1,0 +1,1 @@
+export * from "@vite-hub/auth/vue"

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -1,6 +1,7 @@
 import { join } from "node:path"
 
 import { VITEHUB_GENERATED_ROOT, VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
+import hubAuthNuxt from "@vite-hub/auth/nuxt"
 import { hubDb as hubDatabaseNuxt } from "@vite-hub/database/nuxt"
 import { mergeConfig } from "vite"
 
@@ -174,6 +175,17 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
     ...existing,
   ] as PluginOption[]
   nuxt.hook?.("nitro:config", config => applyNitroConfig(installedPlugins, config, nuxt))
+  if (options.auth) {
+    const envOptions = options.env || {}
+    hubAuthNuxt({
+      auth: options.auth === true ? undefined : options.auth,
+      env: options.env === false
+        ? false
+        : { projectRoot: envOptions.projectRoot || nuxt.options.vite?.root || nuxt.options.rootDir },
+      importsFrom: "vite-hub/auth/vue",
+      nitro: false,
+    }, nuxt)
+  }
   if (options.database) {
     await hubDatabaseNuxt(options.database === true ? {} : options.database)(undefined, nuxt)
     if (!nuxt.options.dev) {

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -181,7 +181,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
       auth: options.auth === true ? undefined : options.auth,
       env: options.env === false
         ? false
-        : { projectRoot: envOptions.projectRoot || nuxt.options.vite?.root || nuxt.options.rootDir },
+        : { projectRoot: envOptions.projectRoot },
       importsFrom: "vite-hub/auth/vue",
       nitro: false,
     }, nuxt)

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -359,7 +359,7 @@ describe("ViteHub Nuxt integration", () => {
 
     await viteHubNuxtModule({ auth: true, preset: "cloudflare" }, nuxt)
 
-    expect((nuxt.options.alias as Record<string, string>)["#vitehub/env/server"]).toBe(resolve("app/.vitehub/env/server.mjs"))
+    expect((nuxt.options.alias as Record<string, string>)["#vitehub/env/server"]).toBe(resolve(".vitehub/env/server.mjs"))
   })
 
   it("keeps Auth composables without Env runtime wiring", async () => {

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -68,6 +68,7 @@ function createNuxt(dev = false, plugins: PluginOption[] = []) {
     },
   }
   return {
+    nitroConfigHooks,
     nuxt,
     async runNitroConfigHook(config: Record<string, unknown>) {
       if (!nitroConfigHooks.length) throw new TypeError("Expected a Nitro config hook.")
@@ -326,6 +327,41 @@ describe("ViteHub Nuxt integration", () => {
     await runNitroConfigHook(nitroConfig)
 
     expect(nitroConfig.alias["@vite-hub/database/runtime/state"]).toBe("./custom-database-state.ts")
+  })
+
+  it("installs the Auth Vue and server runtime integration through the framework module", async () => {
+    const { nitroConfigHooks, nuxt } = createNuxt()
+
+    await viteHubNuxtModule({ auth: true, preset: "cloudflare" }, nuxt)
+
+    const options = nuxt.options as typeof nuxt.options & {
+      imports: { imports: Array<{ from: string, name: string }> }
+      nitro: { alias: Record<string, string>, plugins: string[] }
+    }
+    expect(options.imports.imports).toEqual([
+      { from: "vite-hub/auth/vue", name: "useAuthClient" },
+      { from: "vite-hub/auth/vue", name: "useSession" },
+      { from: "vite-hub/auth/vue", name: "useSignIn" },
+      { from: "vite-hub/auth/vue", name: "useSignUp" },
+      { from: "vite-hub/auth/vue", name: "useUserSession" },
+    ])
+    expect(options.nitro.alias["#vitehub/env/server"]).toBe("/tmp/vitehub-nuxt/.vitehub/env/server.mjs")
+    expect(options.nitro.plugins).toHaveLength(1)
+    expect(options.nitro.plugins[0]).toMatch(/\/runtime\/nuxt\.js$/)
+    expect(nitroConfigHooks).toHaveLength(1)
+  })
+
+  it("keeps Auth composables without Env runtime wiring", async () => {
+    const { nuxt } = createNuxt()
+
+    await viteHubNuxtModule({ auth: true, env: false, preset: "cloudflare" }, nuxt)
+
+    const options = nuxt.options as typeof nuxt.options & {
+      imports: { imports: Array<{ from: string, name: string }> }
+    }
+    expect(options.imports.imports).toHaveLength(5)
+    expect(options.alias).not.toHaveProperty("#vitehub/env/server")
+    expect(options).not.toHaveProperty("nitro")
   })
 
   it("does not concatenate complete Nitro arrays returned by config hooks", async () => {

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -1,3 +1,5 @@
+import { resolve } from "node:path"
+
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { VITEHUB_GENERATED_ROOT, VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
@@ -349,6 +351,15 @@ describe("ViteHub Nuxt integration", () => {
     expect(options.nitro.plugins).toHaveLength(1)
     expect(options.nitro.plugins[0]).toMatch(/\/runtime\/nuxt\.js$/)
     expect(nitroConfigHooks).toHaveLength(1)
+  })
+
+  it("does not resolve a relative Vite root twice for Auth Env imports", async () => {
+    const { nuxt } = createNuxt()
+    Object.assign(nuxt.options.vite, { root: "app" })
+
+    await viteHubNuxtModule({ auth: true, preset: "cloudflare" }, nuxt)
+
+    expect((nuxt.options.alias as Record<string, string>)["#vitehub/env/server"]).toBe(resolve("app/.vitehub/env/server.mjs"))
   })
 
   it("keeps Auth composables without Env runtime wiring", async () => {

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest"
 import * as ownerAgent from "@vite-hub/agent"
 import * as ownerCapabilities from "@vite-hub/agent/capabilities"
 import ownerAuthHandler from "@vite-hub/auth/server"
+import * as ownerAuthVue from "@vite-hub/auth/vue"
 import * as ownerBlobContentType from "@vite-hub/blob/content-type"
 import { setActiveCloudflareEnv as ownerCloudflareEnvSetter } from "@vite-hub/database/runtime/cloudflare-env"
 import { setActiveCloudflareEnv as ownerDatabaseStateSetter } from "@vite-hub/database/runtime/state"
@@ -14,6 +15,7 @@ import * as framework from "vite-hub"
 import * as frameworkAgent from "vite-hub/agent"
 import * as frameworkCapabilities from "vite-hub/agent/capabilities"
 import frameworkAuthHandler from "vite-hub/auth/server"
+import * as frameworkAuthVue from "vite-hub/auth/vue"
 import * as frameworkBlobContentType from "vite-hub/blob/content-type"
 import * as frameworkRateLimit from "vite-hub/rate-limit"
 import { setActiveCloudflareEnv as frameworkDatabaseStateSetter } from "vite-hub/_internal/database/runtime/state"
@@ -136,6 +138,8 @@ describe("framework package contract", () => {
     expect(frameworkCapabilities.email).toBe(ownerCapabilities.email)
     expect(frameworkCapabilities.workspaceShell).toBe(ownerCapabilities.workspaceShell)
     expect(frameworkAuthHandler).toBe(ownerAuthHandler)
+    expect(frameworkAuthVue.authClient).toBe(ownerAuthVue.authClient)
+    expect(frameworkAuthVue.useUserSession).toBe(ownerAuthVue.useUserSession)
     expect(frameworkBlobContentType.detectContentType).toBe(ownerBlobContentType.detectContentType)
     expect(frameworkRateLimit.requireRateLimit).toBe(ownerRateLimit.requireRateLimit)
     expect(frameworkRateLimit.createRateLimiter).toBe(ownerRateLimit.createRateLimiter)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -621,6 +621,9 @@ importers:
 
   packages/auth:
     dependencies:
+      '@vite-hub/env':
+        specifier: workspace:*
+        version: link:../env
       '@vite-hub/runtime':
         specifier: workspace:*
         version: link:../runtime
@@ -652,6 +655,9 @@ importers:
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
         version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
+      vue:
+        specifier: catalog:ui
+        version: 3.5.40(typescript@6.0.3)
 
   packages/blob:
     dependencies:


### PR DESCRIPTION
## Summary

- expose the Better Auth Vue client and normalized session composables from `@vite-hub/auth/vue`, with a `vite-hub/auth/vue` forwarder
- add an owner-package Nuxt integration that installs Auth, auto-imports the Vue composables, and resolves server Env at runtime
- delegate umbrella Nuxt Auth setup to that owner integration while preserving `env: false` and custom Better Auth clients

This upstreams the reusable Auth seam proven in the `wiki-2` patch without taking ownership of Wiki UI, routes, or workflows.

## Verification

- `corepack pnpm --filter @vite-hub/auth typecheck`
- `corepack pnpm --filter @vite-hub/auth build` — build and publint passed
- focused `@vite-hub/auth` Vue, Nuxt, and package tests — 7 passed, no type errors
- focused `vite-hub` Nuxt tests — 9 passed, no type errors
- changed-file lint and `git diff --check`

## Downstream proof gaps

- Published installed-package/type proof is not captured: the dependency-reuse worktree did not expose the complete built owner-package graph, so the umbrella package contract stopped while resolving the unbuilt `vite-hub` entry.
- A disposable `wiki-2` build without the Auth/Vue patch hunks is not captured: shared disk pressure ruled out another full monorepo or consumer install.
