### PR TITLE
feat(ui): improve Agent Invocation sessions

### DIFF
--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -420,6 +420,7 @@ function groupedActivityTitle(activity: InvocationActivity): string {
 }
 
 function renderGroupedActivityIcon(activity: InvocationActivity) {
+  if (activity.status === "failed") return renderActivityIcon(activity);
   if (stringAttribute(activity.attributes, "github.label.name")) return renderNamedActivityIcon("label");
   const delivery = stringAttribute(activity.attributes, "channel.effect.kind")?.toLocaleLowerCase();
   if (delivery === "reaction") {
@@ -463,6 +464,9 @@ function renderActivityGroup(
           renderLabelChip(activity),
           !stringAttribute(activity.attributes, "github.label.name") && channelDeliverySummary(activity)
             ? h("code", { class: "vh-invocation-lifecycle__detail" }, channelDeliverySummary(activity))
+            : null,
+          activity.status === "failed" && activity.body
+            ? h("span", { class: "vh-invocation-lifecycle__failure" }, activity.body)
             : null,
           activity.truncated
             ? h("span", { class: "vh-invocation-event__notice" }, "Some trace content was truncated by the invocation journal.")

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -2,6 +2,7 @@ import { computed, defineComponent, h, onBeforeUnmount, ref, type PropType, Susp
 import type { AgentInvocationConfiguration, AgentInvocationView } from "../types.ts";
 import {
   agentConfigurationSummary,
+  channelDeliverySummary,
   invocationActivities,
   invocationActivityTitle,
   latestInvocationTokens,
@@ -70,16 +71,6 @@ function formatDuration(startedAt: string | undefined, completedAt: string | und
   return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
 }
 
-function configurationLabel(configuration: AgentInvocationConfiguration): string | undefined {
-  const driver = configuration.driver;
-  const model = driver?.model;
-  return [
-    driver?.kind,
-    model?.provider ?? driver?.provider,
-    model?.id,
-  ].filter(Boolean).join(" · ") || undefined;
-}
-
 function workspaceLabel(configuration: AgentInvocationConfiguration): string | undefined {
   const workspace = configuration.workspace;
   return workspace ? [workspace.name, workspace.mode].filter(Boolean).join(" · ") : undefined;
@@ -99,7 +90,13 @@ function renderFolderIcon() {
   ]);
 }
 
-function renderMessage(activity: InvocationActivity, expanded: ReadonlySet<string>, toggleExpanded: (id: string) => void) {
+type InspectTarget = "agent" | "workspace";
+
+function renderMessage(
+  activity: InvocationActivity,
+  expanded: ReadonlySet<string>,
+  toggleExpanded: (id: string) => void,
+) {
   const body = activity.body ?? "";
   const collapsible = activity.role === "user" && (body.length > 720 || body.split(/\r?\n/).length > 12);
   const isExpanded = expanded.has(activity.id);
@@ -130,7 +127,22 @@ function renderMessage(activity: InvocationActivity, expanded: ReadonlySet<strin
   );
 }
 
-type ActivityIcon = "action" | "approval" | "bot" | "change" | "command" | "error" | "eye" | "folder" | "search" | "tool";
+type ActivityIcon =
+  | "action"
+  | "approval"
+  | "bot"
+  | "change"
+  | "check"
+  | "command"
+  | "error"
+  | "eye"
+  | "folder"
+  | "github"
+  | "label"
+  | "message"
+  | "pull-request"
+  | "search"
+  | "tool";
 
 function activityIcon(activity: InvocationActivity): ActivityIcon {
   if (activity.status === "failed" || activity.kind === "error") return "error";
@@ -141,8 +153,22 @@ function activityIcon(activity: InvocationActivity): ActivityIcon {
   if (name.includes("search") || name.includes("find")) return "search";
   if (activity.kind === "reasoning" || activity.kind === "model") return "bot";
   if (activity.kind === "approval") return "approval";
-  if (activity.kind === "action" || activity.kind === "delivery") return "action";
-  if (activity.kind === "preparation") return "folder";
+  if (activity.kind === "delivery") {
+    const delivery = String(activity.attributes["channel.effect.kind"] ?? "").toLocaleLowerCase();
+    if (delivery === "reaction") return "eye";
+    if (["reply", "status", "update"].includes(delivery)) return "message";
+    return "action";
+  }
+  if (activity.kind === "action") return "check";
+  if (activity.kind === "preparation") {
+    const title = invocationActivityTitle(activity).toLocaleLowerCase();
+    if (title.includes("pull request")) return "pull-request";
+    if (title.includes("github")) return "github";
+    if (title.includes("workspace")) return "folder";
+    if (title.includes("agent")) return "bot";
+    if (title.includes("prompt")) return "message";
+    return "check";
+  }
   if (activity.kind === "system") return "bot";
   return "tool";
 }
@@ -152,16 +178,29 @@ const activityIconPaths: Record<ActivityIcon, readonly string[]> = {
   approval: ["M12 3v12", "m8 11 4 4 4-4", "M5 21h14"],
   bot: ["M12 8V4H8", "M4 8h16v10H4z", "M8 12h.01", "M16 12h.01"],
   change: ["M12 20h9", "M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"],
+  check: ["m5 12 4 4L19 6"],
   command: ["m4 17 6-6-6-6", "M12 19h8"],
   error: ["M18 6 6 18", "m6 6 12 12"],
   eye: ["M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12", "M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6"],
   folder: ["M3 6.5h6l2 2h10v9.5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"],
+  github: ["M15 22v-4a4.8 4.8 0 0 0-1-3.5c3.28-.36 6.72-1.61 6.72-7A5.4 5.4 0 0 0 19.22 3.77 5.07 5.07 0 0 0 19.13.32S17.95-.04 15 1.8a13.38 13.38 0 0 0-6 0C6.05-.04 4.87.32 4.87.32A5.07 5.07 0 0 0 4.78 3.77a5.4 5.4 0 0 0-1.5 3.78c0 5.42 3.44 6.61 6.72 7A4.8 4.8 0 0 0 9 18v4", "M9 18c-4.51 2-5-2-7-2"],
+  label: ["M12.586 2.586A2 2 0 0 0 11.172 2H4a2 2 0 0 0-2 2v7.172a2 2 0 0 0 .586 1.414l8.704 8.704a2.426 2.426 0 0 0 3.42 0l4.58-4.58a2.426 2.426 0 0 0 0-3.42z", "M7.5 7.5h.01"],
+  message: ["M21 15a4 4 0 0 1-4 4H8l-5 3V7a4 4 0 0 1 4-4h10a4 4 0 0 1 4 4z"],
+  "pull-request": [
+    "M6 9v12",
+    "M18 15V8a2 2 0 0 0-2-2h-3",
+    "M6 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6",
+    "M18 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6",
+  ],
   search: ["m21 21-4.35-4.35", "M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16"],
   tool: ["M14.7 6.3a4 4 0 0 0-5-5l2.1 2.1-2.4 2.4-2.1-2.1a4 4 0 0 0 5 5L3 18l3 3 9.3-9.3a4 4 0 0 0 5-5l-2.1 2.1-2.4-2.4z"],
 };
 
 function renderActivityIcon(activity: InvocationActivity) {
-  const icon = activityIcon(activity);
+  return renderNamedActivityIcon(activityIcon(activity));
+}
+
+function renderNamedActivityIcon(icon: ActivityIcon) {
   return h("span", { class: "vh-invocation-event__icon", "data-icon": icon, "aria-hidden": "true" }, [
     h("svg", { fill: "none", viewBox: "0 0 24 24" }, activityIconPaths[icon].map(path => h("path", {
       d: path,
@@ -171,12 +210,14 @@ function renderActivityIcon(activity: InvocationActivity) {
   ]);
 }
 
-function renderEvent(activity: InvocationActivity, inspect: (target: "agent" | "workspace") => void) {
+function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarget) => void) {
   const command = activity.command;
   const tokenLabel = activity.kind === "reasoning" || activity.kind === "model"
     ? formatTokens(activity.reasoningTokens)
     : undefined;
-  const suffix = agentConfigurationSummary(activity) ?? (activity.preview ? compactCommand(activity.preview) : tokenLabel);
+  const suffix = agentConfigurationSummary(activity)
+    ?? channelDeliverySummary(activity)
+    ?? (activity.preview ? compactCommand(activity.preview) : tokenLabel);
   const hasDetails = activity.patches.length > 0 || Boolean(command || activity.body || activity.truncated);
   const inspectTarget = activity.attributes["vitehub.inspect.target"] ?? (activity.name === "vitehub.agent.configured" ? "agent" : undefined);
   const inspectable = inspectTarget === "agent" || inspectTarget === "workspace";
@@ -205,8 +246,9 @@ function renderEvent(activity: InvocationActivity, inspect: (target: "agent" | "
   ]);
   return h("li", {
     class: "vh-invocation-activity",
-    "data-kind": activity.kind,
+    "data-activity-id": activity.id,
     "data-inspectable": inspectable ? "true" : undefined,
+    "data-kind": activity.kind,
     "data-status": activity.status,
     key: activity.id,
   }, [
@@ -239,6 +281,186 @@ function renderEvent(activity: InvocationActivity, inspect: (target: "agent" | "
   ]);
 }
 
+function activityDetail(activity: InvocationActivity): string | undefined {
+  const value = activity.attributes["vitehub.activity.detail"];
+  return activity.preview ?? (typeof value === "string" && value.trim() ? value.trim() : undefined);
+}
+
+function githubUrl(invocation: AgentInvocationView): string | undefined {
+  const value = invocation.annotations?.["github.url"];
+  return typeof value === "string" && value ? value : undefined;
+}
+
+function renderPreparationAction(activity: InvocationActivity, inspect: (target: InspectTarget) => void) {
+  const target = activity.attributes["vitehub.inspect.target"];
+  if (target !== "workspace" && target !== "agent") return;
+  return h("button", {
+    "aria-label": target === "workspace" ? "Open Workspace" : "Open Invocation details",
+    class: "vh-invocation-preparation__action",
+    onClick: () => inspect(target),
+    type: "button",
+  }, [renderNamedActivityIcon(target === "workspace" ? "folder" : "bot")]);
+}
+
+function renderPreparationContext(invocation: AgentInvocationView, url: string | undefined) {
+  const repository = invocation.annotations?.["github.repository"];
+  const pullRequest = invocation.annotations?.["github.pullRequest"];
+  if (typeof repository !== "string" || (typeof pullRequest !== "number" && typeof pullRequest !== "string")) {
+    return h("code", invocationContext(invocation));
+  }
+  return h("span", { class: "vh-invocation-preparation__context" }, [
+    h("code", repository),
+    h("span", { "aria-hidden": "true" }, "·"),
+    url
+      ? h("a", {
+          href: url,
+          onClick: (event: MouseEvent) => event.stopPropagation(),
+          rel: "noreferrer",
+          target: "_blank",
+        }, `PR #${pullRequest}`)
+      : h("code", `PR #${pullRequest}`),
+  ]);
+}
+
+function renderPreparationDetail(activity: InvocationActivity, url: string | undefined) {
+  const detail = activityDetail(activity);
+  if (!detail) return;
+  const compact = compactCommand(detail);
+  if (!url || !invocationActivityTitle(activity).toLocaleLowerCase().includes("pull request")) {
+    return h("code", compact);
+  }
+  const match = compact.match(/^(.*?)\s*·\s*(PR #\d+)$/);
+  if (!match) return h("code", compact);
+  return h("span", { class: "vh-invocation-preparation__context" }, [
+    h("code", match[1]),
+    h("span", { "aria-hidden": "true" }, "·"),
+    h("a", { href: url, rel: "noreferrer", target: "_blank" }, match[2]),
+  ]);
+}
+
+function renderChevronDown(className: string) {
+  return h("svg", { "aria-hidden": "true", class: className, fill: "none", viewBox: "0 0 24 24" }, [
+    h("path", { d: "m6 9 6 6 6-6", "stroke-linecap": "round", "stroke-linejoin": "round" }),
+  ]);
+}
+
+function renderPreparationGroup(
+  activities: readonly InvocationActivity[],
+  invocation: AgentInvocationView,
+  inspect: (target: InspectTarget) => void,
+) {
+  const url = githubUrl(invocation);
+  return h("li", {
+    class: "vh-invocation-preparation",
+    key: `preparation:${activities[0]?.id}`,
+  }, [
+    h("details", { class: "vh-invocation-preparation__details" }, [
+      h("summary", { class: "vh-invocation-preparation__summary" }, [
+        renderNamedActivityIcon("check"),
+        h("strong", "Session prepared"),
+        renderPreparationContext(invocation, url),
+        h("small", `${activities.length} steps`),
+        renderChevronDown("vh-invocation-preparation__disclosure"),
+      ]),
+      h("ol", { class: "vh-invocation-preparation__steps" }, activities.map(activity => h("li", {
+        "data-activity-id": activity.id,
+        "data-kind": "preparation",
+        key: activity.id,
+      }, [
+        renderActivityIcon(activity),
+        h("strong", invocationActivityTitle(activity)),
+        renderPreparationDetail(activity, url),
+        renderPreparationAction(activity, inspect),
+      ]))),
+    ]),
+  ]);
+}
+
+function nonEmptyAttribute(activity: InvocationActivity, key: string): string | undefined {
+  const value = activity.attributes[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function activityGroup(activity: InvocationActivity | undefined): string | undefined {
+  return activity ? nonEmptyAttribute(activity, "vitehub.activity.group") : undefined;
+}
+
+function labelStyle(color: string | undefined): Record<string, string> {
+  const normalized = color?.replace(/^#/, "");
+  if (!normalized || !/^[\da-f]{6}$/i.test(normalized)) return {};
+  const red = Number.parseInt(normalized.slice(0, 2), 16);
+  const green = Number.parseInt(normalized.slice(2, 4), 16);
+  const blue = Number.parseInt(normalized.slice(4, 6), 16);
+  const luminance = (red * 299 + green * 587 + blue * 114) / 1_000;
+  return {
+    "--vh-invocation-label-bg": `#${normalized}`,
+    "--vh-invocation-label-fg": luminance > 150 ? "#1f2328" : "#ffffff",
+  };
+}
+
+function renderLabelChip(activity: InvocationActivity) {
+  const name = nonEmptyAttribute(activity, "github.label.name");
+  if (!name) return;
+  return h("span", {
+    class: "vh-invocation-lifecycle__label",
+    "data-operation": nonEmptyAttribute(activity, "github.label.operation"),
+    style: labelStyle(nonEmptyAttribute(activity, "github.label.color")),
+  }, name);
+}
+
+function groupedActivityTitle(activity: InvocationActivity): string {
+  if (!nonEmptyAttribute(activity, "github.label.name")) return invocationActivityTitle(activity);
+  const operation = nonEmptyAttribute(activity, "github.label.operation")?.toLocaleLowerCase();
+  if (operation === "add" || operation === "added") return "Added label";
+  if (operation === "remove" || operation === "removed") return "Removed label";
+  return "Updated label";
+}
+
+function renderGroupedActivityIcon(activity: InvocationActivity) {
+  if (nonEmptyAttribute(activity, "github.label.name")) return renderNamedActivityIcon("label");
+  const delivery = nonEmptyAttribute(activity, "channel.effect.kind")?.toLocaleLowerCase();
+  if (delivery === "reaction") {
+    return h("span", { "aria-label": "eyes", class: "vh-invocation-lifecycle__emoji", role: "img" }, "👀");
+  }
+  if (["reply", "status", "update"].includes(delivery ?? "")) return renderNamedActivityIcon("message");
+  return renderActivityIcon(activity);
+}
+
+function renderActivityGroup(
+  group: string,
+  activities: readonly InvocationActivity[],
+  inspect: (target: InspectTarget) => void,
+) {
+  return h("li", {
+    class: "vh-invocation-lifecycle",
+    "data-activity-group": group,
+    key: `activity-group:${group}:${activities[0]?.id}`,
+  }, [
+    h("ol", { "aria-label": group, class: "vh-invocation-lifecycle__rows" }, activities.map(activity => {
+      const target = activity.attributes["vitehub.inspect.target"];
+      const inspectable = target === "agent" || target === "workspace";
+      return h("li", {
+        "data-activity-id": activity.id,
+        "data-kind": activity.kind,
+        "data-status": activity.status,
+        key: activity.id,
+      }, [
+        h(inspectable ? "button" : "div", {
+          class: "vh-invocation-lifecycle__row",
+          ...(inspectable ? { onClick: () => inspect(target), type: "button" } : {}),
+        }, [
+          renderGroupedActivityIcon(activity),
+          h("span", { class: "vh-invocation-lifecycle__title" }, groupedActivityTitle(activity)),
+          renderLabelChip(activity),
+          !nonEmptyAttribute(activity, "github.label.name") && channelDeliverySummary(activity)
+            ? h("code", { class: "vh-invocation-lifecycle__detail" }, channelDeliverySummary(activity))
+            : null,
+        ]),
+      ]);
+    })),
+  ]);
+}
+
 function inspectorSection(title: string, body: ReturnType<typeof h> | null) {
   return body ? h("section", [h("h4", title), body]) : null;
 }
@@ -258,35 +480,50 @@ function copyIcon(copied: boolean) {
 }
 
 function renderConfiguration(configuration: AgentInvocationConfiguration) {
-  const driver = configurationLabel(configuration);
   const workspace = workspaceLabel(configuration);
+  const disclosures = [
+    configuration.instructions?.length
+      ? h("details", { class: "vh-invocation-inspector__disclosure" }, [
+          h("summary", [h("span", "System instructions"), h("small", `${configuration.instructions.length} block${configuration.instructions.length === 1 ? "" : "s"}`)]),
+          h("pre", { class: "vh-invocation-inspector__instructions" }, configuration.instructions.join("\n\n")),
+        ])
+      : null,
+    configuration.workspace?.sources?.length
+      ? h("details", { class: "vh-invocation-inspector__disclosure" }, [
+          h("summary", [h("span", "Workspace sources"), h("small", `${configuration.workspace.sources.length}`)]),
+          h("ul", { class: "vh-invocation-inspector__items" }, configuration.workspace.sources.map(source =>
+            h("li", [h("span", { "aria-hidden": "true" }, "↳"), h("code", source)]),
+          )),
+        ])
+      : null,
+    configuration.capabilities?.length
+      ? h("details", { class: "vh-invocation-inspector__disclosure" }, [
+          h("summary", [h("span", "Capabilities"), h("small", `${configuration.capabilities.length}`)]),
+          h("div", { class: "vh-invocation-inspector__stack" }, configuration.capabilities.map(capability =>
+            h("details", { class: "vh-invocation-inspector__disclosure" }, [
+              h("summary", [h("span", capability.id), capability.metadata ? h("small", "Metadata") : null]),
+              capability.metadata ? h("pre", JSON.stringify(capability.metadata, null, 2)) : h("p", "No additional metadata."),
+            ]),
+          )),
+        ])
+      : null,
+    configuration.tools?.length
+      ? h("details", { class: "vh-invocation-inspector__disclosure" }, [
+          h("summary", [h("span", "Tools"), h("small", `${configuration.tools.length}`)]),
+          h("ul", { class: "vh-invocation-inspector__items" }, configuration.tools.map(tool =>
+            h("li", [h("span", { "aria-hidden": "true" }, "⌁"), h("code", tool.name)]),
+          )),
+        ])
+      : null,
+  ].filter(item => item !== null);
   return [
     configuration.truncated
       ? inspectorSection("Configuration notice", h("p", "Some configuration values were truncated by the invocation journal."))
       : null,
-    inspectorSection("Environment", h("dl", { class: "vh-invocation-inspector__list" }, [
-      inspectorRow("Driver", driver),
-      inspectorRow("Runtime", configuration.runtime?.name),
-      inspectorRow("Workspace", workspace),
+    inspectorSection("Agent definition", h("div", { class: "vh-invocation-inspector__configuration" }, [
+      workspace ? h("dl", { class: "vh-invocation-inspector__list" }, [inspectorRow("Workspace", workspace)]) : null,
+      ...disclosures,
     ])),
-    configuration.workspace?.sources?.length
-      ? inspectorSection("Sources", h("ul", { class: "vh-invocation-inspector__items" }, configuration.workspace.sources.map(source => h("li", [h("span", { "aria-hidden": "true" }, "↳"), h("code", source)]))))
-      : null,
-    configuration.capabilities?.length
-      ? inspectorSection("Capabilities", h("div", { class: "vh-invocation-inspector__stack" }, configuration.capabilities.map(capability => h("details", { class: "vh-invocation-inspector__disclosure" }, [
-          h("summary", [h("span", capability.id), capability.metadata ? h("small", "Metadata") : null]),
-          capability.metadata ? h("pre", JSON.stringify(capability.metadata, null, 2)) : h("p", "No additional metadata."),
-        ]))))
-      : null,
-    configuration.tools?.length
-      ? inspectorSection("Tools", h("ul", { class: "vh-invocation-inspector__items" }, configuration.tools.map(tool => h("li", [h("span", { "aria-hidden": "true" }, "⌁"), h("code", tool.name)]))))
-      : null,
-    configuration.instructions?.length
-      ? inspectorSection("Instructions", h("details", { class: "vh-invocation-inspector__disclosure" }, [
-          h("summary", [h("span", "Invocation instructions"), h("small", `${configuration.instructions.length} block${configuration.instructions.length === 1 ? "" : "s"}`)]),
-          h("pre", { class: "vh-invocation-inspector__instructions" }, configuration.instructions.join("\n\n")),
-        ]))
-      : null,
   ];
 }
 
@@ -294,21 +531,51 @@ function renderInvocationActivity(
   activity: InvocationActivity,
   expanded: ReadonlySet<string>,
   toggleExpanded: (id: string) => void,
-  inspect: (target: "agent" | "workspace") => void,
+  inspect: (target: InspectTarget) => void,
 ) {
   return activity.kind === "message"
     ? renderMessage(activity, expanded, toggleExpanded)
     : renderEvent(activity, inspect);
 }
 
-function isExternalActivity(activity: InvocationActivity): boolean {
-  return activity.kind === "preparation" || activity.kind === "delivery" || activity.kind === "action";
+function renderActivitySequence(
+  activities: readonly InvocationActivity[],
+  invocation: AgentInvocationView,
+  expanded: ReadonlySet<string>,
+  toggleExpanded: (id: string) => void,
+  inspect: (target: InspectTarget) => void,
+) {
+  const rendered = [];
+  for (let index = 0; index < activities.length;) {
+    const group = activityGroup(activities[index]!);
+    if (group) {
+      let end = index + 1;
+      while (
+        activityGroup(activities[end]) === group
+        && activities[end]!.sequence === activities[end - 1]!.sequence + 1
+      ) end += 1;
+      rendered.push(renderActivityGroup(group, activities.slice(index, end), inspect));
+      index = end;
+      continue;
+    }
+    if (activities[index]!.kind !== "preparation") {
+      rendered.push(renderInvocationActivity(activities[index]!, expanded, toggleExpanded, inspect));
+      index += 1;
+      continue;
+    }
+    let end = index + 1;
+    while (activities[end]?.kind === "preparation") end += 1;
+    rendered.push(renderPreparationGroup(activities.slice(index, end), invocation, inspect));
+    index = end;
+  }
+  return rendered;
 }
 
-function renderChevronDown(className: string) {
-  return h("svg", { "aria-hidden": "true", class: className, fill: "none", viewBox: "0 0 24 24" }, [
-    h("path", { d: "m6 9 6 6 6-6", "stroke-linecap": "round", "stroke-linejoin": "round" }),
-  ]);
+function isExternalActivity(activity: InvocationActivity): boolean {
+  return activity.kind === "preparation"
+    || activity.kind === "delivery"
+    || activity.kind === "action"
+    || activity.kind === "system";
 }
 
 function renderWorkSummary(
@@ -316,7 +583,7 @@ function renderWorkSummary(
   invocation: AgentInvocationView,
   expanded: ReadonlySet<string>,
   toggleExpanded: (id: string) => void,
-  inspect: (target: "agent" | "workspace") => void,
+  inspect: (target: InspectTarget) => void,
 ) {
   if (!activities.length) return null;
   const endedAt = invocation.completedAt ?? invocation.failedAt ?? invocation.cancelledAt ?? invocation.updatedAt;
@@ -328,7 +595,7 @@ function renderWorkSummary(
         renderChevronDown("vh-invocation-work__disclosure"),
       ]),
       h("div", { "aria-hidden": "true", class: "vh-invocation-work__divider" }),
-      h("ol", { class: "vh-invocation-work__activities" }, activities.map(activity => renderInvocationActivity(activity, expanded, toggleExpanded, inspect))),
+      h("ol", { class: "vh-invocation-work__activities" }, renderActivitySequence(activities, invocation, expanded, toggleExpanded, inspect)),
     ]),
   ]);
 }
@@ -338,40 +605,47 @@ function renderInvocationActivities(
   invocation: AgentInvocationView,
   expanded: ReadonlySet<string>,
   toggleExpanded: (id: string) => void,
-  inspect: (target: "agent" | "workspace") => void,
+  inspect: (target: InspectTarget) => void,
 ) {
-  const render = (activity: InvocationActivity) => renderInvocationActivity(activity, expanded, toggleExpanded, inspect);
-  if (invocation.status === "pending" || invocation.status === "running") return activities.map(render);
-
+  if (invocation.status === "pending" || invocation.status === "running") {
+    return renderActivitySequence(activities, invocation, expanded, toggleExpanded, inspect);
+  }
   const firstUser = activities.findIndex(activity => activity.kind === "message" && activity.role === "user");
-  if (firstUser < 0) return activities.map(render);
-
-  let finalAssistant = -1;
-  for (let index = activities.length - 1; index > firstUser; index -= 1) {
+  let lastAssistant = -1;
+  for (let index = activities.length - 1; index >= 0; index -= 1) {
     if (activities[index]!.kind === "message" && activities[index]!.role === "assistant") {
-      finalAssistant = index;
+      lastAssistant = index;
       break;
     }
   }
+  if (firstUser < 0) return renderActivitySequence(activities, invocation, expanded, toggleExpanded, inspect);
 
-  const workEnd = finalAssistant < 0 ? activities.length : finalAssistant;
-  const between = activities.slice(firstUser + 1, workEnd);
-  const external = between.filter(isExternalActivity);
-  const work = between.filter(activity => !isExternalActivity(activity));
-  const suffix = finalAssistant < 0 ? [] : activities.slice(finalAssistant);
+  const prefix = activities.slice(0, firstUser + 1);
+  const tail = activities.slice(firstUser + 1);
+  const externalBeforeFinal = tail.filter((activity, offset) =>
+    isExternalActivity(activity) && (lastAssistant < 0 || firstUser + 1 + offset < lastAssistant),
+  );
+  const externalAfterFinal = tail.filter((activity, offset) =>
+    isExternalActivity(activity) && lastAssistant >= 0 && firstUser + 1 + offset > lastAssistant,
+  );
+  const work = tail.filter((activity, offset) => {
+    const index = firstUser + 1 + offset;
+    return index !== lastAssistant && !isExternalActivity(activity);
+  });
 
   return [
-    ...activities.slice(0, firstUser + 1).map(render),
-    ...external.map(render),
+    ...renderActivitySequence(prefix, invocation, expanded, toggleExpanded, inspect),
+    ...renderActivitySequence(externalBeforeFinal, invocation, expanded, toggleExpanded, inspect),
     renderWorkSummary(work, invocation, expanded, toggleExpanded, inspect),
-    ...suffix.map(render),
+    ...(lastAssistant >= 0 ? [renderInvocationActivity(activities[lastAssistant]!, expanded, toggleExpanded, inspect)] : []),
+    ...renderActivitySequence(externalAfterFinal, invocation, expanded, toggleExpanded, inspect),
   ].filter(item => item !== null);
 }
 
 export const AgentInvocation = defineComponent({
   name: "AgentInvocation",
   emits: {
-    inspect: (target: "agent" | "workspace") => target === "agent" || target === "workspace",
+    inspect: (target: InspectTarget) => target === "agent" || target === "workspace",
   },
   props: {
     header: { default: true, type: Boolean },
@@ -497,6 +771,9 @@ export const AgentInvocationInspector = defineComponent({
             ]),
             inspectorSection("Run", h("dl", { class: "vh-invocation-inspector__list" }, [
               inspectorRow("Agent", configuration?.agent?.name ?? props.invocation.agentName),
+              inspectorRow("Model", configuration?.driver?.model?.id),
+              inspectorRow("Provider", configuration?.driver?.model?.provider ?? configuration?.driver?.provider),
+              inspectorRow("Runtime", configuration?.runtime?.name ?? configuration?.driver?.kind),
               inspectorRow("Messages", metrics.value.messages),
               inspectorRow("Steps", metrics.value.steps),
               metrics.value.changes ? inspectorRow("Changes", metrics.value.changes) : null,

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -10,6 +10,7 @@ import {
   terminalText,
   type InvocationActivity,
 } from "../internal/invocation-activity.ts";
+import { isSafeExternalUrl } from "../internal/url.ts";
 import { AgentDiff } from "./agent-diff.ts";
 import { AgentMarkdown } from "./agent-markdown.ts";
 
@@ -287,7 +288,8 @@ function activityDetail(activity: InvocationActivity): string | undefined {
 }
 
 function githubUrl(invocation: AgentInvocationView): string | undefined {
-  return stringAttribute(invocation.annotations ?? {}, "github.url");
+  const value = stringAttribute(invocation.annotations ?? {}, "github.url");
+  return value && isSafeExternalUrl(value) ? value : undefined;
 }
 
 function renderPreparationAction(activity: InvocationActivity, inspect: (target: InspectTarget) => void) {
@@ -349,14 +351,15 @@ function renderPreparationGroup(
   inspect: (target: InspectTarget) => void,
 ) {
   const url = githubUrl(invocation);
+  const failed = activities.some(activity => activity.status === "failed");
   return h("li", {
     class: "vh-invocation-preparation",
     key: `preparation:${activities[0]?.id}`,
   }, [
     h("details", { class: "vh-invocation-preparation__details" }, [
       h("summary", { class: "vh-invocation-preparation__summary" }, [
-        renderNamedActivityIcon("check"),
-        h("strong", "Session prepared"),
+        renderNamedActivityIcon(failed ? "error" : "check"),
+        h("strong", failed ? "Session preparation failed" : "Session prepared"),
         renderPreparationContext(invocation, url),
         h("small", `${activities.length} steps`),
         renderChevronDown("vh-invocation-preparation__disclosure"),
@@ -414,7 +417,13 @@ function renderGroupedActivityIcon(activity: InvocationActivity) {
   if (stringAttribute(activity.attributes, "github.label.name")) return renderNamedActivityIcon("label");
   const delivery = stringAttribute(activity.attributes, "channel.effect.kind")?.toLocaleLowerCase();
   if (delivery === "reaction") {
-    return h("span", { "aria-label": "eyes", class: "vh-invocation-lifecycle__emoji", role: "img" }, "👀");
+    const intent = stringAttribute(activity.attributes, "channel.effect.intent")?.toLocaleLowerCase();
+    const reaction = intent === "completed"
+      ? { label: "hooray", value: "🎉" }
+      : intent === "failed"
+        ? { label: "confused", value: "😕" }
+        : { label: "eyes", value: "👀" };
+    return h("span", { "aria-label": reaction.label, class: "vh-invocation-lifecycle__emoji", role: "img" }, reaction.value);
   }
   if (["reply", "status", "update"].includes(delivery ?? "")) return renderNamedActivityIcon("message");
   return renderActivityIcon(activity);
@@ -448,6 +457,9 @@ function renderActivityGroup(
           renderLabelChip(activity),
           !stringAttribute(activity.attributes, "github.label.name") && channelDeliverySummary(activity)
             ? h("code", { class: "vh-invocation-lifecycle__detail" }, channelDeliverySummary(activity))
+            : null,
+          activity.truncated
+            ? h("span", { class: "vh-invocation-event__notice" }, "Some trace content was truncated by the invocation journal.")
             : null,
         ]),
       ]);
@@ -605,9 +617,16 @@ function renderInvocationActivities(
     return renderActivitySequence(activities, invocation, expanded, toggleExpanded, inspect);
   }
   const firstUser = activities.findIndex(activity => activity.kind === "message" && activity.role === "user");
+  let lastUser = -1;
+  for (let index = activities.length - 1; index >= 0; index -= 1) {
+    if (activities[index]!.kind === "message" && activities[index]!.role === "user") {
+      lastUser = index;
+      break;
+    }
+  }
   let lastAssistant = -1;
   for (let index = activities.length - 1; index >= 0; index -= 1) {
-    if (activities[index]!.kind === "message" && activities[index]!.role === "assistant") {
+    if (index > lastUser && activities[index]!.kind === "message" && activities[index]!.role === "assistant") {
       lastAssistant = index;
       break;
     }

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -414,6 +414,11 @@ function renderLabelChip(activity: InvocationActivity) {
 function groupedActivityTitle(activity: InvocationActivity): string {
   if (!stringAttribute(activity.attributes, "github.label.name")) return invocationActivityTitle(activity);
   const operation = stringAttribute(activity.attributes, "github.label.operation")?.toLocaleLowerCase();
+  if (activity.status === "failed") {
+    if (operation === "add" || operation === "added") return "Failed to add label";
+    if (operation === "remove" || operation === "removed") return "Failed to remove label";
+    return "Failed to update label";
+  }
   if (operation === "add" || operation === "added") return "Added label";
   if (operation === "remove" || operation === "removed") return "Removed label";
   return "Updated label";
@@ -566,10 +571,7 @@ function renderActivitySequence(
     const group = activityGroup(activities[index]!);
     if (group) {
       let end = index + 1;
-      while (
-        activityGroup(activities[end]) === group
-        && activities[end]!.sequence === activities[end - 1]!.sequence + 1
-      ) end += 1;
+      while (activityGroup(activities[end]) === group) end += 1;
       rendered.push(renderActivityGroup(group, activities.slice(index, end), inspect));
       index = end;
       continue;

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -373,6 +373,12 @@ function renderPreparationGroup(
         h("strong", invocationActivityTitle(activity)),
         renderPreparationDetail(activity, url),
         renderPreparationAction(activity, inspect),
+        activity.body
+          ? h("p", { class: "vh-invocation-preparation__body" }, activity.body)
+          : null,
+        activity.truncated
+          ? h("p", { class: "vh-invocation-event__notice" }, "Some trace content was truncated by the invocation journal.")
+          : null,
       ]))),
     ]),
   ]);

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -6,6 +6,7 @@ import {
   invocationActivities,
   invocationActivityTitle,
   latestInvocationTokens,
+  stringAttribute,
   terminalText,
   type InvocationActivity,
 } from "../internal/invocation-activity.ts";
@@ -282,13 +283,11 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
 }
 
 function activityDetail(activity: InvocationActivity): string | undefined {
-  const value = activity.attributes["vitehub.activity.detail"];
-  return activity.preview ?? (typeof value === "string" && value.trim() ? value.trim() : undefined);
+  return activity.preview ?? stringAttribute(activity.attributes, "vitehub.activity.detail");
 }
 
 function githubUrl(invocation: AgentInvocationView): string | undefined {
-  const value = invocation.annotations?.["github.url"];
-  return typeof value === "string" && value ? value : undefined;
+  return stringAttribute(invocation.annotations ?? {}, "github.url");
 }
 
 function renderPreparationAction(activity: InvocationActivity, inspect: (target: InspectTarget) => void) {
@@ -376,13 +375,8 @@ function renderPreparationGroup(
   ]);
 }
 
-function nonEmptyAttribute(activity: InvocationActivity, key: string): string | undefined {
-  const value = activity.attributes[key];
-  return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
 function activityGroup(activity: InvocationActivity | undefined): string | undefined {
-  return activity ? nonEmptyAttribute(activity, "vitehub.activity.group") : undefined;
+  return activity ? stringAttribute(activity.attributes, "vitehub.activity.group") : undefined;
 }
 
 function labelStyle(color: string | undefined): Record<string, string> {
@@ -399,26 +393,26 @@ function labelStyle(color: string | undefined): Record<string, string> {
 }
 
 function renderLabelChip(activity: InvocationActivity) {
-  const name = nonEmptyAttribute(activity, "github.label.name");
+  const name = stringAttribute(activity.attributes, "github.label.name");
   if (!name) return;
   return h("span", {
     class: "vh-invocation-lifecycle__label",
-    "data-operation": nonEmptyAttribute(activity, "github.label.operation"),
-    style: labelStyle(nonEmptyAttribute(activity, "github.label.color")),
+    "data-operation": stringAttribute(activity.attributes, "github.label.operation"),
+    style: labelStyle(stringAttribute(activity.attributes, "github.label.color")),
   }, name);
 }
 
 function groupedActivityTitle(activity: InvocationActivity): string {
-  if (!nonEmptyAttribute(activity, "github.label.name")) return invocationActivityTitle(activity);
-  const operation = nonEmptyAttribute(activity, "github.label.operation")?.toLocaleLowerCase();
+  if (!stringAttribute(activity.attributes, "github.label.name")) return invocationActivityTitle(activity);
+  const operation = stringAttribute(activity.attributes, "github.label.operation")?.toLocaleLowerCase();
   if (operation === "add" || operation === "added") return "Added label";
   if (operation === "remove" || operation === "removed") return "Removed label";
   return "Updated label";
 }
 
 function renderGroupedActivityIcon(activity: InvocationActivity) {
-  if (nonEmptyAttribute(activity, "github.label.name")) return renderNamedActivityIcon("label");
-  const delivery = nonEmptyAttribute(activity, "channel.effect.kind")?.toLocaleLowerCase();
+  if (stringAttribute(activity.attributes, "github.label.name")) return renderNamedActivityIcon("label");
+  const delivery = stringAttribute(activity.attributes, "channel.effect.kind")?.toLocaleLowerCase();
   if (delivery === "reaction") {
     return h("span", { "aria-label": "eyes", class: "vh-invocation-lifecycle__emoji", role: "img" }, "👀");
   }
@@ -452,7 +446,7 @@ function renderActivityGroup(
           renderGroupedActivityIcon(activity),
           h("span", { class: "vh-invocation-lifecycle__title" }, groupedActivityTitle(activity)),
           renderLabelChip(activity),
-          !nonEmptyAttribute(activity, "github.label.name") && channelDeliverySummary(activity)
+          !stringAttribute(activity.attributes, "github.label.name") && channelDeliverySummary(activity)
             ? h("code", { class: "vh-invocation-lifecycle__detail" }, channelDeliverySummary(activity))
             : null,
         ]),

--- a/packages/ui/src/components/agent-message-parts.ts
+++ b/packages/ui/src/components/agent-message-parts.ts
@@ -1,5 +1,6 @@
 import type { UIMessage } from "ai";
 import { defineComponent, h, type PropType, resolveComponent, type VNodeChild } from "vue";
+import { isSafeExternalUrl } from "../internal/url.ts";
 import { AgentMarkdown } from "./agent-markdown.ts";
 
 type Part = UIMessage["parts"][number];
@@ -18,15 +19,6 @@ function toolValue(part: ToolLikePart): unknown {
 
 function isToolPart(part: Part): part is ToolLikePart {
   return part.type === "dynamic-tool" || part.type.startsWith("tool-");
-}
-
-function isSafeExternalUrl(value: string): boolean {
-  try {
-    const protocol = new URL(value).protocol;
-    return protocol === "http:" || protocol === "https:";
-  } catch {
-    return false;
-  }
 }
 
 function isSafeFileUrl(value: string, filename: string | undefined): boolean {

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -430,6 +430,9 @@ function channelDeliveryTitle(activity: InvocationActivity): string {
   const rawKind = String(activity.attributes["channel.effect.kind"] ?? "").trim();
   const kind = rawKind.toLocaleLowerCase();
   const intent = String(activity.attributes["channel.effect.intent"] ?? "").trim().toLocaleLowerCase();
+  const delivery = rawKind.includes(".") ? rawKind : kind ? normalizedTitle(kind) : "Channel delivery";
+  if (activity.attributes["channel.effect.supported"] === false) return `${delivery} not supported`;
+  if (stringAttribute(activity.attributes, "channel.effect.skipped")) return `${delivery} skipped`;
   if (kind === "reaction") {
     const reaction: Record<string, string> = { completed: "hooray", failed: "confused", started: "eyes" };
     return reaction[intent] ? `Reacted with ${reaction[intent]}` : "Reaction sent";

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -170,7 +170,7 @@ function commandDetails(
   };
 }
 
-function stringAttribute(attributes: Record<string, unknown>, ...keys: string[]): string | undefined {
+export function stringAttribute(attributes: Record<string, unknown>, ...keys: string[]): string | undefined {
   for (const key of keys) {
     const value = attributes[key];
     if (typeof value === "string" && value.trim()) return value.trim();
@@ -445,8 +445,8 @@ function channelDeliveryTitle(activity: InvocationActivity): string {
 export function channelDeliverySummary(activity: InvocationActivity): string | undefined {
   if (activity.kind !== "delivery") return;
   if (activity.attributes["channel.effect.supported"] === false) return "Not supported";
-  const skipped = activity.attributes["channel.effect.skipped"];
-  if (typeof skipped === "string" && skipped.trim()) return normalizedTitle(skipped);
+  const skipped = stringAttribute(activity.attributes, "channel.effect.skipped");
+  if (skipped) return normalizedTitle(skipped);
   const kind = String(activity.attributes["channel.effect.kind"] ?? "").trim().toLocaleLowerCase();
   const intent = String(activity.attributes["channel.effect.intent"] ?? "").trim();
   if (!intent || (kind === "reaction" && ["completed", "failed", "started"].includes(intent.toLocaleLowerCase()))) return;

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -36,6 +36,7 @@ export interface InvocationActivity {
   preview?: string;
   reasoningTokens?: number;
   role?: "assistant" | "system" | "tool" | "user";
+  sequence: number;
   status: "running" | "completed" | "failed";
   totalTokens?: number;
   truncated?: boolean;
@@ -257,11 +258,13 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
   const groups = new Map<string, TraceEventLogEntry[]>();
   const traceTruncated = invocation.observationsTruncated === true
     || (invocation.observations?.some(observation => observation.attributes?.["vitehub.trace.truncated"] === true) ?? false);
+  const hasAgentMessages = (invocation.observations ?? []).some(observation =>
+    observation.name === "agent.message" || observation.name.startsWith("agent.message."),
+  );
   let anonymousMessage = 0;
   let anonymousMessageKey: string | undefined;
   let anonymousMessagePhase: string | undefined;
   let assistantDeltaText = "";
-  const hasAgentMessages = (invocation.observations ?? []).some(observation => observation.name.startsWith("agent.message"));
   for (const observation of invocation.observations ?? []) {
     if (observation.name === "agent.title.recorded") continue;
     const originalAttributes = observation.attributes ?? {};
@@ -352,6 +355,7 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
         name: first.name,
         patches,
         paths,
+        sequence: first.sequence,
         ...(numericAttribute(attributes, "usage.reasoningTokens", "usage.reasoningOutputTokens") !== undefined
           ? { reasoningTokens: numericAttribute(attributes, "usage.reasoningTokens", "usage.reasoningOutputTokens") }
           : {}),
@@ -370,14 +374,10 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
         ...(activityPreview(attributes, command, paths, title) ? { preview: activityPreview(attributes, command, paths, title) } : {}),
       };
     })
-    .sort((left, right) => {
-      const leftSequence = groups.get(left.id)?.[0]?.sequence ?? 0;
-      const rightSequence = groups.get(right.id)?.[0]?.sequence ?? 0;
-      return leftSequence - rightSequence;
-    });
+    .sort((left, right) => left.sequence - right.sequence);
   if (traceTruncated && !activities.some(activity => activity.truncated)) {
     if (activities.length > 0) activities[activities.length - 1] = { ...activities[activities.length - 1]!, truncated: true };
-    else activities.push({ attributes: {}, id: "trace-truncated", kind: "run", name: "vitehub.observation.truncated", patches: [], paths: [], status: "completed", truncated: true });
+    else activities.push({ attributes: {}, id: "trace-truncated", kind: "run", name: "vitehub.observation.truncated", patches: [], paths: [], sequence: 0, status: "completed", truncated: true });
   }
   return activities;
 }
@@ -394,7 +394,7 @@ export function invocationActivityTitle(activity: InvocationActivity): string {
   if (activity.name === "vitehub.agent.configured") return "Agent configured";
   if (activity.kind === "preparation") return "Prepared session";
   if (activity.kind === "system") return "System configuration";
-  if (activity.kind === "delivery") return String(activity.attributes["channel.effect.kind"] ?? "Channel delivery");
+  if (activity.kind === "delivery") return channelDeliveryTitle(activity);
   if (activity.kind === "action") return String(activity.attributes["channel.effect.kind"] ?? activity.attributes["vitehub.action.name"] ?? "Product action");
   if (activity.kind === "plan") return "Updated plan";
   if (activity.kind === "change") return normalizedTitle(String(activity.attributes["tool.name"] ?? "Changed files"));
@@ -424,6 +424,33 @@ export function agentConfigurationSummary(activity: InvocationActivity): string 
     capabilities ? `${capabilities} ${capabilities === 1 ? "capability" : "capabilities"}` : undefined,
     tools ? `${tools} ${tools === 1 ? "tool" : "tools"}` : undefined,
   ].filter(Boolean).join(" · ") || undefined;
+}
+
+function channelDeliveryTitle(activity: InvocationActivity): string {
+  const rawKind = String(activity.attributes["channel.effect.kind"] ?? "").trim();
+  const kind = rawKind.toLocaleLowerCase();
+  const intent = String(activity.attributes["channel.effect.intent"] ?? "").trim().toLocaleLowerCase();
+  if (kind === "reaction") {
+    const reaction: Record<string, string> = { completed: "hooray", failed: "confused", started: "eyes" };
+    return reaction[intent] ? `Reacted with ${reaction[intent]}` : "Reaction sent";
+  }
+  if (kind === "reply") return "Reply sent";
+  if (kind === "status") return "Status updated";
+  if (kind === "title") return "Title updated";
+  if (kind === "update") return "Message updated";
+  if (rawKind.includes(".")) return rawKind;
+  return kind ? `${normalizedTitle(kind)} delivered` : "Channel delivery";
+}
+
+export function channelDeliverySummary(activity: InvocationActivity): string | undefined {
+  if (activity.kind !== "delivery") return;
+  if (activity.attributes["channel.effect.supported"] === false) return "Not supported";
+  const skipped = activity.attributes["channel.effect.skipped"];
+  if (typeof skipped === "string" && skipped.trim()) return normalizedTitle(skipped);
+  const kind = String(activity.attributes["channel.effect.kind"] ?? "").trim().toLocaleLowerCase();
+  const intent = String(activity.attributes["channel.effect.intent"] ?? "").trim();
+  if (!intent || (kind === "reaction" && ["completed", "failed", "started"].includes(intent.toLocaleLowerCase()))) return;
+  return normalizedTitle(intent);
 }
 
 export function terminalText(value: string | undefined): string {

--- a/packages/ui/src/internal/url.ts
+++ b/packages/ui/src/internal/url.ts
@@ -1,0 +1,8 @@
+export function isSafeExternalUrl(value: string): boolean {
+  try {
+    const protocol = new URL(value).protocol;
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    return false;
+  }
+}

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -771,10 +771,23 @@
 .vh-invocation-preparation__steps > li {
   align-items: center;
   color: var(--vh-ui-muted);
-  display: flex;
+  display: grid;
   gap: 0.25rem;
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
   min-height: 1.5rem;
   padding: 0 0.375rem;
+}
+
+.vh-invocation-preparation__body,
+.vh-invocation-preparation__steps .vh-invocation-event__notice {
+  grid-column: 2 / -1;
+  margin: 0 0 0.375rem;
+}
+
+.vh-invocation-preparation__body {
+  color: var(--vh-ui-dimmed);
+  font-size: 0.75rem;
+  white-space: pre-wrap;
 }
 
 .vh-invocation-preparation__steps strong {

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -944,6 +944,13 @@ button.vh-invocation-lifecycle__row:focus-visible {
   white-space: nowrap;
 }
 
+.vh-invocation-lifecycle__failure {
+  color: var(--vh-ui-error);
+  flex: 1;
+  font-size: 0.6875rem;
+  min-width: 0;
+}
+
 .vh-invocation-lifecycle__emoji {
   align-items: center;
   display: inline-flex;

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -682,10 +682,7 @@
   color: var(--vh-ui-muted);
 }
 
-.vh-invocation-activity[data-kind="preparation"],
-.vh-invocation-activity[data-kind="system"],
-.vh-invocation-activity[data-kind="delivery"],
-.vh-invocation-activity[data-kind="action"] {
+.vh-invocation-activity[data-kind="system"] {
   background: color-mix(in oklab, var(--vh-ui-bg-elevated) 52%, transparent);
   border: 1px solid var(--vh-ui-border);
   border-radius: calc(var(--vh-ui-radius) * 1.1);
@@ -693,17 +690,272 @@
   padding: 0.4rem 0.5rem;
 }
 
-.vh-invocation-activity[data-kind="preparation"] {
-  border-inline-start: 2px solid color-mix(in oklab, var(--ui-primary, #2563eb) 60%, var(--vh-ui-border));
+.vh-invocation-preparation {
+  background: color-mix(in oklab, var(--vh-ui-bg-elevated) 28%, transparent);
+  border: 1px solid var(--vh-ui-border);
+  border-radius: calc(var(--vh-ui-radius) * 1.1);
+  list-style: none;
+  margin-block: 0.3rem 1rem;
+  overflow: hidden;
 }
 
-.vh-invocation-activity[data-kind="delivery"],
-.vh-invocation-activity[data-kind="action"] {
-  border-inline-start: 2px solid color-mix(in oklab, var(--ui-info, #0284c7) 60%, var(--vh-ui-border));
+.vh-invocation-preparation__details,
+.vh-invocation-preparation__summary {
+  width: 100%;
+}
+
+.vh-invocation-preparation__summary {
+  align-items: center;
+  color: var(--vh-ui-muted);
+  cursor: pointer;
+  display: flex;
+  gap: 0.25rem;
+  list-style: none;
+  min-height: 1.75rem;
+  padding: 0.125rem 0.375rem;
+  user-select: none;
+}
+
+.vh-invocation-preparation__summary::-webkit-details-marker {
+  display: none;
+}
+
+.vh-invocation-preparation__summary:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--ui-primary, #2563eb) 55%, transparent);
+  outline-offset: -2px;
+}
+
+.vh-invocation-preparation__summary > strong {
+  color: var(--vh-ui-text);
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  font-weight: 550;
+}
+
+.vh-invocation-preparation__summary > code {
+  color: var(--vh-ui-dimmed);
+  flex: 1;
+  font-size: 0.6875rem;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vh-invocation-preparation__summary > small {
+  color: var(--vh-ui-dimmed);
+  flex: 0 0 auto;
+  font-size: 0.625rem;
+}
+
+.vh-invocation-preparation__disclosure {
+  height: 0.75rem;
+  opacity: 0.65;
+  stroke: currentColor;
+  stroke-width: 2;
+  transition: transform 140ms ease;
+  width: 0.75rem;
+}
+
+.vh-invocation-preparation__details[open] .vh-invocation-preparation__disclosure {
+  transform: rotate(180deg);
+}
+
+.vh-invocation-preparation__steps {
+  display: grid;
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0.1875rem;
+}
+
+.vh-invocation-preparation__steps > li {
+  align-items: center;
+  color: var(--vh-ui-muted);
+  display: flex;
+  gap: 0.25rem;
+  min-height: 1.5rem;
+  padding: 0 0.375rem;
+}
+
+.vh-invocation-preparation__steps strong {
+  color: var(--vh-ui-text);
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.vh-invocation-preparation__steps code {
+  color: var(--vh-ui-dimmed);
+  flex: 0 1 auto;
+  font-size: 0.6875rem;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vh-invocation-preparation__context {
+  align-items: center;
+  color: var(--vh-ui-dimmed);
+  display: inline-flex;
+  flex: 0 1 auto;
+  font-size: 0.6875rem;
+  gap: 0.25rem;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.vh-invocation-preparation__summary > .vh-invocation-preparation__context {
+  flex: 1;
+}
+
+.vh-invocation-preparation__context code {
+  flex: 0 1 auto;
+}
+
+.vh-invocation-preparation__context a {
+  color: inherit;
+  flex: 0 0 auto;
+  text-decoration: none;
+}
+
+.vh-invocation-preparation__context a:hover,
+.vh-invocation-preparation__context a:focus-visible {
+  color: var(--vh-ui-text);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.vh-invocation-preparation__action {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  border-radius: 0.25rem;
+  color: var(--vh-ui-muted);
+  cursor: pointer;
+  display: inline-flex;
+  flex: 0 0 1.25rem;
+  height: 1.25rem;
+  justify-content: center;
+  padding: 0;
+  text-decoration: none;
+  width: 1.25rem;
+}
+
+.vh-invocation-preparation__action:hover,
+.vh-invocation-preparation__action:focus-visible {
+  color: var(--vh-ui-text);
+  outline: none;
+}
+
+.vh-invocation-preparation__action .vh-invocation-event__icon {
+  height: 1rem;
+  width: 1rem;
+}
+
+.vh-invocation-preparation__action .vh-invocation-event__icon svg {
+  height: 0.8rem;
+  width: 0.8rem;
 }
 
 .vh-invocation-activity[data-inspectable="true"] .vh-invocation-event__summary {
   cursor: pointer;
+}
+
+.vh-invocation-lifecycle {
+  background: color-mix(in oklab, var(--vh-ui-bg-elevated) 28%, transparent);
+  border: 1px solid var(--vh-ui-border);
+  border-radius: calc(var(--vh-ui-radius) * 1.1);
+  list-style: none;
+  margin-block: 0.3rem 1rem;
+  overflow: hidden;
+}
+
+.vh-invocation-lifecycle__rows {
+  display: grid;
+  list-style: none;
+  margin: 0;
+  padding: 0.1875rem 0;
+}
+
+.vh-invocation-lifecycle__rows > li {
+  min-width: 0;
+}
+
+.vh-invocation-lifecycle__row {
+  align-items: center;
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--vh-ui-muted);
+  display: flex;
+  font: inherit;
+  gap: 0.25rem;
+  min-height: 1.5rem;
+  min-width: 0;
+  padding: 0 0.375rem;
+  text-align: start;
+  width: 100%;
+}
+
+button.vh-invocation-lifecycle__row {
+  cursor: pointer;
+}
+
+button.vh-invocation-lifecycle__row:hover,
+button.vh-invocation-lifecycle__row:focus-visible {
+  color: var(--vh-ui-text);
+}
+
+button.vh-invocation-lifecycle__row:focus-visible {
+  outline: 1px solid color-mix(in oklab, var(--ui-primary, #2563eb) 55%, transparent);
+  outline-offset: -1px;
+}
+
+.vh-invocation-lifecycle__title {
+  color: var(--vh-ui-text);
+  flex: 0 0 auto;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.vh-invocation-lifecycle__detail {
+  color: var(--vh-ui-dimmed);
+  flex: 1;
+  font-size: 0.6875rem;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vh-invocation-lifecycle__emoji {
+  align-items: center;
+  display: inline-flex;
+  flex: 0 0 1.25rem;
+  font-size: 0.75rem;
+  height: 1.25rem;
+  justify-content: center;
+  line-height: 1;
+  width: 1.25rem;
+}
+
+.vh-invocation-lifecycle__label {
+  background: var(--vh-invocation-label-bg, var(--vh-ui-border));
+  border: 1px solid color-mix(in srgb, var(--vh-invocation-label-bg, var(--vh-ui-border)) 80%, #000000);
+  border-radius: 999px;
+  color: var(--vh-invocation-label-fg, var(--vh-ui-text));
+  flex: 0 1 auto;
+  font-size: 0.625rem;
+  font-weight: 550;
+  line-height: 1rem;
+  max-width: 100%;
+  overflow: hidden;
+  padding-inline: 0.4rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .vh-invocation-event__summary {
@@ -729,7 +981,6 @@
 }
 
 details.vh-invocation-event > .vh-invocation-event__summary:hover {
-  background: color-mix(in oklab, var(--vh-ui-bg-elevated) 55%, transparent);
   color: var(--vh-ui-text);
 }
 
@@ -1093,6 +1344,15 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 .vh-invocation-inspector__stack {
   display: grid;
   gap: 0.125rem;
+}
+
+.vh-invocation-inspector__configuration {
+  display: grid;
+  gap: 0.125rem;
+}
+
+.vh-invocation-inspector__configuration > .vh-invocation-inspector__list {
+  margin-block-end: 0.25rem;
 }
 
 .vh-invocation-inspector__disclosure {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -995,6 +995,8 @@ describe("Agent Invocation UI", () => {
       id: "failed-preparation",
       observations: [{
         attributes: {
+          "error.message": "Workspace checkout failed",
+          "vitehub.observation.truncated": true,
           "vitehub.activity.kind": "preparation",
           "vitehub.activity.title": "Workspace failed",
         },
@@ -1012,6 +1014,8 @@ describe("Agent Invocation UI", () => {
     expect(wrapper.get(".vh-invocation-preparation__summary").text()).toContain("Session preparation failed");
     expect(wrapper.find(".vh-invocation-preparation__context a").exists()).toBe(false);
     expect(wrapper.get(".vh-invocation-preparation__context").text()).toContain("PR #1040");
+    expect(wrapper.get(".vh-invocation-preparation__body").text()).toBe("Workspace checkout failed");
+    expect(wrapper.get(".vh-invocation-preparation__steps .vh-invocation-event__notice").text()).toContain("truncated");
   });
 
   it("preserves input transcript order when the latest user has no response", () => {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -1112,8 +1112,42 @@ describe("Agent Invocation UI", () => {
     const row = wrapper.get('[data-activity-group="github-lifecycle"] [data-status="failed"]');
 
     expect(row.get('[data-icon="error"]').attributes("data-icon")).toBe("error");
+    expect(row.get(".vh-invocation-lifecycle__title").text()).toBe("Failed to add label");
     expect(row.get(".vh-invocation-lifecycle__failure").text()).toBe("GitHub rejected the label update");
     expect(row.get(".vh-invocation-lifecycle__label").text()).toBe("Agent: Working");
+  });
+
+  it("groups adjacent lifecycle activities after their observations collapse", () => {
+    const timestamp = "2026-08-24T00:00:00.000Z";
+    const observation = (sequence: number, step: string, phase: "started" | "completed") => ({
+      attributes: {
+        "step.id": step,
+        "vitehub.activity.group": "github-lifecycle",
+        "vitehub.activity.kind": "action",
+        "vitehub.activity.title": step,
+      },
+      name: `vitehub.github.${step}.${phase}`,
+      sequence,
+      timestamp,
+      type: "lifecycle" as const,
+    });
+    const invocation = {
+      createdAt: timestamp,
+      id: "collapsed-lifecycle",
+      observations: [
+        observation(1, "first", "started"),
+        observation(2, "first", "completed"),
+        observation(3, "second", "started"),
+        observation(4, "second", "completed"),
+      ],
+      status: "running" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+
+    expect(wrapper.findAll('[data-activity-group="github-lifecycle"]')).toHaveLength(1);
+    expect(wrapper.findAll('[data-activity-group="github-lifecycle"] .vh-invocation-lifecycle__row')).toHaveLength(2);
   });
 
   it("groups consecutive lifecycle rows and renders structured GitHub labels", () => {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -983,6 +983,104 @@ describe("Agent Invocation UI", () => {
     expect(wrapper.get('.vh-invocation-lifecycle[data-activity-group="github-lifecycle"] .vh-invocation-lifecycle__emoji').text()).toBe("👀");
   });
 
+  it("renders unsafe pull request annotations as text and failed preparation as failed", () => {
+    const timestamp = "2026-08-24T00:00:00.000Z";
+    const invocation = {
+      annotations: {
+        "github.pullRequest": 1040,
+        "github.repository": "vite-hub/vitehub",
+        "github.url": "javascript:alert(1)",
+      },
+      createdAt: timestamp,
+      id: "failed-preparation",
+      observations: [{
+        attributes: {
+          "vitehub.activity.kind": "preparation",
+          "vitehub.activity.title": "Workspace failed",
+        },
+        name: "vitehub.workspace.error",
+        sequence: 1,
+        timestamp,
+        type: "error" as const,
+      }],
+      status: "failed" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+
+    expect(wrapper.get(".vh-invocation-preparation__summary").text()).toContain("Session preparation failed");
+    expect(wrapper.find(".vh-invocation-preparation__context a").exists()).toBe(false);
+    expect(wrapper.get(".vh-invocation-preparation__context").text()).toContain("PR #1040");
+  });
+
+  it("preserves input transcript order when the latest user has no response", () => {
+    const timestamp = "2026-08-24T00:00:00.000Z";
+    const invocation = {
+      createdAt: timestamp,
+      id: "unanswered-turn",
+      observations: [{
+        attributes: {
+          "input.messages": [
+            { id: "user-1", parts: [{ text: "First question", type: "text" }], role: "user" },
+            { id: "assistant-1", parts: [{ text: "First answer", type: "text" }], role: "assistant" },
+            { id: "user-2", parts: [{ text: "Unanswered question", type: "text" }], role: "user" },
+          ],
+        },
+        name: "agent.invocation.started",
+        sequence: 1,
+        timestamp,
+        type: "lifecycle" as const,
+      }],
+      status: "completed" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    const messages = wrapper.findAll(".vh-invocation-message");
+
+    expect(messages.map(message => message.text())).toEqual(["First question", "First answer", "Unanswered question"]);
+    expect(wrapper.find(".vh-invocation-activities > .vh-invocation-message[data-role=\"assistant\"]").exists()).toBe(false);
+  });
+
+  it("renders grouped delivery outcomes, reaction intents, and truncation honestly", () => {
+    const timestamp = "2026-08-24T00:00:00.000Z";
+    const event = (sequence: number, attributes: Record<string, unknown>) => ({
+      attributes: { "vitehub.activity.group": "github-lifecycle", "vitehub.activity.kind": "delivery", ...attributes },
+      name: "vitehub.channel.delivery",
+      sequence,
+      timestamp,
+      type: "lifecycle" as const,
+    });
+    const invocation = {
+      createdAt: timestamp,
+      id: "delivery-outcomes",
+      observations: [
+        event(1, { "channel.effect.kind": "reply", "channel.effect.supported": false }),
+        event(2, { "channel.effect.kind": "status", "channel.effect.skipped": "missing target" }),
+        event(3, { "channel.effect.intent": "completed", "channel.effect.kind": "reaction" }),
+        event(4, { "channel.effect.intent": "failed", "channel.effect.kind": "reaction" }),
+      ],
+      observationsTruncated: true,
+      status: "running" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+
+    expect(wrapper.findAll(".vh-invocation-lifecycle__title").map(title => title.text())).toEqual([
+      "Reply not supported",
+      "Status skipped",
+      "Reacted with hooray",
+      "Reacted with confused",
+    ]);
+    expect(wrapper.findAll(".vh-invocation-lifecycle__emoji").map(emoji => [emoji.text(), emoji.attributes("aria-label")])).toEqual([
+      ["🎉", "hooray"],
+      ["😕", "confused"],
+    ]);
+    expect(wrapper.get(".vh-invocation-event__notice").text()).toContain("truncated");
+  });
+
   it("groups consecutive lifecycle rows and renders structured GitHub labels", () => {
     const timestamp = "2026-08-24T00:00:00.000Z";
     const event = (sequence: number, attributes: Record<string, unknown>, name: string) => ({

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -1085,6 +1085,37 @@ describe("Agent Invocation UI", () => {
     expect(wrapper.get(".vh-invocation-event__notice").text()).toContain("truncated");
   });
 
+  it("exposes grouped lifecycle failures", () => {
+    const timestamp = "2026-08-24T00:00:00.000Z";
+    const invocation = {
+      createdAt: timestamp,
+      id: "lifecycle-failures",
+      observations: [{
+        attributes: {
+          "error.message": "GitHub rejected the label update",
+          "github.label.name": "Agent: Working",
+          "github.label.operation": "add",
+          "vitehub.activity.group": "github-lifecycle",
+          "vitehub.activity.kind": "action",
+          "vitehub.activity.title": "Added label",
+        },
+        name: "vitehub.github.label.error",
+        sequence: 1,
+        timestamp,
+        type: "error" as const,
+      }],
+      status: "running" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    const row = wrapper.get('[data-activity-group="github-lifecycle"] [data-status="failed"]');
+
+    expect(row.get('[data-icon="error"]').attributes("data-icon")).toBe("error");
+    expect(row.get(".vh-invocation-lifecycle__failure").text()).toBe("GitHub rejected the label update");
+    expect(row.get(".vh-invocation-lifecycle__label").text()).toBe("Agent: Working");
+  });
+
   it("groups consecutive lifecycle rows and renders structured GitHub labels", () => {
     const timestamp = "2026-08-24T00:00:00.000Z";
     const event = (sequence: number, attributes: Record<string, unknown>, name: string) => ({

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -828,4 +828,276 @@ describe("Agent Invocation UI", () => {
 
     expect(wrapper.get("article").classes()).toContain("vh-invocation-session--headerless");
   });
+
+  it("coalesces streamed message deltas and omits duplicate terminal payloads", () => {
+    const timestamp = "2026-08-24T00:00:00.000Z";
+    const invocation = {
+      createdAt: timestamp,
+      id: "streamed",
+      observations: [
+        { attributes: { "message.content": "Final ", "message.role": "assistant" }, name: "agent.message.delta", sequence: 1, timestamp, type: "lifecycle" as const },
+        { attributes: { "message.content": "answer", "message.role": "assistant" }, name: "agent.message.delta", sequence: 2, timestamp, type: "lifecycle" as const },
+        { attributes: { "result.text": "Final answer" }, name: "agent.stream.finish", sequence: 3, timestamp, type: "lifecycle" as const },
+        { attributes: { "result.text": "Final answer" }, name: "agent.invocation.finish", sequence: 4, timestamp, type: "lifecycle" as const },
+      ],
+      status: "completed" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+
+    expect(invocationActivities(invocation).map(activity => [activity.name, activity.body])).toEqual([
+      ["agent.message.delta", "Final answer"],
+    ]);
+  });
+
+  it("models preparation and channel delivery observations as first-class activities", () => {
+    const timestamp = "2026-08-24T00:00:00.000Z";
+    const invocation = {
+      createdAt: timestamp,
+      id: "lifecycle",
+      observations: [
+        {
+          attributes: {
+            "vitehub.activity.kind": "preparation",
+            "vitehub.activity.title": "Workspace materialized",
+          },
+          name: "vitehub.workspace.materialized",
+          sequence: 1,
+          timestamp,
+          type: "lifecycle" as const,
+        },
+        {
+          attributes: {
+            "channel.effect.intent": "started",
+            "channel.effect.kind": "reaction",
+          },
+          name: "vitehub.channel.delivery",
+          sequence: 2,
+          timestamp,
+          type: "lifecycle" as const,
+        },
+      ],
+      status: "completed" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+
+    const activities = invocationActivities(invocation);
+    expect(activities.map(activity => activity.kind)).toEqual(["preparation", "delivery"]);
+    expect(activities.map(invocationActivityTitle)).toEqual(["Workspace materialized", "Reacted with eyes"]);
+  });
+
+  it("groups preparation, links the pull request, and emits inspector targets", async () => {
+    const timestamp = "2026-08-24T00:00:00.000Z";
+    const invocation = {
+      annotations: {
+        "github.pullRequest": 1030,
+        "github.repository": "vite-hub/vitehub",
+        "github.url": "https://github.com/vite-hub/vitehub/pull/1030",
+      },
+      completedAt: "2026-08-24T00:02:43.000Z",
+      createdAt: timestamp,
+      id: "prepared",
+      observations: [
+        {
+          attributes: {
+            "vitehub.activity.detail": "vite-hub/vitehub · PR #1030",
+            "vitehub.activity.kind": "preparation",
+            "vitehub.activity.title": "Pull request selected",
+          },
+          name: "vitehub.pull-request.selected",
+          sequence: 1,
+          timestamp,
+          type: "lifecycle" as const,
+        },
+        {
+          attributes: {
+            "vitehub.activity.detail": "1790 files",
+            "vitehub.activity.kind": "preparation",
+            "vitehub.activity.title": "Workspace materialized",
+            "vitehub.inspect.target": "workspace",
+          },
+          name: "vitehub.workspace.materialized",
+          sequence: 2,
+          timestamp,
+          type: "lifecycle" as const,
+        },
+        {
+          attributes: {
+            "message.content": "Review this pull request. ".repeat(50),
+            "message.id": "user",
+            "message.role": "user",
+          },
+          name: "agent.message",
+          sequence: 3,
+          timestamp,
+          type: "lifecycle" as const,
+        },
+        {
+          attributes: { "vitehub.activity.kind": "reasoning", "vitehub.activity.body": "Checked the diff." },
+          name: "agent.reasoning.finish",
+          sequence: 4,
+          timestamp,
+          type: "lifecycle" as const,
+        },
+        {
+          attributes: { "message.content": "Merged after checks passed.", "message.id": "assistant", "message.role": "assistant" },
+          name: "agent.message",
+          sequence: 5,
+          timestamp,
+          type: "lifecycle" as const,
+        },
+        {
+          attributes: {
+            "channel.effect.intent": "started",
+            "channel.effect.kind": "reaction",
+            "vitehub.activity.group": "github-lifecycle",
+          },
+          name: "vitehub.channel.delivery",
+          sequence: 6,
+          timestamp,
+          type: "lifecycle" as const,
+        },
+      ],
+      startedAt: timestamp,
+      status: "completed" as const,
+      traceId: "trace",
+      updatedAt: "2026-08-24T00:02:43.000Z",
+    } satisfies AgentInvocationView;
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+
+    expect(wrapper.get(".vh-invocation-preparation__summary").text()).toContain("Session prepared");
+    expect(wrapper.get(".vh-invocation-preparation__summary").text()).toContain("2 steps");
+    expect(wrapper.get('.vh-invocation-preparation__context a').attributes("href")).toBe(invocation.annotations["github.url"]);
+    await wrapper.get(".vh-invocation-preparation__summary").trigger("click");
+    await wrapper.get('button[aria-label="Open Workspace"]').trigger("click");
+    expect(wrapper.emitted("inspect")).toEqual([["workspace"]]);
+
+    const prompt = wrapper.get('.vh-invocation-message[data-role="user"]');
+    expect(prompt.get(".vh-invocation-message__content").attributes("data-collapsed")).toBe("true");
+    await prompt.get(".vh-invocation-message__more").trigger("click");
+    expect(prompt.get(".vh-invocation-message__content").attributes("data-collapsed")).toBeUndefined();
+
+    expect(wrapper.get(".vh-invocation-work__title").text()).toBe("Worked for 2m 43s");
+    expect(wrapper.get('.vh-invocation-message[data-role="assistant"]').text()).toContain("Merged after checks passed.");
+    expect(wrapper.get('.vh-invocation-lifecycle[data-activity-group="github-lifecycle"] .vh-invocation-lifecycle__emoji').text()).toBe("👀");
+  });
+
+  it("groups consecutive lifecycle rows and renders structured GitHub labels", () => {
+    const timestamp = "2026-08-24T00:00:00.000Z";
+    const event = (sequence: number, attributes: Record<string, unknown>, name: string) => ({
+      attributes: { "vitehub.activity.group": "github-lifecycle", ...attributes },
+      name,
+      sequence,
+      timestamp,
+      type: "lifecycle" as const,
+    });
+    const invocation = {
+      createdAt: timestamp,
+      id: "github-lifecycle",
+      observations: [
+        event(1, {
+          "github.label.color": "d0d7de",
+          "github.label.name": "Agent: Queued",
+          "github.label.operation": "add",
+          "vitehub.activity.kind": "action",
+          "vitehub.activity.title": "Queued label added",
+        }, "vitehub.github.label.queued"),
+        event(2, {
+          "github.label.color": "54aeff",
+          "github.label.name": "Agent: Working",
+          "github.label.operation": "add",
+          "vitehub.activity.kind": "action",
+          "vitehub.activity.title": "Working label added",
+        }, "vitehub.github.label.working"),
+        event(3, {
+          "channel.effect.intent": "started",
+          "channel.effect.kind": "status",
+          "vitehub.activity.kind": "delivery",
+          "vitehub.activity.title": "Working status posted",
+        }, "vitehub.github.status.started"),
+        event(4, {
+          "channel.effect.intent": "started",
+          "channel.effect.kind": "reaction",
+          "vitehub.activity.kind": "delivery",
+          "vitehub.activity.title": "Reacted with eyes",
+        }, "vitehub.github.reaction.started"),
+        {
+          ...event(5, {
+            "vitehub.activity.kind": "action",
+            "vitehub.activity.title": "Working label removed",
+          }, "vitehub.github.label.removed"),
+          attributes: {
+            "github.label.color": "54aeff",
+            "github.label.name": "Agent: Working",
+            "github.label.operation": "remove",
+            "vitehub.activity.group": "github-completion",
+            "vitehub.activity.kind": "action",
+            "vitehub.activity.title": "Working label removed",
+          },
+        },
+        {
+          attributes: {
+            "channel.effect.intent": "completed",
+            "channel.effect.kind": "update",
+            "vitehub.activity.group": "github-completion",
+            "vitehub.activity.kind": "delivery",
+            "vitehub.activity.title": "GitHub result posted",
+          },
+          name: "vitehub.github.status.finished",
+          sequence: 6,
+          timestamp,
+          type: "lifecycle" as const,
+        },
+      ],
+      status: "running" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    const groups = wrapper.findAll(".vh-invocation-lifecycle");
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0]!.findAll(".vh-invocation-lifecycle__row")).toHaveLength(4);
+    expect(groups[1]!.findAll(".vh-invocation-lifecycle__row")).toHaveLength(2);
+    expect(groups[0]!.findAll(".vh-invocation-lifecycle__label").map(chip => chip.text())).toEqual([
+      "Agent: Queued",
+      "Agent: Working",
+    ]);
+    expect(groups[0]!.findAll(".vh-invocation-lifecycle__title").slice(0, 2).map(title => title.text())).toEqual([
+      "Added label",
+      "Added label",
+    ]);
+    expect(groups[0]!.get(".vh-invocation-lifecycle__label").attributes("style")).toContain("#d0d7de");
+    expect(groups[0]!.get(".vh-invocation-lifecycle__emoji").text()).toBe("👀");
+    expect(groups[1]!.get(".vh-invocation-lifecycle__title").text()).toBe("Removed label");
+    expect(groups[1]!.get(".vh-invocation-lifecycle__label").attributes("data-operation")).toBe("remove");
+  });
+
+  it("shows recorded Agent Definition details in one inspector section", () => {
+    const invocation: AgentInvocationView = {
+      configuration: {
+        agent: { name: "babysitter" },
+        capabilities: [{ id: "github" }],
+        driver: { kind: "provider", model: { id: "gpt-5.6-sol", provider: "openai" } },
+        instructions: ["Follow repository instructions."],
+        runtime: { name: "node" },
+        tools: [{ name: "exec" }],
+        workspace: { mode: "write", name: "babysitter", sources: ["github:vite-hub/vitehub"] },
+      },
+      createdAt: "2026-08-24T00:00:00.000Z",
+      id: "configured",
+      observations: [],
+      status: "completed",
+      traceId: "trace",
+      updatedAt: "2026-08-24T00:00:01.000Z",
+    };
+    const wrapper = mount(AgentInvocationInspector, { props: { invocation } });
+
+    expect(wrapper.get(".vh-invocation-inspector__content").text()).toContain("gpt-5.6-sol");
+    expect(wrapper.get(".vh-invocation-inspector__content").text()).toContain("openai");
+    expect(wrapper.get(".vh-invocation-inspector__content").text()).toContain("node");
+    expect(wrapper.findAll(".vh-invocation-inspector__content > section h4").map(node => node.text())).toContain("Agent definition");
+    expect(wrapper.get(".vh-invocation-inspector__configuration").text()).toContain("System instructions");
+  });
 });


### PR DESCRIPTION
Agent Invocation records already contain preparation, product lifecycle, channel delivery, and inspector metadata, but the shared UI exposed those records as disconnected raw rows. Consumers had to rebuild session grouping, duplicate-terminal suppression, and navigation behavior downstream.

This moves the proven Babysitter session treatment into `@vite-hub/ui` while preserving the newer invocation behavior already on `main`.

## Session contract

- Group related preparation and product lifecycle observations into compact activity containers.
- Render GitHub labels and reactions with structured treatment, and link a pull request only when the invocation has a `github.url` annotation.
- Emit inspector targets for Agent Definition and Workspace navigation.
- Collapse long user prompts and completed work while keeping the final response readable.
- Suppress duplicate terminal payloads without replacing `main`'s phase-aware message grouping.
- Keep unknown dotted delivery names intact while giving known delivery types friendly labels.
- Apply the shared compact spacing, icon, disclosure, and activity styles in the package boundary.

## Proof

- `git diff HEAD^ HEAD --check`
- `corepack pnpm --filter @vite-hub/ui typecheck`
- `corepack pnpm --filter @vite-hub/ui exec vp test run test/invocation-ui.test.ts` — 47 tests passed
- Downstream `pnpm patch` proof is deployed in Babysitter; the upstream source change covers the retained patch contracts without copying duplicate implementations already present on `main`.

Exact verified head: `309d09291e4f9075246d7968519cb673163052a6`.
