### PR TITLE
feat(console): switch between project Agents

### DIFF
--- a/fallow.toml
+++ b/fallow.toml
@@ -34,6 +34,7 @@ dynamicallyLoaded = [
   # Registered by the ViteHub Nuxt module and copied as packaged console runtime entries.
   "packages/vite-hub/src/console/runtime/client/*",
   "packages/vite-hub/src/console/runtime/pages/*.vue",
+  "packages/vite-hub/src/console/runtime/server/agents.get.ts",
   "packages/vite-hub/src/console/runtime/server/invocation.get.ts",
   "packages/vite-hub/src/console/runtime/server/invocations.get.ts",
   "packages/vite-hub/src/console/runtime/server/page.get.ts",

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -16,6 +16,7 @@ const folderAgentPattern = /^agent\.(?:c|m)?[jt]s$/i
 const evalDefinitionPattern = /^(?:.+\.)?eval\.(?:c|m)?[jt]s$/i
 const indexDefinitionPattern = /^index\.(?:c|m)?[jt]s$/i
 const colocatedAgentResourceDirectories = new Set(["skills"])
+const maxAgentNameLength = 512
 
 export const agentEvalFileConvention = {
   include: [
@@ -50,9 +51,17 @@ export function discoverAgentEvalFiles(rootDirs: string[]): string[] {
   ))].sort()
 }
 
