### PR TITLE
fix(markdown-template): render scalar bindings in Markdown links

### DIFF
--- a/docs/content/docs/reference/markdown-templates.md
+++ b/docs/content/docs/reference/markdown-templates.md
@@ -113,7 +113,7 @@ Title: Refine navigation
 
 | Syntax | Purpose | Behavior |
 | --- | --- | --- |
-| `{{ path.to.value }}` | Scalar binding | Accepts a string, number, or boolean and escapes Markdown syntax in the value. Missing paths and non-scalar values fail rendering. |
+| `{{ path.to.value }}` | Scalar binding | Accepts a string, number, or boolean and escapes Markdown syntax in the value. A scalar may occupy a complete inline link destination, such as `[Open]({{ url }})`; unsafe destinations fail rendering. Missing paths and non-scalar values fail rendering. |
 | `{{{ path.to.markdown }}}` | Markdown fragment | Inserts trusted Markdown without evaluating bindings, conditions, or imports inside the fragment again. Block Markdown is rejected when the binding appears in an inline position. |
 | `::if{condition}` | Conditional section | Selects an `if`, `else-if`, or `else` branch. Conditions support data paths, literals, `!`, equality and inequality (`===`, `!==`, `==`, and `!=` use strict semantics), `&&`, <code>&#124;&#124;</code>, and parentheses. |
 | `@./relative.md` | Template import | Calls `resolveImport` for a relative file. Absolute paths, URLs, and globs are rejected. |

--- a/docs/content/docs/reference/markdown-templates.md
+++ b/docs/content/docs/reference/markdown-templates.md
@@ -113,7 +113,7 @@ Title: Refine navigation
 
 | Syntax | Purpose | Behavior |
 | --- | --- | --- |
-| `{{ path.to.value }}` | Scalar binding | Accepts a string, number, or boolean and escapes Markdown syntax in the value. A scalar may occupy a complete inline link destination, such as `[Open]({{ url }})`; unsafe destinations fail rendering. Missing paths and non-scalar values fail rendering. |
+| `{{ path.to.value }}` | Scalar binding | Accepts a string, number, or boolean and escapes Markdown syntax in the value. A scalar may occupy a complete inline link destination, such as `[Open]({{ url }})`; unsafe destinations and values whose URL meaning cannot be preserved fail rendering. Missing paths and non-scalar values fail rendering. |
 | `{{{ path.to.markdown }}}` | Markdown fragment | Inserts trusted Markdown without evaluating bindings, conditions, or imports inside the fragment again. Block Markdown is rejected when the binding appears in an inline position. |
 | `::if{condition}` | Conditional section | Selects an `if`, `else-if`, or `else` branch. Conditions support data paths, literals, `!`, equality and inequality (`===`, `!==`, `==`, and `!=` use strict semantics), `&&`, <code>&#124;&#124;</code>, and parentheses. |
 | `@./relative.md` | Template import | Calls `resolveImport` for a relative file. Absolute paths, URLs, and globs are rejected. |

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -55,7 +55,6 @@
   "devDependencies": {
     "@types/node": "catalog:tooling",
     "@vite-hub/internal": "workspace:*",
-    "parse5": "8.0.1",
     "publint": "catalog:tooling",
     "typescript": "catalog:tooling",
     "vite": "catalog:vite",

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@types/node": "catalog:tooling",
     "@vite-hub/internal": "workspace:*",
+    "parse5": "8.0.1",
     "publint": "catalog:tooling",
     "typescript": "catalog:tooling",
     "vite": "catalog:vite",

--- a/packages/email/test/markdown.test.ts
+++ b/packages/email/test/markdown.test.ts
@@ -62,5 +62,12 @@ describe("renderEmailMarkdown", () => {
       html: "<p><a href=\"web+demo:folder%5Citem\">Open item</a></p>",
       text: "[Open item](web+demo:folder%5Citem)",
     })
+
+    await expect(renderEmailMarkdown("[Open item]({{ url }})", {
+      data: { url: "web+demo:\\folder\\item" },
+    })).resolves.toEqual({
+      html: "<p><a href=\"web+demo:%5Cfolder%5Citem\">Open item</a></p>",
+      text: "[Open item](web+demo:%5Cfolder%5Citem)",
+    })
   })
 })

--- a/packages/email/test/markdown.test.ts
+++ b/packages/email/test/markdown.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest"
+import { parseFragment } from "parse5"
 
 import { renderEmailMarkdown } from "../src/markdown.ts"
 
@@ -42,11 +43,22 @@ describe("renderEmailMarkdown", () => {
   })
 
   it("keeps character references inside a scalar link destination", async () => {
-    await expect(renderEmailMarkdown("[Open recap]({{ url }})", {
-      data: { url: "https://example.com/?x=&#x29;*Injected*" },
-    })).resolves.toEqual({
-      html: "<p><a href=\"https://example.com/?x=&#x2%39;*Injected*\">Open recap</a></p>",
-      text: "[Open recap](https://example.com/?x=&#x2%39;*Injected*)",
+    const url = "https://example.com/?x=&#x29;*Injected*"
+    const rendered = await renderEmailMarkdown("[Open recap]({{ url }})", { data: { url } })
+    expect(rendered).toEqual({
+      html: "<p><a href=\"https://example.com/?x=&#x%329;*Injected*\">Open recap</a></p>",
+      text: "[Open recap](https://example.com/?x=&#x%329;*Injected*)",
     })
+
+    const paragraph = parseFragment(rendered.html).childNodes[0]!
+    expect("childNodes" in paragraph).toBe(true)
+    if (!("childNodes" in paragraph)) return
+    const anchor = paragraph.childNodes[0]!
+    expect("attrs" in anchor).toBe(true)
+    if (!("attrs" in anchor)) return
+    const parsedUrl = new URL(anchor.attrs.find(attribute => attribute.name === "href")!.value)
+    const sourceUrl = new URL(url)
+    expect(parsedUrl.search).toBe(sourceUrl.search)
+    expect(decodeURIComponent(parsedUrl.hash)).toBe(sourceUrl.hash)
   })
 })

--- a/packages/email/test/markdown.test.ts
+++ b/packages/email/test/markdown.test.ts
@@ -45,8 +45,8 @@ describe("renderEmailMarkdown", () => {
     await expect(renderEmailMarkdown("[Open recap]({{ url }})", {
       data: { url: "https://example.com/?x=&#x29;*Injected*" },
     })).resolves.toEqual({
-      html: "<p><a href=\"https://example.com/?x=%26%23x29%3B*Injected*\">Open recap</a></p>",
-      text: "[Open recap](https://example.com/?x=%26%23x29%3B*Injected*)",
+      html: "<p><a href=\"https://example.com/?x=%26#x29;*Injected*\">Open recap</a></p>",
+      text: "[Open recap](https://example.com/?x=%26#x29;*Injected*)",
     })
   })
 })

--- a/packages/email/test/markdown.test.ts
+++ b/packages/email/test/markdown.test.ts
@@ -40,4 +40,13 @@ describe("renderEmailMarkdown", () => {
       text: "[Open and share your visual recap](https://prs.onmax.me/recap/2026-07)",
     })
   })
+
+  it("keeps character references inside a scalar link destination", async () => {
+    await expect(renderEmailMarkdown("[Open recap]({{ url }})", {
+      data: { url: "https://example.com/?x=&#x29;*Injected*" },
+    })).resolves.toEqual({
+      html: "<p><a href=\"https://example.com/?x=%26#x29;*Injected*\">Open recap</a></p>",
+      text: "[Open recap](https://example.com/?x=%26#x29;*Injected*)",
+    })
+  })
 })

--- a/packages/email/test/markdown.test.ts
+++ b/packages/email/test/markdown.test.ts
@@ -1,6 +1,4 @@
 import { describe, expect, it } from "vitest"
-import { parseFragment } from "parse5"
-
 import { renderEmailMarkdown } from "../src/markdown.ts"
 
 describe("renderEmailMarkdown", () => {
@@ -42,23 +40,9 @@ describe("renderEmailMarkdown", () => {
     })
   })
 
