### PR TITLE
fix(realtime): preserve markdown frontmatter

### DIFF
--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -61,7 +61,9 @@
   },
   "devDependencies": {
     "@types/node": "catalog:tooling",
+    "@tiptap/pm": "catalog:realtime",
     "@vite-hub/internal": "workspace:*",
+    "linkedom": "^0.18.12",
     "publint": "catalog:tooling",
     "typescript": "catalog:tooling",
     "vite": "catalog:vite",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@tiptap/core": "catalog:realtime",
     "@tiptap/extension-collaboration": "catalog:realtime",
+    "@tiptap/extension-document": "catalog:realtime",
     "@tiptap/extension-image": "catalog:realtime",
     "@tiptap/extension-table": "catalog:realtime",
     "@tiptap/markdown": "catalog:realtime",

--- a/packages/realtime/package.json
+++ b/packages/realtime/package.json
@@ -52,6 +52,7 @@
     "@vite-hub/workspace": "workspace:*",
     "h3": "catalog:unjs",
     "lib0": "catalog:realtime",
+    "marked": "catalog:realtime",
     "pathe": "catalog:unjs",
     "y-protocols": "catalog:realtime",
     "y-websocket": "catalog:realtime",

--- a/packages/realtime/src/editor-extensions.ts
+++ b/packages/realtime/src/editor-extensions.ts
@@ -7,7 +7,7 @@ import { Marked } from "marked"
 
 import { Frontmatter } from "./frontmatter.ts"
 
-const RealtimeDocument = Document.extend({ content: "frontmatter? block*" })
+const RealtimeDocument = Document.extend({ content: "frontmatter? block+" })
 
 export function createRealtimeEditorExtensions() {
   return [

--- a/packages/realtime/src/editor-extensions.ts
+++ b/packages/realtime/src/editor-extensions.ts
@@ -1,0 +1,17 @@
+import Image from "@tiptap/extension-image"
+import { TableKit } from "@tiptap/extension-table"
+import { Markdown } from "@tiptap/markdown"
+import StarterKit from "@tiptap/starter-kit"
+import { Marked } from "marked"
+
+import { Frontmatter } from "./frontmatter.ts"
+
+export function createRealtimeEditorExtensions() {
+  return [
+    StarterKit.configure({ undoRedo: false }),
+    Image,
+    TableKit,
+    Frontmatter,
+    Markdown.configure({ marked: new Marked() as unknown as typeof import("marked").marked }),
+  ]
+}

--- a/packages/realtime/src/editor-extensions.ts
+++ b/packages/realtime/src/editor-extensions.ts
@@ -1,4 +1,5 @@
 import Image from "@tiptap/extension-image"
+import Document from "@tiptap/extension-document"
 import { TableKit } from "@tiptap/extension-table"
 import { Markdown } from "@tiptap/markdown"
 import StarterKit from "@tiptap/starter-kit"
@@ -6,9 +7,12 @@ import { Marked } from "marked"
 
 import { Frontmatter } from "./frontmatter.ts"
 
+const RealtimeDocument = Document.extend({ content: "frontmatter? block*" })
+
 export function createRealtimeEditorExtensions() {
   return [
-    StarterKit.configure({ undoRedo: false }),
+    StarterKit.configure({ document: false, undoRedo: false }),
+    RealtimeDocument,
     Image,
     TableKit,
     Frontmatter,

--- a/packages/realtime/src/frontmatter.ts
+++ b/packages/realtime/src/frontmatter.ts
@@ -23,10 +23,10 @@ export const Frontmatter = Node.create({
   markdownTokenizer: {
     name: "frontmatter",
     level: "block",
-    start: src => /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/.test(src) ? 0 : -1,
+    start: src => /^---\r?\n(?:[\s\S]*?\r?\n)?---(?:\r?\n|$)/.test(src) ? 0 : -1,
     tokenize(src, tokens) {
       if (tokens.length) return
-      const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(src)
+      const match = /^---\r?\n(?:([\s\S]*?)\r?\n)?---(?:\r?\n|$)/.exec(src)
       if (!match) return
       return { type: "frontmatter", raw: match[0], text: match[1] }
     },

--- a/packages/realtime/src/frontmatter.ts
+++ b/packages/realtime/src/frontmatter.ts
@@ -1,0 +1,42 @@
+import { Node } from "@tiptap/core"
+
+export const Frontmatter = Node.create({
+  name: "frontmatter",
+  group: "block",
+  atom: true,
+  selectable: false,
+
+  addAttributes() {
+    return { value: { default: "" } }
+  },
+
+  parseHTML() {
+    return [{ tag: "pre[data-frontmatter]", getAttrs: element => ({ value: element.textContent || "" }) }]
+  },
+
+  renderHTML({ node }) {
+    return ["pre", { "data-frontmatter": "", contenteditable: "false" }, node.attrs.value]
+  },
+
+  markdownTokenName: "frontmatter",
+
+  markdownTokenizer: {
+    name: "frontmatter",
+    level: "block",
+    start: src => /^---\r?\n(?=[\w-]+:)/.test(src) ? 0 : -1,
+    tokenize(src, tokens) {
+      if (tokens.length) return
+      const match = /^---\r?\n(?=[\w-]+:)([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(src)
+      if (!match) return
+      return { type: "frontmatter", raw: match[0], text: match[1] }
+    },
+  },
+
+  parseMarkdown(token, helpers) {
+    return helpers.createNode("frontmatter", { value: token.text || "" })
+  },
+
+  renderMarkdown(node) {
+    return `---\n${node.attrs?.value || ""}\n---`
+  },
+})

--- a/packages/realtime/src/frontmatter.ts
+++ b/packages/realtime/src/frontmatter.ts
@@ -1,4 +1,10 @@
 import { Node } from "@tiptap/core"
+import { Markdown } from "@tiptap/markdown"
+import { Marked } from "marked"
+
+export function createRealtimeMarkdown() {
+  return Markdown.configure({ marked: new Marked() as unknown as typeof import("marked").marked })
+}
 
 export const Frontmatter = Node.create({
   name: "frontmatter",
@@ -23,10 +29,10 @@ export const Frontmatter = Node.create({
   markdownTokenizer: {
     name: "frontmatter",
     level: "block",
-    start: src => /^---\r?\n(?=[\w-]+:)/.test(src) ? 0 : -1,
+    start: src => /^---\r?\n[\s\S]*?\r?\n---(?:\r?\n|$)/.test(src) ? 0 : -1,
     tokenize(src, tokens) {
       if (tokens.length) return
-      const match = /^---\r?\n(?=[\w-]+:)([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(src)
+      const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/.exec(src)
       if (!match) return
       return { type: "frontmatter", raw: match[0], text: match[1] }
     },

--- a/packages/realtime/src/frontmatter.ts
+++ b/packages/realtime/src/frontmatter.ts
@@ -1,10 +1,4 @@
 import { Node } from "@tiptap/core"
-import { Markdown } from "@tiptap/markdown"
-import { Marked } from "marked"
-
-export function createRealtimeMarkdown() {
-  return Markdown.configure({ marked: new Marked() as unknown as typeof import("marked").marked })
-}
 
 export const Frontmatter = Node.create({
   name: "frontmatter",

--- a/packages/realtime/src/frontmatter.ts
+++ b/packages/realtime/src/frontmatter.ts
@@ -1,13 +1,14 @@
 import { Node } from "@tiptap/core"
 
+const frontmatterPattern = /^---\r?\n(?:---(?:\r?\n|$)|([\s\S]*?)\r?\n---(?:\r?\n|$))/
+
 export const Frontmatter = Node.create({
   name: "frontmatter",
-  group: "block",
   atom: true,
   selectable: false,
 
   addAttributes() {
-    return { value: { default: "" } }
+    return { value: { default: null } }
   },
 
   parseHTML() {
@@ -23,20 +24,20 @@ export const Frontmatter = Node.create({
   markdownTokenizer: {
     name: "frontmatter",
     level: "block",
-    start: src => /^---\r?\n(?:[\s\S]*?\r?\n)?---(?:\r?\n|$)/.test(src) ? 0 : -1,
+    start: src => frontmatterPattern.test(src) ? 0 : -1,
     tokenize(src, tokens) {
       if (tokens.length) return
-      const match = /^---\r?\n(?:([\s\S]*?)\r?\n)?---(?:\r?\n|$)/.exec(src)
+      const match = frontmatterPattern.exec(src)
       if (!match) return
       return { type: "frontmatter", raw: match[0], text: match[1] }
     },
   },
 
   parseMarkdown(token, helpers) {
-    return helpers.createNode("frontmatter", { value: token.text || "" })
+    return helpers.createNode("frontmatter", { value: token.text ?? null })
   },
 
   renderMarkdown(node) {
-    return `---\n${node.attrs?.value || ""}\n---`
+    return node.attrs?.value === null ? "---\n---" : `---\n${node.attrs?.value || ""}\n---`
   },
 })

--- a/packages/realtime/src/frontmatter.ts
+++ b/packages/realtime/src/frontmatter.ts
@@ -4,6 +4,7 @@ const frontmatterPattern = /^---\r?\n(?:---(?:\r?\n|$)|([\s\S]*?)\r?\n---(?:\r?\
 
 export const Frontmatter = Node.create({
   name: "frontmatter",
+  priority: 1_000,
   atom: true,
   selectable: false,
 

--- a/packages/realtime/src/frontmatter.ts
+++ b/packages/realtime/src/frontmatter.ts
@@ -16,7 +16,9 @@ export const Frontmatter = Node.create({
     return [{
       tag: "pre[data-frontmatter]",
       getAttrs: element => ({
-        value: element.hasAttribute("data-frontmatter-empty") ? null : element.textContent || "",
+        value: element.hasAttribute("data-frontmatter-empty")
+          ? null
+          : element.getAttribute("data-frontmatter-value") || "",
       }),
     }]
   },
@@ -25,6 +27,7 @@ export const Frontmatter = Node.create({
     return ["pre", {
       "data-frontmatter": "",
       "data-frontmatter-empty": node.attrs.value === null ? "" : undefined,
+      "data-frontmatter-value": node.attrs.value ?? undefined,
       contenteditable: "false",
     }, node.attrs.value ?? ""]
   },

--- a/packages/realtime/src/frontmatter.ts
+++ b/packages/realtime/src/frontmatter.ts
@@ -12,11 +12,20 @@ export const Frontmatter = Node.create({
   },
 
   parseHTML() {
-    return [{ tag: "pre[data-frontmatter]", getAttrs: element => ({ value: element.textContent || "" }) }]
+    return [{
+      tag: "pre[data-frontmatter]",
+      getAttrs: element => ({
+        value: element.hasAttribute("data-frontmatter-empty") ? null : element.textContent || "",
+      }),
+    }]
   },
 
   renderHTML({ node }) {
-    return ["pre", { "data-frontmatter": "", contenteditable: "false" }, node.attrs.value]
+    return ["pre", {
+      "data-frontmatter": "",
+      "data-frontmatter-empty": node.attrs.value === null ? "" : undefined,
+      contenteditable: "false",
+    }, node.attrs.value ?? ""]
   },
 
   markdownTokenName: "frontmatter",

--- a/packages/realtime/src/server.ts
+++ b/packages/realtime/src/server.ts
@@ -1,7 +1,4 @@
 import { Editor } from "@tiptap/core"
-import Image from "@tiptap/extension-image"
-import { TableKit } from "@tiptap/extension-table"
-import StarterKit from "@tiptap/starter-kit"
 import { prosemirrorJSONToYDoc, updateYFragment, yDocToProsemirrorJSON } from "@tiptap/y-tiptap"
 import { assertAuthOrigin } from "@vite-hub/auth/server"
 import { isWorkspaceConflict, normalizeSafeWorkspacePath, resolveWorkspaceStoreTarget, useWorkspace } from "@vite-hub/workspace"
@@ -18,7 +15,7 @@ import type { RealtimeIdentity } from "./presence.ts"
 import type { RealtimeCheckpoint, RealtimeDefinition, RealtimeRegistry } from "./types.ts"
 import { createRealtimeIdentity } from "./presence.ts"
 import { decodeWorkspaceChangePayload, encodeWorkspaceChange, maxAwarenessClients, messageAwareness, messageQueryAwareness, messageWorkspaceChange, readAwarenessClientIds, realtimeCheckpointRejectedCode, realtimeSyncPendingCode } from "./protocol.ts"
-import { createRealtimeMarkdown, Frontmatter } from "./frontmatter.ts"
+import { createRealtimeEditorExtensions } from "./editor-extensions.ts"
 
 const routePrefix = "/api/_vitehub/realtime/"
 const maxMessageBytes = 1024 * 1024
@@ -35,19 +32,11 @@ const durableUpdateCompactionInterval = 128
 const messageSync = 0
 const fragmentName = "default"
 
-const createEditorExtensions = () => [
-  StarterKit.configure({ undoRedo: false }),
-  Image,
-  TableKit,
-  Frontmatter,
-  createRealtimeMarkdown(),
-]
-
 export function markdownToYDoc(markdown: string): Y.Doc {
   const editor = new Editor({
     content: markdown || { type: "doc", content: [{ type: "paragraph" }] },
     contentType: "markdown",
-    extensions: createEditorExtensions(),
+    extensions: createRealtimeEditorExtensions(),
   })
   try {
     return prosemirrorJSONToYDoc(editor.schema, editor.getJSON(), fragmentName)
@@ -60,7 +49,7 @@ export function markdownToYDoc(markdown: string): Y.Doc {
 export function yDocToMarkdown(document: Y.Doc): string {
   const editor = new Editor({
     content: yDocToProsemirrorJSON(document, fragmentName),
-    extensions: createEditorExtensions(),
+    extensions: createRealtimeEditorExtensions(),
   })
   try {
     return editor.getMarkdown()
@@ -74,7 +63,7 @@ export function replaceRealtimeDocument(document: Y.Doc, markdown: string): Uint
   const editor = new Editor({
     content: markdown || { type: "doc", content: [{ type: "paragraph" }] },
     contentType: "markdown",
-    extensions: createEditorExtensions(),
+    extensions: createRealtimeEditorExtensions(),
   })
   const state = Y.encodeStateVector(document)
   try {

--- a/packages/realtime/src/server.ts
+++ b/packages/realtime/src/server.ts
@@ -1,7 +1,6 @@
 import { Editor } from "@tiptap/core"
 import Image from "@tiptap/extension-image"
 import { TableKit } from "@tiptap/extension-table"
-import { Markdown } from "@tiptap/markdown"
 import StarterKit from "@tiptap/starter-kit"
 import { prosemirrorJSONToYDoc, updateYFragment, yDocToProsemirrorJSON } from "@tiptap/y-tiptap"
 import { assertAuthOrigin } from "@vite-hub/auth/server"
@@ -19,7 +18,7 @@ import type { RealtimeIdentity } from "./presence.ts"
 import type { RealtimeCheckpoint, RealtimeDefinition, RealtimeRegistry } from "./types.ts"
 import { createRealtimeIdentity } from "./presence.ts"
 import { decodeWorkspaceChangePayload, encodeWorkspaceChange, maxAwarenessClients, messageAwareness, messageQueryAwareness, messageWorkspaceChange, readAwarenessClientIds, realtimeCheckpointRejectedCode, realtimeSyncPendingCode } from "./protocol.ts"
-import { Frontmatter } from "./frontmatter.ts"
+import { createRealtimeMarkdown, Frontmatter } from "./frontmatter.ts"
 
 const routePrefix = "/api/_vitehub/realtime/"
 const maxMessageBytes = 1024 * 1024
@@ -36,19 +35,19 @@ const durableUpdateCompactionInterval = 128
 const messageSync = 0
 const fragmentName = "default"
 
-const editorExtensions = [
+const createEditorExtensions = () => [
   StarterKit.configure({ undoRedo: false }),
   Image,
   TableKit,
   Frontmatter,
-  Markdown,
+  createRealtimeMarkdown(),
 ]
 
 export function markdownToYDoc(markdown: string): Y.Doc {
   const editor = new Editor({
     content: markdown || { type: "doc", content: [{ type: "paragraph" }] },
     contentType: "markdown",
-    extensions: editorExtensions,
+    extensions: createEditorExtensions(),
   })
   try {
     return prosemirrorJSONToYDoc(editor.schema, editor.getJSON(), fragmentName)
@@ -61,7 +60,7 @@ export function markdownToYDoc(markdown: string): Y.Doc {
 export function yDocToMarkdown(document: Y.Doc): string {
   const editor = new Editor({
     content: yDocToProsemirrorJSON(document, fragmentName),
-    extensions: editorExtensions,
+    extensions: createEditorExtensions(),
   })
   try {
     return editor.getMarkdown()
@@ -75,7 +74,7 @@ export function replaceRealtimeDocument(document: Y.Doc, markdown: string): Uint
   const editor = new Editor({
     content: markdown || { type: "doc", content: [{ type: "paragraph" }] },
     contentType: "markdown",
-    extensions: editorExtensions,
+    extensions: createEditorExtensions(),
   })
   const state = Y.encodeStateVector(document)
   try {

--- a/packages/realtime/src/server.ts
+++ b/packages/realtime/src/server.ts
@@ -19,6 +19,7 @@ import type { RealtimeIdentity } from "./presence.ts"
 import type { RealtimeCheckpoint, RealtimeDefinition, RealtimeRegistry } from "./types.ts"
 import { createRealtimeIdentity } from "./presence.ts"
 import { decodeWorkspaceChangePayload, encodeWorkspaceChange, maxAwarenessClients, messageAwareness, messageQueryAwareness, messageWorkspaceChange, readAwarenessClientIds, realtimeCheckpointRejectedCode, realtimeSyncPendingCode } from "./protocol.ts"
+import { Frontmatter } from "./frontmatter.ts"
 
 const routePrefix = "/api/_vitehub/realtime/"
 const maxMessageBytes = 1024 * 1024
@@ -39,6 +40,7 @@ const editorExtensions = [
   StarterKit.configure({ undoRedo: false }),
   Image,
   TableKit,
+  Frontmatter,
   Markdown,
 ]
 

--- a/packages/realtime/src/vue.ts
+++ b/packages/realtime/src/vue.ts
@@ -13,6 +13,7 @@ import type { MaybeRefOrGetter } from "vue"
 import type { RealtimeIdentity } from "./presence.ts"
 import type { RealtimeCheckpoint, RealtimePerson, RealtimeWorkspaceChange } from "./types.ts"
 import { resolveRealtimeApplicationPath } from "./application-path.ts"
+import { Frontmatter } from "./frontmatter.ts"
 import { createRealtimeIdentity, getRealtimePeople } from "./presence.ts"
 import { decodeWorkspaceChangePayload, encodeWorkspaceChange, isRetryableRealtimeCheckpointCode, messageWorkspaceChange, workspaceRoomId } from "./protocol.ts"
 
@@ -193,6 +194,7 @@ export function useRealtimeTiptap(definition: string, documentId: MaybeRefOrGett
           StarterKit.configure({ undoRedo: false }),
           Image,
           TableKit,
+          Frontmatter,
           Markdown,
           markRaw(Collaboration.configure({ fragment: markRaw(document.value.getXmlFragment("default")) })),
         ]

--- a/packages/realtime/src/vue.ts
+++ b/packages/realtime/src/vue.ts
@@ -2,7 +2,6 @@ import Collaboration from "@tiptap/extension-collaboration"
 import Image from "@tiptap/extension-image"
 import StarterKit from "@tiptap/starter-kit"
 import { TableKit } from "@tiptap/extension-table"
-import { Markdown } from "@tiptap/markdown"
 import { useUserSession } from "@vite-hub/auth/vue"
 import * as decoding from "lib0/decoding"
 import { computed, markRaw, onScopeDispose, ref, shallowRef, toValue, watch } from "vue"
@@ -13,7 +12,7 @@ import type { MaybeRefOrGetter } from "vue"
 import type { RealtimeIdentity } from "./presence.ts"
 import type { RealtimeCheckpoint, RealtimePerson, RealtimeWorkspaceChange } from "./types.ts"
 import { resolveRealtimeApplicationPath } from "./application-path.ts"
-import { Frontmatter } from "./frontmatter.ts"
+import { createRealtimeMarkdown, Frontmatter } from "./frontmatter.ts"
 import { createRealtimeIdentity, getRealtimePeople } from "./presence.ts"
 import { decodeWorkspaceChangePayload, encodeWorkspaceChange, isRetryableRealtimeCheckpointCode, messageWorkspaceChange, workspaceRoomId } from "./protocol.ts"
 
@@ -195,7 +194,7 @@ export function useRealtimeTiptap(definition: string, documentId: MaybeRefOrGett
           Image,
           TableKit,
           Frontmatter,
-          Markdown,
+          createRealtimeMarkdown(),
           markRaw(Collaboration.configure({ fragment: markRaw(document.value.getXmlFragment("default")) })),
         ]
       : []),

--- a/packages/realtime/src/vue.ts
+++ b/packages/realtime/src/vue.ts
@@ -1,7 +1,4 @@
 import Collaboration from "@tiptap/extension-collaboration"
-import Image from "@tiptap/extension-image"
-import StarterKit from "@tiptap/starter-kit"
-import { TableKit } from "@tiptap/extension-table"
 import { useUserSession } from "@vite-hub/auth/vue"
 import * as decoding from "lib0/decoding"
 import { computed, markRaw, onScopeDispose, ref, shallowRef, toValue, watch } from "vue"
@@ -12,7 +9,7 @@ import type { MaybeRefOrGetter } from "vue"
 import type { RealtimeIdentity } from "./presence.ts"
 import type { RealtimeCheckpoint, RealtimePerson, RealtimeWorkspaceChange } from "./types.ts"
 import { resolveRealtimeApplicationPath } from "./application-path.ts"
-import { createRealtimeMarkdown, Frontmatter } from "./frontmatter.ts"
+import { createRealtimeEditorExtensions } from "./editor-extensions.ts"
 import { createRealtimeIdentity, getRealtimePeople } from "./presence.ts"
 import { decodeWorkspaceChangePayload, encodeWorkspaceChange, isRetryableRealtimeCheckpointCode, messageWorkspaceChange, workspaceRoomId } from "./protocol.ts"
 
@@ -190,11 +187,7 @@ export function useRealtimeTiptap(definition: string, documentId: MaybeRefOrGett
     extensions: computed(() => document.value
       && provider.value
         ? [
-          StarterKit.configure({ undoRedo: false }),
-          Image,
-          TableKit,
-          Frontmatter,
-          createRealtimeMarkdown(),
+          ...createRealtimeEditorExtensions(),
           markRaw(Collaboration.configure({ fragment: markRaw(document.value.getXmlFragment("default")) })),
         ]
       : []),

--- a/packages/realtime/test/frontmatter-html.test.ts
+++ b/packages/realtime/test/frontmatter-html.test.ts
@@ -38,7 +38,10 @@ describe("frontmatter HTML", () => {
     const parsed = DOMParser.fromSchema(source.schema).parse(parsedDocument.body)
     expect(parsed.toJSON()).toEqual({
       type: "doc",
-      content: [{ type: "frontmatter", attrs: { value } }],
+      content: [
+        { type: "frontmatter", attrs: { value } },
+        { type: "paragraph" },
+      ],
     })
 
     source.destroy()

--- a/packages/realtime/test/frontmatter-html.test.ts
+++ b/packages/realtime/test/frontmatter-html.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { Editor } from "@tiptap/core"
+import { DOMParser } from "@tiptap/pm/model"
+import { parseHTML } from "linkedom"
+
+import { createRealtimeEditorExtensions } from "../src/editor-extensions.ts"
+
+describe("frontmatter HTML", () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it.each([
+    { sentinel: true, value: null },
+    { sentinel: false, value: "" },
+  ])("round-trips delimiter-only value $value", ({ sentinel, value }) => {
+    const { document, window } = parseHTML("<!doctype html><html><body></body></html>")
+    Object.defineProperty(document, "implementation", {
+      value: { createHTMLDocument: () => parseHTML("<!doctype html><html><body></body></html>").document },
+    })
+    Object.defineProperty(document, "getSelection", {
+      value: () => ({ addRange() {}, rangeCount: 0, removeAllRanges() {} }),
+    })
+    vi.stubGlobal("document", document)
+    vi.stubGlobal("window", window)
+
+    const source = new Editor({
+      extensions: createRealtimeEditorExtensions(),
+      content: { type: "doc", content: [{ type: "frontmatter", attrs: { value } }] },
+      injectCSS: false,
+    })
+
+    const html = source.getHTML()
+    const serialized = parseHTML(html).document.querySelector("pre")!
+    expect(serialized.hasAttribute("data-frontmatter")).toBe(true)
+    expect(serialized.hasAttribute("data-frontmatter-empty")).toBe(sentinel)
+    expect(serialized.textContent).toBe("")
+
+    const parsedDocument = parseHTML(`<!doctype html><html><body>${html}</body></html>`).document
+    const parsed = DOMParser.fromSchema(source.schema).parse(parsedDocument.body)
+    expect(parsed.toJSON()).toEqual({
+      type: "doc",
+      content: [{ type: "frontmatter", attrs: { value } }],
+    })
+
+    source.destroy()
+  })
+})

--- a/packages/realtime/test/frontmatter-html.test.ts
+++ b/packages/realtime/test/frontmatter-html.test.ts
@@ -11,7 +11,8 @@ describe("frontmatter HTML", () => {
   it.each([
     { sentinel: true, value: null },
     { sentinel: false, value: "" },
-  ])("round-trips delimiter-only value $value", ({ sentinel, value }) => {
+    { sentinel: false, value: "\nname: docs" },
+  ])("round-trips frontmatter value $value", ({ sentinel, value }) => {
     const { document, window } = parseHTML("<!doctype html><html><body></body></html>")
     Object.defineProperty(document, "implementation", {
       value: { createHTMLDocument: () => parseHTML("<!doctype html><html><body></body></html>").document },
@@ -32,7 +33,7 @@ describe("frontmatter HTML", () => {
     const serialized = parseHTML(html).document.querySelector("pre")!
     expect(serialized.hasAttribute("data-frontmatter")).toBe(true)
     expect(serialized.hasAttribute("data-frontmatter-empty")).toBe(sentinel)
-    expect(serialized.textContent).toBe("")
+    expect(serialized.getAttribute("data-frontmatter-value")).toBe(value)
 
     const parsedDocument = parseHTML(`<!doctype html><html><body>${html}</body></html>`).document
     const parsed = DOMParser.fromSchema(source.schema).parse(parsedDocument.body)

--- a/packages/realtime/test/server.test.ts
+++ b/packages/realtime/test/server.test.ts
@@ -1065,6 +1065,8 @@ describe("tiptap-markdown documents", () => {
   it("preserves frontmatter independently of its first YAML token", () => {
     const documents = [
       "---\n---",
+      "---\n---\n\n# Page",
+      "---\n\n---\n\n# Page",
       "---\n# comment\nname: docs\n---\n\n# Page",
       "---\n\nname: docs\n---\n\n# Page",
       "---\n\"navigation.order\": 1\n---\n\n# Page",

--- a/packages/realtime/test/server.test.ts
+++ b/packages/realtime/test/server.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { yDocToProsemirrorJSON } from "@tiptap/y-tiptap"
+import type { JSONContent } from "@tiptap/core"
 import * as decoding from "lib0/decoding"
 import * as awarenessProtocol from "y-protocols/awareness"
 import * as Y from "yjs"
@@ -1049,6 +1051,22 @@ describe("tiptap-markdown documents", () => {
     expect(normalized).toContain("![Diagram](https://example.com/diagram.png)")
     expect(normalized).toContain("| One  | Two")
     expect(yDocToMarkdown(markdownToYDoc(normalized))).toBe(normalized)
+  })
+
+  it("round-trips YAML frontmatter without turning it into document headings", () => {
+    const markdown = `---\nname: docs\ndescription: Shared editing\ndisabled: true\n---\n\n# Shared page`
+    const normalized = yDocToMarkdown(markdownToYDoc(markdown))
+
+    expect(normalized).toBe(markdown)
+    expect(yDocToMarkdown(markdownToYDoc(normalized))).toBe(normalized)
+  })
+
+  it("recognizes frontmatter only as the first document block", () => {
+    const leading = yDocToProsemirrorJSON(markdownToYDoc("---\r\nname: docs\r\n---\r\n\r\n# Page"), "default")
+    const later = yDocToProsemirrorJSON(markdownToYDoc("# Page\n\n---\nname: section\n---"), "default")
+
+    expect(leading.content?.map((node: JSONContent) => node.type)).toEqual(["frontmatter", "heading"])
+    expect(later.content?.map((node: JSONContent) => node.type)).not.toContain("frontmatter")
   })
 
   it("conditionally writes the live document for a Workspace checkpoint", async () => {

--- a/packages/realtime/test/server.test.ts
+++ b/packages/realtime/test/server.test.ts
@@ -1091,9 +1091,11 @@ describe("tiptap-markdown documents", () => {
   it("recognizes frontmatter only as the first document block", () => {
     const leading = yDocToProsemirrorJSON(markdownToYDoc("---\r\nname: docs\r\n---\r\n\r\n# Page"), "default")
     const later = yDocToProsemirrorJSON(markdownToYDoc("# Page\n\n---\nname: section\n---"), "default")
+    const nested = "> ---\n> name: quoted\n> ---"
 
     expect(leading.content?.map((node: JSONContent) => node.type)).toEqual(["frontmatter", "heading"])
     expect(later.content?.map((node: JSONContent) => node.type)).not.toContain("frontmatter")
+    expect(yDocToMarkdown(markdownToYDoc(nested))).toBe(nested)
   })
 
   it("conditionally writes the live document for a Workspace checkpoint", async () => {

--- a/packages/realtime/test/server.test.ts
+++ b/packages/realtime/test/server.test.ts
@@ -1064,6 +1064,7 @@ describe("tiptap-markdown documents", () => {
 
   it("preserves frontmatter independently of its first YAML token", () => {
     const documents = [
+      "---\n---",
       "---\n# comment\nname: docs\n---\n\n# Page",
       "---\n\nname: docs\n---\n\n# Page",
       "---\n\"navigation.order\": 1\n---\n\n# Page",

--- a/packages/realtime/test/server.test.ts
+++ b/packages/realtime/test/server.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { yDocToProsemirrorJSON } from "@tiptap/y-tiptap"
 import type { JSONContent } from "@tiptap/core"
+import { marked } from "marked"
 import * as decoding from "lib0/decoding"
 import * as awarenessProtocol from "y-protocols/awareness"
 import * as Y from "yjs"
@@ -1059,6 +1060,29 @@ describe("tiptap-markdown documents", () => {
 
     expect(normalized).toBe(markdown)
     expect(yDocToMarkdown(markdownToYDoc(normalized))).toBe(normalized)
+  })
+
+  it("preserves frontmatter independently of its first YAML token", () => {
+    const documents = [
+      "---\n# comment\nname: docs\n---\n\n# Page",
+      "---\n\nname: docs\n---\n\n# Page",
+      "---\n\"navigation.order\": 1\n---\n\n# Page",
+      "---\n- docs\n- api\n---\n\n# Page",
+    ]
+
+    for (const markdown of documents) {
+      expect(yDocToMarkdown(markdownToYDoc(markdown))).toBe(markdown)
+    }
+  })
+
+  it("does not register frontmatter tokenizers on the shared Markdown parser", () => {
+    const extensions = marked.defaults.extensions
+
+    for (let index = 0; index < 5; index++) {
+      yDocToMarkdown(markdownToYDoc("---\nname: docs\n---\n\n# Page"))
+    }
+
+    expect(marked.defaults.extensions).toBe(extensions)
   })
 
   it("recognizes frontmatter only as the first document block", () => {

--- a/packages/realtime/test/vue.test.ts
+++ b/packages/realtime/test/vue.test.ts
@@ -63,12 +63,12 @@ describe("useRealtimeTiptap", () => {
     const realtime = scope.run(() => useRealtimeTiptap("docs", ref("page.md")))!
     const editor = new Editor({
       extensions: realtime.extensions.value,
-      content: "---\n# comment\nname: docs\n---\n\n# Page",
+      content: "---\n---\n\n# Page",
       contentType: "markdown",
     })
 
     expect(editor.getJSON().content?.map(node => node.type)).toEqual(["frontmatter", "heading"])
-    expect(editor.getMarkdown()).toBe("---\n# comment\nname: docs\n---\n\n# Page")
+    expect(editor.getMarkdown()).toBe("---\n---\n\n# Page")
 
     editor.destroy()
     scope.stop()

--- a/packages/realtime/test/vue.test.ts
+++ b/packages/realtime/test/vue.test.ts
@@ -73,6 +73,9 @@ describe("useRealtimeTiptap", () => {
     editor.commands.insertContentAt(0, { type: "paragraph", content: [{ type: "text", text: "Before" }] })
     expect(editor.getJSON().content?.map(node => node.type)).toEqual(["frontmatter", "heading"])
 
+    editor.commands.deleteRange({ from: 1, to: editor.state.doc.content.size })
+    expect(editor.getJSON().content?.map(node => node.type)).toEqual(["frontmatter", "paragraph"])
+
     editor.destroy()
     scope.stop()
   })

--- a/packages/realtime/test/vue.test.ts
+++ b/packages/realtime/test/vue.test.ts
@@ -70,6 +70,9 @@ describe("useRealtimeTiptap", () => {
     expect(editor.getJSON().content?.map(node => node.type)).toEqual(["frontmatter", "heading"])
     expect(editor.getMarkdown()).toBe("---\n---\n\n# Page")
 
+    editor.commands.insertContentAt(0, { type: "paragraph", content: [{ type: "text", text: "Before" }] })
+    expect(editor.getJSON().content?.map(node => node.type)).toEqual(["frontmatter", "heading"])
+
     editor.destroy()
     scope.stop()
   })

--- a/packages/realtime/test/vue.test.ts
+++ b/packages/realtime/test/vue.test.ts
@@ -2,7 +2,6 @@ import { effectScope, nextTick, ref } from "vue"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { Editor } from "@tiptap/core"
 
-import { Frontmatter } from "../src/frontmatter.ts"
 import { useRealtimeTiptap } from "../src/vue.ts"
 
 const providers = vi.hoisted(() => [] as Array<{
@@ -76,23 +75,6 @@ describe("useRealtimeTiptap", () => {
 
     editor.destroy()
     scope.stop()
-  })
-
-  it("keeps delimiter-only frontmatter distinct in DOM output", () => {
-    const renderHTML = Frontmatter.config.renderHTML as unknown as (props: object) => unknown
-    const parseHTML = Frontmatter.config.parseHTML as unknown as () => Array<{ getAttrs: (element: object) => unknown }>
-    const rendered = renderHTML({ node: { attrs: { value: null } } })
-    const parsed = parseHTML()[0]!.getAttrs({
-      hasAttribute: (name: string) => name === "data-frontmatter-empty",
-      textContent: "",
-    })
-
-    expect(rendered).toEqual(["pre", {
-      "data-frontmatter": "",
-      "data-frontmatter-empty": "",
-      contenteditable: "false",
-    }, ""])
-    expect(parsed).toEqual({ value: null })
   })
 
   it("connects providers only while enabled", async () => {

--- a/packages/realtime/test/vue.test.ts
+++ b/packages/realtime/test/vue.test.ts
@@ -1,5 +1,6 @@
 import { effectScope, nextTick, ref } from "vue"
 import { afterEach, describe, expect, it, vi } from "vitest"
+import { Editor } from "@tiptap/core"
 
 import { useRealtimeTiptap } from "../src/vue.ts"
 
@@ -56,6 +57,23 @@ afterEach(() => {
 })
 
 describe("useRealtimeTiptap", () => {
+  it("preserves frontmatter through the Vue editor extensions", () => {
+    vi.stubGlobal("window", { location: { host: "example.com", protocol: "https:" } })
+    const scope = effectScope()
+    const realtime = scope.run(() => useRealtimeTiptap("docs", ref("page.md")))!
+    const editor = new Editor({
+      extensions: realtime.extensions.value,
+      content: "---\n# comment\nname: docs\n---\n\n# Page",
+      contentType: "markdown",
+    })
+
+    expect(editor.getJSON().content?.map(node => node.type)).toEqual(["frontmatter", "heading"])
+    expect(editor.getMarkdown()).toBe("---\n# comment\nname: docs\n---\n\n# Page")
+
+    editor.destroy()
+    scope.stop()
+  })
+
   it("connects providers only while enabled", async () => {
     vi.stubGlobal("window", { location: { host: "example.com", protocol: "https:" } })
     const enabled = ref(false)

--- a/packages/realtime/test/vue.test.ts
+++ b/packages/realtime/test/vue.test.ts
@@ -2,6 +2,7 @@ import { effectScope, nextTick, ref } from "vue"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { Editor } from "@tiptap/core"
 
+import { Frontmatter } from "../src/frontmatter.ts"
 import { useRealtimeTiptap } from "../src/vue.ts"
 
 const providers = vi.hoisted(() => [] as Array<{
@@ -75,6 +76,23 @@ describe("useRealtimeTiptap", () => {
 
     editor.destroy()
     scope.stop()
+  })
+
+  it("keeps delimiter-only frontmatter distinct in DOM output", () => {
+    const renderHTML = Frontmatter.config.renderHTML as unknown as (props: object) => unknown
+    const parseHTML = Frontmatter.config.parseHTML as unknown as () => Array<{ getAttrs: (element: object) => unknown }>
+    const rendered = renderHTML({ node: { attrs: { value: null } } })
+    const parsed = parseHTML()[0]!.getAttrs({
+      hasAttribute: (name: string) => name === "data-frontmatter-empty",
+      textContent: "",
+    })
+
+    expect(rendered).toEqual(["pre", {
+      "data-frontmatter": "",
+      "data-frontmatter-empty": "",
+      contenteditable: "false",
+    }, ""])
+    expect(parsed).toEqual({ value: null })
   })
 
   it("connects providers only while enabled", async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ catalogs:
     lib0:
       specifier: ^0.2.114
       version: 0.2.117
+    marked:
+      specifier: 17.0.6
+      version: 17.0.6
     y-protocols:
       specifier: ^1.0.6
       version: 1.0.7
@@ -1269,6 +1272,9 @@ importers:
       lib0:
         specifier: catalog:realtime
         version: 0.2.117
+      marked:
+        specifier: catalog:realtime
+        version: 17.0.6
       pathe:
         specifier: catalog:unjs
         version: 2.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ catalogs:
     '@tiptap/markdown':
       specifier: ^3.29.2
       version: 3.29.2
+    '@tiptap/pm':
+      specifier: ^3.29.2
+      version: 3.29.2
     '@tiptap/starter-kit':
       specifier: ^3.29.2
       version: 3.29.2
@@ -1297,12 +1300,18 @@ importers:
         specifier: catalog:realtime
         version: 13.6.30
     devDependencies:
+      '@tiptap/pm':
+        specifier: catalog:realtime
+        version: 3.29.2
       '@types/node':
         specifier: catalog:tooling
         version: 24.13.3
       '@vite-hub/internal':
         specifier: workspace:*
         version: link:../internal
+      linkedom:
+        specifier: ^0.18.12
+        version: 0.18.13
       publint:
         specifier: catalog:tooling
         version: 0.3.21
@@ -9132,6 +9141,10 @@ packages:
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
 
+  css-select@7.0.0:
+    resolution: {integrity: sha512-snmjEVXy+1LnwXdxhYvTMj1d9tOh4HxkA1YmoayVBeeyR2C14Pum7fcxJIm4SswYspVy866eYNwlH6xC3/VH5g==}
+    engines: {node: '>=20.19.0'}
+
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
@@ -10580,6 +10593,9 @@ packages:
   html-whitespace-sensitive-tag-names@3.0.1:
     resolution: {integrity: sha512-q+310vW8zmymYHALr1da4HyXUQ0zgiIwIicEfotYPWGN0OJVEN/58IJ3A4GBYcEq3LGAZqKb+ugvP0GNB9CEAA==}
 
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
   htmlparser2@12.0.0:
     resolution: {integrity: sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==}
     engines: {node: '>=20.19.0'}
@@ -11142,6 +11158,15 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  linkedom@0.18.13:
+    resolution: {integrity: sha512-ES/o9qotMpzpN2MHs+Iq/JcVoOj8Fa5wiQYrTdFpvAnwXL0g66XHHUc9WUMk6nAlBtGsFQ24ne+SYnvnaQ2FSw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: '>= 2'
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   linkify-it@5.0.2:
     resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
@@ -11778,6 +11803,10 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  nth-check@3.0.1:
+    resolution: {integrity: sha512-GX0gsdbGVCgnRgbeGaubfjpBXyYRWOOCVeYh08bSQvDZqxz5ndXs1OTfAt/h36G1xvI94YIspsI0sVFqAV9+RQ==}
+    engines: {node: '>=20.19.0'}
 
   nuxt-component-meta@0.17.2:
     resolution: {integrity: sha512-2/mSSqutOX8t+r8cAX1yUYwAPBqicPO5Rfum3XaHVszxKCF4tXEXBiPGfJY9Zn69x/CIeOdw+aM9wmHzQ5Q+lA==}
@@ -22719,6 +22748,14 @@ snapshots:
       domutils: 3.2.2
       nth-check: 2.1.1
 
+  css-select@7.0.0:
+    dependencies:
+      boolbase: 2.0.0
+      css-what: 8.0.0
+      domhandler: 6.0.1
+      domutils: 4.0.2
+      nth-check: 3.0.1
+
   css-tree@2.2.1:
     dependencies:
       mdn-data: 2.0.28
@@ -24603,6 +24640,13 @@ snapshots:
 
   html-whitespace-sensitive-tag-names@3.0.1: {}
 
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
   htmlparser2@12.0.0:
     dependencies:
       domelementtype: 3.0.0
@@ -25200,6 +25244,14 @@ snapshots:
 
   lines-and-columns@1.2.4:
     optional: true
+
+  linkedom@0.18.13:
+    dependencies:
+      css-select: 7.0.0
+      cssom: 0.5.0
+      html-escaper: 3.0.3
+      htmlparser2: 10.1.0
+      uhyphen: 0.2.0
 
   linkify-it@5.0.2:
     dependencies:
@@ -26414,6 +26466,10 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  nth-check@3.0.1:
+    dependencies:
+      boolbase: 2.0.0
 
   nuxt-component-meta@0.17.2(magicast@0.5.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,9 @@ catalogs:
     '@tiptap/extension-collaboration':
       specifier: ^3.29.2
       version: 3.29.2
+    '@tiptap/extension-document':
+      specifier: ^3.29.2
+      version: 3.29.2
     '@tiptap/extension-image':
       specifier: ^3.29.2
       version: 3.29.2
@@ -1242,6 +1245,9 @@ importers:
       '@tiptap/extension-collaboration':
         specifier: catalog:realtime
         version: 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))(@tiptap/pm@3.29.2)(@tiptap/y-tiptap@3.0.8(prosemirror-model@1.25.11)(prosemirror-state@1.4.4)(prosemirror-view@1.42.1)(y-protocols@1.0.7(yjs@13.6.30))(yjs@13.6.30))(yjs@13.6.30)
+      '@tiptap/extension-document':
+        specifier: catalog:realtime
+        version: 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))
       '@tiptap/extension-image':
         specifier: catalog:realtime
         version: 3.29.2(@tiptap/core@3.29.2(@tiptap/pm@3.29.2))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1832,6 +1832,24 @@ importers:
 
 packages:
 
+  boolbase@2.0.0:
+    resolution: {integrity: sha512-DkVaaQHymRhpYEYo9x1oo7Q7B0Y6KJUsjm3c9eTyFDby4MHLBTwZ6ZDWBel5zrYxj1WsZgC5oLpiz+93MluXeA==}
+    engines: {node: '>=20.19.0'}
+
+  css-what@8.0.0:
+    resolution: {integrity: sha512-DH0Bqq3DNp5tdOReuNyAA+Ev4Y2GS5FMbZpeTLP6C4CDi0h5nL0BmUPChXw3o/qbHLDWHl49sbNqQVY7bMSDdw==}
+    engines: {node: '>=20.19.0'}
+
+  cssom@0.5.0:
+    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
+
+  html-escaper@3.0.3:
+    resolution: {integrity: sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==}
+
+  uhyphen@0.2.0:
+    resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
+
+
   '@ai-sdk/gateway@3.0.151':
     resolution: {integrity: sha512-gsKEm1LleR/xm1FiJjnNxf1ZUKZryj20STsKJB7TdMcaiRqQgeHrdYWv/DNSA8ZBkRahHC+wEYHaI0VR9/EOwQ==}
     engines: {node: '>=18'}
@@ -14325,6 +14343,16 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  boolbase@2.0.0: {}
+
+  css-what@8.0.0: {}
+
+  cssom@0.5.0: {}
+
+  html-escaper@3.0.3: {}
+
+  uhyphen@0.2.0: {}
 
   '@ai-sdk/gateway@3.0.151(zod@4.4.3)':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -59,6 +59,7 @@ catalogs:
     "@tiptap/extension-image": ^3.29.2
     "@tiptap/extension-table": ^3.29.2
     "@tiptap/markdown": ^3.29.2
+    "@tiptap/pm": ^3.29.2
     "@tiptap/starter-kit": ^3.29.2
     "@tiptap/y-tiptap": ^3.0.8
     lib0: ^0.2.114

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,6 +61,7 @@ catalogs:
     "@tiptap/starter-kit": ^3.29.2
     "@tiptap/y-tiptap": ^3.0.8
     lib0: ^0.2.114
+    marked: 17.0.6
     y-protocols: ^1.0.6
     y-websocket: ^3.0.0
     yjs: ^13.6.27

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -55,6 +55,7 @@ catalogs:
   realtime:
     "@tiptap/core": ^3.29.2
     "@tiptap/extension-collaboration": ^3.29.2
+    "@tiptap/extension-document": ^3.29.2
     "@tiptap/extension-image": ^3.29.2
     "@tiptap/extension-table": ^3.29.2
     "@tiptap/markdown": ^3.29.2


### PR DESCRIPTION
Realtime currently parses leading YAML frontmatter as a horizontal rule followed by a heading. That makes a newly opened document appear changed, and a checkpoint can replace the closing delimiter with Markdown heading syntax.

This adds a dedicated frontmatter node to the shared server and Vue Tiptap extension sets. It preserves the opaque YAML payload through Markdown, HTML, and Yjs, recognizes only a complete first document block, and leaves rendering or form controls to the consuming interface. Each editor receives isolated Markdown parser state so repeated conversions and browser remounts do not accumulate tokenizer callbacks.

## Verification

- `pnpm --filter @vite-hub/realtime... build`
- `pnpm --filter @vite-hub/realtime exec vp test test/frontmatter-html.test.ts test/server.test.ts test/vue.test.ts` — 69 tests passed
- `pnpm --filter @vite-hub/realtime typecheck`
- `pnpm exec oxlint packages/realtime/test/frontmatter-html.test.ts packages/realtime/test/vue.test.ts packages/realtime/src/frontmatter.ts`
- `pnpm install --lockfile-only --frozen-lockfile`
