### PR TITLE
fix(agent): make durable Workflow runs portable

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -18,6 +18,7 @@ import {
   createStatusDeliveryEffectIntent,
 } from "./delivery-effects.ts"
 import { createTraceEventLog, getViteHubErrorShape, resolveRuntimeContext } from "@vite-hub/runtime"
+import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { agentResultKind, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
 import { defineChatCapability, getChatCapabilityOptions } from "./chat-trigger.ts"
 import {
@@ -43,7 +44,7 @@ import {
 } from "./channels.ts"
 import { agentInvocationCallbackContextValues, createAgentInvocationContextStore } from "./invocation-context.ts"
 import { bindAgentRunEvents } from "./run-events.ts"
-import { materializeMessageAttachmentData, type AgentMessagePhase } from "./messages.ts"
+import { isAttachmentPart, materializeMessageAttachmentData, type AgentMessagePhase, type Message } from "./messages.ts"
 import {
   createFallbackAgentInvoker,
   hasResolvedAgentInvokerInput,
@@ -716,6 +717,34 @@ async function getAgentWorkflowHandle<
   return handle
 }
 
+async function portableAgentWorkflowRunId(runId: string): Promise<string> {
+  if (/^[a-zA-Z0-9_][a-zA-Z0-9-_]{0,99}$/.test(runId)) return runId
+  const digest = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(runId))
+  return `agent-${Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, "0")).join("")}`
+}
+
+function workflowAttachmentBase64(data: Uint8Array): string {
+  let binary = ""
+  for (let offset = 0; offset < data.length; offset += 0x8000) {
+    binary += String.fromCharCode(...data.subarray(offset, offset + 0x8000))
+  }
+  return btoa(binary)
+}
+
+async function portableWorkflowMessages(messages: Message[]): Promise<Message[]> {
+  const materialized = await materializeMessageAttachmentData(messages)
+  return await Promise.all(materialized.map(async message => ({
+    ...message,
+    parts: await Promise.all(message.parts.map(async (part) => {
+      if (!isAttachmentPart(part)) return part
+      let data = part.data
+      if (data instanceof Blob) data = await data.arrayBuffer()
+      if (data instanceof ArrayBuffer) data = new Uint8Array(data)
+      return data instanceof Uint8Array ? { ...part, data: workflowAttachmentBase64(data) } : part
+    })),
+  })))
+}
+
 async function runAgentAsWorkflow<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -727,6 +756,7 @@ async function runAgentAsWorkflow<
   options: { fresh?: boolean } = {},
 ): Promise<StartedAgentWorkflow<CALL_OPTIONS, TOutput> | undefined> {
   const binding = resolveAgentWorkflowRuntimeBinding<TRuntimeConfig>(agent)
+  const cloudflareEnv = context.cloudflare?.env || getCloudflareEnv(context)
   if (!binding || ("discoveryDefault" in binding && !context.agentIdentity)) return undefined
   if ("discoveryDefault" in binding) {
     const { getWorkflowRuntimeConfig } = await loadAgentWorkflowRuntimeStateModule()
@@ -748,9 +778,10 @@ async function runAgentAsWorkflow<
   const workflowInput = { ...portableResolvedAgentInvokerInput(input) }
   // ponytail: AbortSignal is live process state and cannot cross a durable Workflow payload.
   delete workflowInput.abortSignal
-  if (workflowInput.messages) workflowInput.messages = await materializeMessageAttachmentData(workflowInput.messages)
-  if (workflowInput.message && typeof workflowInput.message !== "string") [workflowInput.message] = await materializeMessageAttachmentData([workflowInput.message])
-  if (Array.isArray(workflowInput.prompt)) workflowInput.prompt = await materializeMessageAttachmentData(workflowInput.prompt)
+  if (input.context?.[requireAgentWorkflowContextKey] === true) delete workflowInput.timeout
+  if (workflowInput.messages) workflowInput.messages = await portableWorkflowMessages(workflowInput.messages)
+  if (workflowInput.message && typeof workflowInput.message !== "string") [workflowInput.message] = await portableWorkflowMessages([workflowInput.message])
+  if (Array.isArray(workflowInput.prompt)) workflowInput.prompt = await portableWorkflowMessages(workflowInput.prompt)
   const inheritedRun = options.fresh && context.run
     ? Object.fromEntries(Object.entries(context.run).filter(([key]) => key !== "runId"))
     : context.run
@@ -766,17 +797,20 @@ async function runAgentAsWorkflow<
     ...(inheritedRun ? { run: inheritedRun } : {}),
   }
   const workflowEvent = {
-    ...(context.cloudflare?.env ? { env: context.cloudflare.env } : {}),
+    ...(cloudflareEnv ? { env: cloudflareEnv } : {}),
     waitUntil: context.waitUntil,
     context: {
       ...(context.cloudflare ? { cloudflare: context.cloudflare } : {}),
       waitUntil: context.waitUntil,
     },
   }
+  const workflowRunId = !options.fresh && context.run?.runId
+    ? await portableAgentWorkflowRunId(context.run.runId)
+    : undefined
   const { runWithWorkflowRuntimeEvent } = await loadAgentWorkflowRuntimeStateModule()
   const run = await runWithWorkflowRuntimeEvent(workflowEvent, () => handle.run(
     payload,
-    !options.fresh && context.run?.runId ? { id: context.run.runId } : {},
+    workflowRunId ? { id: workflowRunId } : {},
   ))
   return { handle, run }
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -631,6 +631,7 @@ interface AgentWorkflowRun<TOutput = unknown> {
   result?: TOutput
   status: "cancelled" | "completed" | "failed" | "queued" | "running" | "unknown"
 }
+type AgentWorkflowOutput<TOutput> = TOutput extends Response ? AgentRunResult : TOutput | AgentRunResult
 interface StartedAgentWorkflow<CALL_OPTIONS = unknown, TOutput = unknown> {
   handle: WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, TOutput>
   run: AgentWorkflowRun<TOutput>
@@ -697,19 +698,19 @@ async function getAgentWorkflowHandle<
   agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>, TOutput>,
   name: string,
   reuseRegistry: boolean,
-): Promise<WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, TOutput>> {
+): Promise<WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, AgentWorkflowOutput<TOutput>>> {
   const handles = agentWorkflowHandles.get(agent as object) || new Map<string, WorkflowHandle<AgentWorkflowInvocationPayload, unknown>>()
   const cacheKey = `${reuseRegistry ? "registry" : "inline"}:${name}`
   const existing = handles.get(cacheKey)
-  if (existing) return existing as WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, TOutput>
+  if (existing) return existing as WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, AgentWorkflowOutput<TOutput>>
 
   const { createWorkflow } = await loadAgentWorkflowModule()
   const { getInlineWorkflowDefinitions, getWorkflowRuntimeRegistry } = await loadAgentWorkflowRuntimeStateModule()
   const handle = (reuseRegistry && getWorkflowRuntimeRegistry()?.[name]) || (agentWorkflowNames.has(name) && getInlineWorkflowDefinitions().has(name))
-    ? createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, TOutput>(name)
-    : createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, TOutput>(name, async (workflowContext) => {
+    ? createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, AgentWorkflowOutput<TOutput>>(name)
+    : createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, AgentWorkflowOutput<TOutput>>(name, async (workflowContext) => {
         const { runAgentWorkflowDefinition } = await import("./runtime/workflow.ts")
-        return await runAgentWorkflowDefinition(agent as never, workflowContext as never, runAgentInline as never) as TOutput
+        return await runAgentWorkflowDefinition(agent as never, workflowContext as never, runAgentInline as never) as AgentWorkflowOutput<TOutput>
       })
   agentWorkflowNames.add(name)
   handles.set(cacheKey, handle as WorkflowHandle<AgentWorkflowInvocationPayload, unknown>)
@@ -757,7 +758,7 @@ async function runAgentAsWorkflow<
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
   options: { fresh?: boolean } = {},
-): Promise<StartedAgentWorkflow<CALL_OPTIONS, TOutput> | undefined> {
+): Promise<StartedAgentWorkflow<CALL_OPTIONS, AgentWorkflowOutput<TOutput>> | undefined> {
   const binding = resolveAgentWorkflowRuntimeBinding<TRuntimeConfig>(agent)
   const cloudflareEnv = context.cloudflare?.env || getCloudflareEnv(context)
   if (!binding || ("discoveryDefault" in binding && !context.agentIdentity)) return undefined
@@ -781,7 +782,6 @@ async function runAgentAsWorkflow<
   const workflowInput = { ...portableResolvedAgentInvokerInput(input) }
   // ponytail: AbortSignal is live process state and cannot cross a durable Workflow payload.
   delete workflowInput.abortSignal
-  if (input.context?.[requireAgentWorkflowContextKey] === true) delete workflowInput.timeout
   if (workflowInput.messages) workflowInput.messages = await portableWorkflowMessages(workflowInput.messages)
   if (workflowInput.message && typeof workflowInput.message !== "string") [workflowInput.message] = await portableWorkflowMessages([workflowInput.message])
   if (Array.isArray(workflowInput.prompt)) workflowInput.prompt = await portableWorkflowMessages(workflowInput.prompt)
@@ -4045,7 +4045,7 @@ export async function startAgentInvocation<
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
   options: { runId?: string } = {},
-): Promise<AgentInvocationController<TOutput | Response, CALL_OPTIONS>> {
+): Promise<AgentInvocationController<TOutput | Response | AgentRunResult, CALL_OPTIONS>> {
   const invocationContext = withAgentIdentityOwner(agent, context)
   const workflow = await runAgentAsWorkflow<TRuntimeConfig, CALL_OPTIONS, TOutput>(
     agent,
@@ -4066,7 +4066,7 @@ export async function runAgent<
   agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>, TOutput>,
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
-): Promise<TOutput | Response | AgentWorkflowRun<TOutput>> {
+): Promise<TOutput | Response | AgentWorkflowRun<AgentWorkflowOutput<TOutput>>> {
   const invocationContext = withAgentIdentityOwner(agent, context)
   const workflow = await runAgentAsWorkflow<TRuntimeConfig, CALL_OPTIONS, TOutput>(agent, invocationContext, input)
   if (workflow) return workflow.run

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -786,7 +786,7 @@ async function runAgentAsWorkflow<
   const payload: AgentWorkflowInvocationPayload<CALL_OPTIONS> = {
     ...(context.agentIdentity ? { agentIdentity: context.agentIdentity } : {}),
     ...(Object.keys(disabledCapabilities).length ? { capabilities: disabledCapabilities } : {}),
-    input: workflowInput,
+    input: cloneWorkflowJsonValue(workflowInput) as AgentRunInput<CALL_OPTIONS>,
     // Headers and bodies may contain webhook credentials and remain process-local by design.
     ...(context.request ? { requestUrl: context.request.url } : {}),
     ...(hasResolvedAgentInvokerInput(input) ? { resolvedInvoker: true } : {}),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -802,7 +802,7 @@ async function runAgentAsWorkflow<
     },
   }
   const workflowRunId = !options.fresh && context.run?.runId
-    ? workflowConfig?.provider === "cloudflare"
+    ? workflowConfig && workflowConfig.provider === "cloudflare"
       ? await portableAgentWorkflowRunId(context.run.runId)
       : context.run.runId
     : undefined

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,6 +6,7 @@ import { openAgentInvocationLifecycle, type AgentInvocationLifecycle } from "./i
 import { cloneWithPropertyDescriptors, toReadableAsyncIterableStream } from "./internal/stream-result.ts"
 import { validateAgentOutput } from "./internal/agent-structured-output.ts"
 import { loadAgentWorkflowModule, loadAgentWorkflowRuntimeStateModule } from "./internal/workflow-runtime-loaders.ts"
+import { workflowBytesToBase64 } from "./internal/workflow-portability.ts"
 import { agentErrorDetails, agentErrorMessage } from "./agent-error.ts"
 import {
   createBackedAgentInvocationController,
@@ -725,14 +726,6 @@ async function portableAgentWorkflowRunId(runId: string): Promise<string> {
   return `${generatedPrefix}${Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, "0")).join("")}`
 }
 
-function workflowAttachmentBase64(data: Uint8Array): string {
-  let binary = ""
-  for (let offset = 0; offset < data.length; offset += 0x8000) {
-    binary += String.fromCharCode(...data.subarray(offset, offset + 0x8000))
-  }
-  return btoa(binary)
-}
-
 async function portableWorkflowMessages(messages: Message[]): Promise<Message[]> {
   const materialized = await materializeMessageAttachmentData(messages)
   return await Promise.all(materialized.map(async message => ({
@@ -743,7 +736,7 @@ async function portableWorkflowMessages(messages: Message[]): Promise<Message[]>
       if (data instanceof Blob) data = await data.arrayBuffer()
       if (data instanceof ArrayBuffer) data = new Uint8Array(data)
       return data instanceof Uint8Array
-        ? { ...part, data: `data:${part.mediaType};base64,${workflowAttachmentBase64(data)}` }
+        ? { ...part, data: `data:${part.mediaType};base64,${workflowBytesToBase64(data)}` }
         : part
     })),
   })))

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -718,9 +718,10 @@ async function getAgentWorkflowHandle<
 }
 
 async function portableAgentWorkflowRunId(runId: string): Promise<string> {
-  if (/^[a-zA-Z0-9_][a-zA-Z0-9-_]{0,99}$/.test(runId)) return runId
+  const generatedPrefix = "vitehub-invalid-"
+  if (/^[a-zA-Z0-9_][a-zA-Z0-9-_]{0,99}$/.test(runId) && !runId.startsWith(generatedPrefix)) return runId
   const digest = await globalThis.crypto.subtle.digest("SHA-256", new TextEncoder().encode(runId))
-  return `agent-${Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, "0")).join("")}`
+  return `${generatedPrefix}${Array.from(new Uint8Array(digest), byte => byte.toString(16).padStart(2, "0")).join("")}`
 }
 
 function workflowAttachmentBase64(data: Uint8Array): string {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -740,7 +740,9 @@ async function portableWorkflowMessages(messages: Message[]): Promise<Message[]>
       let data = part.data
       if (data instanceof Blob) data = await data.arrayBuffer()
       if (data instanceof ArrayBuffer) data = new Uint8Array(data)
-      return data instanceof Uint8Array ? { ...part, data: workflowAttachmentBase64(data) } : part
+      return data instanceof Uint8Array
+        ? { ...part, data: `data:${part.mediaType};base64,${workflowAttachmentBase64(data)}` }
+        : part
     })),
   })))
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6,7 +6,7 @@ import { openAgentInvocationLifecycle, type AgentInvocationLifecycle } from "./i
 import { cloneWithPropertyDescriptors, toReadableAsyncIterableStream } from "./internal/stream-result.ts"
 import { validateAgentOutput } from "./internal/agent-structured-output.ts"
 import { loadAgentWorkflowModule, loadAgentWorkflowRuntimeStateModule } from "./internal/workflow-runtime-loaders.ts"
