### PR TITLE
refactor(agent): own webhook queue lifecycle

### DIFF
--- a/packages/agent/src/internal/webhook-queue.ts
+++ b/packages/agent/src/internal/webhook-queue.ts
@@ -97,3 +97,241 @@ export function hasAgentWebhookQueue(state: StateAdapter): state is AgentWebhook
     isRuntimeFunction(candidate.webhookDeliveryScopes)
   )
 }
+
+export interface AgentWebhookQueueRegistration<Options> {
+  backendId: string
+  options: Options
+  scope: string
+  state: AgentWebhookQueueStateAdapter
+}
+
+export interface AgentWebhookQueueExecution<Options> extends AgentWebhookQueueRegistration<Options> {
+  delivery: AgentWebhookQueueLease
+  lifecycleSignal: AbortSignal
+}
+
+export interface AgentWebhookQueueRegistrar<Options> {
+  register: (registration: AgentWebhookQueueRegistration<Options>) => Promise<boolean>
+  track: (state: StateAdapter, options: Options, scopePrefix?: string) => void
+}
+
+export interface AgentWebhookQueue<Options> {
+  admit: (registration: AgentWebhookQueueRegistration<Options>, delivery: AgentWebhookQueueDelivery) => Promise<boolean>
+  idle: () => Promise<void>
+  register: (registration: AgentWebhookQueueRegistration<Options>) => Promise<boolean>
+  resume: (
+    discover: (registrar: AgentWebhookQueueRegistrar<Options>) => Promise<void>,
+    options?: { scopePrefix?: string },
+  ) => () => Promise<void>
+  stop: () => Promise<void>
+}
+
+interface AgentWebhookQueueOwnerOptions<Options> {
+  execute: (execution: AgentWebhookQueueExecution<Options>) => Promise<number | undefined>
+  resolveBackendId?: (state: AgentWebhookQueueStateAdapter) => Promise<string>
+  resolveWaitUntil: (options: Options) => Promise<((task: Promise<void>) => void) | undefined>
+  retryMs?: number
+}
+
+interface TrackedQueueState<Options> {
+  options: Options
+  scopePrefix?: string
+  scopes?: Map<string, string>
+}
+
+const webhookQueueStopMessage = "[vitehub] Webhook queue stopped during Agent execution."
+
+export function createAgentWebhookQueue<Options>(
+  ownerOptions: AgentWebhookQueueOwnerOptions<Options>,
+): AgentWebhookQueue<Options> {
+  const retryMs = ownerOptions.retryMs ?? 1_000
+  const registrations = new Map<string, AgentWebhookQueueRegistration<Options>>()
+  const trackedStates = new Map<AgentWebhookQueueStateAdapter, TrackedQueueState<Options>>()
+  const draining = new Set<string>()
+  const pending = new Set<string>()
+  const scheduled = new Map<string, { at: number; resolve: () => void; timer: ReturnType<typeof setTimeout> }>()
+  const active = new Map<Promise<number | undefined>, { controller: AbortController; queueId: string }>()
+  const drains = new Set<Promise<void>>()
+  let stopped = false
+
+  const queueId = (registration: AgentWebhookQueueRegistration<Options>) => `${registration.backendId}:${registration.scope}`
+
+  let drain: (id: string) => Promise<void>
+  const schedule = (id: string, at: number, waitUntil?: (task: Promise<void>) => void) => {
+    if (stopped) return
+    const existing = scheduled.get(id)
+    if (existing && existing.at <= at) return
+    if (existing) {
+      clearTimeout(existing.timer)
+      existing.resolve()
+    }
+    let resolveScheduled!: () => void
+    const task = new Promise<void>((resolve) => {
+      resolveScheduled = resolve
+    })
+    const timer = setTimeout(() => {
+      scheduled.delete(id)
+      void drain(id).finally(resolveScheduled)
+    }, Math.max(0, at - Date.now()))
+    timer.unref?.()
+    scheduled.set(id, { at, resolve: resolveScheduled, timer })
+    waitUntil?.(task)
+  }
+
+  const drainOnce = async (id: string) => {
+    const registration = registrations.get(id)
+    if (stopped || !registration) return
+    if (draining.has(id)) {
+      pending.add(id)
+      return
+    }
+    draining.add(id)
+    try {
+      const waitUntil = await ownerOptions.resolveWaitUntil(registration.options)
+      while (!stopped) {
+        const delivery = await registration.state.claimWebhookDelivery(registration.scope)
+        if (!delivery) {
+          if (![...active.values()].some(item => item.queueId === id)) schedule(id, Date.now() + retryMs)
+          break
+        }
+        if (stopped) {
+          await registration.state
+            .retryWebhookDelivery(registration.scope, delivery.deliveryId, delivery.leaseToken, Date.now(), { incrementAttempts: false })
+            .catch(() => undefined)
+          break
+        }
+        const controller = new AbortController()
+        const task = ownerOptions.execute({ ...registration, delivery, lifecycleSignal: controller.signal })
+        active.set(task, { controller, queueId: id })
+        waitUntil?.(task.then(() => undefined))
+        void task
+          .then((retryAt) => {
+            for (const registeredId of registrations.keys()) {
+              if (registeredId !== id) void drain(registeredId)
+            }
+            if (retryAt === undefined || retryAt <= Date.now()) void drain(id)
+            else schedule(id, retryAt, waitUntil)
+          })
+          .catch((error) => {
+            console.error(`[vitehub] Queued webhook delivery "${delivery.deliveryId}" stopped unexpectedly.`, error)
+            schedule(id, Date.now() + retryMs, waitUntil)
+          })
+          .finally(() => active.delete(task))
+      }
+    }
+    catch (error) {
+      console.error("[vitehub] Webhook queue drain failed and will be retried.", error)
+      schedule(id, Date.now() + retryMs, await ownerOptions.resolveWaitUntil(registration.options))
+    }
+    finally {
+      draining.delete(id)
+      if (pending.delete(id)) void drain(id)
+    }
+  }
+
+  drain = (id) => {
+    const task = drainOnce(id)
+    drains.add(task)
+    void task.finally(() => drains.delete(task))
+    return task
+  }
+
+  const register = async (registration: AgentWebhookQueueRegistration<Options>) => {
+    if (!hasAgentWebhookQueue(registration.state)) return false
+    const tracked = trackedStates.get(registration.state)
+    if (tracked?.scopes) tracked.scopes.set(registration.scope, registration.backendId)
+    else if (!tracked) trackedStates.set(registration.state, {
+      options: registration.options,
+      scopes: new Map([[registration.scope, registration.backendId]]),
+    })
+    const id = queueId(registration)
+    registrations.set(id, registration)
+    const task = drain(id)
+    const waitUntil = await ownerOptions.resolveWaitUntil(registration.options)
+    waitUntil?.(task)
+    return true
+  }
+
+  const track = (state: StateAdapter, options: Options, scopePrefix?: string) => {
+    if (!hasAgentWebhookQueue(state) || trackedStates.has(state)) return
+    trackedStates.set(state, { options, scopePrefix })
+  }
+
+  const discoverTrackedScopes = async (defaultScopePrefix?: string) => {
+    for (const [state, tracked] of trackedStates) {
+      const persisted = new Set(await state.webhookDeliveryScopes())
+      if (tracked.scopes) {
+        for (const [scope, backendId] of tracked.scopes) {
+          if (persisted.has(scope)) await register({ backendId, options: tracked.options, scope, state })
+        }
+        continue
+      }
+      if (!ownerOptions.resolveBackendId) continue
+      const backendId = await ownerOptions.resolveBackendId(state)
+      const scopePrefix = tracked.scopePrefix ?? defaultScopePrefix
+      for (const scope of persisted) {
+        if (!scopePrefix || scope.startsWith(scopePrefix)) await register({ backendId, options: tracked.options, scope, state })
+      }
+    }
+  }
+
+  const idle = async () => {
+    while (drains.size || active.size) {
+      await Promise.allSettled([...drains, ...active.keys()])
+    }
+  }
+
+  const stop = async () => {
+    stopped = true
+    for (const timer of scheduled.values()) {
+      clearTimeout(timer.timer)
+      timer.resolve()
+    }
+    scheduled.clear()
+    pending.clear()
+    for (const { controller } of active.values()) controller.abort(new Error(webhookQueueStopMessage))
+    await idle()
+  }
+
+  return {
+    async admit(registration, delivery) {
+      const admitted = await registration.state.enqueueWebhookDelivery(delivery)
+      await register(registration)
+      return admitted
+    },
+    idle,
+    register,
+    resume(discover, resumeOptions = {}) {
+      stopped = false
+      let discovery: Promise<void> | undefined
+      let discovered = false
+      const runDiscovery = async () => {
+        if (stopped || discovery) return
+        discovery = (async () => {
+          if (!discovered) {
+            await discover({ register, track })
+            discovered = true
+          }
+          await discoverTrackedScopes(resumeOptions.scopePrefix)
+        })()
+          .catch(error => console.error("[vitehub] Webhook queue discovery failed and will be retried.", error))
+          .finally(() => {
+            discovery = undefined
+          })
+        await discovery
+      }
+      void runDiscovery()
+      const timer = setInterval(() => {
+        if (stopped) return
+        void runDiscovery()
+        for (const id of registrations.keys()) void drain(id)
+      }, retryMs)
+      timer.unref?.()
+      return async () => {
+        clearInterval(timer)
+        await stop()
+      }
+    },
+    stop,
+  }
+}

