### PR TITLE
fix(blob): make Vercel connections idempotent

### DIFF
--- a/packages/blob/src/provision.ts
+++ b/packages/blob/src/provision.ts
@@ -45,6 +45,28 @@ const VERCEL_BLOB_STORE_NAME = "vitehub-blob"
 const VERCEL_BLOB_STORE_REGION = "iad1"
 const VERCEL_PROJECT_ENVIRONMENTS = ["production", "preview", "development"] as const
 
+function parseObject(value: unknown): Record<string, unknown> {
+  if (!value || Object(value) !== value) throw new Error("Provisioning returned an invalid response.")
+  // SAFETY: The object check establishes the string-keyed JSON object representation.
+  return value as Record<string, unknown>
+}
+
+function parseVercelBlobStoreResponse(value: unknown): VercelBlobStoreResponse {
+  return parseObject(value)
+}
+
+function parseVercelBlobStoresResponse(value: unknown): VercelBlobStoresResponse {
+  return parseObject(value)
+}
+
+function parseVercelBlobStoreCreateResponse(value: unknown): VercelBlobStoreCreateResponse {
+  return parseObject(value)
+}
+
+function parseCloudflareBuckets(value: unknown): { buckets?: CloudflareR2Bucket[] } {
+  return parseObject(value)
+}
+
 function vercelConnectionState(store: VercelBlobStore, projectId: string): "absent" | "equivalent" | "mismatched" {
   const connection = store.projectsMetadata?.find(project => project.projectId === projectId)
   if (!connection) return "absent"
@@ -57,7 +79,7 @@ async function readVercelBlobStore(
   request: ReturnType<typeof createVercelProvisionClient>,
   storeId: string,
 ): Promise<VercelBlobStore> {
-  const response = await request<VercelBlobStoreResponse>(`/storage/stores/${storeId}`)
+  const response = await request(`/storage/stores/${storeId}`, { parse: parseVercelBlobStoreResponse })
   if (!response.store) {
     throw new Error("Vercel Blob provisioning did not return store metadata.")
   }
@@ -81,6 +103,7 @@ async function ensureVercelBlobConnection(
       body: {
         envVarEnvironments: VERCEL_PROJECT_ENVIRONMENTS,
         projectId,
+        type: "integration",
       },
     })
   }
@@ -117,7 +140,7 @@ export function createBlobCloudflareProvisionStep(resolveOptions: () => BlobModu
       }
 
       const request = createCloudflareProvisionClient(config, context.fetch)
