### PR TITLE
fix(agent): normalize AI SDK Workflow results

### DIFF
--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -163,7 +163,12 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
     if (!aiSdkTextResultMarkerKeys.every(key => Object.hasOwn(result, key)) || !aiSdkTextResultGetterKeys.every(key => typeof Object.getOwnPropertyDescriptor(prototype, key)?.get === "function")) unsupportedWorkflowResult()
   }
   if (!providerResultMarkerKeys.some(key => key in result) && !normalizedAgentResultKeys.every(key => Object.hasOwn(result, key))) unsupportedWorkflowResult()
-  const projected = "raw" in result ? portableWorkflowValue(result) : portableWorkflowValue(toAgentRunResult(result))
+  const normalizedResult = toAgentRunResult(result)
+  if (Object.hasOwn(result, "initialResponseMessages")) {
+    const { initialResponseMessages: _initialResponseMessages, ...raw } = result as Record<string, unknown>
+    normalizedResult.raw = raw
+  }
+  const projected = "raw" in result ? portableWorkflowValue(result) : portableWorkflowValue(normalizedResult)
   const jsonProjected = jsonWorkflowValue(projected)
   if (jsonProjected !== unportableWorkflowValue) return jsonProjected
   const { raw: _raw, ...normalized } = toAgentRunResult(result)

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -166,7 +166,9 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
   const normalizedResult = toAgentRunResult(result)
   if (Object.hasOwn(result, "initialResponseMessages")) {
     const { initialResponseMessages: _initialResponseMessages, ...raw } = result as Record<string, unknown>
+    normalizedResult.finishReason = (result as Record<string, unknown>).finishReason
     normalizedResult.raw = raw
+    normalizedResult.warnings = (result as Record<string, unknown>).warnings
   }
   const projected = "raw" in result ? portableWorkflowValue(result) : portableWorkflowValue(normalizedResult)
   const jsonProjected = jsonWorkflowValue(projected)

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -161,7 +161,6 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
     const prototype = Object.getPrototypeOf(result)
     const aiSdkTextResultGetterKeys = ["content", "finalStep", "text"]
     if (!aiSdkTextResultMarkerKeys.every(key => Object.hasOwn(result, key)) || !aiSdkTextResultGetterKeys.every(key => typeof Object.getOwnPropertyDescriptor(prototype, key)?.get === "function")) unsupportedWorkflowResult()
-    if (jsonWorkflowValue((result as Record<string, unknown>).initialResponseMessages) === unportableWorkflowValue) unsupportedWorkflowResult()
   }
   if (!providerResultMarkerKeys.some(key => key in result) && !normalizedAgentResultKeys.every(key => Object.hasOwn(result, key))) unsupportedWorkflowResult()
   const projected = "raw" in result ? portableWorkflowValue(result) : portableWorkflowValue(toAgentRunResult(result))

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -151,11 +151,12 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
   const jsonResult = jsonWorkflowValue(result)
   if (jsonResult !== unportableWorkflowValue) return jsonResult
   const agentResultKeys = ["artifacts", "finishReason", "raw", "text", "usage", "usageRecord", "warnings"]
-  const providerResultKeys = ["_output", "content", "output", "provider", "steps", "totalUsage"]
+  const providerResultMarkerKeys = ["_output", "content", "output", "provider", "steps", "totalUsage"]
+  const providerResultKeys = [...providerResultMarkerKeys, "initialResponseMessages"]
   const normalizedAgentResultKeys = ["finishReason", "raw", "text", "usage", "usageRecord", "warnings"]
   if (!result || typeof result !== "object" || !agentResultKeys.some(key => key in result)) unsupportedWorkflowResult()
   if (!Object.keys(result).every(key => agentResultKeys.includes(key) || providerResultKeys.includes(key))) unsupportedWorkflowResult()