-  it("keeps character references inside a scalar link destination", async () => {
-    const url = "https://example.com/?x=&#x29;*Injected*"
-    const rendered = await renderEmailMarkdown("[Open recap]({{ url }})", { data: { url } })
-    expect(rendered).toEqual({
-      html: "<p><a href=\"https://example.com/?x=&#x%329;*Injected*\">Open recap</a></p>",
-      text: "[Open recap](https://example.com/?x=&#x%329;*Injected*)",
-    })
-
-    const paragraph = parseFragment(rendered.html).childNodes[0]!
-    expect("childNodes" in paragraph).toBe(true)
-    if (!("childNodes" in paragraph)) return
-    const anchor = paragraph.childNodes[0]!
-    expect("attrs" in anchor).toBe(true)
-    if (!("attrs" in anchor)) return
-    const parsedUrl = new URL(anchor.attrs.find(attribute => attribute.name === "href")!.value)
-    const sourceUrl = new URL(url)
-    expect(parsedUrl.search).toBe(sourceUrl.search)
-    expect(decodeURIComponent(parsedUrl.hash)).toBe(sourceUrl.hash)
+  it("rejects a scalar link destination whose meaning would change", async () => {
+    await expect(renderEmailMarkdown("[Open recap]({{ url }})", {
+      data: { url: "https://example.com/?x=&#x29;*Injected*" },
+    })).rejects.toThrow("must resolve to a safe destination")
   })
 })

--- a/packages/email/test/markdown.test.ts
+++ b/packages/email/test/markdown.test.ts
@@ -45,8 +45,8 @@ describe("renderEmailMarkdown", () => {
     await expect(renderEmailMarkdown("[Open recap]({{ url }})", {
       data: { url: "https://example.com/?x=&#x29;*Injected*" },
     })).resolves.toEqual({
-      html: "<p><a href=\"https://example.com/?x=%26#x29;*Injected*\">Open recap</a></p>",
-      text: "[Open recap](https://example.com/?x=%26#x29;*Injected*)",
+      html: "<p><a href=\"https://example.com/?x=&#x2%39;*Injected*\">Open recap</a></p>",
+      text: "[Open recap](https://example.com/?x=&#x2%39;*Injected*)",
     })
   })
 })

--- a/packages/email/test/markdown.test.ts
+++ b/packages/email/test/markdown.test.ts
@@ -45,4 +45,13 @@ describe("renderEmailMarkdown", () => {
       data: { url: "https://example.com/?x=&#x29;*Injected*" },
     })).rejects.toThrow("must resolve to a safe destination")
   })
+
+  it("preserves backslash data in a scalar link query", async () => {
+    await expect(renderEmailMarkdown("[Open recap]({{ url }})", {
+      data: { url: "https://example.com/?q=a\\b" },
+    })).resolves.toEqual({
+      html: "<p><a href=\"https://example.com/?q=a%5Cb\">Open recap</a></p>",
+      text: "[Open recap](https://example.com/?q=a%5Cb)",
+    })
+  })
 })

--- a/packages/email/test/markdown.test.ts
+++ b/packages/email/test/markdown.test.ts
@@ -54,4 +54,13 @@ describe("renderEmailMarkdown", () => {
       text: "[Open recap](https://example.com/?q=a%5Cb)",
     })
   })
+
+  it("preserves backslash data in an opaque scalar destination", async () => {
+    await expect(renderEmailMarkdown("[Open item]({{ url }})", {
+      data: { url: "web+demo:folder\\item" },
+    })).resolves.toEqual({
+      html: "<p><a href=\"web+demo:folder%5Citem\">Open item</a></p>",
+      text: "[Open item](web+demo:folder%5Citem)",
+    })
+  })
 })

--- a/packages/email/test/markdown.test.ts
+++ b/packages/email/test/markdown.test.ts
@@ -45,8 +45,8 @@ describe("renderEmailMarkdown", () => {
     await expect(renderEmailMarkdown("[Open recap]({{ url }})", {
       data: { url: "https://example.com/?x=&#x29;*Injected*" },
     })).resolves.toEqual({
-      html: "<p><a href=\"https://example.com/?x=%26#x29;*Injected*\">Open recap</a></p>",
-      text: "[Open recap](https://example.com/?x=%26#x29;*Injected*)",
+      html: "<p><a href=\"https://example.com/?x=%26%23x29%3B*Injected*\">Open recap</a></p>",
+      text: "[Open recap](https://example.com/?x=%26%23x29%3B*Injected*)",
     })
   })
 })

--- a/packages/email/test/markdown.test.ts
+++ b/packages/email/test/markdown.test.ts
@@ -69,5 +69,19 @@ describe("renderEmailMarkdown", () => {
       html: "<p><a href=\"web+demo:%5Cfolder%5Citem\">Open item</a></p>",
       text: "[Open item](web+demo:%5Cfolder%5Citem)",
     })
+
+    await expect(renderEmailMarkdown("[Open item]({{ url }})", {
+      data: { url: "web+demo:/folder\\item" },
+    })).resolves.toEqual({
+      html: "<p><a href=\"web+demo:/folder%5Citem\">Open item</a></p>",
+      text: "[Open item](web+demo:/folder%5Citem)",
+    })
+
+    await expect(renderEmailMarkdown("[Open item]({{ url }})", {
+      data: { url: "web+demo://host/folder\\item" },
+    })).resolves.toEqual({
+      html: "<p><a href=\"web+demo://host/folder%5Citem\">Open item</a></p>",
+      text: "[Open item](web+demo://host/folder%5Citem)",
+    })
   })
 })

--- a/packages/email/test/markdown.test.ts
+++ b/packages/email/test/markdown.test.ts
@@ -31,4 +31,13 @@ describe("renderEmailMarkdown", () => {
       text: "Hello\n\nRegards, **ViteHub**",
     })
   })
+
+  it("renders a scalar Markdown link destination as one anchor", async () => {
+    await expect(renderEmailMarkdown("[Open and share your visual recap]({{ url }})", {
+      data: { url: "https://prs.onmax.me/recap/2026-07" },
+    })).resolves.toEqual({
+      html: "<p><a href=\"https://prs.onmax.me/recap/2026-07\">Open and share your visual recap</a></p>",
+      text: "[Open and share your visual recap](https://prs.onmax.me/recap/2026-07)",
+    })
+  })
 })

