### PR TITLE
fix(cli): exit after flushing output

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -245,12 +245,21 @@ function trackStream(stream: ViteHubCliStream) {
     },
     async flush() {
       const results = await Promise.all(writes)
+      let flushFailure: { reason: unknown } | undefined
+      try {
+        if (stream.flush) {
+          await stream.flush()
+        }
+      }
+      catch (error: unknown) {
+        flushFailure = { reason: error }
+      }
       const rejected = results.find(result => result.status === "rejected")
       if (rejected) {
         throw rejected.reason
       }
-      if (stream.flush) {
-        await stream.flush()
+      if (flushFailure) {
+        throw flushFailure.reason
       }
     },
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -229,20 +229,26 @@ export async function runViteHubCli(options: RunViteHubCliOptions = {}): Promise
 }
 
 function trackStream(stream: ViteHubCliStream) {
-  const writes = new Set<Promise<unknown>>()
+  const writes: Array<Promise<PromiseSettledResult<unknown>>> = []
   return {
     stream: {
       write(chunk: string | Uint8Array) {
         const result = stream.write(chunk)
         if (result && typeof (result as PromiseLike<unknown>).then === "function") {
-          const write = Promise.resolve(result).then(() => {}, () => {}).finally(() => writes.delete(write))
-          writes.add(write)
+          writes.push(Promise.resolve(result).then<PromiseSettledResult<unknown>>(
+            value => ({ status: "fulfilled", value }),
+            reason => ({ reason, status: "rejected" }),
+          ))
         }
         return result
       },
     },
     async flush() {
-      await Promise.allSettled(writes)
+      const results = await Promise.all(writes)
+      const rejected = results.find(result => result.status === "rejected")
+      if (rejected) {
+        throw rejected.reason
+      }
       if (stream.flush) {
         await stream.flush()
       }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -214,6 +214,25 @@ export async function runViteHubCli(options: RunViteHubCliOptions = {}): Promise
   return result ?? 0
 }
 
+function exitAfterStandardStreamsFlush(exitCode: number): void {
+  let pending = 2
+  const flushed = () => {
+    pending--
+    if (pending === 0) process.exit(exitCode)
+  }
+  process.stdout.write("", flushed)
+  process.stderr.write("", flushed)
+}
+
+export function runViteHubCliEntrypoint(options: RunViteHubCliOptions = {}): void {
+  runViteHubCli(options).then((exitCode) => {
+    exitAfterStandardStreamsFlush(exitCode)
+  }).catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error)
+    exitAfterStandardStreamsFlush(1)
+  })
+}
+
 function isCliEntrypoint() {
   if (!process.argv[1]) return false
   try {
@@ -225,10 +244,5 @@ function isCliEntrypoint() {
 }
 
 if (isCliEntrypoint()) {
-  runViteHubCli().then((exitCode) => {
-    process.exitCode = exitCode
-  }).catch((error: unknown) => {
-    console.error(error instanceof Error ? error.message : error)
-    process.exitCode = 1
-  })
+  runViteHubCliEntrypoint()
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -234,12 +234,10 @@ function trackStream(stream: ViteHubCliStream) {
     stream: {
       write(chunk: string | Uint8Array) {
         const result = stream.write(chunk)
-        if (result && typeof (result as PromiseLike<unknown>).then === "function") {
-          writes.push(Promise.resolve(result).then<PromiseSettledResult<unknown>, PromiseSettledResult<unknown>>(
-            value => ({ status: "fulfilled", value }),
-            reason => ({ reason, status: "rejected" }),
-          ))
-        }
+        writes.push(Promise.resolve(result).then<PromiseSettledResult<unknown>, PromiseSettledResult<unknown>>(
+          value => ({ status: "fulfilled", value }),
+          reason => ({ reason, status: "rejected" }),
+        ))
         return result
       },
     },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -220,8 +220,15 @@ function exitAfterStreamsFlush(exitCode: number, streams: ViteHubCliStreams): vo
     pending--
     if (pending === 0) process.exit(exitCode)
   }
-  streams.stdout.write("", flushed)
-  streams.stderr.write("", flushed)
+  for (const stream of [streams.stdout, streams.stderr]) {
+    if (stream.write.length < 2) {
+      stream.write("")
+      flushed()
+    }
+    else {
+      stream.write("", flushed)
+    }
+  }
 }
 
 export function runViteHubCliEntrypoint(options: RunViteHubCliOptions = {}): void {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -281,7 +281,10 @@ export function runViteHubCliEntrypoint(options: RunViteHubCliEntrypointOptions 
       exitCode = await runViteHubCli({ ...options, stderr: stderr.stream, stdout: stdout.stream })
     }
     catch (error: unknown) {
-      stderr.stream.write(`${error instanceof Error ? error.message : error}\n`)
+      try {
+        stderr.stream.write(`${error instanceof Error ? error.message : error}\n`)
+      }
+      catch {}
       exitCode = 1
     }
     const flushes = await Promise.allSettled([stdout.flush(), stderr.flush()])

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,8 +31,8 @@ type ViteHubCliSpawn = (
 ) => Promise<ViteHubCliSpawnResult>
 
 interface ViteHubCliStreams {
-  stderr: { write: (chunk: string | Uint8Array) => unknown }
-  stdout: { write: (chunk: string | Uint8Array) => unknown }
+  stderr: { write: (chunk: string | Uint8Array, callback?: () => void) => unknown }
+  stdout: { write: (chunk: string | Uint8Array, callback?: () => void) => unknown }
 }
 
 interface ViteHubCliLoadedConfig {
@@ -214,22 +214,26 @@ export async function runViteHubCli(options: RunViteHubCliOptions = {}): Promise
   return result ?? 0
 }
 
-function exitAfterStandardStreamsFlush(exitCode: number): void {
+function exitAfterStreamsFlush(exitCode: number, streams: ViteHubCliStreams): void {
   let pending = 2
   const flushed = () => {
     pending--
     if (pending === 0) process.exit(exitCode)
   }
-  process.stdout.write("", flushed)
-  process.stderr.write("", flushed)
+  streams.stdout.write("", flushed)
+  streams.stderr.write("", flushed)
 }
 
 export function runViteHubCliEntrypoint(options: RunViteHubCliOptions = {}): void {
+  const streams = {
+    stderr: options.stderr || process.stderr,
+    stdout: options.stdout || process.stdout,
+  }
   runViteHubCli(options).then((exitCode) => {
-    exitAfterStandardStreamsFlush(exitCode)
+    exitAfterStreamsFlush(exitCode, streams)
   }).catch((error: unknown) => {
-    console.error(error instanceof Error ? error.message : error)
-    exitAfterStandardStreamsFlush(1)
+    streams.stderr.write(`${error instanceof Error ? error.message : error}\n`)
+    exitAfterStreamsFlush(1, streams)
   })
 }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -269,7 +269,10 @@ export function runViteHubCliEntrypoint(options: RunViteHubCliEntrypointOptions 
       stderr.stream.write(`${error instanceof Error ? error.message : error}\n`)
       exitCode = 1
     }
-    await Promise.allSettled([stdout.flush(), stderr.flush()])
+    const flushes = await Promise.allSettled([stdout.flush(), stderr.flush()])
+    if (flushes.some(result => result.status === "rejected")) {
+      exitCode = 1
+    }
     process.exit(exitCode)
   })()
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -31,8 +31,13 @@ type ViteHubCliSpawn = (
 ) => Promise<ViteHubCliSpawnResult>
 
 interface ViteHubCliStreams {
-  stderr: { write: (chunk: string | Uint8Array, callback?: () => void) => unknown }
-  stdout: { write: (chunk: string | Uint8Array, callback?: () => void) => unknown }
+  stderr: ViteHubCliStream
+  stdout: ViteHubCliStream
+}
+
+interface ViteHubCliStream {
+  flush?: () => unknown
+  write: (chunk: string | Uint8Array, callback?: () => void) => unknown
 }
 
 interface ViteHubCliLoadedConfig {
@@ -214,33 +219,46 @@ export async function runViteHubCli(options: RunViteHubCliOptions = {}): Promise
   return result ?? 0
 }
 
-function exitAfterStreamsFlush(exitCode: number, streams: ViteHubCliStreams): void {
-  let pending = 2
-  const flushed = () => {
-    pending--
-    if (pending === 0) process.exit(exitCode)
-  }
-  for (const stream of [streams.stdout, streams.stderr]) {
-    if (stream.write.length < 2) {
-      Promise.resolve(stream.write("")).then(flushed, flushed)
-    }
-    else {
-      stream.write("", flushed)
-    }
+function trackStream(stream: ViteHubCliStream) {
+  const writes = new Set<Promise<unknown>>()
+  return {
+    stream: {
+      write(chunk: string | Uint8Array) {
+        const result = stream.write(chunk)
+        if (result && typeof (result as PromiseLike<unknown>).then === "function") {
+          const write = Promise.resolve(result).then(() => {}, () => {}).finally(() => writes.delete(write))
+          writes.add(write)
+        }
+        return result
+      },
+    },
+    async flush() {
+      await Promise.allSettled(writes)
+      if (stream.flush) {
+        await stream.flush()
+      }
+      else if (stream === process.stdout || stream === process.stderr) {
+        await new Promise<void>(resolveFlush => stream.write("", resolveFlush))
+      }
+    },
   }
 }
 
 export function runViteHubCliEntrypoint(options: RunViteHubCliOptions = {}): void {
-  const streams = {
-    stderr: options.stderr || process.stderr,
-    stdout: options.stdout || process.stdout,
-  }
-  runViteHubCli(options).then((exitCode) => {
-    exitAfterStreamsFlush(exitCode, streams)
-  }).catch((error: unknown) => {
-    streams.stderr.write(`${error instanceof Error ? error.message : error}\n`)
-    exitAfterStreamsFlush(1, streams)
-  })
+  const stderr = trackStream(options.stderr || process.stderr)
+  const stdout = trackStream(options.stdout || process.stdout)
+  void (async () => {
+    let exitCode: number
+    try {
+      exitCode = await runViteHubCli({ ...options, stderr: stderr.stream, stdout: stdout.stream })
+    }
+    catch (error: unknown) {
+      stderr.stream.write(`${error instanceof Error ? error.message : error}\n`)
+      exitCode = 1
+    }
+    await Promise.allSettled([stdout.flush(), stderr.flush()])
+    process.exit(exitCode)
+  })()
 }
 
 function isCliEntrypoint() {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -235,7 +235,7 @@ function trackStream(stream: ViteHubCliStream) {
       write(chunk: string | Uint8Array) {
         const result = stream.write(chunk)
         if (result && typeof (result as PromiseLike<unknown>).then === "function") {
-          writes.push(Promise.resolve(result).then<PromiseSettledResult<unknown>>(
+          writes.push(Promise.resolve(result).then<PromiseSettledResult<unknown>, PromiseSettledResult<unknown>>(
             value => ({ status: "fulfilled", value }),
             reason => ({ reason, status: "rejected" }),
           ))
@@ -267,7 +267,14 @@ function trackStream(stream: ViteHubCliStream) {
 
 function processEntrypointStream(stream: NodeJS.WriteStream): ViteHubCliEntrypointStream {
   return {
-    flush: () => new Promise<void>(resolveFlush => stream.write("", () => resolveFlush())),
+    flush: () => new Promise<void>((resolveFlush, rejectFlush) => stream.write("", (error) => {
+      if (error) {
+        rejectFlush(error)
+      }
+      else {
+        resolveFlush()
+      }
+    })),
     write: chunk => stream.write(chunk),
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -37,8 +37,12 @@ interface ViteHubCliStreams {
 
 interface ViteHubCliStream {
   flush?: () => unknown
-  write: (chunk: string | Uint8Array, callback?: () => void) => unknown
+  write: (chunk: string | Uint8Array) => unknown
 }
+
+type ViteHubCliEntrypointStream =
+  | { flush: () => unknown, write: (chunk: string | Uint8Array) => unknown }
+  | { flush?: never, write: (chunk: string | Uint8Array) => void | PromiseLike<unknown> }
 
 interface ViteHubCliLoadedConfig {
   plugins: readonly unknown[]
@@ -55,6 +59,11 @@ export interface RunViteHubCliOptions {
   spawn?: ViteHubCliSpawn
   stderr?: ViteHubCliStreams["stderr"]
   stdout?: ViteHubCliStreams["stdout"]
+}
+
+export interface RunViteHubCliEntrypointOptions extends Omit<RunViteHubCliOptions, "stderr" | "stdout"> {
+  stderr?: ViteHubCliEntrypointStream
+  stdout?: ViteHubCliEntrypointStream
 }
 
 async function loadNuxtViteConfig(rootDir: string): Promise<{ plugins: readonly unknown[], root?: string } | undefined> {
@@ -237,16 +246,20 @@ function trackStream(stream: ViteHubCliStream) {
       if (stream.flush) {
         await stream.flush()
       }
-      else if (stream === process.stdout || stream === process.stderr) {
-        await new Promise<void>(resolveFlush => stream.write("", resolveFlush))
-      }
     },
   }
 }
 
-export function runViteHubCliEntrypoint(options: RunViteHubCliOptions = {}): void {
-  const stderr = trackStream(options.stderr || process.stderr)
-  const stdout = trackStream(options.stdout || process.stdout)
+function processEntrypointStream(stream: NodeJS.WriteStream): ViteHubCliEntrypointStream {
+  return {
+    flush: () => new Promise<void>(resolveFlush => stream.write("", () => resolveFlush())),
+    write: chunk => stream.write(chunk),
+  }
+}
+
+export function runViteHubCliEntrypoint(options: RunViteHubCliEntrypointOptions = {}): void {
+  const stderr = trackStream(options.stderr || processEntrypointStream(process.stderr))
+  const stdout = trackStream(options.stdout || processEntrypointStream(process.stdout))
   void (async () => {
     let exitCode: number
     try {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -222,8 +222,7 @@ function exitAfterStreamsFlush(exitCode: number, streams: ViteHubCliStreams): vo
   }
   for (const stream of [streams.stdout, streams.stderr]) {
     if (stream.write.length < 2) {
-      stream.write("")
-      flushed()
+      Promise.resolve(stream.write("")).then(flushed, flushed)
     }
     else {
       stream.write("", flushed)

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -98,6 +98,39 @@ describe("ViteHub CLI", () => {
     expect(stdout.output()).toContain("Usage: vitehub")
   })
 
+  it("awaits asynchronous callback-less entrypoint streams before exiting", async () => {
+    const flushes: Array<() => void> = []
+    const createStream = () => ({
+      output: "",
+      write(chunk: string | Uint8Array) {
+        this.output += String(chunk)
+        return new Promise<void>(resolve => flushes.push(resolve))
+      },
+    })
+    const stdout = createStream()
+    const stderr = createStream()
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
+
+    runViteHubCliEntrypoint({
+      args: ["--help"],
+      loadConfig: async () => ({
+        plugins: [],
+        root: "/repo",
+      }),
+      stderr,
+      stdout,
+    })
+    await vi.waitFor(() => expect(flushes).toHaveLength(2))
+
+    expect(stdout.output).toContain("Usage: vitehub")
+    expect(exit).not.toHaveBeenCalled()
+    flushes.shift()!()
+    await Promise.resolve()
+    expect(exit).not.toHaveBeenCalled()
+    flushes.shift()!()
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0))
+  })
+
   it("routes package-contributed CLI features", async () => {
     const stdout = stream()
     const stderr = stream()

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -50,9 +50,12 @@ describe("ViteHub CLI", () => {
     const callbacks: Array<() => void> = []
     const createStream = () => ({
       output: "",
-      write(chunk: string | Uint8Array, callback?: () => void) {
+      flush() {
+        return new Promise<void>(resolve => callbacks.push(resolve))
+      },
+      write(chunk: string | Uint8Array, callback: () => void = () => {}) {
         this.output += String(chunk)
-        if (callback) callbacks.push(callback)
+        callback()
         return true
       },
     })
@@ -120,12 +123,9 @@ describe("ViteHub CLI", () => {
       stderr,
       stdout,
     })
-    await vi.waitFor(() => expect(flushes).toHaveLength(2))
+    await vi.waitFor(() => expect(flushes).toHaveLength(1))
 
     expect(stdout.output).toContain("Usage: vitehub")
-    expect(exit).not.toHaveBeenCalled()
-    flushes.shift()!()
-    await Promise.resolve()
     expect(exit).not.toHaveBeenCalled()
     flushes.shift()!()
     await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0))

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -60,6 +60,7 @@ describe("ViteHub CLI", () => {
     })
     const stdout = createStream()
     const stderr = createStream()
+    // SAFETY: The mock deliberately returns so tests can observe the requested exit status.
     const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
 
     runViteHubCliEntrypoint({
@@ -90,6 +91,7 @@ describe("ViteHub CLI", () => {
       flush: () => undefined,
       write: vi.fn(),
     }
+    // SAFETY: The mock deliberately returns so tests can observe the requested exit status.
     const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
 
     runViteHubCliEntrypoint({
@@ -106,6 +108,7 @@ describe("ViteHub CLI", () => {
   })
 
   it("exits unsuccessfully when the process stream fails to flush", async () => {
+    // SAFETY: The mock implements the callback overload used by the production flush barrier.
     const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(((
       _chunk: string | Uint8Array,
       callback?: (error?: Error | null) => void,
@@ -113,6 +116,7 @@ describe("ViteHub CLI", () => {
       callback?.(new Error("write failed"))
       return false
     }) as typeof process.stdout.write)
+    // SAFETY: The mock deliberately returns so tests can observe the requested exit status.
     const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
 
     runViteHubCliEntrypoint({
@@ -131,6 +135,7 @@ describe("ViteHub CLI", () => {
   it("exits with callback-less configured entrypoint streams", async () => {
     const stdout = stream()
     const stderr = stream()
+    // SAFETY: The mock deliberately returns so tests can observe the requested exit status.
     const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
 
     runViteHubCliEntrypoint({
@@ -158,6 +163,7 @@ describe("ViteHub CLI", () => {
     })
     const stdout = createStream()
     const stderr = createStream()
+    // SAFETY: The mock deliberately returns so tests can observe the requested exit status.
     const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
 
     runViteHubCliEntrypoint({
@@ -184,6 +190,7 @@ describe("ViteHub CLI", () => {
       write: () => Promise.reject(new Error("write failed")),
     }
     const stderr = stream()
+    // SAFETY: The mock deliberately returns so tests can observe the requested exit status.
     const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
 
     runViteHubCliEntrypoint({
@@ -203,6 +210,7 @@ describe("ViteHub CLI", () => {
   it("flushes and exits when reporting an error throws synchronously", async () => {
     const stdoutFlush = vi.fn()
     const stderrFlush = vi.fn()
+    // SAFETY: The mock deliberately returns so tests can observe the requested exit status.
     const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
 
     runViteHubCliEntrypoint({

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -79,6 +79,25 @@ describe("ViteHub CLI", () => {
     expect(exit).toHaveBeenCalledWith(0)
   })
 
+  it("exits with callback-less configured entrypoint streams", async () => {
+    const stdout = stream()
+    const stderr = stream()
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
+
+    runViteHubCliEntrypoint({
+      args: ["--help"],
+      loadConfig: async () => ({
+        plugins: [],
+        root: "/repo",
+      }),
+      stderr,
+      stdout,
+    })
+
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0))
+    expect(stdout.output()).toContain("Usage: vitehub")
+  })
+
   it("routes package-contributed CLI features", async () => {
     const stdout = stream()
     const stderr = stream()

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -105,6 +105,29 @@ describe("ViteHub CLI", () => {
     await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1))
   })
 
+  it("exits unsuccessfully when the process stream fails to flush", async () => {
+    const stdoutWrite = vi.spyOn(process.stdout, "write").mockImplementation(((
+      _chunk: string | Uint8Array,
+      callback?: (error?: Error | null) => void,
+    ) => {
+      callback?.(new Error("write failed"))
+      return false
+    }) as typeof process.stdout.write)
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
+
+    runViteHubCliEntrypoint({
+      args: ["--help"],
+      loadConfig: async () => ({
+        plugins: [],
+        root: "/repo",
+      }),
+      stderr: stream(),
+    })
+
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1))
+    expect(stdoutWrite).toHaveBeenCalledWith("", expect.any(Function))
+  })
+
   it("exits with callback-less configured entrypoint streams", async () => {
     const stdout = stream()
     const stderr = stream()

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -154,6 +154,26 @@ describe("ViteHub CLI", () => {
     await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0))
   })
 
+  it("exits unsuccessfully when an asynchronous callback-less write fails", async () => {
+    const stdout = {
+      write: () => Promise.reject(new Error("write failed")),
+    }
+    const stderr = stream()
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
+
+    runViteHubCliEntrypoint({
+      args: ["--help"],
+      loadConfig: async () => ({
+        plugins: [],
+        root: "/repo",
+      }),
+      stderr,
+      stdout,
+    })
+
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1))
+  })
+
   it("routes package-contributed CLI features", async () => {
     const stdout = stream()
     const stderr = stream()

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -78,7 +78,31 @@ describe("ViteHub CLI", () => {
     callbacks.shift()!()
     expect(exit).not.toHaveBeenCalled()
     callbacks.shift()!()
-    expect(exit).toHaveBeenCalledWith(0)
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(0))
+  })
+
+  it("exits unsuccessfully when a configured entrypoint stream fails to flush", async () => {
+    const stdout = {
+      flush: () => Promise.reject(new Error("flush failed")),
+      write: vi.fn(),
+    }
+    const stderr = {
+      flush: () => undefined,
+      write: vi.fn(),
+    }
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
+
+    runViteHubCliEntrypoint({
+      args: ["--help"],
+      loadConfig: async () => ({
+        plugins: [],
+        root: "/repo",
+      }),
+      stderr,
+      stdout,
+    })
+
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1))
   })
 
   it("exits with callback-less configured entrypoint streams", async () => {

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -40,7 +40,6 @@ function stream() {
     output: () => value,
     write(chunk: string | Uint8Array) {
       value += String(chunk)
-      return true
     },
   }
 }

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -4,11 +4,12 @@ import { join } from "node:path"
 
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { runViteHubCli } from "../src/index.ts"
+import { runViteHubCli, runViteHubCliEntrypoint } from "../src/index.ts"
 
 const directories: string[] = []
 
 afterEach(async () => {
+  vi.restoreAllMocks()
   await Promise.all(directories.splice(0).map(dir => rm(dir, { force: true, recursive: true })))
 })
 
@@ -45,6 +46,39 @@ function stream() {
 }
 
 describe("ViteHub CLI", () => {
+  it("flushes configured entrypoint streams before exiting", async () => {
+    const callbacks: Array<() => void> = []
+    const createStream = () => ({
+      output: "",
+      write(chunk: string | Uint8Array, callback?: () => void) {
+        this.output += String(chunk)
+        if (callback) callbacks.push(callback)
+        return true
+      },
+    })
+    const stdout = createStream()
+    const stderr = createStream()
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
+
+    runViteHubCliEntrypoint({
+      args: ["--help"],
+      loadConfig: async () => ({
+        plugins: [],
+        root: "/repo",
+      }),
+      stderr,
+      stdout,
+    })
+    await vi.waitFor(() => expect(callbacks).toHaveLength(2))
+
+    expect(stdout.output).toContain("Usage: vitehub")
+    expect(exit).not.toHaveBeenCalled()
+    callbacks.shift()!()
+    expect(exit).not.toHaveBeenCalled()
+    callbacks.shift()!()
+    expect(exit).toHaveBeenCalledWith(0)
+  })
+
   it("routes package-contributed CLI features", async () => {
     const stdout = stream()
     const stderr = stream()

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -177,6 +177,34 @@ describe("ViteHub CLI", () => {
     expect(flush).toHaveBeenCalledOnce()
   })
 
+  it("flushes and exits when reporting an error throws synchronously", async () => {
+    const stdoutFlush = vi.fn()
+    const stderrFlush = vi.fn()
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
+
+    runViteHubCliEntrypoint({
+      args: ["missing"],
+      loadConfig: async () => ({
+        plugins: [],
+        root: "/repo",
+      }),
+      stderr: {
+        flush: stderrFlush,
+        write: () => {
+          throw new Error("write failed")
+        },
+      },
+      stdout: {
+        flush: stdoutFlush,
+        write: vi.fn(),
+      },
+    })
+
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1))
+    expect(stdoutFlush).toHaveBeenCalledOnce()
+    expect(stderrFlush).toHaveBeenCalledOnce()
+  })
+
   it("routes package-contributed CLI features", async () => {
     const stdout = stream()
     const stderr = stream()

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -155,7 +155,9 @@ describe("ViteHub CLI", () => {
   })
 
   it("exits unsuccessfully when an asynchronous callback-less write fails", async () => {
+    const flush = vi.fn()
     const stdout = {
+      flush,
       write: () => Promise.reject(new Error("write failed")),
     }
     const stderr = stream()
@@ -172,6 +174,7 @@ describe("ViteHub CLI", () => {
     })
 
     await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1))
+    expect(flush).toHaveBeenCalledOnce()
   })
 
   it("routes package-contributed CLI features", async () => {

--- a/packages/vite-hub/src/bin.ts
+++ b/packages/vite-hub/src/bin.ts
@@ -1,22 +1,5 @@
 #!/usr/bin/env node
-import process from "node:process"
-
-import { runViteHubCli } from "@vite-hub/cli"
+import { runViteHubCliEntrypoint } from "@vite-hub/cli"
 import { loadViteHubCliConfig } from "./internal/cli-config.ts"
 
-function exitAfterStandardStreamsFlush(exitCode: number): void {
-  let pending = 2
-  const flushed = () => {
-    pending--
-    if (pending === 0) process.exit(exitCode)
-  }
-  process.stdout.write("", flushed)
-  process.stderr.write("", flushed)
-}
-
-runViteHubCli({ loadConfig: loadViteHubCliConfig }).then((exitCode) => {
-  exitAfterStandardStreamsFlush(exitCode)
-}).catch((error: unknown) => {
-  console.error(error instanceof Error ? error.message : error)
-  exitAfterStandardStreamsFlush(1)
-})
+runViteHubCliEntrypoint({ loadConfig: loadViteHubCliConfig })

--- a/packages/vite-hub/src/bin.ts
+++ b/packages/vite-hub/src/bin.ts
@@ -4,9 +4,19 @@ import process from "node:process"
 import { runViteHubCli } from "@vite-hub/cli"
 import { loadViteHubCliConfig } from "./internal/cli-config.ts"
 
+function exitAfterStandardStreamsFlush(exitCode: number): void {
+  let pending = 2
+  const flushed = () => {
+    pending--
+    if (pending === 0) process.exit(exitCode)
+  }
+  process.stdout.write("", flushed)
+  process.stderr.write("", flushed)
+}
+
 runViteHubCli({ loadConfig: loadViteHubCliConfig }).then((exitCode) => {
-  process.exitCode = exitCode
+  exitAfterStandardStreamsFlush(exitCode)
 }).catch((error: unknown) => {
   console.error(error instanceof Error ? error.message : error)
-  process.exitCode = 1
+  exitAfterStandardStreamsFlush(1)
 })

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -3,7 +3,7 @@ import { existsSync, globSync, readFileSync } from "node:fs"
 import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 import { promisify } from "node:util"
 
 import { describe, expect, it } from "vitest"
@@ -345,17 +345,22 @@ describe("framework package contract", () => {
   it("runs the distributed CLI entrypoint with clean help streams", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-bin-"))
     try {
-      await writeFile(join(root, "vite.config.mjs"), `
+      const keepAlive = join(root, "keep-alive.mjs")
+      await Promise.all([
+        writeFile(join(root, "vite.config.mjs"), `
 const namespaces = Array.from({ length: 4096 }, (_, index) => ({
   description: "A package-contributed command whose help output must flush before exit.",
   features: [],
   name: \`namespace-\${String(index).padStart(4, "0")}\`,
 }))
 export default { plugins: [{ name: "large-cli-help", vitehub: { cli: { namespaces } } }] }
-`)
+`),
+        writeFile(keepAlive, "setInterval(() => {}, 60_000)\n"),
+      ])
       const { stderr, stdout } = await execFileAsync(process.execPath, [`${packageRoot}/${manifest.bin.vitehub}`, "--help"], {
         cwd: root,
-        env: { ...process.env, NO_COLOR: "1" },
+        env: { ...process.env, NODE_OPTIONS: `--import=${pathToFileURL(keepAlive).href}`, NO_COLOR: "1" },
+        timeout: 5_000,
       })
 
       expect(stdout).toContain("Usage: vitehub <namespace> <feature>")

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -342,7 +342,7 @@ describe("framework package contract", () => {
     }
   })
 
-  it("runs the distributed CLI entrypoint with clean help streams", async () => {
+  it("runs both distributed CLI entrypoints with clean help streams", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-bin-"))
     try {
       const keepAlive = join(root, "keep-alive.mjs")
@@ -357,16 +357,42 @@ export default { plugins: [{ name: "large-cli-help", vitehub: { cli: { namespace
 `),
         writeFile(keepAlive, "setInterval(() => {}, 60_000)\n"),
       ])
-      const { stderr, stdout } = await execFileAsync(process.execPath, [`${packageRoot}/${manifest.bin.vitehub}`, "--help"], {
+      const entrypoints = [
+        `${packageRoot}/${manifest.bin.vitehub}`,
+        `${repoRoot}/packages/cli/dist/index.js`,
+      ]
+      for (const entrypoint of entrypoints) {
+        const { stderr, stdout } = await execFileAsync(process.execPath, [entrypoint, "--help"], {
+          cwd: root,
+          env: { ...process.env, NODE_OPTIONS: `--import=${pathToFileURL(keepAlive).href}`, NO_COLOR: "1" },
+          timeout: 5_000,
+        })
+
+        expect(stdout).toContain("Usage: vitehub <namespace> <feature>")
+        expect(stdout).toContain("namespace-4095")
+        expect(stdout).toContain("provision")
+        expect(stderr).toBe("")
+      }
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("flushes direct CLI errors before exiting despite active handles", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-cli-error-"))
+    try {
+      const keepAlive = join(root, "keep-alive.mjs")
+      await Promise.all([
+        writeFile(join(root, "vite.config.mjs"), "throw new Error('config exploded')\n"),
+        writeFile(keepAlive, "setInterval(() => {}, 60_000)\n"),
+      ])
+
+      await expect(execFileAsync(process.execPath, [`${repoRoot}/packages/cli/dist/index.js`], {
         cwd: root,
         env: { ...process.env, NODE_OPTIONS: `--import=${pathToFileURL(keepAlive).href}`, NO_COLOR: "1" },
         timeout: 5_000,
-      })
-
-      expect(stdout).toContain("Usage: vitehub <namespace> <feature>")
-      expect(stdout).toContain("namespace-4095")
-      expect(stdout).toContain("provision")
-      expect(stderr).toBe("")
+      })).rejects.toMatchObject({ code: 1, stderr: expect.stringContaining("config exploded") })
     }
     finally {
       await rm(root, { force: true, recursive: true })


### PR DESCRIPTION
## Summary

The distributed ViteHub CLI now exits after stdout and stderr flush their queued output.

Configuration modules and plugins may leave timers or other active handles behind. Commands no longer hang on those handles, while large generated help output remains complete.

## Verification

- `corepack pnpm --filter vite-hub test -- test/package.test.ts` — 10 tests passed, including a preloaded live interval and 4,096 generated namespaces
- `corepack pnpm --filter vite-hub typecheck`
- package build and publint completed as part of the package contract test
- `git diff --check`
