### PR TITLE
feat(workspace): make invocation materialization revision-native

### DIFF
--- a/docs/content/docs/server-primitives/workspace.md
+++ b/docs/content/docs/server-primitives/workspace.md
@@ -398,7 +398,9 @@ export async function testDocs() {
 
 ### Session method options
 
-`startSession({ host, paths, target })` composes Workspace state with an already-open Box Session. `host` is required for execution; `paths` limits materialization and commit scope; `target` defaults to `/workspace`. The caller owns the Box lifecycle, so closing the Workspace Session does not close its host. Integrations that already own a live materialized tree can set `attach: true`; the Session preserves pre-existing live edits, never rematerializes the whole tree, and rolls back only its own uncommitted changes on close.
+`startSession(options)` composes Workspace state with an already-open Box Session. `host` is required for execution; `paths` limits materialization and commit scope; `target` defaults to `/workspace`. `abortSignal` cancels preparation, and `onProgress` reports its materialization phases. The caller owns the Box lifecycle, so closing the Workspace Session does not close its host.
+
+Set `writeBack.exclude` to Workspace-relative paths owned by the runtime rather than the invocation. Excluded paths remain usable in the host tree, but their changes are omitted from `diff()` and `commit()` and their pre-Session state is restored by `close()`. ViteHub always applies the same behavior to `.agent-runs`, `.git`, and `.vitehub`. Integrations that already own a live materialized tree can set `attach: true`; the Session preserves pre-existing live edits, never rematerializes the whole tree, and rolls back only its own uncommitted changes on close.
 
 | Method | Options | Behavior |
 | --- | --- | --- |

--- a/packages/agent/src/harness-agent.ts
+++ b/packages/agent/src/harness-agent.ts
@@ -33,6 +33,7 @@ import {
   withAgentToolStepReporting,
   withJsonCompatibleToolOutputs,
 } from "./tool-runtime.ts"
+import { traceAgentEvent } from "./trace.ts"
 
 import type {
   AgentAdapter,
@@ -51,6 +52,7 @@ import type {
   MaybePromise,
 } from "./types.ts"
 import type { AttachmentData, Message } from "./messages.ts"
+import type { ExecutionAuthority } from "@vite-hub/runtime"
 import type { UserContent, UserModelMessage } from "ai"
 
 type HarnessAgentLike = {
@@ -781,6 +783,43 @@ function harnessWriteBackIgnorePaths(context: AgentAdapterRunContext, instructio
     ...(instructions ? harnessInstructionFiles : []),
     ...colocatedSkillDirectories,
   ]
+}
+
+async function reportHarnessWorkspaceProgress(
+  context: AgentAdapterRunContext,
+  event: {
+    data?: Record<string, unknown>
+    durationMs?: number
+    error?: string
+    id: string
+    label: string
+    status: "started" | "updating" | "completed" | "failed"
+  },
+) {
+  const trace = traceAgentEvent({
+    context: context.context,
+    input: context.input,
+    invoker: context.invoker,
+    run: context.runtime.run,
+    runtime: context.runtime,
+  }, {
+    attributes: {
+      ...event.data,
+      "workspace.durationMs": event.durationMs,
+      "workspace.error": event.error,
+      "workspace.phase": event.id,
+      "workspace.status": event.status,
+    },
+    name: event.id,
+    type: event.status === "failed" ? "error" : "run",
+  })
+  const runEvents = (context.runtime as typeof context.runtime & {
+    runEvents?: { publish(event: { data: unknown, type: string }): Promise<unknown> }
+  }).runEvents
+  await Promise.allSettled([
+    trace,
+    runEvents?.publish({ data: event, type: "workspace.progress" }),
+  ])
 }
 
 function toRunCallbackContext<
@@ -1581,10 +1620,14 @@ export function createHarnessAgentAdapter<
           const commitDefinition = context.workspaceDefinition && context.workspaceAutoCommit !== undefined
             ? workspaceDefinitionWithAutoCommitRules(context.workspaceDefinition, context.workspaceAutoCommit)
             : context.workspaceDefinition
+          const executionAuthority = context.box?.plan.executionAuthority
+            || (context.harnessSandboxProvider as { executionAuthority?: ExecutionAuthority } | undefined)?.executionAuthority
           workspaceSession = await prepareHarnessWorkspaceSession(context.workspaceMaterializationSource || context.workspace, {
             abortSignal,
             ...(hasWorkspaceCommitRules(commitDefinition) ? { definition: commitDefinition } : {}),
+            ...(executionAuthority ? { executionAuthority } : {}),
             ignoreWriteBackPaths: harnessWriteBackIgnorePaths(context, harnessInstructions),
+            onProgress: event => reportHarnessWorkspaceProgress(context, event),
             onWriteBack: diff => setHarnessWorkspaceDiff(context.context, diff),
             paths: selectedWorkspaceScopePaths(context, commitDefinition),
             session: session as never,
@@ -1606,7 +1649,7 @@ export function createHarnessAgentAdapter<
           const destination = globalSkillsDestination || globalSkillsDirectory
           const ensureDestination = await (session as HarnessGlobalSkillsSandbox).run({
             abortSignal,
-            command: `if [ -L '${destination.replace(/'/g, "'\\''")}' ]; then printf '%s\\n' 'Persisted Skill directory cannot be a symlink.' >&2; exit 1; fi && mkdir -p -- '${destination.replace(/'/g, "'\\''")}' && chmod u+rwx -- '${destination.replace(/'/g, "'\\''")}'`,
+            command: `if [ -L '${destination.replace(/'/g, "'\\''")}' ]; then printf '%s\\n' 'Persisted Skill directory cannot be a symlink.' >&2; exit 1; fi && mkdir -p -- '${destination.replace(/'/g, "'\\''")}' && chmod u+rwx '${destination.replace(/'/g, "'\\''")}'`,
           })
           if (ensureDestination.exitCode !== 0) {
             throw new Error(`[vitehub] Failed to prepare global Skill directory: ${ensureDestination.stderr || "sandbox command failed"}`)

--- a/packages/agent/src/harness/box-sandbox.ts
+++ b/packages/agent/src/harness/box-sandbox.ts
@@ -9,6 +9,7 @@ const harnessRemoveDirectory = Symbol.for("vitehub.harnessRemoveDirectory")
 
 type BoxHarnessSandboxSession = HarnessV1NetworkSandboxSession & {
   [harnessRemoveDirectory](path: string): Promise<void>
+  workspaceHost: BoxSession
 }
 
 function streamFromBytes(bytes: Uint8Array) {
@@ -95,6 +96,7 @@ function adaptBoxSession(session: BoxSession): BoxHarnessSandboxSession {
     restricted() {
       return this
     },
+    workspaceHost: session,
     async run({ abortSignal, command, env, workingDirectory }: { abortSignal?: AbortSignal, command: string, env?: Record<string, string>, workingDirectory?: string }) {
       const result = await session.exec("sh", ["-lc", command], {
         cwd: resolvePath(session, workingDirectory || session.cwd),

--- a/packages/agent/src/harness/box-sandbox.ts
+++ b/packages/agent/src/harness/box-sandbox.ts
@@ -3,13 +3,14 @@ import { posix } from "node:path"
 import type { HarnessV1NetworkSandboxSession, HarnessV1SandboxProvider } from "@ai-sdk/harness"
 import type { Box, BoxProcess, BoxSession } from "@vite-hub/box"
 import type { ExecutionAuthority } from "@vite-hub/runtime"
+import type { WorkspaceSessionHost } from "@vite-hub/workspace"
 import { openHarnessBox } from "./shared-box.ts"
 
 const harnessRemoveDirectory = Symbol.for("vitehub.harnessRemoveDirectory")
 
 type BoxHarnessSandboxSession = HarnessV1NetworkSandboxSession & {
   [harnessRemoveDirectory](path: string): Promise<void>
-  workspaceHost: BoxSession
+  workspaceHost: WorkspaceSessionHost
 }
 
 function streamFromBytes(bytes: Uint8Array) {
@@ -57,8 +58,27 @@ function adaptProcess(process: BoxProcess) {
   }
 }
 
-function adaptBoxSession(session: BoxSession): BoxHarnessSandboxSession {
+function adaptBoxSession(session: BoxSession, preparationSignal?: AbortSignal): BoxHarnessSandboxSession {
   if (!session.spawn) throw new Error("[vitehub] Harness Agent Drivers require a Box runtime with process spawning.")
+  let workspaceSignal = preparationSignal
+  const workspaceHost: WorkspaceSessionHost = {
+    detachAbortSignal() {
+      workspaceSignal = undefined
+    },
+    executionAuthority: session.executionAuthority,
+    files: {
+      exists: async path => await session.files.exists(path, { signal: workspaceSignal }),
+      list: async (path, options) => await session.files.list(path, { ...options, signal: workspaceSignal }),
+      mkdir: async (path, options) => await session.files.mkdir(path, { ...options, signal: workspaceSignal }),
+      read: async path => await session.files.read(path, { signal: workspaceSignal }),
+      remove: async (path, options) => await session.files.remove(path, { ...options, signal: workspaceSignal }),
+      write: async (path, content) => await session.files.write(path, content, { signal: workspaceSignal }),
+    },
+    exec: async (command, args, options) => await session.exec(command, args, {
+      ...options,
+      signal: options?.signal || workspaceSignal,
+    }),
+  }
   const adapted = {
     async [harnessRemoveDirectory](path: string) {
       const directory = resolvePath(session, path)
@@ -96,7 +116,7 @@ function adaptBoxSession(session: BoxSession): BoxHarnessSandboxSession {
     restricted() {
       return this
     },
-    workspaceHost: session,
+    workspaceHost,
     async run({ abortSignal, command, env, workingDirectory }: { abortSignal?: AbortSignal, command: string, env?: Record<string, string>, workingDirectory?: string }) {
       const result = await session.exec("sh", ["-lc", command], {
         cwd: resolvePath(session, workingDirectory || session.cwd),
@@ -130,9 +150,9 @@ function adaptBoxSession(session: BoxSession): BoxHarnessSandboxSession {
   return adapted
 }
 
-async function adaptOrClose(session: BoxSession) {
+async function adaptOrClose(session: BoxSession, preparationSignal?: AbortSignal) {
   try {
-    return adaptBoxSession(session)
+    return adaptBoxSession(session, preparationSignal)
   }
   catch (error) {
     await session.close().catch(() => undefined)
@@ -178,14 +198,14 @@ export function createBoxHarnessSandbox(
         id: options?.sessionId,
         initialize: options?.onFirstCreate
           ? async (boxSession) => {
-              adapted = adaptBoxSession(boxSession)
+              adapted = adaptBoxSession(boxSession, options.abortSignal)
               await options.onFirstCreate!(adapted, { abortSignal: options.abortSignal })
             }
           : undefined,
       }, options?.abortSignal)
       try {
         options?.abortSignal?.throwIfAborted()
-        return adapted || await adaptOrClose(session)
+        return adapted || await adaptOrClose(session, options?.abortSignal)
       }
       catch (error) {
         await session.close().catch(() => undefined)
@@ -197,7 +217,7 @@ export function createBoxHarnessSandbox(
       const session = await openInvocationBox(box, { id: options.sessionId }, options.abortSignal)
       try {
         options.abortSignal?.throwIfAborted()
-        return await adaptOrClose(session)
+        return await adaptOrClose(session, options.abortSignal)
       }
       catch (error) {
         await session.close().catch(() => undefined)

--- a/packages/agent/src/harness/box-sandbox.ts
+++ b/packages/agent/src/harness/box-sandbox.ts
@@ -150,16 +150,6 @@ function adaptBoxSession(session: BoxSession, preparationSignal?: AbortSignal): 
   return adapted
 }
 
-async function adaptOrClose(session: BoxSession, preparationSignal?: AbortSignal) {
-  try {
-    return adaptBoxSession(session, preparationSignal)
-  }
-  catch (error) {
-    await session.close().catch(() => undefined)
-    throw error
-  }
-}
-
 async function openInvocationBox(box: Box, options: Parameters<typeof openHarnessBox>[1], signal?: AbortSignal) {
   const opening = openHarnessBox(box, options)
   if (!signal) return await opening
@@ -205,7 +195,7 @@ export function createBoxHarnessSandbox(
       }, options?.abortSignal)
       try {
         options?.abortSignal?.throwIfAborted()
-        return adapted || await adaptOrClose(session, options?.abortSignal)
+        return adapted || adaptBoxSession(session, options?.abortSignal)
       }
       catch (error) {
         await session.close().catch(() => undefined)
@@ -217,7 +207,7 @@ export function createBoxHarnessSandbox(
       const session = await openInvocationBox(box, { id: options.sessionId }, options.abortSignal)
       try {
         options.abortSignal?.throwIfAborted()
-        return await adaptOrClose(session, options.abortSignal)
+        return adaptBoxSession(session, options.abortSignal)
       }
       catch (error) {
         await session.close().catch(() => undefined)

--- a/packages/agent/src/harness/box-sandbox.ts
+++ b/packages/agent/src/harness/box-sandbox.ts
@@ -140,6 +140,30 @@ async function adaptOrClose(session: BoxSession) {
   }
 }
 
+async function openInvocationBox(box: Box, options: Parameters<typeof openHarnessBox>[1], signal?: AbortSignal) {
+  const opening = openHarnessBox(box, options)
+  if (!signal) return await opening
+  signal.throwIfAborted()
+  return await new Promise<BoxSession>((resolve, reject) => {
+    const aborted = () => {
+      opening.then(session => session.close()).catch(() => undefined)
+      reject(signal.reason ?? new DOMException("The operation was aborted.", "AbortError"))
+    }
+    signal.addEventListener("abort", aborted, { once: true })
+    if (signal.aborted) aborted()
+    opening.then(
+      (session) => {
+        signal.removeEventListener("abort", aborted)
+        resolve(session)
+      },
+      (error) => {
+        signal.removeEventListener("abort", aborted)
+        reject(error)
+      },
+    )
+  })
+}
+
 export function createBoxHarnessSandbox(
   box: Box,
 ): HarnessV1SandboxProvider & { readonly executionAuthority: ExecutionAuthority } {
@@ -148,21 +172,37 @@ export function createBoxHarnessSandbox(
     providerId: box.plan.runtime,
     specificationVersion: "harness-sandbox-v1",
     async createSession(options) {
+      options?.abortSignal?.throwIfAborted()
       let adapted: HarnessV1NetworkSandboxSession | undefined
-      const session = await openHarnessBox(box, {
+      const session = await openInvocationBox(box, {
         id: options?.sessionId,
-        signal: options?.abortSignal,
         initialize: options?.onFirstCreate
-          ? async (boxSession, { signal }) => {
+          ? async (boxSession) => {
               adapted = adaptBoxSession(boxSession)
-              await options.onFirstCreate!(adapted, { abortSignal: signal })
+              await options.onFirstCreate!(adapted, { abortSignal: options.abortSignal })
             }
           : undefined,
-      })
-      return adapted || await adaptOrClose(session)
+      }, options?.abortSignal)
+      try {
+        options?.abortSignal?.throwIfAborted()
+        return adapted || await adaptOrClose(session)
+      }
+      catch (error) {
+        await session.close().catch(() => undefined)
+        throw error
+      }
     },
     async resumeSession(options) {
-      return await adaptOrClose(await openHarnessBox(box, { id: options.sessionId, signal: options.abortSignal }))
+      options.abortSignal?.throwIfAborted()
+      const session = await openInvocationBox(box, { id: options.sessionId }, options.abortSignal)
+      try {
+        options.abortSignal?.throwIfAborted()
+        return await adaptOrClose(session)
+      }
+      catch (error) {
+        await session.close().catch(() => undefined)
+        throw error
+      }
     },
   }
 }

--- a/packages/agent/test/box.test.ts
+++ b/packages/agent/test/box.test.ts
@@ -518,7 +518,15 @@ describe("Agent Box", () => {
             write: vi.fn(async () => {}),
           },
           id: globalThis.crypto.randomUUID(),
-          async exec(_command: string, args?: readonly string[]) {
+          async exec(command: string, args?: readonly string[]) {
+            if (command === "test") {
+              return {
+                code: args?.[0] === "-d" ? 0 : 1,
+                ok: args?.[0] === "-d",
+                stderr: "",
+                stdout: "",
+              }
+            }
             const script = args?.[1] || ""
             const codexHome = script.match(/export CODEX_HOME="\$HOME\/([^"]+)"/)?.[1]
             if (codexHome) codexHomes.add(codexHome)

--- a/packages/agent/test/box.test.ts
+++ b/packages/agent/test/box.test.ts
@@ -7,6 +7,7 @@ import { promisify } from "node:util"
 
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { unknownExecutionAuthority } from "@vite-hub/runtime"
+import { createBoxHarnessSandbox } from "../src/harness/box-sandbox.ts"
 
 const harnessSettings = vi.hoisted(() => [] as Record<string, any>[])
 const harnessObservation = vi.hoisted(() => ({
@@ -113,6 +114,42 @@ afterEach(async () => {
 })
 
 describe("Agent Box", () => {
+  it("closes a late Box acquisition while keeping an acquired session independent", async () => {
+    let resolveOpen!: (session: any) => void
+    const pending = new Promise<any>((resolve) => { resolveOpen = resolve })
+    const close = vi.fn(async () => {})
+    const session = {
+      close,
+      cwd: "/workspace",
+      executionAuthority: unknownExecutionAuthority,
+      files: {},
+      id: "pending",
+      spawn: vi.fn(),
+    }
+    const plan = { executionAuthority: unknownExecutionAuthority, runtime: "test" }
+    const controller = new AbortController()
+    const opening = createBoxHarnessSandbox({
+      open: vi.fn(async () => await pending),
+      plan,
+    } as never).createSession({ abortSignal: controller.signal })
+    controller.abort(new Error("invocation canceled"))
+
+    await expect(opening).rejects.toThrow("invocation canceled")
+    resolveOpen(session)
+    await vi.waitFor(() => expect(close).toHaveBeenCalledOnce())
+
+    close.mockClear()
+    const activeController = new AbortController()
+    const active = await createBoxHarnessSandbox({
+      open: vi.fn(async () => session),
+      plan,
+    } as never).createSession({ abortSignal: activeController.signal })
+    activeController.abort(new Error("after acquisition"))
+    expect(close).not.toHaveBeenCalled()
+    await active.destroy()
+    expect(close).toHaveBeenCalledOnce()
+  })
+
   it("runs workspace commands without rematerializing the live Harness tree", { timeout: 20_000 }, async () => {
     const root = await temporaryRoot()
     const stateRoot = join(root, "state")
@@ -505,6 +542,7 @@ describe("Agent Box", () => {
         }
       },
       async open(_input: unknown, options: { initialize?: (session: any, context: { signal?: AbortSignal }) => Promise<void>, signal?: AbortSignal }) {
+        expect(options.signal).toBeUndefined()
         const session = {
           close: vi.fn(async () => {}),
           cwd: "/workspace",

--- a/packages/agent/test/box.test.ts
+++ b/packages/agent/test/box.test.ts
@@ -146,7 +146,7 @@ describe("Agent Box", () => {
     } as never).createSession({ abortSignal: activeController.signal })
     activeController.abort(new Error("after acquisition"))
     expect(close).not.toHaveBeenCalled()
-    await active.destroy()
+    await active.destroy?.()
     expect(close).toHaveBeenCalledOnce()
   })
 

--- a/packages/agent/test/invocation-stream-workspace.test.ts
+++ b/packages/agent/test/invocation-stream-workspace.test.ts
@@ -501,10 +501,10 @@ describe("Agent Invocation Stream write workspace finish lifecycle", () => {
       }),
       mode: "write",
     })
-    expect(workspaceStartSession).toHaveBeenCalledWith({ host: expect.objectContaining({
+    expect(workspaceStartSession).toHaveBeenCalledWith(expect.objectContaining({ abortSignal: expect.any(AbortSignal), host: expect.objectContaining({
       exec: expect.any(Function),
       files: expect.any(Object),
-    }), paths: undefined })
+    }), paths: undefined }))
     expect(workspaceSessionExec).toHaveBeenCalledWith("pnpm", ["test", "--filter", "api"], {
       abortSignal: expect.any(AbortSignal),
       timeout: 1234,

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { noExecutionAuthority, unknownExecutionAuthority } from "@vite-hub/runtime"
+import { createTraceEventLog, noExecutionAuthority, unknownExecutionAuthority } from "@vite-hub/runtime"
 
 import type { ReadonlyWorkspaceFacade, WritableWorkspaceFacade, WorkspaceSource, WorkspaceSourceInput } from "@vite-hub/workspace"
 
@@ -583,6 +583,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: ["AGENTS.md", "CLAUDE.md", "skills/agent-browser"],
       session: harnessFileSession,
@@ -1866,6 +1867,7 @@ describe("defineAgent workspace option", () => {
     harnessCreateSession.mockResolvedValueOnce(harnessSession)
     prepareHarnessWorkspaceSession.mockResolvedValueOnce(harnessWorkspaceSession)
     exists.mockResolvedValue(true)
+    const traceLog = createTraceEventLog()
 
     const agent = withExplicitWorkspaceName(defineAgent({
       driver: {
@@ -1880,7 +1882,7 @@ describe("defineAgent workspace option", () => {
       },
     }), { workspace: "docs" })
 
-    await expect(runAgent(agent, context(), { prompt: "hello" })).resolves.toMatchObject({
+    await expect(runAgent(agent, { ...(context() as unknown as Record<string, unknown>), traceLog } as never, { prompt: "hello" })).resolves.toMatchObject({
       finishReason: "stop",
       text: "ok",
     })
@@ -1889,6 +1891,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
@@ -1908,6 +1911,23 @@ describe("defineAgent workspace option", () => {
     }))
     expect(harnessWorkspaceSession.close).toHaveBeenCalledWith(undefined)
     expect(harnessSession.destroy).toHaveBeenCalledOnce()
+    const onProgress = prepareHarnessWorkspaceSession.mock.calls[0]?.[1]?.onProgress
+    await onProgress?.({
+      data: { bytes: 12, files: 2 },
+      durationMs: 3,
+      id: "workspace.prepare.extract-archive",
+      label: "Extracting workspace revision",
+      status: "completed",
+    })
+    expect(traceLog.entries()).toContainEqual(expect.objectContaining({
+      attributes: expect.objectContaining({
+        bytes: 12,
+        files: 2,
+        "workspace.durationMs": 3,
+        "workspace.status": "completed",
+      }),
+      name: "workspace.prepare.extract-archive",
+    }))
   })
 
   it("ignores generated harness tool writeback only when harness tools are generated", async () => {
@@ -1936,6 +1956,7 @@ describe("defineAgent workspace option", () => {
 
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       ignoreWriteBackPaths: ["harness-tool.mjs"],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",
@@ -2043,6 +2064,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: ["AGENTS.md", "CLAUDE.md"],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
@@ -2117,6 +2139,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: ["AGENTS.md", "CLAUDE.md", "skills/SKILL.md", "skills/review-browser-evidence/SKILL.md"],
       session: harnessFileSession,
@@ -2170,6 +2193,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: ["docs", "portal", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
@@ -2198,6 +2222,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: undefined,
       session: harnessFileSession,
@@ -2244,6 +2269,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: [""],
       session: harnessFileSession,
@@ -2333,6 +2359,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: ["docs", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
@@ -2367,6 +2394,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: ["AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
@@ -2410,6 +2438,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: ["AGENTS.md", "CLAUDE.md", "summary.md", "artifacts/usage", "artifacts/browser", "pr-diff-summary.md"],
       session: harnessFileSession,
@@ -2456,6 +2485,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: ["public", "AGENTS.md", "CLAUDE.md", ".vitehub/sources/public.json"],
       session: harnessFileSession,
@@ -2504,6 +2534,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: ["public", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
@@ -2549,6 +2580,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), expect.objectContaining({
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: [""],
       session: harnessFileSession,
@@ -2649,6 +2681,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: ["public", "AGENTS.md", "CLAUDE.md", "skills/agent-browser", ".vitehub/sources/public.json"],
       session: harnessFileSession,
@@ -2698,6 +2731,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: [""],
       session: harnessFileSession,
@@ -2743,6 +2777,7 @@ describe("defineAgent workspace option", () => {
     expect(prepareHarnessWorkspaceSession).toHaveBeenCalledWith(expect.any(Object), {
       abortSignal: undefined,
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       paths: ["public", "AGENTS.md", "CLAUDE.md"],
       session: harnessFileSession,
@@ -2780,6 +2815,7 @@ describe("defineAgent workspace option", () => {
         },
       }),
       ignoreWriteBackPaths: [],
+      onProgress: expect.any(Function),
       onWriteBack: expect.any(Function),
       session: harnessFileSession,
       sessionWorkDir: "/workspace/codex-session",

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -150,6 +150,8 @@ Use named Workspace Source Binding helpers such as `file()` and `github()`. The 
 
 Workspace definitions are runtime-free. To run generated code, open a [`@vite-hub/box`](../box/README.md) session and pass it to `workspace.startSession({ host: boxSession })`. Workspace materializes files into the host and still owns diff, commit, and rollback; closing without commit restores the host tree from authoritative Workspace state. Box owns execution and the host lifecycle.
 
+GitHub-backed Workspaces pin the branch head before a hosted Session starts and materialize a full-tree Session from one revision archive. Repeated Sessions reuse that immutable archive while the revision is unchanged; scoped Sessions and stores without revision archives use the normal Workspace file API.
+
 Use `startSession({ attach: true, host })` only when another integration already owns the live materialized tree. Attached Sessions preserve that baseline without rematerializing the tree and roll back only their own uncommitted changes on close.
 
 ## MountX projection

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -143,10 +143,15 @@ export interface WorkspaceSyncOptions {
 }
 
 export interface WorkspaceSessionOptions {
+  abortSignal?: AbortSignal
   attach?: boolean
   host?: WorkspaceSessionHost
+  onProgress?: (event: WorkspacePrepareSessionProgressEvent) => void | Promise<void>
   paths?: readonly string[]
   target?: string
+  writeBack?: {
+    exclude?: readonly string[]
+  }
 }
 
 export interface WorkspaceSessionHostFileEntry {

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -171,6 +171,7 @@ export interface WorkspaceSessionHostFiles {
 
 export interface WorkspaceSessionHost {
   readonly executionAuthority: ExecutionAuthority
+  detachAbortSignal?(): void
   files: WorkspaceSessionHostFiles
   exec(
     command: string,

--- a/packages/workspace/src/core/use.ts
+++ b/packages/workspace/src/core/use.ts
@@ -17,6 +17,7 @@ import { useRegisteredWorkspace } from "./registry.ts"
 import { createWorkspace } from "./workspace.ts"
 import { attachWorkspaceSourceRequestExecution, getWorkspaceSourceRequestExecution } from "../sources/request-execution.ts"
 import { workspaceStoreTarget, type WorkspaceStoreTargetCarrier } from "../storage/target.ts"
+import { createHostedWorkspaceSession } from "../session/host.ts"
 
 import type { Tool, ToolSet } from "ai"
 import type { History } from "@vite-hub/history"
@@ -354,8 +355,8 @@ function createReadonlyFs<Name extends WorkspaceName>(
   workspace: Workspace,
 ): ReadonlyWorkspaceFs<Name> {
   const assets = useOptionalWorkspaceAssets(name)
-
-  return attachWorkspaceSourceRequestExecution({
+  let readonlyFs: ReadonlyWorkspaceFs<Name>
+  readonlyFs = attachWorkspaceSourceRequestExecution({
     readFile: async (path, options) => {
       const normalized = normalizePath(path)
       try {
@@ -421,8 +422,20 @@ function createReadonlyFs<Name extends WorkspaceName>(
       path: options?.path || "",
       sources: [],
     },
-    startSession: async (options?: WorkspaceSessionOptions) => await workspace.startSession(options),
+    startSession: async (options?: WorkspaceSessionOptions) => {
+      if (!assets || !options?.host) return await workspace.startSession(options)
+      const overlay = Object.assign(Object.create(workspace) as Workspace, {
+        exists: readonlyFs.exists,
+        glob: readonlyFs.glob,
+        list: readonlyFs.list,
+        readFile: readonlyFs.readFile,
+        search: readonlyFs.search,
+        stat: readonlyFs.stat,
+      })
+      return await createHostedWorkspaceSession(overlay, { ...options, host: options.host })
+    },
   }, getWorkspaceSourceRequestExecution(workspace))
+  return readonlyFs
 }
 
 function toReadOperations(options: WorkspaceFacadeToolOptions | undefined): WorkspaceReadOperations {

--- a/packages/workspace/src/core/workspace.ts
+++ b/packages/workspace/src/core/workspace.ts
@@ -1,7 +1,9 @@
 import { createBasicWorkspaceSession } from "../session/basic.ts"
 import { attachWorkspaceSourceRequestExecution, createWorkspaceSourceRequestExecution } from "../sources/request-execution.ts"
+import { normalizeWorkspaceSources } from "../sources/config.ts"
 import { createWorkspaceSourceView } from "../sources/view.ts"
 import { createWorkspaceStoreFromProvider } from "../storage/provider.ts"
+import { forwardWorkspaceRevisionMaterializer } from "../storage/materialization.ts"
 import { forwardWorkspaceStoreTarget } from "../storage/target.ts"
 import { getCachedWorkspaceStore } from "./workspace-cache.ts"
 import type {
@@ -96,6 +98,9 @@ export function createWorkspace(definition: WorkspaceDefinition): Workspace {
   }
 
   forwardWorkspaceStoreTarget(store, workspace)
+  if (!normalizeWorkspaceSources(definition.sources).some(source => source.requestDescriptor || source.livePaths)) {
+    forwardWorkspaceRevisionMaterializer(store, workspace)
+  }
 
   ;(workspace as WorkspaceWithDefinitionSync).__syncWorkspaceDefinition = async () => {
     const { syncWorkspaceDefinition } = await import("../lifecycle.ts")

--- a/packages/workspace/src/providers/github/shared.ts
+++ b/packages/workspace/src/providers/github/shared.ts
@@ -1,7 +1,7 @@
 import { getActiveCloudflareBinding } from "@vite-hub/internal/runtime/cloudflare-env";
 
 import { workspaceError } from "../../core/errors.ts";
-import { contentToBytes, normalizeWorkspacePath } from "../../core/path.ts";
+import { contentToBytes, normalizeSafeWorkspacePath, normalizeWorkspacePath } from "../../core/path.ts";
 
 import type { GitHubWorkspaceOption, WorkspaceEntry } from "../../core/types.ts";
 
@@ -43,6 +43,58 @@ export interface GitHubFileUpdate {
 export interface GitHubCommitResult {
   commitSha: string;
   treeSha: string;
+}
+
+const githubReadAttempts = 3
+
+function retryDelay(response: Response, attempt: number): number {
+  const retryAfter = response.headers.get("retry-after")
+  if (retryAfter) {
+    const seconds = Number(retryAfter)
+    if (Number.isFinite(seconds)) return Math.min(seconds * 1_000, 2_000)
+    const date = Date.parse(retryAfter)
+    if (Number.isFinite(date)) return Math.min(Math.max(date - Date.now(), 0), 2_000)
+  }
+  return 100 * 2 ** attempt
+}
+
+function retryableGitHubRead(response: Response) {
+  return response.status === 429 || response.status >= 500
+}
+
+async function waitForRetry(delay: number, signal?: AbortSignal) {
+  signal?.throwIfAborted()
+  await new Promise<void>((resolve, reject) => {
+    const aborted = () => {
+      clearTimeout(timeout)
+      reject(signal?.reason || new DOMException("The operation was aborted.", "AbortError"))
+    }
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", aborted)
+      resolve()
+    }, delay)
+    signal?.addEventListener("abort", aborted, { once: true })
+  })
+}
+
+export async function requestGitHub(input: string | URL, init: RequestInit = {}): Promise<Response> {
+  const method = (init.method || "GET").toUpperCase()
+  const retryable = method === "GET" || method === "HEAD"
+  for (let attempt = 0; ; attempt++) {
+    init.signal?.throwIfAborted()
+    let response: Response
+    try {
+      response = await fetch(input, init)
+    }
+    catch (error) {
+      if (!retryable || init.signal?.aborted || attempt + 1 >= githubReadAttempts) throw error
+      await waitForRetry(100 * 2 ** attempt, init.signal || undefined)
+      continue
+    }
+    if (!retryable || !retryableGitHubRead(response) || attempt + 1 >= githubReadAttempts) return response
+    await response.body?.cancel().catch(() => undefined)
+    await waitForRetry(retryDelay(response, attempt), init.signal || undefined)
+  }
 }
 
 class GitHubRequestError extends Error {
@@ -118,7 +170,10 @@ export function joinGitPath(...parts: string[]): string {
 }
 
 export function resolveGitHubWorkspaceRoot(root: string, workspaceName: string): string {
-  return joinGitPath(root.replaceAll("<workspace>", workspaceName));
+  return normalizeSafeWorkspacePath(joinGitPath(root.replaceAll("<workspace>", workspaceName)), {
+    allowEmpty: true,
+    allowReserved: true,
+  });
 }
 
 export function workspacePathFromGitPath(path: string, root: string): string | undefined {
@@ -246,7 +301,7 @@ export async function requestGitHubJson<T>(
   path: string,
   init?: RequestInit,
 ): Promise<T> {
-  const response = await fetch(`https://api.github.com${path}`, {
+  const response = await requestGitHub(`https://api.github.com${path}`, {
     ...init,
     headers: {
       accept: "application/vnd.github+json",
@@ -274,7 +329,7 @@ export async function requestGitHubBytes(
   path: string,
   init?: RequestInit,
 ): Promise<Uint8Array> {
-  const response = await fetch(`https://api.github.com${path}`, {
+  const response = await requestGitHub(`https://api.github.com${path}`, {
     ...init,
     headers: {
       accept: "application/vnd.github.raw+json",
@@ -308,7 +363,7 @@ export async function readGitHubRawFile(input: {
 }): Promise<Uint8Array> {
   const { owner, repo } = splitGitHubRepository(input.repository, "store");
   const path = input.path.split("/").map(encodeURIComponent).join("/");
-  const response = await fetch(
+  const response = await requestGitHub(
     `https://raw.githubusercontent.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/${encodeURIComponent(input.ref)}/${path}`,
     {
       headers: {
@@ -320,6 +375,33 @@ export async function readGitHubRawFile(input: {
   if (!response.ok) {
     const cause = new GitHubRequestError(
       `[vitehub] GitHub workspace raw file request failed for ${input.repository}: ${response.status} ${response.statusText}`,
+      response.status,
+    );
+    throw workspaceError("[vitehub] GitHub workspace request failed.", { cause });
+  }
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+export async function readGitHubArchive(input: {
+  ref: string;
+  repository: string;
+  signal?: AbortSignal;
+  token: string;
+}): Promise<Uint8Array> {
+  const { owner, repo } = splitGitHubRepository(input.repository, "store");
+  const response = await requestGitHub(
+    `https://codeload.github.com/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/tar.gz/${encodeURIComponent(input.ref)}`,
+    {
+      headers: {
+        authorization: `Bearer ${input.token}`,
+        "user-agent": "vitehub-workspace",
+      },
+      signal: input.signal,
+    },
+  );
+  if (!response.ok) {
+    const cause = new GitHubRequestError(
+      `[vitehub] GitHub workspace archive request failed for ${input.repository}: ${response.status} ${response.statusText}`,
       response.status,
     );
     throw workspaceError("[vitehub] GitHub workspace request failed.", { cause });

--- a/packages/workspace/src/providers/github/store.ts
+++ b/packages/workspace/src/providers/github/store.ts
@@ -368,12 +368,26 @@ class GitHubWorkspaceStore implements WorkspaceStore {
         root: this.#root,
         token: this.#token,
       });
-      if (remote.refSha === this.#baselineRefSha) return;
-
-      const takeRemote = new Set(options.takeRemote || []);
+      const takeRemote = options.takeRemote || [];
+      const shouldTakeRemote = (path: string) => takeRemote.some(
+        root => path === root || path.startsWith(`${root}/`),
+      );
       const local = new Map(this.#files);
       const previousRemoteFiles = this.#remoteFiles;
       const changed = new Set([...previousRemoteFiles.keys(), ...local.keys()]);
+      if (remote.refSha === this.#baselineRefSha) {
+        for (const path of changed) {
+          if (!shouldTakeRemote(path)) continue;
+          const file = remote.files.get(path);
+          if (file) this.#files.set(path, githubRemoteFile(path, file));
+          else this.#files.delete(path);
+        }
+        this.#dirty = [...new Set([...this.#remoteFiles.keys(), ...this.#files.keys()])].some(
+          path => !matchesGitHubRemote(this.#files.get(path), this.#remoteFiles.get(path)),
+        );
+        return;
+      }
+
       for (const path of changed) {
         if (matchesGitHubRemote(local.get(path), previousRemoteFiles.get(path))) {
           changed.delete(path);
@@ -383,7 +397,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
         const current = remote.files.get(path);
         if (
           !sameGitHubTreeEntry(previous, current) &&
-          !takeRemote.has(path) &&
+          !shouldTakeRemote(path) &&
           !matchesGitHubRemote(local.get(path), current)
         ) {
           throw workspaceConflict(
@@ -408,7 +422,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
           previousRemoteFiles.get(path),
           remote.files.get(path),
         );
-        if (remoteChanged && takeRemote.has(path)) continue;
+        if (remoteChanged && shouldTakeRemote(path)) continue;
         const file = local.get(path);
         if (file) this.#files.set(path, file);
         else this.#files.delete(path);

--- a/packages/workspace/src/providers/github/store.ts
+++ b/packages/workspace/src/providers/github/store.ts
@@ -423,11 +423,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
       );
 
       for (const path of changed) {
-        const remoteChanged = !sameGitHubTreeEntry(
-          previousRemoteFiles.get(path),
-          remote.files.get(path),
-        );
-        if (remoteChanged && shouldTakeRemote(path)) continue;
+        if (shouldTakeRemote(path)) continue;
         const file = local.get(path);
         if (file) this.#files.set(path, file);
         else this.#files.delete(path);

--- a/packages/workspace/src/providers/github/store.ts
+++ b/packages/workspace/src/providers/github/store.ts
@@ -509,7 +509,16 @@ class GitHubWorkspaceStore implements WorkspaceStore {
   async diff(options: DiffOptions = {}): Promise<WorkspaceDiff> {
     return await this.#mutate(async () => {
       await this.#ensure({ refresh: true });
-      const from = options.from || this.#baseline;
+      const fromSnapshot = options.from || this.#baseline;
+      const from = fromSnapshot && {
+        ...fromSnapshot,
+        entries: Object.fromEntries(Object.entries(fromSnapshot.entries).map(([path, entry]) => [path, {
+          ...entry,
+          ...(entry.metadata?.gitMode === "120000"
+            ? { metadata: { ...entry.metadata, symlinkTarget: undefined } }
+            : {}),
+        }])),
+      };
       const to = await createSnapshotFromEntries(await this.#listEntries("", { recursive: true }, false));
       return diffSnapshots(from, to);
     });

--- a/packages/workspace/src/providers/github/store.ts
+++ b/packages/workspace/src/providers/github/store.ts
@@ -132,9 +132,20 @@ function gitSymlinkTargetFromBytes(bytes: Uint8Array): string {
   return new TextDecoder().decode(bytes).replace(/\0/g, "");
 }
 
+async function waitForGitHubArchive(read: Promise<Uint8Array>, signal?: AbortSignal) {
+  signal?.throwIfAborted();
+  if (!signal) return await read;
+  return await new Promise<Uint8Array>((resolve, reject) => {
+    const abort = () => reject(signal.reason);
+    signal.addEventListener("abort", abort, { once: true });
+    void read.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
+  });
+}
+
 class GitHubWorkspaceStore implements WorkspaceStore {
   #baseline: WorkspaceSnapshot | undefined;
   #archive: { bytes: Uint8Array; revision: string } | undefined;
+  #archiveReads = new Map<string, Promise<Uint8Array>>();
   #baselineRefSha: string | undefined;
   #baselineTreeSha: string | undefined;
   #branch: string;
@@ -179,13 +190,20 @@ class GitHubWorkspaceStore implements WorkspaceStore {
         !isReservedWorkspacePath(path) && (!paths || paths.some(root => path === root || path.startsWith(`${root}/`))),
       ).length;
       if (!this.#dirty && paths === undefined && this.#archive?.revision !== revision) {
-        this.#archive = {
-          bytes: await readGitHubArchive({
+        let read = this.#archiveReads.get(revision);
+        if (!read) {
+          read = readGitHubArchive({
             ref: revision,
             repository: this.#repository,
-            signal: options?.abortSignal,
             token: this.#token,
-          }),
+          });
+          this.#archiveReads.set(revision, read);
+          void read.finally(() => {
+            if (this.#archiveReads.get(revision) === read) this.#archiveReads.delete(revision);
+          }).catch(() => {});
+        }
+        this.#archive = {
+          bytes: await waitForGitHubArchive(read, options?.abortSignal),
           revision,
         };
       }

--- a/packages/workspace/src/providers/github/store.ts
+++ b/packages/workspace/src/providers/github/store.ts
@@ -132,10 +132,10 @@ function gitSymlinkTargetFromBytes(bytes: Uint8Array): string {
   return new TextDecoder().decode(bytes).replace(/\0/g, "");
 }
 
-async function waitForGitHubArchive(read: Promise<Uint8Array>, signal?: AbortSignal) {
+async function waitForGitHubOperation<T>(read: Promise<T>, signal?: AbortSignal) {
   signal?.throwIfAborted();
   if (!signal) return await read;
-  return await new Promise<Uint8Array>((resolve, reject) => {
+  return await new Promise<T>((resolve, reject) => {
     const abort = () => reject(signal.reason);
     signal.addEventListener("abort", abort, { once: true });
     void read.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
@@ -178,12 +178,17 @@ class GitHubWorkspaceStore implements WorkspaceStore {
 
   [workspaceRevisionMaterializer] = {
     currentRevision: async (options?: { abortSignal?: AbortSignal; refresh?: boolean }) => {
-      options?.abortSignal?.throwIfAborted();
-      await this.#mutate(async () => await this.#ensure({ refresh: options?.refresh !== false }));
+      await waitForGitHubOperation(
+        this.#mutate(async () => await this.#ensure({ refresh: options?.refresh !== false })),
+        options?.abortSignal,
+      );
       return this.#baselineRefSha!;
     },
     materializeRevision: async (options?: { abortSignal?: AbortSignal; paths?: readonly string[] }) => {
-      await this.#mutate(async () => await this.#ensure({ refresh: true }));
+      await waitForGitHubOperation(
+        this.#mutate(async () => await this.#ensure({ refresh: true })),
+        options?.abortSignal,
+      );
       const revision = this.#baselineRefSha!;
       const paths = options?.paths;
       const files = [...this.#remoteFiles.keys()].filter(path =>
@@ -203,7 +208,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
           }).catch(() => {});
         }
         this.#archive = {
-          bytes: await waitForGitHubArchive(read, options?.abortSignal),
+          bytes: await waitForGitHubOperation(read, options?.abortSignal),
           revision,
         };
       }

--- a/packages/workspace/src/providers/github/store.ts
+++ b/packages/workspace/src/providers/github/store.ts
@@ -10,12 +10,14 @@ import {
 } from "../../core/path.ts";
 import { createSnapshotFromEntries, diffSnapshots } from "../../storage/utils.ts";
 import { workspaceStoreTarget } from "../../storage/target.ts";
+import { workspaceRevisionMaterializer } from "../../storage/materialization.ts";
 import {
   commitGitHubChanges,
   createGitHubBlob,
   createGitHubFileUpdate,
   gitBlobSha,
   joinGitPath,
+  readGitHubArchive,
   readGitHubRawFile,
   readGitHubBranchState,
   requireGitHubOption,
@@ -132,6 +134,7 @@ function gitSymlinkTargetFromBytes(bytes: Uint8Array): string {
 
 class GitHubWorkspaceStore implements WorkspaceStore {
   #baseline: WorkspaceSnapshot | undefined;
+  #archive: { bytes: Uint8Array; revision: string } | undefined;
   #baselineRefSha: string | undefined;
   #baselineTreeSha: string | undefined;
   #branch: string;
@@ -161,6 +164,40 @@ class GitHubWorkspaceStore implements WorkspaceStore {
   [workspaceStoreTarget]() {
     return { provider: "github" as const, branch: this.#branch, repository: this.#repository };
   }
+
+  [workspaceRevisionMaterializer] = {
+    currentRevision: async (options?: { abortSignal?: AbortSignal; refresh?: boolean }) => {
+      options?.abortSignal?.throwIfAborted();
+      await this.#mutate(async () => await this.#ensure({ refresh: options?.refresh !== false }));
+      return this.#baselineRefSha!;
+    },
+    materializeRevision: async (options?: { abortSignal?: AbortSignal; paths?: readonly string[] }) => {
+      await this.#mutate(async () => await this.#ensure({ refresh: true }));
+      const revision = this.#baselineRefSha!;
+      const paths = options?.paths;
+      const files = [...this.#remoteFiles.keys()].filter(path =>
+        !isReservedWorkspacePath(path) && (!paths || paths.some(root => path === root || path.startsWith(`${root}/`))),
+      ).length;
+      if (!this.#dirty && paths === undefined && this.#archive?.revision !== revision) {
+        this.#archive = {
+          bytes: await readGitHubArchive({
+            ref: revision,
+            repository: this.#repository,
+            signal: options?.abortSignal,
+            token: this.#token,
+          }),
+          revision,
+        };
+      }
+      return {
+        ...(!this.#dirty && paths === undefined ? { archive: this.#archive!.bytes } : {}),
+        files,
+        paths,
+        revision,
+        root: this.#root,
+      };
+    },
+  };
 
   async readFile(path: string): Promise<WorkspaceFile | undefined> {
     const normalized = normalizeSafeWorkspacePath(path);
@@ -344,7 +381,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
         [...remote.files].map(([path, entry]) => [path, githubRemoteFile(path, entry)]),
       );
       this.#baseline = await createSnapshotFromEntries(
-        await this.#listEntries("", { recursive: true }),
+        await this.#listEntries("", { recursive: true }, false),
         "github-workspace-store-rebase",
       );
 
@@ -440,7 +477,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
     return await this.#mutate(async () => {
       await this.#ensure({ refresh: true });
       const from = options.from || this.#baseline;
-      const to = await createSnapshotFromEntries(await this.#listEntries("", { recursive: true }));
+      const to = await createSnapshotFromEntries(await this.#listEntries("", { recursive: true }, false));
       return diffSnapshots(from, to);
     });
   }
@@ -478,6 +515,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
   }
 
   async #load(): Promise<void> {
+    const previousFiles = this.#files;
     const remote = await readGitHubBranchState({
       branch: this.#branch,
       kind: "store",
@@ -490,18 +528,21 @@ class GitHubWorkspaceStore implements WorkspaceStore {
     this.#remoteFiles = remote.files;
     if (!this.#dirty) {
       this.#files = new Map(
-        [...remote.files].map(([path, entry]) => [
-          path,
-          {
+        [...remote.files].map(([path, entry]) => {
+          const previous = previousFiles.get(path);
+          return [path, {
+            ...(previous && previous.gitSha === entry.sha && gitHubFileMode(previous.metadata) === (entry.mode || "100644")
+              ? { bytes: previous.bytes }
+              : {}),
             gitSha: entry.sha!,
             metadata: gitHubFileMetadata(entry),
             path,
             size: entry.size,
-          },
-        ]),
+          }];
+        }),
       );
       this.#baseline = await createSnapshotFromEntries(
-        await this.#listEntries("", { recursive: true }),
+        await this.#listEntries("", { recursive: true }, false),
         "github-workspace-store-load",
       );
     }
@@ -559,7 +600,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
     };
   }
 
-  async #listEntries(prefix: string, options: ListOptions): Promise<WorkspaceEntry[]> {
+  async #listEntries(prefix: string, options: ListOptions, resolveSymlinks = true): Promise<WorkspaceEntry[]> {
     const entries = new Map<string, WorkspaceEntry>();
     for (const file of this.#files.values()) {
       if (isReservedWorkspacePath(file.path)) continue;
@@ -568,7 +609,7 @@ class GitHubWorkspaceStore implements WorkspaceStore {
           entries.set(dir, { path: dir, type: "directory" });
       }
       if (this.#entryInPrefix(file.path, prefix, options))
-        entries.set(file.path, await this.#fileEntry(file));
+        entries.set(file.path, await this.#fileEntry(file, resolveSymlinks));
     }
     return [...entries.values()].sort((a, b) => a.path.localeCompare(b.path));
   }
@@ -580,11 +621,11 @@ class GitHubWorkspaceStore implements WorkspaceStore {
     return options.recursive || !path.slice(prefix.length + 1).includes("/");
   }
 
-  async #fileEntry(file: GitHubWorkspaceStoreFile): Promise<WorkspaceEntry> {
+  async #fileEntry(file: GitHubWorkspaceStoreFile, resolveSymlinks = true): Promise<WorkspaceEntry> {
     return {
       digest: file.gitSha,
       mediaType: file.mediaType,
-      metadata: await this.#fileMetadata(file),
+      metadata: resolveSymlinks ? await this.#fileMetadata(file) : file.metadata,
       path: file.path,
       size: file.size,
       type: "file",

--- a/packages/workspace/src/server.ts
+++ b/packages/workspace/src/server.ts
@@ -401,14 +401,19 @@ export async function runWorkspaceDevCommand<Name extends WorkspaceName>(
   const startSession = starter?.startSession.bind(starter)
   if (!startSession) throw new Error("Workspace Dev command requires a Workspace Session.")
   await materializeWorkspaceDevSources(workspace, input)
-  const session = await withWorkspaceProgress(input.onProgress, {
-    data: { paths: input.paths ?? null },
-    id: "workspace.dev.start-session",
-    label: "Starting workspace session",
-  }, async () => await startSession({ host: input.host, paths: input.paths }))
+  let session: WorkspaceSession | undefined
   const execOptions = { abortSignal: input.abortSignal, timeout: input.timeout }
   let result
   try {
+    await withWorkspaceProgress(input.onProgress, {
+      data: { paths: input.paths ?? null },
+      id: "workspace.dev.start-session",
+      label: "Starting workspace session",
+    }, async () => {
+      session = await startSession({ abortSignal: input.abortSignal, host: input.host, paths: input.paths })
+      return session
+    })
+    if (!session) throw new Error("Workspace Dev Session did not start.")
     result = input.args
       ? await session.exec(command, input.args, execOptions)
       : await session.exec("sh", ["-lc", command], execOptions)
@@ -419,6 +424,7 @@ export async function runWorkspaceDevCommand<Name extends WorkspaceName>(
     }
   }
   catch (error) {
+    if (!session) throw error
     try {
       await session.close()
     }
@@ -427,6 +433,7 @@ export async function runWorkspaceDevCommand<Name extends WorkspaceName>(
     }
     throw error
   }
+  if (!session) throw new Error("Workspace Dev Session did not start.")
   await session.close()
   return result
 }

--- a/packages/workspace/src/server.ts
+++ b/packages/workspace/src/server.ts
@@ -6,6 +6,7 @@ import { getWorkspaceCollectionItem, queryWorkspaceCollection, workspaceCollecti
 import { matchesAny, normalizeSafeWorkspacePath } from "./core/path.ts"
 import { resolveWorkspaceAutoCommit } from "./core/rules.ts"
 import { useWorkspace } from "./core/use.ts"
+import { withWorkspaceProgress } from "./session/progress.ts"
 
 import type { H3Event } from "h3"
 import type { WorkspaceCollectionOptions, WorkspaceCollectionQuery, WorkspaceCollectionSort } from "./collections.ts"
@@ -265,32 +266,6 @@ function workspaceSourceMaterializer(input: unknown): WorkspaceSourceMaterialize
     : undefined
 }
 
-async function withWorkspaceDevProgress<T>(
-  onProgress: WorkspaceDevCommandInput["onProgress"] | undefined,
-  event: Pick<WorkspacePrepareSessionProgressEvent, "id" | "label"> & { data?: Record<string, unknown> },
-  fn: () => Promise<T>,
-): Promise<T> {
-  const startedAt = Date.now()
-  await onProgress?.({ data: event.data, id: event.id, label: event.label, status: "started" })
-  try {
-    const result = await fn()
-    await onProgress?.({ data: event.data, durationMs: Date.now() - startedAt, id: event.id, label: event.label, status: "completed" })
-    return result
-  }
-  catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    await onProgress?.({
-      data: { ...event.data, error: message },
-      durationMs: Date.now() - startedAt,
-      error: message,
-      id: event.id,
-      label: event.label,
-      status: "failed",
-    })
-    throw error
-  }
-}
-
 async function materializeWorkspaceDevSources(
   workspace: Awaited<ReturnType<typeof resolveWorkspace>>,
   input: WorkspaceDevCommandInput,
@@ -298,7 +273,7 @@ async function materializeWorkspaceDevSources(
   const materialize = workspaceSourceMaterializer(workspace) ?? workspaceSourceMaterializer(workspace.fs)
   if (!materialize) return
   const paths = input.paths?.length ? input.paths : [""]
-  await withWorkspaceDevProgress(input.onProgress, {
+  await withWorkspaceProgress(input.onProgress, {
     data: { paths },
     id: "workspace.dev.materialize",
     label: "Materializing workspace sources",
@@ -426,7 +401,7 @@ export async function runWorkspaceDevCommand<Name extends WorkspaceName>(
   const startSession = starter?.startSession.bind(starter)
   if (!startSession) throw new Error("Workspace Dev command requires a Workspace Session.")
   await materializeWorkspaceDevSources(workspace, input)
-  const session = await withWorkspaceDevProgress(input.onProgress, {
+  const session = await withWorkspaceProgress(input.onProgress, {
     data: { paths: input.paths ?? null },
     id: "workspace.dev.start-session",
     label: "Starting workspace session",

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -1,28 +1,27 @@
-import { posix } from "node:path"
-import { gzipSync } from "node:zlib"
-import { lookup } from "mrmime"
+import { Buffer } from "node:buffer"
+import { unknownExecutionAuthority } from "@vite-hub/runtime"
 
-import { contentToBytes, normalizeSafeWorkspacePath } from "../core/path.ts"
+import { normalizeSafeWorkspacePath } from "../core/path.ts"
 import { resolveWorkspaceAutoCommit } from "../core/rules.ts"
-import type {
-  ReadonlyWorkspaceFacade,
-  WritableWorkspaceFacade,
-} from "../core/use.ts"
 import { isMissingWorkspacePathError } from "./scope.ts"
+
+import type { ExecutionAuthority } from "@vite-hub/runtime"
+import type { ReadonlyWorkspaceFacade, WritableWorkspaceFacade } from "../core/use.ts"
 import type {
-  MkdirOptions,
   WorkspaceDefinition,
   WorkspaceDiff,
-  WorkspaceEntry,
   WorkspaceMaterializeSourcesOptions,
   WorkspacePrepareSessionProgressEvent,
   WorkspaceSession,
+  WorkspaceSessionHost,
+  WorkspaceSessionHostFileEntry,
   WorkspaceSessionOptions,
 } from "../core/types.ts"
 
 export interface HarnessSandboxSession {
   readBinaryFile?(options: { abortSignal?: AbortSignal, path: string }): PromiseLike<Uint8Array | null>
-  run(options: { abortSignal?: AbortSignal, command: string, workingDirectory?: string }): PromiseLike<{ exitCode: number, stderr: string, stdout: string }>
+  run(options: { abortSignal?: AbortSignal, command: string, env?: Record<string, string>, workingDirectory?: string }): PromiseLike<{ exitCode: number, stderr?: string, stdout?: string }>
+  workspaceHost?: WorkspaceSessionHost
   writeBinaryFile(options: { abortSignal?: AbortSignal, content: Uint8Array, path: string }): PromiseLike<void>
 }
 
@@ -35,6 +34,7 @@ export interface PrepareHarnessWorkspaceSessionOptions {
   abortSignal?: AbortSignal
   commit?: (diff: WorkspaceDiff) => { message?: string } | false | null | undefined
   definition?: WorkspaceDefinition
+  executionAuthority?: ExecutionAuthority
   ignoreWriteBackPaths?: readonly string[]
   onMaterializeProgress?: WorkspaceMaterializeSourcesOptions["onProgress"]
   onProgress?: (event: WorkspacePrepareSessionProgressEvent) => void | Promise<void>
@@ -45,18 +45,11 @@ export interface PrepareHarnessWorkspaceSessionOptions {
 }
 
 type WorkspaceFacade = ReadonlyWorkspaceFacade | WritableWorkspaceFacade
-type InitialFile = { content: Uint8Array, mediaType?: string, symlinkTarget?: string }
-type InitialTree = {
-  archiveDirectories: Set<string>
-  directories: Set<string>
-  files: Map<string, InitialFile>
-}
 type SourceMaterializer = (options?: WorkspaceMaterializeSourcesOptions) => Promise<unknown>
-type WorkspaceFsWithSources = { materializeSources?: SourceMaterializer }
-type PrepareProgressReporter = PrepareHarnessWorkspaceSessionOptions["onProgress"]
-const archivePath = ".vitehub-workspace.tar.gz"
-const tarBlockSize = 512
-const workspaceReadConcurrency = 16
+type WorkspaceFsWithSession = {
+  materializeSources?: SourceMaterializer
+  startSession?: (options?: WorkspaceSessionOptions) => Promise<WorkspaceSession>
+}
 
 function isWritableWorkspaceFacade(workspace: WorkspaceFacade): workspace is WritableWorkspaceFacade {
   return "startSession" in workspace && typeof workspace.startSession === "function"
@@ -66,153 +59,54 @@ function workspaceSourceMaterializer(workspace: WorkspaceFacade): SourceMaterial
   if ("materializeSources" in workspace && typeof workspace.materializeSources === "function") {
     return options => workspace.materializeSources(options)
   }
-
-  const materializeSources = (workspace.fs as WorkspaceFsWithSources).materializeSources
-  if (typeof materializeSources === "function") {
-    return options => materializeSources(options)
-  }
+  const materializeSources = (workspace.fs as WorkspaceFsWithSession).materializeSources
+  if (typeof materializeSources === "function") return options => materializeSources(options)
 }
 
-function sandboxPath(root: string, path: string) {
-  return posix.join(root, path)
+function workspaceSessionStarter(workspace: WorkspaceFacade) {
+  if (isWritableWorkspaceFacade(workspace)) return workspace.startSession.bind(workspace)
+  const startSession = (workspace.fs as WorkspaceFsWithSession).startSession
+  if (!startSession) throw new Error("[vitehub] Harness Workspace materialization requires Workspace Session support.")
+  return startSession
 }
 
 function shellQuote(value: string) {
   return `'${value.replace(/'/g, "'\\''")}'`
 }
 
-function isGeneratedSourceDescriptorPath(path: string): boolean {
-  return path === ".vitehub" || path === ".vitehub/sources" || /^\.vitehub\/sources\/[^/]+\.json$/.test(path)
-}
-
-function normalizeHarnessWorkspacePath(path = "") {
-  const descriptorPath = normalizeSafeWorkspacePath(path, { allowEmpty: true, allowReserved: true })
-  if (isGeneratedSourceDescriptorPath(descriptorPath)) return descriptorPath
-  return normalizeSafeWorkspacePath(path, { allowEmpty: true })
-}
-
 function normalizeSessionPaths(paths?: readonly string[]): string[] | undefined {
   if (paths === undefined) return undefined
-  const normalized = [...new Set((paths || []).map(normalizeHarnessWorkspacePath))]
+  const normalized = [...new Set(paths.map(path => normalizeSafeWorkspacePath(path, { allowEmpty: true, allowReserved: true })))]
   if (normalized.includes("")) return undefined
   return normalized.sort((left, right) => left.length - right.length || left.localeCompare(right))
 }
 
-function isIgnoredWriteBackPath(path: string, ignoreWriteBackPaths: Set<string>) {
-  for (const ignoredPath of ignoreWriteBackPaths) {
-    if (path === ignoredPath || path.startsWith(`${ignoredPath}/`)) return true
-  }
-  return false
-}
-
-function isIgnoredWriteBackParent(path: string, ignoreWriteBackPaths: Set<string>) {
-  for (const ignoredPath of ignoreWriteBackPaths) {
-    if (ignoredPath.startsWith(`${path}/`)) return true
-  }
-  return false
-}
-
-async function runSandbox(
-  sandbox: HarnessSandboxSession,
-  options: { abortSignal?: AbortSignal, command: string, workingDirectory?: string },
-) {
-  const result = await sandbox.run(options)
-  if (result.exitCode !== 0) {
-    throw new Error(`[vitehub] Failed to prepare Harness Workspace Session: ${result.stderr || "sandbox command failed"}`)
-  }
-  return result
-}
-
 async function withPrepareProgress<T>(
-  onProgress: PrepareProgressReporter | undefined,
+  onProgress: PrepareHarnessWorkspaceSessionOptions["onProgress"],
   event: Pick<WorkspacePrepareSessionProgressEvent, "id" | "label"> & { data?: Record<string, unknown> },
   fn: () => Promise<T>,
-): Promise<T> {
+) {
   const startedAt = Date.now()
   await onProgress?.({ data: event.data, id: event.id, label: event.label, status: "started" })
   try {
     const result = await fn()
-    await onProgress?.({
-      data: event.data,
-      durationMs: Date.now() - startedAt,
-      id: event.id,
-      label: event.label,
-      status: "completed",
-    })
+    await onProgress?.({ data: event.data, durationMs: Date.now() - startedAt, id: event.id, label: event.label, status: "completed" })
     return result
   }
   catch (error) {
-    await onProgress?.({
-      data: {
-        ...event.data,
-        error: error instanceof Error ? error.message : String(error),
-      },
-      durationMs: Date.now() - startedAt,
-      error: error instanceof Error ? error.message : String(error),
-      id: event.id,
-      label: event.label,
-      status: "failed",
-    })
+    const message = error instanceof Error ? error.message : String(error)
+    await onProgress?.({ data: { ...event.data, error: message }, durationMs: Date.now() - startedAt, error: message, id: event.id, label: event.label, status: "failed" })
     throw error
   }
-}
-
-function workspaceFiles(entries: WorkspaceEntry[]) {
-  return entries
-    .filter(entry => entry.type === "file")
-    .sort((left, right) => left.path.localeCompare(right.path))
-}
-
-function workspaceDirectories(entries: WorkspaceEntry[]) {
-  return entries
-    .filter(entry => entry.type === "directory")
-    .map(entry => entry.path)
-    .sort((left, right) => left.localeCompare(right))
-}
-
-function addParentDirectories(directories: Set<string>, path: string) {
-  let directory = posix.dirname(path)
-  while (directory && directory !== ".") {
-    directories.add(directory)
-    directory = posix.dirname(directory)
-  }
-}
-
-async function forEachConcurrent<T>(items: readonly T[], limit: number, fn: (item: T) => Promise<void>) {
-  let index = 0
-  await Promise.all(Array.from({ length: Math.min(limit, items.length) }, async () => {
-    while (index < items.length) {
-      const item = items[index++]
-      if (item !== undefined) await fn(item)
-    }
-  }))
-}
-
-async function workspaceEntries(workspace: WorkspaceFacade, paths: string[] | undefined) {
-  if (paths && !paths.length) return []
-  if (!paths) return await workspace.fs.list("", { recursive: true })
-
-  const entries = new Map<string, WorkspaceEntry>()
-  for (const path of paths) {
-    const stat = await workspace.fs.stat(path).catch(() => undefined)
-    if (!stat) continue
-    entries.set(stat.path, stat)
-    if (stat.type === "directory") {
-      for (const entry of await workspace.fs.list(path, { recursive: true })) entries.set(entry.path, entry)
-    }
-  }
-  return [...entries.values()].sort((left, right) => left.path.localeCompare(right.path))
 }
 
 async function materializeWorkspaceSourcesForSession(
   workspace: WorkspaceFacade,
   paths: string[] | undefined,
-  options: Pick<WorkspaceMaterializeSourcesOptions, "abortSignal" | "onProgress"> = {},
+  options: Pick<WorkspaceMaterializeSourcesOptions, "abortSignal" | "onProgress">,
 ) {
   const materialize = workspaceSourceMaterializer(workspace)
-  if (!materialize) return
-
-  if (paths && !paths.length) return
+  if (!materialize || (paths && !paths.length)) return
   await Promise.all((paths || [""]).map(async (path) => {
     await materialize({ ...options, path }).catch((error) => {
       if (path && isMissingWorkspacePathError(error)) return
@@ -221,320 +115,81 @@ async function materializeWorkspaceSourcesForSession(
   }))
 }
 
-function bytesEqual(left: Uint8Array | undefined, right: Uint8Array) {
-  if (!left || left.byteLength !== right.byteLength) return false
-  for (let index = 0; index < left.byteLength; index++) {
-    if (left[index] !== right[index]) return false
-  }
-  return true
-}
-
-function pathsFromFindOutput(stdout: string) {
-  return stdout
-    .split("\n")
-    .map(path => path.trim())
-    .filter(Boolean)
-    .map(path => path.replace(/^\.\//, ""))
-    .filter(path => path && path !== ".")
-    .sort((left, right) => left.localeCompare(right))
-}
-
-async function resetSandboxWorkDir(
-  sandbox: HarnessSandboxSession,
-  sessionWorkDir: string,
-  abortSignal: AbortSignal | undefined,
-) {
-  const workDir = posix.normalize(sessionWorkDir)
-  const parent = posix.dirname(workDir)
-  const name = posix.basename(workDir)
-  await sandbox.writeBinaryFile({
-    abortSignal,
-    content: new Uint8Array(),
-    path: sandboxPath(parent, ".vitehub-reset"),
-  })
-  await runSandbox(sandbox, {
-    abortSignal,
-    command: `rm -rf -- ${shellQuote(name)} && mkdir -p -- ${shellQuote(name)} && rm -f -- ${shellQuote(".vitehub-reset")}`,
-    workingDirectory: parent,
-  })
-}
-
-function paddedTarContent(content: Uint8Array) {
-  const padding = content.byteLength % tarBlockSize
-    ? tarBlockSize - (content.byteLength % tarBlockSize)
-    : 0
-  if (!padding) return Buffer.from(content)
-  return Buffer.concat([Buffer.from(content), Buffer.alloc(padding)])
-}
-
-function splitTarPath(path: string): { name: string, prefix?: string } {
-  if (Buffer.byteLength(path) <= 100) return { name: path }
-  const parts = path.split("/")
-  for (let index = 1; index < parts.length; index++) {
-    const prefix = parts.slice(0, index).join("/")
-    const name = parts.slice(index).join("/")
-    if (Buffer.byteLength(prefix) <= 155 && Buffer.byteLength(name) <= 100)
-      return { name, prefix }
-  }
-  throw new Error(`[vitehub] Harness Workspace Session path is too long for tar transfer: ${path}`)
-}
-
-function writeTarString(header: Buffer, offset: number, length: number, value: string) {
-  const bytes = Buffer.from(value)
-  bytes.copy(header, offset, 0, Math.min(bytes.byteLength, length))
-}
-
-function writeTarOctal(header: Buffer, offset: number, length: number, value: number) {
-  const text = value.toString(8).padStart(length - 1, "0").slice(-(length - 1))
-  header.write(text, offset, length - 1, "ascii")
-  header[offset + length - 1] = 0
-}
-
-function tarHeader(path: string, options: { linkName?: string, mode: number, size: number, type: "directory" | "file" | "symlink" }) {
-  const header = Buffer.alloc(tarBlockSize)
-  const { name, prefix } = splitTarPath(path)
-  if (options.linkName && Buffer.byteLength(options.linkName) > 100)
-    throw new Error(`[vitehub] Harness Workspace Session symlink target is too long for tar transfer: ${path}`)
-  writeTarString(header, 0, 100, name)
-  writeTarOctal(header, 100, 8, options.mode)
-  writeTarOctal(header, 108, 8, 0)
-  writeTarOctal(header, 116, 8, 0)
-  writeTarOctal(header, 124, 12, options.size)
-  writeTarOctal(header, 136, 12, 0)
-  header.fill(0x20, 148, 156)
-  header[156] = options.type === "directory" ? 0x35 : options.type === "symlink" ? 0x32 : 0x30
-  if (options.linkName) writeTarString(header, 157, 100, options.linkName)
-  writeTarString(header, 257, 6, "ustar")
-  writeTarString(header, 263, 2, "00")
-  if (prefix) writeTarString(header, 345, 155, prefix)
-  let checksum = 0
-  for (const byte of header) checksum += byte
-  header.write(checksum.toString(8).padStart(6, "0"), 148, 6, "ascii")
-  header[154] = 0
-  header[155] = 0x20
-  return header
-}
-
-function createWorkspaceTarGz(directories: Iterable<string>, files: Map<string, InitialFile>) {
-  const blocks: Buffer[] = []
-  for (const directory of [...directories].sort((left, right) => left.localeCompare(right))) {
-    const path = directory.endsWith("/") ? directory : `${directory}/`
-    blocks.push(tarHeader(path, { mode: 0o755, size: 0, type: "directory" }))
-  }
-  for (const [path, file] of [...files.entries()].sort(([left], [right]) => left.localeCompare(right))) {
-    if (file.symlinkTarget) {
-      blocks.push(tarHeader(path, { linkName: file.symlinkTarget, mode: 0o777, size: 0, type: "symlink" }))
-      continue
+function parseHostEntries(stdout: string): WorkspaceSessionHostFileEntry[] {
+  return stdout.split("\n").filter(Boolean).map((line) => {
+    const [type, size, encoded] = line.split("\t")
+    if ((type !== "directory" && type !== "file" && type !== "symlink") || !encoded) {
+      throw new Error("[vitehub] Harness Workspace host returned an invalid file entry.")
     }
-    blocks.push(tarHeader(path, { mode: 0o644, size: file.content.byteLength, type: "file" }))
-    blocks.push(paddedTarContent(file.content))
+    return {
+      path: Buffer.from(encoded, "base64").toString("utf8"),
+      ...(size ? { size: Number(size) } : {}),
+      type,
+    }
+  })
+}
+
+function harnessWorkspaceHost(options: PrepareHarnessWorkspaceSessionOptions): WorkspaceSessionHost {
+  const sandbox = options.session
+  if (sandbox.workspaceHost) {
+    return {
+      executionAuthority: options.executionAuthority || sandbox.workspaceHost.executionAuthority,
+      files: sandbox.workspaceHost.files,
+      exec: (command, args, execOptions) => sandbox.workspaceHost!.exec(command, args, execOptions),
+    }
   }
-  blocks.push(Buffer.alloc(tarBlockSize * 2))
-  return gzipSync(Buffer.concat(blocks))
-}
-
-async function extractWorkspaceArchive(
-  sandbox: HarnessSandboxSession,
-  sessionWorkDir: string,
-  initialTree: InitialTree,
-  directories: Set<string>,
-  abortSignal: AbortSignal | undefined,
-) {
-  if (!initialTree.files.size && !directories.size) return
-  const path = sandboxPath(sessionWorkDir, archivePath)
-  await sandbox.writeBinaryFile({
-    abortSignal,
-    content: createWorkspaceTarGz(directories, initialTree.files),
-    path,
-  })
-  await runSandbox(sandbox, {
-    abortSignal,
-    command: `tar -xzf ${shellQuote(archivePath)} && rm ${shellQuote(archivePath)}`,
-    workingDirectory: sessionWorkDir,
-  })
-}
-
-async function initializeSandboxGitBaseline(
-  sandbox: HarnessSandboxSession,
-  sessionWorkDir: string,
-  abortSignal: AbortSignal | undefined,
-) {
-  await runSandbox(sandbox, {
-    abortSignal,
-    command: "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A -f && git commit --allow-empty --no-gpg-sign --no-verify -qm workspace-baseline || true; fi",
-    workingDirectory: sessionWorkDir,
-  })
-}
-
-async function listSandboxPaths(
-  sandbox: HarnessSandboxSession,
-  sessionWorkDir: string,
-  type: "d" | "f" | "l",
-  abortSignal: AbortSignal | undefined,
-) {
-  const result = await runSandbox(sandbox, {
-    abortSignal,
-    command: `find . -type ${type} -print`,
-    workingDirectory: sessionWorkDir,
-  })
-  return new Set(pathsFromFindOutput(result.stdout))
-}
-
-async function readSandboxSymlinkTarget(
-  sandbox: HarnessSandboxSession,
-  sessionWorkDir: string,
-  path: string,
-  abortSignal: AbortSignal | undefined,
-) {
-  const result = await runSandbox(sandbox, {
-    abortSignal,
-    command: `readlink -- ${shellQuote(path)}`,
-    workingDirectory: sessionWorkDir,
-  })
-  return result.stdout.replace(/\n$/, "")
-}
-
-async function copyWorkspaceToSandbox(
-  workspace: WorkspaceFacade,
-  sandbox: HarnessSandboxSession,
-  sessionWorkDir: string,
-  abortSignal: AbortSignal | undefined,
-  paths: string[] | undefined,
-  onMaterializeProgress: WorkspaceMaterializeSourcesOptions["onProgress"] | undefined,
-  onProgress: PrepareProgressReporter | undefined,
-) {
-  await withPrepareProgress(onProgress, {
-    data: { paths: paths ?? null },
-    id: "workspace.prepare.materialize",
-    label: "Materializing workspace sources",
-  }, async () => {
-    await materializeWorkspaceSourcesForSession(workspace, paths, {
-      ...(abortSignal ? { abortSignal } : {}),
-      ...(onMaterializeProgress ? { onProgress: onMaterializeProgress } : {}),
+  const run = async (command: string, args: readonly string[] = [], runOptions: { cwd?: string, env?: Readonly<Record<string, string>>, signal?: AbortSignal } = {}) => {
+    const result = await sandbox.run({
+      abortSignal: runOptions.signal || options.abortSignal,
+      command: [command, ...args].map(shellQuote).join(" "),
+      ...(runOptions.cwd ? { workingDirectory: runOptions.cwd } : {}),
+      ...(runOptions.env ? { env: { ...runOptions.env } } : {}),
     })
-  })
-  const entries = await withPrepareProgress(onProgress, {
-    data: { paths: paths ?? null },
-    id: "workspace.prepare.entries",
-    label: "Resolving workspace entries",
-  }, async () => await workspaceEntries(workspace, paths))
-  const directoriesToCreate = new Set(workspaceDirectories(entries))
-  const initialTree: InitialTree = {
-    archiveDirectories: directoriesToCreate,
-    directories: new Set(workspaceDirectories(entries)),
-    files: new Map(),
+    return { code: result.exitCode, stderr: result.stderr || "", stdout: result.stdout || "" }
   }
-  const files = workspaceFiles(entries)
-  for (const entry of files) addParentDirectories(directoriesToCreate, entry.path)
-  await withPrepareProgress(onProgress, {
-    data: { files: files.length },
-    id: "workspace.prepare.read-files",
-    label: "Reading workspace files",
-  }, async () => {
-    await forEachConcurrent(files, workspaceReadConcurrency, async (entry) => {
-      const content = await workspace.fs.readFile(entry.path, { encoding: "binary" })
-      const bytes = contentToBytes(content)
-      initialTree.files.set(entry.path, {
-        content: bytes,
-        mediaType: entry.mediaType,
-        symlinkTarget: entry.metadata?.gitMode === "120000"
-          ? typeof entry.metadata.symlinkTarget === "string" ? entry.metadata.symlinkTarget : new TextDecoder().decode(bytes)
-          : undefined,
-      })
-    })
-  })
-  await withPrepareProgress(onProgress, {
-    id: "workspace.prepare.reset-sandbox",
-    label: "Resetting sandbox workspace",
-  }, async () => {
-    await resetSandboxWorkDir(sandbox, sessionWorkDir, abortSignal)
-  })
-  await withPrepareProgress(onProgress, {
-    data: { directories: directoriesToCreate.size, files: initialTree.files.size },
-    id: "workspace.prepare.extract-archive",
-    label: "Extracting workspace archive",
-  }, async () => {
-    await extractWorkspaceArchive(sandbox, sessionWorkDir, initialTree, directoriesToCreate, abortSignal)
-  })
+
+  return {
+    executionAuthority: options.executionAuthority || unknownExecutionAuthority,
+    files: {
+      async exists(path) {
+        return (await run("sh", ["-c", `test -e "$1" || test -L "$1"`, "sh", path])).code === 0
+      },
+      async list(path, listOptions) {
+        const depth = listOptions?.recursive ? "" : " -maxdepth 1"
+        const command = `find "$1" -mindepth 1${depth} -exec sh -c 'for path do if [ -L "$path" ]; then type=symlink; size=; elif [ -d "$path" ]; then type=directory; size=; else type=file; size=$(wc -c < "$path") || exit $?; fi; encoded=$(printf %s "$path" | base64 | tr -d "\\n") || exit $?; printf "%s\\t%s\\t%s\\n" "$type" "$size" "$encoded"; done' sh {} +`
+        const result = await run("sh", ["-c", command, "sh", path])
+        if (result.code !== 0) throw new Error(`[vitehub] Failed to list Harness Workspace host: ${result.stderr || "find failed"}`)
+        return parseHostEntries(result.stdout)
+      },
+      async mkdir(path, mkdirOptions) {
+        const result = await run("mkdir", [...(mkdirOptions?.recursive ? ["-p"] : []), "--", path])
+        if (result.code !== 0) throw new Error(`[vitehub] Failed to create Harness Workspace directory: ${result.stderr || "mkdir failed"}`)
+      },
+      async read(path) {
+        if (!sandbox.readBinaryFile) throw new Error("[vitehub] Harness Workspace Session requires sandbox.readBinaryFile.")
+        return await sandbox.readBinaryFile({ abortSignal: options.abortSignal, path })
+      },
+      async remove(path, removeOptions) {
+        const result = removeOptions?.recursive
+          ? await run("rm", ["-rf", "--", path])
+          : await run("rm", ["-f", "--", path])
+        if (result.code !== 0) throw new Error(`[vitehub] Failed to remove Harness Workspace path: ${result.stderr || "remove failed"}`)
+      },
+      async write(path, content) {
+        await sandbox.writeBinaryFile({ abortSignal: options.abortSignal, content, path })
+      },
+    },
+    exec: run,
+  }
+}
+
+async function initializeSandboxGitBaseline(session: WorkspaceSession, onProgress: PrepareHarnessWorkspaceSessionOptions["onProgress"]) {
   await withPrepareProgress(onProgress, {
     id: "workspace.prepare.git-status",
     label: "Preparing workspace status",
   }, async () => {
-    await initializeSandboxGitBaseline(sandbox, sessionWorkDir, abortSignal)
+    await session.exec("sh", ["-c", "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A -f && git commit --allow-empty --no-gpg-sign --no-verify -qm workspace-baseline || true; fi"])
   })
-  return initialTree
-}
-
-async function copySandboxChangesToWorkspace(
-  session: WorkspaceSession,
-  definition: WorkspaceDefinition | undefined,
-  sandbox: HarnessSandboxSession,
-  sessionWorkDir: string,
-  initialTree: InitialTree,
-  abortSignal: AbortSignal | undefined,
-  ignoreWriteBackPaths: Set<string>,
-  commit: PrepareHarnessWorkspaceSessionOptions["commit"],
-  onWriteBack: PrepareHarnessWorkspaceSessionOptions["onWriteBack"],
-) {
-  if (!sandbox.readBinaryFile) {
-    throw new Error("[vitehub] Harness Workspace Session write mode requires sandbox.readBinaryFile.")
-  }
-
-  const ignoredWriteBackPaths = new Set([...ignoreWriteBackPaths, ".git"])
-  const sandboxDirectories = await listSandboxPaths(sandbox, sessionWorkDir, "d", abortSignal)
-  const sandboxFiles = await listSandboxPaths(sandbox, sessionWorkDir, "f", abortSignal)
-  const sandboxSymlinks = await listSandboxPaths(sandbox, sessionWorkDir, "l", abortSignal)
-  const sandboxFileEntries = new Set([...sandboxFiles, ...sandboxSymlinks])
-  for (const path of initialTree.files.keys()) {
-    if (isIgnoredWriteBackPath(path, ignoredWriteBackPaths)) continue
-    if (!sandboxFileEntries.has(path)) await session.rm(path, { force: true })
-  }
-  for (const path of [...initialTree.directories].sort((left, right) => right.length - left.length)) {
-    if (isIgnoredWriteBackPath(path, ignoredWriteBackPaths)) continue
-    if (isIgnoredWriteBackParent(path, ignoredWriteBackPaths)) continue
-    if (!sandboxDirectories.has(path)) await session.rm(path, { force: true, recursive: true })
-  }
-  for (const path of sandboxDirectories) {
-    if (isIgnoredWriteBackPath(path, ignoredWriteBackPaths)) continue
-    if (!initialTree.directories.has(path) && isIgnoredWriteBackParent(path, ignoredWriteBackPaths)) continue
-    if (initialTree.archiveDirectories.has(path)) continue
-    await session.mkdir(path, { recursive: true } satisfies MkdirOptions)
-  }
-  for (const path of sandboxFiles) {
-    if (isIgnoredWriteBackPath(path, ignoredWriteBackPaths)) continue
-    const initial = initialTree.files.get(path)
-    const content = await sandbox.readBinaryFile({
-      abortSignal,
-      path: sandboxPath(sessionWorkDir, path),
-    })
-    if (!content || (!initial?.symlinkTarget && bytesEqual(initial?.content, content))) continue
-    await session.writeFile(path, content, {
-      mediaType: initial?.mediaType || lookup(path) || undefined,
-    })
-  }
-  for (const path of sandboxSymlinks) {
-    if (isIgnoredWriteBackPath(path, ignoredWriteBackPaths)) continue
-    const initial = initialTree.files.get(path)
-    const target = await readSandboxSymlinkTarget(sandbox, sessionWorkDir, path, abortSignal)
-    if (initial?.symlinkTarget === target) continue
-    await session.writeFile(path, contentToBytes(target), {
-      metadata: { gitMode: "120000" },
-    })
-  }
-
-  const diff = await session.diff()
-  if (!diff.entries.length) return
-  if (commit) {
-    const commitOptions = commit(diff)
-    if (!commitOptions) return
-    await session.commit({ message: commitOptions.message || "harness-workspace-session" })
-    await onWriteBack?.(diff)
-    return
-  }
-  const autoCommit = definition ? resolveWorkspaceAutoCommit(definition, diff) : undefined
-  if (definition && !autoCommit) return
-  await session.commit({ message: autoCommit?.message || "harness-workspace-session" })
-  await onWriteBack?.(diff)
 }
 
 export async function prepareHarnessWorkspaceSession(
@@ -542,45 +197,53 @@ export async function prepareHarnessWorkspaceSession(
   options: PrepareHarnessWorkspaceSessionOptions,
 ): Promise<HarnessWorkspaceSession> {
   const paths = normalizeSessionPaths(options.paths)
-  const ignoreWriteBackPaths = new Set((options.ignoreWriteBackPaths || []).map(normalizeHarnessWorkspacePath))
-  const initialTree = await copyWorkspaceToSandbox(workspace, options.session, options.sessionWorkDir, options.abortSignal, paths, options.onMaterializeProgress, options.onProgress)
-  const sessionOptions: WorkspaceSessionOptions | undefined = paths ? { paths } : undefined
-  const workspaceSession = isWritableWorkspaceFacade(workspace) && (paths === undefined || paths.length)
-    ? await withPrepareProgress(options.onProgress, {
-        data: { paths: paths ?? null },
-        id: "workspace.prepare.start-session",
-        label: "Starting workspace write session",
-      }, async () => await workspace.startSession(sessionOptions))
-    : undefined
+  await withPrepareProgress(options.onProgress, {
+    data: { paths: paths ?? null },
+    id: "workspace.prepare.materialize",
+    label: "Materializing workspace sources",
+  }, async () => await materializeWorkspaceSourcesForSession(workspace, paths, {
+    ...(options.abortSignal ? { abortSignal: options.abortSignal } : {}),
+    ...(options.onMaterializeProgress ? { onProgress: options.onMaterializeProgress } : {}),
+  }))
+
+  const session = await withPrepareProgress(options.onProgress, {
+    data: { paths: paths ?? null },
+    id: "workspace.prepare.start-session",
+    label: "Starting workspace session",
+  }, async () => await workspaceSessionStarter(workspace)({
+    abortSignal: options.abortSignal,
+    host: harnessWorkspaceHost(options),
+    onProgress: options.onProgress,
+    paths,
+    target: options.sessionWorkDir,
+    writeBack: { exclude: options.ignoreWriteBackPaths },
+  }))
+  await initializeSandboxGitBaseline(session, options.onProgress)
 
   return {
     async close(error?: unknown) {
       try {
-        if (!error && workspaceSession) {
-          await copySandboxChangesToWorkspace(
-            workspaceSession,
-            options.definition,
-            options.session,
-            options.sessionWorkDir,
-            initialTree,
-            options.abortSignal,
-            ignoreWriteBackPaths,
-            options.commit,
-            options.onWriteBack,
-          )
+        if (error || !isWritableWorkspaceFacade(workspace)) return
+        const diff = await session.diff()
+        if (!diff.entries.length) return
+        if (options.commit) {
+          const commit = options.commit(diff)
+          if (!commit) return
+          await session.commit({ message: commit.message || "harness-workspace-session" })
+          await options.onWriteBack?.(diff)
+          return
         }
+        const autoCommit = options.definition ? resolveWorkspaceAutoCommit(options.definition, diff) : undefined
+        if (options.definition && !autoCommit) return
+        await session.commit({ message: autoCommit?.message || "harness-workspace-session" })
+        await options.onWriteBack?.(diff)
       }
       finally {
-        await workspaceSession?.close()
+        await session.close()
       }
     },
     async refreshGitBaseline() {
-      await withPrepareProgress(options.onProgress, {
-        id: "workspace.prepare.git-status",
-        label: "Preparing workspace status",
-      }, async () => {
-        await initializeSandboxGitBaseline(options.session, options.sessionWorkDir, options.abortSignal)
-      })
+      await initializeSandboxGitBaseline(session, options.onProgress)
     },
   }
 }

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -205,22 +205,28 @@ export async function prepareHarnessWorkspaceSession(
   }))
 
   const sessionHost = harnessWorkspaceHost(options)
-  const session = await withWorkspaceProgress(options.onProgress, {
-    data: { paths: paths ?? null },
-    id: "workspace.prepare.start-session",
-    label: "Starting workspace session",
-  }, async () => await workspaceSessionStarter(workspace)({
-    abortSignal: options.abortSignal,
-    host: sessionHost.host,
-    onProgress: options.onProgress,
-    paths,
-    target: options.sessionWorkDir,
-    writeBack: { exclude: options.ignoreWriteBackPaths },
-  }))
+  let session: WorkspaceSession | undefined
   try {
+    await withWorkspaceProgress(options.onProgress, {
+      data: { paths: paths ?? null },
+      id: "workspace.prepare.start-session",
+      label: "Starting workspace session",
+    }, async () => {
+      session = await workspaceSessionStarter(workspace)({
+        abortSignal: options.abortSignal,
+        host: sessionHost.host,
+        onProgress: options.onProgress,
+        paths,
+        target: options.sessionWorkDir,
+        writeBack: { exclude: options.ignoreWriteBackPaths },
+      })
+      return session
+    })
+    if (!session) throw new Error("[vitehub] Harness Workspace Session did not start.")
     await initializeSandboxGitBaseline(session, options.onProgress)
   }
   catch (error) {
+    if (!session) throw error
     sessionHost.detachAbortSignal()
     try {
       await session.close()
@@ -230,32 +236,34 @@ export async function prepareHarnessWorkspaceSession(
     }
     throw error
   }
+  const activeSession = session
+  if (!activeSession) throw new Error("[vitehub] Harness Workspace Session did not start.")
 
   return {
     async close(error?: unknown) {
       try {
         if (error || !isWritableWorkspaceFacade(workspace)) return
-        const diff = await session.diff()
+        const diff = await activeSession.diff()
         if (!diff.entries.length) return
         if (options.commit) {
           const commit = options.commit(diff)
           if (!commit) return
-          await session.commit({ message: commit.message || "harness-workspace-session" })
+          await activeSession.commit({ message: commit.message || "harness-workspace-session" })
           await options.onWriteBack?.(diff)
           return
         }
         const autoCommit = options.definition ? resolveWorkspaceAutoCommit(options.definition, diff) : undefined
         if (options.definition && !autoCommit) return
-        await session.commit({ message: autoCommit?.message || "harness-workspace-session" })
+        await activeSession.commit({ message: autoCommit?.message || "harness-workspace-session" })
         await options.onWriteBack?.(diff)
       }
       finally {
         sessionHost.detachAbortSignal()
-        await session.close()
+        await activeSession.close()
       }
     },
     async refreshGitBaseline() {
-      await initializeSandboxGitBaseline(session, options.onProgress)
+      await initializeSandboxGitBaseline(activeSession, options.onProgress)
     },
   }
 }

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -129,18 +129,25 @@ function parseHostEntries(stdout: string): WorkspaceSessionHostFileEntry[] {
   })
 }
 
-function harnessWorkspaceHost(options: PrepareHarnessWorkspaceSessionOptions): WorkspaceSessionHost {
+function harnessWorkspaceHost(options: PrepareHarnessWorkspaceSessionOptions): {
+  detachAbortSignal: () => void
+  host: WorkspaceSessionHost
+} {
   const sandbox = options.session
   if (sandbox.workspaceHost) {
     return {
-      executionAuthority: options.executionAuthority || sandbox.workspaceHost.executionAuthority,
-      files: sandbox.workspaceHost.files,
-      exec: (command, args, execOptions) => sandbox.workspaceHost!.exec(command, args, execOptions),
+      detachAbortSignal() {},
+      host: {
+        executionAuthority: options.executionAuthority || sandbox.workspaceHost.executionAuthority,
+        files: sandbox.workspaceHost.files,
+        exec: (command, args, execOptions) => sandbox.workspaceHost!.exec(command, args, execOptions),
+      },
     }
   }
+  let abortSignal = options.abortSignal
   const run = async (command: string, args: readonly string[] = [], runOptions: { cwd?: string, env?: Readonly<Record<string, string>>, signal?: AbortSignal } = {}) => {
     const result = await sandbox.run({
-      abortSignal: runOptions.signal || options.abortSignal,
+      abortSignal: runOptions.signal || abortSignal,
       command: [command, ...args].map(shellQuote).join(" "),
       ...(runOptions.cwd ? { workingDirectory: runOptions.cwd } : {}),
       ...(runOptions.env ? { env: { ...runOptions.env } } : {}),
@@ -148,7 +155,7 @@ function harnessWorkspaceHost(options: PrepareHarnessWorkspaceSessionOptions): W
     return { code: result.exitCode, stderr: result.stderr || "", stdout: result.stdout || "" }
   }
 
-  return {
+  const host: WorkspaceSessionHost = {
     executionAuthority: options.executionAuthority || unknownExecutionAuthority,
     files: {
       async exists(path) {
@@ -167,7 +174,7 @@ function harnessWorkspaceHost(options: PrepareHarnessWorkspaceSessionOptions): W
       },
       async read(path) {
         if (!sandbox.readBinaryFile) throw new Error("[vitehub] Harness Workspace Session requires sandbox.readBinaryFile.")
-        return await sandbox.readBinaryFile({ abortSignal: options.abortSignal, path })
+        return await sandbox.readBinaryFile({ abortSignal, path })
       },
       async remove(path, removeOptions) {
         const result = removeOptions?.recursive
@@ -176,10 +183,16 @@ function harnessWorkspaceHost(options: PrepareHarnessWorkspaceSessionOptions): W
         if (result.code !== 0) throw new Error(`[vitehub] Failed to remove Harness Workspace path: ${result.stderr || "remove failed"}`)
       },
       async write(path, content) {
-        await sandbox.writeBinaryFile({ abortSignal: options.abortSignal, content, path })
+        await sandbox.writeBinaryFile({ abortSignal, content, path })
       },
     },
     exec: run,
+  }
+  return {
+    detachAbortSignal() {
+      abortSignal = undefined
+    },
+    host,
   }
 }
 
@@ -206,13 +219,14 @@ export async function prepareHarnessWorkspaceSession(
     ...(options.onMaterializeProgress ? { onProgress: options.onMaterializeProgress } : {}),
   }))
 
+  const sessionHost = harnessWorkspaceHost(options)
   const session = await withPrepareProgress(options.onProgress, {
     data: { paths: paths ?? null },
     id: "workspace.prepare.start-session",
     label: "Starting workspace session",
   }, async () => await workspaceSessionStarter(workspace)({
     abortSignal: options.abortSignal,
-    host: harnessWorkspaceHost(options),
+    host: sessionHost.host,
     onProgress: options.onProgress,
     paths,
     target: options.sessionWorkDir,
@@ -239,6 +253,7 @@ export async function prepareHarnessWorkspaceSession(
         await options.onWriteBack?.(diff)
       }
       finally {
+        sessionHost.detachAbortSignal()
         await session.close()
       }
     },

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -3,6 +3,7 @@ import { unknownExecutionAuthority } from "@vite-hub/runtime"
 
 import { normalizeSafeWorkspacePath } from "../core/path.ts"
 import { resolveWorkspaceAutoCommit } from "../core/rules.ts"
+import { withWorkspaceProgress } from "./progress.ts"
 import { isMissingWorkspacePathError } from "./scope.ts"
 
 import type { ExecutionAuthority } from "@vite-hub/runtime"
@@ -79,25 +80,6 @@ function normalizeSessionPaths(paths?: readonly string[]): string[] | undefined 
   const normalized = [...new Set(paths.map(path => normalizeSafeWorkspacePath(path, { allowEmpty: true, allowReserved: true })))]
   if (normalized.includes("")) return undefined
   return normalized.sort((left, right) => left.length - right.length || left.localeCompare(right))
-}
-
-async function withPrepareProgress<T>(
-  onProgress: PrepareHarnessWorkspaceSessionOptions["onProgress"],
-  event: Pick<WorkspacePrepareSessionProgressEvent, "id" | "label"> & { data?: Record<string, unknown> },
-  fn: () => Promise<T>,
-) {
-  const startedAt = Date.now()
-  await onProgress?.({ data: event.data, id: event.id, label: event.label, status: "started" })
-  try {
-    const result = await fn()
-    await onProgress?.({ data: event.data, durationMs: Date.now() - startedAt, id: event.id, label: event.label, status: "completed" })
-    return result
-  }
-  catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    await onProgress?.({ data: { ...event.data, error: message }, durationMs: Date.now() - startedAt, error: message, id: event.id, label: event.label, status: "failed" })
-    throw error
-  }
 }
 
 async function materializeWorkspaceSourcesForSession(
@@ -197,7 +179,7 @@ function harnessWorkspaceHost(options: PrepareHarnessWorkspaceSessionOptions): {
 }
 
 async function initializeSandboxGitBaseline(session: WorkspaceSession, onProgress: PrepareHarnessWorkspaceSessionOptions["onProgress"]) {
-  await withPrepareProgress(onProgress, {
+  await withWorkspaceProgress(onProgress, {
     id: "workspace.prepare.git-status",
     label: "Preparing workspace status",
   }, async () => {
@@ -210,7 +192,7 @@ export async function prepareHarnessWorkspaceSession(
   options: PrepareHarnessWorkspaceSessionOptions,
 ): Promise<HarnessWorkspaceSession> {
   const paths = normalizeSessionPaths(options.paths)
-  await withPrepareProgress(options.onProgress, {
+  await withWorkspaceProgress(options.onProgress, {
     data: { paths: paths ?? null },
     id: "workspace.prepare.materialize",
     label: "Materializing workspace sources",
@@ -220,7 +202,7 @@ export async function prepareHarnessWorkspaceSession(
   }))
 
   const sessionHost = harnessWorkspaceHost(options)
-  const session = await withPrepareProgress(options.onProgress, {
+  const session = await withWorkspaceProgress(options.onProgress, {
     data: { paths: paths ?? null },
     id: "workspace.prepare.start-session",
     label: "Starting workspace session",

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -155,8 +155,11 @@ function harnessWorkspaceHost(options: PrepareHarnessWorkspaceSessionOptions): {
         if (result.code !== 0) throw new Error(`[vitehub] Failed to create Harness Workspace directory: ${result.stderr || "mkdir failed"}`)
       },
       async read(path) {
-        if (!sandbox.readBinaryFile) throw new Error("[vitehub] Harness Workspace Session requires sandbox.readBinaryFile.")
-        return await sandbox.readBinaryFile({ abortSignal, path })
+        if (sandbox.readBinaryFile) return await sandbox.readBinaryFile({ abortSignal, path })
+        const result = await run("sh", ["-c", "test -f \"$1\" || exit 44; base64 < \"$1\"", "sh", path])
+        if (result.code === 44) return null
+        if (result.code !== 0) throw new Error(`[vitehub] Failed to read Harness Workspace file: ${result.stderr || "base64 failed"}`)
+        return Buffer.from(result.stdout.replace(/\s/g, ""), "base64")
       },
       async remove(path, removeOptions) {
         const result = removeOptions?.recursive
@@ -214,7 +217,19 @@ export async function prepareHarnessWorkspaceSession(
     target: options.sessionWorkDir,
     writeBack: { exclude: options.ignoreWriteBackPaths },
   }))
-  await initializeSandboxGitBaseline(session, options.onProgress)
+  try {
+    await initializeSandboxGitBaseline(session, options.onProgress)
+  }
+  catch (error) {
+    sessionHost.detachAbortSignal()
+    try {
+      await session.close()
+    }
+    catch (cleanupError) {
+      throw new AggregateError([error, cleanupError], "[vitehub] Failed to initialize and close Harness Workspace Session.")
+    }
+    throw error
+  }
 
   return {
     async close(error?: unknown) {

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -121,6 +121,9 @@ function harnessWorkspaceHost(options: PrepareHarnessWorkspaceSessionOptions): {
       detachAbortSignal() {},
       host: {
         executionAuthority: options.executionAuthority || sandbox.workspaceHost.executionAuthority,
+        ...(sandbox.workspaceHost.detachAbortSignal
+          ? { detachAbortSignal: sandbox.workspaceHost.detachAbortSignal.bind(sandbox.workspaceHost) }
+          : {}),
         files: sandbox.workspaceHost.files,
         exec: (command, args, execOptions) => sandbox.workspaceHost!.exec(command, args, execOptions),
       },
@@ -139,6 +142,9 @@ function harnessWorkspaceHost(options: PrepareHarnessWorkspaceSessionOptions): {
 
   const host: WorkspaceSessionHost = {
     executionAuthority: options.executionAuthority || unknownExecutionAuthority,
+    detachAbortSignal() {
+      abortSignal = undefined
+    },
     files: {
       async exists(path) {
         return (await run("sh", ["-c", `test -e "$1" || test -L "$1"`, "sh", path])).code === 0
@@ -181,12 +187,16 @@ function harnessWorkspaceHost(options: PrepareHarnessWorkspaceSessionOptions): {
   }
 }
 
-async function initializeSandboxGitBaseline(session: WorkspaceSession, onProgress: PrepareHarnessWorkspaceSessionOptions["onProgress"]) {
+async function initializeSandboxGitBaseline(
+  session: WorkspaceSession,
+  onProgress: PrepareHarnessWorkspaceSessionOptions["onProgress"],
+  abortSignal?: AbortSignal,
+) {
   await withWorkspaceProgress(onProgress, {
     id: "workspace.prepare.git-status",
     label: "Preparing workspace status",
   }, async () => {
-    await session.exec("sh", ["-c", "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A -f && git commit --allow-empty --no-gpg-sign --no-verify -qm workspace-baseline || true; fi"])
+    await session.exec("sh", ["-c", "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A -f && git commit --allow-empty --no-gpg-sign --no-verify -qm workspace-baseline || true; fi"], { abortSignal })
   })
 }
 
@@ -223,7 +233,7 @@ export async function prepareHarnessWorkspaceSession(
       return session
     })
     if (!session) throw new Error("[vitehub] Harness Workspace Session did not start.")
-    await initializeSandboxGitBaseline(session, options.onProgress)
+    await initializeSandboxGitBaseline(session, options.onProgress, options.abortSignal)
   }
   catch (error) {
     if (!session) throw error
@@ -263,7 +273,7 @@ export async function prepareHarnessWorkspaceSession(
       }
     },
     async refreshGitBaseline() {
-      await initializeSandboxGitBaseline(activeSession, options.onProgress)
+      await initializeSandboxGitBaseline(activeSession, options.onProgress, options.abortSignal)
     },
   }
 }

--- a/packages/workspace/src/session/harness.ts
+++ b/packages/workspace/src/session/harness.ts
@@ -65,6 +65,10 @@ function workspaceSourceMaterializer(workspace: WorkspaceFacade): SourceMaterial
 }
 
 function workspaceSessionStarter(workspace: WorkspaceFacade) {
+  const facadeStarter = (workspace as WorkspaceFacade & {
+    startSession?: (options?: WorkspaceSessionOptions) => Promise<WorkspaceSession>
+  }).startSession
+  if (facadeStarter) return facadeStarter.bind(workspace)
   if (isWritableWorkspaceFacade(workspace)) return workspace.startSession.bind(workspace)
   const startSession = (workspace.fs as WorkspaceFsWithSession).startSession
   if (!startSession) throw new Error("[vitehub] Harness Workspace materialization requires Workspace Session support.")

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -732,7 +732,20 @@ export async function createHostedWorkspaceSession(
         if (baseRevision && await revisionMaterializer?.currentRevision({ abortSignal: options.abortSignal }) !== baseRevision) {
           throw workspaceConflict(`[vitehub] Workspace revision changed after this Session materialized: ${baseRevision}.`)
         }
-        await commitHostChanges(host, root, workspace, diff, mediaTypes, commitOptions?.message)
+        try {
+          await commitHostChanges(host, root, workspace, diff, mediaTypes, commitOptions?.message)
+        }
+        catch (error) {
+          if (baseRevision) {
+            try {
+              await workspace.rebase({ takeRemote: diff.entries.map(entry => entry.path) })
+            }
+            catch (rollbackError) {
+              throw new AggregateError([error, rollbackError], "[vitehub] Workspace publication and rollback failed.")
+            }
+          }
+          throw error
+        }
         if (baseRevision) {
           baseRevision = await revisionMaterializer!.currentRevision({
             abortSignal: options.abortSignal,

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -534,7 +534,9 @@ async function materializeWorkspace(
     abortSignal?.throwIfAborted()
     await sanitizeHostSymlinks(host, root)
     abortSignal?.throwIfAborted()
-    return { revision: revision.revision, snapshot: await snapshotHost(host, root, "host-open") }
+    const snapshot = await snapshotHost(host, root, "host-open")
+    abortSignal?.throwIfAborted()
+    return { revision: revision.revision, snapshot }
   }
   const entries = await withWorkspaceProgress(options?.onProgress, {
     data: { paths: paths ?? null },

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -476,9 +476,15 @@ async function sanitizeHostSymlinks(host: WorkspaceSessionHost, root: string) {
   }
 }
 
-async function materializeWorkspace(workspace: Workspace, host: WorkspaceSessionHost, root: string, options?: WorkspaceSessionOptions) {
+async function materializeWorkspace(
+  workspace: Workspace,
+  host: WorkspaceSessionHost,
+  root: string,
+  options?: WorkspaceSessionOptions,
+  useRevisionMaterializer = true,
+) {
   const paths = normalizeSessionPaths(options)
-  const materializer = resolveWorkspaceRevisionMaterializer(workspace)
+  const materializer = useRevisionMaterializer ? resolveWorkspaceRevisionMaterializer(workspace) : undefined
   const revision = materializer
     ? await withWorkspaceProgress(options?.onProgress, {
         data: { paths: paths ?? null },
@@ -628,6 +634,11 @@ export async function createHostedWorkspaceSession(
   catch (error) {
     if (attachedState) throw error
     try {
+      await materializeWorkspace(workspace, host, root, {
+        ...options,
+        abortSignal: undefined,
+        onProgress: undefined,
+      }, false)
       await restoreExcludedHostState(host, root, excludedWriteBackPaths, existingExcludedState)
     }
     catch (restoreError) {

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -609,7 +609,6 @@ async function materializeWorkspace(
 }
 
 async function commitHostChanges(
-  root: string,
   workspace: Workspace,
   diff: WorkspaceDiff,
   contents: ReadonlyMap<string, Uint8Array | string>,
@@ -633,13 +632,9 @@ async function commitHostChanges(
       : undefined
     const content = contents.get(entry.path)
     if (content !== undefined) {
-      const metadata = entry.after.metadata?.gitMode === "120000"
-        && !isSafeHostSymlink(root, entry.path, String(content))
-          ? undefined
-          : entry.after.metadata
       await workspace.writeFile(entry.path, content, {
         mediaType: mediaTypes.get(entry.path) || before?.mediaType,
-        metadata,
+        metadata: entry.after.metadata,
       })
     }
   }
@@ -802,10 +797,20 @@ export async function createHostedWorkspaceSession(
       return filterSessionDiff(await currentDiff(), sessionPaths)
     },
     async commit(commitOptions) {
+      assertOpen()
       const capturedState = await captureHostState(host, root, commitOptions?.message || "host-commit")
       const diff = filterWriteBackDiff(diffSnapshots(baseline, capturedState.snapshot), excludedWriteBackPaths)
       if (!diff.entries.length) return
       assertDiffInsideSessionPaths(diff, sessionPaths)
+      const publicationDiff: WorkspaceDiff = {
+        ...diff,
+        entries: diff.entries.map((entry) => {
+          const content = capturedState.contents.get(entry.path)
+          if (entry.after?.metadata?.gitMode !== "120000" || content === undefined
+            || isSafeHostSymlink(root, entry.path, String(content))) return entry
+          return { ...entry, after: { ...entry.after, metadata: undefined } }
+        }),
+      }
       const revisionMaterializer = resolveWorkspaceRevisionMaterializer(workspace)
       await withWorkspacePublication(revisionMaterializer || workspace, options.abortSignal, async () => {
         if (baseRevision && await revisionMaterializer?.currentRevision({ abortSignal: options.abortSignal }) !== baseRevision) {
@@ -814,18 +819,18 @@ export async function createHostedWorkspaceSession(
         const nextAttachedState = options.attach ? capturedState : undefined
         const nextBaseline = nextAttachedState?.snapshot || await createSnapshotFromEntries(
           Object.entries(baseline.entries)
-            .filter(([path]) => !diff.entries.some(entry => entry.path === path && !entry.after))
+            .filter(([path]) => !publicationDiff.entries.some(entry => entry.path === path && !entry.after))
             .map(([path, entry]) => {
-              const changed = diff.entries.find(item => item.path === path)?.after
+              const changed = publicationDiff.entries.find(item => item.path === path)?.after
               return { path, ...(changed || entry) }
             })
-            .concat(diff.entries
+            .concat(publicationDiff.entries
               .filter(entry => entry.after && !baseline.entries[entry.path])
               .map(entry => ({ path: entry.path, ...entry.after! }))),
           commitOptions?.message || "host-commit",
         )
         try {
-          await commitHostChanges(root, workspace, diff, capturedState.contents, mediaTypes, commitOptions?.message)
+          await commitHostChanges(workspace, publicationDiff, capturedState.contents, mediaTypes, commitOptions?.message)
         }
         catch (error) {
           if (baseRevision) {

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -750,18 +750,17 @@ export async function createHostedWorkspaceSession(
     async close() {
       if (closed) return
       await ensureHostWorkspaceRoot(host, root)
-      const rootExists = true
       let diff: WorkspaceDiff | undefined
       if (options.attach && attachedState) {
         const attachedDiff = filterSessionDiff(diffSnapshots(baseline, await snapshotHost(host, root)), sessionPaths)
         await restoreAttachedHost(host, root, attachedDiff, attachedState)
       }
-      else if (rootExists && excludedState) {
+      else if (excludedState) {
         await restoreExcludedHostState(host, root, excludedWriteBackPaths, excludedState)
         diff = await currentDiff()
       }
       closed = true
-      if (rootExists && diff?.entries.length) await materializeWorkspace(workspace, host, root, options)
+      if (diff?.entries.length) await materializeWorkspace(workspace, host, root, options)
     },
   }
 }

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -619,9 +619,22 @@ export async function createHostedWorkspaceSession(
   let closed = false
   const existingExcludedState = await captureExcludedHostState(host, root, excludedWriteBackPaths)
   let attachedState = options.attach ? await captureHostState(host, root, "host-attach") : undefined
-  const materialization: { revision?: string, snapshot: WorkspaceSnapshot } = attachedState
-    ? { snapshot: attachedState.snapshot }
-    : await materializeWorkspace(workspace, host, root, options)
+  let materialization: { revision?: string, snapshot: WorkspaceSnapshot }
+  try {
+    materialization = attachedState
+      ? { snapshot: attachedState.snapshot }
+      : await materializeWorkspace(workspace, host, root, options)
+  }
+  catch (error) {
+    if (attachedState) throw error
+    try {
+      await restoreExcludedHostState(host, root, excludedWriteBackPaths, existingExcludedState)
+    }
+    catch (restoreError) {
+      throw new AggregateError([error, restoreError], "[vitehub] Workspace Session setup and excluded-state restoration failed.")
+    }
+    throw error
+  }
   let baseline = materialization.snapshot
   let baseRevision = materialization.revision
   const excludedState = attachedState

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -30,6 +30,19 @@ import type {
 } from "../core/types.ts"
 
 const publicationQueues = new WeakMap<object, Promise<void>>()
+const hostInspectionConcurrency = 16
+
+async function mapWithConcurrency<T, U>(values: readonly T[], concurrency: number, visit: (value: T) => Promise<U>) {
+  const results = new Array<U>(values.length)
+  let next = 0
+  await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+    while (next < values.length) {
+      const index = next++
+      results[index] = await visit(values[index]!)
+    }
+  }))
+  return results
+}
 
 async function withWorkspacePublication<T>(key: object, publish: () => Promise<T>): Promise<T> {
   const previous = publicationQueues.get(key) || Promise.resolve()
@@ -201,13 +214,13 @@ async function listHostEntries(
   const entries = (await host.files.list(toHostPath(root, path), { recursive }))
     .map(entry => toWorkspaceEntry(root, entry))
     .filter(entry => !include || include(entry))
-  const resolved = await Promise.all(entries.map(async (workspaceEntry) => {
+  const resolved = await mapWithConcurrency(entries, hostInspectionConcurrency, async (workspaceEntry) => {
     if (workspaceEntry.type !== "file" || isGitSymlinkEntry(workspaceEntry)) return workspaceEntry
     const executable = await host.exec("test", ["-x", workspaceEntry.path], { cwd: root })
     return executable.code === 0
       ? { ...workspaceEntry, metadata: { ...workspaceEntry.metadata, gitMode: "100755" } }
       : workspaceEntry
-  }))
+  })
   return resolved
     .filter(entry => entry.path && entry.path !== ".git" && !entry.path.startsWith(".git/"))
     .sort((left, right) => left.path.localeCompare(right.path))
@@ -634,6 +647,7 @@ export async function createHostedWorkspaceSession(
   catch (error) {
     if (attachedState) throw error
     try {
+      host.detachAbortSignal?.()
       await materializeWorkspace(workspace, host, root, {
         ...options,
         abortSignal: undefined,
@@ -799,6 +813,7 @@ export async function createHostedWorkspaceSession(
     },
     async close() {
       if (closed) return
+      host.detachAbortSignal?.()
       await ensureHostWorkspaceRoot(host, root)
       let diff: WorkspaceDiff | undefined
       if (options.attach && attachedState) {
@@ -809,14 +824,29 @@ export async function createHostedWorkspaceSession(
       else {
         diff = await currentDiff()
       }
-      if (diff?.entries.length) {
-        await materializeWorkspace(workspace, host, root, {
-          ...options,
-          abortSignal: undefined,
-          onProgress: undefined,
-        })
+      let restoreError: unknown
+      try {
+        if (diff?.entries.length) {
+          await materializeWorkspace(workspace, host, root, {
+            ...options,
+            abortSignal: undefined,
+            onProgress: undefined,
+          })
+        }
       }
-      if (!options.attach) await restoreExcludedHostState(host, root, excludedWriteBackPaths, excludedState)
+      catch (error) {
+        restoreError = error
+      }
+      try {
+        if (!options.attach) await restoreExcludedHostState(host, root, excludedWriteBackPaths, excludedState)
+      }
+      catch (excludedError) {
+        if (restoreError) {
+          throw new AggregateError([restoreError, excludedError], "[vitehub] Workspace Session restoration and excluded-state restoration failed.")
+        }
+        throw excludedError
+      }
+      if (restoreError) throw restoreError
       closed = true
     },
   }

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -760,8 +760,14 @@ export async function createHostedWorkspaceSession(
         await restoreExcludedHostState(host, root, excludedWriteBackPaths, excludedState)
         diff = await currentDiff()
       }
+      if (diff?.entries.length) {
+        await materializeWorkspace(workspace, host, root, {
+          ...options,
+          abortSignal: undefined,
+          onProgress: undefined,
+        })
+      }
       closed = true
-      if (diff?.entries.length) await materializeWorkspace(workspace, host, root, options)
     },
   }
 }

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -1,10 +1,14 @@
+import { randomUUID } from "node:crypto"
 import { posix } from "node:path"
 import { normalizeExecutionAuthority } from "@vite-hub/runtime"
 
-import { workspaceError } from "../core/errors.ts"
+import { workspaceConflict, workspaceError } from "../core/errors.ts"
 import { contentToBytes, decodeFile, normalizeSafeWorkspacePath, normalizeWorkspacePath, sha256 } from "../core/path.ts"
 import { createSnapshotFromEntries, diffSnapshots } from "../storage/utils.ts"
 import { assertDiffInsideSessionPaths, assertPathInSessionScope, filterSessionDiff, filterSessionEntries, isMissingWorkspacePathError, scopedSearchQuery } from "./scope.ts"
+import { resolveWorkspaceRevisionMaterializer } from "../storage/materialization.ts"
+
+import type { WorkspaceRevisionMaterialization } from "../storage/materialization.ts"
 
 import type {
   ReadFileOptions,
@@ -20,8 +24,60 @@ import type {
   WorkspaceSessionHost,
   WorkspaceSessionHostFileEntry,
   WorkspaceSessionOptions,
+  WorkspaceSnapshot,
+  WorkspacePrepareSessionProgressEvent,
   WorkspaceSessionWriteFileOptions,
 } from "../core/types.ts"
+
+type PrepareProgressReporter = WorkspaceSessionOptions["onProgress"]
+const publicationQueues = new WeakMap<object, Promise<void>>()
+
+async function withWorkspacePublication<T>(key: object, publish: () => Promise<T>): Promise<T> {
+  const previous = publicationQueues.get(key) || Promise.resolve()
+  let release!: () => void
+  const current = new Promise<void>((resolve) => { release = resolve })
+  publicationQueues.set(key, current)
+  await previous
+  try {
+    return await publish()
+  }
+  finally {
+    release()
+    if (publicationQueues.get(key) === current) publicationQueues.delete(key)
+  }
+}
+
+async function withPrepareProgress<T>(
+  onProgress: PrepareProgressReporter,
+  event: Pick<WorkspacePrepareSessionProgressEvent, "id" | "label"> & { data?: Record<string, unknown> },
+  fn: () => Promise<T>,
+) {
+  const startedAt = Date.now()
+  await onProgress?.({ data: event.data, id: event.id, label: event.label, status: "started" })
+  try {
+    const result = await fn()
+    await onProgress?.({
+      data: event.data,
+      durationMs: Date.now() - startedAt,
+      id: event.id,
+      label: event.label,
+      status: "completed",
+    })
+    return result
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    await onProgress?.({
+      data: { ...event.data, error: message },
+      durationMs: Date.now() - startedAt,
+      error: message,
+      id: event.id,
+      label: event.label,
+      status: "failed",
+    })
+    throw error
+  }
+}
 
 function normalizeTarget(target = "/workspace") {
   const normalized = posix.resolve("/", target.replace(/\\/g, "/"))
@@ -34,8 +90,14 @@ function normalizeSearchRoot(path: string) {
   return normalized === "." ? "" : normalizeSafeWorkspacePath(normalized, { allowEmpty: true })
 }
 
+function normalizeReadableSessionPath(path: string) {
+  const normalized = normalizeSafeWorkspacePath(path, { allowReserved: true })
+  if (/^\.vitehub\/sources\/[^/]+\.json$/.test(normalized)) return normalized
+  return normalizeSafeWorkspacePath(path)
+}
+
 function toHostPath(root: string, path = "") {
-  const normalized = normalizeSafeWorkspacePath(path, { allowEmpty: true })
+  const normalized = normalizeSafeWorkspacePath(path, { allowEmpty: true, allowReserved: true })
   return normalized ? posix.join(root, normalized) : root
 }
 
@@ -56,7 +118,7 @@ function fromHostPath(root: string, path: string) {
   if (!normalizedPath.startsWith(`${normalizedRoot}/`)) {
     throw workspaceError(`[vitehub] Workspace host returned a path outside ${root}: ${path}.`)
   }
-  return normalizeWorkspacePath(normalizedPath.slice(normalizedRoot.length + 1))
+  return normalizeSafeWorkspacePath(normalizedPath.slice(normalizedRoot.length + 1), { allowReserved: true })
 }
 
 function isGitSymlinkEntry(entry: WorkspaceEntry): boolean {
@@ -76,6 +138,42 @@ function isSafeHostSymlink(root: string, path: string, target: string) {
   if (posix.isAbsolute(target)) return false
   const resolved = posix.resolve(posix.dirname(toHostPath(root, path)), target)
   return resolved === root || resolved.startsWith(`${root}/`)
+}
+
+async function isHostPath(host: WorkspaceSessionHost, path: string, flag: "-d" | "-L") {
+  return (await host.exec("test", [flag, path])).code === 0
+}
+
+async function assertHostWorkspaceRoot(host: WorkspaceSessionHost, root: string) {
+  if (await isHostPath(host, root, "-L") || !await isHostPath(host, root, "-d"))
+    throw workspaceError(`[vitehub] Workspace host root must be a directory: ${root}.`)
+}
+
+async function ensureHostWorkspaceRoot(host: WorkspaceSessionHost, root: string) {
+  const symlink = await isHostPath(host, root, "-L")
+  const directory = !symlink && await isHostPath(host, root, "-d")
+  if (directory) return false
+  if (symlink || await host.files.exists(root)) await host.files.remove(root, { recursive: false })
+  await host.files.mkdir(root, { recursive: true })
+  await assertHostWorkspaceRoot(host, root)
+  return true
+}
+
+async function removeHostSymlinkAncestors(host: WorkspaceSessionHost, root: string, path: string) {
+  let ancestor = root
+  for (const component of fromHostPath(root, path).split("/").slice(0, -1)) {
+    ancestor = posix.join(ancestor, component)
+    if (!await isHostPath(host, ancestor, "-L")) continue
+    await host.files.remove(ancestor, { recursive: false })
+    if (await isHostPath(host, ancestor, "-L"))
+      throw workspaceError(`[vitehub] Failed to remove Workspace symlink ancestor: ${ancestor}.`)
+    return
+  }
+}
+
+async function removeHostPath(host: WorkspaceSessionHost, root: string, path: string, recursive: boolean) {
+  await removeHostSymlinkAncestors(host, root, path)
+  await host.files.remove(path, { recursive: await isHostPath(host, path, "-L") ? false : recursive })
 }
 
 async function assertNoHostSymlinkParent(host: WorkspaceSessionHost, root: string, target: string) {
@@ -112,24 +210,33 @@ async function readHostSymlinkTarget(host: WorkspaceSessionHost, root: string, p
 }
 
 async function writeHostSymlink(host: WorkspaceSessionHost, root: string, path: string, target: string) {
-  await host.files.remove(path).catch(() => undefined)
+  await removeHostPath(host, root, path, false)
   const result = await host.exec("ln", ["-s", target, fromHostPath(root, path)], { cwd: root })
   if (result.code !== 0)
     throw workspaceError(`[vitehub] Failed to create workspace symlink: ${path}. ${result.stderr || "ln failed"}`)
 }
 
 async function readHostFile(host: WorkspaceSessionHost, root: string, path: string): Promise<WorkspaceFile | undefined> {
+  await assertHostWorkspaceRoot(host, root)
   if (!await host.files.exists(path)) return undefined
   const content = await host.files.read(path)
   return content ? { content, path: fromHostPath(root, path) } : undefined
 }
 
-async function listHostEntries(host: WorkspaceSessionHost, root: string, path = "", recursive = false): Promise<WorkspaceEntry[]> {
-  const entries = await host.files.list(toHostPath(root, path), { recursive })
-  const resolved = await Promise.all(entries.map(async (entry) => {
-    const workspaceEntry = toWorkspaceEntry(root, entry)
+async function listHostEntries(
+  host: WorkspaceSessionHost,
+  root: string,
+  path = "",
+  recursive = false,
+  include?: (entry: WorkspaceEntry) => boolean,
+): Promise<WorkspaceEntry[]> {
+  await assertHostWorkspaceRoot(host, root)
+  const entries = (await host.files.list(toHostPath(root, path), { recursive }))
+    .map(entry => toWorkspaceEntry(root, entry))
+    .filter(entry => !include || include(entry))
+  const resolved = await Promise.all(entries.map(async (workspaceEntry) => {
     if (workspaceEntry.type !== "file" || isGitSymlinkEntry(workspaceEntry)) return workspaceEntry
-    const executable = await host.exec("test", ["-x", fromHostPath(root, entry.path)], { cwd: root })
+    const executable = await host.exec("test", ["-x", workspaceEntry.path], { cwd: root })
     return executable.code === 0
       ? { ...workspaceEntry, metadata: { ...workspaceEntry.metadata, gitMode: "100755" } }
       : workspaceEntry
@@ -150,7 +257,16 @@ async function snapshotHost(host: WorkspaceSessionHost, root: string, name?: str
 }
 
 async function captureHostState(host: WorkspaceSessionHost, root: string, name?: string) {
+  if (await isHostPath(host, root, "-L"))
+    throw workspaceError(`[vitehub] Workspace host root must be a directory: ${root}.`)
+  if (!await host.files.exists(root)) {
+    return { contents: new Map<string, Uint8Array | string>(), snapshot: await createSnapshotFromEntries([], name) }
+  }
   const entries = await listHostEntries(host, root, "", true)
+  return await captureHostEntriesState(host, root, entries, name)
+}
+
+async function captureHostEntriesState(host: WorkspaceSessionHost, root: string, entries: WorkspaceEntry[], name?: string) {
   const contents = new Map<string, Uint8Array | string>()
   const files = await Promise.all(entries.map(async (entry) => {
     if (entry.type !== "file") return entry
@@ -168,6 +284,49 @@ async function captureHostState(host: WorkspaceSessionHost, root: string, name?:
   return { contents, snapshot: await createSnapshotFromEntries(files, name) }
 }
 
+function isInsideExcludedWriteBackPath(path: string, excluded: readonly string[]) {
+  return excluded.some(item => path === item || path.startsWith(`${item}/`))
+}
+
+async function captureExcludedHostState(host: WorkspaceSessionHost, root: string, excluded: readonly string[]) {
+  if (await isHostPath(host, root, "-L"))
+    throw workspaceError(`[vitehub] Workspace host root must be a directory: ${root}.`)
+  if (!await host.files.exists(root)) return await captureHostEntriesState(host, root, [], "host-excluded")
+  const entries = await listHostEntries(host, root, "", true, entry => isInsideExcludedWriteBackPath(entry.path, excluded))
+  return await captureHostEntriesState(host, root, entries, "host-excluded")
+}
+
+async function restoreExcludedHostState(
+  host: WorkspaceSessionHost,
+  root: string,
+  excluded: readonly string[],
+  state: Awaited<ReturnType<typeof captureExcludedHostState>>,
+) {
+  const roots = excluded.filter((path, index) => !excluded.some((parent, parentIndex) => parentIndex !== index && path.startsWith(`${parent}/`)))
+  for (const path of roots.sort((left, right) => right.length - left.length)) {
+    await removeHostPath(host, root, toHostPath(root, path), true)
+  }
+
+  const entries = Object.entries(state.snapshot.entries)
+    .sort(([left], [right]) => left.split("/").length - right.split("/").length)
+  for (const [path, entry] of entries) {
+    const target = toHostPath(root, path)
+    await removeHostSymlinkAncestors(host, root, target)
+    if (entry.type === "directory") {
+      await host.files.mkdir(target, { recursive: true })
+      continue
+    }
+    const content = state.contents.get(path)
+    if (content === undefined) continue
+    await ensureHostParent(host, target)
+    if (entry.metadata?.gitMode === "120000") await writeHostSymlink(host, root, target, String(content))
+    else {
+      await host.files.write(target, contentToBytes(content))
+      if (entry.metadata?.gitMode === "100755") await makeHostFileExecutable(host, root, target)
+    }
+  }
+}
+
 async function restoreAttachedHost(
   host: WorkspaceSessionHost,
   root: string,
@@ -175,8 +334,9 @@ async function restoreAttachedHost(
   state: Awaited<ReturnType<typeof captureHostState>>,
 ) {
   const changed = [...new Set(diff.entries.map(entry => entry.path))]
-  for (const path of changed.sort((left, right) => right.length - left.length))
-    await host.files.remove(toHostPath(root, path), { recursive: true }).catch(() => undefined)
+  for (const path of changed.sort((left, right) => right.length - left.length)) {
+    await removeHostPath(host, root, toHostPath(root, path), true)
+  }
 
   const baselineEntries = changed
     .map(path => [path, state.snapshot.entries[path]] as const)
@@ -184,6 +344,7 @@ async function restoreAttachedHost(
     .sort(([left], [right]) => left.split("/").length - right.split("/").length)
   for (const [path, entry] of baselineEntries) {
     const target = toHostPath(root, path)
+    await removeHostSymlinkAncestors(host, root, target)
     if (entry.type === "directory") {
       await host.files.mkdir(target, { recursive: true })
       continue
@@ -200,13 +361,27 @@ async function restoreAttachedHost(
 }
 
 async function resetHostWorkspaceRoot(host: WorkspaceSessionHost, root: string) {
-  await host.files.remove(root, { recursive: true }).catch(() => undefined)
-  await host.files.mkdir(root, { recursive: true })
+  if (await ensureHostWorkspaceRoot(host, root)) return
+  for (const entry of await host.files.list(root)) {
+    await removeHostPath(host, root, entry.path, true)
+  }
+}
+
+function isExcludedWriteBackPath(path: string, excluded: readonly string[]) {
+  return excluded.some(item => path === item || path.startsWith(`${item}/`) || item.startsWith(`${path}/`))
+}
+
+function filterWriteBackDiff(diff: WorkspaceDiff, excluded: readonly string[]): WorkspaceDiff {
+  return {
+    ...diff,
+    entries: diff.entries.filter(entry => !isExcludedWriteBackPath(entry.path, excluded)),
+  }
 }
 
 function normalizeSessionPaths(options?: WorkspaceSessionOptions): string[] | undefined {
-  const paths = [...new Set((options?.paths || []).map(path => normalizeSafeWorkspacePath(path, { allowEmpty: true, allowReserved: true })))]
-  if (!paths.length || paths.includes("")) return undefined
+  if (options?.paths === undefined) return undefined
+  const paths = [...new Set(options.paths.map(path => normalizeSafeWorkspacePath(path, { allowEmpty: true, allowReserved: true })))]
+  if (paths.includes("")) return undefined
   return paths.sort((left, right) => left.length - right.length || left.localeCompare(right))
 }
 
@@ -229,34 +404,156 @@ async function sessionEntries(workspace: Workspace, options?: WorkspaceSessionOp
   return [...entries.values()].sort((left, right) => left.path.localeCompare(right.path))
 }
 
+async function extractRevisionArchive(
+  host: WorkspaceSessionHost,
+  root: string,
+  materialization: WorkspaceRevisionMaterialization & { archive: Uint8Array },
+  signal?: AbortSignal,
+) {
+  const stagingRoot = posix.join(root, `.vitehub-workspace-${randomUUID()}`)
+  const archive = posix.join(stagingRoot, "revision.tar.gz")
+  const staging = posix.join(stagingRoot, "extracted")
+  await host.files.mkdir(stagingRoot, { recursive: true })
+  await host.files.write(archive, materialization.archive)
+  await host.files.mkdir(staging, { recursive: true })
+  try {
+    const extracted = await host.exec("tar", ["-xzf", archive, "-C", staging], { signal })
+    if (extracted.code !== 0) {
+      throw workspaceError(`[vitehub] Failed to extract Workspace revision ${materialization.revision}: ${extracted.stderr || "tar failed"}`)
+    }
+    const roots = (await host.files.list(staging)).filter(entry => entry.type === "directory")
+    if (roots.length !== 1) {
+      throw workspaceError(`[vitehub] Workspace revision archive must contain one repository root.`)
+    }
+    const archiveRoot = normalizeSafeWorkspacePath(materialization.root, { allowEmpty: true, allowReserved: true })
+    let source = roots[0]!.path
+    let validSource = true
+    for (const component of archiveRoot.split("/").filter(Boolean)) {
+      source = posix.join(source, component)
+      if ((await host.exec("test", ["-L", source], { signal })).code === 0) {
+        throw workspaceError(`[vitehub] Workspace revision archive root must not contain symlinks: ${materialization.root}.`)
+      }
+      if ((await host.exec("test", ["-d", source], { signal })).code !== 0) {
+        validSource = false
+        break
+      }
+    }
+    if (!validSource && materialization.files > 0) {
+      throw workspaceError(`[vitehub] Workspace revision archive is missing ${materialization.root || "its repository root"}.`)
+    }
+    if (!validSource) return
+    const paths = materialization.paths
+    if (!paths) {
+      const copied = await host.exec("cp", ["-a", `${source}/.`, root], { signal })
+      if (copied.code !== 0) {
+        throw workspaceError(`[vitehub] Failed to materialize Workspace revision ${materialization.revision}: ${copied.stderr || "copy failed"}`)
+      }
+    }
+    else {
+      for (const path of paths) {
+        const selected = posix.join(source, path)
+        if (!await host.files.exists(selected)) continue
+        const destination = toHostPath(root, posix.dirname(path) === "." ? "" : posix.dirname(path))
+        await host.files.mkdir(destination, { recursive: true })
+        const copied = await host.exec("cp", ["-a", selected, destination], { signal })
+        if (copied.code !== 0) {
+          throw workspaceError(`[vitehub] Failed to materialize Workspace revision ${materialization.revision}: ${copied.stderr || "copy failed"}`)
+        }
+      }
+    }
+  }
+  finally {
+    await removeHostPath(host, root, stagingRoot, true)
+  }
+}
+
+async function sanitizeHostSymlinks(host: WorkspaceSessionHost, root: string) {
+  const symlinks = (await listHostEntries(host, root, "", true)).filter(isGitSymlinkEntry)
+  for (const entry of symlinks) {
+    const path = toHostPath(root, entry.path)
+    const target = await readHostSymlinkTarget(host, root, path)
+    if (isSafeHostSymlink(root, entry.path, target)) continue
+    await host.files.remove(path, { recursive: false })
+    await host.files.write(path, contentToBytes(target))
+  }
+}
+
 async function materializeWorkspace(workspace: Workspace, host: WorkspaceSessionHost, root: string, options?: WorkspaceSessionOptions) {
-  await resetHostWorkspaceRoot(host, root)
-  const entries = await sessionEntries(workspace, options)
+  const paths = normalizeSessionPaths(options)
+  const materializer = resolveWorkspaceRevisionMaterializer(workspace)
+  const revision = materializer
+    ? await withPrepareProgress(options?.onProgress, {
+        data: { paths: paths ?? null },
+        id: "workspace.prepare.revision",
+        label: "Resolving workspace revision",
+      }, async () => await materializer.materializeRevision({
+        abortSignal: options?.abortSignal,
+        paths,
+      }))
+    : undefined
+  await withPrepareProgress(options?.onProgress, {
+    id: "workspace.prepare.reset-sandbox",
+    label: "Resetting sandbox workspace",
+  }, async () => await resetHostWorkspaceRoot(host, root))
+  if (revision?.archive) {
+    await withPrepareProgress(options?.onProgress, {
+      data: {
+        bytes: revision.archive.byteLength,
+        files: revision.files,
+        revision: revision.revision,
+      },
+      id: "workspace.prepare.extract-archive",
+      label: "Extracting workspace revision",
+    }, async () => await extractRevisionArchive(host, root, { ...revision, archive: revision.archive! }, options?.abortSignal))
+    await Promise.all([
+      removeHostPath(host, root, toHostPath(root, ".git"), true),
+      removeHostPath(host, root, toHostPath(root, ".vitehub"), true),
+    ])
+    await sanitizeHostSymlinks(host, root)
+    return { revision: revision.revision, snapshot: await snapshotHost(host, root, "host-open") }
+  }
+  const entries = await withPrepareProgress(options?.onProgress, {
+    data: { paths: paths ?? null },
+    id: "workspace.prepare.entries",
+    label: "Resolving workspace entries",
+  }, async () => await sessionEntries(workspace, options))
   const symlinks = new Set(entries.filter(isGitSymlinkEntry).map(entry => entry.path))
   const nested = entries.find(entry => hasSymlinkParent(entry.path, symlinks))
   if (nested)
     throw workspaceError(`[vitehub] Workspace path crosses a symlink parent: ${nested.path}.`)
   for (const entry of entries.filter(entry => entry.type === "directory"))
     await host.files.mkdir(toHostPath(root, entry.path), { recursive: true })
-  for (const entry of entries) {
-    if (entry.type !== "file") continue
-    const target = toHostPath(root, entry.path)
-    await ensureHostParent(host, target)
-    if (isGitSymlinkEntry(entry)) {
-      const symlinkTarget = typeof entry.metadata?.symlinkTarget === "string"
-        ? entry.metadata.symlinkTarget
-        : new TextDecoder().decode(contentToBytes(await workspace.readFile(entry.path, { encoding: "binary" })))
-      if (isSafeHostSymlink(root, entry.path, symlinkTarget))
-        await writeHostSymlink(host, root, target, symlinkTarget)
-      else
-        await host.files.write(target, contentToBytes(symlinkTarget))
+  await withPrepareProgress(options?.onProgress, {
+    data: {
+      bytes: entries.reduce((total, entry) => total + (entry.size || 0), 0),
+      files: entries.filter(entry => entry.type === "file").length,
+    },
+    id: "workspace.prepare.read-files",
+    label: "Reading workspace files",
+  }, async () => {
+    for (const entry of entries) {
+      if (entry.type !== "file") continue
+      const target = toHostPath(root, entry.path)
+      await ensureHostParent(host, target)
+      if (isGitSymlinkEntry(entry)) {
+        const symlinkTarget = typeof entry.metadata?.symlinkTarget === "string"
+          ? entry.metadata.symlinkTarget
+          : new TextDecoder().decode(contentToBytes(await workspace.readFile(entry.path, { encoding: "binary" })))
+        if (isSafeHostSymlink(root, entry.path, symlinkTarget))
+          await writeHostSymlink(host, root, target, symlinkTarget)
+        else
+          await host.files.write(target, contentToBytes(symlinkTarget))
+      }
+      else {
+        await host.files.write(target, contentToBytes(await workspace.readFile(entry.path, { encoding: "binary" })))
+        if (entry.metadata?.gitMode === "100755") await makeHostFileExecutable(host, root, target)
+      }
     }
-    else {
-      await host.files.write(target, contentToBytes(await workspace.readFile(entry.path, { encoding: "binary" })))
-      if (entry.metadata?.gitMode === "100755") await makeHostFileExecutable(host, root, target)
-    }
+  })
+  if (revision && await materializer?.currentRevision({ abortSignal: options?.abortSignal }) !== revision.revision) {
+    throw workspaceConflict(`[vitehub] Workspace revision changed while this Session materialized: ${revision.revision}.`)
   }
-  return await snapshotHost(host, root, "host-open")
+  return { revision: revision?.revision, snapshot: await snapshotHost(host, root, "host-open") }
 }
 
 async function commitHostChanges(
@@ -298,7 +595,7 @@ async function commitHostChanges(
       })
     }
   }
-  await workspace.snapshot({ name: message || "host-commit" })
+  return await workspace.snapshot({ name: message || "host-commit" })
 }
 
 export async function createHostedWorkspaceSession(
@@ -315,9 +612,20 @@ export async function createHostedWorkspaceSession(
   }
   const root = normalizeTarget(options.target)
   const sessionPaths = normalizeSessionPaths(options)
+  const excludedWriteBackPaths = [
+    ".agent-runs",
+    ".git",
+    ".vitehub",
+    ...(options.writeBack?.exclude || []).map(path => normalizeSafeWorkspacePath(path, { allowReserved: true })),
+  ]
   let closed = false
   let attachedState = options.attach ? await captureHostState(host, root, "host-attach") : undefined
-  let baseline = attachedState?.snapshot || await materializeWorkspace(workspace, host, root, options)
+  const materialization: { revision?: string, snapshot: WorkspaceSnapshot } = attachedState
+    ? { snapshot: attachedState.snapshot }
+    : await materializeWorkspace(workspace, host, root, options)
+  let baseline = materialization.snapshot
+  let baseRevision = materialization.revision
+  const excludedState = options.attach ? undefined : await captureExcludedHostState(host, root, excludedWriteBackPaths)
   const mediaTypes = new Map<string, string>()
 
   function assertOpen() {
@@ -326,14 +634,14 @@ export async function createHostedWorkspaceSession(
 
   async function currentDiff() {
     assertOpen()
-    return diffSnapshots(baseline, await snapshotHost(host, root))
+    return filterWriteBackDiff(diffSnapshots(baseline, await snapshotHost(host, root)), excludedWriteBackPaths)
   }
 
   return {
     executionAuthority,
     async readFile<TOptions extends ReadFileOptions | undefined = undefined>(path: string, readOptions?: TOptions): Promise<ReadFileResult<TOptions>> {
       assertOpen()
-      const target = toHostPath(root, assertPathInSessionScope(normalizeSafeWorkspacePath(path), sessionPaths, { masked: true }))
+      const target = toHostPath(root, assertPathInSessionScope(normalizeReadableSessionPath(path), sessionPaths, { masked: true }))
       const file = await readHostFile(host, root, target)
       if (!file) throw workspaceError(`[vitehub] Workspace file does not exist: ${path}.`)
       return decodeFile(file.content, readOptions)
@@ -343,7 +651,7 @@ export async function createHostedWorkspaceSession(
       const target = toHostPath(root, assertPathInSessionScope(normalizeSafeWorkspacePath(path), sessionPaths))
       await assertNoHostSymlinkParent(host, root, target)
       await ensureHostParent(host, target)
-      await host.files.remove(target, { recursive: true }).catch(() => undefined)
+      await removeHostPath(host, root, target, true)
       const symlinkTarget = writeOptions?.metadata?.gitMode === "120000"
         ? new TextDecoder().decode(contentToBytes(content))
         : undefined
@@ -372,7 +680,7 @@ export async function createHostedWorkspaceSession(
       const workspacePath = assertPathInSessionScope(normalizeSafeWorkspacePath(path), sessionPaths)
       const target = toHostPath(root, workspacePath)
       await assertNoHostSymlinkParent(host, root, target)
-      await host.files.remove(target, { recursive: rmOptions?.recursive })
+      await removeHostPath(host, root, target, Boolean(rmOptions?.recursive))
       mediaTypes.delete(normalizeWorkspacePath(workspacePath))
     },
     async list(path = "", listOptions = {}) {
@@ -419,12 +727,24 @@ export async function createHostedWorkspaceSession(
       const diff = await currentDiff()
       if (!diff.entries.length) return
       assertDiffInsideSessionPaths(diff, sessionPaths)
-      await commitHostChanges(host, root, workspace, diff, mediaTypes, commitOptions?.message)
-      if (options.attach) {
-        attachedState = await captureHostState(host, root, commitOptions?.message || "host-commit")
-        baseline = attachedState.snapshot
-      }
-      else baseline = await snapshotHost(host, root, commitOptions?.message || "host-commit")
+      const revisionMaterializer = resolveWorkspaceRevisionMaterializer(workspace)
+      await withWorkspacePublication(revisionMaterializer || workspace, async () => {
+        if (baseRevision && await revisionMaterializer?.currentRevision({ abortSignal: options.abortSignal }) !== baseRevision) {
+          throw workspaceConflict(`[vitehub] Workspace revision changed after this Session materialized: ${baseRevision}.`)
+        }
+        await commitHostChanges(host, root, workspace, diff, mediaTypes, commitOptions?.message)
+        if (baseRevision) {
+          baseRevision = await revisionMaterializer!.currentRevision({
+            abortSignal: options.abortSignal,
+            refresh: false,
+          })
+        }
+        if (options.attach) {
+          attachedState = await captureHostState(host, root, commitOptions?.message || "host-commit")
+          baseline = attachedState.snapshot
+        }
+        else baseline = await snapshotHost(host, root, commitOptions?.message || "host-commit")
+      })
     },
     async exec(command, args = [], execOptions = {}) {
       assertOpen()
@@ -438,12 +758,19 @@ export async function createHostedWorkspaceSession(
     },
     async close() {
       if (closed) return
+      await ensureHostWorkspaceRoot(host, root)
+      const rootExists = true
+      let diff: WorkspaceDiff | undefined
       if (options.attach && attachedState) {
-        const diff = filterSessionDiff(diffSnapshots(baseline, await snapshotHost(host, root)), sessionPaths)
-        await restoreAttachedHost(host, root, diff, attachedState)
+        const attachedDiff = filterSessionDiff(diffSnapshots(baseline, await snapshotHost(host, root)), sessionPaths)
+        await restoreAttachedHost(host, root, attachedDiff, attachedState)
+      }
+      else if (rootExists && excludedState) {
+        await restoreExcludedHostState(host, root, excludedWriteBackPaths, excludedState)
+        diff = await currentDiff()
       }
       closed = true
-      if (!options.attach) await materializeWorkspace(workspace, host, root, options)
+      if (rootExists && diff?.entries.length) await materializeWorkspace(workspace, host, root, options)
     },
   }
 }

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -609,6 +609,7 @@ async function materializeWorkspace(
 }
 
 async function commitHostChanges(
+  root: string,
   workspace: Workspace,
   diff: WorkspaceDiff,
   contents: ReadonlyMap<string, Uint8Array | string>,
@@ -632,9 +633,13 @@ async function commitHostChanges(
       : undefined
     const content = contents.get(entry.path)
     if (content !== undefined) {
+      const metadata = entry.after.metadata?.gitMode === "120000"
+        && !isSafeHostSymlink(root, entry.path, String(content))
+          ? undefined
+          : entry.after.metadata
       await workspace.writeFile(entry.path, content, {
         mediaType: mediaTypes.get(entry.path) || before?.mediaType,
-        metadata: entry.after.metadata,
+        metadata,
       })
     }
   }
@@ -820,7 +825,7 @@ export async function createHostedWorkspaceSession(
           commitOptions?.message || "host-commit",
         )
         try {
-          await commitHostChanges(workspace, diff, capturedState.contents, mediaTypes, commitOptions?.message)
+          await commitHostChanges(root, workspace, diff, capturedState.contents, mediaTypes, commitOptions?.message)
         }
         catch (error) {
           if (baseRevision) {

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -497,6 +497,8 @@ async function materializeWorkspace(
   options?: WorkspaceSessionOptions,
   useRevisionMaterializer = true,
 ) {
+  const abortSignal = options?.abortSignal
+  abortSignal?.throwIfAborted()
   const paths = normalizeSessionPaths(options)
   const materializer = useRevisionMaterializer ? resolveWorkspaceRevisionMaterializer(workspace) : undefined
   const revision = materializer
@@ -513,6 +515,7 @@ async function materializeWorkspace(
     id: "workspace.prepare.reset-sandbox",
     label: "Resetting sandbox workspace",
   }, async () => await resetHostWorkspaceRoot(host, root))
+  abortSignal?.throwIfAborted()
   if (revision?.archive) {
     await withWorkspaceProgress(options?.onProgress, {
       data: {
@@ -539,8 +542,11 @@ async function materializeWorkspace(
   const nested = entries.find(entry => hasSymlinkParent(entry.path, symlinks))
   if (nested)
     throw workspaceError(`[vitehub] Workspace path crosses a symlink parent: ${nested.path}.`)
-  for (const entry of entries.filter(entry => entry.type === "directory"))
+  for (const entry of entries.filter(entry => entry.type === "directory")) {
+    abortSignal?.throwIfAborted()
     await host.files.mkdir(toHostPath(root, entry.path), { recursive: true })
+    abortSignal?.throwIfAborted()
+  }
   await withWorkspaceProgress(options?.onProgress, {
     data: {
       bytes: entries.reduce((total, entry) => total + (entry.size || 0), 0),
@@ -549,7 +555,9 @@ async function materializeWorkspace(
     id: "workspace.prepare.read-files",
     label: "Reading workspace files",
   }, async () => {
+    abortSignal?.throwIfAborted()
     for (const entry of entries) {
+      abortSignal?.throwIfAborted()
       if (entry.type !== "file") continue
       const target = toHostPath(root, entry.path)
       await ensureHostParent(host, target)
@@ -566,6 +574,7 @@ async function materializeWorkspace(
         await host.files.write(target, contentToBytes(await workspace.readFile(entry.path, { encoding: "binary" })))
         if (entry.metadata?.gitMode === "100755") await makeHostFileExecutable(host, root, target)
       }
+      abortSignal?.throwIfAborted()
     }
   })
   if (revision && await materializer?.currentRevision({ abortSignal: options?.abortSignal }) !== revision.revision) {
@@ -640,10 +649,13 @@ export async function createHostedWorkspaceSession(
   const existingExcludedState = await captureExcludedHostState(host, root, excludedWriteBackPaths)
   let attachedState = options.attach ? await captureHostState(host, root, "host-attach") : undefined
   let materialization: { revision?: string, snapshot: WorkspaceSnapshot }
+  let materializedExcludedState: Awaited<ReturnType<typeof captureExcludedHostState>> | undefined
   try {
     materialization = attachedState
       ? { snapshot: attachedState.snapshot }
       : await materializeWorkspace(workspace, host, root, options)
+    if (!attachedState)
+      materializedExcludedState = await captureExcludedHostState(host, root, excludedWriteBackPaths)
   }
   catch (error) {
     if (attachedState) throw error
@@ -667,7 +679,7 @@ export async function createHostedWorkspaceSession(
     ? existingExcludedState
     : mergeExcludedHostState(
         existingExcludedState,
-        await captureExcludedHostState(host, root, excludedWriteBackPaths),
+        materializedExcludedState!,
         excludedWriteBackPaths,
       )
   const mediaTypes = new Map<string, string>()

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -6,6 +6,7 @@ import { workspaceConflict, workspaceError } from "../core/errors.ts"
 import { contentToBytes, decodeFile, normalizeSafeWorkspacePath, normalizeWorkspacePath, sha256 } from "../core/path.ts"
 import { createSnapshotFromEntries, diffSnapshots } from "../storage/utils.ts"
 import { assertDiffInsideSessionPaths, assertPathInSessionScope, filterSessionDiff, filterSessionEntries, isMissingWorkspacePathError, scopedSearchQuery } from "./scope.ts"
+import { withWorkspaceProgress } from "./progress.ts"
 import { resolveWorkspaceRevisionMaterializer } from "../storage/materialization.ts"
 
 import type { WorkspaceRevisionMaterialization } from "../storage/materialization.ts"
@@ -25,11 +26,9 @@ import type {
   WorkspaceSessionHostFileEntry,
   WorkspaceSessionOptions,
   WorkspaceSnapshot,
-  WorkspacePrepareSessionProgressEvent,
   WorkspaceSessionWriteFileOptions,
 } from "../core/types.ts"
 
-type PrepareProgressReporter = WorkspaceSessionOptions["onProgress"]
 const publicationQueues = new WeakMap<object, Promise<void>>()
 
 async function withWorkspacePublication<T>(key: object, publish: () => Promise<T>): Promise<T> {
@@ -44,38 +43,6 @@ async function withWorkspacePublication<T>(key: object, publish: () => Promise<T
   finally {
     release()
     if (publicationQueues.get(key) === current) publicationQueues.delete(key)
-  }
-}
-
-async function withPrepareProgress<T>(
-  onProgress: PrepareProgressReporter,
-  event: Pick<WorkspacePrepareSessionProgressEvent, "id" | "label"> & { data?: Record<string, unknown> },
-  fn: () => Promise<T>,
-) {
-  const startedAt = Date.now()
-  await onProgress?.({ data: event.data, id: event.id, label: event.label, status: "started" })
-  try {
-    const result = await fn()
-    await onProgress?.({
-      data: event.data,
-      durationMs: Date.now() - startedAt,
-      id: event.id,
-      label: event.label,
-      status: "completed",
-    })
-    return result
-  }
-  catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    await onProgress?.({
-      data: { ...event.data, error: message },
-      durationMs: Date.now() - startedAt,
-      error: message,
-      id: event.id,
-      label: event.label,
-      status: "failed",
-    })
-    throw error
   }
 }
 
@@ -417,6 +384,17 @@ async function extractRevisionArchive(
   await host.files.write(archive, materialization.archive)
   await host.files.mkdir(staging, { recursive: true })
   try {
+    const listed = await host.exec("tar", ["-tzf", archive], { signal })
+    if (listed.code !== 0) {
+      throw workspaceError(`[vitehub] Failed to inspect Workspace revision ${materialization.revision}: ${listed.stderr || "tar failed"}`)
+    }
+    const unsafeMember = listed.stdout.split("\n").filter(Boolean).find((member) => {
+      if (member.startsWith("/") || member.includes("\0")) return true
+      return member.replace(/\/+$/, "").split("/").includes("..")
+    })
+    if (unsafeMember) {
+      throw workspaceError(`[vitehub] Workspace revision archive contains an unsafe path: ${unsafeMember}.`)
+    }
     const extracted = await host.exec("tar", ["-xzf", archive, "-C", staging], { signal })
     if (extracted.code !== 0) {
       throw workspaceError(`[vitehub] Failed to extract Workspace revision ${materialization.revision}: ${extracted.stderr || "tar failed"}`)
@@ -482,7 +460,7 @@ async function materializeWorkspace(workspace: Workspace, host: WorkspaceSession
   const paths = normalizeSessionPaths(options)
   const materializer = resolveWorkspaceRevisionMaterializer(workspace)
   const revision = materializer
-    ? await withPrepareProgress(options?.onProgress, {
+    ? await withWorkspaceProgress(options?.onProgress, {
         data: { paths: paths ?? null },
         id: "workspace.prepare.revision",
         label: "Resolving workspace revision",
@@ -491,12 +469,12 @@ async function materializeWorkspace(workspace: Workspace, host: WorkspaceSession
         paths,
       }))
     : undefined
-  await withPrepareProgress(options?.onProgress, {
+  await withWorkspaceProgress(options?.onProgress, {
     id: "workspace.prepare.reset-sandbox",
     label: "Resetting sandbox workspace",
   }, async () => await resetHostWorkspaceRoot(host, root))
   if (revision?.archive) {
-    await withPrepareProgress(options?.onProgress, {
+    await withWorkspaceProgress(options?.onProgress, {
       data: {
         bytes: revision.archive.byteLength,
         files: revision.files,
@@ -512,7 +490,7 @@ async function materializeWorkspace(workspace: Workspace, host: WorkspaceSession
     await sanitizeHostSymlinks(host, root)
     return { revision: revision.revision, snapshot: await snapshotHost(host, root, "host-open") }
   }
-  const entries = await withPrepareProgress(options?.onProgress, {
+  const entries = await withWorkspaceProgress(options?.onProgress, {
     data: { paths: paths ?? null },
     id: "workspace.prepare.entries",
     label: "Resolving workspace entries",
@@ -523,7 +501,7 @@ async function materializeWorkspace(workspace: Workspace, host: WorkspaceSession
     throw workspaceError(`[vitehub] Workspace path crosses a symlink parent: ${nested.path}.`)
   for (const entry of entries.filter(entry => entry.type === "directory"))
     await host.files.mkdir(toHostPath(root, entry.path), { recursive: true })
-  await withPrepareProgress(options?.onProgress, {
+  await withWorkspaceProgress(options?.onProgress, {
     data: {
       bytes: entries.reduce((total, entry) => total + (entry.size || 0), 0),
       files: entries.filter(entry => entry.type === "file").length,

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -811,6 +811,8 @@ export async function createHostedWorkspaceSession(
           return { ...entry, after: { ...entry.after, metadata: undefined } }
         }),
       }
+      const sanitizedPaths = publicationDiff.entries.filter((entry, index) =>
+        entry.after?.metadata?.gitMode !== diff.entries[index]?.after?.metadata?.gitMode)
       const revisionMaterializer = resolveWorkspaceRevisionMaterializer(workspace)
       await withWorkspacePublication(revisionMaterializer || workspace, options.abortSignal, async () => {
         if (baseRevision && await revisionMaterializer?.currentRevision({ abortSignal: options.abortSignal }) !== baseRevision) {
@@ -829,6 +831,13 @@ export async function createHostedWorkspaceSession(
               .map(entry => ({ path: entry.path, ...entry.after! }))),
           commitOptions?.message || "host-commit",
         )
+        for (const entry of sanitizedPaths) {
+          const content = capturedState.contents.get(entry.path)
+          if (content === undefined) continue
+          const target = toHostPath(root, entry.path)
+          await removeHostPath(host, root, target, false)
+          await host.files.write(target, contentToBytes(content))
+        }
         try {
           await commitHostChanges(workspace, publicationDiff, capturedState.contents, mediaTypes, commitOptions?.message)
         }

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -209,6 +209,7 @@ async function listHostEntries(
   path = "",
   recursive = false,
   include?: (entry: WorkspaceEntry) => boolean,
+  includeGit = false,
 ): Promise<WorkspaceEntry[]> {
   await assertHostWorkspaceRoot(host, root)
   const entries = (await host.files.list(toHostPath(root, path), { recursive }))
@@ -222,7 +223,7 @@ async function listHostEntries(
       : workspaceEntry
   })
   return resolved
-    .filter(entry => entry.path && entry.path !== ".git" && !entry.path.startsWith(".git/"))
+    .filter(entry => entry.path && (includeGit || (entry.path !== ".git" && !entry.path.startsWith(".git/"))))
     .sort((left, right) => left.path.localeCompare(right.path))
 }
 
@@ -272,7 +273,7 @@ async function captureExcludedHostState(host: WorkspaceSessionHost, root: string
   if (await isHostPath(host, root, "-L"))
     throw workspaceError(`[vitehub] Workspace host root must be a directory: ${root}.`)
   if (!await host.files.exists(root)) return await captureHostEntriesState(host, root, [], "host-excluded")
-  const entries = await listHostEntries(host, root, "", true, entry => isInsideExcludedWriteBackPath(entry.path, excluded))
+  const entries = await listHostEntries(host, root, "", true, entry => isInsideExcludedWriteBackPath(entry.path, excluded), true)
   return await captureHostEntriesState(host, root, entries, "host-excluded")
 }
 

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -496,6 +496,7 @@ async function materializeWorkspace(
   root: string,
   options?: WorkspaceSessionOptions,
   useRevisionMaterializer = true,
+  onHostMutation?: () => void,
 ) {
   const abortSignal = options?.abortSignal
   abortSignal?.throwIfAborted()
@@ -514,7 +515,10 @@ async function materializeWorkspace(
   await withWorkspaceProgress(options?.onProgress, {
     id: "workspace.prepare.reset-sandbox",
     label: "Resetting sandbox workspace",
-  }, async () => await resetHostWorkspaceRoot(host, root))
+  }, async () => {
+    onHostMutation?.()
+    await resetHostWorkspaceRoot(host, root)
+  })
   abortSignal?.throwIfAborted()
   if (revision?.archive) {
     await withWorkspaceProgress(options?.onProgress, {
@@ -655,15 +659,16 @@ export async function createHostedWorkspaceSession(
   let attachedState = options.attach ? await captureHostState(host, root, "host-attach") : undefined
   let materialization: { revision?: string, snapshot: WorkspaceSnapshot }
   let materializedExcludedState: Awaited<ReturnType<typeof captureExcludedHostState>> | undefined
+  let setupMutatedHost = false
   try {
     materialization = attachedState
       ? { snapshot: attachedState.snapshot }
-      : await materializeWorkspace(workspace, host, root, options)
+      : await materializeWorkspace(workspace, host, root, options, true, () => { setupMutatedHost = true })
     if (!attachedState)
       materializedExcludedState = await captureExcludedHostState(host, root, excludedWriteBackPaths)
   }
   catch (error) {
-    if (attachedState) throw error
+    if (attachedState || !setupMutatedHost) throw error
     try {
       host.detachAbortSignal?.()
       await materializeWorkspace(workspace, host, root, {
@@ -793,6 +798,21 @@ export async function createHostedWorkspaceSession(
         if (baseRevision && await revisionMaterializer?.currentRevision({ abortSignal: options.abortSignal }) !== baseRevision) {
           throw workspaceConflict(`[vitehub] Workspace revision changed after this Session materialized: ${baseRevision}.`)
         }
+        const nextAttachedState = options.attach
+          ? await captureHostState(host, root, commitOptions?.message || "host-commit")
+          : undefined
+        const nextBaseline = nextAttachedState?.snapshot || await createSnapshotFromEntries(
+          Object.entries(baseline.entries)
+            .filter(([path]) => !diff.entries.some(entry => entry.path === path && !entry.after))
+            .map(([path, entry]) => {
+              const changed = diff.entries.find(item => item.path === path)?.after
+              return { path, ...(changed || entry) }
+            })
+            .concat(diff.entries
+              .filter(entry => entry.after && !baseline.entries[entry.path])
+              .map(entry => ({ path: entry.path, ...entry.after! }))),
+          commitOptions?.message || "host-commit",
+        )
         try {
           await commitHostChanges(host, root, workspace, diff, mediaTypes, commitOptions?.message)
         }
@@ -812,11 +832,8 @@ export async function createHostedWorkspaceSession(
             refresh: false,
           })
         }
-        if (options.attach) {
-          attachedState = await captureHostState(host, root, commitOptions?.message || "host-commit")
-          baseline = attachedState.snapshot
-        }
-        else baseline = await snapshotHost(host, root, commitOptions?.message || "host-commit")
+        if (nextAttachedState) attachedState = nextAttachedState
+        baseline = nextBaseline
       })
     },
     async exec(command, args = [], execOptions = {}) {

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -813,12 +813,22 @@ export async function createHostedWorkspaceSession(
       }
       const sanitizedPaths = publicationDiff.entries.filter((entry, index) =>
         entry.after?.metadata?.gitMode !== diff.entries[index]?.after?.metadata?.gitMode)
+      const sanitizedPathNames = new Set(sanitizedPaths.map(entry => entry.path))
+      const sanitizedCapturedSnapshot = sanitizedPaths.length
+        ? await createSnapshotFromEntries(Object.entries(capturedState.snapshot.entries).map(([path, entry]) => ({
+            path,
+            ...entry,
+            ...(sanitizedPathNames.has(path) ? { metadata: undefined } : {}),
+          })), commitOptions?.message || "host-commit")
+        : capturedState.snapshot
       const revisionMaterializer = resolveWorkspaceRevisionMaterializer(workspace)
       await withWorkspacePublication(revisionMaterializer || workspace, options.abortSignal, async () => {
         if (baseRevision && await revisionMaterializer?.currentRevision({ abortSignal: options.abortSignal }) !== baseRevision) {
           throw workspaceConflict(`[vitehub] Workspace revision changed after this Session materialized: ${baseRevision}.`)
         }
-        const nextAttachedState = options.attach ? capturedState : undefined
+        const nextAttachedState = options.attach
+          ? { ...capturedState, snapshot: sanitizedCapturedSnapshot }
+          : undefined
         const nextBaseline = nextAttachedState?.snapshot || await createSnapshotFromEntries(
           Object.entries(baseline.entries)
             .filter(([path]) => !publicationDiff.entries.some(entry => entry.path === path && !entry.after))

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -249,7 +249,7 @@ async function captureHostState(host: WorkspaceSessionHost, root: string, name?:
 
 async function captureHostEntriesState(host: WorkspaceSessionHost, root: string, entries: WorkspaceEntry[], name?: string) {
   const contents = new Map<string, Uint8Array | string>()
-  const files = await Promise.all(entries.map(async (entry) => {
+  const files = await mapWithConcurrency(entries, hostInspectionConcurrency, async (entry) => {
     if (entry.type !== "file") return entry
     const content = isGitSymlinkEntry(entry)
       ? await readHostSymlinkTarget(host, root, toHostPath(root, entry.path))
@@ -261,7 +261,7 @@ async function captureHostEntriesState(host: WorkspaceSessionHost, root: string,
       digest: await sha256(content),
       size: contentToBytes(content).byteLength,
     }
-  }))
+  })
   return { contents, snapshot: await createSnapshotFromEntries(files, name) }
 }
 
@@ -526,11 +526,14 @@ async function materializeWorkspace(
       id: "workspace.prepare.extract-archive",
       label: "Extracting workspace revision",
     }, async () => await extractRevisionArchive(host, root, { ...revision, archive: revision.archive! }, options?.abortSignal))
+    abortSignal?.throwIfAborted()
     await Promise.all([
       removeHostPath(host, root, toHostPath(root, ".git"), true),
       removeHostPath(host, root, toHostPath(root, ".vitehub"), true),
     ])
+    abortSignal?.throwIfAborted()
     await sanitizeHostSymlinks(host, root)
+    abortSignal?.throwIfAborted()
     return { revision: revision.revision, snapshot: await snapshotHost(host, root, "host-open") }
   }
   const entries = await withWorkspaceProgress(options?.onProgress, {

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -819,8 +819,23 @@ export async function createHostedWorkspaceSession(
       let diff: WorkspaceDiff | undefined
       if (options.attach && attachedState) {
         const attachedDiff = filterSessionDiff(diffSnapshots(baseline, await snapshotHost(host, root)), sessionPaths)
-        await restoreAttachedHost(host, root, attachedDiff, attachedState)
-        await restoreExcludedHostState(host, root, excludedWriteBackPaths, excludedState)
+        let attachedRestoreError: unknown
+        try {
+          await restoreAttachedHost(host, root, attachedDiff, attachedState)
+        }
+        catch (error) {
+          attachedRestoreError = error
+        }
+        try {
+          await restoreExcludedHostState(host, root, excludedWriteBackPaths, excludedState)
+        }
+        catch (excludedError) {
+          if (attachedRestoreError) {
+            throw new AggregateError([attachedRestoreError, excludedError], "[vitehub] Attached Workspace Session restoration and excluded-state restoration failed.")
+          }
+          throw excludedError
+        }
+        if (attachedRestoreError) throw attachedRestoreError
       }
       else {
         diff = await currentDiff()

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -603,7 +603,7 @@ export async function createHostedWorkspaceSession(
     : await materializeWorkspace(workspace, host, root, options)
   let baseline = materialization.snapshot
   let baseRevision = materialization.revision
-  const excludedState = options.attach ? undefined : await captureExcludedHostState(host, root, excludedWriteBackPaths)
+  const excludedState = await captureExcludedHostState(host, root, excludedWriteBackPaths)
   const mediaTypes = new Map<string, string>()
 
   function assertOpen() {
@@ -754,8 +754,9 @@ export async function createHostedWorkspaceSession(
       if (options.attach && attachedState) {
         const attachedDiff = filterSessionDiff(diffSnapshots(baseline, await snapshotHost(host, root)), sessionPaths)
         await restoreAttachedHost(host, root, attachedDiff, attachedState)
+        await restoreExcludedHostState(host, root, excludedWriteBackPaths, excludedState)
       }
-      else if (excludedState) {
+      else {
         await restoreExcludedHostState(host, root, excludedWriteBackPaths, excludedState)
         diff = await currentDiff()
       }

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -44,12 +44,28 @@ async function mapWithConcurrency<T, U>(values: readonly T[], concurrency: numbe
   return results
 }
 
-async function withWorkspacePublication<T>(key: object, publish: () => Promise<T>): Promise<T> {
+async function waitForOperation<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
+  signal?.throwIfAborted()
+  if (!signal) return await operation
+  return await new Promise<T>((resolve, reject) => {
+    const abort = () => reject(signal.reason)
+    signal.addEventListener("abort", abort, { once: true })
+    void operation.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort))
+  })
+}
+
+async function withWorkspacePublication<T>(key: object, signal: AbortSignal | undefined, publish: () => Promise<T>): Promise<T> {
   const previous = publicationQueues.get(key) || Promise.resolve()
   let release!: () => void
   const current = new Promise<void>((resolve) => { release = resolve })
   publicationQueues.set(key, current)
-  await previous
+  try {
+    await waitForOperation(previous, signal)
+  }
+  catch (error) {
+    void previous.finally(release)
+    throw error
+  }
   try {
     return await publish()
   }
@@ -593,10 +609,9 @@ async function materializeWorkspace(
 }
 
 async function commitHostChanges(
-  host: WorkspaceSessionHost,
-  root: string,
   workspace: Workspace,
   diff: WorkspaceDiff,
+  contents: ReadonlyMap<string, Uint8Array | string>,
   mediaTypes: Map<string, string>,
   message?: string,
 ) {
@@ -615,19 +630,11 @@ async function commitHostChanges(
     const before = entry.before?.type === "file"
       ? await workspace.stat(entry.path).catch(() => undefined)
       : undefined
-    const target = toHostPath(root, entry.path)
-    const symlinkTarget = entry.after.metadata?.gitMode === "120000"
-      ? await readHostSymlinkTarget(host, root, target)
-      : undefined
-    const file = symlinkTarget === undefined
-      ? await readHostFile(host, root, target)
-      : isSafeHostSymlink(root, entry.path, symlinkTarget)
-          ? { content: symlinkTarget, metadata: entry.after.metadata, path: entry.path }
-          : { content: symlinkTarget, path: entry.path }
-    if (file) {
-      await workspace.writeFile(entry.path, file.content, {
-        mediaType: file.mediaType || mediaTypes.get(entry.path) || before?.mediaType,
-        metadata: symlinkTarget === undefined ? entry.after.metadata : file.metadata,
+    const content = contents.get(entry.path)
+    if (content !== undefined) {
+      await workspace.writeFile(entry.path, content, {
+        mediaType: mediaTypes.get(entry.path) || before?.mediaType,
+        metadata: entry.after.metadata,
       })
     }
   }
@@ -790,17 +797,16 @@ export async function createHostedWorkspaceSession(
       return filterSessionDiff(await currentDiff(), sessionPaths)
     },
     async commit(commitOptions) {
-      const diff = await currentDiff()
+      const capturedState = await captureHostState(host, root, commitOptions?.message || "host-commit")
+      const diff = filterWriteBackDiff(diffSnapshots(baseline, capturedState.snapshot), excludedWriteBackPaths)
       if (!diff.entries.length) return
       assertDiffInsideSessionPaths(diff, sessionPaths)
       const revisionMaterializer = resolveWorkspaceRevisionMaterializer(workspace)
-      await withWorkspacePublication(revisionMaterializer || workspace, async () => {
+      await withWorkspacePublication(revisionMaterializer || workspace, options.abortSignal, async () => {
         if (baseRevision && await revisionMaterializer?.currentRevision({ abortSignal: options.abortSignal }) !== baseRevision) {
           throw workspaceConflict(`[vitehub] Workspace revision changed after this Session materialized: ${baseRevision}.`)
         }
-        const nextAttachedState = options.attach
-          ? await captureHostState(host, root, commitOptions?.message || "host-commit")
-          : undefined
+        const nextAttachedState = options.attach ? capturedState : undefined
         const nextBaseline = nextAttachedState?.snapshot || await createSnapshotFromEntries(
           Object.entries(baseline.entries)
             .filter(([path]) => !diff.entries.some(entry => entry.path === path && !entry.after))
@@ -814,7 +820,7 @@ export async function createHostedWorkspaceSession(
           commitOptions?.message || "host-commit",
         )
         try {
-          await commitHostChanges(host, root, workspace, diff, mediaTypes, commitOptions?.message)
+          await commitHostChanges(workspace, diff, capturedState.contents, mediaTypes, commitOptions?.message)
         }
         catch (error) {
           if (baseRevision) {
@@ -851,6 +857,8 @@ export async function createHostedWorkspaceSession(
       host.detachAbortSignal?.()
       await ensureHostWorkspaceRoot(host, root)
       let diff: WorkspaceDiff | undefined
+      let restoreError: unknown
+      let revisionChanged = false
       if (options.attach && attachedState) {
         const attachedDiff = filterSessionDiff(diffSnapshots(baseline, await snapshotHost(host, root)), sessionPaths)
         let attachedRestoreError: unknown
@@ -872,11 +880,18 @@ export async function createHostedWorkspaceSession(
         if (attachedRestoreError) throw attachedRestoreError
       }
       else {
-        diff = await currentDiff()
+        try {
+          diff = await currentDiff()
+          const revisionMaterializer = resolveWorkspaceRevisionMaterializer(workspace)
+          revisionChanged = Boolean(baseRevision
+            && await revisionMaterializer?.currentRevision() !== baseRevision)
+        }
+        catch (error) {
+          restoreError = error
+        }
       }
-      let restoreError: unknown
       try {
-        if (diff?.entries.length) {
+        if (!restoreError && (diff?.entries.length || revisionChanged)) {
           await materializeWorkspace(workspace, host, root, {
             ...options,
             abortSignal: undefined,

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -263,6 +263,26 @@ async function captureExcludedHostState(host: WorkspaceSessionHost, root: string
   return await captureHostEntriesState(host, root, entries, "host-excluded")
 }
 
+function mergeExcludedHostState(
+  before: Awaited<ReturnType<typeof captureExcludedHostState>>,
+  materialized: Awaited<ReturnType<typeof captureExcludedHostState>>,
+  excluded: readonly string[],
+) {
+  const occupiedRoots = excluded.filter(root => Object.keys(before.snapshot.entries)
+    .some(path => path === root || path.startsWith(`${root}/`)))
+  const entries = Object.fromEntries(Object.entries(materialized.snapshot.entries)
+    .filter(([path]) => !occupiedRoots.some(root => path === root || path.startsWith(`${root}/`))))
+  const contents = new Map(materialized.contents)
+  for (const root of occupiedRoots) {
+    for (const path of [...contents.keys()]) {
+      if (path === root || path.startsWith(`${root}/`)) contents.delete(path)
+    }
+  }
+  for (const [path, entry] of Object.entries(before.snapshot.entries)) entries[path] = entry
+  for (const [path, content] of before.contents) contents.set(path, content)
+  return { contents, snapshot: { ...materialized.snapshot, entries } }
+}
+
 async function restoreExcludedHostState(
   host: WorkspaceSessionHost,
   root: string,
@@ -597,13 +617,20 @@ export async function createHostedWorkspaceSession(
     ...(options.writeBack?.exclude || []).map(path => normalizeSafeWorkspacePath(path, { allowReserved: true })),
   ]
   let closed = false
+  const existingExcludedState = await captureExcludedHostState(host, root, excludedWriteBackPaths)
   let attachedState = options.attach ? await captureHostState(host, root, "host-attach") : undefined
   const materialization: { revision?: string, snapshot: WorkspaceSnapshot } = attachedState
     ? { snapshot: attachedState.snapshot }
     : await materializeWorkspace(workspace, host, root, options)
   let baseline = materialization.snapshot
   let baseRevision = materialization.revision
-  const excludedState = await captureExcludedHostState(host, root, excludedWriteBackPaths)
+  const excludedState = attachedState
+    ? existingExcludedState
+    : mergeExcludedHostState(
+        existingExcludedState,
+        await captureExcludedHostState(host, root, excludedWriteBackPaths),
+        excludedWriteBackPaths,
+      )
   const mediaTypes = new Map<string, string>()
 
   function assertOpen() {
@@ -726,7 +753,6 @@ export async function createHostedWorkspaceSession(
         }
         if (baseRevision) {
           baseRevision = await revisionMaterializer!.currentRevision({
-            abortSignal: options.abortSignal,
             refresh: false,
           })
         }
@@ -757,7 +783,6 @@ export async function createHostedWorkspaceSession(
         await restoreExcludedHostState(host, root, excludedWriteBackPaths, excludedState)
       }
       else {
-        await restoreExcludedHostState(host, root, excludedWriteBackPaths, excludedState)
         diff = await currentDiff()
       }
       if (diff?.entries.length) {
@@ -767,6 +792,7 @@ export async function createHostedWorkspaceSession(
           onProgress: undefined,
         })
       }
+      if (!options.attach) await restoreExcludedHostState(host, root, excludedWriteBackPaths, excludedState)
       closed = true
     },
   }

--- a/packages/workspace/src/session/progress.ts
+++ b/packages/workspace/src/session/progress.ts
@@ -1,0 +1,33 @@
+import type { WorkspacePrepareSessionProgressEvent } from "../core/types.ts"
+
+export async function withWorkspaceProgress<T>(
+  onProgress: ((event: WorkspacePrepareSessionProgressEvent) => void | Promise<void>) | undefined,
+  event: Pick<WorkspacePrepareSessionProgressEvent, "id" | "label"> & { data?: Record<string, unknown> },
+  fn: () => Promise<T>,
+) {
+  const startedAt = Date.now()
+  await onProgress?.({ data: event.data, id: event.id, label: event.label, status: "started" })
+  try {
+    const result = await fn()
+    await onProgress?.({
+      data: event.data,
+      durationMs: Date.now() - startedAt,
+      id: event.id,
+      label: event.label,
+      status: "completed",
+    })
+    return result
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    await onProgress?.({
+      data: { ...event.data, error: message },
+      durationMs: Date.now() - startedAt,
+      error: message,
+      id: event.id,
+      label: event.label,
+      status: "failed",
+    })
+    throw error
+  }
+}

--- a/packages/workspace/src/storage/materialization.ts
+++ b/packages/workspace/src/storage/materialization.ts
@@ -1,0 +1,29 @@
+import type { Workspace } from "../core/types.ts"
+
+export const workspaceRevisionMaterializer: unique symbol = Symbol.for("vitehub.workspace.revisionMaterializer")
+
+export interface WorkspaceRevisionMaterialization {
+  archive?: Uint8Array
+  files: number
+  paths?: readonly string[]
+  revision: string
+  root: string
+}
+
+export interface WorkspaceRevisionMaterializer {
+  currentRevision(options?: { abortSignal?: AbortSignal, refresh?: boolean }): Promise<string>
+  materializeRevision(options?: { abortSignal?: AbortSignal, paths?: readonly string[] }): Promise<WorkspaceRevisionMaterialization>
+}
+
+export type WorkspaceRevisionMaterializerCarrier = {
+  [workspaceRevisionMaterializer]?: WorkspaceRevisionMaterializer
+}
+
+export function forwardWorkspaceRevisionMaterializer(source: unknown, target: unknown): void {
+  const materializer = (source as WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer]
+  if (materializer) (target as WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = materializer
+}
+
+export function resolveWorkspaceRevisionMaterializer(workspace: Workspace): WorkspaceRevisionMaterializer | undefined {
+  return (workspace as Workspace & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer]
+}

--- a/packages/workspace/test/cli.test.ts
+++ b/packages/workspace/test/cli.test.ts
@@ -296,7 +296,7 @@ describe("workspace CLI", () => {
     expect(materializeSources).toHaveBeenCalledWith(expect.objectContaining({
       path: "docs/README.md",
     }))
-    expect(workspace.startSession).toHaveBeenCalledWith({ paths: ["docs/README.md"] })
+    expect(workspace.startSession).toHaveBeenCalledWith({ abortSignal: undefined, paths: ["docs/README.md"] })
     expect(progress).toEqual([
       expect.objectContaining({ id: "workspace.dev.materialize", status: "started" }),
       expect.objectContaining({ data: expect.objectContaining({ source: "docs" }), id: "workspace.dev.materialize.docs", status: "updating" }),
@@ -304,6 +304,27 @@ describe("workspace CLI", () => {
       expect.objectContaining({ id: "workspace.dev.start-session", status: "started" }),
       expect.objectContaining({ id: "workspace.dev.start-session", status: "completed" }),
     ])
+  })
+
+  it("closes an acquired Workspace Dev Session when completed progress fails", async () => {
+    const close = vi.fn(async () => {})
+    const exec = vi.fn()
+    const workspace = {
+      startSession: vi.fn(async () => ({ close, diff: vi.fn(), exec })),
+    }
+
+    await expect(runWorkspaceDevCommand({
+      command: "echo ok",
+      onProgress(event) {
+        if (event.id === "workspace.dev.start-session" && event.status === "completed") {
+          throw new Error("progress unavailable")
+        }
+      },
+      workspace: workspace as never,
+    })).rejects.toThrow("progress unavailable")
+
+    expect(exec).not.toHaveBeenCalled()
+    expect(close).toHaveBeenCalledOnce()
   })
 
   it("uses the portable Workspace shell for string Workspace Dev commands", async () => {

--- a/packages/workspace/test/github-publisher.test.ts
+++ b/packages/workspace/test/github-publisher.test.ts
@@ -194,9 +194,10 @@ describe("GitHub workspace publisher", () => {
       code: "WORKSPACE_FAILED",
       message: "[vitehub] GitHub workspace request failed.",
     })
-    expect(requests.map(request => request.path)).toEqual([
-      "/repos/onmax/repo/git/ref/heads/mirror",
-    ])
+    expect(requests.map(request => request.path)).toEqual(Array.from(
+      { length: 3 },
+      () => "/repos/onmax/repo/git/ref/heads/mirror",
+    ))
   })
 
   it("publishes delete-only snapshots after the last workspace file is removed", async () => {

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -206,6 +206,27 @@ describe("GitHub workspace store", () => {
     expect(requests.filter(request => request.path.startsWith("/onmax/repo/base-sha/"))).toHaveLength(0);
   });
 
+  it("coalesces concurrent first materializations of one revision archive", async () => {
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      { provider: "github", repository: "onmax/repo", token: "token" },
+      "docs",
+    );
+    const materializer = (store as typeof store & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer]!;
+
+    const results = await Promise.all([
+      materializer.materializeRevision(),
+      materializer.materializeRevision(),
+      materializer.materializeRevision(),
+    ]);
+
+    expect(results).toHaveLength(3);
+    expect(results).toEqual(expect.arrayContaining([
+      expect.objectContaining({ archive: archiveBytes, revision: "base-sha" }),
+    ]));
+    expect(requests.filter(request => request.path === "/onmax/repo/tar.gz/base-sha")).toHaveLength(1);
+  });
+
   it("retries transient pinned archive reads within a bounded attempt count", async () => {
     archiveFailures = 2;
     const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -227,6 +227,22 @@ describe("GitHub workspace store", () => {
     expect(requests.filter(request => request.path === "/onmax/repo/tar.gz/base-sha")).toHaveLength(1);
   });
 
+  it("lets callers cancel revision resolution while the GitHub request continues", async () => {
+    const abort = new AbortController();
+    vi.mocked(fetch).mockImplementationOnce(async () => await new Promise<Response>(() => {}));
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      { provider: "github", repository: "onmax/repo", token: "token" },
+      "docs",
+    );
+    const materializer = (store as typeof store & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer]!;
+
+    const resolution = materializer.materializeRevision({ abortSignal: abort.signal });
+    abort.abort();
+
+    await expect(resolution).rejects.toMatchObject({ name: "AbortError" });
+  });
+
   it("retries transient pinned archive reads within a bounded attempt count", async () => {
     archiveFailures = 2;
     const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -1201,6 +1201,42 @@ describe("GitHub workspace store", () => {
     );
   });
 
+  it("discards selected staged writes when the provider revision is unchanged", async () => {
+    seedRemote(".vitehub/workspaces/docs/page.md", "# Authoritative\n");
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        provider: "github",
+        repository: "onmax/repo",
+        root: ".vitehub/workspaces/<workspace>",
+        token: "token",
+      },
+      "docs",
+    );
+
+    await store.writeFile("page.md", { path: "page.md", content: "# Failed invocation\n" });
+    await store.writeFile("draft.md", { path: "draft.md", content: "unrelated draft\n" });
+    await store.rebase?.({ takeRemote: ["page.md"] });
+
+    await expect(store.readFile("page.md")).resolves.toMatchObject({
+      content: textBytes("# Authoritative\n"),
+    });
+    await expect(store.readFile("draft.md")).resolves.toMatchObject({
+      content: textBytes("unrelated draft\n"),
+    });
+    await store.snapshot({ name: "retry" });
+    expect(remoteTree).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        path: ".vitehub/workspaces/docs/page.md",
+        sha: textSha("# Authoritative\n"),
+      }),
+      expect.objectContaining({
+        path: ".vitehub/workspaces/docs/draft.md",
+        sha: textSha("unrelated draft\n"),
+      }),
+    ]));
+  });
+
   it("requires repository and token configuration", async () => {
     const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
 

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -1,6 +1,10 @@
 import { createHash } from "node:crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { clearActiveCloudflareEnv, setActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env";
+import { resolveGitHubWorkspaceRoot } from "../src/providers/github/shared.ts";
+import { workspaceRevisionMaterializer } from "../src/storage/materialization.ts";
+
+import type { WorkspaceRevisionMaterializerCarrier } from "../src/storage/materialization.ts";
 
 const requests: Array<{ body?: unknown; headers: Headers; method: string; path: string }> = [];
 let refSha = "base-sha";
@@ -10,6 +14,8 @@ let commitIndex = 0;
 let treeIndex = 0;
 let mirrorRefSha: string | undefined;
 let mirrorRefStatus = 404;
+let archiveFailures = 0;
+let archiveBytes = textBytes("archive");
 const blobs = new Map<string, Uint8Array>();
 const treesByRef = new Map<string, typeof remoteTree>();
 
@@ -48,6 +54,8 @@ beforeEach(() => {
   treeIndex = 0;
   mirrorRefSha = undefined;
   mirrorRefStatus = 404;
+  archiveFailures = 0;
+  archiveBytes = textBytes("archive");
   blobs.clear();
   treesByRef.clear();
   vi.stubEnv("WORKSPACE_GITHUB_TOKEN", "");
@@ -71,6 +79,13 @@ beforeEach(() => {
             })
           : undefined;
       requests.push({ body, headers: new Headers(init.headers), method, path: url.pathname });
+
+      if (url.hostname === "codeload.github.com") {
+        if (archiveFailures-- > 0) {
+          return new Response("retry", { headers: { "retry-after": "0" }, status: 503 });
+        }
+        return new Response(archiveBytes);
+      }
 
       if (url.hostname === "raw.githubusercontent.com") {
         const [, , , ref, ...path] = decodeURIComponent(url.pathname).split("/");
@@ -148,6 +163,11 @@ beforeEach(() => {
   );
 });
 
+it("rejects GitHub Workspace roots that escape the repository", () => {
+  expect(() => resolveGitHubWorkspaceRoot("../../outside", "docs")).toThrow("escapes the workspace root");
+  expect(() => resolveGitHubWorkspaceRoot("workspaces/<workspace>/../outside", "docs")).toThrow("escapes the workspace root");
+});
+
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
@@ -155,6 +175,95 @@ afterEach(() => {
 });
 
 describe("GitHub workspace store", () => {
+  it("materializes a pinned full revision with one archive request and reuses it while unchanged", async () => {
+    for (let index = 0; index < 856; index++) {
+      seedRemote(`.vitehub/workspaces/docs/files/${index}.txt`, `${index}\n`);
+    }
+    seedRemote(".vitehub/workspaces/docs/CLAUDE.md", "files/0.txt", "120000");
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      { provider: "github", repository: "onmax/repo", token: "token" },
+      "docs",
+    );
+    const materializer = (store as typeof store & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer]!;
+
+    await expect(materializer.materializeRevision()).resolves.toMatchObject({
+      archive: archiveBytes,
+      files: 857,
+      revision: "base-sha",
+      root: ".vitehub/workspaces/docs",
+    });
+    await materializer.materializeRevision();
+    await expect(materializer.materializeRevision({ paths: ["files/0.txt"] })).resolves.toMatchObject({
+      files: 1,
+      paths: ["files/0.txt"],
+      revision: "base-sha",
+    });
+    await expect(materializer.materializeRevision({ paths: ["files/0.txt"] })).resolves.not.toHaveProperty("archive");
+    await expect(store.diff()).resolves.toMatchObject({ entries: [] });
+
+    expect(requests.filter(request => request.path === "/onmax/repo/tar.gz/base-sha")).toHaveLength(1);
+    expect(requests.filter(request => request.path.startsWith("/onmax/repo/base-sha/"))).toHaveLength(0);
+  });
+
+  it("retries transient pinned archive reads within a bounded attempt count", async () => {
+    archiveFailures = 2;
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      { provider: "github", repository: "onmax/repo", token: "token" },
+      "docs",
+    );
+
+    await expect((store as typeof store & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer]!.materializeRevision()).resolves.toMatchObject({
+      revision: "base-sha",
+    });
+    expect(requests.filter(request => request.path === "/onmax/repo/tar.gz/base-sha")).toHaveLength(3);
+  });
+
+  it("falls back to the current Store state when it has staged writes", async () => {
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      { provider: "github", repository: "onmax/repo", token: "token" },
+      "docs",
+    );
+    await store.writeFile("staged.txt", { content: "staged", path: "staged.txt" });
+
+    await expect((store as typeof store & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer]!.materializeRevision())
+      .resolves.toMatchObject({ files: 0, revision: "base-sha" });
+    await expect(store.readFile("staged.txt")).resolves.toMatchObject({ content: textBytes("staged") });
+    expect(requests.filter(request => request.path.includes("/tar.gz/"))).toHaveLength(0);
+  });
+
+  it("does not retry GitHub writes", async () => {
+    const fetchMock = vi.mocked(fetch);
+    const calls = fetchMock.mock.calls.length;
+    fetchMock.mockResolvedValueOnce(new Response("retry", { status: 503 }));
+    const { requestGitHub } = await import("../src/providers/github/shared.ts");
+
+    await expect(requestGitHub("https://api.github.com/write", { method: "POST" }))
+      .resolves.toMatchObject({ status: 503 });
+    expect(fetchMock.mock.calls).toHaveLength(calls + 1);
+  });
+
+  it("retains immutable blob bytes when a branch moves without changing the blob", async () => {
+    seedRemote(".vitehub/workspaces/docs/README.md", "same\n");
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      { provider: "github", repository: "onmax/repo", token: "token" },
+      "docs",
+    );
+
+    await store.readFile("README.md");
+    refSha = "next-sha";
+    remoteTreeSha = "next-tree";
+    requests.length = 0;
+    await store.list();
+    requests.length = 0;
+    await store.readFile("README.md");
+
+    expect(requests).toEqual([]);
+  });
+
   it.each([
     ["Workspace", {
       WORKSPACE_GITHUB_BRANCH: "release",

--- a/packages/workspace/test/github-store.test.ts
+++ b/packages/workspace/test/github-store.test.ts
@@ -1253,6 +1253,49 @@ describe("GitHub workspace store", () => {
     ]));
   });
 
+  it("discards selected staged writes after an unrelated remote change", async () => {
+    seedRemote(".vitehub/workspaces/docs/page.md", "# Authoritative\n");
+    const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
+    const store = createGitHubWorkspaceStore(
+      {
+        provider: "github",
+        repository: "onmax/repo",
+        root: ".vitehub/workspaces/<workspace>",
+        token: "token",
+      },
+      "docs",
+    );
+
+    await store.writeFile("page.md", { path: "page.md", content: "# Failed invocation\n" });
+    await store.writeFile("draft.md", { path: "draft.md", content: "unrelated draft\n" });
+    refSha = "remote-sha";
+    remoteTreeSha = "remote-tree";
+    seedRemote(".vitehub/workspaces/docs/remote.md", "remote addition\n");
+    await store.rebase?.({ takeRemote: ["page.md"] });
+
+    await expect(store.readFile("page.md")).resolves.toMatchObject({
+      content: textBytes("# Authoritative\n"),
+    });
+    await expect(store.readFile("draft.md")).resolves.toMatchObject({
+      content: textBytes("unrelated draft\n"),
+    });
+    await store.snapshot({ name: "retry" });
+    expect(remoteTree).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        path: ".vitehub/workspaces/docs/page.md",
+        sha: textSha("# Authoritative\n"),
+      }),
+      expect.objectContaining({
+        path: ".vitehub/workspaces/docs/draft.md",
+        sha: textSha("unrelated draft\n"),
+      }),
+      expect.objectContaining({
+        path: ".vitehub/workspaces/docs/remote.md",
+        sha: textSha("remote addition\n"),
+      }),
+    ]));
+  });
+
   it("requires repository and token configuration", async () => {
     const { createGitHubWorkspaceStore } = await import("../src/providers/github/store.ts");
 

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -181,6 +181,38 @@ describe("Harness Workspace Session", () => {
     }
   })
 
+  it("restores a canceled acquisition after the sandbox reset", async () => {
+    const docs = workspace()
+    await docs.writeFile("README.md", "authoritative")
+    await docs.snapshot({ name: "baseline" })
+    const sandbox = localSandbox()
+    const root = await sandbox.root
+    const target = join(root, "workspace")
+    const controller = new AbortController()
+    await mkdir(join(target, ".agent-runs"), { recursive: true })
+    await writeFile(join(target, ".agent-runs", "trace.json"), "before")
+
+    try {
+      await expect(prepareHarnessWorkspaceSession(facade(docs) as never, {
+        abortSignal: controller.signal,
+        onProgress(event) {
+          if (event.id === "workspace.prepare.reset-sandbox" && event.status === "completed") {
+            controller.abort(new Error("invocation canceled"))
+            throw new Error("invocation canceled")
+          }
+        },
+        session: sandbox.session,
+        sessionWorkDir: target,
+      })).rejects.toThrow("invocation canceled")
+
+      await expect(readFile(join(target, "README.md"), "utf8")).resolves.toBe("authoritative")
+      await expect(readFile(join(target, ".agent-runs", "trace.json"), "utf8")).resolves.toBe("before")
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("closes and restores a Session when Git baseline initialization fails", async () => {
     const docs = workspace()
     await docs.writeFile("README.md", "authoritative")

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -206,6 +206,31 @@ describe("Harness Workspace Session", () => {
     }
   })
 
+  it("closes an acquired Session when completed progress reporting fails", async () => {
+    const docs = workspace()
+    await docs.writeFile("README.md", "authoritative")
+    await docs.snapshot({ name: "baseline" })
+    const sandbox = localSandbox()
+    const root = await sandbox.root
+    const target = join(root, "workspace")
+
+    try {
+      await expect(prepareHarnessWorkspaceSession(facade(docs) as never, {
+        onProgress(event) {
+          if (event.id === "workspace.prepare.start-session" && event.status === "completed") {
+            throw new Error("progress unavailable")
+          }
+        },
+        session: sandbox.session,
+        sessionWorkDir: target,
+      })).rejects.toThrow("progress unavailable")
+      await expect(readFile(join(target, "README.md"), "utf8")).resolves.toBe("authoritative")
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("keeps an explicitly empty Session scope empty", async () => {
     const docs = workspace()
     await docs.writeFile("README.md", "hidden")

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -133,6 +133,32 @@ describe("Harness Workspace Session", () => {
     }
   })
 
+  it("restores a failed invocation after its operation signal aborts", async () => {
+    const docs = workspace()
+    await docs.writeFile("README.md", "authoritative")
+    await docs.snapshot({ name: "baseline" })
+    const sandbox = localSandbox()
+    const root = await sandbox.root
+    const target = join(root, "workspace")
+    const controller = new AbortController()
+
+    try {
+      const session = await prepareHarnessWorkspaceSession(facade(docs) as never, {
+        abortSignal: controller.signal,
+        session: sandbox.session,
+        sessionWorkDir: target,
+      })
+      await writeFile(join(target, "README.md"), "invocation")
+      controller.abort(new Error("invocation canceled"))
+
+      await expect(session.close(new Error("invocation canceled"))).resolves.toBeUndefined()
+      await expect(readFile(join(target, "README.md"), "utf8")).resolves.toBe("authoritative")
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("keeps an explicitly empty Session scope empty", async () => {
     const docs = workspace()
     await docs.writeFile("README.md", "hidden")

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -1,1089 +1,247 @@
-import { gunzipSync } from "node:zlib"
+import { exec } from "node:child_process"
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { promisify } from "node:util"
 import { describe, expect, it, vi } from "vitest"
 
-import { prepareHarnessWorkspaceSession } from "../src/session/harness.ts"
 import { defineWorkspace } from "../src/index.ts"
 import { createWorkspace } from "../src/core/workspace.ts"
+import { prepareHarnessWorkspaceSession } from "../src/session/harness.ts"
 
-function bytes(content: string): Uint8Array {
-  return new TextEncoder().encode(content)
-}
+import type { Workspace, WorkspaceMaterializeSourcesOptions } from "../src/core/types.ts"
+import type { HarnessSandboxSession } from "../src/session/harness.ts"
 
-function ok(stdout = "") {
-  return { exitCode: 0, stderr: "", stdout }
-}
+const execAsync = promisify(exec)
 
-function sandboxRun(files: string[] = [], directories: string[] = [], symlinks: string[] = []) {
-  return vi.fn(async ({ command }: { command: string }) => {
-    if (command.includes("-type d")) return ok(directories.map(path => `./${path}`).join("\n"))
-    if (command.includes("-type l")) return ok(symlinks.map(path => `./${path}`).join("\n"))
-    if (command.includes("-type f")) return ok(files.map(path => `./${path}`).join("\n"))
-    return ok()
+function workspace() {
+  return createWorkspace({
+    ...defineWorkspace({ store: { provider: "memory" } }),
+    name: `docs-${crypto.randomUUID()}`,
   })
 }
 
-function expectArchiveWrite(writeBinaryFile: ReturnType<typeof vi.fn>, root = "/work/agent", abortSignal: AbortSignal | undefined = undefined) {
-  expect(writeBinaryFile).toHaveBeenCalledWith({
-    abortSignal,
-    content: expect.any(Uint8Array),
-    path: `${root}/.vitehub-workspace.tar.gz`,
-  })
-}
-
-function expectArchiveExtract(run: ReturnType<typeof vi.fn>, root = "/work/agent") {
-  expect(run).toHaveBeenCalledWith({
-    abortSignal: undefined,
-    command: "tar -xzf '.vitehub-workspace.tar.gz' && rm '.vitehub-workspace.tar.gz'",
-    workingDirectory: root,
-  })
-}
-
-function expectGitBaseline(run: ReturnType<typeof vi.fn>, root = "/work/agent") {
-  expect(run).toHaveBeenCalledWith({
-    abortSignal: undefined,
-    command: "if command -v git >/dev/null 2>&1; then git init -q && git config user.email vitehub@example.invalid && git config user.name ViteHub && git add -A -f && git commit --allow-empty --no-gpg-sign --no-verify -qm workspace-baseline || true; fi",
-    workingDirectory: root,
-  })
-}
-
-function expectWorkDirReset(run: ReturnType<typeof vi.fn>, writeBinaryFile: ReturnType<typeof vi.fn>, root = "/work/agent") {
-  const parent = root.replace(/\/[^/]+$/, "") || "/"
-  const name = root.split("/").filter(Boolean).at(-1) || root
-  expect(writeBinaryFile).toHaveBeenCalledWith({
-    abortSignal: undefined,
-    content: new Uint8Array(),
-    path: `${parent}/.vitehub-reset`,
-  })
-  expect(run).toHaveBeenCalledWith({
-    abortSignal: undefined,
-    command: `rm -rf -- '${name}' && mkdir -p -- '${name}' && rm -f -- '.vitehub-reset'`,
-    workingDirectory: parent,
-  })
-}
-
-function archiveEntry(writeBinaryFile: ReturnType<typeof vi.fn>, path: string) {
-  const archive = writeBinaryFile.mock.calls.find(([input]) => input.path.endsWith(".vitehub-workspace.tar.gz"))?.[0].content
-  if (!archive) throw new Error("missing archive write")
-  const tar = gunzipSync(Buffer.from(archive))
-  for (let offset = 0; offset < tar.byteLength; offset += 512) {
-    const name = tar.subarray(offset, offset + 100).toString().replace(/\0.*$/, "")
-    if (!name) break
-    const sizeText = tar.subarray(offset + 124, offset + 136).toString().replace(/\0.*$/, "").trim()
-    const size = Number.parseInt(sizeText || "0", 8)
-    if (name === path) return tar.subarray(offset, offset + 512)
-    offset += Math.ceil(size / 512) * 512
+function facade(docs: Workspace, materializeSources = docs.materializeSources?.bind(docs)) {
+  return {
+    fs: {
+      exists: docs.exists.bind(docs),
+      glob: docs.glob.bind(docs),
+      list: docs.list.bind(docs),
+      readFile: docs.readFile.bind(docs),
+      search: docs.search.bind(docs),
+      stat: docs.stat.bind(docs),
+    },
+    materializeSources,
+    startSession: docs.startSession.bind(docs),
+    tools: {},
   }
-  throw new Error(`missing archive entry: ${path}`)
+}
+
+function localSandbox(): { root: Promise<string>, session: HarnessSandboxSession } {
+  const root = mkdtemp(join(tmpdir(), "vitehub-harness-session-"))
+  return {
+    root,
+    session: {
+      async readBinaryFile(options) {
+        return await readFile(options.path).catch(() => null)
+      },
+      async run(options) {
+        try {
+          const result = await execAsync(options.command, {
+            cwd: options.workingDirectory,
+            env: options.env ? { ...process.env, ...options.env } : process.env,
+            signal: options.abortSignal,
+          })
+          return { exitCode: 0, stderr: result.stderr, stdout: result.stdout }
+        }
+        catch (error) {
+          const failure = error as Error & { code?: number, stderr?: string, stdout?: string }
+          return { exitCode: typeof failure.code === "number" ? failure.code : 1, stderr: failure.stderr || failure.message, stdout: failure.stdout || "" }
+        }
+      },
+      async writeBinaryFile(options) {
+        await mkdir(dirname(options.path), { recursive: true })
+        await writeFile(options.path, options.content)
+      },
+    },
+  }
 }
 
 describe("Harness Workspace Session", () => {
-  it("resets and materializes selected Workspace files into the harness sandbox", async () => {
-    const readme = bytes("# Docs\n")
-    const list = vi.fn(async () => [
-      { path: "README.md", type: "file" },
-      { path: "notes", type: "directory" },
-    ])
-    const readFile = vi.fn(async () => readme)
-    const run = sandboxRun()
-    const writeBinaryFile = vi.fn(async () => {})
+  it("materializes and writes back through the Workspace-hosted Session boundary", async () => {
+    const docs = workspace()
+    await docs.writeFile("README.md", "before")
+    await docs.snapshot({ name: "baseline" })
+    const sandbox = localSandbox()
+    const root = await sandbox.root
+    const target = join(root, "workspace")
+    const progress: Array<{ id: string, status: string }> = []
 
-    const session = await prepareHarnessWorkspaceSession({
-      fs: { list, readFile },
-      tools: {},
-    } as never, {
-      session: { run, writeBinaryFile },
-      sessionWorkDir: "/work/agent",
-    })
-
-    expect(list).toHaveBeenCalledWith("", { recursive: true })
-    expectWorkDirReset(run, writeBinaryFile)
-    expect(readFile).toHaveBeenCalledWith("README.md", { encoding: "binary" })
-    expectArchiveWrite(writeBinaryFile)
-    expectArchiveExtract(run)
-    expectGitBaseline(run)
-
-    await session.close()
-  })
-
-  it("refreshes the harness git baseline after support files are written", async () => {
-    const run = sandboxRun()
-    const writeBinaryFile = vi.fn(async () => {})
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: { list: vi.fn(async () => []), readFile: vi.fn() },
-      tools: {},
-    } as never, {
-      session: { run, writeBinaryFile },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.refreshGitBaseline()
-
-    expect(run).toHaveBeenCalledTimes(3)
-    expectGitBaseline(run)
-
-    await session.close()
-  })
-
-  it("force-adds materialized files to the harness git baseline", async () => {
-    const run = sandboxRun()
-    const writeBinaryFile = vi.fn(async () => {})
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => [
-          { path: ".gitignore", type: "file" },
-          { path: "app.log", type: "file" },
-        ]),
-        readFile: vi.fn(async (path: string) => path === ".gitignore" ? bytes("*.log\n") : bytes("tracked log\n")),
-      },
-      tools: {},
-    } as never, {
-      session: { run, writeBinaryFile },
-      sessionWorkDir: "/work/agent",
-    })
-
-    expect(run).toHaveBeenCalledWith(expect.objectContaining({
-      command: expect.stringContaining("git add -A -f"),
-    }))
-
-    await session.close()
-  })
-
-  it("preserves GitHub symlinks in the harness archive", async () => {
-    const list = vi.fn(async () => [
-      { path: "AGENTS.md", type: "file" },
-      { metadata: { gitMode: "120000" }, path: "CLAUDE.md", type: "file" },
-    ])
-    const readFile = vi.fn(async (path: string) => path === "CLAUDE.md" ? bytes("AGENTS.md") : bytes("# Agents\n"))
-    const run = sandboxRun(["AGENTS.md", "CLAUDE.md"])
-    const writeBinaryFile = vi.fn(async () => {})
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: { list, readFile },
-      tools: {},
-    } as never, {
-      session: { readBinaryFile: vi.fn(async () => null), run, writeBinaryFile },
-      sessionWorkDir: "/work/agent",
-    })
-
-    const header = archiveEntry(writeBinaryFile, "CLAUDE.md")
-    expect(String.fromCharCode(header[156]!)).toBe("2")
-    expect(header.subarray(157, 257).toString().replace(/\0.*$/, "")).toBe("AGENTS.md")
-
-    await session.close()
-  })
-
-  it("uses GitHub symlink target metadata when readFile resolves the target content", async () => {
-    const list = vi.fn(async () => [
-      { path: "AGENTS.md", type: "file" },
-      { metadata: { gitMode: "120000", symlinkTarget: "AGENTS.md" }, path: "CLAUDE.md", type: "file" },
-    ])
-    const readFile = vi.fn(async () => bytes("# Agents\n"))
-    const run = sandboxRun(["AGENTS.md", "CLAUDE.md"])
-    const writeBinaryFile = vi.fn(async () => {})
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: { list, readFile },
-      tools: {},
-    } as never, {
-      session: { readBinaryFile: vi.fn(async () => null), run, writeBinaryFile },
-      sessionWorkDir: "/work/agent",
-    })
-
-    const header = archiveEntry(writeBinaryFile, "CLAUDE.md")
-    expect(String.fromCharCode(header[156]!)).toBe("2")
-    expect(header.subarray(157, 257).toString().replace(/\0.*$/, "")).toBe("AGENTS.md")
-
-    await session.close()
-  })
-
-  it("materializes only selected Workspace Session paths", async () => {
-    const publicReadme = bytes("# Public\n")
-    const stat = vi.fn(async (path: string) => {
-      if (path === "public") return { path: "public", type: "directory" }
-      throw new Error(`unexpected stat ${path}`)
-    })
-    const list = vi.fn(async (path: string) => {
-      if (path === "public") {
-        return [
-          { path: "public", type: "directory" },
-          { mediaType: "text/markdown", path: "public/README.md", type: "file" },
-        ]
-      }
-      throw new Error(`unexpected list ${path}`)
-    })
-    const readFile = vi.fn(async (path: string) => {
-      if (path === "public/README.md") return publicReadme
-      throw new Error(`unexpected read ${path}`)
-    })
-    const startSession = vi.fn(async () => ({
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => ({ entries: [], to: "next" })),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
-    }))
-    const writeBinaryFile = vi.fn(async () => {})
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: { list, readFile, stat },
-      startSession,
-      tools: {},
-    } as never, {
-      paths: ["public"],
-      session: {
-        readBinaryFile: vi.fn(async () => null),
-        run: sandboxRun(["public/README.md"], ["public"]),
-        writeBinaryFile,
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    expect(stat).toHaveBeenCalledWith("public")
-    expect(list).toHaveBeenCalledWith("public", { recursive: true })
-    expect(list).not.toHaveBeenCalledWith("", { recursive: true })
-    expect(readFile).toHaveBeenCalledWith("public/README.md", { encoding: "binary" })
-    expectArchiveWrite(writeBinaryFile)
-    expect(startSession).toHaveBeenCalledWith({ paths: ["public"] })
-
-    await session.close()
-  })
-
-  it("keeps an empty selected Workspace Session scope empty", async () => {
-    const list = vi.fn(async () => [
-      { path: "README.md", type: "file" },
-    ])
-    const materializeSources = vi.fn(async () => ({
-      bytes: 0,
-      directories: 0,
-      durationMs: 0,
-      files: 0,
-      path: "",
-      sources: [],
-    }))
-    const startSession = vi.fn(async () => ({
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => ({ entries: [], to: "next" })),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
-    }))
-    const writeBinaryFile = vi.fn(async () => {})
-    const run = sandboxRun()
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list,
-        materializeSources,
-        readFile: vi.fn(async () => bytes("root")),
-      },
-      startSession,
-      tools: {},
-    } as never, {
-      paths: [],
-      session: {
-        readBinaryFile: vi.fn(async () => null),
-        run,
-        writeBinaryFile,
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    expect(materializeSources).not.toHaveBeenCalled()
-    expect(list).not.toHaveBeenCalled()
-    expectWorkDirReset(run, writeBinaryFile)
-    expect(startSession).not.toHaveBeenCalled()
-
-    await session.close()
-  })
-
-  it("materializes lazy source files before copying them into the harness sandbox", async () => {
-    const sourceFile = bytes("Months of Stock\n")
-    let materialized = false
-    const materializeSources = vi.fn(async () => {
-      materialized = true
-      return {
-        bytes: sourceFile.byteLength,
-        directories: 2,
-        durationMs: 1,
-        files: 1,
-        path: "",
-        sources: [{ source: "portal", status: "ready" }],
-      }
-    })
-    const list = vi.fn(async () => materialized
-      ? [
-          { path: "portal", type: "directory" },
-          { path: "portal/app", type: "directory" },
-          { mediaType: "text/vue", path: "portal/app/OrderSuggestion.vue", type: "file" },
-        ]
-      : [
-          { path: "portal", type: "directory" },
-        ])
-    const readFile = vi.fn(async (path: string) => {
-      if (path === "portal/app/OrderSuggestion.vue") return sourceFile
-      throw new Error(`unexpected read ${path}`)
-    })
-    const writeBinaryFile = vi.fn(async () => {})
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: { list, materializeSources, readFile },
-      tools: {},
-    } as never, {
-      session: {
-        run: sandboxRun(),
-        writeBinaryFile,
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    expect(materializeSources).toHaveBeenCalledWith({ path: "" })
-    expect(list).toHaveBeenCalledWith("", { recursive: true })
-    expectArchiveWrite(writeBinaryFile)
-
-    await session.close()
-  })
-
-  it("passes materialization progress and abort signals to source materialization", async () => {
-    const abortController = new AbortController()
-    const onMaterializeProgress = vi.fn()
-    const sourceFile = bytes("Details\n")
-    const materializeSources = vi.fn(async (options?: Record<string, unknown>) => {
-      await (options?.onProgress as ((event: unknown) => Promise<void> | void) | undefined)?.({
-        mountPath: "portal",
-        path: options?.path,
-        source: "portal",
-        status: "started",
+    try {
+      const session = await prepareHarnessWorkspaceSession(facade(docs) as never, {
+        onProgress: (event) => { progress.push(event) },
+        session: sandbox.session,
+        sessionWorkDir: target,
       })
+      await expect(readFile(join(target, "README.md"), "utf8")).resolves.toBe("before")
+      await writeFile(join(target, "README.md"), "after")
+      await writeFile(join(target, "result.txt"), "done")
+      await session.close()
+
+      await expect(docs.readFile("README.md")).resolves.toBe("after")
+      await expect(docs.readFile("result.txt")).resolves.toBe("done")
+      expect(progress).toEqual(expect.arrayContaining([
+        expect.objectContaining({ id: "workspace.prepare.start-session", status: "completed" }),
+        expect.objectContaining({ id: "workspace.prepare.read-files", status: "completed" }),
+        expect.objectContaining({ id: "workspace.prepare.git-status", status: "completed" }),
+      ]))
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("keeps concurrent invocation trees isolated and discards a failed invocation", async () => {
+    const docs = workspace()
+    await docs.writeFile("README.md", "authoritative")
+    await docs.snapshot({ name: "baseline" })
+    const left = localSandbox()
+    const right = localSandbox()
+    const leftRoot = await left.root
+    const rightRoot = await right.root
+    const leftTarget = join(leftRoot, "workspace")
+    const rightTarget = join(rightRoot, "workspace")
+
+    try {
+      const [leftSession, rightSession] = await Promise.all([
+        prepareHarnessWorkspaceSession(facade(docs) as never, { session: left.session, sessionWorkDir: leftTarget }),
+        prepareHarnessWorkspaceSession(facade(docs) as never, { session: right.session, sessionWorkDir: rightTarget }),
+      ])
+      await writeFile(join(leftTarget, "README.md"), "left")
+      await writeFile(join(rightTarget, "README.md"), "right")
+      await leftSession.close(new Error("failed invocation"))
+
+      await expect(readFile(join(leftTarget, "README.md"), "utf8")).resolves.toBe("authoritative")
+      await expect(readFile(join(rightTarget, "README.md"), "utf8")).resolves.toBe("right")
+      await expect(docs.readFile("README.md")).resolves.toBe("authoritative")
+      await rightSession.close()
+      await expect(docs.readFile("README.md")).resolves.toBe("right")
+    }
+    finally {
+      await rm(leftRoot, { force: true, recursive: true })
+      await rm(rightRoot, { force: true, recursive: true })
+    }
+  })
+
+  it("keeps an explicitly empty Session scope empty", async () => {
+    const docs = workspace()
+    await docs.writeFile("README.md", "hidden")
+    await docs.snapshot({ name: "baseline" })
+    const sandbox = localSandbox()
+    const root = await sandbox.root
+    const target = join(root, "workspace")
+
+    try {
+      const session = await prepareHarnessWorkspaceSession(facade(docs) as never, {
+        paths: [],
+        session: sandbox.session,
+        sessionWorkDir: target,
+      })
+      await expect(readFile(join(target, "README.md"), "utf8")).rejects.toThrow()
+      await session.close()
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("excludes runtime and Harness support paths from write-back", async () => {
+    const docs = workspace()
+    const sandbox = localSandbox()
+    const root = await sandbox.root
+    const target = join(root, "workspace")
+
+    try {
+      const session = await prepareHarnessWorkspaceSession(facade(docs) as never, {
+        ignoreWriteBackPaths: ["AGENTS.md"],
+        session: sandbox.session,
+        sessionWorkDir: target,
+      })
+      await mkdir(join(target, ".agent-runs"), { recursive: true })
+      await mkdir(join(target, ".vitehub"), { recursive: true })
+      await writeFile(join(target, ".agent-runs", "trace.json"), "trace")
+      await writeFile(join(target, ".vitehub", "runtime.json"), "runtime")
+      await writeFile(join(target, "AGENTS.md"), "generated")
+      await writeFile(join(target, "result.txt"), "done")
+      await session.close()
+
+      await expect(docs.readFile("result.txt")).resolves.toBe("done")
+      await expect(docs.exists(".agent-runs/trace.json")).resolves.toBe(false)
+      await expect(docs.list("", { recursive: true })).resolves.not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ path: ".vitehub/runtime.json" }),
+      ]))
+      await expect(docs.exists("AGENTS.md")).resolves.toBe(false)
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("materializes lazy Sources before opening the hosted Session", async () => {
+    const docs = workspace()
+    const onMaterializeProgress = vi.fn()
+    const materializeSources = vi.fn(async (options?: WorkspaceMaterializeSourcesOptions) => {
+      await options?.onProgress?.({ mountPath: "portal", path: options.path || "", source: "portal", status: "started" })
+      await docs.writeFile("portal/details.md", "ready")
+      await docs.snapshot({ name: "source" })
       return {
-        bytes: sourceFile.byteLength,
+        bytes: 5,
         directories: 1,
-        durationMs: 1,
+        durationMs: 0,
         files: 1,
         path: options?.path || "",
-        sources: [{ mountPath: "portal", source: "portal", status: "ready" }],
+        sources: [],
       }
     })
-    const stat = vi.fn(async () => ({ path: "portal", type: "directory" }))
-    const list = vi.fn(async () => [
-      { path: "portal", type: "directory" },
-      { mediaType: "text/markdown", path: "portal/details.md", type: "file" },
-    ])
-    const readFile = vi.fn(async () => sourceFile)
-    const writeBinaryFile = vi.fn(async () => {})
+    const sandbox = localSandbox()
+    const root = await sandbox.root
+    const target = join(root, "workspace")
 
-    const session = await prepareHarnessWorkspaceSession({
-      fs: { list, materializeSources, readFile, stat },
-      tools: {},
-    } as never, {
-      abortSignal: abortController.signal,
-      onMaterializeProgress,
-      paths: ["portal"],
-      session: {
-        run: sandboxRun(),
-        writeBinaryFile,
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    expect(materializeSources).toHaveBeenCalledWith({
-      abortSignal: abortController.signal,
-      onProgress: onMaterializeProgress,
-      path: "portal",
-    })
-    expect(onMaterializeProgress).toHaveBeenCalledWith(expect.objectContaining({
-      mountPath: "portal",
-      path: "portal",
-      source: "portal",
-      status: "started",
-    }))
-    expect(stat).toHaveBeenCalledWith("portal")
-    expect(list).toHaveBeenCalledWith("portal", { recursive: true })
-    expectArchiveWrite(writeBinaryFile, "/work/agent", abortController.signal)
-
-    await session.close()
-  })
-
-  it("skips missing selected paths during sandbox materialization", async () => {
-    const publicReadme = bytes("# Public\n")
-    const stat = vi.fn(async (path: string) => {
-      if (path === "public") return { path: "public", type: "directory" }
-      throw new Error(`missing ${path}`)
-    })
-    const list = vi.fn(async () => [
-      { path: "public/README.md", type: "file" },
-    ])
-    const writeBinaryFile = vi.fn(async () => {})
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list,
-        readFile: vi.fn(async () => publicReadme),
-        stat,
-      },
-      tools: {},
-    } as never, {
-      paths: ["public", ".vitehub/sources/public.json"],
-      session: {
-        run: sandboxRun(),
-        writeBinaryFile,
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    expect(stat).toHaveBeenCalledWith("public")
-    expect(stat).toHaveBeenCalledWith(".vitehub/sources/public.json")
-    expect(list).toHaveBeenCalledWith("public", { recursive: true })
-    expectArchiveWrite(writeBinaryFile)
-
-    await session.close()
-  })
-
-  it("creates parent directories when a selected path is a file", async () => {
-    const readme = bytes("scoped")
-    const run = sandboxRun()
-    const writeBinaryFile = vi.fn(async () => {})
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => {
-          throw new Error("root list should not run")
-        }),
-        readFile: vi.fn(async () => readme),
-        stat: vi.fn(async () => ({ mediaType: "text/markdown", path: "docs/README.md", type: "file" })),
-      },
-      tools: {},
-    } as never, {
-      paths: ["docs/README.md"],
-      session: { run, writeBinaryFile },
-      sessionWorkDir: "/work/agent",
-    })
-
-    expectArchiveWrite(writeBinaryFile)
-    expectArchiveExtract(run)
-
-    await session.close()
-  })
-
-  it("does not recreate synthetic parent directories for unchanged selected file paths", async () => {
-    const workspaceSession = {
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => ({
-        entries: [],
-        to: "next",
-      })),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
+    try {
+      const session = await prepareHarnessWorkspaceSession(facade(docs, materializeSources) as never, {
+        onMaterializeProgress,
+        paths: ["portal"],
+        session: sandbox.session,
+        sessionWorkDir: target,
+      })
+      await expect(readFile(join(target, "portal", "details.md"), "utf8")).resolves.toBe("ready")
+      expect(materializeSources).toHaveBeenCalledWith(expect.objectContaining({ path: "portal" }))
+      expect(onMaterializeProgress).toHaveBeenCalledOnce()
+      await session.close()
     }
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => {
-          throw new Error("root list should not run")
-        }),
-        readFile: vi.fn(async () => bytes("scoped")),
-        stat: vi.fn(async () => ({ mediaType: "text/markdown", path: "docs/README.md", type: "file" })),
-      },
-      startSession: vi.fn(async () => workspaceSession),
-      tools: {},
-    } as never, {
-      paths: ["docs/README.md"],
-      session: {
-        readBinaryFile: vi.fn(async () => bytes("scoped")),
-        run: sandboxRun(["docs/README.md"], ["docs"]),
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    expect(workspaceSession.rm).not.toHaveBeenCalledWith("docs/README.md", { force: true })
-    expect(workspaceSession.rm).not.toHaveBeenCalledWith("docs", { force: true, recursive: true })
-    expect(workspaceSession.mkdir).not.toHaveBeenCalledWith("docs", { recursive: true })
-    expect(workspaceSession.commit).not.toHaveBeenCalled()
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
   })
 
-  it("does not remove synthetic parent directories for removed selected file paths", async () => {
-    const workspaceSession = {
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => ({
-        entries: [{ path: "docs/README.md", type: "removed" }],
-        to: "next",
-      })),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
+  it("refreshes the synthetic Git baseline after support files are added", async () => {
+    const docs = workspace()
+    const sandbox = localSandbox()
+    const root = await sandbox.root
+    const target = join(root, "workspace")
+
+    try {
+      const session = await prepareHarnessWorkspaceSession(facade(docs) as never, {
+        session: sandbox.session,
+        sessionWorkDir: target,
+      })
+      await writeFile(join(target, "AGENTS.md"), "instructions")
+      await session.refreshGitBaseline()
+      await expect(execAsync("git status --porcelain", { cwd: target })).resolves.toMatchObject({ stdout: "" })
+      await session.close(new Error("support files are framework-owned"))
     }
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => {
-          throw new Error("root list should not run")
-        }),
-        readFile: vi.fn(async () => bytes("scoped")),
-        stat: vi.fn(async () => ({ mediaType: "text/markdown", path: "docs/README.md", type: "file" })),
-      },
-      startSession: vi.fn(async () => workspaceSession),
-      tools: {},
-    } as never, {
-      paths: ["docs/README.md"],
-      session: {
-        readBinaryFile: vi.fn(async () => null),
-        run: sandboxRun(),
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    expect(workspaceSession.rm).toHaveBeenCalledWith("docs/README.md", { force: true })
-    expect(workspaceSession.rm).not.toHaveBeenCalledWith("docs", { force: true, recursive: true })
-    expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
-  })
-
-  it("commits harness sandbox additions and updates through write-mode Workspace rules", async () => {
-    const initial = bytes("old")
-    const updated = bytes("new")
-    const added = bytes("added")
-    const writeBackDiff = {
-      entries: [{ path: "README.md", type: "modified" as const }],
-      to: "next",
+    finally {
+      await rm(root, { force: true, recursive: true })
     }
-    const order: string[] = []
-    const workspaceSession = {
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => { order.push("commit") }),
-      diff: vi.fn(async () => writeBackDiff),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
-    }
-    const onWriteBack = vi.fn(async () => { order.push("write-back") })
-    const startSession = vi.fn(async () => workspaceSession)
-    const run = sandboxRun(["README.md", "new.json"])
-    const readBinaryFile = vi.fn(async ({ path }: { path: string }) => path.endsWith("README.md") ? updated : added)
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => [{ mediaType: "text/markdown", path: "README.md", type: "file" }]),
-        readFile: vi.fn(async () => initial),
-      },
-      startSession,
-      tools: {},
-    } as never, {
-      session: {
-        readBinaryFile,
-        run,
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      definition: {
-        name: "docs",
-        rules: {
-          "**": { commit: "chore: update docs" },
-        },
-      },
-      onWriteBack,
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    expect(startSession).toHaveBeenCalledOnce()
-    expect(run).toHaveBeenCalledWith({
-      abortSignal: undefined,
-      command: "find . -type f -print",
-      workingDirectory: "/work/agent",
-    })
-    expect(run).toHaveBeenCalledWith({
-      abortSignal: undefined,
-      command: "find . -type l -print",
-      workingDirectory: "/work/agent",
-    })
-    expect(workspaceSession.writeFile).toHaveBeenCalledWith("README.md", updated, { mediaType: "text/markdown" })
-    expect(workspaceSession.writeFile).toHaveBeenCalledWith("new.json", added, { mediaType: "application/json" })
-    expect(onWriteBack).toHaveBeenCalledWith(writeBackDiff)
-    expect(order).toEqual(["commit", "write-back"])
-    expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "chore: update docs" })
-    expect(workspaceSession.close).toHaveBeenCalledOnce()
-  })
-
-  it.each([[false], [null], [undefined]] as const)("skips harness commits when the commit callback returns %s", async (commitPlan) => {
-    const updated = bytes("new")
-    const diff = {
-      entries: [{ path: "README.md", type: "modified" }],
-      to: "next",
-    }
-    const workspaceSession = {
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => diff),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
-    }
-    const commit = vi.fn(() => commitPlan)
-    const onWriteBack = vi.fn(async () => {})
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => [{ mediaType: "text/markdown", path: "README.md", type: "file" }]),
-        readFile: vi.fn(async () => bytes("old")),
-      },
-      startSession: vi.fn(async () => workspaceSession),
-      tools: {},
-    } as never, {
-      commit,
-      onWriteBack,
-      session: {
-        readBinaryFile: vi.fn(async () => updated),
-        run: sandboxRun(["README.md"]),
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    expect(workspaceSession.writeFile).toHaveBeenCalledWith("README.md", updated, { mediaType: "text/markdown" })
-    expect(commit).toHaveBeenCalledWith(diff)
-    expect(workspaceSession.commit).not.toHaveBeenCalled()
-    expect(onWriteBack).not.toHaveBeenCalled()
-    expect(workspaceSession.close).toHaveBeenCalledOnce()
-  })
-
-  it("commits harness symlinks as Git symlink blobs", async () => {
-    const workspaceSession = {
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => ({
-        entries: [{ path: "linked.txt", type: "added" }],
-        to: "next",
-      })),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
-    }
-    const readBinaryFile = vi.fn(async ({ path }: { path: string }) =>
-      path.endsWith("linked.txt") ? bytes("target bytes") : bytes("result"))
-    const run = vi.fn(async ({ command }: { command: string }) => {
-      if (command.includes("-type d")) return ok()
-      if (command.includes("-type f")) return ok("./result.txt")
-      if (command.includes("-type l")) return ok("./CLAUDE.md\n./linked.txt")
-      if (command === "readlink -- 'CLAUDE.md'") return ok("NEXT.md\n")
-      if (command === "readlink -- 'linked.txt'") return ok("target.txt\n")
-      return ok()
-    })
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => [
-          { metadata: { gitMode: "120000" }, path: "CLAUDE.md", type: "file" },
-        ]),
-        readFile: vi.fn(async () => bytes("AGENTS.md")),
-      },
-      startSession: vi.fn(async () => workspaceSession),
-      tools: {},
-    } as never, {
-      session: {
-        readBinaryFile,
-        run,
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    expect(readBinaryFile).not.toHaveBeenCalledWith({ abortSignal: undefined, path: "/work/agent/linked.txt" })
-    expect(workspaceSession.writeFile).toHaveBeenCalledWith("result.txt", bytes("result"), { mediaType: "text/plain" })
-    expect(workspaceSession.writeFile).toHaveBeenCalledWith("CLAUDE.md", bytes("NEXT.md"), { metadata: { gitMode: "120000" } })
-    expect(workspaceSession.writeFile).toHaveBeenCalledWith("linked.txt", bytes("target.txt"), { metadata: { gitMode: "120000" } })
-    expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
-  })
-
-  it("commits regular files that replace initial harness symlinks", async () => {
-    const workspaceSession = {
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => ({
-        entries: [{ path: "CLAUDE.md", type: "modified" }],
-        to: "next",
-      })),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
-    }
-    const replacement = bytes("# Local instructions\n")
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => [
-          { path: "AGENTS.md", type: "file" },
-          { metadata: { gitMode: "120000" }, path: "CLAUDE.md", type: "file" },
-        ]),
-        readFile: vi.fn(async (path: string) => path === "CLAUDE.md" ? bytes("AGENTS.md") : bytes("# Agents\n")),
-      },
-      startSession: vi.fn(async () => workspaceSession),
-      tools: {},
-    } as never, {
-      session: {
-        readBinaryFile: vi.fn(async ({ path }: { path: string }) =>
-          path.endsWith("CLAUDE.md") ? replacement : bytes("# Agents\n")),
-        run: sandboxRun(["AGENTS.md", "CLAUDE.md"]),
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    expect(workspaceSession.writeFile).toHaveBeenCalledWith("CLAUDE.md", replacement, { mediaType: "text/markdown" })
-    expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
-  })
-
-  it("does not recreate unchanged initial directories during write-back", async () => {
-    const initial = bytes("unchanged")
-    const summary = bytes("summary")
-    const workspaceSession = {
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => ({
-        entries: [{ path: "summary.md", type: "added" }],
-        to: "next",
-      })),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
-    }
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => [
-          { path: "airtable-tasks", type: "directory" },
-          { mediaType: "text/markdown", path: "airtable-tasks/task.md", type: "file" },
-        ]),
-        readFile: vi.fn(async () => initial),
-      },
-      startSession: vi.fn(async () => workspaceSession),
-      tools: {},
-    } as never, {
-      session: {
-        readBinaryFile: vi.fn(async ({ path }: { path: string }) =>
-          path.endsWith("airtable-tasks/task.md") ? initial : summary),
-        run: sandboxRun(["airtable-tasks/task.md", "summary.md"], ["airtable-tasks"]),
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    expect(workspaceSession.mkdir).not.toHaveBeenCalledWith("airtable-tasks", expect.anything())
-    expect(workspaceSession.writeFile).not.toHaveBeenCalledWith("airtable-tasks/task.md", expect.anything(), expect.anything())
-    expect(workspaceSession.writeFile).toHaveBeenCalledWith("summary.md", summary, { mediaType: "text/markdown" })
-    expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
-  })
-
-  it("does not write ignored harness support paths back to Workspace", async () => {
-    const workspaceSession = {
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => ({
-        entries: [{ path: "summary.md", type: "added" }],
-        to: "next",
-      })),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
-    }
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => [
-          { mediaType: "text/markdown", path: "AGENTS.md", type: "file" },
-          { path: "notes", type: "directory" },
-          { mediaType: "text/markdown", path: "notes/keep.md", type: "file" },
-        ]),
-        readFile: vi.fn(async () => bytes("old instructions")),
-      },
-      startSession: vi.fn(async () => workspaceSession),
-      tools: {},
-    } as never, {
-      ignoreWriteBackPaths: ["AGENTS.md", "CLAUDE.md", "notes"],
-      session: {
-        readBinaryFile: vi.fn(async ({ path }: { path: string }) => bytes(path)),
-        run: sandboxRun(
-          [".git/config", "AGENTS.md", "CLAUDE.md", "notes/generated.md", "summary.md"],
-          [".git", ".git/refs", "notes"],
-        ),
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    expect(workspaceSession.writeFile).toHaveBeenCalledWith("summary.md", bytes("/work/agent/summary.md"), { mediaType: "text/markdown" })
-    expect(workspaceSession.writeFile).not.toHaveBeenCalledWith("AGENTS.md", expect.anything(), expect.anything())
-    expect(workspaceSession.writeFile).not.toHaveBeenCalledWith("CLAUDE.md", expect.anything(), expect.anything())
-    expect(workspaceSession.writeFile).not.toHaveBeenCalledWith(".git/config", expect.anything(), expect.anything())
-    expect(workspaceSession.writeFile).not.toHaveBeenCalledWith("notes/generated.md", expect.anything(), expect.anything())
-    expect(workspaceSession.rm).not.toHaveBeenCalledWith("notes/keep.md", expect.anything())
-    expect(workspaceSession.mkdir).not.toHaveBeenCalledWith(".git", expect.anything())
-    expect(workspaceSession.mkdir).not.toHaveBeenCalledWith("notes", expect.anything())
-    expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
-  })
-
-  it("does not write new parent directories created only for ignored paths", async () => {
-    const workspaceSession = {
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => ({ entries: [], to: "next" })),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
-    }
-    const session = await prepareHarnessWorkspaceSession({
-      fs: { list: vi.fn(async () => []), readFile: vi.fn() },
-      startSession: vi.fn(async () => workspaceSession),
-      tools: {},
-    } as never, {
-      ignoreWriteBackPaths: ["skills/review"],
-      session: {
-        readBinaryFile: vi.fn(async ({ path }: { path: string }) => bytes(path)),
-        run: sandboxRun(["skills/review/SKILL.md"], ["skills", "skills/review"]),
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    expect(workspaceSession.mkdir).not.toHaveBeenCalled()
-    expect(workspaceSession.writeFile).not.toHaveBeenCalled()
-  })
-
-  it("does not remove parents of ignored paths", async () => {
-    const workspaceSession = {
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => ({ entries: [], to: "next" })),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
-    }
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => [
-          { path: "skills", type: "directory" },
-          { path: "skills/review", type: "directory" },
-          { mediaType: "text/markdown", path: "skills/review/SKILL.md", type: "file" },
-        ]),
-        readFile: vi.fn(async () => bytes("review")),
-      },
-      startSession: vi.fn(async () => workspaceSession),
-      tools: {},
-    } as never, {
-      ignoreWriteBackPaths: ["skills/review"],
-      session: {
-        readBinaryFile: vi.fn(),
-        run: sandboxRun([], []),
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    expect(workspaceSession.rm).not.toHaveBeenCalled()
-  })
-
-  it("leaves harness changes uncommitted when the commit callback skips them", async () => {
-    const diff = {
-      entries: [{ path: "summary.md", type: "added" as const }],
-      to: "next",
-    }
-    const workspaceSession = {
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => diff),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
-    }
-    const commit = vi.fn(() => false as const)
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => []),
-        readFile: vi.fn(async () => bytes("")),
-      },
-      startSession: vi.fn(async () => workspaceSession),
-      tools: {},
-    } as never, {
-      commit,
-      session: {
-        readBinaryFile: vi.fn(async ({ path }: { path: string }) => bytes(path)),
-        run: sandboxRun(["summary.md"]),
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    expect(commit).toHaveBeenCalledWith(diff)
-    expect(workspaceSession.writeFile).toHaveBeenCalledWith("summary.md", bytes("/work/agent/summary.md"), { mediaType: "text/markdown" })
-    expect(workspaceSession.commit).not.toHaveBeenCalled()
-  })
-
-  it("commits generated files selected by missing Workspace Session paths", async () => {
-    const workspace = createWorkspace({
-      ...defineWorkspace({
-        store: { provider: "memory" },
-      }),
-      name: "docs",
-    })
-    await workspace.snapshot({ name: "baseline" })
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: workspace.list.bind(workspace),
-        materializeSources: workspace.materializeSources,
-        readFile: workspace.readFile.bind(workspace),
-        stat: workspace.stat.bind(workspace),
-      },
-      startSession: workspace.startSession,
-      tools: {},
-    } as never, {
-      paths: ["summary.md"],
-      session: {
-        readBinaryFile: vi.fn(async () => bytes("summary")),
-        run: sandboxRun(["summary.md"]),
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    await expect(workspace.readFile("summary.md")).resolves.toBe("summary")
-  })
-
-  it("rejects out-of-scope harness sandbox changes in the basic Workspace Session", async () => {
-    const workspace = createWorkspace({
-      ...defineWorkspace({ store: { provider: "memory" } }),
-      name: "docs",
-    })
-    await workspace.mkdir("public")
-    await workspace.writeFile("public/README.md", "old")
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: workspace.list.bind(workspace),
-        readFile: workspace.readFile.bind(workspace),
-        stat: workspace.stat.bind(workspace),
-      },
-      startSession: workspace.startSession,
-      tools: {},
-    } as never, {
-      paths: ["public"],
-      session: {
-        readBinaryFile: vi.fn(async ({ path }: { path: string }) => bytes(path)),
-        run: sandboxRun(["private.txt", "public/README.md"], ["public"]),
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await expect(session.close()).rejects.toThrow("outside the session scope")
-    await expect(workspace.exists("private.txt")).resolves.toBe(false)
-  })
-
-  it("commits harness sandbox deletions through write-mode Workspace rules", async () => {
-    const workspaceSession = {
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => ({
-        entries: [{ path: "old.txt", type: "removed" }],
-        to: "next",
-      })),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
-    }
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => [
-          { path: "README.md", type: "file" },
-          { path: "old.txt", type: "file" },
-        ]),
-        readFile: vi.fn(async (path: string) => bytes(path)),
-      },
-      startSession: vi.fn(async () => workspaceSession),
-      tools: {},
-    } as never, {
-      session: {
-        readBinaryFile: vi.fn(async ({ path }: { path: string }) => bytes(path)),
-        run: sandboxRun(["README.md"]),
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    expect(workspaceSession.rm).toHaveBeenCalledWith("old.txt", { force: true })
-    expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
-  })
-
-  it("commits harness sandbox directory and file transitions through Workspace rules", async () => {
-    const workspaceSession = {
-      close: vi.fn(async () => {}),
-      commit: vi.fn(async () => {}),
-      diff: vi.fn(async () => ({
-        entries: [{ path: "node/result.txt", type: "added" }],
-        to: "next",
-      })),
-      mkdir: vi.fn(async () => {}),
-      rm: vi.fn(async () => {}),
-      writeFile: vi.fn(async () => {}),
-    }
-
-    const session = await prepareHarnessWorkspaceSession({
-      fs: {
-        list: vi.fn(async () => [
-          { path: "empty", type: "directory" },
-          { path: "node", type: "file" },
-        ]),
-        readFile: vi.fn(async (path: string) => bytes(path)),
-      },
-      startSession: vi.fn(async () => workspaceSession),
-      tools: {},
-    } as never, {
-      session: {
-        readBinaryFile: vi.fn(async ({ path }: { path: string }) => bytes(path)),
-        run: sandboxRun(["node/result.txt"], ["empty", "node"]),
-        writeBinaryFile: vi.fn(async () => {}),
-      },
-      sessionWorkDir: "/work/agent",
-    })
-
-    await session.close()
-
-    expect(workspaceSession.rm).toHaveBeenCalledWith("node", { force: true })
-    expect(workspaceSession.mkdir).not.toHaveBeenCalledWith("empty", expect.anything())
-    expect(workspaceSession.mkdir).toHaveBeenCalledWith("node", { recursive: true })
-    expect(workspaceSession.writeFile).toHaveBeenCalledWith("node/result.txt", bytes("/work/agent/node/result.txt"), { mediaType: "text/plain" })
-    expect(workspaceSession.commit).toHaveBeenCalledWith({ message: "harness-workspace-session" })
   })
 })

--- a/packages/workspace/test/harness-session.test.ts
+++ b/packages/workspace/test/harness-session.test.ts
@@ -101,6 +101,28 @@ describe("Harness Workspace Session", () => {
     }
   })
 
+  it("materializes through a Harness sandbox without binary reads", async () => {
+    const docs = workspace()
+    await docs.writeFile("README.md", "from workspace")
+    await docs.snapshot({ name: "baseline" })
+    const sandbox = localSandbox()
+    delete sandbox.session.readBinaryFile
+    const root = await sandbox.root
+    const target = join(root, "workspace")
+
+    try {
+      const session = await prepareHarnessWorkspaceSession(facade(docs) as never, {
+        session: sandbox.session,
+        sessionWorkDir: target,
+      })
+      await expect(readFile(join(target, "README.md"), "utf8")).resolves.toBe("from workspace")
+      await session.close()
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("keeps concurrent invocation trees isolated and discards a failed invocation", async () => {
     const docs = workspace()
     await docs.writeFile("README.md", "authoritative")
@@ -152,6 +174,31 @@ describe("Harness Workspace Session", () => {
       controller.abort(new Error("invocation canceled"))
 
       await expect(session.close(new Error("invocation canceled"))).resolves.toBeUndefined()
+      await expect(readFile(join(target, "README.md"), "utf8")).resolves.toBe("authoritative")
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("closes and restores a Session when Git baseline initialization fails", async () => {
+    const docs = workspace()
+    await docs.writeFile("README.md", "authoritative")
+    await docs.snapshot({ name: "baseline" })
+    const sandbox = localSandbox()
+    const root = await sandbox.root
+    const target = join(root, "workspace")
+    const run = sandbox.session.run
+    sandbox.session.run = async (options) => {
+      if (options.command.includes("git init")) throw new Error("git unavailable")
+      return await run(options)
+    }
+
+    try {
+      await expect(prepareHarnessWorkspaceSession(facade(docs) as never, {
+        session: sandbox.session,
+        sessionWorkDir: target,
+      })).rejects.toThrow("git unavailable")
       await expect(readFile(join(target, "README.md"), "utf8")).resolves.toBe("authoritative")
     }
     finally {

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -324,6 +324,35 @@ describe("workspace host sessions", () => {
     }
   })
 
+  it("restores pre-existing excluded state when revision extraction fails after reset", async () => {
+    const docs = workspace()
+    const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-failure-"))
+    const target = join(targetParent, "workspace")
+    await mkdir(join(target, ".agent-runs"), { recursive: true })
+    await writeFile(join(target, ".agent-runs", "trace.json"), "before")
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return "0123456789012345678901234567890123456789"
+      },
+      async materializeRevision() {
+        return {
+          archive: new TextEncoder().encode("not a tar archive"),
+          files: 1,
+          revision: "0123456789012345678901234567890123456789",
+          root: "",
+        }
+      },
+    }
+
+    try {
+      await expect(docs.startSession({ host: localHost(), target })).rejects.toThrow("Failed to inspect Workspace revision")
+      await expect(readFile(join(target, ".agent-runs", "trace.json"), "utf8")).resolves.toBe("before")
+    }
+    finally {
+      await rm(targetParent, { force: true, recursive: true })
+    }
+  })
+
   it("rejects a pinned revision whose configured root is a symlink", async () => {
     const docs = workspace()
     const archive = await symlinkRootRevisionArchive()

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -366,6 +366,61 @@ describe("workspace host sessions", () => {
     }
   })
 
+  it("restores the host when preparation is canceled during the revision snapshot", async () => {
+    const docs = workspace()
+    const archive = await revisionArchive()
+    const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-snapshot-canceled-"))
+    const target = join(targetParent, "workspace")
+    const abort = new AbortController()
+    const host = localHost()
+    const read = host.files.read.bind(host.files)
+    let extracted = false
+    let aborted = false
+    host.files.read = async (path) => {
+      const content = await read(path)
+      if (extracted && !aborted) {
+        aborted = true
+        abort.abort()
+      }
+      return content
+    }
+    await mkdir(join(target, ".agent-runs"), { recursive: true })
+    await writeFile(join(target, ".agent-runs", "trace.json"), "before")
+    await docs.writeFile("README.md", "authoritative")
+    await docs.snapshot({ name: "baseline" })
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return "0123456789012345678901234567890123456789"
+      },
+      async materializeRevision() {
+        return {
+          archive: archive.bytes,
+          files: 6,
+          revision: "0123456789012345678901234567890123456789",
+          root: ".vitehub/workspaces/docs",
+        }
+      },
+    }
+
+    try {
+      await expect(docs.startSession({
+        abortSignal: abort.signal,
+        host,
+        onProgress(event) {
+          if (event.id === "workspace.prepare.extract-archive" && event.status === "completed") extracted = true
+        },
+        target,
+      })).rejects.toThrow()
+      expect(aborted).toBe(true)
+      await expect(readFile(join(target, ".agent-runs", "trace.json"), "utf8")).resolves.toBe("before")
+      await expect(readFile(join(target, "README.md"), "utf8")).resolves.toBe("authoritative")
+    }
+    finally {
+      await rm(archive.source, { force: true, recursive: true })
+      await rm(targetParent, { force: true, recursive: true })
+    }
+  })
+
   it("restores pre-existing excluded state when revision extraction fails after reset", async () => {
     const docs = workspace()
     const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-failure-"))

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1235,6 +1235,18 @@ describe("workspace host sessions", () => {
     await session.close()
   })
 
+  it("publishes an escaping host symlink as an inert file", async () => {
+    const docs = workspace()
+    const session = await docs.startSession({ host: memoryHost() })
+
+    await expect(session.exec("ln", ["-s", "../../outside", "escape"])).resolves.toMatchObject({ exitCode: 0 })
+    await session.commit({ message: "capture unsafe link" })
+
+    await expect(docs.readFile("escape")).resolves.toBe("../../outside")
+    await expect(docs.stat("escape")).resolves.toMatchObject({ metadata: undefined })
+    await session.close()
+  })
+
   it("preserves executable mode through materialization and commit", async () => {
     const docs = workspace()
     const host = memoryHost()

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1252,6 +1252,23 @@ describe("workspace host sessions", () => {
     await expect(session.commit({ message: "too late" })).rejects.toThrow("already closed")
   })
 
+  it("keeps an attached escaping host symlink inert after publication and close", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    await host.files.mkdir("/workspace", { recursive: true })
+    const session = await docs.startSession({ attach: true, host })
+
+    await expect(session.exec("ln", ["-s", "../../outside", "escape"])).resolves.toMatchObject({ exitCode: 0 })
+    await session.commit({ message: "capture unsafe attached link" })
+
+    await expect(docs.readFile("escape")).resolves.toBe("../../outside")
+    await expect(docs.stat("escape")).resolves.toMatchObject({ metadata: undefined })
+    await expect(session.diff()).resolves.toMatchObject({ entries: [] })
+    await session.close()
+    expect(host.readText("/workspace/escape")).toBe("../../outside")
+    await expect(session.exec("test", ["-L", "escape"])).rejects.toThrow("already closed")
+  })
+
   it("preserves executable mode through materialization and commit", async () => {
     const docs = workspace()
     const host = memoryHost()

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -826,6 +826,60 @@ describe("workspace host sessions", () => {
     expect(materializeRevision).toHaveBeenLastCalledWith(expect.objectContaining({ abortSignal: undefined }))
   })
 
+  it("restores excluded state when authoritative close rematerialization fails", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    let materializations = 0
+    await host.files.mkdir("/workspace/.agent-runs", { recursive: true })
+    await host.files.write("/workspace/.agent-runs/trace.json", new TextEncoder().encode("before"))
+    await docs.writeFile("README.md", "authoritative")
+    await docs.snapshot({ name: "baseline" })
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return "0123456789012345678901234567890123456789"
+      },
+      async materializeRevision() {
+        if (materializations++) throw new Error("revision unavailable")
+        return { files: 1, revision: "0123456789012345678901234567890123456789", root: "" }
+      },
+    }
+
+    const session = await docs.startSession({ host })
+    await session.writeFile("README.md", "discarded")
+    await session.writeFile(".agent-runs/trace.json", "invocation")
+    await expect(session.close()).rejects.toThrow("revision unavailable")
+
+    expect(host.readText("/workspace/.agent-runs/trace.json")).toBe("before")
+  })
+
+  it("bounds executable-mode probes while snapshotting large hosts", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    const exec = host.exec.bind(host)
+    let active = 0
+    let maximum = 0
+    host.exec = async (command, args, options) => {
+      if (command !== "test" || args?.[0] !== "-x") return await exec(command, args, options)
+      active++
+      maximum = Math.max(maximum, active)
+      await new Promise(resolve => setTimeout(resolve, 1))
+      try {
+        return await exec(command, args, options)
+      }
+      finally {
+        active--
+      }
+    }
+    for (let index = 0; index < 40; index++) await docs.writeFile(`files/${index}.txt`, String(index))
+    await docs.snapshot({ name: "baseline" })
+
+    const session = await docs.startSession({ host })
+    await session.close()
+
+    expect(maximum).toBeGreaterThan(1)
+    expect(maximum).toBeLessThanOrEqual(16)
+  })
+
   it("keeps unsafe symlinks inert and rejects writes through symlink parents", async () => {
     const docs = workspace()
     const host = memoryHost()

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1237,7 +1237,8 @@ describe("workspace host sessions", () => {
 
   it("publishes an escaping host symlink as an inert file", async () => {
     const docs = workspace()
-    const session = await docs.startSession({ host: memoryHost() })
+    const host = memoryHost()
+    const session = await docs.startSession({ host })
 
     await expect(session.exec("ln", ["-s", "../../outside", "escape"])).resolves.toMatchObject({ exitCode: 0 })
     await session.commit({ message: "capture unsafe link" })
@@ -1245,6 +1246,8 @@ describe("workspace host sessions", () => {
     await expect(docs.readFile("escape")).resolves.toBe("../../outside")
     await expect(docs.stat("escape")).resolves.toMatchObject({ metadata: undefined })
     await session.close()
+    expect(host.readText("/workspace/escape")).toBe("../../outside")
+    await expect(session.commit({ message: "too late" })).rejects.toThrow("already closed")
   })
 
   it("preserves executable mode through materialization and commit", async () => {

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -330,6 +330,8 @@ describe("workspace host sessions", () => {
     const target = join(targetParent, "workspace")
     await mkdir(join(target, ".agent-runs"), { recursive: true })
     await writeFile(join(target, ".agent-runs", "trace.json"), "before")
+    await docs.writeFile("README.md", "authoritative")
+    await docs.snapshot({ name: "baseline" })
     ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
       async currentRevision() {
         return "0123456789012345678901234567890123456789"
@@ -347,6 +349,7 @@ describe("workspace host sessions", () => {
     try {
       await expect(docs.startSession({ host: localHost(), target })).rejects.toThrow("Failed to inspect Workspace revision")
       await expect(readFile(join(target, ".agent-runs", "trace.json"), "utf8")).resolves.toBe("before")
+      await expect(readFile(join(target, "README.md"), "utf8")).resolves.toBe("authoritative")
     }
     finally {
       await rm(targetParent, { force: true, recursive: true })

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -324,6 +324,48 @@ describe("workspace host sessions", () => {
     }
   })
 
+  it("restores the host when preparation is canceled after revision extraction", async () => {
+    const docs = workspace()
+    const archive = await revisionArchive()
+    const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-canceled-"))
+    const target = join(targetParent, "workspace")
+    const abort = new AbortController()
+    await mkdir(join(target, ".agent-runs"), { recursive: true })
+    await writeFile(join(target, ".agent-runs", "trace.json"), "before")
+    await docs.writeFile("README.md", "authoritative")
+    await docs.snapshot({ name: "baseline" })
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return "0123456789012345678901234567890123456789"
+      },
+      async materializeRevision() {
+        return {
+          archive: archive.bytes,
+          files: 6,
+          revision: "0123456789012345678901234567890123456789",
+          root: ".vitehub/workspaces/docs",
+        }
+      },
+    }
+
+    try {
+      await expect(docs.startSession({
+        abortSignal: abort.signal,
+        host: localHost(),
+        onProgress(event) {
+          if (event.id === "workspace.prepare.extract-archive" && event.status === "completed") abort.abort()
+        },
+        target,
+      })).rejects.toThrow()
+      await expect(readFile(join(target, ".agent-runs", "trace.json"), "utf8")).resolves.toBe("before")
+      await expect(readFile(join(target, "README.md"), "utf8")).resolves.toBe("authoritative")
+    }
+    finally {
+      await rm(archive.source, { force: true, recursive: true })
+      await rm(targetParent, { force: true, recursive: true })
+    }
+  })
+
   it("restores pre-existing excluded state when revision extraction fails after reset", async () => {
     const docs = workspace()
     const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-failure-"))
@@ -372,6 +414,34 @@ describe("workspace host sessions", () => {
     })).rejects.toThrow()
 
     expect(host.readText("/workspace/README.md")).toBe("authoritative")
+  })
+
+  it("bounds host file reads while capturing Session state", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    for (let index = 0; index < 40; index++)
+      await docs.writeFile(`files/${index}.txt`, `file ${index}`)
+    await docs.snapshot({ name: "baseline" })
+    const read = host.files.read.bind(host.files)
+    let active = 0
+    let maximum = 0
+    host.files.read = async (path) => {
+      active++
+      maximum = Math.max(maximum, active)
+      await new Promise(resolve => setTimeout(resolve, 1))
+      try {
+        return await read(path)
+      }
+      finally {
+        active--
+      }
+    }
+
+    const session = await docs.startSession({ host })
+    await session.close()
+
+    expect(maximum).toBeGreaterThan(1)
+    expect(maximum).toBeLessThanOrEqual(16)
   })
 
   it("restores the host when post-materialization excluded-state capture fails", async () => {

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1,11 +1,107 @@
-import { posix } from "node:path"
-import { describe, expect, it } from "vitest"
+import { execFile } from "node:child_process"
+import { mkdtemp, mkdir, readFile, readdir, rm, stat, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, posix } from "node:path"
+import { promisify } from "node:util"
+import { describe, expect, it, vi } from "vitest"
 import { noExecutionAuthority, unknownExecutionAuthority } from "@vite-hub/runtime"
 
 import { defineWorkspace } from "../src/core/define.ts"
 import { createWorkspace } from "../src/core/workspace.ts"
+import { fetch as fetchSource } from "../src/sources/fetch.ts"
+import { createMemoryWorkspaceStore } from "../src/storage/memory.ts"
+import { workspaceRevisionMaterializer } from "../src/storage/materialization.ts"
 
 import type { WorkspaceSessionHost, WorkspaceSessionHostFileEntry } from "../src/core/types.ts"
+import type { WorkspaceRevisionMaterializerCarrier } from "../src/storage/materialization.ts"
+
+const execFileAsync = promisify(execFile)
+
+function localHost(): WorkspaceSessionHost {
+  return {
+    executionAuthority: unknownExecutionAuthority,
+    files: {
+      async exists(path) {
+        return await stat(path).then(() => true, () => false)
+      },
+      async list(path, options) {
+        const entries: WorkspaceSessionHostFileEntry[] = []
+        async function visit(root: string) {
+          for (const entry of await readdir(root, { withFileTypes: true })) {
+            const path = join(root, entry.name)
+            const type = entry.isSymbolicLink() ? "symlink" : entry.isDirectory() ? "directory" : "file"
+            entries.push({ path, ...(type === "file" ? { size: (await stat(path)).size } : {}), type })
+            if (options?.recursive && type === "directory") await visit(path)
+          }
+        }
+        await visit(path)
+        return entries
+      },
+      async mkdir(path, options) {
+        await mkdir(path, { recursive: options?.recursive })
+      },
+      async read(path) {
+        return await readFile(path).catch(() => null)
+      },
+      async remove(path, options) {
+        await rm(path, { force: true, recursive: options?.recursive })
+      },
+      async write(path, content) {
+        await mkdir(posix.dirname(path), { recursive: true })
+        await writeFile(path, content)
+      },
+    },
+    async exec(command, args = [], options = {}) {
+      try {
+        const result = await execFileAsync(command, [...args], {
+          cwd: options.cwd,
+          env: options.env ? { ...process.env, ...options.env } : process.env,
+          signal: options.signal,
+          timeout: options.timeout,
+        })
+        return { code: 0, stderr: result.stderr, stdout: result.stdout }
+      }
+      catch (error) {
+        const failure = error as Error & { code?: number, stderr?: string, stdout?: string }
+        return { code: typeof failure.code === "number" ? failure.code : 1, stderr: failure.stderr || failure.message, stdout: failure.stdout || "" }
+      }
+    },
+  }
+}
+
+async function revisionArchive() {
+  const source = await mkdtemp(join(tmpdir(), "vitehub-revision-source-"))
+  const root = join(source, "repo-base", ".vitehub", "workspaces", "docs")
+  await mkdir(join(root, "scripts"), { recursive: true })
+  await mkdir(join(root, ".git"), { recursive: true })
+  await mkdir(join(root, ".vitehub", "meta"), { recursive: true })
+  await mkdir(join(root, ".vitehub-revision"), { recursive: true })
+  await writeFile(join(root, "README.md"), "# Docs\n")
+  await writeFile(join(root, ".git", "config"), "internal")
+  await writeFile(join(root, ".vitehub", "meta", "state.json"), "{}")
+  await writeFile(join(root, ".vitehub-revision", "kept.txt"), "kept")
+  await writeFile(join(root, ".vitehub-revision.tar.gz"), "kept archive name")
+  await writeFile(join(root, "scripts", "run.sh"), "#!/bin/sh\n")
+  await execFileAsync("chmod", ["+x", join(root, "scripts", "run.sh")])
+  await symlink("README.md", join(root, "CLAUDE.md"))
+  await symlink("../../../../outside", join(root, "UNSAFE.md"))
+  const archive = join(source, "revision.tar.gz")
+  await execFileAsync("tar", ["-czf", archive, "-C", source, "repo-base"])
+  return { bytes: new Uint8Array(await readFile(archive)), source }
+}
+
+async function symlinkRootRevisionArchive() {
+  const source = await mkdtemp(join(tmpdir(), "vitehub-revision-source-"))
+  const root = join(source, "repo-base", ".vitehub", "workspaces")
+  const outside = join(source, "outside")
+  await mkdir(root, { recursive: true })
+  await mkdir(outside, { recursive: true })
+  await writeFile(join(outside, "secret.txt"), "host secret")
+  await symlink(outside, join(root, "docs"))
+  const archive = join(source, "revision.tar.gz")
+  await execFileAsync("tar", ["-czf", archive, "-C", source, "repo-base"])
+  return { bytes: new Uint8Array(await readFile(archive)), source }
+}
 
 function memoryHost(): WorkspaceSessionHost & { isExecutable(path: string): boolean, readText(path: string): string | undefined } {
   const files = new Map<string, Uint8Array>()
@@ -74,13 +170,13 @@ function memoryHost(): WorkspaceSessionHost & { isExecutable(path: string): bool
         files.delete(target)
         executables.delete(target)
         symlinks.delete(target)
-        for (const file of [...files.keys()]) {
+        for (const file of files.keys()) {
           if (file.startsWith(`${target}/`)) files.delete(file)
         }
-        for (const directory of [...directories]) {
+        for (const directory of directories) {
           if (directory === target || directory.startsWith(`${target}/`)) directories.delete(directory)
         }
-        for (const link of [...symlinks.keys()]) {
+        for (const link of symlinks.keys()) {
           if (link.startsWith(`${target}/`)) symlinks.delete(link)
         }
       },
@@ -105,8 +201,15 @@ function memoryHost(): WorkspaceSessionHost & { isExecutable(path: string): bool
         files.delete(target)
         return { code: 0, stderr: "", stdout: "" }
       }
-      if (command === "test" && args[0] === "-x")
-        return { code: executables.has(normalize(commandPath(args[1] || ""))) ? 0 : 1, stderr: "", stdout: "" }
+      if (command === "test") {
+        const target = normalize(commandPath(args[1] || ""))
+        const matches = args[0] === "-x"
+          ? executables.has(target)
+          : args[0] === "-L"
+            ? symlinks.has(target)
+            : args[0] === "-d" && directories.has(target)
+        return { code: matches ? 0 : 1, stderr: "", stdout: "" }
+      }
       if (command === "chmod" && args[0] === "+x") {
         executables.add(normalize(commandPath(args[1] || "")))
         return { code: 0, stderr: "", stdout: "" }
@@ -129,6 +232,367 @@ function workspace() {
 }
 
 describe("workspace host sessions", () => {
+  it("extracts a pinned revision archive with root, mode, symlink, and progress semantics", async () => {
+    const docs = workspace()
+    const archive = await revisionArchive()
+    const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-target-"))
+    const target = join(targetParent, "workspace")
+    const progress: Array<{ data?: Record<string, unknown>, id: string, status: string }> = []
+    let materializations = 0
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return "0123456789012345678901234567890123456789"
+      },
+      async materializeRevision() {
+        materializations++
+        return {
+          archive: archive.bytes,
+          files: 6,
+          revision: "0123456789012345678901234567890123456789",
+          root: ".vitehub/workspaces/docs",
+        }
+      },
+    }
+
+    try {
+      const session = await docs.startSession({
+        host: localHost(),
+        onProgress: (event) => { progress.push(event) },
+        target,
+      })
+      await expect(session.readFile("README.md")).resolves.toBe("# Docs\n")
+      await expect(session.readFile("UNSAFE.md")).resolves.toBe("../../../../outside")
+      await expect(session.readFile(".vitehub-revision/kept.txt")).resolves.toBe("kept")
+      await expect(session.readFile(".vitehub-revision.tar.gz")).resolves.toBe("kept archive name")
+      await expect(session.list("", { recursive: true })).resolves.not.toEqual(expect.arrayContaining([
+        expect.objectContaining({ path: ".git/config" }),
+        expect.objectContaining({ path: ".vitehub/meta/state.json" }),
+      ]))
+      await expect(session.list("", { recursive: true })).resolves.toEqual(expect.arrayContaining([
+        expect.objectContaining({ metadata: { gitMode: "120000" }, path: "CLAUDE.md" }),
+        expect.objectContaining({ metadata: { gitMode: "100755" }, path: "scripts/run.sh" }),
+      ]))
+      await session.commit({ message: "unchanged" })
+      await session.close()
+
+      expect(materializations).toBe(1)
+      expect(progress).toContainEqual(expect.objectContaining({
+        data: { bytes: archive.bytes.byteLength, files: 6, revision: "0123456789012345678901234567890123456789" },
+        id: "workspace.prepare.extract-archive",
+        status: "completed",
+      }))
+    }
+    finally {
+      await rm(archive.source, { force: true, recursive: true })
+      await rm(targetParent, { force: true, recursive: true })
+    }
+  })
+
+  it("rejects a pinned revision archive whose declared root is missing", async () => {
+    const docs = workspace()
+    const archive = await revisionArchive()
+    const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-target-"))
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return "0123456789012345678901234567890123456789"
+      },
+      async materializeRevision() {
+        return {
+          archive: archive.bytes,
+          files: 1,
+          revision: "0123456789012345678901234567890123456789",
+          root: "missing",
+        }
+      },
+    }
+
+    try {
+      await expect(docs.startSession({ host: localHost(), target: join(targetParent, "workspace") }))
+        .rejects.toThrow("Workspace revision archive is missing missing")
+    }
+    finally {
+      await rm(archive.source, { force: true, recursive: true })
+      await rm(targetParent, { force: true, recursive: true })
+    }
+  })
+
+  it("rejects a pinned revision whose configured root is a symlink", async () => {
+    const docs = workspace()
+    const archive = await symlinkRootRevisionArchive()
+    const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-target-"))
+    const target = join(targetParent, "workspace")
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return "0123456789012345678901234567890123456789"
+      },
+      async materializeRevision() {
+        return {
+          archive: archive.bytes,
+          files: 1,
+          revision: "0123456789012345678901234567890123456789",
+          root: ".vitehub/workspaces/docs",
+        }
+      },
+    }
+
+    try {
+      await expect(docs.startSession({ host: localHost(), target }))
+        .rejects.toThrow("Workspace revision archive root must not contain symlinks")
+      await expect(stat(join(target, "secret.txt"))).rejects.toMatchObject({ code: "ENOENT" })
+    }
+    finally {
+      await rm(archive.source, { force: true, recursive: true })
+      await rm(targetParent, { force: true, recursive: true })
+    }
+  })
+
+  it("keeps descriptor and live Source files on the source-aware fallback", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ status: "ok" }), {
+      headers: { "content-type": "application/json" },
+    }))
+    const store = createMemoryWorkspaceStore() as ReturnType<typeof createMemoryWorkspaceStore> & WorkspaceRevisionMaterializerCarrier
+    let archiveMaterializations = 0
+    store[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return "0123456789012345678901234567890123456789"
+      },
+      async materializeRevision() {
+        archiveMaterializations++
+        throw new Error("source-aware Workspace used its Store archive")
+      },
+    }
+    const docs = createWorkspace({
+      ...defineWorkspace({
+        sources: {
+          request: fetchSource({ url: "https://status.example.com/request" }),
+          status: fetchSource({ url: "https://status.example.com/live", workspacePath: "status.json" }),
+        },
+        store,
+      }),
+      name: "docs",
+    })
+
+    const session = await docs.startSession({ host: memoryHost() })
+    await expect(session.readFile("status.json")).resolves.toContain('"status": "ok"')
+    await expect(session.readFile(".vitehub/sources/request.json")).resolves.toContain("status.example.com/request")
+    expect(archiveMaterializations).toBe(0)
+    await session.close()
+    vi.restoreAllMocks()
+  })
+
+  it("rejects one concurrent publication after its pinned revision becomes stale", async () => {
+    const definition = { ...defineWorkspace({ store: { provider: "memory" } }), name: "docs" }
+    const firstWorkspace = createWorkspace(definition)
+    const secondWorkspace = createWorkspace(definition)
+    const archive = await revisionArchive()
+    const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-target-"))
+    let revision = "0123456789012345678901234567890123456789"
+    const materializer = {
+      async currentRevision() {
+        return revision
+      },
+      async materializeRevision(options?: { paths?: readonly string[] }) {
+        return {
+          ...(options?.paths ? {} : { archive: archive.bytes }),
+          files: 6,
+          paths: options?.paths,
+          revision,
+          root: ".vitehub/workspaces/docs",
+        }
+      },
+    }
+    ;(firstWorkspace as typeof firstWorkspace & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = materializer
+    ;(secondWorkspace as typeof secondWorkspace & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = materializer
+    const snapshot = firstWorkspace.snapshot.bind(firstWorkspace)
+    firstWorkspace.snapshot = async (options) => {
+      await new Promise(resolve => setTimeout(resolve, 20))
+      const result = await snapshot(options)
+      revision = result.id
+      return result
+    }
+
+    try {
+      await firstWorkspace.writeFile("README.md", "# Docs\n")
+      const first = await firstWorkspace.startSession({ host: localHost(), paths: ["README.md"], target: join(targetParent, "first") })
+      const second = await secondWorkspace.startSession({ host: localHost(), paths: ["README.md"], target: join(targetParent, "second") })
+      await first.writeFile("README.md", "first")
+      await second.writeFile("README.md", "second")
+
+      const firstPublication = first.commit({ message: "first" })
+      await new Promise(resolve => setTimeout(resolve, 1))
+      const publications = await Promise.allSettled([
+        firstPublication,
+        second.commit({ message: "second" }),
+      ])
+      expect(publications.filter(result => result.status === "fulfilled")).toHaveLength(1)
+      expect(publications.find(result => result.status === "rejected")).toMatchObject({
+        reason: { code: "WORKSPACE_CONFLICT" },
+      })
+      await first.writeFile("README.md", "again")
+      await expect(first.commit({ message: "again" })).resolves.toBeUndefined()
+      await first.close()
+      await second.close()
+    }
+    finally {
+      await rm(archive.source, { force: true, recursive: true })
+      await rm(targetParent, { force: true, recursive: true })
+    }
+  })
+
+  it("keeps the provider revision after a no-op publication", async () => {
+    const docs = workspace()
+    const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-target-"))
+    let revision = "0123456789012345678901234567890123456789"
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return revision
+      },
+      async materializeRevision() {
+        return { files: 0, revision, root: "" }
+      },
+    }
+    const snapshot = docs.snapshot.bind(docs)
+    let publications = 0
+    docs.snapshot = async (options) => {
+      const result = await snapshot(options)
+      if (++publications > 1) revision = result.id
+      return result
+    }
+
+    try {
+      const session = await docs.startSession({ host: localHost(), target: join(targetParent, "workspace") })
+      await session.mkdir("empty")
+      await expect(session.commit({ message: "empty directory" })).resolves.toBeUndefined()
+      await session.writeFile("result.txt", "done")
+      await expect(session.commit({ message: "file" })).resolves.toBeUndefined()
+      await expect(docs.readFile("result.txt")).resolves.toBe("done")
+      await session.close()
+    }
+    finally {
+      await rm(targetParent, { force: true, recursive: true })
+    }
+  })
+
+  it("does not follow a symlinked excluded ancestor during cleanup", async () => {
+    const docs = workspace()
+    await docs.writeFile("skills/foo/skill.md", "persisted")
+    await docs.snapshot({ name: "baseline" })
+    const host = localHost()
+    const targetParent = await mkdtemp(join(tmpdir(), "vitehub-session-target-"))
+    const target = join(targetParent, "workspace")
+    const outside = join(targetParent, "outside")
+    await mkdir(outside)
+    await writeFile(join(outside, "sentinel.txt"), "outside")
+
+    try {
+      const session = await docs.startSession({
+        host,
+        target,
+        writeBack: { exclude: ["skills/foo"] },
+      })
+      await host.exec("rm", ["-rf", join(target, "skills")])
+      await host.exec("ln", ["-s", outside, join(target, "skills")])
+      await session.close()
+
+      await expect(readFile(join(outside, "sentinel.txt"), "utf8")).resolves.toBe("outside")
+      await expect(readFile(join(target, "skills/foo/skill.md"), "utf8")).resolves.toBe("persisted")
+    }
+    finally {
+      await rm(targetParent, { force: true, recursive: true })
+    }
+  })
+
+  it("does not follow a symlinked attached ancestor during cleanup", async () => {
+    const docs = workspace()
+    const host = localHost()
+    const targetParent = await mkdtemp(join(tmpdir(), "vitehub-session-target-"))
+    const target = join(targetParent, "workspace")
+    const outside = join(targetParent, "outside")
+    await mkdir(join(target, "skills/foo"), { recursive: true })
+    await writeFile(join(target, "skills/foo/skill.md"), "attached")
+    await mkdir(outside)
+    await writeFile(join(outside, "sentinel.txt"), "outside")
+
+    try {
+      const session = await docs.startSession({ attach: true, host, target })
+      await host.exec("rm", ["-rf", join(target, "skills")])
+      await host.exec("ln", ["-s", outside, join(target, "skills")])
+      await session.close()
+
+      await expect(readFile(join(outside, "sentinel.txt"), "utf8")).resolves.toBe("outside")
+      await expect(readFile(join(target, "skills/foo/skill.md"), "utf8")).resolves.toBe("attached")
+    }
+    finally {
+      await rm(targetParent, { force: true, recursive: true })
+    }
+  })
+
+  it("replaces a symlinked Workspace root without touching its target", async () => {
+    const docs = workspace()
+    await docs.writeFile("README.md", "authoritative")
+    await docs.snapshot({ name: "baseline" })
+    const host = localHost()
+    const targetParent = await mkdtemp(join(tmpdir(), "vitehub-session-target-"))
+    const target = join(targetParent, "workspace")
+    const outside = join(targetParent, "outside")
+    await mkdir(outside)
+    await writeFile(join(outside, "sentinel.txt"), "outside")
+
+    try {
+      const session = await docs.startSession({ host, target })
+      await expect(host.exec("rm", ["-rf", target])).resolves.toMatchObject({ code: 0 })
+      await expect(host.exec("ln", ["-s", outside, target])).resolves.toMatchObject({ code: 0 })
+      await expect(host.exec("test", ["-L", target])).resolves.toMatchObject({ code: 0 })
+      await session.close()
+
+      await expect(readFile(join(outside, "sentinel.txt"), "utf8")).resolves.toBe("outside")
+      expect((await stat(target)).isDirectory()).toBe(true)
+      await expect(readFile(join(target, "README.md"), "utf8")).resolves.toBe("authoritative")
+    }
+    finally {
+      await rm(targetParent, { force: true, recursive: true })
+    }
+  })
+
+  it("excludes framework-owned runtime roots from hosted session write-back", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    const session = await docs.startSession({ host })
+
+    await session.exec("write", [".agent-runs/trace.json", "trace"])
+    await session.exec("write", [".vitehub/runtime.json", "runtime"])
+    await session.exec("write", ["result.txt", "done"])
+    await expect(session.diff()).resolves.toMatchObject({ entries: [{ path: "result.txt", type: "added" }] })
+    await session.commit({ message: "result" })
+    await session.close()
+
+    expect(host.readText("/workspace/.agent-runs/trace.json")).toBeUndefined()
+    expect(host.readText("/workspace/.vitehub/runtime.json")).toBeUndefined()
+    await expect(docs.readFile("result.txt")).resolves.toBe("done")
+    await expect(docs.exists(".agent-runs/trace.json")).resolves.toBe(false)
+    await expect(docs.list("", { recursive: true })).resolves.not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: ".vitehub/runtime.json" }),
+    ]))
+  })
+
+  it("preserves an excluded subtree when its parent is removed", async () => {
+    const docs = workspace()
+    await docs.writeFile("skills/persisted/skill.md", "persisted")
+    await docs.writeFile("skills/transient.md", "transient")
+    await docs.snapshot({ name: "baseline" })
+    const session = await docs.startSession({
+      host: memoryHost(),
+      writeBack: { exclude: ["skills/persisted"] },
+    })
+
+    await session.rm("skills", { recursive: true })
+    await session.commit({ message: "remove transient skills" })
+    await session.close()
+
+    await expect(docs.readFile("skills/persisted/skill.md")).resolves.toBe("persisted")
+    await expect(docs.exists("skills/transient.md")).resolves.toBe(false)
+  })
+
   it("discards an uncommitted basic session overlay", async () => {
     const docs = workspace()
     await docs.writeFile("README.md", "before")

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -946,6 +946,18 @@ describe("workspace host sessions", () => {
     expect(host.readText("/workspace/partial.txt")).toBeUndefined()
   })
 
+  it("preserves Git metadata when closing an attached Session", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    await host.files.mkdir("/workspace/.git", { recursive: true })
+    await host.files.write("/workspace/.git/config", new TextEncoder().encode("checkout"))
+
+    const session = await docs.startSession({ attach: true, host })
+    await session.close()
+
+    expect(host.readText("/workspace/.git/config")).toBe("checkout")
+  })
+
   it("restores excluded host state after an attached commit", async () => {
     const docs = workspace()
     const host = memoryHost()

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -732,6 +732,36 @@ describe("workspace host sessions", () => {
     expect(host.readText("/workspace/partial.txt")).toBeUndefined()
   })
 
+  it("restores a revision-backed host after the Session operation is canceled", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    const abort = new AbortController()
+    await docs.writeFile("README.md", "before")
+    await docs.snapshot({ name: "baseline" })
+    const materializeRevision = vi.fn(async (options?: { abortSignal?: AbortSignal }) => {
+      options?.abortSignal?.throwIfAborted()
+      return {
+        files: 1,
+        revision: "0123456789012345678901234567890123456789",
+        root: "",
+      }
+    })
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return "0123456789012345678901234567890123456789"
+      },
+      materializeRevision,
+    }
+
+    const session = await docs.startSession({ abortSignal: abort.signal, host })
+    await session.writeFile("README.md", "failed mutation")
+    abort.abort()
+    await expect(session.close()).resolves.toBeUndefined()
+
+    expect(host.readText("/workspace/README.md")).toBe("before")
+    expect(materializeRevision).toHaveBeenLastCalledWith(expect.objectContaining({ abortSignal: undefined }))
+  })
+
   it("keeps unsafe symlinks inert and rejects writes through symlink parents", async () => {
     const docs = workspace()
     const host = memoryHost()

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -517,6 +517,38 @@ describe("workspace host sessions", () => {
     }
   })
 
+  it("does not report cancellation after publication has succeeded", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    const abort = new AbortController()
+    let revision = "0123456789012345678901234567890123456789"
+    const currentRevision = vi.fn(async (options?: { abortSignal?: AbortSignal }) => {
+      options?.abortSignal?.throwIfAborted()
+      return revision
+    })
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      currentRevision,
+      async materializeRevision() {
+        return { files: 0, revision, root: "" }
+      },
+    }
+    const snapshot = docs.snapshot.bind(docs)
+    docs.snapshot = async (options) => {
+      const result = await snapshot(options)
+      revision = result.id
+      abort.abort()
+      return result
+    }
+
+    const session = await docs.startSession({ abortSignal: abort.signal, host })
+    await session.writeFile("result.txt", "done")
+    await expect(session.commit({ message: "published" })).resolves.toBeUndefined()
+
+    await expect(docs.readFile("result.txt")).resolves.toBe("done")
+    expect(currentRevision).toHaveBeenLastCalledWith({ refresh: false })
+    await session.close()
+  })
+
   it("keeps the provider revision after a no-op publication", async () => {
     const docs = workspace()
     const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-target-"))
@@ -844,6 +876,20 @@ describe("workspace host sessions", () => {
     expect(host.readText("/workspace/result.txt")).toBe("committed")
     await expect(docs.exists(".agent-runs/trace.json")).resolves.toBe(false)
     await expect(docs.readFile("result.txt")).resolves.toBe("committed")
+  })
+
+  it("restores excluded state that existed before non-attached materialization", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    await host.files.mkdir("/workspace/.agent-runs", { recursive: true })
+    await host.files.write("/workspace/.agent-runs/trace.json", new TextEncoder().encode("before"))
+
+    const session = await docs.startSession({ host })
+    await session.writeFile("result.txt", "discarded")
+    await session.close()
+
+    expect(host.readText("/workspace/.agent-runs/trace.json")).toBe("before")
+    expect(host.readText("/workspace/result.txt")).toBeUndefined()
   })
 
   it("keeps concurrent host changes outside an attached session scope", async () => {

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -471,6 +471,28 @@ describe("workspace host sessions", () => {
     expect(host.readText("/workspace/README.md")).toBe("authoritative")
   })
 
+  it("leaves an unmodified host alone when revision resolution is canceled", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    const abort = new AbortController()
+    await host.files.mkdir("/workspace", { recursive: true })
+    await host.files.write("/workspace/local.txt", new TextEncoder().encode("untouched"))
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return "0123456789012345678901234567890123456789"
+      },
+      async materializeRevision() {
+        abort.abort()
+        abort.signal.throwIfAborted()
+        throw new Error("unreachable")
+      },
+    }
+
+    await expect(docs.startSession({ abortSignal: abort.signal, host })).rejects.toThrow()
+
+    expect(host.readText("/workspace/local.txt")).toBe("untouched")
+  })
+
   it("bounds host file reads while capturing Session state", async () => {
     const docs = workspace()
     const host = memoryHost()
@@ -742,6 +764,34 @@ describe("workspace host sessions", () => {
 
     await expect(docs.readFile("result.txt")).resolves.toBe("done")
     expect(currentRevision).toHaveBeenLastCalledWith({ refresh: false })
+    await session.close()
+  })
+
+  it("does not inspect the host after publication has succeeded", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    await docs.writeFile("README.md", "before")
+    await docs.snapshot({ name: "baseline" })
+    const list = host.files.list.bind(host.files)
+    let rejectInspection = false
+    host.files.list = async (...args) => {
+      if (rejectInspection) throw new Error("host inspection unavailable")
+      return await list(...args)
+    }
+    const snapshot = docs.snapshot.bind(docs)
+    docs.snapshot = async (options) => {
+      const result = await snapshot(options)
+      rejectInspection = true
+      return result
+    }
+
+    const session = await docs.startSession({ host })
+    await session.writeFile("README.md", "after")
+    await expect(session.commit({ message: "published" })).resolves.toBeUndefined()
+    await expect(docs.readFile("README.md")).resolves.toBe("after")
+
+    rejectInspection = false
+    await expect(session.diff()).resolves.toMatchObject({ entries: [] })
     await session.close()
   })
 

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -798,6 +798,24 @@ describe("workspace host sessions", () => {
     expect(host.readText("/workspace/partial.txt")).toBeUndefined()
   })
 
+  it("restores excluded host state after an attached commit", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    await host.files.mkdir("/workspace/.agent-runs", { recursive: true })
+    await host.files.write("/workspace/.agent-runs/trace.json", new TextEncoder().encode("before"))
+
+    const session = await docs.startSession({ attach: true, host })
+    await session.writeFile(".agent-runs/trace.json", "invocation")
+    await session.writeFile("result.txt", "committed")
+    await session.commit({ message: "result" })
+    await session.close()
+
+    expect(host.readText("/workspace/.agent-runs/trace.json")).toBe("before")
+    expect(host.readText("/workspace/result.txt")).toBe("committed")
+    await expect(docs.exists(".agent-runs/trace.json")).resolves.toBe(false)
+    await expect(docs.readFile("result.txt")).resolves.toBe("committed")
+  })
+
   it("keeps concurrent host changes outside an attached session scope", async () => {
     const docs = workspace()
     const host = memoryHost()

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -976,6 +976,26 @@ describe("workspace host sessions", () => {
     await expect(docs.readFile("result.txt")).resolves.toBe("committed")
   })
 
+  it("restores excluded host state when attached rollback fails", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    await host.files.mkdir("/workspace/.agent-runs", { recursive: true })
+    await host.files.write("/workspace/.agent-runs/trace.json", new TextEncoder().encode("before"))
+    await host.files.write("/workspace/live.txt", new TextEncoder().encode("before"))
+
+    const session = await docs.startSession({ attach: true, host })
+    await session.writeFile(".agent-runs/trace.json", "invocation")
+    await session.writeFile("live.txt", "invocation")
+    const remove = host.files.remove.bind(host.files)
+    host.files.remove = async (path, options) => {
+      if (path === "/workspace/live.txt") throw new Error("attached rollback unavailable")
+      await remove(path, options)
+    }
+
+    await expect(session.close()).rejects.toThrow("attached rollback unavailable")
+    expect(host.readText("/workspace/.agent-runs/trace.json")).toBe("before")
+  })
+
   it("restores excluded state that existed before non-attached materialization", async () => {
     const docs = workspace()
     const host = memoryHost()

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -695,6 +695,46 @@ describe("workspace host sessions", () => {
     }
   })
 
+  it("cancels a Session waiting for the publication queue", async () => {
+    const docs = workspace()
+    const abort = new AbortController()
+    let revision = "0123456789012345678901234567890123456789"
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return revision
+      },
+      async materializeRevision() {
+        return { files: 1, revision, root: "" }
+      },
+    }
+    await docs.writeFile("README.md", "before")
+    await docs.snapshot({ name: "baseline" })
+    const first = await docs.startSession({ host: memoryHost() })
+    const second = await docs.startSession({ abortSignal: abort.signal, host: memoryHost() })
+    await first.writeFile("README.md", "first")
+    await second.writeFile("README.md", "second")
+    const snapshot = docs.snapshot.bind(docs)
+    let release!: () => void
+    const blocked = new Promise<void>((resolve) => { release = resolve })
+    docs.snapshot = async (options) => {
+      await blocked
+      const result = await snapshot(options)
+      revision = result.id
+      return result
+    }
+
+    const firstPublication = first.commit({ message: "first" })
+    await new Promise(resolve => setTimeout(resolve, 1))
+    const secondPublication = second.commit({ message: "second" })
+    abort.abort()
+
+    await expect(secondPublication).rejects.toThrow()
+    release()
+    await expect(firstPublication).resolves.toBeUndefined()
+    await first.close()
+    await second.close()
+  })
+
   it("rolls back staged Session changes when provider publication fails", async () => {
     const docs = workspace()
     const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-target-"))
@@ -792,6 +832,38 @@ describe("workspace host sessions", () => {
 
     rejectInspection = false
     await expect(session.diff()).resolves.toMatchObject({ entries: [] })
+    await session.close()
+  })
+
+  it("publishes from the same host capture used by the Session baseline", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    let revision = "0123456789012345678901234567890123456789"
+    let revisionReads = 0
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        if (++revisionReads > 1) await host.files.write("/workspace/README.md", new TextEncoder().encode("later"))
+        return revision
+      },
+      async materializeRevision() {
+        return { files: 1, revision, root: "" }
+      },
+    }
+    await docs.writeFile("README.md", "before")
+    await docs.snapshot({ name: "baseline" })
+    const snapshot = docs.snapshot.bind(docs)
+    docs.snapshot = async (options) => {
+      const result = await snapshot(options)
+      revision = result.id
+      return result
+    }
+
+    const session = await docs.startSession({ host })
+    await session.writeFile("README.md", "captured")
+    await session.commit({ message: "published" })
+
+    await expect(docs.readFile("README.md")).resolves.toBe("captured")
+    await expect(session.diff()).resolves.toMatchObject({ entries: [expect.objectContaining({ path: "README.md" })] })
     await session.close()
   })
 
@@ -1008,6 +1080,60 @@ describe("workspace host sessions", () => {
     await expect(docs.exists("partial.txt")).resolves.toBe(false)
     expect(host.readText("/workspace/README.md")).toBe("before")
     expect(host.readText("/workspace/partial.txt")).toBeUndefined()
+  })
+
+  it("refreshes an unchanged host when the authoritative revision advances", async () => {
+    const docs = workspace()
+    const firstHost = memoryHost()
+    let revision = "0123456789012345678901234567890123456789"
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return revision
+      },
+      async materializeRevision() {
+        return { files: 1, revision, root: "" }
+      },
+    }
+    await docs.writeFile("README.md", "before")
+    await docs.snapshot({ name: "baseline" })
+    const first = await docs.startSession({ host: firstHost })
+    const second = await docs.startSession({ host: memoryHost() })
+    const snapshot = docs.snapshot.bind(docs)
+    docs.snapshot = async (options) => {
+      const result = await snapshot(options)
+      revision = result.id
+      return result
+    }
+    await second.writeFile("README.md", "after")
+    await second.commit({ message: "advance" })
+
+    await first.close()
+
+    expect(firstHost.readText("/workspace/README.md")).toBe("after")
+    await second.close()
+  })
+
+  it("restores excluded state when close-time diff inspection fails", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    await docs.writeFile("README.md", "before")
+    await docs.snapshot({ name: "baseline" })
+    const session = await docs.startSession({ host })
+    await host.files.mkdir("/workspace/.agent-runs", { recursive: true })
+    await host.files.write("/workspace/.agent-runs/trace.json", new TextEncoder().encode("transient"))
+    const list = host.files.list.bind(host.files)
+    let failOnce = true
+    host.files.list = async (...args) => {
+      if (failOnce) {
+        failOnce = false
+        throw new Error("host inspection unavailable")
+      }
+      return await list(...args)
+    }
+
+    await expect(session.close()).rejects.toThrow("host inspection unavailable")
+
+    expect(host.readText("/workspace/.agent-runs/trace.json")).toBeUndefined()
   })
 
   it("restores a revision-backed host after the Session operation is canceled", async () => {

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -103,6 +103,14 @@ async function symlinkRootRevisionArchive() {
   return { bytes: new Uint8Array(await readFile(archive)), source }
 }
 
+async function traversalRevisionArchive() {
+  const source = await mkdtemp(join(tmpdir(), "vitehub-revision-traversal-"))
+  await writeFile(join(source, "payload"), "escaped")
+  const archive = join(source, "revision.tar.gz")
+  await execFileAsync("tar", ["-czf", archive, "--transform=s|payload|../escape|", "-C", source, "payload"])
+  return { bytes: new Uint8Array(await readFile(archive)), source }
+}
+
 function memoryHost(): WorkspaceSessionHost & { isExecutable(path: string): boolean, readText(path: string): string | undefined } {
   const files = new Map<string, Uint8Array>()
   const directories = new Set<string>(["/"])
@@ -339,6 +347,36 @@ describe("workspace host sessions", () => {
       await expect(docs.startSession({ host: localHost(), target }))
         .rejects.toThrow("Workspace revision archive root must not contain symlinks")
       await expect(stat(join(target, "secret.txt"))).rejects.toMatchObject({ code: "ENOENT" })
+    }
+    finally {
+      await rm(archive.source, { force: true, recursive: true })
+      await rm(targetParent, { force: true, recursive: true })
+    }
+  })
+
+  it("rejects revision archive traversal before extraction", async () => {
+    const docs = workspace()
+    const archive = await traversalRevisionArchive()
+    const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-target-"))
+    const target = join(targetParent, "workspace")
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return "0123456789012345678901234567890123456789"
+      },
+      async materializeRevision() {
+        return {
+          archive: archive.bytes,
+          files: 1,
+          revision: "0123456789012345678901234567890123456789",
+          root: "",
+        }
+      },
+    }
+
+    try {
+      await expect(docs.startSession({ host: localHost(), target }))
+        .rejects.toThrow("Workspace revision archive contains an unsafe path")
+      await expect(stat(join(target, "escape"))).rejects.toMatchObject({ code: "ENOENT" })
     }
     finally {
       await rm(archive.source, { force: true, recursive: true })

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -356,6 +356,45 @@ describe("workspace host sessions", () => {
     }
   })
 
+  it("stops fallback materialization when preparation is canceled", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    const abort = new AbortController()
+    await docs.writeFile("README.md", "authoritative")
+    await docs.snapshot({ name: "baseline" })
+
+    await expect(docs.startSession({
+      abortSignal: abort.signal,
+      host,
+      onProgress(event) {
+        if (event.id === "workspace.prepare.read-files" && event.status === "started") abort.abort()
+      },
+    })).rejects.toThrow()
+
+    expect(host.readText("/workspace/README.md")).toBe("authoritative")
+  })
+
+  it("restores the host when post-materialization excluded-state capture fails", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    await host.files.mkdir("/workspace/.agent-runs", { recursive: true })
+    await host.files.write("/workspace/.agent-runs/trace.json", new TextEncoder().encode("before"))
+    await docs.writeFile("README.md", "authoritative")
+    await docs.snapshot({ name: "baseline" })
+    const list = host.files.list.bind(host.files)
+    let workspaceLists = 0
+    host.files.list = async (path, options) => {
+      if (path === "/workspace" && ++workspaceLists === 3)
+        throw new Error("excluded-state capture unavailable")
+      return await list(path, options)
+    }
+
+    await expect(docs.startSession({ host })).rejects.toThrow("excluded-state capture unavailable")
+
+    expect(host.readText("/workspace/.agent-runs/trace.json")).toBe("before")
+    expect(host.readText("/workspace/README.md")).toBe("authoritative")
+  })
+
   it("rejects a pinned revision whose configured root is a symlink", async () => {
     const docs = workspace()
     const archive = await symlinkRootRevisionArchive()

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1245,6 +1245,8 @@ describe("workspace host sessions", () => {
 
     await expect(docs.readFile("escape")).resolves.toBe("../../outside")
     await expect(docs.stat("escape")).resolves.toMatchObject({ metadata: undefined })
+    await expect(session.diff()).resolves.toMatchObject({ entries: [] })
+    await expect(session.commit({ message: "no-op" })).resolves.toBeUndefined()
     await session.close()
     expect(host.readText("/workspace/escape")).toBe("../../outside")
     await expect(session.commit({ message: "too late" })).rejects.toThrow("already closed")

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -439,6 +439,46 @@ describe("workspace host sessions", () => {
     }
   })
 
+  it("rolls back staged Session changes when provider publication fails", async () => {
+    const docs = workspace()
+    const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-target-"))
+    let revision = "0123456789012345678901234567890123456789"
+    ;(docs as typeof docs & WorkspaceRevisionMaterializerCarrier)[workspaceRevisionMaterializer] = {
+      async currentRevision() {
+        return revision
+      },
+      async materializeRevision() {
+        return { files: 1, revision, root: "" }
+      },
+    }
+
+    try {
+      await docs.writeFile("README.md", "authoritative")
+      await docs.snapshot({ name: "baseline" })
+      const session = await docs.startSession({ host: localHost(), paths: ["README.md"], target: join(targetParent, "workspace") })
+      const snapshot = docs.snapshot.bind(docs)
+      const rebase = vi.fn(async (options?: { takeRemote?: string[] }) => {
+        expect(options).toEqual({ takeRemote: ["README.md"] })
+        await docs.writeFile("README.md", "authoritative")
+        revision = (await snapshot({ name: "provider-rollback" })).id
+      })
+      docs.snapshot = async () => {
+        revision = "remote-advanced"
+        throw new Error("provider conflict after staging")
+      }
+      docs.rebase = rebase
+
+      await session.writeFile("README.md", "failed invocation")
+      await expect(session.commit({ message: "conflict" })).rejects.toThrow("provider conflict after staging")
+      await expect(docs.readFile("README.md")).resolves.toBe("authoritative")
+      expect(rebase).toHaveBeenCalledOnce()
+      await session.close()
+    }
+    finally {
+      await rm(targetParent, { force: true, recursive: true })
+    }
+  })
+
   it("keeps the provider revision after a no-op publication", async () => {
     const docs = workspace()
     const targetParent = await mkdtemp(join(tmpdir(), "vitehub-revision-target-"))

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -560,6 +560,21 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
         "@vite-hub/workspace",
       ]))
       await Promise.all([
+        writeFile(join(appDir, "index.ts"), `
+          import { createWorkspace } from "@vite-hub/workspace"
+          import type { WorkspacePrepareSessionProgressEvent, WorkspaceSessionHost } from "@vite-hub/workspace"
+
+          declare const host: WorkspaceSessionHost
+          const workspace = createWorkspace({ name: "packed-consumer" })
+          void workspace.startSession({
+            abortSignal: new AbortController().signal,
+            host,
+            onProgress(event: WorkspacePrepareSessionProgressEvent) {
+              console.log(event.id, event.durationMs, event.data?.bytes, event.data?.files)
+            },
+            writeBack: { exclude: [".consumer-cache"] },
+          })
+        `, "utf8"),
         writeFile(join(appDir, "package.json"), JSON.stringify({
           dependencies: {
             "@vite-hub/workspace": specs["@vite-hub/workspace"],
@@ -571,6 +586,19 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
         writeFile(join(appDir, "pnpm-workspace.yaml"), workspaceConfig(specs), "utf8"),
       ])
       await run("pnpm", ["install", "--no-hoist", "--strict-peer-dependencies"], appDir)
+      await run(process.execPath, [
+        resolve(repoRoot, "node_modules/typescript/bin/tsc"),
+        "--module",
+        "NodeNext",
+        "--moduleResolution",
+        "NodeNext",
+        "--noEmit",
+        "--skipLibCheck",
+        "--strict",
+        "--target",
+        "ESNext",
+        "index.ts",
+      ], appDir)
       const missingShell = await run("node", ["--input-type=module", "--eval", `
         import { createWorkspaceTools } from "@vite-hub/workspace/ai"
         let shellResolved = true


### PR DESCRIPTION
GitHub Workspace preparation currently downloads every selected blob separately, rebuilds an archive, and synthesizes a new Git baseline before each invocation. A full 856-file Workspace therefore scales with file count and can fail because any one raw-file request fails, even though GitHub already exposes the exact revision as one archive.

This moves revision-aware materialization into the Workspace Session boundary. Clean full-tree GitHub Sessions now resolve the authoritative commit first and fetch one codeload archive pinned to that SHA; scoped or dirty Sessions keep the proportional Store path while carrying the same base revision into publication conflict checks. Immutable blob bytes and revision archives survive unchanged refreshes, and every invocation still gets an isolated mutable host tree.

The old harness-owned tar/raw-file/synthetic-Git pipeline is removed. Workspace preparation now reports its existing phases with timing, file, and byte evidence through the Agent trace/run-event path, and hosted write-back excludes framework-owned runtime roots. Archive extraction and rollback also fail closed around traversal, unsafe symlinks, replaced Workspace roots, cancellation, failed publication, excluded or attached paths, and setup cleanup.

## Verification

- `packages/workspace: pnpm --filter @vite-hub/workspace test` — 37 files, 508 tests, no type errors.
- `packages/agent: pnpm --filter @vite-hub/agent test -- --run test/box.test.ts` — 10 focused Box lifecycle tests passed.
- `packages/workspace: pnpm exec vp pack` and `packages/agent: pnpm exec vp pack` — builds and publint pass.
- Packed `@vite-hub/workspace` consumer install/type/runtime contract passes from generated tarballs.
- Changed-file `oxlint` passes with the existing `no-control-regex` warning in the GitHub Store; `git diff --check` passes.
- Deterministic regressions prove one archive request for a full revision, no archive request for scoped preparation, unchanged archive/blob reuse, bounded idempotent retries, stale-base conflicts, same-revision publication rollback, repeat publication, modes/symlinks, cancellation and acquisition cleanup, and progress evidence.

## Boundaries

This does not add a persistent bare Git object cache or detached-worktree tier because Workspace hosts do not yet expose a provider-neutral cache lifecycle. The network-scaling proof is deterministic and mock-backed rather than a live run against the private 378 MB Bitacora repository, and packed-consumer proof covers package/type boundaries rather than a hosted provider invocation.
