### PR TITLE
feat(agent): validate channel metadata

### DIFF
--- a/.vite-doctor-baseline.json
+++ b/.vite-doctor-baseline.json
@@ -13,6 +13,11 @@
     },
     {
       "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
+      "file": "packages/auth/test/published-types.test.ts",
+      "fingerprint": "86fe8e4febdbdf15917a6a92ccbc70cc598a4954a2f8710a5701944d21ec7f71"
+    },
+    {
+      "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
       "file": "packages/blob/src/internal/vite-build.ts",
       "fingerprint": "3f671333476e9daf40c848c406bd8b06f7d38053112a185f703882ff619a7113"
     },
@@ -115,6 +120,11 @@
       "ruleId": "typescript/evidence/no-caller-chosen-result-type",
       "file": "packages/internal/src/provision.ts",
       "fingerprint": "f936e0ceff5bfe8742f7a74e7b378662d2cdf6b7abcaf630278bfd4f1c8d3367"
+    },
+    {
+      "ruleId": "typescript/evidence/no-caller-chosen-result-type",
+      "file": "packages/workspace/src/core/use.ts",
+      "fingerprint": "1e660870d3c03a74e4571073aa2f9347db207f47bf8b595c89313d16ef50262a"
     },
     {
       "ruleId": "typescript/evidence/no-chained-type-assertions",
@@ -365,6 +375,116 @@
       "ruleId": "typescript/strict/no-runtime-typeof",
       "file": "packages/agent/src/capabilities/openapi.ts",
       "fingerprint": "fd8ef26647696c9d20e08bca3252014e049f53920bc2dade16a607169ae09487"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "16fb8969a9fa37198845dc8a501b57c53f0b35824c9f487214028576dd758161"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "1ccf4540d31a6a1081c6493b9831ee4c6a46e45e9810f384bfc3b0b0110189d2"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "2340b220071f11b595c654b293d38e885005b72b4c0852c4a1a3db9d34f637b8"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "388c01b1ed59d94cbecc4ae14a5e197c83df7c39a41aaeeb002e87b849cb568c"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "39892df3463ee78e5248a276a72cbbf42c635d1fe6fc6e08c586d90e79434f53"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "46fc8255f797b83146f8273f3ec3015eb6a8c2e73ce76c784dd9ce6ba16cf488"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "4d07a23ca52802f9bf574854b164397f30a2ca124da908b48f7696cdd286d821"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "4fe93581ece599045b2fdff4f8e0f7d9a27b456b5590d029a58b72ed22b5b70c"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "580e9d17dd9156359701f5cd4d9f360e34b6b82ca02467af88f18a926c05a383"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "7c29dc16de56cdf10cb2f32ab221818eb072306dae72ea21a6a4c5003e1e2113"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "89392df205570bb5a0766560f1634a674c61ee21834644e9b57710c5c1808086"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "991b354927077f886b51ed9a6422c05b3bf63ef6f4b8f87f62106d6038244568"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "9f698c2920e3b7a3576489abcd1ec0900ec7d90c6349decad3d05a971e9efedf"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "afa010f8a3db9fcb7ae953959407b8516ca0db9d813ddf7d43da79df432fad46"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "d803d82e65e9d6b1e407dbcc6616629c709aca5652bf80c0c2d1305899447afc"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "d92750b2abbeb3984ecc18505189d41d71b28ae265a8ea33a11a4605666a4ae7"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "da7d1f5f974ceea43aaf49c3feba5473f38a40cde7b11b44ea824c22a37fd112"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "daf090b40d749bf8435174e43a33957bb08658108cdedc921d0fb321f8e3ce5d"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "ec8b73a3cef4972e4bb17ab3289e502d3048bbbe911328b1ef6f5d7783893224"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "f00248f4fb11a2ff8950fd70da1288d4f861a12b778045ce80d98bb1201803ac"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "f0281159da68534a9e5776ad933e1a1e675d06ff88e6f718527a2c5ee2a2c29a"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "f6ea4a09bc2e248e216d1176b2eb1b43b9b3cde58c023144a9068acf9db02440"
     },
     {
       "ruleId": "typescript/strict/no-runtime-typeof",
@@ -760,6 +880,11 @@
       "ruleId": "typescript/strict/no-runtime-typeof",
       "file": "packages/agent/test/invocations.test.ts",
       "fingerprint": "73c2d7a8668a052dc9fefb9e3ccdf84963eacfbae31e2335e6cf5ae21ae7507b"
+    },
+    {
+      "ruleId": "typescript/strict/no-runtime-typeof",
+      "file": "packages/agent/test/nitro-webhook-queue-shutdown.test.ts",
+      "fingerprint": "06d54e0272636bf9af6f68c6032cec2b4332e89f753abd5af21f2148fb446316"
     },
     {
       "ruleId": "typescript/strict/no-runtime-typeof",
@@ -2063,6 +2188,61 @@
     },
     {
       "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "2624f1f9498d1a74e1f1380b2b2278880c4c50521059ae0889e46b0784188673"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "29f1965f03913ba5c90caef94daa6893a38a88f15be22766e4006e7d2b1a9b7b"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "481fd4fe956644e436938529f0c039449ca6e7402d33858e21bf2b3204553ad4"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "5074f08621fcb0e2769dbd47ae1c7455a40869f9f639a33653dcaeec93fb9fff"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "74130855e31d91da635c667dd4f7261443cf3a8b0aa42c5f9dc7365f9802d697"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "7d19c2bd9fb54a275708e489c5b7d9d358f232ef4305da8281c256c097e9ef2c"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "9a72759ce685b7a6daeafe26c8d434944df8c144ae33674ea0da855e60f82f28"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "b89c86d3536faf3a68e3ae668c7ab2ad86067f1b20cc2b182eb31624b96b4fc2"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "ca0037deb19071e6411508e9da8887f53fb670fecf58089a3eedd67f3d79418e"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "d79391591941fabe93ffb77302a44d2dd01cdae18f6bebdc7e7d6652d732ec34"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "fb6415aec007c78e5c5d2ace73a4191d60fd784f897fa886429bc8bbdfd6d4d5"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
       "file": "packages/agent/src/instruction-composition.ts",
       "fingerprint": "a36f5875d605660ed6467c2970970c0246cc7219041ca7cffb3e2017438db58f"
     },
@@ -2078,6 +2258,11 @@
     },
     {
       "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/internal/message-meta.ts",
+      "fingerprint": "86e6bfa04bd47b4a4aaaf0bcaf02d5047ffdd918ff2c6c2a253bfc2ff039a767"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
       "file": "packages/agent/src/invocations.ts",
       "fingerprint": "6e08f8dc17a880a3f4b63a22240745ad9464e8f47feca49116bc86db7b912343"
     },
@@ -2090,6 +2275,21 @@
       "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
       "file": "packages/agent/src/invocations.ts",
       "fingerprint": "deb7a09ed4d34f2cccc1b5a870b68e95f6458ecdd42defee2a4ce4d8362c12eb"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/server/routes.ts",
+      "fingerprint": "661d61cc64a5664f93f761a4f448234d2878c7690c902a0c9b7875252e8aebd9"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/server/routes.ts",
+      "fingerprint": "9eea90d2b53fde37fa6df1711614bbbf474defc49798505c24e426ef57da2217"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/src/server/routes.ts",
+      "fingerprint": "e701d9e07ebd2074a7184c3f1fc033681b3b617998a76ef6b477403432ad457d"
     },
     {
       "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
@@ -2478,8 +2678,23 @@
     },
     {
       "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/test/nitro-webhook-queue-shutdown.test.ts",
+      "fingerprint": "7c59b0496d578e9050e6d5b87e2c784ba0c18eaf371f0931dd10673f310531ba"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/test/nitro-webhook-queue-shutdown.test.ts",
+      "fingerprint": "9530556e0a7860ee8833de85166c050b909c74d9dbf015c2547d1960dcee88c4"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
       "file": "packages/agent/test/openapi-capability.test.ts",
       "fingerprint": "4ebf691ba8a4bfacb2176decd8fae3424a79d292dc45260f0712e27aac31abf9"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/agent/test/published-chat-adapter-types.test.ts",
+      "fingerprint": "59ea70f603b49a76c928427ddaa4605800a7cff48cedf12f38ebe8c1ddea0bca"
     },
     {
       "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
@@ -2965,6 +3180,21 @@
       "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
       "file": "packages/auth/test/definition.test.ts",
       "fingerprint": "29d8726e7537588a100aa8766bc2a30b7d9adf75332550f0995293515088f430"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/auth/test/published-types.test.ts",
+      "fingerprint": "296aebdb1ac392cf1debc27c310e018312d88f3c90f3906cce664b7bc3fba01b"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/auth/test/published-types.test.ts",
+      "fingerprint": "5cf0d726cb9f558cb1add8455eff0e45ba50a96c7da9700ee82c998b13456e96"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/auth/test/published-types.test.ts",
+      "fingerprint": "e8e301441d9e88f3c8cdac2712753dd54e5b36c5e8f901dbc6a66e126bcaabea"
     },
     {
       "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
@@ -4093,6 +4323,51 @@
     },
     {
       "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/workspace/src/core/use.ts",
+      "fingerprint": "034fe457c8e191d984a8ab23699180b3a7b208df46b407ce13b852894935e583"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/workspace/src/core/use.ts",
+      "fingerprint": "381b832a8e3a5ee09dcb949e50cef8703641b3cff705823cb3f2f81c2c77c548"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/workspace/src/core/use.ts",
+      "fingerprint": "3e3168e26e4dc474e4252fbcc510816b0cff67932e09bc4ab8c11b26013ba01a"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/workspace/src/core/use.ts",
+      "fingerprint": "7d99aacc2e0a18a34e30d8ca900f01a5cabbbb1306007275da14834893b08ccf"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/workspace/src/core/use.ts",
+      "fingerprint": "858f84ab7960ed995fffb5c102671a0538b4f42a97ac2ed4c903d47f5273a262"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/workspace/src/core/use.ts",
+      "fingerprint": "afdb6945627bfde1f5109466d25394f66ac8b317cbd85b0e47140cf85fd74165"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/workspace/src/core/use.ts",
+      "fingerprint": "b4db786fabb08375e4620b0732d8796b68e373be1ef707f4b6787661dbc7e7d7"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/workspace/src/core/use.ts",
+      "fingerprint": "bb767cbca450fae312ef666c4b1f9b59fa0d4db5ee2bd6c722801f86dd68779e"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
+      "file": "packages/workspace/src/core/use.ts",
+      "fingerprint": "efc330abfe8badc51d4d5812ae944e721cd565009bf3a16895d059899a58f8eb"
+    },
+    {
+      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
       "file": "packages/workspace/src/lifecycle.ts",
       "fingerprint": "f1c73502114695f68a8d630954e45427d0013de320c17352f4cd324ccf58f58c"
     },
@@ -4538,6 +4813,46 @@
     },
     {
       "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "110826a46215d1bbb60ad5d134f95b47879dbcf4ec2c9ca9df229e3fed90dded"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "1aa4923b55e126ec15900ea52848a475a4267e1ee9207195d8b7792999f1805f"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "3b12cb78bd7f82c3bb1a11fa14cb32049e313d7fbf249b59c37eeb3d8364616e"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "4a087b6635457b93623799fa6867fbe079b3b81f86cbe6901d2b25f805e7b273"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "4ec62cd6855081c953466d9a6c3094ff543a8fa0e0e49460f75e9acc0545e9cb"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "8c5574d428fcb49edfb4def2fcbd4050dcbc48d31f9e5a4b948ecef206f8e531"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/chat-message-input.ts",
+      "fingerprint": "f42bbf677d9f35ccdef2919bfa587c638bda56476af5e96f299e9c5cc371f969"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/chat-trigger.ts",
+      "fingerprint": "ac2e3e4314622c034dec598856ac978704ce7515abfdfdf3727e38a1a725eb12"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
       "file": "packages/agent/src/index.ts",
       "fingerprint": "05603b638dab53c208524ad1aa846ae0601e18882102774fdc1502efd1501dd0"
     },
@@ -4723,6 +5038,16 @@
     },
     {
       "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/internal/channels.ts",
+      "fingerprint": "76b20152b778cac795358262817fec1c3ad0e2ac0b78d631423be10b17f5a20b"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/internal/message-meta.ts",
+      "fingerprint": "ffdf24ee1818e2163681f0cc70f5f9b33b47cee62b7fad9bbd4b244f07e955e8"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
       "file": "packages/agent/src/invocations-vue.ts",
       "fingerprint": "f2f07dae6037ceb3fd92c27b6b2b690e54efe5c68f06a1ad64290a38a874f119"
     },
