### PR TITLE
feat(console): configure invocation database URL

### DIFF
--- a/docs/content/docs/development/console.md
+++ b/docs/content/docs/development/console.md
@@ -130,6 +130,13 @@ Set `VITEHUB_CONSOLE_DATABASE_URL` when the journal belongs on another volume or
 VITEHUB_CONSOLE_DATABASE_URL=file:/var/lib/my-app/console.sqlite
 ```
 
+Authenticated libSQL endpoints also require `VITEHUB_CONSOLE_DATABASE_AUTH_TOKEN`:
+
+```dotenv [.env]
+VITEHUB_CONSOLE_DATABASE_URL=libsql://my-database.turso.io
+VITEHUB_CONSOLE_DATABASE_AUTH_TOKEN=secret-token
+```
+
 The journal has no automatic TTL or deletion. In production, the operator must define how long to retain the file and how to remove records that may contain sensitive data.
 
 The fallback applies only when an Agent Definition does not configure `invocations`. An explicit `defineAgent({ invocations })` store remains authoritative, and its sessions are not copied into `console.sqlite` or read by the built-in Console.

--- a/docs/content/docs/development/console.md
+++ b/docs/content/docs/development/console.md
@@ -124,6 +124,12 @@ Read [Auth](/docs/server-primitives/auth#authorize-access-routes) for sign-in re
 
 The Console installs a fallback Agent Invocation journal at `.vitehub/data/console.sqlite`. It retains invocation records and selected searchable text, including prompts, messages, final text, and progress updates.
 
+Set `VITEHUB_CONSOLE_DATABASE_URL` when the journal belongs on another volume or libSQL endpoint. Relative `file:` paths resolve from the ViteHub project root:
+
+```dotenv [.env]
+VITEHUB_CONSOLE_DATABASE_URL=file:/var/lib/my-app/console.sqlite
+```
+
 The journal has no automatic TTL or deletion. In production, the operator must define how long to retain the file and how to remove records that may contain sensitive data.
 
 The fallback applies only when an Agent Definition does not configure `invocations`. An explicit `defineAgent({ invocations })` store remains authoritative, and its sessions are not copied into `console.sqlite` or read by the built-in Console.

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -34,7 +34,7 @@ export function resolveConsoleDatabaseOptions(projectRoot: string): ConsoleDatab
 
   const filePath = url.startsWith("file://")
     ? fileURLToPath(url)
-    : resolve(projectRoot, url.slice("file:".length))
+    : resolve(projectRoot, decodeURIComponent(url.slice("file:".length)))
   mkdirSync(dirname(filePath), { recursive: true })
   return { url: pathToFileURL(filePath).href }
 }

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -30,14 +30,14 @@ export function resolveConsoleDatabaseOptions(projectRoot: string): ConsoleDatab
   const configuredUrl = process.env.VITEHUB_CONSOLE_DATABASE_URL?.trim()
   const url = configuredUrl || `file:${resolve(projectRoot, ".vitehub/data/console.sqlite")}`
   const authToken = process.env.VITEHUB_CONSOLE_DATABASE_AUTH_TOKEN
-  if (!url.startsWith("file:")) return { ...(authToken ? { authToken } : {}), url }
+  if (!/^file:/i.test(url)) return { ...(authToken ? { authToken } : {}), url }
 
   const fragmentIndex = url.indexOf("#")
   const urlWithoutFragment = fragmentIndex === -1 ? url : url.slice(0, fragmentIndex)
   const queryIndex = urlWithoutFragment.indexOf("?")
   const fileUrl = queryIndex === -1 ? urlWithoutFragment : urlWithoutFragment.slice(0, queryIndex)
   const query = queryIndex === -1 ? "" : urlWithoutFragment.slice(queryIndex)
-  const isAbsoluteFileUrl = fileUrl.startsWith("file:/")
+  const isAbsoluteFileUrl = /^file:\//i.test(fileUrl)
   const relativeFilePath = isAbsoluteFileUrl
     ? undefined
     : decodeURIComponent(fileUrl.slice("file:".length))

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -1,5 +1,6 @@
 import { mkdirSync } from "node:fs"
 import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
 
 import { createLibsqlAgentInvocationStore } from "@vite-hub/agent/invocations/sqlite"
 import { defineAgentInvocations } from "@vite-hub/agent/server"
@@ -20,14 +21,22 @@ export function getConsoleInvocations(): AgentInvocations {
   return invocations
 }
 
-function consoleDatabaseUrl(projectRoot: string): string {
+interface ConsoleDatabaseOptions {
+  authToken?: string
+  url: string
+}
+
+export function resolveConsoleDatabaseOptions(projectRoot: string): ConsoleDatabaseOptions {
   const configuredUrl = process.env.VITEHUB_CONSOLE_DATABASE_URL?.trim()
   const url = configuredUrl || `file:${resolve(projectRoot, ".vitehub/data/console.sqlite")}`
-  if (!url.startsWith("file:")) return url
+  const authToken = process.env.VITEHUB_CONSOLE_DATABASE_AUTH_TOKEN
+  if (!url.startsWith("file:")) return { ...(authToken ? { authToken } : {}), url }
 
-  const filePath = resolve(projectRoot, url.slice("file:".length))
+  const filePath = url.startsWith("file://")
+    ? fileURLToPath(url)
+    : resolve(projectRoot, url.slice("file:".length))
   mkdirSync(dirname(filePath), { recursive: true })
-  return `file:${filePath}`
+  return { url: `file:${filePath}` }
 }
 
 export function createConsoleInvocations(projectRoot: string): AgentInvocations {
@@ -39,9 +48,7 @@ export function createConsoleInvocations(projectRoot: string): AgentInvocations 
       "result.text",
       "vitehub.activity.progress",
     ],
-    store: createLibsqlAgentInvocationStore({
-      url: consoleDatabaseUrl(projectRoot),
-    }),
+    store: createLibsqlAgentInvocationStore(resolveConsoleDatabaseOptions(projectRoot)),
   })
 }
 

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -1,5 +1,5 @@
 import { mkdirSync } from "node:fs"
-import { resolve } from "node:path"
+import { dirname, resolve } from "node:path"
 
 import { createLibsqlAgentInvocationStore } from "@vite-hub/agent/invocations/sqlite"
 import { defineAgentInvocations } from "@vite-hub/agent/server"
@@ -20,9 +20,17 @@ export function getConsoleInvocations(): AgentInvocations {
   return invocations
 }
 
+function consoleDatabaseUrl(projectRoot: string): string {
+  const configuredUrl = process.env.VITEHUB_CONSOLE_DATABASE_URL?.trim()
+  const url = configuredUrl || `file:${resolve(projectRoot, ".vitehub/data/console.sqlite")}`
+  if (!url.startsWith("file:")) return url
+
+  const filePath = resolve(projectRoot, url.slice("file:".length))
+  mkdirSync(dirname(filePath), { recursive: true })
+  return `file:${filePath}`
+}
+
 export function createConsoleInvocations(projectRoot: string): AgentInvocations {
-  const dataDirectory = resolve(projectRoot, ".vitehub/data")
-  mkdirSync(dataDirectory, { recursive: true })
   return defineAgentInvocations({
     metadataContent: [
       "input.messages",
@@ -32,7 +40,7 @@ export function createConsoleInvocations(projectRoot: string): AgentInvocations 
       "vitehub.activity.progress",
     ],
     store: createLibsqlAgentInvocationStore({
-      url: `file:${resolve(dataDirectory, "console.sqlite")}`,
+      url: consoleDatabaseUrl(projectRoot),
     }),
   })
 }

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -31,12 +31,16 @@ export function resolveConsoleDatabaseOptions(projectRoot: string): ConsoleDatab
   const url = configuredUrl || `file:${resolve(projectRoot, ".vitehub/data/console.sqlite")}`
   const authToken = process.env.VITEHUB_CONSOLE_DATABASE_AUTH_TOKEN
   if (!url.startsWith("file:")) return { ...(authToken ? { authToken } : {}), url }
+  if (url.startsWith("file::memory:")) return { url }
 
-  const filePath = url.startsWith("file://")
-    ? fileURLToPath(url)
-    : resolve(projectRoot, decodeURIComponent(url.slice("file:".length)))
+  const queryIndex = url.indexOf("?")
+  const fileUrl = queryIndex === -1 ? url : url.slice(0, queryIndex)
+  const query = queryIndex === -1 ? "" : url.slice(queryIndex)
+  const filePath = fileUrl.startsWith("file://")
+    ? fileURLToPath(fileUrl)
+    : resolve(projectRoot, decodeURIComponent(fileUrl.slice("file:".length)))
   mkdirSync(dirname(filePath), { recursive: true })
-  return { url: pathToFileURL(filePath).href }
+  return { url: `${pathToFileURL(filePath).href}${query}` }
 }
 
 export function createConsoleInvocations(projectRoot: string): AgentInvocations {

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -37,11 +37,12 @@ export function resolveConsoleDatabaseOptions(projectRoot: string): ConsoleDatab
   const queryIndex = urlWithoutFragment.indexOf("?")
   const fileUrl = queryIndex === -1 ? urlWithoutFragment : urlWithoutFragment.slice(0, queryIndex)
   const query = queryIndex === -1 ? "" : urlWithoutFragment.slice(queryIndex)
-  const relativeFilePath = fileUrl.startsWith("file://")
+  const isAbsoluteFileUrl = fileUrl.startsWith("file:/")
+  const relativeFilePath = isAbsoluteFileUrl
     ? undefined
     : decodeURIComponent(fileUrl.slice("file:".length))
   if (relativeFilePath === ":memory:") return { url: urlWithoutFragment }
-  const filePath = fileUrl.startsWith("file://")
+  const filePath = isAbsoluteFileUrl
     ? fileURLToPath(fileUrl)
     : resolve(projectRoot, relativeFilePath!)
   mkdirSync(dirname(filePath), { recursive: true })

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -33,9 +33,11 @@ export function resolveConsoleDatabaseOptions(projectRoot: string): ConsoleDatab
   if (!url.startsWith("file:")) return { ...(authToken ? { authToken } : {}), url }
   if (url.startsWith("file::memory:")) return { url }
 
-  const queryIndex = url.indexOf("?")
-  const fileUrl = queryIndex === -1 ? url : url.slice(0, queryIndex)
-  const query = queryIndex === -1 ? "" : url.slice(queryIndex)
+  const fragmentIndex = url.indexOf("#")
+  const urlWithoutFragment = fragmentIndex === -1 ? url : url.slice(0, fragmentIndex)
+  const queryIndex = urlWithoutFragment.indexOf("?")
+  const fileUrl = queryIndex === -1 ? urlWithoutFragment : urlWithoutFragment.slice(0, queryIndex)
+  const query = queryIndex === -1 ? "" : urlWithoutFragment.slice(queryIndex)
   const filePath = fileUrl.startsWith("file://")
     ? fileURLToPath(fileUrl)
     : resolve(projectRoot, decodeURIComponent(fileUrl.slice("file:".length)))

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -31,16 +31,19 @@ export function resolveConsoleDatabaseOptions(projectRoot: string): ConsoleDatab
   const url = configuredUrl || `file:${resolve(projectRoot, ".vitehub/data/console.sqlite")}`
   const authToken = process.env.VITEHUB_CONSOLE_DATABASE_AUTH_TOKEN
   if (!url.startsWith("file:")) return { ...(authToken ? { authToken } : {}), url }
-  if (url.startsWith("file::memory:")) return { url }
 
   const fragmentIndex = url.indexOf("#")
   const urlWithoutFragment = fragmentIndex === -1 ? url : url.slice(0, fragmentIndex)
   const queryIndex = urlWithoutFragment.indexOf("?")
   const fileUrl = queryIndex === -1 ? urlWithoutFragment : urlWithoutFragment.slice(0, queryIndex)
   const query = queryIndex === -1 ? "" : urlWithoutFragment.slice(queryIndex)
+  const relativeFilePath = fileUrl.startsWith("file://")
+    ? undefined
+    : decodeURIComponent(fileUrl.slice("file:".length))
+  if (relativeFilePath === ":memory:") return { url: urlWithoutFragment }
   const filePath = fileUrl.startsWith("file://")
     ? fileURLToPath(fileUrl)
-    : resolve(projectRoot, decodeURIComponent(fileUrl.slice("file:".length)))
+    : resolve(projectRoot, relativeFilePath!)
   mkdirSync(dirname(filePath), { recursive: true })
   return { url: `${pathToFileURL(filePath).href}${query}` }
 }

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -1,6 +1,6 @@
 import { mkdirSync } from "node:fs"
 import { dirname, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 import { createLibsqlAgentInvocationStore } from "@vite-hub/agent/invocations/sqlite"
 import { defineAgentInvocations } from "@vite-hub/agent/server"
@@ -36,7 +36,7 @@ export function resolveConsoleDatabaseOptions(projectRoot: string): ConsoleDatab
     ? fileURLToPath(url)
     : resolve(projectRoot, url.slice("file:".length))
   mkdirSync(dirname(filePath), { recursive: true })
-  return { url: `file:${filePath}` }
+  return { url: pathToFileURL(filePath).href }
 }
 
 export function createConsoleInvocations(projectRoot: string): AgentInvocations {

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -814,6 +814,21 @@ describe("Agent invocation console", () => {
     await expect(createConsoleInvocations(process.cwd()).list()).resolves.toMatchObject({ invocations: [] })
   })
 
+  it("recognizes percent-encoded in-memory Console database URLs", () => {
+    const databaseUrl = "file:%3Amemory%3A?cache=shared"
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", databaseUrl)
+
+    expect(resolveConsoleDatabaseOptions(process.cwd())).toEqual({ url: databaseUrl })
+  })
+
+  it("resolves Console database paths that begin with the in-memory name", () => {
+    const projectRoot = join(tmpdir(), "vitehub-console-memory-prefix-project")
+    const databasePath = join(projectRoot, ":memory:backup.sqlite")
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", "file::memory:backup.sqlite")
+
+    expect(resolveConsoleDatabaseOptions(projectRoot)).toEqual({ url: pathToFileURL(databasePath).href })
+  })
+
   it("configures the Console database authentication token", () => {
     vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", "libsql://console.example.com")
     vi.stubEnv("VITEHUB_CONSOLE_DATABASE_AUTH_TOKEN", "console-token")

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -2,7 +2,8 @@ import { existsSync } from "node:fs"
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { createRequire } from "node:module"
 import { tmpdir } from "node:os"
-import { join, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
 import { runInNewContext } from "node:vm"
 
 import { H3 } from "h3"
@@ -14,7 +15,7 @@ import { consoleInvocationsKey, consoleInvocationsRegistryKey, consoleInvocation
 import { serializeConsoleRefresh } from "../src/console/refresh.ts"
 import agentsHandler from "../src/console/runtime/server/agents.get.ts"
 import { installConsoleAgentDefinitions, installConsoleAgents } from "../src/console/runtime/server/agents.ts"
-import { createConsoleInvocations, installConsoleInvocations } from "../src/console/runtime/server/invocations.ts"
+import { createConsoleInvocations, installConsoleInvocations, resolveConsoleDatabaseOptions } from "../src/console/runtime/server/invocations.ts"
 import invocationsHandler from "../src/console/runtime/server/invocations.get.ts"
 import consolePageHandler from "../src/console/runtime/server/page.get.ts"
 import { assertConsoleRequest } from "../src/console/runtime/server/request.ts"
@@ -749,6 +750,32 @@ describe("Agent invocation console", () => {
       await rm(projectRoot, { force: true, recursive: true })
       await rm(unrelatedCwd, { force: true, recursive: true })
     }
+  })
+
+  it("preserves absolute Console database file URLs", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "vitehub-console-file-url-project-"))
+    const databasePath = join(await mkdtemp(join(tmpdir(), "vitehub-console-file-url-data-")), "console.sqlite")
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", pathToFileURL(databasePath).href)
+    try {
+      await createConsoleInvocations(projectRoot).list()
+
+      expect(existsSync(databasePath)).toBe(true)
+      expect(existsSync(join(projectRoot, "console.sqlite"))).toBe(false)
+    }
+    finally {
+      await rm(projectRoot, { force: true, recursive: true })
+      await rm(dirname(databasePath), { force: true, recursive: true })
+    }
+  })
+
+  it("configures the Console database authentication token", () => {
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", "libsql://console.example.com")
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_AUTH_TOKEN", "console-token")
+
+    expect(resolveConsoleDatabaseOptions(process.cwd())).toEqual({
+      authToken: "console-token",
+      url: "libsql://console.example.com",
+    })
   })
 
   it("preserves progress summaries in the console journal", async () => {

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -796,6 +796,23 @@ describe("Agent invocation console", () => {
     })
   })
 
+  it("resolves Console database file URL schemes case-insensitively", () => {
+    const projectRoot = join(tmpdir(), "vitehub-console-uppercase-scheme-project")
+    const relativeDatabasePath = join(projectRoot, "data/invocations.sqlite")
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", "FILE:data/invocations.sqlite")
+
+    expect(resolveConsoleDatabaseOptions(projectRoot)).toEqual({
+      url: pathToFileURL(relativeDatabasePath).href,
+    })
+
+    const absoluteDatabasePath = join(tmpdir(), "vitehub-console-uppercase-scheme", "console.sqlite")
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", pathToFileURL(absoluteDatabasePath).href.replace("file:", "FILE:"))
+
+    expect(resolveConsoleDatabaseOptions(projectRoot)).toEqual({
+      url: pathToFileURL(absoluteDatabasePath).href,
+    })
+  })
+
   it("preserves query parameters on configured Console database file URLs", () => {
     const projectRoot = join(tmpdir(), "vitehub-console-query-project")
     const databasePath = join(projectRoot, "data/invocations.sqlite")

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -754,9 +754,11 @@ describe("Agent invocation console", () => {
 
   it("preserves absolute Console database file URLs", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "vitehub-console-file-url-project-"))
-    const databasePath = join(await mkdtemp(join(tmpdir(), "vitehub-console-file-url-data-")), "console.sqlite")
-    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", pathToFileURL(databasePath).href)
+    const databasePath = join(await mkdtemp(join(tmpdir(), "vitehub-console-file-url-data-")), "console #1.sqlite")
+    const databaseUrl = pathToFileURL(databasePath).href
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", databaseUrl)
     try {
+      expect(resolveConsoleDatabaseOptions(projectRoot)).toEqual({ url: databaseUrl })
       await createConsoleInvocations(projectRoot).list()
 
       expect(existsSync(databasePath)).toBe(true)

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -796,6 +796,16 @@ describe("Agent invocation console", () => {
     })
   })
 
+  it("excludes fragments from configured relative Console database file paths", () => {
+    const projectRoot = join(tmpdir(), "vitehub-console-fragment-project")
+    const databasePath = join(projectRoot, "data/invocations.sqlite")
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", "file:data/invocations.sqlite?mode=rwc#journal")
+
+    expect(resolveConsoleDatabaseOptions(projectRoot)).toEqual({
+      url: `${pathToFileURL(databasePath).href}?mode=rwc`,
+    })
+  })
+
   it("preserves configured in-memory Console database URLs", async () => {
     const databaseUrl = "file::memory:?cache=shared"
     vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", databaseUrl)

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -786,6 +786,16 @@ describe("Agent invocation console", () => {
     }
   })
 
+  it("recognizes one-slash absolute Console database file URLs", () => {
+    const databasePath = join(tmpdir(), "vitehub-console-one-slash", "console.sqlite")
+    const databaseUrl = pathToFileURL(databasePath).href.replace("file:///", "file:/")
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", databaseUrl)
+
+    expect(resolveConsoleDatabaseOptions(join(tmpdir(), "vitehub-console-project"))).toEqual({
+      url: pathToFileURL(databasePath).href,
+    })
+  })
+
   it("preserves query parameters on configured Console database file URLs", () => {
     const projectRoot = join(tmpdir(), "vitehub-console-query-project")
     const databasePath = join(projectRoot, "data/invocations.sqlite")

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -60,6 +60,7 @@ afterEach(() => {
   Reflect.deleteProperty(process, consoleInvocationsKey)
   Reflect.deleteProperty(process, consoleInvocationsRootKey)
   Reflect.deleteProperty(process, consoleInvocationsRegistryKey)
+  vi.unstubAllEnvs()
   vi.unstubAllGlobals()
   vi.restoreAllMocks()
 })
@@ -725,6 +726,24 @@ describe("Agent invocation console", () => {
       expect(agent.invocations).toBe(writer)
       expect(existsSync(join(projectRoot, ".vitehub/data/console.sqlite"))).toBe(true)
       expect(existsSync(join(unrelatedCwd, ".vitehub/data/console.sqlite"))).toBe(false)
+    }
+    finally {
+      await rm(projectRoot, { force: true, recursive: true })
+      await rm(unrelatedCwd, { force: true, recursive: true })
+    }
+  })
+
+  it("uses the configured Console database path relative to the project root", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "vitehub-console-configured-project-"))
+    const unrelatedCwd = await mkdtemp(join(tmpdir(), "vitehub-console-configured-cwd-"))
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", "file:data/invocations.sqlite")
+    vi.spyOn(process, "cwd").mockReturnValue(unrelatedCwd)
+    try {
+      await createConsoleInvocations(projectRoot).list()
+
+      expect(existsSync(join(projectRoot, "data/invocations.sqlite"))).toBe(true)
+      expect(existsSync(join(projectRoot, ".vitehub/data/console.sqlite"))).toBe(false)
+      expect(existsSync(join(unrelatedCwd, "data/invocations.sqlite"))).toBe(false)
     }
     finally {
       await rm(projectRoot, { force: true, recursive: true })

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -786,6 +786,24 @@ describe("Agent invocation console", () => {
     }
   })
 
+  it("preserves query parameters on configured Console database file URLs", () => {
+    const projectRoot = join(tmpdir(), "vitehub-console-query-project")
+    const databasePath = join(projectRoot, "data/invocations.sqlite")
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", "file:data/invocations.sqlite?mode=rwc")
+
+    expect(resolveConsoleDatabaseOptions(projectRoot)).toEqual({
+      url: `${pathToFileURL(databasePath).href}?mode=rwc`,
+    })
+  })
+
+  it("preserves configured in-memory Console database URLs", async () => {
+    const databaseUrl = "file::memory:?cache=shared"
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", databaseUrl)
+
+    expect(resolveConsoleDatabaseOptions(process.cwd())).toEqual({ url: databaseUrl })
+    await expect(createConsoleInvocations(process.cwd()).list()).resolves.toMatchObject({ invocations: [] })
+  })
+
   it("configures the Console database authentication token", () => {
     vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", "libsql://console.example.com")
     vi.stubEnv("VITEHUB_CONSOLE_DATABASE_AUTH_TOKEN", "console-token")

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -752,6 +752,22 @@ describe("Agent invocation console", () => {
     }
   })
 
+  it("decodes configured relative Console database file URLs", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "vitehub-console-encoded-project-"))
+    vi.stubEnv("VITEHUB_CONSOLE_DATABASE_URL", "file:data/my%20journal%231.sqlite")
+    try {
+      const databasePath = join(projectRoot, "data/my journal#1.sqlite")
+      expect(resolveConsoleDatabaseOptions(projectRoot)).toEqual({ url: pathToFileURL(databasePath).href })
+      await createConsoleInvocations(projectRoot).list()
+
+      expect(existsSync(databasePath)).toBe(true)
+      expect(existsSync(join(projectRoot, "data/my%20journal%231.sqlite"))).toBe(false)
+    }
+    finally {
+      await rm(projectRoot, { force: true, recursive: true })
+    }
+  })
+
   it("preserves absolute Console database file URLs", async () => {
     const projectRoot = await mkdtemp(join(tmpdir(), "vitehub-console-file-url-project-"))
     const databasePath = join(await mkdtemp(join(tmpdir(), "vitehub-console-file-url-data-")), "console #1.sqlite")


### PR DESCRIPTION
## Summary

- add `VITEHUB_CONSOLE_DATABASE_URL` for the fallback Console invocation journal
- resolve configured `file:` paths from the ViteHub project root and create their parent directory
- preserve non-file libSQL URLs and document the deployment setting

## Verification

- `corepack pnpm --filter vite-hub test -- console.test.ts` (37 tests, no type errors)
- ViteHub package build and publint completed through the test prerequisite