### PR TITLE
fix(agent): post final replies after progress

### DIFF
--- a/docs/content/docs/capabilities/progress-summary.md
+++ b/docs/content/docs/capabilities/progress-summary.md
@@ -50,6 +50,8 @@ Listen for `data-progress-summary` parts and replace the currently displayed sen
 
 The part is transient, so it does not become conversation history. Keep structured reasoning and tool logs separate when your interface exposes them.
 
+With manual chat delivery, ViteHub edits the current placeholder as summaries arrive. When the Agent finishes, ViteHub deletes that placeholder and posts the final reply as a new message so chat platforms can deliver their normal notification.
+
 ## Understand the runtime behavior
 
 The Capability generates an initial summary when the stream starts. Reasoning deltas and tool start or completion events then mark the current activity dirty. While new activity exists, the Capability generates at most one summary per interval and never overlaps generations. Raw reasoning, tool input, and tool output are excluded from the generated prompt; reasoning is represented only as an `Active` presence signal.

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2899,19 +2899,9 @@ async function flushChatFinishExtensionMessages(
         abortSignal?.throwIfAborted()
       }
       const placeholder = manualDelivery.placeholder
-      if (await deliverToManualDeliveryPlaceholder(placeholder, message, abortSignal
-        ? () => {
-            manualDelivery.placeholder = undefined
-          }
-        : undefined)) {
-        if (abortSignal?.aborted && manualDelivery.errorFallback) {
-          await replaceManualDeliveryPlaceholder(placeholder, manualDelivery.errorFallback)
-        }
-        abortSignal?.throwIfAborted()
-        manualDelivery.placeholder = undefined
-        continue
-      }
+      await deleteManualDeliveryPlaceholder(placeholder)
       manualDelivery.placeholder = undefined
