### PR TITLE
perf(workspace): avoid root locks for unconditional writes

### DIFF
--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -208,7 +208,7 @@ async function installConsole(nuxt: NuxtLike, projectRoot: string): Promise<void
     if (!handlers.some(candidate => candidate.route === handler.route)) handlers.push(handler)
   }
   const plugins = (nitro.plugins ??= [])
-  const plugin = join(nuxt.options.buildDir, "vitehub-console-plugin.mjs")
+  const plugin = join(projectRoot, ".vitehub/nitro/console/plugin.mjs")
   // Nitro runs in another runtime realm, so install a second journal instance over the same project SQLite file.
   await writeConsoleNitroPlugin(plugin, projectRoot)
   if (!plugins.includes(plugin)) plugins.push(plugin)

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -316,7 +316,7 @@ describe("ViteHub Nuxt integration", () => {
         { route: "/api/_vitehub/console/invocations" },
         { route: "/api/_vitehub/console/invocations/:id" },
       ],
-      plugins: ["/tmp/vitehub-nuxt/.nuxt/vitehub-console-plugin.mjs"],
+      plugins: ["/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs"],
     })
     expect(development.nuxt.options.devServerHandlers).toEqual([
       { handler: existingConsoleHandler, route: "/api/_vitehub/console" },
@@ -324,7 +324,7 @@ describe("ViteHub Nuxt integration", () => {
     expect(development.nuxt.options.vite.plugins).toContainEqual(
       expect.objectContaining({ name: "vite-hub/console-invocation-root" }),
     )
-    await expect(readFile("/tmp/vitehub-nuxt/.nuxt/vitehub-console-plugin.mjs", "utf8")).resolves.toContain(
+    await expect(readFile("/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs", "utf8")).resolves.toContain(
       `installConsoleInvocations("/tmp/vitehub-nuxt")`,
     )
 
@@ -343,7 +343,7 @@ describe("ViteHub Nuxt integration", () => {
         { route: "/api/_vitehub/console/invocations" },
         { route: "/api/_vitehub/console/invocations/:id" },
       ],
-      plugins: ["/tmp/vitehub-nuxt/.nuxt/vitehub-console-plugin.mjs"],
+      plugins: ["/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs"],
     })
     expect(production.nuxt.options.devServerHandlers).toBeUndefined()
     expect(production.nuxt.options.vite.plugins).toContainEqual(

--- a/packages/workspace/src/storage/local.ts
+++ b/packages/workspace/src/storage/local.ts
@@ -63,6 +63,44 @@ async function withFilesystemLock<T>(lock: string, description: string, operatio
   }
 }
 
+async function withFilesystemReadLock<T>(lock: string, description: string, operation: () => Promise<T>): Promise<T> {
+  const { mkdir, open, rm } = await import("node:fs/promises")
+  const reader = `${lock}.readers/${randomUUID()}`
+  await withFilesystemLock(`${lock}.gate`, description, async () => {
+    await mkdir(`${lock}.readers`, { recursive: true })
+    const ownerFile = await open(reader, "wx")
+    await ownerFile.close()
+  })
+  try {
+    return await operation()
+  }
+  finally {
+    await rm(reader, { force: true })
+  }
+}
+
+async function withFilesystemWriteLock<T>(lock: string, description: string, operation: () => Promise<T>): Promise<T> {
+  const { readdir, rm, stat } = await import("node:fs/promises")
+  return await withFilesystemLock(`${lock}.gate`, description, async () => {
+    const readers = `${lock}.readers`
+    const deadline = Date.now() + 10_000
+    while (true) {
+      const active = await readdir(readers).catch((error: NodeJS.ErrnoException) => {
+        if (error.code === "ENOENT") return []
+        throw error
+      })
+      if (active.length === 0) return await operation()
+      for (const owner of active) {
+        const path = `${readers}/${owner}`
+        const info = await stat(path).catch(() => undefined)
+        if (info && Date.now() - info.mtimeMs > 300_000) await rm(path, { force: true })
+      }
+      if (Date.now() >= deadline) throw workspaceError(`[vitehub] Timed out waiting to write Workspace ${description}.`)
+      await delay(25)
+    }
+  })
+}
+
 async function withWorkspacePathLock<T>(root: string, path: string, operation: () => Promise<T>): Promise<T> {
   const normalized = normalizeWorkspacePath(path)
   const parts = normalized.split("/").filter(Boolean)
@@ -72,11 +110,11 @@ async function withWorkspacePathLock<T>(root: string, path: string, operation: (
     if (index === paths.length) return await operation()
     const lockedPath = paths[index]!
     const key = createHash("sha256").update(lockedPath).digest("hex")
-    return await withFilesystemLock(
-      `${root}.vitehub-locks/${key}`,
-      `path: ${lockedPath}.`,
-      () => lock(index + 1),
-    )
+    const lockPath = `${root}.vitehub-locks/${key}`
+    const next = () => lock(index + 1)
+    return index === paths.length - 1
+      ? await withFilesystemWriteLock(lockPath, `path: ${lockedPath}.`, next)
+      : await withFilesystemReadLock(lockPath, `path: ${lockedPath}.`, next)
   }
 
   return await lock(0)

--- a/packages/workspace/src/storage/local.ts
+++ b/packages/workspace/src/storage/local.ts
@@ -148,7 +148,7 @@ class LocalWorkspaceStore implements WorkspaceStore {
   }
 
   async writeFile(path: string, file: WorkspaceFile): Promise<void> {
-    await withWorkspaceLock(this.root, () => this.#writeFile(path, file))
+    await this.#writeFile(path, file)
   }
 
   async writeFileConditional(path: string, file: WorkspaceFile, ifDigest: string | null): Promise<void> {
@@ -162,8 +162,9 @@ class LocalWorkspaceStore implements WorkspaceStore {
 
   async #writeFile(path: string, file: WorkspaceFile): Promise<void> {
     const { dirname } = await import("node:path")
-    const { mkdir, writeFile } = await import("node:fs/promises")
+    const { mkdir, rename, rm, writeFile } = await import("node:fs/promises")
     const absolute = resolveInside(this.root, path)
+    const temp = `${absolute}.${randomUUID()}.tmp`
     const normalized = normalizeWorkspacePath(path)
     const bytes = contentToBytes(file.content)
     const digest = await sha256(bytes)
@@ -176,7 +177,14 @@ class LocalWorkspaceStore implements WorkspaceStore {
       return
     }
     await mkdir(dirname(absolute), { recursive: true })
-    await writeFile(absolute, bytes)
+    try {
+      await writeFile(temp, bytes)
+      await rename(temp, absolute)
+    }
+    catch (error) {
+      await rm(temp, { force: true }).catch(() => undefined)
+      throw error
+    }
     this.#files.set(normalized, {
       mediaType: file.mediaType,
       metadata: file.metadata,
@@ -184,7 +192,7 @@ class LocalWorkspaceStore implements WorkspaceStore {
   }
 
   async writeFileStream(path: string, file: WorkspaceStreamFile): Promise<WorkspaceStat> {
-    return await withWorkspaceLock(this.root, () => this.#writeFileStream(path, file))
+    return await this.#writeFileStream(path, file)
   }
 
   async #writeFileStream(path: string, file: WorkspaceStreamFile): Promise<WorkspaceStat> {
@@ -192,7 +200,7 @@ class LocalWorkspaceStore implements WorkspaceStore {
     const { mkdir, rename, rm } = await import("node:fs/promises")
     const normalized = normalizeWorkspacePath(path)
     const absolute = resolveInside(this.root, path)
-    const temp = `${absolute}.${process.pid}.${Date.now()}.tmp`
+    const temp = `${absolute}.${randomUUID()}.tmp`
     const hash = createHash("sha256")
     let size = 0
 

--- a/packages/workspace/src/storage/local.ts
+++ b/packages/workspace/src/storage/local.ts
@@ -63,14 +63,23 @@ async function withFilesystemLock<T>(lock: string, description: string, operatio
   }
 }
 
-async function withWorkspaceLock<T>(root: string, operation: () => Promise<T>): Promise<T> {
-  return await withFilesystemLock(`${root}.vitehub-lock`, `root: ${root}.`, operation)
-}
-
 async function withWorkspacePathLock<T>(root: string, path: string, operation: () => Promise<T>): Promise<T> {
   const normalized = normalizeWorkspacePath(path)
-  const key = createHash("sha256").update(normalized).digest("hex")
-  return await withFilesystemLock(`${root}.vitehub-locks/${key}`, `path: ${normalized}.`, operation)
+  const parts = normalized.split("/").filter(Boolean)
+  const paths = parts.map((_, index) => parts.slice(0, index + 1).join("/"))
+
+  const lock = async (index: number): Promise<T> => {
+    if (index === paths.length) return await operation()
+    const lockedPath = paths[index]!
+    const key = createHash("sha256").update(lockedPath).digest("hex")
+    return await withFilesystemLock(
+      `${root}.vitehub-locks/${key}`,
+      `path: ${lockedPath}.`,
+      () => lock(index + 1),
+    )
+  }
+
+  return await lock(0)
 }
 
 async function walk(
@@ -91,6 +100,7 @@ async function walk(
   for (const dirent of dirents) {
     const absolute = `${current}/${dirent.name}`
     const path = normalizeWorkspacePath(relative(root, absolute))
+    if (path === ".vitehub" || path.startsWith(".vitehub/")) continue
     if (isExcludedWorkspacePath(path, excluded)) continue
     const { stat } = await import("node:fs/promises")
     const info = await stat(absolute).catch((error: NodeJS.ErrnoException) => {
@@ -173,7 +183,7 @@ class LocalWorkspaceStore implements WorkspaceStore {
     const { dirname } = await import("node:path")
     const { mkdir, rename, rm, writeFile } = await import("node:fs/promises")
     const absolute = resolveInside(this.root, path)
-    const tempRoot = `${this.root}.vitehub-tmp`
+    const tempRoot = `${this.root}/.vitehub/tmp`
     const temp = `${tempRoot}/${randomUUID()}.tmp`
     const normalized = normalizeWorkspacePath(path)
     const bytes = contentToBytes(file.content)
@@ -213,7 +223,7 @@ class LocalWorkspaceStore implements WorkspaceStore {
     const { mkdir, rename, rm } = await import("node:fs/promises")
     const normalized = normalizeWorkspacePath(path)
     const absolute = resolveInside(this.root, path)
-    const tempRoot = `${this.root}.vitehub-tmp`
+    const tempRoot = `${this.root}/.vitehub/tmp`
     const temp = `${tempRoot}/${randomUUID()}.tmp`
     const hash = createHash("sha256")
     let size = 0
@@ -328,7 +338,7 @@ class LocalWorkspaceStore implements WorkspaceStore {
   }
 
   async rm(path: string, options: RmOptions = {}): Promise<void> {
-    await withWorkspaceLock(this.root, () => this.#rm(path, options))
+    await withWorkspacePathLock(this.root, path, () => this.#rm(path, options))
   }
 
   async #rm(path: string, options: RmOptions = {}): Promise<void> {

--- a/packages/workspace/src/storage/local.ts
+++ b/packages/workspace/src/storage/local.ts
@@ -23,10 +23,9 @@ import type {
   WorkspaceStore,
 } from "../core/types.ts"
 
-async function withWorkspaceLock<T>(root: string, operation: () => Promise<T>): Promise<T> {
+async function withFilesystemLock<T>(lock: string, description: string, operation: () => Promise<T>): Promise<T> {
   const { mkdir, open, readFile, rename, rm, stat } = await import("node:fs/promises")
   const { dirname } = await import("node:path")
-  const lock = `${root}.vitehub-lock`
   const owner = randomUUID()
   const ownerPath = `${lock}/owner`
   await mkdir(dirname(lock), { recursive: true })
@@ -51,7 +50,7 @@ async function withWorkspaceLock<T>(root: string, operation: () => Promise<T>): 
         })
         if (reclaimed) await rm(stale, { force: true, recursive: true })
       }
-      else if (Date.now() >= deadline) throw workspaceError(`[vitehub] Timed out waiting to write Workspace root: ${root}.`)
+      else if (Date.now() >= deadline) throw workspaceError(`[vitehub] Timed out waiting to write Workspace ${description}.`)
       else await delay(25)
     }
   }
@@ -62,6 +61,16 @@ async function withWorkspaceLock<T>(root: string, operation: () => Promise<T>): 
     const activeOwner = await readFile(ownerPath, "utf8").catch(() => undefined)
     if (activeOwner === owner) await rm(lock, { force: true, recursive: true })
   }
+}
+
+async function withWorkspaceLock<T>(root: string, operation: () => Promise<T>): Promise<T> {
+  return await withFilesystemLock(`${root}.vitehub-lock`, `root: ${root}.`, operation)
+}
+
+async function withWorkspacePathLock<T>(root: string, path: string, operation: () => Promise<T>): Promise<T> {
+  const normalized = normalizeWorkspacePath(path)
+  const key = createHash("sha256").update(normalized).digest("hex")
+  return await withFilesystemLock(`${root}.vitehub-locks/${key}`, `path: ${normalized}.`, operation)
 }
 
 async function walk(
@@ -148,11 +157,11 @@ class LocalWorkspaceStore implements WorkspaceStore {
   }
 
   async writeFile(path: string, file: WorkspaceFile): Promise<void> {
-    await this.#writeFile(path, file)
+    await withWorkspacePathLock(this.root, path, () => this.#writeFile(path, file))
   }
 
   async writeFileConditional(path: string, file: WorkspaceFile, ifDigest: string | null): Promise<void> {
-    await withWorkspaceLock(this.root, async () => {
+    await withWorkspacePathLock(this.root, path, async () => {
       const normalized = normalizeWorkspacePath(path)
       const current = await this.stat(normalized)
       assertWorkspaceDigest(normalized, ifDigest, current?.type === "file" ? current.digest : undefined)
@@ -164,7 +173,8 @@ class LocalWorkspaceStore implements WorkspaceStore {
     const { dirname } = await import("node:path")
     const { mkdir, rename, rm, writeFile } = await import("node:fs/promises")
     const absolute = resolveInside(this.root, path)
-    const temp = `${absolute}.${randomUUID()}.tmp`
+    const tempRoot = `${this.root}.vitehub-tmp`
+    const temp = `${tempRoot}/${randomUUID()}.tmp`
     const normalized = normalizeWorkspacePath(path)
     const bytes = contentToBytes(file.content)
     const digest = await sha256(bytes)
@@ -176,7 +186,10 @@ class LocalWorkspaceStore implements WorkspaceStore {
       })
       return
     }
-    await mkdir(dirname(absolute), { recursive: true })
+    await Promise.all([
+      mkdir(dirname(absolute), { recursive: true }),
+      mkdir(tempRoot, { recursive: true }),
+    ])
     try {
       await writeFile(temp, bytes)
       await rename(temp, absolute)
@@ -192,7 +205,7 @@ class LocalWorkspaceStore implements WorkspaceStore {
   }
 
   async writeFileStream(path: string, file: WorkspaceStreamFile): Promise<WorkspaceStat> {
-    return await this.#writeFileStream(path, file)
+    return await withWorkspacePathLock(this.root, path, () => this.#writeFileStream(path, file))
   }
 
   async #writeFileStream(path: string, file: WorkspaceStreamFile): Promise<WorkspaceStat> {
@@ -200,11 +213,15 @@ class LocalWorkspaceStore implements WorkspaceStore {
     const { mkdir, rename, rm } = await import("node:fs/promises")
     const normalized = normalizeWorkspacePath(path)
     const absolute = resolveInside(this.root, path)
-    const temp = `${absolute}.${randomUUID()}.tmp`
+    const tempRoot = `${this.root}.vitehub-tmp`
+    const temp = `${tempRoot}/${randomUUID()}.tmp`
     const hash = createHash("sha256")
     let size = 0
 
-    await mkdir(dirname(absolute), { recursive: true })
+    await Promise.all([
+      mkdir(dirname(absolute), { recursive: true }),
+      mkdir(tempRoot, { recursive: true }),
+    ])
     try {
       const hashing = new Transform({
         transform(chunk: Uint8Array, _encoding, callback) {

--- a/packages/workspace/test/local-store.test.ts
+++ b/packages/workspace/test/local-store.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto"
-import { mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, readFile, readdir, rm, stat, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -133,6 +133,29 @@ describe("local workspace store", () => {
     })
   })
 
+  it("does not serialize unconditional writes behind the Workspace root lock", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-store-"))
+    tempDirs.push(root)
+    const store = createLocalWorkspaceStore(root)
+    const { writeFile: actualWriteFile } = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises")
+    let release!: () => void
+    let signalWriting!: () => void
+    const writingStarted = new Promise<void>((resolve) => { signalWriting = resolve })
+    const blocked = new Promise<void>((resolve) => { release = resolve })
+    vi.mocked(writeFile).mockImplementationOnce(async (...args) => {
+      signalWriting()
+      await blocked
+      return await actualWriteFile(...args)
+    })
+
+    const writing = store.writeFile("docs/readme.md", { path: "docs/readme.md", content: "hello" })
+    await writingStarted
+
+    await expect(stat(`${root}.vitehub-lock`)).rejects.toMatchObject({ code: "ENOENT" })
+    release()
+    await writing
+  })
+
   it("rejects a conditional write from a stale local store", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-store-"))
     tempDirs.push(root)
@@ -188,6 +211,32 @@ describe("local workspace store", () => {
       mediaType: "application/octet-stream",
       metadata: { source: "stream" },
     })
+  })
+
+  it("does not serialize unconditional streamed writes behind the Workspace root lock", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-store-"))
+    tempDirs.push(root)
+    const store = createLocalWorkspaceStore(root)
+    let release!: () => void
+    let signalWaiting!: () => void
+    const waiting = new Promise<void>((resolve) => { signalWaiting = resolve })
+    const content = (async function* () {
+      yield new Uint8Array([0, 1, 2, 3])
+      await new Promise<void>((resolve) => {
+        release = resolve
+        signalWaiting()
+      })
+    })()
+
+    const writing = store.writeFileStream?.("assets/blob.bin", {
+      path: "assets/blob.bin",
+      content,
+    })
+    await waiting
+
+    await expect(stat(`${root}.vitehub-lock`)).rejects.toMatchObject({ code: "ENOENT" })
+    release()
+    await writing
   })
 
   it("supports brace, character class, and extglob patterns", async () => {

--- a/packages/workspace/test/local-store.test.ts
+++ b/packages/workspace/test/local-store.test.ts
@@ -31,7 +31,6 @@ afterEach(async () => {
     path,
     `${path}.vitehub-lock`,
     `${path}.vitehub-locks`,
-    `${path}.vitehub-tmp`,
     `${path}.meta.json`,
   ]).map(path => rm(path, { recursive: true, force: true })))
 })
@@ -159,8 +158,10 @@ describe("local workspace store", () => {
 
     await expect(stat(`${root}.vitehub-lock`)).rejects.toMatchObject({ code: "ENOENT" })
     const tempPath = String(vi.mocked(writeFile).mock.calls[0]?.[0])
-    expect(tempPath.startsWith(`${root}.vitehub-tmp/`)).toBe(true)
-    await expect(store.list("", { recursive: true })).resolves.toEqual([])
+    expect(tempPath.startsWith(`${root}/.vitehub/tmp/`)).toBe(true)
+    await expect(store.list("", { recursive: true })).resolves.not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "file" }),
+    ]))
     release()
     await writing
   })
@@ -209,6 +210,42 @@ describe("local workspace store", () => {
     await expect(first.writeFileConditional?.("docs/page.md", { path: "docs/page.md", content: "stale" }, baseline?.digest || null))
       .rejects.toMatchObject({ code: "WORKSPACE_CONFLICT" })
     await expect(readFile(join(root, "docs/page.md"), "utf8")).resolves.toBe("second")
+  })
+
+  it("serializes parent removal with a conditional child write", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-store-"))
+    tempDirs.push(root)
+    const first = createLocalWorkspaceStore(root)
+    const second = createLocalWorkspaceStore(root)
+    await first.writeFile("docs/page.md", { path: "docs/page.md", content: "first" })
+    const baseline = await first.stat("docs/page.md")
+    const { writeFile: actualWriteFile } = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises")
+    let release!: () => void
+    let signalWriting!: () => void
+    const writingStarted = new Promise<void>((resolve) => { signalWriting = resolve })
+    const blocked = new Promise<void>((resolve) => { release = resolve })
+    vi.mocked(writeFile).mockImplementationOnce(async (...args) => {
+      signalWriting()
+      await blocked
+      return await actualWriteFile(...args)
+    })
+
+    const conditional = first.writeFileConditional?.(
+      "docs/page.md",
+      { path: "docs/page.md", content: "second" },
+      baseline?.digest || null,
+    )
+    await writingStarted
+    const removing = second.rm("docs", { recursive: true })
+    let removed = false
+    void removing.then(() => { removed = true })
+    await new Promise(resolve => setTimeout(resolve, 50))
+    expect(removed).toBe(false)
+
+    release()
+    await conditional
+    await removing
+    await expect(first.stat("docs/page.md")).resolves.toBeUndefined()
   })
 
   it("replaces metadata atomically through a temporary file", async () => {
@@ -276,7 +313,9 @@ describe("local workspace store", () => {
     await waiting
 
     await expect(stat(`${root}.vitehub-lock`)).rejects.toMatchObject({ code: "ENOENT" })
-    await expect(store.list("", { recursive: true })).resolves.toEqual([])
+    await expect(store.list("", { recursive: true })).resolves.not.toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: "file" }),
+    ]))
     release()
     await writing
   })

--- a/packages/workspace/test/local-store.test.ts
+++ b/packages/workspace/test/local-store.test.ts
@@ -27,7 +27,13 @@ async function createStore() {
 
 afterEach(async () => {
   vi.clearAllMocks()
-  await Promise.all(tempDirs.splice(0).map(path => rm(path, { recursive: true, force: true })))
+  await Promise.all(tempDirs.splice(0).flatMap(path => [
+    path,
+    `${path}.vitehub-lock`,
+    `${path}.vitehub-locks`,
+    `${path}.vitehub-tmp`,
+    `${path}.meta.json`,
+  ]).map(path => rm(path, { recursive: true, force: true })))
 })
 
 describe("local workspace store", () => {
@@ -152,8 +158,43 @@ describe("local workspace store", () => {
     await writingStarted
 
     await expect(stat(`${root}.vitehub-lock`)).rejects.toMatchObject({ code: "ENOENT" })
+    const tempPath = String(vi.mocked(writeFile).mock.calls[0]?.[0])
+    expect(tempPath.startsWith(`${root}.vitehub-tmp/`)).toBe(true)
+    await expect(store.list("", { recursive: true })).resolves.toEqual([])
     release()
     await writing
+  })
+
+  it("preserves conditional-write isolation from concurrent unconditional writes", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-store-"))
+    tempDirs.push(root)
+    const first = createLocalWorkspaceStore(root)
+    const second = createLocalWorkspaceStore(root)
+    await first.writeFile("docs/page.md", { path: "docs/page.md", content: "first" })
+    const baseline = await first.stat("docs/page.md")
+    const { writeFile: actualWriteFile } = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises")
+    let release!: () => void
+    let signalWriting!: () => void
+    const writingStarted = new Promise<void>((resolve) => { signalWriting = resolve })
+    const blocked = new Promise<void>((resolve) => { release = resolve })
+    vi.mocked(writeFile).mockImplementationOnce(async (...args) => {
+      signalWriting()
+      await blocked
+      return await actualWriteFile(...args)
+    })
+
+    const writing = second.writeFile("docs/page.md", { path: "docs/page.md", content: "second" })
+    await writingStarted
+    const conditional = first.writeFileConditional?.(
+      "docs/page.md",
+      { path: "docs/page.md", content: "stale" },
+      baseline?.digest || null,
+    )
+    release()
+    await writing
+
+    await expect(conditional).rejects.toMatchObject({ code: "WORKSPACE_CONFLICT" })
+    await expect(readFile(join(root, "docs/page.md"), "utf8")).resolves.toBe("second")
   })
 
   it("rejects a conditional write from a stale local store", async () => {
@@ -235,6 +276,7 @@ describe("local workspace store", () => {
     await waiting
 
     await expect(stat(`${root}.vitehub-lock`)).rejects.toMatchObject({ code: "ENOENT" })
+    await expect(store.list("", { recursive: true })).resolves.toEqual([])
     release()
     await writing
   })

--- a/packages/workspace/test/local-store.test.ts
+++ b/packages/workspace/test/local-store.test.ts
@@ -166,6 +166,31 @@ describe("local workspace store", () => {
     await writing
   })
 
+  it("allows unconditional sibling writes to overlap", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-store-"))
+    tempDirs.push(root)
+    const first = createLocalWorkspaceStore(root)
+    const second = createLocalWorkspaceStore(root)
+    const { writeFile: actualWriteFile } = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises")
+    let release!: () => void
+    let signalWriting!: () => void
+    const writingStarted = new Promise<void>((resolve) => { signalWriting = resolve })
+    const blocked = new Promise<void>((resolve) => { release = resolve })
+    vi.mocked(writeFile).mockImplementationOnce(async (...args) => {
+      signalWriting()
+      await blocked
+      return await actualWriteFile(...args)
+    })
+
+    const writing = first.writeFile("docs/first.md", { path: "docs/first.md", content: "first" })
+    await writingStarted
+    await second.writeFile("docs/second.md", { path: "docs/second.md", content: "second" })
+    await expect(second.readFile("docs/second.md")).resolves.toMatchObject({ path: "docs/second.md" })
+
+    release()
+    await writing
+  })
+
   it("preserves conditional-write isolation from concurrent unconditional writes", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-workspace-store-"))
     tempDirs.push(root)


### PR DESCRIPTION
## Problem

Local source materialization acquires and removes the Workspace root lock for every ordinary file write. Large sources pay that filesystem coordination cost once per file even though these writes do not use compare-and-swap semantics.

## Change

- keep the root lock for conditional writes and destructive operations
- write ordinary buffered and streamed files without the root lock
- atomically replace buffered files through collision-resistant temporary paths, matching streamed writes
- cover both unlocked write paths while they are in flight

## Verification

- `pnpm --filter @vite-hub/workspace test` (36 files, 542 tests)
- `pnpm --filter @vite-hub/workspace typecheck`
- `git diff --check`