### PR TITLE
fix(agent): start progress summaries before stream setup

### DIFF
--- a/docs/content/docs/capabilities/progress-summary.md
+++ b/docs/content/docs/capabilities/progress-summary.md
@@ -54,15 +54,17 @@ With manual chat delivery, ViteHub edits the current placeholder as summaries ar
 
 ## Understand the runtime behavior
 
-The Capability generates an initial summary when the stream starts. Reasoning deltas and tool start or completion events then mark the current activity dirty. While new activity exists, the Capability generates at most one summary per interval and never overlaps generations. Raw reasoning, tool input, and tool output are excluded from the generated prompt; reasoning is represented only as an `Active` presence signal.
+The Capability starts its initial summary before the primary Driver finishes setup. If the summary completes before the UI stream is available, ViteHub buffers the latest transient part and emits it when the stream attaches.
+
+Positive intervals use a fixed cadence from invocation start, so a slow generation does not postpone the next tick. Generations can overlap; each receives a higher revision, and a stale completion cannot replace a newer completed revision. Set `intervalMs: 0` to generate from reasoning and tool activity through the event-driven microtask behavior instead. Raw reasoning, tool input, and tool output are excluded from the generated prompt; reasoning is represented only as an `Active` presence signal.
 
 The default prompt uses only reasoning presence, sanitized tool names, and the previous summary. It does not include user message text, code, commands, paths, traces, hidden instructions, credentials, raw tool details, or trusted `<context>` payloads.
 
-The Capability stops pending timers when the parent invocation aborts. It also discards pending or in-flight summaries when the primary stream finishes, so progress never delays completion or arrives after terminal output. A generation failure does not interrupt the primary response stream.
+The Capability stops its cadence and aborts every in-flight generation when the parent invocation aborts or the primary stream finishes, cancels, or errors. A generation failure does not interrupt the primary response stream; ViteHub emits a sanitized warning and trace event without logging the Driver error message.
 
 ## Requirements
 
-The primary Agent Driver must expose a compatible async stream or UI message stream. After the initial summary, the Capability remains silent until reasoning or tool lifecycle events provide new activity to summarize.
+The primary Agent Driver must expose a compatible async stream or UI message stream. With a positive interval, the Capability attempts a summary on every tick and suppresses unchanged output. With `intervalMs: 0`, it remains silent after the initial summary until reasoning or tool lifecycle events provide new activity.
 
 Configure a `driver`, `model`, or `execute` option for summary generation. Without one of those options, the Capability uses the Agent model when available.
 
@@ -76,7 +78,7 @@ Configure a `driver`, `model`, or `execute` option for summary generation. Witho
 
 ## Verify the result
 
-Run an invocation and confirm that the primary stream continues immediately while an initial transient `data-progress-summary` part arrives. Perform at least one tool call or emit reasoning for longer than `intervalMs`, then confirm that a later part arrives with a higher `revision`.
+Run an invocation and confirm that the primary stream continues immediately while an initial transient `data-progress-summary` part arrives. Keep the invocation open beyond `intervalMs`, then confirm that a later changed summary arrives with a higher `revision`.
 
 Stop the invocation before the next interval and confirm that no later progress part appears.
 
@@ -88,7 +90,7 @@ Stop the invocation before the next interval and confirm that no later progress 
 | `execute` | `(input) => string \| { summary?: string }` | none | Custom progress generator. |
 | `id` | `string` | `"progress-summary"` | Capability id. |
 | `instructions` | `string` | Capability-owned instructions | System instructions for model-backed generation. |
