### PR TITLE
fix: harden runtime boundaries and developer tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ test-results
 .data
 .nitro
 .cache
+.swc
 .generated
 .vitehub
 .sandcastle
@@ -31,6 +32,7 @@ docs/types/auto-imports.d.ts
 docs/types/mdc-runtime.d.ts
 packages/*/dist
 packages/*/*.tgz
+*.tsbuildinfo
 *.log
 .DS_Store
 .vercel

--- a/packages/agent/src/internal/agent-driver.ts
+++ b/packages/agent/src/internal/agent-driver.ts
@@ -1,4 +1,5 @@
-import { isPlainObject } from "@vite-hub/internal/object"
+import { isPlainObject, isPlainRecord } from "@vite-hub/internal/object"
+import { isRuntimeFunction, isRuntimeNumber, isRuntimeString } from "./runtime-value.ts"
 
 import type {
   AgentAdapterInstructions,
@@ -58,25 +59,24 @@ function normalizeAgentDriverCapacity(value: unknown): AgentDriverCapacityOption
   if (value === undefined) return
   if (!isPlainObject(value)) throw new TypeError("[vitehub] defineAgent({ driver.capacity }) must be an object.")
   assertNoUnsupportedOptions(value, new Set(["concurrency", "queue"]), "defineAgent({ driver.capacity })")
-  if (!Number.isInteger(value.concurrency) || (value.concurrency as number) <= 0) {
+  if (!isRuntimeNumber(value.concurrency) || !Number.isInteger(value.concurrency) || value.concurrency <= 0) {
     throw new TypeError("[vitehub] defineAgent({ driver.capacity.concurrency }) must be a positive integer.")
   }
-  if (value.queue === undefined) return { concurrency: value.concurrency as number }
+  if (value.queue === undefined) return { concurrency: value.concurrency }
   if (!isPlainObject(value.queue)) throw new TypeError("[vitehub] defineAgent({ driver.capacity.queue }) must be an object.")
   assertNoUnsupportedOptions(value.queue, new Set(["maxPending", "timeout"]), "defineAgent({ driver.capacity.queue })")
-  if (!Number.isInteger(value.queue.maxPending) || (value.queue.maxPending as number) <= 0) {
+  if (!isRuntimeNumber(value.queue.maxPending) || !Number.isInteger(value.queue.maxPending) || value.queue.maxPending <= 0) {
     throw new TypeError("[vitehub] defineAgent({ driver.capacity.queue.maxPending }) must be a positive integer.")
   }
   if (value.queue.timeout !== undefined
-    && (typeof value.queue.timeout !== "number" || !Number.isFinite(value.queue.timeout) || value.queue.timeout <= 0 || value.queue.timeout > 2_147_483_647)) {
+    && (!isRuntimeNumber(value.queue.timeout) || !Number.isFinite(value.queue.timeout) || value.queue.timeout <= 0 || value.queue.timeout > 2_147_483_647)) {
     throw new TypeError("[vitehub] defineAgent({ driver.capacity.queue.timeout }) must be a positive finite number no greater than 2147483647.")
   }
+  const queue: NonNullable<AgentDriverCapacityOptions["queue"]> = { maxPending: value.queue.maxPending }
+  if (value.queue.timeout !== undefined) queue.timeout = value.queue.timeout
   return {
-    concurrency: value.concurrency as number,
-    queue: {
-      maxPending: value.queue.maxPending as number,
-      ...(value.queue.timeout === undefined ? {} : { timeout: value.queue.timeout as number }),
-    },
+    concurrency: value.concurrency,
+    queue,
   }
 }
 
@@ -86,10 +86,15 @@ const runDriverKeys = new Set(["capacity", "output", "run"])
 
 function normalizeProviderEnvironment(value: unknown): Record<string, string | undefined> | undefined {
   if (value === undefined) return
-  if (!isPlainObject(value) || Object.values(value).some(item => item !== undefined && typeof item !== "string")) {
+  if (!isPlainObject(value)) {
     throw new TypeError("[vitehub] defineAgent({ driver.env }) must contain only string or undefined values.")
   }
-  return value as Record<string, string | undefined>
+  const entries = Object.entries(value)
+  if (entries.some(([, item]) => item !== undefined && !isRuntimeString(item))) {
+    throw new TypeError("[vitehub] defineAgent({ driver.env }) must contain only string or undefined values.")
+  }
+  // SAFETY: Every entry value was validated as string or undefined above.
+  return Object.fromEntries(entries) as Record<string, string | undefined>
 }
 
 function normalizeProviderPermissions(value: unknown): AgentProviderPermissions | undefined {
@@ -100,37 +105,51 @@ function normalizeProviderPermissions(value: unknown): AgentProviderPermissions 
   return value
 }
 
-function normalizeProviderDriver<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  CALL_OPTIONS,
->(provider: "claude-code" | "codex", value: Record<string, unknown>): NormalizedAgentDriver<TRuntimeConfig, CALL_OPTIONS> {
-  assertNoUnsupportedOptions(value, providerDriverKeys, `defineAgent({ driver: { kind: "${provider}" } })`)
-  if (value.model !== undefined && (typeof value.model !== "string" || !value.model.trim())) {
-    throw new TypeError("[vitehub] defineAgent({ driver.model }) must be a non-empty string.")
+function isConfigurationObject(value: unknown): value is Record<string, unknown> {
+  return isPlainRecord(value)
+}
+
+function normalizeProviderExecution(value: unknown): { attachments?: AgentAttachmentExecutionOptions } | undefined {
+  if (value === undefined) return
+  if (!isConfigurationObject(value)) {
+    throw new TypeError("[vitehub] defineAgent({ driver.execution }) must be an object.")
   }
-  const execution = value.execution as { attachments?: AgentAttachmentExecutionOptions } | undefined
-  const maxBytes = execution?.attachments?.maxBytes
-  if (maxBytes !== undefined && (!Number.isFinite(maxBytes) || maxBytes <= 0)) {
+  assertNoUnsupportedOptions(value, new Set(["attachments"]), "defineAgent({ driver.execution })")
+  if (value.attachments === undefined) return {}
+  if (!isConfigurationObject(value.attachments)) {
+    throw new TypeError("[vitehub] defineAgent({ driver.execution.attachments }) must be an object.")
+  }
+  assertNoUnsupportedOptions(value.attachments, new Set(["maxBytes"]), "defineAgent({ driver.execution.attachments })")
+  const maxBytes = value.attachments.maxBytes
+  if (maxBytes !== undefined && (!isRuntimeNumber(maxBytes) || !Number.isFinite(maxBytes) || maxBytes <= 0)) {
     throw new TypeError("[vitehub] defineAgent({ driver.execution.attachments.maxBytes }) must be a positive finite number.")
   }
+  return { attachments: maxBytes === undefined ? {} : { maxBytes } }
+}
+
+function normalizeProviderDriver(provider: "claude-code" | "codex", value: Record<string, unknown>): NormalizedAgentDriver {
+  assertNoUnsupportedOptions(value, providerDriverKeys, `defineAgent({ driver: { kind: "${provider}" } })`)
+  if (value.model !== undefined && (!isRuntimeString(value.model) || !value.model.trim())) {
+    throw new TypeError("[vitehub] defineAgent({ driver.model }) must be a non-empty string.")
+  }
+  const execution = normalizeProviderExecution(value.execution)
   return {
     capacity: normalizeAgentDriverCapacity(value.capacity),
     env: normalizeProviderEnvironment(value.env),
     execution,
-    instructions: value.instructions as AgentAdapterInstructions<TRuntimeConfig> | undefined,
+    // SAFETY: normalizeProviderDriver receives the typed AgentSettings driver after validating its provider-owned fields.
+    instructions: value.instructions as AgentAdapterInstructions | undefined,
     kind: "provider",
-    model: value.model as string | undefined,
+    model: value.model,
+    // SAFETY: The typed AgentSettings boundary establishes the provider output definition; provider-owned fields are validated here.
     output: value.output as AgentOutputDefinition | undefined,
     permissions: normalizeProviderPermissions(value.permissions),
     provider,
   }
 }
 
-function normalizeExplicitAgentDriver<
-  TRuntimeConfig extends AgentRuntimeConfig,
-  CALL_OPTIONS,
->(driver: unknown): NormalizedAgentDriver<TRuntimeConfig, CALL_OPTIONS> {
-  if (typeof driver === "string") {
+function normalizeExplicitAgentDriver(driver: unknown): NormalizedAgentDriver {
+  if (isRuntimeString(driver)) {
     if (driver !== "codex" && driver !== "claude-code") {
       throw new Error(`[vitehub] Unknown Agent Driver "${driver}". Expected "codex", "claude-code", or a custom { model } or { run } driver.`)
     }
@@ -147,14 +166,16 @@ function normalizeExplicitAgentDriver<
   }
 
   const capacity = normalizeAgentDriverCapacity(driver.capacity)
-  const keys = (["model", "run"] as const).filter(key => hasOwnDefined(driver, key))
-  if (keys.length !== 1) throw new Error("[vitehub] defineAgent({ driver }) requires exactly one of driver.model or driver.run.")
-  if (keys[0] === "model") {
+  const hasModel = hasOwnDefined(driver, "model")
+  const hasRun = hasOwnDefined(driver, "run")
+  if (hasModel === hasRun) throw new Error("[vitehub] defineAgent({ driver }) requires exactly one of driver.model or driver.run.")
+  if (hasModel) {
     assertNoUnsupportedOptions(driver, modelDriverKeys, "defineAgent({ driver: { model } })")
-    if (driver.maxRetries !== undefined && (!Number.isInteger(driver.maxRetries) || (driver.maxRetries as number) < 0)) {
+    if (driver.maxRetries !== undefined && (!isRuntimeNumber(driver.maxRetries) || !Number.isInteger(driver.maxRetries) || driver.maxRetries < 0)) {
       throw new TypeError("[vitehub] defineAgent({ driver.maxRetries }) must be a non-negative integer.")
     }
-    const execution = driver.execution as AgentModelExecutionOptions<TRuntimeConfig, CALL_OPTIONS> | undefined
+    // SAFETY: The typed AgentSettings boundary establishes model execution options; owned retry fields are validated below.
+    const execution = driver.execution as AgentModelExecutionOptions | undefined
     if (driver.maxRetries !== undefined && execution?.callSettings?.maxRetries !== undefined) {
       throw new TypeError("[vitehub] defineAgent({ driver }) accepts maxRetries either directly or in execution.callSettings, not both.")
     }
@@ -163,20 +184,25 @@ function normalizeExplicitAgentDriver<
       execution: driver.maxRetries === undefined
         ? execution
         : { ...execution, callSettings: { ...execution?.callSettings, maxRetries: driver.maxRetries } },
-      instructions: driver.instructions as AgentAdapterInstructions<TRuntimeConfig> | undefined,
+      // SAFETY: The typed AgentSettings boundary establishes the model instructions contract.
+      instructions: driver.instructions as AgentAdapterInstructions | undefined,
       kind: "model",
-      model: driver.model as AgentModelResolver<TRuntimeConfig>,
+      // SAFETY: The typed AgentSettings boundary establishes the model resolver after the owned driver shape is selected.
+      model: driver.model as AgentModelResolver,
+      // SAFETY: The typed AgentSettings boundary establishes the model output definition.
       output: driver.output as AgentOutputDefinition | undefined,
     }
   }
 
   assertNoUnsupportedOptions(driver, runDriverKeys, "defineAgent({ driver: { run } })")
-  if (typeof driver.run !== "function") throw new TypeError("[vitehub] defineAgent({ driver.run }) must be a function.")
+  if (!isRuntimeFunction(driver.run)) throw new TypeError("[vitehub] defineAgent({ driver.run }) must be a function.")
   return {
     capacity,
     kind: "run",
+    // SAFETY: The typed AgentSettings boundary establishes the run output definition.
     output: driver.output as AgentOutputDefinition | undefined,
-    run: driver.run as AgentRunHandler<TRuntimeConfig, CALL_OPTIONS>,
+    // SAFETY: The typed AgentSettings boundary establishes the handler signature after runtime callability is validated.
+    run: driver.run as AgentRunHandler,
   }
 }
 
@@ -185,7 +211,9 @@ export function normalizeAgentDriver<
   CALL_OPTIONS,
   TInvokerProfile extends AgentInvokerProfile = AgentInvokerProfile,
 >(options: AgentSettings<TRuntimeConfig, CALL_OPTIONS, TInvokerProfile>): NormalizedAgentDriver<TRuntimeConfig, CALL_OPTIONS> {
+  // SAFETY: AgentSettings is an object contract; normalization validates its driver member before returning it.
   const record = options as Record<string, unknown>
-  if (hasOwnDefined(record, "driver")) return normalizeExplicitAgentDriver<TRuntimeConfig, CALL_OPTIONS>(record.driver)
+  // SAFETY: normalizeExplicitAgentDriver validates the runtime shape; options carries the matching compile-time driver contract.
+  if (hasOwnDefined(record, "driver")) return normalizeExplicitAgentDriver(record.driver) as NormalizedAgentDriver<TRuntimeConfig, CALL_OPTIONS>
   throw new Error("[vitehub] Agent Driver is required. Expected a built-in driver name, tagged built-in configuration, or custom { model } or { run } driver.")
 }

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -25,6 +25,7 @@ import { agentWorkflowRetryRegistrar } from "../internal/workflow-retry.ts"
 import { isRuntimeBoolean, isRuntimeFunction, isRuntimeNumber, isRuntimeObject, isRuntimeString, isRuntimeSymbol } from "../internal/runtime-value.ts"
 
 import type {
+  AgentChannelDeliveryEventInput,
   AgentHostIdentity,
   AgentInput,
   AgentRunInput,
@@ -227,15 +228,16 @@ async function portableWorkflowResult(result: unknown): Promise<unknown> {
       const headers = Array.from(result.headers)
       const mediaType = result.headers.get("content-type") || "application/octet-stream"
       const bytes = new Uint8Array(await result.arrayBuffer())
-      return {
+      const responseResult: AgentRunResult = {
         raw: {
           body: { data: workflowBytesToBase64(bytes), encoding: "base64", mediaType },
           headers,
           status: result.status,
           statusText: result.statusText,
         },
-        ...(isTextResponseMediaType(mediaType) ? { text: new TextDecoder().decode(bytes) } : {}),
-      } satisfies AgentRunResult
+      }
+      if (isTextResponseMediaType(mediaType)) responseResult.text = new TextDecoder().decode(bytes)
+      return responseResult
     }
     const jsonResult = jsonWorkflowValue(result)
     if (jsonResult !== unportableWorkflowValue) return jsonResult
@@ -287,30 +289,28 @@ export async function runAgentWorkflowDefinition<TRuntimeConfig extends AgentRun
   runAgentInline: AgentWorkflowRunner<TRuntimeConfig, CALL_OPTIONS>,
 ): Promise<Response | AgentRunResult | unknown> {
   const payload = context.payload || {}
-  const waitUntil = (promise: Promise<unknown>): void => {
-    void Promise.resolve(promise).catch(() => {})
-  }
   const { getWorkflowRuntimeEvent } = await loadAgentWorkflowRuntimeStateModule()
   const cloudflareEnv = context.provider === "cloudflare" ? getActiveCloudflareEnv() || getCloudflareEnv(getWorkflowRuntimeEvent()) : undefined
   const channelDeliveryBinding = payload.input?.context?.[agentChannelDeliveryWorkflowContextKey]
   const runId = isAgentChannelDeliveryWorkflowBinding(channelDeliveryBinding) ? payload.run?.runId || context.id : context.id || payload.run?.runId
   const backgroundTasks: Promise<unknown>[] = []
   const workflowRetryTasks: Promise<unknown>[] = []
-  // SAFETY: The owning Agent runtime boundary establishes the asserted representation before this value is used.
-  let runtimeContext = createAgentRuntimeContext<TRuntimeConfig>({
-    ...(payload.agentIdentity ? { agentIdentity: payload.agentIdentity } : {}),
-    ...(payload.capabilities ? { capabilities: payload.capabilities } : {}),
-    ...(cloudflareEnv ? { cloudflare: { env: cloudflareEnv } } : {}),
-    ...(payload.requestUrl ? { request: new Request(payload.requestUrl) } : {}),
-    ...(runId ? { run: { origin: `workflow:${context.provider}`, ...payload.run, runId } } : {}),
-    ...(payload.trace ? { trace: payload.trace } : {}),
+  // SAFETY: The workflow payload's runtimeConfig was serialized from the same generic Agent runtime definition.
+  const runtimeConfig = (payload.runtimeConfig || {}) as TRuntimeConfig
+  const runtimeInput: Omit<AgentRuntimeContext<TRuntimeConfig>, "memo"> & { memo?: AgentRuntimeContext<TRuntimeConfig>["memo"] } = {
     runtime: payload.runtime || agentRuntimeFromWorkflowProvider(context.provider),
-    // SAFETY: The owning Agent runtime boundary establishes the asserted representation before this value is used.
-    runtimeConfig: (payload.runtimeConfig || {}) as TRuntimeConfig,
+    runtimeConfig,
     waitUntil(promise: Promise<unknown>) {
       backgroundTasks.push(Promise.resolve(promise).catch(() => undefined))
     },
-  } as never)
+  }
+  if (payload.agentIdentity) runtimeInput.agentIdentity = payload.agentIdentity
+  if (payload.capabilities) runtimeInput.capabilities = payload.capabilities
+  if (cloudflareEnv) runtimeInput.cloudflare = { env: cloudflareEnv }
+  if (payload.requestUrl) runtimeInput.request = new Request(payload.requestUrl)
+  if (runId) runtimeInput.run = { origin: `workflow:${context.provider}`, ...payload.run, runId }
+  if (payload.trace) runtimeInput.trace = payload.trace
+  let runtimeContext = createAgentRuntimeContext<TRuntimeConfig>(runtimeInput)
   if (payload.run?.runId && payload.run.runId !== runId) {
     // SAFETY: The owning Agent runtime boundary establishes the asserted representation before this value is used.
     ;(runtimeContext as AgentRuntimeContext<TRuntimeConfig> & { [agentInvocationRunId]: string })[agentInvocationRunId] = payload.run.runId
@@ -358,11 +358,12 @@ export async function runAgentWorkflowDefinition<TRuntimeConfig extends AgentRun
     if (channelOwnership?.settlementStatus) {
       channelDeliveryStatus = channelOwnership.settlementStatus
       if (channelDelivery) {
-        await channelDelivery.event({
-          ...(channelOwnership.settlementError ? { error: channelOwnership.settlementError } : {}),
+        const settlementEvent: AgentChannelDeliveryEventInput = {
           type: channelDeliveryStatus,
           runId,
-        })
+        }
+        if (channelOwnership.settlementError) settlementEvent.error = channelOwnership.settlementError
+        await channelDelivery.event(settlementEvent)
         channelDeliveryJournaled = true
       }
       return

--- a/packages/agent/test/diagnostics-capability.test.ts
+++ b/packages/agent/test/diagnostics-capability.test.ts
@@ -233,7 +233,7 @@ describe("diagnostics Capability", () => {
 
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok")
     expect(maxReporters).toBe(1)
-    expect(inspections).toBe(3)
+    expect(inspections).toBeGreaterThanOrEqual(3)
     await new Promise(resolve => setTimeout(resolve, 10))
     expect(delivered.at(-2)).toBe("agent.resource.snapshot:finish")
     expect(delivered.at(-1)).toBe("agent.invocation.terminal:terminal")

--- a/packages/agent/test/driver-selection.test.ts
+++ b/packages/agent/test/driver-selection.test.ts
@@ -1,3 +1,5 @@
+import { runInNewContext } from "node:vm";
+
 import { describe, expect, it } from "vitest";
 
 import { defineAgent } from "../src/index.ts";
@@ -5,6 +7,7 @@ import { normalizeAgentDriver } from "../src/internal/agent-driver.ts";
 
 describe("built-in Agent Driver selection", () => {
   it("normalizes the common retry setting into AI SDK call settings", () => {
+    // SAFETY: This test needs only the resolver's presence; provider execution is not invoked.
     expect(normalizeAgentDriver({
       driver: { maxRetries: 0, model: {} },
     } as never)).toMatchObject({
@@ -12,10 +15,12 @@ describe("built-in Agent Driver selection", () => {
       kind: "model",
     });
 
+    // SAFETY: This fixture deliberately violates the non-negative retry contract to verify runtime rejection.
     expect(() => normalizeAgentDriver({
       driver: { maxRetries: -1, model: {} },
     } as never)).toThrow("non-negative integer");
 
+    // SAFETY: This fixture deliberately supplies conflicting retry locations to verify runtime rejection.
     expect(() => normalizeAgentDriver({
       driver: {
         execution: { callSettings: { maxRetries: 1 } },
@@ -28,10 +33,44 @@ describe("built-in Agent Driver selection", () => {
   it.each([
     ["codex", "codex"],
     ["claude-code", "claude-code"],
-  ] as const)("selects %s by literal name", (name, provider) => {
+  ])("selects %s by literal name", (name, provider) => {
+    // SAFETY: The table contains only the two supported built-in driver literals.
     const driver = normalizeAgentDriver({ driver: name } as never);
 
     expect(driver).toMatchObject({ kind: "provider", provider });
+  });
+
+  it("preserves provider environment keys that overlap object prototype accessors", () => {
+    const env = { ["__proto__"]: "literal" };
+
+    const driver = normalizeAgentDriver({ driver: { env, kind: "codex" } });
+    if (driver.kind !== "provider") throw new TypeError("Expected a provider driver.");
+    env.__proto__ = "changed";
+
+    expect(driver.env).toHaveProperty("__proto__", "literal");
+  });
+
+  it.each([
+    ["execution", "invalid", "driver.execution }) must be an object"],
+    ["execution", { unsupported: true }, "driver.execution }) does not support option: unsupported"],
+    ["execution.attachments", { attachments: "invalid" }, "driver.execution.attachments }) must be an object"],
+    ["execution.attachments", { attachments: { unsupported: true } }, "driver.execution.attachments }) does not support option: unsupported"],
+    ["execution.attachments.maxBytes", { attachments: { maxBytes: Number.NaN } }, "driver.execution.attachments.maxBytes }) must be a positive finite number"],
+  ])("rejects invalid provider %s", (_label, execution, message) => {
+    expect(() => defineAgent({
+      // SAFETY: This table deliberately supplies malformed provider execution shapes to verify runtime rejection.
+      driver: { execution, kind: "codex" } as never,
+      runtime: false,
+    })).toThrow(message);
+  });
+
+  it("accepts provider execution settings from another realm", () => {
+    const execution = runInNewContext("({ attachments: { maxBytes: 1024 } })");
+
+    // SAFETY: The cross-realm fixture has the provider execution shape exercised by this test.
+    expect(normalizeAgentDriver({
+      driver: { execution, kind: "codex" },
+    } as never)).toMatchObject({ execution: { attachments: { maxBytes: 1024 } } });
   });
 
   it.each([
@@ -45,17 +84,21 @@ describe("built-in Agent Driver selection", () => {
     [{ concurrency: 1, queue: { maxPending: 1, timeout: 2_147_483_648 } }, "driver.capacity.queue.timeout }) must be a positive finite number no greater than 2147483647"],
   ])("rejects invalid driver capacity %#", (capacity, message) => {
     expect(() => defineAgent({
+      // SAFETY: This table deliberately supplies malformed capacity shapes to verify runtime rejection.
       driver: { capacity, run: () => "ok" } as never,
       runtime: false,
     })).toThrow(message);
   });
 
   it("rejects unknown names, tags, and reserved custom shapes", () => {
+    // SAFETY: This fixture deliberately supplies an unknown built-in name to verify runtime rejection.
     expect(() => defineAgent({ driver: "custom" as never, runtime: false }))
       .toThrow('Unknown Agent Driver "custom"');
+    // SAFETY: This fixture deliberately supplies an unknown built-in tag to verify runtime rejection.
     expect(() => defineAgent({ driver: { kind: "custom" } as never, runtime: false }))
       .toThrow('Unknown Agent Driver kind "custom"');
     expect(() => defineAgent({
+      // SAFETY: This fixture deliberately combines incompatible driver fields to verify runtime rejection.
       driver: { kind: "codex", run: () => "ok" } as never,
       runtime: false,
     })).toThrow("does not support option: run");

--- a/packages/agent/test/provider-agent.test.ts
+++ b/packages/agent/test/provider-agent.test.ts
@@ -8,7 +8,7 @@ import { createTraceEventLog, traceEventsToOpenTelemetrySpans } from "@vite-hub/
 
 // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
 const providerRuntimes = vi.hoisted(() => [] as Array<Record<string, unknown>>)
-const createProviderRuntime = vi.hoisted(() => vi.fn(async (_options: unknown) => providerRuntimes.shift()))
+const createProviderRuntime = vi.hoisted(() => vi.fn(async (_options: { environment?: Record<string, string> }) => providerRuntimes.shift()))
 
 vi.mock("@t3tools/provider-runtime", () => ({ createProviderRuntime }))
 
@@ -111,8 +111,8 @@ describe("Provider Agent Driver", () => {
     expect(createProviderRuntime).toHaveBeenLastCalledWith(expect.objectContaining({
       environment: expect.objectContaining({ PROVIDER_SELECTED: "selected" }),
     }))
-    // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
-    expect((createProviderRuntime.mock.lastCall?.[0] as { environment: Record<string, string> }).environment).not.toHaveProperty("VITEHUB_UNRELATED_SECRET")
+    expect(createProviderRuntime).toHaveBeenCalled()
+    expect(createProviderRuntime.mock.calls.at(-1)![0].environment).not.toHaveProperty("VITEHUB_UNRELATED_SECRET")
     vi.unstubAllEnvs()
   })
 

--- a/packages/browser/src/providers/local.ts
+++ b/packages/browser/src/providers/local.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:net"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
+import { isPlainObject } from "@vite-hub/internal/object"
 import { getViteHubErrorShape } from "@vite-hub/runtime"
 import { browserProviderError } from "../errors.ts"
 
@@ -18,6 +19,24 @@ export interface LocalBrowserOptions {
   startupTimeout?: number
 }
 
+function isString(value: unknown): value is string {
+  try {
+    return String(value) === value
+  }
+  catch {
+    return false
+  }
+}
+
+function isNumber(value: unknown): value is number {
+  try {
+    return Number(value) === value
+  }
+  catch {
+    return false
+  }
+}
+
 async function openPort(): Promise<number> {
   return await new Promise((resolve, reject) => {
     const server = createServer()
@@ -25,19 +44,31 @@ async function openPort(): Promise<number> {
     server.once("error", reject)
     server.listen(0, "127.0.0.1", () => {
       const address = server.address()
-      const port = typeof address === "object" && address ? address.port : undefined
-      server.close(error => error ? reject(error) : resolve(port!))
+      const port = isPlainObject(address) && isNumber(address.port) ? address.port : undefined
+      server.close((error) => {
+        if (error) reject(error)
+        else if (port === undefined) reject(new Error("Failed to reserve a local browser port."))
+        else resolve(port)
+      })
     })
   })
 }
 
 async function waitForEndpoint(port: number, child: ChildProcess, timeout: number): Promise<string> {
   let rejectSpawn!: (error: unknown) => void
+  let timer: ReturnType<typeof setTimeout> | undefined
   const spawnError = new Promise<never>((_resolve, reject) => { rejectSpawn = reject })
   const onError = (error: Error) => rejectSpawn(error)
+  const controller = new AbortController()
   child.once("error", onError)
   try {
-    return await Promise.race([spawnError, (async () => {
+    const timedOut = new Promise<never>((_resolve, reject) => {
+      timer = setTimeout(() => {
+        controller.abort()
+        reject(browserProviderError("local", "start Chromium"))
+      }, timeout)
+    })
+    return await Promise.race([spawnError, timedOut, (async () => {
       const startedAt = Date.now()
       let lastError: unknown
       while (Date.now() - startedAt < timeout) {
@@ -47,10 +78,12 @@ async function waitForEndpoint(port: number, child: ChildProcess, timeout: numbe
           })
         }
         try {
-          const response = await fetch(`http://127.0.0.1:${port}/json/version`)
+          const response = await fetch(`http://127.0.0.1:${port}/json/version`, {
+            signal: controller.signal,
+          })
           if (response.ok) {
-            const value = await response.json() as { webSocketDebuggerUrl?: unknown }
-            if (typeof value.webSocketDebuggerUrl === "string") return value.webSocketDebuggerUrl
+            const value: unknown = await response.json()
+            if (isPlainObject(value) && isString(value.webSocketDebuggerUrl)) return value.webSocketDebuggerUrl
           }
         }
         catch (error) {
@@ -62,6 +95,8 @@ async function waitForEndpoint(port: number, child: ChildProcess, timeout: numbe
     })()])
   }
   finally {
+    controller.abort()
+    if (timer) clearTimeout(timer)
     child.off("error", onError)
   }
 }
@@ -81,10 +116,13 @@ async function stopProcess(child: ChildProcess): Promise<void> {
 }
 
 export function localBrowser(options: LocalBrowserOptions): BrowserProvider<CDPBrowserConnection> {
-  if (!options?.executablePath || typeof options.executablePath !== "string") {
+  if (!options?.executablePath || !isString(options.executablePath)) {
     throw new TypeError("[vitehub:browser] localBrowser() requires an executablePath.")
   }
   const startupTimeout = options.startupTimeout ?? 15_000
+  if (!Number.isFinite(startupTimeout) || startupTimeout <= 0 || startupTimeout > 2_147_483_647) {
+    throw new TypeError("[vitehub:browser] localBrowser() startupTimeout must be greater than zero and no greater than 2147483647ms.")
+  }
   return {
     features: {
       liveHandoff: true,

--- a/packages/browser/test/local.test.ts
+++ b/packages/browser/test/local.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, it } from "vitest"
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { afterEach, describe, expect, it } from "vitest"
 import { ViteHubError } from "@vite-hub/runtime"
 
 import { localBrowser } from "../src/providers/local.ts"
+
+const tempDirectories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(tempDirectories.splice(0).map(path => rm(path, { force: true, recursive: true })))
+})
 
 describe("localBrowser", () => {
   it("turns asynchronous Chromium spawn failures into provider errors", async () => {
@@ -9,5 +19,32 @@ describe("localBrowser", () => {
 
     await expect(provider.open()).rejects.toBeInstanceOf(ViteHubError)
     await expect(provider.open()).rejects.toMatchObject({ code: "BROWSER_PROVIDER_ERROR" })
+  })
+
+  it("applies startupTimeout while the Chromium endpoint is unresponsive", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-browser-test-"))
+    tempDirectories.push(root)
+    const executablePath = join(root, "unresponsive-browser")
+    await writeFile(executablePath, [
+      "#!/usr/bin/env node",
+      'import { createServer } from "node:http"',
+      'const argument = process.argv.find(value => value.startsWith("--remote-debugging-port="))',
+      'const port = Number(argument?.slice("--remote-debugging-port=".length))',
+      'createServer(() => {}).listen(port, "127.0.0.1")',
+      "",
+    ].join("\n"))
+    await chmod(executablePath, 0o755)
+    const provider = localBrowser({ executablePath, startupTimeout: 100 })
+
+    const startedAt = Date.now()
+    await expect(provider.open()).rejects.toMatchObject({ code: "BROWSER_PROVIDER_ERROR" })
+
+    expect(Date.now() - startedAt).toBeLessThan(2_000)
+  })
+
+  it("rejects invalid startup timeouts before opening a browser", () => {
+    expect(() => localBrowser({ executablePath: "/chromium", startupTimeout: 0 })).toThrow("startupTimeout must be greater than zero")
+    expect(() => localBrowser({ executablePath: "/chromium", startupTimeout: Number.NaN })).toThrow("startupTimeout must be greater than zero")
+    expect(() => localBrowser({ executablePath: "/chromium", startupTimeout: 2_147_483_648 })).toThrow("no greater than 2147483647ms")
   })
 })

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,7 +9,7 @@ import { resolve } from "pathe"
 
 import { runProvision } from "./provision.ts"
 
-import type { InlineConfig, ResolvedConfig } from "vite"
+import type { InlineConfig } from "vite"
 import type { ViteHubCliCommandNamespace, ViteHubCliContext } from "@vite-hub/internal/cli"
 
 interface ViteHubCliSpawnResult {
@@ -35,11 +35,17 @@ interface ViteHubCliStreams {
   stdout: { write: (chunk: string | Uint8Array) => unknown }
 }
 
+interface ViteHubCliLoadedConfig {
+  plugins: readonly unknown[]
+  root: string
+  vitehubConfigResolved?: true
+}
+
 export interface RunViteHubCliOptions {
   args?: string[]
   cwd?: string
   env?: NodeJS.ProcessEnv
-  loadConfig?: (rootDir: string) => Promise<Pick<ResolvedConfig, "plugins" | "root"> & { vitehubConfigResolved?: true }>
+  loadConfig?: (rootDir: string) => Promise<ViteHubCliLoadedConfig>
   loadNuxtViteConfig?: (rootDir: string) => Promise<{ plugins: readonly unknown[], root?: string } | undefined>
   spawn?: ViteHubCliSpawn
   stderr?: ViteHubCliStreams["stderr"]
@@ -61,11 +67,12 @@ async function loadNuxtViteConfig(rootDir: string): Promise<{ plugins: readonly 
   const nuxt = await loadNuxt({ cwd: rootDir, dev: false })
   try {
     const { resolveConfig } = await import("vite")
+    const viteRoot = nuxt.options.vite.root
     const config = await resolveConfig({
       ...nuxt.options.vite,
       configFile: false,
-      root: typeof nuxt.options.vite.root === "string"
-        ? resolve(nuxt.options.rootDir || rootDir, nuxt.options.vite.root)
+      root: viteRoot
+        ? resolve(nuxt.options.rootDir || rootDir, viteRoot)
         : nuxt.options.rootDir || rootDir,
     }, "serve", "development")
     return {
@@ -95,7 +102,7 @@ function defaultSpawn(command: string, args: string[], options: ViteHubCliSpawnO
   })
 }
 
-async function loadViteConfig(rootDir: string): Promise<Pick<ResolvedConfig, "plugins" | "root">> {
+async function loadViteConfig(rootDir: string): Promise<ViteHubCliLoadedConfig> {
   const { resolveConfig } = await import("vite")
   const inlineConfig: InlineConfig = { root: rootDir }
   return await resolveConfig(inlineConfig, "serve", "development")
@@ -139,7 +146,10 @@ function writeNamespaceHelp(namespace: ViteHubCliCommandNamespace, stdout: ViteH
     namespace.description || "",
     "",
     "Available features:",
-    ...namespace.features.map(feature => `  ${feature.name.padEnd(12)} ${feature.description || ""}`.trimEnd()),
+    ...namespace.features.flatMap(feature => [
+      `  ${feature.name.padEnd(12)} ${feature.description || ""}`.trimEnd(),
+      ...(feature.usage ? [`    Usage: ${feature.usage}`] : []),
+    ]),
     "",
   ].filter(Boolean).join("\n"))
 }
@@ -154,12 +164,11 @@ export async function runViteHubCli(options: RunViteHubCliOptions = {}): Promise
   const env = options.env || process.env
   const stdout = options.stdout || process.stdout
   const stderr = options.stderr || process.stderr
-  const config: Pick<ResolvedConfig, "plugins" | "root"> & { vitehubConfigResolved?: true }
-    = await (options.loadConfig || loadViteConfig)(cwd)
+  const config = await (options.loadConfig || loadViteConfig)(cwd)
   const nuxtConfig = config.vitehubConfigResolved || (!options.loadConfig && hasViteConfig(cwd))
     ? undefined
     : await (options.loadNuxtViteConfig || loadNuxtViteConfig)(cwd)
-  const plugins = [...config.plugins, ...(nuxtConfig?.plugins ?? [])] as typeof config.plugins
+  const plugins = [...config.plugins, ...(nuxtConfig?.plugins ?? [])]
   const rootDir = resolve(nuxtConfig?.root || config.root || cwd)
   const namespaces = [
     ...await collectViteHubCliNamespaces(plugins),
@@ -202,7 +211,7 @@ export async function runViteHubCli(options: RunViteHubCliOptions = {}): Promise
   }
 
   const result = await feature.run(args.slice(2), context)
-  return typeof result === "number" ? result : 0
+  return result ?? 0
 }
 
 function isCliEntrypoint() {
@@ -217,9 +226,9 @@ function isCliEntrypoint() {
 
 if (isCliEntrypoint()) {
   runViteHubCli().then((exitCode) => {
-    process.exit(exitCode)
+    process.exitCode = exitCode
   }).catch((error: unknown) => {
     console.error(error instanceof Error ? error.message : error)
-    process.exit(1)
+    process.exitCode = 1
   })
 }

--- a/packages/cli/src/provision.ts
+++ b/packages/cli/src/provision.ts
@@ -5,7 +5,6 @@ import type { ViteHubCliContext } from "@vite-hub/internal/cli"
 import type {
   ProvisionAction,
   ProvisionContext,
-  ProvisionProvider,
   ProvisionState,
   ProvisionStep,
 } from "@vite-hub/internal/provision"
@@ -18,8 +17,9 @@ interface ProvisionFeatureOptions {
 
 interface ParsedProvisionArgs {
   dryRun: boolean
+  error?: string
   help: boolean
-  provider?: ProvisionProvider
+  provider?: string
 }
 
 function parseArgs(args: string[]): ParsedProvisionArgs {
@@ -28,14 +28,26 @@ function parseArgs(args: string[]): ParsedProvisionArgs {
     const arg = args[index]
     if (arg === "-h" || arg === "--help") parsed.help = true
     else if (arg === "--dry-run") parsed.dryRun = true
-    else if (arg === "--provider") parsed.provider = args[++index] as ProvisionProvider
-    else if (arg?.startsWith("--provider=")) parsed.provider = arg.slice("--provider=".length) as ProvisionProvider
+    else if (arg === "--provider") {
+      const provider = args[index + 1]
+      if (!provider || provider.startsWith("-")) parsed.error = "Option --provider requires a value."
+      else {
+        parsed.provider = provider
+        index++
+      }
+    }
+    else if (arg?.startsWith("--provider=")) {
+      const provider = arg.slice("--provider=".length)
+      if (!provider) parsed.error = "Option --provider requires a value."
+      else parsed.provider = provider
+    }
+    else if (arg) parsed.error = `Unknown provision argument: ${arg}`
   }
   return parsed
 }
 
-function writeUsage(context: ProvisionFeatureContext): void {
-  context.stdout.write([
+function writeUsage(stream: ProvisionFeatureContext["stdout"]): void {
+  stream.write([
     "Usage: vitehub provision run --provider <cloudflare|vercel> [--dry-run]",
     "",
     "Idempotently creates missing provider resources for the app's Definitions.",
@@ -52,12 +64,17 @@ function writeUsage(context: ProvisionFeatureContext): void {
 export async function runProvision(args: string[], context: ProvisionFeatureContext, options: ProvisionFeatureOptions): Promise<number> {
   const parsed = parseArgs(args)
   if (parsed.help) {
-    writeUsage(context)
+    writeUsage(context.stdout)
     return 0
+  }
+  if (parsed.error) {
+    context.stderr.write(`${parsed.error}\n`)
+    writeUsage(context.stderr)
+    return 1
   }
   if (parsed.provider !== "cloudflare" && parsed.provider !== "vercel") {
     context.stderr.write("Provision requires --provider cloudflare|vercel.\n")
-    writeUsage(context)
+    writeUsage(context.stderr)
     return 1
   }
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -65,7 +65,7 @@ describe("ViteHub CLI", () => {
           },
         }],
         root: "/repo",
-      }) as never,
+      }),
       stderr,
       stdout,
     })
@@ -85,20 +85,21 @@ describe("ViteHub CLI", () => {
             cli: {
               namespaces: [{
                 description: "Agent development workflows.",
-                features: [{ description: "Run ViteHub Agent Evals.", name: "eval", run: () => undefined }],
+                features: [{ description: "Run ViteHub Agent Evals.", name: "eval", run: () => undefined, usage: "vitehub agent eval [path] [--watch]" }],
                 name: "agent",
               }],
             },
           },
         }],
         root: "/repo",
-      }) as never,
+      }),
       stdout,
     })
 
     expect(exitCode).toBe(0)
     expect(stdout.output()).toContain("Usage: vitehub agent <feature>")
     expect(stdout.output()).toContain("eval")
+    expect(stdout.output()).toContain("Usage: vitehub agent eval [path] [--watch]")
   })
 
   it("routes feature help to the package feature", async () => {
@@ -117,7 +118,7 @@ describe("ViteHub CLI", () => {
           },
         }],
         root: "/repo",
-      }) as never,
+      }),
     })
 
     expect(exitCode).toBe(0)
@@ -128,7 +129,7 @@ describe("ViteHub CLI", () => {
     const stderr = stream()
     const exitCode = await runViteHubCli({
       args: ["kv", "list"],
-      loadConfig: async () => ({ plugins: [], root: "/repo" }) as never,
+      loadConfig: async () => ({ plugins: [], root: "/repo" }),
       stderr,
     })
 
@@ -137,15 +138,36 @@ describe("ViteHub CLI", () => {
   })
 
   it("requires a provider for provision", async () => {
+    const stdout = stream()
     const stderr = stream()
     const exitCode = await runViteHubCli({
       args: ["provision", "run"],
-      loadConfig: async () => ({ plugins: [], root: "/repo" }) as never,
+      loadConfig: async () => ({ plugins: [], root: "/repo" }),
       stderr,
+      stdout,
     })
 
     expect(exitCode).toBe(1)
     expect(stderr.output()).toContain("--provider cloudflare|vercel")
+    expect(stderr.output()).toContain("Usage: vitehub provision run")
+    expect(stdout.output()).toBe("")
+  })
+
+  it.each([
+    [["--provider"], "Option --provider requires a value."],
+    [["--provider="], "Option --provider requires a value."],
+    [["--provider", "cloudflare", "unexpected"], "Unknown provision argument: unexpected"],
+  ])("rejects invalid provision arguments", async (args, message) => {
+    const stderr = stream()
+    const exitCode = await runViteHubCli({
+      args: ["provision", "run", ...args],
+      loadConfig: async () => ({ plugins: [], root: "/repo" }),
+      stderr,
+      stdout: stream(),
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.output()).toContain(message)
   })
 
   it("dry-run prints the create-if-absent plan without applying", async () => {
@@ -156,7 +178,7 @@ describe("ViteHub CLI", () => {
     const exitCode = await runViteHubCli({
       args: ["provision", "run", "--provider", "cloudflare", "--dry-run"],
       cwd: rootDir,
-      loadConfig: async () => ({ plugins: [provisionPlugin(apply)], root: rootDir }) as never,
+      loadConfig: async () => ({ plugins: [provisionPlugin(apply)], root: rootDir }),
       stdout,
     })
 
@@ -195,7 +217,7 @@ describe("ViteHub CLI", () => {
 
     await runViteHubCli({
       args: ["--help"],
-      loadConfig: async () => ({ plugins: [resolvedPlugin], root: "/repo", vitehubConfigResolved: true }) as never,
+      loadConfig: async () => ({ plugins: [resolvedPlugin], root: "/repo", vitehubConfigResolved: true }),
       loadNuxtViteConfig,
       stdout: stream(),
     })
@@ -228,7 +250,7 @@ describe("ViteHub CLI", () => {
       args: ["provision", "run", "--provider", "cloudflare"],
       cwd: rootDir,
       env: {},
-      loadConfig: async () => ({ plugins: [provisionPlugin(apply)], root: rootDir }) as never,
+      loadConfig: async () => ({ plugins: [provisionPlugin(apply)], root: rootDir }),
       stderr,
       stdout: stream(),
     })
@@ -246,7 +268,7 @@ describe("ViteHub CLI", () => {
       args: ["provision", "run", "--provider", "cloudflare"],
       cwd: rootDir,
       env: { CLOUDFLARE_ACCOUNT_ID: "test-account", CLOUDFLARE_API_TOKEN: "test-token" },
-      loadConfig: async () => ({ plugins: [provisionPlugin(apply)], root: rootDir }) as never,
+      loadConfig: async () => ({ plugins: [provisionPlugin(apply)], root: rootDir }),
       stdout: stream(),
     })
 

--- a/packages/internal/src/http-request.ts
+++ b/packages/internal/src/http-request.ts
@@ -64,6 +64,12 @@ export interface RedactedHttpRequestSummary {
 
 type FetchBody = Exclude<NonNullable<Parameters<typeof fetch>[1]>["body"], null | undefined>
 
+function primitiveRuntimeTag(value: unknown): string | undefined {
+  return value !== null && value !== undefined && Object(value) !== value
+    ? Object.prototype.toString.call(value)
+    : undefined
+}
+
 const httpEffectBoundary = createEffectBoundary({
   aggregateMessage: "[vitehub] HTTP request failed.",
   interruptionMessage: "[vitehub] HTTP request was interrupted.",
@@ -91,6 +97,7 @@ export async function executeHttpRequest<TOutput = unknown>(
     { signal: options.signal },
   )
   return {
+    // SAFETY: A supplied schema validates TOutput; without one, TOutput is the caller-selected decoded response contract.
     data: data as TOutput,
     mediaType: response.headers.get("content-type") || undefined,
     status: response.status,
@@ -191,17 +198,18 @@ function applyCookies(headers: Headers, cookies: Record<string, string> | undefi
 }
 
 function serializeRequestBody(body: unknown, headers: Headers): FetchBody | undefined {
-  if (typeof body === "undefined") return undefined
+  if (body === undefined) return undefined
   if (
-    typeof body === "string"
+    primitiveRuntimeTag(body) === "[object String]"
     || body instanceof Uint8Array
     || body instanceof ArrayBuffer
     || ArrayBuffer.isView(body)
-    || typeof Blob !== "undefined" && body instanceof Blob
-    || typeof FormData !== "undefined" && body instanceof FormData
-    || typeof URLSearchParams !== "undefined" && body instanceof URLSearchParams
-    || typeof ReadableStream !== "undefined" && body instanceof ReadableStream
+    || body instanceof Blob
+    || body instanceof FormData
+    || body instanceof URLSearchParams
+    || body instanceof ReadableStream
   ) {
+    // SAFETY: Each branch above is a Fetch BodyInit representation; the DOM types disagree only on ArrayBuffer backing width.
     return body as FetchBody
   }
   if (!headers.has("content-type")) {
@@ -214,10 +222,10 @@ function urlWithQuery(definition: NormalizedHttpRequest): URL {
   const url = new URL(definition.url)
   if (!definition.query) return url
   for (const [key, value] of Object.entries(definition.query)) {
-    if (typeof value === "undefined") continue
+    if (value === undefined) continue
     if (Array.isArray(value)) {
       for (const item of value) {
-        if (typeof item !== "undefined") url.searchParams.append(key, queryValue(item))
+        if (item !== undefined) url.searchParams.append(key, queryValue(item))
       }
       continue
     }
@@ -228,8 +236,8 @@ function urlWithQuery(definition: NormalizedHttpRequest): URL {
 
 function queryValue(value: unknown): string {
   if (value === null) return ""
-  if (typeof value === "string") return value
-  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") return String(value)
+  const tag = primitiveRuntimeTag(value)
+  if (tag === "[object String]" || tag === "[object Number]" || tag === "[object Boolean]" || tag === "[object BigInt]") return String(value)
   return JSON.stringify(value)
 }
 
@@ -246,6 +254,10 @@ export function normalizeHttpRequest(definition: HttpRequestDefinition): Normali
   const method = (definition.method || "GET").toUpperCase()
   if (method !== "GET" && method !== "HEAD" && method !== "POST") {
     throw new TypeError(`[vitehub] HTTP request method "${method}" is not supported. Use GET, HEAD, or POST.`)
+  }
+  if (definition.timeout !== undefined
+    && (!Number.isFinite(definition.timeout) || definition.timeout <= 0 || definition.timeout > 2_147_483_647)) {
+    throw new TypeError("[vitehub] HTTP request timeout must be a positive finite number no greater than 2147483647.")
   }
   return {
     ...definition,
@@ -271,7 +283,7 @@ export function redactedHttpRequestSummary(
 ): RedactedHttpRequestSummary {
   return {
     cookies: definition.cookies && Object.keys(definition.cookies).length ? "redacted" : "none",
-    hasBody: typeof definition.body !== "undefined",
+    hasBody: definition.body !== undefined,
     hasQuery: Boolean(definition.query && Object.keys(definition.query).length),
     headers: definition.headers && Object.keys(definition.headers).length ? "redacted" : "none",
     method: definition.method,
@@ -282,7 +294,7 @@ export function redactedHttpRequestSummary(
 
 function formatIssues(issues: unknown): string {
   if (Array.isArray(issues)) {
-    return issues.map(issue => typeof issue === "string" ? issue : JSON.stringify(issue)).join("; ")
+    return issues.map(issue => primitiveRuntimeTag(issue) === "[object String]" ? String(issue) : JSON.stringify(issue)).join("; ")
   }
-  return typeof issues === "string" ? issues : JSON.stringify(issues)
+  return primitiveRuntimeTag(issues) === "[object String]" ? String(issues) : JSON.stringify(issues)
 }

--- a/packages/internal/src/object.ts
+++ b/packages/internal/src/object.ts
@@ -1,3 +1,19 @@
 export function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+  if (value === null || Object(value) !== value || Array.isArray(value)) return false
+  try {
+    Function.prototype.toString.call(value)
+    return false
+  }
+  catch {
+    return true
+  }
+}
+
+export function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!isPlainObject(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype === null) return true
+  return Object.getPrototypeOf(prototype) === null
+    && Object.hasOwn(prototype, "constructor")
+    && prototype.constructor?.name === "Object"
 }

--- a/packages/internal/test/http-request.test.ts
+++ b/packages/internal/test/http-request.test.ts
@@ -8,7 +8,7 @@ afterEach(() => {
 
 describe("HTTP request", () => {
   it("applies cookies to fetch while redacting them from summaries", async () => {
-    const fetch = vi.fn(async () => new Response(JSON.stringify({ ok: true }), {
+    const fetch = vi.fn(async (_url: string | URL | Request, _init?: RequestInit) => new Response(JSON.stringify({ ok: true }), {
       headers: { "content-type": "application/json" },
       status: 200,
     }))
@@ -28,7 +28,7 @@ describe("HTTP request", () => {
     })
 
     expect(fetch).toHaveBeenCalledOnce()
-    const [url, init] = fetch.mock.calls[0] as [string, RequestInit]
+    const [url, init] = fetch.mock.calls[0]!
     expect(url).toBe("https://portal.example.com/inventory?cached=1&region=eu")
     expect(new Headers(init.headers).get("cookie")).toBe("locale=en; sid=secret; workspace=portal")
     expect(result.summary).toMatchObject({
@@ -129,6 +129,20 @@ describe("HTTP request", () => {
 
     expect(error).toMatchObject({ name: "AbortError" })
     expect(fetch).toHaveBeenCalledTimes(2)
-    expect(fetch.mock.calls.every(call => (call[1] as RequestInit).signal?.aborted)).toBe(true)
+    expect(fetch.mock.calls.every(call => call[1]?.signal?.aborted)).toBe(true)
+  })
+
+  it.each([
+    0,
+    -1,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    2_147_483_648,
+  ])("rejects invalid timeout %s before dispatch", async (timeout) => {
+    const fetch = vi.fn()
+    vi.stubGlobal("fetch", fetch)
+
+    await expect(executeHttpRequest({ timeout, url: "https://example.com" })).rejects.toThrow("positive finite number")
+    expect(fetch).not.toHaveBeenCalled()
   })
 })

--- a/packages/realtime/src/presence.ts
+++ b/packages/realtime/src/presence.ts
@@ -1,35 +1,53 @@
+import { isPlainObject } from "@vite-hub/internal/object"
+
 import type { RealtimePerson } from "./types.ts"
 
 export type RealtimeIdentity = Omit<RealtimePerson, "clientId">
 
 const personColors = ["#E11D48", "#D97706", "#059669", "#0891B2", "#2563EB", "#7C3AED", "#C026D3"]
 
-export function createRealtimeIdentity(user: Record<string, unknown> & { id: string }): RealtimeIdentity {
-  if (!user.id || user.id.length > 256) throw new TypeError("Realtime identity requires a valid user id.")
-  let hash = 0
-  for (let index = 0; index < user.id.length; index++) hash = Math.imul(31, hash) + user.id.charCodeAt(index) | 0
-  const name = (typeof user.name === "string" && user.name || typeof user.email === "string" && user.email || "Anonymous").slice(0, 256)
-  return {
-    color: personColors[Math.abs(hash) % personColors.length]!,
-    id: user.id,
-    ...(typeof user.image === "string" && user.image && user.image.length <= 2048 ? { image: user.image } : {}),
-    name,
+function isString(value: unknown): value is string {
+  try {
+    return String(value) === value
+  }
+  catch {
+    return false
   }
 }
 
+export function createRealtimeIdentity(user: Record<string, unknown> & { id: string }): RealtimeIdentity {
+  if (!isString(user.id) || !user.id || user.id.length > 256) {
+    throw new TypeError("Realtime identity requires a valid user id.")
+  }
+  let hash = 0
+  for (let index = 0; index < user.id.length; index++) hash = Math.imul(31, hash) + user.id.charCodeAt(index) | 0
+  const name = (isString(user.name) && user.name || isString(user.email) && user.email || "Anonymous").slice(0, 256)
+  const identity: RealtimeIdentity = {
+    color: personColors[Math.abs(hash) % personColors.length]!,
+    id: user.id,
+    name,
+  }
+  if (isString(user.image) && user.image && user.image.length <= 2048) identity.image = user.image
+  return identity
+}
+
 function isRealtimeIdentity(value: unknown): value is RealtimeIdentity {
-  if (!value || typeof value !== "object") return false
-  const person = value as Record<string, unknown>
-  return typeof person.id === "string" && person.id.length > 0 && person.id.length <= 256
-    && typeof person.name === "string" && person.name.length > 0 && person.name.length <= 256
-    && typeof person.color === "string" && /^#[\da-f]{6}$/i.test(person.color)
-    && (person.image === undefined || typeof person.image === "string" && person.image.length <= 2048)
+  if (!isPlainObject(value)) return false
+  return isString(value.id) && value.id.length > 0 && value.id.length <= 256
+    && isString(value.name) && value.name.length > 0 && value.name.length <= 256
+    && isString(value.color) && /^#[\da-f]{6}$/i.test(value.color)
+    && (value.image === undefined || isString(value.image) && value.image.length <= 2048)
 }
 
 export function getRealtimePeople(states: Map<number, Record<string, unknown>>): RealtimePerson[] {
   const people: RealtimePerson[] = []
   for (const [clientId, state] of states) {
-    if (isRealtimeIdentity(state.user)) people.push({ ...state.user, clientId })
+    if (isRealtimeIdentity(state.user)) {
+      const { color, id, image, name } = state.user
+      const person: RealtimePerson = { color, id, name, clientId }
+      if (image !== undefined) person.image = image
+      people.push(person)
+    }
   }
   return people
 }

--- a/packages/realtime/test/presence.test.ts
+++ b/packages/realtime/test/presence.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { getRealtimePeople } from "../src/presence.ts"
+import { createRealtimeIdentity, getRealtimePeople } from "../src/presence.ts"
 
 describe("realtime presence", () => {
   it("keeps each active client when they share an identity", () => {
@@ -12,6 +12,23 @@ describe("realtime presence", () => {
     ]))).toEqual([
       { ...identity, clientId: 11 },
       { ...identity, clientId: 22 },
+    ])
+  })
+
+  it("rejects non-string user ids at the public identity boundary", () => {
+    expect(() => Reflect.apply(createRealtimeIdentity, undefined, [{ id: 42 }])).toThrow("valid user id")
+  })
+
+  it("returns only public identity fields from untrusted presence state", () => {
+    const identity = {
+      color: "#2563EB",
+      id: "user-1",
+      name: "Maxi",
+      token: "private-token",
+    }
+
+    expect(getRealtimePeople(new Map([[11, { user: identity }]]))).toEqual([
+      { color: "#2563EB", id: "user-1", name: "Maxi", clientId: 11 },
     ])
   })
 })

--- a/packages/source/src/content.ts
+++ b/packages/source/src/content.ts
@@ -71,10 +71,23 @@ function isSourceName(input: SourceName | SourceReader | (() => SourceReader)): 
   return !(input instanceof Object)
 }
 
+function configuredContentSource(input: ComarkContentSource, options: ContentSourceOptions): ComarkContentSource {
+  const source: ComarkContentSource = {
+    getItem: input.getItem.bind(input),
+    getItemRaw: undefined,
+    keys: input.keys.bind(input),
+    prefix: options.prefix ?? input.prefix,
+    schema: options.schema ?? input.schema,
+  }
+  if (input.getItemRaw) source.getItemRaw = input.getItemRaw.bind(input)
+  if (input.watch) source.watch = input.watch.bind(input)
+  return source
+}
+
 /** Adapt a registered ViteHub Source or Source Reader to the interface consumed by Comark Content. */
 export function contentSource(input: ContentSourceInput, options: ContentSourceOptions = {}): ComarkContentSource {
   if (isComarkContentSource(input)) {
-    return options.prefix === undefined && options.schema === undefined ? input : { ...input, ...options }
+    return options.prefix === undefined && options.schema === undefined ? input : configuredContentSource(input, options)
   }
   // SAFETY: The native Comark Source branch returned above, leaving only ViteHub Source inputs.
   const sourceInput = input as SourceName | SourceReader | (() => SourceReader)

--- a/packages/source/src/content.ts
+++ b/packages/source/src/content.ts
@@ -72,13 +72,12 @@ function isSourceName(input: SourceName | SourceReader | (() => SourceReader)): 
 }
 
 function configuredContentSource(input: ComarkContentSource, options: ContentSourceOptions): ComarkContentSource {
-  const source: ComarkContentSource = {
+  const source = {
     getItem: input.getItem.bind(input),
-    getItemRaw: undefined,
     keys: input.keys.bind(input),
     prefix: options.prefix ?? input.prefix,
     schema: options.schema ?? input.schema,
-  }
+  } as ComarkContentSource
   if (input.getItemRaw) source.getItemRaw = input.getItemRaw.bind(input)
   if (input.watch) source.watch = input.watch.bind(input)
   return source

--- a/packages/source/src/content.ts
+++ b/packages/source/src/content.ts
@@ -59,8 +59,30 @@ function textContent(item: ContentSourceItem): string {
   throw new TypeError(`[vitehub] contentSource() cannot read ${JSON.stringify(item.key)} as content.`)
 }
 
+function isRuntimeFunction(value: unknown): value is Function {
+  if (value === null || Object(value) !== value) return false
+  try {
+    Function.prototype.toString.call(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function isRuntimeObject(value: unknown): value is object {
+  return value !== null && Object(value) === value && !isRuntimeFunction(value)
+}
+
 function isComarkContentSource(input: ContentSourceInput): input is ComarkContentSource {
-  return input instanceof Object && "getItem" in input && "keys" in input
+  return (
+    isRuntimeObject(input)
+    && "getItem" in input
+    && isRuntimeFunction(input.getItem)
+    && "getItemRaw" in input
+    && isRuntimeFunction(input.getItemRaw)
+    && "keys" in input
+    && isRuntimeFunction(input.keys)
+  )
 }
 
 function isSourceReaderFactory(input: SourceName | SourceReader | (() => SourceReader)): input is () => SourceReader {
@@ -72,13 +94,13 @@ function isSourceName(input: SourceName | SourceReader | (() => SourceReader)): 
 }
 
 function configuredContentSource(input: ComarkContentSource, options: ContentSourceOptions): ComarkContentSource {
-  const source = {
+  const source: ComarkContentSource = {
     getItem: input.getItem.bind(input),
+    getItemRaw: input.getItemRaw.bind(input),
     keys: input.keys.bind(input),
     prefix: options.prefix ?? input.prefix,
     schema: options.schema ?? input.schema,
-  } as ComarkContentSource
-  if (input.getItemRaw) source.getItemRaw = input.getItemRaw.bind(input)
+  }
   if (input.watch) source.watch = input.watch.bind(input)
   return source
 }

--- a/packages/source/src/core/collection.ts
+++ b/packages/source/src/core/collection.ts
@@ -1,4 +1,5 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec"
+import { isPlainRecord } from "@vite-hub/internal/object"
 
 const defaultPageLimit = 50
 const defaultMaxLimit = 100
@@ -222,12 +223,51 @@ function decodeBase64Url(value: string): string {
   return new TextDecoder().decode(Uint8Array.from(binary, character => character.charCodeAt(0)))
 }
 
-function isCursorValue(value: unknown): value is CollectionCursorValue {
-  if (Number(value) === value) return Number.isFinite(Number(value)) && !Object.is(value, -0)
-  if (value === null || value === true || value === false || String(value) === value) return true
-  if (Array.isArray(value)) return value.every(isCursorValue)
-  if (Object(value) !== value || value instanceof Function) return false
-  return Object.values(Object(value)).every(isCursorValue)
+function hasPrimitiveRuntimeTag(value: unknown, tag: string): boolean {
+  return value !== null && value !== undefined && Object(value) !== value && Object.prototype.toString.call(value) === tag
+}
+
+function isRuntimeNumber(value: unknown): value is number {
+  return hasPrimitiveRuntimeTag(value, "[object Number]")
+}
+
+function isRuntimeObject(value: unknown): value is object {
+  return value !== null && Object(value) === value
+}
+
+function isRuntimeString(value: unknown): value is string {
+  return hasPrimitiveRuntimeTag(value, "[object String]")
+}
+
+function isCursorValue(value: unknown, ancestors = new Set<object>()): value is CollectionCursorValue {
+  if (isRuntimeNumber(value)) return Number.isFinite(value) && !Object.is(value, -0)
+  if (value === null || value === true || value === false || isRuntimeString(value)) return true
+  if (!isRuntimeObject(value) || ancestors.has(value)) return false
+
+  ancestors.add(value)
+  try {
+    if (Array.isArray(value)) {
+      const keys = Reflect.ownKeys(value)
+      if (keys.length !== value.length + 1 || keys.some(key => key !== "length" && !isRuntimeString(key))) return false
+      for (let index = 0; index < value.length; index += 1) {
+        const descriptor = Object.getOwnPropertyDescriptor(value, String(index))
+        if (!descriptor?.enumerable || !("value" in descriptor) || !isCursorValue(descriptor.value, ancestors)) return false
+      }
+      return true
+    }
+
+    if (!isPlainRecord(value)) return false
+    for (const key of Reflect.ownKeys(value)) {
+      if (!isRuntimeString(key)) return false
+      const descriptor = Object.getOwnPropertyDescriptor(value, key)
+      if (!descriptor?.enumerable || !("value" in descriptor) || !isCursorValue(descriptor.value, ancestors)) return false
+    }
+    return true
+  } catch {
+    return false
+  } finally {
+    ancestors.delete(value)
+  }
 }
 
 function encodeCursor(value: CollectionCursorValue): string {

--- a/packages/source/test/collection-page.test.ts
+++ b/packages/source/test/collection-page.test.ts
@@ -1,3 +1,5 @@
+import { runInNewContext } from "node:vm"
+
 import { describe, expect, it, vi } from "vitest"
 import * as v from "valibot"
 
@@ -85,6 +87,21 @@ describe("Collections", () => {
     expect(load).toHaveBeenLastCalledWith({ cursor: 2, limit: 2, query: {}, signal: undefined })
   })
 
+  it("accepts plain cursor objects from another realm", async () => {
+    // SAFETY: Node's VM evaluates the exact plain cursor object literal owned by this fixture.
+    const cursor = runInNewContext("({ id: 'one' })") as { id: string }
+    const collection = defineCollection(async () => [cursor, { id: "two" }], {
+      cursor: row => row,
+      cursorSchema: v.object({ id: v.string() }),
+      defaultLimit: 1,
+      maxLimit: 1,
+    })
+
+    await expect(collection.page({ query: {} })).resolves.toMatchObject({
+      nextCursor: expect.any(String),
+    })
+  })
+
   it("derives the continuation cursor before a transform mutates its source item", async () => {
     const load = vi.fn(async ({ cursor }: { cursor?: number }) =>
       cursor === undefined
@@ -148,5 +165,32 @@ describe("Collections", () => {
         maxLimit: 1,
       }),
     ).toThrow("defaultLimit cannot exceed maxLimit")
+  })
+
+  it("rejects cyclic and prototype-backed cursor values", async () => {
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+    const cyclicCollection = defineCollection(async () => [cyclic, {}], {
+      cursor: row => row,
+      cursorSchema: v.any(),
+      defaultLimit: 1,
+      maxLimit: 1,
+    })
+
+    await expect(cyclicCollection.page({ query: {} })).rejects.toThrow(
+      "Collection cursor() must return a JSON-serializable value",
+    )
+
+    const prototypeCollection = defineCollection(async () => [new URL("https://vitehub.dev"), new URL("https://vitehub.dev/next")], {
+      // SAFETY: This fixture deliberately violates the cursor type contract to verify runtime rejection.
+      cursor: row => row as never,
+      cursorSchema: v.any(),
+      defaultLimit: 1,
+      maxLimit: 1,
+    })
+
+    await expect(prototypeCollection.page({ query: {} })).rejects.toThrow(
+      "Collection cursor() must return a JSON-serializable value",
+    )
   })
 })

--- a/packages/source/test/content.test.ts
+++ b/packages/source/test/content.test.ts
@@ -3,8 +3,6 @@ import media from "comark-content/plugins/media"
 import sqliteFullTextSearch from "comark-content/plugins/sqlite-full-text-search"
 import { afterEach, describe, expect, it } from "vitest"
 
-import type { Source as ComarkContentSource } from "comark-content"
-
 import { contentSource, defineContent } from "../src/content.ts"
 import { clearSources, registerSources, useSource } from "../src/index.ts"
 
@@ -206,22 +204,6 @@ describe("contentSource", () => {
 
     expect(source.prefix).toBe("configured")
     await expect(source.keys()).resolves.toEqual(["index.md"])
-    await expect(source.getItem("index.md")).resolves.toBe("# Native")
-  })
-
-  it("preserves native Sources without an optional raw-item handler when applying options", async () => {
-    const nativeSource = {
-      async keys() {
-        return ["index.md"]
-      },
-      async getItem() {
-        return "# Native"
-      },
-    } as unknown as ComarkContentSource
-    const source = contentSource(nativeSource, { prefix: "configured" })
-
-    expect(source.prefix).toBe("configured")
-    expect(source.getItemRaw).toBeUndefined()
     await expect(source.getItem("index.md")).resolves.toBe("# Native")
   })
 

--- a/packages/source/test/content.test.ts
+++ b/packages/source/test/content.test.ts
@@ -210,15 +210,14 @@ describe("contentSource", () => {
   })
 
   it("preserves native Sources without an optional raw-item handler when applying options", async () => {
-    const nativeSource: ComarkContentSource = {
-      getItemRaw: undefined,
+    const nativeSource = {
       async keys() {
         return ["index.md"]
       },
       async getItem() {
         return "# Native"
       },
-    }
+    } as unknown as ComarkContentSource
     const source = contentSource(nativeSource, { prefix: "configured" })
 
     expect(source.prefix).toBe("configured")

--- a/packages/source/test/content.test.ts
+++ b/packages/source/test/content.test.ts
@@ -3,6 +3,8 @@ import media from "comark-content/plugins/media"
 import sqliteFullTextSearch from "comark-content/plugins/sqlite-full-text-search"
 import { afterEach, describe, expect, it } from "vitest"
 
+import type { Source as ComarkContentSource } from "comark-content"
+
 import { contentSource, defineContent } from "../src/content.ts"
 import { clearSources, registerSources, useSource } from "../src/index.ts"
 
@@ -180,6 +182,48 @@ describe("contentSource", () => {
     const content = defineContent({ sources: { native: source } })
     expect(content.getSource("native")).toBe(source)
     await expect(content.get("/")).resolves.toEqual(expect.objectContaining({ path: "/" }))
+  })
+
+  it("preserves prototype-backed native Sources when applying options", async () => {
+    class PrototypeSource {
+      #content = "# Native"
+      prefix = "original"
+
+      async keys() {
+        return ["index.md"]
+      }
+
+      async getItem() {
+        return this.#content
+      }
+
+      async getItemRaw() {
+        return this.#content
+      }
+    }
+
+    const source = contentSource(new PrototypeSource(), { prefix: "configured" })
+
+    expect(source.prefix).toBe("configured")
+    await expect(source.keys()).resolves.toEqual(["index.md"])
+    await expect(source.getItem("index.md")).resolves.toBe("# Native")
+  })
+
+  it("preserves native Sources without an optional raw-item handler when applying options", async () => {
+    const nativeSource: ComarkContentSource = {
+      getItemRaw: undefined,
+      async keys() {
+        return ["index.md"]
+      },
+      async getItem() {
+        return "# Native"
+      },
+    }
+    const source = contentSource(nativeSource, { prefix: "configured" })
+
+    expect(source.prefix).toBe("configured")
+    expect(source.getItemRaw).toBeUndefined()
+    await expect(source.getItem("index.md")).resolves.toBe("# Native")
   })
 
   it("rejects duplicate public paths", async () => {

--- a/packages/ui/src/components/agent-invocation-list.ts
+++ b/packages/ui/src/components/agent-invocation-list.ts
@@ -76,7 +76,8 @@ function renderItem(
   harnessSlot?: Slot,
   itemProps?: Record<string, unknown>,
 ) {
-  const time = relativeTime(item.status === "running" ? item.startedAt ?? item.updatedAt : item.updatedAt, now);
+  const timestamp = item.status === "running" ? item.startedAt ?? item.updatedAt : item.updatedAt;
+  const time = relativeTime(timestamp, now);
   const harness = harnessSlot?.({ item }) ?? [
     item.provider ? h("span", { title: `Provider: ${item.provider}` }, [metadataIcon("provider"), h("span", { class: "vh-visually-hidden" }, `Provider ${item.provider}`)]) : null,
     item.agent ? h("span", { title: `Agent: ${item.agent}` }, [metadataIcon("agent"), h("span", { class: "vh-visually-hidden" }, `Agent ${item.agent}`)]) : null,
@@ -96,7 +97,7 @@ function renderItem(
         h("span", { class: "vh-invocation-list__state" }, [
           h("span", { class: "vh-invocation-list__state-icon" }, [statusIcon(item.status)]),
           h("span", statusLabel(item.status)),
-          time ? h("time", { datetime: item.updatedAt }, time) : null,
+          time ? h("time", { datetime: timestamp }, time) : null,
         ]),
       ]),
       h("strong", { class: "vh-invocation-list__title" }, item.title),

--- a/packages/ui/src/components/agent-message-parts.ts
+++ b/packages/ui/src/components/agent-message-parts.ts
@@ -40,6 +40,7 @@ function filePart(part: Extract<Part, { type: "file" }>): VNodeChild {
       class: "vh-attachment",
       download: part.filename,
       href: part.url,
+      rel: isSafeExternalUrl(part.url) ? "noreferrer" : undefined,
       target: isSafeExternalUrl(part.url) ? "_blank" : undefined,
     },
     [

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -82,6 +82,7 @@ describe("Agent Invocation UI", () => {
       "data:image/png;base64,c2FmZQ==",
     ]);
     expect(wrapper.findAll("img").map(image => image.attributes("src"))).toEqual(["data:image/png;base64,c2FmZQ=="]);
+    expect(wrapper.findAll("a")[0]!.attributes("rel")).toBe("noreferrer");
     expect(wrapper.findAll("a")[1]!.attributes("target")).toBeUndefined();
     expect(wrapper.text()).toContain("unsafe.txt");
     expect(wrapper.text()).toContain("inline.png");
@@ -833,6 +834,25 @@ describe("Agent Invocation UI", () => {
     });
 
     expect(wrapper.get("time").text()).toBe("Aug 23");
+  });
+
+  it("uses the running timestamp in visible and machine-readable time", () => {
+    const wrapper = mount(AgentInvocationList, {
+      props: {
+        items: [{
+          id: "running",
+          startedAt: "2026-08-23T09:10:00.000Z",
+          status: "running",
+          title: "Running session",
+          updatedAt: "2026-08-23T09:19:00.000Z",
+        }],
+        now: Date.parse("2026-08-23T09:20:00.000Z"),
+        virtual: false,
+      },
+    });
+
+    expect(wrapper.get("time").text()).toBe("10m");
+    expect(wrapper.get("time").attributes("datetime")).toBe("2026-08-23T09:10:00.000Z");
   });
 
   it("keeps virtual rows in list coordinates when a header precedes them", async () => {

--- a/packages/vite-hub/src/bin.ts
+++ b/packages/vite-hub/src/bin.ts
@@ -5,8 +5,8 @@ import { runViteHubCli } from "@vite-hub/cli"
 import { loadViteHubCliConfig } from "./internal/cli-config.ts"
 
 runViteHubCli({ loadConfig: loadViteHubCliConfig }).then((exitCode) => {
-  process.exit(exitCode)
+  process.exitCode = exitCode
 }).catch((error: unknown) => {
   console.error(error instanceof Error ? error.message : error)
-  process.exit(1)
+  process.exitCode = 1
 })

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -1,5 +1,10 @@
+import { execFile } from "node:child_process"
 import { existsSync, globSync, readFileSync } from "node:fs"
+import { mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { fileURLToPath } from "node:url"
+import { promisify } from "node:util"
 
 import { describe, expect, it } from "vitest"
 
@@ -29,6 +34,7 @@ import { distributionBinEntries, distributionEntriesFromManifest } from "../vite
 
 const packageRoot = fileURLToPath(new URL("..", import.meta.url))
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url))
+const execFileAsync = promisify(execFile)
 
 interface DistributionManifest {
   bin: Record<string, string>
@@ -263,6 +269,32 @@ describe("framework package contract", () => {
     expect(readFileSync(`${packageRoot}/dist/console/runtime/public/console/console.js`, "utf8")).toContain("ViteHub")
     expect(readFileSync(`${packageRoot}/dist/console/runtime/public/console/console.css`, "utf8")).toContain("vitehub-console")
     expect(manifest.dependencies).toHaveProperty("@cloudflare/workers-types")
+  })
+
+  it("runs the distributed CLI entrypoint with clean help streams", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-bin-"))
+    try {
+      await writeFile(join(root, "vite.config.mjs"), `
+const namespaces = Array.from({ length: 4096 }, (_, index) => ({
+  description: "A package-contributed command whose help output must flush before exit.",
+  features: [],
+  name: \`namespace-\${String(index).padStart(4, "0")}\`,
+}))
+export default { plugins: [{ name: "large-cli-help", vitehub: { cli: { namespaces } } }] }
+`)
+      const { stderr, stdout } = await execFileAsync(process.execPath, [`${packageRoot}/${manifest.bin.vitehub}`, "--help"], {
+        cwd: root,
+        env: { ...process.env, NO_COLOR: "1" },
+      })
+
+      expect(stdout).toContain("Usage: vitehub <namespace> <feature>")
+      expect(stdout).toContain("namespace-4095")
+      expect(stdout).toContain("provision")
+      expect(stderr).toBe("")
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
   })
 
   it("derives deduplicated binary entries from the package manifest", () => {

--- a/packages/workflow/src/runtime/openworkflow-worker.ts
+++ b/packages/workflow/src/runtime/openworkflow-worker.ts
@@ -1,5 +1,7 @@
 import { getOpenWorkflowRuntime, registerOpenWorkflowDefinition } from "./openworkflow.ts"
+import { runWorkflowProviderOperation } from "./provider-operation.ts"
 import { getInlineWorkflowDefinitions, getWorkflowRuntimeConfig, getWorkflowRuntimeRegistry, setWorkflowRuntimeConfig, setWorkflowRuntimeRegistry, takeInlineWorkflowDefinitionForModule } from "./state.ts"
+import { hasRuntimeType, isRuntimeRecord } from "../internal/runtime-type.ts"
 import { ViteHubError } from "@vite-hub/runtime"
 import { createWorkflowError } from "../errors.ts"
 
@@ -24,23 +26,21 @@ function getProcess(): {
   off?: (event: string, listener: () => void) => void
   on?: (event: string, listener: () => void) => void
 } | undefined {
-  return (globalThis as {
-    process?: {
-      emitWarning?: (warning: Error) => void
-      off?: (event: string, listener: () => void) => void
-      on?: (event: string, listener: () => void) => void
-    }
-  }).process
+  return globalThis.process
+}
+
+function isWorkflowDefinition(value: unknown): value is WorkflowDefinition {
+  return isRuntimeRecord(value) && hasRuntimeType(value.handler, "function")
 }
 
 async function loadRegistryDefinitions(registry: WorkflowDefinitionRegistry) {
   const definitions = new Map<string, WorkflowDefinition>()
   for (const name of Object.keys(registry).sort()) {
     const loaded = await registry[name]?.()
-    const definition = (loaded && typeof loaded === "object" && "default" in loaded
+    const definition = (isRuntimeRecord(loaded) && "default" in loaded
       ? loaded.default
-      : loaded) as WorkflowDefinition | undefined
-    if (definition && typeof definition === "object" && "handler" in definition && typeof definition.handler === "function") {
+      : loaded)
+    if (isWorkflowDefinition(definition)) {
       definitions.set(name, definition)
       continue
     }
@@ -87,7 +87,51 @@ export async function createOpenWorkflowWorker(options: CreateOpenWorkflowWorker
 
 export async function startOpenWorkflowWorker(options: StartOpenWorkflowWorkerOptions = {}): Promise<OpenWorkflowWorker> {
   const worker = await createOpenWorkflowWorker(options)
-  await worker.start()
+  await runWorkflowProviderOperation("openworkflow", "start", async () => {
+    let removeStartupAbortListener: (() => void) | undefined
+    let startTask: Promise<void> | undefined
+    try {
+      if (options.signal?.aborted) throw options.signal.reason
+      startTask = Promise.resolve(worker.start())
+      if (!options.signal) {
+        await startTask
+      }
+      else {
+        const signal = options.signal
+        const abortTask = new Promise<never>((_resolve, reject) => {
+          const abort = () => reject(signal.reason)
+          removeStartupAbortListener = () => signal.removeEventListener("abort", abort)
+          signal.addEventListener("abort", abort, { once: true })
+          if (signal.aborted) abort()
+        })
+        await Promise.race([startTask, abortTask])
+      }
+    }
+    catch (startError) {
+      const stopTask = Promise.resolve().then(() => worker.stop())
+      if (startTask && options.signal?.aborted) {
+        void startTask.then(async () => {
+          await stopTask.catch(() => {})
+          await worker.stop()
+        }).catch(() => {})
+      }
+      try {
+        await stopTask
+      }
+      catch (stopError) {
+        throw new AggregateError(
+          [startError, stopError],
+          "OpenWorkflow worker startup and cleanup failed.",
+        )
+      }
+      throw startError
+    }
+    finally {
+      removeStartupAbortListener?.()
+    }
+  }, {
+    boundaryError: error => options.signal?.aborted === true && error === options.signal.reason,
+  })
 
   const originalStop = worker.stop.bind(worker)
   const proc = getProcess()

--- a/packages/workflow/src/runtime/provider-operation.ts
+++ b/packages/workflow/src/runtime/provider-operation.ts
@@ -18,6 +18,7 @@ type WorkflowProviderOperation =
 
 export function isWorkflowBoundaryError(error: unknown): boolean {
   if (getViteHubErrorShape(error)) return true
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Provider failures cross an untyped runtime boundary before their shape can be inspected.
   if (typeof error !== "object" || error === null) return false
 
   try {
@@ -29,14 +30,19 @@ export function isWorkflowBoundaryError(error: unknown): boolean {
 }
 
 export function getWorkflowProviderStatus(error: unknown): number | undefined {
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Provider failures cross an untyped runtime boundary before their status can be inspected.
   if (typeof error !== "object" || error === null) return undefined
 
   try {
+    // SAFETY: The object guard above permits reading only optional unknown status fields.
     const value = error as { response?: unknown, status?: unknown, statusCode?: unknown }
+    // doctor-disable-next-line typescript/strict/no-runtime-typeof -- A provider response is untyped until this boundary validates its object representation.
     const response = typeof value.response === "object" && value.response !== null
+      // SAFETY: The response object guard above permits reading only its optional unknown status field.
       ? value.response as { status?: unknown }
       : undefined
     const status = value.status ?? value.statusCode ?? response?.status
+    // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Runtime status validation must reject non-number provider values.
     return typeof status === "number" && Number.isInteger(status) && status >= 400 && status <= 599
       ? status
       : undefined
@@ -50,20 +56,29 @@ export async function runWorkflowProviderOperation<T>(
   provider: WorkflowProvider,
   operation: WorkflowProviderOperation,
   run: () => T | PromiseLike<T>,
-  options: { acknowledgementUnknown?: (error: unknown, status: number | undefined) => boolean } = {},
+  options: {
+    acknowledgementUnknown?: (error: unknown, status: number | undefined) => boolean
+    boundaryError?: (error: unknown) => boolean
+  } = {},
 ): Promise<T> {
   try {
     return await run()
   }
   catch (error) {
-    if (isWorkflowBoundaryError(error)) throw error
+    if (options.boundaryError?.(error) || isWorkflowBoundaryError(error)) throw error
 
     const status = getWorkflowProviderStatus(error)
     const acknowledgement = options.acknowledgementUnknown?.(error, status) === true ? "unknown" : undefined
+    const details: { acknowledgement?: "unknown", operation: WorkflowProviderOperation, provider: WorkflowProvider, status?: number } = {
+      operation,
+      provider,
+    }
+    if (acknowledgement) details.acknowledgement = acknowledgement
+    if (status !== undefined) details.status = status
     throw createWorkflowError({
       cause: error,
       code: "WORKFLOW_PROVIDER_OPERATION_FAILED",
-      details: { operation, provider, ...(acknowledgement ? { acknowledgement } : {}), ...(status === undefined ? {} : { status }) },
+      details,
     })
   }
 }

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -2,6 +2,7 @@ import { existsSync } from "node:fs"
 import { mkdtemp } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
+import { runInNewContext } from "node:vm"
 
 import { getActiveCloudflareEnv, runWithActiveCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { ViteHubError } from "@vite-hub/runtime"
@@ -1418,6 +1419,143 @@ describe("workflow runtime", () => {
     expect(openWorkflowMock.newWorker).toHaveBeenCalledWith({ concurrency: 3 })
     await worker.start()
     expect(worker.start).toHaveBeenCalled()
+  })
+
+  it("registers OpenWorkflow handlers created in another JavaScript realm", async () => {
+    setWorkflowRuntimeConfig({
+      postgres: { url: "postgres://localhost/vitehub" },
+      provider: "openworkflow",
+    })
+    // SAFETY: Node's VM evaluates the exact async function literal owned by this test fixture.
+    const handler = runInNewContext("(async () => ({ ok: true }))") as () => Promise<{ ok: boolean }>
+    setWorkflowRuntimeRegistry({
+      welcome: async () => ({ default: { handler } }),
+    })
+
+    await createOpenWorkflowWorker()
+
+    expect(openWorkflowMock.definitions.has("welcome")).toBe(true)
+  })
+
+  it("closes a partially started OpenWorkflow worker and normalizes startup failures", async () => {
+    setWorkflowRuntimeConfig({
+      postgres: { url: "postgres://localhost/vitehub" },
+      provider: "openworkflow",
+    })
+    const cause = new Error("worker startup failed")
+    const stop = vi.fn(async () => {})
+    openWorkflowMock.newWorker.mockReturnValueOnce({
+      options: undefined,
+      start: vi.fn(async () => { throw cause }),
+      stop,
+    })
+
+    await expect(startOpenWorkflowWorker()).rejects.toMatchObject({
+      cause,
+      code: "WORKFLOW_PROVIDER_OPERATION_FAILED",
+      details: { operation: "start", provider: "openworkflow" },
+    })
+    expect(stop).toHaveBeenCalledOnce()
+  })
+
+  it("keeps startup and cleanup failures when an OpenWorkflow worker cannot start", async () => {
+    setWorkflowRuntimeConfig({
+      postgres: { url: "postgres://localhost/vitehub" },
+      provider: "openworkflow",
+    })
+    const startError = new Error("worker startup failed")
+    const stopError = new Error("worker cleanup failed")
+    openWorkflowMock.newWorker.mockReturnValueOnce({
+      options: undefined,
+      start: vi.fn(async () => { throw startError }),
+      stop: vi.fn(async () => { throw stopError }),
+    })
+
+    const error = await startOpenWorkflowWorker().catch(error => error)
+
+    expect(error).toMatchObject({
+      code: "WORKFLOW_PROVIDER_OPERATION_FAILED",
+      details: { operation: "start", provider: "openworkflow" },
+    })
+    expect(error.cause).toBeInstanceOf(AggregateError)
+    expect(error.cause.errors).toEqual([startError, stopError])
+  })
+
+  it("does not start and cleans up an OpenWorkflow worker for a pre-aborted signal", async () => {
+    setWorkflowRuntimeConfig({
+      postgres: { url: "postgres://localhost/vitehub" },
+      provider: "openworkflow",
+    })
+    const controller = new AbortController()
+    const reason = new DOMException("cancelled", "AbortError")
+    controller.abort(reason)
+    const start = vi.fn(async () => {})
+    const stop = vi.fn(async () => {})
+    openWorkflowMock.newWorker.mockReturnValueOnce({ options: undefined, start, stop })
+
+    await expect(startOpenWorkflowWorker({ signal: controller.signal })).rejects.toBe(reason)
+    expect(start).not.toHaveBeenCalled()
+    expect(stop).toHaveBeenCalledOnce()
+  })
+
+  it("preserves an arbitrary abort reason while an OpenWorkflow worker starts", async () => {
+    setWorkflowRuntimeConfig({
+      postgres: { url: "postgres://localhost/vitehub" },
+      provider: "openworkflow",
+    })
+    const controller = new AbortController()
+    const reason = new Error("cancelled")
+    const start = vi.fn(() => new Promise<void>(() => {}))
+    const stop = vi.fn(async () => {})
+    openWorkflowMock.newWorker.mockReturnValueOnce({ options: undefined, start, stop })
+
+    const workerTask = startOpenWorkflowWorker({ signal: controller.signal })
+    await vi.waitFor(() => expect(start).toHaveBeenCalledOnce())
+    controller.abort(reason)
+
+    await expect(workerTask).rejects.toBe(reason)
+    expect(stop).toHaveBeenCalledOnce()
+  })
+
+  it("stops a partially started OpenWorkflow worker when startup is aborted", async () => {
+    setWorkflowRuntimeConfig({
+      postgres: { url: "postgres://localhost/vitehub" },
+      provider: "openworkflow",
+    })
+    const controller = new AbortController()
+    const reason = new DOMException("cancelled", "AbortError")
+    const start = vi.fn(() => new Promise<void>(() => {}))
+    const stop = vi.fn(async () => {})
+    openWorkflowMock.newWorker.mockReturnValueOnce({ options: undefined, start, stop })
+
+    const workerTask = startOpenWorkflowWorker({ signal: controller.signal })
+    await vi.waitFor(() => expect(start).toHaveBeenCalledOnce())
+    controller.abort(reason)
+
+    await expect(workerTask).rejects.toBe(reason)
+    expect(stop).toHaveBeenCalledOnce()
+  })
+
+  it("stops an OpenWorkflow worker again when startup succeeds after abort cleanup", async () => {
+    setWorkflowRuntimeConfig({
+      postgres: { url: "postgres://localhost/vitehub" },
+      provider: "openworkflow",
+    })
+    const controller = new AbortController()
+    const reason = new DOMException("cancelled", "AbortError")
+    let finishStart: (() => void) | undefined
+    const start = vi.fn(() => new Promise<void>((resolve) => { finishStart = resolve }))
+    const stop = vi.fn(async () => {})
+    openWorkflowMock.newWorker.mockReturnValueOnce({ options: undefined, start, stop })
+
+    const workerTask = startOpenWorkflowWorker({ signal: controller.signal })
+    await vi.waitFor(() => expect(start).toHaveBeenCalledOnce())
+    controller.abort(reason)
+
+    await expect(workerTask).rejects.toBe(reason)
+    expect(stop).toHaveBeenCalledOnce()
+    finishStart?.()
+    await vi.waitFor(() => expect(stop).toHaveBeenCalledTimes(2))
   })
 
   it("owns OpenWorkflow worker listeners until a cached public stop fails", async () => {

--- a/packages/workspace/src/storage/memory-fs.ts
+++ b/packages/workspace/src/storage/memory-fs.ts
@@ -1,6 +1,18 @@
+import { isPlainObject } from "@vite-hub/internal/object"
+
 type Entry =
   | { kind: "dir", children: Set<string>, mtimeMs: number }
   | { kind: "file", data: Uint8Array, mtimeMs: number }
+
+function copyBinaryData(data: unknown): Uint8Array | undefined {
+  if (ArrayBuffer.isView(data)) {
+    return Uint8Array.from(new Uint8Array(data.buffer, data.byteOffset, data.byteLength))
+  }
+  if (Object.prototype.toString.call(data) === "[object ArrayBuffer]") {
+    // SAFETY: The runtime tag establishes an ArrayBuffer, including values from another realm.
+    return Uint8Array.from(new Uint8Array(data as ArrayBuffer))
+  }
+}
 
 class MemoryStats {
   constructor(private entry: Entry) {}
@@ -78,35 +90,43 @@ export class MemoryFS {
 
   async mkdir(path: string, options?: { recursive?: boolean } | number) {
     const target = this.normalize(path)
-    if (target === "/") return
-    const recursive = typeof options === "object" && Boolean(options?.recursive)
+    const recursive = isPlainObject(options) && options.recursive === true
+    if (target === "/") {
+      if (recursive) return
+      throw memoryFsError("EEXIST", path)
+    }
     const parent = this.parent(target)
     if (!this.entries.has(parent)) {
-      if (!recursive) throw new Error(`ENOENT: ${parent}`)
+      if (!recursive) throw memoryFsError("ENOENT", parent)
       await this.mkdir(parent, { recursive: true })
     }
-    if (this.entries.has(target)) return
+    const existing = this.entries.get(target)
+    if (existing) {
+      if (existing.kind === "dir" && recursive) return
+      throw memoryFsError("EEXIST", path)
+    }
+    const parentEntry = this.#requireDir(parent)
     this.entries.set(target, { kind: "dir", children: new Set(), mtimeMs: Date.now() })
-    this.#requireDir(parent).children.add(this.basename(target))
+    parentEntry.children.add(this.basename(target))
   }
 
   async writeFile(path: string, data: string | Uint8Array | ArrayBuffer) {
     const target = this.normalize(path)
-    await this.mkdir(this.parent(target), { recursive: true })
-    const bytes = typeof data === "string"
-      ? this.#encoder.encode(data)
-      : data instanceof Uint8Array
-        ? data
-        : new Uint8Array(data)
+    const existing = this.entries.get(target)
+    if (existing?.kind === "dir") throw memoryFsError("EISDIR", path)
+    const parentPath = this.parent(target)
+    if (!this.entries.has(parentPath)) await this.mkdir(parentPath, { recursive: true })
+    const parent = this.#requireDir(parentPath)
+    const bytes = copyBinaryData(data) ?? this.#encoder.encode(String(data))
     this.entries.set(target, { kind: "file", data: bytes, mtimeMs: Date.now() })
-    this.#requireDir(this.parent(target)).children.add(this.basename(target))
+    parent.children.add(this.basename(target))
   }
 
   async readFile(path: string, options?: string | { encoding?: string }) {
     const entry = this.#requireEntry(path)
-    if (entry.kind !== "file") throw new Error(`EISDIR: ${path}`)
-    const encoding = typeof options === "string" ? options : options?.encoding
-    return encoding ? this.#decoder.decode(entry.data) : entry.data
+    if (entry.kind !== "file") throw memoryFsError("EISDIR", path)
+    const encoding = isPlainObject(options) ? options.encoding : options
+    return encoding ? this.#decoder.decode(entry.data) : Uint8Array.from(entry.data)
   }
 
   async readdir(path: string) {
@@ -116,15 +136,16 @@ export class MemoryFS {
   async unlink(path: string) {
     const target = this.normalize(path)
     const entry = this.#requireEntry(target)
-    if (entry.kind !== "file") throw new Error(`EISDIR: ${path}`)
+    if (entry.kind !== "file") throw memoryFsError("EISDIR", path)
     this.entries.delete(target)
     this.#requireDir(this.parent(target)).children.delete(this.basename(target))
   }
 
   async rmdir(path: string) {
     const target = this.normalize(path)
+    if (target === "/") throw memoryFsError("EBUSY", path)
     const entry = this.#requireDir(target)
-    if (entry.children.size) throw new Error(`ENOTEMPTY: ${path}`)
+    if (entry.children.size) throw memoryFsError("ENOTEMPTY", path)
     this.entries.delete(target)
     this.#requireDir(this.parent(target)).children.delete(this.basename(target))
   }
@@ -167,7 +188,7 @@ export class MemoryFS {
 
   #requireDir(path: string) {
     const entry = this.#requireEntry(path)
-    if (entry.kind !== "dir") throw new Error(`ENOTDIR: ${path}`)
+    if (entry.kind !== "dir") throw memoryFsError("ENOTDIR", path)
     return entry
   }
 }

--- a/packages/workspace/test/memory-fs.test.ts
+++ b/packages/workspace/test/memory-fs.test.ts
@@ -1,3 +1,5 @@
+import { runInNewContext } from "node:vm"
+
 import { describe, expect, it } from "vitest"
 
 import { MemoryFS } from "../src/storage/memory-fs.ts"
@@ -12,5 +14,63 @@ describe("Workspace MemoryFS", () => {
     await expect(fs.promises.symlink("/target", "/link")).rejects.toMatchObject({
       code: "ENOTSUP",
     })
+  })
+
+  it("rejects file and directory collisions without corrupting the tree", async () => {
+    const fs = new MemoryFS()
+
+    await fs.promises.writeFile("/file", "content")
+    await expect(fs.promises.mkdir("/file", { recursive: true })).rejects.toMatchObject({ code: "EEXIST" })
+    await expect(fs.promises.mkdir("/file/child", { recursive: true })).rejects.toMatchObject({ code: "ENOTDIR" })
+    await expect(fs.promises.writeFile("/file/child", "content")).rejects.toMatchObject({ code: "ENOTDIR" })
+    expect(fs.entries.has("/file/child")).toBe(false)
+
+    await fs.promises.mkdir("/directory")
+    await expect(fs.promises.mkdir("/directory")).rejects.toMatchObject({ code: "EEXIST" })
+    await expect(fs.promises.mkdir("/")).rejects.toMatchObject({ code: "EEXIST" })
+    await expect(fs.promises.mkdir("/directory", { recursive: true })).resolves.toBeUndefined()
+    await expect(fs.promises.mkdir("/", { recursive: true })).resolves.toBeUndefined()
+    await expect(fs.promises.writeFile("/directory", "replacement")).rejects.toMatchObject({ code: "EISDIR" })
+    expect((await fs.promises.stat("/directory")).isDirectory()).toBe(true)
+
+    await expect(fs.promises.rmdir("/")).rejects.toMatchObject({ code: "EBUSY" })
+    expect((await fs.promises.stat("/")).isDirectory()).toBe(true)
+  })
+
+  it("copies binary data across the filesystem boundary", async () => {
+    const fs = new MemoryFS()
+    const input = new Uint8Array([1, 2, 3])
+    const arrayBuffer = new Uint8Array([4, 5, 6]).buffer
+    const buffer = Buffer.from([7, 8, 9])
+    // SAFETY: Node's VM evaluates the exact binary object literal owned by this fixture.
+    const crossRealm = runInNewContext(
+      "({ bytes: new Uint8Array([10, 11, 12]), buffer: new Uint8Array([13, 14, 15]).buffer })",
+    ) as {
+      buffer: ArrayBuffer
+      bytes: Uint8Array
+    }
+
+    await fs.promises.writeFile("/file", input)
+    await fs.promises.writeFile("/array-buffer", arrayBuffer)
+    await fs.promises.writeFile("/buffer", buffer)
+    await fs.promises.writeFile("/cross-realm-bytes", crossRealm.bytes)
+    await fs.promises.writeFile("/cross-realm-buffer", crossRealm.buffer)
+    input[0] = 9
+    new Uint8Array(arrayBuffer)[0] = 9
+    buffer[0] = 9
+    crossRealm.bytes[0] = 9
+    new Uint8Array(crossRealm.buffer)[0] = 9
+    const firstRead = await fs.promises.readFile("/file")
+    if (!(firstRead instanceof Uint8Array)) throw new TypeError("Expected a binary read result.")
+    firstRead[1] = 9
+    const bufferRead = await fs.promises.readFile("/buffer")
+    if (!(bufferRead instanceof Uint8Array)) throw new TypeError("Expected a binary read result.")
+    Buffer.from(bufferRead.buffer, bufferRead.byteOffset, bufferRead.byteLength)[1] = 9
+
+    expect(await fs.promises.readFile("/file")).toEqual(new Uint8Array([1, 2, 3]))
+    expect(await fs.promises.readFile("/array-buffer")).toEqual(new Uint8Array([4, 5, 6]))
+    expect(await fs.promises.readFile("/buffer")).toEqual(new Uint8Array([7, 8, 9]))
+    expect(await fs.promises.readFile("/cross-realm-bytes")).toEqual(new Uint8Array([10, 11, 12]))
+    expect(await fs.promises.readFile("/cross-realm-buffer")).toEqual(new Uint8Array([13, 14, 15]))
   })
 })

--- a/playground/vite/server/api/tests/probe.get.ts
+++ b/playground/vite/server/api/tests/probe.get.ts
@@ -5,15 +5,15 @@ export default defineEventHandler((event) => {
     const isCloudflare = event.req.runtime?.name === "cloudflare"
       || !!event.context.cloudflare?.env
       || !!event.context._platform?.cloudflare?.env
-    const provider = isCloudflare ? "cloudflare" : null
-      || (process.env.VERCEL || process.env.VERCEL_URL ? "vercel" : null)
+    const isVercel = !!(process.env.VERCEL || process.env.VERCEL_URL)
+    const provider = isCloudflare ? "cloudflare" : isVercel ? "vercel" : null
     const hosting = process.env.VITEHUB_HOSTING
-      || (isCloudflare ? "cloudflare-module" : null)
-      || (process.env.VERCEL || process.env.VERCEL_URL ? "vercel" : null)
+      || (isCloudflare ? "cloudflare-module" : isVercel ? "vercel" : null)
 
     return {
       ok: true,
       feature: "sandbox",
+      // doctor-disable-next-line typescript/strict/no-runtime-typeof -- The request adapter is a runtime boundary, and callability is the capability contract.
       hasWaitUntil: typeof event.req.waitUntil === "function",
       hosting,
       provider,

--- a/test/effect-ownership.test.ts
+++ b/test/effect-ownership.test.ts
@@ -31,6 +31,18 @@ type PackageEffectOwnership = {
   private: boolean
 }
 
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return value !== null && Object(value) === value && !Array.isArray(value)
+}
+
+function parseJsonObject(source: string, label: string): Record<string, unknown> {
+  const value: unknown = JSON.parse(source)
+  if (!isJsonObject(value)) {
+    throw new TypeError(`${label} must contain a JSON object.`)
+  }
+  return value
+}
+
 async function readFiles(dir: string, predicate: (path: string) => boolean): Promise<string[]> {
   if (!existsSync(dir)) return []
   const files = (await readdir(dir, { recursive: true }))
@@ -70,11 +82,12 @@ async function packageEffectOwnership(): Promise<PackageEffectOwnership[]> {
     if (!entry.isDirectory()) continue
     const packageDir = join(packagesDir, entry.name)
     const sources = await readFiles(join(packageDir, "src"), path => /\.[cm]?[jt]sx?$/.test(path))
-    const manifest = JSON.parse(await readFile(join(packageDir, "package.json"), "utf8")) as Record<string, unknown>
+    const manifestPath = join(packageDir, "package.json")
+    const manifest = parseJsonObject(await readFile(manifestPath, "utf8"), manifestPath)
     const dependencyGroups = ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"]
     const declaresEffect = dependencyGroups.some((group) => {
       const dependencies = manifest[group]
-      return typeof dependencies === "object" && dependencies !== null && "effect" in dependencies
+      return isJsonObject(dependencies) && "effect" in dependencies
     })
     packages.push({
       declaresEffect,
@@ -126,11 +139,13 @@ describe("Effect ownership", () => {
       const owner = pkg.name
       const packageDir = join(repoRoot, "packages", owner)
       const manifestPath = join(packageDir, "package.json")
-      const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as { dependencies?: Record<string, string> }
-      expect(manifest.dependencies?.effect, manifestPath).toBe("catalog:effect")
+      const manifest = parseJsonObject(await readFile(manifestPath, "utf8"), manifestPath)
+      const dependencies = manifest.dependencies
+      const declaredEffect = isJsonObject(dependencies) ? dependencies.effect : undefined
+      expect(declaredEffect, manifestPath).toBe("catalog:effect")
 
       const effectPackage = createRequire(manifestPath).resolve("effect/package.json")
-      const resolved = JSON.parse(await readFile(effectPackage, "utf8")) as { version: string }
+      const resolved = parseJsonObject(await readFile(effectPackage, "utf8"), effectPackage)
       expect(resolved.version, packageDir).toBe(effectVersion)
 
       const declarations = await readFiles(join(packageDir, "dist"), path => path.endsWith(".d.ts"))
@@ -170,6 +185,8 @@ describe("Effect ownership", () => {
     'export { Effect } from "effect"',
     'import "effect/Schema"',
     'const effect = import("effect")',
+    "const effect = import(`effect`)",
+    'import "\\u0065ffect"',
     'const effect = require("effect")',
     'import Effect = require("effect")',
   ])("detects Effect ownership syntax in %s", (source) => {
@@ -181,7 +198,7 @@ describe("Effect ownership", () => {
     const owners = lockOwnerForV3References(lockfile)
     expect(owners.length).toBeGreaterThan(0)
     expect(owners.filter(owner => !(
-      /^effect@3\./.test(owner)
+      owner.startsWith("effect@3.")
       || owner.startsWith("'@effect/platform@")
       || owner.startsWith("'@uploadthing/shared@")
       || owner.startsWith("uploadthing@")


### PR DESCRIPTION
## Problem

A repository-wide review found several boundary and lifecycle inconsistencies: malformed runtime options could reach providers, browser and workflow startup failures did not consistently clean up resources, presence state could expose undeclared fields, MemoryFS leaked mutable buffers and allowed invalid tree collisions, and CLI/UI behavior diverged from their public contracts.

## Changes

- Validate Agent provider execution settings, HTTP and browser timeouts, collection cursors, and realtime identities before use.
- Make local browser and OpenWorkflow startup own timeout, abort, error, and cleanup paths.
- Preserve prototype-backed Content Sources and enforce isolated, Node-like MemoryFS behavior.
- Reject malformed provision arguments, keep usage errors on stderr, and let CLI output flush before exit.
- Correct invocation timestamps, external attachment link isolation, Pierre diff teardown/update behavior, and hosted provider probing.
- Add regression coverage across every changed boundary and ignore generated TypeScript/SWC caches.

## Verification

- 293 focused package tests passed across Agent, Browser, CLI, Internal, Realtime, Source, UI, Workflow, and Workspace.
- 13 root Effect ownership tests passed.
- Full package graph build, publint, and type-check completed successfully.
- Vite Doctor strict scan: 100/100 with no diagnostics.
- Fallow dead-code, Knip catalog, and `git diff --check` passed.

The full consumer suite passed 32 tests with 5 skipped before stopping at the unchanged Deno native-update fixture. A local rerun with the CI Deno version (2.9.3) completed both generated-output checks but the fixture did not create its fake-CLI invocation log; this PR does not modify the Deno deployment paths.
