### PR TITLE
feat(agent): package opt-in Codex runtime

### DIFF
--- a/docs/content/docs/agents/agent-drivers.md
+++ b/docs/content/docs/agents/agent-drivers.md
@@ -68,6 +68,12 @@ The `model` value may also be a compatible AI SDK model or an invocation-time ca
 
 The built-in Drivers reuse T3 Code's normalized Codex and Claude Code runtime while ViteHub owns Agent Definitions, Capabilities, Workspaces, Invocations, and public lifecycle events.
 
+Install the Codex CLI as a project dependency when you select the Codex Driver:
+
+```sh
+pnpm add @openai/codex@0.149.1
+```
+
 ```ts [server/agents/review/agent.ts]
 import { defineAgent } from 'vite-hub/agent'
 
@@ -82,7 +88,7 @@ export default defineAgent({
 })
 ```
 
-Provider Drivers require a local Node.js host with the matching CLI and credentials available to the process. Provider Workspaces also require a POSIX host. Each invocation receives a temporary working directory, optional Workspace files, `AGENTS.md` or `CLAUDE.md`, and Capability tools through a private loopback MCP server. Successful write-mode runs commit through Workspace rules; failed and cancelled runs do not write back.
+Provider Drivers require a local Node.js host with the matching CLI and credentials available to the process. For Codex, ViteHub resolves an installed `@openai/codex` package without requiring a global executable. Production self-hosted Node builds on macOS and Linux copy the CLI wrapper and only the build host's native optional package into `.output/server/node_modules`, so build on the same OS and CPU architecture as the deployment host. If the package is absent, ViteHub falls back to `codex` on the host `PATH`; it does not download a runtime during build or startup. Provider Workspaces also require a POSIX host. Each invocation receives a temporary working directory, optional Workspace files, `AGENTS.md` or `CLAUDE.md`, and Capability tools through a private loopback MCP server. Successful write-mode runs commit through Workspace rules; failed and cancelled runs do not write back.
 
 Provider runtime cursors resume a thread while the Agent Definition process remains active. Chat-backed cursors are also partitioned by origin, invoker, and resolved Chat Session, so a new session cannot inherit provider context from an earlier one. Cursors are process-local and do not survive restarts or resume on another worker; use the Agent Invocation message history as the durable conversation boundary.
 