--- a/packages/agent/src/internal/webhook-queue.ts
+++ b/packages/agent/src/internal/webhook-queue.ts
@@ -253,7 +253,7 @@ export function createAgentWebhookQueue<Options>(
   }
 
   const track = (state: StateAdapter, options: Options, scopePrefix?: string) => {
-    if (!hasAgentWebhookQueue(state) || trackedStates.has(state)) return
+    if (!hasAgentWebhookQueue(state)) return
     trackedStates.set(state, { options, scopePrefix })
   }
 

--- a/packages/agent/src/internal/webhook-queue.ts
+++ b/packages/agent/src/internal/webhook-queue.ts
@@ -152,6 +152,7 @@ export function createAgentWebhookQueue<Options>(
   const scheduled = new Map<string, { at: number; resolve: () => void; timer: ReturnType<typeof setTimeout> }>()
   const active = new Map<Promise<number | undefined>, { controller: AbortController; queueId: string }>()
   const drains = new Set<Promise<void>>()
+  const discoveries = new Set<Promise<void>>()
   let stopped = false
 
   const queueId = (registration: AgentWebhookQueueRegistration<Options>) => `${registration.backendId}:${registration.scope}`
@@ -290,6 +291,7 @@ export function createAgentWebhookQueue<Options>(
     scheduled.clear()
     pending.clear()
     for (const { controller } of active.values()) controller.abort(new Error(webhookQueueStopMessage))
+    await Promise.allSettled([...discoveries])
     await idle()
   }
 
@@ -316,8 +318,10 @@ export function createAgentWebhookQueue<Options>(
         })()
           .catch(error => console.error("[vitehub] Webhook queue discovery failed and will be retried.", error))
           .finally(() => {
+            discoveries.delete(discovery!)
             discovery = undefined
           })
