### PR TITLE
refactor(agent): own resumable chat process custody

### DIFF
--- a/packages/agent/src/internal/resumable-chat.ts
+++ b/packages/agent/src/internal/resumable-chat.ts
@@ -1,0 +1,297 @@
+interface ResumableChatProcessConfig<TContext> {
+  owner: (context: TContext) => string | Promise<string>
+  scope: "process"
+  ttlMs?: number
+}
+
+interface ResumableChatProcessIdentity {
+  agentName: string
+  channelId: string
+  chatId: string
+}
+
+interface ResumableChatProcessCompletion {
+  messageId?: string
+  runId?: string
+  waitUntil: (promise: Promise<unknown>) => void
+}
+
+interface ResumableChatProcessRun {
+  chunks: Uint8Array[]
+  cleanup?: ReturnType<typeof setTimeout>
+  done: boolean
+  failed: boolean
+  hasBody: boolean
+  headers: Headers
+  invocationKey: string
+  latestKey: string
+  reader?: ReadableStreamDefaultReader<Uint8Array>
+  ready: Promise<void>
+  removed: boolean
+  resolveReady: () => void
+  setupError?: unknown
+  setupFailed: boolean
+  setupSettled: boolean
+  status: number
+  statusText: string
+  subscribers: Set<ReadableStreamDefaultController<Uint8Array>>
+  terminalError?: unknown
+}
+
+export interface ResumableChatProcessClaim {
+  kind: "claimed"
+  complete(response: Response, completion: ResumableChatProcessCompletion): Response
+  fail(error: unknown): void
+}
+
+export interface ResumableChatProcessExistingClaim {
+  kind: "existing"
+  response: Promise<Response>
+}
+
+export type ResumableChatProcessClaimResult =
+  | ResumableChatProcessClaim
+  | ResumableChatProcessExistingClaim
+
+export interface ResumableChatProcessSession {
+  claim(invocationId: string): ResumableChatProcessClaimResult
+  latest(): Promise<Response | undefined>
+  stop(invocationId: string): Promise<void>
+}
+
+export interface ResumableChatProcessCustody<TContext> {
+  /** Resolves one process-local session. Claims and bytes never cross this factory instance. */
+  session(
+    context: TContext,
+    identity: ResumableChatProcessIdentity,
+  ): Promise<ResumableChatProcessSession>
+}
+
+const resumableChatDefaultTtlMs = 10 * 60 * 1000
+const resumableChatDiscoveryAttempts = 30
+const resumableChatDiscoveryIntervalMs = 100
+const resumableChatCancellationReason = "Cancelled by the web chat client."
+
+function resumableChatKey(...parts: string[]): string {
+  return JSON.stringify(parts)
+}
+
+function resumableChatResponse(run: ResumableChatProcessRun): Response {
+  if (!run.hasBody) {
+    return new Response(null, {
+      headers: run.headers,
+      status: run.status,
+      statusText: run.statusText,
+    })
+  }
+  let subscriber: ReadableStreamDefaultController<Uint8Array> | undefined
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const chunk of run.chunks) controller.enqueue(chunk)
+        if (run.failed) controller.error(run.terminalError)
+        else if (run.done) controller.close()
+        else {
+          subscriber = controller
+          run.subscribers.add(controller)
+        }
+      },
+      cancel() {
+        if (subscriber) run.subscribers.delete(subscriber)
+      },
+    }),
+    {
+      headers: run.headers,
+      status: run.status,
+      statusText: run.statusText,
+    },
+  )
+}
+
+function closeResumableChatRun(run: ResumableChatProcessRun, failed = false, error?: unknown): void {
+  if (run.done) return
+  run.done = true
+  run.failed = failed
+  run.terminalError = error
+  for (const subscriber of run.subscribers) {
+    if (failed) subscriber.error(error)
+    else subscriber.close()
+  }
+  run.subscribers.clear()
+}
+
+function createResumableChatRun(latestKey: string, invocationKey: string): ResumableChatProcessRun {
+  let resolveReady!: () => void
+  const ready = new Promise<void>((resolve) => {
+    resolveReady = resolve
+  })
+  return {
+    chunks: [],
+    done: false,
+    failed: false,
+    hasBody: false,
+    headers: new Headers(),
+    invocationKey,
+    latestKey,
+    ready,
+    removed: false,
+    resolveReady,
+    setupFailed: false,
+    setupSettled: false,
+    status: 200,
+    statusText: "",
+    subscribers: new Set(),
+  }
+}
+
+async function waitForResumableChatRun(
+  runs: Map<string, ResumableChatProcessRun>,
+  key: string,
+): Promise<ResumableChatProcessRun | undefined> {
+  for (let attempt = 0; attempt < resumableChatDiscoveryAttempts; attempt++) {
+    const run = runs.get(key)
+    if (run) return run
+    await new Promise<void>(resolve => setTimeout(resolve, resumableChatDiscoveryIntervalMs))
+  }
+}
+
+async function readyResumableChatResponse(run: ResumableChatProcessRun): Promise<Response> {
+  await run.ready
+  if (run.setupFailed) throw run.setupError
+  return resumableChatResponse(run)
+}
+
+/**
+ * Owns resumable Chat streams in one generated route process. The returned custody does not
+ * provide durability across process replacement or routing to another handler instance.
+ */
+export function createResumableChatProcessCustody<TContext>(
+  config: ResumableChatProcessConfig<TContext>,
+): ResumableChatProcessCustody<TContext> {
+  const invocationRuns = new Map<string, ResumableChatProcessRun>()
+  const latestRuns = new Map<string, ResumableChatProcessRun>()
+
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Route options can arrive from untyped JavaScript, so validate the public runtime boundary before invocation.
+  const ttlMs = typeof config?.ttlMs === "number" && config.ttlMs > 0
+    ? config.ttlMs
+    : resumableChatDefaultTtlMs
+
+  function removeRun(run: ResumableChatProcessRun): void {
+    if (run.removed) return
+    run.removed = true
+    if (run.cleanup) clearTimeout(run.cleanup)
+    if (invocationRuns.get(run.invocationKey) === run) invocationRuns.delete(run.invocationKey)
+    if (latestRuns.get(run.latestKey) === run) latestRuns.delete(run.latestKey)
+  }
+
+  function scheduleCleanup(run: ResumableChatProcessRun): void {
+    if (run.removed || run.cleanup) return
+    run.cleanup = setTimeout(() => removeRun(run), ttlMs)
+    run.cleanup.unref?.()
+  }
+
+  async function consumeRun(run: ResumableChatProcessRun): Promise<void> {
+    try {
+      while (!run.done) {
+        const chunk = await run.reader!.read()
+        if (chunk.done) break
+        const value = chunk.value.slice()
+        run.chunks.push(value)
+        for (const subscriber of run.subscribers) subscriber.enqueue(value)
+      }
+      closeResumableChatRun(run)
+    } catch (error) {
+      closeResumableChatRun(run, true, error)
+    } finally {
+      scheduleCleanup(run)
+    }
+  }
+
+  function claimedRun(run: ResumableChatProcessRun): ResumableChatProcessClaim {
+    return {
+      kind: "claimed",
+      complete(response, completion) {
+        if (run.setupSettled) throw new Error("[vitehub] Resumable Chat claim was already settled.")
+        const headers = new Headers(response.headers)
+        headers.set("x-vitehub-message-id", completion.messageId || "")
+        headers.set("x-vitehub-run-id", completion.runId || "")
+        headers.delete("content-length")
+        run.headers = headers
+        run.status = response.status
+        run.statusText = response.statusText
+        run.hasBody = Boolean(response.body)
+        run.reader = response.body?.getReader()
+        run.setupSettled = true
+        run.resolveReady()
+        if (!run.reader) {
+          closeResumableChatRun(run)
+          scheduleCleanup(run)
+        } else {
+          const consume = consumeRun(run)
+          completion.waitUntil(consume)
+        }
+        return resumableChatResponse(run)
+      },
+      fail(error) {
+        if (run.setupSettled) return
+        run.setupSettled = true
+        run.setupFailed = true
+        run.setupError = error
+        run.resolveReady()
+        removeRun(run)
+      },
+    }
+  }
+
+  return {
+    async session(context, identity) {
+      // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Route options can arrive from untyped JavaScript, so validate the public runtime boundary before invocation.
+      if (!config || typeof config !== "object" || typeof config.owner !== "function") {
+        throw new TypeError("[vitehub] Resumable web chat requires route.resumable.owner().")
+      }
+      if (config.scope !== "process") {
+        throw new TypeError(
+          '[vitehub] Resumable web chat requires route.resumable.scope to be "process"; streams do not survive process replacement or cross-instance routing.',
+        )
+      }
+      const owner = await config.owner(context)
+      // doctor-disable-next-line typescript/strict/no-runtime-typeof -- JavaScript owner callbacks can violate the declared return type at this public runtime boundary.
+      if (typeof owner !== "string" || !owner.trim()) {
+        throw new TypeError("[vitehub] Resumable web chat owner must be a non-empty string.")
+      }
+      const latestKey = resumableChatKey(
+        identity.agentName,
+        identity.channelId,
+        owner.trim(),
+        identity.chatId,
+      )
+
+      return {
+        claim(invocationId) {
+          const invocationKey = resumableChatKey(latestKey, invocationId)
+          const existing = invocationRuns.get(invocationKey)
+          if (existing) {
+            return { kind: "existing", response: readyResumableChatResponse(existing) }
+          }
+          const run = createResumableChatRun(latestKey, invocationKey)
+          invocationRuns.set(invocationKey, run)
+          latestRuns.set(latestKey, run)
+          return claimedRun(run)
+        },
+        async latest() {
+          const run = latestRuns.get(latestKey) || await waitForResumableChatRun(latestRuns, latestKey)
+          return run ? await readyResumableChatResponse(run) : undefined
+        },
+        async stop(invocationId) {
+          const run = invocationRuns.get(resumableChatKey(latestKey, invocationId))
+          if (!run) return
+          await run.ready
+          if (run.setupFailed) throw run.setupError
+          removeRun(run)
+          closeResumableChatRun(run)
+          await run.reader?.cancel(resumableChatCancellationReason).catch(() => undefined)
+        },
+      }
+    },
+  }
+}

