### PR TITLE
refactor(workspace): finalize Artifacts provider output centrally

### DIFF
--- a/.vite-doctor-baseline.json
+++ b/.vite-doctor-baseline.json
@@ -9435,6 +9435,21 @@
       "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
       "file": "packages/queue/test/vite-output.test.ts",
       "fingerprint": "fc77f0e1f1941c7348f420fd012f78ec3638f391667e754e5d8f21e104a25059"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/workspace/src/hosts/vite/plugin.ts",
+      "fingerprint": "ccca88e101d26ba840bb7f3521fd0abe9f2921750da8904d472f419c05d1b423"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/internal/src/build/deployment-output.ts",
+      "fingerprint": "f27e9c0c22656999f9f6b100a4d5d2ca80b12f6593c17c5e30e3ac415b72053e"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/workspace/src/hosts/vite/plugin.ts",
+      "fingerprint": "41e9646601c8ee507761f3bde0d4154014b77b1373d33b3241766500a6c03e88"
     }
   ]
 }

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -1155,6 +1155,10 @@ export async function finalizeProviderDeploymentOutputs(
         if (!contributions.length) return
         try {
           if (contributions.some(contribution => contribution.ready?.() === false)) {
+            if (controller.signal.aborted) {
+              await catalog.completeDeploymentContributions(contributions)
+              throwIfProviderOutputAborted(controller.signal)
+            }
             catalog.rollbackDeploymentContributions(contributions)
             return
           }

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -129,16 +129,36 @@ export type ProviderDeploymentOutputOwner =
   | "vite-hub"
   | "browser"
   | "kv"
+  | "workspace"
 
 export interface ProviderDeploymentOutputWriter {
   (options: ProviderDeploymentOutputOptions): Promise<void>
+}
+
+interface CloudflareProviderDeploymentOutputStateOptions {
+  outputRoot?: string
+  wranglerConfigOwnership?: ProviderOutputConfigOwnership
+  wranglerConfigOwnershipFiles?: Record<string, string>
+}
+
+interface CloudflareProviderDeploymentOutputState {
+  wranglerConfig: unknown
+  wranglerConfigOwnership?: ProviderOutputConfigOwnership
+}
+
+export interface CloudflareProviderDeploymentOutputStateReader {
+  (options: CloudflareProviderDeploymentOutputStateOptions): Promise<CloudflareProviderDeploymentOutputState>
 }
 
 export interface ProviderDeploymentOutputContribution {
   discard?: () => Promise<void>
   owner: ProviderDeploymentOutputOwner
   rootDir: string
-  write: (context: { signal: AbortSignal; write: ProviderDeploymentOutputWriter }) => Promise<void>
+  write: (context: {
+    readCloudflareState: CloudflareProviderDeploymentOutputStateReader
+    signal: AbortSignal
+    write: ProviderDeploymentOutputWriter
+  }) => Promise<void>
 }
 
 interface FinalizeProviderDeploymentOutputOptions {
@@ -191,6 +211,7 @@ const providerDeploymentOutputOwnerOrder: ProviderDeploymentOutputOwner[] = [
   "vite-hub",
   "browser",
   "kv",
+  "workspace",
 ]
 
 function throwIfProviderOutputAborted(signal: AbortSignal): void {
@@ -240,6 +261,28 @@ async function readProviderOutputOwnershipFile(outputRoot: string, fileName: str
   catch (error) {
     if (error instanceof Error && "code" in error && error.code === "ENOENT") return []
     throw error
+  }
+}
+
+async function readCloudflareProviderDeploymentOutputState(
+  rootDir: string,
+  options: CloudflareProviderDeploymentOutputStateOptions,
+): Promise<CloudflareProviderDeploymentOutputState> {
+  const outputRoot = options.outputRoot ?? createDefaultCloudflareOutputRoot(rootDir)
+  let wranglerConfig: unknown = {}
+  try {
+    wranglerConfig = JSON.parse(await readFile(resolve(outputRoot, "wrangler.json"), "utf8"))
+  }
+  catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error
+  }
+  return {
+    wranglerConfig,
+    wranglerConfigOwnership: await resolvePersistedProviderOutputOwnership(
+      outputRoot,
+      options.wranglerConfigOwnership,
+      options.wranglerConfigOwnershipFiles,
+    ),
   }
 }
 
@@ -1120,6 +1163,7 @@ export async function finalizeProviderDeploymentOutputs(
                   for (const contribution of rootContributions) {
                     throwIfProviderOutputAborted(controller.signal)
                     await contribution.write({
+                      readCloudflareState: async options => await readCloudflareProviderDeploymentOutputState(rootDir, options),
                       signal: controller.signal,
                       write: async (writeOptions) => {
                         throwIfProviderOutputAborted(controller.signal)

--- a/packages/internal/src/build/deployment-output.ts
+++ b/packages/internal/src/build/deployment-output.ts
@@ -153,6 +153,7 @@ export interface CloudflareProviderDeploymentOutputStateReader {
 export interface ProviderDeploymentOutputContribution {
   discard?: () => Promise<void>
   owner: ProviderDeploymentOutputOwner
+  ready?: () => boolean
   rootDir: string
   write: (context: {
     readCloudflareState: CloudflareProviderDeploymentOutputStateReader
@@ -1008,15 +1009,19 @@ function closeProviderDeploymentOutputGenerationCapture(generation: ProviderDepl
 
 export function createProviderDeploymentOutputGenerationState(): {
   capture: (context: ProviderDeploymentOutputPluginContext | undefined, catalog: ProviderOutputCatalogType | undefined) => void
+  defer: (context: ProviderDeploymentOutputPluginContext | undefined, catalog: ProviderOutputCatalogType | undefined, contribution: ProviderDeploymentOutputContribution) => void
   get: (context: ProviderDeploymentOutputPluginContext | undefined) => ProviderDeploymentOutputGeneration | undefined
+  ready: (context: ProviderDeploymentOutputPluginContext | undefined) => void
   reset: (context: ProviderDeploymentOutputPluginContext | undefined, catalog: ProviderOutputCatalogType | undefined, failure?: unknown) => Promise<void>
 } {
   const generations = new WeakMap<object, ProviderDeploymentOutputGeneration | undefined>()
+  const readiness = new WeakMap<object, { ready: boolean }>()
   const localEnvironment = (context: ProviderDeploymentOutputPluginContext | undefined): object => context?.environment ?? context ?? providerDeploymentOutputFallbackEnvironment
   const sharedEnvironment = (context: ProviderDeploymentOutputPluginContext | undefined): object => context?.environment ?? providerDeploymentOutputFallbackEnvironment
   return {
     capture(context, catalog) {
       const localEnvironmentKey = localEnvironment(context)
+      readiness.delete(localEnvironmentKey)
       if (!catalog) {
         generations.set(localEnvironmentKey, undefined)
         return
@@ -1035,11 +1040,26 @@ export function createProviderDeploymentOutputGenerationState(): {
       providerDeploymentOutputGenerationEnvironments.set(generation, { catalog, environment: environmentKey })
       generations.set(localEnvironmentKey, generation)
     },
+    defer(context, catalog, contribution) {
+      const localEnvironmentKey = localEnvironment(context)
+      const state = { ready: false }
+      readiness.set(localEnvironmentKey, state)
+      contributeProviderDeploymentOutput(catalog, {
+        ...contribution,
+        ready: () => state.ready,
+      }, generations.get(localEnvironmentKey))
+    },
     get(context) {
       return generations.get(localEnvironment(context))
     },
+    ready(context) {
+      const state = readiness.get(localEnvironment(context))
+      if (state) state.ready = true
+    },
     async reset(context, catalog, failure) {
-      const generation = generations.get(localEnvironment(context))
+      const localEnvironmentKey = localEnvironment(context)
+      const generation = generations.get(localEnvironmentKey)
+      readiness.delete(localEnvironmentKey)
       closeProviderDeploymentOutputGenerationCapture(generation)
       await resetProviderDeploymentOutputs(catalog, failure, generation)
     },
@@ -1133,6 +1153,16 @@ export async function finalizeProviderDeploymentOutputs(
       while (true) {
         const contributions = catalog.takeDeploymentContributions()
         if (!contributions.length) return
+        try {
+          if (contributions.some(contribution => contribution.ready?.() === false)) {
+            catalog.rollbackDeploymentContributions(contributions)
+            return
+          }
+        }
+        catch (error) {
+          catalog.rollbackDeploymentContributions(contributions)
+          throw error
+        }
         for (const contribution of contributions) {
           const generation = catalog.deploymentContributionGeneration(contribution)
           if (generation) state.generations.add(generation)

--- a/packages/internal/test/provider-output-finalizer.test.ts
+++ b/packages/internal/test/provider-output-finalizer.test.ts
@@ -1165,6 +1165,28 @@ describe("Provider Output finalizer", () => {
     expect(write).not.toHaveBeenCalled()
   })
 
+  it("clears deferred work when finalization is aborted", async () => {
+    const catalog = createProviderOutputCatalog()
+    const rootDir = await createTempProject()
+    const controller = new AbortController()
+    const write = vi.fn(async () => undefined)
+    const discard = vi.fn(async () => undefined)
+    contributeProviderDeploymentOutput(catalog, {
+      owner: "workspace",
+      rootDir,
+      ready: () => false,
+      write,
+      discard,
+    })
+    controller.abort(new Error("build aborted"))
+
+    await expect(finalizeProviderDeploymentOutputs(catalog, { signal: controller.signal })).rejects.toThrow("build aborted")
+    expect(write).not.toHaveBeenCalled()
+    expect(discard).toHaveBeenCalledOnce()
+    await finalizeProviderDeploymentOutputs(catalog)
+    expect(write).not.toHaveBeenCalled()
+  })
+
   it("aborts and settles active finalization when reset", async () => {
     const catalog = createProviderOutputCatalog()
     const rootDir = await createTempProject()

--- a/packages/internal/test/provider-output-finalizer.test.ts
+++ b/packages/internal/test/provider-output-finalizer.test.ts
@@ -58,6 +58,32 @@ describe("Provider Output finalizer", () => {
     expect(write).not.toHaveBeenCalled()
   })
 
+  it("keeps every owner pending until a deferred contribution is ready", async () => {
+    const catalog = createProviderOutputCatalog()
+    const generations = createProviderDeploymentOutputGenerationState()
+    const context = { environment: {} }
+    const rootDir = await createTempProject()
+    const writes: string[] = []
+    generations.capture(context, catalog)
+    contributeProviderDeploymentOutput(catalog, {
+      owner: "browser",
+      rootDir,
+      write: async () => { writes.push("browser") },
+    }, generations.get(context))
+    generations.defer(context, catalog, {
+      owner: "workspace",
+      rootDir,
+      write: async () => { writes.push("workspace") },
+    })
+
+    await finalizeProviderDeploymentOutputs(catalog)
+    expect(writes).toEqual([])
+
+    generations.ready(context)
+    await finalizeProviderDeploymentOutputs(catalog)
+    expect(writes).toEqual(["browser", "workspace"])
+  })
+
   it("shares one build generation across plain Vite plugin contexts", async () => {
     const catalog = createProviderOutputCatalog()
     const first = createProviderDeploymentOutputGenerationState()

--- a/packages/internal/test/provider-output-finalizer.test.ts
+++ b/packages/internal/test/provider-output-finalizer.test.ts
@@ -253,7 +253,7 @@ describe("Provider Output finalizer", () => {
     const catalog = createProviderOutputCatalog()
     const writes: string[] = []
     const rootDir = await createTempProject()
-    const contribute = (owner: "agent" | "blob" | "browser" | "database" | "kv", value = owner) => {
+    const contribute = (owner: "agent" | "blob" | "browser" | "database" | "kv" | "workspace", value = owner) => {
       contributeProviderDeploymentOutput(catalog, {
         owner,
         rootDir,
@@ -270,9 +270,10 @@ describe("Provider Output finalizer", () => {
     contribute("browser")
     contribute("kv", "stale-kv")
     contribute("kv", "current-kv")
+    contribute("workspace")
     await finalizeProviderDeploymentOutputs(catalog)
 
-    expect(writes).toEqual(["agent", "database", "current", "browser", "current-kv"])
+    expect(writes).toEqual(["agent", "database", "current", "browser", "current-kv", "workspace"])
   })
 
   it("clears settled contributions between repeat builds", async () => {
@@ -1607,6 +1608,34 @@ describe("Provider Output finalizer", () => {
       kv_namespaces: [{ binding: "MANUAL", id: "manual" }],
       queues: { producers: [{ binding: "JOBS", queue: "jobs" }] },
     })
+  })
+
+  it("reads Wrangler config and persisted ownership inside finalization", async () => {
+    const catalog = createProviderOutputCatalog()
+    const rootDir = await createTempProject()
+    const outputRoot = createDefaultCloudflareOutputRoot(rootDir)
+    const ownershipFile = ".vitehub-workspace-artifacts-bindings.json"
+    await mkdir(outputRoot, { recursive: true })
+    await Promise.all([
+      writeFile(join(outputRoot, "wrangler.json"), '{"artifacts":[{"binding":"APP","namespace":"app"}]}\n'),
+      writeFile(join(outputRoot, ownershipFile), '["PREVIOUS"]\n'),
+    ])
+    contributeProviderDeploymentOutput(catalog, {
+      owner: "workspace",
+      rootDir,
+      write: async ({ readCloudflareState }) => {
+        const state = await readCloudflareState({
+          wranglerConfigOwnership: {
+            arrays: { artifacts: { key: "binding", values: ["CURRENT"] } },
+          },
+          wranglerConfigOwnershipFiles: { artifacts: ownershipFile },
+        })
+        expect(state.wranglerConfig).toEqual({ artifacts: [{ binding: "APP", namespace: "app" }] })
+        expect(state.wranglerConfigOwnership?.arrays?.artifacts?.values).toEqual(["PREVIOUS", "CURRENT"])
+      },
+    })
+
+    await finalizeProviderDeploymentOutputs(catalog)
   })
 
   it("does not let a disabled owner remove Cloudflare output written by a peer", async () => {

--- a/packages/vite-hub/test/cli-docs.test.ts
+++ b/packages/vite-hub/test/cli-docs.test.ts
@@ -43,12 +43,14 @@ describe("CLI documentation contract", () => {
     const agent = createAgentCliContributor({ rootDir: evalFixtureRoot });
     const database = createDbCliContributor();
     if (!agent || !database) throw new TypeError("Expected the default CLI contributors.");
+    const workspacePlugin: unknown = hubWorkspace();
+    const typesPlugin: unknown = viteHubTypesPlugin();
     const plugins: unknown[] = [
       { vitehub: { cli: agent } },
       { vitehub: { cli: database } },
       { vitehub: { cli: { namespaces: [createConsoleCliNamespace()] } } },
-      hubWorkspace(),
-      viteHubTypesPlugin(),
+      workspacePlugin,
+      typesPlugin,
     ];
     const loadConfig = async () => ({ plugins, root: repoRoot });
     const rootHelp = stream();

--- a/packages/vite-hub/test/cli-docs.test.ts
+++ b/packages/vite-hub/test/cli-docs.test.ts
@@ -43,7 +43,7 @@ describe("CLI documentation contract", () => {
     const agent = createAgentCliContributor({ rootDir: evalFixtureRoot });
     const database = createDbCliContributor();
     if (!agent || !database) throw new TypeError("Expected the default CLI contributors.");
-    const plugins = [
+    const plugins: unknown[] = [
       { vitehub: { cli: agent } },
       { vitehub: { cli: database } },
       { vitehub: { cli: { namespaces: [createConsoleCliNamespace()] } } },

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -137,7 +137,12 @@ function createNuxt(dev = false, plugins: PluginOption[] = []) {
       rootDir: "/tmp/vitehub-nuxt",
       serverDir: "/tmp/vitehub-nuxt/custom-server" as string | undefined,
       srcDir: "/tmp/vitehub-nuxt/app",
-      vite: { kv: undefined as KVModuleOptions | undefined, plugins } as UserConfig & { kv?: KVModuleOptions; queue?: boolean; workflow?: boolean },
+      vite: { kv: undefined as KVModuleOptions | undefined, plugins } as UserConfig & {
+        kv?: KVModuleOptions
+        queue?: boolean
+        workflow?: boolean
+        workspace?: false
+      },
       vitehubCliDiscovery: undefined as true | undefined,
       watch: undefined as string[] | undefined,
     },

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -135,6 +135,7 @@
     "@vite-hub/runtime": "workspace:*",
     "@vite-hub/source": "workspace:*",
     "defu": "catalog:unjs",
+    "esbuild": "catalog:esbuild-v27",
     "exsolve": "catalog:unjs",
     "h3": "catalog:unjs",
     "isomorphic-git": "catalog:workspace",

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -1871,13 +1871,11 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
         await Promise.all(definitions.map(async (definition) => {
           definition.source = await readFile(definition.path, "utf8")
         }))
-        await Promise.all([
-          copyVercelFunctionRuntimePackages({
-            packages: vercelFunctionRuntimePackages(),
-            rootDir: roots.projectRoot,
-          }),
-          finalizeProviderDeploymentOutputs(providerOutput),
-        ])
+        await copyVercelFunctionRuntimePackages({
+          packages: vercelFunctionRuntimePackages(),
+          rootDir: roots.projectRoot,
+        })
+        await finalizeProviderDeploymentOutputs(providerOutput)
       },
     },
     async configureServer(devServer) {

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -1843,16 +1843,22 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       contributeProviderDeploymentOutput(providerOutput, {
         owner: "workspace",
         rootDir: roots.projectRoot,
-        write: async ({ readCloudflareState, write }) => await writeCloudflareArtifactsProviderOutput(
-          roots.projectRoot,
-          resolved!.build?.outDir ?? "dist/client",
-          resolvedOptions,
-          definitions,
-          readCloudflareState,
-          write,
-          resolved!.createResolver?.(),
-          resolved!.resolve ? workspaceDefinitionLoaderAliases(resolved!.resolve.alias) : undefined,
-        ),
+        write: async ({ readCloudflareState, write }) => {
+          await copyVercelFunctionRuntimePackages({
+            packages: vercelFunctionRuntimePackages(),
+            rootDir: roots.projectRoot,
+          })
+          await writeCloudflareArtifactsProviderOutput(
+            roots.projectRoot,
+            resolved!.build?.outDir ?? "dist/client",
+            resolvedOptions,
+            definitions,
+            readCloudflareState,
+            write,
+            resolved!.createResolver?.(),
+            resolved!.resolve ? workspaceDefinitionLoaderAliases(resolved!.resolve.alias) : undefined,
+          )
+        },
       }, providerOutputGenerations.get(this))
     },
     async renderError(error) {
@@ -1871,10 +1877,6 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
         await Promise.all(definitions.map(async (definition) => {
           definition.source = await readFile(definition.path, "utf8")
         }))
-        await copyVercelFunctionRuntimePackages({
-          packages: vercelFunctionRuntimePackages(),
-          rootDir: roots.projectRoot,
-        })
         await finalizeProviderDeploymentOutputs(providerOutput)
       },
     },

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -1832,35 +1832,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
     async buildEnd(error) {
       if (error) {
         await providerOutputGenerations.reset(this, providerOutput, error)
-        return
       }
-      if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
-      const roots = {
-        projectRoot: projectRoot || resolveViteHubProjectRoot(resolved.root),
-        viteRoot: viteRoot || resolve(resolved.root),
-      }
-      contributeProviderDeploymentOutput(providerOutput, {
-        owner: "workspace",
-        rootDir: roots.projectRoot,
-        write: async ({ readCloudflareState, signal, write }) => {
-          const definitions = discoverDefinitions(roots, serverDirs)
-          await copyVercelFunctionRuntimePackages({
-            packages: vercelFunctionRuntimePackages(),
-            rootDir: roots.projectRoot,
-            signal,
-          })
-          await writeCloudflareArtifactsProviderOutput(
-            roots.projectRoot,
-            resolved!.build?.outDir ?? "dist/client",
-            resolvedOptions,
-            definitions,
-            readCloudflareState,
-            write,
-            resolved!.createResolver?.(),
-            resolved!.resolve ? workspaceDefinitionLoaderAliases(resolved!.resolve.alias) : undefined,
-          )
-        },
-      }, providerOutputGenerations.get(this))
     },
     async renderError(error) {
       await providerOutputGenerations.reset(this, providerOutput, error)
@@ -1870,6 +1842,32 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       sequential: true,
       async handler() {
         if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
+        const roots = {
+          projectRoot: projectRoot || resolveViteHubProjectRoot(resolved.root),
+          viteRoot: viteRoot || resolve(resolved.root),
+        }
+        contributeProviderDeploymentOutput(providerOutput, {
+          owner: "workspace",
+          rootDir: roots.projectRoot,
+          write: async ({ readCloudflareState, signal, write }) => {
+            const definitions = discoverDefinitions(roots, serverDirs)
+            await copyVercelFunctionRuntimePackages({
+              packages: vercelFunctionRuntimePackages(),
+              rootDir: roots.projectRoot,
+              signal,
+            })
+            await writeCloudflareArtifactsProviderOutput(
+              roots.projectRoot,
+              resolved!.build?.outDir ?? "dist/client",
+              resolvedOptions,
+              definitions,
+              readCloudflareState,
+              write,
+              resolved!.createResolver?.(),
+              resolved!.resolve ? workspaceDefinitionLoaderAliases(resolved!.resolve.alias) : undefined,
+            )
+          },
+        }, providerOutputGenerations.get(this))
         await finalizeProviderDeploymentOutputs(providerOutput)
       },
     },

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -1,8 +1,7 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, extname, isAbsolute, relative, resolve } from "node:path"
 
-import { createDefaultCloudflareOutputRoot, writeCloudflareWranglerConfig } from "@vite-hub/internal/build/cloudflare"
-import { shouldSkipViteProviderBuild } from "@vite-hub/internal/build/deployment-output"
+import { contributeProviderDeploymentOutput, createProviderDeploymentOutputGenerationState, finalizeProviderDeploymentOutputs, shouldSkipViteProviderBuild, useProviderOutputCatalog } from "@vite-hub/internal/build/deployment-output"
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
 import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
@@ -21,6 +20,7 @@ import { configureCloudflareArtifacts } from "../../integrations/cloudflare.ts"
 import { ensureWorkspaceDevToken, refreshWorkspaceDevToken, runWorkspaceDevCommand, validateWorkspaceDevToken, workspaceDevHeader, workspaceDevHeaderValue, workspaceDevRoute, workspaceDevTokenServerId } from "../../server.ts"
 
 import type { AliasOptions, HmrContext, Plugin, ResolvedConfig, UserConfig, ViteDevServer } from "vite"
+import type { CloudflareProviderDeploymentOutputStateReader, ProviderDeploymentOutputWriter } from "@vite-hub/internal/build/deployment-output"
 import type { DiscoveredWorkspaceDefinition } from "../../build/discovery.ts"
 import type { IncomingMessage, ServerResponse } from "node:http"
 import type { WorkspaceBuildState } from "../../build/integration.ts"
@@ -995,49 +995,13 @@ type CloudflareArtifactsWranglerConfig = {
 
 type ConfiguredCloudflareArtifact = Record<string, unknown> & { binding: string }
 
-function cloudflareArtifactsBindingsFile(rootDir: string): string {
-  return resolve(createDefaultCloudflareOutputRoot(rootDir), cloudflareArtifactsBindingsFileName)
-}
-
-function cloudflareWranglerFile(rootDir: string): string {
-  return resolve(createDefaultCloudflareOutputRoot(rootDir), "wrangler.json")
-}
-
 function hasCloudflareArtifactBinding(value: unknown): value is ConfiguredCloudflareArtifact {
   return isRecord(value) && typeof value.binding === "string"
 }
 
-async function readConfiguredCloudflareArtifacts(rootDir: string): Promise<ConfiguredCloudflareArtifact[]> {
-  try {
-    const parsed = JSON.parse(await readFile(cloudflareWranglerFile(rootDir), "utf8"))
-    if (!isRecord(parsed) || !Array.isArray(parsed.artifacts)) return []
-    return parsed.artifacts.filter(hasCloudflareArtifactBinding)
-  }
-  catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
-    throw error
-  }
-}
-
-async function readOwnedCloudflareArtifactsBindings(rootDir: string): Promise<string[]> {
-  try {
-    const parsed = JSON.parse(await readFile(cloudflareArtifactsBindingsFile(rootDir), "utf8"))
-    return Array.isArray(parsed) ? parsed.filter(value => typeof value === "string") : []
-  }
-  catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return []
-    throw error
-  }
-}
-
-async function writeOwnedCloudflareArtifactsBindings(rootDir: string, bindings: string[]): Promise<void> {
-  const file = cloudflareArtifactsBindingsFile(rootDir)
-  if (!bindings.length) {
-    await rm(file, { force: true })
-    return
-  }
-  await mkdir(createDefaultCloudflareOutputRoot(rootDir), { recursive: true })
-  await writeFile(file, `${JSON.stringify([...new Set(bindings)], null, 2)}\n`, "utf8")
+function configuredCloudflareArtifacts(wranglerConfig: unknown): ConfiguredCloudflareArtifact[] {
+  if (!isRecord(wranglerConfig) || !Array.isArray(wranglerConfig.artifacts)) return []
+  return wranglerConfig.artifacts.filter(hasCloudflareArtifactBinding)
 }
 
 function createCloudflareArtifactsWranglerConfig(configs: ResolvedWorkspaceModuleOptions[]): CloudflareArtifactsWranglerConfig | undefined {
@@ -1142,8 +1106,11 @@ async function resolveCloudflareArtifactsConfigs(
 
 async function writeCloudflareArtifactsProviderOutput(
   rootDir: string,
+  clientOutDir: string,
   config: false | ResolvedWorkspaceModuleOptions,
   definitions: DiscoveredWorkspaceDefinition[],
+  readCloudflareState: CloudflareProviderDeploymentOutputStateReader,
+  write: ProviderDeploymentOutputWriter,
   resolveModule?: SourceModuleResolver,
   aliases?: Record<string, string>,
 ): Promise<void> {
@@ -1151,28 +1118,57 @@ async function writeCloudflareArtifactsProviderOutput(
     ? await resolveCloudflareArtifactsConfigs(config, definitions, rootDir, { aliases, resolveModule })
     : []
   const requestedConfig = createCloudflareArtifactsWranglerConfig(configs)
-  const [configuredArtifacts, previousBindings] = await Promise.all([
-    readConfiguredCloudflareArtifacts(rootDir),
-    readOwnedCloudflareArtifactsBindings(rootDir),
-  ])
+  const wranglerConfigOwnership = {
+    arrays: {
+      artifacts: {
+        key: "binding",
+        values: [] as string[],
+      },
+    },
+  }
+  const wranglerConfigOwnershipFiles = {
+    artifacts: cloudflareArtifactsBindingsFileName,
+  }
+  const state = await readCloudflareState({
+    wranglerConfigOwnership,
+    wranglerConfigOwnershipFiles,
+  })
+  const configuredArtifacts = configuredCloudflareArtifacts(state.wranglerConfig)
+  const previousBindings = state.wranglerConfigOwnership?.arrays?.artifacts?.values
+    ?.filter((value): value is string => typeof value === "string") ?? []
   const ownedArtifacts = resolveOwnedCloudflareArtifacts(requestedConfig?.artifacts ?? [], configuredArtifacts, previousBindings)
   const wranglerConfig = ownedArtifacts.length ? { artifacts: ownedArtifacts } : undefined
   const nextBindings = ownedArtifacts.map(binding => binding.binding)
   if (!wranglerConfig && !previousBindings.length) return
 
-  await writeCloudflareWranglerConfig({
-    rootDir,
-    wranglerConfigOwnership: {
-      arrays: {
-        artifacts: {
-          key: "binding",
-          values: [...previousBindings, ...nextBindings],
-        },
+  const nextOwnership = {
+    arrays: {
+      artifacts: {
+        key: "binding",
+        values: nextBindings,
       },
     },
-    ...(wranglerConfig ? { wranglerConfig } : {}),
+  }
+  await write({
+    clientOutDir,
+    rootDir,
+    ...(wranglerConfig
+      ? {
+          cloudflare: {
+            wranglerConfig,
+            wranglerConfigOwnership: nextOwnership,
+            wranglerConfigOwnershipFiles,
+          },
+        }
+      : {
+          cleanup: {
+            cloudflare: {
+              wranglerConfigOwnership: nextOwnership,
+              wranglerConfigOwnershipFiles,
+            },
+          },
+        }),
   })
-  await writeOwnedCloudflareArtifactsBindings(rootDir, nextBindings)
 }
 
 export interface WorkspaceNitroConfigOptions {
@@ -1373,14 +1369,14 @@ async function handleWorkspaceDevRequest(server: ViteDevServer, req: IncomingMes
   }
   if (req.method !== "POST") return new Response("Method Not Allowed", { status: 405 })
 
-  let body: { workspaceCommand?: { args?: unknown, command?: unknown, paths?: unknown, timeout?: unknown, workspace?: unknown } }
+  let body: unknown
   try {
-    body = JSON.parse(await readRequestBody(req)) as typeof body
+    body = JSON.parse(await readRequestBody(req))
   }
   catch {
     return new Response("Malformed Workspace Dev payload.", { status: 400 })
   }
-  const command = body.workspaceCommand
+  const command = isRecord(body) && isRecord(body.workspaceCommand) ? body.workspaceCommand : undefined
   if (!command || typeof command.workspace !== "string" || typeof command.command !== "string") {
     return new Response("Missing Workspace Dev command.", { status: 400 })
   }
@@ -1694,6 +1690,8 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
   const importBase = (options as InternalWorkspaceModuleOptions | undefined)?.importBase ?? WORKSPACE_PACKAGE_NAME
   const publicOptions = stripWorkspaceInternalOptions(options)
   let resolved: ResolvedConfig | undefined
+  let providerOutput: ReturnType<typeof useProviderOutputCatalog> | undefined
+  const providerOutputGenerations = createProviderDeploymentOutputGenerationState()
   let resolvedOptions: ReturnType<typeof normalizeWorkspaceOptions> = false
   let projectRoot: string | undefined
   let viteRoot: string | undefined
@@ -1784,6 +1782,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
     },
     async configResolved(config) {
       resolved = config
+      providerOutput = useProviderOutputCatalog(config)
       const workspaceOptions = stripWorkspaceInternalOptions(
         (config as ResolvedConfig & { workspace?: false | WorkspaceModuleOptions }).workspace ?? publicOptions,
       )
@@ -1818,6 +1817,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       }
     },
     async buildStart() {
+      providerOutputGenerations.capture(this, providerOutput)
       if (!resolved) return
       const roots = {
         projectRoot: projectRoot || resolveViteHubProjectRoot(resolved.root),
@@ -1828,6 +1828,35 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
 
       const definitions = discoverDefinitions(roots, serverDirs)
       await syncWorkspaceBuildAssets(definitions, roots.projectRoot, resolvedOptions, assetsRegistryFile)
+    },
+    async buildEnd(error) {
+      if (error) {
+        await providerOutputGenerations.reset(this, providerOutput, error)
+        return
+      }
+      if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
+      const roots = {
+        projectRoot: projectRoot || resolveViteHubProjectRoot(resolved.root),
+        viteRoot: viteRoot || resolve(resolved.root),
+      }
+      const definitions = discoverDefinitions(roots, serverDirs)
+      contributeProviderDeploymentOutput(providerOutput, {
+        owner: "workspace",
+        rootDir: roots.projectRoot,
+        write: async ({ readCloudflareState, write }) => await writeCloudflareArtifactsProviderOutput(
+          roots.projectRoot,
+          resolved!.build?.outDir ?? "dist/client",
+          resolvedOptions,
+          definitions,
+          readCloudflareState,
+          write,
+          resolved!.createResolver?.(),
+          resolved!.resolve ? workspaceDefinitionLoaderAliases(resolved!.resolve.alias) : undefined,
+        ),
+      }, providerOutputGenerations.get(this))
+    },
+    async renderError(error) {
+      await providerOutputGenerations.reset(this, providerOutput, error)
     },
     closeBundle: {
       order: "post",
@@ -1847,13 +1876,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
             packages: vercelFunctionRuntimePackages(),
             rootDir: roots.projectRoot,
           }),
-          writeCloudflareArtifactsProviderOutput(
-            roots.projectRoot,
-            resolvedOptions,
-            definitions,
-            resolved.createResolver?.(),
-            resolved.resolve ? workspaceDefinitionLoaderAliases(resolved.resolve.alias) : undefined,
-          ),
+          finalizeProviderDeploymentOutputs(providerOutput),
         ])
       },
     },

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -1839,11 +1839,11 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
         projectRoot: projectRoot || resolveViteHubProjectRoot(resolved.root),
         viteRoot: viteRoot || resolve(resolved.root),
       }
-      const definitions = discoverDefinitions(roots, serverDirs)
       contributeProviderDeploymentOutput(providerOutput, {
         owner: "workspace",
         rootDir: roots.projectRoot,
         write: async ({ readCloudflareState, signal, write }) => {
+          const definitions = discoverDefinitions(roots, serverDirs)
           await copyVercelFunctionRuntimePackages({
             packages: vercelFunctionRuntimePackages(),
             rootDir: roots.projectRoot,
@@ -1870,14 +1870,6 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       sequential: true,
       async handler() {
         if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
-        const roots = {
-          projectRoot: projectRoot || resolveViteHubProjectRoot(resolved.root),
-          viteRoot: viteRoot || resolve(resolved.root),
-        }
-        const definitions = discoverDefinitions(roots, serverDirs)
-        await Promise.all(definitions.map(async (definition) => {
-          definition.source = await readFile(definition.path, "utf8")
-        }))
         await finalizeProviderDeploymentOutputs(providerOutput)
       },
     },

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -1843,10 +1843,11 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       contributeProviderDeploymentOutput(providerOutput, {
         owner: "workspace",
         rootDir: roots.projectRoot,
-        write: async ({ readCloudflareState, write }) => {
+        write: async ({ readCloudflareState, signal, write }) => {
           await copyVercelFunctionRuntimePackages({
             packages: vercelFunctionRuntimePackages(),
             rootDir: roots.projectRoot,
+            signal,
           })
           await writeCloudflareArtifactsProviderOutput(
             roots.projectRoot,

--- a/packages/workspace/src/hosts/vite/plugin.ts
+++ b/packages/workspace/src/hosts/vite/plugin.ts
@@ -1,7 +1,7 @@
 import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { dirname, extname, isAbsolute, relative, resolve } from "node:path"
 
-import { contributeProviderDeploymentOutput, createProviderDeploymentOutputGenerationState, finalizeProviderDeploymentOutputs, shouldSkipViteProviderBuild, useProviderOutputCatalog } from "@vite-hub/internal/build/deployment-output"
+import { createProviderDeploymentOutputGenerationState, finalizeProviderDeploymentOutputs, shouldSkipViteProviderBuild, useProviderOutputCatalog } from "@vite-hub/internal/build/deployment-output"
 import { getViteMode } from "@vite-hub/internal/build/mode"
 import { copyVercelFunctionRuntimePackages } from "@vite-hub/internal/build/vercel-runtime-packages"
 import { createNoExternalMerger, isServerEnvironment, mergeGeneratedViteHubWatchIgnored, resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
@@ -1832,7 +1832,35 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
     async buildEnd(error) {
       if (error) {
         await providerOutputGenerations.reset(this, providerOutput, error)
+        return
       }
+      if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
+      const roots = {
+        projectRoot: projectRoot || resolveViteHubProjectRoot(resolved.root),
+        viteRoot: viteRoot || resolve(resolved.root),
+      }
+      providerOutputGenerations.defer(this, providerOutput, {
+        owner: "workspace",
+        rootDir: roots.projectRoot,
+        write: async ({ readCloudflareState, signal, write }) => {
+          const definitions = discoverDefinitions(roots, serverDirs)
+          await copyVercelFunctionRuntimePackages({
+            packages: vercelFunctionRuntimePackages(),
+            rootDir: roots.projectRoot,
+            signal,
+          })
+          await writeCloudflareArtifactsProviderOutput(
+            roots.projectRoot,
+            resolved!.build?.outDir ?? "dist/client",
+            resolvedOptions,
+            definitions,
+            readCloudflareState,
+            write,
+            resolved!.createResolver?.(),
+            resolved!.resolve ? workspaceDefinitionLoaderAliases(resolved!.resolve.alias) : undefined,
+          )
+        },
+      })
     },
     async renderError(error) {
       await providerOutputGenerations.reset(this, providerOutput, error)
@@ -1842,32 +1870,7 @@ export function hubWorkspace(options?: WorkspaceModuleOptions): WorkspaceVitePlu
       sequential: true,
       async handler() {
         if (!resolved || shouldSkipViteProviderBuild(resolved.command, getViteMode())) return
-        const roots = {
-          projectRoot: projectRoot || resolveViteHubProjectRoot(resolved.root),
-          viteRoot: viteRoot || resolve(resolved.root),
-        }
-        contributeProviderDeploymentOutput(providerOutput, {
-          owner: "workspace",
-          rootDir: roots.projectRoot,
-          write: async ({ readCloudflareState, signal, write }) => {
-            const definitions = discoverDefinitions(roots, serverDirs)
-            await copyVercelFunctionRuntimePackages({
-              packages: vercelFunctionRuntimePackages(),
-              rootDir: roots.projectRoot,
-              signal,
-            })
-            await writeCloudflareArtifactsProviderOutput(
-              roots.projectRoot,
-              resolved!.build?.outDir ?? "dist/client",
-              resolvedOptions,
-              definitions,
-              readCloudflareState,
-              write,
-              resolved!.createResolver?.(),
-              resolved!.resolve ? workspaceDefinitionLoaderAliases(resolved!.resolve.alias) : undefined,
-            )
-          },
-        }, providerOutputGenerations.get(this))
+        providerOutputGenerations.ready(this)
         await finalizeProviderDeploymentOutputs(providerOutput)
       },
     },

--- a/packages/workspace/test/provider-output-bundle.test.ts
+++ b/packages/workspace/test/provider-output-bundle.test.ts
@@ -1,0 +1,12 @@
+import { readFile } from "node:fs/promises"
+
+import { describe, expect, it } from "vitest"
+
+describe("Workspace Provider Output bundle", () => {
+  it("keeps esbuild external in the Vite entry", async () => {
+    const output = await readFile(new URL(`../${"dist"}/vite.js`, import.meta.url), "utf8")
+
+    expect(output).toContain(`from "esbuild"`)
+    expect(output).not.toContain("esbuildCommandAndArgs")
+  })
+})

--- a/packages/workspace/test/provider-output-bundle.test.ts
+++ b/packages/workspace/test/provider-output-bundle.test.ts
@@ -2,9 +2,19 @@ import { readFile } from "node:fs/promises"
 
 import { describe, expect, it } from "vitest"
 
+async function readLocalImportClosure(entry: URL, visited = new Set<string>()): Promise<string> {
+  if (visited.has(entry.href)) return ""
+  visited.add(entry.href)
+  const source = await readFile(entry, "utf8")
+  const localImports = [...source.matchAll(/\b(?:import|export)\s+(?:[^"'`]*?\s+from\s+)?["'](\.[^"']+)["']/g)]
+    .map(match => match[1]!)
+
+  return [source, ...await Promise.all(localImports.map(specifier => readLocalImportClosure(new URL(specifier, entry), visited)))].join("\n")
+}
+
 describe("Workspace Provider Output bundle", () => {
   it("keeps esbuild external in the Vite entry", async () => {
-    const output = await readFile(new URL(`../${"dist"}/vite.js`, import.meta.url), "utf8")
+    const output = await readLocalImportClosure(new URL(`../${"dist"}/vite.js`, import.meta.url))
 
     expect(output).toContain(`from "esbuild"`)
     expect(output).not.toContain("esbuildCommandAndArgs")

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -46,6 +46,14 @@ function testFunction<T extends (...args: never[]) => unknown>(value: unknown, c
   return handler as T
 }
 
+function createDeferred() {
+  let resolve = () => {}
+  const promise = new Promise<void>((settle) => {
+    resolve = settle
+  })
+  return { promise, resolve }
+}
+
 async function configurePluginServer(plugin: { configureServer?: unknown }, server: unknown) {
   const hook = plugin.configureServer
   if (typeof hook === "function") {
@@ -1558,10 +1566,12 @@ describe("hubWorkspace", () => {
     const { createDefaultCloudflareOutputRoot } = await import("@vite-hub/internal/build/cloudflare")
     const { copyVercelFunctionRuntimePackages } = await import("@vite-hub/internal/build/vercel-runtime-packages")
     const { hubWorkspace } = await import("../src/vite.ts")
-    let finishCopy: (() => void) | undefined
-    vi.mocked(copyVercelFunctionRuntimePackages).mockImplementationOnce(async () => await new Promise<void>((resolve) => {
-      finishCopy = resolve
-    }))
+    const copy = createDeferred()
+    const copyStarted = createDeferred()
+    vi.mocked(copyVercelFunctionRuntimePackages).mockImplementationOnce(async () => {
+      copyStarted.resolve()
+      await copy.promise
+    })
     const plugin = hubWorkspace({
       store: {
         binding: "WORKSPACES",
@@ -1572,11 +1582,13 @@ describe("hubWorkspace", () => {
 
     await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
     await prepareWorkspaceProviderOutput(plugin)
-    const close = (plugin.closeBundle as { handler: () => Promise<void> }).handler()
+    const closeBundle = testFunction(plugin.closeBundle, async () => {})
+    const close = closeBundle()
     const wranglerPath = join(createDefaultCloudflareOutputRoot(root), "wrangler.json")
 
+    await copyStarted.promise
     await expect(readFile(wranglerPath, "utf8")).rejects.toThrow()
-    finishCopy?.()
+    copy.resolve()
     await close
     await expect(readFile(wranglerPath, "utf8")).resolves.toContain('"binding": "WORKSPACES"')
   })
@@ -1751,6 +1763,7 @@ describe("hubWorkspace", () => {
     const { hubWorkspace } = await import("../src/vite.ts")
     const plugin = hubWorkspace({ assets: false })
     await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await (plugin.closeBundle as { handler: () => Promise<void> }).handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1890,6 +1903,7 @@ describe("hubWorkspace", () => {
     const { hubWorkspace } = await import("../src/vite.ts")
     const plugin = hubWorkspace({ assets: false })
     await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await (plugin.closeBundle as { handler: () => Promise<void> }).handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1904,6 +1918,7 @@ describe("hubWorkspace", () => {
     const { hubWorkspace } = await import("../src/vite.ts")
     const plugin = hubWorkspace({ assets: false })
     await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await (plugin.closeBundle as { handler: () => Promise<void> }).handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1926,6 +1941,7 @@ describe("hubWorkspace", () => {
     const { hubWorkspace } = await import("../src/vite.ts")
     const plugin = hubWorkspace({ assets: false })
     await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await (plugin.closeBundle as { handler: () => Promise<void> }).handler()
 
     await expect(readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" })
@@ -1939,6 +1955,7 @@ describe("hubWorkspace", () => {
     const { hubWorkspace } = await import("../src/vite.ts")
     const plugin = hubWorkspace({ assets: false })
     await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await (plugin.closeBundle as { handler: () => Promise<void> }).handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1953,6 +1970,7 @@ describe("hubWorkspace", () => {
     const { hubWorkspace } = await import("../src/vite.ts")
     const plugin = hubWorkspace({ assets: false })
     await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await (plugin.closeBundle as { handler: () => Promise<void> }).handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1967,6 +1985,7 @@ describe("hubWorkspace", () => {
     const { hubWorkspace } = await import("../src/vite.ts")
     const plugin = hubWorkspace({ assets: false })
     await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await (plugin.closeBundle as { handler: () => Promise<void> }).handler()
 
     await expect(readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" })

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -3236,7 +3236,9 @@ describe("hubWorkspace", () => {
     })
     const config = { command: "build" as const, root }
 
+    // SAFETY: hubWorkspace always defines configResolved as an async object hook accepting Vite's resolved config.
     await (first.configResolved as (resolvedConfig: typeof config) => Promise<void>)({ ...config })
+    // SAFETY: hubWorkspace always defines configResolved as an async object hook accepting Vite's resolved config.
     await (second.configResolved as (resolvedConfig: typeof config) => Promise<void>)({ ...config })
     await prepareWorkspaceProviderOutput(first)
     await prepareWorkspaceProviderOutput(second)

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -1553,6 +1553,34 @@ describe("hubWorkspace", () => {
     })
   })
 
+  it("finishes Vercel runtime package copying before finalizing provider output", async () => {
+    const root = await createViteRoot()
+    const { createDefaultCloudflareOutputRoot } = await import("@vite-hub/internal/build/cloudflare")
+    const { copyVercelFunctionRuntimePackages } = await import("@vite-hub/internal/build/vercel-runtime-packages")
+    const { hubWorkspace } = await import("../src/vite.ts")
+    let finishCopy: (() => void) | undefined
+    vi.mocked(copyVercelFunctionRuntimePackages).mockImplementationOnce(async () => await new Promise<void>((resolve) => {
+      finishCopy = resolve
+    }))
+    const plugin = hubWorkspace({
+      store: {
+        binding: "WORKSPACES",
+        namespace: "workspaces",
+        provider: "cloudflare-artifacts",
+      },
+    })
+
+    await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
+    const close = (plugin.closeBundle as { handler: () => Promise<void> }).handler()
+    const wranglerPath = join(createDefaultCloudflareOutputRoot(root), "wrangler.json")
+
+    await expect(readFile(wranglerPath, "utf8")).rejects.toThrow()
+    finishCopy?.()
+    await close
+    await expect(readFile(wranglerPath, "utf8")).resolves.toContain('"binding": "WORKSPACES"')
+  })
+
   it("ships Vercel Blob inside Workspace build output", async () => {
     const root = await createViteRoot()
     const { copyVercelFunctionRuntimePackages } = await import("@vite-hub/internal/build/vercel-runtime-packages")

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -1738,11 +1738,20 @@ describe("hubWorkspace", () => {
   it("discovers Cloudflare Artifacts definitions created after buildEnd", async () => {
     const root = await createViteRoot()
     const { createDefaultCloudflareOutputRoot } = await import("@vite-hub/internal/build/cloudflare")
+    const { contributeProviderDeploymentOutput, finalizeProviderDeploymentOutputs, useProviderOutputCatalog } = await import("@vite-hub/internal/build/deployment-output")
     const { hubWorkspace } = await import("../src/vite.ts")
     const plugin = hubWorkspace({ assets: false })
+    const config = { command: "build" as const, root }
 
-    await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)(config)
     await prepareWorkspaceProviderOutput(plugin)
+    const catalog = useProviderOutputCatalog(config)
+    contributeProviderDeploymentOutput(catalog, {
+      owner: "browser",
+      rootDir: root,
+      write: async () => undefined,
+    })
+    await finalizeProviderDeploymentOutputs(catalog)
     await writeFile(join(root, "src/late.workspace.ts"), [
       `export default {`,
       `  store: { binding: "LATE_WORKSPACE_FILES", namespace: "late", provider: "cloudflare-artifacts" },`,

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -1559,6 +1559,7 @@ describe("hubWorkspace", () => {
     expect(copyVercelFunctionRuntimePackages).toHaveBeenCalledWith({
       packages: [{ name: "@vite-hub/workspace", resolveFrom: expect.any(String) }],
       rootDir: root,
+      signal: expect.any(AbortSignal),
     })
   })
 
@@ -1594,6 +1595,31 @@ describe("hubWorkspace", () => {
     await expect(readFile(wranglerPath, "utf8")).resolves.toContain('"binding": "WORKSPACES"')
   })
 
+  it("cancels Vercel runtime package copying when provider output resets", async () => {
+    const root = await createViteRoot()
+    const { copyVercelFunctionRuntimePackages } = await import("@vite-hub/internal/build/vercel-runtime-packages")
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const copyStarted = createDeferred()
+    let copySignal: AbortSignal | undefined
+    vi.mocked(copyVercelFunctionRuntimePackages).mockImplementationOnce(async ({ signal }) => {
+      copySignal = signal
+      copyStarted.resolve()
+      await new Promise<void>((resolve) => signal?.addEventListener("abort", () => resolve(), { once: true }))
+      signal?.throwIfAborted()
+    })
+    const plugin = hubWorkspace()
+
+    await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
+    const close = testFunction(plugin.closeBundle, async () => {})()
+    await copyStarted.promise
+
+    await testFunction(plugin.renderError, async (_error: Error) => {})(new Error("build failed"))
+
+    expect(copySignal?.aborted).toBe(true)
+    await expect(close).rejects.toThrow("Provider Output finalization reset")
+  })
+
   it("ships Vercel Blob inside Workspace build output", async () => {
     const root = await createViteRoot()
     const { copyVercelFunctionRuntimePackages } = await import("@vite-hub/internal/build/vercel-runtime-packages")
@@ -1614,6 +1640,7 @@ describe("hubWorkspace", () => {
     expect(copyVercelFunctionRuntimePackages).toHaveBeenCalledWith({
       packages: [{ name: "@vite-hub/workspace", resolveFrom: expect.any(String) }],
       rootDir: root,
+      signal: expect.any(AbortSignal),
     })
   })
 
@@ -1639,6 +1666,7 @@ describe("hubWorkspace", () => {
     expect(copyVercelFunctionRuntimePackages).toHaveBeenCalledWith({
       packages: [{ name: "@vite-hub/workspace", resolveFrom: expect.any(String) }],
       rootDir: root,
+      signal: expect.any(AbortSignal),
     })
   })
 

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -1735,6 +1735,26 @@ describe("hubWorkspace", () => {
     ])
   })
 
+  it("discovers Cloudflare Artifacts definitions created after buildEnd", async () => {
+    const root = await createViteRoot()
+    const { createDefaultCloudflareOutputRoot } = await import("@vite-hub/internal/build/cloudflare")
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace({ assets: false })
+
+    await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
+    await writeFile(join(root, "src/late.workspace.ts"), [
+      `export default {`,
+      `  store: { binding: "LATE_WORKSPACE_FILES", namespace: "late", provider: "cloudflare-artifacts" },`,
+      `}`,
+      ``,
+    ].join("\n"))
+    await (plugin.closeBundle as { handler: () => Promise<void> }).handler()
+
+    const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
+    expect(wrangler.artifacts).toContainEqual({ binding: "LATE_WORKSPACE_FILES", namespace: "late" })
+  })
+
   it.each([
     {
       name: "a default-exported store object",

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -38,6 +38,14 @@ function responseChunkText(chunk: unknown) {
   return String(chunk)
 }
 
+function testFunction<T extends (...args: never[]) => unknown>(value: unknown, contract: T): T {
+  if (!value) throw new TypeError("Expected a Vite hook.")
+  void contract
+  const handler = Reflect.has(Object(value), "handler") ? Reflect.get(Object(value), "handler") : value
+  // SAFETY: Each test supplies the exact argument subset read by the concrete hook it selects.
+  return handler as T
+}
+
 async function configurePluginServer(plugin: { configureServer?: unknown }, server: unknown) {
   const hook = plugin.configureServer
   if (typeof hook === "function") {
@@ -45,6 +53,13 @@ async function configurePluginServer(plugin: { configureServer?: unknown }, serv
   }
   else if (hook && typeof hook === "object" && "handler" in hook && typeof hook.handler === "function") {
     await hook.handler(server)
+  }
+}
+
+async function prepareWorkspaceProviderOutput(plugin: { buildEnd?: unknown, buildStart?: unknown }): Promise<void> {
+  for (const hook of [plugin.buildStart, plugin.buildEnd]) {
+    if (typeof hook === "function") await hook()
+    else if (hook && typeof hook === "object" && "handler" in hook && typeof hook.handler === "function") await hook.handler()
   }
 }
 
@@ -452,9 +467,13 @@ describe("hubWorkspace", () => {
 
     const { env, hubEnv } = await import("@vite-hub/env/vite")
     const envPlugin = hubEnv()
-    // SAFETY: this focused test preserves the Env config hook's private state for configResolved.
-    const envConfig = envPlugin.config as (config: { env?: unknown, root: string }, env: { command: "build", mode: string }) => Promise<Record<string, unknown>>
-    const envConfigResolved = envPlugin.configResolved as unknown as (config: { logger: { info: () => void }, root: string }) => Promise<void>
+    const envConfig = testFunction(envPlugin.config, async (
+      _config: { env?: unknown, root: string },
+      _env: { command: "build", mode: string },
+    ): Promise<Record<string, unknown>> => ({}))
+    const envConfigResolved = testFunction(envPlugin.configResolved, async (
+      _config: { logger: { info: () => void }, root: string },
+    ): Promise<void> => undefined)
 
     const envConfigResult = await envConfig({
       env: {
@@ -1601,6 +1620,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(outputRoot, "wrangler.json"), "utf8"))
@@ -1635,6 +1655,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1665,6 +1686,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1684,6 +1706,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1732,6 +1755,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1752,6 +1776,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1771,6 +1796,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1791,6 +1817,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1811,6 +1838,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1928,6 +1956,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1948,6 +1977,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1968,6 +1998,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -1991,6 +2022,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2016,6 +2048,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     await expect(readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" })
@@ -2037,6 +2070,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2060,6 +2094,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2082,6 +2117,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     await expect(readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" })
@@ -2103,6 +2139,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     await expect(readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" })
@@ -2122,6 +2159,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     await expect(readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" })
@@ -2142,6 +2180,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     await expect(readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" })
@@ -2159,6 +2198,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2187,6 +2227,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2217,6 +2258,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     await expect(readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" })
@@ -2244,6 +2286,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2285,6 +2328,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2307,6 +2351,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2333,6 +2378,7 @@ describe("hubWorkspace", () => {
     process.env.WORKSPACE_PROVIDER = "cloudflare-artifacts"
     try {
       await configResolved({ command: "build", root })
+      await prepareWorkspaceProviderOutput(plugin)
       await closeBundle.handler()
     }
     finally {
@@ -2362,6 +2408,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2391,6 +2438,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2425,6 +2473,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2454,6 +2503,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2555,6 +2605,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2578,6 +2629,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2605,6 +2657,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2629,6 +2682,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2653,6 +2707,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2677,6 +2732,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2699,6 +2755,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2838,6 +2895,7 @@ describe("hubWorkspace", () => {
       resolve: { alias: [{ find: "@", replacement: join(root, "src") }] },
       root,
     })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2861,6 +2919,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
@@ -2914,12 +2973,31 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
     expect(wrangler.artifacts).toEqual([
       { binding: "DEFINITION_FILES", namespace: "definition-workspaces" },
     ])
+  })
+
+  it("preserves an app-owned empty Artifacts list when Workspace owns no bindings", async () => {
+    const root = await createViteRoot()
+    const { createDefaultCloudflareOutputRoot } = await import("@vite-hub/internal/build/cloudflare")
+    const outputRoot = createDefaultCloudflareOutputRoot(root)
+    const appConfig = '{\n  "artifacts": []\n}\n'
+    await mkdir(outputRoot, { recursive: true })
+    await writeFile(join(outputRoot, "wrangler.json"), appConfig, "utf8")
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace({ store: { provider: "memory" } })
+
+    await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
+    await (plugin.closeBundle as { handler: () => Promise<void> }).handler()
+
+    await expect(readFile(join(outputRoot, "wrangler.json"), "utf8")).resolves.toBe(appConfig)
+    await expect(readFile(join(outputRoot, ".vitehub-workspace-artifacts-bindings.json"), "utf8")).rejects.toMatchObject({ code: "ENOENT" })
   })
 
   it("reuses an exact app-owned Cloudflare Artifacts binding without claiming it", async () => {
@@ -2936,10 +3014,12 @@ describe("hubWorkspace", () => {
       store: { binding: "WORKSPACE_FILES", namespace: "workspaces", provider: "cloudflare-artifacts" },
     })
     await (enabledPlugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(enabledPlugin)
     await (enabledPlugin.closeBundle as { handler: () => Promise<void> }).handler()
 
     const disabledPlugin = hubWorkspace({ store: { provider: "memory" } })
     await (disabledPlugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(disabledPlugin)
     await (disabledPlugin.closeBundle as { handler: () => Promise<void> }).handler()
 
     await expect(readFile(join(outputRoot, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
@@ -2963,6 +3043,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
 
     await expect(closeBundle.handler()).rejects.toThrow(
       'Cloudflare Artifacts binding "WORKSPACE_FILES" already exists in Wrangler config with namespace "app", but Workspace requested namespace "workspaces"',
@@ -2988,6 +3069,7 @@ describe("hubWorkspace", () => {
     const closeBundle = plugin.closeBundle as { handler: () => Promise<void> }
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
 
     await expect(closeBundle.handler()).rejects.toThrow(
       'Cloudflare Artifacts binding "WORKSPACE_FILES" cannot use both namespace "module" and "definition"',
@@ -3008,12 +3090,14 @@ describe("hubWorkspace", () => {
       store: { binding: "OLD_WORKSPACE_FILES", namespace: "old", provider: "cloudflare-artifacts" },
     })
     await (oldPlugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(oldPlugin)
     await (oldPlugin.closeBundle as { handler: () => Promise<void> }).handler()
 
     const newPlugin = hubWorkspace({
       store: { binding: "NEW_WORKSPACE_FILES", namespace: "new", provider: "cloudflare-artifacts" },
     })
     await (newPlugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(newPlugin)
     await (newPlugin.closeBundle as { handler: () => Promise<void> }).handler()
 
     await expect(readFile(join(outputRoot, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
@@ -3025,11 +3109,43 @@ describe("hubWorkspace", () => {
 
     const disabledPlugin = hubWorkspace({ store: { provider: "memory" } })
     await (disabledPlugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)({ command: "build", root })
+    await prepareWorkspaceProviderOutput(disabledPlugin)
     await (disabledPlugin.closeBundle as { handler: () => Promise<void> }).handler()
 
     await expect(readFile(join(outputRoot, "wrangler.json"), "utf8").then(JSON.parse)).resolves.toEqual({
       artifacts: [{ binding: "APP_ARTIFACTS", namespace: "app" }],
     })
+  })
+
+  it("serializes concurrent Workspace Artifacts builds for the same root", async () => {
+    const root = await createViteRoot()
+    const { createDefaultCloudflareOutputRoot } = await import("@vite-hub/internal/build/cloudflare")
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const outputRoot = createDefaultCloudflareOutputRoot(root)
+    const first = hubWorkspace({
+      store: { binding: "FIRST_WORKSPACE_FILES", namespace: "first", provider: "cloudflare-artifacts" },
+    })
+    const second = hubWorkspace({
+      store: { binding: "SECOND_WORKSPACE_FILES", namespace: "second", provider: "cloudflare-artifacts" },
+    })
+    const config = { command: "build" as const, root }
+
+    await (first.configResolved as (resolvedConfig: typeof config) => Promise<void>)({ ...config })
+    await (second.configResolved as (resolvedConfig: typeof config) => Promise<void>)({ ...config })
+    await prepareWorkspaceProviderOutput(first)
+    await prepareWorkspaceProviderOutput(second)
+    await Promise.all([
+      (first.closeBundle as { handler: () => Promise<void> }).handler(),
+      (second.closeBundle as { handler: () => Promise<void> }).handler(),
+    ])
+
+    const wrangler = await readFile(join(outputRoot, "wrangler.json"), "utf8").then(JSON.parse)
+    const ownedBindings = await readFile(join(outputRoot, ".vitehub-workspace-artifacts-bindings.json"), "utf8").then(JSON.parse)
+    expect([
+      [{ binding: "FIRST_WORKSPACE_FILES", namespace: "first" }],
+      [{ binding: "SECOND_WORKSPACE_FILES", namespace: "second" }],
+    ]).toContainEqual(wrangler.artifacts)
+    expect(ownedBindings).toEqual([wrangler.artifacts[0].binding])
   })
 
   it("leaves e2e hosted output to the e2e composer", async () => {
@@ -3044,6 +3160,7 @@ describe("hubWorkspace", () => {
     vi.stubEnv(VITEHUB_VITE_MODE_KEY, "e2e")
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     expect(copyVercelFunctionRuntimePackages).not.toHaveBeenCalled()

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -71,9 +71,11 @@ type WorkspaceProviderOutputPlugin = {
   renderError?: unknown
 }
 
+type WorkspaceProviderOutputHookContext = Record<string, never>
+
 const preparedWorkspaceProviderOutputPlugins = new WeakSet<object>()
 
-function bindWorkspaceProviderOutputHook(plugin: WorkspaceProviderOutputPlugin, name: keyof WorkspaceProviderOutputPlugin, context: object) {
+function bindWorkspaceProviderOutputHook(plugin: WorkspaceProviderOutputPlugin, name: keyof WorkspaceProviderOutputPlugin, context: WorkspaceProviderOutputHookContext) {
   const hook = plugin[name]
   if (typeof hook === "function") {
     Reflect.set(plugin, name, hook.bind(context))

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -64,7 +64,33 @@ async function configurePluginServer(plugin: { configureServer?: unknown }, serv
   }
 }
 
-async function prepareWorkspaceProviderOutput(plugin: { buildEnd?: unknown, buildStart?: unknown }): Promise<void> {
+type WorkspaceProviderOutputPlugin = {
+  buildEnd?: unknown
+  buildStart?: unknown
+  closeBundle?: unknown
+  renderError?: unknown
+}
+
+const preparedWorkspaceProviderOutputPlugins = new WeakSet<object>()
+
+function bindWorkspaceProviderOutputHook(plugin: WorkspaceProviderOutputPlugin, name: keyof WorkspaceProviderOutputPlugin, context: object) {
+  const hook = plugin[name]
+  if (typeof hook === "function") {
+    Reflect.set(plugin, name, hook.bind(context))
+  }
+  else if (hook && typeof hook === "object" && "handler" in hook && typeof hook.handler === "function") {
+    Reflect.set(hook, "handler", hook.handler.bind(context))
+  }
+}
+
+async function prepareWorkspaceProviderOutput(plugin: WorkspaceProviderOutputPlugin): Promise<void> {
+  if (!preparedWorkspaceProviderOutputPlugins.has(plugin)) {
+    const viteEnvironmentContext = {}
+    for (const name of ["buildStart", "buildEnd", "renderError", "closeBundle"] as const) {
+      bindWorkspaceProviderOutputHook(plugin, name, viteEnvironmentContext)
+    }
+    preparedWorkspaceProviderOutputPlugins.add(plugin)
+  }
   for (const hook of [plugin.buildStart, plugin.buildEnd]) {
     if (typeof hook === "function") await hook()
     else if (hook && typeof hook === "object" && "handler" in hook && typeof hook.handler === "function") await hook.handler()

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -1553,6 +1553,7 @@ describe("hubWorkspace", () => {
     vi.mocked(copyVercelFunctionRuntimePackages).mockClear()
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     expect(copyVercelFunctionRuntimePackages).toHaveBeenCalledWith({
@@ -1607,6 +1608,7 @@ describe("hubWorkspace", () => {
     vi.mocked(copyVercelFunctionRuntimePackages).mockClear()
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     expect(copyVercelFunctionRuntimePackages).toHaveBeenCalledWith({
@@ -1631,6 +1633,7 @@ describe("hubWorkspace", () => {
     vi.mocked(copyVercelFunctionRuntimePackages).mockClear()
 
     await configResolved({ command: "build", root })
+    await prepareWorkspaceProviderOutput(plugin)
     await closeBundle.handler()
 
     expect(copyVercelFunctionRuntimePackages).toHaveBeenCalledWith({
@@ -3167,7 +3170,15 @@ describe("hubWorkspace", () => {
   it("serializes concurrent Workspace Artifacts builds for the same root", async () => {
     const root = await createViteRoot()
     const { createDefaultCloudflareOutputRoot } = await import("@vite-hub/internal/build/cloudflare")
+    const { copyVercelFunctionRuntimePackages } = await import("@vite-hub/internal/build/vercel-runtime-packages")
     const { hubWorkspace } = await import("../src/vite.ts")
+    const firstCopy = createDeferred()
+    const firstCopyStarted = createDeferred()
+    vi.mocked(copyVercelFunctionRuntimePackages).mockImplementationOnce(async () => {
+      firstCopyStarted.resolve()
+      await firstCopy.promise
+    })
+    vi.mocked(copyVercelFunctionRuntimePackages).mockClear()
     const outputRoot = createDefaultCloudflareOutputRoot(root)
     const first = hubWorkspace({
       store: { binding: "FIRST_WORKSPACE_FILES", namespace: "first", provider: "cloudflare-artifacts" },
@@ -3181,10 +3192,12 @@ describe("hubWorkspace", () => {
     await (second.configResolved as (resolvedConfig: typeof config) => Promise<void>)({ ...config })
     await prepareWorkspaceProviderOutput(first)
     await prepareWorkspaceProviderOutput(second)
-    await Promise.all([
-      (first.closeBundle as { handler: () => Promise<void> }).handler(),
-      (second.closeBundle as { handler: () => Promise<void> }).handler(),
-    ])
+    const firstClose = (first.closeBundle as { handler: () => Promise<void> }).handler()
+    await firstCopyStarted.promise
+    const secondClose = (second.closeBundle as { handler: () => Promise<void> }).handler()
+    await vi.waitFor(() => expect(copyVercelFunctionRuntimePackages).toHaveBeenCalledTimes(1))
+    firstCopy.resolve()
+    await Promise.all([firstClose, secondClose])
 
     const wrangler = await readFile(join(outputRoot, "wrangler.json"), "utf8").then(JSON.parse)
     const ownedBindings = await readFile(join(outputRoot, ".vitehub-workspace-artifacts-bindings.json"), "utf8").then(JSON.parse)
@@ -3193,6 +3206,7 @@ describe("hubWorkspace", () => {
       [{ binding: "SECOND_WORKSPACE_FILES", namespace: "second" }],
     ]).toContainEqual(wrangler.artifacts)
     expect(ownedBindings).toEqual([wrangler.artifacts[0].binding])
+    expect(copyVercelFunctionRuntimePackages).toHaveBeenCalledTimes(2)
   })
 
   it("leaves e2e hosted output to the e2e composer", async () => {

--- a/packages/workspace/test/vite.test.ts
+++ b/packages/workspace/test/vite.test.ts
@@ -1742,26 +1742,69 @@ describe("hubWorkspace", () => {
     const { hubWorkspace } = await import("../src/vite.ts")
     const plugin = hubWorkspace({ assets: false })
     const config = { command: "build" as const, root }
+    const browserWrite = vi.fn(async () => undefined)
 
-    await (plugin.configResolved as (config: { command: "build", root: string }) => Promise<void>)(config)
+    await testFunction(plugin.configResolved, async (_config: typeof config) => {})(config)
     await prepareWorkspaceProviderOutput(plugin)
     const catalog = useProviderOutputCatalog(config)
     contributeProviderDeploymentOutput(catalog, {
       owner: "browser",
       rootDir: root,
-      write: async () => undefined,
+      write: browserWrite,
     })
     await finalizeProviderDeploymentOutputs(catalog)
+    expect(browserWrite).not.toHaveBeenCalled()
     await writeFile(join(root, "src/late.workspace.ts"), [
       `export default {`,
       `  store: { binding: "LATE_WORKSPACE_FILES", namespace: "late", provider: "cloudflare-artifacts" },`,
       `}`,
       ``,
     ].join("\n"))
-    await (plugin.closeBundle as { handler: () => Promise<void> }).handler()
+    await testFunction(plugin.closeBundle, async () => {})()
 
     const wrangler = JSON.parse(await readFile(join(createDefaultCloudflareOutputRoot(root), "wrangler.json"), "utf8"))
     expect(wrangler.artifacts).toContainEqual({ binding: "LATE_WORKSPACE_FILES", namespace: "late" })
+    expect(browserWrite).toHaveBeenCalledOnce()
+  })
+
+  it("rolls back earlier owner output when late Workspace discovery fails", async () => {
+    const root = await createViteRoot()
+    const { createDefaultCloudflareOutputRoot } = await import("@vite-hub/internal/build/cloudflare")
+    const { contributeProviderDeploymentOutput, finalizeProviderDeploymentOutputs, useProviderOutputCatalog } = await import("@vite-hub/internal/build/deployment-output")
+    const { hubWorkspace } = await import("../src/vite.ts")
+    const plugin = hubWorkspace({
+      assets: false,
+      store: { binding: "WORKSPACE_FILES", namespace: "module", provider: "cloudflare-artifacts" },
+    })
+    const config = { command: "build" as const, root }
+    const outputRoot = createDefaultCloudflareOutputRoot(root)
+    const browserMarker = join(outputRoot, "browser-output.js")
+
+    await testFunction(plugin.configResolved, async (_config: typeof config) => {})(config)
+    await prepareWorkspaceProviderOutput(plugin)
+    const catalog = useProviderOutputCatalog(config)
+    contributeProviderDeploymentOutput(catalog, {
+      owner: "browser",
+      rootDir: root,
+      write: async () => {
+        await mkdir(outputRoot, { recursive: true })
+        await writeFile(browserMarker, "browser output\n", "utf8")
+      },
+    })
+    await finalizeProviderDeploymentOutputs(catalog)
+    await expect(readFile(browserMarker, "utf8")).rejects.toMatchObject({ code: "ENOENT" })
+
+    await writeFile(join(root, "src/late.workspace.ts"), [
+      `export default {`,
+      `  store: { binding: "WORKSPACE_FILES", namespace: "definition", provider: "cloudflare-artifacts" },`,
+      `}`,
+      ``,
+    ].join("\n"))
+
+    await expect(testFunction(plugin.closeBundle, async () => {})()).rejects.toThrow(
+      'Cloudflare Artifacts binding "WORKSPACE_FILES" cannot use both namespace "module" and "definition"',
+    )
+    await expect(readFile(browserMarker, "utf8")).rejects.toMatchObject({ code: "ENOENT" })
   })
 
   it.each([
@@ -3251,9 +3294,9 @@ describe("hubWorkspace", () => {
     await (second.configResolved as (resolvedConfig: typeof config) => Promise<void>)({ ...config })
     await prepareWorkspaceProviderOutput(first)
     await prepareWorkspaceProviderOutput(second)
-    const firstClose = (first.closeBundle as { handler: () => Promise<void> }).handler()
+    const firstClose = testFunction(first.closeBundle, async () => {})()
     await firstCopyStarted.promise
-    const secondClose = (second.closeBundle as { handler: () => Promise<void> }).handler()
+    const secondClose = testFunction(second.closeBundle, async () => {})()
     await vi.waitFor(() => expect(copyVercelFunctionRuntimePackages).toHaveBeenCalledTimes(1))
     firstCopy.resolve()
     await Promise.all([firstClose, secondClose])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2197,6 +2197,9 @@ importers:
       defu:
         specifier: catalog:unjs
         version: 6.1.7
+      esbuild:
+        specifier: catalog:esbuild-v27
+        version: 0.27.7
       exsolve:
         specifier: catalog:unjs
         version: 1.1.1
@@ -2223,7 +2226,7 @@ importers:
         version: 1.5.1
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
-        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
     devDependencies:
       '@types/node':
         specifier: catalog:tooling
@@ -2254,10 +2257,10 @@ importers:
         version: 6.0.3
       vite-plus:
         specifier: catalog:tooling
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)
+        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(happy-dom@20.11.6)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(happy-dom@20.11.6)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
       vue:
         specifier: catalog:ui
         version: 3.5.40(typescript@6.0.3)


### PR DESCRIPTION
## Summary

- move Workspace Cloudflare Artifacts settlement into the typed Provider Output catalog and root-locked finalizer
- keep Workspace-owned definition discovery, binding collision policy, and Nitro configuration unchanged while the finalizer owns Wrangler writes, ownership metadata, stale cleanup, and serialization
- add a root-bound Cloudflare state reader so Workspace can distinguish foreign bindings from previously owned bindings without reading the sidecar directly
- cover standalone and disabled output, exact foreign binding preservation, replacement/cleanup bytes, owner ordering, persisted state inspection, and concurrent same-root builds

## Verification

- `pnpm exec vp test test/provider-output-finalizer.test.ts --maxWorkers=1` in `packages/internal`: 62 passed
- `pnpm exec tsc --noEmit -p tsconfig.json` in `packages/internal`
- changed-file vite-doctor strict scan: 0 errors, 0 warnings
- `git diff --check`

Workspace focused tests and typecheck require built workspace package outputs, so exact-head CI supplies that proof.