-  if (!providerResultKeys.some(key => key in result) && !normalizedAgentResultKeys.every(key => Object.hasOwn(result, key))) unsupportedWorkflowResult()
+  if (!providerResultMarkerKeys.some(key => key in result) && !normalizedAgentResultKeys.every(key => Object.hasOwn(result, key))) unsupportedWorkflowResult()
   const projected = "raw" in result ? portableWorkflowValue(result) : portableWorkflowValue(toAgentRunResult(result))
   const jsonProjected = jsonWorkflowValue(projected)
   if (jsonProjected !== unportableWorkflowValue) return jsonProjected

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -152,11 +152,17 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
   if (jsonResult !== unportableWorkflowValue) return jsonResult
   const agentResultKeys = ["artifacts", "finishReason", "raw", "text", "usage", "usageRecord", "warnings"]
   const providerResultMarkerKeys = ["_output", "content", "output", "provider", "steps", "totalUsage"]
+  const aiSdkTextResultMarkerKeys = ["_output", "steps", "totalUsage"]
   const providerResultKeys = [...providerResultMarkerKeys, "initialResponseMessages"]
   const normalizedAgentResultKeys = ["finishReason", "raw", "text", "usage", "usageRecord", "warnings"]
   if (!result || typeof result !== "object" || !agentResultKeys.some(key => key in result)) unsupportedWorkflowResult()
   if (!Object.keys(result).every(key => agentResultKeys.includes(key) || providerResultKeys.includes(key))) unsupportedWorkflowResult()
-  if (Object.hasOwn(result, "initialResponseMessages") && jsonWorkflowValue((result as Record<string, unknown>).initialResponseMessages) === unportableWorkflowValue) unsupportedWorkflowResult()
+  if (Object.hasOwn(result, "initialResponseMessages")) {
+    const prototype = Object.getPrototypeOf(result)
+    const aiSdkTextResultGetterKeys = ["content", "finalStep", "text"]
+    if (!aiSdkTextResultMarkerKeys.every(key => Object.hasOwn(result, key)) || !aiSdkTextResultGetterKeys.every(key => typeof Object.getOwnPropertyDescriptor(prototype, key)?.get === "function")) unsupportedWorkflowResult()
+    if (jsonWorkflowValue((result as Record<string, unknown>).initialResponseMessages) === unportableWorkflowValue) unsupportedWorkflowResult()
+  }
   if (!providerResultMarkerKeys.some(key => key in result) && !normalizedAgentResultKeys.every(key => Object.hasOwn(result, key))) unsupportedWorkflowResult()
   const projected = "raw" in result ? portableWorkflowValue(result) : portableWorkflowValue(toAgentRunResult(result))
   const jsonProjected = jsonWorkflowValue(projected)

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -156,6 +156,7 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
   const normalizedAgentResultKeys = ["finishReason", "raw", "text", "usage", "usageRecord", "warnings"]
   if (!result || typeof result !== "object" || !agentResultKeys.some(key => key in result)) unsupportedWorkflowResult()
   if (!Object.keys(result).every(key => agentResultKeys.includes(key) || providerResultKeys.includes(key))) unsupportedWorkflowResult()
+  if (Object.hasOwn(result, "initialResponseMessages") && jsonWorkflowValue((result as Record<string, unknown>).initialResponseMessages) === unportableWorkflowValue) unsupportedWorkflowResult()
   if (!providerResultMarkerKeys.some(key => key in result) && !normalizedAgentResultKeys.every(key => Object.hasOwn(result, key))) unsupportedWorkflowResult()
   const projected = "raw" in result ? portableWorkflowValue(result) : portableWorkflowValue(toAgentRunResult(result))
   const jsonProjected = jsonWorkflowValue(projected)

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10755,6 +10755,37 @@ describe("agent message protocol", () => {
       expect(() => structuredClone(completed.result)).not.toThrow()
     })
 
