### PR TITLE
fix: retire Calories ViteHub patches

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -149,7 +149,7 @@ teams({
 
 Set `messages.commentary: 'message'` only when the Driver emits explicit commentary phases that should become public progress. Commentary is hidden by default; ViteHub never publishes reasoning as progress.
 
-Use `messages.delivery: 'manual'` when finish hooks own replies. A generated Workflow may carry manual delivery across a durable boundary when the Channel and host support it. Overlap policies such as `serial`, `drop`, `queue`, and `reject` remain inline and cannot be combined with required durable delivery.
+Use `messages.delivery: 'manual'` when finish hooks own replies. A generated Workflow may carry manual delivery across a durable boundary when the Channel and host support it. An explicit `messages.timeout` bounds inline execution and the durable handoff's typing indicator, but it does not cap the durable Agent Workflow. Overlap policies such as `serial`, `drop`, `queue`, and `reject` remain inline and cannot be combined with required durable delivery.
 
 ## Scope abilities to one Channel
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -756,10 +756,23 @@ async function runAgentAsWorkflow<
   const binding = resolveAgentWorkflowRuntimeBinding<TRuntimeConfig>(agent)
   const cloudflareEnv = context.cloudflare?.env || getCloudflareEnv(context)
   if (!binding || ("discoveryDefault" in binding && !context.agentIdentity)) return undefined
-  const { getWorkflowRuntimeConfig, runWithWorkflowRuntimeEvent } = await loadAgentWorkflowRuntimeStateModule()
-  const workflowConfig = getWorkflowRuntimeConfig()
-  if ("discoveryDefault" in binding) {
-    if (!workflowConfig) return undefined
+  const workflowRuntimeState = await loadAgentWorkflowRuntimeStateModule()
+  let workflowConfig = workflowRuntimeState.getWorkflowRuntimeConfig()
+  let activateCloudflareWorkflow = false
+  if ("discoveryDefault" in binding && workflowConfig === undefined) {
+    if (input.context?.[requireAgentWorkflowContextKey] !== true || !cloudflareEnv) return undefined
+    workflowConfig = { provider: "cloudflare" }
+    activateCloudflareWorkflow = true
+  }
+  if ("discoveryDefault" in binding && workflowConfig === false) return undefined
+  if (input.context?.[requireAgentWorkflowContextKey] === true && workflowConfig && workflowConfig.provider === "cloudflare") {
+    if (!cloudflareEnv) return undefined
+    const workflowName = resolveAgentWorkflowName(agent, binding, context)
+    const workflowBindingName = workflowConfig.binding || (await loadAgentWorkflowModule()).getCloudflareWorkflowBindingName(workflowName)
+    if (!cloudflareEnv[workflowBindingName]) return undefined
+  }
+  if (activateCloudflareWorkflow) {
+    workflowRuntimeState.setWorkflowRuntimeConfig(workflowConfig)
   }
   if ("discoveryDefault" in binding && context.agentIdentity) {
     const owner = (context as AgentRuntimeContext & { [agentIdentityOwner]?: object })[agentIdentityOwner]
@@ -777,6 +790,7 @@ async function runAgentAsWorkflow<
   const workflowInput = { ...portableResolvedAgentInvokerInput(input) }
   // ponytail: AbortSignal is live process state and cannot cross a durable Workflow payload.
   delete workflowInput.abortSignal
+  if (input.context?.[requireAgentWorkflowContextKey] === true) delete workflowInput.timeout
   if (workflowInput.messages) workflowInput.messages = await portableWorkflowMessages(workflowInput.messages)
   if (workflowInput.message && typeof workflowInput.message !== "string") [workflowInput.message] = await portableWorkflowMessages([workflowInput.message])
   if (Array.isArray(workflowInput.prompt)) workflowInput.prompt = await portableWorkflowMessages(workflowInput.prompt)
@@ -807,7 +821,7 @@ async function runAgentAsWorkflow<
       ? await portableAgentWorkflowRunId(context.run.runId)
       : context.run.runId
     : undefined
-  const run = await runWithWorkflowRuntimeEvent(workflowEvent, () => handle.run(
+  const run = await workflowRuntimeState.runWithWorkflowRuntimeEvent(workflowEvent, () => handle.run(
     payload,
     workflowRunId ? { id: workflowRunId } : {},
   ))

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3073,14 +3073,23 @@ async function handleChatSdkMessage(
     )
     const resolvedInvocationInput = invocation.input as AgentRunInput
     if (durableDelivery) {
-      await runAgent(agent as never, runContext as never, withResolvedAgentInvokerInput({
-        ...resolvedInvocationInput,
-        context: {
-          ...resolvedInvocationInput.context,
-          [finalChannelOutputContextKey]: true,
-          [requireAgentWorkflowContextKey]: true,
-        },
-      }, invoker) as never)
+      const durableTyping = startChatTypingRefresh(thread, context)
+      const durableTypingTimeout = setTimeout(() => durableTyping.stop(), options?.timeout ?? 28_000)
+      try {
+        await runAgent(agent as never, runContext as never, withResolvedAgentInvokerInput({
+          ...resolvedInvocationInput,
+          context: {
+            ...resolvedInvocationInput.context,
+            [finalChannelOutputContextKey]: true,
+            [requireAgentWorkflowContextKey]: true,
+          },
+        }, invoker) as never)
+      }
+      catch (error) {
+        clearTimeout(durableTypingTimeout)
+        durableTyping.stop()
+        throw error
+      }
       return
     }
     typing = streamsPhasedReplies || manualDelivery ? startChatTypingRefresh(thread, context) : undefined

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -9475,7 +9475,7 @@ describe("server helpers", () => {
       channels: {
         telegram: testTelegram(telegram, {
           adapter: () => adapter as never,
-          messages: { delivery: "manual", timeout: 60_000 },
+          messages: { delivery: "manual", timeout: 20 },
         }),
       },
       driver: { run: async ({ input }) => {
@@ -9488,7 +9488,7 @@ describe("server helpers", () => {
       },
     })
     const handler = createChannelWebhookRouteHandler(agent as never)
-    setWorkflowRuntimeConfig({ provider: "cloudflare" })
+    setWorkflowRuntimeConfig({ provider: "vercel" })
 
     try {
       const response = await Promise.race([
@@ -9504,15 +9504,152 @@ describe("server helpers", () => {
       if (response === "blocked") throw new Error("Durable chat delivery waited for Workflow completion.")
       expect(response.status).toBe(200)
       expect(adapter.postMessage).not.toHaveBeenCalled()
+      expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
       release()
       await Promise.all(waitUntilTasks)
       await vi.waitFor(() => {
         expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "Durable reply" })
       })
-      expect(observedTimeout).toBe(60_000)
+      expect(observedTimeout).toBeUndefined()
     }
     finally {
       release()
+      resetWorkflowRuntime()
+    }
+  })
+
+  it("activates Cloudflare Workflow delivery for durable discovered Agents", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { getCloudflareWorkflowBindingName } = await import("@vite-hub/workflow")
+    const { resetWorkflowRuntime } = await import("@vite-hub/workflow/runtime/state")
+    const adapter = createTestChatAdapter()
+    const waitUntilTasks: Array<Promise<unknown>> = []
+    let workflowPayload: { input?: { timeout?: number } } | undefined
+    const create = vi.fn(async ({ id, params }: { id: string, params: typeof workflowPayload }) => {
+      workflowPayload = params
+      return { id, status: async () => ({ status: "queued" }) }
+    })
+    const run = vi.fn(() => "internal output")
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: { delivery: "manual", durable: true, timeout: 20 },
+        }),
+      },
+      driver: { run },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = await handler(chatWebhookRequest(91_106), "telegram", {
+        agentIdentity: { name: "calories" },
+        cloudflare: {
+          env: {
+            [getCloudflareWorkflowBindingName("calories")]: { create, get: vi.fn() },
+          },
+        },
+        waitUntil: task => waitUntilTasks.push(task),
+      })
+
+      expect(response.status).toBe(200)
+      expect(create).toHaveBeenCalledOnce()
+      expect(workflowPayload?.input?.timeout).toBeUndefined()
+      expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
+      expect(run).not.toHaveBeenCalled()
+      await Promise.all(waitUntilTasks)
+      await expect(handler(chatWebhookRequest(91_107), "telegram", {
+        agentIdentity: { name: "calories" },
+        cloudflare: { env: {} },
+        waitUntil: task => waitUntilTasks.push(task),
+      })).rejects.toThrow("Durable Channel delivery requires this Agent invocation to start a Workflow")
+    }
+    finally {
+      resetWorkflowRuntime()
+    }
+  })
+
+  it("preserves an explicit Workflow provider opt-out for durable discovered Agents", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { getCloudflareWorkflowBindingName } = await import("@vite-hub/workflow")
+    const { resetWorkflowRuntime, setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
+    const adapter = createTestChatAdapter()
+    const create = vi.fn()
+    const run = vi.fn(() => "internal output")
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: { delivery: "manual", durable: true },
+        }),
+      },
+      driver: { run },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+    setWorkflowRuntimeConfig(false)
+
+    try {
+      await expect(handler(chatWebhookRequest(91_109), "telegram", {
+        agentIdentity: { name: "calories" },
+        cloudflare: {
+          env: {
+            [getCloudflareWorkflowBindingName("calories")]: { create, get: vi.fn() },
+          },
+        },
+      })).rejects.toThrow("Durable Channel delivery requires this Agent invocation to start a Workflow")
+
+      expect(create).not.toHaveBeenCalled()
+      expect(run).not.toHaveBeenCalled()
+    }
+    finally {
+      resetWorkflowRuntime()
+    }
+  })
+
+  it("stops durable typing when the Workflow handoff fails", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const { getCloudflareWorkflowBindingName } = await import("@vite-hub/workflow")
+    const { resetWorkflowRuntime } = await import("@vite-hub/workflow/runtime/state")
+    const adapter = createTestChatAdapter()
+    const waitUntilTasks: Array<Promise<unknown>> = []
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: { delivery: "manual", durable: true, timeout: 60_000 },
+        }),
+      },
+      driver: { run: () => "internal output" },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      await expect(handler(chatWebhookRequest(91_108), "telegram", {
+        agentIdentity: { name: "calories" },
+        cloudflare: {
+          env: {
+            [getCloudflareWorkflowBindingName("calories")]: {
+              create: async () => { throw new Error("Workflow handoff failed") },
+              get: vi.fn(),
+            },
+          },
+        },
+        waitUntil: task => waitUntilTasks.push(task),
+      })).rejects.toThrow("Workflow provider operation failed")
+
+      expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
+      await expect(Promise.race([
+        Promise.all(waitUntilTasks).then(() => "settled"),
+        new Promise(resolve => setTimeout(() => resolve("blocked"), 100)),
+      ])).resolves.toBe("settled")
+    }
+    finally {
       resetWorkflowRuntime()
     }
   })

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -449,7 +449,7 @@ function renderAgentWorkflowRegistryEntry(registryFile: string, definition: Disc
     `    const cached = registryEntryCache.get(${JSON.stringify(definition.name)})`,
     "    if (cached) return cached",
     `    const loaded = await ${renderRegistryImport(registryFile, definition.handler)}`,
-    `    const agent = agentWithColocatedHome(agentWithColocatedSkills(workspaceAgentWithSourceRoot("default" in loaded ? loaded.default : loaded, ${JSON.stringify(resolveAgentWorkspaceSourceRoot(definition.handler))}, ${JSON.stringify(readAgentInstructions(definition.handler))}), ${JSON.stringify(readAgentSkills(definition.handler))}), ${JSON.stringify(readAgentHome(definition.handler))})`,
+    `    const agent = agentWithColocatedHome(agentWithColocatedSkills(workspaceAgentWithSourceRoot(agentWithColocatedInstructions("default" in loaded ? loaded.default : loaded, ${JSON.stringify(readAgentInstructions(definition.handler))}), ${JSON.stringify(resolveAgentWorkspaceSourceRoot(definition.handler))}, ${JSON.stringify(readAgentInstructions(definition.handler))}), ${JSON.stringify(readAgentSkills(definition.handler))}), ${JSON.stringify(readAgentHome(definition.handler))})`,
     `    const entry = { handler: async (context) => await runAgentWorkflowDefinition(agent, { ...context, payload: { ...context.payload, agentIdentity: context.payload?.agentIdentity || { name: ${JSON.stringify(definition.agentIdentity || definition.name)} } } }, runAgentInline) }`,
     `    registryEntryCache.set(${JSON.stringify(definition.name)}, entry)`,
     "    return entry",
@@ -514,7 +514,7 @@ function createWorkflowRegistryContents(
   const imports = [
     ...(needsAgentRuntime
       ? [
-          `import { runAgentInline } from ${JSON.stringify(agentImportBase)}`,
+          `import { agentWithColocatedInstructions, runAgentInline } from ${JSON.stringify(agentImportBase)}`,
           `import { agentWithColocatedHome, agentWithColocatedSkills, runAgentWorkflowDefinition, workspaceAgentWithSourceRoot } from ${JSON.stringify(`${agentImportBase}/runtime/workflow`)}`,
           ...(installAgentWorkflowRuntime
             ? [`import { setAgentWorkflowRuntimeLoaders } from ${JSON.stringify(`${agentImportBase}/server/internal`)}`]

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -210,6 +210,7 @@ describe("Vite workflow provider outputs", () => {
     expect(registry).toContain("workspaceAgentWithSourceRoot")
     expect(registry).toContain("agentWithColocatedSkills")
     expect(registry).toContain("agentWithColocatedHome")
+    expect(registry).toContain('agentWithColocatedInstructions("default" in loaded ? loaded.default : loaded, "Use flat Agent instructions.\\n")')
     expect(registry).toContain(Buffer.from("[user]\nname = ViteHub\n").toString("base64"))
     expect(registry).toContain("__vitehubAgentSkill:skills/review/SKILL.md")
     expect(registry).toContain(JSON.stringify(join(agentDir, "workspace")))


### PR DESCRIPTION
## Summary

- activate discovered Cloudflare Agent Workflows only when a required durable channel handoff has its exact generated binding
- keep channel timeouts at the webhook and typing boundary, including prompt cleanup when a durable handoff fails
- preserve colocated Agent instructions in generated Workflow registries

## Patch audit

Provider cost, manual delivery defaults, Workflow portability, database capabilities, retry translation, and Cloudflare externalization are already upstream. Reply context remains owned by #948, while the patched global `__env__` mutation is obsolete because Cloudflare environments are scoped with `AsyncLocalStorage`.

## Verification

- `pnpm exec vp run build`
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm --filter @vite-hub/workflow typecheck`
- `pnpm --filter @vite-hub/agent exec vp test test/providers.test.ts`
- `pnpm --filter @vite-hub/agent exec vp test test/test-runner.test.ts`
- `pnpm --filter @vite-hub/workflow exec vp test`
- `pnpm lint`
- isolated Calories install, focused channel tests, typecheck, and production build against a composite pkg.pr.new preview of this PR plus the current #948 and #961 heads, with only the two `@vite-hub/*` patches removed