--- a/docs/content/docs/getting-started/installation.md
+++ b/docs/content/docs/getting-started/installation.md
@@ -63,9 +63,13 @@ import { defineWorkspace } from "vite-hub/workspace"
 ```
 
 Install third-party model providers and chat adapters separately. Built-in coding
-providers use the provider runtime pinned by ViteHub. The distribution includes
-the Workflow DevKit runtime and builders for Vercel Workflow; install other
-provider SDKs only when you use them.
+providers use the provider runtime pinned by ViteHub, but ViteHub does not install
+the large Codex native binary for applications that do not use it. Add
+`@openai/codex@0.149.1` when you select the Codex Driver. Self-hosted Node builds
+on macOS and Linux then package only the build host's OS/CPU payload; build on
+the same OS and CPU architecture as the deployment host. The distribution includes the
+Workflow DevKit runtime and builders for Vercel Workflow; install other provider
+SDKs only when you use them.
 
 Until T3 publishes the provider runtime on npm, pnpm consumers using a built-in coding provider must set `blockExoticSubdeps: false` in `pnpm-workspace.yaml`; ViteHub pins an exact pkg.pr.new tarball rather than a moving branch.
 

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -24,7 +24,13 @@ pnpm add @vite-hub/agent @vite-hub/workspace ai
 
 Add the AI SDK model provider you pass to `model`.
 
-The built-in `"codex"` and `"claude-code"` drivers use ViteHub's pinned T3 provider runtime. The provider runtime starts the corresponding local CLI, so its credentials and executable must be available to the host process.
+The built-in `"codex"` and `"claude-code"` drivers use ViteHub's pinned T3 provider runtime. Add Codex only when an Agent uses it:
+
+```sh
+pnpm add @openai/codex@0.149.1
+```
+
+ViteHub resolves that project dependency directly. Production self-hosted Node builds on macOS and Linux copy only the build host's OS/CPU payload, so build on the same OS and CPU architecture as the deployment host. Without the dependency, the Codex Driver keeps using `codex` from the host `PATH`. Claude Code continues to use its host executable. Provider credentials must be available to the host process in either case.
 
 Until T3 publishes the runtime on npm, pnpm consumers must set `blockExoticSubdeps: false` because the pinned runtime is an exact pkg.pr.new tarball.
 

--- a/packages/agent/src/internal/codex-runtime-package.ts
+++ b/packages/agent/src/internal/codex-runtime-package.ts
@@ -22,7 +22,13 @@ function isPackageResolutionMiss(error: unknown): boolean {
 
 export function resolveInstalledCodexExecutable(resolveFrom?: string, platform = process.platform): string | undefined {
   if (platform === "win32") return
-  const appRoot = typeof __VITEHUB_AGENT_APP_ROOT__ === "string" ? __VITEHUB_AGENT_APP_ROOT__ : undefined
+  let appRoot: string | undefined
+  try {
+    appRoot = __VITEHUB_AGENT_APP_ROOT__
+  }
+  catch {
+    // The Vite integration replaces this global. Direct imports keep the existing cwd fallback.
+  }
   const candidates = resolveFrom
     ? [resolveFrom]
     : [appRoot && join(appRoot, "package.json"), join(process.cwd(), "package.json"), import.meta.url].filter((candidate): candidate is string => Boolean(candidate))

--- a/packages/agent/src/internal/codex-runtime-package.ts
+++ b/packages/agent/src/internal/codex-runtime-package.ts
@@ -13,6 +13,7 @@ const codexPlatformPackages: Record<string, string> = {
 }
 
 function isPackageResolutionMiss(error: unknown): boolean {
+  // SAFETY: Node module resolution failures expose their stable error code through ErrnoException.
   const code = (error as NodeJS.ErrnoException | undefined)?.code
   return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND" || code === "ERR_PACKAGE_PATH_NOT_EXPORTED"
 }

--- a/packages/agent/src/internal/codex-runtime-package.ts
+++ b/packages/agent/src/internal/codex-runtime-package.ts
@@ -1,0 +1,70 @@
+import { createRequire } from "node:module"
+import { join } from "node:path"
+
+import type { NodeRuntimePackage } from "@vite-hub/internal/build/vercel-runtime-packages"
+
+const codexPackageName = "@openai/codex"
+
+const codexPlatformPackages: Record<string, string> = {
+  "darwin-arm64": "@openai/codex-darwin-arm64",
+  "darwin-x64": "@openai/codex-darwin-x64",
+  "linux-arm64": "@openai/codex-linux-arm64",
+  "linux-x64": "@openai/codex-linux-x64",
+}
+
+function isPackageResolutionMiss(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | undefined)?.code
+  return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND" || code === "ERR_PACKAGE_PATH_NOT_EXPORTED"
+}
+
+export function resolveInstalledCodexExecutable(resolveFrom?: string, platform = process.platform): string | undefined {
+  if (platform === "win32") return
+  const candidates = resolveFrom
+    ? [resolveFrom]
+    : [join(process.cwd(), "package.json"), import.meta.url]
+  for (const candidate of candidates) {
+    try {
+      return createRequire(candidate).resolve(`${codexPackageName}/bin/codex.js`)
+    }
+    catch (error) {
+      if (!isPackageResolutionMiss(error)) throw error
+    }
+  }
+}
+
+export function resolveCodexRuntimePackages(options: {
+  arch?: string
+  platform?: string
+  rootDir: string
+}): NodeRuntimePackage[] {
+  const resolveFrom = join(options.rootDir, "package.json")
+  const resolver = createRequire(resolveFrom)
+  let packageJsonPath: string
+  try {
+    packageJsonPath = resolver.resolve(`${codexPackageName}/package.json`)
+  }
+  catch (error) {
+    if (isPackageResolutionMiss(error)) return []
+    throw error
+  }
+
+  const platform = options.platform ?? process.platform
+  const arch = options.arch ?? process.arch
+  const platformPackage = codexPlatformPackages[`${platform}-${arch}`]
+  if (!platformPackage) {
+    throw new Error(`[vitehub] Cannot package ${codexPackageName} for ${platform}/${arch}. Self-hosted Codex builds support macOS and Linux on arm64 or x64.`)
+  }
+
+  try {
+    createRequire(packageJsonPath).resolve(`${platformPackage}/package.json`)
+  }
+  catch (error) {
+    if (!isPackageResolutionMiss(error)) throw error
+    throw new Error(`[vitehub] ${codexPackageName} is installed, but its ${platformPackage} optional dependency is missing. Reinstall dependencies on the deployment target before building.`)
+  }
+
+  return [
+    { name: codexPackageName, resolveFrom },
+    { name: platformPackage, resolveFrom: packageJsonPath },
+  ]
+}

--- a/packages/agent/src/internal/codex-runtime-package.ts
+++ b/packages/agent/src/internal/codex-runtime-package.ts
@@ -5,6 +5,8 @@ import type { NodeRuntimePackage } from "@vite-hub/internal/build/vercel-runtime
 
 const codexPackageName = "@openai/codex"
 
+declare const __VITEHUB_AGENT_APP_ROOT__: string | undefined
+
 const codexPlatformPackages: Record<string, string> = {
   "darwin-arm64": "@openai/codex-darwin-arm64",
   "darwin-x64": "@openai/codex-darwin-x64",
@@ -20,9 +22,10 @@ function isPackageResolutionMiss(error: unknown): boolean {
 
 export function resolveInstalledCodexExecutable(resolveFrom?: string, platform = process.platform): string | undefined {
   if (platform === "win32") return
+  const appRoot = typeof __VITEHUB_AGENT_APP_ROOT__ === "string" ? __VITEHUB_AGENT_APP_ROOT__ : undefined
   const candidates = resolveFrom
     ? [resolveFrom]
-    : [join(process.cwd(), "package.json"), import.meta.url]
+    : [appRoot && join(appRoot, "package.json"), join(process.cwd(), "package.json"), import.meta.url].filter((candidate): candidate is string => Boolean(candidate))
   for (const candidate of candidates) {
     try {
       return createRequire(candidate).resolve(`${codexPackageName}/bin/codex.js`)

--- a/packages/agent/src/provider-agent.ts
+++ b/packages/agent/src/provider-agent.ts
@@ -16,6 +16,7 @@ import { composeInstructionDocument } from "./instruction-composition.ts"
 import { agentInvocationCallbackContextValues } from "./invocation-context.ts"
 import { colocatedAgentSkillsContextKey } from "./internal/colocated-agent-skills.ts"
 import { defaultAgentProviderPermissions } from "./internal/agent-driver.ts"
+import { resolveInstalledCodexExecutable } from "./internal/codex-runtime-package.ts"
 import { updateAgentTelemetryConfiguration } from "./internal/agent-telemetry.ts"
 import { agentOutputInstructions } from "./internal/agent-structured-output.ts"
 import { registerAgentInvocationInputHandler } from "./internal/agent-invocation-control.ts"
@@ -1127,8 +1128,14 @@ async function* runProvider<
       await workspaceCleanup
       await cleanupRoot()
     }
+    const codexExecutable = options.provider === "codex" ? resolveInstalledCodexExecutable() : undefined
     runtime = await waitForProviderOperation(
-      createProviderRuntime({ cwd: root, environment: providerEnvironment(providerEnvironmentOverrides), provider: options.provider }),
+      createProviderRuntime({
+        cwd: root,
+        environment: providerEnvironment(providerEnvironmentOverrides),
+        provider: options.provider,
+        ...(codexExecutable ? { settings: { binaryPath: codexExecutable } } : {}),
+      }),
       effectiveSignal,
       async lateRuntime => {
         try {

--- a/packages/agent/src/provider-agent.ts
+++ b/packages/agent/src/provider-agent.ts
@@ -1129,13 +1129,16 @@ async function* runProvider<
       await cleanupRoot()
     }
     const codexExecutable = options.provider === "codex" ? resolveInstalledCodexExecutable() : undefined
+    const runtimeOptions: Parameters<typeof createProviderRuntime>[0] = {
+      cwd: root,
+      environment: providerEnvironment(providerEnvironmentOverrides),
+      provider: options.provider,
+    }
+    const configuredRuntimeOptions: Parameters<typeof createProviderRuntime>[0] = codexExecutable
+      ? { ...runtimeOptions, settings: { binaryPath: codexExecutable } }
+      : runtimeOptions
     runtime = await waitForProviderOperation(
-      createProviderRuntime({
-        cwd: root,
-        environment: providerEnvironment(providerEnvironmentOverrides),
-        provider: options.provider,
-        ...(codexExecutable ? { settings: { binaryPath: codexExecutable } } : {}),
-      }),
+      createProviderRuntime(configuredRuntimeOptions),
       effectiveSignal,
       async lateRuntime => {
         try {

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -730,29 +730,30 @@ function mergeNitroPlugins(nitro: NitroConfig, plugins: string[]): NitroConfig {
   return { ...nitro, plugins: [...existingPlugins, ...plugins] }
 }
 
-function installAgentProviderRuntimePackages(nitro: NitroConfig): NitroConfig {
+function installAgentProviderRuntimePackages(nitro: NitroConfig, rootDir: string): NitroConfig {
   const modules = Array.isArray(nitro.modules) ? nitro.modules : []
-  if (modules.includes(agentProviderRuntimePackagesNitroModule)) return nitro
   return {
     ...nitro,
-    modules: [agentProviderRuntimePackagesNitroModule, ...modules],
+    modules: [createAgentProviderRuntimePackagesNitroModule(rootDir), ...modules],
   }
 }
 
-function agentProviderRuntimePackagesNitroModule(nitro: {
+function createAgentProviderRuntimePackagesNitroModule(rootDir: string): (nitro: {
   hooks: { hook: (name: "compiled", callback: () => Promise<void>) => void }
-  options: { dev?: boolean, output: { serverDir: string }, preset?: string | null, rootDir: string }
-}): void {
-  if (nitro.options.dev !== false || deploymentPresetFromNitro(nitro.options.preset) !== "node") return
-  nitro.hooks.hook("compiled", async () => {
-    const packages = resolveCodexRuntimePackages({ rootDir: nitro.options.rootDir })
-    if (!packages.length) return
-    await copyNodeRuntimePackages({
-      outputNodeModules: join(nitro.options.output.serverDir, "node_modules"),
-      packages,
-      rootDir: nitro.options.rootDir,
+  options: { dev?: boolean, output: { serverDir: string }, preset?: string | null }
+}) => void {
+  return (nitro) => {
+    if (nitro.options.dev !== false || deploymentPresetFromNitro(nitro.options.preset) !== "node") return
+    nitro.hooks.hook("compiled", async () => {
+      const packages = resolveCodexRuntimePackages({ rootDir })
+      if (!packages.length) return
+      await copyNodeRuntimePackages({
+        outputNodeModules: join(nitro.options.output.serverDir, "node_modules"),
+        packages,
+        rootDir,
+      })
     })
-  })
+  }
 }
 
 function normalizeNitroRoute(route: string): string {
@@ -2850,7 +2851,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
         ],
       ))
       const mergedNitro = nitroContext && hasScheduledAgents && !denoOutput
-        ? installAgentProviderRuntimePackages(mergedAgentNitro)
+        ? installAgentProviderRuntimePackages(mergedAgentNitro, root)
         : mergedAgentNitro
       if (nitroContext) {
         const replacement = isRecord(mergedNitro.replace) ? mergedNitro.replace : {}

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -25,7 +25,7 @@ import { agentRouteUsesParam, defaultAgentChatRoute, normalizeAgentRoute } from 
 import { readColocatedAgentInstructions } from "./vite/colocated-agent-instructions.ts"
 import { readColocatedAgentSkills } from "./vite/colocated-agent-skills.ts"
 
-import type { Plugin, ResolvedConfig } from "vite"
+import type { Plugin, ResolvedConfig, UserConfig } from "vite"
 import type { CloudflareAgentStateMigration, CloudflareAgentStateRollupTarget, CloudflareAgentStateTarget } from "./cloudflare.ts"
 import type { AgentModuleOptions, DiscoveredAgentDefinition, ResolvedAgentModuleOptions } from "./types.ts"
 
@@ -2792,6 +2792,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       const generatedRoot = resolveViteHubGeneratedRoot(config)
       const nitroContext = hasNitroConfigContext(config)
       const hasHostedAgents = Boolean(resolved && hasHostedAgentDefinitions(root, serverDirs))
+      const hasScheduledAgents = Boolean(resolved && discoverScheduledAgentDefinitions(root, serverDirs).length)
       const denoOutput = resolved && resolved.runtime === "deno"
       const installCloudflareState = hasHostedAgents && !denoOutput && shouldInstallCloudflareAgentState(resolved, config, environment?.command)
       installsCloudflareState ||= installCloudflareState
@@ -2848,7 +2849,7 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
           ...(installProcessDiscordGateway ? [join(generatedRoot, generatedAgentDiscordGatewayPlugin)] : []),
         ],
       ))
-      const mergedNitro = nitroContext && hasHostedAgents && !denoOutput
+      const mergedNitro = nitroContext && hasScheduledAgents && !denoOutput
         ? installAgentProviderRuntimePackages(mergedAgentNitro)
         : mergedAgentNitro
       if (nitroContext) {
@@ -2858,33 +2859,32 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
           ...replacement,
         }
       }
-      return {
-        ...(typeof agent !== "undefined" ? { agent } : {}),
+      const result: UserConfig & { nitro?: NitroConfig } = {
         define: {
           __VITEHUB_AGENT_APP_ROOT__: JSON.stringify(root),
           ...config.define,
         },
-        ...(nitroHandlers.length
-          ? {
-              build: mergeBuildExternal(config as BuildWithRolldownOptions, optionalMessageAdapterRuntimeExternals),
-            }
-          : {}),
-        ...(nitroContext || nitroHandlers.length || installCloudflareState || installProcessDiscordGateway
-          ? {
-              nitro: mergedNitro,
-            }
-          : {}),
         server: {
           watch: {
             ignored: mergeGeneratedViteHubWatchIgnored(config.server?.watch?.ignored),
           },
         },
       }
+      if (agent !== undefined) result.agent = agent
+      if (nitroHandlers.length) {
+        // SAFETY: Vite's build options accept the Rolldown external field merged by this boundary.
+        result.build = mergeBuildExternal(config as BuildWithRolldownOptions, optionalMessageAdapterRuntimeExternals)
+      }
+      if (nitroContext || nitroHandlers.length || installCloudflareState || installProcessDiscordGateway) {
+        result.nitro = mergedNitro
+      }
+      return result
     },
     async configResolved(config) {
       resolved = config
       agent = config.agent ?? agent
       installsCloudflareState ||= shouldInstallCloudflareAgentState(normalizeAgentOptions(agent), config)
+      // SAFETY: ViteHub's config hook adds this private server-directory symbol before config resolution.
       serverDirs = (config as typeof config & { [VITEHUB_SERVER_DIRS]?: string[] })[VITEHUB_SERVER_DIRS] ?? serverDirs
       const generatedRoot = resolveViteHubGeneratedRoot(config)
       runtimeCapabilities = await resolveGeneratedAgentRuntimeCapabilities(

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -2851,6 +2851,13 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
       const mergedNitro = nitroContext && hasHostedAgents && !denoOutput
         ? installAgentProviderRuntimePackages(mergedAgentNitro)
         : mergedAgentNitro
+      if (nitroContext) {
+        const replacement = isRecord(mergedNitro.replace) ? mergedNitro.replace : {}
+        mergedNitro.replace = {
+          __VITEHUB_AGENT_APP_ROOT__: JSON.stringify(root),
+          ...replacement,
+        }
+      }
       return {
         ...(typeof agent !== "undefined" ? { agent } : {}),
         define: {

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -4,7 +4,8 @@ import { dirname, join, relative, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 
 import { writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
-import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
+import { copyNodeRuntimePackages, copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
+import { deploymentPresetFromNitro } from "@vite-hub/internal/deployment"
 import { createNoExternalMerger, hasNitroConfigContext, isServerEnvironment, mergeGeneratedViteHubWatchIgnored, resolveViteHubGeneratedRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import { getHostingProvider } from "@vite-hub/internal/hosting"
 import { markdownTemplateMaterializationPath } from "@vite-hub/markdown-template/vite"
@@ -18,6 +19,7 @@ import {
 import { normalizeAgentOptions } from "./config.ts"
 import { discoverAgentDefinitions, discoverAgentEvalFiles } from "./discovery.ts"
 import { removeAgentEvaliteConfig, resolveAgentEvalOptions, writeAgentEvaliteConfig } from "./internal/evalite-config.ts"
+import { resolveCodexRuntimePackages } from "./internal/codex-runtime-package.ts"
 import { isPortableAgentWorkflowCapability } from "./internal/final-channel-output.ts"
 import { agentRouteUsesParam, defaultAgentChatRoute, normalizeAgentRoute } from "./internal/routes.ts"
 import { readColocatedAgentInstructions } from "./vite/colocated-agent-instructions.ts"
@@ -726,6 +728,31 @@ function mergeNitroPlugins(nitro: NitroConfig, plugins: string[]): NitroConfig {
   if (plugins.length === 0) return nitro
   const existingPlugins = Array.isArray(nitro.plugins) ? nitro.plugins : []
   return { ...nitro, plugins: [...existingPlugins, ...plugins] }
+}
+
+function installAgentProviderRuntimePackages(nitro: NitroConfig): NitroConfig {
+  const modules = Array.isArray(nitro.modules) ? nitro.modules : []
+  if (modules.includes(agentProviderRuntimePackagesNitroModule)) return nitro
+  return {
+    ...nitro,
+    modules: [agentProviderRuntimePackagesNitroModule, ...modules],
+  }
+}
+
+function agentProviderRuntimePackagesNitroModule(nitro: {
+  hooks: { hook: (name: "compiled", callback: () => Promise<void>) => void }
+  options: { dev?: boolean, output: { serverDir: string }, preset?: string | null, rootDir: string }
+}): void {
+  if (nitro.options.dev !== false || deploymentPresetFromNitro(nitro.options.preset) !== "node") return
+  nitro.hooks.hook("compiled", async () => {
+    const packages = resolveCodexRuntimePackages({ rootDir: nitro.options.rootDir })
+    if (!packages.length) return
+    await copyNodeRuntimePackages({
+      outputNodeModules: join(nitro.options.output.serverDir, "node_modules"),
+      packages,
+      rootDir: nitro.options.rootDir,
+    })
+  })
 }
 
 function normalizeNitroRoute(route: string): string {
@@ -2814,13 +2841,16 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
             getCloudflareStateImport(agent, frameworkOptions),
           )
         : cloneNitroConfig((config as { nitro?: unknown }).nitro)
-      const mergedNitro = (nitroContext ? mergeAgentNitroExternals : cloneNitroConfig)(mergeNitroPlugins(
+      const mergedAgentNitro = (nitroContext ? mergeAgentNitroExternals : cloneNitroConfig)(mergeNitroPlugins(
         mergeNitroHandlers(nitro, nitroHandlers),
         [
           ...(installWebhookQueue ? [join(generatedRoot, generatedAgentWebhookQueuePlugin)] : []),
           ...(installProcessDiscordGateway ? [join(generatedRoot, generatedAgentDiscordGatewayPlugin)] : []),
         ],
       ))
+      const mergedNitro = nitroContext && hasHostedAgents && !denoOutput
+        ? installAgentProviderRuntimePackages(mergedAgentNitro)
+        : mergedAgentNitro
       return {
         ...(typeof agent !== "undefined" ? { agent } : {}),
         ...(nitroHandlers.length

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -2853,6 +2853,10 @@ export function hubAgent(options?: AgentModuleOptions): AgentVitePlugin {
         : mergedAgentNitro
       return {
         ...(typeof agent !== "undefined" ? { agent } : {}),
+        define: {
+          __VITEHUB_AGENT_APP_ROOT__: JSON.stringify(root),
+          ...config.define,
+        },
         ...(nitroHandlers.length
           ? {
               build: mergeBuildExternal(config as BuildWithRolldownOptions, optionalMessageAdapterRuntimeExternals),

--- a/packages/agent/test/codex-runtime-package.test.ts
+++ b/packages/agent/test/codex-runtime-package.test.ts
@@ -40,6 +40,20 @@ describe("Codex runtime package", () => {
     ])
   })
 
+  it("resolves Codex from an app below the process working directory", async () => {
+    const monorepoRoot = await mkdtemp(join(tmpdir(), "vitehub-codex-monorepo-"))
+    tempDirs.push(monorepoRoot)
+    const appRoot = join(monorepoRoot, "apps", "web")
+    await mkdir(appRoot, { recursive: true })
+    await writeFile(join(appRoot, "package.json"), "{}\n")
+    const packageDir = join(appRoot, "node_modules", "@openai", "codex")
+    await mkdir(join(packageDir, "bin"), { recursive: true })
+    await writeFile(join(packageDir, "package.json"), JSON.stringify({ name: "@openai/codex", version: "0.149.1" }))
+    await writeFile(join(packageDir, "bin", "codex.js"), "#!/usr/bin/env node\n")
+
+    expect(resolveInstalledCodexExecutable(join(appRoot, "package.json"))).toBe(join(packageDir, "bin", "codex.js"))
+  })
+
   it("leaves the host Codex executable as the fallback when the package is absent", async () => {
     const rootDir = await mkdtemp(join(tmpdir(), "vitehub-codex-runtime-absent-"))
     tempDirs.push(rootDir)

--- a/packages/agent/test/codex-runtime-package.test.ts
+++ b/packages/agent/test/codex-runtime-package.test.ts
@@ -1,0 +1,71 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+import { resolveCodexRuntimePackages, resolveInstalledCodexExecutable } from "../src/internal/codex-runtime-package.ts"
+
+const tempDirs: string[] = []
+
+async function createProject(options: { platformPackage?: boolean } = {}) {
+  const rootDir = await mkdtemp(join(tmpdir(), "vitehub-codex-runtime-"))
+  tempDirs.push(rootDir)
+  await writeFile(join(rootDir, "package.json"), "{}\n")
+  const packageDir = join(rootDir, "node_modules", "@openai", "codex")
+  await mkdir(join(packageDir, "bin"), { recursive: true })
+  await writeFile(join(packageDir, "package.json"), JSON.stringify({ name: "@openai/codex", version: "0.149.1" }))
+  await writeFile(join(packageDir, "bin", "codex.js"), "#!/usr/bin/env node\n")
+  if (options.platformPackage) {
+    const platformPackageDir = join(rootDir, "node_modules", "@openai", "codex-linux-x64")
+    await mkdir(platformPackageDir, { recursive: true })
+    await writeFile(join(platformPackageDir, "package.json"), JSON.stringify({ name: "@openai/codex", version: "0.149.1-linux-x64" }))
+  }
+  return { packageDir, rootDir }
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
+})
+
+describe("Codex runtime package", () => {
+  it("uses an installed Codex CLI and selects only the deployment platform package", async () => {
+    const { packageDir, rootDir } = await createProject({ platformPackage: true })
+
+    expect(resolveInstalledCodexExecutable(pathToFileURL(join(rootDir, "server.mjs")).href)).toBe(join(packageDir, "bin", "codex.js"))
+    expect(resolveCodexRuntimePackages({ arch: "x64", platform: "linux", rootDir })).toEqual([
+      { name: "@openai/codex", resolveFrom: join(rootDir, "package.json") },
+      { name: "@openai/codex-linux-x64", resolveFrom: join(packageDir, "package.json") },
+    ])
+  })
+
+  it("leaves the host Codex executable as the fallback when the package is absent", async () => {
+    const rootDir = await mkdtemp(join(tmpdir(), "vitehub-codex-runtime-absent-"))
+    tempDirs.push(rootDir)
+    await writeFile(join(rootDir, "package.json"), "{}\n")
+
+    expect(resolveInstalledCodexExecutable(pathToFileURL(join(rootDir, "server.mjs")).href)).toBeUndefined()
+    expect(resolveCodexRuntimePackages({ rootDir })).toEqual([])
+  })
+
+  it("keeps the host Codex command fallback on Windows", async () => {
+    const { rootDir } = await createProject({ platformPackage: true })
+
+    expect(resolveInstalledCodexExecutable(pathToFileURL(join(rootDir, "server.mjs")).href, "win32")).toBeUndefined()
+  })
+
+  it("fails when the installed Codex package lacks the selected native payload", async () => {
+    const { rootDir } = await createProject()
+
+    expect(() => resolveCodexRuntimePackages({ arch: "x64", platform: "linux", rootDir }))
+      .toThrow("@openai/codex-linux-x64 optional dependency is missing")
+  })
+
+  it("fails explicitly for unsupported deployment targets", async () => {
+    const { rootDir } = await createProject({ platformPackage: true })
+
+    expect(() => resolveCodexRuntimePackages({ arch: "riscv64", platform: "linux", rootDir }))
+      .toThrow("Cannot package @openai/codex for linux/riscv64")
+  })
+})

--- a/packages/agent/test/provider-agent.test.ts
+++ b/packages/agent/test/provider-agent.test.ts
@@ -160,10 +160,9 @@ describe("Provider Agent Driver", () => {
   ] as const)("maps %s to its provider runtime mode", async (_label, providerName, permissions, runtimeMode) => {
     const threadId = `thread-permissions-${providerName}-${permissions ?? "omitted"}`
     const provider = runtime(threadId, [event("turn.completed", threadId, { state: "completed" }, { turnId: "turn-1" })])
-    const adapter = createProviderAgentAdapter({
-      ...(permissions ? { permissions } : {}),
-      provider: providerName,
-    })
+    const providerOptions: { permissions?: typeof permissions, provider: typeof providerName } = { provider: providerName }
+    if (permissions) providerOptions.permissions = permissions
+    const adapter = createProviderAgentAdapter(providerOptions)
 
     // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
     await adapter.generate(context(threadId) as never)

--- a/packages/agent/test/provider-agent.test.ts
+++ b/packages/agent/test/provider-agent.test.ts
@@ -9,8 +9,10 @@ import { createTraceEventLog, traceEventsToOpenTelemetrySpans } from "@vite-hub/
 // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
 const providerRuntimes = vi.hoisted(() => [] as Array<Record<string, unknown>>)
 const createProviderRuntime = vi.hoisted(() => vi.fn(async (_options: { environment?: Record<string, string> }) => providerRuntimes.shift()))
+const resolveInstalledCodexExecutable = vi.hoisted(() => vi.fn<() => string | undefined>(() => "/app/node_modules/@openai/codex/bin/codex.js"))
 
 vi.mock("@t3tools/provider-runtime", () => ({ createProviderRuntime }))
+vi.mock("../src/internal/codex-runtime-package.ts", () => ({ resolveInstalledCodexExecutable }))
 
 import { createProviderAgentAdapter, localWorkspaceHost } from "../src/provider-agent.ts"
 import { codexDriver, defineAgent, runAgent } from "../src/index.ts"
@@ -111,10 +113,21 @@ describe("Provider Agent Driver", () => {
 
     expect(createProviderRuntime).toHaveBeenLastCalledWith(expect.objectContaining({
       environment: expect.objectContaining({ PROVIDER_SELECTED: "selected" }),
+      settings: { binaryPath: "/app/node_modules/@openai/codex/bin/codex.js" },
     }))
     expect(createProviderRuntime).toHaveBeenCalled()
     expect(createProviderRuntime.mock.calls.at(-1)![0].environment).not.toHaveProperty("VITEHUB_UNRELATED_SECRET")
     vi.unstubAllEnvs()
+  })
+
+  it("keeps the host Codex executable fallback when the package is absent", async () => {
+    const threadId = "thread-host-codex"
+    runtime(threadId, [event("turn.completed", threadId, { state: "completed" }, { turnId: "turn-1" })])
+    resolveInstalledCodexExecutable.mockReturnValueOnce(undefined)
+
+    await createProviderAgentAdapter({ provider: "codex" }).generate(context(threadId) as never)
+
+    expect(createProviderRuntime).toHaveBeenLastCalledWith(expect.not.objectContaining({ settings: expect.anything() }))
   })
 
   it("does not request another provider event after the turn completes", async () => {

--- a/packages/agent/test/provider-agent.test.ts
+++ b/packages/agent/test/provider-agent.test.ts
@@ -116,7 +116,9 @@ describe("Provider Agent Driver", () => {
       settings: { binaryPath: "/app/node_modules/@openai/codex/bin/codex.js" },
     }))
     expect(createProviderRuntime).toHaveBeenCalled()
-    expect(createProviderRuntime.mock.calls.at(-1)![0].environment).not.toHaveProperty("VITEHUB_UNRELATED_SECRET")
+    const lastRuntimeCall = createProviderRuntime.mock.lastCall
+    expect(lastRuntimeCall).toBeDefined()
+    expect(lastRuntimeCall?.[0].environment).not.toHaveProperty("VITEHUB_UNRELATED_SECRET")
     vi.unstubAllEnvs()
   })
 
@@ -125,6 +127,7 @@ describe("Provider Agent Driver", () => {
     runtime(threadId, [event("turn.completed", threadId, { state: "completed" }, { turnId: "turn-1" })])
     resolveInstalledCodexExecutable.mockReturnValueOnce(undefined)
 
+    // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
     await createProviderAgentAdapter({ provider: "codex" }).generate(context(threadId) as never)
 
     expect(createProviderRuntime).toHaveBeenLastCalledWith(expect.not.objectContaining({ settings: expect.anything() }))

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1229,7 +1229,8 @@ describe("agent Vite plugin", () => {
       "linux-arm64": "@openai/codex-linux-arm64",
       "linux-x64": "@openai/codex-linux-x64",
     }
-    const platformPackage = platformPackages[`${process.platform}-${process.arch}`]!
+    const platformPackage = platformPackages[`${process.platform}-${process.arch}`]
+    if (!platformPackage) throw new Error(`Unsupported test platform ${process.platform}/${process.arch}.`)
     const root = await mkdtemp(join(tmpdir(), "vitehub-agent-codex-output-"))
     try {
       await mkdir(join(root, "server", "agents", "support"), { recursive: true })
@@ -1244,7 +1245,9 @@ describe("agent Vite plugin", () => {
       const plugin = hubAgent()
       const result = isRuntimeFunction(plugin.config)
         ? await plugin.config.call(
+            // SAFETY: This focused fixture does not read the Vite plugin context.
             {} as never,
+            // SAFETY: This fixture supplies the Nitro fields read by the config hook.
             {
               [VITEHUB_NITRO_CONFIG_CONTEXT]: true,
               nitro: { modules: ["existing"] },
@@ -1253,9 +1256,11 @@ describe("agent Vite plugin", () => {
             { command: "build", mode: "production" },
           )
         : undefined
+      // SAFETY: The fixture above supplies Nitro configuration and the hook preserves it in its result.
       const modules = (result as { nitro: { modules: unknown[] } }).nitro.modules
       expect(modules.slice(1)).toEqual(["existing"])
       let compiled: (() => Promise<void>) | undefined
+      // SAFETY: The ViteHub config hook prepends its Nitro setup module to this array.
       ;(modules[0] as (nitro: unknown) => void)({
         hooks: {
           hook(name: string, callback: () => Promise<void>) {
@@ -1271,7 +1276,8 @@ describe("agent Vite plugin", () => {
       })
       vi.mocked(copyNodeRuntimePackages).mockClear()
 
-      await compiled!()
+      if (!compiled) throw new Error("Expected the Nitro compiled hook to be registered.")
+      await compiled()
 
       expect(copyNodeRuntimePackages).toHaveBeenCalledWith({
         outputNodeModules: join(root, ".output", "server", "node_modules"),
@@ -1283,6 +1289,7 @@ describe("agent Vite plugin", () => {
       })
 
       const unsupportedHook = vi.fn()
+      // SAFETY: The ViteHub config hook prepends its Nitro setup module to this array.
       ;(modules[0] as (nitro: unknown) => void)({
         hooks: { hook: unsupportedHook },
         options: {
@@ -1294,6 +1301,7 @@ describe("agent Vite plugin", () => {
       expect(unsupportedHook).not.toHaveBeenCalled()
 
       const devHook = vi.fn()
+      // SAFETY: The ViteHub config hook prepends its Nitro setup module to this array.
       ;(modules[0] as (nitro: unknown) => void)({
         hooks: { hook: devHook },
         options: {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1228,19 +1228,22 @@ describe("agent Vite plugin", () => {
   it("replaces the Agent app root in Nitro server code without overriding user replacements", async () => {
     const { hubAgent } = await import("../src/vite.ts")
     const plugin = hubAgent()
+    // SAFETY: This fixture supplies the private Nitro config context consumed by the plugin.
+    const nitroConfig = {
+      [VITEHUB_NITRO_CONFIG_CONTEXT]: true,
+      nitro: {
+        replace: {
+          __VITEHUB_AGENT_APP_ROOT__: "configured",
+          __VITEHUB_OTHER_REPLACEMENT__: "other",
+        },
+      },
+      root: "/repo/apps/web",
+    } as never
     const result = isRuntimeFunction(plugin.config)
       ? await plugin.config.call(
+          // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
           {} as never,
-          {
-            [VITEHUB_NITRO_CONFIG_CONTEXT]: true,
-            nitro: {
-              replace: {
-                __VITEHUB_AGENT_APP_ROOT__: "configured",
-                __VITEHUB_OTHER_REPLACEMENT__: "other",
-              },
-            },
-            root: "/repo/apps/web",
-          } as never,
+          nitroConfig,
           { command: "build", mode: "production" },
         )
       : undefined
@@ -1291,7 +1294,7 @@ describe("agent Vite plugin", () => {
             { command: "build", mode: "production" },
           )
         : undefined
-      // SAFETY: The fixture above supplies Nitro configuration and the hook preserves it in its result.
+      // SAFETY: The fixture above supplies Nitro configuration and the hook preserves its modules array.
       const modules = (result as { nitro: { modules: unknown[] } }).nitro.modules
       expect(modules.slice(1)).toEqual(["existing"])
       let compiled: (() => Promise<void>) | undefined
@@ -1352,6 +1355,29 @@ describe("agent Vite plugin", () => {
       await rm(root, { force: true, recursive: true })
     }
   }, 15_000)
+
+  it("packages provider runtimes for suffix-only scheduled Agents", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-scheduled-output-"))
+    try {
+      await writeFile(join(root, "support.agent.ts"), "export default {}\n")
+      const plugin = hubAgent()
+      const result = isRuntimeFunction(plugin.config)
+        ? await plugin.config.call(
+            // SAFETY: This focused fixture does not read the Vite plugin context.
+            {} as never,
+            // SAFETY: This fixture supplies the Nitro fields read by the config hook.
+            { [VITEHUB_NITRO_CONFIG_CONTEXT]: true, root } as never,
+            { command: "build", mode: "production" },
+          )
+        : undefined
+
+      expect(result).toMatchObject({ nitro: { modules: [expect.any(Function)] } })
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
 
   it("registers configured Discord Gateway routes with Nitro", async () => {
     const { hubAgent } = await import("../src/vite.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -553,11 +553,13 @@ describe("agent Vite plugin", () => {
     const { hubAgent } = await import("../src/vite.ts")
     const plugin = hubAgent()
     // SAFETY: The plugin under test produced this hook, so the test invokes its documented callable shape.
-    const config = plugin.config as (config: { server?: { watch?: { ignored?: string | string[] } } }) => { server?: { watch?: { ignored?: string[] } } }
+    const config = plugin.config as (config: { define?: Record<string, string>; root?: string; server?: { watch?: { ignored?: string | string[] } } }) => { define?: Record<string, string>; server?: { watch?: { ignored?: string[] } } }
 
     expect(config({}).server?.watch?.ignored).toEqual(["**/.vitehub/**"])
     expect(config({ server: { watch: { ignored: ["**/node_modules/**"] } } }).server?.watch?.ignored).toEqual(["**/node_modules/**", "**/.vitehub/**"])
     expect(config({ server: { watch: { ignored: ["**/.vitehub/**"] } } }).server?.watch?.ignored).toEqual(["**/.vitehub/**"])
+    expect(config({ root: "/repo/apps/web" }).define?.__VITEHUB_AGENT_APP_ROOT__).toBe(JSON.stringify("/repo/apps/web"))
+    expect(config({ define: { __VITEHUB_AGENT_APP_ROOT__: "configured" }, root: "/repo/apps/web" }).define?.__VITEHUB_AGENT_APP_ROOT__).toBe("configured")
   })
 
   it("merges server noExternal", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -20,6 +20,7 @@ import type { AgentChannelChatRouteStandardSchemaV1 } from "../src/server.ts"
 import type { Adapter, ChatInstance, StreamChunk, WebhookOptions } from "chat"
 
 vi.mock("@vite-hub/internal/build/vercel-runtime-packages", () => ({
+  copyNodeRuntimePackages: vi.fn(async () => undefined),
   copyVercelFunctionRuntimePackages: vi.fn(async () => undefined),
 }))
 
@@ -1218,6 +1219,96 @@ describe("agent Vite plugin", () => {
       },
     })
   })
+
+  it("packages an installed Codex CLI into self-hosted Node output", async () => {
+    const { copyNodeRuntimePackages } = await import("@vite-hub/internal/build/vercel-runtime-packages")
+    const { hubAgent } = await import("../src/vite.ts")
+    const platformPackages: Record<string, string> = {
+      "darwin-arm64": "@openai/codex-darwin-arm64",
+      "darwin-x64": "@openai/codex-darwin-x64",
+      "linux-arm64": "@openai/codex-linux-arm64",
+      "linux-x64": "@openai/codex-linux-x64",
+    }
+    const platformPackage = platformPackages[`${process.platform}-${process.arch}`]!
+    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-codex-output-"))
+    try {
+      await mkdir(join(root, "server", "agents", "support"), { recursive: true })
+      await writeFile(join(root, "package.json"), "{}\n")
+      await writeFile(join(root, "server", "agents", "support", "agent.ts"), "export default {}\n")
+      const codexPackageDir = join(root, "node_modules", "@openai", "codex")
+      const platformPackageDir = join(root, "node_modules", ...platformPackage.split("/"))
+      await mkdir(codexPackageDir, { recursive: true })
+      await mkdir(platformPackageDir, { recursive: true })
+      await writeFile(join(codexPackageDir, "package.json"), JSON.stringify({ name: "@openai/codex", version: "0.149.1" }))
+      await writeFile(join(platformPackageDir, "package.json"), JSON.stringify({ name: "@openai/codex", version: `0.149.1-${process.platform}-${process.arch}` }))
+      const plugin = hubAgent()
+      const result = isRuntimeFunction(plugin.config)
+        ? await plugin.config.call(
+            {} as never,
+            {
+              [VITEHUB_NITRO_CONFIG_CONTEXT]: true,
+              nitro: { modules: ["existing"] },
+              root,
+            } as never,
+            { command: "build", mode: "production" },
+          )
+        : undefined
+      const modules = (result as { nitro: { modules: unknown[] } }).nitro.modules
+      expect(modules.slice(1)).toEqual(["existing"])
+      let compiled: (() => Promise<void>) | undefined
+      ;(modules[0] as (nitro: unknown) => void)({
+        hooks: {
+          hook(name: string, callback: () => Promise<void>) {
+            if (name === "compiled") compiled = callback
+          },
+        },
+        options: {
+          dev: false,
+          output: { serverDir: join(root, ".output", "server") },
+          preset: "node-server",
+          rootDir: root,
+        },
+      })
+      vi.mocked(copyNodeRuntimePackages).mockClear()
+
+      await compiled!()
+
+      expect(copyNodeRuntimePackages).toHaveBeenCalledWith({
+        outputNodeModules: join(root, ".output", "server", "node_modules"),
+        packages: [
+          { name: "@openai/codex", resolveFrom: join(root, "package.json") },
+          { name: platformPackage, resolveFrom: join(codexPackageDir, "package.json") },
+        ],
+        rootDir: root,
+      })
+
+      const unsupportedHook = vi.fn()
+      ;(modules[0] as (nitro: unknown) => void)({
+        hooks: { hook: unsupportedHook },
+        options: {
+          output: { serverDir: join(root, ".output", "server") },
+          preset: "cloudflare-module",
+          rootDir: root,
+        },
+      })
+      expect(unsupportedHook).not.toHaveBeenCalled()
+
+      const devHook = vi.fn()
+      ;(modules[0] as (nitro: unknown) => void)({
+        hooks: { hook: devHook },
+        options: {
+          dev: true,
+          output: { serverDir: join(root, ".output", "server") },
+          preset: "node-server",
+          rootDir: root,
+        },
+      })
+      expect(devHook).not.toHaveBeenCalled()
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  }, 15_000)
 
   it("registers configured Discord Gateway routes with Nitro", async () => {
     const { hubAgent } = await import("../src/vite.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1269,7 +1269,8 @@ describe("agent Vite plugin", () => {
     }
     const platformPackage = platformPackages[`${process.platform}-${process.arch}`]
     if (!platformPackage) throw new Error(`Unsupported test platform ${process.platform}/${process.arch}.`)
-    const root = await mkdtemp(join(tmpdir(), "vitehub-agent-codex-output-"))
+    const nitroRoot = await mkdtemp(join(tmpdir(), "vitehub-agent-codex-nitro-"))
+    const root = join(nitroRoot, "app")
     try {
       await mkdir(join(root, "server", "agents", "support"), { recursive: true })
       await writeFile(join(root, "package.json"), "{}\n")
@@ -1309,7 +1310,7 @@ describe("agent Vite plugin", () => {
           dev: false,
           output: { serverDir: join(root, ".output", "server") },
           preset: "node-server",
-          rootDir: root,
+          rootDir: nitroRoot,
         },
       })
       vi.mocked(copyNodeRuntimePackages).mockClear()
@@ -1352,7 +1353,7 @@ describe("agent Vite plugin", () => {
       expect(devHook).not.toHaveBeenCalled()
     }
     finally {
-      await rm(root, { force: true, recursive: true })
+      await rm(nitroRoot, { force: true, recursive: true })
     }
   }, 15_000)
 

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1218,6 +1218,39 @@ describe("agent Vite plugin", () => {
         externals: {
           inline: ["existing", "vite-hub", "@vite-hub/agent", "@ai-sdk/mcp", "@t3tools/provider-runtime"],
         },
+        replace: {
+          __VITEHUB_AGENT_APP_ROOT__: JSON.stringify(process.cwd()),
+        },
+      },
+    })
+  })
+
+  it("replaces the Agent app root in Nitro server code without overriding user replacements", async () => {
+    const { hubAgent } = await import("../src/vite.ts")
+    const plugin = hubAgent()
+    const result = isRuntimeFunction(plugin.config)
+      ? await plugin.config.call(
+          {} as never,
+          {
+            [VITEHUB_NITRO_CONFIG_CONTEXT]: true,
+            nitro: {
+              replace: {
+                __VITEHUB_AGENT_APP_ROOT__: "configured",
+                __VITEHUB_OTHER_REPLACEMENT__: "other",
+              },
+            },
+            root: "/repo/apps/web",
+          } as never,
+          { command: "build", mode: "production" },
+        )
+      : undefined
+
+    expect(result).toMatchObject({
+      nitro: {
+        replace: {
+          __VITEHUB_AGENT_APP_ROOT__: "configured",
+          __VITEHUB_OTHER_REPLACEMENT__: "other",
+        },
       },
     })
   })

--- a/packages/internal/src/build/vercel-runtime-packages.ts
+++ b/packages/internal/src/build/vercel-runtime-packages.ts
@@ -39,6 +39,7 @@ export async function copyVercelFunctionRuntimePackages(options: VercelFunctionR
     await access(serverDir)
   }
   catch (error) {
+    // SAFETY: Node filesystem failures expose their stable error code through ErrnoException.
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return
     throw error
   }
@@ -77,7 +78,9 @@ async function copyPackageToNodeModules(
 
   const resolvedPackageJsonPath = await realpath(packageJsonPath)
   const packageDir = dirname(resolvedPackageJsonPath)
-  const packageJson = JSON.parse(await readFile(resolvedPackageJsonPath, "utf8")) as {
+  const parsedPackageJson: unknown = JSON.parse(await readFile(resolvedPackageJsonPath, "utf8"))
+  // SAFETY: parsePackageJson establishes the object boundary; package metadata fields are optional and consumed defensively below.
+  const packageJson = parsePackageJson(parsedPackageJson, resolvedPackageJsonPath) as {
     dependencies?: Record<string, string>
     exports?: unknown
     main?: string
@@ -191,6 +194,7 @@ async function resolvePackageTraceEntries(
       else if (candidateStat.isDirectory()) return undefined
     }
     catch (error) {
+      // SAFETY: Node filesystem failures expose their stable error code through ErrnoException.
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
     }
   }
@@ -199,6 +203,7 @@ async function resolvePackageTraceEntries(
 }
 
 function collectRuntimeExportTargets(exportsValue: unknown, condition?: string): Set<string> | undefined {
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Package export maps come from JSON, so this parser must inspect their runtime representation.
   if (typeof exportsValue === "string") {
     if (condition === "types") return new Set()
     if (exportsValue.includes("*")) return undefined
@@ -215,6 +220,7 @@ function collectRuntimeExportTargets(exportsValue: unknown, condition?: string):
     return targets
   }
 
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Package export maps come from JSON, so this parser must reject non-object runtime values.
   if (typeof exportsValue !== "object" || exportsValue === null) return new Set()
 
   const targets = new Set<string>()
@@ -251,10 +257,13 @@ async function resolvePackageJson(name: string, resolver: NodeJS.Require, fromDi
       const candidate = join(current, "package.json")
       try {
         await access(candidate)
-        const packageJson = JSON.parse(await readFile(candidate, "utf8")) as { name?: string }
+        const parsedPackageJson: unknown = JSON.parse(await readFile(candidate, "utf8"))
+        // SAFETY: parsePackageJson validates the object boundary before this narrower property view.
+        const packageJson = parsePackageJson(parsedPackageJson, candidate) as { name?: string }
         if (packageJson.name === name) return candidate
       }
       catch (error) {
+        // SAFETY: Node filesystem failures expose their stable error code through ErrnoException.
         if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
       }
       current = dirname(current)
@@ -272,6 +281,7 @@ async function resolvePackageJson(name: string, resolver: NodeJS.Require, fromDi
       return candidate
     }
     catch (error) {
+      // SAFETY: Node filesystem failures expose their stable error code through ErrnoException.
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
     }
     current = dirname(current)
@@ -279,6 +289,16 @@ async function resolvePackageJson(name: string, resolver: NodeJS.Require, fromDi
 }
 
 function isPackageResolutionMiss(error: unknown): boolean {
+  // SAFETY: Node module resolution failures expose their stable error code through ErrnoException.
   const code = (error as NodeJS.ErrnoException | undefined)?.code
   return code === "MODULE_NOT_FOUND" || code === "ERR_MODULE_NOT_FOUND" || code === "ERR_PACKAGE_PATH_NOT_EXPORTED"
+}
+
+function parsePackageJson(value: unknown, path: string): Record<string, unknown> {
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- JSON.parse returns an untrusted runtime value that must be checked at this boundary.
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`Expected ${path} to contain a JSON object.`)
+  }
+  // SAFETY: The checks above establish a non-null, non-array object with string keys.
+  return value as Record<string, unknown>
 }

--- a/packages/internal/src/build/vercel-runtime-packages.ts
+++ b/packages/internal/src/build/vercel-runtime-packages.ts
@@ -7,11 +7,19 @@ import { createDefaultVercelOutputRoot } from "./deployment-output.ts"
 const runtimeExportConditions = new Set(["default", "import", "module", "node", "node-addons", "require"])
 let nodeFileTracePromise: Promise<typeof import("@vercel/nft").nodeFileTrace> | undefined
 
-export interface VercelFunctionRuntimePackage {
+export interface NodeRuntimePackage {
   includePeerDependencies?: boolean
   name: string
   optional?: boolean
   resolveFrom?: string
+}
+
+export type VercelFunctionRuntimePackage = NodeRuntimePackage
+
+interface NodeRuntimePackagesOptions {
+  outputNodeModules: string
+  packages: NodeRuntimePackage[]
+  rootDir: string
 }
 
 interface VercelFunctionRuntimePackagesOptions {
@@ -35,12 +43,21 @@ export async function copyVercelFunctionRuntimePackages(options: VercelFunctionR
     throw error
   }
 
+  await copyNodeRuntimePackages({
+    outputNodeModules: resolve(serverDir, "node_modules"),
+    packages: options.packages,
+    rootDir: options.rootDir,
+  })
+}
+
+export async function copyNodeRuntimePackages(options: NodeRuntimePackagesOptions): Promise<void> {
+  if (!options.packages.length) return
+
   const copied = new Set<string>()
-  const outputNodeModules = resolve(serverDir, "node_modules")
   for (const runtimePackage of options.packages) {
     const resolveFrom = runtimePackage.resolveFrom ?? join(options.rootDir, "package.json")
     const resolver = createRequire(resolveFrom)
-    await copyPackageToNodeModules(runtimePackage.name, resolver, dirname(resolveFrom), outputNodeModules, copied, runtimePackage)
+    await copyPackageToNodeModules(runtimePackage.name, resolver, dirname(resolveFrom), options.outputNodeModules, copied, runtimePackage)
   }
 }
 
@@ -50,7 +67,7 @@ async function copyPackageToNodeModules(
   fromDir: string,
   outputNodeModules: string,
   copied: Set<string>,
-  options: VercelFunctionRuntimePackage = { name },
+  options: NodeRuntimePackage = { name },
 ): Promise<void> {
   const packageJsonPath = await resolvePackageJson(name, resolver, fromDir)
   if (!packageJsonPath) {

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -655,7 +655,9 @@ describe("provider deployment outputs", () => {
       },
     })
 
-    const config = await readFile(join(vercelDir, "config.json"), "utf8").then(JSON.parse) as { crons?: unknown, routes?: unknown, version?: unknown }
+    const parsedConfig: unknown = JSON.parse(await readFile(join(vercelDir, "config.json"), "utf8"))
+    // SAFETY: writeProviderDeploymentOutputs writes a JSON object, whose owned properties are asserted below.
+    const config = parsedConfig as { crons?: unknown, routes?: unknown, version?: unknown }
     expect(config.crons).toBeUndefined()
     expect(config.routes).toEqual([{ handle: "filesystem" }, { dest: "/__server", src: "/(.*)" }])
     expect(config.version).toBe(3)

--- a/packages/internal/test/deployment-output.test.ts
+++ b/packages/internal/test/deployment-output.test.ts
@@ -1,4 +1,5 @@
 import { existsSync } from "node:fs"
+import { spawnSync } from "node:child_process"
 import { mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises"
 import { join, relative } from "node:path"
 import { tmpdir } from "node:os"
@@ -918,6 +919,32 @@ describe("provider deployment outputs", () => {
     expect(existsSync(join(serverDir, "node_modules", "runtime-peer", "package.json"))).toBe(true)
     expect(existsSync(join(serverDir, "node_modules", "transitive-peer", "package.json"))).toBe(true)
     expect(existsSync(join(serverDir, "node_modules", "optional-peer", "package.json"))).toBe(false)
+  })
+
+  it("copies runtime packages into an explicit Node output", async () => {
+    const rootDir = await createTempProject()
+    const outputNodeModules = join(rootDir, ".output", "server", "node_modules")
+    const runtimePackageDir = await writePackage(rootDir, "runtime-package", {
+      dependencies: { "runtime-dependency": "1.0.0" },
+      exports: { ".": "./index.js" },
+      type: "module",
+    })
+    await writePackage(rootDir, "runtime-dependency")
+    await writeFile(join(runtimePackageDir, "index.js"), "import 'runtime-dependency'\nconsole.log('runtime-ready')\n", "utf8")
+    const { copyNodeRuntimePackages } = await import("../src/build/vercel-runtime-packages.ts")
+
+    await copyNodeRuntimePackages({
+      outputNodeModules,
+      packages: [{ name: "runtime-package" }],
+      rootDir,
+    })
+
+    expect(existsSync(join(outputNodeModules, "runtime-package", "index.js"))).toBe(true)
+    expect(existsSync(join(outputNodeModules, "runtime-dependency", "package.json"))).toBe(true)
+    expect(spawnSync(process.execPath, [join(outputNodeModules, "runtime-package", "index.js")], { encoding: "utf8" })).toMatchObject({
+      status: 0,
+      stdout: "runtime-ready\n",
+    })
   })
 
   it("preserves nested dependency versions in copied Vercel runtime packages", async () => {

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -41,15 +41,24 @@ const mocks = vi.hoisted(() => ({
   markdownTemplateLoad: vi.fn(),
   markdownTemplateResolveId: vi.fn(),
   outputHook: vi.fn(),
-  agentHook: vi.fn((config: { [VITEHUB_SERVER_DIRS]?: string[]; nitro?: Record<string, unknown> }) => ({
-    nitro: {
-      ...config.nitro,
-      handlers: config[VITEHUB_SERVER_DIRS]?.map(serverDir => ({
-        handler: `${serverDir}/agents/support.ts`,
-      })),
-      modules: ["agent-module"],
-    },
-  })),
+  agentHook: vi.fn((config: { [VITEHUB_SERVER_DIRS]?: string[]; nitro?: Record<string, unknown>; root?: string }) => {
+    const replace = config.nitro?.replace && typeof config.nitro.replace === "object"
+      ? config.nitro.replace as Record<string, unknown>
+      : {}
+    return {
+      nitro: {
+        ...config.nitro,
+        handlers: config[VITEHUB_SERVER_DIRS]?.map(serverDir => ({
+          handler: `${serverDir}/agents/support.ts`,
+        })),
+        modules: ["agent-module"],
+        replace: {
+          __VITEHUB_AGENT_APP_ROOT__: JSON.stringify(config.root),
+          ...replace,
+        },
+      },
+    }
+  }),
   agentWorkflowRegistryTransform: vi.fn((code: string) => `// transformed\n${code}`),
   queueNitroConfig: vi.fn(async ({ nitro }: { nitro: Record<string, unknown> }) => ({
     ...nitro,
@@ -651,7 +660,12 @@ describe("ViteHub Nuxt integration", () => {
     })
 
     await viteHubNuxtModule({ preset: "cloudflare" }, nuxt)
-    await runNitroConfigHook({})
+    const nitroConfig = {
+      replace: {
+        __VITEHUB_EXISTING_REPLACEMENT__: "existing",
+      },
+    }
+    await runNitroConfigHook(nitroConfig)
 
     expect(mocks.agentHook).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -660,6 +674,10 @@ describe("ViteHub Nuxt integration", () => {
       }),
       expect.anything(),
     )
+    expect(nitroConfig.replace).toEqual({
+      __VITEHUB_AGENT_APP_ROOT__: JSON.stringify("/tmp/vitehub-nuxt/custom-vite-root"),
+      __VITEHUB_EXISTING_REPLACEMENT__: "existing",
+    })
   })
 
   it("finalizes deployment output after later ViteHub post hooks", async () => {

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -15,6 +15,10 @@ import type { Plugin, PluginOption } from "vite"
 
 const databaseRuntimeState = fileURLToPath(new URL("../src/_internal/database/runtime/state", import.meta.url))
 
+function isTestRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && Object(value) === value && !Array.isArray(value)
+}
+
 const mocks = vi.hoisted(() => ({
   objectHook: vi.fn((config: { nitro?: Record<string, unknown> }) => ({
     nitro: {
@@ -42,8 +46,8 @@ const mocks = vi.hoisted(() => ({
   markdownTemplateResolveId: vi.fn(),
   outputHook: vi.fn(),
   agentHook: vi.fn((config: { [VITEHUB_SERVER_DIRS]?: string[]; nitro?: Record<string, unknown>; root?: string }) => {
-    const replace = config.nitro?.replace && typeof config.nitro.replace === "object"
-      ? config.nitro.replace as Record<string, unknown>
+    const replace = isTestRecord(config.nitro?.replace)
+      ? config.nitro.replace
       : {}
     return {
       nitro: {


### PR DESCRIPTION
## Summary

- resolve an app-installed `@openai/codex` CLI through T3's `binaryPath`
- copy only the current macOS/Linux native payload into production self-hosted Node output
- preserve the host `codex` command fallback when the package is absent or the host is Windows
- reuse the existing Node runtime package copier and document the same-host build contract

## Before / after

| Before | After |
| --- | --- |
| Apps maintain a private deployment workspace, run `pnpm deploy`, copy Codex into the image, and rewrite `PATH`. | Apps run `pnpm add @openai/codex@0.149.1`; ViteHub resolves it and packages the matching payload for production Node builds. |
| Generic dependency tracing copies every Codex platform package (~1.8 GB in the research fixture). | ViteHub selects one native package (~309 MB for Linux x64 in the real-package smoke test). |
| Auth and executable setup are mixed in app Docker plumbing. | ViteHub owns executable packaging; the deployment environment still owns credentials and secrets. |
| Non-Codex apps risk inheriting a large binary dependency. | ViteHub does not declare or install Codex; non-Codex apps remain unchanged. |

Production packaging is deliberately limited to macOS/Linux builds targeting the same OS and CPU architecture. Dev/watch and non-Node Nitro targets do not copy the runtime.

## Verification

- `@vite-hub/agent`: 77 focused resolver/provider tests passed
- Nitro packaging contract: 1 passed, including production, dev, and non-Node behavior
- `@vite-hub/internal`: 40 deployment-output tests passed; copied output executes successfully
- agent and internal typechecks passed
- agent and internal package builds passed, including publint
- changed-file lint: 0 errors; 5 unrelated existing warnings
- real Linux x64 package smoke test: copied wrapper returned `codex-cli 0.149.1`, with only `@openai/codex` and `@openai/codex-linux-x64` present

Downstream Quiver validation should build its Nitro image from this package and run an authenticated `codex app-server` invocation before deleting the existing `runtime/codex` workspace.
