### PR TITLE
feat(console): add global session search palette

### DIFF
--- a/packages/agent/src/invocations.ts
+++ b/packages/agent/src/invocations.ts
@@ -199,8 +199,8 @@ function normalizeSearch(search: string | undefined): string | undefined {
 
 function matchesInvocationSearch(record: AgentInvocationRecord, search: string | undefined): boolean {
   if (!search) return true
-  const { cursor: _cursor, observations: _observations, ...summary } = record
-  return JSON.stringify(summary).toLowerCase().includes(search.toLowerCase())
+  const { cursor: _cursor, ...searchable } = record
+  return JSON.stringify(searchable).toLowerCase().includes(search.toLowerCase())
 }
 
 function normalizeBuiltInCursor(cursor: string | undefined): string | undefined {

--- a/packages/agent/src/invocations/sqlite.ts
+++ b/packages/agent/src/invocations/sqlite.ts
@@ -19,6 +19,7 @@ export interface LibsqlAgentInvocationStoreOptions {
 }
 
 const searchBackfillPageSize = 100
+const searchVersion = 2
 
 function tableName(prefix = "vitehub_agent_"): string {
   const name = `${prefix}invocations`
@@ -66,8 +67,7 @@ function storedRecord(record: AgentInvocationRecord): Omit<AgentInvocationRecord
 }
 
 function searchableRecord(record: Omit<AgentInvocationRecord, "cursor">): string {
-  const { observations: _observations, ...summary } = record
-  return JSON.stringify(summary).toLowerCase()
+  return JSON.stringify(record).toLowerCase()
 }
 
 function agentNameRecord(record: Omit<AgentInvocationRecord, "cursor">): string {
@@ -118,6 +118,7 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
         status TEXT NOT NULL,
         agent_name TEXT NOT NULL DEFAULT '',
         search TEXT,
+        search_version INTEGER NOT NULL DEFAULT ${searchVersion},
         record TEXT NOT NULL
       )`)
       const columns = await client.execute(`PRAGMA table_info(${table})`)
@@ -139,11 +140,21 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
           if (!currentColumns.rows.some(row => row.name === "agent_name")) throw error
         }
       }
+      if (!columns.rows.some(row => row.name === "search_version")) {
+        try {
+          await client.execute(`ALTER TABLE ${table} ADD COLUMN search_version INTEGER NOT NULL DEFAULT 0`)
+        }
+        catch (error) {
+          const currentColumns = await client.execute(`PRAGMA table_info(${table})`)
+          if (!currentColumns.rows.some(row => row.name === "search_version")) throw error
+        }
+      }
       let backfillSequence = 0
       while (true) {
         const missingSearch = await client.execute({
-          args: [backfillSequence, searchBackfillPageSize],
-          sql: `SELECT sequence, record FROM ${table} WHERE search IS NULL AND sequence > ? ORDER BY sequence LIMIT ?`,
+          args: [searchVersion, backfillSequence, searchBackfillPageSize],
+          sql: `SELECT sequence, record FROM ${table}
+            WHERE (search IS NULL OR search_version < ?) AND sequence > ? ORDER BY sequence LIMIT ?`,
         })
         if (!missingSearch.rows.length) break
         const searchBackfill = missingSearch.rows.flatMap((row) => {
@@ -151,8 +162,8 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
           const record = deserialize(row.record, row.sequence)
           return record
             ? [{
-                args: [searchableRecord(storedRecord(record)), numberValue(row.sequence)],
-                sql: `UPDATE ${table} SET search = ? WHERE sequence = ? AND search IS NULL`,
+                args: [searchableRecord(storedRecord(record)), searchVersion, numberValue(row.sequence)],
+                sql: `UPDATE ${table} SET search = ?, search_version = ? WHERE sequence = ?`,
               }]
             : []
         })
@@ -219,8 +230,8 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
       return write(async () => {
         await initialize()
         const result = await client.execute({
-          args: [input.id, input.status, agentNameRecord(input), searchableRecord(input), serialize(input)],
-          sql: `INSERT OR IGNORE INTO ${table} (id, status, agent_name, search, record) VALUES (?, ?, ?, ?, ?)`,
+          args: [input.id, input.status, agentNameRecord(input), searchableRecord(input), searchVersion, serialize(input)],
+          sql: `INSERT OR IGNORE INTO ${table} (id, status, agent_name, search, search_version, record) VALUES (?, ?, ?, ?, ?, ?)`,
         })
         const record = await read(input.id)
         if (!record) throw new Error(`[vitehub] SQLite Agent Invocation ${JSON.stringify(input.id)} was not persisted.`)
@@ -305,8 +316,8 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
           const updated = applyAgentInvocationStoreUpdate(record, input)
           const stored = storedRecord(updated)
           await transaction.execute({
-            args: [updated.status, agentNameRecord(stored), searchableRecord(stored), serialize(stored), id],
-            sql: `UPDATE ${table} SET status = ?, agent_name = ?, search = ?, record = ? WHERE id = ?`,
+            args: [updated.status, agentNameRecord(stored), searchableRecord(stored), searchVersion, serialize(stored), id],
+            sql: `UPDATE ${table} SET status = ?, agent_name = ?, search = ?, search_version = ?, record = ? WHERE id = ?`,
           })
           await transaction.commit()
           return updated

--- a/packages/agent/src/invocations/sqlite.ts
+++ b/packages/agent/src/invocations/sqlite.ts
@@ -118,7 +118,7 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
         status TEXT NOT NULL,
         agent_name TEXT NOT NULL DEFAULT '',
         search TEXT,
-        search_version INTEGER NOT NULL DEFAULT ${searchVersion},
+        search_version INTEGER NOT NULL DEFAULT 0,
         record TEXT NOT NULL
       )`)
       const columns = await client.execute(`PRAGMA table_info(${table})`)

--- a/packages/agent/src/invocations/sqlite.ts
+++ b/packages/agent/src/invocations/sqlite.ts
@@ -149,6 +149,12 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
           if (!currentColumns.rows.some(row => row.name === "search_version")) throw error
         }
       }
