### PR TITLE
fix(ui): render complete invocation lifecycle

### DIFF
--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -1,6 +1,7 @@
 import { computed, defineComponent, h, onBeforeUnmount, ref, type PropType, Suspense } from "vue";
 import type { AgentInvocationConfiguration, AgentInvocationView } from "../types.ts";
 import {
+  agentConfigurationSummary,
   invocationActivities,
   invocationActivityTitle,
   latestInvocationTokens,
@@ -98,7 +99,10 @@ function renderFolderIcon() {
   ]);
 }
 
-function renderMessage(activity: InvocationActivity) {
+function renderMessage(activity: InvocationActivity, expanded: ReadonlySet<string>, toggleExpanded: (id: string) => void) {
+  const body = activity.body ?? "";
+  const collapsible = activity.role === "user" && (body.length > 720 || body.split(/\r?\n/).length > 12);
+  const isExpanded = expanded.has(activity.id);
   return h(
     "li",
     {
@@ -107,15 +111,26 @@ function renderMessage(activity: InvocationActivity) {
       key: activity.id,
     },
     [
-      markdown(activity.body, "vh-invocation-message__body"),
+      h("div", {
+        class: "vh-invocation-message__content",
+        "data-collapsed": collapsible && !isExpanded ? "true" : undefined,
+      }, [markdown(body, "vh-invocation-message__body")]),
       activity.truncated
         ? h("p", { class: "vh-invocation-event__notice" }, "Some trace content was truncated by the invocation journal.")
+        : null,
+      collapsible
+        ? h("button", {
+            "aria-expanded": String(isExpanded),
+            class: "vh-invocation-message__more",
+            onClick: () => toggleExpanded(activity.id),
+            type: "button",
+          }, isExpanded ? "Show less" : "Read more")
         : null,
     ],
   );
 }
 
-type ActivityIcon = "action" | "approval" | "bot" | "change" | "command" | "error" | "eye" | "search" | "tool";
+type ActivityIcon = "action" | "approval" | "bot" | "change" | "command" | "error" | "eye" | "folder" | "search" | "tool";
 
 function activityIcon(activity: InvocationActivity): ActivityIcon {
   if (activity.status === "failed" || activity.kind === "error") return "error";
@@ -126,7 +141,9 @@ function activityIcon(activity: InvocationActivity): ActivityIcon {
   if (name.includes("search") || name.includes("find")) return "search";
   if (activity.kind === "reasoning" || activity.kind === "model") return "bot";
   if (activity.kind === "approval") return "approval";
-  if (activity.kind === "action") return "action";
+  if (activity.kind === "action" || activity.kind === "delivery") return "action";
+  if (activity.kind === "preparation") return "folder";
+  if (activity.kind === "system") return "bot";
   return "tool";
 }
 
@@ -138,6 +155,7 @@ const activityIconPaths: Record<ActivityIcon, readonly string[]> = {
   command: ["m4 17 6-6-6-6", "M12 19h8"],
   error: ["M18 6 6 18", "m6 6 12 12"],
   eye: ["M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12", "M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6"],
+  folder: ["M3 6.5h6l2 2h10v9.5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"],
   search: ["m21 21-4.35-4.35", "M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16"],
   tool: ["M14.7 6.3a4 4 0 0 0-5-5l2.1 2.1-2.4 2.4-2.1-2.1a4 4 0 0 0 5 5L3 18l3 3 9.3-9.3a4 4 0 0 0 5-5l-2.1 2.1-2.4-2.4z"],
 };
@@ -153,14 +171,31 @@ function renderActivityIcon(activity: InvocationActivity) {
   ]);
 }
 
-function renderEvent(activity: InvocationActivity) {
+function renderEvent(activity: InvocationActivity, inspect: (target: "agent" | "workspace") => void) {
   const command = activity.command;
   const tokenLabel = activity.kind === "reasoning" || activity.kind === "model"
     ? formatTokens(activity.reasoningTokens)
     : undefined;
-  const suffix = activity.preview ? compactCommand(activity.preview) : tokenLabel;
+  const suffix = agentConfigurationSummary(activity) ?? (activity.preview ? compactCommand(activity.preview) : tokenLabel);
   const hasDetails = activity.patches.length > 0 || Boolean(command || activity.body || activity.truncated);
-  const summary = h(hasDetails ? "summary" : "div", { class: "vh-invocation-event__summary" }, [
+  const inspectTarget = activity.attributes["vitehub.inspect.target"] ?? (activity.name === "vitehub.agent.configured" ? "agent" : undefined);
+  const inspectable = inspectTarget === "agent" || inspectTarget === "workspace";
+  const summary = h(hasDetails ? "summary" : "div", {
+    class: "vh-invocation-event__summary",
+    ...(inspectable
+      ? {
+          role: hasDetails ? undefined : "button",
+          tabindex: hasDetails ? undefined : 0,
+          onClick: () => inspect(inspectTarget),
+          onKeydown: (event: KeyboardEvent) => {
+            if (!hasDetails && (event.key === "Enter" || event.key === " ")) {
+              event.preventDefault();
+              inspect(inspectTarget);
+            }
+          },
+        }
+      : {}),
+  }, [
     renderActivityIcon(activity),
     h("span", { class: "vh-invocation-event__title" }, invocationActivityTitle(activity)),
     suffix ? h("code", { class: "vh-invocation-event__suffix" }, suffix) : null,
@@ -171,6 +206,7 @@ function renderEvent(activity: InvocationActivity) {
   return h("li", {
     class: "vh-invocation-activity",
     "data-kind": activity.kind,
+    "data-inspectable": inspectable ? "true" : undefined,
     "data-status": activity.status,
     key: activity.id,
   }, [
@@ -254,14 +290,103 @@ function renderConfiguration(configuration: AgentInvocationConfiguration) {
   ];
 }
 
+function renderInvocationActivity(
+  activity: InvocationActivity,
+  expanded: ReadonlySet<string>,
+  toggleExpanded: (id: string) => void,
+  inspect: (target: "agent" | "workspace") => void,
+) {
+  return activity.kind === "message"
+    ? renderMessage(activity, expanded, toggleExpanded)
+    : renderEvent(activity, inspect);
+}
+
+function isExternalActivity(activity: InvocationActivity): boolean {
+  return activity.kind === "preparation" || activity.kind === "delivery" || activity.kind === "action";
+}
+
+function renderChevronDown(className: string) {
+  return h("svg", { "aria-hidden": "true", class: className, fill: "none", viewBox: "0 0 24 24" }, [
+    h("path", { d: "m6 9 6 6 6-6", "stroke-linecap": "round", "stroke-linejoin": "round" }),
+  ]);
+}
+
+function renderWorkSummary(
+  activities: readonly InvocationActivity[],
+  invocation: AgentInvocationView,
+  expanded: ReadonlySet<string>,
+  toggleExpanded: (id: string) => void,
+  inspect: (target: "agent" | "workspace") => void,
+) {
+  if (!activities.length) return null;
+  const endedAt = invocation.completedAt ?? invocation.failedAt ?? invocation.cancelledAt ?? invocation.updatedAt;
+  const duration = formatDuration(invocation.startedAt, endedAt);
+  return h("li", { class: "vh-invocation-work", key: "invocation-work" }, [
+    h("details", { class: "vh-invocation-work__details" }, [
+      h("summary", { class: "vh-invocation-work__summary" }, [
+        h("span", { class: "vh-invocation-work__title" }, duration ? `Worked for ${duration}` : "Work details"),
+        renderChevronDown("vh-invocation-work__disclosure"),
+      ]),
+      h("div", { "aria-hidden": "true", class: "vh-invocation-work__divider" }),
+      h("ol", { class: "vh-invocation-work__activities" }, activities.map(activity => renderInvocationActivity(activity, expanded, toggleExpanded, inspect))),
+    ]),
+  ]);
+}
+
+function renderInvocationActivities(
+  activities: readonly InvocationActivity[],
+  invocation: AgentInvocationView,
+  expanded: ReadonlySet<string>,
+  toggleExpanded: (id: string) => void,
+  inspect: (target: "agent" | "workspace") => void,
+) {
+  const render = (activity: InvocationActivity) => renderInvocationActivity(activity, expanded, toggleExpanded, inspect);
+  if (invocation.status === "pending" || invocation.status === "running") return activities.map(render);
+
+  const firstUser = activities.findIndex(activity => activity.kind === "message" && activity.role === "user");
+  if (firstUser < 0) return activities.map(render);
+
+  let finalAssistant = -1;
+  for (let index = activities.length - 1; index > firstUser; index -= 1) {
+    if (activities[index]!.kind === "message" && activities[index]!.role === "assistant") {
+      finalAssistant = index;
+      break;
+    }
+  }
+
+  const workEnd = finalAssistant < 0 ? activities.length : finalAssistant;
+  const between = activities.slice(firstUser + 1, workEnd);
+  const external = between.filter(isExternalActivity);
+  const work = between.filter(activity => !isExternalActivity(activity));
+  const suffix = finalAssistant < 0 ? [] : activities.slice(finalAssistant);
+
+  return [
+    ...activities.slice(0, firstUser + 1).map(render),
+    ...external.map(render),
+    renderWorkSummary(work, invocation, expanded, toggleExpanded, inspect),
+    ...suffix.map(render),
+  ].filter(item => item !== null);
+}
+
 export const AgentInvocation = defineComponent({
   name: "AgentInvocation",
+  emits: {
+    inspect: (target: "agent" | "workspace") => target === "agent" || target === "workspace",
+  },
   props: {
     header: { default: true, type: Boolean },
     invocation: { required: true, type: Object as PropType<AgentInvocationView> },
   },
-  setup(props, { slots }) {
+  setup(props, { emit, slots }) {
     const activities = computed(() => invocationActivities(props.invocation));
+    const expandedMessages = ref<ReadonlySet<string>>(new Set());
+
+    function toggleExpanded(id: string) {
+      const next = new Set(expandedMessages.value);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      expandedMessages.value = next;
+    }
 
     return () => {
       return h("article", {
@@ -287,7 +412,13 @@ export const AgentInvocation = defineComponent({
                 ])
               : null,
             activities.value.length
-              ? h("ol", { "aria-label": "Session thread", class: "vh-invocation-activities" }, activities.value.map(activity => activity.kind === "message" ? renderMessage(activity) : renderEvent(activity)))
+              ? h("ol", { "aria-label": "Session thread", class: "vh-invocation-activities" }, renderInvocationActivities(
+                  activities.value,
+                  props.invocation,
+                  expandedMessages.value,
+                  toggleExpanded,
+                  target => emit("inspect", target),
+                ))
               : h("div", { class: "vh-invocation-empty" }, [h("span", { "aria-hidden": "true" }, "○"), h("p", "Waiting for the first update…")]),
             slots.footer?.({ invocation: props.invocation }),
           ]),

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -5,12 +5,15 @@ type InvocationActivityKind =
   | "action"
   | "approval"
   | "change"
+  | "delivery"
   | "error"
   | "message"
   | "model"
   | "plan"
+  | "preparation"
   | "reasoning"
   | "run"
+  | "system"
   | "tool"
   | "activity";
 
@@ -226,11 +229,12 @@ function activityKind(
   const explicit = attributes["vitehub.activity.kind"];
   if (
     typeof explicit === "string"
-    && ["action", "approval", "change", "error", "message", "model", "plan", "reasoning", "run", "tool", "activity"].includes(explicit)
+    && ["action", "approval", "change", "delivery", "error", "message", "model", "plan", "preparation", "reasoning", "run", "system", "tool", "activity"].includes(explicit)
   ) {
     return explicit as InvocationActivityKind;
   }
-  if (attributes["channel.effect.kind"] || attributes["channel.effect.intent"] || observation.name.includes(".channel.delivery")) return "action";
+  if (attributes["channel.effect.kind"] || attributes["channel.effect.intent"] || observation.name.includes(".channel.delivery")) return "delivery";
+  if (observation.name === "vitehub.agent.configured") return "system";
   if (attributes["tool.name"] || attributes["tool.id"] || observation.name.includes(".tool.")) return "tool";
   if (attributes["approval.id"] || observation.name.includes(".approval.")) return "approval";
   if (observation.type === "error" || observation.name.endsWith(".error")) return "error";
@@ -257,13 +261,15 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
   let anonymousMessageKey: string | undefined;
   let anonymousMessagePhase: string | undefined;
   let assistantDeltaText = "";
+  const hasAgentMessages = (invocation.observations ?? []).some(observation => observation.name.startsWith("agent.message"));
   for (const observation of invocation.observations ?? []) {
-    if (observation.name === "agent.title.recorded" || observation.name === "vitehub.agent.configured") continue;
+    if (observation.name === "agent.title.recorded") continue;
     const originalAttributes = observation.attributes ?? {};
     const delta = messageText({ parts: [{ text: originalAttributes["message.content"] }] });
     const role = messageRole(originalAttributes["message.role"]);
     const resultText = messageText({ parts: [{ text: originalAttributes["result.text"] }] });
     if (resultText && assistantDeltaText.endsWith(resultText)) continue;
+    if (hasAgentMessages && !resultText && (observation.name === "agent.stream.finish" || observation.name === "agent.invocation.finish")) continue;
     if (delta && (role === undefined || role === "assistant")) assistantDeltaText += delta;
     const inputMessages = Array.isArray(originalAttributes["input.messages"])
       ? originalAttributes["input.messages"]
@@ -382,7 +388,13 @@ export function latestInvocationTokens(activities: readonly InvocationActivity[]
 }
 
 export function invocationActivityTitle(activity: InvocationActivity): string {
+  const explicit = activity.attributes["vitehub.activity.title"];
+  if (typeof explicit === "string" && explicit.trim()) return explicit.trim();
   if (activity.name === "vitehub.observation.truncated") return "Trace content was truncated";
+  if (activity.name === "vitehub.agent.configured") return "Agent configured";
+  if (activity.kind === "preparation") return "Prepared session";
+  if (activity.kind === "system") return "System configuration";
+  if (activity.kind === "delivery") return String(activity.attributes["channel.effect.kind"] ?? "Channel delivery");
   if (activity.kind === "action") return String(activity.attributes["channel.effect.kind"] ?? activity.attributes["vitehub.action.name"] ?? "Product action");
   if (activity.kind === "plan") return "Updated plan";
   if (activity.kind === "change") return normalizedTitle(String(activity.attributes["tool.name"] ?? "Changed files"));
@@ -396,6 +408,22 @@ export function invocationActivityTitle(activity: InvocationActivity): string {
   if (activity.kind === "model") return "Thinking";
   if (activity.kind === "run") return activity.name.endsWith(".finish") ? "Finished session" : "Started session";
   return normalizedTitle(activity.name.replace(/\.(start|finish|error|decision|recorded)$/, "").replaceAll(".", " "));
+}
+
+export function agentConfigurationSummary(activity: InvocationActivity): string | undefined {
+  if (activity.name !== "vitehub.agent.configured") return;
+  const configuration = record(activity.attributes["vitehub.agent.configuration"]);
+  if (!configuration) return;
+  const driver = record(configuration.driver);
+  const model = record(driver?.model);
+  const modelName = stringAttribute(model ?? {}, "id") ?? stringAttribute(driver ?? {}, "provider");
+  const capabilities = Array.isArray(configuration.capabilities) ? configuration.capabilities.length : 0;
+  const tools = Array.isArray(configuration.tools) ? configuration.tools.length : 0;
+  return [
+    modelName,
+    capabilities ? `${capabilities} ${capabilities === 1 ? "capability" : "capabilities"}` : undefined,
+    tools ? `${tools} ${tools === 1 ? "tool" : "tools"}` : undefined,
+  ].filter(Boolean).join(" · ") || undefined;
 }
 
 export function terminalText(value: string | undefined): string {

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -113,7 +113,15 @@
 }
 
 .vh-typeset :where(ul, ol) {
-  padding-inline-start: 1.4em;
+  padding-inline-start: 1.25rem;
+}
+
+.vh-typeset ul {
+  list-style-type: disc;
+}
+
+.vh-typeset ol {
+  list-style-type: decimal;
 }
 
 .vh-typeset li + li {
@@ -602,16 +610,15 @@
 }
 
 .vh-invocation-message[data-role="assistant"] {
-  padding-block: 0.85rem;
+  padding: 0.125rem 0.25rem 0.5rem;
 }
 
 .vh-invocation-message[data-role="user"] {
   background: var(--vh-ui-bg-elevated);
-  border: 1px solid var(--vh-ui-border);
-  border-radius: calc(var(--vh-ui-radius) * 1.35);
-  margin-inline-start: clamp(1rem, 12%, 7rem);
-  margin-block: 0.85rem;
-  padding: 0.85rem 1rem;
+  border-radius: 1rem;
+  margin-block: 0.5rem 1rem;
+  margin-inline-start: 20%;
+  padding: 0.75rem;
 }
 
 .vh-invocation-message__body {
@@ -619,9 +626,84 @@
   line-height: 1.65;
 }
 
+.vh-invocation-message__content {
+  min-width: 0;
+  position: relative;
+}
+
+.vh-invocation-message__content[data-collapsed="true"] {
+  max-height: 10.5rem;
+  overflow: hidden;
+}
+
+.vh-invocation-message__content[data-collapsed="true"]::after {
+  background: linear-gradient(to bottom, transparent, var(--vh-ui-bg-elevated));
+  bottom: 0;
+  content: "";
+  height: 3.5rem;
+  inset-inline: 0;
+  pointer-events: none;
+  position: absolute;
+}
+
+.vh-invocation-message__more {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--vh-ui-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.75rem;
+  margin-block-start: 0.35rem;
+  padding: 0;
+  text-decoration: underline dotted;
+  text-underline-offset: 0.25rem;
+}
+
+.vh-invocation-message__more:hover,
+.vh-invocation-message__more:focus-visible {
+  color: var(--vh-ui-text);
+}
+
+.vh-invocation-message[data-role="assistant"] .vh-invocation-message__body,
+.vh-invocation-message[data-role="user"] .vh-invocation-message__body {
+  --vh-typeset-flow: 0.65rem;
+  font-size: 0.875rem;
+  line-height: 1.625;
+}
+
+.vh-invocation-message[data-role="assistant"] .vh-invocation-message__body {
+  margin-inline: 0;
+  padding-inline: 0;
+}
+
 .vh-invocation-event {
   border-radius: 0.375rem;
   color: var(--vh-ui-muted);
+}
+
+.vh-invocation-activity[data-kind="preparation"],
+.vh-invocation-activity[data-kind="system"],
+.vh-invocation-activity[data-kind="delivery"],
+.vh-invocation-activity[data-kind="action"] {
+  background: color-mix(in oklab, var(--vh-ui-bg-elevated) 52%, transparent);
+  border: 1px solid var(--vh-ui-border);
+  border-radius: calc(var(--vh-ui-radius) * 1.1);
+  margin-block: 0.3rem;
+  padding: 0.4rem 0.5rem;
+}
+
+.vh-invocation-activity[data-kind="preparation"] {
+  border-inline-start: 2px solid color-mix(in oklab, var(--ui-primary, #2563eb) 60%, var(--vh-ui-border));
+}
+
+.vh-invocation-activity[data-kind="delivery"],
+.vh-invocation-activity[data-kind="action"] {
+  border-inline-start: 2px solid color-mix(in oklab, var(--ui-info, #0284c7) 60%, var(--vh-ui-border));
+}
+
+.vh-invocation-activity[data-inspectable="true"] .vh-invocation-event__summary {
+  cursor: pointer;
 }
 
 .vh-invocation-event__summary {
@@ -702,6 +784,73 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 
 .vh-invocation-event[open] .vh-invocation-event__disclosure {
   transform: rotate(180deg);
+}
+
+.vh-invocation-work {
+  margin-block-end: 1rem;
+  padding-block-start: 0.25rem;
+}
+
+.vh-invocation-work__details {
+  color: var(--vh-ui-muted);
+}
+
+.vh-invocation-work__summary {
+  align-items: center;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  display: flex;
+  gap: 0.25rem;
+  line-height: 1.25rem;
+  list-style: none;
+  padding: 0 0.25rem;
+  user-select: none;
+  width: fit-content;
+}
+
+.vh-invocation-work__summary::-webkit-details-marker {
+  display: none;
+}
+
+.vh-invocation-work__summary:focus-visible {
+  box-shadow: inset 0 0 0 2px color-mix(in oklab, var(--ui-primary, #2563eb) 70%, transparent);
+  outline: none;
+}
+
+.vh-invocation-work__divider {
+  border-block-start: 1px solid color-mix(in oklab, var(--vh-ui-border) 60%, transparent);
+  margin-block-start: 0.5rem;
+}
+
+.vh-invocation-work__title {
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.vh-invocation-work__disclosure {
+  height: 0.875rem;
+  opacity: 0.7;
+  stroke: currentColor;
+  stroke-width: 2;
+  transition: transform 150ms ease;
+  width: 0.875rem;
+}
+
+.vh-invocation-work__details[open] .vh-invocation-work__disclosure {
+  transform: rotate(180deg);
+}
+
+.vh-invocation-work__activities {
+  display: flex;
+  flex-direction: column;
+  gap: 0.0625rem;
+  list-style: none;
+  margin: 1rem 0 0;
+  padding: 0;
+}
+
+.vh-invocation-work__details:not([open]) > .vh-invocation-work__activities {
+  display: none;
 }
 
 .vh-invocation-event__body,

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -117,6 +117,110 @@ describe("Agent Invocation UI", () => {
     expect(rows[1]!.attributes("style")).toContain("transform: translateY(106px)");
   });
 
+  it("renders configuration and delivery lifecycle events", async () => {
+    const timestamp = "2026-08-22T00:00:00.000Z";
+    const invocation = {
+      createdAt: timestamp,
+      id: "lifecycle",
+      observations: [
+        {
+          attributes: {
+            "vitehub.agent.configuration": {
+              capabilities: [{ id: "db" }, { id: "blob" }],
+              driver: { model: { id: "claude-sonnet-4-5" } },
+              tools: [{ name: "search" }],
+            },
+          },
+          name: "vitehub.agent.configured",
+          sequence: 1,
+          timestamp,
+          type: "lifecycle" as const,
+        },
+        {
+          attributes: { "channel.effect.kind": "telegram.message.sent", "vitehub.inspect.target": "workspace" },
+          name: "agent.channel.delivery",
+          sequence: 2,
+          timestamp,
+          type: "run" as const,
+        },
+      ],
+      status: "completed" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+
+    const activities = invocationActivities(invocation);
+    expect(activities.map(activity => [activity.kind, invocationActivityTitle(activity)])).toEqual([
+      ["system", "Agent configured"],
+      ["delivery", "telegram.message.sent"],
+    ]);
+
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    expect(wrapper.get('[data-kind="system"] .vh-invocation-event__suffix').text()).toBe("claude-sonnet-4-5 · 2 capabilities · 1 tool");
+    await wrapper.get('[data-kind="system"] .vh-invocation-event__summary').trigger("click");
+    await wrapper.get('[data-kind="delivery"] .vh-invocation-event__summary').trigger("keydown", { key: " " });
+    expect(wrapper.emitted("inspect")).toEqual([["agent"], ["workspace"]]);
+  });
+
+  it("collapses long user messages until requested", async () => {
+    const timestamp = "2026-08-22T00:00:00.000Z";
+    const invocation = {
+      createdAt: timestamp,
+      id: "long-message",
+      observations: [{
+        attributes: { "message.content": "x".repeat(721), "message.id": "user", "message.role": "user" },
+        name: "agent.message",
+        sequence: 1,
+        timestamp,
+        type: "lifecycle" as const,
+      }],
+      status: "running" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    expect(wrapper.get(".vh-invocation-message__content").attributes("data-collapsed")).toBe("true");
+    expect(wrapper.get(".vh-invocation-message__more").text()).toBe("Read more");
+
+    await wrapper.get(".vh-invocation-message__more").trigger("click");
+    expect(wrapper.get(".vh-invocation-message__content").attributes("data-collapsed")).toBeUndefined();
+    expect(wrapper.get(".vh-invocation-message__more").text()).toBe("Show less");
+  });
+
+  it("groups terminal work while keeping external effects and the final answer visible", () => {
+    const timestamp = "2026-08-22T00:00:00.000Z";
+    const invocation = {
+      cancelledAt: "2026-08-22T00:00:05.000Z",
+      createdAt: timestamp,
+      id: "completed-thread",
+      observations: [
+        { attributes: { "message.content": "Run it.", "message.id": "user", "message.role": "user" }, name: "agent.message", sequence: 1, timestamp, type: "lifecycle" as const },
+        { attributes: { "tool.id": "shell", "tool.input": { command: "pnpm test" }, "tool.name": "shell" }, name: "agent.tool.start", sequence: 2, timestamp, type: "run" as const },
+        { attributes: { "tool.id": "shell", "tool.output": "passed", "tool.name": "shell" }, name: "agent.tool.finish", sequence: 3, timestamp, type: "run" as const },
+        { attributes: { "channel.effect.kind": "telegram.message.sent" }, name: "agent.channel.delivery", sequence: 4, timestamp, type: "run" as const },
+        { attributes: { "message.content": "Done.", "message.id": "assistant", "message.role": "assistant" }, name: "agent.message", sequence: 5, timestamp, type: "lifecycle" as const },
+      ],
+      startedAt: timestamp,
+      status: "cancelled" as const,
+      traceId: "trace",
+      updatedAt: "2026-08-22T00:00:09.000Z",
+    } satisfies AgentInvocationView;
+
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    const rows = wrapper.findAll(".vh-invocation-activities > li");
+    expect(rows.map(row => row.classes().find(name => name.startsWith("vh-invocation-") && name !== "vh-invocation-activities"))).toEqual([
+      "vh-invocation-message",
+      "vh-invocation-activity",
+      "vh-invocation-work",
+      "vh-invocation-message",
+    ]);
+    expect(rows[1]!.attributes("data-kind")).toBe("delivery");
+    expect(wrapper.get(".vh-invocation-work__title").text()).toBe("Worked for 5s");
+    expect(wrapper.get(".vh-invocation-work__activities").text()).toContain("Shell");
+    expect(rows[3]!.text()).toContain("Done.");
+  });
+
   it("keeps anonymous assistant turns on either side of a tool in sequence", () => {
     const base = { timestamp: "2026-08-22T00:00:00.000Z", type: "lifecycle" as const };
     const invocation = {


### PR DESCRIPTION
## Summary

- render Agent configuration, preparation, delivery, and system lifecycle events with inspection targets
- collapse long user prompts and completed internal work while keeping external effects and final answers visible
- restore Markdown list markers and style the new lifecycle states and disclosures
- cover lifecycle classification, keyboard inspection, prompt expansion, work grouping, and cancellation duration

## Verification

- `pnpm --filter @vite-hub/ui test -- test/invocation-ui.test.ts` — runtime and UI builds plus publint passed; 42 tests passed with no type errors
- `pnpm --filter @vite-hub/ui typecheck`
- focused `vp lint`
- `git diff --check`