+        discoveries.add(discovery)
         await discovery
       }
       void runDiscovery()

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -61,7 +61,7 @@ import {
   isRuntimeSymbol,
   isRuntimeUndefined,
 } from "../internal/runtime-value.ts"
-import { hasAgentWebhookQueue } from "../internal/webhook-queue.ts"
+import { createAgentWebhookQueue, hasAgentWebhookQueue } from "../internal/webhook-queue.ts"
 import { activeAgentInvocation, registerActiveAgentInvocation } from "../internal/agent-invocation-control.ts"
 import {
   agentChannelDeliveryMessageIdentity,
@@ -6774,119 +6774,16 @@ export function createChannelChatRouteHandler(
 }
 
 export function createChannelWebhookRouteHandler(agent: AgentInput<ViteAgentRouteRuntimeContext>): AgentChannelWebhookRouteHandler {
-  const queueScopes = new Map<
-    string,
-    {
-      backendId: string
-      options: AgentChannelWebhookRouteOptions
-      scope: string
-      state: AgentWebhookQueueStateAdapter
-    }
-  >()
-  const queueStates = new Map<AgentWebhookQueueStateAdapter, Map<string, string> | undefined>()
-  const drainingScopes = new Set<string>()
-  const pendingDrainScopes = new Set<string>()
-  const retryTimers = new Map<string, { at: number; resolve: () => void; timer: ReturnType<typeof setTimeout> }>()
-  const activeDeliveries = new Map<Promise<number | undefined>, { controller: AbortController; scope: string }>()
-  const inFlightDrains = new Set<Promise<void>>()
   const activeInvocationScope: WebhookActiveInvocationScope = { owner: "webhook" }
-  let queueStopped = false
-  let drainQueue: (scope: string) => Promise<void>
-
-  const scheduleQueueDrain = (queueId: string, at: number, waitUntil?: AgentWaitUntil) => {
-    const existing = retryTimers.get(queueId)
-    if (existing && existing.at <= at) return
-    if (existing) {
-      clearTimeout(existing.timer)
-      existing.resolve()
-    }
-    let resolveScheduled!: () => void
-    const scheduled = new Promise<void>((resolve) => {
-      resolveScheduled = resolve
-    })
-    const timer = setTimeout(
-      () => {
-        retryTimers.delete(queueId)
-        void drainQueue(queueId).finally(resolveScheduled)
-      },
-      Math.max(0, at - Date.now()),
-    )
-    timer.unref?.()
-    retryTimers.set(queueId, { at, resolve: resolveScheduled, timer })
-    waitUntil?.(scheduled)
-  }
-
-  const drainQueueOnce = async (queueId: string) => {
-    const queue = queueScopes.get(queueId)
-    if (queueStopped || !queue) return
-    if (drainingScopes.has(queueId)) {
-      pendingDrainScopes.add(queueId)
-      return
-    }
-    drainingScopes.add(queueId)
-    try {
-      const waitUntil = await resolveRuntimeWaitUntil(queue.options.waitUntil)
-      while (!queueStopped) {
-        const delivery = await queue.state.claimWebhookDelivery(queue.scope)
-        if (!delivery) {
-          if (![...activeDeliveries.values()].some((active) => active.scope === queueId)) {
-            scheduleQueueDrain(queueId, Date.now() + defaultWebhookQueueRetryMs)
-          }
-          break
-        }
-        if (queueStopped) {
-          await queue.state
-            .retryWebhookDelivery(queue.scope, delivery.deliveryId, delivery.leaseToken, Date.now(), { incrementAttempts: false })
-            .catch(() => undefined)
-          break
-        }
-        const controller = new AbortController()
-        const task = executeQueuedWebhookDelivery(agent, queue.state, activeInvocationScope, queue.backendId, delivery, queue.options, controller.signal)
-        activeDeliveries.set(task, { controller, scope: queueId })
-        waitUntil?.(task)
-        void task
-          .then((retryAt) => {
-            for (const registeredQueueId of queueScopes.keys()) {
-              if (registeredQueueId !== queueId) void drainQueue(registeredQueueId)
-            }
-            if (retryAt === undefined || retryAt <= Date.now()) void drainQueue(queueId)
-            else scheduleQueueDrain(queueId, retryAt, waitUntil)
-          })
-          .catch((error) => {
-            console.error(`[vitehub] Queued webhook delivery "${delivery.deliveryId}" stopped unexpectedly.`, error)
-            scheduleQueueDrain(queueId, Date.now() + defaultWebhookQueueRetryMs, waitUntil)
-          })
-          .finally(() => {
-            activeDeliveries.delete(task)
-          })
-      }
-    } catch (error) {
-      console.error("[vitehub] Webhook queue drain failed and will be retried.", error)
-      scheduleQueueDrain(queueId, Date.now() + defaultWebhookQueueRetryMs, await resolveRuntimeWaitUntil(queue.options.waitUntil))
-    } finally {
-      drainingScopes.delete(queueId)
-      if (pendingDrainScopes.delete(queueId)) void drainQueue(queueId)
-    }
-  }
-
-  drainQueue = (queueId) => {
-    const task = drainQueueOnce(queueId)
-    inFlightDrains.add(task)
-    void task.finally(() => inFlightDrains.delete(task))
-    return task
-  }
-
-  const registerQueue = async (backendId: string, scope: string, state: StateAdapter, options: AgentChannelWebhookRouteOptions) => {
-    if (!hasAgentWebhookQueue(state)) return false
-    if (!queueStates.has(state)) queueStates.set(state, new Map())
-    queueStates.get(state)?.set(scope, backendId)
-    const queueId = `${backendId}:${scope}`
-    queueScopes.set(queueId, { backendId, options, scope, state })
-    const task = drainQueue(queueId)
-    const waitUntil = await resolveRuntimeWaitUntil(options.waitUntil)
-    waitUntil?.(task)
-    return true
-  }
+  const webhookQueue = createAgentWebhookQueue<AgentChannelWebhookRouteOptions>({
+    execute: async ({ backendId, delivery, lifecycleSignal, options, state }) =>
+      await executeQueuedWebhookDelivery(agent, state, activeInvocationScope, backendId, delivery, options, lifecycleSignal),
+    resolveBackendId: resolveWebhookStateBackendId,
+    resolveWaitUntil: async options => await resolveRuntimeWaitUntil(options.waitUntil),
+    retryMs: defaultWebhookQueueRetryMs,
+  })
+  const registerQueue = (backendId: string, scope: string, state: AgentWebhookQueueStateAdapter, options: AgentChannelWebhookRouteOptions) =>
+    webhookQueue.register({ backendId, options, scope, state })
 
   const handler: AgentChannelWebhookRouteHandler = async (request, webhook, handlerOptions = {}) => {
     const webhookStartedAt = Date.now()
@@ -7088,7 +6985,12 @@ export function createChannelWebhookRouteHandler(agent: AgentInput<ViteAgentRout
                       ok: true,
                       queued: true,
                     })
-                  const queued = await webhookQueueState.enqueueWebhookDelivery(delivery)
+                  const queued = await webhookQueue.admit({
+                    backendId,
+                    options: handlerOptions,
+                    scope: webhookState.keyPrefix,
+                    state: webhookQueueState,
+                  }, delivery)
                   return Response.json({ accepted: queued, duplicate: !queued, ok: true, queued })
                 },
               )
