### PR TITLE
fix(database): make useDatabase the canonical runtime gate

### DIFF
--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -37,7 +37,7 @@ composition and explicit feature subpaths for application APIs.
 | `vite-hub/browser/providers/cloudflare` and `vite-hub/browser/providers/local` | Advanced explicit provider selection for low-level Browser Clients. |
 | `vite-hub/channels` and `vite-hub/channels/server` | Channel Definitions and discovered named delivery. |
 | `vite-hub/box` | Box Definitions and built-in runtime selection for trusted-host, Crabbox, ASCII, Cloudflare Sandbox, Cloudflare Computer, and Vercel Sandbox execution. |
-| `vite-hub/database` and `vite-hub/database/drizzle` | Database Definitions and generated Drizzle access. |
+| `vite-hub/database` and `vite-hub/database/drizzle` | Database Definitions and generated `useDatabase()` access. |
 | `vite-hub/env` | Env Declaration helpers and authoring types. |
 | `vite-hub/email`, `vite-hub/email/server`, and `vite-hub/email/markdown` | Email clients, configured runtime delivery, and Dynamic Markdown HTML with a composed Markdown text fallback. |
 | `vite-hub/env/presets` and `vite-hub/env/schema` | Reusable Env presets and schema helpers. |
@@ -101,7 +101,7 @@ for libraries, focused integrations, and advanced composition.
 | `@vite-hub/email/markdown` | Email Package | Dynamic Markdown composition into HTML and a composed Markdown text fallback. |
 | `@vite-hub/email/test` | Email Package | Isolated in-memory message capture for tests. |
 | `#vitehub/emails/<name>` | Email Package | Generated async renderer for a discovered `server/emails/**/*.md` template. |
-| `@vite-hub/database/drizzle` | Database Package | Generated Drizzle `db` and `schema` access. |
+| `@vite-hub/database/drizzle` | Database Package | Generated `useDatabase()` access to a Drizzle database and schema. |
 | `@vite-hub/env` | Env Package | Env Declaration helpers. |
 | `@vite-hub/history` | History Package | Durable history checkpoint contract and types. |
 | `#vitehub/env/public` | Env Package | Generated Public Env access. |

