### PR TITLE
fix(workspace): activate Cloudflare runtime bindings

### DIFF
--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -275,7 +275,7 @@ export default defineWorkspace({
 })
 ```
 
-Set `WORKSPACE_GITHUB_TOKEN`, `VITEHUB_WORKSPACE_GITHUB_TOKEN`, `GITHUB_TOKEN`, or a `GITHUB_TOKEN` runtime binding with permission to read and write the repository contents. Reads and snapshots call the GitHub API, so this Store trades provider independence for GitHub API latency and rate limits. `workspace.snapshot()` writes changed Workspace Store files as a GitHub commit. If the target branch moves after the Workspace Store loaded local changes, snapshot fails with a conflict so the caller can retry from a fresh Workspace Store.
+Set `WORKSPACE_GITHUB_TOKEN`, `VITEHUB_WORKSPACE_GITHUB_TOKEN`, `GITHUB_TOKEN`, or `GH_TOKEN` in the process environment or as a runtime binding with permission to read and write the repository contents. Reads and snapshots call the GitHub API, so this Store trades provider independence for GitHub API latency and rate limits. `workspace.snapshot()` writes changed Workspace Store files as a GitHub commit. If the target branch moves after the Workspace Store loaded local changes, snapshot fails with a conflict so the caller can retry from a fresh Workspace Store.
 
 Publish a Workspace snapshot into an existing GitHub repository with the GitHub publisher:
 

--- a/packages/workspace/src/hosted.ts
+++ b/packages/workspace/src/hosted.ts
@@ -44,7 +44,7 @@ export function installHostedWorkspaceRuntime(): void {
 export function configureHostedWorkspaceRuntime(options: HostedWorkspaceRuntimeOptions = {}): ResolvedWorkspaceModuleOptions {
   const root = resolve(process.cwd(), options.root || ".vitehub/workspaces")
   const store = options.store?.provider === "github"
-    ? resolveGitHubWorkspaceStore(options.store, options.env, { runtime: true })
+    ? resolveGitHubWorkspaceStore(options.store, options.env || {}, { runtime: true })
     : options.store?.provider === "vercel-blob"
       ? undefined
       : resolveCloudflareArtifactsStore(options.store, options.env)

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -6,6 +6,7 @@ import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
 import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
+import { getHostingProvider } from "@vite-hub/internal/hosting"
 
 import { createWorkspaceDefinitionLoader, loadDiscoveredWorkspaceDefinition, shouldBundleWorkspaceAssets } from "../../build/assets.ts"
 import { createWorkspaceRegistryContents, discoverViteWorkspaceDefinitions } from "../../build/discovery.ts"
@@ -623,14 +624,18 @@ function mergeNitroExternal(value: unknown, addition: string): unknown {
   return value
 }
 
+function configureCloudflareNitroRuntime(nitro: NitroConfig): void {
+  const rollupConfig = isRecord(nitro.rollupConfig) ? { ...nitro.rollupConfig } : {}
+  nitro.rollupConfig = { ...rollupConfig, external: mergeNitroExternal(rollupConfig.external, "cloudflare:workers") }
+}
+
 function configureCloudflareArtifactsNitroRuntime(nitro: NitroConfig): void {
   nitro.cloudflare ??= {}
   nitro.cloudflare.wrangler ??= {}
   const compatibilityFlags = nitro.cloudflare.wrangler.compatibility_flags || []
   if (!compatibilityFlags.includes("nodejs_compat")) compatibilityFlags.push("nodejs_compat")
   nitro.cloudflare.wrangler.compatibility_flags = compatibilityFlags
-  const rollupConfig = isRecord(nitro.rollupConfig) ? { ...nitro.rollupConfig } : {}
-  nitro.rollupConfig = { ...rollupConfig, external: mergeNitroExternal(rollupConfig.external, "cloudflare:workers") }
+  configureCloudflareNitroRuntime(nitro)
 }
 
 function moduleImportSpecifier(fromFile: string, targetFile: string): string {
@@ -677,7 +682,7 @@ function renderNitroWorkspacePlugin(
   config: false | ResolvedWorkspaceModuleOptions,
   registryImport: string,
   installHostedRuntime: boolean,
-  cloudflareArtifacts: boolean,
+  cloudflareRuntime: boolean,
   importBase = WORKSPACE_PACKAGE_NAME,
 ): string {
   const hostedRuntimeImport = `${importBase}/internal/runtime/hosted`
@@ -700,7 +705,7 @@ function renderNitroWorkspacePlugin(
         ...(installHostedRuntime ? [`import { installHostedVercelBlobWorkspaceRuntime } from '${hostedVercelBlobRuntimeImport}'`] : []),
         `import { ${config ? "setWorkspaceRuntimeConfig, " : ""}setWorkspaceRuntimeRegistry } from '${runtimeImport}'`,
       ]
-  if (cloudflareArtifacts) {
+  if (cloudflareRuntime) {
     runtimeImports.unshift(
       "import { env as vitehubEnv } from 'cloudflare:workers'",
       `import { setActiveCloudflareEnv } from '${importBase}/internal/runtime/state'`,
@@ -722,7 +727,7 @@ function renderNitroWorkspacePlugin(
     `import registry from ${JSON.stringify(registryImport)}`,
     "",
     "export default function vitehubWorkspacePlugin() {",
-    ...(cloudflareArtifacts ? ["  setActiveCloudflareEnv(vitehubEnv)"] : []),
+    ...(cloudflareRuntime ? ["  setActiveCloudflareEnv(vitehubEnv)"] : []),
     "  setWorkspaceRuntimeRegistry(registry)",
     ...runtimeSetup,
     "}",
@@ -735,7 +740,7 @@ async function writeNitroWorkspacePlugin(
   config: false | ResolvedWorkspaceModuleOptions,
   options: false | WorkspaceModuleOptions | undefined,
   definitions: DiscoveredWorkspaceDefinition[],
-  cloudflareArtifacts = false,
+  cloudflareRuntime = false,
   importBase = WORKSPACE_PACKAGE_NAME,
   definitionOverrides?: Map<string, ResolvedWorkspaceModuleOptions>,
 ): Promise<void> {
@@ -753,7 +758,7 @@ async function writeNitroWorkspacePlugin(
       runtimeConfig,
       moduleImportSpecifier(pluginFile, registryFile),
       definitions.length > 0 && !(runtimeConfig && isHostedWorkspaceStore(runtimeConfig.store)),
-      cloudflareArtifacts,
+      cloudflareRuntime,
       importBase,
     ),
     "utf8",
@@ -783,10 +788,12 @@ export async function createWorkspaceNitroConfig(options: WorkspaceNitroConfigOp
     definitionOverrides,
   })
   const runtimeConfig = shouldConfigureRuntime(workspaceOptions, normalized) ? normalized : false
-  await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, workspaceOptions, definitions, cloudflareArtifactsConfigs.length > 0, WORKSPACE_PACKAGE_NAME, definitionOverrides)
+  const cloudflareRuntime = cloudflareArtifactsConfigs.length > 0 || getHostingProvider(options.hosting) === "cloudflare"
+  await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, workspaceOptions, definitions, cloudflareRuntime, WORKSPACE_PACKAGE_NAME, definitionOverrides)
   const nitro = mergeNitroWorkspaceConfig(options.nitro)
   for (const config of cloudflareArtifactsConfigs) configureCloudflareArtifacts(nitro, config)
   if (cloudflareArtifactsConfigs.length > 0) configureCloudflareArtifactsNitroRuntime(nitro)
+  else if (cloudflareRuntime) configureCloudflareNitroRuntime(nitro)
   return nitro
 }
 
@@ -889,10 +896,12 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
           definitionOverrides,
         })
         const usesCloudflareArtifacts = artifacts.length > 0
-        await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, runtimeOptions, definitions, usesCloudflareArtifacts, importBase, definitionOverrides)
+        const usesCloudflareRuntime = usesCloudflareArtifacts || getHostingProvider(hosting) === "cloudflare"
+        await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, runtimeOptions, definitions, usesCloudflareRuntime, importBase, definitionOverrides)
         const nitro = mergeNitroWorkspaceConfig((config as ViteConfigWithWorkspaceNitro).nitro)
         for (const artifactConfig of artifacts) configureCloudflareArtifacts(nitro, artifactConfig)
         if (usesCloudflareArtifacts) configureCloudflareArtifactsNitroRuntime(nitro)
+        else if (usesCloudflareRuntime) configureCloudflareNitroRuntime(nitro)
         ;(config as ViteConfigWithWorkspaceNitro).nitro = nitro
         viteConfig.nitro = nitro
       }

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -679,10 +679,24 @@ function runtimeWorkspaceConfig(config: false | ResolvedWorkspaceModuleOptions, 
   const store = options.store
   if (!store || "readFile" in store || store.provider !== "github") return config
   const runtimeStore = { ...config.store }
-  for (const key of ["branch", "repo", "repository", "root", "token"] as const) {
+  for (const key of ["branch", "root", "token"] as const) {
     if (typeof store[key] === "function") {
       runtimeStore[key] = store[key]
     }
+    else if (typeof store[key] === "undefined") {
+      delete runtimeStore[key]
+    }
+  }
+  if (typeof store.repository === "function") {
+    runtimeStore.repository = store.repository
+  }
+  else if (typeof store.repo === "function") {
+    runtimeStore.repo = store.repo
+    delete runtimeStore.repository
+  }
+  else if (typeof store.repository === "undefined" && typeof store.repo === "undefined") {
+    delete runtimeStore.repository
+    delete runtimeStore.repo
   }
   return { ...config, store: runtimeStore }
 }
@@ -927,6 +941,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       const roots = resolveWorkspacePluginRoots(config.root, workspaceOptions)
       projectRoot = roots.projectRoot
       viteRoot = roots.viteRoot
+      const resolvedHosting = resolveWorkspaceHosting(hosting, (config as ResolvedConfig & { nitro?: NitroConfig }).nitro)
       if (config.command !== "build")
         process.env.VITEHUB_WORKSPACE_DEV = "true"
       else
@@ -934,7 +949,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       resolvedOptions = normalizeWorkspaceOptions(workspaceOptions, {
         dev: config.command !== "build",
         env: process.env,
-        hosting: hosting ?? process.env.VITEHUB_HOSTING,
+        hosting: resolvedHosting,
         rootDir: roots.projectRoot,
       })
       assetsRegistryFile = resolve(roots.projectRoot, ".vitehub/vite-runtime/workspace/assets/registry.mjs")

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -683,11 +683,12 @@ function runtimeWorkspaceConfig(
   const store = options.store
   if (!store || "readFile" in store || store.provider !== "github") return config
   const runtimeStore = { ...config.store }
+  const isAbsent = (value: unknown) => typeof value === "undefined" || (typeof value === "string" && value.trim().length === 0)
   for (const key of ["branch", "root", "token"] as const) {
     if (typeof store[key] === "function") {
       runtimeStore[key] = store[key]
     }
-    else if (typeof store[key] === "undefined") {
+    else if (isAbsent(store[key])) {
       delete runtimeStore[key]
     }
   }
@@ -698,7 +699,7 @@ function runtimeWorkspaceConfig(
     runtimeStore.repo = store.repo
     delete runtimeStore.repository
   }
-  else if (typeof store.repository === "undefined" && typeof store.repo === "undefined") {
+  else if (isAbsent(store.repository) && isAbsent(store.repo)) {
     delete runtimeStore.repository
     delete runtimeStore.repo
   }

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -379,7 +379,9 @@ function resolveWorkspaceHosting(
   env: Record<string, string | undefined> = process.env,
 ): string | undefined {
   const preset = isRecord(nitro) && typeof nitro.preset === "string" ? nitro.preset : undefined
-  return hosting ?? preset ?? env.NITRO_PRESET ?? env.SERVER_PRESET ?? env.VITEHUB_HOSTING
+  return [hosting, preset, env.NITRO_PRESET, env.SERVER_PRESET, env.VITEHUB_HOSTING]
+    .map(value => value?.trim())
+    .find(Boolean)
 }
 
 type WorkspacePluginRoots = {
@@ -643,10 +645,6 @@ function configureCloudflareNitroRuntime(nitro: NitroConfig): void {
   nitro.rollupConfig = { ...rollupConfig, external: mergeNitroExternal(rollupConfig.external, "cloudflare:workers") }
 }
 
-function configureCloudflareArtifactsNitroRuntime(nitro: NitroConfig): void {
-  configureCloudflareNitroRuntime(nitro)
-}
-
 function moduleImportSpecifier(fromFile: string, targetFile: string): string {
   const specifier = relative(dirname(fromFile), targetFile).replace(/\\/g, "/")
   return specifier.startsWith(".") ? specifier : `./${specifier}`
@@ -822,8 +820,7 @@ export async function createWorkspaceNitroConfig(options: WorkspaceNitroConfigOp
   await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, workspaceOptions, definitions, cloudflareRuntime, WORKSPACE_PACKAGE_NAME, definitionOverrides)
   const nitro = mergeNitroWorkspaceConfig(options.nitro)
   for (const config of cloudflareArtifactsConfigs) configureCloudflareArtifacts(nitro, config)
-  if (cloudflareArtifactsConfigs.length > 0) configureCloudflareArtifactsNitroRuntime(nitro)
-  else if (cloudflareRuntime) configureCloudflareNitroRuntime(nitro)
+  if (cloudflareRuntime) configureCloudflareNitroRuntime(nitro)
   return nitro
 }
 
@@ -835,10 +832,25 @@ interface WorkspaceCliContributingPlugin {
   vitehub?: { cli?: () => unknown | Promise<unknown> }
 }
 
-export type WorkspaceVitePlugin = Plugin & WorkspaceCliContributingPlugin & { api: WorkspaceVitePluginAPI }
+const setWorkspacePluginHosting: unique symbol = Symbol("vitehub.workspace.setHosting")
+
+type WorkspacePluginHosting = string | (() => string | undefined)
+
+export type WorkspaceVitePlugin = Plugin & WorkspaceCliContributingPlugin & {
+  [setWorkspacePluginHosting]?: (hosting: WorkspacePluginHosting) => void
+  api: WorkspaceVitePluginAPI
+}
+
+export function setWorkspaceVitePluginHosting(plugin: unknown, hosting: WorkspacePluginHosting): boolean {
+  if (!plugin || typeof plugin !== "object") return false
+  const setter = (plugin as WorkspaceVitePlugin)[setWorkspacePluginHosting]
+  if (!setter) return false
+  setter(hosting)
+  return true
+}
 
 interface InternalWorkspaceModuleOptions extends WorkspaceModuleOptions {
-  hosting?: string
+  hosting?: WorkspacePluginHosting
   importBase?: string
 }
 
@@ -851,7 +863,7 @@ function stripWorkspaceInternalOptions(options: false | WorkspaceModuleOptions |
 }
 
 export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlugin {
-  const hosting = (options as InternalWorkspaceModuleOptions | undefined)?.hosting
+  let hosting = (options as InternalWorkspaceModuleOptions | undefined)?.hosting
   const importBase = (options as InternalWorkspaceModuleOptions | undefined)?.importBase ?? WORKSPACE_PACKAGE_NAME
   const publicOptions = stripWorkspaceInternalOptions(options)
   let resolved: ResolvedConfig | undefined
@@ -890,6 +902,9 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
   return {
     name: "@vite-hub/workspace/vite",
     enforce: "pre",
+    [setWorkspacePluginHosting](value) {
+      hosting = value
+    },
     api: {
       getWorkspaces: () => manifest.workspaces,
     },
@@ -899,7 +914,10 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
         (config as UserConfig & { workspace?: false | WorkspaceModuleOptions }).workspace ?? publicOptions,
       )
       const roots = resolveWorkspacePluginRoots(config.root || process.cwd(), workspaceOptions)
-      const resolvedHosting = resolveWorkspaceHosting(hosting, (config as ViteConfigWithWorkspaceNitro).nitro)
+      const resolvedHosting = resolveWorkspaceHosting(
+        typeof hosting === "function" ? hosting() : hosting,
+        (config as ViteConfigWithWorkspaceNitro).nitro,
+      )
       const normalized = normalizeWorkspaceOptions(workspaceOptions, {
         dev: env?.command !== "build",
         env: process.env,
@@ -931,8 +949,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
         await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, runtimeOptions, definitions, usesCloudflareRuntime, importBase, definitionOverrides)
         const nitro = mergeNitroWorkspaceConfig((config as ViteConfigWithWorkspaceNitro).nitro)
         for (const artifactConfig of artifacts) configureCloudflareArtifacts(nitro, artifactConfig)
-        if (usesCloudflareArtifacts) configureCloudflareArtifactsNitroRuntime(nitro)
-        else if (usesCloudflareRuntime) configureCloudflareNitroRuntime(nitro)
+        if (usesCloudflareRuntime) configureCloudflareNitroRuntime(nitro)
         ;(config as ViteConfigWithWorkspaceNitro).nitro = nitro
         viteConfig.nitro = nitro
       }
@@ -946,7 +963,10 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       const roots = resolveWorkspacePluginRoots(config.root, workspaceOptions)
       projectRoot = roots.projectRoot
       viteRoot = roots.viteRoot
-      const resolvedHosting = resolveWorkspaceHosting(hosting, (config as ResolvedConfig & { nitro?: NitroConfig }).nitro)
+      const resolvedHosting = resolveWorkspaceHosting(
+        typeof hosting === "function" ? hosting() : hosting,
+        (config as ResolvedConfig & { nitro?: NitroConfig }).nitro,
+      )
       if (config.command !== "build")
         process.env.VITEHUB_WORKSPACE_DEV = "true"
       else

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -373,6 +373,15 @@ type ViteConfigWithWorkspaceNitro = Omit<UserConfig, "plugins"> & {
   nitro?: NitroConfig
 }
 
+function resolveWorkspaceHosting(
+  hosting: string | undefined,
+  nitro: unknown,
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  const preset = isRecord(nitro) && typeof nitro.preset === "string" ? nitro.preset : undefined
+  return hosting ?? preset ?? env.NITRO_PRESET ?? env.SERVER_PRESET ?? env.VITEHUB_HOSTING
+}
+
 type WorkspacePluginRoots = {
   projectRoot: string
   viteRoot: string
@@ -768,10 +777,12 @@ async function writeNitroWorkspacePlugin(
 export async function createWorkspaceNitroConfig(options: WorkspaceNitroConfigOptions = {}): Promise<NitroConfig | null> {
   const workspaceOptions = stripWorkspaceInternalOptions(options.workspace)
   const roots = resolveWorkspacePluginRoots(options.viteRoot || process.cwd(), workspaceOptions)
+  const env = options.env || process.env
+  const hosting = resolveWorkspaceHosting(options.hosting, options.nitro, env)
   const normalized = normalizeWorkspaceOptions(workspaceOptions, {
     dev: options.command !== "build",
-    env: options.env || process.env,
-    hosting: options.hosting ?? process.env.VITEHUB_HOSTING,
+    env,
+    hosting,
     rootDir: roots.projectRoot,
   })
   if (!normalized) return null
@@ -784,11 +795,11 @@ export async function createWorkspaceNitroConfig(options: WorkspaceNitroConfigOp
     aliases: options.aliases,
     artifactsOnly: true,
     env: options.env,
-    hosting: options.hosting,
+    hosting,
     definitionOverrides,
   })
   const runtimeConfig = shouldConfigureRuntime(workspaceOptions, normalized) ? normalized : false
-  const cloudflareRuntime = cloudflareArtifactsConfigs.length > 0 || getHostingProvider(options.hosting) === "cloudflare"
+  const cloudflareRuntime = cloudflareArtifactsConfigs.length > 0 || getHostingProvider(hosting) === "cloudflare"
   await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, workspaceOptions, definitions, cloudflareRuntime, WORKSPACE_PACKAGE_NAME, definitionOverrides)
   const nitro = mergeNitroWorkspaceConfig(options.nitro)
   for (const config of cloudflareArtifactsConfigs) configureCloudflareArtifacts(nitro, config)
@@ -869,13 +880,14 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
         (config as UserConfig & { workspace?: false | WorkspaceModuleOptions }).workspace ?? publicOptions,
       )
       const roots = resolveWorkspacePluginRoots(config.root || process.cwd(), workspaceOptions)
+      const resolvedHosting = resolveWorkspaceHosting(hosting, (config as ViteConfigWithWorkspaceNitro).nitro)
       const normalized = normalizeWorkspaceOptions(workspaceOptions, {
         dev: env?.command !== "build",
         env: process.env,
-        hosting: hosting ?? process.env.VITEHUB_HOSTING,
+        hosting: resolvedHosting,
         rootDir: roots.projectRoot,
       })
-      const runtimeOptions = hosting && normalized && normalized.store.provider !== "local"
+      const runtimeOptions = resolvedHosting && normalized && normalized.store.provider !== "local"
         ? { ...(workspaceOptions || {}), store: workspaceOptions && workspaceOptions.store ? workspaceOptions.store : normalized.store }
         : workspaceOptions
       const viteConfig: ViteConfigWithWorkspaceNitro = {
@@ -892,11 +904,11 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
         const artifacts = await resolveCloudflareArtifactsConfigs(normalized, definitions, roots.projectRoot, {
           aliases: config.resolve?.alias ? workspaceDefinitionLoaderAliases(config.resolve.alias) : undefined,
           artifactsOnly: true,
-          hosting,
+          hosting: resolvedHosting,
           definitionOverrides,
         })
         const usesCloudflareArtifacts = artifacts.length > 0
-        const usesCloudflareRuntime = usesCloudflareArtifacts || getHostingProvider(hosting) === "cloudflare"
+        const usesCloudflareRuntime = usesCloudflareArtifacts || getHostingProvider(resolvedHosting) === "cloudflare"
         await writeNitroWorkspacePlugin(roots.projectRoot, runtimeConfig, runtimeOptions, definitions, usesCloudflareRuntime, importBase, definitionOverrides)
         const nitro = mergeNitroWorkspaceConfig((config as ViteConfigWithWorkspaceNitro).nitro)
         for (const artifactConfig of artifacts) configureCloudflareArtifacts(nitro, artifactConfig)

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -634,16 +634,16 @@ function mergeNitroExternal(value: unknown, addition: string): unknown {
 }
 
 function configureCloudflareNitroRuntime(nitro: NitroConfig): void {
-  const rollupConfig = isRecord(nitro.rollupConfig) ? { ...nitro.rollupConfig } : {}
-  nitro.rollupConfig = { ...rollupConfig, external: mergeNitroExternal(rollupConfig.external, "cloudflare:workers") }
-}
-
-function configureCloudflareArtifactsNitroRuntime(nitro: NitroConfig): void {
   nitro.cloudflare ??= {}
   nitro.cloudflare.wrangler ??= {}
   const compatibilityFlags = nitro.cloudflare.wrangler.compatibility_flags || []
   if (!compatibilityFlags.includes("nodejs_compat")) compatibilityFlags.push("nodejs_compat")
   nitro.cloudflare.wrangler.compatibility_flags = compatibilityFlags
+  const rollupConfig = isRecord(nitro.rollupConfig) ? { ...nitro.rollupConfig } : {}
+  nitro.rollupConfig = { ...rollupConfig, external: mergeNitroExternal(rollupConfig.external, "cloudflare:workers") }
+}
+
+function configureCloudflareArtifactsNitroRuntime(nitro: NitroConfig): void {
   configureCloudflareNitroRuntime(nitro)
 }
 
@@ -674,8 +674,12 @@ function renderRuntimeValue(value: unknown, depth = 0): string {
   return JSON.stringify(value)
 }
 
-function runtimeWorkspaceConfig(config: false | ResolvedWorkspaceModuleOptions, options: false | WorkspaceModuleOptions | undefined): false | ResolvedWorkspaceModuleOptions {
-  if (!config || config.store.provider !== "github" || !options) return config
+function runtimeWorkspaceConfig(
+  config: false | ResolvedWorkspaceModuleOptions,
+  options: false | WorkspaceModuleOptions | undefined,
+  cloudflareRuntime: boolean,
+): false | ResolvedWorkspaceModuleOptions {
+  if (!cloudflareRuntime || !config || config.store.provider !== "github" || !options) return config
   const store = options.store
   if (!store || "readFile" in store || store.provider !== "github") return config
   const runtimeStore = { ...config.store }
@@ -769,7 +773,7 @@ async function writeNitroWorkspacePlugin(
 ): Promise<void> {
   const pluginFile = resolve(root, generatedNitroWorkspacePlugin)
   const registryFile = resolve(root, generatedNitroWorkspaceRegistry)
-  const runtimeConfig = runtimeWorkspaceConfig(config, options)
+  const runtimeConfig = runtimeWorkspaceConfig(config, options, cloudflareRuntime)
   await Promise.all([
     mkdir(dirname(pluginFile), { recursive: true }),
     mkdir(dirname(registryFile), { recursive: true }),

--- a/packages/workspace/src/nuxt.ts
+++ b/packages/workspace/src/nuxt.ts
@@ -1,4 +1,5 @@
 import { createWorkspaceNitroConfig, hubWorkspace } from "./vite.ts"
+import { setWorkspaceVitePluginHosting } from "./hosts/vite/plugin.ts"
 
 import type { WorkspaceModuleOptions } from "./core/types.ts"
 
@@ -43,13 +44,21 @@ export default function viteHubWorkspaceNuxtModule(options: WorkspaceNuxtModuleO
 
   nuxt.options.vite ??= {}
   const workspaceOptions = resolveWorkspaceOptions(options, nuxt.options.vite.workspace)
+  let resolvedNitroHosting: string | undefined
   const plugins = Array.isArray(nuxt.options.vite.plugins) ? nuxt.options.vite.plugins : []
   if (!plugins.some(isWorkspaceVitePlugin)) {
-    plugins.push(hubWorkspace(workspaceOptions === false ? undefined : workspaceOptions))
+    plugins.push(hubWorkspace({
+      ...(workspaceOptions || {}),
+      hosting: () => resolvedNitroHosting,
+    } as never))
+  }
+  for (const plugin of plugins) {
+    if (isWorkspaceVitePlugin(plugin)) setWorkspaceVitePluginHosting(plugin, () => resolvedNitroHosting)
   }
   nuxt.options.vite.plugins = plugins
 
   nuxt.hook?.("nitro:config", async (nitroConfig) => {
+    resolvedNitroHosting = typeof nitroConfig.preset === "string" ? nitroConfig.preset : undefined
     const rootDir = nuxt.options.rootDir || process.cwd()
     const nitro = await createWorkspaceNitroConfig({
       aliases: nuxt.options.alias,

--- a/packages/workspace/src/providers/github/shared.ts
+++ b/packages/workspace/src/providers/github/shared.ts
@@ -73,17 +73,22 @@ export function processEnv(
 }
 
 export function resolveGitHubOption(value: GitHubWorkspaceOption | undefined): string | undefined {
-  return typeof value === "function" ? value() : value;
+  const resolved = typeof value === "function" ? value() : value;
+  return typeof resolved === "string" ? resolved.trim() || undefined : resolved;
 }
 
 function isMaskedGitHubTokenOption(value: string): boolean {
   return value === "********" || value === "<redacted>" || value === "[redacted]";
 }
 
-function activeCloudflareEnv(...keys: string[]): string | undefined {
+function activeCloudflareEnv(
+  keys: string[],
+  accept: (value: string) => boolean = () => true,
+): string | undefined {
   return keys
     .map((key) => getActiveCloudflareBinding<unknown>(key))
-    .find((value): value is string => typeof value === "string" && value.length > 0);
+    .map((value) => typeof value === "string" ? value.trim() : undefined)
+    .find((value): value is string => typeof value === "string" && value.length > 0 && accept(value));
 }
 
 export function requireGitHubOption(
@@ -168,11 +173,11 @@ export function resolveGitHubRepositoryOption(
   return (
     resolveGitHubOption(options.repository) ||
     resolveGitHubOption(options.repo) ||
-    activeCloudflareEnv(
+    activeCloudflareEnv([
       "WORKSPACE_GITHUB_REPOSITORY",
       "VITEHUB_WORKSPACE_GITHUB_REPOSITORY",
       "GITHUB_REPOSITORY",
-    ) ||
+    ]) ||
     processEnv(
       env,
       "WORKSPACE_GITHUB_REPOSITORY",
@@ -188,11 +193,11 @@ export function resolveGitHubBranchOption(
 ): string {
   return (
     resolveGitHubOption(options.branch) ||
-    activeCloudflareEnv(
+    activeCloudflareEnv([
       "WORKSPACE_GITHUB_BRANCH",
       "VITEHUB_WORKSPACE_GITHUB_BRANCH",
       "GITHUB_BRANCH",
-    ) ||
+    ]) ||
     processEnv(
       env,
       "WORKSPACE_GITHUB_BRANCH",
@@ -210,7 +215,7 @@ export function resolveGitHubRootOption(
 ): string {
   return resolveGitHubWorkspaceRoot(
     resolveGitHubOption(options.root) ||
-      activeCloudflareEnv("WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT") ||
+      activeCloudflareEnv(["WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT"]) ||
       processEnv(env, "WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT") ||
       ".vitehub/workspaces/<workspace>",
     workspaceName,
@@ -223,13 +228,13 @@ export function resolveGitHubTokenOption(
 ): string | undefined {
   const token = resolveGitHubOption(options.token);
   if (token && !isMaskedGitHubTokenOption(token)) return token;
-  const bindingToken = activeCloudflareEnv(
+  const bindingToken = activeCloudflareEnv([
     "WORKSPACE_GITHUB_TOKEN",
     "VITEHUB_WORKSPACE_GITHUB_TOKEN",
     "GITHUB_TOKEN",
     "GH_TOKEN",
-  );
-  if (bindingToken && !isMaskedGitHubTokenOption(bindingToken)) return bindingToken;
+  ], value => !isMaskedGitHubTokenOption(value));
+  if (bindingToken) return bindingToken;
   return (
     processEnv(env, "WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN")
   );

--- a/packages/workspace/src/providers/github/shared.ts
+++ b/packages/workspace/src/providers/github/shared.ts
@@ -80,6 +80,12 @@ function isMaskedGitHubTokenOption(value: string): boolean {
   return value === "********" || value === "<redacted>" || value === "[redacted]";
 }
 
+function activeCloudflareEnv(...keys: string[]): string | undefined {
+  return keys
+    .map((key) => getActiveCloudflareBinding<unknown>(key))
+    .find((value): value is string => typeof value === "string" && value.length > 0);
+}
+
 export function requireGitHubOption(
   kind: "publisher" | "store",
   label: string,
@@ -162,6 +168,11 @@ export function resolveGitHubRepositoryOption(
   return (
     resolveGitHubOption(options.repository) ||
     resolveGitHubOption(options.repo) ||
+    activeCloudflareEnv(
+      "WORKSPACE_GITHUB_REPOSITORY",
+      "VITEHUB_WORKSPACE_GITHUB_REPOSITORY",
+      "GITHUB_REPOSITORY",
+    ) ||
     processEnv(
       env,
       "WORKSPACE_GITHUB_REPOSITORY",
@@ -177,6 +188,11 @@ export function resolveGitHubBranchOption(
 ): string {
   return (
     resolveGitHubOption(options.branch) ||
+    activeCloudflareEnv(
+      "WORKSPACE_GITHUB_BRANCH",
+      "VITEHUB_WORKSPACE_GITHUB_BRANCH",
+      "GITHUB_BRANCH",
+    ) ||
     processEnv(
       env,
       "WORKSPACE_GITHUB_BRANCH",
@@ -194,6 +210,7 @@ export function resolveGitHubRootOption(
 ): string {
   return resolveGitHubWorkspaceRoot(
     resolveGitHubOption(options.root) ||
+      activeCloudflareEnv("WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT") ||
       processEnv(env, "WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT") ||
       ".vitehub/workspaces/<workspace>",
     workspaceName,
@@ -206,7 +223,12 @@ export function resolveGitHubTokenOption(
 ): string | undefined {
   const token = resolveGitHubOption(options.token);
   if (token && !isMaskedGitHubTokenOption(token)) return token;
-  const bindingToken = getActiveCloudflareBinding<string>("GITHUB_TOKEN");
+  const bindingToken = activeCloudflareEnv(
+    "WORKSPACE_GITHUB_TOKEN",
+    "VITEHUB_WORKSPACE_GITHUB_TOKEN",
+    "GITHUB_TOKEN",
+    "GH_TOKEN",
+  );
   if (bindingToken && !isMaskedGitHubTokenOption(bindingToken)) return bindingToken;
   return (
     processEnv(env, "WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN")

--- a/packages/workspace/src/storage/provider.ts
+++ b/packages/workspace/src/storage/provider.ts
@@ -82,29 +82,22 @@ export function resolveGitHubWorkspaceStore(
   env: Record<string, string | undefined> = process.env,
   input: Pick<WorkspaceResolutionInput, "runtime"> = {},
 ): GitHubWorkspaceStoreOptions {
-  if (input.runtime) {
-    return {
-      branch: gitHubWorkspaceOption(config.branch)
-        ?? readEnv(env, "WORKSPACE_GITHUB_BRANCH", "VITEHUB_WORKSPACE_GITHUB_BRANCH", "GITHUB_BRANCH"),
-      provider: "github",
-      repository: gitHubWorkspaceOption(config.repository)
-        ?? gitHubWorkspaceOption(config.repo)
-        ?? readEnv(env, "WORKSPACE_GITHUB_REPOSITORY", "VITEHUB_WORKSPACE_GITHUB_REPOSITORY", "GITHUB_REPOSITORY"),
-      root: gitHubWorkspaceOption(config.root)
-        ?? readEnv(env, "WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT"),
-      token: gitHubWorkspaceOption(config.token)
-        ?? readEnv(env, "WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN")
-        ?? MASKED_WORKSPACE_RUNTIME_VALUE,
-    }
-  }
+  const branch = gitHubWorkspaceOption(config.branch)
+    ?? readEnv(env, "WORKSPACE_GITHUB_BRANCH", "VITEHUB_WORKSPACE_GITHUB_BRANCH", "GITHUB_BRANCH")
+  const root = gitHubWorkspaceOption(config.root)
+    ?? readEnv(env, "WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT")
   return {
-    branch: gitHubWorkspaceOption(config.branch) ?? readEnv(env, "WORKSPACE_GITHUB_BRANCH", "VITEHUB_WORKSPACE_GITHUB_BRANCH", "GITHUB_BRANCH") ?? "main",
+    branch: branch ?? (input.runtime ? undefined : "main"),
     provider: "github",
     repository: gitHubWorkspaceOption(config.repository)
       ?? gitHubWorkspaceOption(config.repo)
       ?? readEnv(env, "WORKSPACE_GITHUB_REPOSITORY", "VITEHUB_WORKSPACE_GITHUB_REPOSITORY", "GITHUB_REPOSITORY"),
-    root: gitHubWorkspaceOption(config.root) ?? readEnv(env, "WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT") ?? ".vitehub/workspaces/<workspace>",
-    token: MASKED_WORKSPACE_RUNTIME_VALUE,
+    root: root ?? (input.runtime ? undefined : ".vitehub/workspaces/<workspace>"),
+    token: input.runtime
+      ? gitHubWorkspaceOption(config.token)
+        ?? readEnv(env, "WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN")
+        ?? MASKED_WORKSPACE_RUNTIME_VALUE
+      : MASKED_WORKSPACE_RUNTIME_VALUE,
   }
 }
 

--- a/packages/workspace/src/storage/provider.ts
+++ b/packages/workspace/src/storage/provider.ts
@@ -82,6 +82,21 @@ export function resolveGitHubWorkspaceStore(
   env: Record<string, string | undefined> = process.env,
   input: Pick<WorkspaceResolutionInput, "runtime"> = {},
 ): GitHubWorkspaceStoreOptions {
+  if (input.runtime) {
+    return {
+      branch: gitHubWorkspaceOption(config.branch)
+        ?? readEnv(env, "WORKSPACE_GITHUB_BRANCH", "VITEHUB_WORKSPACE_GITHUB_BRANCH", "GITHUB_BRANCH"),
+      provider: "github",
+      repository: gitHubWorkspaceOption(config.repository)
+        ?? gitHubWorkspaceOption(config.repo)
+        ?? readEnv(env, "WORKSPACE_GITHUB_REPOSITORY", "VITEHUB_WORKSPACE_GITHUB_REPOSITORY", "GITHUB_REPOSITORY"),
+      root: gitHubWorkspaceOption(config.root)
+        ?? readEnv(env, "WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT"),
+      token: gitHubWorkspaceOption(config.token)
+        ?? readEnv(env, "WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN")
+        ?? MASKED_WORKSPACE_RUNTIME_VALUE,
+    }
+  }
   return {
     branch: gitHubWorkspaceOption(config.branch) ?? readEnv(env, "WORKSPACE_GITHUB_BRANCH", "VITEHUB_WORKSPACE_GITHUB_BRANCH", "GITHUB_BRANCH") ?? "main",
     provider: "github",
@@ -89,7 +104,7 @@ export function resolveGitHubWorkspaceStore(
       ?? gitHubWorkspaceOption(config.repo)
       ?? readEnv(env, "WORKSPACE_GITHUB_REPOSITORY", "VITEHUB_WORKSPACE_GITHUB_REPOSITORY", "GITHUB_REPOSITORY"),
     root: gitHubWorkspaceOption(config.root) ?? readEnv(env, "WORKSPACE_GITHUB_ROOT", "VITEHUB_WORKSPACE_GITHUB_ROOT") ?? ".vitehub/workspaces/<workspace>",
-    token: input.runtime ? gitHubWorkspaceOption(config.token) ?? MASKED_WORKSPACE_RUNTIME_VALUE : MASKED_WORKSPACE_RUNTIME_VALUE,
+    token: MASKED_WORKSPACE_RUNTIME_VALUE,
   }
 }
 

--- a/packages/workspace/src/vite.ts
+++ b/packages/workspace/src/vite.ts
@@ -1,1 +1,7 @@
-export * from "./hosts/vite/plugin.ts"
+export { createWorkspaceNitroConfig, hubWorkspace } from "./hosts/vite/plugin.ts"
+export type {
+  NitroConfig,
+  WorkspaceNitroConfigOptions,
+  WorkspaceVitePlugin,
+  WorkspaceVitePluginAPI,
+} from "./hosts/vite/plugin.ts"

--- a/packages/workspace/test/config.test.ts
+++ b/packages/workspace/test/config.test.ts
@@ -258,6 +258,23 @@ describe("workspace config", () => {
     })
   })
 
+  it("defers absent GitHub runtime options until bindings are active", () => {
+    const store = normalizeWorkspaceStoreOptions({
+      provider: "github",
+    }, {
+      env: {},
+      runtime: true,
+    })
+
+    expect(store).toEqual({
+      branch: undefined,
+      provider: "github",
+      repository: undefined,
+      root: undefined,
+      token: "********",
+    })
+  })
+
   it("resolves GitHub store options from the environment", () => {
     const config = normalizeWorkspaceOptions({
       store: {

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -198,6 +198,36 @@ describe("GitHub workspace store", () => {
     expect(resolveGitHubTokenOption(options, {})).toBe("binding-token");
   });
 
+  it("falls through blank active Cloudflare binding aliases", async () => {
+    setActiveCloudflareEnv({
+      WORKSPACE_GITHUB_BRANCH: " ",
+      WORKSPACE_GITHUB_REPOSITORY: " ",
+      WORKSPACE_GITHUB_ROOT: " ",
+      WORKSPACE_GITHUB_TOKEN: " ",
+      VITEHUB_WORKSPACE_GITHUB_BRANCH: " release ",
+      VITEHUB_WORKSPACE_GITHUB_REPOSITORY: " onmax/repo ",
+      VITEHUB_WORKSPACE_GITHUB_ROOT: " state/<workspace> ",
+      VITEHUB_WORKSPACE_GITHUB_TOKEN: " binding-token ",
+    });
+    const {
+      resolveGitHubBranchOption,
+      resolveGitHubRepositoryOption,
+      resolveGitHubRootOption,
+      resolveGitHubTokenOption,
+    } = await import("../src/providers/github/shared.ts");
+    const options = {
+      branch: () => undefined,
+      repository: () => undefined,
+      root: () => undefined,
+      token: () => undefined,
+    };
+
+    expect(resolveGitHubRepositoryOption(options, {})).toBe("onmax/repo");
+    expect(resolveGitHubBranchOption(options, {})).toBe("release");
+    expect(resolveGitHubRootOption(options, "docs", {})).toBe("state/docs");
+    expect(resolveGitHubTokenOption(options, {})).toBe("binding-token");
+  });
+
   it.each(["********", "<redacted>", "[redacted]"])(
     "falls back to env credentials for masked token %s",
     async (maskedToken) => {
@@ -240,6 +270,27 @@ describe("GitHub workspace store", () => {
     },
   );
 
+  it("falls through masked active binding aliases", async () => {
+    process.env.WORKSPACE_GITHUB_TOKEN = "env-token";
+    setActiveCloudflareEnv({
+      GITHUB_TOKEN: "binding-token",
+      WORKSPACE_GITHUB_TOKEN: "********",
+    });
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        provider: "github",
+        repository: "onmax/repo",
+        root: ".vitehub/workspaces/<workspace>",
+      },
+      "docs",
+    );
+
+    await expect(store.list("", { recursive: true })).resolves.toEqual([]);
+
+    expect(requests[0]?.headers.get("authorization")).toBe("Bearer binding-token");
+  });
+
   it("uses lazy options preserved by runtime GitHub store normalization", async () => {
     const { normalizeWorkspaceStoreOptions } = await import("../src/config.ts");
     const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
@@ -260,7 +311,7 @@ describe("GitHub workspace store", () => {
     expect(requests[0]?.headers.get("authorization")).toBe("Bearer callback-token");
   });
 
-  it("falls back from empty lazy options to active Cloudflare bindings", async () => {
+  it("falls back from blank lazy options to active Cloudflare bindings", async () => {
     seedRemote("state/docs/data/existing.json", '{"ok":true}\n');
     setActiveCloudflareEnv({
       WORKSPACE_GITHUB_BRANCH: "main",
@@ -271,11 +322,11 @@ describe("GitHub workspace store", () => {
     const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
     const store = createGitHubWorkspaceStore(
       {
-        branch: () => undefined,
+        branch: () => " ",
         provider: "github",
-        repository: () => undefined,
-        root: () => undefined,
-        token: () => undefined,
+        repository: () => " ",
+        root: () => " ",
+        token: () => " ",
       },
       "docs",
     );

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -152,6 +152,52 @@ afterEach(() => {
 });
 
 describe("GitHub workspace store", () => {
+  it.each([
+    ["Workspace", {
+      WORKSPACE_GITHUB_BRANCH: "release",
+      WORKSPACE_GITHUB_REPOSITORY: "onmax/repo",
+      WORKSPACE_GITHUB_ROOT: "state/<workspace>",
+      WORKSPACE_GITHUB_TOKEN: "binding-token",
+    }],
+    ["ViteHub Workspace", {
+      VITEHUB_WORKSPACE_GITHUB_BRANCH: "release",
+      VITEHUB_WORKSPACE_GITHUB_REPOSITORY: "onmax/repo",
+      VITEHUB_WORKSPACE_GITHUB_ROOT: "state/<workspace>",
+      VITEHUB_WORKSPACE_GITHUB_TOKEN: "binding-token",
+    }],
+    ["GitHub with GITHUB_TOKEN", {
+      GITHUB_BRANCH: "release",
+      GITHUB_REPOSITORY: "onmax/repo",
+      VITEHUB_WORKSPACE_GITHUB_ROOT: "state/<workspace>",
+      GITHUB_TOKEN: "binding-token",
+    }],
+    ["GitHub with GH_TOKEN", {
+      GITHUB_BRANCH: "release",
+      GITHUB_REPOSITORY: "onmax/repo",
+      WORKSPACE_GITHUB_ROOT: "state/<workspace>",
+      GH_TOKEN: "binding-token",
+    }],
+  ] as const)("resolves %s active Cloudflare binding aliases", async (_label, bindings) => {
+    setActiveCloudflareEnv(bindings);
+    const {
+      resolveGitHubBranchOption,
+      resolveGitHubRepositoryOption,
+      resolveGitHubRootOption,
+      resolveGitHubTokenOption,
+    } = await import("../src/providers/github/shared.ts");
+    const options = {
+      branch: () => undefined,
+      repository: () => undefined,
+      root: () => undefined,
+      token: () => undefined,
+    };
+
+    expect(resolveGitHubRepositoryOption(options, {})).toBe("onmax/repo");
+    expect(resolveGitHubBranchOption(options, {})).toBe("release");
+    expect(resolveGitHubRootOption(options, "docs", {})).toBe("state/docs");
+    expect(resolveGitHubTokenOption(options, {})).toBe("binding-token");
+  });
+
   it.each(["********", "<redacted>", "[redacted]"])(
     "falls back to env credentials for masked token %s",
     async (maskedToken) => {
@@ -212,6 +258,32 @@ describe("GitHub workspace store", () => {
     await expect(store.list("", { recursive: true })).resolves.toEqual([]);
 
     expect(requests[0]?.headers.get("authorization")).toBe("Bearer callback-token");
+  });
+
+  it("falls back from empty lazy options to active Cloudflare bindings", async () => {
+    seedRemote("state/docs/data/existing.json", '{"ok":true}\n');
+    setActiveCloudflareEnv({
+      WORKSPACE_GITHUB_BRANCH: "main",
+      WORKSPACE_GITHUB_REPOSITORY: "onmax/repo",
+      WORKSPACE_GITHUB_ROOT: "state/<workspace>",
+      WORKSPACE_GITHUB_TOKEN: "binding-token",
+    });
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        branch: () => undefined,
+        provider: "github",
+        repository: () => undefined,
+        root: () => undefined,
+        token: () => undefined,
+      },
+      "docs",
+    );
+
+    await expect(store.readFile("data/existing.json")).resolves.toMatchObject({
+      content: textBytes('{"ok":true}\n'),
+    });
+    expect(requests[0]?.headers.get("authorization")).toBe("Bearer binding-token");
   });
 
   it("reads, lists, stats, writes, snapshots, and persists metadata through GitHub", async () => {

--- a/packages/workspace/test/nuxt.test.ts
+++ b/packages/workspace/test/nuxt.test.ts
@@ -28,13 +28,13 @@ async function createNuxtHook(store: WorkspaceModuleOptions["store"] = { provide
       dev: false,
       rootDir: root,
       srcDir: root,
-      vite: {},
+      vite: { plugins: [] as unknown[] },
     },
   }
 
   workspaceNuxt({ store }, nuxt)
   expect(nitroConfigHook).toBeDefined()
-  return { nitroConfigHook: nitroConfigHook!, root }
+  return { nitroConfigHook: nitroConfigHook!, root, vitePlugin: nuxt.options.vite.plugins?.[0] }
 }
 
 describe("Workspace Nuxt module", () => {
@@ -55,6 +55,50 @@ describe("Workspace Nuxt module", () => {
       { from: "@vite-hub/workspace/collections/client", name: "useWorkspaceCollection" },
       { from: "@vite-hub/workspace/collections/client", name: "useWorkspaceCollectionItem" },
     ])
+  })
+
+  it("preserves Nitro preset hosting in the registered Vite plugin", async () => {
+    const { nitroConfigHook, root, vitePlugin } = await createNuxtHook({
+      provider: "github",
+      repository: "onmax/repo",
+    })
+    const nitroConfig: Record<string, unknown> = { preset: "cloudflare-module" }
+
+    await nitroConfigHook(nitroConfig)
+    const config = (vitePlugin as { config: (config: { root: string }, env: { command: "build", mode: string }) => Promise<unknown> }).config
+    await config({ root }, { command: "build", mode: "production" })
+
+    const plugin = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
+    expect(plugin).toContain("setActiveCloudflareEnv(vitehubEnv)")
+  })
+
+  it("preserves Nitro preset hosting in a pre-registered Workspace Vite plugin", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-nuxt-existing-plugin-"))
+    tempDirs.push(root)
+    let nitroConfigHook: ((nitroConfig: Record<string, unknown>) => void | Promise<void>) | undefined
+    const vitePlugin = (await import("../src/vite.ts")).hubWorkspace({
+      store: { provider: "github", repository: "onmax/repo" },
+    })
+    const nuxt = {
+      hook(name: "nitro:config", handler: (nitroConfig: Record<string, unknown>) => void | Promise<void>) {
+        if (name === "nitro:config") nitroConfigHook = handler
+      },
+      options: {
+        dev: false,
+        rootDir: root,
+        srcDir: root,
+        vite: { plugins: [vitePlugin] },
+      },
+    }
+    workspaceNuxt({}, nuxt)
+
+    await nitroConfigHook!({ preset: "cloudflare-module" })
+    const config = vitePlugin.config as (config: { root: string }, env: { command: "build", mode: string }) => Promise<unknown>
+    await config({ root }, { command: "build", mode: "production" })
+
+    const plugin = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
+    expect(plugin).toContain("setActiveCloudflareEnv(vitehubEnv)")
+    expect(nuxt.options.vite.plugins).toEqual([vitePlugin])
   })
 
   it("registers the default Cloudflare Artifacts binding and runtime in generated Nitro config", async () => {

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -779,6 +779,27 @@ describe("hubWorkspace", () => {
     expect(pluginSource).toContain("setActiveCloudflareEnv(vitehubEnv)")
   })
 
+  it("falls through blank Cloudflare hosting signals", async () => {
+    const root = await createViteRoot()
+    vi.stubEnv("NITRO_PRESET", " ")
+    vi.stubEnv("SERVER_PRESET", "cloudflare-module")
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace()
+    const config = plugin.config as (config: {
+      root: string
+      workspace: { store: { provider: "github", repository: string } }
+    }, env: { command: "build", mode: string }) => Promise<{ nitro?: { rollupConfig?: { external?: unknown } } }>
+
+    const result = await config({
+      root,
+      workspace: { store: { provider: "github", repository: "onmax/repo" } },
+    }, { command: "build", mode: "production" })
+
+    expect(result.nitro?.rollupConfig).toMatchObject({ external: ["cloudflare:workers"] })
+    const pluginSource = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
+    expect(pluginSource).toContain("setActiveCloudflareEnv(vitehubEnv)")
+  })
+
   it("does not serialize absent or blank GitHub fallbacks over Cloudflare runtime bindings", async () => {
     const root = await createViteRoot()
     vi.stubEnv("GITHUB_REPOSITORY", "vite-hub/build-repository")

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -778,6 +778,28 @@ describe("hubWorkspace", () => {
     expect(pluginSource).toContain("setActiveCloudflareEnv(vitehubEnv)")
   })
 
+  it("does not serialize build-time GitHub fallbacks over Cloudflare runtime bindings", async () => {
+    const root = await createViteRoot()
+    vi.stubEnv("GITHUB_REPOSITORY", "vite-hub/build-repository")
+    vi.stubEnv("NITRO_PRESET", "cloudflare-module")
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace()
+    const config = plugin.config as (config: {
+      root: string
+      workspace: { store: { provider: "github" } }
+    }, env: { command: "build", mode: string }) => Promise<unknown>
+
+    await config({
+      root,
+      workspace: { store: { provider: "github" } },
+    }, { command: "build", mode: "production" })
+
+    const pluginSource = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
+    expect(pluginSource).toContain('"provider": "github"')
+    expect(pluginSource).not.toContain("vite-hub/build-repository")
+    expect(pluginSource).not.toContain('"repository"')
+  })
+
   it("emits Nitro hosted runtime setup for explicit Vercel Blob workspace stores", async () => {
     const root = await createViteRoot()
     const { hubWorkspace } = await import("../src/vite.ts")

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -738,10 +738,13 @@ describe("hubWorkspace", () => {
     await expect(config(userConfig, { command: "build", mode: "production" })).resolves.toMatchObject({
       nitro: {
         plugins: [".vitehub/nitro/workspace/plugin.ts"],
+        rollupConfig: { external: ["cloudflare:workers"] },
       },
     })
 
     const pluginSource = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
+    expect(pluginSource).toContain("import { env as vitehubEnv } from 'cloudflare:workers'")
+    expect(pluginSource).toContain("setActiveCloudflareEnv(vitehubEnv)")
     expect(pluginSource).toContain("configureHostedWorkspaceRuntime")
     expect(pluginSource).toContain('"repository": () => process.env.WORKSPACE_REPO')
     expect(pluginSource).toContain('"token": () => process.env.WORKSPACE_TOKEN')

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -737,6 +737,7 @@ describe("hubWorkspace", () => {
 
     await expect(config(userConfig, { command: "build", mode: "production" })).resolves.toMatchObject({
       nitro: {
+        cloudflare: { wrangler: { compatibility_flags: ["nodejs_compat"] } },
         plugins: [".vitehub/nitro/workspace/plugin.ts"],
         rollupConfig: { external: ["cloudflare:workers"] },
       },
@@ -798,6 +799,26 @@ describe("hubWorkspace", () => {
     expect(pluginSource).toContain('"provider": "github"')
     expect(pluginSource).not.toContain("vite-hub/build-repository")
     expect(pluginSource).not.toContain('"repository"')
+  })
+
+  it("preserves build-time GitHub fallbacks for non-Cloudflare runtimes", async () => {
+    const root = await createViteRoot()
+    vi.stubEnv("GITHUB_REPOSITORY", "vite-hub/build-repository")
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace()
+    const config = plugin.config as (config: {
+      root: string
+      workspace: { store: { provider: "github" } }
+    }, env: { command: "build", mode: string }) => Promise<unknown>
+
+    await config({
+      root,
+      workspace: { store: { provider: "github" } },
+    }, { command: "build", mode: "production" })
+
+    const pluginSource = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
+    expect(pluginSource).toContain('"repository": "vite-hub/build-repository"')
+    expect(pluginSource).not.toContain("setActiveCloudflareEnv")
   })
 
   it("emits Nitro hosted runtime setup for explicit Vercel Blob workspace stores", async () => {

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -751,6 +751,33 @@ describe("hubWorkspace", () => {
     expect(pluginSource).not.toContain('"token": "********"')
   })
 
+  it.each([
+    ["VITEHUB_HOSTING", undefined],
+    ["NITRO_PRESET", undefined],
+    ["SERVER_PRESET", undefined],
+    ["nitro.preset", { preset: "cloudflare-module" }],
+  ] as const)("activates Cloudflare runtime bindings from %s", async (signal, nitro) => {
+    const root = await createViteRoot()
+    if (signal !== "nitro.preset") vi.stubEnv(signal, "cloudflare-module")
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace()
+    const config = plugin.config as (config: {
+      nitro?: { preset?: string }
+      root: string
+      workspace: { store: { provider: "github", repository: string } }
+    }, env: { command: "build", mode: string }) => Promise<{ nitro?: { rollupConfig?: { external?: unknown } } }>
+
+    const result = await config({
+      ...(nitro ? { nitro } : {}),
+      root,
+      workspace: { store: { provider: "github", repository: "onmax/repo" } },
+    }, { command: "build", mode: "production" })
+
+    expect(result.nitro?.rollupConfig).toMatchObject({ external: ["cloudflare:workers"] })
+    const pluginSource = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
+    expect(pluginSource).toContain("setActiveCloudflareEnv(vitehubEnv)")
+  })
+
   it("emits Nitro hosted runtime setup for explicit Vercel Blob workspace stores", async () => {
     const root = await createViteRoot()
     const { hubWorkspace } = await import("../src/vite.ts")
@@ -938,6 +965,21 @@ describe("hubWorkspace", () => {
     expect(pluginSource).toContain("export default function vitehubWorkspacePlugin() {")
     expect(pluginSource).not.toContain("from 'nitro'")
     expect(pluginSource).not.toContain("nitropack/runtime")
+  })
+
+  it("activates standalone Nitro Cloudflare bindings from the provided environment", async () => {
+    const root = await createViteRoot()
+    const { createWorkspaceNitroConfig } = await import("../src/nitro.ts")
+
+    await expect(createWorkspaceNitroConfig({
+      env: { NITRO_PRESET: "cloudflare-module" },
+      viteRoot: root,
+    })).resolves.toMatchObject({
+      rollupConfig: { external: ["cloudflare:workers"] },
+    })
+
+    const pluginSource = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
+    expect(pluginSource).toContain("setActiveCloudflareEnv(vitehubEnv)")
   })
 
   it("uses discovered source roots from generated Nitro workspace registries", async () => {

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -779,7 +779,7 @@ describe("hubWorkspace", () => {
     expect(pluginSource).toContain("setActiveCloudflareEnv(vitehubEnv)")
   })
 
-  it("does not serialize build-time GitHub fallbacks over Cloudflare runtime bindings", async () => {
+  it("does not serialize absent or blank GitHub fallbacks over Cloudflare runtime bindings", async () => {
     const root = await createViteRoot()
     vi.stubEnv("GITHUB_REPOSITORY", "vite-hub/build-repository")
     vi.stubEnv("NITRO_PRESET", "cloudflare-module")
@@ -787,18 +787,20 @@ describe("hubWorkspace", () => {
     const plugin = hubWorkspace()
     const config = plugin.config as (config: {
       root: string
-      workspace: { store: { provider: "github" } }
+      workspace: { store: { branch: string, provider: "github", repo: string, root: string } }
     }, env: { command: "build", mode: string }) => Promise<unknown>
 
     await config({
       root,
-      workspace: { store: { provider: "github" } },
+      workspace: { store: { branch: " ", provider: "github", repo: " ", root: " " } },
     }, { command: "build", mode: "production" })
 
     const pluginSource = await readFile(join(root, ".vitehub", "nitro", "workspace", "plugin.ts"), "utf8")
     expect(pluginSource).toContain('"provider": "github"')
     expect(pluginSource).not.toContain("vite-hub/build-repository")
+    expect(pluginSource).not.toContain('"branch"')
     expect(pluginSource).not.toContain('"repository"')
+    expect(pluginSource).not.toContain('".vitehub/workspaces/<workspace>"')
   })
 
   it("preserves build-time GitHub fallbacks for non-Cloudflare runtimes", async () => {


### PR DESCRIPTION
Cloudflare-hosted GitHub Workspaces now activate the Worker binding map in their generated Nitro runtime. Without that activation, Durable Objects evaluate lazy Workspace callbacks without the request environment, so repository and credential lookup can fail even when the same deployment serves the canonical document through its main Worker.

The GitHub Workspace resolver now falls back to every supported active binding alias for repository, branch, root, and token values. Hosted runtime normalization defers absent GitHub fields until bindings are active, preserving the order explicit option → Worker binding → runtime environment → default. Other hosts retain build-resolved fallbacks, and Cloudflare activation enables the Node compatibility required by the existing async context bridge. Nuxt propagates the Nitro-resolved host to both new and pre-registered Workspace Vite plugins without exposing that integration seam publicly.

## Verification

- `pnpm --filter @vite-hub/workspace test`: build and publint pass; 37 files and 499 tests pass with no type errors
- Focused config, Nuxt, and Vite plugin regressions pass
- Diff is confined to the Workspace package; Realtime checkpoint behavior remains in PR #942
