### PR TITLE
fix(agent): provide runtime capabilities in dev loop

### DIFF
--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1784,7 +1784,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
     name: "@vite-hub/agent/vite",
     async configureServer(server) {
       if (agent !== false) {
-        await registerAgentInvocationStreamEndpoint(server)
+        await registerAgentInvocationStreamEndpoint(server, runtimeCapabilities)
       }
     },
     async handleHotUpdate(context) {

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1784,7 +1784,11 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
     name: "@vite-hub/agent/vite",
     async configureServer(server) {
       if (agent !== false) {
-        await registerAgentInvocationStreamEndpoint(server, runtimeCapabilities)
+        await registerAgentInvocationStreamEndpoint(server, {
+          runtimeCapabilities,
+          schedule: hasScheduleVitePlugin(resolved ?? server.config),
+          scheduleRuntimeImport: getScheduleRuntimeImport(agent, frameworkOptions),
+        })
       }
     },
     async handleHotUpdate(context) {

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -81,6 +81,12 @@ interface AgentDevRuntimeCapability {
   packageName: false | string
 }
 
+interface AgentDevRuntimeOptions {
+  runtimeCapabilities?: AgentDevRuntimeCapability[]
+  schedule?: boolean
+  scheduleRuntimeImport?: string
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value)
 }
@@ -570,6 +576,7 @@ async function runCapabilityCliWithTimeout(
 async function resolveDevRuntimeCapabilities(
   server: ViteDevServer,
   definitions: AgentDevRuntimeCapability[],
+  options: Pick<AgentDevRuntimeOptions, "schedule" | "scheduleRuntimeImport">,
 ): Promise<Record<string, unknown>> {
   const capabilities: Record<string, unknown> = {}
   for (const definition of definitions) {
@@ -577,10 +584,19 @@ async function resolveDevRuntimeCapabilities(
       ? false
       : (await server.ssrLoadModule(definition.packageName))[definition.importName]
   }
+  if (options.schedule) {
+    const [registry, runtime] = await Promise.all([
+      server.ssrLoadModule("#vitehub/schedule/registry"),
+      server.ssrLoadModule(options.scheduleRuntimeImport ?? "@vite-hub/schedule/runtime"),
+    ])
+    runtime.setScheduleRuntimeRegistry(registry.default)
+    capabilities.schedule = { schedules: runtime.schedules }
+  }
   return capabilities
 }
 
-async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: IncomingMessage, tokenOptions: WorkspaceDevTokenOptions, abortSignal: AbortSignal | undefined, capabilities: Record<string, unknown>): Promise<Response> {
+async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: IncomingMessage, tokenOptions: WorkspaceDevTokenOptions, abortSignal: AbortSignal | undefined, runtimeOptions: AgentDevRuntimeOptions): Promise<Response> {
+  const capabilities = await resolveDevRuntimeCapabilities(server, runtimeOptions.runtimeCapabilities ?? [], runtimeOptions)
   const entries = await discoverStreamAgents(server)
   if (req.method === "GET") {
     await ensureWorkspaceDevToken(server.config.root, tokenOptions)
@@ -732,9 +748,8 @@ function errorResponse(error: unknown): Response {
   })
 }
 
-export async function registerAgentInvocationStreamEndpoint(server: ViteDevServer, runtimeCapabilities: AgentDevRuntimeCapability[] = []): Promise<void> {
+export async function registerAgentInvocationStreamEndpoint(server: ViteDevServer, runtimeOptions: AgentDevRuntimeOptions = {}): Promise<void> {
   const tokenOptions = { serverId: workspaceDevTokenServerId(server.config.server.port) }
-  const capabilities = await resolveDevRuntimeCapabilities(server, runtimeCapabilities)
   await refreshWorkspaceDevToken(server.config.root, tokenOptions)
   server.middlewares.use((req, res, next) => {
     if (!routeMatches(req)) {
@@ -752,7 +767,7 @@ export async function registerAgentInvocationStreamEndpoint(server: ViteDevServe
     }
 
     const abort = createAbortSignalFromClose(res, "[vitehub] Agent Invocation Stream response closed.")
-    void handleAgentInvocationStreamRequest(server, req, tokenOptions, abort.signal, capabilities)
+    void handleAgentInvocationStreamRequest(server, req, tokenOptions, abort.signal, runtimeOptions)
       .catch(errorResponse)
       .then(response => writeResponse(res, response))
       .finally(abort.dispose)

--- a/packages/agent/src/vite/invocation-stream-endpoint.ts
+++ b/packages/agent/src/vite/invocation-stream-endpoint.ts
@@ -75,6 +75,12 @@ interface AgentInvocationStreamEntry {
   triggers: Record<string, ResolvedAgentTriggerDefinition<ViteAgentRuntimeContext>>
 }
 
+interface AgentDevRuntimeCapability {
+  importName: string
+  name: string
+  packageName: false | string
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value)
 }
@@ -561,7 +567,20 @@ async function runCapabilityCliWithTimeout(
   }
 }
 
-async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: IncomingMessage, tokenOptions: WorkspaceDevTokenOptions, abortSignal?: AbortSignal): Promise<Response> {
+async function resolveDevRuntimeCapabilities(
+  server: ViteDevServer,
+  definitions: AgentDevRuntimeCapability[],
+): Promise<Record<string, unknown>> {
+  const capabilities: Record<string, unknown> = {}
+  for (const definition of definitions) {
+    capabilities[definition.name] = definition.packageName === false
+      ? false
+      : (await server.ssrLoadModule(definition.packageName))[definition.importName]
+  }
+  return capabilities
+}
+
+async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: IncomingMessage, tokenOptions: WorkspaceDevTokenOptions, abortSignal: AbortSignal | undefined, capabilities: Record<string, unknown>): Promise<Response> {
   const entries = await discoverStreamAgents(server)
   if (req.method === "GET") {
     await ensureWorkspaceDevToken(server.config.root, tokenOptions)
@@ -575,7 +594,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
             context: { invoker: { id: "inspection", kind: "inspection" } },
             messages: [],
           },
-          runtime: createViteAgentRuntimeContext(server, req, entry.identity, { fallbackRoute: agentInvocationStreamRoute, run }),
+          runtime: createViteAgentRuntimeContext(server, req, entry.identity, { capabilities, fallbackRoute: agentInvocationStreamRoute, run }),
         })
       : undefined
     const response = {
@@ -594,7 +613,7 @@ async function handleAgentInvocationStreamRequest(server: ViteDevServer, req: In
   const body = parseBody(await readRequestBody(req))
   const entry = selectedEntry(entries, body.agent)
   const run = body.run || devRun(entry.name)
-  const context = createViteAgentRuntimeContext(server, req, entry.identity, { fallbackRoute: agentInvocationStreamRoute, run })
+  const context = createViteAgentRuntimeContext(server, req, entry.identity, { capabilities, fallbackRoute: agentInvocationStreamRoute, run })
   const payload = payloadFromBody(body)
   const timeout = typeof body.timeout === "number" && Number.isFinite(body.timeout) ? body.timeout : 90_000
 
@@ -713,8 +732,9 @@ function errorResponse(error: unknown): Response {
   })
 }
 
-export async function registerAgentInvocationStreamEndpoint(server: ViteDevServer): Promise<void> {
+export async function registerAgentInvocationStreamEndpoint(server: ViteDevServer, runtimeCapabilities: AgentDevRuntimeCapability[] = []): Promise<void> {
   const tokenOptions = { serverId: workspaceDevTokenServerId(server.config.server.port) }
+  const capabilities = await resolveDevRuntimeCapabilities(server, runtimeCapabilities)
   await refreshWorkspaceDevToken(server.config.root, tokenOptions)
   server.middlewares.use((req, res, next) => {
     if (!routeMatches(req)) {
@@ -732,7 +752,7 @@ export async function registerAgentInvocationStreamEndpoint(server: ViteDevServe
     }
 
     const abort = createAbortSignalFromClose(res, "[vitehub] Agent Invocation Stream response closed.")
-    void handleAgentInvocationStreamRequest(server, req, tokenOptions, abort.signal)
+    void handleAgentInvocationStreamRequest(server, req, tokenOptions, abort.signal, capabilities)
       .catch(errorResponse)
       .then(response => writeResponse(res, response))
       .finally(abort.dispose)

--- a/packages/agent/src/vite/runtime-adapter.ts
+++ b/packages/agent/src/vite/runtime-adapter.ts
@@ -128,11 +128,12 @@ export function createViteAgentRuntimeContext(
   server: ViteDevServer,
   req: IncomingMessage,
   identity: AgentHostIdentity,
-  options: { fallbackRoute: string, run?: AgentRunMetadata },
+  options: { capabilities?: AgentRuntimeContext["capabilities"], fallbackRoute: string, run?: AgentRunMetadata },
 ): ViteAgentRuntimeContext {
   return createAgentRuntimeContext({
     agentIdentity: identity,
     request: createRequest(server, req, options.fallbackRoute),
+    ...(options.capabilities ? { capabilities: options.capabilities } : {}),
     ...(options.run ? { run: options.run } : {}),
     runtime: "vite",
     runtimeConfig: {},

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1767,12 +1767,18 @@ describe("agent chat capability discovery", () => {
     const { db } = await import("../src/capabilities.ts")
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const agentDb = { query: vi.fn() }
+    let runtimeDb: unknown
     const agent = defineAgent({
       capabilities: [db()],
-      driver: { run: () => "ok" },
+      driver: {
+        run: ({ capabilities }) => {
+          runtimeDb = capabilities?.db
+          return "ok"
+        },
+      },
     })
     const { handlers, server } = createFakeServer(root, { default: agent })
-    const agentDb = { query: vi.fn() }
     server.ssrLoadModule.mockImplementation(async (...args: unknown[]) => args[0] === "@vite-hub/database/drizzle"
       ? { agentDb }
       : { default: agent })
@@ -1804,6 +1810,7 @@ describe("agent chat capability discovery", () => {
       { type: "done" },
     ])
     expect(server.ssrLoadModule).toHaveBeenCalledWith("@vite-hub/database/drizzle")
+    expect(runtimeDb).toBe(agentDb)
   })
 
 

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1759,6 +1759,53 @@ describe("agent chat capability discovery", () => {
     })
   })
 
+  it("provides generated runtime Capabilities to Agent Dev Loop invocations", async () => {
+    const root = await createTempRoot("vitehub-agent-dev-runtime-capabilities-")
+    await mkdir(join(root, "server", "agents"), { recursive: true })
+    await writeFile(join(root, "server", "agents", "calories.ts"), "export default {}", "utf8")
+
+    const { db } = await import("../src/capabilities.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
+    const agent = defineAgent({
+      capabilities: [db()],
+      driver: { run: () => "ok" },
+    })
+    const { handlers, server } = createFakeServer(root, { default: agent })
+    const agentDb = { query: vi.fn() }
+    server.ssrLoadModule.mockImplementation(async (...args: unknown[]) => args[0] === "@vite-hub/database/drizzle"
+      ? { agentDb }
+      : { default: agent })
+    const plugin = (await import("../src/vite.ts")).hubAgent()
+    if (typeof plugin.configResolved === "function") {
+      await plugin.configResolved.call({} as never, {
+        command: "serve",
+        plugins: [{ name: "@vite-hub/database/vite" }],
+        root,
+      } as never)
+    }
+    await configurePluginServer(plugin, server)
+
+    const response = await invokeMiddleware(handlers[0]!, {
+      messages: [{
+        id: "user-1",
+        parts: [{ text: "hello", type: "text" }],
+        role: "user",
+      }],
+    }, agentInvocationStreamRoute, {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    })
+
+    expect(response.body.trim().split("\n").map(line => JSON.parse(line))).toEqual([
+      expect.objectContaining({ agent: "calories", type: "start" }),
+      { text: "ok", type: "text-delta" },
+      { type: "finish" },
+      { type: "done" },
+    ])
+    expect(server.ssrLoadModule).toHaveBeenCalledWith("@vite-hub/database/drizzle")
+  })
+
 
   it("consumes Response outputs from the Agent Invocation Stream endpoint", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-response-")

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -1767,26 +1767,34 @@ describe("agent chat capability discovery", () => {
     const { db } = await import("../src/capabilities.ts")
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
-    const agentDb = { query: vi.fn() }
-    let runtimeDb: unknown
+    const initialAgentDb = { query: vi.fn() }
+    let agentDb = initialAgentDb
+    const runtimeDbs: unknown[] = []
+    const schedules = { create: vi.fn() }
+    const setScheduleRuntimeRegistry = vi.fn()
+    let runtimeSchedule: unknown
     const agent = defineAgent({
       capabilities: [db()],
       driver: {
         run: ({ capabilities }) => {
-          runtimeDb = capabilities?.db
+          runtimeDbs.push(capabilities?.db)
+          runtimeSchedule = capabilities?.schedule
           return "ok"
         },
       },
     })
     const { handlers, server } = createFakeServer(root, { default: agent })
-    server.ssrLoadModule.mockImplementation(async (...args: unknown[]) => args[0] === "@vite-hub/database/drizzle"
-      ? { agentDb }
-      : { default: agent })
+    server.ssrLoadModule.mockImplementation(async (...args: unknown[]) => {
+      if (args[0] === "@vite-hub/database/drizzle") return { agentDb }
+      if (args[0] === "#vitehub/schedule/registry") return { default: { reminders: vi.fn() } }
+      if (args[0] === "@vite-hub/schedule/runtime") return { schedules, setScheduleRuntimeRegistry }
+      return { default: agent }
+    })
     const plugin = (await import("../src/vite.ts")).hubAgent()
     if (typeof plugin.configResolved === "function") {
       await plugin.configResolved.call({} as never, {
         command: "serve",
-        plugins: [{ name: "@vite-hub/database/vite" }],
+        plugins: [{ name: "@vite-hub/database/vite" }, { name: "@vite-hub/schedule/vite" }],
         root,
       } as never)
     }
@@ -1810,7 +1818,20 @@ describe("agent chat capability discovery", () => {
       { type: "done" },
     ])
     expect(server.ssrLoadModule).toHaveBeenCalledWith("@vite-hub/database/drizzle")
-    expect(runtimeDb).toBe(agentDb)
+    expect(runtimeDbs).toEqual([initialAgentDb])
+    expect(runtimeSchedule).toEqual({ schedules })
+    expect(setScheduleRuntimeRegistry).toHaveBeenCalledOnce()
+
+    const refreshedAgentDb = { query: vi.fn() }
+    agentDb = refreshedAgentDb
+    await invokeMiddleware(handlers[0]!, {
+      messages: [{ id: "user-2", parts: [{ text: "again", type: "text" }], role: "user" }],
+    }, agentInvocationStreamRoute, {
+      "content-type": "application/json",
+      [agentInvocationStreamHeader]: agentInvocationStreamHeaderValue,
+    })
+    expect(runtimeDbs).toEqual([initialAgentDb, refreshedAgentDb])
+    expect(setScheduleRuntimeRegistry).toHaveBeenCalledTimes(2)
   })
 
 


### PR DESCRIPTION
## Summary

The Vite Agent Dev Loop reused generated runtime Capability definitions, but its invocation context never received their runtime handles. Agents using Capabilities such as `db()` could build successfully and then lose those bindings only through the local invocation endpoint.

This resolves configured runtime modules through Vite and passes the resulting handles into both inspection and invocation contexts. Explicitly disabled Capabilities remain disabled.

## Verification

- `corepack pnpm --filter @vite-hub/agent test -- discovery.test.ts` (49 passed)
- `corepack pnpm --filter @vite-hub/agent typecheck`
- `corepack pnpm exec oxlint packages/agent/src/vite.ts packages/agent/src/vite/invocation-stream-endpoint.ts packages/agent/src/vite/runtime-adapter.ts packages/agent/test/discovery.test.ts`
- Packed this branch's `@vite-hub/agent` into a disposable Calories clone with the downstream Agent patch removed; the Nuxt Dev Loop inspection reported its `blob` and `db` runtime Capabilities as available.

The complete Agent suite was also attempted in this checkout, but remains red across 16 unrelated files with shared mock and subprocess failures; no failure touched this runtime-context path or its focused discovery coverage.