@@ -7116,8 +7018,12 @@ export function createChannelWebhookRouteHandler(agent: AgentInput<ViteAgentRout
                 return outcome.response
               }
             }
-            const queued = await webhookState.state.enqueueWebhookDelivery(delivery)
-            await registerQueue(backendId, webhookState.keyPrefix, webhookState.state, handlerOptions)
+            const queued = await webhookQueue.admit({
+              backendId,
+              options: handlerOptions,
+              scope: webhookState.keyPrefix,
+              state: webhookState.state,
+            }, delivery)
             if (queued) detachAgentChannelDelivery(channelDelivery)
             await recordChannelDeliveryEvidence(channelDelivery, {
               type: queued ? "queued" : "duplicate",
@@ -7396,100 +7302,38 @@ export function createChannelWebhookRouteHandler(agent: AgentInput<ViteAgentRout
       .slice(0, handlerOptions.limit ?? 100)
   }
   handler.resume = (handlerOptions = {}) => {
-    let stopped = false
-    let discovered = false
-    let discovering: Promise<void> | undefined
-    let discoveringScopes: Promise<void> | undefined
-    queueStopped = false
     const agentScopePrefix = `webhook:${webhookScopeComponent(routeAgentIdentity(handlerOptions)?.name || "agent")}:`
-    const discoverScopes = async () => {
-      if (stopped || discoveringScopes) return
-      discoveringScopes = (async () => {
-        for (const [state, knownScopes] of queueStates) {
-          const persistedScopes = new Set(await state.webhookDeliveryScopes())
-          if (knownScopes) {
-            for (const [scope, backendId] of knownScopes) {
-              if (persistedScopes.has(scope)) await registerQueue(backendId, scope, state, handlerOptions)
-            }
-          } else {
-            const backendId = await resolveWebhookStateBackendId(state)
-            for (const scope of persistedScopes) {
-              if (scope.startsWith(agentScopePrefix)) await registerQueue(backendId, scope, state, handlerOptions)
-            }
-          }
+    return webhookQueue.resume(async (registrar) => {
+      const request = new Request("http://vitehub.local/_vitehub/webhook-queue")
+      const context = createRuntimeContext(
+        request,
+        undefined,
+        await resolveRuntimeWaitUntil(handlerOptions.waitUntil),
+        handlerOptions.cloudflare,
+        handlerOptions.runtime,
+        handlerOptions.capabilities,
+        routeAgentIdentity(handlerOptions),
+      )
+      if (handlerOptions.webhookState && !stateResolverOwnsScope(handlerOptions.webhookState)) {
+        // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
+        const state = await resolveMaybe(handlerOptions.webhookState, context as never)
+        if (state) {
+          await state.connect()
+          registrar.track(state, handlerOptions, agentScopePrefix)
         }
-      })()
-        .catch((error) => console.error("[vitehub] Webhook queue scope discovery failed and will be retried.", error))
-        .finally(() => {
-          discoveringScopes = undefined
-        })
-      await discoveringScopes
-    }
-    const discover = async () => {
-      if (stopped || discovered || discovering) return
-      discovering = (async () => {
-        const request = new Request("http://vitehub.local/_vitehub/webhook-queue")
-        const context = createRuntimeContext(
-          request,
-          undefined,
-          await resolveRuntimeWaitUntil(handlerOptions.waitUntil),
-          handlerOptions.cloudflare,
-          handlerOptions.runtime,
-          handlerOptions.capabilities,
-          routeAgentIdentity(handlerOptions),
-        )
-        if (handlerOptions.webhookState && !stateResolverOwnsScope(handlerOptions.webhookState)) {
-          // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
-          const state = await resolveMaybe(handlerOptions.webhookState, context as never)
-          if (state) {
-            await state.connect()
-            if (hasAgentWebhookQueue(state)) {
-              queueStates.set(state, undefined)
-            }
-          }
+      }
+      for (const { registration } of await agentWebhookRegistrations(agent, context)) {
+        const webhookState = await resolveAgentWebhookState(context, registration, handlerOptions)
+        if (webhookState && hasAgentWebhookQueue(webhookState.state)) {
+          await registrar.register({
+            backendId: await resolveWebhookStateBackendId(webhookState.state),
+            options: handlerOptions,
+            scope: webhookState.keyPrefix,
+            state: webhookState.state,
+          })
         }
-        for (const { registration } of await agentWebhookRegistrations(agent, context)) {
-          if (stopped) return
-          const webhookState = await resolveAgentWebhookState(context, registration, handlerOptions)
-          if (webhookState && hasAgentWebhookQueue(webhookState.state)) {
-            const backendId = await resolveWebhookStateBackendId(webhookState.state)
-            await registerQueue(backendId, webhookState.keyPrefix, webhookState.state, handlerOptions)
-          }
-        }
-        await discoverScopes()
-        discovered = true
-      })()
-        .catch((error) => console.error("[vitehub] Webhook queue startup discovery failed and will be retried.", error))
-        .finally(() => {
-          discovering = undefined
-        })
-      await discovering
-    }
-    void discover()
-    const timer = setInterval(() => {
-      if (!stopped) {
-        void discover()
-        if (discovered) void discoverScopes()
-        for (const scope of queueScopes.keys()) void drainQueue(scope)
       }
-    }, defaultWebhookQueueRetryMs)
-    timer.unref?.()
-    return async () => {
-      stopped = true
-      queueStopped = true
-      clearInterval(timer)
-      for (const retryTimer of retryTimers.values()) {
-        clearTimeout(retryTimer.timer)
-        retryTimer.resolve()
-      }
-      retryTimers.clear()
-      pendingDrainScopes.clear()
-      for (const { controller } of activeDeliveries.values()) {
-        controller.abort(new Error("[vitehub] Webhook queue stopped during Agent execution."))
-      }
-      await Promise.allSettled(inFlightDrains)
-      await Promise.allSettled(activeDeliveries.keys())
-    }
+    }, { scopePrefix: agentScopePrefix })
   }
   return handler
 }

--- a/packages/agent/test/webhook-queue-owner.test.ts
+++ b/packages/agent/test/webhook-queue-owner.test.ts
@@ -31,7 +31,7 @@ function queueState(claims: AgentWebhookQueueLease[] = []) {
     extendWebhookDeliveryLease: vi.fn(async () => true),
     retryWebhookDelivery: vi.fn(async () => true),
     webhookDeliveryScopes: vi.fn(async () => ["scope"]),
-  } as AgentWebhookQueueStateAdapter
+  } as unknown as AgentWebhookQueueStateAdapter
   return { queued, state }
 }
 
@@ -94,5 +94,33 @@ describe("Agent webhook queue owner", () => {
 
     await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce())
     await stop()
+  })
+
+  it("waits for scope discovery before stop resolves", async () => {
+    const { state } = queueState()
+    let finishDiscovery!: () => void
+    const discoveryBlocked = new Promise<void>((resolve) => {
+      finishDiscovery = resolve
+    })
+    const queue = createAgentWebhookQueue({
+      execute: async () => undefined,
+      resolveWaitUntil: async () => undefined,
+    })
+    const stop = queue.resume(async (registrar) => {
+      await discoveryBlocked
+      registrar.track(state, {})
+    })
+
+    const stopping = stop()
+    let stopped = false
+    void stopping.then(() => {
+      stopped = true
+    })
+    await Promise.resolve()
+    expect(stopped).toBe(false)
+
+    finishDiscovery()
+    await stopping
+    expect(stopped).toBe(true)
   })
 })

