### PR TITLE
refactor(workflow): own step registry rendering

### DIFF
--- a/packages/internal/src/definition-catalog.ts
+++ b/packages/internal/src/definition-catalog.ts
@@ -82,6 +82,7 @@ function readDirEntries(root: string): Dirent[] {
     return readdirSync(root, { withFileTypes: true })
   }
   catch (error) {
+    // SAFETY: Node filesystem failures expose their stable error code through ErrnoException.
     if ((error as NodeJS.ErrnoException).code === "ENOENT") {
       return []
     }
@@ -213,6 +214,7 @@ function createDefinition<TDefinition extends DiscoveredDefinition>(
     return source.createDefinition({ file, name })
   }
 
+  // SAFETY: Catalog sources may refine DiscoveredDefinition without supplying a custom factory.
   return {
     handler: file,
     name,

--- a/packages/internal/src/definition-catalog.ts
+++ b/packages/internal/src/definition-catalog.ts
@@ -2,7 +2,7 @@ import type { Dirent } from "node:fs"
 import { readdirSync } from "node:fs"
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 
-import { dirname, relative, resolve } from "pathe"
+import { relative, resolve } from "pathe"
 
 import { generatedDirSegments } from "./build/paths.ts"
 
@@ -278,58 +278,11 @@ function createImportExpression(registryFile: string, file: string): string {
   return `import(${JSON.stringify(importPath.startsWith(".") ? importPath : `./${importPath}`)})`
 }
 
-export function createRuntimeRegistryContents(registryFile: string, definitions: Array<Pick<DiscoveredDefinition, "handler" | "name"> & { steps?: string[] }>): string {
-  const needsWorkflowRuntime = definitions.some(definition => definition.steps?.length)
-  const runtimeImport = needsWorkflowRuntime
-    ? [
-        `import { createWorkflowSteps } from "@vite-hub/workflow/runtime/execute"`,
-        `import { takeInlineWorkflowDefinitionForModule } from "@vite-hub/workflow/runtime/state"`,
-      ]
-    : []
-  const imports = definitions.map((definition) => {
-    if (!definition.steps?.length) {
-      return `  ${JSON.stringify(definition.name)}: async () => ${createImportExpression(registryFile, definition.handler)},`
-    }
-
-    const workflowDirectory = /\.(?:c|m)?[jt]s$/i.test(definition.handler) ? dirname(definition.handler) : definition.handler
-    const stepImports = definition.steps.map((step) => {
-      const stepName = relative(workflowDirectory, step)
-      return `{ name: ${JSON.stringify(stepName)}, run: (await ${createImportExpression(registryFile, step)}).default }`
-    })
-
-    const hasIndex = /\.(?:c|m)?[jt]s$/i.test(definition.handler)
-    const indexImport = hasIndex ? `const index = await ${createImportExpression(registryFile, definition.handler)}` : ""
-    const handler = hasIndex
-      ? `index.default?.handler ? index.default : takeInlineWorkflowDefinitionForModule(${JSON.stringify(definition.name)}, index) || { handler: index.default }`
-      : "{ handler: async (context) => { let value = context.payload; for (const step of Object.values(context.steps || {})) value = await step(value); return value } }"
-
-    return [
-      `  ${JSON.stringify(definition.name)}: async () => {`,
-      `    const cached = registryEntryCache.get(${JSON.stringify(definition.name)})`,
-      "    if (cached) return cached",
-      indexImport ? `    ${indexImport}` : "",
-      `    const steps = [${stepImports.join(", ")}]`,
-      `    const definition = ${handler}`,
-      "    const entry = {",
-      "      ...definition,",
-      "      options: { ...definition.options, rootStep: false },",
-      "      handler: async (context) => {",
-      "        const workflowSteps = createWorkflowSteps(context, steps)",
-      "        return await definition.handler({ ...context, steps: workflowSteps })",
-      "      },",
-      "    }",
-      `    registryEntryCache.set(${JSON.stringify(definition.name)}, entry)`,
-      "    return entry",
-      "  },",
-    ].filter(Boolean).join("\n")
-  })
-
+export function createRuntimeRegistryContents(registryFile: string, definitions: Array<Pick<DiscoveredDefinition, "handler" | "name">>): string {
   return [
-    ...runtimeImport,
-    runtimeImport.length ? "" : "",
-    ...(needsWorkflowRuntime ? ["const registryEntryCache = new Map()", ""] : []),
+    "",
     "const registry = {",
-    ...imports,
+    ...definitions.map(definition => `  ${JSON.stringify(definition.name)}: async () => ${createImportExpression(registryFile, definition.handler)},`),
     "}",
     "",
     "export default registry",

--- a/packages/internal/test/definition-discovery.test.ts
+++ b/packages/internal/test/definition-discovery.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { pathToFileURL } from "node:url"
 
 import { afterEach, describe, expect, it } from "vitest"
 
@@ -94,29 +95,33 @@ describe("mergeDefinitions", () => {
 })
 
 describe("createRuntimeRegistryContents", () => {
-  it("creates a sync import map with relative paths", () => {
-    const registryFile = "/root/.vitehub/sandbox/registry.mjs"
+  it.each(["queue", "realtime", "sandbox", "schedule"])("renders and executes the %s owner registry", async (owner) => {
+    const root = await createTempDir(`vitehub-internal-${owner}-registry-`)
+    const registryFile = join(root, ".vitehub", owner, "registry.mjs")
+    const handler = join(root, "definitions", `${owner}.mjs`)
+    await mkdir(join(root, "definitions"), { recursive: true })
+    await writeFile(handler, `export default ${JSON.stringify(owner)}\n`, "utf8")
     const contents = createRuntimeRegistryContents(registryFile, [{
-      handler: "/root/server/sandboxes/release-notes.ts",
-      name: "release-notes",
-    }])
-    expect(contents).toContain('"release-notes": async () => import("../../server/sandboxes/release-notes.ts")')
-    expect(contents).toContain("export default registry")
-  })
-
-  it("creates workflow step registry entries that can wrap inline definitions", () => {
-    const registryFile = "/root/.vitehub/workflow/registry.mjs"
-    const contents = createRuntimeRegistryContents(registryFile, [{
-      handler: "/root/server/workflows/chat/index.ts",
-      name: "server/workflows/chat",
-      steps: ["/root/server/workflows/chat/01.reply.ts"],
+      handler,
+      name: owner,
     }])
 
-    expect(contents).toContain('import { takeInlineWorkflowDefinitionForModule } from "@vite-hub/workflow/runtime/state"')
-    expect(contents).toContain("const registryEntryCache = new Map()")
-    expect(contents).toContain('const cached = registryEntryCache.get("server/workflows/chat")')
-    expect(contents).toContain('takeInlineWorkflowDefinitionForModule("server/workflows/chat", index)')
-    expect(contents).toContain('registryEntryCache.set("server/workflows/chat", entry)')
+    expect(contents).toBe([
+      "",
+      "const registry = {",
+      `  ${JSON.stringify(owner)}: async () => import(${JSON.stringify(`../../definitions/${owner}.mjs`)}),`,
+      "}",
+      "",
+      "export default registry",
+      "",
+    ].join("\n"))
+    expect(contents).not.toContain("@vite-hub/workflow")
+
+    await mkdir(join(root, ".vitehub", owner), { recursive: true })
+    await writeFile(registryFile, contents, "utf8")
+    const generated = await import(`${pathToFileURL(registryFile).href}?owner=${owner}`)
+    const registry = generated.default as Record<string, () => Promise<{ default: string }>>
+    await expect(registry[owner]!()).resolves.toMatchObject({ default: owner })
   })
 })
 

--- a/packages/internal/test/definition-discovery.test.ts
+++ b/packages/internal/test/definition-discovery.test.ts
@@ -120,6 +120,7 @@ describe("createRuntimeRegistryContents", () => {
     await mkdir(join(root, ".vitehub", owner), { recursive: true })
     await writeFile(registryFile, contents, "utf8")
     const generated = await import(`${pathToFileURL(registryFile).href}?owner=${owner}`)
+    // SAFETY: The generated fixture above exports this exact registry contract.
     const registry = generated.default as Record<string, () => Promise<{ default: string }>>
     await expect(registry[owner]!()).resolves.toMatchObject({ default: owner })
   })

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -873,7 +873,7 @@ function renderWorkflowRegistryEntry(registryFile: string, definition: Discovere
   ].filter(Boolean).join("\n")
 }
 
-function createWorkflowRegistryContents(
+export function createWorkflowRegistryContents(
   registryFile: string,
   definitions: DiscoveredWorkflowDefinition[],
   importBases: WorkflowImportBases = {},

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -1435,6 +1435,6 @@ async function generateProviderOutputsWithinLock(
   return artifacts
 }
 
-export async function generateProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedWorkflowArtifacts> {
+export async function generateWorkflowProviderOutputs(options: GenerateProviderOutputsOptions): Promise<GeneratedWorkflowArtifacts> {
   return await withProviderDeploymentOutputLock(options.rootDir, async write => await generateProviderOutputsWithinLock(options, write))
 }

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -7,7 +7,7 @@ import { collectViteHubProviderImportAliases, createNoExternalMerger, isServerEn
 import { normalizeHosting } from "@vite-hub/internal/hosting"
 
 import { normalizeWorkflowOptions } from "./config.ts"
-import { createCloudflareWorkflowNitroConfig, createOptionalViteDevtoolsPlugin, createVercelWorkflowTransformPlugin, generateProviderOutputs, hasVercelNativeWorkflowEntry, workflowPackageName, writeProviderEntries } from "./internal/vite-build.ts"
+import { createCloudflareWorkflowNitroConfig, createOptionalViteDevtoolsPlugin, createVercelWorkflowTransformPlugin, generateWorkflowProviderOutputs, hasVercelNativeWorkflowEntry, workflowPackageName, writeProviderEntries } from "./internal/vite-build.ts"
 
 import type { WorkflowModuleOptions } from "./types.ts"
 import type { ComposedProviderOutput } from "@vite-hub/internal/build/deployment-output"
@@ -179,7 +179,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions, internalOptions: In
       if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) {
         return
       }
-      await generateProviderOutputs({
+      await generateWorkflowProviderOutputs({
         agentImportBase: internalOptions?.agentImportBase,
         clientOutDir: resolve(resolved.root, resolved.build.outDir),
         hosting: internalOptions?.hosting,

--- a/packages/workflow/test/registry.test.ts
+++ b/packages/workflow/test/registry.test.ts
@@ -68,6 +68,7 @@ describe("Workflow registry", () => {
 
     await writeFile(registryFile, contents, "utf8")
     const generated = await import(`${pathToFileURL(registryFile).href}?test=workflow-owner`)
+    // SAFETY: The generated fixture above exports this exact Workflow registry contract.
     const registry = generated.default as Record<string, () => Promise<{
       handler: (context: { name: string, payload: number, provider: "openworkflow" }) => Promise<number>
       options: { owner: string, rootStep: false }

--- a/packages/workflow/test/registry.test.ts
+++ b/packages/workflow/test/registry.test.ts
@@ -1,0 +1,80 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+import { createWorkflowRegistryContents } from "../src/internal/vite-build.ts"
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const directories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map(directory => rm(directory, { force: true, recursive: true })))
+})
+
+describe("Workflow registry", () => {
+  it("renders, caches, and executes step-aware definitions", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-workflow-registry-"))
+    directories.push(root)
+    const workflowDirectory = join(root, "server", "workflows", "release")
+    const registryFile = join(root, ".vitehub", "workflow", "registry.mjs")
+    const handler = join(workflowDirectory, "index.mjs")
+    const step = join(workflowDirectory, "01.add.mjs")
+    await mkdir(join(root, "node_modules", "@vite-hub"), { recursive: true })
+    await mkdir(dirname(registryFile), { recursive: true })
+    await mkdir(workflowDirectory, { recursive: true })
+    await symlink(packageRoot, join(root, "node_modules", "@vite-hub", "workflow"), "dir")
+    await writeFile(handler, "export default { handler: async ({ payload, steps }) => await steps.add(payload), options: { owner: 'workflow' } }\n", "utf8")
+    await writeFile(step, "export default async function add(value) { return value + 1 }\n", "utf8")
+
+    const contents = createWorkflowRegistryContents(registryFile, [{
+      handler,
+      name: "release",
+      source: "server-workflows",
+      steps: [step],
+    }])
+
+    expect(contents).toBe([
+      'import { createWorkflowSteps } from "@vite-hub/workflow/runtime/execute"',
+      'import { takeInlineWorkflowDefinitionForModule } from "@vite-hub/workflow/runtime/state"',
+      "",
+      "const registryEntryCache = new Map()",
+      "",
+      "const registry = {",
+      '  "release": async () => {',
+      '    const cached = registryEntryCache.get("release")',
+      "    if (cached) return cached",
+      '    const index = await import("../../server/workflows/release/index.mjs")',
+      '    const steps = [{ name: "01.add.mjs", run: (await import("../../server/workflows/release/01.add.mjs")).default }]',
+      '    const definition = index.default?.handler ? index.default : takeInlineWorkflowDefinitionForModule("release", index) || { handler: index.default }',
+      "    const entry = {",
+      "      ...definition,",
+      "      options: { ...definition.options, rootStep: false },",
+      "      handler: async (context) => {",
+      "        const workflowSteps = createWorkflowSteps(context, steps)",
+      "        return await definition.handler({ ...context, steps: workflowSteps })",
+      "      },",
+      "    }",
+      '    registryEntryCache.set("release", entry)',
+      "    return entry",
+      "  },",
+      "}",
+      "",
+      "export default registry",
+      "",
+    ].join("\n"))
+
+    await writeFile(registryFile, contents, "utf8")
+    const generated = await import(`${pathToFileURL(registryFile).href}?test=workflow-owner`)
+    const registry = generated.default as Record<string, () => Promise<{
+      handler: (context: { name: string, payload: number, provider: "openworkflow" }) => Promise<number>
+      options: { owner: string, rootStep: false }
+    }>>
+    const definition = await registry.release!()
+    await expect(definition.handler({ name: "release", payload: 1, provider: "openworkflow" })).resolves.toBe(2)
+    expect(definition.options).toEqual({ owner: "workflow", rootStep: false })
+    await expect(registry.release!()).resolves.toBe(definition)
+  })
+})

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -10,7 +10,7 @@ import { hasRuntimeType, isRuntimeRecord } from "../src/internal/runtime-type.ts
 import { createDefaultCloudflareOutputRoot } from "@vite-hub/internal/build/deployment-output"
 
 import { getCloudflareWorkflowBindingName, getCloudflareWorkflowClassName, getCloudflareWorkflowName } from "../src/integrations/cloudflare.ts"
-import { cleanVercelNativeWorkflowOutput, generateProviderOutputs, hasVercelNativeWorkflowEntry, installEmailDefinitionInVercelWorkflowOutput, writeProviderEntries } from "../src/internal/vite-build.ts"
+import { cleanVercelNativeWorkflowOutput, generateWorkflowProviderOutputs, hasVercelNativeWorkflowEntry, installEmailDefinitionInVercelWorkflowOutput, writeProviderEntries } from "../src/internal/vite-build.ts"
 
 const execFileAsync = promisify(execFile)
 const playgroundDir = resolve(import.meta.dirname, "../../../playground/vite")
@@ -115,7 +115,7 @@ it("bundles only the host-inferred Cloudflare output with Cloudflare Email impor
   await writeFile(emailDefinition, "import { EmailMessage } from 'cloudflare:email'\nexport default EmailMessage\n")
   await writeFile(join(workflowDir, "01-email.ts"), "import email from '#vitehub/email/definition'\nexport default async function send() { return email }\n")
 
-  await generateProviderOutputs({
+  await generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist", "client"),
     hosting: "cloudflare-module",
     providerImportAliases: { "#vitehub/email/definition": emailDefinition },
@@ -221,7 +221,7 @@ it("restores prior owned native output when Email installation fails", { timeout
   await writeViteHubWorkflowOwnership(workflowRoot, ["v1/flow.func/index.mjs"], [externalRoute])
   await writeFile(configFile, `${JSON.stringify({ routes: [externalRoute] })}\n`)
 
-  await expect(generateProviderOutputs({
+  await expect(generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     importBase: "@vite-hub/workflow",
     providerImportAliases: { "#vitehub/email/definition": join(rootDir, "missing-email-definition.mjs") },
@@ -351,7 +351,7 @@ it("rejects native generation that would replace unowned canonical WDK output", 
   await mkdir(resolve(configFile, ".."), { recursive: true })
   await writeFile(configFile, `${JSON.stringify({ routes: [externalRoute, canonicalRoute] })}\n`)
 
-  await expect(generateProviderOutputs({
+  await expect(generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     importBase: "@vite-hub/workflow",
     rootDir,
@@ -374,7 +374,7 @@ it("removes stale WDK output when the Vercel provider is disabled", async () => 
   await writeViteHubWorkflowOwnership(workflowRoot, ["stale.mjs"], [workflowRoute])
   await writeFile(configFile, `${JSON.stringify({ routes: [workflowRoute, userRoute] })}\n`)
 
-  await generateProviderOutputs({
+  await generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     rootDir,
     workflow: { provider: "openworkflow", sqlite: { path: ":memory:" } },
@@ -387,7 +387,7 @@ it("removes stale WDK output when the Vercel provider is disabled", async () => 
 it("removes only a prior Workflow-owned Vercel function when the active host changes", async () => {
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-host-transition-")
 
-  await generateProviderOutputs({
+  await generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     hosting: "vercel",
     rootDir,
@@ -405,7 +405,7 @@ it("removes only a prior Workflow-owned Vercel function when the active host cha
   const config = JSON.parse(await readFile(configFile, "utf8"))
   await writeFile(configFile, `${JSON.stringify({ ...config, framework: { slug: "nuxt" }, routes: [...config.routes, userRoute] })}\n`)
 
-  await generateProviderOutputs({
+  await generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     hosting: "cloudflare-module",
     rootDir,
@@ -427,7 +427,7 @@ it("rolls back partial Vercel output when the server bundle fails", async () => 
   await mkdir(workflowDir, { recursive: true })
   await writeFile(join(workflowDir, "broken.workflow.ts"), `import "./missing.js"\nexport default async function broken() {}\n`)
 
-  await expect(generateProviderOutputs({
+  await expect(generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     hosting: "vercel",
     rootDir,
@@ -439,7 +439,7 @@ it("rolls back partial Vercel output when the server bundle fails", async () => 
   expect(existsSync(join(rootDir, ".vercel", "output", "config.json"))).toBe(false)
 
   await rm(join(workflowDir, "broken.workflow.ts"))
-  await generateProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "cloudflare-module", rootDir, workflow: {} })
+  await generateWorkflowProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "cloudflare-module", rootDir, workflow: {} })
   expect(existsSync(join(rootDir, ".vercel", "output", "config.json"))).toBe(false)
 })
 
@@ -447,8 +447,8 @@ it("removes root Vercel output before writing an isolated Workflow function in t
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-root-to-isolated-")
   const configFile = join(rootDir, ".vercel", "output", "config.json")
 
-  await generateProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "vercel", rootDir, workflow: {} })
-  await generateProviderOutputs({
+  await generateWorkflowProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "vercel", rootDir, workflow: {} })
+  await generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     hosting: "vercel",
     rootDir,
@@ -466,10 +466,10 @@ it("preserves a Vercel function with a truncated ownership marker", async () => 
   const functionRoot = join(rootDir, ".vercel", "output", "functions", "__server.func")
   const stateFile = join(rootDir, ".vitehub", "workflow", "vercel-output.json")
 
-  await generateProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "vercel", rootDir, workflow: {} })
+  await generateWorkflowProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "vercel", rootDir, workflow: {} })
   await writeFile(join(functionRoot, ".vitehub-workflow-output.json"), "{\"digest\":")
   await writeFile(stateFile, "{\"serverFunctionName\":")
-  await generateProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "cloudflare-module", rootDir, workflow: {} })
+  await generateWorkflowProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "cloudflare-module", rootDir, workflow: {} })
 
   expect(existsSync(functionRoot)).toBe(true)
   expect(existsSync(join(rootDir, ".vercel", "output", "config.json"))).toBe(true)
@@ -482,10 +482,10 @@ it("preserves Vercel ownership when its root config is truncated", async () => {
   const configFile = join(rootDir, ".vercel", "output", "config.json")
   const stateFile = join(rootDir, ".vitehub", "workflow", "vercel-output.json")
 
-  await generateProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "vercel", rootDir, workflow: {} })
+  await generateWorkflowProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "vercel", rootDir, workflow: {} })
   await writeFile(configFile, "{\"routes\":")
 
-  await expect(generateProviderOutputs({
+  await expect(generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     hosting: "cloudflare-module",
     rootDir,
@@ -503,7 +503,7 @@ it("rolls back marker-owned output after an atomic state write fails", async () 
   const functionRoot = join(rootDir, ".vercel", "output", "functions", serverFunctionName)
   await mkdir(stateFile, { recursive: true })
 
-  await expect(generateProviderOutputs({
+  await expect(generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     hosting: "vercel",
     rootDir,
@@ -513,7 +513,7 @@ it("rolls back marker-owned output after an atomic state write fails", async () 
   expect(existsSync(functionRoot)).toBe(false)
 
   await rm(stateFile, { recursive: true })
-  await generateProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "cloudflare-module", rootDir, workflow: {} })
+  await generateWorkflowProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "cloudflare-module", rootDir, workflow: {} })
   expect(existsSync(functionRoot)).toBe(false)
 })
 
@@ -524,11 +524,11 @@ it("preserves the active Vercel function after ownership state bookkeeping fails
   const markerFile = join(functionRoot, ".vitehub-workflow-output.json")
   const stateFile = join(rootDir, ".vitehub", "workflow", "vercel-output.json")
 
-  await generateProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "vercel", rootDir, workflow: {} })
+  await generateWorkflowProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "vercel", rootDir, workflow: {} })
   await rm(stateFile)
   await mkdir(stateFile)
 
-  await expect(generateProviderOutputs({
+  await expect(generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     hosting: "vercel",
     rootDir,
@@ -548,11 +548,11 @@ it("preserves the previous Vercel function when replacement ownership fails", as
   const replacementFunctionRoot = join(rootDir, ".vercel", "output", "functions", "__workflow.func")
   const stateFile = join(rootDir, ".vitehub", "workflow", "vercel-output.json")
 
-  await generateProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "vercel", rootDir, workflow: {} })
+  await generateWorkflowProviderOutputs({ clientOutDir: join(rootDir, "dist"), hosting: "vercel", rootDir, workflow: {} })
   await rm(stateFile)
   await mkdir(stateFile)
 
-  await expect(generateProviderOutputs({
+  await expect(generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     hosting: "vercel",
     rootDir,
@@ -568,7 +568,7 @@ it("discovers and removes a prior custom-named Workflow Vercel function", async 
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-custom-function-transition-")
   const customFunction = "__custom-workflow.func"
 
-  await generateProviderOutputs({
+  await generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     hosting: "vercel",
     rootDir,
@@ -578,7 +578,7 @@ it("discovers and removes a prior custom-named Workflow Vercel function", async 
   const functionRoot = join(rootDir, ".vercel", "output", "functions", customFunction)
   expect(existsSync(functionRoot)).toBe(true)
 
-  await generateProviderOutputs({
+  await generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     hosting: "cloudflare-module",
     rootDir,
@@ -592,7 +592,7 @@ it("preserves a custom-named Vercel function after ownership changes", async () 
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-custom-function-replaced-")
   const customFunction = "__custom-workflow.func"
 
-  await generateProviderOutputs({
+  await generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     hosting: "vercel",
     rootDir,
@@ -602,7 +602,7 @@ it("preserves a custom-named Vercel function after ownership changes", async () 
   const functionFile = join(rootDir, ".vercel", "output", "functions", customFunction, "index.mjs")
   await writeFile(functionFile, "export default { external: true }\n")
 
-  await generateProviderOutputs({
+  await generateWorkflowProviderOutputs({
     clientOutDir: join(rootDir, "dist"),
     hosting: "cloudflare-module",
     rootDir,
@@ -620,13 +620,13 @@ it("serializes native Vercel generation with disabled-provider cleanup", async (
   await writeFile(join(workflowDir, "01-collect.ts"), "export default async function collect(input) { return input }\n")
 
   await Promise.all([
-    generateProviderOutputs({
+    generateWorkflowProviderOutputs({
       clientOutDir: join(rootDir, "dist"),
       importBase: "@vite-hub/workflow",
       rootDir,
       workflow: { provider: "vercel" },
     }),
-    generateProviderOutputs({
+    generateWorkflowProviderOutputs({
       clientOutDir: join(rootDir, "dist"),
       rootDir,
       workflow: { provider: "openworkflow", sqlite: { path: ":memory:" } },

--- a/playground/vite/build/vite-e2e.ts
+++ b/playground/vite/build/vite-e2e.ts
@@ -29,6 +29,7 @@ import { discoverViteWorkspaceDefinitions } from "../../../packages/workspace/sr
 import { configureCloudflareArtifacts } from "../../../packages/workspace/src/integrations/cloudflare.ts"
 import { normalizeWorkflowOptions } from "../../../packages/workflow/src/config.ts"
 import { discoverWorkflowDefinitions } from "../../../packages/workflow/src/discovery.ts"
+import { createWorkflowRegistryContents } from "../../../packages/workflow/src/internal/vite-build.ts"
 import { createCloudflareWorkflowBindings, getCloudflareWorkflowClassName } from "../../../packages/workflow/src/integrations/cloudflare.ts"
 import { defaultCloudflareCompatibilityDate } from "@vite-hub/internal/build/cloudflare"
 import { copyClientOutput, hasStaticIndex } from "@vite-hub/internal/build/client-output"
@@ -682,7 +683,7 @@ function renderSandboxProviderLoaderModule(file: string, provider: "cloudflare" 
   ].join("\n")
 }
 
-async function prepareFeatureArtifacts(options: ViteE2EComposerOptions) {
+export async function prepareFeatureArtifacts(options: ViteE2EComposerOptions) {
   const generatedDir = ensureGeneratedDir(options.rootDir, viteE2EProductName)
   await rm(generatedDir, { force: true, recursive: true })
   await mkdir(generatedDir, { recursive: true })
@@ -726,7 +727,7 @@ async function prepareFeatureArtifacts(options: ViteE2EComposerOptions) {
   let workflowRegistryFile: string | undefined
   if (workflowDefinitions.length) {
     workflowRegistryFile = resolve(generatedDir, "workflow-registry.mjs")
-    runtimeWrites.push(writeFile(workflowRegistryFile, createRuntimeRegistryContents(workflowRegistryFile, workflowDefinitions), "utf8"))
+    runtimeWrites.push(writeFile(workflowRegistryFile, createWorkflowRegistryContents(workflowRegistryFile, workflowDefinitions), "utf8"))
   }
 
   if (options.db) {

--- a/playground/vite/build/vite-e2e.ts
+++ b/playground/vite/build/vite-e2e.ts
@@ -151,6 +151,7 @@ function resolveIsomorphicGitDependency(specifier: string) {
 }
 
 function resolveSandboxClassName(config: { className?: unknown } | undefined) {
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- The playground accepts provider configuration at this runtime boundary.
   return typeof config?.className === "string" ? config.className : defaultCloudflareSandboxClassName
 }
 
@@ -613,6 +614,7 @@ async function rewriteWorkspaceAssetsRegistryForHostedRuntime(registryFile: stri
     contents = await readFile(registryFile, "utf8")
   }
   catch (error) {
+    // SAFETY: Node filesystem failures expose their stable error code through ErrnoException.
     if ((error as NodeJS.ErrnoException).code === "ENOENT") return
     throw error
   }
@@ -736,18 +738,21 @@ export async function prepareFeatureArtifacts(options: ViteE2EComposerOptions) {
     runtimeWrites.push(writeFile(dbRuntimeFile, renderDbRuntimeModule(dbRuntimeFile, options.db), "utf8"))
   }
 
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- The compatibility composer distinguishes omitted provider configuration.
   if (typeof options.blob !== "undefined") {
     const blobRuntimeFile = resolve(generatedDir, "blob-runtime.mjs")
     alias["@vite-hub/blob"] = blobRuntimeFile
     runtimeWrites.push(writeFile(blobRuntimeFile, renderBlobRuntimeModule(blobRuntimeFile, options.blob), "utf8"))
   }
 
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- The compatibility composer distinguishes omitted provider configuration.
   if (typeof options.kv !== "undefined") {
     const kvRuntimeFile = resolve(generatedDir, "kv-runtime.mjs")
     alias["@vite-hub/kv"] = kvRuntimeFile
     runtimeWrites.push(writeFile(kvRuntimeFile, renderKvRuntimeModule(kvRuntimeFile, options.kv), "utf8"))
   }
 
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- The compatibility composer distinguishes omitted provider configuration.
   if (typeof options.queue !== "undefined") {
     const queueRuntimeFile = resolve(generatedDir, "queue-runtime.mjs")
     alias["@vite-hub/queue"] = queueRuntimeFile
@@ -758,12 +763,14 @@ export async function prepareFeatureArtifacts(options: ViteE2EComposerOptions) {
     alias["@vite-hub/rate-limit"] = resolve(rateLimitPackageDir, "src/index.ts")
   }
 
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- The compatibility composer distinguishes omitted provider configuration.
   if (typeof options.schedule !== "undefined") {
     const scheduleRuntimeFile = resolve(generatedDir, "schedule-runtime.mjs")
     alias["@vite-hub/schedule"] = scheduleRuntimeFile
     runtimeWrites.push(writeFile(scheduleRuntimeFile, renderScheduleRuntimeModule(scheduleRuntimeFile), "utf8"))
   }
 
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- The compatibility composer distinguishes omitted provider configuration.
   if (typeof options.sandbox !== "undefined") {
     const sandboxRuntimeFile = resolve(generatedDir, "sandbox-runtime.mjs")
     alias["@vite-hub/sandbox/runtime/state"] = resolve(sandboxPackageDir, "src/runtime/state.ts")
@@ -771,12 +778,14 @@ export async function prepareFeatureArtifacts(options: ViteE2EComposerOptions) {
     runtimeWrites.push(writeFile(sandboxRuntimeFile, renderSandboxRuntimeModule(sandboxRuntimeFile), "utf8"))
   }
 
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- The compatibility composer distinguishes omitted provider configuration.
   if (typeof options.workflow !== "undefined") {
     const workflowRuntimeFile = resolve(generatedDir, "workflow-runtime.mjs")
     alias["@vite-hub/workflow"] = workflowRuntimeFile
     runtimeWrites.push(writeFile(workflowRuntimeFile, renderWorkflowRuntimeModule(workflowRuntimeFile), "utf8"))
   }
 
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- The compatibility composer distinguishes omitted provider configuration.
   if (typeof options.workspace !== "undefined") {
     const workspaceRuntimeFile = resolve(generatedDir, "workspace-runtime.mjs")
     const workspaceStateRuntimeFile = resolve(generatedDir, "workspace-state-runtime.mjs")
@@ -1334,21 +1343,27 @@ async function writeCloudflareOutput(options: ViteE2EComposerOptions, artifacts:
   }
 
   if (options.kv) {
+    // SAFETY: The fixture owns the Cloudflare config object and supplies the shape expected by this integration.
     configureCloudflareKV({ cloudflare: { wrangler: wranglerConfig } as never }, options.kv)
   }
+  // SAFETY: The fixture owns the Cloudflare config object and supplies the shape expected by this integration.
   configureCloudflareArtifacts({ cloudflare: { wrangler: wranglerConfig } as never }, options.workspace || false)
 
   if (artifacts.sandboxConfig && artifacts.sandboxConfig.provider === "cloudflare") {
     const sandboxClassName = resolveSandboxClassName(artifacts.sandboxConfig)
+    // SAFETY: The fixture owns the Cloudflare config object and supplies the shape expected by this integration.
     configureCloudflareSandbox({ cloudflare: { wrangler: wranglerConfig } as never }, {
+      // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Provider configuration is untyped until this runtime boundary validates it.
       binding: typeof artifacts.sandboxConfig.binding === "string" ? artifacts.sandboxConfig.binding : defaultCloudflareSandboxBinding,
       className: sandboxClassName,
+      // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Provider configuration is untyped until this runtime boundary validates it.
       migrationTag: typeof artifacts.sandboxConfig.migrationTag === "string" ? artifacts.sandboxConfig.migrationTag : defaultCloudflareSandboxMigrationTag,
       name: toSafeAppName(`${workerName}-${sandboxClassName}`),
     })
     await writeCloudflareSandboxDockerfile(outputRoot)
   }
 
+  // SAFETY: The fixture owns the Cloudflare config object and supplies the shape expected by this integration.
   finalizeCloudflareWranglerConfig({ cloudflare: { wrangler: wranglerConfig } } as never)
   await writeFile(resolve(outputRoot, "wrangler.json"), `${JSON.stringify(wranglerConfig, null, 2)}\n`, "utf8")
 }
@@ -1398,6 +1413,7 @@ async function writeVercelOutput(options: ViteE2EComposerOptions, artifacts: Gen
     platform: "node",
   })
 
+  // SAFETY: This extends the owned Vercel config with its supported optional cron entries.
   const vercelConfig = createVercelConfigJson() as ReturnType<typeof createVercelConfigJson> & { crons?: Array<{ path: string, schedule: string }> }
   if (artifacts.scheduleDefinitions.length) {
     vercelConfig.crons = artifacts.scheduleDefinitions.map(definition => ({

--- a/test/workflow-vite-e2e-registry.test.ts
+++ b/test/workflow-vite-e2e-registry.test.ts
@@ -1,0 +1,40 @@
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+
+import { afterEach, expect, it } from "vitest"
+
+import { prepareFeatureArtifacts } from "../playground/vite/build/vite-e2e.ts"
+
+const workflowPackageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "../packages/workflow")
+const directories: string[] = []
+
+afterEach(async () => {
+  await Promise.all(directories.splice(0).map(directory => rm(directory, { force: true, recursive: true })))
+})
+
+it("preserves folder steps in Vite e2e compatibility artifacts", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-workflow-vite-e2e-registry-"))
+  directories.push(root)
+  const workflowDirectory = join(root, "server", "workflows", "release")
+  await mkdir(join(root, "node_modules", "@vite-hub"), { recursive: true })
+  await mkdir(workflowDirectory, { recursive: true })
+  await symlink(workflowPackageRoot, join(root, "node_modules", "@vite-hub", "workflow"), "dir")
+  await writeFile(join(workflowDirectory, "index.mjs"), "export default { handler: async ({ payload, steps }) => await steps.add(payload) }\n", "utf8")
+  await writeFile(join(workflowDirectory, "01.add.mjs"), "export default async function add(value) { return value + 1 }\n", "utf8")
+
+  const artifacts = await prepareFeatureArtifacts({
+    clientOutDir: join(root, "dist", "client"),
+    hosting: "cloudflare",
+    rootDir: root,
+    workflow: { provider: "cloudflare" },
+  })
+
+  expect(artifacts.workflowRegistryFile).toBeDefined()
+  const contents = await readFile(artifacts.workflowRegistryFile!, "utf8")
+  expect(contents).toContain("createWorkflowSteps")
+  const generated = await import(`${pathToFileURL(artifacts.workflowRegistryFile!).href}?test=vite-e2e-owner`)
+  const definition = await generated.default.release()
+  await expect(definition.handler({ name: "release", payload: 1, provider: "cloudflare" })).resolves.toBe(2)
+})


### PR DESCRIPTION
The generic Definition catalog now renders only deterministic name-to-module loaders, so Queue, Realtime, Schedule, and compatibility consumers cannot acquire Workflow runtime imports or step semantics. Workflow keeps step wrapping, caching, and inline-definition handling in its owner renderer; the removed optional `steps` contract is intentionally breaking.

Focused proof covers exact generated output and dynamic import execution for each generic owner, plus Workflow step execution and cache identity.

Tests:
- `pnpm --filter @vite-hub/internal exec vp test test/definition-discovery.test.ts`
- `pnpm --filter @vite-hub/workflow exec vp test test/registry.test.ts`
- `pnpm --filter @vite-hub/queue exec vp test test/discovery.test.ts test/vite.test.ts`
- `pnpm --filter @vite-hub/schedule exec vp test test/discovery.test.ts test/vite.test.ts`
- `TMPDIR=/var/tmp pnpm --filter @vite-hub/realtime exec vp test test/vite.test.ts`
- `pnpm --filter @vite-hub/sandbox exec vp test test/discovery.test.ts`
- package builds/typechecks for Internal, Workflow, Queue, Schedule, and Realtime
- scoped `vp lint` and package `publint` checks

<!-- babysitter:blocker:v1 -->

> [!WARNING]
> **Babysitter is blocked:** Pullfrog completed successfully for head `779fcc40714f3e057ef60a01640245232fef2e07` but did not submit a review for that head; its latest review targets `ecdd097d7682c0c9f531a11f58cb590d32bac466`.
>
> Pullfrog must submit a review for exact head `779fcc40714f3e057ef60a01640245232fef2e07` to satisfy the merge gate.

<!-- /babysitter:blocker:v1 -->