### PR TITLE
fix(agent): use local state for Vite serve

### DIFF
--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -482,6 +482,7 @@ function resolveAgentHosting(config: unknown): "cloudflare" | "netlify" | "verce
 function shouldInstallCloudflareAgentState(
   options: false | ResolvedAgentModuleOptions,
   config: unknown,
+  command?: "build" | "serve",
 ): options is ResolvedAgentModuleOptions {
   if (!options) return false
   const { provider, url } = options.providers.state
@@ -489,6 +490,7 @@ function shouldInstallCloudflareAgentState(
   if (provider !== "auto") return false
   if (url) return false
   if (options.runtime === "cloudflare-agents") return true
+  if (command === "serve" || (isRecord(config) && config.command === "serve")) return false
   if (options.runtime === "vercel" || options.runtime === "deno") return false
   return resolveAgentHosting(config) === "cloudflare"
 }
@@ -1882,7 +1884,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
         })
       },
     },
-    config(config) {
+    config(config, environment) {
       agent = config.agent ?? agent
       const resolved = normalizeAgentOptions(agent)
       serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
@@ -1891,7 +1893,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       const nitroContext = hasNitroConfigContext(config)
       const hasHostedAgents = Boolean(resolved && hasHostedAgentDefinitions(root, serverDirs))
       const denoOutput = resolved && resolved.runtime === "deno"
-      const installCloudflareState = hasHostedAgents && !denoOutput && shouldInstallCloudflareAgentState(resolved, config)
+      const installCloudflareState = hasHostedAgents && !denoOutput && shouldInstallCloudflareAgentState(resolved, config, environment?.command)
       const stateProvider = resolved && resolved.providers.state.provider
       const installWebhookQueue = Boolean(
         resolved

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1679,7 +1679,7 @@ export default defineAgent({
     }
   })
 
-  it("writes local SQLite state when automatic state runs in Vite development", async () => {
+  it("writes local SQLite state in Vite development with a Cloudflare production preset", async () => {
     const { hubAgent } = await import("../src/vite.ts")
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-local-state-routes-"))
     const previousHosting = process.env.VITEHUB_HOSTING
@@ -1688,12 +1688,16 @@ export default defineAgent({
       await mkdir(join(root, "server", "agents"), { recursive: true })
       await writeFile(join(root, "server", "agents", "support.ts"), "export default {}", "utf8")
       const plugin = hubAgent()
+      const result = typeof plugin.config === "function"
+        ? await plugin.config.call({} as never, { preset: "cloudflare", root } as never, { command: "serve", mode: "development" })
+        : undefined
       if (typeof plugin.configResolved === "function") {
-        await plugin.configResolved.call({} as never, { command: "serve", root } as never)
+        await plugin.configResolved.call({} as never, { command: "serve", preset: "cloudflare", root } as never)
       }
 
       const webhookRoute = await readFile(join(root, ".vitehub/agent/chat-webhook-route.ts"), "utf8")
 
+      expect((result as { nitro?: { cloudflare?: unknown } } | undefined)?.nitro?.cloudflare).toBeUndefined()
       expect(webhookRoute).toContain("import { createLibsqlAgentState } from \"@vite-hub/agent/state/sqlite\"")
       expect(webhookRoute).toContain(`const viteHubChatStateOptions = {"url":${JSON.stringify(pathToFileURL(join(root, ".data/vitehub-agent-state.sqlite")).href)}}`)
       expect(webhookRoute).toContain("const runtimeUrl = typeof process === 'object' ? process.env.VITEHUB_AGENT_STATE_URL : undefined")


### PR DESCRIPTION
When automatic Agent state runs under a Cloudflare production preset, Vite development currently inherits the deployment provider and installs Cloudflare Durable Object state. That prevents the local runtime from using the SQLite default it already resolves for `command: serve`.

This passes Vite’s command into the early config hook and makes automatic Cloudflare state selection yield to local development. Explicit Cloudflare state providers and the `cloudflare-agents` runtime keep their existing behavior.

Verified with:

- all 237 Agent provider tests
- Agent typecheck
- Agent package build and publint
- a disposable Calories checkout with the Agent patch removed and this package installed: Nuxt dev started under `vitehub.preset: cloudflare`, `/` returned HTTP 200, and the generated handler used `.data/vitehub-agent-state.sqlite` without a Cloudflare state import