### PR TITLE
test: aggregate package task failures

### DIFF
--- a/.fallow-baseline.json
+++ b/.fallow-baseline.json
@@ -7,9 +7,7 @@
     "backend_family": "",
     "completeness": "complete"
   },
-  "unused_files": [
-    "test/fixtures/package-task-workspace/task.mjs"
-  ],
+  "unused_files": [],
   "unused_exports": [],
   "unused_types": [],
   "private_type_leaks": [],

--- a/.fallow-baseline.json
+++ b/.fallow-baseline.json
@@ -7,7 +7,9 @@
     "backend_family": "",
     "completeness": "complete"
   },
-  "unused_files": [],
+  "unused_files": [
+    "test/fixtures/package-task-workspace/task.mjs"
+  ],
   "unused_exports": [],
   "unused_types": [],
   "private_type_leaks": [],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,8 @@ jobs:
       - run: vp run typecheck
       - run: vp run test:contracts
       - run: vp run examples:verify
-      - run: vp run test
+      - name: Package tests
+        run: vp run test
 
   docs:
     name: docs

--- a/fallow.toml
+++ b/fallow.toml
@@ -10,6 +10,7 @@ dynamicallyLoaded = [
   "test/local/build-playground.mjs",
   "test/preflight.mjs",
   "test/run-package-task.mjs",
+  "test/fixtures/package-task-workspace/task.mjs",
   "docs/content.config.ts",
   "docs/app/assets/main.css",
   "docs/app/shims/*.ts",

--- a/test/fixtures/package-task-workspace/package.json
+++ b/test/fixtures/package-task-workspace/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "package-task-fixture",
+  "private": true
+}

--- a/test/fixtures/package-task-workspace/packages/app/package.json
+++ b/test/fixtures/package-task-workspace/packages/app/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@fixture/app",
+  "dependencies": {
+    "@vite-hub/env": "workspace:*",
+    "@vite-hub/markdown-template": "workspace:*"
+  },
+  "scripts": {
+    "build": "node ../../task.mjs build @fixture/app",
+    "test": "node ../../task.mjs test @fixture/app"
+  }
+}

--- a/test/fixtures/package-task-workspace/packages/core/package.json
+++ b/test/fixtures/package-task-workspace/packages/core/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixture/core",
+  "scripts": {
+    "build": "node ../../task.mjs build @fixture/core",
+    "test": "node ../../task.mjs test @fixture/core"
+  }
+}

--- a/test/fixtures/package-task-workspace/packages/interrupt/package.json
+++ b/test/fixtures/package-task-workspace/packages/interrupt/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixture/interrupt",
+  "scripts": {
+    "build": "node ../../task.mjs build @fixture/interrupt",
+    "test": "node ../../task.mjs test @fixture/interrupt"
+  }
+}

--- a/test/fixtures/package-task-workspace/packages/left/package.json
+++ b/test/fixtures/package-task-workspace/packages/left/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@vite-hub/env",
+  "dependencies": {
+    "@fixture/core": "workspace:*"
+  },
+  "scripts": {
+    "build": "node ../../task.mjs build @vite-hub/env",
+    "test": "node ../../task.mjs test @vite-hub/env"
+  }
+}

--- a/test/fixtures/package-task-workspace/packages/other/package.json
+++ b/test/fixtures/package-task-workspace/packages/other/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@vite-hub/runtime",
+  "scripts": {
+    "build": "node ../../task.mjs build @vite-hub/runtime",
+    "test": "node ../../task.mjs test @vite-hub/runtime"
+  }
+}

--- a/test/fixtures/package-task-workspace/packages/right/package.json
+++ b/test/fixtures/package-task-workspace/packages/right/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@vite-hub/markdown-template",
+  "dependencies": {
+    "@fixture/core": "workspace:*"
+  },
+  "scripts": {
+    "build": "node ../../task.mjs build @vite-hub/markdown-template",
+    "test": "node ../../task.mjs test @vite-hub/markdown-template"
+  }
+}

