### PR TITLE
chore: align Chat SDK consumer fixture

### DIFF
--- a/fixtures/consumer/vite-hub/package.json
+++ b/fixtures/consumer/vite-hub/package.json
@@ -9,7 +9,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@chat-adapter/telegram": "4.37.0",
+    "@chat-adapter/telegram": "4.38.0",
     "vite": "8.0.8",
     "vite-hub": "*"
   },


### PR DESCRIPTION
The ViteHub catalog, lockfile, and published Agent fixture already resolve the coherent Chat SDK 4.38.0 set, but the packed-consumer fixture still installs Telegram 4.37.0. That leaves the external consumer proof behind the package graph it is meant to validate.

This aligns the remaining fixture with the [Telegram 4.38.0 release](https://github.com/vercel/chat/releases/tag/%40chat-adapter/telegram%404.38.0). No lockfile change is needed because `fixtures/consumer/vite-hub` is installed as an isolated external consumer.

## Verification

- `pnpm install --frozen-lockfile --ignore-scripts`
- `TMPDIR=/private/tmp pnpm exec vp run test:consumer`