### PR TITLE
fix(ui): compact invocation spacing in narrow containers

### DIFF
--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -487,6 +487,7 @@
 
 .vh-invocation-session {
   background: var(--vh-ui-bg);
+  container-type: inline-size;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr);
   height: 100%;
@@ -1664,6 +1665,16 @@ summary.vh-invocation-inspector__group-heading:focus-visible,
 .vh-invocation-empty p {
   font-size: 0.8125rem;
   margin: 0;
+}
+
+@container (max-width: 600px) {
+  .vh-invocation-thread__content {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .vh-invocation-message[data-role="user"] {
+    margin-inline-start: 1rem;
+  }
 }
 
 @media (max-width: 600px) {

--- a/packages/ui/test/package.test.ts
+++ b/packages/ui/test/package.test.ts
@@ -56,6 +56,14 @@ function optionalPeerRecord(
 const packageJson = parsePackageManifest(
   readFileSync(new URL("../package.json", import.meta.url), "utf8"),
 );
+const stylesheet = readFileSync(new URL("../dist/styles.css", import.meta.url), "utf8");
+const compactInvocationRules = `  .vh-invocation-thread__content {
+    padding: 1.5rem 1rem 3rem;
+  }
+
+  .vh-invocation-message[data-role="user"] {
+    margin-inline-start: 1rem;
+  }`;
 
 describe("@vite-hub/ui package contract", () => {
   it("exposes the documented entrypoints", () => {
@@ -90,5 +98,11 @@ describe("@vite-hub/ui package contract", () => {
       "./nuxt",
       "./vite",
     ]);
+  });
+
+  it("ships compact invocation styles for narrow sessions and viewports", () => {
+    expect(stylesheet).toMatch(/\.vh-invocation-session\s*\{[^}]*container-type: inline-size;/);
+    expect(stylesheet).toContain(`@container (max-width: 600px) {\n${compactInvocationRules}\n}`);
+    expect(stylesheet).toContain(`@media (max-width: 600px) {\n${compactInvocationRules}\n}`);
   });
 });


### PR DESCRIPTION
## What changed

Agent Invocation sessions now apply their compact spacing from the session's own inline width. The existing viewport media query remains in place for full-page mobile layouts.

- make `.vh-invocation-session` an inline-size query container
- apply the existing compact thread padding and user-message margin at session widths up to 600px
- assert the published stylesheet includes both container and viewport compact rules

## Why

An Agent Invocation can sit inside a narrow split pane while the browser viewport remains wide. The viewport-only media query left those sessions at 2rem horizontal padding, so their content no longer aligned with the surrounding narrow layout.

## Validation

- `pnpm --filter @vite-hub/ui test` (11 files, 110 tests)
- `vp test test/package.test.ts` (3 tests)
- `oxlint packages/ui/test/package.test.ts`
- headless Chromium at a 1280px viewport: a 500px session resolved to 16px inline padding and a 16px user-message margin; a 700px session retained 32px inline padding
