### PR TITLE
feat(agent): expose invoker identity evidence

### DIFF
--- a/packages/agent/src/invoker.ts
+++ b/packages/agent/src/invoker.ts
@@ -1,9 +1,12 @@
+import { hasRuntimeType, isRuntimeRecord, runtimeType } from "./internal/runtime-type.ts"
+
 import type {
   AgentCallbackContext,
   AgentInvocationContextStore,
   AgentInvoker,
   AgentInvokerOptions,
   AgentInvokerProfile,
+  AgentInvokerResolveContext,
   AgentRunInput,
   AgentRunMetadata,
   AgentRuntimeConfig,
@@ -31,19 +34,19 @@ const profileSelectorKeys = [
 ]
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value)
+  return isRuntimeRecord(value) && !Array.isArray(value)
 }
 
 function stringValue(value: unknown): string | undefined {
-  return typeof value === "string" && value.trim() ? value.trim() : undefined
+  return hasRuntimeType(value, "string") && value.trim() ? value.trim() : undefined
 }
 
-function contextRecord(input: object | undefined): Record<string, unknown> {
+function contextRecord(input: unknown): Record<PropertyKey, unknown> {
   return isRecord(input) ? input : {}
 }
 
 function profileIdFromSelector(value: unknown): string | undefined {
-  if (typeof value === "string") return stringValue(value)
+  if (hasRuntimeType(value, "string")) return stringValue(value)
   if (isRecord(value)) return stringValue(value.id)
 }
 
@@ -75,13 +78,12 @@ export function normalizeAgentInvoker(value: unknown, label = "Agent Invoker"): 
   }
   const email = normalizeAgentEmail(value.email) || normalizeAgentEmail(meta?.email)
 
-  return {
-    ...(email ? { email } : {}),
-    id,
-    ...(kind ? { kind } : {}),
-    ...(displayLabel ? { label: displayLabel } : {}),
-    ...(meta ? { meta: { ...meta } } : {}),
-  }
+  const invoker: AgentInvoker = { id }
+  if (email) invoker.email = email
+  if (kind) invoker.kind = kind
+  if (displayLabel) invoker.label = displayLabel
+  if (meta) invoker.meta = { ...meta }
+  return invoker
 }
 
 export function agentInvokerLabel(invoker: AgentInvoker): string | undefined {
@@ -105,6 +107,7 @@ export function normalizeAgentInvokerProfiles<
       throw new Error(`[vitehub] Duplicate Agent Invoker Profile id "${normalized.id}" in one agent.`)
     }
     seen.add(normalized.id)
+    // SAFETY: TProfile extends the normalized Agent Invoker contract and normalization preserves that profile's typed metadata.
     return normalized as TProfile
   })
 }
@@ -117,16 +120,16 @@ export function normalizeAgentInvokerOptions<
   options: AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TProfile> | undefined,
 ): AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TProfile> | undefined {
   if (options === undefined) return undefined
-  if (!isRecord(options)) {
+  const runtimeOptions: unknown = options
+  if (!isRecord(runtimeOptions)) {
     throw new TypeError("[vitehub] defineAgent({ invoker }) must be an object.")
   }
-  const invokerOptions = options as AgentInvokerOptions<TRuntimeConfig, CALL_OPTIONS, TProfile>
-  if (invokerOptions.resolve !== undefined && typeof invokerOptions.resolve !== "function") {
+  if (runtimeOptions.resolve !== undefined && !hasRuntimeType(runtimeOptions.resolve, "function")) {
     throw new TypeError("[vitehub] defineAgent({ invoker.resolve }) must be a function.")
   }
   return {
-    ...invokerOptions,
-    profiles: normalizeAgentInvokerProfiles(invokerOptions.profiles),
+    ...options,
+    profiles: normalizeAgentInvokerProfiles(options.profiles),
   }
 }
 
@@ -139,7 +142,7 @@ export function createFallbackAgentInvoker(run?: AgentRunMetadata): AgentInvoker
   }
 }
 
