### PR TITLE
feat(workspace): honor host inspection concurrency

### DIFF
--- a/packages/box/src/index.ts
+++ b/packages/box/src/index.ts
@@ -189,6 +189,7 @@ export interface BoxSession {
   readonly executionAuthority: ExecutionAuthority;
   readonly files: BoxFiles;
   readonly id: string;
+  readonly inspectionConcurrency?: number;
   readonly ports?: BoxPorts;
   readonly spawn?: (
     command: string,

--- a/packages/box/src/index.ts
+++ b/packages/box/src/index.ts
@@ -296,7 +296,7 @@ const reservedRuntimeNames = new Set([
   "vercel",
 ]);
 
-async function resolveBoxRuntime(value: unknown): Promise<BoxRuntime> {
+async function resolveBoxRuntime(value: BoxRuntimeDefinition): Promise<BoxRuntime> {
   if (isBoxRuntime(value)) {
     if (reservedRuntimeNames.has(value.name) && !isBuiltInBoxRuntime(value)) {
       throw new Error(`[vitehub] Custom Box runtimes cannot use the reserved name "${value.name}". Select the built-in runtime by value instead.`);
@@ -326,30 +326,30 @@ async function resolveBoxRuntime(value: unknown): Promise<BoxRuntime> {
     throw new TypeError("[vitehub] Box requires an explicit built-in runtime value or custom runtime object.");
   }
 
-  const { kind, ...options } = value as Record<string, unknown>;
+  const { kind } = value;
   if (kind === "ascii") {
     const { createAsciiRuntime } = await import("./ascii.ts");
-    return createAsciiRuntime(options as AsciiBoxOptions);
+    return createAsciiRuntime(value);
   }
   if (kind === "crabbox") {
     const { createCrabboxRuntime } = await import("./internal/crabbox.ts");
-    return createCrabboxRuntime(options as CrabboxOptions);
+    return createCrabboxRuntime(value);
   }
   if (kind === "trusted-host") {
     const { createTrustedHostRuntime } = await import("./internal/trusted-host.ts");
-    return createTrustedHostRuntime(options as TrustedHostOptions);
+    return createTrustedHostRuntime(value);
   }
   if (kind === "cloudflare") {
     const { createCloudflareRuntime } = await import("./cloudflare.ts");
-    return createCloudflareRuntime(options as unknown as CloudflareBoxOptions);
+    return createCloudflareRuntime(value);
   }
   if (kind === "cloudflare-computer") {
     const { createCloudflareComputerRuntime } = await import("./cloudflare-computer.ts");
-    return createCloudflareComputerRuntime(options as unknown as CloudflareComputerBoxOptions);
+    return createCloudflareComputerRuntime(value);
   }
   if (kind === "vercel") {
     const { createVercelRuntime } = await import("./vercel.ts");
-    return createVercelRuntime(options as VercelBoxOptions);
+    return createVercelRuntime(value);
   }
   throw new Error(`[vitehub] Unknown Box runtime kind "${String(kind)}". Expected "ascii", "crabbox", "trusted-host", "cloudflare", "cloudflare-computer", or "vercel".`);
 }

--- a/packages/box/src/index.ts
+++ b/packages/box/src/index.ts
@@ -296,7 +296,7 @@ const reservedRuntimeNames = new Set([
   "vercel",
 ]);
 
-async function resolveBoxRuntime(value: BoxRuntimeDefinition): Promise<BoxRuntime> {
+async function resolveBoxRuntime(value: unknown): Promise<BoxRuntime> {
   if (isBoxRuntime(value)) {
     if (reservedRuntimeNames.has(value.name) && !isBuiltInBoxRuntime(value)) {
       throw new Error(`[vitehub] Custom Box runtimes cannot use the reserved name "${value.name}". Select the built-in runtime by value instead.`);
@@ -326,30 +326,30 @@ async function resolveBoxRuntime(value: BoxRuntimeDefinition): Promise<BoxRuntim
     throw new TypeError("[vitehub] Box requires an explicit built-in runtime value or custom runtime object.");
   }
 
-  const { kind } = value;
+  const { kind, ...options } = value as Record<string, unknown>;
   if (kind === "ascii") {
     const { createAsciiRuntime } = await import("./ascii.ts");
-    return createAsciiRuntime(value);
+    return createAsciiRuntime(options as AsciiBoxOptions);
   }
   if (kind === "crabbox") {
     const { createCrabboxRuntime } = await import("./internal/crabbox.ts");
-    return createCrabboxRuntime(value);
+    return createCrabboxRuntime(options as CrabboxOptions);
   }
   if (kind === "trusted-host") {
     const { createTrustedHostRuntime } = await import("./internal/trusted-host.ts");
-    return createTrustedHostRuntime(value);
+    return createTrustedHostRuntime(options as TrustedHostOptions);
   }
   if (kind === "cloudflare") {
     const { createCloudflareRuntime } = await import("./cloudflare.ts");
-    return createCloudflareRuntime(value);
+    return createCloudflareRuntime(options as unknown as CloudflareBoxOptions);
   }
   if (kind === "cloudflare-computer") {
     const { createCloudflareComputerRuntime } = await import("./cloudflare-computer.ts");
-    return createCloudflareComputerRuntime(value);
+    return createCloudflareComputerRuntime(options as unknown as CloudflareComputerBoxOptions);
   }
   if (kind === "vercel") {
     const { createVercelRuntime } = await import("./vercel.ts");
-    return createVercelRuntime(value);
+    return createVercelRuntime(options as VercelBoxOptions);
   }
   throw new Error(`[vitehub] Unknown Box runtime kind "${String(kind)}". Expected "ascii", "crabbox", "trusted-host", "cloudflare", "cloudflare-computer", or "vercel".`);
 }

--- a/packages/box/src/internal/crabbox.ts
+++ b/packages/box/src/internal/crabbox.ts
@@ -694,6 +694,7 @@ function createCrabboxSession(state: CrabboxSessionState, sessionId: string | un
     defaultWorkingDirectory: state.root,
     description: "Crabbox session.",
     id: sessionId || randomUUID(),
+    inspectionConcurrency: 1,
     ports: [0],
     async destroy() {
       if (destroyed) return;

--- a/packages/box/src/internal/crabbox.ts
+++ b/packages/box/src/internal/crabbox.ts
@@ -913,9 +913,8 @@ async function warmup(options: CrabboxSessionOptions, abortSignal: AbortSignal |
   if (result.exitCode !== 0) throw crabboxError("warm Crabbox", result)
   const timing = result.stderr.trim().split(/\r?\n/).reverse().find(line => line.trim().startsWith("{"))
   try {
-    const parsed: unknown = timing && JSON.parse(timing)
-    const leaseId = parsed === Object(parsed) ? Reflect.get(Object(parsed), "leaseId") : undefined
-    if (leaseId && Object.prototype.toString.call(leaseId) === "[object String]") return String(leaseId)
+    const leaseId = timing && (JSON.parse(timing) as { leaseId?: unknown }).leaseId
+    if (typeof leaseId === "string" && leaseId) return leaseId
   }
   catch {}
   throw new Error("[vitehub] Crabbox warmup did not return a lease id.")

--- a/packages/box/src/internal/crabbox.ts
+++ b/packages/box/src/internal/crabbox.ts
@@ -913,8 +913,9 @@ async function warmup(options: CrabboxSessionOptions, abortSignal: AbortSignal |
   if (result.exitCode !== 0) throw crabboxError("warm Crabbox", result)
   const timing = result.stderr.trim().split(/\r?\n/).reverse().find(line => line.trim().startsWith("{"))
   try {
-    const leaseId = timing && (JSON.parse(timing) as { leaseId?: unknown }).leaseId
-    if (typeof leaseId === "string" && leaseId) return leaseId
+    const parsed: unknown = timing && JSON.parse(timing)
+    const leaseId = parsed === Object(parsed) ? Reflect.get(Object(parsed), "leaseId") : undefined
+    if (leaseId && Object.prototype.toString.call(leaseId) === "[object String]") return String(leaseId)
   }
   catch {}
   throw new Error("[vitehub] Crabbox warmup did not return a lease id.")

--- a/packages/box/src/internal/session.ts
+++ b/packages/box/src/internal/session.ts
@@ -20,6 +20,7 @@ export interface RuntimeSession {
   readonly defaultWorkingDirectory: string;
   readonly description?: string;
   readonly id: string;
+  readonly inspectionConcurrency?: number;
   readonly ports?: readonly number[];
   destroy?(): Promise<void>;
   existsFile(options: { abortSignal?: AbortSignal; path: string }): Promise<boolean>;
@@ -222,6 +223,9 @@ export function createBoxSession(
       },
     },
     id: runtime.id,
+    ...(runtime.inspectionConcurrency === undefined
+      ? {}
+      : { inspectionConcurrency: runtime.inspectionConcurrency }),
     ...(runtime.getPortUrl
       ? {
           ports: {

--- a/packages/box/test/crabbox.test.ts
+++ b/packages/box/test/crabbox.test.ts
@@ -137,6 +137,7 @@ describe("createCrabboxRuntime", () => {
         runtime: createCrabboxRuntime({ profile: "babysitter" }),
       }, {})
       const session = await box.open()
+      expect(session.inspectionConcurrency).toBe(1)
       const sessionRoot = dirname(session.cwd)
       await expect(session.exec("sh", ["-c", "mkdir read-only && touch read-only/file && chmod 400 read-only/file && chmod 500 read-only"], {
         cwd: session.cwd,

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -171,6 +171,7 @@ export interface WorkspaceSessionHostFiles {
 
 export interface WorkspaceSessionHost {
   readonly executionAuthority: ExecutionAuthority
+  readonly inspectionConcurrency?: number
   detachAbortSignal?(): void
   files: WorkspaceSessionHostFiles
   exec(

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -82,8 +82,11 @@ function resolveHostInspectionLimiter(host: WorkspaceSessionHost) {
   return run
 }
 
-async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: readonly T[], visit: (value: T) => Promise<U>, signal?: AbortSignal) {
-  const inspect = resolveHostInspectionLimiter(host)
+function inspectHost<T>(host: WorkspaceSessionHost, inspect: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+  return resolveHostInspectionLimiter(host)(inspect, signal)
+}
+
+async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: readonly T[], visit: (value: T) => Promise<U>, _signal?: AbortSignal) {
   const results = new Array<U>(values.length)
   let next = 0
   let failed = false
@@ -95,7 +98,7 @@ async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: read
         const index = next++
         if (index >= values.length) return
         try {
-          results[index] = await inspect(async () => failed ? undefined as U : await visit(values[index]!), signal)
+          results[index] = failed ? undefined as U : await visit(values[index]!)
         }
         catch (error) {
           if (!failed) failure = error
@@ -203,7 +206,7 @@ function isSafeHostSymlink(root: string, path: string, target: string) {
 
 async function isHostPath(host: WorkspaceSessionHost, path: string, flag: "-d" | "-L", abortSignal?: AbortSignal) {
   abortSignal?.throwIfAborted()
-  return (await host.exec("test", [flag, path], { signal: abortSignal })).code === 0
+  return (await inspectHost(host, async () => await host.exec("test", [flag, path], { signal: abortSignal }), abortSignal)).code === 0
 }
 
 async function assertHostWorkspaceRoot(host: WorkspaceSessionHost, root: string, abortSignal?: AbortSignal) {
@@ -215,7 +218,8 @@ async function ensureHostWorkspaceRoot(host: WorkspaceSessionHost, root: string,
   const symlink = await isHostPath(host, root, "-L", abortSignal)
   const directory = !symlink && await isHostPath(host, root, "-d", abortSignal)
   if (directory) return false
-  if (symlink || await host.files.exists(root, { signal: abortSignal })) await host.files.remove(root, { recursive: false, signal: abortSignal })
+  if (symlink || await inspectHost(host, async () => await host.files.exists(root, { signal: abortSignal }), abortSignal))
+    await host.files.remove(root, { recursive: false, signal: abortSignal })
   await host.files.mkdir(root, { recursive: true, signal: abortSignal })
   await assertHostWorkspaceRoot(host, root, abortSignal)
   return true
@@ -269,7 +273,7 @@ async function ensureHostParent(host: WorkspaceSessionHost, path: string, abortS
 }
 
 async function readHostSymlinkTarget(host: WorkspaceSessionHost, root: string, path: string, abortSignal?: AbortSignal): Promise<string> {
-  const result = await host.exec("readlink", [fromHostPath(root, path)], { cwd: root, signal: abortSignal })
+  const result = await inspectHost(host, async () => await host.exec("readlink", [fromHostPath(root, path)], { cwd: root, signal: abortSignal }), abortSignal)
   if (result.code !== 0)
     throw workspaceError(`[vitehub] Failed to read workspace symlink: ${path}.`, {
       cause: new Error(result.stderr || "readlink failed"),
@@ -286,8 +290,8 @@ async function writeHostSymlink(host: WorkspaceSessionHost, root: string, path: 
 
 async function readHostFile(host: WorkspaceSessionHost, root: string, path: string, abortSignal?: AbortSignal): Promise<WorkspaceFile | undefined> {
   await assertHostWorkspaceRoot(host, root, abortSignal)
-  if (!await host.files.exists(path, { signal: abortSignal })) return undefined
-  const content = await host.files.read(path, { signal: abortSignal })
+  if (!await inspectHost(host, async () => await host.files.exists(path, { signal: abortSignal }), abortSignal)) return undefined
+  const content = await inspectHost(host, async () => await host.files.read(path, { signal: abortSignal }), abortSignal)
   return content ? { content, path: fromHostPath(root, path) } : undefined
 }
 
@@ -302,7 +306,7 @@ async function removeHostGitMetadata(host: WorkspaceSessionHost, root: string, s
   for (let index = 0; index < directories.length; index++) {
     signal?.throwIfAborted()
     const directory = directories[index]!
-    for (const entry of await host.files.list(toHostPath(root, directory), { signal })) {
+    for (const entry of await inspectHost(host, async () => await host.files.list(toHostPath(root, directory), { signal }), signal)) {
       const path = fromHostPath(root, entry.path)
       const gitRoot = gitMetadataRoot(path)
       if (gitRoot) {
@@ -330,7 +334,7 @@ async function listHostEntries(
   const workspacePath = normalizeSafeWorkspacePath(path, { allowEmpty: true, allowReserved: true })
   if (isExcludedWorkspacePath(workspacePath, excluded)) return []
   const hostExcluded = excluded.map(item => toHostPath(root, normalizeWorkspacePath(item)))
-  const listed = await host.files.list(toHostPath(root, workspacePath), { exclude: hostExcluded, recursive, signal: abortSignal })
+  const listed = await inspectHost(host, async () => await host.files.list(toHostPath(root, workspacePath), { exclude: hostExcluded, recursive, signal: abortSignal }), abortSignal)
   const entries = listed
     .map(entry => ({ executable: entry.executable, workspaceEntry: toWorkspaceEntry(root, entry) }))
     .filter(({ workspaceEntry }) => !isExcludedWorkspacePath(workspaceEntry.path, excluded) && (!include || include(workspaceEntry)))
@@ -338,7 +342,7 @@ async function listHostEntries(
     abortSignal?.throwIfAborted()
     if (workspaceEntry.type !== "file" || isGitSymlinkEntry(workspaceEntry)) return workspaceEntry
     if (executable !== undefined) return workspaceEntry
-    const probe = await host.exec("test", ["-x", workspaceEntry.path], { cwd: root, signal: abortSignal })
+    const probe = await inspectHost(host, async () => await host.exec("test", ["-x", workspaceEntry.path], { cwd: root, signal: abortSignal }), abortSignal)
     return probe.code === 0
       ? { ...workspaceEntry, metadata: { ...workspaceEntry.metadata, gitMode: "100755" } }
       : workspaceEntry
@@ -362,7 +366,7 @@ async function captureHostState(host: WorkspaceSessionHost, root: string, name?:
   abortSignal?.throwIfAborted()
   if (await isHostPath(host, root, "-L", abortSignal))
     throw workspaceError(`[vitehub] Workspace host root must be a directory: ${root}.`)
-  if (!await host.files.exists(root, { signal: abortSignal })) {
+  if (!await inspectHost(host, async () => await host.files.exists(root, { signal: abortSignal }), abortSignal)) {
     return { contents: new Map<string, Uint8Array | string>(), snapshot: await createSnapshotFromEntries([], name) }
   }
   const entries = await listHostEntries(host, root, "", true, undefined, false, [], abortSignal)
@@ -376,7 +380,7 @@ async function captureHostEntriesState(host: WorkspaceSessionHost, root: string,
     if (entry.type !== "file") return entry
     const content = isGitSymlinkEntry(entry)
       ? await readHostSymlinkTarget(host, root, toHostPath(root, entry.path), abortSignal)
-      : await host.files.read(toHostPath(root, entry.path), { signal: abortSignal })
+      : await inspectHost(host, async () => await host.files.read(toHostPath(root, entry.path), { signal: abortSignal }), abortSignal)
     if (content === null) throw workspaceError(`[vitehub] Workspace host file disappeared while snapshotting: ${entry.path}.`)
     contents.set(entry.path, content)
     return {
@@ -396,7 +400,7 @@ async function captureExcludedHostState(host: WorkspaceSessionHost, root: string
   abortSignal?.throwIfAborted()
   if (await isHostPath(host, root, "-L", abortSignal))
     throw workspaceError(`[vitehub] Workspace host root must be a directory: ${root}.`)
-  if (!await host.files.exists(root, { signal: abortSignal })) return await captureHostEntriesState(host, root, [], "host-excluded", abortSignal)
+  if (!await inspectHost(host, async () => await host.files.exists(root, { signal: abortSignal }), abortSignal)) return await captureHostEntriesState(host, root, [], "host-excluded", abortSignal)
   const entries = await listHostEntries(host, root, "", true, entry => isInsideExcludedWriteBackPath(entry.path, excluded), true, [], abortSignal)
   return await captureHostEntriesState(host, root, entries, "host-excluded", abortSignal)
 }
@@ -507,7 +511,7 @@ async function restoreAttachedHost(
 
 async function resetHostWorkspaceRoot(host: WorkspaceSessionHost, root: string, abortSignal?: AbortSignal) {
   if (await ensureHostWorkspaceRoot(host, root, abortSignal)) return
-  for (const entry of await host.files.list(root, { signal: abortSignal })) {
+  for (const entry of await inspectHost(host, async () => await host.files.list(root, { signal: abortSignal }), abortSignal)) {
     abortSignal?.throwIfAborted()
     await removeHostPath(host, root, entry.path, true, abortSignal)
   }
@@ -585,7 +589,7 @@ async function extractRevisionArchive(
   await host.files.write(archive, materialization.archive, { signal })
   await host.files.mkdir(staging, { recursive: true, signal })
   try {
-    const listed = await host.exec("tar", ["-tzf", archive], { signal })
+    const listed = await inspectHost(host, async () => await host.exec("tar", ["-tzf", archive], { signal }), signal)
     if (listed.code !== 0) {
       throw workspaceError(`[vitehub] Failed to inspect Workspace revision ${materialization.revision}: ${listed.stderr || "tar failed"}`)
     }
@@ -600,7 +604,7 @@ async function extractRevisionArchive(
     if (extracted.code !== 0) {
       throw workspaceError(`[vitehub] Failed to extract Workspace revision ${materialization.revision}: ${extracted.stderr || "tar failed"}`)
     }
-    const roots = (await host.files.list(staging, { signal })).filter(entry => entry.type === "directory")
+    const roots = (await inspectHost(host, async () => await host.files.list(staging, { signal }), signal)).filter(entry => entry.type === "directory")
     if (roots.length !== 1) {
       throw workspaceError(`[vitehub] Workspace revision archive must contain one repository root.`)
     }
@@ -609,10 +613,10 @@ async function extractRevisionArchive(
     let validSource = true
     for (const component of archiveRoot.split("/").filter(Boolean)) {
       source = posix.join(source, component)
-      if ((await host.exec("test", ["-L", source], { signal })).code === 0) {
+      if ((await inspectHost(host, async () => await host.exec("test", ["-L", source], { signal }), signal)).code === 0) {
         throw workspaceError(`[vitehub] Workspace revision archive root must not contain symlinks: ${materialization.root}.`)
       }
-      if ((await host.exec("test", ["-d", source], { signal })).code !== 0) {
+      if ((await inspectHost(host, async () => await host.exec("test", ["-d", source], { signal }), signal)).code !== 0) {
         validSource = false
         break
       }
@@ -631,7 +635,7 @@ async function extractRevisionArchive(
     else {
       for (const path of paths) {
         const selected = posix.join(source, path)
-        if (!await host.files.exists(selected, { signal })) continue
+        if (!await inspectHost(host, async () => await host.files.exists(selected, { signal }), signal)) continue
         const destination = toHostPath(root, posix.dirname(path) === "." ? "" : posix.dirname(path))
         await host.files.mkdir(destination, { recursive: true, signal })
         const copied = await host.exec("cp", ["-a", selected, destination], { signal })
@@ -963,7 +967,7 @@ export async function createHostedWorkspaceSession(
       const hits: WorkspaceSearchHit[] = []
       for (const entry of filterSessionEntries(await listHostEntries(host, root, "", true), sessionPaths).filter(item => item.type === "file")) {
         if (scopedSearchRoots.length && !scopedSearchRoots.some(path => entry.path === path || entry.path.startsWith(`${path}/`))) continue
-        const content = await host.files.read(toHostPath(root, entry.path))
+        const content = await inspectHost(host, async () => await host.files.read(toHostPath(root, entry.path)))
         if (content === null) continue
         const text = new TextDecoder().decode(content)
         hits.push(...searchText(entry.path, text, { ...scoped, limit: limit - hits.length }))

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -82,15 +82,21 @@ function resolveHostInspectionLimiter(host: WorkspaceSessionHost) {
   return run
 }
 
-function inspectHost<T>(host: WorkspaceSessionHost, inspect: () => Promise<T>, signal?: AbortSignal): Promise<T> {
-  return resolveHostInspectionLimiter(host)(inspect, signal)
+function inspectHost<T>(host: WorkspaceSessionHost, inspect: () => Promise<T>, signal?: AbortSignal, assertActive?: () => void): Promise<T> {
+  return resolveHostInspectionLimiter(host)(async () => {
+    assertActive?.()
+    return await inspect()
+  }, signal)
 }
 
-async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: readonly T[], visit: (value: T) => Promise<U>, _signal?: AbortSignal) {
+async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: readonly T[], visit: (value: T, assertActive: () => void) => Promise<U>, _signal?: AbortSignal) {
   const results = new Array<U>(values.length)
   let next = 0
   let failed = false
   let failure: unknown
+  const assertActive = () => {
+    if (failed) throw failure
+  }
   const workers = Array.from(
     { length: Math.min(values.length, resolveHostInspectionConcurrency(host)) },
     async () => {
@@ -98,7 +104,7 @@ async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: read
         const index = next++
         if (index >= values.length) return
         try {
-          results[index] = failed ? undefined as U : await visit(values[index]!)
+          results[index] = await visit(values[index]!, assertActive)
         }
         catch (error) {
           if (!failed) failure = error
@@ -272,8 +278,8 @@ async function ensureHostParent(host: WorkspaceSessionHost, path: string, abortS
     await host.files.mkdir(parent, { recursive: true, signal: abortSignal })
 }
 
-async function readHostSymlinkTarget(host: WorkspaceSessionHost, root: string, path: string, abortSignal?: AbortSignal): Promise<string> {
-  const result = await inspectHost(host, async () => await host.exec("readlink", [fromHostPath(root, path)], { cwd: root, signal: abortSignal }), abortSignal)
+async function readHostSymlinkTarget(host: WorkspaceSessionHost, root: string, path: string, abortSignal?: AbortSignal, assertActive?: () => void): Promise<string> {
+  const result = await inspectHost(host, async () => await host.exec("readlink", [fromHostPath(root, path)], { cwd: root, signal: abortSignal }), abortSignal, assertActive)
   if (result.code !== 0)
     throw workspaceError(`[vitehub] Failed to read workspace symlink: ${path}.`, {
       cause: new Error(result.stderr || "readlink failed"),
@@ -338,11 +344,11 @@ async function listHostEntries(
   const entries = listed
     .map(entry => ({ executable: entry.executable, workspaceEntry: toWorkspaceEntry(root, entry) }))
     .filter(({ workspaceEntry }) => !isExcludedWorkspacePath(workspaceEntry.path, excluded) && (!include || include(workspaceEntry)))
-  const resolved = await mapHostInspections(host, entries, async ({ executable, workspaceEntry }) => {
+  const resolved = await mapHostInspections(host, entries, async ({ executable, workspaceEntry }, assertActive) => {
     abortSignal?.throwIfAborted()
     if (workspaceEntry.type !== "file" || isGitSymlinkEntry(workspaceEntry)) return workspaceEntry
     if (executable !== undefined) return workspaceEntry
-    const probe = await inspectHost(host, async () => await host.exec("test", ["-x", workspaceEntry.path], { cwd: root, signal: abortSignal }), abortSignal)
+    const probe = await inspectHost(host, async () => await host.exec("test", ["-x", workspaceEntry.path], { cwd: root, signal: abortSignal }), abortSignal, assertActive)
     return probe.code === 0
       ? { ...workspaceEntry, metadata: { ...workspaceEntry.metadata, gitMode: "100755" } }
       : workspaceEntry
@@ -375,12 +381,12 @@ async function captureHostState(host: WorkspaceSessionHost, root: string, name?:
 
 async function captureHostEntriesState(host: WorkspaceSessionHost, root: string, entries: WorkspaceEntry[], name?: string, abortSignal?: AbortSignal) {
   const contents = new Map<string, Uint8Array | string>()
-  const files = await mapHostInspections(host, entries, async (entry) => {
+  const files = await mapHostInspections(host, entries, async (entry, assertActive) => {
     abortSignal?.throwIfAborted()
     if (entry.type !== "file") return entry
     const content = isGitSymlinkEntry(entry)
-      ? await readHostSymlinkTarget(host, root, toHostPath(root, entry.path), abortSignal)
-      : await inspectHost(host, async () => await host.files.read(toHostPath(root, entry.path), { signal: abortSignal }), abortSignal)
+      ? await readHostSymlinkTarget(host, root, toHostPath(root, entry.path), abortSignal, assertActive)
+      : await inspectHost(host, async () => await host.files.read(toHostPath(root, entry.path), { signal: abortSignal }), abortSignal, assertActive)
     if (content === null) throw workspaceError(`[vitehub] Workspace host file disappeared while snapshotting: ${entry.path}.`)
     contents.set(entry.path, content)
     return {

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -67,7 +67,29 @@ function resolveHostInspectionLimiter(host: WorkspaceSessionHost) {
 
 async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: readonly T[], visit: (value: T) => Promise<U>) {
   const inspect = resolveHostInspectionLimiter(host)
-  return await Promise.all(values.map(value => inspect(async () => await visit(value))))
+  const results = new Array<U>(values.length)
+  let next = 0
+  let failed = false
+  let failure: unknown
+  const workers = Array.from(
+    { length: Math.min(values.length, resolveHostInspectionConcurrency(host)) },
+    async () => {
+      while (!failed) {
+        const index = next++
+        if (index >= values.length) return
+        try {
+          results[index] = await inspect(async () => failed ? undefined as U : await visit(values[index]!))
+        }
+        catch (error) {
+          if (!failed) failure = error
+          failed = true
+        }
+      }
+    },
+  )
+  await Promise.all(workers)
+  if (failed) throw failure
+  return results
 }
 
 async function waitForOperation<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -30,7 +30,15 @@ import type {
 } from "../core/types.ts"
 
 const publicationQueues = new WeakMap<object, Promise<void>>()
-const hostInspectionConcurrency = 16
+const defaultHostInspectionConcurrency = 16
+
+function resolveHostInspectionConcurrency(host: WorkspaceSessionHost): number {
+  const concurrency = host.inspectionConcurrency ?? defaultHostInspectionConcurrency
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw workspaceError("[vitehub] Workspace host inspectionConcurrency must be a positive integer.")
+  }
+  return concurrency
+}
 
 async function mapWithConcurrency<T, U>(values: readonly T[], concurrency: number, visit: (value: T) => Promise<U>) {
   const results = new Array<U>(values.length)
@@ -269,7 +277,7 @@ async function listHostEntries(
   const entries = listed
     .map(entry => ({ executable: entry.executable, workspaceEntry: toWorkspaceEntry(root, entry) }))
     .filter(({ workspaceEntry }) => !isExcludedWorkspacePath(workspaceEntry.path, excluded) && (!include || include(workspaceEntry)))
-  const resolved = await mapWithConcurrency(entries, hostInspectionConcurrency, async ({ executable, workspaceEntry }) => {
+  const resolved = await mapWithConcurrency(entries, resolveHostInspectionConcurrency(host), async ({ executable, workspaceEntry }) => {
     abortSignal?.throwIfAborted()
     if (workspaceEntry.type !== "file" || isGitSymlinkEntry(workspaceEntry)) return workspaceEntry
     if (executable !== undefined) return workspaceEntry
@@ -306,7 +314,7 @@ async function captureHostState(host: WorkspaceSessionHost, root: string, name?:
 
 async function captureHostEntriesState(host: WorkspaceSessionHost, root: string, entries: WorkspaceEntry[], name?: string, abortSignal?: AbortSignal) {
   const contents = new Map<string, Uint8Array | string>()
-  const files = await mapWithConcurrency(entries, hostInspectionConcurrency, async (entry) => {
+  const files = await mapWithConcurrency(entries, resolveHostInspectionConcurrency(host), async (entry) => {
     abortSignal?.throwIfAborted()
     if (entry.type !== "file") return entry
     const content = isGitSymlinkEntry(entry)
@@ -764,6 +772,7 @@ export async function createHostedWorkspaceSession(
   catch {
     throw new TypeError("[vitehub] Workspace session host must declare executionAuthority.")
   }
+  resolveHostInspectionConcurrency(host)
   const root = normalizeTarget(options.target)
   const sessionPaths = normalizeSessionPaths(options)
   const excludedWriteBackPaths = [

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -31,7 +31,7 @@ import type {
 
 const publicationQueues = new WeakMap<object, Promise<void>>()
 const defaultHostInspectionConcurrency = 16
-const hostInspectionLimiters = new WeakMap<object, <T>(inspect: () => Promise<T>) => Promise<T>>()
+const hostInspectionLimiters = new WeakMap<object, <T>(inspect: () => Promise<T>, signal?: AbortSignal) => Promise<T>>()
 
 function resolveHostInspectionConcurrency(host: WorkspaceSessionHost): number {
   const concurrency = host.inspectionConcurrency ?? defaultHostInspectionConcurrency
@@ -46,26 +46,43 @@ function resolveHostInspectionLimiter(host: WorkspaceSessionHost) {
   if (existing) return existing
   const concurrency = resolveHostInspectionConcurrency(host)
   let active = 0
-  const queued: Array<() => void> = []
-  const run = async <T>(inspect: () => Promise<T>): Promise<T> => {
+  const queued: Array<{ grant: () => void }> = []
+  const run = async <T>(inspect: () => Promise<T>, signal?: AbortSignal): Promise<T> => {
+    signal?.throwIfAborted()
     if (active < concurrency) active++
-    else await new Promise<void>(resolve => queued.push(() => {
-      active++
-      resolve()
-    }))
+    else {
+      await new Promise<void>((resolve, reject) => {
+        const entry = {
+          grant: () => {
+            signal?.removeEventListener("abort", abort)
+            active++
+            resolve()
+          },
+        }
+        const abort = () => {
+          const index = queued.indexOf(entry)
+          if (index < 0) return
+          queued.splice(index, 1)
+          reject(signal?.reason)
+        }
+        signal?.addEventListener("abort", abort, { once: true })
+        queued.push(entry)
+        if (signal?.aborted) abort()
+      })
+    }
     try {
       return await inspect()
     }
     finally {
       active--
-      queued.shift()?.()
+      queued.shift()?.grant()
     }
   }
   hostInspectionLimiters.set(host, run)
   return run
 }
 
-async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: readonly T[], visit: (value: T) => Promise<U>) {
+async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: readonly T[], visit: (value: T) => Promise<U>, signal?: AbortSignal) {
   const inspect = resolveHostInspectionLimiter(host)
   const results = new Array<U>(values.length)
   let next = 0
@@ -78,7 +95,7 @@ async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: read
         const index = next++
         if (index >= values.length) return
         try {
-          results[index] = await inspect(async () => failed ? undefined as U : await visit(values[index]!))
+          results[index] = await inspect(async () => failed ? undefined as U : await visit(values[index]!), signal)
         }
         catch (error) {
           if (!failed) failure = error
@@ -325,7 +342,7 @@ async function listHostEntries(
     return probe.code === 0
       ? { ...workspaceEntry, metadata: { ...workspaceEntry.metadata, gitMode: "100755" } }
       : workspaceEntry
-  })
+  }, abortSignal)
   return resolved
     .filter(entry => entry.path && (includeGit || !gitMetadataRoot(entry.path)))
     .sort((left, right) => left.path.localeCompare(right.path))
@@ -367,7 +384,7 @@ async function captureHostEntriesState(host: WorkspaceSessionHost, root: string,
       digest: await sha256(content),
       size: contentToBytes(content).byteLength,
     }
-  })
+  }, abortSignal)
   return { contents, snapshot: await createSnapshotFromEntries(files, name) }
 }
 

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -31,6 +31,7 @@ import type {
 
 const publicationQueues = new WeakMap<object, Promise<void>>()
 const defaultHostInspectionConcurrency = 16
+const hostInspectionLimiters = new WeakMap<object, <T>(inspect: () => Promise<T>) => Promise<T>>()
 
 function resolveHostInspectionConcurrency(host: WorkspaceSessionHost): number {
   const concurrency = host.inspectionConcurrency ?? defaultHostInspectionConcurrency
@@ -40,16 +41,33 @@ function resolveHostInspectionConcurrency(host: WorkspaceSessionHost): number {
   return concurrency
 }
 
-async function mapWithConcurrency<T, U>(values: readonly T[], concurrency: number, visit: (value: T) => Promise<U>) {
-  const results = new Array<U>(values.length)
-  let next = 0
-  await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, async () => {
-    while (next < values.length) {
-      const index = next++
-      results[index] = await visit(values[index]!)
+function resolveHostInspectionLimiter(host: WorkspaceSessionHost) {
+  const existing = hostInspectionLimiters.get(host)
+  if (existing) return existing
+  const concurrency = resolveHostInspectionConcurrency(host)
+  let active = 0
+  const queued: Array<() => void> = []
+  const run = async <T>(inspect: () => Promise<T>): Promise<T> => {
+    if (active < concurrency) active++
+    else await new Promise<void>(resolve => queued.push(() => {
+      active++
+      resolve()
+    }))
+    try {
+      return await inspect()
     }
-  }))
-  return results
+    finally {
+      active--
+      queued.shift()?.()
+    }
+  }
+  hostInspectionLimiters.set(host, run)
+  return run
+}
+
+async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: readonly T[], visit: (value: T) => Promise<U>) {
+  const inspect = resolveHostInspectionLimiter(host)
+  return await Promise.all(values.map(value => inspect(async () => await visit(value))))
 }
 
 async function waitForOperation<T>(operation: Promise<T>, signal?: AbortSignal): Promise<T> {
@@ -277,7 +295,7 @@ async function listHostEntries(
   const entries = listed
     .map(entry => ({ executable: entry.executable, workspaceEntry: toWorkspaceEntry(root, entry) }))
     .filter(({ workspaceEntry }) => !isExcludedWorkspacePath(workspaceEntry.path, excluded) && (!include || include(workspaceEntry)))
-  const resolved = await mapWithConcurrency(entries, resolveHostInspectionConcurrency(host), async ({ executable, workspaceEntry }) => {
+  const resolved = await mapHostInspections(host, entries, async ({ executable, workspaceEntry }) => {
     abortSignal?.throwIfAborted()
     if (workspaceEntry.type !== "file" || isGitSymlinkEntry(workspaceEntry)) return workspaceEntry
     if (executable !== undefined) return workspaceEntry
@@ -314,7 +332,7 @@ async function captureHostState(host: WorkspaceSessionHost, root: string, name?:
 
 async function captureHostEntriesState(host: WorkspaceSessionHost, root: string, entries: WorkspaceEntry[], name?: string, abortSignal?: AbortSignal) {
   const contents = new Map<string, Uint8Array | string>()
-  const files = await mapWithConcurrency(entries, resolveHostInspectionConcurrency(host), async (entry) => {
+  const files = await mapHostInspections(host, entries, async (entry) => {
     abortSignal?.throwIfAborted()
     if (entry.type !== "file") return entry
     const content = isGitSymlinkEntry(entry)

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -82,14 +82,30 @@ function resolveHostInspectionLimiter(host: WorkspaceSessionHost) {
   return run
 }
 
-function inspectHost<T>(host: WorkspaceSessionHost, inspect: () => Promise<T>, signal?: AbortSignal, assertActive?: () => void): Promise<T> {
+function inspectHost<T>(
+  host: WorkspaceSessionHost,
+  inspect: () => Promise<T>,
+  signal?: AbortSignal,
+  batch?: { assertActive: () => void, fail: (error: unknown) => void },
+): Promise<T> {
   return resolveHostInspectionLimiter(host)(async () => {
-    assertActive?.()
-    return await inspect()
+    batch?.assertActive()
+    try {
+      return await inspect()
+    }
+    catch (error) {
+      batch?.fail(error)
+      throw error
+    }
   }, signal)
 }
 
-async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: readonly T[], visit: (value: T, assertActive: () => void) => Promise<U>, _signal?: AbortSignal) {
+async function mapHostInspections<T, U>(
+  host: WorkspaceSessionHost,
+  values: readonly T[],
+  visit: (value: T, batch: { assertActive: () => void, fail: (error: unknown) => void }) => Promise<U>,
+  _signal?: AbortSignal,
+) {
   const results = new Array<U>(values.length)
   let next = 0
   let failed = false
@@ -97,6 +113,11 @@ async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: read
   const assertActive = () => {
     if (failed) throw failure
   }
+  const fail = (error: unknown) => {
+    if (!failed) failure = error
+    failed = true
+  }
+  const batch = { assertActive, fail }
   const workers = Array.from(
     { length: Math.min(values.length, resolveHostInspectionConcurrency(host)) },
     async () => {
@@ -104,11 +125,10 @@ async function mapHostInspections<T, U>(host: WorkspaceSessionHost, values: read
         const index = next++
         if (index >= values.length) return
         try {
-          results[index] = await visit(values[index]!, assertActive)
+          results[index] = await visit(values[index]!, batch)
         }
         catch (error) {
-          if (!failed) failure = error
-          failed = true
+          fail(error)
         }
       }
     },
@@ -278,13 +298,15 @@ async function ensureHostParent(host: WorkspaceSessionHost, path: string, abortS
     await host.files.mkdir(parent, { recursive: true, signal: abortSignal })
 }
 
-async function readHostSymlinkTarget(host: WorkspaceSessionHost, root: string, path: string, abortSignal?: AbortSignal, assertActive?: () => void): Promise<string> {
-  const result = await inspectHost(host, async () => await host.exec("readlink", [fromHostPath(root, path)], { cwd: root, signal: abortSignal }), abortSignal, assertActive)
-  if (result.code !== 0)
-    throw workspaceError(`[vitehub] Failed to read workspace symlink: ${path}.`, {
-      cause: new Error(result.stderr || "readlink failed"),
-    })
-  return result.stdout.replace(/\n$/, "")
+async function readHostSymlinkTarget(host: WorkspaceSessionHost, root: string, path: string, abortSignal?: AbortSignal, batch?: { assertActive: () => void, fail: (error: unknown) => void }): Promise<string> {
+  return await inspectHost(host, async () => {
+    const result = await host.exec("readlink", [fromHostPath(root, path)], { cwd: root, signal: abortSignal })
+    if (result.code !== 0)
+      throw workspaceError(`[vitehub] Failed to read workspace symlink: ${path}.`, {
+        cause: new Error(result.stderr || "readlink failed"),
+      })
+    return result.stdout.replace(/\n$/, "")
+  }, abortSignal, batch)
 }
 
 async function writeHostSymlink(host: WorkspaceSessionHost, root: string, path: string, target: string, abortSignal?: AbortSignal) {
@@ -344,11 +366,11 @@ async function listHostEntries(
   const entries = listed
     .map(entry => ({ executable: entry.executable, workspaceEntry: toWorkspaceEntry(root, entry) }))
     .filter(({ workspaceEntry }) => !isExcludedWorkspacePath(workspaceEntry.path, excluded) && (!include || include(workspaceEntry)))
-  const resolved = await mapHostInspections(host, entries, async ({ executable, workspaceEntry }, assertActive) => {
+  const resolved = await mapHostInspections(host, entries, async ({ executable, workspaceEntry }, batch) => {
     abortSignal?.throwIfAborted()
     if (workspaceEntry.type !== "file" || isGitSymlinkEntry(workspaceEntry)) return workspaceEntry
     if (executable !== undefined) return workspaceEntry
-    const probe = await inspectHost(host, async () => await host.exec("test", ["-x", workspaceEntry.path], { cwd: root, signal: abortSignal }), abortSignal, assertActive)
+    const probe = await inspectHost(host, async () => await host.exec("test", ["-x", workspaceEntry.path], { cwd: root, signal: abortSignal }), abortSignal, batch)
     return probe.code === 0
       ? { ...workspaceEntry, metadata: { ...workspaceEntry.metadata, gitMode: "100755" } }
       : workspaceEntry
@@ -381,13 +403,16 @@ async function captureHostState(host: WorkspaceSessionHost, root: string, name?:
 
 async function captureHostEntriesState(host: WorkspaceSessionHost, root: string, entries: WorkspaceEntry[], name?: string, abortSignal?: AbortSignal) {
   const contents = new Map<string, Uint8Array | string>()
-  const files = await mapHostInspections(host, entries, async (entry, assertActive) => {
+  const files = await mapHostInspections(host, entries, async (entry, batch) => {
     abortSignal?.throwIfAborted()
     if (entry.type !== "file") return entry
     const content = isGitSymlinkEntry(entry)
-      ? await readHostSymlinkTarget(host, root, toHostPath(root, entry.path), abortSignal, assertActive)
-      : await inspectHost(host, async () => await host.files.read(toHostPath(root, entry.path), { signal: abortSignal }), abortSignal, assertActive)
-    if (content === null) throw workspaceError(`[vitehub] Workspace host file disappeared while snapshotting: ${entry.path}.`)
+      ? await readHostSymlinkTarget(host, root, toHostPath(root, entry.path), abortSignal, batch)
+      : await inspectHost(host, async () => {
+          const content = await host.files.read(toHostPath(root, entry.path), { signal: abortSignal })
+          if (content === null) throw workspaceError(`[vitehub] Workspace host file disappeared while snapshotting: ${entry.path}.`)
+          return content
+        }, abortSignal, batch)
     contents.set(entry.path, content)
     return {
       ...entry,

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1509,6 +1509,48 @@ describe("workspace host sessions", () => {
     expect(maximum).toBeLessThanOrEqual(16)
   })
 
+  it("honors the host inspection concurrency across executable probes and file reads", async () => {
+    const docs = workspace()
+    const host = Object.assign(memoryHost(), { inspectionConcurrency: 1 })
+    const exec = host.exec.bind(host)
+    const read = host.files.read.bind(host.files)
+    let active = 0
+    let maximum = 0
+    const inspect = async <T>(operation: () => Promise<T>) => {
+      active++
+      maximum = Math.max(maximum, active)
+      await new Promise(resolve => setTimeout(resolve, 1))
+      try {
+        return await operation()
+      }
+      finally {
+        active--
+      }
+    }
+    host.exec = async (command, args, options) => command === "test" && args?.[0] === "-x"
+      ? await inspect(async () => await exec(command, args, options))
+      : await exec(command, args, options)
+    host.files.read = async path => await inspect(async () => await read(path))
+    for (let index = 0; index < 8; index++) await docs.writeFile(`files/${index}.txt`, String(index))
+    await docs.snapshot({ name: "baseline" })
+
+    const session = await docs.startSession({ host })
+    await session.close()
+
+    expect(maximum).toBe(1)
+  })
+
+  it("rejects invalid host inspection concurrency", async () => {
+    const docs = workspace()
+    await docs.writeFile("README.md", "docs")
+    await docs.snapshot({ name: "baseline" })
+    const host = Object.assign(memoryHost(), { inspectionConcurrency: 0 })
+
+    await expect(docs.startSession({ host })).rejects.toThrow(
+      "Workspace host inspectionConcurrency must be a positive integer",
+    )
+  })
+
   it("uses host-reported executable modes without spawning probes", async () => {
     const docs = workspace()
     const host = memoryHost()

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1509,7 +1509,7 @@ describe("workspace host sessions", () => {
     expect(maximum).toBeLessThanOrEqual(16)
   })
 
-  it("honors the host inspection concurrency across executable probes and file reads", async () => {
+  it("honors the host inspection concurrency across concurrent operations", async () => {
     const docs = workspace()
     const host = Object.assign(memoryHost(), { inspectionConcurrency: 1 })
     const exec = host.exec.bind(host)
@@ -1535,6 +1535,11 @@ describe("workspace host sessions", () => {
     await docs.snapshot({ name: "baseline" })
 
     const session = await docs.startSession({ host })
+    maximum = 0
+    await Promise.all([
+      session.diff(),
+      session.list("", { recursive: true }),
+    ])
     await session.close()
 
     expect(maximum).toBe(1)

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1513,6 +1513,8 @@ describe("workspace host sessions", () => {
     const docs = workspace()
     const host = Object.assign(memoryHost(), { inspectionConcurrency: 1 })
     const exec = host.exec.bind(host)
+    const exists = host.files.exists.bind(host.files)
+    const list = host.files.list.bind(host.files)
     const read = host.files.read.bind(host.files)
     let active = 0
     let maximum = 0
@@ -1527,10 +1529,12 @@ describe("workspace host sessions", () => {
         active--
       }
     }
-    host.exec = async (command, args, options) => command === "test" && args?.[0] === "-x"
+    host.exec = async (command, args, options) => command === "test"
       ? await inspect(async () => await exec(command, args, options))
       : await exec(command, args, options)
-    host.files.read = async path => await inspect(async () => await read(path))
+    host.files.exists = async (path, options) => await inspect(async () => await exists(path, options))
+    host.files.list = async (path, options) => await inspect(async () => await list(path, options))
+    host.files.read = async (path, options) => await inspect(async () => await read(path, options))
     for (let index = 0; index < 8; index++) await docs.writeFile(`files/${index}.txt`, String(index))
     await docs.snapshot({ name: "baseline" })
 
@@ -1539,6 +1543,8 @@ describe("workspace host sessions", () => {
     await Promise.all([
       session.diff(),
       session.list("", { recursive: true }),
+      session.readFile("files/0.txt"),
+      session.search({ pattern: "0" }),
     ])
     await session.close()
 
@@ -1600,11 +1606,10 @@ describe("workspace host sessions", () => {
     const abort = new AbortController()
     const reason = new Error("inspection expired")
     const second = session.diff({ abortSignal: abort.signal })
-    await vi.waitFor(() => expect(lists).toBe(2))
     abort.abort(reason)
 
     await expect(second).rejects.toBe(reason)
-    expect(reads).toBe(1)
+    expect({ lists, reads }).toEqual({ lists: 1, reads: 1 })
     release()
     await first
     await session.close()

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1554,21 +1554,24 @@ describe("workspace host sessions", () => {
   it("settles active inspections and skips pending work after a batch fails", async () => {
     const docs = workspace()
     const host = Object.assign(memoryHost(), { inspectionConcurrency: 2 })
-    await docs.writeFile("blocker.txt", "blocker")
     for (let index = 0; index < 3; index++) await docs.writeFile(`files/${index}.txt`, String(index))
     await docs.snapshot({ name: "baseline" })
     const session = await docs.startSession({ host })
+    const exists = host.files.exists.bind(host.files)
     const read = host.files.read.bind(host.files)
     let batchReads = 0
     let release!: () => void
     const blocked = new Promise<void>((resolve) => { release = resolve })
+    host.files.exists = async (path, options) => {
+      if (path.endsWith("missing.txt")) await blocked
+      return await exists(path, options)
+    }
     host.files.read = async (path, options) => {
-      if (path.endsWith("blocker.txt")) await blocked
-      else if (++batchReads === 1) throw new Error("inspection failed")
+      if (++batchReads === 1) throw new Error("inspection failed")
       return await read(path, options)
     }
 
-    const blocker = session.readFile("blocker.txt")
+    const blocker = session.readFile("missing.txt")
     const diff = session.diff()
     await vi.waitFor(() => expect(batchReads).toBe(1))
     let settled = false
@@ -1576,7 +1579,7 @@ describe("workspace host sessions", () => {
     await new Promise(resolve => setTimeout(resolve, 1))
     expect(settled).toBe(false)
     release()
-    await blocker
+    await expect(blocker).resolves.toBeUndefined()
     await expect(diff).rejects.toThrow("inspection failed")
     expect(batchReads).toBe(1)
   })

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1573,6 +1573,43 @@ describe("workspace host sessions", () => {
     expect(reads).toBe(2)
   })
 
+  it("settles an aborted inspection while it waits for a host slot", async () => {
+    const docs = workspace()
+    const host = Object.assign(memoryHost(), { inspectionConcurrency: 1 })
+    await docs.writeFile("README.md", "docs")
+    await docs.snapshot({ name: "baseline" })
+    const session = await docs.startSession({ host })
+    const read = host.files.read.bind(host.files)
+    const list = host.files.list.bind(host.files)
+    let release!: () => void
+    const blocked = new Promise<void>((resolve) => { release = resolve })
+    let reads = 0
+    let lists = 0
+    host.files.list = async (path, options) => {
+      lists++
+      return await list(path, options)
+    }
+    host.files.read = async (path, options) => {
+      reads++
+      if (reads === 1) await blocked
+      return await read(path, options)
+    }
+
+    const first = session.diff()
+    await vi.waitFor(() => expect(reads).toBe(1))
+    const abort = new AbortController()
+    const reason = new Error("inspection expired")
+    const second = session.diff({ abortSignal: abort.signal })
+    await vi.waitFor(() => expect(lists).toBe(2))
+    abort.abort(reason)
+
+    await expect(second).rejects.toBe(reason)
+    expect(reads).toBe(1)
+    release()
+    await first
+    await session.close()
+  })
+
   it("rejects invalid host inspection concurrency", async () => {
     const docs = workspace()
     await docs.writeFile("README.md", "docs")

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1545,6 +1545,34 @@ describe("workspace host sessions", () => {
     expect(maximum).toBe(1)
   })
 
+  it("settles active inspections and skips pending work after a batch fails", async () => {
+    const docs = workspace()
+    const host = Object.assign(memoryHost(), { inspectionConcurrency: 2 })
+    for (let index = 0; index < 4; index++) await docs.writeFile(`files/${index}.txt`, String(index))
+    await docs.snapshot({ name: "baseline" })
+    const session = await docs.startSession({ host })
+    const read = host.files.read.bind(host.files)
+    let reads = 0
+    let release!: () => void
+    const active = new Promise<void>((resolve) => { release = resolve })
+    host.files.read = async (path, options) => {
+      reads++
+      if (reads === 1) throw new Error("inspection failed")
+      await active
+      return await read(path, options)
+    }
+
+    const diff = session.diff()
+    await vi.waitFor(() => expect(reads).toBe(2))
+    let settled = false
+    void diff.finally(() => { settled = true }).catch(() => {})
+    await new Promise(resolve => setTimeout(resolve, 1))
+    expect(settled).toBe(false)
+    release()
+    await expect(diff).rejects.toThrow("inspection failed")
+    expect(reads).toBe(2)
+  })
+
   it("rejects invalid host inspection concurrency", async () => {
     const docs = workspace()
     await docs.writeFile("README.md", "docs")

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1557,31 +1557,27 @@ describe("workspace host sessions", () => {
     for (let index = 0; index < 3; index++) await docs.writeFile(`files/${index}.txt`, String(index))
     await docs.snapshot({ name: "baseline" })
     const session = await docs.startSession({ host })
-    const exists = host.files.exists.bind(host.files)
     const read = host.files.read.bind(host.files)
     let batchReads = 0
     let release!: () => void
     const blocked = new Promise<void>((resolve) => { release = resolve })
-    host.files.exists = async (path, options) => {
-      if (path.endsWith("missing.txt")) await blocked
-      return await exists(path, options)
-    }
     host.files.read = async (path, options) => {
-      if (++batchReads === 1) throw new Error("inspection failed")
+      batchReads++
+      if (path.endsWith("files/0.txt")) await blocked
+      if (path.endsWith("files/1.txt")) throw new Error("inspection failed")
       return await read(path, options)
     }
 
-    const blocker = session.readFile("missing.txt")
     const diff = session.diff()
-    await vi.waitFor(() => expect(batchReads).toBe(1))
+    void diff.catch(() => {})
+    await vi.waitFor(() => expect(batchReads).toBe(2))
     let settled = false
     void diff.finally(() => { settled = true }).catch(() => {})
     await new Promise(resolve => setTimeout(resolve, 1))
     expect(settled).toBe(false)
     release()
-    await expect(blocker).resolves.toBeUndefined()
     await expect(diff).rejects.toThrow("inspection failed")
-    expect(batchReads).toBe(1)
+    expect(batchReads).toBe(2)
   })
 
   it("settles an aborted inspection while it waits for a host slot", async () => {

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1553,21 +1553,35 @@ describe("workspace host sessions", () => {
 
   it("settles active inspections and skips pending work after a batch fails", async () => {
     const docs = workspace()
-    const host = Object.assign(memoryHost(), { inspectionConcurrency: 2 })
+    const host = Object.assign(memoryHost(), { inspectionConcurrency: 3 })
     for (let index = 0; index < 3; index++) await docs.writeFile(`files/${index}.txt`, String(index))
     await docs.snapshot({ name: "baseline" })
     const session = await docs.startSession({ host })
+    const exists = host.files.exists.bind(host.files)
     const read = host.files.read.bind(host.files)
     let batchReads = 0
-    let release!: () => void
-    const blocked = new Promise<void>((resolve) => { release = resolve })
+    let releaseIndependent!: () => void
+    const independentBlocked = new Promise<void>((resolve) => { releaseIndependent = resolve })
+    let releaseBatch!: () => void
+    const batchBlocked = new Promise<void>((resolve) => { releaseBatch = resolve })
+    let independentStarted = false
+    host.files.exists = async (path, options) => {
+      if (path.endsWith("missing.txt")) {
+        independentStarted = true
+        await independentBlocked
+      }
+      return await exists(path, options)
+    }
     host.files.read = async (path, options) => {
       batchReads++
-      if (path.endsWith("files/0.txt")) await blocked
+      if (path.endsWith("files/0.txt")) await batchBlocked
       if (path.endsWith("files/1.txt")) throw new Error("inspection failed")
       return await read(path, options)
     }
 
+    const independent = session.readFile("missing.txt")
+    void independent.catch(() => {})
+    await vi.waitFor(() => expect(independentStarted).toBe(true))
     const diff = session.diff()
     void diff.catch(() => {})
     await vi.waitFor(() => expect(batchReads).toBe(2))
@@ -1575,9 +1589,11 @@ describe("workspace host sessions", () => {
     void diff.finally(() => { settled = true }).catch(() => {})
     await new Promise(resolve => setTimeout(resolve, 1))
     expect(settled).toBe(false)
-    release()
+    releaseBatch()
     await expect(diff).rejects.toThrow("inspection failed")
     expect(batchReads).toBe(2)
+    releaseIndependent()
+    await expect(independent).rejects.toThrow("Workspace file does not exist: missing.txt")
   })
 
   it("settles an aborted inspection while it waits for a host slot", async () => {

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1554,29 +1554,31 @@ describe("workspace host sessions", () => {
   it("settles active inspections and skips pending work after a batch fails", async () => {
     const docs = workspace()
     const host = Object.assign(memoryHost(), { inspectionConcurrency: 2 })
-    for (let index = 0; index < 4; index++) await docs.writeFile(`files/${index}.txt`, String(index))
+    await docs.writeFile("blocker.txt", "blocker")
+    for (let index = 0; index < 3; index++) await docs.writeFile(`files/${index}.txt`, String(index))
     await docs.snapshot({ name: "baseline" })
     const session = await docs.startSession({ host })
     const read = host.files.read.bind(host.files)
-    let reads = 0
+    let batchReads = 0
     let release!: () => void
-    const active = new Promise<void>((resolve) => { release = resolve })
+    const blocked = new Promise<void>((resolve) => { release = resolve })
     host.files.read = async (path, options) => {
-      reads++
-      if (reads === 1) throw new Error("inspection failed")
-      await active
+      if (path.endsWith("blocker.txt")) await blocked
+      else if (++batchReads === 1) throw new Error("inspection failed")
       return await read(path, options)
     }
 
+    const blocker = session.readFile("blocker.txt")
     const diff = session.diff()
-    await vi.waitFor(() => expect(reads).toBe(2))
+    await vi.waitFor(() => expect(batchReads).toBe(1))
     let settled = false
     void diff.finally(() => { settled = true }).catch(() => {})
     await new Promise(resolve => setTimeout(resolve, 1))
     expect(settled).toBe(false)
     release()
+    await blocker
     await expect(diff).rejects.toThrow("inspection failed")
-    expect(reads).toBe(2)
+    expect(batchReads).toBe(1)
   })
 
   it("settles an aborted inspection while it waits for a host slot", async () => {


### PR DESCRIPTION
## Summary

- let Workspace Session hosts declare the concurrency they support for file inspection
- retain the existing default of 16 and reject invalid host declarations before mutating the target
- propagate the contract through Box Sessions and declare Crabbox as single-flight

## Verification

- Workspace host-session tests: 3 passed (`bounds executable-mode probes`, custom concurrency, invalid concurrency)
- Crabbox integration test: 1 passed
- `corepack pnpm --filter @vite-hub/workspace typecheck`
- `corepack pnpm --filter @vite-hub/box typecheck`
- Workspace and Box package builds/publint passed as test prerequisites