### PR TITLE
fix(agent): accept nested Vite server roots

### DIFF
--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -5,7 +5,7 @@ import { readWorkspaceDevToken, workspaceDevTokenHeader } from "@vite-hub/worksp
 
 import { formatAgentError } from "./agent-error.ts"
 import { createAgentEvalInclude, discoverAgentEvalFiles } from "./discovery.ts"
-import { runAgentInfoCli } from "./internal/agent-info-cli.ts"
+import { isCompatibleAgentDevServerRoot, runAgentInfoCli } from "./internal/agent-info-cli.ts"
 import { runAgentChannelSyncCli } from "./internal/channel-sync-cli.ts"
 import { vercelAiGatewayPricing, type AgentUsagePricing } from "./internal/usage-pricing.ts"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig, type ResolvedAgentEvalOptions } from "./internal/evalite-config.ts"
@@ -102,6 +102,7 @@ interface AgentDevCliOptions {
 
 interface AgentDevTarget {
   agent: string
+  root: string
   tokenOptions: WorkspaceDevTokenOptions
   url: string
 }
@@ -791,11 +792,12 @@ async function readDiscovery(
   }
 
   const discovery = await response.json().catch(() => ({})) as Partial<AgentDevLoopDiscoveryResponse>
-  if (typeof discovery.root === "string" && discovery.root !== context.rootDir) {
+  if (typeof discovery.root === "string" && !isCompatibleAgentDevServerRoot(context.rootDir, discovery.root)) {
     context.stderr.write(`Compatible Vite Development Server root mismatch: ${discovery.root}\n`)
     return
   }
   const tokenOptions = typeof discovery.workspaceDevTokenServerId === "string" ? { serverId: discovery.workspaceDevTokenServerId } : {}
+  const root = typeof discovery.root === "string" ? discovery.root : context.rootDir
   const agents = (discovery.agents || []).flatMap(agent => typeof agent.name === "string" ? [agent.name] : [])
   const agentTargets = new Map<string, string>()
   for (const agent of discovery.agents || []) {
@@ -813,10 +815,10 @@ async function readDiscovery(
       context.stderr.write(`Unknown Agent Dev Loop Target: ${parsed.agent}\n`)
       return
     }
-    return { agent: target, tokenOptions, url }
+    return { agent: target, root, tokenOptions, url }
   }
   if (agents.length === 1) {
-    return { agent: agents[0]!, tokenOptions, url }
+    return { agent: agents[0]!, root, tokenOptions, url }
   }
   if (!agents.length) {
     context.stderr.write("No Agents discovered.\n")
@@ -1090,10 +1092,11 @@ async function sendDevWorkspaceCommand(
   parsed: ParsedDevArgs,
   context: AgentCliContext,
   fetchImpl: typeof fetch,
+  root: string,
   tokenOptions: WorkspaceDevTokenOptions,
   signal?: AbortSignal,
 ): Promise<number> {
-  const token = await readWorkspaceDevToken(context.rootDir, tokenOptions)
+  const token = await readWorkspaceDevToken(root, tokenOptions)
   if (!token) {
     context.stderr.write("No private Agent Dev Loop command token found. Start the Compatible Vite Development Server first.\n")
     return 1
@@ -1196,7 +1199,7 @@ async function runInteractiveDevLoop(
       if (command) {
         activeRequest = new AbortController()
         try {
-          const exitCode = await sendDevWorkspaceCommand(target.url, target.agent, { command }, parsed, context, fetchImpl, target.tokenOptions, activeRequest.signal)
+          const exitCode = await sendDevWorkspaceCommand(target.url, target.agent, { command }, parsed, context, fetchImpl, target.root, target.tokenOptions, activeRequest.signal)
           if (exitCode !== 0) return exitCode
           continue
         }
@@ -1261,7 +1264,7 @@ export async function runAgentDevCli(
     return await sendDevCliCommand(target.url, target.agent, parsed, context, fetchImpl)
   }
   if (workspaceCommand) {
-    return await sendDevWorkspaceCommand(target.url, target.agent, workspaceCommand, parsed, context, fetchImpl, target.tokenOptions)
+    return await sendDevWorkspaceCommand(target.url, target.agent, workspaceCommand, parsed, context, fetchImpl, target.root, target.tokenOptions)
   }
 
   const payloadStartsInvocation = parsed.payload && (

--- a/packages/agent/src/internal/agent-info-cli.ts
+++ b/packages/agent/src/internal/agent-info-cli.ts
@@ -1,3 +1,5 @@
+import { isAbsolute, relative, resolve, sep } from "node:path"
+
 import { isExecutionAuthority, type ExecutionAuthority } from "@vite-hub/runtime"
 
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } from "../invocation-stream.ts"
@@ -22,6 +24,11 @@ interface ParsedInfoArgs {
   help: boolean
   json: boolean
   url: string
+}
+
+export function isCompatibleAgentDevServerRoot(rootDir: string, serverRoot: string): boolean {
+  const nestedPath = relative(resolve(rootDir), resolve(serverRoot))
+  return nestedPath === "" || (nestedPath !== ".." && !nestedPath.startsWith(`..${sep}`) && !isAbsolute(nestedPath))
 }
 
 function writeInfoUsage(context: AgentInfoCliContext): void {
@@ -245,7 +252,7 @@ export async function runAgentInfoCli<TContext extends AgentInfoCliContext>(
     context.stderr.write(`Agent inspection returned an invalid response from ${parsed.url}.\n`)
     return 1
   }
-  if (typeof result.root === "string" && result.root !== context.rootDir) {
+  if (typeof result.root === "string" && !isCompatibleAgentDevServerRoot(context.rootDir, result.root)) {
     context.stderr.write(`Compatible Vite Development Server root mismatch: ${result.root}\n`)
     return 1
   }

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -941,7 +941,7 @@ describe("agent CLI", () => {
     }
   })
 
-  it("prints concise resolved Agent information from the running Vite server", async () => {
+  it("prints Agent information when the Vite server root is nested under the project root", async () => {
     const stdout = stream()
     const fetchAgentInfo = vi.fn(async () => Response.json({
       inspection: {
@@ -974,7 +974,7 @@ describe("agent CLI", () => {
         tools: [{ name: "search" }, { name: "shell" }],
         warnings: [],
       },
-      root: "/repo",
+      root: "/repo/app",
     }))
 
     const exitCode = await runAgentInfoCli([], {
@@ -1184,7 +1184,7 @@ describe("agent CLI", () => {
     expect(stderr.output()).toBe("Compatible Vite Development Server root mismatch: /other-repo\n")
   })
 
-  it("streams a one-shot Agent Dev Loop message through the Vite endpoint", async () => {
+  it("streams an Agent Dev Loop message when the Vite server root is nested under the project root", async () => {
     const stdout = stream()
     const fetchAgentStream = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
       if (init?.method === "POST") {
@@ -1197,7 +1197,7 @@ describe("agent CLI", () => {
       }
       return Response.json({
         agents: [{ name: "support", triggers: ["chat.message"] }],
-        root: "/repo",
+        root: "/repo/app",
       })
     })
 
@@ -1347,12 +1347,13 @@ describe("agent CLI", () => {
     })
   })
 
-  it("runs ! commands through the selected Agent Workspace command surface", async () => {
+  it("runs ! commands with the nested Vite server root's Workspace token", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vitehub-agent-dev-cli-"))
+    const serverRoot = join(rootDir, "app")
     const stdout = stream()
     const stderr = stream()
     const tokenServerId = "pid-1:5173"
-    const token = await refreshWorkspaceDevToken(rootDir, { serverId: tokenServerId })
+    const token = await refreshWorkspaceDevToken(serverRoot, { serverId: tokenServerId })
     try {
       const payloadPath = join(rootDir, "payload.json")
       await writeFile(payloadPath, JSON.stringify({ tenant: "api" }), "utf8")
@@ -1368,7 +1369,7 @@ describe("agent CLI", () => {
         }
         return Response.json({
           agents: [{ name: "chat", triggers: ["chat.message"] }],
-          root: rootDir,
+          root: serverRoot,
           workspaceDevTokenServerId: tokenServerId,
         })
       })


### PR DESCRIPTION
## Summary

The Agent CLI required the Vite Development Server root to equal the CLI project root. Nuxt mounts Vite from its nested `app` directory, so valid `agent info` and `agent dev` requests were rejected as a project mismatch.

This treats an equal or nested Vite root as compatible in both CLI discovery paths while continuing to reject roots outside the project boundary.

## Verification

- `corepack pnpm --filter @vite-hub/agent test -- cli.test.ts` (59 passed)
- `corepack pnpm --filter @vite-hub/agent typecheck`
- `corepack pnpm exec oxlint packages/agent/src/cli.ts packages/agent/src/internal/agent-info-cli.ts`
- Packed this branch's `@vite-hub/agent` into a disposable Calories clone with the downstream Agent patch removed. Against its real Nuxt Vite root at `app`, `vitehub agent info` returned the Calories inspection and `vitehub agent dev` advanced through discovery to the expected unknown-target validation.
- The installed Calories test suite passed (12 tests).

The disposable Nuxt run's separate Nitro Cloudflare worker could not load the `cloudflare:` protocol, but the Vite Dev Loop endpoint built and served the CLI proof.
