### PR TITLE
fix(vite-hub): preserve database runtime package boundary

### DIFF
--- a/packages/vite-hub/src/_internal/database/runtime/state.ts
+++ b/packages/vite-hub/src/_internal/database/runtime/state.ts
@@ -1,1 +1,4 @@
-export { setActiveCloudflareEnv } from "@vite-hub/database/runtime/cloudflare-env"
+import { setActiveCloudflareEnv as ownerSetActiveCloudflareEnv } from "@vite-hub/database/runtime/cloudflare-env"
+
+export const setActiveCloudflareEnv: (env: Record<string, unknown> | undefined) => void
+  = ownerSetActiveCloudflareEnv

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path"
+import { fileURLToPath } from "node:url"
 
 import { VITEHUB_GENERATED_ROOT, VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import hubAuthNuxt from "@vite-hub/auth/nuxt"
@@ -8,6 +9,8 @@ import { mergeConfig } from "vite"
 import { vitehub } from "./index.ts"
 
 import type { Plugin, PluginOption, UserConfig } from "vite"
+
+const databaseRuntimeState = fileURLToPath(new URL("./_internal/database/runtime/state", import.meta.url))
 
 type NuxtLike = {
   hook?: (name: "nitro:config", callback: (config: Record<string, unknown>) => Promise<void>) => void
@@ -187,12 +190,14 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
     }, nuxt)
   }
   if (options.database) {
+    const nuxtAlias = (nuxt.options.alias ??= {})
+    nuxtAlias["@vite-hub/database/runtime/state"] ??= databaseRuntimeState
     await hubDatabaseNuxt(options.database === true ? {} : options.database)(undefined, nuxt)
     if (!nuxt.options.dev) {
       nuxt.hook?.("nitro:config", async (config) => {
         const alias = (config.alias ??= {}) as Record<string, string>
         alias["@vite-hub/database/runtime/state"]
-          ??= "vite-hub/_internal/database/runtime/state"
+          ??= nuxtAlias["@vite-hub/database/runtime/state"]
       })
     }
   }

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -1,10 +1,13 @@
 import { resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 import { VITEHUB_GENERATED_ROOT, VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import type { PluginOption } from "vite"
+
+const databaseRuntimeState = fileURLToPath(new URL("../src/_internal/database/runtime/state", import.meta.url))
 
 const mocks = vi.hoisted(() => ({
   objectHook: vi.fn((config: { nitro?: Record<string, unknown> }) => ({
@@ -299,26 +302,33 @@ describe("ViteHub Nuxt integration", () => {
     expect((nuxt.options.vite.plugins as unknown[]).flat(Infinity)).toContainEqual(
       expect.objectContaining({ name: "@vite-hub/database/vite" }),
     )
+    expect((nuxt.options.alias as Record<string, string>)["@vite-hub/database/runtime/state"])
+      .toBe(databaseRuntimeState)
     expect(nitroConfig).toMatchObject({
       alias: {
         "@vite-hub/database/drizzle": "/tmp/vitehub-nuxt/custom-vite-root/.vitehub/database/cloudflare-runtime.mjs",
-        "@vite-hub/database/runtime/state": "vite-hub/_internal/database/runtime/state",
+        "@vite-hub/database/runtime/state": databaseRuntimeState,
       },
     })
   })
 
-  it("keeps the Database Nuxt runtime alias out of development", async () => {
+  it("keeps the Database Nitro runtime alias out of development", async () => {
     const { nuxt, runNitroConfigHook } = createNuxt(true)
 
     await viteHubNuxtModule({ database: true, preset: "cloudflare" }, nuxt)
     const nitroConfig = {}
     await runNitroConfigHook(nitroConfig)
 
+    expect((nuxt.options.alias as Record<string, string>)["@vite-hub/database/runtime/state"])
+      .toBe(databaseRuntimeState)
     expect(nitroConfig).not.toHaveProperty("alias.@vite-hub/database/runtime/state")
   })
 
   it("preserves an explicitly configured Database runtime alias", async () => {
     const { nuxt, runNitroConfigHook } = createNuxt()
+    Object.assign(nuxt.options.alias, {
+      "@vite-hub/database/runtime/state": "./custom-nuxt-database-state.ts",
+    })
 
     await viteHubNuxtModule({ database: true, preset: "cloudflare" }, nuxt)
     const nitroConfig = {
@@ -328,6 +338,8 @@ describe("ViteHub Nuxt integration", () => {
     }
     await runNitroConfigHook(nitroConfig)
 
+    expect((nuxt.options.alias as Record<string, string>)["@vite-hub/database/runtime/state"])
+      .toBe("./custom-nuxt-database-state.ts")
     expect(nitroConfig.alias["@vite-hub/database/runtime/state"]).toBe("./custom-database-state.ts")
   })
 

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -83,10 +83,6 @@ const generatedRuntimeOwnerExports = new Set([
   "@vite-hub/workflow/runtime/vercel-vite",
 ])
 
-const frameworkForwarderTargets = new Map([
-  ["./_internal/database/runtime/state", "@vite-hub/database/runtime/cloudflare-env"],
-])
-
 function sourceForwarderTargets(source: string): string[] | undefined {
   const lines = source.split(/\r?\n/).map(line => line.trim()).filter(Boolean)
   if (!lines.length) return
@@ -169,13 +165,12 @@ describe("framework package contract", () => {
       .filter(({ source }) => !exportedForwarders.has(source))
       .map(({ subpath }) => subpath)
       .sort(),
-    ).toEqual([".", "./_internal/kv/runtime/disabled-upstash", "./nuxt"])
+    ).toEqual([".", "./_internal/database/runtime/state", "./_internal/kv/runtime/disabled-upstash", "./nuxt"])
 
     for (const { subpath, targets } of manifestForwarders) {
       const ownerSpecifier = ownerSpecifierForDistributionSubpath(subpath)
-      const expectedTarget = frameworkForwarderTargets.get(subpath) || ownerSpecifier
-      const ownerPackage = expectedTarget.split("/").slice(0, 2).join("/")
-      expect([...new Set(targets)], subpath).toEqual([expectedTarget])
+      const ownerPackage = ownerSpecifier.split("/").slice(0, 2).join("/")
+      expect([...new Set(targets)], subpath).toEqual([ownerSpecifier])
       expect(manifest.dependencies[ownerPackage], subpath).toBeDefined()
     }
   })

--- a/packages/vite-hub/test/published-types.test.ts
+++ b/packages/vite-hub/test/published-types.test.ts
@@ -1,5 +1,7 @@
 import { execFile } from "node:child_process"
-import { resolve } from "node:path"
+import { copyFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { promisify } from "node:util"
 
@@ -11,4 +13,37 @@ const tsc = resolve(packageRoot, "../../node_modules/typescript/bin/tsc")
 
 it("publishes Env's Vite config augmentation from the framework root", async () => {
   await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", resolve(packageRoot, "fixtures/published-types")])
+}, 10_000)
+
+it("keeps the installed Database runtime facade declaration self-contained", async () => {
+  const consumerRoot = await mkdtemp(resolve(tmpdir(), "vite-hub-database-types-"))
+  const installedRoot = resolve(consumerRoot, "node_modules/vite-hub")
+  const installedState = resolve(installedRoot, "dist/_internal/database/runtime/state")
+
+  try {
+    await mkdir(dirname(installedState), { recursive: true })
+    await copyFile(resolve(packageRoot, "package.json"), resolve(installedRoot, "package.json"))
+    await copyFile(resolve(packageRoot, "dist/_internal/database/runtime/state.js"), `${installedState}.js`)
+    await copyFile(resolve(packageRoot, "dist/_internal/database/runtime/state.d.ts"), `${installedState}.d.ts`)
+    await writeFile(resolve(consumerRoot, "consumer.ts"), `
+      import { setActiveCloudflareEnv } from "vite-hub/_internal/database/runtime/state"
+      setActiveCloudflareEnv({ DB: {} })
+    `)
+    await writeFile(resolve(consumerRoot, "package.json"), JSON.stringify({ private: true, type: "module" }))
+    await writeFile(resolve(consumerRoot, "tsconfig.json"), JSON.stringify({
+      compilerOptions: {
+        module: "NodeNext",
+        moduleResolution: "NodeNext",
+        noEmit: true,
+        strict: true,
+        types: [],
+      },
+      files: ["consumer.ts"],
+    }))
+
+    await execFileAsync(process.execPath, [tsc, "--noEmit", "-p", consumerRoot])
+  }
+  finally {
+    await rm(consumerRoot, { recursive: true, force: true })
+  }
 }, 10_000)


### PR DESCRIPTION
## Summary

Nuxt consumers of the umbrella package received a bare Database runtime alias, which Nuxt serialized as a path relative to its generated directory. The umbrella facade declaration also exposed the nested `@vite-hub/database` package, so isolated installs could not type-resolve the facade without linker-specific visibility.

This change resolves the facade to an absolute path owned by `vite-hub` for Nuxt and production Nitro, while preserving explicit consumer aliases. It also gives the facade a self-contained declaration without wrapping or replacing the owner package's runtime setter.

## Verification

- `corepack pnpm --filter vite-hub test` — 9 files and 95 tests passed, with no type errors; dependency builds passed publint
- `corepack pnpm --filter vite-hub typecheck`
- `corepack pnpm exec vp check --no-fmt` on the five changed files
- Added an installed-consumer typecheck with no hoisted `@vite-hub/database` package
