### PR TITLE
fix: harden hosted consumer runtime boundaries

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1000,6 +1000,15 @@ async function applyChannelDeliveryEffectIntents<
       }
       catch (error) {
         delivered = false
+        console.error(JSON.stringify({
+          scope: "vitehub.channel.delivery",
+          event: "outbound.failed",
+          channelId: active.channelId,
+          effect: intent.kind,
+          intent: intent.intent,
+          runId: context.run?.runId,
+          error: agentErrorMessage(error).slice(0, 2_000),
+        }))
         await traceAgentChannelDeliveryEffect(toTraceContext(context), intent, {
           ...metadata,
           "error.message": agentErrorMessage(error),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1000,15 +1000,18 @@ async function applyChannelDeliveryEffectIntents<
       }
       catch (error) {
         delivered = false
-        console.error(JSON.stringify({
-          scope: "vitehub.channel.delivery",
-          event: "outbound.failed",
-          channelId: active.channelId,
-          effect: intent.kind,
-          intent: intent.intent,
-          runId: context.run?.runId,
-          error: agentErrorMessage(error).slice(0, 2_000),
-        }))
+        try {
+          console.error(JSON.stringify({
+            scope: "vitehub.channel.delivery",
+            event: "outbound.failed",
+            channelId: active.channelId.slice(0, 256),
+            effect: intent.kind.slice(0, 256),
+            intent: intent.intent?.slice(0, 256),
+            runId: context.run?.runId.slice(0, 256),
+            error: agentErrorMessage(error).slice(0, 2_000),
+          }))
+        }
+        catch {}
         await traceAgentChannelDeliveryEffect(toTraceContext(context), intent, {
           ...metadata,
           "error.message": agentErrorMessage(error),

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4804,6 +4804,7 @@ describe("agent message protocol", () => {
   it("does not fail invocations when delivery effects or hook observers fail", async () => {
     const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
     const agent = defineAgent({
       capabilities: [
@@ -4843,9 +4844,19 @@ describe("agent message protocol", () => {
 
     try {
       await expect(runAgentTrigger(agent, runtime, "portal.message", {})).resolves.toBe("ok")
+      expect(error).toHaveBeenCalledWith(JSON.stringify({
+        scope: "vitehub.channel.delivery",
+        event: "outbound.failed",
+        channelId: "portal",
+        effect: "reaction",
+        intent: "started",
+        runId: "portal-run",
+        error: "reaction failed",
+      }))
       expect(warn).toHaveBeenCalled()
     }
     finally {
+      error.mockRestore()
       warn.mockRestore()
     }
   })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4804,6 +4804,10 @@ describe("agent message protocol", () => {
   it("does not fail invocations when delivery effects or hook observers fail", async () => {
     const { defineAgent, defineCapability, runAgentTrigger } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
+    const channelId = `portal-${"c".repeat(300)}`
+    const effect = `reaction-${"e".repeat(300)}`
+    const intent = `started-${"i".repeat(300)}`
+    const runId = `portal-run-${"r".repeat(300)}`
     const error = vi.spyOn(console, "error").mockImplementation(() => {})
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
     const agent = defineAgent({
@@ -4811,14 +4815,14 @@ describe("agent message protocol", () => {
         defineCapability({
           id: "feedback",
           prepare(context) {
-            context.delivery.effect({ intent: "started", kind: "reaction" })
+            context.delivery.effect({ intent, kind: effect })
           },
         }),
       ],
       channels: {
-        portal: defineChannel("portal", {
+        [channelId]: defineChannel("portal", {
           effects: {
-            reaction: () => {
+            [effect]: () => {
               throw new Error("reaction failed")
             },
           },
@@ -4827,7 +4831,7 @@ describe("agent message protocol", () => {
             message: {
               invoke: context => ({
                 input: { prompt: "hello" },
-                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId: "portal-run" },
+                run: { channelId: context.trigger.channelId, origin: context.channel.kind, runId },
               }),
             },
           },
@@ -4843,14 +4847,14 @@ describe("agent message protocol", () => {
     const runtime = { memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() }
 
     try {
-      await expect(runAgentTrigger(agent, runtime, "portal.message", {})).resolves.toBe("ok")
+      await expect(runAgentTrigger(agent, runtime, `${channelId}.message`, {})).resolves.toBe("ok")
       expect(error).toHaveBeenCalledWith(JSON.stringify({
         scope: "vitehub.channel.delivery",
         event: "outbound.failed",
-        channelId: "portal",
-        effect: "reaction",
-        intent: "started",
-        runId: "portal-run",
+        channelId: channelId.slice(0, 256),
+        effect: effect.slice(0, 256),
+        intent: intent.slice(0, 256),
+        runId: runId.slice(0, 256),
         error: "reaction failed",
       }))
       expect(warn).toHaveBeenCalled()

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -164,7 +164,7 @@ function renderNitroBlobPlugin(blob: BlobViteRuntimeConfig["blob"], cloudflare: 
 
 function renderNitroBlobMiddleware(importBase = blobPackageName): string {
   return [
-    "// @ts-expect-error Cloudflare provides this virtual module at runtime.",
+    "// @ts-ignore Cloudflare provides this virtual module at runtime.",
     "import { env as vitehubEnv } from 'cloudflare:workers'",
     "import { defineMiddleware } from 'nitro'",
     `import { setActiveCloudflareEnv } from '${importBase}/runtime/state'`,

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -164,6 +164,7 @@ function renderNitroBlobPlugin(blob: BlobViteRuntimeConfig["blob"], cloudflare: 
 
 function renderNitroBlobMiddleware(importBase = blobPackageName): string {
   return [
+    "// @ts-expect-error Cloudflare provides this virtual module at runtime.",
     "import { env as vitehubEnv } from 'cloudflare:workers'",
     "import { defineMiddleware } from 'nitro'",
     `import { setActiveCloudflareEnv } from '${importBase}/runtime/state'`,

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -492,7 +492,7 @@ describe("hubBlob", () => {
     ])
   })
 
-  it("uses Cloudflare defaults for the Nitro runtime when hosting is inferred", async () => {
+  it("uses Cloudflare defaults for the Nitro runtime when hosting is inferred", { timeout: 30_000 }, async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-blob-inferred-cloudflare-"))
     const previousBucket = process.env.BLOB_BUCKET_NAME
     const previousHosting = process.env.VITEHUB_HOSTING
@@ -525,12 +525,6 @@ describe("hubBlob", () => {
       expect(middleware).not.toContain("next")
 
       await symlink(join(workspaceRoot, "node_modules"), join(root, "node_modules"), "dir")
-      await writeFile(join(root, "runtime-types.d.ts"), [
-        "declare module 'cloudflare:workers' {",
-        "  export const env: unknown",
-        "}",
-        "",
-      ].join("\n"))
       await writeFile(join(root, "tsconfig.json"), `${JSON.stringify({
         compilerOptions: {
           module: "Preserve",
@@ -540,7 +534,7 @@ describe("hubBlob", () => {
           strict: true,
           types: [],
         },
-        files: ["runtime-types.d.ts", ".vitehub/nitro/blob/middleware.ts"],
+        files: [".vitehub/nitro/blob/middleware.ts"],
       }, null, 2)}\n`)
       await execFileAsync(process.execPath, [join(workspaceRoot, "node_modules/typescript/bin/tsc"), "-p", root], { cwd: root })
     }

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -537,6 +537,24 @@ describe("hubBlob", () => {
         files: [".vitehub/nitro/blob/middleware.ts"],
       }, null, 2)}\n`)
       await execFileAsync(process.execPath, [join(workspaceRoot, "node_modules/typescript/bin/tsc"), "-p", root], { cwd: root })
+      await writeFile(join(root, "runtime-types.d.ts"), [
+        "declare module 'cloudflare:workers' {",
+        "  export const env: unknown",
+        "}",
+        "",
+      ].join("\n"))
+      await writeFile(join(root, "tsconfig.json"), `${JSON.stringify({
+        compilerOptions: {
+          module: "Preserve",
+          moduleResolution: "Bundler",
+          noEmit: true,
+          skipLibCheck: true,
+          strict: true,
+          types: [],
+        },
+        files: ["runtime-types.d.ts", ".vitehub/nitro/blob/middleware.ts"],
+      }, null, 2)}\n`)
+      await execFileAsync(process.execPath, [join(workspaceRoot, "node_modules/typescript/bin/tsc"), "-p", root], { cwd: root })
     }
     finally {
       if (typeof previousBucket === "undefined") delete process.env.BLOB_BUCKET_NAME

--- a/packages/database/src/nuxt.ts
+++ b/packages/database/src/nuxt.ts
@@ -132,10 +132,7 @@ export function hubDb(options: DatabaseNuxtIntegrationOptions = {}): DatabaseNux
           )
         }
         if (!nuxtOptions.dev) {
-          const runtimeRoot = resolvedOptions.projectRoot
-            ? root
-            : typeof viteConfig.root === "string" ? viteConfig.root : nuxtOptions.srcDir || root
-          mergeNitroDatabaseRuntimeAlias(config, runtimeRoot, provider ?? (d1 ? "cloudflare" : undefined))
+          mergeNitroDatabaseRuntimeAlias(config, root, provider ?? (d1 ? "cloudflare" : undefined))
         }
         if (!nuxtOptions.dev && provider === "cloudflare") {
           await installNitroCloudflareEnvBridge(config, root)

--- a/packages/database/test/nuxt.test.ts
+++ b/packages/database/test/nuxt.test.ts
@@ -218,7 +218,7 @@ describe("Database Nuxt integration", () => {
     }
   })
 
-  it("aliases the hosted runtime from the Nuxt source directory", async () => {
+  it("aliases the hosted runtime from the ViteHub project root", async () => {
     const { hooks, nuxt } = createNuxt({
       database: {
         driver: "d1",
@@ -241,12 +241,12 @@ describe("Database Nuxt integration", () => {
 
     expect(nitroConfig).toMatchObject({
       alias: {
-        "@vite-hub/database/drizzle": "/tmp/vitehub-db-nuxt/app/.vitehub/database/cloudflare-runtime.mjs",
+        "@vite-hub/database/drizzle": "/tmp/vitehub-db-nuxt/.vitehub/database/cloudflare-runtime.mjs",
       },
     })
   })
 
-  it("aliases the hosted runtime from a custom Vite root", async () => {
+  it("keeps the hosted runtime at the ViteHub project root with a custom Vite root", async () => {
     const { hooks, nuxt } = createNuxt({
       dev: false,
       nitro: { preset: "vercel" },
@@ -262,7 +262,7 @@ describe("Database Nuxt integration", () => {
 
     expect(nitroConfig).toMatchObject({
       alias: {
-        "@vite-hub/database/drizzle": "/tmp/vitehub-db-nuxt/custom-vite-root/.vitehub/database/vercel-runtime.mjs",
+        "@vite-hub/database/drizzle": "/tmp/vitehub-db-nuxt/.vitehub/database/vercel-runtime.mjs",
       },
     })
   })

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -570,7 +570,7 @@ describe("ViteHub Nuxt integration", () => {
       .toBe(databaseRuntimeState)
     expect(nitroConfig).toMatchObject({
       alias: {
-        "@vite-hub/database/drizzle": "/tmp/vitehub-nuxt/custom-vite-root/.vitehub/database/cloudflare-runtime.mjs",
+        "@vite-hub/database/drizzle": "/tmp/vitehub-nuxt/.vitehub/database/cloudflare-runtime.mjs",
         "@vite-hub/database/runtime/state": databaseRuntimeState,
       },
     })


### PR DESCRIPTION
Repair three independent ViteHub-owned runtime boundaries exposed by one hosted-consumer validation path; this does not introduce a shared hosted-consumer abstraction.

A production Telegram delivery failure disappeared because Channel effect errors were only attached to optional traces. The shared delivery boundary now emits one best-effort structured console record with capped dynamic fields for the channel, effect, intent, run, and provider error while preserving existing invocation and no-retry behavior.

Installing that fix into the Calories consumer exposed two current-main output regressions. Generated Cloudflare Blob middleware required a consumer-owned ambient declaration, and hosted Database aliases followed Nuxt `srcDir` or a custom Vite `root` even though ViteHub generated both runtime modules under its project root. Generated Blob middleware now handles the provider virtual-module import without a consumer shim, and Database aliases resolve from the ViteHub project root that owns the generated files.

## Verification

- Agent runtime suite: 366 tests passed
- Agent package typecheck
- Blob generated-middleware typecheck with and without consumer Cloudflare declarations, plus package typecheck
- Database Nuxt suite: 24 tests passed
- Database package typecheck
- Aggregate ViteHub Nuxt integration expectation
- `git diff --check`