### PR TITLE
fix(agent): repair invalid structured output

### DIFF
--- a/docs/content/docs/agents/agent-definitions.md
+++ b/docs/content/docs/agents/agent-definitions.md
@@ -87,7 +87,7 @@ export default defineAgent({
 
 Inline `runAgent()` execution returns the validated structured result. A schema failure fails the invocation instead of returning unchecked model output. Workflow-backed calls return an `AgentWorkflowRun` after the Workflow starts. Poll `getWorkflowRun(workflowName, run.id)` until its status is `completed`, then read `result` for the validated Agent value. Treat `failed`, `cancelled`, and `unknown` as terminal states instead of waiting indefinitely.
 
-When a model returns invalid native structured output, the Agent Driver makes one output-only correction call before failing validation. The correction keeps the invocation's prepared model and provider route, but it does not replay conversation messages or expose tools, so completed tool effects cannot run again. Tool results remain available as bounded evidence for the corrected output. Usage records include both model calls, with per-call attribution and aggregate token and cost totals.
+When a model returns invalid native structured output, the Agent Driver makes one output-only correction call before failing validation. The correction keeps the invocation's prepared model and provider route, but it does not replay conversation messages or expose tools, so completed tool effects cannot run again. Tool results remain available as bounded evidence for the corrected output. Usage records include both model calls, with per-call attribution, aggregate token totals, and aggregate cost when provider metadata or configured pricing supplies it.
 
 ## Choose hosted execution
 

--- a/docs/content/docs/agents/agent-definitions.md
+++ b/docs/content/docs/agents/agent-definitions.md
@@ -87,6 +87,8 @@ export default defineAgent({
 
 Inline `runAgent()` execution returns the validated structured result. A schema failure fails the invocation instead of returning unchecked model output. Workflow-backed calls return an `AgentWorkflowRun` after the Workflow starts. Poll `getWorkflowRun(workflowName, run.id)` until its status is `completed`, then read `result` for the validated Agent value. Treat `failed`, `cancelled`, and `unknown` as terminal states instead of waiting indefinitely.
 
+When a model returns invalid native structured output, the Agent Driver makes one output-only correction call before failing validation. The correction keeps the invocation's prepared model and provider route, but it does not replay conversation messages or expose tools, so completed tool effects cannot run again. Tool results remain available as bounded evidence for the corrected output. Usage records include both model calls, with per-call attribution and aggregate token and cost totals.
+
 ## Choose hosted execution
 
 Discovered Agents use the active host's Workflow integration by default. Set `runtime: false` when a hosted Agent must complete inline, or select a named Workflow identity with `runtime: workflow('support')`.

--- a/packages/agent/src/agent-output.ts
+++ b/packages/agent/src/agent-output.ts
@@ -166,7 +166,7 @@ export function toAgentRunResult(value: unknown): AgentRunResult {
 
 function isUsageRecord(value: unknown): value is AgentUsageRecord {
   if (!isRecord(value)) return false
-  return ["cost", "credentialSource", "latency", "model", "raw", "response", "run", "transport", "usage"].some(key => key in value)
+  return ["calls", "cost", "credentialSource", "latency", "model", "raw", "response", "run", "transport", "usage"].some(key => key in value)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -337,19 +337,20 @@ function withFallbackUsageMetadata(
   fallbackMetadataSource: unknown,
   run?: Partial<AgentRunMetadata>,
 ): AgentUsageRecord {
+  const compound = Boolean(record.calls?.length)
   const modelMetadata = modelMetadataFromResult(fallbackMetadataSource)
-  const model = record.model ?? modelMetadata?.model
-  const transport = record.transport ?? modelMetadata?.transport
-  let cost = providerCostFromResult(fallbackMetadataSource)
+  const model = record.model ?? (compound ? undefined : modelMetadata?.model)
+  const transport = record.transport ?? (compound ? undefined : modelMetadata?.transport)
+  let cost = compound ? undefined : providerCostFromResult(fallbackMetadataSource)
   try {
     if (record.cost) cost = materializeAgentUsageCost(record.cost)
   }
   catch {
-    cost = providerCostFromResult(fallbackMetadataSource)
+    cost = compound ? undefined : providerCostFromResult(fallbackMetadataSource)
   }
-  const response = record.response ?? responseFromResult(fallbackMetadataSource)
-  const latency = record.latency ?? latencyFromResult(fallbackMetadataSource)
-  const credentialSource = record.credentialSource ?? credentialSourceFromMetadata(readAgentUsageMetadata(record, fallbackMetadataSource))
+  const response = record.response ?? (compound ? undefined : responseFromResult(fallbackMetadataSource))
+  const latency = record.latency ?? (compound ? undefined : latencyFromResult(fallbackMetadataSource))
+  const credentialSource = record.credentialSource ?? (compound ? undefined : credentialSourceFromMetadata(readAgentUsageMetadata(record, fallbackMetadataSource)))
   const runMetadata = record.run ?? run
   return model || transport || cost || response || latency || credentialSource || runMetadata
     ? {

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -11,7 +11,7 @@ import {
 } from "./capability-runtime.ts"
 import { agentInvocationCallbackContextValues } from "./invocation-context.ts"
 import { composeInstructionDocument } from "./instruction-composition.ts"
-import { agentOutputInstructions, agentOutputJsonSchema, normalizeNativeAgentOutputError } from "./internal/agent-structured-output.ts"
+import { agentOutputInstructions, agentOutputJsonSchema, nativeAgentOutputValidationFailure, normalizeNativeAgentOutputError, validateAgentOutput } from "./internal/agent-structured-output.ts"
 import { synthesizedAgentOutputSymbol } from "./internal/synthesized-agent-output.ts"
 import { getModelCallSettings } from "./internal/model-call-settings.ts"
 import { materializeAgentModel } from "./internal/agent-model.ts"
@@ -1044,6 +1044,34 @@ function mergeCallSettings(
   return settings
 }
 
+function withoutToolCallSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  const {
+    activeTools: _activeTools,
+    experimental_refineToolInput: _experimentalRefineToolInput,
+    experimental_repairToolCall: _experimentalRepairToolCall,
+    onToolExecutionEnd: _onToolExecutionEnd,
+    onToolExecutionStart: _onToolExecutionStart,
+    prepareStep: _prepareStep,
+    repairToolCall: _repairToolCall,
+    toolApproval: _toolApproval,
+    toolChoice: _toolChoice,
+    toolOrder: _toolOrder,
+    tools: _tools,
+    ...rest
+  } = settings
+  return rest
+}
+
+function outputRepairPrompt(text: string, error: Error): string {
+  const cause = error.cause instanceof Error ? error.cause.message : undefined
+  return [
+    "Correct the invalid final Agent output below.",
+    "Return only the corrected JSON value. Do not repeat completed work.",
+    `Validation error: ${cause || error.message}`,
+    `Invalid output: ${JSON.stringify(text)}`,
+  ].join("\n\n")
+}
+
 async function createAgent(
   options: AiSdkAdapterOptions,
   context: AgentAdapterRunContext,
@@ -1114,19 +1142,39 @@ async function createAgent(
   const settings = instrumentedCallSettings ? { ...baseCallSettings, ...instrumentedCallSettings } : baseCallSettings
   const convertedOutputSchema = context.output && context.nativeStructuredOutput !== false ? agentOutputJsonSchema(context.output.schema) : undefined
   const outputSchema = convertedOutputSchema?.type === "object" ? convertedOutputSchema : undefined
+  const nativeOutput = outputSchema ? aiSdk.Output.object({ schema: jsonSchema(outputSchema) }) : undefined
+  const commonSettings = withRuntimeContext(withViteHubTelemetry(settings, context), context)
+  const repairOutput = nativeOutput && context.output
+    ? async (failure: { error: Error, text: string }, callInput: Record<string, unknown>): Promise<AgentAdapterResult> => {
+        const { messages: _messages, options: _options, prompt: _prompt, ...repairCallInput } = callInput
+        try {
+          return await aiSdk.generateText({
+            ...withoutToolCallSettings(commonSettings),
+            ...repairCallInput,
+            instructions,
+            model: instrumentedModel as never,
+            output: nativeOutput,
+            prompt: outputRepairPrompt(failure.text, failure.error),
+            stopWhen: isStepCount(1),
+          } as never) as unknown as AgentAdapterResult
+        }
+        catch (repairError) {
+          return await normalizeNativeAgentOutputError(context.output, repairError)
+        }
+      }
+    : undefined
 
   return {
     agent: new ToolLoopAgent({
-      ...withRuntimeContext(withViteHubTelemetry(settings, context), context),
+      ...commonSettings,
       instructions,
       model: instrumentedModel as never,
-      ...(outputSchema
-        ? { output: aiSdk.Output.object({ schema: jsonSchema(outputSchema) }) }
-        : {}),
+      ...(nativeOutput ? { output: nativeOutput } : {}),
       stopWhen: ((settings as Record<string, unknown>).stopWhen ?? isStepCount(stepLimit ?? 20)) as never,
       ...(Object.keys(toolSet).length ? { tools: toolSet as never } : {}),
     }),
     model: instrumentedModel,
+    repairOutput,
     tools: Object.keys(toolSet).length ? toolSet : undefined,
   }
 }
@@ -1143,22 +1191,40 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       const fallbackCapture = fallback.enabled
         ? createWorkspaceFallbackEvidenceCapture(fallback.maxToolResults)
         : undefined
-      const { agent, model, tools } = await createAgent(options, context, fallbackCapture)
+      const { agent, model, repairOutput, tools } = await createAgent(options, context, fallbackCapture)
       if (context.workspace && tools && "materialize_sources" in tools) {
         await reportWorkspaceMaterialization(tools as AgentToolSet, context.toolStepReporter)
       }
       const usageCapture = createUsageCapture()
+      const repairCallInput = {
+        ...callInput,
+        onEnd: usageCapture.onEnd,
+        onLanguageModelCallEnd: usageCapture.onLanguageModelCallEnd,
+        onStepEnd: usageCapture.onStepEnd,
+      }
       let generated: GenerateTextResult<ToolSet, never, never>
+      let repaired = false
       try {
-        generated = await agent.generate({
-          ...callInput,
-          onEnd: usageCapture.onEnd,
-          onLanguageModelCallEnd: usageCapture.onLanguageModelCallEnd,
-          onStepEnd: usageCapture.onStepEnd,
-        } as never) as GenerateTextResult<ToolSet, never, never>
+        generated = await agent.generate(repairCallInput as never) as GenerateTextResult<ToolSet, never, never>
       }
       catch (error) {
-        return await normalizeNativeAgentOutputError(context.output, error)
+        const failure = await nativeAgentOutputValidationFailure(context.output, error)
+        const repairedOutput = failure && repairOutput
+          ? await repairOutput(failure, repairCallInput) as GenerateTextResult<ToolSet, never, never>
+          : undefined
+        generated = repairedOutput ?? await normalizeNativeAgentOutputError(context.output, error)
+        repaired = Boolean(repairedOutput)
+      }
+      if (!repaired && repairOutput && context.output) {
+        try {
+          await validateAgentOutput(context.output, generated)
+        }
+        catch (error) {
+          generated = await repairOutput({
+            error: error instanceof Error ? error : new Error(String(error)),
+            text: generated.text,
+          }, repairCallInput) as GenerateTextResult<ToolSet, never, never>
+        }
       }
       const result = withResolvedModelMetadata(withCapturedUsage(generated, usageCapture), model) as GenerateTextResult<ToolSet, never, never>
       const text = result.text.trim()

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1305,14 +1305,14 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       let generated: GenerateTextResult<ToolSet, never, never>
       let originalGenerated: GenerateTextResult<ToolSet, never, never> | undefined
       let repaired = false
-      const synthesizedOutput = async (synthesized: { result: unknown, text: string }, original?: unknown) => {
+      const synthesizedOutput = async (synthesized: { result: unknown, text: string }, original?: unknown, repairResult?: unknown) => {
         const captures = [usageCapture, repairUsageCapture, fallbackUsageCapture]
         const raw = withCapturedUsage(original, captures)
         let usageRecord: AgentUsageRecord | undefined
         if (raw && typeof raw === "object" && fallbackUsageCapture.captured) {
           const calls = [
             { capture: usageCapture, result: originalGenerated ?? original },
-            ...(repairUsageCapture.captured ? [{ capture: repairUsageCapture, result: original }] : []),
+            ...(repairUsageCapture.captured ? [{ capture: repairUsageCapture, result: repairResult }] : []),
             { capture: fallbackUsageCapture, result: synthesized.result },
           ]
           usageRecord = await combinedUsageRecord(calls, combinedCapturedUsage(captures))
@@ -1333,6 +1333,21 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
         Object.defineProperty(output, synthesizedAgentOutputSymbol, { value: true })
         return output
       }
+      const validatedSynthesizedOutput = async (synthesized: { result: unknown, text: string }, original?: unknown) => {
+        if (!repairOutput || !context.output) return await synthesizedOutput(synthesized, original)
+        try {
+          await validateAgentOutput(context.output, synthesized.result)
+          return await synthesizedOutput(synthesized, original)
+        }
+        catch (error) {
+          const repairResult = await repairOutput({
+            error: error instanceof Error ? error : new Error(String(error)),
+            evidence: fallbackCapture?.evidence(),
+            text: synthesized.text,
+          }, repairCallInput) as GenerateTextResult<ToolSet, never, never>
+          return await synthesizedOutput({ ...synthesized, text: repairResult.text }, original, repairResult)
+        }
+      }
       try {
         generated = await agent.generate(originalCallInput as never) as GenerateTextResult<ToolSet, never, never>
         originalGenerated = generated
@@ -1342,7 +1357,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
         const synthesized = failure && fallback.enabled && !failure.text.trim()
           ? await synthesizeWorkspaceFallbackFromEvidence(model as never, context, fallbackCapture?.evidence() ?? [], fallbackUsageCapture)
           : undefined
-        if (synthesized) return await synthesizedOutput(synthesized)
+        if (synthesized) return await validatedSynthesizedOutput(synthesized)
         const repairedOutput = failure && repairOutput
           ? await repairOutput({ ...failure, evidence: fallbackCapture?.evidence() }, repairCallInput) as GenerateTextResult<ToolSet, never, never>
           : undefined
@@ -1352,7 +1367,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       if (!repaired && fallback.enabled && (generated.finishReason === "tool-calls" || !generated.text.trim() && hasToolResults(generated))) {
         const synthesized = await synthesizeWorkspaceFallback(model as never, context, generated, fallback.maxToolResults, fallbackUsageCapture)
           ?? await synthesizeWorkspaceFallbackFromEvidence(model as never, context, fallbackCapture?.evidence() ?? [], fallbackUsageCapture)
-        if (synthesized) return await synthesizedOutput(synthesized, generated)
+        if (synthesized) return await validatedSynthesizedOutput(synthesized, generated)
       }
       if (!repaired && repairOutput && context.output) {
         try {
@@ -1384,7 +1399,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       if (fallback.enabled && (result.finishReason === "tool-calls" || !text && hasToolResults(result))) {
         const synthesized = await synthesizeWorkspaceFallback(model as never, context, result, fallback.maxToolResults, fallbackUsageCapture)
           ?? await synthesizeWorkspaceFallbackFromEvidence(model as never, context, fallbackCapture?.evidence() ?? [], fallbackUsageCapture)
-        if (synthesized) return await synthesizedOutput(synthesized, result)
+        if (synthesized) return await validatedSynthesizedOutput(synthesized, result)
       }
       if (text) return result as unknown as AgentAdapterResult
 

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -519,6 +519,7 @@ async function synthesizeWorkspaceFallbackFromEvidence(
     instructions: [
       "Answer the user's last message using only the workspace tool results.",
       "If the tool results are insufficient, say what is missing.",
+      agentOutputInstructions(context.output),
       resolveMessageChannelInstructions(context.context, context),
     ].filter(Boolean).join("\n"),
     model,

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -13,6 +13,7 @@ import { agentInvocationCallbackContextValues } from "./invocation-context.ts"
 import { composeInstructionDocument } from "./instruction-composition.ts"
 import { agentOutputInstructions, agentOutputJsonSchema, nativeAgentOutputValidationFailure, normalizeNativeAgentOutputError, validateAgentOutput } from "./internal/agent-structured-output.ts"
 import { synthesizedAgentOutputSymbol } from "./internal/synthesized-agent-output.ts"
+import { resolveAgentUsageRecord } from "./agent-output.ts"
 import { getModelCallSettings } from "./internal/model-call-settings.ts"
 import { materializeAgentModel } from "./internal/agent-model.ts"
 import {
@@ -55,6 +56,7 @@ import type {
   AgentModelInstrumentationContext,
   AgentRuntimeConfig,
   AgentToolSet,
+  AgentUsageRecord,
   AgentToolResolverWithWorkspace,
   MaybePromise,
 } from "./types.ts"
@@ -842,12 +844,14 @@ function withRuntimeContext(settings: Record<string, unknown>, context: AgentAda
 function createUsageCapture() {
   let captured = false
   let capturedUsage: unknown
+  let metadataSource: unknown
 
   const capture = (event: unknown) => {
     const record = typeof event === "object" && event !== null ? event as { totalUsage?: unknown, usage?: unknown } : undefined
     const usage = record?.usage ?? record?.totalUsage
     if (usage === undefined) return
     capturedUsage = usage
+    metadataSource = event
     captured = true
   }
 
@@ -866,6 +870,9 @@ function createUsageCapture() {
     },
     get usage() {
       return captured ? Promise.resolve(capturedUsage) : undefined
+    },
+    get usageSource() {
+      return captured ? { ...(metadataSource as Record<string, unknown>), usage: capturedUsage } : undefined
     },
   }
 }
@@ -919,6 +926,28 @@ function withCapturedUsage(result: unknown, captures: ReturnType<typeof createUs
     raw: result,
     text: typeof result === "string" ? result : undefined,
     usage,
+  }
+}
+
+async function combinedUsageRecord(
+  calls: Array<{ capture: ReturnType<typeof createUsageCapture>, result?: unknown }>,
+  usage: unknown,
+): Promise<AgentUsageRecord | undefined> {
+  const records = (await Promise.all(calls.map(({ capture, result }) => resolveAgentUsageRecord(
+    result === undefined ? capture.usageSource : withCapturedUsage(result, capture),
+  )))).filter((record): record is AgentUsageRecord => Boolean(record))
+  if (!records.length) return
+  if (records.length === 1) return records[0]
+  const shared = <K extends "credentialSource" | "model" | "transport">(key: K): AgentUsageRecord[K] | undefined => {
+    const value = records[0]![key]
+    return records.every(record => JSON.stringify(record[key]) === JSON.stringify(value)) ? value : undefined
+  }
+  return {
+    calls: records,
+    ...(shared("credentialSource") ? { credentialSource: shared("credentialSource") } : {}),
+    ...(shared("model") ? { model: shared("model") } : {}),
+    ...(shared("transport") ? { transport: shared("transport") } : {}),
+    usage: await usage as AgentUsageRecord["usage"],
   }
 }
 
@@ -1240,9 +1269,11 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
         onStepEnd: usageCapture.onStepEnd,
       }
       let generated: GenerateTextResult<ToolSet, never, never>
+      let originalGenerated: GenerateTextResult<ToolSet, never, never> | undefined
       let repaired = false
       try {
         generated = await agent.generate(originalCallInput as never) as GenerateTextResult<ToolSet, never, never>
+        originalGenerated = generated
       }
       catch (error) {
         const failure = await nativeAgentOutputValidationFailure(context.output, error)
@@ -1272,7 +1303,20 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
           }, repairCallInput) as GenerateTextResult<ToolSet, never, never>
         }
       }
+      const usageRecord = repairUsageCapture.captured
+        ? await combinedUsageRecord([
+            { capture: usageCapture, result: originalGenerated },
+            { capture: repairUsageCapture, result: generated },
+          ], combinedCapturedUsage([usageCapture, repairUsageCapture]))
+        : undefined
       const result = withResolvedModelMetadata(withCapturedUsage(generated, [usageCapture, repairUsageCapture]), model) as GenerateTextResult<ToolSet, never, never>
+      if (usageRecord) {
+        Object.defineProperty(result, "usageRecord", {
+          configurable: true,
+          enumerable: true,
+          value: usageRecord,
+        })
+      }
       const text = result.text.trim()
       if (fallback.enabled && (result.finishReason === "tool-calls" || !text && hasToolResults(result))) {
         const synthesized = await synthesizeWorkspaceFallback(model as never, context, result, fallback.maxToolResults)

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1211,7 +1211,7 @@ async function createAgent(
   const prepareRepairCall = typeof prepareCall === "function"
     ? async (input: Record<string, unknown>) => withoutToolCallSettings(await prepareCall(input as never) as Record<string, unknown>)
     : undefined
-  const repairAgent = context.output
+  const repairAgent = context.output && context.nativeStructuredOutput !== false
     ? new ToolLoopAgent({
         ...repairSettings,
         instructions,
@@ -1221,7 +1221,7 @@ async function createAgent(
         stopWhen: isStepCount(1),
       } as never)
     : undefined
-  const repairOutput = context.output
+  const repairOutput = context.output && context.nativeStructuredOutput !== false
     ? async (failure: { error: Error, evidence?: string[], text: string }, callInput: Record<string, unknown>): Promise<AgentAdapterResult> => {
         const { messages: _messages, options: _options, prompt: _prompt, ...repairCallInput } = callInput
         try {

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1308,7 +1308,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       const synthesizedOutput = async (synthesized: { result: unknown, text: string }, original?: unknown, repairResult?: unknown) => {
         const captures = [usageCapture, repairUsageCapture, fallbackUsageCapture]
         let usageRecord: AgentUsageRecord | undefined
-        if (original && typeof original === "object" && fallbackUsageCapture.captured) {
+        if (fallbackUsageCapture.captured) {
           const calls = [
             { capture: usageCapture, result: originalGenerated ?? original },
             { capture: fallbackUsageCapture, result: synthesized.result },

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1307,15 +1307,17 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       let repaired = false
       const synthesizedOutput = async (synthesized: { result: unknown, text: string }, original?: unknown, repairResult?: unknown) => {
         const captures = [usageCapture, repairUsageCapture, fallbackUsageCapture]
-        const raw = withCapturedUsage(original, captures)
         let usageRecord: AgentUsageRecord | undefined
-        if (raw && typeof raw === "object" && fallbackUsageCapture.captured) {
+        if (original && typeof original === "object" && fallbackUsageCapture.captured) {
           const calls = [
             { capture: usageCapture, result: originalGenerated ?? original },
             { capture: fallbackUsageCapture, result: synthesized.result },
             ...(repairUsageCapture.captured ? [{ capture: repairUsageCapture, result: repairResult }] : []),
           ]
           usageRecord = await combinedUsageRecord(calls, combinedCapturedUsage(captures))
+        }
+        const raw = withCapturedUsage(original, captures)
+        if (raw && typeof raw === "object" && usageRecord) {
           Object.defineProperty(raw, "usageRecord", {
             configurable: true,
             enumerable: true,

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -870,16 +870,35 @@ function createUsageCapture() {
   }
 }
 
-function withCapturedUsage(result: unknown, capture: ReturnType<typeof createUsageCapture>): unknown {
+async function combinedCapturedUsage(captures: ReturnType<typeof createUsageCapture>[]): Promise<unknown> {
+  const usages = await Promise.all(captures.flatMap(capture => capture.usage ? [capture.usage] : []))
+  if (usages.length < 2) return usages[0]
+  const add = (left: unknown, right: unknown): unknown => {
+    if (typeof left === "number" || typeof right === "number") {
+      return (typeof left === "number" ? left : 0) + (typeof right === "number" ? right : 0)
+    }
+    if (!left || typeof left !== "object") return right
+    if (!right || typeof right !== "object") return left
+    const leftRecord = left as Record<string, unknown>
+    const rightRecord = right as Record<string, unknown>
+    return Object.fromEntries([...new Set([...Object.keys(leftRecord), ...Object.keys(rightRecord)])]
+      .map(key => [key, add(leftRecord[key], rightRecord[key])]))
+  }
+  return usages.reduce(add)
+}
+
+function withCapturedUsage(result: unknown, captures: ReturnType<typeof createUsageCapture> | ReturnType<typeof createUsageCapture>[]): unknown {
+  const captureList = Array.isArray(captures) ? captures : [captures]
+  const usage = captureList.some(capture => capture.captured) ? combinedCapturedUsage(captureList) : undefined
   if (result && typeof result === "object") {
     const record = result as Record<string, unknown>
-    const usage = record.usage
+    const resultUsage = record.usage
     const totalUsage = record.totalUsage
     Object.defineProperty(record, "usage", {
       configurable: true,
       enumerable: true,
       get() {
-        return capture.usage ?? usage
+        return usage ?? resultUsage
       },
     })
     if (totalUsage !== undefined) {
@@ -887,19 +906,19 @@ function withCapturedUsage(result: unknown, capture: ReturnType<typeof createUsa
         configurable: true,
         enumerable: true,
         get() {
-          return capture.usage ?? totalUsage
+          return usage ?? totalUsage
         },
       })
     }
     return result
   }
 
-  if (!capture.captured) return result
+  if (usage === undefined) return result
 
   return {
     raw: result,
     text: typeof result === "string" ? result : undefined,
-    usage: capture.usage,
+    usage,
   }
 }
 
@@ -1144,18 +1163,29 @@ async function createAgent(
   const outputSchema = convertedOutputSchema?.type === "object" ? convertedOutputSchema : undefined
   const nativeOutput = outputSchema ? aiSdk.Output.object({ schema: jsonSchema(outputSchema) }) : undefined
   const commonSettings = withRuntimeContext(withViteHubTelemetry(settings, context), context)
+  const repairSettings = withoutToolCallSettings(commonSettings)
+  const prepareCall = commonSettings.prepareCall
+  const prepareRepairCall = typeof prepareCall === "function"
+    ? async (input: Record<string, unknown>) => withoutToolCallSettings(await prepareCall(input as never) as Record<string, unknown>)
+    : undefined
+  const repairAgent = nativeOutput && context.output
+    ? new ToolLoopAgent({
+        ...repairSettings,
+        instructions,
+        model: instrumentedModel as never,
+        output: nativeOutput,
+        ...(prepareRepairCall ? { prepareCall: prepareRepairCall } : {}),
+        stopWhen: isStepCount(1),
+      } as never)
+    : undefined
   const repairOutput = nativeOutput && context.output
     ? async (failure: { error: Error, text: string }, callInput: Record<string, unknown>): Promise<AgentAdapterResult> => {
         const { messages: _messages, options: _options, prompt: _prompt, ...repairCallInput } = callInput
         try {
-          return await aiSdk.generateText({
-            ...withoutToolCallSettings(commonSettings),
+          return await repairAgent!.generate({
             ...repairCallInput,
-            instructions,
-            model: instrumentedModel as never,
-            output: nativeOutput,
+            ...("options" in callInput ? { options: callInput.options } : {}),
             prompt: outputRepairPrompt(failure.text, failure.error),
-            stopWhen: isStepCount(1),
           } as never) as unknown as AgentAdapterResult
         }
         catch (repairError) {
@@ -1196,7 +1226,14 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
         await reportWorkspaceMaterialization(tools as AgentToolSet, context.toolStepReporter)
       }
       const usageCapture = createUsageCapture()
+      const repairUsageCapture = createUsageCapture()
       const repairCallInput = {
+        ...callInput,
+        onEnd: repairUsageCapture.onEnd,
+        onLanguageModelCallEnd: repairUsageCapture.onLanguageModelCallEnd,
+        onStepEnd: repairUsageCapture.onStepEnd,
+      }
+      const originalCallInput = {
         ...callInput,
         onEnd: usageCapture.onEnd,
         onLanguageModelCallEnd: usageCapture.onLanguageModelCallEnd,
@@ -1205,7 +1242,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       let generated: GenerateTextResult<ToolSet, never, never>
       let repaired = false
       try {
-        generated = await agent.generate(repairCallInput as never) as GenerateTextResult<ToolSet, never, never>
+        generated = await agent.generate(originalCallInput as never) as GenerateTextResult<ToolSet, never, never>
       }
       catch (error) {
         const failure = await nativeAgentOutputValidationFailure(context.output, error)
@@ -1214,6 +1251,15 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
           : undefined
         generated = repairedOutput ?? await normalizeNativeAgentOutputError(context.output, error)
         repaired = Boolean(repairedOutput)
+      }
+      if (!repaired && fallback.enabled && (generated.finishReason === "tool-calls" || !generated.text.trim() && hasToolResults(generated))) {
+        const synthesized = await synthesizeWorkspaceFallback(model as never, context, generated, fallback.maxToolResults)
+          ?? await synthesizeWorkspaceFallbackFromEvidence(model as never, context, fallbackCapture?.evidence() ?? [])
+        if (synthesized) {
+          const output = { raw: withCapturedUsage(generated, usageCapture), text: synthesized }
+          Object.defineProperty(output, synthesizedAgentOutputSymbol, { value: true })
+          return output
+        }
       }
       if (!repaired && repairOutput && context.output) {
         try {
@@ -1226,7 +1272,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
           }, repairCallInput) as GenerateTextResult<ToolSet, never, never>
         }
       }
-      const result = withResolvedModelMetadata(withCapturedUsage(generated, usageCapture), model) as GenerateTextResult<ToolSet, never, never>
+      const result = withResolvedModelMetadata(withCapturedUsage(generated, [usageCapture, repairUsageCapture]), model) as GenerateTextResult<ToolSet, never, never>
       const text = result.text.trim()
       if (fallback.enabled && (result.finishReason === "tool-calls" || !text && hasToolResults(result))) {
         const synthesized = await synthesizeWorkspaceFallback(model as never, context, result, fallback.maxToolResults)

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1292,11 +1292,15 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
         onLanguageModelCallEnd: repairUsageCapture.onLanguageModelCallEnd,
         onStepEnd: repairUsageCapture.onStepEnd,
       }
+      const captureOriginalStep = async (event: unknown) => {
+        await usageCapture.onStepEnd(event)
+        fallbackCapture?.collect(event)
+      }
       const originalCallInput = {
         ...callInput,
         onEnd: usageCapture.onEnd,
         onLanguageModelCallEnd: usageCapture.onLanguageModelCallEnd,
-        onStepEnd: usageCapture.onStepEnd,
+        onStepEnd: captureOriginalStep,
       }
       let generated: GenerateTextResult<ToolSet, never, never>
       let originalGenerated: GenerateTextResult<ToolSet, never, never> | undefined

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1124,6 +1124,16 @@ function withoutToolCallSettings(settings: Record<string, unknown>): Record<stri
   return rest
 }
 
+function withoutRepairConversationSettings(settings: Record<string, unknown>): Record<string, unknown> {
+  const {
+    instructions: _instructions,
+    messages: _messages,
+    prompt: _prompt,
+    ...rest
+  } = withoutToolCallSettings(settings)
+  return rest
+}
+
 function outputRepairPrompt(text: string, error: Error, evidence: string[] = []): string {
   const cause = error.cause instanceof Error ? error.cause.message : undefined
   return [
@@ -1210,7 +1220,10 @@ async function createAgent(
   const repairSettings = withoutToolCallSettings(commonSettings)
   const prepareCall = commonSettings.prepareCall
   const prepareRepairCall = typeof prepareCall === "function"
-    ? async (input: Record<string, unknown>) => withoutToolCallSettings(await prepareCall(input as never) as Record<string, unknown>)
+    ? async (input: Record<string, unknown>) => ({
+        ...withoutRepairConversationSettings(await prepareCall(input as never) as Record<string, unknown>),
+        ...(input.prompt === undefined ? {} : { prompt: input.prompt }),
+      })
     : undefined
   const repairAgent = context.output && context.nativeStructuredOutput !== false
     ? new ToolLoopAgent({

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1312,8 +1312,8 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
         if (raw && typeof raw === "object" && fallbackUsageCapture.captured) {
           const calls = [
             { capture: usageCapture, result: originalGenerated ?? original },
-            ...(repairUsageCapture.captured ? [{ capture: repairUsageCapture, result: repairResult }] : []),
             { capture: fallbackUsageCapture, result: synthesized.result },
+            ...(repairUsageCapture.captured ? [{ capture: repairUsageCapture, result: repairResult }] : []),
           ]
           usageRecord = await combinedUsageRecord(calls, combinedCapturedUsage(captures))
           Object.defineProperty(raw, "usageRecord", {
@@ -1396,11 +1396,6 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
         })
       }
       const text = result.text.trim()
-      if (fallback.enabled && (result.finishReason === "tool-calls" || !text && hasToolResults(result))) {
-        const synthesized = await synthesizeWorkspaceFallback(model as never, context, result, fallback.maxToolResults, fallbackUsageCapture)
-          ?? await synthesizeWorkspaceFallbackFromEvidence(model as never, context, fallbackCapture?.evidence() ?? [], fallbackUsageCapture)
-        if (synthesized) return await validatedSynthesizedOutput(synthesized, result)
-      }
       if (text) return result as unknown as AgentAdapterResult
 
       return result as unknown as AgentAdapterResult

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1114,13 +1114,14 @@ function withoutToolCallSettings(settings: Record<string, unknown>): Record<stri
   return rest
 }
 
-function outputRepairPrompt(text: string, error: Error): string {
+function outputRepairPrompt(text: string, error: Error, evidence: string[] = []): string {
   const cause = error.cause instanceof Error ? error.cause.message : undefined
   return [
     "Correct the invalid final Agent output below.",
     "Return only the corrected JSON value. Do not repeat completed work.",
     `Validation error: ${cause || error.message}`,
     `Invalid output: ${JSON.stringify(text)}`,
+    ...(evidence.length ? [`Completed tool results:\n${evidence.join("\n\n---\n\n")}`] : []),
   ].join("\n\n")
 }
 
@@ -1212,13 +1213,13 @@ async function createAgent(
       } as never)
     : undefined
   const repairOutput = nativeOutput && context.output
-    ? async (failure: { error: Error, text: string }, callInput: Record<string, unknown>): Promise<AgentAdapterResult> => {
+    ? async (failure: { error: Error, evidence?: string[], text: string }, callInput: Record<string, unknown>): Promise<AgentAdapterResult> => {
         const { messages: _messages, options: _options, prompt: _prompt, ...repairCallInput } = callInput
         try {
           return await repairAgent!.generate({
             ...repairCallInput,
             ...("options" in callInput ? { options: callInput.options } : {}),
-            prompt: outputRepairPrompt(failure.text, failure.error),
+            prompt: outputRepairPrompt(failure.text, failure.error, failure.evidence),
           } as never) as unknown as AgentAdapterResult
         }
         catch (repairError) {
@@ -1290,7 +1291,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
           return output
         }
         const repairedOutput = failure && repairOutput
-          ? await repairOutput(failure, repairCallInput) as GenerateTextResult<ToolSet, never, never>
+          ? await repairOutput({ ...failure, evidence: fallbackCapture?.evidence() }, repairCallInput) as GenerateTextResult<ToolSet, never, never>
           : undefined
         generated = repairedOutput ?? await normalizeNativeAgentOutputError(context.output, error)
         repaired = Boolean(repairedOutput)
@@ -1311,6 +1312,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
         catch (error) {
           generated = await repairOutput({
             error: error instanceof Error ? error : new Error(String(error)),
+            evidence: fallbackCapture?.evidence(),
             text: generated.text,
           }, repairCallInput) as GenerateTextResult<ToolSet, never, never>
         }

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -500,15 +500,17 @@ async function synthesizeWorkspaceFallback(
   context: AgentAdapterRunContext,
   result: { steps?: Array<{ content?: Array<{ type: string, output?: unknown }> }> },
   maxToolResults: number,
+  usageCapture?: ReturnType<typeof createUsageCapture>,
 ) {
   const evidence = collectToolResults(result, maxToolResults)
-  return await synthesizeWorkspaceFallbackFromEvidence(model, context, evidence)
+  return await synthesizeWorkspaceFallbackFromEvidence(model, context, evidence, usageCapture)
 }
 
 async function synthesizeWorkspaceFallbackFromEvidence(
   model: ToolLoopAgentSettings["model"],
   context: AgentAdapterRunContext,
   evidence: string[],
+  usageCapture?: ReturnType<typeof createUsageCapture>,
 ) {
   if (evidence.length === 0) return undefined
 
@@ -520,6 +522,13 @@ async function synthesizeWorkspaceFallbackFromEvidence(
       resolveMessageChannelInstructions(context.context, context),
     ].filter(Boolean).join("\n"),
     model,
+    ...(usageCapture
+      ? {
+          onEnd: usageCapture.onEnd,
+          onLanguageModelCallEnd: usageCapture.onLanguageModelCallEnd,
+          onStepEnd: usageCapture.onStepEnd,
+        }
+      : {}),
     prompt: [
       `User message:\n${getPromptText(context)}`,
       `Workspace tool results:\n${evidence.join("\n\n---\n\n")}`,
@@ -1252,8 +1261,8 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       const execution = options.execution
       const callInput = await getCallInput(context, execution?.attachments) as Record<string, unknown>
       const fallback = getFallbackOptions(execution?.workspaceFallback)
-      const fallbackCapture = fallback.enabled
-        ? createWorkspaceFallbackEvidenceCapture(fallback.maxToolResults)
+      const fallbackCapture = fallback.enabled || Boolean(context.output)
+        ? createWorkspaceFallbackEvidenceCapture(fallback.enabled ? fallback.maxToolResults : 8)
         : undefined
       const { agent, model, repairOutput, tools } = await createAgent(options, context, fallbackCapture)
       if (context.workspace && tools && "materialize_sources" in tools) {
@@ -1261,6 +1270,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       }
       const usageCapture = createUsageCapture()
       const repairUsageCapture = createUsageCapture()
+      const fallbackUsageCapture = createUsageCapture()
       const repairCallInput = {
         ...callInput,
         onEnd: repairUsageCapture.onEnd,
@@ -1276,6 +1286,25 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       let generated: GenerateTextResult<ToolSet, never, never>
       let originalGenerated: GenerateTextResult<ToolSet, never, never> | undefined
       let repaired = false
+      const synthesizedOutput = async (text: string, original?: unknown) => {
+        const captures = [usageCapture, repairUsageCapture, fallbackUsageCapture]
+        const raw = withCapturedUsage(original, captures)
+        if (raw && typeof raw === "object" && fallbackUsageCapture.captured) {
+          const calls = [
+            { capture: usageCapture, result: originalGenerated ?? original },
+            ...(repairUsageCapture.captured ? [{ capture: repairUsageCapture, result: original }] : []),
+            { capture: fallbackUsageCapture },
+          ]
+          Object.defineProperty(raw, "usageRecord", {
+            configurable: true,
+            enumerable: true,
+            value: await combinedUsageRecord(calls, combinedCapturedUsage(captures)),
+          })
+        }
+        const output = { raw, text }
+        Object.defineProperty(output, synthesizedAgentOutputSymbol, { value: true })
+        return output
+      }
       try {
         generated = await agent.generate(originalCallInput as never) as GenerateTextResult<ToolSet, never, never>
         originalGenerated = generated
@@ -1283,13 +1312,9 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       catch (error) {
         const failure = await nativeAgentOutputValidationFailure(context.output, error)
         const synthesized = failure && fallback.enabled && !failure.text.trim()
-          ? await synthesizeWorkspaceFallbackFromEvidence(model as never, context, fallbackCapture?.evidence() ?? [])
+          ? await synthesizeWorkspaceFallbackFromEvidence(model as never, context, fallbackCapture?.evidence() ?? [], fallbackUsageCapture)
           : undefined
-        if (synthesized) {
-          const output = { raw: withCapturedUsage(undefined, usageCapture), text: synthesized }
-          Object.defineProperty(output, synthesizedAgentOutputSymbol, { value: true })
-          return output
-        }
+        if (synthesized) return await synthesizedOutput(synthesized)
         const repairedOutput = failure && repairOutput
           ? await repairOutput({ ...failure, evidence: fallbackCapture?.evidence() }, repairCallInput) as GenerateTextResult<ToolSet, never, never>
           : undefined
@@ -1297,13 +1322,9 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
         repaired = Boolean(repairedOutput)
       }
       if (!repaired && fallback.enabled && (generated.finishReason === "tool-calls" || !generated.text.trim() && hasToolResults(generated))) {
-        const synthesized = await synthesizeWorkspaceFallback(model as never, context, generated, fallback.maxToolResults)
-          ?? await synthesizeWorkspaceFallbackFromEvidence(model as never, context, fallbackCapture?.evidence() ?? [])
-        if (synthesized) {
-          const output = { raw: withCapturedUsage(generated, usageCapture), text: synthesized }
-          Object.defineProperty(output, synthesizedAgentOutputSymbol, { value: true })
-          return output
-        }
+        const synthesized = await synthesizeWorkspaceFallback(model as never, context, generated, fallback.maxToolResults, fallbackUsageCapture)
+          ?? await synthesizeWorkspaceFallbackFromEvidence(model as never, context, fallbackCapture?.evidence() ?? [], fallbackUsageCapture)
+        if (synthesized) return await synthesizedOutput(synthesized, generated)
       }
       if (!repaired && repairOutput && context.output) {
         try {
@@ -1333,13 +1354,9 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       }
       const text = result.text.trim()
       if (fallback.enabled && (result.finishReason === "tool-calls" || !text && hasToolResults(result))) {
-        const synthesized = await synthesizeWorkspaceFallback(model as never, context, result, fallback.maxToolResults)
-          ?? await synthesizeWorkspaceFallbackFromEvidence(model as never, context, fallbackCapture?.evidence() ?? [])
-        if (synthesized) {
-          const output = { raw: result, text: synthesized }
-          Object.defineProperty(output, synthesizedAgentOutputSymbol, { value: true })
-          return output
-        }
+        const synthesized = await synthesizeWorkspaceFallback(model as never, context, result, fallback.maxToolResults, fallbackUsageCapture)
+          ?? await synthesizeWorkspaceFallbackFromEvidence(model as never, context, fallbackCapture?.evidence() ?? [], fallbackUsageCapture)
+        if (synthesized) return await synthesizedOutput(synthesized, result)
       }
       if (text) return result as unknown as AgentAdapterResult
 

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1281,6 +1281,14 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       }
       catch (error) {
         const failure = await nativeAgentOutputValidationFailure(context.output, error)
+        const synthesized = failure && fallback.enabled && !failure.text.trim()
+          ? await synthesizeWorkspaceFallbackFromEvidence(model as never, context, fallbackCapture?.evidence() ?? [])
+          : undefined
+        if (synthesized) {
+          const output = { raw: withCapturedUsage(undefined, usageCapture), text: synthesized }
+          Object.defineProperty(output, synthesizedAgentOutputSymbol, { value: true })
+          return output
+        }
         const repairedOutput = failure && repairOutput
           ? await repairOutput(failure, repairCallInput) as GenerateTextResult<ToolSet, never, never>
           : undefined

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -14,6 +14,7 @@ import { composeInstructionDocument } from "./instruction-composition.ts"
 import { agentOutputInstructions, agentOutputJsonSchema, nativeAgentOutputValidationFailure, normalizeNativeAgentOutputError, validateAgentOutput } from "./internal/agent-structured-output.ts"
 import { synthesizedAgentOutputSymbol } from "./internal/synthesized-agent-output.ts"
 import { resolveAgentUsageRecord } from "./agent-output.ts"
+import { aggregateAgentUsageCosts } from "./internal/usage-pricing.ts"
 import { getModelCallSettings } from "./internal/model-call-settings.ts"
 import { materializeAgentModel } from "./internal/agent-model.ts"
 import {
@@ -942,8 +943,11 @@ async function combinedUsageRecord(
     const value = records[0]![key]
     return records.every(record => JSON.stringify(record[key]) === JSON.stringify(value)) ? value : undefined
   }
+  const costs = records.flatMap(record => record.cost ? [record.cost] : [])
+  const cost = costs.length === records.length ? aggregateAgentUsageCosts(costs) : undefined
   return {
     calls: records,
+    ...(cost ? { cost } : {}),
     ...(shared("credentialSource") ? { credentialSource: shared("credentialSource") } : {}),
     ...(shared("model") ? { model: shared("model") } : {}),
     ...(shared("transport") ? { transport: shared("transport") } : {}),

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1211,17 +1211,17 @@ async function createAgent(
   const prepareRepairCall = typeof prepareCall === "function"
     ? async (input: Record<string, unknown>) => withoutToolCallSettings(await prepareCall(input as never) as Record<string, unknown>)
     : undefined
-  const repairAgent = nativeOutput && context.output
+  const repairAgent = context.output
     ? new ToolLoopAgent({
         ...repairSettings,
         instructions,
         model: instrumentedModel as never,
-        output: nativeOutput,
+        ...(nativeOutput ? { output: nativeOutput } : {}),
         ...(prepareRepairCall ? { prepareCall: prepareRepairCall } : {}),
         stopWhen: isStepCount(1),
       } as never)
     : undefined
-  const repairOutput = nativeOutput && context.output
+  const repairOutput = context.output
     ? async (failure: { error: Error, evidence?: string[], text: string }, callInput: Record<string, unknown>): Promise<AgentAdapterResult> => {
         const { messages: _messages, options: _options, prompt: _prompt, ...repairCallInput } = callInput
         try {
@@ -1289,19 +1289,28 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       const synthesizedOutput = async (text: string, original?: unknown) => {
         const captures = [usageCapture, repairUsageCapture, fallbackUsageCapture]
         const raw = withCapturedUsage(original, captures)
+        let usageRecord: AgentUsageRecord | undefined
         if (raw && typeof raw === "object" && fallbackUsageCapture.captured) {
           const calls = [
             { capture: usageCapture, result: originalGenerated ?? original },
             ...(repairUsageCapture.captured ? [{ capture: repairUsageCapture, result: original }] : []),
             { capture: fallbackUsageCapture },
           ]
+          usageRecord = await combinedUsageRecord(calls, combinedCapturedUsage(captures))
           Object.defineProperty(raw, "usageRecord", {
             configurable: true,
             enumerable: true,
-            value: await combinedUsageRecord(calls, combinedCapturedUsage(captures)),
+            value: usageRecord,
           })
         }
         const output = { raw, text }
+        if (usageRecord) {
+          Object.defineProperty(output, "usageRecord", {
+            configurable: true,
+            enumerable: true,
+            value: usageRecord,
+          })
+        }
         Object.defineProperty(output, synthesizedAgentOutputSymbol, { value: true })
         return output
       }

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -535,7 +535,8 @@ async function synthesizeWorkspaceFallbackFromEvidence(
     ].join("\n\n"),
   })
 
-  return summary.text.trim() || undefined
+  const text = summary.text.trim()
+  return text ? { result: summary, text } : undefined
 }
 
 function createWorkspaceFallbackEvidenceCapture(maxToolResults: number) {
@@ -712,7 +713,7 @@ function withWorkspaceFallbackFullStream(
 
     const synthesized = await synthesizeWorkspaceFallbackFromEvidence(model, context, fallbackEvidence)
     if (synthesized) {
-      yield* workspaceFallbackTextEvents(synthesized)
+      yield* workspaceFallbackTextEvents(synthesized.text)
       yield workspaceFallbackFinishEvent(finishEvent)
       return
     }
@@ -1286,7 +1287,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
       let generated: GenerateTextResult<ToolSet, never, never>
       let originalGenerated: GenerateTextResult<ToolSet, never, never> | undefined
       let repaired = false
-      const synthesizedOutput = async (text: string, original?: unknown) => {
+      const synthesizedOutput = async (synthesized: { result: unknown, text: string }, original?: unknown) => {
         const captures = [usageCapture, repairUsageCapture, fallbackUsageCapture]
         const raw = withCapturedUsage(original, captures)
         let usageRecord: AgentUsageRecord | undefined
@@ -1294,7 +1295,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
           const calls = [
             { capture: usageCapture, result: originalGenerated ?? original },
             ...(repairUsageCapture.captured ? [{ capture: repairUsageCapture, result: original }] : []),
-            { capture: fallbackUsageCapture },
+            { capture: fallbackUsageCapture, result: synthesized.result },
           ]
           usageRecord = await combinedUsageRecord(calls, combinedCapturedUsage(captures))
           Object.defineProperty(raw, "usageRecord", {
@@ -1303,7 +1304,7 @@ export function createAiSdkAdapter(options: AiSdkAdapterOptions): AgentAdapter {
             value: usageRecord,
           })
         }
-        const output = { raw, text }
+        const output = { raw, text: synthesized.text }
         if (usageRecord) {
           Object.defineProperty(output, "usageRecord", {
             configurable: true,

--- a/packages/agent/src/capabilities/cost.ts
+++ b/packages/agent/src/capabilities/cost.ts
@@ -1,5 +1,5 @@
 import { defineCapability, eagerFinishExtensionSymbol } from "../capability-runtime.ts"
-import { materializeAgentUsageCost, vercelAiGatewayPricing } from "../internal/usage-pricing.ts"
+import { enrichAgentUsageCost, vercelAiGatewayPricing } from "../internal/usage-pricing.ts"
 
 import type { AgentCapabilityDefinition, AgentRuntimeConfig, AgentUsageRecord } from "../types.ts"
 import type { AgentUsagePricing } from "../internal/usage-pricing.ts"
@@ -38,28 +38,11 @@ export function cost<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeCon
       const record = event.invocation.usage
       if (!record) return record
 
-      if (!record.cost && record.usage) {
-        try {
-          const cost = await pricing({
-            model: record.model,
-            response: record.response,
-            run: record.run || event.invocation.run,
-            usage: record.usage,
-          })
-          if (cost) record.cost = materializeAgentUsageCost(cost)
-        }
-        catch {
-          return record
-        }
+      try {
+        Object.assign(record, await enrichAgentUsageCost(record, pricing, event.invocation.run))
       }
-
-      if (record.cost) {
-        try {
-          record.cost = materializeAgentUsageCost(record.cost)
-        }
-        catch {
-          return record
-        }
+      catch {
+        return record
       }
 
       return record

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -113,7 +113,9 @@ const devPayloadMaxLength = 1200
 let devUsagePricing: AgentUsagePricing | undefined
 
 function defaultDevUsagePricing() {
-  return devUsagePricing ??= vercelAiGatewayPricing()
+  return devUsagePricing ??= vercelAiGatewayPricing({
+    fetch: (...args) => globalThis.fetch(...args),
+  })
 }
 
 function writeEvalUsage(context: AgentCliContext): void {

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -8,7 +8,7 @@ import { createAgentEvalInclude, discoverAgentEvalFiles } from "./discovery.ts"
 import { isCompatibleAgentDevServerRoot, runAgentInfoCli } from "./internal/agent-info-cli.ts"
 import { runAgentChannelSyncCli } from "./internal/channel-sync-cli.ts"
 import { runAgentChannelHistoryCli } from "./internal/channel-history-cli.ts"
-import { materializeAgentUsageCost, vercelAiGatewayPricing, type AgentUsagePricing } from "./internal/usage-pricing.ts"
+import { enrichAgentUsageCost, vercelAiGatewayPricing, type AgentUsagePricing } from "./internal/usage-pricing.ts"
 import { resolveAgentEvalOptions, writeAgentEvaliteConfig, type ResolvedAgentEvalOptions } from "./internal/evalite-config.ts"
 import { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute, readAgentInvocationStream } from "./invocation-stream.ts"
 
@@ -345,15 +345,7 @@ function formatUsageNote(summary: string): string {
 
 async function enrichUsageCost(record: AgentUsageRecord): Promise<AgentUsageRecord> {
   try {
-    if (record.cost) return { ...record, cost: materializeAgentUsageCost(record.cost) }
-    if (!record.usage) return record
-    const cost = await defaultDevUsagePricing()({
-      model: record.model,
-      response: record.response,
-      run: record.run,
-      usage: record.usage,
-    })
-    return cost ? { ...record, cost: materializeAgentUsageCost(cost) } : record
+    return await enrichAgentUsageCost(record, defaultDevUsagePricing())
   }
   catch {
     return record

--- a/packages/agent/src/internal/agent-structured-output.ts
+++ b/packages/agent/src/internal/agent-structured-output.ts
@@ -20,9 +20,26 @@ function agentOutputValidationError(code: AgentOutputValidationErrorCode, option
 }
 
 export async function normalizeNativeAgentOutputError(output: AgentOutputDefinition | undefined, error: unknown): Promise<never> {
-  const text = error && typeof error === "object" && "text" in error && typeof error.text === "string" && "name" in error && error.name === "AI_NoObjectGeneratedError" ? error.text : undefined
-  if (output && text !== undefined) await validateAgentOutput(output, text)
+  const failure = await nativeAgentOutputValidationFailure(output, error)
+  if (failure) throw failure.error
   throw error
+}
+
+export async function nativeAgentOutputValidationFailure(
+  output: AgentOutputDefinition | undefined,
+  error: unknown,
+): Promise<{ error: Error, text: string } | undefined> {
+  const text = error && typeof error === "object" && "text" in error && typeof error.text === "string" && "name" in error && error.name === "AI_NoObjectGeneratedError" ? error.text : undefined
+  if (!output || text === undefined) return
+  try {
+    await validateAgentOutput(output, text)
+  }
+  catch (validationError) {
+    if (isAgentOutputValidationError(validationError)) {
+      return { error: validationError as Error, text }
+    }
+    throw validationError
+  }
 }
 
 function isAgentOutputValidationError(value: unknown): boolean {

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -64,6 +64,16 @@ function addDecimalParts(items: Array<{ scale: bigint, units: bigint }>): string
   return fraction ? `${whole}.${fraction}` : whole.toString()
 }
 
+export function aggregateAgentUsageCosts(costs: AgentUsageCost[]): AgentUsageCost | undefined {
+  if (!costs.length) return
+  const source = costs.every(cost => cost.source === costs[0]!.source) ? costs[0]!.source : "custom"
+  return materializeAgentUsageCost({
+    estimated: costs.some(cost => cost.estimated),
+    source,
+    usd: addDecimalParts(costs.map(cost => decimalToParts(cost.usd))),
+  })
+}
+
 function multiplyDecimal(value: string | undefined, count: number | undefined): { scale: bigint, units: bigint } | undefined {
   if (value === undefined || count === undefined || count <= 0) return
   const parts = decimalToParts(value)

--- a/packages/agent/src/internal/usage-pricing.ts
+++ b/packages/agent/src/internal/usage-pricing.ts
@@ -74,6 +74,32 @@ export function aggregateAgentUsageCosts(costs: AgentUsageCost[]): AgentUsageCos
   })
 }
 
+export async function enrichAgentUsageCost(
+  record: AgentUsageRecord,
+  pricing: AgentUsagePricing,
+  run?: Partial<AgentRunMetadata>,
+): Promise<AgentUsageRecord> {
+  const calls = record.calls ? await Promise.all(record.calls.map(call => enrichAgentUsageCost(call, pricing, run))) : undefined
+  let cost = record.cost
+  if (!cost && calls?.length && calls.every(call => call.cost)) {
+    cost = aggregateAgentUsageCosts(calls.map(call => call.cost!))
+  }
+  if (!cost && !calls?.length && record.usage) {
+    const priced = await pricing({
+      model: record.model,
+      response: record.response,
+      run: record.run || run,
+      usage: record.usage,
+    })
+    cost = priced ? materializeAgentUsageCost(priced) : undefined
+  }
+  return {
+    ...record,
+    ...(calls ? { calls } : {}),
+    ...(cost ? { cost: materializeAgentUsageCost(cost) } : {}),
+  }
+}
+
 function multiplyDecimal(value: string | undefined, count: number | undefined): { scale: bigint, units: bigint } | undefined {
   if (value === undefined || count === undefined || count <= 0) return
   const parts = decimalToParts(value)

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1891,6 +1891,7 @@ export interface AgentUsageCredentialSource {
 }
 
 export interface AgentUsageRecord {
+  calls?: AgentUsageRecord[]
   cost?: AgentUsageCost
   credentialSource?: AgentUsageCredentialSource
   latency?: {

--- a/packages/agent/test/cost.test.ts
+++ b/packages/agent/test/cost.test.ts
@@ -1796,4 +1796,40 @@ describe("cost Capability", () => {
       display: "$0.01",
     })
   })
+
+  it("prices compound calls independently before aggregating their cost", async () => {
+    const { cost } = await import("../src/capabilities.ts")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const pricing = vi.fn(async ({ model }: { model?: string }) => ({
+      estimated: true,
+      source: "test",
+      usd: model === "original" ? "0.4" : "0.2",
+    }))
+    const finish = vi.fn()
+    const agent = defineAgent({
+      capabilities: [cost({ pricing })],
+      driver: { run: () => ({
+          text: "ok",
+          usageRecord: {
+            calls: [
+              { model: "original", usage: { inputTokens: 7, outputTokens: 1, totalTokens: 8 } },
+              { model: "repair", usage: { inputTokens: 3, outputTokens: 1, totalTokens: 4 } },
+            ],
+            usage: { inputTokens: 10, outputTokens: 2, totalTokens: 12 },
+          },
+        }) },
+      hooks: { "agent:finish": finish },
+    })
+
+    await runAgent(agent, runtime(), { prompt: "hello" })
+
+    expect(pricing).toHaveBeenCalledTimes(2)
+    expect(finish.mock.calls[0]![0].invocation.usage).toMatchObject({
+      calls: [
+        { cost: { usd: "0.4" }, model: "original" },
+        { cost: { usd: "0.2" }, model: "repair" },
+      ],
+      cost: { display: "~$0.6", estimated: true, source: "test", usd: "0.6" },
+    })
+  })
 })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1818,7 +1818,16 @@ describe("agent message protocol", () => {
       hooks: { "agent:finish": finish },
       driver: {
         execution: { callSettings: {
-          prepareCall: (input: Record<string, unknown>) => ({ ...input, model: repairModel, providerOptions: { test: { route: "repair" } }, toolChoice: "required", tools: { repeat_write: {} } }),
+          prepareCall: (input: Record<string, unknown>) => ({
+            ...input,
+            instructions: "Repeat the original task.",
+            messages: [{ content: "Repeat the original task.", role: "user" }],
+            model: repairModel,
+            prompt: "Repeat the original task.",
+            providerOptions: { test: { route: "repair" } },
+            toolChoice: "required",
+            tools: { repeat_write: {} },
+          }),
           toolChoice: "auto",
         }, workspaceFallback: false },
         model: {} as never,
@@ -1840,6 +1849,8 @@ describe("agent message protocol", () => {
     }))
     expect(repairGenerate.mock.calls[0]![0]).not.toHaveProperty("tools")
     expect(repairGenerate.mock.calls[0]![0]).not.toHaveProperty("toolChoice")
+    expect(repairGenerate.mock.calls[0]![0]).not.toHaveProperty("messages")
+    expect(repairGenerate.mock.calls[0]![0]).not.toHaveProperty("instructions")
     expect(agentSettings[1]).toHaveProperty("tools.db_exec")
     expect(finish.mock.calls[0]![0].invocation.usage).toMatchObject({
       calls: [

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2028,6 +2028,18 @@ describe("agent message protocol", () => {
       cost: { usd: "0.6" },
       usage: { totalTokens: 7 },
     })
+
+    fallbackGenerate.mockResolvedValueOnce({
+      modelId: "fallback-route",
+      providerMetadata: { test: { usage: { cost: 0.2 } } },
+      text: "{\"summary\":\"Saved meal-1\",\"title\":42}",
+    })
+    repairGenerate.mockResolvedValueOnce({ text: "{\"summary\":\"Saved meal-1\",\"title\":\"Skyr\"}" })
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "Save breakfast" })).resolves.toEqual({
+      summary: "Saved meal-1",
+      title: "Skyr",
+    })
+    expect(repairGenerate).toHaveBeenCalledOnce()
   })
 
   it("rejects malformed JSON from structured harness results", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1846,10 +1846,10 @@ describe("agent message protocol", () => {
         { cost: { estimated: false, usd: "0.4" }, model: "original-route", usage: { totalTokens: 7 } },
         { cost: { estimated: false, usd: "0.2" }, model: "repair-route", usage: { totalTokens: 3 } },
       ],
+      cost: { estimated: false, source: "provider", usd: "0.6" },
       usage: { totalTokens: 10 },
     })
     expect(finish.mock.calls[0]![0].invocation.usage).not.toHaveProperty("model")
-    expect(finish.mock.calls[0]![0].invocation.usage).not.toHaveProperty("cost")
   })
 
   it("keeps the ViteHub output error when the single repair remains invalid", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -77,6 +77,35 @@ function deferred<T>() {
   return { promise, reject, resolve }
 }
 
+function nativeSummarySchema() {
+  return {
+    "~standard": {
+      jsonSchema: {
+        input: () => ({
+          properties: { summary: { type: "string" }, title: { type: "string" } },
+          required: ["summary", "title"],
+          type: "object",
+        }),
+      },
+      validate: (value: unknown) => value
+        && typeof value === "object"
+        && typeof (value as { summary?: unknown }).summary === "string"
+        && typeof (value as { title?: unknown }).title === "string"
+        ? { value: value as { summary: string, title: string } }
+        : { issues: [{ message: "Expected a string", path: ["title"] }] },
+      vendor: "vitehub-test",
+      version: 1 as const,
+    },
+  }
+}
+
+function nativeOutputError(text: string) {
+  return Object.assign(new Error("No object generated"), {
+    name: "AI_NoObjectGeneratedError",
+    text,
+  })
+}
+
 async function failedTitleInvocation(options: {
   deliver?: (title: string) => Promise<void> | void
   execute: () => string
@@ -1733,6 +1762,87 @@ describe("agent message protocol", () => {
     })
     await expect(runAgent(scalarAgent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBeDefined()
     expect(agentSettings.at(-1)).not.toHaveProperty("output")
+  })
+
+  it("repairs invalid native output once without re-running tools", async () => {
+    const agentSettings: Record<string, unknown>[] = []
+    const dbExec = vi.fn(() => ({ id: "meal-1" }))
+    const generateText = vi.fn(async (settings: Record<string, unknown>) => {
+      await (settings.onLanguageModelCallEnd as ((event: unknown) => Promise<void>) | undefined)?.({ usage: { totalTokens: 3 } })
+      return { finishReason: "stop", text: "{\"summary\":\"Saved\",\"title\":\"Skyr\"}" }
+    })
+    loadAiSdk.mockResolvedValue({
+      generateText,
+      isStepCount: vi.fn(count => ({ count })),
+      jsonSchema: vi.fn(schema => schema),
+      Output: { object: vi.fn(options => options) },
+      ToolLoopAgent: class {
+        settings: Record<string, unknown>
+
+        constructor(settings: Record<string, unknown>) {
+          this.settings = settings
+          agentSettings.push(settings)
+        }
+
+        async generate() {
+          const tools = this.settings.tools as Record<string, { execute: (input: unknown) => unknown }>
+          await tools.db_exec!.execute({ sql: "INSERT" })
+          return { finishReason: "stop", text: "{\"summary\":\"Saved\",\"title\":42}" }
+        }
+      },
+    })
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [defineCapability({
+        id: "database",
+        tools: { db_exec: { execute: dbExec, name: "db_exec" } },
+      })],
+      driver: {
+        execution: { callSettings: { toolChoice: "auto" } },
+        model: {} as never,
+        output: { schema: nativeSummarySchema() },
+      },
+      runtime: false,
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toEqual({
+      summary: "Saved",
+      title: "Skyr",
+    })
+    expect(dbExec).toHaveBeenCalledOnce()
+    expect(generateText).toHaveBeenCalledOnce()
+    expect(generateText).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("title: Expected a string"),
+    }))
+    expect(generateText.mock.calls[0]![0]).not.toHaveProperty("tools")
+    expect(generateText.mock.calls[0]![0]).not.toHaveProperty("toolChoice")
+    expect(agentSettings[0]).toHaveProperty("tools.db_exec")
+  })
+
+  it("keeps the ViteHub output error when the single repair remains invalid", async () => {
+    const generateText = vi.fn(async () => ({ finishReason: "stop", text: "{\"summary\":\"Saved\",\"title\":42}" }))
+    loadAiSdk.mockResolvedValue({
+      generateText,
+      isStepCount: vi.fn(count => ({ count })),
+      jsonSchema: vi.fn(schema => schema),
+      Output: { object: vi.fn(options => options) },
+      ToolLoopAgent: class {
+        async generate() {
+          throw nativeOutputError("{\"summary\":\"Saved\",\"title\":42}")
+        }
+      },
+    })
+    const { ViteHubError } = await import("@vite-hub/runtime")
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({ driver: { model: {} as never, output: { schema: nativeSummarySchema() } }, runtime: false })
+
+    const error = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}).then(() => undefined, cause => cause as InstanceType<typeof ViteHubError>)
+    expect(generateText).toHaveBeenCalledOnce()
+    expect(error).toMatchObject({
+      code: "AGENT_OUTPUT_SCHEMA_INVALID",
+      message: "[vitehub] Agent output failed schema validation.",
+      name: "ViteHubError",
+    })
   })
 
   it("rejects malformed JSON from structured harness results", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1820,7 +1820,7 @@ describe("agent message protocol", () => {
         execution: { callSettings: {
           prepareCall: (input: Record<string, unknown>) => ({ ...input, model: repairModel, providerOptions: { test: { route: "repair" } }, toolChoice: "required", tools: { repeat_write: {} } }),
           toolChoice: "auto",
-        } },
+        }, workspaceFallback: false },
         model: {} as never,
         output: { schema: nativeSummarySchema() },
       },
@@ -1885,7 +1885,10 @@ describe("agent message protocol", () => {
   })
 
   it("preserves evidence-backed fallback when structured tool output returns or throws without a final value", async () => {
-    const fallbackGenerate = vi.fn(async () => ({ text: "{\"summary\":\"Saved meal-1\",\"title\":\"Skyr\"}" }))
+    const fallbackGenerate = vi.fn(async (settings: Record<string, unknown>) => {
+      await (settings.onLanguageModelCallEnd as ((event: unknown) => Promise<void>) | undefined)?.({ usage: { totalTokens: 2 } })
+      return { text: "{\"summary\":\"Saved meal-1\",\"title\":\"Skyr\"}" }
+    })
     const repairGenerate = vi.fn()
     let throwNativeOutput = false
     loadAiSdk.mockResolvedValue({
@@ -1914,11 +1917,13 @@ describe("agent message protocol", () => {
       },
     })
     const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
     const agent = defineAgent({
       capabilities: [defineCapability({
         id: "database",
         tools: { db_exec: { execute: () => ({ id: "meal-1" }), name: "db_exec" } },
       })],
+      hooks: { "agent:finish": finish },
       driver: { model: {} as never, output: { schema: nativeSummarySchema() } },
       runtime: false,
     })
@@ -1940,6 +1945,7 @@ describe("agent message protocol", () => {
     })
     expect(repairGenerate).not.toHaveBeenCalled()
     expect(fallbackGenerate).toHaveBeenCalledTimes(2)
+    expect(finish.mock.calls.at(-1)![0].invocation.usage).toMatchObject({ usage: { totalTokens: 2 } })
   })
 
   it("rejects malformed JSON from structured harness results", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1792,6 +1792,9 @@ describe("agent message protocol", () => {
           const tools = this.settings.tools as Record<string, { execute: (input: unknown) => unknown }>
           if (tools) {
             await (input.onLanguageModelCallEnd as ((event: unknown) => Promise<void>) | undefined)?.({ usage: { totalTokens: 7 } })
+            await (input.onStepEnd as ((event: unknown) => Promise<void>) | undefined)?.({
+              content: [{ output: { id: "provider-meal-1" }, type: "tool-result" }],
+            })
             await tools.db_exec!.execute({ sql: "INSERT" })
             return {
               finishReason: "stop",
@@ -1845,7 +1848,7 @@ describe("agent message protocol", () => {
     expect(repairGenerate).toHaveBeenCalledWith(expect.objectContaining({
       model: repairModel,
       providerOptions: { test: { route: "repair" } },
-      prompt: expect.stringMatching(/title: Expected a string[\s\S]*meal-1/),
+      prompt: expect.stringMatching(/title: Expected a string[\s\S]*provider-meal-1/),
     }))
     expect(repairGenerate.mock.calls[0]![0]).not.toHaveProperty("tools")
     expect(repairGenerate.mock.calls[0]![0]).not.toHaveProperty("toolChoice")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1972,7 +1972,7 @@ describe("agent message protocol", () => {
 
         async generate(input: Record<string, unknown>) {
           const tools = this.settings.tools as Record<string, { execute: (input: unknown) => unknown }> | undefined
-          if (!tools) return await repairGenerate()
+          if (!tools) return await repairGenerate(input)
           await (input.onLanguageModelCallEnd as ((event: unknown) => Promise<void>) | undefined)?.({
             modelId: "original-route",
             providerMetadata: { test: { usage: { cost: 0.4 } } },
@@ -2040,6 +2040,31 @@ describe("agent message protocol", () => {
       title: "Skyr",
     })
     expect(repairGenerate).toHaveBeenCalledOnce()
+  })
+
+  it("attempts an unsuccessful Workspace fallback only once", async () => {
+    const fallbackGenerate = vi.fn(async () => ({ text: "" }))
+    loadAiSdk.mockResolvedValue({
+      generateText: fallbackGenerate,
+      isStepCount: vi.fn(count => ({ count })),
+      ToolLoopAgent: class {
+        async generate() {
+          return {
+            finishReason: "tool-calls",
+            steps: [{ content: [{ output: { id: "meal-1" }, type: "tool-result" }] }],
+            text: "",
+          }
+        }
+      },
+    })
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({ driver: { model: {} as never }, runtime: false })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toMatchObject({
+      finishReason: "tool-calls",
+      text: undefined,
+    })
+    expect(fallbackGenerate).toHaveBeenCalledOnce()
   })
 
   it("rejects malformed JSON from structured harness results", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1884,9 +1884,10 @@ describe("agent message protocol", () => {
     })
   })
 
-  it("preserves evidence-backed fallback when structured tool output ends without a final value", async () => {
+  it("preserves evidence-backed fallback when structured tool output returns or throws without a final value", async () => {
     const fallbackGenerate = vi.fn(async () => ({ text: "{\"summary\":\"Saved meal-1\",\"title\":\"Skyr\"}" }))
     const repairGenerate = vi.fn()
+    let throwNativeOutput = false
     loadAiSdk.mockResolvedValue({
       generateText: fallbackGenerate,
       isStepCount: vi.fn(count => ({ count })),
@@ -1903,6 +1904,7 @@ describe("agent message protocol", () => {
           const tools = this.settings.tools as Record<string, { execute: (input: unknown) => unknown }> | undefined
           if (!tools) return await repairGenerate()
           const output = await tools.db_exec!.execute({ sql: "INSERT" })
+          if (throwNativeOutput) throw nativeOutputError("")
           return {
             finishReason: "tool-calls",
             steps: [{ content: [{ output, type: "tool-result" }] }],
@@ -1930,6 +1932,14 @@ describe("agent message protocol", () => {
     expect(fallbackGenerate).toHaveBeenCalledWith(expect.objectContaining({
       prompt: expect.stringContaining("meal-1"),
     }))
+
+    throwNativeOutput = true
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "Save breakfast" })).resolves.toEqual({
+      summary: "Saved meal-1",
+      title: "Skyr",
+    })
+    expect(repairGenerate).not.toHaveBeenCalled()
+    expect(fallbackGenerate).toHaveBeenCalledTimes(2)
   })
 
   it("rejects malformed JSON from structured harness results", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -2006,6 +2006,7 @@ describe("agent message protocol", () => {
     expect(repairGenerate).not.toHaveBeenCalled()
     expect(fallbackGenerate).toHaveBeenCalledOnce()
     expect(fallbackGenerate).toHaveBeenCalledWith(expect.objectContaining({
+      instructions: expect.stringContaining('"title"'),
       prompt: expect.stringContaining("meal-1"),
     }))
 

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1872,7 +1872,7 @@ describe("agent message protocol", () => {
         }
       },
     })
-    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { defineAgent, runAgent, runAgentInline } = await import("../src/index.ts")
     const agent = defineAgent({
       driver: {
         model: {} as never,
@@ -1893,6 +1893,9 @@ describe("agent message protocol", () => {
     })
 
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("fixed")
+    expect(repairGenerate).toHaveBeenCalledOnce()
+
+    await expect(runAgentInline(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}, { output: "raw" })).resolves.toMatchObject({ text: "42" })
     expect(repairGenerate).toHaveBeenCalledOnce()
   })
 

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1852,6 +1852,50 @@ describe("agent message protocol", () => {
     expect(finish.mock.calls[0]![0].invocation.usage).not.toHaveProperty("model")
   })
 
+  it("repairs structured output when the schema root is not an object", async () => {
+    const repairGenerate = vi.fn(async () => ({ finishReason: "stop", text: '"fixed"' }))
+    loadAiSdk.mockResolvedValue({
+      isStepCount: vi.fn(count => ({ count })),
+      jsonSchema: vi.fn(schema => schema),
+      Output: { object: vi.fn(options => options) },
+      ToolLoopAgent: class {
+        settings: Record<string, unknown>
+
+        constructor(settings: Record<string, unknown>) {
+          this.settings = settings
+        }
+
+        async generate() {
+          return (this.settings.stopWhen as { count?: number }).count === 1
+            ? await repairGenerate()
+            : { finishReason: "stop", text: "42" }
+        }
+      },
+    })
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      driver: {
+        model: {} as never,
+        output: {
+          schema: {
+            "~standard": {
+              jsonSchema: { input: () => ({ type: "string" }) },
+              validate: (value: unknown) => typeof value === "string"
+                ? { value }
+                : { issues: [{ message: "Expected a string" }] },
+              vendor: "vitehub-test",
+              version: 1 as const,
+            },
+          } as never,
+        },
+      },
+      runtime: false,
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("fixed")
+    expect(repairGenerate).toHaveBeenCalledOnce()
+  })
+
   it("keeps the ViteHub output error when the single repair remains invalid", async () => {
     const repairGenerate = vi.fn(async () => ({ finishReason: "stop", text: "{\"summary\":\"Saved\",\"title\":42}" }))
     loadAiSdk.mockResolvedValue({
@@ -1886,8 +1930,16 @@ describe("agent message protocol", () => {
 
   it("preserves evidence-backed fallback when structured tool output returns or throws without a final value", async () => {
     const fallbackGenerate = vi.fn(async (settings: Record<string, unknown>) => {
-      await (settings.onLanguageModelCallEnd as ((event: unknown) => Promise<void>) | undefined)?.({ usage: { totalTokens: 2 } })
-      return { text: "{\"summary\":\"Saved meal-1\",\"title\":\"Skyr\"}" }
+      await (settings.onLanguageModelCallEnd as ((event: unknown) => Promise<void>) | undefined)?.({
+        modelId: "fallback-route",
+        providerMetadata: { test: { usage: { cost: 0.2 } } },
+        usage: { totalTokens: 2 },
+      })
+      return {
+        modelId: "fallback-route",
+        providerMetadata: { test: { usage: { cost: 0.2 } } },
+        text: "{\"summary\":\"Saved meal-1\",\"title\":\"Skyr\"}",
+      }
     })
     const repairGenerate = vi.fn()
     let throwNativeOutput = false
@@ -1903,13 +1955,20 @@ describe("agent message protocol", () => {
           this.settings = settings
         }
 
-        async generate() {
+        async generate(input: Record<string, unknown>) {
           const tools = this.settings.tools as Record<string, { execute: (input: unknown) => unknown }> | undefined
           if (!tools) return await repairGenerate()
+          await (input.onLanguageModelCallEnd as ((event: unknown) => Promise<void>) | undefined)?.({
+            modelId: "original-route",
+            providerMetadata: { test: { usage: { cost: 0.4 } } },
+            usage: { totalTokens: 5 },
+          })
           const output = await tools.db_exec!.execute({ sql: "INSERT" })
           if (throwNativeOutput) throw nativeOutputError("")
           return {
             finishReason: "tool-calls",
+            modelId: "original-route",
+            providerMetadata: { test: { usage: { cost: 0.4 } } },
             steps: [{ content: [{ output, type: "tool-result" }] }],
             text: "",
           }
@@ -1945,7 +2004,14 @@ describe("agent message protocol", () => {
     })
     expect(repairGenerate).not.toHaveBeenCalled()
     expect(fallbackGenerate).toHaveBeenCalledTimes(2)
-    expect(finish.mock.calls.at(-1)![0].invocation.usage).toMatchObject({ usage: { totalTokens: 2 } })
+    expect(finish.mock.calls.at(-1)![0].invocation.usage).toMatchObject({
+      calls: [
+        { cost: { usd: "0.4" }, model: "original-route", usage: { totalTokens: 5 } },
+        { cost: { usd: "0.2" }, model: "fallback-route", usage: { totalTokens: 2 } },
+      ],
+      cost: { usd: "0.6" },
+      usage: { totalTokens: 7 },
+    })
   })
 
   it("rejects malformed JSON from structured harness results", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1767,12 +1767,11 @@ describe("agent message protocol", () => {
   it("repairs invalid native output once without re-running tools", async () => {
     const agentSettings: Record<string, unknown>[] = []
     const dbExec = vi.fn(() => ({ id: "meal-1" }))
-    const generateText = vi.fn(async (settings: Record<string, unknown>) => {
+    const repairGenerate = vi.fn(async (settings: Record<string, unknown>) => {
       await (settings.onLanguageModelCallEnd as ((event: unknown) => Promise<void>) | undefined)?.({ usage: { totalTokens: 3 } })
       return { finishReason: "stop", text: "{\"summary\":\"Saved\",\"title\":\"Skyr\"}" }
     })
     loadAiSdk.mockResolvedValue({
-      generateText,
       isStepCount: vi.fn(count => ({ count })),
       jsonSchema: vi.fn(schema => schema),
       Output: { object: vi.fn(options => options) },
@@ -1784,21 +1783,34 @@ describe("agent message protocol", () => {
           agentSettings.push(settings)
         }
 
-        async generate() {
+        async generate(input: Record<string, unknown>) {
           const tools = this.settings.tools as Record<string, { execute: (input: unknown) => unknown }>
-          await tools.db_exec!.execute({ sql: "INSERT" })
-          return { finishReason: "stop", text: "{\"summary\":\"Saved\",\"title\":42}" }
+          if (tools) {
+            await (input.onLanguageModelCallEnd as ((event: unknown) => Promise<void>) | undefined)?.({ usage: { totalTokens: 7 } })
+            await tools.db_exec!.execute({ sql: "INSERT" })
+            return { finishReason: "stop", text: "{\"summary\":\"Saved\",\"title\":42}" }
+          }
+          const prepared = typeof this.settings.prepareCall === "function"
+            ? await this.settings.prepareCall({ ...this.settings, ...input }) as Record<string, unknown>
+            : { ...this.settings, ...input }
+          return await repairGenerate(prepared)
         }
       },
     })
     const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const finish = vi.fn()
+    const repairModel = { modelId: "repair-route" }
     const agent = defineAgent({
       capabilities: [defineCapability({
         id: "database",
         tools: { db_exec: { execute: dbExec, name: "db_exec" } },
       })],
+      hooks: { "agent:finish": finish },
       driver: {
-        execution: { callSettings: { toolChoice: "auto" } },
+        execution: { callSettings: {
+          prepareCall: (input: Record<string, unknown>) => ({ ...input, model: repairModel, providerOptions: { test: { route: "repair" } }, toolChoice: "required", tools: { repeat_write: {} } }),
+          toolChoice: "auto",
+        } },
         model: {} as never,
         output: { schema: nativeSummarySchema() },
       },
@@ -1810,24 +1822,33 @@ describe("agent message protocol", () => {
       title: "Skyr",
     })
     expect(dbExec).toHaveBeenCalledOnce()
-    expect(generateText).toHaveBeenCalledOnce()
-    expect(generateText).toHaveBeenCalledWith(expect.objectContaining({
+    expect(repairGenerate).toHaveBeenCalledOnce()
+    expect(repairGenerate).toHaveBeenCalledWith(expect.objectContaining({
+      model: repairModel,
+      providerOptions: { test: { route: "repair" } },
       prompt: expect.stringContaining("title: Expected a string"),
     }))
-    expect(generateText.mock.calls[0]![0]).not.toHaveProperty("tools")
-    expect(generateText.mock.calls[0]![0]).not.toHaveProperty("toolChoice")
-    expect(agentSettings[0]).toHaveProperty("tools.db_exec")
+    expect(repairGenerate.mock.calls[0]![0]).not.toHaveProperty("tools")
+    expect(repairGenerate.mock.calls[0]![0]).not.toHaveProperty("toolChoice")
+    expect(agentSettings[1]).toHaveProperty("tools.db_exec")
+    expect(finish.mock.calls[0]![0].invocation.usage).toMatchObject({ usage: { totalTokens: 10 } })
   })
 
   it("keeps the ViteHub output error when the single repair remains invalid", async () => {
-    const generateText = vi.fn(async () => ({ finishReason: "stop", text: "{\"summary\":\"Saved\",\"title\":42}" }))
+    const repairGenerate = vi.fn(async () => ({ finishReason: "stop", text: "{\"summary\":\"Saved\",\"title\":42}" }))
     loadAiSdk.mockResolvedValue({
-      generateText,
       isStepCount: vi.fn(count => ({ count })),
       jsonSchema: vi.fn(schema => schema),
       Output: { object: vi.fn(options => options) },
       ToolLoopAgent: class {
+        settings: Record<string, unknown>
+
+        constructor(settings: Record<string, unknown>) {
+          this.settings = settings
+        }
+
         async generate() {
+          if ((this.settings.stopWhen as { count?: number }).count === 1) return await repairGenerate()
           throw nativeOutputError("{\"summary\":\"Saved\",\"title\":42}")
         }
       },
@@ -1837,12 +1858,60 @@ describe("agent message protocol", () => {
     const agent = defineAgent({ driver: { model: {} as never, output: { schema: nativeSummarySchema() } }, runtime: false })
 
     const error = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}).then(() => undefined, cause => cause as InstanceType<typeof ViteHubError>)
-    expect(generateText).toHaveBeenCalledOnce()
+    expect(repairGenerate).toHaveBeenCalledOnce()
     expect(error).toMatchObject({
       code: "AGENT_OUTPUT_SCHEMA_INVALID",
       message: "[vitehub] Agent output failed schema validation.",
       name: "ViteHubError",
     })
+  })
+
+  it("preserves evidence-backed fallback when structured tool output ends without a final value", async () => {
+    const fallbackGenerate = vi.fn(async () => ({ text: "{\"summary\":\"Saved meal-1\",\"title\":\"Skyr\"}" }))
+    const repairGenerate = vi.fn()
+    loadAiSdk.mockResolvedValue({
+      generateText: fallbackGenerate,
+      isStepCount: vi.fn(count => ({ count })),
+      jsonSchema: vi.fn(schema => schema),
+      Output: { object: vi.fn(options => options) },
+      ToolLoopAgent: class {
+        settings: Record<string, unknown>
+
+        constructor(settings: Record<string, unknown>) {
+          this.settings = settings
+        }
+
+        async generate() {
+          const tools = this.settings.tools as Record<string, { execute: (input: unknown) => unknown }> | undefined
+          if (!tools) return await repairGenerate()
+          const output = await tools.db_exec!.execute({ sql: "INSERT" })
+          return {
+            finishReason: "tool-calls",
+            steps: [{ content: [{ output, type: "tool-result" }] }],
+            text: "",
+          }
+        }
+      },
+    })
+    const { defineAgent, defineCapability, runAgent } = await import("../src/index.ts")
+    const agent = defineAgent({
+      capabilities: [defineCapability({
+        id: "database",
+        tools: { db_exec: { execute: () => ({ id: "meal-1" }), name: "db_exec" } },
+      })],
+      driver: { model: {} as never, output: { schema: nativeSummarySchema() } },
+      runtime: false,
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { prompt: "Save breakfast" })).resolves.toEqual({
+      summary: "Saved meal-1",
+      title: "Skyr",
+    })
+    expect(repairGenerate).not.toHaveBeenCalled()
+    expect(fallbackGenerate).toHaveBeenCalledOnce()
+    expect(fallbackGenerate).toHaveBeenCalledWith(expect.objectContaining({
+      prompt: expect.stringContaining("meal-1"),
+    }))
   })
 
   it("rejects malformed JSON from structured harness results", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1769,7 +1769,12 @@ describe("agent message protocol", () => {
     const dbExec = vi.fn(() => ({ id: "meal-1" }))
     const repairGenerate = vi.fn(async (settings: Record<string, unknown>) => {
       await (settings.onLanguageModelCallEnd as ((event: unknown) => Promise<void>) | undefined)?.({ usage: { totalTokens: 3 } })
-      return { finishReason: "stop", text: "{\"summary\":\"Saved\",\"title\":\"Skyr\"}" }
+      return {
+        finishReason: "stop",
+        modelId: "repair-route",
+        providerMetadata: { test: { usage: { cost: 0.2 } } },
+        text: "{\"summary\":\"Saved\",\"title\":\"Skyr\"}",
+      }
     })
     loadAiSdk.mockResolvedValue({
       isStepCount: vi.fn(count => ({ count })),
@@ -1788,7 +1793,12 @@ describe("agent message protocol", () => {
           if (tools) {
             await (input.onLanguageModelCallEnd as ((event: unknown) => Promise<void>) | undefined)?.({ usage: { totalTokens: 7 } })
             await tools.db_exec!.execute({ sql: "INSERT" })
-            return { finishReason: "stop", text: "{\"summary\":\"Saved\",\"title\":42}" }
+            return {
+              finishReason: "stop",
+              modelId: "original-route",
+              providerMetadata: { test: { usage: { cost: 0.4 } } },
+              text: "{\"summary\":\"Saved\",\"title\":42}",
+            }
           }
           const prepared = typeof this.settings.prepareCall === "function"
             ? await this.settings.prepareCall({ ...this.settings, ...input }) as Record<string, unknown>
@@ -1831,7 +1841,15 @@ describe("agent message protocol", () => {
     expect(repairGenerate.mock.calls[0]![0]).not.toHaveProperty("tools")
     expect(repairGenerate.mock.calls[0]![0]).not.toHaveProperty("toolChoice")
     expect(agentSettings[1]).toHaveProperty("tools.db_exec")
-    expect(finish.mock.calls[0]![0].invocation.usage).toMatchObject({ usage: { totalTokens: 10 } })
+    expect(finish.mock.calls[0]![0].invocation.usage).toMatchObject({
+      calls: [
+        { cost: { estimated: false, usd: "0.4" }, model: "original-route", usage: { totalTokens: 7 } },
+        { cost: { estimated: false, usd: "0.2" }, model: "repair-route", usage: { totalTokens: 3 } },
+      ],
+      usage: { totalTokens: 10 },
+    })
+    expect(finish.mock.calls[0]![0].invocation.usage).not.toHaveProperty("model")
+    expect(finish.mock.calls[0]![0].invocation.usage).not.toHaveProperty("cost")
   })
 
   it("keeps the ViteHub output error when the single repair remains invalid", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1934,8 +1934,6 @@ describe("agent message protocol", () => {
   it("preserves evidence-backed fallback when structured tool output returns or throws without a final value", async () => {
     const fallbackGenerate = vi.fn(async (settings: Record<string, unknown>) => {
       await (settings.onLanguageModelCallEnd as ((event: unknown) => Promise<void>) | undefined)?.({
-        modelId: "fallback-route",
-        providerMetadata: { test: { usage: { cost: 0.2 } } },
         usage: { totalTokens: 2 },
       })
       return {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1836,7 +1836,7 @@ describe("agent message protocol", () => {
     expect(repairGenerate).toHaveBeenCalledWith(expect.objectContaining({
       model: repairModel,
       providerOptions: { test: { route: "repair" } },
-      prompt: expect.stringContaining("title: Expected a string"),
+      prompt: expect.stringMatching(/title: Expected a string[\s\S]*meal-1/),
     }))
     expect(repairGenerate.mock.calls[0]![0]).not.toHaveProperty("tools")
     expect(repairGenerate.mock.calls[0]![0]).not.toHaveProperty("toolChoice")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,7 +232,7 @@ catalogs:
       specifier: ^10.0.0
       version: 10.6.2
     unstorage:
-      specifier: ^2.0.0-alpha.7
+      specifier: 2.0.0-alpha.7
       version: 2.0.0-alpha.7
     uploadthing:
       specifier: ^7.7.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -93,7 +93,7 @@ catalogs:
     dropbox: ^10.34.0
     files-sdk: ^2.1.0
     google-auth-library: ^10.0.0
-    unstorage: ^2.0.0-alpha.7
+    unstorage: 2.0.0-alpha.7
     uploadthing: ^7.7.4
   tooling:
     "@types/node": ^24.13.3


### PR DESCRIPTION
Structured Agent output could fail after tool work completed, while validation happened too late for the model to correct only its final JSON.

- validate native structured results at the Agent Driver boundary and make exactly one output-only repair attempt
- include the ViteHub validation detail and invalid output in the correction prompt
- preserve invocation-prepared model and provider routing while removing messages and executable tool settings so completed writes cannot repeat
- aggregate usage across the original generation and repair while preserving per-call model and cost attribution
- price compound calls independently for cost and CLI consumers, then aggregate their costs exactly
- preserve evidence-backed workspace fallback for tool-ended empty results
- preserve the final Standard Schema guard, stable ViteHub errors, usage callbacks, and existing streaming behavior
- document the correction call and pin the known-good `unstorage` prerelease used by isolated consumers

Verification:
- `pnpm exec vp test run test/cost.test.ts test/runtime.test.ts --maxWorkers=1` (442 passed)
- `pnpm --filter @vite-hub/agent typecheck`
- dependency-aware `@vite-hub/agent#build`
- `pnpm exec vp run test:consumer` (6 passed)
- `git diff --check origin/main...HEAD`