### PR TITLE
fix(database): make generated D1 migrations portable

### DIFF
--- a/docs/content/docs/server-primitives/database.md
+++ b/docs/content/docs/server-primitives/database.md
@@ -254,6 +254,8 @@ The Database Package discovers Database Definitions, generates the Drizzle Runti
 
 Cloudflare D1 bindings, hosted libSQL URLs, and Nuxt host resources belong in Database configuration or host setup. Route code should keep using the generated Drizzle Runtime Surface.
 
+Cloudflare Nuxt output copies discovered D1 migration SQL beside the generated Wrangler config, so `.output/server` can apply migrations without the source checkout.
+
 ::note
 `@vite-hub/database/nuxt` is a narrow Nuxt lifecycle bridge for one D1 Database Host Resource, mainly to keep Nuxt Content and Cloudflare `wrangler.d1_databases` in sync. Discovered Database Definitions still own the Drizzle Runtime Surface.
 ::

--- a/packages/database/src/nuxt.ts
+++ b/packages/database/src/nuxt.ts
@@ -1,4 +1,4 @@
-import { rm } from "node:fs/promises"
+import { copyFile, mkdir, readdir, rm } from "node:fs/promises"
 import { resolve } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
@@ -18,6 +18,7 @@ import type { Plugin } from "vite"
 type ResolvedDatabaseNuxtIntegrationOptions = Exclude<DatabaseNuxtIntegrationOptions, false>
 const generatedNitroDatabaseMiddleware = ".vitehub/nitro/database/middleware.ts"
 const generatedNitroLocalDatabaseRuntime = "database/local-runtime.mjs"
+const generatedNitroMigrationsDir = ".vitehub/database/migrations"
 const databaseDrizzleImport = "@vite-hub/database/drizzle"
 const databaseRuntimeDir = fileURLToPath(new URL("./runtime/", import.meta.url))
 
@@ -91,13 +92,13 @@ export function hubDb(options: DatabaseNuxtIntegrationOptions = {}): DatabaseNux
     const databaseConfig = resolvedOptions.driver === "d1"
       ? resolveDBViteConfig(resolvedOptions, root, { serverDirs })
       : undefined
-    const migrationsDir = databaseConfig && !databaseConfig.definitionCloudflareConfigured.default
+    const sourceMigrationsDir = databaseConfig && !databaseConfig.definitionCloudflareConfigured.default
       ? databaseConfig.databases.default?.migrationsDir
       : undefined
     const d1 = resolveDatabaseNuxtD1Options(
       resolvedOptions,
       nuxtOptions,
-      migrationsDir ? resolve(root, migrationsDir) : undefined,
+      sourceMigrationsDir ? generatedNitroMigrationsDir : undefined,
     )
     const hook = (nuxt as NuxtLike).hook
     if (typeof hook === "function") {
@@ -119,6 +120,9 @@ export function hubDb(options: DatabaseNuxtIntegrationOptions = {}): DatabaseNux
         }
         if (!nuxtOptions.dev && provider === "cloudflare") {
           await installNitroCloudflareEnvBridge(config, root)
+          if (sourceMigrationsDir) {
+            installNitroCloudflareMigrations(config, resolve(root, sourceMigrationsDir))
+          }
         }
         if (d1) {
           mergeNitroRuntimeContentConfig(config, d1)
@@ -344,6 +348,28 @@ async function installNitroCloudflareEnvBridge(config: Record<string, unknown>, 
     "}",
     "",
   ].join("\n"))
+}
+
+function installNitroCloudflareMigrations(config: Record<string, unknown>, sourceDir: string) {
+  const modules = Array.isArray(config.modules) ? [...config.modules] : []
+  modules.push((nitro: {
+    hooks: { hook: (name: "compiled", callback: () => Promise<void>) => void }
+    options: { output: { serverDir: string } }
+  }) => {
+    nitro.hooks.hook("compiled", async () => {
+      const outputDir = resolve(nitro.options.output.serverDir, generatedNitroMigrationsDir)
+      const entries = await readdir(sourceDir, { withFileTypes: true }).catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") return []
+        throw error
+      })
+      await rm(outputDir, { force: true, recursive: true })
+      await mkdir(outputDir, { recursive: true })
+      await Promise.all(entries
+        .filter(entry => entry.isFile() && entry.name.endsWith(".sql"))
+        .map(entry => copyFile(resolve(sourceDir, entry.name), resolve(outputDir, entry.name))))
+    })
+  })
+  config.modules = modules
 }
 
 function mergeNitroExternal(value: unknown, addition: string): unknown {

--- a/packages/database/test/nuxt.test.ts
+++ b/packages/database/test/nuxt.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { dirname, join } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { describe, expect, it, vi } from "vitest"
@@ -293,15 +293,21 @@ describe("Database Nuxt integration", () => {
     })
   })
 