+    it("normalizes real AI SDK text results before Workflow completion", async () => {
+      const { generateText } = await import("ai")
+      const { MockLanguageModelV3 } = await import("ai/test")
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const result = await generateText({
+        model: new MockLanguageModelV3({
+          doGenerate: {
+            content: [{ text: "portable text", type: "text" }],
+            finishReason: { raw: "stop", unified: "stop" },
+            usage: {
+              inputTokens: { cacheRead: 0, cacheWrite: 0, noCache: 1, total: 1 },
+              outputTokens: { reasoning: 0, text: 2, total: 2 },
+            },
+            warnings: [],
+          },
+        }),
+        prompt: "hello",
+      })
+
+      expect(Object.keys(result)).toContain("initialResponseMessages")
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "ai-sdk-result",
+        name: "ai-sdk-result",
+        payload: {},
+        provider: "vercel",
+      }, async () => result)).resolves.toMatchObject({
+        text: "portable text",
+        usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+      })
+    })
+
     it("rejects structured-cloneable results outside the Workflow JSON contract", async () => {
       const { defineAgent, runAgent } = await import("../src/index.ts")
       const { getWorkflowRun } = await import("@vite-hub/workflow")
@@ -10823,6 +10854,18 @@ describe("agent message protocol", () => {
         payload: {},
         provider: "vercel",
       }, async () => ({ samples: new Uint8Array([1, 2]), text: "portable text" }))).rejects.toMatchObject({
+        isRetryable: false,
+      })
+    })
+
+    it("rejects custom outputs that collide with AI SDK implementation keys", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "custom-ai-sdk-key",
+        name: "custom-ai-sdk-key",
+        payload: {},
+        provider: "vercel",
+      }, async () => ({ initialResponseMessages: new Map([["secret", 1]]), text: "portable text" }))).rejects.toMatchObject({
         isRetryable: false,
       })
     })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10866,8 +10866,8 @@ describe("agent message protocol", () => {
         payload: {},
         provider: "vercel",
       }, async () => ({
-        _output: null,
-        initialResponseMessages: new Map([["secret", 1]]),
+        _output: new Map([["secret", 1]]),
+        initialResponseMessages: [],
         steps: [],
         text: "portable text",
         totalUsage: {},

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10775,6 +10775,10 @@ describe("agent message protocol", () => {
       })
 
       expect(Object.keys(result)).toContain("initialResponseMessages")
+      ;(result as unknown as Record<string, unknown>).initialResponseMessages = [{
+        content: [{ data: new URL("https://example.com/attachment.png"), mediaType: "image/png", type: "file" }],
+        role: "assistant",
+      }]
       await expect(runAgentWorkflowDefinition({} as never, {
         id: "ai-sdk-result",
         name: "ai-sdk-result",

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10785,8 +10785,10 @@ describe("agent message protocol", () => {
         payload: {},
         provider: "vercel",
       }, async () => result)).resolves.toMatchObject({
+        finishReason: "stop",
         text: "portable text",
         usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
+        warnings: [],
       })
       await expect(runAgentWorkflowDefinition({} as never, {
         id: "ai-sdk-result",

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10865,7 +10865,13 @@ describe("agent message protocol", () => {
         name: "custom-ai-sdk-key",
         payload: {},
         provider: "vercel",
-      }, async () => ({ initialResponseMessages: new Map([["secret", 1]]), text: "portable text" }))).rejects.toMatchObject({
+      }, async () => ({
+        _output: null,
+        initialResponseMessages: new Map([["secret", 1]]),
+        steps: [],
+        text: "portable text",
+        totalUsage: {},
+      }))).rejects.toMatchObject({
         isRetryable: false,
       })
     })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10788,6 +10788,12 @@ describe("agent message protocol", () => {
         text: "portable text",
         usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
       })
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "ai-sdk-result",
+        name: "ai-sdk-result",
+        payload: {},
+        provider: "vercel",
+      }, async () => result)).resolves.not.toHaveProperty("raw.initialResponseMessages")
     })
 
     it("rejects structured-cloneable results outside the Workflow JSON contract", async () => {


### PR DESCRIPTION
## Summary

AI SDK v7 `generateText()` results expose `initialResponseMessages` as an own implementation field. The Agent Workflow portability boundary rejected that genuine provider result before it could normalize it into `AgentRunResult`.

- Accept `initialResponseMessages` as an allowed AI SDK implementation field while keeping the established provider markers required for normalization.
- Exercise the real `generateText()` result shape with `MockLanguageModelV3`.
- Keep custom outputs with a colliding implementation key and non-portable state non-retryable.

## Verification

- `@vite-hub/agent` runtime tests: 355 passed
- `@vite-hub/agent` typecheck and build
- `@vite-hub/workflow` non-retryable provider test, typecheck, and build
- Scoped oxlint and `git diff --check`
- Packed consumer install, typecheck, build, and runtime contract
- Independent code review: no remaining findings