-| `intervalMs` | `number` | `10000` | Minimum delay between dirty progress snapshots. |
+| `intervalMs` | `number` | `10000` | Fixed generation cadence. Use `0` for event-driven updates. |
 | `maxLength` | `number` | `180` | Maximum summary length. |
 | `model` | `AgentModelResolver` | Agent model | Model used when no independent Driver is configured. |
 | `template` | `string \| function` | generated | Markdown prompt template. |

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -588,7 +588,7 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
         return state
       }
       invocationStarts.set(context.context, () => {
-        if (context.invocation?.kind === "stream") getState()
+        if (context.invocation?.kind === "stream" && context.driver?.kind === "harness") getState()
       })
       context.output.render((result) => {
         if (isStreamResult(result)) {

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -578,10 +578,18 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
       context.context.set(progressSummaryOutputContextKey, true, { overwrite: true })
       const messages = context.input.messages()
       if (!messages.some(message => message.role === "user") && !context.input.get().prompt) return
-      const state = createProgressSummaryState(context, options, messages)
-      states.set(context.context, state)
+      let state = context.invocation?.kind === "stream"
+        ? createProgressSummaryState(context, options, messages)
+        : undefined
+      if (state) states.set(context.context, state)
+      const getState = () => {
+        state ||= createProgressSummaryState(context, options, messages)
+        states.set(context.context, state)
+        return state
+      }
       context.output.render((result) => {
         if (isStreamResult(result)) {
+          const state = getState()
           const wrapped = new WeakMap<object, AsyncIterable<unknown> & ReadableStream<unknown>>()
           const wrap = (stream: AsyncIterable<unknown> | ReadableStream<unknown>) => {
             const existing = wrapped.get(stream)
@@ -617,7 +625,7 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
           })
         }
         if (!isAsyncIterable(result)) return result
-        return withProgressSummaryStream(result, state)
+        return withProgressSummaryStream(result, getState())
       })
     },
     finish() {},

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -1,6 +1,6 @@
 import { renderMarkdownTemplate } from "@vite-hub/markdown-template"
 import { streamAgentOutputToEvents, toAgentRunResult } from "../agent-output.ts"
-import { defineCapability } from "../capability-runtime.ts"
+import { defineCapability, eagerFinishExtensionSymbol } from "../capability-runtime.ts"
 import { toAgentUiMessageStreamResponse } from "../http-response.ts"
 import { normalizeAgentDriver, resolveNormalizedHarnessDriver } from "../internal/agent-driver.ts"
 import { progressSummaryOutputContextKey } from "../internal/agent-output-events.ts"
@@ -9,6 +9,7 @@ import { markAuxiliaryMessageChannelInstructionContext } from "../internal/chann
 import { isAsyncIterable, toReadableAsyncIterableStream } from "../internal/stream-result.ts"
 import { getMessageText } from "../messages.ts"
 import { normalizeUiMessageStreamChunk } from "../stream-output.ts"
+import { traceAgentEvent } from "../trace.ts"
 
 import type {
   AgentAdapterRunContext,
@@ -173,7 +174,9 @@ function progressSummaryAdapterRunContext(
   }
   return markAuxiliaryMessageChannelInstructionContext({
     actor: context.actor,
+    box: context.box,
     context: context.context,
+    harnessSandboxProvider: context.harnessSandboxProvider,
     toolStepReporter: context.runtimeContext.toolStepReporter,
     input: progressSummaryDriverInput(input, prompt),
     invoker: context.invoker,
@@ -206,6 +209,7 @@ function progressSummaryRunContext(
 async function resultText(result: unknown): Promise<string | undefined> {
   let text = ""
   for await (const event of streamAgentOutputToEvents(result)) {
+    if (event.type === "error" && !event.recoverable) throw new Error(event.error)
     if (event.type === "text-delta") text += event.text
   }
   return text || toAgentRunResult(result).text
@@ -334,85 +338,116 @@ function progressData(summary: string, revision: number) {
   }
 }
 
-function withProgressSummaryStream(
-  stream: AsyncIterable<unknown> | ReadableStream<unknown>,
+interface ProgressSummaryState {
+  attach: (controller: TransformStreamDefaultController<unknown>) => void
+  close: () => void
+  observe: (chunk: unknown) => void
+}
+
+function createProgressSummaryState(
   context: AgentCapabilityRuntimeContext,
   options: ProgressSummaryOptions,
   messages: Message[],
-): AsyncIterable<unknown> & ReadableStream<unknown> {
-  const source = isAsyncIterable(stream)
-    ? toReadableAsyncIterableStream(stream)
-    : stream
+): ProgressSummaryState {
   const activeTools = new Map<string, string>()
   const completedTools: string[] = []
   const activeReasoning = new Set<string>()
+  const controllers = new Set<TransformStreamDefaultController<unknown>>()
+  const generations = new Set<AbortController>()
   const startedAt = Date.now()
   const intervalMs = Math.max(0, options.intervalMs ?? 10_000)
   let reasoningActive = false
   let previous: string | undefined
   let revision = 0
+  let emittedRevision = 0
   let dirty = true
   let running = false
   let closed = false
   let scheduled = false
-  let timer: ReturnType<typeof setTimeout> | undefined
-  let controller: TransformStreamDefaultController<unknown> | undefined
-  let generationAbortController: AbortController | undefined
+  let latest: ReturnType<typeof progressData> | undefined
+  let timer: ReturnType<typeof setInterval> | undefined
   const abortSignal = context.abortSignal ?? context.input.get().abortSignal
   const close = () => {
-    // Progress is transient: never hold the primary stream open or emit stale
-    // activity after its terminal event while independent generation finishes.
+    if (closed) return
     closed = true
-    if (timer) clearTimeout(timer)
-    generationAbortController?.abort()
+    if (timer) clearInterval(timer)
+    for (const generation of generations) generation.abort()
+    generations.clear()
+    controllers.clear()
     scheduled = false
     abortSignal?.removeEventListener("abort", close)
   }
   abortSignal?.addEventListener("abort", close, { once: true })
 
-  const schedule = (immediate = false) => {
-    if (closed || running || scheduled || !dirty) return
-    scheduled = true
-    const run = () => {
-      scheduled = false
-      timer = undefined
-      if (closed || running || !dirty) return
+  const reportError = (error: unknown) => {
+    console.warn("[vitehub] progressSummary() generation failed.")
+    if (!context.runtimeContext) return
+    const task = traceAgentEvent({
+      context: context.context,
+      input: context.input.get(),
+      invoker: context.invoker,
+      run: context.run,
+      runtime: context.runtimeContext,
+    }, {
+      attributes: {
+        "capability.id": context.capability.id,
+        "error.name": error instanceof Error ? error.name : "Error",
+      },
+      name: "agent.progress-summary.error",
+      type: "error",
+    })
+    context.runtimeContext.waitUntil?.(task)
+  }
+
+  const startGeneration = () => {
+    if (closed || (intervalMs === 0 && running)) return
+    if (intervalMs === 0) {
       dirty = false
       running = true
-      const currentRevision = ++revision
-      const inputValue = context.input.get()
-      const generationAbort = new AbortController()
-      generationAbortController = generationAbort
-      const input: ProgressSummaryExecuteInput = {
-        activeTools: [...activeTools.values()],
-        completedTools: completedTools.slice(-5),
-        elapsedMs: Date.now() - startedAt,
-        input: {
-          ...inputValue,
-          abortSignal: inputValue.abortSignal
-            ? AbortSignal.any([inputValue.abortSignal, generationAbort.signal])
-            : generationAbort.signal,
-        },
-        messages,
-        previous,
-        reasoning: reasoningActive ? "Active" : undefined,
-        userText: firstUserText(messages, inputValue),
-      }
-      void generateProgressSummary(context, options, input)
-        .then((summary) => {
-          if (closed || !summary || summary === previous) return
-          previous = summary
-          controller?.enqueue(progressData(summary, currentRevision))
-        })
-        .catch(() => undefined)
-        .finally(() => {
-          if (generationAbortController === generationAbort) generationAbortController = undefined
-          running = false
-          schedule()
-        })
     }
-    if (immediate || intervalMs === 0) queueMicrotask(run)
-    else timer = setTimeout(run, intervalMs)
+    const currentRevision = ++revision
+    const inputValue = context.input.get()
+    const generationAbort = new AbortController()
+    generations.add(generationAbort)
+    const input: ProgressSummaryExecuteInput = {
+      activeTools: [...activeTools.values()],
+      completedTools: completedTools.slice(-5),
+      elapsedMs: Date.now() - startedAt,
+      input: {
+        ...inputValue,
+        abortSignal: inputValue.abortSignal
+          ? AbortSignal.any([inputValue.abortSignal, generationAbort.signal])
+          : generationAbort.signal,
+      },
+      messages,
+      previous,
+      reasoning: reasoningActive ? "Active" : undefined,
+      userText: firstUserText(messages, inputValue),
+    }
+    void generateProgressSummary(context, options, input)
+      .then((summary) => {
+        if (closed || !summary || currentRevision <= emittedRevision || summary === previous) return
+        emittedRevision = currentRevision
+        previous = summary
+        latest = progressData(summary, currentRevision)
+        for (const controller of controllers) controller.enqueue(latest)
+      })
+      .catch(reportError)
+      .finally(() => {
+        generations.delete(generationAbort)
+        if (intervalMs !== 0) return
+        running = false
+        scheduleEventDriven()
+      })
+  }
+
+  const scheduleEventDriven = () => {
+    if (closed || running || scheduled || !dirty) return
+    scheduled = true
+    queueMicrotask(() => {
+      scheduled = false
+      if (!closed && dirty) startGeneration()
+    })
   }
 
   const observe = (chunk: unknown) => {
@@ -453,25 +488,49 @@ function withProgressSummaryStream(
       if (name) completedTools.push(name)
       dirty = true
     }
-    schedule()
+    if (intervalMs === 0) scheduleEventDriven()
   }
 
+  if (intervalMs === 0) scheduleEventDriven()
+  else {
+    startGeneration()
+    timer = setInterval(startGeneration, intervalMs)
+  }
+
+  return {
+    attach(controller) {
+      if (closed) return
+      controllers.add(controller)
+      if (latest) controller.enqueue(latest)
+    },
+    close,
+    observe,
+  }
+}
+
+function withProgressSummaryStream(
+  stream: AsyncIterable<unknown> | ReadableStream<unknown>,
+  state: ProgressSummaryState,
+): AsyncIterable<unknown> & ReadableStream<unknown> {
+  const source = isAsyncIterable(stream)
+    ? toReadableAsyncIterableStream(stream)
+    : stream
   const transformed = source.pipeThrough(new TransformStream({
     start(streamController) {
-      controller = streamController
-      schedule(true)
+      state.attach(streamController)
     },
-    flush: close,
+    flush() {
+      state.close()
+    },
     transform(chunk, streamController) {
-      controller = streamController
       streamController.enqueue(chunk)
-      observe(chunk)
+      state.observe(chunk)
     },
   }))
   const reader = transformed.getReader()
   return toReadableAsyncIterableStream(new ReadableStream({
     async cancel(reason) {
-      close()
+      state.close()
       await reader.cancel(reason)
     },
     async pull(outputController) {
@@ -481,7 +540,7 @@ function withProgressSummaryStream(
         else outputController.enqueue(value)
       }
       catch (error) {
-        close()
+        state.close()
         outputController.error(error)
       }
     },
@@ -505,19 +564,26 @@ function isStreamResult(value: unknown): value is {
 export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
   options: ProgressSummaryOptions<TRuntimeConfig> = {},
 ): AgentCapabilityDefinition<TRuntimeConfig> {
-  return defineCapability({
+  const states = new WeakMap<object, ProgressSummaryState>()
+  return Object.assign(defineCapability({
+    close(context) {
+      states.get(context.context)?.close()
+      states.delete(context.context)
+    },
     id: options.id || "progress-summary",
     output(context) {
       context.context.set(progressSummaryOutputContextKey, true, { overwrite: true })
+      const messages = context.input.messages()
+      if (!messages.some(message => message.role === "user") && !context.input.get().prompt) return
+      const state = createProgressSummaryState(context, options, messages)
+      states.set(context.context, state)
       context.output.render((result) => {
-        const messages = context.input.messages()
-        if (!messages.some(message => message.role === "user") && !context.input.get().prompt) return result
         if (isStreamResult(result)) {
           const wrapped = new WeakMap<object, AsyncIterable<unknown> & ReadableStream<unknown>>()
           const wrap = (stream: AsyncIterable<unknown> | ReadableStream<unknown>) => {
             const existing = wrapped.get(stream)
             if (existing) return existing
-            const value = withProgressSummaryStream(stream, context, options, messages)
+            const value = withProgressSummaryStream(stream, state)
             wrapped.set(stream, value)
             return value
           }
@@ -548,8 +614,11 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
           })
         }
         if (!isAsyncIterable(result)) return result
-        return withProgressSummaryStream(result, context, options, messages)
+        return withProgressSummaryStream(result, state)
       })
     },
+    finish() {},
+  }), {
+    [eagerFinishExtensionSymbol]: true,
   })
 }

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -1,6 +1,6 @@
 import { renderMarkdownTemplate } from "@vite-hub/markdown-template"
 import { streamAgentOutputToEvents, toAgentRunResult } from "../agent-output.ts"
-import { defineCapability, eagerFinishExtensionSymbol } from "../capability-runtime.ts"
+import { capabilityInvocationStartSymbol, defineCapability, eagerFinishExtensionSymbol } from "../capability-runtime.ts"
 import { toAgentUiMessageStreamResponse } from "../http-response.ts"
 import { normalizeAgentDriver, resolveNormalizedHarnessDriver } from "../internal/agent-driver.ts"
 import { progressSummaryOutputContextKey } from "../internal/agent-output-events.ts"
@@ -568,28 +568,32 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
   options: ProgressSummaryOptions<TRuntimeConfig> = {},
 ): AgentCapabilityDefinition<TRuntimeConfig> {
   const states = new WeakMap<object, ProgressSummaryState>()
+  const invocationStarts = new WeakMap<object, () => void>()
   return Object.assign(defineCapability({
     close(context) {
       states.get(context.context)?.close()
       states.delete(context.context)
+      invocationStarts.delete(context.context)
     },
     id: options.id || "progress-summary",
     output(context) {
       context.context.set(progressSummaryOutputContextKey, true, { overwrite: true })
-      const messages = context.input.messages()
-      if (!messages.some(message => message.role === "user") && !context.input.get().prompt) return
-      let state = context.invocation?.kind === "stream"
-        ? createProgressSummaryState(context, options, messages)
-        : undefined
-      if (state) states.set(context.context, state)
+      let state: ProgressSummaryState | undefined
       const getState = () => {
-        state ||= createProgressSummaryState(context, options, messages)
+        if (state) return state
+        const messages = context.input.messages()
+        if (!messages.some(message => message.role === "user") && !context.input.get().prompt) return
+        state = createProgressSummaryState(context, options, messages)
         states.set(context.context, state)
         return state
       }
+      invocationStarts.set(context.context, () => {
+        if (context.invocation?.kind === "stream") getState()
+      })
       context.output.render((result) => {
         if (isStreamResult(result)) {
           const state = getState()
+          if (!state) return result
           const wrapped = new WeakMap<object, AsyncIterable<unknown> & ReadableStream<unknown>>()
           const wrap = (stream: AsyncIterable<unknown> | ReadableStream<unknown>) => {
             const existing = wrapped.get(stream)
@@ -625,11 +629,15 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
           })
         }
         if (!isAsyncIterable(result)) return result
-        return withProgressSummaryStream(result, getState())
+        const state = getState()
+        return state ? withProgressSummaryStream(result, state) : result
       })
     },
     finish() {},
   }), {
+    [capabilityInvocationStartSymbol](context: AgentCapabilityRuntimeContext<TRuntimeConfig>) {
+      invocationStarts.get(context.context)?.()
+    },
     [eagerFinishExtensionSymbol]: true,
   })
 }

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -359,7 +359,7 @@ function createProgressSummaryState(
   let reasoningActive = false
   let previous: string | undefined
   let revision = 0
-  let emittedRevision = 0
+  let completedRevision = 0
   let dirty = true
   let running = false
   let closed = false
@@ -426,13 +426,16 @@ function createProgressSummaryState(
     }
     void generateProgressSummary(context, options, input)
       .then((summary) => {
-        if (closed || !summary || currentRevision <= emittedRevision || summary === previous) return
-        emittedRevision = currentRevision
+        if (closed || !summary || currentRevision <= completedRevision) return
+        completedRevision = currentRevision
+        if (summary === previous) return
         previous = summary
         latest = progressData(summary, currentRevision)
         for (const controller of controllers) controller.enqueue(latest)
       })
-      .catch(reportError)
+      .catch((error) => {
+        if (!closed && !generationAbort.signal.aborted) reportError(error)
+      })
       .finally(() => {
         generations.delete(generationAbort)
         if (intervalMs !== 0) return

--- a/packages/agent/src/capabilities/title.ts
+++ b/packages/agent/src/capabilities/title.ts
@@ -273,7 +273,9 @@ function titleAdapterRunContext(
   }
   return markAuxiliaryMessageChannelInstructionContext({
     actor: context.actor,
+    box: context.box,
     context: context.context,
+    harnessSandboxProvider: context.harnessSandboxProvider,
     toolStepReporter: context.runtimeContext.toolStepReporter,
     input: titleDriverInput(input, prompt),
     invoker: context.invoker,

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -63,6 +63,7 @@ import type {
 } from "./types.ts"
 import type { WorkspaceOverrideRuntime } from "./access-runtime.ts"
 import type { Message } from "./messages.ts"
+import type { Box } from "@vite-hub/box"
 import type { ReadonlyWorkspaceFacade, WorkspaceDefinition, WorkspaceName, WorkspaceSelectedScope, WorkspaceSource, WorkspaceSourceInput } from "@vite-hub/workspace"
 
 type ResolvedAgentOutputRenderer = ((result: unknown, extensions?: AgentOutputExtensions) => MaybePromise<unknown>) & {
@@ -132,8 +133,10 @@ export interface AgentCapabilityInvocationOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 > {
+  box?: Box
   context?: AgentInvocationContextStore
   driverKind?: AgentDriverKind
+  harnessSandboxProvider?: object
   invoker?: AgentInvoker
   model?: AgentModelResolver<TRuntimeConfig, Name>
   phases?: readonly AgentCapabilityRuntimePhase[]
@@ -998,9 +1001,11 @@ export async function resolveAgentCapabilities<
         ...runtimeContext,
         abortSignal: currentInput.abortSignal,
         actor: invoker,
+        box: invocationOptions.box,
         context: invocationContext,
         driver: { kind: driverKind },
         fs: currentWorkspace?.fs,
+        harnessSandboxProvider: invocationOptions.harnessSandboxProvider,
         invoker,
         runtimeContext: runtime,
         workspace: currentWorkspace,

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -137,6 +137,7 @@ export interface AgentCapabilityInvocationOptions<
   context?: AgentInvocationContextStore
   driverKind?: AgentDriverKind
   harnessSandboxProvider?: object
+  invocationKind?: "run" | "stream"
   invoker?: AgentInvoker
   model?: AgentModelResolver<TRuntimeConfig, Name>
   phases?: readonly AgentCapabilityRuntimePhase[]
@@ -1036,7 +1037,7 @@ export async function resolveAgentCapabilities<
         capability,
         mode: capability.mode,
         input,
-        invocation: { input },
+        invocation: { input, kind: invocationOptions.invocationKind || "run" },
         delivery: {
           effect(intent) {
             if (!intent || typeof intent !== "object" || typeof intent.kind !== "string" || !intent.kind.trim()) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1866,6 +1866,7 @@ async function createAgentInvocationContext<
   definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
   context: AgentRuntimeContext<TRuntimeConfig>,
   input: AgentRunInput<CALL_OPTIONS>,
+  invocationKind: "run" | "stream" = "run",
 ): Promise<AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>> {
   const startedAt = Date.now()
   const resolvedContext = createResolvedRuntimeContext(context)
@@ -1991,6 +1992,7 @@ async function createAgentInvocationContext<
       context: invocationContext,
       driverKind,
       harnessSandboxProvider,
+      invocationKind,
       invoker,
       model: agentModel as never,
       resolveCapabilityCli,
@@ -3142,7 +3144,7 @@ async function executeAgentInvocationWithCapacityLease<
   const definition = hasAgentDefinition(agent)
     ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput>
     : undefined
-  const invocation = preparedInvocation ?? await createAgentInvocationContext(definition, context, input)
+  const invocation = preparedInvocation ?? await createAgentInvocationContext(definition, context, input, options.kind)
   const shouldHoldInvocationOutput = () => options.holdCapacity === true || shouldWrapInvocationOutput(invocation)
   const lifecycle = await openAgentInvocationLifecycle<AgentInvocationFinishOutcome>(
     async (outcome) => {
@@ -3882,6 +3884,7 @@ async function executeAgentInvocation<
         agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput>,
         context,
         input,
+        options.kind,
       )
     : undefined
   if (preparedInvocation?.handledResponse) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1987,8 +1987,10 @@ async function createAgentInvocationContext<
     const agentModel = internalDefinition?.[baseAgentModel] as AgentModelResolver<TRuntimeConfig> | undefined
     const resolveCapabilityCli = resolveCapabilityCliRunSurface(definition)
     const capabilities = await resolveAgentCapabilities(capabilityOptions, runtimeContext, input, workspace as never, workspaceMode, {
+      box,
       context: invocationContext,
       driverKind,
+      harnessSandboxProvider,
       invoker,
       model: agentModel as never,
       resolveCapabilityCli,

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -220,9 +220,16 @@ export function withReadableStreamCleanup<T>(
           return
         }
         const error = uiMessageStreamError(result.value)
-        if (error) throw error
         options.onChunk?.(result.value)
         controller.enqueue(result.value)
+        if (error) {
+          await Promise.allSettled([
+            options.cancelOnAbort?.(error),
+            reader.cancel(error),
+          ].filter((task): task is Promise<void> => task !== undefined))
+          await runCleanup({ error, failed: true })
+          controller.error(error)
+        }
       }
       catch (error) {
         await Promise.allSettled([

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -182,6 +182,7 @@ export function withReadableStreamCleanup<T>(
 ): ReadableStream<T> {
   const reader = stream.getReader()
   let cleaned = false
+  let pendingError: unknown
   let wrappedController: ReadableStreamDefaultController<T> | undefined
   const runCleanup = async (outcome: StreamCleanupOutcome = { completed: true, failed: false }) => {
     if (cleaned) return
@@ -212,6 +213,10 @@ export function withReadableStreamCleanup<T>(
       wrappedController = controller
     },
     async pull(controller) {
+      if (pendingError !== undefined) {
+        controller.error(pendingError)
+        return
+      }
       try {
         const result = await reader.read()
         if (result.done) {
@@ -228,7 +233,7 @@ export function withReadableStreamCleanup<T>(
             reader.cancel(error),
           ].filter((task): task is Promise<void> => task !== undefined))
           await runCleanup({ error, failed: true })
-          controller.error(error)
+          pendingError = error
         }
       }
       catch (error) {

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -219,10 +219,16 @@ export function withReadableStreamCleanup<T>(
           controller.close()
           return
         }
+        const error = uiMessageStreamError(result.value)
+        if (error) throw error
         options.onChunk?.(result.value)
         controller.enqueue(result.value)
       }
       catch (error) {
+        await Promise.allSettled([
+          options.cancelOnAbort?.(error),
+          reader.cancel(error),
+        ].filter((task): task is Promise<void> => task !== undefined))
         await runCleanup({ error, failed: true })
         controller.error(error)
       }
@@ -267,6 +273,15 @@ export function uiMessageTextDelta(event: unknown): string | undefined {
     ?? (event as { delta?: unknown, textDelta?: unknown }).textDelta
     ?? (event as { delta?: unknown }).delta
   return typeof text === "string" ? text : undefined
+}
+
+function uiMessageStreamError(event: unknown): Error | undefined {
+  if (streamEventType(event) !== "error" || typeof event !== "object" || event === null) return
+  const error = event as { error?: unknown, errorText?: unknown, message?: unknown, recoverable?: unknown }
+  if (error.recoverable === true) return
+  if (error.error instanceof Error) return error.error
+  const message = error.errorText ?? error.message ?? error.error
+  return new Error(typeof message === "string" && message ? message : "Agent stream failed.")
 }
 
 function isCapabilityCliInput(input: unknown): input is { argv: string[], input?: unknown, json?: boolean } {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -719,6 +719,8 @@ export interface AgentCapabilityContext<
   Name extends WorkspaceName = WorkspaceName,
 > extends AgentAdapterMetadataContext<TRuntimeConfig, Name> {
   abortSignal?: AbortSignal
+  box?: Box
+  harnessSandboxProvider?: object
   invocation?: { input: AgentCapabilityInputContext }
   mode?: AgentCapabilityMode
   runtimeContext?: ResolvedAgentRuntimeContext

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -721,7 +721,7 @@ export interface AgentCapabilityContext<
   abortSignal?: AbortSignal
   box?: Box
   harnessSandboxProvider?: object
-  invocation?: { input: AgentCapabilityInputContext }
+  invocation?: { input: AgentCapabilityInputContext, kind?: "run" | "stream" }
   mode?: AgentCapabilityMode
   runtimeContext?: ResolvedAgentRuntimeContext
   workspaceDefinition?: WorkspaceDefinition
@@ -806,7 +806,7 @@ export interface AgentCapabilityRuntimeContext<
 > extends AgentCapabilityContext<TRuntimeConfig, Name> {
   capability: AgentCapabilityDefinition<TRuntimeConfig, Name>
   input: AgentCapabilityInputContext
-  invocation: { input: AgentCapabilityInputContext }
+  invocation: { input: AgentCapabilityInputContext, kind: "run" | "stream" }
   delivery: {
     effect: (intent: AgentChannelDeliveryEffectIntent) => void
     finishEffect: (effect: AgentChannelDeliveryFinishEffect) => void

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8856,7 +8856,7 @@ describe("agent message protocol", () => {
     vi.useFakeTimers()
     try {
       const { defineAgent, streamAgent } = await import("../src/index.ts")
-      const generations = [deferred<string>(), deferred<string>()]
+      const generations = [deferred<string>(), deferred<string>(), deferred<string>(), deferred<string>()]
       let sourceController!: ReadableStreamDefaultController<unknown>
       const execute = vi.fn(() => generations[execute.mock.calls.length - 1]!.promise)
       const agent = defineAgent({
@@ -8892,6 +8892,12 @@ describe("agent message protocol", () => {
       })
       generations[0]!.resolve("Stale first snapshot")
       await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(execute).toHaveBeenCalledTimes(4)
+      generations[3]!.resolve("Second snapshot")
+      await Promise.resolve()
+      generations[2]!.resolve("Stale third snapshot")
+      await Promise.resolve()
       sourceController.enqueue({ finishReason: "stop", type: "finish" })
       sourceController.close()
       const remaining = []
@@ -8901,10 +8907,12 @@ describe("agent message protocol", () => {
         remaining.push(next.value)
       }
 
-      expect(remaining).not.toContainEqual(expect.objectContaining({
-        data: expect.objectContaining({ revision: 1 }),
-        type: "data-progress-summary",
-      }))
+      for (const revision of [1, 3]) {
+        expect(remaining).not.toContainEqual(expect.objectContaining({
+          data: expect.objectContaining({ revision }),
+          type: "data-progress-summary",
+        }))
+      }
     }
     finally {
       vi.useRealTimers()
@@ -8913,17 +8921,24 @@ describe("agent message protocol", () => {
 
   it("aborts every concurrent progress generation when the primary stream closes", async () => {
     vi.useFakeTimers()
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {})
     try {
       const { defineAgent, streamAgent } = await import("../src/index.ts")
       let sourceController!: ReadableStreamDefaultController<unknown>
       const aborted: number[] = []
-      const execute = vi.fn(input => new Promise<string>((resolve) => {
+      const generations: Promise<string>[] = []
+      const execute = vi.fn((input) => {
         const call = execute.mock.calls.length
-        input.input.abortSignal?.addEventListener("abort", () => {
-          aborted.push(call)
-          resolve("")
-        }, { once: true })
-      }))
+        const generation = new Promise<string>((_resolve, reject) => {
+          input.input.abortSignal?.addEventListener("abort", () => {
+            aborted.push(call)
+            reject(new DOMException("Progress generation aborted.", "AbortError"))
+          }, { once: true })
+        })
+        generations.push(generation)
+        return generation
+      })
+      const traceLog = createTraceEventLog()
       const agent = defineAgent({
         capabilities: [progressSummary({ execute, intervalMs: 10_000 })],
         driver: { run: () => ({
@@ -8936,7 +8951,7 @@ describe("agent message protocol", () => {
             },
           }) },
       })
-      const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", traceLog, waitUntil: vi.fn() }, {
         messages: [createMessage({ role: "user", text: "Check inventory" })],
       }, { output: "ui-message-stream" }) as ReadableStream<unknown>
       const reader = stream.getReader()
@@ -8946,11 +8961,16 @@ describe("agent message protocol", () => {
       sourceController.enqueue({ finishReason: "stop", type: "finish" })
       sourceController.close()
       await reader.read()
+      await Promise.allSettled(generations)
+      await Promise.resolve()
 
       expect(aborted).toEqual([1, 2, 3])
+      expect(warning).not.toHaveBeenCalled()
+      expect(traceLog.entries()).not.toContainEqual(expect.objectContaining({ name: "agent.progress-summary.error" }))
       await reader.cancel()
     }
     finally {
+      warning.mockRestore()
       vi.useRealTimers()
     }
   })
@@ -8979,10 +8999,13 @@ describe("agent message protocol", () => {
     const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
       prompt: "hello",
     }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    const reader = stream.getReader()
 
-    await expect((async () => {
-      for await (const _chunk of stream) {}
-    })()).rejects.toThrow("provider failed")
+    await expect(reader.read()).resolves.toEqual({
+      done: false,
+      value: { errorText: "provider failed", type: "error" },
+    })
+    await expect(reader.read()).rejects.toThrow("provider failed")
     expect(agentError).toHaveBeenCalledOnce()
     expect(finish).not.toHaveBeenCalled()
   })
@@ -9376,7 +9399,7 @@ describe("agent message protocol", () => {
   it("uses capability-owned instructions and Markdown templates with harness drivers", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const session = { destroy: vi.fn() }
-    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessCreateSession.mockResolvedValue(session)
     harnessGenerate.mockResolvedValue({ text: "Reviewing availability for Acme." })
     const agent = defineAgent({
       capabilities: [
@@ -9428,7 +9451,7 @@ describe("agent message protocol", () => {
 
   it("resolves built-in progress summary drivers", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
-    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    harnessCreateSession.mockResolvedValue({ destroy: vi.fn() })
     harnessGenerate.mockResolvedValue({ text: "Checking inventory." })
     const agent = defineAgent({
       capabilities: [
@@ -9465,7 +9488,7 @@ describe("agent message protocol", () => {
   it("keeps user message contents out of the default progress prompt", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const session = { destroy: vi.fn() }
-    harnessCreateSession.mockResolvedValueOnce(session)
+    harnessCreateSession.mockResolvedValue(session)
     harnessGenerate.mockResolvedValue({ text: "Checking inventory." })
     const agent = defineAgent({
       capabilities: [

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -9000,6 +9000,7 @@ describe("agent message protocol", () => {
     const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
       prompt: "hello",
     }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+    await new Promise(resolve => setTimeout(resolve, 0))
     const reader = stream.getReader()
 
     await expect(reader.read()).resolves.toEqual({

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8841,6 +8841,7 @@ describe("agent message protocol", () => {
         },
       } as never,
       context: invocationContext,
+      driverKind: "harness",
       harnessSandboxProvider: sandbox,
       invocationKind: "stream",
     })
@@ -9026,6 +9027,20 @@ describe("agent message protocol", () => {
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
       prompt: "Check inventory",
     })).resolves.toEqual({ text: "Inventory checked." })
+    expect(execute).not.toHaveBeenCalled()
+  })
+
+  it("does not generate progress summaries when a streaming invocation returns a plain value", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const execute = vi.fn(() => "Checking inventory.")
+    const agent = defineAgent({
+      capabilities: [progressSummary({ execute })],
+      driver: { run: () => "Inventory checked." },
+    })
+
+    await expect(streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      prompt: "Check inventory",
+    })).resolves.toBe("Inventory checked.")
     expect(execute).not.toHaveBeenCalled()
   })
 

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -9029,6 +9029,29 @@ describe("agent message protocol", () => {
     expect(execute).not.toHaveBeenCalled()
   })
 
+  it("does not start progress before later Capability input handling finishes", async () => {
+    const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
+    const execute = vi.fn(() => "Checking inventory.")
+    const agent = defineAgent({
+      capabilities: [
+        progressSummary({ execute }),
+        defineCapability({
+          id: "handled-input",
+          input: () => new Response("handled"),
+        }),
+      ],
+      driver: { run: () => {
+        throw new Error("primary Driver should not run")
+      } },
+    })
+
+    const response = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      prompt: "Check inventory",
+    }) as Response
+    await expect(response.text()).resolves.toBe("handled")
+    expect(execute).not.toHaveBeenCalled()
+  })
+
   it("emits an initial progress summary before revising it for later activity", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     let sourceController!: ReadableStreamDefaultController<unknown>

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -8842,6 +8842,7 @@ describe("agent message protocol", () => {
       } as never,
       context: invocationContext,
       harnessSandboxProvider: sandbox,
+      invocationKind: "stream",
     })
 
     await resolved.start?.()
@@ -9008,6 +9009,23 @@ describe("agent message protocol", () => {
     await expect(reader.read()).rejects.toThrow("provider failed")
     expect(agentError).toHaveBeenCalledOnce()
     expect(finish).not.toHaveBeenCalled()
+  })
+
+  it("does not generate progress summaries for non-streaming invocations", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const execute = vi.fn(() => "Checking inventory.")
+    const agent = defineAgent({
+      capabilities: [progressSummary({ execute, intervalMs: 1 })],
+      driver: { run: async () => {
+        await new Promise(resolve => setTimeout(resolve, 10))
+        return { text: "Inventory checked." }
+      } },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      prompt: "Check inventory",
+    })).resolves.toEqual({ text: "Inventory checked." })
+    expect(execute).not.toHaveBeenCalled()
   })
 
   it("emits an initial progress summary before revising it for later activity", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -21,7 +21,10 @@ const loadAiSdk = vi.hoisted(() => vi.fn())
 
 vi.mock("@ai-sdk/harness/agent", () => ({
   HarnessAgent: class {
+    settings: Record<string, unknown>
+
     constructor(settings: Record<string, unknown>) {
+      this.settings = settings
       harnessAgentSettings.push(settings)
     }
 
@@ -62,6 +65,16 @@ function projectedHarnessMessages(entries: Array<["assistant" | "system" | "tool
     ]),
     role: "user",
   }]
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason?: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, reject, resolve }
 }
 
 async function failedTitleInvocation(options: {
@@ -8743,6 +8756,237 @@ describe("agent message protocol", () => {
     }))
   })
 
+  it("starts and buffers progress before delayed Harness setup reaches the HTTP UI stream", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { webChat } = await import("../src/channels.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
+    const primarySession = deferred<{ destroy: ReturnType<typeof vi.fn> }>()
+    const titleGeneration = deferred<string>()
+    harnessCreateSession.mockImplementation(function (this: { settings: Record<string, unknown> }) {
+      return this.settings.instructions ? { destroy: vi.fn() } : primarySession.promise
+    })
+    harnessGenerate.mockResolvedValue({ text: "Preparing the inventory check." })
+    harnessStream.mockReturnValue({
+      toUIMessageStream() {
+        return new ReadableStream({
+          start(controller) {
+            controller.enqueue({ messageId: "assistant-1", type: "start" })
+            controller.enqueue({ finishReason: "stop", type: "finish" })
+            controller.close()
+          },
+        })
+      },
+    })
+    const agent = defineAgent({
+      capabilities: [
+        title({ execute: () => titleGeneration.promise }),
+        progressSummary({
+          driver: { kind: "codex", model: "gpt-5.6-luna", sandbox: false },
+          intervalMs: 60_000,
+        }),
+      ],
+      channels: { portal: webChat },
+      driver: { harness: { provider: "codex" } },
+    })
+    const responseTask = createChannelChatRouteHandler(agent as never)(new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        id: "portal-thread",
+        messages: [{ id: "user-1", parts: [{ text: "Check inventory", type: "text" }], role: "user" }],
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    }), { agentName: "support" })
+
+    await vi.waitFor(() => expect(harnessGenerate).toHaveBeenCalledOnce())
+    let responseResolved = false
+    void responseTask.then(() => { responseResolved = true })
+    await Promise.resolve()
+    expect(responseResolved).toBe(false)
+
+    primarySession.resolve({ destroy: vi.fn() })
+    titleGeneration.resolve("Inventory check")
+    const response = await responseTask
+
+    expect(response.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1")
+    await expect(response.text()).resolves.toContain('"type":"data-progress-summary"')
+  })
+
+  it("propagates the invocation Box sandbox to title and progress Harness drivers", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { createAgentInvocationContextStore } = await import("../src/invocation-context.ts")
+    const harness = { harnessId: "test" }
+    const sandbox = { providerId: "box-test" }
+    const invocationContext = createAgentInvocationContextStore()
+    invocationContext.set("agent.finishHook", true)
+    harnessCreateSession.mockResolvedValue({ destroy: vi.fn() })
+    harnessGenerate.mockResolvedValue({ text: "Auxiliary result" })
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [
+        title({ driver: { harness } }),
+        progressSummary({ driver: { harness }, intervalMs: 60_000 }),
+      ],
+    }, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      runtimeConfig: {},
+      waitUntil: vi.fn(),
+    }, {
+      messages: [createMessage({ role: "user", text: "Check inventory" })],
+    }, undefined, "read", {
+      box: {
+        plan: {
+          identity: "box-test",
+          runtime: "test",
+          workspace: { path: "/workspace" },
+        },
+      } as never,
+      context: invocationContext,
+      harnessSandboxProvider: sandbox,
+    })
+
+    await resolved.start?.()
+    await vi.waitFor(() => expect(harnessGenerate).toHaveBeenCalledTimes(2))
+    await resolved.close()
+
+    expect(harnessAgentSettings).toHaveLength(2)
+    expect(harnessAgentSettings.every(settings => settings.sandbox === sandbox)).toBe(true)
+  })
+
+  it("runs fixed-cadence progress generations concurrently and ignores stale completions", async () => {
+    vi.useFakeTimers()
+    try {
+      const { defineAgent, streamAgent } = await import("../src/index.ts")
+      const generations = [deferred<string>(), deferred<string>()]
+      let sourceController!: ReadableStreamDefaultController<unknown>
+      const execute = vi.fn(() => generations[execute.mock.calls.length - 1]!.promise)
+      const agent = defineAgent({
+        capabilities: [progressSummary({ execute, intervalMs: 10_000 })],
+        driver: { run: () => ({
+            toUIMessageStream() {
+              return new ReadableStream({
+                start(controller) {
+                  sourceController = controller
+                },
+              })
+            },
+          }) },
+      })
+      const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+        messages: [createMessage({ role: "user", text: "Check inventory" })],
+      }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+      const reader = stream.getReader()
+
+      expect(execute).toHaveBeenCalledOnce()
+      await vi.advanceTimersByTimeAsync(10_000)
+      expect(execute).toHaveBeenCalledTimes(2)
+
+      const progress = reader.read()
+      generations[1]!.resolve("Second snapshot")
+      await expect(progress).resolves.toEqual({
+        done: false,
+        value: {
+          data: { revision: 2, summary: "Second snapshot", type: "progress-summary" },
+          transient: true,
+          type: "data-progress-summary",
+        },
+      })
+      generations[0]!.resolve("Stale first snapshot")
+      await Promise.resolve()
+      sourceController.enqueue({ finishReason: "stop", type: "finish" })
+      sourceController.close()
+      const remaining = []
+      for (;;) {
+        const next = await reader.read()
+        if (next.done) break
+        remaining.push(next.value)
+      }
+
+      expect(remaining).not.toContainEqual(expect.objectContaining({
+        data: expect.objectContaining({ revision: 1 }),
+        type: "data-progress-summary",
+      }))
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("aborts every concurrent progress generation when the primary stream closes", async () => {
+    vi.useFakeTimers()
+    try {
+      const { defineAgent, streamAgent } = await import("../src/index.ts")
+      let sourceController!: ReadableStreamDefaultController<unknown>
+      const aborted: number[] = []
+      const execute = vi.fn(input => new Promise<string>((resolve) => {
+        const call = execute.mock.calls.length
+        input.input.abortSignal?.addEventListener("abort", () => {
+          aborted.push(call)
+          resolve("")
+        }, { once: true })
+      }))
+      const agent = defineAgent({
+        capabilities: [progressSummary({ execute, intervalMs: 10_000 })],
+        driver: { run: () => ({
+            toUIMessageStream() {
+              return new ReadableStream({
+                start(controller) {
+                  sourceController = controller
+                },
+              })
+            },
+          }) },
+      })
+      const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+        messages: [createMessage({ role: "user", text: "Check inventory" })],
+      }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+      const reader = stream.getReader()
+
+      await vi.advanceTimersByTimeAsync(20_000)
+      expect(execute).toHaveBeenCalledTimes(3)
+      sourceController.enqueue({ finishReason: "stop", type: "finish" })
+      sourceController.close()
+      await reader.read()
+
+      expect(aborted).toEqual([1, 2, 3])
+      await reader.cancel()
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("fails lifecycle cleanup for nonrecoverable UI errors before finish", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const agentError = vi.fn()
+    const finish = vi.fn()
+    const agent = defineAgent({
+      driver: { run: () => ({
+          toUIMessageStream() {
+            return new ReadableStream({
+              start(controller) {
+                controller.enqueue({ errorText: "provider failed", type: "error" })
+                controller.enqueue({ finishReason: "stop", type: "finish" })
+                controller.close()
+              },
+            })
+          },
+        }) },
+      hooks: {
+        "agent:error": agentError,
+        "agent:finish": finish,
+      },
+    })
+    const stream = await streamAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {
+      prompt: "hello",
+    }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+
+    await expect((async () => {
+      for await (const _chunk of stream) {}
+    })()).rejects.toThrow("provider failed")
+    expect(agentError).toHaveBeenCalledOnce()
+    expect(finish).not.toHaveBeenCalled()
+  })
+
   it("emits an initial progress summary before revising it for later activity", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     let sourceController!: ReadableStreamDefaultController<unknown>
@@ -9011,6 +9255,48 @@ describe("agent message protocol", () => {
     await new Promise(resolve => setTimeout(resolve, 30))
 
     expect(execute).toHaveBeenCalledOnce()
+  })
+
+  it("reports progress driver error events without exposing their messages", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const traceLog = createTraceEventLog()
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {})
+    try {
+      const agent = defineAgent({
+        capabilities: [progressSummary({
+          driver: { run: () => (async function* () {
+              yield { error: new Error("secret progress failure"), type: "error" }
+            })() },
+          intervalMs: 0,
+        })],
+        driver: { run: () => ({
+            toUIMessageStream() {
+              return new ReadableStream({
+                async start(controller) {
+                  await new Promise(resolve => setTimeout(resolve, 20))
+                  controller.enqueue({ finishReason: "stop", type: "finish" })
+                  controller.close()
+                },
+              })
+            },
+          }) },
+      })
+      const stream = await streamAgent(agent, {
+        memo: vi.fn(),
+        runtime: "unknown",
+        traceLog,
+        waitUntil: vi.fn(),
+      }, { prompt: "Check inventory" }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+      for await (const _chunk of stream) {}
+
+      expect(warning).toHaveBeenCalledWith("[vitehub] progressSummary() generation failed.")
+      expect(JSON.stringify(warning.mock.calls)).not.toContain("secret progress failure")
+      await vi.waitFor(() => expect(traceLog.entries().some(event => event.name === "agent.progress-summary.error")).toBe(true))
+      expect(JSON.stringify(traceLog.entries().find(event => event.name === "agent.progress-summary.error"))).not.toContain("secret progress failure")
+    }
+    finally {
+      warning.mockRestore()
+    }
   })
 
   it("observes phased reasoning text without exposing its contents", async () => {


### PR DESCRIPTION
## Summary

- Start progress summary scheduling from the Capability lifecycle, buffer the latest transient update until the UI stream attaches, and keep positive intervals on a fixed overlapping cadence with revision guards.
- Propagate the invocation Box and Harness sandbox provider to title and progress Drivers, then abort every concurrent progress generation during cleanup.
- Fail Agent lifecycle cleanup on nonrecoverable UI error chunks and surface sanitized progress Driver warnings and traces.

## Verification

- `pnpm --filter @vite-hub/agent exec vp test run test/runtime.test.ts` — 361 passed
- `pnpm --filter @vite-hub/agent exec vp test run --reporter=dot` — 1,914 passed
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm --filter @vite-hub/agent build`
- `pnpm vp check --no-fmt <changed files>` — zero errors