-  it("keeps the discovered migration directory in Nitro's D1 binding", async () => {
+  it("materializes discovered migrations in Nitro's Cloudflare output", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vitehub-db-nuxt-migrations-"))
     const definition = join(rootDir, "server/databases/config.ts")
+    const migrationsDir = join(rootDir, "server/databases/migrations")
     await mkdir(dirname(definition), { recursive: true })
     await writeFile(definition, [
       'import { defineDatabase } from "@vite-hub/database"',
       "export default defineDatabase({ schema: {} })",
       "",
     ].join("\n"))
+    await mkdir(migrationsDir, { recursive: true })
+    await Promise.all([
+      writeFile(join(migrationsDir, "0001_portable.sql"), "SELECT 1;\n"),
+      writeFile(join(migrationsDir, "journal.json"), "{}\n"),
+    ])
 
     try {
       const { hooks, nuxt } = createNuxt({
@@ -322,8 +328,20 @@ describe("Database Nuxt integration", () => {
 
       expect(nitroConfig).toHaveProperty(
         "cloudflare.wrangler.d1_databases.0.migrations_dir",
-        join(rootDir, "server/databases/migrations"),
+        ".vitehub/database/migrations",
       )
+
+      const modules = (nitroConfig as { modules: Array<(nitro: unknown) => void> }).modules
+      let compiled: (() => Promise<void>) | undefined
+      modules[0]!({
+        hooks: { hook: (_name: "compiled", callback: () => Promise<void>) => { compiled = callback } },
+        options: { output: { serverDir: join(rootDir, ".output/server") } },
+      })
+      await compiled!()
+
+      const outputMigrationsDir = resolve(rootDir, ".output/server/.vitehub/database/migrations")
+      await expect(readFile(join(outputMigrationsDir, "0001_portable.sql"), "utf8")).resolves.toBe("SELECT 1;\n")
+      await expect(readFile(join(outputMigrationsDir, "journal.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" })
     }
     finally {
       await rm(rootDir, { force: true, recursive: true })

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -403,13 +403,27 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
         mkdir(packDir, { recursive: true }),
       ])
       const specs = await packWorkspacePackages(packDir)
+      await mkdir(join(appDir, "server/databases/migrations"), { recursive: true })
       await Promise.all([
         writeFile(join(appDir, "app.vue"), "<template><main>ViteHub</main></template>\n", "utf8"),
+        writeFile(join(appDir, "server/databases/config.ts"), [
+          'import { defineDatabase } from "vite-hub/database"',
+          "export default defineDatabase({ schema: {} })",
+          "",
+        ].join("\n"), "utf8"),
+        writeFile(join(appDir, "server/databases/migrations/0001_portable.sql"), "SELECT 1;\n", "utf8"),
         writeFile(join(appDir, "nuxt.config.ts"), `
           export default defineNuxtConfig({
             modules: ["vite-hub/nuxt"],
-            nitro: { preset: "cloudflare_module" },
-            vitehub: { database: true, preset: "cloudflare" },
+            nitro: { cloudflare: { deployConfig: true }, preset: "cloudflare_module" },
+            vitehub: {
+              database: {
+                driver: "d1",
+                databaseId: "00000000-0000-0000-0000-000000000000",
+                databaseName: "portable-db",
+              },
+              preset: "cloudflare",
+            },
           })
         `, "utf8"),
         writeFile(join(appDir, "package.json"), JSON.stringify({
@@ -437,11 +451,36 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
       const middleware = await readFile(join(appDir, ".vitehub/nitro/database/middleware.ts"), "utf8")
       expect(middleware).toContain("from '@vite-hub/database/runtime/state'")
       expect(middleware).not.toContain("from 'nitro'")
+
+      const artifactDir = join(root, "artifact")
+      await cp(join(appDir, ".output/server"), artifactDir, { recursive: true })
+      await rm(join(appDir, "server"), { recursive: true })
+      const wrangler = JSON.parse(await readFile(join(artifactDir, "wrangler.json"), "utf8")) as {
+        d1_databases?: Array<{ migrations_dir?: string }>
+      }
+      const migrationsDir = wrangler.d1_databases?.[0]?.migrations_dir
+      expect(migrationsDir).toBeDefined()
+      expect(isAbsolute(migrationsDir!)).toBe(false)
+      expect(existsSync(resolve(artifactDir, migrationsDir!))).toBe(true)
+      const migrations = await run("vp", [
+        "dlx",
+        "wrangler@4.112.0",
+        "d1",
+        "migrations",
+        "list",
+        "DB",
+        "--local",
+        "--config",
+        join(artifactDir, "wrangler.json"),
+        "--persist-to",
+        join(artifactDir, ".wrangler"),
+      ], artifactDir)
+      expect(migrations.stdout).toContain("0001_portable.sql")
     }
     finally {
       await rm(root, { recursive: true, force: true })
     }
-  }, 300_000)
+  }, 600_000)
 
   it("publishes Browser types and Cloudflare adapter without consumer-owned Playwright", async () => {
     const root = await mkdtemp(join(tmpdir(), "vite-hub-browser-consumer-"))


### PR DESCRIPTION
## Summary

PR #926 restored D1 migration discovery, but Nitro serialized the checkout-owned migration path into `.output/server/wrangler.json`. A generated server artifact could therefore lose its migrations when moved away from the source checkout.

- copy discovered top-level migration SQL into `.output/server/.vitehub/database/migrations`
- emit that config-relative directory in the generated Wrangler config
- cover the contract with unit and packed-consumer tests, and document the portable artifact boundary

## Verification

- `vp run --filter @vite-hub/database test` — 12 files and 112 tests passed, with typecheck, package build, and publint clean
- `VITEHUB_CONSUMER_CONTRACT=1 vp test test/consumer/vite-hub.test.ts -t "builds Nuxt database middleware without exposing owner packages"` — passed after copying only `.output/server`, removing source migrations, and listing `0001_portable.sql` with Wrangler 4.112.0
- independent code review — no actionable findings

<!-- babysitter:blocker:v1 -->

> [!WARNING]
> **Babysitter is blocked:** the `pullfrog` check is terminally failed because its configured `openai/gpt-5.6-sol` model has no `OPENAI_API_KEY`, leaving the otherwise verified PR `UNSTABLE`.
>
> Add the repository/Pullfrog OpenAI API key or switch Pullfrog to an available model, then rerun the failed `pullfrog` check so the exact head has all passing checks.

<!-- /babysitter:blocker:v1 -->