### PR TITLE
feat(ui): rework invocation inspector

### DIFF
--- a/docs/app/components/content/examples/InvocationInspectorExample.vue
+++ b/docs/app/components/content/examples/InvocationInspectorExample.vue
@@ -9,8 +9,11 @@ const invocation: AgentInvocationView = {
   },
   configuration: {
     agent: { name: "reviewer", version: "1.0.0" },
-    capabilities: [{ id: "workspace-shell" }, { id: "pull-request" }],
-    driver: { kind: "provider", provider: "codex" },
+    capabilities: [
+      { id: "workspace-shell", metadata: { access: "write", sandbox: "workspace" } },
+      { id: "pull-request" },
+    ],
+    driver: { kind: "provider", model: { id: "gpt-5.6", provider: "codex" } },
     instructions: ["Fix the reported issue, verify it, and update the pull request."],
     runtime: { name: "node" },
     tools: [{ name: "exec_command" }, { name: "apply_patch" }],
@@ -50,9 +53,6 @@ const invocation: AgentInvocationView = {
 
 <template>
   <div class="mx-auto h-[36rem] max-w-md bg-default">
-    <AgentInvocationInspector
-      :invocation="invocation"
-      class="h-full border-x border-default"
-    />
+    <AgentInvocationInspector :invocation="invocation" class="h-full border-x border-default" />
   </div>
 </template>

--- a/docs/content/docs/ui/invocation-inspector.md
+++ b/docs/content/docs/ui/invocation-inspector.md
@@ -25,7 +25,7 @@ icon: i-ph-sidebar-simple-light
 </AgentInvocationInspector>
 ```
 
-The inspector shows identity and status first, then run counts, environment, Sources, Capabilities, tools, instructions, and copy actions for identifiers. Structured configuration uses readable rows and disclosures instead of raw JSON as the primary view.
+The inspector keeps the outcome visible, summarizes the run, and groups the captured Agent setup below it. Sources and tools stay compact, while Capability metadata and instructions expand in place. Terminal errors appear with the exact invocation status. Identifiers remain hidden until copied.
 
 ## Captured configuration
 

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -73,6 +73,16 @@ function formatDuration(startedAt: string | undefined, completedAt: string | und
   return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
 }
 
+function configurationLabel(configuration: AgentInvocationConfiguration): string | undefined {
+  const driver = configuration.driver;
+  const model = driver?.model;
+  return [
+    driver?.kind,
+    model?.provider ?? driver?.provider,
+    model?.id,
+  ].filter(Boolean).join(" · ") || undefined;
+}
+
 function workspaceLabel(configuration: AgentInvocationConfiguration): string | undefined {
   const workspace = configuration.workspace;
   return workspace ? [workspace.name, workspace.mode].filter(Boolean).join(" · ") : undefined;
@@ -486,65 +496,227 @@ function inspectorSection(title: string, body: ReturnType<typeof h> | null) {
   return body ? h("section", [h("h4", title), body]) : null;
 }
 
-function inspectorRow(label: string, value: string | number | undefined, code = false) {
+function inspectorRow(label: string, value: string | number | undefined, icon?: InspectorIcon) {
   if (value === undefined || value === "") return null;
-  return h("div", [h("dt", label), h("dd", code ? [h("code", String(value))] : String(value))]);
+  return h("div", [
+    icon ? h("span", { class: "vh-invocation-inspector__row-icon" }, [inspectorIcon(icon)]) : null,
+    h("dt", label),
+    h("dd", String(value)),
+  ]);
 }
 
 function copyIcon(copied: boolean) {
-  return h("svg", { "aria-hidden": "true", fill: "none", viewBox: "0 0 24 24" }, copied
-    ? [h("path", { d: "m5 12 4 4L19 6", "stroke-linecap": "round", "stroke-linejoin": "round" })]
-    : [
-        h("rect", { height: "13", rx: "2", width: "13", x: "8", y: "8" }),
-        h("path", { d: "M16 8V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3", "stroke-linecap": "round", "stroke-linejoin": "round" }),
-      ]);
+  return h(
+    "svg",
+    { "aria-hidden": "true", fill: "none", viewBox: "0 0 24 24" },
+    copied
+      ? [h("path", { d: "m5 12 4 4L19 6", "stroke-linecap": "round", "stroke-linejoin": "round" })]
+      : [
+          h("rect", { height: "13", rx: "2", width: "13", x: "8", y: "8" }),
+          h("path", {
+            d: "M16 8V5a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v9a2 2 0 0 0 2 2h3",
+            "stroke-linecap": "round",
+            "stroke-linejoin": "round",
+          }),
+        ],
+  );
+}
+
+type InspectorIcon =
+  | "agent"
+  | "capability"
+  | "driver"
+  | "runtime"
+  | "source"
+  | "tool"
+  | "workspace";
+
+const inspectorIconPaths: Record<InspectorIcon, readonly string[]> = {
+  agent: ["M12 8V4H8", "M4 8h16v10H4z", "M8 12h.01", "M16 12h.01"],
+  capability: ["M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10", "m9 12 2 2 4-4"],
+  driver: [
+    "M9 2v3",
+    "M15 2v3",
+    "M9 19v3",
+    "M15 19v3",
+    "M2 9h3",
+    "M2 15h3",
+    "M19 9h3",
+    "M19 15h3",
+    "M5 5h14v14H5z",
+    "M9 9h6v6H9z",
+  ],
+  runtime: ["m16 18 6-6-6-6", "m8 6-6 6 6 6"],
+  source: [
+    "M6 3v12",
+    "M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6",
+    "M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6",
+    "M18 9a9 9 0 0 1-9 9",
+  ],
+  tool: [
+    "M14.7 6.3a4 4 0 0 0-5-5l2.1 2.1-2.4 2.4-2.1-2.1a4 4 0 0 0 5 5L3 18l3 3 9.3-9.3a4 4 0 0 0 5-5l-2.1 2.1-2.4-2.4z",
+  ],
+  workspace: ["M3 6.5h6l2 2h10v9.5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"],
+};
+
+function inspectorIcon(icon: InspectorIcon) {
+  return h(
+    "svg",
+    { "aria-hidden": "true", fill: "none", viewBox: "0 0 24 24" },
+    inspectorIconPaths[icon].map((path) =>
+      h("path", {
+        d: path,
+        "stroke-linecap": "round",
+        "stroke-linejoin": "round",
+      }),
+    ),
+  );
+}
+
+function statusIcon(status: AgentInvocationView["status"]) {
+  const paths: Record<AgentInvocationView["status"], readonly string[]> = {
+    cancelled: ["M18 6 6 18", "M12 22a10 10 0 1 1 0-20 10 10 0 0 1 0 20"],
+    completed: ["m5 12 4 4L19 6"],
+    failed: ["M18 6 6 18", "m6 6 12 12"],
+    pending: ["M12 8v4l3 2", "M12 22a10 10 0 1 1 0-20 10 10 0 0 1 0 20"],
+    running: ["M21 12a9 9 0 1 1-6.219-8.56"],
+  };
+  return h(
+    "svg",
+    { "aria-hidden": "true", fill: "none", viewBox: "0 0 24 24" },
+    paths[status].map((path) =>
+      h("path", {
+        d: path,
+        "stroke-linecap": "round",
+        "stroke-linejoin": "round",
+      }),
+    ),
+  );
+}
+
+function inspectorCollection(title: string, icon: InspectorIcon, items: readonly string[]) {
+  return h("div", { class: "vh-invocation-inspector__group" }, [
+    h("div", { class: "vh-invocation-inspector__group-heading" }, [
+      h("span", { class: "vh-invocation-inspector__group-icon" }, [inspectorIcon(icon)]),
+      h("strong", title),
+      h("small", items.length),
+    ]),
+    h(
+      "ul",
+      { class: "vh-invocation-inspector__items" },
+      items.map((item) => h("li", { key: item }, [h("code", item)])),
+    ),
+  ]);
+}
+
+function inspectorDisclosure(
+  title: string,
+  icon: InspectorIcon,
+  summary: string,
+  body: ReturnType<typeof h>,
+) {
+  return h(
+    "details",
+    { class: "vh-invocation-inspector__group vh-invocation-inspector__disclosure" },
+    [
+      h("summary", { class: "vh-invocation-inspector__group-heading" }, [
+        h("span", { class: "vh-invocation-inspector__group-icon" }, [inspectorIcon(icon)]),
+        h("strong", title),
+        h("small", summary),
+        renderChevronDown("vh-invocation-inspector__chevron"),
+      ]),
+      body,
+    ],
+  );
 }
 
 function renderConfiguration(configuration: AgentInvocationConfiguration) {
+  const driver = configurationLabel(configuration);
   const workspace = workspaceLabel(configuration);
-  const disclosures = [
-    configuration.instructions?.length
-      ? h("details", { class: "vh-invocation-inspector__disclosure" }, [
-          h("summary", [h("span", "System instructions"), h("small", `${configuration.instructions.length} block${configuration.instructions.length === 1 ? "" : "s"}`)]),
-          h("pre", { class: "vh-invocation-inspector__instructions" }, configuration.instructions.join("\n\n")),
+  const setup = [
+    inspectorRow("Driver", driver, "driver"),
+    inspectorRow("Runtime", configuration.runtime?.name, "runtime"),
+    inspectorRow("Workspace", workspace, "workspace"),
+  ].filter((item) => item !== null);
+  const groups = [
+    setup.length
+      ? h("div", { class: "vh-invocation-inspector__group" }, [
+          h("div", { class: "vh-invocation-inspector__group-heading" }, [
+            h("span", { class: "vh-invocation-inspector__group-icon" }, [inspectorIcon("driver")]),
+            h("strong", "Execution"),
+          ]),
+          h("dl", { class: "vh-invocation-inspector__list" }, setup),
         ])
       : null,
     configuration.workspace?.sources?.length
-      ? h("details", { class: "vh-invocation-inspector__disclosure" }, [
-          h("summary", [h("span", "Workspace sources"), h("small", `${configuration.workspace.sources.length}`)]),
-          h("ul", { class: "vh-invocation-inspector__items" }, configuration.workspace.sources.map(source =>
-            h("li", [h("span", { "aria-hidden": "true" }, "↳"), h("code", source)]),
-          )),
-        ])
+      ? inspectorCollection("Sources", "source", configuration.workspace.sources)
       : null,
     configuration.capabilities?.length
-      ? h("details", { class: "vh-invocation-inspector__disclosure" }, [
-          h("summary", [h("span", "Capabilities"), h("small", `${configuration.capabilities.length}`)]),
-          h("div", { class: "vh-invocation-inspector__stack" }, configuration.capabilities.map(capability =>
-            h("details", { class: "vh-invocation-inspector__disclosure" }, [
-              h("summary", [h("span", capability.id), capability.metadata ? h("small", "Metadata") : null]),
-              capability.metadata ? h("pre", JSON.stringify(capability.metadata, null, 2)) : h("p", "No additional metadata."),
+      ? h("div", { class: "vh-invocation-inspector__group" }, [
+          h("div", { class: "vh-invocation-inspector__group-heading" }, [
+            h("span", { class: "vh-invocation-inspector__group-icon" }, [
+              inspectorIcon("capability"),
             ]),
-          )),
+            h("strong", "Capabilities"),
+            h("small", configuration.capabilities.length),
+          ]),
+          h(
+            "div",
+            { class: "vh-invocation-inspector__stack" },
+            configuration.capabilities.map((capability) =>
+              capability.metadata
+                ? h(
+                    "details",
+                    { class: "vh-invocation-inspector__item-disclosure", key: capability.id },
+                    [
+                      h("summary", [
+                        h("code", capability.id),
+                        h("small", "Metadata"),
+                        renderChevronDown("vh-invocation-inspector__chevron"),
+                      ]),
+                      h("pre", JSON.stringify(capability.metadata, null, 2)),
+                    ],
+                  )
+                : h("div", { class: "vh-invocation-inspector__item", key: capability.id }, [
+                    h("code", capability.id),
+                  ]),
+            ),
+          ),
         ])
       : null,
     configuration.tools?.length
-      ? h("details", { class: "vh-invocation-inspector__disclosure" }, [
-          h("summary", [h("span", "Tools"), h("small", `${configuration.tools.length}`)]),
-          h("ul", { class: "vh-invocation-inspector__items" }, configuration.tools.map(tool =>
-            h("li", [h("span", { "aria-hidden": "true" }, "⌁"), h("code", tool.name)]),
-          )),
-        ])
+      ? inspectorCollection(
+          "Tools",
+          "tool",
+          configuration.tools.map((tool) => tool.name),
+        )
       : null,
-  ].filter(item => item !== null);
+    configuration.instructions?.length
+      ? inspectorDisclosure(
+          "Instructions",
+          "agent",
+          `${configuration.instructions.length} block${configuration.instructions.length === 1 ? "" : "s"}`,
+          h(
+            "pre",
+            { class: "vh-invocation-inspector__instructions" },
+            configuration.instructions.join("\n\n"),
+          ),
+        )
+      : null,
+  ].filter((item) => item !== null);
   return [
     configuration.truncated
-      ? inspectorSection("Configuration notice", h("p", "Some configuration values were truncated by the invocation journal."))
+      ? h("div", { class: "vh-invocation-inspector__notice", role: "note" }, [
+          h("strong", "Configuration truncated"),
+          h("p", "Some values were shortened by the invocation journal."),
+        ])
       : null,
-    inspectorSection("Agent definition", h("div", { class: "vh-invocation-inspector__configuration" }, [
-      workspace ? h("dl", { class: "vh-invocation-inspector__list" }, [inspectorRow("Workspace", workspace)]) : null,
-      ...disclosures,
-    ])),
+    groups.length
+      ? inspectorSection(
+          "Captured setup",
+          h("div", { class: "vh-invocation-inspector__groups" }, groups),
+        )
+      : null,
   ];
 }
 
@@ -737,32 +909,47 @@ export const AgentInvocationInspector = defineComponent({
     const copied = ref<"invocation" | "trace">();
     let copyTimer: ReturnType<typeof setTimeout> | undefined;
     const metrics = computed(() => ({
-      changes: activities.value.filter(activity => activity.kind === "change").length,
-      messages: activities.value.filter(activity => activity.kind === "message").length,
-      steps: activities.value.filter(activity => activity.kind !== "message").length,
+      changes: activities.value.filter((activity) => activity.kind === "change").length,
+      messages: activities.value.filter((activity) => activity.kind === "message").length,
+      steps: activities.value.filter((activity) => activity.kind !== "message").length,
       tokens: latestInvocationTokens(activities.value),
     }));
 
     async function copyIdentifier(kind: "invocation" | "trace", value: string | undefined) {
       if (!value || !("navigator" in globalThis) || !navigator.clipboard) return;
-      await navigator.clipboard.writeText(value);
+      try {
+        await navigator.clipboard.writeText(value);
+      } catch {
+        return;
+      }
       copied.value = kind;
       if (copyTimer) clearTimeout(copyTimer);
-      copyTimer = setTimeout(() => { copied.value = undefined; }, 1_600);
+      copyTimer = setTimeout(() => {
+        copied.value = undefined;
+      }, 1_600);
     }
 
     function copyAction(kind: "invocation" | "trace", label: string, value: string | undefined) {
       if (!value) return null;
       const didCopy = copied.value === kind;
-      return h("button", {
-        "aria-label": `Copy ${label}`,
-        class: "vh-invocation-inspector__copy",
-        onClick: () => void copyIdentifier(kind, value),
-        type: "button",
-      }, [
-        h("span", { class: "vh-invocation-inspector__copy-icon" }, [copyIcon(didCopy)]),
-        h("span", didCopy ? "Copied" : `Copy ${label}`),
-      ]);
+      return h(
+        "button",
+        {
+          "aria-label": didCopy ? `Copied ${label}` : `Copy ${label}`,
+          class: "vh-invocation-inspector__copy",
+          onClick: () => void copyIdentifier(kind, value),
+          type: "button",
+        },
+        [
+          h("span", { class: "vh-invocation-inspector__copy-label" }, label),
+          h(
+            "span",
+            { "aria-live": "polite", class: "vh-invocation-inspector__copy-state" },
+            didCopy ? "Copied" : "Copy",
+          ),
+          h("span", { class: "vh-invocation-inspector__copy-icon" }, [copyIcon(didCopy)]),
+        ],
+      );
     }
 
     onBeforeUnmount(() => {
@@ -771,47 +958,95 @@ export const AgentInvocationInspector = defineComponent({
 
     return () => {
       const configuration = props.invocation.configuration;
-      const endedAt = props.invocation.completedAt ?? props.invocation.failedAt ?? props.invocation.cancelledAt;
-      return h("aside", {
+      const agentName = configuration?.agent?.name ?? props.invocation.agentName;
+      const endedAt =
+        props.invocation.completedAt ?? props.invocation.failedAt ?? props.invocation.cancelledAt;
+      const duration =
+        formatDuration(props.invocation.startedAt, endedAt) ??
+        (props.invocation.status === "pending"
+          ? "Waiting to start"
+          : props.invocation.status === "running"
+            ? "In progress"
+            : "Duration unavailable");
+      return h(
+        "aside",
+        {
           "aria-label": "Session details",
           class: "vh-invocation-inspector",
           "data-status": props.invocation.status,
           "data-slot": "invocation-inspector",
-        }, [
+        },
+        [
           h("header", [
-            h("div", [h("h3", "Details"), h("p", invocationProject(props.invocation))]),
+            h("div", [h("p", invocationProject(props.invocation)), h("h3", "Invocation details")]),
             slots.actions?.({ invocation: props.invocation }),
           ]),
           h("div", { class: "vh-invocation-inspector__content" }, [
             h("section", { class: "vh-invocation-inspector__identity" }, [
-              h("div", { class: "vh-invocation-inspector__status" }, [
-                h("span", { class: "vh-invocation-inspector__status-icon", "aria-hidden": "true" }),
-                h("strong", statusLabel(props.invocation.status)),
-                h("small", formatDuration(props.invocation.startedAt, endedAt) ?? "In progress"),
-              ]),
+              h(
+                "div",
+                {
+                  "aria-atomic": "true",
+                  "aria-live": "polite",
+                  class: "vh-invocation-inspector__status",
+                  role: "status",
+                },
+                [
+                  h("span", { class: "vh-invocation-inspector__status-icon" }, [
+                    statusIcon(props.invocation.status),
+                  ]),
+                  h("strong", statusLabel(props.invocation.status)),
+                  h("small", duration),
+                ],
+              ),
               h("h4", invocationTitle(props.invocation)),
               invocationContext(props.invocation) !== props.invocation.id
                 ? h("p", invocationContext(props.invocation))
                 : null,
+              agentName
+                ? h("div", { class: "vh-invocation-inspector__agent" }, [
+                    h("span", { class: "vh-invocation-inspector__agent-icon" }, [
+                      inspectorIcon("agent"),
+                    ]),
+                    h("span", "Agent"),
+                    h("code", agentName),
+                  ])
+                : null,
+              props.invocation.error
+                ? h("div", { class: "vh-invocation-inspector__error" }, [
+                    h("strong", props.invocation.error.name ?? "Invocation failed"),
+                    h("p", props.invocation.error.message),
+                  ])
+                : null,
             ]),
-            inspectorSection("Run", h("dl", { class: "vh-invocation-inspector__list" }, [
-              inspectorRow("Agent", configuration?.agent?.name ?? props.invocation.agentName),
-              inspectorRow("Model", configuration?.driver?.model?.id),
-              inspectorRow("Provider", configuration?.driver?.model?.provider ?? configuration?.driver?.provider),
-              inspectorRow("Runtime", configuration?.runtime?.name ?? configuration?.driver?.kind),
-              inspectorRow("Messages", metrics.value.messages),
-              inspectorRow("Steps", metrics.value.steps),
-              metrics.value.changes ? inspectorRow("Changes", metrics.value.changes) : null,
-              metrics.value.tokens !== undefined ? inspectorRow("Tokens", new Intl.NumberFormat("en").format(metrics.value.tokens)) : null,
-            ])),
+            inspectorSection(
+              "Run summary",
+              h("dl", { class: "vh-invocation-inspector__metrics" }, [
+                h("div", [h("dt", "Messages"), h("dd", metrics.value.messages)]),
+                h("div", [h("dt", "Steps"), h("dd", metrics.value.steps)]),
+                metrics.value.changes
+                  ? h("div", [h("dt", "Changes"), h("dd", metrics.value.changes)])
+                  : null,
+                metrics.value.tokens !== undefined
+                  ? h("div", [
+                      h("dt", "Tokens"),
+                      h("dd", new Intl.NumberFormat("en").format(metrics.value.tokens)),
+                    ])
+                  : null,
+              ]),
+            ),
             ...(configuration ? renderConfiguration(configuration) : []),
             slots.metadata?.({ invocation: props.invocation }),
-            inspectorSection("Identifiers", h("div", { class: "vh-invocation-inspector__copy-list" }, [
-              copyAction("trace", "Trace ID", props.invocation.traceId),
-              copyAction("invocation", "Invocation ID", props.invocation.id),
-            ])),
+            inspectorSection(
+              "Identifiers",
+              h("div", { class: "vh-invocation-inspector__copy-list" }, [
+                copyAction("trace", "Trace ID", props.invocation.traceId),
+                copyAction("invocation", "Invocation ID", props.invocation.id),
+              ]),
+            ),
           ]),
-        ]);
+        ],
+      );
     };
   },
 });

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -73,7 +73,7 @@ function formatDuration(startedAt: string | undefined, completedAt: string | und
   return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
 }
 
-function configurationLabel(configuration: AgentInvocationConfiguration): string | undefined {
+function driverLabel(configuration: AgentInvocationConfiguration): string | undefined {
   const driver = configuration.driver;
   const model = driver?.model;
   return [
@@ -492,17 +492,13 @@ function renderActivityGroup(
   ]);
 }
 
-function inspectorSection(title: string, body: ReturnType<typeof h> | null) {
-  return body ? h("section", [h("h4", title), body]) : null;
+function inspectorSection(title: string, body: ReturnType<typeof h>) {
+  return h("section", [h("h4", title), body]);
 }
 
-function inspectorRow(label: string, value: string | number | undefined, icon?: InspectorIcon) {
+function inspectorRow(label: string, value: string | number | undefined) {
   if (value === undefined || value === "") return null;
-  return h("div", [
-    icon ? h("span", { class: "vh-invocation-inspector__row-icon" }, [inspectorIcon(icon)]) : null,
-    h("dt", label),
-    h("dd", String(value)),
-  ]);
+  return h("div", [h("dt", label), h("dd", String(value))]);
 }
 
 function copyIcon(copied: boolean) {
@@ -519,57 +515,6 @@ function copyIcon(copied: boolean) {
             "stroke-linejoin": "round",
           }),
         ],
-  );
-}
-
-type InspectorIcon =
-  | "agent"
-  | "capability"
-  | "driver"
-  | "runtime"
-  | "source"
-  | "tool"
-  | "workspace";
-
-const inspectorIconPaths: Record<InspectorIcon, readonly string[]> = {
-  agent: ["M12 8V4H8", "M4 8h16v10H4z", "M8 12h.01", "M16 12h.01"],
-  capability: ["M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10", "m9 12 2 2 4-4"],
-  driver: [
-    "M9 2v3",
-    "M15 2v3",
-    "M9 19v3",
-    "M15 19v3",
-    "M2 9h3",
-    "M2 15h3",
-    "M19 9h3",
-    "M19 15h3",
-    "M5 5h14v14H5z",
-    "M9 9h6v6H9z",
-  ],
-  runtime: ["m16 18 6-6-6-6", "m8 6-6 6 6 6"],
-  source: [
-    "M6 3v12",
-    "M18 9a3 3 0 1 0 0-6 3 3 0 0 0 0 6",
-    "M6 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6",
-    "M18 9a9 9 0 0 1-9 9",
-  ],
-  tool: [
-    "M14.7 6.3a4 4 0 0 0-5-5l2.1 2.1-2.4 2.4-2.1-2.1a4 4 0 0 0 5 5L3 18l3 3 9.3-9.3a4 4 0 0 0 5-5l-2.1 2.1-2.4-2.4z",
-  ],
-  workspace: ["M3 6.5h6l2 2h10v9.5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"],
-};
-
-function inspectorIcon(icon: InspectorIcon) {
-  return h(
-    "svg",
-    { "aria-hidden": "true", fill: "none", viewBox: "0 0 24 24" },
-    inspectorIconPaths[icon].map((path) =>
-      h("path", {
-        d: path,
-        "stroke-linecap": "round",
-        "stroke-linejoin": "round",
-      }),
-    ),
   );
 }
 
@@ -594,10 +539,9 @@ function statusIcon(status: AgentInvocationView["status"]) {
   );
 }
 
-function inspectorCollection(title: string, icon: InspectorIcon, items: readonly string[]) {
+function inspectorCollection(title: string, items: readonly string[]) {
   return h("div", { class: "vh-invocation-inspector__group" }, [
     h("div", { class: "vh-invocation-inspector__group-heading" }, [
-      h("span", { class: "vh-invocation-inspector__group-icon" }, [inspectorIcon(icon)]),
       h("strong", title),
       h("small", items.length),
     ]),
@@ -611,7 +555,6 @@ function inspectorCollection(title: string, icon: InspectorIcon, items: readonly
 
 function inspectorDisclosure(
   title: string,
-  icon: InspectorIcon,
   summary: string,
   body: ReturnType<typeof h>,
 ) {
@@ -620,7 +563,6 @@ function inspectorDisclosure(
     { class: "vh-invocation-inspector__group vh-invocation-inspector__disclosure" },
     [
       h("summary", { class: "vh-invocation-inspector__group-heading" }, [
-        h("span", { class: "vh-invocation-inspector__group-icon" }, [inspectorIcon(icon)]),
         h("strong", title),
         h("small", summary),
         renderChevronDown("vh-invocation-inspector__chevron"),
@@ -631,32 +573,28 @@ function inspectorDisclosure(
 }
 
 function renderConfiguration(configuration: AgentInvocationConfiguration) {
-  const driver = configurationLabel(configuration);
+  const driver = driverLabel(configuration);
   const workspace = workspaceLabel(configuration);
   const setup = [
-    inspectorRow("Driver", driver, "driver"),
-    inspectorRow("Runtime", configuration.runtime?.name, "runtime"),
-    inspectorRow("Workspace", workspace, "workspace"),
+    inspectorRow("Driver", driver),
+    inspectorRow("Runtime", configuration.runtime?.name),
+    inspectorRow("Workspace", workspace),
   ].filter((item) => item !== null);
   const groups = [
     setup.length
       ? h("div", { class: "vh-invocation-inspector__group" }, [
           h("div", { class: "vh-invocation-inspector__group-heading" }, [
-            h("span", { class: "vh-invocation-inspector__group-icon" }, [inspectorIcon("driver")]),
             h("strong", "Execution"),
           ]),
           h("dl", { class: "vh-invocation-inspector__list" }, setup),
         ])
       : null,
     configuration.workspace?.sources?.length
-      ? inspectorCollection("Sources", "source", configuration.workspace.sources)
+      ? inspectorCollection("Sources", configuration.workspace.sources)
       : null,
     configuration.capabilities?.length
       ? h("div", { class: "vh-invocation-inspector__group" }, [
           h("div", { class: "vh-invocation-inspector__group-heading" }, [
-            h("span", { class: "vh-invocation-inspector__group-icon" }, [
-              inspectorIcon("capability"),
-            ]),
             h("strong", "Capabilities"),
             h("small", configuration.capabilities.length),
           ]),
@@ -687,14 +625,12 @@ function renderConfiguration(configuration: AgentInvocationConfiguration) {
     configuration.tools?.length
       ? inspectorCollection(
           "Tools",
-          "tool",
           configuration.tools.map((tool) => tool.name),
         )
       : null,
     configuration.instructions?.length
       ? inspectorDisclosure(
           "Instructions",
-          "agent",
           `${configuration.instructions.length} block${configuration.instructions.length === 1 ? "" : "s"}`,
           h(
             "pre",
@@ -1005,9 +941,6 @@ export const AgentInvocationInspector = defineComponent({
                 : null,
               agentName
                 ? h("div", { class: "vh-invocation-inspector__agent" }, [
-                    h("span", { class: "vh-invocation-inspector__agent-icon" }, [
-                      inspectorIcon("agent"),
-                    ]),
                     h("span", "Agent"),
                     h("code", agentName),
                   ])

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -1193,6 +1193,7 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 .vh-invocation-inspector {
   background: var(--vh-ui-bg);
   border-inline-start: 1px solid var(--vh-ui-border);
+  container-type: inline-size;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   height: 100%;
@@ -1205,116 +1206,331 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   align-items: center;
   border-block-end: 1px solid var(--vh-ui-border);
   display: flex;
+  gap: 0.75rem;
   justify-content: space-between;
-  min-height: 3.25rem;
-  padding: 0.55rem 0.8rem;
+  min-height: 3.5rem;
+  padding: 0.6rem 0.9rem;
 }
 
 .vh-invocation-inspector > header h3 {
-  font-size: 0.8125rem;
+  font-size: 0.875rem;
   font-weight: 650;
-  margin: 0;
+  line-height: 1.25;
+  margin: 0.1rem 0 0;
 }
 
 .vh-invocation-inspector > header p {
   color: var(--vh-ui-dimmed);
-  font-size: 0.6875rem;
-  margin: 0.15rem 0 0;
+  font-size: 0.625rem;
+  font-weight: 600;
+  letter-spacing: 0.055em;
+  margin: 0;
+  text-transform: uppercase;
 }
 
 .vh-invocation-inspector__content {
   min-height: 0;
   overflow-y: auto;
   overscroll-behavior-y: contain;
-  padding: 0 0.9rem 1.5rem;
+  padding: 0 1rem 2rem;
   scrollbar-gutter: stable;
 }
 
 .vh-invocation-inspector__content > section {
-  border-block-end: 1px solid var(--vh-ui-border);
-  padding-block: 0.9rem;
+  padding-block: 1rem 0.2rem;
 }
 
 .vh-invocation-inspector__content > section:first-child {
-  padding-block-start: 0;
+  padding-block-start: 1rem;
 }
 
-.vh-invocation-inspector__content h4 {
+.vh-invocation-inspector__content > section > h4 {
   color: var(--vh-ui-muted);
-  font-size: 0.6875rem;
+  font-size: 0.625rem;
   font-weight: 650;
-  letter-spacing: 0.065em;
-  margin: 0 0 0.65rem;
+  letter-spacing: 0.075em;
+  margin: 0 0 0.6rem;
   text-transform: uppercase;
 }
 
 .vh-invocation-inspector__status {
   align-items: center;
+  background: color-mix(in oklab, var(--vh-ui-bg-elevated) 72%, transparent);
+  border: 1px solid var(--vh-ui-border);
+  border-radius: 999px;
   display: flex;
-  gap: 0.4rem;
+  gap: 0.35rem;
+  min-height: 1.75rem;
+  padding: 0.2rem 0.5rem 0.2rem 0.35rem;
+  width: fit-content;
 }
 
 .vh-invocation-inspector__status strong {
-  font-size: 0.75rem;
+  font-size: 0.6875rem;
+  font-weight: 650;
 }
 
 .vh-invocation-inspector__status small {
   color: var(--vh-ui-dimmed);
-  font-size: 0.6875rem;
-  margin-inline-start: auto;
+  font-size: 0.625rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.vh-invocation-inspector__status small::before {
+  color: var(--vh-ui-border);
+  content: "·";
+  margin-inline-end: 0.35rem;
+}
+
+.vh-invocation-inspector__status-icon {
+  align-items: center;
+  color: var(--vh-ui-muted);
+  display: inline-flex;
+  justify-content: center;
+}
+
+.vh-invocation-inspector__status-icon svg {
+  height: 0.875rem;
+  stroke: currentColor;
+  stroke-width: 2;
+  width: 0.875rem;
+}
+
+.vh-invocation-inspector[data-status="running"] .vh-invocation-inspector__status {
+  color: var(--ui-info, #0284c7);
+}
+
+.vh-invocation-inspector[data-status="running"] .vh-invocation-inspector__status-icon svg {
+  animation: vh-invocation-status-spin 800ms linear infinite;
+}
+
+.vh-invocation-inspector[data-status="completed"] .vh-invocation-inspector__status {
+  color: var(--ui-success, #15803d);
+}
+
+.vh-invocation-inspector[data-status="failed"] .vh-invocation-inspector__status {
+  color: var(--vh-ui-error);
+}
+
+.vh-invocation-inspector[data-status="pending"] .vh-invocation-inspector__status {
+  color: var(--ui-warning, #a16207);
 }
 
 .vh-invocation-inspector__identity h4 {
   color: var(--vh-ui-text);
-  font-size: 0.875rem;
-  font-weight: 600;
-  letter-spacing: 0;
-  line-height: 1.4;
-  margin: 0.7rem 0 0;
+  font-size: 1rem;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+  line-height: 1.35;
+  margin: 0.8rem 0 0;
   text-transform: none;
 }
 
 .vh-invocation-inspector__identity p {
   color: var(--vh-ui-dimmed);
-  font-size: 0.6875rem;
+  font-size: 0.75rem;
   line-height: 1.45;
-  margin: 0.2rem 0 0;
+  margin: 0.25rem 0 0;
   overflow-wrap: anywhere;
 }
 
-.vh-invocation-inspector__list dt {
+.vh-invocation-inspector__agent {
+  align-items: center;
+  color: var(--vh-ui-dimmed);
+  display: flex;
+  font-size: 0.6875rem;
+  gap: 0.35rem;
+  margin-block-start: 0.75rem;
+}
+
+.vh-invocation-inspector__agent code {
   color: var(--vh-ui-muted);
+  font-size: 0.6875rem;
+}
+
+.vh-invocation-inspector__agent-icon,
+.vh-invocation-inspector__row-icon,
+.vh-invocation-inspector__group-icon {
+  align-items: center;
+  display: inline-flex;
+  flex: none;
+  justify-content: center;
+}
+
+.vh-invocation-inspector__agent-icon svg,
+.vh-invocation-inspector__row-icon svg,
+.vh-invocation-inspector__group-icon svg {
+  height: 0.875rem;
+  stroke: currentColor;
+  stroke-width: 1.75;
+  width: 0.875rem;
+}
+
+.vh-invocation-inspector__error,
+.vh-invocation-inspector__notice {
+  border: 1px solid color-mix(in oklab, currentColor 18%, transparent);
+  border-radius: calc(var(--vh-ui-radius) * 1.1);
+  margin-block-start: 0.9rem;
+  padding: 0.7rem 0.75rem;
+}
+
+.vh-invocation-inspector__error {
+  background: color-mix(in oklab, var(--vh-ui-error) 7%, transparent);
+  color: var(--vh-ui-error);
+}
+
+.vh-invocation-inspector__notice {
+  background: color-mix(in oklab, var(--ui-warning, #a16207) 7%, transparent);
+  color: var(--ui-warning, #a16207);
+  margin-block-start: 1rem;
+}
+
+.vh-invocation-inspector__error strong,
+.vh-invocation-inspector__notice strong {
+  font-size: 0.75rem;
+  font-weight: 650;
+}
+
+.vh-invocation-inspector__error p,
+.vh-invocation-inspector__notice p {
+  color: inherit;
+  font-size: 0.6875rem;
+  margin: 0.2rem 0 0;
+}
+
+.vh-invocation-inspector__metrics {
+  display: grid;
+  gap: 0.375rem;
+  grid-template-columns: repeat(auto-fit, minmax(4.75rem, 1fr));
+  margin: 0;
+}
+
+.vh-invocation-inspector__metrics > div {
+  background: color-mix(in oklab, var(--vh-ui-bg-elevated) 72%, transparent);
+  border: 1px solid var(--vh-ui-border);
+  border-radius: calc(var(--vh-ui-radius) * 1.05);
+  min-width: 0;
+  padding: 0.55rem 0.6rem;
+}
+
+.vh-invocation-inspector__metrics dt {
+  color: var(--vh-ui-dimmed);
+  font-size: 0.625rem;
+  line-height: 1.2;
+}
+
+.vh-invocation-inspector__metrics dd {
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 650;
+  margin: 0.25rem 0 0;
+  overflow-wrap: anywhere;
+}
+
+.vh-invocation-inspector__groups {
+  border: 1px solid var(--vh-ui-border);
+  border-radius: calc(var(--vh-ui-radius) * 1.2);
+  overflow: hidden;
+}
+
+.vh-invocation-inspector__group {
+  min-width: 0;
+  padding: 0.7rem 0.75rem;
+}
+
+.vh-invocation-inspector__group + .vh-invocation-inspector__group {
+  border-block-start: 1px solid var(--vh-ui-border);
+}
+
+.vh-invocation-inspector__group-heading {
+  align-items: center;
+  color: var(--vh-ui-muted);
+  display: flex;
+  gap: 0.45rem;
+  min-height: 1.25rem;
+  min-width: 0;
+}
+
+.vh-invocation-inspector__group-heading strong {
+  color: var(--vh-ui-text);
+  flex: 1;
+  font-size: 0.75rem;
+  font-weight: 600;
+  min-width: 0;
+}
+
+.vh-invocation-inspector__group-heading small {
+  color: var(--vh-ui-dimmed);
+  font-size: 0.625rem;
+  font-variant-numeric: tabular-nums;
+}
+
+summary.vh-invocation-inspector__group-heading,
+.vh-invocation-inspector__item-disclosure summary {
+  cursor: pointer;
+  list-style: none;
+}
+
+summary.vh-invocation-inspector__group-heading::-webkit-details-marker,
+.vh-invocation-inspector__item-disclosure summary::-webkit-details-marker {
+  display: none;
+}
+
+summary.vh-invocation-inspector__group-heading:focus-visible,
+.vh-invocation-inspector__item-disclosure summary:focus-visible {
+  border-radius: calc(var(--vh-ui-radius) * 0.8);
+  outline: 2px solid color-mix(in oklab, var(--ui-primary, #2563eb) 55%, transparent);
+  outline-offset: 2px;
+}
+
+.vh-invocation-inspector__chevron {
+  height: 0.8rem;
+  stroke: currentColor;
+  stroke-width: 2;
+  transition: transform 150ms ease;
+  width: 0.8rem;
+}
+
+.vh-invocation-inspector__disclosure[open] > summary .vh-invocation-inspector__chevron,
+.vh-invocation-inspector__item-disclosure[open] > summary .vh-invocation-inspector__chevron {
+  transform: rotate(180deg);
+}
+
+.vh-invocation-inspector__list {
+  display: grid;
+  margin: 0.45rem 0 0;
+}
+
+.vh-invocation-inspector__list > div {
+  align-items: center;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: 0.875rem minmax(4.5rem, 0.7fr) minmax(0, 1.3fr);
+  min-width: 0;
+  padding-block: 0.35rem;
+}
+
+.vh-invocation-inspector__list dt {
+  color: var(--vh-ui-dimmed);
   font-size: 0.6875rem;
 }
 
 .vh-invocation-inspector__list dd {
   font-size: 0.6875rem;
   margin: 0;
+  min-width: 0;
   overflow-wrap: anywhere;
   text-align: end;
 }
 
-.vh-invocation-inspector__list {
-  display: grid;
-  margin: 0;
-}
-
-.vh-invocation-inspector__list > div {
-  align-items: baseline;
-  display: grid;
-  gap: 0.75rem;
-  grid-template-columns: minmax(4.5rem, 0.7fr) minmax(0, 1.3fr);
-  padding-block: 0.35rem;
-}
-
-.vh-invocation-inspector__list code {
-  color: var(--vh-ui-muted);
-  font-size: 0.625rem;
+.vh-invocation-inspector__row-icon {
+  color: var(--vh-ui-dimmed);
 }
 
 .vh-invocation-inspector__copy-list {
-  display: grid;
-  gap: 0.125rem;
+  border: 1px solid var(--vh-ui-border);
+  border-radius: calc(var(--vh-ui-radius) * 1.05);
+  overflow: hidden;
 }
 
 .vh-invocation-inspector__copy {
@@ -1322,18 +1538,39 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   appearance: none;
   background: transparent;
   border: 0;
-  border-radius: calc(var(--vh-ui-radius) * 0.8);
   color: var(--vh-ui-muted);
   cursor: pointer;
-  display: flex;
+  display: grid;
   font: inherit;
-  font-size: 0.75rem;
   gap: 0.5rem;
-  min-height: 2rem;
-  padding: 0.35rem 0.45rem;
+  grid-template-columns: minmax(0, 1fr) auto 1rem;
+  min-height: 2.4rem;
+  padding: 0.45rem 0.65rem;
   text-align: start;
-  transition: background-color 120ms ease, color 120ms ease;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease,
+    transform 120ms ease;
   width: 100%;
+}
+
+.vh-invocation-inspector__copy + .vh-invocation-inspector__copy {
+  border-block-start: 1px solid var(--vh-ui-border);
+}
+
+.vh-invocation-inspector__copy-label {
+  color: var(--vh-ui-text);
+  font-size: 0.75rem;
+  min-width: 0;
+}
+
+.vh-invocation-inspector__copy-state {
+  color: var(--vh-ui-dimmed);
+  font-size: 0.625rem;
+}
+
+.vh-invocation-inspector__copy:active {
+  transform: scale(0.98);
 }
 
 .vh-invocation-inspector__copy:hover,
@@ -1343,14 +1580,13 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 }
 
 .vh-invocation-inspector__copy:focus-visible {
-  outline: 1px solid color-mix(in oklab, var(--ui-primary, #2563eb) 55%, transparent);
-  outline-offset: 1px;
+  outline: 2px solid color-mix(in oklab, var(--ui-primary, #2563eb) 55%, transparent);
+  outline-offset: -2px;
 }
 
 .vh-invocation-inspector__copy-icon {
   align-items: center;
   display: inline-flex;
-  flex: 0 0 1rem;
   justify-content: center;
 }
 
@@ -1364,85 +1600,92 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 .vh-invocation-inspector__stack {
   display: grid;
   gap: 0.125rem;
+  margin-block-start: 0.45rem;
 }
 
-.vh-invocation-inspector__configuration {
-  display: grid;
-  gap: 0.125rem;
-}
-
-.vh-invocation-inspector__configuration > .vh-invocation-inspector__list {
-  margin-block-end: 0.25rem;
-}
-
-.vh-invocation-inspector__disclosure {
-  border-radius: calc(var(--vh-ui-radius) * 0.8);
-}
-
-.vh-invocation-inspector__disclosure summary {
+.vh-invocation-inspector__item,
+.vh-invocation-inspector__item-disclosure summary {
   align-items: center;
-  border-radius: inherit;
-  cursor: pointer;
+  border-radius: calc(var(--vh-ui-radius) * 0.8);
   display: flex;
-  font-size: 0.75rem;
-  justify-content: space-between;
-  list-style: none;
-  min-height: 2rem;
-  padding: 0.35rem 0.45rem;
-  transition: background-color 120ms ease;
+  gap: 0.45rem;
+  min-height: 1.8rem;
+  padding: 0.3rem 0.45rem;
 }
 
-.vh-invocation-inspector__disclosure summary:hover,
-.vh-invocation-inspector__disclosure summary:focus-visible {
+.vh-invocation-inspector__item code,
+.vh-invocation-inspector__item-disclosure summary code {
+  flex: 1;
+  font-size: 0.6875rem;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.vh-invocation-inspector__item-disclosure summary:hover {
   background: color-mix(in oklab, var(--vh-ui-bg-elevated) 70%, transparent);
 }
 
-.vh-invocation-inspector__disclosure summary small {
+.vh-invocation-inspector__item-disclosure summary small {
   color: var(--vh-ui-dimmed);
   font-size: 0.625rem;
 }
 
 .vh-invocation-inspector__items {
-  display: grid;
-  gap: 0.125rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
   list-style: none;
-  margin: 0;
+  margin: 0.6rem 0 0;
   padding: 0;
 }
 
 .vh-invocation-inspector__items li {
-  align-items: center;
+  background: color-mix(in oklab, var(--vh-ui-bg-elevated) 72%, transparent);
+  border: 1px solid var(--vh-ui-border);
+  border-radius: calc(var(--vh-ui-radius) * 0.8);
   color: var(--vh-ui-muted);
-  display: flex;
-  font-size: 0.6875rem;
-  gap: 0.45rem;
-  min-height: 1.75rem;
-  padding-inline: 0.45rem;
-}
-
-.vh-invocation-inspector__items li > span {
-  color: var(--vh-ui-dimmed);
+  max-width: 100%;
+  padding: 0.25rem 0.45rem;
 }
 
 .vh-invocation-inspector__items code {
+  display: block;
   font-size: 0.6875rem;
   overflow-wrap: anywhere;
 }
 
-.vh-invocation-inspector__stack pre,
+.vh-invocation-inspector__item-disclosure pre,
 .vh-invocation-inspector__instructions {
   background: color-mix(in oklab, var(--vh-ui-bg-elevated) 65%, transparent);
-  border: 0;
-  border-inline-start: 1px solid var(--vh-ui-border);
-  border-radius: 0;
+  border: 1px solid var(--vh-ui-border);
+  border-radius: calc(var(--vh-ui-radius) * 0.8);
   color: var(--vh-ui-muted);
   font-size: 0.625rem;
   line-height: 1.55;
-  margin: 0.25rem 0.45rem 0.5rem;
+  margin: 0.4rem 0 0;
   max-height: 18rem;
   overflow: auto;
-  padding: 0.55rem 0.65rem;
+  padding: 0.6rem 0.65rem;
   white-space: pre-wrap;
+}
+
+.vh-invocation-inspector__instructions {
+  margin-block-start: 0.65rem;
+}
+
+@container (max-width: 19rem) {
+  .vh-invocation-inspector__metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .vh-invocation-inspector__list > div {
+    grid-template-columns: 0.875rem minmax(0, 1fr);
+  }
+
+  .vh-invocation-inspector__list dd {
+    grid-column: 2;
+    text-align: start;
+  }
 }
 
 .vh-invocation-empty {

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -560,30 +560,6 @@
   padding: 1.5rem 2rem 4rem;
 }
 
-.vh-invocation-inspector__status-icon {
-  background: var(--vh-ui-dimmed);
-  border-radius: 999px;
-  display: inline-block;
-  flex: none;
-}
-
-.vh-invocation-inspector__status-icon {
-  height: 0.55rem;
-  width: 0.55rem;
-}
-
-.vh-invocation-inspector[data-status="running"] .vh-invocation-inspector__status-icon {
-  background: var(--ui-info, #0284c7);
-}
-
-.vh-invocation-inspector[data-status="completed"] .vh-invocation-inspector__status-icon {
-  background: var(--ui-success, #16a34a);
-}
-
-.vh-invocation-inspector[data-status="failed"] .vh-invocation-inspector__status-icon {
-  background: var(--vh-ui-error);
-}
-
 .vh-invocation-session__error {
   background: color-mix(in oklab, var(--vh-ui-error) 7%, transparent);
   border: 1px solid color-mix(in oklab, var(--vh-ui-error) 22%, transparent);
@@ -1286,6 +1262,7 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   align-items: center;
   color: var(--vh-ui-muted);
   display: inline-flex;
+  flex: none;
   justify-content: center;
 }
 
@@ -1346,24 +1323,6 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 .vh-invocation-inspector__agent code {
   color: var(--vh-ui-muted);
   font-size: 0.6875rem;
-}
-
-.vh-invocation-inspector__agent-icon,
-.vh-invocation-inspector__row-icon,
-.vh-invocation-inspector__group-icon {
-  align-items: center;
-  display: inline-flex;
-  flex: none;
-  justify-content: center;
-}
-
-.vh-invocation-inspector__agent-icon svg,
-.vh-invocation-inspector__row-icon svg,
-.vh-invocation-inspector__group-icon svg {
-  height: 0.875rem;
-  stroke: currentColor;
-  stroke-width: 1.75;
-  width: 0.875rem;
 }
 
 .vh-invocation-inspector__error,
@@ -1505,7 +1464,7 @@ summary.vh-invocation-inspector__group-heading:focus-visible,
   align-items: center;
   display: grid;
   gap: 0.5rem;
-  grid-template-columns: 0.875rem minmax(4.5rem, 0.7fr) minmax(0, 1.3fr);
+  grid-template-columns: minmax(4.5rem, 0.7fr) minmax(0, 1.3fr);
   min-width: 0;
   padding-block: 0.35rem;
 }
@@ -1521,10 +1480,6 @@ summary.vh-invocation-inspector__group-heading:focus-visible,
   min-width: 0;
   overflow-wrap: anywhere;
   text-align: end;
-}
-
-.vh-invocation-inspector__row-icon {
-  color: var(--vh-ui-dimmed);
 }
 
 .vh-invocation-inspector__copy-list {
@@ -1549,8 +1504,7 @@ summary.vh-invocation-inspector__group-heading:focus-visible,
   text-align: start;
   transition:
     background-color 120ms ease,
-    color 120ms ease,
-    transform 120ms ease;
+    color 120ms ease;
   width: 100%;
 }
 
@@ -1567,10 +1521,6 @@ summary.vh-invocation-inspector__group-heading:focus-visible,
 .vh-invocation-inspector__copy-state {
   color: var(--vh-ui-dimmed);
   font-size: 0.625rem;
-}
-
-.vh-invocation-inspector__copy:active {
-  transform: scale(0.98);
 }
 
 .vh-invocation-inspector__copy:hover,
@@ -1679,11 +1629,10 @@ summary.vh-invocation-inspector__group-heading:focus-visible,
   }
 
   .vh-invocation-inspector__list > div {
-    grid-template-columns: 0.875rem minmax(0, 1fr);
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .vh-invocation-inspector__list dd {
-    grid-column: 2;
     text-align: start;
   }
 }
@@ -1744,5 +1693,9 @@ summary.vh-invocation-inspector__group-heading:focus-visible,
   .vh-invocation-list__item[data-status="running"] .vh-invocation-list__state-icon svg,
   .vh-invocation-inspector[data-status="running"] .vh-invocation-inspector__status-icon svg {
     animation: none;
+  }
+
+  .vh-invocation-inspector__chevron {
+    transition: none;
   }
 }

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -1741,7 +1741,8 @@ summary.vh-invocation-inspector__group-heading:focus-visible,
     scroll-behavior: auto;
   }
 
-  .vh-invocation-list__item[data-status="running"] .vh-invocation-list__state-icon svg {
+  .vh-invocation-list__item[data-status="running"] .vh-invocation-list__state-icon svg,
+  .vh-invocation-inspector[data-status="running"] .vh-invocation-inspector__status-icon svg {
     animation: none;
   }
 }

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -691,8 +691,53 @@ describe("Agent Invocation UI", () => {
     await Promise.resolve();
 
     expect(writeText).toHaveBeenCalledWith(invocation.traceId);
-    expect(wrapper.get('button[aria-label="Copy Trace ID"]').text()).toContain("Copied");
+    expect(wrapper.get('button[aria-label="Copied Trace ID"]').text()).toContain("Copied");
     wrapper.unmount();
+  });
+
+  it("keeps clipboard failures recoverable", async () => {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        writeText: vi.fn(async () => {
+          throw new Error("Denied");
+        }),
+      },
+    });
+    const invocation: AgentInvocationView = {
+      createdAt: "2026-08-22T00:00:00.000Z",
+      id: "invocation",
+      observations: [],
+      status: "completed",
+      traceId: "trace",
+      updatedAt: "2026-08-22T00:00:01.000Z",
+    };
+    const wrapper = mount(AgentInvocationInspector, { props: { invocation } });
+
+    await wrapper.get('button[aria-label="Copy Trace ID"]').trigger("click");
+    await Promise.resolve();
+
+    expect(wrapper.get('button[aria-label="Copy Trace ID"]').text()).toContain("Copy");
+  });
+
+  it("surfaces the terminal error beside the exact status", () => {
+    const invocation: AgentInvocationView = {
+      createdAt: "2026-08-22T00:00:00.000Z",
+      error: { message: "The provider stopped before returning a result.", name: "Provider error" },
+      failedAt: "2026-08-22T00:00:05.000Z",
+      id: "failed",
+      observations: [],
+      startedAt: "2026-08-22T00:00:00.000Z",
+      status: "failed",
+      traceId: "trace",
+      updatedAt: "2026-08-22T00:00:05.000Z",
+    };
+    const wrapper = mount(AgentInvocationInspector, { props: { invocation } });
+
+    expect(wrapper.get('[role="status"]').text()).toContain("Failed");
+    expect(wrapper.get(".vh-invocation-inspector__error").text()).toBe(
+      "Provider errorThe provider stopped before returning a result.",
+    );
   });
 
   it("uses the cancellation timestamp for terminal duration", () => {
@@ -1241,7 +1286,7 @@ describe("Agent Invocation UI", () => {
     expect(groups[1]!.get(".vh-invocation-lifecycle__label").attributes("data-operation")).toBe("remove");
   });
 
-  it("shows recorded Agent Definition details in one inspector section", () => {
+  it("groups recorded Agent Definition details as captured setup", () => {
     const invocation: AgentInvocationView = {
       configuration: {
         agent: { name: "babysitter" },
@@ -1264,7 +1309,7 @@ describe("Agent Invocation UI", () => {
     expect(wrapper.get(".vh-invocation-inspector__content").text()).toContain("gpt-5.6-sol");
     expect(wrapper.get(".vh-invocation-inspector__content").text()).toContain("openai");
     expect(wrapper.get(".vh-invocation-inspector__content").text()).toContain("node");
-    expect(wrapper.findAll(".vh-invocation-inspector__content > section h4").map(node => node.text())).toContain("Agent definition");
-    expect(wrapper.get(".vh-invocation-inspector__configuration").text()).toContain("System instructions");
+    expect(wrapper.findAll(".vh-invocation-inspector__content > section h4").map(node => node.text())).toContain("Captured setup");
+    expect(wrapper.get(".vh-invocation-inspector__groups").text()).toContain("Instructions");
   });
 });


### PR DESCRIPTION
The invocation inspector exposed every recorded field with nearly equal visual weight, which made it hard to answer the first operational questions: what happened, how long it ran, and what setup produced the result.

This reworks the shared `AgentInvocationInspector` around that decision path while preserving its public prop and slot contract.

## Outcome

- Keep exact status, duration, title, Agent identity, and terminal errors visible at the top.
- Summarize messages, steps, changes, and tokens before the captured setup.
- Group driver, runtime, Workspace, Sources, Capabilities, tools, and instructions into a compact inspectable record.
- Use bounded native disclosures for Capability metadata and instructions, with visible keyboard focus and reduced-motion treatment.
- Keep trace and invocation identifiers hidden until copied, including recoverable clipboard failures.
- Update the docs example and reference copy to demonstrate structured driver and Capability metadata.

## Proof

- `corepack pnpm --filter @vite-hub/ui typecheck`
- `corepack pnpm --filter @vite-hub/ui test` (83 passing before the merged inspector-contract assertion was updated; the updated 54-test invocation suite passes)
- `corepack pnpm --filter @vite-hub/ui exec vp test run test/invocation-ui.test.ts` (54 passing)
- `corepack pnpm --filter vitehub-docs test` (59 passing)
- `corepack pnpm exec vp exec oxlint packages/ui/src/components/agent-invocation.ts packages/ui/test/invocation-ui.test.ts docs/app/components/content/examples/InvocationInspectorExample.vue`
- package build and publint pass as part of the UI test task
- `git diff HEAD^ --check`

## Visual QA

The implementation was checked against the production route and current shadcn/ui, AI Elements, and T3 Code interaction patterns. The T3 collaborative preview could not navigate to the local dev server, so desktop, narrow, light, and dark screenshot verification remains the explicit review risk.