+      await client.execute(`CREATE TRIGGER IF NOT EXISTS ${table}_stale_legacy_search_update
+        AFTER UPDATE OF search, record ON ${table}
+        WHEN NEW.search_version = OLD.search_version
+        BEGIN
+          UPDATE ${table} SET search_version = 0 WHERE sequence = NEW.sequence;
+        END`)
       let backfillSequence = 0
       while (true) {
         const missingSearch = await client.execute({
@@ -315,6 +321,10 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
           }
           const updated = applyAgentInvocationStoreUpdate(record, input)
           const stored = storedRecord(updated)
+          await transaction.execute({
+            args: [id],
+            sql: `UPDATE ${table} SET search_version = -1 WHERE id = ?`,
+          })
           await transaction.execute({
             args: [updated.status, agentNameRecord(stored), searchableRecord(stored), searchVersion, serialize(stored), id],
             sql: `UPDATE ${table} SET status = ?, agent_name = ?, search = ?, search_version = ?, record = ? WHERE id = ?`,

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -1800,6 +1800,32 @@ describe("Agent Invocations", () => {
       await expect(store.list({ search: "fresh observation-only" })).resolves.toEqual({ invocations: [] })
       await expect(createLibsqlAgentInvocationStore({ client }).list({ search: "fresh observation-only" }))
         .resolves.toMatchObject({ invocations: [expect.objectContaining({ id: "fresh-overlapping-legacy-writer" })] })
+
+      await store.update("fresh-overlapping-legacy-writer", {
+        status: "running",
+        timestamp: "2026-01-01T00:01:00.000Z",
+      })
+      await client.execute({
+        args: ["review completed", JSON.stringify({
+          agentName: "review",
+          annotations: { writer: "legacy" },
+          createdAt: "2026-01-01T00:00:00.000Z",
+          id: "fresh-overlapping-legacy-writer",
+          observations: [{
+            attributes: { result: "updated observation-only text" },
+            name: "legacy",
+            timestamp: "2026-01-01T00:02:00.000Z",
+            type: "run",
+          }],
+          status: "completed",
+          traceId: "fresh-overlapping-legacy-trace",
+          updatedAt: "2026-01-01T00:02:00.000Z",
+        }), "fresh-overlapping-legacy-writer"],
+        sql: "UPDATE vitehub_agent_invocations SET search = ?, record = ? WHERE id = ?",
+      })
+      await expect(store.list({ search: "updated observation-only" })).resolves.toEqual({ invocations: [] })
+      await expect(createLibsqlAgentInvocationStore({ client }).list({ search: "updated observation-only" }))
+        .resolves.toMatchObject({ invocations: [expect.objectContaining({ id: "fresh-overlapping-legacy-writer" })] })
     }
     finally {
       client.close()

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -1777,21 +1777,29 @@ describe("Agent Invocations", () => {
       const store = createLibsqlAgentInvocationStore({ client })
       await store.list()
       await client.execute({
-        args: [JSON.stringify({
+        args: ["review completed", JSON.stringify({
           agentName: "review",
           createdAt: "2026-01-01T00:00:00.000Z",
           id: "fresh-overlapping-legacy-writer",
-          observations: [],
+          observations: [{
+            attributes: { result: "fresh observation-only text" },
+            name: "legacy",
+            timestamp: "2026-01-01T00:00:00.000Z",
+            type: "run",
+          }],
           status: "completed",
           traceId: "fresh-overlapping-legacy-trace",
           updatedAt: "2026-01-01T00:00:00.000Z",
         })],
-        sql: "INSERT INTO vitehub_agent_invocations (id, status, record) VALUES ('fresh-overlapping-legacy-writer', 'completed', ?)",
+        sql: "INSERT INTO vitehub_agent_invocations (id, status, search, record) VALUES ('fresh-overlapping-legacy-writer', 'completed', ?, ?)",
       })
 
       await expect(store.list({ agentName: "review" })).resolves.toMatchObject({
         invocations: [expect.objectContaining({ id: "fresh-overlapping-legacy-writer" })],
       })
+      await expect(store.list({ search: "fresh observation-only" })).resolves.toEqual({ invocations: [] })
+      await expect(createLibsqlAgentInvocationStore({ client }).list({ search: "fresh observation-only" }))
+        .resolves.toMatchObject({ invocations: [expect.objectContaining({ id: "fresh-overlapping-legacy-writer" })] })
     }
     finally {
       client.close()

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -1679,7 +1679,7 @@ describe("Agent Invocations", () => {
     }
   })
 
-  it("initializes the libSQL search column concurrently", async () => {
+  it("initializes the libSQL search index concurrently", async () => {
     const directory = await mkdtemp(join(tmpdir(), "vitehub-agent-invocations-migration-"))
     const url = `file:${join(directory, "invocations.sqlite")}`
     const setupClient = createClient({ url })
@@ -1740,7 +1740,7 @@ describe("Agent Invocations", () => {
       const migratedAgent = await firstClient.execute("SELECT agent_name FROM vitehub_agent_invocations WHERE id = 'legacy'")
       expect(migratedAgent.rows[0]?.agent_name).toBe("review")
       await expect(createLibsqlAgentInvocationStore({ client: firstClient }).list({ search: "observation-only" }))
-        .resolves.toEqual({ invocations: [] })
+        .resolves.toMatchObject({ invocations: [expect.objectContaining({ id: "legacy" })] })
       await expect(createLibsqlAgentInvocationStore({ client: firstClient }).list({ agentName: "review" }))
         .resolves.toMatchObject({ invocations: [expect.objectContaining({ id: "legacy" })] })
 

--- a/packages/vite-hub/console.vite.config.ts
+++ b/packages/vite-hub/console.vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   resolve: {
     alias: {
       "vite-hub/agent/vue": resolve(import.meta.dirname, "../agent/src/vue.ts"),
+      "vite-hub/source/client": resolve(import.meta.dirname, "../source/src/client.ts"),
     },
   },
   plugins: [

--- a/packages/vite-hub/src/console/runtime/client/main.js
+++ b/packages/vite-hub/src/console/runtime/client/main.js
@@ -20,6 +20,7 @@ const router = createRouter({
       props: {
         agentsBase: "/api/_vitehub/console/agents",
         apiBase: "/api/_vitehub/console/invocations",
+        searchBase: "/api/_vitehub/console/search",
       },
     },
     {
@@ -29,6 +30,7 @@ const router = createRouter({
       props: {
         agentsBase: "/api/_vitehub/console/agents",
         apiBase: "/api/_vitehub/console/invocations",
+        searchBase: "/api/_vitehub/console/search",
       },
     },
     {
@@ -38,6 +40,7 @@ const router = createRouter({
       props: {
         agentsBase: "/api/_vitehub/console/agents",
         apiBase: "/api/_vitehub/console/invocations",
+        searchBase: "/api/_vitehub/console/search",
       },
     },
   ],

--- a/packages/vite-hub/src/console/runtime/client/request.ts
+++ b/packages/vite-hub/src/console/runtime/client/request.ts
@@ -1,0 +1,14 @@
+export async function requestConsole(
+  path: string,
+  options: { query?: Record<string, unknown>, signal?: AbortSignal },
+): Promise<unknown> {
+  const url = new URL(path, "http://vitehub.local")
+  for (const [key, value] of Object.entries(options.query ?? {})) {
+    if (value === undefined) continue
+    if (Array.isArray(value)) value.forEach(entry => url.searchParams.append(key, String(entry)))
+    else url.searchParams.set(key, String(value))
+  }
+  const response = await fetch(`${url.pathname}${url.search}`, { signal: options.signal })
+  if (!response.ok) throw new Error(`Console request failed with status ${response.status}.`)
+  return response.json()
+}

--- a/packages/vite-hub/src/console/runtime/client/time.ts
+++ b/packages/vite-hub/src/console/runtime/client/time.ts
@@ -1,0 +1,5 @@
+export function relativeDuration(elapsed: number): string {
+  if (elapsed < 60_000) return `${Math.floor(elapsed / 1_000)}s`
+  if (elapsed < 3_600_000) return `${Math.floor(elapsed / 60_000)}m`
+  return `${Math.floor(elapsed / 3_600_000)}h`
+}

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -11,10 +11,13 @@ import type {
   AgentInvocationView,
 } from "@vite-hub/ui";
 import { decodeAgentRouteParam, encodeAgentRouteParam } from "../agent-route";
+import { requestConsole } from "../client/request";
+import { relativeDuration } from "../client/time";
+import ConsoleSearch from "./console-search.vue";
 
 const route = useRoute();
 const router = useRouter();
-const props = defineProps<{ agentsBase: string; apiBase: string }>();
+const props = defineProps<{ agentsBase: string; apiBase: string; searchBase: string }>();
 const initialAgentParam = decodeAgentRouteParam(route.params.agent);
 const selectedInvocationId = ref<string>();
 const selectedAgentName = ref(initialAgentParam?.trim() ? initialAgentParam : undefined);
@@ -30,12 +33,6 @@ const isDesktop = ref(false);
 let clock: ReturnType<typeof setInterval> | undefined;
 let media: MediaQueryList | undefined;
 let agentsRequest: AbortController | undefined;
-
-const request = async (path: string, options: { signal?: AbortSignal }): Promise<unknown> => {
-  const response = await fetch(path, { signal: options.signal });
-  if (!response.ok) throw new Error(`Console request failed with status ${response.status}.`);
-  return response.json();
-};
 const recordSuccessfulPoll = () => {
   lastSuccessfulPollAt.value = new Date();
 };
@@ -44,15 +41,15 @@ const list = useAgentInvocations({
   baseURL: props.apiBase,
   onSuccess: recordSuccessfulPoll,
   pollInterval: 5_000,
-  request,
-  requestSummaries: request,
+  request: requestConsole,
+  requestSummaries: requestConsole,
   query: computed(() => selectedAgentName.value ? { agent: selectedAgentName.value } : undefined),
 });
 const detail = useAgentInvocation(selectedInvocationId, {
   baseURL: props.apiBase,
   onSuccess: recordSuccessfulPoll,
   pollInterval: 3_000,
-  request,
+  request: requestConsole,
 });
 
 const invocationItems = computed<AgentInvocationListItem[]>(() =>
@@ -180,12 +177,6 @@ function errorMessage(error: unknown): string | undefined {
       : undefined;
 }
 
-function relativeDuration(elapsed: number): string {
-  if (elapsed < 60_000) return `${Math.floor(elapsed / 1_000)}s`;
-  if (elapsed < 3_600_000) return `${Math.floor(elapsed / 60_000)}m`;
-  return `${Math.floor(elapsed / 3_600_000)}h`;
-}
-
 async function selectInvocation(id: string): Promise<void> {
   sessionsOpen.value = false;
   await router.push({
@@ -210,7 +201,7 @@ async function loadAgents(): Promise<void> {
   agentsRequest = controller;
   agentsLoading.value = true;
   try {
-    const value = record(await request(props.agentsBase, { signal: controller.signal }));
+    const value = record(await requestConsole(props.agentsBase, { signal: controller.signal }));
     // doctor-disable-next-line typescript/strict/no-runtime-typeof -- The console API response is untrusted JSON, so validate every array entry before using it as an Agent identity.
     const names = Array.isArray(value?.agents)
       ? value.agents.filter((name): name is string => typeof name === "string" && Boolean(name.trim()))
@@ -371,6 +362,14 @@ onBeforeUnmount(() => {
           </div>
           <span class="text-xs text-dimmed">{{ invocationItems.length }}</span>
         </div>
+        <div class="px-2 pb-3" :class="collapsed ? 'pt-2' : ''">
+          <UDashboardSearchButton
+            :collapsed="collapsed"
+            block
+            class="w-full bg-transparent ring-default"
+            label="Search sessions"
+          />
+        </div>
         <div
           v-if="!collapsed && errorMessage(list.error.value || list.loadMoreError.value)"
           class="px-3"
@@ -471,6 +470,8 @@ onBeforeUnmount(() => {
         />
       </template>
     </UDashboardSidebar>
+
+    <ConsoleSearch :agent-names="agentNames" :search-base="searchBase" />
 
     <UDashboardPanel id="agent-session">
       <div class="min-h-0 flex-1" aria-live="polite">

--- a/packages/vite-hub/src/console/runtime/components/console-search.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-search.vue
@@ -1,0 +1,151 @@
+<script setup lang="ts">
+import { useCollection } from "vite-hub/source/client"
+import { computed, onBeforeUnmount, ref, watch } from "vue"
+import { useRouter } from "vue-router"
+
+import type { CommandPaletteGroup, CommandPaletteItem } from "@nuxt/ui"
+import type { Collection } from "@vite-hub/source"
+import type { AgentInvocationListItem } from "@vite-hub/ui"
+import { encodeAgentRouteParam } from "../agent-route"
+import { requestConsole } from "../client/request"
+import { relativeDuration } from "../client/time"
+
+interface ConsoleSearchFilter {
+  search?: string
+}
+
+interface ConsoleSearchItem {
+  agentName?: string
+  context: string
+  excerpt?: string
+  id: string
+  status: AgentInvocationListItem["status"]
+  updatedAt: string
+}
+
+declare global {
+  interface ViteHubCollectionMap {
+    "vitehub-console-search": Collection<ConsoleSearchItem, ConsoleSearchFilter, ConsoleSearchFilter>
+  }
+}
+
+const props = defineProps<{ agentNames: string[], searchBase: string }>()
+const router = useRouter()
+const open = ref(false)
+const searchTerm = ref("")
+const debouncedSearchTerm = ref("")
+let searchTimer: ReturnType<typeof setTimeout> | undefined
+
+const searchFilter = computed<ConsoleSearchFilter>(() =>
+  debouncedSearchTerm.value ? { search: debouncedSearchTerm.value } : {},
+)
+const sessionSearch = useCollection("vitehub-console-search", {
+  filter: searchFilter,
+  limit: 12,
+  request: (_endpoint, options) => requestConsole(props.searchBase, options),
+})
+const sessionItems = computed<CommandPaletteItem[]>(() =>
+  sessionSearch.pending.value
+    ? []
+    : sessionSearch.items.value.map(item => ({
+        description: itemDescription(item),
+        disabled: !item.agentName,
+        icon: "i-lucide-message-square-text",
+        label: item.excerpt || (item.agentName ? `${item.agentName} session` : "Agent Invocation"),
+        onSelect: () => selectSession(item),
+      })),
+)
+const groups = computed<CommandPaletteGroup[]>(() => [
+  {
+    id: "agents",
+    items: props.agentNames.map(name => ({
+      icon: "i-lucide-bot",
+      label: name,
+      onSelect: () => selectAgent(name),
+    })),
+    label: "Agents",
+  },
+  {
+    id: "sessions",
+    ignoreFilter: true,
+    items: sessionItems.value,
+    label: debouncedSearchTerm.value ? "Sessions" : "Recent sessions",
+  },
+])
+
+function errorMessage(error: unknown): string | undefined {
+  return error instanceof Error
+    ? error.message
+    : error
+      ? "The console could not load this data."
+      : undefined
+}
+
+function itemDescription(item: ConsoleSearchItem): string {
+  const updatedAt = new Date(item.updatedAt).valueOf()
+  const age = Number.isFinite(updatedAt)
+    ? `${relativeDuration(Math.max(0, Date.now() - updatedAt))} ago`
+    : undefined
+  return [item.agentName, item.status, age, item.excerpt ? undefined : item.context]
+    .filter(Boolean)
+    .join(" · ")
+}
+
+async function selectAgent(name: string): Promise<void> {
+  open.value = false
+  await router.push({
+    name: "vitehub-console-agent",
+    params: { agent: encodeAgentRouteParam(name) },
+  })
+}
+
+async function selectSession(item: ConsoleSearchItem): Promise<void> {
+  if (!item.agentName) return
+  open.value = false
+  await router.push({
+    name: "vitehub-console-invocation",
+    params: { agent: encodeAgentRouteParam(item.agentName), invocation: item.id },
+  })
+}
+
+watch(searchTerm, (value) => {
+  if (searchTimer) clearTimeout(searchTimer)
+  searchTimer = setTimeout(() => {
+    debouncedSearchTerm.value = value.trim()
+  }, 150)
+})
+
+watch(open, (value) => {
+  if (value) void sessionSearch.refresh()
+})
+
+onBeforeUnmount(() => {
+  if (searchTimer) clearTimeout(searchTimer)
+})
+</script>
+
+<template>
+  <UDashboardSearch
+    v-model:open="open"
+    v-model:search-term="searchTerm"
+    :groups="groups"
+    :loading="sessionSearch.pending.value"
+    placeholder="Search sessions and Agents…"
+    preserve-group-order
+  >
+    <template #empty="{ searchTerm: value }">
+      <div class="grid justify-items-center gap-2 px-6 py-10 text-center">
+        <UIcon
+          :name="sessionSearch.error.value ? 'i-lucide-cloud-off' : 'i-lucide-search-x'"
+          class="size-6 text-dimmed"
+        />
+        <p class="text-sm font-medium text-highlighted">
+          {{ sessionSearch.error.value ? "Could not search sessions" : value.trim() ? "No matching sessions" : "No sessions yet" }}
+        </p>
+        <p class="text-xs text-muted">
+          {{ sessionSearch.error.value ? errorMessage(sessionSearch.error.value) : value.trim() ? "Try another phrase from the session." : "Agent Invocations will appear here." }}
+        </p>
+      </div>
+    </template>
+  </UDashboardSearch>
+</template>

--- a/packages/vite-hub/src/console/runtime/pages/agents.vue
+++ b/packages/vite-hub/src/console/runtime/pages/agents.vue
@@ -10,5 +10,6 @@ useHead({ title: "Agents · ViteHub Console" });
   <ConsoleApp
     :agents-base="`${appBaseURL}/api/_vitehub/console/agents`"
     :api-base="`${appBaseURL}/api/_vitehub/console/invocations`"
+    :search-base="`${appBaseURL}/api/_vitehub/console/search`"
   />
 </template>

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -24,7 +24,13 @@ export function createConsoleInvocations(projectRoot: string): AgentInvocations 
   const dataDirectory = resolve(projectRoot, ".vitehub/data")
   mkdirSync(dataDirectory, { recursive: true })
   return defineAgentInvocations({
-    metadataContent: ["vitehub.activity.progress"],
+    metadataContent: [
+      "input.messages",
+      "input.prompt",
+      "message.content",
+      "result.text",
+      "vitehub.activity.progress",
+    ],
     store: createLibsqlAgentInvocationStore({
       url: `file:${resolve(dataDirectory, "console.sqlite")}`,
     }),

--- a/packages/vite-hub/src/console/runtime/server/search.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/search.get.ts
@@ -9,7 +9,6 @@ const collectionHandler = defineCollectionHandler(consoleSearch)
 
 export default async function consoleSearchHandler(event: ConsoleRequestEvent): Promise<unknown> {
   assertConsoleRequest(event)
-  // SAFETY: Nitro supplies the H3 event consumed by the Collection handler; the console request contract
-  // is the smaller request subset used for its read-only method guard.
+  // SAFETY: Nitro supplies this H3 event; ConsoleRequestEvent is its smaller read-only guard contract.
   return await collectionHandler(event as never)
 }

--- a/packages/vite-hub/src/console/runtime/server/search.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/search.get.ts
@@ -1,0 +1,15 @@
+import { defineCollectionHandler } from "@vite-hub/source/server"
+
+import { assertConsoleRequest } from "./request.ts"
+import { consoleSearch } from "./search.ts"
+
+import type { ConsoleRequestEvent } from "./request.ts"
+
+const collectionHandler = defineCollectionHandler(consoleSearch)
+
+export default async function consoleSearchHandler(event: ConsoleRequestEvent): Promise<unknown> {
+  assertConsoleRequest(event)
+  // SAFETY: Nitro supplies the H3 event consumed by the Collection handler; the console request contract
+  // is the smaller request subset used for its read-only method guard.
+  return await collectionHandler(event as never)
+}

--- a/packages/vite-hub/src/console/runtime/server/search.ts
+++ b/packages/vite-hub/src/console/runtime/server/search.ts
@@ -43,15 +43,16 @@ const querySchema: StandardSchemaV1<ConsoleSearchQuery, ConsoleSearchQuery> = {
       if (Object(value) !== value || Array.isArray(value)) {
         return { issues: [{ message: "Console search query must be an object." }] }
       }
-      const query = value as Record<string, unknown>
+      const query = Object(value)
       if (Reflect.ownKeys(query).some(key => key !== "search")) {
         return { issues: [{ message: "Console search only accepts a search query." }] }
       }
-      if (query.search === undefined) return { value: {} }
-      if (String(query.search) !== query.search) {
+      const rawSearch = Reflect.get(query, "search")
+      if (rawSearch === undefined) return { value: {} }
+      if (String(rawSearch) !== rawSearch) {
         return { issues: [{ message: "Console search must have one string value." }] }
       }
-      const search = query.search.trim()
+      const search = String(rawSearch).trim()
       if (search.length > 256) {
         return { issues: [{ message: "Console search must be at most 256 characters." }] }
       }
@@ -61,11 +62,11 @@ const querySchema: StandardSchemaV1<ConsoleSearchQuery, ConsoleSearchQuery> = {
 }
 
 function searchableStrings(value: unknown, values: string[], ancestors = new WeakSet<object>()): void {
-  if (typeof value === "string") {
-    values.push(value)
+  if (Object.prototype.toString.call(value) === "[object String]") {
+    values.push(String(value))
     return
   }
-  if (!value || typeof value !== "object" || ancestors.has(value)) return
+  if (!(value instanceof Object) || ancestors.has(value)) return
   ancestors.add(value)
   try {
     for (const child of Array.isArray(value) ? value : Object.values(value)) {
@@ -101,17 +102,15 @@ export const consoleSearch = defineCollection(
   async ({ cursor, limit, query, signal }): Promise<ConsoleSearchRow[]> => {
     signal?.throwIfAborted()
     const invocations = getConsoleInvocations()
-    const page = await invocations.list({
-      ...(cursor ? { cursor } : {}),
-      limit,
-      ...(query.search ? { search: query.search } : {}),
-    })
+    const listQuery: Parameters<typeof invocations.list>[0] = { limit }
+    if (cursor) listQuery.cursor = cursor
+    if (query.search) listQuery.search = query.search
+    const page = await invocations.list(listQuery)
     const rows = await Promise.all(page.invocations.map(async (summary) => {
       const record = query.search ? await invocations.get(summary.id) : undefined
-      return {
-        ...(record ? { excerpt: consoleSearchExcerpt(record, query.search) } : {}),
-        summary,
-      }
+      const row: ConsoleSearchRow = { summary }
+      if (record) row.excerpt = consoleSearchExcerpt(record, query.search)
+      return row
     }))
     signal?.throwIfAborted()
     return rows
@@ -123,14 +122,15 @@ export const consoleSearch = defineCollection(
     maxLimit: 24,
     querySchema,
     transform(row): ConsoleSearchItem {
-      return {
-        ...(row.summary.agentName ? { agentName: row.summary.agentName } : {}),
+      const item: ConsoleSearchItem = {
         context: row.summary.threadId || row.summary.origin || row.summary.channelId || row.summary.id,
-        ...(row.excerpt ? { excerpt: row.excerpt } : {}),
         id: row.summary.id,
         status: row.summary.status,
         updatedAt: row.summary.updatedAt || row.summary.startedAt || row.summary.createdAt,
       }
+      if (row.summary.agentName) item.agentName = row.summary.agentName
+      if (row.excerpt) item.excerpt = row.excerpt
+      return item
     },
   },
 )

--- a/packages/vite-hub/src/console/runtime/server/search.ts
+++ b/packages/vite-hub/src/console/runtime/server/search.ts
@@ -1,0 +1,136 @@
+import { defineCollection } from "@vite-hub/source"
+
+import { getConsoleInvocations } from "./invocations.ts"
+
+import type { AgentInvocationRecord, AgentInvocationSummary } from "@vite-hub/agent"
+import type { StandardSchemaV1 } from "@standard-schema/spec"
+
+export interface ConsoleSearchItem {
+  agentName?: string
+  context: string
+  excerpt?: string
+  id: string
+  status: AgentInvocationSummary["status"]
+  updatedAt: string
+}
+
+interface ConsoleSearchQuery {
+  search?: string
+}
+
+interface ConsoleSearchRow {
+  excerpt?: string
+  summary: AgentInvocationSummary
+}
+
+const cursorSchema: StandardSchemaV1<string, string> = {
+  "~standard": {
+    version: 1,
+    vendor: "vitehub-console",
+    validate(value) {
+      return String(value) === value
+        ? { value }
+        : { issues: [{ message: "Console search cursor must be a string." }] }
+    },
+  },
+}
+
+const querySchema: StandardSchemaV1<ConsoleSearchQuery, ConsoleSearchQuery> = {
+  "~standard": {
+    version: 1,
+    vendor: "vitehub-console",
+    validate(value) {
+      if (Object(value) !== value || Array.isArray(value)) {
+        return { issues: [{ message: "Console search query must be an object." }] }
+      }
+      const query = value as Record<string, unknown>
+      if (Reflect.ownKeys(query).some(key => key !== "search")) {
+        return { issues: [{ message: "Console search only accepts a search query." }] }
+      }
+      if (query.search === undefined) return { value: {} }
+      if (String(query.search) !== query.search) {
+        return { issues: [{ message: "Console search must have one string value." }] }
+      }
+      const search = query.search.trim()
+      if (search.length > 256) {
+        return { issues: [{ message: "Console search must be at most 256 characters." }] }
+      }
+      return { value: search ? { search } : {} }
+    },
+  },
+}
+
+function searchableStrings(value: unknown, values: string[], ancestors = new WeakSet<object>()): void {
+  if (typeof value === "string") {
+    values.push(value)
+    return
+  }
+  if (!value || typeof value !== "object" || ancestors.has(value)) return
+  ancestors.add(value)
+  try {
+    for (const child of Array.isArray(value) ? value : Object.values(value)) {
+      searchableStrings(child, values, ancestors)
+    }
+  }
+  finally {
+    ancestors.delete(value)
+  }
+}
+
+export function consoleSearchExcerpt(record: AgentInvocationRecord, search: string | undefined): string | undefined {
+  if (!search) return
+  const values: string[] = []
+  searchableStrings(record.observations, values)
+  searchableStrings({
+    annotations: record.annotations,
+    error: record.error,
+    origin: record.origin,
+    threadId: record.threadId,
+  }, values)
+  const normalizedSearch = search.toLowerCase()
+  const match = values.find(value => value.toLowerCase().includes(normalizedSearch))
+  if (!match) return
+  const text = match.replace(/\s+/g, " ").trim()
+  const index = text.toLowerCase().indexOf(normalizedSearch)
+  const start = Math.max(0, index - 56)
+  const end = Math.min(text.length, index + search.length + 104)
+  return `${start ? "…" : ""}${text.slice(start, end)}${end < text.length ? "…" : ""}`
+}
+
+export const consoleSearch = defineCollection(
+  async ({ cursor, limit, query, signal }): Promise<ConsoleSearchRow[]> => {
+    signal?.throwIfAborted()
+    const invocations = getConsoleInvocations()
+    const page = await invocations.list({
+      ...(cursor ? { cursor } : {}),
+      limit,
+      ...(query.search ? { search: query.search } : {}),
+    })
+    const rows = await Promise.all(page.invocations.map(async (summary) => {
+      const record = query.search ? await invocations.get(summary.id) : undefined
+      return {
+        ...(record ? { excerpt: consoleSearchExcerpt(record, query.search) } : {}),
+        summary,
+      }
+    }))
+    signal?.throwIfAborted()
+    return rows
+  },
+  {
+    cursor: row => row.summary.cursor,
+    cursorSchema,
+    defaultLimit: 12,
+    maxLimit: 24,
+    querySchema,
+    transform(row): ConsoleSearchItem {
+      return {
+        ...(row.summary.agentName ? { agentName: row.summary.agentName } : {}),
+        context: row.summary.threadId || row.summary.origin || row.summary.channelId || row.summary.id,
+        ...(row.excerpt ? { excerpt: row.excerpt } : {}),
+        id: row.summary.id,
+        status: row.summary.status,
+        updatedAt: row.summary.updatedAt || row.summary.startedAt || row.summary.createdAt,
+      }
+    },
+  },
+)

--- a/packages/vite-hub/src/console/vite.ts
+++ b/packages/vite-hub/src/console/vite.ts
@@ -89,6 +89,7 @@ export function consoleVitePlugin(): Plugin {
             join(consoleRuntimeRoot, "server/invocation.get.js"),
             join(consoleRuntimeRoot, "server/invocations.get.js"),
             join(consoleRuntimeRoot, "server/agents.get.js"),
+            join(consoleRuntimeRoot, "server/search.get.js"),
             join(consoleRuntimeRoot, "server/page.get.js"),
           ].includes(handler?.handler))
         : []
@@ -96,6 +97,7 @@ export function consoleVitePlugin(): Plugin {
         { handler: join(consoleRuntimeRoot, "server/agents.get.js"), route: "/api/_vitehub/console/agents" },
         { handler: join(consoleRuntimeRoot, "server/invocations.get.js"), route: "/api/_vitehub/console/invocations" },
         { handler: join(consoleRuntimeRoot, "server/invocation.get.js"), route: "/api/_vitehub/console/invocations/:id" },
+        { handler: join(consoleRuntimeRoot, "server/search.get.js"), route: "/api/_vitehub/console/search" },
         { handler: join(consoleRuntimeRoot, "server/page.get.js"), route: "/_vitehub" },
         { handler: join(consoleRuntimeRoot, "server/page.get.js"), route: "/_vitehub/**" },
       )

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { runInNewContext } from "node:vm"
 
+import { H3 } from "h3"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { createServer } from "vite"
 
@@ -16,6 +17,8 @@ import { installConsoleAgentDefinitions, installConsoleAgents } from "../src/con
 import { createConsoleInvocations, installConsoleInvocations } from "../src/console/runtime/server/invocations.ts"
 import invocationsHandler from "../src/console/runtime/server/invocations.get.ts"
 import { assertConsoleRequest } from "../src/console/runtime/server/request.ts"
+import searchHandler from "../src/console/runtime/server/search.get.ts"
+import { consoleSearch } from "../src/console/runtime/server/search.ts"
 import { consoleInvocationRootPlugin, consoleVitePlugin } from "../src/console/vite.ts"
 
 import { runAgent } from "@vite-hub/agent"
@@ -103,6 +106,7 @@ describe("Agent invocation console", () => {
         "/api/_vitehub/console/agents",
         "/api/_vitehub/console/invocations",
         "/api/_vitehub/console/invocations/:id",
+        "/api/_vitehub/console/search",
         "/_vitehub",
         "/_vitehub/**",
       ])
@@ -280,6 +284,59 @@ describe("Agent invocation console", () => {
     await expect(invocationsHandler(requestEvent)).resolves.toMatchObject({
       invocations: [{ agentName: "review" }],
     })
+  })
+
+  it("searches session text through the console Collection", async () => {
+    const store = createMemoryAgentInvocationStore()
+    store.create({
+      agentName: "babysitter",
+      createdAt: "2026-08-23T12:00:00.000Z",
+      id: "matching-invocation",
+      observations: [{
+        attributes: { "message.content": "The pull request was merged via the queue." },
+        name: "agent.message",
+        sequence: 1,
+        timestamp: "2026-08-23T12:00:00.000Z",
+        type: "run",
+      }],
+      status: "completed",
+      traceId: "matching-trace",
+      updatedAt: "2026-08-23T12:00:00.000Z",
+    })
+    store.create({
+      agentName: "review",
+      createdAt: "2026-08-23T11:00:00.000Z",
+      id: "other-invocation",
+      observations: [],
+      status: "completed",
+      traceId: "other-trace",
+      updatedAt: "2026-08-23T11:00:00.000Z",
+    })
+    installConsoleInvocationFallback(defineAgentInvocations({ store }), process.cwd())
+
+    const query = await consoleSearch.parseQuery({ search: "merged via" })
+    await expect(consoleSearch.page({ query })).resolves.toEqual({
+      items: [{
+        agentName: "babysitter",
+        context: "matching-invocation",
+        excerpt: "The pull request was merged via the queue.",
+        id: "matching-invocation",
+        status: "completed",
+        updatedAt: "2026-08-23T12:00:00.000Z",
+      }],
+      nextCursor: null,
+    })
+
+    const app = new H3().get("/search", searchHandler as never)
+    const response = await app.request("/search?limit=12&search=merged%20via")
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      items: [expect.objectContaining({ id: "matching-invocation" })],
+      nextCursor: null,
+    })
+
+    const invalidResponse = await app.request("/search?search=one&search=two")
+    expect(invalidResponse.status).toBe(400)
   })
 
   it("accepts persisted Agent names up to the metadata limit", async () => {
@@ -512,6 +569,9 @@ describe("Agent invocation console", () => {
       const reader = createConsoleInvocations(projectRoot)
       const invocation = await reader.getByRunId("console-cross-realm")
       expect(invocation).toMatchObject({ status: "completed" })
+      await expect(reader.list({ search: "persisted" })).resolves.toMatchObject({
+        invocations: [expect.objectContaining({ id: invocation?.id })],
+      })
       expect(invocation?.observations).toContainEqual(expect.objectContaining({
         attributes: expect.objectContaining({
           "vitehub.agent.configuration": expect.objectContaining({

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -327,6 +327,7 @@ describe("Agent invocation console", () => {
       nextCursor: null,
     })
 
+    // SAFETY: the test mounts the generated Nitro handler on the equivalent H3 route contract.
     const app = new H3().get("/search", searchHandler as never)
     const response = await app.request("/search?limit=12&search=merged%20via")
     expect(response.status).toBe(200)

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
       "src/console/runtime/server/invocation.get.ts",
       "src/console/runtime/server/invocations.get.ts",
       "src/console/runtime/server/page.get.ts",
+      "src/console/runtime/server/search.get.ts",
     ],
     exports: {
       exclude: ["bin"],
@@ -71,6 +72,7 @@ export default defineConfig({
         delete exports["./console/runtime/server/invocation.get"]
         delete exports["./console/runtime/server/invocations.get"]
         delete exports["./console/runtime/server/page.get"]
+        delete exports["./console/runtime/server/search.get"]
         return {
           ...exports,
           "./ui/styles.css": "./dist/ui/styles.css",


### PR DESCRIPTION
## What changed

- Open a full Nuxt UI dashboard search palette from the console sidebar or Cmd/Ctrl+K, with Agent and session result groups.
- Search every Agent session through a typed Sources Collection and return a focused text excerpt without exposing raw observations in the search response.
- Persist searchable human input/output observation fields in the console journal and include retained observations in memory and SQLite invocation search.
- Version and backfill SQLite search indexes so existing retained session text becomes searchable after upgrade.

## Why

The sidebar search was constrained to the session list and metadata, so phrases from prompts, messages, progress, and final output could not find the session that contained them. The console now uses the same full-palette interaction as the Nuxt UI dashboard template and puts session search behind the ViteHub Sources boundary.

## Verification

- `corepack pnpm --filter @vite-hub/agent exec vp test test/invocations.test.ts` (58 passed)
- `corepack pnpm --filter vite-hub exec vp test test/console.test.ts` (27 passed, no type errors)
- `corepack pnpm vp run -t vite-hub#build`
- `corepack pnpm exec vp lint` on all changed source and test files
- `git diff --check`

The shared browser preview client could not navigate or capture a snapshot in this run. The standalone console assets and API fixture served locally, and the packed UI build completed successfully. Existing journals can only index content they previously retained; the expanded console metadata policy applies to new observations.