### PR TITLE
fix(agent): rebase conflicting workspace commits

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2642,13 +2642,20 @@ async function commitWorkspaceChanges<
   if (!context.workspaceDefinition || !isWritableWorkspaceFacade(context.workspace)) return
 
   const diff = await context.workspace.diff()
-  const { resolveWorkspaceAutoCommit } = await import("@vite-hub/workspace")
+  const { isWorkspaceConflict, resolveWorkspaceAutoCommit } = await import("@vite-hub/workspace")
   const commit = resolveWorkspaceAutoCommit(
     workspaceDefinitionWithAutoCommitRules(context.workspaceDefinition, context.workspaceAutoCommit),
     diff,
   )
   if (!commit) return
-  await context.workspace.snapshot({ name: commit.message })
+  try {
+    await context.workspace.snapshot({ name: commit.message })
+  }
+  catch (error) {
+    if (!isWorkspaceConflict(error)) throw error
+    await context.workspace.history.rebase()
+    await context.workspace.snapshot({ name: commit.message })
+  }
 }
 
 async function applyFinalOutputRenderers<

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2648,13 +2648,15 @@ async function commitWorkspaceChanges<
     diff,
   )
   if (!commit) return
-  try {
-    await context.workspace.snapshot({ name: commit.message })
-  }
-  catch (error) {
-    if (!isWorkspaceConflict(error)) throw error
-    await context.workspace.history.rebase()
-    await context.workspace.snapshot({ name: commit.message })
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await context.workspace.snapshot({ name: commit.message })
+      return
+    }
+    catch (error) {
+      if (!isWorkspaceConflict(error) || attempt >= 2) throw error
+      await context.workspace.history.rebase()
+    }
   }
 }
 

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -2933,7 +2933,7 @@ describe("defineAgent workspace option", () => {
     expect(snapshot).toHaveBeenCalledWith({ name: "chore: archive audio" })
   })
 
