### PR TITLE
fix(agent): decode workflow audio data URLs before transcription

### DIFF
--- a/packages/agent/src/capabilities/transcribe.ts
+++ b/packages/agent/src/capabilities/transcribe.ts
@@ -1,5 +1,5 @@
 import { defineCapability } from "../capability-runtime.ts"
-import { appendMessageText } from "../messages.ts"
+import { appendMessageText, attachmentStringByteLength, attachmentStringBytes } from "../messages.ts"
 import { loadAiSdk } from "../internal/ai-sdk-runtime.ts"
 import { isTranscriptionAbortError, isTranscriptionError, transcriptionError } from "./transcription.ts"
 
@@ -172,9 +172,8 @@ async function toAiSdkAudio(audio: AudioPart, maxBytes: number): Promise<Paramet
   const data = await resolveAudioData(audio, maxBytes)
   if (data instanceof Blob) return await data.arrayBuffer()
   if (typeof data === "string" && /^data:/i.test(data)) {
-    const bytes = bytesFromAudioString(data)
-    assertWithinMaxBytes(bytes.byteLength, maxBytes, "audio data")
-    return bytes
+    assertWithinMaxBytes(attachmentStringByteLength(data, audio.mediaType), maxBytes, "audio data")
+    return attachmentStringBytes(data, audio.mediaType)
   }
   if (data) return data
   if (audio.url) return new URL(audio.url)
