### PR TITLE
fix(database): preserve Nuxt migration directory

### DIFF
--- a/packages/database/src/config.ts
+++ b/packages/database/src/config.ts
@@ -48,14 +48,19 @@ function objectLiteralBody(value: string | undefined) {
   return closeIndex === undefined ? undefined : trimmed.slice(1, closeIndex)
 }
 
+function stripLeadingEntryComments(entry: string) {
+  return entry.replace(/^(?:\s|\/\/[^\n]*(?:\n|$)|\/\*[\s\S]*?\*\/)+/, "")
+}
+
 function readEntryKey(entry: string): string | undefined {
-  const match = /^\s*(?:([A-Za-z_$][\w$]*)|["']([^"']+)["'])\s*(?::|$)/.exec(entry)
-  return match?.[1] || match?.[2]
+  const match = /^\s*(?:([A-Za-z_$][\w$]*)|["']([^"']+)["']|\[\s*["']([^"']+)["']\s*\])\s*(?::|$)/.exec(stripLeadingEntryComments(entry))
+  return match?.[1] || match?.[2] || match?.[3]
 }
 
 function readEntryValue(entry: string): string | undefined {
-  const match = /^\s*(?:[A-Za-z_$][\w$]*|["'][^"']+["'])\s*:/.exec(entry)
-  return match ? entry.slice(match[0].length).trim() : undefined
+  const normalized = stripLeadingEntryComments(entry)
+  const match = /^\s*(?:[A-Za-z_$][\w$]*|["'][^"']+["']|\[\s*["'][^"']+["']\s*\])\s*:/.exec(normalized)
+  return match ? normalized.slice(match[0].length).trim() : undefined
 }
 
 function readObjectPropertyValue(body: string | undefined, property: string): string | undefined {
@@ -132,9 +137,26 @@ function readStringValue(body: string | undefined, property: string): string | u
   return typeof resolved === "string" && resolved.trim() ? resolved : undefined
 }
 
