### PR TITLE
fix(docs): preserve highlighted preview source on open

### DIFF
--- a/docs/app/components/content/ComponentPreview.vue
+++ b/docs/app/components/content/ComponentPreview.vue
@@ -82,7 +82,7 @@ const sourceLabel = computed(() => (sourceOpen.value ? "Hide code" : "View code"
       </Suspense>
     </div>
 
-    <div v-if="sourceOpen" class="component-preview-source border-t border-default">
+    <div v-show="sourceOpen" class="component-preview-source border-t border-default">
       <MDC :value="sourceBlock" :parser-options="sourceParserOptions" :tag="false" />
     </div>
   </div>

--- a/docs/test/ui-docs.test.ts
+++ b/docs/test/ui-docs.test.ts
@@ -43,13 +43,14 @@ describe("UI documentation", () => {
     }
   });
 
-  it("sends component preview source through the Markdown syntax highlighter", () => {
+  it("server-renders component preview source through the Markdown syntax highlighter", () => {
     const preview = readFileSync(
       resolve(docsRoot, "app/components/content/ComponentPreview.vue"),
       "utf8",
     );
 
     expect(preview).toContain('import highlighter from "#mdc-highlighter"');
+    expect(preview).toContain('<div v-show="sourceOpen"');
     expect(preview).toContain('<MDC :value="sourceBlock"');
     expect(preview).toContain(':parser-options="sourceParserOptions"');
     expect(preview).not.toContain("<code>{{ source }}</code>");


### PR DESCRIPTION
## Summary

- server-render component preview source while keeping it visually collapsed
- preserve Shiki token markup when the code panel is opened after hydration
- cover the server-rendered source contract in the UI docs regression test

## Context

#1043 added syntax highlighting, but it merged before the client-open verification fix was pushed. With `v-if`, opening the panel after hydration mounted MDC on the client and produced raw code with no highlighted token spans. Using `v-show` keeps the highlighted markup in the SSR payload without changing the collapsed default.

## Verification

- `corepack pnpm --dir docs test` (14 files, 62 tests)
- `corepack pnpm exec oxlint docs/app/components/content/ComponentPreview.vue docs/test/ui-docs.test.ts`
- `git diff --check origin/main...HEAD`
- browser: collapsed initially; clicking View code reveals 234 token spans with 8 computed colors in light and dark modes
- browser: filename, source, and copy control preserved; zero `/api/_mdc/highlight` requests