+      abortSignal?.throwIfAborted()
     }
     await postChatMessage(thread, message, abortSignal)
   }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2903,6 +2903,7 @@ async function flushChatFinishExtensionMessages(
         await deleteManualDeliveryPlaceholder(placeholder)
       }
       catch (cause) {
+        abortSignal?.throwIfAborted()
         if (await replaceManualDeliveryPlaceholder(placeholder, message).catch(() => false)) {
           manualDelivery.placeholder = undefined
           continue

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2899,7 +2899,16 @@ async function flushChatFinishExtensionMessages(
         abortSignal?.throwIfAborted()
       }
       const placeholder = manualDelivery.placeholder
-      await deleteManualDeliveryPlaceholder(placeholder)
+      try {
+        await deleteManualDeliveryPlaceholder(placeholder)
+      }
+      catch (cause) {
+        if (await replaceManualDeliveryPlaceholder(placeholder, message).catch(() => false)) {
+          manualDelivery.placeholder = undefined
+          continue
+        }
+        throw cause
+      }
       manualDelivery.placeholder = undefined
       abortSignal?.throwIfAborted()
     }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2791,17 +2791,18 @@ async function postChatErrorFallback(
     else {
       await enforceChatInvocationTimeout(
         cleanup,
-        Math.max(0, maximumInvocationDeadline + cloudflareChatFallbackTimeoutMs - Date.now()),
+        Math.max(0, maximumInvocationDeadline + cloudflareChatFallbackTimeoutMs - chatFallbackDeliveryReserveMs - Date.now()),
       ).catch(() => undefined)
     }
   }
+  const fallbackPlaceholder = manualDelivery?.placeholderCleanup ? undefined : manualDelivery?.placeholder
   const fallbackDeliveryAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
   const fallbackDelivery = (async () => {
     if (!fallback) {
-      if (manualDelivery?.placeholder) await deleteManualDeliveryPlaceholder(manualDelivery.placeholder)
+      if (fallbackPlaceholder) await deleteManualDeliveryPlaceholder(fallbackPlaceholder)
       return
     }
-    if (await deliverToManualDeliveryPlaceholder(manualDelivery?.placeholder, fallback)) return
+    if (await deliverToManualDeliveryPlaceholder(fallbackPlaceholder, fallback)) return
     fallbackDeliveryAbort?.signal.throwIfAborted()
     const sent = await thread.post(fallback).catch(() => undefined)
     if (!sent) return
@@ -2899,26 +2900,29 @@ async function flushChatFinishExtensionMessages(
         abortSignal?.throwIfAborted()
       }
       const placeholder = manualDelivery.placeholder
-      const placeholderCleanup = deleteManualDeliveryPlaceholder(placeholder)
+      let deliveredToPlaceholder = false
+      const placeholderCleanup = (async () => {
+        try {
+          await deleteManualDeliveryPlaceholder(placeholder)
+        }
+        catch {
+          abortSignal?.throwIfAborted()
+          deliveredToPlaceholder = await replaceManualDeliveryPlaceholder(placeholder, message).catch(() => false)
+          abortSignal?.throwIfAborted()
+        }
+        manualDelivery.placeholder = undefined
+        abortSignal?.throwIfAborted()
+      })()
       manualDelivery.placeholderCleanup = placeholderCleanup
       try {
         await placeholderCleanup
-      }
-      catch (cause) {
-        abortSignal?.throwIfAborted()
-        if (await replaceManualDeliveryPlaceholder(placeholder, message).catch(() => false)) {
-          manualDelivery.placeholder = undefined
-          continue
-        }
-        throw cause
       }
       finally {
         if (manualDelivery.placeholderCleanup === placeholderCleanup) {
           manualDelivery.placeholderCleanup = undefined
         }
       }
-      manualDelivery.placeholder = undefined
-      abortSignal?.throwIfAborted()
+      if (deliveredToPlaceholder) continue
     }
     await postChatMessage(thread, message, abortSignal)
   }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2899,8 +2899,10 @@ async function flushChatFinishExtensionMessages(
         abortSignal?.throwIfAborted()
       }
       const placeholder = manualDelivery.placeholder
+      const placeholderCleanup = deleteManualDeliveryPlaceholder(placeholder)
+      manualDelivery.placeholderCleanup = placeholderCleanup
       try {
-        await deleteManualDeliveryPlaceholder(placeholder)
+        await placeholderCleanup
       }
       catch (cause) {
         abortSignal?.throwIfAborted()
@@ -2909,6 +2911,11 @@ async function flushChatFinishExtensionMessages(
           continue
         }
         throw cause
+      }
+      finally {
+        if (manualDelivery.placeholderCleanup === placeholderCleanup) {
+          manualDelivery.placeholderCleanup = undefined
+        }
       }
       manualDelivery.placeholder = undefined
       abortSignal?.throwIfAborted()

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -10339,7 +10339,7 @@ describe("server helpers", () => {
     }
   })
 
