### PR TITLE
test: separate root contract layers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: 2.9.3
 
       - run: vp run test:consumer
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,8 +81,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
-      - run: vp run build
-      - run: vp run playground:vite:build:local --provider cloudflare
       - name: Provider Output Contract
         run: vp run test:output:cloudflare
       - name: Local Provider Run
@@ -113,8 +111,6 @@ jobs:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
-      - run: vp run build
-      - run: vp run playground:vite:build:local --provider vercel
       - name: Provider Output Contract
         run: vp run test:output:vercel
       - name: Local Provider Run

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -176,7 +176,7 @@ jobs:
 
       - name: Provider Output Contract (cloudflare)
         if: matrix.provider == 'cloudflare'
-        run: vp run test:output:cloudflare
+        run: vp test --config test/output/vitest.config.ts test/output/cloudflare.test.ts
 
       - name: Dry-run Cloudflare deploy
         if: matrix.provider == 'cloudflare'
@@ -213,7 +213,7 @@ jobs:
 
       - name: Provider Output Contract (vercel)
         if: matrix.provider == 'vercel'
-        run: vp run test:output:vercel
+        run: vp test --config test/output/vitest.config.ts test/output/vercel.test.ts
 
       - name: Relax Vercel cron cadence for live deploy
         if: matrix.provider == 'vercel'

--- a/test/consumer/vitest.config.ts
+++ b/test/consumer/vitest.config.ts
@@ -7,7 +7,10 @@ import { testLayerIncludes } from "../layers.ts"
 export default defineConfig({
   test: {
     environment: "node",
-    include: testLayerIncludes.output,
+    env: {
+      VITEHUB_CONSUMER_CONTRACT: "1",
+    },
+    include: testLayerIncludes.consumer,
     root: resolve(import.meta.dirname, "../.."),
   },
 })

--- a/test/layers.ts
+++ b/test/layers.ts
@@ -1,0 +1,26 @@
+export const testLayerIncludes = Object.freeze({
+  contracts: ["test/*.test.ts"],
+  consumer: ["test/consumer/**/*.test.ts"],
+  output: ["test/output/**/*.test.ts"],
+  packages: ["packages/*/test/**/*.test.ts", "packages/*/test/**/*.test-d.ts"],
+});
+
+export function testLayersFor(path: string) {
+  const normalized = path.replaceAll("\\", "/");
+  const layers = [];
+
+  if (/^test\/[^/]+\.test\.ts$/.test(normalized)) {
+    layers.push("contracts");
+  }
+  if (/^test\/consumer\/.+\.test\.ts$/.test(normalized)) {
+    layers.push("consumer");
+  }
+  if (/^test\/output\/.+\.test\.ts$/.test(normalized)) {
+    layers.push("output");
+  }
+  if (/^packages\/[^/]+\/test\/.+\.test(?:-d)?\.ts$/.test(normalized)) {
+    layers.push("packages");
+  }
+
+  return layers;
+}

--- a/test/tasks.ts
+++ b/test/tasks.ts
@@ -1,0 +1,31 @@
+const outputConfig = "--config test/output/vitest.config.ts";
+
+function providerOutputTask(provider: "cloudflare" | "vercel") {
+  return {
+    cache: false,
+    command: `vp run playground:vite:build:local --provider ${provider} && vp test ${outputConfig} test/output/${provider}.test.ts`,
+  };
+}
+
+export const rootTestTasks = Object.freeze({
+  test: {
+    cache: false,
+    command: "node test/run-package-task.mjs test",
+  },
+  "test:contracts": {
+    cache: false,
+    command: "vp test --config vitest.config.ts",
+    dependsOn: ["build"],
+  },
+  "test:consumer": {
+    cache: false,
+    command: "vp test --config test/consumer/vitest.config.ts",
+    dependsOn: ["build"],
+  },
+  "test:output": {
+    cache: false,
+    command: "vp run test:output:cloudflare && vp run test:output:vercel",
+  },
+  "test:output:cloudflare": providerOutputTask("cloudflare"),
+  "test:output:vercel": providerOutputTask("vercel"),
+});