--- a/test/fixtures/package-task-workspace/packages/serial-a/package.json
+++ b/test/fixtures/package-task-workspace/packages/serial-a/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixture/serial-a",
+  "scripts": {
+    "build": "node ../../task.mjs build @fixture/serial-a",
+    "test": "node ../../task.mjs test @fixture/serial-a"
+  }
+}

--- a/test/fixtures/package-task-workspace/packages/serial-b/package.json
+++ b/test/fixtures/package-task-workspace/packages/serial-b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@fixture/serial-b",
+  "scripts": {
+    "build": "node ../../task.mjs build @fixture/serial-b",
+    "test": "node ../../task.mjs test @fixture/serial-b"
+  }
+}

--- a/test/fixtures/package-task-workspace/task.mjs
+++ b/test/fixtures/package-task-workspace/task.mjs
@@ -1,0 +1,33 @@
+import { appendFileSync } from "node:fs"
+
+const [phase, name] = process.argv.slice(2)
+const log = process.env.VITEHUB_FIXTURE_LOG
+const delay = Number(process.env.VITEHUB_FIXTURE_DELAY ?? 0)
+const failures = new Map(
+  (process.env.VITEHUB_FIXTURE_FAILURES ?? "")
+    .split(",")
+    .filter(Boolean)
+    .map(entry => entry.split("=")),
+)
+const signals = new Set((process.env.VITEHUB_FIXTURE_SIGNALS ?? "").split(",").filter(Boolean))
+
+function record(event) {
+  if (log) appendFileSync(log, `${phase}:${event}:${name}\n`)
+}
+
+record("start")
+
+process.on("SIGTERM", () => {
+  record("signal")
+  process.exit(143)
+})
+
+await new Promise(resolve => setTimeout(resolve, delay))
+
+if (phase === "test" && signals.has(name)) {
+  process.kill(process.pid, "SIGTERM")
+  await new Promise(resolve => setTimeout(resolve, 10_000))
+}
+
+record("end")
+process.exit(phase === "test" ? Number(failures.get(name) ?? 0) : 0)

--- a/test/fixtures/package-task-workspace/task.mjs
+++ b/test/fixtures/package-task-workspace/task.mjs
@@ -9,6 +9,12 @@ const failures = new Map(
     .filter(Boolean)
     .map(entry => entry.split("=")),
 )