-  it("rebases and retries a conflicting Workspace auto-commit", async () => {
+  it("rebases and retries racing Workspace auto-commits", async () => {
     diff.mockResolvedValueOnce({
       entries: [{ after: { type: "file" }, path: "inbox/audio.md", type: "added" }],
       to: "next",
@@ -2942,7 +2942,9 @@ describe("defineAgent workspace option", () => {
       message: "chore: archive audio",
       paths: ["inbox/audio.md"],
     })
-    snapshot.mockRejectedValueOnce(new ViteHubError("WORKSPACE_CONFLICT", "Remote Workspace changed."))
+    snapshot
+      .mockRejectedValueOnce(new ViteHubError("WORKSPACE_CONFLICT", "Remote Workspace changed."))
+      .mockRejectedValueOnce(new ViteHubError("WORKSPACE_CONFLICT", "Remote Workspace changed again."))
     const { defineAgent, runAgent } = await import("../src/index.ts")
 
     const agent = withExplicitWorkspaceName(defineAgent({
@@ -2952,9 +2954,33 @@ describe("defineAgent workspace option", () => {
 
     await expect(runAgent(agent, context(), { messages: [] })).resolves.toBe("ok")
 
-    expect(rebase).toHaveBeenCalledOnce()
-    expect(snapshot).toHaveBeenCalledTimes(2)
-    expect(snapshot).toHaveBeenNthCalledWith(2, { name: "chore: archive audio" })
+    expect(rebase).toHaveBeenCalledTimes(2)
+    expect(snapshot).toHaveBeenCalledTimes(3)
+    expect(snapshot).toHaveBeenNthCalledWith(3, { name: "chore: archive audio" })
+  })
+
+  it("bounds conflicting Workspace auto-commit retries", async () => {
+    diff.mockResolvedValueOnce({
+      entries: [{ after: { type: "file" }, path: "inbox/audio.md", type: "added" }],
+      to: "next",
+    })
+    resolveWorkspaceAutoCommit.mockReturnValueOnce({
+      message: "chore: archive audio",
+      paths: ["inbox/audio.md"],
+    })
+    snapshot.mockRejectedValue(new ViteHubError("WORKSPACE_CONFLICT", "Remote Workspace changed."))
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+
+    const agent = withExplicitWorkspaceName(defineAgent({
+      workspace: { commit: "chore: archive audio", mode: "write" },
+      driver: { run: () => "ok" },
+    }), { workspace: "docs" })
+
+    await expect(runAgent(agent, context(), { messages: [] }))
+      .rejects.toMatchObject({ code: "WORKSPACE_CONFLICT" })
+
+    expect(rebase).toHaveBeenCalledTimes(2)
+    expect(snapshot).toHaveBeenCalledTimes(3)
   })
 
   it("turns workspace commit into a default auto-commit rule", async () => {

--- a/packages/agent/test/workspace.test.ts
+++ b/packages/agent/test/workspace.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
-import { createTraceEventLog, noExecutionAuthority, unknownExecutionAuthority } from "@vite-hub/runtime"
+import { createTraceEventLog, noExecutionAuthority, unknownExecutionAuthority, ViteHubError } from "@vite-hub/runtime"
 
 import type { ReadonlyWorkspaceFacade, WritableWorkspaceFacade, WorkspaceSource, WorkspaceSourceInput } from "@vite-hub/workspace"
 
@@ -13,6 +13,7 @@ const list = vi.fn()
 const exists = vi.fn()
 const stat = vi.fn()
 const diff = vi.fn()
+const rebase = vi.fn()
 const snapshot = vi.fn()
 const tools = vi.fn(() => ({}))
 const inspectTools = vi.fn(() => ({}))
@@ -28,6 +29,7 @@ const tempRoots: string[] = []
 const useWorkspace = vi.fn<(name: string, options?: Record<string, unknown>) => ReadonlyWorkspaceFacade | WritableWorkspaceFacade>(() => ({
   diff,
   fs: { exists, list, readFile, stat, writeFile },
+  history: { rebase },
   snapshot,
   tools: Object.assign(tools, {
     inspect: inspectTools,
@@ -218,6 +220,7 @@ describe("defineAgent workspace option", () => {
     list.mockReset()
     list.mockResolvedValue([])
     readFile.mockReset()
+    rebase.mockReset()
     writeFile.mockReset()
     snapshot.mockReset()
     resolveRegisteredWorkspaceDefinition.mockReset()
@@ -2928,6 +2931,30 @@ describe("defineAgent workspace option", () => {
       expect.objectContaining({ entries: [expect.objectContaining({ path: "inbox/audio.md" })] }),
     )
     expect(snapshot).toHaveBeenCalledWith({ name: "chore: archive audio" })
+  })
+
+  it("rebases and retries a conflicting Workspace auto-commit", async () => {
+    diff.mockResolvedValueOnce({
+      entries: [{ after: { type: "file" }, path: "inbox/audio.md", type: "added" }],
+      to: "next",
+    })
+    resolveWorkspaceAutoCommit.mockReturnValueOnce({
+      message: "chore: archive audio",
+      paths: ["inbox/audio.md"],
+    })
+    snapshot.mockRejectedValueOnce(new ViteHubError("WORKSPACE_CONFLICT", "Remote Workspace changed."))
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+
+    const agent = withExplicitWorkspaceName(defineAgent({
+      workspace: { commit: "chore: archive audio", mode: "write" },
+      driver: { run: () => "ok" },
+    }), { workspace: "docs" })
+
+    await expect(runAgent(agent, context(), { messages: [] })).resolves.toBe("ok")
+
+    expect(rebase).toHaveBeenCalledOnce()
+    expect(snapshot).toHaveBeenCalledTimes(2)
+    expect(snapshot).toHaveBeenNthCalledWith(2, { name: "chore: archive audio" })
   })
 
   it("turns workspace commit into a default auto-commit rule", async () => {


### PR DESCRIPTION
## Problem

Two or more simultaneous Agent messages can write disjoint artifacts to the same GitHub-backed Workspace. They load the same branch head; as commits advance the branch, a later Agent's automatic commit can throw `WORKSPACE_CONFLICT` and replace an otherwise valid reply with the Channel fallback.

## Change

When automatic Workspace commit hits `WORKSPACE_CONFLICT`, rebase through the existing conflict-aware Workspace history boundary and retry the snapshot with a bounded three-attempt policy. Disjoint writes survive repeated branch advances; overlapping path changes still fail during rebase, and persistent races still fail closed after the bound.

## Verification

- `pnpm exec vp test test/workspace.test.ts` (174 passed)
- `pnpm run typecheck`
- `pnpm run build`