### PR TITLE
feat(agent): improve channel message handling

### DIFF
--- a/packages/agent/src/agent-error.ts
+++ b/packages/agent/src/agent-error.ts
@@ -96,6 +96,10 @@ export type AgentPublicErrorCode =
   | "CAPABILITY_NOT_FOUND"
   | "INTERNAL"
   | "LLM_GATE_REJECTED"
+  | "PROVIDER_AUTHENTICATION_FAILED"
+  | "PROVIDER_QUOTA_EXHAUSTED"
+  | "PROVIDER_RATE_LIMITED"
+  | "PROVIDER_UNAVAILABLE"
   | "RATE_LIMIT_REJECTED"
   | "RATE_LIMIT_UNAVAILABLE"
   | "TRANSCRIPTION_AUTHENTICATION_FAILED"
@@ -143,8 +147,50 @@ function publicError(
   return { code, ...(details ? { details } : {}), error }
 }
 
+function aiSdkProviderPublicError(error: unknown): AgentPublicError | undefined {
+  const retry = readAgentErrorProperty(error, "name") === "AI_RetryError"
+    ? readAgentErrorProperty(error, "lastError")
+    : error
+  const name = readAgentErrorProperty(retry, "name")
+  if (name === "AI_LoadAPIKeyError") {
+    return publicError("PROVIDER_AUTHENTICATION_FAILED", "AI provider credentials were rejected.")
+  }
+  if (name !== "AI_APICallError") return
+
+  const status = readAgentErrorProperty(retry, "statusCode")
+  const data = readAgentErrorProperty(retry, "data")
+  const nested = readAgentErrorProperty(data, "error")
+  const code = [
+    readAgentErrorProperty(nested, "code"),
+    readAgentErrorProperty(nested, "type"),
+    readAgentErrorProperty(data, "code"),
+  ].find(value => typeof value === "string")
+  const quota = typeof code === "string" && [
+    "credit_balance_exhausted",
+    "insufficient_quota",
+    "organization_spend_limit_exceeded",
+    "organization_usage_limit_exceeded",
+    "project_spend_limit_exceeded",
+  ].includes(code)
+
+  if (status === 401 || status === 403 && !quota) {
+    return publicError("PROVIDER_AUTHENTICATION_FAILED", "AI provider credentials were rejected.")
+  }
+  if (status === 402 || quota) {
+    return publicError("PROVIDER_QUOTA_EXHAUSTED", "AI provider quota is exhausted.")
+  }
+  if (status === 429) {
+    return publicError("PROVIDER_RATE_LIMITED", "AI provider is temporarily rate limited. Try again later.")
+  }
+  if (typeof status === "number" && status >= 500) {
+    return publicError("PROVIDER_UNAVAILABLE", "AI provider is temporarily unavailable. Try again later.")
+  }
+}
+
 export function toAgentPublicError(error: unknown, context: AgentPublicErrorContext): AgentPublicError {
   try {
+    const providerError = aiSdkProviderPublicError(error)
+    if (providerError) return providerError
     const viteHubError = getViteHubErrorShape(error)
     if (viteHubError?.code === "AUTHENTICATION_REQUIRED") {
       return publicError("AUTHENTICATION_REQUIRED", "Authentication required.")

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -7,7 +7,7 @@ import { cloneWithPropertyDescriptors, toReadableAsyncIterableStream } from "./i
 import { validateAgentOutput } from "./internal/agent-structured-output.ts"
 import { loadAgentWorkflowModule, loadAgentWorkflowRuntimeStateModule } from "./internal/workflow-runtime-loaders.ts"
 import { cloneWorkflowJsonValue, workflowBytesToBase64 } from "./internal/workflow-portability.ts"
-import { agentErrorDetails, agentErrorMessage } from "./agent-error.ts"
+import { agentErrorDetails, agentErrorMessage, toAgentPublicError } from "./agent-error.ts"
 import { agentChannelDeliveryTracker } from "./internal/channel-delivery.ts"
 import {
   createBackedAgentInvocationController,
@@ -201,6 +201,12 @@ export type {
   AgentInvocationSnapshot,
   AgentInvocationStatus,
 } from "./agent-invocation.ts"
+
+export type {
+  AgentPublicError,
+  AgentPublicErrorCode,
+  AgentPublicErrorDetails,
+} from "./agent-error.ts"
 
 export type {
   AgentAccessInvocationContextValue,
@@ -2885,6 +2891,7 @@ function createAgentErrorHookEvent<
     ...errorEvent,
     error: errorEvent.error,
     errorMessage: errorEvent.errorMessage ?? agentErrorDetails(errorEvent.error).message,
+    publicError: toAgentPublicError(errorEvent.error, "http"),
     reaction: delivery.reaction,
     reply: delivery.reply,
     status: delivery.status,

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2468,10 +2468,12 @@ function createChatSdkConfig(
   const identity: ChatConfig["identity"] = options?.identity ?? (options?.transcripts
     ? ({ author }) => author.isBot === true ? null : `${adapterName}:${author.userId}`
     : undefined)
-  const concurrency = chatSdkOption<ChatConfig["concurrency"] | "parallel" | "serial">(options, "concurrency")
+  const concurrency = chatSdkOption<ChatConfig["concurrency"] | "parallel" | "serial" | "steer">(options, "concurrency")
   return objectWithoutUndefined({
     adapters: { [adapterName]: adapter },
-    concurrency: concurrency === "parallel" ? "concurrent" : concurrency === "serial" ? "queue" : concurrency,
+    // TODO: forward active Chat messages through Agent Invocation steering once
+    // model and Workflow runtimes expose the same resumable input contract.
+    concurrency: concurrency === "parallel" ? "concurrent" : concurrency === "serial" || concurrency === "steer" ? "queue" : concurrency,
     dedupeTtlMs: chatSdkOption<number>(options, "dedupeTtlMs"),
     fallbackStreamingPlaceholderText,
     identity,
@@ -2929,6 +2931,7 @@ function chatErrorHookArgs(
     : undefined
   return {
     error,
+    publicError: toAgentPublicError(error, "http"),
     history: input ? uiMessagesToAgentMessages(input.messages) : [],
     message: {
       id: inputMessage?.id || message.id,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -2,6 +2,7 @@ import type { Message, StreamEvent } from "./messages.ts"
 import type { AgentRunEventPublisher, AgentRunEvents } from "./run-events.ts"
 import type { Box, BoxDefinition, BoxRequirement } from "@vite-hub/box"
 import type { StandardJSONSchemaV1, StandardSchemaV1 } from "@standard-schema/spec"
+import type { AgentPublicError } from "./agent-error.ts"
 import type { JSONSchema7 } from "json-schema"
 import type { Adapter, AdapterPostableMessage, IdentityResolver, StateAdapter, TranscriptsConfig } from "chat"
 import type { MountedExtension } from "eve/extension"
@@ -556,6 +557,7 @@ export interface AgentOutputExtensionEvent {
 export interface AgentFinishEvent<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
+  TOutput = unknown,
 > {
   actor: AgentActor
   error?: unknown
@@ -569,7 +571,7 @@ export interface AgentFinishEvent<
     run?: AgentRunMetadata
     usage?: AgentUsageRecord
   }
-  result?: unknown
+  result?: TOutput
   runtime: ResolvedAgentRuntimeContext<TRuntimeConfig> & { runEvents?: AgentRunEventPublisher }
   text?: string
 }
@@ -577,7 +579,8 @@ export interface AgentFinishEvent<
 export type AgentFinishHookEvent<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
-> = Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "error" | "errorMessage"> & {
+  TOutput = unknown,
+> = Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS, TOutput>, "error" | "errorMessage"> & {
   reaction: (input: AgentChannelDeliveryReactionInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"reaction">
   reply: (input: AgentChannelDeliveryReplyInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"reply">
   status: (input: AgentChannelDeliveryStatusInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"status">
@@ -589,6 +592,7 @@ export type AgentErrorHookEvent<
 > = Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "error" | "errorMessage" | "result" | "text"> & {
   error: unknown
   errorMessage: string
+  publicError: AgentPublicError
   reaction: (input: AgentChannelDeliveryReactionInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"reaction">
   reply: (input: AgentChannelDeliveryReplyInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"reply">
   status: (input: AgentChannelDeliveryStatusInput, options?: AgentChannelDeliveryEffectIntentOptions) => AgentChannelDeliveryEffectIntent<"status">
@@ -602,7 +606,10 @@ export type AgentErrorHook<
 export type AgentFinishHook<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
-> = (event: AgentFinishHookEvent<TRuntimeConfig, CALL_OPTIONS>) => MaybePromise<void | AgentChannelDeliveryFinishEffectResult>
+  TOutput = unknown,
+> = {
+  bivarianceHack(event: AgentFinishHookEvent<TRuntimeConfig, CALL_OPTIONS, TOutput>): MaybePromise<void | AgentChannelDeliveryFinishEffectResult>
+}["bivarianceHack"]
 
 export type AgentInputHook<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
@@ -614,9 +621,10 @@ export interface AgentInvocationHooks<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   CALL_OPTIONS = unknown,
   TContextValues extends object = AgentInvocationContextValues,
+  TOutput = unknown,
 > {
   "agent:error"?: AgentErrorHook<TRuntimeConfig, CALL_OPTIONS>
-  "agent:finish"?: AgentFinishHook<TRuntimeConfig, CALL_OPTIONS>
+  "agent:finish"?: AgentFinishHook<TRuntimeConfig, CALL_OPTIONS, TOutput>
   "agent:input"?: AgentInputHook<TRuntimeConfig, CALL_OPTIONS, TContextValues>
 }
 
@@ -1323,13 +1331,14 @@ type AgentSharedSettings<
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
   TContextValues extends object = AgentInvocationContextValues,
   TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined,
+  TOutput = unknown,
 > = {
   box?: BoxDefinition<AgentRunCallbackContext<TRuntimeConfig, CALL_OPTIONS, TContextValues>>
   capabilities?: TCapabilities
   channels?: AgentChannelInputs<TRuntimeConfig>
   cli?: AgentDefinitionCliOptions
   description?: string
-  hooks?: AgentCapabilityHooks<TRuntimeConfig> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS, TContextValues>
+  hooks?: AgentCapabilityHooks<TRuntimeConfig> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS, TContextValues, TOutput>
   invoker?: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues>
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   name?: string
@@ -1349,7 +1358,7 @@ export type AgentSettings<
   TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined,
   TOutput = unknown,
   TDriver extends AgentDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues, TOutput> = AgentDriver<TRuntimeConfig, CALL_OPTIONS, TContextValues, TOutput>,
-> = AgentSharedSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities> & {
+> = AgentSharedSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues, TCapabilities, TOutput> & {
   driver: TDriver
 }
 
@@ -1369,7 +1378,7 @@ export interface AgentDefinition<
   chat?: AgentChatOptions<TRuntimeConfig>
   cli?: AgentDefinitionCliOptions
   description?: string
-  hooks?: AgentCapabilityHooks<TRuntimeConfig, WorkspaceName> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS, TContextValues>
+  hooks?: AgentCapabilityHooks<TRuntimeConfig, WorkspaceName> & AgentHookObserverHooks & AgentInvocationHooks<TRuntimeConfig, CALL_OPTIONS, TContextValues, TOutput>
   invoker?: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile, TContextValues>
   messages?: AgentMessageChannelSettings<TRuntimeConfig>
   name?: string
@@ -1539,6 +1548,7 @@ export interface AgentChatAgentHookArgs<TRuntimeConfig extends AgentRuntimeConfi
 
 export interface AgentChatErrorHookArgs<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> extends AgentChatAgentHookArgs<TRuntimeConfig> {
   error: unknown
+  publicError: AgentPublicError
   toolResults: AgentToolStepItem[]
 }
 
@@ -1607,7 +1617,7 @@ export type AgentChatMessage =
 
 export type AgentChatSendMessage = (message: AgentChatMessage) => Promise<void>
 
-export type AgentMessageConcurrency = "drop" | "parallel" | "queue" | "reject" | "serial" | (string & {})
+export type AgentMessageConcurrency = "drop" | "parallel" | "queue" | "reject" | "serial" | "steer" | (string & {})
 
 export type AgentMessageDeliveryKind = "direct" | "mention" | "subscribed"
 

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -9828,6 +9828,39 @@ describe("server helpers", () => {
     }
   })
 
+  it("posts the sanitized provider quota message to chat", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter({ deferMessageProcessing: true })
+    const error = Object.assign(new Error("private balance"), {
+      data: { error: { code: "insufficient_quota" } },
+      name: "AI_APICallError",
+      statusCode: 429,
+    })
+    const agent = defineAgent({
+      capabilities: [defineChatCapability({
+        platforms: { telegram: () => adapter as never },
+        webhooks: { telegram: {} },
+      })],
+      driver: { run: () => { throw error } },
+    })
+    const tasks: Promise<unknown>[] = []
+
+    try {
+      const response = await createChannelWebhookRouteHandler(agent as never)(chatWebhookRequest(2003), "telegram", {
+        waitUntil: task => tasks.push(task),
+      })
+      expect(response.status).toBe(200)
+      await Promise.all(tasks)
+      expect(adapter.postMessage).toHaveBeenLastCalledWith("telegram:456", "AI provider quota is exhausted.")
+    }
+    finally {
+      consoleError.mockRestore()
+    }
+  })
+
   it("keeps name-spoofed rate-limit errors behind the generic chat fallback", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")
@@ -9867,6 +9900,7 @@ describe("server helpers", () => {
     ["drop", "drop"],
     ["queue", "queue"],
     ["serial", "queue"],
+    ["steer", "queue"],
   ] as const)("maps ViteHub %s message concurrency to Chat SDK %s", async (concurrency, expectedConcurrency) => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -9849,7 +9849,7 @@ describe("server helpers", () => {
     const tasks: Promise<unknown>[] = []
 
     try {
-      const response = await createChannelWebhookRouteHandler(agent as never)(chatWebhookRequest(2003), "telegram", {
+      const response = await createChannelWebhookRouteHandler(agent as never)(chatWebhookRequest(90_003), "telegram", {
         waitUntil: task => tasks.push(task),
       })
       expect(response.status).toBe(200)

--- a/packages/agent/test/public-error.test.ts
+++ b/packages/agent/test/public-error.test.ts
@@ -25,6 +25,24 @@ describe("Agent public error seams", () => {
     })
   })
 
+  it("normalizes AI SDK provider failures without exposing provider payloads", () => {
+    expect(toAgentPublicError({
+      data: { error: { code: "insufficient_quota", message: "private balance" } },
+      name: "AI_APICallError",
+      statusCode: 429,
+    }, "http")).toEqual({
+      code: "PROVIDER_QUOTA_EXHAUSTED",
+      error: "AI provider quota is exhausted.",
+    })
+    expect(toAgentPublicError({
+      lastError: { name: "AI_APICallError", statusCode: 503 },
+      name: "AI_RetryError",
+    }, "http")).toEqual({
+      code: "PROVIDER_UNAVAILABLE",
+      error: "AI provider is temporarily unavailable. Try again later.",
+    })
+  })
+
   it("redacts unowned HTTP failures and hostile metadata", async () => {
     const hostile = new Proxy({}, {
       get() {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -6026,7 +6026,7 @@ describe("agent message protocol", () => {
   it("rejects overlap-policy concurrency with durable message delivery", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
-    for (const concurrency of ["drop", "queue", "reject", "serial", "tenant-policy"] as const) {
+    for (const concurrency of ["drop", "queue", "reject", "serial", "steer", "tenant-policy"] as const) {
       expect(() => defineAgent({
         channels: { telegram: telegram({ adapter: () => ({}) as never }) },
         driver: { run: () => "ok" },

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -10,7 +10,7 @@ import { remoteMcpServer } from "../src/mcp.ts"
 import { stdioMcpServer } from "../src/mcp/stdio.ts"
 import { streamAgentOutputToEvents, toAgentRunResult } from "../src/output.ts"
 import { defineAgentRunEvents, type AgentRunEventPublisher } from "../src/server.ts"
-import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentOutputExtensionProvider, AgentToolDefinition, AgentToolSchema, StreamEvent } from "../src/index.ts"
+import type { AgentChatFinishExtension, AgentInvocationContextStore, AgentInvokerProfile, AgentOutputExtensionProvider, AgentPublicError, AgentToolDefinition, AgentToolSchema, StreamEvent } from "../src/index.ts"
 import type { MCPClient } from "@ai-sdk/mcp"
 import type { StandardSchemaV1 } from "@standard-schema/spec"
 import githubExtension from "@github-tools/eve-extension"
@@ -151,6 +151,7 @@ describe("agent public types", () => {
           expectTypeOf<AgentErrorHookEvent>().toMatchTypeOf<{ error: unknown }>()
           expectTypeOf(event.error).toEqualTypeOf<unknown>()
           expectTypeOf(event.errorMessage).toEqualTypeOf<string>()
+          expectTypeOf(event.publicError).toEqualTypeOf<AgentPublicError>()
           // @ts-expect-error Agent Error Hooks do not receive successful results.
           void event.result
           // @ts-expect-error Agent Error Hooks do not receive successful text.
@@ -271,6 +272,11 @@ describe("agent public types", () => {
     } satisfies StandardSchemaV1<unknown, { summary: string, title: string }>
     const agent = defineAgent({
       driver: { output: { schema }, run: () => "{}" },
+      hooks: {
+        "agent:finish"(event) {
+          expectTypeOf(event.result).toEqualTypeOf<{ summary: string, title: string } | undefined>()
+        },
+      },
       runtime: false,
     })
     const result = runAgentInline(agent, {} as AgentRuntimeContext, {})


### PR DESCRIPTION
Channel consumers currently need app-level plumbing to classify provider failures and recover typed structured output, while correction-heavy chats cannot express steering intent. This moves those shared seams into the Agent boundary.

- Normalize AI SDK authentication, quota, rate-limit, and availability failures into sanitized public errors, expose `publicError` to hooks, and use those errors in the default channel fallback.
- Infer Standard Schema output in finish hooks so consumers can use `event.result` without a parallel type declaration.
- Accept `messages.concurrency: "steer"`; Chat uses queue semantics until model and Workflow runtimes expose the same resumable-input contract, which is recorded as an implementation TODO.

## Verification

- `corepack pnpm --filter @vite-hub/agent build`
- `corepack pnpm --filter @vite-hub/agent typecheck`
- Provider public-error tests: 4 passed
- Chat error/concurrency tests: 7 passed
- Durable concurrency test: 1 passed

The full package suite was also attempted. After fixing a test update-ID collision introduced here, eight unrelated tests remained blocked by fresh-worktree timeouts or missing root build output; all changed-path tests pass independently.
