### PR TITLE
feat(agent): add Vue Agent client composables

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -280,6 +280,19 @@ export default defineAgent({
 })
 ```
 
+In Vue, create the Agent client handle and pass it to the chat adapter. ViteHub derives the generated endpoint from the Agent name and delegates messages, status, errors, actions, and UI-message streaming to `@ai-sdk/vue`.
+
+```vue [app/components/SupportChat.vue]
+<script setup lang="ts">
+import { useAgent, useChat } from '@vite-hub/agent/vue'
+
+const agent = useAgent('support')
+const { messages, status, sendMessage, stop } = useChat(agent)
+</script>
+```
+
+The `vite-hub/nuxt` integration auto-imports both composables when `agent` is enabled; framework-distribution imports are also available from `vite-hub/agent/vue`. Pass `api` for an application-owned endpoint, or pass an AI SDK `transport` when the request protocol needs further customization. An explicit transport takes precedence over `api`. When `routes.chat` is disabled, `useChat(agent)` requires one of those explicit options instead of deriving an unavailable route.
+
 ViteHub reads the raw request body once and runs `authenticate` with `rawBody`. It then requires a non-empty `messages` array containing `user` or `assistant` messages, accepts optional string `id`, `messageId`, and `trigger` fields, and passes additional AI SDK fields unchanged to admission validation. An `admission.body` Standard Schema adds product-specific validation to that shared contract instead of recreating it.
 
 `input.trust` lists request body fields that may be copied after authentication. Add `timeout` only when authenticated callers may control Agent Invocation duration; ViteHub forwards positive, finite numeric values and ignores invalid timeouts. Use `admission.context` only when the route needs to derive or validate different `chat.message` input.

--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -24,6 +24,7 @@ composition and explicit feature subpaths for application APIs.
 | `vite-hub/agent/eval` | Agent Eval authoring helpers; install Evalite and the test runner explicitly. |
 | `vite-hub/agent/harness/local-sandbox` | Trusted local harness sandbox helper for development and Agent Evals. |
 | `vite-hub/agent/cloudflare` | Cloudflare Agent state configuration helpers. |
+| `vite-hub/agent/vue` | Vue Agent client handle and AI SDK chat composable. |
 | `vite-hub/agent/server` and `vite-hub/agent/state/sqlite` | Manual server integration and libSQL-compatible durable Agent state. |
 | `vite-hub/auth` and `vite-hub/auth/server` | Auth Definitions and server runtime helpers. |
 | `vite-hub/auth/agent` | Better Auth session mapping into Agent Invokers. |
@@ -79,6 +80,7 @@ for libraries, focused integrations, and advanced composition.
 | `@vite-hub/agent/test` | Agent Package | Agent test runner helpers for local and CI Agent Invocation checks. |
 | `@vite-hub/agent/harness/local-sandbox` | Agent Package | Trusted local harness sandbox helper for development and Agent Evals. |
 | `@vite-hub/agent/cloudflare` | Agent Package | Cloudflare Agent state helpers. |
+| `@vite-hub/agent/vue` | Agent Package | Vue Agent client handle and AI SDK chat composable. |
 | `@vite-hub/auth` | Auth Package | Auth Definition helpers. |
 | `@vite-hub/auth/server` | Auth Package | Better Auth runtime creation, request handlers, and session access for manual host integration. |
 | `@vite-hub/blob` | Blob Package | Blob Runtime Helpers and Blob Store access. |

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -133,7 +133,6 @@
     "@ai-sdk/gateway": "catalog:ai",
     "@ai-sdk/harness": "catalog:ai",
     "@ai-sdk/harness-codex": "catalog:ai",
-    "@ai-sdk/vue": "catalog:ai",
     "@chat-adapter/telegram": "catalog:chat",
     "@libsql/client": "catalog:database",
     "@openai/codex-sdk": "0.144.5",
@@ -171,7 +170,8 @@
     "vue": "catalog:ui"
   },
   "optionalDependencies": {
-    "@ai-sdk/mcp": "catalog:ai"
+    "@ai-sdk/mcp": "catalog:ai",
+    "@ai-sdk/vue": "catalog:ai"
   },
   "peerDependencies": {
     "@ai-sdk/harness-claude-code": "catalog:ai",

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -117,6 +117,10 @@
       "types": "./dist/vite.d.ts",
       "import": "./dist/vite.js"
     },
+    "./vue": {
+      "types": "./dist/vue.d.ts",
+      "import": "./dist/vue.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {
@@ -129,6 +133,7 @@
     "@ai-sdk/gateway": "catalog:ai",
     "@ai-sdk/harness": "catalog:ai",
     "@ai-sdk/harness-codex": "catalog:ai",
+    "@ai-sdk/vue": "catalog:ai",
     "@chat-adapter/telegram": "catalog:chat",
     "@libsql/client": "catalog:database",
     "@openai/codex-sdk": "0.144.5",
@@ -162,7 +167,8 @@
     "typescript": "catalog:tooling",
     "vite": "catalog:vite",
     "vite-plus": "catalog:tooling",
-    "vitest": "catalog:tooling"
+    "vitest": "catalog:tooling",
+    "vue": "catalog:ui"
   },
   "optionalDependencies": {
     "@ai-sdk/mcp": "catalog:ai"
@@ -177,7 +183,8 @@
     "@vite-hub/workflow": "workspace:*",
     "askweb": "catalog:ai",
     "vite": "catalog:vite-compat",
-    "vitest": "catalog:tooling"
+    "vitest": "catalog:tooling",
+    "vue": "catalog:ui"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/harness-claude-code": {
@@ -208,6 +215,9 @@
       "optional": true
     },
     "vitest": {
+      "optional": true
+    },
+    "vue": {
       "optional": true
     }
   },

--- a/packages/agent/src/config.ts
+++ b/packages/agent/src/config.ts
@@ -1,8 +1,6 @@
-import type { AgentModuleOptions, ResolvedAgentModuleOptions } from "./types.ts"
+import { defaultAgentChatRoute, defaultAgentDiscordGatewayRoute, defaultAgentWebhookRoute } from "./internal/routes.ts"
 
-const defaultAgentChatRoute = "/api/_vitehub/agents/[agent]/chat"
-const defaultAgentDiscordGatewayRoute = "/api/_vitehub/agents/[agent]/discord/gateway"
-const defaultAgentWebhookRoute = "/api/_vitehub/agents/[agent]/webhooks/[webhook]"
+import type { AgentModuleOptions, ResolvedAgentModuleOptions } from "./types.ts"
 
 function normalizeAgentRouteOption(value: boolean | string | undefined, defaultRoute: string): false | string {
   if (value === true) return defaultRoute

--- a/packages/agent/src/internal/routes.ts
+++ b/packages/agent/src/internal/routes.ts
@@ -1,0 +1,19 @@
+export const defaultAgentChatRoute = "/api/_vitehub/agents/[agent]/chat"
+export const defaultAgentDiscordGatewayRoute = "/api/_vitehub/agents/[agent]/discord/gateway"
+export const defaultAgentWebhookRoute = "/api/_vitehub/agents/[agent]/webhooks/[webhook]"
+
+export function normalizeAgentRoute(route: string): string {
+  const normalized = route.startsWith("/") ? route : `/${route}`
+  return normalized.replace(/\[([^\]]+)\]/g, ":$1")
+}
+
+export function resolveAgentRoutePath(route: string, values: Record<string, string>): string {
+  return normalizeAgentRoute(route).replace(/(^|\/):([^/]+)/g, (match, prefix: string, param: string) => {
+    if (!(param in values)) return match
+    return `${prefix}${encodeURIComponent(values[param]!)}`
+  })
+}
+
+export function agentRouteUsesParam(route: false | string | undefined, param: string): boolean {
+  return Boolean(route && normalizeAgentRoute(route).split("/").includes(`:${param}`))
+}

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -18,6 +18,7 @@ import {
 import { normalizeAgentOptions } from "./config.ts"
 import { discoverAgentDefinitions, discoverAgentEvalFiles } from "./discovery.ts"
 import { removeAgentEvaliteConfig, resolveAgentEvalOptions, writeAgentEvaliteConfig } from "./internal/evalite-config.ts"
+import { agentRouteUsesParam, normalizeAgentRoute } from "./internal/routes.ts"
 import { readColocatedAgentHome } from "./vite/colocated-agent-home.ts"
 import { readColocatedAgentInstructions } from "./vite/colocated-agent-instructions.ts"
 import { readColocatedAgentSkills } from "./vite/colocated-agent-skills.ts"
@@ -651,8 +652,7 @@ function mergeNitroPlugins(nitro: NitroConfig, plugins: string[]): NitroConfig {
 }
 
 function normalizeNitroRoute(route: string): string {
-  const normalized = route.startsWith("/") ? route : `/${route}`
-  return normalized.replace(/\[([^\]]+)\]/g, ":$1")
+  return normalizeAgentRoute(route)
 }
 
 function escapeRegExp(value: string): string {
@@ -670,7 +670,7 @@ function routeRegexSource(route: false | string | undefined, captureParams: stri
 }
 
 function routeUsesParam(route: false | string | undefined, param: string): boolean {
-  return Boolean(route && normalizeNitroRoute(route).split("/").includes(`:${param}`))
+  return agentRouteUsesParam(route, param)
 }
 
 function generatedWebhookRoute(route: false | string | undefined): string {
@@ -1551,6 +1551,11 @@ async function generateAgentDenoServer(
     "  return Response.json({ error: true, status, statusText: message, message }, { status })",
     "}",
     "",
+    "function decodeRouteParam(value) {",
+    "  try { return decodeURIComponent(value || '') }",
+    "  catch { return value || '' }",
+    "}",
+    "",
     "function readDenoArg(args, index, name) {",
     "  const arg = args[index]",
     "  if (arg === name) return { index: index + 1, value: args[index + 1] }",
@@ -1586,8 +1591,8 @@ async function generateAgentDenoServer(
     "  const webhookMatch = webhookRoutePattern.exec(pathname)",
     "  const isWebhookRoute = Boolean(webhookMatch)",
     "  const groups = (webhookMatch || chatMatch)?.groups || {}",
-    "  const agent = groups.agent || (agentNames.length === 1 ? agentNames[0] : undefined)",
-    "  const webhook = groups.webhook || ''",
+    "  const agent = groups.agent ? decodeRouteParam(groups.agent) : (agentNames.length === 1 ? agentNames[0] : undefined)",
+    "  const webhook = decodeRouteParam(groups.webhook)",
     "  const handler = agent ? (isWebhookRoute ? webhookHandlers[agent] : chatHandlers[agent]) : undefined",
     "  if (!handler || (!chatMatch && !webhookMatch)) return jsonError(404, 'Unknown ViteHub agent route.')",
     `  return isWebhookRoute ? await handler(request, webhook, { agentIdentity: agentIdentities[agent]${routeCapabilities.requestProperty}${options.libsqlState ? ", state: viteHubChatStateResolver, webhookState: viteHubChatStateResolver" : ""} }) : await handler(request, { agentIdentity: agentIdentities[agent]${routeCapabilities.requestProperty}${options.libsqlState ? ", state: viteHubChatStateResolver" : ""} })`,
@@ -1949,6 +1954,10 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       ))
       return {
         ...(typeof agent !== "undefined" ? { agent } : {}),
+        define: {
+          ...config.define,
+          __VITEHUB_AGENT_CHAT_ROUTE__: JSON.stringify(resolved ? resolved.routes.chat : false),
+        },
         ...(nitroHandlers.length
           ? {
               build: mergeBuildExternal(config as BuildWithRolldownOptions, optionalMessageAdapterRuntimeExternals),

--- a/packages/agent/src/vue.ts
+++ b/packages/agent/src/vue.ts
@@ -1,0 +1,52 @@
+import { useChat as useAiChat } from "@ai-sdk/vue"
+import { DefaultChatTransport } from "ai"
+import { onScopeDispose } from "vue"
+
+import { defaultAgentChatRoute, resolveAgentRoutePath } from "./internal/routes.ts"
+
+import type { UseChatHelpers } from "@ai-sdk/vue"
+import type { ChatInit, UIMessage } from "ai"
+
+declare const __VITEHUB_AGENT_CHAT_ROUTE__: string | false
+declare const __VITEHUB_APP_BASE_URL__: string
+
+export interface AgentClient {
+  readonly name: string
+}
+
+export type AgentChatInit<UI_MESSAGE extends UIMessage = UIMessage> = ChatInit<UI_MESSAGE> & {
+  api?: string
+}
+
+export function useAgent(name: string): AgentClient {
+  return { name }
+}
+
+function agentChatRoute(name: string): string {
+  const route = typeof __VITEHUB_AGENT_CHAT_ROUTE__ === "undefined"
+    ? defaultAgentChatRoute
+    : __VITEHUB_AGENT_CHAT_ROUTE__
+  if (route === false) {
+    throw new TypeError("[vitehub] useChat() requires an Agent chat route. Enable routes.chat or pass api or transport explicitly.")
+  }
+  const path = resolveAgentRoutePath(route, { agent: name })
+  const baseURL = typeof __VITEHUB_APP_BASE_URL__ === "undefined" ? "/" : __VITEHUB_APP_BASE_URL__
+  return baseURL === "/" ? path : `${baseURL.replace(/\/+$/, "")}${path}`
+}
+
+export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
+  agent: AgentClient,
+  options: AgentChatInit<UI_MESSAGE> = {},
+): UseChatHelpers<UI_MESSAGE> {
+  const { api, transport, ...init } = options
+  const chat = useAiChat<UI_MESSAGE>({
+    ...init,
+    transport: transport ?? new DefaultChatTransport<UI_MESSAGE>({
+      api: api ?? agentChatRoute(agent.name),
+    }),
+  })
+  onScopeDispose(chat.stop, true)
+  return chat
+}
+
+export type { UseChatHelpers } from "@ai-sdk/vue"

--- a/packages/agent/test/deployment-catalog.test.ts
+++ b/packages/agent/test/deployment-catalog.test.ts
@@ -85,11 +85,14 @@ function deploymentRuntimeModules(): Map<string, string> {
   ])
 }
 
-async function createDeploymentRuntimeFixture(adapter: "deno" | "netlify" | "nitro" = "nitro"): Promise<DeploymentRuntimeFixture> {
+async function createDeploymentRuntimeFixture(
+  adapter: "deno" | "netlify" | "nitro" = "nitro",
+  supportName = "support",
+): Promise<DeploymentRuntimeFixture> {
   const root = await mkdtemp(adapter === "netlify"
     ? join(import.meta.dirname, "fixtures", "deployment-catalog-")
     : join(tmpdir(), "vitehub-agent-deployment-catalog-"))
-  const supportRoot = join(root, "server", "agents", "support")
+  const supportRoot = join(root, "server", "agents", ...supportName.split("/"))
   const reviewerRoot = join(root, "server", "agents", "reviewer")
   const capture: DeploymentRuntimeCapture = { workspaceRegistry: {} }
   const scope = globalThis as typeof globalThis & Record<string, unknown>
@@ -354,20 +357,20 @@ describe("generated Agent deployment catalog", () => {
 
   it("executes the same catalog through the Deno Adapter", async () => {
     await runtime!.close()
-    runtime = await createDeploymentRuntimeFixture("deno")
+    runtime = await createDeploymentRuntimeFixture("deno", "team/support")
 
-    await expect((await runtime.request("support", "chat")).json()).resolves.toMatchObject({
+    await expect((await runtime.request("team%2Fsupport", "chat")).json()).resolves.toMatchObject({
       agent: "support",
-      agentIdentity: { name: "support", workspace: "support" },
+      agentIdentity: { name: "team/support", workspace: "team/support" },
       kind: "chat",
     })
-    await expect((await runtime.request("support", "webhooks/channel")).json()).resolves.toMatchObject({
+    await expect((await runtime.request("team%2Fsupport", "webhooks/channel")).json()).resolves.toMatchObject({
       agent: "support",
-      agentIdentity: { name: "support", workspace: "support" },
+      agentIdentity: { name: "team/support", workspace: "team/support" },
       kind: "webhook",
       webhook: "channel",
     })
     expect(await runtime.request("missing", "chat")).toMatchObject({ status: 404 })
-    expect(Object.keys(runtime.capture.workspaceRegistry)).toEqual(["support"])
+    expect(Object.keys(runtime.capture.workspaceRegistry)).toEqual(["team/support"])
   })
 })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1050,6 +1050,16 @@ describe("agent Vite plugin", () => {
       },
       webhook,
     ])
+
+    const plugin = hubAgent({ routes: { chat: "/chat/[agent]" } })
+    const result = typeof plugin.config === "function"
+      ? await plugin.config.call({} as never, { root: hostedAgentRoot }, { command: "build", mode: "production" })
+      : undefined
+    expect(result).toMatchObject({
+      define: {
+        __VITEHUB_AGENT_CHAT_ROUTE__: JSON.stringify("/chat/[agent]"),
+      },
+    })
   })
 
   it("does not register agent routes without hosted Agents", async () => {

--- a/packages/agent/test/vue-types.test-d.ts
+++ b/packages/agent/test/vue-types.test-d.ts
@@ -1,0 +1,23 @@
+import { describe, expectTypeOf, it } from "vitest"
+
+import { useAgent, useChat, type AgentChatInit, type AgentClient } from "../src/vue.ts"
+
+import type { ChatTransport, UIMessage } from "ai"
+import type { ComputedRef, ShallowRef } from "vue"
+
+describe("Agent Vue client types", () => {
+  it("preserves AI SDK Vue message and transport types", () => {
+    const agent = useAgent("support")
+    expectTypeOf(agent).toEqualTypeOf<AgentClient>()
+    expectTypeOf(agent.name).toEqualTypeOf<string>()
+
+    const transport = {} as ChatTransport<UIMessage>
+    const init = { api: "/api/support", transport } satisfies AgentChatInit
+    const chat = useChat(agent, init)
+
+    expectTypeOf(chat.id).toEqualTypeOf<ComputedRef<string>>()
+    expectTypeOf(chat.messages).toEqualTypeOf<ShallowRef<UIMessage[]>>()
+    expectTypeOf(chat.status.value).toEqualTypeOf<"submitted" | "streaming" | "ready" | "error">()
+    expectTypeOf(chat.sendMessage).toBeFunction()
+  })
+})

--- a/packages/agent/test/vue.test.ts
+++ b/packages/agent/test/vue.test.ts
@@ -1,0 +1,132 @@
+import { effectScope } from "vue"
+import { createUIMessageStream, createUIMessageStreamResponse } from "ai"
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { useAgent, useChat } from "../src/vue.ts"
+
+import type { ChatTransport, UIMessage } from "ai"
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe("Agent Vue clients", () => {
+  it("sends Agent chat requests to the generated route and streams reactive messages", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => createUIMessageStreamResponse({
+      stream: createUIMessageStream({
+        execute({ writer }) {
+          writer.write({ id: "answer", type: "text-start" })
+          writer.write({ delta: "Hello from ViteHub", id: "answer", type: "text-delta" })
+          writer.write({ id: "answer", type: "text-end" })
+        },
+      }),
+    }))
+    vi.stubGlobal("fetch", fetch)
+    const scope = effectScope()
+    const chat = scope.run(() => useChat(useAgent("team/review"), { id: "chat-1" }))!
+
+    await chat.sendMessage({ text: "Hello" })
+
+    expect(fetch).toHaveBeenCalledOnce()
+    const [api, request] = fetch.mock.calls[0]!
+    expect(api).toBe("/api/_vitehub/agents/team%2Freview/chat")
+    expect(JSON.parse(String(request?.body))).toMatchObject({
+      id: "chat-1",
+      messages: [{ parts: [{ text: "Hello", type: "text" }], role: "user" }],
+      trigger: "submit-message",
+    })
+    expect(chat.status.value).toBe("ready")
+    expect(chat.messages.value.at(-1)).toMatchObject({
+      parts: [{ text: "Hello from ViteHub", type: "text" }],
+      role: "assistant",
+    })
+
+    scope.stop()
+  })
+
+  it("prefers an explicit transport over the API option", async () => {
+    const sendMessages = vi.fn(async () => new ReadableStream({
+      start(controller) {
+        controller.close()
+      },
+    }))
+    const transport: ChatTransport<UIMessage> = {
+      reconnectToStream: async () => null,
+      sendMessages,
+    }
+    const scope = effectScope()
+    const chat = scope.run(() => useChat(useAgent("support"), {
+      api: "/unused",
+      transport,
+    }))!
+
+    await chat.sendMessage({ text: "Hello" })
+
+    expect(sendMessages).toHaveBeenCalledOnce()
+    scope.stop()
+  })
+
+  it("derives the API from the configured generated chat route", async () => {
+    vi.stubGlobal("__VITEHUB_AGENT_CHAT_ROUTE__", "chat/[agent]")
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => createUIMessageStreamResponse({
+      stream: createUIMessageStream({ execute() {} }),
+    }))
+    vi.stubGlobal("fetch", fetch)
+    const scope = effectScope()
+    const chat = scope.run(() => useChat(useAgent("team/review")))!
+
+    await chat.sendMessage({ text: "Hello" })
+
+    expect(fetch).toHaveBeenCalledWith("/chat/team%2Freview", expect.anything())
+    scope.stop()
+  })
+
+  it("prefixes the generated chat route with the application base URL", async () => {
+    vi.stubGlobal("__VITEHUB_APP_BASE_URL__", "/portal/")
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => createUIMessageStreamResponse({
+      stream: createUIMessageStream({ execute() {} }),
+    }))
+    vi.stubGlobal("fetch", fetch)
+    const scope = effectScope()
+    const chat = scope.run(() => useChat(useAgent("support")))!
+
+    await chat.sendMessage({ text: "Hello" })
+
+    expect(fetch).toHaveBeenCalledWith("/portal/api/_vitehub/agents/support/chat", expect.anything())
+    scope.stop()
+  })
+
+  it("rejects an implicit API when the generated chat route is disabled", () => {
+    vi.stubGlobal("__VITEHUB_AGENT_CHAT_ROUTE__", false)
+    const scope = effectScope()
+
+    expect(() => scope.run(() => useChat(useAgent("support")))).toThrow(
+      "useChat() requires an Agent chat route. Enable routes.chat or pass api or transport explicitly.",
+    )
+    expect(() => scope.run(() => useChat(useAgent("support"), { api: "/chat/support" }))).not.toThrow()
+    scope.stop()
+  })
+
+  it("stops an active stream when its Vue scope is disposed", async () => {
+    let aborted = false
+    const transport: ChatTransport<UIMessage> = {
+      reconnectToStream: async () => null,
+      sendMessages: async ({ abortSignal }) => new ReadableStream({
+        start(controller) {
+          abortSignal?.addEventListener("abort", () => {
+            aborted = true
+            controller.error(new DOMException("Aborted", "AbortError"))
+          })
+        },
+      }),
+    }
+    const scope = effectScope()
+    const chat = scope.run(() => useChat(useAgent("support"), { transport }))!
+    const request = chat.sendMessage({ text: "Hello" })
+    await vi.waitFor(() => expect(chat.status.value).toBe("submitted"))
+
+    scope.stop()
+    await request
+
+    expect(aborted).toBe(true)
+    expect(chat.status.value).toBe("ready")
+  })
+})

--- a/packages/agent/vite.config.ts
+++ b/packages/agent/vite.config.ts
@@ -57,6 +57,7 @@ export default defineConfig({
       "src/server/internal.ts",
       "src/server/workspace.ts",
       "src/test.ts",
+      "src/vue.ts",
       "src/vite.ts",
     ],
     exports: {

--- a/packages/vite-hub/fixtures/published-types/consumer.ts
+++ b/packages/vite-hub/fixtures/published-types/consumer.ts
@@ -12,6 +12,7 @@ import * as agentEval from "vite-hub/agent/eval"
 import * as localHarnessSandbox from "vite-hub/agent/harness/local-sandbox"
 import * as agentServer from "vite-hub/agent/server"
 import * as agentSqliteState from "vite-hub/agent/state/sqlite"
+import { useAgent, useChat } from "vite-hub/agent/vue"
 import * as authAgent from "vite-hub/auth/agent"
 import { createAuthClient, useUserSession } from "vite-hub/auth/vue"
 import type { BoxDefinition } from "vite-hub/box"
@@ -50,6 +51,7 @@ export const appFacingModules = [
 export const nuxtModule = viteHubNuxtModule
 export const customAuthClient = createAuthClient({ basePath: "/auth" })
 export const userSession = useUserSession(customAuthClient)
+export const supportChat = useChat(useAgent("support"))
 export const builtInAgent = defineAgent({ driver: "codex", runtime: false })
 export const builtInBox = { runtime: "trusted-host" } satisfies BoxDefinition
 export const builtInAgentName = "codex" satisfies BuiltInAgentDriverName

--- a/packages/vite-hub/package.json
+++ b/packages/vite-hub/package.json
@@ -70,6 +70,7 @@
     "./agent/harness/local-sandbox": "./dist/agent/harness/local-sandbox.js",
     "./agent/server": "./dist/agent/server.js",
     "./agent/state/sqlite": "./dist/agent/state/sqlite.js",
+    "./agent/vue": "./dist/agent/vue.js",
     "./auth": "./dist/auth.js",
     "./auth/agent": "./dist/auth/agent.js",
     "./auth/server": "./dist/auth/server.js",

--- a/packages/vite-hub/src/agent/vue.ts
+++ b/packages/vite-hub/src/agent/vue.ts
@@ -1,0 +1,1 @@
+export * from "@vite-hub/agent/vue"

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -16,13 +16,33 @@ type NuxtLike = {
   hook?: (name: "nitro:config", callback: (config: Record<string, unknown>) => Promise<void>) => void
   options: {
     alias?: Record<string, string>
+    app?: {
+      baseURL?: string
+    }
     buildDir: string
     dev?: boolean
+    imports?: {
+      imports?: Array<{ as?: string, from: string, name: string }>
+    }
     rootDir?: string
     serverDir?: string
     srcDir?: string
     vite?: UserConfig
     vitehub?: Parameters<typeof vitehub>[0]
+  }
+}
+
+const agentVueComposables = ["useAgent", "useChat"]
+
+function addAgentVueImports(nuxt: NuxtLike): void {
+  nuxt.options.imports ??= {}
+  const imports = (nuxt.options.imports.imports ??= [])
+  for (const name of agentVueComposables) {
+    const existing = imports.find(entry => (entry.as ?? entry.name) === name)
+    if (existing && existing.from !== "vite-hub/agent/vue") {
+      throw new TypeError(`[vitehub] Cannot auto-import ${name} from vite-hub/agent/vue because it is already configured from ${existing.from}.`)
+    }
+    if (!existing) imports.push({ from: "vite-hub/agent/vue", name })
   }
 }
 
@@ -170,6 +190,10 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
     [VITEHUB_NITRO_CONFIG_CONTEXT]?: true
     [VITEHUB_SERVER_DIRS]?: string[]
   }
+  viteConfig.define = {
+    ...viteConfig.define,
+    __VITEHUB_APP_BASE_URL__: JSON.stringify(nuxt.options.app?.baseURL || "/"),
+  }
   viteConfig[VITEHUB_GENERATED_ROOT] = join(nuxt.options.buildDir, "vitehub")
   viteConfig[VITEHUB_NITRO_CONFIG_CONTEXT] = true
   if (nuxt.options.serverDir) viteConfig[VITEHUB_SERVER_DIRS] = [nuxt.options.serverDir]
@@ -178,6 +202,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
     ...existing,
   ] as PluginOption[]
   nuxt.hook?.("nitro:config", config => applyNitroConfig(installedPlugins, config, nuxt))
+  if (options.agent) addAgentVueImports(nuxt)
   if (options.auth) {
     const envOptions = options.env || {}
     hubAuthNuxt({

--- a/packages/vite-hub/test/nuxt-agent.test.ts
+++ b/packages/vite-hub/test/nuxt-agent.test.ts
@@ -28,16 +28,20 @@ it("registers generated Agent handlers from the Nuxt build directory", async () 
       if (name === "nitro:config") nitroConfigHook = callback
     },
     options: {
+      app: { baseURL: "/portal/" },
       buildDir,
       dev: false,
       rootDir,
       serverDir,
       srcDir,
-      vite: {},
+      vite: { define: {} },
     },
   }
 
   viteHubNuxtModule({ agent: true, preset: "node" }, nuxt)
+  expect(nuxt.options.vite.define).toMatchObject({
+    __VITEHUB_APP_BASE_URL__: JSON.stringify("/portal/"),
+  })
   if (!nitroConfigHook) throw new TypeError("Expected a Nitro config hook.")
   const nitroConfig: Record<string, unknown> = {}
   await nitroConfigHook(nitroConfig)

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -365,6 +365,48 @@ describe("ViteHub Nuxt integration", () => {
     expect(nitroConfigHooks).toHaveLength(1)
   })
 
+  it("auto-imports Agent Vue clients only when Agent Definitions are enabled", async () => {
+    const { nuxt } = createNuxt()
+
+    await viteHubNuxtModule({ agent: true, preset: "cloudflare" }, nuxt)
+
+    expect((nuxt.options as typeof nuxt.options & {
+      imports: { imports: Array<{ from: string, name: string }> }
+    }).imports.imports).toEqual([
+      { from: "vite-hub/agent/vue", name: "useAgent" },
+      { from: "vite-hub/agent/vue", name: "useChat" },
+    ])
+  })
+
+  it("rejects a configured Nuxt composable that would bind a different useChat", async () => {
+    const { nuxt } = createNuxt()
+    Object.assign(nuxt.options, {
+      imports: { imports: [{ from: "@ai-sdk/vue", name: "useChat" }] },
+    })
+
+    await expect(viteHubNuxtModule({ agent: true, preset: "cloudflare" }, nuxt))
+      .rejects.toThrow("Cannot auto-import useChat from vite-hub/agent/vue because it is already configured from @ai-sdk/vue")
+  })
+
+  it("checks Nuxt composable collisions against their exposed aliases", async () => {
+    const { nuxt } = createNuxt()
+    Object.assign(nuxt.options, {
+      imports: { imports: [{ as: "useAiChat", from: "@ai-sdk/vue", name: "useChat" }] },
+    })
+
+    await viteHubNuxtModule({ agent: true, preset: "cloudflare" }, nuxt)
+    expect((nuxt.options as typeof nuxt.options & {
+      imports: { imports: Array<{ as?: string, from: string, name: string }> }
+    }).imports.imports).toContainEqual({ from: "vite-hub/agent/vue", name: "useChat" })
+
+    const { nuxt: conflictingNuxt } = createNuxt()
+    Object.assign(conflictingNuxt.options, {
+      imports: { imports: [{ as: "useChat", from: "custom-chat", name: "chat" }] },
+    })
+    await expect(viteHubNuxtModule({ agent: true, preset: "cloudflare" }, conflictingNuxt))
+      .rejects.toThrow("Cannot auto-import useChat from vite-hub/agent/vue because it is already configured from custom-chat")
+  })
+
   it("does not resolve a relative Vite root twice for Auth Env imports", async () => {
     const { nuxt } = createNuxt()
     Object.assign(nuxt.options.vite, { root: "app" })

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest"
 
 import * as ownerAgent from "@vite-hub/agent"
 import * as ownerCapabilities from "@vite-hub/agent/capabilities"
+import * as ownerAgentVue from "@vite-hub/agent/vue"
 import ownerAuthHandler from "@vite-hub/auth/server"
 import * as ownerAuthVue from "@vite-hub/auth/vue"
 import * as ownerBlobContentType from "@vite-hub/blob/content-type"
@@ -14,6 +15,7 @@ import * as ownerRateLimit from "@vite-hub/rate-limit"
 import * as framework from "vite-hub"
 import * as frameworkAgent from "vite-hub/agent"
 import * as frameworkCapabilities from "vite-hub/agent/capabilities"
+import * as frameworkAgentVue from "vite-hub/agent/vue"
 import frameworkAuthHandler from "vite-hub/auth/server"
 import * as frameworkAuthVue from "vite-hub/auth/vue"
 import * as frameworkBlobContentType from "vite-hub/blob/content-type"
@@ -133,6 +135,8 @@ describe("framework package contract", () => {
     expect(frameworkAgent.defineAgent).toBe(ownerAgent.defineAgent)
     expect(frameworkCapabilities.email).toBe(ownerCapabilities.email)
     expect(frameworkCapabilities.workspaceShell).toBe(ownerCapabilities.workspaceShell)
+    expect(frameworkAgentVue.useAgent).toBe(ownerAgentVue.useAgent)
+    expect(frameworkAgentVue.useChat).toBe(ownerAgentVue.useChat)
     expect(frameworkAuthHandler).toBe(ownerAuthHandler)
     expect(frameworkAuthVue.authClient).toBe(ownerAuthVue.authClient)
     expect(frameworkAuthVue.useUserSession).toBe(ownerAuthVue.useUserSession)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@ai-sdk/harness-codex':
       specifier: 1.0.41
       version: 1.0.41
+    '@ai-sdk/vue':
+      specifier: 4.0.19
+      version: 4.0.19
     '@modelcontextprotocol/sdk':
       specifier: ^1.29.0
       version: 1.29.0
@@ -523,6 +526,9 @@ importers:
       '@ai-sdk/harness-codex':
         specifier: catalog:ai
         version: 1.0.41(patch_hash=b074c42ac5b900be09038dd290494f98db78ae119330a08d360fd7f530e02327)(zod@4.4.3)
+      '@ai-sdk/vue':
+        specifier: catalog:ai
+        version: 4.0.19(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       '@chat-adapter/telegram':
         specifier: catalog:chat
         version: 4.35.0(ai@7.0.19(zod@4.4.3))(workflow@5.0.0-beta.35(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.3)(react@19.2.6)(typescript@6.0.3)(ws@8.21.0))(zod@4.4.3)
@@ -623,6 +629,9 @@ importers:
       vite-plus:
         specifier: catalog:tooling
         version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)
+      vue:
+        specifier: catalog:ui
+        version: 3.5.40(typescript@6.0.3)
     optionalDependencies:
       '@ai-sdk/mcp':
         specifier: catalog:ai
@@ -1732,6 +1741,12 @@ packages:
   '@ai-sdk/vue@3.0.228':
     resolution: {integrity: sha512-8+t7DEJt97r7ZmYR641oxr0KLes27tnx3TybYhi/KQm/UUtuq66nhMKealZY6y6Tq3Yg9+gsOgcoCAu13YWtWA==}
     engines: {node: '>=18'}
+    peerDependencies:
+      vue: ^3.3.4
+
+  '@ai-sdk/vue@4.0.19':
+    resolution: {integrity: sha512-K8EGL/J055lBcuGCKc1wVa+qAfNCMqcDxef5MII7g2eWFxrifDyEvF/WTmpBm6Rq0WXlmOZ8HxtE7MOgwftuZw==}
+    engines: {node: '>=22'}
     peerDependencies:
       vue: ^3.3.4
 
@@ -13978,6 +13993,15 @@ snapshots:
     dependencies:
       '@ai-sdk/provider-utils': 4.0.39(zod@4.4.3)
       ai: 6.0.228(zod@4.4.3)
+      swrv: 1.2.0(vue@3.5.40(typescript@6.0.3))
+      vue: 3.5.40(typescript@6.0.3)
+    transitivePeerDependencies:
+      - zod
+
+  '@ai-sdk/vue@4.0.19(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider-utils': 5.0.7(zod@4.4.3)
+      ai: 7.0.19(zod@4.4.3)
       swrv: 1.2.0(vue@3.5.40(typescript@6.0.3))
       vue: 3.5.40(typescript@6.0.3)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -526,9 +526,6 @@ importers:
       '@ai-sdk/harness-codex':
         specifier: catalog:ai
         version: 1.0.41(patch_hash=b074c42ac5b900be09038dd290494f98db78ae119330a08d360fd7f530e02327)(zod@4.4.3)
-      '@ai-sdk/vue':
-        specifier: catalog:ai
-        version: 4.0.19(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
       '@chat-adapter/telegram':
         specifier: catalog:chat
         version: 4.35.0(ai@7.0.19(zod@4.4.3))(workflow@5.0.0-beta.35(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/core@11.1.19(@nestjs/common@11.1.19(reflect-metadata@0.2.2)(rxjs@7.8.2))(reflect-metadata@0.2.2)(rxjs@7.8.2))(@opentelemetry/api@1.9.1)(@swc/cli@0.8.1(@swc/core@1.15.3(@swc/helpers@0.5.23))(chokidar@5.0.0))(@swc/core@1.15.3(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(magicast@0.5.3)(react@19.2.6)(typescript@6.0.3)(ws@8.21.0))(zod@4.4.3)
@@ -636,6 +633,9 @@ importers:
       '@ai-sdk/mcp':
         specifier: catalog:ai
         version: 2.0.0(zod@4.4.3)
+      '@ai-sdk/vue':
+        specifier: catalog:ai
+        version: 4.0.19(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
 
   packages/auth:
     dependencies:
@@ -14006,6 +14006,7 @@ snapshots:
       vue: 3.5.40(typescript@6.0.3)
     transitivePeerDependencies:
       - zod
+    optional: true
 
   '@alloc/quick-lru@5.2.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ catalogs:
     "@ai-sdk/harness-claude-code": 1.0.40
     "@ai-sdk/harness-codex": 1.0.41
     "@ai-sdk/mcp": 2.0.0
+    "@ai-sdk/vue": 4.0.19
     "@modelcontextprotocol/sdk": ^1.29.0
     "@types/json-schema": ^7.0.15
     agents: ^0.17.4


### PR DESCRIPTION
## Summary

- add `useAgent(name)` and `useChat(agent, init?)` from `@vite-hub/agent/vue`, deriving the configured generated Agent chat route while delegating reactive state and UI-message streaming to `@ai-sdk/vue`
- expose the same API through `vite-hub/agent/vue` and Nuxt auto-imports, with explicit `api` and `transport` customization and targeted auto-import collision errors
- preserve encoded nested Agent names in generated Deno routes, stop active chat streams with their Vue scope, and document the route-enabled `webChat()` setup

## Boundary

This keeps the Agent handle general and the chat behavior in one Vue adapter. It does not add generic invocation methods, components, input state, persistence, session policy, or application proxy abstractions.

## Verification

- `corepack pnpm --filter @vite-hub/agent test -- test/vue.test.ts test/deployment-catalog.test.ts` (9 tests)
- `corepack pnpm --filter @vite-hub/agent exec vp test test/providers.test.ts --run -t 'publishes Nitro chat routes only when configured'`
- `corepack pnpm --filter @vite-hub/agent typecheck`
- `corepack pnpm --filter vite-hub test -- test/nuxt.test.ts test/package.test.ts` (23 tests, published type checks)
- `corepack pnpm --filter vite-hub typecheck`
- `corepack pnpm exec vp test test/contracts.test.ts --run` (12 tests)
- `corepack pnpm exec vp check --no-fmt <touched TypeScript files>`
