### PR TITLE
fix(nuxt): wire env and Cloudflare email bindings

### DIFF
--- a/packages/email/src/vite.ts
+++ b/packages/email/src/vite.ts
@@ -111,17 +111,21 @@ function renderConfiguredEmailDefinitionModule(
   driverImport: string,
   runtimeEnvImport: string,
   cloudflare: boolean,
+  cloudflareEmail: boolean,
 ): string {
   return [
     `import createDriver from ${JSON.stringify(driverImport)}`,
     `import { resolveServerEnv } from ${JSON.stringify(runtimeEnvImport)}`,
     ...(cloudflare ? ["import { env as vitehubEmailEnv } from \"cloudflare:workers\""] : []),
+    ...(cloudflareEmail ? ["import { EmailMessage } from \"cloudflare:email\""] : []),
     "",
     `const registry = ${JSON.stringify(definition.options, null, 2)}`,
     "export const definition = {",
     "  driver: () => {",
     `    const options = resolveServerEnv(registry${cloudflare ? ", { env: vitehubEmailEnv }" : ""})`,
-    `    return createDriver(${renderResolvedOptions(definition.options, "options")})`,
+    `    return createDriver(${cloudflareEmail
+      ? `{ ...${renderResolvedOptions(definition.options, "options")}, binding: vitehubEmailEnv.EMAIL, EmailMessage }`
+      : renderResolvedOptions(definition.options, "options")})`,
     "  },",
     "}",
     "export default definition",
@@ -145,17 +149,31 @@ function mergeNitroExternal(value: unknown, addition: string): unknown {
   return value
 }
 
-function configureNitroCloudflareWorkers(config: Record<string, unknown>): void {
+function configureNitroCloudflareWorkers(config: Record<string, unknown>, email: boolean): void {
   const nitro = isRecord(config.nitro) ? config.nitro : {}
   const rollupConfig = isRecord(nitro.rollupConfig) ? nitro.rollupConfig : {}
   const cloudflare = isRecord(nitro.cloudflare) ? nitro.cloudflare : {}
   const wrangler = isRecord(cloudflare.wrangler) ? cloudflare.wrangler : {}
   const compatibilityFlags = Array.isArray(wrangler.compatibility_flags) ? [...wrangler.compatibility_flags] : []
+  const sendEmail = Array.isArray(wrangler.send_email) ? [...wrangler.send_email] : []
   if (!compatibilityFlags.includes("nodejs_compat")) compatibilityFlags.push("nodejs_compat")
+  if (email && !sendEmail.some(binding => isRecord(binding) && binding.name === "EMAIL")) sendEmail.push({ name: "EMAIL" })
   config.nitro = {
     ...nitro,
-    cloudflare: { ...cloudflare, wrangler: { ...wrangler, compatibility_flags: compatibilityFlags } },
-    rollupConfig: { ...rollupConfig, external: mergeNitroExternal(rollupConfig.external, "cloudflare:workers") },
+    cloudflare: {
+      ...cloudflare,
+      wrangler: {
+        ...wrangler,
+        compatibility_flags: compatibilityFlags,
+        ...(sendEmail.length ? { send_email: sendEmail } : {}),
+      },
+    },
+    rollupConfig: {
+      ...rollupConfig,
+      external: email
+        ? mergeNitroExternal(mergeNitroExternal(rollupConfig.external, "cloudflare:workers"), "cloudflare:email")
+        : mergeNitroExternal(rollupConfig.external, "cloudflare:workers"),
+    },
   }
 }
 
@@ -169,6 +187,7 @@ export function hubEmail(options: EmailVitePluginOptions): EmailVitePlugin {
   const runtimeEnvImport = internalOptions.runtimeEnvImport
     ?? resolve(dirname(resolvePackageImport("@vite-hub/env/package.json")), "dist/server.js")
   let cloudflare = false
+  const cloudflareEmail = configured.driver === "unemail/driver/cloudflare-email"
   let definition: GeneratedEmailDefinition | undefined
 
   return {
@@ -179,7 +198,7 @@ export function hubEmail(options: EmailVitePluginOptions): EmailVitePlugin {
     },
     config(config) {
       cloudflare = getHostingProvider(resolveHosting(internalOptions, config as Record<string, unknown>)) === "cloudflare"
-      if (cloudflare) configureNitroCloudflareWorkers(config as Record<string, unknown>)
+      if (cloudflare) configureNitroCloudflareWorkers(config as Record<string, unknown>, cloudflareEmail)
       return {
         ssr: { noExternal: mergeNoExternal(config.ssr?.noExternal) },
       }
@@ -190,13 +209,13 @@ export function hubEmail(options: EmailVitePluginOptions): EmailVitePlugin {
         handler: resolve(resolveViteHubGeneratedRoot(config), "email/definition.mjs"),
       }
       const entry = definition.handler.replace(/\.mjs$/, ".entry.mjs")
-      await writeFileIfChanged(entry, renderConfiguredEmailDefinitionModule(definition, driverImport, runtimeEnvImport, cloudflare))
+      await writeFileIfChanged(entry, renderConfiguredEmailDefinitionModule(definition, driverImport, runtimeEnvImport, cloudflare, cloudflare && cloudflareEmail))
       try {
         await bundleEsmEntry(entry, definition.handler, {
-          external: cloudflare ? ["cloudflare:workers"] : undefined,
+          external: cloudflare ? ["node:*", "cloudflare:workers", ...(cloudflareEmail ? ["cloudflare:email"] : [])] : undefined,
           format: "esm",
           minifyWhitespace: true,
-          platform: "node",
+          platform: cloudflare ? "neutral" : "node",
           rootDir: config.root,
         })
       }

--- a/packages/email/test/vite.test.ts
+++ b/packages/email/test/vite.test.ts
@@ -97,6 +97,28 @@ describe("hubEmail", () => {
     expect(source).toContain("resolveServerEnv(registry,{env:vitehubEmailEnv})")
   })
 
+  it("wires the Cloudflare Email driver to its Worker binding", async () => {
+    const root = await createTempProject()
+    const plugin = hubEmail({ driver: "unemail/driver/cloudflare-email" })
+    const config = plugin.config as unknown as (config: Record<string, unknown>) => Record<string, unknown>
+    const cloudflareConfig = { nitro: { preset: "cloudflare-module" } }
+
+    config(cloudflareConfig)
+    expect(cloudflareConfig).toMatchObject({
+      nitro: {
+        cloudflare: { wrangler: { send_email: [{ name: "EMAIL" }] } },
+        rollupConfig: { external: ["cloudflare:workers", "cloudflare:email"] },
+      },
+    })
+
+    await resolvePlugin(plugin, root)
+    const source = await loadConfiguredDefinition(plugin)
+    expect(source).toContain("cloudflare:email")
+    expect(source).toContain("binding:vitehubEmailEnv.EMAIL")
+    expect(source).toContain("EmailMessage")
+    expect(source).not.toContain("fileURLToPath(import.meta.url)")
+  })
+
   it("uses the development Nitro preset instead of the deployment target", async () => {
     const root = await createTempProject()
     const plugin = hubEmail({

--- a/packages/vite-hub/src/cloudflare-prerender.mjs
+++ b/packages/vite-hub/src/cloudflare-prerender.mjs
@@ -5,6 +5,14 @@ export class DurableObject {
   }
 }
 
+export class EmailMessage {
+  constructor(from, to, raw) {
+    this.from = from
+    this.to = to
+    this.raw = raw
+  }
+}
+
 export class WorkflowEntrypoint {
   constructor(ctx, env) {
     this.ctx = ctx

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -282,17 +282,28 @@ function cloneRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {}
 }
 
+function matchesRollupExternal(value: unknown, source: string, args: unknown[]): boolean {
+  if (typeof value === "string") return value === source
+  if (value instanceof RegExp) {
+    value.lastIndex = 0
+    return value.test(source)
+  }
+  if (typeof value === "function") return Boolean(value(source, ...args))
+  if (Array.isArray(value)) return value.some(entry => matchesRollupExternal(entry, source, args))
+  return false
+}
+
 function configureCloudflarePrerender(config: Record<string, unknown>): void {
   const rollupConfig = cloneRecord(config.rollupConfig)
   const external = rollupConfig.external
-  if (Array.isArray(external)) rollupConfig.external = external.filter(value => value !== "cloudflare:workers")
-  else if (external === "cloudflare:workers") delete rollupConfig.external
-  else if (typeof external === "function") {
+  const prerenderImports = new Set(["cloudflare:email", "cloudflare:workers"])
+  if (typeof external !== "undefined") {
     rollupConfig.external = (source: string, ...args: unknown[]) =>
-      source === "cloudflare:workers" ? false : external(source, ...args)
+      prerenderImports.has(source) ? false : matchesRollupExternal(external, source, args)
   }
   config.alias = {
     ...cloneRecord(config.alias),
+    "cloudflare:email": fileURLToPath(new URL("./cloudflare-prerender.mjs", import.meta.url)),
     "cloudflare:workers": fileURLToPath(new URL("./cloudflare-prerender.mjs", import.meta.url)),
   }
   config.rollupConfig = rollupConfig

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -4,16 +4,19 @@ import { fileURLToPath } from "node:url"
 import { resolveViteHubProjectRoot, VITEHUB_GENERATED_ROOT, VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import hubAuthNuxt from "@vite-hub/auth/nuxt"
 import { hubDb as hubDatabaseNuxt } from "@vite-hub/database/nuxt"
+import { createEnvImportAliases } from "@vite-hub/env/vite"
 import { mergeConfig } from "vite"
 
 import { vitehub } from "./index.ts"
 
 import type { DatabaseNuxtIntegrationOptions } from "@vite-hub/database"
+import type { EnvIntegrationOptions, EnvViteConfigOptions, EnvViteUserConfig } from "@vite-hub/env"
 import type { Plugin, PluginOption, UserConfig } from "vite"
 
 const databaseRuntimeState = fileURLToPath(new URL("./_internal/database/runtime/state", import.meta.url))
-type ViteHubNuxtOptions = Omit<Parameters<typeof vitehub>[0], "database"> & {
+type ViteHubNuxtOptions = Omit<Parameters<typeof vitehub>[0], "database" | "env"> & {
   database?: boolean | Exclude<DatabaseNuxtIntegrationOptions, false>
+  env?: false | EnvIntegrationOptions & EnvViteConfigOptions
 }
 
 type NuxtLike = {
@@ -70,6 +73,24 @@ function addVueImports(nuxt: NuxtLike, from: string, names: string[]): void {
     }
     if (!existing) imports.push({ from, name })
   }
+}
+
+function isEnvDeclarationNamespace(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value) && (value as Record<string, unknown>).kind !== "env-variable")
+}
+
+function mergeEnvDeclarationNamespaces<T extends Record<string, unknown>>(
+  existing: T | undefined,
+  configured: T,
+): T {
+  const merged = { ...existing }
+  for (const [key, value] of Object.entries(configured)) {
+    const current = merged[key]
+    merged[key] = isEnvDeclarationNamespace(current) && isEnvDeclarationNamespace(value)
+      ? mergeEnvDeclarationNamespaces(current, value)
+      : value
+  }
+  return merged as T
 }
 
 type QueueNitroConfigHandler = (options: {
@@ -220,10 +241,21 @@ type ViteHubNuxtModule = {
 const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(inlineOptions, nuxt): Promise<void> {
   if (!nuxt) return
 
-  const options = {
+  const moduleOptions = {
     ...nuxt.options.vitehub,
     ...inlineOptions,
   } as ViteHubNuxtOptions
+  const configuredEnv = moduleOptions.env
+  const envConfig = configuredEnv && typeof configuredEnv === "object"
+    ? { define: configuredEnv.define, public: configuredEnv.public, server: configuredEnv.server }
+    : undefined
+  const envOptions = configuredEnv && typeof configuredEnv === "object"
+    ? Object.fromEntries(Object.entries(configuredEnv).filter(([key]) => !["define", "public", "server"].includes(key)))
+    : configuredEnv
+  const options = {
+    ...moduleOptions,
+    env: envOptions,
+  } as Parameters<typeof vitehub>[0]
   const rootDir = nuxt.options.rootDir || process.cwd()
   const viteRoot = resolve(rootDir, typeof nuxt.options.vite?.root === "string" ? nuxt.options.vite.root : rootDir)
   const projectRoot = resolveViteHubProjectRoot(viteRoot)
@@ -281,10 +313,19 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
   ]
 
   nuxt.options.vite ??= {}
-  const viteConfig = nuxt.options.vite as UserConfig & {
+  const viteConfig = nuxt.options.vite as UserConfig & EnvViteUserConfig & {
     [VITEHUB_GENERATED_ROOT]?: string
     [VITEHUB_NITRO_CONFIG_CONTEXT]?: true
     [VITEHUB_SERVER_DIRS]?: string[]
+  }
+  if (envConfig && Object.values(envConfig).some(Boolean)) {
+    const existingEnv = viteConfig.env ?? {}
+    viteConfig.env = {
+      ...existingEnv,
+      ...(envConfig.define ? { define: mergeEnvDeclarationNamespaces(existingEnv.define, envConfig.define) } : {}),
+      ...(envConfig.public ? { public: mergeEnvDeclarationNamespaces(existingEnv.public, envConfig.public) } : {}),
+      ...(envConfig.server ? { server: mergeEnvDeclarationNamespaces(existingEnv.server, envConfig.server) } : {}),
+    }
   }
   viteConfig.define = {
     ...viteConfig.define,
@@ -297,7 +338,30 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
     ...plugins.filter(plugin => !existingNames.has(plugin.name)),
     ...existing,
   ] as PluginOption[]
-  nuxt.hook?.("nitro:config", config => applyNitroConfig(installedPlugins, config, nuxt))
+  const envPlugin = installedPlugins.find(plugin => plugin.name === "@vite-hub/env/vite") as Plugin & {
+    api?: { resolveProjectRoot?: (viteRoot: string) => string }
+  } | undefined
+  const configuredEnvProjectRootOption = options.env && typeof options.env === "object"
+    ? options.env.projectRoot
+    : undefined
+  const configuredEnvProjectRoot = configuredEnvProjectRootOption
+    ? resolve(viteRoot, configuredEnvProjectRootOption)
+    : undefined
+  const envProjectRoot = envPlugin?.api?.resolveProjectRoot?.(viteRoot) ?? configuredEnvProjectRoot ?? projectRoot
+  if (envPlugin?.api?.resolveProjectRoot && configuredEnvProjectRoot) {
+    if (configuredEnvProjectRoot !== envProjectRoot) {
+      throw new TypeError(`[vitehub] Env projectRoot ${JSON.stringify(configuredEnvProjectRootOption)} conflicts with the installed Env Vite plugin.`)
+    }
+  }
+  const generatedAliases = {
+    ...(options.env === false ? {} : createEnvImportAliases({ projectRoot: envProjectRoot })),
+    "#vitehub/templates": join(projectRoot, ".vitehub/markdown-template/templates.mjs"),
+  }
+  nuxt.hook?.("nitro:config", async (config) => {
+    await applyNitroConfig(installedPlugins, config, nuxt)
+    const alias = (config.alias ??= {}) as Record<string, string>
+    for (const [name, path] of Object.entries(generatedAliases)) alias[name] ??= path
+  })
   if (options.agent) addVueImports(nuxt, "vite-hub/agent/vue", agentVueComposables)
   if (options.auth) {
     const envOptions = options.env || {}
@@ -309,6 +373,12 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
       importsFrom: "vite-hub/auth/vue",
       nitro: false,
     }, nuxt)
+  }
+  const nuxtAlias = (nuxt.options.alias ??= {})
+  const nitroAlias = ((nuxt.options.nitro ??= {}).alias ??= {}) as Record<string, string>
+  for (const [name, path] of Object.entries(generatedAliases)) {
+    nuxtAlias[name] ??= path
+    nitroAlias[name] ??= path
   }
   if (options.realtime) {
     addVueImports(nuxt, "vite-hub/realtime", ["defineRealtime"])

--- a/packages/vite-hub/test/nuxt-agent.test.ts
+++ b/packages/vite-hub/test/nuxt-agent.test.ts
@@ -38,7 +38,7 @@ it("registers generated Agent handlers from the Nuxt build directory", async () 
     },
   }
 
-  viteHubNuxtModule({ agent: true, preset: "node" }, nuxt)
+  await viteHubNuxtModule({ agent: true, preset: "node" }, nuxt)
   expect(nuxt.options.vite.define).toMatchObject({
     __VITEHUB_APP_BASE_URL__: JSON.stringify("/portal/"),
   })

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -265,6 +265,9 @@ describe("ViteHub Nuxt integration", () => {
         nitro: expect.objectContaining({ preset: "cloudflare_module" }),
         resolve: {
           alias: {
+            "#vitehub/env/public": "/tmp/vitehub-nuxt/.vitehub/env/public.mjs",
+            "#vitehub/env/server": "/tmp/vitehub-nuxt/.vitehub/env/server.mjs",
+            "#vitehub/templates": "/tmp/vitehub-nuxt/.vitehub/markdown-template/templates.mjs",
             "~": "/tmp/vitehub-nuxt/app",
           },
         },
@@ -279,6 +282,11 @@ describe("ViteHub Nuxt integration", () => {
     )
     expect(mocks.outputHook).not.toHaveBeenCalled()
     expect(nitroConfig).toEqual({
+      alias: {
+        "#vitehub/env/public": "/tmp/vitehub-nuxt/.vitehub/env/public.mjs",
+        "#vitehub/env/server": "/tmp/vitehub-nuxt/.vitehub/env/server.mjs",
+        "#vitehub/templates": "/tmp/vitehub-nuxt/.vitehub/markdown-template/templates.mjs",
+      },
       cloudflare: {
         wrangler: {
           d1_databases: [d1Binding, d1Binding],
@@ -349,6 +357,132 @@ describe("ViteHub Nuxt integration", () => {
         include: ["../.vitehub/types.d.ts", "../apps/api/.vitehub/**/*.d.ts"],
       },
     })
+  })
+
+  it("accepts Env declarations under vitehub and installs generated runtime aliases", async () => {
+    const { nuxt, runNitroConfigHook } = createNuxt()
+    const githubToken = { source: "GITHUB_TOKEN" }
+
+    await viteHubNuxtModule({
+      env: {
+        projectRoot: "apps/api",
+        server: { githubToken },
+      },
+      preset: "node",
+    } as never, nuxt)
+
+    expect(mocks.vitehub).toHaveBeenCalledWith({
+      env: { projectRoot: "apps/api" },
+      preset: "node",
+    })
+    expect(nuxt.options.vite).toMatchObject({
+      env: { server: { githubToken } },
+    })
+    expect(nuxt.options.alias).toMatchObject({
+      "#vitehub/env/server": "/tmp/vitehub-nuxt/apps/api/.vitehub/env/server.mjs",
+      "#vitehub/templates": "/tmp/vitehub-nuxt/.vitehub/markdown-template/templates.mjs",
+    })
+
+    const nitroConfig = { alias: { "#vitehub/templates": "./custom-templates.mjs" } }
+    await runNitroConfigHook(nitroConfig)
+    expect(nitroConfig.alias).toMatchObject({
+      "#vitehub/env/server": "/tmp/vitehub-nuxt/apps/api/.vitehub/env/server.mjs",
+      "#vitehub/templates": "./custom-templates.mjs",
+    })
+  })
+
+  it("replaces existing Env array declarations instead of concatenating data values", async () => {
+    const { nuxt } = createNuxt()
+    const vite = nuxt.options.vite as typeof nuxt.options.vite & { env?: Record<string, unknown> }
+    vite.env = { public: { regions: ["old"] } }
+
+    await viteHubNuxtModule({
+      env: { public: { regions: ["new"] } },
+      preset: "node",
+    } as never, nuxt)
+
+    expect(vite.env).toMatchObject({ public: { regions: ["new"] } })
+  })
+
+  it("merges nested Env declaration namespaces without merging declaration leaves", async () => {
+    const { nuxt } = createNuxt()
+    const vite = nuxt.options.vite as typeof nuxt.options.vite & { env?: Record<string, unknown> }
+    vite.env = {
+      server: {
+        database: {
+          password: { source: "OLD_PASSWORD" },
+          url: { source: "DATABASE_URL" },
+        },
+      },
+    }
+
+    await viteHubNuxtModule({
+      env: { server: { database: { password: { source: "DATABASE_PASSWORD" } } } },
+      preset: "node",
+    } as never, nuxt)
+
+    expect(vite.env).toMatchObject({
+      server: {
+        database: {
+          password: { source: "DATABASE_PASSWORD" },
+          url: { source: "DATABASE_URL" },
+        },
+      },
+    })
+  })
+
+  it("preserves Env namespace children named source and kind", async () => {
+    const { nuxt } = createNuxt()
+    const vite = nuxt.options.vite as typeof nuxt.options.vite & { env?: Record<string, unknown> }
+    vite.env = {
+      server: {
+        service: {
+          kind: { source: "SERVICE_KIND" },
+          source: { source: "SERVICE_SOURCE" },
+        },
+      },
+    }
+
+    await viteHubNuxtModule({
+      env: { server: { service: { token: { source: "SERVICE_TOKEN" } } } },
+      preset: "node",
+    } as never, nuxt)
+
+    expect(vite.env).toMatchObject({
+      server: {
+        service: {
+          kind: { source: "SERVICE_KIND" },
+          source: { source: "SERVICE_SOURCE" },
+          token: { source: "SERVICE_TOKEN" },
+        },
+      },
+    })
+  })
+
+  it("derives Env aliases from an existing Env Vite plugin", async () => {
+    const envPlugin = {
+      name: "@vite-hub/env/vite",
+      api: {
+        resolveProjectRoot: (root: string) => resolve(root, "packages/config"),
+      },
+    }
+    const { nuxt } = createNuxt(false, [envPlugin])
+
+    await viteHubNuxtModule({ preset: "node" }, nuxt)
+
+    expect(nuxt.options.alias).toMatchObject({
+      "#vitehub/env/server": "/tmp/vitehub-nuxt/packages/config/.vitehub/env/server.mjs",
+    })
+  })
+
+  it("keeps Env runtime aliases disabled while retaining Markdown templates", async () => {
+    const { nuxt } = createNuxt()
+
+    await viteHubNuxtModule({ env: false, preset: "node" }, nuxt)
+
+    const alias = nuxt.options.alias as Record<string, string>
+    expect(alias).not.toHaveProperty("#vitehub/env/server")
+    expect(alias["#vitehub/templates"]).toBe("/tmp/vitehub-nuxt/.vitehub/markdown-template/templates.mjs")
   })
 
   it("includes generated types from every configured integration project root", async () => {
@@ -575,7 +709,9 @@ describe("ViteHub Nuxt integration", () => {
     }
     expect(options.imports.imports).toHaveLength(5)
     expect(options.alias).not.toHaveProperty("#vitehub/env/server")
-    expect(options.nitro).not.toHaveProperty("alias")
+    expect(options.nitro.alias).toEqual({
+      "#vitehub/templates": "/tmp/vitehub-nuxt/.vitehub/markdown-template/templates.mjs",
+    })
     expect(options.nitro).not.toHaveProperty("plugins")
   })
 
@@ -605,7 +741,7 @@ describe("ViteHub Nuxt integration", () => {
     await viteHubNuxtModule({ preset: "node" }, nuxt)
     await runNitroConfigHook(nitroConfig)
 
-    expect(nitroConfig).toEqual({
+    expect(nitroConfig).toMatchObject({
       modules: ["first", "second"],
     })
   })

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -575,11 +575,49 @@ describe("vitehub", () => {
     expect(existingPrerender).toHaveBeenCalledWith(prerenderConfig)
     expect(prerenderConfig).toMatchObject({
       alias: {
+        "cloudflare:email": expect.stringMatching(/cloudflare-prerender\.mjs$/),
         "cloudflare:workers": expect.stringMatching(/cloudflare-prerender\.mjs$/),
         existing: "/existing",
       },
-      rollupConfig: { external: ["node:fs"] },
     })
+    const external = prerenderConfig.rollupConfig.external as unknown as (source: string) => boolean
+    expect(external("cloudflare:workers")).toBe(false)
+    expect(external("node:fs")).toBe(true)
+  })
+
+  it("aliases every Cloudflare Email runtime import during Nitro prerendering", async () => {
+    const config = await applyDeploymentConfig({ preset: "cloudflare" })
+    const hooks = (config.nitro as { hooks: Record<string, unknown> }).hooks
+    const prerender = hooks["prerender:config"] as (config: Record<string, unknown>) => Promise<void>
+    const prerenderConfig = {
+      rollupConfig: { external: ["cloudflare:email", "cloudflare:workers"] },
+    }
+
+    await prerender(prerenderConfig)
+
+    expect(prerenderConfig).toMatchObject({
+      alias: {
+        "cloudflare:email": expect.stringMatching(/cloudflare-prerender\.mjs$/),
+        "cloudflare:workers": expect.stringMatching(/cloudflare-prerender\.mjs$/),
+      },
+    })
+    const external = prerenderConfig.rollupConfig.external as unknown as (source: string) => boolean
+    expect(external("cloudflare:email")).toBe(false)
+    expect(external("cloudflare:workers")).toBe(false)
+  })
+
+  it("overrides matching regex externals for Cloudflare prerender imports", async () => {
+    const config = await applyDeploymentConfig({ preset: "cloudflare" })
+    const hooks = (config.nitro as { hooks: Record<string, unknown> }).hooks
+    const prerender = hooks["prerender:config"] as (config: Record<string, unknown>) => Promise<void>
+    const prerenderConfig = { rollupConfig: { external: [/^cloudflare:/, /^node:/] } }
+
+    await prerender(prerenderConfig)
+
+    const external = prerenderConfig.rollupConfig.external as unknown as (source: string) => boolean
+    expect(external("cloudflare:email")).toBe(false)
+    expect(external("cloudflare:workers")).toBe(false)
+    expect(external("node:fs")).toBe(true)
   })
 
   it("leaves deployment output to the Nitro module matching the active preset", async () => {


### PR DESCRIPTION
Nuxt consumers could configure Env only through raw Vite options, generated Env and Markdown imports were unavailable to Nitro, and the Cloudflare Email driver had no Worker binding. This made the obvious top-level vitehub configuration fail at build or runtime.

This change accepts Env declarations under vitehub.env, exposes generated runtime aliases to Nuxt and Nitro, and wires unemail/driver/cloudflare-email to an EMAIL send_email binding with Cloudflare EmailMessage.

Verified with:
- pnpm exec vp test -- test/nuxt.test.ts
- pnpm exec vp test -- test/vite.test.ts
- pnpm --filter vite-hub typecheck
- pnpm --filter @vite-hub/email typecheck
- package builds for vite-hub and @vite-hub/email