### PR TITLE
ci: pin GitHub Actions to immutable commits

### DIFF
--- a/.github/actions/setup-deno/action.yml
+++ b/.github/actions/setup-deno/action.yml
@@ -14,6 +14,6 @@ runs:
         fi
         echo "version=$version" >> "$GITHUB_OUTPUT"
 
-    - uses: denoland/setup-deno@v2
+    - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
       with:
         deno-version: ${{ steps.deno.outputs.version }}

--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -3,7 +3,7 @@ description: Install Vite+ and project dependencies
 runs:
   using: composite
   steps:
-    - uses: voidzero-dev/setup-vp@v1
+    - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
       with:
         node-version: "24"
         cache: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directories:
+      - /
+      - /.github/actions/setup
+      - /.github/actions/setup-deno
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -36,7 +36,7 @@ export async function findGitHubActionPolicyFiles(repoRoot) {
     findYamlFiles(resolve(githubRoot, "workflows"), name => /\.ya?ml$/.test(name)),
     findYamlFiles(repoRoot, name => /^action\.ya?ml$/.test(name), new Set([".git", "node_modules"])),
   ])
-  return [...workflows, ...actions].sort()
+  return [...new Set([...workflows, ...actions])].sort()
 }
 
 export function inspectGitHubActionReferences(path, source) {
@@ -84,8 +84,10 @@ export function inspectGitHubActionReferences(path, source) {
 
   const findPair = (map, key) => map.items.find(pair => isScalar(pair.key) && pair.key.value === key)
   const inspectSteps = (steps) => {
+    if (isAlias(steps)) steps = steps.resolve(document)
     if (!isSeq(steps)) return
-    for (const step of steps.items) {
+    for (let step of steps.items) {
+      if (isAlias(step)) step = step.resolve(document)
       if (isMap(step)) inspectUses(findPair(step, "uses"), step.comment ?? "")
     }
   }
@@ -93,7 +95,7 @@ export function inspectGitHubActionReferences(path, source) {
   const root = document.contents
   if (!isMap(root)) return failures
 
-  if (normalizedPath.startsWith(".github/workflows/")) {
+  if (!/(?:^|\/)action\.ya?ml$/.test(normalizedPath) && normalizedPath.startsWith(".github/workflows/")) {
     const jobs = findPair(root, "jobs")?.value
     if (!isMap(jobs)) return failures
     for (const jobPair of jobs.items) {

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -38,6 +38,7 @@ export async function findGitHubActionPolicyFiles(repoRoot) {
 }
 
 export function inspectGitHubActionReferences(path, source) {
+  const normalizedPath = path.replaceAll("\\", "/")
   const lineCounter = new LineCounter()
   const document = parseDocument(source, { lineCounter, schema: "failsafe" })
   const failures = document.errors.map(error => ({
@@ -89,7 +90,7 @@ export function inspectGitHubActionReferences(path, source) {
   const root = document.contents
   if (!isMap(root)) return failures
 
-  if (path.startsWith(".github/workflows/")) {
+  if (normalizedPath.startsWith(".github/workflows/")) {
     const jobs = findPair(root, "jobs")?.value
     if (!isMap(jobs)) return failures
     for (const jobPair of jobs.items) {

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -105,11 +105,12 @@ export function inspectGitHubActionReferences(path, source) {
   if (!isActionManifest && normalizedPath.startsWith(".github/workflows/")) {
     const jobs = findPair(root, "jobs")?.value
     if (!isMap(jobs)) return failures
+    const enclosingJobsComment = jobs.items.length === 1 ? jobs.comment ?? "" : ""
     for (const jobPair of jobs.items) {
       const aliasComment = jobPair.value?.comment ?? ""
       const job = isAlias(jobPair.value) ? jobPair.value.resolve(document) : jobPair.value
       if (!isMap(job)) continue
-      inspectUses(findPair(job, "uses"), aliasComment || job.comment || jobs.comment || "")
+      inspectUses(findPair(job, "uses"), aliasComment || job.comment || enclosingJobsComment)
       inspectSteps(findPair(job, "steps")?.value)
     }
   }

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -1,0 +1,120 @@
+import { readdir, readFile } from "node:fs/promises"
+import { relative, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import { isScalar, LineCounter, parseDocument, visit } from "yaml"
+
+const actionCommitPattern = /^[^/@\s]+\/[^/@\s]+(?:\/[^/@\s]+)*@[0-9a-f]{40}$/
+const versionCommentPattern = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
+
+async function findYamlFiles(directory, filter) {
+  let entries
+  try {
+    entries = await readdir(directory, { withFileTypes: true })
+  }
+  catch (error) {
+    if (error.code === "ENOENT") return []
+    throw error
+  }
+
+  const files = []
+  for (const entry of entries) {
+    const path = resolve(directory, entry.name)
+    if (entry.isDirectory()) files.push(...await findYamlFiles(path, filter))
+    else if (entry.isFile() && filter(entry.name)) files.push(path)
+  }
+  return files
+}
+
+export async function findGitHubActionPolicyFiles(repoRoot) {
+  const githubRoot = resolve(repoRoot, ".github")
+  const [workflows, actions] = await Promise.all([
+    findYamlFiles(resolve(githubRoot, "workflows"), name => /\.ya?ml$/.test(name)),
+    findYamlFiles(resolve(githubRoot, "actions"), name => /^action\.ya?ml$/.test(name)),
+  ])
+  return [...workflows, ...actions].sort()
+}
+
+export function inspectGitHubActionReferences(path, source) {
+  const lineCounter = new LineCounter()
+  const document = parseDocument(source, { lineCounter })
+  const failures = document.errors.map(error => ({
+    line: error.linePos?.[0]?.line ?? 1,
+    message: `invalid YAML: ${error.message.split("\n", 1)[0]}`,
+    path,
+  }))
+
+  if (failures.length > 0) return failures
+
+  visit(document, {
+    Pair(_key, pair) {
+      if (!isScalar(pair.key) || pair.key.value !== "uses") return
+
+      const line = lineCounter.linePos(pair.key.range?.[0] ?? 0).line
+      if (!isScalar(pair.value) || typeof pair.value.value !== "string") {
+        failures.push({ line, message: "uses must be a string", path })
+        return
+      }
+
+      const reference = pair.value.value
+      if (reference.startsWith("./")) return
+      if (!actionCommitPattern.test(reference)) {
+        failures.push({
+          line,
+          message: `external action must use a full 40-character commit SHA: ${reference}`,
+          path,
+        })
+        return
+      }
+
+      const versionComment = pair.value.comment?.trim() ?? ""
+      if (!versionCommentPattern.test(versionComment)) {
+        failures.push({
+          line,
+          message: `pinned external action must have an exact version comment (for example, # v1.2.3): ${reference}`,
+          path,
+        })
+      }
+    },
+  })
+
+  return failures
+}
+
+export async function checkGitHubActionPins(repoRoot) {
+  const files = await findGitHubActionPolicyFiles(repoRoot)
+  if (files.length === 0) {
+    return [{ line: 1, message: "no workflow or composite action YAML files found", path: ".github" }]
+  }
+
+  const failures = []
+  for (const file of files) {
+    const source = await readFile(file, "utf8")
+    const path = relative(repoRoot, file)
+    failures.push(...inspectGitHubActionReferences(path, source))
+  }
+  return failures
+}
+
+export async function runActionPinCheck(args, output = process) {
+  if (args.length > 1) {
+    output.stderr.write("Usage: node .github/scripts/check-action-pins.mjs [repo-root]\n")
+    return 2
+  }
+
+  const repoRoot = resolve(args[0] ?? import.meta.dirname, args[0] ? "." : "../..")
+  const failures = await checkGitHubActionPins(repoRoot)
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      output.stderr.write(`${failure.path}:${failure.line}: ${failure.message}\n`)
+    }
+    return 1
+  }
+
+  output.stdout.write("GitHub Action references are pinned.\n")
+  return 0
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  process.exitCode = await runActionPinCheck(process.argv.slice(2))
+}

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -2,7 +2,7 @@ import { readdir, readFile } from "node:fs/promises"
 import { relative, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 
-import { isScalar, LineCounter, parseDocument, visit } from "yaml"
+import { isMap, isScalar, isSeq, LineCounter, parseDocument } from "yaml"
 
 const actionCommitPattern = /^[^/@\s]+\/[^/@\s]+(?:\/[^/@\s]+)*@[0-9a-f]{40}$/
 const versionCommentPattern = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
@@ -48,37 +48,60 @@ export function inspectGitHubActionReferences(path, source) {
 
   if (failures.length > 0) return failures
 
-  visit(document, {
-    Pair(_key, pair) {
-      if (!isScalar(pair.key) || pair.key.value !== "uses") return
+  const inspectUses = (pair) => {
+    if (!pair) return
 
-      const line = lineCounter.linePos(pair.key.range?.[0] ?? 0).line
-      if (!isScalar(pair.value) || pair.value.value === null) {
-        failures.push({ line, message: "uses must be a string", path })
-        return
-      }
+    const line = lineCounter.linePos(pair.key.range?.[0] ?? 0).line
+    if (!isScalar(pair.value) || pair.value.value === null) {
+      failures.push({ line, message: "uses must be a string", path })
+      return
+    }
 
-      const reference = pair.value.value
-      if (reference.startsWith("./")) return
-      if (!actionCommitPattern.test(reference)) {
-        failures.push({
-          line,
-          message: `external action must use a full 40-character commit SHA: ${reference}`,
-          path,
-        })
-        return
-      }
+    const reference = pair.value.value
+    if (reference.startsWith("./")) return
+    if (!actionCommitPattern.test(reference)) {
+      failures.push({
+        line,
+        message: `external action must use a full 40-character commit SHA: ${reference}`,
+        path,
+      })
+      return
+    }
 
-      const versionComment = pair.value.comment?.trim() ?? ""
-      if (!versionCommentPattern.test(versionComment)) {
-        failures.push({
-          line,
-          message: `pinned external action must have an exact version comment (for example, # v1.2.3): ${reference}`,
-          path,
-        })
-      }
-    },
-  })
+    const versionComment = pair.value.comment?.trim() ?? ""
+    if (!versionCommentPattern.test(versionComment)) {
+      failures.push({
+        line,
+        message: `pinned external action must have an exact version comment (for example, # v1.2.3): ${reference}`,
+        path,
+      })
+    }
+  }
+
+  const findPair = (map, key) => map.items.find(pair => isScalar(pair.key) && pair.key.value === key)
+  const inspectSteps = (steps) => {
+    if (!isSeq(steps)) return
+    for (const step of steps.items) {
+      if (isMap(step)) inspectUses(findPair(step, "uses"))
+    }
+  }
+
+  const root = document.contents
+  if (!isMap(root)) return failures
+
+  if (path.startsWith(".github/workflows/")) {
+    const jobs = findPair(root, "jobs")?.value
+    if (!isMap(jobs)) return failures
+    for (const jobPair of jobs.items) {
+      if (!isMap(jobPair.value)) continue
+      inspectUses(findPair(jobPair.value, "uses"))
+      inspectSteps(findPair(jobPair.value, "steps")?.value)
+    }
+  }
+  else {
+    const runs = findPair(root, "runs")?.value
+    if (isMap(runs)) inspectSteps(findPair(runs, "steps")?.value)
+  }
 
   return failures
 }

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url"
 import { isAlias, isMap, isScalar, isSeq, LineCounter, parseDocument } from "yaml"
 
 const actionCommitPattern = /^[^/@\s]+\/[^/@\s]+(?:\/[^/@\s]+)*@[0-9a-f]{40}$/
+const dockerDigestPattern = /^docker:\/\/[^@\s]+@sha256:[0-9a-f]{64}$/
 const versionCommentPattern = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
 
 async function findYamlFiles(directory, filter, ignoredDirectories = new Set(), recursive = true) {
@@ -63,10 +64,16 @@ export function inspectGitHubActionReferences(path, source) {
 
     const reference = value.value
     if (reference.startsWith("./")) return
-    if (!actionCommitPattern.test(reference)) {
+    const isDockerReference = reference.startsWith("docker://")
+    const isImmutable = isDockerReference
+      ? dockerDigestPattern.test(reference)
+      : actionCommitPattern.test(reference)
+    if (!isImmutable) {
       failures.push({
         line,
-        message: `external action must use a full 40-character commit SHA: ${reference}`,
+        message: isDockerReference
+          ? `Docker action must use a full SHA-256 digest: ${reference}`
+          : `external action must use a full 40-character commit SHA: ${reference}`,
         path,
       })
       return

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -87,12 +87,13 @@ export function inspectGitHubActionReferences(path, source) {
     return isScalar(pairKey) && pairKey.value === key
   })
   const inspectSteps = (steps) => {
+    const sequenceComment = steps?.comment ?? ""
     if (isAlias(steps)) steps = steps.resolve(document)
     if (!isSeq(steps)) return
     for (let step of steps.items) {
       const aliasComment = step?.comment ?? ""
       if (isAlias(step)) step = step.resolve(document)
-      if (isMap(step)) inspectUses(findPair(step, "uses"), aliasComment || step.comment || "")
+      if (isMap(step)) inspectUses(findPair(step, "uses"), aliasComment || step.comment || sequenceComment)
     }
   }
 
@@ -105,9 +106,10 @@ export function inspectGitHubActionReferences(path, source) {
     const jobs = findPair(root, "jobs")?.value
     if (!isMap(jobs)) return failures
     for (const jobPair of jobs.items) {
+      const aliasComment = jobPair.value?.comment ?? ""
       const job = isAlias(jobPair.value) ? jobPair.value.resolve(document) : jobPair.value
       if (!isMap(job)) continue
-      inspectUses(findPair(job, "uses"), job.comment ?? "")
+      inspectUses(findPair(job, "uses"), aliasComment || job.comment || "")
       inspectSteps(findPair(job, "steps")?.value)
     }
   }

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -1,4 +1,4 @@
-import { readdir, readFile } from "node:fs/promises"
+import { readdir, readFile, stat } from "node:fs/promises"
 import { relative, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 
@@ -23,7 +23,9 @@ async function findYamlFiles(directory, filter, ignoredDirectories = new Set()) 
     if (entry.isDirectory() && !ignoredDirectories.has(entry.name)) {
       files.push(...await findYamlFiles(path, filter, ignoredDirectories))
     }
-    else if (entry.isFile() && filter(entry.name)) files.push(path)
+    else if (filter(entry.name) && (entry.isFile() || (entry.isSymbolicLink() && (await stat(path)).isFile()))) {
+      files.push(path)
+    }
   }
   return files
 }
@@ -49,7 +51,7 @@ export function inspectGitHubActionReferences(path, source) {
 
   if (failures.length > 0) return failures
 
-  const inspectUses = (pair) => {
+  const inspectUses = (pair, enclosingComment = "") => {
     if (!pair) return
 
     const line = lineCounter.linePos(pair.key.range?.[0] ?? 0).line
@@ -69,7 +71,7 @@ export function inspectGitHubActionReferences(path, source) {
       return
     }
 
-    const versionComment = pair.value.comment?.trim() ?? ""
+    const versionComment = pair.value.comment?.trim() ?? enclosingComment.trim()
     if (!versionCommentPattern.test(versionComment)) {
       failures.push({
         line,
@@ -83,7 +85,7 @@ export function inspectGitHubActionReferences(path, source) {
   const inspectSteps = (steps) => {
     if (!isSeq(steps)) return
     for (const step of steps.items) {
-      if (isMap(step)) inspectUses(findPair(step, "uses"))
+      if (isMap(step)) inspectUses(findPair(step, "uses"), step.comment ?? "")
     }
   }
 

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -7,7 +7,7 @@ import { isAlias, isMap, isScalar, isSeq, LineCounter, parseDocument } from "yam
 const actionCommitPattern = /^[^/@\s]+\/[^/@\s]+(?:\/[^/@\s]+)*@[0-9a-f]{40}$/
 const versionCommentPattern = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
 
-async function findYamlFiles(directory, filter, ignoredDirectories = new Set()) {
+async function findYamlFiles(directory, filter, ignoredDirectories = new Set(), recursive = true) {
   let entries
   try {
     entries = await readdir(directory, { withFileTypes: true })
@@ -20,7 +20,7 @@ async function findYamlFiles(directory, filter, ignoredDirectories = new Set()) 
   const files = []
   for (const entry of entries) {
     const path = resolve(directory, entry.name)
-    if (entry.isDirectory() && !ignoredDirectories.has(entry.name)) {
+    if (recursive && entry.isDirectory() && !ignoredDirectories.has(entry.name)) {
       files.push(...await findYamlFiles(path, filter, ignoredDirectories))
     }
     else if (filter(entry.name) && (entry.isFile() || (entry.isSymbolicLink() && (await stat(path)).isFile()))) {
@@ -33,7 +33,7 @@ async function findYamlFiles(directory, filter, ignoredDirectories = new Set()) 
 export async function findGitHubActionPolicyFiles(repoRoot) {
   const githubRoot = resolve(repoRoot, ".github")
   const [workflows, actions] = await Promise.all([
-    findYamlFiles(resolve(githubRoot, "workflows"), name => /\.ya?ml$/.test(name)),
+    findYamlFiles(resolve(githubRoot, "workflows"), name => /\.ya?ml$/.test(name), new Set(), false),
     findYamlFiles(repoRoot, name => /^action\.ya?ml$/.test(name), new Set([".git", "node_modules"])),
   ])
   return [...new Set([...workflows, ...actions])].sort()

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -99,9 +99,10 @@ export function inspectGitHubActionReferences(path, source) {
     const jobs = findPair(root, "jobs")?.value
     if (!isMap(jobs)) return failures
     for (const jobPair of jobs.items) {
-      if (!isMap(jobPair.value)) continue
-      inspectUses(findPair(jobPair.value, "uses"))
-      inspectSteps(findPair(jobPair.value, "steps")?.value)
+      const job = isAlias(jobPair.value) ? jobPair.value.resolve(document) : jobPair.value
+      if (!isMap(job)) continue
+      inspectUses(findPair(job, "uses"))
+      inspectSteps(findPair(job, "steps")?.value)
     }
   }
   else {

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -56,7 +56,7 @@ export function inspectGitHubActionReferences(path, source) {
 
     const line = lineCounter.linePos(pair.key.range?.[0] ?? 0).line
     const value = isAlias(pair.value) ? pair.value.resolve(document) : pair.value
-    if (!isScalar(value) || typeof value.value !== "string") {
+    if (!isScalar(value)) {
       failures.push({ line, message: "uses must be a string", path })
       return
     }
@@ -82,7 +82,10 @@ export function inspectGitHubActionReferences(path, source) {
     }
   }
 
-  const findPair = (map, key) => map.items.find(pair => isScalar(pair.key) && pair.key.value === key)
+  const findPair = (map, key) => map.items.find((pair) => {
+    const pairKey = isAlias(pair.key) ? pair.key.resolve(document) : pair.key
+    return isScalar(pairKey) && pairKey.value === key
+  })
   const inspectSteps = (steps) => {
     if (isAlias(steps)) steps = steps.resolve(document)
     if (!isSeq(steps)) return
@@ -101,7 +104,7 @@ export function inspectGitHubActionReferences(path, source) {
     for (const jobPair of jobs.items) {
       const job = isAlias(jobPair.value) ? jobPair.value.resolve(document) : jobPair.value
       if (!isMap(job)) continue
-      inspectUses(findPair(job, "uses"))
+      inspectUses(findPair(job, "uses"), job.comment ?? "")
       inspectSteps(findPair(job, "steps")?.value)
     }
   }

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -7,7 +7,7 @@ import { isScalar, LineCounter, parseDocument, visit } from "yaml"
 const actionCommitPattern = /^[^/@\s]+\/[^/@\s]+(?:\/[^/@\s]+)*@[0-9a-f]{40}$/
 const versionCommentPattern = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
 
-async function findYamlFiles(directory, filter) {
+async function findYamlFiles(directory, filter, ignoredDirectories = new Set()) {
   let entries
   try {
     entries = await readdir(directory, { withFileTypes: true })
@@ -20,7 +20,9 @@ async function findYamlFiles(directory, filter) {
   const files = []
   for (const entry of entries) {
     const path = resolve(directory, entry.name)
-    if (entry.isDirectory()) files.push(...await findYamlFiles(path, filter))
+    if (entry.isDirectory() && !ignoredDirectories.has(entry.name)) {
+      files.push(...await findYamlFiles(path, filter, ignoredDirectories))
+    }
     else if (entry.isFile() && filter(entry.name)) files.push(path)
   }
   return files
@@ -30,14 +32,14 @@ export async function findGitHubActionPolicyFiles(repoRoot) {
   const githubRoot = resolve(repoRoot, ".github")
   const [workflows, actions] = await Promise.all([
     findYamlFiles(resolve(githubRoot, "workflows"), name => /\.ya?ml$/.test(name)),
-    findYamlFiles(resolve(githubRoot, "actions"), name => /^action\.ya?ml$/.test(name)),
+    findYamlFiles(repoRoot, name => /^action\.ya?ml$/.test(name), new Set([".git", "node_modules"])),
   ])
   return [...workflows, ...actions].sort()
 }
 
 export function inspectGitHubActionReferences(path, source) {
   const lineCounter = new LineCounter()
-  const document = parseDocument(source, { lineCounter })
+  const document = parseDocument(source, { lineCounter, schema: "failsafe" })
   const failures = document.errors.map(error => ({
     line: error.linePos?.[0]?.line ?? 1,
     message: `invalid YAML: ${error.message.split("\n", 1)[0]}`,
@@ -51,7 +53,7 @@ export function inspectGitHubActionReferences(path, source) {
       if (!isScalar(pair.key) || pair.key.value !== "uses") return
 
       const line = lineCounter.linePos(pair.key.range?.[0] ?? 0).line
-      if (!isScalar(pair.value) || typeof pair.value.value !== "string") {
+      if (!isScalar(pair.value) || pair.value.value === null) {
         failures.push({ line, message: "uses must be a string", path })
         return
       }

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -90,8 +90,9 @@ export function inspectGitHubActionReferences(path, source) {
     if (isAlias(steps)) steps = steps.resolve(document)
     if (!isSeq(steps)) return
     for (let step of steps.items) {
+      const aliasComment = step?.comment ?? ""
       if (isAlias(step)) step = step.resolve(document)
-      if (isMap(step)) inspectUses(findPair(step, "uses"), step.comment ?? "")
+      if (isMap(step)) inspectUses(findPair(step, "uses"), aliasComment || step.comment || "")
     }
   }
 

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -98,7 +98,9 @@ export function inspectGitHubActionReferences(path, source) {
   const root = document.contents
   if (!isMap(root)) return failures
 
-  if (!/(?:^|\/)action\.ya?ml$/.test(normalizedPath) && normalizedPath.startsWith(".github/workflows/")) {
+  const isDirectWorkflow = /^\.github\/workflows\/[^/]+\.ya?ml$/.test(normalizedPath)
+  const isActionManifest = /(?:^|\/)action\.ya?ml$/.test(normalizedPath) && !isDirectWorkflow
+  if (!isActionManifest && normalizedPath.startsWith(".github/workflows/")) {
     const jobs = findPair(root, "jobs")?.value
     if (!isMap(jobs)) return failures
     for (const jobPair of jobs.items) {

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -109,7 +109,7 @@ export function inspectGitHubActionReferences(path, source) {
       const aliasComment = jobPair.value?.comment ?? ""
       const job = isAlias(jobPair.value) ? jobPair.value.resolve(document) : jobPair.value
       if (!isMap(job)) continue
-      inspectUses(findPair(job, "uses"), aliasComment || job.comment || "")
+      inspectUses(findPair(job, "uses"), aliasComment || job.comment || jobs.comment || "")
       inspectSteps(findPair(job, "steps")?.value)
     }
   }

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -90,10 +90,11 @@ export function inspectGitHubActionReferences(path, source) {
     const sequenceComment = steps?.comment ?? ""
     if (isAlias(steps)) steps = steps.resolve(document)
     if (!isSeq(steps)) return
+    const enclosingSequenceComment = steps.items.length === 1 ? sequenceComment : ""
     for (let step of steps.items) {
       const aliasComment = step?.comment ?? ""
       if (isAlias(step)) step = step.resolve(document)
-      if (isMap(step)) inspectUses(findPair(step, "uses"), aliasComment || step.comment || sequenceComment)
+      if (isMap(step)) inspectUses(findPair(step, "uses"), aliasComment || step.comment || enclosingSequenceComment)
     }
   }
 

--- a/.github/scripts/check-action-pins.mjs
+++ b/.github/scripts/check-action-pins.mjs
@@ -2,7 +2,7 @@ import { readdir, readFile, stat } from "node:fs/promises"
 import { relative, resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 
-import { isMap, isScalar, isSeq, LineCounter, parseDocument } from "yaml"
+import { isAlias, isMap, isScalar, isSeq, LineCounter, parseDocument } from "yaml"
 
 const actionCommitPattern = /^[^/@\s]+\/[^/@\s]+(?:\/[^/@\s]+)*@[0-9a-f]{40}$/
 const versionCommentPattern = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/
@@ -55,12 +55,13 @@ export function inspectGitHubActionReferences(path, source) {
     if (!pair) return
 
     const line = lineCounter.linePos(pair.key.range?.[0] ?? 0).line
-    if (!isScalar(pair.value) || pair.value.value === null) {
+    const value = isAlias(pair.value) ? pair.value.resolve(document) : pair.value
+    if (!isScalar(value) || typeof value.value !== "string") {
       failures.push({ line, message: "uses must be a string", path })
       return
     }
 
-    const reference = pair.value.value
+    const reference = value.value
     if (reference.startsWith("./")) return
     if (!actionCommitPattern.test(reference)) {
       failures.push({

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     name: ci
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup
@@ -53,7 +53,7 @@ jobs:
     name: docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/setup
 
       - run: vp run --filter vitehub-docs test
@@ -68,9 +68,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/setup
-      - uses: denoland/setup-deno@v2
+      - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
         with:
           deno-version: 2.9.3
 
@@ -81,7 +81,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/setup
 
       - name: Provider Output Contract
@@ -111,7 +111,7 @@ jobs:
         ports:
           - 8080:8080
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/setup
 
       - name: Provider Output Contract
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/setup
 
       - run: npm install -g netlify-cli@23.15.1

--- a/.github/workflows/live-smoke.yml
+++ b/.github/workflows/live-smoke.yml
@@ -21,14 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: Production
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/setup
 
       - name: Build vitehub packages
         run: vp run build
 
       - name: Upload package builds
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: vitehub-package-dist
           path: |
@@ -48,11 +48,11 @@ jobs:
       matrix:
         provider: [cloudflare, vercel]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/setup
 
       - name: Download package builds
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: vitehub-package-dist
           path: packages
@@ -364,7 +364,7 @@ jobs:
 
       - name: Upload stage evidence
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: live-smoke-evidence-${{ matrix.provider }}-${{ github.run_attempt }}
           path: live-smoke-evidence/${{ matrix.provider }}.json
@@ -381,20 +381,20 @@ jobs:
       contents: read
       issues: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - run: mkdir -p live-smoke-evidence
 
       - name: Download provider stage evidence
         continue-on-error: true
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: live-smoke-evidence-*
           path: live-smoke-evidence
 
       - name: Identify provider jobs in this attempt
         id: attempt
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRunAttempt, {
@@ -427,7 +427,7 @@ jobs:
             > live-smoke-report.json
 
       - name: Upload aggregate stage evidence
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: live-smoke-report-${{ github.run_attempt }}
           path: live-smoke-report.json
@@ -436,7 +436,7 @@ jobs:
 
       - name: Update tracked failure issue
         if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && needs.setup-cloudflare.result == 'success' && needs.live-smoke.result == 'success')
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const { readFileSync } = require("node:fs")

--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -17,7 +17,7 @@ jobs:
     name: publish preview packages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
       - uses: ./.github/actions/setup
 
       - run: vp run build

--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -21,11 +21,11 @@ jobs:
       contents: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 1
       - name: Run agent
-        uses: pullfrog/pullfrog@v0
+        uses: pullfrog/pullfrog@86f7dba19a2e8fddcc11c703e3fd906d8deae145 # v0.1.64
         with:
           prompt: ${{ inputs.prompt }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,11 @@ jobs:
     name: release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
-      - uses: voidzero-dev/setup-vp@v1
+      - uses: voidzero-dev/setup-vp@250f29ce396baf5e8f24498e17c0dfdebabc26eb # v1.15.0
         with:
           node-version: "24"
           cache: true

--- a/docs/scripts/build.mjs
+++ b/docs/scripts/build.mjs
@@ -22,6 +22,7 @@ export const buildWarningBudget = Object.freeze([
   { name: "build plugin timings", maximum: 3, text: "[PLUGIN_TIMINGS]" },
   { name: "VueUse pure annotations", maximum: 2, text: "[INVALID_ANNOTATION]" },
   { name: "Rollup pure annotations", maximum: 2, text: "contains an annotation that Rollup cannot interpret", warningTokenRequired: false },
+  { name: "Nuxt UI button imports", maximum: 2, text: "[INEFFECTIVE_DYNAMIC_IMPORT]" },
   { name: "Vite chunk size", maximum: 1, text: "[plugin builtin:vite-reporter]" },
   { name: "Nitro Cloudflare assets override", maximum: 1, text: "Wrangler config assetsset" },
 ]);

--- a/docs/test/build-warnings.test.ts
+++ b/docs/test/build-warnings.test.ts
@@ -32,6 +32,7 @@ describe("docs build warning budget", () => {
     const warnings = [
       "[warn] [docus] AI assistant disabled: missing AI binding",
       "[warn] [PLUGIN_TIMINGS] render pages took 1s",
+      "[warn] [INEFFECTIVE_DYNAMIC_IMPORT] Button.vue is dynamically and statically imported",
       "[warn] [Icon] failed to load icon `simple-icons:pnpm`",
       "[warn] [nitro] [cloudflare] Wrangler config `assets`set by config or modules is overridden and will be ignored.",
     ].join("\n")

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "url": "git+https://github.com/vite-hub/vitehub.git"
   },
   "type": "module",
+  "dependencies": {
+    "yaml": "catalog:tooling"
+  },
   "devDependencies": {
     "@cloudflare/sandbox": "catalog:sandbox",
     "@types/node": "catalog:tooling",
@@ -48,8 +51,7 @@
     "vite-doctor": "catalog:",
     "vite-hub": "workspace:*",
     "vite-plus": "catalog:tooling",
-    "vitest": "catalog:tooling",
-    "yaml": "catalog:tooling"
+    "vitest": "catalog:tooling"
   },
   "devEngines": {
     "runtime": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "vite-doctor": "catalog:",
     "vite-hub": "workspace:*",
     "vite-plus": "catalog:tooling",
-    "vitest": "catalog:tooling"
+    "vitest": "catalog:tooling",
+    "yaml": "catalog:tooling"
   },
   "devEngines": {
     "runtime": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -285,6 +285,9 @@ catalogs:
     vue-tsc:
       specifier: ^3.3.7
       version: 3.3.7
+    yaml:
+      specifier: ^2.9.0
+      version: 2.9.0
   ui:
     '@iconify-json/lucide':
       specifier: ^1.2.117
@@ -528,6 +531,9 @@ importers:
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
         version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
+      yaml:
+        specifier: catalog:tooling
+        version: 2.9.0
 
   docs:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -413,6 +413,10 @@ patchedDependencies:
 importers:
 
   .:
+    dependencies:
+      yaml:
+        specifier: catalog:tooling
+        version: 2.9.0
     devDependencies:
       '@cloudflare/sandbox':
         specifier: catalog:sandbox
@@ -531,10 +535,6 @@ importers:
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
         version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
-      yaml:
-        specifier: catalog:tooling
-        version: 2.9.0
-
   docs:
     dependencies:
       '@nuxt/content':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -118,6 +118,7 @@ catalogs:
     vite-plus: ^0.1.24
     vitest: ^4.1.4
     vue-tsc: ^3.3.7
+    yaml: ^2.9.0
   ui:
     "@iconify-json/lucide": ^1.2.117
     "@iconify-json/ph": ^1.2.2

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -152,6 +152,15 @@ describe("GitHub Action pin policy", () => {
     await expect(checkGitHubActionPins(root)).resolves.toEqual([])
   })
 
+  it("allows a pinned reusable workflow with an enclosing jobs version comment", async () => {
+    const reference = "owner/repo/.github/workflows/build.yml@1234567890abcdef1234567890abcdef12345678"
+    const root = await createFixture({
+      ".github/workflows/ci.yml": `jobs: { call: { uses: "${reference}" } } # v1.2.3\n`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([])
+  })
+
   it("allows pinned action references through YAML aliases", async () => {
     const reference = pinnedCheckout.split(" #")[0]
     const root = await createFixture({

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -198,6 +198,15 @@ jobs:
     await expect(checkGitHubActionPins(root)).resolves.toEqual([])
   })
 
+  it("allows pinned steps with a flow-sequence version comment", async () => {
+    const reference = pinnedCheckout.split(" #")[0]
+    const root = await createFixture({
+      ".github/workflows/ci.yml": `jobs:\n  test:\n    steps: [{ uses: ${reference} }] # v6.1.0\n`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([])
+  })
+
   it("inspects action references through aliased workflow jobs", async () => {
     const root = await createFixture({
       ".github/workflows/ci.yml": `job: &unpinned-job
@@ -211,6 +220,15 @@ jobs:
     await expect(checkGitHubActionPins(root)).resolves.toEqual([
       expect.objectContaining({ message: expect.stringContaining("actions/checkout@v6") }),
     ])
+  })
+
+  it("allows a pinned aliased reusable-workflow job with a version comment", async () => {
+    const reference = "owner/repo/.github/workflows/build.yml@1234567890abcdef1234567890abcdef12345678"
+    const root = await createFixture({
+      ".github/workflows/ci.yml": `job: &call\n  uses: ${reference}\njobs:\n  call: *call # v1.2.3\n`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([])
   })
 
   it("inspects action fields whose mapping keys are aliases", async () => {

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -1,0 +1,111 @@
+import { spawnSync } from "node:child_process"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, resolve } from "node:path"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  checkGitHubActionPins,
+  findGitHubActionPolicyFiles,
+} from "../.github/scripts/check-action-pins.mjs"
+
+const repoRoot = resolve(import.meta.dirname, "..")
+const scriptPath = resolve(repoRoot, ".github/scripts/check-action-pins.mjs")
+const pinnedCheckout = "actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0"
+const temporaryDirectories: string[] = []
+
+async function createFixture(files: Record<string, string>) {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-action-policy-"))
+  temporaryDirectories.push(root)
+  for (const [path, source] of Object.entries(files)) {
+    const destination = resolve(root, path)
+    await mkdir(resolve(destination, ".."), { recursive: true })
+    await writeFile(destination, source)
+  }
+  return root
+}
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map(path => rm(path, { force: true, recursive: true })))
+})
+
+describe("GitHub Action pin policy", () => {
+  it("parses every repository workflow and composite action", async () => {
+    const files = await findGitHubActionPolicyFiles(repoRoot)
+
+    expect(files.map(path => path.replace(`${repoRoot}/`, ""))).toEqual([
+      ".github/actions/setup-deno/action.yml",
+      ".github/actions/setup/action.yml",
+      ".github/workflows/ci.yml",
+      ".github/workflows/live-smoke.yml",
+      ".github/workflows/pkg-pr-new.yml",
+      ".github/workflows/pullfrog.yml",
+      ".github/workflows/release.yml",
+    ])
+    await expect(checkGitHubActionPins(repoRoot)).resolves.toEqual([])
+  })
+
+  it("allows full commit pins with version comments and local actions", async () => {
+    const root = await createFixture({
+      ".github/actions/setup/action.yaml": `runs:\n  using: composite\n  steps:\n    - uses: ${pinnedCheckout}\n`,
+      ".github/workflows/ci.yaml": "jobs:\n  test:\n    steps:\n      - { uses: './.github/actions/setup' }\n",
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([])
+  })
+
+  it.each([
+    ["movable tag", "actions/checkout@v6 # v6.1.0", "full 40-character commit SHA"],
+    ["missing version comment", pinnedCheckout.split(" #")[0], "exact version comment"],
+    ["branch reference in a flow mapping", "actions/checkout@main", "full 40-character commit SHA"],
+  ])("rejects a %s", async (_name, reference, message) => {
+    const root = await createFixture({
+      ".github/workflows/ci.yml": `jobs:\n  test:\n    steps:\n      - { uses: "${reference}" }\n`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([
+      expect.objectContaining({ line: 4, message: expect.stringContaining(message), path: ".github/workflows/ci.yml" }),
+    ])
+  })
+
+  it("rejects malformed YAML and non-string uses values", async () => {
+    const malformedRoot = await createFixture({
+      ".github/workflows/broken.yml": "jobs: [\n",
+    })
+    const nonStringRoot = await createFixture({
+      ".github/workflows/ci.yml": "jobs:\n  test:\n    steps:\n      - uses:\n          action: checkout\n",
+    })
+
+    await expect(checkGitHubActionPins(malformedRoot)).resolves.toEqual([
+      expect.objectContaining({ message: expect.stringContaining("invalid YAML") }),
+    ])
+    await expect(checkGitHubActionPins(nonStringRoot)).resolves.toEqual([
+      expect.objectContaining({ message: "uses must be a string" }),
+    ])
+  })
+
+  it("has stable success, policy failure, and usage-error CLI contracts", async () => {
+    const passingRoot = await createFixture({
+      ".github/workflows/ci.yml": `steps:\n  - uses: ${pinnedCheckout}\n`,
+    })
+    const failingRoot = await createFixture({
+      ".github/workflows/ci.yml": "steps:\n  - uses: actions/checkout@v6\n",
+    })
+
+    const passing = spawnSync(process.execPath, [scriptPath, passingRoot], { encoding: "utf8" })
+    expect(passing).toMatchObject({ status: 0, stderr: "", stdout: "GitHub Action references are pinned.\n" })
+
+    const failing = spawnSync(process.execPath, [scriptPath, failingRoot], { encoding: "utf8" })
+    expect(failing.status).toBe(1)
+    expect(failing.stdout).toBe("")
+    expect(failing.stderr).toContain(".github/workflows/ci.yml:2: external action must use a full 40-character commit SHA")
+
+    const usageError = spawnSync(process.execPath, [scriptPath, passingRoot, failingRoot], { encoding: "utf8" })
+    expect(usageError).toMatchObject({
+      status: 2,
+      stderr: "Usage: node .github/scripts/check-action-pins.mjs [repo-root]\n",
+      stdout: "",
+    })
+  })
+})

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -93,6 +93,20 @@ describe("GitHub Action pin policy", () => {
     ])
   })
 
+  it("classifies nested action manifests under .github/workflows as actions", async () => {
+    const root = await createFixture({
+      ".github/workflows/actions/setup/action.yml": "runs:\n  using: composite\n  steps:\n    - uses: actions/checkout@v6\n",
+      ".github/workflows/ci.yml": "jobs:\n  test:\n    steps:\n      - uses: ./github/workflows/actions/setup\n",
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining("full 40-character commit SHA"),
+        path: ".github/workflows/actions/setup/action.yml",
+      }),
+    ])
+  })
+
   it("follows symlinked composite action manifests", async () => {
     const root = await createFixture({
       ".github/workflows/ci.yml": "steps:\n  - uses: ./tools/setup\n",
@@ -124,6 +138,27 @@ describe("GitHub Action pin policy", () => {
     })
 
     await expect(checkGitHubActionPins(root)).resolves.toEqual([])
+  })
+
+  it("inspects action references through aliased step containers and steps", async () => {
+    const root = await createFixture({
+      ".github/workflows/ci.yml": `step: &unpinned-step
+  uses: actions/checkout@v6
+steps: &unpinned-steps
+  - uses: actions/setup-node@v6
+jobs:
+  container-alias:
+    steps: *unpinned-steps
+  step-alias:
+    steps:
+      - *unpinned-step
+`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([
+      expect.objectContaining({ message: expect.stringContaining("actions/setup-node@v6") }),
+      expect.objectContaining({ message: expect.stringContaining("actions/checkout@v6") }),
+    ])
   })
 
   it.each([

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -161,6 +161,19 @@ describe("GitHub Action pin policy", () => {
     await expect(checkGitHubActionPins(root)).resolves.toEqual([])
   })
 
+  it("does not share an enclosing jobs version comment across reusable workflows", async () => {
+    const first = "owner/repo/.github/workflows/first.yml@1234567890abcdef1234567890abcdef12345678"
+    const second = "owner/repo/.github/workflows/second.yml@abcdef1234567890abcdef1234567890abcdef12"
+    const root = await createFixture({
+      ".github/workflows/ci.yml": `jobs: { first: { uses: "${first}" }, second: { uses: "${second}" } } # v1.2.3\n`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([
+      expect.objectContaining({ message: expect.stringContaining(first) }),
+      expect.objectContaining({ message: expect.stringContaining(second) }),
+    ])
+  })
+
   it("allows pinned action references through YAML aliases", async () => {
     const reference = pinnedCheckout.split(" #")[0]
     const root = await createFixture({

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -55,6 +55,15 @@ describe("GitHub Action pin policy", () => {
     await expect(checkGitHubActionPins(root)).resolves.toEqual([])
   })
 
+  it("ignores uses keys outside action invocation fields", async () => {
+    const root = await createFixture({
+      ".github/actions/setup/action.yml": `inputs:\n  uses:\n    description: Not an action reference\nruns:\n  using: composite\n  steps:\n    - uses: ${pinnedCheckout}\n`,
+      ".github/workflows/ci.yml": `env:\n  uses: not-an-action-reference\njobs:\n  test:\n    env:\n      uses: still-not-an-action-reference\n    steps:\n      - uses: ${pinnedCheckout}\n`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([])
+  })
+
   it("finds composite actions outside .github/actions", async () => {
     const root = await createFixture({
       ".github/workflows/ci.yml": "steps:\n  - uses: ./tools/setup\n",
@@ -101,10 +110,10 @@ describe("GitHub Action pin policy", () => {
 
   it("has stable success, policy failure, and usage-error CLI contracts", async () => {
     const passingRoot = await createFixture({
-      ".github/workflows/ci.yml": `steps:\n  - uses: ${pinnedCheckout}\n`,
+      ".github/workflows/ci.yml": `jobs:\n  test:\n    steps:\n      - uses: ${pinnedCheckout}\n`,
     })
     const failingRoot = await createFixture({
-      ".github/workflows/ci.yml": "steps:\n  - uses: actions/checkout@v6\n",
+      ".github/workflows/ci.yml": "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@v6\n",
     })
 
     const passing = spawnSync(process.execPath, [scriptPath, passingRoot], { encoding: "utf8" })
@@ -113,7 +122,7 @@ describe("GitHub Action pin policy", () => {
     const failing = spawnSync(process.execPath, [scriptPath, failingRoot], { encoding: "utf8" })
     expect(failing.status).toBe(1)
     expect(failing.stdout).toBe("")
-    expect(failing.stderr).toContain(".github/workflows/ci.yml:2: external action must use a full 40-character commit SHA")
+    expect(failing.stderr).toContain(".github/workflows/ci.yml:4: external action must use a full 40-character commit SHA")
 
     const usageError = spawnSync(process.execPath, [scriptPath, passingRoot, failingRoot], { encoding: "utf8" })
     expect(usageError).toMatchObject({

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -56,6 +56,25 @@ describe("GitHub Action pin policy", () => {
     await expect(checkGitHubActionPins(root)).resolves.toEqual([])
   })
 
+  it("allows Docker actions pinned to full SHA-256 digests", async () => {
+    const digest = "1a".repeat(32)
+    const root = await createFixture({
+      ".github/workflows/ci.yml": `jobs:\n  test:\n    steps:\n      - uses: docker://alpine@sha256:${digest} # v3.22.1\n`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([])
+  })
+
+  it("rejects Docker actions that use movable tags", async () => {
+    const root = await createFixture({
+      ".github/workflows/ci.yml": "jobs:\n  test:\n    steps:\n      - uses: docker://alpine:3.22\n",
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([
+      expect.objectContaining({ message: expect.stringContaining("full SHA-256 digest") }),
+    ])
+  })
+
   it("ignores uses keys outside action invocation fields", async () => {
     const root = await createFixture({
       ".github/actions/setup/action.yml": `inputs:\n  uses:\n    description: Not an action reference\nruns:\n  using: composite\n  steps:\n    - uses: ${pinnedCheckout}\n`,

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -116,6 +116,16 @@ describe("GitHub Action pin policy", () => {
     await expect(checkGitHubActionPins(root)).resolves.toEqual([])
   })
 
+  it("allows pinned action references through YAML aliases", async () => {
+    const reference = pinnedCheckout.split(" #")[0]
+    const root = await createFixture({
+      ".github/actions/setup/action.yml": `inputs:\n  checkout:\n    default: &checkout ${reference}\nruns:\n  using: composite\n  steps:\n    - uses: *checkout # v6.1.0\n`,
+      ".github/workflows/ci.yml": `env:\n  CHECKOUT: &checkout ${reference}\njobs:\n  test:\n    steps:\n      - uses: *checkout # v6.1.0\n`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([])
+  })
+
   it.each([
     ["movable tag", "actions/checkout@v6 # v6.1.0", "full 40-character commit SHA"],
     ["missing version comment", pinnedCheckout.split(" #")[0], "exact version comment"],

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -143,6 +143,19 @@ describe("GitHub Action pin policy", () => {
     await expect(checkGitHubActionPins(root)).resolves.toEqual([])
   })
 
+  it("does not share an enclosing sequence version comment across actions", async () => {
+    const first = pinnedCheckout.split(" #")[0]
+    const second = "actions/setup-node@1234567890abcdef1234567890abcdef12345678"
+    const root = await createFixture({
+      ".github/workflows/ci.yml": `jobs:\n  test:\n    steps: [{ uses: "${first}" }, { uses: "${second}" }] # v6.1.0\n`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([
+      expect.objectContaining({ message: expect.stringContaining(first) }),
+      expect.objectContaining({ message: expect.stringContaining(second) }),
+    ])
+  })
+
   it("allows a pinned reusable workflow with a flow-mapping version comment", async () => {
     const reference = "owner/repo/.github/workflows/build.yml@1234567890abcdef1234567890abcdef12345678"
     const root = await createFixture({

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -107,6 +107,19 @@ describe("GitHub Action pin policy", () => {
     ])
   })
 
+  it("classifies a direct workflow named action.yml as a workflow", async () => {
+    const root = await createFixture({
+      ".github/workflows/action.yml": "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@v6\n",
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining("full 40-character commit SHA"),
+        path: ".github/workflows/action.yml",
+      }),
+    ])
+  })
+
   it("follows symlinked composite action manifests", async () => {
     const root = await createFixture({
       ".github/workflows/ci.yml": "steps:\n  - uses: ./tools/setup\n",

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "node:child_process"
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 
@@ -91,6 +91,29 @@ describe("GitHub Action pin policy", () => {
         path: "tools/setup/action.yml",
       }),
     ])
+  })
+
+  it("follows symlinked composite action manifests", async () => {
+    const root = await createFixture({
+      ".github/workflows/ci.yml": "steps:\n  - uses: ./tools/setup\n",
+      "tools/setup/composite.yml": "runs:\n  using: composite\n  steps:\n    - uses: actions/checkout@v6\n",
+    })
+    await symlink("composite.yml", resolve(root, "tools/setup/action.yml"))
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining("full 40-character commit SHA"),
+        path: "tools/setup/action.yml",
+      }),
+    ])
+  })
+
+  it("allows a pinned action with a flow-mapping version comment", async () => {
+    const root = await createFixture({
+      ".github/workflows/ci.yml": `jobs:\n  test:\n    steps:\n      - { uses: "${pinnedCheckout.split(" #")[0]}" } # v6.1.0\n`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([])
   })
 
   it.each([

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -183,6 +183,21 @@ jobs:
     ])
   })
 
+  it("allows a pinned aliased step with a version comment", async () => {
+    const reference = pinnedCheckout.split(" #")[0]
+    const root = await createFixture({
+      ".github/workflows/ci.yml": `step: &checkout
+  uses: ${reference}
+jobs:
+  test:
+    steps:
+      - *checkout # v6.1.0
+`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([])
+  })
+
   it("inspects action references through aliased workflow jobs", async () => {
     const root = await createFixture({
       ".github/workflows/ci.yml": `job: &unpinned-job

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -55,6 +55,20 @@ describe("GitHub Action pin policy", () => {
     await expect(checkGitHubActionPins(root)).resolves.toEqual([])
   })
 
+  it("finds composite actions outside .github/actions", async () => {
+    const root = await createFixture({
+      ".github/workflows/ci.yml": "steps:\n  - uses: ./tools/setup\n",
+      "tools/setup/action.yml": "runs:\n  using: composite\n  steps:\n    - uses: actions/checkout@v6\n",
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining("full 40-character commit SHA"),
+        path: "tools/setup/action.yml",
+      }),
+    ])
+  })
+
   it.each([
     ["movable tag", "actions/checkout@v6 # v6.1.0", "full 40-character commit SHA"],
     ["missing version comment", pinnedCheckout.split(" #")[0], "exact version comment"],

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -161,6 +161,21 @@ jobs:
     ])
   })
 
+  it("inspects action references through aliased workflow jobs", async () => {
+    const root = await createFixture({
+      ".github/workflows/ci.yml": `job: &unpinned-job
+  steps:
+    - uses: actions/checkout@v6
+jobs:
+  test: *unpinned-job
+`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([
+      expect.objectContaining({ message: expect.stringContaining("actions/checkout@v6") }),
+    ])
+  })
+
   it.each([
     ["movable tag", "actions/checkout@v6 # v6.1.0", "full 40-character commit SHA"],
     ["missing version comment", pinnedCheckout.split(" #")[0], "exact version comment"],

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -93,6 +93,15 @@ describe("GitHub Action pin policy", () => {
     ])
   })
 
+  it("ignores nested YAML files that GitHub does not discover as workflows", async () => {
+    const root = await createFixture({
+      ".github/workflows/ci.yml": `jobs:\n  test:\n    steps:\n      - uses: ${pinnedCheckout}\n`,
+      ".github/workflows/fixtures/example.yml": "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@v6\n",
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([])
+  })
+
   it("classifies nested action manifests under .github/workflows as actions", async () => {
     const root = await createFixture({
       ".github/workflows/actions/setup/action.yml": "runs:\n  using: composite\n  steps:\n    - uses: actions/checkout@v6\n",

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -130,6 +130,15 @@ describe("GitHub Action pin policy", () => {
     await expect(checkGitHubActionPins(root)).resolves.toEqual([])
   })
 
+  it("allows a pinned reusable workflow with a flow-mapping version comment", async () => {
+    const reference = "owner/repo/.github/workflows/build.yml@1234567890abcdef1234567890abcdef12345678"
+    const root = await createFixture({
+      ".github/workflows/ci.yml": `jobs:\n  call: { uses: "${reference}" } # v1.2.3\n`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([])
+  })
+
   it("allows pinned action references through YAML aliases", async () => {
     const reference = pinnedCheckout.split(" #")[0]
     const root = await createFixture({
@@ -173,6 +182,18 @@ jobs:
 
     await expect(checkGitHubActionPins(root)).resolves.toEqual([
       expect.objectContaining({ message: expect.stringContaining("actions/checkout@v6") }),
+    ])
+  })
+
+  it("inspects action fields whose mapping keys are aliases", async () => {
+    const root = await createFixture({
+      ".github/actions/setup/action.yml": `inputs:\n  uses-key:\n    default: &uses-key uses\n  steps-key:\n    default: &steps-key steps\n  runs-key:\n    default: &runs-key runs\n? *runs-key\n:\n  using: composite\n  ? *steps-key\n  :\n    - ? *uses-key\n      : actions/checkout@v6\n`,
+      ".github/workflows/ci.yml": `env:\n  JOBS_KEY: &jobs-key jobs\n  STEPS_KEY: &steps-key steps\n  USES_KEY: &uses-key uses\n? *jobs-key\n:\n  test:\n    ? *steps-key\n    :\n      - ? *uses-key\n        : actions/setup-node@v6\n`,
+    })
+
+    await expect(checkGitHubActionPins(root)).resolves.toEqual([
+      expect.objectContaining({ message: expect.stringContaining("actions/checkout@v6") }),
+      expect.objectContaining({ message: expect.stringContaining("actions/setup-node@v6") }),
     ])
   })
 

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from "vitest"
 import {
   checkGitHubActionPins,
   findGitHubActionPolicyFiles,
+  inspectGitHubActionReferences,
 } from "../.github/scripts/check-action-pins.mjs"
 
 const repoRoot = resolve(import.meta.dirname, "..")
@@ -62,6 +63,20 @@ describe("GitHub Action pin policy", () => {
     })
 
     await expect(checkGitHubActionPins(root)).resolves.toEqual([])
+  })
+
+  it("classifies Windows-style workflow paths", () => {
+    const failures = inspectGitHubActionReferences(
+      ".github\\workflows\\ci.yml",
+      "jobs:\n  test:\n    steps:\n      - uses: actions/checkout@v6\n",
+    )
+
+    expect(failures).toEqual([
+      expect.objectContaining({
+        message: expect.stringContaining("full 40-character commit SHA"),
+        path: ".github\\workflows\\ci.yml",
+      }),
+    ])
   })
 
   it("finds composite actions outside .github/actions", async () => {

--- a/test/github-actions-policy.test.ts
+++ b/test/github-actions-policy.test.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from "node:child_process"
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join, resolve } from "node:path"
+import { join, relative, resolve } from "node:path"
 
 import { afterEach, describe, expect, it } from "vitest"
 
@@ -35,7 +35,7 @@ describe("GitHub Action pin policy", () => {
   it("parses every repository workflow and composite action", async () => {
     const files = await findGitHubActionPolicyFiles(repoRoot)
 
-    expect(files.map(path => path.replace(`${repoRoot}/`, ""))).toEqual([
+    expect(files.map(path => relative(repoRoot, path).replaceAll("\\", "/"))).toEqual([
       ".github/actions/setup-deno/action.yml",
       ".github/actions/setup/action.yml",
       ".github/workflows/ci.yml",


### PR DESCRIPTION
## Summary

- pin every external workflow and composite Action to its verified upstream release commit, retaining same-line version comments
- add weekly Dependabot updates for workflows and both local composite Action directories
- enforce the policy with a YAML-AST checker and repository/fixture/CLI tests while allowing local `./` actions

## Verification

- `corepack pnpm install --offline --frozen-lockfile --ignore-scripts`
- `corepack pnpm exec vp check --no-fmt .github/scripts/check-action-pins.mjs test/github-actions-policy.test.ts`
- `corepack pnpm exec vp test test/github-actions-policy.test.ts test/live-smoke-report.test.ts` (30 tests)
- `node .github/scripts/check-action-pins.mjs`
- upstream `git ls-remote` release-tag checks for all seven pinned commits
- `git diff --check`

## Repository policy

A read-only API check reports `sha_pinning_required: false`; this PR does not change repository settings. PR #1082 adds a workflow with a movable Action ref and will need to satisfy this policy when rebased. PR #1097 touches `ci.yml` in a separate test-step hunk.