### PR TITLE
ci: report live smoke failure stages

### DIFF
--- a/.github/scripts/live-smoke-report.mjs
+++ b/.github/scripts/live-smoke-report.mjs
@@ -40,7 +40,11 @@ export function createStageEvidence({ provider, currentStage, conclusion, runId,
   return evidence;
 }
 
-export function aggregateStageEvidence({ evidence, setupStatus, matrixStatus, runId, runAttempt, runUrl }) {
+export function aggregateStageEvidence({ evidence, setupStatus, attemptProviders, runId, runAttempt, runUrl }) {
+  if (!Array.isArray(attemptProviders) || new Set(attemptProviders).size !== attemptProviders.length) {
+    throw new Error("attemptProviders must be a unique provider list");
+  }
+  for (const provider of attemptProviders) assertAllowed(provider, liveSmokeProviders, "attempt provider");
   const byProvider = new Map();
   for (const entry of evidence) {
     validateEvidence(entry);
@@ -56,8 +60,6 @@ export function aggregateStageEvidence({ evidence, setupStatus, matrixStatus, ru
     }
   }
 
-  const rerunHasKnownFailedProvider = matrixStatus === "failure"
-    && [...byProvider.values()].some(entry => entry.run.attempt < runAttempt && entry.conclusion !== "success");
   const providers = liveSmokeProviders.map((provider) => {
     if (setupStatus !== "success") {
       return createStageEvidence({
@@ -71,10 +73,8 @@ export function aggregateStageEvidence({ evidence, setupStatus, matrixStatus, ru
       });
     }
     const entry = byProvider.get(provider);
-    const preservesUntouchedSuccess = entry?.run.attempt < runAttempt
-      && entry.conclusion === "success"
-      && rerunHasKnownFailedProvider;
-    if (entry && !(matrixStatus === "failure" && entry.run.attempt < runAttempt && !preservesUntouchedSuccess)) {
+    const providerRanThisAttempt = attemptProviders.includes(provider);
+    if (entry && !(providerRanThisAttempt && entry.run.attempt < runAttempt)) {
       return entry.run.attempt === runAttempt
         ? entry
         : { ...entry, evidenceAttempt: entry.run.attempt, run: { id: String(runId), attempt: runAttempt, url: runUrl } };
@@ -86,7 +86,7 @@ export function aggregateStageEvidence({ evidence, setupStatus, matrixStatus, ru
       runId,
       runAttempt,
       runUrl,
-      reason: matrixStatus === "failure" && entry
+      reason: providerRanThisAttempt && entry
         ? "provider job failed without current-attempt stage evidence"
         : "provider stage evidence was not uploaded",
     });
@@ -252,12 +252,12 @@ function runFromCommandLine(args) {
     });
   }
   if (command === "aggregate") {
-    if (!options.directory || !options["setup-status"] || !options["matrix-status"]) {
-      throw new Error("aggregate requires --directory, --setup-status, and --matrix-status");
+    if (!options.directory || !options["setup-status"] || options["attempt-providers"] === undefined) {
+      throw new Error("aggregate requires --directory, --setup-status, and --attempt-providers");
     }
     return aggregateStageEvidence({
+      attemptProviders: options["attempt-providers"] ? options["attempt-providers"].split(",") : [],
       evidence: readEvidence(resolve(options.directory)),
-      matrixStatus: options["matrix-status"],
       setupStatus: options["setup-status"],
       ...run,
     });

--- a/.github/scripts/live-smoke-report.mjs
+++ b/.github/scripts/live-smoke-report.mjs
@@ -40,7 +40,7 @@ export function createStageEvidence({ provider, currentStage, conclusion, runId,
   return evidence;
 }
 
-export function aggregateStageEvidence({ evidence, setupStatus, runId, runAttempt, runUrl }) {
+export function aggregateStageEvidence({ evidence, setupStatus, matrixStatus, runId, runAttempt, runUrl }) {
   const byProvider = new Map();
   for (const entry of evidence) {
     validateEvidence(entry);
@@ -56,6 +56,8 @@ export function aggregateStageEvidence({ evidence, setupStatus, runId, runAttemp
     }
   }
 
+  const rerunHasKnownFailedProvider = matrixStatus === "failure"
+    && [...byProvider.values()].some(entry => entry.run.attempt < runAttempt && entry.conclusion !== "success");
   const providers = liveSmokeProviders.map((provider) => {
     if (setupStatus !== "success") {
       return createStageEvidence({
@@ -69,7 +71,10 @@ export function aggregateStageEvidence({ evidence, setupStatus, runId, runAttemp
       });
     }
     const entry = byProvider.get(provider);
-    if (entry) {
+    const preservesUntouchedSuccess = entry?.run.attempt < runAttempt
+      && entry.conclusion === "success"
+      && rerunHasKnownFailedProvider;
+    if (entry && !(matrixStatus === "failure" && entry.run.attempt < runAttempt && !preservesUntouchedSuccess)) {
       return entry.run.attempt === runAttempt
         ? entry
         : { ...entry, evidenceAttempt: entry.run.attempt, run: { id: String(runId), attempt: runAttempt, url: runUrl } };
@@ -81,7 +86,9 @@ export function aggregateStageEvidence({ evidence, setupStatus, runId, runAttemp
       runId,
       runAttempt,
       runUrl,
-      reason: "provider stage evidence was not uploaded",
+      reason: matrixStatus === "failure" && entry
+        ? "provider job failed without current-attempt stage evidence"
+        : "provider stage evidence was not uploaded",
     });
   });
 
@@ -245,11 +252,12 @@ function runFromCommandLine(args) {
     });
   }
   if (command === "aggregate") {
-    if (!options.directory || !options["setup-status"]) {
-      throw new Error("aggregate requires --directory and --setup-status");
+    if (!options.directory || !options["setup-status"] || !options["matrix-status"]) {
+      throw new Error("aggregate requires --directory, --setup-status, and --matrix-status");
     }
     return aggregateStageEvidence({
       evidence: readEvidence(resolve(options.directory)),
+      matrixStatus: options["matrix-status"],
       setupStatus: options["setup-status"],
       ...run,
     });

--- a/.github/scripts/live-smoke-report.mjs
+++ b/.github/scripts/live-smoke-report.mjs
@@ -44,13 +44,16 @@ export function aggregateStageEvidence({ evidence, setupStatus, runId, runAttemp
   const byProvider = new Map();
   for (const entry of evidence) {
     validateEvidence(entry);
-    if (entry.run.id !== String(runId) || entry.run.attempt !== runAttempt) {
-      throw new Error(`stage evidence for ${entry.provider} belongs to another run attempt`);
+    if (entry.run.id !== String(runId) || entry.run.attempt > runAttempt) {
+      throw new Error(`stage evidence for ${entry.provider} belongs to another run`);
     }
-    if (byProvider.has(entry.provider)) {
+    const previous = byProvider.get(entry.provider);
+    if (previous?.run.attempt === entry.run.attempt) {
       throw new Error(`duplicate evidence for ${entry.provider}`);
     }
-    byProvider.set(entry.provider, entry);
+    if (!previous || previous.run.attempt < entry.run.attempt) {
+      byProvider.set(entry.provider, entry);
+    }
   }
 
   const providers = liveSmokeProviders.map((provider) => {
@@ -65,7 +68,13 @@ export function aggregateStageEvidence({ evidence, setupStatus, runId, runAttemp
         reason: `shared package build ${setupStatus}`,
       });
     }
-    return byProvider.get(provider) ?? createStageEvidence({
+    const entry = byProvider.get(provider);
+    if (entry) {
+      return entry.run.attempt === runAttempt
+        ? entry
+        : { ...entry, evidenceAttempt: entry.run.attempt, run: { id: String(runId), attempt: runAttempt, url: runUrl } };
+    }
+    return createStageEvidence({
       provider,
       currentStage: "preflight",
       conclusion: "failure",

--- a/.github/scripts/live-smoke-report.mjs
+++ b/.github/scripts/live-smoke-report.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+export const liveSmokeProviders = Object.freeze(["cloudflare", "vercel"]);
+export const liveSmokeStages = Object.freeze(["preflight", "provision", "build", "deploy", "runtime"]);
+
+const conclusions = Object.freeze(["success", "failure", "cancelled"]);
+const issueLabel = "live-smoke-failure";
+const issueTitle = "Live Smoke failure";
+
+export function createStageEvidence({ provider, currentStage, conclusion, runId, runAttempt, runUrl, reason }) {
+  assertAllowed(provider, liveSmokeProviders, "provider");
+  assertAllowed(currentStage, liveSmokeStages, "stage");
+  assertAllowed(conclusion, conclusions, "conclusion");
+  if (conclusion === "success" && currentStage !== "runtime") {
+    throw new Error("a successful provider run must reach the runtime stage");
+  }
+  if (!runId || !runUrl || !Number.isInteger(runAttempt) || runAttempt < 1) {
+    throw new Error("runId, runUrl, and a positive integer runAttempt are required");
+  }
+
+  const currentIndex = liveSmokeStages.indexOf(currentStage);
+  const stages = Object.fromEntries(liveSmokeStages.map((stage, index) => {
+    if (index < currentIndex) return [stage, "success"];
+    if (index > currentIndex) return [stage, "skipped"];
+    return [stage, conclusion];
+  }));
+
+  const evidence = {
+    schemaVersion: 1,
+    provider,
+    currentStage,
+    conclusion,
+    stages,
+    run: { id: String(runId), attempt: runAttempt, url: runUrl },
+  };
+  if (reason) evidence.reason = reason;
+  return evidence;
+}
+
+export function aggregateStageEvidence({ evidence, setupStatus, runId, runAttempt, runUrl }) {
+  const byProvider = new Map();
+  for (const entry of evidence) {
+    validateEvidence(entry);
+    if (entry.run.id !== String(runId) || entry.run.attempt !== runAttempt) {
+      throw new Error(`stage evidence for ${entry.provider} belongs to another run attempt`);
+    }
+    if (byProvider.has(entry.provider)) {
+      throw new Error(`duplicate evidence for ${entry.provider}`);
+    }
+    byProvider.set(entry.provider, entry);
+  }
+
+  const providers = liveSmokeProviders.map((provider) => {
+    if (setupStatus !== "success") {
+      return createStageEvidence({
+        provider,
+        currentStage: "preflight",
+        conclusion: setupStatus === "cancelled" ? "cancelled" : "failure",
+        runId,
+        runAttempt,
+        runUrl,
+        reason: `shared package build ${setupStatus}`,
+      });
+    }
+    return byProvider.get(provider) ?? createStageEvidence({
+      provider,
+      currentStage: "preflight",
+      conclusion: "failure",
+      runId,
+      runAttempt,
+      runUrl,
+      reason: "provider stage evidence was not uploaded",
+    });
+  });
+
+  return {
+    schemaVersion: 1,
+    conclusion: providers.every(provider => provider.conclusion === "success") ? "success" : "failure",
+    providers,
+    run: { id: String(runId), attempt: runAttempt, url: runUrl },
+  };
+}
+
+export async function updateLiveSmokeIssue({ github, context, report }) {
+  validateReport(report);
+  const marker = `<!-- vitehub-live-smoke-run:${report.run.id}:${report.run.attempt} -->`;
+  const { data: openIssues } = await github.rest.issues.listForRepo({
+    ...context.repo,
+    labels: issueLabel,
+    state: "open",
+    per_page: 100,
+  });
+  const issue = openIssues.find(candidate => !candidate.pull_request);
+
+  if (report.conclusion === "success") {
+    if (!issue) return { action: "none" };
+    const body = formatIssueUpdate(report, marker);
+    if (!await issueHasMarker({ github, context, issue, marker })) {
+      await github.rest.issues.createComment({ ...context.repo, issue_number: issue.number, body });
+    }
+    await github.rest.issues.update({
+      ...context.repo,
+      issue_number: issue.number,
+      state: "closed",
+      state_reason: "completed",
+    });
+    return { action: "closed", issueNumber: issue.number };
+  }
+
+  const body = formatIssueUpdate(report, marker);
+  if (!issue) {
+    const { data: created } = await github.rest.issues.create({
+      ...context.repo,
+      title: issueTitle,
+      body,
+      labels: [issueLabel],
+    });
+    return { action: "created", issueNumber: created.number };
+  }
+  if (await issueHasMarker({ github, context, issue, marker })) {
+    return { action: "deduplicated", issueNumber: issue.number };
+  }
+  await github.rest.issues.createComment({ ...context.repo, issue_number: issue.number, body });
+  return { action: "commented", issueNumber: issue.number };
+}
+
+function formatIssueUpdate(report, marker) {
+  const summary = report.conclusion === "success"
+    ? "Nightly Live Smoke passed for Cloudflare and Vercel. Closing this issue."
+    : ["Nightly Live Smoke failed.", "", ...report.providers
+        .filter(provider => provider.conclusion !== "success")
+        .map(provider => `- ${provider.provider}: ${provider.currentStage} (${provider.conclusion})`)]
+        .join("\n");
+  return [
+    marker,
+    summary,
+    "",
+    `Run: ${report.run.url}`,
+    "",
+    "<details><summary>Stage evidence</summary>",
+    "",
+    "```json",
+    JSON.stringify(report, null, 2),
+    "```",
+    "</details>",
+  ].join("\n");
+}
+
+async function issueHasMarker({ github, context, issue, marker }) {
+  if (issue.body?.includes(marker)) return true;
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    ...context.repo,
+    issue_number: issue.number,
+    per_page: 100,
+  });
+  return comments.some(comment => comment.body?.includes(marker));
+}
+
+function validateEvidence(evidence) {
+  if (!evidence || evidence.schemaVersion !== 1) throw new Error("unsupported stage evidence");
+  assertAllowed(evidence.provider, liveSmokeProviders, "provider");
+  assertAllowed(evidence.currentStage, liveSmokeStages, "stage");
+  assertAllowed(evidence.conclusion, conclusions, "conclusion");
+  if (!evidence.run?.id || !evidence.run.url || !Number.isInteger(evidence.run.attempt)) {
+    throw new Error("stage evidence has invalid run metadata");
+  }
+}
+
+function validateReport(report) {
+  if (!report || report.schemaVersion !== 1 || !Array.isArray(report.providers)) {
+    throw new Error("unsupported live smoke report");
+  }
+  const providers = new Set();
+  for (const evidence of report.providers) {
+    validateEvidence(evidence);
+    providers.add(evidence.provider);
+    if (evidence.run.id !== report.run?.id || evidence.run.attempt !== report.run?.attempt) {
+      throw new Error("provider evidence does not match the aggregate run");
+    }
+  }
+  if (providers.size !== liveSmokeProviders.length || liveSmokeProviders.some(provider => !providers.has(provider))) {
+    throw new Error("aggregate report must contain Cloudflare and Vercel evidence");
+  }
+  const conclusion = report.providers.every(provider => provider.conclusion === "success") ? "success" : "failure";
+  if (report.conclusion !== conclusion) throw new Error("aggregate conclusion does not match provider evidence");
+}
+
+function assertAllowed(value, allowed, name) {
+  if (!allowed.includes(value)) {
+    throw new Error(`invalid ${name}: ${value}`);
+  }
+}
+
+function readEvidence(directory) {
+  const entries = [];
+  for (const item of readdirSync(directory, { withFileTypes: true })) {
+    const path = resolve(directory, item.name);
+    if (item.isDirectory()) entries.push(...readEvidence(path));
+    else if (item.isFile() && item.name.endsWith(".json")) entries.push(JSON.parse(readFileSync(path, "utf8")));
+  }
+  return entries;
+}
+
+function parseOptions(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 2) {
+    const flag = args[index];
+    const value = args[index + 1];
+    if (!flag?.startsWith("--") || value === undefined || value.startsWith("--")) {
+      throw new Error(`invalid option near ${flag ?? "end of input"}`);
+    }
+    const name = flag.slice(2);
+    if (options[name] !== undefined) throw new Error(`duplicate option: ${flag}`);
+    options[name] = value;
+  }
+  return options;
+}
+
+function runFromCommandLine(args) {
+  const [command, ...optionArgs] = args;
+  const options = parseOptions(optionArgs);
+  const run = {
+    runId: options["run-id"],
+    runAttempt: Number(options["run-attempt"]),
+    runUrl: options["run-url"],
+  };
+  if (command === "evidence") {
+    return createStageEvidence({
+      provider: options.provider,
+      currentStage: options.stage,
+      conclusion: options.conclusion,
+      ...run,
+    });
+  }
+  if (command === "aggregate") {
+    if (!options.directory || !options["setup-status"]) {
+      throw new Error("aggregate requires --directory and --setup-status");
+    }
+    return aggregateStageEvidence({
+      evidence: readEvidence(resolve(options.directory)),
+      setupStatus: options["setup-status"],
+      ...run,
+    });
+  }
+  throw new Error("usage: live-smoke-report.mjs evidence|aggregate [options]");
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  try {
+    process.stdout.write(`${JSON.stringify(runFromCommandLine(process.argv.slice(2)), null, 2)}\n`);
+  }
+  catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -9,6 +9,9 @@ concurrency:
   group: live-smoke-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   VERCEL_CLI_VERSION: 54.5.1
 
@@ -39,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     timeout-minutes: 30
+    env:
+      LIVE_SMOKE_STAGE: preflight
     strategy:
       fail-fast: false
       matrix:
@@ -53,7 +58,7 @@ jobs:
           name: vitehub-package-dist
           path: packages
 
-      - name: Validate Cloudflare env
+      - name: Preflight Cloudflare
         if: matrix.provider == 'cloudflare'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -73,7 +78,7 @@ jobs:
             exit 1
           fi
 
-      - name: Prepare Vercel project
+      - name: Preflight Vercel
         id: prepare_vercel
         if: matrix.provider == 'vercel'
         env:
@@ -151,6 +156,9 @@ jobs:
           echo "org_id=$VERCEL_ORG_ID" >> "$GITHUB_OUTPUT"
           echo "project_id=$VERCEL_PROJECT_ID" >> "$GITHUB_OUTPUT"
 
+      - name: Enter provision stage
+        run: echo "LIVE_SMOKE_STAGE=provision" >> "$GITHUB_ENV"
+
       - name: Provision Cloudflare resources
         if: matrix.provider == 'cloudflare'
         env:
@@ -161,6 +169,19 @@ jobs:
           VITEHUB_HOSTING: cloudflare
           VITEHUB_VITE_MODE: e2e
         run: vp run playground:vite:provision --provider cloudflare
+
+      - name: Provision Vercel resources
+        if: matrix.provider == 'vercel'
+        env:
+          VERCEL_PROJECT_ID: ${{ steps.prepare_vercel.outputs.project_id }}
+          VERCEL_TEAM_ID: ${{ steps.prepare_vercel.outputs.org_id }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VITEHUB_HOSTING: vercel
+          VITEHUB_VITE_MODE: e2e
+        run: vp run playground:vite:provision --provider vercel
+
+      - name: Enter build stage
+        run: echo "LIVE_SMOKE_STAGE=build" >> "$GITHUB_ENV"
 
       - name: Build playground (cloudflare)
         if: matrix.provider == 'cloudflare'
@@ -184,16 +205,6 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
         run: vp dlx wrangler --cwd playground/vite/dist/vite deploy --config wrangler.json --dry-run
-
-      - name: Provision Vercel resources
-        if: matrix.provider == 'vercel'
-        env:
-          VERCEL_PROJECT_ID: ${{ steps.prepare_vercel.outputs.project_id }}
-          VERCEL_TEAM_ID: ${{ steps.prepare_vercel.outputs.org_id }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VITEHUB_HOSTING: vercel
-          VITEHUB_VITE_MODE: e2e
-        run: vp run playground:vite:provision --provider vercel
 
       - name: Build playground (vercel)
         if: matrix.provider == 'vercel'
@@ -228,6 +239,9 @@ jobs:
             writeFileSync(configFile, `${JSON.stringify(config, null, 2)}\n`)
           }
           NODE
+
+      - name: Enter deploy stage
+        run: echo "LIVE_SMOKE_STAGE=deploy" >> "$GITHUB_ENV"
 
       - name: Deploy Cloudflare
         id: deploy_cloudflare
@@ -278,6 +292,9 @@ jobs:
             echo "url=${{ steps.deploy_vercel.outputs.url }}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Enter runtime stage
+        run: echo "LIVE_SMOKE_STAGE=runtime" >> "$GITHUB_ENV"
+
       - name: KV Live E2E (${{ matrix.provider }})
         run: vp run kv:e2e --mode live --provider ${{ matrix.provider }} --url "${{ steps.url.outputs.url }}"
 
@@ -311,28 +328,86 @@ jobs:
       - name: DB Live E2E
         run: vp run database:e2e --url "${{ steps.url.outputs.url }}"
 
-  report-failure:
-    name: report failure
+      - name: Create stage evidence
+        if: always()
+        env:
+          LIVE_SMOKE_CONCLUSION: ${{ job.status }}
+          LIVE_SMOKE_PROVIDER: ${{ matrix.provider }}
+          LIVE_SMOKE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          LIVE_SMOKE_RUN_ID: ${{ github.run_id }}
+          LIVE_SMOKE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          mkdir -p live-smoke-evidence
+          node .github/scripts/live-smoke-report.mjs evidence \
+            --provider "$LIVE_SMOKE_PROVIDER" \
+            --stage "$LIVE_SMOKE_STAGE" \
+            --conclusion "$LIVE_SMOKE_CONCLUSION" \
+            --run-id "$LIVE_SMOKE_RUN_ID" \
+            --run-attempt "$LIVE_SMOKE_RUN_ATTEMPT" \
+            --run-url "$LIVE_SMOKE_RUN_URL" \
+            > "live-smoke-evidence/$LIVE_SMOKE_PROVIDER.json"
+
+      - name: Upload stage evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: live-smoke-evidence-${{ matrix.provider }}-${{ github.run_attempt }}
+          path: live-smoke-evidence/${{ matrix.provider }}.json
+          retention-days: 30
+          if-no-files-found: error
+
+  report-live-smoke:
+    name: report live smoke
     needs: [setup-cloudflare, live-smoke]
-    if: failure() && github.event_name == 'schedule'
+    if: always() && github.event_name == 'schedule'
     runs-on: ubuntu-latest
     permissions:
+      actions: read
+      contents: read
       issues: write
     steps:
-      - uses: actions/github-script@v8
+      - uses: actions/checkout@v6
+
+      - run: mkdir -p live-smoke-evidence
+
+      - name: Download provider stage evidence
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          pattern: live-smoke-evidence-*-${{ github.run_attempt }}
+          path: live-smoke-evidence
+          merge-multiple: true
+
+      - name: Aggregate provider stages
+        env:
+          LIVE_SMOKE_RUN_ATTEMPT: ${{ github.run_attempt }}
+          LIVE_SMOKE_RUN_ID: ${{ github.run_id }}
+          LIVE_SMOKE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          LIVE_SMOKE_SETUP_STATUS: ${{ needs.setup-cloudflare.result }}
+        run: |
+          node .github/scripts/live-smoke-report.mjs aggregate \
+            --directory live-smoke-evidence \
+            --setup-status "$LIVE_SMOKE_SETUP_STATUS" \
+            --run-id "$LIVE_SMOKE_RUN_ID" \
+            --run-attempt "$LIVE_SMOKE_RUN_ATTEMPT" \
+            --run-url "$LIVE_SMOKE_RUN_URL" \
+            > live-smoke-report.json
+
+      - name: Upload aggregate stage evidence
+        uses: actions/upload-artifact@v6
+        with:
+          name: live-smoke-report-${{ github.run_attempt }}
+          path: live-smoke-report.json
+          retention-days: 30
+          if-no-files-found: error
+
+      - name: Update tracked failure issue
+        uses: actions/github-script@v8
         with:
           script: |
-            const title = "Live Smoke failure"
-            const body = [
-              `Nightly Live Smoke failed: ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
-              "",
-              "Keep this issue open until a green scheduled run; close it then.",
-            ].join("\n")
-            const { data: issues } = await github.rest.issues.listForRepo({
-              ...context.repo, labels: "live-smoke-failure", state: "open",
-            })
-            if (issues.length > 0) {
-              await github.rest.issues.createComment({ ...context.repo, issue_number: issues[0].number, body })
-            } else {
-              await github.rest.issues.create({ ...context.repo, title, body, labels: ["live-smoke-failure"] })
-            }
+            const { readFileSync } = require("node:fs")
+            const { pathToFileURL } = require("node:url")
+            const report = JSON.parse(readFileSync("live-smoke-report.json", "utf8"))
+            const reporter = await import(pathToFileURL(`${process.env.GITHUB_WORKSPACE}/.github/scripts/live-smoke-report.mjs`).href)
+            const result = await reporter.updateLiveSmokeIssue({ github, context, report })
+            core.info(`Live Smoke issue action: ${result.action}`)

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -41,7 +41,6 @@ jobs:
     needs: setup-cloudflare
     runs-on: ubuntu-latest
     environment: Production
-    timeout-minutes: 30
     env:
       LIVE_SMOKE_STAGE: preflight
     strategy:
@@ -161,6 +160,7 @@ jobs:
 
       - name: Provision Cloudflare resources
         if: matrix.provider == 'cloudflare'
+        timeout-minutes: 15
         env:
           BLOB_BUCKET_NAME: ${{ secrets.CLOUDFLARE_R2_BUCKET_NAME }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -172,6 +172,7 @@ jobs:
 
       - name: Provision Vercel resources
         if: matrix.provider == 'vercel'
+        timeout-minutes: 15
         env:
           VERCEL_PROJECT_ID: ${{ steps.prepare_vercel.outputs.project_id }}
           VERCEL_TEAM_ID: ${{ steps.prepare_vercel.outputs.org_id }}
@@ -185,6 +186,7 @@ jobs:
 
       - name: Build playground (cloudflare)
         if: matrix.provider == 'cloudflare'
+        timeout-minutes: 15
         env:
           BLOB_BUCKET_NAME: ${{ secrets.CLOUDFLARE_R2_BUCKET_NAME }}
           KV_NAMESPACE_ID: ${{ secrets.CLOUDFLARE_KV_NAMESPACE_ID }}
@@ -197,10 +199,12 @@ jobs:
 
       - name: Provider Output Contract (cloudflare)
         if: matrix.provider == 'cloudflare'
+        timeout-minutes: 5
         run: vp test --config test/output/vitest.config.ts test/output/cloudflare.test.ts
 
       - name: Dry-run Cloudflare deploy
         if: matrix.provider == 'cloudflare'
+        timeout-minutes: 5
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -208,6 +212,7 @@ jobs:
 
       - name: Build playground (vercel)
         if: matrix.provider == 'vercel'
+        timeout-minutes: 15
         env:
           BLOB_READ_WRITE_TOKEN: ${{ steps.prepare_vercel.outputs.blob_token }}
           KV_REST_API_TOKEN: ${{ steps.prepare_vercel.outputs.kv_token }}
@@ -224,6 +229,7 @@ jobs:
 
       - name: Provider Output Contract (vercel)
         if: matrix.provider == 'vercel'
+        timeout-minutes: 5
         run: vp test --config test/output/vitest.config.ts test/output/vercel.test.ts
 
       - name: Relax Vercel cron cadence for live deploy
@@ -246,6 +252,7 @@ jobs:
       - name: Deploy Cloudflare
         id: deploy_cloudflare
         if: matrix.provider == 'cloudflare'
+        timeout-minutes: 15
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -261,6 +268,7 @@ jobs:
       - name: Deploy Vercel
         id: deploy_vercel
         if: matrix.provider == 'vercel'
+        timeout-minutes: 15
         env:
           VERCEL_ORG_ID: ${{ steps.prepare_vercel.outputs.org_id }}
           VERCEL_PROJECT_ID: ${{ steps.prepare_vercel.outputs.project_id }}
@@ -296,6 +304,7 @@ jobs:
         run: echo "LIVE_SMOKE_STAGE=runtime" >> "$GITHUB_ENV"
 
       - name: KV Live E2E (${{ matrix.provider }})
+        timeout-minutes: 10
         run: vp run kv:e2e --mode live --provider ${{ matrix.provider }} --url "${{ steps.url.outputs.url }}"
 
       - name: Queue Live E2E (${{ matrix.provider }})
@@ -304,6 +313,7 @@ jobs:
 
       - name: Rate Limit Live E2E (cloudflare)
         if: matrix.provider == 'cloudflare'
+        timeout-minutes: 10
         run: vp run rate-limit:e2e --mode live --provider cloudflare --url "${{ steps.url.outputs.url }}"
 
       - name: Schedule Live E2E (${{ matrix.provider }})
@@ -311,6 +321,7 @@ jobs:
         run: vp run schedule:e2e --provider "${{ matrix.provider }}" --url "${{ steps.url.outputs.url }}" --timeout 270000
 
       - name: Sandbox Live E2E (${{ matrix.provider }})
+        timeout-minutes: 10
         run: vp run sandbox:e2e --mode live --provider ${{ matrix.provider }} --url "${{ steps.url.outputs.url }}"
 
       - name: Workflow Live E2E (${{ matrix.provider }})
@@ -318,14 +329,17 @@ jobs:
         run: vp run workflow:e2e --provider "${{ matrix.provider }}" --url "${{ steps.url.outputs.url }}"
 
       - name: Workspace Live E2E (${{ matrix.provider }})
+        timeout-minutes: 10
         run: vp run workspace:e2e --mode live --provider ${{ matrix.provider }} --url "${{ steps.url.outputs.url }}"
 
       - name: Blob Live E2E
+        timeout-minutes: 10
         env:
           VERCEL_PROTECTION_BYPASS: ${{ secrets.VERCEL_PROTECTION_BYPASS }}
         run: vp run blob:e2e --mode live --url "${{ steps.url.outputs.url }}"
 
       - name: DB Live E2E
+        timeout-minutes: 10
         run: vp run database:e2e --url "${{ steps.url.outputs.url }}"
 
       - name: Create stage evidence
@@ -374,9 +388,8 @@ jobs:
         continue-on-error: true
         uses: actions/download-artifact@v8
         with:
-          pattern: live-smoke-evidence-*-${{ github.run_attempt }}
+          pattern: live-smoke-evidence-*
           path: live-smoke-evidence
-          merge-multiple: true
 
       - name: Aggregate provider stages
         env:

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -392,18 +392,35 @@ jobs:
           pattern: live-smoke-evidence-*
           path: live-smoke-evidence
 
+      - name: Identify provider jobs in this attempt
+        id: attempt
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRunAttempt, {
+              ...context.repo,
+              run_id: context.runId,
+              attempt_number: Number(process.env.GITHUB_RUN_ATTEMPT),
+              per_page: 100,
+            })
+            const providers = jobs.flatMap(({ name }) => {
+              const match = /^live smoke \((cloudflare|vercel)\)$/.exec(name)
+              return match ? [match[1]] : []
+            })
+            core.setOutput("providers", [...new Set(providers)].join(","))
+
       - name: Aggregate provider stages
         env:
           LIVE_SMOKE_RUN_ATTEMPT: ${{ github.run_attempt }}
           LIVE_SMOKE_RUN_ID: ${{ github.run_id }}
           LIVE_SMOKE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          LIVE_SMOKE_MATRIX_STATUS: ${{ needs.live-smoke.result }}
           LIVE_SMOKE_SETUP_STATUS: ${{ needs.setup-cloudflare.result }}
+          LIVE_SMOKE_ATTEMPT_PROVIDERS: ${{ steps.attempt.outputs.providers }}
         run: |
           node .github/scripts/live-smoke-report.mjs aggregate \
             --directory live-smoke-evidence \
-            --matrix-status "$LIVE_SMOKE_MATRIX_STATUS" \
             --setup-status "$LIVE_SMOKE_SETUP_STATUS" \
+            --attempt-providers "$LIVE_SMOKE_ATTEMPT_PROVIDERS" \
             --run-id "$LIVE_SMOKE_RUN_ID" \
             --run-attempt "$LIVE_SMOKE_RUN_ATTEMPT" \
             --run-url "$LIVE_SMOKE_RUN_URL" \

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Preflight Vercel
         id: prepare_vercel
         if: matrix.provider == 'vercel'
+        timeout-minutes: 10
         env:
           BLOB_READ_WRITE_TOKEN: ${{ secrets.BLOB_READ_WRITE_TOKEN }}
           KV_REST_API_TOKEN: ${{ secrets.KV_REST_API_TOKEN }}
@@ -373,7 +374,7 @@ jobs:
   report-live-smoke:
     name: report live smoke
     needs: [setup-cloudflare, live-smoke]
-    if: always() && github.event_name == 'schedule'
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -396,10 +397,12 @@ jobs:
           LIVE_SMOKE_RUN_ATTEMPT: ${{ github.run_attempt }}
           LIVE_SMOKE_RUN_ID: ${{ github.run_id }}
           LIVE_SMOKE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          LIVE_SMOKE_MATRIX_STATUS: ${{ needs.live-smoke.result }}
           LIVE_SMOKE_SETUP_STATUS: ${{ needs.setup-cloudflare.result }}
         run: |
           node .github/scripts/live-smoke-report.mjs aggregate \
             --directory live-smoke-evidence \
+            --matrix-status "$LIVE_SMOKE_MATRIX_STATUS" \
             --setup-status "$LIVE_SMOKE_SETUP_STATUS" \
             --run-id "$LIVE_SMOKE_RUN_ID" \
             --run-attempt "$LIVE_SMOKE_RUN_ATTEMPT" \
@@ -415,6 +418,7 @@ jobs:
           if-no-files-found: error
 
       - name: Update tracked failure issue
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && needs.setup-cloudflare.result == 'success' && needs.live-smoke.result == 'success')
         uses: actions/github-script@v8
         with:
           script: |

--- a/test/live-smoke-report.test.ts
+++ b/test/live-smoke-report.test.ts
@@ -20,7 +20,7 @@ const run = {
   runUrl: "https://github.com/vite-hub/vitehub/actions/runs/12345",
 }
 
-const successfulJobs = { matrixStatus: "success", setupStatus: "success" }
+const successfulJobs = { attemptProviders: ["cloudflare", "vercel"], setupStatus: "success" }
 
 function evidence(provider: "cloudflare" | "vercel", currentStage = "runtime", conclusion = "success") {
   return createStageEvidence({ provider, currentStage, conclusion, ...run })
@@ -103,6 +103,7 @@ describe("live smoke stage evidence", () => {
         evidence("vercel"),
       ],
       ...successfulJobs,
+      attemptProviders: ["vercel"],
       ...run,
     })
 
@@ -123,8 +124,8 @@ describe("live smoke stage evidence", () => {
         createStageEvidence({ provider: "cloudflare", currentStage: "runtime", conclusion: "success", ...earlierRun }),
         createStageEvidence({ provider: "vercel", currentStage: "runtime", conclusion: "success", ...earlierRun }),
       ],
-      matrixStatus: "failure",
       setupStatus: "success",
+      attemptProviders: ["cloudflare", "vercel"],
       ...run,
     })
 
@@ -139,8 +140,8 @@ describe("live smoke stage evidence", () => {
         createStageEvidence({ provider: "cloudflare", currentStage: "runtime", conclusion: "success", ...earlierRun }),
         createStageEvidence({ provider: "vercel", currentStage: "deploy", conclusion: "failure", ...earlierRun }),
       ],
-      matrixStatus: "failure",
       setupStatus: "success",
+      attemptProviders: ["vercel"],
       ...run,
     })
 
@@ -153,8 +154,40 @@ describe("live smoke stage evidence", () => {
     })
   })
 
+  it("preserves untouched success when the rerun provider uploads fresh failure evidence", () => {
+    const earlierRun = { ...run, runAttempt: 1 }
+    const report = aggregateStageEvidence({
+      evidence: [
+        createStageEvidence({ provider: "cloudflare", currentStage: "runtime", conclusion: "success", ...earlierRun }),
+        createStageEvidence({ provider: "vercel", currentStage: "deploy", conclusion: "failure", ...earlierRun }),
+        evidence("vercel", "deploy", "failure"),
+      ],
+      setupStatus: "success",
+      attemptProviders: ["vercel"],
+      ...run,
+    })
+
+    expect(report.providers[0]).toMatchObject({ provider: "cloudflare", conclusion: "success", evidenceAttempt: 1 })
+    expect(report.providers[1]).toMatchObject({ provider: "vercel", currentStage: "deploy", conclusion: "failure" })
+  })
+
+  it("rejects both stale successes when all provider jobs rerun", () => {
+    const earlierRun = { ...run, runAttempt: 1 }
+    const report = aggregateStageEvidence({
+      evidence: [
+        createStageEvidence({ provider: "cloudflare", currentStage: "runtime", conclusion: "success", ...earlierRun }),
+        createStageEvidence({ provider: "vercel", currentStage: "runtime", conclusion: "success", ...earlierRun }),
+      ],
+      setupStatus: "success",
+      attemptProviders: ["cloudflare", "vercel"],
+      ...run,
+    })
+
+    expect(report.providers.every(provider => provider.reason === "provider job failed without current-attempt stage evidence")).toBe(true)
+  })
+
   it("attributes a shared setup failure to both provider preflights", () => {
-    const report = aggregateStageEvidence({ evidence: [], matrixStatus: "skipped", setupStatus: "failure", ...run })
+    const report = aggregateStageEvidence({ evidence: [], setupStatus: "failure", attemptProviders: [], ...run })
 
     expect(report.providers.every(provider => provider.currentStage === "preflight")).toBe(true)
     expect(report.providers.every(provider => provider.conclusion === "failure")).toBe(true)
@@ -184,8 +217,8 @@ describe("live smoke stage evidence", () => {
         scriptPath,
         "aggregate",
         "--directory", directory,
-        "--matrix-status", "success",
         "--setup-status", "success",
+        "--attempt-providers", "cloudflare,vercel",
         "--run-id", run.runId,
         "--run-attempt", String(run.runAttempt),
         "--run-url", run.runUrl,
@@ -232,7 +265,7 @@ describe("scheduled failure issue updates", () => {
 
   it("comments on the tracked issue for a new failed run", async () => {
     const fixture = githubFixture({ issues: [{ body: "older run", number: 17 }] })
-    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare"), evidence("vercel", "runtime", "failure")], matrixStatus: "failure", setupStatus: "success", ...run })
+    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare"), evidence("vercel", "runtime", "failure")], setupStatus: "success", attemptProviders: ["cloudflare", "vercel"], ...run })
 
     await expect(updateLiveSmokeIssue({ ...fixture, report })).resolves.toEqual({ action: "commented", issueNumber: 17 })
     expect(fixture.api.createComment).toHaveBeenCalledOnce()
@@ -242,7 +275,7 @@ describe("scheduled failure issue updates", () => {
   it("deduplicates a repeated update for the same run attempt", async () => {
     const marker = `<!-- vitehub-live-smoke-run:${run.runId}:${run.runAttempt} -->`
     const fixture = githubFixture({ issues: [{ body: "older run", number: 17 }], comments: [{ body: marker }] })
-    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare", "build", "failure"), evidence("vercel")], matrixStatus: "failure", setupStatus: "success", ...run })
+    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare", "build", "failure"), evidence("vercel")], setupStatus: "success", attemptProviders: ["cloudflare", "vercel"], ...run })
 
     await expect(updateLiveSmokeIssue({ ...fixture, report })).resolves.toEqual({ action: "deduplicated", issueNumber: 17 })
     expect(fixture.api.createComment).not.toHaveBeenCalled()
@@ -283,7 +316,8 @@ describe("live smoke workflow reporting contract", () => {
     expect(workflow).toContain("pattern: live-smoke-evidence-*")
     expect(workflow).not.toContain("timeout-minutes: 30")
     expect(workflow).not.toContain("merge-multiple: true")
-    expect(workflow).toContain("LIVE_SMOKE_MATRIX_STATUS: ${{ needs.live-smoke.result }}")
+    expect(workflow).toContain("listJobsForWorkflowRunAttempt")
+    expect(workflow).toContain('--attempt-providers "$LIVE_SMOKE_ATTEMPT_PROVIDERS"')
     expect(workflow).toContain("github.event_name == 'workflow_dispatch' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)")
   })
 })

--- a/test/live-smoke-report.test.ts
+++ b/test/live-smoke-report.test.ts
@@ -20,6 +20,8 @@ const run = {
   runUrl: "https://github.com/vite-hub/vitehub/actions/runs/12345",
 }
 
+const successfulJobs = { matrixStatus: "success", setupStatus: "success" }
+
 function evidence(provider: "cloudflare" | "vercel", currentStage = "runtime", conclusion = "success") {
   return createStageEvidence({ provider, currentStage, conclusion, ...run })
 }
@@ -70,7 +72,7 @@ describe("live smoke stage evidence", () => {
   it("aggregates both matrix providers and rejects a partial green run", () => {
     const report = aggregateStageEvidence({
       evidence: [evidence("cloudflare"), evidence("vercel", "deploy", "failure")],
-      setupStatus: "success",
+      ...successfulJobs,
       ...run,
     })
 
@@ -82,7 +84,7 @@ describe("live smoke stage evidence", () => {
   })
 
   it("turns missing matrix evidence into an explicit preflight failure", () => {
-    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare")], setupStatus: "success", ...run })
+    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare")], ...successfulJobs, ...run })
 
     expect(report.providers[1]).toMatchObject({
       provider: "vercel",
@@ -100,7 +102,7 @@ describe("live smoke stage evidence", () => {
         createStageEvidence({ provider: "vercel", currentStage: "deploy", conclusion: "failure", ...earlierRun }),
         evidence("vercel"),
       ],
-      setupStatus: "success",
+      ...successfulJobs,
       ...run,
     })
 
@@ -114,8 +116,45 @@ describe("live smoke stage evidence", () => {
     expect(report.providers[1]).not.toHaveProperty("evidenceAttempt")
   })
 
+  it("rejects stale successful evidence when the rerun matrix failed", () => {
+    const earlierRun = { ...run, runAttempt: 1 }
+    const report = aggregateStageEvidence({
+      evidence: [
+        createStageEvidence({ provider: "cloudflare", currentStage: "runtime", conclusion: "success", ...earlierRun }),
+        createStageEvidence({ provider: "vercel", currentStage: "runtime", conclusion: "success", ...earlierRun }),
+      ],
+      matrixStatus: "failure",
+      setupStatus: "success",
+      ...run,
+    })
+
+    expect(report.conclusion).toBe("failure")
+    expect(report.providers.every(provider => provider.reason === "provider job failed without current-attempt stage evidence")).toBe(true)
+  })
+
+  it("preserves an untouched successful provider when a failed job is rerun", () => {
+    const earlierRun = { ...run, runAttempt: 1 }
+    const report = aggregateStageEvidence({
+      evidence: [
+        createStageEvidence({ provider: "cloudflare", currentStage: "runtime", conclusion: "success", ...earlierRun }),
+        createStageEvidence({ provider: "vercel", currentStage: "deploy", conclusion: "failure", ...earlierRun }),
+      ],
+      matrixStatus: "failure",
+      setupStatus: "success",
+      ...run,
+    })
+
+    expect(report.providers[0]).toMatchObject({ provider: "cloudflare", conclusion: "success", evidenceAttempt: 1 })
+    expect(report.providers[1]).toMatchObject({
+      provider: "vercel",
+      currentStage: "preflight",
+      conclusion: "failure",
+      reason: "provider job failed without current-attempt stage evidence",
+    })
+  })
+
   it("attributes a shared setup failure to both provider preflights", () => {
-    const report = aggregateStageEvidence({ evidence: [], setupStatus: "failure", ...run })
+    const report = aggregateStageEvidence({ evidence: [], matrixStatus: "skipped", setupStatus: "failure", ...run })
 
     expect(report.providers.every(provider => provider.currentStage === "preflight")).toBe(true)
     expect(report.providers.every(provider => provider.conclusion === "failure")).toBe(true)
@@ -145,6 +184,7 @@ describe("live smoke stage evidence", () => {
         scriptPath,
         "aggregate",
         "--directory", directory,
+        "--matrix-status", "success",
         "--setup-status", "success",
         "--run-id", run.runId,
         "--run-attempt", String(run.runAttempt),
@@ -181,7 +221,7 @@ describe("scheduled failure issue updates", () => {
     const fixture = githubFixture()
     const report = aggregateStageEvidence({
       evidence: [evidence("cloudflare", "provision", "failure"), evidence("vercel")],
-      setupStatus: "success",
+      ...successfulJobs,
       ...run,
     })
 
@@ -192,7 +232,7 @@ describe("scheduled failure issue updates", () => {
 
   it("comments on the tracked issue for a new failed run", async () => {
     const fixture = githubFixture({ issues: [{ body: "older run", number: 17 }] })
-    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare"), evidence("vercel", "runtime", "failure")], setupStatus: "success", ...run })
+    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare"), evidence("vercel", "runtime", "failure")], matrixStatus: "failure", setupStatus: "success", ...run })
 
     await expect(updateLiveSmokeIssue({ ...fixture, report })).resolves.toEqual({ action: "commented", issueNumber: 17 })
     expect(fixture.api.createComment).toHaveBeenCalledOnce()
@@ -202,7 +242,7 @@ describe("scheduled failure issue updates", () => {
   it("deduplicates a repeated update for the same run attempt", async () => {
     const marker = `<!-- vitehub-live-smoke-run:${run.runId}:${run.runAttempt} -->`
     const fixture = githubFixture({ issues: [{ body: "older run", number: 17 }], comments: [{ body: marker }] })
-    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare", "build", "failure"), evidence("vercel")], setupStatus: "success", ...run })
+    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare", "build", "failure"), evidence("vercel")], matrixStatus: "failure", setupStatus: "success", ...run })
 
     await expect(updateLiveSmokeIssue({ ...fixture, report })).resolves.toEqual({ action: "deduplicated", issueNumber: 17 })
     expect(fixture.api.createComment).not.toHaveBeenCalled()
@@ -211,7 +251,7 @@ describe("scheduled failure issue updates", () => {
 
   it("comments with green evidence and closes the tracked issue", async () => {
     const fixture = githubFixture({ issues: [{ body: "failed run", number: 17 }] })
-    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare"), evidence("vercel")], setupStatus: "success", ...run })
+    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare"), evidence("vercel")], ...successfulJobs, ...run })
 
     await expect(updateLiveSmokeIssue({ ...fixture, report })).resolves.toEqual({ action: "closed", issueNumber: 17 })
     expect(fixture.api.createComment).toHaveBeenCalledOnce()
@@ -243,5 +283,7 @@ describe("live smoke workflow reporting contract", () => {
     expect(workflow).toContain("pattern: live-smoke-evidence-*")
     expect(workflow).not.toContain("timeout-minutes: 30")
     expect(workflow).not.toContain("merge-multiple: true")
+    expect(workflow).toContain("LIVE_SMOKE_MATRIX_STATUS: ${{ needs.live-smoke.result }}")
+    expect(workflow).toContain("github.event_name == 'workflow_dispatch' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)")
   })
 })

--- a/test/live-smoke-report.test.ts
+++ b/test/live-smoke-report.test.ts
@@ -1,0 +1,224 @@
+import { execFileSync, spawnSync } from "node:child_process"
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+
+import { describe, expect, it, vi } from "vitest"
+
+import {
+  aggregateStageEvidence,
+  createStageEvidence,
+  liveSmokeStages,
+  updateLiveSmokeIssue,
+} from "../.github/scripts/live-smoke-report.mjs"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const scriptPath = resolve(repoRoot, ".github/scripts/live-smoke-report.mjs")
+const run = {
+  runId: "12345",
+  runAttempt: 2,
+  runUrl: "https://github.com/vite-hub/vitehub/actions/runs/12345",
+}
+
+function evidence(provider: "cloudflare" | "vercel", currentStage = "runtime", conclusion = "success") {
+  return createStageEvidence({ provider, currentStage, conclusion, ...run })
+}
+
+function githubFixture({ issues = [], comments = [] }: {
+  issues?: Array<{ body?: string, number: number, pull_request?: object }>
+  comments?: Array<{ body?: string }>
+} = {}) {
+  const api = {
+    create: vi.fn(async () => ({ data: { number: 99 } })),
+    createComment: vi.fn(async () => ({ data: {} })),
+    listComments: vi.fn(async () => ({ data: comments })),
+    listForRepo: vi.fn(async () => ({ data: issues })),
+    update: vi.fn(async () => ({ data: {} })),
+  }
+  return {
+    api,
+    github: {
+      paginate: vi.fn(async (request, options) => (await request(options)).data),
+      rest: { issues: api },
+    },
+    context: { repo: { owner: "vite-hub", repo: "vitehub" } },
+  }
+}
+
+describe("live smoke stage evidence", () => {
+  it.each(liveSmokeStages)("records a %s failure without claiming later stages ran", (currentStage) => {
+    const report = evidence("cloudflare", currentStage, "failure")
+    const currentIndex = liveSmokeStages.indexOf(currentStage)
+
+    expect(report.currentStage).toBe(currentStage)
+    expect(report.conclusion).toBe("failure")
+    for (const [index, stage] of liveSmokeStages.entries()) {
+      expect(report.stages[stage]).toBe(index < currentIndex ? "success" : index === currentIndex ? "failure" : "skipped")
+    }
+  })
+
+  it("records all stages on a successful provider run", () => {
+    expect(evidence("vercel").stages).toEqual({
+      preflight: "success",
+      provision: "success",
+      build: "success",
+      deploy: "success",
+      runtime: "success",
+    })
+  })
+
+  it("aggregates both matrix providers and rejects a partial green run", () => {
+    const report = aggregateStageEvidence({
+      evidence: [evidence("cloudflare"), evidence("vercel", "deploy", "failure")],
+      setupStatus: "success",
+      ...run,
+    })
+
+    expect(report.conclusion).toBe("failure")
+    expect(report.providers.map(provider => [provider.provider, provider.currentStage, provider.conclusion])).toEqual([
+      ["cloudflare", "runtime", "success"],
+      ["vercel", "deploy", "failure"],
+    ])
+  })
+
+  it("turns missing matrix evidence into an explicit preflight failure", () => {
+    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare")], setupStatus: "success", ...run })
+
+    expect(report.providers[1]).toMatchObject({
+      provider: "vercel",
+      currentStage: "preflight",
+      conclusion: "failure",
+      reason: "provider stage evidence was not uploaded",
+    })
+  })
+
+  it("attributes a shared setup failure to both provider preflights", () => {
+    const report = aggregateStageEvidence({ evidence: [], setupStatus: "failure", ...run })
+
+    expect(report.providers.every(provider => provider.currentStage === "preflight")).toBe(true)
+    expect(report.providers.every(provider => provider.conclusion === "failure")).toBe(true)
+  })
+
+  it("prints JSON only from the real evidence entrypoint", () => {
+    const stdout = execFileSync(process.execPath, [
+      scriptPath,
+      "evidence",
+      "--provider", "cloudflare",
+      "--stage", "build",
+      "--conclusion", "failure",
+      "--run-id", run.runId,
+      "--run-attempt", String(run.runAttempt),
+      "--run-url", run.runUrl,
+    ], { encoding: "utf8" })
+
+    expect(JSON.parse(stdout)).toMatchObject({ provider: "cloudflare", currentStage: "build", conclusion: "failure" })
+  })
+
+  it("aggregates provider fixture files through the real entrypoint", () => {
+    const directory = mkdtempSync(join(tmpdir(), "vitehub-live-smoke-report-"))
+    try {
+      writeFileSync(join(directory, "cloudflare.json"), JSON.stringify(evidence("cloudflare")))
+      writeFileSync(join(directory, "vercel.json"), JSON.stringify(evidence("vercel")))
+      const stdout = execFileSync(process.execPath, [
+        scriptPath,
+        "aggregate",
+        "--directory", directory,
+        "--setup-status", "success",
+        "--run-id", run.runId,
+        "--run-attempt", String(run.runAttempt),
+        "--run-url", run.runUrl,
+      ], { encoding: "utf8" })
+
+      expect(JSON.parse(stdout)).toMatchObject({ conclusion: "success" })
+    }
+    finally {
+      rmSync(directory, { recursive: true })
+    }
+  })
+
+  it("rejects an invalid stage through stderr and status 2", () => {
+    const result = spawnSync(process.execPath, [
+      scriptPath,
+      "evidence",
+      "--provider", "cloudflare",
+      "--stage", "unknown",
+      "--conclusion", "failure",
+      "--run-id", run.runId,
+      "--run-attempt", String(run.runAttempt),
+      "--run-url", run.runUrl,
+    ], { encoding: "utf8" })
+
+    expect(result.status).toBe(2)
+    expect(result.stdout).toBe("")
+    expect(result.stderr).toContain("invalid stage: unknown")
+  })
+})
+
+describe("scheduled failure issue updates", () => {
+  it("creates the tracked issue for the first failed run", async () => {
+    const fixture = githubFixture()
+    const report = aggregateStageEvidence({
+      evidence: [evidence("cloudflare", "provision", "failure"), evidence("vercel")],
+      setupStatus: "success",
+      ...run,
+    })
+
+    await expect(updateLiveSmokeIssue({ ...fixture, report })).resolves.toEqual({ action: "created", issueNumber: 99 })
+    expect(fixture.api.create).toHaveBeenCalledOnce()
+    expect(fixture.api.create.mock.calls[0]?.[0].body).toContain("- cloudflare: provision (failure)")
+  })
+
+  it("comments on the tracked issue for a new failed run", async () => {
+    const fixture = githubFixture({ issues: [{ body: "older run", number: 17 }] })
+    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare"), evidence("vercel", "runtime", "failure")], setupStatus: "success", ...run })
+
+    await expect(updateLiveSmokeIssue({ ...fixture, report })).resolves.toEqual({ action: "commented", issueNumber: 17 })
+    expect(fixture.api.createComment).toHaveBeenCalledOnce()
+    expect(fixture.api.create).not.toHaveBeenCalled()
+  })
+
+  it("deduplicates a repeated update for the same run attempt", async () => {
+    const marker = `<!-- vitehub-live-smoke-run:${run.runId}:${run.runAttempt} -->`
+    const fixture = githubFixture({ issues: [{ body: "older run", number: 17 }], comments: [{ body: marker }] })
+    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare", "build", "failure"), evidence("vercel")], setupStatus: "success", ...run })
+
+    await expect(updateLiveSmokeIssue({ ...fixture, report })).resolves.toEqual({ action: "deduplicated", issueNumber: 17 })
+    expect(fixture.api.createComment).not.toHaveBeenCalled()
+    expect(fixture.api.create).not.toHaveBeenCalled()
+  })
+
+  it("comments with green evidence and closes the tracked issue", async () => {
+    const fixture = githubFixture({ issues: [{ body: "failed run", number: 17 }] })
+    const report = aggregateStageEvidence({ evidence: [evidence("cloudflare"), evidence("vercel")], setupStatus: "success", ...run })
+
+    await expect(updateLiveSmokeIssue({ ...fixture, report })).resolves.toEqual({ action: "closed", issueNumber: 17 })
+    expect(fixture.api.createComment).toHaveBeenCalledOnce()
+    expect(fixture.api.update).toHaveBeenCalledWith(expect.objectContaining({
+      issue_number: 17,
+      state: "closed",
+      state_reason: "completed",
+    }))
+  })
+})
+
+describe("live smoke workflow reporting contract", () => {
+  const workflow = readFileSync(resolve(repoRoot, ".github/workflows/live-smoke.yml"), "utf8")
+
+  it("grants only the reporter the permissions needed to read evidence and update issues", () => {
+    const reporter = workflow.slice(workflow.indexOf("  report-live-smoke:"))
+    expect(workflow).toMatch(/permissions:\n  contents: read/)
+    expect(reporter).toContain("actions: read")
+    expect(reporter).toContain("contents: read")
+    expect(reporter).toContain("issues: write")
+  })
+
+  it("records every named stage and aggregates both matrix providers", () => {
+    expect(workflow).toContain("LIVE_SMOKE_STAGE: preflight")
+    for (const stage of liveSmokeStages.slice(1)) {
+      expect(workflow).toContain(`LIVE_SMOKE_STAGE=${stage}`)
+    }
+    expect(workflow).toContain("if: always()")
+    expect(workflow).toContain("pattern: live-smoke-evidence-*-${{ github.run_attempt }}")
+    expect(workflow).toContain("merge-multiple: true")
+  })
+})

--- a/test/live-smoke-report.test.ts
+++ b/test/live-smoke-report.test.ts
@@ -92,6 +92,28 @@ describe("live smoke stage evidence", () => {
     })
   })
 
+  it("reuses the latest provider evidence from an earlier rerun attempt", () => {
+    const earlierRun = { ...run, runAttempt: 1 }
+    const report = aggregateStageEvidence({
+      evidence: [
+        createStageEvidence({ provider: "cloudflare", currentStage: "runtime", conclusion: "success", ...earlierRun }),
+        createStageEvidence({ provider: "vercel", currentStage: "deploy", conclusion: "failure", ...earlierRun }),
+        evidence("vercel"),
+      ],
+      setupStatus: "success",
+      ...run,
+    })
+
+    expect(report.conclusion).toBe("success")
+    expect(report.providers[0]).toMatchObject({
+      provider: "cloudflare",
+      conclusion: "success",
+      evidenceAttempt: 1,
+      run: { attempt: 2 },
+    })
+    expect(report.providers[1]).not.toHaveProperty("evidenceAttempt")
+  })
+
   it("attributes a shared setup failure to both provider preflights", () => {
     const report = aggregateStageEvidence({ evidence: [], setupStatus: "failure", ...run })
 
@@ -218,7 +240,8 @@ describe("live smoke workflow reporting contract", () => {
       expect(workflow).toContain(`LIVE_SMOKE_STAGE=${stage}`)
     }
     expect(workflow).toContain("if: always()")
-    expect(workflow).toContain("pattern: live-smoke-evidence-*-${{ github.run_attempt }}")
-    expect(workflow).toContain("merge-multiple: true")
+    expect(workflow).toContain("pattern: live-smoke-evidence-*")
+    expect(workflow).not.toContain("timeout-minutes: 30")
+    expect(workflow).not.toContain("merge-multiple: true")
   })
 })


### PR DESCRIPTION
Scheduled Live Smoke now records the provider and current stage before it reports a failure, so a provisioning failure no longer looks like a runtime regression. Each matrix leg uploads JSON for preflight, provision, build, deploy, and runtime; the scheduled reporter combines both providers and treats missing evidence as a failure.

The tracked `live-smoke-failure` issue gets one update per run attempt. A new failure creates the issue, later failures comment with the stage report, repeated reporting is suppressed, and a run closes the issue only when Cloudflare and Vercel both finish green. The reporter alone receives `issues: write`; other jobs retain read-only repository access.

Verification:
- `vp test test/live-smoke-report.test.ts` — 18 tests passed across all five failure stages, provider success, matrix aggregation, missing evidence, setup failure, issue create/comment/dedupe/close, permissions, and real CLI output/status
- parsed `.github/workflows/live-smoke.yml` as YAML and asserted the provider matrix and reporter permissions
- `vp run doctor:typescript` — 100/100, no findings
- `vp run lint` — passed with existing repository warnings

No provider command or credential-backed workflow was run locally.