@@ -195,21 +194,6 @@ export function audioExtensionFor(mediaType = "", fallback = "ogg"): string {
   if (normalized === "audio/wav" || normalized === "audio/x-wav") return "wav"
   if (normalized === "audio/webm") return "webm"
   return fallback
-}
-
-function bytesFromBase64(value: string): Uint8Array {
-  if (typeof atob === "function") {
-    const binary = atob(value)
-    return Uint8Array.from(binary, char => char.charCodeAt(0))
-  }
-  return new Uint8Array(Buffer.from(value, "base64"))
-}
-
-function bytesFromAudioString(value: string): Uint8Array {
-  const dataUrl = /^data:([^,]*),(.*)$/i.exec(value)
-  if (dataUrl?.[1]?.toLowerCase().split(";").includes("base64")) return bytesFromBase64(dataUrl[2] || "")
-  if (dataUrl?.[2]) return new TextEncoder().encode(decodeURIComponent(dataUrl[2]))
-  return new TextEncoder().encode(value)
 }
 
 async function responseBytes(response: Response, maxBytes: number): Promise<Uint8Array> {
@@ -267,7 +251,11 @@ export async function audioBytes(audio: AudioPart, options?: { maxBytes?: number
   if (data instanceof ArrayBuffer) return new Uint8Array(data)
   if (ArrayBuffer.isView(data)) return new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
   if (typeof data === "string") {
-    const bytes = bytesFromAudioString(data)
+    if (/^data:/i.test(data)) {
+      assertWithinMaxBytes(attachmentStringByteLength(data, audio.mediaType), maxBytes, "audio data")
+      return attachmentStringBytes(data, audio.mediaType)
+    }
+    const bytes = new TextEncoder().encode(data)
     assertWithinMaxBytes(bytes.byteLength, maxBytes, "audio data")
     return bytes
   }

--- a/packages/agent/src/capabilities/transcribe.ts
+++ b/packages/agent/src/capabilities/transcribe.ts
@@ -164,7 +164,7 @@ async function resolveAudioData(audio: AudioPart, maxBytes: number): Promise<Aud
   if (data instanceof Blob) assertWithinMaxBytes(data.size, maxBytes, "downloaded audio")
   else if (data instanceof ArrayBuffer) assertWithinMaxBytes(data.byteLength, maxBytes, "downloaded audio")
   else if (ArrayBuffer.isView(data)) assertWithinMaxBytes(data.byteLength, maxBytes, "downloaded audio")
-  else if (typeof data === "string") assertWithinMaxBytes(data.length, maxBytes, "downloaded audio")
+  else if (typeof data === "string" && !/^data:/i.test(data)) assertWithinMaxBytes(data.length, maxBytes, "downloaded audio")
   return data
 }
 

--- a/packages/agent/src/capabilities/transcribe.ts
+++ b/packages/agent/src/capabilities/transcribe.ts
@@ -171,6 +171,11 @@ async function resolveAudioData(audio: AudioPart, maxBytes: number): Promise<Aud
 async function toAiSdkAudio(audio: AudioPart, maxBytes: number): Promise<Parameters<AiSdkTranscribe>[0]["audio"]> {
   const data = await resolveAudioData(audio, maxBytes)
   if (data instanceof Blob) return await data.arrayBuffer()
+  if (typeof data === "string" && /^data:/i.test(data)) {
+    const bytes = bytesFromAudioString(data)
+    assertWithinMaxBytes(bytes.byteLength, maxBytes, "audio data")
+    return bytes
+  }
   if (data) return data
   if (audio.url) return new URL(audio.url)
   throw new TypeError("[vitehub] transcribe() requires audio data, fetchData, or url.")

--- a/packages/agent/src/messages.ts
+++ b/packages/agent/src/messages.ts
@@ -231,6 +231,55 @@ export function attachmentStringBytes(value: string, mediaType: string): Uint8Ar
   return base64Bytes(value)
 }
 
+export function attachmentStringByteLength(value: string, mediaType: string): number {
+  const dataUrl = /^data:([^,]*?),(.*)$/is.exec(value)
+  if (!dataUrl) {
+    if (isTextAttachmentMediaType(mediaType)) return utf8ByteLength(value)
+    return base64ByteLength(value)
+  }
+  const encoded = dataUrl[2]!
+  if (dataUrl[1]!.split(";").some(parameter => parameter.toLowerCase() === "base64")) {
+    return base64ByteLength(encoded)
+  }
+  let byteLength = 0
+  for (let index = 0; index < encoded.length;) {
+    if (encoded.charCodeAt(index) === 37) {
+      const encodedByte = encoded.slice(index + 1, index + 3)
+      if (!/^[\da-f]{2}$/i.test(encodedByte)) throw new URIError("URI malformed")
+      byteLength++
+      index += 3
+      continue
+    }
+    const codePoint = encoded.codePointAt(index)!
+    byteLength += codePoint <= 0x7F ? 1 : codePoint <= 0x7FF ? 2 : codePoint <= 0xFFFF ? 3 : 4
+    index += codePoint > 0xFFFF ? 2 : 1
+  }
+  return byteLength
+}
+
+function base64ByteLength(value: string): number {
+  let normalizedLength = 0
+  let previous = ""
+  let last = ""
+  for (const character of value) {
+    if (/\s/.test(character)) continue
+    normalizedLength++
+    previous = last
+    last = character
+  }
+  const padding = last === "=" ? previous === "=" ? 2 : 1 : 0
+  return Math.floor(normalizedLength * 3 / 4) - padding
+}
+
+function utf8ByteLength(value: string): number {
+  let byteLength = 0
+  for (const character of value) {
+    const codePoint = character.codePointAt(0)!
+    byteLength += codePoint <= 0x7F ? 1 : codePoint <= 0x7FF ? 2 : codePoint <= 0xFFFF ? 3 : 4
+  }
+  return byteLength
+}
+
 function base64Bytes(value: string): Uint8Array {
   const normalized = value.replaceAll(/\s/g, "").replaceAll("-", "+").replaceAll("_", "/")
   const padded = normalized.padEnd(normalized.length + (4 - normalized.length % 4) % 4, "=")

--- a/packages/agent/test/transcription.test.ts
+++ b/packages/agent/test/transcription.test.ts
@@ -711,6 +711,17 @@ describe("agent transcription", () => {
       await capability.input?.(rawBase64Context.context as never)
       expect(aiTranscribe).toHaveBeenLastCalledWith(expect.objectContaining({ audio: "T2dnUwECAw==" }))
 
+      const lazyDataUrlContext = createTranscriptionCapabilityContext([
+        createMessage({
+          parts: [{ fetchData: () => "data:audio/ogg;base64,T2dnUwECAw==", mediaType: "audio/ogg", type: "audio" }],
+          role: "user",
+        }),
+      ])
+      await transcribe({ maxBytes: 7, model: "mock-transcription-model" }).input?.(lazyDataUrlContext.context as never)
+      expect(aiTranscribe).toHaveBeenLastCalledWith(expect.objectContaining({
+        audio: new Uint8Array([79, 103, 103, 83, 1, 2, 3]),
+      }))
+
       const oversized = transcribe({ maxBytes: 6, model: "mock-transcription-model" })
       await expect(oversized.input?.(createTranscriptionCapabilityContext([
         createMessage({
@@ -718,7 +729,7 @@ describe("agent transcription", () => {
           role: "user",
         }),
       ]).context as never)).rejects.toThrow("exceeds maxBytes")
-      expect(aiTranscribe).toHaveBeenCalledTimes(2)
+      expect(aiTranscribe).toHaveBeenCalledTimes(3)
     }
     finally {
       vi.doUnmock("ai")

--- a/packages/agent/test/transcription.test.ts
+++ b/packages/agent/test/transcription.test.ts
@@ -680,6 +680,51 @@ describe("agent transcription", () => {
     }
   })
 
+  it("decodes Workflow audio data URLs before AI SDK transcription", async () => {
+    const aiTranscribe = vi.fn(async () => ({ text: "voice transcript" }))
+    vi.doMock("ai", () => ({
+      createDownload: vi.fn(() => vi.fn()),
+      transcribe: aiTranscribe,
+    }))
+    try {
+      const capability = transcribe({ model: "mock-transcription-model" })
+      const context = createTranscriptionCapabilityContext([
+        createMessage({
+          parts: [{ data: "data:audio/ogg;base64,T2dnUwECAw==", mediaType: "audio/ogg", type: "audio" }],
+          role: "user",
+        }),
+      ])
+
+      await capability.input?.(context.context as never)
+
+      expect(aiTranscribe).toHaveBeenCalledWith(expect.objectContaining({
+        audio: new Uint8Array([79, 103, 103, 83, 1, 2, 3]),
+        model: "mock-transcription-model",
+      }))
+
+      const rawBase64Context = createTranscriptionCapabilityContext([
+        createMessage({
+          parts: [{ data: "T2dnUwECAw==", mediaType: "audio/ogg", type: "audio" }],
+          role: "user",
+        }),
+      ])
+      await capability.input?.(rawBase64Context.context as never)
+      expect(aiTranscribe).toHaveBeenLastCalledWith(expect.objectContaining({ audio: "T2dnUwECAw==" }))
+
+      const oversized = transcribe({ maxBytes: 6, model: "mock-transcription-model" })
+      await expect(oversized.input?.(createTranscriptionCapabilityContext([
+        createMessage({
+          parts: [{ data: "data:audio/ogg;base64,T2dnUwECAw==", mediaType: "audio/ogg", type: "audio" }],
+          role: "user",
+        }),
+      ]).context as never)).rejects.toThrow("exceeds maxBytes")
+      expect(aiTranscribe).toHaveBeenCalledTimes(2)
+    }
+    finally {
+      vi.doUnmock("ai")
+    }
+  })
+
   it.each([
     [402, false, "TRANSCRIPTION_QUOTA_EXCEEDED", "[vitehub] Transcription provider quota is exhausted."],
     [408, true, "TRANSCRIPTION_PROVIDER_FAILED", "[vitehub] Transcription provider failed."],

--- a/packages/agent/test/transcription.test.ts
+++ b/packages/agent/test/transcription.test.ts
@@ -157,6 +157,11 @@ describe("agent transcription", () => {
       mediaType: "audio/ogg",
       type: "audio",
     })).resolves.toEqual(new Uint8Array([1, 2]))
+    await expect(audioBytes({
+      data: "data:audio/ogg,%FF%D8%FF",
+      mediaType: "audio/ogg",
+      type: "audio",
+    })).resolves.toEqual(new Uint8Array([255, 216, 255]))
   })
 
   it("sends OpenRouter transcription models namespaced model ids with normal JSON output", async () => {
@@ -711,6 +716,17 @@ describe("agent transcription", () => {
       await capability.input?.(rawBase64Context.context as never)
       expect(aiTranscribe).toHaveBeenLastCalledWith(expect.objectContaining({ audio: "T2dnUwECAw==" }))
 
+      const percentEncodedContext = createTranscriptionCapabilityContext([
+        createMessage({
+          parts: [{ data: "data:audio/ogg,%FF%D8%FF", mediaType: "audio/ogg", type: "audio" }],
+          role: "user",
+        }),
+      ])
+      await capability.input?.(percentEncodedContext.context as never)
+      expect(aiTranscribe).toHaveBeenLastCalledWith(expect.objectContaining({
+        audio: new Uint8Array([255, 216, 255]),
+      }))
+
       const lazyDataUrlContext = createTranscriptionCapabilityContext([
         createMessage({
           parts: [{ fetchData: () => "data:audio/ogg;base64,T2dnUwECAw==", mediaType: "audio/ogg", type: "audio" }],
@@ -723,13 +739,16 @@ describe("agent transcription", () => {
       }))
 
       const oversized = transcribe({ maxBytes: 6, model: "mock-transcription-model" })
+      const decode = vi.spyOn(globalThis, "atob")
       await expect(oversized.input?.(createTranscriptionCapabilityContext([
         createMessage({
           parts: [{ data: "data:audio/ogg;base64,T2dnUwECAw==", mediaType: "audio/ogg", type: "audio" }],
           role: "user",
         }),
       ]).context as never)).rejects.toThrow("exceeds maxBytes")
-      expect(aiTranscribe).toHaveBeenCalledTimes(3)
+      expect(decode).not.toHaveBeenCalled()
+      decode.mockRestore()
+      expect(aiTranscribe).toHaveBeenCalledTimes(4)
     }
     finally {
       vi.doUnmock("ai")


### PR DESCRIPTION
Workflow portability serializes binary audio attachments as data URLs, but Agent transcription forwarded those strings unchanged to AI SDK 7. AI SDK treats string audio as raw base64 and rejects the full data URL before calling the transcription provider.

Decode only `data:` audio strings at the shared transcription boundary. Raw base64 strings keep their existing behavior, and `maxBytes` applies to the decoded bytes.

## Verification

- `corepack pnpm exec vp test run test/transcription.test.ts` (36 passed)
- `corepack pnpm --filter @vite-hub/agent typecheck`
- `node --test tests/openrouter-transcription.test.mjs` in Calories (downstream patched-consumer proof)
- `git diff --check`

The full Agent suite is not claimed as passing. It hit widespread unrelated 5-second timeouts across other test files on this machine and was stopped; the focused transcription suite stayed green.
