### PR TITLE
fix(agent): seed isolated Codex homes selectively

### DIFF
--- a/docs/content/docs/agents/boxes.md
+++ b/docs/content/docs/agents/boxes.md
@@ -68,7 +68,9 @@ For every invocation, `checkout` fetches `ref` from `remote`, verifies the fetch
 
 Use `cwd` instead when the caller already owns an authoritative directory. `checkout` and `cwd` are mutually exclusive. Git is an implicit checkout requirement and appears in resolved Box metadata.
 
-The runtime creates an owner-only Home outside the checkout, sets the XDG directories beneath it, and exposes the same environment to Codex, Git, `gh`, MCP servers, and ordinary Box commands. The `"codex"` driver uses `$HOME/.codex` directly and contributes `codex login status` automatically, so Codex refreshes remain in Box state.
+The runtime creates an owner-only Home outside the checkout, sets the XDG directories beneath it, and exposes the same environment to Codex, Git, `gh`, MCP servers, and ordinary Box commands. The `"codex"` driver contributes `codex login status` automatically and normally uses `$HOME/.codex` directly.
+
+When the Agent has colocated `skills/`, ViteHub instead gives each invocation a separate Codex Home, copies only `$HOME/.codex/auth.json` and `$HOME/.codex/config.toml` into it, installs the managed Skills, and deletes that Home when the invocation closes. Other files under `$HOME/.codex` are not copied, and Codex history, refreshed authentication, or other state created inside the isolated Home is not written back. Declare authentication and configuration through `box.home`, as in the example; the Box-owned `.codex` directory remains the authoritative seed.
 
 The example's committed `.vitehub/box/gitconfig` can configure Git without containing a token:
 

--- a/docs/content/docs/capabilities/skills.md
+++ b/docs/content/docs/capabilities/skills.md
@@ -95,7 +95,7 @@ Model-facing Skill guidance belongs in Agent Driver Instructions or deterministi
 For harness-backed drivers, `skills()` contributes the skill directory to the Harness Workspace Session instead of adding model-facing instructions or tools.
 With `shellExecution: 'write'`, model-backed Workspace Shell writes commit Workspace Session changes back into the Workspace.
 With `source`, ViteHub still uses normal Workspace Source materialization, visibility, and Agent inspection metadata. `skills()` does not fetch source files at invocation time.
