### PR TITLE
fix(agent): deliver durable workflow failures

### DIFF
--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -2,6 +2,7 @@ import { defineCapability } from "./capability-runtime.ts"
 import { createChatMessageTriggerInput } from "./chat-message-input.ts"
 import { toAgentPublicError } from "./agent-error.ts"
 import { createReplyDeliveryEffectIntent, defineFinishEffect } from "./delivery-effects.ts"
+import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
 
 import type {
   AgentCapabilityDefinition,
@@ -16,6 +17,7 @@ import type {
   AgentInvocationContextStore,
   AgentRunMetadata,
   AgentRuntimeConfig,
+  AgentRuntimeContext,
   AgentTriggerDefinition,
   AgentWebhookRegistrationDefinition,
 } from "./types.ts"
@@ -80,12 +82,14 @@ export async function resolveChatErrorFallbackText<TRuntimeConfig extends AgentR
   options: AgentChatOptions<TRuntimeConfig> | undefined,
   args: AgentChatErrorHookArgs<TRuntimeConfig>,
   callbackDelivered?: () => boolean,
+  resolveFallback?: (fallback: Promise<unknown>) => Promise<unknown>,
 ): Promise<string | undefined> {
   const fallback = options?.errorFallbackText
   if (fallback === null) return
   if (typeof fallback === "function") {
     try {
-      return await fallback(args) || undefined
+      const resolution = Promise.resolve(fallback(args))
+      return await (resolveFallback ? resolveFallback(resolution) : resolution) as string || undefined
     }
     catch {
       return callbackDelivered?.() ? undefined : defaultChatErrorFallbackText
@@ -99,7 +103,7 @@ function durableChatErrorFallback<TRuntimeConfig extends AgentRuntimeConfig>(
   options: AgentChatOptions<TRuntimeConfig>,
 ) {
   const effect = defineFinishEffect<TRuntimeConfig>(async (context) => {
-    if (context.error === undefined || !context.run?.origin?.startsWith("workflow:")) return
+    if (context.error === undefined || !(context as unknown as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey]) return
     const replies: ReturnType<typeof createReplyDeliveryEffectIntent>[] = []
     const chat = getAgentChatContext(context.context)
     const fallback = await resolveChatErrorFallbackText(options, {
@@ -119,7 +123,7 @@ function durableChatErrorFallback<TRuntimeConfig extends AgentRuntimeConfig>(
     if (fallback) replies.push(createReplyDeliveryEffectIntent(fallback, { intent: "chat.error-fallback" }))
     return replies
   })
-  effect.active = context => context.error !== undefined && Boolean(context.run?.origin?.startsWith("workflow:"))
+  effect.active = context => context.error !== undefined && Boolean((context as unknown as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey])
   effect.kind = "reply"
   return effect
 }

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -135,6 +135,7 @@ export function resolveDurableChatErrorFallbackText<TRuntimeConfig extends Agent
 export async function resolveDurableChatErrorFallbackIntents<TRuntimeConfig extends AgentRuntimeConfig>(
   options: AgentChatOptions<TRuntimeConfig> | undefined,
   args: Omit<AgentChatErrorHookArgs<TRuntimeConfig>, "thread">,
+  resolveFallback?: (fallback: Promise<unknown>) => Promise<unknown>,
 ): Promise<AgentChannelDeliveryEffectIntent[]> {
   const intents: AgentChannelDeliveryEffectIntent[] = []
   let acceptingIntents = true
@@ -147,7 +148,9 @@ export async function resolveDurableChatErrorFallbackIntents<TRuntimeConfig exte
       },
     },
   } as AgentChatErrorHookArgs<TRuntimeConfig>
-  const fallback = await resolveDurableChatErrorFallbackText(options, hookArgs, () => intents.length > 0)
+  const fallback = resolveFallback
+    ? await resolveChatErrorFallbackText(options, hookArgs, () => intents.length > 0, resolveFallback)
+    : await resolveDurableChatErrorFallbackText(options, hookArgs, () => intents.length > 0)
   acceptingIntents = false
   if (!intents.length && fallback) intents.push(createReplyDeliveryEffectIntent(fallback, { intent: "chat.error-fallback" }))
   return intents

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -134,15 +134,18 @@ export async function resolveDurableChatErrorFallbackIntents<TRuntimeConfig exte
   args: Omit<AgentChatErrorHookArgs<TRuntimeConfig>, "thread">,
 ): Promise<AgentChannelDeliveryEffectIntent[]> {
   const intents: AgentChannelDeliveryEffectIntent[] = []
+  let acceptingIntents = true
   const hookArgs = {
     ...args,
     thread: {
       post: async (message: unknown) => {
+        if (!acceptingIntents) throw new Error("Durable chat error fallback resolution has already completed.")
         intents.push(createReplyDeliveryEffectIntent(message as never, { intent: "chat.error-fallback" }))
       },
     },
   } as AgentChatErrorHookArgs<TRuntimeConfig>
   const fallback = await resolveDurableChatErrorFallbackText(options, hookArgs, () => intents.length > 0)
+  acceptingIntents = false
   if (!intents.length && fallback) intents.push(createReplyDeliveryEffectIntent(fallback, { intent: "chat.error-fallback" }))
   return intents
 }

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -78,6 +78,12 @@ export const CHAT_FINISH_EXTENSION_CONTEXT_KEY = "chat.finish"
 const defaultChatErrorFallbackText = "Sorry, I couldn't process that message."
 const durableChatErrorFallbackTimeoutMs = 30_000
 
+export function durableChatErrorFallbackTimeout(
+  options: Pick<AgentChatOptions, "timeout"> | undefined,
+): number {
+  return Math.min(options?.timeout ?? durableChatErrorFallbackTimeoutMs, durableChatErrorFallbackTimeoutMs)
+}
+
 type KnownChatWebhookPlatform = keyof typeof CHAT_WEBHOOK_DEFAULTS
 
 export async function resolveChatErrorFallbackText<TRuntimeConfig extends AgentRuntimeConfig>(
@@ -106,7 +112,7 @@ export function resolveDurableChatErrorFallbackText<TRuntimeConfig extends Agent
   args: AgentChatErrorHookArgs<TRuntimeConfig>,
   callbackDelivered?: () => boolean,
 ): Promise<string | undefined> {
-  const timeout = Math.min(options?.timeout ?? durableChatErrorFallbackTimeoutMs, durableChatErrorFallbackTimeoutMs)
+  const timeout = durableChatErrorFallbackTimeout(options)
   return resolveChatErrorFallbackText(options, args, callbackDelivered, async (resolution) => {
     let timeoutId: ReturnType<typeof setTimeout> | undefined
     try {

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -75,6 +75,7 @@ const CHAT_WEBHOOK_DEFAULTS = {
 
 export const CHAT_FINISH_EXTENSION_CONTEXT_KEY = "chat.finish"
 const defaultChatErrorFallbackText = "Sorry, I couldn't process that message."
+const durableChatErrorFallbackTimeoutMs = 30_000
 
 type KnownChatWebhookPlatform = keyof typeof CHAT_WEBHOOK_DEFAULTS
 
@@ -99,6 +100,28 @@ export async function resolveChatErrorFallbackText<TRuntimeConfig extends AgentR
   return typeof fallback === "string" ? fallback : defaultChatErrorFallbackText
 }
 
+export function resolveDurableChatErrorFallbackText<TRuntimeConfig extends AgentRuntimeConfig>(
+  options: AgentChatOptions<TRuntimeConfig> | undefined,
+  args: AgentChatErrorHookArgs<TRuntimeConfig>,
+  callbackDelivered?: () => boolean,
+): Promise<string | undefined> {
+  const timeout = Math.min(options?.timeout ?? durableChatErrorFallbackTimeoutMs, durableChatErrorFallbackTimeoutMs)
+  return resolveChatErrorFallbackText(options, args, callbackDelivered, async (resolution) => {
+    let timeoutId: ReturnType<typeof setTimeout> | undefined
+    try {
+      return await Promise.race([
+        resolution,
+        new Promise<never>((_resolve, reject) => {
+          timeoutId = setTimeout(() => reject(new Error(`Durable chat error fallback timed out after ${timeout}ms.`)), timeout)
+        }),
+      ])
+    }
+    finally {
+      if (timeoutId) clearTimeout(timeoutId)
+    }
+  })
+}
+
 function durableChatErrorFallback<TRuntimeConfig extends AgentRuntimeConfig>(
   options: AgentChatOptions<TRuntimeConfig>,
 ) {
@@ -106,7 +129,7 @@ function durableChatErrorFallback<TRuntimeConfig extends AgentRuntimeConfig>(
     if (context.error === undefined || !(context as unknown as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey]) return
     const replies: ReturnType<typeof createReplyDeliveryEffectIntent>[] = []
     const chat = getAgentChatContext(context.context)
-    const fallback = await resolveChatErrorFallbackText(options, {
+    const fallback = await resolveDurableChatErrorFallbackText(options, {
       error: context.error,
       history: context.input.messages || [],
       message: chat?.message || { text: "" },

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -170,7 +170,8 @@ function durableChatErrorFallback<TRuntimeConfig extends AgentRuntimeConfig>(
       toolResults: context.event.toolResults,
     })
   })
-  effect.active = context => context.error !== undefined
+  effect.active = context => options.errorFallbackText !== null
+    && context.error !== undefined
     && Boolean((context as unknown as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey])
     && (Boolean(getAgentChatContext(context.context)) || context.context.has("channel"))
   effect.kind = "chat.error-fallback"

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -147,16 +147,20 @@ function durableChatErrorFallback<TRuntimeConfig extends AgentRuntimeConfig>(
   const effect = defineFinishEffect<TRuntimeConfig>(async (context) => {
     if (context.error === undefined || !(context as unknown as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey]) return
     const chat = getAgentChatContext(context.context)
+    const channel = context.context.get<AgentChannelContext>("channel")
+    if (!chat && !channel) return
     return await resolveDurableChatErrorFallbackIntents(options, {
       error: context.error,
       history: context.input.messages || [],
-      message: chat?.message || { text: "" },
+      message: chat?.message || channel?.message || { text: "" },
       publicError: toAgentPublicError(context.error, "http"),
       run: context.run,
       toolResults: context.event.toolResults,
     })
   })
-  effect.active = context => context.error !== undefined && Boolean((context as unknown as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey])
+  effect.active = context => context.error !== undefined
+    && Boolean((context as unknown as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey])
+    && (Boolean(getAgentChatContext(context.context)) || context.context.has("channel"))
   effect.kind = "reply"
   return effect
 }

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -77,6 +77,9 @@ const CHAT_WEBHOOK_DEFAULTS = {
 export const CHAT_FINISH_EXTENSION_CONTEXT_KEY = "chat.finish"
 const defaultChatErrorFallbackText = "Sorry, I couldn't process that message."
 const durableChatErrorFallbackTimeoutMs = 30_000
+export function isDurableChatErrorFallbackEffect(effect: unknown): boolean {
+  return typeof effect === "function" && (effect as { kind?: string }).kind === "chat.error-fallback"
+}
 
 export function durableChatErrorFallbackTimeout(
   options: Pick<AgentChatOptions, "timeout"> | undefined,
@@ -170,7 +173,7 @@ function durableChatErrorFallback<TRuntimeConfig extends AgentRuntimeConfig>(
   effect.active = context => context.error !== undefined
     && Boolean((context as unknown as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey])
     && (Boolean(getAgentChatContext(context.context)) || context.context.has("channel"))
-  effect.kind = "reply"
+  effect.kind = "chat.error-fallback"
   return effect
 }
 

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -1,10 +1,13 @@
 import { defineCapability } from "./capability-runtime.ts"
 import { createChatMessageTriggerInput } from "./chat-message-input.ts"
+import { toAgentPublicError } from "./agent-error.ts"
+import { createReplyDeliveryEffectIntent, defineFinishEffect } from "./delivery-effects.ts"
 
 import type {
   AgentCapabilityDefinition,
   AgentCapabilityTypeContract,
   AgentChatAgentHookArgs,
+  AgentChatErrorHookArgs,
   AgentChatCapabilityOptions,
   AgentChatFinishExtension,
   AgentChatOptions,
@@ -69,8 +72,57 @@ const CHAT_WEBHOOK_DEFAULTS = {
 } satisfies Record<string, Partial<AgentWebhookRegistrationDefinition> & { provider?: string }>
 
 export const CHAT_FINISH_EXTENSION_CONTEXT_KEY = "chat.finish"
+const defaultChatErrorFallbackText = "Sorry, I couldn't process that message."
 
 type KnownChatWebhookPlatform = keyof typeof CHAT_WEBHOOK_DEFAULTS
+
+export async function resolveChatErrorFallbackText<TRuntimeConfig extends AgentRuntimeConfig>(
+  options: AgentChatOptions<TRuntimeConfig> | undefined,
+  args: AgentChatErrorHookArgs<TRuntimeConfig>,
+  callbackDelivered?: () => boolean,
+): Promise<string | undefined> {
+  const fallback = options?.errorFallbackText
+  if (fallback === null) return
+  if (typeof fallback === "function") {
+    try {
+      return await fallback(args) || undefined
+    }
+    catch {
+      return callbackDelivered?.() ? undefined : defaultChatErrorFallbackText
+    }
+  }
+  if (args.publicError.code !== "INTERNAL") return args.publicError.error
+  return typeof fallback === "string" ? fallback : defaultChatErrorFallbackText
+}
+
+function durableChatErrorFallback<TRuntimeConfig extends AgentRuntimeConfig>(
+  options: AgentChatOptions<TRuntimeConfig>,
+) {
+  const effect = defineFinishEffect<TRuntimeConfig>(async (context) => {
+    if (context.error === undefined || !context.run?.origin?.startsWith("workflow:")) return
+    const replies: ReturnType<typeof createReplyDeliveryEffectIntent>[] = []
+    const chat = getAgentChatContext(context.context)
+    const fallback = await resolveChatErrorFallbackText(options, {
+      error: context.error,
+      history: context.input.messages || [],
+      message: chat?.message || { text: "" },
+      publicError: toAgentPublicError(context.error, "http"),
+      run: context.run,
+      thread: {
+        post: async (message) => {
+          replies.push(createReplyDeliveryEffectIntent(message as never, { intent: "chat.error-fallback" }))
+        },
+      },
+      toolResults: context.event.toolResults,
+    }, () => replies.length > 0)
+    if (replies.length) return replies
+    if (fallback) replies.push(createReplyDeliveryEffectIntent(fallback, { intent: "chat.error-fallback" }))
+    return replies
+  })
+  effect.active = context => context.error !== undefined && Boolean(context.run?.origin?.startsWith("workflow:"))
+  effect.kind = "reply"
+  return effect
+}
 
 export interface AgentChatRunContext<
   TMessageMetadata extends object = Record<string, unknown>,
@@ -257,6 +309,7 @@ export function defineChatCapability<
     },
     output(context) {
       context.finish.provide(() => context.context.get<AgentChatFinishExtension>(CHAT_FINISH_EXTENSION_CONTEXT_KEY))
+      context.delivery.finishEffect(durableChatErrorFallback(options) as never)
     },
     triggers: {
       message: createChatMessageTrigger(options),

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -13,6 +13,7 @@ import type {
   AgentChatFinishExtension,
   AgentChatOptions,
   AgentChatPlatformResolver,
+  AgentChannelDeliveryEffectIntent,
   AgentChannelWebhookRegistrationDefinition,
   AgentInvocationContextStore,
   AgentRunMetadata,
@@ -122,29 +123,38 @@ export function resolveDurableChatErrorFallbackText<TRuntimeConfig extends Agent
   })
 }
 
+export async function resolveDurableChatErrorFallbackIntents<TRuntimeConfig extends AgentRuntimeConfig>(
+  options: AgentChatOptions<TRuntimeConfig> | undefined,
+  args: Omit<AgentChatErrorHookArgs<TRuntimeConfig>, "thread">,
+): Promise<AgentChannelDeliveryEffectIntent[]> {
+  const intents: AgentChannelDeliveryEffectIntent[] = []
+  const hookArgs = {
+    ...args,
+    thread: {
+      post: async (message: unknown) => {
+        intents.push(createReplyDeliveryEffectIntent(message as never, { intent: "chat.error-fallback" }))
+      },
+    },
+  } as AgentChatErrorHookArgs<TRuntimeConfig>
+  const fallback = await resolveDurableChatErrorFallbackText(options, hookArgs, () => intents.length > 0)
+  if (!intents.length && fallback) intents.push(createReplyDeliveryEffectIntent(fallback, { intent: "chat.error-fallback" }))
+  return intents
+}
+
 function durableChatErrorFallback<TRuntimeConfig extends AgentRuntimeConfig>(
   options: AgentChatOptions<TRuntimeConfig>,
 ) {
   const effect = defineFinishEffect<TRuntimeConfig>(async (context) => {
     if (context.error === undefined || !(context as unknown as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey]) return
-    const replies: ReturnType<typeof createReplyDeliveryEffectIntent>[] = []
     const chat = getAgentChatContext(context.context)
-    const fallback = await resolveDurableChatErrorFallbackText(options, {
+    return await resolveDurableChatErrorFallbackIntents(options, {
       error: context.error,
       history: context.input.messages || [],
       message: chat?.message || { text: "" },
       publicError: toAgentPublicError(context.error, "http"),
       run: context.run,
-      thread: {
-        post: async (message) => {
-          replies.push(createReplyDeliveryEffectIntent(message as never, { intent: "chat.error-fallback" }))
-        },
-      },
       toolResults: context.event.toolResults,
-    }, () => replies.length > 0)
-    if (replies.length) return replies
-    if (fallback) replies.push(createReplyDeliveryEffectIntent(fallback, { intent: "chat.error-fallback" }))
-    return replies
+    })
   })
   effect.active = context => context.error !== undefined && Boolean((context as unknown as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey])
   effect.kind = "reply"

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -175,6 +175,7 @@ import type {
   AgentInvocationSnapshot,
 } from "./agent-invocation.ts"
 import type { StreamEvent } from "./messages.ts"
+import type { AgentChannelContext } from "./chat-trigger.ts"
 import type { AgentTraceContext } from "./trace.ts"
 import type { ResolvedAgentTriggerInvocation, ResolvedAgentTriggerInvocationResult } from "./trigger-runtime.ts"
 import type {
@@ -3325,10 +3326,12 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
   if (!options) return
   const invocationContext = createAgentInvocationContextStore(input.context)
   const chat = getAgentChatContext(invocationContext)
+  const channel = invocationContext.get<AgentChannelContext>("channel")
+  if (!chat && !channel) return
   const intents = await resolveDurableChatErrorFallbackIntents(options, {
     error,
     history: input.messages || [],
-    message: chat?.message || { text: "" },
+    message: chat?.message || channel?.message || { text: "" },
     publicError: toAgentPublicError(error, "http"),
     run: context.run,
     toolResults: [],
@@ -3998,7 +4001,7 @@ async function executeAgentInvocationWithCapacityLease<
         cancelOnAbort: options.holdCapacity === true
           ? async reason => { await Promise.allSettled([...uiMessageSources.values()].map(({ cancel }) => cancel(reason))) }
           : undefined,
-        ...(collectToolResult ? { onWrappedChunk: collectToolResult } : {}),
+        ...(collectToolResult ? { onNormalizedChunk: collectToolResult } : {}),
         projection,
       })
     }
@@ -4111,7 +4114,7 @@ async function executeAgentInvocationWithCapacityLease<
             }
           }, {
             abortSignal: invocation.input.abortSignal,
-            ...(collectToolResult ? { onWrappedChunk: collectToolResult } : {}),
+            ...(collectToolResult ? { onNormalizedChunk: collectToolResult } : {}),
             projection,
           })
           const headers = new Headers(response.headers)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3131,11 +3131,13 @@ async function finishAgentInvocation<
         ...(text !== undefined ? { text } : {}),
         toolResults: [...context.toolResults],
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
+      const provisionalEvent = provisionalFinishEvent(context, eventBase)
+      const provisionallyActiveDeliveryProviders = activeFinishDeliveryEffectProviders(context, provisionalEvent)
       const hasDurableFailureDelivery = failed
         && context.durableErrorFallbackTimeout !== undefined
-        && context.finishDeliveryEffectProviders.some(isDurableChatErrorFallbackEffect)
+        && provisionallyActiveDeliveryProviders.some(isDurableChatErrorFallbackEffect)
       const provisionalActiveDeliveryProviders = hasDurableFailureDelivery
-        ? activeFinishDeliveryEffectProviders(context, provisionalFinishEvent(context, eventBase))
+        ? provisionallyActiveDeliveryProviders
         : await prepareProvisionalTitleDeliverySupport(context, eventBase)
       const cleanupOnlyFailure = outcome.status === "success" && closeError !== undefined
       const outcomeHook = failed

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -22,7 +22,7 @@ import {
 import { createTraceEventLog, deriveTraceRuns, getViteHubErrorShape, resolveRuntimeContext, traceEventsToOpenTelemetrySpans } from "@vite-hub/runtime"
 import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
-import { defineChatCapability, getAgentChatContext, getChatCapabilityOptions, resolveDurableChatErrorFallbackText } from "./chat-trigger.ts"
+import { defineChatCapability, getAgentChatContext, getChatCapabilityOptions, resolveDurableChatErrorFallbackIntents } from "./chat-trigger.ts"
 import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
 import {
   bindMessageChannelInstructions,
@@ -2002,7 +2002,9 @@ async function createAgentInvocationContext<
   const telemetryInvocationId = createTraceId()
   const toolResults: AgentToolStepItem[] = []
   const toolStepReporter: NonNullable<AgentRuntimeContext<TRuntimeConfig>["toolStepReporter"]> = async (step) => {
-    if (step.toolResults?.length) toolResults.push(...step.toolResults)
+    if (step.toolResults?.length) {
+      for (const result of step.toolResults) appendAgentToolResult(toolResults, result)
+    }
     await context.toolStepReporter?.(step)
   }
   invocationContext.set(agentInvocationTraceIdContextKey, telemetryInvocationId, { overwrite: true })
@@ -2260,6 +2262,27 @@ async function createAgentInvocationContext<
     }, error)
     scheduleAgentTelemetry(definition?.telemetry, runtimeContext, { name: definition?.name, version: definition?.version }, telemetryInvocationId)
     throw error
+  }
+}
+
+function appendAgentToolResult(results: AgentToolStepItem[], result: AgentToolStepItem): void {
+  const id = result.toolCallId ?? result.id
+  if (id !== undefined && results.some(candidate => (candidate.toolCallId ?? candidate.id) === id)) return
+  results.push(result)
+}
+
+function agentToolResultStreamCollector(toolResults: AgentToolStepItem[]): (chunk: unknown) => void {
+  const toolNames = new Map<string, string>()
+  const textPhases = new Map<string, AgentMessagePhase | "hidden">()
+  return (chunk) => {
+    const event = toAgentStreamEvent(chunk, toolNames, textPhases)
+    if (event?.type === "tool-result" && !event.error) {
+      appendAgentToolResult(toolResults, {
+        output: event.output,
+        toolCallId: event.id,
+        toolName: event.name,
+      })
+    }
   }
 }
 
@@ -2537,6 +2560,7 @@ function withStreamedResult(
   stream: AsyncIterable<unknown>,
   result: unknown,
   fallbackUsageRecord?: Extract<StreamEvent, { type: "usage" }>["usageRecord"],
+  toolResults?: AgentToolStepItem[],
 ) {
   const toolNames = new Map<string, string>()
   const textPhases = new Map<string, AgentMessagePhase | "hidden">()
@@ -2554,6 +2578,13 @@ function withStreamedResult(
     stream: (async function* () {
       for await (const chunk of stream) {
         const event = toAgentStreamEvent(chunk, toolNames, textPhases)
+        if (toolResults && event?.type === "tool-result" && !event.error) {
+          appendAgentToolResult(toolResults, {
+            output: event.output,
+            toolCallId: event.id,
+            toolName: event.name,
+          })
+        }
         const explicitlyPhasedTextChunk = chunk && typeof chunk === "object"
           && "phase" in chunk && (chunk as { phase?: unknown }).phase !== undefined
           && "type" in chunk && ["text", "text-delta", "text-end", "text-start"].includes(String((chunk as { type?: unknown }).type))
@@ -2971,20 +3002,35 @@ async function finishAgentInvocation<
   outcome: AgentInvocationFinishOutcome,
 ): Promise<void> {
   const durationMs = Date.now() - context.startedAt
-  const failed = outcome.status === "error"
-  const error = failed ? outcome.error : undefined
-  const result = outcome.status === "success" ? outcome.result : undefined
-  const runResult = failed || result === undefined ? undefined : toAgentRunResult(result)
-  const text = runResult?.text
+  let failed = outcome.status === "error"
+  let error = outcome.status === "error" ? outcome.error : undefined
+  let result = outcome.status === "success" ? outcome.result : undefined
+  let usage = outcome.status === "success" ? outcome.usage : undefined
+  const usageResolved = outcome.status === "success" && outcome.usageResolved
+  let runResult = failed || result === undefined ? undefined : toAgentRunResult(result)
+  let text = runResult?.text
+  let closeError: unknown
   try {
     await context.startTask
-    await context.close()
+    try {
+      await context.close()
+    }
+    catch (cleanupError) {
+      closeError = cleanupError
+      if (!failed) {
+        failed = true
+        result = undefined
+        runResult = undefined
+        text = undefined
+        error = cleanupError
+      }
+    }
     let resultKind: string | undefined
-    let usage = failed ? undefined : outcome.usage
+    if (failed) usage = undefined
     if (!failed) {
       try {
         resultKind = agentResultKind(result)
-        if (!outcome.usageResolved) usage ??= await resolveAgentUsageRecord(result, context.run)
+        if (!usageResolved) usage ??= await resolveAgentUsageRecord(result, context.run)
       }
       catch {
         // Invocation data must not change Agent output or mask the original failure.
@@ -3051,9 +3097,13 @@ async function finishAgentInvocation<
     else {
       await traceAgentInvocationError(toTraceContext(context), error)
     }
+    if (closeError !== undefined) throw closeError
   }
   catch (finishError) {
     await traceAgentInvocationError(toTraceContext(context), failed ? error : finishError)
+    if (closeError !== undefined && finishError !== closeError) {
+      throw new AggregateError([closeError, finishError], "[vitehub] Capability cleanup and Agent finish lifecycle both failed.")
+    }
     throw finishError
   }
   finally {
@@ -3125,7 +3175,7 @@ async function finalizeAgentInvocationResult<
       const enrichedStream = withEagerStreamUsageExtensions(source.stream, context, result)
       const stream = options.wrapStream?.(enrichedStream) || enrichedStream
       if (shouldWrapOutput) {
-        const streamed = withStreamedResult(stream, result)
+        const streamed = withStreamedResult(stream, result, undefined, context.toolResults)
         if (!context.finalOutputRenderers.length && (!context.output || !options.finalizeRawStreams)) {
           const value = withCapabilityCleanup(streamed.stream, async (outcome) => {
             const finishOutcome = finishOutcomeFromCleanup(outcome, result)
@@ -3270,21 +3320,16 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
   if (!(context as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey]) return
   const options = getChatCapabilityOptions<TRuntimeConfig>(definition?.capabilities || [])
   if (!options) return
-  const intents: AgentChannelDeliveryEffectIntent[] = []
   const invocationContext = createAgentInvocationContextStore(input.context)
   const chat = getAgentChatContext(invocationContext)
-  const fallback = await resolveDurableChatErrorFallbackText(options, {
+  const intents = await resolveDurableChatErrorFallbackIntents(options, {
     error,
     history: input.messages || [],
     message: chat?.message || { text: "" },
     publicError: toAgentPublicError(error, "http"),
     run: context.run,
-    thread: {
-      post: async message => intents.push(createReplyDeliveryEffectIntent(message as never, { intent: "chat.error-fallback" })),
-    },
     toolResults: [],
-  }, () => intents.length > 0)
-  if (!intents.length && fallback) intents.push(createReplyDeliveryEffectIntent(fallback, { intent: "chat.error-fallback" }))
+  })
   if (!intents.length) return
   const invoker = createFallbackAgentInvoker(context.run)
   await applyChannelDeliveryEffectIntents({
@@ -3297,6 +3342,29 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
     run: context.run,
     runtimeContext: createResolvedRuntimeContext(context),
   } as never, intents)
+}
+
+async function createAgentInvocationContextWithWorkflowFailureDelivery<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
+  context: AgentRuntimeContext<TRuntimeConfig>,
+  input: AgentRunInput<CALL_OPTIONS>,
+  kind: "run" | "stream",
+): Promise<AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>> {
+  try {
+    return await createAgentInvocationContext(definition, context, input, kind)
+  }
+  catch (error) {
+    try {
+      await deliverUnpreparedWorkflowFailure(definition, context, input, error)
+    }
+    catch (deliveryError) {
+      throw new AggregateError([error, deliveryError], "[vitehub] Agent setup failed and Workflow fallback delivery also failed.")
+    }
+    throw error
+  }
 }
 
 async function executeAgentInvocationWithCapacityLease<
@@ -3314,19 +3382,8 @@ async function executeAgentInvocationWithCapacityLease<
   const definition = hasAgentDefinition(agent)
     ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput>
     : undefined
-  let invocation: AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>
-  try {
-    invocation = preparedInvocation ?? await createAgentInvocationContext(definition, context, input, options.kind)
-  }
-  catch (error) {
-    try {
-      await deliverUnpreparedWorkflowFailure(definition, context, input, error)
-    }
-    catch (deliveryError) {
-      throw new AggregateError([error, deliveryError], "[vitehub] Agent setup failed and Workflow fallback delivery also failed.")
-    }
-    throw error
-  }
+  const invocation = preparedInvocation
+    ?? await createAgentInvocationContextWithWorkflowFailureDelivery(definition, context, input, options.kind)
   const shouldHoldInvocationOutput = () => options.holdCapacity === true || shouldWrapInvocationOutput(invocation)
   const lifecycle = await openAgentInvocationLifecycle<AgentInvocationFinishOutcome>(
     async (outcome) => {
@@ -3456,6 +3513,7 @@ async function executeAgentInvocationWithCapacityLease<
           let finishTask: Promise<void> | undefined
           let streamedText = ""
           let streamedUsageRecord: Extract<StreamEvent, { type: "usage" }>["usageRecord"] | undefined
+          const collectToolResult = agentToolResultStreamCollector(invocation.toolResults)
           let preserved: object
           let uiMessageStreamCreated = false
           const finishPreserved = async (outcome: CapabilityCleanupOutcome) => {
@@ -3516,6 +3574,7 @@ async function executeAgentInvocationWithCapacityLease<
                     abortSignal: invocation.input.abortSignal,
                     cancelOnAbort: source.cancel,
                     onChunk(chunk) {
+                      collectToolResult(chunk)
                       streamedText += uiMessageTextDelta(chunk) || ""
                       streamedUsageRecord = usageRecordFromStreamChunk(chunk, rendered) ?? streamedUsageRecord
                     },
@@ -3585,7 +3644,7 @@ async function executeAgentInvocationWithCapacityLease<
           const source = preservedSources.get(renderedStream) ?? cancellableAsyncIterableSource(renderedStream)
           preservedSources.set(renderedStream, source)
           const enrichedStream = withEagerStreamUsageExtensions(source.stream, invocation, rendered)
-          const streamed = withStreamedResult(enrichedStream, rendered, driverUsageRecord)
+          const streamed = withStreamedResult(enrichedStream, rendered, driverUsageRecord, invocation.toolResults)
           const value = withCapabilityCleanup(streamed.stream, async (outcome) => {
             invocation.input.abortSignal?.removeEventListener("abort", onAbort)
             finishing = true
@@ -3911,7 +3970,9 @@ async function executeAgentInvocationWithCapacityLease<
         : isAsyncIterable(capacityRendered)
           ? withEagerStreamUsageExtensions(capacityRendered, invocation, rendered)
           : capacityRendered
-      return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(enrichedRendered, invocation), shouldHoldInvocationOutput(), async (outcome, streamedText, streamedUsageRecord) => {
+      const shouldWrapOutput = shouldHoldInvocationOutput()
+      const collectToolResult = shouldWrapOutput ? agentToolResultStreamCollector(invocation.toolResults) : undefined
+      return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(enrichedRendered, invocation), shouldWrapOutput, async (outcome, streamedText, streamedUsageRecord) => {
         const cancellations = await Promise.allSettled([...uiMessageSources.values()].map(({ cancel }) => cancel(outcome.failed ? outcome.error : undefined)))
         const rejected = cancellations.find((result): result is PromiseRejectedResult => result.status === "rejected")
         if (rejected) outcome = { error: rejected.reason, failed: true }
@@ -3929,9 +3990,14 @@ async function executeAgentInvocationWithCapacityLease<
         else {
           await finishStreamAgentInvocation(invocation, lifecycle, finishResult, finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
         }
-      }, projection, invocation.input.abortSignal, options.holdCapacity === true
-        ? async reason => { await Promise.allSettled([...uiMessageSources.values()].map(({ cancel }) => cancel(reason))) }
-        : undefined)
+      }, {
+        abortSignal: invocation.input.abortSignal,
+        cancelOnAbort: options.holdCapacity === true
+          ? async reason => { await Promise.allSettled([...uiMessageSources.values()].map(({ cancel }) => cancel(reason))) }
+          : undefined,
+        ...(collectToolResult ? { onWrappedChunk: collectToolResult } : {}),
+        projection,
+      })
     }
 
     let isStreamResult = hasTraceableStreamResult(rendered)
@@ -3984,7 +4050,7 @@ async function executeAgentInvocationWithCapacityLease<
       : customRun ? rendered as AsyncIterable<StreamEvent> : streamAgentOutputToEvents(rendered)
     const shouldWrapOutput = shouldHoldInvocationOutput()
     const source = shouldWrapOutput ? cancellableAsyncIterableSource(stream) : undefined
-    const streamed = withStreamedResult(withEagerStreamUsageExtensions(source?.stream ?? stream, invocation, rendered), rendered, driverUsageRecord)
+    const streamed = withStreamedResult(withEagerStreamUsageExtensions(source?.stream ?? stream, invocation, rendered), rendered, driverUsageRecord, invocation.toolResults)
     const tracedStream = maybeTraceAgentStream(streamed.stream as AsyncIterable<StreamEvent>, invocation)
     const value = shouldWrapOutput
       ? withCapabilityCleanup(tracedStream, async (outcome) => {
@@ -4023,7 +4089,9 @@ async function executeAgentInvocationWithCapacityLease<
             toUIMessageStream: () => uiMessageStreamFromResponse(response),
           }, invocation.outputRenderers, invocation.outputExtensionProviders, outputExtensions, response)
           const enrichedResponseStream = withEagerUiMessageStreamUsageExtensions(renderedResponseStream, invocation)
-          const finalized = await finalizeUiMessageStreamOutput(enrichedResponseStream, shouldHoldInvocationOutput(), async (outcome, streamedText, streamedUsageRecord) => {
+          const shouldWrapOutput = shouldHoldInvocationOutput()
+          const collectToolResult = shouldWrapOutput ? agentToolResultStreamCollector(invocation.toolResults) : undefined
+          const finalized = await finalizeUiMessageStreamOutput(enrichedResponseStream, shouldWrapOutput, async (outcome, streamedText, streamedUsageRecord) => {
             if (!outcome.failed && !outcome.completed) {
               await lifecycle.finish({
                 result: resultWithStreamedTextAndUsage(response, streamedText || "", streamedUsageRecord),
@@ -4038,7 +4106,11 @@ async function executeAgentInvocationWithCapacityLease<
               const driverUsageRecord = await resolveFinishUsageRecord(invocation, response)
               await finishStreamAgentInvocation(invocation, lifecycle, resultWithStreamedTextAndUsage(response, streamedText || "", streamedUsageRecord, driverUsageRecord), finishOutcomeFromCleanup(outcome), streamFailureMessage, outputExtensions)
             }
-          }, projection, invocation.input.abortSignal)
+          }, {
+            abortSignal: invocation.input.abortSignal,
+            ...(collectToolResult ? { onWrappedChunk: collectToolResult } : {}),
+            projection,
+          })
           const headers = new Headers(response.headers)
           headers.delete("content-encoding")
           headers.delete("content-length")
@@ -4074,14 +4146,15 @@ async function executeAgentInvocation<
   options: AgentInvocationExecutionOptions,
 ): Promise<Response | AsyncIterable<StreamEvent> | unknown> {
   const definition = hasAgentDefinition(agent) ? agent as object : undefined
-  const preparedInvocation = definition && inspectAgentCapacity(definition)
-    ? await createAgentInvocationContext(
-        agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput>,
-        context,
-        input,
-        options.kind,
-      )
-    : undefined
+  let preparedInvocation: AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS> | undefined
+  if (definition && inspectAgentCapacity(definition)) {
+    preparedInvocation = await createAgentInvocationContextWithWorkflowFailureDelivery(
+      agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput>,
+      context,
+      input,
+      options.kind,
+    )
+  }
   if (preparedInvocation?.handledResponse) {
     return await executeAgentInvocationWithCapacityLease(agent, context, input, options, preparedInvocation)
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -22,7 +22,7 @@ import {
 import { createTraceEventLog, deriveTraceRuns, getViteHubErrorShape, resolveRuntimeContext, traceEventsToOpenTelemetrySpans } from "@vite-hub/runtime"
 import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
-import { defineChatCapability, getAgentChatContext, getChatCapabilityOptions, resolveChatErrorFallbackText } from "./chat-trigger.ts"
+import { defineChatCapability, getAgentChatContext, getChatCapabilityOptions, resolveDurableChatErrorFallbackText } from "./chat-trigger.ts"
 import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
 import {
   bindMessageChannelInstructions,
@@ -2164,8 +2164,9 @@ async function createAgentInvocationContext<
       }
     }
     const transformedTools = resolveCapabilityCli ? capabilities.tools : await applyCapabilityToolTransforms(capabilities.tools, capabilities.toolTransforms)
+    const preparedTools = withJsonCompatibleToolOutputs(applyAgentToolPolicies(transformedTools) || {})
     const tools = Object.keys(transformedTools || {}).length
-      ? withAgentToolStepReporting(withJsonCompatibleToolOutputs(applyAgentToolPolicies(transformedTools) || {}), toolStepReporter)
+      ? driverKind === "harness" ? preparedTools : withAgentToolStepReporting(preparedTools, toolStepReporter)
       : undefined
     const activeWorkspace = capabilities.workspace || workspace
     const sourceResolvedWorkspaceDefinition = invocationContext.get<WorkspaceDefinition>("workspace.sourceResolution.definition")
@@ -3272,7 +3273,7 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
   const intents: AgentChannelDeliveryEffectIntent[] = []
   const invocationContext = createAgentInvocationContextStore(input.context)
   const chat = getAgentChatContext(invocationContext)
-  const fallback = await resolveChatErrorFallbackText(options, {
+  const fallback = await resolveDurableChatErrorFallbackText(options, {
     error,
     history: input.messages || [],
     message: chat?.message || { text: "" },

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -22,7 +22,7 @@ import {
 import { createTraceEventLog, deriveTraceRuns, getViteHubErrorShape, resolveRuntimeContext, traceEventsToOpenTelemetrySpans } from "@vite-hub/runtime"
 import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
-import { defineChatCapability, durableChatErrorFallbackTimeout, getAgentChatContext, getChatCapabilityOptions, resolveDurableChatErrorFallbackIntents } from "./chat-trigger.ts"
+import { defineChatCapability, durableChatErrorFallbackTimeout, getAgentChatContext, getChatCapabilityOptions, isDurableChatErrorFallbackEffect, resolveDurableChatErrorFallbackIntents } from "./chat-trigger.ts"
 import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
 import {
   bindMessageChannelInstructions,
@@ -1072,43 +1072,6 @@ async function applyChannelDeliveryEffectIntents<
     if (titleDelivery && delivered) {
       context.context.set(messageChannelTitleDeliveredContextKey, true, { overwrite: true })
     }
-  }
-}
-
-async function applyDurableErrorFallbackIntent<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  CALL_OPTIONS,
->(
-  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
-  intent: AgentChannelDeliveryEffectIntent,
-  timeout: number,
-  finish?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>,
-): Promise<void> {
-  const controller = new AbortController()
-  const parentSignal = context.input.abortSignal
-  const abortSignal = parentSignal ? AbortSignal.any([parentSignal, controller.signal]) : controller.signal
-  const delivery = applyChannelDeliveryEffectIntents({
-    ...context,
-    input: { ...context.input, abortSignal },
-  }, [intent], finish)
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
-  let timedOut = false
-  try {
-    await Promise.race([
-      delivery,
-      new Promise<never>((_resolve, reject) => {
-        timeoutId = setTimeout(() => {
-          timedOut = true
-          const error = Object.assign(new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`), { isRetryable: false as const })
-          controller.abort(error)
-          reject(error)
-        }, timeout)
-      }),
-    ])
-  }
-  finally {
-    if (timeoutId) clearTimeout(timeoutId)
-    if (timedOut) void delivery.catch(() => undefined)
   }
 }
 
@@ -2905,6 +2868,49 @@ async function resolveFinishDeliveryEffectIntents<
   return intents
 }
 
+async function applyDurableFailureDeliveryEffects<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  providers: readonly AgentChannelDeliveryFinishEffect[],
+  event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>,
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+  timeout: number,
+): Promise<void> {
+  const fallbackProviders = providers.filter(isDurableChatErrorFallbackEffect)
+  const otherProviders = providers.filter(provider => !isDurableChatErrorFallbackEffect(provider))
+  const controller = new AbortController()
+  const parentSignal = context.input.abortSignal
+  const abortSignal = parentSignal ? AbortSignal.any([parentSignal, controller.signal]) : controller.signal
+  const deliveryContext = { ...context, input: { ...context.input, abortSignal } }
+  const operation = (async () => {
+    for (const group of [fallbackProviders, otherProviders]) {
+      const intents = await resolveFinishDeliveryEffectIntents(group, event, deliveryContext)
+      for (const intent of intents) await applyChannelDeliveryEffectIntents(deliveryContext, [intent], event)
+    }
+  })()
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => {
+          const error = Object.assign(
+            new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`),
+            { isRetryable: false as const },
+          )
+          controller.abort(error)
+          reject(error)
+        }, timeout)
+      }),
+    ])
+  }
+  finally {
+    if (timeoutId) clearTimeout(timeoutId)
+    void operation.catch(() => undefined)
+  }
+}
+
 function createFinishDeliveryEffectContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -3112,12 +3118,12 @@ async function finishAgentInvocation<
         const extensions = await createAgentInvocationExtensions(eventBase as never, finishExtensionProviders)
         const finishEvent = { ...eventBase, extensions }
         const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, finishEvent as never)
-        const finishIntents = await resolveFinishDeliveryEffectIntents(activeDeliveryProviders, finishEvent as never, context)
-        for (const intent of finishIntents) {
-          if (intent.intent === "chat.error-fallback" && context.durableErrorFallbackTimeout !== undefined) {
-            await applyDurableErrorFallbackIntent(context, intent, context.durableErrorFallbackTimeout, finishEvent as never)
-          }
-          else {
+        if (failed && context.durableErrorFallbackTimeout !== undefined && activeDeliveryProviders.some(isDurableChatErrorFallbackEffect)) {
+          await applyDurableFailureDeliveryEffects(activeDeliveryProviders, finishEvent as never, context, context.durableErrorFallbackTimeout)
+        }
+        else {
+          const finishIntents = await resolveFinishDeliveryEffectIntents(activeDeliveryProviders, finishEvent as never, context)
+          for (const intent of finishIntents) {
             await applyChannelDeliveryEffectIntents(context, [intent], finishEvent as never)
           }
         }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3056,7 +3056,10 @@ async function finishAgentInvocation<
         toolResults: [...context.toolResults],
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
       const provisionalActiveDeliveryProviders = await prepareProvisionalTitleDeliverySupport(context, eventBase)
-      const outcomeHook = failed ? context.errorHook : context.finishHook
+      const cleanupOnlyFailure = outcome.status === "success" && closeError !== undefined
+      const outcomeHook = failed
+        ? cleanupOnlyFailure ? undefined : context.errorHook
+        : context.finishHook
       const hookName = failed ? "agent:error" : "agent:finish"
       const hasOutcomeConsumer = Boolean(outcomeHook || provisionalActiveDeliveryProviders.length || hasDeferredFinishDeliveryEffectProvider(context.finishDeliveryEffectProviders))
       const finishExtensionProviders = hasOutcomeConsumer

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3283,7 +3283,7 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
     },
     toolResults: [],
   }, () => intents.length > 0)
-  if (fallback) intents.push(createReplyDeliveryEffectIntent(fallback, { intent: "chat.error-fallback" }))
+  if (!intents.length && fallback) intents.push(createReplyDeliveryEffectIntent(fallback, { intent: "chat.error-fallback" }))
   if (!intents.length) return
   const invoker = createFallbackAgentInvoker(context.run)
   await applyChannelDeliveryEffectIntents({

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3181,6 +3181,7 @@ async function finishAgentInvocation<
           }
         }
         const runOutcomeHook = async (hookContext: typeof context) => {
+          const hookFinishEvent = { ...finishEvent, input: hookContext.input }
           let outcomeHookResult: void | AgentChannelDeliveryFinishEffectResult
           await runObservedAgentHook(context.hooks, {
             ids: { runId: context.run?.runId },
@@ -3189,13 +3190,13 @@ async function finishAgentInvocation<
             phase: failed ? "error" : "finish",
           }, async () => {
             outcomeHookResult = failed
-              ? await outcomeHook?.(createAgentErrorHookEvent(finishEvent, hookContext) as never)
-              : await outcomeHook?.(createAgentFinishHookEvent(finishEvent, hookContext) as never)
+              ? await outcomeHook?.(createAgentErrorHookEvent(hookFinishEvent, hookContext) as never)
+              : await outcomeHook?.(createAgentFinishHookEvent(hookFinishEvent, hookContext) as never)
           })
-          if (outcomeHookResult) {
+          if (outcomeHookResult && !hookContext.input.abortSignal?.aborted) {
             const outcomeHookIntents: AgentChannelDeliveryEffectIntent[] = []
             appendDeliveryEffectIntent(outcomeHookIntents, outcomeHookResult)
-            await applyChannelDeliveryEffectIntents(hookContext, outcomeHookIntents, finishEvent)
+            await applyChannelDeliveryEffectIntents(hookContext, outcomeHookIntents, hookFinishEvent)
           }
         }
         if (durableFailureDeadline) {
@@ -3447,18 +3448,19 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
   const chat = getAgentChatContext(invocationContext)
   const channel = invocationContext.get<AgentChannelContext>("channel")
   if (!chat && !channel) return
-  const intents = await resolveDurableChatErrorFallbackIntents(options, {
-    error,
-    history: input.messages || [],
-    message: chat?.message || channel?.message || { text: "" },
-    publicError: toAgentPublicError(error, "http"),
-    run: context.run,
-    toolResults: [],
-  })
-  if (!intents.length) return
   const invoker = createFallbackAgentInvoker(context.run)
   const timeout = durableChatErrorFallbackTimeout(options)
-  await runWithinDurableFailureDeadline(createDurableFailureDeadline(timeout), async (abortSignal) => {
+  const deadline = createDurableFailureDeadline(timeout)
+  await runWithinDurableFailureDeadline(deadline, async (abortSignal) => {
+    const intents = await resolveDurableChatErrorFallbackIntents(options, {
+      error,
+      history: input.messages || [],
+      message: chat?.message || channel?.message || { text: "" },
+      publicError: toAgentPublicError(error, "http"),
+      run: context.run,
+      toolResults: [],
+    }, async resolution => await resolution)
+    if (!intents.length) return
     await applyChannelDeliveryEffectIntents({
       actor: invoker,
       channels: definition?.channels,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3424,15 +3424,25 @@ type AgentInvocationExecutionOptions =
     onFinish?: (outcome: AgentInvocationFinishOutcome) => void
   }
 
-function deferPreparedInvocationFailure<
+async function finishPreparedInvocationFailure<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(
   preparedInvocation: AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>,
   error: unknown,
-): void {
+  waitForFinish: boolean,
+): Promise<void> {
   const finishTask = finishAgentInvocation(preparedInvocation, { error, status: "error" })
-  registerAgentBackgroundTask(preparedInvocation.runtimeContext, finishTask)
+  if (!waitForFinish) {
+    registerAgentBackgroundTask(preparedInvocation.runtimeContext, finishTask)
+    return
+  }
+  try {
+    await finishTask
+  }
+  catch (finishError) {
+    throw new AggregateError([error, finishError], "[vitehub] Agent capacity acquisition and finish lifecycle both failed.")
+  }
 }
 
 async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
@@ -3460,7 +3470,7 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
       run: context.run,
       toolResults: [],
     }, async resolution => await resolution)
-    if (!intents.length) return
+    if (abortSignal.aborted || !intents.length) return
     await applyChannelDeliveryEffectIntents({
       actor: invoker,
       channels: definition?.channels,
@@ -4296,7 +4306,8 @@ async function executeAgentInvocation<
   }
   catch (error) {
     if (preparedInvocation) {
-      deferPreparedInvocationFailure(preparedInvocation, error)
+      const workflowExecution = Boolean((context as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey])
+      await finishPreparedInvocationFailure(preparedInvocation, error, workflowExecution)
     }
     throw error
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2911,6 +2911,33 @@ async function applyDurableFailureDeliveryEffects<
   }
 }
 
+async function resolveDurableFailureFinishExtensions<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  event: Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">,
+  providers: ResolvedAgentFinishExtensionProvider[],
+  timeout: number,
+): Promise<AgentFinishExtensions> {
+  const operation = createAgentInvocationExtensions(event as never, providers)
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => reject(Object.assign(
+          new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`),
+          { isRetryable: false as const },
+        )), timeout)
+      }),
+    ])
+  }
+  finally {
+    if (timeoutId) clearTimeout(timeoutId)
+    void operation.catch(() => undefined)
+  }
+}
+
 function createFinishDeliveryEffectContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -3120,11 +3147,20 @@ async function finishAgentInvocation<
         ? context.finishExtensionProviders
         : context.finishExtensionProviders.filter(provider => provider.eager)
       if (hasOutcomeConsumer || finishExtensionProviders.length) {
-        const extensions = await createAgentInvocationExtensions(eventBase as never, finishExtensionProviders)
+        if (hasDurableFailureDelivery) {
+          const fallbackEvent = provisionalFinishEvent(context, eventBase)
+          const fallbackProviders = activeFinishDeliveryEffectProviders(context, fallbackEvent)
+            .filter(isDurableChatErrorFallbackEffect)
+          await applyDurableFailureDeliveryEffects(fallbackProviders, fallbackEvent, context, context.durableErrorFallbackTimeout!)
+        }
+        const extensions = hasDurableFailureDelivery
+          ? await resolveDurableFailureFinishExtensions(eventBase, finishExtensionProviders, context.durableErrorFallbackTimeout!)
+          : await createAgentInvocationExtensions(eventBase as never, finishExtensionProviders)
         const finishEvent = { ...eventBase, extensions }
         const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, finishEvent as never)
-        if (failed && context.durableErrorFallbackTimeout !== undefined && activeDeliveryProviders.some(isDurableChatErrorFallbackEffect)) {
-          await applyDurableFailureDeliveryEffects(activeDeliveryProviders, finishEvent as never, context, context.durableErrorFallbackTimeout)
+          .filter(provider => !hasDurableFailureDelivery || !isDurableChatErrorFallbackEffect(provider))
+        if (hasDurableFailureDelivery) {
+          await applyDurableFailureDeliveryEffects(activeDeliveryProviders, finishEvent as never, context, context.durableErrorFallbackTimeout!)
         }
         else {
           const finishIntents = await resolveFinishDeliveryEffectIntents(activeDeliveryProviders, finishEvent as never, context)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2868,6 +2868,49 @@ async function resolveFinishDeliveryEffectIntents<
   return intents
 }
 
+interface DurableFailureDeadline {
+  expiresAt: number
+  timeout: number
+}
+
+function createDurableFailureDeadline(timeout: number): DurableFailureDeadline {
+  return { expiresAt: Date.now() + timeout, timeout }
+}
+
+function durableFailureTimeoutError(timeout: number): Error & { isRetryable: false } {
+  return Object.assign(
+    new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`),
+    { isRetryable: false as const },
+  )
+}
+
+async function runWithinDurableFailureDeadline<T>(
+  deadline: DurableFailureDeadline,
+  operation: (abortSignal: AbortSignal) => Promise<T>,
+  parentSignal?: AbortSignal,
+): Promise<T> {
+  const controller = new AbortController()
+  const abortSignal = parentSignal ? AbortSignal.any([parentSignal, controller.signal]) : controller.signal
+  const task = operation(abortSignal)
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      task,
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => {
+          const error = durableFailureTimeoutError(deadline.timeout)
+          controller.abort(error)
+          reject(error)
+        }, Math.max(0, deadline.expiresAt - Date.now()))
+      }),
+    ])
+  }
+  finally {
+    if (timeoutId) clearTimeout(timeoutId)
+    void task.catch(() => undefined)
+  }
+}
+
 async function applyDurableFailureDeliveryEffects<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -2875,40 +2918,17 @@ async function applyDurableFailureDeliveryEffects<
   providers: readonly AgentChannelDeliveryFinishEffect[],
   event: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>,
   context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
-  timeout: number,
+  deadline: DurableFailureDeadline,
 ): Promise<void> {
   const fallbackProviders = providers.filter(isDurableChatErrorFallbackEffect)
   const otherProviders = providers.filter(provider => !isDurableChatErrorFallbackEffect(provider))
-  const controller = new AbortController()
-  const parentSignal = context.input.abortSignal
-  const abortSignal = parentSignal ? AbortSignal.any([parentSignal, controller.signal]) : controller.signal
-  const deliveryContext = { ...context, input: { ...context.input, abortSignal } }
-  const operation = (async () => {
+  await runWithinDurableFailureDeadline(deadline, async (abortSignal) => {
+    const deliveryContext = { ...context, input: { ...context.input, abortSignal } }
     for (const group of [fallbackProviders, otherProviders]) {
       const intents = await resolveFinishDeliveryEffectIntents(group, event, deliveryContext)
       for (const intent of intents) await applyChannelDeliveryEffectIntents(deliveryContext, [intent], event)
     }
-  })()
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
-  try {
-    await Promise.race([
-      operation,
-      new Promise<never>((_resolve, reject) => {
-        timeoutId = setTimeout(() => {
-          const error = Object.assign(
-            new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`),
-            { isRetryable: false as const },
-          )
-          controller.abort(error)
-          reject(error)
-        }, timeout)
-      }),
-    ])
-  }
-  finally {
-    if (timeoutId) clearTimeout(timeoutId)
-    void operation.catch(() => undefined)
-  }
+  }, context.input.abortSignal)
 }
 
 async function resolveDurableFailureFinishExtensions<
@@ -2917,25 +2937,12 @@ async function resolveDurableFailureFinishExtensions<
 >(
   event: Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">,
   providers: ResolvedAgentFinishExtensionProvider[],
-  timeout: number,
+  deadline: DurableFailureDeadline,
 ): Promise<AgentFinishExtensions> {
-  const operation = createAgentInvocationExtensions(event as never, providers)
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
-  try {
-    return await Promise.race([
-      operation,
-      new Promise<never>((_resolve, reject) => {
-        timeoutId = setTimeout(() => reject(Object.assign(
-          new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`),
-          { isRetryable: false as const },
-        )), timeout)
-      }),
-    ])
-  }
-  finally {
-    if (timeoutId) clearTimeout(timeoutId)
-    void operation.catch(() => undefined)
-  }
+  return await runWithinDurableFailureDeadline(
+    deadline,
+    async () => await createAgentInvocationExtensions(event as never, providers),
+  )
 }
 
 function createFinishDeliveryEffectContext<
@@ -3136,6 +3143,9 @@ async function finishAgentInvocation<
       const hasDurableFailureDelivery = failed
         && context.durableErrorFallbackTimeout !== undefined
         && provisionallyActiveDeliveryProviders.some(isDurableChatErrorFallbackEffect)
+      const durableFailureDeadline = hasDurableFailureDelivery
+        ? createDurableFailureDeadline(context.durableErrorFallbackTimeout!)
+        : undefined
       const provisionalActiveDeliveryProviders = hasDurableFailureDelivery
         ? provisionallyActiveDeliveryProviders
         : await prepareProvisionalTitleDeliverySupport(context, eventBase)
@@ -3153,16 +3163,16 @@ async function finishAgentInvocation<
           const fallbackEvent = provisionalFinishEvent(context, eventBase)
           const fallbackProviders = activeFinishDeliveryEffectProviders(context, fallbackEvent)
             .filter(isDurableChatErrorFallbackEffect)
-          await applyDurableFailureDeliveryEffects(fallbackProviders, fallbackEvent, context, context.durableErrorFallbackTimeout!)
+          await applyDurableFailureDeliveryEffects(fallbackProviders, fallbackEvent, context, durableFailureDeadline!)
         }
         const extensions = hasDurableFailureDelivery
-          ? await resolveDurableFailureFinishExtensions(eventBase, finishExtensionProviders, context.durableErrorFallbackTimeout!)
+          ? await resolveDurableFailureFinishExtensions(eventBase, finishExtensionProviders, durableFailureDeadline!)
           : await createAgentInvocationExtensions(eventBase as never, finishExtensionProviders)
         const finishEvent = { ...eventBase, extensions }
         const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, finishEvent as never)
           .filter(provider => !hasDurableFailureDelivery || !isDurableChatErrorFallbackEffect(provider))
         if (hasDurableFailureDelivery) {
-          await applyDurableFailureDeliveryEffects(activeDeliveryProviders, finishEvent as never, context, context.durableErrorFallbackTimeout!)
+          await applyDurableFailureDeliveryEffects(activeDeliveryProviders, finishEvent as never, context, durableFailureDeadline!)
         }
         else {
           const finishIntents = await resolveFinishDeliveryEffectIntents(activeDeliveryProviders, finishEvent as never, context)
@@ -3170,21 +3180,31 @@ async function finishAgentInvocation<
             await applyChannelDeliveryEffectIntents(context, [intent], finishEvent as never)
           }
         }
-        let outcomeHookResult: void | AgentChannelDeliveryFinishEffectResult
-        await runObservedAgentHook(context.hooks, {
-          ids: { runId: context.run?.runId },
-          name: hookName,
-          owner: "agent",
-          phase: failed ? "error" : "finish",
-        }, async () => {
-          outcomeHookResult = failed
-            ? await outcomeHook?.(createAgentErrorHookEvent(finishEvent, context) as never)
-            : await outcomeHook?.(createAgentFinishHookEvent(finishEvent, context) as never)
-        })
-        if (outcomeHookResult) {
-          const outcomeHookIntents: AgentChannelDeliveryEffectIntent[] = []
-          appendDeliveryEffectIntent(outcomeHookIntents, outcomeHookResult)
-          await applyChannelDeliveryEffectIntents(context, outcomeHookIntents, finishEvent)
+        const runOutcomeHook = async (hookContext: typeof context) => {
+          let outcomeHookResult: void | AgentChannelDeliveryFinishEffectResult
+          await runObservedAgentHook(context.hooks, {
+            ids: { runId: context.run?.runId },
+            name: hookName,
+            owner: "agent",
+            phase: failed ? "error" : "finish",
+          }, async () => {
+            outcomeHookResult = failed
+              ? await outcomeHook?.(createAgentErrorHookEvent(finishEvent, hookContext) as never)
+              : await outcomeHook?.(createAgentFinishHookEvent(finishEvent, hookContext) as never)
+          })
+          if (outcomeHookResult) {
+            const outcomeHookIntents: AgentChannelDeliveryEffectIntent[] = []
+            appendDeliveryEffectIntent(outcomeHookIntents, outcomeHookResult)
+            await applyChannelDeliveryEffectIntents(hookContext, outcomeHookIntents, finishEvent)
+          }
+        }
+        if (durableFailureDeadline) {
+          await runWithinDurableFailureDeadline(durableFailureDeadline, async (abortSignal) => {
+            await runOutcomeHook({ ...context, input: { ...context.input, abortSignal } })
+          }, context.input.abortSignal)
+        }
+        else {
+          await runOutcomeHook(context)
         }
       }
     }
@@ -3437,35 +3457,19 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
   })
   if (!intents.length) return
   const invoker = createFallbackAgentInvoker(context.run)
-  const controller = new AbortController()
-  const abortSignal = input.abortSignal ? AbortSignal.any([input.abortSignal, controller.signal]) : controller.signal
-  const delivery = applyChannelDeliveryEffectIntents({
-    actor: invoker,
-    channels: definition?.channels,
-    context: invocationContext,
-    hooks: definition?.hooks as AgentHookObserverHooks | undefined,
-    input: { ...input, abortSignal },
-    invoker,
-    run: context.run,
-    runtimeContext: createResolvedRuntimeContext(context),
-  } as never, intents)
   const timeout = durableChatErrorFallbackTimeout(options)
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
-  try {
-    await Promise.race([
-      delivery,
-      new Promise<never>((_resolve, reject) => {
-        timeoutId = setTimeout(() => {
-          const timeoutError = Object.assign(new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`), { isRetryable: false as const })
-          controller.abort(timeoutError)
-          reject(timeoutError)
-        }, timeout)
-      }),
-    ])
-  }
-  finally {
-    if (timeoutId) clearTimeout(timeoutId)
-  }
+  await runWithinDurableFailureDeadline(createDurableFailureDeadline(timeout), async (abortSignal) => {
+    await applyChannelDeliveryEffectIntents({
+      actor: invoker,
+      channels: definition?.channels,
+      context: invocationContext,
+      hooks: definition?.hooks as AgentHookObserverHooks | undefined,
+      input: { ...input, abortSignal },
+      invoker,
+      run: context.run,
+      runtimeContext: createResolvedRuntimeContext(context),
+    } as never, intents)
+  }, input.abortSignal)
 }
 
 async function createAgentInvocationContextWithWorkflowFailureDelivery<

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -162,6 +162,7 @@ import type {
   AgentSettings,
   AgentStaticCapabilitiesList,
   AgentTelemetry,
+  AgentToolStepItem,
   AgentUsageRecord,
   AgentWorkflowRuntimeBinding,
   MaybePromise,
@@ -732,7 +733,7 @@ async function getAgentWorkflowHandle<
     : createWorkflow<AgentWorkflowInvocationPayload<CALL_OPTIONS>, AgentWorkflowOutput<TOutput>>(name, async (workflowContext) => {
         const { runAgentWorkflowDefinition } = await import("./runtime/workflow.ts")
         return await runAgentWorkflowDefinition(agent as never, workflowContext as never, runAgentInline as never) as AgentWorkflowOutput<TOutput>
-      })
+      }, { rootStep: false })
   agentWorkflowNames.add(name)
   handles.set(cacheKey, handle as WorkflowHandle<AgentWorkflowInvocationPayload, unknown>)
   agentWorkflowHandles.set(agent as object, handles)
@@ -1773,6 +1774,7 @@ type AgentInvocationContext<
   close: () => Promise<void>
   deliveryEffectIntents: AgentChannelDeliveryEffectIntent[]
   toolStepReporter?: AgentRuntimeContext<TRuntimeConfig>["toolStepReporter"]
+  toolResults: AgentToolStepItem[]
   driverContributions: AgentDriverContribution[]
   finalOutputRenderers: AgentCapabilityRegistries["finalOutputRenderers"]
   finishDeliveryEffectProviders: AgentChannelDeliveryFinishEffect[]
@@ -1997,6 +1999,11 @@ async function createAgentInvocationContext<
   const resolvedContext = createResolvedRuntimeContext(context)
   const invocationContext = createAgentInvocationContextStore(input.context)
   const telemetryInvocationId = createTraceId()
+  const toolResults: AgentToolStepItem[] = []
+  const toolStepReporter: NonNullable<AgentRuntimeContext<TRuntimeConfig>["toolStepReporter"]> = async (step) => {
+    if (step.toolResults?.length) toolResults.push(...step.toolResults)
+    await context.toolStepReporter?.(step)
+  }
   invocationContext.set(agentInvocationTraceIdContextKey, telemetryInvocationId, { overwrite: true })
   const tracedRuntimeContextBase = resolvedContext.trace && resolvedContext.traceLog
     ? resolvedContext
@@ -2157,7 +2164,7 @@ async function createAgentInvocationContext<
     }
     const transformedTools = resolveCapabilityCli ? capabilities.tools : await applyCapabilityToolTransforms(capabilities.tools, capabilities.toolTransforms)
     const tools = Object.keys(transformedTools || {}).length
-      ? withAgentToolStepReporting(withJsonCompatibleToolOutputs(applyAgentToolPolicies(transformedTools) || {}), context.toolStepReporter)
+      ? withAgentToolStepReporting(withJsonCompatibleToolOutputs(applyAgentToolPolicies(transformedTools) || {}), toolStepReporter)
       : undefined
     const activeWorkspace = capabilities.workspace || workspace
     const sourceResolvedWorkspaceDefinition = invocationContext.get<WorkspaceDefinition>("workspace.sourceResolution.definition")
@@ -2181,7 +2188,8 @@ async function createAgentInvocationContext<
       close: capabilities.close,
       context: invocationContext,
       deliveryEffectIntents: capabilities.registries.deliveryEffectIntents,
-      toolStepReporter: context.toolStepReporter,
+      toolStepReporter,
+      toolResults,
       driverContributions: capabilities.driverContributions,
       finalOutputRenderers: capabilities.registries.finalOutputRenderers,
       finishDeliveryEffectProviders: capabilities.registries.finishDeliveryEffectProviders,
@@ -2279,6 +2287,7 @@ type InvocationRunContext<
   telemetry?: AgentTelemetry<TRuntimeConfig>
   telemetryAgent: { name?: string, version?: string }
   telemetryInvocationId: string
+  toolResults: AgentToolStepItem[]
   workspace?: ReadonlyWorkspaceFacade | WritableWorkspaceFacade
   workspaceAutoCommit?: boolean | string
   workspaceDefinition?: WorkspaceDefinition
@@ -2337,6 +2346,7 @@ function withEagerStreamUsageExtensions<
         },
         result,
         runtime: context.runtimeContext,
+        toolResults: [...context.toolResults],
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
       await createAgentInvocationExtensions(eventBase as never, providers)
       if (chunk && typeof chunk === "object") {
@@ -2995,6 +3005,7 @@ async function finishAgentInvocation<
         ...(result !== undefined ? { result } : {}),
         runtime: context.runtimeContext,
         ...(text !== undefined ? { text } : {}),
+        toolResults: [...context.toolResults],
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
       const provisionalActiveDeliveryProviders = await prepareProvisionalTitleDeliverySupport(context, eventBase)
       const outcomeHook = failed ? context.errorHook : context.finishHook

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3104,7 +3104,12 @@ async function finishAgentInvocation<
         ...(text !== undefined ? { text } : {}),
         toolResults: [...context.toolResults],
       } satisfies Omit<AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>, "extensions">
-      const provisionalActiveDeliveryProviders = await prepareProvisionalTitleDeliverySupport(context, eventBase)
+      const hasDurableFailureDelivery = failed
+        && context.durableErrorFallbackTimeout !== undefined
+        && context.finishDeliveryEffectProviders.some(isDurableChatErrorFallbackEffect)
+      const provisionalActiveDeliveryProviders = hasDurableFailureDelivery
+        ? activeFinishDeliveryEffectProviders(context, provisionalFinishEvent(context, eventBase))
+        : await prepareProvisionalTitleDeliverySupport(context, eventBase)
       const cleanupOnlyFailure = outcome.status === "success" && closeError !== undefined
       const outcomeHook = failed
         ? cleanupOnlyFailure ? undefined : context.errorHook

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1099,7 +1099,7 @@ async function applyDurableErrorFallbackIntent<
       new Promise<never>((_resolve, reject) => {
         timeoutId = setTimeout(() => {
           timedOut = true
-          const error = new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`)
+          const error = Object.assign(new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`), { isRetryable: false as const })
           controller.abort(error)
           reject(error)
         }, timeout)
@@ -3407,7 +3407,7 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
       delivery,
       new Promise<never>((_resolve, reject) => {
         timeoutId = setTimeout(() => {
-          const timeoutError = new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`)
+          const timeoutError = Object.assign(new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`), { isRetryable: false as const })
           controller.abort(timeoutError)
           reject(timeoutError)
         }, timeout)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -22,7 +22,7 @@ import {
 import { createTraceEventLog, deriveTraceRuns, getViteHubErrorShape, resolveRuntimeContext, traceEventsToOpenTelemetrySpans } from "@vite-hub/runtime"
 import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
-import { defineChatCapability, getAgentChatContext, getChatCapabilityOptions, resolveDurableChatErrorFallbackIntents } from "./chat-trigger.ts"
+import { defineChatCapability, durableChatErrorFallbackTimeout, getAgentChatContext, getChatCapabilityOptions, resolveDurableChatErrorFallbackIntents } from "./chat-trigger.ts"
 import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
 import {
   bindMessageChannelInstructions,
@@ -3338,7 +3338,7 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
   })
   if (!intents.length) return
   const invoker = createFallbackAgentInvoker(context.run)
-  await applyChannelDeliveryEffectIntents({
+  const delivery = applyChannelDeliveryEffectIntents({
     actor: invoker,
     channels: definition?.channels,
     context: invocationContext,
@@ -3348,6 +3348,19 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
     run: context.run,
     runtimeContext: createResolvedRuntimeContext(context),
   } as never, intents)
+  const timeout = durableChatErrorFallbackTimeout(options)
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      delivery,
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => reject(new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`)), timeout)
+      }),
+    ])
+  }
+  finally {
+    if (timeoutId) clearTimeout(timeoutId)
+  }
 }
 
 async function createAgentInvocationContextWithWorkflowFailureDelivery<

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1075,6 +1075,43 @@ async function applyChannelDeliveryEffectIntents<
   }
 }
 
+async function applyDurableErrorFallbackIntent<
+  TRuntimeConfig extends AgentRuntimeConfig,
+  CALL_OPTIONS,
+>(
+  context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>,
+  intent: AgentChannelDeliveryEffectIntent,
+  timeout: number,
+  finish?: AgentFinishEvent<TRuntimeConfig, CALL_OPTIONS>,
+): Promise<void> {
+  const controller = new AbortController()
+  const parentSignal = context.input.abortSignal
+  const abortSignal = parentSignal ? AbortSignal.any([parentSignal, controller.signal]) : controller.signal
+  const delivery = applyChannelDeliveryEffectIntents({
+    ...context,
+    input: { ...context.input, abortSignal },
+  }, [intent], finish)
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  let timedOut = false
+  try {
+    await Promise.race([
+      delivery,
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => {
+          timedOut = true
+          const error = new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`)
+          controller.abort(error)
+          reject(error)
+        }, timeout)
+      }),
+    ])
+  }
+  finally {
+    if (timeoutId) clearTimeout(timeoutId)
+    if (timedOut) void delivery.catch(() => undefined)
+  }
+}
+
 export { applyAgentToolPolicies, withAgentToolStepReporting } from "./tool-runtime.ts"
 export { defineCapability } from "./capability-runtime.ts"
 export { defineFinishEffect } from "./delivery-effects.ts"
@@ -2193,6 +2230,10 @@ async function createAgentInvocationContext<
       close: capabilities.close,
       context: invocationContext,
       deliveryEffectIntents: capabilities.registries.deliveryEffectIntents,
+      durableErrorFallbackTimeout: (() => {
+        const options = getChatCapabilityOptions<TRuntimeConfig>(definition?.capabilities || [])
+        return options ? durableChatErrorFallbackTimeout(options) : undefined
+      })(),
       toolStepReporter,
       toolResults,
       driverContributions: capabilities.driverContributions,
@@ -2295,6 +2336,7 @@ type InvocationRunContext<
   close: () => Promise<void>
   context: AgentInvocationContextStore
   deliveryEffectIntents?: readonly AgentChannelDeliveryEffectIntent[]
+  durableErrorFallbackTimeout?: number
   finishDeliveryEffectProviders: AgentChannelDeliveryFinishEffect[]
   finishExtensionProviders: ResolvedAgentFinishExtensionProvider[]
   finalOutputRenderers: AgentCapabilityRegistries["finalOutputRenderers"]
@@ -3070,7 +3112,15 @@ async function finishAgentInvocation<
         const extensions = await createAgentInvocationExtensions(eventBase as never, finishExtensionProviders)
         const finishEvent = { ...eventBase, extensions }
         const activeDeliveryProviders = activeFinishDeliveryEffectProviders(context, finishEvent as never)
-        await applyChannelDeliveryEffectIntents(context, await resolveFinishDeliveryEffectIntents(activeDeliveryProviders, finishEvent as never, context), finishEvent as never)
+        const finishIntents = await resolveFinishDeliveryEffectIntents(activeDeliveryProviders, finishEvent as never, context)
+        for (const intent of finishIntents) {
+          if (intent.intent === "chat.error-fallback" && context.durableErrorFallbackTimeout !== undefined) {
+            await applyDurableErrorFallbackIntent(context, intent, context.durableErrorFallbackTimeout, finishEvent as never)
+          }
+          else {
+            await applyChannelDeliveryEffectIntents(context, [intent], finishEvent as never)
+          }
+        }
         let outcomeHookResult: void | AgentChannelDeliveryFinishEffectResult
         await runObservedAgentHook(context.hooks, {
           ids: { runId: context.run?.runId },
@@ -3079,8 +3129,8 @@ async function finishAgentInvocation<
           phase: failed ? "error" : "finish",
         }, async () => {
           outcomeHookResult = failed
-            ? await context.errorHook?.(createAgentErrorHookEvent(finishEvent, context))
-            : await context.finishHook?.(createAgentFinishHookEvent(finishEvent, context))
+            ? await outcomeHook?.(createAgentErrorHookEvent(finishEvent, context) as never)
+            : await outcomeHook?.(createAgentFinishHookEvent(finishEvent, context) as never)
         })
         if (outcomeHookResult) {
           const outcomeHookIntents: AgentChannelDeliveryEffectIntent[] = []
@@ -3338,12 +3388,14 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
   })
   if (!intents.length) return
   const invoker = createFallbackAgentInvoker(context.run)
+  const controller = new AbortController()
+  const abortSignal = input.abortSignal ? AbortSignal.any([input.abortSignal, controller.signal]) : controller.signal
   const delivery = applyChannelDeliveryEffectIntents({
     actor: invoker,
     channels: definition?.channels,
     context: invocationContext,
     hooks: definition?.hooks as AgentHookObserverHooks | undefined,
-    input,
+    input: { ...input, abortSignal },
     invoker,
     run: context.run,
     runtimeContext: createResolvedRuntimeContext(context),
@@ -3354,7 +3406,11 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
     await Promise.race([
       delivery,
       new Promise<never>((_resolve, reject) => {
-        timeoutId = setTimeout(() => reject(new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`)), timeout)
+        timeoutId = setTimeout(() => {
+          const timeoutError = new Error(`Durable chat error fallback delivery timed out after ${timeout}ms.`)
+          controller.abort(timeoutError)
+          reject(timeoutError)
+        }, timeout)
       }),
     ])
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -22,7 +22,8 @@ import {
 import { createTraceEventLog, deriveTraceRuns, getViteHubErrorShape, resolveRuntimeContext, traceEventsToOpenTelemetrySpans } from "@vite-hub/runtime"
 import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
-import { defineChatCapability, getChatCapabilityOptions } from "./chat-trigger.ts"
+import { defineChatCapability, getAgentChatContext, getChatCapabilityOptions, resolveChatErrorFallbackText } from "./chat-trigger.ts"
+import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
 import {
   bindMessageChannelInstructions,
   finishMessageChannelTitleDelivery,
@@ -3259,6 +3260,44 @@ function deferPreparedInvocationFailure<
   registerAgentBackgroundTask(preparedInvocation.runtimeContext, finishTask)
 }
 
+async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
+  context: AgentRuntimeContext<TRuntimeConfig>,
+  input: AgentRunInput<CALL_OPTIONS>,
+  error: unknown,
+): Promise<void> {
+  if (!(context as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey]) return
+  const options = getChatCapabilityOptions<TRuntimeConfig>(definition?.capabilities || [])
+  if (!options) return
+  const intents: AgentChannelDeliveryEffectIntent[] = []
+  const invocationContext = createAgentInvocationContextStore(input.context)
+  const chat = getAgentChatContext(invocationContext)
+  const fallback = await resolveChatErrorFallbackText(options, {
+    error,
+    history: input.messages || [],
+    message: chat?.message || { text: "" },
+    publicError: toAgentPublicError(error, "http"),
+    run: context.run,
+    thread: {
+      post: async message => intents.push(createReplyDeliveryEffectIntent(message as never, { intent: "chat.error-fallback" })),
+    },
+    toolResults: [],
+  }, () => intents.length > 0)
+  if (fallback) intents.push(createReplyDeliveryEffectIntent(fallback, { intent: "chat.error-fallback" }))
+  if (!intents.length) return
+  const invoker = createFallbackAgentInvoker(context.run)
+  await applyChannelDeliveryEffectIntents({
+    actor: invoker,
+    channels: definition?.channels,
+    context: invocationContext,
+    hooks: definition?.hooks as AgentHookObserverHooks | undefined,
+    input,
+    invoker,
+    run: context.run,
+    runtimeContext: createResolvedRuntimeContext(context),
+  } as never, intents)
+}
+
 async function executeAgentInvocationWithCapacityLease<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
@@ -3274,7 +3313,19 @@ async function executeAgentInvocationWithCapacityLease<
   const definition = hasAgentDefinition(agent)
     ? agent as unknown as AgentDefinition<TRuntimeConfig, CALL_OPTIONS, any, any, TOutput>
     : undefined
-  const invocation = preparedInvocation ?? await createAgentInvocationContext(definition, context, input, options.kind)
+  let invocation: AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>
+  try {
+    invocation = preparedInvocation ?? await createAgentInvocationContext(definition, context, input, options.kind)
+  }
+  catch (error) {
+    try {
+      await deliverUnpreparedWorkflowFailure(definition, context, input, error)
+    }
+    catch (deliveryError) {
+      throw new AggregateError([error, deliveryError], "[vitehub] Agent setup failed and Workflow fallback delivery also failed.")
+    }
+    throw error
+  }
   const shouldHoldInvocationOutput = () => options.holdCapacity === true || shouldWrapInvocationOutput(invocation)
   const lifecycle = await openAgentInvocationLifecycle<AgentInvocationFinishOutcome>(
     async (outcome) => {

--- a/packages/agent/src/internal/workflow-execution.ts
+++ b/packages/agent/src/internal/workflow-execution.ts
@@ -1,0 +1,1 @@
+export const agentWorkflowExecutionContextKey: unique symbol = Symbol.for("vitehub.agent.workflow-execution") as never

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -103,6 +103,8 @@ function unsupportedWorkflowResult(): never {
 
 function nonRetryableAgentWorkflowError(error: unknown): unknown {
   if (readAgentErrorProperty(error, "isRetryable") === false) return error
+  const nestedNonRetryable = error instanceof AggregateError
+    && error.errors.some(candidate => readAgentErrorProperty(nonRetryableAgentWorkflowError(candidate), "isRetryable") === false)
   const code = getViteHubErrorShape(error)?.code
   const publicError = toAgentPublicError(error, "invocation")
   const terminalProvider = publicError.code === "PROVIDER_AUTHENTICATION_FAILED"
@@ -121,7 +123,7 @@ function nonRetryableAgentWorkflowError(error: unknown): unknown {
   const exhaustedOutput = code === "AGENT_OUTPUT_INVALID_JSON"
     || code === "AGENT_OUTPUT_SCHEMA_INVALID"
     || name === "AI_NoObjectGeneratedError"
-  if (!terminalProvider && !permanentProviderRequest && !exhaustedOutput) return error
+  if (!nestedNonRetryable && !terminalProvider && !permanentProviderRequest && !exhaustedOutput) return error
 
   const value = error instanceof Error ? error : new Error(String(error), { cause: error })
   try {

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -1,4 +1,5 @@
 import { getActiveCloudflareEnv, getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
+import { getViteHubErrorShape } from "@vite-hub/runtime"
 
 import { createAgentRuntimeContext } from "./context.ts"
 import { workspaceAgentWithSourceRoot } from "../workspace-agent.ts"
@@ -8,6 +9,7 @@ import { loadAgentWorkflowRuntimeStateModule } from "../internal/workflow-runtim
 import { cloneWorkflowJsonValue, workflowBytesToBase64 } from "../internal/workflow-portability.ts"
 import { restoreResolvedAgentInvokerInput } from "../invoker.ts"
 import { toAgentRunResult } from "../agent-output.ts"
+import { readAgentErrorProperty, toAgentPublicError } from "../agent-error.ts"
 import { agentChannelDeliveryWorkflowContextKey, resumeWorkflowAgentChannelDelivery, withAgentChannelDelivery } from "../internal/channel-delivery.ts"
 
 import type {
@@ -95,6 +97,38 @@ function unsupportedWorkflowResult(): never {
   const error = new TypeError("Agent Workflow results must contain only JSON-compatible values.") as TypeError & { isRetryable: false }
   error.isRetryable = false
   throw error
+}
+
+function nonRetryableAgentWorkflowError(error: unknown): unknown {
+  if (readAgentErrorProperty(error, "isRetryable") === false) return error
+  const code = getViteHubErrorShape(error)?.code
+  const publicError = toAgentPublicError(error, "invocation")
+  const terminalProvider = publicError.code === "PROVIDER_AUTHENTICATION_FAILED"
+    || publicError.code === "PROVIDER_QUOTA_EXHAUSTED"
+  const retry = readAgentErrorProperty(error, "name") === "AI_RetryError"
+    ? readAgentErrorProperty(error, "lastError")
+    : error
+  const name = readAgentErrorProperty(retry, "name")
+  const status = readAgentErrorProperty(retry, "statusCode")
+  const permanentProviderRequest = name === "AI_LoadAPIKeyError"
+    || name === "AI_APICallError"
+    && typeof status === "number"
+    && status >= 400
+    && status < 500
+    && ![408, 409, 425, 429].includes(status)
+  const exhaustedOutput = code === "AGENT_OUTPUT_INVALID_JSON"
+    || code === "AGENT_OUTPUT_SCHEMA_INVALID"
+    || name === "AI_NoObjectGeneratedError"
+  if (!terminalProvider && !permanentProviderRequest && !exhaustedOutput) return error
+
+  const value = error instanceof Error ? error : new Error(String(error), { cause: error })
+  try {
+    Object.defineProperty(value, "isRetryable", { configurable: true, value: false })
+    return value
+  }
+  catch {
+    return Object.assign(new Error(value.message, { cause: value }), { isRetryable: false as const })
+  }
 }
 
 function isTextResponseMediaType(mediaType: string): boolean {
@@ -245,7 +279,7 @@ export async function runAgentWorkflowDefinition<
       await channelDelivery.event({ error: error instanceof Error ? error.message : String(error), type: "invocation.failed", runId }).catch(() => undefined)
       await channelDelivery.event({ error: error instanceof Error ? error.message : String(error), type: "failed", runId }).catch(() => undefined)
     }
-    throw error
+    throw nonRetryableAgentWorkflowError(error)
   }
   finally {
     while (backgroundTasks.length) {

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -112,6 +112,7 @@ function nonRetryableAgentWorkflowError(error: unknown): unknown {
   const retry = readAgentErrorProperty(error, "name") === "AI_RetryError"
     ? readAgentErrorProperty(error, "lastError")
     : error
+  const exhaustedProviderRetries = retry !== error
   const name = readAgentErrorProperty(retry, "name")
   const status = readAgentErrorProperty(retry, "statusCode")
   const permanentProviderRequest = name === "AI_LoadAPIKeyError"
@@ -123,7 +124,7 @@ function nonRetryableAgentWorkflowError(error: unknown): unknown {
   const exhaustedOutput = code === "AGENT_OUTPUT_INVALID_JSON"
     || code === "AGENT_OUTPUT_SCHEMA_INVALID"
     || name === "AI_NoObjectGeneratedError"
-  if (!nestedNonRetryable && !terminalProvider && !permanentProviderRequest && !exhaustedOutput) return error
+  if (!nestedNonRetryable && !terminalProvider && !permanentProviderRequest && !exhaustedProviderRetries && !exhaustedOutput) return error
 
   const value = error instanceof Error ? error : new Error(String(error), { cause: error })
   try {

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -11,6 +11,7 @@ import { restoreResolvedAgentInvokerInput } from "../invoker.ts"
 import { toAgentRunResult } from "../agent-output.ts"
 import { readAgentErrorProperty, toAgentPublicError } from "../agent-error.ts"
 import { agentChannelDeliveryWorkflowContextKey, resumeWorkflowAgentChannelDelivery, withAgentChannelDelivery } from "../internal/channel-delivery.ts"
+import { agentWorkflowExecutionContextKey } from "../internal/workflow-execution.ts"
 
 import type {
   AgentHostIdentity,
@@ -22,6 +23,7 @@ import type {
   AgentRuntimeContext,
   AgentRuntimeName,
 } from "../types.ts"
+
 import type { WorkflowExecutionContext, WorkflowProvider } from "@vite-hub/workflow"
 import type { AgentChannelDeliveryWorkflowBinding } from "../internal/channel-delivery.ts"
 
@@ -245,6 +247,7 @@ export async function runAgentWorkflowDefinition<
       backgroundTasks.push(Promise.resolve(promise).catch(() => undefined))
     },
   } as never)
+  Object.defineProperty(runtimeContext, agentWorkflowExecutionContextKey, { enumerable: true, value: true })
 
   const channelDeliveryBinding = payload.input?.context?.[agentChannelDeliveryWorkflowContextKey]
   const channelDelivery = isAgentChannelDeliveryWorkflowBinding(channelDeliveryBinding)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -8,7 +8,7 @@ import { awaitAgentInvocationResult } from "../agent-invocation.ts"
 import { hasTraceableStreamResult, isAsyncIterable, streamAgentOutputToEvents } from "../agent-output.ts"
 import { toAgentPublicError } from "../agent-error.ts"
 import { getAccessCapabilityOptions } from "../capabilities/access-metadata.ts"
-import { assertChatDeliveryOptions, CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCapabilityOptions } from "../chat-trigger.ts"
+import { assertChatDeliveryOptions, CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCapabilityOptions, resolveChatErrorFallbackText } from "../chat-trigger.ts"
 import { chatTriggerHistoryLimit, createChatMessageTriggerInput, resolveChatSessionBaseId, resolveChatSessionId, resolveChatTriggerHistory, uiMessagesToAgentMessages } from "../chat-message-input.ts"
 import { normalizeCapabilities } from "../capability-runtime.ts"
 import { deliveryArtifactAttachments } from "../delivery-artifacts.ts"
@@ -200,7 +200,6 @@ type AgentDefinitionWithCapabilities = {
   chat?: AgentChatOptions
 }
 
-const defaultChatErrorFallbackText = "Sorry, I couldn't process that message."
 const chatFinishMessagesKey = Symbol("vitehub.chat.finish.messages")
 const chatNativeStreamUpdateIntervalMs = 1
 const chatTypingRefreshIntervalMs = 4000
@@ -3051,29 +3050,6 @@ async function deliverToManualDeliveryPlaceholder(
   return false
 }
 
-async function resolveChatErrorFallbackText(
-  options: AgentChatOptions | undefined,
-  args: AgentChatErrorHookArgs<ViteAgentRouteRuntimeConfig>,
-  resolutionTimeout?: number,
-  resolutionAbort?: AbortController,
-  callbackDelivered?: () => boolean,
-): Promise<string | undefined> {
-  const fallback = options?.errorFallbackText
-  if (fallback === null) return undefined
-  if (typeof fallback === "function") {
-    try {
-      const resolved = await enforceChatInvocationTimeout(Promise.resolve(fallback(args)), resolutionTimeout, resolutionAbort)
-      return resolved || undefined
-    }
-    catch {
-      return callbackDelivered?.() ? undefined : defaultChatErrorFallbackText
-    }
-  }
-  const publicError = toAgentPublicError(args.error, "http")
-  if (publicError.code !== "INTERNAL") return publicError.error
-  return typeof fallback === "string" ? fallback : defaultChatErrorFallbackText
-}
-
 interface ManualChatDeliveryState {
   errorFallback?: string
   placeholder?: unknown
@@ -3112,16 +3088,14 @@ async function postChatErrorFallback(
     resolveCallbackDelivery = resolve
   })
   const fallbackResolutionAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
-  const fallbackResolution = resolveChatErrorFallbackText(
+  const fallbackResolution = enforceChatInvocationTimeout(resolveChatErrorFallbackText(
     options,
     chatErrorHookArgs(thread, message, input, run, error, toolResults, fallbackResolutionAbort?.signal, () => {
       callbackDelivered = true
       resolveCallbackDelivery?.()
     }),
-    fallbackResolutionTimeout,
-    fallbackResolutionAbort,
     () => callbackDelivered,
-  )
+  ), fallbackResolutionTimeout, fallbackResolutionAbort)
   const fallback = typeof options?.errorFallbackText === "function"
     ? await Promise.race([fallbackResolution, callbackDelivery.then(() => undefined)])
     : await fallbackResolution

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3088,14 +3088,15 @@ async function postChatErrorFallback(
     resolveCallbackDelivery = resolve
   })
   const fallbackResolutionAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
-  const fallbackResolution = enforceChatInvocationTimeout(resolveChatErrorFallbackText(
+  const fallbackResolution = resolveChatErrorFallbackText(
     options,
     chatErrorHookArgs(thread, message, input, run, error, toolResults, fallbackResolutionAbort?.signal, () => {
       callbackDelivered = true
       resolveCallbackDelivery?.()
     }),
     () => callbackDelivered,
-  ), fallbackResolutionTimeout, fallbackResolutionAbort)
+    resolution => enforceChatInvocationTimeout(resolution, fallbackResolutionTimeout, fallbackResolutionAbort),
+  )
   const fallback = typeof options?.errorFallbackText === "function"
     ? await Promise.race([fallbackResolution, callbackDelivery.then(() => undefined)])
     : await fallbackResolution

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -334,6 +334,7 @@ export function normalizeUiMessageStream(
   stream: ReadableStream<unknown>,
   options: {
     omitUsageEvents?: boolean
+    onChunk?: (chunk: unknown) => void
     onUsageRecord?: (usageRecord: AgentUsageRecord) => void
   } = {},
 ): ReadableStream<unknown> {
@@ -342,7 +343,9 @@ export function normalizeUiMessageStream(
       const usageRecord = usageRecordFromStreamChunk(chunk, stream)
       if (usageRecord) options.onUsageRecord?.(usageRecord)
       if (options.omitUsageEvents && streamEventType(chunk) === "usage" && usageRecord) return
-      controller.enqueue(normalizeUiMessageStreamChunk(chunk))
+      const normalized = normalizeUiMessageStreamChunk(chunk)
+      options.onChunk?.(normalized)
+      controller.enqueue(normalized)
     },
   }))
 }
@@ -485,11 +488,11 @@ export async function finalizeUiMessageStreamOutput(
   options: {
     abortSignal?: AbortSignal
     cancelOnAbort?: (reason: unknown) => Promise<void>
-    onWrappedChunk?: (chunk: unknown) => void
+    onNormalizedChunk?: (chunk: unknown) => void
     projection?: AgentUIMessageStreamProjection
   } = {},
 ): Promise<FinalizedStreamOutput<unknown>> {
-  const { abortSignal, cancelOnAbort, onWrappedChunk, projection } = options
+  const { abortSignal, cancelOnAbort, onNormalizedChunk, projection } = options
   const hasUiMessageStream = isUIMessageStreamResult(rendered)
   const hasAsyncIterable = isAsyncIterable(rendered)
   const text = hasUiMessageStream || hasAsyncIterable ? undefined : textFromRenderedOutput(rendered)
@@ -517,6 +520,7 @@ export async function finalizeUiMessageStreamOutput(
         },
   }), {
     omitUsageEvents: true,
+    onChunk: onNormalizedChunk,
     onUsageRecord: usageRecord => { streamedUsageRecord = usageRecord },
   }), projection)
   let streamedText = ""
@@ -528,7 +532,6 @@ export async function finalizeUiMessageStreamOutput(
           abortSignal,
           cancelOnAbort,
           onChunk(chunk) {
-            onWrappedChunk?.(chunk)
             streamedText += uiMessageTextDelta(chunk) || ""
             streamedUsageRecord = usageRecordFromStreamChunk(chunk, rendered) ?? streamedUsageRecord
           },

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -482,10 +482,14 @@ export async function finalizeUiMessageStreamOutput(
   rendered: unknown,
   shouldWrapOutput: boolean,
   finish: (outcome: StreamCleanupOutcome, streamedText?: string, streamedUsageRecord?: AgentUsageRecord) => MaybePromise<void>,
-  projection?: AgentUIMessageStreamProjection,
-  abortSignal?: AbortSignal,
-  cancelOnAbort?: (reason: unknown) => Promise<void>,
+  options: {
+    abortSignal?: AbortSignal
+    cancelOnAbort?: (reason: unknown) => Promise<void>
+    onWrappedChunk?: (chunk: unknown) => void
+    projection?: AgentUIMessageStreamProjection
+  } = {},
 ): Promise<FinalizedStreamOutput<unknown>> {
+  const { abortSignal, cancelOnAbort, onWrappedChunk, projection } = options
   const hasUiMessageStream = isUIMessageStreamResult(rendered)
   const hasAsyncIterable = isAsyncIterable(rendered)
   const text = hasUiMessageStream || hasAsyncIterable ? undefined : textFromRenderedOutput(rendered)
@@ -524,6 +528,7 @@ export async function finalizeUiMessageStreamOutput(
           abortSignal,
           cancelOnAbort,
           onChunk(chunk) {
+            onWrappedChunk?.(chunk)
             streamedText += uiMessageTextDelta(chunk) || ""
             streamedUsageRecord = usageRecordFromStreamChunk(chunk, rendered) ?? streamedUsageRecord
           },

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -116,6 +116,12 @@ function createToolCallId(name: string): string {
   return `${name}-${Date.now()}-${Math.random().toString(16).slice(2)}`
 }
 
+function toolCallIdFromExecutionOptions(value: unknown): string | undefined {
+  if (!value || typeof value !== "object") return
+  const toolCallId = (value as { toolCallId?: unknown }).toolCallId
+  return typeof toolCallId === "string" && toolCallId ? toolCallId : undefined
+}
+
 function getErrorOutput(error: unknown): string {
   return error instanceof Error ? error.message : String(error)
 }
@@ -186,7 +192,7 @@ export function withAgentToolStepReporting<TTools extends AgentToolSet>(tools: T
       async execute(input: unknown, ...args: unknown[]) {
         const toolCall: AgentToolStepItem = {
           input,
-          toolCallId: createToolCallId(name),
+          toolCallId: toolCallIdFromExecutionOptions(args[0]) ?? createToolCallId(name),
           toolName: name,
         }
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1744,6 +1744,7 @@ export type AgentToolSchema<T = unknown> = AgentToolStandardSchema<T> | (JSONSch
 
 export interface AgentToolExecutionContext {
   abortSignal?: AbortSignal
+  toolCallId?: string
 }
 
 export interface AgentToolDefinition<TInput = unknown, TOutput = unknown> {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -574,6 +574,7 @@ export interface AgentFinishEvent<
   result?: TOutput
   runtime: ResolvedAgentRuntimeContext<TRuntimeConfig> & { runEvents?: AgentRunEventPublisher }
   text?: string
+  toolResults: AgentToolStepItem[]
 }
 
 export type AgentFinishHookEvent<

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -7716,6 +7716,7 @@ describe("server helpers", () => {
       await vi.waitFor(() => expect(consoleError.mock.calls.filter(([message]) =>
         typeof message === "string" && message.includes('"event":"retry.scheduled"') && message.includes('"providerDeliveryId":"delivery-terminal"'),
       )).toHaveLength(1))
+      await Promise.resolve()
 
       await vi.advanceTimersByTimeAsync(1_000)
       await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(2))
@@ -7724,6 +7725,7 @@ describe("server helpers", () => {
       await vi.waitFor(() => expect(consoleError.mock.calls.filter(([message]) =>
         typeof message === "string" && message.includes('"event":"retry.scheduled"') && message.includes('"providerDeliveryId":"delivery-terminal"'),
       )).toHaveLength(2))
+      await Promise.resolve()
       await vi.advanceTimersByTimeAsync(2_000)
       await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(3))
       await vi.waitFor(() => expect(completeDelivery).toHaveBeenCalledOnce())

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -11930,7 +11930,7 @@ describe("server helpers", () => {
     const handler = createChannelWebhookRouteHandler(agent as never)
 
     try {
-      const responseError = handler(chatWebhookRequest(91_023), "telegram", {
+      const responseError = handler(chatWebhookRequest(91_023, 457), "telegram", {
         cloudflare: { env: {} },
         waitUntil: () => undefined,
       }).catch(error => error)
@@ -11946,7 +11946,7 @@ describe("server helpers", () => {
       await expect(responseError).resolves.toMatchObject({
         message: "Chat invocation timed out after 28000ms.",
       })
-      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Please try again.")
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:457", "Please try again.")
     }
     finally {
       consoleError.mockRestore()

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12336,7 +12336,7 @@ describe("agent message protocol", () => {
             context: { channel: { message: { text: "I ate skyr" } } },
             prompt: "I ate skyr",
           },
-          run: { channelId: "telegram", threadId: "telegram:123" },
+          run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
         },
         provider: "cloudflare",
       }, runAgentInline)).rejects.toBe(failure)
@@ -12345,6 +12345,42 @@ describe("agent message protocol", () => {
       expect(postMessage).toHaveBeenCalledWith("telegram:123", {
         markdown: "The meal was saved, but I could not finish the reply.",
       })
+    })
+
+    it("delivers durable failure fallbacks when Capability setup fails", async () => {
+      const { defineAgent, runAgentInline } = await import("../src/index.ts")
+      const { telegram } = await import("../src/channels.ts")
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const postMessage = vi.fn(async () => undefined)
+      const failure = new Error("Capability setup failed")
+      const agent = defineAgent({
+        capabilities: async () => { throw failure },
+        channels: {
+          telegram: telegram({
+            adapter: () => ({
+              channelIdFromThreadId: () => "telegram:123",
+              postMessage,
+            }) as never,
+          }),
+        },
+        driver: { run: async () => ({ text: "unreachable" }) },
+        messages: { errorFallbackText: "Please try again." },
+      })
+
+      await expect(runAgentWorkflowDefinition(agent, {
+        id: "run-before-capabilities",
+        name: "setup",
+        payload: {
+          input: {
+            context: { channel: { message: { text: "Hello" } } },
+            prompt: "Hello",
+          },
+          run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
+        },
+        provider: "cloudflare",
+      }, runAgentInline)).rejects.toBe(failure)
+
+      expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "Please try again." })
     })
 
     it.each([

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12692,6 +12692,51 @@ describe("agent message protocol", () => {
       }
     })
 
+    it("does not apply chat fallback deadlines to non-channel Workflow invocations", async () => {
+      vi.useFakeTimers()
+      try {
+        const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
+        const { telegram } = await import("../src/channels.ts")
+        const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+        const failure = new Error("provider failed")
+        const settled = vi.fn()
+        let releaseExtension!: () => void
+        const finishExtension = vi.fn(() => new Promise<{ ready: true }>((resolve) => {
+          releaseExtension = () => resolve({ ready: true })
+        }))
+        const agent = defineAgent({
+          capabilities: [defineCapability({
+            id: "slow-finish-extension",
+            prepare(context) {
+              context.finish.provide(finishExtension)
+            },
+          })],
+          channels: { telegram: telegram({ adapter: vi.fn() as never }) },
+          driver: { run: async () => { throw failure } },
+          messages: { errorFallbackText: "Please try again.", timeout: 10 },
+        })
+
+        const result = runAgentWorkflowDefinition(agent, {
+          id: "non-channel-workflow",
+          name: "failure",
+          payload: { input: { prompt: "scheduled work" }, run: { origin: "schedule" } },
+          provider: "cloudflare",
+        }, runAgentInline).catch(error => error).then((error) => {
+          settled()
+          return error
+        })
+
+        await vi.waitFor(() => expect(finishExtension).toHaveBeenCalledOnce())
+        await vi.advanceTimersByTimeAsync(10)
+        expect(settled).not.toHaveBeenCalled()
+        releaseExtension()
+        expect(await result).toBe(failure)
+      }
+      finally {
+        vi.useRealTimers()
+      }
+    })
+
     it("delivers durable failure fallbacks when Capability setup fails", async () => {
       const { defineAgent, runAgentInline } = await import("../src/index.ts")
       const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12545,6 +12545,50 @@ describe("agent message protocol", () => {
       expect(fallback).not.toHaveBeenCalled()
     })
 
+    it("bounds durable setup fallback delivery", async () => {
+      vi.useFakeTimers()
+      try {
+        const { defineAgent, runAgent } = await import("../src/index.ts")
+        const { telegram } = await import("../src/channels.ts")
+        const { agentWorkflowExecutionContextKey } = await import("../src/internal/workflow-execution.ts")
+        const failure = new Error("Capability setup failed")
+        const agent = defineAgent({
+          capabilities: async () => { throw failure },
+          channels: {
+            telegram: telegram({
+              adapter: () => ({
+                channelIdFromThreadId: () => "telegram:123",
+                postMessage: () => new Promise(() => undefined),
+              }) as never,
+            }),
+          },
+          driver: { run: async () => ({ text: "unreachable" }) },
+          messages: { errorFallbackText: "Please try again.", timeout: 10 },
+        })
+
+        const result = runAgent(agent, {
+          [agentWorkflowExecutionContextKey]: true,
+          memo: vi.fn(),
+          run: { channelId: "telegram", origin: "telegram", runId: "stalled-setup-fallback", threadId: "telegram:123" },
+          runtime: "unknown",
+          waitUntil: vi.fn(),
+        }, {
+          context: { channel: { message: { text: "Hello" } } },
+          prompt: "Hello",
+        }).catch(error => error)
+
+        await vi.advanceTimersByTimeAsync(10)
+        const error = await result
+        expect(error).toBeInstanceOf(AggregateError)
+        if (!(error instanceof AggregateError)) throw error
+        expect(error.errors).toContain(failure)
+        expect(error.errors[1]).toMatchObject({ message: "Durable chat error fallback delivery timed out after 10ms." })
+      }
+      finally {
+        vi.useRealTimers()
+      }
+    })
+
     it("delivers durable setup fallbacks for capacity-limited Agents", async () => {
       const { defineAgent, runAgentInline } = await import("../src/index.ts")
       const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -10,7 +10,7 @@ import { toAgentFetchResponse } from "../src/http-response.ts"
 import { toJsonCompatibleValue } from "../src/tool-runtime.ts"
 import { adapterDefinition } from "./adapter-definition.ts"
 
-import type { AgentChannelDeliveryFinishEffectCallback, AgentFinishEvent } from "../src/index.ts"
+import type { AgentChannelDeliveryFinishEffectCallback, AgentChannelDeliveryFinishEffectResult, AgentFinishEvent } from "../src/index.ts"
 import type { WritableWorkspaceFacade } from "@vite-hub/workspace"
 
 const harnessAgentSettings = vi.hoisted(() => [] as Record<string, unknown>[])
@@ -12537,7 +12537,10 @@ describe("agent message protocol", () => {
         const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
         const failure = new Error("provider failed")
         const postMessage = vi.fn(async () => undefined)
-        const errorHook = vi.fn(() => new Promise<void>(() => undefined))
+        let releaseErrorHook!: () => void
+        const errorHook = vi.fn((event: { input: { abortSignal?: AbortSignal }, reply: (message: string) => AgentChannelDeliveryFinishEffectResult }) => new Promise<AgentChannelDeliveryFinishEffectResult>((resolve) => {
+          releaseErrorHook = () => resolve(event.reply("Too late."))
+        }))
         const agent = defineAgent({
           channels: {
             telegram: telegram({
@@ -12577,6 +12580,10 @@ describe("agent message protocol", () => {
           message: "Durable chat error fallback delivery timed out after 10ms.",
         }))
         expect(error).toMatchObject({ isRetryable: false })
+        expect(errorHook.mock.calls[0]?.[0].input.abortSignal).toMatchObject({ aborted: true })
+        releaseErrorHook()
+        await vi.runAllTimersAsync()
+        expect(postMessage).toHaveBeenCalledOnce()
       }
       finally {
         vi.useRealTimers()
@@ -12936,6 +12943,59 @@ describe("agent message protocol", () => {
         }).catch(error => error)
 
         await vi.advanceTimersByTimeAsync(10)
+        const error = await result
+        expect(error).toBeInstanceOf(AggregateError)
+        if (!(error instanceof AggregateError)) throw error
+        expect(error.errors).toContain(failure)
+        expect(error.errors[1]).toMatchObject({ isRetryable: false, message: "Durable chat error fallback delivery timed out after 10ms." })
+      }
+      finally {
+        vi.useRealTimers()
+      }
+    })
+
+    it("shares the durable setup fallback deadline across resolution and delivery", async () => {
+      vi.useFakeTimers()
+      try {
+        const { defineAgent, runAgent } = await import("../src/index.ts")
+        const { telegram } = await import("../src/channels.ts")
+        const { agentWorkflowExecutionContextKey } = await import("../src/internal/workflow-execution.ts")
+        const failure = new Error("Capability setup failed")
+        const postMessage = vi.fn(() => new Promise(() => undefined))
+        const agent = defineAgent({
+          capabilities: async () => { throw failure },
+          channels: {
+            telegram: telegram({
+              adapter: () => ({
+                channelIdFromThreadId: () => "telegram:123",
+                postMessage,
+              }) as never,
+            }),
+          },
+          driver: { run: async () => ({ text: "unreachable" }) },
+          messages: {
+            errorFallbackText: async () => {
+              await new Promise(resolve => setTimeout(resolve, 8))
+              return "Please try again."
+            },
+            timeout: 10,
+          },
+        })
+
+        const result = runAgent(agent, {
+          [agentWorkflowExecutionContextKey]: true,
+          memo: vi.fn(),
+          run: { channelId: "telegram", origin: "telegram", runId: "shared-setup-deadline", threadId: "telegram:123" },
+          runtime: "unknown",
+          waitUntil: vi.fn(),
+        }, {
+          context: { channel: { message: { text: "Hello" } } },
+          prompt: "Hello",
+        }).catch(error => error)
+
+        await vi.advanceTimersByTimeAsync(8)
+        await vi.waitFor(() => expect(postMessage).toHaveBeenCalledOnce())
+        await vi.advanceTimersByTimeAsync(2)
         const error = await result
         expect(error).toBeInstanceOf(AggregateError)
         if (!(error instanceof AggregateError)) throw error

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12481,6 +12481,53 @@ describe("agent message protocol", () => {
       expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "The UI streamed write completed before the failure." })
     })
 
+    it("bounds durable prepared fallback delivery", async () => {
+      vi.useFakeTimers()
+      try {
+        const { defineAgent, runAgentInline } = await import("../src/index.ts")
+        const { telegram } = await import("../src/channels.ts")
+        const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+        const failure = new Error("provider failed")
+        const postMessage = vi.fn(() => new Promise(() => undefined))
+        const agent = defineAgent({
+          channels: {
+            telegram: telegram({
+              adapter: () => ({
+                channelIdFromThreadId: () => "telegram:123",
+                postMessage,
+              }) as never,
+            }),
+          },
+          driver: { run: async () => { throw failure } },
+          messages: { errorFallbackText: "Please try again.", timeout: 10 },
+        })
+
+        const result = runAgentWorkflowDefinition(agent, {
+          id: "stalled-prepared-fallback",
+          name: "failure",
+          payload: {
+            input: {
+              context: { channel: { message: { text: "Hello" } } },
+              prompt: "Hello",
+            },
+            run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
+          },
+          provider: "cloudflare",
+        }, runAgentInline).catch(error => error)
+
+        await vi.waitFor(() => expect(postMessage).toHaveBeenCalledOnce())
+        await vi.advanceTimersByTimeAsync(10)
+        const error = await result
+        expect(error).toBeInstanceOf(AggregateError)
+        if (!(error instanceof AggregateError)) throw error
+        expect(error.errors).toContain(failure)
+        expect(error.errors).toContainEqual(expect.objectContaining({ message: "Durable chat error fallback delivery timed out after 10ms." }))
+      }
+      finally {
+        vi.useRealTimers()
+      }
+    })
+
     it("delivers durable failure fallbacks when Capability setup fails", async () => {
       const { defineAgent, runAgentInline } = await import("../src/index.ts")
       const { telegram } = await import("../src/channels.ts")
@@ -12675,6 +12722,7 @@ describe("agent message protocol", () => {
       const { telegram } = await import("../src/channels.ts")
       const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
       const postMessage = vi.fn(async () => undefined)
+      const errorHook = vi.fn(async () => undefined)
       const cleanupFailure = new Error("Capability cleanup failed")
       const agent = defineAgent({
         capabilities: [defineCapability({
@@ -12690,6 +12738,7 @@ describe("agent message protocol", () => {
           }),
         },
         driver: { run: async () => ({ text: "completed before cleanup" }) },
+        hooks: { "agent:error": errorHook },
         messages: { errorFallbackText: "Cleanup failed after completion." },
       })
 
@@ -12708,6 +12757,7 @@ describe("agent message protocol", () => {
 
       expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "Cleanup failed after completion." })
       expect(postMessage).toHaveBeenCalledOnce()
+      expect(errorHook).not.toHaveBeenCalled()
     })
 
     it("preserves cleanup failures when later Agent error handling also fails", async () => {
@@ -12772,6 +12822,35 @@ describe("agent message protocol", () => {
       await vi.advanceTimersByTimeAsync(10)
       await expect(resolution).resolves.toBe("Sorry, I couldn't process that message.")
       vi.useRealTimers()
+    })
+
+    it("ignores fallback posts after durable callback resolution times out", async () => {
+      vi.useFakeTimers()
+      try {
+        const { resolveDurableChatErrorFallbackIntents } = await import("../src/chat-trigger.ts")
+        const resolution = resolveDurableChatErrorFallbackIntents({
+          errorFallbackText: async ({ thread }) => {
+            await new Promise(resolve => setTimeout(resolve, 20))
+            await thread.post("late fallback")
+          },
+          timeout: 10,
+        }, {
+          error: new Error("provider failed"),
+          history: [],
+          message: { text: "hello" },
+          publicError: { code: "INTERNAL", error: "Internal error" },
+          toolResults: [],
+        })
+
+        await vi.advanceTimersByTimeAsync(10)
+        const intents = await resolution
+        expect(intents).toHaveLength(1)
+        await vi.advanceTimersByTimeAsync(20)
+        expect(intents).toHaveLength(1)
+      }
+      finally {
+        vi.useRealTimers()
+      }
     })
 
     it.each([

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 import { createMessage, getMessageText } from "@vite-hub/agent"
 import { createRateLimiter } from "@vite-hub/rate-limit"
 import { memoryRateLimitDriver } from "@vite-hub/rate-limit/drivers/memory"
-import { createTraceEventLog, deriveTraceRuns, emitTraceEvent, unknownExecutionAuthority } from "@vite-hub/runtime"
+import { createTraceEventLog, deriveTraceRuns, emitTraceEvent, unknownExecutionAuthority, ViteHubError } from "@vite-hub/runtime"
 import { chat, mcp, progressSummary, title, schedule, subagents } from "../src/capabilities.ts"
 import { toAgentFetchResponse } from "../src/http-response.ts"
 import { toJsonCompatibleValue } from "../src/tool-runtime.ts"
@@ -12279,6 +12279,102 @@ describe("agent message protocol", () => {
         result: false,
         status: "completed",
       })
+    })
+
+    it("delivers durable failure fallbacks with completed write tool results", async () => {
+      const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
+      const { telegram } = await import("../src/channels.ts")
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const postMessage = vi.fn(async () => undefined)
+      const failure = Object.assign(new Error("provider unavailable"), {
+        name: "AI_APICallError",
+        statusCode: 503,
+      })
+      const fallback = vi.fn(({ toolResults }) => {
+        expect(toolResults).toEqual([expect.objectContaining({
+          input: { calories: 240 },
+          output: { id: "meal-1" },
+          toolName: "save_meal",
+        })])
+        return "The meal was saved, but I could not finish the reply."
+      })
+      const agent = defineAgent({
+        capabilities: [defineCapability({
+          id: "meals",
+          mode: "write",
+          tools: {
+            save_meal: {
+              execute: () => ({ id: "meal-1" }),
+              name: "save_meal",
+            },
+          },
+        })],
+        channels: {
+          telegram: telegram({
+            adapter: () => ({
+              channelIdFromThreadId: () => "telegram:123",
+              postMessage,
+            }) as never,
+          }),
+        },
+        driver: {
+          run: async ({ tools }) => {
+            await tools!.save_meal!.execute!({ calories: 240 })
+            throw failure
+          },
+        },
+        messages: { errorFallbackText: fallback },
+      })
+
+      expect(agent.capabilities?.map(capability => capability.id)).toContain("chat")
+
+      await expect(runAgentWorkflowDefinition(agent, {
+        id: "run-after-write",
+        name: "calories",
+        payload: {
+          input: {
+            context: { channel: { message: { text: "I ate skyr" } } },
+            prompt: "I ate skyr",
+          },
+          run: { channelId: "telegram", threadId: "telegram:123" },
+        },
+        provider: "cloudflare",
+      }, runAgentInline)).rejects.toBe(failure)
+
+      expect(fallback).toHaveBeenCalledOnce()
+      expect(postMessage).toHaveBeenCalledWith("telegram:123", {
+        markdown: "The meal was saved, but I could not finish the reply.",
+      })
+    })
+
+    it.each([
+      Object.assign(new Error("invalid provider request"), { name: "AI_APICallError", statusCode: 400 }),
+      new ViteHubError("AGENT_OUTPUT_SCHEMA_INVALID", "output failed schema validation"),
+    ])("marks permanent Agent Workflow failures as non-retryable", async (failure) => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "terminal-agent-failure",
+        name: "agent",
+        payload: {},
+        provider: "cloudflare",
+      }, async () => { throw failure })).rejects.toMatchObject({ isRetryable: false })
+    })
+
+    it("leaves transient provider failures retryable at safe inner seams", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const failure = Object.assign(new Error("provider unavailable"), {
+        name: "AI_APICallError",
+        statusCode: 503,
+      })
+
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "transient-agent-failure",
+        name: "agent",
+        payload: {},
+        provider: "cloudflare",
+      }, async () => { throw failure })).rejects.toBe(failure)
+      expect(failure).not.toHaveProperty("isRetryable")
     })
 
     it("normalizes noncloneable Agent results before Workflow completion", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -13007,6 +13007,56 @@ describe("agent message protocol", () => {
       }
     })
 
+    it("does not deliver setup fallbacks that resolve after the durable deadline", async () => {
+      vi.useFakeTimers()
+      try {
+        const { defineAgent, runAgent } = await import("../src/index.ts")
+        const { telegram } = await import("../src/channels.ts")
+        const { agentWorkflowExecutionContextKey } = await import("../src/internal/workflow-execution.ts")
+        const failure = new Error("Capability setup failed")
+        const postMessage = vi.fn(async () => undefined)
+        const agent = defineAgent({
+          capabilities: async () => { throw failure },
+          channels: {
+            telegram: telegram({
+              adapter: () => ({
+                channelIdFromThreadId: () => "telegram:123",
+                postMessage,
+              }) as never,
+            }),
+          },
+          driver: { run: async () => ({ text: "unreachable" }) },
+          messages: {
+            errorFallbackText: async () => {
+              await new Promise(resolve => setTimeout(resolve, 12))
+              return "Too late."
+            },
+            timeout: 10,
+          },
+        })
+
+        const result = runAgent(agent, {
+          [agentWorkflowExecutionContextKey]: true,
+          memo: vi.fn(),
+          run: { channelId: "telegram", origin: "telegram", runId: "late-setup-fallback", threadId: "telegram:123" },
+          runtime: "unknown",
+          waitUntil: vi.fn(),
+        }, {
+          context: { channel: { message: { text: "Hello" } } },
+          prompt: "Hello",
+        }).catch(error => error)
+
+        await vi.advanceTimersByTimeAsync(10)
+        const error = await result
+        expect(error).toBeInstanceOf(AggregateError)
+        await vi.advanceTimersByTimeAsync(2)
+        expect(postMessage).not.toHaveBeenCalled()
+      }
+      finally {
+        vi.useRealTimers()
+      }
+    })
+
     it("delivers durable setup fallbacks for capacity-limited Agents", async () => {
       const { defineAgent, runAgentInline } = await import("../src/index.ts")
       const { telegram } = await import("../src/channels.ts")
@@ -13045,6 +13095,72 @@ describe("agent message protocol", () => {
 
       expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "Please try again." })
       expect(postMessage).toHaveBeenCalledOnce()
+    })
+
+    it("awaits durable failure finalization when Workflow capacity acquisition fails", async () => {
+      vi.useFakeTimers()
+      try {
+        const { defineAgent, runAgent, runAgentInline } = await import("../src/index.ts")
+        const { telegram } = await import("../src/channels.ts")
+        const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+        let releaseDriver!: () => void
+        const driverGate = new Promise<void>((resolve) => { releaseDriver = resolve })
+        const postMessage = vi.fn(() => new Promise(() => undefined))
+        const driverRun = vi.fn(async () => {
+          await driverGate
+          return { text: "done" }
+        })
+        const agent = defineAgent({
+          channels: {
+            telegram: telegram({
+              adapter: () => ({
+                channelIdFromThreadId: () => "telegram:123",
+                postMessage,
+              }) as never,
+            }),
+          },
+          driver: {
+            capacity: { concurrency: 1, queue: { maxPending: 1, timeout: 1 } },
+            run: driverRun,
+          },
+          messages: { errorFallbackText: "Please try again.", timeout: 10 },
+        })
+        const first = runAgent(agent, {
+          memo: vi.fn(),
+          run: { origin: "test", runId: "capacity-holder" },
+          runtime: "unknown",
+          waitUntil: vi.fn(),
+        }, { prompt: "Hold capacity" })
+        await vi.waitFor(() => expect(driverRun).toHaveBeenCalledOnce())
+
+        const result = runAgentWorkflowDefinition(agent, {
+          id: "capacity-timeout-fallback",
+          name: "capacity",
+          payload: {
+            input: {
+              context: { channel: { message: { text: "Hello" } } },
+              prompt: "Hello",
+            },
+            run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
+          },
+          provider: "cloudflare",
+        }, runAgentInline).catch(error => error)
+
+        await vi.advanceTimersByTimeAsync(1)
+        await vi.waitFor(() => expect(postMessage).toHaveBeenCalledOnce())
+        await vi.advanceTimersByTimeAsync(10)
+        const error = await result
+        expect(error).toBeInstanceOf(AggregateError)
+        if (!(error instanceof AggregateError)) throw error
+        expect(error.errors[0]).toMatchObject({ code: "AGENT_CAPACITY_QUEUE_TIMEOUT" })
+        expect(error.errors[1]).toMatchObject({ isRetryable: false, message: "Durable chat error fallback delivery timed out after 10ms." })
+
+        releaseDriver()
+        await first
+      }
+      finally {
+        vi.useRealTimers()
+      }
     })
 
     it("delivers durable failure fallbacks when Capability cleanup also fails", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12370,6 +12370,116 @@ describe("agent message protocol", () => {
       })
     })
 
+    it("delivers streamed tool results to durable failure fallbacks without duplicates", async () => {
+      const { defineAgent, streamAgent } = await import("../src/index.ts")
+      const { telegram } = await import("../src/channels.ts")
+      const { agentWorkflowExecutionContextKey } = await import("../src/internal/workflow-execution.ts")
+      const postMessage = vi.fn(async () => undefined)
+      const fallback = vi.fn(({ toolResults }) => {
+        expect(toolResults).toEqual([{
+          output: { id: "meal-1" },
+          toolCallId: "save-1",
+          toolName: "save_meal",
+        }])
+        return "The streamed write completed before the failure."
+      })
+      const agent = defineAgent({
+        channels: {
+          telegram: telegram({
+            adapter: () => ({
+              channelIdFromThreadId: () => "telegram:123",
+              postMessage,
+            }) as never,
+          }),
+        },
+        driver: { run: () => (async function* () {
+          yield { output: { id: "meal-1" }, toolCallId: "save-1", toolName: "save_meal", type: "tool-result" }
+          yield { output: { id: "meal-1" }, toolCallId: "save-1", toolName: "save_meal", type: "tool-result" }
+          throw new Error("stream failed")
+        })() },
+        messages: { errorFallbackText: fallback },
+      })
+
+      const stream = await streamAgent(agent, {
+        [agentWorkflowExecutionContextKey]: true,
+        memo: vi.fn(),
+        run: { channelId: "telegram", origin: "telegram", runId: "streamed-write-failure", threadId: "telegram:123" },
+        runtime: "unknown",
+        waitUntil: vi.fn(),
+      }, {
+        context: { channel: { message: { text: "Save this meal" } } },
+        prompt: "Save this meal",
+      }) as AsyncIterable<unknown>
+      await expect(async () => {
+        for await (const _event of stream) {}
+      }).rejects.toThrow("stream failed")
+
+      expect(fallback).toHaveBeenCalledOnce()
+      expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "The streamed write completed before the failure." })
+    })
+
+    it("delivers UI-message stream tool results to durable failure fallbacks without duplicates", async () => {
+      const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
+      const { telegram } = await import("../src/channels.ts")
+      const { agentWorkflowExecutionContextKey } = await import("../src/internal/workflow-execution.ts")
+      const postMessage = vi.fn(async () => undefined)
+      let fallbackToolResults: unknown
+      const fallback = vi.fn(({ toolResults }) => {
+        fallbackToolResults = toolResults
+        return "The UI streamed write completed before the failure."
+      })
+      const agent = defineAgent({
+        capabilities: [defineCapability({
+          id: "meals",
+          mode: "write",
+          tools: {
+            save_meal: {
+              execute: () => ({ id: "meal-1" }),
+              name: "save_meal",
+            },
+          },
+        })],
+        channels: {
+          telegram: telegram({
+            adapter: () => ({
+              channelIdFromThreadId: () => "telegram:123",
+              postMessage,
+            }) as never,
+          }),
+        },
+        driver: { run: ({ tools }) => (async function* () {
+          await tools!.save_meal!.execute!({ calories: 240 }, { toolCallId: "save-1" } as never)
+          yield { id: "save-1", name: "save_meal", output: { id: "meal-1" }, type: "tool-result" }
+          yield { id: "save-1", name: "save_meal", output: { id: "meal-1" }, type: "tool-result" }
+          throw new Error("UI stream failed")
+        })() },
+        messages: { errorFallbackText: fallback },
+      })
+
+      const stream = await streamAgent(agent, {
+        [agentWorkflowExecutionContextKey]: true,
+        memo: vi.fn(),
+        run: { channelId: "telegram", origin: "telegram", runId: "ui-streamed-write-failure", threadId: "telegram:123" },
+        runtime: "unknown",
+        waitUntil: vi.fn(),
+      }, {
+        context: { channel: { message: { text: "Save this meal" } } },
+        prompt: "Save this meal",
+      }, { output: "ui-message-stream" }) as ReadableStream<unknown>
+      await expect(async () => {
+        for await (const _event of stream) {}
+      }).rejects.toThrow("UI stream failed")
+
+      expect(fallback).toHaveBeenCalledOnce()
+      expect(fallbackToolResults).toEqual([{
+        input: { calories: 240 },
+        output: { id: "meal-1" },
+        toolCallId: "save-1",
+        toolName: "save_meal",
+      }])
+      expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "The UI streamed write completed before the failure." })
+    })
+
     it("delivers durable failure fallbacks when Capability setup fails", async () => {
       const { defineAgent, runAgentInline } = await import("../src/index.ts")
       const { telegram } = await import("../src/channels.ts")
@@ -12410,6 +12520,171 @@ describe("agent message protocol", () => {
 
       expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "Please try again." })
       expect(postMessage).toHaveBeenCalledOnce()
+    })
+
+    it("delivers durable setup fallbacks for capacity-limited Agents", async () => {
+      const { defineAgent, runAgentInline } = await import("../src/index.ts")
+      const { telegram } = await import("../src/channels.ts")
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const postMessage = vi.fn(async () => undefined)
+      const failure = new Error("Capacity-limited Capability setup failed")
+      const agent = defineAgent({
+        capabilities: async () => { throw failure },
+        channels: {
+          telegram: telegram({
+            adapter: () => ({
+              channelIdFromThreadId: () => "telegram:123",
+              postMessage,
+            }) as never,
+          }),
+        },
+        driver: {
+          capacity: { concurrency: 1 },
+          run: async () => ({ text: "unreachable" }),
+        },
+        messages: { errorFallbackText: "Please try again." },
+      })
+
+      await expect(runAgentWorkflowDefinition(agent, {
+        id: "capacity-setup-failure",
+        name: "setup",
+        payload: {
+          input: {
+            context: { channel: { message: { text: "Hello" } } },
+            prompt: "Hello",
+          },
+          run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
+        },
+        provider: "cloudflare",
+      }, runAgentInline)).rejects.toBe(failure)
+
+      expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "Please try again." })
+      expect(postMessage).toHaveBeenCalledOnce()
+    })
+
+    it("delivers durable failure fallbacks when Capability cleanup also fails", async () => {
+      const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
+      const { telegram } = await import("../src/channels.ts")
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const postMessage = vi.fn(async () => undefined)
+      const providerFailure = new Error("provider failed")
+      const cleanupFailure = new Error("Capability cleanup failed")
+      const agent = defineAgent({
+        capabilities: [defineCapability({
+          close: async () => { throw cleanupFailure },
+          id: "cleanup-failure",
+        })],
+        channels: {
+          telegram: telegram({
+            adapter: () => ({
+              channelIdFromThreadId: () => "telegram:123",
+              postMessage,
+            }) as never,
+          }),
+        },
+        driver: { run: async () => { throw providerFailure } },
+        messages: { errorFallbackText: "The request failed." },
+      })
+
+      await expect(runAgentWorkflowDefinition(agent, {
+        id: "cleanup-failure",
+        name: "cleanup",
+        payload: {
+          input: {
+            context: { channel: { message: { text: "Hello" } } },
+            prompt: "Hello",
+          },
+          run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
+        },
+        provider: "cloudflare",
+      }, runAgentInline)).rejects.toBeInstanceOf(AggregateError)
+
+      expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "The request failed." })
+      expect(postMessage).toHaveBeenCalledOnce()
+    })
+
+    it("delivers durable failure fallbacks when Capability cleanup is the only failure", async () => {
+      const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
+      const { telegram } = await import("../src/channels.ts")
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const postMessage = vi.fn(async () => undefined)
+      const cleanupFailure = new Error("Capability cleanup failed")
+      const agent = defineAgent({
+        capabilities: [defineCapability({
+          close: async () => { throw cleanupFailure },
+          id: "cleanup-only-failure",
+        })],
+        channels: {
+          telegram: telegram({
+            adapter: () => ({
+              channelIdFromThreadId: () => "telegram:123",
+              postMessage,
+            }) as never,
+          }),
+        },
+        driver: { run: async () => ({ text: "completed before cleanup" }) },
+        messages: { errorFallbackText: "Cleanup failed after completion." },
+      })
+
+      await expect(runAgentWorkflowDefinition(agent, {
+        id: "cleanup-only-failure",
+        name: "cleanup",
+        payload: {
+          input: {
+            context: { channel: { message: { text: "Hello" } } },
+            prompt: "Hello",
+          },
+          run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
+        },
+        provider: "cloudflare",
+      }, runAgentInline)).rejects.toBe(cleanupFailure)
+
+      expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "Cleanup failed after completion." })
+      expect(postMessage).toHaveBeenCalledOnce()
+    })
+
+    it("preserves cleanup failures when later Agent error handling also fails", async () => {
+      const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
+      const { telegram } = await import("../src/channels.ts")
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const providerFailure = new Error("provider failed")
+      const cleanupFailure = new Error("Capability cleanup failed")
+      const hookFailure = new Error("Agent error hook failed")
+      const agent = defineAgent({
+        capabilities: [defineCapability({
+          close: async () => { throw cleanupFailure },
+          id: "combined-failures",
+        })],
+        channels: {
+          telegram: telegram({
+            adapter: () => ({
+              channelIdFromThreadId: () => "telegram:123",
+              postMessage: async () => undefined,
+            }) as never,
+          }),
+        },
+        driver: { run: async () => { throw providerFailure } },
+        hooks: { "agent:error": async () => { throw hookFailure } },
+        messages: { errorFallbackText: "The request failed." },
+      })
+
+      const failure = await runAgentWorkflowDefinition(agent, {
+        id: "combined-failures",
+        name: "cleanup",
+        payload: {
+          input: {
+            context: { channel: { message: { text: "Hello" } } },
+            prompt: "Hello",
+          },
+          run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
+        },
+        provider: "cloudflare",
+      }, runAgentInline).catch(error => error)
+      const errors = (function flatten(error: unknown): unknown[] {
+        return error instanceof AggregateError ? error.errors.flatMap(flatten) : [error]
+      })(failure)
+
+      expect(errors).toEqual(expect.arrayContaining([providerFailure, cleanupFailure, hookFailure]))
     })
 
     it("bounds durable error fallback callbacks", async () => {
@@ -12473,6 +12748,24 @@ describe("agent message protocol", () => {
         provider: "cloudflare",
       }, async () => { throw failure })).rejects.toBe(failure)
       expect(failure).not.toHaveProperty("isRetryable")
+    })
+
+    it("marks exhausted transient provider retries as non-retryable at the Workflow boundary", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const failure = Object.assign(new Error("provider retries exhausted"), {
+        lastError: Object.assign(new Error("provider unavailable"), {
+          name: "AI_APICallError",
+          statusCode: 503,
+        }),
+        name: "AI_RetryError",
+      })
+
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "exhausted-transient-provider-failure",
+        name: "agent",
+        payload: {},
+        provider: "cloudflare",
+      }, async () => { throw failure })).rejects.toMatchObject({ isRetryable: false })
     })
 
     it("normalizes noncloneable Agent results before Workflow completion", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12454,6 +12454,7 @@ describe("agent message protocol", () => {
           throw new Error("UI stream failed")
         })() },
         messages: { errorFallbackText: fallback },
+        uiMessageStream: { tools: "hidden" },
       })
 
       const stream = await streamAgent(agent, {
@@ -12520,6 +12521,28 @@ describe("agent message protocol", () => {
 
       expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "Please try again." })
       expect(postMessage).toHaveBeenCalledOnce()
+    })
+
+    it("does not resolve chat fallbacks for non-chat Workflow invocations", async () => {
+      const { defineAgent, runAgent } = await import("../src/index.ts")
+      const { agentWorkflowExecutionContextKey } = await import("../src/internal/workflow-execution.ts")
+      const failure = new Error("Scheduled Capability setup failed")
+      const fallback = vi.fn(() => "Please try again.")
+      const agent = defineAgent({
+        capabilities: async () => { throw failure },
+        driver: { run: async () => ({ text: "unreachable" }) },
+        messages: { errorFallbackText: fallback },
+      })
+
+      await expect(runAgent(agent, {
+        [agentWorkflowExecutionContextKey]: true,
+        memo: vi.fn(),
+        run: { origin: "schedule", runId: "scheduled-setup-failure" },
+        runtime: "unknown",
+        waitUntil: vi.fn(),
+      }, { prompt: "Run the scheduled task" })).rejects.toBe(failure)
+
+      expect(fallback).not.toHaveBeenCalled()
     })
 
     it("delivers durable setup fallbacks for capacity-limited Agents", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12641,6 +12641,57 @@ describe("agent message protocol", () => {
       }
     })
 
+    it("delivers durable fallbacks before a stalled finish extension and bounds completion", async () => {
+      vi.useFakeTimers()
+      try {
+        const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
+        const { telegram } = await import("../src/channels.ts")
+        const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+        const failure = new Error("provider failed")
+        const postMessage = vi.fn(async () => undefined)
+        const agent = defineAgent({
+          capabilities: [defineCapability({
+            id: "stalled-finish-extension",
+            prepare(context) {
+              context.finish.provide(() => new Promise(() => undefined))
+            },
+          })],
+          channels: {
+            telegram: telegram({
+              adapter: () => ({
+                channelIdFromThreadId: () => "telegram:123",
+                postMessage,
+              }) as never,
+            }),
+          },
+          driver: { run: async () => { throw failure } },
+          messages: { errorFallbackText: "Please try again.", timeout: 10 },
+        })
+
+        const result = runAgentWorkflowDefinition(agent, {
+          id: "stalled-finish-extension",
+          name: "failure",
+          payload: {
+            input: { context: { channel: { message: { text: "Hello" } } }, prompt: "Hello" },
+            run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
+          },
+          provider: "cloudflare",
+        }, runAgentInline).catch(error => error)
+
+        await vi.waitFor(() => expect(postMessage).toHaveBeenCalledOnce())
+        await vi.advanceTimersByTimeAsync(10)
+        const error = await result
+        expect(error).toBeInstanceOf(AggregateError)
+        if (!(error instanceof AggregateError)) throw error
+        expect(error.errors).toContain(failure)
+        expect(error.errors).toContainEqual(expect.objectContaining({ message: "Durable chat error fallback delivery timed out after 10ms." }))
+        expect(error).toMatchObject({ isRetryable: false })
+      }
+      finally {
+        vi.useRealTimers()
+      }
+    })
+
     it("delivers durable failure fallbacks when Capability setup fails", async () => {
       const { defineAgent, runAgentInline } = await import("../src/index.ts")
       const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12522,6 +12522,7 @@ describe("agent message protocol", () => {
         if (!(error instanceof AggregateError)) throw error
         expect(error.errors).toContain(failure)
         expect(error.errors).toContainEqual(expect.objectContaining({ message: "Durable chat error fallback delivery timed out after 10ms." }))
+        expect(error).toMatchObject({ isRetryable: false })
       }
       finally {
         vi.useRealTimers()
@@ -12629,7 +12630,7 @@ describe("agent message protocol", () => {
         expect(error).toBeInstanceOf(AggregateError)
         if (!(error instanceof AggregateError)) throw error
         expect(error.errors).toContain(failure)
-        expect(error.errors[1]).toMatchObject({ message: "Durable chat error fallback delivery timed out after 10ms." })
+        expect(error.errors[1]).toMatchObject({ isRetryable: false, message: "Durable chat error fallback delivery timed out after 10ms." })
       }
       finally {
         vi.useRealTimers()

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -307,6 +307,29 @@ describe("agent message protocol", () => {
     )
   })
 
+  it("reports Harness capability tool results once", async () => {
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const toolStepReporter = vi.fn()
+    harnessCreateSession.mockResolvedValueOnce({ destroy: vi.fn() })
+    harnessGenerate.mockImplementationOnce(async () => {
+      const tools = harnessAgentSettings.at(-1)?.tools as Record<string, { execute: (input: unknown) => Promise<unknown> }>
+      await tools.selected!.execute({ value: 1 })
+      return { text: "ok" }
+    })
+    const agent = defineAgent({
+      capabilities: [defineCapability({
+        id: "selected",
+        tools: { selected: { execute: (input: unknown) => input, name: "selected" } },
+      })],
+      driver: { harness: { provider: "codex" } },
+    })
+
+    await runAgent(agent, { memo: vi.fn(), runtime: "unknown", toolStepReporter, waitUntil: vi.fn() }, { prompt: "hello" })
+
+    expect(toolStepReporter).toHaveBeenCalledTimes(2)
+    expect(toolStepReporter.mock.calls.filter(([step]) => step.toolResults?.length)).toHaveLength(1)
+  })
+
   it("rejects definition-time contributions from invocation-resolved Capabilities", async () => {
     const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
     const agent = defineAgent({
@@ -12387,6 +12410,26 @@ describe("agent message protocol", () => {
 
       expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "Please try again." })
       expect(postMessage).toHaveBeenCalledOnce()
+    })
+
+    it("bounds durable error fallback callbacks", async () => {
+      vi.useFakeTimers()
+      const { resolveDurableChatErrorFallbackText } = await import("../src/chat-trigger.ts")
+      const resolution = resolveDurableChatErrorFallbackText({
+        errorFallbackText: () => new Promise(() => undefined),
+        timeout: 10,
+      }, {
+        error: new Error("provider failed"),
+        history: [],
+        message: { text: "hello" },
+        publicError: { code: "INTERNAL", error: "Internal error" },
+        thread: { post: async () => undefined },
+        toolResults: [],
+      })
+
+      await vi.advanceTimersByTimeAsync(10)
+      await expect(resolution).resolves.toBe("Sorry, I couldn't process that message.")
+      vi.useRealTimers()
     })
 
     it.each([

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12364,7 +12364,12 @@ describe("agent message protocol", () => {
           }),
         },
         driver: { run: async () => ({ text: "unreachable" }) },
-        messages: { errorFallbackText: "Please try again." },
+        messages: {
+          errorFallbackText: async ({ thread }) => {
+            await thread.post("Please try again.")
+            return "Do not duplicate the posted fallback."
+          },
+        },
       })
 
       await expect(runAgentWorkflowDefinition(agent, {
@@ -12381,6 +12386,7 @@ describe("agent message protocol", () => {
       }, runAgentInline)).rejects.toBe(failure)
 
       expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "Please try again." })
+      expect(postMessage).toHaveBeenCalledOnce()
     })
 
     it.each([
@@ -12391,6 +12397,19 @@ describe("agent message protocol", () => {
 
       await expect(runAgentWorkflowDefinition({} as never, {
         id: "terminal-agent-failure",
+        name: "agent",
+        payload: {},
+        provider: "cloudflare",
+      }, async () => { throw failure })).rejects.toMatchObject({ isRetryable: false })
+    })
+
+    it("preserves permanent failure classification through finish failures", async () => {
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const providerFailure = Object.assign(new Error("invalid provider request"), { name: "AI_APICallError", statusCode: 400 })
+      const failure = new AggregateError([providerFailure, new Error("fallback delivery failed")])
+
+      await expect(runAgentWorkflowDefinition({} as never, {
+        id: "terminal-aggregate-failure",
         name: "agent",
         payload: {},
         provider: "cloudflare",

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12448,7 +12448,7 @@ describe("agent message protocol", () => {
           }),
         },
         driver: { run: ({ tools }) => (async function* () {
-          await tools!.save_meal!.execute!({ calories: 240 }, { toolCallId: "save-1" } as never)
+          await tools!.save_meal!.execute!({ calories: 240 }, { toolCallId: "save-1" })
           yield { id: "save-1", name: "save_meal", output: { id: "meal-1" }, type: "tool-result" }
           yield { id: "save-1", name: "save_meal", output: { id: "meal-1" }, type: "tool-result" }
           throw new Error("UI stream failed")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12529,6 +12529,60 @@ describe("agent message protocol", () => {
       }
     })
 
+    it("bounds durable Agent error hooks", async () => {
+      vi.useFakeTimers()
+      try {
+        const { defineAgent, runAgentInline } = await import("../src/index.ts")
+        const { telegram } = await import("../src/channels.ts")
+        const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+        const failure = new Error("provider failed")
+        const postMessage = vi.fn(async () => undefined)
+        const errorHook = vi.fn(() => new Promise<void>(() => undefined))
+        const agent = defineAgent({
+          channels: {
+            telegram: telegram({
+              adapter: () => ({
+                channelIdFromThreadId: () => "telegram:123",
+                postMessage,
+              }) as never,
+            }),
+          },
+          driver: { run: async () => { throw failure } },
+          hooks: { "agent:error": errorHook },
+          messages: { errorFallbackText: "Please try again.", timeout: 10 },
+        })
+
+        const result = runAgentWorkflowDefinition(agent, {
+          id: "stalled-error-hook",
+          name: "failure",
+          payload: {
+            input: {
+              context: { channel: { message: { text: "Hello" } } },
+              prompt: "Hello",
+            },
+            run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
+          },
+          provider: "cloudflare",
+        }, runAgentInline).catch(error => error)
+
+        await vi.waitFor(() => expect(postMessage).toHaveBeenCalledOnce())
+        await vi.waitFor(() => expect(errorHook).toHaveBeenCalledOnce())
+        await vi.advanceTimersByTimeAsync(10)
+        const error = await result
+        expect(error).toBeInstanceOf(AggregateError)
+        if (!(error instanceof AggregateError)) throw error
+        expect(error.errors).toContain(failure)
+        expect(error.errors).toContainEqual(expect.objectContaining({
+          isRetryable: false,
+          message: "Durable chat error fallback delivery timed out after 10ms.",
+        }))
+        expect(error).toMatchObject({ isRetryable: false })
+      }
+      finally {
+        vi.useRealTimers()
+      }
+    })
+
     it("delivers durable fallbacks before a stalled title effect and bounds the complete finish path", async () => {
       vi.useFakeTimers()
       try {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12529,6 +12529,66 @@ describe("agent message protocol", () => {
       }
     })
 
+    it("delivers durable fallbacks before a stalled title effect and bounds the complete finish path", async () => {
+      vi.useFakeTimers()
+      try {
+        const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
+        const { defineFinishEffect, telegram } = await import("../src/channels.ts")
+        const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+        const failure = new Error("provider failed")
+        const postMessage = vi.fn(async () => undefined)
+        const setThreadTitle = vi.fn(() => new Promise(() => undefined))
+        const agent = defineAgent({
+          capabilities: [defineCapability({
+            id: "thread-title",
+            prepare(context) {
+              const effect = defineFinishEffect(() => ({ kind: "title", payload: { title: "Prepared title" } }))
+              effect.kind = "title"
+              context.delivery.finishEffect(effect)
+            },
+          })],
+          channels: {
+            telegram: telegram({
+              adapter: () => ({
+                channelIdFromThreadId: () => "telegram:123",
+                postMessage,
+                setThreadTitle,
+              }) as never,
+            }),
+          },
+          driver: { run: async () => { throw failure } },
+          messages: { errorFallbackText: "Please try again.", timeout: 10 },
+        })
+
+        const result = runAgentWorkflowDefinition(agent, {
+          id: "stalled-title-before-fallback",
+          name: "failure",
+          payload: {
+            input: {
+              context: { channel: { message: { text: "Hello" } } },
+              messages: [createMessage({ role: "user", text: "Hello" })],
+              prompt: "Hello",
+            },
+            run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
+          },
+          provider: "cloudflare",
+        }, runAgentInline).catch(error => error)
+
+        await vi.waitFor(() => expect(postMessage).toHaveBeenCalledOnce())
+        expect(setThreadTitle).toHaveBeenCalledOnce()
+        await vi.advanceTimersByTimeAsync(10)
+        const error = await result
+        expect(error).toBeInstanceOf(AggregateError)
+        if (!(error instanceof AggregateError)) throw error
+        expect(error.errors).toContain(failure)
+        expect(error.errors).toContainEqual(expect.objectContaining({ message: "Durable chat error fallback delivery timed out after 10ms." }))
+        expect(error).toMatchObject({ isRetryable: false })
+      }
+      finally {
+        vi.useRealTimers()
+      }
+    })
+
     it("delivers durable failure fallbacks when Capability setup fails", async () => {
       const { defineAgent, runAgentInline } = await import("../src/index.ts")
       const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12589,6 +12589,58 @@ describe("agent message protocol", () => {
       }
     })
 
+    it("starts the durable failure deadline before title-support adapter resolution", async () => {
+      vi.useFakeTimers()
+      try {
+        const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
+        const { defineFinishEffect, telegram } = await import("../src/channels.ts")
+        const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+        const failure = new Error("provider failed")
+        const adapter = vi.fn(() => new Promise(() => undefined) as never)
+        const agent = defineAgent({
+          capabilities: [defineCapability({
+            id: "thread-title",
+            prepare(context) {
+              const effect = defineFinishEffect(() => ({ kind: "title", payload: { title: "Prepared title" } }))
+              effect.kind = "title"
+              context.delivery.finishEffect(effect)
+            },
+          })],
+          channels: {
+            telegram: telegram({ adapter }),
+          },
+          driver: { run: async () => { throw failure } },
+          messages: { errorFallbackText: "Please try again.", timeout: 10 },
+        })
+
+        const result = runAgentWorkflowDefinition(agent, {
+          id: "stalled-title-adapter-resolution",
+          name: "failure",
+          payload: {
+            input: {
+              context: { channel: { message: { text: "Hello" } } },
+              messages: [createMessage({ role: "user", text: "Hello" })],
+              prompt: "Hello",
+            },
+            run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
+          },
+          provider: "cloudflare",
+        }, runAgentInline).catch(error => error)
+
+        await vi.waitFor(() => expect(adapter).toHaveBeenCalledOnce())
+        await vi.advanceTimersByTimeAsync(10)
+        const error = await result
+        expect(error).toBeInstanceOf(AggregateError)
+        if (!(error instanceof AggregateError)) throw error
+        expect(error.errors).toContain(failure)
+        expect(error.errors).toContainEqual(expect.objectContaining({ message: "Durable chat error fallback delivery timed out after 10ms." }))
+        expect(error).toMatchObject({ isRetryable: false })
+      }
+      finally {
+        vi.useRealTimers()
+      }
+    })
+
     it("delivers durable failure fallbacks when Capability setup fails", async () => {
       const { defineAgent, runAgentInline } = await import("../src/index.ts")
       const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12737,6 +12737,54 @@ describe("agent message protocol", () => {
       }
     })
 
+    it("does not apply fallback deadlines when durable error fallbacks are disabled", async () => {
+      vi.useFakeTimers()
+      try {
+        const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
+        const { telegram } = await import("../src/channels.ts")
+        const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+        const failure = new Error("provider failed")
+        let releaseExtension!: () => void
+        const finishExtension = vi.fn(() => new Promise<{ ready: true }>((resolve) => {
+          releaseExtension = () => resolve({ ready: true })
+        }))
+        const settled = vi.fn()
+        const agent = defineAgent({
+          capabilities: [defineCapability({
+            id: "slow-finish-extension",
+            prepare(context) {
+              context.finish.provide(finishExtension)
+            },
+          })],
+          channels: { telegram: telegram({ adapter: vi.fn() as never }) },
+          driver: { run: async () => { throw failure } },
+          messages: { errorFallbackText: null, timeout: 10 },
+        })
+
+        const result = runAgentWorkflowDefinition(agent, {
+          id: "disabled-error-fallback",
+          name: "failure",
+          payload: {
+            input: { context: { channel: { message: { text: "Hello" } } }, prompt: "Hello" },
+            run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
+          },
+          provider: "cloudflare",
+        }, runAgentInline).catch(error => error).then((error) => {
+          settled()
+          return error
+        })
+
+        await vi.waitFor(() => expect(finishExtension).toHaveBeenCalledOnce())
+        await vi.advanceTimersByTimeAsync(10)
+        expect(settled).not.toHaveBeenCalled()
+        releaseExtension()
+        expect(await result).toBe(failure)
+      }
+      finally {
+        vi.useRealTimers()
+      }
+    })
+
     it("delivers durable failure fallbacks when Capability setup fails", async () => {
       const { defineAgent, runAgentInline } = await import("../src/index.ts")
       const { telegram } = await import("../src/channels.ts")

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -450,7 +450,7 @@ function renderAgentWorkflowRegistryEntry(registryFile: string, definition: Disc
     "    if (cached) return cached",
     `    const loaded = await ${renderRegistryImport(registryFile, definition.handler)}`,
     `    const agent = agentWithColocatedHome(agentWithColocatedSkills(workspaceAgentWithSourceRoot(agentWithColocatedInstructions("default" in loaded ? loaded.default : loaded, ${JSON.stringify(readAgentInstructions(definition.handler))}), ${JSON.stringify(resolveAgentWorkspaceSourceRoot(definition.handler))}, ${JSON.stringify(readAgentInstructions(definition.handler))}), ${JSON.stringify(readAgentSkills(definition.handler))}), ${JSON.stringify(readAgentHome(definition.handler))})`,
-    `    const entry = { handler: async (context) => await runAgentWorkflowDefinition(agent, { ...context, payload: { ...context.payload, agentIdentity: context.payload?.agentIdentity || { name: ${JSON.stringify(definition.agentIdentity || definition.name)} } } }, runAgentInline) }`,
+    `    const entry = { options: { rootStep: false }, handler: async (context) => await runAgentWorkflowDefinition(agent, { ...context, payload: { ...context.payload, agentIdentity: context.payload?.agentIdentity || { name: ${JSON.stringify(definition.agentIdentity || definition.name)} } } }, runAgentInline) }`,
     `    registryEntryCache.set(${JSON.stringify(definition.name)}, entry)`,
     "    return entry",
     "  },",

--- a/packages/workflow/src/runtime/client.ts
+++ b/packages/workflow/src/runtime/client.ts
@@ -103,7 +103,10 @@ export function createWorkflow<TPayload = unknown, TResult = unknown>(
     if (typeof handler !== "function") {
       throw new TypeError("`createWorkflow()` requires a workflow handler.")
     }
-    registerInlineWorkflowDefinition(name, { handler: handler as WorkflowHandler })
+    registerInlineWorkflowDefinition(name, {
+      handler: handler as WorkflowHandler,
+      ...(createOptions.rootStep === undefined ? {} : { options: { rootStep: createOptions.rootStep } }),
+    })
     return {
       cancel: (id: string) => cancelWorkflow<TPayload, TResult>(name, id),
       name,
@@ -137,7 +140,10 @@ export function createWorkflow<TPayload = unknown, TResult = unknown>(
     if (typeof handler !== "function") {
       throw new TypeError("`createWorkflow()` requires a workflow handler.")
     }
-    registerInlineWorkflowDefinition(name, { handler: handler as WorkflowHandler })
+    registerInlineWorkflowDefinition(name, {
+      handler: handler as WorkflowHandler,
+      ...(createOptions?.rootStep === undefined ? {} : { options: { rootStep: createOptions.rootStep } }),
+    })
   }
   else if (handlerOrOptions !== undefined && (typeof handlerOrOptions !== "object" || handlerOrOptions === null)) {
     throw new TypeError("`createWorkflow()` options must be an object.")

--- a/packages/workflow/src/types.ts
+++ b/packages/workflow/src/types.ts
@@ -154,6 +154,7 @@ export interface WorkflowCreateOptions<TPayload = unknown, TResult = unknown> {
   handler?: WorkflowHandler<TPayload, TResult>
   id?: (context: { name: string, payload?: TPayload }) => Promise<WorkflowRunIdValue> | WorkflowRunIdValue
   name?: string
+  rootStep?: boolean
 }
 
 export interface WorkflowDefinitionOptions<TPayload = unknown, TResult = unknown> {

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -676,6 +676,44 @@ describe("workflow runtime", () => {
     expect(stepDo.mock.calls.map(call => call[0])).toEqual(["pipeline/01.first", "pipeline/02.second"])
   })
 
+  it("does not replay a root handler after a completed write", async () => {
+    const transient = Object.assign(new Error("provider unavailable"), {
+      name: "AI_APICallError",
+      statusCode: 503,
+    })
+    let writes = 0
+    const stepDo = vi.fn(async (_name: string, _options: unknown, run: () => Promise<unknown>) => {
+      for (let attempt = 0; attempt < 4; attempt++) {
+        try {
+          return await run()
+        }
+        catch (error) {
+          if (attempt === 3) throw error
+        }
+      }
+    })
+
+    await expect(runCloudflareWorkflow({
+      config: { provider: "cloudflare" },
+      env: {},
+      event: { id: "run-after-write" },
+      name: "agent",
+      registry: {
+        agent: async () => {
+          createWorkflow("agent", async () => {
+            writes += 1
+            throw transient
+          }, { rootStep: false })
+          return { default: takeInlineWorkflowDefinition("agent")! }
+        },
+      },
+      step: { do: stepDo } as WorkflowProviderStep,
+    })).rejects.toBe(transient)
+
+    expect(writes).toBe(1)
+    expect(stepDo).not.toHaveBeenCalled()
+  })
+
   it("runs inline folder workflows through generated step wrappers", async () => {
     const stepDo = vi.fn(async (_name: string, _options: unknown, run: () => unknown) => await run())
     const step = { do: stepDo } as WorkflowProviderStep

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -206,6 +206,7 @@ describe("Vite workflow provider outputs", () => {
     expect(cloudflareWorkerBundleContents).not.toMatch(/\b(?:from\s*|import\s*\(\s*)["']@vite-hub\/workspace(?:\/[^"']*)?["']/)
     const registry = await readFile(join(rootDir, ".vitehub", "workflow", "registry.mjs"), "utf8")
     expect(registry).toContain("runAgentWorkflowDefinition")
+    expect(registry).toContain("options: { rootStep: false }")
     expect(registry).toContain('agentIdentity: context.payload?.agentIdentity || { name: "nuxt" }')
     expect(registry).toContain("workspaceAgentWithSourceRoot")
     expect(registry).toContain("agentWithColocatedSkills")


### PR DESCRIPTION
Durable Agent Workflow failures could leave the originating channel silent after Workflow custody, while the default Cloudflare root step could replay the entire Agent invocation after a completed write.

This makes failure handling part of the Agent runtime contract: workflow-origin failures reuse `messages.errorFallbackText`, completed capability tool results—including normalized generic and UI-message streamed results—are available to that policy without duplicates, and existing channel reply effects perform delivery. The Workflow boundary is tracked independently from the originating channel, failures during Agent setup are delivered after custody even before Capability outputs exist (including capacity-limited Agents), fallback callbacks are bounded, cleanup-only and combined cleanup failures do not suppress delivery or lose lifecycle errors, and terminal retry classification survives combined lifecycle failures. Inline chat errors keep their current route-owned behavior.

Agent Workflows now register with `rootStep: false`, so Cloudflare cannot replay the opaque Agent invocation. Provider/model retries remain owned by the inner driver; permanent provider 4xx/auth/quota failures, exhausted provider retries, and exhausted structured-output validation are marked non-retryable. Provider tool-call identities are preserved so reporter and stream copies correlate, while Harness tool reporting remains single-owned.

## Verification

- `@vite-hub/agent` runtime suite: 421 tests passed
- `@vite-hub/agent` provider suite: 281 tests passed
- `@vite-hub/workflow` suite: 125 tests passed
- `@vite-hub/agent` and `@vite-hub/workflow` typecheck passed
- `@vite-hub/agent` and `@vite-hub/workflow` builds passed
- affected lint passed with no errors (two existing warnings)
- `git diff --check` passed

