### PR TITLE
fix(nuxt): keep console plugin outside build cache

### DIFF
--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -208,7 +208,7 @@ async function installConsole(nuxt: NuxtLike, projectRoot: string): Promise<void
     if (!handlers.some(candidate => candidate.route === handler.route)) handlers.push(handler)
   }
   const plugins = (nitro.plugins ??= [])
-  const plugin = join(nuxt.options.buildDir, "vitehub-console-plugin.mjs")
+  const plugin = join(projectRoot, ".vitehub/nitro/console/plugin.mjs")
   // Nitro runs in another runtime realm, so install a second journal instance over the same project SQLite file.
   await writeConsoleNitroPlugin(plugin, projectRoot)
   if (!plugins.includes(plugin)) plugins.push(plugin)

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -316,7 +316,7 @@ describe("ViteHub Nuxt integration", () => {
         { route: "/api/_vitehub/console/invocations" },
         { route: "/api/_vitehub/console/invocations/:id" },
       ],
-      plugins: ["/tmp/vitehub-nuxt/.nuxt/vitehub-console-plugin.mjs"],
+      plugins: ["/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs"],
     })
     expect(development.nuxt.options.devServerHandlers).toEqual([
       { handler: existingConsoleHandler, route: "/api/_vitehub/console" },
@@ -324,7 +324,7 @@ describe("ViteHub Nuxt integration", () => {
     expect(development.nuxt.options.vite.plugins).toContainEqual(
       expect.objectContaining({ name: "vite-hub/console-invocation-root" }),
     )
-    await expect(readFile("/tmp/vitehub-nuxt/.nuxt/vitehub-console-plugin.mjs", "utf8")).resolves.toContain(
+    await expect(readFile("/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs", "utf8")).resolves.toContain(
       `installConsoleInvocations("/tmp/vitehub-nuxt")`,
     )
 
@@ -343,7 +343,7 @@ describe("ViteHub Nuxt integration", () => {
         { route: "/api/_vitehub/console/invocations" },
         { route: "/api/_vitehub/console/invocations/:id" },
       ],
-      plugins: ["/tmp/vitehub-nuxt/.nuxt/vitehub-console-plugin.mjs"],
+      plugins: ["/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs"],
     })
     expect(production.nuxt.options.devServerHandlers).toBeUndefined()
     expect(production.nuxt.options.vite.plugins).toContainEqual(


### PR DESCRIPTION
Nuxt build caching can change `nuxt.options.buildDir` after ViteHub creates the console Nitro plugin, leaving Nitro configured with a path that no longer exists.

Generate the plugin under the stable project `.vitehub` directory instead. This matches the standalone Vite console integration and keeps development and production behavior unchanged.

## Verification

- `pnpm --filter vite-hub typecheck`
- `pnpm --filter vite-hub exec vp test -- test/nuxt.test.ts` (50 tests)