--- a/packages/agent/test/webhook-queue-owner.test.ts
+++ b/packages/agent/test/webhook-queue-owner.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { createAgentWebhookQueue } from "../src/internal/webhook-queue.ts"
 
-import type { AgentWebhookQueueDelivery, AgentWebhookQueueLease, AgentWebhookQueueStateAdapter } from "../src/internal/webhook-queue.ts"
+import type { AgentWebhookQueueLease, AgentWebhookQueueStateAdapter } from "../src/internal/webhook-queue.ts"
 
 function delivery(id: string, attempts = 0): AgentWebhookQueueLease {
   return {
@@ -22,6 +22,7 @@ function delivery(id: string, attempts = 0): AgentWebhookQueueLease {
 
 function queueState(claims: AgentWebhookQueueLease[] = []) {
   const queued = [...claims]
+  // SAFETY: The queue owner only exercises the webhook queue methods supplied by this focused fixture.
   const state = {
     claimWebhookDelivery: vi.fn(async () => queued.shift() ?? null),
     claimWebhookSteering: vi.fn(async () => true),
@@ -30,7 +31,7 @@ function queueState(claims: AgentWebhookQueueLease[] = []) {
     extendWebhookDeliveryLease: vi.fn(async () => true),
     retryWebhookDelivery: vi.fn(async () => true),
     webhookDeliveryScopes: vi.fn(async () => ["scope"]),
-  } as unknown as AgentWebhookQueueStateAdapter
+  } as AgentWebhookQueueStateAdapter
   return { queued, state }
 }
 
@@ -42,7 +43,7 @@ describe("Agent webhook queue owner", () => {
     const queue = createAgentWebhookQueue({ execute, resolveWaitUntil: async () => undefined })
     const registration = { backendId: "backend", options: {}, scope: "scope", state }
 
-    await expect(queue.admit(registration, lease as AgentWebhookQueueDelivery)).resolves.toBe(true)
+    await expect(queue.admit(registration, lease)).resolves.toBe(true)
     await queue.idle()
     await queue.register(registration)
     await queue.idle()
@@ -74,10 +75,11 @@ describe("Agent webhook queue owner", () => {
     expect(stopped).toHaveBeenCalledTimes(2)
   })
 
-  it("rediscovers persisted scopes after restart", async () => {
+  it("rediscovers every persisted scope when registration wins startup", async () => {
     const fixture = queueState([delivery("persisted")])
     const { state } = fixture
-    state.claimWebhookDelivery = vi.fn(async (scope: string) => scope === "scope" ? fixture.queued.shift() ?? null : null)
+    state.webhookDeliveryScopes = vi.fn(async () => ["scope:declared", "scope:persisted"])
+    state.claimWebhookDelivery = vi.fn(async (scope: string) => scope === "scope:persisted" ? fixture.queued.shift() ?? null : null)
     const execute = vi.fn(async () => undefined)
     const queue = createAgentWebhookQueue({
       execute,
@@ -86,8 +88,8 @@ describe("Agent webhook queue owner", () => {
       retryMs: 5,
     })
     const stop = queue.resume(async (registrar) => {
-      registrar.track(state, {}, "scope")
       await registrar.register({ backendId: "backend", options: {}, scope: "scope:declared", state })
+      registrar.track(state, {}, "scope:")
     }, { scopePrefix: "scope" })
 
     await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce())

--- a/packages/agent/test/webhook-queue-owner.test.ts
+++ b/packages/agent/test/webhook-queue-owner.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createAgentWebhookQueue } from "../src/internal/webhook-queue.ts"
+
+import type { AgentWebhookQueueDelivery, AgentWebhookQueueLease, AgentWebhookQueueStateAdapter } from "../src/internal/webhook-queue.ts"
+
+function delivery(id: string, attempts = 0): AgentWebhookQueueLease {
+  return {
+    attempts,
+    concurrencyGroup: "agent:default",
+    concurrencyLimit: 1,
+    deliveryId: id,
+    enqueuedAt: 0,
+    leaseExpiresAt: Date.now() + 1_000,
+    leaseToken: `lease-${id}`,
+    leaseTtlMs: 1_000,
+    request: { body: "", headers: {}, method: "POST", url: "https://example.com/webhook" },
+    scope: "scope",
+    webhookId: "github",
+  }
+}
+
+function queueState(claims: AgentWebhookQueueLease[] = []) {
+  const queued = [...claims]
+  const state = {
+    claimWebhookDelivery: vi.fn(async () => queued.shift() ?? null),
+    claimWebhookSteering: vi.fn(async () => true),
+    completeWebhookDelivery: vi.fn(async () => true),
+    enqueueWebhookDelivery: vi.fn(async () => true),
+    extendWebhookDeliveryLease: vi.fn(async () => true),
+    retryWebhookDelivery: vi.fn(async () => true),
+    webhookDeliveryScopes: vi.fn(async () => ["scope"]),
+  } as unknown as AgentWebhookQueueStateAdapter
+  return { queued, state }
+}
+
+describe("Agent webhook queue owner", () => {
+  it("admits a delivery, drains it once, and ignores duplicate registrations", async () => {
+    const lease = delivery("one")
+    const { state } = queueState([lease])
+    const execute = vi.fn(async () => undefined)
+    const queue = createAgentWebhookQueue({ execute, resolveWaitUntil: async () => undefined })
+    const registration = { backendId: "backend", options: {}, scope: "scope", state }
+
+    await expect(queue.admit(registration, lease as AgentWebhookQueueDelivery)).resolves.toBe(true)
+    await queue.idle()
+    await queue.register(registration)
+    await queue.idle()
+
+    expect(state.enqueueWebhookDelivery).toHaveBeenCalledOnce()
+    expect(execute).toHaveBeenCalledOnce()
+  })
+
+  it("isolates concurrent scopes and aborts active work before stop resolves", async () => {
+    const first = queueState([delivery("one")])
+    const second = queueState([delivery("two")])
+    const stopped = vi.fn()
+    const execute = vi.fn(async ({ lifecycleSignal }: { lifecycleSignal: AbortSignal }) => {
+      await new Promise<void>((resolve) => lifecycleSignal.addEventListener("abort", () => {
+        stopped()
+        resolve()
+      }, { once: true }))
+      return Date.now()
+    })
+    const queue = createAgentWebhookQueue({ execute, resolveWaitUntil: async () => undefined })
+
+    await Promise.all([
+      queue.register({ backendId: "first", options: {}, scope: "scope", state: first.state }),
+      queue.register({ backendId: "second", options: {}, scope: "scope", state: second.state }),
+    ])
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledTimes(2))
+    await queue.stop()
+
+    expect(stopped).toHaveBeenCalledTimes(2)
+  })
+
+  it("rediscovers persisted scopes after restart", async () => {
+    const fixture = queueState([delivery("persisted")])
+    const { state } = fixture
+    state.claimWebhookDelivery = vi.fn(async (scope: string) => scope === "scope" ? fixture.queued.shift() ?? null : null)
+    const execute = vi.fn(async () => undefined)
+    const queue = createAgentWebhookQueue({
+      execute,
+      resolveBackendId: async () => "backend",
+      resolveWaitUntil: async () => undefined,
+      retryMs: 5,
+    })
+    const stop = queue.resume(async (registrar) => {
+      registrar.track(state, {}, "scope")
+      await registrar.register({ backendId: "backend", options: {}, scope: "scope:declared", state })
+    }, { scopePrefix: "scope" })
+
+    await vi.waitFor(() => expect(execute).toHaveBeenCalledOnce())
+    await stop()
+  })
+})


### PR DESCRIPTION
## Summary

- move webhook admission, per-scope draining, retry scheduling, persisted-scope discovery, and shutdown cancellation behind the Agent webhook queue module
- keep route-specific invocation execution behind one injected adapter and keep HTTP request/response concerns in the route owner
- characterize duplicate registration, concurrent-scope isolation, shutdown aborts, and restart discovery

## Verification

- `corepack pnpm exec vp run -t @vite-hub/agent#build`
- `corepack pnpm --filter @vite-hub/agent typecheck`
- focused queue/provider lifecycle suite: 13 passed, 308 skipped
- `corepack pnpm exec vp test test/nitro-webhook-queue-shutdown.test.ts --reporter=dot`: 1 passed

## Overlap

PR #1076 also edits `packages/agent/src/server/routes.ts` to bound inbound request bodies. This PR does not change raw-body capture, parsing, verification, or limits; the overlap is contextual to the same route file and its import block, not queue behavior.