### PR TITLE
fix(ui): render truncation as system activity

### DIFF
--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -763,11 +763,17 @@ function renderInvocationActivities(
 
   const prefix = activities.slice(0, firstUser + 1);
   const tail = activities.slice(firstUser + 1);
+  const terminal = tail.filter(activity => activity.name === "vitehub.observation.truncated");
   const externalBeforeFinal = tail.filter((activity, offset) =>
-    isExternalActivity(activity) && (lastAssistant < 0 || firstUser + 1 + offset < lastAssistant),
+    activity.name !== "vitehub.observation.truncated"
+    && isExternalActivity(activity)
+    && (lastAssistant < 0 || firstUser + 1 + offset < lastAssistant),
   );
   const externalAfterFinal = tail.filter((activity, offset) =>
-    isExternalActivity(activity) && lastAssistant >= 0 && firstUser + 1 + offset > lastAssistant,
+    activity.name !== "vitehub.observation.truncated"
+    && isExternalActivity(activity)
+    && lastAssistant >= 0
+    && firstUser + 1 + offset > lastAssistant,
   );
   const work = tail.filter((activity, offset) => {
     const index = firstUser + 1 + offset;
@@ -780,6 +786,7 @@ function renderInvocationActivities(
     renderWorkSummary(work, invocation, expanded, toggleExpanded, inspect),
     ...(lastAssistant >= 0 ? [renderInvocationActivity(activities[lastAssistant]!, expanded, toggleExpanded, inspect)] : []),
     ...renderActivitySequence(externalAfterFinal, invocation, expanded, toggleExpanded, inspect),
+    ...renderActivitySequence(terminal, invocation, expanded, toggleExpanded, inspect),
   ].filter(item => item !== null);
 }
 

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -868,7 +868,9 @@ export const AgentInvocationInspector = defineComponent({
     const metrics = computed(() => ({
       changes: activities.value.filter((activity) => activity.kind === "change").length,
       messages: activities.value.filter((activity) => activity.kind === "message").length,
-      steps: activities.value.filter((activity) => activity.kind !== "message").length,
+      steps: activities.value.filter((activity) =>
+        activity.kind !== "message" && activity.name !== "vitehub.observation.truncated"
+      ).length,
       tokens: latestInvocationTokens(activities.value),
     }));
 

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -376,11 +376,21 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
       };
     })
     .sort((left, right) => left.sequence - right.sequence);
-  if (traceTruncated && !activities.some(activity => activity.truncated)) {
-    if (activities.length > 0) activities[activities.length - 1] = { ...activities[activities.length - 1]!, truncated: true };
-    else activities.push({ attributes: {}, id: "trace-truncated", kind: "run", name: "vitehub.observation.truncated", patches: [], paths: [], sequence: 0, status: "completed", truncated: true });
+  const contentTruncated = traceTruncated || activities.some(activity => activity.truncated);
+  const compactActivities = activities.map(({ truncated: _truncated, ...activity }) => activity);
+  if (contentTruncated && !compactActivities.some(activity => activity.name === "vitehub.observation.truncated")) {
+    compactActivities.push({
+      attributes: {},
+      id: "trace-truncated",
+      kind: "system",
+      name: "vitehub.observation.truncated",
+      patches: [],
+      paths: [],
+      sequence: (compactActivities.at(-1)?.sequence ?? -1) + 1,
+      status: "completed",
+    });
   }
-  return activities;
+  return compactActivities;
 }
 
 export function latestInvocationTokens(activities: readonly InvocationActivity[]): number | undefined {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -1289,6 +1289,36 @@ describe("Agent Invocation UI", () => {
     expect(wrapper.find(".vh-invocation-activities > .vh-invocation-message[data-role=\"assistant\"]").exists()).toBe(false);
   });
 
+  it("renders truncation after work when the latest user has no response", () => {
+    const timestamp = "2026-08-24T00:00:00.000Z";
+    const invocation = {
+      createdAt: timestamp,
+      id: "truncated-unanswered-turn",
+      observations: [{
+        attributes: { "message.content": "Unanswered question", "message.id": "user", "message.role": "user" },
+        name: "agent.message",
+        sequence: 1,
+        timestamp,
+        type: "lifecycle" as const,
+      }, {
+        attributes: { "error.message": "Model request failed", "tool.name": "generate" },
+        name: "agent.tool.error",
+        sequence: 2,
+        timestamp,
+        type: "error" as const,
+      }],
+      observationsTruncated: true,
+      status: "failed" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    const rows = wrapper.findAll(".vh-invocation-activities > li");
+
+    expect(rows.at(-2)?.classes()).toContain("vh-invocation-work");
+    expect(rows.at(-1)?.attributes("data-activity-id")).toBe("trace-truncated");
+  });
+
   it("renders grouped delivery outcomes, reaction intents, and truncation honestly", () => {
     const timestamp = "2026-08-24T00:00:00.000Z";
     const event = (sequence: number, attributes: Record<string, unknown>) => ({

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -107,6 +107,9 @@ describe("Agent Invocation UI", () => {
     });
     const wrapper = mount(AgentInvocation, { props: { invocation } });
     expect(wrapper.text()).toContain("Trace content was truncated");
+    const inspector = mount(AgentInvocationInspector, { props: { invocation } });
+    const metrics = inspector.findAll(".vh-invocation-inspector__metrics > div");
+    expect(metrics.find(metric => metric.get("dt").text() === "Steps")?.get("dd").text()).toBe("1");
   });
 
   it("renders only HTTP source URLs as links", () => {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -62,7 +62,22 @@ describe("Agent Invocation UI", () => {
       updatedAt: timestamp,
     } satisfies AgentInvocationView;
 
-    expect(invocationActivities(invocation).every(activity => activity.truncated)).toBe(true);
+    const activities = invocationActivities(invocation);
+    expect(activities.slice(0, -1).every(activity => activity.truncated === undefined)).toBe(true);
+    expect(activities.at(-1)).toMatchObject({
+      id: "trace-truncated",
+      kind: "system",
+      name: "vitehub.observation.truncated",
+      sequence: 2,
+      status: "completed",
+    });
+    expect(invocationActivities({
+      ...invocation,
+      observations: [],
+      observationsTruncated: true,
+    })).toEqual([
+      expect.objectContaining({ id: "trace-truncated", kind: "system", sequence: 0 }),
+    ]);
   });
 
   it("discloses bounded ordinary observations", () => {
@@ -82,9 +97,16 @@ describe("Agent Invocation UI", () => {
       updatedAt: timestamp,
     } satisfies AgentInvocationView;
 
-    expect(invocationActivities(invocation)).toEqual([
-      expect.objectContaining({ truncated: true }),
-    ]);
+    const activities = invocationActivities(invocation);
+    expect(activities).toHaveLength(2);
+    expect(activities[0]).not.toHaveProperty("truncated");
+    expect(activities[1]).toMatchObject({
+      id: "trace-truncated",
+      kind: "system",
+      name: "vitehub.observation.truncated",
+    });
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    expect(wrapper.text()).toContain("Trace content was truncated");
   });
 
   it("renders only HTTP source URLs as links", () => {
@@ -1234,7 +1256,7 @@ describe("Agent Invocation UI", () => {
     expect(wrapper.find(".vh-invocation-preparation__context a").exists()).toBe(false);
     expect(wrapper.get(".vh-invocation-preparation__context").text()).toContain("PR #1040");
     expect(wrapper.get(".vh-invocation-preparation__body").text()).toBe("Workspace checkout failed");
-    expect(wrapper.get(".vh-invocation-preparation__steps .vh-invocation-event__notice").text()).toContain("truncated");
+    expect(wrapper.get('[data-activity-id="trace-truncated"] .vh-invocation-event__title').text()).toBe("Trace content was truncated");
   });
 
   it("preserves input transcript order when the latest user has no response", () => {
@@ -1302,7 +1324,7 @@ describe("Agent Invocation UI", () => {
       ["🎉", "hooray"],
       ["😕", "confused"],
     ]);
-    expect(wrapper.get(".vh-invocation-event__notice").text()).toContain("truncated");
+    expect(wrapper.get('[data-activity-id="trace-truncated"] .vh-invocation-event__title').text()).toBe("Trace content was truncated");
   });
 
   it("exposes grouped lifecycle failures", () => {


### PR DESCRIPTION
## Summary

- render invocation-journal truncation as its own terminal system activity
- stop marking an arbitrary message, preparation step, or delivery event as truncated
- preserve ordering and cover empty, trace-level, and observation-level truncation

## Verification

- full `@vite-hub/ui` suite: 114 passed
- focused affected rendering tests: 4 passed
- `corepack pnpm --filter @vite-hub/ui typecheck`
- package build/publint passed as the test prerequisite

## Visual QA

The system-activity rendering is covered in happy-dom against the existing Console component. The collaborative browser preview is unavailable in this environment, so no live browser screenshot was captured.