-Global sources are materialized into an ephemeral harness profile for the session. Codex receives an isolated `CODEX_HOME` containing those Skills, an empty `config.toml`, and only the available authentication file from the configured Box or host profile.
+Global sources are materialized into an ephemeral harness profile for the session. Codex receives an isolated `CODEX_HOME` containing those Skills plus the available `auth.json` and `config.toml` from the configured Box or host profile. ViteHub discards invocation-created Codex state when the session closes.
 
 ## Requirements
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -87,9 +87,9 @@ export default defineAgent({
 });
 ```
 
-Put Agent-owned Skills under `server/agents/codex/skills/`; discovery materializes them into the Harness Workspace and the isolated Codex profile automatically. Use `skills()` for Workspace-backed or external Source Skills.
+Put Agent-owned Skills under `server/agents/codex/skills/`; discovery materializes them into the Harness Workspace and the isolated Codex profile automatically. For a Box-backed Codex Agent, ViteHub seeds that invocation profile with only `.codex/auth.json` and `.codex/config.toml`, installs the managed Skills, and deletes the profile on close. Other Box Codex files are not copied, and invocation-created Codex state is not written back. Use `skills()` for Workspace-backed or external Source Skills.
 
-Put static Box Home files under `server/agents/codex/home/`; discovery embeds dotfiles and binary files into `box.home.files`. Use `box.home.state` for credentials or other files that must refresh or persist.
+Put static Box Home files under `server/agents/codex/home/`; discovery embeds dotfiles and binary files into `box.home.files`. Use `box.home.state` for credentials or other durable files updated directly through the Box Home.
 
 Use `driver: "codex"` or `driver: "claude-code"` for the defaults. Use a tagged value such as `{ kind: "claude-code", model, maxTurns }` when configuration is needed. The Claude Code default owns a local harness sandbox; use `{ kind: "claude-code", sandbox: false }` when a Box should own its process environment and working directory.
 
@@ -159,7 +159,7 @@ export default defineAgent<any, { ref: string; remote: string; sha: string }>({
 
 `checkout` fetches one invocation-resolved Git ref, verifies its full SHA, and runs the harness in an isolated detached checkout with normal commit and explicit-push behavior. The Box deletes it on completion or boot failure. Use `cwd` instead for a caller-owned authoritative directory; the two modes are mutually exclusive.
 
-`env` and `home.files` are immutable boot inputs. `home.state` is writable, persists CLI refreshes under an exclusive session lease, and resolves its seed only when state does not exist. Every Box gets a private Home; missing declarations fail instead of falling back to the machine's normal Home. The `"codex"` driver contributes a generic `codex login status` check, and other CLIs use string or direct-argv `requires` entries without provider-specific Box APIs. Do not combine `box.cwd` or `box.checkout` with Agent Workspace materialization.
+`env` and `home.files` are immutable boot inputs. `home.state` is writable, persists changes made directly against the mounted state under an exclusive session lease, and resolves its seed only when state does not exist. An isolated Codex profile treats Box state as its authentication and configuration seed; its own changes are disposable. Every Box gets a private Home; missing declarations fail instead of falling back to the machine's normal Home. The `"codex"` driver contributes a generic `codex login status` check, and other CLIs use string or direct-argv `requires` entries without provider-specific Box APIs. Do not combine `box.cwd` or `box.checkout` with Agent Workspace materialization.
 
 For model-backed drivers, put free-form guidance for configured Sources, Capabilities, and Skills in `driver.instructions` or a deterministic imported instruction file. Tool descriptions and schemas stay with the tools as structured contracts.
 

--- a/packages/agent/src/harness/codex.ts
+++ b/packages/agent/src/harness/codex.ts
@@ -221,33 +221,22 @@ async function prepareCodexHome(session: object, invocation?: { id?: string, iso
   const sandbox = session as { run(options: { command: string, env?: Record<string, string | undefined> }): Promise<{ exitCode: number, stderr?: string }> }
   const result = await sandbox.run({
     command:
-      'codex_home="${CODEX_HOME:-$HOME/.codex}" && ambient_home="${VITEHUB_AMBIENT_CODEX_HOME:-$HOME/.codex}" && mkdir -p "$codex_home" && chmod 700 "$codex_home" && if [ "$codex_home" != "$ambient_home" ] && [ -d "$ambient_home" ]; then cp -R "$ambient_home"/. "$codex_home"; fi && rm -rf -- "$codex_home/skills/.git" && manifest="$codex_home/skills.vitehub-managed" && if [ -f "$manifest" ]; then while IFS= read -r encoded || [ -n "$encoded" ]; do managed=$(printf \'%s\' "$encoded" | base64 -d) || exit 1; case "$managed" in \'\'|/*|..|../*|*/..|*/../*) exit 1 ;; esac; rm -rf -- "$codex_home/skills/$managed"; done < "$manifest" && rm -f -- "$manifest"; fi && manifest="$codex_home/skills/.vitehub-colocated" && if [ -f "$manifest" ]; then while IFS= read -r managed || [ -n "$managed" ]; do case "$managed" in \'\'|*/*|.. ) exit 1 ;; esac; rm -rf -- "$codex_home/skills/$managed"; done < "$manifest" && rm -f -- "$manifest"; fi && if [ ! -e "$codex_home/config.toml" ]; then : > "$codex_home/config.toml"; fi && chmod 600 "$codex_home/config.toml" && if [ "$codex_home" != "$ambient_home" ]; then baseline="$codex_home.vitehub-baseline" && rm -rf -- "$baseline" && mkdir -p "$baseline" && cp -R "$codex_home"/. "$baseline"; fi',
+      'codex_home="${CODEX_HOME:-$HOME/.codex}" && ambient_home="${VITEHUB_AMBIENT_CODEX_HOME:-$HOME/.codex}" && mkdir -p "$codex_home" && chmod 700 "$codex_home" && if [ "$codex_home" != "$ambient_home" ]; then if [ -f "$ambient_home/auth.json" ] && [ ! -e "$codex_home/auth.json" ]; then cp "$ambient_home/auth.json" "$codex_home/auth.json" && chmod 600 "$codex_home/auth.json"; fi && if [ -f "$ambient_home/config.toml" ] && [ ! -e "$codex_home/config.toml" ]; then cp "$ambient_home/config.toml" "$codex_home/config.toml"; fi; fi && if [ ! -e "$codex_home/config.toml" ]; then : > "$codex_home/config.toml"; fi && chmod 600 "$codex_home/config.toml"',
   })
   if (result.exitCode !== 0) {
     if (invocation?.isolateBoxHome && invocation.id) {
-      await sandbox.run({ command: `rm -rf -- "$HOME/.vitehub/codex-home-${invocation.id}" "$HOME/.vitehub/codex-home-${invocation.id}.vitehub-baseline"` }).catch(() => undefined)
+      await sandbox.run({ command: `rm -rf -- "$HOME/.vitehub/codex-home-${invocation.id}"` }).catch(() => undefined)
     }
     throw new Error(`[vitehub] Failed to prepare Codex Home: ${result.stderr || "sandbox command failed"}`)
   }
   if (!invocation?.isolateBoxHome || !invocation.id) return
   return {
-    async close(error) {
-      if (error !== undefined) {
-        const cleanup = await sandbox.run({
-          command: `rm -rf -- "$HOME/.vitehub/codex-home-${invocation.id}" "$HOME/.vitehub/codex-home-${invocation.id}.vitehub-baseline"`,
-        })
-        if (cleanup.exitCode !== 0) {
-          throw new Error(`[vitehub] Failed to discard the invocation Codex Home after preparation failed: ${cleanup.stderr || "sandbox command failed"}`)
-        }
-        return
-      }
-      // Merge generated and modified Codex state without replaying unchanged seeded state.
-      // Concurrent changes to the same path remain completion ordered; ambient-only entries are additive.
+    async close() {
       const cleanup = await sandbox.run({
-        command: `codex_home="$HOME/.vitehub/codex-home-${invocation.id}" && ambient_home="\${VITEHUB_AMBIENT_CODEX_HOME:-$HOME/.codex}" && baseline="$codex_home.vitehub-baseline" && status=0; rm -rf -- "$codex_home/skills/.git" || status=$?; manifest="$codex_home/skills.vitehub-managed"; if [ -f "$manifest" ]; then while IFS= read -r encoded || [ -n "$encoded" ]; do managed=$(printf '%s' "$encoded" | base64 -d) || { status=1; break; }; case "$managed" in ''|/*|..|../*|*/..|*/../*) status=1; break ;; esac; rm -rf -- "$codex_home/skills/$managed" "$baseline/skills/$managed" || status=$?; done < "$manifest"; rm -f -- "$manifest" || status=$?; fi; manifest="$codex_home/skills/.vitehub-colocated"; if [ -f "$manifest" ]; then while IFS= read -r managed || [ -n "$managed" ]; do case "$managed" in ''|*/*|.. ) status=1; break ;; esac; rm -rf -- "$codex_home/skills/$managed" "$baseline/skills/$managed" || status=$?; done < "$manifest"; rm -f -- "$manifest" || status=$?; fi; if [ "$status" -eq 0 ] && [ -d "$baseline" ]; then find "$baseline" -type f -exec sh -c 'baseline="$1"; codex_home="$2"; ambient_home="$3"; shift 3; for seeded do relative="\${seeded#"$baseline"/}"; if [ ! -e "$codex_home/$relative" ]; then if cmp -s "$seeded" "$ambient_home/$relative"; then rm -f -- "$ambient_home/$relative" || exit $?; fi; elif cmp -s "$seeded" "$codex_home/$relative"; then rm -f -- "$codex_home/$relative" || exit $?; fi; done' sh "$baseline" "$codex_home" "$ambient_home" {} + || status=$?; fi; if [ "$status" -eq 0 ]; then rm -rf -- "$baseline" || status=$?; fi; if [ "$status" -eq 0 ]; then mkdir -p "$ambient_home" || status=$?; fi; if [ "$status" -eq 0 ]; then cp -R "$codex_home"/. "$ambient_home" || status=$?; fi; if [ "$status" -eq 0 ]; then rm -rf -- "$codex_home" || status=$?; fi; exit "$status"`,
+        command: `rm -rf -- "$HOME/.vitehub/codex-home-${invocation.id}"`,
       })
       if (cleanup.exitCode !== 0) {
-        throw new Error(`[vitehub] Failed to preserve Codex state and remove the invocation Codex Home: ${cleanup.stderr || "sandbox command failed"}`)
+        throw new Error(`[vitehub] Failed to remove the invocation Codex Home: ${cleanup.stderr || "sandbox command failed"}`)
       }
     },
   }

--- a/packages/agent/test/box.test.ts
+++ b/packages/agent/test/box.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process"
-import { chmod, mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from "node:fs/promises"
+import { chmod, mkdir, mkdtemp, readFile, readdir, realpath, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { promisify } from "node:util"
@@ -9,6 +9,7 @@ import { unknownExecutionAuthority } from "@vite-hub/runtime"
 
 const harnessSettings = vi.hoisted(() => [] as Record<string, any>[])
 const harnessObservation = vi.hoisted(() => ({
+  additionalGlobalSkill: undefined as string | undefined,
   before: undefined as string | undefined,
   command: false,
   exitCode: undefined as number | undefined,
@@ -17,7 +18,6 @@ const harnessObservation = vi.hoisted(() => ({
   generateCount: 0,
   globalSkill: "global",
   live: undefined as string | undefined,
-  requiredCodexStates: [] as string[],
 }))
 
 vi.mock("@ai-sdk/harness/agent", () => ({
@@ -64,7 +64,7 @@ vi.mock("@ai-sdk/harness/agent", () => ({
         return { text: live }
       }
       const result = await session.host.run({
-        command: `codex_home="\${CODEX_HOME:-$HOME/.codex}"; pwd; printf '%s\\n' "$HOME" "$codex_home"; test -f AGENTS.md; test -f "$codex_home/skills/${harnessObservation.globalSkill}/SKILL.md"; grep -q configured-model "$codex_home/config.toml"; grep -q box "$codex_home/auth.json"; ${harnessObservation.requiredCodexStates.map(state => `test -f "$codex_home/${state}"; `).join("")}printf durable > "$codex_home/${codexState}"; printf changed > changed.txt`,
+        command: `codex_home="\${CODEX_HOME:-$HOME/.codex}"; pwd; printf '%s\\n' "$HOME" "$codex_home"; test -f AGENTS.md; test -f "$codex_home/skills/${harnessObservation.globalSkill}/SKILL.md"; ${harnessObservation.additionalGlobalSkill ? `test -f "$codex_home/skills/${harnessObservation.additionalGlobalSkill}/SKILL.md"; ` : ""}grep -q configured-model "$codex_home/config.toml"; grep -q box "$codex_home/auth.json"; printf durable > "$codex_home/${codexState}"; printf changed > changed.txt`,
         workingDirectory: session.sessionWorkDir,
       })
       if (result.exitCode) throw new Error(result.stderr)
@@ -78,6 +78,7 @@ const exec = promisify(execFile)
 
 afterEach(async () => {
   harnessSettings.length = 0
+  harnessObservation.additionalGlobalSkill = undefined
   harnessObservation.command = false
   harnessObservation.before = undefined
   harnessObservation.exitCode = undefined
@@ -86,7 +87,6 @@ afterEach(async () => {
   harnessObservation.generateCount = 0
   harnessObservation.globalSkill = "global"
   harnessObservation.live = undefined
-  harnessObservation.requiredCodexStates = []
   await Promise.all(roots.splice(0).map(root => rm(root, { force: true, recursive: true })))
 })
 
@@ -192,7 +192,7 @@ describe("Agent Box", () => {
           },
         },
       })
-      harnessObservation.globalSkill = "review"
+      harnessObservation.additionalGlobalSkill = "review"
 
       const result = await runAgent(agent, {
         memo: vi.fn((_key, create) => create()),
@@ -210,24 +210,7 @@ describe("Agent Box", () => {
 
       await expect(readFile(join(worktree, "changed.txt"), "utf8")).resolves.toBe("changed")
       await expect(stat(codexHome)).rejects.toMatchObject({ code: "ENOENT" })
-      harnessObservation.requiredCodexStates = ["session-state-1"]
-      await expect(Promise.all([1, 2].map(() => runAgent(agent, {
-        memo: vi.fn((_key, create) => create()),
-        runtime: "vite",
-        waitUntil: vi.fn(),
-      }, {
-        options: { worktreePath: worktree },
-        prompt: "Continue repairing the project concurrently.",
-      })))).resolves.toHaveLength(2)
-      harnessObservation.requiredCodexStates = ["session-state-2", "session-state-3"]
-      await expect(runAgent(agent, {
-        memo: vi.fn((_key, create) => create()),
-        runtime: "vite",
-        waitUntil: vi.fn(),
-      }, {
-        options: { worktreePath: worktree },
-        prompt: "Continue repairing the project.",
-      })).resolves.toMatchObject({ text: expect.any(String) })
+      expect((await readdir(stateRoot, { recursive: true })).some(path => path.includes("session-state-1"))).toBe(false)
       expect(harnessSettings.at(-1)?.sandbox).toMatchObject({ providerId: "trusted-host" })
       expect(harnessSettings.at(-1)?.sandboxConfig.workDir).toBeUndefined()
     }

--- a/packages/agent/test/codex-harness.test.ts
+++ b/packages/agent/test/codex-harness.test.ts
@@ -1,5 +1,12 @@
+import { execFile } from "node:child_process"
+import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { promisify } from "node:util"
+
 import { describe, expect, it, vi } from "vitest"
 
+const execFileAsync = promisify(execFile)
 const createCodex = vi.hoisted(() => vi.fn(settings => ({ provider: "codex", settings })))
 
 vi.mock("@ai-sdk/harness-codex", () => ({
@@ -236,55 +243,67 @@ describe("createCodexDriver", () => {
       .toBe(".vitehub/codex-home-invocation-1/skills")
   })
 
-  it("uses Box-owned Codex Home without replacing its authentication state", async () => {
-    const { createCodexDriver } = await import("../src/harness/codex.ts")
-    const run = vi.fn(async (_options: { command: string, env?: Record<string, string | undefined> }) => ({ exitCode: 0, stderr: "" }))
-    const restrictedRun = vi.fn(async (_options: { command: string, env?: Record<string, string | undefined> }) => ({ exitCode: 0, stderr: "" }))
-    const rawSession = {
-      defaultWorkingDirectory: "/sandbox/run-1",
-      env: { CODEX_HOME: "/box/.codex", HOME: "/box" },
-      restricted: () => ({ run: restrictedRun, spawn: vi.fn() }),
-      run,
-      spawn: vi.fn(),
-    }
-    const provider = {
-      specificationVersion: "harness-sandbox-v1",
-      async createSession(options: { onFirstCreate?: (session: object, context: object) => Promise<void> }) {
-        await options.onFirstCreate?.(rawSession, {})
-        return rawSession
-      },
-    }
-    const driver = createCodexDriver({ sandbox: provider })
-    const adaptSandbox = (driver.harness as Record<PropertyKey, unknown>)[Symbol.for("vitehub.harnessInvocationSandboxAdapter")] as (provider: object, options: { box: boolean, defaultSandbox: boolean, invocation: { id: string, isolateBoxHome: boolean } }) => { createSession: () => Promise<typeof rawSession> }
-    const invocation = { id: "invocation-1", isolateBoxHome: true }
-    const session = await adaptSandbox(provider, { box: true, defaultSandbox: false, invocation }).createSession()
+  it("keeps isolated Box Codex Homes selective and disposable", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-codex-home-"))
+    const boxHome = join(root, "box")
+    const ambientHome = join(boxHome, ".codex")
+    const sessionEnv = { CODEX_HOME: ambientHome, HOME: boxHome }
+    await mkdir(join(ambientHome, "sessions"), { recursive: true })
+    await writeFile(join(ambientHome, "auth.json"), "ambient-auth")
+    await writeFile(join(ambientHome, "config.toml"), "model = 'gpt-5.5'")
+    await writeFile(join(ambientHome, "sessions", "ambient.jsonl"), "ambient-session")
 
-    const prepareSession = (driver.harness as Record<PropertyKey, unknown>)[Symbol.for("vitehub.harnessSessionPrepare")] as (session: object, invocation?: { id: string, isolateBoxHome: boolean }) => Promise<{ close: (error?: unknown) => Promise<void> } | undefined>
-    const prepared = await prepareSession(session, invocation)
+    try {
+      const { createCodexDriver } = await import("../src/harness/codex.ts")
+      const run = vi.fn(async (options: { command: string, env?: Record<string, string | undefined> }) => {
+        const { stderr, stdout } = await execFileAsync("/bin/sh", ["-c", options.command], {
+          env: { ...process.env, ...sessionEnv, ...options.env },
+        })
+        return { exitCode: 0, stderr, stdout }
+      })
+      const rawSession = {
+        defaultWorkingDirectory: join(root, "workspace"),
+        env: sessionEnv,
+        restricted: () => ({ run, spawn: vi.fn() }),
+        run,
+        spawn: vi.fn(),
+      }
+      const provider = {
+        specificationVersion: "harness-sandbox-v1",
+        async createSession() {
+          return rawSession
+        },
+      }
+      const driver = createCodexDriver({ sandbox: provider })
+      const adaptSandbox = (driver.harness as Record<PropertyKey, unknown>)[Symbol.for("vitehub.harnessInvocationSandboxAdapter")] as (provider: object, options: { box: boolean, defaultSandbox: boolean, invocation: { id: string, isolateBoxHome: boolean } }) => { createSession: () => Promise<typeof rawSession> }
+      const prepareSession = (driver.harness as Record<PropertyKey, unknown>)[Symbol.for("vitehub.harnessSessionPrepare")] as (session: object, invocation?: { id: string, isolateBoxHome: boolean }) => Promise<{ close: (error?: unknown) => Promise<void> } | undefined>
+      const firstInvocation = { id: "invocation-1", isolateBoxHome: true }
+      const secondInvocation = { id: "invocation-2", isolateBoxHome: true }
+      const firstHome = join(boxHome, ".vitehub", "codex-home-invocation-1")
+      const secondHome = join(boxHome, ".vitehub", "codex-home-invocation-2")
+      const first = await prepareSession(await adaptSandbox(provider, { box: true, defaultSandbox: false, invocation: firstInvocation }).createSession(), firstInvocation)
 
-    expect(run).toHaveBeenCalledWith(expect.objectContaining({
-      command: expect.stringContaining('export VITEHUB_AMBIENT_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"; export CODEX_HOME="$HOME/.vitehub/codex-home-invocation-1";'),
-    }))
-    expect(run.mock.calls[0][0].command).toContain('ambient_home="${VITEHUB_AMBIENT_CODEX_HOME:-$HOME/.codex}"')
-    expect(run.mock.calls[0][0].command).toContain('cp -R "$ambient_home"/. "$codex_home"')
-    expect(run.mock.calls[0][0].command).toContain('rm -rf -- "$codex_home/skills/$managed"')
-    expect(run.mock.calls[0][0].command).toContain('manifest="$codex_home/skills/.vitehub-colocated"')
-    expect(run.mock.calls[0][0].command).toContain('baseline="$codex_home.vitehub-baseline"')
-    await session.run({ command: "codex exec" })
-    expect(run).toHaveBeenLastCalledWith({
-      command: 'export VITEHUB_AMBIENT_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"; export CODEX_HOME="$HOME/.vitehub/codex-home-invocation-1"; codex exec',
-    })
-    await session.restricted().run({ command: "codex exec" })
-    expect(restrictedRun).toHaveBeenCalledWith({
-      command: 'export VITEHUB_AMBIENT_CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"; export CODEX_HOME="$HOME/.vitehub/codex-home-invocation-1"; codex exec',
-    })
-    await prepared?.close()
-    expect(run).toHaveBeenLastCalledWith({
-      command: expect.stringMatching(/rm -rf -- "\$codex_home\/skills\/\$managed".*find "\$baseline" -type f.*cmp -s.*cp -R "\$codex_home"\/\. "\$ambient_home".*if \[ "\$status" -eq 0 \]; then rm -rf/),
-    })
-    expect(run.mock.calls.at(-1)?.[0].command).toContain('"$codex_home/skills/.vitehub-colocated"')
-    expect(run.mock.calls.at(-1)?.[0].command).toContain('"$baseline/skills/$managed"')
-    expect(run.mock.calls.at(-1)?.[0].command).toContain('cmp -s "$seeded" "$ambient_home/$relative"')
+      expect(await readFile(join(firstHome, "auth.json"), "utf8")).toBe("ambient-auth")
+      expect(await readFile(join(firstHome, "config.toml"), "utf8")).toBe("model = 'gpt-5.5'")
+      await expect(access(join(firstHome, "sessions", "ambient.jsonl"))).rejects.toThrow()
+      await writeFile(join(firstHome, "invocation-state.json"), "first")
+
+      const second = await prepareSession(await adaptSandbox(provider, { box: true, defaultSandbox: false, invocation: secondInvocation }).createSession(), secondInvocation)
+      expect(await readFile(join(secondHome, "auth.json"), "utf8")).toBe("ambient-auth")
+      await expect(access(join(secondHome, "invocation-state.json"))).rejects.toThrow()
+
+      await first?.close()
+      await second?.close()
+      await expect(access(firstHome)).rejects.toThrow()
+      await expect(access(secondHome)).rejects.toThrow()
+      expect(await readFile(join(ambientHome, "auth.json"), "utf8")).toBe("ambient-auth")
+      expect(await readFile(join(ambientHome, "config.toml"), "utf8")).toBe("model = 'gpt-5.5'")
+      expect(await readFile(join(ambientHome, "sessions", "ambient.jsonl"), "utf8")).toBe("ambient-session")
+      await expect(access(join(ambientHome, "invocation-state.json"))).rejects.toThrow()
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
   })
 
   it("discards the isolated Box Codex Home when harness preparation fails", async () => {
@@ -297,7 +316,7 @@ describe("createCodexDriver", () => {
     await prepared?.close(new Error("materialization failed"))
 
     expect(run).toHaveBeenLastCalledWith({
-      command: 'rm -rf -- "$HOME/.vitehub/codex-home-failed-invocation" "$HOME/.vitehub/codex-home-failed-invocation.vitehub-baseline"',
+      command: 'rm -rf -- "$HOME/.vitehub/codex-home-failed-invocation"',
     })
     expect(run.mock.calls.at(-1)?.[0].command).not.toContain("cp -R")
   })


### PR DESCRIPTION
## Summary

- keep colocated-Skill Codex invocations on separate invocation-owned Codex Homes
- seed only `auth.json` and `config.toml`, then discard invocation state instead of cloning and merging the whole Box profile
- document the disposable lifecycle and cover authentication, configuration, isolation, ambient non-writeback, and managed/colocated Skills

## Verification

- `pnpm exec vp run -t @vite-hub/agent#build`
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm exec vp test test/codex-harness.test.ts --maxWorkers=1 --testTimeout=60000`
- `pnpm exec vp test test/box.test.ts -t "runs Codex in the authoritative trusted-host workspace with the selected Home" --maxWorkers=1 --testTimeout=60000`
- `pnpm exec vp test test/box.test.ts -t "keeps a shared Box global Skill profile stable for the full invocation" --maxWorkers=1 --testTimeout=60000`
- `pnpm exec vp lint src/harness/codex.ts test/codex-harness.test.ts test/box.test.ts`
- `git diff --check`