### PR TITLE
fix(ui): tighten code view line height

### DIFF
--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -1708,7 +1708,7 @@ summary.vh-invocation-inspector__group-heading:focus-visible,
   --diffs-font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
   --diffs-font-size: 0.8125rem;
   --diffs-header-font-family: var(--font-sans, ui-sans-serif, system-ui, sans-serif);
-  --diffs-line-height: 1.5rem;
+  --diffs-line-height: 1.25rem;
   --diffs-modified-base: var(--vh-ui-info);
   background: var(--vh-ui-bg);
   color: var(--vh-ui-text);


### PR DESCRIPTION
Code and diff views pair 13 px text with 24 px rows, which makes console file inspection too sparse. This reduces the shared Pierre line-height token to 20 px so CodeView, MultiFileDiff, PatchDiff, FileDiff, File, and UnresolvedFile use denser, consistent rows.

## Verification

- `corepack pnpm --filter @vite-hub/ui test` (109 tests passed, no type errors)
- Browser-checked `/docs/ui/diff`; file, diff, conflict, and virtualized code rows rendered at 20 px
- `git diff --check`