-function readDefinitionCloudflareConfig(file: string): CloudflareD1BindingConfig | undefined {
-  const body = objectLiteralBody(readObjectPropertyValue(readDefinitionObjectBody(file), "cloudflare"))
-  if (!body) return
+function readDefinitionCloudflareConfig(file: string): { configured: boolean, value?: CloudflareD1BindingConfig } {
+  const definitionBody = readDefinitionObjectBody(file)
+  const definitionEntries = typeof definitionBody === "undefined"
+    ? []
+    : splitTopLevel(definitionBody).map(stripLeadingEntryComments)
+  const cloudflareEntries = definitionEntries.filter(entry => readEntryKey(entry) === "cloudflare")
+  const expression = cloudflareEntries.length ? readEntryValue(cloudflareEntries.at(-1)!) : undefined
+  let configured = typeof definitionBody === "undefined"
+  for (const entry of definitionEntries) {
+    if (!entry.trim()) continue
+    const key = readEntryKey(entry)
+    if (entry.trimStart().startsWith("...") || !key) {
+      configured = true
+    }
+    else if (key === "cloudflare") {
+      configured = readEntryValue(entry)?.trim() !== "undefined"
+    }
+  }
+  const body = objectLiteralBody(expression)
+  if (!body) return { configured }
   const httpExpression = readObjectPropertyValue(body, "http")?.trim()
   const httpBody = objectLiteralBody(httpExpression)
   const http = httpExpression === "true"
@@ -153,7 +175,10 @@ function readDefinitionCloudflareConfig(file: string): CloudflareD1BindingConfig
     migrationsTable: readStringValue(body, "migrationsTable"),
     previewDatabaseId: readConfigValue(body, "previewDatabaseId"),
   } satisfies CloudflareD1BindingConfig
-  return Object.values(value).some(item => typeof item !== "undefined") ? value : undefined
+  return {
+    configured: true,
+    ...(Object.values(value).some(item => typeof item !== "undefined") ? { value } : {}),
+  }
 }
 
 function readDefinitionConnectionConfig(file: string) {
@@ -313,15 +338,18 @@ export function resolveDBViteConfig(
   if (!definitions.length) return
 
   const databases: Record<string, ResolvedDrizzleDatabaseConfig> = {}
+  const definitionCloudflareConfigured: Record<string, boolean> = {}
   const generatedDrizzleConfigFilesByDatabase: Record<string, string> = {}
   const generatedSchemaFilesByDatabase: Record<string, string> = {}
   for (const definition of definitions) {
     const migrationsDir = getDefaultMigrationsDir(rootDir, definition)
+    const definitionCloudflare = readDefinitionCloudflareConfig(definition.handler)
+    definitionCloudflareConfigured[definition.name] = definitionCloudflare.configured
     const generatedSchemaFile = createGeneratedSchemaFile(rootDir, definition.name)
     generatedDrizzleConfigFilesByDatabase[definition.name] = createGeneratedDrizzleConfigFile(rootDir, definition.name)
     generatedSchemaFilesByDatabase[definition.name] = generatedSchemaFile
     databases[definition.name] = {
-      cloudflare: normalizeCloudflareConfig(readDefinitionCloudflareConfig(definition.handler), definition.name, migrationsDir),
+      cloudflare: normalizeCloudflareConfig(definitionCloudflare.value, definition.name, migrationsDir),
       connection: resolveDefinitionConnection(definition.handler, definition.name, options?.connection),
       dialect: "sqlite",
       drizzle: {},
@@ -336,6 +364,7 @@ export function resolveDBViteConfig(
   return {
     databaseNames: definitions.map(definition => definition.name),
     databases,
+    definitionCloudflareConfigured,
     definitionDefaults: {
       ...(options && options.driver === "d1"
         ? { cloudflare: { binding: options.binding } }

--- a/packages/database/src/nuxt.ts
+++ b/packages/database/src/nuxt.ts
@@ -87,7 +87,18 @@ export function hubDb(options: DatabaseNuxtIntegrationOptions = {}): DatabaseNux
     }
     installVitePlugin(viteConfig, { ...resolvedOptions, projectRoot: root })
 
-    const d1 = resolveDatabaseNuxtD1Options(resolvedOptions, nuxtOptions)
+    const serverDirs = nuxtOptions.serverDir ? [nuxtOptions.serverDir] : undefined
+    const databaseConfig = resolvedOptions.driver === "d1"
+      ? resolveDBViteConfig(resolvedOptions, root, { serverDirs })
+      : undefined
+    const migrationsDir = databaseConfig && !databaseConfig.definitionCloudflareConfigured.default
+      ? databaseConfig.databases.default?.migrationsDir
+      : undefined
+    const d1 = resolveDatabaseNuxtD1Options(
+      resolvedOptions,
+      nuxtOptions,
+      migrationsDir ? resolve(root, migrationsDir) : undefined,
+    )
     const hook = (nuxt as NuxtLike).hook
     if (typeof hook === "function") {
       hook("nitro:config", async (config) => {
@@ -99,7 +110,7 @@ export function hubDb(options: DatabaseNuxtIntegrationOptions = {}): DatabaseNux
             root,
             generatedRoot,
             resolvedOptions,
-            nuxtOptions.serverDir ? [nuxtOptions.serverDir] : undefined,
+            serverDirs,
           )
         }
         if (!nuxtOptions.dev) {
@@ -238,6 +249,7 @@ function resolveDatabaseViteOptions(options: ResolvedDatabaseNuxtIntegrationOpti
 function resolveDatabaseNuxtD1Options(
   options: ResolvedDatabaseNuxtIntegrationOptions,
   nuxtOptions: NuxtLike["options"],
+  migrationsDir?: string,
 ): ResolvedDatabaseNuxtD1Options | undefined {
   if (options.driver !== "d1") return
 
@@ -246,6 +258,7 @@ function resolveDatabaseNuxtD1Options(
     database: "default",
     databaseId: options.databaseId,
     databaseName: options.databaseName,
+    migrationsDir,
     migrationsTable: options.migrationsTable,
     previewDatabaseId: options.previewDatabaseId,
   })

--- a/packages/database/src/types.ts
+++ b/packages/database/src/types.ts
@@ -120,6 +120,7 @@ export interface ResolvedDrizzleDatabaseConfig extends RuntimeDrizzleDatabaseCon
 export interface ResolvedDBViteConfig {
   databaseNames: string[]
   databases: Record<string, ResolvedDrizzleDatabaseConfig>
+  definitionCloudflareConfigured: Record<string, boolean>
   definitionDefaults: {
     cloudflare?: CloudflareD1BindingConfig
     connection?: DatabaseConnectionConfig

--- a/packages/database/test/config.test.ts
+++ b/packages/database/test/config.test.ts
@@ -151,6 +151,92 @@ describe("resolveDBViteConfig", () => {
     expect(resolved?.generatedDrizzleConfigFilesByDatabase.default).toBe(join(rootDir, ".vitehub/database/drizzle/default.config.ts"))
     expect(resolved?.generatedSchemaFilesByDatabase.default).toBe(join(rootDir, ".vitehub/database/schema/default.ts"))
     expect(resolved?.generatedDrizzleConfigFile).toBe(join(rootDir, ".vitehub/database/drizzle.config.ts"))
+    expect(resolved?.definitionCloudflareConfigured).toEqual({ default: false })
+  })
+
+  it("records dynamic Definition Cloudflare configuration that cannot be resolved statically", async () => {
+    const rootDir = await createTempProject()
+    const file = join(rootDir, "server/databases/config.ts")
+    await mkdir(dirname(file), { recursive: true })
+    await writeFile(file, [
+      "import { defineDatabase } from '@vite-hub/database'",
+      "const cloudflare = { binding: 'APP_DB' }",
+      "export default defineDatabase({ cloudflare, schema: {} })",
+      "",
+    ].join("\n"))
+
+    const resolved = resolveDBViteConfig(undefined, rootDir)
+
+    expect(resolved?.databases.default.cloudflare).toBeUndefined()
+    expect(resolved?.definitionCloudflareConfigured).toEqual({ default: true })
+  })
+
+  it("does not treat an empty parsed Definition object as unresolvable Cloudflare configuration", async () => {
+    const rootDir = await createTempProject()
+    const file = join(rootDir, "server/databases/config.ts")
+    await mkdir(dirname(file), { recursive: true })
+    await writeFile(file, [
+      "import { defineDatabase } from '@vite-hub/database'",
+      "export default defineDatabase({})",
+      "",
+    ].join("\n"))
+
+    expect(resolveDBViteConfig(undefined, rootDir)?.definitionCloudflareConfigured).toEqual({ default: false })
+  })
+
+  it("treats a literal undefined Definition Cloudflare value as omitted", async () => {
+    const rootDir = await createTempProject()
+    const file = join(rootDir, "server/databases/config.ts")
+    await mkdir(dirname(file), { recursive: true })
+    await writeFile(file, [
+      "import { defineDatabase } from '@vite-hub/database'",
+      "export default defineDatabase({ cloudflare: undefined, schema: {} })",
+      "",
+    ].join("\n"))
+
+    expect(resolveDBViteConfig(undefined, rootDir)?.definitionCloudflareConfigured).toEqual({ default: false })
+  })
+
+  it("recognizes a static computed Definition Cloudflare property", async () => {
+    const rootDir = await createTempProject()
+    const file = join(rootDir, "server/databases/config.ts")
+    await mkdir(dirname(file), { recursive: true })
+    await writeFile(file, [
+      "import { defineDatabase } from '@vite-hub/database'",
+      "const cloudflare = { binding: 'APP_DB' }",
+      "export default defineDatabase({ ['cloudflare']: cloudflare, schema: {} })",
+      "",
+    ].join("\n"))
+
+    expect(resolveDBViteConfig(undefined, rootDir)?.definitionCloudflareConfigured).toEqual({ default: true })
+  })
+
+  it("recognizes a configured Definition Cloudflare property after an undefined one", async () => {
+    const rootDir = await createTempProject()
+    const file = join(rootDir, "server/databases/config.ts")
+    await mkdir(dirname(file), { recursive: true })
+    await writeFile(file, [
+      "import { defineDatabase } from '@vite-hub/database'",
+      "const cloudflare = { binding: 'APP_DB' }",
+      "export default defineDatabase({ cloudflare: undefined, cloudflare, schema: {} })",
+      "",
+    ].join("\n"))
+
+    expect(resolveDBViteConfig(undefined, rootDir)?.definitionCloudflareConfigured).toEqual({ default: true })
+  })
+
+  it("treats a final undefined Definition Cloudflare property as omitted", async () => {
+    const rootDir = await createTempProject()
+    const file = join(rootDir, "server/databases/config.ts")
+    await mkdir(dirname(file), { recursive: true })
+    await writeFile(file, [
+      "import { defineDatabase } from '@vite-hub/database'",
+      "const cloudflare = { binding: 'APP_DB' }",
+      "export default defineDatabase({ cloudflare, cloudflare: undefined, schema: {} })",
+      "",
+    ].join("\n"))
+
+    expect(resolveDBViteConfig(undefined, rootDir)?.definitionCloudflareConfigured).toEqual({ default: false })
   })
 
   it("resolves named database defaults from definition locations", async () => {

--- a/packages/database/test/nuxt.test.ts
+++ b/packages/database/test/nuxt.test.ts
@@ -293,6 +293,86 @@ describe("Database Nuxt integration", () => {
     })
   })
 
+  it("keeps the discovered migration directory in Nitro's D1 binding", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-db-nuxt-migrations-"))
+    const definition = join(rootDir, "server/databases/config.ts")
+    await mkdir(dirname(definition), { recursive: true })
+    await writeFile(definition, [
+      'import { defineDatabase } from "@vite-hub/database"',
+      "export default defineDatabase({ schema: {} })",
+      "",
+    ].join("\n"))
+
+    try {
+      const { hooks, nuxt } = createNuxt({
+        database: {
+          driver: "d1",
+          databaseId: "content-id",
+          databaseName: "content-db",
+        },
+        dev: false,
+        nitro: { preset: "cloudflare_module" },
+        rootDir,
+        vite: {},
+      })
+
+      await hubDb()(undefined, nuxt)
+      const nitroConfig = {}
+      await callHook(hooks, "nitro:config", nitroConfig)
+
+      expect(nitroConfig).toHaveProperty(
+        "cloudflare.wrangler.d1_databases.0.migrations_dir",
+        join(rootDir, "server/databases/migrations"),
+      )
+    }
+    finally {
+      await rm(rootDir, { force: true, recursive: true })
+    }
+  })
+
+  it("does not assign migrations from a definition with its own D1 resource to the Nuxt binding", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-db-nuxt-separate-migrations-"))
+    const definition = join(rootDir, "server/databases/config.ts")
+    await mkdir(dirname(definition), { recursive: true })
+    await writeFile(definition, [
+      'import { defineDatabase } from "@vite-hub/database"',
+      "const appDatabase = {",
+      "  cloudflare: { binding: 'APP_DB', databaseId: 'app-id', databaseName: 'app-db' },",
+      "}",
+      "export default defineDatabase({",
+      "  // The application database is a separate D1 resource.",
+      "  ...appDatabase,",
+      "  schema: {},",
+      "})",
+      "",
+    ].join("\n"))
+
+    try {
+      const { hooks, nuxt } = createNuxt({
+        database: {
+          driver: "d1",
+          databaseId: "content-id",
+          databaseName: "content-db",
+        },
+        dev: false,
+        nitro: { preset: "cloudflare_module" },
+        rootDir,
+        vite: {},
+      })
+
+      await hubDb()(undefined, nuxt)
+      const nitroConfig = {}
+      await callHook(hooks, "nitro:config", nitroConfig)
+
+      expect(nitroConfig).not.toHaveProperty(
+        "cloudflare.wrangler.d1_databases.0.migrations_dir",
+      )
+    }
+    finally {
+      await rm(rootDir, { force: true, recursive: true })
+    }
+  })
+
   it("maintains the discovered database runtime for Nitro development", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vitehub-db-nuxt-local-"))
     const buildDir = join(rootDir, ".nuxt")


### PR DESCRIPTION
The Database Nuxt integration emitted its D1 binding without the migration directory already known from the discovered default database definition. Nitro therefore wrote a `.output/server/wrangler.json` whose D1 migration command could not find the project migrations.

This resolves the default definition through the existing Database config path and carries its absolute migration directory into the Nuxt D1 projection when the Definition inherits that host resource. Definitions with explicit or ambiguous Cloudflare configuration remain separate. Projects without a discovered default definition keep the existing behavior.

Verification:
- `corepack pnpm --filter @vite-hub/database test` — 112 tests passed
- `corepack pnpm --filter @vite-hub/database typecheck`
- Database build and publint passed through the package test gate
- A disposable installed Calories Nuxt 5 production build passed without ViteHub patches, and `.output/server/wrangler.json` emitted the existing `server/databases/migrations` directory