### PR TITLE
fix(agent): route database capability through vite-hub

### DIFF
--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -674,6 +674,7 @@ export function vitehub(options: ViteHubOptions): PluginOption[] {
       providerImportAliases,
       runtimeCapabilityImports: {
         blob: blobEnabled ? `${generatedImportBase}/blob` : false,
+        db: options.database ? "vite-hub/database/drizzle" : false,
         email: "vite-hub/email/server",
         kv: `${generatedImportBase}/kv`,
       },

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -254,6 +254,7 @@ describe("vitehub", () => {
       },
       runtimeCapabilityImports: {
         blob: "vite-hub/_internal/blob",
+        db: "vite-hub/database/drizzle",
         email: "vite-hub/email/server",
         kv: "vite-hub/_internal/kv",
       },
@@ -312,6 +313,9 @@ describe("vitehub", () => {
       },
     }))
     vitehub({ agent: true, preset: "node" })
+    expect(integrationMocks.hubAgent).toHaveBeenLastCalledWith(expect.objectContaining({
+      runtimeCapabilityImports: expect.objectContaining({ db: false }),
+    }))
     expect(integrationMocks.hubWorkflow).toHaveBeenLastCalledWith({}, expect.objectContaining({
       implicitlyEnabled: true,
       includeUserAppEntry: false,


### PR DESCRIPTION
## Summary

- pass the public `vite-hub/database/drizzle` entry to generated Agent runtime capabilities when database support is enabled
- explicitly disable the database runtime import when the integration is absent
- cover enabled and disabled framework composition

## Verification

- `pnpm --filter vite-hub test -- test/vite.test.ts` — build and publint passed; 73 tests passed with no type errors
- `pnpm --filter vite-hub typecheck`
- focused `vp lint`
- `git diff --check`