@@ -4849,6 +5174,11 @@
     {
       "ruleId": "typescript/style/no-conditional-empty-object-spread",
       "file": "packages/agent/src/server/routes.ts",
+      "fingerprint": "339fd667bb3a797e6a8ab35db62de5213a1a41211ef358465d0992f515022ff0"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/server/routes.ts",
       "fingerprint": "3813245b123cb1a793056fa1dcbe1507798eb8e5d981b926a1228bd8fb0d7aed"
     },
     {
@@ -4890,6 +5220,11 @@
       "ruleId": "typescript/style/no-conditional-empty-object-spread",
       "file": "packages/agent/src/server/routes.ts",
       "fingerprint": "654415819a16a34068a3a241829021f31cfc14aa7dceee00797da28fcdf477d8"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/server/routes.ts",
+      "fingerprint": "6f945feccf0fb9a04734f9372d17f3a227b414c11ceb81d8d643193e7ea40257"
     },
     {
       "ruleId": "typescript/style/no-conditional-empty-object-spread",
@@ -4944,6 +5279,11 @@
     {
       "ruleId": "typescript/style/no-conditional-empty-object-spread",
       "file": "packages/agent/src/server/routes.ts",
+      "fingerprint": "d137f72f37edc2c62c48e1ccdfcb880587ab0f9b5ea9ddcd73fdc2c39dd094f2"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/server/routes.ts",
       "fingerprint": "d5bdfd450222b68357f7cbb0f7af18214eb1cb7c245d079692755e4ba05041b5"
     },
     {
@@ -4960,6 +5300,11 @@
       "ruleId": "typescript/style/no-conditional-empty-object-spread",
       "file": "packages/agent/src/server/routes.ts",
       "fingerprint": "e6aa7c990600e005452c5e0fb2f185f19dfbf84b1f3b7a8fbb0120512877f39f"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/agent/src/server/routes.ts",
+      "fingerprint": "e9bd3fdbab10fac010bd38231f741e85c9012229766479051d4b3e3b9f14c194"
     },
     {
       "ruleId": "typescript/style/no-conditional-empty-object-spread",
@@ -5318,6 +5663,11 @@
     },
     {
       "ruleId": "typescript/style/no-conditional-empty-object-spread",
+      "file": "packages/vite-hub/src/console/runtime/server/invocations.ts",
+      "fingerprint": "44e852943412a045698effd5529d7462fe828c602707ced487bad37e224cdf7c"
+    },
+    {
+      "ruleId": "typescript/style/no-conditional-empty-object-spread",
       "file": "packages/vite-hub/src/index.ts",
       "fingerprint": "3f5ce656e073396bedd449eae5e7db971d48bf416e0e99e93ad71f9a4cb30927"
     },
@@ -5420,201 +5770,6 @@
       "ruleId": "typescript/style/no-conditional-empty-object-spread",
       "file": "packages/workspace/test/host-session.test.ts",
       "fingerprint": "bf8b9da65d3f66d4a302613b2a462c7a7211adebe35027d4e2f254d90da662fb"
-    },
-    {
-      "ruleId": "typescript/evidence/no-caller-chosen-result-type",
-      "file": "packages/workspace/src/core/use.ts",
-      "fingerprint": "1e660870d3c03a74e4571073aa2f9347db207f47bf8b595c89313d16ef50262a"
-    },
-    {
-      "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
-      "file": "packages/auth/test/published-types.test.ts",
-      "fingerprint": "86fe8e4febdbdf15917a6a92ccbc70cc598a4954a2f8710a5701944d21ec7f71"
-    },
-    {
-      "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "dff740293ff38ee26eef6c9b17c693e1f282c2fa8f6c50b8c55b4b0258d32c3f"
-    },
-    {
-      "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "ffa0f00330309d8f7d4b0700787d1c2d17ad5b79e74e03329297ca49af7f6ef2"
-    },
-    {
-      "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "ceee1fcc46cac63b135dfa9aec47dbdb78f5c41aacaa01f70da2e3829d32a080"
-    },
-    {
-      "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "fa7ac3516d194a4106fffa0ffdd6b5def17e95e6df0d53a926cc1aee1b411419"
-    },
-    {
-      "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "d21bf5d4914e7f50e8f2e183db791f60432ce04f9331697cdfe6919b5210226d"
-    },
-    {
-      "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "c1e3e48fb6c740662f4d4fa56259d72ee7e6839d0591aeea365e1e4c04c79e0f"
-    },
-    {
-      "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "ee5a210a41ea2209edaae0a1dfda8db50d1350a4471d0acb49dae34540babd19"
-    },
-    {
-      "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "97c34456c6fb3fee4221f6a1a8ee38a169dc1bdc09f61ed3ff8a9efa2cf4cfe1"
-    },
-    {
-      "ruleId": "typescript/boundaries/no-unvalidated-deserialization",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "ae9d2741ccce663eac0db242a0b8d4fdf63df9144eefd29816fcb73ad7f3aa9a"
-    },
-    {
-      "ruleId": "typescript/strict/no-runtime-typeof",
-      "file": "packages/agent/test/nitro-webhook-queue-shutdown.test.ts",
-      "fingerprint": "06d54e0272636bf9af6f68c6032cec2b4332e89f753abd5af21f2148fb446316"
-    },
-    {
-      "ruleId": "typescript/strict/no-runtime-typeof",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "69b1c2339453b6a09752ed8d87a733d2fa31e951b45b08d57de2b5b880b9c7f7"
-    },
-    {
-      "ruleId": "typescript/strict/no-runtime-typeof",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "ff81644ad2f02dfc260fa130b38370029c8c3a3316ddb8611fb3aeec0ffc528b"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/agent/test/nitro-webhook-queue-shutdown.test.ts",
-      "fingerprint": "7c59b0496d578e9050e6d5b87e2c784ba0c18eaf371f0931dd10673f310531ba"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/agent/test/nitro-webhook-queue-shutdown.test.ts",
-      "fingerprint": "9530556e0a7860ee8833de85166c050b909c74d9dbf015c2547d1960dcee88c4"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/agent/test/published-chat-adapter-types.test.ts",
-      "fingerprint": "59ea70f603b49a76c928427ddaa4605800a7cff48cedf12f38ebe8c1ddea0bca"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/auth/test/published-types.test.ts",
-      "fingerprint": "296aebdb1ac392cf1debc27c310e018312d88f3c90f3906cce664b7bc3fba01b"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/auth/test/published-types.test.ts",
-      "fingerprint": "5cf0d726cb9f558cb1add8455eff0e45ba50a96c7da9700ee82c998b13456e96"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/auth/test/published-types.test.ts",
-      "fingerprint": "e8e301441d9e88f3c8cdac2712753dd54e5b36c5e8f901dbc6a66e126bcaabea"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/workspace/src/core/use.ts",
-      "fingerprint": "efc330abfe8badc51d4d5812ae944e721cd565009bf3a16895d059899a58f8eb"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/workspace/src/core/use.ts",
-      "fingerprint": "858f84ab7960ed995fffb5c102671a0538b4f42a97ac2ed4c903d47f5273a262"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/workspace/src/core/use.ts",
-      "fingerprint": "381b832a8e3a5ee09dcb949e50cef8703641b3cff705823cb3f2f81c2c77c548"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/workspace/src/core/use.ts",
-      "fingerprint": "afdb6945627bfde1f5109466d25394f66ac8b317cbd85b0e47140cf85fd74165"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/workspace/src/core/use.ts",
-      "fingerprint": "7d99aacc2e0a18a34e30d8ca900f01a5cabbbb1306007275da14834893b08ccf"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/workspace/src/core/use.ts",
-      "fingerprint": "b4db786fabb08375e4620b0732d8796b68e373be1ef707f4b6787661dbc7e7d7"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/workspace/src/core/use.ts",
-      "fingerprint": "3e3168e26e4dc474e4252fbcc510816b0cff67932e09bc4ab8c11b26013ba01a"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/workspace/src/core/use.ts",
-      "fingerprint": "034fe457c8e191d984a8ab23699180b3a7b208df46b407ce13b852894935e583"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "packages/workspace/src/core/use.ts",
-      "fingerprint": "bb767cbca450fae312ef666c4b1f9b59fa0d4db5ee2bd6c722801f86dd68779e"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "886536d2687037d96fcdd8cd7454c22053455a6e20d1be7c8cfaf2790eafd1ad"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "c9328d5ca3142a5bf379024b33346d86a99795920ce4096b2bbfe5f50990a580"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "24a820373139acc6283aff73885d5b2bbeadc2a00880dfce6f5c28667ba675f9"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "055c5285d881a455f668440e4f6ca5e73a2b8af941a559b1d02282e1a16337d3"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "6410590caf3a7e4b53ab275565ce9cebf44ee3326141510b267dd297ef075e33"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "5b327ef18316324fd452857e314c376949558f2a8f3c056eea0b127a4ae6ff2d"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "d0a6fcd4edcc5236aaf114d306eedfb5ae47ef0dcd5b6ec2be12c65b2c5fbb07"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "f6282ea8e799b7d47c88d34668aa24779b91dc47ad0f2bbcad1bb96b26fdb649"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "4b7103b6506b6e6d0a31772ec1782e5d26ef010b9227dfc8548574625baedce8"
-    },
-    {
-      "ruleId": "typescript/strict/require-safety-comment-for-type-assertion",
-      "file": "test/consumer/vite-hub.test.ts",
-      "fingerprint": "f9804445b874c405196f1d60ac0fc8ee8e7bf01917aef7b5927ab6778c08f3e3"
     }
   ]
 }

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -178,7 +178,7 @@ teams({
 
 `deliveryKind` is `direct`, `mention`, or `subscribed`. Returning `false` posts no fallback error because the Agent never started.
 
-Set `messages.meta` to a Standard Schema when application-owned Channel metadata must be validated before Capabilities, hooks, or the Driver run. The schema may normalize or add defaults, but its output must be an object. Put the schema on shared Agent message settings or on one Channel to override it for that Channel.
+Set `messages.meta` to a Standard Schema when application-owned Channel metadata must be validated before Capabilities, hooks, or the Driver run. The schema may normalize or add defaults, but its output must be an object. Set `metaRevision` to a stable value and change it whenever the schema contract changes so durable Agent Workflows can reuse parsed metadata across processes. Without a revision, durable execution validates the metadata again. Put both settings on shared Agent message settings or on one Channel to override them for that Channel.
 
 ```ts
 import { defineAgent } from 'vite-hub/agent'
@@ -188,6 +188,7 @@ export default defineAgent({
   driver: { run: ({ context }) => context.get('channel')?.meta },
   messages: {
     meta: v.object({ audience: v.optional(v.picklist(['support', 'technical'])) }),
+    metaRevision: '1',
   },
 })
 ```

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -178,6 +178,20 @@ teams({
 
 `deliveryKind` is `direct`, `mention`, or `subscribed`. Returning `false` posts no fallback error because the Agent never started.
 
+Set `messages.meta` to a Standard Schema when application-owned Channel metadata must be validated before Capabilities, hooks, or the Driver run. The schema may normalize or add defaults, but its output must be an object. Put the schema on shared Agent message settings or on one Channel to override it for that Channel.
+
+```ts
+import { defineAgent } from 'vite-hub/agent'
+import * as v from 'valibot'
+
+export default defineAgent({
+  driver: { run: ({ context }) => context.get('channel')?.meta },
+  messages: {
+    meta: v.object({ audience: v.optional(v.picklist(['support', 'technical'])) }),
+  },
+})
+```
+
 Set `messages.commentary: 'message'` only when the Driver emits explicit commentary phases for public progress. Commentary is hidden by default; ViteHub never publishes reasoning as progress.
 
 Use `messages.delivery: 'manual'` when finish hooks own replies. A generated Workflow may carry manual delivery across a durable boundary when the Channel and host support it. An explicit `messages.timeout` bounds inline execution and the durable handoff's typing indicator, but it does not cap the durable Agent Workflow. `steer` queues overlapping messages and preserves that Workflow handoff. Other overlap policies such as `serial`, `drop`, `queue`, and `reject` remain inline and cannot be combined with required durable delivery.

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -44,6 +44,12 @@ export interface ChatMessageTriggerInputResult<TRuntimeConfig extends AgentRunti
   selectedMessages: UIMessageLike[]
 }
 
+const derivedChatInvokers = new WeakSet<object>()
+
+export function hasDerivedChatTriggerInvoker(invoker: unknown): boolean {
+  return typeof invoker === "object" && invoker !== null && derivedChatInvokers.has(invoker)
+}
+
 function uiMessageText(message: UIMessageLike): string {
   const parts = Array.isArray(message.parts) ? message.parts : []
   return parts
@@ -407,6 +413,7 @@ export function createChatMessageTriggerInput<TRuntimeConfig extends AgentRuntim
     : transportSessionId)
   const hookArgs = createChatTriggerHookArgs(options, selectedMessages, triggerInput?.run, triggerInput?.session)
   const invoker = resolveChatTriggerInvoker(triggerInput)
+  if (invoker && !triggerInput?.invoker) derivedChatInvokers.add(invoker)
   return {
     hookArgs,
     input: {

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -46,6 +46,10 @@ export interface ChatMessageTriggerInputResult<TRuntimeConfig extends AgentRunti
 
 const derivedChatInvokers = new WeakSet<object>()
 
+export function markDerivedChatTriggerInvoker(invoker: unknown): void {
+  if (typeof invoker === "object" && invoker !== null) derivedChatInvokers.add(invoker)
+}
+
 export function hasDerivedChatTriggerInvoker(invoker: unknown): boolean {
   return typeof invoker === "object" && invoker !== null && derivedChatInvokers.has(invoker)
 }
@@ -413,7 +417,7 @@ export function createChatMessageTriggerInput<TRuntimeConfig extends AgentRuntim
     : transportSessionId)
   const hookArgs = createChatTriggerHookArgs(options, selectedMessages, triggerInput?.run, triggerInput?.session)
   const invoker = resolveChatTriggerInvoker(triggerInput)
-  if (invoker && !triggerInput?.invoker) derivedChatInvokers.add(invoker)
+  if (!triggerInput?.invoker) markDerivedChatTriggerInvoker(invoker)
   return {
     hookArgs,
     input: {

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -44,14 +44,18 @@ export interface ChatMessageTriggerInputResult<TRuntimeConfig extends AgentRunti
   selectedMessages: UIMessageLike[]
 }
 
-const derivedChatInvokers = new WeakSet<object>()
+const derivedChatInvokers = new WeakMap<object, AgentInvoker>()
 
-export function markDerivedChatTriggerInvoker(invoker: unknown): void {
-  if (typeof invoker === "object" && invoker !== null) derivedChatInvokers.add(invoker)
+export function markDerivedChatTriggerInvoker(invoker: unknown, source?: AgentInvoker): void {
+  if (typeof invoker === "object" && invoker !== null) derivedChatInvokers.set(invoker, source || invoker as AgentInvoker)
 }
 
 export function hasDerivedChatTriggerInvoker(invoker: unknown): boolean {
-  return typeof invoker === "object" && invoker !== null && derivedChatInvokers.has(invoker)
+  return derivedChatTriggerInvoker(invoker) !== undefined
+}
+
+export function derivedChatTriggerInvoker(invoker: unknown): AgentInvoker | undefined {
+  return typeof invoker === "object" && invoker !== null ? derivedChatInvokers.get(invoker) : undefined
 }
 
 function uiMessageText(message: UIMessageLike): string {

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -368,6 +368,7 @@ function selectChatHistory(messages: UIMessageLike[], triggerHistory: AgentChatT
 }
 
 function createChatTriggerHookArgs<TRuntimeConfig extends AgentRuntimeConfig>(
+  _options: AgentChatOptions<TRuntimeConfig>,
   messages: UIMessageLike[],
   run: AgentRunMetadata | undefined,
   session: AgentChatMessageTriggerInput["session"] | undefined,
@@ -404,7 +405,7 @@ export function createChatMessageTriggerInput<TRuntimeConfig extends AgentRuntim
   const providerSessionId = triggerInput?.context?.["chat.sessionId"] || (transportSessionId && selectedSessionId
     ? `${transportSessionId}:chat-session:${selectedSessionId}`
     : transportSessionId)
-  const hookArgs = createChatTriggerHookArgs<TRuntimeConfig>(selectedMessages, triggerInput?.run, triggerInput?.session)
+  const hookArgs = createChatTriggerHookArgs(options, selectedMessages, triggerInput?.run, triggerInput?.session)
   const invoker = resolveChatTriggerInvoker(triggerInput)
   return {
     hookArgs,

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -63,11 +63,7 @@ function chatIdentity(user: Record<string, unknown> | undefined, run: AgentRunMe
 }
 
 export function resolveChatTriggerInvoker(triggerInput: AgentChatMessageTriggerInput | undefined): AgentInvoker | undefined {
-  const userMeta: Record<string, unknown> = {}
-  for (const key of ["id", "sub", "email", "username", "name", "customer"]) {
-    const value = firstString(triggerInput?.user?.[key])?.trim()
-    if (value) userMeta[key] = value
-  }
+  const userMeta = chatTriggerUserMeta(triggerInput?.user)
   const meta = Object.keys(userMeta).length || triggerInput?.meta
     ? { ...userMeta, ...triggerInput?.meta }
     : undefined
@@ -81,6 +77,15 @@ export function resolveChatTriggerInvoker(triggerInput: AgentChatMessageTriggerI
           ...(meta ? { meta } : {}),
         }, "chat.message input.user")
       : undefined
+}
+
+export function chatTriggerUserMeta(user: Record<string, unknown> | undefined): Record<string, unknown> {
+  const userMeta: Record<string, unknown> = {}
+  for (const key of ["id", "sub", "email", "username", "name", "customer"]) {
+    const value = firstString(user?.[key])?.trim()
+    if (value) userMeta[key] = value
+  }
+  return userMeta
 }
 
 function uiToolName(part: Record<string, unknown>): string {

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -214,22 +214,24 @@ export type AgentChannelContext<
 > = AgentChatContext<TMeta, TUser, TMessageMetadata> & { run?: AgentRunMetadata }
 
 declare global {
-  interface ViteHubAgentChannelMeta {}
-  interface ViteHubAgentChannelUser {}
   interface ViteHubAgentInvocationContextValues {
-    chat: AgentChatContext<ViteHubAgentChannelMeta, ViteHubAgentChannelUser>
-    channel: AgentChannelContext<ViteHubAgentChannelMeta, ViteHubAgentChannelUser>
+    chat: AgentChatContext
+    channel: AgentChannelContext
   }
   interface ViteHubWorkspaceSourceResolutionContextMap {
-    channel: AgentChannelContext<ViteHubAgentChannelMeta, ViteHubAgentChannelUser>
+    channel: AgentChannelContext
   }
 }
 
-export function getAgentChatContext(
+export function getAgentChatContext<
+  TMeta extends object = Record<string, unknown>,
+  TUser extends object = Record<string, unknown>,
+>(
   input: AgentInvocationContextStore | { context: AgentInvocationContextStore },
-): AgentChatContext<ViteHubAgentChannelMeta, ViteHubAgentChannelUser> | undefined {
+): AgentChatContext<TMeta, TUser> | undefined {
   const store = "get" in input ? input : input.context
-  return store.get(agentChatContextKey)
+  // SAFETY: The caller supplies the Agent-owned metadata contract for this context lookup.
+  return store.get(agentChatContextKey) as AgentChatContext<TMeta, TUser> | undefined
 }
 
 async function resolveChatThinkingFallback<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -223,15 +223,21 @@ declare global {
   }
 }
 
+export function getAgentChatContext(
+  input: AgentInvocationContextStore | { context: AgentInvocationContextStore },
+): AgentChatContext | undefined
 export function getAgentChatContext<
-  TMeta extends object = Record<string, unknown>,
-  TUser extends object = Record<string, unknown>,
+  TSchema extends { "~standard": { types?: { output: object } } },
 >(
   input: AgentInvocationContextStore | { context: AgentInvocationContextStore },
-): AgentChatContext<TMeta, TUser> | undefined {
+  _metaSchema: TSchema,
+): AgentChatContext<NonNullable<TSchema["~standard"]["types"]>["output"]> | undefined
+export function getAgentChatContext(
+  input: AgentInvocationContextStore | { context: AgentInvocationContextStore },
+  _metaSchema?: unknown,
+): AgentChatContext | undefined {
   const store = "get" in input ? input : input.context
-  // SAFETY: The caller supplies the Agent-owned metadata contract for this context lookup.
-  return store.get(agentChatContextKey) as AgentChatContext<TMeta, TUser> | undefined
+  return store.get(agentChatContextKey)
 }
 
 async function resolveChatThinkingFallback<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -384,7 +384,7 @@ export function chat<
   const TOptions extends AgentChatCapabilityOptions<any> = AgentChatCapabilityOptions,
 >(
   // SAFETY: Chat Capability normalization establishes the asserted trigger and delivery contract.
-  options: TOptions = {} as TOptions,
+  options: TOptions & { meta?: never } = {} as TOptions,
 ): AgentCapabilityDefinition<ChatRuntimeConfigOf<TOptions>, WorkspaceName, ChatCapabilityTypeContract<string>> {
   // SAFETY: AgentChatCapabilityOptions is the public subset of the same Chat Capability option contract.
   return defineChatCapability(options as AgentChatOptions<ChatRuntimeConfigOf<TOptions>>) as AgentCapabilityDefinition<ChatRuntimeConfigOf<TOptions>, WorkspaceName, ChatCapabilityTypeContract<string>>

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -29,7 +29,7 @@ import { getAgentInvocationRecoveryWorkflowName } from "@vite-hub/internal/agent
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
 import { defineChatCapability, durableChatErrorFallbackTimeout, getAgentChatContext, getChatCapabilityOptions, isDurableChatErrorFallbackEffect, resolveDurableChatErrorFallbackIntents } from "./chat-trigger.ts"
 import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
-import { hasParsedAgentMessageMeta, parseAgentMessageMeta } from "./internal/message-meta.ts"
+import { hasParsedAgentMessageMeta, parseAgentMessageMeta, withParsedAgentMessageMeta } from "./internal/message-meta.ts"
 import {
   bindMessageChannelInstructions,
   finishMessageChannelTitleDelivery,
@@ -921,7 +921,10 @@ async function runAgentAsWorkflow<
   const handle = await getAgentWorkflowHandle<TRuntimeConfig, CALL_OPTIONS, TOutput>(agent, workflowName, Boolean(context.agentIdentity))
   const resolvedContext = createResolvedRuntimeContext(context)
   // ponytail: AbortSignal is live process state and cannot cross a durable Workflow payload.
-  const workflowInput = await portableAgentWorkflowInput(input)
+  const parsedInput = hasAgentDefinition(agent)
+    ? await withParsedAgentMessageMeta(agent, input, context.run)
+    : input
+  const workflowInput = await portableAgentWorkflowInput(parsedInput)
   const channelDeliveryBinding = input.context?.[agentChannelDeliveryWorkflowContextKey]
   const durableChannelDelivery = isAgentChannelDeliveryWorkflowBinding(channelDeliveryBinding)
   const inheritedRun = options.fresh && context.run && !durableChannelDelivery
@@ -934,7 +937,7 @@ async function runAgentAsWorkflow<
     input: cloneWorkflowJsonValue(workflowInput) as AgentRunInput<CALL_OPTIONS>,
     // Headers and bodies may contain webhook credentials and remain process-local by design.
     ...(context.request ? { requestUrl: context.request.url } : {}),
-    ...(hasParsedAgentMessageMeta(input) ? { parsedMessageMeta: true } : {}),
+    ...(hasParsedAgentMessageMeta(parsedInput) ? { parsedMessageMeta: true } : {}),
     ...(hasResolvedAgentInvokerInput(input) ? { resolvedInvoker: true } : {}),
     runtime: context.runtime,
     runtimeConfig: resolvedContext.runtimeConfig,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2970,7 +2970,7 @@ async function createAgentInvocationContext<
   const resolvedContext = createResolvedRuntimeContext(context)
   const invocationContext = createAgentInvocationContextStore(input.context)
   await parseAgentMessageMeta(definition, invocationContext, context.run)
-  const parsedInput = { ...input, context: invocationContext.toJSON() }
+  input = { ...input, context: invocationContext.toJSON() }
   const telemetryInvocationId = createTraceId()
   let telemetryScheduler: AgentTelemetryScheduler | undefined
   const telemetryChanged = (entry: TraceEventLogEntry) => telemetryScheduler?.changed(entry)
@@ -3037,7 +3037,7 @@ async function createAgentInvocationContext<
       definition?.invoker,
       callbackContext,
       invocationContext,
-      parsedInput,
+      input,
       context.run,
       invocationContext.get(scheduledAgentTurnContextKey) === true,
     )

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -26,6 +26,7 @@ import { agentTelemetryTask } from "./internal/telemetry-task.ts"
 import { getAgentTelemetryConfiguration, safeAgentTelemetryMetadata, setAgentTelemetryConfiguration } from "./internal/agent-telemetry.ts"
 import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { getAgentInvocationRecoveryWorkflowName } from "@vite-hub/internal/agent-workflow"
+import { parseStandardSchema } from "@vite-hub/internal/http-request"
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
 import { defineChatCapability, durableChatErrorFallbackTimeout, getAgentChatContext, getChatCapabilityOptions, isDurableChatErrorFallbackEffect, resolveDurableChatErrorFallbackIntents } from "./chat-trigger.ts"
 import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
@@ -1082,6 +1083,30 @@ function activeAgentChannel<TRuntimeConfig extends AgentRuntimeConfig>(
   const channelId = run?.channelId || trigger?.channelId
   const channel = channelId ? channels?.[channelId] : undefined
   return channel && channelId ? { channel, channelId, trigger } : undefined
+}
+
+async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
+  invocationContext: AgentInvocationContextStore,
+  run?: AgentRunMetadata,
+): Promise<void> {
+  const activeMessages = activeAgentChannel(definition?.channels, invocationContext, run)?.channel.messages
+  const schema = activeMessages
+    ? activeMessages.meta ?? definition?.messages?.meta
+    : definition?.messages?.meta
+  if (!schema) return
+  if (!schema["~standard"] || !hasRuntimeType(schema["~standard"].validate, "function")) {
+    throw new TypeError("[vitehub] defineAgent({ messages: { meta } }) requires a Standard Schema.")
+  }
+  const channel = invocationContext.get("channel")
+  const chat = invocationContext.get("chat")
+  if (!channel && !chat) return
+  const meta = await parseStandardSchema(schema, channel?.meta ?? chat?.meta ?? {}, "agent channel metadata")
+  if (!isRuntimeObject(meta) || Array.isArray(meta)) {
+    throw new TypeError("[vitehub] Agent channel metadata schema must return an object.")
+  }
+  if (channel) invocationContext.set("channel", { ...channel, meta }, { overwrite: true })
+  if (chat) invocationContext.set("chat", { ...chat, meta }, { overwrite: true })
 }
 
 async function setChannelDeliverySupportContext<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
@@ -2973,6 +2998,7 @@ async function createAgentInvocationContext<
   const startedAt = Date.now()
   const resolvedContext = createResolvedRuntimeContext(context)
   const invocationContext = createAgentInvocationContextStore(input.context)
+  await parseAgentMessageMeta(definition, invocationContext, context.run)
   const telemetryInvocationId = createTraceId()
   let telemetryScheduler: AgentTelemetryScheduler | undefined
   const telemetryChanged = (entry: TraceEventLogEntry) => telemetryScheduler?.changed(entry)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -29,7 +29,7 @@ import { getAgentInvocationRecoveryWorkflowName } from "@vite-hub/internal/agent
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
 import { defineChatCapability, durableChatErrorFallbackTimeout, getAgentChatContext, getChatCapabilityOptions, isDurableChatErrorFallbackEffect, resolveDurableChatErrorFallbackIntents } from "./chat-trigger.ts"
 import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
-import { parseAgentMessageMeta } from "./internal/message-meta.ts"
+import { hasParsedAgentMessageMeta, parseAgentMessageMeta } from "./internal/message-meta.ts"
 import {
   bindMessageChannelInstructions,
   finishMessageChannelTitleDelivery,
@@ -665,6 +665,7 @@ interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
     workflowName: string
   }
   requestUrl?: string
+  parsedMessageMeta?: boolean
   resolvedInvoker?: boolean
   run?: Partial<AgentRunMetadata>
   trace?: AgentRuntimeContext["trace"]
@@ -933,6 +934,7 @@ async function runAgentAsWorkflow<
     input: cloneWorkflowJsonValue(workflowInput) as AgentRunInput<CALL_OPTIONS>,
     // Headers and bodies may contain webhook credentials and remain process-local by design.
     ...(context.request ? { requestUrl: context.request.url } : {}),
+    ...(hasParsedAgentMessageMeta(input) ? { parsedMessageMeta: true } : {}),
     ...(hasResolvedAgentInvokerInput(input) ? { resolvedInvoker: true } : {}),
     runtime: context.runtime,
     runtimeConfig: resolvedContext.runtimeConfig,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -930,6 +930,7 @@ async function runAgentAsWorkflow<
   const inheritedRun = options.fresh && context.run && !durableChannelDelivery
     ? Object.fromEntries(Object.entries(context.run).filter(([key]) => key !== "runId"))
     : context.run
+  // SAFETY: withParsedAgentMessageMeta preserves this invocation's call-options type.
   const parsedMessageMeta = parsedAgentMessageMetaReceiptId(agent, parsedInput as AgentRunInput<CALL_OPTIONS>, context.run)
   const payload: AgentWorkflowInvocationPayload<CALL_OPTIONS> = {
     ...(context.agentIdentity ? { agentIdentity: context.agentIdentity } : {}),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -26,10 +26,10 @@ import { agentTelemetryTask } from "./internal/telemetry-task.ts"
 import { getAgentTelemetryConfiguration, safeAgentTelemetryMetadata, setAgentTelemetryConfiguration } from "./internal/agent-telemetry.ts"
 import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { getAgentInvocationRecoveryWorkflowName } from "@vite-hub/internal/agent-workflow"
-import { parseStandardSchema } from "@vite-hub/internal/http-request"
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
 import { defineChatCapability, durableChatErrorFallbackTimeout, getAgentChatContext, getChatCapabilityOptions, isDurableChatErrorFallbackEffect, resolveDurableChatErrorFallbackIntents } from "./chat-trigger.ts"
 import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
+import { parseAgentMessageMeta } from "./internal/message-meta.ts"
 import {
   bindMessageChannelInstructions,
   finishMessageChannelTitleDelivery,
@@ -1058,13 +1058,6 @@ function createAgentCallbackContext<TRuntimeConfig extends AgentRuntimeConfig>(
   return callbackContext
 }
 
-type AgentTriggerContextValue = {
-  channelId?: string
-  id?: string
-  name?: string
-  source?: "capability" | "channel"
-}
-
 function channelDeliveryEffectHandlers<TRuntimeConfig extends AgentRuntimeConfig>(
   channel: AgentChannelDefinition<TRuntimeConfig>,
   intent: AgentChannelDeliveryEffectIntent,
@@ -1083,30 +1076,6 @@ function activeAgentChannel<TRuntimeConfig extends AgentRuntimeConfig>(
   const channelId = run?.channelId || trigger?.channelId
   const channel = channelId ? channels?.[channelId] : undefined
   return channel && channelId ? { channel, channelId, trigger } : undefined
-}
-
-async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
-  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
-  invocationContext: AgentInvocationContextStore,
-  run?: AgentRunMetadata,
-): Promise<void> {
-  const activeMessages = activeAgentChannel(definition?.channels, invocationContext, run)?.channel.messages
-  const schema = activeMessages
-    ? activeMessages.meta ?? definition?.messages?.meta
-    : definition?.messages?.meta
-  if (!schema) return
-  if (!schema["~standard"] || !hasRuntimeType(schema["~standard"].validate, "function")) {
-    throw new TypeError("[vitehub] defineAgent({ messages: { meta } }) requires a Standard Schema.")
-  }
-  const channel = invocationContext.get("channel")
-  const chat = invocationContext.get("chat")
-  if (!channel && !chat) return
-  const meta = await parseStandardSchema(schema, channel?.meta ?? chat?.meta ?? {}, "agent channel metadata")
-  if (!isRuntimeObject(meta) || Array.isArray(meta)) {
-    throw new TypeError("[vitehub] Agent channel metadata schema must return an object.")
-  }
-  if (channel) invocationContext.set("channel", { ...channel, meta }, { overwrite: true })
-  if (chat) invocationContext.set("chat", { ...chat, meta }, { overwrite: true })
 }
 
 async function setChannelDeliverySupportContext<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -939,7 +939,7 @@ async function runAgentAsWorkflow<
     input: cloneWorkflowJsonValue(workflowInput) as AgentRunInput<CALL_OPTIONS>,
     // Headers and bodies may contain webhook credentials and remain process-local by design.
     ...(context.request ? { requestUrl: context.request.url } : {}),
-    ...(parsedMessageMeta ? { parsedMessageMeta } : {}),
+    ...(parsedMessageMeta !== undefined ? { parsedMessageMeta } : {}),
     ...(hasResolvedAgentInvokerInput(input) ? { resolvedInvoker: true } : {}),
     runtime: context.runtime,
     runtimeConfig: resolvedContext.runtimeConfig,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2970,6 +2970,7 @@ async function createAgentInvocationContext<
   const resolvedContext = createResolvedRuntimeContext(context)
   const invocationContext = createAgentInvocationContextStore(input.context)
   await parseAgentMessageMeta(definition, invocationContext, context.run)
+  const parsedInput = { ...input, context: invocationContext.toJSON() }
   const telemetryInvocationId = createTraceId()
   let telemetryScheduler: AgentTelemetryScheduler | undefined
   const telemetryChanged = (entry: TraceEventLogEntry) => telemetryScheduler?.changed(entry)
@@ -3036,7 +3037,7 @@ async function createAgentInvocationContext<
       definition?.invoker,
       callbackContext,
       invocationContext,
-      input,
+      parsedInput,
       context.run,
       invocationContext.get(scheduledAgentTurnContextKey) === true,
     )

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -29,7 +29,7 @@ import { getAgentInvocationRecoveryWorkflowName } from "@vite-hub/internal/agent
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
 import { defineChatCapability, durableChatErrorFallbackTimeout, getAgentChatContext, getChatCapabilityOptions, isDurableChatErrorFallbackEffect, resolveDurableChatErrorFallbackIntents } from "./chat-trigger.ts"
 import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
-import { hasParsedAgentMessageMeta, parseAgentMessageMeta, withParsedAgentMessageMeta } from "./internal/message-meta.ts"
+import { parsedAgentMessageMetaReceiptId, parseAgentMessageMeta, withParsedAgentMessageMeta } from "./internal/message-meta.ts"
 import {
   bindMessageChannelInstructions,
   finishMessageChannelTitleDelivery,
@@ -665,7 +665,7 @@ interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
     workflowName: string
   }
   requestUrl?: string
-  parsedMessageMeta?: boolean
+  parsedMessageMeta?: string
   resolvedInvoker?: boolean
   run?: Partial<AgentRunMetadata>
   trace?: AgentRuntimeContext["trace"]
@@ -930,6 +930,7 @@ async function runAgentAsWorkflow<
   const inheritedRun = options.fresh && context.run && !durableChannelDelivery
     ? Object.fromEntries(Object.entries(context.run).filter(([key]) => key !== "runId"))
     : context.run
+  const parsedMessageMeta = parsedAgentMessageMetaReceiptId(agent, parsedInput as AgentRunInput<CALL_OPTIONS>, context.run)
   const payload: AgentWorkflowInvocationPayload<CALL_OPTIONS> = {
     ...(context.agentIdentity ? { agentIdentity: context.agentIdentity } : {}),
     ...(Object.keys(disabledCapabilities).length ? { capabilities: disabledCapabilities } : {}),
@@ -937,7 +938,7 @@ async function runAgentAsWorkflow<
     input: cloneWorkflowJsonValue(workflowInput) as AgentRunInput<CALL_OPTIONS>,
     // Headers and bodies may contain webhook credentials and remain process-local by design.
     ...(context.request ? { requestUrl: context.request.url } : {}),
-    ...(hasParsedAgentMessageMeta(agent, parsedInput, context.run) ? { parsedMessageMeta: true } : {}),
+    ...(parsedMessageMeta ? { parsedMessageMeta } : {}),
     ...(hasResolvedAgentInvokerInput(input) ? { resolvedInvoker: true } : {}),
     runtime: context.runtime,
     runtimeConfig: resolvedContext.runtimeConfig,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -2975,7 +2975,7 @@ async function createAgentInvocationContext<
   const resolvedContext = createResolvedRuntimeContext(context)
   const invocationContext = createAgentInvocationContextStore(input.context)
   await parseAgentMessageMeta(definition, invocationContext, context.run)
-  input = { ...input, context: invocationContext.toJSON() }
+  input = { ...input, context: { ...input.context, ...invocationContext.toJSON() } }
   const telemetryInvocationId = createTraceId()
   let telemetryScheduler: AgentTelemetryScheduler | undefined
   const telemetryChanged = (entry: TraceEventLogEntry) => telemetryScheduler?.changed(entry)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -29,7 +29,8 @@ import { getAgentInvocationRecoveryWorkflowName } from "@vite-hub/internal/agent
 import { agentResultKind, agentStreamErrorSymbol, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
 import { defineChatCapability, durableChatErrorFallbackTimeout, getAgentChatContext, getChatCapabilityOptions, isDurableChatErrorFallbackEffect, resolveDurableChatErrorFallbackIntents } from "./chat-trigger.ts"
 import { agentWorkflowExecutionContextKey } from "./internal/workflow-execution.ts"
-import { parsedAgentMessageMetaReceiptId, parseAgentMessageMeta, withParsedAgentMessageMeta } from "./internal/message-meta.ts"
+import { parsedAgentMessageMetaState, parseAgentMessageMeta, withParsedAgentMessageMeta } from "./internal/message-meta.ts"
+import type { ParsedAgentMessageMetaState } from "./internal/message-meta.ts"
 import {
   bindMessageChannelInstructions,
   finishMessageChannelTitleDelivery,
@@ -665,7 +666,7 @@ interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
     workflowName: string
   }
   requestUrl?: string
-  parsedMessageMeta?: string
+  parsedMessageMeta?: ParsedAgentMessageMetaState
   resolvedInvoker?: boolean
   run?: Partial<AgentRunMetadata>
   trace?: AgentRuntimeContext["trace"]
@@ -931,7 +932,7 @@ async function runAgentAsWorkflow<
     ? Object.fromEntries(Object.entries(context.run).filter(([key]) => key !== "runId"))
     : context.run
   // SAFETY: withParsedAgentMessageMeta preserves this invocation's call-options type.
-  const parsedMessageMeta = parsedAgentMessageMetaReceiptId(agent, parsedInput as AgentRunInput<CALL_OPTIONS>, context.run)
+  const parsedMessageMeta = parsedAgentMessageMetaState(agent, parsedInput as AgentRunInput<CALL_OPTIONS>, context.run)
   const payload: AgentWorkflowInvocationPayload<CALL_OPTIONS> = {
     ...(context.agentIdentity ? { agentIdentity: context.agentIdentity } : {}),
     ...(Object.keys(disabledCapabilities).length ? { capabilities: disabledCapabilities } : {}),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -937,7 +937,7 @@ async function runAgentAsWorkflow<
     input: cloneWorkflowJsonValue(workflowInput) as AgentRunInput<CALL_OPTIONS>,
     // Headers and bodies may contain webhook credentials and remain process-local by design.
     ...(context.request ? { requestUrl: context.request.url } : {}),
-    ...(hasParsedAgentMessageMeta(parsedInput) ? { parsedMessageMeta: true } : {}),
+    ...(hasParsedAgentMessageMeta(agent, parsedInput, context.run) ? { parsedMessageMeta: true } : {}),
     ...(hasResolvedAgentInvokerInput(input) ? { resolvedInvoker: true } : {}),
     runtime: context.runtime,
     runtimeConfig: resolvedContext.runtimeConfig,

--- a/packages/agent/src/internal/channels.ts
+++ b/packages/agent/src/internal/channels.ts
@@ -300,9 +300,9 @@ export function resolveAgentChannelChatOptions<TRuntimeConfig extends AgentRunti
   }
   if (channelMessageOverrides.length) {
     if (messageChannelCount > 1) {
-      const unsupportedOverrides = channelMessageOverrides.some(({ commentary: _commentary, filter: _filter, stream: _stream, ...channelMessages }) => Object.keys(channelMessages).length > 0)
+      const unsupportedOverrides = channelMessageOverrides.some(({ commentary: _commentary, filter: _filter, meta: _meta, stream: _stream, ...channelMessages }) => Object.keys(channelMessages).length > 0)
       if (unsupportedOverrides) {
-        throw new TypeError("[vitehub] Channel-local messages options other than commentary, filter, or stream are only supported when an Agent defines one message-shaped Channel. Move shared settings to defineAgent({ messages }) until Channel-scoped chat triggers land.")
+        throw new TypeError("[vitehub] Channel-local messages options other than commentary, filter, meta, or stream are only supported when an Agent defines one message-shaped Channel. Move shared settings to defineAgent({ messages }) until Channel-scoped chat triggers land.")
       }
     }
     else {

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -6,6 +6,16 @@ import { hasRuntimeType, isRuntimeObject } from "./runtime-type.ts"
 import type { AgentDefinition, AgentInvocationContextStore, AgentRunInput, AgentRunMetadata, AgentRuntimeConfig } from "../types.ts"
 
 const parsedAgentMessageMetaContextKey = "vitehub.agent.messageMetaParsed"
+const parsedAgentMessageMetaReceipt = Object.freeze({})
+
+function withParsedMeta(invoker: unknown, rawMeta: Record<string, unknown>, meta: Record<string, unknown>): unknown {
+  if (!isRuntimeObject(invoker)) return invoker
+  const record = invoker as Record<string, unknown>
+  if (record.kind !== "chat" || !isRuntimeObject(record.meta)) return invoker
+  const invokerMeta: Record<string, unknown> = { ...record.meta }
+  for (const key of Object.keys(rawMeta)) delete invokerMeta[key]
+  return { ...record, meta: { ...invokerMeta, ...meta } }
+}
 
 function activeMessageSettings<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
   definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
@@ -26,20 +36,26 @@ export async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeC
   const channelMessages = activeMessageSettings(definition, invocationContext, run)
   const schema = channelMessages ? channelMessages.meta ?? definition?.messages?.meta : definition?.messages?.meta
   if (!schema) return
-  if (invocationContext.get(parsedAgentMessageMetaContextKey) === true) return
+  if (invocationContext.get(parsedAgentMessageMetaContextKey) === parsedAgentMessageMetaReceipt) return
   if (!schema["~standard"] || !hasRuntimeType(schema["~standard"].validate, "function")) {
     throw new TypeError("[vitehub] defineAgent({ messages: { meta } }) requires a Standard Schema.")
   }
   const channel = invocationContext.get("channel")
   const chat = invocationContext.get("chat")
   if (!isRuntimeObject(channel) && !isRuntimeObject(chat)) return
-  const meta = await parseStandardSchema(schema, channel?.meta ?? chat?.meta ?? {}, "agent channel metadata")
+  const rawMeta = channel?.meta ?? chat?.meta ?? {}
+  const meta = await parseStandardSchema(schema, rawMeta, "agent channel metadata")
   if (!isRuntimeObject(meta) || Array.isArray(meta)) {
     throw new TypeError("[vitehub] Agent channel metadata schema must return an object.")
   }
   if (isRuntimeObject(channel)) invocationContext.set("channel", { ...channel, meta }, { overwrite: true })
   if (isRuntimeObject(chat)) invocationContext.set("chat", { ...chat, meta }, { overwrite: true })
-  invocationContext.set(parsedAgentMessageMetaContextKey, true, { overwrite: true })
+  const invoker = withParsedMeta(invocationContext.get("invoker"), rawMeta, meta)
+  if (invoker !== invocationContext.get("invoker")) {
+    invocationContext.set("actor", invoker, { overwrite: true })
+    invocationContext.set("invoker", invoker, { overwrite: true })
+  }
+  invocationContext.set(parsedAgentMessageMetaContextKey, parsedAgentMessageMetaReceipt, { overwrite: true })
 }
 
 export async function withParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -1,6 +1,6 @@
 import { parseStandardSchema } from "@vite-hub/internal/http-request"
 
-import { chatTriggerUserMeta, hasDerivedChatTriggerInvoker } from "../chat-message-input.ts"
+import { chatTriggerUserMeta, hasDerivedChatTriggerInvoker, markDerivedChatTriggerInvoker } from "../chat-message-input.ts"
 import { createAgentInvocationContextStore } from "../invocation-context.ts"
 import { normalizeAgentInvoker } from "../invoker.ts"
 import { hasRuntimeType, isRuntimeObject, isRuntimeRecord } from "./runtime-type.ts"
@@ -9,6 +9,10 @@ import type { AgentDefinition, AgentInvocationContextStore, AgentRunInput, Agent
 
 const parsedAgentMessageMetaContextKey = "vitehub.agent.messageMetaParsed"
 interface ParsedAgentMessageMetaReceipt {
+  revision?: string
+}
+export interface ParsedAgentMessageMetaState {
+  derivedInvoker?: true
   revision?: string
 }
 
@@ -48,24 +52,30 @@ export function hasParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntimeCon
   return input.context?.[parsedAgentMessageMetaContextKey] === parsedAgentMessageMetaReceipt(definition, invocationContext, run)
 }
 
-export function parsedAgentMessageMetaReceiptId<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
+export function parsedAgentMessageMetaState<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
   definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
   input: AgentRunInput<CALL_OPTIONS>,
   run?: AgentRunMetadata,
-): string | undefined {
+): ParsedAgentMessageMetaState | undefined {
   const invocationContext = createAgentInvocationContextStore(input.context)
   const receipt = parsedAgentMessageMetaReceipt(definition, invocationContext, run)
-  return input.context?.[parsedAgentMessageMetaContextKey] === receipt ? receipt?.revision : undefined
+  if (input.context?.[parsedAgentMessageMetaContextKey] !== receipt) return
+  return {
+    ...(hasDerivedChatTriggerInvoker(invocationContext.get("invoker")) ? { derivedInvoker: true } : {}),
+    ...(receipt?.revision !== undefined ? { revision: receipt.revision } : {}),
+  }
 }
 
 export function restoreParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
   definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
   input: AgentRunInput<CALL_OPTIONS>,
   run?: AgentRunMetadata,
-  revision?: string,
+  state?: ParsedAgentMessageMetaState,
 ): AgentRunInput<CALL_OPTIONS> {
+  if (!state) return input
+  if (state.derivedInvoker) markDerivedChatTriggerInvoker(input.context?.invoker)
   const receipt = parsedAgentMessageMetaReceipt(definition, createAgentInvocationContextStore(input.context), run)
-  if (!receipt || revision === undefined || receipt.revision !== revision) return input
+  if (!receipt || state.revision === undefined || receipt.revision !== state.revision) return input
   return {
     ...input,
     context: { ...input.context, [parsedAgentMessageMetaContextKey]: receipt },
@@ -87,7 +97,9 @@ function withParsedMeta(invoker: unknown, rawMeta: unknown, meta: Record<string,
     meta: { ...invokerMeta, ...chatTriggerUserMeta(isRuntimeRecord(user) ? user : undefined), ...meta },
   }
   if (isRuntimeObject(rawMeta) && Object.hasOwn(rawMeta, "email")) normalizedInvoker.email = undefined
-  return normalizeAgentInvoker(normalizedInvoker)
+  const normalized = normalizeAgentInvoker(normalizedInvoker)
+  markDerivedChatTriggerInvoker(normalized)
+  return normalized
 }
 
 function activeMessageSettings<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -49,7 +49,8 @@ export function hasParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntimeCon
   run?: AgentRunMetadata,
 ): boolean {
   const invocationContext = createAgentInvocationContextStore(input.context)
-  return input.context?.[parsedAgentMessageMetaContextKey] === parsedAgentMessageMetaReceipt(definition, invocationContext, run)
+  const receipt = parsedAgentMessageMetaReceipt(definition, invocationContext, run)
+  return receipt !== undefined && input.context?.[parsedAgentMessageMetaContextKey] === receipt
 }
 
 export function parsedAgentMessageMetaState<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -65,7 +65,7 @@ export function restoreParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntim
   revision?: string,
 ): AgentRunInput<CALL_OPTIONS> {
   const receipt = parsedAgentMessageMetaReceipt(definition, createAgentInvocationContextStore(input.context), run)
-  if (!receipt || !revision || receipt.revision !== revision) return input
+  if (!receipt || revision === undefined || receipt.revision !== revision) return input
   return {
     ...input,
     context: { ...input.context, [parsedAgentMessageMetaContextKey]: receipt },

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -77,7 +77,17 @@ export function restoreParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntim
   if (state.derivedInvoker) markDerivedChatTriggerInvoker(input.context?.invoker, state.derivedInvoker)
   const receipt = parsedAgentMessageMetaReceipt(definition, createAgentInvocationContextStore(input.context), run)
   if (!receipt || state.revision === undefined || receipt.revision !== state.revision) {
-    return state.derivedInvoker ? withoutResolvedAgentInvokerInput(input) : input
+    if (!state.derivedInvoker) return input
+    const unresolved = withoutResolvedAgentInvokerInput(input)
+    if (receipt) return unresolved
+    return {
+      ...unresolved,
+      context: {
+        ...unresolved.context,
+        actor: state.derivedInvoker,
+        invoker: state.derivedInvoker,
+      },
+    }
   }
   return {
     ...input,

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -1,6 +1,6 @@
 import { parseStandardSchema } from "@vite-hub/internal/http-request"
 
-import { chatTriggerUserMeta } from "../chat-message-input.ts"
+import { chatTriggerUserMeta, hasDerivedChatTriggerInvoker } from "../chat-message-input.ts"
 import { createAgentInvocationContextStore } from "../invocation-context.ts"
 import { normalizeAgentInvoker } from "../invoker.ts"
 import { hasRuntimeType, isRuntimeObject, isRuntimeRecord } from "./runtime-type.ts"
@@ -72,8 +72,9 @@ export function restoreParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntim
   }
 }
 
-function withParsedMeta(invoker: unknown, rawMeta: unknown, meta: Record<string, unknown>, user: unknown): unknown {
+function withParsedMeta(invoker: unknown, rawMeta: unknown, meta: Record<string, unknown>, user: unknown, derived: boolean): unknown {
   if (!isRuntimeObject(invoker)) return invoker
+  if (!derived) return invoker
   // SAFETY: isRuntimeObject established the mutable string-keyed record representation.
   const record = invoker as Record<string, unknown>
   if (record.kind !== "chat" || !isRuntimeObject(record.meta)) return invoker
@@ -131,7 +132,13 @@ export async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeC
   if (isRuntimeObject(chat)) invocationContext.set("chat", { ...chat, meta }, { overwrite: true })
   // SAFETY: the object-output check above establishes a metadata record.
   const user = isRuntimeObject(channel) ? channel.user : isRuntimeObject(chat) ? chat.user : undefined
-  const invoker = withParsedMeta(invocationContext.get("invoker"), rawMeta, meta as Record<string, unknown>, user)
+  const invoker = withParsedMeta(
+    invocationContext.get("invoker"),
+    rawMeta,
+    meta as Record<string, unknown>,
+    user,
+    hasDerivedChatTriggerInvoker(invocationContext.get("invoker")),
+  )
   if (invoker !== invocationContext.get("invoker")) {
     invocationContext.set("actor", invoker, { overwrite: true })
     invocationContext.set("invoker", invoker, { overwrite: true })

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -1,6 +1,7 @@
 import { parseStandardSchema } from "@vite-hub/internal/http-request"
 
 import { createAgentInvocationContextStore } from "../invocation-context.ts"
+import { normalizeAgentInvoker } from "../invoker.ts"
 import { hasRuntimeType, isRuntimeObject } from "./runtime-type.ts"
 
 import type { AgentDefinition, AgentInvocationContextStore, AgentRunInput, AgentRunMetadata, AgentRuntimeConfig } from "../types.ts"
@@ -25,7 +26,11 @@ function withParsedMeta(invoker: unknown, rawMeta: Record<string, unknown>, meta
   if (record.kind !== "chat" || !isRuntimeObject(record.meta)) return invoker
   const invokerMeta: Record<string, unknown> = { ...record.meta }
   for (const key of Object.keys(rawMeta)) delete invokerMeta[key]
-  return { ...record, meta: { ...invokerMeta, ...meta } }
+  return normalizeAgentInvoker({
+    ...record,
+    ...(Object.hasOwn(rawMeta, "email") ? { email: undefined } : {}),
+    meta: { ...invokerMeta, ...meta },
+  })
 }
 
 function activeMessageSettings<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -8,7 +8,7 @@ import type { AgentDefinition, AgentInvocationContextStore, AgentRunInput, Agent
 
 const parsedAgentMessageMetaContextKey = "vitehub.agent.messageMetaParsed"
 interface ParsedAgentMessageMetaReceipt {
-  id: string
+  revision?: string
 }
 
 const parsedAgentMessageMetaReceipts = new WeakMap<object, WeakMap<object, Map<string | undefined, ParsedAgentMessageMetaReceipt>>>()
@@ -18,7 +18,7 @@ function parsedAgentMessageMetaReceipt<TRuntimeConfig extends AgentRuntimeConfig
   invocationContext: AgentInvocationContextStore,
   run?: AgentRunMetadata,
 ): ParsedAgentMessageMetaReceipt | undefined {
-  const { channelId, schema } = activeMessageSettings(definition, invocationContext, run)
+  const { channelId, revision, schema } = activeMessageSettings(definition, invocationContext, run)
   if (!definition || !schema || !isRuntimeObject(schema)) return
   let definitionReceipts = parsedAgentMessageMetaReceipts.get(definition)
   if (!definitionReceipts) {
@@ -32,7 +32,7 @@ function parsedAgentMessageMetaReceipt<TRuntimeConfig extends AgentRuntimeConfig
   }
   let receipt = schemaReceipts.get(channelId)
   if (!receipt) {
-    receipt = Object.freeze({ id: crypto.randomUUID() })
+    receipt = Object.freeze({ revision })
     schemaReceipts.set(channelId, receipt)
   }
   return receipt
@@ -54,17 +54,17 @@ export function parsedAgentMessageMetaReceiptId<TRuntimeConfig extends AgentRunt
 ): string | undefined {
   const invocationContext = createAgentInvocationContextStore(input.context)
   const receipt = parsedAgentMessageMetaReceipt(definition, invocationContext, run)
-  return input.context?.[parsedAgentMessageMetaContextKey] === receipt ? receipt?.id : undefined
+  return input.context?.[parsedAgentMessageMetaContextKey] === receipt ? receipt?.revision : undefined
 }
 
 export function restoreParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
   definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
   input: AgentRunInput<CALL_OPTIONS>,
   run?: AgentRunMetadata,
-  receiptId?: string,
+  revision?: string,
 ): AgentRunInput<CALL_OPTIONS> {
   const receipt = parsedAgentMessageMetaReceipt(definition, createAgentInvocationContextStore(input.context), run)
-  if (!receipt || receipt.id !== receiptId) return input
+  if (!receipt || !revision || receipt.revision !== revision) return input
   return {
     ...input,
     context: { ...input.context, [parsedAgentMessageMetaContextKey]: receipt },
@@ -73,17 +73,19 @@ export function restoreParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntim
 
 function withParsedMeta(invoker: unknown, rawMeta: unknown, meta: Record<string, unknown>): unknown {
   if (!isRuntimeObject(invoker)) return invoker
+  // SAFETY: isRuntimeObject established the mutable string-keyed record representation.
   const record = invoker as Record<string, unknown>
   if (record.kind !== "chat" || !isRuntimeObject(record.meta)) return invoker
   const invokerMeta: Record<string, unknown> = { ...record.meta }
   if (isRuntimeObject(rawMeta)) {
     for (const key of Object.keys(rawMeta)) delete invokerMeta[key]
   }
-  return normalizeAgentInvoker({
+  const normalizedInvoker: Record<string, unknown> = {
     ...record,
-    ...(isRuntimeObject(rawMeta) && Object.hasOwn(rawMeta, "email") ? { email: undefined } : {}),
     meta: { ...invokerMeta, ...meta },
-  })
+  }
+  if (isRuntimeObject(rawMeta) && Object.hasOwn(rawMeta, "email")) normalizedInvoker.email = undefined
+  return normalizeAgentInvoker(normalizedInvoker)
 }
 
 function activeMessageSettings<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
@@ -94,8 +96,10 @@ function activeMessageSettings<TRuntimeConfig extends AgentRuntimeConfig, CALL_O
   const trigger = invocationContext.get("agent.trigger")
   const triggerChannelId = isRuntimeObject(trigger) && hasRuntimeType(trigger.channelId, "string") ? trigger.channelId : undefined
   const channelId = run?.channelId || triggerChannelId
-  const messages = channelId ? definition?.channels?.[channelId]?.messages : undefined
-  return { channelId, schema: messages ? messages.meta ?? definition?.messages?.meta : definition?.messages?.meta }
+  const configuredChannelMessages = channelId ? definition?.channels?.[channelId]?.messages : undefined
+  const channelMessages = configuredChannelMessages || undefined
+  const messages = channelMessages?.meta ? channelMessages : definition?.messages
+  return { channelId, revision: messages?.metaRevision, schema: messages?.meta }
 }
 
 export async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
@@ -124,7 +128,8 @@ export async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeC
   }
   if (isRuntimeObject(channel)) invocationContext.set("channel", { ...channel, meta }, { overwrite: true })
   if (isRuntimeObject(chat)) invocationContext.set("chat", { ...chat, meta }, { overwrite: true })
-  const invoker = withParsedMeta(invocationContext.get("invoker"), rawMeta, meta)
+  // SAFETY: the object-output check above establishes a metadata record.
+  const invoker = withParsedMeta(invocationContext.get("invoker"), rawMeta, meta as Record<string, unknown>)
   if (invoker !== invocationContext.get("invoker")) {
     invocationContext.set("actor", invoker, { overwrite: true })
     invocationContext.set("invoker", invoker, { overwrite: true })

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -7,13 +7,17 @@ import { hasRuntimeType, isRuntimeObject } from "./runtime-type.ts"
 import type { AgentDefinition, AgentInvocationContextStore, AgentRunInput, AgentRunMetadata, AgentRuntimeConfig } from "../types.ts"
 
 const parsedAgentMessageMetaContextKey = "vitehub.agent.messageMetaParsed"
-const parsedAgentMessageMetaReceipts = new WeakMap<object, WeakMap<object, Map<string | undefined, object>>>()
+interface ParsedAgentMessageMetaReceipt {
+  id: string
+}
+
+const parsedAgentMessageMetaReceipts = new WeakMap<object, WeakMap<object, Map<string | undefined, ParsedAgentMessageMetaReceipt>>>()
 
 function parsedAgentMessageMetaReceipt<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
   definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
   invocationContext: AgentInvocationContextStore,
   run?: AgentRunMetadata,
-): object | undefined {
+): ParsedAgentMessageMetaReceipt | undefined {
   const { channelId, schema } = activeMessageSettings(definition, invocationContext, run)
   if (!definition || !schema || !isRuntimeObject(schema)) return
   let definitionReceipts = parsedAgentMessageMetaReceipts.get(definition)
@@ -28,7 +32,7 @@ function parsedAgentMessageMetaReceipt<TRuntimeConfig extends AgentRuntimeConfig
   }
   let receipt = schemaReceipts.get(channelId)
   if (!receipt) {
-    receipt = Object.freeze({})
+    receipt = Object.freeze({ id: crypto.randomUUID() })
     schemaReceipts.set(channelId, receipt)
   }
   return receipt
@@ -43,13 +47,24 @@ export function hasParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntimeCon
   return input.context?.[parsedAgentMessageMetaContextKey] === parsedAgentMessageMetaReceipt(definition, invocationContext, run)
 }
 
+export function parsedAgentMessageMetaReceiptId<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
+  input: AgentRunInput<CALL_OPTIONS>,
+  run?: AgentRunMetadata,
+): string | undefined {
+  const invocationContext = createAgentInvocationContextStore(input.context)
+  const receipt = parsedAgentMessageMetaReceipt(definition, invocationContext, run)
+  return input.context?.[parsedAgentMessageMetaContextKey] === receipt ? receipt?.id : undefined
+}
+
 export function restoreParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
   definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
   input: AgentRunInput<CALL_OPTIONS>,
   run?: AgentRunMetadata,
+  receiptId?: string,
 ): AgentRunInput<CALL_OPTIONS> {
   const receipt = parsedAgentMessageMetaReceipt(definition, createAgentInvocationContextStore(input.context), run)
-  if (!receipt) return input
+  if (!receipt || receipt.id !== receiptId) return input
   return {
     ...input,
     context: { ...input.context, [parsedAgentMessageMetaContextKey]: receipt },

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -59,7 +59,11 @@ export async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeC
   const channel = invocationContext.get("channel")
   const chat = invocationContext.get("chat")
   if (!isRuntimeObject(channel) && !isRuntimeObject(chat)) return
-  const rawMeta = channel?.meta ?? chat?.meta ?? {}
+  const rawMeta = channel?.meta !== undefined
+    ? channel.meta
+    : chat?.meta !== undefined
+      ? chat.meta
+      : {}
   const meta = await parseStandardSchema(schema, rawMeta, "agent channel metadata")
   if (!isRuntimeObject(meta) || Array.isArray(meta)) {
     throw new TypeError("[vitehub] Agent channel metadata schema must return an object.")

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -8,6 +8,17 @@ import type { AgentDefinition, AgentInvocationContextStore, AgentRunInput, Agent
 const parsedAgentMessageMetaContextKey = "vitehub.agent.messageMetaParsed"
 const parsedAgentMessageMetaReceipt = Object.freeze({})
 
+export function hasParsedAgentMessageMeta(input: AgentRunInput): boolean {
+  return input.context?.[parsedAgentMessageMetaContextKey] === parsedAgentMessageMetaReceipt
+}
+
+export function restoreParsedAgentMessageMeta<CALL_OPTIONS>(input: AgentRunInput<CALL_OPTIONS>): AgentRunInput<CALL_OPTIONS> {
+  return {
+    ...input,
+    context: { ...input.context, [parsedAgentMessageMetaContextKey]: parsedAgentMessageMetaReceipt },
+  }
+}
+
 function withParsedMeta(invoker: unknown, rawMeta: Record<string, unknown>, meta: Record<string, unknown>): unknown {
   if (!isRuntimeObject(invoker)) return invoker
   const record = invoker as Record<string, unknown>

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -5,6 +5,8 @@ import { hasRuntimeType, isRuntimeObject } from "./runtime-type.ts"
 
 import type { AgentDefinition, AgentInvocationContextStore, AgentRunInput, AgentRunMetadata, AgentRuntimeConfig } from "../types.ts"
 
+const parsedAgentMessageMetaContextKey = "vitehub.agent.messageMetaParsed"
+
 function activeMessageSettings<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
   definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
   invocationContext: AgentInvocationContextStore,
@@ -24,6 +26,7 @@ export async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeC
   const channelMessages = activeMessageSettings(definition, invocationContext, run)
   const schema = channelMessages ? channelMessages.meta ?? definition?.messages?.meta : definition?.messages?.meta
   if (!schema) return
+  if (invocationContext.get(parsedAgentMessageMetaContextKey) === true) return
   if (!schema["~standard"] || !hasRuntimeType(schema["~standard"].validate, "function")) {
     throw new TypeError("[vitehub] defineAgent({ messages: { meta } }) requires a Standard Schema.")
   }
@@ -36,6 +39,7 @@ export async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeC
   }
   if (isRuntimeObject(channel)) invocationContext.set("channel", { ...channel, meta }, { overwrite: true })
   if (isRuntimeObject(chat)) invocationContext.set("chat", { ...chat, meta }, { overwrite: true })
+  invocationContext.set(parsedAgentMessageMetaContextKey, true, { overwrite: true })
 }
 
 export async function withParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -2,7 +2,7 @@ import { parseStandardSchema } from "@vite-hub/internal/http-request"
 
 import { chatTriggerUserMeta, hasDerivedChatTriggerInvoker, markDerivedChatTriggerInvoker } from "../chat-message-input.ts"
 import { createAgentInvocationContextStore } from "../invocation-context.ts"
-import { normalizeAgentInvoker } from "../invoker.ts"
+import { normalizeAgentInvoker, withoutResolvedAgentInvokerInput } from "../invoker.ts"
 import { hasRuntimeType, isRuntimeObject, isRuntimeRecord } from "./runtime-type.ts"
 
 import type { AgentDefinition, AgentInvocationContextStore, AgentRunInput, AgentRunMetadata, AgentRuntimeConfig } from "../types.ts"
@@ -75,7 +75,9 @@ export function restoreParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntim
   if (!state) return input
   if (state.derivedInvoker) markDerivedChatTriggerInvoker(input.context?.invoker)
   const receipt = parsedAgentMessageMetaReceipt(definition, createAgentInvocationContextStore(input.context), run)
-  if (!receipt || state.revision === undefined || receipt.revision !== state.revision) return input
+  if (!receipt || state.revision === undefined || receipt.revision !== state.revision) {
+    return state.derivedInvoker ? withoutResolvedAgentInvokerInput(input) : input
+  }
   return {
     ...input,
     context: { ...input.context, [parsedAgentMessageMetaContextKey]: receipt },

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -7,28 +7,66 @@ import { hasRuntimeType, isRuntimeObject } from "./runtime-type.ts"
 import type { AgentDefinition, AgentInvocationContextStore, AgentRunInput, AgentRunMetadata, AgentRuntimeConfig } from "../types.ts"
 
 const parsedAgentMessageMetaContextKey = "vitehub.agent.messageMetaParsed"
-const parsedAgentMessageMetaReceipt = Object.freeze({})
+const parsedAgentMessageMetaReceipts = new WeakMap<object, WeakMap<object, Map<string | undefined, object>>>()
 
-export function hasParsedAgentMessageMeta(input: AgentRunInput): boolean {
-  return input.context?.[parsedAgentMessageMetaContextKey] === parsedAgentMessageMetaReceipt
+function parsedAgentMessageMetaReceipt<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
+  invocationContext: AgentInvocationContextStore,
+  run?: AgentRunMetadata,
+): object | undefined {
+  const { channelId, schema } = activeMessageSettings(definition, invocationContext, run)
+  if (!definition || !schema || !isRuntimeObject(schema)) return
+  let definitionReceipts = parsedAgentMessageMetaReceipts.get(definition)
+  if (!definitionReceipts) {
+    definitionReceipts = new WeakMap()
+    parsedAgentMessageMetaReceipts.set(definition, definitionReceipts)
+  }
+  let schemaReceipts = definitionReceipts.get(schema)
+  if (!schemaReceipts) {
+    schemaReceipts = new Map()
+    definitionReceipts.set(schema, schemaReceipts)
+  }
+  let receipt = schemaReceipts.get(channelId)
+  if (!receipt) {
+    receipt = Object.freeze({})
+    schemaReceipts.set(channelId, receipt)
+  }
+  return receipt
 }
 
-export function restoreParsedAgentMessageMeta<CALL_OPTIONS>(input: AgentRunInput<CALL_OPTIONS>): AgentRunInput<CALL_OPTIONS> {
+export function hasParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
+  input: AgentRunInput<CALL_OPTIONS>,
+  run?: AgentRunMetadata,
+): boolean {
+  const invocationContext = createAgentInvocationContextStore(input.context)
+  return input.context?.[parsedAgentMessageMetaContextKey] === parsedAgentMessageMetaReceipt(definition, invocationContext, run)
+}
+
+export function restoreParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
+  input: AgentRunInput<CALL_OPTIONS>,
+  run?: AgentRunMetadata,
+): AgentRunInput<CALL_OPTIONS> {
+  const receipt = parsedAgentMessageMetaReceipt(definition, createAgentInvocationContextStore(input.context), run)
+  if (!receipt) return input
   return {
     ...input,
-    context: { ...input.context, [parsedAgentMessageMetaContextKey]: parsedAgentMessageMetaReceipt },
+    context: { ...input.context, [parsedAgentMessageMetaContextKey]: receipt },
   }
 }
 
-function withParsedMeta(invoker: unknown, rawMeta: Record<string, unknown>, meta: Record<string, unknown>): unknown {
+function withParsedMeta(invoker: unknown, rawMeta: unknown, meta: Record<string, unknown>): unknown {
   if (!isRuntimeObject(invoker)) return invoker
   const record = invoker as Record<string, unknown>
   if (record.kind !== "chat" || !isRuntimeObject(record.meta)) return invoker
   const invokerMeta: Record<string, unknown> = { ...record.meta }
-  for (const key of Object.keys(rawMeta)) delete invokerMeta[key]
+  if (isRuntimeObject(rawMeta)) {
+    for (const key of Object.keys(rawMeta)) delete invokerMeta[key]
+  }
   return normalizeAgentInvoker({
     ...record,
-    ...(Object.hasOwn(rawMeta, "email") ? { email: undefined } : {}),
+    ...(isRuntimeObject(rawMeta) && Object.hasOwn(rawMeta, "email") ? { email: undefined } : {}),
     meta: { ...invokerMeta, ...meta },
   })
 }
@@ -41,7 +79,8 @@ function activeMessageSettings<TRuntimeConfig extends AgentRuntimeConfig, CALL_O
   const trigger = invocationContext.get("agent.trigger")
   const triggerChannelId = isRuntimeObject(trigger) && hasRuntimeType(trigger.channelId, "string") ? trigger.channelId : undefined
   const channelId = run?.channelId || triggerChannelId
-  return channelId ? definition?.channels?.[channelId]?.messages : undefined
+  const messages = channelId ? definition?.channels?.[channelId]?.messages : undefined
+  return { channelId, schema: messages ? messages.meta ?? definition?.messages?.meta : definition?.messages?.meta }
 }
 
 export async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
@@ -49,10 +88,10 @@ export async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeC
   invocationContext: AgentInvocationContextStore,
   run?: AgentRunMetadata,
 ): Promise<void> {
-  const channelMessages = activeMessageSettings(definition, invocationContext, run)
-  const schema = channelMessages ? channelMessages.meta ?? definition?.messages?.meta : definition?.messages?.meta
+  const { schema } = activeMessageSettings(definition, invocationContext, run)
   if (!schema) return
-  if (invocationContext.get(parsedAgentMessageMetaContextKey) === parsedAgentMessageMetaReceipt) return
+  const receipt = parsedAgentMessageMetaReceipt(definition, invocationContext, run)
+  if (receipt && invocationContext.get(parsedAgentMessageMetaContextKey) === receipt) return
   if (!schema["~standard"] || !hasRuntimeType(schema["~standard"].validate, "function")) {
     throw new TypeError("[vitehub] defineAgent({ messages: { meta } }) requires a Standard Schema.")
   }
@@ -75,7 +114,7 @@ export async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeC
     invocationContext.set("actor", invoker, { overwrite: true })
     invocationContext.set("invoker", invoker, { overwrite: true })
   }
-  invocationContext.set(parsedAgentMessageMetaContextKey, parsedAgentMessageMetaReceipt, { overwrite: true })
+  if (receipt) invocationContext.set(parsedAgentMessageMetaContextKey, receipt, { overwrite: true })
 }
 
 export async function withParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -1,0 +1,49 @@
+import { parseStandardSchema } from "@vite-hub/internal/http-request"
+
+import { createAgentInvocationContextStore } from "../invocation-context.ts"
+import { hasRuntimeType, isRuntimeObject } from "./runtime-type.ts"
+
+import type { AgentDefinition, AgentInvocationContextStore, AgentRunInput, AgentRunMetadata, AgentRuntimeConfig } from "../types.ts"
+
+function activeMessageSettings<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
+  invocationContext: AgentInvocationContextStore,
+  run?: AgentRunMetadata,
+) {
+  const trigger = invocationContext.get("agent.trigger")
+  const triggerChannelId = isRuntimeObject(trigger) && hasRuntimeType(trigger.channelId, "string") ? trigger.channelId : undefined
+  const channelId = run?.channelId || triggerChannelId
+  return channelId ? definition?.channels?.[channelId]?.messages : undefined
+}
+
+export async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
+  invocationContext: AgentInvocationContextStore,
+  run?: AgentRunMetadata,
+): Promise<void> {
+  const channelMessages = activeMessageSettings(definition, invocationContext, run)
+  const schema = channelMessages ? channelMessages.meta ?? definition?.messages?.meta : definition?.messages?.meta
+  if (!schema) return
+  if (!schema["~standard"] || !hasRuntimeType(schema["~standard"].validate, "function")) {
+    throw new TypeError("[vitehub] defineAgent({ messages: { meta } }) requires a Standard Schema.")
+  }
+  const channel = invocationContext.get("channel")
+  const chat = invocationContext.get("chat")
+  if (!isRuntimeObject(channel) && !isRuntimeObject(chat)) return
+  const meta = await parseStandardSchema(schema, channel?.meta ?? chat?.meta ?? {}, "agent channel metadata")
+  if (!isRuntimeObject(meta) || Array.isArray(meta)) {
+    throw new TypeError("[vitehub] Agent channel metadata schema must return an object.")
+  }
+  if (isRuntimeObject(channel)) invocationContext.set("channel", { ...channel, meta }, { overwrite: true })
+  if (isRuntimeObject(chat)) invocationContext.set("chat", { ...chat, meta }, { overwrite: true })
+}
+
+export async function withParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
+  definition: AgentDefinition<TRuntimeConfig, CALL_OPTIONS> | undefined,
+  input: AgentRunInput<CALL_OPTIONS>,
+  run?: AgentRunMetadata,
+): Promise<AgentRunInput<CALL_OPTIONS>> {
+  const invocationContext = createAgentInvocationContextStore(input.context)
+  await parseAgentMessageMeta(definition, invocationContext, run)
+  return { ...input, context: invocationContext.toJSON() }
+}

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -1,8 +1,9 @@
 import { parseStandardSchema } from "@vite-hub/internal/http-request"
 
+import { chatTriggerUserMeta } from "../chat-message-input.ts"
 import { createAgentInvocationContextStore } from "../invocation-context.ts"
 import { normalizeAgentInvoker } from "../invoker.ts"
-import { hasRuntimeType, isRuntimeObject } from "./runtime-type.ts"
+import { hasRuntimeType, isRuntimeObject, isRuntimeRecord } from "./runtime-type.ts"
 
 import type { AgentDefinition, AgentInvocationContextStore, AgentRunInput, AgentRunMetadata, AgentRuntimeConfig } from "../types.ts"
 
@@ -71,7 +72,7 @@ export function restoreParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntim
   }
 }
 
-function withParsedMeta(invoker: unknown, rawMeta: unknown, meta: Record<string, unknown>): unknown {
+function withParsedMeta(invoker: unknown, rawMeta: unknown, meta: Record<string, unknown>, user: unknown): unknown {
   if (!isRuntimeObject(invoker)) return invoker
   // SAFETY: isRuntimeObject established the mutable string-keyed record representation.
   const record = invoker as Record<string, unknown>
@@ -82,7 +83,7 @@ function withParsedMeta(invoker: unknown, rawMeta: unknown, meta: Record<string,
   }
   const normalizedInvoker: Record<string, unknown> = {
     ...record,
-    meta: { ...invokerMeta, ...meta },
+    meta: { ...invokerMeta, ...chatTriggerUserMeta(isRuntimeRecord(user) ? user : undefined), ...meta },
   }
   if (isRuntimeObject(rawMeta) && Object.hasOwn(rawMeta, "email")) normalizedInvoker.email = undefined
   return normalizeAgentInvoker(normalizedInvoker)
@@ -129,7 +130,8 @@ export async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeC
   if (isRuntimeObject(channel)) invocationContext.set("channel", { ...channel, meta }, { overwrite: true })
   if (isRuntimeObject(chat)) invocationContext.set("chat", { ...chat, meta }, { overwrite: true })
   // SAFETY: the object-output check above establishes a metadata record.
-  const invoker = withParsedMeta(invocationContext.get("invoker"), rawMeta, meta as Record<string, unknown>)
+  const user = isRuntimeObject(channel) ? channel.user : isRuntimeObject(chat) ? chat.user : undefined
+  const invoker = withParsedMeta(invocationContext.get("invoker"), rawMeta, meta as Record<string, unknown>, user)
   if (invoker !== invocationContext.get("invoker")) {
     invocationContext.set("actor", invoker, { overwrite: true })
     invocationContext.set("invoker", invoker, { overwrite: true })
@@ -144,5 +146,5 @@ export async function withParsedAgentMessageMeta<TRuntimeConfig extends AgentRun
 ): Promise<AgentRunInput<CALL_OPTIONS>> {
   const invocationContext = createAgentInvocationContextStore(input.context)
   await parseAgentMessageMeta(definition, invocationContext, run)
-  return { ...input, context: invocationContext.toJSON() }
+  return { ...input, context: { ...input.context, ...invocationContext.toJSON() } }
 }

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -1,18 +1,18 @@
 import { parseStandardSchema } from "@vite-hub/internal/http-request"
 
-import { chatTriggerUserMeta, hasDerivedChatTriggerInvoker, markDerivedChatTriggerInvoker } from "../chat-message-input.ts"
+import { chatTriggerUserMeta, derivedChatTriggerInvoker, markDerivedChatTriggerInvoker } from "../chat-message-input.ts"
 import { createAgentInvocationContextStore } from "../invocation-context.ts"
 import { normalizeAgentInvoker, withoutResolvedAgentInvokerInput } from "../invoker.ts"
 import { hasRuntimeType, isRuntimeObject, isRuntimeRecord } from "./runtime-type.ts"
 
-import type { AgentDefinition, AgentInvocationContextStore, AgentRunInput, AgentRunMetadata, AgentRuntimeConfig } from "../types.ts"
+import type { AgentDefinition, AgentInvocationContextStore, AgentInvoker, AgentRunInput, AgentRunMetadata, AgentRuntimeConfig } from "../types.ts"
 
 const parsedAgentMessageMetaContextKey = "vitehub.agent.messageMetaParsed"
 interface ParsedAgentMessageMetaReceipt {
   revision?: string
 }
 export interface ParsedAgentMessageMetaState {
-  derivedInvoker?: true
+  derivedInvoker?: AgentInvoker
   revision?: string
 }
 
@@ -62,7 +62,7 @@ export function parsedAgentMessageMetaState<TRuntimeConfig extends AgentRuntimeC
   const receipt = parsedAgentMessageMetaReceipt(definition, invocationContext, run)
   if (!receipt || input.context?.[parsedAgentMessageMetaContextKey] !== receipt) return
   return {
-    ...(hasDerivedChatTriggerInvoker(invocationContext.get("invoker")) ? { derivedInvoker: true } : {}),
+    ...(derivedChatTriggerInvoker(invocationContext.get("invoker")) ? { derivedInvoker: derivedChatTriggerInvoker(invocationContext.get("invoker")) } : {}),
     ...(receipt?.revision !== undefined ? { revision: receipt.revision } : {}),
   }
 }
@@ -74,7 +74,7 @@ export function restoreParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntim
   state?: ParsedAgentMessageMetaState,
 ): AgentRunInput<CALL_OPTIONS> {
   if (!state) return input
-  if (state.derivedInvoker) markDerivedChatTriggerInvoker(input.context?.invoker)
+  if (state.derivedInvoker) markDerivedChatTriggerInvoker(input.context?.invoker, state.derivedInvoker)
   const receipt = parsedAgentMessageMetaReceipt(definition, createAgentInvocationContextStore(input.context), run)
   if (!receipt || state.revision === undefined || receipt.revision !== state.revision) {
     return state.derivedInvoker ? withoutResolvedAgentInvokerInput(input) : input
@@ -85,18 +85,15 @@ export function restoreParsedAgentMessageMeta<TRuntimeConfig extends AgentRuntim
   }
 }
 
-function withParsedMeta(invoker: unknown, rawMeta: unknown, meta: Record<string, unknown>, user: unknown, derived: boolean): unknown {
+function withParsedMeta(invoker: unknown, rawMeta: unknown, meta: Record<string, unknown>, user: unknown, derived: AgentInvoker | undefined): unknown {
   if (!isRuntimeObject(invoker)) return invoker
   if (!derived) return invoker
-  // SAFETY: isRuntimeObject established the mutable string-keyed record representation.
-  const record = invoker as Record<string, unknown>
-  if (record.kind !== "chat" || !isRuntimeObject(record.meta)) return invoker
-  const invokerMeta: Record<string, unknown> = { ...record.meta }
+  const invokerMeta: Record<string, unknown> = { ...derived.meta }
   if (isRuntimeObject(rawMeta)) {
     for (const key of Object.keys(rawMeta)) delete invokerMeta[key]
   }
   const normalizedInvoker: Record<string, unknown> = {
-    ...record,
+    ...derived,
     meta: { ...invokerMeta, ...chatTriggerUserMeta(isRuntimeRecord(user) ? user : undefined), ...meta },
   }
   if (isRuntimeObject(rawMeta) && Object.hasOwn(rawMeta, "email")) normalizedInvoker.email = undefined
@@ -152,7 +149,7 @@ export async function parseAgentMessageMeta<TRuntimeConfig extends AgentRuntimeC
     rawMeta,
     meta as Record<string, unknown>,
     user,
-    hasDerivedChatTriggerInvoker(invocationContext.get("invoker")),
+    derivedChatTriggerInvoker(invocationContext.get("invoker")),
   )
   if (invoker !== invocationContext.get("invoker")) {
     invocationContext.set("actor", invoker, { overwrite: true })

--- a/packages/agent/src/internal/message-meta.ts
+++ b/packages/agent/src/internal/message-meta.ts
@@ -60,7 +60,7 @@ export function parsedAgentMessageMetaState<TRuntimeConfig extends AgentRuntimeC
 ): ParsedAgentMessageMetaState | undefined {
   const invocationContext = createAgentInvocationContextStore(input.context)
   const receipt = parsedAgentMessageMetaReceipt(definition, invocationContext, run)
-  if (input.context?.[parsedAgentMessageMetaContextKey] !== receipt) return
+  if (!receipt || input.context?.[parsedAgentMessageMetaContextKey] !== receipt) return
   return {
     ...(hasDerivedChatTriggerInvoker(invocationContext.get("invoker")) ? { derivedInvoker: true } : {}),
     ...(receipt?.revision !== undefined ? { revision: receipt.revision } : {}),

--- a/packages/agent/src/invoker.ts
+++ b/packages/agent/src/invoker.ts
@@ -177,6 +177,13 @@ export function hasResolvedAgentInvokerInput(input: AgentRunInput): boolean {
   return contextRecord(input.context)[resolvedAgentInvokerInputKey] === true
 }
 
+export function withoutResolvedAgentInvokerInput<CALL_OPTIONS>(input: AgentRunInput<CALL_OPTIONS>): AgentRunInput<CALL_OPTIONS> {
+  if (!hasResolvedAgentInvokerInput(input)) return input
+  const context = { ...input.context }
+  Reflect.deleteProperty(context, resolvedAgentInvokerInputKey)
+  return { ...input, context }
+}
+
 export function portableResolvedAgentInvokerInput<CALL_OPTIONS>(input: AgentRunInput<CALL_OPTIONS>): AgentRunInput<CALL_OPTIONS> {
   if (!hasResolvedAgentInvokerInput(input)) return input
   const context = contextRecord(input.context)

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -11,6 +11,7 @@ import { bindAgentInvocations } from "../invocations.ts"
 import { cloneWorkflowJsonValue, workflowBytesToBase64 } from "../internal/workflow-portability.ts"
 import { restoreResolvedAgentInvokerInput } from "../invoker.ts"
 import { restoreParsedAgentMessageMeta } from "../internal/message-meta.ts"
+import type { ParsedAgentMessageMetaState } from "../internal/message-meta.ts"
 import { toAgentRunResult } from "../agent-output.ts"
 import { readAgentErrorProperty, toAgentPublicError } from "../agent-error.ts"
 import {
@@ -55,7 +56,7 @@ export interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
     workflowName: string
   }
   requestUrl?: string
-  parsedMessageMeta?: string
+  parsedMessageMeta?: ParsedAgentMessageMetaState
   resolvedInvoker?: boolean
   run?: Partial<AgentRunMetadata>
   trace?: AgentRuntimeContext["trace"]

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -55,7 +55,7 @@ export interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
     workflowName: string
   }
   requestUrl?: string
-  parsedMessageMeta?: boolean
+  parsedMessageMeta?: string
   resolvedInvoker?: boolean
   run?: Partial<AgentRunMetadata>
   trace?: AgentRuntimeContext["trace"]
@@ -372,7 +372,9 @@ export async function runAgentWorkflowDefinition<TRuntimeConfig extends AgentRun
     }
     if (channelDelivery) await channelDelivery.event({ type: "invocation.started", runId }).catch(() => undefined)
     let restoredWorkflowInput = workflowInput as AgentRunInput<CALL_OPTIONS>
-    if (payload.parsedMessageMeta) restoredWorkflowInput = restoreParsedAgentMessageMeta(agent, restoredWorkflowInput, runtimeContext.run)
+    if (payload.parsedMessageMeta) {
+      restoredWorkflowInput = restoreParsedAgentMessageMeta(agent, restoredWorkflowInput, runtimeContext.run, payload.parsedMessageMeta)
+    }
     if (payload.resolvedInvoker) restoredWorkflowInput = restoreResolvedAgentInvokerInput(restoredWorkflowInput)
     const inlineResult = await runAgentInline(
       agent,

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -10,6 +10,7 @@ import { agentInvocationRecoveryTasks } from "../internal/invocation-recovery.ts
 import { bindAgentInvocations } from "../invocations.ts"
 import { cloneWorkflowJsonValue, workflowBytesToBase64 } from "../internal/workflow-portability.ts"
 import { restoreResolvedAgentInvokerInput } from "../invoker.ts"
+import { restoreParsedAgentMessageMeta } from "../internal/message-meta.ts"
 import { toAgentRunResult } from "../agent-output.ts"
 import { readAgentErrorProperty, toAgentPublicError } from "../agent-error.ts"
 import {
@@ -54,6 +55,7 @@ export interface AgentWorkflowInvocationPayload<CALL_OPTIONS = unknown> {
     workflowName: string
   }
   requestUrl?: string
+  parsedMessageMeta?: boolean
   resolvedInvoker?: boolean
   run?: Partial<AgentRunMetadata>
   trace?: AgentRuntimeContext["trace"]
@@ -369,11 +371,14 @@ export async function runAgentWorkflowDefinition<TRuntimeConfig extends AgentRun
       return
     }
     if (channelDelivery) await channelDelivery.event({ type: "invocation.started", runId }).catch(() => undefined)
+    let restoredWorkflowInput = workflowInput as AgentRunInput<CALL_OPTIONS>
+    if (payload.parsedMessageMeta) restoredWorkflowInput = restoreParsedAgentMessageMeta(restoredWorkflowInput)
+    if (payload.resolvedInvoker) restoredWorkflowInput = restoreResolvedAgentInvokerInput(restoredWorkflowInput)
     const inlineResult = await runAgentInline(
       agent,
       runtimeContext,
       // SAFETY: The owning Agent runtime boundary establishes the asserted representation before this value is used.
-      payload.resolvedInvoker ? restoreResolvedAgentInvokerInput(workflowInput as AgentRunInput<CALL_OPTIONS>) : (workflowInput as AgentRunInput<CALL_OPTIONS>),
+      restoredWorkflowInput,
     )
     channelOwnership?.abortSignal?.throwIfAborted()
     const result = await portableWorkflowResult(inlineResult)

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -10,7 +10,7 @@ import { agentInvocationRecoveryTasks } from "../internal/invocation-recovery.ts
 import { bindAgentInvocations } from "../invocations.ts"
 import { cloneWorkflowJsonValue, workflowBytesToBase64 } from "../internal/workflow-portability.ts"
 import { restoreResolvedAgentInvokerInput } from "../invoker.ts"
-import { restoreParsedAgentMessageMeta } from "../internal/message-meta.ts"
+import { hasParsedAgentMessageMeta, restoreParsedAgentMessageMeta } from "../internal/message-meta.ts"
 import type { ParsedAgentMessageMetaState } from "../internal/message-meta.ts"
 import { toAgentRunResult } from "../agent-output.ts"
 import { readAgentErrorProperty, toAgentPublicError } from "../agent-error.ts"
@@ -377,7 +377,11 @@ export async function runAgentWorkflowDefinition<TRuntimeConfig extends AgentRun
     if (payload.parsedMessageMeta !== undefined) {
       restoredWorkflowInput = restoreParsedAgentMessageMeta(agent, restoredWorkflowInput, runtimeContext.run, payload.parsedMessageMeta)
     }
-    if (payload.resolvedInvoker) restoredWorkflowInput = restoreResolvedAgentInvokerInput(restoredWorkflowInput)
+    const derivedInvokerNeedsResolution = payload.parsedMessageMeta?.derivedInvoker
+      && !hasParsedAgentMessageMeta(agent, restoredWorkflowInput, runtimeContext.run)
+    if (payload.resolvedInvoker && !derivedInvokerNeedsResolution) {
+      restoredWorkflowInput = restoreResolvedAgentInvokerInput(restoredWorkflowInput)
+    }
     const inlineResult = await runAgentInline(
       agent,
       runtimeContext,

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -372,7 +372,7 @@ export async function runAgentWorkflowDefinition<TRuntimeConfig extends AgentRun
     }
     if (channelDelivery) await channelDelivery.event({ type: "invocation.started", runId }).catch(() => undefined)
     let restoredWorkflowInput = workflowInput as AgentRunInput<CALL_OPTIONS>
-    if (payload.parsedMessageMeta) restoredWorkflowInput = restoreParsedAgentMessageMeta(restoredWorkflowInput)
+    if (payload.parsedMessageMeta) restoredWorkflowInput = restoreParsedAgentMessageMeta(agent, restoredWorkflowInput, runtimeContext.run)
     if (payload.resolvedInvoker) restoredWorkflowInput = restoreResolvedAgentInvokerInput(restoredWorkflowInput)
     const inlineResult = await runAgentInline(
       agent,

--- a/packages/agent/src/runtime/workflow.ts
+++ b/packages/agent/src/runtime/workflow.ts
@@ -373,7 +373,7 @@ export async function runAgentWorkflowDefinition<TRuntimeConfig extends AgentRun
     if (channelDelivery) await channelDelivery.event({ type: "invocation.started", runId }).catch(() => undefined)
     // SAFETY: the Workflow payload preserves the originating Agent call options while crossing the portable runtime boundary.
     let restoredWorkflowInput = workflowInput as AgentRunInput<CALL_OPTIONS>
-    if (payload.parsedMessageMeta) {
+    if (payload.parsedMessageMeta !== undefined) {
       restoredWorkflowInput = restoreParsedAgentMessageMeta(agent, restoredWorkflowInput, runtimeContext.run, payload.parsedMessageMeta)
     }
     if (payload.resolvedInvoker) restoredWorkflowInput = restoreResolvedAgentInvokerInput(restoredWorkflowInput)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2713,7 +2713,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
               }
               let recoveredWorkflowInput = recoveredInput
               if (restored.message.parsedMessageMeta) {
-                recoveredWorkflowInput = restoreParsedAgentMessageMeta(recoveredWorkflowInput)
+                recoveredWorkflowInput = restoreParsedAgentMessageMeta(agent, recoveredWorkflowInput, run)
               }
               if (restored.message.resolvedInvoker) {
                 const recoveredInvoker = resolveInputAgentInvoker(recoveredWorkflowInput.context)
@@ -2952,7 +2952,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
         pendingQueue = durableSteerPendingQueue(queue)
         successorClaimId = crypto.randomUUID()
         let queuedInput = queued.message.input
-        if (queued.message.parsedMessageMeta) queuedInput = restoreParsedAgentMessageMeta(queuedInput)
+        if (queued.message.parsedMessageMeta) queuedInput = restoreParsedAgentMessageMeta(agent, queuedInput, queued.message.run)
         if (queued.message.resolvedInvoker) {
           const queuedInvoker = resolveInputAgentInvoker(queuedInput.context)
           if (queuedInvoker) queuedInput = withResolvedAgentInvokerInput(queuedInput, queuedInvoker)
@@ -3007,7 +3007,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
         if (ownerReleased) return
         if (successorStartAttempted && isAmbiguousAgentWorkflowStartFailure(error) && successorInput && queued?.message) {
           let retryInput = successorInput
-          if (queued.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(retryInput)
+          if (queued.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(agent, retryInput, queued.message.run)
           if (queued.message.resolvedInvoker) {
             const retryInvoker = resolveInputAgentInvoker(retryInput.context)
             if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
@@ -3073,7 +3073,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
             )
           } catch (settlementError) {
             let retryInput = successorPending.message.input
-            if (successorPending.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(retryInput)
+            if (successorPending.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(agent, retryInput, successorPending.message.run)
             if (successorPending.message.resolvedInvoker) {
               const retryInvoker = resolveInputAgentInvoker(retryInput.context)
               if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
@@ -3114,7 +3114,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
           await restoreDurableSteerQueue(resolved.state, queue, queued.message)
         }
         let retryInput = claimedPending.message.input
-        if (claimedPending.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(retryInput)
+        if (claimedPending.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(agent, retryInput, claimedPending.message.run)
         if (claimedPending.message.resolvedInvoker) {
           const retryInvoker = resolveInputAgentInvoker(retryInput.context)
           if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
@@ -4665,7 +4665,7 @@ async function handleChatSdkMessage(
         },
         invoker,
       ) as AgentRunInput
-      let workflowInputHasParsedMessageMeta = hasParsedAgentMessageMeta(workflowInput)
+      let workflowInputHasParsedMessageMeta = hasParsedAgentMessageMeta(agent, workflowInput, run)
       let workflowInputHasResolvedInvoker = hasResolvedAgentInvokerInput(workflowInput)
       let workflowInvokerKey = JSON.stringify(resolveInputAgentInvoker(workflowInput.context) ?? null)
       let workflowCapabilities = portableWorkflowCapabilityOverrides(context.capabilities)
@@ -4905,7 +4905,7 @@ async function handleChatSdkMessage(
           throw new Error("[vitehub] Durable steered Channel delivery lost ownership while its Agent Workflow was starting.")
         }
         const workflowStartInput = workflowInputHasParsedMessageMeta
-          ? restoreParsedAgentMessageMeta(workflowInput)
+          ? restoreParsedAgentMessageMeta(agent, workflowInput, workflowRun)
           : workflowInput
         // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
         await runAgent(agent as never, workflowRunContext as never, workflowStartInput as never)
@@ -5016,7 +5016,7 @@ async function handleChatSdkMessage(
                       recoveryStartAttempts++
                       // SAFETY: The owning Agent runtime boundary creates these values with the internal startup contract.
                       const recoveryStartInput = workflowInputHasParsedMessageMeta
-                        ? restoreParsedAgentMessageMeta(recoveryInput)
+                        ? restoreParsedAgentMessageMeta(agent, recoveryInput, workflowRun)
                         : recoveryInput
                       await runAgent(agent as never, workflowRunContext as never, recoveryStartInput as never)
                       return
@@ -5055,7 +5055,7 @@ async function handleChatSdkMessage(
               // depend on another webhook arriving.
               // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
               const recoveredWorkflowInput = workflowInputHasParsedMessageMeta
-                ? restoreParsedAgentMessageMeta(workflowInput)
+                ? restoreParsedAgentMessageMeta(agent, workflowInput, workflowRun)
                 : workflowInput
               await runAgent(agent as never, workflowRunContext as never, recoveredWorkflowInput as never)
               durableHandoff = true
@@ -5126,7 +5126,7 @@ async function handleChatSdkMessage(
                 try {
                   // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
                   const settlementRetryInput = workflowInputHasParsedMessageMeta
-                    ? restoreParsedAgentMessageMeta(workflowInput)
+                    ? restoreParsedAgentMessageMeta(agent, workflowInput, workflowRun)
                     : workflowInput
                   await runAgent(agent as never, workflowRunContext as never, settlementRetryInput as never)
                 } catch (retryError) {
@@ -5155,7 +5155,7 @@ async function handleChatSdkMessage(
                 try {
                   // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
                   const settlementRetryInput = workflowInputHasParsedMessageMeta
-                    ? restoreParsedAgentMessageMeta(workflowInput)
+                    ? restoreParsedAgentMessageMeta(agent, workflowInput, workflowRun)
                     : workflowInput
                   await runAgent(agent as never, workflowRunContext as never, settlementRetryInput as never)
                 } catch (retryError) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -21,7 +21,7 @@ import { assertChatDeliveryOptions, CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCa
 import {
   chatTriggerHistoryLimit,
   createChatMessageTriggerInput,
-  hasDerivedChatTriggerInvoker,
+  derivedChatTriggerInvoker,
   markDerivedChatTriggerInvoker,
   resolveChatSessionBaseId,
   resolveChatSessionId,
@@ -4502,7 +4502,7 @@ async function isChatMessageAuthorized(
   messageContext?: MessageContext,
 ): Promise<AgentInvoker | undefined> {
   const invocationContext = createAgentInvocationContextStore(input.context)
-  const derivedInvoker = hasDerivedChatTriggerInvoker(invocationContext.get("invoker"))
+  const derivedInvoker = derivedChatTriggerInvoker(invocationContext.get("invoker"))
   const invoker = await resolveAgentInvoker(
     // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
     (agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined)?.invoker,
@@ -4511,7 +4511,7 @@ async function isChatMessageAuthorized(
     input,
     run,
   )
-  if (derivedInvoker) markDerivedChatTriggerInvoker(invoker)
+  if (derivedInvoker) markDerivedChatTriggerInvoker(invoker, derivedInvoker)
   for (const accessOptions of getAccessCapabilityOptions(getAgentCapabilities(agent))) {
     if (!accessOptions.chat) continue
     const result = await accessOptions.chat.resolve({

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -52,7 +52,7 @@ import { registerAgentWorkflowRetry } from "../internal/workflow-retry.ts"
 import { loadAgentWorkflowRuntimeStateModule } from "../internal/workflow-runtime-loaders.ts"
 import { portableWorkflowCapabilityOverrides } from "../internal/workflow-portability.ts"
 import { createResumableChatProcessCustody } from "../internal/resumable-chat.ts"
-import { withParsedAgentMessageMeta } from "../internal/message-meta.ts"
+import { hasParsedAgentMessageMeta, restoreParsedAgentMessageMeta, withParsedAgentMessageMeta } from "../internal/message-meta.ts"
 import {
   isRuntimeBigInt,
   isRuntimeBoolean,
@@ -2712,9 +2712,12 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
                 throw new Error("[vitehub] Durable steered Channel delivery queue changed while restored ownership was being claimed.")
               }
               let recoveredWorkflowInput = recoveredInput
+              if (restored.message.parsedMessageMeta) {
+                recoveredWorkflowInput = restoreParsedAgentMessageMeta(recoveredWorkflowInput)
+              }
               if (restored.message.resolvedInvoker) {
-                const recoveredInvoker = resolveInputAgentInvoker(recoveredInput.context)
-                if (recoveredInvoker) recoveredWorkflowInput = withResolvedAgentInvokerInput(recoveredInput, recoveredInvoker)
+                const recoveredInvoker = resolveInputAgentInvoker(recoveredWorkflowInput.context)
+                if (recoveredInvoker) recoveredWorkflowInput = withResolvedAgentInvokerInput(recoveredWorkflowInput, recoveredInvoker)
               }
               let recoveredWorkflowAccepted = false
               let recoveredWorkflowRetryRegistered = false
@@ -2949,6 +2952,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
         pendingQueue = durableSteerPendingQueue(queue)
         successorClaimId = crypto.randomUUID()
         let queuedInput = queued.message.input
+        if (queued.message.parsedMessageMeta) queuedInput = restoreParsedAgentMessageMeta(queuedInput)
         if (queued.message.resolvedInvoker) {
           const queuedInvoker = resolveInputAgentInvoker(queuedInput.context)
           if (queuedInvoker) queuedInput = withResolvedAgentInvokerInput(queuedInput, queuedInvoker)
@@ -3003,9 +3007,10 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
         if (ownerReleased) return
         if (successorStartAttempted && isAmbiguousAgentWorkflowStartFailure(error) && successorInput && queued?.message) {
           let retryInput = successorInput
+          if (queued.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(retryInput)
           if (queued.message.resolvedInvoker) {
-            const retryInvoker = resolveInputAgentInvoker(successorInput.context)
-            if (retryInvoker) retryInput = withResolvedAgentInvokerInput(successorInput, retryInvoker)
+            const retryInvoker = resolveInputAgentInvoker(retryInput.context)
+            if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
           }
           const retryMessage = queued.message
           registerAgentWorkflowRetry(
@@ -3068,6 +3073,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
             )
           } catch (settlementError) {
             let retryInput = successorPending.message.input
+            if (successorPending.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(retryInput)
             if (successorPending.message.resolvedInvoker) {
               const retryInvoker = resolveInputAgentInvoker(retryInput.context)
               if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
@@ -3108,6 +3114,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
           await restoreDurableSteerQueue(resolved.state, queue, queued.message)
         }
         let retryInput = claimedPending.message.input
+        if (claimedPending.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(retryInput)
         if (claimedPending.message.resolvedInvoker) {
           const retryInvoker = resolveInputAgentInvoker(retryInput.context)
           if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
@@ -3210,6 +3217,7 @@ interface DurableSteerQueueMessage {
   input?: AgentRunInput
   invokerKey?: string
   ownerToken?: string
+  parsedMessageMeta?: boolean
   requestUrl?: string
   resolvedInvoker?: boolean
   run?: AgentRunMetadata
@@ -3518,6 +3526,7 @@ async function restoreDurableSteerQueue(state: StateAdapter, queue: string, prev
       input: restoredInput,
       capabilities: newerMessage.capabilities ?? previous.capabilities,
       requestUrl: newerMessage.requestUrl ?? previous.requestUrl,
+      parsedMessageMeta: newerMessage.parsedMessageMeta ?? previous.parsedMessageMeta,
       resolvedInvoker: newerMessage.resolvedInvoker ?? previous.resolvedInvoker,
       run: newerMessage.run ?? previous.run,
     }
@@ -4656,6 +4665,7 @@ async function handleChatSdkMessage(
         },
         invoker,
       ) as AgentRunInput
+      let workflowInputHasParsedMessageMeta = hasParsedAgentMessageMeta(workflowInput)
       let workflowInputHasResolvedInvoker = hasResolvedAgentInvokerInput(workflowInput)
       let workflowInvokerKey = JSON.stringify(resolveInputAgentInvoker(workflowInput.context) ?? null)
       let workflowCapabilities = portableWorkflowCapabilityOverrides(context.capabilities)
@@ -4723,6 +4733,7 @@ async function handleChatSdkMessage(
                 : [currentErrorDelivery],
               input: workflowInput,
               invokerKey: workflowInvokerKey,
+              parsedMessageMeta: workflowInputHasParsedMessageMeta,
               requestUrl: workflowRequestUrl,
               resolvedInvoker: workflowInputHasResolvedInvoker,
               run,
@@ -4783,6 +4794,7 @@ async function handleChatSdkMessage(
                   errorDeliveries: [currentErrorDelivery],
                   input: workflowInput,
                   invokerKey: workflowInvokerKey,
+                  parsedMessageMeta: workflowInputHasParsedMessageMeta,
                   requestUrl: workflowRequestUrl,
                   resolvedInvoker: workflowInputHasResolvedInvoker,
                   run: workflowRun,
@@ -4796,6 +4808,7 @@ async function handleChatSdkMessage(
             // The persisted entry remains the CAS expectation below. Rebinding
             // steer ownership must not mutate that expected value in place.
             workflowInput = structuredClone(previous.message.input)
+            workflowInputHasParsedMessageMeta = previous.message.parsedMessageMeta === true
             workflowInputHasResolvedInvoker = previous.message.resolvedInvoker === true
             workflowInvokerKey = durableSteerInvokerKey(previous.message)
             workflowCapabilities = previous.message.capabilities
@@ -4867,6 +4880,7 @@ async function handleChatSdkMessage(
               input: workflowInput,
               invokerKey: workflowInvokerKey,
               ownerToken: steerLock.token,
+              parsedMessageMeta: workflowInputHasParsedMessageMeta,
               requestUrl: workflowRequestUrl,
               resolvedInvoker: workflowInputHasResolvedInvoker,
               run: workflowRun,
@@ -6497,16 +6511,15 @@ export function createChannelChatRouteHandler(
         invokerInput,
         triggerInput.run,
       )
-      triggerInput = {
-        // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
-        ...(withResolvedAgentInvokerInput(triggerInput as never, invoker) as AgentChatMessageTriggerInput),
+      // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
+      triggerInput = withResolvedAgentInvokerInput({
+        ...triggerInput,
         context: invokerInput.context,
-        // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
         invoker,
         ...(isRuntimeObject(invokerInput.context?.channel) && isRuntimeObject(invokerInput.context.channel.meta)
           ? { meta: invokerInput.context.channel.meta }
           : {}),
-      }
+      } as never, invoker) as AgentChatMessageTriggerInput
       const sessionId = triggerInput.run?.threadId ?? triggerInput.run?.runId
       let selectedSessionId = resolveChatSessionId(triggerInput.messages, chatOptions.sessions, triggerInput.session)
       const registration = {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -5015,7 +5015,10 @@ async function handleChatSdkMessage(
                     try {
                       recoveryStartAttempts++
                       // SAFETY: The owning Agent runtime boundary creates these values with the internal startup contract.
-                      await runAgent(agent as never, workflowRunContext as never, recoveryInput as never)
+                      const recoveryStartInput = workflowInputHasParsedMessageMeta
+                        ? restoreParsedAgentMessageMeta(recoveryInput)
+                        : recoveryInput
+                      await runAgent(agent as never, workflowRunContext as never, recoveryStartInput as never)
                       return
                     } catch (recoveryError) {
                       if (isAmbiguousAgentWorkflowStartFailure(recoveryError)) return
@@ -5051,7 +5054,10 @@ async function handleChatSdkMessage(
               // lease was lost. Start a fresh Workflow so persisted custody does not
               // depend on another webhook arriving.
               // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
-              await runAgent(agent as never, workflowRunContext as never, workflowInput as never)
+              const recoveredWorkflowInput = workflowInputHasParsedMessageMeta
+                ? restoreParsedAgentMessageMeta(workflowInput)
+                : workflowInput
+              await runAgent(agent as never, workflowRunContext as never, recoveredWorkflowInput as never)
               durableHandoff = true
             } catch (retryError) {
               if (isAmbiguousAgentWorkflowStartFailure(retryError)) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4556,6 +4556,12 @@ async function handleChatSdkMessage(
       await recordChannelDeliveryEvidence(delivery, { type: "rejected" })
       return
     }
+    const parsedChannelContext = authorizationInput.context?.channel
+    input = {
+      ...input,
+      context: authorizationInput.context,
+      ...(isRuntimeObject(parsedChannelContext) && isRuntimeObject(parsedChannelContext.meta) ? { meta: parsedChannelContext.meta } : {}),
+    }
 
     const manualDelivery = options?.delivery === "manual"
     const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
@@ -6494,8 +6500,12 @@ export function createChannelChatRouteHandler(
       triggerInput = {
         // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
         ...(withResolvedAgentInvokerInput(triggerInput as never, invoker) as AgentChatMessageTriggerInput),
+        context: invokerInput.context,
         // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
         invoker,
+        ...(isRuntimeObject(invokerInput.context?.channel) && isRuntimeObject(invokerInput.context.channel.meta)
+          ? { meta: invokerInput.context.channel.meta }
+          : {}),
       }
       const sessionId = triggerInput.run?.threadId ?? triggerInput.run?.runId
       let selectedSessionId = resolveChatSessionId(triggerInput.messages, chatOptions.sessions, triggerInput.session)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -2713,7 +2713,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
                 throw new Error("[vitehub] Durable steered Channel delivery queue changed while restored ownership was being claimed.")
               }
               let recoveredWorkflowInput = recoveredInput
-              if (restored.message.parsedMessageMeta) {
+              if (restored.message.parsedMessageMeta !== undefined) {
                 recoveredWorkflowInput = restoreParsedAgentMessageMeta(
                   // SAFETY: route discovery narrows this runtime value to an Agent Definition before recovery starts.
                   agent as AgentDefinition | undefined,
@@ -2960,7 +2960,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
         successorClaimId = crypto.randomUUID()
         let queuedInput = queued.message.input
         // SAFETY: queued durable messages retain the Agent Definition selected by this route.
-        if (queued.message.parsedMessageMeta) queuedInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, queuedInput, queued.message.run, queued.message.parsedMessageMeta)
+        if (queued.message.parsedMessageMeta !== undefined) queuedInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, queuedInput, queued.message.run, queued.message.parsedMessageMeta)
         if (queued.message.resolvedInvoker) {
           const queuedInvoker = resolveInputAgentInvoker(queuedInput.context)
           if (queuedInvoker) queuedInput = withResolvedAgentInvokerInput(queuedInput, queuedInvoker)
@@ -3016,7 +3016,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
         if (successorStartAttempted && isAmbiguousAgentWorkflowStartFailure(error) && successorInput && queued?.message) {
           let retryInput = successorInput
           // SAFETY: settlement retries reuse the Agent Definition selected for the queued message.
-          if (queued.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, queued.message.run, queued.message.parsedMessageMeta)
+          if (queued.message.parsedMessageMeta !== undefined) retryInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, queued.message.run, queued.message.parsedMessageMeta)
           if (queued.message.resolvedInvoker) {
             const retryInvoker = resolveInputAgentInvoker(retryInput.context)
             if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
@@ -3083,7 +3083,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
           } catch (settlementError) {
             let retryInput = successorPending.message.input
             // SAFETY: successor settlement retries retain the Agent Definition selected by this route.
-            if (successorPending.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, successorPending.message.run, successorPending.message.parsedMessageMeta)
+            if (successorPending.message.parsedMessageMeta !== undefined) retryInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, successorPending.message.run, successorPending.message.parsedMessageMeta)
             if (successorPending.message.resolvedInvoker) {
               const retryInvoker = resolveInputAgentInvoker(retryInput.context)
               if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
@@ -3125,7 +3125,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
         }
         let retryInput = claimedPending.message.input
         // SAFETY: claimed pending messages retain the Agent Definition selected by this route.
-        if (claimedPending.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, claimedPending.message.run, claimedPending.message.parsedMessageMeta)
+        if (claimedPending.message.parsedMessageMeta !== undefined) retryInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, claimedPending.message.run, claimedPending.message.parsedMessageMeta)
         if (claimedPending.message.resolvedInvoker) {
           const retryInvoker = resolveInputAgentInvoker(retryInput.context)
           if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
@@ -4586,26 +4586,6 @@ async function handleChatSdkMessage(
     if (isRuntimeNumber(options?.timeout) && Number.isFinite(options.timeout) && options.timeout > 0) {
       input.timeout = options.timeout
     }
-    const authorizationInput = await withParsedAgentMessageMeta(
-      // SAFETY: generated chat routes provide the runtime config represented by ViteAgentRouteRuntimeConfig.
-      agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined,
-      createChatMessageTriggerInput(options || {}, input).input,
-      input.run,
-    )
-    const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, authorizationInput, input.run, messageContext)
-    if (!invoker) {
-      await recordChannelDeliveryEvidence(delivery, { type: "rejected" })
-      return
-    }
-    const parsedChannelContext = authorizationInput.context?.channel
-    input = withAgentInvokerRunAnnotation({
-      ...input,
-      context: authorizationInput.context,
-      ...(isRuntimeObject(parsedChannelContext) && isRuntimeObject(parsedChannelContext.meta) ? { meta: parsedChannelContext.meta } : {}),
-    }, invoker)
-
-    const manualDelivery = options?.delivery === "manual"
-    const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
     const messages = scopeCurrentChatUiMessage(
       await chatTriggerMessages(thread, message, options, messageContext, historyThroughCurrent),
       message.id,
@@ -4635,6 +4615,26 @@ async function handleChatSdkMessage(
         return
       }
     }
+    const authorizationInput = await withParsedAgentMessageMeta(
+      // SAFETY: generated chat routes provide the runtime config represented by ViteAgentRouteRuntimeConfig.
+      agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined,
+      createChatMessageTriggerInput(options || {}, input).input,
+      input.run,
+    )
+    const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, authorizationInput, input.run, messageContext)
+    if (!invoker) {
+      await recordChannelDeliveryEvidence(delivery, { type: "rejected" })
+      return
+    }
+    const parsedChannelContext = authorizationInput.context?.channel
+    input = withAgentInvokerRunAnnotation({
+      ...input,
+      context: authorizationInput.context,
+      ...(isRuntimeObject(parsedChannelContext) && isRuntimeObject(parsedChannelContext.meta) ? { meta: parsedChannelContext.meta } : {}),
+    }, invoker)
+
+    const manualDelivery = options?.delivery === "manual"
+    const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
     input = { ...input, messages }
     // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
     const invocation = await resolveAgentTriggerInvocation(agent as never, context as never, "chat.message", input)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -53,7 +53,8 @@ import { registerAgentWorkflowRetry } from "../internal/workflow-retry.ts"
 import { loadAgentWorkflowRuntimeStateModule } from "../internal/workflow-runtime-loaders.ts"
 import { portableWorkflowCapabilityOverrides } from "../internal/workflow-portability.ts"
 import { createResumableChatProcessCustody } from "../internal/resumable-chat.ts"
-import { parsedAgentMessageMetaReceiptId, restoreParsedAgentMessageMeta, withParsedAgentMessageMeta } from "../internal/message-meta.ts"
+import { parsedAgentMessageMetaState, restoreParsedAgentMessageMeta, withParsedAgentMessageMeta } from "../internal/message-meta.ts"
+import type { ParsedAgentMessageMetaState } from "../internal/message-meta.ts"
 import {
   isRuntimeBigInt,
   isRuntimeBoolean,
@@ -3228,7 +3229,7 @@ interface DurableSteerQueueMessage {
   input?: AgentRunInput
   invokerKey?: string
   ownerToken?: string
-  parsedMessageMeta?: string
+  parsedMessageMeta?: ParsedAgentMessageMetaState
   requestUrl?: string
   resolvedInvoker?: boolean
   run?: AgentRunMetadata
@@ -4697,7 +4698,7 @@ async function handleChatSdkMessage(
         },
         invoker,
       ) as AgentRunInput
-      let workflowInputHasParsedMessageMeta = parsedAgentMessageMetaReceiptId(agent, workflowInput, run)
+      let workflowInputHasParsedMessageMeta = parsedAgentMessageMetaState(agent, workflowInput, run)
       let workflowInputHasResolvedInvoker = hasResolvedAgentInvokerInput(workflowInput)
       let workflowInvokerKey = JSON.stringify(resolveInputAgentInvoker(workflowInput.context) ?? null)
       let workflowCapabilities = portableWorkflowCapabilityOverrides(context.capabilities)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -5125,7 +5125,10 @@ async function handleChatSdkMessage(
                 durableHandoff = true
                 try {
                   // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
-                  await runAgent(agent as never, workflowRunContext as never, workflowInput as never)
+                  const settlementRetryInput = workflowInputHasParsedMessageMeta
+                    ? restoreParsedAgentMessageMeta(workflowInput)
+                    : workflowInput
+                  await runAgent(agent as never, workflowRunContext as never, settlementRetryInput as never)
                 } catch (retryError) {
                   if (!isAmbiguousAgentWorkflowStartFailure(retryError)) {
                     detachAgentChannelDelivery(delivery)
@@ -5151,7 +5154,10 @@ async function handleChatSdkMessage(
                 steerPending = failedPending
                 try {
                   // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
-                  await runAgent(agent as never, workflowRunContext as never, workflowInput as never)
+                  const settlementRetryInput = workflowInputHasParsedMessageMeta
+                    ? restoreParsedAgentMessageMeta(workflowInput)
+                    : workflowInput
+                  await runAgent(agent as never, workflowRunContext as never, settlementRetryInput as never)
                 } catch (retryError) {
                   if (!isAmbiguousAgentWorkflowStartFailure(retryError)) {
                     detachAgentChannelDelivery(delivery)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4904,8 +4904,11 @@ async function handleChatSdkMessage(
           steerStartOwnershipLost = true
           throw new Error("[vitehub] Durable steered Channel delivery lost ownership while its Agent Workflow was starting.")
         }
+        const workflowStartInput = workflowInputHasParsedMessageMeta
+          ? restoreParsedAgentMessageMeta(workflowInput)
+          : workflowInput
         // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
-        await runAgent(agent as never, workflowRunContext as never, workflowInput as never)
+        await runAgent(agent as never, workflowRunContext as never, workflowStartInput as never)
         durableHandoff = true
         if (steerStartOwnershipLost && steerLock && !(await state.state.extendLock(steerLock, steerTtlMs))) {
           throw new Error("[vitehub] Durable steered Channel delivery lost ownership while its Agent Workflow was starting.")

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -21,6 +21,8 @@ import { assertChatDeliveryOptions, CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCa
 import {
   chatTriggerHistoryLimit,
   createChatMessageTriggerInput,
+  hasDerivedChatTriggerInvoker,
+  markDerivedChatTriggerInvoker,
   resolveChatSessionBaseId,
   resolveChatSessionId,
   resolveChatTriggerHistory,
@@ -4453,7 +4455,7 @@ function withChatFinishExtension<CALL_OPTIONS>(input: AgentRunInput<CALL_OPTIONS
   return {
     ...input,
     context: {
-      ...(input.context || {}),
+      ...input.context,
       [CHAT_FINISH_EXTENSION_CONTEXT_KEY]: chat,
     },
   }
@@ -4490,6 +4492,7 @@ async function isChatMessageAuthorized(
   messageContext?: MessageContext,
 ): Promise<AgentInvoker | undefined> {
   const invocationContext = createAgentInvocationContextStore(input.context)
+  const derivedInvoker = hasDerivedChatTriggerInvoker(invocationContext.get("invoker"))
   const invoker = await resolveAgentInvoker(
     // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
     (agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined)?.invoker,
@@ -4498,6 +4501,7 @@ async function isChatMessageAuthorized(
     input,
     run,
   )
+  if (derivedInvoker) markDerivedChatTriggerInvoker(invoker)
   for (const accessOptions of getAccessCapabilityOptions(getAgentCapabilities(agent))) {
     if (!accessOptions.chat) continue
     const result = await accessOptions.chat.resolve({
@@ -4587,6 +4591,24 @@ async function handleChatSdkMessage(
     if (isRuntimeNumber(options?.timeout) && Number.isFinite(options.timeout) && options.timeout > 0) {
       input.timeout = options.timeout
     }
+    const authorizationInput = await withParsedAgentMessageMeta(
+      // SAFETY: generated chat routes provide the runtime config represented by ViteAgentRouteRuntimeConfig.
+      agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined,
+      createChatMessageTriggerInput(options || {}, input).input,
+      input.run,
+    )
+    const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, authorizationInput, input.run, messageContext)
+    if (!invoker) {
+      await recordChannelDeliveryEvidence(delivery, { type: "rejected" })
+      return
+    }
+    const parsedChannelContext = authorizationInput.context?.channel
+    input = withAgentInvokerRunAnnotation({
+      ...input,
+      context: authorizationInput.context,
+      ...(isRuntimeObject(parsedChannelContext) && isRuntimeObject(parsedChannelContext.meta) ? { meta: parsedChannelContext.meta } : {}),
+    }, invoker)
+
     const messages = scopeCurrentChatUiMessage(
       await chatTriggerMessages(thread, message, options, messageContext, historyThroughCurrent),
       message.id,
@@ -4616,23 +4638,6 @@ async function handleChatSdkMessage(
         return
       }
     }
-    const authorizationInput = await withParsedAgentMessageMeta(
-      // SAFETY: generated chat routes provide the runtime config represented by ViteAgentRouteRuntimeConfig.
-      agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined,
-      createChatMessageTriggerInput(options || {}, input).input,
-      input.run,
-    )
-    const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, authorizationInput, input.run, messageContext)
-    if (!invoker) {
-      await recordChannelDeliveryEvidence(delivery, { type: "rejected" })
-      return
-    }
-    const parsedChannelContext = authorizationInput.context?.channel
-    input = withAgentInvokerRunAnnotation({
-      ...input,
-      context: authorizationInput.context,
-      ...(isRuntimeObject(parsedChannelContext) && isRuntimeObject(parsedChannelContext.meta) ? { meta: parsedChannelContext.meta } : {}),
-    }, invoker)
 
     const manualDelivery = options?.delivery === "manual"
     const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -6512,11 +6512,19 @@ export function createChannelChatRouteHandler(
         resumableClaim = claim
       }
       const chatOptions = getChannelChatOptions(agent, routeOptions.channelId, getAgentChatOptions(agent)) || {}
-      const invokerInput = await withParsedAgentMessageMeta(
-        agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined,
-        createChatMessageTriggerInput(chatOptions, triggerInput).input,
-        triggerInput.run,
-      )
+      let invokerInput: AgentRunInput
+      try {
+        invokerInput = await withParsedAgentMessageMeta(
+          agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined,
+          createChatMessageTriggerInput(chatOptions, triggerInput).input,
+          triggerInput.run,
+        )
+      } catch (error) {
+        if (error instanceof Error && error.message.startsWith("[vitehub] Invalid agent channel metadata:")) {
+          throw createRouteBodyError(error.message)
+        }
+        throw error
+      }
       const invoker = await resolveAgentInvoker(
         // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
         (agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined)?.invoker,

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -55,7 +55,7 @@ import { registerAgentWorkflowRetry } from "../internal/workflow-retry.ts"
 import { loadAgentWorkflowRuntimeStateModule } from "../internal/workflow-runtime-loaders.ts"
 import { portableWorkflowCapabilityOverrides } from "../internal/workflow-portability.ts"
 import { createResumableChatProcessCustody } from "../internal/resumable-chat.ts"
-import { parsedAgentMessageMetaState, restoreParsedAgentMessageMeta, withParsedAgentMessageMeta } from "../internal/message-meta.ts"
+import { hasParsedAgentMessageMeta, parsedAgentMessageMetaState, restoreParsedAgentMessageMeta, withParsedAgentMessageMeta } from "../internal/message-meta.ts"
 import type { ParsedAgentMessageMetaState } from "../internal/message-meta.ts"
 import {
   isRuntimeBigInt,
@@ -2725,7 +2725,9 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
                   restored.message.parsedMessageMeta,
                 )
               }
-              if (restored.message.resolvedInvoker) {
+              const recoveredDerivedInvokerNeedsResolution = restored.message.parsedMessageMeta?.derivedInvoker
+                && !hasParsedAgentMessageMeta(agent as AgentDefinition | undefined, recoveredWorkflowInput, restored.message.run)
+              if (restored.message.resolvedInvoker && !recoveredDerivedInvokerNeedsResolution) {
                 const recoveredInvoker = resolveInputAgentInvoker(recoveredWorkflowInput.context)
                 if (recoveredInvoker) recoveredWorkflowInput = withResolvedAgentInvokerInput(recoveredWorkflowInput, recoveredInvoker)
               }
@@ -2964,7 +2966,9 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
         let queuedInput = queued.message.input
         // SAFETY: queued durable messages retain the Agent Definition selected by this route.
         if (queued.message.parsedMessageMeta !== undefined) queuedInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, queuedInput, queued.message.run, queued.message.parsedMessageMeta)
-        if (queued.message.resolvedInvoker) {
+        const queuedDerivedInvokerNeedsResolution = queued.message.parsedMessageMeta?.derivedInvoker
+          && !hasParsedAgentMessageMeta(agent as AgentDefinition | undefined, queuedInput, queued.message.run)
+        if (queued.message.resolvedInvoker && !queuedDerivedInvokerNeedsResolution) {
           const queuedInvoker = resolveInputAgentInvoker(queuedInput.context)
           if (queuedInvoker) queuedInput = withResolvedAgentInvokerInput(queuedInput, queuedInvoker)
         }
@@ -3020,7 +3024,9 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
           let retryInput = successorInput
           // SAFETY: settlement retries reuse the Agent Definition selected for the queued message.
           if (queued.message.parsedMessageMeta !== undefined) retryInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, queued.message.run, queued.message.parsedMessageMeta)
-          if (queued.message.resolvedInvoker) {
+          const retryDerivedInvokerNeedsResolution = queued.message.parsedMessageMeta?.derivedInvoker
+            && !hasParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, queued.message.run)
+          if (queued.message.resolvedInvoker && !retryDerivedInvokerNeedsResolution) {
             const retryInvoker = resolveInputAgentInvoker(retryInput.context)
             if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
           }
@@ -3087,7 +3093,9 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
             let retryInput = successorPending.message.input
             // SAFETY: successor settlement retries retain the Agent Definition selected by this route.
             if (successorPending.message.parsedMessageMeta !== undefined) retryInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, successorPending.message.run, successorPending.message.parsedMessageMeta)
-            if (successorPending.message.resolvedInvoker) {
+            const retryDerivedInvokerNeedsResolution = successorPending.message.parsedMessageMeta?.derivedInvoker
+              && !hasParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, successorPending.message.run)
+            if (successorPending.message.resolvedInvoker && !retryDerivedInvokerNeedsResolution) {
               const retryInvoker = resolveInputAgentInvoker(retryInput.context)
               if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
             }
@@ -3129,7 +3137,9 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
         let retryInput = claimedPending.message.input
         // SAFETY: claimed pending messages retain the Agent Definition selected by this route.
         if (claimedPending.message.parsedMessageMeta !== undefined) retryInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, claimedPending.message.run, claimedPending.message.parsedMessageMeta)
-        if (claimedPending.message.resolvedInvoker) {
+        const retryDerivedInvokerNeedsResolution = claimedPending.message.parsedMessageMeta?.derivedInvoker
+          && !hasParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, claimedPending.message.run)
+        if (claimedPending.message.resolvedInvoker && !retryDerivedInvokerNeedsResolution) {
           const retryInvoker = resolveInputAgentInvoker(retryInput.context)
           if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
         }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -3550,7 +3550,7 @@ async function restoreDurableSteerQueue(state: StateAdapter, queue: string, prev
       input: restoredInput,
       capabilities: newerMessage.capabilities ?? previous.capabilities,
       requestUrl: newerMessage.requestUrl ?? previous.requestUrl,
-      parsedMessageMeta: newerMessage.parsedMessageMeta ?? previous.parsedMessageMeta,
+      parsedMessageMeta: newerMessage.parsedMessageMeta,
       resolvedInvoker: newerMessage.resolvedInvoker ?? previous.resolvedInvoker,
       run: newerMessage.run ?? previous.run,
     }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -52,6 +52,7 @@ import { registerAgentWorkflowRetry } from "../internal/workflow-retry.ts"
 import { loadAgentWorkflowRuntimeStateModule } from "../internal/workflow-runtime-loaders.ts"
 import { portableWorkflowCapabilityOverrides } from "../internal/workflow-portability.ts"
 import { createResumableChatProcessCustody } from "../internal/resumable-chat.ts"
+import { withParsedAgentMessageMeta } from "../internal/message-meta.ts"
 import {
   isRuntimeBigInt,
   isRuntimeBoolean,
@@ -4545,7 +4546,11 @@ async function handleChatSdkMessage(
     if (isRuntimeNumber(options?.timeout) && Number.isFinite(options.timeout) && options.timeout > 0) {
       input.timeout = options.timeout
     }
-    const authorizationInput = createChatMessageTriggerInput(options || {}, input).input
+    const authorizationInput = await withParsedAgentMessageMeta(
+      agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined,
+      createChatMessageTriggerInput(options || {}, input).input,
+      input.run,
+    )
     const invoker = await isChatMessageAuthorized(agent, context, registration, thread, message, authorizationInput, input.run, messageContext)
     if (!invoker) {
       await recordChannelDeliveryEvidence(delivery, { type: "rejected" })
@@ -6472,7 +6477,11 @@ export function createChannelChatRouteHandler(
         resumableClaim = claim
       }
       const chatOptions = getChannelChatOptions(agent, routeOptions.channelId, getAgentChatOptions(agent)) || {}
-      const invokerInput = createChatMessageTriggerInput(chatOptions, triggerInput).input
+      const invokerInput = await withParsedAgentMessageMeta(
+        agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined,
+        createChatMessageTriggerInput(chatOptions, triggerInput).input,
+        triggerInput.run,
+      )
       const invoker = await resolveAgentInvoker(
         // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
         (agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined)?.invoker,

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -52,7 +52,7 @@ import { registerAgentWorkflowRetry } from "../internal/workflow-retry.ts"
 import { loadAgentWorkflowRuntimeStateModule } from "../internal/workflow-runtime-loaders.ts"
 import { portableWorkflowCapabilityOverrides } from "../internal/workflow-portability.ts"
 import { createResumableChatProcessCustody } from "../internal/resumable-chat.ts"
-import { hasParsedAgentMessageMeta, restoreParsedAgentMessageMeta, withParsedAgentMessageMeta } from "../internal/message-meta.ts"
+import { parsedAgentMessageMetaReceiptId, restoreParsedAgentMessageMeta, withParsedAgentMessageMeta } from "../internal/message-meta.ts"
 import {
   isRuntimeBigInt,
   isRuntimeBoolean,
@@ -2713,7 +2713,12 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
               }
               let recoveredWorkflowInput = recoveredInput
               if (restored.message.parsedMessageMeta) {
-                recoveredWorkflowInput = restoreParsedAgentMessageMeta(agent, recoveredWorkflowInput, run)
+                recoveredWorkflowInput = restoreParsedAgentMessageMeta(
+                  agent as AgentDefinition | undefined,
+                  recoveredWorkflowInput,
+                  restored.message.run,
+                  restored.message.parsedMessageMeta,
+                )
               }
               if (restored.message.resolvedInvoker) {
                 const recoveredInvoker = resolveInputAgentInvoker(recoveredWorkflowInput.context)
@@ -2952,7 +2957,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
         pendingQueue = durableSteerPendingQueue(queue)
         successorClaimId = crypto.randomUUID()
         let queuedInput = queued.message.input
-        if (queued.message.parsedMessageMeta) queuedInput = restoreParsedAgentMessageMeta(agent, queuedInput, queued.message.run)
+        if (queued.message.parsedMessageMeta) queuedInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, queuedInput, queued.message.run, queued.message.parsedMessageMeta)
         if (queued.message.resolvedInvoker) {
           const queuedInvoker = resolveInputAgentInvoker(queuedInput.context)
           if (queuedInvoker) queuedInput = withResolvedAgentInvokerInput(queuedInput, queuedInvoker)
@@ -3007,7 +3012,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
         if (ownerReleased) return
         if (successorStartAttempted && isAmbiguousAgentWorkflowStartFailure(error) && successorInput && queued?.message) {
           let retryInput = successorInput
-          if (queued.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(agent, retryInput, queued.message.run)
+          if (queued.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, queued.message.run, queued.message.parsedMessageMeta)
           if (queued.message.resolvedInvoker) {
             const retryInvoker = resolveInputAgentInvoker(retryInput.context)
             if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
@@ -3073,7 +3078,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
             )
           } catch (settlementError) {
             let retryInput = successorPending.message.input
-            if (successorPending.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(agent, retryInput, successorPending.message.run)
+            if (successorPending.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, successorPending.message.run, successorPending.message.parsedMessageMeta)
             if (successorPending.message.resolvedInvoker) {
               const retryInvoker = resolveInputAgentInvoker(retryInput.context)
               if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
@@ -3114,7 +3119,7 @@ export function installAgentChannelDeliveryWorkflowResolver(): void {
           await restoreDurableSteerQueue(resolved.state, queue, queued.message)
         }
         let retryInput = claimedPending.message.input
-        if (claimedPending.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(agent, retryInput, claimedPending.message.run)
+        if (claimedPending.message.parsedMessageMeta) retryInput = restoreParsedAgentMessageMeta(agent as AgentDefinition | undefined, retryInput, claimedPending.message.run, claimedPending.message.parsedMessageMeta)
         if (claimedPending.message.resolvedInvoker) {
           const retryInvoker = resolveInputAgentInvoker(retryInput.context)
           if (retryInvoker) retryInput = withResolvedAgentInvokerInput(retryInput, retryInvoker)
@@ -3217,7 +3222,7 @@ interface DurableSteerQueueMessage {
   input?: AgentRunInput
   invokerKey?: string
   ownerToken?: string
-  parsedMessageMeta?: boolean
+  parsedMessageMeta?: string
   requestUrl?: string
   resolvedInvoker?: boolean
   run?: AgentRunMetadata
@@ -4665,7 +4670,7 @@ async function handleChatSdkMessage(
         },
         invoker,
       ) as AgentRunInput
-      let workflowInputHasParsedMessageMeta = hasParsedAgentMessageMeta(agent, workflowInput, run)
+      let workflowInputHasParsedMessageMeta = parsedAgentMessageMetaReceiptId(agent, workflowInput, run)
       let workflowInputHasResolvedInvoker = hasResolvedAgentInvokerInput(workflowInput)
       let workflowInvokerKey = JSON.stringify(resolveInputAgentInvoker(workflowInput.context) ?? null)
       let workflowCapabilities = portableWorkflowCapabilityOverrides(context.capabilities)
@@ -4808,7 +4813,7 @@ async function handleChatSdkMessage(
             // The persisted entry remains the CAS expectation below. Rebinding
             // steer ownership must not mutate that expected value in place.
             workflowInput = structuredClone(previous.message.input)
-            workflowInputHasParsedMessageMeta = previous.message.parsedMessageMeta === true
+            workflowInputHasParsedMessageMeta = previous.message.parsedMessageMeta
             workflowInputHasResolvedInvoker = previous.message.resolvedInvoker === true
             workflowInvokerKey = durableSteerInvokerKey(previous.message)
             workflowCapabilities = previous.message.capabilities
@@ -4905,7 +4910,7 @@ async function handleChatSdkMessage(
           throw new Error("[vitehub] Durable steered Channel delivery lost ownership while its Agent Workflow was starting.")
         }
         const workflowStartInput = workflowInputHasParsedMessageMeta
-          ? restoreParsedAgentMessageMeta(agent, workflowInput, workflowRun)
+          ? restoreParsedAgentMessageMeta(agent, workflowInput, workflowRun, workflowInputHasParsedMessageMeta)
           : workflowInput
         // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
         await runAgent(agent as never, workflowRunContext as never, workflowStartInput as never)
@@ -5016,7 +5021,7 @@ async function handleChatSdkMessage(
                       recoveryStartAttempts++
                       // SAFETY: The owning Agent runtime boundary creates these values with the internal startup contract.
                       const recoveryStartInput = workflowInputHasParsedMessageMeta
-                        ? restoreParsedAgentMessageMeta(agent, recoveryInput, workflowRun)
+                        ? restoreParsedAgentMessageMeta(agent, recoveryInput, workflowRun, workflowInputHasParsedMessageMeta)
                         : recoveryInput
                       await runAgent(agent as never, workflowRunContext as never, recoveryStartInput as never)
                       return
@@ -5055,7 +5060,7 @@ async function handleChatSdkMessage(
               // depend on another webhook arriving.
               // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
               const recoveredWorkflowInput = workflowInputHasParsedMessageMeta
-                ? restoreParsedAgentMessageMeta(agent, workflowInput, workflowRun)
+                ? restoreParsedAgentMessageMeta(agent, workflowInput, workflowRun, workflowInputHasParsedMessageMeta)
                 : workflowInput
               await runAgent(agent as never, workflowRunContext as never, recoveredWorkflowInput as never)
               durableHandoff = true
@@ -5126,7 +5131,7 @@ async function handleChatSdkMessage(
                 try {
                   // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
                   const settlementRetryInput = workflowInputHasParsedMessageMeta
-                    ? restoreParsedAgentMessageMeta(agent, workflowInput, workflowRun)
+                    ? restoreParsedAgentMessageMeta(agent, workflowInput, workflowRun, workflowInputHasParsedMessageMeta)
                     : workflowInput
                   await runAgent(agent as never, workflowRunContext as never, settlementRetryInput as never)
                 } catch (retryError) {
@@ -5155,7 +5160,7 @@ async function handleChatSdkMessage(
                 try {
                   // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
                   const settlementRetryInput = workflowInputHasParsedMessageMeta
-                    ? restoreParsedAgentMessageMeta(agent, workflowInput, workflowRun)
+                    ? restoreParsedAgentMessageMeta(agent, workflowInput, workflowRun, workflowInputHasParsedMessageMeta)
                     : workflowInput
                   await runAgent(agent as never, workflowRunContext as never, settlementRetryInput as never)
                 } catch (retryError) {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1685,6 +1685,7 @@ interface AgentChatBaseOptions<TRuntimeConfig extends AgentRuntimeConfig = Agent
 export interface AgentChatCapabilityOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>
   extends AgentChatBaseOptions<TRuntimeConfig> {
   meta?: never
+  metaRevision?: never
   platforms?: never
   webhooks?: never
 }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1614,6 +1614,7 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
   lockScope?: AgentMessageLockScope
   messageHistory?: unknown
   meta?: StandardSchemaV1<unknown, Record<string, unknown>>
+  metaRevision?: string
   sessions?: boolean | AgentChatSessionOptions
   state?: AgentChatStateResolver<TRuntimeConfig>
   stream?: boolean

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1613,6 +1613,7 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
   identity?: IdentityResolver
   lockScope?: AgentMessageLockScope
   messageHistory?: unknown
+  meta?: StandardSchemaV1<unknown, Record<string, unknown>>
   sessions?: boolean | AgentChatSessionOptions
   state?: AgentChatStateResolver<TRuntimeConfig>
   stream?: boolean

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1683,6 +1683,7 @@ interface AgentChatBaseOptions<TRuntimeConfig extends AgentRuntimeConfig = Agent
 
 export interface AgentChatCapabilityOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>
   extends AgentChatBaseOptions<TRuntimeConfig> {
+  meta?: never
   platforms?: never
   webhooks?: never
 }

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -316,6 +316,37 @@ describe("Agent message metadata", () => {
     })
   })
 
+  it("rebuilds a derived Invoker after removing the metadata schema", async () => {
+    const previousAgent = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
+    const input = createChatMessageTriggerInput({}, {
+      messages: [{ parts: [{ text: "hello", type: "text" }], role: "user" }],
+      meta: { audience: "technical" },
+      user: { id: "chat:user-1" },
+    }).input
+    const prepared = await withParsedAgentMessageMeta(previousAgent, input)
+    const state = parsedAgentMessageMetaState(previousAgent, prepared)
+    const portable = await portableAgentWorkflowInput(withResolvedAgentInvokerInput(prepared, prepared.context!.invoker!))
+    let observed: unknown
+    const currentAgent = defineAgent({
+      driver: { run: ({ context }) => {
+        observed = context.get("invoker")
+        return "ok"
+      } },
+      invoker: {
+        resolve: ({ defaultInvoker }) => ({ ...defaultInvoker, id: "current-agent" }),
+      },
+    })
+
+    await runAgentWorkflowDefinition(currentAgent, {
+      id: "message-meta-schema-removal",
+      name: "message-meta-schema-removal",
+      payload: { input: portable, parsedMessageMeta: state, resolvedInvoker: true },
+      provider: "cloudflare",
+    }, runAgentInline)
+
+    expect(observed).toMatchObject({ id: "current-agent", kind: "chat" })
+  })
+
   it("transforms nonportable metadata before a durable handoff", async () => {
     const agent = defineAgent({
       driver: { run: () => "ok" },

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -10,6 +10,8 @@ import {
   withParsedAgentMessageMeta,
 } from "../src/internal/message-meta.ts"
 
+vi.mock("#vitehub/agent/registry", () => ({ default: {} }))
+
 const metaSchema = {
   "~standard": {
     validate(input: unknown) {
@@ -99,6 +101,19 @@ describe("Agent message metadata", () => {
     expect(run).not.toHaveBeenCalled()
   })
 
+  it("passes explicit null metadata to the schema", async () => {
+    const validate = vi.fn(() => ({ issues: [{ message: "metadata must be an object" }] }))
+    const agent = defineAgent({
+      driver: { run: () => "unreachable" },
+      messages: { meta: { "~standard": { validate } } as never },
+    })
+
+    await expect(runAgentInline(agent, runtime(), {
+      context: { channel: { meta: null } } as never,
+    })).rejects.toThrow("Invalid agent channel metadata")
+    expect(validate).toHaveBeenCalledWith(null)
+  })
+
   it("rejects schemas that transform metadata to a non-object", async () => {
     const agent = defineAgent({
       driver: { run: () => "unreachable" },
@@ -147,6 +162,27 @@ describe("Agent message metadata", () => {
 
     expect(parses).toBe(1)
     expect(restored.context?.channel).toEqual({ meta: { parse: 1 } })
+  })
+
+  it("transforms nonportable metadata before a durable handoff", async () => {
+    const agent = defineAgent({
+      driver: { run: () => "ok" },
+      messages: {
+        meta: {
+          "~standard": {
+            validate: (input: unknown) => ({ value: { sentAt: (input as { sentAt: Date }).sentAt.toISOString() } }),
+            vendor: "vitehub-test",
+            version: 1,
+          },
+        },
+      },
+    })
+    const input = { context: { channel: { meta: { sentAt: new Date("2026-08-27T09:00:00.000Z") } } } }
+
+    await expect(portableAgentWorkflowInput(input)).rejects.toThrow()
+    const portable = await portableAgentWorkflowInput(await withParsedAgentMessageMeta(agent, input))
+
+    expect(portable.context?.channel).toEqual({ meta: { sentAt: "2026-08-27T09:00:00.000Z" } })
   })
 
   it("does not trust a caller-provided parsed marker", async () => {

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -209,6 +209,27 @@ describe("Agent message metadata", () => {
     expect(restored.context?.channel).toEqual({ meta: { parse: 1 } })
   })
 
+  it("restores trusted parsed metadata with an empty revision", async () => {
+    let parses = 0
+    const schema = {
+      "~standard": {
+        validate: () => ({ value: { parse: ++parses } }),
+        vendor: "vitehub-test",
+        version: 1,
+      },
+    } as const
+    const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema, metaRevision: "" } })
+    const prepared = await withParsedAgentMessageMeta(agent, { context: { channel: { meta: {} } } })
+    const receiptId = parsedAgentMessageMetaReceiptId(agent, prepared)
+    const portable = await portableAgentWorkflowInput(prepared)
+    const restored = restoreParsedAgentMessageMeta(agent, portable, undefined, receiptId)
+
+    await parseAgentMessageMeta(agent, createAgentInvocationContextStore(restored.context))
+
+    expect(receiptId).toBe("")
+    expect(parses).toBe(1)
+  })
+
   it("revalidates durable metadata when the schema receipt is no longer current", async () => {
     const previousAgent = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
     const prepared = await withParsedAgentMessageMeta(previousAgent, { context: { channel: { meta: { audience: "technical" } } } })
@@ -377,28 +398,20 @@ describe("Agent message metadata", () => {
     expect(context.get("actor")).toEqual(context.get("invoker"))
   })
 
-  it("resolves programmatic Invokers from parsed metadata", async () => {
+  it("preserves explicit programmatic Invokers while parsing Channel metadata", async () => {
     const resolve = vi.fn(({ defaultInvoker, input }) => {
       expect(input.context?.invoker).toEqual({
-        email: {
-          address: "user@example.com",
-          domain: "example.com",
-        },
         id: "chat:user-1",
         kind: "chat",
-        meta: { audience: "technical", email: "user@example.com" },
+        meta: { audience: "technical", email: "user@example.com", ignored: true },
       })
       return defaultInvoker
     })
     const run = vi.fn(({ invoker }) => {
       expect(invoker).toEqual({
-        email: {
-          address: "user@example.com",
-          domain: "example.com",
-        },
         id: "chat:user-1",
         kind: "chat",
-        meta: { audience: "technical", email: "user@example.com" },
+        meta: { audience: "technical", email: "user@example.com", ignored: true },
       })
       return "ok"
     })
@@ -406,13 +419,9 @@ describe("Agent message metadata", () => {
       capabilities: ({ input }) => {
         expect(input.context?.channel).toEqual({ meta: { audience: "technical" } })
         expect(input.context?.invoker).toEqual({
-          email: {
-            address: "user@example.com",
-            domain: "example.com",
-          },
           id: "chat:user-1",
           kind: "chat",
-          meta: { audience: "technical", email: "user@example.com" },
+          meta: { audience: "technical", email: "user@example.com", ignored: true },
         })
         return []
       },

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -8,7 +8,7 @@ import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
 import { hasResolvedAgentInvokerInput, withResolvedAgentInvokerInput } from "../src/invoker.ts"
 import {
   hasParsedAgentMessageMeta,
-  parsedAgentMessageMetaReceiptId,
+  parsedAgentMessageMetaState,
   parseAgentMessageMeta,
   restoreParsedAgentMessageMeta,
   withParsedAgentMessageMeta,
@@ -199,10 +199,10 @@ describe("Agent message metadata", () => {
     const prepared = await withParsedAgentMessageMeta(agent, { context: { channel: { meta: {} } } })
 
     expect(hasParsedAgentMessageMeta(agent, prepared)).toBe(true)
-    const receiptId = parsedAgentMessageMetaReceiptId(agent, prepared)
+    const receipt = parsedAgentMessageMetaState(agent, prepared)
     const portable = await portableAgentWorkflowInput(prepared)
     const workflowAgent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema, metaRevision: "durable-v1" } })
-    const restored = restoreParsedAgentMessageMeta(workflowAgent, portable, undefined, receiptId)
+    const restored = restoreParsedAgentMessageMeta(workflowAgent, portable, undefined, receipt)
     await parseAgentMessageMeta(workflowAgent, createAgentInvocationContextStore(restored.context))
 
     expect(parses).toBe(1)
@@ -220,20 +220,20 @@ describe("Agent message metadata", () => {
     } as const
     const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema, metaRevision: "" } })
     const prepared = await withParsedAgentMessageMeta(agent, { context: { channel: { meta: {} } } })
-    const receiptId = parsedAgentMessageMetaReceiptId(agent, prepared)
+    const receipt = parsedAgentMessageMetaState(agent, prepared)
     const portable = await portableAgentWorkflowInput(prepared)
-    const restored = restoreParsedAgentMessageMeta(agent, portable, undefined, receiptId)
+    const restored = restoreParsedAgentMessageMeta(agent, portable, undefined, receipt)
 
     await parseAgentMessageMeta(agent, createAgentInvocationContextStore(restored.context))
 
-    expect(receiptId).toBe("")
+    expect(receipt).toEqual({ revision: "" })
     expect(parses).toBe(1)
   })
 
   it("revalidates durable metadata when the schema receipt is no longer current", async () => {
     const previousAgent = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
     const prepared = await withParsedAgentMessageMeta(previousAgent, { context: { channel: { meta: { audience: "technical" } } } })
-    const previousReceiptId = parsedAgentMessageMetaReceiptId(previousAgent, prepared)
+    const previousReceipt = parsedAgentMessageMetaState(previousAgent, prepared)
     const portable = await portableAgentWorkflowInput(prepared)
     const currentAgent = defineAgent({
       driver: { run: () => "ok" },
@@ -248,12 +248,49 @@ describe("Agent message metadata", () => {
         metaRevision: "current-v2",
       },
     })
-    const restored = restoreParsedAgentMessageMeta(currentAgent, portable, undefined, previousReceiptId)
+    const restored = restoreParsedAgentMessageMeta(currentAgent, portable, undefined, previousReceipt)
     const context = createAgentInvocationContextStore(restored.context)
 
     await parseAgentMessageMeta(currentAgent, context)
 
     expect(context.get("channel")).toEqual({ meta: { audience: "current" } })
+  })
+
+  it("rebuilds a derived Invoker after durable revalidation", async () => {
+    const previousAgent = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
+    const input = createChatMessageTriggerInput({}, {
+      messages: [{ parts: [{ text: "hello", type: "text" }], role: "user" }],
+      meta: { audience: "technical" },
+      user: { id: "chat:user-1" },
+    }).input
+    const prepared = await withParsedAgentMessageMeta(previousAgent, input)
+    const state = parsedAgentMessageMetaState(previousAgent, prepared)
+    const portable = await portableAgentWorkflowInput(prepared)
+    const currentAgent = defineAgent({
+      driver: { run: () => "ok" },
+      messages: {
+        meta: {
+          "~standard": {
+            validate: () => ({ value: { audience: "current" } }),
+            vendor: "vitehub-test",
+            version: 1,
+          },
+        },
+        metaRevision: "current-v2",
+      },
+    })
+    const restored = restoreParsedAgentMessageMeta(currentAgent, portable, undefined, state)
+    const context = createAgentInvocationContextStore(restored.context)
+
+    await parseAgentMessageMeta(currentAgent, context)
+
+    expect(state).toEqual({ derivedInvoker: true, revision: "test-v1" })
+    expect(context.get("channel")).toEqual({ meta: { audience: "current" }, user: { id: "chat:user-1" } })
+    expect(context.get("invoker")).toEqual({
+      id: "chat:user-1",
+      kind: "chat",
+      meta: { audience: "current", id: "chat:user-1" },
+    })
   })
 
   it("transforms nonportable metadata before a durable handoff", async () => {

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { defineAgent, runAgentInline } from "../src/index.ts"
+
+const metaSchema = {
+  "~standard": {
+    validate(input: unknown) {
+      const meta = input as Record<string, unknown>
+      if (!meta || typeof meta !== "object" || Array.isArray(meta) || ![undefined, "support", "technical"].includes(meta.audience as string | undefined)) {
+        return { issues: [{ message: "audience must be support or technical" }] }
+      }
+      return { value: { audience: meta.audience ?? "support" } }
+    },
+    vendor: "vitehub-test",
+    version: 1,
+  },
+} as const
+
+function runtime(run?: { channelId?: string, runId: string }) {
+  return {
+    memo: vi.fn(),
+    run,
+    runtime: "unknown" as const,
+    waitUntil: vi.fn(),
+  }
+}
+
+describe("Agent message metadata", () => {
+  it("validates and transforms shared channel and chat metadata before the driver runs", async () => {
+    let observed: unknown
+    const agent = defineAgent({
+      driver: { run: ({ context }) => {
+        observed = { channel: context.get("channel"), chat: context.get("chat") }
+        return "ok"
+      } },
+      messages: { meta: metaSchema },
+    })
+
+    await runAgentInline(agent, runtime(), {
+      context: {
+        channel: { meta: { audience: "technical", ignored: true } },
+        chat: { meta: { audience: "technical", ignored: true } },
+      },
+    })
+
+    expect(observed).toEqual({
+      channel: { meta: { audience: "technical" } },
+      chat: { meta: { audience: "technical" } },
+    })
+  })
+
+  it("uses the active Channel metadata schema over shared settings", async () => {
+    let observed: unknown
+    const channelSchema = {
+      "~standard": {
+        validate: () => ({ value: { source: "channel" } }),
+        vendor: "vitehub-test",
+        version: 1,
+      },
+    } as const
+    const agent = defineAgent({
+      channels: { support: { kind: "support", messages: { meta: channelSchema } } },
+      driver: { run: ({ context }) => {
+        observed = context.get("channel")
+        return "ok"
+      } },
+      messages: { meta: metaSchema },
+    })
+
+    await runAgentInline(agent, runtime({ channelId: "support", runId: "run-support" }), {
+      context: { channel: { meta: { audience: "technical" } } },
+    })
+
+    expect(observed).toEqual({ meta: { source: "channel" } })
+  })
+
+  it("rejects invalid metadata before the driver runs", async () => {
+    const run = vi.fn(() => "unreachable")
+    const agent = defineAgent({ driver: { run }, messages: { meta: metaSchema } })
+
+    await expect(runAgentInline(agent, runtime(), {
+      context: { channel: { meta: { audience: "customer" } } },
+    })).rejects.toThrow("Invalid agent channel metadata")
+    expect(run).not.toHaveBeenCalled()
+  })
+
+  it("rejects schemas that transform metadata to a non-object", async () => {
+    const agent = defineAgent({
+      driver: { run: () => "unreachable" },
+      messages: { meta: { "~standard": { validate: () => ({ value: "invalid" }) } } as never },
+    })
+
+    await expect(runAgentInline(agent, runtime(), {
+      context: { channel: { meta: {} } },
+    })).rejects.toThrow("metadata schema must return an object")
+  })
+})

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -143,6 +143,24 @@ describe("Agent message metadata", () => {
     expect(prepared.context?.channel).toEqual({ meta: { parse: 1 } })
   })
 
+  it("does not reuse another Agent Definition's metadata receipt", async () => {
+    const first = defineAgent({ driver: { run: () => "ok" }, messages: { meta: metaSchema } })
+    const secondSchema = {
+      "~standard": {
+        validate: () => ({ value: { owner: "second" } }),
+        vendor: "vitehub-test",
+        version: 1,
+      },
+    } as const
+    const second = defineAgent({ driver: { run: () => "ok" }, messages: { meta: secondSchema } })
+    const prepared = await withParsedAgentMessageMeta(first, { context: { channel: { meta: {} } } })
+    const context = createAgentInvocationContextStore(prepared.context)
+
+    await parseAgentMessageMeta(second, context)
+
+    expect(context.get("channel")).toEqual({ meta: { owner: "second" } })
+  })
+
   it("restores trusted parsed metadata after a durable handoff", async () => {
     let parses = 0
     const schema = {
@@ -155,9 +173,9 @@ describe("Agent message metadata", () => {
     const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema } })
     const prepared = await withParsedAgentMessageMeta(agent, { context: { channel: { meta: {} } } })
 
-    expect(hasParsedAgentMessageMeta(prepared)).toBe(true)
+    expect(hasParsedAgentMessageMeta(agent, prepared)).toBe(true)
     const portable = await portableAgentWorkflowInput(prepared)
-    const restored = restoreParsedAgentMessageMeta(portable)
+    const restored = restoreParsedAgentMessageMeta(agent, portable)
     await parseAgentMessageMeta(agent, createAgentInvocationContextStore(restored.context))
 
     expect(parses).toBe(1)
@@ -223,6 +241,27 @@ describe("Agent message metadata", () => {
       kind: "chat",
       meta: { audience: "technical", email: "user@example.com" },
     })
+    expect(context.get("actor")).toEqual(context.get("invoker"))
+  })
+
+  it("rebuilds a chat invoker when null metadata is normalized", async () => {
+    const schema = {
+      "~standard": {
+        validate: () => ({ value: { audience: "support" } }),
+        vendor: "vitehub-test",
+        version: 1,
+      },
+    } as const
+    const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema } })
+    const context = createAgentInvocationContextStore({
+      actor: { id: "chat:user-1", kind: "chat", meta: {} },
+      channel: { meta: null },
+      invoker: { id: "chat:user-1", kind: "chat", meta: {} },
+    })
+
+    await parseAgentMessageMeta(agent, context)
+
+    expect(context.get("invoker")).toEqual({ id: "chat:user-1", kind: "chat", meta: { audience: "support" } })
     expect(context.get("actor")).toEqual(context.get("invoker"))
   })
 

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -265,9 +265,19 @@ describe("Agent message metadata", () => {
     }).input
     const prepared = await withParsedAgentMessageMeta(previousAgent, input)
     const state = parsedAgentMessageMetaState(previousAgent, prepared)
-    const portable = await portableAgentWorkflowInput(prepared)
+    const portable = await portableAgentWorkflowInput(withResolvedAgentInvokerInput(prepared, prepared.context!.invoker!))
+    let observed: unknown
     const currentAgent = defineAgent({
-      driver: { run: () => "ok" },
+      driver: { run: ({ context }) => {
+        observed = { channel: context.get("channel"), invoker: context.get("invoker") }
+        return "ok"
+      } },
+      invoker: {
+        resolve: ({ defaultInvoker }) => ({
+          ...defaultInvoker,
+          id: `audience:${defaultInvoker.meta?.audience}`,
+        }),
+      },
       messages: {
         meta: {
           "~standard": {
@@ -280,20 +290,20 @@ describe("Agent message metadata", () => {
       },
     })
     const restored = restoreParsedAgentMessageMeta(currentAgent, portable, undefined, state)
-    const context = createAgentInvocationContextStore(restored.context)
-
-    await parseAgentMessageMeta(currentAgent, context)
+    await runAgentInline(currentAgent, runtime(), restored)
 
     expect(state).toEqual({ derivedInvoker: true, revision: "test-v1" })
-    expect(context.get("channel")).toEqual({
-      message: { parts: [{ text: "hello", type: "text" }], role: "user" },
-      meta: { audience: "current" },
-      user: { id: "chat:user-1" },
-    })
-    expect(context.get("invoker")).toEqual({
-      id: "chat:user-1",
-      kind: "chat",
-      meta: { audience: "current", id: "chat:user-1" },
+    expect(observed).toEqual({
+      channel: {
+        message: { text: "hello" },
+        meta: { audience: "current" },
+        user: { id: "chat:user-1" },
+      },
+      invoker: {
+        id: "audience:current",
+        kind: "chat",
+        meta: { audience: "current", id: "chat:user-1" },
+      },
     })
   })
 

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { createChatMessageTriggerInput } from "../src/chat-message-input.ts"
+import { createChatMessageTriggerInput, markDerivedChatTriggerInvoker } from "../src/chat-message-input.ts"
 import { defineAgent, portableAgentWorkflowInput, runAgentInline } from "../src/index.ts"
 import { resolveAgentChannelChatOptions } from "../src/internal/channels.ts"
 import { hasRuntimeType, isRuntimeRecord } from "../src/internal/runtime-type.ts"
@@ -275,8 +275,11 @@ describe("Agent message metadata", () => {
       user: { id: "chat:user-1" },
     }).input
     const prepared = await withParsedAgentMessageMeta(previousAgent, input)
-    const state = parsedAgentMessageMetaState(previousAgent, prepared)
-    const portable = await portableAgentWorkflowInput(withResolvedAgentInvokerInput(prepared, prepared.context!.invoker!))
+    const resolvedInvoker = { id: "audience:technical", kind: "service" }
+    markDerivedChatTriggerInvoker(resolvedInvoker, prepared.context!.invoker!)
+    const resolvedInput = withResolvedAgentInvokerInput(prepared, resolvedInvoker)
+    const state = parsedAgentMessageMetaState(previousAgent, resolvedInput)
+    const portable = await portableAgentWorkflowInput(resolvedInput)
     let observed: unknown
     const currentAgent = defineAgent({
       driver: { run: ({ context }) => {
@@ -311,7 +314,14 @@ describe("Agent message metadata", () => {
       provider: "cloudflare",
     }, runAgentInline)
 
-    expect(state).toEqual({ derivedInvoker: true, revision: "test-v1" })
+    expect(state).toEqual({
+      derivedInvoker: {
+        id: "chat:user-1",
+        kind: "chat",
+        meta: { audience: "technical", id: "chat:user-1" },
+      },
+      revision: "test-v1",
+    })
     expect(observed).toEqual({
       channel: {
         message: { text: "hello" },

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -122,4 +122,41 @@ describe("Agent message metadata", () => {
     expect(parses).toBe(1)
     expect(prepared.context?.channel).toEqual({ meta: { parse: 1 } })
   })
+
+  it("does not trust a caller-provided parsed marker", async () => {
+    let parses = 0
+    const schema = {
+      "~standard": {
+        validate: () => ({ value: { parse: ++parses } }),
+        vendor: "vitehub-test",
+        version: 1,
+      },
+    } as const
+    const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema } })
+
+    await parseAgentMessageMeta(agent, createAgentInvocationContextStore({
+      channel: { meta: {} },
+      "vitehub.agent.messageMetaParsed": true,
+    }))
+
+    expect(parses).toBe(1)
+  })
+
+  it("rebuilds a chat invoker from parsed metadata", async () => {
+    const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: metaSchema } })
+    const context = createAgentInvocationContextStore({
+      actor: { id: "chat:user-1", kind: "chat", meta: { audience: "technical", email: "user@example.com", ignored: true } },
+      channel: { meta: { audience: "technical", ignored: true } },
+      invoker: { id: "chat:user-1", kind: "chat", meta: { audience: "technical", email: "user@example.com", ignored: true } },
+    })
+
+    await parseAgentMessageMeta(agent, context)
+
+    expect(context.get("invoker")).toEqual({
+      id: "chat:user-1",
+      kind: "chat",
+      meta: { audience: "technical", email: "user@example.com" },
+    })
+    expect(context.get("actor")).toEqual(context.get("invoker"))
+  })
 })

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { defineAgent, portableAgentWorkflowInput, runAgentInline } from "../src/index.ts"
 import { resolveAgentChannelChatOptions } from "../src/internal/channels.ts"
+import { hasRuntimeType, isRuntimeRecord } from "../src/internal/runtime-type.ts"
 import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
 import {
   hasParsedAgentMessageMeta,
@@ -16,8 +17,8 @@ vi.mock("#vitehub/agent/registry", () => ({ default: {} }))
 const metaSchema = {
   "~standard": {
     validate(input: unknown) {
-      const meta = input as Record<string, unknown>
-      if (!meta || typeof meta !== "object" || Array.isArray(meta) || ![undefined, "support", "technical"].includes(meta.audience as string | undefined)) {
+      const meta = isRuntimeRecord(input) && !Array.isArray(input) ? input : undefined
+      if (!meta || ![undefined, "support", "technical"].includes(hasRuntimeType(meta.audience, "string") ? meta.audience : undefined)) {
         return { issues: [{ message: "audience must be support or technical" }] }
       }
       return { value: { audience: meta.audience ?? "support" } }
@@ -26,6 +27,8 @@ const metaSchema = {
     version: 1,
   },
 } as const
+
+const metaSettings = { meta: metaSchema, metaRevision: "test-v1" } as const
 
 function runtime(run?: { channelId?: string, runId: string }) {
   return {
@@ -39,7 +42,7 @@ function runtime(run?: { channelId?: string, runId: string }) {
 describe("Agent message metadata", () => {
   it("allows Channel-local metadata schemas with multiple message Channels", () => {
     expect(() => resolveAgentChannelChatOptions({
-      support: { kind: "support", messages: { meta: metaSchema } },
+      support: { kind: "support", messages: metaSettings },
       technical: { kind: "technical", messages: {} },
     }, undefined)).not.toThrow()
   })
@@ -51,7 +54,7 @@ describe("Agent message metadata", () => {
         observed = { channel: context.get("channel"), chat: context.get("chat") }
         return "ok"
       } },
-      messages: { meta: metaSchema },
+      messages: metaSettings,
     })
 
     await runAgentInline(agent, runtime(), {
@@ -77,12 +80,12 @@ describe("Agent message metadata", () => {
       },
     } as const
     const agent = defineAgent({
-      channels: { support: { kind: "support", messages: { meta: channelSchema } } },
+      channels: { support: { kind: "support", messages: { meta: channelSchema, metaRevision: "channel-v1" } } },
       driver: { run: ({ context }) => {
         observed = context.get("channel")
         return "ok"
       } },
-      messages: { meta: metaSchema },
+      messages: metaSettings,
     })
 
     await runAgentInline(agent, runtime({ channelId: "support", runId: "run-support" }), {
@@ -94,7 +97,7 @@ describe("Agent message metadata", () => {
 
   it("rejects invalid metadata before the driver runs", async () => {
     const run = vi.fn(() => "unreachable")
-    const agent = defineAgent({ driver: { run }, messages: { meta: metaSchema } })
+    const agent = defineAgent({ driver: { run }, messages: metaSettings })
 
     await expect(runAgentInline(agent, runtime(), {
       context: { channel: { meta: { audience: "customer" } } },
@@ -106,10 +109,12 @@ describe("Agent message metadata", () => {
     const validate = vi.fn(() => ({ issues: [{ message: "metadata must be an object" }] }))
     const agent = defineAgent({
       driver: { run: () => "unreachable" },
+      // SAFETY: this deliberately incomplete schema tests runtime validation of untyped definitions.
       messages: { meta: { "~standard": { validate } } as never },
     })
 
     await expect(runAgentInline(agent, runtime(), {
+      // SAFETY: explicit null is outside the typed contract and is the boundary case under test.
       context: { channel: { meta: null } } as never,
     })).rejects.toThrow("Invalid agent channel metadata")
     expect(validate).toHaveBeenCalledWith(null)
@@ -118,6 +123,7 @@ describe("Agent message metadata", () => {
   it("rejects schemas that transform metadata to a non-object", async () => {
     const agent = defineAgent({
       driver: { run: () => "unreachable" },
+      // SAFETY: this deliberately invalid output schema tests the runtime object-output guard.
       messages: { meta: { "~standard": { validate: () => ({ value: "invalid" }) } } as never },
     })
 
@@ -135,7 +141,7 @@ describe("Agent message metadata", () => {
         version: 1,
       },
     } as const
-    const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema } })
+    const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema, metaRevision: "parse-v1" } })
     const prepared = await withParsedAgentMessageMeta(agent, { context: { channel: { meta: {} } } })
 
     await parseAgentMessageMeta(agent, createAgentInvocationContextStore(prepared.context))
@@ -145,7 +151,7 @@ describe("Agent message metadata", () => {
   })
 
   it("does not reuse another Agent Definition's metadata receipt", async () => {
-    const first = defineAgent({ driver: { run: () => "ok" }, messages: { meta: metaSchema } })
+    const first = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
     const secondSchema = {
       "~standard": {
         validate: () => ({ value: { owner: "second" } }),
@@ -171,22 +177,23 @@ describe("Agent message metadata", () => {
         version: 1,
       },
     } as const
-    const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema } })
+    const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema, metaRevision: "durable-v1" } })
     const prepared = await withParsedAgentMessageMeta(agent, { context: { channel: { meta: {} } } })
 
     expect(hasParsedAgentMessageMeta(agent, prepared)).toBe(true)
     const receiptId = parsedAgentMessageMetaReceiptId(agent, prepared)
     const portable = await portableAgentWorkflowInput(prepared)
-    const restored = restoreParsedAgentMessageMeta(agent, portable, undefined, receiptId)
-    await parseAgentMessageMeta(agent, createAgentInvocationContextStore(restored.context))
+    const workflowAgent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema, metaRevision: "durable-v1" } })
+    const restored = restoreParsedAgentMessageMeta(workflowAgent, portable, undefined, receiptId)
+    await parseAgentMessageMeta(workflowAgent, createAgentInvocationContextStore(restored.context))
 
     expect(parses).toBe(1)
     expect(restored.context?.channel).toEqual({ meta: { parse: 1 } })
   })
 
   it("revalidates durable metadata when the schema receipt is no longer current", async () => {
-    const previousAgent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: metaSchema } })
-    const prepared = await withParsedAgentMessageMeta(previousAgent, { context: { channel: { meta: { audience: "TECHNICAL" } } } })
+    const previousAgent = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
+    const prepared = await withParsedAgentMessageMeta(previousAgent, { context: { channel: { meta: { audience: "technical" } } } })
     const previousReceiptId = parsedAgentMessageMetaReceiptId(previousAgent, prepared)
     const portable = await portableAgentWorkflowInput(prepared)
     const currentAgent = defineAgent({
@@ -199,6 +206,7 @@ describe("Agent message metadata", () => {
             version: 1,
           },
         },
+        metaRevision: "current-v2",
       },
     })
     const restored = restoreParsedAgentMessageMeta(currentAgent, portable, undefined, previousReceiptId)
@@ -215,6 +223,7 @@ describe("Agent message metadata", () => {
       messages: {
         meta: {
           "~standard": {
+            // SAFETY: this schema's contract requires a Date and the test supplies one before portability.
             validate: (input: unknown) => ({ value: { sentAt: (input as { sentAt: Date }).sentAt.toISOString() } }),
             vendor: "vitehub-test",
             version: 1,
@@ -250,7 +259,7 @@ describe("Agent message metadata", () => {
   })
 
   it("rebuilds a chat invoker from parsed metadata", async () => {
-    const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: metaSchema } })
+    const agent = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
     const context = createAgentInvocationContextStore({
       actor: { id: "chat:user-1", kind: "chat", meta: { audience: "technical", email: "user@example.com", ignored: true } },
       channel: { meta: { audience: "technical", ignored: true } },
@@ -293,7 +302,7 @@ describe("Agent message metadata", () => {
   })
 
   it("removes derived Invoker identity stripped by the metadata schema", async () => {
-    const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: metaSchema } })
+    const agent = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
     const context = createAgentInvocationContextStore({
       actor: {
         email: { address: "raw@example.com", domain: "example.com" },
@@ -361,7 +370,7 @@ describe("Agent message metadata", () => {
       },
       driver: { run },
       invoker: { resolve },
-      messages: { meta: metaSchema },
+      messages: metaSettings,
     })
 
     await runAgentInline(agent, runtime(), {

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -204,6 +204,15 @@ describe("Agent message metadata", () => {
       return "ok"
     })
     const agent = defineAgent({
+      capabilities: ({ input }) => {
+        expect(input.context?.channel).toEqual({ meta: { audience: "technical" } })
+        expect(input.context?.invoker).toEqual({
+          id: "chat:user-1",
+          kind: "chat",
+          meta: { audience: "technical", email: "user@example.com" },
+        })
+        return []
+      },
       driver: { run },
       invoker: { resolve },
       messages: { meta: metaSchema },

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest"
 
 import { defineAgent, runAgentInline } from "../src/index.ts"
 import { resolveAgentChannelChatOptions } from "../src/internal/channels.ts"
+import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
+import { parseAgentMessageMeta, withParsedAgentMessageMeta } from "../src/internal/message-meta.ts"
 
 const metaSchema = {
   "~standard": {
@@ -101,5 +103,23 @@ describe("Agent message metadata", () => {
     await expect(runAgentInline(agent, runtime(), {
       context: { channel: { meta: {} } },
     })).rejects.toThrow("metadata schema must return an object")
+  })
+
+  it("reuses metadata parsed before authorization during invocation", async () => {
+    let parses = 0
+    const schema = {
+      "~standard": {
+        validate: () => ({ value: { parse: ++parses } }),
+        vendor: "vitehub-test",
+        version: 1,
+      },
+    } as const
+    const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema } })
+    const prepared = await withParsedAgentMessageMeta(agent, { context: { channel: { meta: {} } } })
+
+    await parseAgentMessageMeta(agent, createAgentInvocationContextStore(prepared.context))
+
+    expect(parses).toBe(1)
+    expect(prepared.context?.channel).toEqual({ meta: { parse: 1 } })
   })
 })

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest"
 
 import { defineAgent, runAgentInline } from "../src/index.ts"
+import { resolveAgentChannelChatOptions } from "../src/internal/channels.ts"
 
 const metaSchema = {
   "~standard": {
@@ -26,6 +27,13 @@ function runtime(run?: { channelId?: string, runId: string }) {
 }
 
 describe("Agent message metadata", () => {
+  it("allows Channel-local metadata schemas with multiple message Channels", () => {
+    expect(() => resolveAgentChannelChatOptions({
+      support: { kind: "support", messages: { meta: metaSchema } },
+      technical: { kind: "technical", messages: {} },
+    }, undefined)).not.toThrow()
+  })
+
   it("validates and transforms shared channel and chat metadata before the driver runs", async () => {
     let observed: unknown
     const agent = defineAgent({

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -179,6 +179,10 @@ describe("Agent message metadata", () => {
     await parseAgentMessageMeta(agent, context)
 
     expect(context.get("invoker")).toEqual({
+      email: {
+        address: "user@example.com",
+        domain: "example.com",
+      },
       id: "chat:user-1",
       kind: "chat",
       meta: { audience: "technical", email: "user@example.com" },

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -221,6 +221,10 @@ describe("Agent message metadata", () => {
   it("resolves programmatic Invokers from parsed metadata", async () => {
     const resolve = vi.fn(({ defaultInvoker, input }) => {
       expect(input.context?.invoker).toEqual({
+        email: {
+          address: "user@example.com",
+          domain: "example.com",
+        },
         id: "chat:user-1",
         kind: "chat",
         meta: { audience: "technical", email: "user@example.com" },
@@ -229,6 +233,10 @@ describe("Agent message metadata", () => {
     })
     const run = vi.fn(({ invoker }) => {
       expect(invoker).toEqual({
+        email: {
+          address: "user@example.com",
+          domain: "example.com",
+        },
         id: "chat:user-1",
         kind: "chat",
         meta: { audience: "technical", email: "user@example.com" },
@@ -239,6 +247,10 @@ describe("Agent message metadata", () => {
       capabilities: ({ input }) => {
         expect(input.context?.channel).toEqual({ meta: { audience: "technical" } })
         expect(input.context?.invoker).toEqual({
+          email: {
+            address: "user@example.com",
+            domain: "example.com",
+          },
           id: "chat:user-1",
           kind: "chat",
           meta: { audience: "technical", email: "user@example.com" },

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -345,15 +345,23 @@ describe("Agent message metadata", () => {
     }).input
     const prepared = await withParsedAgentMessageMeta(previousAgent, input)
     const state = parsedAgentMessageMetaState(previousAgent, prepared)
-    const portable = await portableAgentWorkflowInput(withResolvedAgentInvokerInput(prepared, prepared.context!.invoker!))
+    const portable = await portableAgentWorkflowInput(withResolvedAgentInvokerInput(prepared, {
+      id: "previous-service",
+      kind: "service",
+      meta: { audience: "technical" },
+    }))
     let observed: unknown
+    let resolverInput: unknown
     const currentAgent = defineAgent({
       driver: { run: ({ context }) => {
         observed = context.get("invoker")
         return "ok"
       } },
       invoker: {
-        resolve: ({ defaultInvoker }) => ({ ...defaultInvoker, id: "current-agent" }),
+        resolve: ({ defaultInvoker }) => {
+          resolverInput = defaultInvoker
+          return { ...defaultInvoker, id: "current-agent" }
+        },
       },
     })
 
@@ -364,6 +372,7 @@ describe("Agent message metadata", () => {
       provider: "cloudflare",
     }, runAgentInline)
 
+    expect(resolverInput).toMatchObject({ id: "chat:user-1", kind: "chat" })
     expect(observed).toMatchObject({ id: "current-agent", kind: "chat" })
   })
 

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -285,7 +285,11 @@ describe("Agent message metadata", () => {
     await parseAgentMessageMeta(currentAgent, context)
 
     expect(state).toEqual({ derivedInvoker: true, revision: "test-v1" })
-    expect(context.get("channel")).toEqual({ meta: { audience: "current" }, user: { id: "chat:user-1" } })
+    expect(context.get("channel")).toEqual({
+      message: { parts: [{ text: "hello", type: "text" }], role: "user" },
+      meta: { audience: "current" },
+      user: { id: "chat:user-1" },
+    })
     expect(context.get("invoker")).toEqual({
       id: "chat:user-1",
       kind: "chat",
@@ -446,6 +450,7 @@ describe("Agent message metadata", () => {
     })
     const run = vi.fn(({ invoker }) => {
       expect(invoker).toEqual({
+        email: { address: "user@example.com", domain: "example.com" },
         id: "chat:user-1",
         kind: "chat",
         meta: { audience: "technical", email: "user@example.com", ignored: true },

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -231,6 +231,16 @@ describe("Agent message metadata", () => {
     expect(parses).toBe(1)
   })
 
+  it("does not emit parsed metadata state when no schema is configured", () => {
+    const agent = defineAgent({ driver: { run: () => "ok" } })
+    const input = createChatMessageTriggerInput({}, {
+      messages: [{ parts: [{ text: "hello", type: "text" }], role: "user" }],
+      user: { id: "chat:user-1" },
+    }).input
+
+    expect(parsedAgentMessageMetaState(agent, input)).toBeUndefined()
+  })
+
   it("revalidates durable metadata when the schema receipt is no longer current", async () => {
     const previousAgent = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
     const prepared = await withParsedAgentMessageMeta(previousAgent, { context: { channel: { meta: { audience: "technical" } } } })

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
+import { createChatMessageTriggerInput } from "../src/chat-message-input.ts"
 import { defineAgent, portableAgentWorkflowInput, runAgentInline } from "../src/index.ts"
 import { resolveAgentChannelChatOptions } from "../src/internal/channels.ts"
 import { hasRuntimeType, isRuntimeRecord } from "../src/internal/runtime-type.ts"
@@ -277,11 +278,12 @@ describe("Agent message metadata", () => {
 
   it("rebuilds a chat invoker from parsed metadata", async () => {
     const agent = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
-    const context = createAgentInvocationContextStore({
-      actor: { id: "chat:user-1", kind: "chat", meta: { audience: "technical", email: "user@example.com", ignored: true } },
-      channel: { meta: { audience: "technical", ignored: true } },
-      invoker: { id: "chat:user-1", kind: "chat", meta: { audience: "technical", email: "user@example.com", ignored: true } },
-    })
+    const input = createChatMessageTriggerInput({}, {
+      messages: [{ parts: [{ text: "hello", type: "text" }], role: "user" }],
+      meta: { audience: "technical", ignored: true },
+      user: { email: "user@example.com", id: "chat:user-1" },
+    }).input
+    const context = createAgentInvocationContextStore(input.context)
 
     await parseAgentMessageMeta(agent, context)
 
@@ -292,9 +294,27 @@ describe("Agent message metadata", () => {
       },
       id: "chat:user-1",
       kind: "chat",
-      meta: { audience: "technical", email: "user@example.com" },
+      meta: { audience: "technical", email: "user@example.com", id: "chat:user-1" },
     })
     expect(context.get("actor")).toEqual(context.get("invoker"))
+  })
+
+  it("preserves metadata owned by an explicit chat Invoker", async () => {
+    const agent = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
+    const input = createChatMessageTriggerInput({}, {
+      invoker: { id: "trusted", kind: "chat", meta: { audience: "internal", ignored: "trusted" } },
+      messages: [{ parts: [{ text: "hello", type: "text" }], role: "user" }],
+      meta: { audience: "technical", ignored: "untrusted" },
+    }).input
+    const context = createAgentInvocationContextStore(input.context)
+
+    await parseAgentMessageMeta(agent, context)
+
+    expect(context.get("invoker")).toEqual({
+      id: "trusted",
+      kind: "chat",
+      meta: { audience: "internal", ignored: "trusted" },
+    })
   })
 
   it("rebuilds a chat invoker when null metadata is normalized", async () => {
@@ -306,72 +326,51 @@ describe("Agent message metadata", () => {
       },
     } as const
     const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema } })
-    const context = createAgentInvocationContextStore({
-      actor: { id: "chat:user-1", kind: "chat", meta: {} },
-      channel: { meta: null },
-      invoker: { id: "chat:user-1", kind: "chat", meta: {} },
-    })
+    const input = createChatMessageTriggerInput({}, {
+      messages: [{ parts: [{ text: "hello", type: "text" }], role: "user" }],
+      user: { id: "chat:user-1" },
+    }).input
+    const context = createAgentInvocationContextStore({ ...input.context, channel: { meta: null } })
 
     await parseAgentMessageMeta(agent, context)
 
-    expect(context.get("invoker")).toEqual({ id: "chat:user-1", kind: "chat", meta: { audience: "support" } })
+    expect(context.get("invoker")).toEqual({ id: "chat:user-1", kind: "chat", meta: { audience: "support", id: "chat:user-1" } })
     expect(context.get("actor")).toEqual(context.get("invoker"))
   })
 
   it("removes derived Invoker identity stripped by the metadata schema", async () => {
     const agent = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
-    const context = createAgentInvocationContextStore({
-      actor: {
-        email: { address: "raw@example.com", domain: "example.com" },
-        id: "chat:user-1",
-        kind: "chat",
-        meta: { audience: "technical", email: "raw@example.com" },
-      },
-      channel: { meta: { audience: "technical", email: "raw@example.com" } },
-      invoker: {
-        email: { address: "raw@example.com", domain: "example.com" },
-        id: "chat:user-1",
-        kind: "chat",
-        meta: { audience: "technical", email: "raw@example.com" },
-      },
-    })
+    const input = createChatMessageTriggerInput({}, {
+      messages: [{ parts: [{ text: "hello", type: "text" }], role: "user" }],
+      meta: { audience: "technical", email: "raw@example.com" },
+      user: { id: "chat:user-1" },
+    }).input
+    const context = createAgentInvocationContextStore(input.context)
 
     await parseAgentMessageMeta(agent, context)
 
     expect(context.get("invoker")).toEqual({
       id: "chat:user-1",
       kind: "chat",
-      meta: { audience: "technical" },
+      meta: { audience: "technical", id: "chat:user-1" },
     })
     expect(context.get("actor")).toEqual(context.get("invoker"))
   })
 
   it("retains user identity metadata when the schema strips the matching raw field", async () => {
     const agent = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
-    const context = createAgentInvocationContextStore({
-      actor: {
-        email: { address: "user@example.com", domain: "example.com" },
-        id: "chat:user@example.com",
-        kind: "chat",
-        meta: { audience: "technical", email: "user@example.com" },
-      },
-      channel: {
-        meta: { audience: "technical", email: "user@example.com" },
-        user: { email: "user@example.com" },
-      },
-      invoker: {
-        email: { address: "user@example.com", domain: "example.com" },
-        id: "chat:user@example.com",
-        kind: "chat",
-        meta: { audience: "technical", email: "user@example.com" },
-      },
-    })
+    const input = createChatMessageTriggerInput({}, {
+      messages: [{ parts: [{ text: "hello", type: "text" }], role: "user" }],
+      meta: { audience: "technical", email: "user@example.com" },
+      user: { email: "user@example.com" },
+    }).input
+    const context = createAgentInvocationContextStore(input.context)
 
     await parseAgentMessageMeta(agent, context)
 
     expect(context.get("invoker")).toEqual({
       email: { address: "user@example.com", domain: "example.com" },
-      id: "chat:user@example.com",
+      id: "user@example.com",
       kind: "chat",
       meta: { audience: "technical", email: "user@example.com" },
     })

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { defineAgent, runAgentInline } from "../src/index.ts"
+import { defineAgent, portableAgentWorkflowInput, runAgentInline } from "../src/index.ts"
 import { resolveAgentChannelChatOptions } from "../src/internal/channels.ts"
 import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
-import { parseAgentMessageMeta, withParsedAgentMessageMeta } from "../src/internal/message-meta.ts"
+import {
+  hasParsedAgentMessageMeta,
+  parseAgentMessageMeta,
+  restoreParsedAgentMessageMeta,
+  withParsedAgentMessageMeta,
+} from "../src/internal/message-meta.ts"
 
 const metaSchema = {
   "~standard": {
@@ -121,6 +126,27 @@ describe("Agent message metadata", () => {
 
     expect(parses).toBe(1)
     expect(prepared.context?.channel).toEqual({ meta: { parse: 1 } })
+  })
+
+  it("restores trusted parsed metadata after a durable handoff", async () => {
+    let parses = 0
+    const schema = {
+      "~standard": {
+        validate: () => ({ value: { parse: ++parses } }),
+        vendor: "vitehub-test",
+        version: 1,
+      },
+    } as const
+    const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: schema } })
+    const prepared = await withParsedAgentMessageMeta(agent, { context: { channel: { meta: {} } } })
+
+    expect(hasParsedAgentMessageMeta(prepared)).toBe(true)
+    const portable = await portableAgentWorkflowInput(prepared)
+    const restored = restoreParsedAgentMessageMeta(portable)
+    await parseAgentMessageMeta(agent, createAgentInvocationContextStore(restored.context))
+
+    expect(parses).toBe(1)
+    expect(restored.context?.channel).toEqual({ meta: { parse: 1 } })
   })
 
   it("does not trust a caller-provided parsed marker", async () => {

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -4,6 +4,7 @@ import { defineAgent, portableAgentWorkflowInput, runAgentInline } from "../src/
 import { resolveAgentChannelChatOptions } from "../src/internal/channels.ts"
 import { hasRuntimeType, isRuntimeRecord } from "../src/internal/runtime-type.ts"
 import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
+import { hasResolvedAgentInvokerInput, withResolvedAgentInvokerInput } from "../src/invoker.ts"
 import {
   hasParsedAgentMessageMeta,
   parsedAgentMessageMetaReceiptId,
@@ -148,6 +149,22 @@ describe("Agent message metadata", () => {
 
     expect(parses).toBe(1)
     expect(prepared.context?.channel).toEqual({ meta: { parse: 1 } })
+  })
+
+  it("preserves resolved Invoker custody while parsing metadata", async () => {
+    const resolve = vi.fn(() => ({ id: "chat:replacement", kind: "chat" }))
+    const agent = defineAgent({
+      driver: { run: () => "ok" },
+      invoker: { resolve },
+      messages: metaSettings,
+    })
+    const prepared = await withParsedAgentMessageMeta(agent, withResolvedAgentInvokerInput({
+      context: { channel: { meta: { audience: "technical" } } },
+    }, { id: "chat:user-1", kind: "chat", meta: { audience: "technical" } }))
+
+    expect(hasResolvedAgentInvokerInput(prepared)).toBe(true)
+    await runAgentInline(agent, runtime(), prepared)
+    expect(resolve).not.toHaveBeenCalled()
   })
 
   it("does not reuse another Agent Definition's metadata receipt", async () => {
@@ -325,6 +342,38 @@ describe("Agent message metadata", () => {
       id: "chat:user-1",
       kind: "chat",
       meta: { audience: "technical" },
+    })
+    expect(context.get("actor")).toEqual(context.get("invoker"))
+  })
+
+  it("retains user identity metadata when the schema strips the matching raw field", async () => {
+    const agent = defineAgent({ driver: { run: () => "ok" }, messages: metaSettings })
+    const context = createAgentInvocationContextStore({
+      actor: {
+        email: { address: "user@example.com", domain: "example.com" },
+        id: "chat:user@example.com",
+        kind: "chat",
+        meta: { audience: "technical", email: "user@example.com" },
+      },
+      channel: {
+        meta: { audience: "technical", email: "user@example.com" },
+        user: { email: "user@example.com" },
+      },
+      invoker: {
+        email: { address: "user@example.com", domain: "example.com" },
+        id: "chat:user@example.com",
+        kind: "chat",
+        meta: { audience: "technical", email: "user@example.com" },
+      },
+    })
+
+    await parseAgentMessageMeta(agent, context)
+
+    expect(context.get("invoker")).toEqual({
+      email: { address: "user@example.com", domain: "example.com" },
+      id: "chat:user@example.com",
+      kind: "chat",
+      meta: { audience: "technical", email: "user@example.com" },
     })
     expect(context.get("actor")).toEqual(context.get("invoker"))
   })

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -6,6 +6,7 @@ import { resolveAgentChannelChatOptions } from "../src/internal/channels.ts"
 import { hasRuntimeType, isRuntimeRecord } from "../src/internal/runtime-type.ts"
 import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
 import { hasResolvedAgentInvokerInput, withResolvedAgentInvokerInput } from "../src/invoker.ts"
+import { runAgentWorkflowDefinition } from "../src/runtime/workflow.ts"
 import {
   hasParsedAgentMessageMeta,
   parsedAgentMessageMetaState,
@@ -289,8 +290,16 @@ describe("Agent message metadata", () => {
         metaRevision: "current-v2",
       },
     })
-    const restored = restoreParsedAgentMessageMeta(currentAgent, portable, undefined, state)
-    await runAgentInline(currentAgent, runtime(), restored)
+    await runAgentWorkflowDefinition(currentAgent, {
+      id: "message-meta-revalidation",
+      name: "message-meta-revalidation",
+      payload: {
+        input: portable,
+        parsedMessageMeta: state,
+        resolvedInvoker: true,
+      },
+      provider: "cloudflare",
+    }, runAgentInline)
 
     expect(state).toEqual({ derivedInvoker: true, revision: "test-v1" })
     expect(observed).toEqual({

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -185,4 +185,42 @@ describe("Agent message metadata", () => {
     })
     expect(context.get("actor")).toEqual(context.get("invoker"))
   })
+
+  it("resolves programmatic Invokers from parsed metadata", async () => {
+    const resolve = vi.fn(({ defaultInvoker, input }) => {
+      expect(input.context?.invoker).toEqual({
+        id: "chat:user-1",
+        kind: "chat",
+        meta: { audience: "technical", email: "user@example.com" },
+      })
+      return defaultInvoker
+    })
+    const run = vi.fn(({ invoker }) => {
+      expect(invoker).toEqual({
+        id: "chat:user-1",
+        kind: "chat",
+        meta: { audience: "technical", email: "user@example.com" },
+      })
+      return "ok"
+    })
+    const agent = defineAgent({
+      driver: { run },
+      invoker: { resolve },
+      messages: { meta: metaSchema },
+    })
+
+    await runAgentInline(agent, runtime(), {
+      context: {
+        channel: { meta: { audience: "technical", ignored: true } },
+        invoker: {
+          id: "chat:user-1",
+          kind: "chat",
+          meta: { audience: "technical", email: "user@example.com", ignored: true },
+        },
+      },
+    })
+
+    expect(resolve).toHaveBeenCalledOnce()
+    expect(run).toHaveBeenCalledOnce()
+  })
 })

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -5,6 +5,7 @@ import { resolveAgentChannelChatOptions } from "../src/internal/channels.ts"
 import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
 import {
   hasParsedAgentMessageMeta,
+  parsedAgentMessageMetaReceiptId,
   parseAgentMessageMeta,
   restoreParsedAgentMessageMeta,
   withParsedAgentMessageMeta,
@@ -174,12 +175,38 @@ describe("Agent message metadata", () => {
     const prepared = await withParsedAgentMessageMeta(agent, { context: { channel: { meta: {} } } })
 
     expect(hasParsedAgentMessageMeta(agent, prepared)).toBe(true)
+    const receiptId = parsedAgentMessageMetaReceiptId(agent, prepared)
     const portable = await portableAgentWorkflowInput(prepared)
-    const restored = restoreParsedAgentMessageMeta(agent, portable)
+    const restored = restoreParsedAgentMessageMeta(agent, portable, undefined, receiptId)
     await parseAgentMessageMeta(agent, createAgentInvocationContextStore(restored.context))
 
     expect(parses).toBe(1)
     expect(restored.context?.channel).toEqual({ meta: { parse: 1 } })
+  })
+
+  it("revalidates durable metadata when the schema receipt is no longer current", async () => {
+    const previousAgent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: metaSchema } })
+    const prepared = await withParsedAgentMessageMeta(previousAgent, { context: { channel: { meta: { audience: "TECHNICAL" } } } })
+    const previousReceiptId = parsedAgentMessageMetaReceiptId(previousAgent, prepared)
+    const portable = await portableAgentWorkflowInput(prepared)
+    const currentAgent = defineAgent({
+      driver: { run: () => "ok" },
+      messages: {
+        meta: {
+          "~standard": {
+            validate: () => ({ value: { audience: "current" } }),
+            vendor: "vitehub-test",
+            version: 1,
+          },
+        },
+      },
+    })
+    const restored = restoreParsedAgentMessageMeta(currentAgent, portable, undefined, previousReceiptId)
+    const context = createAgentInvocationContextStore(restored.context)
+
+    await parseAgentMessageMeta(currentAgent, context)
+
+    expect(context.get("channel")).toEqual({ meta: { audience: "current" } })
   })
 
   it("transforms nonportable metadata before a durable handoff", async () => {

--- a/packages/agent/test/message-meta.test.ts
+++ b/packages/agent/test/message-meta.test.ts
@@ -190,6 +190,34 @@ describe("Agent message metadata", () => {
     expect(context.get("actor")).toEqual(context.get("invoker"))
   })
 
+  it("removes derived Invoker identity stripped by the metadata schema", async () => {
+    const agent = defineAgent({ driver: { run: () => "ok" }, messages: { meta: metaSchema } })
+    const context = createAgentInvocationContextStore({
+      actor: {
+        email: { address: "raw@example.com", domain: "example.com" },
+        id: "chat:user-1",
+        kind: "chat",
+        meta: { audience: "technical", email: "raw@example.com" },
+      },
+      channel: { meta: { audience: "technical", email: "raw@example.com" } },
+      invoker: {
+        email: { address: "raw@example.com", domain: "example.com" },
+        id: "chat:user-1",
+        kind: "chat",
+        meta: { audience: "technical", email: "raw@example.com" },
+      },
+    })
+
+    await parseAgentMessageMeta(agent, context)
+
+    expect(context.get("invoker")).toEqual({
+      id: "chat:user-1",
+      kind: "chat",
+      meta: { audience: "technical" },
+    })
+    expect(context.get("actor")).toEqual(context.get("invoker"))
+  })
+
   it("resolves programmatic Invokers from parsed metadata", async () => {
     const resolve = vi.fn(({ defaultInvoker, input }) => {
       expect(input.context?.invoker).toEqual({

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -14496,6 +14496,7 @@ describe("server helpers", () => {
       if (stalledFallback === "resolution") return await new Promise<string>(() => undefined)
       return "Queued delivery failed."
     })
+    let metadataParses = 0
     const agent = defineAgent({
       channels: {
         telegram: testTelegram(telegram, {
@@ -14511,6 +14512,18 @@ describe("server helpers", () => {
       },
       driver: { run: () => "internal output" },
       hooks: { "agent:finish": (event) => event.reply("Durable reply") },
+      messages: {
+        meta: {
+          "~standard": {
+            validate: (value) => {
+              metadataParses++
+              return { value: value as Record<string, unknown> }
+            },
+            vendor: "vitehub-test",
+            version: 1,
+          },
+        },
+      },
     })
     // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
     const handler = createChannelWebhookRouteHandler(agent as never)
@@ -14596,6 +14609,7 @@ describe("server helpers", () => {
       } else expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", "Queued delivery failed.")
       expect(await state.queueDepth(binding!.steer!.queue)).toBe(0)
       expect(await state.queueDepth(binding!.steer!.pendingQueue)).toBe(0)
+      expect(metadataParses).toBe(2)
     } finally {
       queueReplaceHead.mockRestore()
       setActiveCloudflareEnv(undefined)

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -14699,6 +14699,7 @@ describe("server helpers", () => {
       driver: { run: () => "internal output" },
       hooks: { "agent:finish": (event) => event.reply("Durable reply") },
       messages: {
+        metaRevision: "settlement-retry-v1",
         meta: {
           "~standard": {
             validate: (value) => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -3599,7 +3599,14 @@ describe("server helpers", () => {
     const run = vi.fn(() => "unreachable")
     const handler = createChannelChatRouteHandler(
       defineAgent({
-        channels: { portal: webChat() },
+        channels: {
+          portal: webChat({
+            route: {
+              admission: { authenticate: () => true },
+              input: { trust: ["meta"] },
+            },
+          }),
+        },
         driver: { run },
         messages: {
           meta: {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -3592,6 +3592,50 @@ describe("server helpers", () => {
     expect(run).toHaveBeenCalled()
   })
 
+  it("returns a client error for invalid webChat Channel metadata", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { webChat } = await import("../src/channels.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
+    const run = vi.fn(() => "unreachable")
+    const handler = createChannelChatRouteHandler(
+      defineAgent({
+        channels: { portal: webChat() },
+        driver: { run },
+        messages: {
+          meta: {
+            "~standard": {
+              validate: (value: unknown) => {
+                const meta = value as Record<string, unknown>
+                return meta.audience === "technical"
+                  ? { value: meta }
+                  : { issues: [{ message: "audience must be technical" }] }
+              },
+              vendor: "vitehub-test",
+              version: 1,
+            },
+          },
+        },
+      }) as never,
+      { channelId: "portal" },
+    )
+
+    const response = await handler(
+      new Request("https://example.com/api/_vitehub/agents/support/chat", {
+        body: JSON.stringify({
+          messages: [{ id: "user-1", parts: [{ text: "hello", type: "text" }], role: "user" }],
+          meta: { audience: "customer" },
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+      { agentName: "support" },
+    )
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toMatchObject({ error: expect.stringContaining("Invalid agent channel metadata") })
+    expect(run).not.toHaveBeenCalled()
+  })
+
   it("uses route Channel chat state for webChat approvals", async () => {
     const stateDir = await mkdtemp(join(tmpdir(), "vitehub-channel-chat-state-"))
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -857,6 +857,9 @@ describe("agent public types", () => {
     type _PublicTelegram = ChannelExports["telegram"]
     type _PublicTeams = ChannelExports["teams"]
 
+    // @ts-expect-error Message metadata schemas belong to Agent or Channel definitions, not the legacy chat() Capability.
+    chat({ meta: {} as StandardSchemaV1<unknown, Record<string, unknown>> })
+
     type ServerExports = typeof import("../src/server.ts")
     type _PublicDiscordGatewayRouteHandler = ServerExports["createDiscordGatewayRouteHandler"]
     type _PublicResumableChatRouteContext = import("../src/server.ts").AgentChannelChatRouteResumableContext

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -860,6 +860,8 @@ describe("agent public types", () => {
     // @ts-expect-error Message metadata schemas belong to Agent or Channel definitions, not the legacy chat() Capability.
     // SAFETY: the type fixture needs only the Standard Schema type to verify this rejected legacy option.
     chat({ meta: {} as StandardSchemaV1<unknown, Record<string, unknown>> })
+    // @ts-expect-error Message metadata revisions belong to Agent or Channel definitions, not the legacy chat() Capability.
+    chat({ metaRevision: "v1" })
 
     type ServerExports = typeof import("../src/server.ts")
     type _PublicDiscordGatewayRouteHandler = ServerExports["createDiscordGatewayRouteHandler"]

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -25,15 +25,6 @@ declare global {
     "support.customerScope": { customers: string[] }
     trustedScope: string
   }
-  interface ViteHubAgentChannelMeta {
-    access?: string
-    audience?: string
-    customer?: string
-  }
-  interface ViteHubAgentChannelUser {
-    id?: string
-    email?: string
-  }
 }
 
 describe("agent public types", () => {
@@ -1459,9 +1450,9 @@ describe("agent public types", () => {
         {
           id: "support-audience",
           prepare({ actor, channel, invoker }) {
-            expectTypeOf(channel?.meta?.customer).toEqualTypeOf<string | undefined>()
+            expectTypeOf(channel?.meta?.customer).toEqualTypeOf<unknown>()
             expectTypeOf(channel?.run?.origin).toEqualTypeOf<string | undefined>()
-            expectTypeOf(channel?.user?.email).toEqualTypeOf<string | undefined>()
+            expectTypeOf(channel?.user?.email).toEqualTypeOf<unknown>()
             expectTypeOf(actor.id).toEqualTypeOf<string>()
             expectTypeOf(invoker.id).toEqualTypeOf<string>()
           },


### PR DESCRIPTION
## Summary

- add Standard Schema validation and transformation for Agent and Channel message metadata
- validate metadata before Capabilities, hooks, and Drivers observe invocation context
- replace app-global Channel metadata augmentation with explicit generic chat-context access so different Agents can own different schemas

## Verification

- `vp test run test/message-meta.test.ts` (4 tests)
- `pnpm --filter @vite-hub/agent typecheck`
- `vp run -t @vite-hub/agent#build` (including publint)