+function normalizeDiscoveredAgentName(name: string): string {
+  const normalized = name.trim()
+  if (normalized.length > maxAgentNameLength) {
+    throw new TypeError("[vitehub] Agent names cannot exceed 512 characters.")
+  }
+  return normalized
+}
+
 function normalizeSuffixAgentName(rootDir: string, file: string) {
   const name = normalizeSuffixDefinitionName(rootDir, file, agentSuffixPattern, { stripPrefix: "src/" })
-  return name.startsWith("server/") ? undefined : name.trim()
+  return name.startsWith("server/") ? undefined : normalizeDiscoveredAgentName(name)
 }
 
 function stripComments(source: string) {
@@ -170,7 +179,7 @@ export function discoverAgentDefinitions(options:
             if (isColocatedAgentResourcePath(path)) return
           }
           if (isInsideFolderAgent(file, folderAgentDirs)) return
-          return relative(directory, file).replace(/\.(?:c|m)?[jt]s$/i, "").replace(/\/index$/i, "").trim()
+          return normalizeDiscoveredAgentName(relative(directory, file).replace(/\.(?:c|m)?[jt]s$/i, "").replace(/\/index$/i, ""))
         },
         createDefinition({ file, name }) {
           return {

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -111,6 +111,7 @@ function discoverFolderAgentDefinitions(scanDirs: string[]): DiscoveredAgentDefi
       entries = readdirSync(current, { withFileTypes: true })
     }
     catch (error) {
+      // SAFETY: Node filesystem errors expose `code`; other errors simply fail this comparison.
       if ((error as NodeJS.ErrnoException).code === "ENOENT") return
       throw error
     }
@@ -124,7 +125,7 @@ function discoverFolderAgentDefinitions(scanDirs: string[]): DiscoveredAgentDefi
 
       if (!entry.isFile() || (!folderAgentPattern.test(basename(file)) && !indexDefinitionPattern.test(basename(file)))) continue
       const source = readFileSync(file, "utf8")
-      const agent = relative(agentsRoot, dirname(file)).replace(/\\/g, "/").trim()
+      const agent = normalizeDiscoveredAgentName(relative(agentsRoot, dirname(file)).replace(/\\/g, "/"))
       if (!agent || agent === ".") continue
       const workspace = isWorkspaceAgentDefinition(source)
       candidates.push({

--- a/packages/agent/src/discovery.ts
+++ b/packages/agent/src/discovery.ts
@@ -52,7 +52,7 @@ export function discoverAgentEvalFiles(rootDirs: string[]): string[] {
 
 function normalizeSuffixAgentName(rootDir: string, file: string) {
   const name = normalizeSuffixDefinitionName(rootDir, file, agentSuffixPattern, { stripPrefix: "src/" })
-  return name.startsWith("server/") ? undefined : name
+  return name.startsWith("server/") ? undefined : name.trim()
 }
 
 function stripComments(source: string) {
@@ -115,7 +115,7 @@ function discoverFolderAgentDefinitions(scanDirs: string[]): DiscoveredAgentDefi
 
       if (!entry.isFile() || (!folderAgentPattern.test(basename(file)) && !indexDefinitionPattern.test(basename(file)))) continue
       const source = readFileSync(file, "utf8")
-      const agent = relative(agentsRoot, dirname(file)).replace(/\\/g, "/")
+      const agent = relative(agentsRoot, dirname(file)).replace(/\\/g, "/").trim()
       if (!agent || agent === ".") continue
       const workspace = isWorkspaceAgentDefinition(source)
       candidates.push({
@@ -170,7 +170,7 @@ export function discoverAgentDefinitions(options:
             if (isColocatedAgentResourcePath(path)) return
           }
           if (isInsideFolderAgent(file, folderAgentDirs)) return
-          return relative(directory, file).replace(/\.(?:c|m)?[jt]s$/i, "").replace(/\/index$/i, "")
+          return relative(directory, file).replace(/\.(?:c|m)?[jt]s$/i, "").replace(/\/index$/i, "").trim()
         },
         createDefinition({ file, name }) {
           return {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1870,7 +1870,7 @@ export const defineAgent: DefineAgent = ((options: unknown) => {
   let normalizedOptions = channels === agentOptions.channels
     ? agentOptions
     : { ...agentOptions, channels }
-  if (name && name !== normalizedOptions.name) normalizedOptions = { ...normalizedOptions, name }
+  if (name !== normalizedOptions.name) normalizedOptions = { ...normalizedOptions, name }
   if (isWorkspaceAgentOptions(normalizedOptions)) {
     return createWorkspaceAgentDefinition(normalizedOptions)
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1866,9 +1866,11 @@ export const defineAgent: DefineAgent = ((options: unknown) => {
   // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
   const agentOptions = options as AgentSettings
   const channels = normalizeAgentChannels(agentOptions.channels)
-  const normalizedOptions = channels === agentOptions.channels
+  const name = agentOptions.name?.trim()
+  let normalizedOptions = channels === agentOptions.channels
     ? agentOptions
     : { ...agentOptions, channels }
+  if (name && name !== normalizedOptions.name) normalizedOptions = { ...normalizedOptions, name }
   if (isWorkspaceAgentOptions(normalizedOptions)) {
     return createWorkspaceAgentDefinition(normalizedOptions)
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1867,6 +1867,9 @@ export const defineAgent: DefineAgent = ((options: unknown) => {
   const agentOptions = options as AgentSettings
   const channels = normalizeAgentChannels(agentOptions.channels)
   const name = agentOptions.name?.trim()
+  if (name && name.length > 512) {
+    throw new TypeError("[vitehub] Agent names cannot exceed 512 characters.")
+  }
   let normalizedOptions = channels === agentOptions.channels
     ? agentOptions
     : { ...agentOptions, channels }

--- a/packages/agent/src/invocations.ts
+++ b/packages/agent/src/invocations.ts
@@ -57,6 +57,7 @@ export interface AgentInvocationRecord {
 }
 
 export interface AgentInvocationListOptions {
+  agentName?: string
   cursor?: string
   limit?: number
   search?: string
@@ -488,12 +489,16 @@ export function createMemoryAgentInvocationStore(): AgentInvocationStore {
       const limit = normalizeLimit(options.limit)
       const cursor = normalizeBuiltInCursor(options.cursor)
       const search = normalizeSearch(options.search)
+      const agentName = options.agentName?.trim()
       const statuses = options.status === undefined
         ? undefined
         : new Set(Array.isArray(options.status) ? options.status : [options.status])
       const before = cursor === undefined ? Number.POSITIVE_INFINITY : Number(cursor)
       const candidates = [...records.values()]
-        .filter(record => Number(record.cursor) < before && (!statuses || statuses.has(record.status)) && matchesInvocationSearch(record, search))
+        .filter(record => Number(record.cursor) < before
+          && (!agentName || record.agentName === agentName)
+          && (!statuses || statuses.has(record.status))
+          && matchesInvocationSearch(record, search))
         .sort((a, b) => Number(b.cursor) - Number(a.cursor))
       const page = candidates.slice(0, limit)
       return {

--- a/packages/agent/src/invocations/sqlite.ts
+++ b/packages/agent/src/invocations/sqlite.ts
@@ -248,8 +248,8 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
       }
       const agentName = listOptions.agentName?.trim()
       if (agentName) {
-        filters.push("agent_name = ?")
-        args.push(agentName)
+        filters.push("(agent_name = ? OR (agent_name IS NULL AND json_extract(record, '$.agentName') = ?))")
+        args.push(agentName, agentName)
       }
       const search = searchValue(listOptions.search)
       if (search) {

--- a/packages/agent/src/invocations/sqlite.ts
+++ b/packages/agent/src/invocations/sqlite.ts
@@ -248,7 +248,7 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
       }
       const agentName = listOptions.agentName?.trim()
       if (agentName) {
-        filters.push("(agent_name = ? OR (agent_name IS NULL AND json_extract(record, '$.agentName') = ?))")
+        filters.push("(agent_name = ? OR (agent_name IS NULL OR agent_name = '') AND json_extract(record, '$.agentName') = ?)")
         args.push(agentName, agentName)
       }
       const search = searchValue(listOptions.search)

--- a/packages/agent/src/invocations/sqlite.ts
+++ b/packages/agent/src/invocations/sqlite.ts
@@ -214,6 +214,11 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
         filters.push(`status IN (${statuses.map(() => "?").join(", ")})`)
         args.push(...statuses)
       }
+      const agentName = listOptions.agentName?.trim()
+      if (agentName) {
+        filters.push("json_extract(record, '$.agentName') = ?")
+        args.push(agentName)
+      }
       const search = searchValue(listOptions.search)
       if (search) {
         filters.push("search LIKE ? ESCAPE '\\'")

--- a/packages/agent/src/invocations/sqlite.ts
+++ b/packages/agent/src/invocations/sqlite.ts
@@ -70,6 +70,10 @@ function searchableRecord(record: Omit<AgentInvocationRecord, "cursor">): string
   return JSON.stringify(summary).toLowerCase()
 }
 
+function agentNameRecord(record: Omit<AgentInvocationRecord, "cursor">): string {
+  return record.agentName || ""
+}
+
 function escapeLike(value: string): string {
   return value.replace(/[\\%_]/g, match => `\\${match}`)
 }
@@ -112,6 +116,7 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
         sequence INTEGER PRIMARY KEY AUTOINCREMENT,
         id TEXT NOT NULL UNIQUE,
         status TEXT NOT NULL,
+        agent_name TEXT NOT NULL DEFAULT '',
         search TEXT,
         record TEXT NOT NULL
       )`)
@@ -123,6 +128,15 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
         catch (error) {
           const currentColumns = await client.execute(`PRAGMA table_info(${table})`)
           if (!currentColumns.rows.some(row => row.name === "search")) throw error
+        }
+      }
+      if (!columns.rows.some(row => row.name === "agent_name")) {
+        try {
+          await client.execute(`ALTER TABLE ${table} ADD COLUMN agent_name TEXT`)
+        }
+        catch (error) {
+          const currentColumns = await client.execute(`PRAGMA table_info(${table})`)
+          if (!currentColumns.rows.some(row => row.name === "agent_name")) throw error
         }
       }
       let backfillSequence = 0
@@ -144,7 +158,25 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
         })
         if (searchBackfill.length) await client.batch(searchBackfill, "write")
       }
+      backfillSequence = 0
+      while (true) {
+        const missingAgentNames = await client.execute({
+          args: [backfillSequence, searchBackfillPageSize],
+          sql: `SELECT sequence, record FROM ${table} WHERE agent_name IS NULL AND sequence > ? ORDER BY sequence LIMIT ?`,
+        })
+        if (!missingAgentNames.rows.length) break
+        const agentNameBackfill = missingAgentNames.rows.map((row) => {
+          backfillSequence = Math.max(backfillSequence, numberValue(row.sequence))
+          const record = deserialize(row.record, row.sequence)
+          return {
+            args: [record ? agentNameRecord(storedRecord(record)) : "", numberValue(row.sequence)],
+            sql: `UPDATE ${table} SET agent_name = ? WHERE sequence = ? AND agent_name IS NULL`,
+          }
+        })
+        await client.batch(agentNameBackfill, "write")
+      }
       await client.execute(`CREATE INDEX IF NOT EXISTS ${table}_status_sequence ON ${table} (status, sequence DESC)`)
+      await client.execute(`CREATE INDEX IF NOT EXISTS ${table}_agent_name_sequence ON ${table} (agent_name, sequence DESC)`)
       await client.execute(`CREATE TABLE IF NOT EXISTS ${table}_claims (
         id TEXT PRIMARY KEY,
         claim_id TEXT NOT NULL,
@@ -184,8 +216,8 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
       return write(async () => {
         await initialize()
         const result = await client.execute({
-          args: [input.id, input.status, searchableRecord(input), serialize(input)],
-          sql: `INSERT OR IGNORE INTO ${table} (id, status, search, record) VALUES (?, ?, ?, ?)`,
+          args: [input.id, input.status, agentNameRecord(input), searchableRecord(input), serialize(input)],
+          sql: `INSERT OR IGNORE INTO ${table} (id, status, agent_name, search, record) VALUES (?, ?, ?, ?, ?)`,
         })
         const record = await read(input.id)
         if (!record) throw new Error(`[vitehub] SQLite Agent Invocation ${JSON.stringify(input.id)} was not persisted.`)
@@ -216,7 +248,7 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
       }
       const agentName = listOptions.agentName?.trim()
       if (agentName) {
-        filters.push("json_extract(record, '$.agentName') = ?")
+        filters.push("agent_name = ?")
         args.push(agentName)
       }
       const search = searchValue(listOptions.search)
@@ -270,8 +302,8 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
           const updated = applyAgentInvocationStoreUpdate(record, input)
           const stored = storedRecord(updated)
           await transaction.execute({
-            args: [updated.status, searchableRecord(stored), serialize(stored), id],
-            sql: `UPDATE ${table} SET status = ?, search = ?, record = ? WHERE id = ?`,
+            args: [updated.status, agentNameRecord(stored), searchableRecord(stored), serialize(stored), id],
+            sql: `UPDATE ${table} SET status = ?, agent_name = ?, search = ?, record = ? WHERE id = ?`,
           })
           await transaction.commit()
           return updated

--- a/packages/agent/src/invocations/sqlite.ts
+++ b/packages/agent/src/invocations/sqlite.ts
@@ -177,6 +177,9 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
       }
       await client.execute(`CREATE INDEX IF NOT EXISTS ${table}_status_sequence ON ${table} (status, sequence DESC)`)
       await client.execute(`CREATE INDEX IF NOT EXISTS ${table}_agent_name_sequence ON ${table} (agent_name, sequence DESC)`)
+      await client.execute(`CREATE INDEX IF NOT EXISTS ${table}_legacy_agent_name_sequence
+        ON ${table} (json_extract(record, '$.agentName'), sequence DESC)
+        WHERE agent_name IS NULL OR agent_name = ''`)
       await client.execute(`CREATE TABLE IF NOT EXISTS ${table}_claims (
         id TEXT PRIMARY KEY,
         claim_id TEXT NOT NULL,
@@ -248,7 +251,7 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
       }
       const agentName = listOptions.agentName?.trim()
       if (agentName) {
-        filters.push("(agent_name = ? OR (agent_name IS NULL OR agent_name = '') AND json_extract(record, '$.agentName') = ?)")
+        filters.push("(agent_name = ? OR ((agent_name IS NULL OR agent_name = '') AND json_extract(record, '$.agentName') = ?))")
         args.push(agentName, agentName)
       }
       const search = searchValue(listOptions.search)

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -2896,15 +2896,19 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
   }
 }
 
-export function discoverAgentDefinitionNames(
+export function discoverAgentDefinitionEntries(
   root: string,
   serverDirs?: string[],
-): string[] {
+): Array<{ handler: string, name: string }> {
   const resolvedServerDirs = serverDirs ?? [join(root, "server")]
-  return [...new Set([
+  const entries = [
     ...discoverAgentDefinitions({ mode: "vite-suffix", rootDir: root }),
     ...discoverAgentDefinitions({ mode: "server-agents", scanDirs: resolvedServerDirs }),
-  ].map(definition => definition.name))].sort()
+  ]
+  return [...new Map(entries.map(definition => [definition.name, {
+    handler: definition.handler,
+    name: definition.name,
+  }])).values()].sort((left, right) => left.name.localeCompare(right.name))
 }
 
 declare module "vite" {

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -2896,6 +2896,17 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
   }
 }
 
+export function discoverAgentDefinitionNames(
+  root: string,
+  serverDirs?: string[],
+): string[] {
+  const resolvedServerDirs = serverDirs ?? [join(root, "server")]
+  return [...new Set([
+    ...discoverAgentDefinitions({ mode: "vite-suffix", rootDir: root }),
+    ...discoverAgentDefinitions({ mode: "server-agents", scanDirs: resolvedServerDirs }),
+  ].map(definition => definition.name))].sort()
+}
+
 declare module "vite" {
   interface UserConfig {
     agent?: false | AgentModuleOptions

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -2905,10 +2905,10 @@ export function discoverAgentDefinitionEntries(
     ...discoverAgentDefinitions({ mode: "vite-suffix", rootDir: root }),
     ...discoverAgentDefinitions({ mode: "server-agents", scanDirs: resolvedServerDirs }),
   ]
-  return [...new Map(entries.map(definition => [definition.name, {
+  return [...new Map(entries.map(definition => [definition.handler, {
     handler: definition.handler,
     name: definition.name,
-  }])).values()].sort((left, right) => left.name.localeCompare(right.name))
+  }])).values()].sort((left, right) => left.name.localeCompare(right.name) || left.handler.localeCompare(right.handler))
 }
 
 declare module "vite" {

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -171,6 +171,17 @@ describe("agent discovery", () => {
     ])
   })
 
+  it("rejects file-derived Agent identities beyond the persisted identity limit", async () => {
+    const root = await createTempRoot("vitehub-agent-long-name-")
+    const segments = Array.from({ length: 6 }, (_, index) => `${index}-${"a".repeat(90)}`)
+    const directory = join(root, "server", "agents", ...segments)
+    await mkdir(directory, { recursive: true })
+    await writeFile(join(directory, "index.ts"), "export default {}", "utf8")
+
+    expect(() => discoverAgentDefinitions({ mode: "server-agents", scanDirs: [join(root, "server")] }))
+      .toThrow("[vitehub] Agent names cannot exceed 512 characters.")
+  })
+
   it("discovers server agent files and colocated workspace configs", async () => {
     const root = await createTempRoot("vitehub-agent-server-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -162,6 +162,15 @@ describe("agent discovery", () => {
     ])
   })
 
+  it("normalizes file-derived Agent identities", async () => {
+    const root = await createTempRoot("vitehub-agent-normalized-name-")
+    await writeFile(join(root, "review .agent.ts"), "export default {}", "utf8")
+
+    expect(discoverAgentDefinitions({ rootDir: root })).toEqual([
+      expect.objectContaining({ name: "review", source: "vite-suffix" }),
+    ])
+  })
+
   it("discovers server agent files and colocated workspace configs", async () => {
     const root = await createTempRoot("vitehub-agent-server-")
     await mkdir(join(root, "server", "agents"), { recursive: true })

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -1730,6 +1730,24 @@ describe("Agent Invocations", () => {
         .resolves.toEqual({ invocations: [] })
       await expect(createLibsqlAgentInvocationStore({ client: firstClient }).list({ agentName: "review" }))
         .resolves.toMatchObject({ invocations: [expect.objectContaining({ id: "legacy" })] })
+
+      const initializedStore = createLibsqlAgentInvocationStore({ client: firstClient })
+      await initializedStore.list()
+      await setupClient.execute({
+        args: [JSON.stringify({
+          agentName: "review",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          id: "overlapping-legacy-writer",
+          observations: [],
+          status: "completed",
+          traceId: "overlapping-legacy-trace",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        })],
+        sql: "INSERT INTO vitehub_agent_invocations (id, status, record) VALUES ('overlapping-legacy-writer', 'completed', ?)",
+      })
+      await expect(initializedStore.list({ agentName: "review" })).resolves.toMatchObject({
+        invocations: [expect.objectContaining({ id: "overlapping-legacy-writer" })],
+      })
     }
     finally {
       setupClient.close()

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -1746,13 +1746,42 @@ describe("Agent Invocations", () => {
         sql: "INSERT INTO vitehub_agent_invocations (id, status, record) VALUES ('overlapping-legacy-writer', 'completed', ?)",
       })
       await expect(initializedStore.list({ agentName: "review" })).resolves.toMatchObject({
-        invocations: [expect.objectContaining({ id: "overlapping-legacy-writer" })],
+        invocations: expect.arrayContaining([expect.objectContaining({ id: "overlapping-legacy-writer" })]),
       })
     }
     finally {
       setupClient.close()
       firstClient.close()
       secondClient.close()
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  it("filters old-shape writes in fresh libSQL journals", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "vitehub-agent-invocations-fresh-overlap-"))
+    const client = createClient({ url: `file:${join(directory, "invocations.sqlite")}` })
+    try {
+      const store = createLibsqlAgentInvocationStore({ client })
+      await store.list()
+      await client.execute({
+        args: [JSON.stringify({
+          agentName: "review",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          id: "fresh-overlapping-legacy-writer",
+          observations: [],
+          status: "completed",
+          traceId: "fresh-overlapping-legacy-trace",
+          updatedAt: "2026-01-01T00:00:00.000Z",
+        })],
+        sql: "INSERT INTO vitehub_agent_invocations (id, status, record) VALUES ('fresh-overlapping-legacy-writer', 'completed', ?)",
+      })
+
+      await expect(store.list({ agentName: "review" })).resolves.toMatchObject({
+        invocations: [expect.objectContaining({ id: "fresh-overlapping-legacy-writer" })],
+      })
+    }
+    finally {
+      client.close()
       await rm(directory, { force: true, recursive: true })
     }
   })

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -1616,6 +1616,19 @@ describe("Agent Invocations", () => {
       expect(agentQueryPlan.rows.map(row => String(row.detail))).toContainEqual(
         expect.stringContaining("vitehub_agent_invocations_agent_name_sequence"),
       )
+      const compatibleAgentQueryPlan = await readerClient.execute({
+        args: ["review", "review"],
+        sql: `EXPLAIN QUERY PLAN SELECT sequence, record FROM vitehub_agent_invocations
+          WHERE agent_name = ? OR ((agent_name IS NULL OR agent_name = '') AND json_extract(record, '$.agentName') = ?)
+          ORDER BY sequence DESC LIMIT 51`,
+      })
+      const compatibleAgentPlanDetails = compatibleAgentQueryPlan.rows.map(row => String(row.detail))
+      expect(compatibleAgentPlanDetails).toContainEqual(
+        expect.stringContaining("vitehub_agent_invocations_agent_name_sequence"),
+      )
+      expect(compatibleAgentPlanDetails).toContainEqual(
+        expect.stringContaining("vitehub_agent_invocations_legacy_agent_name_sequence"),
+      )
       const localeLowercase = vi.spyOn(String.prototype, "toLocaleLowerCase").mockImplementation(function (this: string) {
         return String(this).replaceAll("I", "ı").toLowerCase()
       })

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -39,6 +39,25 @@ describe("Agent Invocations", () => {
     expect(store.list({ search: "1" })).toEqual({ invocations: [] })
   })
 
+  it("filters memory-store records by exact Agent name", async () => {
+    const store = createMemoryAgentInvocationStore()
+    for (const agentName of ["review", "review-assistant"]) {
+      await store.create({
+        agentName,
+        createdAt: "2026-02-02T02:02:02.000Z",
+        id: agentName,
+        observations: [],
+        status: "completed",
+        traceId: `${agentName}-trace`,
+        updatedAt: "2026-02-02T02:02:02.000Z",
+      })
+    }
+
+    expect(store.list({ agentName: "review" })).toMatchObject({
+      invocations: [{ agentName: "review" }],
+    })
+  })
+
   it("does not let a stalled store block Agent execution", async () => {
     const memory = createMemoryAgentInvocationStore()
     const invocations = defineAgentInvocations({
@@ -1553,6 +1572,16 @@ describe("Agent Invocations", () => {
       })
       await runAgent(agent, runtime("durable-run", { "github.repository": "vite-hub/vitehub" }), {})
       await runAgent(agent, runtime("unicode-search", { "github.repository": "Éclair" }), {})
+      await runAgent(
+        defineAgent({
+          driver: { run: () => "reviewed" },
+          invocations,
+          name: "review",
+          runtime: false,
+        }),
+        runtime("named-review"),
+        {},
+      )
 
       const restored = defineAgentInvocations({
         store: createLibsqlAgentInvocationStore({ client: readerClient }),
@@ -1573,6 +1602,12 @@ describe("Agent Invocations", () => {
       })
       await expect(restored.list({ search: "éclair" })).resolves.toMatchObject({
         invocations: [expect.objectContaining({ status: "completed" })],
+      })
+      await expect(restored.list({ agentName: "review" })).resolves.toMatchObject({
+        invocations: [expect.objectContaining({ agentName: "review" })],
+      })
+      await expect(restored.list({ agentName: "review-assistant" })).resolves.toEqual({
+        invocations: [],
       })
       const localeLowercase = vi.spyOn(String.prototype, "toLocaleLowerCase").mockImplementation(function (this: string) {
         return String(this).replaceAll("I", "ı").toLowerCase()

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -1609,6 +1609,13 @@ describe("Agent Invocations", () => {
       await expect(restored.list({ agentName: "review-assistant" })).resolves.toEqual({
         invocations: [],
       })
+      const agentQueryPlan = await readerClient.execute({
+        args: ["review"],
+        sql: "EXPLAIN QUERY PLAN SELECT sequence, record FROM vitehub_agent_invocations WHERE agent_name = ? ORDER BY sequence DESC LIMIT 51",
+      })
+      expect(agentQueryPlan.rows.map(row => String(row.detail))).toContainEqual(
+        expect.stringContaining("vitehub_agent_invocations_agent_name_sequence"),
+      )
       const localeLowercase = vi.spyOn(String.prototype, "toLocaleLowerCase").mockImplementation(function (this: string) {
         return String(this).replaceAll("I", "ı").toLowerCase()
       })
@@ -1674,6 +1681,7 @@ describe("Agent Invocations", () => {
       )`)
       await setupClient.execute({
         args: [JSON.stringify({
+          agentName: "review",
           annotations: { repository: "Éclair" },
           createdAt: "2026-01-01T00:00:00.000Z",
           id: "legacy",
@@ -1716,8 +1724,12 @@ describe("Agent Invocations", () => {
         { invocations: [expect.objectContaining({ id: "legacy" })] },
         { invocations: [expect.objectContaining({ id: "legacy" })] },
       ])
+      const migratedAgent = await firstClient.execute("SELECT agent_name FROM vitehub_agent_invocations WHERE id = 'legacy'")
+      expect(migratedAgent.rows[0]?.agent_name).toBe("review")
       await expect(createLibsqlAgentInvocationStore({ client: firstClient }).list({ search: "observation-only" }))
         .resolves.toEqual({ invocations: [] })
+      await expect(createLibsqlAgentInvocationStore({ client: firstClient }).list({ agentName: "review" }))
+        .resolves.toMatchObject({ invocations: [expect.objectContaining({ id: "legacy" })] })
     }
     finally {
       setupClient.close()

--- a/packages/vite-hub/src/console/internal.ts
+++ b/packages/vite-hub/src/console/internal.ts
@@ -1,8 +1,8 @@
 import type { AgentInvocations } from "@vite-hub/agent"
 
-export const consoleInvocationsKey = Symbol.for("vitehub.console.invocations")
-export const consoleInvocationsRootKey = Symbol.for("vitehub.console.invocations.root")
-export const consoleInvocationsRegistryKey = Symbol.for("vitehub.console.invocations.registry")
+export const consoleInvocationsKey: unique symbol = Symbol.for("vitehub.console.invocations")
+export const consoleInvocationsRootKey: unique symbol = Symbol.for("vitehub.console.invocations.root")
+export const consoleInvocationsRegistryKey: unique symbol = Symbol.for("vitehub.console.invocations.registry")
 
 type ConsoleInvocationsByRoot = {
   get(key: string): AgentInvocations | undefined

--- a/packages/vite-hub/src/console/refresh.ts
+++ b/packages/vite-hub/src/console/refresh.ts
@@ -1,0 +1,9 @@
+export function serializeConsoleRefresh(refresh: () => Promise<void>): () => Promise<void> {
+  let queue = Promise.resolve()
+
+  return () => {
+    const result = queue.then(refresh)
+    queue = result.catch(() => {})
+    return result
+  }
+}

--- a/packages/vite-hub/src/console/runtime/client/main.js
+++ b/packages/vite-hub/src/console/runtime/client/main.js
@@ -17,7 +17,10 @@ const router = createRouter({
       component: ConsoleApp,
       name: "vitehub-console-agents",
       path: "/agents/:invocation?",
-      props: { apiBase: "/api/_vitehub/console/invocations" },
+      props: {
+        agentsBase: "/api/_vitehub/console/agents",
+        apiBase: "/api/_vitehub/console/invocations",
+      },
     },
   ],
 });

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -16,9 +16,7 @@ const router = useRouter();
 const props = defineProps<{ agentsBase: string; apiBase: string }>();
 const initialAgentQuery = Array.isArray(route.query.agent) ? route.query.agent[0] : route.query.agent;
 const selectedInvocationId = ref<string>();
-const selectedAgentName = ref(
-  typeof initialAgentQuery === "string" && initialAgentQuery.trim() ? initialAgentQuery : undefined,
-);
+const selectedAgentName = ref(initialAgentQuery?.trim() ? initialAgentQuery : undefined);
 const agentNames = ref<string[]>([]);
 const agentsLoading = ref(true);
 const paginationRetryRevision = ref(0);
@@ -214,6 +212,7 @@ async function loadAgents(): Promise<void> {
   agentsLoading.value = true;
   try {
     const value = record(await request(props.agentsBase, { signal: controller.signal }));
+    // doctor-disable-next-line typescript/strict/no-runtime-typeof -- The console API response is untrusted JSON, so validate every array entry before using it as an Agent identity.
     const names = Array.isArray(value?.agents)
       ? value.agents.filter((name): name is string => typeof name === "string" && Boolean(name.trim()))
       : [];

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -19,8 +19,7 @@ const selectedInvocationId = ref<string>();
 const selectedAgentName = ref(
   typeof initialAgentQuery === "string" && initialAgentQuery.trim() ? initialAgentQuery : undefined,
 );
-const discoveredAgentNames = ref<string[]>([]);
-const observedAgentNames = ref<string[]>([]);
+const agentNames = ref<string[]>([]);
 const agentsLoading = ref(true);
 const paginationRetryRevision = ref(0);
 const lastSuccessfulPollAt = ref<Date>();
@@ -70,15 +69,12 @@ const invocationItems = computed<AgentInvocationListItem[]>(() =>
     updatedAt: invocation.updatedAt || invocation.startedAt || invocation.createdAt,
   })),
 );
-const availableAgentNames = computed(() =>
-  [...new Set([...discoveredAgentNames.value, ...observedAgentNames.value])].sort(),
-);
-const hasMultipleAgents = computed(() => availableAgentNames.value.length > 1);
+const hasMultipleAgents = computed(() => agentNames.value.length > 1);
 const selectedAgentLabel = computed(() =>
   selectedAgentName.value || (agentsLoading.value ? "Loading agents" : "Agents"),
 );
 const agentMenuItems = computed<DropdownMenuItem[]>(() =>
-  availableAgentNames.value.map((name) => ({
+  agentNames.value.map((name) => ({
     icon: "i-lucide-bot",
     label: name,
     onSelect: () => selectAgent(name),
@@ -99,6 +95,7 @@ const selectedSummary = computed(() =>
 const invocationView = computed<AgentInvocationView | undefined>(() => {
   const invocation = detail.invocation.value;
   if (!invocation || invocation.id !== selectedInvocationId.value) return;
+  if (selectedAgentName.value && invocation.agentName !== selectedAgentName.value) return;
   const persistedConfiguration = invocationConfiguration(record(invocation)?.configuration);
   const configuration = persistedConfiguration ?? observedConfiguration(detail.observations.value);
   const view: AgentInvocationView = {
@@ -220,7 +217,7 @@ async function loadAgents(): Promise<void> {
     const names = Array.isArray(value?.agents)
       ? value.agents.filter((name): name is string => typeof name === "string" && Boolean(name.trim()))
       : [];
-    if (agentsRequest === controller) discoveredAgentNames.value = [...new Set(names)];
+    if (agentsRequest === controller) agentNames.value = [...new Set(names)];
   } catch (error) {
     if (error instanceof DOMException && error.name === "AbortError") return;
   } finally {
@@ -263,17 +260,7 @@ watch(
 );
 
 watch(
-  () => list.invocations.value
-    .map(invocation => invocation.agentName)
-    .filter((name): name is string => Boolean(name)),
-  (names) => {
-    observedAgentNames.value = [...new Set([...observedAgentNames.value, ...names])].sort();
-  },
-  { immediate: true },
-);
-
-watch(
-  [routeAgent, availableAgentNames],
+  [routeAgent, agentNames],
   ([requestedAgent, names]) => {
     if (!names.length) return;
     selectedAgentName.value = requestedAgent && names.includes(requestedAgent)
@@ -281,6 +268,20 @@ watch(
       : names[0];
   },
   { immediate: true },
+);
+
+watch(
+  [selectedAgentName, () => detail.invocation.value],
+  async ([agentName, invocation]) => {
+    if (
+      !agentName ||
+      !invocation ||
+      invocation.id !== selectedInvocationId.value ||
+      invocation.agentName === agentName
+    ) return;
+    selectedInvocationId.value = undefined;
+    await router.replace({ name: "vitehub-console-agents", query: { agent: agentName } });
+  },
 );
 
 onMounted(() => {

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -2,9 +2,9 @@
 import { AgentInvocation, AgentInvocationInspector, AgentInvocationList } from "@vite-hub/ui";
 import { useAgentInvocation, useAgentInvocations } from "vite-hub/agent/vue";
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
-import { RouterLink, useRoute, useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 
-import type { SplitterItem } from "@nuxt/ui";
+import type { DropdownMenuItem, SplitterItem } from "@nuxt/ui";
 import type {
   AgentInvocationConfiguration,
   AgentInvocationListItem,
@@ -13,8 +13,15 @@ import type {
 
 const route = useRoute();
 const router = useRouter();
-const props = defineProps<{ apiBase: string }>();
+const props = defineProps<{ agentsBase: string; apiBase: string }>();
+const initialAgentQuery = Array.isArray(route.query.agent) ? route.query.agent[0] : route.query.agent;
 const selectedInvocationId = ref<string>();
+const selectedAgentName = ref(
+  typeof initialAgentQuery === "string" && initialAgentQuery.trim() ? initialAgentQuery : undefined,
+);
+const discoveredAgentNames = ref<string[]>([]);
+const observedAgentNames = ref<string[]>([]);
+const agentsLoading = ref(true);
 const paginationRetryRevision = ref(0);
 const lastSuccessfulPollAt = ref<Date>();
 const nowMs = ref(Date.now());
@@ -24,6 +31,7 @@ const detailsOpen = ref(false);
 const isDesktop = ref(false);
 let clock: ReturnType<typeof setInterval> | undefined;
 let media: MediaQueryList | undefined;
+let agentsRequest: AbortController | undefined;
 
 const request = async (path: string, options: { signal?: AbortSignal }): Promise<unknown> => {
   const response = await fetch(path, { signal: options.signal });
@@ -40,6 +48,7 @@ const list = useAgentInvocations({
   pollInterval: 5_000,
   request,
   requestSummaries: request,
+  query: computed(() => selectedAgentName.value ? { agent: selectedAgentName.value } : undefined),
 });
 const detail = useAgentInvocation(selectedInvocationId, {
   baseURL: props.apiBase,
@@ -61,8 +70,27 @@ const invocationItems = computed<AgentInvocationListItem[]>(() =>
     updatedAt: invocation.updatedAt || invocation.startedAt || invocation.createdAt,
   })),
 );
+const availableAgentNames = computed(() =>
+  [...new Set([...discoveredAgentNames.value, ...observedAgentNames.value])].sort(),
+);
+const hasMultipleAgents = computed(() => availableAgentNames.value.length > 1);
+const selectedAgentLabel = computed(() =>
+  selectedAgentName.value || (agentsLoading.value ? "Loading agents" : "Agents"),
+);
+const agentMenuItems = computed<DropdownMenuItem[]>(() =>
+  availableAgentNames.value.map((name) => ({
+    icon: "i-lucide-bot",
+    label: name,
+    onSelect: () => selectAgent(name),
+    trailingIcon: selectedAgentName.value === name ? "i-lucide-check" : undefined,
+  })),
+);
 const routeInvocation = computed(() => {
   const value = route.params.invocation;
+  return Array.isArray(value) ? value[0] : value;
+});
+const routeAgent = computed(() => {
+  const value = route.query.agent;
   return Array.isArray(value) ? value[0] : value;
 });
 const selectedSummary = computed(() =>
@@ -165,11 +193,47 @@ function relativeDuration(elapsed: number): string {
 
 async function selectInvocation(id: string): Promise<void> {
   sessionsOpen.value = false;
-  await router.push({ name: "vitehub-console-agents", params: { invocation: id } });
+  await router.push({
+    name: "vitehub-console-agents",
+    params: { invocation: id },
+    query: selectedAgentName.value ? { agent: selectedAgentName.value } : {},
+  });
+}
+
+async function selectAgent(name: string): Promise<void> {
+  if (name === selectedAgentName.value) return;
+  selectedAgentName.value = name;
+  selectedInvocationId.value = undefined;
+  await router.push({
+    name: "vitehub-console-agents",
+    query: { agent: name },
+  });
+}
+
+async function loadAgents(): Promise<void> {
+  agentsRequest?.abort();
+  const controller = new AbortController();
+  agentsRequest = controller;
+  agentsLoading.value = true;
+  try {
+    const value = record(await request(props.agentsBase, { signal: controller.signal }));
+    const names = Array.isArray(value?.agents)
+      ? value.agents.filter((name): name is string => typeof name === "string" && Boolean(name.trim()))
+      : [];
+    if (agentsRequest === controller) discoveredAgentNames.value = [...new Set(names)];
+  } catch (error) {
+    if (error instanceof DOMException && error.name === "AbortError") return;
+  } finally {
+    if (agentsRequest === controller) {
+      agentsRequest = undefined;
+      agentsLoading.value = false;
+    }
+  }
 }
 
 async function refresh(): Promise<void> {
   await Promise.all([
+    loadAgents(),
     list.refresh(),
     selectedInvocationId.value ? detail.refresh() : Promise.resolve(),
   ]);
@@ -191,13 +255,36 @@ watch(
       await router.replace({
         name: "vitehub-console-agents",
         params: { invocation: firstInvocation },
+        query: selectedAgentName.value ? { agent: selectedAgentName.value } : {},
       });
     }
   },
   { immediate: true },
 );
 
+watch(
+  () => list.invocations.value
+    .map(invocation => invocation.agentName)
+    .filter((name): name is string => Boolean(name)),
+  (names) => {
+    observedAgentNames.value = [...new Set([...observedAgentNames.value, ...names])].sort();
+  },
+  { immediate: true },
+);
+
+watch(
+  [routeAgent, availableAgentNames],
+  ([requestedAgent, names]) => {
+    if (!names.length) return;
+    selectedAgentName.value = requestedAgent && names.includes(requestedAgent)
+      ? requestedAgent
+      : names[0];
+  },
+  { immediate: true },
+);
+
 onMounted(() => {
+  void loadAgents();
   media = window.matchMedia("(min-width: 1024px)");
   updateDesktop();
   media.addEventListener("change", updateDesktop);
@@ -207,6 +294,7 @@ onMounted(() => {
 });
 
 onBeforeUnmount(() => {
+  agentsRequest?.abort();
   if (clock) clearInterval(clock);
   media?.removeEventListener("change", updateDesktop);
 });
@@ -228,24 +316,40 @@ onBeforeUnmount(() => {
       resizable
     >
       <template #header="{ collapsed }">
-        <RouterLink
-          class="flex min-w-0 items-center gap-2.5 rounded-md text-start outline-none focus-visible:ring-2 focus-visible:ring-primary"
-          :to="{ name: 'vitehub-console-agents' }"
+        <UDropdownMenu
+          :items="agentMenuItems"
+          :content="{ align: 'start', collisionPadding: 12 }"
+          :ui="{ content: collapsed ? 'w-44' : 'w-(--reka-dropdown-menu-trigger-width)' }"
         >
-          <span
-            class="grid size-7 shrink-0 grid-cols-3 items-end gap-0.5 rounded-md bg-highlighted p-1.5"
-            aria-hidden="true"
-            ><i class="h-2/3 bg-inverted" /><i class="h-full bg-primary" /><i
-              class="h-4/5 bg-inverted"
-          /></span>
-          <span v-if="!collapsed" class="grid min-w-0 leading-none"
-            ><small class="text-[10px] font-bold uppercase tracking-[.12em] text-muted"
-              >ViteHub</small
-            ><strong class="mt-1 truncate text-sm font-semibold text-highlighted"
-              >Console</strong
-            ></span
+          <button
+            type="button"
+            class="flex h-10 w-full min-w-0 items-center gap-2.5 rounded-md px-1.5 text-start outline-none data-[state=open]:bg-elevated focus-visible:ring-2 focus-visible:ring-primary disabled:cursor-default"
+            :class="hasMultipleAgents ? 'hover:bg-elevated/70' : ''"
+            :disabled="!hasMultipleAgents"
+            :aria-label="hasMultipleAgents ? `Switch Agent. ${selectedAgentLabel} selected.` : selectedAgentLabel"
           >
-        </RouterLink>
+            <span
+              class="grid size-7 shrink-0 grid-cols-3 items-end gap-0.5 rounded-md bg-highlighted p-1.5"
+              aria-hidden="true"
+              ><i class="h-2/3 bg-inverted" /><i class="h-full bg-primary" /><i
+                class="h-4/5 bg-inverted"
+            /></span>
+            <span v-if="!collapsed" class="grid min-w-0 flex-1 leading-none"
+              ><small class="truncate text-[10px] font-bold uppercase tracking-[.12em] text-muted"
+                >ViteHub Console</small
+              ><strong class="mt-1 truncate text-sm font-semibold text-highlighted">{{
+                selectedAgentLabel
+              }}</strong></span
+            >
+            <UIcon
+              v-if="!collapsed"
+              name="i-lucide-chevrons-up-down"
+              class="size-3.5 shrink-0 text-dimmed"
+              :class="hasMultipleAgents ? 'opacity-100' : 'opacity-0'"
+              aria-hidden="true"
+            />
+          </button>
+        </UDropdownMenu>
       </template>
 
       <template #default="{ collapsed }">

--- a/packages/vite-hub/src/console/runtime/pages/agents.vue
+++ b/packages/vite-hub/src/console/runtime/pages/agents.vue
@@ -7,5 +7,8 @@ useHead({ title: "Agents · ViteHub Console" });
 </script>
 
 <template>
-  <ConsoleApp :api-base="`${appBaseURL}/api/_vitehub/console/invocations`" />
+  <ConsoleApp
+    :agents-base="`${appBaseURL}/api/_vitehub/console/agents`"
+    :api-base="`${appBaseURL}/api/_vitehub/console/invocations`"
+  />
 </template>

--- a/packages/vite-hub/src/console/runtime/server/agents.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.get.ts
@@ -11,9 +11,8 @@ interface ConsoleAgentsResult {
 const agentsHandler: (event: ConsoleRequestEvent) => Promise<ConsoleAgentsResult> = async (event) => {
   assertConsoleRequest(event)
   const agents = new Set(getConsoleAgents())
-  if (agents.size) return { agents: [...agents].sort() }
   let cursor: string | undefined
-  // ponytail: This fallback runs only without discovered definitions; add a store-level distinct-name query if large journals make the scan measurable.
+  // ponytail: Add a store-level distinct-name query if large journals make this compatibility scan measurable.
   do {
     const page = await getConsoleInvocations().list({ cursor, limit: 100 })
     for (const invocation of page.invocations) {

--- a/packages/vite-hub/src/console/runtime/server/agents.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.get.ts
@@ -1,4 +1,5 @@
 import { getConsoleAgents } from "./agents.ts"
+import { getConsoleInvocations } from "./invocations.ts"
 import { assertConsoleRequest } from "./request.ts"
 
 import type { ConsoleRequestEvent } from "./request.ts"
@@ -7,9 +8,20 @@ interface ConsoleAgentsResult {
   agents: readonly string[]
 }
 
-const agentsHandler: (event: ConsoleRequestEvent) => ConsoleAgentsResult = (event) => {
+const agentsHandler: (event: ConsoleRequestEvent) => Promise<ConsoleAgentsResult> = async (event) => {
   assertConsoleRequest(event)
-  return { agents: getConsoleAgents() }
+  const agents = new Set(getConsoleAgents())
+  if (agents.size) return { agents: [...agents].sort() }
+  let cursor: string | undefined
+  // ponytail: This fallback runs only without discovered definitions; add a store-level distinct-name query if large journals make the scan measurable.
+  do {
+    const page = await getConsoleInvocations().list({ cursor, limit: 100 })
+    for (const invocation of page.invocations) {
+      if (invocation.agentName) agents.add(invocation.agentName)
+    }
+    cursor = page.cursor
+  } while (cursor)
+  return { agents: [...agents].sort() }
 }
 
 export default agentsHandler

--- a/packages/vite-hub/src/console/runtime/server/agents.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.get.ts
@@ -1,0 +1,15 @@
+import { getConsoleAgents } from "./agents.ts"
+import { assertConsoleRequest } from "./request.ts"
+
+import type { ConsoleRequestEvent } from "./request.ts"
+
+interface ConsoleAgentsResult {
+  agents: readonly string[]
+}
+
+const agentsHandler: (event: ConsoleRequestEvent) => ConsoleAgentsResult = (event) => {
+  assertConsoleRequest(event)
+  return { agents: getConsoleAgents() }
+}
+
+export default agentsHandler

--- a/packages/vite-hub/src/console/runtime/server/agents.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.ts
@@ -18,6 +18,7 @@ export function installConsoleAgents(
   invocations: AgentInvocations,
 ): readonly string[] {
   const agents = [...new Set(agentNames.map(name => name.trim()).filter(Boolean))].sort()
+  // SAFETY: This intersection only attaches console-owned metadata to the Agent invocation journal.
   const consoleInvocations = invocations as ConsoleAgentInvocations
   consoleInvocations[consoleAgentsKey] = agents
   return agents
@@ -28,14 +29,21 @@ export function installConsoleAgentDefinitions(
   invocations: AgentInvocations,
 ): readonly string[] {
   return installConsoleAgents(entries.map(({ definition, fallbackName }) => {
+    // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Generated plugins can import arbitrary JavaScript definitions, so inspect their runtime shape at this boundary.
+    // SAFETY: The object check establishes the string-keyed record needed to inspect a generated module namespace.
     const module = definition && typeof definition === "object" ? definition as Record<string, unknown> : undefined
-    const agent = module?.default && typeof module.default === "object"
-      ? module.default as Record<string, unknown>
-      : module
+    let agent = module
+    // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Generated plugins can provide an arbitrary default export, so inspect its runtime shape at this boundary.
+    if (module?.default && typeof module.default === "object") {
+      // SAFETY: The object check establishes the string-keyed record needed to inspect a generated module default export.
+      agent = module.default as Record<string, unknown>
+    }
+    // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Agent Definitions may come from untyped JavaScript, so verify the identity before installing it.
     return typeof agent?.name === "string" && agent.name.trim() ? agent.name : fallbackName
   }), invocations)
 }
 
 export function getConsoleAgents(): readonly string[] {
+  // SAFETY: The global journal registry may be absent; when present, installConsoleAgents owns this metadata field.
   return (resolveConsoleInvocations() as ConsoleAgentInvocations | undefined)?.[consoleAgentsKey] ?? []
 }

--- a/packages/vite-hub/src/console/runtime/server/agents.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.ts
@@ -20,6 +20,11 @@ export type ConsoleAgentScope = {
   [consoleInvocationsRootKey]?: string
 }
 
+export type ConsoleAgentDefinitionEntry = {
+  definition: unknown
+  fallbackName: string
+}
+
 function agentsByRoot(value: unknown): ConsoleAgentsByRoot | undefined {
   // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Registry values cross Vite SSR realms, so realm-local prototypes cannot establish this boundary.
   if (!value || (typeof value !== "object" && typeof value !== "function")) return
@@ -73,6 +78,20 @@ export function installConsoleAgents(
     registry[consoleAgentsKey] = agents
   }
   return agents
+}
+
+export function installConsoleAgentDefinitions(
+  entries: readonly ConsoleAgentDefinitionEntry[],
+  projectRoot: string,
+  scope: ConsoleAgentScope = globalThis as ConsoleAgentScope,
+): readonly string[] {
+  return installConsoleAgents(entries.map(({ definition, fallbackName }) => {
+    const module = definition && typeof definition === "object" ? definition as Record<string, unknown> : undefined
+    const agent = module?.default && typeof module.default === "object"
+      ? module.default as Record<string, unknown>
+      : module
+    return typeof agent?.name === "string" && agent.name.trim() ? agent.name : fallbackName
+  }), projectRoot, scope)
 }
 
 export function getConsoleAgents(): readonly string[] {

--- a/packages/vite-hub/src/console/runtime/server/agents.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.ts
@@ -1,0 +1,80 @@
+import { resolve } from "node:path"
+
+import { consoleInvocationsRootKey } from "../../internal.ts"
+
+export const consoleAgentsKey: unique symbol = Symbol.for("vitehub.console.agents")
+export const consoleAgentsRegistryKey: unique symbol = Symbol.for("vitehub.console.agents.registry")
+
+type ConsoleAgentsByRoot = {
+  get(key: string): readonly string[] | undefined
+  set(key: string, value: readonly string[]): unknown
+  readonly size: number
+}
+
+type ConsoleAgentRegistry = Record<symbol, ConsoleAgentsByRoot | readonly string[] | undefined>
+
+export type ConsoleAgentScope = {
+  process?: unknown
+  [consoleAgentsKey]?: readonly string[]
+  [consoleAgentsRegistryKey]?: ConsoleAgentsByRoot
+  [consoleInvocationsRootKey]?: string
+}
+
+function agentsByRoot(value: unknown): ConsoleAgentsByRoot | undefined {
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Registry values cross Vite SSR realms, so realm-local prototypes cannot establish this boundary.
+  if (!value || (typeof value !== "object" && typeof value !== "function")) return
+  // SAFETY: The structural checks below validate every ConsoleAgentsByRoot member before use.
+  const registry = value as Partial<ConsoleAgentsByRoot>
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Callable members are the realm-independent registry contract.
+  return typeof registry.get === "function"
+    && typeof registry.set === "function"
+    && Number.isInteger(registry.size)
+    // SAFETY: The preceding checks validate every ConsoleAgentsByRoot member.
+    ? registry as ConsoleAgentsByRoot
+    : undefined
+}
+
+function processRegistry(scope: ConsoleAgentScope): ConsoleAgentRegistry | undefined {
+  return scope.process && (typeof scope.process === "object" || typeof scope.process === "function")
+    ? scope.process as ConsoleAgentRegistry
+    : undefined
+}
+
+function normalizedAgentNames(agentNames: readonly string[]): readonly string[] {
+  return [...new Set(agentNames.map(name => name.trim()).filter(Boolean))].sort()
+}
+
+export function resolveConsoleAgents(
+  scope: ConsoleAgentScope = globalThis as ConsoleAgentScope,
+): readonly string[] | undefined {
+  const root = scope[consoleInvocationsRootKey]
+  const registered = agentsByRoot(processRegistry(scope)?.[consoleAgentsRegistryKey])
+  if (root) return registered?.get(root) ?? scope[consoleAgentsKey]
+  if (!root && registered && registered.size > 1) return scope[consoleAgentsKey]
+  return processRegistry(scope)?.[consoleAgentsKey] as readonly string[] | undefined
+    ?? scope[consoleAgentsKey]
+}
+
+export function installConsoleAgents(
+  agentNames: readonly string[],
+  projectRoot: string,
+  scope: ConsoleAgentScope = globalThis as ConsoleAgentScope,
+): readonly string[] {
+  const root = resolve(projectRoot)
+  const agents = normalizedAgentNames(agentNames)
+  scope[consoleAgentsKey] = agents
+  scope[consoleInvocationsRootKey] = root
+  const registry = processRegistry(scope)
+  if (registry) {
+    const agentsByProject = agentsByRoot(registry[consoleAgentsRegistryKey])
+      ?? new Map<string, readonly string[]>()
+    agentsByProject.set(root, agents)
+    registry[consoleAgentsRegistryKey] = agentsByProject
+    registry[consoleAgentsKey] = agents
+  }
+  return agents
+}
+
+export function getConsoleAgents(): readonly string[] {
+  return resolveConsoleAgents() ?? []
+}

--- a/packages/vite-hub/src/console/runtime/server/agents.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.ts
@@ -1,89 +1,31 @@
-import { resolve } from "node:path"
+import { resolveConsoleInvocations } from "../../internal.ts"
 
-import { consoleInvocationsRootKey } from "../../internal.ts"
+import type { AgentInvocations } from "@vite-hub/agent"
 
 export const consoleAgentsKey: unique symbol = Symbol.for("vitehub.console.agents")
-export const consoleAgentsRegistryKey: unique symbol = Symbol.for("vitehub.console.agents.registry")
-
-type ConsoleAgentsByRoot = {
-  get(key: string): readonly string[] | undefined
-  set(key: string, value: readonly string[]): unknown
-  readonly size: number
-}
-
-type ConsoleAgentRegistry = Record<symbol, ConsoleAgentsByRoot | readonly string[] | undefined>
-
-export type ConsoleAgentScope = {
-  process?: unknown
-  [consoleAgentsKey]?: readonly string[]
-  [consoleAgentsRegistryKey]?: ConsoleAgentsByRoot
-  [consoleInvocationsRootKey]?: string
-}
 
 export type ConsoleAgentDefinitionEntry = {
   definition: unknown
   fallbackName: string
 }
 
-function agentsByRoot(value: unknown): ConsoleAgentsByRoot | undefined {
-  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Registry values cross Vite SSR realms, so realm-local prototypes cannot establish this boundary.
-  if (!value || (typeof value !== "object" && typeof value !== "function")) return
-  // SAFETY: The structural checks below validate every ConsoleAgentsByRoot member before use.
-  const registry = value as Partial<ConsoleAgentsByRoot>
-  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Callable members are the realm-independent registry contract.
-  return typeof registry.get === "function"
-    && typeof registry.set === "function"
-    && Number.isInteger(registry.size)
-    // SAFETY: The preceding checks validate every ConsoleAgentsByRoot member.
-    ? registry as ConsoleAgentsByRoot
-    : undefined
-}
-
-function processRegistry(scope: ConsoleAgentScope): ConsoleAgentRegistry | undefined {
-  return scope.process && (typeof scope.process === "object" || typeof scope.process === "function")
-    ? scope.process as ConsoleAgentRegistry
-    : undefined
-}
-
-function normalizedAgentNames(agentNames: readonly string[]): readonly string[] {
-  return [...new Set(agentNames.map(name => name.trim()).filter(Boolean))].sort()
-}
-
-export function resolveConsoleAgents(
-  scope: ConsoleAgentScope = globalThis as ConsoleAgentScope,
-): readonly string[] | undefined {
-  const root = scope[consoleInvocationsRootKey]
-  const registered = agentsByRoot(processRegistry(scope)?.[consoleAgentsRegistryKey])
-  if (root) return registered?.get(root) ?? scope[consoleAgentsKey]
-  if (!root && registered && registered.size > 1) return scope[consoleAgentsKey]
-  return processRegistry(scope)?.[consoleAgentsKey] as readonly string[] | undefined
-    ?? scope[consoleAgentsKey]
+type ConsoleAgentInvocations = AgentInvocations & {
+  [consoleAgentsKey]?: readonly string[]
 }
 
 export function installConsoleAgents(
   agentNames: readonly string[],
-  projectRoot: string,
-  scope: ConsoleAgentScope = globalThis as ConsoleAgentScope,
+  invocations: AgentInvocations,
 ): readonly string[] {
-  const root = resolve(projectRoot)
-  const agents = normalizedAgentNames(agentNames)
-  scope[consoleAgentsKey] = agents
-  scope[consoleInvocationsRootKey] = root
-  const registry = processRegistry(scope)
-  if (registry) {
-    const agentsByProject = agentsByRoot(registry[consoleAgentsRegistryKey])
-      ?? new Map<string, readonly string[]>()
-    agentsByProject.set(root, agents)
-    registry[consoleAgentsRegistryKey] = agentsByProject
-    registry[consoleAgentsKey] = agents
-  }
+  const agents = [...new Set(agentNames.map(name => name.trim()).filter(Boolean))].sort()
+  const consoleInvocations = invocations as ConsoleAgentInvocations
+  consoleInvocations[consoleAgentsKey] = agents
   return agents
 }
 
 export function installConsoleAgentDefinitions(
   entries: readonly ConsoleAgentDefinitionEntry[],
-  projectRoot: string,
-  scope: ConsoleAgentScope = globalThis as ConsoleAgentScope,
+  invocations: AgentInvocations,
 ): readonly string[] {
   return installConsoleAgents(entries.map(({ definition, fallbackName }) => {
     const module = definition && typeof definition === "object" ? definition as Record<string, unknown> : undefined
@@ -91,9 +33,9 @@ export function installConsoleAgentDefinitions(
       ? module.default as Record<string, unknown>
       : module
     return typeof agent?.name === "string" && agent.name.trim() ? agent.name : fallbackName
-  }), projectRoot, scope)
+  }), invocations)
 }
 
 export function getConsoleAgents(): readonly string[] {
-  return resolveConsoleAgents() ?? []
+  return (resolveConsoleInvocations() as ConsoleAgentInvocations | undefined)?.[consoleAgentsKey] ?? []
 }

--- a/packages/vite-hub/src/console/runtime/server/invocations.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.get.ts
@@ -26,7 +26,7 @@ const invocationsHandler: (event: ConsoleRequestEvent) => Promise<AgentInvocatio
   }
   const cursor = query.get("cursor") || undefined
   const agentName = query.get("agent")?.trim() || undefined
-  if (agentName && agentName.length > 256) {
+  if (agentName && agentName.length > 512) {
     throw Object.assign(new Error("Invalid Agent name"), {
       statusCode: 400,
       statusMessage: "Invalid Agent name",

--- a/packages/vite-hub/src/console/runtime/server/invocations.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.get.ts
@@ -25,6 +25,13 @@ const invocationsHandler: (event: ConsoleRequestEvent) => Promise<AgentInvocatio
     }
   }
   const cursor = query.get("cursor") || undefined
+  const agentName = query.get("agent")?.trim() || undefined
+  if (agentName && agentName.length > 256) {
+    throw Object.assign(new Error("Invalid Agent name"), {
+      statusCode: 400,
+      statusMessage: "Invalid Agent name",
+    })
+  }
   const limitValue = query.get("limit")
   const limit = limitValue === null ? undefined : Number(limitValue)
   if (limit !== undefined && (!Number.isInteger(limit) || limit < 1)) {
@@ -34,6 +41,7 @@ const invocationsHandler: (event: ConsoleRequestEvent) => Promise<AgentInvocatio
     })
   }
   return getConsoleInvocations().list({
+    ...(agentName ? { agentName } : {}),
     ...(cursor ? { cursor } : {}),
     ...(limit === undefined ? {} : { limit }),
   })

--- a/packages/vite-hub/src/console/server.ts
+++ b/packages/vite-hub/src/console/server.ts
@@ -3,5 +3,15 @@ import {
   getConsoleInvocations,
   installConsoleInvocations,
 } from "./runtime/server/invocations.ts"
+import {
+  getConsoleAgents,
+  installConsoleAgents,
+} from "./runtime/server/agents.ts"
 
-export { createConsoleInvocations, getConsoleInvocations, installConsoleInvocations }
+export {
+  createConsoleInvocations,
+  getConsoleAgents,
+  getConsoleInvocations,
+  installConsoleAgents,
+  installConsoleInvocations,
+}

--- a/packages/vite-hub/src/console/server.ts
+++ b/packages/vite-hub/src/console/server.ts
@@ -5,6 +5,7 @@ import {
 } from "./runtime/server/invocations.ts"
 import {
   getConsoleAgents,
+  installConsoleAgentDefinitions,
   installConsoleAgents,
 } from "./runtime/server/agents.ts"
 
@@ -12,6 +13,7 @@ export {
   createConsoleInvocations,
   getConsoleAgents,
   getConsoleInvocations,
+  installConsoleAgentDefinitions,
   installConsoleAgents,
   installConsoleInvocations,
 }

--- a/packages/vite-hub/src/console/vite.ts
+++ b/packages/vite-hub/src/console/vite.ts
@@ -25,8 +25,8 @@ function renderConsoleNitroPlugin(projectRoot: string, agents: readonly ConsoleA
   return [
     `import { installConsoleAgentDefinitions, installConsoleInvocations } from "vite-hub/console/server"`,
     ...agents.map((agent, index) => `import * as vitehubConsoleAgent${index} from ${JSON.stringify(agent.handler)}`),
-    `installConsoleInvocations(${JSON.stringify(projectRoot)})`,
-    `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], ${JSON.stringify(projectRoot)})`,
+    `const vitehubConsoleInvocations = installConsoleInvocations(${JSON.stringify(projectRoot)})`,
+    `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], vitehubConsoleInvocations)`,
     "export default function viteHubConsolePlugin() {}",
     "",
   ].join("\n")

--- a/packages/vite-hub/src/console/vite.ts
+++ b/packages/vite-hub/src/console/vite.ts
@@ -2,7 +2,8 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
-import { resolveViteHubProjectRoot } from "@vite-hub/internal/build/vite"
+import { discoverAgentDefinitionNames } from "@vite-hub/agent/vite"
+import { resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import type { Plugin } from "vite"
 
@@ -18,20 +19,32 @@ type ConsoleNitroConfig = {
   [key: string]: unknown
 }
 
-function renderConsoleNitroPlugin(projectRoot: string): string {
+function renderConsoleNitroPlugin(projectRoot: string, agentNames: readonly string[]): string {
   return [
-    `import { installConsoleInvocations } from "vite-hub/console/server"`,
+    `import { installConsoleAgents, installConsoleInvocations } from "vite-hub/console/server"`,
     `installConsoleInvocations(${JSON.stringify(projectRoot)})`,
+    `installConsoleAgents(${JSON.stringify(agentNames)}, ${JSON.stringify(projectRoot)})`,
     "export default function viteHubConsolePlugin() {}",
     "",
   ].join("\n")
 }
 
-async function writeConsoleNitroPlugin(file: string, projectRoot: string): Promise<void> {
-  const contents = renderConsoleNitroPlugin(projectRoot)
+async function writeConsoleNitroPlugin(
+  file: string,
+  projectRoot: string,
+  agentNames: readonly string[],
+): Promise<void> {
+  const contents = renderConsoleNitroPlugin(projectRoot, agentNames)
   if (await readFile(file, "utf8").catch(() => undefined) === contents) return
   await mkdir(resolve(file, ".."), { recursive: true })
   await writeFile(file, contents, "utf8")
+}
+
+export function discoverConsoleAgentNames(
+  root: string,
+  serverDirs = [join(root, "server")],
+): string[] {
+  return discoverAgentDefinitionNames(root, serverDirs)
 }
 
 function generatedRegistration(value: string, path: string): boolean {
@@ -39,13 +52,15 @@ function generatedRegistration(value: string, path: string): boolean {
 }
 
 export function consoleVitePlugin(): Plugin {
+  let generatedPlugin: string | undefined
+  let projectRoot: string | undefined
   return {
     name: "vite-hub/console",
     async config(config) {
       const root = resolve(config.root || process.cwd())
-      const projectRoot = resolveViteHubProjectRoot(root)
-      const plugin = resolve(root, generatedConsolePlugin)
-      await writeConsoleNitroPlugin(plugin, projectRoot)
+      projectRoot = resolveViteHubProjectRoot(root)
+      generatedPlugin = resolve(root, generatedConsolePlugin)
+      await writeConsoleNitroPlugin(generatedPlugin, projectRoot, discoverConsoleAgentNames(root))
 
       // SAFETY: Nitro extends Vite's user config with this documented top-level configuration object.
       const viteConfig = config as typeof config & { nitro?: ConsoleNitroConfig }
@@ -56,10 +71,12 @@ export function consoleVitePlugin(): Plugin {
         ? nitro.handlers.filter(handler => ![
             join(consoleRuntimeRoot, "server/invocation.get.js"),
             join(consoleRuntimeRoot, "server/invocations.get.js"),
+            join(consoleRuntimeRoot, "server/agents.get.js"),
             join(consoleRuntimeRoot, "server/page.get.js"),
           ].includes(handler?.handler))
         : []
       handlers.push(
+        { handler: join(consoleRuntimeRoot, "server/agents.get.js"), route: "/api/_vitehub/console/agents" },
         { handler: join(consoleRuntimeRoot, "server/invocations.get.js"), route: "/api/_vitehub/console/invocations" },
         { handler: join(consoleRuntimeRoot, "server/invocation.get.js"), route: "/api/_vitehub/console/invocations/:id" },
         { handler: join(consoleRuntimeRoot, "server/page.get.js"), route: "/_vitehub" },
@@ -68,13 +85,23 @@ export function consoleVitePlugin(): Plugin {
       const plugins = Array.isArray(nitro.plugins)
         ? nitro.plugins.filter(candidate => !generatedRegistration(candidate, generatedConsolePlugin))
         : []
-      plugins.push(plugin)
+      plugins.push(generatedPlugin)
       const publicAssets = Array.isArray(nitro.publicAssets)
         ? nitro.publicAssets.filter(asset => asset?.baseURL !== "/_vitehub/assets")
         : []
       publicAssets.push({ baseURL: "/_vitehub/assets", dir: consolePublicRoot, fallthrough: false })
 
       viteConfig.nitro = { ...nitro, handlers, plugins, publicAssets }
+    },
+    async configResolved(config) {
+      projectRoot ||= resolveViteHubProjectRoot(config.root)
+      generatedPlugin ||= resolve(config.root, generatedConsolePlugin)
+      const serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS]
+      await writeConsoleNitroPlugin(
+        generatedPlugin,
+        projectRoot,
+        discoverConsoleAgentNames(config.root, serverDirs),
+      )
     },
   }
 }

--- a/packages/vite-hub/src/console/vite.ts
+++ b/packages/vite-hub/src/console/vite.ts
@@ -57,10 +57,22 @@ function generatedRegistration(value: string, path: string): boolean {
 export function consoleVitePlugin(): Plugin {
   let generatedPlugin: string | undefined
   let projectRoot: string | undefined
+  let root: string | undefined
+  let serverDirs: string[] | undefined
+
+  async function refreshAgentDefinitions(): Promise<void> {
+    if (!generatedPlugin || !projectRoot || !root) return
+    await writeConsoleNitroPlugin(
+      generatedPlugin,
+      projectRoot,
+      discoverAgentDefinitionEntries(root, serverDirs),
+    )
+  }
+
   return {
     name: "vite-hub/console",
     async config(config) {
-      const root = resolve(config.root || process.cwd())
+      root = resolve(config.root || process.cwd())
       projectRoot = resolveViteHubProjectRoot(root)
       generatedPlugin = resolve(root, generatedConsolePlugin)
       await writeConsoleNitroPlugin(generatedPlugin, projectRoot, discoverAgentDefinitionEntries(root))
@@ -97,15 +109,18 @@ export function consoleVitePlugin(): Plugin {
       viteConfig.nitro = { ...nitro, handlers, plugins, publicAssets }
     },
     async configResolved(config) {
+      root = config.root
       projectRoot ||= resolveViteHubProjectRoot(config.root)
       generatedPlugin ||= resolve(config.root, generatedConsolePlugin)
       // SAFETY: VITEHUB_SERVER_DIRS is ViteHub-owned config state populated with string paths.
-      const serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS]
-      await writeConsoleNitroPlugin(
-        generatedPlugin,
-        projectRoot,
-        discoverAgentDefinitionEntries(config.root, serverDirs),
-      )
+      serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS]
+      await refreshAgentDefinitions()
+    },
+    configureServer(server) {
+      const refresh = async () => await refreshAgentDefinitions()
+      server.watcher.on("add", refresh)
+      server.watcher.on("change", refresh)
+      server.watcher.on("unlink", refresh)
     },
   }
 }

--- a/packages/vite-hub/src/console/vite.ts
+++ b/packages/vite-hub/src/console/vite.ts
@@ -7,6 +7,8 @@ import { resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/intern
 
 import type { Plugin } from "vite"
 
+import { serializeConsoleRefresh } from "./refresh.ts"
+
 const frameworkAgentSpecifier = "vite-hub/agent"
 const consoleRuntimeRoot = fileURLToPath(new URL("./runtime", import.meta.url))
 const consolePublicRoot = join(consoleRuntimeRoot, "public/console")
@@ -60,14 +62,14 @@ export function consoleVitePlugin(): Plugin {
   let root: string | undefined
   let serverDirs: string[] | undefined
 
-  async function refreshAgentDefinitions(): Promise<void> {
+  const refreshAgentDefinitions = serializeConsoleRefresh(async () => {
     if (!generatedPlugin || !projectRoot || !root) return
     await writeConsoleNitroPlugin(
       generatedPlugin,
       projectRoot,
       discoverAgentDefinitionEntries(root, serverDirs),
     )
-  }
+  })
 
   return {
     name: "vite-hub/console",

--- a/packages/vite-hub/src/console/vite.ts
+++ b/packages/vite-hub/src/console/vite.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
-import { discoverAgentDefinitionNames } from "@vite-hub/agent/vite"
+import { discoverAgentDefinitionEntries } from "@vite-hub/agent/vite"
 import { resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 
 import type { Plugin } from "vite"
@@ -19,11 +19,14 @@ type ConsoleNitroConfig = {
   [key: string]: unknown
 }
 
-function renderConsoleNitroPlugin(projectRoot: string, agentNames: readonly string[]): string {
+type ConsoleAgentEntry = { handler: string, name: string }
+
+function renderConsoleNitroPlugin(projectRoot: string, agents: readonly ConsoleAgentEntry[]): string {
   return [
-    `import { installConsoleAgents, installConsoleInvocations } from "vite-hub/console/server"`,
+    `import { installConsoleAgentDefinitions, installConsoleInvocations } from "vite-hub/console/server"`,
+    ...agents.map((agent, index) => `import * as vitehubConsoleAgent${index} from ${JSON.stringify(agent.handler)}`),
     `installConsoleInvocations(${JSON.stringify(projectRoot)})`,
-    `installConsoleAgents(${JSON.stringify(agentNames)}, ${JSON.stringify(projectRoot)})`,
+    `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], ${JSON.stringify(projectRoot)})`,
     "export default function viteHubConsolePlugin() {}",
     "",
   ].join("\n")
@@ -32,9 +35,9 @@ function renderConsoleNitroPlugin(projectRoot: string, agentNames: readonly stri
 async function writeConsoleNitroPlugin(
   file: string,
   projectRoot: string,
-  agentNames: readonly string[],
+  agents: readonly ConsoleAgentEntry[],
 ): Promise<void> {
-  const contents = renderConsoleNitroPlugin(projectRoot, agentNames)
+  const contents = renderConsoleNitroPlugin(projectRoot, agents)
   if (await readFile(file, "utf8").catch(() => undefined) === contents) return
   await mkdir(resolve(file, ".."), { recursive: true })
   await writeFile(file, contents, "utf8")
@@ -44,7 +47,7 @@ export function discoverConsoleAgentNames(
   root: string,
   serverDirs = [join(root, "server")],
 ): string[] {
-  return discoverAgentDefinitionNames(root, serverDirs)
+  return discoverAgentDefinitionEntries(root, serverDirs).map(agent => agent.name)
 }
 
 function generatedRegistration(value: string, path: string): boolean {
@@ -60,7 +63,7 @@ export function consoleVitePlugin(): Plugin {
       const root = resolve(config.root || process.cwd())
       projectRoot = resolveViteHubProjectRoot(root)
       generatedPlugin = resolve(root, generatedConsolePlugin)
-      await writeConsoleNitroPlugin(generatedPlugin, projectRoot, discoverConsoleAgentNames(root))
+      await writeConsoleNitroPlugin(generatedPlugin, projectRoot, discoverAgentDefinitionEntries(root))
 
       // SAFETY: Nitro extends Vite's user config with this documented top-level configuration object.
       const viteConfig = config as typeof config & { nitro?: ConsoleNitroConfig }
@@ -100,7 +103,7 @@ export function consoleVitePlugin(): Plugin {
       await writeConsoleNitroPlugin(
         generatedPlugin,
         projectRoot,
-        discoverConsoleAgentNames(config.root, serverDirs),
+        discoverAgentDefinitionEntries(config.root, serverDirs),
       )
     },
   }

--- a/packages/vite-hub/src/console/vite.ts
+++ b/packages/vite-hub/src/console/vite.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 import { discoverAgentDefinitionEntries } from "@vite-hub/agent/vite"
 import { resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
@@ -24,7 +24,7 @@ type ConsoleAgentEntry = { handler: string, name: string }
 function renderConsoleNitroPlugin(projectRoot: string, agents: readonly ConsoleAgentEntry[]): string {
   return [
     `import { installConsoleAgentDefinitions, installConsoleInvocations } from "vite-hub/console/server"`,
-    ...agents.map((agent, index) => `import * as vitehubConsoleAgent${index} from ${JSON.stringify(agent.handler)}`),
+    ...agents.map((agent, index) => `import * as vitehubConsoleAgent${index} from ${JSON.stringify(pathToFileURL(agent.handler).href)}`),
     `const vitehubConsoleInvocations = installConsoleInvocations(${JSON.stringify(projectRoot)})`,
     `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], vitehubConsoleInvocations)`,
     "export default function viteHubConsolePlugin() {}",
@@ -99,6 +99,7 @@ export function consoleVitePlugin(): Plugin {
     async configResolved(config) {
       projectRoot ||= resolveViteHubProjectRoot(config.root)
       generatedPlugin ||= resolve(config.root, generatedConsolePlugin)
+      // SAFETY: VITEHUB_SERVER_DIRS is ViteHub-owned config state populated with string paths.
       const serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS]
       await writeConsoleNitroPlugin(
         generatedPlugin,

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -234,6 +234,7 @@ async function installConsole(
   await refreshAgentDefinitions()
   if (nuxt.options.dev) {
     // doctor-disable-next-line typescript/evidence/no-chained-type-assertions -- Nuxt exposes hook overloads, while this structural seam keeps narrow test hosts assignable.
+    // SAFETY: Nuxt's hook overload includes builder:watch with this callback contract.
     const hookBuilderWatch = nuxt.hook as unknown as ((name: "builder:watch", callback: () => Promise<void>) => void) | undefined
     hookBuilderWatch?.("builder:watch", refreshAgentDefinitions)
   }

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -2,6 +2,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
+import { discoverAgentDefinitionEntries } from "@vite-hub/agent/vite"
 import { resolveViteHubProjectRoot, VITEHUB_GENERATED_ROOT, VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import { normalizeNitroPreset, resolveDeploymentPlan } from "@vite-hub/internal/deployment"
 import hubAuthNuxt from "@vite-hub/auth/nuxt"
@@ -12,7 +13,7 @@ import { mergeConfig } from "vite"
 
 import { vitehub } from "./index.ts"
 import { installConsoleInvocations } from "./console/runtime/server/invocations.ts"
-import { consoleInvocationRootPlugin, discoverConsoleAgentNames } from "./console/vite.ts"
+import { consoleInvocationRootPlugin } from "./console/vite.ts"
 import { mergeGeneratedNitroConfig, type GeneratedServerHandler } from "./internal/types.ts"
 
 import type { DatabaseNuxtIntegrationOptions } from "@vite-hub/database"
@@ -157,11 +158,12 @@ function addVueImports(nuxt: NuxtLike, from: string, names: string[]): void {
   }
 }
 
-function renderConsoleNitroPlugin(projectRoot: string, agentNames: readonly string[]): string {
+function renderConsoleNitroPlugin(projectRoot: string, agents: readonly { handler: string, name: string }[]): string {
   return [
-    `import { installConsoleAgents, installConsoleInvocations } from "vite-hub/console/server"`,
+    `import { installConsoleAgentDefinitions, installConsoleInvocations } from "vite-hub/console/server"`,
+    ...agents.map((agent, index) => `import * as vitehubConsoleAgent${index} from ${JSON.stringify(agent.handler)}`),
     `installConsoleInvocations(${JSON.stringify(projectRoot)})`,
-    `installConsoleAgents(${JSON.stringify(agentNames)}, ${JSON.stringify(projectRoot)})`,
+    `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], ${JSON.stringify(projectRoot)})`,
     "export default function viteHubConsolePlugin() {}",
     "",
   ].join("\n")
@@ -170,9 +172,9 @@ function renderConsoleNitroPlugin(projectRoot: string, agentNames: readonly stri
 async function writeConsoleNitroPlugin(
   file: string,
   projectRoot: string,
-  agentNames: readonly string[],
+  agents: readonly { handler: string, name: string }[],
 ): Promise<void> {
-  const contents = renderConsoleNitroPlugin(projectRoot, agentNames)
+  const contents = renderConsoleNitroPlugin(projectRoot, agents)
   if (await readFile(file, "utf8").catch(() => undefined) === contents) return
   await mkdir(resolve(file, ".."), { recursive: true })
   await writeFile(file, contents, "utf8")
@@ -224,7 +226,7 @@ async function installConsole(
   await writeConsoleNitroPlugin(
     plugin,
     projectRoot,
-    discoverConsoleAgentNames(discoveryRoot, serverDirs),
+    discoverAgentDefinitionEntries(discoveryRoot, serverDirs),
   )
   if (!plugins.includes(plugin)) plugins.push(plugin)
 }

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -162,8 +162,8 @@ function renderConsoleNitroPlugin(projectRoot: string, agents: readonly { handle
   return [
     `import { installConsoleAgentDefinitions, installConsoleInvocations } from "vite-hub/console/server"`,
     ...agents.map((agent, index) => `import * as vitehubConsoleAgent${index} from ${JSON.stringify(agent.handler)}`),
-    `installConsoleInvocations(${JSON.stringify(projectRoot)})`,
-    `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], ${JSON.stringify(projectRoot)})`,
+    `const vitehubConsoleInvocations = installConsoleInvocations(${JSON.stringify(projectRoot)})`,
+    `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], vitehubConsoleInvocations)`,
     "export default function viteHubConsolePlugin() {}",
     "",
   ].join("\n")

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -228,6 +228,17 @@ async function installConsole(
     projectRoot,
     discoverAgentDefinitionEntries(discoveryRoot, serverDirs),
   )
+  if (nuxt.options.dev) {
+    // doctor-disable-next-line typescript/evidence/no-chained-type-assertions -- Nuxt exposes hook overloads, while this structural seam keeps narrow test hosts assignable.
+    const hookBuilderWatch = nuxt.hook as unknown as ((name: "builder:watch", callback: () => Promise<void>) => void) | undefined
+    hookBuilderWatch?.("builder:watch", async () => {
+      await writeConsoleNitroPlugin(
+        plugin,
+        projectRoot,
+        discoverAgentDefinitionEntries(discoveryRoot, serverDirs),
+      )
+    })
+  }
   if (!plugins.includes(plugin)) plugins.push(plugin)
 }
 

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join, relative, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 import { discoverAgentDefinitionEntries } from "@vite-hub/agent/vite"
 import { resolveViteHubProjectRoot, VITEHUB_GENERATED_ROOT, VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
@@ -161,7 +161,7 @@ function addVueImports(nuxt: NuxtLike, from: string, names: string[]): void {
 function renderConsoleNitroPlugin(projectRoot: string, agents: readonly { handler: string, name: string }[]): string {
   return [
     `import { installConsoleAgentDefinitions, installConsoleInvocations } from "vite-hub/console/server"`,
-    ...agents.map((agent, index) => `import * as vitehubConsoleAgent${index} from ${JSON.stringify(agent.handler)}`),
+    ...agents.map((agent, index) => `import * as vitehubConsoleAgent${index} from ${JSON.stringify(pathToFileURL(agent.handler).href)}`),
     `const vitehubConsoleInvocations = installConsoleInvocations(${JSON.stringify(projectRoot)})`,
     `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], vitehubConsoleInvocations)`,
     "export default function viteHubConsolePlugin() {}",

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -12,7 +12,7 @@ import { mergeConfig } from "vite"
 
 import { vitehub } from "./index.ts"
 import { installConsoleInvocations } from "./console/runtime/server/invocations.ts"
-import { consoleInvocationRootPlugin } from "./console/vite.ts"
+import { consoleInvocationRootPlugin, discoverConsoleAgentNames } from "./console/vite.ts"
 import { mergeGeneratedNitroConfig, type GeneratedServerHandler } from "./internal/types.ts"
 
 import type { DatabaseNuxtIntegrationOptions } from "@vite-hub/database"
@@ -157,23 +157,33 @@ function addVueImports(nuxt: NuxtLike, from: string, names: string[]): void {
   }
 }
 
-function renderConsoleNitroPlugin(projectRoot: string): string {
+function renderConsoleNitroPlugin(projectRoot: string, agentNames: readonly string[]): string {
   return [
-    `import { installConsoleInvocations } from "vite-hub/console/server"`,
+    `import { installConsoleAgents, installConsoleInvocations } from "vite-hub/console/server"`,
     `installConsoleInvocations(${JSON.stringify(projectRoot)})`,
+    `installConsoleAgents(${JSON.stringify(agentNames)}, ${JSON.stringify(projectRoot)})`,
     "export default function viteHubConsolePlugin() {}",
     "",
   ].join("\n")
 }
 
-async function writeConsoleNitroPlugin(file: string, projectRoot: string): Promise<void> {
-  const contents = renderConsoleNitroPlugin(projectRoot)
+async function writeConsoleNitroPlugin(
+  file: string,
+  projectRoot: string,
+  agentNames: readonly string[],
+): Promise<void> {
+  const contents = renderConsoleNitroPlugin(projectRoot, agentNames)
   if (await readFile(file, "utf8").catch(() => undefined) === contents) return
   await mkdir(resolve(file, ".."), { recursive: true })
   await writeFile(file, contents, "utf8")
 }
 
-async function installConsole(nuxt: NuxtLike, projectRoot: string): Promise<void> {
+async function installConsole(
+  nuxt: NuxtLike,
+  projectRoot: string,
+  discoveryRoot: string,
+  serverDirs?: string[],
+): Promise<void> {
   const uiModule = (await import("@vite-hub/ui/nuxt")).default
   const uiConfigured = (nuxt.options.modules ?? []).some((entry) => {
     const module = Array.isArray(entry) ? entry[0] : entry
@@ -201,6 +211,7 @@ async function installConsole(nuxt: NuxtLike, projectRoot: string): Promise<void
   }
   const handlers = (nitro.handlers ??= [])
   const additions = [
+    { handler: join(consoleRuntimeRoot, "server/agents.get.js"), route: "/api/_vitehub/console/agents" },
     { handler: join(consoleRuntimeRoot, "server/invocations.get.js"), route: "/api/_vitehub/console/invocations" },
     { handler: join(consoleRuntimeRoot, "server/invocation.get.js"), route: "/api/_vitehub/console/invocations/:id" },
   ]
@@ -210,7 +221,11 @@ async function installConsole(nuxt: NuxtLike, projectRoot: string): Promise<void
   const plugins = (nitro.plugins ??= [])
   const plugin = join(projectRoot, ".vitehub/nitro/console/plugin.mjs")
   // Nitro runs in another runtime realm, so install a second journal instance over the same project SQLite file.
-  await writeConsoleNitroPlugin(plugin, projectRoot)
+  await writeConsoleNitroPlugin(
+    plugin,
+    projectRoot,
+    discoverConsoleAgentNames(discoveryRoot, serverDirs),
+  )
   if (!plugins.includes(plugin)) plugins.push(plugin)
 }
 
@@ -427,7 +442,14 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
   const rootDir = nuxt.options.rootDir || process.cwd()
   const viteRoot = resolve(rootDir, typeof nuxt.options.vite?.root === "string" ? nuxt.options.vite.root : rootDir)
   const projectRoot = resolveViteHubProjectRoot(viteRoot)
-  if (options.console) await installConsole(nuxt, projectRoot)
+  if (options.console) {
+    await installConsole(
+      nuxt,
+      projectRoot,
+      viteRoot,
+      nuxt.options.serverDir ? [nuxt.options.serverDir] : undefined,
+    )
+  }
   nuxt.options.vite ??= {}
   const viteConfig = nuxt.options.vite as UserConfig & EnvViteUserConfig & {
     [VITEHUB_GENERATED_ROOT]?: string

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -13,6 +13,7 @@ import { mergeConfig } from "vite"
 
 import { vitehub } from "./index.ts"
 import { installConsoleInvocations } from "./console/runtime/server/invocations.ts"
+import { serializeConsoleRefresh } from "./console/refresh.ts"
 import { consoleInvocationRootPlugin } from "./console/vite.ts"
 import { mergeGeneratedNitroConfig, type GeneratedServerHandler } from "./internal/types.ts"
 
@@ -222,22 +223,19 @@ async function installConsole(
   }
   const plugins = (nitro.plugins ??= [])
   const plugin = join(projectRoot, ".vitehub/nitro/console/plugin.mjs")
+  const refreshAgentDefinitions = serializeConsoleRefresh(async () => {
+    await writeConsoleNitroPlugin(
+      plugin,
+      projectRoot,
+      discoverAgentDefinitionEntries(discoveryRoot, serverDirs),
+    )
+  })
   // Nitro runs in another runtime realm, so install a second journal instance over the same project SQLite file.
-  await writeConsoleNitroPlugin(
-    plugin,
-    projectRoot,
-    discoverAgentDefinitionEntries(discoveryRoot, serverDirs),
-  )
+  await refreshAgentDefinitions()
   if (nuxt.options.dev) {
     // doctor-disable-next-line typescript/evidence/no-chained-type-assertions -- Nuxt exposes hook overloads, while this structural seam keeps narrow test hosts assignable.
     const hookBuilderWatch = nuxt.hook as unknown as ((name: "builder:watch", callback: () => Promise<void>) => void) | undefined
-    hookBuilderWatch?.("builder:watch", async () => {
-      await writeConsoleNitroPlugin(
-        plugin,
-        projectRoot,
-        discoverAgentDefinitionEntries(discoveryRoot, serverDirs),
-      )
-    })
+    hookBuilderWatch?.("builder:watch", refreshAgentDefinitions)
   }
   if (!plugins.includes(plugin)) plugins.push(plugin)
 }

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -10,6 +10,8 @@ import { createServer } from "vite"
 
 import { defineAgent } from "../src/agent.ts"
 import { consoleInvocationsKey, consoleInvocationsRegistryKey, consoleInvocationsRootKey, installConsoleInvocationFallback, resolveConsoleInvocations } from "../src/console/internal.ts"
+import agentsHandler from "../src/console/runtime/server/agents.get.ts"
+import { consoleAgentsKey, consoleAgentsRegistryKey, installConsoleAgents } from "../src/console/runtime/server/agents.ts"
 import { createConsoleInvocations, installConsoleInvocations } from "../src/console/runtime/server/invocations.ts"
 import invocationsHandler from "../src/console/runtime/server/invocations.get.ts"
 import { assertConsoleRequest } from "../src/console/runtime/server/request.ts"
@@ -52,6 +54,9 @@ afterEach(() => {
   Reflect.deleteProperty(process, consoleInvocationsKey)
   Reflect.deleteProperty(process, consoleInvocationsRootKey)
   Reflect.deleteProperty(process, consoleInvocationsRegistryKey)
+  Reflect.deleteProperty(globalThis, consoleAgentsKey)
+  Reflect.deleteProperty(process, consoleAgentsKey)
+  Reflect.deleteProperty(process, consoleAgentsRegistryKey)
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
 })
@@ -60,6 +65,9 @@ describe("Agent invocation console", () => {
   it("registers the standalone console UI and invocation API with Nitro", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-console-host-"))
     try {
+      await writeFile(join(root, "package.json"), "{}\n")
+      await writeFile(join(root, "review.agent.ts"), "export default {}\n")
+      await writeFile(join(root, "support.agent.ts"), "export default {}\n")
       const plugin = consoleVitePlugin()
       const configHook = plugin.config
       if (!configHook) throw new TypeError("Expected a console config hook.")
@@ -76,6 +84,7 @@ describe("Agent invocation console", () => {
       if (!config.nitro) throw new TypeError("Expected the console Nitro configuration.")
 
       expect(config.nitro.handlers.map(handler => handler.route)).toEqual([
+        "/api/_vitehub/console/agents",
         "/api/_vitehub/console/invocations",
         "/api/_vitehub/console/invocations/:id",
         "/_vitehub",
@@ -88,10 +97,45 @@ describe("Agent invocation console", () => {
       await expect(readFile(config.nitro.plugins[0]!, "utf8")).resolves.toContain(
         `installConsoleInvocations(${JSON.stringify(root)})`,
       )
+      await expect(readFile(config.nitro.plugins[0]!, "utf8")).resolves.toContain(
+        `installConsoleAgents(["review","support"], ${JSON.stringify(root)})`,
+      )
     }
     finally {
       await rm(root, { force: true, recursive: true })
     }
+  })
+
+  it("serves discovered Agent names in stable order", () => {
+    installConsoleAgents(["support", "review", "support"], process.cwd())
+
+    expect(agentsHandler(event("127.0.0.1"))).toEqual({
+      agents: ["review", "support"],
+    })
+  })
+
+  it("filters console sessions by exact Agent name", async () => {
+    const store = createMemoryAgentInvocationStore()
+    for (const agentName of ["review", "review-assistant"]) {
+      store.create({
+        agentName,
+        createdAt: "2026-08-23T12:00:00.000Z",
+        id: agentName,
+        observations: [],
+        status: "completed",
+        traceId: `trace-${agentName}`,
+        updatedAt: "2026-08-23T12:00:00.000Z",
+      })
+    }
+    installConsoleInvocationFallback(defineAgentInvocations({ store }), process.cwd())
+    const requestEvent = event("127.0.0.1")
+    const url = "http://localhost/api/_vitehub/console/invocations?agent=review"
+    requestEvent.node!.req!.url = url
+    requestEvent.req!.url = url
+
+    await expect(invocationsHandler(requestEvent)).resolves.toMatchObject({
+      invocations: [{ agentName: "review" }],
+    })
   })
 
   it("refreshes invocation summaries in one request without observations", async () => {

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -139,6 +139,26 @@ describe("Agent invocation console", () => {
     await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({ agents: ["review", "support"] })
   })
 
+  it("keeps persisted Agent names alongside discovered definitions", async () => {
+    const store = createMemoryAgentInvocationStore()
+    store.create({
+      agentName: "archived",
+      createdAt: "2026-08-23T12:00:00.000Z",
+      id: "archived-invocation",
+      observations: [],
+      status: "completed",
+      traceId: "archived-trace",
+      updatedAt: "2026-08-23T12:00:00.000Z",
+    })
+    const invocations = defineAgentInvocations({ store })
+    installConsoleInvocationFallback(invocations, process.cwd())
+    installConsoleAgents(["current"], invocations)
+
+    await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({
+      agents: ["archived", "current"],
+    })
+  })
+
   it("uses explicit Agent Definition names instead of discovered route names", async () => {
     const definition = defineAgent({ driver: { run: () => "ok" }, name: " support " })
     expect(definition.name).toBe("support")

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -11,7 +11,7 @@ import { createServer } from "vite"
 import { defineAgent } from "../src/agent.ts"
 import { consoleInvocationsKey, consoleInvocationsRegistryKey, consoleInvocationsRootKey, installConsoleInvocationFallback, resolveConsoleInvocations } from "../src/console/internal.ts"
 import agentsHandler from "../src/console/runtime/server/agents.get.ts"
-import { consoleAgentsKey, consoleAgentsRegistryKey, installConsoleAgentDefinitions, installConsoleAgents } from "../src/console/runtime/server/agents.ts"
+import { installConsoleAgentDefinitions, installConsoleAgents } from "../src/console/runtime/server/agents.ts"
 import { createConsoleInvocations, installConsoleInvocations } from "../src/console/runtime/server/invocations.ts"
 import invocationsHandler from "../src/console/runtime/server/invocations.get.ts"
 import { assertConsoleRequest } from "../src/console/runtime/server/request.ts"
@@ -54,9 +54,6 @@ afterEach(() => {
   Reflect.deleteProperty(process, consoleInvocationsKey)
   Reflect.deleteProperty(process, consoleInvocationsRootKey)
   Reflect.deleteProperty(process, consoleInvocationsRegistryKey)
-  Reflect.deleteProperty(globalThis, consoleAgentsKey)
-  Reflect.deleteProperty(process, consoleAgentsKey)
-  Reflect.deleteProperty(process, consoleAgentsRegistryKey)
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
 })
@@ -95,7 +92,7 @@ describe("Agent invocation console", () => {
       ])
       expect(config.nitro.plugins).toEqual([resolve(root, ".vitehub/nitro/console/plugin.mjs")])
       await expect(readFile(config.nitro.plugins[0]!, "utf8")).resolves.toContain(
-        `installConsoleInvocations(${JSON.stringify(root)})`,
+        `const vitehubConsoleInvocations = installConsoleInvocations(${JSON.stringify(root)})`,
       )
       await expect(readFile(config.nitro.plugins[0]!, "utf8")).resolves.toContain(
         `fallbackName: "review"`,
@@ -106,20 +103,52 @@ describe("Agent invocation console", () => {
     }
   })
 
-  it("serves discovered Agent names in stable order", () => {
-    installConsoleAgents(["support", "review", "support"], process.cwd())
+  it("serves discovered Agent names in stable order for the active project", async () => {
+    const first = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
+    const second = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
+    installConsoleInvocationFallback(first, "/first")
+    installConsoleAgents(["support", "review", "support"], first)
+    installConsoleInvocationFallback(second, "/second")
+    installConsoleAgents(["billing"], second)
 
-    expect(agentsHandler(event("127.0.0.1"))).toEqual({
-      agents: ["review", "support"],
+    await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({
+      agents: ["billing"],
     })
+
+    scope[consoleInvocationsRootKey] = "/first"
+    await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({ agents: ["review", "support"] })
   })
 
-  it("uses explicit Agent Definition names instead of discovered route names", () => {
+  it("uses explicit Agent Definition names instead of discovered route names", async () => {
+    const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
+    installConsoleInvocationFallback(invocations, process.cwd())
     installConsoleAgentDefinitions([
       { definition: { default: defineAgent({ driver: { run: () => "ok" }, name: "support" }) }, fallbackName: "help" },
-    ], process.cwd())
+    ], invocations)
 
-    expect(agentsHandler(event("127.0.0.1"))).toEqual({ agents: ["support"] })
+    await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({ agents: ["support"] })
+  })
+
+  it("finds Agent names beyond the first persisted invocation page", async () => {
+    const store = createMemoryAgentInvocationStore()
+    for (const [index, agentName] of ["archived", ...Array.from({ length: 100 }, () => "current")].entries()) {
+      store.create({
+        agentName,
+        createdAt: "2026-08-23T12:00:00.000Z",
+        id: `inv-${index}`,
+        observations: [],
+        status: "completed",
+        traceId: `trace-${index}`,
+        updatedAt: "2026-08-23T12:00:00.000Z",
+      })
+    }
+    const invocations = defineAgentInvocations({ store })
+    installConsoleInvocationFallback(invocations, process.cwd())
+    installConsoleAgents([], invocations)
+
+    await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({
+      agents: ["archived", "current"],
+    })
   })
 
   it("filters console sessions by exact Agent name", async () => {

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -11,7 +11,7 @@ import { createServer } from "vite"
 import { defineAgent } from "../src/agent.ts"
 import { consoleInvocationsKey, consoleInvocationsRegistryKey, consoleInvocationsRootKey, installConsoleInvocationFallback, resolveConsoleInvocations } from "../src/console/internal.ts"
 import agentsHandler from "../src/console/runtime/server/agents.get.ts"
-import { consoleAgentsKey, consoleAgentsRegistryKey, installConsoleAgents } from "../src/console/runtime/server/agents.ts"
+import { consoleAgentsKey, consoleAgentsRegistryKey, installConsoleAgentDefinitions, installConsoleAgents } from "../src/console/runtime/server/agents.ts"
 import { createConsoleInvocations, installConsoleInvocations } from "../src/console/runtime/server/invocations.ts"
 import invocationsHandler from "../src/console/runtime/server/invocations.get.ts"
 import { assertConsoleRequest } from "../src/console/runtime/server/request.ts"
@@ -98,7 +98,7 @@ describe("Agent invocation console", () => {
         `installConsoleInvocations(${JSON.stringify(root)})`,
       )
       await expect(readFile(config.nitro.plugins[0]!, "utf8")).resolves.toContain(
-        `installConsoleAgents(["review","support"], ${JSON.stringify(root)})`,
+        `fallbackName: "review"`,
       )
     }
     finally {
@@ -112,6 +112,14 @@ describe("Agent invocation console", () => {
     expect(agentsHandler(event("127.0.0.1"))).toEqual({
       agents: ["review", "support"],
     })
+  })
+
+  it("uses explicit Agent Definition names instead of discovered route names", () => {
+    installConsoleAgentDefinitions([
+      { definition: { default: defineAgent({ driver: { run: () => "ok" }, name: "support" }) }, fallbackName: "help" },
+    ], process.cwd())
+
+    expect(agentsHandler(event("127.0.0.1"))).toEqual({ agents: ["support"] })
   })
 
   it("filters console sessions by exact Agent name", async () => {

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -1,5 +1,5 @@
 import { existsSync } from "node:fs"
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { createRequire } from "node:module"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
@@ -142,6 +142,59 @@ describe("Agent invocation console", () => {
     ], invocations)
 
     await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({ agents: ["help"] })
+  })
+
+  it("rejects Agent names beyond the persisted identity limit", () => {
+    expect(() => defineAgent({ driver: { run: () => "ok" }, name: "a".repeat(513) }))
+      .toThrow("Agent names cannot exceed 512 characters")
+  })
+
+  it("keeps colliding discovered route names until definitions resolve", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-console-collision-"))
+    try {
+      await writeFile(join(root, "package.json"), "{}\n")
+      await writeFile(join(root, "review.agent.ts"), "export default {}\n")
+      await mkdir(join(root, "server", "agents"), { recursive: true })
+      await writeFile(join(root, "server", "agents", "review.ts"), "export default {}\n")
+      const plugin = consoleVitePlugin()
+      const configHook = plugin.config
+      if (!configHook) throw new TypeError("Expected a console config hook.")
+      const configHandler = "handler" in configHook ? configHook.handler : configHook
+      const config = { root }
+      await Reflect.apply(configHandler, {}, [config, { command: "build", mode: "production" }])
+      const generated = await readFile(resolve(root, ".vitehub/nitro/console/plugin.mjs"), "utf8")
+      expect(generated.match(/fallbackName: "review"/g)).toHaveLength(2)
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("regenerates discovered Agents when definitions change in development", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-console-watch-"))
+    try {
+      await writeFile(join(root, "package.json"), "{}\n")
+      await writeFile(join(root, "review.agent.ts"), "export default {}\n")
+      const plugin = consoleVitePlugin()
+      const configHook = plugin.config
+      if (!configHook) throw new TypeError("Expected a console config hook.")
+      const configHandler = "handler" in configHook ? configHook.handler : configHook
+      await Reflect.apply(configHandler, {}, [{ root }, { command: "serve", mode: "development" }])
+
+      const listeners = new Map<string, () => Promise<void>>()
+      const configureServer = plugin.configureServer
+      if (!configureServer) throw new TypeError("Expected a console development-server hook.")
+      const configureServerHandler = "handler" in configureServer ? configureServer.handler : configureServer
+      Reflect.apply(configureServerHandler, {}, [{ watcher: { on: (event: string, listener: () => Promise<void>) => listeners.set(event, listener) } }])
+
+      await writeFile(join(root, "support.agent.ts"), "export default {}\n")
+      await listeners.get("add")?.()
+      await expect(readFile(resolve(root, ".vitehub/nitro/console/plugin.mjs"), "utf8"))
+        .resolves.toContain(`fallbackName: "support"`)
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
   })
 
   it("finds Agent names beyond the first persisted invocation page", async () => {

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -97,6 +97,7 @@ describe("Agent invocation console", () => {
       await expect(readFile(config.nitro.plugins[0]!, "utf8")).resolves.toContain(
         `fallbackName: "review"`,
       )
+      await expect(readFile(config.nitro.plugins[0]!, "utf8")).resolves.toContain(`from "file://`)
     }
     finally {
       await rm(root, { force: true, recursive: true })
@@ -120,10 +121,12 @@ describe("Agent invocation console", () => {
   })
 
   it("uses explicit Agent Definition names instead of discovered route names", async () => {
+    const definition = defineAgent({ driver: { run: () => "ok" }, name: " support " })
+    expect(definition.name).toBe("support")
     const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
     installConsoleInvocationFallback(invocations, process.cwd())
     installConsoleAgentDefinitions([
-      { definition: { default: defineAgent({ driver: { run: () => "ok" }, name: "support" }) }, fallbackName: "help" },
+      { definition: { default: definition }, fallbackName: "help" },
     ], invocations)
 
     await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({ agents: ["support"] })

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -10,6 +10,7 @@ import { createServer } from "vite"
 
 import { defineAgent } from "../src/agent.ts"
 import { consoleInvocationsKey, consoleInvocationsRegistryKey, consoleInvocationsRootKey, installConsoleInvocationFallback, resolveConsoleInvocations } from "../src/console/internal.ts"
+import { serializeConsoleRefresh } from "../src/console/refresh.ts"
 import agentsHandler from "../src/console/runtime/server/agents.get.ts"
 import { installConsoleAgentDefinitions, installConsoleAgents } from "../src/console/runtime/server/agents.ts"
 import { createConsoleInvocations, installConsoleInvocations } from "../src/console/runtime/server/invocations.ts"
@@ -59,6 +60,24 @@ afterEach(() => {
 })
 
 describe("Agent invocation console", () => {
+  it("serializes generated Agent registry refreshes", async () => {
+    const releases: Array<() => void> = []
+    const started: number[] = []
+    const refresh = serializeConsoleRefresh(async () => {
+      started.push(started.length)
+      await new Promise<void>(resolve => releases.push(resolve))
+    })
+
+    const first = refresh()
+    const second = refresh()
+    await vi.waitFor(() => expect(started).toEqual([0]))
+    releases.shift()?.()
+    await vi.waitFor(() => expect(started).toEqual([0, 1]))
+    releases.shift()?.()
+
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined])
+  })
+
   it("registers the standalone console UI and invocation API with Nitro", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-console-host-"))
     try {

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -132,6 +132,18 @@ describe("Agent invocation console", () => {
     await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({ agents: ["support"] })
   })
 
+  it("uses the discovered name when an explicit Agent Definition name is blank", async () => {
+    const definition = defineAgent({ driver: { run: () => "ok" }, name: "   " })
+    expect(definition.name).toBe("")
+    const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
+    installConsoleInvocationFallback(invocations, process.cwd())
+    installConsoleAgentDefinitions([
+      { definition: { default: definition }, fallbackName: "help" },
+    ], invocations)
+
+    await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({ agents: ["help"] })
+  })
+
   it("finds Agent names beyond the first persisted invocation page", async () => {
     const store = createMemoryAgentInvocationStore()
     for (const [index, agentName] of ["archived", ...Array.from({ length: 100 }, () => "current")].entries()) {
@@ -175,6 +187,29 @@ describe("Agent invocation console", () => {
 
     await expect(invocationsHandler(requestEvent)).resolves.toMatchObject({
       invocations: [{ agentName: "review" }],
+    })
+  })
+
+  it("accepts persisted Agent names up to the metadata limit", async () => {
+    const agentName = "a".repeat(512)
+    const store = createMemoryAgentInvocationStore()
+    store.create({
+      agentName,
+      createdAt: "2026-08-23T12:00:00.000Z",
+      id: "long-name",
+      observations: [],
+      status: "completed",
+      traceId: "trace-long-name",
+      updatedAt: "2026-08-23T12:00:00.000Z",
+    })
+    installConsoleInvocationFallback(defineAgentInvocations({ store }), process.cwd())
+    const requestEvent = event("127.0.0.1")
+    const url = `http://localhost/api/_vitehub/console/invocations?agent=${agentName}`
+    requestEvent.node!.req!.url = url
+    requestEvent.req!.url = url
+
+    await expect(invocationsHandler(requestEvent)).resolves.toMatchObject({
+      invocations: [{ agentName }],
     })
   })
 

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -329,7 +329,7 @@ describe("ViteHub Nuxt integration", () => {
       `installConsoleInvocations("/tmp/vitehub-nuxt")`,
     )
     await expect(readFile("/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs", "utf8")).resolves.toContain(
-      `installConsoleAgents([], "/tmp/vitehub-nuxt")`,
+      `installConsoleAgentDefinitions([], "/tmp/vitehub-nuxt")`,
     )
 
     mocks.uiModule.mockClear()

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -326,10 +326,10 @@ describe("ViteHub Nuxt integration", () => {
       expect.objectContaining({ name: "vite-hub/console-invocation-root" }),
     )
     await expect(readFile("/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs", "utf8")).resolves.toContain(
-      `installConsoleInvocations("/tmp/vitehub-nuxt")`,
+      `const vitehubConsoleInvocations = installConsoleInvocations("/tmp/vitehub-nuxt")`,
     )
     await expect(readFile("/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs", "utf8")).resolves.toContain(
-      `installConsoleAgentDefinitions([], "/tmp/vitehub-nuxt")`,
+      `installConsoleAgentDefinitions([], vitehubConsoleInvocations)`,
     )
 
     mocks.uiModule.mockClear()

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -313,6 +313,7 @@ describe("ViteHub Nuxt integration", () => {
     ])
     expect(development.nuxt.options.nitro).toMatchObject({
       handlers: [
+        { route: "/api/_vitehub/console/agents" },
         { route: "/api/_vitehub/console/invocations" },
         { route: "/api/_vitehub/console/invocations/:id" },
       ],
@@ -327,6 +328,9 @@ describe("ViteHub Nuxt integration", () => {
     await expect(readFile("/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs", "utf8")).resolves.toContain(
       `installConsoleInvocations("/tmp/vitehub-nuxt")`,
     )
+    await expect(readFile("/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs", "utf8")).resolves.toContain(
+      `installConsoleAgents([], "/tmp/vitehub-nuxt")`,
+    )
 
     mocks.uiModule.mockClear()
     const production = createNuxt(false)
@@ -340,6 +344,7 @@ describe("ViteHub Nuxt integration", () => {
     ])
     expect(production.nuxt.options.nitro).toMatchObject({
       handlers: [
+        { route: "/api/_vitehub/console/agents" },
         { route: "/api/_vitehub/console/invocations" },
         { route: "/api/_vitehub/console/invocations/:id" },
       ],

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -259,6 +259,8 @@ describe("framework package contract", () => {
     expect(consolePage).toContain(':retry-key="paginationRetryRevision"')
     expect(consolePage).toContain("list.loadMoreError.value")
     expect(consolePage).toContain("Retry loading older sessions")
+    expect(consolePage).toContain("Switch Agent")
+    expect(consolePage).toContain("agentMenuItems")
     expect(consolePage).not.toContain("groupConsoleSessions")
     expect(readFileSync(`${packageRoot}/dist/console/runtime/public/console/console.js`, "utf8")).toContain("ViteHub")
     expect(readFileSync(`${packageRoot}/dist/console/runtime/public/console/console.css`, "utf8")).toContain("vitehub-console")

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -261,6 +261,8 @@ describe("framework package contract", () => {
     expect(consolePage).toContain("Retry loading older sessions")
     expect(consolePage).toContain("Switch Agent")
     expect(consolePage).toContain("agentMenuItems")
+    expect(consolePage).toContain("invocation.agentName !== selectedAgentName.value")
+    expect(consolePage).toContain("invocation.agentName === agentName")
     expect(consolePage).not.toContain("groupConsoleSessions")
     expect(readFileSync(`${packageRoot}/dist/console/runtime/public/console/console.js`, "utf8")).toContain("ViteHub")
     expect(readFileSync(`${packageRoot}/dist/console/runtime/public/console/console.css`, "utf8")).toContain("vitehub-console")

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -58,6 +58,7 @@ export default defineConfig({
     }],
     entry: [
       ...distributionEntries,
+      "src/console/runtime/server/agents.get.ts",
       "src/console/runtime/server/invocation.get.ts",
       "src/console/runtime/server/invocations.get.ts",
       "src/console/runtime/server/page.get.ts",
@@ -66,6 +67,7 @@ export default defineConfig({
       exclude: ["bin"],
       bin: distributionBinEntries,
       customExports(exports) {
+        delete exports["./console/runtime/server/agents.get"]
         delete exports["./console/runtime/server/invocation.get"]
         delete exports["./console/runtime/server/invocations.get"]
         delete exports["./console/runtime/server/page.get"]


### PR DESCRIPTION
Projects can define multiple Agent Definitions, but the console header could not select one and the session list mixed every Agent together. This adds a compact project-Agent switcher at the console boundary and carries the selection through discovery, persistence, API filtering, and routing.

## Agent selector behavior

- One discovered Agent keeps the same 40px header control, disables the menu, and reserves the chevron footprint so loading and multi-Agent states do not shift the layout.
- Multiple Agents open a compact top-left dropdown, adapted to the existing ViteHub Console visual language.
- Selecting an Agent writes `?agent=` to the route, clears the prior invocation, and filters sessions by exact Agent name.
- Vite and Nuxt builds discover Agent Definitions and install their stable, deduplicated names into the Nitro console runtime.
- Existing persisted sessions remain a fallback source of Agent names if discovery data is unavailable.

## Verification

- `packages/agent`: 57 invocation tests passed
- `packages/vite-hub`: 74 console, Nuxt, and package tests passed with type diagnostics
- `packages/agent`: build and typecheck passed
- `packages/vite-hub`: console build, package build, publint, and typecheck passed
- Scoped `vp lint` and `git diff --check` passed