### PR TITLE
fix(agent): preserve borrowed MCP clients

### DIFF
--- a/docs/content/docs/capabilities/mcp.md
+++ b/docs/content/docs/capabilities/mcp.md
@@ -17,7 +17,8 @@ Use the configuration example below as the starting point, then tighten modes, p
 
 ## What it adds
 
-The Capability normalizes MCP tool names with the server name, attaches sanitized MCP metadata, and closes MCP clients after the invocation.
+The Capability normalizes MCP tool names with the server name, attaches sanitized MCP metadata, and closes MCP clients created from configs or resolvers after the invocation.
+Static direct clients stay application-owned so they can be reused across invocations.
 Tool names, descriptions, and schemas stay with the MCP tool contract. Put broader guidance about when to use an MCP server in Agent Driver Instructions.
 An optional approved fingerprint map can block added or changed tool definitions before they reach an Agent Driver.
 
@@ -47,6 +48,7 @@ export default defineAgent({
 
 During resolution, `mcp()` connects to each configured MCP Server and asks for its tool set.
 ViteHub prefixes normalized tool names with `mcp_<server>_` and rejects duplicate normalized names.
+Pass a resolver or client config for an invocation-owned connection, or a static direct client when the application owns its lifetime.
 
 The Capability redacts secret-shaped metadata keys before exposing MCP metadata.
 

--- a/docs/content/docs/capabilities/mcp.md
+++ b/docs/content/docs/capabilities/mcp.md
@@ -25,7 +25,7 @@ An optional approved fingerprint map can block added or changed tool definitions
 ## Configuration
 
 Pass a server map.
-Each entry can resolve to an MCP client or MCP client configuration owned by the application.
+Each entry can be a static direct MCP client borrowed from the application, or a client config or resolver whose resolved client is owned by the Agent Invocation.
 
 ```ts [server/agents/support.ts]
 import { defineAgent } from '@vite-hub/agent'

--- a/packages/agent/src/capabilities/mcp.ts
+++ b/packages/agent/src/capabilities/mcp.ts
@@ -110,8 +110,9 @@ async function resolveMcpClient<
 >(
   server: McpServerConfig<TRuntimeConfig, Name>,
   context: AgentCapabilityRuntimeContext<TRuntimeConfig, Name>,
-): Promise<{ client: McpClient, metadata: unknown }> {
-  const resolved = typeof server === "function" ? await server(context) : server
+): Promise<{ client: McpClient, metadata: unknown, owned: boolean }> {
+  const owned = typeof server === "function"
+  const resolved = owned ? await server(context) : server
   if (isMcpClient(resolved)) {
     return {
       client: resolved,
@@ -119,12 +120,14 @@ async function resolveMcpClient<
         client: true,
         serverInfo: sanitizeMcpMetadata(resolved.serverInfo),
       },
+      owned,
     }
   }
   if (isMcpClientConfig(resolved)) {
     return {
       client: await createMcpClient(resolved),
       metadata: sanitizeMcpMetadata(resolved),
+      owned: true,
     }
   }
   throw new TypeError("[vitehub] mcp({ servers }) entries must resolve to an MCP client or MCP client config.")
@@ -147,8 +150,8 @@ export function mcp<
       const clients: McpClient[] = []
       clientsByContext.set(context, clients)
       for (const [serverName, server] of Object.entries(options.servers)) {
-        const { client, metadata } = await resolveMcpClient(server, context)
-        clients.push(client)
+        const { client, metadata, owned } = await resolveMcpClient(server, context)
+        if (owned) clients.push(client)
         const serverTools = await client.tools()
         if (options.integrity && Object.hasOwn(options.integrity, serverName)) {
           await assertMcpToolIntegrity(serverName, serverTools, options.integrity[serverName])

--- a/packages/agent/test/mcp-capability.test.ts
+++ b/packages/agent/test/mcp-capability.test.ts
@@ -38,7 +38,7 @@ async function fingerprintTools(tools: Record<string, unknown>) {
 }
 
 describe("mcp capability", () => {
-  it("loads direct client tools with namespaced metadata and closes clients", async () => {
+  it("loads direct client tools with namespaced metadata without closing the borrowed client", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { mcp } = await import("../src/capabilities.ts")
     const client = createClient({
@@ -69,7 +69,33 @@ describe("mcp capability", () => {
     })
 
     await resolved.close()
-    expect(client.close).toHaveBeenCalledTimes(1)
+    expect(client.close).not.toHaveBeenCalled()
+  })
+
+  it("keeps a static direct client usable across invocations", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { mcp } = await import("../src/capabilities.ts")
+    let closed = false
+    const execute = vi.fn(async () => {
+      if (closed) throw new Error("Attempted to send a request from a closed client")
+      return "ok"
+    })
+    const client = createClient({ lookup: { execute } })
+    client.close.mockImplementation(async () => {
+      closed = true
+      return undefined
+    })
+    const capability = mcp({ servers: { portal: client } })
+
+    const first = await resolveAgentCapabilities({ capabilities: [capability] }, runtime(), {})
+    await expect(first.tools!.mcp_portal_lookup!.execute!({})).resolves.toBe("ok")
+    await first.close()
+    const second = await resolveAgentCapabilities({ capabilities: [capability] }, runtime(), {})
+    await expect(second.tools!.mcp_portal_lookup!.execute!({})).resolves.toBe("ok")
+    await second.close()
+
+    expect(client.close).not.toHaveBeenCalled()
+    expect(execute).toHaveBeenCalledTimes(2)
   })
 
   it("creates clients from config entries and redacts secret metadata", async () => {
@@ -158,8 +184,8 @@ describe("mcp capability", () => {
     await expect(resolveAgentCapabilities({
       capabilities: [mcp({
         servers: {
-          "same!": first,
-          "same_": second,
+          "same!": () => first,
+          "same_": () => second,
         },
       })],
     }, runtime(), {})).rejects.toThrow("Duplicate MCP tool name")
@@ -179,7 +205,7 @@ describe("mcp capability", () => {
         integrity: {
           docs: await fingerprintTools(tools),
         },
-        servers: { docs: client },
+        servers: { docs: () => client },
       })],
     }, runtime(), {})
 
@@ -201,7 +227,7 @@ describe("mcp capability", () => {
           integrity: {
             docs: await fingerprintTools(approved),
           },
-          servers: { docs: client },
+          servers: { docs: () => client },
         })],
       }, runtime(), {})
     }
@@ -243,7 +269,7 @@ describe("mcp capability", () => {
     const client = createClient(await createTools(tools))
 
     await expect(resolveAgentCapabilities({
-      capabilities: [mcp({ integrity: { docs: {} }, servers: { docs: client } })],
+      capabilities: [mcp({ integrity: { docs: {} }, servers: { docs: () => client } })],
     }, runtime(), {})).rejects.toMatchObject({
       code: "MCP_TOOL_DEFINITION_DRIFT",
       details: { added: expect.arrayContaining([expect.any(String)]), server: "docs" },

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5,7 +5,7 @@ import { createMessage, getMessageText } from "@vite-hub/agent"
 import { createRateLimiter } from "@vite-hub/rate-limit"
 import { memoryRateLimitDriver } from "@vite-hub/rate-limit/drivers/memory"
 import { createTraceEventLog, deriveTraceRuns, emitTraceEvent, unknownExecutionAuthority } from "@vite-hub/runtime"
-import { chat, progressSummary, title, schedule, subagents } from "../src/capabilities.ts"
+import { chat, mcp, progressSummary, title, schedule, subagents } from "../src/capabilities.ts"
 import { toAgentFetchResponse } from "../src/http-response.ts"
 import { toJsonCompatibleValue } from "../src/tool-runtime.ts"
 import { adapterDefinition } from "./adapter-definition.ts"
@@ -8809,6 +8809,56 @@ describe("agent message protocol", () => {
 
     expect(response.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1")
     await expect(response.text()).resolves.toContain('"type":"data-progress-summary"')
+  })
+
+  it("keeps borrowed MCP tools callable across Harness chat invocations", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { webChat } = await import("../src/channels.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
+    let closed = false
+    const execute = vi.fn(async () => {
+      if (closed) throw new Error("Attempted to send a request from a closed client")
+      return { segment: "Critical Overstock" }
+    })
+    const client = {
+      close: vi.fn(async () => { closed = true }),
+      tools: vi.fn(async () => ({ inventory_health: { execute } })),
+    }
+    harnessCreateSession.mockResolvedValue({ destroy: vi.fn() })
+    harnessStream.mockImplementation(function (this: { settings: { tools: Record<string, { execute: (input: unknown) => Promise<unknown> }> } }) {
+      const tool = this.settings.tools.mcp_portal_inventory_health!
+      return {
+        fullStream: (async function* () {
+          yield { input: {}, toolCallId: "inventory-1", toolName: "mcp_portal_inventory_health", type: "tool-input-available" }
+          const output = await tool.execute({})
+          yield { output, toolCallId: "inventory-1", type: "tool-output-available" }
+          yield { id: "final-1", type: "text-start" }
+          yield { delta: "Critical Overstock is largest.", id: "final-1", type: "text-delta" }
+          yield { id: "final-1", type: "text-end" }
+          yield { finishReason: "stop", type: "finish" }
+        })(),
+      }
+    })
+    const agent = defineAgent({
+      capabilities: [mcp({ servers: { portal: client } })],
+      channels: { portal: webChat },
+      driver: { harness: { provider: "codex" } },
+    })
+    const handler = createChannelChatRouteHandler(agent as never)
+    const request = (id: string) => new Request("https://example.com/api/_vitehub/agents/support/chat", {
+      body: JSON.stringify({
+        id,
+        messages: [{ id: `user-${id}`, parts: [{ text: "Which segment is largest?", type: "text" }], role: "user" }],
+      }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    })
+
+    await expect((await handler(request("first"), { agentName: "support" })).text()).resolves.toContain("Critical Overstock is largest.")
+    await expect((await handler(request("second"), { agentName: "support" })).text()).resolves.toContain("Critical Overstock is largest.")
+
+    expect(execute).toHaveBeenCalledTimes(2)
+    expect(client.close).not.toHaveBeenCalled()
   })
 
   it("propagates the invocation Box sandbox to title and progress Harness drivers", async () => {


### PR DESCRIPTION
## Summary

- keep static direct MCP clients application-owned across agent invocations
- retain per-invocation cleanup for client configs and resolver-created clients
- cover repeated Harness tool calls and final web-chat response delivery

## Verification

- `pnpm vp test run test/mcp-capability.test.ts test/runtime.test.ts -t "mcp capability|keeps borrowed MCP tools callable across Harness chat invocations"` — 14 passed
- `pnpm --filter @vite-hub/agent typecheck` — passed
- `pnpm vp run lint` — passed with existing warnings
- `pnpm --filter @vite-hub/agent test` — 1,913 passed; six unrelated existing environment/timeout failures (`chmod: --: No such file or directory` in Box fixtures plus fixture timeouts)