### PR TITLE
fix: generate host-native workflow infrastructure

### DIFF
--- a/fixtures/consumer/vite-hub/server/workflows/pipeline/02.email.ts
+++ b/fixtures/consumer/vite-hub/server/workflows/pipeline/02.email.ts
@@ -1,0 +1,11 @@
+import { email } from "vite-hub/email/server"
+
+export default async function send(value: unknown) {
+  await email.send({
+    from: "ViteHub <hello@example.com>",
+    subject: "Packed workflow",
+    text: "ViteHub packed workflow proof",
+    to: "user@example.com",
+  })
+  return value
+}

--- a/packages/email/package.json
+++ b/packages/email/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@types/node": "catalog:tooling",
     "@vite-hub/internal": "workspace:*",
+    "@vite-hub/workflow": "workspace:*",
     "publint": "catalog:tooling",
     "typescript": "catalog:tooling",
     "vite": "catalog:vite",

--- a/packages/email/src/runtime/email.ts
+++ b/packages/email/src/runtime/email.ts
@@ -5,10 +5,13 @@ import { emailError } from "../errors.ts"
 
 import type { EmailClient, EmailMessage, EmailSendResult } from "../types.ts"
 
-const client = definition ? createEmail(definition) : undefined
+const runtimeDefinition = Symbol.for("vitehub.email.definition")
+let client = definition ? createEmail(definition) : undefined
 
 export const email: EmailClient = {
   async send(message: EmailMessage): Promise<EmailSendResult> {
+    const generated = (globalThis as typeof globalThis & { [runtimeDefinition]?: typeof definition })[runtimeDefinition]
+    client ??= generated ? createEmail(generated) : undefined
     if (!client) {
       throw emailError(
         "EMAIL_NOT_CONFIGURED",

--- a/packages/email/src/vite.ts
+++ b/packages/email/src/vite.ts
@@ -10,6 +10,7 @@ import { getHostingProvider } from "@vite-hub/internal/hosting"
 import { extractMarkdownTemplateImportSpecifiers } from "@vite-hub/markdown-template/internal/vite"
 
 import type { EnvRuntimeConfigOptions, EnvRuntimeRegistry } from "@vite-hub/env"
+import type { ViteHubProviderImportContributor } from "@vite-hub/internal/build/vite"
 import type { Plugin } from "vite"
 
 export const EMAIL_DEFINITION_ID = "#vitehub/email/definition"
@@ -39,7 +40,7 @@ export interface EmailVitePluginAPI {
   prepareTypes: (options: { materialize?: boolean, projectRoot: string, serverDirs?: string[] }) => Promise<Record<string, string>>
 }
 
-export type EmailVitePlugin = Plugin & { api: EmailVitePluginAPI }
+export type EmailVitePlugin = Plugin & ViteHubProviderImportContributor & { api: EmailVitePluginAPI }
 
 export function hubEmailOptionalPeerResolver(): Plugin & { api: { prepareTypes: (projectRoot: string) => Promise<void> } } {
   const prepareTypes = async (projectRoot: string) => {
@@ -379,6 +380,11 @@ export function hubEmail(options: EmailVitePluginOptions): EmailVitePlugin {
     api: {
       getDefinition: () => definition,
       prepareTypes,
+    },
+    vitehub: {
+      providerOutput: {
+        getImportAliases: (): Record<string, string> => definition ? { [EMAIL_DEFINITION_ID]: definition.handler } : {},
+      },
     },
     async config(config) {
       serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs

--- a/packages/email/src/vite.ts
+++ b/packages/email/src/vite.ts
@@ -391,10 +391,13 @@ export function hubEmail(options: EmailVitePluginOptions): EmailVitePlugin {
         : {}
       return {
         ...(cloudflare || vercel
-          ? { resolve: { alias: Object.entries(emailTemplatePaths).map(([name, replacement]) => ({
-              find: exactIdPattern(`${emailTemplatePrefix}${name}`),
-              replacement,
-            })) } }
+          ? { resolve: { alias: [
+              { find: EMAIL_DEFINITION_ID, replacement: resolve(resolveViteHubGeneratedRoot(config), "email/definition.mjs") },
+              ...Object.entries(emailTemplatePaths).map(([name, replacement]) => ({
+                find: exactIdPattern(`${emailTemplatePrefix}${name}`),
+                replacement,
+              })),
+            ] } }
           : {}),
         ssr: { noExternal: mergeNoExternal(config.ssr?.noExternal) },
       }

--- a/packages/email/src/vite.ts
+++ b/packages/email/src/vite.ts
@@ -381,9 +381,10 @@ export function hubEmail(options: EmailVitePluginOptions): EmailVitePlugin {
     },
     async config(config) {
       serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
-      const hosting = getHostingProvider(resolveHosting(internalOptions, config as Record<string, unknown>))
+      const configRecord = config as Record<string, unknown>
+      const hosting = getHostingProvider(resolveHosting(internalOptions, configRecord))
       cloudflare = hosting === "cloudflare"
-      vercel = hosting === "vercel"
+      vercel = hosting === "vercel" || (isRecord(configRecord.workflow) && configRecord.workflow.provider === "vercel")
       updateTemplateRoots(resolveViteHubProjectRoot(config.root ?? process.cwd()))
       if (cloudflare) configureNitroCloudflareWorkers(config as Record<string, unknown>, cloudflareEmail)
       const emailTemplatePaths = cloudflare || vercel

--- a/packages/email/src/vite.ts
+++ b/packages/email/src/vite.ts
@@ -59,6 +59,7 @@ export function hubEmailOptionalPeerResolver(): Plugin & { api: { prepareTypes: 
 interface InternalEmailVitePluginOptions {
   hosting?: string
   runtimeEnvImport?: string
+  workflowProvider?: string
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -384,7 +385,9 @@ export function hubEmail(options: EmailVitePluginOptions): EmailVitePlugin {
       const configRecord = config as Record<string, unknown>
       const hosting = getHostingProvider(resolveHosting(internalOptions, configRecord))
       cloudflare = hosting === "cloudflare"
-      vercel = hosting === "vercel" || (isRecord(configRecord.workflow) && configRecord.workflow.provider === "vercel")
+      vercel = hosting === "vercel"
+        || internalOptions.workflowProvider === "vercel"
+        || (isRecord(configRecord.workflow) && configRecord.workflow.provider === "vercel")
       updateTemplateRoots(resolveViteHubProjectRoot(config.root ?? process.cwd()))
       if (cloudflare) configureNitroCloudflareWorkers(config as Record<string, unknown>, cloudflareEmail)
       const emailTemplatePaths = cloudflare || vercel

--- a/packages/email/src/vite.ts
+++ b/packages/email/src/vite.ts
@@ -338,6 +338,7 @@ export function hubEmail(options: EmailVitePluginOptions): EmailVitePlugin {
   let buildStarted = false
   let materialized = false
   let materializationRequested = false
+  let providerImportAliases: Promise<Record<string, string>> | undefined
   let watchFiles = new Set<string>()
 
   const updateTemplateRoots = (nextProjectRoot: string, nextServerDirs = serverDirs) => {
@@ -383,12 +384,14 @@ export function hubEmail(options: EmailVitePluginOptions): EmailVitePlugin {
     },
     vitehub: {
       providerOutput: {
-        async getImportAliases(): Promise<Record<string, string>> {
-          const templates = await prepareTypes({ materialize: true, projectRoot, serverDirs })
-          return {
+        getImportAliases(): Promise<Record<string, string>> {
+          providerImportAliases ??= prepareTypes({ materialize: true, projectRoot, serverDirs }).then(templates => ({
             ...(definition ? { [EMAIL_DEFINITION_ID]: definition.handler } : {}),
             ...Object.fromEntries(Object.entries(templates).map(([name, replacement]) => [`${emailTemplatePrefix}${name}`, replacement])),
-          }
+          })).finally(() => {
+            providerImportAliases = undefined
+          })
+          return providerImportAliases
         },
       },
     },

--- a/packages/email/src/vite.ts
+++ b/packages/email/src/vite.ts
@@ -383,7 +383,13 @@ export function hubEmail(options: EmailVitePluginOptions): EmailVitePlugin {
     },
     vitehub: {
       providerOutput: {
-        getImportAliases: (): Record<string, string> => definition ? { [EMAIL_DEFINITION_ID]: definition.handler } : {},
+        async getImportAliases(): Promise<Record<string, string>> {
+          const templates = await prepareTypes({ materialize: true, projectRoot, serverDirs })
+          return {
+            ...(definition ? { [EMAIL_DEFINITION_ID]: definition.handler } : {}),
+            ...Object.fromEntries(Object.entries(templates).map(([name, replacement]) => [`${emailTemplatePrefix}${name}`, replacement])),
+          }
+        },
       },
     },
     async config(config) {

--- a/packages/email/test/runtime.test.ts
+++ b/packages/email/test/runtime.test.ts
@@ -1,4 +1,4 @@
-import { expect, it, vi } from "vitest"
+import { afterEach, expect, it, vi } from "vitest"
 
 import type { EmailDriver, EmailMessage } from "../src/index.ts"
 
@@ -10,17 +10,13 @@ const fixture = vi.hoisted(() => ({
   })),
 }))
 
-vi.mock("#vitehub/email/definition", () => ({
-  default: {
-    driver: {
-      initialize: fixture.initialize,
-      name: "fixture",
-      send: fixture.send,
-    } satisfies EmailDriver,
-  },
-}))
-
-import { email } from "../src/server.ts"
+const definition = {
+  driver: {
+    initialize: fixture.initialize,
+    name: "fixture",
+    send: fixture.send,
+  } satisfies EmailDriver,
+}
 
 const message: EmailMessage = {
   from: "hello@example.com",
@@ -29,7 +25,29 @@ const message: EmailMessage = {
   to: "maxi@example.com",
 }
 
+afterEach(() => {
+  delete (globalThis as Record<PropertyKey, unknown>)[Symbol.for("vitehub.email.definition")]
+  vi.clearAllMocks()
+  vi.resetModules()
+})
+
 it("keeps the configured driver's lifecycle across sends", async () => {
+  vi.doMock("#vitehub/email/definition", () => ({ default: definition }))
+  const { email } = await import("../src/server.ts")
+
+  await email.send(message)
+  await email.send(message)
+
+  expect(fixture.initialize).toHaveBeenCalledOnce()
+  expect(fixture.send).toHaveBeenCalledTimes(2)
+})
+
+it("resolves a generated definition installed after the server module loads", async () => {
+  vi.doMock("#vitehub/email/definition", () => ({ default: undefined }))
+  const { email } = await import("../src/server.ts")
+
+  ;(globalThis as Record<PropertyKey, unknown>)[Symbol.for("vitehub.email.definition")] = definition
+
   await email.send(message)
   await email.send(message)
 

--- a/packages/email/test/vite.test.ts
+++ b/packages/email/test/vite.test.ts
@@ -247,6 +247,8 @@ describe("hubEmail", () => {
 
   it("exposes its generated definition to directly composed Vercel Workflows", async () => {
     const root = await createTempProject()
+    await mkdir(join(root, "server", "emails"), { recursive: true })
+    await writeFile(join(root, "server", "emails", "monthly-recap.md"), "Hello {{name}}")
     await symlink(join(import.meta.dirname, "../../../node_modules"), join(root, "node_modules"), process.platform === "win32" ? "junction" : "dir")
     const workflow = hubWorkflow({ provider: "vercel" })
     const server = await createServer({
@@ -265,8 +267,11 @@ describe("hubEmail", () => {
       await expect(workflow.vitehub?.workflow?.prepareScheduleRuntime?.()).resolves.toMatchObject({
         bundleAlias: {
           [EMAIL_DEFINITION_ID]: join(root, ".vitehub", "email", "definition.mjs"),
+          "#vitehub/emails/monthly-recap": join(root, ".vitehub", "email", "templates", "monthly-recap.mjs"),
         },
       })
+      await expect(readFile(join(root, ".vitehub", "email", "templates", "monthly-recap.mjs"), "utf8"))
+        .resolves.toContain("Hello {{name}}")
     }
     finally {
       await server.close()

--- a/packages/email/test/vite.test.ts
+++ b/packages/email/test/vite.test.ts
@@ -232,10 +232,13 @@ describe("hubEmail", () => {
 
   it("exposes its generated definition to explicitly selected Vercel Workflows", async () => {
     const root = await createTempProject()
-    const plugin = hubEmail({ driver: "unemail/driver/resend" })
+    const plugin = hubEmail({
+      driver: "unemail/driver/resend",
+      workflowProvider: "vercel",
+    } as Parameters<typeof hubEmail>[0])
     const config = plugin.config as unknown as (config: Record<string, unknown>) => Promise<Record<string, unknown>>
 
-    expect(await config({ root, workflow: { provider: "vercel" } })).toMatchObject({ resolve: { alias: [
+    expect(await config({ root })).toMatchObject({ resolve: { alias: [
       { find: EMAIL_DEFINITION_ID, replacement: join(root, ".vitehub", "email", "definition.mjs") },
     ] } })
   })

--- a/packages/email/test/vite.test.ts
+++ b/packages/email/test/vite.test.ts
@@ -209,10 +209,13 @@ describe("hubEmail", () => {
     } as Parameters<typeof hubEmail>[0])
     const config = plugin.config as unknown as (config: Record<string, unknown>) => Promise<Record<string, unknown>>
 
-    expect(await config({ root })).toMatchObject({ resolve: { alias: [{
-      find: /^#vitehub\/emails\/monthly-recap$/,
-      replacement: join(root, ".vitehub", "email", "templates", "monthly-recap.mjs"),
-    }] } })
+    expect(await config({ root })).toMatchObject({ resolve: { alias: [
+      { find: EMAIL_DEFINITION_ID, replacement: join(root, ".vitehub", "email", "definition.mjs") },
+      {
+        find: /^#vitehub\/emails\/monthly-recap$/,
+        replacement: join(root, ".vitehub", "email", "templates", "monthly-recap.mjs"),
+      },
+    ] } })
     await resolvePlugin(plugin, root)
 
     expect(await readFile(join(root, ".vitehub", "email", "templates", "monthly-recap.mjs"), "utf8"))
@@ -275,10 +278,13 @@ describe("hubEmail", () => {
     await writeFile(join(root, "server", "emails", "welcome.md"), "Welcome")
     const plugin = hubEmail({ driver: "unemail/driver/resend", hosting: "vercel" } as Parameters<typeof hubEmail>[0])
     const config = plugin.config as unknown as (config: Record<string, unknown>) => Promise<Record<string, unknown>>
-    await expect(config({ root: appRoot })).resolves.toMatchObject({ resolve: { alias: [{
-      find: /^#vitehub\/emails\/welcome$/,
-      replacement: join(root, ".vitehub", "email", "templates", "welcome.mjs"),
-    }] } })
+    await expect(config({ root: appRoot })).resolves.toMatchObject({ resolve: { alias: [
+      { find: EMAIL_DEFINITION_ID, replacement: join(appRoot, ".vitehub", "email", "definition.mjs") },
+      {
+        find: /^#vitehub\/emails\/welcome$/,
+        replacement: join(root, ".vitehub", "email", "templates", "welcome.mjs"),
+      },
+    ] } })
   })
 
   it("serializes development refreshes and watches imported templates", async () => {

--- a/packages/email/test/vite.test.ts
+++ b/packages/email/test/vite.test.ts
@@ -230,6 +230,16 @@ describe("hubEmail", () => {
       .toContain("Updated template")
   })
 
+  it("exposes its generated definition to explicitly selected Vercel Workflows", async () => {
+    const root = await createTempProject()
+    const plugin = hubEmail({ driver: "unemail/driver/resend" })
+    const config = plugin.config as unknown as (config: Record<string, unknown>) => Promise<Record<string, unknown>>
+
+    expect(await config({ root, workflow: { provider: "vercel" } })).toMatchObject({ resolve: { alias: [
+      { find: EMAIL_DEFINITION_ID, replacement: join(root, ".vitehub", "email", "definition.mjs") },
+    ] } })
+  })
+
   it("resolves nested standalone host templates through exact aliases", async () => {
     const root = await createTempProject()
     const parentTemplate = join(root, "server", "emails", "monthly.md")

--- a/packages/email/test/vite.test.ts
+++ b/packages/email/test/vite.test.ts
@@ -264,12 +264,17 @@ describe("hubEmail", () => {
     try {
       expect(server.config.plugins.find(plugin => plugin.name === "@vite-hub/email/vite"))
         .toHaveProperty("api.getDefinition")
-      await expect(workflow.vitehub?.workflow?.prepareScheduleRuntime?.()).resolves.toMatchObject({
+      const contributions = await Promise.all([
+        workflow.vitehub?.workflow?.prepareScheduleRuntime?.(),
+        workflow.vitehub?.workflow?.prepareScheduleRuntime?.(),
+      ])
+      expect(contributions[0]).toMatchObject({
         bundleAlias: {
           [EMAIL_DEFINITION_ID]: join(root, ".vitehub", "email", "definition.mjs"),
           "#vitehub/emails/monthly-recap": join(root, ".vitehub", "email", "templates", "monthly-recap.mjs"),
         },
       })
+      expect(contributions[1]).toMatchObject({ bundleAlias: contributions[0]?.bundleAlias })
       await expect(readFile(join(root, ".vitehub", "email", "templates", "monthly-recap.mjs"), "utf8"))
         .resolves.toContain("Hello {{name}}")
     }

--- a/packages/email/test/vite.test.ts
+++ b/packages/email/test/vite.test.ts
@@ -1,10 +1,12 @@
-import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
 import { env } from "@vite-hub/env"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { createServer } from "vite"
+
+import { hubWorkflow } from "@vite-hub/workflow/vite"
 
 import { createEmail } from "../src/client.ts"
 import { EMAIL_DEFINITION_ID, hubEmail, hubEmailOptionalPeerResolver, resolveEmailTemplateModulePath } from "../src/vite.ts"
@@ -241,6 +243,34 @@ describe("hubEmail", () => {
     expect(await config({ root })).toMatchObject({ resolve: { alias: [
       { find: EMAIL_DEFINITION_ID, replacement: join(root, ".vitehub", "email", "definition.mjs") },
     ] } })
+  })
+
+  it("exposes its generated definition to directly composed Vercel Workflows", async () => {
+    const root = await createTempProject()
+    await symlink(join(import.meta.dirname, "../../../node_modules"), join(root, "node_modules"), process.platform === "win32" ? "junction" : "dir")
+    const workflow = hubWorkflow({ provider: "vercel" })
+    const server = await createServer({
+      appType: "custom",
+      configFile: false,
+      plugins: [
+        hubEmail({ driver: "unemail/driver/resend" }),
+        workflow,
+      ],
+      root,
+      server: { middlewareMode: true },
+    })
+    try {
+      expect(server.config.plugins.find(plugin => plugin.name === "@vite-hub/email/vite"))
+        .toHaveProperty("api.getDefinition")
+      await expect(workflow.vitehub?.workflow?.prepareScheduleRuntime?.()).resolves.toMatchObject({
+        bundleAlias: {
+          [EMAIL_DEFINITION_ID]: join(root, ".vitehub", "email", "definition.mjs"),
+        },
+      })
+    }
+    finally {
+      await server.close()
+    }
   })
 
   it("resolves nested standalone host templates through exact aliases", async () => {

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -86,7 +86,7 @@ interface NetlifyProviderDeploymentCleanup {
   outputRoot?: string
 }
 
-interface ProviderDeploymentOutputOptions extends SharedDeploymentOptions {
+export interface ProviderDeploymentOutputOptions extends SharedDeploymentOptions {
   afterWrite?: () => Promise<void>
   cloudflare?: CloudflareProviderDeploymentOutput
   cleanup?: {
@@ -99,7 +99,7 @@ interface ProviderDeploymentOutputOptions extends SharedDeploymentOptions {
 }
 
 const composedProviderOutputKey = Symbol.for("vitehub.composedProviderOutput")
-const providerDeploymentOutputWrites = new Map<string, Promise<void>>()
+const providerDeploymentOutputWrites = new Map<string, Promise<unknown>>()
 
 export interface ComposedProviderOutput {
   runtimeModuleFilesByProduct: Record<string, Record<string, string> | undefined>
@@ -356,15 +356,22 @@ async function writeProviderDeploymentOutputsNow(options: ProviderDeploymentOutp
   await options.afterWrite?.()
 }
 
-export async function writeProviderDeploymentOutputs(options: ProviderDeploymentOutputOptions): Promise<void> {
-  const key = resolve(options.rootDir)
+export async function withProviderDeploymentOutputLock<T>(
+  rootDir: string,
+  operation: (write: (options: ProviderDeploymentOutputOptions) => Promise<void>) => Promise<T>,
+): Promise<T> {
+  const key = resolve(rootDir)
   const previous = providerDeploymentOutputWrites.get(key) ?? Promise.resolve()
-  const write = previous.catch(() => undefined).then(() => writeProviderDeploymentOutputsNow(options))
+  const write = previous.catch(() => undefined).then(() => operation(writeProviderDeploymentOutputsNow))
   providerDeploymentOutputWrites.set(key, write)
   try {
-    await write
+    return await write
   }
   finally {
     if (providerDeploymentOutputWrites.get(key) === write) providerDeploymentOutputWrites.delete(key)
   }
+}
+
+export async function writeProviderDeploymentOutputs(options: ProviderDeploymentOutputOptions): Promise<void> {
+  await withProviderDeploymentOutputLock(options.rootDir, async write => await write(options))
 }

--- a/packages/internal/src/build/esbuild.ts
+++ b/packages/internal/src/build/esbuild.ts
@@ -246,12 +246,11 @@ export async function bundleEsmEntry(
           js: [
             options.banner,
             ...(format === "esm" && platform === "node" ? [
-              'import { createRequire as __createRequire } from "node:module";',
-              'import { dirname as __vitehubDirname } from "node:path";',
-              'import { fileURLToPath as __vitehubFileURLToPath } from "node:url";',
-              "globalThis.require = __createRequire(import.meta.url);",
-              "globalThis.__filename = __vitehubFileURLToPath(import.meta.url);",
-              "globalThis.__dirname = __vitehubDirname(globalThis.__filename);",
+              "if (globalThis.process?.getBuiltinModule && import.meta.url) {",
+              '  globalThis.require = globalThis.process.getBuiltinModule("node:module").createRequire(import.meta.url);',
+              '  globalThis.__filename = globalThis.process.getBuiltinModule("node:url").fileURLToPath(import.meta.url);',
+              '  globalThis.__dirname = globalThis.process.getBuiltinModule("node:path").dirname(globalThis.__filename);',
+              "}",
             ] : []),
           ].filter(Boolean).join("\n"),
         }

--- a/packages/internal/src/build/esbuild.ts
+++ b/packages/internal/src/build/esbuild.ts
@@ -18,6 +18,7 @@ interface BundleEsmEntryOptions {
   platform?: "browser" | "node" | "neutral"
   plugins?: Plugin[]
   rootDir?: string
+  workingDir?: string
 }
 
 const viteRawNamespace = "vitehub-vite-raw"
@@ -240,6 +241,7 @@ export async function bundleEsmEntry(
   const frameworkRuntime = Object.keys(aliases || {}).some(specifier => specifier === "vite-hub" || specifier.startsWith("vite-hub/"))
 
   await bundle({
+    absWorkingDir: options.workingDir,
     alias: aliases,
     banner: options.banner || (format === "esm" && platform === "node")
       ? {

--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -5,6 +5,14 @@ type NoExternalValue = string | true | RegExp | (string | RegExp)[] | undefined
 type WatchIgnoredMatcher = string | RegExp | ((testString: string, ...args: unknown[]) => boolean)
 type WatchIgnoredValue = WatchIgnoredMatcher | WatchIgnoredMatcher[] | undefined
 
+export interface ViteHubProviderImportContributor {
+  vitehub?: {
+    providerOutput?: {
+      getImportAliases?: () => Record<string, string>
+    }
+  }
+}
+
 const generatedViteHubFilesPattern = "**/.vitehub/**"
 const projectRootDirectoryMarkers = [
   ["server", "agents"],

--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -8,7 +8,7 @@ type WatchIgnoredValue = WatchIgnoredMatcher | WatchIgnoredMatcher[] | undefined
 export interface ViteHubProviderImportContributor {
   vitehub?: {
     providerOutput?: {
-      getImportAliases?: () => Record<string, string>
+      getImportAliases?: () => Promise<Record<string, string>> | Record<string, string>
     }
   }
 }

--- a/packages/internal/src/build/vite.ts
+++ b/packages/internal/src/build/vite.ts
@@ -13,6 +13,14 @@ export interface ViteHubProviderImportContributor {
   }
 }
 
+export async function collectViteHubProviderImportAliases(
+  plugins: ViteHubProviderImportContributor[],
+): Promise<Record<string, string>> {
+  return Object.assign({}, ...await Promise.all(plugins.map(async plugin =>
+    await plugin.vitehub?.providerOutput?.getImportAliases?.() ?? {},
+  )))
+}
+
 const generatedViteHubFilesPattern = "**/.vitehub/**"
 const projectRootDirectoryMarkers = [
   ["server", "agents"],

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -533,39 +533,6 @@ describe("provider deployment outputs", () => {
     })
   })
 
-  it("keeps after-write lifecycles inside root-scoped serialization", async () => {
-    const rootDir = await createTempProject()
-    const { writeProviderDeploymentOutputs } = await import("../src/build/deployment-output.ts")
-    const order: string[] = []
-    let releaseFirst!: () => void
-    const firstGate = new Promise<void>((resolve) => {
-      releaseFirst = resolve
-    })
-
-    const first = writeProviderDeploymentOutputs({
-      afterWrite: async () => {
-        order.push("first:start")
-        await firstGate
-        order.push("first:end")
-      },
-      clientOutDir: "dist/client",
-      rootDir,
-    })
-    const second = writeProviderDeploymentOutputs({
-      afterWrite: async () => {
-        order.push("second")
-      },
-      clientOutDir: "dist/client",
-      rootDir,
-    })
-
-    await new Promise(resolve => setTimeout(resolve, 0))
-    expect(order).toEqual(["first:start"])
-    releaseFirst()
-    await Promise.all([first, second])
-    expect(order).toEqual(["first:start", "first:end", "second"])
-  })
-
   it("writes Netlify functions with static config and preserves shared config keys", async () => {
     const rootDir = await createTempProject()
     const {

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -533,6 +533,39 @@ describe("provider deployment outputs", () => {
     })
   })
 
+  it("keeps after-write lifecycles inside root-scoped serialization", async () => {
+    const rootDir = await createTempProject()
+    const { writeProviderDeploymentOutputs } = await import("../src/build/deployment-output.ts")
+    const order: string[] = []
+    let releaseFirst!: () => void
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+
+    const first = writeProviderDeploymentOutputs({
+      afterWrite: async () => {
+        order.push("first:start")
+        await firstGate
+        order.push("first:end")
+      },
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+    const second = writeProviderDeploymentOutputs({
+      afterWrite: async () => {
+        order.push("second")
+      },
+      clientOutDir: "dist/client",
+      rootDir,
+    })
+
+    await new Promise(resolve => setTimeout(resolve, 0))
+    expect(order).toEqual(["first:start"])
+    releaseFirst()
+    await Promise.all([first, second])
+    expect(order).toEqual(["first:start", "first:end", "second"])
+  })
+
   it("writes Netlify functions with static config and preserves shared config keys", async () => {
     const rootDir = await createTempProject()
     const {

--- a/packages/internal/test/esbuild.test.ts
+++ b/packages/internal/test/esbuild.test.ts
@@ -2,7 +2,9 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { pathToFileURL } from "node:url"
+import { runInNewContext } from "node:vm"
 
+import { transform } from "esbuild"
 import { afterEach, describe, expect, it } from "vitest"
 
 import type { Plugin } from "esbuild"
@@ -245,13 +247,19 @@ describe("bundleEsmEntry", () => {
     const { bundleEsmEntry } = await import("../src/build/esbuild.ts")
     await bundleEsmEntry(entry, outfile, { format: "esm", platform: "node" })
 
-    await expect(readFile(outfile, "utf8")).resolves.toContain("globalThis.__filename = __vitehubFileURLToPath(import.meta.url);")
+    const bundled = await readFile(outfile, "utf8")
+    expect(bundled).toContain("if (globalThis.process?.getBuiltinModule && import.meta.url) {")
+    expect(bundled).toContain('globalThis.__filename = globalThis.process.getBuiltinModule("node:url").fileURLToPath(import.meta.url);')
+    expect(bundled).not.toMatch(/(?:const|let|var|import).*__vitehub/)
     const loaded = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: () => { dirname: string, filename: string, requireType: string } }
     expect(loaded.default()).toEqual({
       dirname: dirname(outfile),
       filename: outfile,
       requireType: "function",
     })
+
+    const commonjs = await transform(bundled, { format: "cjs", logLevel: "silent", target: "node24" })
+    expect(() => runInNewContext(commonjs.code, { exports: {}, module: { exports: {} } })).not.toThrow()
   })
 
   it("does not redeclare Netlify runtime filename globals", async () => {

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -141,6 +141,7 @@ function renderProviderEntry(file: string, registryFile: string, provider: "clou
       ? [
           `import workflowRegistry from ${JSON.stringify(createImportPath(file, workflowRuntime.registryFile))}`,
           `import { setWorkflowRuntimeConfig, setWorkflowRuntimeRegistry } from ${JSON.stringify(`${workflowRuntime.importBase}/runtime/state`)}`,
+          `import { runWithVercelWorkflowRuntimeEvent } from ${JSON.stringify(`${workflowRuntime.importBase}/runtime/vercel-vite`)}`,
           ...(workflowRuntime.native
             ? [
                 `import { setVercelWorkflowRuntimeModules } from ${JSON.stringify(`${workflowRuntime.importBase}/runtime/vercel-vite`)}`,
@@ -209,7 +210,9 @@ function renderProviderEntry(file: string, registryFile: string, provider: "clou
                 "  setWorkflowRuntimeRegistry(workflowRegistry)",
               ]
             : []),
-          "  await runSchedule(name, definition.cron, new Date())",
+          workflowRuntime
+            ? "  await runWithVercelWorkflowRuntimeEvent(req, res, () => runSchedule(name, definition.cron, new Date()))"
+            : "  await runSchedule(name, definition.cron, new Date())",
           "  res.statusCode = 204",
           "  res.end()",
           "}",

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -358,6 +358,7 @@ export async function writeVercelScheduleFunctions(options: {
       platform: "node",
       plugins: [createScheduleDefinitionAliasPlugin(), ...(options.workflow?.bundlePlugins ?? [])],
       rootDir: options.rootDir,
+      workingDir: options.rootDir,
     })
     await rm(wrapperFile, { force: true })
     await writeFile(resolve(functionDir, ".vc-config.json"), `${JSON.stringify(createNodeFunctionConfig(), null, 2)}\n`, "utf8")

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -54,11 +54,19 @@ interface GeneratedScheduleArtifacts {
 
 interface GenerateProviderOutputsOptions {
   bundleAlias?: Record<string, string>
+  bundleExternal?: string[]
   clientOutDir: string
   definitions?: DiscoveredScheduleDefinition[]
   rootDir: string
   runtimeImport?: string
   source?: DiscoveredScheduleDefinition["source"]
+  workflow?: ScheduleWorkflowRuntime
+}
+
+export interface ScheduleWorkflowRuntime {
+  bundleAlias: Record<string, string>
+  importBase: string
+  registryFile: string
 }
 
 async function removeEmptyDirectories(directory: string, rootDir: string): Promise<void> {
@@ -122,12 +130,23 @@ function readStaticString(source: string | undefined): string | undefined {
   }
 }
 
-function renderProviderEntry(file: string, registryFile: string, provider: "cloudflare" | "vercel", scheduleName?: string) {
+function renderProviderEntry(file: string, registryFile: string, provider: "cloudflare" | "vercel", scheduleName?: string, workflow?: ScheduleWorkflowRuntime) {
   const runtimeImport = createImportPath(file, scheduleRuntimeEntry)
+  const workflowRuntime = provider === "vercel" ? workflow : undefined
   return [
     `import scheduleRegistry from ${JSON.stringify(createImportPath(file, registryFile))}`,
     `import { executeStaticSchedule } from ${JSON.stringify(runtimeImport)}`,
+    ...(workflowRuntime
+      ? [
+          `import workflowRegistry from ${JSON.stringify(createImportPath(file, workflowRuntime.registryFile))}`,
+          `import { setWorkflowRuntimeConfig, setWorkflowRuntimeRegistry } from ${JSON.stringify(`${workflowRuntime.importBase}/runtime/state`)}`,
+          `import { setVercelWorkflowRuntimeModules } from ${JSON.stringify(`${workflowRuntime.importBase}/runtime/vercel-vite`)}`,
+          `import * as workflowApi from "workflow/api"`,
+          `import * as workflowRuntime from "workflow/runtime"`,
+        ]
+      : []),
     "",
+    workflowRuntime ? "setVercelWorkflowRuntimeModules(workflowApi, workflowRuntime)" : "",
     "async function loadScheduleDefinition(name) {",
     "  const loader = scheduleRegistry[name]",
     "  if (!loader) return undefined",
@@ -179,6 +198,12 @@ function renderProviderEntry(file: string, registryFile: string, provider: "clou
           "    res.end('Missing schedule definition.')",
           "    return",
           "  }",
+          ...(workflowRuntime
+            ? [
+                "  setWorkflowRuntimeConfig({ provider: 'vercel' })",
+                "  setWorkflowRuntimeRegistry(workflowRegistry)",
+              ]
+            : []),
           "  await runSchedule(name, definition.cron, new Date())",
           "  res.statusCode = 204",
           "  res.end()",
@@ -290,10 +315,12 @@ export async function readDefinitionCrons(definitions: DiscoveredScheduleDefinit
 
 export async function writeVercelScheduleFunctions(options: {
   bundleAlias?: Record<string, string>
+  bundleExternal?: string[]
   definitions: DiscoveredScheduleDefinition[]
   outputRoot: string
   registryFile: string
   rootDir: string
+  workflow?: ScheduleWorkflowRuntime
 }, crons: Map<string, string>) {
   const definitions = staticScheduleDefinitions(options.definitions)
   const outputRoot = options.outputRoot
@@ -314,9 +341,10 @@ export async function writeVercelScheduleFunctions(options: {
     const functionFile = resolve(functionDir, "index.mjs")
     const wrapperFile = resolve(functionDir, "index.source.mjs")
     await mkdir(functionDir, { recursive: true })
-    await writeFile(wrapperFile, renderProviderEntry(wrapperFile, options.registryFile, "vercel", definition.name), "utf8")
+    await writeFile(wrapperFile, renderProviderEntry(wrapperFile, options.registryFile, "vercel", definition.name, options.workflow), "utf8")
     await bundleEsmEntry(wrapperFile, functionFile, {
       alias: options.bundleAlias,
+      external: options.bundleExternal,
       format: "esm",
       platform: "node",
       plugins: [createScheduleDefinitionAliasPlugin()],
@@ -568,10 +596,12 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   }
   await writeVercelScheduleFunctions({
     bundleAlias: options.bundleAlias,
+    bundleExternal: options.bundleExternal,
     definitions: artifacts.definitions,
     outputRoot: createDefaultVercelOutputRoot(options.rootDir),
     registryFile: artifacts.registryFile,
     rootDir: options.rootDir,
+    workflow: options.workflow,
   }, crons)
   await writeNetlifyScheduleFunctions({
     definitions: artifacts.definitions,

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -5,7 +5,7 @@ import { fileURLToPath } from "node:url"
 import { isDeepStrictEqual } from "node:util"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
-import { createDefaultCloudflareOutputRoot, createDefaultNetlifyOutputRoot, createDefaultVercelOutputRoot } from "@vite-hub/internal/build/deployment-output"
+import { createDefaultCloudflareOutputRoot, createDefaultNetlifyOutputRoot, createDefaultVercelOutputRoot, withProviderDeploymentOutputLock } from "@vite-hub/internal/build/deployment-output"
 import { bundleEsmEntry } from "@vite-hub/internal/build/esbuild"
 import { createImportPath, ensureGeneratedDir } from "@vite-hub/internal/build/paths"
 import { createNodeFunctionConfig, createVercelConfigJson } from "@vite-hub/internal/build/vercel-config"
@@ -580,7 +580,7 @@ async function cleanCloudflareScheduleOutput(rootDir: string, stateFile: string)
   ])
 }
 
-export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedScheduleArtifacts> {
+async function generateProviderOutputsWithinLock(options: GenerateProviderOutputsOptions): Promise<GeneratedScheduleArtifacts> {
   const generatedDir = ensureGeneratedDir(options.rootDir, productName)
   const cloudflareStateFile = resolve(generatedDir, cloudflareOutputStateFileName)
   const artifacts = await writeProviderEntries(options.rootDir, options.source, options.definitions)
@@ -620,4 +620,8 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     rootDir: options.rootDir,
   })
   return artifacts
+}
+
+export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedScheduleArtifacts> {
+  return await withProviderDeploymentOutputLock(options.rootDir, async () => await generateProviderOutputsWithinLock(options))
 }

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -66,6 +66,7 @@ interface GenerateProviderOutputsOptions {
 export interface ScheduleWorkflowRuntime {
   bundleAlias: Record<string, string>
   importBase: string
+  native: boolean
   registryFile: string
 }
 
@@ -140,13 +141,17 @@ function renderProviderEntry(file: string, registryFile: string, provider: "clou
       ? [
           `import workflowRegistry from ${JSON.stringify(createImportPath(file, workflowRuntime.registryFile))}`,
           `import { setWorkflowRuntimeConfig, setWorkflowRuntimeRegistry } from ${JSON.stringify(`${workflowRuntime.importBase}/runtime/state`)}`,
-          `import { setVercelWorkflowRuntimeModules } from ${JSON.stringify(`${workflowRuntime.importBase}/runtime/vercel-vite`)}`,
-          `import * as workflowApi from "workflow/api"`,
-          `import * as workflowRuntime from "workflow/runtime"`,
+          ...(workflowRuntime.native
+            ? [
+                `import { setVercelWorkflowRuntimeModules } from ${JSON.stringify(`${workflowRuntime.importBase}/runtime/vercel-vite`)}`,
+                `import * as workflowApi from "workflow/api"`,
+                `import * as workflowRuntime from "workflow/runtime"`,
+              ]
+            : []),
         ]
       : []),
     "",
-    workflowRuntime ? "setVercelWorkflowRuntimeModules(workflowApi, workflowRuntime)" : "",
+    workflowRuntime?.native ? "setVercelWorkflowRuntimeModules(workflowApi, workflowRuntime)" : "",
     "async function loadScheduleDefinition(name) {",
     "  const loader = scheduleRegistry[name]",
     "  if (!loader) return undefined",

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -65,6 +65,7 @@ interface GenerateProviderOutputsOptions {
 
 export interface ScheduleWorkflowRuntime {
   bundleAlias: Record<string, string>
+  bundlePlugins?: Plugin[]
   importBase: string
   native: boolean
   registryFile: string
@@ -355,7 +356,7 @@ export async function writeVercelScheduleFunctions(options: {
       external: options.bundleExternal,
       format: "esm",
       platform: "node",
-      plugins: [createScheduleDefinitionAliasPlugin()],
+      plugins: [createScheduleDefinitionAliasPlugin(), ...(options.workflow?.bundlePlugins ?? [])],
       rootDir: options.rootDir,
     })
     await rm(wrapperFile, { force: true })

--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -580,7 +580,7 @@ async function cleanCloudflareScheduleOutput(rootDir: string, stateFile: string)
   ])
 }
 
-async function generateProviderOutputsWithinLock(options: GenerateProviderOutputsOptions): Promise<GeneratedScheduleArtifacts> {
+export async function generateProviderOutputsWithinLock(options: GenerateProviderOutputsOptions): Promise<GeneratedScheduleArtifacts> {
   const generatedDir = ensureGeneratedDir(options.rootDir, productName)
   const cloudflareStateFile = resolve(generatedDir, cloudflareOutputStateFileName)
   const artifacts = await writeProviderEntries(options.rootDir, options.source, options.definitions)

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -598,7 +598,7 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
         },
         ...(workflow ? { bundleExternal: ["@vitejs/devtools-core", "@vitejs/devtools-kit", "@vitejs/devtools-rolldown"] } : {}),
         clientOutDir: resolved.build.outDir,
-        definitions: emitStandaloneProviderOutput ? discoverRegistrySchedules() : [],
+        definitions: emitStandaloneProviderOutput ? discoverViteSchedules() : [],
         rootDir: projectRoot ?? resolved.root,
         runtimeImport: internalOptions.runtimeImport,
         source: standaloneProviderSource,

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -7,10 +7,12 @@ import { createRuntimeRegistryContents } from "@vite-hub/internal/definition-cat
 import { createNoExternalMerger, isServerEnvironment, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import { discoverScheduleDefinitions } from "./discovery.ts"
+import { getVercelSchedulePath } from "./integrations/vercel.ts"
 import { generateProviderOutputs, readDefinitionCrons, schedulePackageName } from "./internal/provider-output.ts"
 import { createScheduleTargetsContents, SCHEDULE_TARGETS_ID } from "./targets-module.ts"
 
 import type { Plugin, ResolvedConfig, UserConfig } from "vite"
+import type { ScheduleWorkflowRuntime } from "./internal/provider-output.ts"
 import type { DiscoveredScheduleDefinition } from "./types.ts"
 
 const SCHEDULE_VITE_PLUGIN_NAME = "@vite-hub/schedule/vite"
@@ -66,6 +68,19 @@ type NitroConfig = Record<string, unknown> & {
   } & Record<string, unknown>
   modules?: unknown[]
   plugins?: unknown[]
+  vercel?: {
+    config?: {
+      crons?: Array<{ path: string, schedule: string }>
+    } & Record<string, unknown>
+  } & Record<string, unknown>
+}
+
+interface WorkflowVitePlugin extends Plugin {
+  vitehub?: {
+    workflow?: {
+      prepareScheduleRuntime?: () => Promise<ScheduleWorkflowRuntime | undefined>
+    }
+  }
 }
 
 type ViteConfigWithNitro = UserConfig & {
@@ -164,6 +179,29 @@ function mergeNitroScheduleConfig(value: unknown, options: { crons: string[], pl
     ...existingTriggers,
     crons: [...new Set([...existingCrons, ...options.crons])],
   }
+  return nitro
+}
+
+function mergeNitroVercelCrons(
+  value: unknown,
+  definitions: DiscoveredScheduleDefinition[],
+  crons: Map<string, string>,
+): NitroConfig {
+  const nitro = cloneNitroConfig(value)
+  const vercel = isRecord(nitro.vercel) ? { ...nitro.vercel } : {}
+  const config = isRecord(vercel.config) ? { ...vercel.config } : {}
+  const existing = Array.isArray(config.crons)
+    ? config.crons.filter(cron => isRecord(cron) && typeof cron.path === "string" && !cron.path.startsWith("/api/vitehub/schedules/vercel/"))
+    : []
+  config.crons = [
+    ...existing,
+    ...definitions.map(definition => ({
+      path: getVercelSchedulePath(definition.name),
+      schedule: crons.get(definition.name)!,
+    })),
+  ]
+  vercel.config = config
+  nitro.vercel = vercel
   return nitro
 }
 
@@ -389,9 +427,18 @@ export async function createScheduleNitroConfig(options: ScheduleNitroConfigOpti
     serverDirs: options.serverDirs,
     serverRootDir: roots.projectRoot,
   })
-  if (!shouldInstallNitroSchedulePlugin(definitions, options)) {
-    return null
+  const installNitroPlugin = shouldInstallNitroSchedulePlugin(definitions, options)
+  const nitroPreset = isRecord(options.nitro) && typeof options.nitro.preset === "string" ? options.nitro.preset : ""
+  const vercelDefinitions = options.command === "build" && options.providerOutput === "standalone" && nitroPreset.startsWith("vercel")
+    ? definitions.filter(definition => definition.runtimeOnly !== true)
+    : []
+  if (!installNitroPlugin && !vercelDefinitions.length) return null
+
+  let nitro = options.nitro
+  if (vercelDefinitions.length) {
+    nitro = mergeNitroVercelCrons(nitro, vercelDefinitions, await readDefinitionCrons(vercelDefinitions))
   }
+  if (!installNitroPlugin) return nitro as NitroConfig
 
   const nitroDefinitions = processRuntime && options.providerOutput !== "nitro" ? [] : selectNitroScheduleDefinitions(definitions, options)
   const crons = options.command === "build"
@@ -411,7 +458,7 @@ export async function createScheduleNitroConfig(options: ScheduleNitroConfigOpti
     ),
     runtimeImport: (options as InternalScheduleVitePluginOptions).runtimeImport,
   })
-  return mergeNitroScheduleConfig(options.nitro, {
+  return mergeNitroScheduleConfig(nitro, {
     crons,
     plugin,
     providerWake: nitroDefinitions.length > 0,
@@ -475,9 +522,6 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
       })
       emitStandaloneProviderOutput = (options.runtime === undefined || options.providerOutput === "standalone") && shouldEmitStandaloneProviderOutput(definitions, options)
       standaloneProviderSource = selectStandaloneProviderSource(definitions, options)
-      if (!shouldInstallNitroSchedulePlugin(definitions, options)) {
-        return null
-      }
       const nitro = await createScheduleNitroConfig({
         ...options,
         command: env.command,
@@ -542,16 +586,22 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
       if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) {
         return
       }
+      const workflow = await ((resolved.plugins ?? []) as WorkflowVitePlugin[])
+        .find(candidate => candidate.vitehub?.workflow?.prepareScheduleRuntime)
+        ?.vitehub?.workflow?.prepareScheduleRuntime?.()
       await generateProviderOutputs({
         bundleAlias: {
           ...resolveStringAliases(resolved),
           ...internalOptions.providerImportAliases,
+          ...workflow?.bundleAlias,
         },
+        ...(workflow ? { bundleExternal: ["@vitejs/devtools-core", "@vitejs/devtools-kit", "@vitejs/devtools-rolldown"] } : {}),
         clientOutDir: resolved.build.outDir,
         definitions: emitStandaloneProviderOutput ? discoverRegistrySchedules() : [],
-        rootDir: resolved.root,
+        rootDir: projectRoot ?? resolved.root,
         runtimeImport: internalOptions.runtimeImport,
         source: standaloneProviderSource,
+        workflow,
       })
     },
   }

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -432,8 +432,12 @@ export async function createScheduleNitroConfig(options: ScheduleNitroConfigOpti
   const nitroPreset = isRecord(options.nitro) && typeof options.nitro.preset === "string"
     ? options.nitro.preset
     : process.env.NITRO_PRESET || process.env.SERVER_PRESET || process.env.VITEHUB_HOSTING || ""
-  const vercelDefinitions = options.command === "build" && options.providerOutput === "standalone" && nitroPreset.startsWith("vercel")
-    ? definitions.filter(definition => definition.runtimeOnly !== true)
+  const standaloneProviderSource = selectStandaloneProviderSource(definitions, options)
+  const vercelDefinitions = options.command === "build" && nitroPreset.startsWith("vercel") && shouldEmitStandaloneProviderOutput(definitions, options)
+    ? definitions.filter(definition =>
+        definition.runtimeOnly !== true
+        && (standaloneProviderSource === undefined || definition.source === standaloneProviderSource),
+      )
     : []
   if (!installNitroPlugin && !vercelDefinitions.length) return null
 

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -429,7 +429,9 @@ export async function createScheduleNitroConfig(options: ScheduleNitroConfigOpti
     serverRootDir: roots.projectRoot,
   })
   const installNitroPlugin = shouldInstallNitroSchedulePlugin(definitions, options)
-  const nitroPreset = isRecord(options.nitro) && typeof options.nitro.preset === "string" ? options.nitro.preset : ""
+  const nitroPreset = isRecord(options.nitro) && typeof options.nitro.preset === "string"
+    ? options.nitro.preset
+    : process.env.NITRO_PRESET || process.env.SERVER_PRESET || process.env.VITEHUB_HOSTING || ""
   const vercelDefinitions = options.command === "build" && options.providerOutput === "standalone" && nitroPreset.startsWith("vercel")
     ? definitions.filter(definition => definition.runtimeOnly !== true)
     : []
@@ -597,7 +599,7 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
           ...workflow?.bundleAlias,
         },
         ...(workflow ? { bundleExternal: ["@vitejs/devtools-core", "@vitejs/devtools-kit", "@vitejs/devtools-rolldown"] } : {}),
-        clientOutDir: resolved.build.outDir,
+        clientOutDir: resolve(resolved.root, resolved.build.outDir),
         definitions: emitStandaloneProviderOutput ? discoverRegistrySchedules() : [],
         rootDir: projectRoot ?? resolved.root,
         runtimeImport: internalOptions.runtimeImport,

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -598,7 +598,7 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
         },
         ...(workflow ? { bundleExternal: ["@vitejs/devtools-core", "@vitejs/devtools-kit", "@vitejs/devtools-rolldown"] } : {}),
         clientOutDir: resolved.build.outDir,
-        definitions: emitStandaloneProviderOutput ? discoverViteSchedules() : [],
+        definitions: emitStandaloneProviderOutput ? discoverRegistrySchedules() : [],
         rootDir: projectRoot ?? resolved.root,
         runtimeImport: internalOptions.runtimeImport,
         source: standaloneProviderSource,

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -1,14 +1,14 @@
 import { mkdir, writeFile } from "node:fs/promises"
 import { dirname, relative, resolve, normalize } from "node:path"
 
-import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
+import { shouldSkipViteProviderBuild, withProviderDeploymentOutputLock } from "@vite-hub/internal/build/deployment-output"
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { createRuntimeRegistryContents } from "@vite-hub/internal/definition-catalog"
 import { createNoExternalMerger, isServerEnvironment, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import { discoverScheduleDefinitions } from "./discovery.ts"
 import { getVercelSchedulePath } from "./integrations/vercel.ts"
-import { generateProviderOutputs, readDefinitionCrons, schedulePackageName } from "./internal/provider-output.ts"
+import { generateProviderOutputsWithinLock, readDefinitionCrons, schedulePackageName } from "./internal/provider-output.ts"
 import { createScheduleTargetsContents, SCHEDULE_TARGETS_ID } from "./targets-module.ts"
 
 import type { Plugin, ResolvedConfig, UserConfig } from "vite"
@@ -589,22 +589,27 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
       if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) {
         return
       }
-      const workflow = await ((resolved.plugins ?? []) as WorkflowVitePlugin[])
+      const config = resolved
+      const rootDir = projectRoot ?? config.root
+      const prepareWorkflow = ((config.plugins ?? []) as WorkflowVitePlugin[])
         .find(candidate => candidate.vitehub?.workflow?.prepareScheduleRuntime)
-        ?.vitehub?.workflow?.prepareScheduleRuntime?.()
-      await generateProviderOutputs({
-        bundleAlias: {
-          ...resolveStringAliases(resolved),
-          ...internalOptions.providerImportAliases,
-          ...workflow?.bundleAlias,
-        },
-        ...(workflow ? { bundleExternal: ["@vitejs/devtools-core", "@vitejs/devtools-kit", "@vitejs/devtools-rolldown"] } : {}),
-        clientOutDir: resolve(resolved.root, resolved.build.outDir),
-        definitions: emitStandaloneProviderOutput ? discoverRegistrySchedules() : [],
-        rootDir: projectRoot ?? resolved.root,
-        runtimeImport: internalOptions.runtimeImport,
-        source: standaloneProviderSource,
-        workflow,
+        ?.vitehub?.workflow?.prepareScheduleRuntime
+      await withProviderDeploymentOutputLock(rootDir, async () => {
+        const workflow = await prepareWorkflow?.()
+        await generateProviderOutputsWithinLock({
+          bundleAlias: {
+            ...resolveStringAliases(config),
+            ...internalOptions.providerImportAliases,
+            ...workflow?.bundleAlias,
+          },
+          ...(workflow ? { bundleExternal: ["@vitejs/devtools-core", "@vitejs/devtools-kit", "@vitejs/devtools-rolldown"] } : {}),
+          clientOutDir: resolve(config.root, config.build.outDir),
+          definitions: emitStandaloneProviderOutput ? discoverRegistrySchedules() : [],
+          rootDir,
+          runtimeImport: internalOptions.runtimeImport,
+          source: standaloneProviderSource,
+          workflow,
+        })
       })
     },
   }

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -4,7 +4,7 @@ import { dirname, relative, resolve, normalize } from "node:path"
 import { shouldSkipViteProviderBuild, withProviderDeploymentOutputLock } from "@vite-hub/internal/build/deployment-output"
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { createRuntimeRegistryContents } from "@vite-hub/internal/definition-catalog"
-import { createNoExternalMerger, isServerEnvironment, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
+import { collectViteHubProviderImportAliases, createNoExternalMerger, isServerEnvironment, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import { discoverScheduleDefinitions } from "./discovery.ts"
 import { getVercelSchedulePath } from "./integrations/vercel.ts"
@@ -13,6 +13,7 @@ import { createScheduleTargetsContents, SCHEDULE_TARGETS_ID } from "./targets-mo
 
 import type { Plugin, ResolvedConfig, UserConfig } from "vite"
 import type { ScheduleWorkflowRuntime } from "./internal/provider-output.ts"
+import type { ViteHubProviderImportContributor } from "@vite-hub/internal/build/vite"
 import type { DiscoveredScheduleDefinition } from "./types.ts"
 
 const SCHEDULE_VITE_PLUGIN_NAME = "@vite-hub/schedule/vite"
@@ -603,9 +604,11 @@ export function hubSchedule(options: ScheduleVitePluginOptions = {}): ScheduleVi
         ?.vitehub?.workflow?.prepareScheduleRuntime
       await withProviderDeploymentOutputLock(rootDir, async () => {
         const workflow = await prepareWorkflow?.()
+        const contributedAliases = await collectViteHubProviderImportAliases((config.plugins ?? []) as Array<Plugin & ViteHubProviderImportContributor>)
         await generateProviderOutputsWithinLock({
           bundleAlias: {
             ...resolveStringAliases(config),
+            ...contributedAliases,
             ...internalOptions.providerImportAliases,
             ...workflow?.bundleAlias,
           },

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -190,8 +190,9 @@ function mergeNitroVercelCrons(
   const nitro = cloneNitroConfig(value)
   const vercel = isRecord(nitro.vercel) ? { ...nitro.vercel } : {}
   const config = isRecord(vercel.config) ? { ...vercel.config } : {}
+  const generatedPaths = new Set(definitions.map(definition => getVercelSchedulePath(definition.name)))
   const existing = Array.isArray(config.crons)
-    ? config.crons.filter(cron => isRecord(cron) && typeof cron.path === "string" && !cron.path.startsWith("/api/vitehub/schedules/vercel/"))
+    ? config.crons.filter(cron => isRecord(cron) && typeof cron.path === "string" && !generatedPaths.has(cron.path))
     : []
   config.crons = [
     ...existing,

--- a/packages/schedule/src/vite.ts
+++ b/packages/schedule/src/vite.ts
@@ -433,7 +433,10 @@ export async function createScheduleNitroConfig(options: ScheduleNitroConfigOpti
     ? options.nitro.preset
     : process.env.NITRO_PRESET || process.env.SERVER_PRESET || process.env.VITEHUB_HOSTING || ""
   const standaloneProviderSource = selectStandaloneProviderSource(definitions, options)
-  const vercelDefinitions = options.command === "build" && nitroPreset.startsWith("vercel") && shouldEmitStandaloneProviderOutput(definitions, options)
+  const vercelDefinitions = options.command === "build"
+    && nitroPreset.startsWith("vercel")
+    && (options.runtime === undefined || options.providerOutput === "standalone")
+    && shouldEmitStandaloneProviderOutput(definitions, options)
     ? definitions.filter(definition =>
         definition.runtimeOnly !== true
         && (standaloneProviderSource === undefined || definition.source === standaloneProviderSource),

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -101,6 +101,7 @@ describe("schedule provider output", () => {
     await writeFile(vercelRuntime, "export function setVercelWorkflowRuntimeModules() { globalThis.__workflowModules = true }\nexport async function runWithVercelWorkflowRuntimeEvent(req, res, run) { globalThis.__workflowEvent = { req, res }; return await run() }\n")
     await writeFile(workflowApi, "export const api = true\n")
     await writeFile(workflowRuntime, "export const runtime = true\n")
+    let workflowTransformRan = false
 
     await generateProviderOutputs({
       bundleAlias: {
@@ -113,6 +114,14 @@ describe("schedule provider output", () => {
       rootDir,
       workflow: {
         bundleAlias: {},
+        bundlePlugins: [{
+          name: "test-workflow-transform",
+          setup(build) {
+            build.onEnd(() => {
+              workflowTransformRan = true
+            })
+          },
+        }],
         importBase: "test-workflow",
         native: true,
         registryFile: workflowRegistry,
@@ -125,6 +134,7 @@ describe("schedule provider output", () => {
     expect(output).toContain("__workflowConfig")
     expect(output).toContain("__workflowRegistry")
     expect(output).toContain("__workflowEvent")
+    expect(workflowTransformRan).toBe(true)
   })
 
   it("installs inline Workflow definitions without Workflow DevKit", async () => {

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -78,12 +78,51 @@ describe("schedule provider output", () => {
       schedule: "0 0 * * *",
     }])
     expect(await readFile(vercelFunction, "utf8")).toContain("executeStaticSchedule")
+    expect(await readFile(vercelFunction, "utf8")).not.toContain("setWorkflowRuntimeRegistry")
     expect(existsSync(join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "schedules", "vercel", "agent-turn.func"))).toBe(false)
     await expect(readFile(netlifyFunction, "utf8")).resolves.toContain("export const config = {")
     expect(existsSync(join(createDefaultNetlifyOutputRoot(rootDir), "functions", "vitehub-schedule-agent-turn.mjs"))).toBe(false)
     await expect(readFile(netlifyFunction, "utf8")).resolves.toContain("schedule: \"0 0 * * *\"")
     await expect(readFile(netlifyFunction, "utf8")).resolves.toContain("executeStaticSchedule")
     await expect(readFile(join(rootDir, ".vitehub", "schedule", "registry.mjs"), "utf8")).resolves.not.toContain("agent-turn")
+  })
+
+  it("installs a composed Workflow runtime in Vercel schedule functions", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-workflow-output-")
+    const workflowDir = join(rootDir, ".vitehub", "workflow")
+    await mkdir(workflowDir, { recursive: true })
+    const workflowRegistry = join(workflowDir, "registry.mjs")
+    const state = join(workflowDir, "state.mjs")
+    const vercelRuntime = join(workflowDir, "vercel-runtime.mjs")
+    const workflowApi = join(workflowDir, "workflow-api.mjs")
+    const workflowRuntime = join(workflowDir, "workflow-runtime.mjs")
+    await writeFile(workflowRegistry, "export default { recap: async () => ({}) }\n")
+    await writeFile(state, "export function setWorkflowRuntimeConfig(value) { globalThis.__workflowConfig = value }\nexport function setWorkflowRuntimeRegistry(value) { globalThis.__workflowRegistry = value }\n")
+    await writeFile(vercelRuntime, "export function setVercelWorkflowRuntimeModules() { globalThis.__workflowModules = true }\n")
+    await writeFile(workflowApi, "export const api = true\n")
+    await writeFile(workflowRuntime, "export const runtime = true\n")
+
+    await generateProviderOutputs({
+      bundleAlias: {
+        "test-workflow/runtime/state": state,
+        "test-workflow/runtime/vercel-vite": vercelRuntime,
+        "workflow/api": workflowApi,
+        "workflow/runtime": workflowRuntime,
+      },
+      clientOutDir: "dist/client",
+      rootDir,
+      workflow: {
+        bundleAlias: {},
+        importBase: "test-workflow",
+        registryFile: workflowRegistry,
+      },
+    })
+
+    const vercelFunction = join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "schedules", "vercel", "cleanup.func", "index.mjs")
+    const output = await readFile(vercelFunction, "utf8")
+    expect(output).toContain("__workflowModules")
+    expect(output).toContain("__workflowConfig")
+    expect(output).toContain("__workflowRegistry")
   })
 
   it("creates Netlify scheduled function output contributions", async () => {

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -114,6 +114,7 @@ describe("schedule provider output", () => {
       workflow: {
         bundleAlias: {},
         importBase: "test-workflow",
+        native: true,
         registryFile: workflowRegistry,
       },
     })
@@ -123,6 +124,35 @@ describe("schedule provider output", () => {
     expect(output).toContain("__workflowModules")
     expect(output).toContain("__workflowConfig")
     expect(output).toContain("__workflowRegistry")
+  })
+
+  it("installs inline Workflow definitions without Workflow DevKit", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-inline-workflow-output-")
+    const workflowDir = join(rootDir, ".vitehub", "workflow")
+    await mkdir(workflowDir, { recursive: true })
+    const workflowRegistry = join(workflowDir, "registry.mjs")
+    const state = join(workflowDir, "state.mjs")
+    await writeFile(workflowRegistry, "export default { recap: async () => ({}) }\n")
+    await writeFile(state, "export function setWorkflowRuntimeConfig(value) { globalThis.__workflowConfig = value }\nexport function setWorkflowRuntimeRegistry(value) { globalThis.__workflowRegistry = value }\n")
+
+    await generateProviderOutputs({
+      bundleAlias: { "test-workflow/runtime/state": state },
+      clientOutDir: "dist/client",
+      rootDir,
+      workflow: {
+        bundleAlias: {},
+        importBase: "test-workflow",
+        native: false,
+        registryFile: workflowRegistry,
+      },
+    })
+
+    const output = await readFile(join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "schedules", "vercel", "cleanup.func", "index.mjs"), "utf8")
+    expect(output).toContain("__workflowConfig")
+    expect(output).toContain("__workflowRegistry")
+    expect(output).not.toContain("workflow/api")
+    expect(output).not.toContain("workflow/runtime")
+    expect(output).not.toContain("setVercelWorkflowRuntimeModules")
   })
 
   it("creates Netlify scheduled function output contributions", async () => {

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -98,7 +98,7 @@ describe("schedule provider output", () => {
     const workflowRuntime = join(workflowDir, "workflow-runtime.mjs")
     await writeFile(workflowRegistry, "export default { recap: async () => ({}) }\n")
     await writeFile(state, "export function setWorkflowRuntimeConfig(value) { globalThis.__workflowConfig = value }\nexport function setWorkflowRuntimeRegistry(value) { globalThis.__workflowRegistry = value }\n")
-    await writeFile(vercelRuntime, "export function setVercelWorkflowRuntimeModules() { globalThis.__workflowModules = true }\n")
+    await writeFile(vercelRuntime, "export function setVercelWorkflowRuntimeModules() { globalThis.__workflowModules = true }\nexport async function runWithVercelWorkflowRuntimeEvent(req, res, run) { globalThis.__workflowEvent = { req, res }; return await run() }\n")
     await writeFile(workflowApi, "export const api = true\n")
     await writeFile(workflowRuntime, "export const runtime = true\n")
 
@@ -124,6 +124,7 @@ describe("schedule provider output", () => {
     expect(output).toContain("__workflowModules")
     expect(output).toContain("__workflowConfig")
     expect(output).toContain("__workflowRegistry")
+    expect(output).toContain("__workflowEvent")
   })
 
   it("installs inline Workflow definitions without Workflow DevKit", async () => {
@@ -133,10 +134,12 @@ describe("schedule provider output", () => {
     const workflowRegistry = join(workflowDir, "registry.mjs")
     const state = join(workflowDir, "state.mjs")
     await writeFile(workflowRegistry, "export default { recap: async () => ({}) }\n")
+    const vercelRuntime = join(workflowDir, "vercel-runtime.mjs")
     await writeFile(state, "export function setWorkflowRuntimeConfig(value) { globalThis.__workflowConfig = value }\nexport function setWorkflowRuntimeRegistry(value) { globalThis.__workflowRegistry = value }\n")
+    await writeFile(vercelRuntime, "export async function runWithVercelWorkflowRuntimeEvent(req, res, run) { globalThis.__workflowEvent = { req, res }; return await run() }\n")
 
     await generateProviderOutputs({
-      bundleAlias: { "test-workflow/runtime/state": state },
+      bundleAlias: { "test-workflow/runtime/state": state, "test-workflow/runtime/vercel-vite": vercelRuntime },
       clientOutDir: "dist/client",
       rootDir,
       workflow: {
@@ -150,6 +153,7 @@ describe("schedule provider output", () => {
     const output = await readFile(join(rootDir, ".vercel", "output", "functions", "api", "vitehub", "schedules", "vercel", "cleanup.func", "index.mjs"), "utf8")
     expect(output).toContain("__workflowConfig")
     expect(output).toContain("__workflowRegistry")
+    expect(output).toContain("__workflowEvent")
     expect(output).not.toContain("workflow/api")
     expect(output).not.toContain("workflow/runtime")
     expect(output).not.toContain("setVercelWorkflowRuntimeModules")

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -5,7 +5,7 @@ import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { afterAll, describe, expect, it } from "vitest"
-import { createDefaultCloudflareOutputRoot, createDefaultNetlifyOutputRoot } from "@vite-hub/internal/build/deployment-output"
+import { createDefaultCloudflareOutputRoot, createDefaultNetlifyOutputRoot, withProviderDeploymentOutputLock } from "@vite-hub/internal/build/deployment-output"
 import { createVercelConfigJson } from "@vite-hub/internal/build/vercel-config"
 
 import { createNetlifyScheduleFunctionOutputs, generateProviderOutputs, resolveScheduleDefinitionEntry, resolveScheduleRuntimeEntry, validateProviderCron, writeVercelScheduleFunctions } from "../src/internal/provider-output.ts"
@@ -33,6 +33,31 @@ afterAll(async () => {
 })
 
 describe("schedule provider output", () => {
+  it("serializes Schedule output with other provider output writers", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-output-lock-")
+    const configFile = join(rootDir, ".vercel", "output", "config.json")
+    let release!: () => void
+    let markStarted!: () => void
+    const started = new Promise<void>(resolve => { markStarted = resolve })
+    const gate = new Promise<void>(resolve => { release = resolve })
+    const owner = withProviderDeploymentOutputLock(rootDir, async () => {
+      markStarted()
+      await gate
+    })
+    await started
+
+    const generation = generateProviderOutputs({ clientOutDir: "dist/client", rootDir })
+    await new Promise(resolve => setTimeout(resolve, 20))
+    expect(existsSync(configFile)).toBe(false)
+
+    release()
+    await Promise.all([owner, generation])
+    expect(JSON.parse(await readFile(configFile, "utf8")).crons).toEqual([{
+      path: "/api/vitehub/schedules/vercel/cleanup",
+      schedule: "0 0 * * *",
+    }])
+  })
+
   it("keeps esbuild external in built provider output code", async () => {
     const distDir = join(packageRoot, "dist")
     const outputFiles = (await readdir(distDir)).filter(file => file.endsWith(".js"))

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -101,7 +101,7 @@ describe("schedule provider output", () => {
     await writeFile(vercelRuntime, "export function setVercelWorkflowRuntimeModules() { globalThis.__workflowModules = true }\nexport async function runWithVercelWorkflowRuntimeEvent(req, res, run) { globalThis.__workflowEvent = { req, res }; return await run() }\n")
     await writeFile(workflowApi, "export const api = true\n")
     await writeFile(workflowRuntime, "export const runtime = true\n")
-    let workflowTransformRan = false
+    let workflowTransformWorkingDir: string | undefined
 
     await generateProviderOutputs({
       bundleAlias: {
@@ -117,9 +117,7 @@ describe("schedule provider output", () => {
         bundlePlugins: [{
           name: "test-workflow-transform",
           setup(build) {
-            build.onEnd(() => {
-              workflowTransformRan = true
-            })
+            workflowTransformWorkingDir = build.initialOptions.absWorkingDir
           },
         }],
         importBase: "test-workflow",
@@ -134,7 +132,7 @@ describe("schedule provider output", () => {
     expect(output).toContain("__workflowConfig")
     expect(output).toContain("__workflowRegistry")
     expect(output).toContain("__workflowEvent")
-    expect(workflowTransformRan).toBe(true)
+    expect(workflowTransformWorkingDir).toBe(rootDir)
   })
 
   it("installs inline Workflow definitions without Workflow DevKit", async () => {

--- a/packages/schedule/test/vite.test.ts
+++ b/packages/schedule/test/vite.test.ts
@@ -30,6 +30,23 @@ function resolvePluginConfig(plugin: ReturnType<typeof hubSchedule>, root: strin
 }
 
 describe("Vite schedule integration", () => {
+  it("collects provider import aliases without a Workflow plugin", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-provider-aliases-"))
+    const getImportAliases = vi.fn(async () => ({}))
+    const plugin = hubSchedule()
+
+    ;(plugin.configResolved as (config: Record<string, unknown>) => void)({
+      build: { outDir: "dist" },
+      command: "build",
+      plugins: [{ vitehub: { providerOutput: { getImportAliases } } }],
+      resolve: { alias: [] },
+      root,
+    })
+    await (plugin.closeBundle as () => Promise<void>)()
+
+    expect(getImportAliases).toHaveBeenCalledOnce()
+  })
+
   it("runs before downstream framework integrations that consume Provider Output config", () => {
     const plugin = hubSchedule()
 

--- a/packages/schedule/test/vite.test.ts
+++ b/packages/schedule/test/vite.test.ts
@@ -746,6 +746,24 @@ describe("Vite schedule integration", () => {
     await expect(readFile(join(createDefaultNetlifyOutputRoot(root), "functions", "vitehub-schedule-sync.mjs"), "utf8")).rejects.toThrow()
   })
 
+  it("keeps suffix Schedule discovery relative to a nested Vite root", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "vitehub-schedule-project-root-"))
+    const viteRoot = join(projectRoot, "apps", "web")
+    await mkdir(join(viteRoot, "src"), { recursive: true })
+    await mkdir(join(projectRoot, "apps", "sibling", "src"), { recursive: true })
+    await writeFile(join(viteRoot, "src", "cleanup.schedule.ts"), "export default defineSchedule({ cron: '0 0 * * *', handler: () => {} })\n")
+    await writeFile(join(projectRoot, "apps", "sibling", "src", "noise.schedule.ts"), "export default defineSchedule({ cron: '0 1 * * *', handler: () => {} })\n")
+
+    const plugin = hubSchedule({ projectRoot })
+    await (plugin.config as (config: Record<string, unknown>, env: { command: "build", mode: string }) => unknown)({ root: viteRoot }, { command: "build", mode: "production" })
+    ;(plugin.configResolved as (config: Record<string, unknown>) => void)({ build: { outDir: "dist" }, command: "build", resolve: { alias: [] }, root: viteRoot })
+    await (plugin.closeBundle as () => Promise<void>)()
+
+    const registry = await readFile(join(projectRoot, ".vitehub", "schedule", "registry.mjs"), "utf8")
+    expect(registry).toContain('"cleanup"')
+    expect(registry).not.toContain("noise")
+  })
+
   it("serves a stable lazy registry for discovered schedule files", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-vite-"))
     await mkdir(join(root, "src"), { recursive: true })

--- a/packages/schedule/test/vite.test.ts
+++ b/packages/schedule/test/vite.test.ts
@@ -571,7 +571,11 @@ describe("Vite schedule integration", () => {
     const userConfig: Record<string, unknown> = {
       nitro: {
         preset: "vercel",
-        vercel: { config: { crons: [{ path: "/api/user", schedule: "5 0 * * *" }] } },
+        vercel: { config: { crons: [
+          { path: "/api/user", schedule: "5 0 * * *" },
+          { path: "/api/vitehub/schedules/vercel/authored", schedule: "10 0 * * *" },
+          { path: "/api/vitehub/schedules/vercel/cleanup", schedule: "15 0 * * *" },
+        ] } },
       },
       root,
     }
@@ -587,6 +591,7 @@ describe("Vite schedule integration", () => {
           config: {
             crons: [
               { path: "/api/user", schedule: "5 0 * * *" },
+              { path: "/api/vitehub/schedules/vercel/authored", schedule: "10 0 * * *" },
               { path: "/api/vitehub/schedules/vercel/cleanup", schedule: "0 0 * * *" },
             ],
           },

--- a/packages/schedule/test/vite.test.ts
+++ b/packages/schedule/test/vite.test.ts
@@ -628,6 +628,22 @@ describe("Vite schedule integration", () => {
     expect(userConfig).not.toHaveProperty("nitro.plugins")
   })
 
+  it("adds auto-selected standalone schedules to Vercel's Nitro output config", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-vercel-auto-"))
+    await mkdir(join(root, "src"), { recursive: true })
+    await writeFile(join(root, "src", "cleanup.schedule.ts"), "export default defineSchedule({ cron: '0 0 * * *', handler: () => {} })\n", "utf8")
+
+    const nitro = await createScheduleNitroConfig({
+      command: "build",
+      nitro: { preset: "vercel" },
+      root,
+    })
+
+    expect(nitro).toMatchObject({
+      vercel: { config: { crons: [{ path: "/api/vitehub/schedules/vercel/cleanup", schedule: "0 0 * * *" }] } },
+    })
+  })
+
   it.each(["NITRO_PRESET", "SERVER_PRESET"])("adds standalone schedules to Vercel Nitro config selected by %s", async (environmentVariable) => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-vercel-env-"))
     await mkdir(join(root, "src"), { recursive: true })

--- a/packages/schedule/test/vite.test.ts
+++ b/packages/schedule/test/vite.test.ts
@@ -628,6 +628,26 @@ describe("Vite schedule integration", () => {
     expect(userConfig).not.toHaveProperty("nitro.plugins")
   })
 
+  it.each(["NITRO_PRESET", "SERVER_PRESET"])("adds standalone schedules to Vercel Nitro config selected by %s", async (environmentVariable) => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-vercel-env-"))
+    await mkdir(join(root, "src"), { recursive: true })
+    await writeFile(join(root, "src", "cleanup.schedule.ts"), "export default defineSchedule({ cron: '0 0 * * *', handler: () => {} })\n", "utf8")
+    vi.stubEnv(environmentVariable, "vercel")
+    try {
+      const nitro = await createScheduleNitroConfig({
+        command: "build",
+        providerOutput: "standalone",
+        root,
+      })
+      expect(nitro).toMatchObject({
+        vercel: { config: { crons: [{ path: "/api/vitehub/schedules/vercel/cleanup", schedule: "0 0 * * *" }] } },
+      })
+    }
+    finally {
+      vi.unstubAllEnvs()
+    }
+  })
+
   it("can force Nitro plugin output for suffix schedules", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-force-nitro-"))
     await mkdir(join(root, "src"), { recursive: true })

--- a/packages/schedule/test/vite.test.ts
+++ b/packages/schedule/test/vite.test.ts
@@ -559,6 +559,43 @@ describe("Vite schedule integration", () => {
     await expect(readFile(join(root, ".vitehub", "nitro", "schedule", "module.mjs"), "utf8")).rejects.toThrow()
   })
 
+  it("adds standalone schedules to Vercel's Nitro output config", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-vercel-"))
+    await mkdir(join(root, "src"), { recursive: true })
+    await writeFile(join(root, "src", "cleanup.schedule.ts"), [
+      "import { defineSchedule } from '@vite-hub/schedule'",
+      "export default defineSchedule({ cron: '0 0 * * *', handler: () => {} })",
+      "",
+    ].join("\n"), "utf8")
+
+    const userConfig: Record<string, unknown> = {
+      nitro: {
+        preset: "vercel",
+        vercel: { config: { crons: [{ path: "/api/user", schedule: "5 0 * * *" }] } },
+      },
+      root,
+    }
+    const plugin = hubSchedule({ providerOutput: "standalone" })
+    await (plugin.config as (config: Record<string, unknown>, env: { command: "build", mode: string }) => unknown)(
+      userConfig,
+      { command: "build", mode: "production" },
+    )
+
+    expect(userConfig).toMatchObject({
+      nitro: {
+        vercel: {
+          config: {
+            crons: [
+              { path: "/api/user", schedule: "5 0 * * *" },
+              { path: "/api/vitehub/schedules/vercel/cleanup", schedule: "0 0 * * *" },
+            ],
+          },
+        },
+      },
+    })
+    expect(userConfig).not.toHaveProperty("nitro.plugins")
+  })
+
   it("can force Nitro plugin output for suffix schedules", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-force-nitro-"))
     await mkdir(join(root, "src"), { recursive: true })

--- a/packages/schedule/test/vite.test.ts
+++ b/packages/schedule/test/vite.test.ts
@@ -644,6 +644,21 @@ describe("Vite schedule integration", () => {
     })
   })
 
+  it("does not add auto-selected Vercel crons when Process Runtime owns the schedule", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-vercel-auto-process-"))
+    await mkdir(join(root, "src"), { recursive: true })
+    await writeFile(join(root, "src", "cleanup.schedule.ts"), "export default defineSchedule({ cron: '0 0 * * *', handler: () => {} })\n", "utf8")
+
+    const nitro = await createScheduleNitroConfig({
+      command: "build",
+      nitro: { preset: "vercel" },
+      root,
+      runtime: { driver: "process" },
+    })
+
+    expect(nitro).not.toHaveProperty("vercel.config.crons")
+  })
+
   it.each(["NITRO_PRESET", "SERVER_PRESET"])("adds standalone schedules to Vercel Nitro config selected by %s", async (environmentVariable) => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-vercel-env-"))
     await mkdir(join(root, "src"), { recursive: true })

--- a/packages/schedule/test/vite.test.ts
+++ b/packages/schedule/test/vite.test.ts
@@ -380,6 +380,33 @@ describe("Vite schedule integration", () => {
     })
   })
 
+  it("emits server schedules in explicit standalone Provider Wake output", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-server-standalone-output-"))
+    await mkdir(join(root, "server", "schedules"), { recursive: true })
+    await mkdir(join(root, "dist", "client"), { recursive: true })
+    await writeFile(join(root, "server", "schedules", "report.ts"), [
+      "import { defineSchedule } from '@vite-hub/schedule'",
+      "export default defineSchedule({ cron: '0 9 * * *', handler: () => {} })",
+      "",
+    ].join("\n"), "utf8")
+
+    const plugin = hubSchedule({ projectRoot: root, providerOutput: "standalone" })
+    await (plugin.config as (config: Record<string, unknown>, env: { command: "build" | "serve", mode: string }) => unknown)(
+      { root },
+      { command: "build", mode: "production" },
+    )
+    ;(plugin.configResolved as (config: Record<string, unknown>) => void)({
+      build: { outDir: "dist/client" },
+      command: "build",
+      resolve: { alias: [] },
+      root,
+    })
+    await (plugin.closeBundle as () => Promise<void>)()
+
+    await expect(readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8")).resolves.toContain("\"0 9 * * *\"")
+    await expect(readFile(join(createDefaultNetlifyOutputRoot(root), "functions", "vitehub-schedule-report.mjs"), "utf8")).resolves.toContain("schedule: \"0 9 * * *\"")
+  })
+
   it("writes a resolvable Process Runtime registry for direct Nitro config integration", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-schedule-direct-nitro-process-"))
     await mkdir(join(root, "server", "schedules"), { recursive: true })

--- a/packages/vite-hub/package.json
+++ b/packages/vite-hub/package.json
@@ -58,6 +58,7 @@
     "./_internal/workflow": "./dist/_internal/workflow.js",
     "./_internal/workflow/runtime/execute": "./dist/_internal/workflow/runtime/execute.js",
     "./_internal/workflow/runtime/state": "./dist/_internal/workflow/runtime/state.js",
+    "./_internal/workflow/runtime/vercel-vite": "./dist/_internal/workflow/runtime/vercel-vite.js",
     "./_internal/workspace": "./dist/_internal/workspace.js",
     "./_internal/workspace/internal/runtime/hosted": "./dist/_internal/workspace/internal/runtime/hosted.js",
     "./_internal/workspace/internal/runtime/hosted-vercel-blob": "./dist/_internal/workspace/internal/runtime/hosted-vercel-blob.js",

--- a/packages/vite-hub/src/_internal/workflow/runtime/vercel-vite.ts
+++ b/packages/vite-hub/src/_internal/workflow/runtime/vercel-vite.ts
@@ -1,0 +1,1 @@
+export * from "@vite-hub/workflow/runtime/vercel-vite"

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -704,6 +704,7 @@ export function vitehub(options: ViteHubOptions): PluginOption[] {
       ...emailOptions,
       hosting: plan.nitroPreset,
       runtimeEnvImport: "vite-hub/env/server",
+      workflowProvider: options.workflow && options.workflow !== true ? options.workflow.provider : undefined,
     } as unknown as EmailVitePluginOptions))
   }
   else plugins.push(hubEmailOptionalPeerResolver())

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -292,7 +292,11 @@ describe("vitehub", () => {
       ...email,
       hosting: "node-server",
       runtimeEnvImport: "vite-hub/env/server",
+      workflowProvider: undefined,
     })
+
+    vitehub({ email, preset: "node", workflow: { provider: "vercel" } })
+    expect(integrationMocks.hubEmail).toHaveBeenLastCalledWith(expect.objectContaining({ workflowProvider: "vercel" }))
   })
 
   it("uses Cloudflare Email when Email is enabled by preset", () => {
@@ -302,6 +306,7 @@ describe("vitehub", () => {
       driver: "unemail/driver/cloudflare-email",
       hosting: "cloudflare-module",
       runtimeEnvImport: "vite-hub/env/server",
+      workflowProvider: undefined,
     })
   })
 

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -164,7 +164,7 @@ export function hasVercelNativeWorkflowEntry(rootDir: string, definitions: Disco
       return
     }
     const source = readFileSync(file, "utf8")
-    if (/^\s*["']use workflow["'];?/m.test(source)) {
+    if (/(?:^|[{};])\s*["']use workflow["'];?/.test(source)) {
       const colocated = definitionDirs.some((definitionDir) => {
         const path = relative(definitionDir, file)
         return !path.startsWith("..") && !isAbsolute(path)

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -6,6 +6,7 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path"
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
 import { readColocatedAgentFiles } from "@vite-hub/internal/build/colocated-agent-files"
 import { createDefaultCloudflareOutputRoot, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
+import { bundleEsmEntry } from "@vite-hub/internal/build/esbuild"
 import { VITEHUB_MODES, getViteMode } from "@vite-hub/internal/build/mode"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vite-hub/internal/build/paths"
 import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
@@ -166,6 +167,32 @@ export function hasVercelNativeWorkflowEntry(rootDir: string, definitions: Disco
   return hasNativeEntry
 }
 
+async function installEmailDefinitionInVercelWorkflowOutput(rootDir: string, emailDefinitionFile: string): Promise<void> {
+  const flowFile = resolve(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs")
+  if (!existsSync(flowFile)) return
+  const generatedDir = ensureGeneratedDir(rootDir, productName)
+  const bootstrapEntry = resolve(generatedDir, "email-workflow-bootstrap.entry.mjs")
+  const workflowBundle = resolve(generatedDir, "email-workflow-bootstrap.source.mjs")
+  try {
+    await writeFile(workflowBundle, await readFile(flowFile, "utf8"), "utf8")
+    await writeFile(bootstrapEntry, [
+      `import viteHubEmailDefinition from ${JSON.stringify(createImportPath(bootstrapEntry, emailDefinitionFile))}`,
+      `globalThis[Symbol.for("vitehub.email.definition")] = viteHubEmailDefinition`,
+      `export * from ${JSON.stringify(createImportPath(bootstrapEntry, workflowBundle))}`,
+      "",
+    ].join("\n"), "utf8")
+    await bundleEsmEntry(bootstrapEntry, flowFile, {
+      format: "esm",
+      platform: "node",
+      rootDir,
+    })
+  }
+  finally {
+    await rm(bootstrapEntry, { force: true })
+    await rm(workflowBundle, { force: true })
+  }
+}
+
 async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: DiscoveredWorkflowDefinition[], aliases: Record<string, string> = {}, nativeFiles: string[] = []): Promise<void> {
   if (!hasVercelNativeWorkflowEntry(rootDir, definitions, aliases, nativeFiles)) return
   const builders = await loadVercelWorkflowBuilders()
@@ -189,6 +216,8 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
     workingDir: rootDir,
   })
   await withVercelWorkflowPackageLink(rootDir, async () => await builder.build())
+  const emailDefinitionFile = aliases["#vitehub/email/definition"]
+  if (emailDefinitionFile) await installEmailDefinitionInVercelWorkflowOutput(rootDir, emailDefinitionFile)
   const workflowConfig = JSON.parse(await readFile(outputConfigFile, "utf8")) as { routes?: unknown[], [key: string]: unknown }
   await writeFile(outputConfigFile, `${JSON.stringify({
     ...workflowConfig,
@@ -478,14 +507,9 @@ function getGeneratedVercelWorkflowExport(definition: DiscoveredWorkflowDefiniti
 function createVercelNativeWorkflowContents(
   nativeFile: string,
   definitions: DiscoveredWorkflowDefinition[],
-  emailDefinitionFile?: string,
 ): string {
-  const imports = emailDefinitionFile
-    ? [`import viteHubEmailDefinition from ${JSON.stringify(createImportPath(nativeFile, emailDefinitionFile))}`]
-    : []
-  const workflows = emailDefinitionFile
-    ? [`globalThis[Symbol.for("vitehub.email.definition")] = viteHubEmailDefinition`]
-    : []
+  const imports: string[] = []
+  const workflows: string[] = []
   for (const definition of definitions) {
     const workflowExport = getGeneratedVercelWorkflowExport(definition)
     const steps = definition.steps
@@ -708,7 +732,6 @@ export async function writeProviderEntries(
   serverDirs?: string[],
   includeUserAppEntry = true,
   transformRegistry?: (code: string, id: string) => string | Promise<string>,
-  providerImportAliases: Record<string, string> = {},
 ) {
   const generatedDir = ensureGeneratedDir(rootDir, productName)
   await mkdir(generatedDir, { recursive: true })
@@ -727,7 +750,6 @@ export async function writeProviderEntries(
       createVercelNativeWorkflowContents(
         vercelNativeFile,
         definitions,
-        providerImportAliases["#vitehub/email/definition"],
       ),
       "utf8",
     )
@@ -877,7 +899,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     workflow: options.importBase,
     workspace: options.workspaceImportBase,
     workspaceDependencies: options.workspaceDependencyRuntimeImports,
-  }, options.serverDirs, options.includeUserAppEntry, options.transformRegistry, options.providerImportAliases)
+  }, options.serverDirs, options.includeUserAppEntry, options.transformRegistry)
   const cloudflareWorkflowConfig = resolveWorkflowConfig(options.workflow, "cloudflare")
   const vercelWorkflowConfig = resolveWorkflowConfig(options.workflow, "vercel")
   const cloudflareOutput = cloudflareWorkflowConfig && cloudflareWorkflowConfig.provider === "cloudflare"

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -168,6 +168,7 @@ export function hasVercelNativeWorkflowEntry(rootDir: string, definitions: Disco
 }
 
 async function installEmailDefinitionInVercelWorkflowOutput(rootDir: string, emailDefinitionFile: string): Promise<void> {
+  // WDK's Vercel builder emits step registrations and workflow orchestration in one combined flow function.
   const flowFile = resolve(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs")
   if (!existsSync(flowFile)) return
   const generatedDir = ensureGeneratedDir(rootDir, productName)

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -11,7 +11,7 @@ import { bundleEsmEntry } from "@vite-hub/internal/build/esbuild"
 import { VITEHUB_MODES, getViteMode } from "@vite-hub/internal/build/mode"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vite-hub/internal/build/paths"
 import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
-import { transformSync } from "esbuild"
+import { buildSync } from "esbuild"
 import type { Plugin } from "esbuild"
 
 import { normalizeWorkflowOptions } from "../config.ts"
@@ -165,12 +165,20 @@ export function hasVercelNativeWorkflowEntry(rootDir: string, definitions: Disco
       return
     }
     const source = readFileSync(file, "utf8")
-    const parsedSource = transformSync(source, {
+    const parsed = buildSync({
+      bundle: false,
       format: "esm",
       legalComments: "none",
-      loader: /\.[cm]?[jt]sx$/.test(file) ? "tsx" : "ts",
+      metafile: true,
       minifySyntax: true,
-    }).code
+      stdin: {
+        contents: source,
+        loader: /\.[cm]?[jt]sx$/.test(file) ? "tsx" : "ts",
+        sourcefile: file,
+      },
+      write: false,
+    })
+    const parsedSource = parsed.outputFiles[0].text
     if (/^\s*["']use workflow["'];?/m.test(parsedSource)) {
       const colocated = definitionDirs.some((definitionDir) => {
         const path = relative(definitionDir, file)
@@ -181,8 +189,8 @@ export function hasVercelNativeWorkflowEntry(rootDir: string, definitions: Disco
       }
       hasNativeEntry = true
     }
-    for (const match of source.matchAll(/(?:from\s*|import\s*(?:\(\s*)?)["']([^"']+)["']/g)) {
-      const specifier = match[1]
+    const imports = Object.values(parsed.metafile.outputs).flatMap(output => output.imports)
+    for (const { path: specifier } of imports) {
       const alias = Object.entries(aliases)
         .find(([find]) => specifier === find || specifier.startsWith(`${find}/`))
       const imported = specifier.startsWith(".")

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -372,12 +372,22 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
     routes: [...(workflowConfig.routes ?? []), ...viteHubRoutes],
   }, null, 2)}\n`, "utf8")
   const generatedFiles = await collectVercelNativeWorkflowFiles(workflowRoot)
+  const ownedFiles = Object.fromEntries(Object.entries(generatedFiles)
+    .filter(([file, digest]) => previousFiles[file] !== digest || previousFiles[file] === previousOwnership?.files[file]))
+  const routeTargetsOwnedFunction = (route: unknown) => {
+    if (!route || typeof route !== "object") return false
+    const target = ["dest", "src"]
+      .map(key => (route as Record<string, unknown>)[key])
+      .find(value => typeof value === "string" && value.includes("/.well-known/workflow/v1/"))
+    if (typeof target !== "string") return false
+    const functionName = target.match(/\/\.well-known\/workflow\/v1\/([^/?]+)/)?.[1]
+    return Boolean(functionName && Object.keys(ownedFiles).some(file => file.startsWith(`v1/${functionName}.func/`)))
+  }
   const ownership: VercelNativeWorkflowOwnership = {
-    files: Object.fromEntries(Object.entries(generatedFiles)
-      .filter(([file, digest]) => previousFiles[file] !== digest || previousFiles[file] === previousOwnership?.files[file])),
-    routes: (workflowConfig.routes ?? [])
+    files: ownedFiles,
+    routes: [...new Map([...(workflowConfig.routes ?? []), ...preservedRoutes].map(route => [JSON.stringify(route), route])).values()]
       .filter(route => JSON.stringify(route).includes("/.well-known/workflow/v1/"))
-      .filter(route => !externalWorkflowRoutes.has(JSON.stringify(route)))
+      .filter(route => !externalWorkflowRoutes.has(JSON.stringify(route)) || routeTargetsOwnedFunction(route))
       .map(route => JSON.stringify(route)),
     version: 1,
   }

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -190,7 +190,7 @@ export function hasVercelNativeWorkflowEntry(rootDir: string, definitions: Disco
       }
       hasNativeEntry = true
     }
-    if (definitionHandlers.has(file) && !/\bnative\s*:/.test(parsedSource)) return
+    if (definitionHandlers.has(file) && !/\bnative\s*(?::|(?=[,}]))/.test(parsedSource)) return
     const imports = Object.values(parsed.metafile.outputs).flatMap(output => output.imports)
     for (const { path: specifier } of imports) {
       const alias = Object.entries(aliases)

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -213,7 +213,7 @@ function resolveWorkflowConfig(workflow: WorkflowModuleOptions | undefined, host
   return normalizeWorkflowOptions(workflow, { hosting }) ?? false
 }
 
-export interface GeneratedWorkflowArtifacts {
+interface GeneratedWorkflowArtifacts {
   cloudflareWorkerFile: string
   cloudflareWorkflowConfig: false | ResolvedWorkflowOptions
   definitions: DiscoveredWorkflowDefinition[]

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -376,12 +376,13 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
     .filter(([file, digest]) => previousFiles[file] !== digest || previousFiles[file] === previousOwnership?.files[file]))
   const routeTargetsOwnedFunction = (route: unknown) => {
     if (!route || typeof route !== "object") return false
-    const target = ["dest", "src"]
+    return ["dest", "src"]
       .map(key => (route as Record<string, unknown>)[key])
-      .find(value => typeof value === "string" && value.includes("/.well-known/workflow/v1/"))
-    if (typeof target !== "string") return false
-    const functionName = target.match(/\/\.well-known\/workflow\/v1\/([^/?]+)/)?.[1]
-    return Boolean(functionName && Object.keys(ownedFiles).some(file => file.startsWith(`v1/${functionName}.func/`)))
+      .filter((value): value is string => typeof value === "string")
+      .some((target) => {
+        const functionPath = target.match(/\/\.well-known\/workflow\/(v1\/[^?]+)/)?.[1]
+        return Boolean(functionPath && Object.keys(ownedFiles).some(file => file.startsWith(`${functionPath}.func/`)))
+      })
   }
   const ownership: VercelNativeWorkflowOwnership = {
     files: ownedFiles,
@@ -425,7 +426,7 @@ interface GeneratedWorkflowArtifacts {
   generatedDir: string
   providerDefinitions: DiscoveredWorkflowDefinition[]
   registryFile: string
-  vercelNativeFile?: string
+  vercelNativeFiles: string[]
   vercelServerFile: string
 }
 
@@ -675,27 +676,25 @@ function getGeneratedVercelWorkflowExport(definition: DiscoveredWorkflowDefiniti
 
 function createVercelNativeWorkflowContents(
   nativeFile: string,
-  definitions: DiscoveredWorkflowDefinition[],
+  definition: DiscoveredWorkflowDefinition,
 ): string {
   const imports: string[] = []
   const workflows: string[] = []
-  for (const definition of definitions) {
-    const workflowExport = getGeneratedVercelWorkflowExport(definition)
-    const steps = definition.steps
-    if (!workflowExport || !steps) continue
-    const stepNames = steps.map((step, index) => {
-      const implementation = `${workflowExport}Step${index}Implementation`
-      const name = `${workflowExport}Step${index}`
-      imports.push(`import ${implementation} from ${JSON.stringify(createImportPath(nativeFile, step))}`)
-      workflows.push(`async function ${name}(input) {\n  "use step"\n  return await ${implementation}(input)\n}`)
-      return name
-    })
-    workflows.push(`export async function ${workflowExport}(context) {\n  "use workflow"\n  let value = context.payload\n${stepNames.map(name => `  value = await ${name}(value)`).join("\n")}\n  return value\n}`)
-  }
+  const workflowExport = getGeneratedVercelWorkflowExport(definition)
+  const steps = definition.steps
+  if (!workflowExport || !steps) return ""
+  const stepNames = steps.map((step, index) => {
+    const implementation = `${workflowExport}Step${index}Implementation`
+    const name = `${workflowExport}Step${index}`
+    imports.push(`import ${implementation} from ${JSON.stringify(createImportPath(nativeFile, step))}`)
+    workflows.push(`async function ${name}(input) {\n  "use step"\n  return await ${implementation}(input)\n}`)
+    return name
+  })
+  workflows.push(`export async function ${workflowExport}(context) {\n  "use workflow"\n  let value = context.payload\n${stepNames.map(name => `  value = await ${name}(value)`).join("\n")}\n  return value\n}`)
   return [...imports, "", ...workflows, ""].join("\n")
 }
 
-function renderWorkflowRegistryEntry(registryFile: string, definition: DiscoveredWorkflowDefinition, vercelNativeFile?: string) {
+function renderWorkflowRegistryEntry(registryFile: string, definition: DiscoveredWorkflowDefinition, vercelNativeFiles: Record<string, string> = {}) {
   if (definition.source === "agent-workflow") {
     return renderAgentWorkflowRegistryEntry(registryFile, definition)
   }
@@ -713,6 +712,7 @@ function renderWorkflowRegistryEntry(registryFile: string, definition: Discovere
   const hasIndex = /\.(?:c|m)?[jt]s$/i.test(definition.handler)
   const indexImport = hasIndex ? `const index = await ${renderRegistryImport(registryFile, definition.handler)}` : ""
   const nativeExport = getGeneratedVercelWorkflowExport(definition)
+  const vercelNativeFile = vercelNativeFiles[definition.name]
   const nativeImport = nativeExport && vercelNativeFile
     ? `const native = (await ${renderRegistryImport(registryFile, vercelNativeFile)}).${nativeExport}\n    native.workflowId ||= ${JSON.stringify(`workflow//./.vitehub/workflow/vercel-native//${nativeExport}`)}`
     : ""
@@ -746,7 +746,7 @@ function createWorkflowRegistryContents(
   registryFile: string,
   definitions: DiscoveredWorkflowDefinition[],
   importBases: WorkflowImportBases = {},
-  vercelNativeFile?: string,
+  vercelNativeFiles: Record<string, string> = {},
 ): string {
   const agentImportBase = importBases.agent ?? "@vite-hub/agent"
   const workflowImportBase = importBases.workflow ?? workflowPackageName
@@ -808,7 +808,7 @@ function createWorkflowRegistryContents(
       : []),
     ...(needsRegistryEntryCache ? ["const registryEntryCache = new Map()", ""] : []),
     "const registry = {",
-    ...definitions.map(definition => renderWorkflowRegistryEntry(registryFile, definition, vercelNativeFile)),
+    ...definitions.map(definition => renderWorkflowRegistryEntry(registryFile, definition, vercelNativeFiles)),
     "}",
     "",
     "export default registry",
@@ -912,26 +912,24 @@ export async function writeProviderEntries(
   const userAppEntry = includeUserAppEntry ? resolveWorkflowUserAppEntry(definitionRootDir) : undefined
   const cloudflareWorkflowConfig = resolveWorkflowConfig(workflow, "cloudflare")
 
-  const vercelNativeFile = resolve(generatedDir, "vercel-native.mjs")
-  const hasGeneratedVercelWorkflows = definitions.some(getGeneratedVercelWorkflowExport)
-  if (hasGeneratedVercelWorkflows) {
-    await writeFile(
-      vercelNativeFile,
-      createVercelNativeWorkflowContents(
-        vercelNativeFile,
-        definitions,
-      ),
-      "utf8",
-    )
-  }
-  else {
-    await rm(vercelNativeFile, { force: true })
-  }
+  const vercelNativeDir = resolve(generatedDir, "vercel-native")
+  const nativeDefinitions = definitions.filter(definition => getGeneratedVercelWorkflowExport(definition))
+  await rm(resolve(generatedDir, "vercel-native.mjs"), { force: true })
+  await rm(vercelNativeDir, { force: true, recursive: true })
+  const vercelNativeFiles = Object.fromEntries(nativeDefinitions.map((definition, index) => [
+    definition.name,
+    resolve(vercelNativeDir, `${index}.mjs`),
+  ]))
+  if (nativeDefinitions.length) await mkdir(vercelNativeDir, { recursive: true })
+  await Promise.all(nativeDefinitions.map(async definition => {
+    const nativeFile = vercelNativeFiles[definition.name]
+    await writeFile(nativeFile, createVercelNativeWorkflowContents(nativeFile, definition), "utf8")
+  }))
   const registryContents = createWorkflowRegistryContents(
     registryFile,
     definitions,
     importBases,
-    hasGeneratedVercelWorkflows ? vercelNativeFile : undefined,
+    vercelNativeFiles,
   )
   await writeFile(registryFile, transformRegistry ? await transformRegistry(registryContents, registryFile) : registryContents, "utf8")
 
@@ -953,7 +951,7 @@ export async function writeProviderEntries(
     generatedDir,
     providerDefinitions,
     registryFile,
-    ...(hasGeneratedVercelWorkflows ? { vercelNativeFile } : {}),
+    vercelNativeFiles: Object.values(vercelNativeFiles),
     vercelServerFile: entryFiles.vercel,
   }
 }
@@ -1103,7 +1101,7 @@ async function generateProviderOutputsWithinLock(
           await buildVercelNativeWorkflowOutput(options.rootDir, artifacts.providerDefinitions, {
             ...options.providerImportAliases,
             ...options.providerRuntimeImportAliases?.vercel,
-          }, artifacts.vercelNativeFile ? [artifacts.vercelNativeFile] : [], previousNativeOutput)
+          }, artifacts.vercelNativeFiles, previousNativeOutput)
         }
         else {
           await cleanVercelNativeWorkflowOutput(options.rootDir)

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -179,9 +179,9 @@ export async function installEmailDefinitionInVercelWorkflowOutput(rootDir: stri
     await writeFile(workflowBundle, await readFile(flowFile, "utf8"), "utf8")
     await writeFile(bootstrapEntry, [
       `import viteHubEmailDefinition from ${JSON.stringify(createImportPath(bootstrapEntry, emailDefinitionFile))}`,
-      `import workflowHandler from ${JSON.stringify(createImportPath(bootstrapEntry, workflowBundle))}`,
+      `import * as workflowModule from ${JSON.stringify(createImportPath(bootstrapEntry, workflowBundle))}`,
       `globalThis[Symbol.for("vitehub.email.definition")] = viteHubEmailDefinition`,
-      "export default workflowHandler",
+      "export default workflowModule.default",
       `export * from ${JSON.stringify(createImportPath(bootstrapEntry, workflowBundle))}`,
       "",
     ].join("\n"), "utf8")

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -22,6 +22,7 @@ import type { Plugin as VitePlugin } from "vite"
 
 export const workflowPackageName = "@vite-hub/workflow"
 const productName = "workflow"
+const vercelNativeWorkflowOwnershipMarker = ".vitehub-owned"
 
 const generatedRegistryFileName = "registry.mjs"
 const cloudflareWorkflowWranglerConfigKeys = ["compatibility_date", "compatibility_flags", "main", "observability", "workflows"]
@@ -200,7 +201,9 @@ export async function installEmailDefinitionInVercelWorkflowOutput(rootDir: stri
 
 export async function cleanVercelNativeWorkflowOutput(rootDir: string): Promise<void> {
   const outputRoot = resolve(rootDir, ".vercel", "output")
-  await rm(resolve(outputRoot, "functions", ".well-known", "workflow"), { force: true, recursive: true })
+  const workflowRoot = resolve(outputRoot, "functions", ".well-known", "workflow")
+  if (!existsSync(resolve(workflowRoot, vercelNativeWorkflowOwnershipMarker))) return
+  await rm(workflowRoot, { force: true, recursive: true })
   const configFile = resolve(outputRoot, "config.json")
   let config: { routes?: Array<Record<string, unknown>>, [key: string]: unknown }
   try {
@@ -244,6 +247,7 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
     workingDir: rootDir,
   })
   await withVercelWorkflowPackageLink(rootDir, async () => await builder.build())
+  await writeFile(resolve(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", vercelNativeWorkflowOwnershipMarker), "\n", "utf8")
   const emailDefinitionFile = aliases["#vitehub/email/definition"]
   if (emailDefinitionFile) await installEmailDefinitionInVercelWorkflowOutput(rootDir, emailDefinitionFile)
   const workflowConfig = JSON.parse(await readFile(outputConfigFile, "utf8")) as { routes?: unknown[], [key: string]: unknown }

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -956,10 +956,15 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
       rootDir: options.rootDir,
       ...(vercelOutput ? { vercel: vercelOutput } : {}),
     })
-    if (vercelOutput) await buildVercelNativeWorkflowOutput(options.rootDir, artifacts.providerDefinitions, {
-      ...options.providerImportAliases,
-      ...options.providerRuntimeImportAliases?.vercel,
-    }, artifacts.vercelNativeFile ? [artifacts.vercelNativeFile] : [])
+    if (vercelOutput) {
+      await buildVercelNativeWorkflowOutput(options.rootDir, artifacts.providerDefinitions, {
+        ...options.providerImportAliases,
+        ...options.providerRuntimeImportAliases?.vercel,
+      }, artifacts.vercelNativeFile ? [artifacts.vercelNativeFile] : [])
+    }
+    else {
+      await cleanVercelNativeWorkflowOutput(options.rootDir)
+    }
   }
   if (workflowTransformPlugin && options.importBase) await withVercelWorkflowPackageLink(options.rootDir, writeOutputs)
   else await writeOutputs()

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -378,6 +378,15 @@ async function readVercelNativeWorkflowState(rootDir: string): Promise<VercelNat
   }
 }
 
+function assertNoExternalCanonicalWorkflowOutput(state: VercelNativeWorkflowState): void {
+  const externalCanonicalFiles = Object.entries(state.files)
+    .filter(([file, digest]) => /^v1\/(?:flow|step)\.func\/|^v1\/webhook\//.test(file) && state.ownership?.files[file] !== digest)
+    .map(([file]) => file)
+  if (externalCanonicalFiles.length) {
+    throw new Error(`Native Vercel Workflow output conflicts with existing unowned Workflow DevKit functions: ${externalCanonicalFiles.join(", ")}. Build all native Workflow source directories together.`)
+  }
+}
+
 async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: DiscoveredWorkflowDefinition[], aliases: Record<string, string> = {}, nativeFiles: string[] = [], previousState?: VercelNativeWorkflowState): Promise<void> {
   if (!hasVercelNativeWorkflowEntry(rootDir, definitions, aliases, nativeFiles)) {
     await cleanVercelNativeWorkflowOutput(rootDir)
@@ -394,6 +403,7 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
   const workflowRoot = resolve(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
   const previousOwnership = previousState?.ownership
   const previousFiles = previousState?.files ?? {}
+  if (previousState) assertNoExternalCanonicalWorkflowOutput(previousState)
   const previouslyOwnedRoutes = new Set(previousOwnership?.routes ?? [])
   const preservedRoutes = (previousState?.routes ?? []).filter(route => JSON.stringify(route).includes("/.well-known/workflow/v1/") && !previouslyOwnedRoutes.has(JSON.stringify(route)))
   const currentRoutes = (viteHubConfig.routes ?? []).filter(route => !previouslyOwnedRoutes.has(JSON.stringify(route)))
@@ -423,39 +433,39 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
     await withVercelWorkflowPackageLink(rootDir, async () => await builder.build())
     const emailDefinitionFile = aliases["#vitehub/email/definition"]
     if (emailDefinitionFile) await installEmailDefinitionInVercelWorkflowOutput(rootDir, emailDefinitionFile)
+    const workflowConfig = JSON.parse(await readFile(outputConfigFile, "utf8")) as { routes?: unknown[], [key: string]: unknown }
+    await writeFile(outputConfigFile, `${JSON.stringify({
+      ...workflowConfig,
+      ...viteHubConfig,
+      routes: [...(workflowConfig.routes ?? []), ...viteHubRoutes],
+    }, null, 2)}\n`, "utf8")
+    const generatedFiles = await collectVercelNativeWorkflowFiles(workflowRoot)
+    const ownedFiles = Object.fromEntries(Object.entries(generatedFiles)
+      .filter(([file, digest]) => previousFiles[file] !== digest || previousFiles[file] === previousOwnership?.files[file]))
+    const routeTargetsOwnedFunction = (route: unknown) => {
+      if (!route || typeof route !== "object") return false
+      return ["dest", "src"]
+        .map(key => (route as Record<string, unknown>)[key])
+        .filter((value): value is string => typeof value === "string")
+        .some((target) => {
+          const functionPath = target.match(/\/\.well-known\/workflow\/(v1\/[^?]+)/)?.[1]
+          return Boolean(functionPath && Object.keys(ownedFiles).some(file => file.startsWith(`${functionPath}.func/`)))
+        })
+    }
+    const ownership: VercelNativeWorkflowOwnership = {
+      files: ownedFiles,
+      routes: [...new Map([...(workflowConfig.routes ?? []), ...preservedRoutes].map(route => [JSON.stringify(route), route])).values()]
+        .filter(route => JSON.stringify(route).includes("/.well-known/workflow/v1/"))
+        .filter(route => !externalWorkflowRoutes.has(JSON.stringify(route)) || routeTargetsOwnedFunction(route))
+        .map(route => JSON.stringify(route)),
+      version: 1,
+    }
+    await writeFile(resolve(workflowRoot, vercelNativeWorkflowOwnershipMarker), `${JSON.stringify(ownership, null, 2)}\n`, "utf8")
   }
   catch (error) {
     await restoreVercelNativeWorkflowOutput(rootDir, snapshot)
     throw error
   }
-  const workflowConfig = JSON.parse(await readFile(outputConfigFile, "utf8")) as { routes?: unknown[], [key: string]: unknown }
-  await writeFile(outputConfigFile, `${JSON.stringify({
-    ...workflowConfig,
-    ...viteHubConfig,
-    routes: [...(workflowConfig.routes ?? []), ...viteHubRoutes],
-  }, null, 2)}\n`, "utf8")
-  const generatedFiles = await collectVercelNativeWorkflowFiles(workflowRoot)
-  const ownedFiles = Object.fromEntries(Object.entries(generatedFiles)
-    .filter(([file, digest]) => previousFiles[file] !== digest || previousFiles[file] === previousOwnership?.files[file]))
-  const routeTargetsOwnedFunction = (route: unknown) => {
-    if (!route || typeof route !== "object") return false
-    return ["dest", "src"]
-      .map(key => (route as Record<string, unknown>)[key])
-      .filter((value): value is string => typeof value === "string")
-      .some((target) => {
-        const functionPath = target.match(/\/\.well-known\/workflow\/(v1\/[^?]+)/)?.[1]
-        return Boolean(functionPath && Object.keys(ownedFiles).some(file => file.startsWith(`${functionPath}.func/`)))
-      })
-  }
-  const ownership: VercelNativeWorkflowOwnership = {
-    files: ownedFiles,
-    routes: [...new Map([...(workflowConfig.routes ?? []), ...preservedRoutes].map(route => [JSON.stringify(route), route])).values()]
-      .filter(route => JSON.stringify(route).includes("/.well-known/workflow/v1/"))
-      .filter(route => !externalWorkflowRoutes.has(JSON.stringify(route)) || routeTargetsOwnedFunction(route))
-      .map(route => JSON.stringify(route)),
-    version: 1,
-  }
-  await writeFile(resolve(workflowRoot, vercelNativeWorkflowOwnershipMarker), `${JSON.stringify(ownership, null, 2)}\n`, "utf8")
 }
 
 function resolveWorkflowUserAppEntry(rootDir: string) {
@@ -1153,6 +1163,12 @@ async function generateProviderOutputsWithinLock(
     : undefined
   const writeOutputs = async () => {
     const previousNativeOutput = await readVercelNativeWorkflowState(options.rootDir)
+    if (vercelOutput && hasVercelNativeWorkflowEntry(options.rootDir, artifacts.providerDefinitions, {
+      ...options.providerImportAliases,
+      ...options.providerRuntimeImportAliases?.vercel,
+    }, artifacts.vercelNativeFiles)) {
+      assertNoExternalCanonicalWorkflowOutput(previousNativeOutput)
+    }
     await writeProviderDeploymentOutputs({
       clientOutDir: options.clientOutDir,
       cloudflare: cloudflareOutput,

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -167,7 +167,7 @@ export function hasVercelNativeWorkflowEntry(rootDir: string, definitions: Disco
   return hasNativeEntry
 }
 
-async function installEmailDefinitionInVercelWorkflowOutput(rootDir: string, emailDefinitionFile: string): Promise<void> {
+export async function installEmailDefinitionInVercelWorkflowOutput(rootDir: string, emailDefinitionFile: string): Promise<void> {
   // WDK's Vercel builder emits step registrations and workflow orchestration in one combined flow function.
   const flowFile = resolve(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs")
   if (!existsSync(flowFile)) return
@@ -175,6 +175,7 @@ async function installEmailDefinitionInVercelWorkflowOutput(rootDir: string, ema
   const bootstrapEntry = resolve(generatedDir, "email-workflow-bootstrap.entry.mjs")
   const workflowBundle = resolve(generatedDir, "email-workflow-bootstrap.source.mjs")
   try {
+    await mkdir(generatedDir, { recursive: true })
     await writeFile(workflowBundle, await readFile(flowFile, "utf8"), "utf8")
     await writeFile(bootstrapEntry, [
       `import viteHubEmailDefinition from ${JSON.stringify(createImportPath(bootstrapEntry, emailDefinitionFile))}`,
@@ -183,6 +184,7 @@ async function installEmailDefinitionInVercelWorkflowOutput(rootDir: string, ema
       "",
     ].join("\n"), "utf8")
     await bundleEsmEntry(bootstrapEntry, flowFile, {
+      external: ["@aws-sdk/credential-provider-web-identity"],
       format: "esm",
       platform: "node",
       rootDir,

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -80,7 +80,7 @@ async function loadVercelWorkflowBuilders(): Promise<VercelWorkflowBuilders | un
   return await import("@workflow/builders") as VercelWorkflowBuilders
 }
 
-async function createVercelWorkflowTransformPlugin(rootDir: string): Promise<Plugin | undefined> {
+export async function createVercelWorkflowTransformPlugin(rootDir: string): Promise<Plugin | undefined> {
   const builders = await loadVercelWorkflowBuilders()
   if (!builders) return undefined
   return builders.createSwcPlugin({ mode: "workflow", projectRoot: rootDir })
@@ -179,7 +179,9 @@ export async function installEmailDefinitionInVercelWorkflowOutput(rootDir: stri
     await writeFile(workflowBundle, await readFile(flowFile, "utf8"), "utf8")
     await writeFile(bootstrapEntry, [
       `import viteHubEmailDefinition from ${JSON.stringify(createImportPath(bootstrapEntry, emailDefinitionFile))}`,
+      `import workflowHandler from ${JSON.stringify(createImportPath(bootstrapEntry, workflowBundle))}`,
       `globalThis[Symbol.for("vitehub.email.definition")] = viteHubEmailDefinition`,
+      "export default workflowHandler",
       `export * from ${JSON.stringify(createImportPath(bootstrapEntry, workflowBundle))}`,
       "",
     ].join("\n"), "utf8")
@@ -196,8 +198,30 @@ export async function installEmailDefinitionInVercelWorkflowOutput(rootDir: stri
   }
 }
 
+export async function cleanVercelNativeWorkflowOutput(rootDir: string): Promise<void> {
+  const outputRoot = resolve(rootDir, ".vercel", "output")
+  await rm(resolve(outputRoot, "functions", ".well-known", "workflow"), { force: true, recursive: true })
+  const configFile = resolve(outputRoot, "config.json")
+  let config: { routes?: Array<Record<string, unknown>>, [key: string]: unknown }
+  try {
+    config = JSON.parse(await readFile(configFile, "utf8"))
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
+    throw error
+  }
+  if (!Array.isArray(config.routes)) return
+  const routes = config.routes.filter(route => !JSON.stringify(route).includes("/.well-known/workflow/v1/"))
+  if (routes.length !== config.routes.length) {
+    await writeFile(configFile, `${JSON.stringify({ ...config, routes }, null, 2)}\n`, "utf8")
+  }
+}
+
 async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: DiscoveredWorkflowDefinition[], aliases: Record<string, string> = {}, nativeFiles: string[] = []): Promise<void> {
-  if (!hasVercelNativeWorkflowEntry(rootDir, definitions, aliases, nativeFiles)) return
+  if (!hasVercelNativeWorkflowEntry(rootDir, definitions, aliases, nativeFiles)) {
+    await cleanVercelNativeWorkflowOutput(rootDir)
+    return
+  }
   const builders = await loadVercelWorkflowBuilders()
   if (!builders) {
     throw new Error("Native Vercel workflows require the optional workflow and @workflow/builders peer dependencies.")
@@ -270,6 +294,7 @@ interface GenerateProviderOutputsOptions {
   importBase?: string
   providerImportAliases?: Record<string, string>
   providerRuntimeImportAliases?: Partial<Record<WorkflowProvider, Record<string, string>>>
+  definitionRootDir?: string
   rootDir: string
   serverDirs?: string[]
   serverFunctionName?: string
@@ -735,14 +760,15 @@ export async function writeProviderEntries(
   serverDirs?: string[],
   includeUserAppEntry = true,
   transformRegistry?: (code: string, id: string) => string | Promise<string>,
+  definitionRootDir = rootDir,
 ) {
   const generatedDir = ensureGeneratedDir(rootDir, productName)
   await mkdir(generatedDir, { recursive: true })
 
   const registryFile = resolve(generatedDir, generatedRegistryFileName)
-  const definitions = discoverWorkflowDefinitions({ rootDir, serverDirs })
+  const definitions = discoverWorkflowDefinitions({ rootDir: definitionRootDir, serverDirs })
   const providerDefinitions = definitions
-  const userAppEntry = includeUserAppEntry ? resolveWorkflowUserAppEntry(rootDir) : undefined
+  const userAppEntry = includeUserAppEntry ? resolveWorkflowUserAppEntry(definitionRootDir) : undefined
   const cloudflareWorkflowConfig = resolveWorkflowConfig(workflow, "cloudflare")
 
   const vercelNativeFile = resolve(generatedDir, "vercel-native.mjs")
@@ -902,7 +928,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     workflow: options.importBase,
     workspace: options.workspaceImportBase,
     workspaceDependencies: options.workspaceDependencyRuntimeImports,
-  }, options.serverDirs, options.includeUserAppEntry, options.transformRegistry)
+  }, options.serverDirs, options.includeUserAppEntry, options.transformRegistry, options.definitionRootDir)
   const cloudflareWorkflowConfig = resolveWorkflowConfig(options.workflow, "cloudflare")
   const vercelWorkflowConfig = resolveWorkflowConfig(options.workflow, "vercel")
   const cloudflareOutput = cloudflareWorkflowConfig && cloudflareWorkflowConfig.provider === "cloudflare"

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -11,6 +11,7 @@ import { bundleEsmEntry } from "@vite-hub/internal/build/esbuild"
 import { VITEHUB_MODES, getViteMode } from "@vite-hub/internal/build/mode"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vite-hub/internal/build/paths"
 import { resolveUserAppEntry } from "@vite-hub/internal/build/user-entry"
+import { transformSync } from "esbuild"
 import type { Plugin } from "esbuild"
 
 import { normalizeWorkflowOptions } from "../config.ts"
@@ -164,7 +165,13 @@ export function hasVercelNativeWorkflowEntry(rootDir: string, definitions: Disco
       return
     }
     const source = readFileSync(file, "utf8")
-    if (/(?:^|[{};])\s*["']use workflow["'];?/.test(source)) {
+    const parsedSource = transformSync(source, {
+      format: "esm",
+      legalComments: "none",
+      loader: /\.[cm]?[jt]sx$/.test(file) ? "tsx" : "ts",
+      minifySyntax: true,
+    }).code
+    if (/^\s*["']use workflow["'];?/m.test(parsedSource)) {
       const colocated = definitionDirs.some((definitionDir) => {
         const path = relative(definitionDir, file)
         return !path.startsWith("..") && !isAbsolute(path)

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -80,7 +80,7 @@ interface VercelWorkflowBuilders {
   createSwcPlugin: (options: { mode: "workflow", projectRoot: string }) => Plugin
 }
 
-function createOptionalViteDevtoolsPlugin(rootDir: string): Plugin {
+export function createOptionalViteDevtoolsPlugin(rootDir: string): Plugin {
   const require = createRequire(join(rootDir, "package.json"))
   const namespace = "vitehub-optional-vite-devtools"
   return {

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -153,6 +153,7 @@ export function hasVercelNativeWorkflowEntry(rootDir: string, definitions: Disco
   ])]
   let hasNativeEntry = false
   const visited = new Set<string>()
+  const definitionHandlers = new Set(definitions.map(definition => definition.handler))
   const visit = (file: string) => {
     if (visited.has(file)) return
     visited.add(file)
@@ -189,6 +190,7 @@ export function hasVercelNativeWorkflowEntry(rootDir: string, definitions: Disco
       }
       hasNativeEntry = true
     }
+    if (definitionHandlers.has(file) && !/\bnative\s*:/.test(parsedSource)) return
     const imports = Object.values(parsed.metafile.outputs).flatMap(output => output.imports)
     for (const { path: specifier } of imports) {
       const alias = Object.entries(aliases)

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -391,7 +391,11 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
   const preservedRoutes = (previousState?.routes ?? []).filter(route => JSON.stringify(route).includes("/.well-known/workflow/v1/") && !previouslyOwnedRoutes.has(JSON.stringify(route)))
   const currentRoutes = (viteHubConfig.routes ?? []).filter(route => !previouslyOwnedRoutes.has(JSON.stringify(route)))
   const viteHubRoutes = [...new Map([...currentRoutes, ...preservedRoutes].map(route => [JSON.stringify(route), route])).values()]
-  snapshot.config = Buffer.from(`${JSON.stringify({ ...viteHubConfig, routes: viteHubRoutes }, null, 2)}\n`)
+  const rollbackRoutes = [...new Map([
+    ...currentRoutes,
+    ...(previousState?.routes ?? []).filter(route => JSON.stringify(route).includes("/.well-known/workflow/v1/")),
+  ].map(route => [JSON.stringify(route), route])).values()]
+  snapshot.config = Buffer.from(`${JSON.stringify({ ...viteHubConfig, routes: rollbackRoutes }, null, 2)}\n`)
   const externalWorkflowRoutes = new Set(preservedRoutes
     .filter(route => JSON.stringify(route).includes("/.well-known/workflow/v1/"))
     .map(route => JSON.stringify(route)))

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -916,9 +916,9 @@ export async function writeProviderEntries(
   const nativeDefinitions = definitions.filter(definition => getGeneratedVercelWorkflowExport(definition))
   await rm(resolve(generatedDir, "vercel-native.mjs"), { force: true })
   await rm(vercelNativeDir, { force: true, recursive: true })
-  const vercelNativeFiles = Object.fromEntries(nativeDefinitions.map((definition, index) => [
+  const vercelNativeFiles = Object.fromEntries(nativeDefinitions.map(definition => [
     definition.name,
-    resolve(vercelNativeDir, `${index}.mjs`),
+    resolve(vercelNativeDir, `${createHash("sha256").update(definition.name).digest("hex")}.mjs`),
   ]))
   if (nativeDefinitions.length) await mkdir(vercelNativeDir, { recursive: true })
   await Promise.all(nativeDefinitions.map(async definition => {

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -229,6 +229,7 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
 
   const outputConfigFile = resolve(rootDir, ".vercel", "output", "config.json")
   const viteHubConfig = JSON.parse(await readFile(outputConfigFile, "utf8")) as { routes?: unknown[] }
+  const viteHubRoutes = (viteHubConfig.routes ?? []).filter(route => !JSON.stringify(route).includes("/.well-known/workflow/v1/"))
   const definitionDirs = [...new Set([
     ...definitions.map(definition => dirname(definition.handler)),
     ...nativeFiles.map(file => dirname(file)),
@@ -249,7 +250,7 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
   await writeFile(outputConfigFile, `${JSON.stringify({
     ...workflowConfig,
     ...viteHubConfig,
-    routes: [...(workflowConfig.routes ?? []), ...(viteHubConfig.routes ?? [])],
+    routes: [...(workflowConfig.routes ?? []), ...viteHubRoutes],
   }, null, 2)}\n`, "utf8")
 }
 
@@ -953,18 +954,20 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
       cleanup: {
         cloudflare: cloudflareOutput ? undefined : () => createCloudflareWorkflowCleanup(options.rootDir),
       },
+      afterWrite: async () => {
+        if (vercelOutput) {
+          await buildVercelNativeWorkflowOutput(options.rootDir, artifacts.providerDefinitions, {
+            ...options.providerImportAliases,
+            ...options.providerRuntimeImportAliases?.vercel,
+          }, artifacts.vercelNativeFile ? [artifacts.vercelNativeFile] : [])
+        }
+        else {
+          await cleanVercelNativeWorkflowOutput(options.rootDir)
+        }
+      },
       rootDir: options.rootDir,
       ...(vercelOutput ? { vercel: vercelOutput } : {}),
     })
-    if (vercelOutput) {
-      await buildVercelNativeWorkflowOutput(options.rootDir, artifacts.providerDefinitions, {
-        ...options.providerImportAliases,
-        ...options.providerRuntimeImportAliases?.vercel,
-      }, artifacts.vercelNativeFile ? [artifacts.vercelNativeFile] : [])
-    }
-    else {
-      await cleanVercelNativeWorkflowOutput(options.rootDir)
-    }
   }
   if (workflowTransformPlugin && options.importBase) await withVercelWorkflowPackageLink(options.rootDir, writeOutputs)
   else await writeOutputs()

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -110,10 +110,13 @@ async function withVercelWorkflowPackageLink<T>(rootDir: string, run: () => Prom
   }
 }
 
-async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: DiscoveredWorkflowDefinition[], aliases: Record<string, string> = {}): Promise<void> {
+async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: DiscoveredWorkflowDefinition[], aliases: Record<string, string> = {}, nativeFiles: string[] = []): Promise<void> {
   const builders = await loadVercelWorkflowBuilders()
   if (!definitions.length) return
-  const definitionDirs = [...new Set(definitions.map(definition => dirname(definition.handler)))]
+  const definitionDirs = [...new Set([
+    ...definitions.map(definition => dirname(definition.handler)),
+    ...nativeFiles.map(file => dirname(file)),
+  ])]
   let hasNativeEntry = false
   const visited = new Set<string>()
   const visit = (file: string) => {
@@ -160,6 +163,7 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
     }
   }
   for (const definition of definitions) visit(definition.handler)
+  for (const file of nativeFiles) visit(file)
   if (!hasNativeEntry) return
   if (!builders) {
     throw new Error("Native Vercel workflows require the optional workflow and @workflow/builders peer dependencies.")
@@ -209,13 +213,14 @@ function resolveWorkflowConfig(workflow: WorkflowModuleOptions | undefined, host
   return normalizeWorkflowOptions(workflow, { hosting }) ?? false
 }
 
-interface GeneratedWorkflowArtifacts {
+export interface GeneratedWorkflowArtifacts {
   cloudflareWorkerFile: string
   cloudflareWorkflowConfig: false | ResolvedWorkflowOptions
   definitions: DiscoveredWorkflowDefinition[]
   generatedDir: string
   providerDefinitions: DiscoveredWorkflowDefinition[]
   registryFile: string
+  vercelNativeFile?: string
   vercelServerFile: string
 }
 
@@ -457,7 +462,39 @@ function renderAgentWorkflowRegistryEntry(registryFile: string, definition: Disc
   ].join("\n")
 }
 
-function renderWorkflowRegistryEntry(registryFile: string, definition: DiscoveredWorkflowDefinition) {
+function getGeneratedVercelWorkflowExport(definition: DiscoveredWorkflowDefinition): string | undefined {
+  if (!definition.steps?.length || /\.(?:c|m)?[jt]s$/i.test(definition.handler)) return
+  return `${getCloudflareWorkflowClassName(definition.name)}Native`
+}
+
+function createVercelNativeWorkflowContents(
+  nativeFile: string,
+  definitions: DiscoveredWorkflowDefinition[],
+  emailDefinitionFile?: string,
+): string {
+  const imports = emailDefinitionFile
+    ? [`import viteHubEmailDefinition from ${JSON.stringify(createImportPath(nativeFile, emailDefinitionFile))}`]
+    : []
+  const workflows = emailDefinitionFile
+    ? [`globalThis[Symbol.for("vitehub.email.definition")] = viteHubEmailDefinition`]
+    : []
+  for (const definition of definitions) {
+    const workflowExport = getGeneratedVercelWorkflowExport(definition)
+    const steps = definition.steps
+    if (!workflowExport || !steps) continue
+    const stepNames = steps.map((step, index) => {
+      const implementation = `${workflowExport}Step${index}Implementation`
+      const name = `${workflowExport}Step${index}`
+      imports.push(`import ${implementation} from ${JSON.stringify(createImportPath(nativeFile, step))}`)
+      workflows.push(`async function ${name}(input) {\n  "use step"\n  return await ${implementation}(input)\n}`)
+      return name
+    })
+    workflows.push(`export async function ${workflowExport}(context) {\n  "use workflow"\n  let value = context.payload\n${stepNames.map(name => `  value = await ${name}(value)`).join("\n")}\n  return value\n}`)
+  }
+  return [...imports, "", ...workflows, ""].join("\n")
+}
+
+function renderWorkflowRegistryEntry(registryFile: string, definition: DiscoveredWorkflowDefinition, vercelNativeFile?: string) {
   if (definition.source === "agent-workflow") {
     return renderAgentWorkflowRegistryEntry(registryFile, definition)
   }
@@ -474,6 +511,10 @@ function renderWorkflowRegistryEntry(registryFile: string, definition: Discovere
 
   const hasIndex = /\.(?:c|m)?[jt]s$/i.test(definition.handler)
   const indexImport = hasIndex ? `const index = await ${renderRegistryImport(registryFile, definition.handler)}` : ""
+  const nativeExport = getGeneratedVercelWorkflowExport(definition)
+  const nativeImport = nativeExport && vercelNativeFile
+    ? `const native = (await ${renderRegistryImport(registryFile, vercelNativeFile)}).${nativeExport}\n    native.workflowId ||= ${JSON.stringify(`workflow//./.vitehub/workflow/vercel-native//${nativeExport}`)}`
+    : ""
   const handler = hasIndex
     ? `index.default?.handler ? index.default : takeInlineWorkflowDefinitionForModule(${JSON.stringify(definition.name)}, index) || { handler: index.default }`
     : "{ handler: async (context) => { let value = context.payload; for (const step of Object.values(context.steps || {})) value = await step(value); return value } }"
@@ -483,11 +524,12 @@ function renderWorkflowRegistryEntry(registryFile: string, definition: Discovere
     `    const cached = registryEntryCache.get(${JSON.stringify(definition.name)})`,
     "    if (cached) return cached",
     indexImport ? `    ${indexImport}` : "",
+    nativeImport ? `    ${nativeImport}` : "",
     `    const steps = [${stepImports.join(", ")}]`,
     `    const definition = ${handler}`,
     "    const entry = {",
     "      ...definition,",
-    "      options: { ...definition.options, rootStep: false },",
+    `      options: { ...definition.options, rootStep: false${nativeImport ? ", native" : ""} },`,
     "      handler: async (context) => {",
     "        const workflowSteps = createWorkflowSteps(context, steps)",
     "        return await definition.handler({ ...context, steps: workflowSteps })",
@@ -503,6 +545,7 @@ function createWorkflowRegistryContents(
   registryFile: string,
   definitions: DiscoveredWorkflowDefinition[],
   importBases: WorkflowImportBases = {},
+  vercelNativeFile?: string,
 ): string {
   const agentImportBase = importBases.agent ?? "@vite-hub/agent"
   const workflowImportBase = importBases.workflow ?? workflowPackageName
@@ -564,7 +607,7 @@ function createWorkflowRegistryContents(
       : []),
     ...(needsRegistryEntryCache ? ["const registryEntryCache = new Map()", ""] : []),
     "const registry = {",
-    ...definitions.map(definition => renderWorkflowRegistryEntry(registryFile, definition)),
+    ...definitions.map(definition => renderWorkflowRegistryEntry(registryFile, definition, vercelNativeFile)),
     "}",
     "",
     "export default registry",
@@ -650,13 +693,14 @@ function renderProviderEntry(
   ].filter(Boolean).join("\n")
 }
 
-async function writeProviderEntries(
+export async function writeProviderEntries(
   rootDir: string,
   workflow: WorkflowModuleOptions | undefined,
   importBases: WorkflowImportBases = {},
   serverDirs?: string[],
   includeUserAppEntry = true,
   transformRegistry?: (code: string, id: string) => string | Promise<string>,
+  providerImportAliases: Record<string, string> = {},
 ) {
   const generatedDir = ensureGeneratedDir(rootDir, productName)
   await mkdir(generatedDir, { recursive: true })
@@ -667,7 +711,28 @@ async function writeProviderEntries(
   const userAppEntry = includeUserAppEntry ? resolveWorkflowUserAppEntry(rootDir) : undefined
   const cloudflareWorkflowConfig = resolveWorkflowConfig(workflow, "cloudflare")
 
-  const registryContents = createWorkflowRegistryContents(registryFile, definitions, importBases)
+  const vercelNativeFile = resolve(generatedDir, "vercel-native.mjs")
+  const hasGeneratedVercelWorkflows = definitions.some(getGeneratedVercelWorkflowExport)
+  if (hasGeneratedVercelWorkflows) {
+    await writeFile(
+      vercelNativeFile,
+      createVercelNativeWorkflowContents(
+        vercelNativeFile,
+        definitions,
+        providerImportAliases["#vitehub/email/definition"],
+      ),
+      "utf8",
+    )
+  }
+  else {
+    await rm(vercelNativeFile, { force: true })
+  }
+  const registryContents = createWorkflowRegistryContents(
+    registryFile,
+    definitions,
+    importBases,
+    hasGeneratedVercelWorkflows ? vercelNativeFile : undefined,
+  )
   await writeFile(registryFile, transformRegistry ? await transformRegistry(registryContents, registryFile) : registryContents, "utf8")
 
   const entryFiles: Record<WorkflowProvider, string> = { cloudflare: "", openworkflow: "", vercel: "" }
@@ -688,6 +753,7 @@ async function writeProviderEntries(
     generatedDir,
     providerDefinitions,
     registryFile,
+    ...(hasGeneratedVercelWorkflows ? { vercelNativeFile } : {}),
     vercelServerFile: entryFiles.vercel,
   }
 }
@@ -803,7 +869,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     workflow: options.importBase,
     workspace: options.workspaceImportBase,
     workspaceDependencies: options.workspaceDependencyRuntimeImports,
-  }, options.serverDirs, options.includeUserAppEntry, options.transformRegistry)
+  }, options.serverDirs, options.includeUserAppEntry, options.transformRegistry, options.providerImportAliases)
   const cloudflareWorkflowConfig = resolveWorkflowConfig(options.workflow, "cloudflare")
   const vercelWorkflowConfig = resolveWorkflowConfig(options.workflow, "vercel")
   const cloudflareOutput = cloudflareWorkflowConfig && cloudflareWorkflowConfig.provider === "cloudflare"
@@ -834,7 +900,7 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
     if (vercelOutput) await buildVercelNativeWorkflowOutput(options.rootDir, artifacts.providerDefinitions, {
       ...options.providerImportAliases,
       ...options.providerRuntimeImportAliases?.vercel,
-    })
+    }, artifacts.vercelNativeFile ? [artifacts.vercelNativeFile] : [])
   }
   if (workflowTransformPlugin && options.importBase) await withVercelWorkflowPackageLink(options.rootDir, writeOutputs)
   else await writeOutputs()

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -5,7 +5,7 @@ import { dirname, isAbsolute, join, relative, resolve } from "node:path"
 
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
 import { readColocatedAgentFiles } from "@vite-hub/internal/build/colocated-agent-files"
-import { createDefaultCloudflareOutputRoot, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
+import { createDefaultCloudflareOutputRoot, withProviderDeploymentOutputLock } from "@vite-hub/internal/build/deployment-output"
 import { bundleEsmEntry } from "@vite-hub/internal/build/esbuild"
 import { VITEHUB_MODES, getViteMode } from "@vite-hub/internal/build/mode"
 import { computePackageDir, createImportPath, ensureGeneratedDir, resolveRuntimeModule as resolveRuntimeFromPkg } from "@vite-hub/internal/build/paths"
@@ -17,7 +17,7 @@ import { discoverWorkflowDefinitions } from "../discovery.ts"
 import { createCloudflareWorkflowBindings, getCloudflareWorkflowClassName } from "../integrations/cloudflare.ts"
 
 import type { DiscoveredWorkflowDefinition, ResolvedWorkflowOptions, WorkflowModuleOptions, WorkflowProvider } from "../types.ts"
-import type { CloudflareProviderDeploymentOutput, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
+import type { CloudflareProviderDeploymentOutput, ProviderDeploymentOutputOptions, VercelProviderDeploymentOutput } from "@vite-hub/internal/build/deployment-output"
 import type { Plugin as VitePlugin } from "vite"
 
 export const workflowPackageName = "@vite-hub/workflow"
@@ -923,7 +923,10 @@ function createVercelOutput(
   }
 }
 
-export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedWorkflowArtifacts> {
+async function generateProviderOutputsWithinLock(
+  options: GenerateProviderOutputsOptions,
+  writeProviderDeploymentOutputs: (options: ProviderDeploymentOutputOptions) => Promise<void>,
+): Promise<GeneratedWorkflowArtifacts> {
   const artifacts = await writeProviderEntries(options.rootDir, options.workflow, {
     agent: options.agentImportBase,
     workflow: options.importBase,
@@ -972,4 +975,8 @@ export async function generateProviderOutputs(options: GenerateProviderOutputsOp
   if (workflowTransformPlugin && options.importBase) await withVercelWorkflowPackageLink(options.rootDir, writeOutputs)
   else await writeOutputs()
   return artifacts
+}
+
+export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedWorkflowArtifacts> {
+  return await withProviderDeploymentOutputLock(options.rootDir, async write => await generateProviderOutputsWithinLock(options, write))
 }

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -38,6 +38,11 @@ interface VercelNativeWorkflowState {
   routes: unknown[]
 }
 
+interface VercelNativeWorkflowSnapshot {
+  config?: Buffer
+  files: Record<string, Buffer>
+}
+
 async function readVercelNativeWorkflowOwnership(ownershipFile: string): Promise<VercelNativeWorkflowOwnership | undefined> {
   try {
     const ownership = JSON.parse(await readFile(ownershipFile, "utf8")) as VercelNativeWorkflowOwnership
@@ -311,6 +316,45 @@ async function collectVercelNativeWorkflowFiles(workflowRoot: string, directory 
   return files
 }
 
+async function snapshotVercelNativeWorkflowOutput(rootDir: string): Promise<VercelNativeWorkflowSnapshot> {
+  const outputRoot = resolve(rootDir, ".vercel", "output")
+  const workflowRoot = resolve(outputRoot, "functions", ".well-known", "workflow")
+  const files: Record<string, Buffer> = {}
+  const collect = async (directory: string): Promise<void> => {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const file = resolve(directory, entry.name)
+      if (entry.isDirectory()) await collect(file)
+      else files[relative(workflowRoot, file)] = await readFile(file)
+    }
+  }
+  if (existsSync(workflowRoot)) await collect(workflowRoot)
+  let config: Buffer | undefined
+  try {
+    config = await readFile(resolve(outputRoot, "config.json"))
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
+  return { config, files }
+}
+
+async function restoreVercelNativeWorkflowOutput(rootDir: string, snapshot: VercelNativeWorkflowSnapshot): Promise<void> {
+  const outputRoot = resolve(rootDir, ".vercel", "output")
+  const workflowRoot = resolve(outputRoot, "functions", ".well-known", "workflow")
+  await rm(workflowRoot, { force: true, recursive: true })
+  await Promise.all(Object.entries(snapshot.files).map(async ([file, contents]) => {
+    const outputFile = resolve(workflowRoot, file)
+    await mkdir(dirname(outputFile), { recursive: true })
+    await writeFile(outputFile, contents)
+  }))
+  const configFile = resolve(outputRoot, "config.json")
+  if (snapshot.config) {
+    await mkdir(outputRoot, { recursive: true })
+    await writeFile(configFile, snapshot.config)
+  }
+  else await rm(configFile, { force: true })
+}
+
 async function readVercelNativeWorkflowState(rootDir: string): Promise<VercelNativeWorkflowState> {
   const outputRoot = resolve(rootDir, ".vercel", "output")
   const workflowRoot = resolve(outputRoot, "functions", ".well-known", "workflow")
@@ -337,6 +381,7 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
     throw new Error("Native Vercel workflows require the optional workflow and @workflow/builders peer dependencies.")
   }
 
+  const snapshot = await snapshotVercelNativeWorkflowOutput(rootDir)
   const outputConfigFile = resolve(rootDir, ".vercel", "output", "config.json")
   const viteHubConfig = JSON.parse(await readFile(outputConfigFile, "utf8")) as { routes?: unknown[] }
   const workflowRoot = resolve(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
@@ -346,6 +391,7 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
   const preservedRoutes = (previousState?.routes ?? []).filter(route => JSON.stringify(route).includes("/.well-known/workflow/v1/") && !previouslyOwnedRoutes.has(JSON.stringify(route)))
   const currentRoutes = (viteHubConfig.routes ?? []).filter(route => !previouslyOwnedRoutes.has(JSON.stringify(route)))
   const viteHubRoutes = [...new Map([...currentRoutes, ...preservedRoutes].map(route => [JSON.stringify(route), route])).values()]
+  snapshot.config = Buffer.from(`${JSON.stringify({ ...viteHubConfig, routes: viteHubRoutes }, null, 2)}\n`)
   const externalWorkflowRoutes = new Set(preservedRoutes
     .filter(route => JSON.stringify(route).includes("/.well-known/workflow/v1/"))
     .map(route => JSON.stringify(route)))
@@ -362,9 +408,15 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
     workflowsBundlePath: "./.well-known/workflow/v1/flow.js",
     workingDir: rootDir,
   })
-  await withVercelWorkflowPackageLink(rootDir, async () => await builder.build())
-  const emailDefinitionFile = aliases["#vitehub/email/definition"]
-  if (emailDefinitionFile) await installEmailDefinitionInVercelWorkflowOutput(rootDir, emailDefinitionFile)
+  try {
+    await withVercelWorkflowPackageLink(rootDir, async () => await builder.build())
+    const emailDefinitionFile = aliases["#vitehub/email/definition"]
+    if (emailDefinitionFile) await installEmailDefinitionInVercelWorkflowOutput(rootDir, emailDefinitionFile)
+  }
+  catch (error) {
+    await restoreVercelNativeWorkflowOutput(rootDir, snapshot)
+    throw error
+  }
   const workflowConfig = JSON.parse(await readFile(outputConfigFile, "utf8")) as { routes?: unknown[], [key: string]: unknown }
   await writeFile(outputConfigFile, `${JSON.stringify({
     ...workflowConfig,

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -110,9 +110,8 @@ async function withVercelWorkflowPackageLink<T>(rootDir: string, run: () => Prom
   }
 }
 
-async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: DiscoveredWorkflowDefinition[], aliases: Record<string, string> = {}, nativeFiles: string[] = []): Promise<void> {
-  const builders = await loadVercelWorkflowBuilders()
-  if (!definitions.length) return
+export function hasVercelNativeWorkflowEntry(rootDir: string, definitions: DiscoveredWorkflowDefinition[], aliases: Record<string, string> = {}, nativeFiles: string[] = []): boolean {
+  if (!definitions.length) return false
   const definitionDirs = [...new Set([
     ...definitions.map(definition => dirname(definition.handler)),
     ...nativeFiles.map(file => dirname(file)),
@@ -164,13 +163,22 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
   }
   for (const definition of definitions) visit(definition.handler)
   for (const file of nativeFiles) visit(file)
-  if (!hasNativeEntry) return
+  return hasNativeEntry
+}
+
+async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: DiscoveredWorkflowDefinition[], aliases: Record<string, string> = {}, nativeFiles: string[] = []): Promise<void> {
+  if (!hasVercelNativeWorkflowEntry(rootDir, definitions, aliases, nativeFiles)) return
+  const builders = await loadVercelWorkflowBuilders()
   if (!builders) {
     throw new Error("Native Vercel workflows require the optional workflow and @workflow/builders peer dependencies.")
   }
 
   const outputConfigFile = resolve(rootDir, ".vercel", "output", "config.json")
   const viteHubConfig = JSON.parse(await readFile(outputConfigFile, "utf8")) as { routes?: unknown[] }
+  const definitionDirs = [...new Set([
+    ...definitions.map(definition => dirname(definition.handler)),
+    ...nativeFiles.map(file => dirname(file)),
+  ])]
   const builder = new builders.VercelBuildOutputAPIBuilder({
     buildTarget: "vercel-build-output-api",
     dirs: definitionDirs,

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -317,7 +317,7 @@ async function collectVercelNativeWorkflowFiles(workflowRoot: string, directory 
       Object.assign(files, await collectVercelNativeWorkflowFiles(workflowRoot, outputFile))
     }
     else if (entry.name !== vercelNativeWorkflowOwnershipMarker) {
-      files[relative(workflowRoot, outputFile)] = createHash("sha256").update(await readFile(outputFile)).digest("hex")
+      files[relative(workflowRoot, outputFile).replaceAll("\\", "/")] = createHash("sha256").update(await readFile(outputFile)).digest("hex")
     }
   }
   return files

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -1,5 +1,6 @@
+import { createHash } from "node:crypto"
 import { existsSync, readFileSync, readdirSync, statSync } from "node:fs"
-import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises"
+import { mkdir, readFile, readdir, rm, rmdir, symlink, writeFile } from "node:fs/promises"
 import { builtinModules, createRequire } from "node:module"
 import { dirname, isAbsolute, join, relative, resolve } from "node:path"
 
@@ -23,6 +24,32 @@ import type { Plugin as VitePlugin } from "vite"
 export const workflowPackageName = "@vite-hub/workflow"
 const productName = "workflow"
 const vercelNativeWorkflowOwnershipMarker = ".vitehub-owned"
+
+interface VercelNativeWorkflowOwnership {
+  cleanup?: boolean
+  files: Record<string, string>
+  routes: string[]
+  version: 1
+}
+
+interface VercelNativeWorkflowState {
+  files: Record<string, string>
+  ownership?: VercelNativeWorkflowOwnership
+  routes: unknown[]
+}
+
+async function readVercelNativeWorkflowOwnership(ownershipFile: string): Promise<VercelNativeWorkflowOwnership | undefined> {
+  try {
+    const ownership = JSON.parse(await readFile(ownershipFile, "utf8")) as VercelNativeWorkflowOwnership
+    if (ownership.version !== 1 || !ownership.files || !Array.isArray(ownership.routes)) return
+    if (Object.entries(ownership.files).some(([file, digest]) => isAbsolute(file) || typeof digest !== "string")) return
+    if (ownership.routes.some(route => typeof route !== "string")) return
+    return ownership
+  }
+  catch {
+    return
+  }
+}
 
 const generatedRegistryFileName = "registry.mjs"
 const cloudflareWorkflowWranglerConfigKeys = ["compatibility_date", "compatibility_flags", "main", "observability", "workflows"]
@@ -202,25 +229,105 @@ export async function installEmailDefinitionInVercelWorkflowOutput(rootDir: stri
 export async function cleanVercelNativeWorkflowOutput(rootDir: string): Promise<void> {
   const outputRoot = resolve(rootDir, ".vercel", "output")
   const workflowRoot = resolve(outputRoot, "functions", ".well-known", "workflow")
-  if (!existsSync(resolve(workflowRoot, vercelNativeWorkflowOwnershipMarker))) return
-  await rm(workflowRoot, { force: true, recursive: true })
+  const ownershipFile = resolve(workflowRoot, vercelNativeWorkflowOwnershipMarker)
+  const ownership = await readVercelNativeWorkflowOwnership(ownershipFile)
+  if (!ownership) return
+  if (Object.keys(ownership.files).some(file => relative(workflowRoot, resolve(workflowRoot, file)).startsWith(".."))) return
+
+  let hasReplacement = false
+  const ownedFiles: string[] = []
+  for (const [file, digest] of Object.entries(ownership.files)) {
+    const outputFile = resolve(workflowRoot, file)
+    let contents: Buffer
+    try {
+      contents = await readFile(outputFile)
+    }
+    catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        if (!ownership.cleanup) hasReplacement = true
+        continue
+      }
+      throw error
+    }
+    if (createHash("sha256").update(contents).digest("hex") !== digest) {
+      hasReplacement = true
+      continue
+    }
+    ownedFiles.push(outputFile)
+  }
+  if (hasReplacement) {
+    await rm(ownershipFile, { force: true })
+    return
+  }
+  if (!ownership.cleanup) await writeFile(ownershipFile, `${JSON.stringify({ ...ownership, cleanup: true }, null, 2)}\n`, "utf8")
+  await Promise.all(ownedFiles.map(async file => await rm(file, { force: true })))
   const configFile = resolve(outputRoot, "config.json")
-  let config: { routes?: Array<Record<string, unknown>>, [key: string]: unknown }
+  let config: { routes?: Array<Record<string, unknown>>, [key: string]: unknown } | undefined
   try {
     config = JSON.parse(await readFile(configFile, "utf8"))
   }
   catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
+  if (Array.isArray(config?.routes)) {
+    const ownedRoutes = new Set(ownership.routes)
+    const routes = config.routes.filter(route => !ownedRoutes.has(JSON.stringify(route)))
+    if (routes.length !== config.routes.length) {
+      await writeFile(configFile, `${JSON.stringify({ ...config, routes }, null, 2)}\n`, "utf8")
+    }
+  }
+  await rm(ownershipFile, { force: true })
+  await removeEmptyDirectories(workflowRoot)
+}
+
+async function removeEmptyDirectories(directory: string): Promise<boolean> {
+  let entries
+  try {
+    entries = await readdir(directory, { withFileTypes: true })
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return true
     throw error
   }
-  if (!Array.isArray(config.routes)) return
-  const routes = config.routes.filter(route => !JSON.stringify(route).includes("/.well-known/workflow/v1/"))
-  if (routes.length !== config.routes.length) {
-    await writeFile(configFile, `${JSON.stringify({ ...config, routes }, null, 2)}\n`, "utf8")
+  for (const entry of entries) {
+    if (entry.isDirectory()) await removeEmptyDirectories(resolve(directory, entry.name))
+  }
+  if ((await readdir(directory)).length) return false
+  await rmdir(directory)
+  return true
+}
+
+async function collectVercelNativeWorkflowFiles(workflowRoot: string, directory = workflowRoot): Promise<Record<string, string>> {
+  const files: Record<string, string> = {}
+  for (const entry of await readdir(directory, { withFileTypes: true })) {
+    const outputFile = resolve(directory, entry.name)
+    if (entry.isDirectory()) {
+      Object.assign(files, await collectVercelNativeWorkflowFiles(workflowRoot, outputFile))
+    }
+    else if (entry.name !== vercelNativeWorkflowOwnershipMarker) {
+      files[relative(workflowRoot, outputFile)] = createHash("sha256").update(await readFile(outputFile)).digest("hex")
+    }
+  }
+  return files
+}
+
+async function readVercelNativeWorkflowState(rootDir: string): Promise<VercelNativeWorkflowState> {
+  const outputRoot = resolve(rootDir, ".vercel", "output")
+  const workflowRoot = resolve(outputRoot, "functions", ".well-known", "workflow")
+  let routes: unknown[] = []
+  try {
+    const config = JSON.parse(await readFile(resolve(outputRoot, "config.json"), "utf8")) as { routes?: unknown[] }
+    routes = config.routes ?? []
+  }
+  catch {}
+  return {
+    files: existsSync(workflowRoot) ? await collectVercelNativeWorkflowFiles(workflowRoot) : {},
+    ownership: await readVercelNativeWorkflowOwnership(resolve(workflowRoot, vercelNativeWorkflowOwnershipMarker)),
+    routes,
   }
 }
 
-async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: DiscoveredWorkflowDefinition[], aliases: Record<string, string> = {}, nativeFiles: string[] = []): Promise<void> {
+async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: DiscoveredWorkflowDefinition[], aliases: Record<string, string> = {}, nativeFiles: string[] = [], previousState?: VercelNativeWorkflowState): Promise<void> {
   if (!hasVercelNativeWorkflowEntry(rootDir, definitions, aliases, nativeFiles)) {
     await cleanVercelNativeWorkflowOutput(rootDir)
     return
@@ -232,7 +339,16 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
 
   const outputConfigFile = resolve(rootDir, ".vercel", "output", "config.json")
   const viteHubConfig = JSON.parse(await readFile(outputConfigFile, "utf8")) as { routes?: unknown[] }
-  const viteHubRoutes = (viteHubConfig.routes ?? []).filter(route => !JSON.stringify(route).includes("/.well-known/workflow/v1/"))
+  const workflowRoot = resolve(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
+  const previousOwnership = previousState?.ownership
+  const previousFiles = previousState?.files ?? {}
+  const previouslyOwnedRoutes = new Set(previousOwnership?.routes ?? [])
+  const preservedRoutes = (previousState?.routes ?? []).filter(route => JSON.stringify(route).includes("/.well-known/workflow/v1/") && !previouslyOwnedRoutes.has(JSON.stringify(route)))
+  const currentRoutes = (viteHubConfig.routes ?? []).filter(route => !previouslyOwnedRoutes.has(JSON.stringify(route)))
+  const viteHubRoutes = [...new Map([...currentRoutes, ...preservedRoutes].map(route => [JSON.stringify(route), route])).values()]
+  const externalWorkflowRoutes = new Set(preservedRoutes
+    .filter(route => JSON.stringify(route).includes("/.well-known/workflow/v1/"))
+    .map(route => JSON.stringify(route)))
   const definitionDirs = [...new Set([
     ...definitions.map(definition => dirname(definition.handler)),
     ...nativeFiles.map(file => dirname(file)),
@@ -247,7 +363,6 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
     workingDir: rootDir,
   })
   await withVercelWorkflowPackageLink(rootDir, async () => await builder.build())
-  await writeFile(resolve(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", vercelNativeWorkflowOwnershipMarker), "\n", "utf8")
   const emailDefinitionFile = aliases["#vitehub/email/definition"]
   if (emailDefinitionFile) await installEmailDefinitionInVercelWorkflowOutput(rootDir, emailDefinitionFile)
   const workflowConfig = JSON.parse(await readFile(outputConfigFile, "utf8")) as { routes?: unknown[], [key: string]: unknown }
@@ -256,6 +371,17 @@ async function buildVercelNativeWorkflowOutput(rootDir: string, definitions: Dis
     ...viteHubConfig,
     routes: [...(workflowConfig.routes ?? []), ...viteHubRoutes],
   }, null, 2)}\n`, "utf8")
+  const generatedFiles = await collectVercelNativeWorkflowFiles(workflowRoot)
+  const ownership: VercelNativeWorkflowOwnership = {
+    files: Object.fromEntries(Object.entries(generatedFiles)
+      .filter(([file, digest]) => previousFiles[file] !== digest || previousFiles[file] === previousOwnership?.files[file])),
+    routes: (workflowConfig.routes ?? [])
+      .filter(route => JSON.stringify(route).includes("/.well-known/workflow/v1/"))
+      .filter(route => !externalWorkflowRoutes.has(JSON.stringify(route)))
+      .map(route => JSON.stringify(route)),
+    version: 1,
+  }
+  await writeFile(resolve(workflowRoot, vercelNativeWorkflowOwnershipMarker), `${JSON.stringify(ownership, null, 2)}\n`, "utf8")
 }
 
 function resolveWorkflowUserAppEntry(rootDir: string) {
@@ -955,6 +1081,7 @@ async function generateProviderOutputsWithinLock(
       }, options.serverFunctionName)
     : undefined
   const writeOutputs = async () => {
+    const previousNativeOutput = await readVercelNativeWorkflowState(options.rootDir)
     await writeProviderDeploymentOutputs({
       clientOutDir: options.clientOutDir,
       cloudflare: cloudflareOutput,
@@ -966,7 +1093,7 @@ async function generateProviderOutputsWithinLock(
           await buildVercelNativeWorkflowOutput(options.rootDir, artifacts.providerDefinitions, {
             ...options.providerImportAliases,
             ...options.providerRuntimeImportAliases?.vercel,
-          }, artifacts.vercelNativeFile ? [artifacts.vercelNativeFile] : [])
+          }, artifacts.vercelNativeFile ? [artifacts.vercelNativeFile] : [], previousNativeOutput)
         }
         else {
           await cleanVercelNativeWorkflowOutput(options.rootDir)

--- a/packages/workflow/src/runtime/vercel-vite.ts
+++ b/packages/workflow/src/runtime/vercel-vite.ts
@@ -10,6 +10,10 @@ import type { ResolvedWorkflowOptions, WorkflowDefinitionRegistry } from "../typ
 
 export { setVercelWorkflowRuntimeModules } from "./vercel.ts"
 
+export async function runWithVercelWorkflowRuntimeEvent<T>(req: unknown, res: unknown, run: () => T | Promise<T>): Promise<T> {
+  return await runWithWorkflowRuntimeEvent({ req, res, waitUntil: vercelWaitUntil }, run)
+}
+
 interface WorkflowVercelServerOptions {
   app?: WorkflowApp
   registry?: WorkflowDefinitionRegistry
@@ -25,7 +29,7 @@ export function createWorkflowVercelServer(options: WorkflowVercelServerOptions 
     onRequest({ handle, req, res }) {
       setWorkflowRuntimeConfig(options.workflow)
       setWorkflowRuntimeRegistry(options.registry)
-      return runWithWorkflowRuntimeEvent({ req, res, waitUntil: vercelWaitUntil }, handle)
+      return runWithVercelWorkflowRuntimeEvent(req, res, handle)
     },
   }) as WorkflowVercelServer
 }

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -114,7 +114,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
         [`${importBase}/runtime/vercel-vite`]: projectRequire.resolve(`${importBase}/runtime/vercel-vite`),
         ...(workflowApi && workflowRequire
           ? {
-              "@workflow/core/runtime/world-target": createRequire(workflowApi).resolve("@workflow/world-vercel"),
+              "@workflow/core/runtime/world-target": createRequire(workflowRequire.resolve("@workflow/builders")).resolve("@workflow/world-vercel"),
               "workflow/api": workflowApi,
               "workflow/runtime": workflowRequire.resolve("workflow/runtime"),
             }

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -81,10 +81,10 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
     return database ? { "@vite-hub/database/drizzle": database } : {}
   }
 
-  function providerImportAliases(): Record<string, string> {
+  async function providerImportAliases(): Promise<Record<string, string>> {
     if (!resolved) return { ...internalOptions?.providerImportAliases }
-    const contributedAliases = Object.assign({}, ...(resolved.plugins as Array<Plugin & ViteHubProviderImportContributor>)
-      .map(plugin => plugin.vitehub?.providerOutput?.getImportAliases?.() ?? {}))
+    const contributedAliases = Object.assign({}, ...await Promise.all((resolved.plugins as Array<Plugin & ViteHubProviderImportContributor>)
+      .map(async plugin => await plugin.vitehub?.providerOutput?.getImportAliases?.() ?? {})))
     return {
       ...resolveStringAliases(resolved),
       ...contributedAliases,
@@ -106,12 +106,13 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
       ?.vitehub?.agent?.transformWorkflowRegistry, resolved.root)
     const importBase = internalOptions?.importBase ?? workflowPackageName
     const projectRequire = createRequire(resolve(resolved.root, "package.json"))
-    const native = hasVercelNativeWorkflowEntry(rootDir, artifacts.providerDefinitions, providerImportAliases(), artifacts.vercelNativeFiles)
+    const aliases = await providerImportAliases()
+    const native = hasVercelNativeWorkflowEntry(rootDir, artifacts.providerDefinitions, aliases, artifacts.vercelNativeFiles)
     const workflowRequire = native ? createRequire(import.meta.url) : undefined
     const workflowApi = workflowRequire?.resolve("workflow/api")
     return {
       bundleAlias: {
-        ...providerImportAliases(),
+        ...aliases,
         [`${importBase}/runtime/state`]: projectRequire.resolve(`${importBase}/runtime/state`),
         [`${importBase}/runtime/vercel-vite`]: projectRequire.resolve(`${importBase}/runtime/vercel-vite`),
         ...(workflowApi && workflowRequire
@@ -178,7 +179,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
         agentImportBase: internalOptions?.agentImportBase,
         clientOutDir: resolve(resolved.root, resolved.build.outDir),
         importBase: internalOptions?.importBase,
-        providerImportAliases: providerImportAliases(),
+        providerImportAliases: await providerImportAliases(),
         providerRuntimeImportAliases: {
           cloudflare: providerRuntimeImportAliases("cloudflare"),
           vercel: providerRuntimeImportAliases("vercel"),

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -43,6 +43,10 @@ interface AgentWorkflowRegistryPlugin extends Plugin {
   }
 }
 
+interface EmailDefinitionPlugin extends Plugin {
+  api?: { getDefinition?: () => { handler: string } | undefined }
+}
+
 const mergeNoExternal = createNoExternalMerger(workflowPackageName)
 
 type InternalWorkflowModuleOptions = Exclude<WorkflowModuleOptions, false> & {
@@ -82,8 +86,12 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
 
   function providerImportAliases(): Record<string, string> {
     if (!resolved) return { ...internalOptions?.providerImportAliases }
+    const emailDefinition = (resolved.plugins as EmailDefinitionPlugin[])
+      .find(plugin => plugin.name === "@vite-hub/email/vite")
+      ?.api?.getDefinition?.()
     return {
       ...resolveStringAliases(resolved),
+      ...(emailDefinition ? { "#vitehub/email/definition": emailDefinition.handler } : {}),
       ...internalOptions?.providerImportAliases,
     }
   }
@@ -107,6 +115,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
     const workflowApi = workflowRequire?.resolve("workflow/api")
     return {
       bundleAlias: {
+        ...providerImportAliases(),
         [`${importBase}/runtime/state`]: projectRequire.resolve(`${importBase}/runtime/state`),
         [`${importBase}/runtime/vercel-vite`]: projectRequire.resolve(`${importBase}/runtime/vercel-vite`),
         ...(workflowApi && workflowRequire

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -11,6 +11,7 @@ import { createCloudflareWorkflowNitroConfig, createOptionalViteDevtoolsPlugin, 
 import type { WorkflowModuleOptions } from "./types.ts"
 import type { ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
 import type { Plugin as EsbuildPlugin } from "esbuild"
+import type { ViteHubProviderImportContributor } from "@vite-hub/internal/build/vite"
 import type { Plugin, ResolvedConfig } from "vite"
 
 interface WorkflowNitroConfigOptions {
@@ -41,10 +42,6 @@ interface AgentWorkflowRegistryPlugin extends Plugin {
       transformWorkflowRegistry?: (code: string, id: string) => string | Promise<string>
     }
   }
-}
-
-interface EmailDefinitionPlugin extends Plugin {
-  api?: { getDefinition?: () => { handler: string } | undefined }
 }
 
 const mergeNoExternal = createNoExternalMerger(workflowPackageName)
@@ -86,12 +83,11 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
 
   function providerImportAliases(): Record<string, string> {
     if (!resolved) return { ...internalOptions?.providerImportAliases }
-    const emailDefinition = (resolved.plugins as EmailDefinitionPlugin[])
-      .find(plugin => plugin.name === "@vite-hub/email/vite")
-      ?.api?.getDefinition?.()
+    const contributedAliases = Object.assign({}, ...(resolved.plugins as Array<Plugin & ViteHubProviderImportContributor>)
+      .map(plugin => plugin.vitehub?.providerOutput?.getImportAliases?.() ?? {}))
     return {
       ...resolveStringAliases(resolved),
-      ...(emailDefinition ? { "#vitehub/email/definition": emailDefinition.handler } : {}),
+      ...contributedAliases,
       ...internalOptions?.providerImportAliases,
     }
   }

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -6,10 +6,11 @@ import { getProviderRuntimeModule, shouldSkipViteProviderBuild, useComposedProvi
 import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import { normalizeWorkflowOptions } from "./config.ts"
-import { createCloudflareWorkflowNitroConfig, generateProviderOutputs, hasVercelNativeWorkflowEntry, workflowPackageName, writeProviderEntries } from "./internal/vite-build.ts"
+import { createCloudflareWorkflowNitroConfig, createVercelWorkflowTransformPlugin, generateProviderOutputs, hasVercelNativeWorkflowEntry, workflowPackageName, writeProviderEntries } from "./internal/vite-build.ts"
 
 import type { WorkflowModuleOptions } from "./types.ts"
 import type { ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
+import type { Plugin as EsbuildPlugin } from "esbuild"
 import type { Plugin, ResolvedConfig } from "vite"
 
 interface WorkflowNitroConfigOptions {
@@ -25,6 +26,7 @@ export type WorkflowVitePlugin = Plugin & {
       createNitroConfig?: (options: WorkflowNitroConfigOptions) => Promise<Record<string, unknown>>
       prepareScheduleRuntime?: () => Promise<{
         bundleAlias: Record<string, string>
+        bundlePlugins?: EsbuildPlugin[]
         importBase: string
         native: boolean
         registryFile: string
@@ -97,8 +99,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
       workspaceDependencies: internalOptions?.workspaceDependencyRuntimeImports,
     }, serverDirs, internalOptions?.includeUserAppEntry, (resolved.plugins as AgentWorkflowRegistryPlugin[])
       .find(plugin => plugin.vitehub?.agent?.transformWorkflowRegistry)
-      ?.vitehub?.agent?.transformWorkflowRegistry)
-    if (!artifacts.providerDefinitions.length) return
+      ?.vitehub?.agent?.transformWorkflowRegistry, resolved.root)
     const importBase = internalOptions?.importBase ?? workflowPackageName
     const projectRequire = createRequire(resolve(rootDir, "package.json"))
     const native = hasVercelNativeWorkflowEntry(rootDir, artifacts.providerDefinitions, providerImportAliases(), artifacts.vercelNativeFile ? [artifacts.vercelNativeFile] : [])
@@ -116,6 +117,9 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
             }
           : {}),
       },
+      ...(native
+        ? { bundlePlugins: [await createVercelWorkflowTransformPlugin(rootDir)].filter((plugin): plugin is EsbuildPlugin => Boolean(plugin)) }
+        : {}),
       importBase,
       native,
       registryFile: artifacts.registryFile,
@@ -174,6 +178,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
           vercel: providerRuntimeImportAliases("vercel"),
         },
         rootDir: resolveViteHubProjectRoot(resolved.root),
+        definitionRootDir: resolved.root,
         serverDirs,
         serverFunctionName: resolveNitroVercelFunctionName(resolved, "workflow"),
         includeUserAppEntry: internalOptions?.includeUserAppEntry,

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -102,7 +102,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
       ?.vitehub?.agent?.transformWorkflowRegistry, resolved.root)
     const importBase = internalOptions?.importBase ?? workflowPackageName
     const projectRequire = createRequire(resolve(resolved.root, "package.json"))
-    const native = hasVercelNativeWorkflowEntry(rootDir, artifacts.providerDefinitions, providerImportAliases(), artifacts.vercelNativeFile ? [artifacts.vercelNativeFile] : [])
+    const native = hasVercelNativeWorkflowEntry(rootDir, artifacts.providerDefinitions, providerImportAliases(), artifacts.vercelNativeFiles)
     const workflowRequire = native ? createRequire(import.meta.url) : undefined
     const workflowApi = workflowRequire?.resolve("workflow/api")
     return {

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path"
 
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { getProviderRuntimeModule, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
+import { collectViteHubProviderImportAliases, createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import { normalizeWorkflowOptions } from "./config.ts"
 import { createCloudflareWorkflowNitroConfig, createOptionalViteDevtoolsPlugin, createVercelWorkflowTransformPlugin, generateProviderOutputs, hasVercelNativeWorkflowEntry, workflowPackageName, writeProviderEntries } from "./internal/vite-build.ts"
@@ -83,8 +83,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
 
   async function providerImportAliases(): Promise<Record<string, string>> {
     if (!resolved) return { ...internalOptions?.providerImportAliases }
-    const contributedAliases = Object.assign({}, ...await Promise.all((resolved.plugins as Array<Plugin & ViteHubProviderImportContributor>)
-      .map(async plugin => await plugin.vitehub?.providerOutput?.getImportAliases?.() ?? {})))
+    const contributedAliases = await collectViteHubProviderImportAliases(resolved.plugins as Array<Plugin & ViteHubProviderImportContributor>)
     return {
       ...resolveStringAliases(resolved),
       ...contributedAliases,

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -26,6 +26,7 @@ export type WorkflowVitePlugin = Plugin & {
       prepareScheduleRuntime?: () => Promise<{
         bundleAlias: Record<string, string>
         importBase: string
+        native: boolean
         registryFile: string
       } | undefined>
     }
@@ -105,17 +106,22 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
     if (!artifacts.providerDefinitions.length) return
     const importBase = internalOptions?.importBase ?? workflowPackageName
     const projectRequire = createRequire(resolve(rootDir, "package.json"))
-    const workflowRequire = createRequire(import.meta.url)
-    const workflowApi = workflowRequire.resolve("workflow/api")
+    const workflowRequire = artifacts.vercelNativeFile ? createRequire(import.meta.url) : undefined
+    const workflowApi = workflowRequire?.resolve("workflow/api")
     return {
       bundleAlias: {
         [`${importBase}/runtime/state`]: projectRequire.resolve(`${importBase}/runtime/state`),
         [`${importBase}/runtime/vercel-vite`]: projectRequire.resolve(`${importBase}/runtime/vercel-vite`),
-        "@workflow/core/runtime/world-target": createRequire(workflowApi).resolve("@workflow/world-vercel"),
-        "workflow/api": workflowApi,
-        "workflow/runtime": workflowRequire.resolve("workflow/runtime"),
+        ...(workflowApi && workflowRequire
+          ? {
+              "@workflow/core/runtime/world-target": createRequire(workflowApi).resolve("@workflow/world-vercel"),
+              "workflow/api": workflowApi,
+              "workflow/runtime": workflowRequire.resolve("workflow/runtime"),
+            }
+          : {}),
       },
       importBase,
+      native: Boolean(artifacts.vercelNativeFile),
       registryFile: artifacts.registryFile,
     }
   }

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -6,7 +6,7 @@ import { getProviderRuntimeModule, shouldSkipViteProviderBuild, useComposedProvi
 import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import { normalizeWorkflowOptions } from "./config.ts"
-import { createCloudflareWorkflowNitroConfig, generateProviderOutputs, workflowPackageName, writeProviderEntries } from "./internal/vite-build.ts"
+import { createCloudflareWorkflowNitroConfig, generateProviderOutputs, hasVercelNativeWorkflowEntry, workflowPackageName, writeProviderEntries } from "./internal/vite-build.ts"
 
 import type { WorkflowModuleOptions } from "./types.ts"
 import type { ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
@@ -106,7 +106,8 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
     if (!artifacts.providerDefinitions.length) return
     const importBase = internalOptions?.importBase ?? workflowPackageName
     const projectRequire = createRequire(resolve(rootDir, "package.json"))
-    const workflowRequire = artifacts.vercelNativeFile ? createRequire(import.meta.url) : undefined
+    const native = hasVercelNativeWorkflowEntry(rootDir, artifacts.providerDefinitions, providerImportAliases(), artifacts.vercelNativeFile ? [artifacts.vercelNativeFile] : [])
+    const workflowRequire = native ? createRequire(import.meta.url) : undefined
     const workflowApi = workflowRequire?.resolve("workflow/api")
     return {
       bundleAlias: {
@@ -121,7 +122,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
           : {}),
       },
       importBase,
-      native: Boolean(artifacts.vercelNativeFile),
+      native,
       registryFile: artifacts.registryFile,
     }
   }

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -80,15 +80,10 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
 
   function providerImportAliases(): Record<string, string> {
     if (!resolved) return { ...internalOptions?.providerImportAliases }
-    const aliases = {
+    return {
       ...resolveStringAliases(resolved),
       ...internalOptions?.providerImportAliases,
     }
-    const emailDefinition = (resolved.plugins as Array<Plugin & {
-      api?: { getDefinition?: () => { handler?: string } }
-    }>).find(plugin => plugin.name === "@vite-hub/email/vite")?.api?.getDefinition?.()?.handler
-    if (emailDefinition) aliases["#vitehub/email/definition"] = emailDefinition
-    return aliases
   }
 
   async function prepareScheduleRuntime() {
@@ -102,7 +97,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
       workspaceDependencies: internalOptions?.workspaceDependencyRuntimeImports,
     }, serverDirs, internalOptions?.includeUserAppEntry, (resolved.plugins as AgentWorkflowRegistryPlugin[])
       .find(plugin => plugin.vitehub?.agent?.transformWorkflowRegistry)
-      ?.vitehub?.agent?.transformWorkflowRegistry, providerImportAliases())
+      ?.vitehub?.agent?.transformWorkflowRegistry)
     if (!artifacts.providerDefinitions.length) return
     const importBase = internalOptions?.importBase ?? workflowPackageName
     const projectRequire = createRequire(resolve(rootDir, "package.json"))

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -101,7 +101,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
       .find(plugin => plugin.vitehub?.agent?.transformWorkflowRegistry)
       ?.vitehub?.agent?.transformWorkflowRegistry, resolved.root)
     const importBase = internalOptions?.importBase ?? workflowPackageName
-    const projectRequire = createRequire(resolve(rootDir, "package.json"))
+    const projectRequire = createRequire(resolve(resolved.root, "package.json"))
     const native = hasVercelNativeWorkflowEntry(rootDir, artifacts.providerDefinitions, providerImportAliases(), artifacts.vercelNativeFile ? [artifacts.vercelNativeFile] : [])
     const workflowRequire = native ? createRequire(import.meta.url) : undefined
     const workflowApi = workflowRequire?.resolve("workflow/api")
@@ -170,7 +170,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
       }
       await generateProviderOutputs({
         agentImportBase: internalOptions?.agentImportBase,
-        clientOutDir: resolved.build.outDir,
+        clientOutDir: resolve(resolved.root, resolved.build.outDir),
         importBase: internalOptions?.importBase,
         providerImportAliases: providerImportAliases(),
         providerRuntimeImportAliases: {

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -1,8 +1,12 @@
+import { createRequire } from "node:module"
+import { resolve } from "node:path"
+
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { getProviderRuntimeModule, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
-import { createCloudflareWorkflowNitroConfig, generateProviderOutputs, workflowPackageName } from "./internal/vite-build.ts"
+import { normalizeWorkflowOptions } from "./config.ts"
+import { createCloudflareWorkflowNitroConfig, generateProviderOutputs, workflowPackageName, writeProviderEntries } from "./internal/vite-build.ts"
 
 import type { WorkflowModuleOptions } from "./types.ts"
 import type { ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
@@ -19,6 +23,11 @@ export type WorkflowVitePlugin = Plugin & {
   vitehub?: {
     workflow?: {
       createNitroConfig?: (options: WorkflowNitroConfigOptions) => Promise<Record<string, unknown>>
+      prepareScheduleRuntime?: () => Promise<{
+        bundleAlias: Record<string, string>
+        importBase: string
+        registryFile: string
+      } | undefined>
     }
   }
 }
@@ -68,6 +77,49 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
     return database ? { "@vite-hub/database/drizzle": database } : {}
   }
 
+  function providerImportAliases(): Record<string, string> {
+    if (!resolved) return { ...internalOptions?.providerImportAliases }
+    const aliases = {
+      ...resolveStringAliases(resolved),
+      ...internalOptions?.providerImportAliases,
+    }
+    const emailDefinition = (resolved.plugins as Array<Plugin & {
+      api?: { getDefinition?: () => { handler?: string } }
+    }>).find(plugin => plugin.name === "@vite-hub/email/vite")?.api?.getDefinition?.()?.handler
+    if (emailDefinition) aliases["#vitehub/email/definition"] = emailDefinition
+    return aliases
+  }
+
+  async function prepareScheduleRuntime() {
+    if (!resolved) throw new Error("[vitehub] Workflow runtime preparation requires resolved Vite config.")
+    if (normalizeWorkflowOptions(workflow, { hosting: "vercel" })?.provider !== "vercel") return
+    const rootDir = resolveViteHubProjectRoot(resolved.root)
+    const artifacts = await writeProviderEntries(rootDir, workflow, {
+      agent: internalOptions?.agentImportBase,
+      workflow: internalOptions?.importBase,
+      workspace: internalOptions?.workspaceImportBase,
+      workspaceDependencies: internalOptions?.workspaceDependencyRuntimeImports,
+    }, serverDirs, internalOptions?.includeUserAppEntry, (resolved.plugins as AgentWorkflowRegistryPlugin[])
+      .find(plugin => plugin.vitehub?.agent?.transformWorkflowRegistry)
+      ?.vitehub?.agent?.transformWorkflowRegistry, providerImportAliases())
+    if (!artifacts.providerDefinitions.length) return
+    const importBase = internalOptions?.importBase ?? workflowPackageName
+    const projectRequire = createRequire(resolve(rootDir, "package.json"))
+    const workflowRequire = createRequire(import.meta.url)
+    const workflowApi = workflowRequire.resolve("workflow/api")
+    return {
+      bundleAlias: {
+        [`${importBase}/runtime/state`]: projectRequire.resolve(`${importBase}/runtime/state`),
+        [`${importBase}/runtime/vercel-vite`]: projectRequire.resolve(`${importBase}/runtime/vercel-vite`),
+        "@workflow/core/runtime/world-target": createRequire(workflowApi).resolve("@workflow/world-vercel"),
+        "workflow/api": workflowApi,
+        "workflow/runtime": workflowRequire.resolve("workflow/runtime"),
+      },
+      importBase,
+      registryFile: artifacts.registryFile,
+    }
+  }
+
   return {
     name: "@vite-hub/workflow/vite",
     config(config) {
@@ -103,6 +155,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
             transformRegistry,
           })
         },
+        prepareScheduleRuntime,
       },
     },
     async closeBundle() {
@@ -113,15 +166,12 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
         agentImportBase: internalOptions?.agentImportBase,
         clientOutDir: resolved.build.outDir,
         importBase: internalOptions?.importBase,
-        providerImportAliases: {
-          ...resolveStringAliases(resolved),
-          ...internalOptions?.providerImportAliases,
-        },
+        providerImportAliases: providerImportAliases(),
         providerRuntimeImportAliases: {
           cloudflare: providerRuntimeImportAliases("cloudflare"),
           vercel: providerRuntimeImportAliases("vercel"),
         },
-        rootDir: resolved.root,
+        rootDir: resolveViteHubProjectRoot(resolved.root),
         serverDirs,
         serverFunctionName: resolveNitroVercelFunctionName(resolved, "workflow"),
         includeUserAppEntry: internalOptions?.includeUserAppEntry,

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -6,7 +6,7 @@ import { getProviderRuntimeModule, shouldSkipViteProviderBuild, useComposedProvi
 import { createNoExternalMerger, isServerEnvironment, resolveNitroVercelFunctionName, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import { normalizeWorkflowOptions } from "./config.ts"
-import { createCloudflareWorkflowNitroConfig, createVercelWorkflowTransformPlugin, generateProviderOutputs, hasVercelNativeWorkflowEntry, workflowPackageName, writeProviderEntries } from "./internal/vite-build.ts"
+import { createCloudflareWorkflowNitroConfig, createOptionalViteDevtoolsPlugin, createVercelWorkflowTransformPlugin, generateProviderOutputs, hasVercelNativeWorkflowEntry, workflowPackageName, writeProviderEntries } from "./internal/vite-build.ts"
 
 import type { WorkflowModuleOptions } from "./types.ts"
 import type { ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
@@ -117,9 +117,10 @@ export function hubWorkflow(options?: WorkflowModuleOptions): WorkflowVitePlugin
             }
           : {}),
       },
-      ...(native
-        ? { bundlePlugins: [await createVercelWorkflowTransformPlugin(rootDir)].filter((plugin): plugin is EsbuildPlugin => Boolean(plugin)) }
-        : {}),
+      bundlePlugins: [
+        createOptionalViteDevtoolsPlugin(rootDir),
+        ...(native ? [await createVercelWorkflowTransformPlugin(rootDir)] : []),
+      ].filter((plugin): plugin is EsbuildPlugin => Boolean(plugin)),
       importBase,
       native,
       registryFile: artifacts.registryFile,

--- a/packages/workflow/test/config.test.ts
+++ b/packages/workflow/test/config.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest"
 import { normalizeWorkflowOptions } from "../src/config.ts"
 import { createCloudflareWorkflowBindings, getCloudflareWorkflowBindingName, getCloudflareWorkflowClassName, getCloudflareWorkflowName } from "../src/integrations/cloudflare.ts"
 import { getVercelWorkflowName } from "../src/integrations/vercel.ts"
+import { hubWorkflow } from "../src/vite.ts"
 
 describe("workflow config", () => {
   it("infers cloudflare from hosting", () => {
@@ -90,6 +91,13 @@ describe("workflow config", () => {
     expect(normalizeWorkflowOptions({}, { hosting: "docker" })).toEqual({
       provider: "vercel",
     })
+  })
+
+  it("does not prepare a Vercel schedule runtime for Cloudflare workflows", async () => {
+    const plugin = hubWorkflow({ provider: "cloudflare" })
+    ;(plugin.configResolved as (config: unknown) => void)({ root: "/unused" })
+
+    await expect(plugin.vitehub?.workflow?.prepareScheduleRuntime?.()).resolves.toBeUndefined()
   })
 
   it("rejects invalid openworkflow options", () => {

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -236,8 +236,13 @@ describe("Vite workflow provider outputs", () => {
     const viteConfig = join(rootDir, "vite.config.ts")
     await writeFile(viteConfig, (await readFile(viteConfig, "utf8"))
       .replace("const baseConfig = {", `const baseConfig = {\n    resolve: { alias: { "@": resolve(import.meta.dirname, ".") } },`)
-      .replace("plugins: [hubMarkdownTemplate(), hubWorkflow()],", `plugins: [hubMarkdownTemplate(), hubWorkflow(), { name: "nitro:main", config() {} }],`)
+      .replace("plugins: [hubMarkdownTemplate(), hubWorkflow()],", `plugins: [hubMarkdownTemplate(), { name: "@vite-hub/email/vite", api: { getDefinition: () => ({ handler: resolve(import.meta.dirname, "server/email.ts") }) } }, hubWorkflow(), { name: "nitro:main", config() {} }],`)
       .replaceAll("workflow: {},", "workflow: { provider: \"vercel\" },"))
+    const generatedWorkflowDir = join(rootDir, "server", "workflows", "monthly-recap")
+    await mkdir(generatedWorkflowDir, { recursive: true })
+    await writeFile(join(rootDir, "server", "email.ts"), "export default { driver: () => ({ send: async () => ({}) }) }\n")
+    await writeFile(join(generatedWorkflowDir, "01-collect.ts"), "export default async function collect(input) { return { ...input, collected: true } }\n")
+    await writeFile(join(generatedWorkflowDir, "02-send.ts"), "import { email } from '@vite-hub/email/server'\nexport default async function send(input) { await email.send(input); return input }\n")
     await writeFile(join(rootDir, "server", "workflows", "durable.ts"), [
       `export async function durable() {`,
       `  "use workflow"`,
@@ -257,8 +262,18 @@ describe("Vite workflow provider outputs", () => {
 
     expect(existsSync(join(rootDir, "dist", "vite"))).toBe(false)
     expect(existsSync(join(rootDir, ".vercel", "output", "config.json"))).toBe(true)
+    const generatedNative = await readFile(join(rootDir, ".vitehub", "workflow", "vercel-native.mjs"), "utf8")
+    expect(generatedNative).toContain('"use workflow"')
+    expect(generatedNative).toContain('"use step"')
+    expect(generatedNative).toContain('globalThis[Symbol.for("vitehub.email.definition")] = viteHubEmailDefinition')
+    const registry = await readFile(join(rootDir, ".vitehub", "workflow", "registry.mjs"), "utf8")
+    const nativeExport = `${getCloudflareWorkflowClassName("monthly-recap")}Native`
+    expect(registry).toContain(nativeExport)
+    expect(registry).toContain(`workflow//./.vitehub/workflow/vercel-native//${nativeExport}`)
     expect(await readFile(join(rootDir, ".vercel", "output", "functions", "__workflow.func", "index.mjs"), "utf8")).toContain("workflowId")
     expect(existsSync(join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs"))).toBe(true)
+    const combinedFlow = await readFile(join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs"), "utf8")
+    expect(combinedFlow).toMatch(/globalThis\[(?:\/\*.*?\*\/\s*)?Symbol\.for\(["']vitehub\.email\.definition["']\)\]\s*=/)
     expect(existsSync(join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "webhook", "[token].func", "index.mjs"))).toBe(true)
     expect(await readFile(join(rootDir, ".vercel", "output", "config.json"), "utf8")).toContain("/.well-known/workflow/v1/webhook/")
   }, buildOutputTestTimeout)

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { existsSync } from "node:fs"
 import { cp, mkdir, mkdtemp, readdir, readFile, realpath, rm, stat, symlink, writeFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
@@ -14,6 +15,18 @@ const playgroundDir = resolve(import.meta.dirname, "../../../playground/vite")
 const buildOutputTestTimeout = 60_000
 const tempNodeModuleBuildDirs = new Set([".vite-temp"])
 const tempDirs: string[] = []
+
+async function writeViteHubWorkflowOwnership(workflowRoot: string, files: string[], routes: unknown[]) {
+  const ownership = {
+    files: Object.fromEntries(await Promise.all(files.map(async file => [
+      file,
+      createHash("sha256").update(await readFile(join(workflowRoot, file))).digest("hex"),
+    ]))),
+    routes: routes.map(route => JSON.stringify(route)),
+    version: 1,
+  }
+  await writeFile(join(workflowRoot, ".vitehub-owned"), `${JSON.stringify(ownership)}\n`)
+}
 
 it("detects user-authored native Vercel workflow entries", async () => {
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-native-entry-")
@@ -76,16 +89,77 @@ it("removes stale WDK functions and routes", async () => {
   const configFile = join(rootDir, ".vercel", "output", "config.json")
   await mkdir(workflowRoot, { recursive: true })
   await writeFile(join(workflowRoot, "stale.mjs"), "stale\n")
-  await writeFile(join(workflowRoot, ".vitehub-owned"), "\n")
-  await writeFile(configFile, `${JSON.stringify({ routes: [
-    { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" },
-    { src: "/user", dest: "/user" },
-  ] })}\n`)
+  const workflowRoute = { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" }
+  const userRoute = { src: "/user", dest: "/user" }
+  await writeViteHubWorkflowOwnership(workflowRoot, ["stale.mjs"], [workflowRoute])
+  await writeFile(configFile, `${JSON.stringify({ routes: [workflowRoute, userRoute] })}\n`)
 
   await cleanVercelNativeWorkflowOutput(rootDir)
 
   expect(existsSync(workflowRoot)).toBe(false)
   expect(JSON.parse(await readFile(configFile, "utf8")).routes).toEqual([{ src: "/user", dest: "/user" }])
+})
+
+it("preserves WDK output that replaced a prior ViteHub build", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-replaced-wdk-")
+  const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
+  const configFile = join(rootDir, ".vercel", "output", "config.json")
+  const workflowRoute = { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" }
+  await mkdir(workflowRoot, { recursive: true })
+  await writeFile(join(workflowRoot, "v1.mjs"), "vitehub\n")
+  await writeFile(join(workflowRoot, "package.json"), "{}\n")
+  await writeViteHubWorkflowOwnership(workflowRoot, ["v1.mjs", "package.json"], [workflowRoute])
+  await writeFile(join(workflowRoot, "v1.mjs"), "external replacement\n")
+  await writeFile(join(workflowRoot, "external.mjs"), "external\n")
+  await writeFile(configFile, `${JSON.stringify({ routes: [workflowRoute] })}\n`)
+
+  await cleanVercelNativeWorkflowOutput(rootDir)
+
+  await expect(readFile(join(workflowRoot, "v1.mjs"), "utf8")).resolves.toBe("external replacement\n")
+  await expect(readFile(join(workflowRoot, "package.json"), "utf8")).resolves.toBe("{}\n")
+  await expect(readFile(join(workflowRoot, "external.mjs"), "utf8")).resolves.toBe("external\n")
+  expect(JSON.parse(await readFile(configFile, "utf8")).routes).toEqual([workflowRoute])
+  expect(existsSync(join(workflowRoot, ".vitehub-owned"))).toBe(false)
+})
+
+it("preserves the owned output unit when an external build removes one file", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-partial-wdk-")
+  const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
+  const configFile = join(rootDir, ".vercel", "output", "config.json")
+  const workflowRoute = { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" }
+  await mkdir(workflowRoot, { recursive: true })
+  await writeFile(join(workflowRoot, "flow.mjs"), "flow\n")
+  await writeFile(join(workflowRoot, "package.json"), "{}\n")
+  await writeViteHubWorkflowOwnership(workflowRoot, ["flow.mjs", "package.json"], [workflowRoute])
+  await rm(join(workflowRoot, "flow.mjs"))
+  await writeFile(configFile, `${JSON.stringify({ routes: [workflowRoute] })}\n`)
+
+  await cleanVercelNativeWorkflowOutput(rootDir)
+
+  await expect(readFile(join(workflowRoot, "package.json"), "utf8")).resolves.toBe("{}\n")
+  expect(JSON.parse(await readFile(configFile, "utf8")).routes).toEqual([workflowRoute])
+  expect(existsSync(join(workflowRoot, ".vitehub-owned"))).toBe(false)
+})
+
+it("retries route cleanup after an interrupted owned-output cleanup", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-retry-cleanup-")
+  const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
+  const configFile = join(rootDir, ".vercel", "output", "config.json")
+  const workflowRoute = { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" }
+  await mkdir(workflowRoot, { recursive: true })
+  await writeFile(join(workflowRoot, "v1.mjs"), "vitehub\n")
+  await writeViteHubWorkflowOwnership(workflowRoot, ["v1.mjs"], [workflowRoute])
+  await writeFile(configFile, "invalid json\n")
+
+  await expect(cleanVercelNativeWorkflowOutput(rootDir)).rejects.toThrow()
+  expect(existsSync(join(workflowRoot, "v1.mjs"))).toBe(false)
+  expect(existsSync(join(workflowRoot, ".vitehub-owned"))).toBe(true)
+
+  await writeFile(configFile, `${JSON.stringify({ routes: [workflowRoute] })}\n`)
+  await cleanVercelNativeWorkflowOutput(rootDir)
+
+  expect(existsSync(workflowRoot)).toBe(false)
+  expect(JSON.parse(await readFile(configFile, "utf8")).routes).toEqual([])
 })
 
 it("preserves Workflow DevKit output not owned by ViteHub", async () => {
@@ -100,7 +174,41 @@ it("preserves Workflow DevKit output not owned by ViteHub", async () => {
   await cleanVercelNativeWorkflowOutput(rootDir)
 
   await expect(readFile(join(workflowRoot, "external.mjs"), "utf8")).resolves.toBe("external\n")
-  expect(JSON.parse(await readFile(configFile, "utf8")).routes).toEqual([externalRoute])
+  expect(JSON.parse(await readFile(configFile, "utf8")).routes).toContainEqual(externalRoute)
+})
+
+it("does not claim unowned WDK output during native generation", { timeout: buildOutputTestTimeout }, async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-generate-with-unowned-wdk-")
+  const workflowDir = join(rootDir, "server", "workflows", "recap")
+  const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
+  const configFile = join(rootDir, ".vercel", "output", "config.json")
+  const externalRoute = { src: "/.well-known/workflow/v1/external", dest: "/.well-known/workflow/v1/external" }
+  await mkdir(workflowDir, { recursive: true })
+  await mkdir(workflowRoot, { recursive: true })
+  await writeFile(join(workflowDir, "01-collect.ts"), "export default async function collect(input) { return input }\n")
+  await writeFile(join(workflowRoot, "external.mjs"), "previous ViteHub output\n")
+  await writeViteHubWorkflowOwnership(workflowRoot, ["external.mjs"], [])
+  await writeFile(join(workflowRoot, "external.mjs"), "external\n")
+  await mkdir(resolve(configFile, ".."), { recursive: true })
+  await writeFile(configFile, `${JSON.stringify({ routes: [externalRoute] })}\n`)
+
+  await generateProviderOutputs({
+    clientOutDir: join(rootDir, "dist"),
+    importBase: "@vite-hub/workflow",
+    rootDir,
+    workflow: { provider: "vercel" },
+  })
+
+  const ownership = JSON.parse(await readFile(join(workflowRoot, ".vitehub-owned"), "utf8"))
+  expect(ownership.files).not.toHaveProperty("external.mjs")
+  expect(ownership.routes).not.toContain(JSON.stringify(externalRoute))
+  await expect(readFile(join(workflowRoot, "external.mjs"), "utf8")).resolves.toBe("external\n")
+  expect(JSON.parse(await readFile(configFile, "utf8")).routes).toContainEqual(externalRoute)
+
+  await cleanVercelNativeWorkflowOutput(rootDir)
+
+  await expect(readFile(join(workflowRoot, "external.mjs"), "utf8")).resolves.toBe("external\n")
+  expect(JSON.parse(await readFile(configFile, "utf8")).routes).toContainEqual(externalRoute)
 })
 
 it("removes stale WDK output when the Vercel provider is disabled", async () => {
@@ -109,11 +217,10 @@ it("removes stale WDK output when the Vercel provider is disabled", async () => 
   const configFile = join(rootDir, ".vercel", "output", "config.json")
   await mkdir(workflowRoot, { recursive: true })
   await writeFile(join(workflowRoot, "stale.mjs"), "stale\n")
-  await writeFile(join(workflowRoot, ".vitehub-owned"), "\n")
-  await writeFile(configFile, `${JSON.stringify({ routes: [
-    { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" },
-    { src: "/user", dest: "/user" },
-  ] })}\n`)
+  const workflowRoute = { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" }
+  const userRoute = { src: "/user", dest: "/user" }
+  await writeViteHubWorkflowOwnership(workflowRoot, ["stale.mjs"], [workflowRoute])
+  await writeFile(configFile, `${JSON.stringify({ routes: [workflowRoute, userRoute] })}\n`)
 
   await generateProviderOutputs({
     clientOutDir: join(rootDir, "dist"),

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -108,6 +108,33 @@ it("removes stale WDK output when the Vercel provider is disabled", async () => 
   expect(JSON.parse(await readFile(configFile, "utf8")).routes).toEqual([{ src: "/user", dest: "/user" }])
 })
 
+it("serializes native Vercel generation with disabled-provider cleanup", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-concurrent-cleanup-")
+  const workflowDir = join(rootDir, "server", "workflows", "recap")
+  await mkdir(workflowDir, { recursive: true })
+  await writeFile(join(workflowDir, "01-collect.ts"), "export default async function collect(input) { return input }\n")
+
+  await Promise.all([
+    generateProviderOutputs({
+      clientOutDir: join(rootDir, "dist"),
+      importBase: "@vite-hub/workflow",
+      rootDir,
+      workflow: { provider: "vercel" },
+    }),
+    generateProviderOutputs({
+      clientOutDir: join(rootDir, "dist"),
+      rootDir,
+      workflow: { provider: "openworkflow", sqlite: { path: ":memory:" } },
+    }),
+  ])
+
+  const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
+  const configFile = join(rootDir, ".vercel", "output", "config.json")
+  expect(existsSync(workflowRoot)).toBe(false)
+  const routes = JSON.parse(await readFile(configFile, "utf8")).routes ?? []
+  expect(routes.some((route: unknown) => JSON.stringify(route).includes("/.well-known/workflow/v1/"))).toBe(false)
+}, buildOutputTestTimeout)
+
 function resolvePlaygroundNodeModules() {
   const nodeModules = join(playgroundDir, "node_modules")
   return existsSync(nodeModules) ? nodeModules : resolve(playgroundDir, "../../node_modules")

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -59,6 +59,17 @@ it("ignores workflow directive examples in comments", async () => {
   expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(false)
 })
 
+it("ignores native entries imported only in comments", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-commented-native-import-")
+  const workflowFile = join(rootDir, "server", "workflows", "welcome.workflow.ts")
+  const nativeFile = join(rootDir, "server", "durable.ts")
+  await mkdir(join(rootDir, "server", "workflows"), { recursive: true })
+  await writeFile(workflowFile, `// import { durable } from "../durable.js"\nexport default defineWorkflow(async () => "inline")\n`)
+  await writeFile(nativeFile, `export async function durable() {\n  "use workflow"\n}\n`)
+
+  expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(false)
+})
+
 it("keeps suffix Workflow discovery relative to a nested Vite root", async () => {
   const projectRoot = await createWorkspaceTempDir("vitehub-workflow-project-root-")
   const viteRoot = join(projectRoot, "apps", "web")

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -70,6 +70,17 @@ it("ignores native entries imported only in comments", async () => {
   expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(false)
 })
 
+it("ignores unrelated native functions imported by inline workflows", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-unrelated-native-import-")
+  const workflowFile = join(rootDir, "server", "workflows", "welcome.workflow.ts")
+  const nativeFile = join(rootDir, "server", "workflows", "durable.ts")
+  await mkdir(join(rootDir, "server", "workflows"), { recursive: true })
+  await writeFile(workflowFile, `import "./durable.js"\nexport default defineWorkflow(async () => "inline")\n`)
+  await writeFile(nativeFile, `export async function durable() { "use workflow" }\n`)
+
+  expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(false)
+})
+
 it("keeps suffix Workflow discovery relative to a nested Vite root", async () => {
   const projectRoot = await createWorkspaceTempDir("vitehub-workflow-project-root-")
   const viteRoot = join(projectRoot, "apps", "web")

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -132,6 +132,34 @@ it("installs the Email definition when the WDK flow has only named exports", asy
   expect(combinedFlow).toMatch(/globalThis\[(?:\/\*.*?\*\/\s*)?Symbol\.for\(["']vitehub\.email\.definition["']\)\]\s*=/)
 })
 
+it("restores native output when Email installation fails", { timeout: buildOutputTestTimeout }, async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-email-rollback-")
+  const workflowDir = join(rootDir, "server", "workflows", "recap")
+  const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
+  const configFile = join(rootDir, ".vercel", "output", "config.json")
+  const externalFile = join(workflowRoot, "v1", "flow.func", "index.mjs")
+  const externalRoute = { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" }
+  await mkdir(workflowDir, { recursive: true })
+  await mkdir(resolve(externalFile, ".."), { recursive: true })
+  await writeFile(join(workflowDir, "01-collect.ts"), "export default async function collect(input) { return input }\n")
+  await writeFile(externalFile, "external flow\n")
+  await writeFile(configFile, `${JSON.stringify({ routes: [externalRoute] })}\n`)
+
+  await expect(generateProviderOutputs({
+    clientOutDir: join(rootDir, "dist"),
+    importBase: "@vite-hub/workflow",
+    providerImportAliases: { "#vitehub/email/definition": join(rootDir, "missing-email-definition.mjs") },
+    rootDir,
+    workflow: { provider: "vercel" },
+  })).rejects.toThrow()
+
+  await expect(readFile(externalFile, "utf8")).resolves.toBe("external flow\n")
+  const routes = JSON.parse(await readFile(configFile, "utf8")).routes
+  expect(routes).toContainEqual(externalRoute)
+  expect(routes.filter((route: unknown) => JSON.stringify(route).includes("/.well-known/workflow/v1/"))).toEqual([externalRoute])
+  expect(existsSync(join(workflowRoot, ".vitehub-owned"))).toBe(false)
+})
+
 it("removes stale WDK functions and routes", async () => {
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-clean-wdk-")
   const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -7,7 +7,7 @@ import { promisify } from "node:util"
 import { afterAll, describe, expect, it } from "vitest"
 
 import { getCloudflareWorkflowBindingName, getCloudflareWorkflowClassName, getCloudflareWorkflowName } from "../src/integrations/cloudflare.ts"
-import { hasVercelNativeWorkflowEntry, installEmailDefinitionInVercelWorkflowOutput } from "../src/internal/vite-build.ts"
+import { cleanVercelNativeWorkflowOutput, hasVercelNativeWorkflowEntry, installEmailDefinitionInVercelWorkflowOutput, writeProviderEntries } from "../src/internal/vite-build.ts"
 
 const execFileAsync = promisify(execFile)
 const playgroundDir = resolve(import.meta.dirname, "../../../playground/vite")
@@ -26,12 +26,25 @@ it("detects user-authored native Vercel workflow entries", async () => {
   expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(true)
 })
 
+it("keeps suffix Workflow discovery relative to a nested Vite root", async () => {
+  const projectRoot = await createWorkspaceTempDir("vitehub-workflow-project-root-")
+  const viteRoot = join(projectRoot, "apps", "web")
+  await mkdir(join(viteRoot, "src"), { recursive: true })
+  await mkdir(join(projectRoot, "apps", "sibling", "src"), { recursive: true })
+  await writeFile(join(viteRoot, "src", "cleanup.workflow.ts"), "export default defineWorkflow(async () => undefined)\n")
+  await writeFile(join(projectRoot, "apps", "sibling", "src", "noise.workflow.ts"), "export default defineWorkflow(async () => undefined)\n")
+
+  const artifacts = await writeProviderEntries(projectRoot, false, {}, undefined, false, undefined, viteRoot)
+
+  expect(artifacts.definitions.map(definition => definition.name)).toEqual(["cleanup"])
+})
+
 it("preserves WDK optional externals while installing the Email definition", async () => {
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-email-bootstrap-")
   const flowFile = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs")
   const emailDefinitionFile = join(rootDir, "email-definition.mjs")
   await mkdir(resolve(flowFile, ".."), { recursive: true })
-  await writeFile(flowFile, `import credentials from "@aws-sdk/credential-provider-web-identity"\nexport { credentials }\n`)
+  await writeFile(flowFile, `import credentials from "@aws-sdk/credential-provider-web-identity"\nexport { credentials }\nexport default async function handler() {}\n`)
   await writeFile(emailDefinitionFile, "export default { handler: async () => undefined }\n")
 
   await installEmailDefinitionInVercelWorkflowOutput(rootDir, emailDefinitionFile)
@@ -39,6 +52,24 @@ it("preserves WDK optional externals while installing the Email definition", asy
   const combinedFlow = await readFile(flowFile, "utf8")
   expect(combinedFlow).toContain("@aws-sdk/credential-provider-web-identity")
   expect(combinedFlow).toMatch(/globalThis\[(?:\/\*.*?\*\/\s*)?Symbol\.for\(["']vitehub\.email\.definition["']\)\]\s*=/)
+  expect(combinedFlow).toMatch(/export\s*\{[^}]*\s+as\s+default/)
+})
+
+it("removes stale WDK functions and routes", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-clean-wdk-")
+  const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
+  const configFile = join(rootDir, ".vercel", "output", "config.json")
+  await mkdir(workflowRoot, { recursive: true })
+  await writeFile(join(workflowRoot, "stale.mjs"), "stale\n")
+  await writeFile(configFile, `${JSON.stringify({ routes: [
+    { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" },
+    { src: "/user", dest: "/user" },
+  ] })}\n`)
+
+  await cleanVercelNativeWorkflowOutput(rootDir)
+
+  expect(existsSync(workflowRoot)).toBe(false)
+  expect(JSON.parse(await readFile(configFile, "utf8")).routes).toEqual([{ src: "/user", dest: "/user" }])
 })
 
 function resolvePlaygroundNodeModules() {
@@ -312,6 +343,7 @@ describe("Vite workflow provider outputs", () => {
     expect(existsSync(join(rootDir, ".vitehub", "workflow", "vercel-native.mjs"))).toBe(false)
     await expect(readFile(join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs"), "utf8"))
       .resolves.toMatch(/globalThis\[(?:\/\*.*?\*\/\s*)?Symbol\.for\(["']vitehub\.email\.definition["']\)\]\s*=/)
+
   }, buildOutputTestTimeout)
 
   it("rejects native Vercel entries outside discovered definition directories", async () => {

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -50,6 +50,15 @@ it("detects compact user-authored native Vercel workflow directives", async () =
   expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(true)
 })
 
+it("ignores workflow directive examples in comments", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-commented-native-entry-")
+  const workflowFile = join(rootDir, "server", "workflows", "welcome.workflow.ts")
+  await mkdir(join(rootDir, "server", "workflows"), { recursive: true })
+  await writeFile(workflowFile, `/*\n"use workflow"\n*/\nexport default defineWorkflow(async () => "inline")\n`)
+
+  expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(false)
+})
+
 it("keeps suffix Workflow discovery relative to a nested Vite root", async () => {
   const projectRoot = await createWorkspaceTempDir("vitehub-workflow-project-root-")
   const viteRoot = join(projectRoot, "apps", "web")

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -69,6 +69,38 @@ it("keeps generated native step imports scoped to each directory Workflow", asyn
   expect(nativeContents.every(contents => !(contents.includes("01-alpha.ts") && contents.includes("01-beta.ts")))).toBe(true)
 })
 
+it("keeps generated native module paths stable when discovery order changes", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-native-identity-")
+  const betaDir = join(rootDir, "server", "workflows", "beta")
+  await mkdir(betaDir, { recursive: true })
+  await writeFile(join(betaDir, "01-beta.ts"), "export default async function beta(input) { return input }\n")
+
+  const before = await writeProviderEntries(rootDir, { provider: "vercel" })
+  const [betaFile] = before.vercelNativeFiles
+
+  const alphaDir = join(rootDir, "server", "workflows", "alpha")
+  await mkdir(alphaDir, { recursive: true })
+  await writeFile(join(alphaDir, "01-alpha.ts"), "export default async function alpha(input) { return input }\n")
+  const after = await writeProviderEntries(rootDir, { provider: "vercel" })
+
+  expect(betaFile).toMatch(/\/vercel-native\/[a-f0-9]{64}\.mjs$/)
+  expect(after.vercelNativeFiles).toContain(betaFile)
+})
+
+it("keeps astral Unicode native module identities distinct", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-native-unicode-")
+  for (const name of ["😀", "😁"]) {
+    const workflowDir = join(rootDir, "server", "workflows", name)
+    await mkdir(workflowDir, { recursive: true })
+    await writeFile(join(workflowDir, "01-step.ts"), "export default async function step(input) { return input }\n")
+  }
+
+  const artifacts = await writeProviderEntries(rootDir, { provider: "vercel" })
+
+  expect(artifacts.vercelNativeFiles).toHaveLength(2)
+  expect(new Set(artifacts.vercelNativeFiles)).toHaveLength(2)
+})
+
 it("preserves WDK optional externals while installing the Email definition", async () => {
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-email-bootstrap-")
   const flowFile = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs")
@@ -531,7 +563,8 @@ describe("Vite workflow provider outputs", () => {
 
     expect(existsSync(join(rootDir, "dist", "vite"))).toBe(false)
     expect(existsSync(join(rootDir, ".vercel", "output", "config.json"))).toBe(true)
-    const generatedNative = await readFile(join(rootDir, ".vitehub", "workflow", "vercel-native", "0.mjs"), "utf8")
+    const [generatedNativeFile] = await readdir(join(rootDir, ".vitehub", "workflow", "vercel-native"))
+    const generatedNative = await readFile(join(rootDir, ".vitehub", "workflow", "vercel-native", generatedNativeFile), "utf8")
     expect(generatedNative).toContain('"use workflow"')
     expect(generatedNative).toContain('"use step"')
     expect(generatedNative).not.toContain("vitehub.email.definition")

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -248,7 +248,7 @@ describe("Vite workflow provider outputs", () => {
     const viteConfig = join(rootDir, "vite.config.ts")
     await writeFile(viteConfig, (await readFile(viteConfig, "utf8"))
       .replace("const baseConfig = {", `const baseConfig = {\n    resolve: { alias: { "@": resolve(import.meta.dirname, ".") } },`)
-      .replace("plugins: [hubMarkdownTemplate(), hubWorkflow()],", `plugins: [hubMarkdownTemplate(), { name: "@vite-hub/email/vite", api: { getDefinition: () => ({ handler: resolve(import.meta.dirname, "server/email.ts") }) } }, hubWorkflow(), { name: "nitro:main", config() {} }],`)
+      .replace("plugins: [hubMarkdownTemplate(), hubWorkflow()],", `plugins: [hubMarkdownTemplate(), { name: "email-definition-alias", config: () => ({ resolve: { alias: { "#vitehub/email/definition": resolve(import.meta.dirname, "server/email.ts") } } }) }, hubWorkflow(), { name: "nitro:main", config() {} }],`)
       .replaceAll("workflow: {},", "workflow: { provider: \"vercel\" },"))
     const generatedWorkflowDir = join(rootDir, "server", "workflows", "monthly-recap")
     await mkdir(generatedWorkflowDir, { recursive: true })
@@ -277,7 +277,7 @@ describe("Vite workflow provider outputs", () => {
     const generatedNative = await readFile(join(rootDir, ".vitehub", "workflow", "vercel-native.mjs"), "utf8")
     expect(generatedNative).toContain('"use workflow"')
     expect(generatedNative).toContain('"use step"')
-    expect(generatedNative).toContain('globalThis[Symbol.for("vitehub.email.definition")] = viteHubEmailDefinition')
+    expect(generatedNative).not.toContain("vitehub.email.definition")
     const registry = await readFile(join(rootDir, ".vitehub", "workflow", "registry.mjs"), "utf8")
     const nativeExport = `${getCloudflareWorkflowClassName("monthly-recap")}Native`
     expect(registry).toContain(nativeExport)
@@ -288,6 +288,15 @@ describe("Vite workflow provider outputs", () => {
     expect(combinedFlow).toMatch(/globalThis\[(?:\/\*.*?\*\/\s*)?Symbol\.for\(["']vitehub\.email\.definition["']\)\]\s*=/)
     expect(existsSync(join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "webhook", "[token].func", "index.mjs"))).toBe(true)
     expect(await readFile(join(rootDir, ".vercel", "output", "config.json"), "utf8")).toContain("/.well-known/workflow/v1/webhook/")
+
+    await rm(generatedWorkflowDir, { recursive: true })
+    await execFileAsync("vp", ["build"], {
+      cwd: rootDir,
+      env: { ...process.env, VITEHUB_HOSTING: "vercel", VITEHUB_VITE_MODE: "workflow" },
+    })
+    expect(existsSync(join(rootDir, ".vitehub", "workflow", "vercel-native.mjs"))).toBe(false)
+    await expect(readFile(join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs"), "utf8"))
+      .resolves.toMatch(/globalThis\[(?:\/\*.*?\*\/\s*)?Symbol\.for\(["']vitehub\.email\.definition["']\)\]\s*=/)
   }, buildOutputTestTimeout)
 
   it("rejects native Vercel entries outside discovered definition directories", async () => {

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -277,7 +277,7 @@ it("preserves Workflow DevKit output not owned by ViteHub", async () => {
   expect(JSON.parse(await readFile(configFile, "utf8")).routes).toContainEqual(externalRoute)
 })
 
-it("does not claim unowned WDK output during native generation", { timeout: buildOutputTestTimeout }, async () => {
+it("rejects native generation that would replace unowned canonical WDK output", { timeout: buildOutputTestTimeout }, async () => {
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-generate-with-unowned-wdk-")
   const workflowDir = join(rootDir, "server", "workflows", "recap")
   const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
@@ -296,26 +296,16 @@ it("does not claim unowned WDK output during native generation", { timeout: buil
   await mkdir(resolve(configFile, ".."), { recursive: true })
   await writeFile(configFile, `${JSON.stringify({ routes: [externalRoute, canonicalRoute] })}\n`)
 
-  await generateProviderOutputs({
+  await expect(generateProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     importBase: "@vite-hub/workflow",
     rootDir,
     workflow: { provider: "vercel" },
-  })
-
-  const ownership = JSON.parse(await readFile(join(workflowRoot, ".vitehub-owned"), "utf8"))
-  expect(ownership.files).not.toHaveProperty("external.mjs")
-  expect(ownership.routes).not.toContain(JSON.stringify(externalRoute))
-  expect(ownership.files).toHaveProperty("v1/webhook/[token].func/index.mjs")
-  expect(ownership.routes).toContain(JSON.stringify(canonicalRoute))
-  await expect(readFile(join(workflowRoot, "external.mjs"), "utf8")).resolves.toBe("external\n")
-  expect(JSON.parse(await readFile(configFile, "utf8")).routes).toContainEqual(externalRoute)
-
-  await cleanVercelNativeWorkflowOutput(rootDir)
+  })).rejects.toThrow(/conflicts with existing unowned Workflow DevKit functions/)
 
   await expect(readFile(join(workflowRoot, "external.mjs"), "utf8")).resolves.toBe("external\n")
-  expect(JSON.parse(await readFile(configFile, "utf8")).routes).toContainEqual(externalRoute)
-  expect(JSON.parse(await readFile(configFile, "utf8")).routes).not.toContainEqual(canonicalRoute)
+  await expect(readFile(canonicalFlow, "utf8")).resolves.toBe("external canonical flow\n")
+  expect(JSON.parse(await readFile(configFile, "utf8")).routes).toEqual([externalRoute, canonicalRoute])
 })
 
 it("removes stale WDK output when the Vercel provider is disabled", async () => {

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -52,6 +52,23 @@ it("keeps suffix Workflow discovery relative to a nested Vite root", async () =>
   expect(artifacts.definitions.map(definition => definition.name)).toEqual(["cleanup"])
 })
 
+it("keeps generated native step imports scoped to each directory Workflow", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-native-isolation-")
+  for (const name of ["alpha", "beta"]) {
+    const workflowDir = join(rootDir, "server", "workflows", name)
+    await mkdir(workflowDir, { recursive: true })
+    await writeFile(join(workflowDir, `01-${name}.ts`), `export default async function ${name}(input) { return input }\n`)
+  }
+
+  const artifacts = await writeProviderEntries(rootDir, { provider: "vercel" })
+  const nativeContents = await Promise.all(artifacts.vercelNativeFiles.map(file => readFile(file, "utf8")))
+
+  expect(nativeContents).toHaveLength(2)
+  expect(nativeContents.filter(contents => contents.includes("01-alpha.ts"))).toHaveLength(1)
+  expect(nativeContents.filter(contents => contents.includes("01-beta.ts"))).toHaveLength(1)
+  expect(nativeContents.every(contents => !(contents.includes("01-alpha.ts") && contents.includes("01-beta.ts")))).toBe(true)
+})
+
 it("preserves WDK optional externals while installing the Email definition", async () => {
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-email-bootstrap-")
   const flowFile = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs")
@@ -183,8 +200,8 @@ it("does not claim unowned WDK output during native generation", { timeout: buil
   const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
   const configFile = join(rootDir, ".vercel", "output", "config.json")
   const externalRoute = { src: "/.well-known/workflow/v1/external", dest: "/.well-known/workflow/v1/external" }
-  const canonicalRoute = { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" }
-  const canonicalFlow = join(workflowRoot, "v1", "flow.func", "index.mjs")
+  const canonicalRoute = { src: "/.well-known/workflow/v1/webhook/(?<token>.*)", dest: "/.well-known/workflow/v1/webhook/[token]" }
+  const canonicalFlow = join(workflowRoot, "v1", "webhook", "[token].func", "index.mjs")
   await mkdir(workflowDir, { recursive: true })
   await mkdir(workflowRoot, { recursive: true })
   await mkdir(resolve(canonicalFlow, ".."), { recursive: true })
@@ -206,7 +223,7 @@ it("does not claim unowned WDK output during native generation", { timeout: buil
   const ownership = JSON.parse(await readFile(join(workflowRoot, ".vitehub-owned"), "utf8"))
   expect(ownership.files).not.toHaveProperty("external.mjs")
   expect(ownership.routes).not.toContain(JSON.stringify(externalRoute))
-  expect(ownership.files).toHaveProperty("v1/flow.func/index.mjs")
+  expect(ownership.files).toHaveProperty("v1/webhook/[token].func/index.mjs")
   expect(ownership.routes).toContain(JSON.stringify(canonicalRoute))
   await expect(readFile(join(workflowRoot, "external.mjs"), "utf8")).resolves.toBe("external\n")
   expect(JSON.parse(await readFile(configFile, "utf8")).routes).toContainEqual(externalRoute)
@@ -514,7 +531,7 @@ describe("Vite workflow provider outputs", () => {
 
     expect(existsSync(join(rootDir, "dist", "vite"))).toBe(false)
     expect(existsSync(join(rootDir, ".vercel", "output", "config.json"))).toBe(true)
-    const generatedNative = await readFile(join(rootDir, ".vitehub", "workflow", "vercel-native.mjs"), "utf8")
+    const generatedNative = await readFile(join(rootDir, ".vitehub", "workflow", "vercel-native", "0.mjs"), "utf8")
     expect(generatedNative).toContain('"use workflow"')
     expect(generatedNative).toContain('"use step"')
     expect(generatedNative).not.toContain("vitehub.email.definition")
@@ -534,7 +551,7 @@ describe("Vite workflow provider outputs", () => {
       cwd: rootDir,
       env: { ...process.env, VITEHUB_HOSTING: "vercel", VITEHUB_VITE_MODE: "workflow" },
     })
-    expect(existsSync(join(rootDir, ".vitehub", "workflow", "vercel-native.mjs"))).toBe(false)
+    expect(existsSync(join(rootDir, ".vitehub", "workflow", "vercel-native"))).toBe(false)
     await expect(readFile(join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs"), "utf8"))
       .resolves.toMatch(/globalThis\[(?:\/\*.*?\*\/\s*)?Symbol\.for\(["']vitehub\.email\.definition["']\)\]\s*=/)
     const rebuiltRoutes = JSON.parse(await readFile(join(rootDir, ".vercel", "output", "config.json"), "utf8")).routes as unknown[]

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -183,14 +183,18 @@ it("does not claim unowned WDK output during native generation", { timeout: buil
   const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
   const configFile = join(rootDir, ".vercel", "output", "config.json")
   const externalRoute = { src: "/.well-known/workflow/v1/external", dest: "/.well-known/workflow/v1/external" }
+  const canonicalRoute = { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" }
+  const canonicalFlow = join(workflowRoot, "v1", "flow.func", "index.mjs")
   await mkdir(workflowDir, { recursive: true })
   await mkdir(workflowRoot, { recursive: true })
+  await mkdir(resolve(canonicalFlow, ".."), { recursive: true })
   await writeFile(join(workflowDir, "01-collect.ts"), "export default async function collect(input) { return input }\n")
   await writeFile(join(workflowRoot, "external.mjs"), "previous ViteHub output\n")
   await writeViteHubWorkflowOwnership(workflowRoot, ["external.mjs"], [])
   await writeFile(join(workflowRoot, "external.mjs"), "external\n")
+  await writeFile(canonicalFlow, "external canonical flow\n")
   await mkdir(resolve(configFile, ".."), { recursive: true })
-  await writeFile(configFile, `${JSON.stringify({ routes: [externalRoute] })}\n`)
+  await writeFile(configFile, `${JSON.stringify({ routes: [externalRoute, canonicalRoute] })}\n`)
 
   await generateProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
@@ -202,6 +206,8 @@ it("does not claim unowned WDK output during native generation", { timeout: buil
   const ownership = JSON.parse(await readFile(join(workflowRoot, ".vitehub-owned"), "utf8"))
   expect(ownership.files).not.toHaveProperty("external.mjs")
   expect(ownership.routes).not.toContain(JSON.stringify(externalRoute))
+  expect(ownership.files).toHaveProperty("v1/flow.func/index.mjs")
+  expect(ownership.routes).toContain(JSON.stringify(canonicalRoute))
   await expect(readFile(join(workflowRoot, "external.mjs"), "utf8")).resolves.toBe("external\n")
   expect(JSON.parse(await readFile(configFile, "utf8")).routes).toContainEqual(externalRoute)
 
@@ -209,6 +215,7 @@ it("does not claim unowned WDK output during native generation", { timeout: buil
 
   await expect(readFile(join(workflowRoot, "external.mjs"), "utf8")).resolves.toBe("external\n")
   expect(JSON.parse(await readFile(configFile, "utf8")).routes).toContainEqual(externalRoute)
+  expect(JSON.parse(await readFile(configFile, "utf8")).routes).not.toContainEqual(canonicalRoute)
 })
 
 it("removes stale WDK output when the Vercel provider is disabled", async () => {

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -76,6 +76,7 @@ it("removes stale WDK functions and routes", async () => {
   const configFile = join(rootDir, ".vercel", "output", "config.json")
   await mkdir(workflowRoot, { recursive: true })
   await writeFile(join(workflowRoot, "stale.mjs"), "stale\n")
+  await writeFile(join(workflowRoot, ".vitehub-owned"), "\n")
   await writeFile(configFile, `${JSON.stringify({ routes: [
     { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" },
     { src: "/user", dest: "/user" },
@@ -87,12 +88,28 @@ it("removes stale WDK functions and routes", async () => {
   expect(JSON.parse(await readFile(configFile, "utf8")).routes).toEqual([{ src: "/user", dest: "/user" }])
 })
 
+it("preserves Workflow DevKit output not owned by ViteHub", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-unowned-wdk-")
+  const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
+  const configFile = join(rootDir, ".vercel", "output", "config.json")
+  const externalRoute = { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" }
+  await mkdir(workflowRoot, { recursive: true })
+  await writeFile(join(workflowRoot, "external.mjs"), "external\n")
+  await writeFile(configFile, `${JSON.stringify({ routes: [externalRoute] })}\n`)
+
+  await cleanVercelNativeWorkflowOutput(rootDir)
+
+  await expect(readFile(join(workflowRoot, "external.mjs"), "utf8")).resolves.toBe("external\n")
+  expect(JSON.parse(await readFile(configFile, "utf8")).routes).toEqual([externalRoute])
+})
+
 it("removes stale WDK output when the Vercel provider is disabled", async () => {
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-disable-vercel-")
   const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
   const configFile = join(rootDir, ".vercel", "output", "config.json")
   await mkdir(workflowRoot, { recursive: true })
   await writeFile(join(workflowRoot, "stale.mjs"), "stale\n")
+  await writeFile(join(workflowRoot, ".vitehub-owned"), "\n")
   await writeFile(configFile, `${JSON.stringify({ routes: [
     { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" },
     { src: "/user", dest: "/user" },

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -132,7 +132,7 @@ it("installs the Email definition when the WDK flow has only named exports", asy
   expect(combinedFlow).toMatch(/globalThis\[(?:\/\*.*?\*\/\s*)?Symbol\.for\(["']vitehub\.email\.definition["']\)\]\s*=/)
 })
 
-it("restores native output when Email installation fails", { timeout: buildOutputTestTimeout }, async () => {
+it("restores prior owned native output when Email installation fails", { timeout: buildOutputTestTimeout }, async () => {
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-email-rollback-")
   const workflowDir = join(rootDir, "server", "workflows", "recap")
   const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
@@ -142,7 +142,8 @@ it("restores native output when Email installation fails", { timeout: buildOutpu
   await mkdir(workflowDir, { recursive: true })
   await mkdir(resolve(externalFile, ".."), { recursive: true })
   await writeFile(join(workflowDir, "01-collect.ts"), "export default async function collect(input) { return input }\n")
-  await writeFile(externalFile, "external flow\n")
+  await writeFile(externalFile, "prior owned flow\n")
+  await writeViteHubWorkflowOwnership(workflowRoot, ["v1/flow.func/index.mjs"], [externalRoute])
   await writeFile(configFile, `${JSON.stringify({ routes: [externalRoute] })}\n`)
 
   await expect(generateProviderOutputs({
@@ -153,11 +154,13 @@ it("restores native output when Email installation fails", { timeout: buildOutpu
     workflow: { provider: "vercel" },
   })).rejects.toThrow()
 
-  await expect(readFile(externalFile, "utf8")).resolves.toBe("external flow\n")
+  await expect(readFile(externalFile, "utf8")).resolves.toBe("prior owned flow\n")
   const routes = JSON.parse(await readFile(configFile, "utf8")).routes
   expect(routes).toContainEqual(externalRoute)
   expect(routes.filter((route: unknown) => JSON.stringify(route).includes("/.well-known/workflow/v1/"))).toEqual([externalRoute])
-  expect(existsSync(join(workflowRoot, ".vitehub-owned"))).toBe(false)
+  const ownership = JSON.parse(await readFile(join(workflowRoot, ".vitehub-owned"), "utf8"))
+  expect(ownership.files).toHaveProperty("v1/flow.func/index.mjs")
+  expect(ownership.routes).toEqual([JSON.stringify(externalRoute)])
 })
 
 it("removes stale WDK functions and routes", async () => {

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -50,6 +50,17 @@ it("detects compact user-authored native Vercel workflow directives", async () =
   expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(true)
 })
 
+it("detects shorthand user-authored native Vercel workflow options", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-shorthand-native-option-")
+  const workflowFile = join(rootDir, "server", "workflows", "welcome.workflow.ts")
+  const nativeFile = join(rootDir, "server", "workflows", "durable.ts")
+  await mkdir(join(rootDir, "server", "workflows"), { recursive: true })
+  await writeFile(workflowFile, `import { durable as native } from "./durable.js"\nexport default defineWorkflow(async () => "inline", { native })\n`)
+  await writeFile(nativeFile, `export async function durable() {\n  "use workflow"\n}\n`)
+
+  expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(true)
+})
+
 it("ignores workflow directive examples in comments", async () => {
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-commented-native-entry-")
   const workflowFile = join(rootDir, "server", "workflows", "welcome.workflow.ts")

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -7,7 +7,7 @@ import { promisify } from "node:util"
 import { afterAll, describe, expect, it } from "vitest"
 
 import { getCloudflareWorkflowBindingName, getCloudflareWorkflowClassName, getCloudflareWorkflowName } from "../src/integrations/cloudflare.ts"
-import { cleanVercelNativeWorkflowOutput, hasVercelNativeWorkflowEntry, installEmailDefinitionInVercelWorkflowOutput, writeProviderEntries } from "../src/internal/vite-build.ts"
+import { cleanVercelNativeWorkflowOutput, generateProviderOutputs, hasVercelNativeWorkflowEntry, installEmailDefinitionInVercelWorkflowOutput, writeProviderEntries } from "../src/internal/vite-build.ts"
 
 const execFileAsync = promisify(execFile)
 const playgroundDir = resolve(import.meta.dirname, "../../../playground/vite")
@@ -67,6 +67,27 @@ it("removes stale WDK functions and routes", async () => {
   ] })}\n`)
 
   await cleanVercelNativeWorkflowOutput(rootDir)
+
+  expect(existsSync(workflowRoot)).toBe(false)
+  expect(JSON.parse(await readFile(configFile, "utf8")).routes).toEqual([{ src: "/user", dest: "/user" }])
+})
+
+it("removes stale WDK output when the Vercel provider is disabled", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-disable-vercel-")
+  const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
+  const configFile = join(rootDir, ".vercel", "output", "config.json")
+  await mkdir(workflowRoot, { recursive: true })
+  await writeFile(join(workflowRoot, "stale.mjs"), "stale\n")
+  await writeFile(configFile, `${JSON.stringify({ routes: [
+    { src: "/.well-known/workflow/v1/flow", dest: "/.well-known/workflow/v1/flow" },
+    { src: "/user", dest: "/user" },
+  ] })}\n`)
+
+  await generateProviderOutputs({
+    clientOutDir: join(rootDir, "dist"),
+    rootDir,
+    workflow: { provider: "openworkflow", sqlite: { path: ":memory:" } },
+  })
 
   expect(existsSync(workflowRoot)).toBe(false)
   expect(JSON.parse(await readFile(configFile, "utf8")).routes).toEqual([{ src: "/user", dest: "/user" }])

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -379,6 +379,9 @@ describe("Vite workflow provider outputs", () => {
     expect(existsSync(join(rootDir, ".vitehub", "workflow", "vercel-native.mjs"))).toBe(false)
     await expect(readFile(join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs"), "utf8"))
       .resolves.toMatch(/globalThis\[(?:\/\*.*?\*\/\s*)?Symbol\.for\(["']vitehub\.email\.definition["']\)\]\s*=/)
+    const rebuiltRoutes = JSON.parse(await readFile(join(rootDir, ".vercel", "output", "config.json"), "utf8")).routes as unknown[]
+    const workflowRoutes = rebuiltRoutes.filter(route => JSON.stringify(route).includes("/.well-known/workflow/v1/"))
+    expect(workflowRoutes).toEqual([...new Set(workflowRoutes.map(route => JSON.stringify(route)))].map(route => JSON.parse(route)))
 
   }, buildOutputTestTimeout)
 

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -7,7 +7,7 @@ import { promisify } from "node:util"
 import { afterAll, describe, expect, it } from "vitest"
 
 import { getCloudflareWorkflowBindingName, getCloudflareWorkflowClassName, getCloudflareWorkflowName } from "../src/integrations/cloudflare.ts"
-import { hasVercelNativeWorkflowEntry } from "../src/internal/vite-build.ts"
+import { hasVercelNativeWorkflowEntry, installEmailDefinitionInVercelWorkflowOutput } from "../src/internal/vite-build.ts"
 
 const execFileAsync = promisify(execFile)
 const playgroundDir = resolve(import.meta.dirname, "../../../playground/vite")
@@ -24,6 +24,21 @@ it("detects user-authored native Vercel workflow entries", async () => {
   await writeFile(nativeFile, `export async function durable() {\n  "use workflow"\n}\n`)
 
   expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(true)
+})
+
+it("preserves WDK optional externals while installing the Email definition", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-email-bootstrap-")
+  const flowFile = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs")
+  const emailDefinitionFile = join(rootDir, "email-definition.mjs")
+  await mkdir(resolve(flowFile, ".."), { recursive: true })
+  await writeFile(flowFile, `import credentials from "@aws-sdk/credential-provider-web-identity"\nexport { credentials }\n`)
+  await writeFile(emailDefinitionFile, "export default { handler: async () => undefined }\n")
+
+  await installEmailDefinitionInVercelWorkflowOutput(rootDir, emailDefinitionFile)
+
+  const combinedFlow = await readFile(flowFile, "utf8")
+  expect(combinedFlow).toContain("@aws-sdk/credential-provider-web-identity")
+  expect(combinedFlow).toMatch(/globalThis\[(?:\/\*.*?\*\/\s*)?Symbol\.for\(["']vitehub\.email\.definition["']\)\]\s*=/)
 })
 
 function resolvePlaygroundNodeModules() {

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -45,7 +45,7 @@ it("detects compact user-authored native Vercel workflow directives", async () =
   const nativeFile = join(rootDir, "server", "workflows", "durable.ts")
   await mkdir(join(rootDir, "server", "workflows"), { recursive: true })
   await writeFile(workflowFile, `import { durable } from "./durable.js"\nexport default defineWorkflow(async () => "inline", { native: durable })\n`)
-  await writeFile(nativeFile, `export async function durable() { "use workflow"; return "durable" }\n`)
+  await writeFile(nativeFile, `export async function durable() { /* durable prologue */ "use workflow"; return "durable" }\n`)
 
   expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(true)
 })

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -39,6 +39,17 @@ it("detects user-authored native Vercel workflow entries", async () => {
   expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(true)
 })
 
+it("detects compact user-authored native Vercel workflow directives", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-compact-native-entry-")
+  const workflowFile = join(rootDir, "server", "workflows", "welcome.workflow.ts")
+  const nativeFile = join(rootDir, "server", "workflows", "durable.ts")
+  await mkdir(join(rootDir, "server", "workflows"), { recursive: true })
+  await writeFile(workflowFile, `import { durable } from "./durable.js"\nexport default defineWorkflow(async () => "inline", { native: durable })\n`)
+  await writeFile(nativeFile, `export async function durable() { "use workflow"; return "durable" }\n`)
+
+  expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(true)
+})
+
 it("keeps suffix Workflow discovery relative to a nested Vite root", async () => {
   const projectRoot = await createWorkspaceTempDir("vitehub-workflow-project-root-")
   const viteRoot = join(projectRoot, "apps", "web")

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -7,12 +7,24 @@ import { promisify } from "node:util"
 import { afterAll, describe, expect, it } from "vitest"
 
 import { getCloudflareWorkflowBindingName, getCloudflareWorkflowClassName, getCloudflareWorkflowName } from "../src/integrations/cloudflare.ts"
+import { hasVercelNativeWorkflowEntry } from "../src/internal/vite-build.ts"
 
 const execFileAsync = promisify(execFile)
 const playgroundDir = resolve(import.meta.dirname, "../../../playground/vite")
 const buildOutputTestTimeout = 60_000
 const tempNodeModuleBuildDirs = new Set([".vite-temp"])
 const tempDirs: string[] = []
+
+it("detects user-authored native Vercel workflow entries", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-native-entry-")
+  const workflowFile = join(rootDir, "server", "workflows", "welcome.workflow.ts")
+  const nativeFile = join(rootDir, "server", "workflows", "durable.ts")
+  await mkdir(join(rootDir, "server", "workflows"), { recursive: true })
+  await writeFile(workflowFile, `import { durable } from "./durable.js"\nexport default defineWorkflow(async () => "inline", { native: durable })\n`)
+  await writeFile(nativeFile, `export async function durable() {\n  "use workflow"\n}\n`)
+
+  expect(hasVercelNativeWorkflowEntry(rootDir, [{ handler: workflowFile, name: "welcome", source: "vite-suffix" }])).toBe(true)
+})
 
 function resolvePlaygroundNodeModules() {
   const nodeModules = join(playgroundDir, "node_modules")

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -55,6 +55,21 @@ it("preserves WDK optional externals while installing the Email definition", asy
   expect(combinedFlow).toMatch(/export\s*\{[^}]*\s+as\s+default/)
 })
 
+it("installs the Email definition when the WDK flow has only named exports", async () => {
+  const rootDir = await createWorkspaceTempDir("vitehub-workflow-email-named-flow-")
+  const flowFile = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow", "v1", "flow.func", "index.mjs")
+  const emailDefinitionFile = join(rootDir, "email-definition.mjs")
+  await mkdir(resolve(flowFile, ".."), { recursive: true })
+  await writeFile(flowFile, "export async function POST() {}\n")
+  await writeFile(emailDefinitionFile, "export default { handler: async () => undefined }\n")
+
+  await installEmailDefinitionInVercelWorkflowOutput(rootDir, emailDefinitionFile)
+
+  const combinedFlow = await readFile(flowFile, "utf8")
+  expect(combinedFlow).toContain("POST")
+  expect(combinedFlow).toMatch(/globalThis\[(?:\/\*.*?\*\/\s*)?Symbol\.for\(["']vitehub\.email\.definition["']\)\]\s*=/)
+})
+
 it("removes stale WDK functions and routes", async () => {
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-clean-wdk-")
   const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1005,6 +1005,9 @@ importers:
       '@vite-hub/internal':
         specifier: workspace:*
         version: link:../internal
+      '@vite-hub/workflow':
+        specifier: workspace:*
+        version: link:../workflow
       publint:
         specifier: catalog:tooling
         version: 0.3.21

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -1109,7 +1109,7 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
       expect(workspacePlugin).toContain("vite-hub/_internal/workspace/runtime")
       expect(nativeWorkflow).toContain('"use workflow"')
       expect(nativeWorkflow).toContain('"use step"')
-      expect(nativeWorkflow).toContain('globalThis[Symbol.for("vitehub.email.definition")]')
+      expect(nativeWorkflow).not.toContain("vitehub.email.definition")
       expect(scheduleFunction).toContain("setWorkflowRuntimeRegistry")
       expect(flowBundle).toContain("vitehub.email.definition")
       expect(flowBundle).toContain("RESEND_API_KEY")

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -1078,15 +1078,18 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
         ...process.env,
         VITEHUB_PRESET: "vercel",
       })
-      const [agentRoute, authTypes, blobPlugin, emailTemplate, envServer, vercelConfig, workflowRegistry, workspacePlugin] = await Promise.all([
+      const [agentRoute, authTypes, blobPlugin, emailTemplate, envServer, workflowRegistry, workspacePlugin, nativeWorkflow, scheduleFunction, flowBundle, vercelConfig] = await Promise.all([
         readFile(join(appDir, ".vitehub/agent/chat-webhook-route.ts"), "utf8"),
         readFile(join(appDir, ".vitehub/types/auth.d.ts"), "utf8"),
         readFile(join(appDir, ".vitehub/nitro/blob/plugin.ts"), "utf8"),
         readFile(join(appDir, ".vitehub/email/templates/welcome.mjs"), "utf8"),
         readFile(join(appDir, ".vitehub/env/server.mjs"), "utf8"),
-        readFile(join(appDir, ".vercel/output/config.json"), "utf8"),
         readFile(join(appDir, ".vitehub/workflow/registry.mjs"), "utf8"),
         readFile(join(appDir, ".vitehub/nitro/workspace/plugin.ts"), "utf8"),
+        readFile(join(appDir, ".vitehub/workflow/vercel-native.mjs"), "utf8"),
+        readFile(join(appDir, ".vercel/output/functions/api/vitehub/schedules/vercel/heartbeat.func/index.mjs"), "utf8"),
+        readFile(join(appDir, ".vercel/output/functions/.well-known/workflow/v1/flow.func/index.mjs"), "utf8"),
+        readFile(join(appDir, ".vercel/output/config.json"), "utf8"),
       ])
       expect(agentRoute).toContain("vite-hub/_internal/agent")
       expect(agentRoute).toContain("vite-hub/_internal/workspace/runtime")
@@ -1095,10 +1098,6 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
       expect(blobPlugin).toContain("vite-hub/_internal/blob/runtime/state")
       expect(emailTemplate).toContain("Welcome")
       expect(envServer).toContain("vite-hub/env/server")
-      expect(JSON.parse(vercelConfig).crons).toContainEqual({
-        path: "/api/vitehub/schedules/vercel/heartbeat",
-        schedule: "0 0 * * *",
-      })
       expect(workflowRegistry).toContain("vite-hub/_internal/agent")
       expect(workflowRegistry).toContain("setAgentWorkflowRuntimeLoaders")
       expect(workflowRegistry).toContain("vite-hub/_internal/workflow/runtime/execute")
@@ -1108,6 +1107,17 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
       expect(workflowRegistry).not.toContain("vite-hub/sandbox")
       expect(workflowRegistry).toContain("vite-hub/shell/workspace")
       expect(workspacePlugin).toContain("vite-hub/_internal/workspace/runtime")
+      expect(nativeWorkflow).toContain('"use workflow"')
+      expect(nativeWorkflow).toContain('"use step"')
+      expect(nativeWorkflow).toContain('globalThis[Symbol.for("vitehub.email.definition")]')
+      expect(scheduleFunction).toContain("setWorkflowRuntimeRegistry")
+      expect(flowBundle).toContain("vitehub.email.definition")
+      expect(flowBundle).toContain("RESEND_API_KEY")
+      expect(flowBundle).toMatch(/globalThis\[(?:\/\*.*?\*\/\s*)?Symbol\.for\(["']vitehub\.email\.definition["']\)\]\s*=/)
+      expect(JSON.parse(vercelConfig).crons).toContainEqual({
+        path: "/api/vitehub/schedules/vercel/heartbeat",
+        schedule: "0 0 * * *",
+      })
 
       await run("pnpm", ["run", "build"], appDir, process.env)
       const smoke = await run("pnpm", ["run", "smoke"], appDir)

--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -1078,6 +1078,7 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
         ...process.env,
         VITEHUB_PRESET: "vercel",
       })
+      const [nativeWorkflowFile] = await readdir(join(appDir, ".vitehub/workflow/vercel-native"))
       const [agentRoute, authTypes, blobPlugin, emailTemplate, envServer, workflowRegistry, workspacePlugin, nativeWorkflow, scheduleFunction, flowBundle, vercelConfig] = await Promise.all([
         readFile(join(appDir, ".vitehub/agent/chat-webhook-route.ts"), "utf8"),
         readFile(join(appDir, ".vitehub/types/auth.d.ts"), "utf8"),
@@ -1086,7 +1087,7 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
         readFile(join(appDir, ".vitehub/env/server.mjs"), "utf8"),
         readFile(join(appDir, ".vitehub/workflow/registry.mjs"), "utf8"),
         readFile(join(appDir, ".vitehub/nitro/workspace/plugin.ts"), "utf8"),
-        readFile(join(appDir, ".vitehub/workflow/vercel-native.mjs"), "utf8"),
+        readFile(join(appDir, ".vitehub/workflow/vercel-native", nativeWorkflowFile), "utf8"),
         readFile(join(appDir, ".vercel/output/functions/api/vitehub/schedules/vercel/heartbeat.func/index.mjs"), "utf8"),
         readFile(join(appDir, ".vercel/output/functions/.well-known/workflow/v1/flow.func/index.mjs"), "utf8"),
         readFile(join(appDir, ".vercel/output/config.json"), "utf8"),


### PR DESCRIPTION
## Problem

Entry-less ordered workflow directories currently stop at ViteHub's portable discovery boundary: consumers still need host-native directives, an entry module, or provider-specific wiring before Vercel can schedule and execute the same ordered steps that Cloudflare accepts. Generated schedule bundles can also collide at module scope, and a generated Email definition is not available inside a native workflow worker.

## Change

- generate the Vercel-native workflow and step directives from entry-less ordered workflow directories, attach the native export and stable workflow ID to the runtime registry, and build it through Workflow DevKit
- compose Workflow runtime installation into Vercel schedule functions only when a Vercel Workflow capability is enabled, while preserving user cron configuration and Cloudflare output
- make generated Node bundle globals declaration-free and safe when Workflow DevKit recompiles them for its neutral CommonJS VM
- install the generated Email definition in native workflow bundles and resolve it lazily from the Email runtime
- cover the contract through package regressions and the packed `vite-hub` consumer without a consumer-authored workflow index, directives, provider branch, or native adapter


Source/Collection is intentionally excluded: it is a separate Source-domain API and none of the Workflow, Schedule, or Email changes depend on it.

## Validation

- `pnpm install --frozen-lockfile`
- focused lint and typecheck for Internal, Email, Workflow, Schedule, and ViteHub changes
- Internal: 15 tests
- Email: 2 tests
- Workflow: 24 focused tests
- Schedule: 63 focused tests
- repository package build graph, including publint
- packed `vite-hub` consumer: fresh strict install, typecheck, Cloudflare build, Vercel cron/function/native workflow build, Netlify smoke, collision-free combined WDK output, and generated Email installation in the combined Vercel flow

Repository-wide `pnpm exec vp lint` is currently blocked before linting by the unchanged database example definition identity check in `packages/database/examples/vite/src/analytics.database.ts`; the changed packages and root consumer files pass scoped lint. Live deployment and workflow triggering were not run.