### PR TITLE
feat(agent): default message channel progress

### DIFF
--- a/docs/content/docs/capabilities/chat.md
+++ b/docs/content/docs/capabilities/chat.md
@@ -83,7 +83,7 @@ For adapter-backed delivery, inspect the Channel-generated webhook registrations
 | `lockScope` | `"agent" \| "channel" \| "thread" \| string` | inherited | Scope used for message locks. |
 | `dedupeTtlMs` | `number` | inherited | Time-to-live for Chat SDK duplicate-message keys. |
 | `userName` | `string` | `"vitehub"` | Agent username used by adapter-backed Chat SDK delivery. |
-| `fallbackStreamingPlaceholderText` | `string \| string[] \| null \| function` | inherited | Placeholder text while streaming starts. Arrays pick one entry per Agent Invocation; empty arrays skip the placeholder. |
+| `fallbackStreamingPlaceholderText` | `string \| string[] \| null \| function` | message Channels: `"Working on it…"`; otherwise inherited | Disposable progress message. ViteHub safely updates it when progress is available, deletes it on completion, then posts the final reply separately. Arrays pick one entry per Agent Invocation; `null` and empty arrays disable it. |
 | `errorFallbackText` | `string \| null \| function` | inherited | Fallback message when chat handling fails. |
 
 ## Reference

--- a/docs/content/docs/capabilities/progress-summary.md
+++ b/docs/content/docs/capabilities/progress-summary.md
@@ -7,7 +7,9 @@ navigation.group: Decisions and output
 icon: i-lucide-message-circle-more
 ---
 
-`progressSummary()` observes reasoning and tool lifecycle events while an Agent works, then emits a replaceable one-sentence status as transient `data-progress-summary` stream data.
+`progressSummary()` observes reasoning presence and tool lifecycle events while an Agent works, then emits a replaceable one-sentence status as transient `data-progress-summary` stream data.
+
+Adapter-backed message Channels enable it by default. ViteHub posts `Working on it…`, replaces that message with safe progress summaries when the Driver exposes useful events, deletes it on completion, and posts the final reply as a new message. GitHub Channels are not message Channels, so they keep their single final delivery.
 
 ## Add progress summaries
 
@@ -50,7 +52,7 @@ Listen for `data-progress-summary` parts and replace the currently displayed sen
 
 The part is transient, so it does not become conversation history. Keep structured reasoning and tool logs separate when your interface exposes them.
 
-With manual chat delivery, ViteHub edits the current placeholder as summaries arrive. When the Agent finishes, ViteHub deletes that placeholder and posts the final reply as a new message so chat platforms can deliver their normal notification.
+With adapter-backed message delivery, ViteHub edits the current placeholder as summaries arrive. When the Agent finishes, ViteHub deletes that placeholder and posts the final reply as a new message so chat platforms can deliver their normal notification. Set `messages.fallbackStreamingPlaceholderText` to `null` on a Channel to opt out.
 
 ## Understand the runtime behavior
 
@@ -64,7 +66,7 @@ The Capability stops its cadence and aborts every in-flight generation when the 
 
 ## Requirements
 