--- a/packages/markdown-template/package.json
+++ b/packages/markdown-template/package.json
@@ -38,6 +38,7 @@
     "test": "vp run -t @vite-hub/markdown-template#build && vp test"
   },
   "dependencies": {
+    "character-entities-legacy": "3.0.0",
     "comark": "catalog:ui"
   },
   "devDependencies": {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -153,7 +153,7 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
   const hasHtmlReferencePrefix = /&#(?:\d+|x[\dA-F]+)/i.test(value)
     || [...value.matchAll(/&([A-Za-z][A-Za-z\d]*)(?=[^=A-Za-z\d]|$)/g)]
       .some(match => legacyHtmlReferences.has(match[1]!))
-  if (value.trim() !== value || /%(?![\dA-F]{2})/i.test(value) || hasPathBackslash || hasHtmlReferencePrefix || /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
+  if (value.startsWith(" ") || value.endsWith(" ") || /%(?![\dA-F]{2})/i.test(value) || hasPathBackslash || hasHtmlReferencePrefix || /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
     const codePoint = character.codePointAt(0)!
     return codePoint < 32 || codePoint === 127
   })) {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -146,7 +146,7 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
   const hasHtmlReferencePrefix = /&#(?:\d+|x[\dA-F]+)/i.test(value)
     || [...value.matchAll(/&([A-Za-z][A-Za-z\d]*)(?=[^=A-Za-z\d]|$)/g)]
       .some(match => legacyHtmlReferences.has(match[1]!))
-  if (hasHtmlReferencePrefix || /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
+  if (value.includes("\\") || hasHtmlReferencePrefix || /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
     const codePoint = character.codePointAt(0)!
     return codePoint < 32 || codePoint === 127
   })) {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -156,7 +156,9 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
       : encodeURI(value)
     encoded = encoded
       .replace(/%25([\dA-F]{2})/gi, "%$1")
-      .replace(/&(?=(?:#\d{1,7}|#[xX][\dA-F]{1,6}|[A-Za-z][A-Za-z\d]{1,31});)/g, "%26")
+      .replace(/&(?:#\d{1,7}|#[xX][\dA-F]{1,6}|[A-Za-z][A-Za-z\d]{1,31});/g, reference =>
+        reference.replace(/([A-Za-z\d]);$/, (_suffix, character: string) =>
+          `%${character.codePointAt(0)!.toString(16).toUpperCase()};`))
       .replace(/[()]/g, character => `%${character.codePointAt(0)!.toString(16).toUpperCase()}`)
   }
   catch {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -156,9 +156,11 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
       : encodeURI(value)
     encoded = encoded
       .replace(/%25([\dA-F]{2})/gi, "%$1")
-      .replace(/&(?:#\d{1,7}|#[xX][\dA-F]{1,6}|[A-Za-z][A-Za-z\d]{1,31});/g, reference =>
-        reference.replace(/([A-Za-z\d]);$/, (_suffix, character: string) =>
-          `%${character.codePointAt(0)!.toString(16).toUpperCase()};`))
+      .replace(/&(?:#\d{1,7}|#[xX][\dA-F]{1,6}|[A-Za-z][A-Za-z\d]{1,31});/g, (reference) => {
+        const index = /^&#[xX]/.test(reference) ? 3 : reference.startsWith("&#") ? 2 : 1
+        const character = reference[index]!
+        return `${reference.slice(0, index)}%${character.codePointAt(0)!.toString(16).toUpperCase()}${reference.slice(index + 1)}`
+      })
       .replace(/[()]/g, character => `%${character.codePointAt(0)!.toString(16).toUpperCase()}`)
   }
   catch {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -100,7 +100,10 @@ async function normalizeLinkBindings(template: string): Promise<{
   const token = `VITEHUBMARKDOWNTEMPLATELINK${crypto.randomUUID().replaceAll("-", "")}`
   const candidates: Array<{ binding: string, path: string }> = []
   const prepared = template.replace(tagBindingPattern, (binding, path: string, offset: number, source: string) => {
-    if (!/\]\(\s*$/.test(source.slice(0, offset)) || !/^\s*\)/.test(source.slice(offset + binding.length))) {
+    const suffix = source.slice(offset + binding.length)
+    const closesDestination = /^\s*\)/.test(suffix)
+      || /^\s+(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))\s*\)/.test(suffix)
+    if (!/\]\(\s*$/.test(source.slice(0, offset)) || !closesDestination) {
       return binding
     }
     const index = candidates.push({ binding, path }) - 1

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -148,7 +148,6 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
   const hierarchical = !scheme
     || /^(?:file|ftp|https?|wss?)$/i.test(scheme[1]!)
     || value[scheme[0].length] === "/"
-    || value[scheme[0].length] === "\\"
   const hasPathBackslash = hierarchical
     && value.slice(0, suffixIndex < 0 ? undefined : suffixIndex).includes("\\")
   const hasHtmlReferencePrefix = /&#(?:\d+|x[\dA-F]+)/i.test(value)

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -151,7 +151,7 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
       : encodeURI(value)
     encoded = encoded
       .replace(/%25([\dA-F]{2})/gi, "%$1")
-      .replace(/&(?:#(?:\d+|x[\dA-F]+)|[A-Za-z][A-Za-z\d]+);/gi, encodeURIComponent)
+      .replace(/&(?=(?:#\d{1,7}|#[xX][\dA-F]{1,6}|[A-Za-z][A-Za-z\d]{1,31});)/g, "%26")
       .replace(/[()]/g, character => `%${character.codePointAt(0)!.toString(16).toUpperCase()}`)
   }
   catch {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -141,7 +141,7 @@ function linkBindingIndices(nodes: ComarkNode[], token: string): Set<number> {
 
 async function safeLinkDestination(path: string, data: Record<string, unknown>): Promise<string> {
   const value = scalarValue(path, data)
-  if ([...value].some((character) => {
+  if (/^[a-z][a-z\d+.-]*:\/\/(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
     const codePoint = character.codePointAt(0)!
     return codePoint < 32 || codePoint === 127
   })) {
@@ -149,18 +149,9 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
   }
   let encoded: string
   try {
-    const ipv6Authority = value.match(/^((?:[a-z][a-z\d+.-]*:)?\/\/(?:[^/?#]*@)?)\[([^\]]+)]/i)
-    const parsed = ipv6Authority ? new URL(value, "https://vitehub.invalid") : undefined
-    encoded = ipv6Authority && parsed?.hostname.startsWith("[") && parsed.hostname.endsWith("]")
-      ? `${encodeURI(ipv6Authority[1]!)}[${encodeURI(ipv6Authority[2]!)}]${encodeURI(value.slice(ipv6Authority[0].length))}`
-      : encodeURI(value)
+    encoded = encodeURI(value)
     encoded = encoded
       .replace(/%25([\dA-F]{2})/gi, "%$1")
-      .replace(/&(?:#\d{1,7}|#[xX][\dA-F]{1,6}|[A-Za-z][A-Za-z\d]{1,31});/g, (reference) => {
-        const index = /^&#[xX]/.test(reference) ? 3 : reference.startsWith("&#") ? 2 : 1
-        const character = reference[index]!
-        return `${reference.slice(0, index)}%${character.codePointAt(0)!.toString(16).toUpperCase()}${reference.slice(index + 1)}`
-      })
       .replace(/[()]/g, character => `%${character.codePointAt(0)!.toString(16).toUpperCase()}`)
   }
   catch {
@@ -170,7 +161,7 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
   const tree = await parseTemplateMarkdown(`[link](<${encoded}>)`)
   const paragraph = tree.nodes[0]
   const link = isElement(paragraph) && paragraph[0] === "p" ? paragraph[2] : undefined
-  if (!link || !isElement(link) || link[0] !== "a" || typeof link[1].href !== "string") {
+  if (!link || !isElement(link) || link[0] !== "a" || link[1].href !== encoded) {
     throw new Error(`[vitehub] Markdown template link binding "{{ ${path} }}" must resolve to a safe destination.`)
   }
   return encoded

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -159,7 +159,6 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
   const scheme = value.match(/^([a-z][a-z\d+.-]*):/i)
   const hierarchical = !scheme
     || /^(?:file|ftp|https?|wss?)$/i.test(scheme[1]!)
-    || value[scheme[0].length] === "/"
   const hasPathBackslash = hierarchical
     && value.slice(0, suffixIndex < 0 ? undefined : suffixIndex).includes("\\")
   const hasHtmlReferencePrefix = /&#(?:\d+|x[\dA-F]+)/i.test(value)

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -37,6 +37,8 @@ const templatePathPattern = new RegExp(`^${templatePathSource}$`)
 const tripleBindingPattern = new RegExp(String.raw`\{\{\{\s*(${templatePathSource})\s*\}\}\}`, "g")
 const tagBindingPattern = new RegExp(String.raw`(?<!\{)\{\{(?!\{)\s*(${templatePathSource})\s*\}\}(?!\})`, "g")
 const legacyHtmlReferences = new Set(characterEntitiesLegacy)
+const closesLinkDestinationPattern = /(?:\s*\)|\s+(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))\s*\))/y
+const closesEnclosedLinkDestinationPattern = /\s*>(?:\s*\)|\s+(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))\s*\))/y
 
 interface TemplatePreparation {
   prepare: (value: string) => Promise<string>
@@ -102,14 +104,13 @@ async function normalizeLinkBindings(template: string): Promise<{
   const token = `VITEHUBMARKDOWNTEMPLATELINK${crypto.randomUUID().replaceAll("-", "")}`
   const candidates: Array<{ binding: string, path: string }> = []
   const prepared = template.replace(tagBindingPattern, (binding, path: string, offset: number, source: string) => {
-    const prefix = source.slice(0, offset)
-    const suffix = source.slice(offset + binding.length)
-    const closesDestination = /^\s*\)/.test(suffix)
-      || /^\s+(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))\s*\)/.test(suffix)
-    const closesEnclosedDestination = /^\s*>\s*\)/.test(suffix)
-      || /^\s*>\s+(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))\s*\)/.test(suffix)
-    const completeDestination = /\]\(\s*$/.test(prefix) && closesDestination
-    const completeEnclosedDestination = /\]\(\s*<\s*$/.test(prefix) && closesEnclosedDestination
+    const suffixOffset = offset + binding.length
+    closesLinkDestinationPattern.lastIndex = suffixOffset
+    closesEnclosedLinkDestinationPattern.lastIndex = suffixOffset
+    const completeDestination = hasLinkDestinationPrefix(source, offset, false)
+      && closesLinkDestinationPattern.test(source)
+    const completeEnclosedDestination = hasLinkDestinationPrefix(source, offset, true)
+      && closesEnclosedLinkDestinationPattern.test(source)
     if (!completeDestination && !completeEnclosedDestination) {
       return binding
     }
@@ -126,6 +127,17 @@ async function normalizeLinkBindings(template: string): Promise<{
     if (!linked.has(index)) rendered = rendered.replace(`${token}${index}END`, candidate.binding)
   }
   return { links: candidates, template: rendered, token }
+}
+
+function hasLinkDestinationPrefix(source: string, offset: number, enclosed: boolean): boolean {
+  let cursor = offset
+  while (cursor > 0 && /\s/.test(source[cursor - 1]!)) cursor--
+  if (enclosed) {
+    if (source[cursor - 1] !== "<") return false
+    cursor--
+    while (cursor > 0 && /\s/.test(source[cursor - 1]!)) cursor--
+  }
+  return source[cursor - 2] === "]" && source[cursor - 1] === "("
 }
 
 function linkBindingIndices(nodes: ComarkNode[], token: string): Set<number> {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -164,7 +164,9 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
   const hasHtmlReferencePrefix = /&#(?:\d+|x[\dA-F]+)/i.test(value)
     || [...value.matchAll(/&([A-Za-z][A-Za-z\d]*)(?=[^=A-Za-z\d]|$)/g)]
       .some(match => legacyHtmlReferences.has(match[1]!))
-  if (value.startsWith(" ") || value.endsWith(" ") || /%(?![\dA-F]{2})/i.test(value) || hasPathBackslash || hasHtmlReferencePrefix || /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
+  const hasBracketedAuthority = /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value)
+    || /^(?:file|ftp|https?|wss?):\/*(?:[^/?#]*@)?\[/i.test(value)
+  if (value.startsWith(" ") || value.endsWith(" ") || /%(?![\dA-F]{2})/i.test(value) || hasPathBackslash || hasHtmlReferencePrefix || hasBracketedAuthority || [...value].some((character) => {
     const codePoint = character.codePointAt(0)!
     return codePoint < 32 || codePoint === 127
   })) {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -100,10 +100,15 @@ async function normalizeLinkBindings(template: string): Promise<{
   const token = `VITEHUBMARKDOWNTEMPLATELINK${crypto.randomUUID().replaceAll("-", "")}`
   const candidates: Array<{ binding: string, path: string }> = []
   const prepared = template.replace(tagBindingPattern, (binding, path: string, offset: number, source: string) => {
+    const prefix = source.slice(0, offset)
     const suffix = source.slice(offset + binding.length)
     const closesDestination = /^\s*\)/.test(suffix)
       || /^\s+(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))\s*\)/.test(suffix)
-    if (!/\]\(\s*$/.test(source.slice(0, offset)) || !closesDestination) {
+    const closesEnclosedDestination = /^\s*>\s*\)/.test(suffix)
+      || /^\s*>\s+(?:"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\((?:\\.|[^)\\])*\))\s*\)/.test(suffix)
+    const completeDestination = /\]\(\s*$/.test(prefix) && closesDestination
+    const completeEnclosedDestination = /\]\(\s*<\s*$/.test(prefix) && closesEnclosedDestination
+    if (!completeDestination && !completeEnclosedDestination) {
       return binding
     }
     const index = candidates.push({ binding, path }) - 1

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -149,8 +149,8 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
   }
   let encoded: string
   try {
-    const ipv6Authority = value.match(/^([a-z][a-z\d+.-]*:\/\/(?:[^/?#]*@)?)\[([^\]]+)]/i)
-    const parsed = ipv6Authority ? new URL(value) : undefined
+    const ipv6Authority = value.match(/^((?:[a-z][a-z\d+.-]*:)?\/\/(?:[^/?#]*@)?)\[([^\]]+)]/i)
+    const parsed = ipv6Authority ? new URL(value, "https://vitehub.invalid") : undefined
     encoded = ipv6Authority && parsed?.hostname.startsWith("[") && parsed.hostname.endsWith("]")
       ? `${encodeURI(ipv6Authority[1]!)}[${encodeURI(ipv6Authority[2]!)}]${encodeURI(value.slice(ipv6Authority[0].length))}`
       : encodeURI(value)

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -146,7 +146,7 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
   try {
     const ipv6Authority = value.match(/^([a-z][a-z\d+.-]*:\/\/(?:[^/?#]*@)?)\[([^\]]+)]/i)
     const parsed = ipv6Authority ? new URL(value) : undefined
-    encoded = ipv6Authority && parsed?.hostname === `[${ipv6Authority[2]}]`
+    encoded = ipv6Authority && parsed?.hostname.startsWith("[") && parsed.hostname.endsWith("]")
       ? `${encodeURI(ipv6Authority[1]!)}[${encodeURI(ipv6Authority[2]!)}]${encodeURI(value.slice(ipv6Authority[0].length))}`
       : encodeURI(value)
     encoded = encoded

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -141,7 +141,8 @@ function linkBindingIndices(nodes: ComarkNode[], token: string): Set<number> {
 
 async function safeLinkDestination(path: string, data: Record<string, unknown>): Promise<string> {
   const value = scalarValue(path, data)
-  if (/^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
+  const hasHtmlReferencePrefix = /&(?:#(?:\d+|x[\dA-F]+)|[A-Za-z][A-Za-z\d]+(?=[^=A-Za-z\d]|$))/i.test(value)
+  if (hasHtmlReferencePrefix || /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
     const codePoint = character.codePointAt(0)!
     return codePoint < 32 || codePoint === 127
   })) {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -151,8 +151,8 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
       : encodeURI(value)
     encoded = encoded
       .replace(/%25([\dA-F]{2})/gi, "%$1")
+      .replace(/&(?:#(?:\d+|x[\dA-F]+)|[A-Za-z][A-Za-z\d]+);/gi, encodeURIComponent)
       .replace(/[()]/g, character => `%${character.codePointAt(0)!.toString(16).toUpperCase()}`)
-      .replace(/&(?=(?:#\d{1,7}|#[xX][\dA-F]{1,6}|[A-Za-z][A-Za-z\d]{1,31});)/g, "%26")
   }
   catch {
     throw new Error(`[vitehub] Markdown template link binding "{{ ${path} }}" must resolve to a safe destination.`)

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -144,7 +144,13 @@ function linkBindingIndices(nodes: ComarkNode[], token: string): Set<number> {
 async function safeLinkDestination(path: string, data: Record<string, unknown>): Promise<string> {
   const value = scalarValue(path, data)
   const suffixIndex = value.search(/[?#]/)
-  const hasPathBackslash = value.slice(0, suffixIndex < 0 ? undefined : suffixIndex).includes("\\")
+  const scheme = value.match(/^([a-z][a-z\d+.-]*):/i)
+  const hierarchical = !scheme
+    || /^(?:file|ftp|https?|wss?)$/i.test(scheme[1]!)
+    || value[scheme[0].length] === "/"
+    || value[scheme[0].length] === "\\"
+  const hasPathBackslash = hierarchical
+    && value.slice(0, suffixIndex < 0 ? undefined : suffixIndex).includes("\\")
   const hasHtmlReferencePrefix = /&#(?:\d+|x[\dA-F]+)/i.test(value)
     || [...value.matchAll(/&([A-Za-z][A-Za-z\d]*)(?=[^=A-Za-z\d]|$)/g)]
       .some(match => legacyHtmlReferences.has(match[1]!))

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -1,3 +1,4 @@
+import { characterEntitiesLegacy } from "character-entities-legacy"
 import { renderMarkdown } from "comark/render"
 
 import { evaluateCondition, templatePathValue } from "./condition.ts"
@@ -35,6 +36,7 @@ const templatePathSource = String.raw`[A-Za-z_$][\w$-]*(?:\.[A-Za-z_$][\w$-]*)*`
 const templatePathPattern = new RegExp(`^${templatePathSource}$`)
 const tripleBindingPattern = new RegExp(String.raw`\{\{\{\s*(${templatePathSource})\s*\}\}\}`, "g")
 const tagBindingPattern = new RegExp(String.raw`(?<!\{)\{\{(?!\{)\s*(${templatePathSource})\s*\}\}(?!\})`, "g")
+const legacyHtmlReferences = new Set(characterEntitiesLegacy)
 
 interface TemplatePreparation {
   prepare: (value: string) => Promise<string>
@@ -141,7 +143,9 @@ function linkBindingIndices(nodes: ComarkNode[], token: string): Set<number> {
 
 async function safeLinkDestination(path: string, data: Record<string, unknown>): Promise<string> {
   const value = scalarValue(path, data)
-  const hasHtmlReferencePrefix = /&(?:#(?:\d+|x[\dA-F]+)|[A-Za-z][A-Za-z\d]+(?=[^=A-Za-z\d]|$))/i.test(value)
+  const hasHtmlReferencePrefix = /&#(?:\d+|x[\dA-F]+)/i.test(value)
+    || [...value.matchAll(/&([A-Za-z][A-Za-z\d]*)(?=[^=A-Za-z\d]|$)/g)]
+      .some(match => legacyHtmlReferences.has(match[1]!))
   if (hasHtmlReferencePrefix || /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
     const codePoint = character.codePointAt(0)!
     return codePoint < 32 || codePoint === 127

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -143,10 +143,12 @@ function linkBindingIndices(nodes: ComarkNode[], token: string): Set<number> {
 
 async function safeLinkDestination(path: string, data: Record<string, unknown>): Promise<string> {
   const value = scalarValue(path, data)
+  const suffixIndex = value.search(/[?#]/)
+  const hasPathBackslash = value.slice(0, suffixIndex < 0 ? undefined : suffixIndex).includes("\\")
   const hasHtmlReferencePrefix = /&#(?:\d+|x[\dA-F]+)/i.test(value)
     || [...value.matchAll(/&([A-Za-z][A-Za-z\d]*)(?=[^=A-Za-z\d]|$)/g)]
       .some(match => legacyHtmlReferences.has(match[1]!))
-  if (value.includes("\\") || hasHtmlReferencePrefix || /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
+  if (hasPathBackslash || hasHtmlReferencePrefix || /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
     const codePoint = character.codePointAt(0)!
     return codePoint < 32 || codePoint === 127
   })) {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -144,9 +144,15 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
   }
   let encoded: string
   try {
-    encoded = encodeURI(value)
+    const ipv6Authority = value.match(/^([a-z][a-z\d+.-]*:\/\/(?:[^/?#]*@)?)\[([^\]]+)]/i)
+    const parsed = ipv6Authority ? new URL(value) : undefined
+    encoded = ipv6Authority && parsed?.hostname === `[${ipv6Authority[2]}]`
+      ? `${encodeURI(ipv6Authority[1]!)}[${encodeURI(ipv6Authority[2]!)}]${encodeURI(value.slice(ipv6Authority[0].length))}`
+      : encodeURI(value)
+    encoded = encoded
       .replace(/%25([\dA-F]{2})/gi, "%$1")
       .replace(/[()]/g, character => `%${character.codePointAt(0)!.toString(16).toUpperCase()}`)
+      .replace(/&(?=(?:#\d{1,7}|#[xX][\dA-F]{1,6}|[A-Za-z][A-Za-z\d]{1,31});)/g, "%26")
   }
   catch {
     throw new Error(`[vitehub] Markdown template link binding "{{ ${path} }}" must resolve to a safe destination.`)
@@ -158,7 +164,7 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
   if (!link || !isElement(link) || link[0] !== "a" || typeof link[1].href !== "string") {
     throw new Error(`[vitehub] Markdown template link binding "{{ ${path} }}" must resolve to a safe destination.`)
   }
-  return link[1].href
+  return encoded
 }
 
 function assertTemplate(template: string): void {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -20,6 +20,8 @@ interface RenderState {
   data: Record<string, unknown>
   fragmentToken: string
   fragments: Array<{ path: string }>
+  linkToken: string
+  links: Array<{ path: string }>
   validateConditionPath?: (path: string) => boolean
 }
 
@@ -74,17 +76,86 @@ export async function renderMarkdownTemplateInternal(
       }, preparation)
     : shorthand
   validateConditionalDirectives(await directiveValidationSource(imported))
+  const normalizedLinks = await normalizeLinkBindings(imported)
   const fragmentToken = `VITEHUBMARKDOWNTEMPLATEFRAGMENT${crypto.randomUUID().replaceAll("-", "")}`
-  const normalized = await normalizeTripleBindings(imported, fragmentToken, preparation.runtime)
+  const normalized = await normalizeTripleBindings(normalizedLinks.template, fragmentToken, preparation.runtime)
   const tree = await parseTemplateMarkdown(normalized.template, true)
   const nodes = await composeNodes(tree.nodes, {
     data,
     fragmentToken,
     fragments: normalized.fragments,
+    linkToken: normalizedLinks.token,
+    links: normalizedLinks.links,
     validateConditionPath: options.validateConditionPath,
   })
   const rendered = cleanMarkdown(await renderMarkdown({ ...tree, nodes }, { components: preparation.runtime.components }))
   return restoreTemplateTokens(restoreTemplateTags(rendered, preparation.tagTokens, data), preparation.protectedTokens)
+}
+
+async function normalizeLinkBindings(template: string): Promise<{
+  links: RenderState["links"]
+  template: string
+  token: string
+}> {
+  const token = `VITEHUBMARKDOWNTEMPLATELINK${crypto.randomUUID().replaceAll("-", "")}`
+  const candidates: Array<{ binding: string, path: string }> = []
+  const prepared = template.replace(tagBindingPattern, (binding, path: string, offset: number, source: string) => {
+    if (!/\]\(\s*$/.test(source.slice(0, offset)) || !/^\s*\)/.test(source.slice(offset + binding.length))) {
+      return binding
+    }
+    const index = candidates.push({ binding, path }) - 1
+    return `${token}${index}END`
+  })
+  if (!candidates.length) return { links: [], template, token }
+
+  const tree = await parseTemplateMarkdown(prepared)
+  const linked = linkBindingIndices(tree.nodes, token)
+  let rendered = prepared
+  for (let index = 0; index < candidates.length; index++) {
+    const candidate = candidates[index]!
+    if (!linked.has(index)) rendered = rendered.replace(`${token}${index}END`, candidate.binding)
+  }
+  return { links: candidates, template: rendered, token }
+}
+
+function linkBindingIndices(nodes: ComarkNode[], token: string): Set<number> {
+  const found = new Set<number>()
+  for (const node of nodes) {
+    if (!isElement(node)) continue
+    if (node[0] === "a" && typeof node[1].href === "string") {
+      const match = node[1].href.match(new RegExp(`^${token}(\\d+)END$`))
+      if (match) found.add(Number(match[1]))
+    }
+    for (const index of linkBindingIndices(node.slice(2) as ComarkNode[], token)) found.add(index)
+  }
+  return found
+}
+
+async function safeLinkDestination(path: string, data: Record<string, unknown>): Promise<string> {
+  const value = scalarValue(path, data)
+  if ([...value].some((character) => {
+    const codePoint = character.codePointAt(0)!
+    return codePoint < 32 || codePoint === 127
+  })) {
+    throw new Error(`[vitehub] Markdown template link binding "{{ ${path} }}" must resolve to a safe destination.`)
+  }
+  let encoded: string
+  try {
+    encoded = encodeURI(value)
+      .replace(/%25([\dA-F]{2})/gi, "%$1")
+      .replace(/[()]/g, character => `%${character.codePointAt(0)!.toString(16).toUpperCase()}`)
+  }
+  catch {
+    throw new Error(`[vitehub] Markdown template link binding "{{ ${path} }}" must resolve to a safe destination.`)
+  }
+
+  const tree = await parseTemplateMarkdown(`[link](<${encoded}>)`)
+  const paragraph = tree.nodes[0]
+  const link = isElement(paragraph) && paragraph[0] === "p" ? paragraph[2] : undefined
+  if (!link || !isElement(link) || link[0] !== "a" || typeof link[1].href !== "string") {
+    throw new Error(`[vitehub] Markdown template link binding "{{ ${path} }}" must resolve to a safe destination.`)
+  }
+  return link[1].href
 }
 
 function assertTemplate(template: string): void {
@@ -315,12 +386,23 @@ async function composeNode(
   if (tag === "binding") return [renderBinding(attrs, state.data)]
   if (tag === "code") return [node]
   if (tag === "p") return await composeParagraph(attrs, children, state)
-  return [[tag, attrs, ...(await composeNodes(
+  const composedAttrs = tag === "a" ? await composeLinkAttributes(attrs, state) : attrs
+  return [[tag, composedAttrs, ...(await composeNodes(
     children,
     state,
     tag,
     inlineFragments,
   ))] as ComarkElement]
+}
+
+async function composeLinkAttributes(
+  attrs: Record<string, unknown>,
+  state: RenderState,
+): Promise<Record<string, unknown>> {
+  if (typeof attrs.href !== "string") return attrs
+  const match = attrs.href.match(new RegExp(`^${state.linkToken}(\\d+)END$`))
+  const link = match ? state.links[Number(match[1])] : undefined
+  return link ? { ...attrs, href: await safeLinkDestination(link.path, state.data) } : attrs
 }
 
 async function composeParagraph(

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -141,7 +141,7 @@ function linkBindingIndices(nodes: ComarkNode[], token: string): Set<number> {
 
 async function safeLinkDestination(path: string, data: Record<string, unknown>): Promise<string> {
   const value = scalarValue(path, data)
-  if (/^(?:[a-z][a-z\d+.-]*:)?\/\/(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
+  if (/^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
     const codePoint = character.codePointAt(0)!
     return codePoint < 32 || codePoint === 127
   })) {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -153,7 +153,7 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
   const hasHtmlReferencePrefix = /&#(?:\d+|x[\dA-F]+)/i.test(value)
     || [...value.matchAll(/&([A-Za-z][A-Za-z\d]*)(?=[^=A-Za-z\d]|$)/g)]
       .some(match => legacyHtmlReferences.has(match[1]!))
-  if (value.trim() !== value || hasPathBackslash || hasHtmlReferencePrefix || /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
+  if (value.trim() !== value || /%(?![\dA-F]{2})/i.test(value) || hasPathBackslash || hasHtmlReferencePrefix || /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
     const codePoint = character.codePointAt(0)!
     return codePoint < 32 || codePoint === 127
   })) {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -141,7 +141,7 @@ function linkBindingIndices(nodes: ComarkNode[], token: string): Set<number> {
 
 async function safeLinkDestination(path: string, data: Record<string, unknown>): Promise<string> {
   const value = scalarValue(path, data)
-  if (/^[a-z][a-z\d+.-]*:\/\/(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
+  if (/^(?:[a-z][a-z\d+.-]*:)?\/\/(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
     const codePoint = character.codePointAt(0)!
     return codePoint < 32 || codePoint === 127
   })) {

--- a/packages/markdown-template/src/render.ts
+++ b/packages/markdown-template/src/render.ts
@@ -154,7 +154,7 @@ async function safeLinkDestination(path: string, data: Record<string, unknown>):
   const hasHtmlReferencePrefix = /&#(?:\d+|x[\dA-F]+)/i.test(value)
     || [...value.matchAll(/&([A-Za-z][A-Za-z\d]*)(?=[^=A-Za-z\d]|$)/g)]
       .some(match => legacyHtmlReferences.has(match[1]!))
-  if (hasPathBackslash || hasHtmlReferencePrefix || /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
+  if (value.trim() !== value || hasPathBackslash || hasHtmlReferencePrefix || /^(?:[a-z][a-z\d+.-]*:)?\/{2,}(?:[^/?#]*@)?\[/i.test(value) || [...value].some((character) => {
     const codePoint = character.codePointAt(0)!
     return codePoint < 32 || codePoint === 127
   })) {

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -47,6 +47,10 @@ describe("renderMarkdownTemplate", () => {
     })).resolves.toBe("[Open recap](https://example.com/?a=1&debug)")
 
     await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
+      data: { url: "https://example.com/?q=a\\b" },
+    })).resolves.toBe("[Open recap](https://example.com/?q=a%5Cb)")
+
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
       data: { url: "https://example.com/a) [Injected](https://evil.test?q=\"x\"" },
     })).resolves.toBe("[Open recap](https://example.com/a%29%20%5BInjected%5D%28https://evil.test?q=%22x%22)")
 

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -71,6 +71,8 @@ describe("renderMarkdownTemplate", () => {
       " https://example.com/recap",
       "https://example.com/recap ",
       "https://example.com/\uD800",
+      "https://example.com/%zz",
+      "https://example.com/?q=%",
       "https://example.com/a\\b",
       "https://example.com/?x=&#x29;*Injected*",
       "https://example.com/?x=&#65/foo",

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -50,12 +50,20 @@ describe("renderMarkdownTemplate", () => {
     const characterReferenceMarkdown = await renderMarkdownTemplate("[Open recap]({{ url }})", {
       data: { url: characterReferenceUrl },
     })
-    expect(characterReferenceMarkdown).toBe("[Open recap](https://example.com/?x=%26#x29;*Injected*)")
+    expect(characterReferenceMarkdown).toBe("[Open recap](https://example.com/?x=&#x2%39;*Injected*)")
     const renderedUrl = new URL(characterReferenceMarkdown.slice("[Open recap](".length, -1))
     const sourceUrl = new URL(characterReferenceUrl)
     expect(renderedUrl.pathname).toBe(sourceUrl.pathname)
-    expect(renderedUrl.search).toBe("?x=%26")
-    expect(renderedUrl.hash).toBe(sourceUrl.hash)
+    expect(renderedUrl.search).toBe(sourceUrl.search)
+    expect(decodeURIComponent(renderedUrl.hash)).toBe(sourceUrl.hash)
+
+    const namedReferenceUrl = "https://example.com/?a=1&amp;b=2"
+    const namedReferenceMarkdown = await renderMarkdownTemplate("[Open recap]({{ url }})", {
+      data: { url: namedReferenceUrl },
+    })
+    expect(namedReferenceMarkdown).toBe("[Open recap](https://example.com/?a=1&am%70;b=2)")
+    const namedReferenceRenderedUrl = new URL(namedReferenceMarkdown.slice("[Open recap](".length, -1))
+    expect([...namedReferenceRenderedUrl.searchParams]).toEqual([...new URL(namedReferenceUrl).searchParams])
 
     await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
       data: { url: "http://[::1]/recap" },

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -46,9 +46,16 @@ describe("renderMarkdownTemplate", () => {
       data: { url: "https://example.com/a) [Injected](https://evil.test?q=\"x\"" },
     })).resolves.toBe("[Open recap](https://example.com/a%29%20%5BInjected%5D%28https://evil.test?q=%22x%22)")
 
-    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
-      data: { url: "https://example.com/?x=&#x29;*Injected*" },
-    })).resolves.toBe("[Open recap](https://example.com/?x=%26%23x29%3B*Injected*)")
+    const characterReferenceUrl = "https://example.com/?x=&#x29;*Injected*"
+    const characterReferenceMarkdown = await renderMarkdownTemplate("[Open recap]({{ url }})", {
+      data: { url: characterReferenceUrl },
+    })
+    expect(characterReferenceMarkdown).toBe("[Open recap](https://example.com/?x=%26#x29;*Injected*)")
+    const renderedUrl = new URL(characterReferenceMarkdown.slice("[Open recap](".length, -1))
+    const sourceUrl = new URL(characterReferenceUrl)
+    expect(renderedUrl.pathname).toBe(sourceUrl.pathname)
+    expect(renderedUrl.search).toBe("?x=%26")
+    expect(renderedUrl.hash).toBe(sourceUrl.hash)
 
     await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
       data: { url: "http://[::1]/recap" },

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -62,6 +62,8 @@ describe("renderMarkdownTemplate", () => {
       "https://example.com/first\n[Injected](https://evil.test)",
       "https://example.com/\uD800",
       "https://example.com/?x=&#x29;*Injected*",
+      "https://example.com/?x=&#65/foo",
+      "https://example.com/?x=&copy/foo",
       "https://example.com/?a=1&amp;b=2",
       "http://[::1]/recap",
       "//[::1]/recap",

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -50,7 +50,7 @@ describe("renderMarkdownTemplate", () => {
     const characterReferenceMarkdown = await renderMarkdownTemplate("[Open recap]({{ url }})", {
       data: { url: characterReferenceUrl },
     })
-    expect(characterReferenceMarkdown).toBe("[Open recap](https://example.com/?x=&#x2%39;*Injected*)")
+    expect(characterReferenceMarkdown).toBe("[Open recap](https://example.com/?x=&#x%329;*Injected*)")
     const renderedUrl = new URL(characterReferenceMarkdown.slice("[Open recap](".length, -1))
     const sourceUrl = new URL(characterReferenceUrl)
     expect(renderedUrl.pathname).toBe(sourceUrl.pathname)
@@ -61,7 +61,7 @@ describe("renderMarkdownTemplate", () => {
     const namedReferenceMarkdown = await renderMarkdownTemplate("[Open recap]({{ url }})", {
       data: { url: namedReferenceUrl },
     })
-    expect(namedReferenceMarkdown).toBe("[Open recap](https://example.com/?a=1&am%70;b=2)")
+    expect(namedReferenceMarkdown).toBe("[Open recap](https://example.com/?a=1&%61mp;b=2)")
     const namedReferenceRenderedUrl = new URL(namedReferenceMarkdown.slice("[Open recap](".length, -1))
     expect([...namedReferenceRenderedUrl.searchParams]).toEqual([...new URL(namedReferenceUrl).searchParams])
 

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -46,37 +46,6 @@ describe("renderMarkdownTemplate", () => {
       data: { url: "https://example.com/a) [Injected](https://evil.test?q=\"x\"" },
     })).resolves.toBe("[Open recap](https://example.com/a%29%20%5BInjected%5D%28https://evil.test?q=%22x%22)")
 
-    const characterReferenceUrl = "https://example.com/?x=&#x29;*Injected*"
-    const characterReferenceMarkdown = await renderMarkdownTemplate("[Open recap]({{ url }})", {
-      data: { url: characterReferenceUrl },
-    })
-    expect(characterReferenceMarkdown).toBe("[Open recap](https://example.com/?x=&#x%329;*Injected*)")
-    const renderedUrl = new URL(characterReferenceMarkdown.slice("[Open recap](".length, -1))
-    const sourceUrl = new URL(characterReferenceUrl)
-    expect(renderedUrl.pathname).toBe(sourceUrl.pathname)
-    expect(renderedUrl.search).toBe(sourceUrl.search)
-    expect(decodeURIComponent(renderedUrl.hash)).toBe(sourceUrl.hash)
-
-    const namedReferenceUrl = "https://example.com/?a=1&amp;b=2"
-    const namedReferenceMarkdown = await renderMarkdownTemplate("[Open recap]({{ url }})", {
-      data: { url: namedReferenceUrl },
-    })
-    expect(namedReferenceMarkdown).toBe("[Open recap](https://example.com/?a=1&%61mp;b=2)")
-    const namedReferenceRenderedUrl = new URL(namedReferenceMarkdown.slice("[Open recap](".length, -1))
-    expect([...namedReferenceRenderedUrl.searchParams]).toEqual([...new URL(namedReferenceUrl).searchParams])
-
-    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
-      data: { url: "http://[::1]/recap" },
-    })).resolves.toBe("[Open recap](http://[::1]/recap)")
-
-    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
-      data: { url: "http://[0:0:0:0:0:0:0:1]/recap" },
-    })).resolves.toBe("[Open recap](http://[0:0:0:0:0:0:0:1]/recap)")
-
-    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
-      data: { url: "//[::1]/recap" },
-    })).resolves.toBe("[Open recap](//[::1]/recap)")
-
     await expect(renderMarkdownTemplate("[Open recap]({{ url }} \"Monthly recap\")", {
       data: { url: "https://prs.onmax.me/recap/2026-07" },
     })).resolves.toBe("[Open recap](https://prs.onmax.me/recap/2026-07){title=\"Monthly recap\"}")
@@ -92,6 +61,9 @@ describe("renderMarkdownTemplate", () => {
       "data:text/html,<script>alert(1)</script>",
       "https://example.com/first\n[Injected](https://evil.test)",
       "https://example.com/\uD800",
+      "https://example.com/?x=&#x29;*Injected*",
+      "https://example.com/?a=1&amp;b=2",
+      "http://[::1]/recap",
     ]) {
       await expect(renderMarkdownTemplate("[Open recap]({{ url }})", { data: { url } }))
         .rejects.toThrow("must resolve to a safe destination")

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -64,6 +64,7 @@ describe("renderMarkdownTemplate", () => {
       "https://example.com/?x=&#x29;*Injected*",
       "https://example.com/?a=1&amp;b=2",
       "http://[::1]/recap",
+      "//[::1]/recap",
     ]) {
       await expect(renderMarkdownTemplate("[Open recap]({{ url }})", { data: { url } }))
         .rejects.toThrow("must resolve to a safe destination")

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -45,6 +45,10 @@ describe("renderMarkdownTemplate", () => {
     await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
       data: { url: "https://example.com/a) [Injected](https://evil.test?q=\"x\"" },
     })).resolves.toBe("[Open recap](https://example.com/a%29%20%5BInjected%5D%28https://evil.test?q=%22x%22)")
+
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }} \"Monthly recap\")", {
+      data: { url: "https://prs.onmax.me/recap/2026-07" },
+    })).resolves.toBe("[Open recap](https://prs.onmax.me/recap/2026-07){title=\"Monthly recap\"}")
   })
 
   it("rejects unsafe Markdown link destinations", async () => {

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -62,6 +62,14 @@ describe("renderMarkdownTemplate", () => {
       data: { url: "/recap\u00A0" },
     })).resolves.toBe("[Open recap](/recap%C2%A0)")
 
+    await expect(renderMarkdownTemplate("[Open item]({{ url }})", {
+      data: { url: "web+demo:/folder\\item" },
+    })).resolves.toBe("[Open item](web+demo:/folder%5Citem)")
+
+    await expect(renderMarkdownTemplate("[Open item]({{ url }})", {
+      data: { url: "web+demo://host/folder\\item" },
+    })).resolves.toBe("[Open item](web+demo://host/folder%5Citem)")
+
     await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
       data: { url: "https://example.com/a) [Injected](https://evil.test?q=\"x\"" },
     })).resolves.toBe("[Open recap](https://example.com/a%29%20%5BInjected%5D%28https://evil.test?q=%22x%22)")

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -34,6 +34,14 @@ describe("renderMarkdownTemplate", () => {
       data: { url: "https://prs.onmax.me/recap/2026-07" },
     })).resolves.toBe("[Open recap](https://prs.onmax.me/recap/2026-07)")
 
+    await expect(renderMarkdownTemplate("[Open page]({{ page }})", {
+      data: { page: 42 },
+    })).resolves.toBe("[Open page](42)")
+
+    await expect(renderMarkdownTemplate("[Open state]({{ enabled }})", {
+      data: { enabled: true },
+    })).resolves.toBe("[Open state](true)")
+
     await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
       data: { url: "/recap/July 2026_(final)?share=team&from=email#top" },
     })).resolves.toBe("[Open recap](/recap/July%202026_%28final%29?share=team&from=email#top)")
@@ -102,6 +110,20 @@ describe("renderMarkdownTemplate", () => {
       "No recap",
       "::",
     ].join("\n"), { data: { enabled: false } })).resolves.toBe("No recap")
+  })
+
+  it("keeps scalar bindings in other Markdown destinations unchanged", async () => {
+    await expect(renderMarkdownTemplate("[Open item](/items/{{ id }})", {
+      data: { id: "abc" },
+    })).resolves.toBe("\\[Open item\\](/items/abc)")
+
+    await expect(renderMarkdownTemplate("![Preview]({{ url }})", {
+      data: { url: "https://example.com/preview.png" },
+    })).resolves.toBe("!\\[Preview\\](https://example.com/preview.png)")
+
+    await expect(renderMarkdownTemplate("[Open item][item]\n\n[item]: {{ url }}", {
+      data: { url: "https://example.com/item" },
+    })).resolves.toBe("\\[Open item\\][item]\n\n[item]: https://example.com/item")
   })
 
   it("renders Markdown fragments without recursively evaluating template syntax", async () => {

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -29,6 +29,49 @@ describe("renderMarkdownTemplate", () => {
     ].join("\n"))
   })
 
+  it("renders scalar bindings as complete Markdown link destinations", async () => {
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
+      data: { url: "https://prs.onmax.me/recap/2026-07" },
+    })).resolves.toBe("[Open recap](https://prs.onmax.me/recap/2026-07)")
+
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
+      data: { url: "/recap/July 2026_(final)?share=team&from=email#top" },
+    })).resolves.toBe("[Open recap](/recap/July%202026_%28final%29?share=team&from=email#top)")
+
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
+      data: { url: "https://example.com/recap/July%202026?signature=a%2Fb%3D" },
+    })).resolves.toBe("[Open recap](https://example.com/recap/July%202026?signature=a%2Fb%3D)")
+
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
+      data: { url: "https://example.com/a) [Injected](https://evil.test?q=\"x\"" },
+    })).resolves.toBe("[Open recap](https://example.com/a%29%20%5BInjected%5D%28https://evil.test?q=%22x%22)")
+  })
+
+  it("rejects unsafe Markdown link destinations", async () => {
+    for (const url of [
+      "javascript:alert(1)",
+      "data:text/html,<script>alert(1)</script>",
+      "https://example.com/first\n[Injected](https://evil.test)",
+      "https://example.com/\uD800",
+    ]) {
+      await expect(renderMarkdownTemplate("[Open recap]({{ url }})", { data: { url } }))
+        .rejects.toThrow("must resolve to a safe destination")
+    }
+
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }})"))
+      .rejects.toThrow("binding \"{{ url }}\" is not defined")
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", { data: { url: {} } }))
+      .rejects.toThrow("must resolve to a scalar value")
+
+    await expect(renderMarkdownTemplate([
+      "::if{enabled}",
+      "[Open recap]({{ missing }})",
+      "::else",
+      "No recap",
+      "::",
+    ].join("\n"), { data: { enabled: false } })).resolves.toBe("No recap")
+  })
+
   it("renders Markdown fragments without recursively evaluating template syntax", async () => {
     const template = [
       "# Review",

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -54,6 +54,10 @@ describe("renderMarkdownTemplate", () => {
       data: { url: "http://[::1]/recap" },
     })).resolves.toBe("[Open recap](http://[::1]/recap)")
 
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
+      data: { url: "http://[0:0:0:0:0:0:0:1]/recap" },
+    })).resolves.toBe("[Open recap](http://[0:0:0:0:0:0:0:1]/recap)")
+
     await expect(renderMarkdownTemplate("[Open recap]({{ url }} \"Monthly recap\")", {
       data: { url: "https://prs.onmax.me/recap/2026-07" },
     })).resolves.toBe("[Open recap](https://prs.onmax.me/recap/2026-07){title=\"Monthly recap\"}")

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -68,6 +68,10 @@ describe("renderMarkdownTemplate", () => {
     await expect(renderMarkdownTemplate("[Open recap]({{ url }} \"Monthly recap\")", {
       data: { url: "https://prs.onmax.me/recap/2026-07" },
     })).resolves.toBe("[Open recap](https://prs.onmax.me/recap/2026-07){title=\"Monthly recap\"}")
+
+    await expect(renderMarkdownTemplate("[Open recap](<{{ url }}> \"Monthly recap\")", {
+      data: { url: "https://prs.onmax.me/recap/2026-07" },
+    })).resolves.toBe("[Open recap](https://prs.onmax.me/recap/2026-07){title=\"Monthly recap\"}")
   })
 
   it("rejects unsafe Markdown link destinations", async () => {

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -99,6 +99,8 @@ describe("renderMarkdownTemplate", () => {
       "https://example.com/?x=&copy/foo",
       "https://example.com/?a=1&amp;b=2",
       "http://[::1]/recap",
+      "http:[::1]/recap",
+      "ftp:/[::1]/recap",
       "//[::1]/recap",
       "///[::1]/recap",
     ]) {

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -46,6 +46,14 @@ describe("renderMarkdownTemplate", () => {
       data: { url: "https://example.com/a) [Injected](https://evil.test?q=\"x\"" },
     })).resolves.toBe("[Open recap](https://example.com/a%29%20%5BInjected%5D%28https://evil.test?q=%22x%22)")
 
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
+      data: { url: "https://example.com/?x=&#x29;*Injected*" },
+    })).resolves.toBe("[Open recap](https://example.com/?x=%26#x29;*Injected*)")
+
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
+      data: { url: "http://[::1]/recap" },
+    })).resolves.toBe("[Open recap](http://[::1]/recap)")
+
     await expect(renderMarkdownTemplate("[Open recap]({{ url }} \"Monthly recap\")", {
       data: { url: "https://prs.onmax.me/recap/2026-07" },
     })).resolves.toBe("[Open recap](https://prs.onmax.me/recap/2026-07){title=\"Monthly recap\"}")

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -48,7 +48,7 @@ describe("renderMarkdownTemplate", () => {
 
     await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
       data: { url: "https://example.com/?x=&#x29;*Injected*" },
-    })).resolves.toBe("[Open recap](https://example.com/?x=%26#x29;*Injected*)")
+    })).resolves.toBe("[Open recap](https://example.com/?x=%26%23x29%3B*Injected*)")
 
     await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
       data: { url: "http://[::1]/recap" },

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -65,6 +65,7 @@ describe("renderMarkdownTemplate", () => {
       "data:text/html,<script>alert(1)</script>",
       "https://example.com/first\n[Injected](https://evil.test)",
       "https://example.com/\uD800",
+      "https://example.com/a\\b",
       "https://example.com/?x=&#x29;*Injected*",
       "https://example.com/?x=&#65/foo",
       "https://example.com/?x=&copy/foo",

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -43,6 +43,10 @@ describe("renderMarkdownTemplate", () => {
     })).resolves.toBe("[Open recap](https://example.com/recap/July%202026?signature=a%2Fb%3D)")
 
     await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
+      data: { url: "https://example.com/?a=1&debug" },
+    })).resolves.toBe("[Open recap](https://example.com/?a=1&debug)")
+
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
       data: { url: "https://example.com/a) [Injected](https://evil.test?q=\"x\"" },
     })).resolves.toBe("[Open recap](https://example.com/a%29%20%5BInjected%5D%28https://evil.test?q=%22x%22)")
 

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -68,6 +68,8 @@ describe("renderMarkdownTemplate", () => {
       "javascript:alert(1)",
       "data:text/html,<script>alert(1)</script>",
       "https://example.com/first\n[Injected](https://evil.test)",
+      " https://example.com/recap",
+      "https://example.com/recap ",
       "https://example.com/\uD800",
       "https://example.com/a\\b",
       "https://example.com/?x=&#x29;*Injected*",

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -51,6 +51,10 @@ describe("renderMarkdownTemplate", () => {
     })).resolves.toBe("[Open recap](https://example.com/?q=a%5Cb)")
 
     await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
+      data: { url: "/recap\u00A0" },
+    })).resolves.toBe("[Open recap](/recap%C2%A0)")
+
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
       data: { url: "https://example.com/a) [Injected](https://evil.test?q=\"x\"" },
     })).resolves.toBe("[Open recap](https://example.com/a%29%20%5BInjected%5D%28https://evil.test?q=%22x%22)")
 

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -65,6 +65,7 @@ describe("renderMarkdownTemplate", () => {
       "https://example.com/?a=1&amp;b=2",
       "http://[::1]/recap",
       "//[::1]/recap",
+      "///[::1]/recap",
     ]) {
       await expect(renderMarkdownTemplate("[Open recap]({{ url }})", { data: { url } }))
         .rejects.toThrow("must resolve to a safe destination")

--- a/packages/markdown-template/test/render.test.ts
+++ b/packages/markdown-template/test/render.test.ts
@@ -73,6 +73,10 @@ describe("renderMarkdownTemplate", () => {
       data: { url: "http://[0:0:0:0:0:0:0:1]/recap" },
     })).resolves.toBe("[Open recap](http://[0:0:0:0:0:0:0:1]/recap)")
 
+    await expect(renderMarkdownTemplate("[Open recap]({{ url }})", {
+      data: { url: "//[::1]/recap" },
+    })).resolves.toBe("[Open recap](//[::1]/recap)")
+
     await expect(renderMarkdownTemplate("[Open recap]({{ url }} \"Monthly recap\")", {
       data: { url: "https://prs.onmax.me/recap/2026-07" },
     })).resolves.toBe("[Open recap](https://prs.onmax.me/recap/2026-07){title=\"Monthly recap\"}")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1128,6 +1128,9 @@ importers:
 
   packages/markdown-template:
     dependencies:
+      character-entities-legacy:
+        specifier: 3.0.0
+        version: 3.0.0
       comark:
         specifier: catalog:ui
         version: 0.5.1(shiki@4.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -996,9 +996,6 @@ importers:
       '@vite-hub/internal':
         specifier: workspace:*
         version: link:../internal
-      parse5:
-        specifier: 8.0.1
-        version: 8.0.1
       publint:
         specifier: catalog:tooling
         version: 0.3.21

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -996,6 +996,9 @@ importers:
       '@vite-hub/internal':
         specifier: workspace:*
         version: link:../internal
+      parse5:
+        specifier: 8.0.1
+        version: 8.0.1
       publint:
         specifier: catalog:tooling
         version: 0.3.21


### PR DESCRIPTION
`@vite-hub/markdown-template` parsed authored Markdown before substituting scalar bindings, so a complete dynamic destination such as `[Open recap]({{ url }})` stopped being a link before Email received the composed Markdown.

This keeps complete inline anchor destinations structural through Markdown parsing, evaluates their values only in selected branches, percent-encodes bound delimiters while preserving valid percent escapes, and validates the resulting destination through Comark. Values that Comark would reject or reinterpret fail closed instead of producing a different link target. Optional link titles remain structural. Mixed destinations, images, and reference definitions keep their existing behavior.

## Verification

- `pnpm --dir packages/markdown-template test` — 32 passed
- `pnpm --dir packages/markdown-template typecheck`
- `pnpm --dir packages/email test` — 37 passed, including type checks
- `pnpm --dir packages/email typecheck`
- `git diff --check`
- packed `@vite-hub/markdown-template` consumer loaded the real PRs `server/emails/monthly-recap.md` and produced exactly one `<a href="https://prs.onmax.me/recap/2026-07">Open and share your visual recap</a>`
- regressions cover normal and pre-encoded URLs, delimiter injection, unsafe protocols, ambiguous destinations, missing or non-scalar values, optional titles, and selected-branch evaluation