### PR TITLE
fix(env): require declared Cloudflare secrets

### DIFF
--- a/docs/content/docs/frameworks-hosts/cloudflare.md
+++ b/docs/content/docs/frameworks-hosts/cloudflare.md
@@ -77,7 +77,7 @@ find dist -maxdepth 4 -type f | sort
 
 Agent routes should come from generated Provider Output. Raw Cloudflare Worker fetch handlers are not a public Agent API.
 
-Required secret Server Env declarations with one exact Env Source are written to `secrets.required` in the generated Wrangler configuration. Wrangler reuses an existing Worker secret and stops deployment when that binding is absent; ViteHub records only the binding name and never resolves or writes its value during build. Optional secrets, non-secret values, defaults, and alternative source lists remain runtime-only because Wrangler's required list cannot express fallback names.
+Required secret Server Env declarations with one exact Env Source are written to `secrets.required` in the generated Wrangler configuration, including each configured named Wrangler environment because secrets are not inherited. Wrangler reuses an existing Worker secret and stops deployment when that binding is absent; ViteHub records only the binding name and never resolves or writes its value during build. Optional secrets, non-secret values, defaults, and alternative source lists remain runtime-only because Wrangler's required list cannot express fallback names.
 
 ### Workers Builds
 

--- a/docs/content/docs/frameworks-hosts/cloudflare.md
+++ b/docs/content/docs/frameworks-hosts/cloudflare.md
@@ -77,6 +77,8 @@ find dist -maxdepth 4 -type f | sort
 
 Agent routes should come from generated Provider Output. Raw Cloudflare Worker fetch handlers are not a public Agent API.
 
+Required secret Server Env declarations with one exact Env Source are written to `secrets.required` in the generated Wrangler configuration. Wrangler reuses an existing Worker secret and stops deployment when that binding is absent; ViteHub records only the binding name and never resolves or writes its value during build. Optional secrets, non-secret values, defaults, and alternative source lists remain runtime-only because Wrangler's required list cannot express fallback names.
+
 ### Workers Builds
 
 Use Nitro's generated deployment command for production and non-production Workers Builds:

