### PR TITLE
feat(source): add typed source collections

### DIFF
--- a/docs/content/docs/server-primitives/source.md
+++ b/docs/content/docs/server-primitives/source.md
@@ -49,7 +49,7 @@ export default defineEventHandler(() => {
 
 | Import | Use |
 | --- | --- |
-| `defineSource`, `defineSources`, `custom` from `vite-hub/source` | Define Sources and custom loaders without selecting an implementation. |
+| `defineSource`, `defineSources`, `createSource`, `defineCollection`, `custom` from `vite-hub/source` | Define Sources, materialize context-dependent keyed readers, and compose readers without selecting an implementation. |
 | `registerSource`, `registerSources`, `clearSources`, `getRegisteredSource`, `useSource` from `vite-hub/source` | Manage and read the process-local Source registry. |
 | `file`, `glob`, `github`, `markdown`, `mcpResources` from the matching `vite-hub/source/*` subpath | Select one built-in loader and its private implementation closure. |
 | `getViteHubErrorShape` from `@vite-hub/runtime` | Inspect registry, path, and loader failures by `SOURCE_*` code. |
@@ -193,6 +193,37 @@ export default defineEventHandler(async () => {
   }
 })
 ```
+
+## Compose keyed Source readers
+
+Use `defineCollection()` when an application has keyed readers whose keys can overlap. Each Collection identity is a `[source, key]` tuple, so the source alias remains part of both the runtime value and its inferred type.
+
+```ts [server/recaps.ts]
+import { createSource, defineCollection, defineSource } from 'vite-hub/source'
+
+const github = defineSource(context => ({
+  async get(month: `${number}-${number}`) {
+    return { month, rootDir: context.rootDir }
+  },
+  async items() {
+    return [{ key: '2026-07' as const }]
+  },
+}))
+
+export const recaps = defineCollection({
+  sources: {
+    github: createSource(github, { rootDir: process.cwd() }),
+  },
+})
+
+await recaps.get(['github', '2026-07'])
+await recaps.items()
+// [{ key: '2026-07', source: 'github', identity: ['github', '2026-07'] }]
+```
+
+Collection aliases must be strings. `get()` infers the accepted key and result independently for each alias. `items()` is available on every Collection, but it rejects a partially enumerable Collection before starting any reader; when all readers implement `items()`, each returned item is tagged with `source` and `identity`.
+
+`defineSource(context => reader)` defines a context-dependent keyed reader, and `createSource()` materializes it with a `SourceContext`. This composition layer is independent of the process-local registry: existing `defineSources()`, `registerSources()`, and `useSource()` behavior is unchanged.
 
 ## Use Sources with Workspace
 

--- a/packages/source/README.md
+++ b/packages/source/README.md
@@ -62,6 +62,24 @@ article.metadata?.revision
 const articles = await useSource("articles").items()
 ```
 
+Compose runtime Source readers into a typed Collection when keys can overlap:
+
+```ts
+import { defineCollection, defineSource } from "@vite-hub/source"
+
+const recaps = defineCollection({
+  sources: {
+    github: defineSource({
+      get: async (month: `${number}-${number}`) => ({ month }),
+      items: async () => [{ key: "2026-07" as const }],
+    }),
+  },
+})
+
+await recaps.get(["github", "2026-07"])
+await recaps.items() // [{ key: "2026-07", source: "github", identity: ["github", "2026-07"] }]
+```
+
 Keep binary assets behind the Blob boundary and store a serializable reference in
 the record. This keeps ordinary record reads lazy while treating the structured
 data and its assets as one logical item.

--- a/packages/source/src/core/collection.ts
+++ b/packages/source/src/core/collection.ts
@@ -22,9 +22,11 @@ type CollectionSourceItem<TReader> =
   TReader extends { items(): Promise<Array<infer TItem extends { key: string }>> } ? TItem : never
 
 type ValidCollectionSource<TReader> =
-  [TReader] extends [{ items(): Promise<Array<infer TItem extends { key: string }>> }]
-    ? Exclude<TItem["key"], CollectionSourceKey<TReader>> extends never ? TReader : never
-    : TReader
+  [CollectionSourceItem<TReader>] extends [never]
+    ? TReader
+    : Exclude<CollectionSourceItem<TReader>["key"], CollectionSourceKey<TReader>> extends never
+      ? TReader
+      : never
 
 type ValidCollectionSources<TSources extends CollectionSources> = {
   [TSource in keyof TSources]: ValidCollectionSource<TSources[TSource]>

--- a/packages/source/src/core/collection.ts
+++ b/packages/source/src/core/collection.ts
@@ -7,8 +7,13 @@ interface CollectionSourceReader {
 
 type CollectionSources = Record<string, CollectionSourceReader>
 
+type CollectionSourceKeyFunction<TReader> =
+  TReader extends { get(key: infer TKey): Promise<unknown> } ? (key: TKey) => void : never
+
 type CollectionSourceKey<TReader> =
-  TReader extends { get(key: infer TKey): Promise<unknown> } ? Extract<TKey, string> : never
+  CollectionSourceKeyFunction<TReader> extends (key: infer TKey) => void
+    ? Extract<TKey, string>
+    : never
 
 type CollectionSourceValue<TReader> =
   TReader extends { get(key: never): Promise<infer TValue> } ? TValue : never

--- a/packages/source/src/core/collection.ts
+++ b/packages/source/src/core/collection.ts
@@ -28,24 +28,13 @@ type Equal<TLeft, TRight> =
       : false
     : false
 
-type CollectionSourceGetSignatures<TReader> = TReader extends { get: {
-  (key: infer TKey1): Promise<infer TValue1>
-  (key: infer TKey2): Promise<infer TValue2>
-  (key: infer TKey3): Promise<infer TValue3>
-  (key: infer TKey4): Promise<infer TValue4>
-  (key: infer TKey5): Promise<infer TValue5>
-} } ? [[TKey1, TValue1], [TKey2, TValue2], [TKey3, TValue3], [TKey4, TValue4], [TKey5, TValue5]] : never
-
-type SignaturesAreEqual<TSignatures extends unknown[], TExpected = TSignatures[number]> =
-  TSignatures extends [infer TSignature, ...infer TRest]
-    ? Equal<TSignature, TExpected> extends true
-      ? SignaturesAreEqual<TRest, TExpected>
-      : false
-    : true
-
 type ValidCollectionGet<TReader> =
   TReader extends unknown
-    ? SignaturesAreEqual<CollectionSourceGetSignatures<TReader>> extends true ? TReader : never
+    ? TReader extends { get: infer TGet }
+      ? Equal<TGet, (key: CollectionSourceKey<TReader>) => Promise<CollectionSourceValue<TReader>>> extends true
+        ? TReader
+        : never
+      : never
     : never
 
 type ValidCollectionSource<TReader> =

--- a/packages/source/src/core/collection.ts
+++ b/packages/source/src/core/collection.ts
@@ -21,11 +21,38 @@ type CollectionSourceValue<TReader> =
 type CollectionSourceItem<TReader> =
   TReader extends { items(): Promise<Array<infer TItem extends { key: string }>> } ? TItem : never
 
+type Equal<TLeft, TRight> =
+  (<T>() => T extends TLeft ? 1 : 2) extends (<T>() => T extends TRight ? 1 : 2)
+    ? (<T>() => T extends TRight ? 1 : 2) extends (<T>() => T extends TLeft ? 1 : 2)
+      ? true
+      : false
+    : false
+
+type CollectionSourceGetSignatures<TReader> = TReader extends { get: {
+  (key: infer TKey1): Promise<infer TValue1>
+  (key: infer TKey2): Promise<infer TValue2>
+  (key: infer TKey3): Promise<infer TValue3>
+  (key: infer TKey4): Promise<infer TValue4>
+  (key: infer TKey5): Promise<infer TValue5>
+} } ? [[TKey1, TValue1], [TKey2, TValue2], [TKey3, TValue3], [TKey4, TValue4], [TKey5, TValue5]] : never
+
+type SignaturesAreEqual<TSignatures extends unknown[], TExpected = TSignatures[number]> =
+  TSignatures extends [infer TSignature, ...infer TRest]
+    ? Equal<TSignature, TExpected> extends true
+      ? SignaturesAreEqual<TRest, TExpected>
+      : false
+    : true
+
+type ValidCollectionGet<TReader> =
+  TReader extends unknown
+    ? SignaturesAreEqual<CollectionSourceGetSignatures<TReader>> extends true ? TReader : never
+    : never
+
 type ValidCollectionSource<TReader> =
   [CollectionSourceItem<TReader>] extends [never]
-    ? TReader
+    ? ValidCollectionGet<TReader>
     : Exclude<CollectionSourceItem<TReader>["key"], CollectionSourceKey<TReader>> extends never
-      ? TReader
+      ? ValidCollectionGet<TReader>
       : never
 
 type ValidCollectionSources<TSources extends CollectionSources> = {

--- a/packages/source/src/core/collection.ts
+++ b/packages/source/src/core/collection.ts
@@ -22,7 +22,7 @@ type CollectionSourceItem<TReader> =
   TReader extends { items(): Promise<Array<infer TItem extends { key: string }>> } ? TItem : never
 
 type ValidCollectionSource<TReader> =
-  TReader extends { items(): Promise<Array<infer TItem extends { key: string }>> }
+  [TReader] extends [{ items(): Promise<Array<infer TItem extends { key: string }>> }]
     ? Exclude<TItem["key"], CollectionSourceKey<TReader>> extends never ? TReader : never
     : TReader
 

--- a/packages/source/src/core/collection.ts
+++ b/packages/source/src/core/collection.ts
@@ -1,0 +1,96 @@
+import { sourceError } from "./errors.ts"
+
+interface CollectionSourceReader {
+  get(key: never): Promise<unknown>
+  items?(): Promise<Array<{ key: string }>>
+}
+
+type CollectionSources = Record<string, CollectionSourceReader>
+
+type CollectionSourceKey<TReader> =
+  TReader extends { get(key: infer TKey): Promise<unknown> } ? Extract<TKey, string> : never
+
+type CollectionSourceValue<TReader> =
+  TReader extends { get(key: never): Promise<infer TValue> } ? TValue : never
+
+type CollectionSourceItem<TReader> =
+  TReader extends { items(): Promise<Array<infer TItem extends { key: string }>> } ? TItem : never
+
+type ValidCollectionSource<TReader> =
+  TReader extends { items(): Promise<Array<infer TItem extends { key: string }>> }
+    ? Exclude<TItem["key"], CollectionSourceKey<TReader>> extends never ? TReader : never
+    : TReader
+
+type ValidCollectionSources<TSources extends CollectionSources> = {
+  [TSource in keyof TSources]: ValidCollectionSource<TSources[TSource]>
+}
+
+type TaggedCollectionItem<TSource extends string, TReader> =
+  [CollectionSourceItem<TReader>] extends [never]
+    ? never
+    : CollectionSourceItem<TReader> extends infer TItem extends { key: string }
+      ? Omit<TItem, "identity" | "source"> & {
+          identity: readonly [TSource, TItem["key"]]
+          source: TSource
+        }
+      : never
+
+type CollectionItem<TSources extends CollectionSources> = {
+  [TSource in Extract<keyof TSources, string>]: TaggedCollectionItem<TSource, TSources[TSource]>
+}[Extract<keyof TSources, string>]
+
+interface CollectionDefinition<TSources extends CollectionSources> {
+  readonly sources: TSources & ValidCollectionSources<TSources>
+}
+
+interface CollectionReader<TSources extends CollectionSources> {
+  get<TSource extends Extract<keyof TSources, string>>(identity: readonly [
+    source: TSource,
+    key: CollectionSourceKey<TSources[TSource]>,
+  ]): Promise<CollectionSourceValue<TSources[TSource]>>
+  items(): Promise<Array<CollectionItem<TSources>>>
+}
+
+export function defineCollection<const TSources extends CollectionSources>(
+  collection: CollectionDefinition<TSources>,
+): CollectionReader<TSources> {
+  const { sources } = collection
+
+  async function get<TSource extends Extract<keyof TSources, string>>(
+    identity: readonly [source: TSource, key: CollectionSourceKey<TSources[TSource]>],
+  ): Promise<CollectionSourceValue<TSources[TSource]>> {
+    if (!Array.isArray(identity) || identity.length !== 2
+      || typeof identity[0] !== "string" || typeof identity[1] !== "string") {
+      throw new TypeError("[vitehub] Collection identity must be a [source, key] string tuple.")
+    }
+
+    const [source, key] = identity
+    if (!Object.hasOwn(sources, source)) {
+      throw sourceError(`[vitehub] Collection source alias ${JSON.stringify(source)} is not defined.`)
+    }
+
+    return await (sources[source].get as (key: string) => Promise<CollectionSourceValue<TSources[TSource]>>)(key)
+  }
+
+  async function items(): Promise<Array<CollectionItem<TSources>>> {
+    const entries = Object.entries(sources)
+    for (const [source, reader] of entries) {
+      if (typeof reader.items !== "function") {
+        throw sourceError(`[vitehub] Collection source alias ${JSON.stringify(source)} is not enumerable.`)
+      }
+    }
+
+    const groups = await Promise.all(entries.map(async ([source, reader]) =>
+      (await reader.items!()).map(item => ({
+        ...item,
+        identity: [source, item.key],
+        source,
+      })),
+    ))
+
+    // Object.entries erases the alias/item correlation validated by CollectionDefinition.
+    return groups.flat() as unknown as Array<CollectionItem<TSources>>
+  }
+
+  return { get, items }
+}

--- a/packages/source/src/core/collection.ts
+++ b/packages/source/src/core/collection.ts
@@ -40,6 +40,18 @@ type CollectionItem<TSources extends CollectionSources> = {
   [TSource in Extract<keyof TSources, string>]: TaggedCollectionItem<TSource, TSources[TSource]>
 }[Extract<keyof TSources, string>]
 
+type CollectionIdentity<TSources extends CollectionSources> = {
+  [TSource in Extract<keyof TSources, string>]: readonly [
+    source: TSource,
+    key: CollectionSourceKey<TSources[TSource]>,
+  ]
+}[Extract<keyof TSources, string>]
+
+type CollectionIdentityValue<TSources extends CollectionSources, TIdentity> =
+  TIdentity extends readonly [infer TSource extends Extract<keyof TSources, string>, string]
+    ? CollectionSourceValue<TSources[TSource]>
+    : never
+
 interface CollectionDefinition<TSources extends CollectionSources> {
   readonly sources: TSources
     & ValidCollectionSources<TSources>
@@ -47,10 +59,9 @@ interface CollectionDefinition<TSources extends CollectionSources> {
 }
 
 interface CollectionReader<TSources extends CollectionSources> {
-  get<TSource extends Extract<keyof TSources, string>>(identity: readonly [
-    source: TSource,
-    key: CollectionSourceKey<TSources[TSource]>,
-  ]): Promise<CollectionSourceValue<TSources[TSource]>>
+  get<const TIdentity extends CollectionIdentity<TSources>>(
+    identity: TIdentity,
+  ): Promise<CollectionIdentityValue<TSources, TIdentity>>
   items(): Promise<Array<CollectionItem<TSources>>>
 }
 
@@ -59,9 +70,9 @@ export function defineCollection<const TSources extends CollectionSources>(
 ): CollectionReader<TSources> {
   const sources: TSources = collection.sources
 
-  async function get<TSource extends Extract<keyof TSources, string>>(
-    identity: readonly [source: TSource, key: CollectionSourceKey<TSources[TSource]>],
-  ): Promise<CollectionSourceValue<TSources[TSource]>> {
+  async function get<const TIdentity extends CollectionIdentity<TSources>>(
+    identity: TIdentity,
+  ): Promise<CollectionIdentityValue<TSources, TIdentity>> {
     if (!Array.isArray(identity) || identity.length !== 2
       || typeof identity[0] !== "string" || typeof identity[1] !== "string") {
       throw new TypeError("[vitehub] Collection identity must be a [source, key] string tuple.")
@@ -72,7 +83,7 @@ export function defineCollection<const TSources extends CollectionSources>(
       throw sourceError(`[vitehub] Collection source alias ${JSON.stringify(source)} is not defined.`)
     }
 
-    return await (sources[source].get as (key: string) => Promise<CollectionSourceValue<TSources[TSource]>>)(key)
+    return await (sources[source].get as (key: string) => Promise<CollectionIdentityValue<TSources, TIdentity>>)(key)
   }
 
   async function items(): Promise<Array<CollectionItem<TSources>>> {

--- a/packages/source/src/core/collection.ts
+++ b/packages/source/src/core/collection.ts
@@ -25,22 +25,25 @@ type ValidCollectionSources<TSources extends CollectionSources> = {
   [TSource in keyof TSources]: ValidCollectionSource<TSources[TSource]>
 }
 
+type TaggedCollectionItemVariant<TSource extends string, TItem> =
+  TItem extends { key: string }
+    ? Omit<TItem, "identity" | "source"> & {
+        identity: readonly [TSource, TItem["key"]]
+        source: TSource
+      }
+    : never
+
 type TaggedCollectionItem<TSource extends string, TReader> =
-  [CollectionSourceItem<TReader>] extends [never]
-    ? never
-    : CollectionSourceItem<TReader> extends infer TItem extends { key: string }
-      ? Omit<TItem, "identity" | "source"> & {
-          identity: readonly [TSource, TItem["key"]]
-          source: TSource
-        }
-      : never
+  TaggedCollectionItemVariant<TSource, CollectionSourceItem<TReader>>
 
 type CollectionItem<TSources extends CollectionSources> = {
   [TSource in Extract<keyof TSources, string>]: TaggedCollectionItem<TSource, TSources[TSource]>
 }[Extract<keyof TSources, string>]
 
 interface CollectionDefinition<TSources extends CollectionSources> {
-  readonly sources: TSources & ValidCollectionSources<TSources>
+  readonly sources: TSources
+    & ValidCollectionSources<TSources>
+    & Record<Exclude<keyof TSources, string>, never>
 }
 
 interface CollectionReader<TSources extends CollectionSources> {
@@ -54,7 +57,7 @@ interface CollectionReader<TSources extends CollectionSources> {
 export function defineCollection<const TSources extends CollectionSources>(
   collection: CollectionDefinition<TSources>,
 ): CollectionReader<TSources> {
-  const { sources } = collection
+  const sources: TSources = collection.sources
 
   async function get<TSource extends Extract<keyof TSources, string>>(
     identity: readonly [source: TSource, key: CollectionSourceKey<TSources[TSource]>],

--- a/packages/source/src/core/define.ts
+++ b/packages/source/src/core/define.ts
@@ -1,9 +1,30 @@
-import type { Source } from "./types.ts"
+import type { Source, SourceContext } from "./types.ts"
 
-export function defineSource<const TSource extends Source>(source: TSource): TSource {
+interface KeyedSourceReader {
+  get(key: never): Promise<unknown>
+}
+
+type RuntimeSourceDefinition<TReader extends KeyedSourceReader> =
+  (context: SourceContext) => TReader
+
+export function defineSource<const TSource extends Source>(source: TSource): TSource
+export function defineSource<const TReader extends KeyedSourceReader>(source: TReader): TReader
+export function defineSource<const TReader extends KeyedSourceReader>(
+  definition: RuntimeSourceDefinition<TReader>,
+): RuntimeSourceDefinition<TReader>
+export function defineSource(
+  source: Source | KeyedSourceReader | RuntimeSourceDefinition<KeyedSourceReader>,
+) {
   return source
 }
 
 export function defineSources<const TSources extends Record<string, Source>>(sources: TSources): TSources {
   return sources
+}
+
+export function createSource<const TReader extends KeyedSourceReader>(
+  definition: RuntimeSourceDefinition<TReader>,
+  context: SourceContext,
+): TReader {
+  return definition(context)
 }

--- a/packages/source/src/index.ts
+++ b/packages/source/src/index.ts
@@ -1,4 +1,5 @@
-export { defineSource, defineSources } from "./core/define.ts"
+export { defineCollection } from "./core/collection.ts"
+export { createSource, defineSource, defineSources } from "./core/define.ts"
 export {
   clearSources,
   getRegisteredSource,

--- a/packages/source/test/collection.test.ts
+++ b/packages/source/test/collection.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createSource, defineCollection, defineSource } from "../src/index.ts"
+
+function enumerable<const TKey extends string, TData>(key: TKey, data: TData) {
+  return {
+    async get(requested: TKey) {
+      return { data, key: requested }
+    },
+    async items() {
+      return [{ data, identity: ["reader", key], key, source: "reader" }]
+    },
+  }
+}
+
+describe("Source Collections", () => {
+  it("keeps equal Source keys distinct by alias", async () => {
+    const collection = defineCollection({
+      sources: {
+        first: enumerable("same", 1),
+        second: enumerable("same", 2),
+      },
+    })
+
+    await expect(collection.items()).resolves.toEqual([
+      { data: 1, identity: ["first", "same"], key: "same", source: "first" },
+      { data: 2, identity: ["second", "same"], key: "same", source: "second" },
+    ])
+    await expect(collection.get(["second", "same"])).resolves.toEqual({ data: 2, key: "same" })
+  })
+
+  it("supports keyed context Sources and validates Collection failures", async () => {
+    const definition = defineSource(context => ({
+      async get(key: string) {
+        return `${context.rootDir}:${key.toUpperCase()}`
+      },
+    }))
+    const keyed = createSource(definition, { rootDir: "/recaps" })
+    const collection = defineCollection({ sources: { keyed } })
+
+    await expect(collection.get(["keyed", "july"])).resolves.toBe("/recaps:JULY")
+    await expect(collection.items()).rejects.toMatchObject({ code: "SOURCE_FAILED", name: "ViteHubError" })
+    await expect(collection.get(["missing" as "keyed", "july"])).rejects.toThrow("source alias \"missing\" is not defined")
+    await expect(collection.get("keyed:july" as never)).rejects.toBeInstanceOf(TypeError)
+  })
+
+  it("rejects non-enumerable Collections before reading any Source", async () => {
+    const items = vi.fn(async () => [{ key: "one" }])
+    const collection = defineCollection({
+      sources: {
+        enumerable: { async get(key: string) { return key }, items },
+        keyed: { async get(key: string) { return key } },
+      },
+    })
+
+    await expect(collection.items()).rejects.toThrow("source alias \"keyed\" is not enumerable")
+    expect(items).not.toHaveBeenCalled()
+  })
+})

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -104,6 +104,13 @@ describe("@vite-hub/source types", () => {
     const source = "count" as "count" | "keyed"
     // @ts-expect-error A union alias must remain correlated with its Source key
     await collection.get([source, "2026-07"])
+    const conditionalReader = Math.random() > 0.5
+      ? reader("a" as "a" | "shared", 1)
+      : reader("b" as "b" | "shared", 2)
+    const conditionalCollection = defineCollection({ sources: { conditional: conditionalReader } })
+    await conditionalCollection.get(["conditional", "shared"])
+    // @ts-expect-error A key must be accepted by every possible reader variant
+    await conditionalCollection.get(["conditional", "a"])
     // @ts-expect-error enumerable item keys must be accepted by the Source reader
     defineCollection({ sources: { invalid: { async get(_key: "one") {}, async items() { return [{ key: "two" as const }] } } } })
     // @ts-expect-error Collection aliases must be strings

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -105,12 +105,20 @@ describe("@vite-hub/source types", () => {
     // @ts-expect-error A union alias must remain correlated with its Source key
     await collection.get([source, "2026-07"])
     const conditionalReader = Math.random() > 0.5
-      ? reader("a" as "a" | "shared", 1)
-      : reader("b" as "b" | "shared", 2)
+      ? { async get(key: "a" | "shared") { return key } }
+      : { async get(key: "b" | "shared") { return key } }
     const conditionalCollection = defineCollection({ sources: { conditional: conditionalReader } })
     await conditionalCollection.get(["conditional", "shared"])
     // @ts-expect-error A key must be accepted by every possible reader variant
     await conditionalCollection.get(["conditional", "a"])
+    const enumerableUnion = Math.random() > 0.5
+      ? { async get(key: "a" | "shared") { return key }, async items() { return [{ key: "shared" as const }] } }
+      : { async get(key: "b" | "shared") { return key }, async items() { return [{ key: "shared" as const }] } }
+    const enumerableCollection = defineCollection({ sources: { enumerable: enumerableUnion } })
+    const emittedIdentity = (await enumerableCollection.items())[0]!.identity
+    await enumerableCollection.get(emittedIdentity)
+    // @ts-expect-error Enumerable union readers cannot emit a variant-only key
+    defineCollection({ sources: { invalidUnion: (Math.random() > 0.5 ? reader("a", 1) : reader("b", 2)) } })
     // @ts-expect-error enumerable item keys must be accepted by the Source reader
     defineCollection({ sources: { invalid: { async get(_key: "one") {}, async items() { return [{ key: "two" as const }] } } } })
     // @ts-expect-error Collection aliases must be strings

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -81,12 +81,30 @@ describe("@vite-hub/source types", () => {
       .toEqualTypeOf<{ month: "2026-07", rootDir: string }>()
     expectTypeOf((await collection.items())[0]!.source).toEqualTypeOf<"count" | "title">()
 
+    const variants = defineCollection({
+      sources: {
+        variant: {
+          async get(key: "a" | "b") { return key },
+          async items(): Promise<Array<{ key: "a", a: number } | { key: "b", b: string }>> {
+            return [{ key: "a", a: 1 }]
+          },
+        },
+      },
+    })
+    const variant = (await variants.items())[0]!
+    if (variant.key === "a")
+      expectTypeOf(variant.a).toBeNumber()
+    else
+      expectTypeOf(variant.b).toBeString()
+
     // @ts-expect-error Collection aliases are inferred
     await collection.get(["missing", "same"])
     // @ts-expect-error Source keys are inferred per alias
     await collection.get(["count", "different"])
     // @ts-expect-error enumerable item keys must be accepted by the Source reader
     defineCollection({ sources: { invalid: { async get(_key: "one") {}, async items() { return [{ key: "two" as const }] } } } })
+    // @ts-expect-error Collection aliases must be strings
+    defineCollection({ sources: { 0: reader("same", 1) } })
   })
 
   it("accepts SDK clients and transports without exposing SDK types", () => {

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -119,6 +119,14 @@ describe("@vite-hub/source types", () => {
     await enumerableCollection.get(emittedIdentity)
     // @ts-expect-error Enumerable union readers cannot emit a variant-only key
     defineCollection({ sources: { invalidUnion: (Math.random() > 0.5 ? reader("a", 1) : reader("b", 2)) } })
+    const mixedUnion = Math.random() > 0.5
+      ? { async get(key: "a" | "shared") { return key }, async items() { return [{ key: "shared" as const }] } }
+      : { async get(key: "b" | "shared") { return key } }
+    const mixedCollection = defineCollection({ sources: { mixed: mixedUnion } })
+    const mixedIdentity = (await mixedCollection.items())[0]!.identity
+    await mixedCollection.get(mixedIdentity)
+    // @ts-expect-error Mixed reader unions cannot emit a variant-only key either
+    defineCollection({ sources: { invalidMixed: (Math.random() > 0.5 ? reader("a", 1) : { async get(key: "b") { return key } }) } })
     // @ts-expect-error enumerable item keys must be accepted by the Source reader
     defineCollection({ sources: { invalid: { async get(_key: "one") {}, async items() { return [{ key: "two" as const }] } } } })
     // @ts-expect-error Collection aliases must be strings

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -3,7 +3,9 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 
 import {
+  createSource,
   custom,
+  defineCollection,
   defineSource,
   defineSources,
   registerSources,
@@ -48,6 +50,45 @@ declare global {
 }
 
 describe("@vite-hub/source types", () => {
+  it("infers Collection aliases, keys, values, and enumerable items", async () => {
+    function reader<const TKey extends string, TData>(key: TKey, data: TData) {
+      return {
+        async get(requested: TKey) {
+          return { data, key: requested }
+        },
+        async items() {
+          return [{ data, key }]
+        },
+      }
+    }
+
+    const keyedDefinition = defineSource(context => ({
+      async get(month: "2026-07") {
+        return { month, rootDir: context.rootDir }
+      },
+    }))
+    const collection = defineCollection({
+      sources: {
+        count: reader("same", 1),
+        keyed: createSource(keyedDefinition, { rootDir: "/recaps" }),
+        title: reader("same", "Title"),
+      },
+    })
+
+    expectTypeOf(await collection.get(["count", "same"]))
+      .toEqualTypeOf<{ data: number, key: "same" }>()
+    expectTypeOf(await collection.get(["keyed", "2026-07"]))
+      .toEqualTypeOf<{ month: "2026-07", rootDir: string }>()
+    expectTypeOf((await collection.items())[0]!.source).toEqualTypeOf<"count" | "title">()
+
+    // @ts-expect-error Collection aliases are inferred
+    await collection.get(["missing", "same"])
+    // @ts-expect-error Source keys are inferred per alias
+    await collection.get(["count", "different"])
+    // @ts-expect-error enumerable item keys must be accepted by the Source reader
+    defineCollection({ sources: { invalid: { async get(_key: "one") {}, async items() { return [{ key: "two" as const }] } } } })
+  })
+
   it("accepts SDK clients and transports without exposing SDK types", () => {
     const client = new Client({ name: "test", version: "1.0.0" })
     const transport = new StreamableHTTPClientTransport(new URL("https://example.com/mcp"))

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -134,6 +134,20 @@ describe("@vite-hub/source types", () => {
     const overloadedReader = null as unknown as OverloadedReader
     // @ts-expect-error Overloaded get methods have an ambiguous Collection contract
     defineCollection({ sources: { overloaded: overloadedReader } })
+    const conditionalGeneric = null as unknown as {
+      get<TKey extends string>(key: TKey): Promise<TKey extends "a" ? { a: number } : never>
+    }
+    // @ts-expect-error Generic key-dependent get methods cannot be represented by the Collection return type
+    defineCollection({ sources: { conditionalGeneric } })
+    interface GenericItems {
+      a: { a: number }
+      b: { b: string }
+    }
+    const indexedGeneric = null as unknown as {
+      get<TKey extends keyof GenericItems>(key: TKey): Promise<GenericItems[TKey]>
+    }
+    // @ts-expect-error Generic key-dependent get methods must use an explicit union-parameter contract
+    defineCollection({ sources: { indexedGeneric } })
     // @ts-expect-error enumerable item keys must be accepted by the Source reader
     defineCollection({ sources: { invalid: { async get(_key: "one") {}, async items() { return [{ key: "two" as const }] } } } })
     // @ts-expect-error Collection aliases must be strings

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -127,6 +127,13 @@ describe("@vite-hub/source types", () => {
     await mixedCollection.get(mixedIdentity)
     // @ts-expect-error Mixed reader unions cannot emit a variant-only key either
     defineCollection({ sources: { invalidMixed: (Math.random() > 0.5 ? reader("a", 1) : { async get(key: "b") { return key } }) } })
+    interface OverloadedReader {
+      get(key: "a"): Promise<{ a: number }>
+      get(key: "b"): Promise<{ b: string }>
+    }
+    const overloadedReader = null as unknown as OverloadedReader
+    // @ts-expect-error Overloaded get methods have an ambiguous Collection contract
+    defineCollection({ sources: { overloaded: overloadedReader } })
     // @ts-expect-error enumerable item keys must be accepted by the Source reader
     defineCollection({ sources: { invalid: { async get(_key: "one") {}, async items() { return [{ key: "two" as const }] } } } })
     // @ts-expect-error Collection aliases must be strings

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -101,6 +101,9 @@ describe("@vite-hub/source types", () => {
     await collection.get(["missing", "same"])
     // @ts-expect-error Source keys are inferred per alias
     await collection.get(["count", "different"])
+    const source = "count" as "count" | "keyed"
+    // @ts-expect-error A union alias must remain correlated with its Source key
+    await collection.get([source, "2026-07"])
     // @ts-expect-error enumerable item keys must be accepted by the Source reader
     defineCollection({ sources: { invalid: { async get(_key: "one") {}, async items() { return [{ key: "two" as const }] } } } })
     // @ts-expect-error Collection aliases must be strings


### PR DESCRIPTION
Source readers could retrieve typed items independently, but consumers had to hand-roll alias dispatch and could not identify equal keys from different Sources without losing type inference.

This adds a Collection composition layer with stable `[source, key]` identities. `get()` preserves each alias's key and return type, while `items()` tags enumerable items and rejects a partially enumerable Collection before starting reader work. Existing Source definitions, registration, and runtime readers remain unchanged; `createSource()` only materializes a context-dependent keyed reader.

## Verification

- `pnpm --filter @vite-hub/source typecheck`
- `pnpm --filter @vite-hub/source test` — 59 tests, build and publint pass
- `pnpm vp run lint`
- `pnpm vp run fallow:dead-code`
- packed consumer proof without the Source patch — 2 runtime tests and strict TypeScript contract pass
