### PR TITLE
fix(schedule): discover Nuxt server suffix definitions

### DIFF
--- a/packages/schedule/src/discovery.ts
+++ b/packages/schedule/src/discovery.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs"
-import { resolve } from "node:path"
+import { isAbsolute, relative, resolve, sep } from "node:path"
 
 import {
   createDirectoryDefinitionSource,
@@ -62,13 +62,25 @@ export function discoverScheduleDefinitions(options:
   const serverRoots = resolveDefinitionScanRoots(options.serverRootDir || options.rootDir, options.scanDirs)
   const serverScanDirs = options.serverDirs ?? serverRoots.map(root => resolve(root, "server"))
 
+  for (const directory of serverScanDirs) {
+    if (roots.every((root) => {
+      const path = relative(resolve(root), resolve(directory))
+      return path === ".." || path.startsWith(`..${sep}`) || isAbsolute(path)
+    })) {
+      roots.push(directory)
+    }
+  }
+
   return mergeDefinitions(
     "schedule",
     discoverDefinitions("schedule", [
       createSuffixDefinitionSource("vite-suffix", roots, scheduleSuffixPattern, normalizeSuffixScheduleName, {
         createDefinition: createDiscoveredScheduleDefinition("vite-suffix"),
       }),
-    ]),
+    ]).filter(definition => !serverScanDirs.some((directory) => {
+      const path = relative(resolve(directory, "schedules"), definition.handler)
+      return path !== ".." && !path.startsWith(`..${sep}`) && !isAbsolute(path)
+    })),
     discoverDefinitions("schedule", [
       createDirectoryDefinitionSource("server-schedules", serverScanDirs, "schedules", {
         createDefinition: createDiscoveredScheduleDefinition("server-schedules"),

--- a/packages/schedule/test/discovery.test.ts
+++ b/packages/schedule/test/discovery.test.ts
@@ -77,6 +77,24 @@ describe("discoverScheduleDefinitions", () => {
     ])
   })
 
+  it("discovers suffix schedules in a sibling Nuxt server directory", async () => {
+    const rootDir = await createTempDir("vitehub-schedule-nuxt-server-discovery-")
+    const appDir = join(rootDir, "app")
+    const serverDir = join(rootDir, "server")
+    await mkdir(join(serverDir, "schedules"), { recursive: true })
+    await writeFile(join(serverDir, "monthly.schedule.ts"), "export default null\n", "utf8")
+    await writeFile(join(serverDir, "schedules", "daily.schedule.ts"), "export default null\n", "utf8")
+
+    expect(discoverScheduleDefinitions({
+      rootDir: appDir,
+      serverDirs: [serverDir],
+      serverRootDir: rootDir,
+    })).toMatchObject([
+      { name: "daily.schedule", source: "server-schedules" },
+      { name: "monthly", source: "vite-suffix" },
+    ])
+  })
+
   it("does not parse defineSchedule options to override discovery identity", async () => {
     const rootDir = await createTempDir("vitehub-schedule-ignore-inline-id-")
     await writeFile(


### PR DESCRIPTION
Nuxt can use `app/` as its Vite root while keeping Nitro definitions in the sibling `server/` directory. Schedule suffix discovery only scanned the Vite root, so `server/monthly.schedule.ts` was silently omitted and no provider cron was generated.

This includes resolved server directories when they sit outside the existing Vite scan roots, while excluding `server/schedules/` from suffix discovery so the directory convention remains owned by its existing source.

## Verification

- `pnpm --filter @vite-hub/schedule test` — 198 tests passed
- Packed Nuxt Cloudflare consumer imports `server/monthly.schedule.ts` in the generated registry, emits `0 8 1 * *` in the final Wrangler config, includes the `cloudflare:scheduled` hook, and excludes the MCP/PKCE dependency closure.