### PR TITLE
fix(agent): time out Harness attachment resolution

### DIFF
--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -111,6 +111,7 @@ const harnessGeneratedFiles = ["harness-tool.mjs"] as const
 const harnessInstructionFiles = ["AGENTS.md", "CLAUDE.md"] as const
 const harnessAttachmentDirectory = ".vitehub/attachments"
 const harnessAttachmentMaxBytes = 25 * 1024 * 1024
+const harnessAttachmentResolutionTimeoutMs = 15_000
 const harnessAgentPackage = "@ai-sdk/harness/agent"
 const harnessRemoveDirectory = Symbol.for("vitehub.harnessRemoveDirectory")
 const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
@@ -582,17 +583,31 @@ async function resolveHarnessAttachmentData(
     throw abortSignalError(abortSignal, "[vitehub] Harness attachment resolution aborted.")
   }
   const fetchedPromise = resolveAttachmentData(part)
-  const fetched = abortSignal
-    ? await new Promise<AttachmentData | undefined>((resolve, reject) => {
-        const onAbort = () => {
-          abortSignal.removeEventListener("abort", onAbort)
-          reject(abortSignalError(abortSignal, "[vitehub] Harness attachment resolution aborted."))
-        }
-        if (abortSignal.aborted) return onAbort()
-        abortSignal.addEventListener("abort", onAbort, { once: true })
-        fetchedPromise.then(resolve, reject).finally(() => abortSignal.removeEventListener("abort", onAbort))
-      })
-    : await fetchedPromise
+  const fetched = await new Promise<AttachmentData | undefined>((resolve, reject) => {
+    const cleanup = () => {
+      clearTimeout(timeout)
+      abortSignal?.removeEventListener("abort", onAbort)
+    }
+    const onAbort = () => {
+      cleanup()
+      reject(abortSignalError(abortSignal!, "[vitehub] Harness attachment resolution aborted."))
+    }
+    const timeout = setTimeout(() => {
+      cleanup()
+      reject(new Error(`[vitehub] Harness attachment resolution timed out after ${harnessAttachmentResolutionTimeoutMs}ms.`))
+    }, harnessAttachmentResolutionTimeoutMs)
+    abortSignal?.addEventListener("abort", onAbort, { once: true })
+    fetchedPromise.then(
+      (value) => {
+        cleanup()
+        resolve(value)
+      },
+      (error) => {
+        cleanup()
+        reject(error)
+      },
+    )
+  })
   return isAttachmentData(fetched) ? fetched : undefined
 }
 

--- a/packages/agent/test/harness-chat-history.test.ts
+++ b/packages/agent/test/harness-chat-history.test.ts
@@ -22,6 +22,7 @@ interface CapturedTurn {
 const roots: string[] = []
 
 afterEach(async () => {
+  vi.useRealTimers()
   vi.restoreAllMocks()
   await Promise.all(roots.splice(0).map(root => rm(root, { force: true, recursive: true })))
 })
@@ -344,6 +345,43 @@ describe("Harness chat history", () => {
     controller.abort(new Error("request closed"))
 
     await expect(invocation).rejects.toThrow("request closed")
+    expect(turns).toEqual([])
+    expect(await attachmentPaths(root)).toEqual([])
+  })
+
+  it("times out stalled Channel attachment resolution before Harness invocation", async () => {
+    vi.useFakeTimers()
+    const root = await createRoot()
+    const turns: CapturedTurn[] = []
+    let markFetchStarted!: () => void
+    const fetchStarted = new Promise<void>((resolve) => {
+      markFetchStarted = resolve
+    })
+    const agent = defineAgent({
+      driver: {
+        harness: createHistoryHarness(turns),
+        sandbox: createLocalHarnessSandbox({ rootDir: root }),
+      },
+    })
+
+    const invocation = runAgent(agent, runtime, {
+      context: { chat: {} },
+      messages: [createMessage({
+        parts: [{
+          fetchData: () => {
+            markFetchStarted()
+            return new Promise<Uint8Array>(() => {})
+          },
+          mediaType: "image/png",
+          type: "image",
+        }],
+        role: "user",
+      })],
+    })
+    await fetchStarted
+    await vi.advanceTimersByTimeAsync(15_000)
+
+    await expect(invocation).rejects.toThrow("Harness attachment resolution timed out after 15000ms")
     expect(turns).toEqual([])
     expect(await attachmentPaths(root)).toEqual([])
   })


### PR DESCRIPTION
Channel attachment callbacks can currently stall forever before a Harness turn starts. This caps each attachment resolution at 15 seconds, while preserving the invocation abort reason when the caller cancels first.

The regression uses a stalled `fetchData()` callback and verifies that the Harness is never invoked and its temporary attachment directory stays clean.

Verification:
- `corepack pnpm --filter @vite-hub/agent exec vp test run test/harness-chat-history.test.ts` (9 passed)
- `corepack pnpm --filter @vite-hub/agent typecheck`
- `corepack pnpm --filter @vite-hub/agent exec vp lint src/harness-agent.ts test/harness-chat-history.test.ts`
- `corepack pnpm --filter @vite-hub/agent build` (including publint)
- Installed `@vite-hub/agent@b0bfc3f` from pkg.pr.new in an empty consumer, then verified a stalled image `fetchData()` rejected after 15134ms without invoking the Harness