### PR TITLE
feat(source): add composable ignore defaults

### DIFF
--- a/docs/content/docs/server-primitives/source.md
+++ b/docs/content/docs/server-primitives/source.md
@@ -93,9 +93,11 @@ Source has no discovery or Vite Integration by itself. Import the module that re
 | `file(input)` | A path string, `{ path, workspacePath?, mediaType? }`, or inline `{ workspacePath, content, mediaType? }`. | Reads one file from the Source Context root. `workspacePath` controls the Source key. |
 | `markdown(options)` | `{ path, workspacePath?, mediaType? }` or inline `{ workspacePath, content, mediaType? }`. | Uses the `file()` contract with `text/markdown` as the default media type. Unlike `file()`, it requires an options object. |
 | `glob(options)` | `include`, `cwd`, `ignore`, `dot`, `followSymlinks`, `keyCache`, `prefix`. | Expands local files with `tinyglobby`; `keyCache: false` refreshes keys on each read path. |
-| `github(options)` | `repo`, `ref`, `root`, `auth`, `include`, `exclude`, `cache`. | Retrieves repository archive content. `auth` can be a token string or a trusted callback. |
-| `mcpResources(options)` | `server`, `include`, `exclude`, `path`, `request`, `cache`. | Reads MCP Resource content. `server` can be a client, client config, or resolver. |
+| `github(options)` | `repo`, `ref`, `root`, `auth`, `include`, `ignore`, `cache`. | Retrieves repository archive content. `auth` can be a token string or a trusted callback. |
+| `mcpResources(options)` | `server`, `include`, `ignore`, `path`, `request`, `cache`. | Reads MCP Resource content. `server` can be a client, client config, or resolver. |
 | `custom(source)` | A `Source` object. | Use when the built-in loaders do not match the origin contract. |
+
+Use `sourceIgnores` from `vite-hub/source` for reusable dependency, generated-output, media, secret, and system-file patterns. Workspace GitHub Sources apply `sourceIgnores.defaults` automatically; pass `ignore: false` to opt out or provide more patterns to extend the defaults.
 
 ### Cache options
 

--- a/packages/source/src/ignores.ts
+++ b/packages/source/src/ignores.ts
@@ -1,0 +1,45 @@
+const dependencies = Object.freeze([
+  "**/node_modules/**",
+  "**/.pnpm-store/**",
+  "**/.venv/**",
+  "**/dbt_packages/**",
+] as const)
+
+const generated = Object.freeze([
+  "**/.nuxt/**",
+  "**/.output/**",
+  "**/coverage/**",
+  "**/playwright-report/**",
+  "**/target/**",
+  "**/test-results/**",
+] as const)
+
+const media = Object.freeze(["**/*.{gif,ico,jpeg,jpg,png,webp}"] as const)
+const secrets = Object.freeze(["**/.env", "**/.env.*"] as const)
+const system = Object.freeze([
+  "**/.DS_Store",
+  "**/__pycache__/**",
+  "**/*.pyc",
+] as const)
+
+export const sourceIgnores: Readonly<{
+  defaults: readonly string[]
+  dependencies: readonly string[]
+  generated: readonly string[]
+  media: readonly string[]
+  secrets: readonly string[]
+  system: readonly string[]
+}> = Object.freeze({
+  defaults: Object.freeze([
+    ...dependencies,
+    ...generated,
+    ...media,
+    ...secrets,
+    ...system,
+  ] as const),
+  dependencies,
+  generated,
+  media,
+  secrets,
+  system,
+})

--- a/packages/source/src/index.ts
+++ b/packages/source/src/index.ts
@@ -25,4 +25,5 @@ export {
 } from "./core/registry.ts"
 export type * from "./core/types.ts"
 export type { SourceErrorCode } from "./core/errors.ts"
+export { sourceIgnores } from "./ignores.ts"
 export { custom } from "./sources/custom.ts"