+const buildFailures = new Map(
+  (process.env.VITEHUB_FIXTURE_BUILD_FAILURES ?? "")
+    .split(",")
+    .filter(Boolean)
+    .map(entry => entry.split("=")),
+)
 const signals = new Set((process.env.VITEHUB_FIXTURE_SIGNALS ?? "").split(",").filter(Boolean))
 
 function record(event) {
@@ -30,4 +36,4 @@ if (phase === "test" && signals.has(name)) {
 }
 
 record("end")
-process.exit(phase === "test" ? Number(failures.get(name) ?? 0) : 0)
+process.exit(Number((phase === "build" ? buildFailures : failures).get(name) ?? 0))

--- a/test/run-package-task.mjs
+++ b/test/run-package-task.mjs
@@ -1,86 +1,321 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
-import { readdirSync, readFileSync } from "node:fs";
-import { join } from "node:path";
+import { spawn } from "node:child_process"
+import { appendFile, readdir, readFile } from "node:fs/promises"
+import { constants } from "node:os"
+import { join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 
-const task = process.argv[2];
+const DEFAULT_MAX_PARALLEL = 2
+const DEFAULT_PARALLEL_SAFE_PACKAGES = Object.freeze([
+  "@vite-hub/env",
+  "@vite-hub/markdown-template",
+  "@vite-hub/runtime",
+])
 
-if (!task) {
-  console.error("Usage: node test/run-package-task.mjs <task>");
-  process.exit(1);
+function parseList(value) {
+  return value ? value.split(",").map(entry => entry.trim()).filter(Boolean) : []
 }
 
-const packageDirs = readdirSync("packages", { withFileTypes: true })
-  .filter(entry => entry.isDirectory())
-  .map(entry => join("packages", entry.name));
+function parseArguments(argv) {
+  const [task, ...rest] = argv
+  if (!task) throw new Error("Usage: node test/run-package-task.mjs <task> [options]")
 
-const packages = packageDirs
-  .map((dir) => {
-    const manifest = JSON.parse(readFileSync(join(dir, "package.json"), "utf8"));
-    return { dir, manifest, name: manifest.name };
-  })
-  .sort((a, b) => a.name.localeCompare(b.name));
+  const options = {
+    maxParallel: DEFAULT_MAX_PARALLEL,
+    packageNames: undefined,
+    parallelSafePackages: DEFAULT_PARALLEL_SAFE_PACKAGES,
+    task,
+    workspaceRoot: process.cwd(),
+  }
 
-const packageByName = new Map(packages.map(pkg => [pkg.name, pkg]));
-const visited = new Set();
-const visiting = new Set();
-const orderedPackages = [];
+  for (let index = 0; index < rest.length; index += 2) {
+    const flag = rest[index]
+    const value = rest[index + 1]
+    if (!value) throw new Error(`Missing value for ${flag}`)
+    if (flag === "--workspace") options.workspaceRoot = resolve(value)
+    else if (flag === "--packages") options.packageNames = parseList(value)
+    else if (flag === "--max-parallel") options.maxParallel = Number(value)
+    else throw new Error(`Unknown option: ${flag}`)
+  }
 
-function workspaceDependencies(manifest) {
+  if (!Number.isInteger(options.maxParallel) || options.maxParallel < 1 || options.maxParallel > 4) {
+    throw new Error("--max-parallel must be an integer from 1 to 4")
+  }
+  return options
+}
+
+async function loadPackages(workspaceRoot) {
+  const packagesDir = join(workspaceRoot, "packages")
+  const entries = await readdir(packagesDir, { withFileTypes: true })
+  const packages = await Promise.all(entries
+    .filter(entry => entry.isDirectory())
+    .map(async (entry) => {
+      const dir = join(packagesDir, entry.name)
+      const manifest = JSON.parse(await readFile(join(dir, "package.json"), "utf8"))
+      return { dir, manifest, name: manifest.name }
+    }))
+  return packages.sort((left, right) => left.name.localeCompare(right.name))
+}
+
+function workspaceDependencies(pkg, packageByName) {
   return [
-    ...Object.entries(manifest.dependencies ?? {}),
-    ...Object.entries(manifest.devDependencies ?? {}),
-    ...Object.entries(manifest.peerDependencies ?? {}),
+    ...Object.entries(pkg.manifest.dependencies ?? {}),
+    ...Object.entries(pkg.manifest.devDependencies ?? {}),
+    ...Object.entries(pkg.manifest.peerDependencies ?? {}),
   ]
     .filter(([name, version]) => packageByName.has(name) && String(version).startsWith("workspace:"))
     .map(([name]) => name)
-    .sort((a, b) => a.localeCompare(b));
+    .sort((left, right) => left.localeCompare(right))
 }
 
-function visit(pkg) {
-  if (visited.has(pkg.name)) {
-    return;
-  }
-  if (visiting.has(pkg.name)) {
-    throw new Error(`Circular workspace dependency involving ${pkg.name}`);
+function selectPackages(packages, task, requestedNames) {
+  const packageByName = new Map(packages.map(pkg => [pkg.name, pkg]))
+  const selectedNames = requestedNames?.length
+    ? requestedNames
+    : packages.filter(pkg => pkg.manifest.scripts?.[task]).map(pkg => pkg.name)
+
+  for (const name of selectedNames) {
+    if (!packageByName.has(name)) throw new Error(`Unknown workspace package: ${name}`)
+    if (!packageByName.get(name).manifest.scripts?.[task]) throw new Error(`${name} does not define ${task}`)
   }
 
-  visiting.add(pkg.name);
-  for (const dependencyName of workspaceDependencies(pkg.manifest)) {
-    visit(packageByName.get(dependencyName));
-  }
-  visiting.delete(pkg.name);
-  visited.add(pkg.name);
-  orderedPackages.push(pkg);
-}
-
-for (const pkg of packages) {
-  visit(pkg);
-}
-
-for (const pkg of orderedPackages) {
-  if (!pkg.manifest.scripts?.[task]) {
-    continue;
-  }
-
-  console.log(`\n[${task}] ${pkg.name}`);
-  const standardTestScript = `vp run -t ${pkg.name}#build && vp test`;
-  if (task === "test" && pkg.manifest.scripts?.build && pkg.manifest.scripts.test === standardTestScript) {
-    run("vp", ["run", "--filter", pkg.name, "--ignore-depends-on", "build"]);
-    run("vp", ["test"], { cwd: pkg.dir });
-  }
-  else {
-    run("vp", ["run", "--filter", pkg.name, "--ignore-depends-on", task]);
+  return {
+    packageByName,
+    selected: selectedNames.map(name => packageByName.get(name)).sort((left, right) => left.name.localeCompare(right.name)),
   }
 }
 
-function run(command, args, options = {}) {
-  const result = spawnSync(command, args, {
-    cwd: options.cwd,
-    env: process.env,
-    stdio: "inherit",
-  });
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+function buildClosure(selected, packageByName) {
+  const names = new Set()
+  function add(pkg) {
+    if (names.has(pkg.name)) return
+    names.add(pkg.name)
+    for (const dependency of workspaceDependencies(pkg, packageByName)) add(packageByName.get(dependency))
+  }
+  for (const pkg of selected) add(pkg)
+  return [...names]
+    .map(name => packageByName.get(name))
+    .filter(pkg => pkg.manifest.scripts?.build)
+    .sort((left, right) => left.name.localeCompare(right.name))
+}
+
+function signalExitCode(signal) {
+  return 128 + (constants.signals[signal] ?? 0)
+}
+
+function executePackage(pkg, phase, options) {
+  const packageScript = pkg.manifest.scripts?.[phase]
+  if (phase === "test" && packageScript && /(?:^|&&\s*)vp test(?:\s|$)/.test(packageScript)) {
+    return spawnCommand(join(options.workspaceRoot, "node_modules/.bin/vp"), ["test"], pkg.dir, options.signal)
+  }
+  if (phase === "test" && packageScript?.trim() === `vp run -t ${pkg.name}#build`) {
+    return Promise.resolve({ code: 0, signal: undefined })
+  }
+  return spawnCommand("corepack", ["pnpm", "--dir", pkg.dir, "run", phase], options.workspaceRoot, options.signal)
+}
+
+function spawnCommand(command, args, cwd, abortSignal) {
+  return new Promise((resolvePromise) => {
+    const detached = process.platform !== "win32"
+    const child = spawn(command, args, { cwd, detached, env: process.env, stdio: "inherit" })
+    const onAbort = () => {
+      const signal = abortSignal.reason || "SIGTERM"
+      try {
+        if (detached && child.pid) process.kill(-child.pid, signal)
+        else child.kill(signal)
+      }
+      catch (error) {
+        if (error.code !== "ESRCH") throw error
+      }
+    }
+    if (abortSignal?.aborted) onAbort()
+    else abortSignal?.addEventListener("abort", onAbort, { once: true })
+
+    child.on("error", error => resolvePromise({ code: 1, error, signal: undefined }))
+    child.on("close", (code, signal) => {
+      abortSignal?.removeEventListener("abort", onAbort)
+      resolvePromise({ code: signal ? signalExitCode(signal) : (code ?? 1), signal })
+    })
+  })
+}
+
+async function runPhase({ execute, maxParallel, packages, packageByName, parallelSafePackages, phase, priorResults, signal }) {
+  const packageNames = new Set(packages.map(pkg => pkg.name))
+  const pending = new Map(packages.map(pkg => [pkg.name, pkg]))
+  const results = new Map()
+  const safe = new Set(parallelSafePackages)
+  const dependencies = new Map(packages.map(pkg => [
+    pkg.name,
+    workspaceDependencies(pkg, packageByName).filter(name => packageNames.has(name)),
+  ]))
+
+  while (pending.size > 0) {
+    let changed = false
+    for (const [name] of [...pending].sort(([left], [right]) => left.localeCompare(right))) {
+      const blockedByPrior = priorResults?.get(name)
+      const blockedDependency = dependencies.get(name).find((dependency) => {
+        const result = results.get(dependency)
+        return result?.status === "failed" || result?.status === "skipped"
+      })
+      const interrupted = signal.aborted ? String(signal.reason || "SIGTERM") : undefined
+      if (blockedByPrior?.status === "failed" || blockedByPrior?.status === "skipped" || blockedDependency || interrupted) {
+        const reason = interrupted
+          ? `interrupted by ${interrupted}`
+          : blockedByPrior?.status === "failed" || blockedByPrior?.status === "skipped"
+            ? `${phase === "test" ? "build" : "prior task"} did not pass`
+            : `dependency ${blockedDependency} did not pass`
+        results.set(name, { reason, status: "skipped" })
+        pending.delete(name)
+        changed = true
+      }
+    }
+    if (pending.size === 0) break
+
+    const ready = [...pending.values()]
+      .filter(pkg => dependencies.get(pkg.name).every(name => results.get(name)?.status === "passed"))
+      .sort((left, right) => left.name.localeCompare(right.name))
+    if (ready.length === 0) {
+      if (changed) continue
+      throw new Error(`Circular workspace dependency in ${phase} package graph`)
+    }
+
+    const safeReady = ready.filter(pkg => safe.has(pkg.name))
+    const batch = safeReady.length > 0 ? safeReady.slice(0, maxParallel) : [ready[0]]
+
+    for (const pkg of batch) {
+      pending.delete(pkg.name)
+      console.log(`\n[${phase}] ${pkg.name}`)
+    }
+    const completed = await Promise.all(batch.map(async (pkg) => {
+      const outcome = await execute(pkg, phase, { signal })
+      return [pkg.name, outcome]
+    }))
+    for (const [name, outcome] of completed) {
+      results.set(name, outcome.code === 0
+        ? { status: "passed" }
+        : { code: outcome.code, error: outcome.error, signal: outcome.signal, status: "failed" })
+    }
+  }
+  return results
+}
+
+function formatResult(result) {
+  if (!result) return "not run"
+  if (result.status === "passed") return "passed"
+  if (result.status === "skipped") return `skipped: ${result.reason}`
+  if (result.signal) return `failed (${result.signal})`
+  return `failed (exit ${result.code})`
+}
+
+function packageStatus(build, task) {
+  if (build?.status === "failed" || task?.status === "failed") return "FAIL"
+  if (build?.status === "skipped" || task?.status === "skipped") return "SKIP"
+  return "PASS"
+}
+
+function renderSummary(task, packages, buildResults, taskResults) {
+  const rows = packages.map((pkg) => {
+    const build = buildResults?.get(pkg.name)
+    const result = taskResults.get(pkg.name)
+    const status = packageStatus(build, result)
+    const detail = task === "test"
+      ? `build: ${formatResult(build)}, test: ${formatResult(result)}`
+      : formatResult(result)
+    return { build, detail, name: pkg.name, result, status }
+  })
+
+  const output = [`\nPackage task summary: ${task}`]
+  for (const row of rows) output.push(`${row.status} ${row.name} (${row.detail})`)
+  const failures = rows.filter(row => row.status === "FAIL")
+  if (failures.length > 0) {
+    output.push("", "Failures:")
+    for (const row of failures) output.push(`- ${row.name}: ${row.detail}`)
+  }
+
+  const markdown = [`## Package task: ${task}`, "", "| Package | Build | Task |", "| --- | --- | --- |"]
+  for (const row of rows) markdown.push(`| ${row.name} | ${formatResult(row.build)} | ${formatResult(row.result)} |`)
+  markdown.push("")
+  return { failures, markdown: markdown.join("\n"), output: output.join("\n") }
+}
+
+export async function runPackageTask(options) {
+  const workspaceRoot = resolve(options.workspaceRoot ?? process.cwd())
+  const packages = await loadPackages(workspaceRoot)
+  const { packageByName, selected } = selectPackages(packages, options.task, options.packageNames)
+  const controller = options.controller ?? new AbortController()
+  const execute = options.execute ?? ((pkg, phase, executionOptions) => executePackage(pkg, phase, {
+    ...executionOptions,
+    workspaceRoot,
+  }))
+  let buildResults
+
+  if (options.task === "test") {
+    const buildPackages = buildClosure(selected, packageByName)
+    buildResults = await runPhase({
+      execute,
+      maxParallel: options.maxParallel ?? DEFAULT_MAX_PARALLEL,
+      packages: buildPackages,
+      packageByName,
+      parallelSafePackages: options.parallelSafePackages ?? DEFAULT_PARALLEL_SAFE_PACKAGES,
+      phase: "build",
+      signal: controller.signal,
+    })
+  }
+
+  const taskResults = await runPhase({
+    execute,
+    maxParallel: options.maxParallel ?? DEFAULT_MAX_PARALLEL,
+    packages: selected,
+    packageByName,
+    parallelSafePackages: options.parallelSafePackages ?? DEFAULT_PARALLEL_SAFE_PACKAGES,
+    phase: options.task,
+    priorResults: buildResults,
+    signal: controller.signal,
+  })
+  const summaryPackages = packages.filter(pkg => buildResults?.has(pkg.name) || taskResults.has(pkg.name))
+  const summary = renderSummary(options.task, summaryPackages, buildResults, taskResults)
+  console.log(summary.output)
+  if (process.env.GITHUB_STEP_SUMMARY) await appendFile(process.env.GITHUB_STEP_SUMMARY, `${summary.markdown}\n`)
+
+  const failedResults = [
+    ...(buildResults?.values() ?? []),
+    ...taskResults.values(),
+  ].filter(result => result.status === "failed")
+  let exitCode = 0
+  if (controller.signal.aborted) exitCode = signalExitCode(String(controller.signal.reason || "SIGTERM"))
+  else if (failedResults.length === 1) exitCode = failedResults[0].code ?? 1
+  else if (failedResults.length > 1) exitCode = 1
+  return { ...summary, exitCode }
+}
+
+async function main() {
+  let options
+  try {
+    options = parseArguments(process.argv.slice(2))
+  }
+  catch (error) {
+    console.error(error.message)
+    process.exitCode = 2
+    return
+  }
+
+  const controller = new AbortController()
+  const interrupt = signal => controller.abort(signal)
+  process.once("SIGINT", interrupt)
+  process.once("SIGTERM", interrupt)
+  try {
+    const result = await runPackageTask({ ...options, controller })
+    process.exitCode = result.exitCode
+  }
+  catch (error) {
+    console.error(error.stack || error.message)
+    process.exitCode = 1
+  }
+  finally {
+    process.removeListener("SIGINT", interrupt)
+    process.removeListener("SIGTERM", interrupt)
   }
 }
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+if (isMain) await main()

--- a/test/run-package-task.test.ts
+++ b/test/run-package-task.test.ts
@@ -51,6 +51,7 @@ async function runFixture(packages: string[], env: NodeJS.ProcessEnv = {}) {
     return { ...result, code: 0, log: await readFile(log, "utf8"), summary: await readFile(summary, "utf8") }
   }
   catch (error) {
+    // SAFETY: execFile rejects with an ExecFileException augmented with the captured output.
     const failure = error as Error & { code: number, stderr: string, stdout: string }
     return { code: failure.code, stderr: failure.stderr, stdout: failure.stdout, log: await readFile(log, "utf8"), summary: await readFile(summary, "utf8") }
   }

--- a/test/run-package-task.test.ts
+++ b/test/run-package-task.test.ts
@@ -60,7 +60,7 @@ describe("package task runner", () => {
   it("aggregates independent failures, skips dependents, and builds the diamond once", async () => {
     const result = await runFixture(
       ["@fixture/app", "@fixture/core", "@vite-hub/env", "@vite-hub/markdown-template", "@vite-hub/runtime"],
-      { VITEHUB_FIXTURE_DELAY: "30", VITEHUB_FIXTURE_FAILURES: "@vite-hub/env=3,@vite-hub/markdown-template=7" },
+      { VITEHUB_FIXTURE_DELAY: "500", VITEHUB_FIXTURE_FAILURES: "@vite-hub/env=3,@vite-hub/markdown-template=7" },
     )
 
     expect(result.code).toBe(1)
@@ -110,6 +110,19 @@ describe("package task runner", () => {
       "test:start:@fixture/serial-b",
       "test:end:@fixture/serial-b",
     ])
+  })
+
+  it("skips a package test and its dependents after its build fails", async () => {
+    const result = await runFixture(
+      ["@fixture/app", "@vite-hub/env"],
+      { VITEHUB_FIXTURE_BUILD_FAILURES: "@vite-hub/env=5" },
+    )
+
+    expect(result.code).toBe(5)
+    expect(result.summary).toContain("| @vite-hub/env | failed (exit 5) | skipped: build did not pass |")
+    expect(result.summary).toContain("| @fixture/app | skipped: dependency @vite-hub/env did not pass | skipped: build did not pass |")
+    expect(result.log).not.toContain("test:start:@vite-hub/env")
+    expect(result.log).not.toContain("test:start:@fixture/app")
   })
 
   it("propagates a package signal as the aggregate exit status", async () => {

--- a/test/run-package-task.test.ts
+++ b/test/run-package-task.test.ts
@@ -1,0 +1,148 @@
+import { execFile, spawn } from "node:child_process"
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+import { promisify } from "node:util"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+const execFileAsync = promisify(execFile)
+const repoRoot = resolve(import.meta.dirname, "..")
+const runner = join(repoRoot, "test/run-package-task.mjs")
+const fixtureRoot = join(repoRoot, "test/fixtures/package-task-workspace")
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map(root => rm(root, { force: true, recursive: true })))
+})
+
+async function tempFile(name: string) {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-package-task-"))
+  roots.push(root)
+  return join(root, name)
+}
+
+async function runFixture(packages: string[], env: NodeJS.ProcessEnv = {}) {
+  const log = await tempFile("events.log")
+  const summary = await tempFile("summary.md")
+  await writeFile(log, "")
+  await writeFile(summary, "")
+
+  try {
+    const args = [
+      runner,
+      "test",
+      "--workspace",
+      fixtureRoot,
+      "--packages",
+      packages.join(","),
+      "--max-parallel",
+      "2",
+    ]
+    const result = await execFileAsync(process.execPath, args, {
+      cwd: fixtureRoot,
+      env: {
+        ...process.env,
+        GITHUB_STEP_SUMMARY: summary,
+        VITEHUB_FIXTURE_LOG: log,
+        ...env,
+      },
+    })
+    return { ...result, code: 0, log: await readFile(log, "utf8"), summary: await readFile(summary, "utf8") }
+  }
+  catch (error) {
+    const failure = error as Error & { code: number, stderr: string, stdout: string }
+    return { code: failure.code, stderr: failure.stderr, stdout: failure.stdout, log: await readFile(log, "utf8"), summary: await readFile(summary, "utf8") }
+  }
+}
+
+describe("package task runner", () => {
+  it("aggregates independent failures, skips dependents, and builds the diamond once", async () => {
+    const result = await runFixture(
+      ["@fixture/app", "@fixture/core", "@vite-hub/env", "@vite-hub/markdown-template", "@vite-hub/runtime"],
+      { VITEHUB_FIXTURE_DELAY: "30", VITEHUB_FIXTURE_FAILURES: "@vite-hub/env=3,@vite-hub/markdown-template=7" },
+    )
+
+    expect(result.code).toBe(1)
+    expect(result.stdout).toContain("FAIL @vite-hub/env")
+    expect(result.stdout).toContain("FAIL @vite-hub/markdown-template")
+    expect(result.stdout).toContain("SKIP @fixture/app")
+    expect(result.summary).toContain("| @vite-hub/env | passed | failed (exit 3) |")
+    expect(result.summary).toContain("| @vite-hub/markdown-template | passed | failed (exit 7) |")
+    expect(result.summary).toContain("| @fixture/app | passed | skipped")
+
+    const events = result.log.trim().split("\n")
+    for (const name of ["@fixture/app", "@fixture/core", "@vite-hub/env", "@vite-hub/markdown-template", "@vite-hub/runtime"]) {
+      expect(events.filter(event => event === `build:start:${name}`)).toHaveLength(1)
+    }
+    expect(events).not.toContain("test:start:@fixture/app")
+    const lastStart = Math.max(
+      events.indexOf("test:start:@vite-hub/env"),
+      events.indexOf("test:start:@vite-hub/markdown-template"),
+    )
+    const firstEnd = Math.min(
+      events.indexOf("test:end:@vite-hub/env"),
+      events.indexOf("test:end:@vite-hub/markdown-template"),
+    )
+    expect(lastStart).toBeLessThan(firstEnd)
+
+    const rows = result.stdout.split("\n").filter(line => /^(?:PASS|FAIL|SKIP) @(?:fixture|vite-hub)\//.test(line))
+    expect(rows.map(row => row.split(" ")[1])).toEqual([
+      "@fixture/app",
+      "@fixture/core",
+      "@vite-hub/env",
+      "@vite-hub/markdown-template",
+      "@vite-hub/runtime",
+    ])
+  }, 15_000)
+
+  it("keeps packages outside the safe allowlist serial", async () => {
+    const result = await runFixture(["@fixture/serial-a", "@fixture/serial-b"], { VITEHUB_FIXTURE_DELAY: "20" })
+
+    expect(result.code).toBe(0)
+    expect(result.log.trim().split("\n")).toEqual([
+      "build:start:@fixture/serial-a",
+      "build:end:@fixture/serial-a",
+      "build:start:@fixture/serial-b",
+      "build:end:@fixture/serial-b",
+      "test:start:@fixture/serial-a",
+      "test:end:@fixture/serial-a",
+      "test:start:@fixture/serial-b",
+      "test:end:@fixture/serial-b",
+    ])
+  })
+
+  it("propagates a package signal as the aggregate exit status", async () => {
+    const result = await runFixture(["@vite-hub/runtime"], { VITEHUB_FIXTURE_SIGNALS: "@vite-hub/runtime" })
+
+    expect(result.code).toBe(143)
+    expect(result.stdout).toContain("failed (exit 143)")
+  })
+
+  it("forwards interruption to the active package and stops scheduling", async () => {
+    const log = await tempFile("interrupt.log")
+    await writeFile(log, "")
+    const child = spawn(process.execPath, [
+      runner,
+      "test",
+      "--workspace",
+      fixtureRoot,
+      "--packages",
+      "@fixture/interrupt,@fixture/serial-a",
+    ], {
+      cwd: fixtureRoot,
+      env: { ...process.env, VITEHUB_FIXTURE_DELAY: "10000", VITEHUB_FIXTURE_LOG: log },
+      stdio: ["ignore", "pipe", "pipe"],
+    })
+    let stdout = ""
+    child.stdout.on("data", chunk => stdout += chunk)
+
+    await expect.poll(async () => readFile(log, "utf8"), { timeout: 5_000 }).toContain("build:start:@fixture/interrupt")
+    child.kill("SIGTERM")
+    const code = await new Promise<number | null>(resolve => child.on("close", resolve))
+
+    expect(code).toBe(143)
+    expect(await readFile(log, "utf8")).toContain("build:signal:@fixture/interrupt")
+    expect(stdout).toContain("SKIP @fixture/serial-a")
+  }, 10_000)
+})


### PR DESCRIPTION
Package tasks now finish the dependency graph instead of exiting after the first failure. The runner builds each reachable package once, skips dependents whose prerequisite failed, prints deterministic local and GitHub summaries, and preserves child exit or interruption status.

Concurrency is capped at two and restricted to Runtime, Env, and Markdown Template. Every other package remains exclusive, so this change does not add concurrency to suites that may share ports or filesystem state.

## Test plan

- `corepack pnpm exec vp test --config vitest.config.ts test/run-package-task.test.ts test/test-layers.test.ts`
- `node test/run-package-task.mjs test --packages @vite-hub/markdown-template,@vite-hub/runtime`
- `corepack pnpm exec vp run lint`
- `node --check test/run-package-task.mjs`

The three-package allowlist run also reported two existing Env assertions as failures. Running `vp test test/vite.test.ts` directly in `packages/env` reproduces both, so this PR does not mask or reclassify them.