--- a/packages/agent/src/internal/resumable-chat.ts
+++ b/packages/agent/src/internal/resumable-chat.ts
@@ -221,14 +221,26 @@ export function createResumableChatProcessCustody<TContext>(
         run.statusText = response.statusText
         run.hasBody = Boolean(response.body)
         run.reader = response.body?.getReader()
-        run.setupSettled = true
-        run.resolveReady()
         if (!run.reader) {
+          run.setupSettled = true
+          run.resolveReady()
           closeResumableChatRun(run)
           scheduleCleanup(run)
         } else {
           const consume = consumeRun(run)
-          completion.waitUntil(consume)
+          try {
+            completion.waitUntil(consume)
+            run.setupSettled = true
+            run.resolveReady()
+          } catch (error) {
+            run.setupSettled = true
+            run.setupFailed = true
+            run.setupError = error
+            run.resolveReady()
+            removeRun(run)
+            void run.reader.cancel(error).catch(() => {})
+            throw error
+          }
         }
         return resumableChatResponse(run)
       },

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -51,6 +51,7 @@ import { isAmbiguousAgentWorkflowStartFailure } from "../internal/workflow-start
 import { registerAgentWorkflowRetry } from "../internal/workflow-retry.ts"
 import { loadAgentWorkflowRuntimeStateModule } from "../internal/workflow-runtime-loaders.ts"
 import { portableWorkflowCapabilityOverrides } from "../internal/workflow-portability.ts"