-import { workflowBytesToBase64 } from "./internal/workflow-portability.ts"
+import { cloneWorkflowJsonValue, workflowBytesToBase64 } from "./internal/workflow-portability.ts"
 import { agentErrorDetails, agentErrorMessage } from "./agent-error.ts"
 import {
   createBackedAgentInvocationController,
@@ -731,13 +731,14 @@ async function portableWorkflowMessages(messages: Message[]): Promise<Message[]>
   return await Promise.all(materialized.map(async message => ({
     ...message,
     parts: await Promise.all(message.parts.map(async (part) => {
-      if (!isAttachmentPart(part)) return part
+      if (!isAttachmentPart(part)) return cloneWorkflowJsonValue(part) as typeof part
       let data = part.data
       if (data instanceof Blob) data = await data.arrayBuffer()
       if (data instanceof ArrayBuffer) data = new Uint8Array(data)
-      return data instanceof Uint8Array
+      const portable = data instanceof Uint8Array
         ? { ...part, data: `data:${part.mediaType};base64,${workflowBytesToBase64(data)}` }
         : part
+      return cloneWorkflowJsonValue(portable) as typeof part
     })),
   })))
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -755,9 +755,10 @@ async function runAgentAsWorkflow<
   const binding = resolveAgentWorkflowRuntimeBinding<TRuntimeConfig>(agent)
   const cloudflareEnv = context.cloudflare?.env || getCloudflareEnv(context)
   if (!binding || ("discoveryDefault" in binding && !context.agentIdentity)) return undefined
+  const { getWorkflowRuntimeConfig, runWithWorkflowRuntimeEvent } = await loadAgentWorkflowRuntimeStateModule()
+  const workflowConfig = getWorkflowRuntimeConfig()
   if ("discoveryDefault" in binding) {
-    const { getWorkflowRuntimeConfig } = await loadAgentWorkflowRuntimeStateModule()
-    if (!getWorkflowRuntimeConfig()) return undefined
+    if (!workflowConfig) return undefined
   }
   if ("discoveryDefault" in binding && context.agentIdentity) {
     const owner = (context as AgentRuntimeContext & { [agentIdentityOwner]?: object })[agentIdentityOwner]
@@ -801,9 +802,10 @@ async function runAgentAsWorkflow<
     },
   }
   const workflowRunId = !options.fresh && context.run?.runId
-    ? await portableAgentWorkflowRunId(context.run.runId)
+    ? workflowConfig?.provider === "cloudflare"
+      ? await portableAgentWorkflowRunId(context.run.runId)
+      : context.run.runId
     : undefined