--- a/test/test-layers.test.ts
+++ b/test/test-layers.test.ts
@@ -57,13 +57,18 @@ describe("root test layers", () => {
   })
 
   it("keeps package tests behind their package build", () => {
+    const packageDirsWithTests = new Set(
+      trackedTestFiles()
+        .filter(path => path.startsWith("packages/"))
+        .map(path => path.split("/").slice(0, 2).join("/")),
+    )
     const violations = readdirSync(resolve(repoRoot, "packages"), { withFileTypes: true })
-      .filter(entry => entry.isDirectory())
+      .filter(entry => entry.isDirectory() && packageDirsWithTests.has(`packages/${entry.name}`))
       .flatMap((entry) => {
         const manifestPath = join(repoRoot, "packages", entry.name, "package.json")
         const manifest = parse(packageManifestSchema, JSON.parse(readFileSync(manifestPath, "utf8")))
-        if (!manifest.scripts?.test) return []
-        return manifest.scripts.build && manifest.scripts.test.includes("#build")
+        return manifest.scripts?.build
+          && manifest.scripts.test?.includes(`${manifest.name}#build`)
           ? []
           : [manifest.name]
       })

--- a/test/test-layers.test.ts
+++ b/test/test-layers.test.ts
@@ -1,0 +1,73 @@
+import { execFileSync } from "node:child_process"
+import { readFileSync, readdirSync } from "node:fs"
+import { join, resolve } from "node:path"
+
+import { object, optional, parse, string } from "valibot"
+import { describe, expect, it } from "vitest"
+
+import { testLayerIncludes, testLayersFor } from "./layers.ts"
+import { rootTestTasks } from "./tasks.ts"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const packageManifestSchema = object({
+  name: string(),
+  scripts: optional(object({
+    build: optional(string()),
+    test: optional(string()),
+  })),
+})
+
+function trackedTestFiles() {
+  return execFileSync("git", ["ls-files"], { cwd: repoRoot, encoding: "utf8" })
+    .trim()
+    .split("\n")
+    .filter(path => /^(?:packages|test)\//.test(path) && /\.test(?:-d)?\.ts$/.test(path))
+}
+
+describe("root test layers", () => {
+  it("assigns every tracked root and package test to one layer", () => {
+    const assignments = trackedTestFiles().map(path => ({ layers: testLayersFor(path), path }))
+
+    expect(assignments.filter(({ layers }) => layers.length !== 1)).toEqual([])
+    for (const layer of Object.keys(testLayerIncludes)) {
+      expect(assignments.some(assignment => assignment.layers.includes(layer)), layer).toBe(true)
+    }
+  })
+
+  it("keeps named root tasks on their owned configs", () => {
+    expect(rootTestTasks["test:contracts"]).toMatchObject({
+      command: "vp test --config vitest.config.ts",
+      dependsOn: ["build"],
+    })
+    expect(rootTestTasks["test:consumer"]).toMatchObject({
+      command: "vp test --config test/consumer/vitest.config.ts",
+      dependsOn: ["build"],
+    })
+    expect(rootTestTasks["test:output"].command).toBe(
+      "vp run test:output:cloudflare && vp run test:output:vercel",
+    )
+    for (const provider of ["cloudflare", "vercel"]) {
+      const task = provider === "cloudflare"
+        ? rootTestTasks["test:output:cloudflare"]
+        : rootTestTasks["test:output:vercel"]
+      const { command } = task
+      expect(command).toContain(`vp run playground:vite:build:local --provider ${provider}`)
+      expect(command).toContain(`test/output/${provider}.test.ts`)
+    }
+  })
+
+  it("keeps package tests behind their package build", () => {
+    const violations = readdirSync(resolve(repoRoot, "packages"), { withFileTypes: true })
+      .filter(entry => entry.isDirectory())
+      .flatMap((entry) => {
+        const manifestPath = join(repoRoot, "packages", entry.name, "package.json")
+        const manifest = parse(packageManifestSchema, JSON.parse(readFileSync(manifestPath, "utf8")))
+        if (!manifest.scripts?.test) return []
+        return manifest.scripts.build && manifest.scripts.test.includes("#build")
+          ? []
+          : [manifest.name]
+      })
+
+    expect(violations).toEqual([])
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig } from "vite-plus";
 
+import { rootTestTasks } from "./test/tasks.ts";
+
 export default defineConfig({
   run: {
     tasks: {
@@ -111,32 +113,7 @@ export default defineConfig({
         command: "node packages/schedule/test/e2e-live.mjs",
         dependsOn: ["@vite-hub/schedule#build"],
       },
-      test: {
-        cache: false,
-        command: "node test/run-package-task.mjs test",
-      },
-      "test:contracts": {
-        cache: false,
-        command: "vp test",
-      },
-      "test:consumer": {
-        cache: false,
-        command:
-          "VITEHUB_CONSUMER_CONTRACT=1 vp test test/consumer/vite-hub.test.ts test/consumer/source-closures.test.ts",
-        dependsOn: ["build"],
-      },
-      "test:output": {
-        cache: false,
-        command: "vp test --config test/output/vitest.config.ts",
-      },
-      "test:output:cloudflare": {
-        cache: false,
-        command: "vp test --config test/output/vitest.config.ts test/output/cloudflare.test.ts",
-      },
-      "test:output:vercel": {
-        cache: false,
-        command: "vp test --config test/output/vitest.config.ts test/output/vercel.test.ts",
-      },
+      ...rootTestTasks,
       typecheck: {
         cache: false,
         command:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,10 @@
 import { defineConfig } from "vitest/config"
 
+import { testLayerIncludes } from "./test/layers.ts"
+
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["test/**/*.test.ts"],
-    exclude: ["test/output/**", "test/local/**"],
+    include: testLayerIncludes.contracts,
   },
 })


### PR DESCRIPTION
Root test commands currently overlap: `test:contracts` also discovers consumer contracts, `test:consumer` omits the deployment-preset contract, and provider output tasks assume an artifact was built elsewhere. That makes a named task depend on caller knowledge rather than its own contract.

This change:
- gives repository contracts, packed consumers, provider output, and package tests explicit owned layers
- includes every consumer contract through a dedicated config and moves the consumer environment flag out of shell syntax
- declares package builds for contract and consumer tasks; provider output tasks build their own offline artifact
- keeps live smoke assertions on the exact artifact produced for deployment
- adds an inventory guard that rejects duplicate or unowned root/package test files and verifies package tests remain build-backed

Verification:
- `vp run test:contracts` — 3 files, 29 tests passed from a build-producing task
- `vp test --config vitest.config.ts test/test-layers.test.ts` — 3 tests passed
- focused consumer contract — 1 passed, 6 skipped
- Cloudflare output task — 9 tests passed
- Vercel output contract rerun — 6 tests passed
- `vp run doctor:typescript` — 100/100, no findings
- `vp run lint` — passed with existing repository warnings

The first complete Vercel output-task run built its artifact, then the existing offline-import test crossed its 5-second timeout; the immediate artifact-only rerun passed all 6 tests.