### PR TITLE
fix: retire downstream ViteHub patches

### DIFF
--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4948,9 +4948,6 @@ export function createChannelWebhookRouteHandler(
             if (concurrencyKey !== undefined && !concurrencyKey.trim()) {
               return await terminalChannelDeliveryResponse(channelDelivery, createJsonErrorResponse(500, "Webhook delivery ownership requires a non-empty concurrencyKey when configured."))
             }
-            if (invocation.webhook.busy === "steer" && invocation.webhook.rehydrate) {
-              return await terminalChannelDeliveryResponse(channelDelivery, createJsonErrorResponse(500, "Webhook delivery ownership cannot combine busy steering with rehydration."))
-            }
             const concurrencyLimit = positiveWebhookConcurrencyLimit(invocation.webhook.concurrencyLimit)!
             if (!hasAgentWebhookQueue(webhookState.state)) {
               return await terminalChannelDeliveryResponse(channelDelivery, createJsonErrorResponse(503, "Persistent webhook concurrency requires a queue-capable Agent state provider."))

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3396,7 +3396,6 @@ async function handleChatSdkMessage(
 
     const manualDelivery = options?.delivery === "manual"
     const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
-    typing = streamsPhasedReplies || manualDelivery ? startChatTypingRefresh(thread, context) : undefined
     const messages = await chatTriggerMessages(thread, message, options, messageContext, historyThroughCurrent)
     const currentMessage = message.id
       ? messages.find(item => item.id === message.id)
@@ -3429,6 +3428,7 @@ async function handleChatSdkMessage(
       return
     }
 
+    typing = streamsPhasedReplies || manualDelivery ? startChatTypingRefresh(thread, context) : undefined
     assertChatDeliveryOptions(options || {})
     run = invocation.run
     await recordChannelDeliveryEvidence(delivery, { type: "accepted", runId: run?.runId })

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3394,6 +3394,9 @@ async function handleChatSdkMessage(
       return
     }
 
+    const manualDelivery = options?.delivery === "manual"
+    const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
+    typing = streamsPhasedReplies || manualDelivery ? startChatTypingRefresh(thread, context) : undefined
     const messages = await chatTriggerMessages(thread, message, options, messageContext, historyThroughCurrent)
     const currentMessage = message.id
       ? messages.find(item => item.id === message.id)
@@ -3427,8 +3430,6 @@ async function handleChatSdkMessage(
     }
 
     assertChatDeliveryOptions(options || {})
-    const manualDelivery = options?.delivery === "manual"
-    const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
     run = invocation.run
     await recordChannelDeliveryEvidence(delivery, { type: "accepted", runId: run?.runId })
     await recordChannelDeliveryEvidence(delivery, { type: "invocation.started", runId: run?.runId })
@@ -3447,7 +3448,8 @@ async function handleChatSdkMessage(
       if (state.workflowCustodySupported === false) {
         throw new Error("[vitehub] Durable Channel delivery requires reconstructable State across Agent Workflow custody. Configure Channel state or a generated host State provider.")
       }
-      const durableTyping = startChatTypingRefresh(thread, context)
+      const durableTyping = typing || startChatTypingRefresh(thread, context)
+      typing = undefined
       const durableTypingTimeout = setTimeout(() => durableTyping.stop(), options?.timeout ?? 28_000)
       try {
         await runAgent(agent as never, runContext as never, withResolvedAgentInvokerInput({
@@ -3475,7 +3477,6 @@ async function handleChatSdkMessage(
       }
       return
     }
-    typing = streamsPhasedReplies || manualDelivery ? startChatTypingRefresh(thread, context) : undefined
     const thinkingFallback = invocation.metadata?.thinkingFallback
     if (manualDelivery && typeof thinkingFallback === "string") {
       const placeholderDelivery = thread.post(thinkingFallback).then(async (placeholder) => {

--- a/packages/agent/src/state/sqlite.ts
+++ b/packages/agent/src/state/sqlite.ts
@@ -398,7 +398,7 @@ export class ViteHubSqliteAgentStateAdapter implements AgentWebhookQueueStateAda
         WHERE candidate.scope = ? AND candidate.delivery_id = ? AND candidate.status IN ('running', 'steering')
           AND candidate.lease_token = ?
           AND (
-            candidate.lease_expires_at > ? OR (
+            candidate.status = 'steering' OR candidate.lease_expires_at > ? OR (
               (
                 SELECT COUNT(*) FROM ${this.tables.webhookQueue} AS active_group
                 WHERE active_group.status = 'running' AND active_group.lease_expires_at > ?

--- a/packages/agent/src/state/sqlite.ts
+++ b/packages/agent/src/state/sqlite.ts
@@ -396,8 +396,8 @@ export class ViteHubSqliteAgentStateAdapter implements AgentWebhookQueueStateAda
       tx,
       `UPDATE ${this.tables.webhookQueue} SET lease_expires_at = ?
         WHERE scope = ? AND delivery_id = ? AND status IN ('running', 'steering')
-          AND lease_token = ? AND lease_expires_at > ? RETURNING delivery_id`,
-      [now + ttlMs, scope, deliveryId, leaseToken, now],
+          AND lease_token = ? RETURNING delivery_id`,
+      [now + ttlMs, scope, deliveryId, leaseToken],
     ))
     return extended.length > 0
   }

--- a/packages/agent/src/state/sqlite.ts
+++ b/packages/agent/src/state/sqlite.ts
@@ -394,10 +394,27 @@ export class ViteHubSqliteAgentStateAdapter implements AgentWebhookQueueStateAda
     const now = Date.now()
     const extended = await this.transaction(async tx => await execute(
       tx,
-      `UPDATE ${this.tables.webhookQueue} SET lease_expires_at = ?
-        WHERE scope = ? AND delivery_id = ? AND status IN ('running', 'steering')
-          AND lease_token = ? RETURNING delivery_id`,
-      [now + ttlMs, scope, deliveryId, leaseToken],
+      `UPDATE ${this.tables.webhookQueue} AS candidate SET lease_expires_at = ?
+        WHERE candidate.scope = ? AND candidate.delivery_id = ? AND candidate.status IN ('running', 'steering')
+          AND candidate.lease_token = ?
+          AND (
+            candidate.lease_expires_at > ? OR (
+              (
+                SELECT COUNT(*) FROM ${this.tables.webhookQueue} AS active_group
+                WHERE active_group.status = 'running' AND active_group.lease_expires_at > ?
+                  AND active_group.concurrency_group = candidate.concurrency_group
+              ) < candidate.concurrency_limit
+              AND (
+                candidate.concurrency_key IS NULL OR NOT EXISTS (
+                  SELECT 1 FROM ${this.tables.webhookQueue} AS active_key
+                  WHERE active_key.status = 'running' AND active_key.lease_expires_at > ?
+                    AND active_key.concurrency_key = candidate.concurrency_key
+                )
+              )
+            )
+          )
+        RETURNING delivery_id`,
+      [now + ttlMs, scope, deliveryId, leaseToken, now, now, now],
     ))
     return extended.length > 0
   }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -419,7 +419,7 @@ interface AgentWebhookInvocationOwnershipBase {
 }
 
 export type AgentWebhookInvocationOwnership<CALL_OPTIONS = unknown> = AgentWebhookInvocationOwnershipBase & (
-  | { busy: "steer", concurrencyKey: string, concurrencyLimit: number, rehydrate?: never }
+  | { busy: "steer", concurrencyKey: string, concurrencyLimit: number, rehydrate?: () => MaybePromise<AgentWebhookRehydrateResult<CALL_OPTIONS>> }
   | { busy?: undefined, concurrencyKey?: string, concurrencyLimit: number, rehydrate?: () => MaybePromise<AgentWebhookRehydrateResult<CALL_OPTIONS>> }
   | { busy?: undefined, concurrencyKey?: string, concurrencyLimit?: undefined, rehydrate?: never }
 )

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -9017,6 +9017,48 @@ describe("server helpers", () => {
     }
   })
 
+  it("starts typing before chat context resolves", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    let contextStarted!: () => void
+    let releaseContext!: () => void
+    const contextStartedPromise = new Promise<void>(resolve => { contextStarted = resolve })
+    const contextReleasePromise = new Promise<void>(resolve => { releaseContext = resolve })
+    const adapter = createTestChatAdapter({ attachmentFetchData: async () => {
+      contextStarted()
+      await contextReleasePromise
+      return Buffer.from([1, 2, 3])
+    } })
+    const agent = defineAgent({
+      capabilities: [
+        defineChatCapability({
+          platforms: {
+            telegram: () => adapter as never,
+          },
+          webhooks: {
+            telegram: {},
+          },
+        }),
+      ],
+      driver: { run: () => ({ text: "ok" }) },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const responsePromise = handler(new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+      body: JSON.stringify({ message: { chat: { id: 456, type: "private" }, document: { content: "context", file_name: "context.txt", mime_type: "text/plain" }, from: { id: 123 }, message_id: 44, text: "hello" } }),
+      method: "POST",
+    }), "telegram")
+    await contextStartedPromise
+    try {
+      expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
+    }
+    finally {
+      releaseContext()
+    }
+    await expect(responsePromise).resolves.toMatchObject({ status: 200 })
+  })
+
   it("does not block chat webhook handling on typing status", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineChatCapability } = await import("../src/chat-trigger.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -6969,6 +6969,18 @@ describe("server helpers", () => {
     const stateDir = await mkdtemp(join(tmpdir(), "vitehub-webhook-steer-"))
     const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
     const retryDelivery = vi.spyOn(state, "retryWebhookDelivery")
+    const rehydrate = vi.fn((deliveryId: string) => ({
+      input: { prompt: `fresh ${deliveryId}` },
+      run: { runId: deliveryId },
+      webhook: {
+        busy: "steer" as const,
+        concurrencyGroup: "reviews",
+        concurrencyKey: "pr-42",
+        concurrencyLimit: 1,
+        concurrencyTtlMs: 1_000,
+        deliveryId,
+      },
+    }))
     const releases: Array<() => void> = []
     const closeControls: Array<() => void> = []
     const steeredInputs: unknown[] = []
@@ -7019,6 +7031,7 @@ describe("server helpers", () => {
                     concurrencyLimit: 1,
                     concurrencyTtlMs: 1_000,
                     deliveryId,
+                    rehydrate: () => rehydrate(deliveryId),
                   },
                 }
               },
@@ -7053,6 +7066,7 @@ describe("server helpers", () => {
       const first = await handler(request("delivery-1"), "github", options)
       await expect(first.json()).resolves.toEqual({ accepted: true, duplicate: false, ok: true, queued: true })
       await vi.waitFor(() => expect(run).toHaveBeenCalledOnce())
+      expect(rehydrate).toHaveBeenCalledWith("delivery-1")
       expect(run.mock.calls[0]?.[0]).toEqual(expect.objectContaining({ run: expect.objectContaining({ runId: "delivery-1" }) }))
 
       const waitUntilCount = waitUntilTasks.length

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -9031,7 +9031,7 @@ describe("server helpers", () => {
     }
   })
 
-  it("starts typing before chat context resolves", async () => {
+  it("starts typing only after chat context is accepted", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
@@ -9064,12 +9064,9 @@ describe("server helpers", () => {
       method: "POST",
     }), "telegram")
     await contextStartedPromise
-    try {
-      expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
-    }
-    finally {
-      releaseContext()
-    }
+    expect(adapter.startTyping).not.toHaveBeenCalled()
+    releaseContext()
+    await vi.waitFor(() => expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined))
     await expect(responsePromise).resolves.toMatchObject({ status: 200 })
   })
 

--- a/packages/agent/test/sqlite-state-provider.test.ts
+++ b/packages/agent/test/sqlite-state-provider.test.ts
@@ -144,6 +144,31 @@ describe("SQLite Agent State Provider", () => {
     await state.disconnect()
   })
 
+  it("renews delayed steering ownership after its execution lease renews", async () => {
+    const { state, url } = await createState()
+    await state.connect()
+    const queue = state as ViteHubSqliteAgentStateAdapter
+    const execution = webhookDelivery("delivery-execution", "pr-1")
+    const steering = webhookDelivery("delivery-steering", "pr-1")
+
+    await queue.enqueueWebhookDelivery(execution)
+    const executionLease = await queue.claimWebhookDelivery(execution.scope)
+    expect(executionLease?.deliveryId).toBe(execution.deliveryId)
+    await expect(queue.claimWebhookSteering(steering, "steering-token", Date.now() + 1_000)).resolves.toBe(true)
+
+    const client = createClient({ url })
+    await client.execute({
+      args: [execution.deliveryId, steering.deliveryId],
+      sql: "UPDATE test_agent_state_webhook_queue SET lease_expires_at = 0 WHERE delivery_id IN (?, ?)",
+    })
+    await expect(queue.extendWebhookDeliveryLease(execution.scope, execution.deliveryId, executionLease!.leaseToken, 30_000)).resolves.toBe(true)
+    await expect(queue.extendWebhookDeliveryLease(steering.scope, steering.deliveryId, "wrong-token", 30_000)).resolves.toBe(false)
+    await expect(queue.extendWebhookDeliveryLease(steering.scope, steering.deliveryId, "steering-token", 30_000)).resolves.toBe(true)
+
+    client.close()
+    await state.disconnect()
+  })
+
   it("retries transient SQLite contention while persisting webhook deliveries", async () => {
     const client = createClient({ url: ":memory:" })
     let busyCompletion = true

--- a/packages/agent/test/sqlite-state-provider.test.ts
+++ b/packages/agent/test/sqlite-state-provider.test.ts
@@ -118,6 +118,16 @@ describe("SQLite Agent State Provider", () => {
     })
     await expect(queue.extendWebhookDeliveryLease(first!.scope, first!.deliveryId, "wrong-token", 30_000)).resolves.toBe(false)
     await expect(queue.extendWebhookDeliveryLease(first!.scope, first!.deliveryId, first!.leaseToken, 30_000)).resolves.toBe(true)
+    await client.execute({
+      args: [first!.scope, first!.deliveryId],
+      sql: "UPDATE test_agent_state_webhook_queue SET lease_expires_at = 0 WHERE scope = ? AND delivery_id = ?",
+    })
+    const competingDelivery = { ...webhookDelivery("delivery-competing", "pr-competing"), scope: "webhook:review:linear:" }
+    await expect(queue.enqueueWebhookDelivery(competingDelivery)).resolves.toBe(true)
+    const competingLease = await queue.claimWebhookDelivery(competingDelivery.scope)
+    expect(competingLease?.deliveryId).toBe(competingDelivery.deliveryId)
+    await expect(queue.extendWebhookDeliveryLease(first!.scope, first!.deliveryId, first!.leaseToken, 30_000)).resolves.toBe(false)
+    await queue.completeWebhookDelivery(competingLease!.scope, competingLease!.deliveryId, competingLease!.leaseToken)
     await expect(queue.completeWebhookDelivery(first!.scope, first!.deliveryId, "wrong-token")).resolves.toBe(false)
     await expect(queue.completeWebhookDelivery(first!.scope, first!.deliveryId, first!.leaseToken)).resolves.toBe(true)
     await expect(client.execute({

--- a/packages/agent/test/sqlite-state-provider.test.ts
+++ b/packages/agent/test/sqlite-state-provider.test.ts
@@ -111,9 +111,15 @@ describe("SQLite Agent State Provider", () => {
     expect(second?.deliveryId).toBe("delivery-3")
     await expect(queue.claimWebhookDelivery("webhook:review:github:")).resolves.toBeNull()
 
+    const client = createClient({ url })
+    await client.execute({
+      args: [first!.scope, first!.deliveryId],
+      sql: "UPDATE test_agent_state_webhook_queue SET lease_expires_at = 0 WHERE scope = ? AND delivery_id = ?",
+    })
+    await expect(queue.extendWebhookDeliveryLease(first!.scope, first!.deliveryId, "wrong-token", 30_000)).resolves.toBe(false)
+    await expect(queue.extendWebhookDeliveryLease(first!.scope, first!.deliveryId, first!.leaseToken, 30_000)).resolves.toBe(true)
     await expect(queue.completeWebhookDelivery(first!.scope, first!.deliveryId, "wrong-token")).resolves.toBe(false)
     await expect(queue.completeWebhookDelivery(first!.scope, first!.deliveryId, first!.leaseToken)).resolves.toBe(true)
-    const client = createClient({ url })
     await expect(client.execute({
       args: [first!.scope, first!.deliveryId],
       sql: "SELECT status, value FROM test_agent_state_webhook_queue WHERE scope = ? AND delivery_id = ?",

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -77,7 +77,6 @@ describe("agent public types", () => {
         concurrencyKey: "pull-request:1",
         concurrencyLimit: 1,
         deliveryId: "delivery-steer",
-        // @ts-expect-error Successful busy steering bypasses queue-time rehydration.
         rehydrate: () => ({
           input: { prompt: "fresh", options: { mode: "fresh" } },
           webhook: { concurrencyLimit: 1, deliveryId: "delivery-steer" },

--- a/packages/workspace/src/core/path.ts
+++ b/packages/workspace/src/core/path.ts
@@ -23,7 +23,7 @@ export function normalizeSafeWorkspacePath(path = "", options: SafeWorkspacePath
 
   if (!options.allowEmpty && !normalized) throw workspacePathError(path)
   if (raw.startsWith("/") || parts.some(part => part === "." || part === "..")) throw workspacePathError(path)
-  if (!options.allowReserved && (parts[0] === ".git" || parts[0] === ".vitehub")) throw workspacePathError(path)
+  if (!options.allowReserved && (parts.some(part => part.toLowerCase() === ".git") || parts[0] === ".vitehub")) throw workspacePathError(path)
 
   return normalized
 }

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -219,6 +219,12 @@ async function readHostFile(host: WorkspaceSessionHost, root: string, path: stri
   return content ? { content, path: fromHostPath(root, path) } : undefined
 }
 
+function gitMetadataRoot(path: string) {
+  const parts = path.split("/")
+  const index = parts.findIndex(part => part.toLowerCase() === ".git")
+  return index === -1 ? undefined : parts.slice(0, index + 1).join("/")
+}
+
 async function listHostEntries(
   host: WorkspaceSessionHost,
   root: string,
@@ -239,7 +245,7 @@ async function listHostEntries(
       : workspaceEntry
   })
   return resolved
-    .filter(entry => entry.path && (includeGit || (entry.path !== ".git" && !entry.path.startsWith(".git/"))))
+    .filter(entry => entry.path && (includeGit || !gitMetadataRoot(entry.path)))
     .sort((left, right) => left.path.localeCompare(right.path))
 }
 
@@ -282,7 +288,7 @@ async function captureHostEntriesState(host: WorkspaceSessionHost, root: string,
 }
 
 function isInsideExcludedWriteBackPath(path: string, excluded: readonly string[]) {
-  return excluded.some(item => path === item || path.startsWith(`${item}/`))
+  return Boolean(gitMetadataRoot(path)) || excluded.some(item => path === item || path.startsWith(`${item}/`))
 }
 
 async function captureExcludedHostState(host: WorkspaceSessionHost, root: string, excluded: readonly string[]) {
@@ -298,8 +304,11 @@ function mergeExcludedHostState(
   materialized: Awaited<ReturnType<typeof captureExcludedHostState>>,
   excluded: readonly string[],
 ) {
-  const occupiedRoots = excluded.filter(root => Object.keys(before.snapshot.entries)
-    .some(path => path === root || path.startsWith(`${root}/`)))
+  const beforePaths = Object.keys(before.snapshot.entries)
+  const occupiedRoots = [...new Set([
+    ...excluded.filter(root => beforePaths.some(path => path === root || path.startsWith(`${root}/`))),
+    ...beforePaths.map(gitMetadataRoot).filter((path): path is string => Boolean(path)),
+  ])]
   const entries = Object.fromEntries(Object.entries(materialized.snapshot.entries)
     .filter(([path]) => !occupiedRoots.some(root => path === root || path.startsWith(`${root}/`))))
   const contents = new Map(materialized.contents)
@@ -319,7 +328,16 @@ async function restoreExcludedHostState(
   excluded: readonly string[],
   state: Awaited<ReturnType<typeof captureExcludedHostState>>,
 ) {
-  const roots = excluded.filter((path, index) => !excluded.some((parent, parentIndex) => parentIndex !== index && path.startsWith(`${parent}/`)))
+  const currentGitRoots = (await listHostEntries(
+    host,
+    root,
+    "",
+    true,
+    entry => Boolean(gitMetadataRoot(entry.path)),
+    true,
+  )).map(entry => gitMetadataRoot(entry.path)!)
+  const excludedRoots = [...new Set([...excluded, ...currentGitRoots])]
+  const roots = excludedRoots.filter((path, index) => !excludedRoots.some((parent, parentIndex) => parentIndex !== index && path.startsWith(`${parent}/`)))
   for (const path of roots.sort((left, right) => right.length - left.length)) {
     await removeHostPath(host, root, toHostPath(root, path), true)
   }
@@ -385,7 +403,7 @@ async function resetHostWorkspaceRoot(host: WorkspaceSessionHost, root: string) 
 }
 
 function isExcludedWriteBackPath(path: string, excluded: readonly string[]) {
-  return excluded.some(item => path === item || path.startsWith(`${item}/`) || item.startsWith(`${path}/`))
+  return Boolean(gitMetadataRoot(path)) || excluded.some(item => path === item || path.startsWith(`${item}/`) || item.startsWith(`${path}/`))
 }
 
 function filterWriteBackDiff(diff: WorkspaceDiff, excluded: readonly string[]): WorkspaceDiff {

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1332,6 +1332,26 @@ describe("workspace host sessions", () => {
     expect(host.readText("/workspace/.git/config")).toBe("checkout")
   })
 
+  it("hides and rejects writes to nested Git metadata", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    await host.files.mkdir("/workspace/nested/.Git", { recursive: true })
+    await host.files.write("/workspace/nested/.Git/config", new TextEncoder().encode("checkout"))
+
+    const session = await docs.startSession({ attach: true, host })
+    await expect(session.list("", { recursive: true })).resolves.not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ path: "nested/.Git/config" }),
+    ]))
+    await expect(session.writeFile("nested/.Git/config", "mutated")).rejects.toThrow("Workspace path escapes")
+    await expect(session.exec("write", ["nested/.Git/config", "mutated"])).resolves.toMatchObject({ exitCode: 0 })
+    await expect(session.exec("write", ["nested/.Git/new", "created"])).resolves.toMatchObject({ exitCode: 0 })
+    await session.commit({ message: "ignore nested Git metadata" })
+    await session.close()
+
+    expect(host.readText("/workspace/nested/.Git/config")).toBe("checkout")
+    expect(host.readText("/workspace/nested/.Git/new")).toBeUndefined()
+  })
+
   it("restores excluded host state after an attached commit", async () => {
     const docs = workspace()
     const host = memoryHost()


### PR DESCRIPTION
Bitácora and Quiver still carried four ViteHub package patches. Most hunks had already landed upstream, but two runtime gaps remained: an active webhook lease could not renew after its clock expiry, and nested case-insensitive .git metadata was exposed to Workspace snapshots and write-back.

Retiring the patches against the packed preview also exposed that queued webhook rehydration and active-run steering were unnecessarily exclusive even though the runtime already has distinct paths for them.

This moves the remaining behavior to the ViteHub boundaries that own it:

- allow the current execution lease token to renew after expiry only when group and key capacity remain available, while current steering ownership and stale-token fencing remain intact
- hide, reject, and restore nested case-insensitive .git metadata
- steer an active webhook run, then rehydrate only when the delivery falls back to the queue

## Verification

- all ViteHub PR checks pass, including consumer and Cloudflare, Netlify, and Vercel verification
- Agent typecheck; accepted/rejected typing regressions: 2 passed; SQLite state-provider tests: 22 passed; steering plus rehydration regression: 1 passed; type tests: 27 passed
- Workspace typecheck; host-session tests: 49 passed. The remaining archive-traversal case needs GNU tar --transform and is unsupported by macOS BSD tar
- targeted lint: 0 errors
- Bitácora 0578081: frozen install, 6 tests, typecheck, build
- Quiver Agents 21b331c: frozen install, typecheck, build
- Quiver Babysitter fd6e309: frozen install, 11 tests, typecheck, build

Those consumer commits use the PR preview to remove every published ViteHub patch while retaining unrelated third-party patches.