-The primary Agent Driver must expose a compatible async stream or UI message stream. With a positive interval, the Capability attempts a summary on every tick and suppresses unchanged output. With `intervalMs: 0`, it remains silent after the first-chunk summary until reasoning or tool lifecycle events provide new activity.
+Streaming Drivers expose progress through their async or UI message stream. Model-backed non-streaming Drivers use AI SDK step-finish events. With a positive interval, the Capability attempts a summary on every tick and suppresses unchanged output. With `intervalMs: 0`, it remains silent after the first event until reasoning presence or tool lifecycle events provide new activity.
 
 Configure a `driver`, `model`, or `execute` option for summary generation. Without one of those options, the Capability uses the Agent model when available.
 

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -4,7 +4,7 @@ import { capabilityInvocationStartSymbol, defineCapability, eagerFinishExtension
 import { toAgentUiMessageStreamResponse } from "../http-response.ts"
 import { normalizeAgentDriver, resolveNormalizedHarnessDriver } from "../internal/agent-driver.ts"
 import { progressSummaryOutputContextKey } from "../internal/agent-output-events.ts"
-import { messageChannelProgressContextKey, updateMessageChannelProgress } from "../internal/message-channel-progress.ts"
+import { messageChannelProgressContextKey, messageChannelProgressUpdatesClosedContextKey, type MessageChannelProgressReference, updateMessageChannelProgress } from "../internal/message-channel-progress.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 import { quietExpectedAuxiliaryHarnessCancellation } from "../internal/auxiliary-harness.ts"
 import { markAuxiliaryMessageChannelInstructionContext } from "../internal/channels.ts"
@@ -593,10 +593,31 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
 ): AgentCapabilityDefinition<TRuntimeConfig> {
   const states = new WeakMap<object, ProgressSummaryState>()
   const invocationStarts = new WeakMap<object, () => void>()
+  const generatedTasks = new WeakMap<object, Promise<void>>()
+  const generatedAborts = new WeakMap<object, AbortController>()
   return Object.assign(defineCapability({
-    close(context) {
+    async close(context) {
+      context.context.set(messageChannelProgressUpdatesClosedContextKey, true, { overwrite: true })
+      generatedAborts.get(context.context)?.abort(new DOMException("Progress summary closed.", "AbortError"))
+      generatedAborts.delete(context.context)
       states.get(context.context)?.close()
       states.delete(context.context)
+      const task = generatedTasks.get(context.context)
+      if (task) {
+        let timeoutId: ReturnType<typeof setTimeout> | undefined
+        const settled = await Promise.race([
+          task.then(() => true),
+          new Promise<false>(resolve => {
+            timeoutId = setTimeout(() => resolve(false), 1_000)
+          }),
+        ])
+        if (timeoutId) clearTimeout(timeoutId)
+        if (!settled) {
+          const progress = context.context.get<MessageChannelProgressReference>(messageChannelProgressContextKey)
+          if (progress) progress.reusable = false
+        }
+      }
+      generatedTasks.delete(context.context)
       invocationStarts.delete(context.context)
     },
     id: options.id || "progress-summary",
@@ -606,6 +627,7 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
       let generatedPrevious: string | undefined
       const generatedCompletedTools: string[] = []
       const generatedStartedAt = Date.now()
+      let generatedLastAt = 0
       const getState = () => {
         if (state) return state
         const messages = context.input.messages()
@@ -618,37 +640,56 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
         if (context.invocation?.kind === "stream" && context.driver?.kind === "harness") getState()
       })
       if (context.invocation?.kind === "run") {
+        const generatedAbort = new AbortController()
+        generatedAborts.set(context.context, generatedAbort)
         context.modelExecution.instrument({
           callSettings({ callSettings }) {
-            const previous = typeof callSettings.onStepFinish === "function"
-              ? callSettings.onStepFinish as (event: unknown) => MaybePromise<void>
+            const previous = typeof callSettings.onStepEnd === "function"
+              ? callSettings.onStepEnd as (event: unknown) => MaybePromise<void>
+              : typeof callSettings.onStepFinish === "function"
+                ? callSettings.onStepFinish as (event: unknown) => MaybePromise<void>
               : undefined
             return {
-              async onStepFinish(event: unknown) {
+              async onStepEnd(event: unknown) {
                 await previous?.(event)
                 if (!context.context.get(messageChannelProgressContextKey)) return
                 const evidence = stepProgressEvidence(event)
+                if (!evidence.reasoning && !evidence.completedTools.length) return
                 generatedCompletedTools.push(...evidence.completedTools)
-                const messages = context.input.messages()
-                const inputValue = context.input.get()
-                try {
-                  const summary = await generateProgressSummary(context, options, {
-                    activeTools: [],
-                    completedTools: generatedCompletedTools.slice(-5),
-                    elapsedMs: Date.now() - generatedStartedAt,
-                    input: inputValue,
-                    messages,
-                    previous: generatedPrevious,
-                    reasoning: evidence.reasoning ? "Active" : undefined,
-                    userText: firstUserText(messages, inputValue),
-                  })
-                  if (!summary || summary === generatedPrevious) return
-                  generatedPrevious = summary
-                  await updateMessageChannelProgress(context, summary)
-                }
-                catch {
-                  console.warn("[vitehub] progressSummary() generation failed.")
-                }
+                const now = Date.now()
+                if (generatedLastAt && now - generatedLastAt < (options.intervalMs ?? 10_000)) return
+                generatedLastAt = now
+                const previousTask = generatedTasks.get(context.context) || Promise.resolve()
+                const task = previousTask.then(async () => {
+                  const messages = context.input.messages()
+                  const inputValue = context.input.get()
+                  const input = {
+                    ...inputValue,
+                    abortSignal: inputValue.abortSignal
+                      ? AbortSignal.any([inputValue.abortSignal, generatedAbort.signal])
+                      : generatedAbort.signal,
+                  }
+                  try {
+                    const summary = await generateProgressSummary(context, options, {
+                      activeTools: [],
+                      completedTools: generatedCompletedTools.slice(-5),
+                      elapsedMs: Date.now() - generatedStartedAt,
+                      input,
+                      messages,
+                      previous: generatedPrevious,
+                      reasoning: evidence.reasoning ? "Active" : undefined,
+                      userText: firstUserText(messages, input),
+                    })
+                    if (!summary || summary === generatedPrevious) return
+                    generatedPrevious = summary
+                    await updateMessageChannelProgress(context, summary)
+                  }
+                  catch {
+                    if (generatedAbort.signal.aborted) return
+                    console.warn("[vitehub] progressSummary() generation failed.")
+                  }
+                })
+                generatedTasks.set(context.context, task)
               },
             }
           },

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -38,6 +38,8 @@ export interface ProgressSummarySnapshot {
   userText: string
 }
 
+export const progressSummaryCapabilityMetadataKey = "vitehub.progress-summary"
+
 export interface ProgressSummaryExecuteInput extends ProgressSummarySnapshot {
   input: AgentRunInput
   messages: Message[]
@@ -621,6 +623,7 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
       invocationStarts.delete(context.context)
     },
     id: options.id || "progress-summary",
+    metadata: { [progressSummaryCapabilityMetadataKey]: true },
     output(context) {
       context.context.set(progressSummaryOutputContextKey, true, { overwrite: true })
       let state: ProgressSummaryState | undefined

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -113,16 +113,18 @@ function eventToolId(value: unknown): string {
   return typeof id === "string" ? id : ""
 }
 
-function stepProgressEvidence(value: unknown): { completedTools: string[], reasoning: boolean } {
-  if (!isRecord(value)) return { completedTools: [], reasoning: false }
-  const parts = [
-    ...(Array.isArray(value.content) ? value.content : []),
-    ...(Array.isArray(value.toolCalls) ? value.toolCalls : []),
-    ...(Array.isArray(value.toolResults) ? value.toolResults : []),
-  ]
+function stepProgressEvidence(value: unknown): { activeTools: string[], completedTools: string[], reasoning: boolean } {
+  if (!isRecord(value)) return { activeTools: [], completedTools: [], reasoning: false }
+  const content = Array.isArray(value.content) ? value.content : []
+  const toolCalls = [...content, ...(Array.isArray(value.toolCalls) ? value.toolCalls : [])]
+    .filter(part => eventType(part).includes("tool-call"))
+  const toolResults = [...content, ...(Array.isArray(value.toolResults) ? value.toolResults : [])]
+    .filter(part => eventType(part).includes("tool-result") || eventType(part).includes("tool-output"))
+  const completedIds = new Set(toolResults.map(eventToolId).filter(Boolean))
   return {
-    completedTools: [...new Set(parts.map(eventToolName).filter(Boolean))],
-    reasoning: parts.some(part => eventType(part).includes("reasoning")),
+    activeTools: [...new Set(toolCalls.filter(part => !completedIds.has(eventToolId(part))).map(eventToolName).filter(Boolean))],
+    completedTools: [...new Set(toolResults.map(eventToolName).filter(Boolean))],
+    reasoning: content.some(part => eventType(part).includes("reasoning")),
   }
 }
 
@@ -657,7 +659,7 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
                 await previous?.(event)
                 if (!context.context.get(messageChannelProgressContextKey)) return
                 const evidence = stepProgressEvidence(event)
-                if (!evidence.reasoning && !evidence.completedTools.length) return
+                if (!evidence.reasoning && !evidence.activeTools.length && !evidence.completedTools.length) return
                 generatedCompletedTools.push(...evidence.completedTools)
                 const now = Date.now()
                 if (generatedLastAt && now - generatedLastAt < (options.intervalMs ?? 10_000)) return
@@ -674,7 +676,7 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
                   }
                   try {
                     const summary = await generateProgressSummary(context, options, {
-                      activeTools: [],
+                      activeTools: evidence.activeTools,
                       completedTools: generatedCompletedTools.slice(-5),
                       elapsedMs: Date.now() - generatedStartedAt,
                       input,

--- a/packages/agent/src/capabilities/progress-summary.ts
+++ b/packages/agent/src/capabilities/progress-summary.ts
@@ -4,6 +4,7 @@ import { capabilityInvocationStartSymbol, defineCapability, eagerFinishExtension
 import { toAgentUiMessageStreamResponse } from "../http-response.ts"
 import { normalizeAgentDriver, resolveNormalizedHarnessDriver } from "../internal/agent-driver.ts"
 import { progressSummaryOutputContextKey } from "../internal/agent-output-events.ts"
+import { messageChannelProgressContextKey, updateMessageChannelProgress } from "../internal/message-channel-progress.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 import { quietExpectedAuxiliaryHarnessCancellation } from "../internal/auxiliary-harness.ts"
 import { markAuxiliaryMessageChannelInstructionContext } from "../internal/channels.ts"
@@ -108,6 +109,19 @@ function eventToolId(value: unknown): string {
   if (!isRecord(value)) return ""
   const id = value.toolCallId ?? value.id
   return typeof id === "string" ? id : ""
+}
+
+function stepProgressEvidence(value: unknown): { completedTools: string[], reasoning: boolean } {
+  if (!isRecord(value)) return { completedTools: [], reasoning: false }
+  const parts = [
+    ...(Array.isArray(value.content) ? value.content : []),
+    ...(Array.isArray(value.toolCalls) ? value.toolCalls : []),
+    ...(Array.isArray(value.toolResults) ? value.toolResults : []),
+  ]
+  return {
+    completedTools: [...new Set(parts.map(eventToolName).filter(Boolean))],
+    reasoning: parts.some(part => eventType(part).includes("reasoning")),
+  }
 }
 
 function firstUserText(messages: Message[], input: AgentRunInput): string {
@@ -589,6 +603,9 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
     output(context) {
       context.context.set(progressSummaryOutputContextKey, true, { overwrite: true })
       let state: ProgressSummaryState | undefined
+      let generatedPrevious: string | undefined
+      const generatedCompletedTools: string[] = []
+      const generatedStartedAt = Date.now()
       const getState = () => {
         if (state) return state
         const messages = context.input.messages()
@@ -600,6 +617,43 @@ export function progressSummary<TRuntimeConfig extends AgentRuntimeConfig = Agen
       invocationStarts.set(context.context, () => {
         if (context.invocation?.kind === "stream" && context.driver?.kind === "harness") getState()
       })
+      if (context.invocation?.kind === "run") {
+        context.modelExecution.instrument({
+          callSettings({ callSettings }) {
+            const previous = typeof callSettings.onStepFinish === "function"
+              ? callSettings.onStepFinish as (event: unknown) => MaybePromise<void>
+              : undefined
+            return {
+              async onStepFinish(event: unknown) {
+                await previous?.(event)
+                if (!context.context.get(messageChannelProgressContextKey)) return
+                const evidence = stepProgressEvidence(event)
+                generatedCompletedTools.push(...evidence.completedTools)
+                const messages = context.input.messages()
+                const inputValue = context.input.get()
+                try {
+                  const summary = await generateProgressSummary(context, options, {
+                    activeTools: [],
+                    completedTools: generatedCompletedTools.slice(-5),
+                    elapsedMs: Date.now() - generatedStartedAt,
+                    input: inputValue,
+                    messages,
+                    previous: generatedPrevious,
+                    reasoning: evidence.reasoning ? "Active" : undefined,
+                    userText: firstUserText(messages, inputValue),
+                  })
+                  if (!summary || summary === generatedPrevious) return
+                  generatedPrevious = summary
+                  await updateMessageChannelProgress(context, summary)
+                }
+                catch {
+                  console.warn("[vitehub] progressSummary() generation failed.")
+                }
+              },
+            }
+          },
+        })
+      }
       context.output.render((result) => {
         if (isStreamResult(result)) {
           const state = getState()

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -3,7 +3,7 @@ import { CHAT_FINISH_EXTENSION_CONTEXT_KEY } from "./chat-trigger.ts"
 import { readPullRequestContext } from "./capabilities/repository-host-context.ts"
 import { defineCapability } from "./capability-runtime.ts"
 import { isAsyncIterable } from "./internal/stream-result.ts"
-import { clearMessageChannelProgress, messageChannelProgressClearedContextKey, messageChannelProgressContextKey, type MessageChannelProgressReference } from "./internal/message-channel-progress.ts"
+import { clearMessageChannelProgress, messageChannelProgressClearedContextKey, messageChannelProgressContextKey, type MessageChannelProgressReference, withinMessageChannelProgressDeadline } from "./internal/message-channel-progress.ts"
 import {
   deliveryArtifactAttachments,
   deliveryArtifactMarkdownReferencePaths,
@@ -1249,7 +1249,10 @@ async function messageChannelReplyEffect<TRuntimeConfig extends AgentRuntimeConf
     if (progress && context.context.get<boolean>(messageChannelProgressClearedContextKey) !== true) {
       if (progress.reusable !== false && context.effect.intent === "chat.error-fallback" && adapter.editMessage && !attachments.length && !files.length) {
         try {
-          await adapter.editMessage(progress.threadId, progress.messageId, message)
+          await withinMessageChannelProgressDeadline(
+            adapter.editMessage(progress.threadId, progress.messageId, message),
+            "[vitehub] Timed out replacing message Channel progress with an error fallback.",
+          )
           context.context.set(messageChannelProgressClearedContextKey, true, { overwrite: true })
           return
         }

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -3,6 +3,7 @@ import { CHAT_FINISH_EXTENSION_CONTEXT_KEY } from "./chat-trigger.ts"
 import { readPullRequestContext } from "./capabilities/repository-host-context.ts"
 import { defineCapability } from "./capability-runtime.ts"
 import { isAsyncIterable } from "./internal/stream-result.ts"
+import { messageChannelProgressClearedContextKey, messageChannelProgressContextKey, type MessageChannelProgressReference } from "./internal/message-channel-progress.ts"
 import {
   deliveryArtifactAttachments,
   deliveryArtifactMarkdownReferencePaths,
@@ -1238,6 +1239,20 @@ async function messageChannelReplyEffect<TRuntimeConfig extends AgentRuntimeConf
     ? await resolveEffectOption(context.channel.adapter as MaybeResolvable<Adapter, AgentChannelDeliveryEffectContext<TRuntimeConfig>>, context)
     : undefined
   if (adapter && context.run?.threadId) {
+    const progress = context.context.get<MessageChannelProgressReference>(messageChannelProgressContextKey)
+    if (progress && context.context.get<boolean>(messageChannelProgressClearedContextKey) !== true) {
+      try {
+        await adapter.deleteMessage(progress.threadId, progress.messageId)
+        context.context.set(messageChannelProgressClearedContextKey, true, { overwrite: true })
+      }
+      catch {
+        if (adapter.editMessage && !attachments.length && !files.length) {
+          await adapter.editMessage(progress.threadId, progress.messageId, message)
+          context.context.set(messageChannelProgressClearedContextKey, true, { overwrite: true })
+          return
+        }
+      }
+    }
     await adapter.postMessage(adapter.channelIdFromThreadId(context.run.threadId), message)
   }
 }

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -3,7 +3,7 @@ import { CHAT_FINISH_EXTENSION_CONTEXT_KEY } from "./chat-trigger.ts"
 import { readPullRequestContext } from "./capabilities/repository-host-context.ts"
 import { defineCapability } from "./capability-runtime.ts"
 import { isAsyncIterable } from "./internal/stream-result.ts"
-import { messageChannelProgressClearedContextKey, messageChannelProgressContextKey, type MessageChannelProgressReference } from "./internal/message-channel-progress.ts"
+import { clearMessageChannelProgress, messageChannelProgressClearedContextKey, messageChannelProgressContextKey, type MessageChannelProgressReference } from "./internal/message-channel-progress.ts"
 import {
   deliveryArtifactAttachments,
   deliveryArtifactMarkdownReferencePaths,
@@ -1209,6 +1209,12 @@ async function messageChannelReplyEffect<TRuntimeConfig extends AgentRuntimeConf
       ? await resolveEffectOption(context.channel.adapter as MaybeResolvable<Adapter, AgentChannelDeliveryEffectContext<TRuntimeConfig>>, context)
       : undefined
     if (adapter && context.run?.threadId) {
+      try {
+        await clearMessageChannelProgress({ ...context, adapter })
+      }
+      catch {
+        console.warn("[vitehub] failed to clear message Channel progress.")
+      }
       const threadId = adapter.channelIdFromThreadId(context.run.threadId)
       if (adapter.stream && await adapter.stream(threadId, stream) !== null) return
       let body = ""
@@ -1241,12 +1247,21 @@ async function messageChannelReplyEffect<TRuntimeConfig extends AgentRuntimeConf
   if (adapter && context.run?.threadId) {
     const progress = context.context.get<MessageChannelProgressReference>(messageChannelProgressContextKey)
     if (progress && context.context.get<boolean>(messageChannelProgressClearedContextKey) !== true) {
+      if (progress.reusable !== false && context.effect.intent === "chat.error-fallback" && adapter.editMessage && !attachments.length && !files.length) {
+        try {
+          await adapter.editMessage(progress.threadId, progress.messageId, message)
+          context.context.set(messageChannelProgressClearedContextKey, true, { overwrite: true })
+          return
+        }
+        catch {
+          // Fall through to delete-then-post so a failed edit does not suppress the fallback.
+        }
+      }
       try {
-        await adapter.deleteMessage(progress.threadId, progress.messageId)
-        context.context.set(messageChannelProgressClearedContextKey, true, { overwrite: true })
+        await clearMessageChannelProgress({ ...context, adapter })
       }
       catch {
-        if (adapter.editMessage && !attachments.length && !files.length) {
+        if (progress.reusable !== false && adapter.editMessage && !attachments.length && !files.length) {
           await adapter.editMessage(progress.threadId, progress.messageId, message)
           context.context.set(messageChannelProgressClearedContextKey, true, { overwrite: true })
           return

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1261,11 +1261,8 @@ async function messageChannelReplyEffect<TRuntimeConfig extends AgentRuntimeConf
         await clearMessageChannelProgress({ ...context, adapter })
       }
       catch {
-        if (progress.reusable !== false && adapter.editMessage && !attachments.length && !files.length) {
-          await adapter.editMessage(progress.threadId, progress.messageId, message)
-          context.context.set(messageChannelProgressClearedContextKey, true, { overwrite: true })
-          return
-        }
+        // Terminal replies are always new notifications. A failed disposable
+        // cleanup must not make progress-message reuse part of the success path.
       }
     }
     await adapter.postMessage(adapter.channelIdFromThreadId(context.run.threadId), message)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -25,7 +25,7 @@ import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasT
 import { defineChatCapability, getAgentChatContext, getChatCapabilityOptions, resolveDurableChatErrorFallbackText } from "./chat-trigger.ts"
 import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
 import { activeMessageChannelContextKey, clearMessageChannelProgress, messageChannelProgressContextKey } from "./internal/message-channel-progress.ts"
-import { progressSummary } from "./capabilities/progress-summary.ts"
+import { progressSummary, progressSummaryCapabilityMetadataKey } from "./capabilities/progress-summary.ts"
 import {
   bindMessageChannelInstructions,
   finishMessageChannelTitleDelivery,
@@ -2068,7 +2068,8 @@ async function createAgentInvocationContext<
     if (invocationContext.get(messageChannelProgressContextKey)
       && activeChannel?.messages !== false
       && activeChannel?.messages?.fallbackStreamingPlaceholderText !== null
-      && !capabilityDefinitions.some(capability => capability.id === "progress-summary")) {
+      && !capabilityDefinitions.some(capability => capability.id === "progress-summary"
+        || capability.metadata?.[progressSummaryCapabilityMetadataKey] === true)) {
       capabilityDefinitions.push(progressSummary<TRuntimeConfig>())
     }
     const resolvedCapabilityDefinitions = normalizeCapabilities(capabilityDefinitions) as AgentCapabilityDefinition<TRuntimeConfig>[]

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -24,7 +24,7 @@ import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
 import { defineChatCapability, getAgentChatContext, getChatCapabilityOptions, resolveDurableChatErrorFallbackText } from "./chat-trigger.ts"
 import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
-import { activeMessageChannelContextKey, messageChannelProgressContextKey } from "./internal/message-channel-progress.ts"
+import { activeMessageChannelContextKey, clearMessageChannelProgress, messageChannelProgressContextKey } from "./internal/message-channel-progress.ts"
 import { progressSummary } from "./capabilities/progress-summary.ts"
 import {
   bindMessageChannelInstructions,
@@ -3065,6 +3065,23 @@ async function finishAgentInvocation<
     throw finishError
   }
   finally {
+    if ((context.runtimeContext as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey]) {
+      try {
+        await clearMessageChannelProgress({
+          ...context.runtimeContext,
+          actor: context.actor,
+          channel: activeAgentChannel(context.channels, context.context, context.run)?.channel,
+          context: context.context,
+          input: context.input,
+          invoker: context.invoker,
+          run: context.run,
+          workspace: context.workspace,
+        })
+      }
+      catch {
+        console.warn("[vitehub] failed to clear message Channel progress.")
+      }
+    }
     scheduleAgentTelemetry(context.telemetry, context.runtimeContext, context.telemetryAgent, context.telemetryInvocationId)
   }
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3294,35 +3294,54 @@ async function deliverUnpreparedWorkflowFailure<TRuntimeConfig extends AgentRunt
   error: unknown,
 ): Promise<void> {
   if (!(context as AgentRuntimeContext & { [agentWorkflowExecutionContextKey]?: boolean })[agentWorkflowExecutionContextKey]) return
-  const options = getChatCapabilityOptions<TRuntimeConfig>(definition?.capabilities || [])
-  if (!options) return
-  const intents: AgentChannelDeliveryEffectIntent[] = []
   const invocationContext = createAgentInvocationContextStore(input.context)
-  const chat = getAgentChatContext(invocationContext)
-  const fallback = await resolveDurableChatErrorFallbackText(options, {
-    error,
-    history: input.messages || [],
-    message: chat?.message || { text: "" },
-    publicError: toAgentPublicError(error, "http"),
-    run: context.run,
-    thread: {
-      post: async message => intents.push(createReplyDeliveryEffectIntent(message as never, { intent: "chat.error-fallback" })),
-    },
-    toolResults: [],
-  }, () => intents.length > 0)
-  if (!intents.length && fallback) intents.push(createReplyDeliveryEffectIntent(fallback, { intent: "chat.error-fallback" }))
-  if (!intents.length) return
   const invoker = createFallbackAgentInvoker(context.run)
-  await applyChannelDeliveryEffectIntents({
-    actor: invoker,
-    channels: definition?.channels,
-    context: invocationContext,
-    hooks: definition?.hooks as AgentHookObserverHooks | undefined,
-    input,
-    invoker,
-    run: context.run,
-    runtimeContext: createResolvedRuntimeContext(context),
-  } as never, intents)
+  const runtimeContext = createResolvedRuntimeContext(context)
+  try {
+    const options = getChatCapabilityOptions<TRuntimeConfig>(definition?.capabilities || [])
+    if (!options) return
+    const intents: AgentChannelDeliveryEffectIntent[] = []
+    const chat = getAgentChatContext(invocationContext)
+    const fallback = await resolveDurableChatErrorFallbackText(options, {
+      error,
+      history: input.messages || [],
+      message: chat?.message || { text: "" },
+      publicError: toAgentPublicError(error, "http"),
+      run: context.run,
+      thread: {
+        post: async message => intents.push(createReplyDeliveryEffectIntent(message as never, { intent: "chat.error-fallback" })),
+      },
+      toolResults: [],
+    }, () => intents.length > 0)
+    if (!intents.length && fallback) intents.push(createReplyDeliveryEffectIntent(fallback, { intent: "chat.error-fallback" }))
+    if (!intents.length) return
+    await applyChannelDeliveryEffectIntents({
+      actor: invoker,
+      channels: definition?.channels,
+      context: invocationContext,
+      hooks: definition?.hooks as AgentHookObserverHooks | undefined,
+      input,
+      invoker,
+      run: context.run,
+      runtimeContext,
+    } as never, intents)
+  }
+  finally {
+    try {
+      await clearMessageChannelProgress({
+        ...runtimeContext,
+        actor: invoker,
+        channel: activeAgentChannel(definition?.channels, invocationContext, context.run)?.channel,
+        context: invocationContext,
+        input,
+        invoker,
+        run: context.run,
+      })
+    }
+    catch {
+      console.warn("[vitehub] failed to clear message Channel progress.")
+    }
+  }
 }
 
 async function executeAgentInvocationWithCapacityLease<

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -24,6 +24,8 @@ import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
 import { defineChatCapability, getAgentChatContext, getChatCapabilityOptions, resolveDurableChatErrorFallbackText } from "./chat-trigger.ts"
 import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
+import { activeMessageChannelContextKey, messageChannelProgressContextKey } from "./internal/message-channel-progress.ts"
+import { progressSummary } from "./capabilities/progress-summary.ts"
 import {
   bindMessageChannelInstructions,
   finishMessageChannelTitleDelivery,
@@ -2024,10 +2026,9 @@ async function createAgentInvocationContext<
       ? { ...tracedRuntimeContext, runEvents: boundRunEvents }
       : tracedRuntimeContext
     const callbackContext = createAgentCallbackContext(runtimeContext)
-    bindMessageChannelInstructions(
-      invocationContext,
-      activeAgentChannel(definition?.channels, invocationContext, context.run)?.channel,
-    )
+    const invocationChannel = activeAgentChannel(definition?.channels, invocationContext, context.run)?.channel
+    bindMessageChannelInstructions(invocationContext, invocationChannel)
+    if (invocationChannel) invocationContext.set(activeMessageChannelContextKey, invocationChannel, { overwrite: true })
     invocationContext.set(scheduledAgentChannelIdsContextKey, Object.keys(definition?.channels || {}), { overwrite: true })
     invocationContext.set(scheduledAgentNameContextKey, context.agentIdentity?.name, { overwrite: true })
     const colocatedSkills = (definition as AgentDefinitionWithBaseResolve<TRuntimeConfig, CALL_OPTIONS> | undefined)?.[colocatedAgentSkillsSymbol]
@@ -2059,11 +2060,18 @@ async function createAgentInvocationContext<
       : []
     const activeChannel = activeAgentChannel(definition?.channels, invocationContext, context.run)?.channel
     const channelCapabilities = activeChannel?.capabilities || []
-    const resolvedCapabilityDefinitions = normalizeCapabilities([
+    const capabilityDefinitions = [
       ...invocationResolvedCapabilities,
       ...(definition?.capabilities || []),
       ...channelCapabilities,
-    ]) as AgentCapabilityDefinition<TRuntimeConfig>[]
+    ]
+    if (invocationContext.get(messageChannelProgressContextKey)
+      && activeChannel?.messages !== false
+      && activeChannel?.messages?.fallbackStreamingPlaceholderText !== null
+      && !capabilityDefinitions.some(capability => capability.id === "progress-summary")) {
+      capabilityDefinitions.push(progressSummary<TRuntimeConfig>())
+    }
+    const resolvedCapabilityDefinitions = normalizeCapabilities(capabilityDefinitions) as AgentCapabilityDefinition<TRuntimeConfig>[]
     const workspaceMode = workspaceOptions ? workspaceModeFromOptions(workspaceOptions) : "read"
     validateAgentCapabilityComposition(resolvedCapabilityDefinitions, {
       hasBox: Boolean(definition?.box),

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -278,6 +278,9 @@ export function resolveAgentChannelChatOptions<TRuntimeConfig extends AgentRunti
   }
 
   if (!hasMessageChannel) return undefined
+  if (options.fallbackStreamingPlaceholderText === undefined) {
+    options.fallbackStreamingPlaceholderText = "Working on it…"
+  }
   if (channelIdentities.length) {
     if (messageChannelCount > 1) {
       throw new TypeError("[vitehub] Channel-local identity resolvers are only supported when an Agent defines one message-shaped Channel. Move shared identity to defineAgent({ messages: { identity } }) until Channel-scoped chat triggers land.")

--- a/packages/agent/src/internal/message-channel-progress.ts
+++ b/packages/agent/src/internal/message-channel-progress.ts
@@ -1,26 +1,58 @@
 import { resolveRuntimeValue } from "@vite-hub/runtime"
 
-import type { AgentCapabilityRuntimeContext, AgentChannelDefinition } from "../types.ts"
+import type { AgentCapabilityRuntimeContext, AgentChannelDefinition, AgentInvocationContextStore, AgentRuntimeConfig } from "../types.ts"
 import type { Adapter } from "chat"
 
 export const activeMessageChannelContextKey = "agent.channel.active"
 export const messageChannelProgressContextKey = "agent.channel.progress"
 export const messageChannelProgressClearedContextKey = "agent.channel.progress.cleared"
+export const messageChannelProgressUpdatesClosedContextKey = "agent.channel.progress.updates-closed"
 
 export interface MessageChannelProgressReference {
   messageId: string
+  ready?: Promise<MessageChannelProgressReference | undefined>
+  reusable?: boolean
   threadId: string
+}
+
+async function resolveMessageChannelProgressReference(
+  progress: MessageChannelProgressReference | undefined,
+): Promise<{ messageId: string, threadId: string } | undefined> {
+  const resolved = progress?.ready ? await progress.ready : progress
+  if (typeof resolved?.messageId !== "string" || typeof resolved.threadId !== "string") return
+  return { messageId: resolved.messageId, threadId: resolved.threadId }
+}
+
+interface MessageChannelProgressRuntimeContext<TRuntimeConfig extends AgentRuntimeConfig> {
+  [key: string]: unknown
+  adapter?: Adapter
+  channel?: AgentChannelDefinition<TRuntimeConfig>
+  context: AgentInvocationContextStore
+}
+
+export async function clearMessageChannelProgress<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: MessageChannelProgressRuntimeContext<TRuntimeConfig>,
+): Promise<boolean> {
+  const channel = context.channel || context.context.get<AgentChannelDefinition<TRuntimeConfig>>(activeMessageChannelContextKey)
+  const progress = await resolveMessageChannelProgressReference(context.context.get<MessageChannelProgressReference>(messageChannelProgressContextKey))
+  if (!channel?.adapter || !progress || context.context.get<boolean>(messageChannelProgressClearedContextKey) === true) return false
+  const adapter = context.adapter || await resolveRuntimeValue(channel.adapter, context as never) as Adapter | undefined
+  if (!adapter?.deleteMessage) return false
+  await adapter.deleteMessage(progress.threadId, progress.messageId)
+  context.context.set(messageChannelProgressClearedContextKey, true, { overwrite: true })
+  return true
 }
 
 export async function updateMessageChannelProgress(
   context: AgentCapabilityRuntimeContext,
   summary: string,
 ): Promise<boolean> {
+  if (context.context.get<boolean>(messageChannelProgressUpdatesClosedContextKey) === true) return false
   const channel = context.context.get<AgentChannelDefinition>(activeMessageChannelContextKey)
-  const progress = context.context.get<MessageChannelProgressReference>(messageChannelProgressContextKey)
+  const progress = await resolveMessageChannelProgressReference(context.context.get<MessageChannelProgressReference>(messageChannelProgressContextKey))
   if (!channel?.adapter || !progress) return false
   const adapter = await resolveRuntimeValue(channel.adapter, context as never) as Adapter | undefined
-  if (!adapter?.editMessage) return false
+  if (!adapter?.editMessage || context.context.get<boolean>(messageChannelProgressUpdatesClosedContextKey) === true) return false
   await adapter.editMessage(progress.threadId, progress.messageId, { markdown: summary })
   return true
 }

--- a/packages/agent/src/internal/message-channel-progress.ts
+++ b/packages/agent/src/internal/message-channel-progress.ts
@@ -9,6 +9,28 @@ export const messageChannelProgressClearedContextKey = "agent.channel.progress.c
 export const messageChannelProgressUpdatesClosedContextKey = "agent.channel.progress.updates-closed"
 const messageChannelProgressCleanupTimeoutMs = 1_000
 
+export async function withinMessageChannelProgressDeadline<T>(
+  operation: Promise<T>,
+  message: string,
+  onTimeout?: () => void,
+): Promise<T> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => {
+          onTimeout?.()
+          reject(new Error(message))
+        }, messageChannelProgressCleanupTimeoutMs)
+      }),
+    ])
+  }
+  finally {
+    if (timeoutId) clearTimeout(timeoutId)
+  }
+}
+
 export interface MessageChannelProgressReference {
   messageId: string
   ready?: Promise<MessageChannelProgressReference | undefined>
@@ -39,22 +61,16 @@ export async function clearMessageChannelProgress<TRuntimeConfig extends AgentRu
   if (!channel?.adapter || !progress || context.context.get<boolean>(messageChannelProgressClearedContextKey) === true) return false
   const adapter = context.adapter || await resolveRuntimeValue(channel.adapter, context as never) as Adapter | undefined
   if (!adapter?.deleteMessage) return false
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
   try {
-    await Promise.race([
+    await withinMessageChannelProgressDeadline(
       adapter.deleteMessage(progress.threadId, progress.messageId),
-      new Promise<never>((_resolve, reject) => {
-        timeoutId = setTimeout(() => reject(new Error("[vitehub] Timed out clearing message Channel progress.")), messageChannelProgressCleanupTimeoutMs)
-      }),
-    ])
+      "[vitehub] Timed out clearing message Channel progress.",
+    )
   }
   catch (error) {
     const reference = context.context.get<MessageChannelProgressReference>(messageChannelProgressContextKey)
     if (reference) reference.reusable = false
     throw error
-  }
-  finally {
-    if (timeoutId) clearTimeout(timeoutId)
   }
   context.context.set(messageChannelProgressClearedContextKey, true, { overwrite: true })
   return true

--- a/packages/agent/src/internal/message-channel-progress.ts
+++ b/packages/agent/src/internal/message-channel-progress.ts
@@ -7,6 +7,7 @@ export const activeMessageChannelContextKey = "agent.channel.active"
 export const messageChannelProgressContextKey = "agent.channel.progress"
 export const messageChannelProgressClearedContextKey = "agent.channel.progress.cleared"
 export const messageChannelProgressUpdatesClosedContextKey = "agent.channel.progress.updates-closed"
+const messageChannelProgressCleanupTimeoutMs = 1_000
 
 export interface MessageChannelProgressReference {
   messageId: string
@@ -38,7 +39,23 @@ export async function clearMessageChannelProgress<TRuntimeConfig extends AgentRu
   if (!channel?.adapter || !progress || context.context.get<boolean>(messageChannelProgressClearedContextKey) === true) return false
   const adapter = context.adapter || await resolveRuntimeValue(channel.adapter, context as never) as Adapter | undefined
   if (!adapter?.deleteMessage) return false
-  await adapter.deleteMessage(progress.threadId, progress.messageId)
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      adapter.deleteMessage(progress.threadId, progress.messageId),
+      new Promise<never>((_resolve, reject) => {
+        timeoutId = setTimeout(() => reject(new Error("[vitehub] Timed out clearing message Channel progress.")), messageChannelProgressCleanupTimeoutMs)
+      }),
+    ])
+  }
+  catch (error) {
+    const reference = context.context.get<MessageChannelProgressReference>(messageChannelProgressContextKey)
+    if (reference) reference.reusable = false
+    throw error
+  }
+  finally {
+    if (timeoutId) clearTimeout(timeoutId)
+  }
   context.context.set(messageChannelProgressClearedContextKey, true, { overwrite: true })
   return true
 }

--- a/packages/agent/src/internal/message-channel-progress.ts
+++ b/packages/agent/src/internal/message-channel-progress.ts
@@ -1,0 +1,26 @@
+import { resolveRuntimeValue } from "@vite-hub/runtime"
+
+import type { AgentCapabilityRuntimeContext, AgentChannelDefinition } from "../types.ts"
+import type { Adapter } from "chat"
+
+export const activeMessageChannelContextKey = "agent.channel.active"
+export const messageChannelProgressContextKey = "agent.channel.progress"
+export const messageChannelProgressClearedContextKey = "agent.channel.progress.cleared"
+
+export interface MessageChannelProgressReference {
+  messageId: string
+  threadId: string
+}
+
+export async function updateMessageChannelProgress(
+  context: AgentCapabilityRuntimeContext,
+  summary: string,
+): Promise<boolean> {
+  const channel = context.context.get<AgentChannelDefinition>(activeMessageChannelContextKey)
+  const progress = context.context.get<MessageChannelProgressReference>(messageChannelProgressContextKey)
+  if (!channel?.adapter || !progress) return false
+  const adapter = await resolveRuntimeValue(channel.adapter, context as never) as Adapter | undefined
+  if (!adapter?.editMessage) return false
+  await adapter.editMessage(progress.threadId, progress.messageId, { markdown: summary })
+  return true
+}

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3103,9 +3103,15 @@ async function deliverToManualDeliveryPlaceholder(
   beforeDelete?: () => void,
 ): Promise<boolean> {
   if (!placeholder) return false
-  if (await replaceManualDeliveryPlaceholder(placeholder, message).catch(() => false)) return true
+  if (await withinMessageChannelProgressDeadline(
+    replaceManualDeliveryPlaceholder(placeholder, message),
+    "Disposable chat progress replacement timed out.",
+  ).catch(() => false)) return true
   beforeDelete?.()
-  await deleteManualDeliveryPlaceholder(placeholder)
+  await withinMessageChannelProgressDeadline(
+    deleteManualDeliveryPlaceholder(placeholder),
+    "Disposable chat progress cleanup timed out.",
+  ).catch(() => undefined)
   return false
 }
 
@@ -3175,7 +3181,9 @@ async function postChatErrorFallback(
   const fallbackDeliveryAbort = maximumInvocationDeadline === undefined ? undefined : new AbortController()
   const fallbackDelivery = (async () => {
     if (!fallback) {
-      if (fallbackPlaceholder) await deleteManualDeliveryPlaceholder(fallbackPlaceholder)
+      if (fallbackPlaceholder) {
+        await deleteManualDeliveryPlaceholderWithin(fallbackPlaceholder).catch(() => undefined)
+      }
       return
     }
     if (await deliverToManualDeliveryPlaceholder(fallbackPlaceholder, fallback)) return
@@ -3636,7 +3644,9 @@ async function handleChatSdkMessage(
           await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState, invocationDeadlineAbort?.signal)
           const unusedPlaceholder = manualDeliveryState.placeholder
           if (unusedPlaceholder) {
-            await deleteManualDeliveryPlaceholder(unusedPlaceholder)
+            await deleteManualDeliveryPlaceholderWithin(unusedPlaceholder).catch(error => {
+              console.warn("[vitehub] Could not delete an unused progress message.", error)
+            })
             if (manualDeliveryState.placeholder === unusedPlaceholder) {
               manualDeliveryState.placeholder = undefined
             }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3026,6 +3026,29 @@ async function replaceManualDeliveryPlaceholder(placeholder: unknown, message: A
   return true
 }
 
+async function replaceManualDeliveryPlaceholderWithin(
+  placeholder: unknown,
+  message: AgentChatMessage,
+  timeoutMs = 1_000,
+  onTimeout?: () => void,
+): Promise<boolean> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    return await Promise.race([
+      replaceManualDeliveryPlaceholder(placeholder, message),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          onTimeout?.()
+          reject(new Error("Disposable chat progress replacement timed out."))
+        }, timeoutMs)
+      }),
+    ])
+  }
+  finally {
+    if (timeoutId) clearTimeout(timeoutId)
+  }
+}
+
 async function deleteManualDeliveryPlaceholder(placeholder: unknown): Promise<void> {
   const message = "Manual chat delivery could not remove its placeholder."
   if (!placeholder || typeof placeholder !== "object" || !("delete" in placeholder) || typeof placeholder.delete !== "function") {
@@ -3622,8 +3645,14 @@ async function handleChatSdkMessage(
                 }
               }
               else if (text) {
-                if (!await replaceManualDeliveryPlaceholder(completedPlaceholder, { markdown: text }).catch(() => false)) throw error
-                text = ""
+                const replaced = await replaceManualDeliveryPlaceholderWithin(completedPlaceholder, { markdown: text }, 1_000, () => {
+                  if (progressReference) progressReference.reusable = false
+                }).catch(() => false)
+                if (manualDeliveryState.placeholder === completedPlaceholder) {
+                  manualDeliveryState.placeholder = undefined
+                }
+                if (replaced) text = ""
+                else console.warn("[vitehub] Could not replace a progress message; posting final output separately.", error)
               }
             }
             finally {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -17,7 +17,7 @@ import { finalChannelOutputContextKey, hasOnlyPortableAgentWorkflowCapabilities,
 import { agentChannelHistoryHeader } from "../internal/channel-history.ts"
 import { agentChannelSyncProviderHeader } from "../internal/channel-sync.ts"
 import { agentOutputEventObserverContextKey } from "../internal/agent-output-events.ts"
-import { messageChannelProgressContextKey, type MessageChannelProgressReference } from "../internal/message-channel-progress.ts"
+import { messageChannelProgressContextKey, type MessageChannelProgressReference, withinMessageChannelProgressDeadline } from "../internal/message-channel-progress.ts"
 import { attachmentStringBytes, isAttachmentData } from "../messages.ts"
 import { resolveAgentInvoker, withResolvedAgentInvokerInput } from "../invoker.ts"
 import { createAgentRuntimeContext } from "../runtime/context.ts"
@@ -1498,6 +1498,7 @@ function createManualDeliveryProgressUpdater(
   manualDelivery: { placeholder?: unknown },
   waitUntil: AgentWaitUntil,
   abortSignal?: AbortSignal,
+  placeholderReady?: Promise<unknown>,
 ): {
   finish: () => Promise<void>
   update: (summary: string) => void
@@ -1519,6 +1520,9 @@ function createManualDeliveryProgressUpdater(
       draining = undefined
       if (active && latest && manualDelivery.placeholder) startDrain()
     })
+  }
+  if (placeholderReady) {
+    waitUntil(placeholderReady.then(() => startDrain()).catch(() => undefined))
   }
 
   return {
@@ -3026,29 +3030,6 @@ async function replaceManualDeliveryPlaceholder(placeholder: unknown, message: A
   return true
 }
 
-async function replaceManualDeliveryPlaceholderWithin(
-  placeholder: unknown,
-  message: AgentChatMessage,
-  timeoutMs = 1_000,
-  onTimeout?: () => void,
-): Promise<boolean> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
-  try {
-    return await Promise.race([
-      replaceManualDeliveryPlaceholder(placeholder, message),
-      new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          onTimeout?.()
-          reject(new Error("Disposable chat progress replacement timed out."))
-        }, timeoutMs)
-      }),
-    ])
-  }
-  finally {
-    if (timeoutId) clearTimeout(timeoutId)
-  }
-}
-
 async function deleteManualDeliveryPlaceholder(placeholder: unknown): Promise<void> {
   const message = "Manual chat delivery could not remove its placeholder."
   if (!placeholder || typeof placeholder !== "object" || !("delete" in placeholder) || typeof placeholder.delete !== "function") {
@@ -3064,24 +3045,13 @@ async function deleteManualDeliveryPlaceholder(placeholder: unknown): Promise<vo
 
 async function deleteManualDeliveryPlaceholderWithin(
   placeholder: unknown,
-  timeoutMs = 1_000,
   onTimeout?: () => void,
 ): Promise<void> {
-  let timeoutId: ReturnType<typeof setTimeout> | undefined
-  try {
-    await Promise.race([
-      deleteManualDeliveryPlaceholder(placeholder),
-      new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(() => {
-          onTimeout?.()
-          reject(new Error("Disposable chat progress cleanup timed out."))
-        }, timeoutMs)
-      }),
-    ])
-  }
-  finally {
-    if (timeoutId) clearTimeout(timeoutId)
-  }
+  await withinMessageChannelProgressDeadline(
+    deleteManualDeliveryPlaceholder(placeholder),
+    "Disposable chat progress cleanup timed out.",
+    onTimeout,
+  )
 }
 
 async function postDisposableChatMessage(thread: Thread, message: string): Promise<unknown> {
@@ -3521,12 +3491,11 @@ async function handleChatSdkMessage(
         }
         return placeholder
       })
-      if (manualDelivery) {
-        manualDeliveryState.placeholder = await enforceChatInvocationTimeout(
-          placeholderDelivery,
-          maximumInvocationDeadline === undefined ? undefined : Math.max(0, maximumInvocationDeadline - Date.now()),
-          invocationDeadlineAbort,
-        )
+      if (durableDelivery) {
+        // Workflow custody needs a JSON-serializable concrete reference. Keep
+        // this settlement bounded; inline execution below can carry the pending
+        // reference and starts without waiting.
+        manualDeliveryState.placeholder = await settleAutomaticProgressMessage(placeholderDelivery, context.waitUntil)
       }
       else {
         automaticProgressSettlement = settleAutomaticProgressMessage(placeholderDelivery, context.waitUntil)
@@ -3575,8 +3544,13 @@ async function handleChatSdkMessage(
       return
     }
     const chatFinish = createChatFinishExtension(input, registration)
-    progress = manualDeliveryState.placeholder
-      ? createManualDeliveryProgressUpdater(manualDeliveryState, context.waitUntil, invocationDeadlineAbort?.signal)
+    progress = manualDelivery && automaticProgressSettlement
+      ? createManualDeliveryProgressUpdater(
+          manualDeliveryState,
+          context.waitUntil,
+          invocationDeadlineAbort?.signal,
+          automaticProgressSettlement,
+        )
       : undefined
     const remainingMaximumInvocationTimeout = maximumInvocationDeadline === undefined
       ? undefined
@@ -3627,7 +3601,7 @@ async function handleChatSdkMessage(
           invocationDeadlineAbort?.signal.throwIfAborted()
           const completedPlaceholder = !manualDelivery && manualDeliveryState.placeholder
           if (completedPlaceholder) {
-            const placeholderCleanup = deleteManualDeliveryPlaceholderWithin(completedPlaceholder, 1_000, () => {
+            const placeholderCleanup = deleteManualDeliveryPlaceholderWithin(completedPlaceholder, () => {
               if (progressReference) progressReference.reusable = false
             })
             manualDeliveryState.placeholderCleanup = placeholderCleanup
@@ -3638,21 +3612,9 @@ async function handleChatSdkMessage(
               }
             }
             catch (error) {
-              if (progressReference?.reusable === false) {
-                console.warn("[vitehub] Could not delete a progress message with unsettled updates; posting final output separately.", error)
-                if (manualDeliveryState.placeholder === completedPlaceholder) {
-                  manualDeliveryState.placeholder = undefined
-                }
-              }
-              else if (text) {
-                const replaced = await replaceManualDeliveryPlaceholderWithin(completedPlaceholder, { markdown: text }, 1_000, () => {
-                  if (progressReference) progressReference.reusable = false
-                }).catch(() => false)
-                if (manualDeliveryState.placeholder === completedPlaceholder) {
-                  manualDeliveryState.placeholder = undefined
-                }
-                if (replaced) text = ""
-                else console.warn("[vitehub] Could not replace a progress message; posting final output separately.", error)
+              console.warn("[vitehub] Could not delete a progress message; posting final output separately.", error)
+              if (manualDeliveryState.placeholder === completedPlaceholder) {
+                manualDeliveryState.placeholder = undefined
               }
             }
             finally {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3555,9 +3555,9 @@ async function handleChatSdkMessage(
                 const summary = progressSummaryFromEvent(event)
                 if (summary) progress?.update(summary)
               },
-              ...(progressReference ? { [messageChannelProgressContextKey]: progressReference } : {}),
             }
           : {}),
+        ...(progressReference ? { [messageChannelProgressContextKey]: progressReference } : {}),
         ...(options?.stream === false || manualDelivery ? { [finalChannelOutputContextKey]: true } : {}),
       },
     }, invoker), chatFinish)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3053,6 +3053,27 @@ async function postDisposableChatMessage(thread: Thread, message: string): Promi
   }
 }
 
+async function settleAutomaticProgressMessage(
+  delivery: Promise<unknown>,
+  waitUntil: (task: Promise<unknown>) => void,
+): Promise<unknown> {
+  const pending = Symbol("pending")
+  const safeDelivery = delivery.catch(() => undefined)
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  const settled = await Promise.race([
+    safeDelivery,
+    new Promise<typeof pending>(resolve => {
+      timeoutId = setTimeout(() => resolve(pending), 1_000)
+    }),
+  ])
+  if (timeoutId) clearTimeout(timeoutId)
+  if (settled !== pending) return settled
+  waitUntil(safeDelivery.then(async (placeholder) => {
+    if (!placeholder) return
+    await deleteManualDeliveryPlaceholder(placeholder)
+  }).catch(() => undefined))
+}
+
 function messageChannelProgressReference(placeholder: unknown): MessageChannelProgressReference | undefined {
   if (!placeholder || typeof placeholder !== "object") return
   const { id, threadId } = placeholder as { id?: unknown, threadId?: unknown }
@@ -3445,6 +3466,7 @@ async function handleChatSdkMessage(
     const resolvedInvocationInput = invocation.input as AgentRunInput
     const thinkingFallback = invocation.metadata?.thinkingFallback
     const ownsProgressMessage = typeof thinkingFallback === "string" && (manualDelivery || !streamsPhasedReplies)
+    let automaticProgressSettlement: Promise<unknown> | undefined
     if (ownsProgressMessage) {
       const placeholderDelivery = postDisposableChatMessage(thread, thinkingFallback).then(async (placeholder) => {
         if (invocationDeadlineAbort?.signal.aborted) {
@@ -3453,13 +3475,25 @@ async function handleChatSdkMessage(
         }
         return placeholder
       })
-      manualDeliveryState.placeholder = await enforceChatInvocationTimeout(
-        placeholderDelivery,
-        maximumInvocationDeadline === undefined ? undefined : Math.max(0, maximumInvocationDeadline - Date.now()),
-        invocationDeadlineAbort,
-      )
+      if (manualDelivery) {
+        manualDeliveryState.placeholder = await enforceChatInvocationTimeout(
+          placeholderDelivery,
+          maximumInvocationDeadline === undefined ? undefined : Math.max(0, maximumInvocationDeadline - Date.now()),
+          invocationDeadlineAbort,
+        )
+      }
+      else {
+        automaticProgressSettlement = settleAutomaticProgressMessage(placeholderDelivery, context.waitUntil)
+      }
     }
     const progressReference = messageChannelProgressReference(manualDeliveryState.placeholder)
+      || (automaticProgressSettlement
+        ? {
+            messageId: "",
+            ready: automaticProgressSettlement.then(messageChannelProgressReference),
+            threadId: thread.id,
+          }
+        : undefined)
     if (durableDelivery) {
       if (state.workflowCustodySupported === false) {
         throw new Error("[vitehub] Durable Channel delivery requires reconstructable State across Agent Workflow custody. Configure Channel state or a generated host State provider.")
@@ -3532,10 +3566,14 @@ async function handleChatSdkMessage(
       // framework-owned placeholder without exposing ordinary Agent text.
       await enforceChatInvocationTimeout(
         (async () => {
-          const result = manualDelivery
-            ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
-            : await runAgentInline(agent as never, runContext as never, invocationInput as never)
-          const text = await collectAgentOutput(result, progress?.update, toolResult => toolResults.push(toolResult))
+          const resultPromise = manualDelivery
+            ? streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
+            : runAgentInline(agent as never, runContext as never, invocationInput as never)
+          if (automaticProgressSettlement) {
+            manualDeliveryState.placeholder = await automaticProgressSettlement
+          }
+          const result = await resultPromise
+          let text = await collectAgentOutput(result, progress?.update, toolResult => toolResults.push(toolResult))
           await progress?.finish()
           invocationDeadlineAbort?.signal.throwIfAborted()
           const completedPlaceholder = !manualDelivery && manualDeliveryState.placeholder
@@ -3546,6 +3584,15 @@ async function handleChatSdkMessage(
               await placeholderCleanup
               if (manualDeliveryState.placeholder === completedPlaceholder) {
                 manualDeliveryState.placeholder = undefined
+              }
+            }
+            catch (error) {
+              if (progressReference?.reusable === false) {
+                console.warn("[vitehub] Could not delete a progress message with unsettled updates; posting final output separately.", error)
+              }
+              else {
+                if (!text || !await replaceManualDeliveryPlaceholder(completedPlaceholder, { markdown: text }).catch(() => false)) throw error
+                text = ""
               }
             }
             finally {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3644,8 +3644,9 @@ async function handleChatSdkMessage(
           await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState, invocationDeadlineAbort?.signal)
           const unusedPlaceholder = manualDeliveryState.placeholder
           if (unusedPlaceholder) {
-            await deleteManualDeliveryPlaceholderWithin(unusedPlaceholder).catch(error => {
+            await deleteManualDeliveryPlaceholderWithin(unusedPlaceholder).catch((error) => {
               console.warn("[vitehub] Could not delete an unused progress message.", error)
+              throw error
             })
             if (manualDeliveryState.placeholder === unusedPlaceholder) {
               manualDeliveryState.placeholder = undefined

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -17,6 +17,7 @@ import { finalChannelOutputContextKey, hasOnlyPortableAgentWorkflowCapabilities,
 import { agentChannelHistoryHeader } from "../internal/channel-history.ts"
 import { agentChannelSyncProviderHeader } from "../internal/channel-sync.ts"
 import { agentOutputEventObserverContextKey } from "../internal/agent-output-events.ts"
+import { messageChannelProgressContextKey, type MessageChannelProgressReference } from "../internal/message-channel-progress.ts"
 import { attachmentStringBytes, isAttachmentData } from "../messages.ts"
 import { resolveAgentInvoker, withResolvedAgentInvokerInput } from "../invoker.ts"
 import { createAgentRuntimeContext } from "../runtime/context.ts"
@@ -3038,6 +3039,27 @@ async function deleteManualDeliveryPlaceholder(placeholder: unknown): Promise<vo
   }
 }
 
+async function postDisposableChatMessage(thread: Thread, message: string): Promise<unknown> {
+  const adapter = thread.adapter
+  const sent = await adapter.postMessage(thread.id, message)
+  if (!sent?.id) return sent
+  const threadId = sent.threadId || thread.id
+  return {
+    ...sent,
+    delete: async () => await adapter.deleteMessage(threadId, sent.id),
+    edit: adapter.editMessage
+      ? async (value: unknown) => await adapter.editMessage!(threadId, sent.id, value as AdapterPostableMessage)
+      : undefined,
+  }
+}
+
+function messageChannelProgressReference(placeholder: unknown): MessageChannelProgressReference | undefined {
+  if (!placeholder || typeof placeholder !== "object") return
+  const { id, threadId } = placeholder as { id?: unknown, threadId?: unknown }
+  if ((typeof id !== "string" && typeof id !== "number") || typeof threadId !== "string") return
+  return { messageId: String(id), threadId }
+}
+
 async function deliverToManualDeliveryPlaceholder(
   placeholder: unknown,
   message: AgentChatMessage,
@@ -3403,7 +3425,9 @@ async function handleChatSdkMessage(
       return
     }
 
-    typing = streamsPhasedReplies || manualDelivery ? startChatTypingRefresh(thread, context) : undefined
+    typing = streamsPhasedReplies || manualDelivery || options?.fallbackStreamingPlaceholderText !== undefined
+      ? startChatTypingRefresh(thread, context)
+      : undefined
     assertChatDeliveryOptions(options || {})
     run = invocation.run
     await recordChannelDeliveryEvidence(delivery, { type: "accepted", runId: run?.runId })
@@ -3419,6 +3443,23 @@ async function handleChatSdkMessage(
       && await hasActiveWorkflowRuntime(agent as never, runContext as never, true)
     )
     const resolvedInvocationInput = invocation.input as AgentRunInput
+    const thinkingFallback = invocation.metadata?.thinkingFallback
+    const ownsProgressMessage = typeof thinkingFallback === "string" && (manualDelivery || !streamsPhasedReplies)
+    if (ownsProgressMessage) {
+      const placeholderDelivery = postDisposableChatMessage(thread, thinkingFallback).then(async (placeholder) => {
+        if (invocationDeadlineAbort?.signal.aborted) {
+          await deleteManualDeliveryPlaceholder(placeholder)
+          invocationDeadlineAbort.signal.throwIfAborted()
+        }
+        return placeholder
+      })
+      manualDeliveryState.placeholder = await enforceChatInvocationTimeout(
+        placeholderDelivery,
+        maximumInvocationDeadline === undefined ? undefined : Math.max(0, maximumInvocationDeadline - Date.now()),
+        invocationDeadlineAbort,
+      )
+    }
+    const progressReference = messageChannelProgressReference(manualDeliveryState.placeholder)
     if (durableDelivery) {
       if (state.workflowCustodySupported === false) {
         throw new Error("[vitehub] Durable Channel delivery requires reconstructable State across Agent Workflow custody. Configure Channel state or a generated host State provider.")
@@ -3438,6 +3479,7 @@ async function handleChatSdkMessage(
               state: "chat",
             },
             [finalChannelOutputContextKey]: true,
+            ...(progressReference ? { [messageChannelProgressContextKey]: progressReference } : {}),
             [requireAgentWorkflowContextKey]: true,
           },
         }, invoker) as never)
@@ -3452,23 +3494,8 @@ async function handleChatSdkMessage(
       }
       return
     }
-    const thinkingFallback = invocation.metadata?.thinkingFallback
-    if (manualDelivery && typeof thinkingFallback === "string") {
-      const placeholderDelivery = thread.post(thinkingFallback).then(async (placeholder) => {
-        if (invocationDeadlineAbort?.signal.aborted) {
-          await deleteManualDeliveryPlaceholder(placeholder)
-          invocationDeadlineAbort.signal.throwIfAborted()
-        }
-        return placeholder
-      })
-      manualDeliveryState.placeholder = await enforceChatInvocationTimeout(
-        placeholderDelivery,
-        maximumInvocationDeadline === undefined ? undefined : Math.max(0, maximumInvocationDeadline - Date.now()),
-        invocationDeadlineAbort,
-      )
-    }
     const chatFinish = createChatFinishExtension(input, registration)
-    progress = manualDelivery
+    progress = manualDeliveryState.placeholder
       ? createManualDeliveryProgressUpdater(manualDeliveryState, context.waitUntil, invocationDeadlineAbort?.signal)
       : undefined
     const remainingMaximumInvocationTimeout = maximumInvocationDeadline === undefined
@@ -3493,6 +3520,7 @@ async function handleChatSdkMessage(
                 const summary = progressSummaryFromEvent(event)
                 if (summary) progress?.update(summary)
               },
+              ...(progressReference ? { [messageChannelProgressContextKey]: progressReference } : {}),
             }
           : {}),
         ...(options?.stream === false || manualDelivery ? { [finalChannelOutputContextKey]: true } : {}),
@@ -3508,20 +3536,9 @@ async function handleChatSdkMessage(
             ? await streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
             : await runAgentInline(agent as never, runContext as never, invocationInput as never)
           const text = await collectAgentOutput(result, progress?.update, toolResult => toolResults.push(toolResult))
-          if (!manualDelivery && text) {
-            invocationDeadlineAbort?.signal.throwIfAborted()
-            if (!await postDiscordSplitContent(thread, { markdown: text }, invocationDeadlineAbort?.signal)) {
-              const sent = await thread.post({ markdown: text })
-              if (invocationDeadlineAbort?.signal.aborted) {
-                await deleteManualDeliveryPlaceholder(sent)
-                invocationDeadlineAbort.signal.throwIfAborted()
-              }
-            }
-          }
           await progress?.finish()
-          await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState, invocationDeadlineAbort?.signal)
           invocationDeadlineAbort?.signal.throwIfAborted()
-          const completedPlaceholder = manualDeliveryState.placeholder
+          const completedPlaceholder = !manualDelivery && manualDeliveryState.placeholder
           if (completedPlaceholder) {
             const placeholderCleanup = deleteManualDeliveryPlaceholder(completedPlaceholder)
             manualDeliveryState.placeholderCleanup = placeholderCleanup
@@ -3535,6 +3552,24 @@ async function handleChatSdkMessage(
               if (manualDeliveryState.placeholderCleanup === placeholderCleanup) {
                 manualDeliveryState.placeholderCleanup = undefined
               }
+            }
+          }
+          if (!manualDelivery && text) {
+            invocationDeadlineAbort?.signal.throwIfAborted()
+            if (!await postDiscordSplitContent(thread, { markdown: text }, invocationDeadlineAbort?.signal)) {
+              const sent = await thread.post({ markdown: text })
+              if (invocationDeadlineAbort?.signal.aborted) {
+                await deleteManualDeliveryPlaceholder(sent)
+                invocationDeadlineAbort.signal.throwIfAborted()
+              }
+            }
+          }
+          await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState, invocationDeadlineAbort?.signal)
+          const unusedPlaceholder = manualDeliveryState.placeholder
+          if (unusedPlaceholder) {
+            await deleteManualDeliveryPlaceholder(unusedPlaceholder)
+            if (manualDeliveryState.placeholder === unusedPlaceholder) {
+              manualDeliveryState.placeholder = undefined
             }
           }
         })(),

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3592,6 +3592,9 @@ async function handleChatSdkMessage(
           const resultPromise = manualDelivery
             ? streamAgent(agent as never, runContext as never, invocationInput as never, { output: "events" })
             : runAgentInline(agent as never, runContext as never, invocationInput as never)
+          // Progress delivery is best-effort, but observing the primary rejection
+          // cannot wait for its bounded settlement without risking an unhandled rejection.
+          void resultPromise.catch(() => {})
           if (automaticProgressSettlement) {
             manualDeliveryState.placeholder = await automaticProgressSettlement
           }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3046,6 +3046,7 @@ async function postDisposableChatMessage(thread: Thread, message: string): Promi
   const threadId = sent.threadId || thread.id
   return {
     ...sent,
+    threadId,
     delete: async () => await adapter.deleteMessage(threadId, sent.id),
     edit: adapter.editMessage
       ? async (value: unknown) => await adapter.editMessage!(threadId, sent.id, value as AdapterPostableMessage)
@@ -3589,9 +3590,12 @@ async function handleChatSdkMessage(
             catch (error) {
               if (progressReference?.reusable === false) {
                 console.warn("[vitehub] Could not delete a progress message with unsettled updates; posting final output separately.", error)
+                if (manualDeliveryState.placeholder === completedPlaceholder) {
+                  manualDeliveryState.placeholder = undefined
+                }
               }
-              else {
-                if (!text || !await replaceManualDeliveryPlaceholder(completedPlaceholder, { markdown: text }).catch(() => false)) throw error
+              else if (text) {
+                if (!await replaceManualDeliveryPlaceholder(completedPlaceholder, { markdown: text }).catch(() => false)) throw error
                 text = ""
               }
             }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3470,9 +3470,6 @@ async function handleChatSdkMessage(
       return
     }
 
-    typing = streamsPhasedReplies || manualDelivery || options?.fallbackStreamingPlaceholderText !== undefined
-      ? startChatTypingRefresh(thread, context)
-      : undefined
     assertChatDeliveryOptions(options || {})
     run = invocation.run
     await recordChannelDeliveryEvidence(delivery, { type: "accepted", runId: run?.runId })
@@ -3490,6 +3487,9 @@ async function handleChatSdkMessage(
     const resolvedInvocationInput = invocation.input as AgentRunInput
     const thinkingFallback = invocation.metadata?.thinkingFallback
     const ownsProgressMessage = typeof thinkingFallback === "string" && (manualDelivery || !streamsPhasedReplies)
+    typing = streamsPhasedReplies || manualDelivery || ownsProgressMessage
+      ? startChatTypingRefresh(thread, context)
+      : undefined
     let automaticProgressSettlement: Promise<unknown> | undefined
     if (ownsProgressMessage) {
       const placeholderDelivery = postDisposableChatMessage(thread, thinkingFallback).then(async (placeholder) => {
@@ -3552,7 +3552,7 @@ async function handleChatSdkMessage(
       return
     }
     const chatFinish = createChatFinishExtension(input, registration)
-    progress = manualDelivery && automaticProgressSettlement
+    progress = automaticProgressSettlement
       ? createManualDeliveryProgressUpdater(
           manualDeliveryState,
           context.waitUntil,
@@ -3644,9 +3644,15 @@ async function handleChatSdkMessage(
           await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState, invocationDeadlineAbort?.signal)
           const unusedPlaceholder = manualDeliveryState.placeholder
           if (unusedPlaceholder) {
-            await deleteManualDeliveryPlaceholderWithin(unusedPlaceholder).catch((error) => {
+            let cleanupTimedOut = false
+            await deleteManualDeliveryPlaceholderWithin(unusedPlaceholder, () => {
+              cleanupTimedOut = true
+              if (manualDeliveryState.placeholder === unusedPlaceholder) {
+                manualDeliveryState.placeholder = undefined
+              }
+            }).catch((error) => {
               console.warn("[vitehub] Could not delete an unused progress message.", error)
-              throw error
+              if (!cleanupTimedOut) throw error
             })
             if (manualDeliveryState.placeholder === unusedPlaceholder) {
               manualDeliveryState.placeholder = undefined

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3039,6 +3039,28 @@ async function deleteManualDeliveryPlaceholder(placeholder: unknown): Promise<vo
   }
 }
 
+async function deleteManualDeliveryPlaceholderWithin(
+  placeholder: unknown,
+  timeoutMs = 1_000,
+  onTimeout?: () => void,
+): Promise<void> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      deleteManualDeliveryPlaceholder(placeholder),
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          onTimeout?.()
+          reject(new Error("Disposable chat progress cleanup timed out."))
+        }, timeoutMs)
+      }),
+    ])
+  }
+  finally {
+    if (timeoutId) clearTimeout(timeoutId)
+  }
+}
+
 async function postDisposableChatMessage(thread: Thread, message: string): Promise<unknown> {
   const adapter = thread.adapter
   const sent = await adapter.postMessage(thread.id, message)
@@ -3579,7 +3601,9 @@ async function handleChatSdkMessage(
           invocationDeadlineAbort?.signal.throwIfAborted()
           const completedPlaceholder = !manualDelivery && manualDeliveryState.placeholder
           if (completedPlaceholder) {
-            const placeholderCleanup = deleteManualDeliveryPlaceholder(completedPlaceholder)
+            const placeholderCleanup = deleteManualDeliveryPlaceholderWithin(completedPlaceholder, 1_000, () => {
+              if (progressReference) progressReference.reusable = false
+            })
             manualDeliveryState.placeholderCleanup = placeholderCleanup
             try {
               await placeholderCleanup

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -10439,6 +10439,61 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenCalledOnce()
   })
 
+  it("preserves primary output before automatic finish replies when progress cleanup fails", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.deleteMessage.mockRejectedValue(new Error("delete failed"))
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, { adapter: () => adapter as never }),
+      },
+      driver: { run: () => "Primary reply" },
+      hooks: {
+        "agent:finish": event => event.reply("Finish reply"),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_004_9), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Primary reply" })
+    expect(adapter.postMessage).toHaveBeenLastCalledWith("telegram:456", { markdown: "Finish reply" })
+  })
+
+  it("bounds stalled automatic progress replacement before final output", async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.deleteMessage.mockRejectedValue(new Error("delete failed"))
+    adapter.editMessage.mockImplementation(() => new Promise(() => undefined))
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, { adapter: () => adapter as never }),
+      },
+      driver: { run: () => "Final answer" },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = handler(chatWebhookRequest(91_004_10), "telegram")
+      await vi.waitFor(() => expect(adapter.editMessage).toHaveBeenCalledOnce(), { interval: 0 })
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      await expect(response).resolves.toMatchObject({ status: 200 })
+      expect(adapter.postMessage).toHaveBeenLastCalledWith("telegram:456", { markdown: "Final answer" })
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it.each(["rejects", "stalls"])("starts automatic output when default progress posting $label", async (label) => {
     vi.useFakeTimers()
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -154,7 +154,9 @@ function createTestChatAdapter(options: { attachmentFetchData?: () => Promise<Bu
       }
       return Response.json({ ok: true })
     }),
-    deleteMessage: vi.fn(async () => {}),
+    deleteMessage: vi.fn(async (threadId: string, messageId: string) => {
+      cachedMessages.set(threadId, (cachedMessages.get(threadId) ?? []).filter(message => message.id !== messageId))
+    }),
     initialize: vi.fn(async (chat: ChatInstance) => {
       chatInstance = chat
     }),
@@ -4335,7 +4337,7 @@ describe("server helpers", () => {
     expect(deliveryKinds).toEqual(["direct", "mention", "subscribed", "mention"])
   })
 
-  it("defaults adapter-backed Channels to final-only delivery", async () => {
+  it("defaults adapter-backed Channels to disposable progress and final-only delivery", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram, webChat } = await import("../src/channels.ts")
     const { createChannelChatRouteHandler, createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
@@ -4368,9 +4370,10 @@ describe("server helpers", () => {
     await expect(response.json()).resolves.toEqual({ ok: true })
     await Promise.all(waitUntilTasks)
     expect(agent.chat).toMatchObject({ stream: false })
-    expect(adapter.startTyping).not.toHaveBeenCalled()
-    expect(adapter.postMessage).toHaveBeenCalledOnce()
-    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "final answer" })
+    expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Working on it…")
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "final answer" })
     expect(adapter.editMessage).not.toHaveBeenCalled()
 
     const streamResponse = await createChannelChatRouteHandler(agent as never)(new Request("https://example.com/api/_vitehub/agents/support/chat", {
@@ -4385,7 +4388,7 @@ describe("server helpers", () => {
     await expect(streamResponse.text()).resolves.toContain("final answer")
   })
 
-  it("posts only the final Discord reply without a progress edit after harness tool events", async () => {
+  it("uses fallback progress for Discord harness tool events without a summary model", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { discord } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
@@ -4443,8 +4446,9 @@ describe("server helpers", () => {
     expect(response.status).toBe(200)
     await Promise.all(waitUntilTasks)
     expect(agent.chat).toMatchObject({ stream: false })
-    expect(adapter.postMessage).toHaveBeenCalledOnce()
-    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "The image shows a dental X-ray." })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Working on it…")
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "The image shows a dental X-ray." })
     expect(adapter.editMessage).not.toHaveBeenCalled()
   })
 
@@ -4530,8 +4534,8 @@ describe("server helpers", () => {
     expect(response.status).toBe(200)
     await Promise.all(waitUntilTasks)
     await vi.waitFor(() => {
-      expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "...")
-      expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", "...")
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Working on it…")
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", "Working on it…")
     })
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Checking the image." })
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-2", { markdown: "The image shows a dental X-ray." })
@@ -4558,7 +4562,7 @@ describe("server helpers", () => {
       channels: {
         discord: discord({
           adapter: () => adapter as never,
-          messages: { commentary: "message" },
+          messages: { commentary: "message", fallbackStreamingPlaceholderText: null },
         }),
       },
       driver: {
@@ -4587,7 +4591,7 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(200)
     expect(adapter.postMessage).toHaveBeenCalledTimes(2)
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", expect.any(String), { markdown: "Final answer." })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Final answer." })
   })
 
   it("does not block non-Cloudflare webhooks on stalled commentary delivery", async () => {
@@ -4600,7 +4604,7 @@ describe("server helpers", () => {
       channels: {
         discord: discord({
           adapter: () => adapter as never,
-          messages: { commentary: "message" },
+          messages: { commentary: "message", fallbackStreamingPlaceholderText: null },
         }),
       },
       driver: {
@@ -4618,7 +4622,7 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(200)
     expect(adapter.postMessage).toHaveBeenCalledTimes(2)
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:999", expect.any(String), { markdown: "Final answer." })
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:999", { markdown: "Final answer." })
   })
 
   it("delivers unphased final output when commentary is configured", async () => {
@@ -4842,12 +4846,13 @@ describe("server helpers", () => {
     })
 
     await handler(request(1), "progressive")
-    expect(progressiveAdapter.postMessage).toHaveBeenCalledWith("telegram:456", "...")
+    expect(progressiveAdapter.postMessage).toHaveBeenCalledWith("telegram:456", "Working on it…")
     expect(progressiveAdapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "channel reply" })
 
     await handler(request(2), "final")
-    expect(finalAdapter.postMessage).toHaveBeenCalledOnce()
-    expect(finalAdapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "channel reply" })
+    expect(finalAdapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Working on it…")
+    expect(finalAdapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(finalAdapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "channel reply" })
     expect(finalAdapter.editMessage).not.toHaveBeenCalled()
   })
 
@@ -4907,7 +4912,7 @@ describe("server helpers", () => {
     const shortResponse = await handler(request(7), "discord")
 
     expect(shortResponse.status).toBe(200)
-    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "...")
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Working on it…")
     expect(adapter.postMessage).toHaveBeenCalledTimes(1)
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "short reply" })
 
@@ -4919,7 +4924,7 @@ describe("server helpers", () => {
     const longResponse = await handler(request(8), "discord")
 
     expect(longResponse.status).toBe(200)
-    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "...")
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Working on it…")
     expect(adapter.editMessage).toHaveBeenNthCalledWith(1, "telegram:456", "sent-2", { markdown: replyText })
     expect(adapter.editMessage).toHaveBeenNthCalledWith(2, "telegram:456", "sent-2", {
       attachments: [],
@@ -4985,13 +4990,15 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(200)
     expect(adapter.editMessage).not.toHaveBeenCalled()
-    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", {
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Working on it…")
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", {
       raw: expect.stringMatching(/ \(1\/2\)$/),
     })
-    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", {
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(3, "telegram:456", {
       raw: expect.stringMatching(/ \(2\/2\)$/),
     })
-    expect(adapter.postMessage).toHaveBeenCalledTimes(2)
+    expect(adapter.postMessage).toHaveBeenCalledTimes(3)
   })
 
   it("maps audio mime file attachments by default without resolving bytes", async () => {
@@ -10159,8 +10166,12 @@ describe("server helpers", () => {
       releaseFirst()
       await expect(firstResponse).resolves.toMatchObject({ status: 200 })
 
-      expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", { markdown: "ok" })
-      expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:789", { markdown: "ok" })
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Working on it…")
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "ok" })
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(3, "telegram:789", "Working on it…")
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(4, "telegram:789", { markdown: "ok" })
+      expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+      expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:789", "sent-3")
     }
     finally {
       releaseFirst()
@@ -10298,7 +10309,7 @@ describe("server helpers", () => {
       channels: {
         telegram: testTelegram(telegram, {
           adapter: () => adapter as never,
-          messages: { delivery: "automatic" },
+          messages: { delivery: "automatic", fallbackStreamingPlaceholderText: null },
         }),
       },
       driver: { run: () => "Agent output" },
@@ -10314,6 +10325,55 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", { markdown: "Agent output" })
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Explicit reply" })
     expect(adapter.editMessage).not.toHaveBeenCalled()
+  })
+
+  it("uses one disposable progress message by default before automatic output", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, { adapter: () => adapter as never }),
+      },
+      driver: { run: () => "Final answer" },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_004_1), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Working on it…")
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Final answer" })
+    expect(adapter.deleteMessage.mock.invocationCallOrder[0]).toBeLessThan(adapter.postMessage.mock.invocationCallOrder[1]!)
+  })
+
+  it("replaces default progress with the error fallback when automatic output fails", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: { errorFallbackText: "Please try again." },
+        }),
+      },
+      driver: { run: () => { throw new Error("model failed") } },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      await expect(handler(chatWebhookRequest(91_004_2), "telegram")).rejects.toThrow("model failed")
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Working on it…")
+      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", "Please try again.")
+    }
+    finally {
+      consoleError.mockRestore()
+    }
   })
 
   it("delivers only explicit manual replies after deleting the placeholder", async () => {
@@ -10441,13 +10501,14 @@ describe("server helpers", () => {
       expect(response).not.toBe("blocked")
       if (response === "blocked") throw new Error("Durable chat delivery waited for Workflow completion.")
       expect(response.status).toBe(200)
-      expect(adapter.postMessage).not.toHaveBeenCalled()
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Working on it…")
       expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
       release()
       await Promise.all(waitUntilTasks)
       await vi.waitFor(() => {
         expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "Durable reply" })
       })
+      expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
       await expect(handler.deliveries(chatWebhookRequest(91_100), "telegram", {
         agentIdentity: { name: "calories" },
       })).resolves.toEqual([
@@ -10553,7 +10614,7 @@ describe("server helpers", () => {
     const state = Object.assign(createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` }), { workflowCustody: true })
     const adapter = createTestChatAdapter()
     const waitUntilTasks: Array<Promise<unknown>> = []
-    let workflowPayload: { input?: { timeout?: number } } | undefined
+    let workflowPayload: { input?: { context?: Record<string, unknown>, timeout?: number } } | undefined
     const create = vi.fn(async ({ id, params }: { id: string, params: typeof workflowPayload }) => {
       workflowPayload = params
       return { id, status: async () => ({ status: "queued" }) }
@@ -10585,6 +10646,11 @@ describe("server helpers", () => {
       expect(response.status).toBe(200)
       expect(create).toHaveBeenCalledOnce()
       expect(workflowPayload?.input?.timeout).toBeUndefined()
+      expect(workflowPayload?.input?.context?.["agent.channel.progress"]).toEqual({
+        messageId: "sent-1",
+        threadId: "telegram:456",
+      })
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Working on it…")
       expect(adapter.startTyping).toHaveBeenCalledWith("telegram:456", undefined)
       expect(run).not.toHaveBeenCalled()
       await Promise.all(waitUntilTasks)
@@ -11852,6 +11918,7 @@ describe("server helpers", () => {
           },
           messages: {
             errorFallbackText: "Please try again.",
+            fallbackStreamingPlaceholderText: null,
             timeout: 50_000,
           },
           webhooks: { secretToken: false },
@@ -11914,6 +11981,7 @@ describe("server helpers", () => {
           adapter: () => adapter as never,
           messages: {
             errorFallbackText: "Please try again.",
+            fallbackStreamingPlaceholderText: null,
             timeout: 50_000,
           },
           webhooks: { secretToken: false },
@@ -11971,6 +12039,7 @@ describe("server helpers", () => {
           adapter: () => adapter as never,
           messages: {
             errorFallbackText: "Please try again.",
+            fallbackStreamingPlaceholderText: null,
             stream: false,
             timeout: 50_000,
           },
@@ -12039,6 +12108,7 @@ describe("server helpers", () => {
           adapter: () => adapter as never,
           messages: {
             errorFallbackText: "Please try again.",
+            fallbackStreamingPlaceholderText: null,
             stream: false,
             timeout: 50_000,
           },
@@ -12091,6 +12161,7 @@ describe("server helpers", () => {
             errorFallbackText: async ({ thread }) => {
               await thread.post("Tailored fallback.")
             },
+            fallbackStreamingPlaceholderText: null,
           },
           webhooks: { secretToken: false },
         }),
@@ -12130,6 +12201,7 @@ describe("server helpers", () => {
             errorFallbackText: () => new Promise<string>((resolve) => {
               resolveFallback = resolve
             }),
+            fallbackStreamingPlaceholderText: null,
           },
           webhooks: { secretToken: false },
         }),
@@ -12180,6 +12252,7 @@ describe("server helpers", () => {
             errorFallbackText: async ({ thread }) => {
               await thread.post("Tailored fallback.")
             },
+            fallbackStreamingPlaceholderText: null,
           },
           webhooks: { secretToken: false },
         }),
@@ -13367,6 +13440,7 @@ describe("server helpers", () => {
       channels: {
         support: testTelegram(telegram, {
           adapter: () => adapter as never,
+          messages: { fallbackStreamingPlaceholderText: null },
         }),
       },
       driver: { run: () => "agent answer" },
@@ -13423,6 +13497,7 @@ describe("server helpers", () => {
       channels: {
         support: testTelegram(telegram, {
           adapter: () => adapter as never,
+          messages: { fallbackStreamingPlaceholderText: null },
         }),
       },
       driver: { run: () => "agent answer" },
@@ -13483,6 +13558,7 @@ describe("server helpers", () => {
       channels: {
         support: testTelegram(telegram, {
           adapter: () => adapter as never,
+          messages: { fallbackStreamingPlaceholderText: null },
         }),
       },
       driver: {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -10325,6 +10325,7 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", { markdown: "Agent output" })
     expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Explicit reply" })
     expect(adapter.editMessage).not.toHaveBeenCalled()
+    expect(adapter.startTyping).not.toHaveBeenCalled()
   })
 
   it("uses one disposable progress message by default before automatic output", async () => {
@@ -11426,6 +11427,42 @@ describe("server helpers", () => {
     expect(adapter.postMessage).not.toHaveBeenCalledWith("telegram:456", { markdown: "Private model output" })
   })
 
+  it("updates an automatic placeholder from streamed progress summaries", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: { stream: false },
+        }),
+      },
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield {
+              data: { revision: 1, summary: "Reviewing the request.", type: "progress-summary" },
+              transient: true,
+              type: "data-progress-summary",
+            }
+            yield { delta: "Final answer", phase: "final", type: "text-delta" }
+            yield { finishReason: "stop", type: "finish" }
+          })(),
+        }),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_013_1), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Reviewing the request." })
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.postMessage).toHaveBeenLastCalledWith("telegram:456", { markdown: "Final answer" })
+  })
+
   it("does not block manual completion on a hanging progress edit", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
@@ -11914,6 +11951,46 @@ describe("server helpers", () => {
     }
     finally {
       consoleError.mockRestore()
+    }
+  })
+
+  it("keeps a successful no-reply invocation successful when progress cleanup times out", async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.deleteMessage.mockImplementation(async () => {
+      await new Promise(resolve => setTimeout(resolve, 2_000))
+    })
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: {
+            delivery: "manual",
+            errorFallbackText: "Please try again.",
+          },
+        }),
+      },
+      driver: { run: () => ({ text: "" }) },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = handler(chatWebhookRequest(91_028_1), "telegram")
+      await vi.waitFor(() => expect(adapter.deleteMessage).toHaveBeenCalledOnce(), { interval: 0 })
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      await expect(response).resolves.toMatchObject({ status: 200 })
+      expect(adapter.editMessage).not.toHaveBeenCalled()
+      await vi.advanceTimersByTimeAsync(1_000)
+      expect(adapter.postMessage).toHaveBeenCalledOnce()
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
     }
   })
 

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -10377,6 +10377,30 @@ describe("server helpers", () => {
     }
   })
 
+  it("preserves automatic finish replies when progress cleanup fails", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.deleteMessage.mockRejectedValue(new Error("delete failed"))
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, { adapter: () => adapter as never }),
+      },
+      driver: { run: () => ({ text: "" }) },
+      hooks: {
+        "agent:finish": event => event.reply("Final reply"),
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_004_6), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Final reply" })
+    expect(adapter.postMessage).toHaveBeenCalledOnce()
+  })
+
   it.each(["rejects", "stalls"])("starts automatic output when default progress posting $label", async (label) => {
     vi.useFakeTimers()
     const { defineAgent } = await import("../src/index.ts")
@@ -10520,6 +10544,7 @@ describe("server helpers", () => {
     const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-default-workflow-state-"))
     const state = Object.assign(createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` }), { workflowCustody: true })
     const adapter = createTestChatAdapter()
+    adapter.postMessage.mockResolvedValue({ id: "sent-1", raw: {} })
     const waitUntilTasks: Array<Promise<unknown>> = []
     let observedTimeout: number | undefined | "not-run" = "not-run"
     let release!: () => void

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -10336,7 +10336,15 @@ describe("server helpers", () => {
       channels: {
         telegram: testTelegram(telegram, { adapter: () => adapter as never }),
       },
-      driver: { run: () => "Final answer" },
+      driver: {
+        run: ({ input }) => {
+          expect(input.context?.["agent.channel.progress"]).toEqual(expect.objectContaining({
+            ready: expect.any(Promise),
+            threadId: "telegram:456",
+          }))
+          return "Final answer"
+        },
+      },
     })
     const handler = createChannelWebhookRouteHandler(agent as never)
 

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -10608,6 +10608,39 @@ describe("server helpers", () => {
     }
   })
 
+  it("bounds stalled default progress replacement before posting the error fallback", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.editMessage.mockImplementation(() => new Promise(() => undefined))
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: { errorFallbackText: "Please try again." },
+        }),
+      },
+      driver: { run: () => { throw new Error("model failed") } },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = expect(handler(chatWebhookRequest(91_004_12), "telegram")).rejects.toThrow("model failed")
+      await vi.waitFor(() => expect(adapter.editMessage).toHaveBeenCalledOnce(), { interval: 0 })
+      await vi.advanceTimersByTimeAsync(2_000)
+      await response
+      expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+      expect(adapter.postMessage).toHaveBeenLastCalledWith("telegram:456", "Please try again.")
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("delivers only explicit manual replies after deleting the placeholder", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -10469,6 +10469,35 @@ describe("server helpers", () => {
     }
   })
 
+  it("observes automatic invocation failures while progress posting stalls", async () => {
+    vi.useFakeTimers()
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.postMessage.mockImplementationOnce(() => new Promise(() => undefined))
+    const run = vi.fn(() => { throw new Error("model failed") })
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, { adapter: () => adapter as never }),
+      },
+      driver: { run },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = expect(handler(chatWebhookRequest(91_004_8), "telegram")).rejects.toThrow("model failed")
+      await vi.waitFor(() => expect(run).toHaveBeenCalledOnce(), { interval: 0 })
+      await vi.advanceTimersByTimeAsync(1_000)
+      await response
+    }
+    finally {
+      consoleError.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("replaces default progress with the error fallback when automatic output fails", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -10357,7 +10357,7 @@ describe("server helpers", () => {
     expect(adapter.deleteMessage.mock.invocationCallOrder[0]).toBeLessThan(adapter.postMessage.mock.invocationCallOrder[1]!)
   })
 
-  it("replaces default progress with automatic output when cleanup fails", async () => {
+  it("posts automatic output separately when progress cleanup fails", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
@@ -10377,8 +10377,8 @@ describe("server helpers", () => {
 
       expect(response.status).toBe(200)
       expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
-      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Final answer" })
-      expect(adapter.postMessage).toHaveBeenCalledOnce()
+      expect(adapter.editMessage).not.toHaveBeenCalled()
+      expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Final answer" })
     }
     finally {
       warn.mockRestore()
@@ -10435,8 +10435,8 @@ describe("server helpers", () => {
     const response = await handler(chatWebhookRequest(91_004_6), "telegram")
 
     expect(response.status).toBe(200)
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Final reply" })
-    expect(adapter.postMessage).toHaveBeenCalledOnce()
+    expect(adapter.editMessage).not.toHaveBeenCalled()
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Final reply" })
   })
 
   it("preserves primary output before automatic finish replies when progress cleanup fails", async () => {
@@ -10459,19 +10459,18 @@ describe("server helpers", () => {
     const response = await handler(chatWebhookRequest(91_004_9), "telegram")
 
     expect(response.status).toBe(200)
-    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Primary reply" })
+    expect(adapter.editMessage).not.toHaveBeenCalled()
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Primary reply" })
     expect(adapter.postMessage).toHaveBeenLastCalledWith("telegram:456", { markdown: "Finish reply" })
   })
 
-  it("bounds stalled automatic progress replacement before final output", async () => {
-    vi.useFakeTimers()
+  it("does not replace default progress with successful terminal output", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
     adapter.deleteMessage.mockRejectedValue(new Error("delete failed"))
-    adapter.editMessage.mockImplementation(() => new Promise(() => undefined))
     const agent = defineAgent({
       channels: {
         telegram: testTelegram(telegram, { adapter: () => adapter as never }),
@@ -10481,15 +10480,44 @@ describe("server helpers", () => {
     const handler = createChannelWebhookRouteHandler(agent as never)
 
     try {
-      const response = handler(chatWebhookRequest(91_004_10), "telegram")
-      await vi.waitFor(() => expect(adapter.editMessage).toHaveBeenCalledOnce(), { interval: 0 })
-      await vi.advanceTimersByTimeAsync(1_000)
+      const response = await handler(chatWebhookRequest(91_004_10), "telegram")
 
-      await expect(response).resolves.toMatchObject({ status: 200 })
+      expect(response.status).toBe(200)
+      expect(adapter.editMessage).not.toHaveBeenCalled()
       expect(adapter.postMessage).toHaveBeenLastCalledWith("telegram:456", { markdown: "Final answer" })
     }
     finally {
       warn.mockRestore()
+    }
+  })
+
+  it("starts manual inline execution without waiting for default progress posting", async () => {
+    vi.useFakeTimers()
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.postMessage.mockImplementationOnce(() => new Promise(() => undefined))
+    const run = vi.fn(() => "Final answer")
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          adapter: () => adapter as never,
+          messages: { delivery: "manual", durable: false },
+        }),
+      },
+      driver: { run },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = handler(chatWebhookRequest(91_004_11), "telegram")
+      await vi.waitFor(() => expect(run).toHaveBeenCalledOnce(), { interval: 0 })
+      await vi.advanceTimersByTimeAsync(1_000)
+      await expect(response).resolves.toMatchObject({ status: 200 })
+      expect(adapter.postMessage).toHaveBeenCalledOnce()
+    }
+    finally {
       vi.useRealTimers()
     }
   })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -10385,6 +10385,36 @@ describe("server helpers", () => {
     }
   })
 
+  it("bounds stalled automatic progress cleanup before final output", async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.deleteMessage.mockImplementation(() => new Promise(() => undefined))
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, { adapter: () => adapter as never }),
+      },
+      driver: { run: () => "Final answer" },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = handler(chatWebhookRequest(91_004_7), "telegram")
+      await vi.waitFor(() => expect(adapter.deleteMessage).toHaveBeenCalledOnce(), { interval: 0 })
+      await vi.advanceTimersByTimeAsync(1_000)
+
+      await expect(response).resolves.toMatchObject({ status: 200 })
+      expect(adapter.postMessage).toHaveBeenLastCalledWith("telegram:456", { markdown: "Final answer" })
+    }
+    finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
   it("preserves automatic finish replies when progress cleanup fails", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -10349,6 +10349,64 @@ describe("server helpers", () => {
     expect(adapter.deleteMessage.mock.invocationCallOrder[0]).toBeLessThan(adapter.postMessage.mock.invocationCallOrder[1]!)
   })
 
+  it("replaces default progress with automatic output when cleanup fails", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined)
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.deleteMessage.mockRejectedValueOnce(new Error("delete failed"))
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, { adapter: () => adapter as never }),
+      },
+      driver: { run: () => "Final answer" },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = await handler(chatWebhookRequest(91_004_3), "telegram")
+
+      expect(response.status).toBe(200)
+      expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+      expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Final answer" })
+      expect(adapter.postMessage).toHaveBeenCalledOnce()
+    }
+    finally {
+      warn.mockRestore()
+    }
+  })
+
+  it.each(["rejects", "stalls"])("starts automatic output when default progress posting $label", async (label) => {
+    vi.useFakeTimers()
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.postMessage.mockImplementationOnce(() => label === "rejects"
+      ? Promise.reject(new Error("post failed"))
+      : new Promise(() => undefined))
+    const run = vi.fn(() => "Final answer")
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, { adapter: () => adapter as never }),
+      },
+      driver: { run },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = handler(chatWebhookRequest(label === "rejects" ? 91_004_4 : 91_004_5), "telegram")
+      await vi.waitFor(() => expect(run).toHaveBeenCalledOnce(), { interval: 0 })
+      await vi.advanceTimersByTimeAsync(1_000)
+      await expect(response).resolves.toMatchObject({ status: 200 })
+      expect(adapter.postMessage).toHaveBeenLastCalledWith("telegram:456", { markdown: "Final answer" })
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("replaces default progress with the error fallback when automatic output fails", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")
@@ -11800,7 +11858,7 @@ describe("server helpers", () => {
     }
   })
 
-  it("reserves Cloudflare background time for manual error delivery", async () => {
+  it("replaces default automatic progress when the invocation times out", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
@@ -11816,9 +11874,8 @@ describe("server helpers", () => {
         telegram: testTelegram(telegram, {
           adapter: () => adapter as never,
           messages: {
-            delivery: "manual",
             errorFallbackText: "Please try again.",
-            fallbackStreamingPlaceholderText: "Analyzing photo…",
+            stream: false,
             timeout: 50_000,
           },
           webhooks: { secretToken: false },
@@ -11834,6 +11891,7 @@ describe("server helpers", () => {
         waitUntil: () => undefined,
       })).rejects.toThrow("model timeout")
       expect(run).toHaveBeenCalledOnce()
+      expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Working on it…")
       expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", "Please try again.")
     }
     finally {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4978,6 +4978,107 @@ describe("agent message protocol", () => {
     expect(event).toHaveBeenCalledWith(expect.objectContaining({ type: "outbound.completed" }))
   })
 
+  it("deletes durable channel progress before posting the final reply", async () => {
+    const { defineAgent, runAgentInline } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const calls: string[] = []
+    const adapter = {
+      channelIdFromThreadId: (threadId: string) => threadId,
+      deleteMessage: vi.fn(async () => { calls.push("delete") }),
+      editMessage: vi.fn(),
+      postMessage: vi.fn(async () => { calls.push("post") }),
+    }
+    const agent = defineAgent({
+      channels: {
+        telegram: defineChannel("telegram", { adapter: () => adapter as never }),
+      },
+      driver: { run: () => "internal" },
+      hooks: {
+        "agent:finish": event => event.reply("Final reply"),
+      },
+    })
+
+    await runAgentInline(agent, {
+      memo: vi.fn(),
+      run: { channelId: "telegram", origin: "workflow:cloudflare", runId: "run-1", threadId: "telegram:456" },
+      runtime: "cloudflare-agents",
+      runtimeConfig: {},
+      waitUntil: vi.fn(),
+    }, {
+      context: {
+        "agent.channel.progress": { messageId: "sent-1", threadId: "telegram:456" },
+      },
+      prompt: "hello",
+    })
+
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "Final reply" })
+    expect(calls).toEqual(["delete", "post"])
+  })
+
+  it("rewrites durable channel progress from model steps without exposing reasoning", async () => {
+    const { progressSummary } = await import("../src/capabilities/progress-summary.ts")
+    const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    let calls = 0
+    const adapter = {
+      channelIdFromThreadId: (threadId: string) => threadId,
+      editMessage: vi.fn(),
+    }
+    const model = {
+      async doGenerate() {
+        calls++
+        return {
+          content: calls === 1
+            ? [
+                { text: "PRIVATE_CHAIN_OF_THOUGHT", type: "reasoning" },
+                { input: "{}", toolCallId: "save-1", toolName: "save_meal", type: "tool-call" },
+              ]
+            : [{ text: "Saved", type: "text" }],
+          finishReason: { raw: calls === 1 ? "tool_calls" : "stop", unified: calls === 1 ? "tool-calls" : "stop" },
+          usage: {
+            inputTokens: { cacheRead: 0, cacheWrite: 0, noCache: 1, total: 1 },
+            outputTokens: { reasoning: 0, text: 1, total: 1 },
+          },
+          warnings: [],
+        }
+      },
+      modelId: "progress-test",
+      provider: "test",
+      specificationVersion: "v3",
+      supportedUrls: {},
+    }
+    const agent = defineAgent({
+      capabilities: [defineCapability({
+        id: "meals",
+        tools: { save_meal: { execute: () => ({ id: "meal-1" }), name: "save_meal" } },
+      })],
+      channels: {
+        telegram: defineChannel("telegram", {
+          adapter: () => adapter as never,
+          capabilities: [progressSummary({ execute: () => "Checking the meal." })],
+        }),
+      },
+      driver: { model: model as never },
+    })
+
+    await runAgentInline(agent, {
+      memo: vi.fn(),
+      run: { channelId: "telegram", origin: "workflow:cloudflare", runId: "run-2", threadId: "telegram:456" },
+      runtime: "cloudflare-agents",
+      runtimeConfig: {},
+      waitUntil: vi.fn(),
+    }, {
+      context: {
+        "agent.channel.progress": { messageId: "sent-1", threadId: "telegram:456" },
+      },
+      prompt: "save meal",
+    })
+
+    expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Checking the meal." })
+    expect(JSON.stringify(adapter.editMessage.mock.calls)).not.toContain("PRIVATE_CHAIN_OF_THOUGHT")
+  })
+
   it("exposes Agent Trigger metadata", async () => {
     const { defineChannel } = await import("../src/channels.ts")
     const { resolveAgentTriggers } = await import("../src/trigger-runtime.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -4999,6 +4999,7 @@ describe("agent message protocol", () => {
     })
 
     await runAgentInline(agent, {
+      [Symbol.for("vitehub.agent.workflow-execution")]: true,
       memo: vi.fn(),
       run: { channelId: "telegram", origin: "workflow:cloudflare", runId: "run-1", threadId: "telegram:456" },
       runtime: "cloudflare-agents",
@@ -5014,6 +5015,113 @@ describe("agent message protocol", () => {
     expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
     expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "Final reply" })
     expect(calls).toEqual(["delete", "post"])
+  })
+
+  it("deletes durable channel progress before posting a streamed final reply", async () => {
+    const { defineAgent, runAgentInline } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const calls: string[] = []
+    const adapter = {
+      channelIdFromThreadId: (threadId: string) => threadId,
+      deleteMessage: vi.fn(async () => { calls.push("delete") }),
+      postMessage: vi.fn(async () => { calls.push("post") }),
+    }
+    const agent = defineAgent({
+      channels: {
+        telegram: defineChannel("telegram", { adapter: () => adapter as never }),
+      },
+      driver: { run: () => "internal" },
+      hooks: {
+        "agent:finish": event => event.reply((async function* () { yield "Final reply" })()),
+      },
+    })
+
+    await runAgentInline(agent, {
+      [Symbol.for("vitehub.agent.workflow-execution")]: true,
+      memo: vi.fn(),
+      run: { channelId: "telegram", origin: "workflow:cloudflare", runId: "stream-run", threadId: "telegram:456" },
+      runtime: "cloudflare-agents",
+      runtimeConfig: {},
+      waitUntil: vi.fn(),
+    }, {
+      context: {
+        "agent.channel.progress": { messageId: "sent-1", threadId: "telegram:456" },
+      },
+      prompt: "hello",
+    })
+
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "Final reply" })
+    expect(calls).toEqual(["delete", "post"])
+  })
+
+  it.each([
+    { driver: { run: () => "internal" }, fails: false, label: "success without a reply" },
+    { driver: { run: () => { throw new Error("failed") } }, fails: true, label: "failure without a fallback" },
+  ])("deletes durable channel progress on $label", async ({ driver, fails }) => {
+    const { defineAgent, runAgentInline } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const adapter = {
+      channelIdFromThreadId: (threadId: string) => threadId,
+      deleteMessage: vi.fn(),
+    }
+    const agent = defineAgent({
+      channels: {
+        telegram: defineChannel("telegram", { adapter: () => adapter as never }),
+      },
+      driver,
+      messages: { errorFallbackText: null },
+    })
+    const invocation = runAgentInline(agent, {
+      [Symbol.for("vitehub.agent.workflow-execution")]: true,
+      memo: vi.fn(),
+      run: { channelId: "telegram", origin: "workflow:cloudflare", runId: "terminal-run", threadId: "telegram:456" },
+      runtime: "cloudflare-agents",
+      runtimeConfig: {},
+      waitUntil: vi.fn(),
+    }, {
+      context: {
+        "agent.channel.progress": { messageId: "sent-1", threadId: "telegram:456" },
+      },
+      prompt: "hello",
+    })
+
+    if (fails) await expect(invocation).rejects.toThrow("failed")
+    else await expect(invocation).resolves.toBe("internal")
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+  })
+
+  it("deletes durable channel progress when finish processing throws", async () => {
+    const { defineAgent, runAgentInline } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const adapter = {
+      channelIdFromThreadId: (threadId: string) => threadId,
+      deleteMessage: vi.fn(),
+    }
+    const agent = defineAgent({
+      channels: {
+        telegram: defineChannel("telegram", { adapter: () => adapter as never }),
+      },
+      driver: { run: () => "internal" },
+      hooks: {
+        "agent:finish": () => { throw new Error("finish failed") },
+      },
+    })
+
+    await expect(runAgentInline(agent, {
+      [Symbol.for("vitehub.agent.workflow-execution")]: true,
+      memo: vi.fn(),
+      run: { channelId: "telegram", origin: "workflow:cloudflare", runId: "failed-finish", threadId: "telegram:456" },
+      runtime: "cloudflare-agents",
+      runtimeConfig: {},
+      waitUntil: vi.fn(),
+    }, {
+      context: {
+        "agent.channel.progress": { messageId: "sent-1", threadId: "telegram:456" },
+      },
+      prompt: "hello",
+    })).rejects.toThrow("finish failed")
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
   })
 
   it("rewrites durable channel progress from model steps without exposing reasoning", async () => {
@@ -5048,6 +5156,8 @@ describe("agent message protocol", () => {
       specificationVersion: "v3",
       supportedUrls: {},
     }
+    const summary = vi.fn(() => "Checking the meal.")
+    const onStepEnd = vi.fn()
     const agent = defineAgent({
       capabilities: [defineCapability({
         id: "meals",
@@ -5056,10 +5166,10 @@ describe("agent message protocol", () => {
       channels: {
         telegram: defineChannel("telegram", {
           adapter: () => adapter as never,
-          capabilities: [progressSummary({ execute: () => "Checking the meal." })],
+          capabilities: [progressSummary({ execute: summary })],
         }),
       },
-      driver: { model: model as never },
+      driver: { execution: { callSettings: { onStepEnd } }, model: model as never },
     })
 
     await runAgentInline(agent, {
@@ -5077,6 +5187,55 @@ describe("agent message protocol", () => {
 
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", { markdown: "Checking the meal." })
     expect(JSON.stringify(adapter.editMessage.mock.calls)).not.toContain("PRIVATE_CHAIN_OF_THOUGHT")
+    expect(summary).toHaveBeenCalledOnce()
+    expect(onStepEnd).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not generate durable progress for a text-only model step", async () => {
+    const { progressSummary } = await import("../src/capabilities/progress-summary.ts")
+    const { defineAgent, runAgentInline } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const summary = vi.fn(() => "Unnecessary progress.")
+    const model = {
+      async doGenerate() {
+        return {
+          content: [{ text: "Done", type: "text" }],
+          finishReason: { raw: "stop", unified: "stop" },
+          usage: {
+            inputTokens: { cacheRead: 0, cacheWrite: 0, noCache: 1, total: 1 },
+            outputTokens: { reasoning: 0, text: 1, total: 1 },
+          },
+          warnings: [],
+        }
+      },
+      modelId: "text-only-progress-test",
+      provider: "test",
+      specificationVersion: "v3",
+      supportedUrls: {},
+    }
+    const agent = defineAgent({
+      channels: {
+        telegram: defineChannel("telegram", {
+          capabilities: [progressSummary({ execute: summary })],
+        }),
+      },
+      driver: { model: model as never },
+    })
+
+    await runAgentInline(agent, {
+      memo: vi.fn(),
+      run: { channelId: "telegram", origin: "workflow:cloudflare", runId: "text-only-run", threadId: "telegram:456" },
+      runtime: "cloudflare-agents",
+      runtimeConfig: {},
+      waitUntil: vi.fn(),
+    }, {
+      context: {
+        "agent.channel.progress": { messageId: "sent-1", threadId: "telegram:456" },
+      },
+      prompt: "hello",
+    })
+
+    expect(summary).not.toHaveBeenCalled()
   })
 
   it("exposes Agent Trigger metadata", async () => {
@@ -12078,6 +12237,8 @@ describe("agent message protocol", () => {
       const { telegram } = await import("../src/channels.ts")
       const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
       const postMessage = vi.fn(async () => undefined)
+      const editMessage = vi.fn(async () => undefined)
+      const deleteMessage = vi.fn(async () => undefined)
       const failure = Object.assign(new Error("provider unavailable"), {
         name: "AI_APICallError",
         statusCode: 503,
@@ -12105,6 +12266,8 @@ describe("agent message protocol", () => {
           telegram: telegram({
             adapter: () => ({
               channelIdFromThreadId: () => "telegram:123",
+              deleteMessage,
+              editMessage,
               postMessage,
             }) as never,
           }),
@@ -12125,7 +12288,10 @@ describe("agent message protocol", () => {
         name: "calories",
         payload: {
           input: {
-            context: { channel: { message: { text: "I ate skyr" } } },
+            context: {
+              "agent.channel.progress": { messageId: "progress-1", threadId: "telegram:123" },
+              channel: { message: { text: "I ate skyr" } },
+            },
             prompt: "I ate skyr",
           },
           run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
@@ -12134,9 +12300,11 @@ describe("agent message protocol", () => {
       }, runAgentInline)).rejects.toBe(failure)
 
       expect(fallback).toHaveBeenCalledOnce()
-      expect(postMessage).toHaveBeenCalledWith("telegram:123", {
+      expect(editMessage).toHaveBeenCalledWith("telegram:123", "progress-1", {
         markdown: "The meal was saved, but I could not finish the reply.",
       })
+      expect(deleteMessage).not.toHaveBeenCalled()
+      expect(postMessage).not.toHaveBeenCalled()
     })
 
     it("delivers durable failure fallbacks when Capability setup fails", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5091,6 +5091,41 @@ describe("agent message protocol", () => {
     expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
   })
 
+  it("deletes durable channel progress when Capability setup fails without a fallback", async () => {
+    const { defineAgent, defineCapability, runAgentInline } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const adapter = {
+      channelIdFromThreadId: (threadId: string) => threadId,
+      deleteMessage: vi.fn(),
+    }
+    const agent = defineAgent({
+      capabilities: [defineCapability({
+        id: "setup-failure",
+        resolve: () => { throw new Error("setup failed") },
+      })],
+      channels: {
+        telegram: defineChannel("telegram", { adapter: () => adapter as never }),
+      },
+      driver: { run: () => "internal" },
+      messages: { errorFallbackText: null },
+    })
+
+    await expect(runAgentInline(agent, {
+      [Symbol.for("vitehub.agent.workflow-execution")]: true,
+      memo: vi.fn(),
+      run: { channelId: "telegram", origin: "workflow:cloudflare", runId: "setup-failure", threadId: "telegram:456" },
+      runtime: "cloudflare-agents",
+      runtimeConfig: {},
+      waitUntil: vi.fn(),
+    }, {
+      context: {
+        "agent.channel.progress": { messageId: "sent-1", threadId: "telegram:456" },
+      },
+      prompt: "hello",
+    })).rejects.toThrow("setup failed")
+    expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+  })
+
   it("deletes durable channel progress when finish processing throws", async () => {
     const { defineAgent, runAgentInline } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5166,7 +5166,7 @@ describe("agent message protocol", () => {
       channels: {
         telegram: defineChannel("telegram", {
           adapter: () => adapter as never,
-          capabilities: [progressSummary({ execute: summary })],
+          capabilities: [progressSummary({ execute: summary, id: "custom-progress" })],
         }),
       },
       driver: { execution: { callSettings: { onStepEnd } }, model: model as never },

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12307,6 +12307,53 @@ describe("agent message protocol", () => {
       expect(postMessage).not.toHaveBeenCalled()
     })
 
+    it("bounds durable progress replacement before posting an error fallback", async () => {
+      vi.useFakeTimers()
+      const { defineAgent, runAgentInline } = await import("../src/index.ts")
+      const { telegram } = await import("../src/channels.ts")
+      const { runAgentWorkflowDefinition } = await import("../src/runtime/workflow.ts")
+      const postMessage = vi.fn(async () => undefined)
+      const editMessage = vi.fn(() => new Promise<never>(() => undefined))
+      const deleteMessage = vi.fn(async () => undefined)
+      const failure = new Error("provider unavailable")
+      const agent = defineAgent({
+        channels: {
+          telegram: telegram({
+            adapter: () => ({
+              channelIdFromThreadId: () => "telegram:123",
+              deleteMessage,
+              editMessage,
+              postMessage,
+            }) as never,
+          }),
+        },
+        driver: { run: async () => { throw failure } },
+        messages: { errorFallbackText: "Please try again." },
+      })
+      const invocation = expect(runAgentWorkflowDefinition(agent, {
+        id: "run-stalled-fallback-edit",
+        name: "calories",
+        payload: {
+          input: {
+            context: {
+              "agent.channel.progress": { messageId: "progress-1", threadId: "telegram:123" },
+              channel: { message: { text: "Hello" } },
+            },
+            prompt: "Hello",
+          },
+          run: { channelId: "telegram", origin: "telegram", threadId: "telegram:123" },
+        },
+        provider: "cloudflare",
+      }, runAgentInline)).rejects.toBe(failure)
+
+      await vi.waitFor(() => expect(editMessage).toHaveBeenCalledOnce(), { interval: 0 })
+      await vi.advanceTimersByTimeAsync(1_000)
+      await invocation
+      expect(deleteMessage).toHaveBeenCalledWith("telegram:123", "progress-1")
+      expect(postMessage).toHaveBeenCalledWith("telegram:123", { markdown: "Please try again." })
+      vi.useRealTimers()
+    })
+
     it("delivers durable failure fallbacks when Capability setup fails", async () => {
       const { defineAgent, runAgentInline } = await import("../src/index.ts")
       const { telegram } = await import("../src/channels.ts")

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,7 +232,7 @@ catalogs:
       specifier: ^10.0.0
       version: 10.6.2
     unstorage:
-      specifier: ^2.0.0-alpha.7
+      specifier: 2.0.0-alpha.7
       version: 2.0.0-alpha.7
     uploadthing:
       specifier: ^7.7.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,7 +232,7 @@ catalogs:
       specifier: ^10.0.0
       version: 10.6.2
     unstorage:
-      specifier: 2.0.0-alpha.7
+      specifier: ^2.0.0-alpha.7
       version: 2.0.0-alpha.7
     uploadthing:
       specifier: ^7.7.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -93,7 +93,7 @@ catalogs:
     dropbox: ^10.34.0
     files-sdk: ^2.1.0
     google-auth-library: ^10.0.0
-    unstorage: ^2.0.0-alpha.7
+    unstorage: 2.0.0-alpha.7
     uploadthing: ^7.7.4
   tooling:
     "@types/node": ^24.13.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -93,7 +93,7 @@ catalogs:
     dropbox: ^10.34.0
     files-sdk: ^2.1.0
     google-auth-library: ^10.0.0
-    unstorage: 2.0.0-alpha.7
+    unstorage: ^2.0.0-alpha.7
     uploadthing: ^7.7.4
   tooling:
     "@types/node": ^24.13.3


### PR DESCRIPTION
Message-shaped Channels currently acknowledge work with typing only, then stay silent until the final reply or failure. This makes the Channel lifecycle disposable and observable by default without exposing model chain-of-thought.

## Behavior

- starts best-effort Working on it… delivery before inline or durable Agent execution; inline execution does not wait for adapter latency, while durable custody waits at most one second for the concrete message reference it must serialize
- rewrites that message from safe AI SDK reasoning-presence and tool-lifecycle summaries when available
- deletes progress before posting the final reply as a new notification, with bounded cleanup so terminal output still wins
- edits progress into the configured error fallback on failure
- leaves GitHub single-delivery because GitHub Channels are not message-shaped; null opts other Channels out

## Dependency prerequisite

- pins `unstorage` to `2.0.0-alpha.7`; `alpha.8` is currently missing the resolvable `destr` dependency and breaks the packed consumer build

## Proof

- focused message-progress lifecycle tests pass
- Agent typecheck passed
- Agent build and publint passed
- packed consumer suite passed
- scoped Standards and Spec review completed; actionable exact-head findings repaired
- git diff --check passed

Stacked on #997 because durable final and failure delivery own the Workflow completion side of this lifecycle.
