### PR TITLE
fix(blob): generate Nitro files from project root

### DIFF
--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -1,7 +1,7 @@
 import { writeFileIfChanged } from "@vite-hub/internal/definition-catalog"
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { composeNitroCloudflareProviderOutput, registerCloudflareProviderOutput, resetComposedProviderOutput, shouldSkipViteProviderBuild, useComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
-import { createNoExternalMerger, hasNitroConfigContext, isServerEnvironment, resolveNitroVercelFunctionName } from "@vite-hub/internal/build/vite"
+import { createNoExternalMerger, hasNitroConfigContext, isServerEnvironment, resolveNitroVercelFunctionName, resolveViteHubProjectRoot } from "@vite-hub/internal/build/vite"
 import { getHostingProvider } from "@vite-hub/internal/hosting"
 import { resolve } from "pathe"
 
@@ -279,7 +279,7 @@ export function hubBlob(options?: BlobModuleOptions, internalOptions: InternalBl
     async configResolved(config) {
       resolved = config
       clientOutDir = config.build.outDir
-      rootDir = config.root
+      rootDir = resolveViteHubProjectRoot(config.root)
       blob = config.blob ?? blob
       const configuredNitro = (config as { nitro?: unknown }).nitro
       cloudflareOwnedByNitro = (nitroOwned || hasNitroConfigContext(config)) && isNitroCloudflareHost(configuredNitro)
@@ -288,7 +288,7 @@ export function hubBlob(options?: BlobModuleOptions, internalOptions: InternalBl
         configuredNitro,
         blobConfig.blob ? blobConfig.blob.serve : undefined,
         cloudflareOwnedByNitro,
-        config.root,
+        rootDir,
       )
       ;(config as { nitro?: unknown }).nitro = mergeNitroCloudflareBlobOutput(config, nitro, blob, cloudflareOwnedByNitro)
       providerOutput = useComposedProviderOutput(config)
@@ -296,7 +296,7 @@ export function hubBlob(options?: BlobModuleOptions, internalOptions: InternalBl
       const hosting = getNitroHostingProvider(configuredNitro)
         ?? (resolveNitroVercelFunctionName(config, "blob") ? "vercel" : undefined)
       await refreshBlobGeneratedFiles(
-        config.root,
+        rootDir,
         runtimeConfig.blob,
         cloudflareOwnedByNitro,
         importBase,

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process"
 import { existsSync } from "node:fs"
-import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
@@ -216,6 +216,31 @@ describe("hubBlob", () => {
     finally {
       await rm(root, { force: true, recursive: true })
       await rm(staleRoot, { force: true, recursive: true })
+    }
+  })
+
+  it("generates Nitro Blob files from the Nuxt project root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-blob-nuxt-root-"))
+    const appRoot = join(root, "app")
+    const generatedPlugin = join(root, ".vitehub", "nitro", "blob", "plugin.ts")
+    try {
+      await mkdir(appRoot)
+      await writeFile(join(root, "package.json"), JSON.stringify({ name: "blob-nuxt-app" }))
+      const plugin = hubBlob({ driver: "fs" }, { nitroOwned: true })
+      const resolvedConfig = {
+        build: { outDir: "dist" },
+        nitro: {},
+        root: appRoot,
+      }
+
+      await (plugin.configResolved as (config: unknown) => void | Promise<void>)(resolvedConfig as never)
+
+      expect(resolvedConfig).toHaveProperty("nitro.plugins", [generatedPlugin])
+      expect(existsSync(generatedPlugin)).toBe(true)
+      expect(existsSync(join(appRoot, ".vitehub"))).toBe(false)
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
     }
   })
 


### PR DESCRIPTION
## Summary

- resolve Blob generation through the shared ViteHub project-root boundary when Nuxt gives Vite an `app/` root
- register Nitro plugins and handlers from the same resolved root used for generated files and provider output
- preserve ordinary Vite-root behavior and cover the Nuxt package-root case with a regression test

## Verification

- `pnpm --filter @vite-hub/blob test -- test/vite.test.ts` — build and publint passed; 24 tests passed with no type errors
- `pnpm --filter @vite-hub/blob typecheck`
- focused `vp lint`
- `git diff --check`