### PR TITLE
fix(agent): package optional runtimes

### DIFF
--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -162,9 +162,11 @@
     "vite-plus": "catalog:tooling",
     "vitest": "catalog:tooling"
   },
+  "optionalDependencies": {
+    "@ai-sdk/mcp": "catalog:ai"
+  },
   "peerDependencies": {
     "@ai-sdk/harness-claude-code": "catalog:ai",
-    "@ai-sdk/mcp": "catalog:ai",
     "@chat-adapter/discord": "catalog:chat",
     "@vercel/functions": "catalog:vercel",
     "@vite-hub/blob": "workspace:*",
@@ -177,9 +179,6 @@
   },
   "peerDependenciesMeta": {
     "@ai-sdk/harness-claude-code": {
-      "optional": true
-    },
-    "@ai-sdk/mcp": {
       "optional": true
     },
     "@chat-adapter/discord": {

--- a/packages/agent/src/capabilities/mcp.ts
+++ b/packages/agent/src/capabilities/mcp.ts
@@ -73,8 +73,7 @@ function sanitizeMcpMetadata(value: unknown, seen = new WeakSet<object>()): unkn
 }
 
 async function createMcpClient(config: McpClientConfig): Promise<McpClient> {
-  const specifier = ["@ai-sdk", "mcp"].join("/")
-  const runtime = await import(specifier) as typeof import("@ai-sdk/mcp")
+  const runtime = await import("@ai-sdk/mcp")
   return await runtime.createMCPClient(config as never)
 }
 

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -112,7 +112,6 @@ const harnessInstructionFiles = ["AGENTS.md", "CLAUDE.md"] as const
 const harnessAttachmentDirectory = ".vitehub/attachments"
 const harnessAttachmentMaxBytes = 25 * 1024 * 1024
 const harnessAttachmentResolutionTimeoutMs = 15_000
-const harnessAgentPackage = "@ai-sdk/harness/agent"
 const harnessRemoveDirectory = Symbol.for("vitehub.harnessRemoveDirectory")
 const harnessSandboxAdapter = Symbol.for("vitehub.harnessSandboxAdapter")
 const harnessInvocationSandboxAdapter = Symbol.for("vitehub.harnessInvocationSandboxAdapter")
@@ -974,7 +973,7 @@ async function createHarnessAgent<
   ) => Promise<void>,
 ): Promise<{ agent: HarnessAgentLike, instructions?: string, workDir?: string }> {
   assertSupportedHarnessDriverContributions(context)
-  const { HarnessAgent } = await import(/* @vite-ignore */ harnessAgentPackage) as unknown as { HarnessAgent: HarnessAgentConstructor }
+  const { HarnessAgent } = await import("@ai-sdk/harness/agent") as unknown as { HarnessAgent: HarnessAgentConstructor }
   const harness = await resolveHarness(options.harness, context)
   const globalSkillsDirectory = resolveHarnessGlobalSkillsDirectory(harness, context, invocation)
   if (context.globalSkills?.length && !isHarnessRelativeDirectory(globalSkillsDirectory)) {

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -5,7 +5,7 @@ import { pathToFileURL } from "node:url"
 
 import { writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
-import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored, resolveViteHubGeneratedRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, hasNitroConfigContext, isServerEnvironment, mergeGeneratedViteHubWatchIgnored, resolveViteHubGeneratedRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import { getHostingProvider } from "@vite-hub/internal/hosting"
 import { markdownTemplateMaterializationPath } from "@vite-hub/markdown-template/vite"
 
@@ -56,6 +56,7 @@ const optionalMessageAdapterRuntimeExternals = [
   "utf-8-validate",
   "zlib-sync",
 ]
+const nitroAgentRuntimeInlines = ["vite-hub", agentPackageName, "@ai-sdk/mcp"]
 const optionalNetlifyAgentBundleExternals = [
   "@ai-sdk/harness",
   "@ai-sdk/harness/*",
@@ -618,6 +619,17 @@ function mergeCloudflareAgentStateNitroConfig(value: unknown, stateImport: strin
   installCloudflareAgentStateEntrypoint(nitro, { stateImport } as never)
   nitro.rollupConfig ||= {}
   nitro.rollupConfig.external = mergeCloudflareWorkersExternal(nitro.rollupConfig.external as RollupExternalOption | undefined)
+  return nitro
+}
+
+function mergeAgentNitroExternals(value: unknown): NitroConfig {
+  const nitro = cloneNitroConfig(value)
+  const externals = isRecord(nitro.externals) ? { ...nitro.externals } : {}
+  const existingInline = Array.isArray(externals.inline) ? externals.inline : []
+  externals.inline = externals.inline === true
+    ? true
+    : [...new Set([...existingInline, ...nitroAgentRuntimeInlines])]
+  nitro.externals = externals
   return nitro
 }
 
@@ -1872,6 +1884,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
       const root = resolve(config.root || process.cwd())
       const generatedRoot = resolveViteHubGeneratedRoot(config)
+      const nitroContext = hasNitroConfigContext(config)
       const hasHostedAgents = Boolean(resolved && hasHostedAgentDefinitions(root, serverDirs))
       const denoOutput = resolved && resolved.runtime === "deno"
       const installCloudflareState = hasHostedAgents && !denoOutput && shouldInstallCloudflareAgentState(resolved, config)
@@ -1909,10 +1922,10 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
             getCloudflareStateImport(agent, frameworkOptions),
           )
         : cloneNitroConfig((config as { nitro?: unknown }).nitro)
-      const mergedNitro = mergeNitroPlugins(
+      const mergedNitro = (nitroContext ? mergeAgentNitroExternals : cloneNitroConfig)(mergeNitroPlugins(
         mergeNitroHandlers(nitro, nitroHandlers),
         installWebhookQueue ? [join(generatedRoot, generatedAgentWebhookQueuePlugin)] : [],
-      )
+      ))
       return {
         ...(typeof agent !== "undefined" ? { agent } : {}),
         ...(nitroHandlers.length
@@ -1920,7 +1933,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
               build: mergeBuildExternal(config as BuildWithRolldownOptions, optionalMessageAdapterRuntimeExternals),
             }
           : {}),
-        ...(nitroHandlers.length || installCloudflareState
+        ...(nitroContext || nitroHandlers.length || installCloudflareState
           ? {
               nitro: mergedNitro,
             }

--- a/packages/agent/test/nuxt-runtime-output.test.ts
+++ b/packages/agent/test/nuxt-runtime-output.test.ts
@@ -1,0 +1,157 @@
+import { execFile, spawn } from "node:child_process"
+import { once } from "node:events"
+import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from "node:fs/promises"
+import { createServer } from "node:net"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+import { expect, it } from "vitest"
+
+import { syncPackedWorkspaceDependencies } from "../../internal/test-utils/published-types.js"
+
+const execFileAsync = promisify(execFile)
+const packageRoot = resolve(import.meta.dirname, "..")
+const workspaceRoot = resolve(packageRoot, "../..")
+const childProcessTimeout = 60_000
+const packedPackages = [
+  "agent",
+  "box",
+  "markdown-template",
+  "rate-limit",
+  "runtime",
+  "source",
+  "workspace",
+] as const
+
+async function runPnpm(args: string[], cwd: string): Promise<void> {
+  const npmExecPath = process.env.npm_execpath
+  const command = npmExecPath?.includes("pnpm") ? process.execPath : "corepack"
+  const commandArgs = npmExecPath?.includes("pnpm") ? [npmExecPath, ...args] : ["pnpm", ...args]
+  try {
+    await execFileAsync(command, commandArgs, {
+      cwd,
+      env: { ...process.env, CI: "true" },
+      killSignal: "SIGKILL",
+      timeout: childProcessTimeout,
+    })
+  }
+  catch (error) {
+    const output = error as Error & { stderr?: string, stdout?: string }
+    throw new Error([output.message, output.stdout, output.stderr].filter(Boolean).join("\n"), { cause: error })
+  }
+}
+
+async function availablePort(): Promise<number> {
+  const server = createServer()
+  server.listen(0, "127.0.0.1")
+  await once(server, "listening")
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("Could not allocate a test port")
+  await new Promise<void>((resolveClose, reject) => server.close(error => error ? reject(error) : resolveClose()))
+  return address.port
+}
+
+async function readTree(root: string): Promise<string> {
+  const entries = await readdir(root, { withFileTypes: true })
+  return (await Promise.all(entries.map(async (entry) => {
+    const path = join(root, entry.name)
+    return entry.isDirectory() ? await readTree(path) : /\.m?js$/.test(entry.name) ? await readFile(path, "utf8") : ""
+  }))).join("\n")
+}
+
+async function requestWhenReady(url: string): Promise<Response> {
+  let lastError: unknown
+  for (let attempt = 0; attempt < 50; attempt++) {
+    try {
+      return await fetch(url)
+    }
+    catch (error) {
+      lastError = error
+      await new Promise(resolveWait => setTimeout(resolveWait, 100))
+    }
+  }
+  throw lastError
+}
+
+it("packages optional Agent runtimes into immutable Nuxt output", { timeout: 120_000 }, async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-agent-nuxt-runtime-"))
+  try {
+    await mkdir(join(root, "server", "api"), { recursive: true })
+    await writeFile(join(root, "package.json"), `${JSON.stringify({
+      dependencies: {
+        "@ai-sdk/mcp": "2.0.0",
+        "@vite-hub/agent": "file:./vite-hub-agent-0.0.1.tgz",
+        nuxt: "4.4.8",
+        vite: "8.2.0",
+      },
+      packageManager: "pnpm@10.33.0",
+      private: true,
+      type: "module",
+    }, null, 2)}\n`, "utf8")
+    await writeFile(join(root, "pnpm-workspace.yaml"), "packages:\n  - .\n", "utf8")
+    await writeFile(join(root, "app.vue"), "<template><div>ViteHub runtime proof</div></template>\n", "utf8")
+    await writeFile(join(root, "server", "api", "proof.get.ts"), `
+import { defineAgent } from "@vite-hub/agent"
+import { mcp } from "@vite-hub/agent/capabilities"
+
+const agent = defineAgent({ driver: { kind: "codex" } })
+const capability = mcp({
+  servers: {
+    proof: { transport: { type: "http", url: "http://127.0.0.1:1/mcp" } },
+  },
+})
+
+export default defineEventHandler(async () => {
+  let mcp = "loaded"
+  try {
+    await capability.resolve?.({ tools: { add() {} } } as never)
+  }
+  catch (error) {
+    const message = String(error)
+    if (message.includes("Cannot find") && message.includes("@ai-sdk/mcp")) throw error
+    mcp = "loaded-before-transport-error"
+  }
+  return { agent: (await agent.resolve({ run: {}, runtime: "node", waitUntil() {} })).name, mcp }
+})
+`, "utf8")
+
+    await syncPackedWorkspaceDependencies(
+      root,
+      workspaceRoot,
+      packedPackages.map(name => `@vite-hub/${name}`),
+    )
+    await Promise.all(packedPackages.map(name =>
+      runPnpm(["pack", "--pack-destination", root], join(workspaceRoot, "packages", name))))
+    await runPnpm(["install", "--prefer-offline", "--ignore-scripts", "--no-frozen-lockfile"], root)
+    await runPnpm(["exec", "nuxt", "build"], root)
+
+    const output = await readTree(join(root, ".output", "server"))
+    expect(output).toContain("HarnessAgent.createSession")
+    expect(output).not.toContain('["@ai-sdk", "mcp"].join("/")')
+
+    await rename(join(root, "node_modules"), join(root, "source-node_modules"))
+    const port = await availablePort()
+    const child = spawn(process.execPath, [join(root, ".output", "server", "index.mjs")], {
+      cwd: root,
+      env: { ...process.env, NITRO_PORT: String(port) },
+      stdio: "ignore",
+    })
+    const exited = once(child, "exit")
+    try {
+      const response = await requestWhenReady(`http://127.0.0.1:${port}/api/proof`)
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({
+        agent: "ai-sdk-harness",
+        mcp: "loaded-before-transport-error",
+      })
+    }
+    finally {
+      child.kill()
+      await exited
+    }
+  }
+  finally {
+    await rm(root, { force: true, recursive: true })
+  }
+})

--- a/packages/agent/test/nuxt-runtime-output.test.ts
+++ b/packages/agent/test/nuxt-runtime-output.test.ts
@@ -80,7 +80,6 @@ it("packages optional Agent runtimes into immutable Nuxt output", { timeout: 120
     await mkdir(join(root, "server", "api"), { recursive: true })
     await writeFile(join(root, "package.json"), `${JSON.stringify({
       dependencies: {
-        "@ai-sdk/mcp": "2.0.0",
         "@vite-hub/agent": "file:./vite-hub-agent-0.0.1.tgz",
         nuxt: "4.4.8",
         vite: "8.2.0",
@@ -126,21 +125,26 @@ export default defineEventHandler(async () => {
     await runPnpm(["install", "--prefer-offline", "--ignore-scripts", "--no-frozen-lockfile"], root)
     await runPnpm(["exec", "nuxt", "build"], root)
 
-    const output = await readTree(join(root, ".output", "server"))
+    const outputServer = join(root, ".output", "server")
+    const output = await readTree(outputServer)
     expect(output).toContain("HarnessAgent.createSession")
+    expect(output).toContain("createMCPClient")
     expect(output).not.toContain('["@ai-sdk", "mcp"].join("/")')
 
     await rename(join(root, "node_modules"), join(root, "source-node_modules"))
     const port = await availablePort()
-    const child = spawn(process.execPath, [join(root, ".output", "server", "index.mjs")], {
+    const child = spawn(process.execPath, [join(outputServer, "index.mjs")], {
       cwd: root,
       env: { ...process.env, NITRO_PORT: String(port) },
-      stdio: "ignore",
+      stdio: ["ignore", "ignore", "pipe"],
     })
+    let stderr = ""
+    child.stderr.setEncoding("utf8")
+    child.stderr.on("data", chunk => stderr += chunk)
     const exited = once(child, "exit")
     try {
       const response = await requestWhenReady(`http://127.0.0.1:${port}/api/proof`)
-      expect(response.status).toBe(200)
+      expect(response.status, `${await response.clone().text()}\n${stderr}`).toBe(200)
       await expect(response.json()).resolves.toEqual({
         agent: "ai-sdk-harness",
         mcp: "loaded-before-transport-error",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7,7 +7,7 @@ import { pathToFileURL } from "node:url"
 import { promisify } from "node:util"
 
 import { Message } from "chat"
-import { VITEHUB_GENERATED_ROOT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
+import { VITEHUB_GENERATED_ROOT, VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import { hubMarkdownTemplate } from "@vite-hub/markdown-template/vite"
 import { build } from "vite"
 import { describe, expect, it, vi } from "vitest"
@@ -1060,6 +1060,25 @@ describe("agent Vite plugin", () => {
       : undefined
 
     expect((result as { nitro?: unknown } | undefined)?.nitro).toBeUndefined()
+  })
+
+  it("inlines Agent runtimes in Nitro output", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const plugin = hubAgent()
+    const result = typeof plugin.config === "function"
+      ? await plugin.config.call({} as never, {
+          [VITEHUB_NITRO_CONFIG_CONTEXT]: true,
+          nitro: { externals: { inline: ["existing"] } },
+        } as never, { command: "build", mode: "production" })
+      : undefined
+
+    expect(result).toMatchObject({
+      nitro: {
+        externals: {
+          inline: ["existing", "vite-hub", "@vite-hub/agent", "@ai-sdk/mcp"],
+        },
+      },
+    })
   })
 
   it("registers configured Discord Gateway routes with Nitro", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,9 +18,6 @@ catalogs:
     '@ai-sdk/harness-codex':
       specifier: 1.0.41
       version: 1.0.41
-    '@ai-sdk/mcp':
-      specifier: 2.0.0
-      version: 2.0.0
     '@modelcontextprotocol/sdk':
       specifier: ^1.29.0
       version: 1.29.0
@@ -582,9 +579,6 @@ importers:
       '@ai-sdk/harness-claude-code':
         specifier: catalog:ai
         version: 1.0.40(zod@4.4.3)
-      '@ai-sdk/mcp':
-        specifier: catalog:ai
-        version: 2.0.0(zod@4.4.3)
       '@chat-adapter/discord':
         specifier: catalog:chat
         version: 4.35.0(ai@7.0.19(zod@4.4.3))(workflow@5.0.0-beta.35(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.3)(react@19.2.6)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
@@ -618,6 +612,10 @@ importers:
       vite-plus:
         specifier: catalog:tooling
         version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)
+    optionalDependencies:
+      '@ai-sdk/mcp':
+        specifier: catalog:ai
+        version: 2.0.0(zod@4.4.3)
 
   packages/auth:
     dependencies:
@@ -13861,6 +13859,7 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       pkce-challenge: 5.0.1
       zod: 4.4.3
+    optional: true
 
   '@ai-sdk/provider-utils@4.0.39(zod@4.4.3)':
     dependencies:
@@ -13876,6 +13875,7 @@ snapshots:
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
       zod: 4.4.3
+    optional: true
 
   '@ai-sdk/provider-utils@5.0.12(zod@4.4.3)':
     dependencies:
@@ -13900,6 +13900,7 @@ snapshots:
   '@ai-sdk/provider@4.0.0':
     dependencies:
       json-schema: 0.4.0
+    optional: true
 
   '@ai-sdk/provider@4.0.3':
     dependencies:


### PR DESCRIPTION
## Summary

Portal's Nuxt production output could omit the Agent package's MCP and Harness runtimes because computed dynamic imports were invisible to the application bundler. This makes both imports analyzable, installs MCP as an optional Agent runtime dependency, and inlines the Agent runtime closure into Nitro output while keeping MCP lazy.

The regression packs the workspace packages into a temporary Nuxt consumer which depends only on the Agent tarball, builds its production server, removes the consumer install tree, then exercises both the Codex adapter and MCP loading from the immutable output.

## Verification

- `pnpm --dir packages/agent exec vp test test/nuxt-runtime-output.test.ts`
- `pnpm --dir packages/agent exec vp test test/mcp-capability.test.ts`
- `pnpm --dir packages/agent exec vp test test/harness-codex-patch.test.ts`
- `pnpm --dir packages/agent exec vp test test/providers.test.ts -t 'inlines Agent runtimes in Nitro output'`
- `pnpm --dir packages/agent typecheck`
- `pnpm --dir packages/agent build`
- `pnpm exec vp run test:consumer`
- `pnpm exec oxlint packages/agent/src/vite.ts packages/agent/test/providers.test.ts packages/agent/test/nuxt-runtime-output.test.ts` (only pre-existing warnings in `providers.test.ts`)

The focused concurrent Agent Box test still fails in the existing colocated-skills installation race and reproduces unchanged on `origin/main`.