-  it("preserves manual placeholder ownership when cleanup fails after the deadline", async () => {
+  it("preserves the manual error fallback when final reply cleanup fails after the deadline", async () => {
     vi.useFakeTimers()
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")
@@ -10363,6 +10363,9 @@ describe("server helpers", () => {
         }),
       },
       driver: { run: () => ({ text: "" }) },
+      hooks: {
+        "agent:finish": event => event.reply("Final reply"),
+      },
     })
     const handler = createChannelWebhookRouteHandler(agent as never)
 
@@ -10377,6 +10380,7 @@ describe("server helpers", () => {
         message: "Chat invocation timed out after 28000ms.",
       })
       expect(adapter.postMessage).toHaveBeenCalledOnce()
+      expect(adapter.editMessage).toHaveBeenCalledOnce()
       expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", "Please try again.")
     }
     finally {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -9382,7 +9382,7 @@ describe("server helpers", () => {
     expect(adapter.editMessage).not.toHaveBeenCalled()
   })
 
-  it("delivers only explicit manual replies and replaces the placeholder once", async () => {
+  it("delivers only explicit manual replies after deleting the placeholder", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
@@ -9417,8 +9417,9 @@ describe("server helpers", () => {
     expect(response.status).toBe(200)
     expect(run).toHaveBeenCalledOnce()
     expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Analyzing photo…")
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Calories reply" })
-    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Dashboard reply" })
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Calories reply" })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(3, "telegram:456", { markdown: "Dashboard reply" })
     expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", { markdown: "{\"internal\":\"structured output\"}" })
     expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
     const typingOrder = adapter.startTyping.mock.invocationCallOrder[0]
@@ -9852,7 +9853,8 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(200)
     expect(adapter.editMessage).toHaveBeenNthCalledWith(1, "telegram:456", "sent-1", { markdown: "Validating the result." })
-    expect(adapter.editMessage).toHaveBeenNthCalledWith(2, "telegram:456", "sent-1", { markdown: "Validated reply" })
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Validated reply" })
   })
 
   it("updates a manual placeholder with progress summaries before the final reply", async () => {
@@ -9898,11 +9900,12 @@ describe("server helpers", () => {
     const response = await handler(chatWebhookRequest(91_013), "telegram")
 
     expect(response.status).toBe(200)
-    expect(adapter.postMessage).toHaveBeenCalledOnce()
-    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Analyzing photo…")
+    expect(adapter.postMessage).toHaveBeenCalledTimes(2)
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Analyzing photo…")
     expect(adapter.editMessage).toHaveBeenNthCalledWith(1, "telegram:456", "sent-1", { markdown: "Reviewing the request." })
     expect(adapter.editMessage).toHaveBeenNthCalledWith(2, "telegram:456", "sent-1", { markdown: "Checking current inventory." })
-    expect(adapter.editMessage).toHaveBeenNthCalledWith(3, "telegram:456", "sent-1", { markdown: "Final customer reply" })
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Final customer reply" })
     expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", { markdown: "Private model output" })
   })
 
@@ -10063,12 +10066,11 @@ describe("server helpers", () => {
     }
   })
 
-  it("posts a buffered manual stream when placeholder editing fails", async () => {
+  it("posts a streamed manual reply after deleting the placeholder", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
-    adapter.editMessage.mockRejectedValueOnce(new Error("edit failed"))
     const agent = defineAgent({
       channels: {
         telegram: testTelegram(telegram, {
@@ -10092,7 +10094,6 @@ describe("server helpers", () => {
     const response = await handler(chatWebhookRequest(91_011), "telegram")
 
     expect(response.status).toBe(200)
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Streamed reply" })
     expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Streamed reply" })
   })
@@ -10105,6 +10106,9 @@ describe("server helpers", () => {
     const adapter = createTestChatAdapter()
     adapter.postMessage.mockImplementationOnce(async threadId => ({
       id: "sent-1",
+      threadId,
+    })).mockImplementationOnce(async threadId => ({
+      id: "sent-2",
       threadId,
     })).mockRejectedValueOnce(new Error("post failed"))
     const agent = defineAgent({
@@ -10130,9 +10134,9 @@ describe("server helpers", () => {
 
     try {
       await expect(handler(chatWebhookRequest(91_012), "telegram")).rejects.toThrow("post failed")
-      expect(adapter.editMessage).toHaveBeenCalledOnce()
-      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "First reply" })
-      expect(adapter.postMessage).toHaveBeenNthCalledWith(3, "telegram:456", "Delivery failed.")
+      expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "First reply" })
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(4, "telegram:456", "Delivery failed.")
     }
     finally {
       consoleError.mockRestore()

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -10339,16 +10339,16 @@ describe("server helpers", () => {
     }
   })
 
-  it("preserves the manual error fallback when final reply cleanup fails after the deadline", async () => {
+  it("preserves the manual error fallback when the cleanup edit finishes after the deadline", async () => {
     vi.useFakeTimers()
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
-    adapter.deleteMessage.mockImplementation(async () => {
+    adapter.deleteMessage.mockRejectedValueOnce(new Error("delete failed"))
+    adapter.editMessage.mockImplementationOnce(async () => {
       await new Promise(resolve => setTimeout(resolve, 29_000))
-      throw new Error("delete failed")
     })
     const agent = defineAgent({
       channels: {
@@ -10380,8 +10380,9 @@ describe("server helpers", () => {
         message: "Chat invocation timed out after 28000ms.",
       })
       expect(adapter.postMessage).toHaveBeenCalledOnce()
-      expect(adapter.editMessage).toHaveBeenCalledOnce()
-      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", "Please try again.")
+      expect(adapter.editMessage).toHaveBeenCalledTimes(2)
+      expect(adapter.editMessage).toHaveBeenNthCalledWith(1, "telegram:456", "sent-1", { markdown: "Final reply" })
+      expect(adapter.editMessage).toHaveBeenNthCalledWith(2, "telegram:456", "sent-1", "Please try again.")
     }
     finally {
       consoleError.mockRestore()
@@ -10389,7 +10390,7 @@ describe("server helpers", () => {
     }
   })
 
-  it("posts the manual error fallback after final reply cleanup succeeds past the deadline", async () => {
+  it("posts the manual error fallback before final reply cleanup succeeds at the background deadline", async () => {
     vi.useFakeTimers()
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")
@@ -10397,7 +10398,7 @@ describe("server helpers", () => {
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     adapter.deleteMessage.mockImplementation(async () => {
-      await new Promise(resolve => setTimeout(resolve, 29_000))
+      await new Promise(resolve => setTimeout(resolve, 30_000))
     })
     const agent = defineAgent({
       channels: {
@@ -10431,6 +10432,8 @@ describe("server helpers", () => {
       expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
       expect(adapter.editMessage).not.toHaveBeenCalled()
       expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", "Please try again.")
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(adapter.postMessage).toHaveBeenCalledTimes(2)
     }
     finally {
       consoleError.mockRestore()
@@ -11124,7 +11127,7 @@ describe("server helpers", () => {
     }))
   })
 
-  it("fails clearly when an unreplaceable manual reply cannot remove its placeholder", async () => {
+  it("posts an unreplaceable manual reply when placeholder cleanup is ambiguous", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
@@ -11158,11 +11161,14 @@ describe("server helpers", () => {
     })
     const handler = createChannelWebhookRouteHandler(agent as never)
 
-    await expect(handler(chatWebhookRequest(91_009), "telegram")).rejects.toThrow(
-      "Manual chat delivery could not remove its placeholder.",
-    )
-    expect(adapter.postMessage).toHaveBeenCalledOnce()
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", "Sorry, I couldn't process that message.")
+    const response = await handler(chatWebhookRequest(91_009), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", expect.objectContaining({
+      attachments: expect.any(Array),
+      markdown: "See the result.",
+    }))
+    expect(adapter.editMessage).not.toHaveBeenCalled()
   })
 
   it("lets chat webhooks opt out of streaming model execution", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -10098,6 +10098,37 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Streamed reply" })
   })
 
+  it("delivers the final reply through the placeholder when deletion fails", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.deleteMessage.mockRejectedValueOnce(new Error("delete failed"))
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+          },
+        }),
+      },
+      driver: { run: () => "Private output" },
+      hooks: {
+        "agent:finish": event => event.reply("Final reply"),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_040), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Final reply" })
+    expect(adapter.postMessage).toHaveBeenCalledOnce()
+  })
+
   it("does not overwrite the first manual reply when a later reply fails", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -10389,6 +10389,55 @@ describe("server helpers", () => {
     }
   })
 
+  it("posts the manual error fallback after final reply cleanup succeeds past the deadline", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.deleteMessage.mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 29_000))
+    })
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            errorFallbackText: "Please try again.",
+            fallbackStreamingPlaceholderText: "Analyzing photo…",
+            timeout: 50_000,
+          },
+        }),
+      },
+      driver: { run: () => ({ text: "" }) },
+      hooks: {
+        "agent:finish": event => event.reply("Final reply"),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const responseError = handler(chatWebhookRequest(91_041), "telegram", {
+        cloudflare: { env: {} },
+        waitUntil: () => undefined,
+      }).catch(error => error)
+      await vi.advanceTimersByTimeAsync(29_000)
+
+      await expect(responseError).resolves.toMatchObject({
+        message: "Chat invocation timed out after 28000ms.",
+      })
+      expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+      expect(adapter.editMessage).not.toHaveBeenCalled()
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", "Please try again.")
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("bounds provider error details in chat logs", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")


### PR DESCRIPTION
## Summary

- delete the transient manual-delivery placeholder before the final reply
- post the final reply as a new chat message so platform notifications fire
- document and test the progress-to-final delivery contract

## Verification

- `pnpm --filter @vite-hub/agent typecheck`
- `vp test run test/providers.test.ts` (253 passed)
- `vp run -t @vite-hub/agent#build`