+import { createResumableChatProcessCustody } from "../internal/resumable-chat.ts"
 import {
   isRuntimeBigInt,
   isRuntimeBoolean,
@@ -132,6 +133,7 @@ import type {
 import type { UIMessage } from "ai"
 import type { AgentWebhookQueueDelivery, AgentWebhookQueueLease, AgentWebhookQueueStateAdapter } from "../internal/webhook-queue.ts"
 import type { AgentChannelDeliveryTracker, AgentChannelDeliveryWorkflowBinding } from "../internal/channel-delivery.ts"
+import type { ResumableChatProcessClaim } from "../internal/resumable-chat.ts"
 
 interface ViteAgentRouteRuntimeConfig extends AgentRuntimeConfig {
   agent?: unknown
@@ -6356,128 +6358,21 @@ function agentChatFetchErrorResponse(error: unknown): Response {
   return toHttpErrorResponse(error, error instanceof TypeError ? 400 : 500)!
 }
 
-const resumableChatDefaultTtlMs = 10 * 60 * 1000
-const resumableChatDiscoveryAttempts = 30
-const resumableChatDiscoveryIntervalMs = 100
-
-interface ResumableChatRun {
-  chunks: Uint8Array[]
-  done: boolean
-  error?: unknown
-  hasBody: boolean
-  headers: Headers
-  invocationKey: string
-  latestKey: string
-  reader?: ReadableStreamDefaultReader<Uint8Array>
-  ready: Promise<void>
-  resolveReady: () => void
-  setupError?: unknown
-  status: number
-  statusText: string
-  subscribers: Set<ReadableStreamDefaultController<Uint8Array>>
-}
-
-function resumableChatKey(...parts: string[]): string {
-  return JSON.stringify(parts)
-}
-
-function resumableChatResponse(run: ResumableChatRun): Response {
-  if (!run.hasBody) {
-    return new Response(null, {
-      headers: run.headers,
-      status: run.status,
-      statusText: run.statusText,
-    })
-  }
-  let subscriber: ReadableStreamDefaultController<Uint8Array> | undefined
-  return new Response(new ReadableStream<Uint8Array>({
-    start(controller) {
-      for (const chunk of run.chunks) controller.enqueue(chunk)
-      if (run.error) controller.error(run.error)
-      else if (run.done) controller.close()
-      else {
-        subscriber = controller
-        run.subscribers.add(controller)
-      }
-    },
-    cancel() {
-      if (subscriber) run.subscribers.delete(subscriber)
-    },
-  }), {
-    headers: run.headers,
-    status: run.status,
-    statusText: run.statusText,
-  })
-}
-
-async function resumableChatOwner(
-  config: AgentChannelChatRouteResumableOptions | undefined,
-  context: AgentChannelChatRouteResumableContext,
-): Promise<string> {
-  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Route options can arrive from untyped JavaScript, so validate the public runtime boundary before invocation.
-  if (!config || typeof config !== "object" || typeof config.owner !== "function") {
-    throw new TypeError("[vitehub] Resumable web chat requires route.resumable.owner().")
-  }
-  if (config.scope !== "process") {
-    throw new TypeError('[vitehub] Resumable web chat requires route.resumable.scope to be "process"; streams do not survive process replacement or cross-instance routing.')
-  }
-  const owner = await config.owner(context)
-  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- JavaScript owner callbacks can violate the declared return type at this public runtime boundary.
-  if (typeof owner !== "string" || !owner.trim()) {
-    throw new TypeError("[vitehub] Resumable web chat owner must be a non-empty string.")
-  }
-  return owner.trim()
-}
-
-function closeResumableChatRun(run: ResumableChatRun, error?: unknown): void {
-  if (run.done) return
-  run.done = true
-  run.error = error
-  for (const subscriber of run.subscribers) {
-    if (error) subscriber.error(error)
-    else subscriber.close()
-  }
-  run.subscribers.clear()
-}
-
-function scheduleResumableChatRunCleanup(
-  run: ResumableChatRun,
-  resumable: AgentChannelChatRouteResumableOptions,
-  resumableRuns: Map<string, ResumableChatRun>,
-  latestResumableRuns: Map<string, ResumableChatRun>,
-): void {
-  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- JavaScript route options can violate the declared numeric type at this public runtime boundary.
-  const ttlMs = typeof resumable.ttlMs === "number" && resumable.ttlMs > 0 ? resumable.ttlMs : resumableChatDefaultTtlMs
-  const cleanup = setTimeout(() => {
-    resumableRuns.delete(run.invocationKey)
-    if (latestResumableRuns.get(run.latestKey) === run) latestResumableRuns.delete(run.latestKey)
-  }, ttlMs)
-  cleanup.unref?.()
-}
-
-async function waitForResumableChatRun(runs: Map<string, ResumableChatRun>, key: string): Promise<ResumableChatRun | undefined> {
-  for (let attempt = 0; attempt < resumableChatDiscoveryAttempts; attempt++) {
-    const run = runs.get(key)
-    if (run) return run
-    await new Promise<void>(resolve => setTimeout(resolve, resumableChatDiscoveryIntervalMs))
-  }
-}
-
 export function createChannelChatRouteHandler(
   agent: AgentInput<ViteAgentRouteRuntimeContext>,
   options: AgentChannelChatRouteHandlerOptions = {},
 ): AgentChannelChatRouteHandler {
   const routeOptions = resolveAgentChannelChatRouteHandlerOptions(agent, options)
-  const resumableRuns = new Map<string, ResumableChatRun>()
-  const latestResumableRuns = new Map<string, ResumableChatRun>()
+  const resumableCustody = routeOptions.resumable
+    ? createResumableChatProcessCustody<AgentChannelChatRouteResumableContext>(routeOptions.resumable)
+    : undefined
   const handler: AgentChannelChatRouteHandler = async (request, handlerOptions = {}) => {
-    const resumable = routeOptions.resumable
-    if (request.method !== "POST" && (!resumable || (request.method !== "GET" && request.method !== "DELETE"))) {
+    if (request.method !== "POST" && (!resumableCustody || (request.method !== "GET" && request.method !== "DELETE"))) {
       return createJsonErrorResponse(405, "Agent chat route only accepts POST requests.")
     }
 
     let delivery: AgentChannelDeliveryTracker | undefined
-    let claimedRun: ResumableChatRun | undefined
+    let resumableClaim: ResumableChatProcessClaim | undefined
     try {
       if (request.method !== "POST") {
         const searchParams = new URL(request.url).searchParams
@@ -6498,30 +6393,27 @@ export function createChannelChatRouteHandler(
           request,
         })
         if (auth === false) throw createRouteError(401, "Agent chat route request was not admitted.")
-        const owner = await resumableChatOwner(resumable, {
-          agentName,
-          // SAFETY: false is rejected immediately above.
-          auth: auth as never,
-          body,
-          event: handlerOptions.event,
-          rawBody: "",
-          request,
-        })
-        const latestKey = resumableChatKey(agentName, routeOptions.channelId || "http", owner, id)
-        const run = request.method === "DELETE"
-          ? resumableRuns.get(resumableChatKey(latestKey, messageId!))
-          : latestResumableRuns.get(latestKey) || await waitForResumableChatRun(latestResumableRuns, latestKey)
-        if (!run) return new Response(null, { status: 204 })
-        await run.ready
-        if (run.setupError) throw run.setupError
+        const session = await resumableCustody!.session(
+          {
+            agentName,
+            // SAFETY: false is rejected immediately above.
+            auth: auth as never,
+            body,
+            event: handlerOptions.event,
+            rawBody: "",
+            request,
+          },
+          {
+            agentName,
+            channelId: routeOptions.channelId || "http",
+            chatId: id,
+          },
+        )
         if (request.method === "DELETE") {
-          if (latestResumableRuns.get(run.latestKey) === run) latestResumableRuns.delete(run.latestKey)
-          resumableRuns.delete(run.invocationKey)
-          closeResumableChatRun(run)
-          await run.reader?.cancel("Cancelled by the web chat client.").catch(() => undefined)
+          await session.stop(messageId!)
           return new Response(null, { status: 204 })
         }
-        return resumableChatResponse(run)
+        return await session.latest() || new Response(null, { status: 204 })
       }
       const captured = await captureAgentInboundBody(request, handlerOptions.maxBodyBytes ?? routeOptions.maxBodyBytes)
       request = captured.request
@@ -6565,38 +6457,19 @@ export function createChannelChatRouteHandler(
         rawBody: parsed.rawBody,
         request,
       }
-      const resumableOwner = resumable ? await resumableChatOwner(resumable, inputContext) : undefined
+      const resumableSession = resumableCustody
+        ? await resumableCustody.session(inputContext, {
+            agentName,
+            channelId: routeOptions.channelId || "http",
+            chatId: optionalBodyString(body.id, "id") || "default",
+          })
+        : undefined
       const admittedInput = mergeAgentChannelChatRouteInput(trustedInput, await routeOptions.admission?.context?.(inputContext))
       let triggerInput = mergeAgentChannelChatRouteInput(admittedInput, await routeOptions.mapInput?.({ ...inputContext, input: admittedInput }))
-      if (resumableOwner) {
-        const chatId = optionalBodyString(body.id, "id") || "default"
-        const latestKey = resumableChatKey(agentName, routeOptions.channelId || "http", resumableOwner, chatId)
-        const invocationKey = resumableChatKey(latestKey, resumableMessageId || "default")
-        const existingRun = resumableRuns.get(invocationKey)
-        if (existingRun) {
-          await existingRun.ready
-          if (existingRun.setupError) throw existingRun.setupError
-          return resumableChatResponse(existingRun)
-        }
-        let resolveReady!: () => void
-        const ready = new Promise<void>((resolve) => {
-          resolveReady = resolve
-        })
-        claimedRun = {
-          chunks: [],
-          done: false,
-          hasBody: false,
-          headers: new Headers(),
-          invocationKey,
-          latestKey,
-          ready,
-          resolveReady,
-          status: 200,
-          statusText: "",
-          subscribers: new Set(),
-        }
-        resumableRuns.set(invocationKey, claimedRun)
-        latestResumableRuns.set(latestKey, claimedRun)
+      if (resumableSession) {
+        const claim = resumableSession.claim(resumableMessageId || "default")
+        if (claim.kind === "existing") return await claim.response
+        resumableClaim = claim
       }
       const chatOptions = getChannelChatOptions(agent, routeOptions.channelId, getAgentChatOptions(agent)) || {}
       const invokerInput = createChatMessageTriggerInput(chatOptions, triggerInput).input
@@ -6703,49 +6576,14 @@ export function createChannelChatRouteHandler(
       )
       if (approvalSessionId) result = trackAgentChatApprovals(result, state, invoker.id, approvalSessionId, approvalTtlMs)
       const response = await observeChannelDeliveryResponse(await toAgentChatFetchResponse(result), delivery, triggerInput.run?.runId)
-      if (!claimedRun || !resumable) return response
-
-      const headers = new Headers(response.headers)
-      headers.set("x-vitehub-message-id", resumableMessageId || "")
-      headers.set("x-vitehub-run-id", triggerInput.run?.runId || "")
-      headers.delete("content-length")
-      claimedRun.headers = headers
-      claimedRun.status = response.status
-      claimedRun.statusText = response.statusText
-      claimedRun.hasBody = Boolean(response.body)
-      claimedRun.reader = response.body?.getReader()
-      claimedRun.resolveReady()
-      if (!claimedRun.reader) {
-        closeResumableChatRun(claimedRun)
-        scheduleResumableChatRunCleanup(claimedRun, resumable, resumableRuns, latestResumableRuns)
-      } else {
-        const run = claimedRun
-        const consume = (async () => {
-          try {
-            while (!run.done) {
-              const chunk = await run.reader!.read()
-              if (chunk.done) break
-              const value = chunk.value.slice()
-              run.chunks.push(value)
-              for (const subscriber of run.subscribers) subscriber.enqueue(value)
-            }
-            closeResumableChatRun(run)
-          } catch (error) {
-            closeResumableChatRun(run, error)
-          } finally {
-            scheduleResumableChatRunCleanup(run, resumable, resumableRuns, latestResumableRuns)
-          }
-        })()
-        context.waitUntil(consume)
-      }
-      return resumableChatResponse(claimedRun)
+      if (!resumableClaim) return response
+      return resumableClaim.complete(response, {
+        messageId: resumableMessageId,
+        runId: triggerInput.run?.runId,
+        waitUntil: promise => context.waitUntil(promise),
+      })
     } catch (error) {
-      if (claimedRun) {
-        claimedRun.setupError = error
-        claimedRun.resolveReady()
-        resumableRuns.delete(claimedRun.invocationKey)
-        if (latestResumableRuns.get(claimedRun.latestKey) === claimedRun) latestResumableRuns.delete(claimedRun.latestKey)
-      }
+      resumableClaim?.fail(error)
       if (delivery) {
         await settleChannelDeliveryInvocation(delivery, "failed", "failed", {
           error: channelDeliveryError(error),

--- a/packages/agent/test/resumable-chat.test.ts
+++ b/packages/agent/test/resumable-chat.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it, vi } from "vitest"
+import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { defineChatCapability } from "../src/chat-trigger.ts"
 import { defineAgent } from "../src/index.ts"
+import { createResumableChatProcessCustody } from "../src/internal/resumable-chat.ts"
 import { createChannelChatRouteHandler } from "../src/server/internal.ts"
+
+import type { ResumableChatProcessClaim } from "../src/internal/resumable-chat.ts"
 
 function chatRequest(
   method: "DELETE" | "GET" | "POST",
@@ -38,6 +41,220 @@ function resumableHandler(run: () => Response | Promise<Response>) {
     },
   )
 }
+
+function processCustody(ttlMs?: number) {
+  return createResumableChatProcessCustody<{ auth: string }>({
+    owner: ({ auth }) => auth,
+    scope: "process",
+    ttlMs,
+  })
+}
+
+async function processSession(custody = processCustody(), auth = "user-1") {
+  return await custody.session(
+    { auth },
+    { agentName: "support", channelId: "http", chatId: "chat-1" },
+  )
+}
+
+function expectClaimed(
+  result: ReturnType<Awaited<ReturnType<typeof processSession>>["claim"]>,
+): ResumableChatProcessClaim {
+  expect(result.kind).toBe("claimed")
+  if (result.kind !== "claimed") throw new Error("Expected a new resumable Chat claim.")
+  return result
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe("resumable Chat process custody", () => {
+  it("replays bodyless and HTTP error responses with stable metadata", async () => {
+    const session = await processSession()
+    const bodyless = expectClaimed(session.claim("message-1"))
+    const bodylessResponse = bodyless.complete(new Response(null, { status: 204 }), {
+      messageId: "message-1",
+      runId: "run-1",
+      waitUntil: vi.fn(),
+    })
+
+    expect(bodylessResponse.status).toBe(204)
+    expect(bodylessResponse.body).toBeNull()
+    expect(bodylessResponse.headers.get("x-vitehub-message-id")).toBe("message-1")
+    const bodylessDuplicate = session.claim("message-1")
+    expect(bodylessDuplicate.kind).toBe("existing")
+    if (bodylessDuplicate.kind === "existing") {
+      await expect(bodylessDuplicate.response).resolves.toMatchObject({ status: 204 })
+    }
+
+    const tasks: Promise<unknown>[] = []
+    const failed = expectClaimed(session.claim("message-2"))
+    failed.complete(
+      new Response("unavailable", {
+        headers: { "content-length": "11", "x-origin": "agent" },
+        status: 503,
+        statusText: "Unavailable",
+      }),
+      {
+        messageId: "message-2",
+        runId: "run-2",
+        waitUntil: promise => tasks.push(promise),
+      },
+    )
+    await Promise.all(tasks)
+    const replay = session.claim("message-2")
+    expect(replay.kind).toBe("existing")
+    if (replay.kind === "existing") {
+      const response = await replay.response
+      expect(response.status).toBe(503)
+      expect(response.statusText).toBe("Unavailable")
+      expect(response.headers.get("content-length")).toBeNull()
+      expect(response.headers.get("x-origin")).toBe("agent")
+      await expect(response.text()).resolves.toBe("unavailable")
+    }
+
+    await session.stop("message-1")
+    await session.stop("message-2")
+  })
+
+  it("keeps the producer alive when one subscriber cancels and fans producer failures out", async () => {
+    const session = await processSession()
+    let source!: ReadableStreamDefaultController<Uint8Array>
+    const sourceCancelled = vi.fn()
+    const tasks: Promise<unknown>[] = []
+    const claim = expectClaimed(session.claim("message-1"))
+    const response = claim.complete(
+      new Response(
+        new ReadableStream<Uint8Array>({
+          cancel: sourceCancelled,
+          start(controller) {
+            source = controller
+          },
+        }),
+      ),
+      {
+        messageId: "message-1",
+        runId: "run-1",
+        waitUntil: promise => tasks.push(promise),
+      },
+    )
+
+    await response.body!.cancel("browser disconnected")
+    expect(sourceCancelled).not.toHaveBeenCalled()
+    const duplicate = session.claim("message-1")
+    expect(duplicate.kind).toBe("existing")
+    if (duplicate.kind !== "existing") throw new Error("Expected the active claim.")
+    const replay = await duplicate.response
+    const replayBody = replay.text()
+    source.enqueue(new TextEncoder().encode("partial"))
+    source.error(new Error("producer failed"))
+
+    await Promise.all(tasks)
+    await expect(replayBody).rejects.toThrow("producer failed")
+    const terminal = session.claim("message-1")
+    if (terminal.kind !== "existing") throw new Error("Expected the terminal claim.")
+    await expect((await terminal.response).text()).rejects.toThrow("producer failed")
+    await session.stop("message-1")
+  })
+
+  it("isolates owners and custody instances", async () => {
+    const custody = processCustody()
+    const owner = await processSession(custody, "user-1")
+    const otherOwner = await processSession(custody, "user-2")
+    const otherProcess = await processSession(processCustody(), "user-1")
+    const ownerClaim = expectClaimed(owner.claim("message-1"))
+    ownerClaim.complete(new Response(null, { status: 204 }), {
+      messageId: "message-1",
+      runId: "run-1",
+      waitUntil: vi.fn(),
+    })
+
+    const otherOwnerClaim = expectClaimed(otherOwner.claim("message-1"))
+    const otherProcessClaim = expectClaimed(otherProcess.claim("message-1"))
+    otherOwnerClaim.fail(new Error("test cleanup"))
+    otherProcessClaim.fail(new Error("test cleanup"))
+    await owner.stop("message-1")
+  })
+
+  it("times out latest-run discovery without retaining polling timers", async () => {
+    vi.useFakeTimers()
+    const session = await processSession()
+    const latest = session.latest()
+
+    await vi.advanceTimersByTimeAsync(3_000)
+
+    await expect(latest).resolves.toBeUndefined()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("expires terminal claims at custom and default TTLs without leaking timers", async () => {
+    vi.useFakeTimers()
+    const custom = await processSession(processCustody(50))
+    const customClaim = expectClaimed(custom.claim("message-1"))
+    customClaim.complete(new Response(null, { status: 204 }), {
+      messageId: "message-1",
+      runId: "run-1",
+      waitUntil: vi.fn(),
+    })
+    expect(custom.claim("message-1").kind).toBe("existing")
+    await vi.advanceTimersByTimeAsync(50)
+    const customReplacement = expectClaimed(custom.claim("message-1"))
+    customReplacement.fail(new Error("test cleanup"))
+
+    const defaults = await processSession()
+    const defaultClaim = expectClaimed(defaults.claim("message-1"))
+    defaultClaim.complete(new Response(null, { status: 204 }), {
+      messageId: "message-1",
+      runId: "run-1",
+      waitUntil: vi.fn(),
+    })
+    await vi.advanceTimersByTimeAsync(599_999)
+    expect(defaults.claim("message-1").kind).toBe("existing")
+    await vi.advanceTimersByTimeAsync(1)
+    const defaultReplacement = expectClaimed(defaults.claim("message-1"))
+    defaultReplacement.fail(new Error("test cleanup"))
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it("shares setup errors with duplicates, then releases the failed claim", async () => {
+    const session = await processSession()
+    const claim = expectClaimed(session.claim("message-1"))
+    const duplicate = session.claim("message-1")
+    if (duplicate.kind !== "existing") throw new Error("Expected the active claim.")
+    claim.fail(new Error("setup failed"))
+
+    await expect(duplicate.response).rejects.toThrow("setup failed")
+    const retry = expectClaimed(session.claim("message-1"))
+    retry.fail(new Error("test cleanup"))
+  })
+
+  it("stops active producers, removes both indexes, and leaves no cleanup timer", async () => {
+    vi.useFakeTimers()
+    const session = await processSession()
+    const cancelled = vi.fn()
+    const tasks: Promise<unknown>[] = []
+    const claim = expectClaimed(session.claim("message-1"))
+    const response = claim.complete(
+      new Response(new ReadableStream<Uint8Array>({ cancel: cancelled })),
+      {
+        messageId: "message-1",
+        runId: "run-1",
+        waitUntil: promise => tasks.push(promise),
+      },
+    )
+    await response.body!.cancel("browser disconnected")
+
+    await session.stop("message-1")
+    await Promise.all(tasks)
+
+    expect(cancelled).toHaveBeenCalledWith("Cancelled by the web chat client.")
+    expect(vi.getTimerCount()).toBe(0)
+    const retry = expectClaimed(session.claim("message-1"))
+    retry.fail(new Error("test cleanup"))
+  })
+})
 
 describe("resumable Agent chat routes", () => {
   it("invokes duplicate POSTs once and replays the stream only to its authenticated owner", async () => {

--- a/packages/agent/test/resumable-chat.test.ts
+++ b/packages/agent/test/resumable-chat.test.ts
@@ -230,6 +230,30 @@ describe("resumable Chat process custody", () => {
     retry.fail(new Error("test cleanup"))
   })
 
+  it("releases and cancels a claim when background ownership registration fails", async () => {
+    const session = await processSession()
+    const cancelled = vi.fn()
+    const claim = expectClaimed(session.claim("message-1"))
+    const duplicate = session.claim("message-1")
+    if (duplicate.kind !== "existing") throw new Error("Expected the active claim.")
+
+    expect(() => claim.complete(
+      new Response(new ReadableStream<Uint8Array>({ cancel: cancelled })),
+      {
+        messageId: "message-1",
+        runId: "run-1",
+        waitUntil: () => {
+          throw new Error("registration failed")
+        },
+      },
+    )).toThrow("registration failed")
+
+    await expect(duplicate.response).rejects.toThrow("registration failed")
+    expect(cancelled).toHaveBeenCalledWith(expect.objectContaining({ message: "registration failed" }))
+    const retry = expectClaimed(session.claim("message-1"))
+    retry.fail(new Error("test cleanup"))
+  })
+
   it("stops active producers, removes both indexes, and leaves no cleanup timer", async () => {
     vi.useFakeTimers()
     const session = await processSession()


### PR DESCRIPTION
Moves resumable Chat claim keys, process-local indexes, response replay, subscriber fan-out, setup and terminal failures, stop handling, discovery polling, and TTL cleanup behind one internal custody factory. The route now handles HTTP admission and Agent invocation, then calls `claim`, `latest`, `stop`, `complete`, or `fail`; resumability remains explicitly process-local and does not imply cross-instance durability.

## Verification

- `vp test run test/resumable-chat.test.ts --maxWorkers=1 --no-file-parallelism` (15 tests)
- `vp test run test/vue.test.ts --maxWorkers=1 --no-file-parallelism -t 'resumable'` (5 tests)
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm --filter @vite-hub/agent build` (includes publint)

## Overlap

#1087 changes adjacent approval custody in `server/routes.ts`, while #1069 changes Runtime context construction. A local merge-tree check confirms #1087 and this branch merge cleanly; neither changes resumable behavior.
