### PR TITLE
feat(agent): add OpenRouter transcription model

### DIFF
--- a/docs/content/docs/capabilities/transcribe.md
+++ b/docs/content/docs/capabilities/transcribe.md
@@ -39,6 +39,34 @@ export default defineAgent({
 })
 ```
 
+### OpenRouter
+
+Use `openRouterTranscriptionModel()` to keep OpenRouter authentication, audio encoding, request shape, and provider errors behind the AI SDK transcription model interface.
+
+```ts [server/agents/voice.ts]
+import { defineAgent } from '@vite-hub/agent'
+import {
+  openRouterTranscriptionModel,
+  transcribe,
+} from '@vite-hub/agent/capabilities'
+
+export default defineAgent({
+  driver: { model },
+  capabilities: [
+    transcribe({
+      model: openRouterTranscriptionModel({
+        apiKey: () => env.OPENROUTER_API_KEY,
+        model: 'openai/gpt-4o-transcribe',
+      }),
+    }),
+  ],
+})
+```
+
+The adapter uses OpenRouter's base64 JSON request with `response_format: 'json'`. This avoids provider-specific multipart handling in Agent Definitions and does not request `verbose_json`, which OpenRouter only supports for some upstream providers.
+
+AI SDK `providerOptions.openrouter` values for `language`, `temperature`, and `provider` routing are forwarded to OpenRouter. Unsupported OpenRouter transcription options fail explicitly instead of being silently ignored.
+
 ## Runtime behavior
 
 `transcribe()` runs before model execution.
@@ -184,6 +212,8 @@ When artifacts are enabled, inspect the Workspace for transcript files and the f
 | `client.submit({ source, metadata, abortSignal })` | `submitted` operation | Submits a remote HTTP(S) source and returns the provider operation ID. |
 | `client.receive(payload)` | `completed \| failed` completion | Normalizes an already-authenticated provider completion payload. |
 | `elevenLabsScribe(options)` | `TranscriptionDriver` | Maps remote Scribe v2 submission and callback payloads without exposing provider types. |
+
+`openRouterTranscriptionModel({ apiKey, model })` returns an AI SDK transcription model for synchronous `transcribe({ model })` usage.
 
 Without `artifacts.directory`, transcripts use `transcripts/<date>/<stem>.txt` and audio is placed beside the transcript. If transcripts are disabled, audio uses `audio/<date>/<stem>.<extension>`.
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -187,7 +187,7 @@ Pass `--json` for the structured inspection contract.
 - `webSearch()` searches and reads the web with [Brave](https://brave.com/search/api/), [Exa](https://docs.exa.ai/), [Jina](https://jina.ai/en-US/reader/), [SearXNG](https://docs.searxng.org/dev/search_api.html), [SerpApi](https://serpapi.com/search-api), [SerpBase](https://serpbase.dev/docs), or [Tavily](https://docs.tavily.com/).
 - `openapi()` turns an allowed OpenAPI `operationId` subset into bounded HTTP tools, or into a generated Capability CLI when `cli` is set.
 - `papercuts()` lets an Agent report small runtime and developer-experience friction to an application-owned sink, with an optional Capability CLI command.
-- `transcribe()` uses the [AI SDK transcription API](https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/transcribe).
+- `transcribe()` uses the [AI SDK transcription API](https://ai-sdk.dev/v7/docs/reference/ai-sdk-core/transcribe); `openRouterTranscriptionModel()` provides OpenRouter transcription without consumer-owned HTTP handling.
 - `createTranscription()` composes remote asynchronous submission and completion through a provider-neutral driver; `elevenLabsScribe()` is the built-in Scribe v2 adapter.
 - `mcp()` connects tools from [Model Context Protocol](https://modelcontextprotocol.io/) servers through `@ai-sdk/mcp`.
 - `kv()`, `blob()`, `db()`, and `email()` expose [`@vite-hub/kv`](../kv/README.md), [`@vite-hub/blob`](../blob/README.md), [`@vite-hub/database`](../database/README.md), and [`@vite-hub/email`](../email/README.md).

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -90,6 +90,9 @@ export {
   elevenLabsScribe,
 } from "./transcription-elevenlabs.ts"
 export {
+  openRouterTranscriptionModel,
+} from "./transcription-openrouter.ts"
+export {
   cost,
   vercelAiGatewayPricing,
 } from "./cost.ts"
@@ -347,6 +350,9 @@ export type {
 export type {
   ElevenLabsScribeOptions,
 } from "./transcription-elevenlabs.ts"
+export type {
+  OpenRouterTranscriptionModelOptions,
+} from "./transcription-openrouter.ts"
 export type {
   BlobCapabilityOptions,
 } from "./storage/blob.ts"

--- a/packages/agent/src/capabilities/transcribe.ts
+++ b/packages/agent/src/capabilities/transcribe.ts
@@ -180,16 +180,16 @@ function normalizeAudioMediaType(mediaType = ""): string {
   return mediaType.toLowerCase().split(";")[0]?.trim() || ""
 }
 
-export function audioExtensionFor(mediaType = ""): string {
+export function audioExtensionFor(mediaType = "", fallback = "ogg"): string {
   const normalized = normalizeAudioMediaType(mediaType)
   if (normalized === "audio/aac") return "aac"
   if (normalized === "audio/flac" || normalized === "audio/x-flac") return "flac"
-  if (normalized === "audio/mpeg") return "mp3"
+  if (normalized === "audio/mp3" || normalized === "audio/mpeg") return "mp3"
   if (normalized === "audio/mp4" || normalized === "audio/x-m4a") return "m4a"
   if (normalized === "audio/ogg" || normalized === "audio/opus") return "ogg"
   if (normalized === "audio/wav" || normalized === "audio/x-wav") return "wav"
   if (normalized === "audio/webm") return "webm"
-  return "ogg"
+  return fallback
 }
 
 function bytesFromBase64(value: string): Uint8Array {

--- a/packages/agent/src/capabilities/transcription-openrouter.ts
+++ b/packages/agent/src/capabilities/transcription-openrouter.ts
@@ -1,0 +1,191 @@
+import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
+import { audioExtensionFor } from "./transcribe.ts"
+
+import type { MaybePromise } from "../types.ts"
+import type { TranscriptionModel } from "ai"
+
+type OpenRouterTranscriptionModel = Extract<TranscriptionModel, { specificationVersion: "v4" }>
+type AiSdk = typeof import("ai")
+
+export interface OpenRouterTranscriptionModelOptions {
+  apiKey: string | (() => MaybePromise<string>)
+  model: string
+}
+
+interface OpenRouterTranscriptionResponse {
+  error?: { message?: unknown }
+  language?: unknown
+  text?: unknown
+  usage?: { seconds?: unknown }
+}
+
+interface OpenRouterTranscriptionProviderOptions {
+  language?: string
+  provider?: Record<string, unknown>
+  temperature?: number
+}
+
+const endpoint = "https://openrouter.ai/api/v1/audio/transcriptions"
+
+function nonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0
+}
+
+function responseHeaders(response: Response): Record<string, string> {
+  return Object.fromEntries(response.headers.entries())
+}
+
+function providerOptions(value: unknown): OpenRouterTranscriptionProviderOptions {
+  if (value === undefined) return {}
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("[vitehub] OpenRouter transcription provider options must be an object.")
+  }
+  const options = value as Record<string, unknown>
+  const unsupported = Object.keys(options).filter(key => !["language", "provider", "temperature"].includes(key))
+  if (unsupported.length) {
+    throw new TypeError(`[vitehub] Unsupported OpenRouter transcription provider option: ${unsupported.join(", ")}.`)
+  }
+  if (options.language !== undefined && !nonEmptyString(options.language)) {
+    throw new TypeError("[vitehub] OpenRouter transcription language must be a non-empty string.")
+  }
+  if (options.temperature !== undefined && (typeof options.temperature !== "number" || !Number.isFinite(options.temperature) || options.temperature < 0 || options.temperature > 1)) {
+    throw new TypeError("[vitehub] OpenRouter transcription temperature must be between 0 and 1.")
+  }
+  if (options.provider !== undefined && (!options.provider || typeof options.provider !== "object" || Array.isArray(options.provider))) {
+    throw new TypeError("[vitehub] OpenRouter transcription provider routing options must be an object.")
+  }
+  return options as OpenRouterTranscriptionProviderOptions
+}
+
+async function resolveApiKey(value: OpenRouterTranscriptionModelOptions["apiKey"], aiSdk: AiSdk): Promise<string> {
+  const apiKey = typeof value === "function" ? await value() : value
+  if (!nonEmptyString(apiKey)) {
+    throw new aiSdk.LoadAPIKeyError({ message: "OpenRouter transcription requires an API key." })
+  }
+  return apiKey
+}
+
+export function openRouterTranscriptionModel(options: OpenRouterTranscriptionModelOptions): OpenRouterTranscriptionModel {
+  if (!options || typeof options !== "object") {
+    throw new TypeError("[vitehub] openRouterTranscriptionModel() requires options.")
+  }
+  if (typeof options.apiKey !== "string" && typeof options.apiKey !== "function") {
+    throw new TypeError("[vitehub] openRouterTranscriptionModel({ apiKey }) requires a string or resolver.")
+  }
+  if (!nonEmptyString(options.model)) {
+    throw new TypeError("[vitehub] openRouterTranscriptionModel({ model }) requires a non-empty model id.")
+  }
+
+  return {
+    modelId: options.model,
+    provider: "openrouter.transcription",
+    specificationVersion: "v4",
+    async doGenerate(input) {
+      const aiSdk = await loadAiSdk()
+      const openrouter = providerOptions(input.providerOptions?.openrouter)
+      const format = audioExtensionFor(input.mediaType, "")
+      if (!format) throw new TypeError(`[vitehub] OpenRouter transcription does not support ${input.mediaType}.`)
+      const body = {
+        input_audio: {
+          data: aiSdk.convertDataContentToBase64String(input.audio),
+          format,
+        },
+        model: options.model,
+        ...openrouter,
+        response_format: "json",
+      }
+      const headers = new Headers()
+      for (const [name, value] of Object.entries(input.headers || {})) {
+        if (value !== undefined) headers.set(name, value)
+      }
+      headers.set("authorization", `Bearer ${await resolveApiKey(options.apiKey, aiSdk)}`)
+      headers.set("content-type", "application/json")
+
+      let response: Response
+      try {
+        response = await fetch(endpoint, {
+          body: JSON.stringify(body),
+          headers,
+          method: "POST",
+          signal: input.abortSignal,
+        })
+      }
+      catch (cause) {
+        if (input.abortSignal?.aborted) throw cause
+        throw new aiSdk.APICallError({
+          cause,
+          isRetryable: true,
+          message: "OpenRouter transcription request failed.",
+          requestBodyValues: { model: options.model, response_format: "json" },
+          url: endpoint,
+        })
+      }
+
+      let responseText: string
+      try {
+        responseText = await response.text()
+      }
+      catch (cause) {
+        if (input.abortSignal?.aborted) throw cause
+        throw new aiSdk.APICallError({
+          cause,
+          isRetryable: true,
+          message: "OpenRouter transcription response failed.",
+          requestBodyValues: { model: options.model, response_format: "json" },
+          responseHeaders: responseHeaders(response),
+          statusCode: response.status,
+          url: endpoint,
+        })
+      }
+      let parsed: unknown
+      try {
+        parsed = JSON.parse(responseText)
+      }
+      catch (cause) {
+        if (!response.ok) {
+          throw new aiSdk.APICallError({
+            cause,
+            message: `OpenRouter transcription failed with ${response.status}.`,
+            requestBodyValues: { model: options.model, response_format: "json" },
+            responseBody: responseText,
+            responseHeaders: responseHeaders(response),
+            statusCode: response.status,
+            url: endpoint,
+          })
+        }
+        throw new aiSdk.InvalidResponseDataError({ data: responseText })
+      }
+      const result = parsed && typeof parsed === "object"
+        ? parsed as OpenRouterTranscriptionResponse
+        : undefined
+
+      if (!response.ok) {
+        throw new aiSdk.APICallError({
+          message: nonEmptyString(result?.error?.message)
+            ? result.error.message
+            : `OpenRouter transcription failed with ${response.status}.`,
+          requestBodyValues: { model: options.model, response_format: "json" },
+          responseBody: responseText,
+          responseHeaders: responseHeaders(response),
+          statusCode: response.status,
+          url: endpoint,
+        })
+      }
+      if (typeof result?.text !== "string") throw new aiSdk.InvalidResponseDataError({ data: parsed })
+
+      return {
+        durationInSeconds: typeof result.usage?.seconds === "number" ? result.usage.seconds : undefined,
+        language: nonEmptyString(result.language) ? result.language : undefined,
+        response: {
+          body: result,
+          headers: responseHeaders(response),
+          modelId: options.model,
+          timestamp: new Date(),
+        },
+        segments: [],
+        text: result.text,
+        warnings: [],
+      }
+    },
+  }
+}

--- a/packages/agent/test/transcription.test.ts
+++ b/packages/agent/test/transcription.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { getTranscriptionResults, streamTranscription, title, transcribe } from "../src/capabilities.ts"
+import { getTranscriptionResults, openRouterTranscriptionModel, streamTranscription, title, transcribe } from "../src/capabilities.ts"
 import { audioBytes, audioExtensionFor } from "../src/capabilities/transcribe.ts"
 import { createMessage, defineAgent, runAgent, serializeMessages } from "../src/index.ts"
 
@@ -149,12 +149,239 @@ describe("agent transcription", () => {
 
   it("normalizes audio extensions and bytes", async () => {
     expect(audioExtensionFor("audio/mpeg; codecs=mp3")).toBe("mp3")
+    expect(audioExtensionFor("audio/mp3")).toBe("mp3")
+    expect(audioExtensionFor("audio/unknown", "")).toBe("")
     expect(audioExtensionFor("audio/opus")).toBe("ogg")
     await expect(audioBytes({
       data: "data:audio/ogg;codecs=opus;base64,AQI=",
       mediaType: "audio/ogg",
       type: "audio",
     })).resolves.toEqual(new Uint8Array([1, 2]))
+  })
+
+  it("sends OpenRouter transcription models namespaced model ids with normal JSON output", async () => {
+    const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({
+      text: "voice transcript",
+      usage: { seconds: 1.25 },
+    }), {
+      headers: { "content-type": "application/json", "x-generation-id": "gen-1" },
+      status: 200,
+    }))
+    try {
+      const model = openRouterTranscriptionModel({
+        apiKey: () => "secret",
+        model: "openai/gpt-4o-transcribe",
+      })
+      const result = await model.doGenerate({
+        audio: new Uint8Array([1, 2, 3]),
+        headers: { "x-vitehub": "agent" },
+        mediaType: "audio/ogg; codecs=opus",
+        providerOptions: {
+          openrouter: {
+            language: "en",
+            provider: { order: ["openai"] },
+            temperature: 0.2,
+          },
+        },
+      })
+
+      expect(request).toHaveBeenCalledOnce()
+      const [url, init] = request.mock.calls[0] || []
+      expect(url).toBe("https://openrouter.ai/api/v1/audio/transcriptions")
+      expect(init?.method).toBe("POST")
+      expect(Object.fromEntries(new Headers(init?.headers).entries())).toMatchObject({
+        authorization: "Bearer secret",
+        "content-type": "application/json",
+        "x-vitehub": "agent",
+      })
+      expect(JSON.parse(String(init?.body))).toEqual({
+        input_audio: { data: "AQID", format: "ogg" },
+        language: "en",
+        model: "openai/gpt-4o-transcribe",
+        provider: { order: ["openai"] },
+        response_format: "json",
+        temperature: 0.2,
+      })
+      expect(result).toMatchObject({
+        durationInSeconds: 1.25,
+        response: { modelId: "openai/gpt-4o-transcribe" },
+        text: "voice transcript",
+      })
+    }
+    finally {
+      request.mockRestore()
+    }
+  })
+
+  it("exposes retryable OpenRouter provider failures to AI SDK transcription retries", async () => {
+    const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("null", { status: 503 }))
+    try {
+      const model = openRouterTranscriptionModel({
+        apiKey: "secret",
+        model: "openai/gpt-4o-transcribe",
+      })
+
+      await expect(model.doGenerate({
+        audio: new Uint8Array([1]),
+        mediaType: "audio/wav",
+      })).rejects.toMatchObject({
+        isRetryable: true,
+        statusCode: 503,
+      })
+    }
+    finally {
+      request.mockRestore()
+    }
+  })
+
+  it("normalizes OpenRouter response stream failures for AI SDK transcription retries", async () => {
+    const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(new ReadableStream({
+      start(controller) {
+        controller.error(new Error("connection reset"))
+      },
+    }), { status: 200 }))
+    try {
+      const model = openRouterTranscriptionModel({
+        apiKey: "secret",
+        model: "openai/gpt-4o-transcribe",
+      })
+
+      await expect(model.doGenerate({
+        audio: new Uint8Array([1]),
+        mediaType: "audio/wav",
+      })).rejects.toMatchObject({
+        isRetryable: true,
+        message: "OpenRouter transcription response failed.",
+        statusCode: 200,
+      })
+    }
+    finally {
+      request.mockRestore()
+    }
+  })
+
+  it("rejects unsupported OpenRouter transcription provider options", async () => {
+    const model = openRouterTranscriptionModel({
+      apiKey: "secret",
+      model: "openai/gpt-4o-transcribe",
+    })
+
+    await expect(model.doGenerate({
+      audio: new Uint8Array([1]),
+      mediaType: "audio/wav",
+      providerOptions: { openrouter: { unsupported: true } },
+    })).rejects.toThrow("Unsupported OpenRouter transcription provider option: unsupported")
+  })
+
+  it("validates OpenRouter transcription credentials, provider options, and response shapes", async () => {
+    const model = openRouterTranscriptionModel({
+      apiKey: "secret",
+      model: "openai/gpt-4o-transcribe",
+    })
+    const input = { audio: new Uint8Array([1]), mediaType: "audio/wav" }
+
+    await expect(openRouterTranscriptionModel({
+      apiKey: () => "",
+      model: "openai/gpt-4o-transcribe",
+    }).doGenerate(input)).rejects.toMatchObject({ name: "AI_LoadAPIKeyError" })
+    await expect(model.doGenerate({ ...input, providerOptions: { openrouter: { language: "" } } }))
+      .rejects.toThrow("language must be a non-empty string")
+    await expect(model.doGenerate({ ...input, providerOptions: { openrouter: { temperature: -0.1 } } }))
+      .rejects.toThrow("temperature must be between 0 and 1")
+    await expect(model.doGenerate({ ...input, providerOptions: { openrouter: { temperature: 1.1 } } }))
+      .rejects.toThrow("temperature must be between 0 and 1")
+    await expect(model.doGenerate({ ...input, providerOptions: { openrouter: { provider: [] } } }))
+      .rejects.toThrow("provider routing options must be an object")
+
+    const request = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(new Response("unavailable", { status: 502 }))
+      .mockResolvedValueOnce(new Response("not json", { status: 200 }))
+      .mockResolvedValueOnce(new Response("null", { status: 200 }))
+    try {
+      await expect(model.doGenerate(input)).rejects.toMatchObject({
+        isRetryable: true,
+        responseBody: "unavailable",
+        statusCode: 502,
+      })
+      await expect(model.doGenerate(input)).rejects.toMatchObject({ name: "AI_InvalidResponseDataError" })
+      await expect(model.doGenerate(input)).rejects.toMatchObject({ name: "AI_InvalidResponseDataError" })
+    }
+    finally {
+      request.mockRestore()
+    }
+  })
+
+  it("accepts OpenRouter temperature boundaries and rejects unsupported audio formats", async () => {
+    const request = vi.spyOn(globalThis, "fetch").mockImplementation(async () => new Response(JSON.stringify({ text: "ok" })))
+    const model = openRouterTranscriptionModel({ apiKey: "secret", model: "openai/gpt-4o-transcribe" })
+    try {
+      await expect(model.doGenerate({
+        audio: new Uint8Array([1]),
+        mediaType: "audio/mp3",
+        providerOptions: { openrouter: { temperature: 0 } },
+      })).resolves.toMatchObject({ text: "ok" })
+      await expect(model.doGenerate({
+        audio: new Uint8Array([1]),
+        mediaType: "audio/wav",
+        providerOptions: { openrouter: { temperature: 1 } },
+      })).resolves.toMatchObject({ text: "ok" })
+      await expect(model.doGenerate({ audio: new Uint8Array([1]), mediaType: "audio/unknown" }))
+        .rejects.toThrow("does not support audio/unknown")
+      expect(request).toHaveBeenCalledTimes(2)
+      expect(JSON.parse(String(request.mock.calls[0]?.[1]?.body))).toMatchObject({
+        input_audio: { format: "mp3" },
+        temperature: 0,
+      })
+      expect(JSON.parse(String(request.mock.calls[1]?.[1]?.body))).toMatchObject({ temperature: 1 })
+    }
+    finally {
+      request.mockRestore()
+    }
+  })
+
+  it("normalizes request failures while preserving OpenRouter transcription aborts", async () => {
+    const model = openRouterTranscriptionModel({ apiKey: "secret", model: "openai/gpt-4o-transcribe" })
+    const input = { audio: new Uint8Array([1]), mediaType: "audio/wav" }
+    const connectionError = new Error("connection reset")
+    const abortError = new DOMException("aborted", "AbortError")
+    const controller = new AbortController()
+    controller.abort(abortError)
+    const request = vi.spyOn(globalThis, "fetch")
+      .mockRejectedValueOnce(connectionError)
+      .mockRejectedValueOnce(abortError)
+    try {
+      await expect(model.doGenerate(input)).rejects.toMatchObject({
+        cause: connectionError,
+        isRetryable: true,
+      })
+      await expect(model.doGenerate({ ...input, abortSignal: controller.signal })).rejects.toBe(abortError)
+    }
+    finally {
+      request.mockRestore()
+    }
+  })
+
+  it("runs the OpenRouter model through the transcribe Capability contract", async () => {
+    const request = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(JSON.stringify({ text: "voice transcript" })))
+    try {
+      const capability = transcribe({
+        model: openRouterTranscriptionModel({ apiKey: "secret", model: "openai/gpt-4o-transcribe" }),
+      })
+      const context = createTranscriptionCapabilityContext([
+        createMessage({
+          parts: [{ data: "AQI=", mediaType: "audio/wav", type: "audio" }],
+          role: "user",
+        }),
+      ])
+
+      await capability.input?.(context.context as never)
+
+      expect(context.messages.at(-1)?.parts).toEqual([{ id: "text-0", text: "voice transcript", type: "text" }])
+      expect(getTranscriptionResults(context.invocationContext)).toMatchObject([{ transcript: "voice transcript" }])
+    }
+    finally {
+      request.mockRestore()
+    }
   })
 
   it("resolves lazy audio bytes with size limits", async () => {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -1,8 +1,8 @@
 import { describe, expectTypeOf, it } from "vitest"
-import type { LanguageModel } from "ai"
+import type { LanguageModel, TranscriptionModel } from "ai"
 
 import { defineAgent, defineAgentInvoker, defineCapability, defineFinishEffect, runAgent, runAgentInline, startAgentInvocation, type AgentActor, type AgentCapabilitiesResolverContext, type AgentCapabilityCliCommand, type AgentCapabilityCliResolver, type AgentCapabilityDefinition, type AgentChannelDeliveryEffectContext, type AgentChannelDeliveryEffectIntent, type AgentChannelDeliveryEffectKind, type AgentChannelDeliveryFinishEffect, type AgentChannelDeliveryFinishEffectContext, type AgentChannelDefinition, type AgentChannelDeliveryReplyPayload, type AgentChannelDeliveryReplyStream, type AgentChannelFactory, type AgentChannelInput, type AgentChannelInputs, type AgentDeliveryArtifact, type AgentDriver, type AgentDriverCapacityOptions, type AgentDriverCapacityQueueOptions, type AgentErrorHookEvent, type AgentFinishEvent, type AgentFinishHookEvent, type AgentGatewayModel, type AgentHarnessDriver, type AgentHookObserverEvent, type AgentInvoker, type AgentMessageChannelSettings, type AgentMessageDeliveryKind, type AgentModelInput, type AgentModuleOptions, type AgentRunInput, type AgentRunInputContextValues, type AgentRunResult, type AgentRuntimeConfig, type AgentRuntimeContext, type AgentTriggerInvokeResult, type AgentTriggerRunInvokeResult, type AgentUIMessageStreamProjection, type AgentUsageRecord, type ImagePart, type PublishedAgentDeliveryArtifact } from "../src/index.ts"
-import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, papercuts, repositoryHost, repositoryHostContext, sandbox, schedule, skills, streamTranscription, subagents, transcribe, cost, vercelAiGatewayPricing, webSearch, workspaceShell, type AgentUsagePricing, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput, type CostOptions, type VercelAiGatewayPricingOptions } from "../src/capabilities.ts"
+import { access, blob, browser, chat, title, db, email, fetch, getTranscriptionResults, git, inputCommands, kv, mcp, openapi, openRouterTranscriptionModel, papercuts, repositoryHost, repositoryHostContext, sandbox, schedule, skills, streamTranscription, subagents, transcribe, cost, vercelAiGatewayPricing, webSearch, workspaceShell, type AgentUsagePricing, type EmailCapabilityOptions, type EmailCapabilityToolPolicy, type PapercutReportContext, type PapercutReportEvent, type SubagentToolInput, type CostOptions, type VercelAiGatewayPricingOptions } from "../src/capabilities.ts"
 import { gmail, type GmailCapabilityMode, type GmailCapabilityOptions } from "../src/capabilities.ts"
 import { defineChannel, github, http, pullRequest, teams, telegram, webChat, type GitHubPullRequestCommand, type GitHubPullRequestRunContext } from "../src/channels.ts"
 import { defineEval, hasCapabilityExtension, textContains, type AgentEvalDefinition, type AgentObservation, type AgentScorer } from "../src/eval.ts"
@@ -809,6 +809,13 @@ describe("agent public types", () => {
         },
       },
     })
+
+    const openRouterTranscription = openRouterTranscriptionModel({
+      apiKey: () => "secret",
+      model: "openai/gpt-4o-transcribe",
+    })
+    expectTypeOf(openRouterTranscription).toMatchTypeOf<TranscriptionModel>()
+    transcribe({ model: openRouterTranscription })
 
     const streamingTranscription = streamTranscription({
       audio: new ReadableStream<Uint8Array>(),


### PR DESCRIPTION
OpenRouter transcription currently forces Agent Definitions to own audio encoding, authentication, request handling, and provider error normalization. The generic OpenAI provider can also request `verbose_json`, which OpenRouter rejects for some upstream routes.

- Add `openRouterTranscriptionModel()` for the existing `transcribe({ model })` contract, using OpenRouter normal JSON and base64 audio without a new dependency.
- Load AI SDK runtime values only when transcription executes, preserving the lazy root and capabilities import boundary.
- Normalize API-key, transport, HTTP, response-stream, and response-shape failures through AI SDK errors so existing transcription retries can react to retryable failures.
- Preserve supported AI SDK `providerOptions.openrouter` values for language, temperature, and provider routing, and reject unsupported options explicitly.
- Preserve recognized audio formats and reject unsupported MIME types instead of relabeling bytes.
- Cover the exact namespaced `openai/gpt-4o-transcribe` request, `response_format: "json"`, retryable failures, aborts, public types, and the Capability integration.
- Document the consumer-facing Agent Definition usage.

## Verification

- `pnpm vp run -t @vite-hub/agent#build` (publint passed)
- `pnpm --filter @vite-hub/agent exec vp test test/transcription.test.ts` (35 passed)
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm vp check --no-fmt packages/agent/src/capabilities/transcribe.ts packages/agent/src/capabilities/transcription-openrouter.ts packages/agent/src/capabilities/index.ts packages/agent/test/transcription.test.ts packages/agent/test/types.test-d.ts docs/content/docs/capabilities/transcribe.md packages/agent/README.md` (0 errors; one pre-existing unused type-fixture warning)
- `git diff --check`