### PR TITLE
feat(docs): add an intentional dark palette

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -29,16 +29,16 @@ Avoid clouds, shields, cubes, honeycombs, generic lightning bolts, decorative lo
 
 ## Color
 
-The public docs use a monochrome system.
+The public docs use a monochrome system with equal light and dark modes.
 
-| Token | Value | Use |
-| --- | --- | --- |
-| Ink | `#09090b` | Logo, headings, high-contrast surfaces |
-| Paper | `#fafafa` | Light backgrounds and mark containers |
-| Graphite | `#18181b` | Dark surfaces |
-| Mist | `#f4f4f5` | Quiet surfaces |
-| Line | `#d4d4d8` | Borders and route rails |
-| Muted | `#71717a` | Secondary text and endpoint dots |
+| Token | Light | Dark | Use |
+| --- | --- | --- | --- |
+| Canvas | `#ffffff` | `#09090b` | Page background |
+| Raised | `#fafafa` | `#18181b` | Cards, code, and raised controls |
+| Line | `#e4e4e7` | `#27272a` | Borders and route rails |
+| Text | `#3f3f46` | `#e4e4e7` | Body text |
+| Highlighted | `#18181b` | `#fafafa` | Logo, headings, and selected states |
+| Muted | `#71717a` | `#a1a1aa` | Secondary text and endpoint dots |
 
 Keep the system black, white, and zinc. Active states can use stronger ink, heavier borders, or route-line placement instead of hue.
 

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -31,7 +31,7 @@ Avoid clouds, shields, cubes, honeycombs, generic lightning bolts, decorative lo
 
 The public docs use a monochrome system with equal light and dark modes.
 
-| Token | Light | Dark | Use |
+| Role | Light | Dark | Use |
 | --- | --- | --- | --- |
 | Canvas | `#ffffff` | `#09090b` | Page background |
 | Raised | `#fafafa` | `#18181b` | Cards, code, and raised controls |

--- a/docs/app/assets/main.css
+++ b/docs/app/assets/main.css
@@ -11,6 +11,29 @@
   --vh-muted: #71717a;
 }
 
+:root.light {
+  color-scheme: light;
+}
+
+:root.dark {
+  color-scheme: dark;
+  --ui-bg: var(--vh-ink);
+  --ui-bg-muted: #18181b;
+  --ui-bg-elevated: #18181b;
+  --ui-bg-accented: #27272a;
+  --ui-bg-inverted: var(--vh-paper);
+  --ui-border: #27272a;
+  --ui-border-muted: #18181b;
+  --ui-border-accented: #3f3f46;
+  --ui-border-inverted: var(--vh-paper);
+  --ui-text-dimmed: #71717a;
+  --ui-text-muted: #a1a1aa;
+  --ui-text-toned: #d4d4d8;
+  --ui-text: #e4e4e7;
+  --ui-text-highlighted: var(--vh-paper);
+  --ui-text-inverted: var(--vh-ink);
+}
+
 @media (min-width: 1280px) {
   :root {
     --vh-sidebar-width: 286px;

--- a/docs/app/assets/main.css
+++ b/docs/app/assets/main.css
@@ -6,9 +6,6 @@
   --vh-content-width: 796px;
   --vh-ink: #09090b;
   --vh-paper: #fafafa;
-  --vh-mist: #f4f4f5;
-  --vh-line: #d4d4d8;
-  --vh-muted: #71717a;
 }
 
 :root.light {

--- a/docs/test/color-mode.test.ts
+++ b/docs/test/color-mode.test.ts
@@ -11,20 +11,20 @@ describe("docs color mode", () => {
     expect(header).toContain("<UColorModeButton />");
   });
 
-  it("defines ViteHub-owned light and dark browser palettes", async () => {
+  it("defines browser schemes and a ViteHub-owned dark palette", async () => {
     const styles = await readFile(
       new URL("../app/assets/main.css", import.meta.url),
       "utf8",
     );
+    const lightRule = styles.match(/:root\.light \{(?<body>[^}]+)\}/)?.groups?.body;
+    const darkRule = styles.match(/:root\.dark \{(?<body>[^}]+)\}/)?.groups?.body;
 
-    expect(styles).toContain(":root.light");
-    expect(styles).toContain("color-scheme: light");
-    expect(styles).toContain(":root.dark");
-    expect(styles).toContain("color-scheme: dark");
-    expect(styles).toContain("--ui-bg: var(--vh-ink)");
-    expect(styles).toContain("--ui-bg-elevated: #18181b");
-    expect(styles).toContain("--ui-border: #27272a");
-    expect(styles).toContain("--ui-text: #e4e4e7");
-    expect(styles).toContain("--ui-text-highlighted: var(--vh-paper)");
+    expect(lightRule).toContain("color-scheme: light");
+    expect(darkRule).toContain("color-scheme: dark");
+    expect(darkRule).toContain("--ui-bg: var(--vh-ink)");
+    expect(darkRule).toContain("--ui-bg-elevated: #18181b");
+    expect(darkRule).toContain("--ui-border: #27272a");
+    expect(darkRule).toContain("--ui-text: #e4e4e7");
+    expect(darkRule).toContain("--ui-text-highlighted: var(--vh-paper)");
   });
 });