-      const listed = await request<{ buckets?: CloudflareR2Bucket[] }>("/r2/buckets")
+      const listed = await request("/r2/buckets", { parse: parseCloudflareBuckets })
       const existing = new Set((listed.result?.buckets ?? []).map(bucket => bucket.name).filter((name): name is string => Boolean(name)))
 
       return [...new Set(buckets)].map((bucketName): ProvisionAction => ({
@@ -151,7 +174,7 @@ export function createBlobVercelProvisionStep(resolveOptions: () => BlobModuleOp
       }
 
       const request = createVercelProvisionClient(config, context.fetch)
-      const listed = await request<VercelBlobStoresResponse>("/v1/storage/stores")
+      const listed = await request("/v1/storage/stores", { parse: parseVercelBlobStoresResponse })
       const existing = (listed.stores ?? []).find(store =>
         (!store.type || store.type === "blob")
         && (store.access ?? "public") === requested.access,
@@ -162,8 +185,9 @@ export function createBlobVercelProvisionStep(resolveOptions: () => BlobModuleOp
         name: existing?.name ?? VERCEL_BLOB_STORE_NAME,
         exists: Boolean(existing),
         apply: async () => {
-          const store = existing ?? (await request<VercelBlobStoreCreateResponse>("/v1/storage/stores/blob", {
+          const store = existing ?? (await request("/v1/storage/stores/blob", {
             method: "POST",
+            parse: parseVercelBlobStoreCreateResponse,
             body: {
               access: requested.access,
               name: VERCEL_BLOB_STORE_NAME,

--- a/packages/blob/src/provision.ts
+++ b/packages/blob/src/provision.ts
@@ -1,6 +1,7 @@
 import {
   createCloudflareProvisionClient,
   createVercelProvisionClient,
+  ProvisionRequestError,
   resolveCloudflareProvisionConfig,
   resolveVercelProvisionConfig,
 } from "@vite-hub/internal/provision"
@@ -19,8 +20,13 @@ interface VercelBlobStore {
   access?: "private" | "public"
   id?: string
   name?: string
-  projectsMetadata?: Array<{ projectId?: string }>
+  projectsMetadata?: VercelBlobProjectMetadata[]
   type?: string
+}
+
+interface VercelBlobProjectMetadata {
+  environments?: string[]
+  projectId?: string
 }
 
 interface VercelBlobStoresResponse {
@@ -31,9 +37,63 @@ interface VercelBlobStoreCreateResponse {
   store?: VercelBlobStore
 }
 
+interface VercelBlobStoreResponse {
+  store?: VercelBlobStore
+}
+
 const VERCEL_BLOB_STORE_NAME = "vitehub-blob"
 const VERCEL_BLOB_STORE_REGION = "iad1"
 const VERCEL_PROJECT_ENVIRONMENTS = ["production", "preview", "development"] as const
+
+function vercelConnectionState(store: VercelBlobStore, projectId: string): "absent" | "equivalent" | "mismatched" {
+  const connection = store.projectsMetadata?.find(project => project.projectId === projectId)
+  if (!connection) return "absent"
+  return VERCEL_PROJECT_ENVIRONMENTS.every(environment => connection.environments?.includes(environment))
+    ? "equivalent"
+    : "mismatched"
+}
+
+async function readVercelBlobStore(
+  request: ReturnType<typeof createVercelProvisionClient>,
+  storeId: string,
+): Promise<VercelBlobStore> {
+  const response = await request<VercelBlobStoreResponse>(`/storage/stores/${storeId}`)
+  if (!response.store) {
+    throw new Error("Vercel Blob provisioning did not return store metadata.")
+  }
+  return response.store
+}
+
+async function ensureVercelBlobConnection(
+  request: ReturnType<typeof createVercelProvisionClient>,
+  storeId: string,
+  projectId: string,
+): Promise<void> {
+  const state = vercelConnectionState(await readVercelBlobStore(request, storeId), projectId)
+  if (state === "equivalent") return
+  if (state === "mismatched") {
+    throw new Error("Vercel Blob is connected to the project without all required environments.")
+  }
+
+  try {
+    await request(`/v1/storage/stores/${storeId}/connections`, {
+      method: "POST",
+      body: {
+        envVarEnvironments: VERCEL_PROJECT_ENVIRONMENTS,
+        projectId,
+      },
+    })
+  }
+  catch (error) {
+    if (!(error instanceof ProvisionRequestError) || error.status !== 400) throw error
+    const current = vercelConnectionState(await readVercelBlobStore(request, storeId), projectId)
+    if (current === "equivalent") return
+    if (current === "mismatched") {
+      throw new Error("Vercel Blob is connected to the project without all required environments.")
+    }
+    throw error
+  }
+}
 
 function resolvedStores(options: BlobModuleOptions | undefined, env: Record<string, string | undefined>): ResolvedBlobStoreConfig[] {
   const config = resolveBlobViteConfig(options, { env })
@@ -113,16 +173,7 @@ export function createBlobVercelProvisionStep(resolveOptions: () => BlobModuleOp
           if (!store?.id) {
             throw new Error("Vercel Blob provisioning did not return a store id.")
           }
-          if (!store.projectsMetadata?.some(project => project.projectId === projectId)) {
-            await request(`/v1/storage/stores/${store.id}/connections`, {
-              method: "POST",
-              body: {
-                envVarEnvironments: VERCEL_PROJECT_ENVIRONMENTS,
-                projectId,
-                type: "integration",
-              },
-            })
-          }
+          await ensureVercelBlobConnection(request, store.id, projectId)
           return {}
         },
       }]

--- a/packages/blob/test/provision.test.ts
+++ b/packages/blob/test/provision.test.ts
@@ -12,28 +12,28 @@ describe("blob cloudflare provision step", () => {
   const env = { CLOUDFLARE_ACCOUNT_ID: "acc", CLOUDFLARE_API_TOKEN: "token", BLOB_BUCKET_NAME: "assets" }
 
   it("does not create an existing R2 bucket", async () => {
-    const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
       if (init?.method === "POST") throw new Error("must not create existing bucket")
       return jsonResponse({ success: true, result: { buckets: [{ name: "assets" }] } })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const context: ProvisionContext = { env, fetch: fetchImpl, logger: { log: () => {}, warn: () => {} } }
     const actions = await createBlobCloudflareProvisionStep(() => ({ driver: "cloudflare-r2", bucketName: "assets" })).plan(context)
     expect(actions).toHaveLength(1)
     expect(actions[0]!.exists).toBe(true)
     await actions[0]!.apply()
-    expect((fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === "POST")).toBe(false)
+    expect(fetchImpl.mock.calls.some(([, init]) => init?.method === "POST")).toBe(false)
   })
 
   it("creates a missing R2 bucket", async () => {
     const posted: unknown[] = []
-    const fetchImpl = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (_input, init) => {
       if (init?.method === "POST") {
         posted.push(JSON.parse(String(init.body)))
         return jsonResponse({ success: true, result: {} })
       }
       return jsonResponse({ success: true, result: { buckets: [] } })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const context: ProvisionContext = { env, fetch: fetchImpl, logger: { log: () => {}, warn: () => {} } }
     const actions = await createBlobCloudflareProvisionStep(() => ({ driver: "cloudflare-r2", bucketName: "assets" })).plan(context)
@@ -57,13 +57,13 @@ describe("blob vercel provision step", () => {
 
   it("re-reads list entries without connection metadata before connecting", async () => {
     const requests: Array<{ method: string, url: string, body: unknown }> = []
-    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
       const url = String(input)
       requests.push({ body: init?.body ? JSON.parse(String(init.body)) : undefined, method: init?.method ?? "GET", url })
       if (url.includes("/v1/storage/stores/store_1/connections")) return jsonResponse({}, 201)
       if (url.includes("/storage/stores/store_1")) return jsonResponse({ store: { projectsMetadata: [] } })
       return jsonResponse({ stores: [{ id: "store_1", name: "vitehub-blob", type: "blob" }] })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const actions = await createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" })).plan(context(fetchImpl))
     expect(actions).toHaveLength(1)
@@ -77,7 +77,7 @@ describe("blob vercel provision step", () => {
       { body: undefined, method: "GET", url: expect.stringContaining("/v1/storage/stores") },
       { body: undefined, method: "GET", url: expect.stringContaining("/storage/stores/store_1") },
       {
-        body: { envVarEnvironments: requiredEnvironments, projectId: "prj_1" },
+        body: { envVarEnvironments: requiredEnvironments, projectId: "prj_1", type: "integration" },
         method: "POST",
         url: expect.stringContaining("/v1/storage/stores/store_1/connections"),
       },
@@ -85,14 +85,14 @@ describe("blob vercel provision step", () => {
   })
 
   it("trusts the exact store state over omitted list metadata for an existing connection", async () => {
-    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
       const url = String(input)
       if (init?.method === "POST") throw new Error("must not reconnect an equivalent store")
       if (url.includes("/storage/stores/store_private")) {
         return jsonResponse({ store: { projectsMetadata: [connectedProject()] } })
       }
       return jsonResponse({ stores: [{ access: "private", id: "store_private", name: "vitehub-blob", type: "blob" }] })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const actions = await createBlobVercelProvisionStep(() => ({ access: "private", driver: "vercel-blob" })).plan(context(fetchImpl))
     expect(actions).toHaveLength(1)
@@ -104,7 +104,7 @@ describe("blob vercel provision step", () => {
 
   it("is idempotent across repeated provision runs", async () => {
     let connected = false
-    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchMock = vi.fn<typeof fetch>(async (input, init) => {
       const url = String(input)
       if (url.includes("/v1/storage/stores/store_1/connections")) {
         connected = true
@@ -115,20 +115,20 @@ describe("blob vercel provision step", () => {
       }
       return jsonResponse({ stores: [{ id: "store_1", name: "vitehub-blob", type: "blob" }] })
     })
-    const fetchImpl = fetchMock as unknown as typeof globalThis.fetch
+    const fetchImpl = fetchMock
 
     const step = createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" }))
     await (await step.plan(context(fetchImpl)))[0]!.apply()
     await (await step.plan(context(fetchImpl)))[0]!.apply()
 
     const connectionRequests = fetchMock.mock.calls.filter(([input, init]) =>
-      String(input).includes("/connections") && (init as RequestInit | undefined)?.method === "POST")
+      String(input).includes("/connections") && init?.method === "POST")
     expect(connectionRequests).toHaveLength(1)
   })
 
   it("creates and connects a private Blob store instead of selecting an existing public store", async () => {
     const requests: Array<{ method: string | undefined, url: string, body: unknown }> = []
-    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
       const url = String(input)
       requests.push({
         body: init?.body ? JSON.parse(String(init.body)) : undefined,
@@ -141,7 +141,7 @@ describe("blob vercel provision step", () => {
       if (url.includes("/storage/stores/store_private")) return jsonResponse({ store: { projectsMetadata: [] } })
       if (init?.method === "POST") return jsonResponse({}, 201)
       return jsonResponse({ stores: [{ access: "public", id: "store_public", name: "existing-public", type: "blob" }] })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const actions = await createBlobVercelProvisionStep(() => ({ access: "private", driver: "vercel-blob" })).plan(context(fetchImpl))
     expect(actions).toHaveLength(1)
@@ -161,7 +161,7 @@ describe("blob vercel provision step", () => {
         url: expect.stringContaining("/storage/stores/store_private"),
       },
       {
-        body: { envVarEnvironments: requiredEnvironments, projectId: "prj_1" },
+        body: { envVarEnvironments: requiredEnvironments, projectId: "prj_1", type: "integration" },
         method: "POST",
         url: expect.stringContaining("/v1/storage/stores/store_private/connections"),
       },
@@ -169,14 +169,14 @@ describe("blob vercel provision step", () => {
   })
 
   it("rejects an existing project connection with incomplete environments", async () => {
-    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
       if (init?.method === "POST") throw new Error("must not create a duplicate project connection")
       const url = String(input)
       if (url.includes("/storage/stores/store_1")) {
         return jsonResponse({ store: { projectsMetadata: [connectedProject("prj_1", ["production"])] } })
       }
       return jsonResponse({ stores: [{ id: "store_1", type: "blob" }] })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const actions = await createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" })).plan(context(fetchImpl))
     await expect(actions[0]!.apply()).rejects.toThrow("without all required environments")
@@ -185,7 +185,7 @@ describe("blob vercel provision step", () => {
 
   it("accepts a concurrent connection only after the exact store proves equivalence", async () => {
     let reads = 0
-    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
       const url = String(input)
       if (init?.method === "POST") return jsonResponse({ error: { code: "already_connected" } }, 400)
       if (url.includes("/storage/stores/store_1")) {
@@ -193,7 +193,7 @@ describe("blob vercel provision step", () => {
         return jsonResponse({ store: { projectsMetadata: reads === 1 ? [] : [connectedProject()] } })
       }
       return jsonResponse({ stores: [{ id: "store_1", type: "blob" }] })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const actions = await createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" })).plan(context(fetchImpl))
     await expect(actions[0]!.apply()).resolves.toEqual({})
@@ -202,18 +202,21 @@ describe("blob vercel provision step", () => {
 
   it("does not treat an invalid connection type or a different project as success", async () => {
     const leakedSecret = "provider-secret-in-error-body"
-    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
       const url = String(input)
       if (init?.method === "POST") {
-        const body = JSON.parse(String(init.body)) as Record<string, unknown>
-        expect(body).not.toHaveProperty("type")
+        expect(String(init.body)).toBe(JSON.stringify({
+          envVarEnvironments: requiredEnvironments,
+          projectId: "prj_1",
+          type: "integration",
+        }))
         return jsonResponse({ error: { code: "invalid_connection_type", detail: leakedSecret } }, 400)
       }
       if (url.includes("/storage/stores/store_1")) {
         return jsonResponse({ store: { projectsMetadata: [connectedProject("prj_other")] } })
       }
       return jsonResponse({ stores: [{ id: "store_1", type: "blob" }] })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const actions = await createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" })).plan(context(fetchImpl))
     let provisionError: Error | undefined
@@ -221,19 +224,19 @@ describe("blob vercel provision step", () => {
       await actions[0]!.apply()
     }
     catch (error) {
-      provisionError = error as Error
+      provisionError = error instanceof Error ? error : new Error(String(error))
     }
     expect(provisionError?.message).toContain("POST /v1/storage/stores/store_1/connections (400)")
     expect(provisionError?.message).not.toContain(leakedSecret)
   })
 
   it("surfaces wrong-team authorization without attempting a connection", async () => {
-    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+    const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
       const url = String(input)
       if (url.includes("/storage/stores/store_1")) return jsonResponse({ error: "wrong team" }, 403)
       if (init?.method === "POST") throw new Error("must not connect a store outside the team scope")
       return jsonResponse({ stores: [{ id: "store_1", type: "blob" }] })
-    }) as unknown as typeof globalThis.fetch
+    })
 
     const actions = await createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" })).plan(context(fetchImpl))
     await expect(actions[0]!.apply()).rejects.toThrow("GET /storage/stores/store_1 (403)")

--- a/packages/blob/test/provision.test.ts
+++ b/packages/blob/test/provision.test.ts
@@ -4,8 +4,8 @@ import { createBlobCloudflareProvisionStep, createBlobVercelProvisionStep } from
 
 import type { ProvisionContext } from "@vite-hub/internal/provision"
 
-function jsonResponse(body: unknown) {
-  return new Response(JSON.stringify(body), { headers: { "content-type": "application/json" } })
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), { headers: { "content-type": "application/json" }, status })
 }
 
 describe("blob cloudflare provision step", () => {
@@ -45,20 +45,27 @@ describe("blob cloudflare provision step", () => {
 
 describe("blob vercel provision step", () => {
   const env = { VERCEL_TOKEN: "vtoken", VERCEL_PROJECT_ID: "prj_1", BLOB_READ_WRITE_TOKEN: "secret-token" }
+  const requiredEnvironments = ["production", "preview", "development"]
 
-  it("reuses a public Blob store and connects it without exposing its token", async () => {
-    const requests: Array<{ url: string, body: unknown }> = []
+  function context(fetchImpl: typeof globalThis.fetch): ProvisionContext {
+    return { env, fetch: fetchImpl, logger: { log: () => {}, warn: () => {} } }
+  }
+
+  function connectedProject(projectId = "prj_1", environments = requiredEnvironments) {
+    return { environments, projectId }
+  }
+
+  it("re-reads list entries without connection metadata before connecting", async () => {
+    const requests: Array<{ method: string, url: string, body: unknown }> = []
     const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = String(input)
-      if (init?.method === "POST") {
-        requests.push({ url, body: init.body ? JSON.parse(String(init.body)) : undefined })
-        return jsonResponse({})
-      }
+      requests.push({ body: init?.body ? JSON.parse(String(init.body)) : undefined, method: init?.method ?? "GET", url })
+      if (url.includes("/v1/storage/stores/store_1/connections")) return jsonResponse({}, 201)
+      if (url.includes("/storage/stores/store_1")) return jsonResponse({ store: { projectsMetadata: [] } })
       return jsonResponse({ stores: [{ id: "store_1", name: "vitehub-blob", type: "blob" }] })
     }) as unknown as typeof globalThis.fetch
 
-    const context: ProvisionContext = { env, fetch: fetchImpl, logger: { log: () => {}, warn: () => {} } }
-    const actions = await createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" })).plan(context)
+    const actions = await createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" })).plan(context(fetchImpl))
     expect(actions).toHaveLength(1)
     expect(actions[0]!.exists).toBe(true)
     const result = await actions[0]!.apply()
@@ -66,34 +73,57 @@ describe("blob vercel provision step", () => {
     expect(result.ids).toBeUndefined()
     expect(JSON.stringify(result)).not.toContain("secret-token")
     expect(JSON.stringify(requests)).not.toContain("secret-token")
-    expect(requests).toEqual([{
-      body: {
-        envVarEnvironments: ["production", "preview", "development"],
-        projectId: "prj_1",
-        type: "integration",
+    expect(requests).toEqual([
+      { body: undefined, method: "GET", url: expect.stringContaining("/v1/storage/stores") },
+      { body: undefined, method: "GET", url: expect.stringContaining("/storage/stores/store_1") },
+      {
+        body: { envVarEnvironments: requiredEnvironments, projectId: "prj_1" },
+        method: "POST",
+        url: expect.stringContaining("/v1/storage/stores/store_1/connections"),
       },
-      url: expect.stringContaining("/v1/storage/stores/store_1/connections"),
-    }])
+    ])
   })
 
-  it("does not reconnect an already connected private Blob store", async () => {
-    const fetchImpl = vi.fn(async () => jsonResponse({
-      stores: [{
-        access: "private",
-        id: "store_private",
-        name: "vitehub-blob",
-        projectsMetadata: [{ projectId: "prj_1" }],
-        type: "blob",
-      }],
-    })) as unknown as typeof globalThis.fetch
+  it("trusts the exact store state over omitted list metadata for an existing connection", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      if (init?.method === "POST") throw new Error("must not reconnect an equivalent store")
+      if (url.includes("/storage/stores/store_private")) {
+        return jsonResponse({ store: { projectsMetadata: [connectedProject()] } })
+      }
+      return jsonResponse({ stores: [{ access: "private", id: "store_private", name: "vitehub-blob", type: "blob" }] })
+    }) as unknown as typeof globalThis.fetch
 
-    const context: ProvisionContext = { env, fetch: fetchImpl, logger: { log: () => {}, warn: () => {} } }
-    const actions = await createBlobVercelProvisionStep(() => ({ access: "private", driver: "vercel-blob" })).plan(context)
+    const actions = await createBlobVercelProvisionStep(() => ({ access: "private", driver: "vercel-blob" })).plan(context(fetchImpl))
     expect(actions).toHaveLength(1)
     expect(actions[0]!.exists).toBe(true)
     await actions[0]!.apply()
 
-    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it("is idempotent across repeated provision runs", async () => {
+    let connected = false
+    const fetchMock = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes("/v1/storage/stores/store_1/connections")) {
+        connected = true
+        return jsonResponse({}, 201)
+      }
+      if (url.includes("/storage/stores/store_1")) {
+        return jsonResponse({ store: { projectsMetadata: connected ? [connectedProject()] : [] } })
+      }
+      return jsonResponse({ stores: [{ id: "store_1", name: "vitehub-blob", type: "blob" }] })
+    })
+    const fetchImpl = fetchMock as unknown as typeof globalThis.fetch
+
+    const step = createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" }))
+    await (await step.plan(context(fetchImpl)))[0]!.apply()
+    await (await step.plan(context(fetchImpl)))[0]!.apply()
+
+    const connectionRequests = fetchMock.mock.calls.filter(([input, init]) =>
+      String(input).includes("/connections") && (init as RequestInit | undefined)?.method === "POST")
+    expect(connectionRequests).toHaveLength(1)
   })
 
   it("creates and connects a private Blob store instead of selecting an existing public store", async () => {
@@ -108,12 +138,12 @@ describe("blob vercel provision step", () => {
       if (url.includes("/v1/storage/stores/blob")) {
         return jsonResponse({ store: { access: "private", id: "store_private", name: "vitehub-blob", type: "blob" } })
       }
-      if (init?.method === "POST") return jsonResponse({})
+      if (url.includes("/storage/stores/store_private")) return jsonResponse({ store: { projectsMetadata: [] } })
+      if (init?.method === "POST") return jsonResponse({}, 201)
       return jsonResponse({ stores: [{ access: "public", id: "store_public", name: "existing-public", type: "blob" }] })
     }) as unknown as typeof globalThis.fetch
 
-    const context: ProvisionContext = { env, fetch: fetchImpl, logger: { log: () => {}, warn: () => {} } }
-    const actions = await createBlobVercelProvisionStep(() => ({ access: "private", driver: "vercel-blob" })).plan(context)
+    const actions = await createBlobVercelProvisionStep(() => ({ access: "private", driver: "vercel-blob" })).plan(context(fetchImpl))
     expect(actions).toHaveLength(1)
     expect(actions[0]!.exists).toBe(false)
     await actions[0]!.apply()
@@ -126,14 +156,87 @@ describe("blob vercel provision step", () => {
         url: expect.stringContaining("/v1/storage/stores/blob"),
       },
       {
-        body: {
-          envVarEnvironments: ["production", "preview", "development"],
-          projectId: "prj_1",
-          type: "integration",
-        },
+        body: undefined,
+        method: "GET",
+        url: expect.stringContaining("/storage/stores/store_private"),
+      },
+      {
+        body: { envVarEnvironments: requiredEnvironments, projectId: "prj_1" },
         method: "POST",
         url: expect.stringContaining("/v1/storage/stores/store_private/connections"),
       },
     ])
+  })
+
+  it("rejects an existing project connection with incomplete environments", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === "POST") throw new Error("must not create a duplicate project connection")
+      const url = String(input)
+      if (url.includes("/storage/stores/store_1")) {
+        return jsonResponse({ store: { projectsMetadata: [connectedProject("prj_1", ["production"])] } })
+      }
+      return jsonResponse({ stores: [{ id: "store_1", type: "blob" }] })
+    }) as unknown as typeof globalThis.fetch
+
+    const actions = await createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" })).plan(context(fetchImpl))
+    await expect(actions[0]!.apply()).rejects.toThrow("without all required environments")
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
+  })
+
+  it("accepts a concurrent connection only after the exact store proves equivalence", async () => {
+    let reads = 0
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      if (init?.method === "POST") return jsonResponse({ error: { code: "already_connected" } }, 400)
+      if (url.includes("/storage/stores/store_1")) {
+        reads++
+        return jsonResponse({ store: { projectsMetadata: reads === 1 ? [] : [connectedProject()] } })
+      }
+      return jsonResponse({ stores: [{ id: "store_1", type: "blob" }] })
+    }) as unknown as typeof globalThis.fetch
+
+    const actions = await createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" })).plan(context(fetchImpl))
+    await expect(actions[0]!.apply()).resolves.toEqual({})
+    expect(reads).toBe(2)
+  })
+
+  it("does not treat an invalid connection type or a different project as success", async () => {
+    const leakedSecret = "provider-secret-in-error-body"
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      if (init?.method === "POST") {
+        const body = JSON.parse(String(init.body)) as Record<string, unknown>
+        expect(body).not.toHaveProperty("type")
+        return jsonResponse({ error: { code: "invalid_connection_type", detail: leakedSecret } }, 400)
+      }
+      if (url.includes("/storage/stores/store_1")) {
+        return jsonResponse({ store: { projectsMetadata: [connectedProject("prj_other")] } })
+      }
+      return jsonResponse({ stores: [{ id: "store_1", type: "blob" }] })
+    }) as unknown as typeof globalThis.fetch
+
+    const actions = await createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" })).plan(context(fetchImpl))
+    let provisionError: Error | undefined
+    try {
+      await actions[0]!.apply()
+    }
+    catch (error) {
+      provisionError = error as Error
+    }
+    expect(provisionError?.message).toContain("POST /v1/storage/stores/store_1/connections (400)")
+    expect(provisionError?.message).not.toContain(leakedSecret)
+  })
+
+  it("surfaces wrong-team authorization without attempting a connection", async () => {
+    const fetchImpl = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes("/storage/stores/store_1")) return jsonResponse({ error: "wrong team" }, 403)
+      if (init?.method === "POST") throw new Error("must not connect a store outside the team scope")
+      return jsonResponse({ stores: [{ id: "store_1", type: "blob" }] })
+    }) as unknown as typeof globalThis.fetch
+
+    const actions = await createBlobVercelProvisionStep(() => ({ driver: "vercel-blob" })).plan(context(fetchImpl))
+    await expect(actions[0]!.apply()).rejects.toThrow("GET /storage/stores/store_1 (403)")
+    expect(fetchImpl).toHaveBeenCalledTimes(2)
   })
 })

--- a/packages/database/src/provision.ts
+++ b/packages/database/src/provision.ts
@@ -19,6 +19,17 @@ interface PlannedDatabase {
   nuxt: boolean
 }
 
+function parseDatabases(value: unknown): CloudflareD1Database[] {
+  if (!Array.isArray(value)) throw new Error("Cloudflare provisioning returned an invalid database list.")
+  // SAFETY: D1 database fields are optional and consumers narrow them before use.
+  return value as CloudflareD1Database[]
+}
+
+function parseDatabase(value: unknown): CloudflareD1Database {
+  if (!value || Object(value) !== value) throw new Error("Cloudflare provisioning returned an invalid database.")
+  return value
+}
+
 export function getDatabaseNuxtProvisionStateKey(databaseName: string) {
   return encodeURIComponent(databaseName.trim())
 }
@@ -61,7 +72,7 @@ export function createDatabaseProvisionStep(resolveRootDir: () => string, option
       if (!planned.length) return []
 
       const request = createCloudflareProvisionClient(config, context.fetch)
-      const listed = await request<CloudflareD1Database[]>("/d1/database")
+      const listed = await request("/d1/database", { parse: parseDatabases })
       const idByName = new Map((listed.result ?? [])
         .filter((database): database is { name: string, uuid: string } => Boolean(database.name && database.uuid))
         .map(database => [database.name, database.uuid]))
@@ -75,7 +86,7 @@ export function createDatabaseProvisionStep(resolveRootDir: () => string, option
           apply: async () => {
             let id = existingId
             if (!id) {
-              const created = await request<CloudflareD1Database>("/d1/database", { method: "POST", body: { name: databaseName } })
+              const created = await request("/d1/database", { method: "POST", body: { name: databaseName }, parse: parseDatabase })
               id = created.result?.uuid
             }
             if (!id) return {}

--- a/packages/internal/src/provision.ts
+++ b/packages/internal/src/provision.ts
@@ -70,7 +70,14 @@ interface ProvisionRequestOptions {
   query?: Record<string, string>
 }
 
-export type ProvisionRequest = <T>(path: string, options?: ProvisionRequestOptions) => Promise<T>
+interface ParsedProvisionRequestOptions<T> extends ProvisionRequestOptions {
+  parse: (value: unknown) => T
+}
+
+export interface ProvisionRequest {
+  (path: string, options?: ProvisionRequestOptions): Promise<unknown>
+  <T>(path: string, options: ParsedProvisionRequestOptions<T>): Promise<T>
+}
 
 export class ProvisionRequestError extends Error {
   readonly status: number
@@ -84,25 +91,29 @@ export class ProvisionRequestError extends Error {
 
 // Minimal JSON REST client for provisioning. Uses the provided fetch; no SDK dependency.
 function createJsonClient(baseURL: string, headers: Record<string, string>, fetchImpl: typeof globalThis.fetch, baseQuery?: Record<string, string>): ProvisionRequest {
-  return async function request<T>(path: string, options: ProvisionRequestOptions = {}): Promise<T> {
+  return async function request<T>(path: string, options: ProvisionRequestOptions | ParsedProvisionRequestOptions<T> = {}): Promise<unknown> {
     const url = new URL(`${baseURL}${path}`)
     for (const [key, value] of Object.entries({ ...baseQuery, ...options.query })) {
       url.searchParams.set(key, value)
     }
     const init: RequestInit = { method: options.method ?? "GET", headers: { ...headers } }
-    if (typeof options.body !== "undefined") {
-      ;(init.headers as Record<string, string>)["content-type"] = "application/json"
+    if (options.body !== undefined) {
+      init.headers = { ...init.headers, "content-type": "application/json" }
       init.body = JSON.stringify(options.body)
     }
     const response = await fetchImpl(url, init)
     if (!response.ok) {
       throw new ProvisionRequestError(`Provision request failed: ${options.method ?? "GET"} ${path} (${response.status}).`, response.status)
     }
-    return await response.json() as T
+    const value: unknown = await response.json()
+    return "parse" in options ? options.parse(value) : value
   }
 }
 
-export type CloudflareProvisionRequest = <T>(path: string, options?: ProvisionRequestOptions) => Promise<CloudflareEnvelope<T>>
+export interface CloudflareProvisionRequest {
+  (path: string, options?: ProvisionRequestOptions): Promise<CloudflareEnvelope<unknown>>
+  <T>(path: string, options: ParsedProvisionRequestOptions<T>): Promise<CloudflareEnvelope<T>>
+}
 
 // Keep provisioning HTTP local so the CLI does not grow a public CI abstraction.
 export function createCloudflareProvisionClient(config: CloudflareProvisionConfig, fetchImpl: typeof globalThis.fetch = globalThis.fetch): CloudflareProvisionRequest {
@@ -111,7 +122,19 @@ export function createCloudflareProvisionClient(config: CloudflareProvisionConfi
     { authorization: `Bearer ${config.token}` },
     fetchImpl,
   )
-  return <T>(path: string, options?: ProvisionRequestOptions) => client<CloudflareEnvelope<T>>(path, options)
+  return async <T>(path: string, options: ProvisionRequestOptions | ParsedProvisionRequestOptions<T> = {}) => {
+    // SAFETY: Without a parser, Cloudflare result data retains the request's unknown response contract.
+    const parse = "parse" in options ? options.parse : (value: unknown) => value as T
+    return await client(path, {
+      ...options,
+      parse(value) {
+        if (!value || Object(value) !== value) throw new Error("Cloudflare provisioning returned an invalid response.")
+        // SAFETY: The object check establishes the optional Cloudflare envelope representation.
+        const envelope = value as CloudflareEnvelope<unknown>
+        return { ...envelope, result: envelope.result === undefined ? undefined : parse(envelope.result) }
+      },
+    })
+  }
 }
 
 // Minimal Vercel REST client for provisioning. teamId is applied to every request as a query param.

--- a/packages/internal/src/provision.ts
+++ b/packages/internal/src/provision.ts
@@ -72,6 +72,16 @@ interface ProvisionRequestOptions {
 
 export type ProvisionRequest = <T>(path: string, options?: ProvisionRequestOptions) => Promise<T>
 
+export class ProvisionRequestError extends Error {
+  readonly status: number
+
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = "ProvisionRequestError"
+    this.status = status
+  }
+}
+
 // Minimal JSON REST client for provisioning. Uses the provided fetch; no SDK dependency.
 function createJsonClient(baseURL: string, headers: Record<string, string>, fetchImpl: typeof globalThis.fetch, baseQuery?: Record<string, string>): ProvisionRequest {
   return async function request<T>(path: string, options: ProvisionRequestOptions = {}): Promise<T> {
@@ -86,7 +96,7 @@ function createJsonClient(baseURL: string, headers: Record<string, string>, fetc
     }
     const response = await fetchImpl(url, init)
     if (!response.ok) {
-      throw new Error(`Provision request failed: ${options.method ?? "GET"} ${path} (${response.status}).`)
+      throw new ProvisionRequestError(`Provision request failed: ${options.method ?? "GET"} ${path} (${response.status}).`, response.status)
     }
     return await response.json() as T
   }

--- a/packages/queue/src/provision.ts
+++ b/packages/queue/src/provision.ts
@@ -9,6 +9,12 @@ interface CloudflareQueue {
   queue_name?: string
 }
 
+function parseQueues(value: unknown): CloudflareQueue[] {
+  if (!Array.isArray(value)) throw new Error("Cloudflare provisioning returned an invalid queue list.")
+  // SAFETY: Queue fields are optional and consumers narrow queue_name before use.
+  return value as CloudflareQueue[]
+}
+
 export function createQueueProvisionStep(resolveRootDir: () => string, resolveNamePrefix: () => string | undefined = () => undefined): ProvisionStep {
   return {
     id: "queue:cloudflare-queues",
@@ -25,7 +31,7 @@ export function createQueueProvisionStep(resolveRootDir: () => string, resolveNa
       const names = discoverQueueDefinitions({ rootDir: resolveRootDir() }).map(definition => getCloudflareQueueName(definition.name, namePrefix))
       if (!names.length) return []
 
-      const listed = await request<CloudflareQueue[]>("/queues")
+      const listed = await request("/queues", { parse: parseQueues })
       const existing = new Set((listed.result ?? []).map(queue => queue.queue_name).filter((name): name is string => Boolean(name)))
 
       return names.map((name): ProvisionAction => ({


### PR DESCRIPTION
## Summary

- re-read an exact Vercel Blob store before deciding whether its project connection exists
- require the target project to include production, preview, and development environments
- recover from a concurrent 400 only when a second exact read proves equivalent state
- keep the established Blob connection payload and provider error bodies out of diagnostics
- parse provisioning responses explicitly at the shared HTTP boundary

## Why

Scheduled live provisioning can discover an existing Blob store from the list endpoint and then receive a 400 while posting its connection. List entries do not reliably include project connection metadata, so they cannot establish whether reconnecting is necessary.

The public Vercel OpenAPI does not document the Blob connection route. This change therefore preserves the repository's established `type: "integration"` payload for that route while making its surrounding idempotency checks stricter. A 400 is accepted only when an authoritative second read proves that the requested project and all three environments are connected.

## Verification

- `node node_modules/vite-doctor/dist/cli.mjs scan . --extends vite-doctor/typescript/strict --since HEAD^ --baseline .vite-doctor-baseline.json --new-only --no-cache --max-warnings 0`
- `corepack pnpm --filter @vite-hub/internal exec tsc --noEmit -p ./tsconfig.json`
- Direct Blob, database, and queue validation was unavailable without the package builds prohibited in this repair pass; CI will run those checks on the pushed head.

Coverage includes incomplete list metadata, authoritative existing state, repeated provision, public/private selection, incomplete environments, a concurrent connect, invalid connection input, a different project, wrong-team authorization, and secret-redacted errors.

## Overlap

This PR is based directly on `main`, not stacked on #1071. Both PRs add the same minimal status-bearing provisioning error seam in `packages/internal/src/provision.ts`; whichever lands second may need a small conflict resolution there, while their provider behavior and tests remain independent.
