### PR TITLE
ci(docs): enable Cloudflare preview URLs

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -196,6 +196,8 @@ export default defineNuxtConfig({
       wrangler: {
         name: "vitehub-docs",
         compatibility_date: "2026-07-19",
+        workers_dev: false,
+        preview_urls: true,
         d1_databases: [
           {
             binding: "DB",


### PR DESCRIPTION
Enables versioned preview URLs for the ViteHub documentation Worker while keeping the ordinary `workers.dev` route disabled.

Cloudflare Builds now has a non-production trigger that runs the existing docs tests and build, then uploads a Worker version without promoting it to production. Production continues to deploy the same Worker, D1 binding, and `vitehub.dev` custom domain.

Verification:
- `pnpm --filter vitehub-docs run typecheck`
- docs test suite: 54 passed
- Cloudflare API: preview trigger enabled for non-main branches and `previews_enabled: true`