### PR TITLE
fix(markdown-template): load colocated templates in Nuxt Nitro

### DIFF
--- a/packages/markdown-template/src/vite.ts
+++ b/packages/markdown-template/src/vite.ts
@@ -28,6 +28,7 @@ async function writeFileIfChanged(path: string, contents: string): Promise<void>
     current = await readFile(path, "utf8")
   }
   catch (error) {
+    // SAFETY: Node filesystem failures expose their stable error code through ErrnoException.
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
   }
   if (current === contents) return

--- a/packages/markdown-template/src/vite.ts
+++ b/packages/markdown-template/src/vite.ts
@@ -57,6 +57,7 @@ export function hubMarkdownTemplate(options: HubMarkdownTemplateOptions = {}): P
       if (!resolved || resolved.external) {
         this.error(`[vitehub] Could not resolve Markdown template ${JSON.stringify(request.path)}${importer ? ` from ${JSON.stringify(importer)}` : ""}.`)
       }
+      if (parseMarkdownTemplateRequest(resolved.id) && resolved.id.includes("?")) return resolved.id
       return `${resolved.id}?${markdownTemplateModuleQuery}`
     },
     async load(id) {

--- a/packages/markdown-template/test/vite.test.ts
+++ b/packages/markdown-template/test/vite.test.ts
@@ -12,7 +12,7 @@ import {
   ScriptTarget,
 } from "typescript"
 import { build } from "vite"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { extractMarkdownTemplateImportSpecifiers, markdownTemplateMaterializationPath, parseMarkdownTemplateRequest } from "../src/internal/vite.ts"
 import { hubMarkdownTemplate } from "../src/vite.ts"
@@ -49,6 +49,22 @@ describe("hubMarkdownTemplate", () => {
     expect(parseMarkdownTemplateRequest("./prompt.template.md?raw")).toBeUndefined()
     expect(parseMarkdownTemplateRequest("./prompt.template.md?url")).toBeUndefined()
     expect(parseMarkdownTemplateRequest("./prompt.template.md?markdown-template")).toEqual({ path: "./prompt.template.md" })
+  })
+
+  it("keeps resolved Markdown template module ids stable", async () => {
+    const resolveId = hubMarkdownTemplate().resolveId as unknown as (
+      this: { resolve: (source: string) => Promise<{ id: string }> },
+      source: string,
+    ) => Promise<string | undefined>
+
+    const resolve = vi.fn(async (source: string) => ({ id: `/app/${source.slice(2)}` }))
+    await expect(resolveId.call({ resolve }, "./reply.template.md?markdown-template")).resolves.toBe(
+      "/app/reply.template.md?markdown-template",
+    )
+    expect(resolve).toHaveBeenCalledWith("./reply.template.md", undefined, { skipSelf: true })
+    await expect(resolveId.call({
+      resolve: async source => ({ id: `${source}?markdown-template` }),
+    }, "/app/reply.template.md")).resolves.toBe("/app/reply.template.md?markdown-template")
   })
 
   it("extracts imports from indented paragraph continuations", () => {

--- a/packages/markdown-template/test/vite.test.ts
+++ b/packages/markdown-template/test/vite.test.ts
@@ -52,7 +52,9 @@ describe("hubMarkdownTemplate", () => {
   })
 
   it("keeps resolved Markdown template module ids stable", async () => {
-    const resolveId = hubMarkdownTemplate().resolveId as unknown as (
+    const resolveIdCandidate: unknown = hubMarkdownTemplate().resolveId
+    // SAFETY: hubMarkdownTemplate defines resolveId as this function hook; the test supplies its only used context method.
+    const resolveId = resolveIdCandidate as (
       this: { resolve: (source: string) => Promise<{ id: string }> },
       source: string,
     ) => Promise<string | undefined>
@@ -103,6 +105,7 @@ describe("hubMarkdownTemplate", () => {
     })
 
     await Promise.all([rm(template), rm(partial)])
+    // SAFETY: The fixture entry exports the declared default function and is built immediately above.
     const bundled = await import(`${pathToFileURL(outfile).href}?t=${Date.now()}`) as { default: () => Promise<string> }
     await expect(bundled.default()).resolves.toBe("# Babysitter\n\nReview PR 42..\n\n[Policy](@./missing.md)\n\n`@./missing.md`\n\n`multiline @./missing.md code`\n\n> ```md\n> @./missing.md\n> ```\n\n```\n@./missing.md\n```\n\n- Example\n  ```\n  @./missing.md\n  ```\n- Fenced example\n  ```md\n  @./missing.md\n  ```\n- Context\nReview PR 42.\n\n> Waiting")
     const typesPath = join(root, ".vitehub", "types", "markdown-template.d.ts")
@@ -152,6 +155,7 @@ describe("hubMarkdownTemplate", () => {
       .resolves.toContain('declare module "*.template.md"')
     await expect(readFile(join(root, ".vitehub", "markdown-template", "templates.mjs"), "utf8")).rejects.toThrow()
     await expect(readFile(join(root, ".vitehub", "types", "templates.d.ts"), "utf8")).rejects.toThrow()
+    // SAFETY: The fixture entry exports the declared default function and is built immediately above.
     const bundled = await import(`${pathToFileURL(join(app, "dist", "entry.mjs")).href}?t=${Date.now()}`) as { default: () => Promise<string> }
     await expect(bundled.default()).resolves.toBe("Hello ViteHub.")
   }, 15_000)

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -515,10 +515,10 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
         }
       })
     | undefined
-  const markdownTemplatePluginCandidate: unknown = replayPlugins.find(
+  const markdownTemplatePluginCandidate: unknown = installedPlugins.find(
     plugin => plugin.name === "@vite-hub/markdown-template/vite",
   )
-  // SAFETY: The canonical Markdown Template plugin name identifies its function-hook contract.
+  // SAFETY: The canonical Markdown Template plugin name identifies the framework-owned function-hook contract.
   const markdownTemplatePlugin = markdownTemplatePluginCandidate as MarkdownTemplatePlugin | undefined
   const emailTemplatePaths =
     (await emailPlugin?.api?.prepareTypes?.({

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -82,7 +82,17 @@ function markdownTemplateResolver(plugin: MarkdownTemplatePlugin): Plugin {
   return {
     name: "vite-hub/nuxt-markdown-templates",
     load(id, ...args) {
-      return plugin.load.call(this, id.startsWith("\0raw:") ? id.slice(5) : id, ...args)
+      const context = Object.create(this) as typeof this
+      Object.defineProperty(context, "resolve", {
+        value: async (...resolveArgs: Parameters<typeof this.resolve>) => {
+          const resolved = await this.resolve(...resolveArgs)
+          return resolved && {
+            ...resolved,
+            id: resolved.id.startsWith("\0raw:") ? resolved.id.slice(5) : resolved.id,
+          }
+        },
+      })
+      return plugin.load.call(context, id.startsWith("\0raw:") ? id.slice(5) : id, ...args)
     },
     async resolveId(...args) {
       const resolved = await plugin.resolveId.call(this, ...args)
@@ -91,13 +101,24 @@ function markdownTemplateResolver(plugin: MarkdownTemplatePlugin): Plugin {
   }
 }
 
+function pluginOptionHasName(option: PluginOption, name: string): boolean {
+  if (Array.isArray(option)) return option.some(candidate => pluginOptionHasName(candidate, name))
+  return Boolean(option && typeof option === "object" && "name" in option && option.name === name)
+}
+
 function installMarkdownTemplateResolver(config: Record<string, unknown>, plugin: MarkdownTemplatePlugin | undefined): void {
   if (!plugin) return
   // SAFETY: Nitro rollupConfig is an object namespace owned and initialized here.
   const rollupConfig = (config.rollupConfig ??= {}) as Record<string, unknown>
   // SAFETY: Nitro Rollup plugins use Vite's compatible Plugin contract.
-  const plugins = (rollupConfig.plugins ??= []) as Plugin[]
-  if (!plugins.some(candidate => candidate.name === "vite-hub/nuxt-markdown-templates")) {
+  const configuredPlugins = rollupConfig.plugins as PluginOption | undefined
+  const plugins = Array.isArray(configuredPlugins)
+    ? configuredPlugins
+    : configuredPlugins
+      ? [configuredPlugins]
+      : []
+  rollupConfig.plugins = plugins
+  if (!plugins.some(candidate => pluginOptionHasName(candidate, "vite-hub/nuxt-markdown-templates"))) {
     plugins.push(markdownTemplateResolver(plugin))
   }
 }

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -70,6 +70,36 @@ function installEmailTemplateResolver(config: Record<string, unknown>, root: str
   }
 }
 
+function markdownTemplateResolver(plugin: Plugin): Plugin {
+  const load = plugin.load as unknown as CallableFunction
+  const resolveId = plugin.resolveId as unknown as CallableFunction
+  return {
+    name: "vite-hub/nuxt-markdown-templates",
+    load(id, ...args) {
+      return Reflect.apply(load, this, [id.startsWith("\0raw:") ? id.slice(5) : id, ...args])
+    },
+    async resolveId(...args) {
+      const resolved = await Reflect.apply(resolveId, this, args)
+      if (typeof resolved === "string" && resolved.startsWith("\0raw:")) return resolved.slice(5)
+      if (resolved && typeof resolved === "object" && "id" in resolved && resolved.id.startsWith("\0raw:")) {
+        return { ...resolved, id: resolved.id.slice(5) }
+      }
+      return resolved
+    },
+  }
+}
+
+function installMarkdownTemplateResolver(config: Record<string, unknown>, plugin: Plugin | undefined): void {
+  if (typeof plugin?.load !== "function" || typeof plugin.resolveId !== "function") return
+  // SAFETY: Nitro rollupConfig is an object namespace owned and initialized here.
+  const rollupConfig = (config.rollupConfig ??= {}) as Record<string, unknown>
+  // SAFETY: Nitro Rollup plugins use Vite's compatible Plugin contract.
+  const plugins = (rollupConfig.plugins ??= []) as Plugin[]
+  if (!plugins.some(candidate => candidate.name === "vite-hub/nuxt-markdown-templates")) {
+    plugins.push(markdownTemplateResolver(plugin))
+  }
+}
+
 function addTypeScriptDefaults(options: Record<string, unknown>, includes: string[], excludes: string[]): void {
   // SAFETY: The TypeScript namespace is initialized to the object contract mutated below.
   const typescript = (options.typescript ??= {}) as Record<string, unknown>
@@ -462,6 +492,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
         }
       })
     | undefined
+  const markdownTemplatePlugin = replayPlugins.find(plugin => plugin.name === "@vite-hub/markdown-template/vite")
   const emailTemplatePaths =
     (await emailPlugin?.api?.prepareTypes?.({
       materialize: true,
@@ -528,6 +559,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
   nuxt.hook?.("nitro:config", async config => {
     await applyNitroConfig(replayPlugins, config, nuxt)
     Object.assign(config, mergeGeneratedCollectionNitroConfig(config, collectionHandlers))
+    installMarkdownTemplateResolver(config, markdownTemplatePlugin)
     if (emailPlugin && nuxt.options.dev) {
       installEmailTemplateResolver(config, join(projectRoot, ".vitehub/email/templates"))
     }

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -104,7 +104,7 @@ function markdownTemplateResolver(plugin: MarkdownTemplatePlugin): Plugin {
 
 function pluginOptionHasName(option: PluginOption, name: string): boolean {
   if (Array.isArray(option)) return option.some(candidate => pluginOptionHasName(candidate, name))
-  return Boolean(option && typeof option === "object" && "name" in option && option.name === name)
+  return Boolean(option && Reflect.get(Object(option), "name") === name)
 }
 
 function installMarkdownTemplateResolver(config: Record<string, unknown>, plugin: MarkdownTemplatePlugin | undefined): void {

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -104,7 +104,7 @@ function markdownTemplateResolver(plugin: MarkdownTemplatePlugin): Plugin {
 
 function pluginOptionHasName(option: PluginOption, name: string): boolean {
   if (Array.isArray(option)) return option.some(candidate => pluginOptionHasName(candidate, name))
-  return Boolean(option && option.name === name)
+  return Boolean(option && typeof option === "object" && "name" in option && option.name === name)
 }
 
 function installMarkdownTemplateResolver(config: Record<string, unknown>, plugin: MarkdownTemplatePlugin | undefined): void {

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -19,7 +19,7 @@ import { mergeGeneratedCollectionNitroConfig, type GeneratedCollectionHandler } 
 
 import type { DatabaseNuxtIntegrationOptions } from "@vite-hub/database"
 import type { EnvIntegrationOptions, EnvViteConfigOptions, EnvViteUserConfig } from "@vite-hub/env"
-import type { Plugin, PluginOption, UserConfig } from "vite"
+import type { HookHandler, Plugin, PluginOption, UserConfig } from "vite"
 
 const databaseRuntimeState = fileURLToPath(new URL("./_internal/database/runtime/state", import.meta.url))
 type ViteHubNuxtOptions = Omit<Parameters<typeof vitehub>[0], "database" | "env"> & {
@@ -70,27 +70,29 @@ function installEmailTemplateResolver(config: Record<string, unknown>, root: str
   }
 }
 
-function markdownTemplateResolver(plugin: Plugin): Plugin {
-  const load = plugin.load as unknown as CallableFunction
-  const resolveId = plugin.resolveId as unknown as CallableFunction
+type MarkdownTemplatePlugin = Omit<Plugin, "load" | "resolveId"> & {
+  load: HookHandler<NonNullable<Plugin["load"]>>
+  resolveId(
+    this: ThisParameterType<HookHandler<NonNullable<Plugin["resolveId"]>>>,
+    ...args: Parameters<HookHandler<NonNullable<Plugin["resolveId"]>>>
+  ): Promise<string | undefined> | string | undefined
+}
+
+function markdownTemplateResolver(plugin: MarkdownTemplatePlugin): Plugin {
   return {
     name: "vite-hub/nuxt-markdown-templates",
     load(id, ...args) {
-      return Reflect.apply(load, this, [id.startsWith("\0raw:") ? id.slice(5) : id, ...args])
+      return plugin.load.call(this, id.startsWith("\0raw:") ? id.slice(5) : id, ...args)
     },
     async resolveId(...args) {
-      const resolved = await Reflect.apply(resolveId, this, args)
-      if (typeof resolved === "string" && resolved.startsWith("\0raw:")) return resolved.slice(5)
-      if (resolved && typeof resolved === "object" && "id" in resolved && resolved.id.startsWith("\0raw:")) {
-        return { ...resolved, id: resolved.id.slice(5) }
-      }
-      return resolved
+      const resolved = await plugin.resolveId.call(this, ...args)
+      return resolved?.startsWith("\0raw:") ? resolved.slice(5) : resolved
     },
   }
 }
 
-function installMarkdownTemplateResolver(config: Record<string, unknown>, plugin: Plugin | undefined): void {
-  if (typeof plugin?.load !== "function" || typeof plugin.resolveId !== "function") return
+function installMarkdownTemplateResolver(config: Record<string, unknown>, plugin: MarkdownTemplatePlugin | undefined): void {
+  if (!plugin) return
   // SAFETY: Nitro rollupConfig is an object namespace owned and initialized here.
   const rollupConfig = (config.rollupConfig ??= {}) as Record<string, unknown>
   // SAFETY: Nitro Rollup plugins use Vite's compatible Plugin contract.
@@ -492,7 +494,11 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
         }
       })
     | undefined
-  const markdownTemplatePlugin = replayPlugins.find(plugin => plugin.name === "@vite-hub/markdown-template/vite")
+  const markdownTemplatePluginCandidate: unknown = replayPlugins.find(
+    plugin => plugin.name === "@vite-hub/markdown-template/vite",
+  )
+  // SAFETY: The canonical Markdown Template plugin name identifies its function-hook contract.
+  const markdownTemplatePlugin = markdownTemplatePluginCandidate as MarkdownTemplatePlugin | undefined
   const emailTemplatePaths =
     (await emailPlugin?.api?.prepareTypes?.({
       materialize: true,

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -82,6 +82,7 @@ function markdownTemplateResolver(plugin: MarkdownTemplatePlugin): Plugin {
   return {
     name: "vite-hub/nuxt-markdown-templates",
     load(id, ...args) {
+      // SAFETY: Object.create preserves the complete Rollup plugin context supplied as this.
       const context = Object.create(this) as typeof this
       Object.defineProperty(context, "resolve", {
         value: async (...resolveArgs: Parameters<typeof this.resolve>) => {
@@ -103,7 +104,7 @@ function markdownTemplateResolver(plugin: MarkdownTemplatePlugin): Plugin {
 
 function pluginOptionHasName(option: PluginOption, name: string): boolean {
   if (Array.isArray(option)) return option.some(candidate => pluginOptionHasName(candidate, name))
-  return Boolean(option && typeof option === "object" && "name" in option && option.name === name)
+  return Boolean(option && option.name === name)
 }
 
 function installMarkdownTemplateResolver(config: Record<string, unknown>, plugin: MarkdownTemplatePlugin | undefined): void {

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -230,7 +230,9 @@ describe("ViteHub Nuxt integration", () => {
       load: standaloneLoad,
       resolveId: standaloneResolveId,
     }])
-    const nitroConfig = { rollupConfig: { plugins: existingPlugin as Plugin | Plugin[] } }
+    const nitroConfig: { rollupConfig: { plugins: Plugin | Plugin[] } } = {
+      rollupConfig: { plugins: existingPlugin },
+    }
     const nestedResolve = vi.fn().mockResolvedValue({
       id: "\0raw:/app/server/api/name.md",
       meta: { marker: "preserved" },
@@ -246,6 +248,7 @@ describe("ViteHub Nuxt integration", () => {
     await viteHubNuxtModule({ preset: "node" }, nuxt)
     await runNitroConfigHook(nitroConfig)
 
+    // SAFETY: The Nitro configuration hook normalizes this plugin option to an array.
     const plugins = nitroConfig.rollupConfig.plugins as Plugin[]
     expect(plugins[0]).toBe(existingPlugin)
     expect(plugins.map(plugin => plugin.name)).toEqual([

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -223,16 +223,23 @@ describe("ViteHub Nuxt integration", () => {
       load: mocks.markdownTemplateLoad,
       resolveId: mocks.markdownTemplateResolveId,
     }])
-    const nitroConfig = { rollupConfig: { plugins: [existingPlugin] } }
-    const context = { marker: "nitro-context" }
+    const nitroConfig = { rollupConfig: { plugins: existingPlugin as Plugin | Plugin[] } }
+    const nestedResolve = vi.fn().mockResolvedValue({
+      id: "\0raw:/app/server/api/name.md",
+      meta: { marker: "preserved" },
+    })
+    const context = { marker: "nitro-context", resolve: nestedResolve }
     mocks.markdownTemplateResolveId.mockResolvedValueOnce(
       "\0raw:/app/server/api/reply.template.md?markdown-template",
     )
+    mocks.markdownTemplateLoad.mockImplementationOnce(function (this: { resolve: typeof nestedResolve }) {
+      return this.resolve("./name.md", "/app/server/api/reply.template.md")
+    })
 
     await viteHubNuxtModule({ preset: "node" }, nuxt)
     await runNitroConfigHook(nitroConfig)
 
-    const plugins = nitroConfig.rollupConfig.plugins
+    const plugins = nitroConfig.rollupConfig.plugins as Plugin[]
     expect(plugins[0]).toBe(existingPlugin)
     expect(plugins.map(plugin => plugin.name)).toEqual([
       "existing-nitro-plugin",
@@ -248,12 +255,19 @@ describe("ViteHub Nuxt integration", () => {
     await expect(markdownPlugin.resolveId.call(context, "./reply.template.md", "/app/server/api/reply.ts")).resolves.toBe(
       "/app/server/api/reply.template.md?markdown-template",
     )
-    await markdownPlugin.load.call(context, "\0raw:/app/server/api/reply.template.md?markdown-template")
+    await expect(markdownPlugin.load.call(
+      context,
+      "\0raw:/app/server/api/reply.template.md?markdown-template",
+    )).resolves.toEqual({
+      id: "/app/server/api/name.md",
+      meta: { marker: "preserved" },
+    })
     expect(mocks.markdownTemplateResolveId.mock.contexts[0]).toBe(context)
-    expect(mocks.markdownTemplateLoad.mock.contexts[0]).toBe(context)
+    expect(Object.getPrototypeOf(mocks.markdownTemplateLoad.mock.contexts[0])).toBe(context)
     expect(mocks.markdownTemplateLoad).toHaveBeenCalledWith(
       "/app/server/api/reply.template.md?markdown-template",
     )
+    expect(nestedResolve).toHaveBeenCalledWith("./name.md", "/app/server/api/reply.template.md")
   })
 
   it.each([

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -10,7 +10,7 @@ import {
   VITEHUB_SERVER_DIRS,
 } from "@vite-hub/internal/build/vite"
 
-import type { PluginOption } from "vite"
+import type { Plugin, PluginOption } from "vite"
 
 const databaseRuntimeState = fileURLToPath(new URL("../src/_internal/database/runtime/state", import.meta.url))
 
@@ -37,6 +37,8 @@ const mocks = vi.hoisted(() => ({
   envHook: vi.fn((config: Record<string, unknown>) => {
     config.envReady = true
   }),
+  markdownTemplateLoad: vi.fn(),
+  markdownTemplateResolveId: vi.fn(),
   outputHook: vi.fn(),
   agentHook: vi.fn((config: { [VITEHUB_SERVER_DIRS]?: string[]; nitro?: Record<string, unknown> }) => ({
     nitro: {
@@ -112,6 +114,8 @@ describe("ViteHub Nuxt integration", () => {
     mocks.existingQueueNitroConfig.mockClear()
     mocks.existingOwnerConfig.mockClear()
     mocks.envHook.mockClear()
+    mocks.markdownTemplateLoad.mockClear()
+    mocks.markdownTemplateResolveId.mockClear()
     mocks.outputHook.mockClear()
     mocks.queueNitroConfig.mockClear()
     mocks.sandboxHook.mockClear()
@@ -210,6 +214,47 @@ describe("ViteHub Nuxt integration", () => {
         config: mocks.envHook,
       },
     ])
+  })
+
+  it("loads colocated Markdown templates through Nitro Rollup", async () => {
+    const existingPlugin: Plugin = { name: "existing-nitro-plugin" }
+    const { nuxt, runNitroConfigHook } = createNuxt(false, [{
+      name: "@vite-hub/markdown-template/vite",
+      load: mocks.markdownTemplateLoad,
+      resolveId: mocks.markdownTemplateResolveId,
+    }])
+    const nitroConfig = { rollupConfig: { plugins: [existingPlugin] } }
+    const context = { marker: "nitro-context" }
+    mocks.markdownTemplateResolveId.mockResolvedValueOnce(
+      "\0raw:/app/server/api/reply.template.md?markdown-template",
+    )
+
+    await viteHubNuxtModule({ preset: "node" }, nuxt)
+    await runNitroConfigHook(nitroConfig)
+
+    const plugins = nitroConfig.rollupConfig.plugins
+    expect(plugins[0]).toBe(existingPlugin)
+    expect(plugins.map(plugin => plugin.name)).toEqual([
+      "existing-nitro-plugin",
+      "vite-hub/nuxt-markdown-templates",
+    ])
+
+    const markdownPlugin = plugins[1] as Plugin
+    const resolveId = markdownPlugin.resolveId as unknown as (
+      this: typeof context,
+      source: string,
+      importer: string,
+    ) => unknown
+    const load = markdownPlugin.load as unknown as (this: typeof context, id: string) => unknown
+    await expect(resolveId.call(context, "./reply.template.md", "/app/server/api/reply.ts")).resolves.toBe(
+      "/app/server/api/reply.template.md?markdown-template",
+    )
+    await load.call(context, "\0raw:/app/server/api/reply.template.md?markdown-template")
+    expect(mocks.markdownTemplateResolveId.mock.contexts[0]).toBe(context)
+    expect(mocks.markdownTemplateLoad.mock.contexts[0]).toBe(context)
+    expect(mocks.markdownTemplateLoad).toHaveBeenCalledWith(
+      "/app/server/api/reply.template.md?markdown-template",
+    )
   })
 
   it.each([

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -213,15 +213,22 @@ describe("ViteHub Nuxt integration", () => {
         },
         config: mocks.envHook,
       },
+      {
+        name: "@vite-hub/markdown-template/vite",
+        load: mocks.markdownTemplateLoad,
+        resolveId: mocks.markdownTemplateResolveId,
+      },
     ])
   })
 
   it("loads colocated Markdown templates through Nitro Rollup", async () => {
     const existingPlugin: Plugin = { name: "existing-nitro-plugin" }
+    const standaloneLoad = vi.fn()
+    const standaloneResolveId = vi.fn()
     const { nuxt, runNitroConfigHook } = createNuxt(false, [{
       name: "@vite-hub/markdown-template/vite",
-      load: mocks.markdownTemplateLoad,
-      resolveId: mocks.markdownTemplateResolveId,
+      load: standaloneLoad,
+      resolveId: standaloneResolveId,
     }])
     const nitroConfig = { rollupConfig: { plugins: existingPlugin as Plugin | Plugin[] } }
     const nestedResolve = vi.fn().mockResolvedValue({
@@ -267,6 +274,8 @@ describe("ViteHub Nuxt integration", () => {
     expect(mocks.markdownTemplateLoad).toHaveBeenCalledWith(
       "/app/server/api/reply.template.md?markdown-template",
     )
+    expect(standaloneResolveId).not.toHaveBeenCalled()
+    expect(standaloneLoad).not.toHaveBeenCalled()
     expect(nestedResolve).toHaveBeenCalledWith("./name.md", "/app/server/api/reply.template.md")
   })
 
@@ -379,6 +388,7 @@ describe("ViteHub Nuxt integration", () => {
       expect.objectContaining({ name: "@vite-hub/sandbox/vite" }),
       expect.objectContaining({ name: "@vite-hub/workflow/vite" }),
       expect.objectContaining({ name: "@vite-hub/env/vite" }),
+      expect.objectContaining({ name: "@vite-hub/markdown-template/vite" }),
       existingQueuePlugin,
       existingOwnerPlugin,
       existingPlugin,
@@ -474,6 +484,9 @@ describe("ViteHub Nuxt integration", () => {
       preset: "cloudflare_module",
       queues: {
         handlers: [{ handler: "custom-server/queues/email.ts" }],
+      },
+      rollupConfig: {
+        plugins: [expect.objectContaining({ name: "vite-hub/nuxt-markdown-templates" })],
       },
       sandbox: true,
       workflows: true,

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -239,17 +239,16 @@ describe("ViteHub Nuxt integration", () => {
       "vite-hub/nuxt-markdown-templates",
     ])
 
-    const markdownPlugin = plugins[1] as Plugin
-    const resolveId = markdownPlugin.resolveId as unknown as (
-      this: typeof context,
-      source: string,
-      importer: string,
-    ) => unknown
-    const load = markdownPlugin.load as unknown as (this: typeof context, id: string) => unknown
-    await expect(resolveId.call(context, "./reply.template.md", "/app/server/api/reply.ts")).resolves.toBe(
+    const markdownPluginCandidate: unknown = plugins[1]
+    // SAFETY: The preceding names assertion identifies the installed resolver and its function hooks.
+    const markdownPlugin = markdownPluginCandidate as {
+      load(this: typeof context, id: string): unknown
+      resolveId(this: typeof context, source: string, importer: string): unknown
+    }
+    await expect(markdownPlugin.resolveId.call(context, "./reply.template.md", "/app/server/api/reply.ts")).resolves.toBe(
       "/app/server/api/reply.template.md?markdown-template",
     )
-    await load.call(context, "\0raw:/app/server/api/reply.template.md?markdown-template")
+    await markdownPlugin.load.call(context, "\0raw:/app/server/api/reply.template.md?markdown-template")
     expect(mocks.markdownTemplateResolveId.mock.contexts[0]).toBe(context)
     expect(mocks.markdownTemplateLoad.mock.contexts[0]).toBe(context)
     expect(mocks.markdownTemplateLoad).toHaveBeenCalledWith(


### PR DESCRIPTION
Colocated `*.template.md` imports already work in Vite, but Nuxt's Nitro server build did not receive the Markdown-template plugin's resolver and loader. Server routes could therefore compile through Vite and then fail when Nitro bundled the same import.

This carries the replayed `@vite-hub/markdown-template/vite` hooks into Nitro Rollup while preserving existing Nitro plugins. The adapter also removes Nitro's `\0raw:` wrapper before Markdown loading, and Markdown resolution now keeps an already-tagged resolved ID stable instead of appending the query twice.

The change is limited to colocated Markdown-template imports. It does not restore the removed template catalog or include other downstream patch hunks.

## Verification

- `@vite-hub/markdown-template`: focused Vite suite, 7 tests passed; typecheck and package build passed.
- `vite-hub`: focused Nuxt suite, 46 tests passed; typecheck and package build passed.
- Focused Oxlint and `git diff --check` passed.
- Disposable Nuxt 4.4.8 / Nitro 2.13.4 node-server build passed with a server route importing `./reply.template.md`; the emitted server returned `Hello Nitro.` from that route.