### PR TITLE
fix(agent): support Codex local images

### DIFF
--- a/packages/agent/test/harness-codex-patch.test.ts
+++ b/packages/agent/test/harness-codex-patch.test.ts
@@ -3,7 +3,7 @@ import { execFile } from "node:child_process"
 import { build } from "esbuild"
 import { chmod, mkdir, mkdtemp, readFile, readdir, readlink, rm, writeFile } from "node:fs/promises"
 import { join } from "node:path"
-import { pathToFileURL } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 import { promisify } from "node:util"
 import { describe, expect, it, vi } from "vitest"
 
@@ -16,6 +16,48 @@ const exec = promisify(execFile)
 const codexBridgeInstallCommand = "if command -v corepack >/dev/null 2>&1 && corepack pnpm@10.33.2 --dir /tmp/harness/codex install --ignore-workspace --frozen-lockfile --store-dir /tmp/harness/codex/.pnpm-store; then :; else pnpm --dir /tmp/harness/codex install --ignore-workspace --frozen-lockfile --store-dir /tmp/harness/codex/.pnpm-store; fi"
 
 describe("ViteHub Codex harness", () => {
+  it("preserves ordered text and sandbox-local images in Codex prompts", async () => {
+    const fixture = await mkdtemp(join(import.meta.dirname, ".codex-input-"))
+    const output = join(fixture, "adapter.mjs")
+
+    try {
+      await build({
+        bundle: true,
+        entryPoints: [fileURLToPath(import.meta.resolve("@ai-sdk/harness-codex"))],
+        footer: { js: "export { extractUserInput, startMessageSchema }" },
+        format: "esm",
+        outfile: output,
+        platform: "node",
+      })
+      const { extractUserInput, startMessageSchema } = await import(`${pathToFileURL(output).href}?${Date.now()}`)
+      const prompt = extractUserInput({
+        content: [
+          { text: "Compare ", type: "text" },
+          { image: "/workspace/before.png", type: "image" },
+          { image: "./after.png", type: "image" },
+        ],
+        role: "user",
+      })
+
+      expect(prompt).toEqual([
+        { text: "Compare ", type: "text" },
+        { path: "/workspace/before.png", type: "local_image" },
+        { path: "./after.png", type: "local_image" },
+      ])
+      expect(() => extractUserInput({
+        content: [{ image: "https://example.com/image.png", type: "image" }],
+        role: "user",
+      })).toThrow("Images must be materialized to a sandbox-local path")
+      expect(() => startMessageSchema.parse({
+        prompt: [{ path: "https://example.com/image.png", type: "local_image" }],
+        type: "start",
+      })).toThrow("Codex local image paths must begin")
+    }
+    finally {
+      await rm(fixture, { force: true, recursive: true })
+    }
+  })
+
   it("bootstraps inside the sandbox workspace with the supported bridge", async () => {
     const harness = createCodexDriver({ sandbox: false }).harness as ReturnType<typeof createCodex>
     const bootstrap = await harness.getBootstrap!()
@@ -79,6 +121,7 @@ describe("ViteHub Codex harness", () => {
       pathConvertedToFileURL: true,
       runtimeESMResolver: false,
     })
+    expect(codexChunk?.source).toContain('type: "local_image"')
 
     const { stdout } = await exec(process.execPath, [
       "--input-type=module",

--- a/patches/@ai-sdk__harness-codex@1.0.41.patch
+++ b/patches/@ai-sdk__harness-codex@1.0.41.patch
@@ -1,0 +1,310 @@
+diff --git a/dist/index.js b/dist/index.js
+index 99eca92075fed634678059855b7c8990fcdf0cc6..3adf1bd185987b7a1e00fbec18c9648ddb72accd 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -106,7 +106,24 @@ import {
+ } from "@ai-sdk/harness";
+ import { z } from "zod/v4";
+ var outboundMessageSchema = harnessV1BridgeOutboundMessageSchema;
++function isSandboxLocalImagePath(value) {
++  return value.startsWith("/") || value.startsWith("./") || value.startsWith("../");
++}
++var codexUserInputSchema = z.array(
++  z.discriminatedUnion("type", [
++    z.object({ type: z.literal("text"), text: z.string() }),
++    z.object({
++      type: z.literal("local_image"),
++      path: z.string().refine(
++        isSandboxLocalImagePath,
++        "Codex local image paths must begin with '/', './', or '../'."
++      )
++    })
++  ])
++);
++var codexPromptInputSchema = z.union([z.string(), codexUserInputSchema]);
+ var startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
++  prompt: codexPromptInputSchema,
+   reasoningEffort: z.enum(["low", "medium", "high"]).optional(),
+   webSearch: z.boolean().optional(),
+   // Resume signal. When supplied, the bridge calls
+@@ -608,22 +625,22 @@ function createSession({
+         description: t.description,
+         inputSchema: t.inputSchema
+       }));
+-      let promptText = extractUserText(promptOpts.prompt);
++      let promptInput = extractUserInput(promptOpts.prompt);
+       if (!instructionsApplied) {
+         const instructions = (promptOpts.instructions ? promptOpts.instructions + "\n\n" : "") + "Only respond with your `final` message once you have fully addressed the user request.";
+-        promptText = frameInitialPromptGuidance({
++        promptInput = frameInitialPromptInput({
+           instructions,
++          prompt: promptInput,
+           toolUsageBlock: tools.length > 0 ? composeToolUsageInstructions({
+             tools,
+             cliShimPath
+-          }) : void 0,
+-          userText: promptText
++          }) : void 0
+         });
+       }
+       instructionsApplied = true;
+       const startMessage = {
+         type: "start",
+-        prompt: promptText,
++        prompt: promptInput,
+         tools,
+         model,
+         reasoningEffort,
+@@ -819,10 +836,10 @@ function createSession({
+     }
+   };
+ }
+-function frameInitialPromptGuidance({
++function frameInitialPromptInput({
+   instructions,
+-  toolUsageBlock,
+-  userText
++  prompt,
++  toolUsageBlock
+ }) {
+   const blocks = [];
+   if (instructions) {
+@@ -835,12 +852,15 @@ ${instructions}
+     );
+   }
+   if (toolUsageBlock) blocks.push(toolUsageBlock);
+-  if (blocks.length === 0) return userText;
+-  return `${blocks.join("\n\n")}
+-
+-<user-message>
+-${userText}
+-</user-message>`;
++  if (blocks.length === 0) return prompt;
++  const prefix = `${blocks.join("\n\n")}\n\n<user-message>\n`;
++  const suffix = "\n</user-message>";
++  if (typeof prompt === "string") return `${prefix}${prompt}${suffix}`;
++  return [
++    { type: "text", text: prefix },
++    ...prompt,
++    { type: "text", text: suffix }
++  ];
+ }
+ function composeToolUsageInstructions({
+   tools,
+@@ -867,21 +887,29 @@ function composeToolUsageInstructions({
+   lines.push("</host-tool-instructions>");
+   return lines.join("\n");
+ }
+-function extractUserText(prompt) {
++function extractUserInput(prompt) {
+   if (typeof prompt === "string") return prompt;
+   const { content } = prompt;
+   if (typeof content === "string") return content;
++  if (content.every((part) => part.type === "text")) {
++    return content.map((part) => part.text).join("\n\n");
++  }
+   const parts = [];
+   for (const part of content) {
+-    if (part.type !== "text") {
+-      throw new HarnessCapabilityUnsupportedError({
+-        harnessId: "codex",
+-        message: `The codex harness does not yet support user message parts of type '${part.type}'. Pass a string or a user message whose content contains only text parts.`
+-      });
++    if (part.type === "text") {
++      parts.push({ type: "text", text: part.text });
++      continue;
+     }
+-    parts.push(part.text);
++    if (part.type === "image" && typeof part.image === "string" && isSandboxLocalImagePath(part.image)) {
++      parts.push({ type: "local_image", path: part.image });
++      continue;
++    }
++    throw new HarnessCapabilityUnsupportedError({
++      harnessId: "codex",
++      message: `The codex harness cannot send user message parts of type '${part.type}' as native Codex input. Images must be materialized to a sandbox-local path beginning with '/', './', or '../'.`
++    });
+   }
+-  return parts.join("\n\n");
++  return parts;
+ }
+
+ // src/index.ts
+diff --git a/src/codex-bridge-protocol.ts b/src/codex-bridge-protocol.ts
+index e53d0f89ffb0b0b8fdadeb90fcbdf6a5d91913b3..da3d9439e3e31d478f6e63cffde2452cc216f489 100644
+--- a/src/codex-bridge-protocol.ts
++++ b/src/codex-bridge-protocol.ts
+@@ -16,7 +16,32 @@ import { z } from 'zod/v4';
+ export const outboundMessageSchema = harnessV1BridgeOutboundMessageSchema;
+ export type OutboundMessage = z.infer<typeof outboundMessageSchema>;
+
++export function isSandboxLocalImagePath(value: string): boolean {
++  return (
++    value.startsWith('/') || value.startsWith('./') || value.startsWith('../')
++  );
++}
++
++const codexUserInputSchema = z.array(
++  z.discriminatedUnion('type', [
++    z.object({ type: z.literal('text'), text: z.string() }),
++    z.object({
++      type: z.literal('local_image'),
++      path: z
++        .string()
++        .refine(
++          isSandboxLocalImagePath,
++          "Codex local image paths must begin with '/', './', or '../'.",
++        ),
++    }),
++  ]),
++);
++export type CodexUserInput = z.infer<typeof codexUserInputSchema>[number];
++const codexPromptInputSchema = z.union([z.string(), codexUserInputSchema]);
++export type CodexPromptInput = z.infer<typeof codexPromptInputSchema>;
++
+ export const startMessageSchema = harnessV1BridgeStartBaseSchema.extend({
++  prompt: codexPromptInputSchema,
+   reasoningEffort: z.enum(['low', 'medium', 'high']).optional(),
+   webSearch: z.boolean().optional(),
+   // Resume signal. When supplied, the bridge calls
+diff --git a/src/codex-harness.ts b/src/codex-harness.ts
+index ae51a7b3106de24ae72a4cfb5e6bbaf5c0ce68fe..66f0511bb4b5d49d003eab4d5777a28c9db1488d 100644
+--- a/src/codex-harness.ts
++++ b/src/codex-harness.ts
+@@ -41,7 +41,10 @@ import { WebSocket } from 'ws';
+ import { z } from 'zod/v4';
+ import { resolveCodexEnv, type CodexAuthOptions } from './codex-auth';
+ import {
++  isSandboxLocalImagePath,
+   outboundMessageSchema,
++  type CodexPromptInput,
++  type CodexUserInput,
+   type InboundMessage,
+   type OutboundMessage,
+ } from './codex-bridge-protocol';
+@@ -773,13 +776,14 @@ function createSession({
+         description: t.description,
+         inputSchema: t.inputSchema,
+       }));
+-      let promptText = extractUserText(promptOpts.prompt);
++      let promptInput = extractUserInput(promptOpts.prompt);
+       if (!instructionsApplied) {
+         const instructions =
+           (promptOpts.instructions ? promptOpts.instructions + '\n\n' : '') +
+           'Only respond with your `final` message once you have fully addressed the user request.';
+-        promptText = frameInitialPromptGuidance({
++        promptInput = frameInitialPromptInput({
+           instructions,
++          prompt: promptInput,
+           toolUsageBlock:
+             tools.length > 0
+               ? composeToolUsageInstructions({
+@@ -787,14 +791,13 @@ function createSession({
+                   cliShimPath,
+                 })
+               : undefined,
+-          userText: promptText,
+         });
+       }
+       instructionsApplied = true;
+
+       const startMessage = {
+         type: 'start' as const,
+-        prompt: promptText,
++        prompt: promptInput,
+         tools,
+         model,
+         reasoningEffort,
+@@ -1042,19 +1045,19 @@ function createSession({
+ }
+
+ /*
+- * Frame session instructions, host-tool relay guidance, and the user's text so
++ * Frame session instructions, host-tool relay guidance, and the user's input so
+  * Codex treats the prepended blocks as operating guidance rather than user
+  * prose. Applied only to the first user message of a fresh session.
+  */
+-function frameInitialPromptGuidance({
++function frameInitialPromptInput({
+   instructions,
++  prompt,
+   toolUsageBlock,
+-  userText,
+ }: {
+   instructions: string | undefined;
++  prompt: CodexPromptInput;
+   toolUsageBlock: string | undefined;
+-  userText: string;
+-}): string {
++}): CodexPromptInput {
+   const blocks: string[] = [];
+   if (instructions) {
+     blocks.push(
+@@ -1065,8 +1068,17 @@ function frameInitialPromptGuidance({
+     );
+   }
+   if (toolUsageBlock) blocks.push(toolUsageBlock);
+-  if (blocks.length === 0) return userText;
+-  return `${blocks.join('\n\n')}\n\n<user-message>\n${userText}\n</user-message>`;
++  if (blocks.length === 0) return prompt;
++
++  const prefix = `${blocks.join('\n\n')}\n\n<user-message>\n`;
++  const suffix = '\n</user-message>';
++  if (typeof prompt === 'string') return `${prefix}${prompt}${suffix}`;
++
++  return [
++    { type: 'text', text: prefix },
++    ...prompt,
++    { type: 'text', text: suffix },
++  ];
+ }
+
+ function composeToolUsageInstructions({
+@@ -1102,26 +1114,32 @@ function composeToolUsageInstructions({
+   return lines.join('\n');
+ }
+
+-/*
+- * Reduce a `HarnessV1Prompt` to the plain user text the bridge forwards
+- * to the Codex SDK. File and image parts on the message are not yet
+- * supported by the underlying runtime — throw rather than silently drop
+- * them so callers learn about the gap instead of seeing mysteriously
+- * truncated prompts.
+- */
+-function extractUserText(prompt: HarnessV1Prompt): string {
++function extractUserInput(prompt: HarnessV1Prompt): CodexPromptInput {
+   if (typeof prompt === 'string') return prompt;
+   const { content } = prompt;
+   if (typeof content === 'string') return content;
+-  const parts: string[] = [];
++  if (content.every(part => part.type === 'text')) {
++    return content.map(part => part.text).join('\n\n');
++  }
++
++  const parts: CodexUserInput[] = [];
+   for (const part of content) {
+-    if (part.type !== 'text') {
+-      throw new HarnessCapabilityUnsupportedError({
+-        harnessId: 'codex',
+-        message: `The codex harness does not yet support user message parts of type '${part.type}'. Pass a string or a user message whose content contains only text parts.`,
+-      });
++    if (part.type === 'text') {
++      parts.push({ type: 'text', text: part.text });
++      continue;
++    }
++    if (
++      part.type === 'image' &&
++      typeof part.image === 'string' &&
++      isSandboxLocalImagePath(part.image)
++    ) {
++      parts.push({ type: 'local_image', path: part.image });
++      continue;
+     }
+-    parts.push(part.text);
++    throw new HarnessCapabilityUnsupportedError({
++      harnessId: 'codex',
++      message: `The codex harness cannot send user message parts of type '${part.type}' as native Codex input. Images must be materialized to a sandbox-local path beginning with '/', './', or '../'.`,
++    });
+   }
+-  return parts.join('\n\n');
++  return parts;
+ }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,6 +345,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-nXN3zsjYbryO1ExQdeIkna3umuJ8ZZ87xxqQXLFrP4M=
 
+patchedDependencies:
+  '@ai-sdk/harness-codex@1.0.41':
+    hash: b074c42ac5b900be09038dd290494f98db78ae119330a08d360fd7f530e02327
+    path: patches/@ai-sdk__harness-codex@1.0.41.patch
+
 importers:
 
   .:
@@ -517,7 +522,7 @@ importers:
         version: 1.0.39(ws@8.21.1)(zod@4.4.3)
       '@ai-sdk/harness-codex':
         specifier: catalog:ai
-        version: 1.0.41(zod@4.4.3)
+        version: 1.0.41(patch_hash=b074c42ac5b900be09038dd290494f98db78ae119330a08d360fd7f530e02327)(zod@4.4.3)
       '@chat-adapter/telegram':
         specifier: catalog:chat
         version: 4.35.0(ai@7.0.19(zod@4.4.3))(workflow@5.0.0-beta.35(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.3)(react@19.2.6)(typescript@6.0.3)(ws@8.21.1))(zod@4.4.3)
@@ -13827,7 +13832,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@ai-sdk/harness-codex@1.0.41(zod@4.4.3)':
+  '@ai-sdk/harness-codex@1.0.41(patch_hash=b074c42ac5b900be09038dd290494f98db78ae119330a08d360fd7f530e02327)(zod@4.4.3)':
     dependencies:
       '@ai-sdk/harness': 1.0.39(ws@8.21.1)(zod@4.4.3)
       '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -148,3 +148,5 @@ packageExtensions:
   "@nuxt/content@3":
     dependencies:
       h3: ^1.15.11
+patchedDependencies:
+  '@ai-sdk/harness-codex@1.0.41': patches/@ai-sdk__harness-codex@1.0.41.patch


### PR DESCRIPTION
## Summary

- patch the pinned `@ai-sdk/harness-codex@1.0.41` with the canonical local-image implementation from [vercel/ai#18024](https://github.com/vercel/ai/pull/18024)
- preserve ordered text and sandbox-local image parts while rejecting URL-backed image input
- verify the patched adapter is embedded in the published Agent build

## Verification

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm exec vp run -t @vite-hub/agent#build` (publint clean)
- `corepack pnpm --filter @vite-hub/agent exec vp test run test/harness-codex-patch.test.ts` (12/12)
- `corepack pnpm --filter @vite-hub/agent typecheck`
- `git diff --check origin/main...HEAD`