-  const { runWithWorkflowRuntimeEvent } = await loadAgentWorkflowRuntimeStateModule()
   const run = await runWithWorkflowRuntimeEvent(workflowEvent, () => handle.run(
     payload,
     workflowRunId ? { id: workflowRunId } : {},

--- a/packages/agent/src/internal/workflow-portability.ts
+++ b/packages/agent/src/internal/workflow-portability.ts
@@ -17,6 +17,7 @@ export function cloneWorkflowJsonValue(value: unknown): unknown {
     if (!input || typeof input !== "object" || seen.has(input)) throw new TypeError("Agent Workflow inputs must contain only JSON-compatible values.")
     seen.add(input)
     try {
+      if (Reflect.ownKeys(input).some(key => typeof key === "symbol")) throw new TypeError("Agent Workflow inputs must contain only JSON-compatible values.")
       if (Array.isArray(input)) {
         if (input.length !== Object.keys(input).length) throw new TypeError("Agent Workflow inputs must contain only JSON-compatible values.")
         return Array.from({ length: input.length }, (_, index) => {

--- a/packages/agent/src/internal/workflow-portability.ts
+++ b/packages/agent/src/internal/workflow-portability.ts
@@ -8,10 +8,13 @@ export function workflowBytesToBase64(data: Uint8Array): string {
 
 const omittedWorkflowValue = Symbol("vitehub.agent.omitted-workflow-value")
 
-export function cloneWorkflowJsonValue(value: unknown): unknown {
+export function cloneWorkflowJsonValue(value: unknown, options: { omitUndefinedObjectProperties?: boolean } = {}): unknown {
   const seen = new WeakSet<object>()
   const clone = (input: unknown, objectProperty = false): unknown | typeof omittedWorkflowValue => {
-    if (input === undefined && objectProperty) return omittedWorkflowValue
+    if (input === undefined && objectProperty) {
+      if (options.omitUndefinedObjectProperties !== false) return omittedWorkflowValue
+      throw new TypeError("Agent Workflow inputs must contain only JSON-compatible values.")
+    }
     if (input === null || typeof input === "string" || typeof input === "boolean") return input
     if (typeof input === "number" && Number.isFinite(input) && !Object.is(input, -0)) return input
     if (!input || typeof input !== "object" || seen.has(input)) throw new TypeError("Agent Workflow inputs must contain only JSON-compatible values.")

--- a/packages/agent/src/internal/workflow-portability.ts
+++ b/packages/agent/src/internal/workflow-portability.ts
@@ -31,7 +31,9 @@ export function cloneWorkflowJsonValue(value: unknown): unknown {
       const output: Record<string, unknown> = {}
       for (const key of Object.keys(input)) {
         const item = clone((input as Record<string, unknown>)[key], true)
-        if (item !== omittedWorkflowValue) output[key] = item
+        if (item !== omittedWorkflowValue) {
+          Object.defineProperty(output, key, { configurable: true, enumerable: true, value: item, writable: true })
+        }
       }
       return output
     }

--- a/packages/agent/src/internal/workflow-portability.ts
+++ b/packages/agent/src/internal/workflow-portability.ts
@@ -5,3 +5,41 @@ export function workflowBytesToBase64(data: Uint8Array): string {
   }
   return btoa(binary)
 }
+
+const omittedWorkflowValue = Symbol("vitehub.agent.omitted-workflow-value")
+
+export function cloneWorkflowJsonValue(value: unknown): unknown {
+  const seen = new WeakSet<object>()
+  const clone = (input: unknown, objectProperty = false): unknown | typeof omittedWorkflowValue => {
+    if (input === undefined && objectProperty) return omittedWorkflowValue
+    if (input === null || typeof input === "string" || typeof input === "boolean") return input
+    if (typeof input === "number" && Number.isFinite(input) && !Object.is(input, -0)) return input
+    if (!input || typeof input !== "object" || seen.has(input)) throw new TypeError("Agent Workflow inputs must contain only JSON-compatible values.")
+    seen.add(input)
+    try {
+      if (Array.isArray(input)) {
+        if (input.length !== Object.keys(input).length) throw new TypeError("Agent Workflow inputs must contain only JSON-compatible values.")
+        return Array.from({ length: input.length }, (_, index) => {
+          if (!Object.hasOwn(input, index)) throw new TypeError("Agent Workflow inputs must contain only JSON-compatible values.")
+          const item = clone(input[index])
+          if (item === omittedWorkflowValue) throw new TypeError("Agent Workflow inputs must contain only JSON-compatible values.")
+          return item
+        })
+      }
+      const prototype = Object.getPrototypeOf(input)
+      if (prototype !== Object.prototype && prototype !== null) throw new TypeError("Agent Workflow inputs must contain only JSON-compatible values.")
+      const output: Record<string, unknown> = {}
+      for (const key of Object.keys(input)) {
+        const item = clone((input as Record<string, unknown>)[key], true)
+        if (item !== omittedWorkflowValue) output[key] = item
+      }
+      return output
+    }
+    finally {
+      seen.delete(input)
+    }
+  }
+  const cloned = clone(value)
+  if (cloned === omittedWorkflowValue) throw new TypeError("Agent Workflow inputs must contain only JSON-compatible values.")
+  return cloned
+}

--- a/packages/agent/src/internal/workflow-portability.ts
+++ b/packages/agent/src/internal/workflow-portability.ts
@@ -1,0 +1,7 @@
+export function workflowBytesToBase64(data: Uint8Array): string {
+  let binary = ""
+  for (let offset = 0; offset < data.length; offset += 0x8000) {
+    binary += String.fromCharCode(...data.subarray(offset, offset + 0x8000))
+  }
+  return btoa(binary)
+}

--- a/packages/agent/src/invoker.ts
+++ b/packages/agent/src/invoker.ts
@@ -186,7 +186,7 @@ export function portableResolvedAgentInvokerInput<CALL_OPTIONS>(input: AgentRunI
   return {
     ...input,
     context: {
-      ...context,
+      ...Object.fromEntries(Object.entries(context)),
       [agentActorContextKey]: portableInvoker,
       [agentInvokerContextKey]: portableInvoker,
     },

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -49,7 +49,6 @@ export type AgentWorkflowRunner<
   agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
-  options?: { output: "raw" },
 ) => Promise<Response | AgentRunResult | unknown>
 
 function agentRuntimeFromWorkflowProvider(provider: WorkflowProvider): AgentRuntimeName {
@@ -153,9 +152,10 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
   if (jsonResult !== unportableWorkflowValue) return jsonResult
   const agentResultKeys = ["artifacts", "finishReason", "raw", "text", "usage", "usageRecord", "warnings"]
   const providerResultKeys = ["_output", "content", "output", "provider", "steps", "totalUsage"]
+  const normalizedAgentResultKeys = ["finishReason", "raw", "text", "usage", "usageRecord", "warnings"]
   if (!result || typeof result !== "object" || !agentResultKeys.some(key => key in result)) unsupportedWorkflowResult()
   if (!Object.keys(result).every(key => agentResultKeys.includes(key) || providerResultKeys.includes(key))) unsupportedWorkflowResult()
-  if (!providerResultKeys.some(key => key in result)) unsupportedWorkflowResult()
+  if (!providerResultKeys.some(key => key in result) && !normalizedAgentResultKeys.every(key => Object.hasOwn(result, key))) unsupportedWorkflowResult()
   const projected = "raw" in result ? portableWorkflowValue(result) : portableWorkflowValue(toAgentRunResult(result))
   const jsonProjected = jsonWorkflowValue(projected)
   if (jsonProjected !== unportableWorkflowValue) return jsonProjected
@@ -203,6 +203,5 @@ export async function runAgentWorkflowDefinition<
     payload.resolvedInvoker
       ? restoreResolvedAgentInvokerInput((payload.input ?? {}) as AgentRunInput<CALL_OPTIONS>)
       : (payload.input ?? {}) as AgentRunInput<CALL_OPTIONS>,
-    { output: "raw" },
   ))
 }

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -68,6 +68,7 @@ function isJsonWorkflowValue(value: unknown, seen = new WeakSet<object>()): bool
   if (value === null || typeof value === "string" || typeof value === "boolean") return true
   if (typeof value === "number") return Number.isFinite(value) && !Object.is(value, -0)
   if (!value || typeof value !== "object" || seen.has(value)) return false
+  if (Reflect.ownKeys(value).some(key => typeof key === "symbol")) return false
   seen.add(value)
   let portable = false
   if (Array.isArray(value)) {
@@ -82,9 +83,10 @@ function isJsonWorkflowValue(value: unknown, seen = new WeakSet<object>()): bool
 }
 
 function jsonWorkflowValue(value: unknown): unknown | typeof unportableWorkflowValue {
-  if (!isJsonWorkflowValue(value)) return unportableWorkflowValue
   try {
-    const serialized = JSON.stringify(cloneWorkflowJsonValue(value))
+    const cloned = cloneWorkflowJsonValue(value)
+    if (!isJsonWorkflowValue(cloned)) return unportableWorkflowValue
+    const serialized = JSON.stringify(cloned)
     return serialized === undefined ? unportableWorkflowValue : JSON.parse(serialized)
   }
   catch {

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -152,6 +152,7 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
   const providerResultKeys = ["_output", "content", "output", "provider", "steps", "totalUsage"]
   if (!result || typeof result !== "object" || !agentResultKeys.some(key => key in result)) unsupportedWorkflowResult()
   if (!Object.keys(result).every(key => agentResultKeys.includes(key) || providerResultKeys.includes(key))) unsupportedWorkflowResult()
+  if (!providerResultKeys.some(key => key in result)) unsupportedWorkflowResult()
   const projected = "raw" in result ? portableWorkflowValue(result) : portableWorkflowValue(toAgentRunResult(result))
   const jsonProjected = jsonWorkflowValue(projected)
   if (jsonProjected !== unportableWorkflowValue) return jsonProjected

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -71,7 +71,7 @@ function workflowResultBase64(data: Uint8Array): string {
 }
 
 function isTextResponseMediaType(mediaType: string): boolean {
-  return mediaType.startsWith("text/")
+  return mediaType.toLowerCase().startsWith("text/")
     || /^(?:application\/(?:[^;]+\+)?(?:json|xml|yaml|javascript)|image\/svg\+xml)(?:;|$)/i.test(mediaType)
 }
 
@@ -106,7 +106,7 @@ function portableWorkflowValue(value: unknown, seen = new WeakMap<object, unknow
 
 async function portableWorkflowResult(result: unknown): Promise<unknown> {
   if (result instanceof Response) {
-    const headers = Object.fromEntries(result.headers)
+    const headers = Array.from(result.headers)
     const mediaType = result.headers.get("content-type") || "application/octet-stream"
     const bytes = new Uint8Array(await result.arrayBuffer())
     return {

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -85,6 +85,12 @@ function jsonWorkflowValue(value: unknown): unknown | typeof unportableWorkflowV
   }
 }
 
+function unsupportedWorkflowResult(): never {
+  const error = new TypeError("Agent Workflow results must contain only JSON-compatible values.") as TypeError & { isRetryable: false }
+  error.isRetryable = false
+  throw error
+}
+
 function isTextResponseMediaType(mediaType: string): boolean {
   return mediaType.toLowerCase().startsWith("text/")
     || /^(?:application\/(?:[^;]+\+)?(?:json|xml|yaml|javascript)|image\/svg\+xml)(?:;|$)/i.test(mediaType)
@@ -136,16 +142,14 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
   const jsonResult = jsonWorkflowValue(result)
   if (jsonResult !== unportableWorkflowValue) return jsonResult
   const agentResultKeys = ["artifacts", "finishReason", "raw", "text", "usage", "usageRecord", "warnings"]
-  if (!result || typeof result !== "object" || !agentResultKeys.some(key => key in result)) {
-    const error = new TypeError("Agent Workflow results must contain only JSON-compatible values.") as TypeError & { isRetryable: false }
-    error.isRetryable = false
-    throw error
-  }
+  if (!result || typeof result !== "object" || !agentResultKeys.some(key => key in result)) unsupportedWorkflowResult()
   const projected = "raw" in result ? portableWorkflowValue(result) : portableWorkflowValue(toAgentRunResult(result))
   const jsonProjected = jsonWorkflowValue(projected)
   if (jsonProjected !== unportableWorkflowValue) return jsonProjected
   const { raw: _raw, ...normalized } = toAgentRunResult(result)
-  return portableWorkflowValue(normalized)
+  const portable = portableWorkflowValue(normalized)
+  if (jsonWorkflowValue(portable) === unportableWorkflowValue) unsupportedWorkflowResult()
+  return portable
 }
 
 export async function runAgentWorkflowDefinition<

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -49,6 +49,7 @@ export type AgentWorkflowRunner<
   agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>,
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
+  options?: { output: "raw" },
 ) => Promise<Response | AgentRunResult | unknown>
 
 function agentRuntimeFromWorkflowProvider(provider: WorkflowProvider): AgentRuntimeName {
@@ -200,5 +201,6 @@ export async function runAgentWorkflowDefinition<
     payload.resolvedInvoker
       ? restoreResolvedAgentInvokerInput((payload.input ?? {}) as AgentRunInput<CALL_OPTIONS>)
       : (payload.input ?? {}) as AgentRunInput<CALL_OPTIONS>,
+    { output: "raw" },
   ))
 }

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -6,6 +6,7 @@ import { decodeColocatedAgentHome, withColocatedAgentHome } from "../internal/co
 import { decodeColocatedAgentSkills, withColocatedAgentSkills } from "../internal/colocated-agent-skills.ts"
 import { loadAgentWorkflowRuntimeStateModule } from "../internal/workflow-runtime-loaders.ts"
 import { restoreResolvedAgentInvokerInput } from "../invoker.ts"
+import { toAgentRunResult } from "../agent-output.ts"
 
 import type {
   AgentHostIdentity,
@@ -59,6 +60,16 @@ function waitUntil(promise: Promise<unknown>): void {
   void Promise.resolve(promise).catch(() => {})
 }
 
+function portableWorkflowResult(result: unknown): unknown {
+  try {
+    return structuredClone(result)
+  }
+  catch {
+    const { raw: _raw, ...normalized } = toAgentRunResult(result)
+    return structuredClone(normalized)
+  }
+}
+
 export async function runAgentWorkflowDefinition<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
@@ -86,11 +97,11 @@ export async function runAgentWorkflowDefinition<
     waitUntil,
   } as never)
 
-  return await runAgentInline(
+  return portableWorkflowResult(await runAgentInline(
     agent,
     runtimeContext,
     payload.resolvedInvoker
       ? restoreResolvedAgentInvokerInput((payload.input ?? {}) as AgentRunInput<CALL_OPTIONS>)
       : (payload.input ?? {}) as AgentRunInput<CALL_OPTIONS>,
-  )
+  ))
 }

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -5,7 +5,7 @@ import { workspaceAgentWithSourceRoot } from "../workspace-agent.ts"
 import { decodeColocatedAgentHome, withColocatedAgentHome } from "../internal/colocated-agent-home.ts"
 import { decodeColocatedAgentSkills, withColocatedAgentSkills } from "../internal/colocated-agent-skills.ts"
 import { loadAgentWorkflowRuntimeStateModule } from "../internal/workflow-runtime-loaders.ts"
-import { workflowBytesToBase64 } from "../internal/workflow-portability.ts"
+import { cloneWorkflowJsonValue, workflowBytesToBase64 } from "../internal/workflow-portability.ts"
 import { restoreResolvedAgentInvokerInput } from "../invoker.ts"
 import { toAgentRunResult } from "../agent-output.ts"
 
@@ -83,7 +83,7 @@ function isJsonWorkflowValue(value: unknown, seen = new WeakSet<object>()): bool
 function jsonWorkflowValue(value: unknown): unknown | typeof unportableWorkflowValue {
   if (!isJsonWorkflowValue(value)) return unportableWorkflowValue
   try {
-    const serialized = JSON.stringify(value)
+    const serialized = JSON.stringify(cloneWorkflowJsonValue(value))
     return serialized === undefined ? unportableWorkflowValue : JSON.parse(serialized)
   }
   catch {

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -72,7 +72,7 @@ function isJsonWorkflowValue(value: unknown, seen = new WeakSet<object>()): bool
   if (Array.isArray(value)) {
     portable = value.length === Object.keys(value).length && value.every(item => item !== undefined && isJsonWorkflowValue(item, seen))
   }
-  else if (!(value instanceof Map || value instanceof Set || value instanceof ArrayBuffer || ArrayBuffer.isView(value) || value instanceof Date)) {
+  else if (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null) {
     portable = Object.values(value).every(item => item !== undefined && isJsonWorkflowValue(item, seen))
   }
   seen.delete(value)

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -63,20 +63,40 @@ function waitUntil(promise: Promise<unknown>): void {
 
 const unportableWorkflowValue = Symbol("vitehub.agent.unportable-workflow-value")
 
+function isJsonWorkflowValue(value: unknown, seen = new WeakSet<object>()): boolean {
+  if (value === null || typeof value === "string" || typeof value === "boolean") return true
+  if (typeof value === "number") return Number.isFinite(value)
+  if (!value || typeof value !== "object" || seen.has(value)) return false
+  seen.add(value)
+  if (Array.isArray(value)) return value.every(item => item === undefined || isJsonWorkflowValue(item, seen))
+  if (value instanceof Map || value instanceof Set || value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return false
+  if (value instanceof Date) return Number.isFinite(value.getTime())
+  return Object.values(value).every(item => item === undefined || isJsonWorkflowValue(item, seen))
+}
+
+function jsonWorkflowValue(value: unknown): unknown | typeof unportableWorkflowValue {
+  if (!isJsonWorkflowValue(value)) return unportableWorkflowValue
+  try {
+    const serialized = JSON.stringify(value)
+    return serialized === undefined ? unportableWorkflowValue : JSON.parse(serialized)
+  }
+  catch {
+    return unportableWorkflowValue
+  }
+}
+
 function isTextResponseMediaType(mediaType: string): boolean {
   return mediaType.toLowerCase().startsWith("text/")
     || /^(?:application\/(?:[^;]+\+)?(?:json|xml|yaml|javascript)|image\/svg\+xml)(?:;|$)/i.test(mediaType)
 }
 
 function portableWorkflowValue(value: unknown, seen = new WeakMap<object, unknown>()): unknown {
-  try {
-    return structuredClone(value)
-  }
-  catch {}
-
+  if (value === null || typeof value === "string" || typeof value === "boolean") return value
+  if (typeof value === "number") return Number.isFinite(value) ? value : unportableWorkflowValue
   if (!value || typeof value !== "object") return unportableWorkflowValue
-  const existing = seen.get(value)
-  if (existing) return existing
+  if (value instanceof Map || value instanceof Set || value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return unportableWorkflowValue
+  if (value instanceof Date) return Number.isFinite(value.getTime()) ? value.toISOString() : unportableWorkflowValue
+  if (seen.has(value)) return unportableWorkflowValue
   if (Array.isArray(value)) {
     const projected: unknown[] = []
     seen.set(value, projected)
@@ -84,17 +104,18 @@ function portableWorkflowValue(value: unknown, seen = new WeakMap<object, unknow
       const portable = portableWorkflowValue(item, seen)
       projected.push(portable === unportableWorkflowValue ? undefined : portable)
     }
+    seen.delete(value)
     return projected
   }
 
   const projected: Record<string, unknown> = {}
   seen.set(value, projected)
   for (const [key, item] of Object.entries(value)) {
-    if (key === "raw") continue
     const portable = portableWorkflowValue(item, seen)
     if (portable !== unportableWorkflowValue) projected[key] = portable
   }
-  return projected
+  seen.delete(value)
+  return Object.keys(projected).length || Object.keys(value).length === 0 ? projected : unportableWorkflowValue
 }
 
 async function portableWorkflowResult(result: unknown): Promise<unknown> {
@@ -112,13 +133,13 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
       ...(isTextResponseMediaType(mediaType) ? { text: new TextDecoder().decode(bytes) } : {}),
     } satisfies AgentRunResult
   }
-  try {
-    return structuredClone(result)
-  }
-  catch {
-    const { raw: _raw, ...normalized } = toAgentRunResult(result)
-    return portableWorkflowValue(normalized)
-  }
+  const jsonResult = jsonWorkflowValue(result)
+  if (jsonResult !== unportableWorkflowValue) return jsonResult
+  const projected = portableWorkflowValue(result)
+  const jsonProjected = jsonWorkflowValue(projected)
+  if (jsonProjected !== unportableWorkflowValue) return jsonProjected
+  const { raw: _raw, ...normalized } = toAgentRunResult(result)
+  return portableWorkflowValue(normalized)
 }
 
 export async function runAgentWorkflowDefinition<

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -151,8 +151,7 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
   const agentResultKeys = ["artifacts", "finishReason", "raw", "text", "usage", "usageRecord", "warnings"]
   const providerResultKeys = ["_output", "content", "output", "provider", "steps", "totalUsage"]
   if (!result || typeof result !== "object" || !agentResultKeys.some(key => key in result)) unsupportedWorkflowResult()
-  const prototype = Object.getPrototypeOf(result)
-  if ((prototype === Object.prototype || prototype === null) && !Object.keys(result).every(key => agentResultKeys.includes(key) || providerResultKeys.includes(key))) unsupportedWorkflowResult()
+  if (!Object.keys(result).every(key => agentResultKeys.includes(key) || providerResultKeys.includes(key))) unsupportedWorkflowResult()
   const projected = "raw" in result ? portableWorkflowValue(result) : portableWorkflowValue(toAgentRunResult(result))
   const jsonProjected = jsonWorkflowValue(projected)
   if (jsonProjected !== unportableWorkflowValue) return jsonProjected

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -84,7 +84,7 @@ function isJsonWorkflowValue(value: unknown, seen = new WeakSet<object>()): bool
 
 function jsonWorkflowValue(value: unknown): unknown | typeof unportableWorkflowValue {
   try {
-    const cloned = cloneWorkflowJsonValue(value)
+    const cloned = cloneWorkflowJsonValue(value, { omitUndefinedObjectProperties: false })
     if (!isJsonWorkflowValue(cloned)) return unportableWorkflowValue
     const serialized = JSON.stringify(cloned)
     return serialized === undefined ? unportableWorkflowValue : JSON.parse(serialized)

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -70,7 +70,7 @@ function isJsonWorkflowValue(value: unknown, seen = new WeakSet<object>()): bool
   seen.add(value)
   if (Array.isArray(value)) return value.every(item => item === undefined || isJsonWorkflowValue(item, seen))
   if (value instanceof Map || value instanceof Set || value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return false
-  if (value instanceof Date) return Number.isFinite(value.getTime())
+  if (value instanceof Date) return false
   return Object.values(value).every(item => item === undefined || isJsonWorkflowValue(item, seen))
 }
 
@@ -95,7 +95,7 @@ function portableWorkflowValue(value: unknown, seen = new WeakMap<object, unknow
   if (typeof value === "number") return Number.isFinite(value) ? value : unportableWorkflowValue
   if (!value || typeof value !== "object") return unportableWorkflowValue
   if (value instanceof Map || value instanceof Set || value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return unportableWorkflowValue
-  if (value instanceof Date) return Number.isFinite(value.getTime()) ? value.toISOString() : unportableWorkflowValue
+  if (value instanceof Date) return unportableWorkflowValue
   if (seen.has(value)) return unportableWorkflowValue
   if (Array.isArray(value)) {
     const projected: unknown[] = []
@@ -135,7 +135,13 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
   }
   const jsonResult = jsonWorkflowValue(result)
   if (jsonResult !== unportableWorkflowValue) return jsonResult
-  const projected = portableWorkflowValue(result)
+  const agentResultKeys = ["artifacts", "finishReason", "raw", "text", "usage", "usageRecord", "warnings"]
+  if (!result || typeof result !== "object" || !agentResultKeys.some(key => key in result)) {
+    const error = new TypeError("Agent Workflow results must contain only JSON-compatible values.") as TypeError & { isRetryable: false }
+    error.isRetryable = false
+    throw error
+  }
+  const projected = "raw" in result ? portableWorkflowValue(result) : portableWorkflowValue(toAgentRunResult(result))
   const jsonProjected = jsonWorkflowValue(projected)
   if (jsonProjected !== unportableWorkflowValue) return jsonProjected
   const { raw: _raw, ...normalized } = toAgentRunResult(result)

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -65,7 +65,7 @@ const unportableWorkflowValue = Symbol("vitehub.agent.unportable-workflow-value"
 
 function isJsonWorkflowValue(value: unknown, seen = new WeakSet<object>()): boolean {
   if (value === null || typeof value === "string" || typeof value === "boolean") return true
-  if (typeof value === "number") return Number.isFinite(value)
+  if (typeof value === "number") return Number.isFinite(value) && !Object.is(value, -0)
   if (!value || typeof value !== "object" || seen.has(value)) return false
   seen.add(value)
   let portable = false
@@ -104,7 +104,7 @@ function isTextResponseMediaType(mediaType: string): boolean {
 
 function portableWorkflowValue(value: unknown, seen = new WeakMap<object, unknown>()): unknown {
   if (value === null || typeof value === "string" || typeof value === "boolean") return value
-  if (typeof value === "number") return Number.isFinite(value) ? value : unportableWorkflowValue
+  if (typeof value === "number") return Number.isFinite(value) && !Object.is(value, -0) ? value : unportableWorkflowValue
   if (!value || typeof value !== "object") return unportableWorkflowValue
   if (value instanceof Map || value instanceof Set || value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return unportableWorkflowValue
   if (value instanceof Date) return unportableWorkflowValue

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -148,7 +148,10 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
   const jsonResult = jsonWorkflowValue(result)
   if (jsonResult !== unportableWorkflowValue) return jsonResult
   const agentResultKeys = ["artifacts", "finishReason", "raw", "text", "usage", "usageRecord", "warnings"]
+  const providerResultKeys = ["_output", "content", "output", "provider", "steps", "totalUsage"]
   if (!result || typeof result !== "object" || !agentResultKeys.some(key => key in result)) unsupportedWorkflowResult()
+  const prototype = Object.getPrototypeOf(result)
+  if ((prototype === Object.prototype || prototype === null) && !Object.keys(result).every(key => agentResultKeys.includes(key) || providerResultKeys.includes(key))) unsupportedWorkflowResult()
   const projected = "raw" in result ? portableWorkflowValue(result) : portableWorkflowValue(toAgentRunResult(result))
   const jsonProjected = jsonWorkflowValue(projected)
   if (jsonProjected !== unportableWorkflowValue) return jsonProjected

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -68,10 +68,15 @@ function isJsonWorkflowValue(value: unknown, seen = new WeakSet<object>()): bool
   if (typeof value === "number") return Number.isFinite(value)
   if (!value || typeof value !== "object" || seen.has(value)) return false
   seen.add(value)
-  if (Array.isArray(value)) return value.every(item => item === undefined || isJsonWorkflowValue(item, seen))
-  if (value instanceof Map || value instanceof Set || value instanceof ArrayBuffer || ArrayBuffer.isView(value)) return false
-  if (value instanceof Date) return false
-  return Object.values(value).every(item => item === undefined || isJsonWorkflowValue(item, seen))
+  let portable = false
+  if (Array.isArray(value)) {
+    portable = value.length === Object.keys(value).length && value.every(item => item !== undefined && isJsonWorkflowValue(item, seen))
+  }
+  else if (!(value instanceof Map || value instanceof Set || value instanceof ArrayBuffer || ArrayBuffer.isView(value) || value instanceof Date)) {
+    portable = Object.values(value).every(item => item !== undefined && isJsonWorkflowValue(item, seen))
+  }
+  seen.delete(value)
+  return portable
 }
 
 function jsonWorkflowValue(value: unknown): unknown | typeof unportableWorkflowValue {

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -5,6 +5,7 @@ import { workspaceAgentWithSourceRoot } from "../workspace-agent.ts"
 import { decodeColocatedAgentHome, withColocatedAgentHome } from "../internal/colocated-agent-home.ts"
 import { decodeColocatedAgentSkills, withColocatedAgentSkills } from "../internal/colocated-agent-skills.ts"
 import { loadAgentWorkflowRuntimeStateModule } from "../internal/workflow-runtime-loaders.ts"
+import { workflowBytesToBase64 } from "../internal/workflow-portability.ts"
 import { restoreResolvedAgentInvokerInput } from "../invoker.ts"
 import { toAgentRunResult } from "../agent-output.ts"
 
@@ -62,14 +63,6 @@ function waitUntil(promise: Promise<unknown>): void {
 
 const unportableWorkflowValue = Symbol("vitehub.agent.unportable-workflow-value")
 
-function workflowResultBase64(data: Uint8Array): string {
-  let binary = ""
-  for (let offset = 0; offset < data.length; offset += 0x8000) {
-    binary += String.fromCharCode(...data.subarray(offset, offset + 0x8000))
-  }
-  return btoa(binary)
-}
-
 function isTextResponseMediaType(mediaType: string): boolean {
   return mediaType.toLowerCase().startsWith("text/")
     || /^(?:application\/(?:[^;]+\+)?(?:json|xml|yaml|javascript)|image\/svg\+xml)(?:;|$)/i.test(mediaType)
@@ -111,7 +104,7 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
     const bytes = new Uint8Array(await result.arrayBuffer())
     return {
       raw: {
-        body: { data: workflowResultBase64(bytes), encoding: "base64", mediaType },
+        body: { data: workflowBytesToBase64(bytes), encoding: "base64", mediaType },
         headers,
         status: result.status,
         statusText: result.statusText,

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -131,6 +131,7 @@ function portableWorkflowValue(value: unknown, seen = new WeakMap<object, unknow
 }
 
 async function portableWorkflowResult(result: unknown): Promise<unknown> {
+  try {
   if (result instanceof Response) {
     const headers = Array.from(result.headers)
     const mediaType = result.headers.get("content-type") || "application/octet-stream"
@@ -159,6 +160,11 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
   const portable = portableWorkflowValue(normalized)
   if (jsonWorkflowValue(portable) === unportableWorkflowValue) unsupportedWorkflowResult()
   return portable
+  }
+  catch (error) {
+    if (error && typeof error === "object" && (error as { isRetryable?: unknown }).isRetryable === false) throw error
+    unsupportedWorkflowResult()
+  }
 }
 
 export async function runAgentWorkflowDefinition<

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -70,7 +70,8 @@ function isJsonWorkflowValue(value: unknown, seen = new WeakSet<object>()): bool
   seen.add(value)
   let portable = false
   if (Array.isArray(value)) {
-    portable = value.length === Object.keys(value).length && value.every(item => item !== undefined && isJsonWorkflowValue(item, seen))
+    portable = value.length === Object.keys(value).length
+      && Array.from({ length: value.length }, (_, index) => Object.hasOwn(value, index) && value[index] !== undefined && isJsonWorkflowValue(value[index], seen)).every(Boolean)
   }
   else if (Object.getPrototypeOf(value) === Object.prototype || Object.getPrototypeOf(value) === null) {
     portable = Object.values(value).every(item => item !== undefined && isJsonWorkflowValue(item, seen))

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -62,6 +62,19 @@ function waitUntil(promise: Promise<unknown>): void {
 
 const unportableWorkflowValue = Symbol("vitehub.agent.unportable-workflow-value")
 
+function workflowResultBase64(data: Uint8Array): string {
+  let binary = ""
+  for (let offset = 0; offset < data.length; offset += 0x8000) {
+    binary += String.fromCharCode(...data.subarray(offset, offset + 0x8000))
+  }
+  return btoa(binary)
+}
+
+function isTextResponseMediaType(mediaType: string): boolean {
+  return mediaType.startsWith("text/")
+    || /^(?:application\/(?:[^;]+\+)?(?:json|xml|yaml|javascript)|image\/svg\+xml)(?:;|$)/i.test(mediaType)
+}
+
 function portableWorkflowValue(value: unknown, seen = new WeakMap<object, unknown>()): unknown {
   try {
     return structuredClone(value)
@@ -93,14 +106,17 @@ function portableWorkflowValue(value: unknown, seen = new WeakMap<object, unknow
 
 async function portableWorkflowResult(result: unknown): Promise<unknown> {
   if (result instanceof Response) {
-    const text = await result.text()
+    const headers = Object.fromEntries(result.headers)
+    const mediaType = result.headers.get("content-type") || "application/octet-stream"
+    const bytes = new Uint8Array(await result.arrayBuffer())
     return {
       raw: {
-        headers: Object.fromEntries(result.headers),
+        body: { data: workflowResultBase64(bytes), encoding: "base64", mediaType },
+        headers,
         status: result.status,
         statusText: result.statusText,
       },
-      text,
+      ...(isTextResponseMediaType(mediaType) ? { text: new TextDecoder().decode(bytes) } : {}),
     } satisfies AgentRunResult
   }
   try {

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -60,13 +60,55 @@ function waitUntil(promise: Promise<unknown>): void {
   void Promise.resolve(promise).catch(() => {})
 }
 
-function portableWorkflowResult(result: unknown): unknown {
+const unportableWorkflowValue = Symbol("vitehub.agent.unportable-workflow-value")
+
+function portableWorkflowValue(value: unknown, seen = new WeakMap<object, unknown>()): unknown {
+  try {
+    return structuredClone(value)
+  }
+  catch {}
+
+  if (!value || typeof value !== "object") return unportableWorkflowValue
+  const existing = seen.get(value)
+  if (existing) return existing
+  if (Array.isArray(value)) {
+    const projected: unknown[] = []
+    seen.set(value, projected)
+    for (const item of value) {
+      const portable = portableWorkflowValue(item, seen)
+      projected.push(portable === unportableWorkflowValue ? undefined : portable)
+    }
+    return projected
+  }
+
+  const projected: Record<string, unknown> = {}
+  seen.set(value, projected)
+  for (const [key, item] of Object.entries(value)) {
+    if (key === "raw") continue
+    const portable = portableWorkflowValue(item, seen)
+    if (portable !== unportableWorkflowValue) projected[key] = portable
+  }
+  return projected
+}
+
+async function portableWorkflowResult(result: unknown): Promise<unknown> {
+  if (result instanceof Response) {
+    const text = await result.text()
+    return {
+      raw: {
+        headers: Object.fromEntries(result.headers),
+        status: result.status,
+        statusText: result.statusText,
+      },
+      text,
+    } satisfies AgentRunResult
+  }
   try {
     return structuredClone(result)
   }
   catch {
     const { raw: _raw, ...normalized } = toAgentRunResult(result)
-    return structuredClone(normalized)
+    return portableWorkflowValue(normalized)
   }
 }
 
@@ -97,7 +139,7 @@ export async function runAgentWorkflowDefinition<
     waitUntil,
   } as never)
 
-  return portableWorkflowResult(await runAgentInline(
+  return await portableWorkflowResult(await runAgentInline(
     agent,
     runtimeContext,
     payload.resolvedInvoker

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -5908,7 +5908,7 @@ describe("server helpers", () => {
       await vi.waitFor(() => expect(run).toHaveBeenCalledOnce())
       releaseRun()
       await vi.waitFor(async () => {
-        await expect(getWorkflowRun("support-agent", "vitehub-invalid-9c275643d82405183e9293c71c825199e9297cba8a1fa1c92d6067b1dbbd0df7")).resolves.toMatchObject({
+        await expect(getWorkflowRun("support-agent", "github:delivery-workflow")).resolves.toMatchObject({
           result: "accepted github delivery",
           status: "completed",
         })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -9508,7 +9508,7 @@ describe("server helpers", () => {
       await vi.waitFor(() => {
         expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "Durable reply" })
       })
-      expect(observedTimeout).toBeUndefined()
+      expect(observedTimeout).toBe(60_000)
     }
     finally {
       release()

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -5905,6 +5905,7 @@ describe("server helpers", () => {
       expect(response.status).toBe(200)
       expect(json).toEqual({ accepted: true, ok: true })
       await Promise.all(waitUntilTasks)
+      await vi.waitFor(() => expect(run).toHaveBeenCalledOnce())
       releaseRun()
       await vi.waitFor(async () => {
         await expect(getWorkflowRun("support-agent", "vitehub-invalid-9c275643d82405183e9293c71c825199e9297cba8a1fa1c92d6067b1dbbd0df7")).resolves.toMatchObject({
@@ -5912,7 +5913,6 @@ describe("server helpers", () => {
           status: "completed",
         })
       })
-      expect(run).toHaveBeenCalledOnce()
     }
     finally {
       resetWorkflowRuntime()

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -5907,7 +5907,7 @@ describe("server helpers", () => {
       await Promise.all(waitUntilTasks)
       releaseRun()
       await vi.waitFor(async () => {
-        await expect(getWorkflowRun("support-agent", "github:delivery-workflow")).resolves.toMatchObject({
+        await expect(getWorkflowRun("support-agent", "vitehub-invalid-9c275643d82405183e9293c71c825199e9297cba8a1fa1c92d6067b1dbbd0df7")).resolves.toMatchObject({
           result: "accepted github delivery",
           status: "completed",
         })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -9508,7 +9508,7 @@ describe("server helpers", () => {
       await vi.waitFor(() => {
         expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "Durable reply" })
       })
-      expect(observedTimeout).toBe(60_000)
+      expect(observedTimeout).toBeUndefined()
     }
     finally {
       release()

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10668,8 +10668,6 @@ describe("agent message protocol", () => {
       const { getWorkflowRun } = await import("@vite-hub/workflow")
       const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
       const waitUntilTasks: Array<Promise<unknown>> = []
-      let resolveRuntimeConfig: unknown
-      let runtimeConfig: unknown
       setWorkflowRuntimeConfig({ provider: "vercel" })
 
       const agent = defineAgent({
@@ -11688,6 +11686,8 @@ describe("agent message protocol", () => {
       const { getWorkflowRun } = await import("@vite-hub/workflow")
       const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
       const waitUntilTasks: Array<Promise<unknown>> = []
+      let resolveRuntimeConfig: unknown
+      let runtimeConfig: unknown
       setWorkflowRuntimeConfig({ provider: "vercel" })
 
       const agent = {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10825,6 +10825,7 @@ describe("agent message protocol", () => {
             { fetchData: () => new Uint8Array([1, 2, 3]), mediaType: "image/jpeg", type: "image" },
             { data: new Blob([new Uint8Array([4, 5, 6])]), mediaType: "audio/mpeg", type: "audio" },
             { data: new Uint8Array([7, 8, 9]).buffer, mediaType: "application/pdf", type: "file" },
+            { data: new Uint8Array([10, 11, 12]), mediaType: "text/plain", type: "file" },
           ],
           role: "user",
         },
@@ -10833,9 +10834,10 @@ describe("agent message protocol", () => {
       await Promise.all(waitUntilTasks)
       await expect(getWorkflowRun("portable-attachments", run.id)).resolves.toMatchObject({
         result: [
-          { data: "AQID", mediaType: "image/jpeg", type: "image" },
-          { data: "BAUG", mediaType: "audio/mpeg", type: "audio" },
-          { data: "BwgJ", mediaType: "application/pdf", type: "file" },
+          { data: "data:image/jpeg;base64,AQID", mediaType: "image/jpeg", type: "image" },
+          { data: "data:audio/mpeg;base64,BAUG", mediaType: "audio/mpeg", type: "audio" },
+          { data: "data:application/pdf;base64,BwgJ", mediaType: "application/pdf", type: "file" },
+          { data: "data:text/plain;base64,CgsM", mediaType: "text/plain", type: "file" },
         ],
         status: "completed",
       })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10839,6 +10839,16 @@ describe("agent message protocol", () => {
       }, async () => [undefined])).rejects.toMatchObject({ isRetryable: false })
     })
 
+    it("rejects custom output instances with non-JSON prototypes", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "prototype-result",
+        name: "prototype-result",
+        payload: {},
+        provider: "vercel",
+      }, async () => /portable/)).rejects.toMatchObject({ isRetryable: false })
+    })
+
     it("serializes Response results before Workflow completion", async () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11694,6 +11694,7 @@ describe("agent message protocol", () => {
           return {
             async generate({ runtime }) {
               return {
+                provider: "test",
                 raw: {
                   resolveRuntimeConfig: context.runtimeConfig,
                   runtimeConfig: runtime.runtimeConfig,

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11686,23 +11686,18 @@ describe("agent message protocol", () => {
       const { getWorkflowRun } = await import("@vite-hub/workflow")
       const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
       const waitUntilTasks: Array<Promise<unknown>> = []
-      let resolveRuntimeConfig: unknown
       let runtimeConfig: unknown
       setWorkflowRuntimeConfig({ provider: "vercel" })
 
-      const agent = {
-        runtime: workflow("configured-agent"),
-        async resolve(context) {
-          resolveRuntimeConfig = context.runtimeConfig
-          return {
-            async generate({ runtime }) {
-              runtimeConfig = runtime.runtimeConfig
-              return "configured"
-            },
-            name: "configured",
-          }
+      const agent = defineAgent({
+        driver: {
+          run({ runtime }) {
+            runtimeConfig = runtime.runtimeConfig
+            return "configured"
+          },
         },
-      } as ReturnType<typeof defineAgent>
+        runtime: workflow("configured-agent"),
+      })
       const run = await runAgent(agent, {
         memo: vi.fn(),
         runtime: "vercel",
@@ -11715,7 +11710,6 @@ describe("agent message protocol", () => {
         result: "configured",
         status: "completed",
       })
-      expect(resolveRuntimeConfig).toEqual({ region: "iad" })
       expect(runtimeConfig).toEqual({ region: "iad" })
     })
 

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10668,6 +10668,8 @@ describe("agent message protocol", () => {
       const { getWorkflowRun } = await import("@vite-hub/workflow")
       const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
       const waitUntilTasks: Array<Promise<unknown>> = []
+      let resolveRuntimeConfig: unknown
+      let runtimeConfig: unknown
       setWorkflowRuntimeConfig({ provider: "vercel" })
 
       const agent = defineAgent({
@@ -11691,15 +11693,11 @@ describe("agent message protocol", () => {
       const agent = {
         runtime: workflow("configured-agent"),
         async resolve(context) {
+          resolveRuntimeConfig = context.runtimeConfig
           return {
             async generate({ runtime }) {
-              return {
-                provider: "test",
-                raw: {
-                  resolveRuntimeConfig: context.runtimeConfig,
-                  runtimeConfig: runtime.runtimeConfig,
-                },
-              }
+              runtimeConfig = runtime.runtimeConfig
+              return "configured"
             },
             name: "configured",
           }
@@ -11714,16 +11712,11 @@ describe("agent message protocol", () => {
 
       await Promise.all(waitUntilTasks)
       await expect(getWorkflowRun("configured-agent", run.id)).resolves.toMatchObject({
-        result: {
-          raw: {
-            raw: {
-              resolveRuntimeConfig: { region: "iad" },
-              runtimeConfig: { region: "iad" },
-            },
-          },
-        },
+        result: "configured",
         status: "completed",
       })
+      expect(resolveRuntimeConfig).toEqual({ region: "iad" })
+      expect(runtimeConfig).toEqual({ region: "iad" })
     })
 
     it("reuses generated workflow definitions across equivalent agent instances", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10866,6 +10866,19 @@ describe("agent message protocol", () => {
       })
     })
 
+    it("does not execute custom toJSON hooks in Workflow results", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const result = Object.defineProperty({ score: 1 }, "toJSON", {
+        value: () => ({ score: 2 }),
+      })
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "custom-json-result",
+        name: "custom-json-result",
+        payload: {},
+        provider: "vercel",
+      }, async () => result)).resolves.toEqual({ score: 1 })
+    })
+
     it("rejects undefined array entries that JSON would change", async () => {
       const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
       await expect(runAgentWorkflowDefinition({} as never, {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10753,7 +10753,12 @@ describe("agent message protocol", () => {
       setWorkflowRuntimeConfig({ provider: "vercel" })
 
       const agent = defineAgent({
-        driver: { run: () => ({ provider: { request: () => "raw" }, text: "portable text" }) },
+        driver: { run: () => ({
+          provider: { request: () => "raw" },
+          text: "portable text",
+          usageRecord: { raw: { inspect: () => "provider usage" }, usage: { inputTokens: 3 } },
+          warnings: [{ inspect: () => "provider warning", message: "portable warning" }],
+        }) },
       })
       const run = await runAgent(agent, {
         agentIdentity: { name: "portable-result" },
@@ -10764,9 +10769,52 @@ describe("agent message protocol", () => {
 
       await Promise.all(waitUntilTasks)
       const completed = await getWorkflowRun("portable-result", run.id)
-      expect(completed).toMatchObject({ result: { text: "portable text" }, status: "completed" })
+      expect(completed).toMatchObject({
+        result: {
+          text: "portable text",
+          usageRecord: { usage: { inputTokens: 3 } },
+          warnings: [{ message: "portable warning" }],
+        },
+        status: "completed",
+      })
       expect(completed.result).not.toHaveProperty("provider")
+      expect(completed.result).not.toHaveProperty("usageRecord.raw")
       expect(() => structuredClone(completed.result)).not.toThrow()
+    })
+
+    it("serializes Response results before Workflow completion", async () => {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const agent = defineAgent({
+        driver: { run: () => new Response("portable response", {
+          headers: { "content-type": "text/plain", "x-agent": "portable" },
+          status: 202,
+          statusText: "Accepted",
+        }) },
+      })
+      const run = await runAgent(agent, {
+        agentIdentity: { name: "portable-response" },
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, { prompt: "hello" }) as { id: string }
+
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("portable-response", run.id)).resolves.toMatchObject({
+        result: {
+          raw: {
+            headers: { "content-type": "text/plain", "x-agent": "portable" },
+            status: 202,
+            statusText: "Accepted",
+          },
+          text: "portable response",
+        },
+        status: "completed",
+      })
     })
 
     it("preserves only the request URL across Agent Workflows", async () => {
@@ -11546,7 +11594,8 @@ describe("agent message protocol", () => {
       const { getWorkflowRun } = await import("@vite-hub/workflow")
       const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
       const waitUntilTasks: Array<Promise<unknown>> = []
-      const workflowRunId = "agent-3f69a017b830c1f1fff0bccb6bee512d714787164444d45f1a92c14b11a3ff37"
+      const workflowRunId = "vitehub-invalid-3f69a017b830c1f1fff0bccb6bee512d714787164444d45f1a92c14b11a3ff37"
+      let consumerRunId = "telegram:42:103"
       setWorkflowRuntimeConfig({ provider: "cloudflare" })
 
       const agent = defineAgent({
@@ -11556,7 +11605,7 @@ describe("agent message protocol", () => {
             message: {
               invoke: () => ({
                 input: { prompt: "hello" },
-                run: { origin: "telegram", runId: "telegram:42:103" },
+                run: { origin: "telegram", runId: consumerRunId },
               }),
             },
           },
@@ -11576,6 +11625,15 @@ describe("agent message protocol", () => {
         result: workflowRunId,
         status: "completed",
       })
+
+      consumerRunId = workflowRunId
+      const reservedRun = await runAgentTrigger(agent, {
+        memo: vi.fn(),
+        runtime: "cloudflare-agents",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, "telegram.message", {}) as { id: string }
+      expect(reservedRun.id).not.toBe(workflowRunId)
+      expect(reservedRun.id).toMatch(/^vitehub-invalid-[a-f0-9]{64}$/)
     })
 
     it("passes explicit Cloudflare env through workflow inline fallback", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10755,7 +10755,7 @@ describe("agent message protocol", () => {
       expect(() => structuredClone(completed.result)).not.toThrow()
     })
 
-    it("normalizes structured-cloneable results to the Workflow JSON contract", async () => {
+    it("rejects structured-cloneable results outside the Workflow JSON contract", async () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")
       const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
@@ -10767,7 +10767,7 @@ describe("agent message protocol", () => {
           bytes: new Uint8Array([1, 2]),
           count: 1n,
           metadata: new Map([["provider", "custom"]]),
-          text: "portable text",
+          score: 1,
         }) },
       })
       const run = await runAgent(agent, {
@@ -10779,9 +10779,27 @@ describe("agent message protocol", () => {
 
       await Promise.all(waitUntilTasks)
       await expect(getWorkflowRun("json-portable-result", run.id)).resolves.toMatchObject({
-        result: { text: "portable text" },
-        status: "completed",
+        status: "failed",
       })
+    })
+
+    it("rejects outputs whose JSON representation would change their declared type", async () => {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const agent = defineAgent({ driver: { run: () => ({ createdAt: new Date(0) }) } })
+      const run = await runAgent(agent, {
+        agentIdentity: { name: "typed-json-result" },
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, { prompt: "hello" }) as { id: string }
+
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("typed-json-result", run.id)).resolves.toMatchObject({ status: "failed" })
     })
 
     it("serializes Response results before Workflow completion", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11063,6 +11063,14 @@ describe("agent message protocol", () => {
       })).rejects.toThrow("Agent Workflow inputs must contain only JSON-compatible values.")
     })
 
+    it("preserves __proto__ as an own Workflow input property", async () => {
+      const { cloneWorkflowJsonValue } = await import("../src/internal/workflow-portability.ts")
+      const cloned = cloneWorkflowJsonValue(JSON.parse('{"__proto__":{"privileged":true}}')) as Record<string, unknown>
+      expect(Object.hasOwn(cloned, "__proto__")).toBe(true)
+      expect(Object.getPrototypeOf(cloned)).toBe(Object.prototype)
+      expect(cloned.__proto__).toEqual({ privileged: true })
+    })
+
     it("reconstructs Blob and Database tools inside required Workflows", async () => {
       const blobList = vi.fn(async () => ({ blobs: [{ pathname: "workflow/input.jpg" }] }))
       const dbSchema = vi.fn(async () => ({ meals: true }))

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10815,6 +10815,18 @@ describe("agent message protocol", () => {
       })
     })
 
+    it("rejects lossy custom outputs that share Agent result keys", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "custom-result",
+        name: "custom-result",
+        payload: {},
+        provider: "vercel",
+      }, async () => ({ samples: new Uint8Array([1, 2]), text: "portable text" }))).rejects.toMatchObject({
+        isRetryable: false,
+      })
+    })
+
     it("preserves repeated references in JSON-compatible outputs", async () => {
       const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
       const shared = { score: 1 }

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10718,33 +10718,6 @@ describe("agent message protocol", () => {
       })
     })
 
-    it("removes request timeouts from required Agent Workflow payloads", async () => {
-      const { defineAgent, runAgent } = await import("../src/index.ts")
-      const { requireAgentWorkflowContextKey } = await import("../src/internal/final-channel-output.ts")
-      const { getWorkflowRun } = await import("@vite-hub/workflow")
-      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
-      const waitUntilTasks: Array<Promise<unknown>> = []
-      setWorkflowRuntimeConfig({ provider: "vercel" })
-
-      const agent = defineAgent({ driver: { run: context => ({ timeout: context.input.timeout ?? null }) } })
-      const run = await runAgent(agent, {
-        agentIdentity: { name: "required-workflow-timeout" },
-        memo: vi.fn(),
-        runtime: "vercel",
-        waitUntil: promise => waitUntilTasks.push(promise),
-      }, {
-        context: { [requireAgentWorkflowContextKey]: true },
-        prompt: "hello",
-        timeout: 28_000,
-      }) as { id: string }
-
-      await Promise.all(waitUntilTasks)
-      await expect(getWorkflowRun("required-workflow-timeout", run.id)).resolves.toMatchObject({
-        result: { timeout: null },
-        status: "completed",
-      })
-    })
-
     it("normalizes noncloneable Agent results before Workflow completion", async () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10802,6 +10802,19 @@ describe("agent message protocol", () => {
       await expect(getWorkflowRun("typed-json-result", run.id)).resolves.toMatchObject({ status: "failed" })
     })
 
+    it("rejects Agent result envelopes with no portable fields", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "unsupported-result",
+        name: "unsupported-result",
+        payload: {},
+        provider: "vercel",
+      }, async () => ({ raw: new Map() }))).rejects.toMatchObject({
+        isRetryable: false,
+        message: "Agent Workflow results must contain only JSON-compatible values.",
+      })
+    })
+
     it("serializes Response results before Workflow completion", async () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10780,6 +10780,7 @@ describe("agent message protocol", () => {
       await expect(getWorkflowRun("portable-response", run.id)).resolves.toMatchObject({
         result: {
           raw: {
+            body: { data: "cG9ydGFibGUgcmVzcG9uc2U=", encoding: "base64", mediaType: "text/plain" },
             headers: { "content-type": "text/plain", "x-agent": "portable" },
             status: 202,
             statusText: "Accepted",
@@ -10788,6 +10789,40 @@ describe("agent message protocol", () => {
         },
         status: "completed",
       })
+    })
+
+    it("preserves binary Response bodies before Workflow completion", async () => {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const agent = defineAgent({
+        driver: { run: () => new Response(new Uint8Array([0xff, 0x00, 0x80]), {
+          headers: { "content-type": "image/png" },
+        }) },
+      })
+      const run = await runAgent(agent, {
+        agentIdentity: { name: "portable-binary-response" },
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, { prompt: "hello" }) as { id: string }
+
+      await Promise.all(waitUntilTasks)
+      const completed = await getWorkflowRun("portable-binary-response", run.id)
+      expect(completed).toMatchObject({
+        result: {
+          raw: {
+            body: { data: "/wCA", encoding: "base64", mediaType: "image/png" },
+            headers: { "content-type": "image/png" },
+            status: 200,
+          },
+        },
+        status: "completed",
+      })
+      expect(completed.result).not.toHaveProperty("text")
     })
 
     it("preserves only the request URL across Agent Workflows", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11689,15 +11689,18 @@ describe("agent message protocol", () => {
       let runtimeConfig: unknown
       setWorkflowRuntimeConfig({ provider: "vercel" })
 
-      const agent = defineAgent({
-        driver: {
-          run({ runtime }) {
-            runtimeConfig = runtime.runtimeConfig
-            return "configured"
-          },
+      const agent = {
+        async resolve(context) {
+          runtimeConfig = context.runtimeConfig
+          return {
+            async generate() {
+              return { finishReason: "stop", text: "configured", usage: {} }
+            },
+            name: "configured",
+          }
         },
         runtime: workflow("configured-agent"),
-      })
+      } as ReturnType<typeof defineAgent>
       const run = await runAgent(agent, {
         memo: vi.fn(),
         runtime: "vercel",
@@ -11707,7 +11710,7 @@ describe("agent message protocol", () => {
 
       await Promise.all(waitUntilTasks)
       await expect(getWorkflowRun("configured-agent", run.id)).resolves.toMatchObject({
-        result: "configured",
+        result: { text: "configured" },
         status: "completed",
       })
       expect(runtimeConfig).toEqual({ region: "iad" })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10839,6 +10839,18 @@ describe("agent message protocol", () => {
       }, async () => [undefined])).rejects.toMatchObject({ isRetryable: false })
     })
 
+    it("rejects sparse arrays whose custom properties mask missing indices", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const result = Array(1) as unknown[] & { note?: string }
+      result.note = "not an array entry"
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "sparse-result",
+        name: "sparse-result",
+        payload: {},
+        provider: "vercel",
+      }, async () => result)).rejects.toMatchObject({ isRetryable: false })
+    })
+
     it("rejects custom output instances with non-JSON prototypes", async () => {
       const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
       await expect(runAgentWorkflowDefinition({} as never, {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10851,6 +10851,16 @@ describe("agent message protocol", () => {
       }, async () => result)).rejects.toMatchObject({ isRetryable: false })
     })
 
+    it("rejects negative zero that JSON would change", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "negative-zero-result",
+        name: "negative-zero-result",
+        payload: {},
+        provider: "vercel",
+      }, async () => -0)).rejects.toMatchObject({ isRetryable: false })
+    })
+
     it("rejects custom output instances with non-JSON prototypes", async () => {
       const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
       await expect(runAgentWorkflowDefinition({} as never, {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10718,6 +10718,57 @@ describe("agent message protocol", () => {
       })
     })
 
+    it("removes request timeouts from required Agent Workflow payloads", async () => {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const { requireAgentWorkflowContextKey } = await import("../src/internal/final-channel-output.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const agent = defineAgent({ driver: { run: context => ({ timeout: context.input.timeout ?? null }) } })
+      const run = await runAgent(agent, {
+        agentIdentity: { name: "required-workflow-timeout" },
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, {
+        context: { [requireAgentWorkflowContextKey]: true },
+        prompt: "hello",
+        timeout: 28_000,
+      }) as { id: string }
+
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("required-workflow-timeout", run.id)).resolves.toMatchObject({
+        result: { timeout: null },
+        status: "completed",
+      })
+    })
+
+    it("normalizes noncloneable Agent results before Workflow completion", async () => {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const agent = defineAgent({
+        driver: { run: () => ({ provider: { request: () => "raw" }, text: "portable text" }) },
+      })
+      const run = await runAgent(agent, {
+        agentIdentity: { name: "portable-result" },
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, { prompt: "hello" }) as { id: string }
+
+      await Promise.all(waitUntilTasks)
+      const completed = await getWorkflowRun("portable-result", run.id)
+      expect(completed).toMatchObject({ result: { text: "portable text" }, status: "completed" })
+      expect(completed.result).not.toHaveProperty("provider")
+      expect(() => structuredClone(completed.result)).not.toThrow()
+    })
+
     it("preserves only the request URL across Agent Workflows", async () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")
@@ -10752,7 +10803,7 @@ describe("agent message protocol", () => {
       })
     })
 
-    it("materializes a lazy message attachment before Workflows", async () => {
+    it("serializes binary message attachments before Workflows", async () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")
       const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
@@ -10760,7 +10811,7 @@ describe("agent message protocol", () => {
       setWorkflowRuntimeConfig({ provider: "vercel" })
 
       const agent = defineAgent({
-        driver: { run: context => context.messages[0]?.parts[0] },
+        driver: { run: context => context.messages[0]?.parts },
       })
       const run = await runAgent(agent, {
         agentIdentity: { name: "portable-attachments" },
@@ -10770,18 +10821,22 @@ describe("agent message protocol", () => {
       }, {
         message: {
           id: "message-1",
-          parts: [{ fetchData: () => new Uint8Array([1, 2, 3]), mediaType: "image/jpeg", type: "image" }],
+          parts: [
+            { fetchData: () => new Uint8Array([1, 2, 3]), mediaType: "image/jpeg", type: "image" },
+            { data: new Blob([new Uint8Array([4, 5, 6])]), mediaType: "audio/mpeg", type: "audio" },
+            { data: new Uint8Array([7, 8, 9]).buffer, mediaType: "application/pdf", type: "file" },
+          ],
           role: "user",
         },
       }) as { id: string }
 
       await Promise.all(waitUntilTasks)
       await expect(getWorkflowRun("portable-attachments", run.id)).resolves.toMatchObject({
-        result: {
-          data: new Uint8Array([1, 2, 3]),
-          mediaType: "image/jpeg",
-          type: "image",
-        },
+        result: [
+          { data: "AQID", mediaType: "image/jpeg", type: "image" },
+          { data: "BAUG", mediaType: "audio/mpeg", type: "audio" },
+          { data: "BwgJ", mediaType: "application/pdf", type: "file" },
+        ],
         status: "completed",
       })
     })
@@ -11484,7 +11539,70 @@ describe("agent message protocol", () => {
       })
     })
 
-    it("passes Cloudflare env through workflow inline fallback", async () => {
+    it("maps invalid trigger run ids to deterministic Workflow ids", async () => {
+      const { defineAgent, runAgentTrigger, workflow } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      const workflowRunId = "agent-3f69a017b830c1f1fff0bccb6bee512d714787164444d45f1a92c14b11a3ff37"
+      setWorkflowRuntimeConfig({ provider: "cloudflare" })
+
+      const agent = defineAgent({
+        capabilities: [{
+          id: "telegram",
+          triggers: {
+            message: {
+              invoke: () => ({
+                input: { prompt: "hello" },
+                run: { origin: "telegram", runId: "telegram:42:103" },
+              }),
+            },
+          },
+        }],
+        driver: { run: context => context.run?.runId },
+        runtime: workflow("telegram-agent"),
+      })
+      const run = await runAgentTrigger(agent, {
+        memo: vi.fn(),
+        runtime: "cloudflare-agents",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, "telegram.message", {}) as { id: string }
+
+      expect(run.id).toBe(workflowRunId)
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("telegram-agent", workflowRunId)).resolves.toMatchObject({
+        result: workflowRunId,
+        status: "completed",
+      })
+    })
+
+    it("passes explicit Cloudflare env through workflow inline fallback", async () => {
+      const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "cloudflare" })
+
+      const agent = defineAgent({
+        runtime: workflow("explicit-cloudflare-env-agent"),
+        driver: { run: context => context.cloudflare?.env?.NUXT_SITE },
+      })
+      const run = await runAgent(agent, {
+        cloudflare: { env: { NUXT_SITE: "explicit.nuxt.com" } },
+        memo: vi.fn(),
+        runtime: "cloudflare-agents",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, {}) as { id: string }
+
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("explicit-cloudflare-env-agent", run.id)).resolves.toMatchObject({
+        result: "explicit.nuxt.com",
+        status: "completed",
+      })
+    })
+
+    it("passes the active Cloudflare env through workflow inline fallback", async () => {
+      const { runWithActiveCloudflareEnv } = await import("@vite-hub/internal/runtime/cloudflare-env")
       const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")
       const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
@@ -11495,21 +11613,22 @@ describe("agent message protocol", () => {
         runtime: workflow("cloudflare-agent"),
         driver: { run: context => context.cloudflare?.env?.NUXT_SITE },
       })
-      const run = await runAgent(agent, {
-        cloudflare: { env: { NUXT_SITE: "nuxt.com" } },
-        memo: vi.fn(),
-        runtime: "cloudflare-agents",
-        waitUntil: promise => waitUntilTasks.push(promise),
-      }, {}) as { id: string }
+      await runWithActiveCloudflareEnv({ NUXT_SITE: "nuxt.com" }, async () => {
+        const run = await runAgent(agent, {
+          memo: vi.fn(),
+          runtime: "cloudflare-agents",
+          waitUntil: promise => waitUntilTasks.push(promise),
+        }, {}) as { id: string }
 
-      expect(run).toMatchObject({
-        provider: "cloudflare",
-        status: "queued",
-      })
-      await Promise.all(waitUntilTasks)
-      await expect(getWorkflowRun("cloudflare-agent", run.id)).resolves.toMatchObject({
-        result: "nuxt.com",
-        status: "completed",
+        expect(run).toMatchObject({
+          provider: "cloudflare",
+          status: "queued",
+        })
+        await Promise.all(waitUntilTasks)
+        await expect(getWorkflowRun("cloudflare-agent", run.id)).resolves.toMatchObject({
+          result: "nuxt.com",
+          status: "completed",
+        })
       })
     })
   })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10827,6 +10827,20 @@ describe("agent message protocol", () => {
       })
     })
 
+    it("rejects lossy custom result instances that share Agent result keys", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      class CustomResult {
+        samples = new Uint8Array([1, 2])
+        text = "portable text"
+      }
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "custom-result-instance",
+        name: "custom-result-instance",
+        payload: {},
+        provider: "vercel",
+      }, async () => new CustomResult())).rejects.toMatchObject({ isRetryable: false })
+    })
+
     it("marks result property access failures as non-retryable", async () => {
       const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
       const result = Object.defineProperty({}, "value", { enumerable: true, get: () => { throw new Error("getter failed") } })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10755,6 +10755,35 @@ describe("agent message protocol", () => {
       expect(() => structuredClone(completed.result)).not.toThrow()
     })
 
+    it("normalizes structured-cloneable results to the Workflow JSON contract", async () => {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const { getWorkflowRun } = await import("@vite-hub/workflow")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      const waitUntilTasks: Array<Promise<unknown>> = []
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+
+      const agent = defineAgent({
+        driver: { run: () => ({
+          bytes: new Uint8Array([1, 2]),
+          count: 1n,
+          metadata: new Map([["provider", "custom"]]),
+          text: "portable text",
+        }) },
+      })
+      const run = await runAgent(agent, {
+        agentIdentity: { name: "json-portable-result" },
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: promise => waitUntilTasks.push(promise),
+      }, { prompt: "hello" }) as { id: string }
+
+      await Promise.all(waitUntilTasks)
+      await expect(getWorkflowRun("json-portable-result", run.id)).resolves.toMatchObject({
+        result: { text: "portable text" },
+        status: "completed",
+      })
+    })
+
     it("serializes Response results before Workflow completion", async () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10764,7 +10764,12 @@ describe("agent message protocol", () => {
 
       const agent = defineAgent({
         driver: { run: () => new Response("portable response", {
-          headers: { "content-type": "text/plain", "x-agent": "portable" },
+          headers: [
+            ["content-type", "Text/Plain"],
+            ["set-cookie", "first=one"],
+            ["set-cookie", "second=two"],
+            ["x-agent", "portable"],
+          ],
           status: 202,
           statusText: "Accepted",
         }) },
@@ -10780,8 +10785,13 @@ describe("agent message protocol", () => {
       await expect(getWorkflowRun("portable-response", run.id)).resolves.toMatchObject({
         result: {
           raw: {
-            body: { data: "cG9ydGFibGUgcmVzcG9uc2U=", encoding: "base64", mediaType: "text/plain" },
-            headers: { "content-type": "text/plain", "x-agent": "portable" },
+            body: { data: "cG9ydGFibGUgcmVzcG9uc2U=", encoding: "base64", mediaType: "Text/Plain" },
+            headers: [
+              ["content-type", "Text/Plain"],
+              ["set-cookie", "first=one"],
+              ["set-cookie", "second=two"],
+              ["x-agent", "portable"],
+            ],
             status: 202,
             statusText: "Accepted",
           },
@@ -10816,7 +10826,7 @@ describe("agent message protocol", () => {
         result: {
           raw: {
             body: { data: "/wCA", encoding: "base64", mediaType: "image/png" },
-            headers: { "content-type": "image/png" },
+            headers: [["content-type", "image/png"]],
             status: 200,
           },
         },

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10827,6 +10827,17 @@ describe("agent message protocol", () => {
       })
     })
 
+    it("marks result property access failures as non-retryable", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const result = Object.defineProperty({}, "value", { enumerable: true, get: () => { throw new Error("getter failed") } })
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "throwing-result",
+        name: "throwing-result",
+        payload: {},
+        provider: "cloudflare",
+      }, async () => result)).rejects.toMatchObject({ isRetryable: false })
+    })
+
     it("preserves repeated references in JSON-compatible outputs", async () => {
       const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
       const shared = { score: 1 }
@@ -11035,6 +11046,21 @@ describe("agent message protocol", () => {
         ],
         status: "completed",
       })
+    })
+
+    it("rejects non-JSON data in non-attachment message parts", async () => {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const { setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+      setWorkflowRuntimeConfig({ provider: "vercel" })
+      const agent = defineAgent({ driver: { run: () => "unused" } })
+      await expect(runAgent(agent, {
+        agentIdentity: { name: "portable-message-parts" },
+        memo: vi.fn(),
+        runtime: "vercel",
+        waitUntil: vi.fn(),
+      }, {
+        message: { parts: [{ data: 1n, type: "data" }], role: "user" } as never,
+      })).rejects.toThrow("Agent Workflow inputs must contain only JSON-compatible values.")
     })
 
     it("reconstructs Blob and Database tools inside required Workflows", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10815,6 +10815,30 @@ describe("agent message protocol", () => {
       })
     })
 
+    it("preserves repeated references in JSON-compatible outputs", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const shared = { score: 1 }
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "repeated-result",
+        name: "repeated-result",
+        payload: {},
+        provider: "vercel",
+      }, async () => ({ first: shared, second: shared }))).resolves.toEqual({
+        first: { score: 1 },
+        second: { score: 1 },
+      })
+    })
+
+    it("rejects undefined array entries that JSON would change", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "undefined-result",
+        name: "undefined-result",
+        payload: {},
+        provider: "vercel",
+      }, async () => [undefined])).rejects.toMatchObject({ isRetryable: false })
+    })
+
     it("serializes Response results before Workflow completion", async () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11709,7 +11709,7 @@ describe("agent message protocol", () => {
             message: {
               invoke: (_context, input: { text: string }) => ({
                 input: { prompt: input.text },
-                run: { origin: "portal", runId: "portal-run" },
+                run: { origin: "portal", runId: "portal:run" },
               }),
             },
           },
@@ -11724,12 +11724,12 @@ describe("agent message protocol", () => {
       }, "portal.message", { text: "hello" }) as { id: string }
 
       expect(run).toMatchObject({
-        id: "portal-run",
+        id: "portal:run",
         provider: "vercel",
         status: "queued",
       })
       await Promise.all(waitUntilTasks)
-      await expect(getWorkflowRun("portal-agent", "portal-run")).resolves.toMatchObject({
+      await expect(getWorkflowRun("portal-agent", "portal:run")).resolves.toMatchObject({
         result: "received hello",
         status: "completed",
       })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10827,6 +10827,18 @@ describe("agent message protocol", () => {
       })
     })
 
+    it("rejects lossy custom outputs containing only Agent result keys", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "custom-result-keys",
+        name: "custom-result-keys",
+        payload: {},
+        provider: "vercel",
+      }, async () => ({ raw: new Uint8Array([1]), text: "portable text" }))).rejects.toMatchObject({
+        isRetryable: false,
+      })
+    })
+
     it("rejects lossy custom result instances that share Agent result keys", async () => {
       const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
       class CustomResult {

--- a/packages/agent/test/test-runner.test.ts
+++ b/packages/agent/test/test-runner.test.ts
@@ -17,6 +17,7 @@ vi.mock("@vite-hub/workflow", () => ({
 
 vi.mock("@vite-hub/workflow/runtime/state", () => ({
   getInlineWorkflowDefinitions: vi.fn(() => new Map()),
+  getWorkflowRuntimeConfig: vi.fn(() => undefined),
   getWorkflowRuntimeRegistry: vi.fn(() => undefined),
   runWithWorkflowRuntimeEvent: vi.fn((_event, callback) => callback()),
 }))

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -269,9 +269,9 @@ describe("agent public types", () => {
 
     expectTypeOf(result).toEqualTypeOf<Promise<Response | { summary: string, title: string }>>()
     expectTypeOf(rawResult).toEqualTypeOf<Promise<unknown>>()
-    expectTypeOf<Extract<Awaited<typeof workflowResult>, { id: string }>["result"]>().toEqualTypeOf<{ summary: string, title: string } | undefined>()
+    expectTypeOf<Extract<Awaited<typeof workflowResult>, { id: string }>["result"]>().toEqualTypeOf<AgentRunResult | { summary: string, title: string } | undefined>()
     expectTypeOf<Awaited<typeof controlled>["support"]>().toEqualTypeOf<{ followUp: boolean, steer: boolean }>()
-    expectTypeOf<Extract<Awaited<ReturnType<Awaited<typeof controlled>["inspect"]>>, { outcome: "available" }>["invocation"]["output"]>().toEqualTypeOf<Response | { summary: string, title: string } | undefined>()
+    expectTypeOf<Extract<Awaited<ReturnType<Awaited<typeof controlled>["inspect"]>>, { outcome: "available" }>["invocation"]["output"]>().toEqualTypeOf<AgentRunResult | Response | { summary: string, title: string } | undefined>()
   })
 
   it("accepts literal false as the inline runtime opt-out", () => {

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -276,12 +276,13 @@ function record(value: unknown): Record<string, unknown> {
 }
 
 function mergeCloudflareWorkersExternal(external: unknown): unknown {
-  if (external === undefined) return ["cloudflare:workers"]
-  if (typeof external === "string") return external === "cloudflare:workers" ? [external] : [external, "cloudflare:workers"]
-  if (external instanceof RegExp) return [external, "cloudflare:workers"]
-  if (Array.isArray(external)) return external.includes("cloudflare:workers") ? external : [...external, "cloudflare:workers"]
+  const cloudflareRuntimeModules = ["cloudflare:workers", "cloudflare:workflows"]
+  if (external === undefined) return cloudflareRuntimeModules
+  if (typeof external === "string") return [...new Set([external, ...cloudflareRuntimeModules])]
+  if (external instanceof RegExp) return [external, ...cloudflareRuntimeModules]
+  if (Array.isArray(external)) return [...new Set([...external, ...cloudflareRuntimeModules])]
   if (typeof external === "function") {
-    return (source: string, importer?: string, isResolved?: boolean) => source === "cloudflare:workers" || external(source, importer, isResolved)
+    return (source: string, importer?: string, isResolved?: boolean) => cloudflareRuntimeModules.includes(source) || external(source, importer, isResolved)
   }
   return external
 }

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -612,6 +612,7 @@ function renderProviderEntry(
   ]
   if (spec.name === "cloudflare") {
     imports.push(`import { runCloudflareWorkflow } from ${JSON.stringify(createImportPath(entryFile, resolveRuntimeModule("runtime/cloudflare-runner")))}`)
+    imports.push(`import { NonRetryableError } from "cloudflare:workflows"`)
   }
   if (userAppEntry) {
     imports.push(`import workflowApp from ${JSON.stringify(createImportPath(entryFile, userAppEntry))}`)
@@ -625,7 +626,7 @@ function renderProviderEntry(
         "}",
         "",
         "export async function runViteHubWorkflowDefinition(name, env, event, step) {",
-        "  return await runCloudflareWorkflow({ config: workflowConfig, env: env || {}, event, name, registry: workflowRegistry, step })",
+        "  return await runCloudflareWorkflow({ config: workflowConfig, createNonRetryableError: error => new NonRetryableError(error.message, error.name), env: env || {}, event, name, registry: workflowRegistry, step })",
         "}",
       ]
     : []
@@ -719,6 +720,7 @@ function createCloudflareOutput(
         "@vercel/queue",
         "@vercel/sandbox",
         "cloudflare:workers",
+        "cloudflare:workflows",
         ...nodeBuiltinExternals,
         "workflow",
         "workflow/api",

--- a/packages/workflow/src/runtime/cloudflare-runner.ts
+++ b/packages/workflow/src/runtime/cloudflare-runner.ts
@@ -13,6 +13,7 @@ export interface CloudflareWorkflowEvent {
 
 export interface RunCloudflareWorkflowOptions {
   config: false | ResolvedWorkflowOptions | undefined
+  createNonRetryableError?: (error: Error & { isRetryable: false }) => Error
   env: CloudflareWorkerEnv
   event: CloudflareWorkflowEvent
   name: string
@@ -20,7 +21,11 @@ export interface RunCloudflareWorkflowOptions {
   step?: WorkflowProviderStep
 }
 
-export async function runCloudflareWorkflow({ config, env, event, name, registry, step }: RunCloudflareWorkflowOptions): Promise<unknown> {
+function isNonRetryableError(error: unknown): error is Error & { isRetryable: false } {
+  return error instanceof Error && (error as { isRetryable?: unknown }).isRetryable === false
+}
+
+export async function runCloudflareWorkflow({ config, createNonRetryableError, env, event, name, registry, step }: RunCloudflareWorkflowOptions): Promise<unknown> {
   setWorkflowRuntimeConfig(config)
   setWorkflowRuntimeRegistry(registry)
 
@@ -30,12 +35,18 @@ export async function runCloudflareWorkflow({ config, env, event, name, registry
       throw new Error(`Missing workflow definition: ${name}`)
     }
 
-    return await runWithWorkflowRuntimeEvent({ env, step }, () => runWorkflowHandler({
-      id: event?.instanceId || event?.id,
-      name,
-      payload: event?.payload,
-      provider: "cloudflare",
-      step,
-    }, definition))
+    try {
+      return await runWithWorkflowRuntimeEvent({ env, step }, () => runWorkflowHandler({
+        id: event?.instanceId || event?.id,
+        name,
+        payload: event?.payload,
+        provider: "cloudflare",
+        step,
+      }, definition))
+    }
+    catch (error) {
+      if (createNonRetryableError && isNonRetryableError(error)) throw createNonRetryableError(error)
+      throw error
+    }
   })
 }

--- a/packages/workflow/src/runtime/cloudflare-runner.ts
+++ b/packages/workflow/src/runtime/cloudflare-runner.ts
@@ -3,7 +3,7 @@ import { runWithActiveCloudflareEnv, type CloudflareWorkerEnv } from "@vite-hub/
 import { runWorkflowHandler } from "./execute.ts"
 import { loadWorkflowDefinition, runWithWorkflowRuntimeEvent, setWorkflowRuntimeConfig, setWorkflowRuntimeRegistry } from "./state.ts"
 
-import type { ResolvedWorkflowOptions, WorkflowDefinitionRegistry, WorkflowProviderStep } from "../types.ts"
+import type { ResolvedWorkflowOptions, WorkflowDefinitionRegistry, WorkflowProviderStep, WorkflowStepOptions } from "../types.ts"
 
 export interface CloudflareWorkflowEvent {
   id?: string
@@ -25,9 +25,36 @@ function isNonRetryableError(error: unknown): error is Error & { isRetryable: fa
   return error instanceof Error && (error as { isRetryable?: unknown }).isRetryable === false
 }
 
+function translateNonRetryableError(
+  error: unknown,
+  createNonRetryableError: RunCloudflareWorkflowOptions["createNonRetryableError"],
+): unknown {
+  return createNonRetryableError && isNonRetryableError(error) ? createNonRetryableError(error) : error
+}
+
+function wrapCloudflareWorkflowStep(
+  step: WorkflowProviderStep | undefined,
+  createNonRetryableError: RunCloudflareWorkflowOptions["createNonRetryableError"],
+): WorkflowProviderStep | undefined {
+  if (!step?.do || !createNonRetryableError) return step
+  return {
+    async do<TResult>(name: string, options: WorkflowStepOptions, run: () => TResult | Promise<TResult>): Promise<TResult> {
+      return await step.do!(name, options, async () => {
+        try {
+          return await run()
+        }
+        catch (error) {
+          throw translateNonRetryableError(error, createNonRetryableError)
+        }
+      })
+    },
+  }
+}
+
 export async function runCloudflareWorkflow({ config, createNonRetryableError, env, event, name, registry, step }: RunCloudflareWorkflowOptions): Promise<unknown> {
   setWorkflowRuntimeConfig(config)
   setWorkflowRuntimeRegistry(registry)
+  const providerStep = wrapCloudflareWorkflowStep(step, createNonRetryableError)
 
   return await runWithActiveCloudflareEnv(env, async () => {
     const definition = await loadWorkflowDefinition(name)
@@ -36,17 +63,16 @@ export async function runCloudflareWorkflow({ config, createNonRetryableError, e
     }
 
     try {
-      return await runWithWorkflowRuntimeEvent({ env, step }, () => runWorkflowHandler({
+      return await runWithWorkflowRuntimeEvent({ env, step: providerStep }, () => runWorkflowHandler({
         id: event?.instanceId || event?.id,
         name,
         payload: event?.payload,
         provider: "cloudflare",
-        step,
+        step: providerStep,
       }, definition))
     }
     catch (error) {
-      if (createNonRetryableError && isNonRetryableError(error)) throw createNonRetryableError(error)
-      throw error
+      throw translateNonRetryableError(error, createNonRetryableError)
     }
   })
 }

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -542,6 +542,17 @@ describe("workflow runtime", () => {
     const original = Object.assign(new Error("invalid input"), { isRetryable: false as const })
     const converted = new Error("non-retryable: invalid input")
     const createNonRetryableError = vi.fn(() => converted)
+    const step = {
+      do: vi.fn(async (_name: string, _options: unknown, run: () => unknown) => {
+        try {
+          return await run()
+        }
+        catch (error) {
+          expect(error).toBe(converted)
+          throw error
+        }
+      }),
+    } as WorkflowProviderStep
 
     await expect(runCloudflareWorkflow({
       config: { provider: "cloudflare" },
@@ -552,9 +563,11 @@ describe("workflow runtime", () => {
       registry: {
         welcome: async () => ({ default: { handler: async () => { throw original } } }),
       },
+      step,
     })).rejects.toBe(converted)
 
     expect(createNonRetryableError).toHaveBeenCalledWith(original)
+    expect(step.do).toHaveBeenCalledOnce()
   })
 
   it("isolates overlapping Cloudflare fetch environments", async () => {

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -538,6 +538,25 @@ describe("workflow runtime", () => {
     )
   })
 
+  it("converts explicitly non-retryable Cloudflare workflow errors", async () => {
+    const original = Object.assign(new Error("invalid input"), { isRetryable: false as const })
+    const converted = new Error("non-retryable: invalid input")
+    const createNonRetryableError = vi.fn(() => converted)
+
+    await expect(runCloudflareWorkflow({
+      config: { provider: "cloudflare" },
+      createNonRetryableError,
+      env: {},
+      event: { id: "run-1" },
+      name: "welcome",
+      registry: {
+        welcome: async () => ({ default: { handler: async () => { throw original } } }),
+      },
+    })).rejects.toBe(converted)
+
+    expect(createNonRetryableError).toHaveBeenCalledWith(original)
+  })
+
   it("isolates overlapping Cloudflare fetch environments", async () => {
     let arrivals = 0
     let release!: () => void

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -199,6 +199,8 @@ describe("Vite workflow provider outputs", () => {
     expect(cloudflareWorkerContents).not.toContain('runViteHubWorkflowDefinition("inline"')
     const cloudflareWorkerBundleContents = await readFile(cloudflareWorkerBundle, "utf8")
     expect(cloudflareWorkerBundleContents).toContain("runViteHubWorkflowDefinition")
+    expect(cloudflareWorkerBundleContents).toContain("NonRetryableError")
+    expect(cloudflareWorkerBundleContents).toContain("cloudflare:workflows")
     expect(cloudflareWorkerBundleContents).toContain("Repository host context loaded through Vite raw semantics.")
     expect(cloudflareWorkerBundleContents).toContain("bundled Markdown template")
     expect(cloudflareWorkerBundleContents).not.toMatch(/\b(?:from\s*|import\s*\(\s*)["']@vite-hub\/workspace(?:\/[^"']*)?["']/)

--- a/playground/vite/build/vite-e2e.ts
+++ b/playground/vite/build/vite-e2e.ts
@@ -926,6 +926,7 @@ function renderCloudflareEntry(file: string, options: ViteE2EComposerOptions, ar
   }
   if (artifacts.workflowBindings.length) {
     imports.push(`import { WorkflowEntrypoint } from "cloudflare:workers"`)
+    imports.push(`import { NonRetryableError } from "cloudflare:workflows"`)
   }
   if (artifacts.sandboxConfig && options.sandbox) {
     imports.push(`import { Sandbox as CloudflareSandbox } from "@cloudflare/sandbox"`)
@@ -936,7 +937,7 @@ function renderCloudflareEntry(file: string, options: ViteE2EComposerOptions, ar
     return [
       `export class ${binding?.class_name || getCloudflareWorkflowClassName(definition.name)} extends WorkflowEntrypoint {`,
       "  async run(event, step) {",
-      `    return await runCloudflareWorkflow({ config: workflowConfig, env: this.env || {}, event, name: ${JSON.stringify(definition.name)}, registry: workflowRegistry, step })`,
+      `    return await runCloudflareWorkflow({ config: workflowConfig, createNonRetryableError: error => new NonRetryableError(error.message, error.name), env: this.env || {}, event, name: ${JSON.stringify(definition.name)}, registry: workflowRegistry, step })`,
       "  }",
       "}",
       "",

--- a/playground/vite/build/vite-e2e.ts
+++ b/playground/vite/build/vite-e2e.ts
@@ -1269,6 +1269,7 @@ async function writeCloudflareOutput(options: ViteE2EComposerOptions, artifacts:
       "@vercel/sandbox",
       "askweb",
       "cloudflare:workers",
+      "cloudflare:workflows",
       "files-sdk",
       "files-sdk/akamai",
       "files-sdk/azure",


### PR DESCRIPTION
## Summary

Durable Agent runs could cross the Workflow boundary with values Cloudflare cannot serialize or accept: provider-owned result objects, binary attachment containers, and consumer run IDs containing illegal characters. Errors explicitly marked non-retryable also lost that intent before reaching Cloudflare Workflows.

- Materialize supported Agent inputs into portable Workflow payloads, including unambiguous base64 attachment data, and reject unsupported values before provider handoff.
- Preserve valid Workflow IDs while deterministically hashing invalid Cloudflare consumer IDs in a reserved namespace.
- Enforce the durable JSON result contract without silently dropping fields, including lossless binary Response bodies and repeated headers.
- Preserve explicit and request-scoped Cloudflare env propagation, and translate `isRetryable === false` errors to `NonRetryableError` inside generated Cloudflare provider steps.

## Boundary

Existing Workflow configuration installation, explicit Agent Invocation budgets, and request-scoped environment ownership remain authoritative. This change adds no global runtime state, adapter-specific Telegram behavior, typing lifecycle, or broad Workflow redesign.

## Verification

- Final PR head `5f00c6b` passed [GitHub Actions CI run #6854](https://github.com/vite-hub/vitehub/actions/runs/31441241830), including lint, typechecks, contract and package tests, packed-consumer isolation, and Cloudflare, Vercel, Netlify, and docs verification.
- Agent Workflow runtime: 353 passed locally.
- Workflow package runtime: 123 passed locally.
- Agent and Workflow builds, publint, and typechecks passed locally.

## Known follow-up

A post-merge exact-head probe with `ai@7.0.38` found that the Workflow result allowlist rejects a real `generateText()` result because its own `initialResponseMessages` field is not recognized before `toAgentRunResult()` normalization. The current regression fixtures use a simplified provider-shaped object and do not cover this runtime class, so ordinary model-backed durable runs need a follow-up fix and real AI SDK result test.