--- a/packages/env/src/vite.ts
+++ b/packages/env/src/vite.ts
@@ -23,6 +23,7 @@ export { createRuntimeRegistry as createRuntimeEnvRegistry } from "./core/resolv
 
 import type {
   EnvIntegrationOptions,
+  EnvRuntimeConfigOptions,
   EnvRuntimeImportSpecifiers,
   EnvRuntimeRegistry,
   EnvRuntimeRegistryValue,
@@ -45,6 +46,7 @@ const defaultRuntimeImports = {
 export { env }
 
 export interface EnvVitePluginAPI {
+  createServerEnvRegistry: (declarations: EnvRuntimeConfigOptions | undefined) => EnvRuntimeRegistry
   getPublicEnv: () => Record<string, unknown>
   getServerEnvRegistry: () => EnvRuntimeRegistry
   resolveProjectRoot: (viteRoot: string) => string
@@ -76,12 +78,13 @@ export function hubEnv(options: EnvIntegrationOptions = {}): EnvVitePlugin {
   let diagnosticsText: string | undefined
   const getPublicEnv = () => buildPublicConfig
   const getServerEnvRegistry = () => serverRegistry
+  const createServerEnvRegistry = (declarations: EnvRuntimeConfigOptions | undefined) => createRuntimeRegistry(declarations, { prefix: options.prefix })
   const resolveProjectRoot = (viteRoot: string) => resolveViteHubProjectRoot(resolve(viteRoot), { projectRoot: options.projectRoot })
   const runtimeImports = resolveRuntimeImports(options.runtimeImports)
 
   return {
     name: ENV_VITE_PLUGIN_NAME,
-    api: { getPublicEnv, getServerEnvRegistry, resolveProjectRoot },
+    api: { createServerEnvRegistry, getPublicEnv, getServerEnvRegistry, resolveProjectRoot },
     async config(config, env) {
       const envConfig = (config as UserConfig & EnvViteUserConfig).env
       validateEnvConfigShape(envConfig, "vite")
@@ -113,9 +116,7 @@ export function hubEnv(options: EnvIntegrationOptions = {}): EnvVitePlugin {
       })
 
       buildPublicConfig = Object.fromEntries(publicResult.entries.map(entry => [entry.key, entry.value]))
-      serverRegistry = createRuntimeRegistry(envConfig.server, {
-        prefix: options.prefix,
-      })
+      serverRegistry = createServerEnvRegistry(envConfig.server)
       diagnosticsText = formatDiagnostics([...publicResult.diagnostics, ...defineResult.diagnostics], options.diagnostics)
 
       return {

--- a/packages/env/src/vite.ts
+++ b/packages/env/src/vite.ts
@@ -49,6 +49,7 @@ export interface EnvVitePluginAPI {
   createServerEnvRegistry: (declarations: EnvRuntimeConfigOptions | undefined) => EnvRuntimeRegistry
   getPublicEnv: () => Record<string, unknown>
   getServerEnvRegistry: () => EnvRuntimeRegistry
+  onServerEnvRegistry: (handler: (registry: EnvRuntimeRegistry, config: UserConfig) => void) => void
   resolveProjectRoot: (viteRoot: string) => string
 }
 
@@ -76,6 +77,7 @@ export function hubEnv(options: EnvIntegrationOptions = {}): EnvVitePlugin {
   let buildPublicConfig: Record<string, unknown> = {}
   let serverRegistry: EnvRuntimeRegistry = {}
   let diagnosticsText: string | undefined
+  const serverRegistryHandlers = new Set<(registry: EnvRuntimeRegistry, config: UserConfig) => void>()
   const getPublicEnv = () => buildPublicConfig
   const getServerEnvRegistry = () => serverRegistry
   const createServerEnvRegistry = (declarations: EnvRuntimeConfigOptions | undefined) => createRuntimeRegistry(declarations, { prefix: options.prefix })
@@ -84,7 +86,13 @@ export function hubEnv(options: EnvIntegrationOptions = {}): EnvVitePlugin {
 
   return {
     name: ENV_VITE_PLUGIN_NAME,
-    api: { createServerEnvRegistry, getPublicEnv, getServerEnvRegistry, resolveProjectRoot },
+    api: {
+      createServerEnvRegistry,
+      getPublicEnv,
+      getServerEnvRegistry,
+      onServerEnvRegistry: handler => serverRegistryHandlers.add(handler),
+      resolveProjectRoot,
+    },
     async config(config, env) {
       const envConfig = (config as UserConfig & EnvViteUserConfig).env
       validateEnvConfigShape(envConfig, "vite")
@@ -117,6 +125,7 @@ export function hubEnv(options: EnvIntegrationOptions = {}): EnvVitePlugin {
 
       buildPublicConfig = Object.fromEntries(publicResult.entries.map(entry => [entry.key, entry.value]))
       serverRegistry = createServerEnvRegistry(envConfig.server)
+      for (const handler of serverRegistryHandlers) handler(serverRegistry, config)
       diagnosticsText = formatDiagnostics([...publicResult.diagnostics, ...defineResult.diagnostics], options.diagnostics)
 
       return {

--- a/packages/env/src/vite.ts
+++ b/packages/env/src/vite.ts
@@ -97,6 +97,8 @@ export function hubEnv(options: EnvIntegrationOptions = {}): EnvVitePlugin {
       const envConfig = (config as UserConfig & EnvViteUserConfig).env
       validateEnvConfigShape(envConfig, "vite")
       if (!envConfig) {
+        serverRegistry = {}
+        for (const handler of serverRegistryHandlers) handler(serverRegistry, config)
         return
       }
 

--- a/packages/internal/src/build/cloudflare-provider-output.ts
+++ b/packages/internal/src/build/cloudflare-provider-output.ts
@@ -32,6 +32,7 @@ interface CloudflareProviderOutputContribution {
   r2Buckets?: CloudflareR2Bucket[]
   rateLimits?: CloudflareRateLimit[]
   requiredSecrets?: string[]
+  requiredSecretsByEnvironment?: Record<string, string[]>
 }
 
 interface CloudflareProviderOutputCatalog {
@@ -90,8 +91,9 @@ function removeEntries(existing: unknown, entries: unknown[] | undefined): unkno
 function removeContribution(wrangler: Record<string, unknown>, contribution: CloudflareProviderOutputContribution): Record<string, unknown> {
   const queues = cloneProviderRecord(wrangler.queues)
   const secrets = cloneProviderRecord(wrangler.secrets)
+  const environments = cloneProviderRecord(wrangler.env)
   const hasQueues = Boolean(contribution.queues?.consumers?.length || contribution.queues?.producers?.length)
-  const hasSecrets = Boolean(contribution.requiredSecrets?.length)
+  const hasSecrets = Boolean(contribution.requiredSecrets?.length || Object.keys(contribution.requiredSecretsByEnvironment ?? {}).length)
   if (contribution.queues?.consumers?.length) {
     const consumers = removeEntries(queues.consumers, contribution.queues.consumers)
     if (consumers.length) queues.consumers = consumers
@@ -107,13 +109,25 @@ function removeContribution(wrangler: Record<string, unknown>, contribution: Clo
     if (required.length) secrets.required = required
     else delete secrets.required
   }
+  for (const [name, requiredSecrets] of Object.entries(contribution.requiredSecretsByEnvironment ?? {})) {
+    const environment = cloneProviderRecord(environments[name])
+    const environmentSecrets = cloneProviderRecord(environment.secrets)
+    const required = removeEntries(environmentSecrets.required, requiredSecrets)
+    if (required.length) environmentSecrets.required = required
+    else delete environmentSecrets.required
+    if (Object.keys(environmentSecrets).length) environment.secrets = environmentSecrets
+    else delete environment.secrets
+    environments[name] = environment
+  }
   const withoutOwned = { ...wrangler }
   if (hasQueues) delete withoutOwned.queues
   if (hasSecrets) delete withoutOwned.secrets
+  if (hasSecrets) delete withoutOwned.env
   return {
     ...withoutOwned,
     ...(hasQueues && Object.keys(queues).length ? { queues } : {}),
     ...(hasSecrets && Object.keys(secrets).length ? { secrets } : {}),
+    ...(hasSecrets && Object.keys(environments).length ? { env: environments } : {}),
     ...(contribution.r2Buckets?.length ? { r2_buckets: removeEntries(wrangler.r2_buckets, contribution.r2Buckets) } : {}),
     ...(contribution.rateLimits?.length ? { ratelimits: removeEntries(wrangler.ratelimits, contribution.rateLimits) } : {}),
   }
@@ -122,6 +136,7 @@ function removeContribution(wrangler: Record<string, unknown>, contribution: Clo
 function mergeContribution(wrangler: Record<string, unknown>, owner: string, contribution: CloudflareProviderOutputContribution): [Record<string, unknown>, CloudflareProviderOutputContribution] {
   const queues = cloneProviderRecord(wrangler.queues)
   const secrets = cloneProviderRecord(wrangler.secrets)
+  const environments = cloneProviderRecord(wrangler.env)
   const consumers = compatibleEntries(queues.consumers, contribution.queues?.consumers, "queue", [], owner)
   const producers = compatibleEntries(queues.producers, contribution.queues?.producers, "binding", ["queue"], owner)
   const r2Buckets = compatibleEntries(wrangler.r2_buckets, contribution.r2Buckets, "binding", ["bucket_name"], owner)
@@ -129,6 +144,19 @@ function mergeContribution(wrangler: Record<string, unknown>, owner: string, con
   const currentRequiredSecrets = Array.isArray(secrets.required) ? secrets.required : []
   const requiredSecrets = (contribution.requiredSecrets ?? []).filter(name => !currentRequiredSecrets.includes(name))
   if (requiredSecrets.length) secrets.required = [...currentRequiredSecrets, ...requiredSecrets]
+  const requiredSecretsByEnvironment: Record<string, string[]> = {}
+  for (const [name, value] of Object.entries(environments)) {
+    const environment = cloneProviderRecord(value)
+    const environmentSecrets = cloneProviderRecord(environment.secrets)
+    const current = Array.isArray(environmentSecrets.required) ? environmentSecrets.required : []
+    const required = (contribution.requiredSecrets ?? []).filter(secret => !current.includes(secret))
+    if (required.length) {
+      environmentSecrets.required = [...current, ...required]
+      environment.secrets = environmentSecrets
+      environments[name] = environment
+      requiredSecretsByEnvironment[name] = required
+    }
+  }
   const nextQueues = mergeProviderOutputConfig(
     queues,
     {
@@ -149,6 +177,7 @@ function mergeContribution(wrangler: Record<string, unknown>, owner: string, con
       ...(r2Buckets.length ? { r2_buckets: r2Buckets } : {}),
       ...(rateLimits.length ? { ratelimits: rateLimits } : {}),
       ...(Object.keys(secrets).length ? { secrets } : {}),
+      ...(Object.keys(environments).length ? { env: environments } : {}),
     },
     {
       arrays: {
@@ -161,6 +190,7 @@ function mergeContribution(wrangler: Record<string, unknown>, owner: string, con
     r2Buckets,
     rateLimits,
     requiredSecrets,
+    requiredSecretsByEnvironment,
   }]
 }
 

--- a/packages/internal/src/build/cloudflare-provider-output.ts
+++ b/packages/internal/src/build/cloudflare-provider-output.ts
@@ -31,6 +31,7 @@ interface CloudflareProviderOutputContribution {
   }
   r2Buckets?: CloudflareR2Bucket[]
   rateLimits?: CloudflareRateLimit[]
+  requiredSecrets?: string[]
 }
 
 interface CloudflareProviderOutputCatalog {
@@ -81,14 +82,16 @@ function compatibleEntries<T extends Record<string, unknown>>(existing: unknown,
   })
 }
 
-function removeEntries(existing: unknown, entries: Array<Record<string, unknown>> | undefined): unknown[] {
+function removeEntries(existing: unknown, entries: unknown[] | undefined): unknown[] {
   if (!Array.isArray(existing) || !entries?.length) return Array.isArray(existing) ? existing : []
   return existing.filter(entry => !entries.some(previous => isDeepStrictEqual(entry, previous)))
 }
 
 function removeContribution(wrangler: Record<string, unknown>, contribution: CloudflareProviderOutputContribution): Record<string, unknown> {
   const queues = cloneProviderRecord(wrangler.queues)
+  const secrets = cloneProviderRecord(wrangler.secrets)
   const hasQueues = Boolean(contribution.queues?.consumers?.length || contribution.queues?.producers?.length)
+  const hasSecrets = Boolean(contribution.requiredSecrets?.length)
   if (contribution.queues?.consumers?.length) {
     const consumers = removeEntries(queues.consumers, contribution.queues.consumers)
     if (consumers.length) queues.consumers = consumers
@@ -99,10 +102,18 @@ function removeContribution(wrangler: Record<string, unknown>, contribution: Clo
     if (producers.length) queues.producers = producers
     else delete queues.producers
   }
-  const { queues: _queues, ...withoutQueues } = wrangler
+  if (contribution.requiredSecrets?.length) {
+    const required = removeEntries(secrets.required, contribution.requiredSecrets)
+    if (required.length) secrets.required = required
+    else delete secrets.required
+  }
+  const withoutOwned = { ...wrangler }
+  if (hasQueues) delete withoutOwned.queues
+  if (hasSecrets) delete withoutOwned.secrets
   return {
-    ...(hasQueues ? withoutQueues : wrangler),
+    ...withoutOwned,
     ...(hasQueues && Object.keys(queues).length ? { queues } : {}),
+    ...(hasSecrets && Object.keys(secrets).length ? { secrets } : {}),
     ...(contribution.r2Buckets?.length ? { r2_buckets: removeEntries(wrangler.r2_buckets, contribution.r2Buckets) } : {}),
     ...(contribution.rateLimits?.length ? { ratelimits: removeEntries(wrangler.ratelimits, contribution.rateLimits) } : {}),
   }
@@ -110,10 +121,14 @@ function removeContribution(wrangler: Record<string, unknown>, contribution: Clo
 
 function mergeContribution(wrangler: Record<string, unknown>, owner: string, contribution: CloudflareProviderOutputContribution): [Record<string, unknown>, CloudflareProviderOutputContribution] {
   const queues = cloneProviderRecord(wrangler.queues)
+  const secrets = cloneProviderRecord(wrangler.secrets)
   const consumers = compatibleEntries(queues.consumers, contribution.queues?.consumers, "queue", [], owner)
   const producers = compatibleEntries(queues.producers, contribution.queues?.producers, "binding", ["queue"], owner)
   const r2Buckets = compatibleEntries(wrangler.r2_buckets, contribution.r2Buckets, "binding", ["bucket_name"], owner)
   const rateLimits = compatibleEntries(wrangler.ratelimits, contribution.rateLimits, "name", ["namespace_id", "simple"], owner)
+  const currentRequiredSecrets = Array.isArray(secrets.required) ? secrets.required : []
+  const requiredSecrets = (contribution.requiredSecrets ?? []).filter(name => !currentRequiredSecrets.includes(name))
+  if (requiredSecrets.length) secrets.required = [...currentRequiredSecrets, ...requiredSecrets]
   const nextQueues = mergeProviderOutputConfig(
     queues,
     {
@@ -133,6 +148,7 @@ function mergeContribution(wrangler: Record<string, unknown>, owner: string, con
       ...(Object.keys(nextQueues).length ? { queues: nextQueues } : {}),
       ...(r2Buckets.length ? { r2_buckets: r2Buckets } : {}),
       ...(rateLimits.length ? { ratelimits: rateLimits } : {}),
+      ...(Object.keys(secrets).length ? { secrets } : {}),
     },
     {
       arrays: {
@@ -144,6 +160,7 @@ function mergeContribution(wrangler: Record<string, unknown>, owner: string, con
     queues: { consumers, producers },
     r2Buckets,
     rateLimits,
+    requiredSecrets,
   }]
 }
 

--- a/packages/internal/src/build/cloudflare-provider-output.ts
+++ b/packages/internal/src/build/cloudflare-provider-output.ts
@@ -110,6 +110,7 @@ function removeContribution(wrangler: Record<string, unknown>, contribution: Clo
     else delete secrets.required
   }
   for (const [name, requiredSecrets] of Object.entries(contribution.requiredSecretsByEnvironment ?? {})) {
+    if (!(name in environments)) continue
     const environment = cloneProviderRecord(environments[name])
     const environmentSecrets = cloneProviderRecord(environment.secrets)
     const required = removeEntries(environmentSecrets.required, requiredSecrets)

--- a/packages/internal/test/cloudflare-provider-output.test.ts
+++ b/packages/internal/test/cloudflare-provider-output.test.ts
@@ -90,6 +90,34 @@ describe("Cloudflare provider output", () => {
     )
   })
 
+  it("composes and removes required secrets independently in named environments", () => {
+    const config = {}
+    registerCloudflareProviderOutput(config, "env", {
+      requiredSecrets: ["EXISTING_SECRET", "VITEHUB_TOKEN"],
+    })
+
+    const first = composeNitroCloudflareProviderOutput(config, {
+      cloudflare: {
+        wrangler: {
+          secrets: { required: ["EXISTING_SECRET"] },
+          env: {
+            staging: { secrets: { required: ["VITEHUB_TOKEN"] } },
+            production: { name: "production-worker" },
+          },
+        },
+      },
+    })
+    expect(first).toHaveProperty("cloudflare.wrangler.env.staging.secrets.required", ["VITEHUB_TOKEN", "EXISTING_SECRET"])
+    expect(first).toHaveProperty("cloudflare.wrangler.env.production.secrets.required", ["EXISTING_SECRET", "VITEHUB_TOKEN"])
+
+    registerCloudflareProviderOutput(config, "env", {})
+    const second = composeNitroCloudflareProviderOutput(config, first)
+    expect(second).toHaveProperty("cloudflare.wrangler.secrets.required", ["EXISTING_SECRET"])
+    expect(second).toHaveProperty("cloudflare.wrangler.env.staging.secrets.required", ["VITEHUB_TOKEN"])
+    expect(second).not.toHaveProperty("cloudflare.wrangler.env.production.secrets")
+    expect(second).toHaveProperty("cloudflare.wrangler.env.production.name", "production-worker")
+  })
+
   it("replaces an owner's contribution without changing application policy", () => {
     const config = {}
     registerCloudflareProviderOutput(config, "queue", {

--- a/packages/internal/test/cloudflare-provider-output.test.ts
+++ b/packages/internal/test/cloudflare-provider-output.test.ts
@@ -68,6 +68,28 @@ describe("Cloudflare provider output", () => {
     ).toThrow(/already assigned/)
   })
 
+  it("composes required secrets without taking ownership of existing names", () => {
+    const config = {}
+    registerCloudflareProviderOutput(config, "env", {
+      requiredSecrets: ["EXISTING_SECRET", "VITEHUB_TOKEN"],
+    })
+
+    const first = composeNitroCloudflareProviderOutput(config, {
+      cloudflare: {
+        wrangler: {
+          secrets: { required: ["EXISTING_SECRET"] },
+        },
+      },
+    })
+    expect(first).toHaveProperty("cloudflare.wrangler.secrets.required", ["EXISTING_SECRET", "VITEHUB_TOKEN"])
+
+    registerCloudflareProviderOutput(config, "env", {})
+    expect(composeNitroCloudflareProviderOutput(config, first)).toHaveProperty(
+      "cloudflare.wrangler.secrets.required",
+      ["EXISTING_SECRET"],
+    )
+  })
+
   it("replaces an owner's contribution without changing application policy", () => {
     const config = {}
     registerCloudflareProviderOutput(config, "queue", {

--- a/packages/internal/test/cloudflare-provider-output.test.ts
+++ b/packages/internal/test/cloudflare-provider-output.test.ts
@@ -116,6 +116,19 @@ describe("Cloudflare provider output", () => {
     expect(second).toHaveProperty("cloudflare.wrangler.env.staging.secrets.required", ["VITEHUB_TOKEN"])
     expect(second).not.toHaveProperty("cloudflare.wrangler.env.production.secrets")
     expect(second).toHaveProperty("cloudflare.wrangler.env.production.name", "production-worker")
+
+    const removalConfig = {}
+    registerCloudflareProviderOutput(removalConfig, "env", { requiredSecrets: ["VITEHUB_TOKEN"] })
+    const withEnvironment = composeNitroCloudflareProviderOutput(removalConfig, {
+      cloudflare: { wrangler: { env: { staging: { name: "staging-worker" } } } },
+    })
+    const withEnvironmentCloudflare = withEnvironment.cloudflare as { wrangler: Record<string, unknown> }
+    const { env: _env, ...wranglerWithoutEnvironments } = withEnvironmentCloudflare.wrangler
+    const withoutEnvironments = composeNitroCloudflareProviderOutput(removalConfig, {
+      ...withEnvironment,
+      cloudflare: { ...withEnvironmentCloudflare, wrangler: wranglerWithoutEnvironments },
+    })
+    expect(withoutEnvironments).not.toHaveProperty("cloudflare.wrangler.env")
   })
 
   it("replaces an owner's contribution without changing application policy", () => {

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -21,6 +21,7 @@ import { hubSandbox } from "@vite-hub/sandbox/vite"
 import { hubSchedule } from "@vite-hub/schedule/vite"
 import { hubWorkflow } from "@vite-hub/workflow/vite"
 import { hubWorkspace } from "@vite-hub/workspace/vite"
+import { composeNitroCloudflareProviderOutput, registerCloudflareProviderOutput } from "@vite-hub/internal/build/deployment-output"
 import { finalizeDeploymentPlanOutput } from "@vite-hub/internal/build/deployment-plan-output"
 import { finalizeDenoDeploymentOutput } from "@vite-hub/internal/build/deno-runtime-packages"
 import { assertDeploymentService, deploymentPresetFromNitro, resolveDeploymentPlan } from "@vite-hub/internal/deployment"
@@ -34,7 +35,8 @@ import type { BrowserModuleOptions } from "@vite-hub/browser/vite"
 import type { ChannelsVitePluginOptions } from "@vite-hub/channels/vite"
 import type { DBModulePublicOptions } from "@vite-hub/database"
 import type { EmailVitePluginOptions } from "@vite-hub/email/vite"
-import type { EnvIntegrationOptions } from "@vite-hub/env"
+import type { EnvIntegrationOptions, EnvRuntimeRegistry } from "@vite-hub/env"
+import type { EnvVitePlugin } from "@vite-hub/env/vite"
 import type { KVModuleOptions } from "@vite-hub/kv"
 import type { DeploymentPlan, DeploymentService } from "@vite-hub/internal/deployment"
 import type { QueueModuleOptions } from "@vite-hub/queue"
@@ -282,6 +284,29 @@ function cloneRecord(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value) ? { ...value } : {}
 }
 
+function requiredCloudflareSecretNames(registry: EnvRuntimeRegistry): string[] {
+  const names = new Set<string>()
+  const visit = (value: unknown): void => {
+    const entry = cloneRecord(value)
+    const source = cloneRecord(entry.source)
+    if (source.kind === "env" && typeof source.name === "string") {
+      const sources = Array.isArray(source.names) ? source.names : [source.name]
+      if (
+        entry.required === true
+        && entry.secret === true
+        && entry.default === undefined
+        && sources.length === 1
+        && typeof sources[0] === "string"
+      ) names.add(sources[0])
+      return
+    }
+    if (entry.kind === "literal") return
+    for (const child of Object.values(entry)) visit(child)
+  }
+  for (const value of Object.values(registry)) visit(value)
+  return [...names]
+}
+
 function matchesRollupExternal(value: unknown, source: string, args: unknown[]): boolean {
   if (typeof value === "string") return value === source
   if (value instanceof RegExp) {
@@ -353,6 +378,7 @@ function deploymentPlugins(
   blobEnabled: boolean,
   services: object,
   options: ViteHubOptions,
+  envPlugin: EnvVitePlugin | undefined,
 ): Plugin[] {
   let deployCommandOwned = false
   const nitroPreset = plan.preset === "cloudflare" && options.realtime ? "cloudflare-durable" : plan.nitroPreset
@@ -477,6 +503,14 @@ function deploymentPlugins(
     {
       name: "vite-hub/deployment-output",
       enforce: "post",
+      config(config) {
+        if (plan.preset !== "cloudflare" || !envPlugin) return
+        registerCloudflareProviderOutput(config, "env", {
+          requiredSecrets: requiredCloudflareSecretNames(envPlugin.api.getServerEnvRegistry()),
+        })
+        const viteConfig = config as { nitro?: unknown }
+        viteConfig.nitro = composeNitroCloudflareProviderOutput(config, viteConfig.nitro)
+      },
       configResolved(config) {
         const nitro = cloneRecord((config as { nitro?: unknown }).nitro)
         deployCommandOwned = typeof cloneRecord(nitro.commands).deploy === "string"
@@ -536,7 +570,17 @@ export function vitehub(options: ViteHubOptions): PluginOption[] {
   const manifestServices = hasExplicitBlobStore(options.blob)
     ? { ...plan.services, blob: { configured: true, supported: true } }
     : plan.services
-  plugins.push(...deploymentPlugins(plan, requestedServices, blobEnabled, manifestServices, options))
+  const envPlugin = options.env === false
+    ? undefined
+    : hubEnv({
+        ...options.env,
+        runtimeImports: {
+          secret: "vite-hub/env/secret",
+          server: "vite-hub/env/server",
+          ...options.env?.runtimeImports,
+        },
+      })
+  plugins.push(...deploymentPlugins(plan, requestedServices, blobEnabled, manifestServices, options, envPlugin))
   const providerImportAliases: Record<string, string> = {}
   const configuredKV = options.kv && options.kv !== true ? options.kv : undefined
   const presetKV = options.kv ? resolveKVViteConfig(configuredKV, { hosting: plan.nitroPreset }).kv : false
@@ -547,17 +591,7 @@ export function vitehub(options: ViteHubOptions): PluginOption[] {
   plugins.push(frameworkDependencyResolver(options, providerImportAliases, blobEnabled, presetKVOptions || undefined))
   plugins.push(hubMarkdownTemplate({ runtimeImport: `${generatedImportBase}/markdown-template` }))
 
-  if (options.env !== false) {
-    const envOptions = options.env ?? {}
-    plugins.push(hubEnv({
-      ...envOptions,
-      runtimeImports: {
-        secret: "vite-hub/env/secret",
-        server: "vite-hub/env/server",
-        ...envOptions.runtimeImports,
-      },
-    }))
-  }
+  if (envPlugin) plugins.push(envPlugin)
 
   if (options.auth) {
     plugins.push(hubAuth({

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -11,7 +11,7 @@ import { hubBrowser } from "@vite-hub/browser/vite"
 import { hubChannels } from "@vite-hub/channels/vite"
 import { hubDb } from "@vite-hub/database/vite"
 import { hubEmail } from "@vite-hub/email/vite"
-import { createRuntimeEnvRegistry, hubEnv } from "@vite-hub/env/vite"
+import { hubEnv } from "@vite-hub/env/vite"
 import { hubKv, hubKvOptionalPeerResolver, resolveKVViteConfig } from "@vite-hub/kv/vite"
 import { hubMarkdownTemplate } from "@vite-hub/markdown-template/vite"
 import { hubQueue } from "@vite-hub/queue/vite"
@@ -517,10 +517,9 @@ function deploymentPlugins(
         if (plan.preset === "cloudflare") {
           deploymentEnvPlugin.current ??= findEnvPlugin(config.plugins)
           if (deploymentEnvPlugin.current) {
-            const envConfig = (config as { env?: { server?: Parameters<typeof createRuntimeEnvRegistry>[0] } }).env
-            const prefix = options.env && typeof options.env === "object" ? options.env.prefix : undefined
+            const envConfig = (config as { env?: { server?: Parameters<EnvVitePlugin["api"]["createServerEnvRegistry"]>[0] } }).env
             registerCloudflareProviderOutput(config, "env", {
-              requiredSecrets: requiredCloudflareSecretNames(createRuntimeEnvRegistry(envConfig?.server, { prefix })),
+              requiredSecrets: requiredCloudflareSecretNames(deploymentEnvPlugin.current.api.createServerEnvRegistry(envConfig?.server)),
             })
             nitro = composeNitroCloudflareProviderOutput(config, nitro)
           }

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -381,6 +381,7 @@ function deploymentPlugins(
   envPlugin: EnvVitePlugin | undefined,
 ): Plugin[] {
   let deployCommandOwned = false
+  const deploymentEnvPlugin = { current: envPlugin }
   const nitroPreset = plan.preset === "cloudflare" && options.realtime ? "cloudflare-durable" : plan.nitroPreset
   return [
     {
@@ -503,10 +504,17 @@ function deploymentPlugins(
     {
       name: "vite-hub/deployment-output",
       enforce: "post",
+      vitehub: {
+        deploymentOutput: {
+          useEnvPlugin(plugin: EnvVitePlugin) {
+            deploymentEnvPlugin.current = plugin
+          },
+        },
+      },
       config(config) {
-        if (plan.preset !== "cloudflare" || !envPlugin) return
+        if (plan.preset !== "cloudflare" || !deploymentEnvPlugin.current) return
         registerCloudflareProviderOutput(config, "env", {
-          requiredSecrets: requiredCloudflareSecretNames(envPlugin.api.getServerEnvRegistry()),
+          requiredSecrets: requiredCloudflareSecretNames(deploymentEnvPlugin.current.api.getServerEnvRegistry()),
         })
         const viteConfig = config as { nitro?: unknown }
         viteConfig.nitro = composeNitroCloudflareProviderOutput(config, viteConfig.nitro)
@@ -518,7 +526,7 @@ function deploymentPlugins(
           throw new Error("[vitehub] The " + JSON.stringify(plan.preset) + " deployment plan requires Nitro preset " + JSON.stringify(nitroPreset) + ".")
         }
       },
-    },
+    } as Plugin,
   ]
 }
 

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -47,7 +47,7 @@ import type { SandboxPublicOptions } from "@vite-hub/sandbox/vite"
 import type { ScheduleVitePluginOptions } from "@vite-hub/schedule/vite"
 import type { WorkflowModuleOptions } from "@vite-hub/workflow"
 import type { WorkspaceModuleOptions } from "@vite-hub/workspace"
-import type { Plugin, PluginOption } from "vite"
+import type { Plugin, PluginOption, UserConfig } from "vite"
 
 type FrameworkDependencyName = Extract<keyof typeof frameworkPackageManifest.dependencies, `@vite-hub/${string}`>
 
@@ -398,6 +398,20 @@ function deploymentPlugins(
 ): Plugin[] {
   let deployCommandOwned = false
   const deploymentEnvPlugin = { current: envPlugin }
+  const subscribedEnvPlugins = new WeakSet<EnvVitePlugin>()
+  const subscribeEnvPlugin = (plugin: EnvVitePlugin): void => {
+    deploymentEnvPlugin.current = plugin
+    if (subscribedEnvPlugins.has(plugin) || plan.preset !== "cloudflare") return
+    subscribedEnvPlugins.add(plugin)
+    plugin.api.onServerEnvRegistry((registry: EnvRuntimeRegistry, config: UserConfig) => {
+      registerCloudflareProviderOutput(config, "env", {
+        requiredSecrets: requiredCloudflareSecretNames(registry),
+      })
+      const viteConfig = config as typeof config & { nitro?: unknown }
+      viteConfig.nitro = composeNitroCloudflareProviderOutput(config, viteConfig.nitro)
+    })
+  }
+  if (envPlugin) subscribeEnvPlugin(envPlugin)
   const nitroPreset = plan.preset === "cloudflare" && options.realtime ? "cloudflare-durable" : plan.nitroPreset
   return [
     {
@@ -517,6 +531,7 @@ function deploymentPlugins(
         if (plan.preset === "cloudflare") {
           deploymentEnvPlugin.current ??= findEnvPlugin(config.plugins)
           if (deploymentEnvPlugin.current) {
+            subscribeEnvPlugin(deploymentEnvPlugin.current)
             const envConfig = (config as { env?: { server?: Parameters<EnvVitePlugin["api"]["createServerEnvRegistry"]>[0] } }).env
             registerCloudflareProviderOutput(config, "env", {
               requiredSecrets: requiredCloudflareSecretNames(deploymentEnvPlugin.current.api.createServerEnvRegistry(envConfig?.server)),
@@ -533,12 +548,13 @@ function deploymentPlugins(
       vitehub: {
         deploymentOutput: {
           useEnvPlugin(plugin: EnvVitePlugin) {
-            deploymentEnvPlugin.current = plugin
+            subscribeEnvPlugin(plugin)
           },
         },
       },
       config(config) {
         deploymentEnvPlugin.current ??= findEnvPlugin(config.plugins)
+        if (deploymentEnvPlugin.current) subscribeEnvPlugin(deploymentEnvPlugin.current)
         if (plan.preset !== "cloudflare" || typeof deploymentEnvPlugin.current?.api?.getServerEnvRegistry !== "function") return
         registerCloudflareProviderOutput(config, "env", {
           requiredSecrets: requiredCloudflareSecretNames(deploymentEnvPlugin.current.api.getServerEnvRegistry()),
@@ -551,6 +567,7 @@ function deploymentPlugins(
       configResolved(config) {
         if (plan.preset === "cloudflare") {
           deploymentEnvPlugin.current ??= findEnvPlugin(config.plugins)
+          if (deploymentEnvPlugin.current) subscribeEnvPlugin(deploymentEnvPlugin.current)
           if (typeof deploymentEnvPlugin.current?.api?.getServerEnvRegistry === "function") {
             registerCloudflareProviderOutput(config, "env", {
               requiredSecrets: requiredCloudflareSecretNames(deploymentEnvPlugin.current.api.getServerEnvRegistry()),

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -11,7 +11,7 @@ import { hubBrowser } from "@vite-hub/browser/vite"
 import { hubChannels } from "@vite-hub/channels/vite"
 import { hubDb } from "@vite-hub/database/vite"
 import { hubEmail } from "@vite-hub/email/vite"
-import { hubEnv } from "@vite-hub/env/vite"
+import { createRuntimeEnvRegistry, hubEnv } from "@vite-hub/env/vite"
 import { hubKv, hubKvOptionalPeerResolver, resolveKVViteConfig } from "@vite-hub/kv/vite"
 import { hubMarkdownTemplate } from "@vite-hub/markdown-template/vite"
 import { hubQueue } from "@vite-hub/queue/vite"
@@ -445,7 +445,7 @@ function deploymentPlugins(
             provider: plan.services.sandbox.adapter,
           }
         }
-        const nitro = cloneRecord((config as { nitro?: unknown }).nitro)
+        let nitro = cloneRecord((config as { nitro?: unknown }).nitro)
         if (blobEnabled && plan.services.blob.supported && plan.services.blob.adapter === "cloudflare-r2") {
           const optionBlob = options.blob === true ? undefined : options.blob
           const configuredBlob = (config as { blob?: BlobModuleOptions }).blob
@@ -513,6 +513,17 @@ function deploymentPlugins(
             }
           }
           nitro.preset = nitroPreset
+        }
+        if (plan.preset === "cloudflare") {
+          deploymentEnvPlugin.current ??= findEnvPlugin(config.plugins)
+          if (deploymentEnvPlugin.current) {
+            const envConfig = (config as { env?: { server?: Parameters<typeof createRuntimeEnvRegistry>[0] } }).env
+            const prefix = options.env && typeof options.env === "object" ? options.env.prefix : undefined
+            registerCloudflareProviderOutput(config, "env", {
+              requiredSecrets: requiredCloudflareSecretNames(createRuntimeEnvRegistry(envConfig?.server, { prefix })),
+            })
+            nitro = composeNitroCloudflareProviderOutput(config, nitro)
+          }
         }
         ;(config as { nitro?: unknown }).nitro = nitro
       },

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -24,6 +24,7 @@ import { hubWorkspace } from "@vite-hub/workspace/vite"
 import { composeNitroCloudflareProviderOutput, registerCloudflareProviderOutput } from "@vite-hub/internal/build/deployment-output"
 import { finalizeDeploymentPlanOutput } from "@vite-hub/internal/build/deployment-plan-output"
 import { finalizeDenoDeploymentOutput } from "@vite-hub/internal/build/deno-runtime-packages"
+import { VITEHUB_NITRO_CONFIG_CONTEXT } from "@vite-hub/internal/build/vite"
 import { assertDeploymentService, deploymentPresetFromNitro, resolveDeploymentPlan } from "@vite-hub/internal/deployment"
 
 import { viteHubTypesPlugin } from "./internal/types.ts"
@@ -528,14 +529,26 @@ function deploymentPlugins(
       },
       config(config) {
         deploymentEnvPlugin.current ??= findEnvPlugin(config.plugins)
-        if (plan.preset !== "cloudflare" || !deploymentEnvPlugin.current) return
+        if (plan.preset !== "cloudflare" || typeof deploymentEnvPlugin.current?.api?.getServerEnvRegistry !== "function") return
         registerCloudflareProviderOutput(config, "env", {
           requiredSecrets: requiredCloudflareSecretNames(deploymentEnvPlugin.current.api.getServerEnvRegistry()),
         })
-        const viteConfig = config as { nitro?: unknown }
-        viteConfig.nitro = composeNitroCloudflareProviderOutput(config, viteConfig.nitro)
+        if ((config as { [VITEHUB_NITRO_CONFIG_CONTEXT]?: boolean })[VITEHUB_NITRO_CONFIG_CONTEXT] === true) {
+          const viteConfig = config as { nitro?: unknown }
+          viteConfig.nitro = composeNitroCloudflareProviderOutput(config, viteConfig.nitro)
+        }
       },
       configResolved(config) {
+        if (plan.preset === "cloudflare") {
+          deploymentEnvPlugin.current ??= findEnvPlugin(config.plugins)
+          if (typeof deploymentEnvPlugin.current?.api?.getServerEnvRegistry === "function") {
+            registerCloudflareProviderOutput(config, "env", {
+              requiredSecrets: requiredCloudflareSecretNames(deploymentEnvPlugin.current.api.getServerEnvRegistry()),
+            })
+            const viteConfig = config as typeof config & { nitro?: unknown }
+            viteConfig.nitro = composeNitroCloudflareProviderOutput(config, viteConfig.nitro)
+          }
+        }
         const nitro = cloneRecord((config as { nitro?: unknown }).nitro)
         deployCommandOwned = typeof cloneRecord(nitro.commands).deploy === "string"
         if (config.command === "build" && nitro.preset !== nitroPreset) {

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -556,10 +556,7 @@ function deploymentPlugins(
       config(config) {
         deploymentEnvPlugin.current ??= findEnvPlugin(config.plugins)
         if (deploymentEnvPlugin.current) subscribeEnvPlugin(deploymentEnvPlugin.current)
-        if (plan.preset !== "cloudflare" || typeof deploymentEnvPlugin.current?.api?.getServerEnvRegistry !== "function") return
-        registerCloudflareProviderOutput(config, "env", {
-          requiredSecrets: requiredCloudflareSecretNames(deploymentEnvPlugin.current.api.getServerEnvRegistry()),
-        })
+        if (plan.preset !== "cloudflare") return
         if ((config as { [VITEHUB_NITRO_CONFIG_CONTEXT]?: boolean })[VITEHUB_NITRO_CONFIG_CONTEXT] === true) {
           const viteConfig = config as { nitro?: unknown }
           viteConfig.nitro = composeNitroCloudflareProviderOutput(config, viteConfig.nitro)
@@ -569,13 +566,8 @@ function deploymentPlugins(
         if (plan.preset === "cloudflare") {
           deploymentEnvPlugin.current ??= findEnvPlugin(config.plugins)
           if (deploymentEnvPlugin.current) subscribeEnvPlugin(deploymentEnvPlugin.current)
-          if (typeof deploymentEnvPlugin.current?.api?.getServerEnvRegistry === "function") {
-            registerCloudflareProviderOutput(config, "env", {
-              requiredSecrets: requiredCloudflareSecretNames(deploymentEnvPlugin.current.api.getServerEnvRegistry()),
-            })
-            const viteConfig = config as typeof config & { nitro?: unknown }
-            viteConfig.nitro = composeNitroCloudflareProviderOutput(config, viteConfig.nitro)
-          }
+          const viteConfig = config as typeof config & { nitro?: unknown }
+          viteConfig.nitro = composeNitroCloudflareProviderOutput(config, viteConfig.nitro)
         }
         const nitro = cloneRecord((config as { nitro?: unknown }).nitro)
         deployCommandOwned = typeof cloneRecord(nitro.commands).deploy === "string"

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -307,6 +307,21 @@ function requiredCloudflareSecretNames(registry: EnvRuntimeRegistry): string[] {
   return [...names]
 }
 
+function findEnvPlugin(options: unknown): EnvVitePlugin | undefined {
+  if (Array.isArray(options)) {
+    for (const option of options) {
+      const plugin = findEnvPlugin(option)
+      if (plugin) return plugin
+    }
+    return
+  }
+  if (!options || typeof options !== "object") return
+  const plugin = options as Partial<EnvVitePlugin>
+  return plugin.name === "@vite-hub/env/vite" && typeof plugin.api?.getServerEnvRegistry === "function"
+    ? plugin as EnvVitePlugin
+    : undefined
+}
+
 function matchesRollupExternal(value: unknown, source: string, args: unknown[]): boolean {
   if (typeof value === "string") return value === source
   if (value instanceof RegExp) {
@@ -512,6 +527,7 @@ function deploymentPlugins(
         },
       },
       config(config) {
+        deploymentEnvPlugin.current ??= findEnvPlugin(config.plugins)
         if (plan.preset !== "cloudflare" || !deploymentEnvPlugin.current) return
         registerCloudflareProviderOutput(config, "env", {
           requiredSecrets: requiredCloudflareSecretNames(deploymentEnvPlugin.current.api.getServerEnvRegistry()),

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -404,6 +404,7 @@ function deploymentPlugins(
     if (subscribedEnvPlugins.has(plugin) || plan.preset !== "cloudflare") return
     subscribedEnvPlugins.add(plugin)
     plugin.api.onServerEnvRegistry((registry: EnvRuntimeRegistry, config: UserConfig) => {
+      if (cloneRecord((config as { vitehub?: unknown }).vitehub).preset !== plan.preset) return
       registerCloudflareProviderOutput(config, "env", {
         requiredSecrets: requiredCloudflareSecretNames(registry),
       })

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -189,7 +189,11 @@ async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, u
   config.server ??= {}
   const transformWorkflowRegistry = plugins.map(agentWorkflowRegistryTransform).find(Boolean)
 
-  for (const plugin of plugins) {
+  const orderedPlugins = [...plugins].sort((left, right) => {
+    const order = (plugin: Plugin): number => plugin.enforce === "pre" ? -1 : plugin.enforce === "post" ? 1 : 0
+    return order(left) - order(right)
+  })
+  for (const plugin of orderedPlugins) {
     const handler = configHandler(plugin)
     if (handler) {
       const result = await handler.call({} as never, config, environment)

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -200,7 +200,9 @@ async function applyNitroConfig(plugins: Plugin[], nitroConfig: Record<string, u
   const transformWorkflowRegistry = plugins.map(agentWorkflowRegistryTransform).find(Boolean)
 
   const orderedPlugins = [...plugins].sort((left, right) => {
-    const order = (plugin: Plugin): number => plugin.enforce === "pre" ? -1 : plugin.enforce === "post" ? 1 : 0
+    const order = (plugin: Plugin): number => plugin.name === "vite-hub/deployment-output"
+      ? 2
+      : plugin.enforce === "pre" ? -1 : plugin.enforce === "post" ? 1 : 0
     return order(left) - order(right)
   })
   for (const plugin of orderedPlugins) {

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -150,6 +150,16 @@ function workflowNitroConfigHandler(plugin: Plugin): WorkflowNitroConfigHandler 
   }).vitehub?.workflow?.createNitroConfig
 }
 
+function deploymentOutputEnvPluginHandler(plugin: Plugin): ((envPlugin: Plugin) => void) | undefined {
+  return (plugin as Plugin & {
+    vitehub?: {
+      deploymentOutput?: {
+        useEnvPlugin?: (envPlugin: Plugin) => void
+      }
+    }
+  }).vitehub?.deploymentOutput?.useEnvPlugin
+}
+
 function withoutDeploymentOutput(options: readonly unknown[]): unknown[] {
   return options.flatMap((option) => {
     if (Array.isArray(option)) return [withoutDeploymentOutput(option)]
@@ -315,6 +325,10 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
       && !plugins.some(candidate => candidate.name === plugin.name),
     ),
   ]
+  const replayEnvPlugin = replayPlugins.find(plugin => plugin.name === "@vite-hub/env/vite")
+  if (replayEnvPlugin) {
+    for (const plugin of replayPlugins) deploymentOutputEnvPluginHandler(plugin)?.(replayEnvPlugin)
+  }
 
   nuxt.options.vite ??= {}
   const viteConfig = nuxt.options.vite as UserConfig & EnvViteUserConfig & {
@@ -342,7 +356,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
     ...plugins.filter(plugin => !existingNames.has(plugin.name)),
     ...existing,
   ] as PluginOption[]
-  const envPlugin = replayPlugins.find(plugin => plugin.name === "@vite-hub/env/vite") as Plugin & {
+  const envPlugin = replayEnvPlugin as Plugin & {
     api?: { resolveProjectRoot?: (viteRoot: string) => string }
   } | undefined
   const configuredEnvProjectRootOption = options.env && typeof options.env === "object"

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -288,9 +288,9 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
     })(undefined, nuxt)
   }
 
-  const plugins = flattenPlugins(vitehub(options as Parameters<typeof vitehub>[0]))
-    .filter(plugin => plugin.name !== "vite-hub/deployment-output")
+  const installedPlugins = flattenPlugins(vitehub(options as Parameters<typeof vitehub>[0]))
     .filter(plugin => !(options.database && plugin.name === "@vite-hub/database/vite"))
+  const plugins = installedPlugins.filter(plugin => plugin.name !== "vite-hub/deployment-output")
   const existing = withoutDeploymentOutput(
     Array.isArray(nuxt.options.vite?.plugins) ? nuxt.options.vite.plugins : [],
   )
@@ -304,8 +304,8 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
       .filter(plugin => plugin.name)
       .map(plugin => [plugin.name, plugin]),
   )
-  const installedPlugins = [
-    ...plugins.map(plugin => existingPluginsByName.get(plugin.name) || plugin),
+  const replayPlugins = [
+    ...installedPlugins.map(plugin => existingPluginsByName.get(plugin.name) || plugin),
     ...flattenPlugins(existing).filter(plugin =>
       (plugin.name.startsWith("@vite-hub/") || plugin.name.startsWith("vite-hub/"))
       && !plugins.some(candidate => candidate.name === plugin.name),
@@ -338,7 +338,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
     ...plugins.filter(plugin => !existingNames.has(plugin.name)),
     ...existing,
   ] as PluginOption[]
-  const envPlugin = installedPlugins.find(plugin => plugin.name === "@vite-hub/env/vite") as Plugin & {
+  const envPlugin = replayPlugins.find(plugin => plugin.name === "@vite-hub/env/vite") as Plugin & {
     api?: { resolveProjectRoot?: (viteRoot: string) => string }
   } | undefined
   const configuredEnvProjectRootOption = options.env && typeof options.env === "object"
@@ -358,7 +358,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
     "#vitehub/templates": join(projectRoot, ".vitehub/markdown-template/templates.mjs"),
   }
   nuxt.hook?.("nitro:config", async (config) => {
-    await applyNitroConfig(installedPlugins, config, nuxt)
+    await applyNitroConfig(replayPlugins, config, nuxt)
     const alias = (config.alias ??= {}) as Record<string, string>
     for (const [name, path] of Object.entries(generatedAliases)) alias[name] ??= path
   })

--- a/packages/vite-hub/test/deployment-integration.test.ts
+++ b/packages/vite-hub/test/deployment-integration.test.ts
@@ -291,6 +291,24 @@ describe("built-in deployment preset integration", () => {
         nitro?: { cloudflare?: { wrangler?: { secrets?: { required?: string[] } } } }
       }).nitro?.cloudflare?.wrangler?.secrets?.required).toBeUndefined()
       expect((nodeConfig as typeof nodeConfig & { nitro?: { cloudflare?: unknown } }).nitro?.cloudflare).toBeUndefined()
+
+      const [first, second] = await Promise.all([
+        resolveConfig({
+          env: { server: { first: env({ secret: true, source: env.source("FIRST_TOKEN") }) } },
+          root,
+          plugins: [vitehub({ env: false, preset: "cloudflare" }), envPlugin],
+        } as Parameters<typeof resolveConfig>[0] & EnvViteUserConfig, "build"),
+        resolveConfig({
+          env: { server: { second: env({ secret: true, source: env.source("SECOND_TOKEN") }) } },
+          root,
+          plugins: [vitehub({ env: false, preset: "cloudflare" }), envPlugin],
+        } as Parameters<typeof resolveConfig>[0] & EnvViteUserConfig, "build"),
+      ])
+      const required = (config: typeof first) => (config as typeof config & {
+        nitro?: { cloudflare?: { wrangler?: { secrets?: { required?: string[] } } } }
+      }).nitro?.cloudflare?.wrangler?.secrets?.required
+      expect(required(first)).toEqual(["FIRST_TOKEN"])
+      expect(required(second)).toEqual(["SECOND_TOKEN"])
     }
     finally {
       await rm(root, { force: true, recursive: true })

--- a/packages/vite-hub/test/deployment-integration.test.ts
+++ b/packages/vite-hub/test/deployment-integration.test.ts
@@ -1,8 +1,8 @@
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { join, resolve } from "node:path"
 
-import { resolveConfig } from "vite"
+import { createBuilder, resolveConfig } from "vite"
 import { describe, expect, it } from "vitest"
 
 import { env, hubEnv } from "@vite-hub/env/vite"
@@ -152,6 +152,36 @@ describe("built-in deployment preset integration", () => {
       await rm(root, { force: true, recursive: true })
     }
   })
+
+  it("emits required Server Env secrets through the Nitro Vite plugin", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-required-secrets-build-"))
+    try {
+      await mkdir(join(root, "server", "routes"), { recursive: true })
+      await symlink(resolve(import.meta.dirname, "../../../node_modules"), join(root, "node_modules"), "dir")
+      await writeFile(join(root, "index.html"), "<main>ok</main>\n")
+      await writeFile(join(root, "server", "routes", "index.ts"), "export default () => 'ok'\n")
+      const { nitro } = await import("nitro/vite" as string) as { nitro: () => unknown }
+      const builder = await createBuilder({
+        env: {
+          server: {
+            token: env({ secret: true, source: env.source("VITEHUB_TOKEN") }),
+          },
+        },
+        logLevel: "silent",
+        root,
+        plugins: [vitehub({ preset: "cloudflare" }), nitro() as never],
+      } as Parameters<typeof createBuilder>[0] & EnvViteUserConfig)
+      await builder.buildApp()
+
+      const wrangler = JSON.parse(await readFile(join(root, ".output", "server", "wrangler.json"), "utf8")) as {
+        secrets?: { required?: string[] }
+      }
+      expect(wrangler.secrets?.required).toEqual(["VITEHUB_TOKEN"])
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  }, 30_000)
 
   it("declares required secrets from a standalone Env plugin", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-standalone-required-secrets-"))

--- a/packages/vite-hub/test/deployment-integration.test.ts
+++ b/packages/vite-hub/test/deployment-integration.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { resolveConfig } from "vite"
 import { describe, expect, it } from "vitest"
 
-import { env } from "@vite-hub/env/vite"
+import { env, hubEnv } from "@vite-hub/env/vite"
 import { vitehub } from "../src/index.ts"
 
 import type { EnvViteUserConfig } from "@vite-hub/env"
@@ -147,6 +147,31 @@ describe("built-in deployment preset integration", () => {
       expect((config as typeof config & {
         nitro?: { cloudflare?: { wrangler?: { secrets?: { required?: string[] } } } }
       }).nitro?.cloudflare?.wrangler?.secrets?.required).toEqual(["APP_SECRET", "VITEHUB_TOKEN"])
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("declares required secrets from a standalone Env plugin", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-standalone-required-secrets-"))
+    try {
+      const config = await resolveConfig({
+        env: {
+          server: {
+            token: env({ secret: true, source: env.source("VITEHUB_TOKEN") }),
+          },
+        },
+        root,
+        plugins: [
+          vitehub({ env: false, preset: "cloudflare" }),
+          hubEnv(),
+        ],
+      } as Parameters<typeof resolveConfig>[0] & EnvViteUserConfig, "build")
+
+      expect((config as typeof config & {
+        nitro?: { cloudflare?: { wrangler?: { secrets?: { required?: string[] } } } }
+      }).nitro?.cloudflare?.wrangler?.secrets?.required).toEqual(["VITEHUB_TOKEN"])
     }
     finally {
       await rm(root, { force: true, recursive: true })

--- a/packages/vite-hub/test/deployment-integration.test.ts
+++ b/packages/vite-hub/test/deployment-integration.test.ts
@@ -178,6 +178,45 @@ describe("built-in deployment preset integration", () => {
     }
   })
 
+  it("declares required secrets in named environments from later post hooks", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-late-required-secrets-"))
+    try {
+      const config = await resolveConfig({
+        env: {
+          server: {
+            token: env({ secret: true, source: env.source("VITEHUB_TOKEN") }),
+          },
+        },
+        root,
+        plugins: [
+          vitehub({ preset: "cloudflare" }),
+          {
+            name: "app/cloudflare-environments",
+            enforce: "post",
+            config() {
+              return {
+                nitro: {
+                  cloudflare: {
+                    wrangler: {
+                      env: { staging: { name: "staging-worker" } },
+                    },
+                  },
+                },
+              }
+            },
+          },
+        ],
+      } as Parameters<typeof resolveConfig>[0] & EnvViteUserConfig, "build")
+
+      expect((config as typeof config & {
+        nitro?: { cloudflare?: { wrangler?: { env?: { staging?: { secrets?: { required?: string[] } } } } } }
+      }).nitro?.cloudflare?.wrangler?.env?.staging?.secrets?.required).toEqual(["VITEHUB_TOKEN"])
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("keeps required Server Env secrets out of non-Cloudflare output", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-node-required-secrets-"))
     try {

--- a/packages/vite-hub/test/deployment-integration.test.ts
+++ b/packages/vite-hub/test/deployment-integration.test.ts
@@ -267,6 +267,29 @@ describe("built-in deployment preset integration", () => {
     }
   })
 
+  it("keeps standalone Env subscriptions scoped to their Cloudflare configuration", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-reused-env-plugin-"))
+    try {
+      const envPlugin = hubEnv()
+      const server = { token: env({ secret: true, source: env.source("VITEHUB_TOKEN") }) }
+      await resolveConfig({
+        env: { server },
+        root,
+        plugins: [vitehub({ env: false, preset: "cloudflare" }), envPlugin],
+      } as Parameters<typeof resolveConfig>[0] & EnvViteUserConfig, "build")
+      const nodeConfig = await resolveConfig({
+        env: { server },
+        root,
+        plugins: [vitehub({ env: false, preset: "node" }), envPlugin],
+      } as Parameters<typeof resolveConfig>[0] & EnvViteUserConfig, "build")
+
+      expect((nodeConfig as typeof nodeConfig & { nitro?: { cloudflare?: unknown } }).nitro?.cloudflare).toBeUndefined()
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("declares required secrets in named environments from later post hooks", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-late-required-secrets-"))
     try {

--- a/packages/vite-hub/test/deployment-integration.test.ts
+++ b/packages/vite-hub/test/deployment-integration.test.ts
@@ -183,6 +183,32 @@ describe("built-in deployment preset integration", () => {
     }
   }, 30_000)
 
+  it("emits prefixed secrets from a standalone Env plugin through Nitro", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-prefixed-standalone-secrets-build-"))
+    try {
+      await mkdir(join(root, "server", "routes"), { recursive: true })
+      await symlink(resolve(import.meta.dirname, "../../../node_modules"), join(root, "node_modules"), "dir")
+      await writeFile(join(root, "index.html"), "<main>ok</main>\n")
+      await writeFile(join(root, "server", "routes", "index.ts"), "export default () => 'ok'\n")
+      const { nitro } = await import("nitro/vite" as string) as { nitro: () => unknown }
+      const builder = await createBuilder({
+        env: { server: { token: env({ secret: true }) } },
+        logLevel: "silent",
+        root,
+        plugins: [vitehub({ env: false, preset: "cloudflare" }), hubEnv({ prefix: "APP_" }), nitro() as never],
+      } as Parameters<typeof createBuilder>[0] & EnvViteUserConfig)
+      await builder.buildApp()
+
+      const wrangler = JSON.parse(await readFile(join(root, ".output", "server", "wrangler.json"), "utf8")) as {
+        secrets?: { required?: string[] }
+      }
+      expect(wrangler.secrets?.required).toEqual(["APP_TOKEN"])
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  }, 30_000)
+
   it("declares required secrets from a standalone Env plugin", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-standalone-required-secrets-"))
     try {

--- a/packages/vite-hub/test/deployment-integration.test.ts
+++ b/packages/vite-hub/test/deployment-integration.test.ts
@@ -209,6 +209,39 @@ describe("built-in deployment preset integration", () => {
     }
   }, 30_000)
 
+  it("emits secrets contributed by later pre hooks through Nitro", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-late-pre-secrets-build-"))
+    try {
+      await mkdir(join(root, "server", "routes"), { recursive: true })
+      await symlink(resolve(import.meta.dirname, "../../../node_modules"), join(root, "node_modules"), "dir")
+      await writeFile(join(root, "index.html"), "<main>ok</main>\n")
+      await writeFile(join(root, "server", "routes", "index.ts"), "export default () => 'ok'\n")
+      const { nitro } = await import("nitro/vite" as string) as { nitro: () => unknown }
+      const builder = await createBuilder({
+        logLevel: "silent",
+        root,
+        plugins: [
+          vitehub({ preset: "cloudflare" }),
+          {
+            name: "app/server-env",
+            enforce: "pre",
+            config: () => ({ env: { server: { token: env({ secret: true, source: env.source("LATE_TOKEN") }) } } }),
+          },
+          nitro() as never,
+        ],
+      } as Parameters<typeof createBuilder>[0] & EnvViteUserConfig)
+      await builder.buildApp()
+
+      const wrangler = JSON.parse(await readFile(join(root, ".output", "server", "wrangler.json"), "utf8")) as {
+        secrets?: { required?: string[] }
+      }
+      expect(wrangler.secrets?.required).toEqual(["LATE_TOKEN"])
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  }, 30_000)
+
   it("declares required secrets from a standalone Env plugin", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-standalone-required-secrets-"))
     try {

--- a/packages/vite-hub/test/deployment-integration.test.ts
+++ b/packages/vite-hub/test/deployment-integration.test.ts
@@ -5,7 +5,10 @@ import { join } from "node:path"
 import { resolveConfig } from "vite"
 import { describe, expect, it } from "vitest"
 
+import { env } from "@vite-hub/env/vite"
 import { vitehub } from "../src/index.ts"
+
+import type { EnvViteUserConfig } from "@vite-hub/env"
 
 describe("built-in deployment preset integration", () => {
   it.each(["cloudflare", "netlify", "vercel", "deno", "node"] as const)("resolves the minimal %s preset with real owner plugins", async (preset) => {
@@ -110,6 +113,60 @@ describe("built-in deployment preset integration", () => {
       expect((config as typeof config & {
         nitro?: { cloudflare?: { wrangler?: { name?: string } } }
       }).nitro?.cloudflare?.wrangler?.name).toBe("physical-worker")
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("declares exact required Server Env secrets in Cloudflare output", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-required-secrets-"))
+    try {
+      const config = await resolveConfig({
+        env: {
+          server: {
+            nested: {
+              required: env({ secret: true, source: env.source("VITEHUB_TOKEN") }),
+              optional: env({ optional: true, secret: true, source: env.source("OPTIONAL_TOKEN") }),
+              alternatives: env({ secret: true, source: env.source(["PRIMARY_TOKEN", "FALLBACK_TOKEN"]) }),
+              publicValue: env({ source: env.source("PUBLIC_VALUE") }),
+            },
+          },
+        },
+        nitro: {
+          cloudflare: {
+            wrangler: {
+              secrets: { required: ["APP_SECRET"] },
+            },
+          },
+        },
+        root,
+        plugins: [vitehub({ preset: "cloudflare" })],
+      } as Parameters<typeof resolveConfig>[0] & EnvViteUserConfig, "build")
+
+      expect((config as typeof config & {
+        nitro?: { cloudflare?: { wrangler?: { secrets?: { required?: string[] } } } }
+      }).nitro?.cloudflare?.wrangler?.secrets?.required).toEqual(["APP_SECRET", "VITEHUB_TOKEN"])
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("keeps required Server Env secrets out of non-Cloudflare output", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-node-required-secrets-"))
+    try {
+      const config = await resolveConfig({
+        env: {
+          server: {
+            token: env({ secret: true, source: env.source("VITEHUB_TOKEN") }),
+          },
+        },
+        root,
+        plugins: [vitehub({ preset: "node" })],
+      } as Parameters<typeof resolveConfig>[0] & EnvViteUserConfig, "build")
+
+      expect((config as typeof config & { nitro?: { cloudflare?: unknown } }).nitro?.cloudflare).toBeUndefined()
     }
     finally {
       await rm(root, { force: true, recursive: true })

--- a/packages/vite-hub/test/deployment-integration.test.ts
+++ b/packages/vite-hub/test/deployment-integration.test.ts
@@ -277,12 +277,19 @@ describe("built-in deployment preset integration", () => {
         root,
         plugins: [vitehub({ env: false, preset: "cloudflare" }), envPlugin],
       } as Parameters<typeof resolveConfig>[0] & EnvViteUserConfig, "build")
+      const emptyCloudflareConfig = await resolveConfig({
+        root,
+        plugins: [vitehub({ env: false, preset: "cloudflare" }), envPlugin],
+      } as Parameters<typeof resolveConfig>[0], "build")
       const nodeConfig = await resolveConfig({
         env: { server },
         root,
         plugins: [vitehub({ env: false, preset: "node" }), envPlugin],
       } as Parameters<typeof resolveConfig>[0] & EnvViteUserConfig, "build")
 
+      expect((emptyCloudflareConfig as typeof emptyCloudflareConfig & {
+        nitro?: { cloudflare?: { wrangler?: { secrets?: { required?: string[] } } } }
+      }).nitro?.cloudflare?.wrangler?.secrets?.required).toBeUndefined()
       expect((nodeConfig as typeof nodeConfig & { nitro?: { cloudflare?: unknown } }).nitro?.cloudflare).toBeUndefined()
     }
     finally {

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -51,6 +51,7 @@ const mocks = vi.hoisted(() => ({
       sandbox: config[VITEHUB_NITRO_CONFIG_CONTEXT],
     },
   })),
+  useEnvPlugin: vi.fn(),
   vitehub: vi.fn(),
   workflowNitroConfig: vi.fn(async ({ nitro }: { nitro: Record<string, unknown> }) => ({
     ...nitro,
@@ -102,6 +103,7 @@ describe("ViteHub Nuxt integration", () => {
     mocks.outputHook.mockClear()
     mocks.queueNitroConfig.mockClear()
     mocks.sandboxHook.mockClear()
+    mocks.useEnvPlugin.mockClear()
     mocks.workflowNitroConfig.mockClear()
     mocks.vitehub.mockReset()
     mocks.vitehub.mockReturnValue([
@@ -167,6 +169,11 @@ describe("ViteHub Nuxt integration", () => {
         name: "vite-hub/deployment-output",
         enforce: "post",
         config: mocks.outputHook,
+        vitehub: {
+          deploymentOutput: {
+            useEnvPlugin: mocks.useEnvPlugin,
+          },
+        },
       },
       {
         name: "@vite-hub/env/vite",
@@ -315,6 +322,9 @@ describe("ViteHub Nuxt integration", () => {
     )
     expect(mocks.outputHook).toHaveBeenCalledOnce()
     expect(mocks.envHook).toHaveBeenCalledOnce()
+    expect(mocks.useEnvPlugin).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "@vite-hub/env/vite" }),
+    )
     expect(nitroConfig).toEqual({
       alias: {
         "#vitehub/env/public": "/tmp/vitehub-nuxt/.vitehub/env/public.mjs",
@@ -339,6 +349,20 @@ describe("ViteHub Nuxt integration", () => {
       sandbox: true,
       workflows: true,
     })
+  })
+
+  it("binds deployment output to an existing Env plugin selected for replay", async () => {
+    const existingEnvPlugin = {
+      name: "@vite-hub/env/vite",
+      api: { resolveProjectRoot: (root: string) => resolveViteHubProjectRoot(root) },
+      config: vi.fn(),
+    }
+    const { nuxt } = createNuxt(false, [existingEnvPlugin])
+
+    await viteHubNuxtModule({ preset: "cloudflare" }, nuxt)
+
+    expect(mocks.useEnvPlugin).toHaveBeenCalledWith(existingEnvPlugin)
+    expect((nuxt.options.vite.plugins as unknown[]).flat(Infinity)).toContain(existingEnvPlugin)
   })
 
   it("replays configured Nuxt Vite options into Nitro hooks", async () => {

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -384,6 +384,39 @@ describe("ViteHub Nuxt integration", () => {
     )
   })
 
+  it("finalizes deployment output after later ViteHub post hooks", async () => {
+    const lateCloudflarePlugin = {
+      name: "vite-hub/custom-cloudflare",
+      enforce: "post" as const,
+      config() {
+        return {
+          nitro: {
+            cloudflare: {
+              wrangler: {
+                env: { staging: { name: "staging-worker" } },
+              },
+            },
+          },
+        }
+      },
+    }
+    const { nuxt, runNitroConfigHook } = createNuxt(false, [lateCloudflarePlugin])
+
+    await viteHubNuxtModule({ preset: "cloudflare" }, nuxt)
+    await runNitroConfigHook({})
+
+    expect(mocks.outputHook).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nitro: expect.objectContaining({
+          cloudflare: expect.objectContaining({
+            wrangler: expect.objectContaining({ env: { staging: { name: "staging-worker" } } }),
+          }),
+        }),
+      }),
+      expect.anything(),
+    )
+  })
+
   it("adds generated and Cloudflare types to Nuxt and Nitro", async () => {
     const { nuxt } = createNuxt()
 

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url"
 
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
-import { VITEHUB_GENERATED_ROOT, VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
+import { resolveViteHubProjectRoot, VITEHUB_GENERATED_ROOT, VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import type { PluginOption } from "vite"
 
@@ -29,6 +29,9 @@ const mocks = vi.hoisted(() => ({
       ownerPlugin: true,
     },
   })),
+  envHook: vi.fn((config: Record<string, unknown>) => {
+    config.envReady = true
+  }),
   outputHook: vi.fn(),
   agentHook: vi.fn((config: { [VITEHUB_SERVER_DIRS]?: string[], nitro?: Record<string, unknown> }) => ({
     nitro: {
@@ -95,6 +98,7 @@ describe("ViteHub Nuxt integration", () => {
     mocks.existingQueueConfig.mockClear()
     mocks.existingQueueNitroConfig.mockClear()
     mocks.existingOwnerConfig.mockClear()
+    mocks.envHook.mockClear()
     mocks.outputHook.mockClear()
     mocks.queueNitroConfig.mockClear()
     mocks.sandboxHook.mockClear()
@@ -161,7 +165,20 @@ describe("ViteHub Nuxt integration", () => {
       },
       {
         name: "vite-hub/deployment-output",
+        enforce: "post",
         config: mocks.outputHook,
+      },
+      {
+        name: "@vite-hub/env/vite",
+        api: {
+          resolveProjectRoot: vi.fn((root: string) => {
+            const envOptions = (mocks.vitehub.mock.calls.at(-1)?.[0] as {
+              env?: { projectRoot?: string }
+            } | undefined)?.env
+            return envOptions?.projectRoot ? resolve(root, envOptions.projectRoot) : resolveViteHubProjectRoot(root)
+          }),
+        },
+        config: mocks.envHook,
       },
     ])
   })
@@ -193,6 +210,7 @@ describe("ViteHub Nuxt integration", () => {
       { name: "vite-hub/deployment-output" },
     ]])
     mocks.outputHook.mockImplementationOnce((config: { nitro?: Record<string, unknown> }) => {
+      if (!(config as Record<string, unknown>).envReady) return
       const cloudflare = config.nitro?.cloudflare as Record<string, unknown> | undefined
       const wrangler = cloudflare?.wrangler as Record<string, unknown> | undefined
       config.nitro = {
@@ -220,6 +238,7 @@ describe("ViteHub Nuxt integration", () => {
       expect.objectContaining({ name: "@vite-hub/agent/vite" }),
       expect.objectContaining({ name: "@vite-hub/sandbox/vite" }),
       expect.objectContaining({ name: "@vite-hub/workflow/vite" }),
+      expect.objectContaining({ name: "@vite-hub/env/vite" }),
       existingQueuePlugin,
       existingOwnerPlugin,
       existingPlugin,
@@ -295,6 +314,7 @@ describe("ViteHub Nuxt integration", () => {
       },
     )
     expect(mocks.outputHook).toHaveBeenCalledOnce()
+    expect(mocks.envHook).toHaveBeenCalledOnce()
     expect(nitroConfig).toEqual({
       alias: {
         "#vitehub/env/public": "/tmp/vitehub-nuxt/.vitehub/env/public.mjs",

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -192,6 +192,20 @@ describe("ViteHub Nuxt integration", () => {
       existingPlugin,
       { name: "vite-hub/deployment-output" },
     ]])
+    mocks.outputHook.mockImplementationOnce((config: { nitro?: Record<string, unknown> }) => {
+      const cloudflare = config.nitro?.cloudflare as Record<string, unknown> | undefined
+      const wrangler = cloudflare?.wrangler as Record<string, unknown> | undefined
+      config.nitro = {
+        ...config.nitro,
+        cloudflare: {
+          ...cloudflare,
+          wrangler: {
+            ...wrangler,
+            secrets: { required: ["VITEHUB_TOKEN"] },
+          },
+        },
+      }
+    })
 
     await viteHubNuxtModule({ preset: "cloudflare" }, nuxt)
 
@@ -280,7 +294,7 @@ describe("ViteHub Nuxt integration", () => {
         mode: "development",
       },
     )
-    expect(mocks.outputHook).not.toHaveBeenCalled()
+    expect(mocks.outputHook).toHaveBeenCalledOnce()
     expect(nitroConfig).toEqual({
       alias: {
         "#vitehub/env/public": "/tmp/vitehub-nuxt/.vitehub/env/public.mjs",
@@ -292,6 +306,7 @@ describe("ViteHub Nuxt integration", () => {
           d1_databases: [d1Binding, d1Binding],
           name: "vitehub-nuxt",
           observability: { enabled: true },
+          secrets: { required: ["VITEHUB_TOKEN"] },
         },
       },
       ownerPlugin: true,

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -35,7 +35,10 @@ vi.mock("@vite-hub/browser/vite", () => ({ hubBrowser: integrationMocks.hubBrows
 vi.mock("@vite-hub/channels/vite", () => ({ hubChannels: integrationMocks.hubChannels }))
 vi.mock("@vite-hub/database/vite", () => ({ hubDb: integrationMocks.hubDb }))
 vi.mock("@vite-hub/email/vite", () => ({ hubEmail: integrationMocks.hubEmail }))
-vi.mock("@vite-hub/env/vite", () => ({ hubEnv: integrationMocks.hubEnv }))
+vi.mock("@vite-hub/env/vite", async importOriginal => ({
+  ...await importOriginal<typeof import("@vite-hub/env/vite")>(),
+  hubEnv: integrationMocks.hubEnv,
+}))
 vi.mock("@vite-hub/kv/vite", () => ({
   hubKv: integrationMocks.hubKv,
   hubKvOptionalPeerResolver: integrationMocks.hubKvOptionalPeerResolver,

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -13,7 +13,13 @@ const integrationMocks = vi.hoisted(() => ({
   hubChannels: vi.fn(() => ({ name: "@vite-hub/channels/vite" })),
   hubDb: vi.fn(() => ({ name: "@vite-hub/database/vite" })),
   hubEmail: vi.fn(() => ({ name: "@vite-hub/email/vite" })),
-  hubEnv: vi.fn(() => ({ name: "@vite-hub/env/vite" })),
+  hubEnv: vi.fn(() => ({
+    api: {
+      createServerEnvRegistry: () => ({}),
+      getServerEnvRegistry: () => ({}),
+    },
+    name: "@vite-hub/env/vite",
+  })),
   hubKv: vi.fn(() => ({ name: "@vite-hub/kv/vite" })),
   hubKvOptionalPeerResolver: vi.fn(() => ({ name: "@vite-hub/kv/optional-peers" })),
   hubMarkdownTemplate: vi.fn(() => ({ name: "@vite-hub/markdown-template/vite" })),

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -17,6 +17,7 @@ const integrationMocks = vi.hoisted(() => ({
     api: {
       createServerEnvRegistry: () => ({}),
       getServerEnvRegistry: () => ({}),
+      onServerEnvRegistry: () => {},
     },
     name: "@vite-hub/env/vite",
   })),


### PR DESCRIPTION
## Summary

- add exact required secret Server Env sources to generated Cloudflare `secrets.required`
- preserve user-authored required secrets and provider-output ownership when Env declarations change
- keep values, optional declarations, defaults, and fallback source lists runtime-only

## Why

A Worker could deploy without a required secret binding and only fail on its first runtime invocation. Wrangler can validate required secret names during deployment without ViteHub resolving secret values at build time.

## Verification

- `pnpm --filter vite-hub test` (121 tests)
- `pnpm --filter vite-hub typecheck`
- `pnpm --filter @vite-hub/internal typecheck`
- focused provider-output test (7 tests)
- scoped `vp lint`

Live Cloudflare deployment was not run; it requires an account with managed secret state.