--- a/packages/source/src/sources/github/cache.ts
+++ b/packages/source/src/sources/github/cache.ts
@@ -38,5 +38,5 @@ export function githubAuthenticationScope(token: string | undefined) {
 
 function normalizePatternCacheKey(value: string | readonly string[] | undefined) {
   if (!value) return ""
-  return typeof value === "string" ? value : value.join(",")
+  return Array.isArray(value) ? value.join(",") : String(value)
 }

--- a/packages/source/src/sources/github/cache.ts
+++ b/packages/source/src/sources/github/cache.ts
@@ -12,7 +12,7 @@ export function normalizeGitHubCache(options: Pick<GitHubSourceOptions, "cache">
 
 export function createGitHubCacheKey(input: {
   authScope: string
-  ignore?: string | string[]
+  ignore?: string | readonly string[]
   include?: string | string[]
   key?: string
   kind: string
@@ -36,7 +36,7 @@ export function githubAuthenticationScope(token: string | undefined) {
   return token ? createHash("sha256").update(token).digest("hex") : "anonymous"
 }
 
-function normalizePatternCacheKey(value: string | string[] | undefined) {
+function normalizePatternCacheKey(value: string | readonly string[] | undefined) {
   if (!value) return ""
-  return Array.isArray(value) ? value.join(",") : value
+  return typeof value === "string" ? value : value.join(",")
 }

--- a/packages/source/src/sources/github/cache.ts
+++ b/packages/source/src/sources/github/cache.ts
@@ -12,7 +12,7 @@ export function normalizeGitHubCache(options: Pick<GitHubSourceOptions, "cache">
 
 export function createGitHubCacheKey(input: {
   authScope: string
-  exclude?: string | string[]
+  ignore?: string | string[]
   include?: string | string[]
   key?: string
   kind: string
@@ -26,7 +26,7 @@ export function createGitHubCacheKey(input: {
     input.ref,
     input.root,
     normalizePatternCacheKey(input.include),
-    normalizePatternCacheKey(input.exclude),
+    normalizePatternCacheKey(input.ignore),
     input.authScope,
     input.key || "",
   ].join(":")

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -84,7 +84,7 @@ export function github(options: GitHubSourceOptions): Source<string> {
 
   function shouldInclude(key: string) {
     if (options.include && !matchesAny(key, options.include)) return false
-    if (options.exclude && matchesAny(key, options.exclude)) return false
+    if (options.ignore && matchesAny(key, options.ignore)) return false
     return true
   }
 
@@ -331,7 +331,7 @@ export function github(options: GitHubSourceOptions): Source<string> {
   function cacheKey(kind: string, token: string | undefined, key = "", resolvedRef?: string) {
     return createGitHubCacheKey({
       authScope: githubAuthenticationScope(token),
-      exclude: options.exclude,
+      ignore: options.ignore,
       include: options.include,
       key,
       kind,
@@ -344,7 +344,7 @@ export function github(options: GitHubSourceOptions): Source<string> {
   return {
     cache: options.cache,
     fingerprint: {
-      exclude: options.exclude,
+      ignore: options.ignore,
       include: options.include,
       ref: configuredRef || "default",
       repo: options.repo,

--- a/packages/source/src/sources/github/types.ts
+++ b/packages/source/src/sources/github/types.ts
@@ -6,7 +6,7 @@ export interface GitHubSourceOptions {
   root?: string
   auth?: false | string | (() => string | undefined)
   include?: string | string[]
-  ignore?: string | string[]
+  ignore?: string | readonly string[]
   cache?: false | SourceCacheOptions
 }
 

--- a/packages/source/src/sources/github/types.ts
+++ b/packages/source/src/sources/github/types.ts
@@ -6,7 +6,7 @@ export interface GitHubSourceOptions {
   root?: string
   auth?: false | string | (() => string | undefined)
   include?: string | string[]
-  exclude?: string | string[]
+  ignore?: string | string[]
   cache?: false | SourceCacheOptions
 }
 

--- a/packages/source/src/sources/glob.ts
+++ b/packages/source/src/sources/glob.ts
@@ -11,7 +11,7 @@ export interface GlobSourceOptions {
   dot?: boolean
   followSymlinks?: boolean
   include: string | string[]
-  ignore?: string | string[]
+  ignore?: string | readonly string[]
   keyCache?: boolean
   prefix?: string
 }
@@ -115,8 +115,8 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
   return source
 }
 
-function normalizePatterns(patterns: string | string[] | undefined): string[] {
-  return Array.isArray(patterns) ? patterns : patterns ? [patterns] : []
+function normalizePatterns(patterns: string | readonly string[] | undefined): readonly string[] {
+  return typeof patterns === "string" ? [patterns] : patterns || []
 }
 
 function resolveSourceRoot(ctx: SourceContext) {

--- a/packages/source/src/sources/glob.ts
+++ b/packages/source/src/sources/glob.ts
@@ -16,9 +16,9 @@ export interface GlobSourceOptions {
   prefix?: string
 }
 
-export function glob<const TKey extends string = string>(options: GlobSourceOptions): Source<TKey> {
-  let snapshot: { key: string, keys: Promise<TKey[]> } | undefined
-  let latest: { key: string, keys: TKey[] } | undefined
+export function glob(options: GlobSourceOptions): Source<string> {
+  let snapshot: { key: string, keys: Promise<string[]> } | undefined
+  let latest: { key: string, keys: string[] } | undefined
 
   async function getContextKey(ctx: SourceContext) {
     return resolveCwd(resolveSourceRoot(ctx), options.cwd)
@@ -37,7 +37,7 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
     return files
       .map(file => normalizeSourcePath(file))
       .filter(file => matchesAny(file, options.include) && !matchesAny(file, ignore))
-      .sort((left, right) => left.localeCompare(right)) as TKey[]
+      .sort((left, right) => left.localeCompare(right))
   }
 
   async function refreshKeys(ctx: SourceContext) {
@@ -67,7 +67,7 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
     return await getCachedKeys(ctx)
   }
 
-  async function assertKey(key: TKey, ctx: SourceContext) {
+  async function assertKey(key: string, ctx: SourceContext) {
     const keys = await getKnownKeys(ctx)
     if (keys.includes(key)) return
     if (options.keyCache !== false) {
@@ -77,7 +77,7 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
     throw sourceError(`[vitehub] glob could not find ${JSON.stringify(key)}.`)
   }
 
-  const source: Source<TKey> = {
+  const source: Source<string> = {
     name: "glob",
     async prepare(ctx: SourceContext) {
       snapshot = undefined
@@ -86,7 +86,7 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
     getKeys(ctx: SourceContext) {
       return getCachedKeys(ctx)
     },
-    async getMeta(key: TKey, ctx: SourceContext) {
+    async getMeta(key: string, ctx: SourceContext) {
       await assertKey(key, ctx)
       const { stat } = await import("node:fs/promises")
       const { resolve } = await import("node:path")
@@ -96,7 +96,7 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
         digest: `${info.size}:${info.mtimeMs}`,
       }
     },
-    async getItem(key: TKey, ctx: SourceContext): Promise<SourceItem<TKey>> {
+    async getItem(key: string, ctx: SourceContext): Promise<SourceItem<string>> {
       await assertKey(key, ctx)
       const { readFile, stat } = await import("node:fs/promises")
       const { resolve } = await import("node:path")
@@ -116,7 +116,8 @@ export function glob<const TKey extends string = string>(options: GlobSourceOpti
 }
 
 function normalizePatterns(patterns: string | readonly string[] | undefined): readonly string[] {
-  return typeof patterns === "string" ? [patterns] : patterns || []
+  if (!patterns) return []
+  return Array.isArray(patterns) ? patterns : [String(patterns)]
 }
 
 function resolveSourceRoot(ctx: SourceContext) {

--- a/packages/source/src/sources/mcp-resources.ts
+++ b/packages/source/src/sources/mcp-resources.ts
@@ -113,7 +113,7 @@ export type McpResourcesServer =
 
 export interface McpResourcesSourceOptions<TKey extends string = string> {
   cache?: false | SourceCacheOptions
-  exclude?: string | string[]
+  ignore?: string | string[]
   include?: string | string[]
   path?: (resource: McpResourceDescriptor) => TKey | string | undefined
   request?: McpResourcesRequestOptions
@@ -280,9 +280,9 @@ function resourceKey<TKey extends string>(resource: McpResourceDescriptor, optio
   return normalizeSafeSourcePath(resolved) as TKey
 }
 
-function shouldInclude(path: string, options: Pick<McpResourcesSourceOptions, "include" | "exclude">) {
+function shouldInclude(path: string, options: Pick<McpResourcesSourceOptions, "ignore" | "include">) {
   if (options.include && !matchesAny(path, options.include)) return false
-  if (options.exclude && matchesAny(path, options.exclude)) return false
+  if (options.ignore && matchesAny(path, options.ignore)) return false
   return true
 }
 
@@ -398,7 +398,7 @@ export function mcpResources<const TKey extends string = string>(options: McpRes
   return {
     cache: options.cache,
     fingerprint: {
-      exclude: options.exclude,
+      ignore: options.ignore,
       include: options.include,
       server: typeof options.server === "function"
         ? "[function]"

--- a/packages/source/src/sources/mcp-resources.ts
+++ b/packages/source/src/sources/mcp-resources.ts
@@ -113,7 +113,7 @@ export type McpResourcesServer =
 
 export interface McpResourcesSourceOptions<TKey extends string = string> {
   cache?: false | SourceCacheOptions
-  ignore?: string | string[]
+  ignore?: string | readonly string[]
   include?: string | string[]
   path?: (resource: McpResourceDescriptor) => TKey | string | undefined
   request?: McpResourcesRequestOptions

--- a/packages/source/src/sources/path.ts
+++ b/packages/source/src/sources/path.ts
@@ -4,7 +4,7 @@ import { normalizeSourcePath } from "../core/path.ts"
 
 export function matchesAny(path: string, patterns?: string | readonly string[]): boolean {
   if (!patterns) return true
-  const list = typeof patterns === "string" ? [patterns] : patterns
+  const list = Array.isArray(patterns) ? patterns : [String(patterns)]
   return picomatch.isMatch(
     normalizeSourcePath(path),
     list.map(pattern => normalizeSourcePath(pattern)),

--- a/packages/source/src/sources/path.ts
+++ b/packages/source/src/sources/path.ts
@@ -2,9 +2,9 @@ import picomatch from "picomatch"
 
 import { normalizeSourcePath } from "../core/path.ts"
 
-export function matchesAny(path: string, patterns?: string | string[]): boolean {
+export function matchesAny(path: string, patterns?: string | readonly string[]): boolean {
   if (!patterns) return true
-  const list = Array.isArray(patterns) ? patterns : [patterns]
+  const list = typeof patterns === "string" ? [patterns] : patterns
   return picomatch.isMatch(
     normalizeSourcePath(path),
     list.map(pattern => normalizeSourcePath(pattern)),

--- a/packages/source/test/ignores.test.ts
+++ b/packages/source/test/ignores.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+
+import { sourceIgnores } from "../src/index.ts"
+
+describe("Source ignores", () => {
+  it("publishes frozen composable ignore groups", () => {
+    expect(sourceIgnores.defaults).toEqual([
+      ...sourceIgnores.dependencies,
+      ...sourceIgnores.generated,
+      ...sourceIgnores.media,
+      ...sourceIgnores.secrets,
+      ...sourceIgnores.system,
+    ])
+    expect(Object.isFrozen(sourceIgnores)).toBe(true)
+    expect(Object.values(sourceIgnores).every(Object.isFrozen)).toBe(true)
+    expect(sourceIgnores.defaults).toContain("**/node_modules/**")
+    expect(sourceIgnores.defaults).toContain("**/.env.*")
+  })
+})

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -220,7 +220,7 @@ describe("@vite-hub/source GitHub source", () => {
     ])
   })
 
-  it("applies GitHub include and exclude filters to root-relative keys", async () => {
+  it("applies GitHub include and ignore filters to root-relative keys", async () => {
     stubGitHubSource({
       "dbt/models/marts/orders.sql": "select 1\n",
       "dbt/models/private/secret.sql": "select secret\n",
@@ -230,7 +230,7 @@ describe("@vite-hub/source GitHub source", () => {
 
     registerSources({
       dbt: github({
-        exclude: "models/private/**",
+        ignore: "models/private/**",
         include: ["models/**/*.sql", "macros/**/*.sql"],
         repo: "acme/app",
         root: "dbt",

--- a/packages/source/test/sources/mcp-resources.test.ts
+++ b/packages/source/test/sources/mcp-resources.test.ts
@@ -85,7 +85,7 @@ describe("mcpResources", () => {
 
   it("filters resources and supports custom paths", async () => {
     const source = mcpResources({
-      exclude: "**/blog-posts.json",
+      ignore: "**/blog-posts.json",
       path: resource => `mcp/${resource.name}.json`,
       server: createClient(),
     })

--- a/packages/source/test/sources/mcp-resources.test.ts
+++ b/packages/source/test/sources/mcp-resources.test.ts
@@ -1,5 +1,3 @@
-import { readFile } from "node:fs/promises"
-
 import { describe, expect, it, vi } from "vitest"
 
 import { mcpResources } from "../../src/mcp.ts"
@@ -43,17 +41,12 @@ function createClient(): McpResourcesClient {
 
 describe("mcpResources", () => {
   it("owns the MCP SDK as a private build dependency", async () => {
-    const pkg = JSON.parse(await readFile(new URL("../../package.json", import.meta.url), "utf8")) as {
-      dependencies?: Record<string, string>
-      devDependencies?: Record<string, string>
-      peerDependencies?: Record<string, string>
-      peerDependenciesMeta?: Record<string, unknown>
-    }
+    const { default: pkg } = await import("../../package.json", { with: { type: "json" } })
 
-    expect(pkg.dependencies?.["@modelcontextprotocol/sdk"]).toBeUndefined()
+    expect(Object.hasOwn(pkg.dependencies, "@modelcontextprotocol/sdk")).toBe(false)
     expect(pkg.devDependencies?.["@modelcontextprotocol/sdk"]).toBe("catalog:ai")
-    expect(pkg.peerDependencies?.["@modelcontextprotocol/sdk"]).toBeUndefined()
-    expect(pkg.peerDependenciesMeta?.["@modelcontextprotocol/sdk"]).toBeUndefined()
+    expect(Object.hasOwn(pkg.peerDependencies, "@modelcontextprotocol/sdk")).toBe(false)
+    expect(Object.hasOwn(pkg.peerDependenciesMeta, "@modelcontextprotocol/sdk")).toBe(false)
   })
 
   it("lists paginated MCP resources as source paths", async () => {

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -12,6 +12,7 @@ import {
   defineSource,
   defineSources,
   registerSources,
+  sourceIgnores,
   type Source,
   type SourceData,
   type SourceItem,
@@ -21,6 +22,7 @@ import {
 } from "../src/index.ts"
 import { file } from "../src/file.ts"
 import { github } from "../src/github.ts"
+import { glob } from "../src/glob.ts"
 import { mcpResources, type McpResourcesClient, type McpResourcesTransport } from "../src/mcp.ts"
 
 interface Meal {
@@ -287,6 +289,8 @@ describe("@vite-hub/source types", () => {
     const staticSource = file({ content: "# Docs\n", workspacePath: "README.md" })
     expectTypeOf(file({ content: "# Docs\n", workspacePath: "README.md" })).toMatchTypeOf<Source<"README.md">>()
     expectTypeOf(github({ auth: false, repo: "acme/app" })).toMatchTypeOf<Source>()
+    expectTypeOf(github({ ignore: sourceIgnores.defaults, repo: "acme/app" })).toMatchTypeOf<Source>()
+    expectTypeOf(glob({ ignore: sourceIgnores.generated, include: "**/*.md" })).toMatchTypeOf<Source>()
     expectTypeOf(
       mcpResources({
         server: {
@@ -301,6 +305,9 @@ describe("@vite-hub/source types", () => {
     ).toMatchTypeOf<Source<string>>()
     expectTypeOf(
       mcpResources({ server: { transport: { type: "http", url: "https://example.com/mcp" } } }),
+    ).toMatchTypeOf<Source<string>>()
+    expectTypeOf(
+      mcpResources({ ignore: sourceIgnores.media, server: { transport: { type: "http", url: "https://example.com/mcp" } } }),
     ).toMatchTypeOf<Source<string>>()
     const sources = defineSources({
       docs: staticSource,

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -524,7 +524,10 @@ export interface WorkspaceFetchSourceInput<TResponse = unknown, TOutput = TRespo
 
 export type WorkspaceGlobSourceInput = SourcePackageGlobSourceOptions & WorkspaceSourceBindingOptions
 
-export type WorkspaceGitHubSourceInput = SourcePackageGitHubSourceOptions & WorkspaceSourceBindingOptions
+export type WorkspaceGitHubSourceInput =
+  Omit<SourcePackageGitHubSourceOptions, "ignore">
+  & { ignore?: false | string | readonly string[] }
+  & WorkspaceSourceBindingOptions
 
 export type WorkspaceMcpResourcesSourceInput<TKey extends string = string> =
   Omit<SourcePackageMcpResourcesSourceOptions<TKey>, "cache"> & WorkspaceSourceBindingOptions

--- a/packages/workspace/src/index.ts
+++ b/packages/workspace/src/index.ts
@@ -1,5 +1,6 @@
 export { defineWorkspace } from "./core/define.ts"
 export { createWorkspace } from "./core/workspace.ts"
+export { sourceIgnores } from "@vite-hub/source"
 export {
   custom,
   fetch,

--- a/packages/workspace/src/sources/config.ts
+++ b/packages/workspace/src/sources/config.ts
@@ -326,7 +326,7 @@ function inferredSourceFingerprintOptions(family: WorkspaceSourceFamily, input: 
   if (family !== "github" || !isPlainRecord(input)) return input
   return {
     ...input,
-    ignore: resolveGitHubIgnore(input.ignore as false | string | readonly string[] | undefined),
+    ignore: resolveGitHubIgnore(input.ignore),
   }
 }
 

--- a/packages/workspace/src/sources/config.ts
+++ b/packages/workspace/src/sources/config.ts
@@ -4,6 +4,7 @@ import { workspaceError } from "../core/errors.ts"
 import { decodeFile, normalizeSafeWorkspacePath } from "../core/path.ts"
 import { fetch as fetchSource } from "./fetch.ts"
 import { getLiveWorkspaceSourcePaths, markLiveWorkspaceSource } from "./live.ts"
+import { resolveGitHubIgnore } from "./github-ignore.ts"
 import { loadMcpResourcesSource } from "./mcp-resources-loader.ts"
 import { prepareWorkspaceSource } from "./preparation.ts"
 import {
@@ -293,7 +294,7 @@ function createInferredWorkspaceSource(family: WorkspaceSourceFamily, input: Wor
     ...inferredSourceDefaults(family, input),
     fingerprint: {
       inferredSource: family,
-      options: input,
+      options: inferredSourceFingerprintOptions(family, input),
     },
     async prepare(ctx) {
       const loaded = await loadSource()
@@ -319,6 +320,14 @@ function createInferredWorkspaceSource(family: WorkspaceSourceFamily, input: Wor
   }
 
   return livePaths ? markLiveWorkspaceSource(source, livePaths) : source
+}
+
+function inferredSourceFingerprintOptions(family: WorkspaceSourceFamily, input: WorkspaceSourceInput) {
+  if (family !== "github" || !isPlainRecord(input)) return input
+  return {
+    ...input,
+    ignore: resolveGitHubIgnore(input.ignore as false | string | readonly string[] | undefined),
+  }
 }
 
 async function loadInferredWorkspaceSource(family: WorkspaceSourceFamily, input: WorkspaceSourceInput): Promise<WorkspaceSource> {

--- a/packages/workspace/src/sources/github-ignore.ts
+++ b/packages/workspace/src/sources/github-ignore.ts
@@ -1,9 +1,28 @@
 import { sourceIgnores } from "@vite-hub/source"
+import { workspaceError } from "../core/errors.ts"
 
-export function resolveGitHubIgnore(ignore: false | string | readonly string[] | undefined): string[] | undefined {
+export function resolveGitHubIgnore(ignore: unknown): string[] | undefined {
   if (ignore === false) return
+  if (ignore === undefined) return [...sourceIgnores.defaults]
+  const single = runtimeString(ignore)
+  if (single !== undefined) return [...sourceIgnores.defaults, single]
+  if (!Array.isArray(ignore)) throw invalidGitHubIgnore()
+  const parsed: string[] = []
+  for (const value of ignore) {
+    const item = runtimeString(value)
+    if (item === undefined) throw invalidGitHubIgnore()
+    parsed.push(item)
+  }
   return [
     ...sourceIgnores.defaults,
-    ...(typeof ignore === "string" ? [ignore] : ignore || []),
+    ...parsed,
   ]
+}
+
+function runtimeString(value: unknown): string | undefined {
+  return Object.prototype.toString.call(value) === "[object String]" ? String(value) : undefined
+}
+
+function invalidGitHubIgnore(): Error {
+  return workspaceError("[vitehub] GitHub Source ignore must be false, a string, or an array of strings.")
 }

--- a/packages/workspace/src/sources/github-ignore.ts
+++ b/packages/workspace/src/sources/github-ignore.ts
@@ -1,0 +1,9 @@
+import { sourceIgnores } from "@vite-hub/source"
+
+export function resolveGitHubIgnore(ignore: false | string | readonly string[] | undefined): string[] | undefined {
+  if (ignore === false) return
+  return [
+    ...sourceIgnores.defaults,
+    ...(typeof ignore === "string" ? [ignore] : ignore || []),
+  ]
+}

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -1,7 +1,7 @@
 import { getActiveCloudflareBinding } from "@vite-hub/internal/runtime/cloudflare-env"
-import { sourceIgnores } from "@vite-hub/source"
 import { github as createGitHubSource, type GitHubSourceOptions as SourcePackageGitHubSourceOptions } from "@vite-hub/source/github"
 
+import { resolveGitHubIgnore } from "./github-ignore.ts"
 import { prepareWorkspaceSource } from "./preparation.ts"
 import { withWorkspaceRuntimeOptions } from "./runtime-options.ts"
 import { resolveWorkspaceEnv } from "../env.ts"
@@ -88,14 +88,6 @@ export function github(input: GitHubSourceInput): WorkspaceSource {
       return await source.getMeta?.(key, ctx)
     },
   }, resolvedOptions)
-}
-
-function resolveGitHubIgnore(ignore: GitHubSourceOptions["ignore"]): string[] | undefined {
-  if (ignore === false) return
-  return [
-    ...sourceIgnores.defaults,
-    ...(typeof ignore === "string" ? [ignore] : ignore || []),
-  ]
 }
 
 function resolvableGitHubSource(resolve: GitHubSourceResolver): WorkspaceSource {

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -16,7 +16,7 @@ const githubTokenEnvNames = ["WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB
 export interface GitHubSourceOptions extends Omit<SourcePackageGitHubSourceOptions, "auth" | "ignore">, WorkspaceSourceRuntimeOptions {
   auth?: GitHubAuth
   /** Adds to the default Source ignores. Set to false to include every matched path. */
-  ignore?: false | string | string[]
+  ignore?: false | string | readonly string[]
 }
 
 export type GitHubSourceResolver = (

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -1,4 +1,5 @@
 import { getActiveCloudflareBinding } from "@vite-hub/internal/runtime/cloudflare-env"
+import { sourceIgnores } from "@vite-hub/source"
 import { github as createGitHubSource, type GitHubSourceOptions as SourcePackageGitHubSourceOptions } from "@vite-hub/source/github"
 
 import { prepareWorkspaceSource } from "./preparation.ts"
@@ -12,8 +13,10 @@ type GitHubAuth = NonNullable<SourcePackageGitHubSourceOptions["auth"]>
 type GitHubResolvedSourceOptions = Omit<GitHubSourceOptions, "repo"> & Partial<Pick<GitHubSourceOptions, "repo">>
 const githubTokenEnvNames = ["WORKSPACE_GITHUB_TOKEN", "VITEHUB_WORKSPACE_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"] as const
 
-export interface GitHubSourceOptions extends Omit<SourcePackageGitHubSourceOptions, "auth">, WorkspaceSourceRuntimeOptions {
+export interface GitHubSourceOptions extends Omit<SourcePackageGitHubSourceOptions, "auth" | "ignore">, WorkspaceSourceRuntimeOptions {
   auth?: GitHubAuth
+  /** Adds to the default Source ignores. Set to false to include every matched path. */
+  ignore?: false | string | string[]
 }
 
 export type GitHubSourceResolver = (
@@ -28,7 +31,10 @@ export function github(input: GitHubSourceInput): WorkspaceSource {
   if (typeof input === "function") return resolvableGitHubSource(input)
 
   const options = input
-  const resolvedOptions = { ...options }
+  const resolvedOptions = {
+    ...options,
+    ignore: resolveGitHubIgnore(options.ignore),
+  }
   const baseSource = createGitHubSource({
     ...resolvedOptions,
     auth: createGitHubAuthResolver(resolvedOptions.auth),
@@ -51,7 +57,7 @@ export function github(input: GitHubSourceInput): WorkspaceSource {
   return withWorkspaceRuntimeOptions({
     ...baseSource,
     fingerprint: {
-      exclude: resolvedOptions.exclude,
+      ignore: resolvedOptions.ignore,
       include: resolvedOptions.include,
       ref: resolvedOptions.ref,
       repo: resolvedOptions.repo,
@@ -82,6 +88,14 @@ export function github(input: GitHubSourceInput): WorkspaceSource {
       return await source.getMeta?.(key, ctx)
     },
   }, resolvedOptions)
+}
+
+function resolveGitHubIgnore(ignore: GitHubSourceOptions["ignore"]): string[] | undefined {
+  if (ignore === false) return
+  return [
+    ...sourceIgnores.defaults,
+    ...(typeof ignore === "string" ? [ignore] : ignore || []),
+  ]
 }
 
 function resolvableGitHubSource(resolve: GitHubSourceResolver): WorkspaceSource {

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -17,6 +17,7 @@ import * as loader from "../src/loader.ts"
 import * as publish from "../src/publish.ts"
 import { registerWorkspace } from "../src/test.ts"
 import { syncWorkspaceDefinition } from "../src/lifecycle.ts"
+import { materializeWorkspaceSources } from "../src/sources/materialization.ts"
 import { setWorkspaceRuntimeAssetsRegistry } from "../src/runtime/state.ts"
 import { createWorkspaceAssets } from "../src/runtime/assets.ts"
 import { useRegisteredWorkspace } from "../src/core/registry.ts"
@@ -278,11 +279,12 @@ describe("sources, loaders, and publishers", () => {
       repo: "acme/app",
     } as const
 
-    await syncWorkspaceDefinition({
+    await materializeWorkspaceSources({
       name: "github-ignore-policy-cache",
       sources: {
         docs: {
           cache: options.cache,
+          materialize: "lazy",
           fingerprint: {
             inferredSource: "github",
             options,
@@ -302,13 +304,14 @@ describe("sources, loaders, and publishers", () => {
       ".env": "SECRET=updated\n",
       "README.md": "# Updated docs\n",
     })
-    await syncWorkspaceDefinition({
+    await materializeWorkspaceSources({
       name: "github-ignore-policy-cache",
       sources: { docs: options },
     }, store)
 
     await expect(store.readFile("docs/.env")).resolves.toBeUndefined()
-    await expect(store.readFile("docs/README.md")).resolves.toMatchObject({ content: "# Updated docs\n" })
+    const updatedReadme = await store.readFile("docs/README.md")
+    expect(Buffer.from(updatedReadme?.content || "").toString("utf8")).toBe("# Updated docs\n")
   })
 
   it("resolves GitHub auth lazily from runtime env", async () => {

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -271,6 +271,46 @@ describe("sources, loaders, and publishers", () => {
     ])
   })
 
+  it("invalidates cached inferred GitHub snapshots when the effective ignore policy changes", async () => {
+    const store = createMemoryWorkspaceStore()
+    const options = {
+      cache: { maxAge: 3600 },
+      repo: "acme/app",
+    } as const
+
+    await syncWorkspaceDefinition({
+      name: "github-ignore-policy-cache",
+      sources: {
+        docs: {
+          cache: options.cache,
+          fingerprint: {
+            inferredSource: "github",
+            options,
+          },
+          async getKeys() {
+            return [".env", "README.md"]
+          },
+          async getItem(key: string) {
+            return { key, content: key === ".env" ? "SECRET=value\n" : "# Docs\n" }
+          },
+        },
+      },
+    }, store)
+    await expect(store.readFile("docs/.env")).resolves.toMatchObject({ content: "SECRET=value\n" })
+
+    stubGitHubSource({
+      ".env": "SECRET=updated\n",
+      "README.md": "# Updated docs\n",
+    })
+    await syncWorkspaceDefinition({
+      name: "github-ignore-policy-cache",
+      sources: { docs: options },
+    }, store)
+
+    await expect(store.readFile("docs/.env")).resolves.toBeUndefined()
+    await expect(store.readFile("docs/README.md")).resolves.toMatchObject({ content: "# Updated docs\n" })
+  })
+
   it("resolves GitHub auth lazily from runtime env", async () => {
     stubGitHubSource({
       "docs/README.md": "# Docs\n",

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -228,7 +228,7 @@ describe("sources, loaders, and publishers", () => {
     expect(vi.mocked(fetch).mock.calls.some(([url]) => String(url).includes("/tar.gz/latest-commit-sha"))).toBe(true)
   })
 
-  it("applies GitHub include and exclude filters to root-relative keys", async () => {
+  it("applies GitHub include and ignore filters to root-relative keys", async () => {
     stubGitHubSource({
       "dbt/models/marts/orders.sql": "select 1\n",
       "dbt/models/private/secret.sql": "select secret\n",
@@ -240,12 +240,34 @@ describe("sources, loaders, and publishers", () => {
       repo: "acme/app",
       root: "dbt",
       include: ["models/**/*.sql", "macros/**/*.sql"],
-      exclude: "models/private/**",
+      ignore: "models/private/**",
     })
 
     await expect(githubSource.getKeys({ rootDir: "", workspace: "github-filters" })).resolves.toEqual([
       "models/marts/orders.sql",
       "macros/date_spine.sql",
+    ])
+  })
+
+  it("applies safe GitHub ignores by default and supports opting out", async () => {
+    stubGitHubSource({
+      ".env": "SECRET=value\n",
+      "README.md": "# Docs\n",
+      "coverage/report.json": "{}\n",
+      "node_modules/example/index.js": "export default true\n",
+      "public/logo.png": "image\n",
+    })
+
+    const filtered = github({ repo: "acme/app" })
+    await expect(filtered.getKeys({ rootDir: "", workspace: "github-default-ignores" })).resolves.toEqual(["README.md"])
+
+    const unfiltered = github({ ignore: false, repo: "acme/app" })
+    await expect(unfiltered.getKeys({ rootDir: "", workspace: "github-ignore-opt-out" })).resolves.toEqual([
+      ".env",
+      "README.md",
+      "coverage/report.json",
+      "node_modules/example/index.js",
+      "public/logo.png",
     ])
   })
 

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -4,6 +4,7 @@ import { describe, expectTypeOf, it } from "vitest"
 
 import {
   defineWorkspace,
+  sourceIgnores,
   useWorkspace,
 } from "../src/index.ts"
 import { createWorkspaceTools, type WorkspaceMaterializeSourcesResult, type WorkspaceShellResult } from "../src/ai.ts"
@@ -132,6 +133,12 @@ describe("workspace types", () => {
       root: "docs",
       include: "**/*.md",
       ignore: "docs/drafts/**",
+    })
+    github({ ignore: sourceIgnores.defaults, repo: "acme/app" })
+    defineWorkspace({
+      sources: {
+        docs: { ignore: false, repo: "acme/docs" },
+      },
     })
     // @ts-expect-error Source Instructions no longer belong on Source config.
     github({ repo: "acme/app", instructions: "Use for hosted docs." })

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -131,7 +131,7 @@ describe("workspace types", () => {
       repo: "acme/app",
       root: "docs",
       include: "**/*.md",
-      exclude: "docs/drafts/**",
+      ignore: "docs/drafts/**",
     })
     // @ts-expect-error Source Instructions no longer belong on Source config.
     github({ repo: "acme/app", instructions: "Use for hosted docs." })

--- a/packages/workspace/test/types.test-d.ts
+++ b/packages/workspace/test/types.test-d.ts
@@ -72,6 +72,7 @@ describe("workspace types", () => {
   })
 
   it("does not expose a placeholder mount contract", () => {
+    // SAFETY: This type-only fixture is never evaluated and exists to exercise the Workspace surface.
     const workspace = {} as Workspace
     // @ts-expect-error Workspace mounts require a real host projection contract.
     workspace.mount()
@@ -176,6 +177,7 @@ describe("workspace types", () => {
           jsonSchema: {
             input: () => ({ type: "object" }),
           },
+          // SAFETY: The type-only schema fixture models a validator accepting this record contract.
           validate: (input: unknown) => ({ value: input as Record<string, unknown> }),
         },
       },
@@ -258,7 +260,8 @@ describe("workspace types", () => {
 
     const readonly = useWorkspace("typed")
     const writable = useWorkspace("typed", { mode: "write" })
-    const runtimeWorkspace = null as unknown as Workspace
+    // SAFETY: This type-only fixture is never evaluated and exists to exercise runtime-only methods.
+    const runtimeWorkspace: Workspace = undefined!
 
     expectTypeOf(definition).toMatchTypeOf<object>()
     expectTypeOf(createWorkspaceTools(createWorkspaceAssets({
@@ -297,7 +300,8 @@ describe("workspace types", () => {
     expectTypeOf(githubWorkspaceOptions).toMatchTypeOf<WorkspaceModuleOptions>()
     expectTypeOf(lazyGithubWorkspaceOptions).toMatchTypeOf<WorkspaceModuleOptions>()
     expectTypeOf(removedOptions).toMatchTypeOf<WorkspaceModuleOptions>()
-    const session = null as unknown as Awaited<ReturnType<typeof writable.startSession>>
+    // SAFETY: This type-only fixture is never evaluated and exists to exercise the session surface.
+    const session: Awaited<ReturnType<typeof writable.startSession>> = undefined!
     // @ts-expect-error runtime selection belongs to Box, not Workspace session options
     await writable.startSession({ runtime: "local" })
     expectTypeOf(session.exec).toBeFunction()


### PR DESCRIPTION
## Summary

Source filtering now uses the same ignore option across glob, GitHub, and MCP Resource Sources. The former GitHub and MCP exclude option is removed in favor of the final consistent contract.

The sourceIgnores export provides frozen dependency, generated-output, media, secret, and system groups plus their combined defaults. Workspace GitHub Sources compose those defaults automatically, accept additional ignore patterns, and support ignore: false as an explicit opt-out. Lower-level Source loaders remain policy-neutral.

Documentation and all repository callers have been migrated to the final API.

## Verification

- `corepack pnpm --filter @vite-hub/source test -- test/ignores.test.ts test/sources/github.test.ts test/sources/mcp-resources.test.ts` — 35 tests passed
- `corepack pnpm --filter @vite-hub/workspace test -- test/source-loader-publisher.test.ts` — 55 tests passed with no type errors
- Source and Workspace typechecks passed
- both package builds and publint passed
- `git diff --check`