-export function resolveInputAgentInvoker(inputContext: object | undefined): AgentInvoker | undefined {
+export function resolveInputAgentInvoker(inputContext: unknown): AgentInvoker | undefined {
   const context = contextRecord(inputContext)
   const value = context[agentInvokerContextKey] ?? context[agentActorContextKey]
   return value === undefined
@@ -171,7 +174,7 @@ export function withResolvedAgentInvokerInput<CALL_OPTIONS>(
 }
 
 export function hasResolvedAgentInvokerInput(input: AgentRunInput): boolean {
-  return (input.context as { [resolvedAgentInvokerInputKey]?: unknown } | undefined)?.[resolvedAgentInvokerInputKey] === true
+  return contextRecord(input.context)[resolvedAgentInvokerInputKey] === true
 }
 
 export function portableResolvedAgentInvokerInput<CALL_OPTIONS>(input: AgentRunInput<CALL_OPTIONS>): AgentRunInput<CALL_OPTIONS> {
@@ -181,13 +184,11 @@ export function portableResolvedAgentInvokerInput<CALL_OPTIONS>(input: AgentRunI
   const serializedMeta: unknown = invoker.meta === undefined
     ? undefined
     : JSON.parse(JSON.stringify(invoker.meta, (_key, value) => {
-        return typeof value === "bigint" || typeof value === "function" || typeof value === "symbol" ? undefined : value
+        return ["bigint", "function", "symbol"].includes(runtimeType(value)) ? undefined : value
       }))
   const portableMeta = isRecord(serializedMeta) ? serializedMeta : undefined
-  const portableInvoker = {
-    ...invoker,
-    ...(portableMeta ? { meta: portableMeta } : {}),
-  }
+  const portableInvoker: AgentInvoker = { ...invoker }
+  if (portableMeta) portableInvoker.meta = portableMeta
   return {
     ...input,
     context: {
@@ -202,7 +203,7 @@ export function restoreResolvedAgentInvokerInput<CALL_OPTIONS>(input: AgentRunIn
   return { ...input, context: { ...input.context, [resolvedAgentInvokerInputKey]: true } }
 }
 
-function selectedProfileId(inputContext: object | undefined): string | undefined {
+function selectedProfileId(inputContext: unknown): string | undefined {
   const context = contextRecord(inputContext)
   for (const key of profileSelectorKeys) {
     const id = profileIdFromSelector(context[key])
@@ -214,7 +215,7 @@ function selectAgentInvokerProfile<
   TProfile extends AgentInvokerProfile,
 >(
   profiles: readonly TProfile[],
-  inputContext: object | undefined,
+  inputContext: unknown,
 ): TProfile | undefined {
   if (!profiles.length) return undefined
 
@@ -243,31 +244,31 @@ export async function resolveAgentInvoker<
   const normalizedOptions = normalizeAgentInvokerOptions(options)
   const profiles = normalizedOptions?.profiles || []
   const requestedInvoker = resolveInputAgentInvoker(input.context)
-  if (requestedInvoker && (input.context as { [resolvedAgentInvokerInputKey]?: unknown } | undefined)?.[resolvedAgentInvokerInputKey] === true) {
+  if (requestedInvoker && hasResolvedAgentInvokerInput(input)) {
     ensureAgentInvokerContext(invocationContext, requestedInvoker)
     return requestedInvoker
   }
   const defaultInvoker = requestedInvoker || createFallbackAgentInvoker(run)
   const selectedProfile = selectAgentInvokerProfile(profiles, input.context)
   const selectedEmail = selectedProfile?.email || defaultInvoker.email
-  const selectedInvoker = selectedProfile
-    ? {
-        ...selectedProfile,
-        ...(selectedEmail ? { email: selectedEmail } : {}),
-        ...(defaultInvoker.meta || selectedProfile.meta
-          ? { meta: { ...defaultInvoker.meta, ...selectedProfile.meta } }
-          : {}),
-      }
-    : undefined
-  const resolved = await normalizedOptions?.resolve?.({
+  let selectedInvoker: AgentInvoker | undefined
+  if (selectedProfile) {
+    selectedInvoker = { ...selectedProfile }
+    if (selectedEmail) selectedInvoker.email = selectedEmail
+    if (defaultInvoker.meta || selectedProfile.meta) {
+      selectedInvoker.meta = { ...defaultInvoker.meta, ...selectedProfile.meta }
+    }
+  }
+  const resolveContext: AgentInvokerResolveContext<TRuntimeConfig, CALL_OPTIONS, TProfile> = {
     ...callbackContext,
     context: invocationContext,
     defaultInvoker,
     input,
     profiles,
-    ...(run ? { run } : {}),
-    ...(selectedProfile ? { selectedProfile } : {}),
-  })
+  }
+  if (run) resolveContext.run = run
+  if (selectedProfile) resolveContext.selectedProfile = selectedProfile
+  const resolved = await normalizedOptions?.resolve?.(resolveContext)
   if (requireMatchingRequestedInvoker && normalizedOptions?.resolve) {
     if (!requestedInvoker || resolved === undefined || resolved === null) {
       throw new Error("[vitehub] Scheduled Agent turns require matching invoker reauthorization.")

--- a/packages/agent/src/invoker.ts
+++ b/packages/agent/src/invoker.ts
@@ -84,6 +84,10 @@ export function normalizeAgentInvoker(value: unknown, label = "Agent Invoker"): 
   }
 }
 
+export function agentInvokerLabel(invoker: AgentInvoker): string | undefined {
+  return stringValue(invoker.label) || stringValue(invoker.meta?.name)
+}
+
 export function normalizeAgentInvokerProfiles<
   TProfile extends AgentInvokerProfile = AgentInvokerProfile,
 >(

--- a/packages/agent/src/invoker.ts
+++ b/packages/agent/src/invoker.ts
@@ -178,11 +178,12 @@ export function portableResolvedAgentInvokerInput<CALL_OPTIONS>(input: AgentRunI
   if (!hasResolvedAgentInvokerInput(input)) return input
   const context = contextRecord(input.context)
   const invoker = normalizeAgentInvoker(context[agentInvokerContextKey] ?? context[agentActorContextKey])
-  const portableMeta = invoker.meta === undefined
+  const serializedMeta: unknown = invoker.meta === undefined
     ? undefined
     : JSON.parse(JSON.stringify(invoker.meta, (_key, value) => {
         return typeof value === "bigint" || typeof value === "function" || typeof value === "symbol" ? undefined : value
-      })) as Record<string, unknown>
+      }))
+  const portableMeta = isRecord(serializedMeta) ? serializedMeta : undefined
   const portableInvoker = {
     ...invoker,
     ...(portableMeta ? { meta: portableMeta } : {}),

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4443,13 +4443,15 @@ function withAgentInvokerRunAnnotation(
 ): AgentChatMessageTriggerInput {
   const triggeredBy = agentInvokerLabel(invoker)
   if (!triggeredBy || !input.run) return input
+  const annotations = { ...input.run.annotations }
+  delete annotations.triggeredBy
   return {
     ...input,
     run: {
       ...input.run,
       annotations: {
-        ...input.run.annotations,
         triggeredBy,
+        ...annotations,
       },
     },
   }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4441,16 +4441,16 @@ function withAgentInvokerRunAnnotation(
   input: AgentChatMessageTriggerInput,
   invoker: AgentInvoker,
 ): AgentChatMessageTriggerInput {
-  const triggeredBy = agentInvokerLabel(invoker)
-  if (!triggeredBy || !input.run) return input
+  if (!input.run) return input
   const annotations = { ...input.run.annotations }
   delete annotations.triggeredBy
+  const triggeredBy = agentInvokerLabel(invoker)
   return {
     ...input,
     run: {
       ...input.run,
       annotations: {
-        triggeredBy,
+        ...(triggeredBy ? { triggeredBy } : {}),
         ...annotations,
       },
     },

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -34,7 +34,7 @@ import { agentChannelHistoryHeader } from "../internal/channel-history.ts"
 import { agentChannelSyncProviderHeader } from "../internal/channel-sync.ts"
 import { agentOutputEventObserverContextKey } from "../internal/agent-output-events.ts"
 import { attachmentStringBytes, isAttachmentData } from "../messages.ts"
-import { hasResolvedAgentInvokerInput, resolveInputAgentInvoker, resolveAgentInvoker, withResolvedAgentInvokerInput } from "../invoker.ts"
+import { agentInvokerLabel, hasResolvedAgentInvokerInput, resolveInputAgentInvoker, resolveAgentInvoker, withResolvedAgentInvokerInput } from "../invoker.ts"
 import { createAgentRuntimeContext } from "../runtime/context.ts"
 import { createAgentUIMessageStreamResponse } from "../stream-output.ts"
 import {
@@ -4437,6 +4437,24 @@ function withChatFinishExtension<CALL_OPTIONS>(input: AgentRunInput<CALL_OPTIONS
   }
 }
 
+function withAgentInvokerRunAnnotation(
+  input: AgentChatMessageTriggerInput,
+  invoker: AgentInvoker,
+): AgentChatMessageTriggerInput {
+  const triggeredBy = agentInvokerLabel(invoker)
+  if (!triggeredBy || !input.run) return input
+  return {
+    ...input,
+    run: {
+      ...input.run,
+      annotations: {
+        ...input.run.annotations,
+        triggeredBy,
+      },
+    },
+  }
+}
+
 async function isChatMessageAuthorized(
   agent: AgentInput<ViteAgentRouteRuntimeContext>,
   context: ViteAgentRouteRuntimeContext,
@@ -4551,6 +4569,7 @@ async function handleChatSdkMessage(
       await recordChannelDeliveryEvidence(delivery, { type: "rejected" })
       return
     }
+    input = withAgentInvokerRunAnnotation(input, invoker)
 
     const manualDelivery = options?.delivery === "manual"
     const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
@@ -6482,12 +6501,12 @@ export function createChannelChatRouteHandler(
         invokerInput,
         triggerInput.run,
       )
-      triggerInput = {
+      triggerInput = withAgentInvokerRunAnnotation({
         // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
         ...(withResolvedAgentInvokerInput(triggerInput as never, invoker) as AgentChatMessageTriggerInput),
         // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
         invoker,
-      }
+      }, invoker)
       const sessionId = triggerInput.run?.threadId ?? triggerInput.run?.runId
       let selectedSessionId = resolveChatSessionId(triggerInput.messages, chatOptions.sessions, triggerInput.session)
       const registration = {

--- a/packages/agent/src/trace.ts
+++ b/packages/agent/src/trace.ts
@@ -2,6 +2,7 @@ import { hasRuntimeType } from "./internal/runtime-type.ts"
 import { emitTraceEvent } from "@vite-hub/runtime"
 
 import { agentErrorDetails } from "./agent-error.ts"
+import { agentInvokerLabel } from "./invoker.ts"
 import type { AgentActivity, StreamEvent } from "./messages.ts"
 import type {
   AgentInvocationContextStore,
@@ -41,6 +42,7 @@ function invocationAttributes(
   return {
     "agent.invoker.id": context.invoker.id,
     "agent.invoker.kind": context.invoker.kind,
+    "agent.invoker.label": agentInvokerLabel(context.invoker),
     "agent.run.id": context.run?.runId,
     "channel.delivery.id": context.runtime.channelDelivery?.id,
     "channel.delivery.provider": context.runtime.channelDelivery?.provider,

--- a/packages/agent/test/invoker.test.ts
+++ b/packages/agent/test/invoker.test.ts
@@ -65,6 +65,6 @@ describe("Agent Invoker", () => {
       actor: { id: "user-1", kind: "user", meta: { tenant: "acme" } },
       invoker: { id: "user-1", kind: "user", meta: { tenant: "acme" } },
     })
-    expect((portable.context as { invoker: { meta: Record<string, unknown> } }).invoker.meta.loadTenant).toBeUndefined()
+    expect(portable.context?.invoker?.meta?.loadTenant).toBeUndefined()
   })
 })

--- a/packages/agent/test/invoker.test.ts
+++ b/packages/agent/test/invoker.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, it } from "vitest"
 
-import { normalizeAgentInvoker, portableResolvedAgentInvokerInput, withResolvedAgentInvokerInput } from "../src/invoker.ts"
+import { agentInvokerLabel, normalizeAgentInvoker, portableResolvedAgentInvokerInput, withResolvedAgentInvokerInput } from "../src/invoker.ts"
 
 describe("Agent Invoker", () => {
+  it("resolves a human-readable label from the explicit label or metadata name", () => {
+    expect(agentInvokerLabel({ id: "user-1", label: "  Maxi  ", meta: { name: "Ignored" } })).toBe("Maxi")
+    expect(agentInvokerLabel({ id: "user-1", meta: { name: "  Metadata Maxi  " } })).toBe("Metadata Maxi")
+    expect(agentInvokerLabel({ id: "user-1", meta: { name: 123 } })).toBeUndefined()
+  })
+
   it("normalizes Agent Actor email without changing invoker metadata", () => {
     const meta = {
       email: "metadata@example.net",

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2910,6 +2910,43 @@ describe("server helpers", () => {
     expect(Object.keys(annotations)[0]).toBe("triggeredBy")
   })
 
+  it("removes caller-supplied invoker identity evidence when the invoker has no label", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
+    let annotations: Record<string, boolean | number | string | null> | undefined
+    const agent = defineAgent({
+      capabilities: [defineChatCapability()],
+      driver: {
+        run({ run }) {
+          annotations = run.annotations
+          return "ok"
+        },
+      },
+      invoker: { resolve: () => ({ id: "customer:acme", kind: "customer" }) },
+    })
+    // SAFETY: This synthetic test input exercises a hook that does not inspect the omitted host-only context.
+    const handler = createChannelChatRouteHandler(agent as never, {
+      mapInput: () => ({ run: { annotations: { source: "portal", triggeredBy: "spoofed" } } }),
+    })
+
+    const response = await handler(
+      new Request("https://example.com/api/_vitehub/agents/support/chat", {
+        body: JSON.stringify({
+          id: "portal-thread",
+          messages: [{ id: "user-1", parts: [{ text: "hello", type: "text" }], role: "user" }],
+        }),
+        headers: { "content-type": "application/json" },
+        method: "POST",
+      }),
+      { agentName: "support" },
+    )
+
+    expect(response.status).toBe(200)
+    await response.text()
+    expect(annotations).toEqual({ source: "portal" })
+  })
+
   it("consumes only approval responses issued by the server session", async () => {
     const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-approval-"))
     const agentModule = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2919,7 +2919,7 @@ describe("server helpers", () => {
       capabilities: [defineChatCapability()],
       driver: {
         run({ run }) {
-          annotations = run.annotations
+          annotations = run?.annotations
           return "ok"
         },
       },

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2850,7 +2850,10 @@ describe("server helpers", () => {
       },
     })
     // SAFETY: This synthetic test input exercises a hook that does not inspect the omitted host-only context.
-    const handler = createChannelChatRouteHandler(agent as never)
+    const callerAnnotations = Object.fromEntries(Array.from({ length: 32 }, (_, index) => [`caller.${index}`, index]))
+    const handler = createChannelChatRouteHandler(agent as never, {
+      mapInput: () => ({ run: { annotations: callerAnnotations } }),
+    })
 
     const response = await handler(
       new Request("https://example.com/api/_vitehub/agents/support/chat", {
@@ -2902,11 +2905,9 @@ describe("server helpers", () => {
         }),
       }),
     )
-    expect(run).toHaveBeenCalledWith(expect.objectContaining({
-      run: expect.objectContaining({
-        annotations: { triggeredBy: "Acme Customer" },
-      }),
-    }))
+    const annotations = run.mock.calls[0]?.[0].run.annotations
+    expect(annotations).toEqual({ triggeredBy: "Acme Customer", ...callerAnnotations })
+    expect(Object.keys(annotations)[0]).toBe("triggeredBy")
   })
 
   it("consumes only approval responses issued by the server session", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2849,8 +2849,8 @@ describe("server helpers", () => {
         run,
       },
     })
-    // SAFETY: This synthetic test input exercises a hook that does not inspect the omitted host-only context.
     const callerAnnotations = Object.fromEntries(Array.from({ length: 32 }, (_, index) => [`caller.${index}`, index]))
+    // SAFETY: This synthetic test input exercises a hook that does not inspect the omitted host-only context.
     const handler = createChannelChatRouteHandler(agent as never, {
       mapInput: () => ({ run: { annotations: callerAnnotations } }),
     })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2831,6 +2831,7 @@ describe("server helpers", () => {
     const resolveInvoker = vi.fn(({ defaultInvoker, request }) => ({
       id: `customer:${request.headers.get("x-customer")}`,
       kind: "customer",
+      label: "Acme Customer",
       meta: {
         fallback: defaultInvoker.id,
         user: request.headers.get("x-user"),
@@ -2901,6 +2902,11 @@ describe("server helpers", () => {
         }),
       }),
     )
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({
+      run: expect.objectContaining({
+        annotations: { triggeredBy: "Acme Customer" },
+      }),
+    }))
   })
 
   it("consumes only approval responses issued by the server session", async () => {
@@ -5095,13 +5101,20 @@ describe("server helpers", () => {
     const { telegram, webChat } = await import("../src/channels.ts")
     const { createChannelChatRouteHandler, createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter()
+    const run = vi.fn(() => ({ text: "final answer" }))
     const agent = defineAgent({
       channels: {
         web: webChat,
         // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
         telegram: testTelegram(telegram, { adapter: () => adapter as never }),
       },
-      driver: { run: () => ({ text: "final answer" }) },
+      driver: { run },
+      invoker: {
+        resolve: ({ defaultInvoker }) => ({
+          ...defaultInvoker,
+          meta: { name: "Maxi" },
+        }),
+      },
     })
     // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
     const handler = createChannelWebhookRouteHandler(agent as never)
@@ -5128,6 +5141,11 @@ describe("server helpers", () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ ok: true })
     await Promise.all(waitUntilTasks)
+    expect(run).toHaveBeenCalledWith(expect.objectContaining({
+      run: expect.objectContaining({
+        annotations: { triggeredBy: "Maxi" },
+      }),
+    }))
     expect(agent.chat).toMatchObject({ stream: false })
     expect(adapter.startTyping).not.toHaveBeenCalled()
     expect(adapter.postMessage).toHaveBeenCalledOnce()

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -955,7 +955,7 @@ describe("agent message protocol", () => {
       ],
       driver: { run: () => "ok" },
       invoker: {
-        resolve: () => ({ id: "tenant-1", kind: "tenant" }),
+        resolve: () => ({ id: "tenant-1", kind: "tenant", meta: { name: "Acme Tenant" } }),
       },
     })
 
@@ -972,6 +972,7 @@ describe("agent message protocol", () => {
     expect(traceLog.entries()[0]!.attributes).toMatchObject({
       "agent.invoker.id": "tenant-1",
       "agent.invoker.kind": "tenant",
+      "agent.invoker.label": "Acme Tenant",
       "error.message": "capability setup failed",
     })
   })


### PR DESCRIPTION
## Summary

- derive one normalized human-readable Agent Invoker label from `label` or `meta.name`
- annotate HTTP and adapter-backed Channel runs with `triggeredBy` while preserving existing annotations
- include the same label in Agent invocation Trace Events

## Verification

- `corepack pnpm exec vp test -- --run test/invoker.test.ts test/runtime.test.ts test/providers.test.ts -t "resolves a human-readable label|preserves resolved invokers in setup failure Trace Events|serves AI SDK UI message chat requests|defaults adapter-backed Channels to final-only delivery"` (4 passed)
- `corepack pnpm --filter @vite-hub/agent typecheck`
- `corepack pnpm --filter @vite-hub/agent build`
- broader three-file run: 720 passed; two unrelated queued-webhook tests timed out after the install skipped the native SQLite build script