### PR TITLE
fix(blob): make R2 provisioning idempotent

### DIFF
--- a/.vite-doctor-baseline.json
+++ b/.vite-doctor-baseline.json
@@ -14,17 +14,22 @@
     {
       "ruleId": "typescript/evidence/no-caller-chosen-result-type",
       "file": "packages/internal/src/provision.ts",
-      "fingerprint": "a11ca1e5063740d7bf1a7bcbcc82140c81c9191f412a9fc7db920bb46837de15"
+      "fingerprint": "67db4c08ead9f88daf16cfff678199df46683f04616f8cd5fe590365d81f5f77"
     },
     {
       "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
       "file": "packages/internal/src/provision.ts",
-      "fingerprint": "f889ff71b448fc866c6e52b25d7b110d0ca89d9970ee6ae9b484c9568039107e"
+      "fingerprint": "8cc83ade6a0c33cb876eee578370ddaafc14b84d6b7d56609033698f08df6e88"
     },
     {
       "ruleId": "typescript/strict/no-runtime-typeof",
       "file": "packages/internal/src/provision.ts",
       "fingerprint": "bf37d92efb94cd48aa1b792c176aa4b0d94a7739362553678a1aced05541fc58"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/internal/src/provision.ts",
+      "fingerprint": "1e1320ef631585e4cee43268408cd191a535c04cd8eec71896b6bfc8b921cb7e"
     },
     {
       "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
@@ -34,7 +39,12 @@
     {
       "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
       "file": "packages/internal/src/provision.ts",
-      "fingerprint": "1ceb1542cb77a649ea627d5620b4522fb9afdfa6867684dae49ccf61dd0b9f82"
+      "fingerprint": "daaa2833f087e18471804f785aec66d71f6298afcc26c3ab30c3453aa173f8d3"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/internal/src/provision.ts",
+      "fingerprint": "6f5933e2cc120184f1e5c067a207506b81fc52da98cc15854e372f6670a3fa40"
     },
     {
       "ruleId": "typescript/evidence/no-chained-type-assertions",

--- a/.vite-doctor-baseline.json
+++ b/.vite-doctor-baseline.json
@@ -2,6 +2,41 @@
   "version": 1,
   "diagnostics": [
     {
+      "ruleId": "typescript/evidence/no-caller-chosen-result-type",
+      "file": "packages/internal/src/provision.ts",
+      "fingerprint": "286788cd8dabcf42da7f1c36e2dc8c50c1cfe9a69fa7a52ebaaf9f038800a930"
+    },
+    {
+      "ruleId": "typescript/evidence/no-caller-chosen-result-type",
+      "file": "packages/internal/src/provision.ts",
+      "fingerprint": "f936e0ceff5bfe8742f7a74e7b378662d2cdf6b7abcaf630278bfd4f1c8d3367"
+    },
+    {
+      "ruleId": "typescript/evidence/no-caller-chosen-result-type",
+      "file": "packages/internal/src/provision.ts",
+      "fingerprint": "a11ca1e5063740d7bf1a7bcbcc82140c81c9191f412a9fc7db920bb46837de15"
+    },
+    {
+      "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
+      "file": "packages/internal/src/provision.ts",
+      "fingerprint": "f889ff71b448fc866c6e52b25d7b110d0ca89d9970ee6ae9b484c9568039107e"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/internal/src/provision.ts",
+      "fingerprint": "bf37d92efb94cd48aa1b792c176aa4b0d94a7739362553678a1aced05541fc58"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/internal/src/provision.ts",
+      "fingerprint": "e05e1a4993a8b6a3034ecb67bc7d1545cd4d89af454040fa55e791ea8d0413fb"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/internal/src/provision.ts",
+      "fingerprint": "1ceb1542cb77a649ea627d5620b4522fb9afdfa6867684dae49ccf61dd0b9f82"
+    },
+    {
       "ruleId": "typescript/evidence/no-chained-type-assertions",
       "file": "packages/agent/test/runtime.test.ts",
       "fingerprint": "370c3e9b1c0f4ca6cd45f11c13b36c33922713bc756d9f0f14b5a6f507c2d410"

--- a/packages/blob/src/provision.ts
+++ b/packages/blob/src/provision.ts
@@ -44,7 +44,6 @@ interface VercelBlobStoreResponse {
 const VERCEL_BLOB_STORE_NAME = "vitehub-blob"
 const VERCEL_BLOB_STORE_REGION = "iad1"
 const VERCEL_PROJECT_ENVIRONMENTS = ["production", "preview", "development"] as const
-const CLOUDFLARE_R2_BUCKET_LIST_MAX_PAGES = 100
 const CLOUDFLARE_R2_BUCKET_LIST_PER_PAGE = "1000"
 
 async function listCloudflareR2BucketNames(request: CloudflareProvisionRequest): Promise<Set<string>> {
@@ -52,7 +51,7 @@ async function listCloudflareR2BucketNames(request: CloudflareProvisionRequest):
   const cursors = new Set<string>()
   let cursor: string | undefined
 
-  for (let page = 0; page < CLOUDFLARE_R2_BUCKET_LIST_MAX_PAGES; page++) {
+  while (true) {
     const query: Record<string, string> = {
       per_page: CLOUDFLARE_R2_BUCKET_LIST_PER_PAGE,
     }
@@ -73,8 +72,6 @@ async function listCloudflareR2BucketNames(request: CloudflareProvisionRequest):
     cursors.add(nextCursor)
     cursor = nextCursor
   }
-
-  throw new Error(`Cloudflare R2 bucket listing exceeded ${CLOUDFLARE_R2_BUCKET_LIST_MAX_PAGES} pages.`)
 }
 
 async function createCloudflareR2Bucket(request: CloudflareProvisionRequest, bucketName: string): Promise<void> {

--- a/packages/blob/src/provision.ts
+++ b/packages/blob/src/provision.ts
@@ -53,11 +53,12 @@ async function listCloudflareR2BucketNames(request: CloudflareProvisionRequest):
   let cursor: string | undefined
 
   for (let page = 0; page < CLOUDFLARE_R2_BUCKET_LIST_MAX_PAGES; page++) {
+    const query: Record<string, string> = {
+      per_page: CLOUDFLARE_R2_BUCKET_LIST_PER_PAGE,
+    }
+    if (cursor) query.cursor = cursor
     const listed = await request<{ buckets?: CloudflareR2Bucket[] }>("/r2/buckets", {
-      query: {
-        per_page: CLOUDFLARE_R2_BUCKET_LIST_PER_PAGE,
-        ...(cursor ? { cursor } : {}),
-      },
+      query,
     })
     for (const bucket of listed.result?.buckets ?? []) {
       if (bucket.name) names.add(bucket.name)

--- a/packages/blob/src/provision.ts
+++ b/packages/blob/src/provision.ts
@@ -81,7 +81,9 @@ async function createCloudflareR2Bucket(request: CloudflareProvisionRequest, buc
     await request("/r2/buckets", { method: "POST", body: { name: bucketName } })
   }
   catch (error) {
-    if (!(error instanceof ProvisionRequestError) || error.status !== 409) throw error
+    const duplicate = error instanceof ProvisionRequestError
+      && (error.status === 409 || (error.status === 400 && error.codes.includes(10004)))
+    if (!duplicate) throw error
     const existing = await request<CloudflareR2Bucket>(`/r2/buckets/${encodeURIComponent(bucketName)}`)
     if (existing.result?.name !== bucketName) throw error
   }

--- a/packages/blob/src/provision.ts
+++ b/packages/blob/src/provision.ts
@@ -58,6 +58,7 @@ async function listCloudflareR2BucketNames(request: CloudflareProvisionRequest):
     }
     if (cursor) query.cursor = cursor
     const listed = await request<{ buckets?: CloudflareR2Bucket[] }>("/r2/buckets", {
+      parse: parseCloudflareBuckets,
       query,
     })
     for (const bucket of listed.result?.buckets ?? []) {
@@ -84,7 +85,9 @@ async function createCloudflareR2Bucket(request: CloudflareProvisionRequest, buc
     const duplicate = error instanceof ProvisionRequestError
       && (error.status === 409 || (error.status === 400 && error.codes.includes(10004)))
     if (!duplicate) throw error
-    const existing = await request<CloudflareR2Bucket>(`/r2/buckets/${encodeURIComponent(bucketName)}`)
+    const existing = await request<CloudflareR2Bucket>(`/r2/buckets/${encodeURIComponent(bucketName)}`, {
+      parse: parseCloudflareBucket,
+    })
     if (existing.result?.name !== bucketName) throw error
   }
 }
@@ -108,6 +111,10 @@ function parseVercelBlobStoreCreateResponse(value: unknown): VercelBlobStoreCrea
 }
 
 function parseCloudflareBuckets(value: unknown): { buckets?: CloudflareR2Bucket[] } {
+  return parseObject(value)
+}
+
+function parseCloudflareBucket(value: unknown): CloudflareR2Bucket {
   return parseObject(value)
 }
 

--- a/packages/blob/src/provision.ts
+++ b/packages/blob/src/provision.ts
@@ -9,7 +9,7 @@ import { readEnv } from "@vite-hub/internal/env"
 
 import { resolveBlobViteConfig } from "./vite-config.ts"
 
-import type { ProvisionAction, ProvisionStep } from "@vite-hub/internal/provision"
+import type { CloudflareProvisionRequest, ProvisionAction, ProvisionStep } from "@vite-hub/internal/provision"
 import type { BlobModuleOptions, ResolvedBlobStoreConfig } from "./types.ts"
 
 interface CloudflareR2Bucket {
@@ -44,6 +44,47 @@ interface VercelBlobStoreResponse {
 const VERCEL_BLOB_STORE_NAME = "vitehub-blob"
 const VERCEL_BLOB_STORE_REGION = "iad1"
 const VERCEL_PROJECT_ENVIRONMENTS = ["production", "preview", "development"] as const
+const CLOUDFLARE_R2_BUCKET_LIST_MAX_PAGES = 100
+const CLOUDFLARE_R2_BUCKET_LIST_PER_PAGE = "1000"
+
+async function listCloudflareR2BucketNames(request: CloudflareProvisionRequest): Promise<Set<string>> {
+  const names = new Set<string>()
+  const cursors = new Set<string>()
+  let cursor: string | undefined
+
+  for (let page = 0; page < CLOUDFLARE_R2_BUCKET_LIST_MAX_PAGES; page++) {
+    const listed = await request<{ buckets?: CloudflareR2Bucket[] }>("/r2/buckets", {
+      query: {
+        per_page: CLOUDFLARE_R2_BUCKET_LIST_PER_PAGE,
+        ...(cursor ? { cursor } : {}),
+      },
+    })
+    for (const bucket of listed.result?.buckets ?? []) {
+      if (bucket.name) names.add(bucket.name)
+    }
+
+    const nextCursor = listed.result_info?.cursor?.trim()
+    if (!nextCursor) return names
+    if (cursors.has(nextCursor)) {
+      throw new Error("Cloudflare R2 bucket listing returned a repeated pagination cursor.")
+    }
+    cursors.add(nextCursor)
+    cursor = nextCursor
+  }
+
+  throw new Error(`Cloudflare R2 bucket listing exceeded ${CLOUDFLARE_R2_BUCKET_LIST_MAX_PAGES} pages.`)
+}
+
+async function createCloudflareR2Bucket(request: CloudflareProvisionRequest, bucketName: string): Promise<void> {
+  try {
+    await request("/r2/buckets", { method: "POST", body: { name: bucketName } })
+  }
+  catch (error) {
+    if (!(error instanceof ProvisionRequestError) || error.status !== 409) throw error
+    const existing = await request<CloudflareR2Bucket>(`/r2/buckets/${encodeURIComponent(bucketName)}`)
+    if (existing.result?.name !== bucketName) throw error
+  }
+}
 
 function parseObject(value: unknown): Record<string, unknown> {
   if (!value || Object(value) !== value) throw new Error("Provisioning returned an invalid response.")
@@ -140,8 +181,7 @@ export function createBlobCloudflareProvisionStep(resolveOptions: () => BlobModu
       }
 
       const request = createCloudflareProvisionClient(config, context.fetch)
-      const listed = await request("/r2/buckets", { parse: parseCloudflareBuckets })
-      const existing = new Set((listed.result?.buckets ?? []).map(bucket => bucket.name).filter((name): name is string => Boolean(name)))
+      const existing = await listCloudflareR2BucketNames(request)
 
       return [...new Set(buckets)].map((bucketName): ProvisionAction => ({
         kind: "cloudflare-r2-bucket",
@@ -149,7 +189,7 @@ export function createBlobCloudflareProvisionStep(resolveOptions: () => BlobModu
         exists: existing.has(bucketName),
         apply: async () => {
           if (!existing.has(bucketName)) {
-            await request(`/r2/buckets`, { method: "POST", body: { name: bucketName } })
+            await createCloudflareR2Bucket(request, bucketName)
           }
           return {}
         },

--- a/packages/blob/test/provision.test.ts
+++ b/packages/blob/test/provision.test.ts
@@ -8,6 +8,10 @@ function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { headers: { "content-type": "application/json" }, status })
 }
 
+function mockFetch(implementation: (input: string | URL | Request, init?: RequestInit) => Promise<Response>): typeof globalThis.fetch {
+  return vi.fn(implementation)
+}
+
 async function captureError(promise: Promise<unknown>): Promise<Error> {
   try {
     await promise
@@ -31,14 +35,14 @@ describe("blob cloudflare provision step", () => {
 
   it("finds an existing R2 bucket on the second cursor page", async () => {
     const urls: URL[] = []
-    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
       if (init?.method === "POST") throw new Error("must not create existing bucket")
       const url = new URL(String(input))
       urls.push(url)
       return url.searchParams.get("cursor") === "next-page"
         ? jsonResponse({ success: true, result: { buckets: [{ name: "assets" }] } })
         : jsonResponse({ success: true, result: { buckets: [{ name: "other" }] }, result_info: { cursor: "next-page" } })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const actions = await plan(fetchImpl)
     expect(actions).toHaveLength(1)
@@ -51,7 +55,7 @@ describe("blob cloudflare provision step", () => {
 
   it("creates a missing R2 bucket", async () => {
     const posted: unknown[] = []
-    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
+    const fetchImpl = mockFetch(async (_input: string | URL | Request, init?: RequestInit) => {
       if (init?.method === "POST") {
         posted.push(JSON.parse(String(init.body)))
         return jsonResponse({ success: true, result: {} })
@@ -66,11 +70,11 @@ describe("blob cloudflare provision step", () => {
   })
 
   it("rejects a repeated R2 pagination cursor", async () => {
-    const fetchImpl = vi.fn(async () => jsonResponse({
+    const fetchImpl = mockFetch(async () => jsonResponse({
       success: true,
       result: { buckets: [] },
       result_info: { cursor: "repeated" },
-    })) as unknown as typeof globalThis.fetch
+    }))
 
     await expect(plan(fetchImpl)).rejects.toThrow("repeated pagination cursor")
     expect(fetchImpl).toHaveBeenCalledTimes(2)
@@ -78,11 +82,11 @@ describe("blob cloudflare provision step", () => {
 
   it("bounds R2 bucket pagination", async () => {
     let calls = 0
-    const fetchImpl = vi.fn(async () => jsonResponse({
+    const fetchImpl = mockFetch(async () => jsonResponse({
       success: true,
       result: { buckets: [] },
       result_info: { cursor: `cursor-${++calls}` },
-    })) as unknown as typeof globalThis.fetch
+    }))
 
     await expect(plan(fetchImpl)).rejects.toThrow("exceeded 100 pages")
     expect(fetchImpl).toHaveBeenCalledTimes(100)
@@ -90,7 +94,7 @@ describe("blob cloudflare provision step", () => {
 
   it("accepts a create conflict only after the exact R2 bucket becomes visible", async () => {
     const requests: Array<{ method: string | undefined, url: URL }> = []
-    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(String(input))
       requests.push({ method: init?.method, url })
       if (url.pathname.endsWith("/r2/buckets/assets")) {
@@ -100,7 +104,7 @@ describe("blob cloudflare provision step", () => {
         return jsonResponse({ errors: [{ message: "bucket already exists" }], success: false }, 409)
       }
       return jsonResponse({ success: true, result: { buckets: [] } })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const actions = await plan(fetchImpl)
     await expect(actions[0]!.apply()).resolves.toEqual({})
@@ -112,28 +116,28 @@ describe("blob cloudflare provision step", () => {
   })
 
   it("preserves a create conflict when the exact R2 read returns a different bucket", async () => {
-    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(String(input))
       if (url.pathname.endsWith("/r2/buckets/assets")) {
         return jsonResponse({ success: true, result: { name: "different" } })
       }
       if (init?.method === "POST") return jsonResponse({ success: false }, 409)
       return jsonResponse({ success: true, result: { buckets: [] } })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const actions = await plan(fetchImpl)
     await expect(actions[0]!.apply()).rejects.toThrow("POST /r2/buckets (409)")
   })
 
   it("rejects a create conflict when the exact R2 bucket cannot be read", async () => {
-    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(String(input))
       if (url.pathname.endsWith("/r2/buckets/assets")) {
         return jsonResponse({ errors: [{ message: "provider-secret" }], success: false }, 403)
       }
       if (init?.method === "POST") return jsonResponse({ success: false }, 409)
       return jsonResponse({ success: true, result: { buckets: [] } })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const actions = await plan(fetchImpl)
     const error = await captureError(actions[0]!.apply())
@@ -142,10 +146,10 @@ describe("blob cloudflare provision step", () => {
   })
 
   it("propagates a redacted R2 authentication error", async () => {
-    const fetchImpl = vi.fn(async () => jsonResponse({
+    const fetchImpl = mockFetch(async () => jsonResponse({
       errors: [{ message: "invalid token token" }],
       success: false,
-    }, 401)) as unknown as typeof globalThis.fetch
+    }, 401))
 
     const error = await captureError(plan(fetchImpl))
     expect(error.message).toContain("GET /r2/buckets (401)")
@@ -156,14 +160,14 @@ describe("blob cloudflare provision step", () => {
   it("reuses the R2 bucket on repeated provision", async () => {
     let exists = false
     let creates = 0
-    const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = mockFetch(async (_input: string | URL | Request, init?: RequestInit) => {
       if (init?.method === "POST") {
         creates++
         exists = true
         return jsonResponse({ success: true, result: { name: "assets" } })
       }
       return jsonResponse({ success: true, result: { buckets: exists ? [{ name: "assets" }] : [] } })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const first = await plan(fetchImpl)
     expect(first[0]!.exists).toBe(false)

--- a/packages/blob/test/provision.test.ts
+++ b/packages/blob/test/provision.test.ts
@@ -81,16 +81,20 @@ describe("blob cloudflare provision step", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(2)
   })
 
-  it("bounds R2 bucket pagination", async () => {
+  it("continues R2 bucket pagination beyond 100 pages", async () => {
     let calls = 0
-    const fetchImpl = mockFetch(async () => jsonResponse({
-      success: true,
-      result: { buckets: [] },
-      result_info: { cursor: `cursor-${++calls}` },
-    }))
+    const fetchImpl = mockFetch(async () => {
+      calls++
+      return jsonResponse({
+        success: true,
+        result: { buckets: calls === 101 ? [{ name: "assets" }] : [] },
+        result_info: calls === 101 ? undefined : { cursor: `cursor-${calls}` },
+      })
+    })
 
-    await expect(plan(fetchImpl)).rejects.toThrow("exceeded 100 pages")
-    expect(fetchImpl).toHaveBeenCalledTimes(100)
+    const actions = await plan(fetchImpl)
+    expect(actions[0]!.exists).toBe(true)
+    expect(fetchImpl).toHaveBeenCalledTimes(101)
   })
 
   it("accepts Cloudflare's duplicate-bucket error only after the exact R2 bucket becomes visible", async () => {

--- a/packages/blob/test/provision.test.ts
+++ b/packages/blob/test/provision.test.ts
@@ -8,21 +8,45 @@ function jsonResponse(body: unknown, status = 200) {
   return new Response(JSON.stringify(body), { headers: { "content-type": "application/json" }, status })
 }
 
+async function captureError(promise: Promise<unknown>): Promise<Error> {
+  try {
+    await promise
+  }
+  catch (error) {
+    if (error instanceof Error) return error
+    throw error
+  }
+  throw new Error("Expected promise to reject.")
+
 describe("blob cloudflare provision step", () => {
   const env = { CLOUDFLARE_ACCOUNT_ID: "acc", CLOUDFLARE_API_TOKEN: "token", BLOB_BUCKET_NAME: "assets" }
 
-  it("does not create an existing R2 bucket", async () => {
-    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
-      if (init?.method === "POST") throw new Error("must not create existing bucket")
-      return jsonResponse({ success: true, result: { buckets: [{ name: "assets" }] } })
-    })
+  function context(fetchImpl: typeof globalThis.fetch): ProvisionContext {
+    return { env, fetch: fetchImpl, logger: { log: () => {}, warn: () => {} } }
+  }
 
-    const context: ProvisionContext = { env, fetch: fetchImpl, logger: { log: () => {}, warn: () => {} } }
-    const actions = await createBlobCloudflareProvisionStep(() => ({ driver: "cloudflare-r2", bucketName: "assets" })).plan(context)
+  async function plan(fetchImpl: typeof globalThis.fetch) {
+    return await createBlobCloudflareProvisionStep(() => ({ driver: "cloudflare-r2", bucketName: "assets" })).plan(context(fetchImpl))
+  }
+
+  it("finds an existing R2 bucket on the second cursor page", async () => {
+    const urls: URL[] = []
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "POST") throw new Error("must not create existing bucket")
+      const url = new URL(String(input))
+      urls.push(url)
+      return url.searchParams.get("cursor") === "next-page"
+        ? jsonResponse({ success: true, result: { buckets: [{ name: "assets" }] } })
+        : jsonResponse({ success: true, result: { buckets: [{ name: "other" }] }, result_info: { cursor: "next-page" } })
+    }) as unknown as typeof globalThis.fetch
+
+    const actions = await plan(fetchImpl)
     expect(actions).toHaveLength(1)
     expect(actions[0]!.exists).toBe(true)
     await actions[0]!.apply()
-    expect(fetchImpl.mock.calls.some(([, init]) => init?.method === "POST")).toBe(false)
+    expect(urls).toHaveLength(2)
+    expect(urls[0]!.searchParams.get("per_page")).toBe("1000")
+    expect(urls[1]!.searchParams.get("cursor")).toBe("next-page")
   })
 
   it("creates a missing R2 bucket", async () => {
@@ -35,11 +59,119 @@ describe("blob cloudflare provision step", () => {
       return jsonResponse({ success: true, result: { buckets: [] } })
     })
 
-    const context: ProvisionContext = { env, fetch: fetchImpl, logger: { log: () => {}, warn: () => {} } }
-    const actions = await createBlobCloudflareProvisionStep(() => ({ driver: "cloudflare-r2", bucketName: "assets" })).plan(context)
+    const actions = await plan(fetchImpl)
     expect(actions[0]!.exists).toBe(false)
     await actions[0]!.apply()
     expect(posted).toEqual([{ name: "assets" }])
+  })
+
+  it("rejects a repeated R2 pagination cursor", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      success: true,
+      result: { buckets: [] },
+      result_info: { cursor: "repeated" },
+    })) as unknown as typeof globalThis.fetch
+
+    await expect(plan(fetchImpl)).rejects.toThrow("repeated pagination cursor")
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it("bounds R2 bucket pagination", async () => {
+    let calls = 0
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      success: true,
+      result: { buckets: [] },
+      result_info: { cursor: `cursor-${++calls}` },
+    })) as unknown as typeof globalThis.fetch
+
+    await expect(plan(fetchImpl)).rejects.toThrow("exceeded 100 pages")
+    expect(fetchImpl).toHaveBeenCalledTimes(100)
+  })
+
+  it("accepts a create conflict only after the exact R2 bucket becomes visible", async () => {
+    const requests: Array<{ method: string | undefined, url: URL }> = []
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input))
+      requests.push({ method: init?.method, url })
+      if (url.pathname.endsWith("/r2/buckets/assets")) {
+        return jsonResponse({ success: true, result: { name: "assets" } })
+      }
+      if (init?.method === "POST") {
+        return jsonResponse({ errors: [{ message: "bucket already exists" }], success: false }, 409)
+      }
+      return jsonResponse({ success: true, result: { buckets: [] } })
+    }) as unknown as typeof globalThis.fetch
+
+    const actions = await plan(fetchImpl)
+    await expect(actions[0]!.apply()).resolves.toEqual({})
+    expect(requests.map(request => [request.method, request.url.pathname])).toEqual([
+      ["GET", "/client/v4/accounts/acc/r2/buckets"],
+      ["POST", "/client/v4/accounts/acc/r2/buckets"],
+      ["GET", "/client/v4/accounts/acc/r2/buckets/assets"],
+    ])
+  })
+
+  it("preserves a create conflict when the exact R2 read returns a different bucket", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input))
+      if (url.pathname.endsWith("/r2/buckets/assets")) {
+        return jsonResponse({ success: true, result: { name: "different" } })
+      }
+      if (init?.method === "POST") return jsonResponse({ success: false }, 409)
+      return jsonResponse({ success: true, result: { buckets: [] } })
+    }) as unknown as typeof globalThis.fetch
+
+    const actions = await plan(fetchImpl)
+    await expect(actions[0]!.apply()).rejects.toThrow("POST /r2/buckets (409)")
+  })
+
+  it("rejects a create conflict when the exact R2 bucket cannot be read", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(String(input))
+      if (url.pathname.endsWith("/r2/buckets/assets")) {
+        return jsonResponse({ errors: [{ message: "provider-secret" }], success: false }, 403)
+      }
+      if (init?.method === "POST") return jsonResponse({ success: false }, 409)
+      return jsonResponse({ success: true, result: { buckets: [] } })
+    }) as unknown as typeof globalThis.fetch
+
+    const actions = await plan(fetchImpl)
+    const error = await captureError(actions[0]!.apply())
+    expect(error.message).toContain("GET /r2/buckets/assets (403)")
+    expect(error.message).not.toContain("provider-secret")
+  })
+
+  it("propagates a redacted R2 authentication error", async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse({
+      errors: [{ message: "invalid token token" }],
+      success: false,
+    }, 401)) as unknown as typeof globalThis.fetch
+
+    const error = await captureError(plan(fetchImpl))
+    expect(error.message).toContain("GET /r2/buckets (401)")
+    expect(error.message).not.toContain("token")
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+  })
+
+  it("reuses the R2 bucket on repeated provision", async () => {
+    let exists = false
+    let creates = 0
+    const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        creates++
+        exists = true
+        return jsonResponse({ success: true, result: { name: "assets" } })
+      }
+      return jsonResponse({ success: true, result: { buckets: exists ? [{ name: "assets" }] : [] } })
+    }) as unknown as typeof globalThis.fetch
+
+    const first = await plan(fetchImpl)
+    expect(first[0]!.exists).toBe(false)
+    await first[0]!.apply()
+    const second = await plan(fetchImpl)
+    expect(second[0]!.exists).toBe(true)
+    await second[0]!.apply()
+    expect(creates).toBe(1)
   })
 })
 

--- a/packages/blob/test/provision.test.ts
+++ b/packages/blob/test/provision.test.ts
@@ -21,6 +21,7 @@ async function captureError(promise: Promise<unknown>): Promise<Error> {
     throw error
   }
   throw new Error("Expected promise to reject.")
+}
 
 describe("blob cloudflare provision step", () => {
   const env = { CLOUDFLARE_ACCOUNT_ID: "acc", CLOUDFLARE_API_TOKEN: "token", BLOB_BUCKET_NAME: "assets" }
@@ -92,7 +93,7 @@ describe("blob cloudflare provision step", () => {
     expect(fetchImpl).toHaveBeenCalledTimes(100)
   })
 
-  it("accepts a create conflict only after the exact R2 bucket becomes visible", async () => {
+  it("accepts Cloudflare's duplicate-bucket error only after the exact R2 bucket becomes visible", async () => {
     const requests: Array<{ method: string | undefined, url: URL }> = []
     const fetchImpl = mockFetch(async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(String(input))
@@ -101,7 +102,7 @@ describe("blob cloudflare provision step", () => {
         return jsonResponse({ success: true, result: { name: "assets" } })
       }
       if (init?.method === "POST") {
-        return jsonResponse({ errors: [{ message: "bucket already exists" }], success: false }, 409)
+        return jsonResponse({ errors: [{ code: 10004, message: "bucket already exists" }], success: false }, 400)
       }
       return jsonResponse({ success: true, result: { buckets: [] } })
     })
@@ -113,6 +114,21 @@ describe("blob cloudflare provision step", () => {
       ["POST", "/client/v4/accounts/acc/r2/buckets"],
       ["GET", "/client/v4/accounts/acc/r2/buckets/assets"],
     ])
+  })
+
+  it("does not treat another Cloudflare 400 response as a duplicate bucket", async () => {
+    const fetchImpl = mockFetch(async (_input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "POST") {
+        return jsonResponse({ errors: [{ code: 10005, message: "provider-secret" }], success: false }, 400)
+      }
+      return jsonResponse({ success: true, result: { buckets: [] } })
+    })
+
+    const actions = await plan(fetchImpl)
+    const error = await captureError(actions[0]!.apply())
+    expect(error.message).toContain("POST /r2/buckets (400)")
+    expect(error.message).not.toContain("provider-secret")
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
   })
 
   it("preserves a create conflict when the exact R2 read returns a different bucket", async () => {

--- a/packages/internal/src/provision.ts
+++ b/packages/internal/src/provision.ts
@@ -62,7 +62,7 @@ export interface CloudflareEnvelope<T> {
   result?: T
   result_info?: { cursor?: string }
   success?: boolean
-  errors?: Array<{ message?: string }>
+  errors?: Array<{ code?: number, message?: string }>
 }
 
 interface ProvisionRequestOptions {
@@ -81,11 +81,13 @@ export interface ProvisionRequest {
 }
 
 export class ProvisionRequestError extends Error {
+  readonly codes: readonly number[]
   readonly status: number
 
-  constructor(message: string, status: number) {
-    super(message)
+  constructor(method: string, path: string, status: number, codes: readonly number[] = []) {
+    super(`Provision request failed: ${method} ${path} (${status}).`)
     this.name = "ProvisionRequestError"
+    this.codes = codes
     this.status = status
   }
 }
@@ -104,7 +106,9 @@ function createJsonClient(baseURL: string, headers: Record<string, string>, fetc
     }
     const response = await fetchImpl(url, init)
     if (!response.ok) {
-      throw new ProvisionRequestError(`Provision request failed: ${options.method ?? "GET"} ${path} (${response.status}).`, response.status)
+      const body = await response.json().catch(() => undefined) as { errors?: Array<{ code?: unknown }> } | undefined
+      const codes = body?.errors?.flatMap(error => typeof error.code === "number" ? [error.code] : []) ?? []
+      throw new ProvisionRequestError(options.method ?? "GET", path, response.status, codes)
     }
     const value: unknown = await response.json()
     return "parse" in options ? options.parse(value) : value

--- a/packages/internal/src/provision.ts
+++ b/packages/internal/src/provision.ts
@@ -60,6 +60,7 @@ export function resolveVercelProvisionConfig(env: Record<string, string | undefi
 
 export interface CloudflareEnvelope<T> {
   result?: T
+  result_info?: { cursor?: string }
   success?: boolean
   errors?: Array<{ message?: string }>
 }


### PR DESCRIPTION
Cloudflare R2 provisioning now follows every bucket-list cursor before deciding that a bucket is absent. A create conflict counts as success only when an exact bucket read returns the requested name; mismatched and unreadable conflicts still fail with redacted request errors. This fixes the false-create path seen in scheduled live smoke without hiding authentication or provider failures.

The implementation follows Cloudflare's current [List Buckets](https://developers.cloudflare.com/api/resources/r2/subresources/buckets/methods/list/) and [Get Bucket](https://developers.cloudflare.com/api/resources/r2/subresources/buckets/methods/get/) contracts. Pagination requests 1,000 entries per page, and rejects cursor cycles.

## Verification

- `vp test test/provision.test.ts` in `packages/blob`: 12 tests
- `vp test test/vite-output.test.ts` in `packages/blob`: 33 tests
- `vp run test:output:cloudflare`: 9 tests after local Provider Output build
- `pnpm run typecheck` in `packages/blob` and `packages/internal`
- `vp run -t @vite-hub/blob#build`: Blob/internal builds and publint
- focused oxlint and `git diff --check`

No authenticated Cloudflare request, provision, or deployment ran. The scheduled live-smoke job remains the provider-runtime proof after merge.