### PR TITLE
fix(docs): highlight component preview source

### DIFF
--- a/docs/app/components/content/ComponentPreview.vue
+++ b/docs/app/components/content/ComponentPreview.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import highlighter from "#mdc-highlighter";
 import { computed, defineAsyncComponent, ref } from "vue";
 
 const props = withDefaults(
@@ -32,6 +33,20 @@ if (!loader) {
 // SAFETY: Vue files loaded through Vite expose their component as the module default export.
 const example = defineAsyncComponent(loader as () => Promise<{ default: object }>);
 const source = (exampleSources[examplePath] || "").trim();
+const sourceFence = "`".repeat(
+  Math.max(3, ...Array.from(source.matchAll(/`+/g), ([match]) => match.length + 1)),
+);
+const sourceBlock = `${sourceFence}vue [${props.name}.vue]\n${source}\n${sourceFence}`;
+const sourceParserOptions = {
+  highlight: {
+    highlighter,
+    theme: {
+      light: "material-theme-lighter",
+      default: "material-theme",
+      dark: "material-theme-palenight",
+    },
+  },
+};
 const sourceOpen = ref(false);
 const sourceLabel = computed(() => (sourceOpen.value ? "Hide code" : "View code"));
 </script>
@@ -67,19 +82,8 @@ const sourceLabel = computed(() => (sourceOpen.value ? "Hide code" : "View code"
       </Suspense>
     </div>
 
-    <div v-if="sourceOpen" class="border-t border-default">
-      <ProsePre
-        :code="source"
-        :filename="`${name}.vue`"
-        language="vue"
-        :ui="{
-          root: '!my-0 !rounded-none',
-          header: '!rounded-none !border-0 !border-b',
-          base: '!rounded-none !border-0',
-        }"
-      >
-        <code>{{ source }}</code>
-      </ProsePre>
+    <div v-if="sourceOpen" class="component-preview-source border-t border-default">
+      <MDC :value="sourceBlock" :parser-options="sourceParserOptions" :tag="false" />
     </div>
   </div>
 </template>

--- a/docs/test/ui-docs.test.ts
+++ b/docs/test/ui-docs.test.ts
@@ -43,6 +43,18 @@ describe("UI documentation", () => {
     }
   });
 
+  it("sends component preview source through the Markdown syntax highlighter", () => {
+    const preview = readFileSync(
+      resolve(docsRoot, "app/components/content/ComponentPreview.vue"),
+      "utf8",
+    );
+
+    expect(preview).toContain('import highlighter from "#mdc-highlighter"');
+    expect(preview).toContain('<MDC :value="sourceBlock"');
+    expect(preview).toContain(':parser-options="sourceParserOptions"');
+    expect(preview).not.toContain("<code>{{ source }}</code>");
+  });
+
   it("loads previews through the public Nuxt module", () => {
     const config = readFileSync(resolve(docsRoot, "nuxt.config.ts"), "utf8");
     const manifest = readFileSync(resolve(docsRoot, "package.json"), "utf8");


### PR DESCRIPTION
Component previews passed raw Vue source into `ProsePre`, which provides the code frame and copy control but does not tokenize its slot. Invocation examples therefore rendered in one color.

The shared preview now wraps the exact source in a safe Markdown fence and sends it through the docs' existing MDC and Shiki highlighter. This fixes every component preview while preserving the collapsed default, filename, source text, and copy behavior.

## Before and now

| Before | Now |
| --- | --- |
| ![Invocation example source rendered without syntax colors](https://drop.vitehub.dev/i/3e210aa1-4932-4982-abe0-5200df11912d.png) | ![Invocation example source rendered with Vue syntax highlighting](https://drop.vitehub.dev/i/46bd282b-c4bb-49f4-9c52-d832196e7ca0.png) |

## Verification

- `pnpm --dir docs test`: 13 files, 60 tests passed
- `oxlint docs/app/components/content/ComponentPreview.vue docs/test/ui-docs.test.ts`
- Browser check on `/docs/ui/invocation-list/`: 232 token spans across 7 computed colors, with the filename and source text preserved
- Production build compiled the client and server and prerendered `/docs/ui/invocation-list/`; the full command later stopped when the home-page OG renderer timed out
- Docs typecheck is blocked by seven errors inside the installed Docus dependency; no error references a changed file
