### PR TITLE
feat(agent): export invocation telemetry over OTLP

### DIFF
--- a/docs/content/docs/agents/agent-definitions.md
+++ b/docs/content/docs/agents/agent-definitions.md
@@ -109,6 +109,7 @@ With the implicit discovery-default Workflow binding, direct `runAgent()` calls 
 | `runtime` | Selects inline or Workflow-backed hosted execution. |
 | `hooks` | Observes input, completion, failure, Capability lifecycle, or hook execution. |
 | `runEvents` | Publishes application-owned progress for an invocation with a stable run id. |
+| `telemetry` | Exports completed invocation traces without changing Agent output. |
 | `name`, `description`, `version` | Adds explicit discovery and inspection metadata. |
 | `cli.capabilities` | Enables or disables Capability-contributed CLI commands. |
 

--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -142,7 +142,25 @@ export default defineAgent({
 })
 ```
 
-Every invocation also has an in-memory metadata trace through `runtime.trace` and `runtime.traceLog`. The default log is process-local and is not persisted across a Workflow boundary. Supply your own trace sink when the application needs durable observability.
+Every invocation also has an in-memory metadata trace through `runtime.trace` and `runtime.traceLog`. The default log is process-local and is not persisted across a Workflow boundary.
+
+Use the Agent telemetry option to send completed invocation spans to an OTLP/HTTP JSON receiver:
+
+```ts [server/agents/support.ts]
+import { defineAgent, otlpHttpJson } from '@vite-hub/agent'
+
+export default defineAgent({
+  name: 'support',
+  telemetry: otlpHttpJson({
+    endpoint: 'https://console.example/v1/traces',
+    headers: { authorization: `Bearer ${process.env.CONSOLE_TOKEN!}` },
+    resource: { 'service.namespace': 'quiver' },
+  }),
+  driver: { model: 'openai/gpt-5.1-mini' },
+})
+```
+
+Pass the complete traces endpoint, including `/v1/traces` when the receiver uses the conventional OTLP path. ViteHub exports only metadata, even when the invocation uses a caller-supplied content trace log, and includes setup failures that occur before the Driver starts. Export runs through `runtime.waitUntil()`, so delivery failures do not replace the Agent result. Receivers should deduplicate spans by trace and span id because retries can deliver the same invocation more than once.
 
 ## Control child work
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -89,6 +89,7 @@ import {
   withJsonCompatibleToolOutputs,
 } from "./tool-runtime.ts"
 import {
+  agentInvocationTraceIdContextKey,
   traceAgentInvocationError,
   traceAgentChannelDeliveryEffect,
   traceAgentInvocationFinish,
@@ -1784,6 +1785,7 @@ type AgentInvocationContext<
   startTask?: Promise<void>
   telemetry?: AgentTelemetry<TRuntimeConfig>
   telemetryAgent: { name?: string, version?: string }
+  telemetryInvocationId: string
   instructions?: string
   startedAt: number
   actor: AgentInvoker
@@ -1931,11 +1933,13 @@ function scheduleAgentTelemetry<TRuntimeConfig extends AgentRuntimeConfig>(
   telemetry: AgentTelemetry<TRuntimeConfig> | undefined,
   runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>,
   agent: { name?: string, version?: string },
+  invocationId: string,
 ): void {
   if (!telemetry || !runtime.traceLog) return
   const task = Promise.resolve()
     .then(async () => {
-      const runs = deriveTraceRuns(runtime.traceLog!.entries())
+      const events = runtime.traceLog!.entries().filter(event => event.attributes?.["agent.invocation.id"] === invocationId)
+      const runs = deriveTraceRuns(events)
       const id = runtime.run?.runId || runtime.trace?.id
       const run = (id ? runs.find(candidate => candidate.id === id) : undefined) || (runs.length === 1 ? runs[0] : undefined)
       if (!run || run.status === "running") return
@@ -1978,6 +1982,8 @@ async function createAgentInvocationContext<
       }
   let runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig> & { runEvents?: AgentRunEventPublisher } = tracedRuntimeContext
   const invocationContext = createAgentInvocationContextStore(input.context)
+  const telemetryInvocationId = createTraceId()
+  invocationContext.set(agentInvocationTraceIdContextKey, telemetryInvocationId, { overwrite: true })
   let invoker = createFallbackAgentInvoker(context.run)
   try {
     const boundRunEvents = bindAgentRunEvents(definition?.runEvents, tracedRuntimeContext)
@@ -2178,6 +2184,7 @@ async function createAgentInvocationContext<
       startedAt,
       telemetry: definition?.telemetry,
       telemetryAgent: { name: definition?.name, version: definition?.version },
+      telemetryInvocationId,
       tools,
       workspace: activeWorkspace,
       workspaceAutoCommit,
@@ -2216,7 +2223,7 @@ async function createAgentInvocationContext<
       run: context.run,
       runtime: runtimeContext,
     }, error)
-    scheduleAgentTelemetry(definition?.telemetry, runtimeContext, { name: definition?.name, version: definition?.version })
+    scheduleAgentTelemetry(definition?.telemetry, runtimeContext, { name: definition?.name, version: definition?.version }, telemetryInvocationId)
     throw error
   }
 }
@@ -2246,6 +2253,7 @@ type InvocationRunContext<
   startedAt: number
   telemetry?: AgentTelemetry<TRuntimeConfig>
   telemetryAgent: { name?: string, version?: string }
+  telemetryInvocationId: string
   workspace?: ReadonlyWorkspaceFacade | WritableWorkspaceFacade
   workspaceAutoCommit?: boolean | string
   workspaceDefinition?: WorkspaceDefinition
@@ -3010,7 +3018,7 @@ async function finishAgentInvocation<
     throw finishError
   }
   finally {
-    scheduleAgentTelemetry(context.telemetry, context.runtimeContext, context.telemetryAgent)
+    scheduleAgentTelemetry(context.telemetry, context.runtimeContext, context.telemetryAgent, context.telemetryInvocationId)
   }
 }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1932,27 +1932,28 @@ function scheduleAgentTelemetry<TRuntimeConfig extends AgentRuntimeConfig>(
   runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>,
   agent: { name?: string, version?: string },
 ): void {
-  const traceLog = runtime.traceLog
-  if (!telemetry || !traceLog) return
-  const runs = deriveTraceRuns(traceLog.entries())
-  const id = runtime.run?.runId || runtime.trace?.id
-  const run = (id ? runs.find(candidate => candidate.id === id) : undefined) || (runs.length === 1 ? runs[0] : undefined)
-  if (!run || run.status === "running") return
-  const name = runtime.agentIdentity?.name || agent.name
-  const spans = traceEventsToOpenTelemetrySpans(run.events, { content: "metadata" }).map((span, index) => index
-    ? span
-    : {
-        ...span,
-        attributes: {
-          ...span.attributes,
-          "gen_ai.operation.name": "invoke_agent",
-          ...(name ? { "gen_ai.agent.name": name, "vitehub.agent.name": name } : {}),
-          ...(agent.version ? { "gen_ai.agent.version": agent.version, "vitehub.agent.version": agent.version } : {}),
-          "vitehub.runtime.name": runtime.runtime,
-        },
-      })
+  if (!telemetry || !runtime.traceLog) return
   const task = Promise.resolve()
-    .then(() => telemetry({ agent: { ...(name ? { name } : {}), ...(agent.version ? { version: agent.version } : {}) }, run: runtime.run, runtime, spans }))
+    .then(async () => {
+      const runs = deriveTraceRuns(runtime.traceLog!.entries())
+      const id = runtime.run?.runId || runtime.trace?.id
+      const run = (id ? runs.find(candidate => candidate.id === id) : undefined) || (runs.length === 1 ? runs[0] : undefined)
+      if (!run || run.status === "running") return
+      const name = runtime.agentIdentity?.name || agent.name
+      const spans = traceEventsToOpenTelemetrySpans(run.events, { content: "metadata" }).map((span, index) => index
+        ? span
+        : {
+            ...span,
+            attributes: {
+              ...span.attributes,
+              "gen_ai.operation.name": "invoke_agent",
+              ...(name ? { "gen_ai.agent.name": name, "vitehub.agent.name": name } : {}),
+              ...(agent.version ? { "gen_ai.agent.version": agent.version, "vitehub.agent.version": agent.version } : {}),
+              "vitehub.runtime.name": runtime.runtime,
+            },
+          })
+      await telemetry({ agent: { ...(name ? { name } : {}), ...(agent.version ? { version: agent.version } : {}) }, run: runtime.run, runtime, spans })
+    })
     .catch(() => console.error("[vitehub] Agent telemetry export failed."))
   registerAgentBackgroundTask(runtime, task)
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1929,6 +1929,22 @@ function registerAgentBackgroundTask(runtime: Pick<ResolvedAgentRuntimeContext, 
   catch {}
 }
 
+function agentInvocationTraceLog(traceLog: NonNullable<ResolvedAgentRuntimeContext["traceLog"]>, invocationId: string, runId?: string): NonNullable<ResolvedAgentRuntimeContext["traceLog"]> {
+  return {
+    append(event) {
+      return traceLog.append({
+        ...event,
+        attributes: {
+          "agent.invocation.id": invocationId,
+          ...(runId ? { "agent.run.id": runId } : {}),
+          ...event.attributes,
+        },
+      })
+    },
+    entries: () => traceLog.entries(),
+  }
+}
+
 function scheduleAgentTelemetry<TRuntimeConfig extends AgentRuntimeConfig>(
   telemetry: AgentTelemetry<TRuntimeConfig> | undefined,
   runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>,
@@ -1973,17 +1989,20 @@ async function createAgentInvocationContext<
 ): Promise<AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>> {
   const startedAt = Date.now()
   const resolvedContext = createResolvedRuntimeContext(context)
-  const tracedRuntimeContext = resolvedContext.trace && resolvedContext.traceLog
+  const invocationContext = createAgentInvocationContextStore(input.context)
+  const telemetryInvocationId = createTraceId()
+  invocationContext.set(agentInvocationTraceIdContextKey, telemetryInvocationId, { overwrite: true })
+  const tracedRuntimeContextBase = resolvedContext.trace && resolvedContext.traceLog
     ? resolvedContext
     : {
         ...resolvedContext,
         trace: resolvedContext.trace || { id: createTraceId(context.run) },
         traceLog: resolvedContext.traceLog || createTraceEventLog(),
       }
+  const tracedRuntimeContext = definition?.telemetry && tracedRuntimeContextBase.traceLog
+    ? { ...tracedRuntimeContextBase, traceLog: agentInvocationTraceLog(tracedRuntimeContextBase.traceLog, telemetryInvocationId, context.run?.runId) }
+    : tracedRuntimeContextBase
   let runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig> & { runEvents?: AgentRunEventPublisher } = tracedRuntimeContext
-  const invocationContext = createAgentInvocationContextStore(input.context)
-  const telemetryInvocationId = createTraceId()
-  invocationContext.set(agentInvocationTraceIdContextKey, telemetryInvocationId, { overwrite: true })
   let invoker = createFallbackAgentInvoker(context.run)
   try {
     const boundRunEvents = bindAgentRunEvents(definition?.runEvents, tracedRuntimeContext)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -19,7 +19,7 @@ import {
   createReplyDeliveryEffectIntent,
   createStatusDeliveryEffectIntent,
 } from "./delivery-effects.ts"
-import { createTraceEventLog, getViteHubErrorShape, resolveRuntimeContext } from "@vite-hub/runtime"
+import { createTraceEventLog, deriveTraceRuns, getViteHubErrorShape, resolveRuntimeContext, traceEventsToOpenTelemetrySpans } from "@vite-hub/runtime"
 import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
 import { defineChatCapability, getChatCapabilityOptions } from "./chat-trigger.ts"
@@ -45,7 +45,7 @@ import {
   webChat as builtInWebChat,
 } from "./channels.ts"
 import { agentInvocationCallbackContextValues, createAgentInvocationContextStore } from "./invocation-context.ts"
-import { bindAgentRunEvents } from "./run-events.ts"
+import { bindAgentRunEvents, type AgentRunEventPublisher } from "./run-events.ts"
 import { isAttachmentPart, materializeMessageAttachmentData, type AgentMessagePhase, type Message } from "./messages.ts"
 import {
   createFallbackAgentInvoker,
@@ -160,6 +160,7 @@ import type {
   AgentRuntimeContext,
   AgentSettings,
   AgentStaticCapabilitiesList,
+  AgentTelemetry,
   AgentUsageRecord,
   AgentWorkflowRuntimeBinding,
   MaybePromise,
@@ -399,6 +400,8 @@ export type {
   AgentToolPolicyContext,
   AgentToolPolicyDecision,
   AgentStateProviderOptions,
+  AgentTelemetry,
+  AgentTelemetryExportContext,
   AgentTriggerContext,
   AgentTriggerDefinition,
   AgentTriggerInvokeResult,
@@ -425,6 +428,9 @@ export type {
   WorkspaceAgentWorkspaceOptions,
   WorkspaceAgentWorkspaceConfig,
 } from "./types.ts"
+
+export { otlpHttpJson } from "./telemetry.ts"
+export type { OtlpHttpJsonOptions, OtlpResourceAttributes } from "./telemetry.ts"
 
 export {
   createAgentInspectionMetadata,
@@ -1163,7 +1169,7 @@ function defineBaseAgent<
   options: AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentInvocationContextValues, AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined, TOutput>,
 ): AgentDefinition<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, AgentInvocationContextValues, TOutput> {
   const driver = normalizeAgentDriver(options)
-  const { box, capabilities, cli, description, hooks, messages, name, runtime = defaultAgentWorkflowRuntime(), runEvents, uiMessageStream, version, workspace } = options
+  const { box, capabilities, cli, description, hooks, messages, name, runtime = defaultAgentWorkflowRuntime(), runEvents, telemetry, uiMessageStream, version, workspace } = options
   const channels = normalizeAgentChannels(options.channels)
   if (box && driver.kind !== "harness") {
     throw new Error("[vitehub] defineAgent({ box }) currently requires a harness Agent Driver.")
@@ -1229,6 +1235,7 @@ function defineBaseAgent<
     name,
     runtime,
     runEvents,
+    telemetry,
     run,
     uiMessageStream,
     version,
@@ -1775,6 +1782,8 @@ type AgentInvocationContext<
   outputRenderers: AgentCapabilityRegistries["outputRenderers"]
   runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>
   startTask?: Promise<void>
+  telemetry?: AgentTelemetry<TRuntimeConfig>
+  telemetryAgent: { name?: string, version?: string }
   instructions?: string
   startedAt: number
   actor: AgentInvoker
@@ -1910,6 +1919,44 @@ async function registerResolvedAgentWorkspaceDefinition(name: string, definition
   registerWorkspace(name, workspace)
 }
 
+function registerAgentBackgroundTask(runtime: Pick<ResolvedAgentRuntimeContext, "waitUntil">, task: Promise<unknown>): void {
+  void task.catch(() => {})
+  try {
+    runtime.waitUntil(task)
+  }
+  catch {}
+}
+
+function scheduleAgentTelemetry<TRuntimeConfig extends AgentRuntimeConfig>(
+  telemetry: AgentTelemetry<TRuntimeConfig> | undefined,
+  runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>,
+  agent: { name?: string, version?: string },
+): void {
+  const traceLog = runtime.traceLog
+  if (!telemetry || !traceLog) return
+  const runs = deriveTraceRuns(traceLog.entries())
+  const id = runtime.run?.runId || runtime.trace?.id
+  const run = (id ? runs.find(candidate => candidate.id === id) : undefined) || (runs.length === 1 ? runs[0] : undefined)
+  if (!run || run.status === "running") return
+  const name = runtime.agentIdentity?.name || agent.name
+  const spans = traceEventsToOpenTelemetrySpans(run.events, { content: "metadata" }).map((span, index) => index
+    ? span
+    : {
+        ...span,
+        attributes: {
+          ...span.attributes,
+          "gen_ai.operation.name": "invoke_agent",
+          ...(name ? { "gen_ai.agent.name": name, "vitehub.agent.name": name } : {}),
+          ...(agent.version ? { "gen_ai.agent.version": agent.version, "vitehub.agent.version": agent.version } : {}),
+          "vitehub.runtime.name": runtime.runtime,
+        },
+      })
+  const task = Promise.resolve()
+    .then(() => telemetry({ agent: { ...(name ? { name } : {}), ...(agent.version ? { version: agent.version } : {}) }, run: runtime.run, runtime, spans }))
+    .catch(() => console.error("[vitehub] Agent telemetry export failed."))
+  registerAgentBackgroundTask(runtime, task)
+}
+
 async function createAgentInvocationContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -1928,22 +1975,23 @@ async function createAgentInvocationContext<
         trace: resolvedContext.trace || { id: createTraceId(context.run) },
         traceLog: resolvedContext.traceLog || createTraceEventLog(),
       }
-  const boundRunEvents = bindAgentRunEvents(definition?.runEvents, tracedRuntimeContext)
-  const runtimeContext = boundRunEvents
-    ? { ...tracedRuntimeContext, runEvents: boundRunEvents }
-    : tracedRuntimeContext
-  const callbackContext = createAgentCallbackContext(runtimeContext)
+  let runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig> & { runEvents?: AgentRunEventPublisher } = tracedRuntimeContext
   const invocationContext = createAgentInvocationContextStore(input.context)
-  bindMessageChannelInstructions(
-    invocationContext,
-    activeAgentChannel(definition?.channels, invocationContext, context.run)?.channel,
-  )
-  invocationContext.set(scheduledAgentChannelIdsContextKey, Object.keys(definition?.channels || {}), { overwrite: true })
-  invocationContext.set(scheduledAgentNameContextKey, context.agentIdentity?.name, { overwrite: true })
-  const colocatedSkills = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[colocatedAgentSkillsSymbol]
-  invocationContext.set(colocatedAgentSkillsContextKey, colocatedSkills, { overwrite: true })
   let invoker = createFallbackAgentInvoker(context.run)
   try {
+    const boundRunEvents = bindAgentRunEvents(definition?.runEvents, tracedRuntimeContext)
+    runtimeContext = boundRunEvents
+      ? { ...tracedRuntimeContext, runEvents: boundRunEvents }
+      : tracedRuntimeContext
+    const callbackContext = createAgentCallbackContext(runtimeContext)
+    bindMessageChannelInstructions(
+      invocationContext,
+      activeAgentChannel(definition?.channels, invocationContext, context.run)?.channel,
+    )
+    invocationContext.set(scheduledAgentChannelIdsContextKey, Object.keys(definition?.channels || {}), { overwrite: true })
+    invocationContext.set(scheduledAgentNameContextKey, context.agentIdentity?.name, { overwrite: true })
+    const colocatedSkills = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[colocatedAgentSkillsSymbol]
+    invocationContext.set(colocatedAgentSkillsContextKey, colocatedSkills, { overwrite: true })
     invoker = await resolveAgentInvoker(
       definition?.invoker,
       callbackContext,
@@ -2127,6 +2175,8 @@ async function createAgentInvocationContext<
       runtimeContext,
       startTask: undefined as Promise<void> | undefined,
       startedAt,
+      telemetry: definition?.telemetry,
+      telemetryAgent: { name: definition?.name, version: definition?.version },
       tools,
       workspace: activeWorkspace,
       workspaceAutoCommit,
@@ -2165,6 +2215,7 @@ async function createAgentInvocationContext<
       run: context.run,
       runtime: runtimeContext,
     }, error)
+    scheduleAgentTelemetry(definition?.telemetry, runtimeContext, { name: definition?.name, version: definition?.version })
     throw error
   }
 }
@@ -2192,6 +2243,8 @@ type InvocationRunContext<
   runtimeContext: ResolvedAgentRuntimeContext<TRuntimeConfig>
   run?: AgentRunContext<TRuntimeConfig, CALL_OPTIONS>["run"]
   startedAt: number
+  telemetry?: AgentTelemetry<TRuntimeConfig>
+  telemetryAgent: { name?: string, version?: string }
   workspace?: ReadonlyWorkspaceFacade | WritableWorkspaceFacade
   workspaceAutoCommit?: boolean | string
   workspaceDefinition?: WorkspaceDefinition
@@ -2955,6 +3008,9 @@ async function finishAgentInvocation<
     await traceAgentInvocationError(toTraceContext(context), failed ? error : finishError)
     throw finishError
   }
+  finally {
+    scheduleAgentTelemetry(context.telemetry, context.runtimeContext, context.telemetryAgent)
+  }
 }
 
 async function finalizeAgentInvocationResult<
@@ -3146,47 +3202,15 @@ type AgentInvocationExecutionOptions =
     onFinish?: (outcome: AgentInvocationFinishOutcome) => void
   }
 
-async function closePreparedInvocationAfterFailure<
+function deferPreparedInvocationFailure<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(
   preparedInvocation: AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>,
   error: unknown,
-  message: string,
-): Promise<never> {
-  const errors = [error]
-  try {
-    await preparedInvocation.startTask
-  }
-  catch (startError) {
-    errors.push(startError)
-  }
-  try {
-    await preparedInvocation.close()
-  }
-  catch (closeError) {
-    errors.push(closeError)
-  }
-  if (errors.length > 1) throw new AggregateError(errors, message)
-  throw error
-}
-
-function deferPreparedInvocationCloseAfterFailure<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  CALL_OPTIONS,
->(
-  preparedInvocation: AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>,
 ): void {
-  const cleanupTask = (async () => {
-    try {
-      await preparedInvocation.startTask
-    }
-    finally {
-      await preparedInvocation.close()
-    }
-  })()
-  preparedInvocation.runtimeContext.waitUntil?.(cleanupTask)
-  void cleanupTask.catch(() => {})
+  const finishTask = finishAgentInvocation(preparedInvocation, { error, status: "error" })
+  registerAgentBackgroundTask(preparedInvocation.runtimeContext, finishTask)
 }
 
 async function executeAgentInvocationWithCapacityLease<
@@ -3201,16 +3225,6 @@ async function executeAgentInvocationWithCapacityLease<
   preparedInvocation?: AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>,
 ): Promise<Response | AsyncIterable<StreamEvent> | unknown> {
   const customRun = hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)
-  let adapter: AgentAdapter<CALL_OPTIONS> | undefined
-  try {
-    adapter = customRun ? undefined : await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(agent, context)
-  }
-  catch (error) {
-    if (preparedInvocation) {
-      return await closePreparedInvocationAfterFailure(preparedInvocation, error, "[vitehub] Agent Driver resolution and invocation cleanup failed.")
-    }
-    throw error
-  }
   const definition = hasAgentDefinition(agent)
     ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput>
     : undefined
@@ -3240,6 +3254,13 @@ async function executeAgentInvocationWithCapacityLease<
   }
 
   const executionFailureMessage = options.kind === "run" || customRun ? runFailureMessage : streamFailureMessage
+  let adapter: AgentAdapter<CALL_OPTIONS> | undefined
+  try {
+    adapter = customRun ? undefined : await resolveAgentForRun<TRuntimeConfig, CALL_OPTIONS>(agent, invocation.runtimeContext)
+  }
+  catch (error) {
+    return await lifecycle.fail({ error, status: "error" }, error, executionFailureMessage)
+  }
   let result: unknown
   try {
     const adapterContext = toAgentAdapterRunContext(invocation)
@@ -3974,7 +3995,7 @@ async function executeAgentInvocation<
   }
   catch (error) {
     if (preparedInvocation) {
-      deferPreparedInvocationCloseAfterFailure(preparedInvocation)
+      deferPreparedInvocationFailure(preparedInvocation, error)
     }
     throw error
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1935,9 +1935,9 @@ function agentInvocationTraceLog(traceLog: NonNullable<ResolvedAgentRuntimeConte
       return traceLog.append({
         ...event,
         attributes: {
+          ...event.attributes,
           "agent.invocation.id": invocationId,
           ...(runId ? { "agent.run.id": runId } : {}),
-          ...event.attributes,
         },
       })
     },

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -208,7 +208,7 @@ export async function runAgentWorkflowDefinition<
     runtime: payload.runtime || agentRuntimeFromWorkflowProvider(context.provider),
     runtimeConfig: (payload.runtimeConfig || {}) as TRuntimeConfig,
     waitUntil(promise: Promise<unknown>) {
-      backgroundTasks.push(Promise.resolve(promise))
+      backgroundTasks.push(Promise.resolve(promise).catch(() => undefined))
     },
   } as never)
 

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -248,7 +248,9 @@ export async function runAgentWorkflowDefinition<
     throw error
   }
   finally {
-    await Promise.allSettled(backgroundTasks)
+    while (backgroundTasks.length) {
+      await Promise.allSettled(backgroundTasks.splice(0))
+    }
   }
 }
 

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -59,10 +59,6 @@ function agentRuntimeFromWorkflowProvider(provider: WorkflowProvider): AgentRunt
   return "unknown"
 }
 
-function waitUntil(promise: Promise<unknown>): void {
-  void Promise.resolve(promise).catch(() => {})
-}
-
 const unportableWorkflowValue = Symbol("vitehub.agent.unportable-workflow-value")
 
 function isJsonWorkflowValue(value: unknown, seen = new WeakSet<object>()): boolean {
@@ -200,6 +196,7 @@ export async function runAgentWorkflowDefinition<
     ? getActiveCloudflareEnv() || getCloudflareEnv(getWorkflowRuntimeEvent())
     : undefined
   const runId = context.id || payload.run?.runId
+  const backgroundTasks: Promise<unknown>[] = []
   let runtimeContext = createAgentRuntimeContext<TRuntimeConfig>({
     ...(payload.agentIdentity ? { agentIdentity: payload.agentIdentity } : {}),
     ...(payload.capabilities ? { capabilities: payload.capabilities } : {}),
@@ -210,7 +207,9 @@ export async function runAgentWorkflowDefinition<
       : {}),
     runtime: payload.runtime || agentRuntimeFromWorkflowProvider(context.provider),
     runtimeConfig: (payload.runtimeConfig || {}) as TRuntimeConfig,
-    waitUntil,
+    waitUntil(promise: Promise<unknown>) {
+      backgroundTasks.push(Promise.resolve(promise))
+    },
   } as never)
 
   const channelDeliveryBinding = payload.input?.context?.[agentChannelDeliveryWorkflowContextKey]
@@ -247,6 +246,9 @@ export async function runAgentWorkflowDefinition<
       await channelDelivery.event({ error: error instanceof Error ? error.message : String(error), type: "failed", runId }).catch(() => undefined)
     }
     throw error
+  }
+  finally {
+    await Promise.allSettled(backgroundTasks)
   }
 }
 

--- a/packages/agent/src/telemetry.ts
+++ b/packages/agent/src/telemetry.ts
@@ -24,9 +24,13 @@ function otlpAnyValue(value: unknown): OtlpAnyValue {
   if (typeof value === "boolean") return { boolValue: value }
   if (typeof value === "number") {
     if (!Number.isFinite(value)) return { stringValue: String(value) }
-    return Number.isInteger(value) ? { intValue: String(value) } : { doubleValue: value }
+    return Number.isSafeInteger(value) ? { intValue: String(value) } : { doubleValue: value }
   }
-  if (typeof value === "bigint") return { intValue: String(value) }
+  if (typeof value === "bigint") {
+    return value >= -(2n ** 63n) && value <= 2n ** 63n - 1n
+      ? { intValue: String(value) }
+      : { stringValue: String(value) }
+  }
   if (typeof value === "string") return { stringValue: value }
   if (Array.isArray(value)) return { arrayValue: { values: value.map(otlpAnyValue) } }
   if (value && typeof value === "object") {

--- a/packages/agent/src/telemetry.ts
+++ b/packages/agent/src/telemetry.ts
@@ -1,0 +1,135 @@
+import type { OpenTelemetrySpanView } from "@vite-hub/runtime"
+
+import type { AgentRuntimeConfig, AgentTelemetry, AgentTelemetryExportContext, MaybePromise } from "./types.ts"
+
+export type OtlpResourceAttributes = Record<string, boolean | number | string>
+
+export interface OtlpHttpJsonOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+  endpoint: string
+  headers?: Record<string, string> | ((context: AgentTelemetryExportContext<TRuntimeConfig>) => MaybePromise<Record<string, string>>)
+  resource?: OtlpResourceAttributes | ((context: AgentTelemetryExportContext<TRuntimeConfig>) => MaybePromise<OtlpResourceAttributes>)
+}
+
+type OtlpAnyValue =
+  | { arrayValue: { values: OtlpAnyValue[] } }
+  | { boolValue: boolean }
+  | { doubleValue: number }
+  | { intValue: string }
+  | { kvlistValue: { values: Array<{ key: string, value: OtlpAnyValue }> } }
+  | { stringValue: string }
+
+const retryableStatuses = new Set([429, 502, 503, 504])
+
+function otlpAnyValue(value: unknown): OtlpAnyValue {
+  if (typeof value === "boolean") return { boolValue: value }
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return { stringValue: String(value) }
+    return Number.isInteger(value) ? { intValue: String(value) } : { doubleValue: value }
+  }
+  if (typeof value === "bigint") return { intValue: String(value) }
+  if (typeof value === "string") return { stringValue: value }
+  if (Array.isArray(value)) return { arrayValue: { values: value.map(otlpAnyValue) } }
+  if (value && typeof value === "object") {
+    return {
+      kvlistValue: {
+        values: Object.entries(value).flatMap(([key, child]) => child === undefined ? [] : [{ key, value: otlpAnyValue(child) }]),
+      },
+    }
+  }
+  return { stringValue: String(value) }
+}
+
+function otlpAttributes(attributes: Record<string, unknown> | undefined) {
+  return Object.entries(attributes || {}).flatMap(([key, value]) => value === undefined ? [] : [{ key, value: otlpAnyValue(value) }])
+}
+
+function unixNanos(value: string | undefined, fallback: string): string {
+  const millis = Date.parse(value || fallback)
+  return String(BigInt(Number.isFinite(millis) ? millis : Date.parse(fallback)) * 1_000_000n)
+}
+
+function otlpSpan(span: OpenTelemetrySpanView, fallbackEndTime: string) {
+  return {
+    attributes: otlpAttributes(span.attributes),
+    endTimeUnixNano: unixNanos(span.endTime, fallbackEndTime),
+    kind: 1,
+    name: span.name,
+    ...(span.parentSpanId ? { parentSpanId: span.parentSpanId } : {}),
+    spanId: span.spanId,
+    startTimeUnixNano: unixNanos(span.startTime, fallbackEndTime),
+    status: { code: span.status.code === "ERROR" ? 2 : 1, ...(span.status.message ? { message: span.status.message } : {}) },
+    traceId: span.traceId,
+  }
+}
+
+function retryAfterMs(response: Response, attempt: number): number {
+  const value = response.headers.get("retry-after")
+  if (value) {
+    const seconds = Number(value)
+    if (Number.isFinite(seconds)) return Math.min(Math.max(seconds * 1_000, 0), 10_000)
+    const date = Date.parse(value)
+    if (Number.isFinite(date)) return Math.min(Math.max(date - Date.now(), 0), 10_000)
+  }
+  return 100 * 2 ** attempt * (0.5 + Math.random())
+}
+
+async function wait(milliseconds: number): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, milliseconds))
+}
+
+async function postOtlp(endpoint: string, headers: Headers, body: string): Promise<void> {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    let response: Response
+    try {
+      response = await fetch(endpoint, {
+        body,
+        headers,
+        method: "POST",
+        signal: AbortSignal.timeout(10_000),
+      })
+    }
+    catch (error) {
+      if (attempt < 2) {
+        await wait(100 * 2 ** attempt * (0.5 + Math.random()))
+        continue
+      }
+      throw new Error("OTLP/HTTP JSON telemetry export failed.", { cause: error })
+    }
+    if (response.ok) return
+    if (attempt < 2 && retryableStatuses.has(response.status)) {
+      await wait(retryAfterMs(response, attempt))
+      continue
+    }
+    throw new Error(`OTLP/HTTP JSON telemetry export failed with status ${response.status}.`)
+  }
+}
+
+export function otlpHttpJson<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
+  options: OtlpHttpJsonOptions<TRuntimeConfig>,
+): AgentTelemetry<TRuntimeConfig> {
+  return async (context) => {
+    if (!context.spans.length) return
+    const [configuredHeaders, configuredResource] = await Promise.all([
+      typeof options.headers === "function" ? options.headers(context) : options.headers,
+      typeof options.resource === "function" ? options.resource(context) : options.resource,
+    ])
+    const headers = new Headers(configuredHeaders)
+    headers.set("content-type", "application/json")
+    const fallbackEndTime = context.spans[0]?.endTime || new Date().toISOString()
+    const resource = {
+      "service.name": context.agent.name || "vitehub-agent",
+      ...(context.agent.version ? { "service.version": context.agent.version } : {}),
+      "vitehub.runtime.name": context.runtime.runtime,
+      ...configuredResource,
+    }
+    await postOtlp(options.endpoint, headers, JSON.stringify({
+      resourceSpans: [{
+        resource: { attributes: otlpAttributes(resource) },
+        scopeSpans: [{
+          scope: { name: "vitehub.agent" },
+          spans: context.spans.map(span => otlpSpan(span, fallbackEndTime)),
+        }],
+      }],
+    }))
+  }
+}

--- a/packages/agent/src/trace.ts
+++ b/packages/agent/src/trace.ts
@@ -22,6 +22,8 @@ export interface AgentTraceContext<TRuntimeConfig extends AgentRuntimeConfig = A
   runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>
 }
 
+export const agentInvocationTraceIdContextKey = "agent.invocation.traceId"
+
 export function hasAgentTraceLog(context: { runtime: ResolvedAgentRuntimeContext }): boolean {
   return Boolean(context.runtime.traceLog)
 }
@@ -98,9 +100,12 @@ export async function traceAgentEvent<TRuntimeConfig extends AgentRuntimeConfig>
   event: TraceEvent,
 ): Promise<void> {
   try {
-    const attributes = context.run?.runId
-      ? { "agent.run.id": context.run.runId, ...event.attributes }
-      : event.attributes
+    const invocationId = context.context.get<string>(agentInvocationTraceIdContextKey)
+    const attributes = {
+      ...(invocationId ? { "agent.invocation.id": invocationId } : {}),
+      ...(context.run?.runId ? { "agent.run.id": context.run.runId } : {}),
+      ...event.attributes,
+    }
     await emitTraceEvent(context.runtime, {
       ...event,
       ...(attributes ? { attributes } : {}),

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -15,6 +15,7 @@ import type {
   RuntimeCapabilityHandle,
   RuntimeHostContext,
   RuntimeWaitUntil,
+  OpenTelemetrySpanView,
 } from "@vite-hub/runtime"
 import type {
   ReadonlyWorkspaceFacade,
@@ -205,6 +206,20 @@ export interface AgentRunMetadata<TOrigin extends string = string> {
   runId: string
   threadId?: string
 }
+
+export interface AgentTelemetryExportContext<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+  agent: {
+    name?: string
+    version?: string
+  }
+  run?: AgentRunMetadata
+  runtime: ResolvedAgentRuntimeContext<TRuntimeConfig>
+  spans: readonly OpenTelemetrySpanView[]
+}
+
+export type AgentTelemetry<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> = (
+  context: AgentTelemetryExportContext<TRuntimeConfig>,
+) => MaybePromise<void>
 
 export interface AgentChannelDelivery {
   agentName: string
@@ -1320,6 +1335,7 @@ type AgentSharedSettings<
   name?: string
   runtime?: AgentRuntimeBinding
   runEvents?: AgentRunEvents
+  telemetry?: AgentTelemetry<TRuntimeConfig>
   uiMessageStream?: AgentUIMessageStreamProjectionResolver<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   version?: string
   workspace?: WorkspaceAgentWorkspaceConfig
@@ -1359,6 +1375,7 @@ export interface AgentDefinition<
   name?: string
   runtime?: AgentRuntimeBinding
   runEvents?: AgentRunEvents
+  telemetry?: AgentTelemetry<TRuntimeConfig>
   resolve(context: AgentRuntimeContext<TRuntimeConfig>): Promise<AgentAdapter<CALL_OPTIONS>>
   run?(context: AgentRunContext<TRuntimeConfig, CALL_OPTIONS, WorkspaceName, TContextValues>): MaybePromise<Response | AgentRunResult | AsyncIterable<StreamEvent> | unknown>
   uiMessageStream?: AgentUIMessageStreamProjectionResolver<TRuntimeConfig, CALL_OPTIONS, TContextValues>

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12218,6 +12218,38 @@ describe("agent message protocol", () => {
       else await expect(workflow).resolves.toBe("ok")
     })
 
+    it("retains Workflow background work registered during cleanup", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      let releaseFirst!: () => void
+      let releaseSecond!: () => void
+      const second = new Promise<void>(resolve => { releaseSecond = resolve })
+      let runtimeContext!: { waitUntil: (task: Promise<unknown>) => void }
+      const first = new Promise<void>(resolve => { releaseFirst = resolve }).then(() => runtimeContext.waitUntil(second))
+      let markRegistered!: () => void
+      const registered = new Promise<void>(resolve => { markRegistered = resolve })
+      let settled = false
+      const workflow = runAgentWorkflowDefinition({} as never, {
+        id: "nested-background",
+        name: "nested-background",
+        payload: {},
+        provider: "vercel",
+      }, async (_agent, context) => {
+        runtimeContext = context
+        context.waitUntil(first)
+        markRegistered()
+        return "ok"
+      })
+      void workflow.finally(() => { settled = true })
+
+      await registered
+      releaseFirst()
+      await first
+      await Promise.resolve()
+      expect(settled).toBe(false)
+      releaseSecond()
+      await expect(workflow).resolves.toBe("ok")
+    })
+
     it("observes Workflow background failures while the invocation is pending", async () => {
       const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
       let rejectTask!: (error: Error) => void

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12218,6 +12218,41 @@ describe("agent message protocol", () => {
       else await expect(workflow).resolves.toBe("ok")
     })
 
+    it("observes Workflow background failures while the invocation is pending", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      let rejectTask!: (error: Error) => void
+      let releaseRun!: () => void
+      let markRegistered!: () => void
+      const task = new Promise<void>((_resolve, reject) => { rejectTask = reject })
+      const run = new Promise<void>(resolve => { releaseRun = resolve })
+      const registered = new Promise<void>(resolve => { markRegistered = resolve })
+      const unhandled = vi.fn()
+      process.on("unhandledRejection", unhandled)
+
+      try {
+        const workflow = runAgentWorkflowDefinition({} as never, {
+          id: "background-rejection",
+          name: "background-rejection",
+          payload: {},
+          provider: "vercel",
+        }, async (_agent, context) => {
+          context.waitUntil(task)
+          markRegistered()
+          await run
+          return "ok"
+        })
+        await registered
+        rejectTask(new Error("background failed"))
+        await new Promise(resolve => setImmediate(resolve))
+        expect(unhandled).not.toHaveBeenCalled()
+        releaseRun()
+        await expect(workflow).resolves.toBe("ok")
+      }
+      finally {
+        process.off("unhandledRejection", unhandled)
+      }
+    })
+
     it("rejects sparse arrays whose custom properties mask missing indices", async () => {
       const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
       const result = Array(1) as unknown[] & { note?: string }

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12193,6 +12193,31 @@ describe("agent message protocol", () => {
       }, async () => [undefined])).rejects.toMatchObject({ isRetryable: false })
     })
 
+    it.each(["success", "failure"] as const)("retains Workflow background work through %s", async (outcome) => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      let release!: () => void
+      const pending = new Promise<void>(resolve => { release = resolve })
+      let settled = false
+      const workflow = runAgentWorkflowDefinition({} as never, {
+        id: `background-${outcome}`,
+        name: `background-${outcome}`,
+        payload: {},
+        provider: "vercel",
+      }, async (_agent, context) => {
+        context.waitUntil(pending)
+        if (outcome === "failure") throw new Error("Agent failed")
+        return "ok"
+      })
+      void workflow.finally(() => { settled = true }).catch(() => {})
+
+      await Promise.resolve()
+      await Promise.resolve()
+      expect(settled).toBe(false)
+      release()
+      if (outcome === "failure") await expect(workflow).rejects.toThrow("Agent failed")
+      else await expect(workflow).resolves.toBe("ok")
+    })
+
     it("rejects sparse arrays whose custom properties mask missing indices", async () => {
       const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
       const result = Array(1) as unknown[] & { note?: string }

--- a/packages/agent/test/telemetry.test.ts
+++ b/packages/agent/test/telemetry.test.ts
@@ -77,6 +77,21 @@ describe("Agent telemetry", () => {
     expect(fetch).toHaveBeenCalledTimes(2)
   })
 
+  it("encodes only safe integers as OTLP int64 values", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => new Response(null, { status: 200 }))
+    vi.stubGlobal("fetch", fetch)
+
+    await otlpHttpJson({ endpoint: "https://console.example/v1/traces", resource: { build: 1e21 } })({
+      agent: {},
+      runtime: { memo: vi.fn(), runtime: "unknown", runtimeConfig: {}, waitUntil: vi.fn() },
+      spans: [{ attributes: { count: 12 }, name: "vitehub.run", spanId: "0123456789abcdef", startTime: "2026-01-01T00:00:00.000Z", status: { code: "OK" }, traceId: "0123456789abcdef0123456789abcdef" }],
+    })
+
+    const body = JSON.parse(String(fetch.mock.calls[0]?.[1]?.body))
+    expect(body.resourceSpans[0].resource.attributes).toContainEqual({ key: "build", value: { doubleValue: 1e21 } })
+    expect(body.resourceSpans[0].scopeSpans[0].spans[0].attributes).toContainEqual({ key: "count", value: { intValue: "12" } })
+  })
+
   it("exports one metadata-only trace after a successful invocation", async () => {
     const tasks: Promise<unknown>[] = []
     const telemetry = vi.fn()
@@ -243,6 +258,34 @@ describe("Agent telemetry", () => {
     await Promise.all(tasks)
 
     expect(error).toHaveBeenCalledWith("[vitehub] Agent telemetry export failed.")
+    error.mockRestore()
+  })
+
+  it("does not let cyclic telemetry preparation change Agent output", async () => {
+    const tasks: Promise<unknown>[] = []
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+    const traceLog = createTraceEventLog({ content: "content" })
+    const agent = defineAgent({
+      telemetry: vi.fn(),
+      driver: {
+        async run(context) {
+          await context.traceLog?.append({ attributes: { details: cyclic }, name: "application.content", type: "run" })
+          return "ok"
+        },
+      },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-cyclic-trace" },
+      runtime: "unknown",
+      traceLog,
+      waitUntil(task) { tasks.push(Promise.resolve(task)) },
+    }, {})).resolves.toBe("ok")
+    await Promise.all(tasks)
+    expect(error).not.toHaveBeenCalled()
     error.mockRestore()
   })
 

--- a/packages/agent/test/telemetry.test.ts
+++ b/packages/agent/test/telemetry.test.ts
@@ -103,7 +103,7 @@ describe("Agent telemetry", () => {
       driver: {
         async run(context) {
           await context.traceLog?.append({
-            attributes: { prompt: "secret prompt" },
+            attributes: { prompt: "secret prompt", source: "custom" },
             name: "application.content",
             type: "run",
           })
@@ -128,6 +128,7 @@ describe("Agent telemetry", () => {
       run: { runId: "run-1" },
       spans: [{
         attributes: {
+          source: "custom",
           "gen_ai.agent.name": "support",
           "gen_ai.operation.name": "invoke_agent",
           "vitehub.agent.name": "support",

--- a/packages/agent/test/telemetry.test.ts
+++ b/packages/agent/test/telemetry.test.ts
@@ -139,6 +139,31 @@ describe("Agent telemetry", () => {
     expect(JSON.stringify(exported.spans)).not.toContain("secret prompt")
   })
 
+  it("exports separate spans when invocations reuse a host trace and log", async () => {
+    const tasks: Promise<unknown>[] = []
+    const telemetry = vi.fn()
+    const traceLog = createTraceEventLog()
+    const runtime = {
+      memo: vi.fn(),
+      runtime: "unknown" as const,
+      trace: { id: "host-trace" },
+      traceLog,
+      waitUntil(task: PromiseLike<unknown>) { tasks.push(Promise.resolve(task)) },
+    }
+    const agent = defineAgent({ telemetry, driver: { run: () => "ok" } })
+
+    await runAgent(agent, runtime, {})
+    await runAgent(agent, runtime, {})
+    await Promise.all(tasks)
+
+    expect(telemetry).toHaveBeenCalledTimes(2)
+    const [first, second] = telemetry.mock.calls.map(call => call[0].spans[0])
+    expect(first.attributes["agent.invocation.id"]).not.toBe(second.attributes["agent.invocation.id"])
+    expect(first.spanId).not.toBe(second.spanId)
+    expect(first.attributes["vitehub.trace.id"]).toBe("host-trace")
+    expect(second.attributes["vitehub.trace.id"]).toBe("host-trace")
+  })
+
   it("exports Capability setup failures without replacing the original error", async () => {
     const tasks: Promise<unknown>[] = []
     const telemetry = vi.fn()

--- a/packages/agent/test/telemetry.test.ts
+++ b/packages/agent/test/telemetry.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { createTraceEventLog } from "@vite-hub/runtime"
+import { defineAgent, otlpHttpJson, runAgent } from "../src/index.ts"
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("Agent telemetry", () => {
+  it("sends completed spans as OTLP/HTTP JSON", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => new Response(null, { status: 200 }))
+    vi.stubGlobal("fetch", fetch)
+    const telemetry = otlpHttpJson({
+      endpoint: "https://console.example/v1/traces",
+      headers: { authorization: "Bearer token" },
+      resource: { "deployment.environment.name": "production" },
+    })
+    const runtime = {
+      memo: vi.fn(),
+      runtime: "vercel" as const,
+      runtimeConfig: {},
+      waitUntil: vi.fn(),
+    }
+
+    await telemetry({
+      agent: { name: "support", version: "1.0.0" },
+      run: { runId: "run-1" },
+      runtime,
+      spans: [{
+        attributes: { "usage.record": { usage: { totalTokens: 12 } } },
+        endTime: "2026-01-01T00:00:00.010Z",
+        name: "vitehub.run",
+        spanId: "0123456789abcdef",
+        startTime: "2026-01-01T00:00:00.000Z",
+        status: { code: "OK" },
+        traceId: "0123456789abcdef0123456789abcdef",
+      }],
+    })
+
+    expect(fetch).toHaveBeenCalledTimes(1)
+    const [endpoint, request] = fetch.mock.calls[0]!
+    const body = JSON.parse(String(request?.body))
+    const resource = Object.fromEntries(body.resourceSpans[0].resource.attributes.map((attribute: { key: string, value: unknown }) => [attribute.key, attribute.value]))
+    const span = body.resourceSpans[0].scopeSpans[0].spans[0]
+    expect(endpoint).toBe("https://console.example/v1/traces")
+    expect(new Headers(request?.headers).get("authorization")).toBe("Bearer token")
+    expect(new Headers(request?.headers).get("content-type")).toBe("application/json")
+    expect(resource).toMatchObject({
+      "deployment.environment.name": { stringValue: "production" },
+      "service.name": { stringValue: "support" },
+      "service.version": { stringValue: "1.0.0" },
+      "vitehub.runtime.name": { stringValue: "vercel" },
+    })
+    expect(span).toMatchObject({
+      endTimeUnixNano: String(BigInt(Date.parse("2026-01-01T00:00:00.010Z")) * 1_000_000n),
+      kind: 1,
+      spanId: "0123456789abcdef",
+      startTimeUnixNano: String(BigInt(Date.parse("2026-01-01T00:00:00.000Z")) * 1_000_000n),
+      status: { code: 1 },
+      traceId: "0123456789abcdef0123456789abcdef",
+    })
+  })
+
+  it("retries transient OTLP responses", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>()
+      .mockResolvedValueOnce(new Response(null, { headers: { "retry-after": "0" }, status: 503 }))
+      .mockResolvedValueOnce(new Response(null, { status: 200 }))
+    vi.stubGlobal("fetch", fetch)
+
+    await otlpHttpJson({ endpoint: "https://console.example/v1/traces" })({
+      agent: {},
+      runtime: { memo: vi.fn(), runtime: "unknown", runtimeConfig: {}, waitUntil: vi.fn() },
+      spans: [{ name: "vitehub.run", spanId: "0123456789abcdef", startTime: "2026-01-01T00:00:00.000Z", status: { code: "OK" }, traceId: "0123456789abcdef0123456789abcdef" }],
+    })
+
+    expect(fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it("exports one metadata-only trace after a successful invocation", async () => {
+    const tasks: Promise<unknown>[] = []
+    const telemetry = vi.fn()
+    const traceLog = createTraceEventLog({ content: "content" })
+    const agent = defineAgent({
+      name: "support",
+      telemetry,
+      version: "1.0.0",
+      driver: {
+        async run(context) {
+          await context.traceLog?.append({
+            attributes: { prompt: "secret prompt" },
+            name: "application.content",
+            type: "run",
+          })
+          return "ok"
+        },
+      },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-1" },
+      runtime: "unknown",
+      traceLog,
+      waitUntil(task) { tasks.push(Promise.resolve(task)) },
+    }, {})).resolves.toBe("ok")
+    await Promise.all(tasks)
+
+    expect(telemetry).toHaveBeenCalledTimes(1)
+    const exported = telemetry.mock.calls[0]![0]
+    expect(exported).toMatchObject({
+      agent: { name: "support", version: "1.0.0" },
+      run: { runId: "run-1" },
+      spans: [{
+        attributes: {
+          "gen_ai.agent.name": "support",
+          "gen_ai.operation.name": "invoke_agent",
+          "vitehub.agent.name": "support",
+          "vitehub.run.id": "run-1",
+        },
+        status: { code: "OK" },
+      }],
+    })
+    expect(JSON.stringify(exported.spans)).not.toContain("secret prompt")
+  })
+
+  it("exports Capability setup failures without replacing the original error", async () => {
+    const tasks: Promise<unknown>[] = []
+    const telemetry = vi.fn()
+    const agent = defineAgent({
+      capabilities: () => { throw new Error("Capability setup failed") },
+      telemetry,
+      driver: { run: () => "unreachable" },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-setup-failure" },
+      runtime: "unknown",
+      waitUntil(task) { tasks.push(Promise.resolve(task)) },
+    }, {})).rejects.toThrow("Capability setup failed")
+    await Promise.all(tasks)
+
+    expect(telemetry).toHaveBeenCalledTimes(1)
+    expect(telemetry.mock.calls[0]![0].spans[0]).toMatchObject({
+      attributes: { "error.message": "Capability setup failed" },
+      status: { code: "ERROR", message: "Capability setup failed" },
+    })
+  })
+
+  it("exports run-event binding failures when waitUntil also throws", async () => {
+    const telemetry = vi.fn()
+    const agent = defineAgent({
+      runEvents: {} as never,
+      telemetry,
+      driver: { run: () => "unreachable" },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-events-failure" },
+      runtime: "unknown",
+      waitUntil() { throw new Error("waitUntil unavailable") },
+    }, {})).rejects.toThrow("defineAgent({ runEvents }) requires a definition created by defineAgentRunEvents()")
+    await vi.waitFor(() => expect(telemetry).toHaveBeenCalledWith(expect.objectContaining({
+      spans: [expect.objectContaining({ status: expect.objectContaining({ code: "ERROR" }) })],
+    })))
+  })
+
+  it("exports Driver resolution failures", async () => {
+    const tasks: Promise<unknown>[] = []
+    const telemetry = vi.fn()
+    const agent = defineAgent({
+      telemetry,
+      driver: { model: () => { throw new Error("Model resolution failed") } },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-driver-failure" },
+      runtime: "unknown",
+      waitUntil(task) { tasks.push(Promise.resolve(task)) },
+    }, {})).rejects.toThrow("Model resolution failed")
+    await Promise.all(tasks)
+
+    expect(telemetry).toHaveBeenCalledWith(expect.objectContaining({
+      spans: [expect.objectContaining({ status: { code: "ERROR", message: "Model resolution failed" } })],
+    }))
+  })
+
+  it("exports capacity admission failures after closing the prepared invocation", async () => {
+    let release!: () => void
+    let markStarted!: () => void
+    const gate = new Promise<void>(resolve => { release = resolve })
+    const started = new Promise<void>(resolve => { markStarted = resolve })
+    const tasks: Promise<unknown>[] = []
+    const telemetry = vi.fn()
+    const agent = defineAgent({
+      telemetry,
+      driver: {
+        capacity: { concurrency: 1 },
+        async run() {
+          markStarted()
+          await gate
+          return "ok"
+        },
+      },
+    })
+    const runtime = (runId: string) => ({
+      memo: vi.fn(),
+      run: { runId },
+      runtime: "unknown" as const,
+      waitUntil(task: PromiseLike<unknown>) { tasks.push(Promise.resolve(task)) },
+    })
+
+    const active = runAgent(agent, runtime("run-active"), {})
+    await started
+    await expect(runAgent(agent, runtime("run-rejected"), {})).rejects.toMatchObject({ code: "AGENT_CAPACITY_QUEUE_FULL" })
+    await vi.waitFor(() => expect(telemetry).toHaveBeenCalledWith(expect.objectContaining({
+      run: { runId: "run-rejected" },
+      spans: [expect.objectContaining({ status: expect.objectContaining({ code: "ERROR" }) })],
+    })))
+
+    release()
+    await active
+    await Promise.all(tasks)
+  })
+
+  it("does not let telemetry failures change Agent output", async () => {
+    const tasks: Promise<unknown>[] = []
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
+    const agent = defineAgent({
+      telemetry: () => { throw new Error("Console unavailable") },
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-export-failure" },
+      runtime: "unknown",
+      waitUntil(task) { tasks.push(Promise.resolve(task)) },
+    }, {})).resolves.toBe("ok")
+    await Promise.all(tasks)
+
+    expect(error).toHaveBeenCalledWith("[vitehub] Agent telemetry export failed.")
+    error.mockRestore()
+  })
+
+  it("does not let waitUntil registration failures change Agent output", async () => {
+    const telemetry = vi.fn()
+    const agent = defineAgent({ telemetry, driver: { run: () => "ok" } })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "run-wait-until-failure" },
+      runtime: "unknown",
+      waitUntil() { throw new Error("waitUntil unavailable") },
+    }, {})).resolves.toBe("ok")
+    await vi.waitFor(() => expect(telemetry).toHaveBeenCalledOnce())
+  })
+})

--- a/packages/agent/test/telemetry.test.ts
+++ b/packages/agent/test/telemetry.test.ts
@@ -103,7 +103,7 @@ describe("Agent telemetry", () => {
       driver: {
         async run(context) {
           await context.traceLog?.append({
-            attributes: { prompt: "secret prompt", source: "custom" },
+            attributes: { "agent.invocation.id": "caller-value", "agent.run.id": "caller-run", prompt: "secret prompt", source: "custom" },
             name: "application.content",
             type: "run",
           })
@@ -129,6 +129,7 @@ describe("Agent telemetry", () => {
       spans: [{
         attributes: {
           source: "custom",
+          "agent.run.id": "run-1",
           "gen_ai.agent.name": "support",
           "gen_ai.operation.name": "invoke_agent",
           "vitehub.agent.name": "support",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -539,7 +539,7 @@ export function traceEventsToOpenTelemetrySpans(events: Iterable<TraceEventLogEn
         endTime: step.endTime || run.endTime,
         name: step.name,
         parentSpanId: spanId,
-        spanId: openTelemetryId(`${run.id}:${step.id}`, 16),
+        spanId: openTelemetryId(`${spanId}:${step.id}`, 16),
         startTime: step.startTime,
         status: {
           code: step.status === "failed" || (!step.endTime && run.status === "failed") ? "ERROR" : "OK",

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -169,6 +169,10 @@ export interface OpenTelemetrySpanView {
   traceId: string
 }
 
+export interface OpenTelemetrySpanViewOptions {
+  content?: TraceEventContentPolicy
+}
+
 export interface RuntimeHostContext<TRuntimeConfig = Record<string, unknown>> {
   capabilities?: RuntimeCapabilities
   cloudflare?: {
@@ -488,16 +492,22 @@ function openTelemetryId(value: string, length: 16 | 32): string {
   return /^0+$/.test(id) ? `1${id.slice(1)}` : id
 }
 
-export function traceEventsToOpenTelemetrySpans(events: Iterable<TraceEventLogEntry>): OpenTelemetrySpanView[] {
-  return deriveTraceRuns(events).flatMap((run) => {
+export function traceEventsToOpenTelemetrySpans(events: Iterable<TraceEventLogEntry>, options: OpenTelemetrySpanViewOptions = {}): OpenTelemetrySpanView[] {
+  const entries = [...events].map(entry => options.content === "metadata"
+    ? { ...entry, attributes: metadataAttributes(entry.attributes) }
+    : entry)
+  return deriveTraceRuns(entries).flatMap((run) => {
     const rawParentSpanId = traceRunParentId(run)
     const rawTraceId = traceRunTraceId(run)
     const parentSpanId = rawParentSpanId ? openTelemetryId(rawParentSpanId, 16) : undefined
     const spanId = openTelemetryId(run.id, 16)
     const traceId = openTelemetryId(rawTraceId, 32)
+    const attributes = Object.assign({}, ...run.events.filter(event => !stepId(event)).map(event => event.attributes || {}))
+    const errorMessage = firstString(...run.events.slice().reverse().map(event => event.attributes?.["error.message"]))
     return [
       {
         attributes: {
+          ...attributes,
           "vitehub.run.id": run.id,
           ...(rawParentSpanId ? { "vitehub.trace.parentId": rawParentSpanId } : {}),
           "vitehub.trace.id": rawTraceId,
@@ -507,7 +517,10 @@ export function traceEventsToOpenTelemetrySpans(events: Iterable<TraceEventLogEn
         ...(parentSpanId ? { parentSpanId } : {}),
         spanId,
         startTime: run.startTime,
-        status: { code: run.status === "failed" ? "ERROR" : "OK" },
+        status: {
+          code: run.status === "failed" ? "ERROR" : "OK",
+          ...(run.status === "failed" && errorMessage ? { message: errorMessage } : {}),
+        },
         traceId,
       } satisfies OpenTelemetrySpanView,
       ...run.steps.map(step => ({
@@ -516,12 +529,15 @@ export function traceEventsToOpenTelemetrySpans(events: Iterable<TraceEventLogEn
           "vitehub.run.id": run.id,
           "vitehub.step.id": step.id,
         },
-        endTime: step.endTime,
+        endTime: step.endTime || run.endTime,
         name: step.name,
         parentSpanId: spanId,
         spanId: openTelemetryId(`${run.id}:${step.id}`, 16),
         startTime: step.startTime,
-        status: { code: step.status === "failed" ? "ERROR" : "OK" } as const,
+        status: {
+          code: step.status === "failed" || (!step.endTime && run.status === "failed") ? "ERROR" : "OK",
+          ...(typeof step.attributes?.["error.message"] === "string" ? { message: step.attributes["error.message"] } : {}),
+        } as const,
         traceId,
       })),
     ]

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -448,10 +448,10 @@ export function deriveTraceRuns(events: Iterable<TraceEventLogEntry>): TraceRunV
     }
 
     const terminal = sorted.slice().reverse().find(event => isTraceRunError(event) || isTraceRunFinish(event))
-    const status: TraceRunStatus = sorted.some(isTraceRunError)
+    const status: TraceRunStatus = sorted.some(event => event.name === "agent.stream.error" || event.name === "run.error")
       ? "failed"
       : terminal
-        ? "completed"
+        ? isTraceRunError(terminal) ? "failed" : "completed"
         : "running"
     const endTime = status === "running" ? undefined : terminal?.timestamp
     return {
@@ -472,6 +472,10 @@ function traceRunTraceId(run: TraceRunView): string {
 
 function traceRunParentId(run: TraceRunView): string | undefined {
   return firstString(...run.events.map(event => event.trace?.parentId))
+}
+
+function traceRunSpanId(run: TraceRunView): string {
+  return firstString(...run.events.map(event => event.attributes?.["agent.invocation.id"]), run.id) || run.id
 }
 
 function isOpenTelemetryId(value: string, length: number): boolean {
@@ -503,7 +507,7 @@ export function traceEventsToOpenTelemetrySpans(events: Iterable<TraceEventLogEn
     const rawParentSpanId = traceRunParentId(run)
     const rawTraceId = traceRunTraceId(run)
     const parentSpanId = rawParentSpanId ? openTelemetryId(rawParentSpanId, 16) : undefined
-    const spanId = openTelemetryId(run.id, 16)
+    const spanId = openTelemetryId(traceRunSpanId(run), 16)
     const traceId = openTelemetryId(rawTraceId, 32)
     const attributes = Object.assign({}, ...run.events.filter(event => !stepId(event)).map(event => event.attributes || {}))
     const errorMessage = firstString(...run.events.slice().reverse().map(event => event.attributes?.["error.message"]))

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -448,7 +448,7 @@ export function deriveTraceRuns(events: Iterable<TraceEventLogEntry>): TraceRunV
     }
 
     const terminal = sorted.slice().reverse().find(event => isTraceRunError(event) || isTraceRunFinish(event))
-    const status: TraceRunStatus = sorted.some(event => event.name === "agent.stream.error" || event.name === "run.error")
+    const status: TraceRunStatus = sorted.some(event => (event.name === "agent.stream.error" && event.attributes?.["error.recoverable"] !== true) || event.name === "run.error")
       ? "failed"
       : terminal
         ? isTraceRunError(terminal) ? "failed" : "completed"

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -292,21 +292,24 @@ function isContentAttributeKey(key: string): boolean {
   return key.split(".").some((part, index) => index > 0 && contentAttributeKeys.has(part))
 }
 
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  return Boolean(value && typeof value === "object" && Object.getPrototypeOf(value) === Object.prototype)
-}
-
-function metadataValue(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(metadataValue)
-  if (!isPlainRecord(value)) return value
+function metadataValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (!value || typeof value !== "object") return value
+  if (seen.has(value)) return "[Circular]"
+  seen.add(value)
+  if (Array.isArray(value)) {
+    const next = value.map(child => metadataValue(child, seen))
+    seen.delete(value)
+    return next
+  }
   const omitted: string[] = []
   const next = Object.fromEntries(Object.entries(value).flatMap(([key, child]) => {
     if (isContentAttributeKey(key)) {
       omitted.push(key)
       return []
     }
-    return [[key, metadataValue(child)]]
+    return [[key, metadataValue(child, seen)]]
   }))
+  seen.delete(value)
   if (omitted.length) next["content.omitted"] = omitted
   return next
 }

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -558,4 +558,17 @@ describe("@vite-hub/runtime", () => {
     expect(JSON.stringify(span)).not.toContain("secret prompt")
     expect(JSON.stringify(span)).not.toContain("secret result")
   })
+
+  it("recursively redacts traversable non-plain attribute objects", async () => {
+    const details = Object.assign(Object.create(null) as Record<string, unknown>, {
+      nested: { prompt: "secret prompt", safe: true },
+    })
+    const log = createTraceEventLog({ content: "content" })
+    await log.append({ attributes: { details }, name: "agent.invocation", type: "run" })
+
+    const [span] = traceEventsToOpenTelemetrySpans(log.entries(), { content: "metadata" })
+
+    expect(span?.attributes?.details).toEqual({ nested: { "content.omitted": ["prompt"], safe: true } })
+    expect(JSON.stringify(span)).not.toContain("secret prompt")
+  })
 })

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -571,4 +571,14 @@ describe("@vite-hub/runtime", () => {
     expect(span?.attributes?.details).toEqual({ nested: { "content.omitted": ["prompt"], safe: true } })
     expect(JSON.stringify(span)).not.toContain("secret prompt")
   })
+
+  it("uses the terminal invocation outcome after a recovered error", async () => {
+    const log = createTraceEventLog()
+    await log.append({ name: "agent.invocation.start", trace: { id: "trace-1" }, type: "run" })
+    await log.append({ attributes: { "error.message": "best-effort start failed" }, name: "agent.invocation.error", trace: { id: "trace-1" }, type: "error" })
+    await log.append({ name: "agent.invocation.finish", trace: { id: "trace-1" }, type: "run" })
+
+    expect(deriveTraceRuns(log.entries())[0]?.status).toBe("completed")
+    expect(traceEventsToOpenTelemetrySpans(log.entries())[0]?.status).toEqual({ code: "OK" })
+  })
 })

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -581,4 +581,17 @@ describe("@vite-hub/runtime", () => {
     expect(deriveTraceRuns(log.entries())[0]?.status).toBe("completed")
     expect(traceEventsToOpenTelemetrySpans(log.entries())[0]?.status).toEqual({ code: "OK" })
   })
+
+  it("derives child span ids from the invocation-specific root", async () => {
+    const event = (invocationId: string, sequence: number) => [
+      { attributes: { "agent.invocation.id": invocationId }, name: "agent.invocation.start", sequence, timestamp: "2026-01-01T00:00:00.000Z", trace: { id: "host-trace" }, type: "run" as const },
+      { attributes: { "agent.invocation.id": invocationId, "step.id": "model" }, name: "agent.model.finish", sequence: sequence + 1, timestamp: "2026-01-01T00:00:00.010Z", trace: { id: "host-trace" }, type: "run" as const },
+      { attributes: { "agent.invocation.id": invocationId }, name: "agent.invocation.finish", sequence: sequence + 2, timestamp: "2026-01-01T00:00:00.020Z", trace: { id: "host-trace" }, type: "run" as const },
+    ]
+
+    const [firstRoot, firstChild] = traceEventsToOpenTelemetrySpans(event("invocation-1", 1))
+    const [secondRoot, secondChild] = traceEventsToOpenTelemetrySpans(event("invocation-2", 4))
+    expect(firstRoot?.spanId).not.toBe(secondRoot?.spanId)
+    expect(firstChild?.spanId).not.toBe(secondChild?.spanId)
+  })
 })

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -518,4 +518,44 @@ describe("@vite-hub/runtime", () => {
     expect(spans[1]!.parentSpanId).toBe(spans[0]!.spanId)
     expect(spans[1]!.traceId).toBe(spans[0]!.traceId)
   })
+
+  it("redacts content and preserves invocation metadata at the OpenTelemetry export seam", async () => {
+    const log = createTraceEventLog({ content: "content" })
+    await log.append({
+      attributes: {
+        "agent.run.id": "run-1",
+        prompt: "secret prompt",
+        "runtime.name": "vercel",
+      },
+      name: "agent.invocation.start",
+      timestamp: "2026-01-01T00:00:00.000Z",
+      trace: { id: "trace-1" },
+      type: "run",
+    })
+    await log.append({
+      attributes: {
+        "agent.run.id": "run-1",
+        "error.message": "provider failed",
+        result: "secret result",
+      },
+      name: "agent.invocation.error",
+      timestamp: "2026-01-01T00:00:00.010Z",
+      trace: { id: "trace-1" },
+      type: "error",
+    })
+
+    const [span] = traceEventsToOpenTelemetrySpans(log.entries(), { content: "metadata" })
+
+    expect(span).toMatchObject({
+      attributes: {
+        "agent.run.id": "run-1",
+        "content.omitted": ["result"],
+        "error.message": "provider failed",
+        "runtime.name": "vercel",
+      },
+      status: { code: "ERROR", message: "provider failed" },
+    })
+    expect(JSON.stringify(span)).not.toContain("secret prompt")
+    expect(JSON.stringify(span)).not.toContain("secret result")
+  })
 })

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -582,6 +582,16 @@ describe("@vite-hub/runtime", () => {
     expect(traceEventsToOpenTelemetrySpans(log.entries())[0]?.status).toEqual({ code: "OK" })
   })
 
+  it("preserves success after a recoverable stream error", async () => {
+    const log = createTraceEventLog()
+    await log.append({ name: "agent.invocation.start", trace: { id: "trace-1" }, type: "run" })
+    await log.append({ attributes: { "error.recoverable": true }, name: "agent.stream.error", trace: { id: "trace-1" }, type: "error" })
+    await log.append({ name: "agent.invocation.finish", trace: { id: "trace-1" }, type: "run" })
+
+    expect(deriveTraceRuns(log.entries())[0]?.status).toBe("completed")
+    expect(traceEventsToOpenTelemetrySpans(log.entries())[0]?.status).toEqual({ code: "OK" })
+  })
+
   it("derives child span ids from the invocation-specific root", async () => {
     const event = (invocationId: string, sequence: number) => [
       { attributes: { "agent.invocation.id": invocationId }, name: "agent.invocation.start", sequence, timestamp: "2026-01-01T00:00:00.000Z", trace: { id: "host-trace" }, type: "run" as const },

--- a/packages/vite-hub/fixtures/published-types/consumer.ts
+++ b/packages/vite-hub/fixtures/published-types/consumer.ts
@@ -1,6 +1,6 @@
 import { defineConfig } from "vite"
 import { vitehub } from "vite-hub"
-import { defineAgent } from "vite-hub/agent"
+import { defineAgent, otlpHttpJson } from "vite-hub/agent"
 import type {
   BuiltInAgentDriver,
   BuiltInAgentDriverName,
@@ -50,7 +50,11 @@ export const nuxtModule = viteHubNuxtModule
 export const customAuthClient = createAuthClient({ basePath: "/auth" })
 export const userSession = useUserSession(customAuthClient)
 export const supportChat = useChat(useAgent("support"))
-export const builtInAgent = defineAgent({ driver: "codex", runtime: false })
+export const builtInAgent = defineAgent({
+  driver: "codex",
+  runtime: false,
+  telemetry: otlpHttpJson({ endpoint: "https://console.example/v1/traces" }),
+})
 export const builtInBox = { runtime: "trusted-host" } satisfies BoxDefinition
 export const builtInAgentName = "codex" satisfies BuiltInAgentDriverName
 export const configuredCodex = { kind: "codex", reasoningEffort: "high" } satisfies BuiltInAgentDriver


### PR DESCRIPTION
## Problem

Agent Trace Events are process-local by default, while consumer-side finish hooks miss setup, Driver-resolution, and capacity-admission failures. Products such as Console need one reliable export boundary for the complete Agent Invocation lifecycle without owning ViteHub internals.

## Change

- adds a singular `telemetry` callback to Agent Definitions and an `otlpHttpJson()` adapter exported from `vite-hub/agent`
- converts only the completed current run to OTLP/HTTP JSON, reapplies metadata redaction at the export boundary, and preserves error and usage metadata
- exports setup, Driver-resolution, capacity, success, and terminal failure paths through best-effort `runtime.waitUntil()` registration
- retries transient OTLP responses without adding an OpenTelemetry SDK dependency, provider, batching layer, or Console-specific receiver to ViteHub
- keeps exporter and host registration failures from changing Agent output or masking the original error

The Agent option is a transport callback rather than a Capability because Capability setup itself can fail. The built-in adapter posts directly with `fetch`, so host-level OpenTelemetry and Vercel tracing configuration remain independently owned.

## Verification

- `pnpm test` in `packages/runtime` — 26 tests passed
- focused Agent lifecycle matrix — 467 tests passed
- Agent telemetry suite — 9 tests passed
- Agent, Runtime, and `vite-hub` typechecks passed
- Agent dependency build and `vite-hub` build passed with publint
- published `vite-hub/agent` consumer and package contract tests — 10 tests passed
- full Agent suite reached 2,019 passing tests; its two load-sensitive timeouts and tutorial build prerequisite all passed when rerun individually with the framework package built
- independent delegated re-review found no remaining correctness, security, or lifecycle findings