### PR TITLE
chore(agent): update embedded provider runtime

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7252,7 +7252,7 @@ packages:
     resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
 
   '@t3tools/contracts@https://pkg.pr.new/vite-hub/t3code/@t3tools/contracts@66628e8b8dcf468201b93c958604d641f89e62ef':
-    resolution: {tarball: https://pkg.pr.new/vite-hub/t3code/@t3tools/contracts@66628e8b8dcf468201b93c958604d641f89e62ef}
+    resolution: {integrity: sha512-iV1zseVu6hHWVBpaZrOeE9na3zdBpY/ruGnxsV1yoNVF9N+YLHSIeqj2u92nePtrLvovhpBoul2GWyY3Ux9JVQ==, tarball: https://pkg.pr.new/vite-hub/t3code/@t3tools/contracts@66628e8b8dcf468201b93c958604d641f89e62ef}
     version: 0.0.33
     peerDependencies:
       effect: 4.0.0-beta.103

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,7 +73,7 @@ catalogs:
       version: 0.45.2
   default:
     '@t3tools/provider-runtime':
-      specifier: https://pkg.pr.new/vite-hub/t3code/@t3tools/provider-runtime@67cf65b129d2c52a20199243565ecb8bd63c7af1
+      specifier: https://pkg.pr.new/vite-hub/t3code/@t3tools/provider-runtime@66628e8b8dcf468201b93c958604d641f89e62ef
       version: 0.0.33
   effect:
     effect:
@@ -576,7 +576,7 @@ importers:
         version: 1.1.0
       '@t3tools/provider-runtime':
         specifier: 'catalog:'
-        version: https://pkg.pr.new/vite-hub/t3code/@t3tools/provider-runtime@67cf65b129d2c52a20199243565ecb8bd63c7af1(@anthropic-ai/sdk@0.120.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ioredis@5.11.1)(zod@4.4.3)
+        version: https://pkg.pr.new/vite-hub/t3code/@t3tools/provider-runtime@66628e8b8dcf468201b93c958604d641f89e62ef(@anthropic-ai/sdk@0.120.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ioredis@5.11.1)(zod@4.4.3)
       '@types/json-schema':
         specifier: catalog:ai
         version: 7.0.15
@@ -7222,14 +7222,14 @@ packages:
   '@swc/types@0.1.27':
     resolution: {integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==}
 
-  '@t3tools/contracts@https://pkg.pr.new/vite-hub/t3code/@t3tools/contracts@67cf65b129d2c52a20199243565ecb8bd63c7af1':
-    resolution: {integrity: sha512-gDbn2n4UMNyuX1FC/mXm7C2TrsWf6WluLuyt0UwREGJYQLS/JRfkfWkXe0SHg6FIY2RnXrtnh1bvhrvpnshthA==, tarball: https://pkg.pr.new/vite-hub/t3code/@t3tools/contracts@67cf65b129d2c52a20199243565ecb8bd63c7af1}
+  '@t3tools/contracts@https://pkg.pr.new/vite-hub/t3code/@t3tools/contracts@66628e8b8dcf468201b93c958604d641f89e62ef':
+    resolution: {integrity: sha512-iV1zseVu6hHWVBpaZrOeE9na3zdBpY/ruGnxsV1yoNVF9N+YLHSIeqj2u92nePtrLvovhpBoul2GWyY3Ux9JVQ==, tarball: https://pkg.pr.new/vite-hub/t3code/@t3tools/contracts@66628e8b8dcf468201b93c958604d641f89e62ef}
     version: 0.0.33
     peerDependencies:
       effect: 4.0.0-beta.103
 
-  '@t3tools/provider-runtime@https://pkg.pr.new/vite-hub/t3code/@t3tools/provider-runtime@67cf65b129d2c52a20199243565ecb8bd63c7af1':
-    resolution: {integrity: sha512-1Oj9mB5AtqI5LvDKisZEhPiXLP+NDYVGNNg7cNG3ZHa/KBBjvJ5f9Qf61Np7ZcRMxhbUD7YEoQQvNblapef4wg==, tarball: https://pkg.pr.new/vite-hub/t3code/@t3tools/provider-runtime@67cf65b129d2c52a20199243565ecb8bd63c7af1}
+  '@t3tools/provider-runtime@https://pkg.pr.new/vite-hub/t3code/@t3tools/provider-runtime@66628e8b8dcf468201b93c958604d641f89e62ef':
+    resolution: {integrity: sha512-IYE+HQxeTy1fINtMY/8WRZysmU6w40EhfERaiTcIsP5nAqXuJI2XcEPCC5uPugEz0zzKc5ncAgSpBWMEw9kvwg==, tarball: https://pkg.pr.new/vite-hub/t3code/@t3tools/provider-runtime@66628e8b8dcf468201b93c958604d641f89e62ef}
     version: 0.0.33
     engines: {node: ^22.16 || ^23.11 || >=24.10}
 
@@ -20016,15 +20016,15 @@ snapshots:
     dependencies:
       '@swc/counter': 0.1.3
 
-  '@t3tools/contracts@https://pkg.pr.new/vite-hub/t3code/@t3tools/contracts@67cf65b129d2c52a20199243565ecb8bd63c7af1(effect@4.0.0-beta.103)':
+  '@t3tools/contracts@https://pkg.pr.new/vite-hub/t3code/@t3tools/contracts@66628e8b8dcf468201b93c958604d641f89e62ef(effect@4.0.0-beta.103)':
     dependencies:
       effect: 4.0.0-beta.103
 
-  '@t3tools/provider-runtime@https://pkg.pr.new/vite-hub/t3code/@t3tools/provider-runtime@67cf65b129d2c52a20199243565ecb8bd63c7af1(@anthropic-ai/sdk@0.120.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ioredis@5.11.1)(zod@4.4.3)':
+  '@t3tools/provider-runtime@https://pkg.pr.new/vite-hub/t3code/@t3tools/provider-runtime@66628e8b8dcf468201b93c958604d641f89e62ef(@anthropic-ai/sdk@0.120.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(ioredis@5.11.1)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/claude-agent-sdk': 0.3.238(@anthropic-ai/sdk@0.120.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.4.3))(zod@4.4.3)
       '@effect/platform-node': 4.0.0-beta.103(effect@4.0.0-beta.103)(ioredis@5.11.1)
-      '@t3tools/contracts': https://pkg.pr.new/vite-hub/t3code/@t3tools/contracts@67cf65b129d2c52a20199243565ecb8bd63c7af1(effect@4.0.0-beta.103)
+      '@t3tools/contracts': https://pkg.pr.new/vite-hub/t3code/@t3tools/contracts@66628e8b8dcf468201b93c958604d641f89e62ef(effect@4.0.0-beta.103)
       effect: 4.0.0-beta.103
     transitivePeerDependencies:
       - '@anthropic-ai/sdk'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ packages:
   - "docs"
   - "packages/*"
 catalog:
-  '@t3tools/provider-runtime': https://pkg.pr.new/vite-hub/t3code/@t3tools/provider-runtime@67cf65b129d2c52a20199243565ecb8bd63c7af1
+  '@t3tools/provider-runtime': https://pkg.pr.new/vite-hub/t3code/@t3tools/provider-runtime@66628e8b8dcf468201b93c958604d641f89e62ef
 
 catalogMode: prefer
 


### PR DESCRIPTION
ViteHub still consumes the provider runtime from the fork before its latest upstream sync, so it misses the current T3 provider notification lifecycle behavior.

This updates the workspace catalog and lockfile to the verified package published from `vite-hub/t3code@66628e8b8dcf468201b93c958604d641f89e62ef`. That commit contains the synced upstream runtime while retaining ViteHub's embedded-runtime packages.

Verification:

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm --filter @vite-hub/agent typecheck`
- focused Agent runtime tests: 65 passed
- Agent build and publint passed as part of the full test command
- full Agent suite: 1,950 passed; 5 unrelated timing/fixture tests failed
- `git diff --check`
