### PR TITLE
feat(agent): add operational diagnostics primitives

### DIFF
--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -186,7 +186,17 @@ export default defineAgent({
 
 Invocation journals are metadata-only by default. Set `content: 'content'` only when the application must persist prompts, messages, reasoning, tool inputs and outputs, and result text. That opt-in stores sensitive model content in the configured durable store; apply the same access controls, retention policy, and encryption requirements as the source data.
 
-The journal records pending, running, completed, failed, and cancelled states plus bounded invocation metadata and trace observations. Use `invocations.list()` for cursor-based summaries, `invocations.get(id)` for a stored record ID, and `invocations.getByRunId(runId, agentName?)` when starting from the source run ID. Always pass the Agent Definition name for a named Definition; the name is part of its durable invocation identity. Journal failures never change the Agent Invocation result.
+The journal records pending, running, completed, failed, and cancelled states plus bounded invocation metadata and trace observations. Failed records retain bounded `cause` and `AggregateError.errors` trees, common status and code fields, and public ViteHub error details. Use `invocations.list()` for cursor-based summaries, `invocations.get(id)` for a stored record ID, and `invocations.getByRunId(runId, agentName?)` when starting from the source run ID. Always pass the Agent Definition name for a named Definition; the name is part of its durable invocation identity. Journal failures never change the Agent Invocation result.
+
+When an application exposes the standard invocation journal route, inspect it without a dashboard:
+
+```sh
+vitehub agent invocations list --status running
+vitehub agent invocations show INVOCATION_ID
+vitehub agent invocations tail INVOCATION_ID
+```
+
+The CLI defaults to `http://localhost:5173/api/invocations`. Use `--url` or `VITEHUB_AGENT_INVOCATIONS_URL` for another local endpoint, and `--json` for automation-safe output.
 
 Cloudflare and OpenWorkflow create the journal after durable recovery dispatch and reconcile failures after the generated Agent module loads but before the Agent handler starts. If that module cannot be evaluated, use Workflow inspection because the Agent-owned invocation store is unavailable.
 

--- a/docs/content/docs/capabilities/diagnostics.md
+++ b/docs/content/docs/capabilities/diagnostics.md
@@ -57,7 +57,7 @@ Unsupported sources are recorded in `support`. Unlimited cgroup values are omitt
 
 ## Sampling behavior
 
-Sampling is bounded to one active inspection and one coalesced pending reason. A slow inspector cannot create an unbounded polling backlog. Finish supersedes a stale poll and waits for the final observation before the Capability closes.
+Sampling is bounded to one active inspection and one coalesced pending reason. Reporter delivery is ordered and bounded by `timeout`. A slow inspector or reporter cannot create an unbounded polling backlog. Finish supersedes a stale poll and waits for the final observation before the Capability closes.
 
 `diagnostics()` is separate from `otlp()`: diagnostics records operator health and resource pressure, while OTLP exports the Agent Invocation trace. Keeping the lanes separate prevents a broken telemetry receiver from recursively hiding its own delivery failure.
 
@@ -67,10 +67,10 @@ Sampling is bounded to one active inspection and one coalesced pending reason. A
 | --- | --- | --- | --- |
 | `reporter` | `RuntimeDiagnosticReporter` | Structured console output | Receives operational events. |
 | `resources` | `RuntimeResourceInspector` | None | Enables scoped resource sampling. |
-| `interval` | `number` | `10000` | Resource polling interval in milliseconds. |
+| `interval` | `number` | `10000` | Resource polling interval in milliseconds. Must not exceed `heartbeat`. |
 | `heartbeat` | `number` | `60000` | Maximum interval between snapshot events in milliseconds. |
 | `peakStepBytes` | `number` | `67108864` | Minimum peak increase before a peak event. |
-| `timeout` | `number` | `1000` | Maximum duration of one resource inspection in milliseconds. |
+| `timeout` | `number` | `1000` | Maximum duration of one resource inspection or reporter delivery in milliseconds. |
 
 ## Related
 

--- a/docs/content/docs/capabilities/diagnostics.md
+++ b/docs/content/docs/capabilities/diagnostics.md
@@ -1,0 +1,79 @@
+---
+title: Diagnostics
+description: Report Agent Invocation outcomes and scoped runtime resource observations.
+navigation.title: Diagnostics
+navigation.order: 126
+navigation.group: External context
+icon: i-lucide-gauge
+---
+
+`diagnostics()` is an opt-in operational Capability. It reports a terminal event for every Agent Invocation and can sample resources through a Runtime inspector. Reporters receive structured events, so an application can write JSON logs, metrics, or another operations sink without coupling the Agent Definition to one dashboard.
+
+## Observe a Node service
+
+Use ViteHub's Node adapter to observe process, host, and Linux cgroup resources:
+
+```ts [server/agents/worker.ts]
+import { defineAgent } from 'vite-hub/agent'
+import { diagnostics } from 'vite-hub/agent/capabilities'
+import { nodeRuntimeResources } from 'vite-hub/runtime/node'
+
+export default defineAgent({
+  name: 'worker',
+  capabilities: [
+    diagnostics({
+      resources: nodeRuntimeResources(),
+    }),
+  ],
+  driver: { model: 'openai/gpt-5.1-mini' },
+})
+```
+
+The default reporter writes structured console objects. Pass `reporter` to own delivery:
+
+```ts
+diagnostics({
+  resources: nodeRuntimeResources(),
+  reporter: event => operations.write(event),
+})
+```
+
+Reporter and inspector failures are contained. They produce a local diagnostic and do not replace a successful Agent result.
+
+## Event contract
+
+The Capability reports:
+
+| Event | When |
+| --- | --- |
+| `agent.invocation.terminal` | The invocation completes or fails. Includes outcome, duration, run ID when present, and a bounded structured error. |
+| `agent.resource.snapshot` | Sampling starts, finishes, or reaches the heartbeat interval. |
+| `agent.resource.peak` | A peak observation grows by at least `peakStepBytes`. |
+| `agent.resource.inspect.failed` | The inspector fails or exceeds its timeout. |
+
+Resource observations declare a `scope`, `source`, `unit`, and numeric `value`. The Node adapter uses `process` for Node memory and CPU, `host` for available host memory, and `service` for Linux cgroup v2 values. A service observation provides correlation with an invocation's run ID; it is not per-invocation attribution when multiple invocations share the service.
+
+Unsupported sources are recorded in `support`. Unlimited cgroup values are omitted rather than reported as zero. This keeps small machines and non-Linux hosts honest without requiring application-specific `/proc` parsing.
+
+## Sampling behavior
+
+Sampling is bounded to one active inspection and one coalesced pending reason. A slow inspector cannot create an unbounded polling backlog. Finish supersedes a stale poll and waits for the final observation before the Capability closes.
+
+`diagnostics()` is separate from `otlp()`: diagnostics records operator health and resource pressure, while OTLP exports the Agent Invocation trace. Keeping the lanes separate prevents a broken telemetry receiver from recursively hiding its own delivery failure.
+
+## Options
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `reporter` | `RuntimeDiagnosticReporter` | Structured console output | Receives operational events. |
+| `resources` | `RuntimeResourceInspector` | None | Enables scoped resource sampling. |
+| `interval` | `number` | `10000` | Resource polling interval in milliseconds. |
+| `heartbeat` | `number` | `60000` | Maximum interval between snapshot events in milliseconds. |
+| `peakStepBytes` | `number` | `67108864` | Minimum peak increase before a peak event. |
+| `timeout` | `number` | `1000` | Maximum duration of one resource inspection in milliseconds. |
+
+## Related
+
+- [OTLP](/docs/capabilities/otlp)
+- [Invocations](/docs/agents/invocations)
+- [Runtime context](/docs/concepts/runtime-context)

--- a/docs/content/docs/capabilities/official-capabilities.md
+++ b/docs/content/docs/capabilities/official-capabilities.md
@@ -43,6 +43,7 @@ import {
   transcribe,
   usage,
   cost,
+  diagnostics,
   webSearch,
   workspaceShell,
 } from '@vite-hub/agent/capabilities'
@@ -80,6 +81,7 @@ import {
 | Sandbox execution | [`sandbox()`](/docs/capabilities/sandbox) | The Agent may run an allowlisted executable in an isolated runtime. |
 | Schedules | [`schedule()`](/docs/capabilities/schedule) | The Agent declares scheduled invocations or manages Runtime Schedules through tools. |
 | OTLP traces | [`otlp()`](/docs/capabilities/otlp) | Completed Agent Invocation traces should be exported to an OpenTelemetry receiver. |
+| Operational diagnostics | [`diagnostics()`](/docs/capabilities/diagnostics) | Invocation outcomes and scoped runtime resource observations should go to an application-owned reporter. |
 
 ### External context
 

--- a/docs/content/docs/capabilities/otlp.md
+++ b/docs/content/docs/capabilities/otlp.md
@@ -76,7 +76,9 @@ This contribution belongs to the Capability's entry in the configuration event. 
 
 ## Delivery behavior
 
-The exporter retries transient HTTP failures and honors `Retry-After`. Export is best effort and runs through the host's `waitUntil()` boundary; an unavailable receiver does not change Agent output. Receivers should deduplicate by trace ID and span ID because a retried request can contain the same completed invocation.
+The exporter retries transient HTTP failures and honors `Retry-After`. Export is best effort and runs through the host's `waitUntil()` boundary; an unavailable receiver does not change Agent output. Receiver failures produce a bounded structured local error with the Capability ID, invocation ID, run ID, and export phase.
+
+Set `live: true` when the receiver should see trace state while the invocation runs. Live delivery permits one request in flight and coalesces additional changes into one latest snapshot. It cannot build an unbounded request or memory backlog when the receiver is slow. The terminal snapshot supersedes stale live work and is always attempted after the active request settles. Receivers should deduplicate by trace ID and span ID because a retried or live request can contain spans seen previously.
 
 Streaming command output remains trace activity, not a log drain. Provider command start, output deltas, and completion use the same tool-call ID so a session UI can group them without inspecting terminal escape sequences.
 
@@ -87,6 +89,7 @@ Streaming command output remains trace activity, not a log drain. Provider comma
 | `endpoint` | `string` | Required | Complete OTLP traces endpoint, commonly ending in `/v1/traces`. |
 | `headers` | `Record<string, string>` or resolver | None | Request headers resolved for each export. |
 | `resource` | OTLP resource attributes or resolver | Agent and runtime defaults | Additional resource attributes. |
+| `live` | `boolean` | `false` | Exports coalesced trace snapshots while the invocation runs, followed by the terminal snapshot. |
 | `content.inputs` | `boolean` | `false` | Includes user and tool input content in invocation spans. |
 | `content.instructions` | `boolean` | `false` | Includes resolved Agent instructions in the configuration event. |
 | `content.outputs` | `boolean` | `false` | Includes assistant, tool, and result output content in invocation spans. |

--- a/docs/content/docs/reference/import-paths.md
+++ b/docs/content/docs/reference/import-paths.md
@@ -49,6 +49,7 @@ composition and explicit feature subpaths for application APIs.
 | `vite-hub/rate-limit` | Source-local managed Rate Limit handles and direct Rate Limiters. |
 | `vite-hub/realtime`, `vite-hub/realtime/server`, and `vite-hub/realtime/vue` | Realtime Definitions, manual server integration, and Vue collaborative editing with canonical [Realtime checkpoints](/docs/reference/realtime). |
 | `vite-hub/runtime` | Runtime Host Context, policy, approval, trace, and capability APIs. |
+| `vite-hub/runtime/node` | Node process, host, and Linux cgroup resource observations. |
 | `vite-hub/sandbox` | Sandbox Definitions and Sandbox Run helpers. |
 | `vite-hub/schedule` and `vite-hub/schedule/runtime` | Static and runtime Schedule APIs. |
 | `vite-hub/schedule/runtime/driver` and `vite-hub/schedule/runtime/process` | Host wake registration and process-backed runtime Schedule controls. |

--- a/packages/agent/src/capabilities/diagnostics.ts
+++ b/packages/agent/src/capabilities/diagnostics.ts
@@ -50,22 +50,46 @@ function defaultReporter(event: RuntimeDiagnosticEvent): void {
   else console.info(output)
 }
 
-async function report(reporter: RuntimeDiagnosticReporter, event: RuntimeDiagnosticEvent): Promise<void> {
-  try {
-    await reporter(event)
+function boundedReporter(reporter: RuntimeDiagnosticReporter, timeout: number): RuntimeDiagnosticReporter {
+  let active: Promise<void> | undefined
+  const wait = async (delivery: Promise<void>): Promise<boolean> => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(new DOMException("Diagnostic reporting timed out.", "TimeoutError")), timeout)
+    timer.unref?.()
+    try {
+      await Promise.race([
+        delivery,
+        new Promise<never>((_resolve, reject) => controller.signal.addEventListener("abort", () => reject(controller.signal.reason), { once: true })),
+      ])
+      return true
+    }
+    catch (error) {
+      console.warn({
+        component: "@vite-hub/agent",
+        error: normalizeRuntimeDiagnosticError(error, { includeStack: true }),
+        event: "agent.diagnostics.report.failed",
+        timestamp: new Date().toISOString(),
+      })
+      return false
+    }
+    finally {
+      clearTimeout(timer)
+    }
   }
-  catch (error) {
-    console.warn({
-      component: "@vite-hub/agent",
-      error: normalizeRuntimeDiagnosticError(error, { includeStack: true }),
-      event: "agent.diagnostics.report.failed",
-      timestamp: new Date().toISOString(),
+  return async (event) => {
+    if (active && !await wait(active)) return
+    const delivery = Promise.resolve().then(() => reporter(event))
+    const slot = delivery.then(() => undefined, () => undefined)
+    active = slot
+    void slot.then(() => {
+      if (active === slot) active = undefined
     })
+    await wait(delivery)
   }
 }
 
 function peakObservations(snapshot: RuntimeResourceSnapshot): RuntimeResourceObservation[] {
-  return snapshot.observations.filter(observation => observation.name.endsWith(".peak") || observation.name === "memory.max_rss")
+  return snapshot.observations.filter(observation => observation.unit === "bytes" && (observation.name.endsWith(".peak") || observation.name === "memory.max_rss"))
 }
 
 function createMonitor(options: {
@@ -85,7 +109,7 @@ function createMonitor(options: {
   let pending: "finish" | "poll" | "start" | undefined
   let stopped = false
 
-  const emit = async (name: string, snapshot: RuntimeResourceSnapshot, reason: string) => await report(options.reporter, {
+  const emit = async (name: string, snapshot: RuntimeResourceSnapshot, reason: string) => await options.reporter({
     attributes: {
       reason,
       ...(options.runId ? { run_id: options.runId } : {}),
@@ -115,7 +139,7 @@ function createMonitor(options: {
         }
       }
       if (changed.length) {
-        await report(options.reporter, {
+        await options.reporter({
           attributes: {
             ...(options.runId ? { run_id: options.runId } : {}),
             peaks: changed,
@@ -135,7 +159,7 @@ function createMonitor(options: {
       }
     }
     catch (error) {
-      await report(options.reporter, {
+      await options.reporter({
         attributes: { reason, ...(options.runId ? { run_id: options.runId } : {}) },
         component: "@vite-hub/agent",
         error: normalizeRuntimeDiagnosticError(error, { includeStack: true }),
@@ -217,8 +241,9 @@ export function diagnostics<TRuntimeConfig extends AgentRuntimeConfig = AgentRun
   const heartbeat = positiveDuration(options.heartbeat, 60_000, "heartbeat")
   const interval = positiveDuration(options.interval, 10_000, "interval")
   const peakStepBytes = positiveBytes(options.peakStepBytes, 64 * 1024 * 1024)
-  const reporter = options.reporter || defaultReporter
   const timeout = positiveDuration(options.timeout, 1_000, "timeout")
+  if (interval > heartbeat) throw new TypeError("[vitehub] diagnostics({ interval }) cannot exceed diagnostics({ heartbeat }).")
+  const reporter = boundedReporter(options.reporter || defaultReporter, timeout)
   const capability = defineCapability<TRuntimeConfig>({
     id: "diagnostics",
     metadata: {
@@ -244,7 +269,7 @@ export function diagnostics<TRuntimeConfig extends AgentRuntimeConfig = AgentRun
     },
     async finish(event) {
       const cancelled = event.error !== undefined && event.input.abortSignal?.aborted === true
-      await report(reporter, {
+      await reporter({
         attributes: {
           duration_ms: event.invocation.durationMs,
           outcome: cancelled ? "cancelled" : event.error ? "failed" : "completed",

--- a/packages/agent/src/capabilities/diagnostics.ts
+++ b/packages/agent/src/capabilities/diagnostics.ts
@@ -52,10 +52,9 @@ function defaultReporter(event: RuntimeDiagnosticEvent): void {
 
 function boundedReporter(reporter: RuntimeDiagnosticReporter, timeout: number): RuntimeDiagnosticReporter {
   let active: Promise<void> | undefined
-  const wait = async (delivery: Promise<void>): Promise<boolean> => {
+  const wait = async (delivery: Promise<void>, duration = timeout): Promise<boolean> => {
     const controller = new AbortController()
-    const timer = setTimeout(() => controller.abort(new DOMException("Diagnostic reporting timed out.", "TimeoutError")), timeout)
-    timer.unref?.()
+    const timer = setTimeout(() => controller.abort(new DOMException("Diagnostic reporting timed out.", "TimeoutError")), duration)
     try {
       await Promise.race([
         delivery,
@@ -77,7 +76,11 @@ function boundedReporter(reporter: RuntimeDiagnosticReporter, timeout: number): 
     }
   }
   return async (event) => {
-    if (active && !await wait(active)) return
+    const deadline = Date.now() + timeout
+    while (active) {
+      const remaining = deadline - Date.now()
+      if (remaining <= 0 || !await wait(active, remaining)) return
+    }
     const delivery = Promise.resolve().then(() => reporter(event))
     const slot = delivery.then(() => undefined, () => undefined)
     active = slot
@@ -123,7 +126,6 @@ function createMonitor(options: {
 
   const inspect = async (reason: "finish" | "poll" | "start", inspection: Promise<RuntimeResourceSnapshot>, controller: AbortController) => {
     const timer = setTimeout(() => controller.abort(new DOMException("Resource inspection timed out.", "TimeoutError")), options.timeout)
-    timer.unref?.()
     try {
       const snapshot = await Promise.race([
         inspection,
@@ -215,7 +217,6 @@ function createMonitor(options: {
         activeInspection.then(() => true),
         new Promise<false>((resolve) => {
           timer = setTimeout(() => resolve(false), options.timeout)
-          timer.unref?.()
         }),
       ])
       if (timer) clearTimeout(timer)

--- a/packages/agent/src/capabilities/diagnostics.ts
+++ b/packages/agent/src/capabilities/diagnostics.ts
@@ -109,8 +109,10 @@ function createMonitor(options: {
       for (const observation of peakObservations(snapshot)) {
         const key = `${observation.source}:${observation.scope}:${observation.name}`
         const previous = peaks.get(key)
-        peaks.set(key, Math.max(previous || 0, observation.value))
-        if (previous !== undefined && observation.value >= previous + options.peakStepBytes) changed.push(observation)
+        if (previous === undefined || observation.value >= previous + options.peakStepBytes) {
+          peaks.set(key, observation.value)
+          if (previous !== undefined) changed.push(observation)
+        }
       }
       if (changed.length) {
         await report(options.reporter, {
@@ -156,7 +158,10 @@ function createMonitor(options: {
     const controlledInspection = Promise.resolve().then(() => options.inspector.inspect({ signal: controller.signal }))
     const task = inspect(reason, controlledInspection, controller)
     activeAttempt = task
-    const slot = controlledInspection.then(() => undefined, () => undefined)
+    const slot = Promise.all([
+      controlledInspection.then(() => undefined, () => undefined),
+      task,
+    ]).then(() => undefined)
     activeInspection = slot
     void slot.then(() => {
       if (activeInspection !== slot) return

--- a/packages/agent/src/capabilities/diagnostics.ts
+++ b/packages/agent/src/capabilities/diagnostics.ts
@@ -1,0 +1,233 @@
+import { normalizeRuntimeDiagnosticError } from "@vite-hub/runtime"
+import { defineCapability, eagerFinishExtensionSymbol } from "../capability-runtime.ts"
+
+import type { AgentCapabilityDefinition, AgentRuntimeConfig } from "../types.ts"
+import type {
+  RuntimeDiagnosticEvent,
+  RuntimeDiagnosticReporter,
+  RuntimeResourceInspector,
+  RuntimeResourceObservation,
+  RuntimeResourceSnapshot,
+} from "@vite-hub/runtime"
+
+const monitorContextKey = "vitehub.diagnostics.monitor"
+
+export interface DiagnosticsCapabilityOptions {
+  heartbeat?: number
+  interval?: number
+  peakStepBytes?: number
+  reporter?: RuntimeDiagnosticReporter
+  resources?: RuntimeResourceInspector
+  timeout?: number
+}
+
+interface DiagnosticsMonitor {
+  sample(reason: "finish" | "poll" | "start"): Promise<void>
+  start(): Promise<void>
+  stop(): Promise<void>
+}
+
+function positiveDuration(value: number | undefined, fallback: number, label: string): number {
+  const resolved = value ?? fallback
+  if (!Number.isFinite(resolved) || resolved <= 0 || resolved > 2_147_483_647) {
+    throw new TypeError(`[vitehub] diagnostics({ ${label} }) must be a positive duration in milliseconds.`)
+  }
+  return resolved
+}
+
+function positiveBytes(value: number | undefined, fallback: number): number {
+  const resolved = value ?? fallback
+  if (!Number.isFinite(resolved) || resolved <= 0) {
+    throw new TypeError("[vitehub] diagnostics({ peakStepBytes }) must be a positive number of bytes.")
+  }
+  return resolved
+}
+
+function defaultReporter(event: RuntimeDiagnosticEvent): void {
+  const output = { ...event, event: event.name }
+  if (event.level === "error") console.error(output)
+  else if (event.level === "warn") console.warn(output)
+  else console.info(output)
+}
+
+async function report(reporter: RuntimeDiagnosticReporter, event: RuntimeDiagnosticEvent): Promise<void> {
+  try {
+    await reporter(event)
+  }
+  catch (error) {
+    console.warn({
+      component: "@vite-hub/agent",
+      error: normalizeRuntimeDiagnosticError(error, { includeStack: true }),
+      event: "agent.diagnostics.report.failed",
+      timestamp: new Date().toISOString(),
+    })
+  }
+}
+
+function peakObservations(snapshot: RuntimeResourceSnapshot): RuntimeResourceObservation[] {
+  return snapshot.observations.filter(observation => observation.name.endsWith(".peak") || observation.name === "memory.max_rss")
+}
+
+function createMonitor(options: {
+  heartbeat: number
+  inspector: RuntimeResourceInspector
+  interval: number
+  peakStepBytes: number
+  reporter: RuntimeDiagnosticReporter
+  runId?: string
+  timeout: number
+}): DiagnosticsMonitor {
+  const peaks = new Map<string, number>()
+  let active: Promise<void> | undefined
+  let interval: ReturnType<typeof setInterval> | undefined
+  let lastHeartbeatAt = 0
+  let pending: "finish" | "poll" | "start" | undefined
+  let stopped = false
+
+  const emit = async (name: string, snapshot: RuntimeResourceSnapshot, reason: string) => await report(options.reporter, {
+    attributes: {
+      reason,
+      ...(options.runId ? { run_id: options.runId } : {}),
+      resource: snapshot,
+    },
+    component: "@vite-hub/agent",
+    level: "info",
+    name,
+    timestamp: snapshot.observedAt,
+  })
+
+  const inspect = async (reason: "finish" | "poll" | "start") => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(new DOMException("Resource inspection timed out.", "TimeoutError")), options.timeout)
+    timer.unref?.()
+    try {
+      const snapshot = await Promise.race([
+        Promise.resolve(options.inspector.inspect({ signal: controller.signal })),
+        new Promise<never>((_resolve, reject) => controller.signal.addEventListener("abort", () => reject(controller.signal.reason), { once: true })),
+      ])
+      const changed: RuntimeResourceObservation[] = []
+      for (const observation of peakObservations(snapshot)) {
+        const key = `${observation.source}:${observation.scope}:${observation.name}`
+        const previous = peaks.get(key)
+        peaks.set(key, Math.max(previous || 0, observation.value))
+        if (previous !== undefined && observation.value >= previous + options.peakStepBytes) changed.push(observation)
+      }
+      if (changed.length) {
+        await report(options.reporter, {
+          attributes: {
+            ...(options.runId ? { run_id: options.runId } : {}),
+            peaks: changed,
+            reason,
+            resource: snapshot,
+          },
+          component: "@vite-hub/agent",
+          level: "warn",
+          name: "agent.resource.peak",
+          timestamp: snapshot.observedAt,
+        })
+      }
+      const now = Date.now()
+      if (reason !== "poll" || now - lastHeartbeatAt >= options.heartbeat) {
+        await emit("agent.resource.snapshot", snapshot, reason)
+        lastHeartbeatAt = now
+      }
+    }
+    catch (error) {
+      await report(options.reporter, {
+        attributes: { reason, ...(options.runId ? { run_id: options.runId } : {}) },
+        component: "@vite-hub/agent",
+        error: normalizeRuntimeDiagnosticError(error, { includeStack: true }),
+        level: "warn",
+        name: "agent.resource.inspect.failed",
+        timestamp: new Date().toISOString(),
+      })
+    }
+    finally {
+      clearTimeout(timer)
+    }
+  }
+
+  const drain = (reason: "finish" | "poll" | "start"): Promise<void> => {
+    if (active) {
+      if (reason === "finish" || pending !== "finish") pending = reason
+      return active.then(() => active || Promise.resolve())
+    }
+    const task = inspect(reason)
+    active = task
+    void task.then(() => {
+      if (active !== task) return
+      active = undefined
+      const next = pending
+      pending = undefined
+      if (next) void drain(next)
+    })
+    return task
+  }
+
+  return {
+    sample: drain,
+    async stop() {
+      if (stopped) return
+      stopped = true
+      if (interval) clearInterval(interval)
+      interval = undefined
+      await drain("finish")
+      while (active) await active
+    },
+    async start() {
+      await drain("start")
+      interval = setInterval(() => void drain("poll"), options.interval)
+      interval.unref?.()
+    },
+  }
+}
+
+export function diagnostics<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
+  options: DiagnosticsCapabilityOptions = {},
+): AgentCapabilityDefinition<TRuntimeConfig> {
+  if (!options || typeof options !== "object") throw new TypeError("[vitehub] diagnostics() requires an options object when provided.")
+  const heartbeat = positiveDuration(options.heartbeat, 60_000, "heartbeat")
+  const interval = positiveDuration(options.interval, 10_000, "interval")
+  const peakStepBytes = positiveBytes(options.peakStepBytes, 64 * 1024 * 1024)
+  const reporter = options.reporter || defaultReporter
+  const timeout = positiveDuration(options.timeout, 1_000, "timeout")
+  const capability = defineCapability<TRuntimeConfig>({
+    id: "diagnostics",
+    metadata: {
+      ...(options.resources ? { resources: true } : {}),
+      ...(options.resources ? { heartbeat, interval, peakStepBytes, timeout } : {}),
+    },
+    async prepare(context) {
+      if (!options.resources) return
+      const monitor = createMonitor({
+        heartbeat,
+        inspector: options.resources,
+        interval,
+        peakStepBytes,
+        reporter,
+        runId: context.run?.runId,
+        timeout,
+      })
+      context.context.set(monitorContextKey, monitor)
+      await monitor.start()
+    },
+    async close(context) {
+      await context.context.get<DiagnosticsMonitor>(monitorContextKey)?.stop()
+    },
+    async finish(event) {
+      await report(reporter, {
+        attributes: {
+          duration_ms: event.invocation.durationMs,
+          outcome: event.error ? "failed" : "completed",
+          ...(event.invocation.run?.runId ? { run_id: event.invocation.run.runId } : {}),
+        },
+        component: "@vite-hub/agent",
+        ...(event.error ? { error: normalizeRuntimeDiagnosticError(event.error, { includeStack: true }) } : {}),
+        level: event.error ? "error" : "info",
+        name: "agent.invocation.terminal",
+        timestamp: new Date().toISOString(),
+      })
+    },
+  })
+  return Object.assign(capability, { [eagerFinishExtensionSymbol]: true })
+}

--- a/packages/agent/src/capabilities/diagnostics.ts
+++ b/packages/agent/src/capabilities/diagnostics.ts
@@ -78,7 +78,8 @@ function createMonitor(options: {
   timeout: number
 }): DiagnosticsMonitor {
   const peaks = new Map<string, number>()
-  let active: Promise<void> | undefined
+  let activeAttempt: Promise<void> | undefined
+  let activeInspection: Promise<void> | undefined
   let interval: ReturnType<typeof setInterval> | undefined
   let lastHeartbeatAt = 0
   let pending: "finish" | "poll" | "start" | undefined
@@ -96,13 +97,12 @@ function createMonitor(options: {
     timestamp: snapshot.observedAt,
   })
 
-  const inspect = async (reason: "finish" | "poll" | "start") => {
-    const controller = new AbortController()
+  const inspect = async (reason: "finish" | "poll" | "start", inspection: Promise<RuntimeResourceSnapshot>, controller: AbortController) => {
     const timer = setTimeout(() => controller.abort(new DOMException("Resource inspection timed out.", "TimeoutError")), options.timeout)
     timer.unref?.()
     try {
       const snapshot = await Promise.race([
-        Promise.resolve(options.inspector.inspect({ signal: controller.signal })),
+        inspection,
         new Promise<never>((_resolve, reject) => controller.signal.addEventListener("abort", () => reject(controller.signal.reason), { once: true })),
       ])
       const changed: RuntimeResourceObservation[] = []
@@ -148,18 +148,23 @@ function createMonitor(options: {
   }
 
   const drain = (reason: "finish" | "poll" | "start"): Promise<void> => {
-    if (active) {
+    if (activeInspection) {
       if (reason === "finish" || pending !== "finish") pending = reason
-      return active.then(() => active || Promise.resolve())
+      return activeAttempt || Promise.resolve()
     }
-    const task = inspect(reason)
-    active = task
-    void task.then(() => {
-      if (active !== task) return
-      active = undefined
+    const controller = new AbortController()
+    const controlledInspection = Promise.resolve().then(() => options.inspector.inspect({ signal: controller.signal }))
+    const task = inspect(reason, controlledInspection, controller)
+    activeAttempt = task
+    const slot = controlledInspection.then(() => undefined, () => undefined)
+    activeInspection = slot
+    void slot.then(() => {
+      if (activeInspection !== slot) return
+      activeAttempt = undefined
+      activeInspection = undefined
       const next = pending
       pending = undefined
-      if (next) void drain(next)
+      if (next && !stopped) void drain(next)
     })
     return task
   }
@@ -172,7 +177,6 @@ function createMonitor(options: {
       if (interval) clearInterval(interval)
       interval = undefined
       await drain("finish")
-      while (active) await active
     },
     async start() {
       await drain("start")
@@ -215,15 +219,16 @@ export function diagnostics<TRuntimeConfig extends AgentRuntimeConfig = AgentRun
       await context.context.get<DiagnosticsMonitor>(monitorContextKey)?.stop()
     },
     async finish(event) {
+      const cancelled = event.input.abortSignal?.aborted === true
       await report(reporter, {
         attributes: {
           duration_ms: event.invocation.durationMs,
-          outcome: event.error ? "failed" : "completed",
+          outcome: cancelled ? "cancelled" : event.error ? "failed" : "completed",
           ...(event.invocation.run?.runId ? { run_id: event.invocation.run.runId } : {}),
         },
         component: "@vite-hub/agent",
         ...(event.error ? { error: normalizeRuntimeDiagnosticError(event.error, { includeStack: true }) } : {}),
-        level: event.error ? "error" : "info",
+        level: cancelled ? "info" : event.error ? "error" : "info",
         name: "agent.invocation.terminal",
         timestamp: new Date().toISOString(),
       })

--- a/packages/agent/src/capabilities/diagnostics.ts
+++ b/packages/agent/src/capabilities/diagnostics.ts
@@ -164,7 +164,7 @@ function createMonitor(options: {
       activeInspection = undefined
       const next = pending
       pending = undefined
-      if (next && !stopped) void drain(next)
+      if (next && (!stopped || next === "finish")) void drain(next)
     })
     return task
   }
@@ -176,7 +176,26 @@ function createMonitor(options: {
       stopped = true
       if (interval) clearInterval(interval)
       interval = undefined
-      await drain("finish")
+      if (!activeInspection) {
+        await drain("finish")
+        return
+      }
+      pending = "finish"
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const settled = await Promise.race([
+        activeInspection.then(() => true),
+        new Promise<false>((resolve) => {
+          timer = setTimeout(() => resolve(false), options.timeout)
+          timer.unref?.()
+        }),
+      ])
+      if (timer) clearTimeout(timer)
+      if (!settled) {
+        pending = undefined
+        return
+      }
+      await Promise.resolve()
+      await activeAttempt
     },
     async start() {
       await drain("start")
@@ -219,7 +238,7 @@ export function diagnostics<TRuntimeConfig extends AgentRuntimeConfig = AgentRun
       await context.context.get<DiagnosticsMonitor>(monitorContextKey)?.stop()
     },
     async finish(event) {
-      const cancelled = event.input.abortSignal?.aborted === true
+      const cancelled = event.error !== undefined && event.input.abortSignal?.aborted === true
       await report(reporter, {
         attributes: {
           duration_ms: event.invocation.durationMs,

--- a/packages/agent/src/capabilities/index.ts
+++ b/packages/agent/src/capabilities/index.ts
@@ -96,6 +96,12 @@ export {
   cost,
   vercelAiGatewayPricing,
 } from "./cost.ts"
+export {
+  diagnostics,
+} from "./diagnostics.ts"
+export type {
+  DiagnosticsCapabilityOptions,
+} from "./diagnostics.ts"
 export type {
   AgentUsagePricing,
   AgentUsagePricingContext,

--- a/packages/agent/src/cli.ts
+++ b/packages/agent/src/cli.ts
@@ -6,6 +6,7 @@ import { readWorkspaceDevToken, workspaceDevTokenHeader } from "@vite-hub/worksp
 import { formatAgentError } from "./agent-error.ts"
 import { createAgentEvalInclude, discoverAgentEvalFiles } from "./discovery.ts"
 import { isCompatibleAgentDevServerRoot, runAgentInfoCli } from "./internal/agent-info-cli.ts"
+import { runAgentInvocationsCli } from "./internal/agent-invocations-cli.ts"
 import { runAgentChannelSyncCli } from "./internal/channel-sync-cli.ts"
 import { runAgentChannelHistoryCli } from "./internal/channel-history-cli.ts"
 import { enrichAgentUsageCost, vercelAiGatewayPricing, type AgentUsagePricing } from "./internal/usage-pricing.ts"
@@ -1296,6 +1297,12 @@ export function createAgentCliContributor(options?: false | AgentCliContributorO
       run: async (args, context) => await runAgentDevCli(args, context),
       usage: "vitehub agent dev [message...] [--agent <name>]",
     },
+    {
+      description: "Inspect an application's durable Agent Invocation journal.",
+      name: "invocations",
+      run: async (args, context) => await runAgentInvocationsCli(args, context),
+      usage: "vitehub agent invocations <list|show|tail> [id] [--url <url>] [--json]",
+    },
   ]
   if (evalFiles.length) {
     features.unshift({
@@ -1345,4 +1352,4 @@ export function createAgentCliContributor(options?: false | AgentCliContributorO
   }
 }
 
-export { runAgentInfoCli }
+export { runAgentInfoCli, runAgentInvocationsCli }

--- a/packages/agent/src/internal/agent-info-cli.ts
+++ b/packages/agent/src/internal/agent-info-cli.ts
@@ -146,9 +146,10 @@ function agentInfoExecutionAuthority(authority: ExecutionAuthority): string[] {
   ]
 }
 
-function agentInfoNames(values: Array<{ name: string }>, fallback: string): string {
+function agentInfoNames(values: Array<{ id?: string, name?: string }>, fallback: string): string {
   if (!values.length) return fallback
-  const names = values.slice(0, 5).map(value => value.name)
+  const names = values.slice(0, 5).map(value => value.name || value.id).filter(value => value !== undefined)
+  if (!names.length) return fallback
   return values.length > names.length ? `${names.join(", ")}, +${values.length - names.length} more` : names.join(", ")
 }
 
@@ -161,6 +162,7 @@ function writeAgentInfo(context: AgentInfoCliContext, metadata: AgentInspectionM
     `Driver: ${agentInfoDriver(metadata.config)}`,
     `Capacity: ${agentInfoCapacity(metadata.config)}`,
     ...(isExecutionAuthority(authority) ? agentInfoExecutionAuthority(authority) : ["Execution authority: unavailable"]),
+    `Capabilities: ${plural(metadata.capabilities?.length || 0, "Capability", "Capabilities")} (${agentInfoNames(metadata.capabilities || [], "none")})`,
     `Tools: ${plural(metadata.tools?.length || 0, "tool")} (${agentInfoNames(metadata.tools || [], "none")})`,
     `Workspace files: ${plural(files.files, "file")}, ${plural(files.directories, "directory", "directories")}, ${plural(files.sources, "source")}`,
     `Instructions: ${plural(metadata.instructions?.length || 0, "document")}`,

--- a/packages/agent/src/internal/agent-invocations-cli.ts
+++ b/packages/agent/src/internal/agent-invocations-cli.ts
@@ -1,5 +1,6 @@
 import type { AgentInvocationListResult, AgentInvocationRecord } from "../invocations.ts"
 import type { AgentInvocationDetailResult } from "../invocations-vue.ts"
+import type { RuntimeDiagnosticError } from "@vite-hub/runtime"
 
 interface AgentInvocationsCliContext {
   env: NodeJS.ProcessEnv
@@ -108,8 +109,15 @@ async function request<T>(url: URL, fetchImpl: typeof fetch, timeout: number): P
   return await response.json() as T
 }
 
+function formatError(error: RuntimeDiagnosticError, indent = ""): string {
+  const lines = [`${indent}${error.name || "Error"}: ${error.message}`]
+  if (error.cause) lines.push(formatError(error.cause, `${indent}  caused by `))
+  for (const nested of error.errors || []) lines.push(formatError(nested, `${indent}  `))
+  return lines.join("\n")
+}
+
 function summary(record: AgentInvocationRecord | AgentInvocationListResult["invocations"][number]): string {
-  const error = record.error ? ` ${record.error.name || "Error"}: ${record.error.message}` : ""
+  const error = record.error ? ` ${formatError(record.error)}` : ""
   return `${record.id} ${record.status} ${record.updatedAt}${error}`
 }
 
@@ -168,7 +176,7 @@ export async function runAgentInvocationsCli(
         context.stdout.write(parsed.json ? `${JSON.stringify(observation)}\n` : `${observation.sequence} ${observation.timestamp} ${observation.name}\n`)
       }
       if (record.status === "completed" || record.status === "failed" || record.status === "cancelled") {
-        if (record.error) context.stderr.write(`${record.error.name || "Error"}: ${record.error.message}\n`)
+        if (record.error) context.stderr.write(`${formatError(record.error)}\n`)
         return record.status === "completed" ? 0 : 1
       }
       await sleep(parsed.interval)

--- a/packages/agent/src/internal/agent-invocations-cli.ts
+++ b/packages/agent/src/internal/agent-invocations-cli.ts
@@ -1,0 +1,176 @@
+import type { AgentInvocationListResult, AgentInvocationRecord } from "../invocations.ts"
+
+interface AgentInvocationsCliContext {
+  env: NodeJS.ProcessEnv
+  stderr: { write: (chunk: string | Uint8Array) => unknown }
+  stdout: { write: (chunk: string | Uint8Array) => unknown }
+}
+
+export interface AgentInvocationsCliOptions {
+  fetch?: typeof fetch
+  sleep?: (milliseconds: number) => Promise<void>
+  timeout?: number
+}
+
+interface ParsedArgs {
+  action?: "list" | "show" | "tail"
+  help: boolean
+  id?: string
+  interval: number
+  json: boolean
+  limit?: number
+  status?: string
+  url: string
+}
+
+function usage(context: AgentInvocationsCliContext): void {
+  context.stdout.write([
+    "Usage: vitehub agent invocations <list|show|tail> [id] [options]",
+    "",
+    "Inspect an application's Agent Invocation journal over HTTP.",
+    "",
+    "Options:",
+    "  --url <url>       Invocation endpoint. Defaults to http://localhost:5173/api/invocations.",
+    "  --status <status> Filter list results by status.",
+    "  --limit <count>   Limit list results.",
+    "  --interval <ms>   Tail polling interval. Defaults to 1000.",
+    "  --json            Print JSON or JSON Lines.",
+    "  -h, --help        Show this help.",
+    "",
+  ].join("\n"))
+}
+
+function optionValue(args: string[], index: number, flag: string): string {
+  const value = args[index + 1]
+  if (!value || value.startsWith("-")) throw new Error(`Missing value for ${flag}.`)
+  return value
+}
+
+function positiveInteger(value: string, flag: string): number {
+  const result = Number(value)
+  if (!Number.isSafeInteger(result) || result <= 0) throw new Error(`${flag} requires a positive integer.`)
+  return result
+}
+
+function parse(args: string[], env: NodeJS.ProcessEnv): ParsedArgs {
+  const parsed: ParsedArgs = {
+    help: false,
+    interval: 1_000,
+    json: false,
+    url: env.VITEHUB_AGENT_INVOCATIONS_URL || "http://localhost:5173/api/invocations",
+  }
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index]!
+    if (argument === "-h" || argument === "--help") parsed.help = true
+    else if (argument === "--json") parsed.json = true
+    else if (argument === "--url") {
+      parsed.url = optionValue(args, index, argument)
+      index += 1
+    }
+    else if (argument.startsWith("--url=")) parsed.url = argument.slice(6)
+    else if (argument === "--status") {
+      parsed.status = optionValue(args, index, argument)
+      index += 1
+    }
+    else if (argument.startsWith("--status=")) parsed.status = argument.slice(9)
+    else if (argument === "--limit") {
+      parsed.limit = positiveInteger(optionValue(args, index, argument), argument)
+      index += 1
+    }
+    else if (argument.startsWith("--limit=")) parsed.limit = positiveInteger(argument.slice(8), "--limit")
+    else if (argument === "--interval") {
+      parsed.interval = positiveInteger(optionValue(args, index, argument), argument)
+      index += 1
+    }
+    else if (argument.startsWith("--interval=")) parsed.interval = positiveInteger(argument.slice(11), "--interval")
+    else if (argument.startsWith("-")) throw new Error(`Unknown option: ${argument}.`)
+    else if (!parsed.action && (argument === "list" || argument === "show" || argument === "tail")) parsed.action = argument
+    else if (!parsed.id) parsed.id = argument
+    else throw new Error(`Unexpected argument: ${argument}.`)
+  }
+  if (!parsed.help && !parsed.action) throw new Error("Choose list, show, or tail.")
+  if (!parsed.help && parsed.action !== "list" && !parsed.id) throw new Error(`${parsed.action} requires an invocation id.`)
+  return parsed
+}
+
+function endpoint(parsed: ParsedArgs, id?: string): URL {
+  const base = new URL(parsed.url)
+  if (id) base.pathname = `${base.pathname.replace(/\/$/, "")}/${encodeURIComponent(id)}`
+  if (!id && parsed.status) base.searchParams.set("status", parsed.status)
+  if (!id && parsed.limit) base.searchParams.set("limit", String(parsed.limit))
+  return base
+}
+
+async function request<T>(url: URL, fetchImpl: typeof fetch, timeout: number): Promise<T> {
+  const response = await fetchImpl(url.href, { headers: { accept: "application/json" }, signal: AbortSignal.timeout(timeout) })
+  if (!response.ok) throw new Error((await response.text()).trim() || `Invocation inspection failed with status ${response.status}.`)
+  return await response.json() as T
+}
+
+function summary(record: AgentInvocationRecord | AgentInvocationListResult["invocations"][number]): string {
+  const error = record.error ? ` ${record.error.name || "Error"}: ${record.error.message}` : ""
+  return `${record.id} ${record.status} ${record.updatedAt}${error}`
+}
+
+function writeRecord(context: AgentInvocationsCliContext, record: AgentInvocationRecord, json: boolean): void {
+  if (json) context.stdout.write(`${JSON.stringify(record, null, 2)}\n`)
+  else {
+    context.stdout.write(`${summary(record)}\n`)
+    for (const observation of record.observations) {
+      context.stdout.write(`  ${observation.sequence} ${observation.timestamp} ${observation.name}\n`)
+    }
+  }
+}
+
+export async function runAgentInvocationsCli(
+  args: string[],
+  context: AgentInvocationsCliContext,
+  options: AgentInvocationsCliOptions = {},
+): Promise<number> {
+  let parsed: ParsedArgs
+  try {
+    parsed = parse(args, context.env)
+  }
+  catch (error) {
+    context.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    usage(context)
+    return 1
+  }
+  if (parsed.help) {
+    usage(context)
+    return 0
+  }
+  const fetchImpl = options.fetch || globalThis.fetch
+  const timeout = options.timeout ?? 30_000
+  try {
+    if (parsed.action === "list") {
+      const result = await request<AgentInvocationListResult>(endpoint(parsed), fetchImpl, timeout)
+      if (parsed.json) context.stdout.write(`${JSON.stringify(result, null, 2)}\n`)
+      else for (const record of result.invocations) context.stdout.write(`${summary(record)}\n`)
+      return 0
+    }
+    if (parsed.action === "show") {
+      writeRecord(context, await request<AgentInvocationRecord>(endpoint(parsed, parsed.id), fetchImpl, timeout), parsed.json)
+      return 0
+    }
+
+    const sleep = options.sleep || (async milliseconds => await new Promise(resolve => setTimeout(resolve, milliseconds)))
+    let sequence = 0
+    for (;;) {
+      const record = await request<AgentInvocationRecord>(endpoint(parsed, parsed.id), fetchImpl, timeout)
+      for (const observation of record.observations.filter(observation => observation.sequence > sequence)) {
+        sequence = Math.max(sequence, observation.sequence)
+        context.stdout.write(parsed.json ? `${JSON.stringify(observation)}\n` : `${observation.sequence} ${observation.timestamp} ${observation.name}\n`)
+      }
+      if (record.status === "completed" || record.status === "failed" || record.status === "cancelled") {
+        if (record.error) context.stderr.write(`${record.error.name || "Error"}: ${record.error.message}\n`)
+        return record.status === "completed" ? 0 : 1
+      }
+      await sleep(parsed.interval)
+    }
+  }
+  catch (error) {
+    context.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+    return 1
+  }
+}

--- a/packages/agent/src/internal/agent-invocations-cli.ts
+++ b/packages/agent/src/internal/agent-invocations-cli.ts
@@ -1,4 +1,5 @@
 import type { AgentInvocationListResult, AgentInvocationRecord } from "../invocations.ts"
+import type { AgentInvocationDetailResult } from "../invocations-vue.ts"
 
 interface AgentInvocationsCliContext {
   env: NodeJS.ProcessEnv
@@ -122,6 +123,10 @@ function writeRecord(context: AgentInvocationsCliContext, record: AgentInvocatio
   }
 }
 
+function detailRecord(result: AgentInvocationDetailResult): AgentInvocationRecord {
+  return { ...result.invocation, observations: result.observations }
+}
+
 export async function runAgentInvocationsCli(
   args: string[],
   context: AgentInvocationsCliContext,
@@ -150,14 +155,14 @@ export async function runAgentInvocationsCli(
       return 0
     }
     if (parsed.action === "show") {
-      writeRecord(context, await request<AgentInvocationRecord>(endpoint(parsed, parsed.id), fetchImpl, timeout), parsed.json)
+      writeRecord(context, detailRecord(await request<AgentInvocationDetailResult>(endpoint(parsed, parsed.id), fetchImpl, timeout)), parsed.json)
       return 0
     }
 
     const sleep = options.sleep || (async milliseconds => await new Promise(resolve => setTimeout(resolve, milliseconds)))
     let sequence = 0
     for (;;) {
-      const record = await request<AgentInvocationRecord>(endpoint(parsed, parsed.id), fetchImpl, timeout)
+      const record = detailRecord(await request<AgentInvocationDetailResult>(endpoint(parsed, parsed.id), fetchImpl, timeout))
       for (const observation of record.observations.filter(observation => observation.sequence > sequence)) {
         sequence = Math.max(sequence, observation.sequence)
         context.stdout.write(parsed.json ? `${JSON.stringify(observation)}\n` : `${observation.sequence} ${observation.timestamp} ${observation.name}\n`)

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 import { refreshWorkspaceDevToken, workspaceDevTokenHeader } from "@vite-hub/workspace/server"
 import { describe, expect, it, vi } from "vitest"
 
-import { createAgentCliContributor, runAgentDevCli, runAgentEvalCli, runAgentInfoCli } from "../src/cli.ts"
+import { createAgentCliContributor, runAgentDevCli, runAgentEvalCli, runAgentInfoCli, runAgentInvocationsCli } from "../src/cli.ts"
 import { runAgentChannelHistoryCli } from "../src/internal/channel-history-cli.ts"
 import { channelRegistration, runAgentChannelSyncCli } from "../src/internal/channel-sync-cli.ts"
 import { getAgentChannelSyncDefinition } from "../src/internal/channel-sync.ts"
@@ -49,6 +49,7 @@ describe("agent CLI", () => {
           expect.objectContaining({ name: "eval" }),
           expect.objectContaining({ name: "info" }),
           expect.objectContaining({ name: "dev" }),
+          expect.objectContaining({ name: "invocations" }),
         ],
         name: "agent",
       }, {
@@ -67,6 +68,7 @@ describe("agent CLI", () => {
         features: [
           expect.objectContaining({ name: "info" }),
           expect.objectContaining({ name: "dev" }),
+          expect.objectContaining({ name: "invocations" }),
         ],
         name: "agent",
       }, {
@@ -1268,6 +1270,7 @@ describe("agent CLI", () => {
       "  Credentials: ambient",
       "  Process execution: arbitrary",
       "  Isolation: none",
+      "Capabilities: 0 Capabilities (none)",
       "Tools: 2 tools (search, shell)",
       "Workspace files: 1 file, 1 directory, 1 source",
       "Instructions: 1 document",
@@ -1319,6 +1322,76 @@ describe("agent CLI", () => {
       warnings: [],
     })
     expect(fetchAgentInfo).toHaveBeenCalledWith("http://localhost:5173/__vitehub/agent/invocation-stream?inspect=1&agent=support", expect.anything())
+  })
+
+  it("lists durable Agent Invocations as JSON", async () => {
+    const stdout = stream()
+    const fetchInvocations = vi.fn(async () => Response.json({
+      invocations: [{
+        createdAt: "2026-08-22T10:00:00.000Z",
+        cursor: "1",
+        id: "invocation-1",
+        status: "failed",
+        traceId: "trace-1",
+        updatedAt: "2026-08-22T10:01:00.000Z",
+      }],
+    }))
+
+    const exitCode = await runAgentInvocationsCli([
+      "list", "--status", "failed", "--limit", "10", "--json",
+    ], {
+      env: {},
+      stderr: stream(),
+      stdout,
+    }, { fetch: fetchInvocations as never })
+
+    expect(exitCode).toBe(0)
+    expect(JSON.parse(stdout.output())).toMatchObject({ invocations: [{ id: "invocation-1", status: "failed" }] })
+    expect(fetchInvocations).toHaveBeenCalledWith(
+      "http://localhost:5173/api/invocations?status=failed&limit=10",
+      expect.objectContaining({ headers: { accept: "application/json" } }),
+    )
+  })
+
+  it("tails new observations and prints a nested terminal failure", async () => {
+    const stdout = stream()
+    const stderr = stream()
+    const base = {
+      createdAt: "2026-08-22T10:00:00.000Z",
+      cursor: "1",
+      id: "invocation-1",
+      traceId: "trace-1",
+      updatedAt: "2026-08-22T10:01:00.000Z",
+    }
+    const fetchInvocations = vi.fn()
+      .mockResolvedValueOnce(Response.json({
+        ...base,
+        observations: [{ name: "agent.started", sequence: 1, timestamp: base.createdAt, type: "lifecycle" }],
+        status: "running",
+      }))
+      .mockResolvedValueOnce(Response.json({
+        ...base,
+        error: {
+          errors: [{ message: "Checkout failed", name: "Error" }, { message: "Restore failed", name: "Error" }],
+          message: "Workspace failed",
+          name: "AggregateError",
+        },
+        observations: [
+          { name: "agent.started", sequence: 1, timestamp: base.createdAt, type: "lifecycle" },
+          { name: "agent.failed", sequence: 2, timestamp: base.updatedAt, type: "error" },
+        ],
+        status: "failed",
+      }))
+
+    const exitCode = await runAgentInvocationsCli(["tail", "invocation-1", "--json"], {
+      env: {},
+      stderr,
+      stdout,
+    }, { fetch: fetchInvocations as never, sleep: async () => {} })
+
+    expect(exitCode).toBe(1)
+    expect(stdout.output().trim().split("\n").map(line => JSON.parse(line).sequence)).toEqual([1, 2])
+    expect(stderr.output()).toBe("AggregateError: Workspace failed\n")
   })
 
   it("prints unknown execution authority without inferring restrictions", async () => {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -1418,7 +1418,12 @@ describe("agent CLI", () => {
 
     expect(exitCode).toBe(1)
     expect(stdout.output().trim().split("\n").map(line => JSON.parse(line).sequence)).toEqual([1, 2])
-    expect(stderr.output()).toBe("AggregateError: Workspace failed\n")
+    expect(stderr.output()).toBe([
+      "AggregateError: Workspace failed",
+      "  Error: Checkout failed",
+      "  Error: Restore failed",
+      "",
+    ].join("\n"))
   })
 
   it("prints unknown execution authority without inferring restrictions", async () => {

--- a/packages/agent/test/cli.test.ts
+++ b/packages/agent/test/cli.test.ts
@@ -1353,6 +1353,32 @@ describe("agent CLI", () => {
     )
   })
 
+  it("shows a wrapped invocation detail record", async () => {
+    const stdout = stream()
+    const timestamp = "2026-08-22T10:00:00.000Z"
+    const fetchInvocations = vi.fn(async () => Response.json({
+      invocation: {
+        createdAt: timestamp,
+        cursor: "1",
+        id: "invocation-1",
+        status: "completed",
+        traceId: "trace-1",
+        updatedAt: timestamp,
+      },
+      observations: [{ name: "agent.completed", sequence: 1, timestamp, type: "lifecycle" }],
+    }))
+
+    const exitCode = await runAgentInvocationsCli(["show", "invocation-1"], {
+      env: {},
+      stderr: stream(),
+      stdout,
+    }, { fetch: fetchInvocations as never })
+
+    expect(exitCode).toBe(0)
+    expect(stdout.output()).toContain("invocation-1 completed")
+    expect(stdout.output()).toContain("1 2026-08-22T10:00:00.000Z agent.completed")
+  })
+
   it("tails new observations and prints a nested terminal failure", async () => {
     const stdout = stream()
     const stderr = stream()
@@ -1365,22 +1391,23 @@ describe("agent CLI", () => {
     }
     const fetchInvocations = vi.fn()
       .mockResolvedValueOnce(Response.json({
-        ...base,
+        invocation: { ...base, status: "running" },
         observations: [{ name: "agent.started", sequence: 1, timestamp: base.createdAt, type: "lifecycle" }],
-        status: "running",
       }))
       .mockResolvedValueOnce(Response.json({
-        ...base,
-        error: {
-          errors: [{ message: "Checkout failed", name: "Error" }, { message: "Restore failed", name: "Error" }],
-          message: "Workspace failed",
-          name: "AggregateError",
+        invocation: {
+          ...base,
+          error: {
+            errors: [{ message: "Checkout failed", name: "Error" }, { message: "Restore failed", name: "Error" }],
+            message: "Workspace failed",
+            name: "AggregateError",
+          },
+          status: "failed",
         },
         observations: [
           { name: "agent.started", sequence: 1, timestamp: base.createdAt, type: "lifecycle" },
           { name: "agent.failed", sequence: 2, timestamp: base.updatedAt, type: "error" },
         ],
-        status: "failed",
       }))
 
     const exitCode = await runAgentInvocationsCli(["tail", "invocation-1", "--json"], {

--- a/packages/agent/test/diagnostics-capability.test.ts
+++ b/packages/agent/test/diagnostics-capability.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { diagnostics } from "../src/capabilities.ts"
+import { defineAgent, runAgent } from "../src/index.ts"
+
+import type { RuntimeDiagnosticEvent, RuntimeResourceSnapshot } from "@vite-hub/runtime"
+
+function snapshot(peak: number): RuntimeResourceSnapshot {
+  return {
+    observedAt: new Date().toISOString(),
+    observations: [{ name: "memory.peak", scope: "service", source: "linux-cgroup-v2", unit: "bytes", value: peak }],
+    support: [{ scope: "service", source: "linux-cgroup-v2", supported: true }],
+  }
+}
+
+describe("diagnostics Capability", () => {
+  it("reports scoped start, peak, finish, and terminal events", async () => {
+    const events: RuntimeDiagnosticEvent[] = []
+    const snapshots = [snapshot(64), snapshot(256)]
+    const agent = defineAgent({
+      capabilities: [diagnostics({
+        peakStepBytes: 64,
+        reporter: (event) => { events.push(event) },
+        resources: { inspect: async () => snapshots.shift() || snapshot(256) },
+      })],
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "diagnostic-run" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).resolves.toBe("ok")
+
+    expect(events.map(event => event.name)).toEqual([
+      "agent.resource.snapshot",
+      "agent.resource.peak",
+      "agent.resource.snapshot",
+      "agent.invocation.terminal",
+    ])
+    expect(events[1]).toMatchObject({
+      attributes: { run_id: "diagnostic-run" },
+      level: "warn",
+    })
+    expect(events.at(-1)).toMatchObject({
+      attributes: { outcome: "completed", run_id: "diagnostic-run" },
+      level: "info",
+    })
+  })
+
+  it("does not let inspection or reporter failures change Agent output", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const agent = defineAgent({
+      capabilities: [diagnostics({
+        reporter: () => { throw new Error("Logger unavailable") },
+        resources: { inspect: () => { throw new Error("Resource inspector unavailable") } },
+      })],
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { runId: "diagnostic-failure" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).resolves.toBe("ok")
+    expect(warn).toHaveBeenCalledWith(expect.objectContaining({ event: "agent.diagnostics.report.failed" }))
+    warn.mockRestore()
+  })
+
+  it("rejects invalid sampling options", () => {
+    expect(() => diagnostics({ interval: 0 })).toThrow("diagnostics({ interval })")
+    expect(() => diagnostics({ peakStepBytes: 0 })).toThrow("diagnostics({ peakStepBytes })")
+  })
+})

--- a/packages/agent/test/diagnostics-capability.test.ts
+++ b/packages/agent/test/diagnostics-capability.test.ts
@@ -224,6 +224,42 @@ describe("diagnostics Capability", () => {
     expect(delivered.at(-1)).toBe("agent.invocation.terminal:terminal")
   })
 
+  it("does not overlap reporting between concurrent invocations", async () => {
+    let activeReporters = 0
+    let maxReporters = 0
+    let releaseFirst: (() => void) | undefined
+    const firstBlocked = new Promise<void>((resolve) => { releaseFirst = resolve })
+    const firstStarted = Promise.withResolvers<void>()
+    let reports = 0
+    const agent = defineAgent({
+      capabilities: [diagnostics({
+        reporter: async () => {
+          reports += 1
+          activeReporters += 1
+          maxReporters = Math.max(maxReporters, activeReporters)
+          if (reports === 1) {
+            firstStarted.resolve()
+            await firstBlocked
+          }
+          activeReporters -= 1
+        },
+        timeout: 50,
+      })],
+      driver: { run: () => "ok" },
+    })
+    const runtime = () => ({ memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() })
+
+    const first = runAgent(agent, runtime(), {})
+    await firstStarted.promise
+    const second = runAgent(agent, runtime(), {})
+    const third = runAgent(agent, runtime(), {})
+    releaseFirst?.()
+
+    await expect(Promise.all([first, second, third])).resolves.toEqual(["ok", "ok", "ok"])
+    expect(reports).toBe(3)
+    expect(maxReporters).toBe(1)
+  })
+
   it("reports an aborted invocation as cancelled", async () => {
     const events: RuntimeDiagnosticEvent[] = []
     const controller = new AbortController()

--- a/packages/agent/test/diagnostics-capability.test.ts
+++ b/packages/agent/test/diagnostics-capability.test.ts
@@ -49,6 +49,26 @@ describe("diagnostics Capability", () => {
     })
   })
 
+  it("reports cumulative peak growth across smaller samples", async () => {
+    const events: RuntimeDiagnosticEvent[] = []
+    const snapshots = [snapshot(64), snapshot(104), snapshot(144)]
+    const agent = defineAgent({
+      capabilities: [diagnostics({
+        interval: 1,
+        peakStepBytes: 64,
+        reporter: (event) => { events.push(event) },
+        resources: { inspect: async () => snapshots.shift() || snapshot(144) },
+      })],
+      driver: { run: async () => {
+        await new Promise(resolve => setTimeout(resolve, 5))
+        return "ok"
+      } },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok")
+    expect(events.filter(event => event.name === "agent.resource.peak")).toHaveLength(1)
+  })
+
   it("does not let inspection or reporter failures change Agent output", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
     const agent = defineAgent({
@@ -126,6 +146,45 @@ describe("diagnostics Capability", () => {
 
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok")
     expect(events.filter(event => event.name === "agent.resource.snapshot").map(event => event.attributes?.reason)).toEqual(["start", "finish"])
+    expect(inspections).toBe(3)
+  })
+
+  it("does not overlap reporting between samples", async () => {
+    let activeReporters = 0
+    let inspections = 0
+    let maxReporters = 0
+    let releasePoll: (() => void) | undefined
+    let startPoll: (() => void) | undefined
+    const pollReporting = new Promise<void>((resolve) => { startPoll = resolve })
+    const pollBlocked = new Promise<void>((resolve) => { releasePoll = resolve })
+    const agent = defineAgent({
+      capabilities: [diagnostics({
+        heartbeat: 1,
+        interval: 1,
+        reporter: async (event) => {
+          activeReporters += 1
+          maxReporters = Math.max(maxReporters, activeReporters)
+          if (event.attributes?.reason === "poll") {
+            startPoll?.()
+            await pollBlocked
+          }
+          activeReporters -= 1
+        },
+        resources: { inspect: async () => {
+          inspections += 1
+          return snapshot(inspections)
+        } },
+        timeout: 50,
+      })],
+      driver: { run: async () => {
+        await pollReporting
+        setTimeout(() => releasePoll?.(), 1)
+        return "ok"
+      } },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok")
+    expect(maxReporters).toBe(1)
     expect(inspections).toBe(3)
   })
 

--- a/packages/agent/test/diagnostics-capability.test.ts
+++ b/packages/agent/test/diagnostics-capability.test.ts
@@ -96,6 +96,39 @@ describe("diagnostics Capability", () => {
     await blocked
   })
 
+  it("takes a final sample after an active poll settles during shutdown", async () => {
+    const events: RuntimeDiagnosticEvent[] = []
+    let releasePoll: (() => void) | undefined
+    let startPoll: (() => void) | undefined
+    const pollStarted = new Promise<void>((resolve) => { startPoll = resolve })
+    const pollBlocked = new Promise<void>((resolve) => { releasePoll = resolve })
+    let inspections = 0
+    const agent = defineAgent({
+      capabilities: [diagnostics({
+        interval: 1,
+        reporter: (event) => { events.push(event) },
+        resources: { inspect: async () => {
+          inspections += 1
+          if (inspections === 2) {
+            startPoll?.()
+            await pollBlocked
+          }
+          return snapshot(inspections)
+        } },
+        timeout: 50,
+      })],
+      driver: { run: async () => {
+        await pollStarted
+        setTimeout(() => releasePoll?.(), 1)
+        return "ok"
+      } },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok")
+    expect(events.filter(event => event.name === "agent.resource.snapshot").map(event => event.attributes?.reason)).toEqual(["start", "finish"])
+    expect(inspections).toBe(3)
+  })
+
   it("reports an aborted invocation as cancelled", async () => {
     const events: RuntimeDiagnosticEvent[] = []
     const controller = new AbortController()
@@ -109,6 +142,21 @@ describe("diagnostics Capability", () => {
 
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { abortSignal: controller.signal })).rejects.toThrow("Cancelled.")
     expect(events.at(-1)).toMatchObject({ attributes: { outcome: "cancelled" }, level: "info", name: "agent.invocation.terminal" })
+  })
+
+  it("reports a successful invocation as completed after a late abort", async () => {
+    const events: RuntimeDiagnosticEvent[] = []
+    const controller = new AbortController()
+    const agent = defineAgent({
+      capabilities: [diagnostics({ reporter: (event) => { events.push(event) } })],
+      driver: { run: () => {
+        controller.abort(new DOMException("Too late.", "AbortError"))
+        return "ok"
+      } },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { abortSignal: controller.signal })).resolves.toBe("ok")
+    expect(events.at(-1)).toMatchObject({ attributes: { outcome: "completed" }, level: "info", name: "agent.invocation.terminal" })
   })
 
   it("rejects invalid sampling options", () => {

--- a/packages/agent/test/diagnostics-capability.test.ts
+++ b/packages/agent/test/diagnostics-capability.test.ts
@@ -231,6 +231,10 @@ describe("diagnostics Capability", () => {
     const firstBlocked = new Promise<void>((resolve) => { releaseFirst = resolve })
     let startFirst: (() => void) | undefined
     const firstStarted = new Promise<void>((resolve) => { startFirst = resolve })
+    let releaseQueued: (() => void) | undefined
+    const queuedBlocked = new Promise<void>((resolve) => { releaseQueued = resolve })
+    let startQueued: (() => void) | undefined
+    const queuedStarted = new Promise<void>((resolve) => { startQueued = resolve })
     let reports = 0
     const agent = defineAgent({
       capabilities: [diagnostics({
@@ -241,6 +245,10 @@ describe("diagnostics Capability", () => {
           if (reports === 1) {
             startFirst?.()
             await firstBlocked
+          }
+          else {
+            startQueued?.()
+            await queuedBlocked
           }
           activeReporters -= 1
         },
@@ -255,6 +263,9 @@ describe("diagnostics Capability", () => {
     const second = runAgent(agent, runtime(), {})
     const third = runAgent(agent, runtime(), {})
     releaseFirst?.()
+    await queuedStarted
+    await Promise.resolve()
+    releaseQueued?.()
 
     await expect(Promise.all([first, second, third])).resolves.toEqual(["ok", "ok", "ok"])
     expect(reports).toBe(3)

--- a/packages/agent/test/diagnostics-capability.test.ts
+++ b/packages/agent/test/diagnostics-capability.test.ts
@@ -229,7 +229,8 @@ describe("diagnostics Capability", () => {
     let maxReporters = 0
     let releaseFirst: (() => void) | undefined
     const firstBlocked = new Promise<void>((resolve) => { releaseFirst = resolve })
-    const firstStarted = Promise.withResolvers<void>()
+    let startFirst: (() => void) | undefined
+    const firstStarted = new Promise<void>((resolve) => { startFirst = resolve })
     let reports = 0
     const agent = defineAgent({
       capabilities: [diagnostics({
@@ -238,7 +239,7 @@ describe("diagnostics Capability", () => {
           activeReporters += 1
           maxReporters = Math.max(maxReporters, activeReporters)
           if (reports === 1) {
-            firstStarted.resolve()
+            startFirst?.()
             await firstBlocked
           }
           activeReporters -= 1
@@ -250,7 +251,7 @@ describe("diagnostics Capability", () => {
     const runtime = () => ({ memo: vi.fn(), runtime: "unknown" as const, waitUntil: vi.fn() })
 
     const first = runAgent(agent, runtime(), {})
-    await firstStarted.promise
+    await firstStarted
     const second = runAgent(agent, runtime(), {})
     const third = runAgent(agent, runtime(), {})
     releaseFirst?.()

--- a/packages/agent/test/diagnostics-capability.test.ts
+++ b/packages/agent/test/diagnostics-capability.test.ts
@@ -69,6 +69,23 @@ describe("diagnostics Capability", () => {
     expect(events.filter(event => event.name === "agent.resource.peak")).toHaveLength(1)
   })
 
+  it("does not apply byte peak thresholds to other units", async () => {
+    const events: RuntimeDiagnosticEvent[] = []
+    const agent = defineAgent({
+      capabilities: [diagnostics({
+        reporter: (event) => { events.push(event) },
+        resources: { inspect: async () => ({
+          observedAt: new Date().toISOString(),
+          observations: [{ name: "requests.peak", scope: "service", source: "custom", unit: "count", value: 100_000_000 }],
+        }) },
+      })],
+      driver: { run: () => "ok" },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok")
+    expect(events.some(event => event.name === "agent.resource.peak")).toBe(false)
+  })
+
   it("does not let inspection or reporter failures change Agent output", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
     const agent = defineAgent({
@@ -85,6 +102,20 @@ describe("diagnostics Capability", () => {
       runtime: "unknown",
       waitUntil: vi.fn(),
     }, {})).resolves.toBe("ok")
+    expect(warn).toHaveBeenCalledWith(expect.objectContaining({ event: "agent.diagnostics.report.failed" }))
+    warn.mockRestore()
+  })
+
+  it("does not let a non-settling reporter own the invocation lifecycle", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const run = vi.fn(() => "ok")
+    const agent = defineAgent({
+      capabilities: [diagnostics({ reporter: () => new Promise<void>(() => {}), timeout: 5 })],
+      driver: { run },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok")
+    expect(run).toHaveBeenCalledOnce()
     expect(warn).toHaveBeenCalledWith(expect.objectContaining({ event: "agent.diagnostics.report.failed" }))
     warn.mockRestore()
   })
@@ -150,6 +181,7 @@ describe("diagnostics Capability", () => {
   })
 
   it("does not overlap reporting between samples", async () => {
+    const delivered: string[] = []
     let activeReporters = 0
     let inspections = 0
     let maxReporters = 0
@@ -164,6 +196,7 @@ describe("diagnostics Capability", () => {
         reporter: async (event) => {
           activeReporters += 1
           maxReporters = Math.max(maxReporters, activeReporters)
+          delivered.push(`${event.name}:${event.attributes?.reason || "terminal"}`)
           if (event.attributes?.reason === "poll") {
             startPoll?.()
             await pollBlocked
@@ -174,11 +207,11 @@ describe("diagnostics Capability", () => {
           inspections += 1
           return snapshot(inspections)
         } },
-        timeout: 50,
+        timeout: 5,
       })],
       driver: { run: async () => {
         await pollReporting
-        setTimeout(() => releasePoll?.(), 1)
+        setTimeout(() => releasePoll?.(), 10)
         return "ok"
       } },
     })
@@ -186,6 +219,9 @@ describe("diagnostics Capability", () => {
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok")
     expect(maxReporters).toBe(1)
     expect(inspections).toBe(3)
+    await new Promise(resolve => setTimeout(resolve, 10))
+    expect(delivered.at(-2)).toBe("agent.resource.snapshot:finish")
+    expect(delivered.at(-1)).toBe("agent.invocation.terminal:terminal")
   })
 
   it("reports an aborted invocation as cancelled", async () => {
@@ -220,6 +256,7 @@ describe("diagnostics Capability", () => {
 
   it("rejects invalid sampling options", () => {
     expect(() => diagnostics({ interval: 0 })).toThrow("diagnostics({ interval })")
+    expect(() => diagnostics({ heartbeat: 10, interval: 11 })).toThrow("cannot exceed")
     expect(() => diagnostics({ peakStepBytes: 0 })).toThrow("diagnostics({ peakStepBytes })")
   })
 })

--- a/packages/agent/test/diagnostics-capability.test.ts
+++ b/packages/agent/test/diagnostics-capability.test.ts
@@ -69,6 +69,48 @@ describe("diagnostics Capability", () => {
     warn.mockRestore()
   })
 
+  it("does not overlap an inspector that ignores timeout abort", async () => {
+    let active = 0
+    let maxActive = 0
+    let release: (() => void) | undefined
+    const blocked = new Promise<void>((resolve) => { release = resolve })
+    const inspect = vi.fn(async () => {
+      active += 1
+      maxActive = Math.max(maxActive, active)
+      await blocked
+      active -= 1
+      return snapshot(64)
+    })
+    const agent = defineAgent({
+      capabilities: [diagnostics({ interval: 1, reporter: () => {}, resources: { inspect }, timeout: 5 })],
+      driver: { run: async () => {
+        await new Promise(resolve => setTimeout(resolve, 15))
+        return "ok"
+      } },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok")
+    expect(inspect).toHaveBeenCalledTimes(1)
+    expect(maxActive).toBe(1)
+    release?.()
+    await blocked
+  })
+
+  it("reports an aborted invocation as cancelled", async () => {
+    const events: RuntimeDiagnosticEvent[] = []
+    const controller = new AbortController()
+    const agent = defineAgent({
+      capabilities: [diagnostics({ reporter: (event) => { events.push(event) } })],
+      driver: { run: () => {
+        controller.abort(new DOMException("Cancelled.", "AbortError"))
+        throw controller.signal.reason
+      } },
+    })
+
+    await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, { abortSignal: controller.signal })).rejects.toThrow("Cancelled.")
+    expect(events.at(-1)).toMatchObject({ attributes: { outcome: "cancelled" }, level: "info", name: "agent.invocation.terminal" })
+  })
+
   it("rejects invalid sampling options", () => {
     expect(() => diagnostics({ interval: 0 })).toThrow("diagnostics({ interval })")
     expect(() => diagnostics({ peakStepBytes: 0 })).toThrow("diagnostics({ peakStepBytes })")

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -27,6 +27,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
+    "./node": "./dist/node.js",
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -1,0 +1,144 @@
+import { readFile } from "node:fs/promises"
+import { join } from "node:path"
+import { availableMemory, memoryUsage, resourceUsage } from "node:process"
+
+import type {
+  RuntimeResourceInspector,
+  RuntimeResourceObservation,
+  RuntimeResourceScope,
+  RuntimeResourceSnapshot,
+  RuntimeResourceSupport,
+  RuntimeResourceUnit,
+} from "./diagnostics.ts"
+
+type ReadText = (path: string) => Promise<string>
+
+export interface NodeRuntimeResourceInspectorOptions {
+  now?: () => Date
+  readText?: ReadText
+}
+
+function observation(
+  name: string,
+  value: number | undefined,
+  scope: RuntimeResourceScope,
+  source: string,
+  unit: RuntimeResourceUnit,
+): RuntimeResourceObservation[] {
+  return value === undefined || !Number.isFinite(value) ? [] : [{ name, scope, source, unit, value }]
+}
+
+async function optionalRead(readText: ReadText, path: string): Promise<string | undefined> {
+  try {
+    return await readText(path)
+  }
+  catch {
+    return undefined
+  }
+}
+
+function numericFile(value: string | undefined): number | undefined {
+  if (!value || value.trim() === "max") return
+  const result = Number(value.trim())
+  return Number.isFinite(result) ? result : undefined
+}
+
+function pairs(value: string | undefined): Record<string, number> {
+  return Object.fromEntries((value || "").trim().split("\n").flatMap((line) => {
+    const [key, raw] = line.trim().split(/\s+/, 2)
+    const count = Number(raw)
+    return key && Number.isFinite(count) ? [[key, count]] : []
+  }))
+}
+
+function meminfo(value: string | undefined): Record<string, number> {
+  return Object.fromEntries((value || "").trim().split("\n").flatMap((line) => {
+    const match = /^(\w+):\s+(\d+)\s+kB$/.exec(line)
+    return match ? [[match[1]!, Number(match[2]) * 1_024]] : []
+  }))
+}
+
+async function cgroupObservations(readText: ReadText): Promise<{
+  observations: RuntimeResourceObservation[]
+  support: RuntimeResourceSupport
+}> {
+  const membership = await optionalRead(readText, "/proc/self/cgroup")
+  const relative = membership?.split("\n").find(line => line.startsWith("0::"))?.slice(3)
+  if (relative === undefined) {
+    return { observations: [], support: { reason: "unsupported-runtime", scope: "service", source: "linux-cgroup-v2", supported: false } }
+  }
+  const root = join("/sys/fs/cgroup", relative)
+  const [current, peak, high, max, swapCurrent, swapPeak, events, cpu] = await Promise.all([
+    optionalRead(readText, join(root, "memory.current")),
+    optionalRead(readText, join(root, "memory.peak")),
+    optionalRead(readText, join(root, "memory.high")),
+    optionalRead(readText, join(root, "memory.max")),
+    optionalRead(readText, join(root, "memory.swap.current")),
+    optionalRead(readText, join(root, "memory.swap.peak")),
+    optionalRead(readText, join(root, "memory.events")),
+    optionalRead(readText, join(root, "cpu.stat")),
+  ])
+  if (current === undefined && events === undefined && cpu === undefined) {
+    return { observations: [], support: { reason: "permission-denied", scope: "service", source: "linux-cgroup-v2", supported: false } }
+  }
+  const memoryEvents = pairs(events)
+  const cpuValues = pairs(cpu)
+  return {
+    observations: [
+      ...observation("memory.current", numericFile(current), "service", "linux-cgroup-v2", "bytes"),
+      ...observation("memory.peak", numericFile(peak), "service", "linux-cgroup-v2", "bytes"),
+      ...observation("memory.high", numericFile(high), "service", "linux-cgroup-v2", "bytes"),
+      ...observation("memory.max", numericFile(max), "service", "linux-cgroup-v2", "bytes"),
+      ...observation("memory.swap.current", numericFile(swapCurrent), "service", "linux-cgroup-v2", "bytes"),
+      ...observation("memory.swap.peak", numericFile(swapPeak), "service", "linux-cgroup-v2", "bytes"),
+      ...observation("memory.events.high", memoryEvents.high, "service", "linux-cgroup-v2", "count"),
+      ...observation("memory.events.max", memoryEvents.max, "service", "linux-cgroup-v2", "count"),
+      ...observation("memory.events.oom", memoryEvents.oom, "service", "linux-cgroup-v2", "count"),
+      ...observation("memory.events.oom_kill", memoryEvents.oom_kill, "service", "linux-cgroup-v2", "count"),
+      ...observation("cpu.usage", cpuValues.usage_usec, "service", "linux-cgroup-v2", "microseconds"),
+    ],
+    support: { scope: "service", source: "linux-cgroup-v2", supported: true },
+  }
+}
+
+export function nodeRuntimeResources(options: NodeRuntimeResourceInspectorOptions = {}): RuntimeResourceInspector {
+  const now = options.now || (() => new Date())
+  const readText = options.readText || (async path => await readFile(path, "utf8"))
+  return {
+    async inspect(): Promise<RuntimeResourceSnapshot> {
+      const memory = memoryUsage()
+      const usage = resourceUsage()
+      const [cgroup, linuxMeminfo] = process.platform === "linux"
+        ? await Promise.all([cgroupObservations(readText), optionalRead(readText, "/proc/meminfo")])
+        : [{ observations: [], support: { reason: "unsupported-runtime", scope: "service", source: "linux-cgroup-v2", supported: false } as const }, undefined] as const
+      const host = meminfo(linuxMeminfo)
+      return {
+        observedAt: now().toISOString(),
+        observations: [
+          ...observation("memory.rss", memory.rss, "process", "node", "bytes"),
+          ...observation("memory.heap.total", memory.heapTotal, "process", "node", "bytes"),
+          ...observation("memory.heap.used", memory.heapUsed, "process", "node", "bytes"),
+          ...observation("memory.external", memory.external, "process", "node", "bytes"),
+          ...observation("memory.array_buffers", memory.arrayBuffers, "process", "node", "bytes"),
+          ...observation("memory.max_rss", usage.maxRSS * 1_024, "process", "node", "bytes"),
+          ...observation("cpu.user", usage.userCPUTime, "process", "node", "microseconds"),
+          ...observation("cpu.system", usage.systemCPUTime, "process", "node", "microseconds"),
+          ...observation("memory.available", availableMemory(), "process", "node", "bytes"),
+          ...observation("memory.available", host.MemAvailable, "host", "linux-proc", "bytes"),
+          ...observation("memory.swap.free", host.SwapFree, "host", "linux-proc", "bytes"),
+          ...cgroup.observations,
+        ],
+        support: [
+          { scope: "process", source: "node", supported: true },
+          {
+            ...(linuxMeminfo === undefined ? { reason: "collection-failed" as const } : {}),
+            scope: "host",
+            source: "linux-proc",
+            supported: linuxMeminfo !== undefined,
+          },
+          cgroup.support,
+        ],
+      }
+    },
+  }
+}

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -108,7 +108,8 @@ export function nodeRuntimeResources(options: NodeRuntimeResourceInspectorOption
     async inspect(): Promise<RuntimeResourceSnapshot> {
       const memory = memoryUsage()
       const usage = resourceUsage()
-      const [cgroup, linuxMeminfo] = process.platform === "linux"
+      const linux = process.platform === "linux"
+      const [cgroup, linuxMeminfo] = linux
         ? await Promise.all([cgroupObservations(readText), optionalRead(readText, "/proc/meminfo")])
         : [{ observations: [], support: { reason: "unsupported-runtime", scope: "service", source: "linux-cgroup-v2", supported: false } as const }, undefined] as const
       const host = meminfo(linuxMeminfo)
@@ -131,7 +132,7 @@ export function nodeRuntimeResources(options: NodeRuntimeResourceInspectorOption
         support: [
           { scope: "process", source: "node", supported: true },
           {
-            ...(linuxMeminfo === undefined ? { reason: "collection-failed" as const } : {}),
+            ...(linuxMeminfo === undefined ? { reason: linux ? "collection-failed" as const : "unsupported-runtime" as const } : {}),
             scope: "host",
             source: "linux-proc",
             supported: linuxMeminfo !== undefined,

--- a/packages/runtime/test/node-diagnostics.test.ts
+++ b/packages/runtime/test/node-diagnostics.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest"
+
+import { nodeRuntimeResources } from "../src/node.ts"
+
+describe("Node Runtime diagnostics", () => {
+  it("reports process, host, and cgroup observations with honest scopes", async () => {
+    const files: Record<string, string> = {
+      "/proc/self/cgroup": "0::/user.slice/babysitter.service\n",
+      "/proc/meminfo": "MemAvailable:       4194304 kB\nSwapFree:            2097152 kB\n",
+      "/sys/fs/cgroup/user.slice/babysitter.service/memory.current": "1048576\n",
+      "/sys/fs/cgroup/user.slice/babysitter.service/memory.peak": "2097152\n",
+      "/sys/fs/cgroup/user.slice/babysitter.service/memory.high": "max\n",
+      "/sys/fs/cgroup/user.slice/babysitter.service/memory.max": "6291456\n",
+      "/sys/fs/cgroup/user.slice/babysitter.service/memory.swap.current": "524288\n",
+      "/sys/fs/cgroup/user.slice/babysitter.service/memory.swap.peak": "1048576\n",
+      "/sys/fs/cgroup/user.slice/babysitter.service/memory.events": "high 2\nmax 1\noom 0\noom_kill 0\n",
+      "/sys/fs/cgroup/user.slice/babysitter.service/cpu.stat": "usage_usec 123\n",
+    }
+    const inspector = nodeRuntimeResources({
+      now: () => new Date("2026-08-22T10:00:00.000Z"),
+      readText: async path => files[path] ?? Promise.reject(Object.assign(new Error("missing"), { code: "ENOENT" })),
+    })
+
+    const snapshot = await inspector.inspect()
+
+    expect(snapshot.observedAt).toBe("2026-08-22T10:00:00.000Z")
+    expect(snapshot.support).toContainEqual({ scope: "service", source: "linux-cgroup-v2", supported: true })
+    expect(snapshot.observations).toEqual(expect.arrayContaining([
+      { name: "memory.current", scope: "service", source: "linux-cgroup-v2", unit: "bytes", value: 1_048_576 },
+      { name: "memory.peak", scope: "service", source: "linux-cgroup-v2", unit: "bytes", value: 2_097_152 },
+      { name: "memory.rss", scope: "process", source: "node", unit: "bytes", value: expect.any(Number) },
+      { name: "memory.available", scope: "host", source: "linux-proc", unit: "bytes", value: 4_294_967_296 },
+    ]))
+    expect(snapshot.observations.some(item => item.name === "memory.high")).toBe(false)
+  })
+})

--- a/packages/runtime/test/node-diagnostics.test.ts
+++ b/packages/runtime/test/node-diagnostics.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { nodeRuntimeResources } from "../src/node.ts"
 
@@ -32,5 +32,18 @@ describe("Node Runtime diagnostics", () => {
       { name: "memory.available", scope: "host", source: "linux-proc", unit: "bytes", value: 4_294_967_296 },
     ]))
     expect(snapshot.observations.some(item => item.name === "memory.high")).toBe(false)
+  })
+
+  it("reports Linux-only sources as unsupported on other platforms", async () => {
+    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("darwin")
+    const inspector = nodeRuntimeResources()
+
+    const snapshot = await inspector.inspect()
+
+    expect(snapshot.support).toEqual(expect.arrayContaining([
+      { reason: "unsupported-runtime", scope: "host", source: "linux-proc", supported: false },
+      { reason: "unsupported-runtime", scope: "service", source: "linux-cgroup-v2", supported: false },
+    ]))
+    platform.mockRestore()
   })
 })

--- a/packages/runtime/test/package.test.ts
+++ b/packages/runtime/test/package.test.ts
@@ -4,6 +4,6 @@ import { verifyBuiltPackageExports } from "../../internal/test-utils/built-packa
 
 describe("@vite-hub/runtime package contract", () => {
   it("loads documented exports from built package targets", async () => {
-    await verifyBuiltPackageExports(new URL("../", import.meta.url), "@vite-hub/runtime", ["."])
+    await verifyBuiltPackageExports(new URL("../", import.meta.url), "@vite-hub/runtime", [".", "./node"])
   })
 })

--- a/packages/runtime/vite.config.ts
+++ b/packages/runtime/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vite-plus";
 export default defineConfig({
   pack: {
     tsconfig: "tsconfig.build.json",
-    entry: ["src/index.ts"],
+    entry: ["src/index.ts", "src/node.ts"],
     exports: {
       inlinedDependencies: false,
     },

--- a/packages/vite-hub/package.json
+++ b/packages/vite-hub/package.json
@@ -108,6 +108,7 @@
     "./realtime/server": "./dist/realtime/server.js",
     "./realtime/vue": "./dist/realtime/vue.js",
     "./runtime": "./dist/runtime.js",
+    "./runtime/node": "./dist/runtime/node.js",
     "./sandbox": "./dist/sandbox.js",
     "./schedule": "./dist/schedule.js",
     "./schedule/runtime": "./dist/schedule/runtime.js",

--- a/packages/vite-hub/src/runtime/node.ts
+++ b/packages/vite-hub/src/runtime/node.ts
@@ -1,0 +1,1 @@
+export * from "@vite-hub/runtime/node"

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -22,7 +22,9 @@ import frameworkAuthHandler from "vite-hub/auth/server"
 import * as frameworkAuthVue from "vite-hub/auth/vue"
 import * as frameworkBlobContentType from "vite-hub/blob/content-type"
 import * as frameworkRateLimit from "vite-hub/rate-limit"
+import * as frameworkRuntimeNode from "vite-hub/runtime/node"
 import { setActiveCloudflareEnv as frameworkDatabaseStateSetter } from "vite-hub/_internal/database/runtime/state"
+import * as ownerRuntimeNode from "@vite-hub/runtime/node"
 import { distributionBinEntries, distributionEntriesFromManifest } from "../vite.config.ts"
 
 const packageRoot = fileURLToPath(new URL("..", import.meta.url))
@@ -147,6 +149,7 @@ describe("framework package contract", () => {
     expect(frameworkBlobContentType.detectContentType).toBe(ownerBlobContentType.detectContentType)
     expect(frameworkRateLimit.requireRateLimit).toBe(ownerRateLimit.requireRateLimit)
     expect(frameworkRateLimit.createRateLimiter).toBe(ownerRateLimit.createRateLimiter)
+    expect(frameworkRuntimeNode.nodeRuntimeResources).toBe(ownerRuntimeNode.nodeRuntimeResources)
   })
 
   it("keeps the Database environment setter on its owner runtime instance", () => {


### PR DESCRIPTION
Small and long-running Agent services need inspectable resource pressure and terminal failures without each application rebuilding `/proc`, cgroup, error-tree, and polling logic.

## What changed

- Adds opt-in `diagnostics()` as an Agent Capability with application-owned reporting, terminal events, bounded sampling, heartbeats, peak events, and contained reporter/inspector failures.
- Adds Runtime-owned structured diagnostic and scoped resource contracts.
- Adds `nodeRuntimeResources()` for process, host `/proc`, and Linux cgroup v2 observations with explicit scope/support semantics.
- Exposes the adapter through `@vite-hub/runtime/node` and `vite-hub/runtime/node`.
- Adds `vitehub agent invocations list|show|tail` for local journal inspection, including nested terminal failures.
- Documents diagnostics as a separate operations lane from OTLP so a failing trace receiver cannot hide its own failure.

The Capability owns Agent policy and lifecycle, Runtime owns portable contracts, and the Node adapter owns platform details. Applications provide only the reporter they already use.

## Verification

- Runtime full suite: 40 tests passed.
- Agent full suite: 70 files and 1,984 tests passed.
- Framework full suite: 9 files and 139 tests passed with no type errors.
- Package builds and publint passed for Runtime, Agent, and the framework distribution.
- Babysitter `pnpm patch` proof passed 17 tests, full typecheck, frozen install, and production builds with the application-specific resource monitor removed.

Depends on #988 for the shared bounded diagnostic error contract.
