### PR TITLE
fix(schedule): externalize Node built-ins in Cloudflare output

### DIFF
--- a/packages/schedule/src/internal/provider-output.ts
+++ b/packages/schedule/src/internal/provider-output.ts
@@ -514,6 +514,7 @@ async function writeCloudflareScheduleOutput(options: {
     bundleEsmEntry(options.bundleEntry, resolve(outputRoot, main), {
       alias: options.bundleAlias,
       conditions: ["workerd", "worker", "browser", "default"],
+      external: ["node:*"],
       format: "esm",
       platform: "neutral",
       plugins: [createScheduleDefinitionAliasPlugin()],

--- a/packages/schedule/test/provider-output.test.ts
+++ b/packages/schedule/test/provider-output.test.ts
@@ -112,6 +112,23 @@ describe("schedule provider output", () => {
     await expect(readFile(join(rootDir, ".vitehub", "schedule", "registry.mjs"), "utf8")).resolves.not.toContain("agent-turn")
   })
 
+  it("preserves Node built-ins for the Cloudflare runtime", async () => {
+    const rootDir = await createTempProject("vitehub-schedule-cloudflare-node-builtins-")
+    await writeFile(join(rootDir, "src", "cleanup.schedule.ts"), [
+      "import { AsyncLocalStorage } from 'node:async_hooks'",
+      "import { defineSchedule } from '@vite-hub/schedule'",
+      "",
+      "const storage = new AsyncLocalStorage()",
+      "export default defineSchedule({ cron: '0 0 * * *', handler: () => storage.getStore() })",
+      "",
+    ].join("\n"), "utf8")
+
+    await generateProviderOutputs({ clientOutDir: "dist/client", rootDir })
+
+    await expect(readFile(join(createDefaultCloudflareOutputRoot(rootDir), "index.js"), "utf8"))
+      .resolves.toContain('from "node:async_hooks"')
+  })
+
   it("installs a composed Workflow runtime in Vercel schedule functions", async () => {
     const rootDir = await createTempProject("vitehub-schedule-workflow-output-")
     const workflowDir = join(rootDir, ".vitehub", "workflow")


### PR DESCRIPTION
- Fixes scheduled Workflow builds that failed while Schedule bundled its Cloudflare provider artifact during a Vercel build by preserving node:* imports for the nodejs_compat runtime.
- Adds a provider-output regression covering node:async_hooks in a Schedule handler.
- Validation: Schedule 211/211 with no type errors; Workflow 157/157.
- Packed /Users/maxi/vitehub/prs proof with Schedule and Workflow patches absent: install, typecheck, 7/7 tests, Vercel build, native Workflow output, runtime wiring, and the monthly cron all pass.