### PR TITLE
docs: add release governance policies

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -156,3 +156,7 @@ corepack pnpm exec vp run verify
 ```
 
 `verify` runs the preflight first and includes the native Deno package consumer test. A missing or different Deno version is a contributor setup error, not a ViteHub runtime failure. Package scripts own package-local test, build, and typecheck behavior.
+
+## Project policies
+
+ViteHub is available under the [Apache License 2.0](LICENSE). Report suspected vulnerabilities through the [security policy](SECURITY.md) before sharing details publicly.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security policy
+
+## Supported versions
+
+ViteHub is under active development and has not reached 1.0. Security fixes land on the current `main` branch. Published 0.x packages are development snapshots and do not receive backports.
+
+| Version | Security fixes |
+| --- | --- |
+| Current `main` | Supported |
+| Published 0.x versions | No backports |
+
+If a vulnerability affects a published package, include its exact package name and version in the report. Maintainers may publish a new 0.x release after the fix lands on `main`.
+
+## Report a vulnerability privately
+
+Do not disclose vulnerability details in a public issue, discussion, pull request, or Discord message.
+
+Start on the repository's [GitHub Security Advisories page](https://github.com/vite-hub/vitehub/security/advisories). If GitHub shows a **Report a vulnerability** button, use that form. If the form is unavailable, open a [GitHub issue](https://github.com/vite-hub/vitehub/issues/new) containing only a request for a private security contact. Do not include vulnerability details in that issue. A maintainer will establish a private channel for the report.
+
+Once you have a private channel, include:
+
+- the affected package, version, or commit;
+- the practical impact and the conditions required to trigger it;
+- reproducible steps or a minimal proof of concept;
+- any suggested mitigation or fix;
+- your planned disclosure date and whether you want public credit.
+
+Remove credentials, personal data, and private repository content from the report. Do not access data or systems that you do not own or have permission to test.
+
+## Response expectations
+
+Maintainers aim to acknowledge a private report within 7 calendar days and provide an initial assessment within 14 calendar days. These are response targets, not a promise that a fix will be ready within 14 days. Fix timing depends on severity, affected packages, and the work needed to verify the change across supported hosts.
+
+The initial assessment will confirm whether the report is a security issue, request more information, or explain why it does not meet the security threshold. While an accepted report remains open, maintainers will share material status changes in the private thread.
+
+If you have not received an acknowledgement after 7 days, follow up in the same private thread. If no private thread exists yet, comment on the contact-request issue without adding vulnerability details.
+
+## Coordinated disclosure
+
+Keep the report and related fixes private until maintainers publish a security advisory or agree to another disclosure date with you. State any disclosure deadline in the initial report so there is time to assess the issue, prepare a fix, and notify affected users.
+
+Maintainers will coordinate the advisory, fixed release, and reporter credit. You may decline credit. This policy does not promise payment or a bug bounty.
+
+## Use public channels for other reports
+
+Use [GitHub issues](https://github.com/vite-hub/vitehub/issues) for reproducible bugs and documentation gaps. Use the [ViteHub Discord community](https://discord.gg/YTRDsRP3) for implementation questions and design discussion. Neither channel is private, so do not post secrets, customer data, private repository content, or suspected vulnerability details there.

--- a/docs/content/trust/contact.md
+++ b/docs/content/trust/contact.md
@@ -17,6 +17,6 @@ Open a [GitHub issue](https://github.com/vite-hub/vitehub/issues) for a reproduc
 
 ## Security reports
 
-Do not publish a suspected vulnerability in Discord or a public issue. Use a [private GitHub security advisory](https://github.com/vite-hub/vitehub/security/advisories/new) so the report, proof, and remediation discussion remain private until maintainers can assess the impact. Include affected versions and a safe reproduction. Do not include credentials or data taken from systems you do not own or have permission to test.
+Do not publish a suspected vulnerability in Discord or a public issue. Follow the [ViteHub security policy](https://github.com/vite-hub/vitehub/security/policy) to establish a private reporting channel before sharing the report or proof. Include affected versions and a safe reproduction. Do not include credentials or data taken from systems you do not own or have permission to test.
 
 ViteHub does not publish a support phone number or postal office. If the project adopts a legal entity, mailing address, or dedicated support email, this page and the site's structured identity data should be updated together.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "description": "ViteHub monorepo workspace.",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vite-hub/vitehub.git"
+  },
   "type": "module",
   "devDependencies": {
     "@cloudflare/sandbox": "catalog:sandbox",

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -2,12 +2,14 @@ import { execFileSync } from "node:child_process"
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { array, object, optional, record, string } from "valibot"
 import { describe, expect, it } from "vitest"
 import {
   packageDir,
   packageInfo,
   packageInfoByPublishName,
   packageInfos,
+  packageManifestSchema,
   packageNames,
   readJson,
   readPackageManifest,
@@ -25,6 +27,16 @@ const ignoredGeneratedDirs = new Set([
   "dist",
   "node_modules",
 ])
+
+const showcaseManifestSchema = object({
+  label: optional(string()),
+  frameworks: optional(record(string(), object({
+    modes: optional(record(string(), object({
+      phases: optional(record(string(), string())),
+      supplementalFiles: optional(array(string())),
+    }))),
+  }))),
+})
 
 function exportTargetPath(packageName: PackageName, target: string) {
   return join(packageDir(packageName), target.replace(/^\.\//, ""))
@@ -101,10 +113,7 @@ describe("package manifest contracts", () => {
   })
 
   it("uses the repository Apache license and source metadata for every public package", () => {
-    const rootManifest = readJson<{
-      license?: string
-      repository?: { type?: string, url?: string }
-    }>(join(repoRoot, "package.json"))
+    const rootManifest = readJson(packageManifestSchema, join(repoRoot, "package.json"))
     const expectedRepository = {
       type: "git",
       url: "git+https://github.com/vite-hub/vitehub.git",
@@ -174,7 +183,7 @@ describe("package manifest contracts", () => {
       cwd: repoRoot,
       encoding: "utf8",
     }).trim().split("\n")
-    const positions = new Map(order.map((path, index) => [readJson<{ name: string }>(join(repoRoot, path)).name, index]))
+    const positions = new Map(order.map((path, index) => [readJson(packageManifestSchema, join(repoRoot, path)).name, index]))
 
     expect(positions.size).toBe(packageInfos.length)
     for (const info of packageInfos) {
@@ -333,10 +342,7 @@ describe("showcase contracts", () => {
         continue
       }
 
-      const manifest = readJson<{
-        label?: string
-        frameworks?: Record<string, { modes?: Record<string, { phases?: Record<string, string>, supplementalFiles?: string[] }> }>
-      }>(manifestPath)
+      const manifest = readJson(showcaseManifestSchema, manifestPath)
 
       expect(manifest.label, `${packageName} showcase should have a label`).toEqual(expect.any(String))
       expect(manifest.frameworks, `${packageName} showcase should list frameworks`).toEqual(expect.any(Object))

--- a/test/contracts.test.ts
+++ b/test/contracts.test.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process"
-import { existsSync, readFileSync } from "node:fs"
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
@@ -97,6 +98,75 @@ describe("package manifest contracts", () => {
       expect(exportTarget(manifest.exports?.["."])).toBe("./dist/index.js")
       expect(manifest.exports?.["./package.json"]).toBe("./package.json")
     }
+  })
+
+  it("uses the repository Apache license and source metadata for every public package", () => {
+    const rootManifest = readJson<{
+      license?: string
+      repository?: { type?: string, url?: string }
+    }>(join(repoRoot, "package.json"))
+    const expectedRepository = {
+      type: "git",
+      url: "git+https://github.com/vite-hub/vitehub.git",
+    }
+
+    expect(rootManifest).toMatchObject({
+      license: "Apache-2.0",
+      repository: expectedRepository,
+    })
+    expect(readFileSync(join(repoRoot, "LICENSE"), "utf8")).toContain("Apache License\n                           Version 2.0, January 2004")
+
+    for (const info of packageInfos) {
+      const manifest = readPackageManifest(info.name)
+      expect(manifest.license, `${info.packageName} should use the repository license`).toBe("Apache-2.0")
+      expect(manifest.repository, `${info.packageName} should identify its monorepo source`).toEqual({
+        ...expectedRepository,
+        directory: `packages/${info.name}`,
+      })
+    }
+  })
+
+  it("includes the repository license in every packed public package", () => {
+    const packDir = mkdtempSync(join(tmpdir(), "vitehub-license-pack-"))
+    const license = readFileSync(join(repoRoot, "LICENSE"), "utf8")
+
+    try {
+      for (const info of packageInfos) {
+        const before = new Set(readdirSync(packDir))
+        execFileSync("pnpm", ["--filter", info.packageName, "pack", "--pack-destination", packDir], {
+          cwd: repoRoot,
+          encoding: "utf8",
+          stdio: "pipe",
+        })
+        const tarballs = readdirSync(packDir).filter(file => !before.has(file))
+        expect(tarballs, `${info.packageName} should create one tarball`).toHaveLength(1)
+
+        const tarball = join(packDir, tarballs[0]!)
+        const listing = execFileSync("tar", ["-tzf", tarball], { encoding: "utf8" }).split("\n")
+        expect(listing, `${info.packageName} should include the root license`).toContain("package/LICENSE")
+        expect(execFileSync("tar", ["-xOf", tarball, "package/LICENSE"], { encoding: "utf8" }))
+          .toBe(license)
+      }
+    }
+    finally {
+      rmSync(packDir, { recursive: true })
+    }
+  }, 30_000)
+
+  it("publishes security reporting and project policy links", () => {
+    const security = readFileSync(join(repoRoot, "SECURITY.md"), "utf8")
+    const readme = readFileSync(join(repoRoot, "README.md"), "utf8")
+    const contact = readFileSync(join(repoRoot, "docs/content/trust/contact.md"), "utf8")
+
+    expect(security).toContain("https://github.com/vite-hub/vitehub/security/advisories")
+    expect(security).toContain("https://github.com/vite-hub/vitehub/issues/new")
+    expect(security).toContain("https://discord.gg/YTRDsRP3")
+    expect(security).toContain("Published 0.x versions | No backports")
+    expect(security).not.toMatch(/mailto:|[\w.+-]+@[\w.-]+/)
+    expect(readme).toContain("[Apache License 2.0](LICENSE)")
+    expect(readme).toContain("[security policy](SECURITY.md)")
+    expect(contact).toContain("https://github.com/vite-hub/vitehub/security/policy")
+    expect(contact).not.toContain("/security/advisories/new")
   })
 
   it("publishes required package dependencies before their consumers", () => {

--- a/test/utils/repo.ts
+++ b/test/utils/repo.ts
@@ -1,6 +1,8 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs"
 import { join, relative, resolve } from "node:path"
 
+import { array, boolean, type GenericSchema, type InferOutput, object, optional, parse, record, string, union } from "valibot"
+
 import { listWorkspacePackageInfos } from "../../packages/internal/src/workspace-inventory.ts"
 
 export const repoRoot = resolve(import.meta.dirname, "../..")
@@ -9,34 +11,42 @@ export const packageNames = packageInfos.map(info => info.name)
 
 export type PackageName = string
 
-type PackageManifest = {
-  name?: string
-  description?: string
-  license?: string
-  sideEffects?: boolean | string[]
-  type?: string
-  types?: string
-  exports?: Record<string, string | Record<string, string>>
-  files?: string[]
-  dependencies?: Record<string, string>
-  devDependencies?: Record<string, string>
-  optionalDependencies?: Record<string, string>
-  peerDependencies?: Record<string, string>
-  peerDependenciesMeta?: Record<string, { optional?: boolean }>
-  repository?: { directory?: string, type?: string, url?: string }
-  scripts?: Record<string, string>
-}
+const stringRecord = record(string(), string())
+
+export const packageManifestSchema = object({
+  name: string(),
+  bin: optional(stringRecord),
+  description: optional(string()),
+  license: optional(string()),
+  sideEffects: optional(union([boolean(), array(string())])),
+  type: optional(string()),
+  types: optional(string()),
+  exports: optional(record(string(), union([string(), stringRecord]))),
+  files: optional(array(string())),
+  dependencies: optional(stringRecord),
+  devDependencies: optional(stringRecord),
+  optionalDependencies: optional(stringRecord),
+  peerDependencies: optional(stringRecord),
+  peerDependenciesMeta: optional(record(string(), object({ optional: optional(boolean()) }))),
+  repository: optional(object({
+    directory: optional(string()),
+    type: optional(string()),
+    url: optional(string()),
+  })),
+  scripts: optional(stringRecord),
+})
 
 export function packageDir(packageName: PackageName) {
   return join(repoRoot, "packages", packageName)
 }
 
-export function readJson<T>(path: string): T {
-  return JSON.parse(readFileSync(path, "utf8")) as T
+export function readJson<TSchema extends GenericSchema>(schema: TSchema, path: string): InferOutput<TSchema> {
+  const value: unknown = JSON.parse(readFileSync(path, "utf8"))
+  return parse(schema, value)
 }
 
 export function readPackageManifest(packageName: PackageName) {
-  return readJson<PackageManifest>(join(packageDir(packageName), "package.json"))
+  return readJson(packageManifestSchema, join(packageDir(packageName), "package.json"))
 }
 
 export function packageInfo(packageName: PackageName) {

--- a/test/utils/repo.ts
+++ b/test/utils/repo.ts
@@ -23,6 +23,7 @@ type PackageManifest = {
   optionalDependencies?: Record<string, string>
   peerDependencies?: Record<string, string>
   peerDependenciesMeta?: Record<string, { optional?: boolean }>
+  repository?: { directory?: string, type?: string, url?: string }
   scripts?: Record<string, string>
 }
 


### PR DESCRIPTION
## Summary

- publish the canonical Apache-2.0 license and align root/public-package repository metadata
- add a security policy for current `main`, pre-1.0 releases, response targets, and coordinated disclosure
- route reporters through GitHub's security policy with a no-details contact fallback because private vulnerability reporting is currently disabled
- enforce policy links and verify that every public package tarball contains the exact root license

## Verification

- `corepack pnpm exec vp run test:contracts` (34 existing tests passed; the new all-package pack check hit Vitest's default 5s timeout, then passed after receiving a bounded 30s timeout)
- `corepack pnpm exec vp test test/contracts.test.ts --config vitest.config.ts`
- `corepack pnpm --dir docs exec vp test test/agent-readiness.test.ts`
- `corepack pnpm exec vp exec oxlint test/contracts.test.ts test/utils/repo.ts`
- `git diff --check origin/main...HEAD`

The package contract packs all 25 public packages and compares each `package/LICENSE` byte-for-byte with the repository license.
