### PR TITLE
fix(workspace): avoid per-file executable probes

### DIFF
--- a/packages/agent/src/provider-agent.ts
+++ b/packages/agent/src/provider-agent.ts
@@ -385,7 +385,12 @@ export function localWorkspaceHost(): WorkspaceSessionHost {
           for (const entry of await readdir(directory, { withFileTypes: true })) {
             const target = join(directory, entry.name)
             const type = entry.isSymbolicLink() ? "symlink" : entry.isDirectory() ? "directory" : "file"
-            entries.push({ path: target, ...(type === "file" ? { size: (await lstat(target)).size } : {}), type })
+            const stats = type === "file" ? await lstat(target) : undefined
+            entries.push({
+              path: target,
+              ...(stats ? { executable: Boolean(stats.mode & 0o100), size: stats.size } : {}),
+              type,
+            })
             if (options?.recursive && type === "directory") await visit(target)
           }
         }

--- a/packages/agent/test/provider-agent.test.ts
+++ b/packages/agent/test/provider-agent.test.ts
@@ -632,6 +632,27 @@ describe("Provider Agent Driver", () => {
     await rm(heartbeatFile, { force: true })
   })
 
+  it("reports executable modes while listing local Workspace files", async () => {
+    const root = `/tmp/vitehub-provider-file-modes-${crypto.randomUUID()}`
+    await mkdir(root, { recursive: true })
+    try {
+      await writeFile(`${root}/README.md`, "docs")
+      await writeFile(`${root}/group.sh`, "#!/bin/sh\n")
+      await writeFile(`${root}/run.sh`, "#!/bin/sh\n")
+      await chmod(`${root}/group.sh`, 0o010)
+      await chmod(`${root}/run.sh`, 0o755)
+
+      await expect(localWorkspaceHost().files.list(root)).resolves.toEqual(expect.arrayContaining([
+        expect.objectContaining({ executable: false, path: `${root}/group.sh`, type: "file" }),
+        expect.objectContaining({ executable: false, path: `${root}/README.md`, type: "file" }),
+        expect.objectContaining({ executable: true, path: `${root}/run.sh`, type: "file" }),
+      ]))
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
   it("binds Workspace command directory variables to the active root", async () => {
     const cwd = new URL("fixtures/workspace-source-root", import.meta.url).pathname
     const result = await localWorkspaceHost().exec(process.execPath, ["-e", "process.stdout.write(JSON.stringify({ INIT_CWD: process.env.INIT_CWD, OLDPWD: process.env.OLDPWD, PWD: process.env.PWD, cwd: process.cwd() }))"], {

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -153,6 +153,7 @@ export interface WorkspaceSessionOptions {
 }
 
 export interface WorkspaceSessionHostFileEntry {
+  executable?: boolean
   path: string
   size?: number
   type: "directory" | "file" | "symlink"

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -183,7 +183,11 @@ async function assertNoHostSymlinkParent(host: WorkspaceSessionHost, root: strin
 
 function toWorkspaceEntry(root: string, entry: WorkspaceSessionHostFileEntry): WorkspaceEntry {
   return {
-    metadata: entry.type === "symlink" ? { gitMode: "120000" } : undefined,
+    metadata: entry.type === "symlink"
+      ? { gitMode: "120000" }
+      : entry.type === "file" && entry.executable
+        ? { gitMode: "100755" }
+        : undefined,
     path: fromHostPath(root, entry.path),
     size: entry.size,
     type: entry.type === "directory" ? "directory" : "file",
@@ -235,12 +239,13 @@ async function listHostEntries(
 ): Promise<WorkspaceEntry[]> {
   await assertHostWorkspaceRoot(host, root)
   const entries = (await host.files.list(toHostPath(root, path), { recursive }))
-    .map(entry => toWorkspaceEntry(root, entry))
-    .filter(entry => !include || include(entry))
-  const resolved = await mapWithConcurrency(entries, hostInspectionConcurrency, async (workspaceEntry) => {
+    .map(entry => ({ executable: entry.executable, workspaceEntry: toWorkspaceEntry(root, entry) }))
+    .filter(({ workspaceEntry }) => !include || include(workspaceEntry))
+  const resolved = await mapWithConcurrency(entries, hostInspectionConcurrency, async ({ executable, workspaceEntry }) => {
     if (workspaceEntry.type !== "file" || isGitSymlinkEntry(workspaceEntry)) return workspaceEntry
-    const executable = await host.exec("test", ["-x", workspaceEntry.path], { cwd: root })
-    return executable.code === 0
+    if (executable !== undefined) return workspaceEntry
+    const probe = await host.exec("test", ["-x", workspaceEntry.path], { cwd: root })
+    return probe.code === 0
       ? { ...workspaceEntry, metadata: { ...workspaceEntry.metadata, gitMode: "100755" } }
       : workspaceEntry
   })

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1220,6 +1220,42 @@ describe("workspace host sessions", () => {
     expect(maximum).toBeLessThanOrEqual(16)
   })
 
+  it("uses host-reported executable modes without spawning probes", async () => {
+    const docs = workspace()
+    const host = memoryHost()
+    const list = host.files.list.bind(host.files)
+    const exec = host.exec.bind(host)
+    let probes = 0
+    let runExecutable = true
+    host.files.list = async (path, options) => (await list(path, options)).map(entry => entry.type === "file"
+      ? { ...entry, executable: entry.path.endsWith("/scripts/run.sh") ? runExecutable : host.isExecutable(entry.path) }
+      : entry)
+    host.exec = async (command, args, options) => {
+      if (command === "test" && args?.[0] === "-x") probes++
+      return await exec(command, args, options)
+    }
+    await docs.writeFile("README.md", "docs")
+    await docs.writeFile("scripts/run.sh", "#!/bin/sh\n", { metadata: { gitMode: "100755" } })
+    await docs.snapshot({ name: "baseline" })
+
+    const session = await docs.startSession({ host })
+    await expect(session.list("", { recursive: true })).resolves.toEqual(expect.arrayContaining([
+      expect.objectContaining({ metadata: undefined, path: "README.md" }),
+      expect.objectContaining({ metadata: { gitMode: "100755" }, path: "scripts/run.sh" }),
+    ]))
+    runExecutable = false
+    await expect(session.diff()).resolves.toMatchObject({ entries: [expect.objectContaining({
+      after: expect.objectContaining({ metadata: undefined }),
+      before: expect.objectContaining({ metadata: { gitMode: "100755" } }),
+      path: "scripts/run.sh",
+      type: "modified",
+    })] })
+    await session.close()
+
+    expect(probes).toBe(0)
+    expect(host.isExecutable("/workspace/scripts/run.sh")).toBe(true)
+  })
+
   it("keeps unsafe symlinks inert and rejects writes through symlink parents", async () => {
     const docs = workspace()
     const host = memoryHost()


### PR DESCRIPTION
A Workspace Session currently shells out to `test -x` once for every host file. Babysitter provider workspaces can contain about 130,000 dependency files, which leaves teardown running for nearly an hour after the Agent Invocation timeout.

This change lets a Workspace host report the executable bit in its file listing. The local host already calls `lstat()`, so it now returns that bit with the file size. Hosts that do not report it keep the bounded `test -x` fallback.

Verification:
- Workspace host-session suite: 49 passed
- Agent provider suite: 52 passed
- Workspace and Agent typechecks passed
- Regression loop drops executable probes from 4 to 0 while preserving `100755`