--- a/docs/test/color-mode.test.ts
+++ b/docs/test/color-mode.test.ts
@@ -1,0 +1,30 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("docs color mode", () => {
+  it("offers a manual color-mode control", async () => {
+    const header = await readFile(
+      new URL("../app/components/AppHeader.vue", import.meta.url),
+      "utf8",
+    );
+
+    expect(header).toContain("<UColorModeButton />");
+  });
+
+  it("defines ViteHub-owned light and dark browser palettes", async () => {
+    const styles = await readFile(
+      new URL("../app/assets/main.css", import.meta.url),
+      "utf8",
+    );
+
+    expect(styles).toContain(":root.light");
+    expect(styles).toContain("color-scheme: light");
+    expect(styles).toContain(":root.dark");
+    expect(styles).toContain("color-scheme: dark");
+    expect(styles).toContain("--ui-bg: var(--vh-ink)");
+    expect(styles).toContain("--ui-bg-elevated: #18181b");
+    expect(styles).toContain("--ui-border: #27272a");
+    expect(styles).toContain("--ui-text: #e4e4e7");
+    expect(styles).toContain("--ui-text-highlighted: var(--vh-paper)");
+  });
+});


### PR DESCRIPTION
The docs already expose Nuxt UI color-mode switching, but the dark appearance still inherits the framework palette. That leaves the base canvas at Graphite and gives ViteHub no stable dark color contract.

This change gives the docs an explicit ViteHub-owned dark palette inspired by Vercel's restrained near-black hierarchy. Ink (`#09090b`) becomes the canvas, Graphite (`#18181b`) holds raised areas, zinc borders separate controls, and Paper (`#fafafa`) marks headings and selected states. The existing system preference, manual toggle, page structure, and light palette stay unchanged.

## Color contract

| Role | Light | Dark |
| --- | --- | --- |
| Canvas | `#ffffff` | `#09090b` |
| Raised | `#fafafa` | `#18181b` |
| Border | `#e4e4e7` | `#27272a` |
| Text | `#3f3f46` | `#e4e4e7` |
| Highlighted | `#18181b` | `#fafafa` |
| Muted | `#71717a` | `#a1a1aa` |

The browser `color-scheme` now follows the active mode so native controls render in the same appearance. A focused regression test keeps the existing toggle and both browser palettes wired.

## Visual proof

| Dark desktop | Preserved light mobile |
| --- | --- |
| ![ViteHub landing page with the new Ink dark canvas and Graphite controls](https://drop.vitehub.dev/i/bbaa601d-c1ff-491e-b027-368f23c1c746.png) | ![ViteHub landing page in the unchanged light palette at a 390 pixel viewport](https://drop.vitehub.dev/i/027ef3c0-945e-4bee-85f2-27f5138f0964.png) |

## Verification

- `corepack pnpm --dir docs exec vp test`: 14 files and 61 tests passed
- `corepack pnpm exec vp run docs:build`: production client, server, and 288 prerendered routes built
- `corepack pnpm exec vp run lint`: completed with the repository's existing baseline warnings
- focused Oxlint and `git diff --check`: passed
- local browser at 1440x900: system dark resolved the documented tokens and manual switching changed both the root class and native `color-scheme` to light
- local browser at 390x844: light mode preserved the existing layout with zero horizontal overflow