--- a/docs/content/docs/server-primitives/database.md
+++ b/docs/content/docs/server-primitives/database.md
@@ -37,13 +37,13 @@ export default defineConfig({
 import { defineDatabase } from '@vite-hub/database'
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
-export const notes = sqliteTable('notes', {
-  id: integer('id').primaryKey(),
-  title: text('title').notNull(),
-})
-
 export default defineDatabase({
-  schema: { notes },
+  schema: {
+    notes: sqliteTable('notes', {
+      id: integer('id').primaryKey(),
+      title: text('title').notNull(),
+    }),
+  },
 })
 ```
 
@@ -54,7 +54,7 @@ export default defineDatabase({
 | Import | Use |
 | --- | --- |
 | `defineDatabase` from `@vite-hub/database` | Declare a Database Definition. |
-| `db`, `databases`, `schema` from `@vite-hub/database/drizzle` | Query the generated Drizzle Runtime Surface. |
+| `useDatabase` from `@vite-hub/database/drizzle` | Select a generated Drizzle database and its schema by name. |
 | `hubDb` from `@vite-hub/database/vite` | Register database discovery, generated schema, and Provider Output. |
 | `@vite-hub/database/config` | Resolve database config values and discovery config. |
 | `@vite-hub/database/cli` | Use package-owned database CLI contribution. |
@@ -97,14 +97,14 @@ Database Definitions keep the Database Table Schema next to the server code that
 import { defineDatabase } from '@vite-hub/database'
 import { integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
-export const notes = sqliteTable('notes', {
-  id: integer('id').primaryKey(),
-  title: text('title').notNull(),
-  body: text('body').notNull(),
-})
-
 export default defineDatabase({
-  schema: { notes },
+  schema: {
+    notes: sqliteTable('notes', {
+      id: integer('id').primaryKey(),
+      title: text('title').notNull(),
+      body: text('body').notNull(),
+    }),
+  },
 })
 ```
 
@@ -143,12 +143,13 @@ pnpm vitehub db migrate
 
 ## Use it at runtime
 
-Use the generated Drizzle Runtime Surface from server code.
+Call `useDatabase()` from server code with the discovered database name. Use `default` for a Default Database.
 
 ```ts [server/api/notes.get.ts]
-import { db, schema } from '@vite-hub/database/drizzle'
+import { useDatabase } from '@vite-hub/database/drizzle'
 
 export default defineEventHandler(() => {
+  const { db, schema } = useDatabase('default')
   return db.select().from(schema.notes)
 })
 ```

--- a/docs/skills/vitehub/references/server-primitives.md
+++ b/docs/skills/vitehub/references/server-primitives.md
@@ -18,6 +18,8 @@ provider output          deployment artifact when applicable
 
 With the current facade, register `vitehub()` from `vite-hub` and import application APIs from feature subpaths such as `vite-hub/kv`, `vite-hub/blob`, or `vite-hub/rate-limit`. Validate those paths against installed exports before coding.
 
+For Database runtime access, import `useDatabase` from `vite-hub/database/drizzle` and call it with the discovered database name. Use `useDatabase("default")` for a Default Database. Query through the returned `db` and `schema`; do not import a Database Definition into application code or use the direct `db`, `schema`, or `databases` exports.
+
 ## Authority
 
 Runtime Helpers called by application code keep authority in the application. If an Agent needs the same behavior, grant the narrow Capability documented for that feature; do not make every application primitive an Agent tool.

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -7,7 +7,7 @@
   <img alt="Vite" src="https://img.shields.io/badge/Vite-discovery-646cff?style=flat-square">
 </p>
 
-`@vite-hub/database` turns a colocated Drizzle schema into generated `db` and `schema` imports for server code.
+`@vite-hub/database` turns a colocated Drizzle schema into a generated `useDatabase()` lookup for server code.
 
 ## Install
 
@@ -35,10 +35,11 @@ export default defineDatabase({
 
 ```ts
 // server/api/notes.get.ts
-import { db, schema } from "@vite-hub/database/drizzle"
+import { useDatabase } from "@vite-hub/database/drizzle"
 import { defineEventHandler } from "h3"
 
 export default defineEventHandler(() => {
+  const { db, schema } = useDatabase("default")
   return db.select().from(schema.notes)
 })
 ```
@@ -59,7 +60,7 @@ Use `src/database.ts` or `server/databases/config.ts` for one default database. 
 
 `@vite-hub/database/drizzle` is resolved by the Vite integration for server code and provider output. Plain `node` execution of files that import it is not a supported local runtime path.
 
-`defineDatabase()` also returns the typed Drizzle database, so application code can import a definition directly and query it without another runtime factory.
+Application code calls `useDatabase()` with the discovered name. Use `default` for a Default Database.
 
 ## Remote D1 development
 

--- a/packages/database/examples/vite/src/server.ts
+++ b/packages/database/examples/vite/src/server.ts
@@ -1,12 +1,14 @@
 import { H3, readBody } from "h3"
 import { desc, sql } from "drizzle-orm"
 
-import { databases } from "@vite-hub/database/drizzle"
+import { useDatabase } from "@vite-hub/database/drizzle"
 
 const app = new H3()
+const analytics = useDatabase("analytics")
+const primary = useDatabase("primary")
 
 async function ensureNotesTable() {
-  await databases.primary.db.run(sql`
+  await primary.db.run(sql`
     create table if not exists notes (
       id integer primary key autoincrement,
       title text not null
@@ -15,7 +17,7 @@ async function ensureNotesTable() {
 }
 
 async function ensureAnalyticsEventsTable() {
-  await databases.analytics.db.run(sql`
+  await analytics.db.run(sql`
     create table if not exists analytics_events (
       id integer primary key autoincrement,
       name text not null
@@ -25,31 +27,31 @@ async function ensureAnalyticsEventsTable() {
 
 app.get("/api/notes", async () => {
   await ensureNotesTable()
-  const notes = await databases.primary.db.select().from(databases.primary.schema.notes).orderBy(desc(databases.primary.schema.notes.id))
+  const notes = await primary.db.select().from(primary.schema.notes).orderBy(desc(primary.schema.notes.id))
   return { notes, ok: true }
 })
 
 app.post("/api/notes", async (event) => {
   await ensureNotesTable()
   const body = await readBody<{ title?: string }>(event)
-  const result = await databases.primary.db.insert(databases.primary.schema.notes).values({ title: body.title || "hello database" }).returning()
+  const result = await primary.db.insert(primary.schema.notes).values({ title: body.title || "hello database" }).returning()
   return { note: result[0], ok: true }
 })
 
 app.get("/api/analytics/events", async () => {
   await ensureAnalyticsEventsTable()
-  const events = await databases.analytics.db
+  const events = await analytics.db
     .select()
-    .from(databases.analytics.schema.analyticsEvents)
-    .orderBy(desc(databases.analytics.schema.analyticsEvents.id))
+    .from(analytics.schema.analyticsEvents)
+    .orderBy(desc(analytics.schema.analyticsEvents.id))
   return { events, ok: true }
 })
 
 app.post("/api/analytics/events", async (event) => {
   await ensureAnalyticsEventsTable()
   const body = await readBody<{ name?: string }>(event)
-  const result = await databases.analytics.db
-    .insert(databases.analytics.schema.analyticsEvents)
+  const result = await analytics.db
+    .insert(analytics.schema.analyticsEvents)
     .values({ name: body.name || "page-view" })
     .returning()
   return { event: result[0], ok: true }

--- a/packages/database/src/drizzle-subpath.d.ts
+++ b/packages/database/src/drizzle-subpath.d.ts
@@ -1,7 +1,6 @@
 import "./virtual-module.d.ts"
 
 import type { BaseSQLiteDatabase } from "drizzle-orm/sqlite-core"
-import databaseEntries from "#vitehub/database/databases"
 import schema from "#vitehub/database/schema"
 import type { AgentDatabaseHandle } from "./runtime/agent.js"
 
@@ -12,8 +11,14 @@ export interface RuntimeDatabaseEntry<TSchema extends Record<string, unknown>> {
   schema: TSchema
 }
 
+export interface DatabaseRegistry {}
+
+type RegisteredDatabaseSchema<Name extends keyof DatabaseRegistry> = DatabaseRegistry[Name] extends {
+  schema: infer TSchema extends Record<string, unknown>
+} ? TSchema : never
+
 type RuntimeDatabaseRegistry = {
-  [Name in keyof typeof databaseEntries]: RuntimeDatabaseEntry<typeof databaseEntries[Name]["schema"]>
+  [Name in keyof DatabaseRegistry]: RuntimeDatabaseEntry<RegisteredDatabaseSchema<Name>>
 }
 
 type RuntimeDatabaseLookup = RuntimeDatabaseRegistry & {

--- a/packages/database/src/drizzle.ts
+++ b/packages/database/src/drizzle.ts
@@ -1,5 +1,4 @@
 import schema from "#vitehub/database/schema"
-import databaseEntries from "#vitehub/database/databases"
 import { databases as runtimeDatabases, db as runtimeDb } from "./runtime/drizzle-runtime.ts"
 import { createAgentDatabase } from "./runtime/agent.ts"
 
@@ -12,8 +11,14 @@ export interface RuntimeDatabaseEntry<TSchema extends Record<string, unknown>> {
   schema: TSchema
 }
 
+export interface DatabaseRegistry {}
+
+type RegisteredDatabaseSchema<Name extends keyof DatabaseRegistry> = DatabaseRegistry[Name] extends {
+  schema: infer TSchema extends Record<string, unknown>
+} ? TSchema : never
+
 type RuntimeDatabaseRegistry = {
-  [Name in keyof typeof databaseEntries]: RuntimeDatabaseEntry<typeof databaseEntries[Name]["schema"]>
+  [Name in keyof DatabaseRegistry]: RuntimeDatabaseEntry<RegisteredDatabaseSchema<Name>>
 }
 
 type RuntimeDatabaseLookup = RuntimeDatabaseRegistry & {

--- a/packages/database/src/internal/generated.ts
+++ b/packages/database/src/internal/generated.ts
@@ -68,9 +68,16 @@ function renderGeneratedDatabaseTypes(file: string, definitions: DiscoveredDatab
   const schemaDefinitionIndex = Math.max(0, definitions.findIndex(definition => definition.name === "default"))
   const registryEntries = definitions.flatMap((definition, index) => [
     `    ${JSON.stringify(definition.name)}: {`,
-    `      config: import("@vite-hub/database").ResolvedDrizzleDatabaseConfig`,
     `      schema: typeof database_${index}.schema`,
     "    },",
+  ])
+  const registryDeclarations = ["@vite-hub/database/drizzle", "vite-hub/database/drizzle"].flatMap(moduleName => [
+    `declare module ${JSON.stringify(moduleName)} {`,
+    "  interface DatabaseRegistry {",
+    ...registryEntries,
+    "  }",
+    "}",
+    "",
   ])
 
   return [
@@ -82,12 +89,7 @@ function renderGeneratedDatabaseTypes(file: string, definitions: DiscoveredDatab
     "  interface DatabaseSchema extends DefaultDatabaseSchema {}",
     "}",
     "",
-    'declare module "#vitehub/database/databases" {',
-    "  interface DatabaseRegistry {",
-    ...registryEntries,
-    "  }",
-    "}",
-    "",
+    ...registryDeclarations,
     "export {}",
     "",
   ].join("\n")

--- a/packages/database/test/nuxt.test.ts
+++ b/packages/database/test/nuxt.test.ts
@@ -789,7 +789,7 @@ describe("Database Nuxt integration", () => {
 
       expect(plugin.api.getConfig()?.rootDir).toBe(projectRoot)
       await expect(readFile(join(projectRoot, ".vitehub/types/database.d.ts"), "utf8"))
-        .resolves.toContain('declare module "#vitehub/database/databases"')
+        .resolves.toContain('declare module "vite-hub/database/drizzle"')
 
       const nitroConfig = { alias: {}, modules: [], preset: "cloudflare_module" }
       await callHook(hooks, "nitro:config", nitroConfig)

--- a/packages/database/test/types-published.test-d.ts
+++ b/packages/database/test/types-published.test-d.ts
@@ -11,7 +11,7 @@ const analyticsSchema = {
   events: sqliteTable("events", { name: text("name").notNull() }),
 }
 
-declare module "#vitehub/database/databases" {
+declare module "@vite-hub/database/drizzle" {
   interface DatabaseRegistry {
     analytics: {
       config: import("@vite-hub/database").ResolvedDrizzleDatabaseConfig

--- a/packages/database/test/vite.test.ts
+++ b/packages/database/test/vite.test.ts
@@ -99,8 +99,11 @@ describe("hubDb", () => {
     })
     await mkdir(join(rootDir, "server"), { recursive: true })
     await writeFile(join(rootDir, "server", "query.ts"), [
-      "import { db, schema } from '@vite-hub/database/drizzle'",
-      "export const query = () => db.select().from(schema.notes)",
+      "import { useDatabase } from '@vite-hub/database/drizzle'",
+      "export const query = () => {",
+      "  const { db, schema } = useDatabase('default')",
+      "  return db.select().from(schema.notes)",
+      "}",
       "",
     ].join("\n"))
     await writeFile(join(rootDir, "index.html"), "<div>ViteHub Database</div>")
@@ -347,7 +350,8 @@ describe("hubDb", () => {
     expect(databasesCode).toContain("\"server/databases/migrations\"")
     const generatedTypesFile = join(rootDir, ".vitehub/types/database.d.ts")
     const generatedTypes = await readFile(generatedTypesFile, "utf8")
-    expect(generatedTypes).toContain('declare module "#vitehub/database/databases"')
+    expect(generatedTypes).toContain('declare module "@vite-hub/database/drizzle"')
+    expect(generatedTypes).toContain('declare module "vite-hub/database/drizzle"')
     expect(generatedTypes).toContain("type DefaultDatabaseSchema = typeof database_0.schema")
     expect(generatedTypes).toContain('declare module "#vitehub/database/schema" {\n  interface DatabaseSchema extends DefaultDatabaseSchema {}')
 

--- a/packages/vite-hub/fixtures/published-types/consumer.ts
+++ b/packages/vite-hub/fixtures/published-types/consumer.ts
@@ -15,6 +15,7 @@ import { useAgent, useChat } from "vite-hub/agent/vue"
 import * as authAgent from "vite-hub/auth/agent"
 import { createAuthClient, useUserSession } from "vite-hub/auth/vue"
 import type { BoxDefinition } from "vite-hub/box"
+import { useDatabase } from "vite-hub/database/drizzle"
 import { env } from "vite-hub/env"
 import * as markdownTemplate from "vite-hub/markdown-template"
 import viteHubNuxtModule from "vite-hub/nuxt"
@@ -26,6 +27,14 @@ import * as cloudflareWorkspace from "vite-hub/workspace/cloudflare"
 import * as workspaceLoader from "vite-hub/workspace/loader"
 import * as workspacePublisher from "vite-hub/workspace/publish"
 import * as workspaceServer from "vite-hub/workspace/server"
+
+declare module "vite-hub/database/drizzle" {
+  interface DatabaseRegistry {
+    default: {
+      schema: { notes: { title: string } }
+    }
+  }
+}
 
 export const appFacingModules = [
   agentCloudflare,
@@ -48,6 +57,7 @@ export const nuxtModule = viteHubNuxtModule
 export const customAuthClient = createAuthClient({ basePath: "/auth" })
 export const userSession = useUserSession(customAuthClient)
 export const supportChat = useChat(useAgent("support"))
+export const notesTable = useDatabase("default").schema.notes
 export const builtInAgent = defineAgent({
   driver: "codex",
   runtime: false,

--- a/packages/vite-hub/src/database/drizzle.ts
+++ b/packages/vite-hub/src/database/drizzle.ts
@@ -1,1 +1,29 @@
+import {
+  databases as runtimeDatabases,
+  schema,
+  useDatabase as useRuntimeDatabase,
+} from "@vite-hub/database/drizzle"
+
+import type { RuntimeDatabaseEntry } from "@vite-hub/database/drizzle"
+
 export * from "@vite-hub/database/drizzle"
+
+export interface DatabaseRegistry {}
+
+type RegisteredDatabaseSchema<Name extends keyof DatabaseRegistry> = DatabaseRegistry[Name] extends {
+  schema: infer TSchema extends Record<string, unknown>
+} ? TSchema : never
+
+type RuntimeDatabaseRegistry = {
+  [Name in keyof DatabaseRegistry]: RuntimeDatabaseEntry<RegisteredDatabaseSchema<Name>>
+}
+
+type RuntimeDatabaseLookup = RuntimeDatabaseRegistry & {
+  default: RuntimeDatabaseEntry<typeof schema>
+} & Record<string, RuntimeDatabaseEntry<Record<string, unknown>>>
+
+export const databases = runtimeDatabases as RuntimeDatabaseLookup
+
+export function useDatabase<Name extends keyof RuntimeDatabaseRegistry>(name: Name): RuntimeDatabaseRegistry[Name] {
+  return useRuntimeDatabase(name as never) as RuntimeDatabaseRegistry[Name]
+}

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -173,7 +173,13 @@ describe("framework package contract", () => {
       .filter(({ source }) => !exportedForwarders.has(source))
       .map(({ subpath }) => subpath)
       .sort(),
-    ).toEqual([".", "./_internal/database/runtime/state", "./_internal/kv/runtime/disabled-upstash", "./nuxt"])
+    ).toEqual([
+      ".",
+      "./_internal/database/runtime/state",
+      "./_internal/kv/runtime/disabled-upstash",
+      "./database/drizzle",
+      "./nuxt",
+    ])
 
     for (const { subpath, targets } of manifestForwarders) {
       const ownerSpecifier = ownerSpecifierForDistributionSubpath(subpath)

--- a/playground/vite/build/vite-e2e.ts
+++ b/playground/vite/build/vite-e2e.ts
@@ -178,6 +178,7 @@ function renderDbRuntimeModule(file: string, config: ResolvedDBViteConfig) {
     "export const databases = {",
     ...databaseEntries,
     "}",
+    "export function useDatabase(name) { return databases[name] }",
     "",
     ...(config.databaseNames.includes("default")
       ? [

--- a/playground/vite/src/server.db.ts
+++ b/playground/vite/src/server.db.ts
@@ -2,9 +2,11 @@ import { H3, readValidatedBody } from "h3"
 import { desc, sql } from "drizzle-orm"
 import * as v from "valibot"
 
-import { databases } from "@vite-hub/database/drizzle"
+import { useDatabase } from "@vite-hub/database/drizzle"
 
 const app = new H3()
+const analytics = useDatabase("analytics")
+const primary = useDatabase("primary")
 const noteBody = v.object({
   title: v.string(),
 })
@@ -13,7 +15,7 @@ const analyticsEventBody = v.object({
 })
 
 async function ensureNotesTable() {
-  await databases.primary.db.run(sql`
+  await primary.db.run(sql`
     create table if not exists notes (
       id integer primary key autoincrement,
       title text not null
@@ -22,7 +24,7 @@ async function ensureNotesTable() {
 }
 
 async function ensureAnalyticsEventsTable() {
-  await databases.analytics.db.run(sql`
+  await analytics.db.run(sql`
     create table if not exists analytics_events (
       id integer primary key autoincrement,
       name text not null
@@ -34,31 +36,31 @@ app.get("/", () => ({ db: "drizzle", ok: true }))
 
 app.get("/api/database", async () => {
   await ensureNotesTable()
-  const notes = await databases.primary.db.select().from(databases.primary.schema.notes).orderBy(desc(databases.primary.schema.notes.id))
+  const notes = await primary.db.select().from(primary.schema.notes).orderBy(desc(primary.schema.notes.id))
   return { notes, ok: true }
 })
 
 app.post("/api/database", async (event) => {
   await ensureNotesTable()
   const body = await readValidatedBody(event, noteBody)
-  const result = await databases.primary.db.insert(databases.primary.schema.notes).values({ title: body.title }).returning()
+  const result = await primary.db.insert(primary.schema.notes).values({ title: body.title }).returning()
   return { note: result[0], ok: true }
 })
 
 app.get("/api/database/analytics", async () => {
   await ensureAnalyticsEventsTable()
-  const events = await databases.analytics.db
+  const events = await analytics.db
     .select()
-    .from(databases.analytics.schema.analyticsEvents)
-    .orderBy(desc(databases.analytics.schema.analyticsEvents.id))
+    .from(analytics.schema.analyticsEvents)
+    .orderBy(desc(analytics.schema.analyticsEvents.id))
   return { events, ok: true }
 })
 
 app.post("/api/database/analytics", async (event) => {
   await ensureAnalyticsEventsTable()
   const body = await readValidatedBody(event, analyticsEventBody)
-  const result = await databases.analytics.db
-    .insert(databases.analytics.schema.analyticsEvents)
+  const result = await analytics.db
+    .insert(analytics.schema.analyticsEvents)
     .values({ name: body.name })
     .returning()
   return { event: result[0], ok: true }

--- a/playground/vite/src/server.e2e.ts
+++ b/playground/vite/src/server.e2e.ts
@@ -3,7 +3,7 @@ import { desc, sql } from "drizzle-orm"
 import * as v from "valibot"
 
 import { blob } from "@vite-hub/blob"
-import { databases } from "@vite-hub/database/drizzle"
+import { useDatabase } from "@vite-hub/database/drizzle"
 import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { kv } from "@vite-hub/kv"
 import { deferQueue, runQueue } from "@vite-hub/queue"
@@ -15,7 +15,9 @@ import { deferWorkflow, getWorkflowRun, runWorkflow } from "@vite-hub/workflow"
 import { resolveTrustedMarkerCallbackUrl } from "../../_shared/queue-test"
 
 const app = new H3()
+const analytics = useDatabase("analytics")
 const queueName = "welcome-email"
+const primary = useDatabase("primary")
 const workflowName = "welcome"
 
 declare global {
@@ -95,7 +97,7 @@ function assertCloudflareRateLimit(event: unknown) {
 }
 
 async function ensureNotesTable() {
-  await databases.primary.db.run(sql`
+  await primary.db.run(sql`
     create table if not exists notes (
       id integer primary key autoincrement,
       title text not null
@@ -104,7 +106,7 @@ async function ensureNotesTable() {
 }
 
 async function ensureAnalyticsEventsTable() {
-  await databases.analytics.db.run(sql`
+  await analytics.db.run(sql`
     create table if not exists analytics_events (
       id integer primary key autoincrement,
       name text not null
@@ -188,31 +190,31 @@ app.get("/api/blob/serve", async (event) => {
 
 app.get("/api/database", async () => {
   await ensureNotesTable()
-  const notes = await databases.primary.db.select().from(databases.primary.schema.notes).orderBy(desc(databases.primary.schema.notes.id))
+  const notes = await primary.db.select().from(primary.schema.notes).orderBy(desc(primary.schema.notes.id))
   return { notes, ok: true }
 })
 
 app.post("/api/database", async (event) => {
   await ensureNotesTable()
   const body = await readValidatedBody(event, noteBody)
-  const result = await databases.primary.db.insert(databases.primary.schema.notes).values({ title: body.title }).returning()
+  const result = await primary.db.insert(primary.schema.notes).values({ title: body.title }).returning()
   return { note: result[0], ok: true }
 })
 
 app.get("/api/database/analytics", async () => {
   await ensureAnalyticsEventsTable()
-  const events = await databases.analytics.db
+  const events = await analytics.db
     .select()
-    .from(databases.analytics.schema.analyticsEvents)
-    .orderBy(desc(databases.analytics.schema.analyticsEvents.id))
+    .from(analytics.schema.analyticsEvents)
+    .orderBy(desc(analytics.schema.analyticsEvents.id))
   return { events, ok: true }
 })
 
 app.post("/api/database/analytics", async (event) => {
   await ensureAnalyticsEventsTable()
   const body = await readValidatedBody(event, analyticsEventBody)
-  const result = await databases.analytics.db
-    .insert(databases.analytics.schema.analyticsEvents)
+  const result = await analytics.db
+    .insert(analytics.schema.analyticsEvents)
     .values({ name: body.name })
     .returning()
   return { event: result[0], ok: true }


### PR DESCRIPTION
Summary:
- type generated database registries through public drizzle entrypoints for owner-package and facade consumers
- keep useDatabase typed for default and named databases
- document and teach useDatabase as the single application query path

Root cause:
Generated declarations augmented a package-private import that facade-only consumers could not resolve, so useDatabase accepted never.

Verification:
- Database package: 125 tests passed, type errors: none
- vite-hub package: 139 tests passed, type errors: none
- Docs: 55 tests passed
- Bundled ViteHub skill validation passed
- Downstream Calories typecheck and Cloudflare production build passed with the patched declarations