### PR TITLE
feat(console): add usage dashboard

### DIFF
--- a/docs/content/docs/development/console.md
+++ b/docs/content/docs/development/console.md
@@ -199,7 +199,7 @@ The Console API accepts `GET` requests only. Responses set `Cache-Control: no-st
 
 ## Inspect usage
 
-Open **Usage** in the Console sidebar to inspect provider-reported tokens and cost across the past 24 hours, 7 days, 30 days, or 90 days. The dashboard groups completed Agent Invocations by time and model. A warning appears when the bounded journal scan reaches 10,000 records, so partial totals are never presented as complete.
+Open **Usage** in the Console sidebar to inspect provider-reported tokens and cost across the past 24 hours, 7 days, 30 days, or 90 days. The dashboard groups completed Agent Invocations by time and model. A warning appears when the bounded journal scan reaches 10,000 records or a recorded finish event is truncated, so partial totals are never presented as complete.
 
 Session details also show the normalized usage record for one invocation. Add the [Usage Capability](/docs/capabilities/usage) when the provider needs an explicit usage request or the Agent must expose the normalized Agent Usage Record at finish. Providers that report usage without the Capability still appear because the recorded finish event is authoritative.
 

--- a/docs/content/docs/development/console.md
+++ b/docs/content/docs/development/console.md
@@ -199,7 +199,9 @@ The Console API accepts `GET` requests only. Responses set `Cache-Control: no-st
 
 ## Inspect usage
 
-Session details show recorded token totals when the invocation trace contains provider usage. Add the [Usage Capability](/docs/capabilities/usage) when the provider needs an explicit usage request or the Agent must expose the normalized Agent Usage Record at finish.
+Open **Usage** in the Console sidebar to inspect provider-reported tokens and cost across the past 24 hours, 7 days, 30 days, or 90 days. The dashboard groups completed Agent Invocations by time and model. A warning appears when the bounded journal scan reaches 10,000 records, so partial totals are never presented as complete.
+
+Session details also show the normalized usage record for one invocation. Add the [Usage Capability](/docs/capabilities/usage) when the provider needs an explicit usage request or the Agent must expose the normalized Agent Usage Record at finish. Providers that report usage without the Capability still appear because the recorded finish event is authoritative.
 
 The Console does not calculate missing provider data. Token counts, model metadata, and provider-reported cost remain absent when the provider does not report them.
 

--- a/packages/vite-hub/src/console/runtime/client/main.js
+++ b/packages/vite-hub/src/console/runtime/client/main.js
@@ -39,6 +39,7 @@ const router = createRouter({
         apiBase: "/api/_vitehub/console/invocations",
         searchBase: "/api/_vitehub/console/search",
         sectionsBase,
+        usageBase: "/api/_vitehub/console/usage",
       },
     },
     {
@@ -51,6 +52,7 @@ const router = createRouter({
         apiBase: "/api/_vitehub/console/invocations",
         searchBase: "/api/_vitehub/console/search",
         sectionsBase,
+        usageBase: "/api/_vitehub/console/usage",
       },
     },
     {
@@ -76,6 +78,19 @@ const router = createRouter({
         sectionsBase,
       },
     },
+    {
+      component: ConsoleApp,
+      name: "vitehub-console-usage",
+      path: "/usage",
+      meta: { consoleSection: "usage", title: "Usage · ViteHub Console" },
+      props: {
+        agentsBase: "/api/_vitehub/console/agents",
+        apiBase: "/api/_vitehub/console/invocations",
+        searchBase: "/api/_vitehub/console/search",
+        sectionsBase,
+        usageBase: "/api/_vitehub/console/usage",
+      },
+    },
   ],
 });
 
@@ -91,5 +106,4 @@ router.beforeEach(async (to) => {
 router.afterEach((to) => {
   document.title = String(to.meta.title ?? "ViteHub Console");
 });
-
 createApp(App).use(router).use(ui).use(createViteHubUI()).mount("#app");

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -376,8 +376,11 @@ watch(selectedInvocationId, () => {
   selectedActivityId.value = undefined;
 });
 
+watch(isUsageRoute, (usageRoute) => {
+  rememberConsoleSection(usageRoute ? "usage" : "agents");
+}, { immediate: true });
+
 onMounted(() => {
-  rememberConsoleSection("agents");
   media = window.matchMedia("(min-width: 1280px)");
   updateDesktop();
   media.addEventListener("change", updateDesktop);

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -29,6 +29,8 @@ import ConsoleBackButton from "./console-back-button.vue";
 import ConsoleFrame from "./console-frame.vue";
 import ConsoleMark from "./console-mark.vue";
 import ConsoleSearch from "./console-search.vue";
+import ConsoleUsage from "./console-usage.vue";
+import ConsoleUsageSummary from "./console-usage-summary.vue";
 
 const route = useRoute();
 const router = useRouter();
@@ -37,6 +39,7 @@ const props = defineProps<{
   apiBase: string;
   searchBase: string;
   sectionsBase: string;
+  usageBase: string;
 }>();
 const initialAgentParam = decodeAgentRouteParam(route.params.agent);
 const selectedInvocationId = ref<string>();
@@ -108,6 +111,7 @@ const routeInvocation = computed(() => {
 const routeAgent = computed(() => {
   return decodeAgentRouteParam(route.params.agent);
 });
+const isUsageRoute = computed(() => route.name === resolveConsoleRouteName(route.name, "vitehub-console-usage"));
 const selectedSummary = computed(() =>
   list.invocations.value.find((invocation) => invocation.id === selectedInvocationId.value),
 );
@@ -146,6 +150,7 @@ const selectedProject = computed(() =>
 const selectedExternalUrl = computed(() =>
   selectedDisplay.value ? agentInvocationExternalUrl(selectedDisplay.value) : undefined,
 );
+const invocationUsage = computed(() => record(invocationView.value)?.usage);
 const splitterItems: SplitterItem[] = [
   {
     id: "thread",
@@ -229,6 +234,20 @@ async function selectAgent(name: string): Promise<void> {
   });
 }
 
+async function toggleUsage(): Promise<void> {
+  sessionsOpen.value = false;
+  if (isUsageRoute.value) {
+    await router.push(selectedAgentName.value
+      ? {
+          name: resolveConsoleRouteName(route.name, "vitehub-console-agent"),
+          params: { agent: encodeAgentRouteParam(selectedAgentName.value) },
+        }
+      : { name: resolveConsoleRouteName(route.name, "vitehub-console-agents") });
+    return;
+  }
+  await router.push({ name: resolveConsoleRouteName(route.name, "vitehub-console-usage") });
+}
+
 async function loadAgents(): Promise<void> {
   agentsRequest?.abort();
   const controller = new AbortController();
@@ -301,8 +320,12 @@ function updatePageVisibility(): void {
 }
 
 watch(
-  [routeInvocation, routeAgent, () => list.invocations.value[0]?.id, selectedAgentName],
-  async ([requestedInvocation, requestedAgent, firstInvocation, agentName]) => {
+  [routeInvocation, routeAgent, () => list.invocations.value[0]?.id, selectedAgentName, isUsageRoute],
+  async ([requestedInvocation, requestedAgent, firstInvocation, agentName, usageRoute]) => {
+    if (usageRoute) {
+      selectedInvocationId.value = undefined;
+      return;
+    }
     const agentRouteReady = !requestedAgent || requestedAgent === agentName;
     selectedInvocationId.value =
       requestedInvocation || (agentRouteReady ? firstInvocation : undefined);
@@ -317,8 +340,9 @@ watch(
 );
 
 watch(
-  [routeAgent, agentNames],
-  async ([requestedAgent, names]) => {
+  [routeAgent, agentNames, isUsageRoute],
+  async ([requestedAgent, names, usageRoute]) => {
+    if (usageRoute) return;
     if (!names.length) return;
     const agentName = requestedAgent && names.includes(requestedAgent) ? requestedAgent : names[0];
     selectedAgentName.value = agentName;
@@ -332,8 +356,9 @@ watch(
   { immediate: true },
 );
 
-watch([selectedAgentName, () => detail.invocation.value], async ([agentName, invocation]) => {
+watch([selectedAgentName, () => detail.invocation.value, isUsageRoute], async ([agentName, invocation, usageRoute]) => {
   if (
+    usageRoute ||
     !agentName ||
     !invocation ||
     invocation.id !== selectedInvocationId.value ||
@@ -528,17 +553,32 @@ onBeforeUnmount(() => {
       </template>
 
       <template #footer="{ collapsed, collapse }">
-        <UTooltip :text="collapsed ? 'Show sessions' : 'Hide sessions'">
-          <UButton
-            class="max-lg:hidden"
-            :icon="collapsed ? 'i-lucide-panel-left-open' : 'i-lucide-panel-left-close'"
-            color="neutral"
-            variant="ghost"
-            size="xs"
-            :aria-label="collapsed ? 'Show sessions' : 'Hide sessions'"
-            @click="collapse(!collapsed)"
-          />
-        </UTooltip>
+        <div class="flex min-w-0 items-center gap-1" :class="collapsed ? 'justify-center' : ''">
+          <UTooltip :text="isUsageRoute ? 'Back to sessions' : 'Usage'">
+            <UButton
+              :block="!collapsed"
+              :class="collapsed ? '' : 'min-w-0 flex-1 justify-start'"
+              :icon="isUsageRoute ? 'i-lucide-arrow-left' : 'i-lucide-chart-no-axes-column'"
+              :label="collapsed ? undefined : isUsageRoute ? 'Sessions' : 'Usage'"
+              color="neutral"
+              :variant="isUsageRoute ? 'soft' : 'ghost'"
+              size="xs"
+              :aria-label="isUsageRoute ? 'Back to sessions' : 'Usage'"
+              @click="toggleUsage"
+            />
+          </UTooltip>
+          <UTooltip :text="collapsed ? 'Show sessions' : 'Hide sessions'">
+            <UButton
+              class="max-lg:hidden"
+              :icon="collapsed ? 'i-lucide-panel-left-open' : 'i-lucide-panel-left-close'"
+              color="neutral"
+              variant="ghost"
+              size="xs"
+              :aria-label="collapsed ? 'Show sessions' : 'Hide sessions'"
+              @click="collapse(!collapsed)"
+            />
+          </UTooltip>
+        </div>
       </template>
     </UDashboardSidebar>
 
@@ -549,7 +589,13 @@ onBeforeUnmount(() => {
       :sections-base="sectionsBase"
     />
 
-    <UDashboardPanel id="agent-session" :ui="{ body: 'min-h-0 overflow-hidden p-0 gap-0' }">
+    <ConsoleUsage
+      v-if="isUsageRoute"
+      :base="usageBase"
+      @open-sessions="sessionsOpen = true"
+    />
+
+    <UDashboardPanel v-else id="agent-session" :ui="{ body: 'min-h-0 overflow-hidden p-0 gap-0' }">
       <template #header>
         <UDashboardNavbar
           :title="selectedTitle"
@@ -672,6 +718,9 @@ onBeforeUnmount(() => {
                   class="h-full"
                   @select-activity="selectActivity"
                 >
+                  <template v-if="invocationUsage" #metadata>
+                    <ConsoleUsageSummary :usage="invocationUsage" />
+                  </template>
                   <template #actions>
                     <UButton
                       icon="i-lucide-panel-right-close"
@@ -710,6 +759,9 @@ onBeforeUnmount(() => {
                   class="h-full"
                   @select-activity="selectActivity"
                 >
+                  <template v-if="invocationUsage" #metadata>
+                    <ConsoleUsageSummary :usage="invocationUsage" />
+                  </template>
                   <template #actions>
                     <UButton
                       icon="i-lucide-x"

--- a/packages/vite-hub/src/console/runtime/components/console-usage-summary.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-usage-summary.vue
@@ -10,7 +10,8 @@ function number(value: unknown): number | undefined {
 }
 
 function formatTokens(value: unknown): string {
-  const resolved = number(value) ?? 0
+  const resolved = number(value)
+  if (resolved === undefined) return "—"
   return new Intl.NumberFormat("en", {
     maximumFractionDigits: 1,
     notation: resolved >= 10_000 ? "compact" : "standard",

--- a/packages/vite-hub/src/console/runtime/components/console-usage-summary.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-usage-summary.vue
@@ -1,0 +1,61 @@
+<script setup lang="ts">
+import { computed } from "vue"
+
+const props = defineProps<{ usage: Record<string, unknown> }>()
+
+function number(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function formatTokens(value: unknown): string {
+  const resolved = number(value) ?? 0
+  return new Intl.NumberFormat("en", {
+    maximumFractionDigits: 1,
+    notation: resolved >= 10_000 ? "compact" : "standard",
+  }).format(resolved)
+}
+
+const cost = computed(() => {
+  const value = props.usage.cost
+  return value instanceof Object && !Array.isArray(value)
+    ? Object.fromEntries(Object.entries(value))
+    : undefined
+})
+</script>
+
+<template>
+  <section>
+    <h4>Usage</h4>
+    <dl class="grid grid-cols-2 gap-3">
+      <div>
+        <dt class="text-xs text-muted">Processed tokens</dt>
+        <dd class="mt-1 text-sm font-semibold tabular-nums">
+          {{ formatTokens(usage.totalTokens) }}
+        </dd>
+      </div>
+      <div v-if="cost">
+        <dt class="text-xs text-muted">Cost</dt>
+        <dd class="mt-1 text-sm font-semibold tabular-nums">{{ cost.display }}</dd>
+      </div>
+      <div>
+        <dt class="text-xs text-muted">Input</dt>
+        <dd class="mt-1 text-xs tabular-nums text-toned">{{ formatTokens(usage.inputTokens) }}</dd>
+      </div>
+      <div>
+        <dt class="text-xs text-muted">Output</dt>
+        <dd class="mt-1 text-xs tabular-nums text-toned">{{ formatTokens(usage.outputTokens) }}</dd>
+      </div>
+      <div v-if="number(usage.cachedInputTokens) !== undefined">
+        <dt class="text-xs text-muted">Cached input</dt>
+        <dd class="mt-1 text-xs tabular-nums text-toned">{{ formatTokens(usage.cachedInputTokens) }}</dd>
+      </div>
+      <div v-if="number(usage.reasoningTokens) !== undefined">
+        <dt class="text-xs text-muted">Reasoning</dt>
+        <dd class="mt-1 text-xs tabular-nums text-toned">{{ formatTokens(usage.reasoningTokens) }}</dd>
+      </div>
+    </dl>
+    <p v-if="cost" class="mt-3 text-[11px] leading-4 text-dimmed">
+      {{ cost.estimated === true ? "Estimated" : "Reported" }} by {{ cost.source }}
+    </p>
+  </section>
+</template>

--- a/packages/vite-hub/src/console/runtime/components/console-usage-summary.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-usage-summary.vue
@@ -11,7 +11,7 @@ function number(value: unknown): number | undefined {
 
 function formatTokens(value: unknown): string {
   const resolved = number(value)
-  if (resolved === undefined) return "—"
+  if (resolved === undefined) return "Unavailable"
   return new Intl.NumberFormat("en", {
     maximumFractionDigits: 1,
     notation: resolved >= 10_000 ? "compact" : "standard",

--- a/packages/vite-hub/src/console/runtime/components/console-usage-summary.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-usage-summary.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import { computed } from "vue"
+import * as v from "valibot"
 
 const props = defineProps<{ usage: Record<string, unknown> }>()
 
 function number(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+  const result = v.safeParse(v.pipe(v.number(), v.check(Number.isFinite)), value)
+  return result.success ? result.output : undefined
 }
 
 function formatTokens(value: unknown): string {

--- a/packages/vite-hub/src/console/runtime/components/console-usage.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-usage.vue
@@ -217,7 +217,7 @@ onBeforeUnmount(() => request?.abort())
           variant="subtle"
           icon="i-lucide-triangle-alert"
           title="Partial usage"
-          description="The journal scan or a recorded invocation hit its storage limit. Totals cover only retained usage evidence in this period."
+          description="Some usage evidence is unavailable for this period, so the totals may be incomplete."
         />
 
         <template v-if="loading && !summary">

--- a/packages/vite-hub/src/console/runtime/components/console-usage.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-usage.vue
@@ -12,6 +12,7 @@ const usageTotalsEntries = {
   cachedInputTokens: v.number(),
   cachedInputTokensAvailable: v.boolean(),
   costAvailable: v.boolean(),
+  costEstimated: v.boolean(),
   costUsd: v.string(),
   inputTokens: v.number(),
   inputTokensAvailable: v.boolean(),
@@ -83,22 +84,23 @@ function formatTokens(value: number): string {
   }).format(value)
 }
 
-function formatCost(value: string | number): string {
+function formatCost(value: string, estimated = false): string {
   const resolved = Number(value) || 0
-  if (typeof value === "string" && resolved > 0 && resolved < 0.01 && /^0\.\d+$/.test(value)) {
-    return `$${value}`
+  if (resolved > 0 && resolved < 0.01 && /^0\.\d+$/.test(value)) {
+    return `${estimated ? "~" : ""}$${value}`
   }
-  return new Intl.NumberFormat("en", {
+  const display = new Intl.NumberFormat("en", {
     currency: "USD",
     maximumFractionDigits: 2,
     minimumFractionDigits: 2,
     style: "currency",
   }).format(resolved)
+  return estimated ? `~${display}` : display
 }
 
 function formatValue(totals: UsageTotals): string {
   if (!metricAvailable(totals)) return "Unavailable"
-  return metric.value === "cost" ? formatCost(totals.costUsd) : formatTokens(totals.totalTokens)
+  return metric.value === "cost" ? formatCost(totals.costUsd, totals.costEstimated) : formatTokens(totals.totalTokens)
 }
 
 function formatPeriod(value: string, resolution: "day" | "hour"): string {
@@ -308,7 +310,7 @@ onBeforeUnmount(() => request?.abort())
                       {{ model.totalTokensAvailable ? formatTokens(model.totalTokens) : "—" }}
                     </td>
                     <td class="px-4 py-3 text-right tabular-nums sm:px-5">
-                      {{ model.costAvailable ? formatCost(model.costUsd) : "—" }}
+                      {{ model.costAvailable ? formatCost(model.costUsd, model.costEstimated) : "—" }}
                     </td>
                   </tr>
                 </tbody>

--- a/packages/vite-hub/src/console/runtime/components/console-usage.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-usage.vue
@@ -1,0 +1,295 @@
+<script setup lang="ts">
+import { computed, onBeforeUnmount, ref, watch } from "vue"
+
+import { requestConsole } from "../client/request"
+
+type UsageMetric = "cost" | "tokens"
+type UsageWindow = "24h" | "7d" | "30d" | "90d"
+type UsageTotals = {
+  cacheWriteTokens: number
+  cachedInputTokens: number
+  costUsd: string
+  inputTokens: number
+  invocations: number
+  outputTokens: number
+  reasoningTokens: number
+  totalTokens: number
+}
+type UsageModel = UsageTotals & { model: string }
+type UsageBucket = UsageTotals & { models: UsageModel[], start: string }
+type UsageSummary = {
+  available: boolean
+  buckets: UsageBucket[]
+  costAvailable: boolean
+  from: string
+  generatedAt: string
+  models: UsageModel[]
+  partial: boolean
+  resolution: "day" | "hour"
+  to: string
+  totals: UsageTotals
+}
+
+const props = defineProps<{ base: string }>()
+const emit = defineEmits<{ openSessions: [] }>()
+const window = ref<UsageWindow>("30d")
+const metric = ref<UsageMetric>("cost")
+const summary = ref<UsageSummary>()
+const loading = ref(true)
+const error = ref<unknown>()
+let request: AbortController | undefined
+
+const windowOptions: Array<{ label: string, value: UsageWindow }> = [
+  { label: "24 hours", value: "24h" },
+  { label: "7 days", value: "7d" },
+  { label: "30 days", value: "30d" },
+  { label: "90 days", value: "90d" },
+]
+const metricOptions: Array<{ label: string, value: UsageMetric }> = [
+  { label: "Cost", value: "cost" },
+  { label: "Tokens", value: "tokens" },
+]
+const value = (totals: UsageTotals): number => metric.value === "cost"
+  ? Number(totals.costUsd) || 0
+  : totals.totalTokens
+const chartMaximum = computed(() => Math.max(0, ...(summary.value?.buckets.map(value) ?? [])))
+const chartBuckets = computed(() => (summary.value?.buckets ?? []).map(bucket => ({
+  ...bucket,
+  height: chartMaximum.value ? Math.max(2, value(bucket) / chartMaximum.value * 100) : 0,
+})))
+
+function formatTokens(value: number): string {
+  return new Intl.NumberFormat("en", {
+    maximumFractionDigits: 1,
+    notation: value >= 10_000 ? "compact" : "standard",
+  }).format(value)
+}
+
+function formatCost(value: string | number): string {
+  const resolved = Number(value) || 0
+  const digits = resolved > 0 && resolved < 0.01 ? 4 : 2
+  return new Intl.NumberFormat("en", {
+    currency: "USD",
+    maximumFractionDigits: digits,
+    minimumFractionDigits: 2,
+    style: "currency",
+  }).format(resolved)
+}
+
+function formatValue(totals: UsageTotals): string {
+  return metric.value === "cost" ? formatCost(totals.costUsd) : formatTokens(totals.totalTokens)
+}
+
+function formatPeriod(value: string, resolution: "day" | "hour"): string {
+  return new Intl.DateTimeFormat("en", resolution === "hour"
+    ? { day: "numeric", hour: "numeric", month: "short" }
+    : { day: "numeric", month: "short" }).format(new Date(value))
+}
+
+function errorMessage(value: unknown): string | undefined {
+  return value instanceof Error ? value.message : value ? "Usage could not be loaded." : undefined
+}
+
+async function load(): Promise<void> {
+  request?.abort()
+  const controller = new AbortController()
+  request = controller
+  loading.value = true
+  try {
+    const result = await requestConsole(props.base, {
+      query: { window: window.value },
+      signal: controller.signal,
+    }) as UsageSummary
+    if (request !== controller) return
+    summary.value = result
+    error.value = undefined
+    if (!result.costAvailable) metric.value = "tokens"
+  }
+  catch (value) {
+    if (value instanceof Object && "name" in value && value.name === "AbortError") return
+    if (request === controller) error.value = value
+  }
+  finally {
+    if (request === controller) {
+      request = undefined
+      loading.value = false
+    }
+  }
+}
+
+watch(window, () => void load(), { immediate: true })
+onBeforeUnmount(() => request?.abort())
+</script>
+
+<template>
+  <UDashboardPanel id="console-usage" :ui="{ body: 'min-h-0 overflow-y-auto p-0 gap-0' }">
+    <template #header>
+      <UDashboardNavbar title="Usage" :ui="{ root: 'border-b border-default' }">
+        <template #right>
+          <UTooltip text="Open sessions">
+            <UButton
+              class="lg:hidden"
+              icon="i-lucide-panel-left"
+              color="neutral"
+              variant="ghost"
+              size="sm"
+              aria-label="Open sessions"
+              @click="emit('openSessions')"
+            />
+          </UTooltip>
+          <div
+            v-if="summary?.costAvailable"
+            class="inline-flex rounded-md bg-elevated p-0.5"
+            aria-label="Usage metric"
+          >
+            <UButton
+              v-for="option in metricOptions"
+              :key="option.value"
+              :label="option.label"
+              color="neutral"
+              size="xs"
+              :variant="metric === option.value ? 'solid' : 'ghost'"
+              @click="metric = option.value"
+            />
+          </div>
+          <USelect
+            v-model="window"
+            aria-label="Usage period"
+            class="w-28"
+            size="sm"
+            value-key="value"
+            :items="windowOptions"
+          />
+          <UTooltip text="Refresh usage">
+            <UButton
+              aria-label="Refresh usage"
+              color="neutral"
+              icon="i-lucide-refresh-cw"
+              size="sm"
+              variant="ghost"
+              :loading="loading"
+              @click="load"
+            />
+          </UTooltip>
+        </template>
+      </UDashboardNavbar>
+    </template>
+
+    <template #body>
+      <main class="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-8 sm:px-6 lg:py-10">
+        <UAlert
+          v-if="errorMessage(error)"
+          color="error"
+          variant="subtle"
+          icon="i-lucide-cloud-off"
+          title="Could not load usage"
+          :description="errorMessage(error)"
+          :actions="[{ label: 'Try again', icon: 'i-lucide-refresh-cw', onClick: load }]"
+        />
+        <UAlert
+          v-if="summary?.partial"
+          color="warning"
+          variant="subtle"
+          icon="i-lucide-triangle-alert"
+          title="Partial usage"
+          description="The journal scan reached 10,000 records. Totals cover the newest records in this period."
+        />
+
+        <template v-if="loading && !summary">
+          <section class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <USkeleton v-for="index in 4" :key="index" class="h-28 rounded-lg" />
+          </section>
+          <USkeleton class="h-72 rounded-lg" />
+        </template>
+
+        <UEmpty
+          v-else-if="!summary?.available"
+          class="min-h-96"
+          icon="i-lucide-chart-no-axes-column"
+          title="No usage recorded yet"
+          description="Provider-reported usage appears here after an Agent Invocation completes."
+        />
+
+        <template v-else-if="summary">
+          <section class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div class="rounded-lg border border-default bg-elevated/30 p-4">
+              <p class="text-xs text-muted">{{ metric === "cost" ? "API cost" : "Processed tokens" }}</p>
+              <p class="mt-2 text-2xl font-semibold tracking-tight tabular-nums">
+                {{ formatValue(summary.totals) }}
+              </p>
+            </div>
+            <div class="rounded-lg border border-default bg-elevated/30 p-4">
+              <p class="text-xs text-muted">Sessions</p>
+              <p class="mt-2 text-2xl font-semibold tracking-tight tabular-nums">
+                {{ formatTokens(summary.totals.invocations) }}
+              </p>
+            </div>
+            <div class="rounded-lg border border-default bg-elevated/30 p-4">
+              <p class="text-xs text-muted">Input tokens</p>
+              <p class="mt-2 text-2xl font-semibold tracking-tight tabular-nums">
+                {{ formatTokens(summary.totals.inputTokens) }}
+              </p>
+            </div>
+            <div class="rounded-lg border border-default bg-elevated/30 p-4">
+              <p class="text-xs text-muted">Output tokens</p>
+              <p class="mt-2 text-2xl font-semibold tracking-tight tabular-nums">
+                {{ formatTokens(summary.totals.outputTokens) }}
+              </p>
+            </div>
+          </section>
+
+          <section class="rounded-lg border border-default p-4 sm:p-6">
+            <div class="flex flex-wrap items-baseline justify-between gap-2">
+              <h2 class="text-sm font-semibold">
+                {{ summary.resolution === "hour" ? "Hourly" : "Daily" }} {{ metric === "cost" ? "cost" : "tokens" }}
+              </h2>
+              <p class="text-xs text-muted">
+                {{ formatPeriod(summary.from, summary.resolution) }}–{{ formatPeriod(summary.to, summary.resolution) }}
+              </p>
+            </div>
+            <div class="mt-8 flex h-56 items-end gap-px border-b border-default" aria-label="Usage over time">
+              <UTooltip
+                v-for="bucket in chartBuckets"
+                :key="bucket.start"
+                :text="`${formatPeriod(bucket.start, summary.resolution)}: ${formatValue(bucket)}`"
+              >
+                <div class="flex h-full min-w-0 flex-1 items-end">
+                  <span
+                    class="w-full rounded-t-sm bg-primary/70 transition-[height]"
+                    :style="{ height: `${bucket.height}%` }"
+                  />
+                </div>
+              </UTooltip>
+            </div>
+          </section>
+
+          <section class="overflow-hidden rounded-lg border border-default">
+            <div class="border-b border-default px-4 py-3 sm:px-5">
+              <h2 class="text-sm font-semibold">Models</h2>
+            </div>
+            <div class="overflow-x-auto">
+              <table class="w-full min-w-lg text-sm">
+                <thead class="text-left text-xs text-muted">
+                  <tr>
+                    <th class="px-4 py-3 font-medium sm:px-5">Model</th>
+                    <th class="px-4 py-3 text-right font-medium">Calls</th>
+                    <th class="px-4 py-3 text-right font-medium">Tokens</th>
+                    <th class="px-4 py-3 text-right font-medium sm:px-5">Cost</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr v-for="model in summary.models" :key="model.model" class="border-t border-default">
+                    <td class="px-4 py-3 font-medium sm:px-5">{{ model.model }}</td>
+                    <td class="px-4 py-3 text-right tabular-nums text-muted">{{ formatTokens(model.invocations) }}</td>
+                    <td class="px-4 py-3 text-right tabular-nums">{{ formatTokens(model.totalTokens) }}</td>
+                    <td class="px-4 py-3 text-right tabular-nums sm:px-5">{{ formatCost(model.costUsd) }}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </section>
+        </template>
+      </main>
+    </template>
+  </UDashboardPanel>
+</template>

--- a/packages/vite-hub/src/console/runtime/components/console-usage.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-usage.vue
@@ -85,10 +85,12 @@ function formatTokens(value: number): string {
 
 function formatCost(value: string | number): string {
   const resolved = Number(value) || 0
-  const digits = resolved > 0 && resolved < 0.01 ? 4 : 2
+  if (typeof value === "string" && resolved > 0 && resolved < 0.01 && /^0\.\d+$/.test(value)) {
+    return `$${value}`
+  }
   return new Intl.NumberFormat("en", {
     currency: "USD",
-    maximumFractionDigits: digits,
+    maximumFractionDigits: 2,
     minimumFractionDigits: 2,
     style: "currency",
   }).format(resolved)

--- a/packages/vite-hub/src/console/runtime/components/console-usage.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-usage.vue
@@ -215,7 +215,7 @@ onBeforeUnmount(() => request?.abort())
           variant="subtle"
           icon="i-lucide-triangle-alert"
           title="Partial usage"
-          description="The journal scan reached 10,000 records. Totals cover the newest records in this period."
+          description="The journal scan or a recorded invocation hit its storage limit. Totals cover only retained usage evidence in this period."
         />
 
         <template v-if="loading && !summary">

--- a/packages/vite-hub/src/console/runtime/components/console-usage.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-usage.vue
@@ -1,34 +1,49 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from "vue"
+import * as v from "valibot"
 
 import { requestConsole } from "../client/request"
 
 type UsageMetric = "cost" | "tokens"
 type UsageWindow = "24h" | "7d" | "30d" | "90d"
-type UsageTotals = {
-  cacheWriteTokens: number
-  cachedInputTokens: number
-  costUsd: string
-  inputTokens: number
-  invocations: number
-  outputTokens: number
-  reasoningTokens: number
-  totalTokens: number
+const usageTotalsEntries = {
+  cacheWriteTokens: v.number(),
+  cacheWriteTokensAvailable: v.boolean(),
+  cachedInputTokens: v.number(),
+  cachedInputTokensAvailable: v.boolean(),
+  costAvailable: v.boolean(),
+  costUsd: v.string(),
+  inputTokens: v.number(),
+  inputTokensAvailable: v.boolean(),
+  invocations: v.number(),
+  outputTokens: v.number(),
+  outputTokensAvailable: v.boolean(),
+  reasoningTokens: v.number(),
+  reasoningTokensAvailable: v.boolean(),
+  totalTokens: v.number(),
+  totalTokensAvailable: v.boolean(),
 }
-type UsageModel = UsageTotals & { model: string }
-type UsageBucket = UsageTotals & { models: UsageModel[], start: string }
-type UsageSummary = {
-  available: boolean
-  buckets: UsageBucket[]
-  costAvailable: boolean
-  from: string
-  generatedAt: string
-  models: UsageModel[]
-  partial: boolean
-  resolution: "day" | "hour"
-  to: string
-  totals: UsageTotals
-}
+const usageTotalsSchema = v.object(usageTotalsEntries)
+const usageModelSchema = v.object({ ...usageTotalsEntries, model: v.string() })
+const usageBucketSchema = v.object({
+  ...usageTotalsEntries,
+  models: v.array(usageModelSchema),
+  start: v.string(),
+})
+const usageSummarySchema = v.object({
+  available: v.boolean(),
+  buckets: v.array(usageBucketSchema),
+  costAvailable: v.boolean(),
+  from: v.string(),
+  generatedAt: v.string(),
+  models: v.array(usageModelSchema),
+  partial: v.boolean(),
+  resolution: v.picklist(["day", "hour"]),
+  to: v.string(),
+  totals: usageTotalsSchema,
+})
+type UsageTotals = v.InferOutput<typeof usageTotalsSchema>
+type UsageSummary = v.InferOutput<typeof usageSummarySchema>
 
 const props = defineProps<{ base: string }>()
 const emit = defineEmits<{ openSessions: [] }>()
@@ -49,9 +64,12 @@ const metricOptions: Array<{ label: string, value: UsageMetric }> = [
   { label: "Cost", value: "cost" },
   { label: "Tokens", value: "tokens" },
 ]
-const value = (totals: UsageTotals): number => metric.value === "cost"
-  ? Number(totals.costUsd) || 0
-  : totals.totalTokens
+const metricAvailable = (totals: UsageTotals): boolean => metric.value === "cost"
+  ? totals.costAvailable
+  : totals.totalTokensAvailable
+const value = (totals: UsageTotals): number => metricAvailable(totals)
+  ? metric.value === "cost" ? Number(totals.costUsd) || 0 : totals.totalTokens
+  : 0
 const chartMaximum = computed(() => Math.max(0, ...(summary.value?.buckets.map(value) ?? [])))
 const chartBuckets = computed(() => (summary.value?.buckets ?? []).map(bucket => ({
   ...bucket,
@@ -77,6 +95,7 @@ function formatCost(value: string | number): string {
 }
 
 function formatValue(totals: UsageTotals): string {
+  if (!metricAvailable(totals)) return "Unavailable"
   return metric.value === "cost" ? formatCost(totals.costUsd) : formatTokens(totals.totalTokens)
 }
 
@@ -95,11 +114,13 @@ async function load(): Promise<void> {
   const controller = new AbortController()
   request = controller
   loading.value = true
+  summary.value = undefined
+  error.value = undefined
   try {
-    const result = await requestConsole(props.base, {
+    const result = v.parse(usageSummarySchema, await requestConsole(props.base, {
       query: { window: window.value },
       signal: controller.signal,
-    }) as UsageSummary
+    }))
     if (request !== controller) return
     summary.value = result
     error.value = undefined
@@ -227,13 +248,13 @@ onBeforeUnmount(() => request?.abort())
             <div class="rounded-lg border border-default bg-elevated/30 p-4">
               <p class="text-xs text-muted">Input tokens</p>
               <p class="mt-2 text-2xl font-semibold tracking-tight tabular-nums">
-                {{ formatTokens(summary.totals.inputTokens) }}
+                {{ summary.totals.inputTokensAvailable ? formatTokens(summary.totals.inputTokens) : "—" }}
               </p>
             </div>
             <div class="rounded-lg border border-default bg-elevated/30 p-4">
               <p class="text-xs text-muted">Output tokens</p>
               <p class="mt-2 text-2xl font-semibold tracking-tight tabular-nums">
-                {{ formatTokens(summary.totals.outputTokens) }}
+                {{ summary.totals.outputTokensAvailable ? formatTokens(summary.totals.outputTokens) : "—" }}
               </p>
             </div>
           </section>
@@ -281,8 +302,12 @@ onBeforeUnmount(() => request?.abort())
                   <tr v-for="model in summary.models" :key="model.model" class="border-t border-default">
                     <td class="px-4 py-3 font-medium sm:px-5">{{ model.model }}</td>
                     <td class="px-4 py-3 text-right tabular-nums text-muted">{{ formatTokens(model.invocations) }}</td>
-                    <td class="px-4 py-3 text-right tabular-nums">{{ formatTokens(model.totalTokens) }}</td>
-                    <td class="px-4 py-3 text-right tabular-nums sm:px-5">{{ formatCost(model.costUsd) }}</td>
+                    <td class="px-4 py-3 text-right tabular-nums">
+                      {{ model.totalTokensAvailable ? formatTokens(model.totalTokens) : "—" }}
+                    </td>
+                    <td class="px-4 py-3 text-right tabular-nums sm:px-5">
+                      {{ model.costAvailable ? formatCost(model.costUsd) : "—" }}
+                    </td>
                   </tr>
                 </tbody>
               </table>

--- a/packages/vite-hub/src/console/runtime/components/console-usage.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-usage.vue
@@ -17,6 +17,7 @@ const usageTotalsEntries = {
   inputTokens: v.number(),
   inputTokensAvailable: v.boolean(),
   invocations: v.number(),
+  invocationsAvailable: v.boolean(),
   outputTokens: v.number(),
   outputTokensAvailable: v.boolean(),
   reasoningTokens: v.number(),
@@ -228,7 +229,7 @@ onBeforeUnmount(() => request?.abort())
         </template>
 
         <UEmpty
-          v-else-if="!summary?.available"
+          v-else-if="!error && !summary?.available"
           class="min-h-96"
           icon="i-lucide-chart-no-axes-column"
           title="No usage recorded yet"
@@ -246,7 +247,7 @@ onBeforeUnmount(() => request?.abort())
             <div class="rounded-lg border border-default bg-elevated/30 p-4">
               <p class="text-xs text-muted">Sessions</p>
               <p class="mt-2 text-2xl font-semibold tracking-tight tabular-nums">
-                {{ formatTokens(summary.totals.invocations) }}
+                {{ summary.totals.invocationsAvailable ? formatTokens(summary.totals.invocations) : "—" }}
               </p>
             </div>
             <div class="rounded-lg border border-default bg-elevated/30 p-4">
@@ -305,7 +306,9 @@ onBeforeUnmount(() => request?.abort())
                 <tbody>
                   <tr v-for="model in summary.models" :key="model.model" class="border-t border-default">
                     <td class="px-4 py-3 font-medium sm:px-5">{{ model.model }}</td>
-                    <td class="px-4 py-3 text-right tabular-nums text-muted">{{ formatTokens(model.invocations) }}</td>
+                    <td class="px-4 py-3 text-right tabular-nums text-muted">
+                      {{ model.invocationsAvailable ? formatTokens(model.invocations) : "—" }}
+                    </td>
                     <td class="px-4 py-3 text-right tabular-nums">
                       {{ model.totalTokensAvailable ? formatTokens(model.totalTokens) : "—" }}
                     </td>

--- a/packages/vite-hub/src/console/runtime/console-route.ts
+++ b/packages/vite-hub/src/console/runtime/console-route.ts
@@ -11,7 +11,7 @@ export function resolveConsoleRouteName(currentRouteName: string | symbol | null
   // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Vue Router defines route names as strings or symbols; only host-decorated string names can carry a suffix.
   if (typeof currentRouteName !== "string") return targetRouteName
 
-  const consoleRouteName = ["vitehub-console-invocation", "vitehub-console-agents", "vitehub-console-agent", "vitehub-console-kv", "vitehub-console"].find(
+  const consoleRouteName = ["vitehub-console-invocation", "vitehub-console-agents", "vitehub-console-agent", "vitehub-console-usage", "vitehub-console-kv", "vitehub-console"].find(
     (routeName) => currentRouteName.startsWith(routeName),
   )
 

--- a/packages/vite-hub/src/console/runtime/pages/agents.vue
+++ b/packages/vite-hub/src/console/runtime/pages/agents.vue
@@ -1,12 +1,17 @@
 <script setup lang="ts">
 import { useHead, useRuntimeConfig } from "#imports";
+import { computed } from "vue";
+import { useRoute } from "vue-router";
 
 import ConsoleApp from "../components/console-app.vue";
 import ConsoleProvider from "../components/console-provider.vue";
 
 const appBaseURL = useRuntimeConfig().app.baseURL.replace(/\/+$/, "");
+const route = useRoute();
 
-useHead({ title: "Agents · ViteHub Console" });
+useHead({ title: computed(() => route.name?.toString().startsWith("vitehub-console-usage")
+  ? "Usage · ViteHub Console"
+  : "Agents · ViteHub Console") });
 </script>
 
 <template>
@@ -17,6 +22,7 @@ useHead({ title: "Agents · ViteHub Console" });
         :api-base="`${appBaseURL}/api/_vitehub/console/invocations`"
         :search-base="`${appBaseURL}/api/_vitehub/console/search`"
         :sections-base="`${appBaseURL}/api/_vitehub/console/sections`"
+        :usage-base="`${appBaseURL}/api/_vitehub/console/usage`"
       />
     </ConsoleProvider>
     <template #fallback>

--- a/packages/vite-hub/src/console/runtime/sections.ts
+++ b/packages/vite-hub/src/console/runtime/sections.ts
@@ -1,4 +1,4 @@
-export const consoleSectionIds = ["agents", "kv"] as const
+export const consoleSectionIds = ["agents", "usage", "kv"] as const
 
 export type ConsoleSectionId = (typeof consoleSectionIds)[number]
 
@@ -8,6 +8,12 @@ export const consoleSectionDetails = {
     icon: "i-lucide-bot",
     label: "Agents",
     routeName: "vitehub-console-agents",
+  },
+  usage: {
+    description: "Review token use and cost evidence over time.",
+    icon: "i-lucide-chart-no-axes-combined",
+    label: "Usage",
+    routeName: "vitehub-console-usage",
   },
   kv: {
     description: "Inspect configured KV stores without changing data.",
@@ -34,7 +40,7 @@ export function isConsoleSectionId(value: unknown): value is ConsoleSectionId {
 }
 
 export function resolveConsoleSectionIds(options: { agent?: unknown; kv?: unknown }): ConsoleSectionId[] {
-  return [...(options.agent ? ["agents" as const] : []), ...(options.kv ? ["kv" as const] : [])]
+  return [...(options.agent ? ["agents" as const, "usage" as const] : []), ...(options.kv ? ["kv" as const] : [])]
 }
 
 export function prioritizeConsoleSectionIds(

--- a/packages/vite-hub/src/console/runtime/server/invocation.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocation.get.ts
@@ -1,12 +1,13 @@
 import { getConsoleInvocations } from "./invocations.ts"
 import { assertConsoleRequest, consoleRequestURL } from "./request.ts"
+import { invocationUsage } from "./usage.ts"
 
 import type { ConsoleRequestEvent } from "./request.ts"
 import type { AgentInvocationSummary } from "@vite-hub/agent"
 import type { TraceEventLogEntry } from "@vite-hub/runtime"
 
 interface ConsoleInvocationDetail {
-  invocation: AgentInvocationSummary
+  invocation: AgentInvocationSummary & { usage?: ReturnType<typeof invocationUsage> }
   observations: readonly TraceEventLogEntry[]
 }
 
@@ -22,7 +23,8 @@ const invocationHandler: (event: ConsoleRequestEvent) => Promise<ConsoleInvocati
     })
   }
   const { observations, ...summary } = invocation
-  return { invocation: summary, observations }
+  const usage = invocationUsage(invocation)
+  return { invocation: { ...summary, ...(usage ? { usage } : {}) }, observations }
 }
 
 export default invocationHandler

--- a/packages/vite-hub/src/console/runtime/server/usage.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.get.ts
@@ -1,0 +1,47 @@
+import { getConsoleInvocations } from "./invocations.ts"
+import { assertConsoleRequest, consoleRequestURL } from "./request.ts"
+import { createUsageSummary } from "./usage.ts"
+
+import type { ConsoleUsageWindow } from "./usage.ts"
+import type { ConsoleRequestEvent } from "./request.ts"
+import type { AgentInvocations } from "@vite-hub/agent"
+
+const caches = new WeakMap<AgentInvocations, Map<string, { expiresAt: number, value: Promise<Record<string, unknown>> }>>()
+
+function cached(
+  invocations: AgentInvocations,
+  key: string,
+  resolve: () => Promise<Record<string, unknown>>,
+): Promise<Record<string, unknown>> {
+  const cache = caches.get(invocations) ?? new Map()
+  caches.set(invocations, cache)
+  const now = Date.now()
+  const current = cache.get(key)
+  if (current && current.expiresAt > now) return current.value
+  const value = Promise.resolve().then(resolve).catch((error) => {
+    if (cache.get(key)?.value === value) cache.delete(key)
+    throw error
+  })
+  cache.set(key, { expiresAt: now + 5_000, value })
+  return value
+}
+
+const usageHandler = async (event: ConsoleRequestEvent): Promise<Record<string, unknown>> => {
+  assertConsoleRequest(event)
+  const query = consoleRequestURL(event).searchParams
+  const agentName = query.get("agent")?.trim() || undefined
+  if (agentName && agentName.length > 512) {
+    throw Object.assign(new Error("Invalid Agent name"), {
+      statusCode: 400,
+      statusMessage: "Invalid Agent name",
+    })
+  }
+  const window = (query.get("window") || "30d") as ConsoleUsageWindow
+  const invocations = getConsoleInvocations()
+  return cached(invocations, `${agentName || "*"}:${window}`, () => createUsageSummary(
+    invocations,
+    { agentName, window },
+  ))
+}
+
+export default usageHandler

--- a/packages/vite-hub/src/console/runtime/server/usage.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.get.ts
@@ -15,6 +15,9 @@ function cached(
   const cache = caches.get(invocations) ?? new Map()
   caches.set(invocations, cache)
   const now = Date.now()
+  for (const [cachedKey, entry] of cache) {
+    if (entry.expiresAt <= now) cache.delete(cachedKey)
+  }
   const current = cache.get(key)
   if (current && current.expiresAt > now) return current.value
   const value = Promise.resolve().then(resolve).catch((error) => {
@@ -44,7 +47,7 @@ const usageHandler = async (event: ConsoleRequestEvent): Promise<Record<string, 
     })
   }
   const invocations = getConsoleInvocations()
-  return cached(invocations, `${agentName || "*"}:${window}`, () => createUsageSummary(
+  return cached(invocations, JSON.stringify([agentName ?? null, window]), () => createUsageSummary(
     invocations,
     { agentName, window },
   ))

--- a/packages/vite-hub/src/console/runtime/server/usage.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.get.ts
@@ -1,8 +1,7 @@
 import { getConsoleInvocations } from "./invocations.ts"
 import { assertConsoleRequest, consoleRequestURL } from "./request.ts"
-import { createUsageSummary } from "./usage.ts"
+import { createUsageSummary, parseConsoleUsageWindow } from "./usage.ts"
 
-import type { ConsoleUsageWindow } from "./usage.ts"
 import type { ConsoleRequestEvent } from "./request.ts"
 import type { AgentInvocations } from "@vite-hub/agent"
 
@@ -36,7 +35,14 @@ const usageHandler = async (event: ConsoleRequestEvent): Promise<Record<string, 
       statusMessage: "Invalid Agent name",
     })
   }
-  const window = (query.get("window") || "30d") as ConsoleUsageWindow
+  const windowValue = query.get("window")
+  const window = windowValue === null ? "30d" : parseConsoleUsageWindow(windowValue)
+  if (!window) {
+    throw Object.assign(new Error("Invalid usage window"), {
+      statusCode: 400,
+      statusMessage: "Invalid usage window",
+    })
+  }
   const invocations = getConsoleInvocations()
   return cached(invocations, `${agentName || "*"}:${window}`, () => createUsageSummary(
     invocations,

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -1,4 +1,5 @@
 import type { AgentInvocationRecord, AgentInvocations } from "@vite-hub/agent"
+import * as v from "valibot"
 
 export interface ConsoleUsageCost {
   display: string
@@ -25,25 +26,38 @@ interface UsageWindow {
 }
 
 interface UsageTotal {
+  cacheWriteTokensAvailable: boolean
   cacheWriteTokens: number
+  cachedInputTokensAvailable: boolean
   cachedInputTokens: number
   costAvailable: boolean
   costUnits: bigint
+  inputTokensAvailable: boolean
   inputTokens: number
   invocations: number
+  outputTokensAvailable: boolean
   outputTokens: number
+  reasoningTokensAvailable: boolean
   reasoningTokens: number
+  totalTokensAvailable: boolean
   totalTokens: number
 }
 
 interface PublicUsageTotals {
+  cacheWriteTokensAvailable: boolean
   cacheWriteTokens: number
+  cachedInputTokensAvailable: boolean
   cachedInputTokens: number
+  costAvailable: boolean
   costUsd: string
+  inputTokensAvailable: boolean
   inputTokens: number
   invocations: number
+  outputTokensAvailable: boolean
   outputTokens: number
+  reasoningTokensAvailable: boolean
   reasoningTokens: number
+  totalTokensAvailable: boolean
   totalTokens: number
 }
 
@@ -56,9 +70,15 @@ const usageWindows: Record<ConsoleUsageWindow, UsageWindow> = {
   "90d": { bucket: "day", durationMs: 90 * 24 * 60 * 60 * 1_000 },
 }
 
+export function parseConsoleUsageWindow(value: string): ConsoleUsageWindow | undefined {
+  if (value === "24h" || value === "7d" || value === "30d" || value === "90d") return value
+}
+
 const decimalPlaces = 18
 const decimalScale = 10n ** BigInt(decimalPlaces)
 const maximumUsageRecords = 10_000
+const finiteNumberSchema = v.pipe(v.number(), v.check(Number.isFinite), v.minValue(0))
+const stringSchema = v.string()
 
 function object(value: unknown): Record<string, unknown> | undefined {
   return value instanceof Object && !Array.isArray(value)
@@ -67,7 +87,8 @@ function object(value: unknown): Record<string, unknown> | undefined {
 }
 
 function finiteNumber(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined
+  const result = v.safeParse(finiteNumberSchema, value)
+  return result.success ? result.output : undefined
 }
 
 function detailNumber(details: unknown, ...keys: string[]): number | undefined {
@@ -79,11 +100,16 @@ function detailNumber(details: unknown, ...keys: string[]): number | undefined {
   }
 }
 
-function decimalUnits(value: unknown): bigint | undefined {
-  if (typeof value !== "string" || !/^\d+(?:\.\d+)?$/.test(value)) return
+function decimalUnits(value: string | undefined): bigint | undefined {
+  if (!value || !/^\d+(?:\.\d+)?$/.test(value)) return
   const [whole, fraction = ""] = value.split(".")
   const padded = `${fraction}${"0".repeat(decimalPlaces)}`.slice(0, decimalPlaces)
   return BigInt(whole!) * decimalScale + BigInt(padded)
+}
+
+function stringValue(value: unknown): string | undefined {
+  const result = v.safeParse(stringSchema, value)
+  return result.success ? result.output : undefined
 }
 
 function decimalString(value: bigint): string {
@@ -95,17 +121,18 @@ function decimalString(value: bigint): string {
   return fraction ? `${whole}.${fraction}` : whole.toString()
 }
 
+function allPresent<T>(values: Array<T | undefined>): values is T[] {
+  return values.every(value => value !== undefined)
+}
+
 function sumNumber(values: Array<number | undefined>): number | undefined {
-  const present = values.filter((value): value is number => value !== undefined)
-  return present.length ? present.reduce((total, value) => total + value, 0) : undefined
+  if (!values.length || !allPresent(values)) return
+  return values.reduce((total, value) => total + value, 0)
 }
 
 function sumCost(values: Array<ConsoleUsageCost | undefined>): ConsoleUsageCost | undefined {
-  const units = values.flatMap((value) => {
-    const resolved = decimalUnits(value?.usd)
-    return resolved === undefined ? [] : [resolved]
-  })
-  if (!units.length) return
+  const units = values.map(value => decimalUnits(value?.usd))
+  if (!units.length || !allPresent(units)) return
   const total = units.reduce((sum, value) => sum + value, 0n)
   const estimated = values.some(value => value?.estimated === true)
   const sources = [...new Set(values.flatMap(value => value?.source ? [value.source] : []))]
@@ -125,14 +152,15 @@ function usageNode(value: unknown, includeCalls = true): ConsoleInvocationUsage 
   const inputDetails = object(usage?.inputTokenDetails)
   const outputDetails = object(usage?.outputTokenDetails)
   const cost = object(record.cost)
-  const costUnits = decimalUnits(cost?.usd)
-  const projectedCost: ConsoleUsageCost | undefined = costUnits === undefined
+  const costUsd = stringValue(cost?.usd)
+  const costUnits = decimalUnits(costUsd)
+  const projectedCost: ConsoleUsageCost | undefined = costUnits === undefined || costUsd === undefined
     ? undefined
     : {
-        display: typeof cost?.display === "string" ? cost.display : `$${cost?.usd}`,
+        display: stringValue(cost?.display) ?? `$${costUsd}`,
         estimated: cost?.estimated === true,
-        source: typeof cost?.source === "string" ? cost.source : "provider",
-        usd: String(cost?.usd),
+        source: stringValue(cost?.source) ?? "provider",
+        usd: costUsd,
       }
   const calls = includeCalls && Array.isArray(record.calls)
     ? record.calls.flatMap((call) => {
@@ -142,14 +170,15 @@ function usageNode(value: unknown, includeCalls = true): ConsoleInvocationUsage 
     : []
   const inputTokens = finiteNumber(usage?.inputTokens)
   const outputTokens = finiteNumber(usage?.outputTokens)
+  const model = stringValue(record.model)?.trim()
   const projected: ConsoleInvocationUsage = {
-    ...(typeof record.model === "string" && record.model.trim() ? { model: record.model.trim() } : {}),
+    ...(model ? { model } : {}),
     ...(inputTokens !== undefined ? { inputTokens } : {}),
     ...(outputTokens !== undefined ? { outputTokens } : {}),
     ...(finiteNumber(usage?.totalTokens) !== undefined
       ? { totalTokens: finiteNumber(usage?.totalTokens) }
-      : inputTokens !== undefined || outputTokens !== undefined
-        ? { totalTokens: (inputTokens ?? 0) + (outputTokens ?? 0) }
+        : inputTokens !== undefined && outputTokens !== undefined
+          ? { totalTokens: inputTokens + outputTokens }
         : {}),
     ...(detailNumber(inputDetails, "cacheReadTokens", "cacheRead", "cachedInputTokens") !== undefined
       ? { cachedInputTokens: detailNumber(inputDetails, "cacheReadTokens", "cacheRead", "cachedInputTokens") }
@@ -208,42 +237,60 @@ function bucketStarts(from: string, to: string, resolution: UsageWindow["bucket"
 
 function emptyTotals(): UsageTotal {
   return {
+    cacheWriteTokensAvailable: true,
     cacheWriteTokens: 0,
+    cachedInputTokensAvailable: true,
     cachedInputTokens: 0,
-    costAvailable: false,
+    costAvailable: true,
     costUnits: 0n,
+    inputTokensAvailable: true,
     inputTokens: 0,
     invocations: 0,
+    outputTokensAvailable: true,
     outputTokens: 0,
+    reasoningTokensAvailable: true,
     reasoningTokens: 0,
+    totalTokensAvailable: true,
     totalTokens: 0,
   }
 }
 
 function addUsage(total: UsageTotal, usage: ConsoleInvocationUsage): void {
   total.invocations++
+  total.inputTokensAvailable &&= usage.inputTokens !== undefined
   total.inputTokens += usage.inputTokens ?? 0
+  total.outputTokensAvailable &&= usage.outputTokens !== undefined
   total.outputTokens += usage.outputTokens ?? 0
+  total.totalTokensAvailable &&= usage.totalTokens !== undefined
   total.totalTokens += usage.totalTokens ?? 0
+  total.cachedInputTokensAvailable &&= usage.cachedInputTokens !== undefined
   total.cachedInputTokens += usage.cachedInputTokens ?? 0
+  total.cacheWriteTokensAvailable &&= usage.cacheWriteTokens !== undefined
   total.cacheWriteTokens += usage.cacheWriteTokens ?? 0
+  total.reasoningTokensAvailable &&= usage.reasoningTokens !== undefined
   total.reasoningTokens += usage.reasoningTokens ?? 0
   const cost = decimalUnits(usage.cost?.usd)
-  if (cost !== undefined) {
-    total.costAvailable = true
-    total.costUnits += cost
-  }
+  total.costAvailable &&= cost !== undefined
+  total.costUnits += cost ?? 0n
 }
 
 function publicTotals(total: UsageTotal): PublicUsageTotals {
+  const hasUsage = total.invocations > 0
   return {
+    cacheWriteTokensAvailable: hasUsage && total.cacheWriteTokensAvailable,
     cacheWriteTokens: total.cacheWriteTokens,
+    cachedInputTokensAvailable: hasUsage && total.cachedInputTokensAvailable,
     cachedInputTokens: total.cachedInputTokens,
+    costAvailable: hasUsage && total.costAvailable,
     costUsd: decimalString(total.costUnits),
+    inputTokensAvailable: hasUsage && total.inputTokensAvailable,
     inputTokens: total.inputTokens,
     invocations: total.invocations,
+    outputTokensAvailable: hasUsage && total.outputTokensAvailable,
     outputTokens: total.outputTokens,
+    reasoningTokensAvailable: hasUsage && total.reasoningTokensAvailable,
     reasoningTokens: total.reasoningTokens,
+    totalTokensAvailable: hasUsage && total.totalTokensAvailable,
     totalTokens: total.totalTokens,
   }
 }
@@ -275,7 +322,6 @@ export async function createUsageSummary(
   let cursor: string | undefined
   let scanned = 0
   let partial = false
-  let reachedStart = false
 
   do {
     const page = await invocations.list({
@@ -286,11 +332,9 @@ export async function createUsageSummary(
     scanned += page.invocations.length
     const summaries = page.invocations.filter((summary) => {
       const timestamp = Date.parse(usageTime(summary))
-      if (Number.isFinite(timestamp) && timestamp < fromDate.valueOf()) {
-        reachedStart = true
-        return false
-      }
-      return summary.status === "completed" && timestamp <= now.valueOf()
+      return summary.status === "completed"
+        && timestamp >= fromDate.valueOf()
+        && timestamp <= now.valueOf()
     })
     const records = await Promise.all(summaries.map(summary => invocations.get(summary.id)))
     for (const record of records) {
@@ -317,8 +361,10 @@ export async function createUsageSummary(
       }
     }
     cursor = page.cursor
-    if (scanned >= maximumUsageRecords && cursor && !reachedStart) partial = true
-  } while (cursor && !reachedStart && scanned < maximumUsageRecords)
+    if (scanned >= maximumUsageRecords && cursor) partial = true
+  } while (cursor && scanned < maximumUsageRecords)
+
+  const publicTotal = publicTotals(totals)
 
   return {
     available: totals.invocations > 0,
@@ -329,7 +375,7 @@ export async function createUsageSummary(
         models: [...(bucketModels.get(start) ?? new Map<string, UsageTotal>()).entries()]
           .map(([model, modelTotal]) => ({ model, ...publicTotals(modelTotal) })),
       })),
-    costAvailable: totals.costAvailable,
+    costAvailable: publicTotal.costAvailable,
     from,
     generatedAt: new Date().toISOString(),
     models: [...models.entries()]
@@ -338,6 +384,6 @@ export async function createUsageSummary(
     partial,
     resolution: window.bucket,
     to,
-    totals: publicTotals(totals),
+    totals: publicTotal,
   }
 }

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -87,7 +87,7 @@ export function parseConsoleUsageWindow(value: string): ConsoleUsageWindow | und
 }
 
 const maximumUsageRecords = 10_000
-const finiteNumberSchema = v.pipe(v.number(), v.check(Number.isFinite), v.minValue(0))
+const finiteNumberSchema = v.pipe(v.number(), v.check((value: number) => Number.isFinite(value)), v.minValue(0))
 const stringSchema = v.string()
 
 function object(value: unknown): Record<string, unknown> | undefined {
@@ -189,7 +189,7 @@ function usageNode(value: unknown, includeCalls = true, inheritedModel?: string)
   const model = stringValue(record.model)?.trim() || inheritedModel
   const rawCalls = includeCalls && Array.isArray(record.calls) ? record.calls : []
   const directCalls = rawCalls.map(call => usageNode(call, true, model))
-  const calls = directCalls.flatMap(projected => projected?.calls?.length ? projected.calls : projected ? [projected] : [])
+  const calls = directCalls.flatMap(projected => projected?.calls?.length ? projected.calls : [projected ?? {}])
   const inputTokens = finiteNumber(usage?.inputTokens)
   const outputTokens = finiteNumber(usage?.outputTokens)
   const reasoningTokens = detailNumber(outputDetails, "reasoningTokens", "reasoningOutputTokens", "reasoning")

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -20,6 +20,11 @@ export interface ConsoleInvocationUsage {
   totalTokens?: number
 }
 
+interface InvocationUsageProjection {
+  incomplete: boolean
+  usage?: ConsoleInvocationUsage
+}
+
 interface UsageWindow {
   bucket: "day" | "hour"
   durationMs: number
@@ -220,13 +225,21 @@ function usageNode(value: unknown, includeCalls = true): ConsoleInvocationUsage 
   return Object.keys(projected).length ? projected : undefined
 }
 
-export function invocationUsage(record: AgentInvocationRecord): ConsoleInvocationUsage | undefined {
+function invocationUsageProjection(record: AgentInvocationRecord): InvocationUsageProjection {
   for (let index = record.observations.length - 1; index >= 0; index--) {
     const observation = record.observations[index]!
     if (observation.name !== "agent.invocation.finish") continue
     const usage = usageNode(observation.attributes?.["usage.record"])
-    if (usage) return usage
+    if (observation.attributes?.["vitehub.observation.truncated"] === true) {
+      return { incomplete: true }
+    }
+    if (usage) return { incomplete: false, usage }
   }
+  return { incomplete: false }
+}
+
+export function invocationUsage(record: AgentInvocationRecord): ConsoleInvocationUsage | undefined {
+  return invocationUsageProjection(record).usage
 }
 
 function bucketStart(timestamp: string, resolution: UsageWindow["bucket"]): string | undefined {
@@ -370,11 +383,13 @@ export async function createUsageSummary(
       const bucket = bucketStart(usageTime(record), window.bucket)
       if (!bucket) continue
       const bucketTotal = buckets.get(bucket) ?? emptyTotals()
-      const usage = invocationUsage(record)
+      const projection = invocationUsageProjection(record)
+      const usage = projection.usage
       if (!usage) {
         addMissingUsage(totals)
         addMissingUsage(bucketTotal)
         buckets.set(bucket, bucketTotal)
+        partial ||= projection.incomplete
         continue
       }
       recordedUsage++

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -31,7 +31,7 @@ interface UsageTotal {
   cachedInputTokensAvailable: boolean
   cachedInputTokens: number
   costAvailable: boolean
-  costUnits: bigint
+  cost: Decimal
   inputTokensAvailable: boolean
   inputTokens: number
   invocations: number
@@ -41,6 +41,11 @@ interface UsageTotal {
   reasoningTokens: number
   totalTokensAvailable: boolean
   totalTokens: number
+}
+
+interface Decimal {
+  scale: number
+  units: bigint
 }
 
 interface PublicUsageTotals {
@@ -74,8 +79,6 @@ export function parseConsoleUsageWindow(value: string): ConsoleUsageWindow | und
   if (value === "24h" || value === "7d" || value === "30d" || value === "90d") return value
 }
 
-const decimalPlaces = 18
-const decimalScale = 10n ** BigInt(decimalPlaces)
 const maximumUsageRecords = 10_000
 const finiteNumberSchema = v.pipe(v.number(), v.check(Number.isFinite), v.minValue(0))
 const stringSchema = v.string()
@@ -100,11 +103,13 @@ function detailNumber(details: unknown, ...keys: string[]): number | undefined {
   }
 }
 
-function decimalUnits(value: string | undefined): bigint | undefined {
+function decimal(value: string | undefined): Decimal | undefined {
   if (!value || !/^\d+(?:\.\d+)?$/.test(value)) return
   const [whole, fraction = ""] = value.split(".")
-  const padded = `${fraction}${"0".repeat(decimalPlaces)}`.slice(0, decimalPlaces)
-  return BigInt(whole!) * decimalScale + BigInt(padded)
+  return {
+    scale: fraction.length,
+    units: BigInt(`${whole}${fraction}`),
+  }
 }
 
 function stringValue(value: unknown): string | undefined {
@@ -112,11 +117,22 @@ function stringValue(value: unknown): string | undefined {
   return result.success ? result.output : undefined
 }
 
-function decimalString(value: bigint): string {
-  const whole = value / decimalScale
-  const fraction = (value % decimalScale)
+function addDecimal(left: Decimal, right: Decimal): Decimal {
+  const scale = Math.max(left.scale, right.scale)
+  return {
+    scale,
+    units: left.units * 10n ** BigInt(scale - left.scale)
+      + right.units * 10n ** BigInt(scale - right.scale),
+  }
+}
+
+function decimalString(value: Decimal): string {
+  if (value.scale === 0) return value.units.toString()
+  const scale = 10n ** BigInt(value.scale)
+  const whole = value.units / scale
+  const fraction = (value.units % scale)
     .toString()
-    .padStart(decimalPlaces, "0")
+    .padStart(value.scale, "0")
     .replace(/0+$/, "")
   return fraction ? `${whole}.${fraction}` : whole.toString()
 }
@@ -131,9 +147,9 @@ function sumNumber(values: Array<number | undefined>): number | undefined {
 }
 
 function sumCost(values: Array<ConsoleUsageCost | undefined>): ConsoleUsageCost | undefined {
-  const units = values.map(value => decimalUnits(value?.usd))
-  if (!units.length || !allPresent(units)) return
-  const total = units.reduce((sum, value) => sum + value, 0n)
+  const decimals = values.map(value => decimal(value?.usd))
+  if (!decimals.length || !allPresent(decimals)) return
+  const total = decimals.reduce(addDecimal, { scale: 0, units: 0n })
   const estimated = values.some(value => value?.estimated === true)
   const sources = [...new Set(values.flatMap(value => value?.source ? [value.source] : []))]
   const usd = decimalString(total)
@@ -153,8 +169,8 @@ function usageNode(value: unknown, includeCalls = true): ConsoleInvocationUsage 
   const outputDetails = object(usage?.outputTokenDetails)
   const cost = object(record.cost)
   const costUsd = stringValue(cost?.usd)
-  const costUnits = decimalUnits(costUsd)
-  const projectedCost: ConsoleUsageCost | undefined = costUnits === undefined || costUsd === undefined
+  const costValue = decimal(costUsd)
+  const projectedCost: ConsoleUsageCost | undefined = costValue === undefined || costUsd === undefined
     ? undefined
     : {
         display: stringValue(cost?.display) ?? `$${costUsd}`,
@@ -162,12 +178,9 @@ function usageNode(value: unknown, includeCalls = true): ConsoleInvocationUsage 
         source: stringValue(cost?.source) ?? "provider",
         usd: costUsd,
       }
-  const calls = includeCalls && Array.isArray(record.calls)
-    ? record.calls.flatMap((call) => {
-        const projected = usageNode(call, false)
-        return projected ? [projected] : []
-      })
-    : []
+  const rawCalls = includeCalls && Array.isArray(record.calls) ? record.calls : []
+  const directCalls = rawCalls.map(call => usageNode(call, true))
+  const calls = directCalls.flatMap(projected => projected?.calls?.length ? projected.calls : projected ? [projected] : [])
   const inputTokens = finiteNumber(usage?.inputTokens)
   const outputTokens = finiteNumber(usage?.outputTokens)
   const model = stringValue(record.model)?.trim()
@@ -192,14 +205,17 @@ function usageNode(value: unknown, includeCalls = true): ConsoleInvocationUsage 
     ...(projectedCost ? { cost: projectedCost } : {}),
     ...(calls.length ? { calls } : {}),
   }
-  if (calls.length) {
-    projected.inputTokens ??= sumNumber(calls.map(call => call.inputTokens))
-    projected.outputTokens ??= sumNumber(calls.map(call => call.outputTokens))
-    projected.totalTokens ??= sumNumber(calls.map(call => call.totalTokens))
-    projected.cachedInputTokens ??= sumNumber(calls.map(call => call.cachedInputTokens))
-    projected.cacheWriteTokens ??= sumNumber(calls.map(call => call.cacheWriteTokens))
-    projected.reasoningTokens ??= sumNumber(calls.map(call => call.reasoningTokens))
-    projected.cost ??= sumCost(calls.map(call => call.cost))
+  if (rawCalls.length && allPresent(directCalls)) {
+    const assign = <Key extends keyof ConsoleInvocationUsage>(key: Key, value: ConsoleInvocationUsage[Key]) => {
+      if (projected[key] === undefined && value !== undefined) projected[key] = value
+    }
+    assign("inputTokens", sumNumber(directCalls.map(call => call.inputTokens)))
+    assign("outputTokens", sumNumber(directCalls.map(call => call.outputTokens)))
+    assign("totalTokens", sumNumber(directCalls.map(call => call.totalTokens)))
+    assign("cachedInputTokens", sumNumber(directCalls.map(call => call.cachedInputTokens)))
+    assign("cacheWriteTokens", sumNumber(directCalls.map(call => call.cacheWriteTokens)))
+    assign("reasoningTokens", sumNumber(directCalls.map(call => call.reasoningTokens)))
+    assign("cost", sumCost(directCalls.map(call => call.cost)))
   }
   return Object.keys(projected).length ? projected : undefined
 }
@@ -242,7 +258,7 @@ function emptyTotals(): UsageTotal {
     cachedInputTokensAvailable: true,
     cachedInputTokens: 0,
     costAvailable: true,
-    costUnits: 0n,
+    cost: { scale: 0, units: 0n },
     inputTokensAvailable: true,
     inputTokens: 0,
     invocations: 0,
@@ -269,28 +285,39 @@ function addUsage(total: UsageTotal, usage: ConsoleInvocationUsage): void {
   total.cacheWriteTokens += usage.cacheWriteTokens ?? 0
   total.reasoningTokensAvailable &&= usage.reasoningTokens !== undefined
   total.reasoningTokens += usage.reasoningTokens ?? 0
-  const cost = decimalUnits(usage.cost?.usd)
+  const cost = decimal(usage.cost?.usd)
   total.costAvailable &&= cost !== undefined
-  total.costUnits += cost ?? 0n
+  if (cost) total.cost = addDecimal(total.cost, cost)
 }
 
-function publicTotals(total: UsageTotal): PublicUsageTotals {
-  const hasUsage = total.invocations > 0
+function addMissingUsage(total: UsageTotal): void {
+  total.invocations++
+  total.cacheWriteTokensAvailable = false
+  total.cachedInputTokensAvailable = false
+  total.costAvailable = false
+  total.inputTokensAvailable = false
+  total.outputTokensAvailable = false
+  total.reasoningTokensAvailable = false
+  total.totalTokensAvailable = false
+}
+
+function publicTotals(total: UsageTotal, complete = true): PublicUsageTotals {
+  const hasEvidence = total.invocations > 0 || complete
   return {
-    cacheWriteTokensAvailable: hasUsage && total.cacheWriteTokensAvailable,
+    cacheWriteTokensAvailable: hasEvidence && total.cacheWriteTokensAvailable,
     cacheWriteTokens: total.cacheWriteTokens,
-    cachedInputTokensAvailable: hasUsage && total.cachedInputTokensAvailable,
+    cachedInputTokensAvailable: hasEvidence && total.cachedInputTokensAvailable,
     cachedInputTokens: total.cachedInputTokens,
-    costAvailable: hasUsage && total.costAvailable,
-    costUsd: decimalString(total.costUnits),
-    inputTokensAvailable: hasUsage && total.inputTokensAvailable,
+    costAvailable: hasEvidence && total.costAvailable,
+    costUsd: decimalString(total.cost),
+    inputTokensAvailable: hasEvidence && total.inputTokensAvailable,
     inputTokens: total.inputTokens,
     invocations: total.invocations,
-    outputTokensAvailable: hasUsage && total.outputTokensAvailable,
+    outputTokensAvailable: hasEvidence && total.outputTokensAvailable,
     outputTokens: total.outputTokens,
-    reasoningTokensAvailable: hasUsage && total.reasoningTokensAvailable,
+    reasoningTokensAvailable: hasEvidence && total.reasoningTokensAvailable,
     reasoningTokens: total.reasoningTokens,
-    totalTokensAvailable: hasUsage && total.totalTokensAvailable,
+    totalTokensAvailable: hasEvidence && total.totalTokensAvailable,
     totalTokens: total.totalTokens,
   }
 }
@@ -320,6 +347,7 @@ export async function createUsageSummary(
   const bucketModels = new Map<string, Map<string, UsageTotal>>()
   const models = new Map<string, UsageTotal>()
   let cursor: string | undefined
+  let recordedUsage = 0
   let scanned = 0
   let partial = false
 
@@ -339,11 +367,18 @@ export async function createUsageSummary(
     const records = await Promise.all(summaries.map(summary => invocations.get(summary.id)))
     for (const record of records) {
       if (!record) continue
-      const usage = invocationUsage(record) ?? {}
       const bucket = bucketStart(usageTime(record), window.bucket)
       if (!bucket) continue
-      addUsage(totals, usage)
       const bucketTotal = buckets.get(bucket) ?? emptyTotals()
+      const usage = invocationUsage(record)
+      if (!usage) {
+        addMissingUsage(totals)
+        addMissingUsage(bucketTotal)
+        buckets.set(bucket, bucketTotal)
+        continue
+      }
+      recordedUsage++
+      addUsage(totals, usage)
       addUsage(bucketTotal, usage)
       buckets.set(bucket, bucketTotal)
       const calls = usage.calls?.length ? usage.calls : [usage]
@@ -363,14 +398,14 @@ export async function createUsageSummary(
     if (scanned >= maximumUsageRecords && cursor) partial = true
   } while (cursor && scanned < maximumUsageRecords)
 
-  const publicTotal = publicTotals(totals)
+  const publicTotal = publicTotals(totals, !partial)
 
   return {
-    available: totals.invocations > 0,
+    available: recordedUsage > 0,
     buckets: bucketStarts(from, to, window.bucket)
       .map(start => ({
         start,
-        ...publicTotals(buckets.get(start) ?? emptyTotals()),
+        ...publicTotals(buckets.get(start) ?? emptyTotals(), !partial),
         models: [...(bucketModels.get(start) ?? new Map<string, UsageTotal>()).entries()]
           .map(([model, modelTotal]) => ({ model, ...publicTotals(modelTotal) })),
       })),

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -64,6 +64,7 @@ interface PublicUsageTotals {
   costUsd: string
   inputTokensAvailable: boolean
   inputTokens: number
+  invocationsAvailable: boolean
   invocations: number
   outputTokensAvailable: boolean
   outputTokens: number
@@ -331,6 +332,7 @@ function publicTotals(total: UsageTotal, complete = true): PublicUsageTotals {
     costUsd: decimalString(total.cost),
     inputTokensAvailable: hasEvidence && total.inputTokensAvailable,
     inputTokens: total.inputTokens,
+    invocationsAvailable: complete,
     invocations: total.invocations,
     outputTokensAvailable: hasEvidence && total.outputTokensAvailable,
     outputTokens: total.outputTokens,

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -339,8 +339,7 @@ export async function createUsageSummary(
     const records = await Promise.all(summaries.map(summary => invocations.get(summary.id)))
     for (const record of records) {
       if (!record) continue
-      const usage = invocationUsage(record)
-      if (!usage) continue
+      const usage = invocationUsage(record) ?? {}
       const bucket = bucketStart(usageTime(record), window.bucket)
       if (!bucket) continue
       addUsage(totals, usage)

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -172,6 +172,7 @@ function usageNode(value: unknown, includeCalls = true): ConsoleInvocationUsage 
   const usage = object(record.usage)
   const inputDetails = object(usage?.inputTokenDetails)
   const outputDetails = object(usage?.outputTokenDetails)
+  const usageDetails = object(usage?.details)
   const cost = object(record.cost)
   const costUsd = stringValue(cost?.usd)
   const costValue = decimal(costUsd)
@@ -188,6 +189,8 @@ function usageNode(value: unknown, includeCalls = true): ConsoleInvocationUsage 
   const calls = directCalls.flatMap(projected => projected?.calls?.length ? projected.calls : projected ? [projected] : [])
   const inputTokens = finiteNumber(usage?.inputTokens)
   const outputTokens = finiteNumber(usage?.outputTokens)
+  const reasoningTokens = detailNumber(outputDetails, "reasoningTokens", "reasoningOutputTokens", "reasoning")
+    ?? detailNumber(usageDetails, "reasoningOutputTokens")
   const model = stringValue(record.model)?.trim()
   const projected: ConsoleInvocationUsage = {
     ...(model ? { model } : {}),
@@ -204,12 +207,10 @@ function usageNode(value: unknown, includeCalls = true): ConsoleInvocationUsage 
     ...(detailNumber(inputDetails, "cacheWriteTokens", "cacheWrite") !== undefined
       ? { cacheWriteTokens: detailNumber(inputDetails, "cacheWriteTokens", "cacheWrite") }
       : {}),
-    ...(detailNumber(outputDetails, "reasoningTokens", "reasoningOutputTokens", "reasoning") !== undefined
-      ? { reasoningTokens: detailNumber(outputDetails, "reasoningTokens", "reasoningOutputTokens", "reasoning") }
-      : {}),
     ...(projectedCost ? { cost: projectedCost } : {}),
     ...(calls.length ? { calls } : {}),
   }
+  if (reasoningTokens !== undefined) projected.reasoningTokens = reasoningTokens
   if (rawCalls.length && allPresent(directCalls)) {
     const assign = <Key extends keyof ConsoleInvocationUsage>(key: Key, value: ConsoleInvocationUsage[Key]) => {
       if (projected[key] === undefined && value !== undefined) projected[key] = value

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -194,6 +194,8 @@ function usageNode(value: unknown, includeCalls = true, inheritedModel?: string)
   const outputTokens = finiteNumber(usage?.outputTokens)
   const reasoningTokens = detailNumber(outputDetails, "reasoningTokens", "reasoningOutputTokens", "reasoning")
     ?? detailNumber(usageDetails, "reasoningOutputTokens")
+  const cachedInputTokens = detailNumber(inputDetails, "cacheReadTokens", "cacheRead", "cachedTokens")
+    ?? detailNumber(usageDetails, "cachedInputTokens")
   const projected: ConsoleInvocationUsage = {
     ...(model ? { model } : {}),
     ...(inputTokens !== undefined ? { inputTokens } : {}),
@@ -203,9 +205,7 @@ function usageNode(value: unknown, includeCalls = true, inheritedModel?: string)
         : inputTokens !== undefined && outputTokens !== undefined
           ? { totalTokens: inputTokens + outputTokens }
         : {}),
-    ...(detailNumber(inputDetails, "cacheReadTokens", "cacheRead", "cachedInputTokens") !== undefined
-      ? { cachedInputTokens: detailNumber(inputDetails, "cacheReadTokens", "cacheRead", "cachedInputTokens") }
-      : {}),
+    ...(cachedInputTokens !== undefined ? { cachedInputTokens } : {}),
     ...(detailNumber(inputDetails, "cacheWriteTokens", "cacheWrite") !== undefined
       ? { cacheWriteTokens: detailNumber(inputDetails, "cacheWriteTokens", "cacheWrite") }
       : {}),
@@ -369,6 +369,7 @@ export async function createUsageSummary(
   let recordedUsage = 0
   let scanned = 0
   let partial = false
+  let scanTruncated = false
 
   do {
     const page = await invocations.list({
@@ -427,25 +428,28 @@ export async function createUsageSummary(
       }
     }
     cursor = page.cursor
-    if (scanned >= maximumUsageRecords && cursor) partial = true
+    if (scanned >= maximumUsageRecords && cursor) {
+      partial = true
+      scanTruncated = true
+    }
   } while (cursor && scanned < maximumUsageRecords)
 
-  const publicTotal = publicTotals(totals, !partial)
+  const publicTotal = publicTotals(totals, !scanTruncated)
 
   return {
     available: recordedUsage > 0,
     buckets: bucketStarts(from, to, window.bucket)
       .map(start => ({
         start,
-        ...publicTotals(buckets.get(start) ?? emptyTotals(), !partial),
+        ...publicTotals(buckets.get(start) ?? emptyTotals(), !scanTruncated),
         models: [...(bucketModels.get(start) ?? new Map<string, UsageTotal>()).entries()]
-          .map(([model, modelTotal]) => ({ model, ...publicTotals(modelTotal, !partial) })),
+          .map(([model, modelTotal]) => ({ model, ...publicTotals(modelTotal, !scanTruncated) })),
       })),
     costAvailable: publicTotal.costAvailable,
     from,
     generatedAt: new Date().toISOString(),
     models: [...models.entries()]
-      .map(([model, total]) => ({ model, ...publicTotals(total, !partial) }))
+      .map(([model, total]) => ({ model, ...publicTotals(total, !scanTruncated) }))
       .sort((left, right) => right.totalTokens - left.totalTokens || left.model.localeCompare(right.model)),
     partial,
     resolution: window.bucket,

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -376,7 +376,7 @@ export async function createUsageSummary(
   do {
     const page = await invocations.list({
       ...(options.agentName ? { agentName: options.agentName } : {}),
-      ...(cursor ? { cursor } : {}),
+      ...(cursor === undefined ? {} : { cursor }),
       limit: Math.min(100, maximumUsageRecords - scanned),
       status: "completed",
     })
@@ -430,11 +430,11 @@ export async function createUsageSummary(
       }
     }
     cursor = page.cursor
-    if (scanned >= maximumUsageRecords && cursor) {
+    if (scanned >= maximumUsageRecords && cursor !== undefined) {
       partial = true
       scanTruncated = true
     }
-  } while (cursor && scanned < maximumUsageRecords)
+  } while (cursor !== undefined && scanned < maximumUsageRecords)
 
   const publicTotal = publicTotals(totals, !scanTruncated)
 

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -1,0 +1,343 @@
+import type { AgentInvocationRecord, AgentInvocations } from "@vite-hub/agent"
+
+export interface ConsoleUsageCost {
+  display: string
+  estimated: boolean
+  source: string
+  usd: string
+}
+
+export interface ConsoleInvocationUsage {
+  cacheWriteTokens?: number
+  cachedInputTokens?: number
+  calls?: ConsoleInvocationUsage[]
+  cost?: ConsoleUsageCost
+  inputTokens?: number
+  model?: string
+  outputTokens?: number
+  reasoningTokens?: number
+  totalTokens?: number
+}
+
+interface UsageWindow {
+  bucket: "day" | "hour"
+  durationMs: number
+}
+
+interface UsageTotal {
+  cacheWriteTokens: number
+  cachedInputTokens: number
+  costAvailable: boolean
+  costUnits: bigint
+  inputTokens: number
+  invocations: number
+  outputTokens: number
+  reasoningTokens: number
+  totalTokens: number
+}
+
+interface PublicUsageTotals {
+  cacheWriteTokens: number
+  cachedInputTokens: number
+  costUsd: string
+  inputTokens: number
+  invocations: number
+  outputTokens: number
+  reasoningTokens: number
+  totalTokens: number
+}
+
+export type ConsoleUsageWindow = "24h" | "7d" | "30d" | "90d"
+
+const usageWindows: Record<ConsoleUsageWindow, UsageWindow> = {
+  "24h": { bucket: "hour", durationMs: 24 * 60 * 60 * 1_000 },
+  "7d": { bucket: "day", durationMs: 7 * 24 * 60 * 60 * 1_000 },
+  "30d": { bucket: "day", durationMs: 30 * 24 * 60 * 60 * 1_000 },
+  "90d": { bucket: "day", durationMs: 90 * 24 * 60 * 60 * 1_000 },
+}
+
+const decimalPlaces = 18
+const decimalScale = 10n ** BigInt(decimalPlaces)
+const maximumUsageRecords = 10_000
+
+function object(value: unknown): Record<string, unknown> | undefined {
+  return value instanceof Object && !Array.isArray(value)
+    ? Object.fromEntries(Object.entries(value))
+    : undefined
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined
+}
+
+function detailNumber(details: unknown, ...keys: string[]): number | undefined {
+  const value = object(details)
+  if (!value) return
+  for (const key of keys) {
+    const resolved = finiteNumber(value[key])
+    if (resolved !== undefined) return resolved
+  }
+}
+
+function decimalUnits(value: unknown): bigint | undefined {
+  if (typeof value !== "string" || !/^\d+(?:\.\d+)?$/.test(value)) return
+  const [whole, fraction = ""] = value.split(".")
+  const padded = `${fraction}${"0".repeat(decimalPlaces)}`.slice(0, decimalPlaces)
+  return BigInt(whole!) * decimalScale + BigInt(padded)
+}
+
+function decimalString(value: bigint): string {
+  const whole = value / decimalScale
+  const fraction = (value % decimalScale)
+    .toString()
+    .padStart(decimalPlaces, "0")
+    .replace(/0+$/, "")
+  return fraction ? `${whole}.${fraction}` : whole.toString()
+}
+
+function sumNumber(values: Array<number | undefined>): number | undefined {
+  const present = values.filter((value): value is number => value !== undefined)
+  return present.length ? present.reduce((total, value) => total + value, 0) : undefined
+}
+
+function sumCost(values: Array<ConsoleUsageCost | undefined>): ConsoleUsageCost | undefined {
+  const units = values.flatMap((value) => {
+    const resolved = decimalUnits(value?.usd)
+    return resolved === undefined ? [] : [resolved]
+  })
+  if (!units.length) return
+  const total = units.reduce((sum, value) => sum + value, 0n)
+  const estimated = values.some(value => value?.estimated === true)
+  const sources = [...new Set(values.flatMap(value => value?.source ? [value.source] : []))]
+  const usd = decimalString(total)
+  return {
+    display: `${estimated ? "~" : ""}$${usd}`,
+    estimated,
+    source: sources.length === 1 ? sources[0]! : "mixed",
+    usd,
+  }
+}
+
+function usageNode(value: unknown, includeCalls = true): ConsoleInvocationUsage | undefined {
+  const record = object(value)
+  if (!record) return
+  const usage = object(record.usage)
+  const inputDetails = object(usage?.inputTokenDetails)
+  const outputDetails = object(usage?.outputTokenDetails)
+  const cost = object(record.cost)
+  const costUnits = decimalUnits(cost?.usd)
+  const projectedCost: ConsoleUsageCost | undefined = costUnits === undefined
+    ? undefined
+    : {
+        display: typeof cost?.display === "string" ? cost.display : `$${cost?.usd}`,
+        estimated: cost?.estimated === true,
+        source: typeof cost?.source === "string" ? cost.source : "provider",
+        usd: String(cost?.usd),
+      }
+  const calls = includeCalls && Array.isArray(record.calls)
+    ? record.calls.flatMap((call) => {
+        const projected = usageNode(call, false)
+        return projected ? [projected] : []
+      })
+    : []
+  const inputTokens = finiteNumber(usage?.inputTokens)
+  const outputTokens = finiteNumber(usage?.outputTokens)
+  const projected: ConsoleInvocationUsage = {
+    ...(typeof record.model === "string" && record.model.trim() ? { model: record.model.trim() } : {}),
+    ...(inputTokens !== undefined ? { inputTokens } : {}),
+    ...(outputTokens !== undefined ? { outputTokens } : {}),
+    ...(finiteNumber(usage?.totalTokens) !== undefined
+      ? { totalTokens: finiteNumber(usage?.totalTokens) }
+      : inputTokens !== undefined || outputTokens !== undefined
+        ? { totalTokens: (inputTokens ?? 0) + (outputTokens ?? 0) }
+        : {}),
+    ...(detailNumber(inputDetails, "cacheReadTokens", "cacheRead", "cachedInputTokens") !== undefined
+      ? { cachedInputTokens: detailNumber(inputDetails, "cacheReadTokens", "cacheRead", "cachedInputTokens") }
+      : {}),
+    ...(detailNumber(inputDetails, "cacheWriteTokens", "cacheWrite") !== undefined
+      ? { cacheWriteTokens: detailNumber(inputDetails, "cacheWriteTokens", "cacheWrite") }
+      : {}),
+    ...(detailNumber(outputDetails, "reasoningTokens", "reasoningOutputTokens", "reasoning") !== undefined
+      ? { reasoningTokens: detailNumber(outputDetails, "reasoningTokens", "reasoningOutputTokens", "reasoning") }
+      : {}),
+    ...(projectedCost ? { cost: projectedCost } : {}),
+    ...(calls.length ? { calls } : {}),
+  }
+  if (calls.length) {
+    projected.inputTokens ??= sumNumber(calls.map(call => call.inputTokens))
+    projected.outputTokens ??= sumNumber(calls.map(call => call.outputTokens))
+    projected.totalTokens ??= sumNumber(calls.map(call => call.totalTokens))
+    projected.cachedInputTokens ??= sumNumber(calls.map(call => call.cachedInputTokens))
+    projected.cacheWriteTokens ??= sumNumber(calls.map(call => call.cacheWriteTokens))
+    projected.reasoningTokens ??= sumNumber(calls.map(call => call.reasoningTokens))
+    projected.cost ??= sumCost(calls.map(call => call.cost))
+  }
+  return Object.keys(projected).length ? projected : undefined
+}
+
+export function invocationUsage(record: AgentInvocationRecord): ConsoleInvocationUsage | undefined {
+  for (let index = record.observations.length - 1; index >= 0; index--) {
+    const observation = record.observations[index]!
+    if (observation.name !== "agent.invocation.finish") continue
+    const usage = usageNode(observation.attributes?.["usage.record"])
+    if (usage) return usage
+  }
+}
+
+function bucketStart(timestamp: string, resolution: UsageWindow["bucket"]): string | undefined {
+  const date = new Date(timestamp)
+  if (!Number.isFinite(date.valueOf())) return
+  if (resolution === "hour") date.setUTCMinutes(0, 0, 0)
+  else date.setUTCHours(0, 0, 0, 0)
+  return date.toISOString()
+}
+
+function bucketStarts(from: string, to: string, resolution: UsageWindow["bucket"]): string[] {
+  const start = bucketStart(from, resolution)
+  const end = bucketStart(to, resolution)
+  if (!start || !end) return []
+  const dates: string[] = []
+  const current = new Date(start)
+  while (current.toISOString() <= end) {
+    dates.push(current.toISOString())
+    if (resolution === "hour") current.setUTCHours(current.getUTCHours() + 1)
+    else current.setUTCDate(current.getUTCDate() + 1)
+  }
+  return dates
+}
+
+function emptyTotals(): UsageTotal {
+  return {
+    cacheWriteTokens: 0,
+    cachedInputTokens: 0,
+    costAvailable: false,
+    costUnits: 0n,
+    inputTokens: 0,
+    invocations: 0,
+    outputTokens: 0,
+    reasoningTokens: 0,
+    totalTokens: 0,
+  }
+}
+
+function addUsage(total: UsageTotal, usage: ConsoleInvocationUsage): void {
+  total.invocations++
+  total.inputTokens += usage.inputTokens ?? 0
+  total.outputTokens += usage.outputTokens ?? 0
+  total.totalTokens += usage.totalTokens ?? 0
+  total.cachedInputTokens += usage.cachedInputTokens ?? 0
+  total.cacheWriteTokens += usage.cacheWriteTokens ?? 0
+  total.reasoningTokens += usage.reasoningTokens ?? 0
+  const cost = decimalUnits(usage.cost?.usd)
+  if (cost !== undefined) {
+    total.costAvailable = true
+    total.costUnits += cost
+  }
+}
+
+function publicTotals(total: UsageTotal): PublicUsageTotals {
+  return {
+    cacheWriteTokens: total.cacheWriteTokens,
+    cachedInputTokens: total.cachedInputTokens,
+    costUsd: decimalString(total.costUnits),
+    inputTokens: total.inputTokens,
+    invocations: total.invocations,
+    outputTokens: total.outputTokens,
+    reasoningTokens: total.reasoningTokens,
+    totalTokens: total.totalTokens,
+  }
+}
+
+function usageTime(record: Pick<AgentInvocationRecord, "completedAt" | "createdAt" | "updatedAt">): string {
+  return record.completedAt || record.updatedAt || record.createdAt
+}
+
+function consoleError(message: string): Error {
+  return Object.assign(new Error(message), { statusCode: 400, statusMessage: message })
+}
+
+export async function createUsageSummary(
+  invocations: AgentInvocations,
+  options: { agentName?: string, now?: Date | number | string, window?: ConsoleUsageWindow } = {},
+): Promise<Record<string, unknown>> {
+  const windowName = options.window ?? "30d"
+  const window = usageWindows[windowName]
+  if (!window) throw consoleError("Invalid usage window")
+  const now = options.now instanceof Date ? options.now : new Date(options.now ?? Date.now())
+  if (!Number.isFinite(now.valueOf())) throw consoleError("Invalid usage timestamp")
+  const to = now.toISOString()
+  const fromDate = new Date(now.valueOf() - window.durationMs)
+  const from = fromDate.toISOString()
+  const totals = emptyTotals()
+  const buckets = new Map<string, UsageTotal>()
+  const bucketModels = new Map<string, Map<string, UsageTotal>>()
+  const models = new Map<string, UsageTotal>()
+  let cursor: string | undefined
+  let scanned = 0
+  let partial = false
+  let reachedStart = false
+
+  do {
+    const page = await invocations.list({
+      ...(options.agentName ? { agentName: options.agentName } : {}),
+      ...(cursor ? { cursor } : {}),
+      limit: Math.min(100, maximumUsageRecords - scanned),
+    })
+    scanned += page.invocations.length
+    const summaries = page.invocations.filter((summary) => {
+      const timestamp = Date.parse(usageTime(summary))
+      if (Number.isFinite(timestamp) && timestamp < fromDate.valueOf()) {
+        reachedStart = true
+        return false
+      }
+      return summary.status === "completed" && timestamp <= now.valueOf()
+    })
+    const records = await Promise.all(summaries.map(summary => invocations.get(summary.id)))
+    for (const record of records) {
+      if (!record) continue
+      const usage = invocationUsage(record)
+      if (!usage) continue
+      const bucket = bucketStart(usageTime(record), window.bucket)
+      if (!bucket) continue
+      addUsage(totals, usage)
+      const bucketTotal = buckets.get(bucket) ?? emptyTotals()
+      addUsage(bucketTotal, usage)
+      buckets.set(bucket, bucketTotal)
+      const calls = usage.calls?.length ? usage.calls : [usage]
+      for (const call of calls) {
+        const model = call.model || usage.model || "Unknown model"
+        const modelTotal = models.get(model) ?? emptyTotals()
+        addUsage(modelTotal, call)
+        models.set(model, modelTotal)
+        const periodModels = bucketModels.get(bucket) ?? new Map<string, UsageTotal>()
+        const periodModelTotal = periodModels.get(model) ?? emptyTotals()
+        addUsage(periodModelTotal, call)
+        periodModels.set(model, periodModelTotal)
+        bucketModels.set(bucket, periodModels)
+      }
+    }
+    cursor = page.cursor
+    if (scanned >= maximumUsageRecords && cursor && !reachedStart) partial = true
+  } while (cursor && !reachedStart && scanned < maximumUsageRecords)
+
+  return {
+    available: totals.invocations > 0,
+    buckets: bucketStarts(from, to, window.bucket)
+      .map(start => ({
+        start,
+        ...publicTotals(buckets.get(start) ?? emptyTotals()),
+        models: [...(bucketModels.get(start) ?? new Map<string, UsageTotal>()).entries()]
+          .map(([model, modelTotal]) => ({ model, ...publicTotals(modelTotal) })),
+      })),
+    costAvailable: totals.costAvailable,
+    from,
+    generatedAt: new Date().toISOString(),
+    models: [...models.entries()]
+      .map(([model, total]) => ({ model, ...publicTotals(total) }))
+      .sort((left, right) => right.totalTokens - left.totalTokens || left.model.localeCompare(right.model)),
+    partial,
+    resolution: window.bucket,
+    to,
+    totals: publicTotals(totals),
+  }
+}

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -166,7 +166,7 @@ function sumCost(values: Array<ConsoleUsageCost | undefined>): ConsoleUsageCost 
   }
 }
 
-function usageNode(value: unknown, includeCalls = true): ConsoleInvocationUsage | undefined {
+function usageNode(value: unknown, includeCalls = true, inheritedModel?: string): ConsoleInvocationUsage | undefined {
   const record = object(value)
   if (!record) return
   const usage = object(record.usage)
@@ -184,14 +184,14 @@ function usageNode(value: unknown, includeCalls = true): ConsoleInvocationUsage 
         source: stringValue(cost?.source) ?? "provider",
         usd: costUsd,
       }
+  const model = stringValue(record.model)?.trim() || inheritedModel
   const rawCalls = includeCalls && Array.isArray(record.calls) ? record.calls : []
-  const directCalls = rawCalls.map(call => usageNode(call, true))
+  const directCalls = rawCalls.map(call => usageNode(call, true, model))
   const calls = directCalls.flatMap(projected => projected?.calls?.length ? projected.calls : projected ? [projected] : [])
   const inputTokens = finiteNumber(usage?.inputTokens)
   const outputTokens = finiteNumber(usage?.outputTokens)
   const reasoningTokens = detailNumber(outputDetails, "reasoningTokens", "reasoningOutputTokens", "reasoning")
     ?? detailNumber(usageDetails, "reasoningOutputTokens")
-  const model = stringValue(record.model)?.trim()
   const projected: ConsoleInvocationUsage = {
     ...(model ? { model } : {}),
     ...(inputTokens !== undefined ? { inputTokens } : {}),
@@ -370,6 +370,7 @@ export async function createUsageSummary(
       ...(options.agentName ? { agentName: options.agentName } : {}),
       ...(cursor ? { cursor } : {}),
       limit: Math.min(100, maximumUsageRecords - scanned),
+      status: "completed",
     })
     scanned += page.invocations.length
     const summaries = page.invocations.filter((summary) => {

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -36,6 +36,7 @@ interface UsageTotal {
   cachedInputTokensAvailable: boolean
   cachedInputTokens: number
   costAvailable: boolean
+  costEstimated: boolean
   cost: Decimal
   inputTokensAvailable: boolean
   inputTokens: number
@@ -59,6 +60,7 @@ interface PublicUsageTotals {
   cachedInputTokensAvailable: boolean
   cachedInputTokens: number
   costAvailable: boolean
+  costEstimated: boolean
   costUsd: string
   inputTokensAvailable: boolean
   inputTokens: number
@@ -272,6 +274,7 @@ function emptyTotals(): UsageTotal {
     cachedInputTokensAvailable: true,
     cachedInputTokens: 0,
     costAvailable: true,
+    costEstimated: false,
     cost: { scale: 0, units: 0n },
     inputTokensAvailable: true,
     inputTokens: 0,
@@ -301,6 +304,7 @@ function addUsage(total: UsageTotal, usage: ConsoleInvocationUsage): void {
   total.reasoningTokens += usage.reasoningTokens ?? 0
   const cost = decimal(usage.cost?.usd)
   total.costAvailable &&= cost !== undefined
+  total.costEstimated ||= usage.cost?.estimated === true
   if (cost) total.cost = addDecimal(total.cost, cost)
 }
 
@@ -323,6 +327,7 @@ function publicTotals(total: UsageTotal, complete = true): PublicUsageTotals {
     cachedInputTokensAvailable: hasEvidence && total.cachedInputTokensAvailable,
     cachedInputTokens: total.cachedInputTokens,
     costAvailable: hasEvidence && total.costAvailable,
+    costEstimated: total.costEstimated,
     costUsd: decimalString(total.cost),
     inputTokensAvailable: hasEvidence && total.inputTokensAvailable,
     inputTokens: total.inputTokens,

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -320,7 +320,7 @@ function addMissingUsage(total: UsageTotal): void {
 }
 
 function publicTotals(total: UsageTotal, complete = true): PublicUsageTotals {
-  const hasEvidence = total.invocations > 0 || complete
+  const hasEvidence = complete
   return {
     cacheWriteTokensAvailable: hasEvidence && total.cacheWriteTokensAvailable,
     cacheWriteTokens: total.cacheWriteTokens,
@@ -385,8 +385,18 @@ export async function createUsageSummary(
         && timestamp <= now.valueOf()
     })
     const records = await Promise.all(summaries.map(summary => invocations.get(summary.id)))
-    for (const record of records) {
-      if (!record) continue
+    for (const [index, record] of records.entries()) {
+      if (!record) {
+        const bucket = bucketStart(usageTime(summaries[index]!), window.bucket)
+        if (bucket) {
+          const bucketTotal = buckets.get(bucket) ?? emptyTotals()
+          addMissingUsage(totals)
+          addMissingUsage(bucketTotal)
+          buckets.set(bucket, bucketTotal)
+        }
+        partial = true
+        continue
+      }
       const bucket = bucketStart(usageTime(record), window.bucket)
       if (!bucket) continue
       const bucketTotal = buckets.get(bucket) ?? emptyTotals()
@@ -396,7 +406,7 @@ export async function createUsageSummary(
         addMissingUsage(totals)
         addMissingUsage(bucketTotal)
         buckets.set(bucket, bucketTotal)
-        partial ||= projection.incomplete
+        partial = true
         continue
       }
       recordedUsage++
@@ -429,13 +439,13 @@ export async function createUsageSummary(
         start,
         ...publicTotals(buckets.get(start) ?? emptyTotals(), !partial),
         models: [...(bucketModels.get(start) ?? new Map<string, UsageTotal>()).entries()]
-          .map(([model, modelTotal]) => ({ model, ...publicTotals(modelTotal) })),
+          .map(([model, modelTotal]) => ({ model, ...publicTotals(modelTotal, !partial) })),
       })),
     costAvailable: publicTotal.costAvailable,
     from,
     generatedAt: new Date().toISOString(),
     models: [...models.entries()]
-      .map(([model, total]) => ({ model, ...publicTotals(total) }))
+      .map(([model, total]) => ({ model, ...publicTotals(total, !partial) }))
       .sort((left, right) => right.totalTokens - left.totalTokens || left.model.localeCompare(right.model)),
     partial,
     resolution: window.bucket,

--- a/packages/vite-hub/src/console/vite.ts
+++ b/packages/vite-hub/src/console/vite.ts
@@ -308,6 +308,7 @@ export function consoleVitePlugin(options: ConsoleVitePluginOptions = {}): Plugi
                 join(consoleRuntimeRoot, "server/agents.get.js"),
                 join(consoleRuntimeRoot, "server/sections.get.js"),
                 join(consoleRuntimeRoot, "server/search.get.js"),
+                join(consoleRuntimeRoot, "server/usage.get.js"),
                 join(consoleRuntimeRoot, "server/page.get.js"),
               ].includes(handler?.handler),
           )
@@ -336,6 +337,9 @@ export function consoleVitePlugin(options: ConsoleVitePluginOptions = {}): Plugi
                 route: "/api/_vitehub/console/search",
               },
             ]
+          : []),
+        ...(sections.includes("usage")
+          ? [{ handler: join(consoleRuntimeRoot, "server/usage.get.js"), route: "/api/_vitehub/console/usage" }]
           : []),
         { handler: join(consoleRuntimeRoot, "server/page.get.js"), route: "/_vitehub" },
         { handler: join(consoleRuntimeRoot, "server/page.get.js"), route: "/_vitehub/**" },

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -362,6 +362,9 @@ async function installConsole(
             },
           ]
         : []),
+      ...(sections.includes("usage")
+        ? [{ file: join(consoleRuntimeRoot, "pages/agents.vue"), name: "vitehub-console-usage", path: "/_vitehub/usage" }]
+        : []),
       ...(sections.includes("kv")
         ? [
             {
@@ -406,6 +409,9 @@ async function installConsole(
             route: "/api/_vitehub/console/search",
           },
         ]
+      : []),
+    ...(sections.includes("usage")
+      ? [{ handler: join(consoleRuntimeRoot, "server/usage.get.js"), route: "/api/_vitehub/console/usage" }]
       : []),
   ]
   for (const handler of additions) {

--- a/packages/vite-hub/test/console-route.test.ts
+++ b/packages/vite-hub/test/console-route.test.ts
@@ -25,6 +25,8 @@ describe("Console routes", () => {
       .toBe("vitehub-console-agent___da")
     expect(resolveConsoleRouteName("vitehub-console-agent___en___default", "vitehub-console-invocation"))
       .toBe("vitehub-console-invocation___en___default")
+    expect(resolveConsoleRouteName("vitehub-console-usage___en", "vitehub-console-agent"))
+      .toBe("vitehub-console-agent___en")
     expect(resolveConsoleRouteName("vitehub-console-agent", "vitehub-console-invocation"))
       .toBe("vitehub-console-invocation")
     expect(resolveConsoleRouteName(Symbol("vitehub-console-agent"), "vitehub-console-invocation"))

--- a/packages/vite-hub/test/console-sections.test.ts
+++ b/packages/vite-hub/test/console-sections.test.ts
@@ -18,9 +18,9 @@ function memoryStorage(initial?: string) {
 
 describe("Console section preferences", () => {
   it("prioritizes the last active section without losing configured sections", () => {
-    expect(prioritizeConsoleSectionIds(["agents", "kv"], "kv")).toEqual(["kv", "agents"])
+    expect(prioritizeConsoleSectionIds(["agents", "usage", "kv"], "kv")).toEqual(["kv", "agents", "usage"])
     expect(prioritizeConsoleSectionIds(["agents"], "kv")).toEqual(["agents"])
-    expect(prioritizeConsoleSectionIds(["agents", "kv"], undefined)).toEqual(["agents", "kv"])
+    expect(prioritizeConsoleSectionIds(["agents", "usage", "kv"], undefined)).toEqual(["agents", "usage", "kv"])
   })
 
   it("persists and validates the last section", () => {

--- a/packages/vite-hub/test/console-usage.test.ts
+++ b/packages/vite-hub/test/console-usage.test.ts
@@ -114,4 +114,56 @@ describe("Console usage projection", () => {
     })
     expect(list).toHaveBeenCalledWith(expect.objectContaining({ status: "completed" }))
   })
+
+  it("marks missing usage evidence incomplete for model totals", async () => {
+    const recorded = invocationRecordFromUsageRecord({
+      model: "recorded-model",
+      usage: { totalTokens: 10 },
+    })
+    const missing = {
+      ...recorded,
+      cursor: "missing-usage",
+      id: "missing-usage",
+      observations: [],
+      traceId: "missing-usage-trace",
+    }
+    const records = new Map([[recorded.id, recorded], [missing.id, missing]])
+    const invocations = {
+      get: vi.fn(async (id: string) => records.get(id)),
+      getByRunId: vi.fn(),
+      list: vi.fn(async () => ({
+        invocations: [...records.values()].map(({ observations: _observations, ...summary }) => summary),
+      })),
+    }
+
+    // doctor-disable-next-line typescript/evidence/no-chained-type-assertions -- SAFETY: This fixture supplies the three read methods used by the usage summary.
+    await expect(createUsageSummary(invocations as unknown as Parameters<typeof createUsageSummary>[0], {
+      now: "2026-08-27T12:00:00.000Z",
+      window: "24h",
+    })).resolves.toMatchObject({
+      models: [{ model: "recorded-model", totalTokens: 10, totalTokensAvailable: false }],
+      partial: true,
+      totals: { invocations: 2, totalTokens: 10, totalTokensAvailable: false },
+    })
+  })
+
+  it("marks records that disappear after listing as incomplete", async () => {
+    const record = invocationRecord({ totalTokens: 10 })
+    const { observations: _observations, ...summary } = record
+    const invocations = {
+      get: vi.fn(async () => undefined),
+      getByRunId: vi.fn(),
+      list: vi.fn(async () => ({ invocations: [summary] })),
+    }
+
+    // doctor-disable-next-line typescript/evidence/no-chained-type-assertions -- SAFETY: This fixture supplies the three read methods used by the usage summary.
+    await expect(createUsageSummary(invocations as unknown as Parameters<typeof createUsageSummary>[0], {
+      now: "2026-08-27T12:00:00.000Z",
+      window: "24h",
+    })).resolves.toMatchObject({
+      available: false,
+      partial: true,
+      totals: { invocations: 1, totalTokensAvailable: false },
+    })
+  })
 })

--- a/packages/vite-hub/test/console-usage.test.ts
+++ b/packages/vite-hub/test/console-usage.test.ts
@@ -6,6 +6,7 @@ function invocationRecordFromUsageRecord(usageRecord: Record<string, unknown>) {
   return {
     completedAt: "2026-08-27T10:00:00.000Z",
     createdAt: "2026-08-27T10:00:00.000Z",
+    cursor: "usage-invocation",
     id: "usage-invocation",
     observations: [{
       attributes: { "usage.record": usageRecord },
@@ -55,6 +56,38 @@ describe("Console usage projection", () => {
         { model: "leaf-model", totalTokens: 6 },
       ],
       totalTokens: 10,
+    })
+  })
+
+  it("preserves raw-only calls as unavailable model evidence", async () => {
+    const record = invocationRecordFromUsageRecord({
+      calls: [
+        { model: "known-model", usage: { totalTokens: 10 } },
+        { raw: { requestId: "raw-only" } },
+      ],
+      usage: { totalTokens: 15 },
+    })
+    const { observations: _observations, ...summary } = record
+    const invocations = {
+      get: vi.fn(async () => record),
+      getByRunId: vi.fn(async () => record),
+      list: vi.fn(async () => ({ invocations: [summary] })),
+    }
+
+    expect(invocationUsage(record)).toEqual({
+      calls: [{ model: "known-model", totalTokens: 10 }, {}],
+      totalTokens: 15,
+    })
+    // doctor-disable-next-line typescript/evidence/no-chained-type-assertions -- SAFETY: This fixture supplies the three read methods used by the usage summary.
+    await expect(createUsageSummary(invocations as unknown as Parameters<typeof createUsageSummary>[0], {
+      now: "2026-08-27T12:00:00.000Z",
+      window: "24h",
+    })).resolves.toMatchObject({
+      models: expect.arrayContaining([
+        expect.objectContaining({ model: "known-model", totalTokens: 10, totalTokensAvailable: true }),
+        expect.objectContaining({ invocations: 1, model: "Unknown model", totalTokensAvailable: false }),
+      ]),
+      totals: { totalTokens: 15, totalTokensAvailable: true },
     })
   })
 

--- a/packages/vite-hub/test/console-usage.test.ts
+++ b/packages/vite-hub/test/console-usage.test.ts
@@ -115,6 +115,38 @@ describe("Console usage projection", () => {
     expect(list).toHaveBeenCalledWith(expect.objectContaining({ status: "completed" }))
   })
 
+  it("preserves empty opaque cursors while scanning usage pages", async () => {
+    const first = invocationRecord({ totalTokens: 10 })
+    const second = {
+      ...invocationRecord({ totalTokens: 20 }),
+      cursor: "second-usage",
+      id: "second-usage",
+      traceId: "second-usage-trace",
+    }
+    const records = new Map([[first.id, first], [second.id, second]])
+    const list = vi.fn(async (options?: { cursor?: string }) => ({
+      ...(options?.cursor === undefined ? { cursor: "" } : {}),
+      invocations: [options?.cursor === undefined ? first : second]
+        .map(({ observations: _observations, ...summary }) => summary),
+    }))
+    const invocations = {
+      get: vi.fn(async (id: string) => records.get(id)),
+      getByRunId: vi.fn(),
+      list,
+    }
+
+    // doctor-disable-next-line typescript/evidence/no-chained-type-assertions -- SAFETY: This fixture supplies the three read methods used by the usage summary.
+    await expect(createUsageSummary(invocations as unknown as Parameters<typeof createUsageSummary>[0], {
+      now: "2026-08-27T12:00:00.000Z",
+      window: "24h",
+    })).resolves.toMatchObject({
+      available: true,
+      partial: false,
+      totals: { invocations: 2, totalTokens: 30 },
+    })
+    expect(list).toHaveBeenNthCalledWith(2, expect.objectContaining({ cursor: "" }))
+  })
+
   it("marks missing usage evidence incomplete for model totals", async () => {
     const recorded = invocationRecordFromUsageRecord({
       model: "recorded-model",

--- a/packages/vite-hub/test/console-usage.test.ts
+++ b/packages/vite-hub/test/console-usage.test.ts
@@ -1,13 +1,14 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
-import { invocationUsage } from "../src/console/runtime/server/usage.ts"
+import { createUsageSummary, invocationUsage } from "../src/console/runtime/server/usage.ts"
 
-function invocationRecord(usage: Record<string, unknown>) {
+function invocationRecordFromUsageRecord(usageRecord: Record<string, unknown>) {
   return {
+    completedAt: "2026-08-27T10:00:00.000Z",
     createdAt: "2026-08-27T10:00:00.000Z",
     id: "usage-invocation",
     observations: [{
-      attributes: { "usage.record": { usage } },
+      attributes: { "usage.record": usageRecord },
       name: "agent.invocation.finish",
       sequence: 1,
       timestamp: "2026-08-27T10:00:00.000Z",
@@ -17,6 +18,10 @@ function invocationRecord(usage: Record<string, unknown>) {
     traceId: "usage-trace",
     updatedAt: "2026-08-27T10:00:00.000Z",
   } satisfies Parameters<typeof invocationUsage>[0]
+}
+
+function invocationRecord(usage: Record<string, unknown>) {
+  return invocationRecordFromUsageRecord({ usage })
 }
 
 describe("Console usage projection", () => {
@@ -33,5 +38,47 @@ describe("Console usage projection", () => {
       outputTokenDetails: { reasoningTokens: 0 },
       totalTokens: 10,
     }))).toEqual({ reasoningTokens: 0, totalTokens: 10 })
+  })
+
+  it("inherits the nearest compound model while flattening calls", () => {
+    expect(invocationUsage(invocationRecordFromUsageRecord({
+      calls: [{
+        calls: [
+          { usage: { totalTokens: 4 } },
+          { model: "leaf-model", usage: { totalTokens: 6 } },
+        ],
+        model: "compound-model",
+      }],
+    }))).toMatchObject({
+      calls: [
+        { model: "compound-model", totalTokens: 4 },
+        { model: "leaf-model", totalTokens: 6 },
+      ],
+      totalTokens: 10,
+    })
+  })
+
+  it("filters completed invocations before applying the scan limit", async () => {
+    const record = invocationRecord({ totalTokens: 10 })
+    const { observations: _observations, ...summary } = record
+    const list = vi.fn(async (options?: { status?: string }) => options?.status === "completed"
+      ? { invocations: [summary] }
+      : { cursor: "pending-page", invocations: [] })
+    const invocations = {
+      get: vi.fn(async () => record),
+      getByRunId: vi.fn(async () => record),
+      list,
+    }
+
+    // doctor-disable-next-line typescript/evidence/no-chained-type-assertions -- SAFETY: This fixture supplies the three read methods used by the usage summary.
+    await expect(createUsageSummary(invocations as unknown as Parameters<typeof createUsageSummary>[0], {
+      now: "2026-08-27T12:00:00.000Z",
+      window: "24h",
+    })).resolves.toMatchObject({
+      available: true,
+      partial: false,
+      totals: { invocations: 1, totalTokens: 10 },
+    })
+    expect(list).toHaveBeenCalledWith(expect.objectContaining({ status: "completed" }))
   })
 })

--- a/packages/vite-hub/test/console-usage.test.ts
+++ b/packages/vite-hub/test/console-usage.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest"
+
+import { invocationUsage } from "../src/console/runtime/server/usage.ts"
+
+function invocationRecord(usage: Record<string, unknown>) {
+  return {
+    createdAt: "2026-08-27T10:00:00.000Z",
+    id: "usage-invocation",
+    observations: [{
+      attributes: { "usage.record": { usage } },
+      name: "agent.invocation.finish",
+      sequence: 1,
+      timestamp: "2026-08-27T10:00:00.000Z",
+      type: "lifecycle" as const,
+    }],
+    status: "completed" as const,
+    traceId: "usage-trace",
+    updatedAt: "2026-08-27T10:00:00.000Z",
+  } satisfies Parameters<typeof invocationUsage>[0]
+}
+
+describe("Console usage projection", () => {
+  it("reads reasoning tokens from fallback usage details", () => {
+    expect(invocationUsage(invocationRecord({
+      details: { reasoningOutputTokens: 4 },
+      totalTokens: 10,
+    }))).toEqual({ reasoningTokens: 4, totalTokens: 10 })
+  })
+
+  it("prefers normalized output token details", () => {
+    expect(invocationUsage(invocationRecord({
+      details: { reasoningOutputTokens: 9 },
+      outputTokenDetails: { reasoningTokens: 0 },
+      totalTokens: 10,
+    }))).toEqual({ reasoningTokens: 0, totalTokens: 10 })
+  })
+})

--- a/packages/vite-hub/test/console-usage.test.ts
+++ b/packages/vite-hub/test/console-usage.test.ts
@@ -141,7 +141,7 @@ describe("Console usage projection", () => {
       now: "2026-08-27T12:00:00.000Z",
       window: "24h",
     })).resolves.toMatchObject({
-      models: [{ model: "recorded-model", totalTokens: 10, totalTokensAvailable: false }],
+      models: [{ model: "recorded-model", totalTokens: 10, totalTokensAvailable: true }],
       partial: true,
       totals: { invocations: 2, totalTokens: 10, totalTokensAvailable: false },
     })

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -448,7 +448,7 @@ describe("Agent invocation console", () => {
       const plugin = consoleVitePlugin({
         console: { exposure: "host-managed" },
         preset: "node",
-        sections: ["agents", "kv"],
+        sections: ["agents", "usage", "kv"],
       })
       const configHook = plugin.config
       if (!configHook) throw new TypeError("Expected a console config hook.")
@@ -476,7 +476,7 @@ describe("Agent invocation console", () => {
       ])
       expect(config.nitro.publicAssets).toEqual([expect.objectContaining({ baseURL: "/_vitehub/assets" })])
       expect(config.nitro.plugins).toEqual([resolve(root, ".vitehub/nitro/console/plugin.mjs")])
-      await expect(readFile(config.nitro.plugins[0]!, "utf8")).resolves.toContain(`installConsoleSections(${JSON.stringify(root)}, ["agents","kv"])`)
+      await expect(readFile(config.nitro.plugins[0]!, "utf8")).resolves.toContain(`installConsoleSections(${JSON.stringify(root)}, ["agents","usage","kv"])`)
       await expect(readFile(config.nitro.plugins[0]!, "utf8")).resolves.toContain(
         `const vitehubConsoleInvocations = installConsoleInvocations(${JSON.stringify(root)})`,
       )

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -2188,6 +2188,53 @@ describe("Agent invocation console", () => {
     })
   })
 
+  it("marks truncated finish usage incomplete", async () => {
+    const store = createMemoryAgentInvocationStore()
+    for (const [id, truncated] of [["complete", false], ["truncated", true]] as const) {
+      store.create({
+        completedAt: "2026-08-27T10:00:00.000Z",
+        createdAt: "2026-08-27T09:59:00.000Z",
+        id,
+        observations: [{
+          attributes: {
+            "usage.record": {
+              model: id,
+              usage: { inputTokens: 4, outputTokens: 6, totalTokens: 10 },
+            },
+            ...(truncated ? { "vitehub.observation.truncated": true } : {}),
+          },
+          name: "agent.invocation.finish",
+          sequence: 1,
+          timestamp: "2026-08-27T10:00:00.000Z",
+          type: "lifecycle",
+        }],
+        status: "completed",
+        traceId: `trace-${id}`,
+        updatedAt: "2026-08-27T10:00:00.000Z",
+      })
+    }
+    const invocations = defineAgentInvocations({ store })
+
+    expect(invocationUsage((await invocations.get("truncated"))!)).toBeUndefined()
+    await expect(createUsageSummary(invocations, {
+      now: "2026-08-27T12:00:00.000Z",
+      window: "24h",
+    })).resolves.toMatchObject({
+      available: true,
+      models: [expect.objectContaining({ model: "complete", totalTokens: 10 })],
+      partial: true,
+      totals: {
+        inputTokens: 4,
+        inputTokensAvailable: false,
+        invocations: 2,
+        outputTokens: 6,
+        outputTokensAvailable: false,
+        totalTokens: 10,
+        totalTokensAvailable: false,
+      },
+    })
+  })
+
   it("scans creation-ordered pages for recent completions", async () => {
     const store = createMemoryAgentInvocationStore()
     store.create({

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -44,6 +44,7 @@ import { consoleSearch } from "../src/console/runtime/server/search.ts"
 import sectionsHandler from "../src/console/runtime/server/sections.get.ts"
 import { installConsoleSections } from "../src/console/runtime/server/sections.ts"
 import { consoleInvocationRootPlugin, consoleVitePlugin, updateConsoleInvocationRootState } from "../src/console/vite.ts"
+import usageHandler from "../src/console/runtime/server/usage.get.ts"
 import { createUsageSummary, invocationUsage } from "../src/console/runtime/server/usage.ts"
 
 import { runAgent } from "@vite-hub/agent"
@@ -1997,6 +1998,16 @@ describe("Agent invocation console", () => {
       outputTokens: 12,
       totalTokens: 30,
     })
+  })
+
+  it("rejects overlong Agent filters at the usage endpoint", async () => {
+    const requestEvent = event("127.0.0.1")
+    const url = `http://localhost/api/_vitehub/console/usage?agent=${"a".repeat(513)}`
+    if (!requestEvent.node?.req || !requestEvent.req) throw new TypeError("Expected a request event.")
+    requestEvent.node.req.url = url
+    requestEvent.req.url = url
+
+    await expect(usageHandler(requestEvent)).rejects.toMatchObject({ statusCode: 400 })
   })
 
   it("searches session text through the console Collection", async () => {

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -2165,7 +2165,7 @@ describe("Agent invocation console", () => {
       now: "2026-08-27T12:00:00.000Z",
       window: "24h",
     })).resolves.toMatchObject({
-      models: [{ model: "leaf-a" }, { model: "leaf-b" }],
+      models: [{ model: "leaf-b" }, { model: "leaf-a" }],
       totals: { costUsd: "0.00000000000000000001", totalTokens: 15 },
     })
   })

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -2000,6 +2000,104 @@ describe("Agent invocation console", () => {
     })
   })
 
+  it("keeps incomplete nested usage dimensions unavailable", async () => {
+    const store = createMemoryAgentInvocationStore()
+    store.create({
+      completedAt: "2026-08-27T10:00:00.000Z",
+      createdAt: "2026-08-27T09:59:00.000Z",
+      id: "partial-usage",
+      observations: [{
+        attributes: {
+          "usage.record": {
+            calls: [
+              {
+                cost: { display: "$0.01", estimated: false, source: "provider", usd: "0.01" },
+                model: "priced-input",
+                usage: { inputTokens: 10, totalTokens: 10 },
+              },
+              {
+                model: "unpriced-output",
+                usage: { outputTokens: 5, totalTokens: 5 },
+              },
+            ],
+          },
+        },
+        name: "agent.invocation.finish",
+        sequence: 1,
+        timestamp: "2026-08-27T10:00:00.000Z",
+        type: "lifecycle",
+      }],
+      status: "completed",
+      traceId: "trace-partial-usage",
+      updatedAt: "2026-08-27T10:00:00.000Z",
+    })
+    const invocations = defineAgentInvocations({ store })
+    const record = (await invocations.get("partial-usage"))!
+    const projected = invocationUsage(record)
+
+    expect(projected).toMatchObject({ totalTokens: 15 })
+    expect(projected).not.toHaveProperty("cost")
+    expect(projected).not.toHaveProperty("inputTokens")
+    expect(projected).not.toHaveProperty("outputTokens")
+    await expect(createUsageSummary(invocations, {
+      now: "2026-08-27T12:00:00.000Z",
+      window: "24h",
+    })).resolves.toMatchObject({
+      costAvailable: false,
+      models: [
+        expect.objectContaining({ costAvailable: true, model: "priced-input", outputTokensAvailable: false }),
+        expect.objectContaining({ costAvailable: false, inputTokensAvailable: false, model: "unpriced-output" }),
+      ],
+      totals: {
+        costAvailable: false,
+        inputTokensAvailable: false,
+        outputTokensAvailable: false,
+        totalTokens: 15,
+        totalTokensAvailable: true,
+      },
+    })
+  })
+
+  it("scans creation-ordered pages for recent completions", async () => {
+    const store = createMemoryAgentInvocationStore()
+    store.create({
+      completedAt: "2026-08-27T10:00:00.000Z",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      id: "long-running-usage",
+      observations: [{
+        attributes: { "usage.record": { usage: { inputTokens: 4, outputTokens: 6, totalTokens: 10 } } },
+        name: "agent.invocation.finish",
+        sequence: 1,
+        timestamp: "2026-08-27T10:00:00.000Z",
+        type: "lifecycle",
+      }],
+      status: "completed",
+      traceId: "trace-long-running-usage",
+      updatedAt: "2026-08-27T10:00:00.000Z",
+    })
+    for (let index = 0; index < 100; index++) {
+      store.create({
+        completedAt: "2026-01-02T00:00:00.000Z",
+        createdAt: "2026-01-02T00:00:00.000Z",
+        id: `old-usage-${index}`,
+        observations: [],
+        status: "completed",
+        traceId: `trace-old-usage-${index}`,
+        updatedAt: "2026-01-02T00:00:00.000Z",
+      })
+    }
+    const invocations = defineAgentInvocations({ store })
+
+    await expect(createUsageSummary(invocations, {
+      now: "2026-08-27T12:00:00.000Z",
+      window: "24h",
+    })).resolves.toMatchObject({
+      available: true,
+      partial: false,
+      totals: { invocations: 1, totalTokens: 10 },
+    })
+  })
+
   it("rejects overlong Agent filters at the usage endpoint", async () => {
     const requestEvent = event("127.0.0.1")
     const url = `http://localhost/api/_vitehub/console/usage?agent=${"a".repeat(513)}`

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -2151,6 +2151,7 @@ describe("Agent invocation console", () => {
     const record = {
       completedAt: "2026-08-27T10:00:00.000Z",
       createdAt: "2026-08-27T10:00:00.000Z",
+      cursor: "raw-only-usage",
       id: "raw-only-usage",
       observations: [{
         attributes: {

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -2038,6 +2038,29 @@ describe("Agent invocation console", () => {
     })
   })
 
+  it("projects cached input tokens from supported usage records", () => {
+    const invocation = (usage: Record<string, unknown>) => ({
+      createdAt: "2026-08-27T09:59:00.000Z",
+      cursor: "cached-usage",
+      id: "cached-usage",
+      observations: [{
+        attributes: { "usage.record": { usage } },
+        name: "agent.invocation.finish",
+        sequence: 1,
+        timestamp: "2026-08-27T10:00:00.000Z",
+        type: "lifecycle" as const,
+      }],
+      status: "completed" as const,
+      traceId: "trace-cached-usage",
+      updatedAt: "2026-08-27T10:00:00.000Z",
+    })
+
+    expect(invocationUsage(invocation({ inputTokenDetails: { cachedTokens: 4 } })))
+      .toMatchObject({ cachedInputTokens: 4 })
+    expect(invocationUsage(invocation({ details: { cachedInputTokens: 6 } })))
+      .toMatchObject({ cachedInputTokens: 6 })
+  })
+
   it("keeps incomplete nested usage dimensions unavailable", async () => {
     const store = createMemoryAgentInvocationStore()
     store.create({

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -1998,7 +1998,6 @@ describe("Agent invocation console", () => {
       models: [
         { costUsd: "0.01", invocations: 1, model: "model-a", totalTokens: 15 },
         { costUsd: "0.02", invocations: 1, model: "model-b", totalTokens: 15 },
-        expect.objectContaining({ costAvailable: false, invocations: 1, model: "Unknown model", totalTokensAvailable: false }),
       ],
       partial: false,
       resolution: "hour",
@@ -2014,6 +2013,17 @@ describe("Agent invocation console", () => {
         totalTokensAvailable: false,
       },
     })
+    const summary = await createUsageSummary(invocations, {
+      now: "2026-08-27T12:00:00.000Z",
+      window: "24h",
+    }) as { buckets: Array<Record<string, unknown>> }
+    expect(summary.buckets).toContainEqual(expect.objectContaining({
+      costAvailable: true,
+      costUsd: "0",
+      invocations: 0,
+      start: "2026-08-27T11:00:00.000Z",
+      totalTokensAvailable: true,
+    }))
     expect(invocationUsage((await invocations.get("usage-invocation"))!)).toMatchObject({
       cost: { estimated: true, source: "mixed", usd: "0.03" },
       inputTokens: 18,
@@ -2080,6 +2090,104 @@ describe("Agent invocation console", () => {
     })
   })
 
+  it("preserves recursive usage evidence and arbitrary decimal scale", async () => {
+    const store = createMemoryAgentInvocationStore()
+    store.create({
+      completedAt: "2026-08-27T10:00:00.000Z",
+      createdAt: "2026-08-27T09:59:00.000Z",
+      id: "recursive-usage",
+      observations: [{
+        attributes: {
+          "usage.record": {
+            calls: [{
+              calls: [
+                {
+                  cost: { display: "$0.000000000000000000005", estimated: false, source: "provider", usd: "0.000000000000000000005" },
+                  model: "leaf-a",
+                  usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+                },
+                {
+                  cost: { display: "$0.000000000000000000005", estimated: false, source: "provider", usd: "0.000000000000000000005" },
+                  model: "leaf-b",
+                  usage: { inputTokens: 4, outputTokens: 6, totalTokens: 10 },
+                },
+              ],
+            }],
+          },
+        },
+        name: "agent.invocation.finish",
+        sequence: 1,
+        timestamp: "2026-08-27T10:00:00.000Z",
+        type: "lifecycle",
+      }],
+      status: "completed",
+      traceId: "trace-recursive-usage",
+      updatedAt: "2026-08-27T10:00:00.000Z",
+    })
+    const invocations = defineAgentInvocations({ store })
+    const projected = invocationUsage((await invocations.get("recursive-usage"))!)
+
+    expect(projected).toMatchObject({
+      calls: [{ model: "leaf-a" }, { model: "leaf-b" }],
+      cost: { usd: "0.00000000000000000001" },
+      totalTokens: 15,
+    })
+    await expect(createUsageSummary(invocations, {
+      now: "2026-08-27T12:00:00.000Z",
+      window: "24h",
+    })).resolves.toMatchObject({
+      models: [{ model: "leaf-a" }, { model: "leaf-b" }],
+      totals: { costUsd: "0.00000000000000000001", totalTokens: 15 },
+    })
+  })
+
+  it("does not synthesize complete parent evidence across raw-only calls", async () => {
+    const record = {
+      observations: [{
+        attributes: {
+          "usage.record": {
+            calls: [
+              {
+                cost: { display: "$0.01", estimated: false, source: "provider", usd: "0.01" },
+                usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+              },
+              { raw: { requestId: "raw-only" } },
+            ],
+          },
+        },
+        name: "agent.invocation.finish",
+      }],
+    } as unknown as Parameters<typeof invocationUsage>[0]
+
+    const projected = invocationUsage(record)
+    expect(projected).not.toHaveProperty("cost")
+    expect(projected).not.toHaveProperty("inputTokens")
+    expect(projected).not.toHaveProperty("outputTokens")
+    expect(projected).not.toHaveProperty("totalTokens")
+  })
+
+  it("keeps completed sessions without usage in the no-usage state", async () => {
+    const store = createMemoryAgentInvocationStore()
+    store.create({
+      completedAt: "2026-08-27T10:00:00.000Z",
+      createdAt: "2026-08-27T09:59:00.000Z",
+      id: "missing-only",
+      observations: [],
+      status: "completed",
+      traceId: "trace-missing-only",
+      updatedAt: "2026-08-27T10:00:00.000Z",
+    })
+
+    await expect(createUsageSummary(defineAgentInvocations({ store }), {
+      now: "2026-08-27T12:00:00.000Z",
+      window: "24h",
+    })).resolves.toMatchObject({
+      available: false,
+      models: [],
+      totals: { costAvailable: false, invocations: 1, totalTokensAvailable: false },
+    })
+  })
+
   it("scans creation-ordered pages for recent completions", async () => {
     const store = createMemoryAgentInvocationStore()
     store.create({
@@ -2128,6 +2236,41 @@ describe("Agent invocation console", () => {
     requestEvent.req.url = url
 
     await expect(usageHandler(requestEvent)).rejects.toMatchObject({ statusCode: 400 })
+  })
+
+  it("keeps the all-Agent usage cache separate from an Agent named star", async () => {
+    const store = createMemoryAgentInvocationStore()
+    const timestamp = new Date(Date.now() - 1_000).toISOString()
+    for (const [agentName, totalTokens] of [["*", 1], ["review", 2]] as const) {
+      store.create({
+        agentName,
+        completedAt: timestamp,
+        createdAt: timestamp,
+        id: `cache-${agentName}`,
+        observations: [{
+          attributes: { "usage.record": { usage: { totalTokens } } },
+          name: "agent.invocation.finish",
+          sequence: 1,
+          timestamp,
+          type: "lifecycle",
+        }],
+        status: "completed",
+        traceId: `trace-cache-${agentName}`,
+        updatedAt: timestamp,
+      })
+    }
+    installConsoleInvocationFallback(defineAgentInvocations({ store }), process.cwd())
+    const allEvent = event("127.0.0.1")
+    const starEvent = event("127.0.0.1")
+    const allUrl = "http://localhost/api/_vitehub/console/usage"
+    const starUrl = "http://localhost/api/_vitehub/console/usage?agent=*"
+    allEvent.node!.req!.url = allUrl
+    allEvent.req!.url = allUrl
+    starEvent.node!.req!.url = starUrl
+    starEvent.req!.url = starUrl
+
+    await expect(usageHandler(allEvent)).resolves.toMatchObject({ totals: { totalTokens: 3 } })
+    await expect(usageHandler(starEvent)).resolves.toMatchObject({ totals: { totalTokens: 1 } })
   })
 
   it("searches session text through the console Collection", async () => {

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -1920,7 +1920,7 @@ describe("Agent invocation console", () => {
     expect([...new Set(ids)]).toEqual(["pending-3", "completed-1", "pending-2", "completed-0"])
   })
 
-  it("summarizes recorded usage without requiring the Usage Capability", async () => {
+  it("summarizes recorded usage and marks missing completion evidence unavailable", async () => {
     const store = createMemoryAgentInvocationStore()
     store.create({
       agentName: "review",
@@ -1954,6 +1954,15 @@ describe("Agent invocation console", () => {
       updatedAt: "2026-08-27T10:00:00.000Z",
     })
     store.create({
+      completedAt: "2026-08-27T10:30:00.000Z",
+      createdAt: "2026-08-27T10:29:00.000Z",
+      id: "missing-usage",
+      observations: [],
+      status: "completed",
+      traceId: "trace-missing-usage",
+      updatedAt: "2026-08-27T10:30:00.000Z",
+    })
+    store.create({
       completedAt: "2026-08-28T10:00:00.000Z",
       createdAt: "2026-08-28T10:00:00.000Z",
       id: "future-usage",
@@ -1977,20 +1986,33 @@ describe("Agent invocation console", () => {
       available: true,
       buckets: expect.arrayContaining([
         expect.objectContaining({
+          costAvailable: false,
           costUsd: "0.03",
-          invocations: 1,
+          invocations: 2,
           start: "2026-08-27T10:00:00.000Z",
           totalTokens: 30,
+          totalTokensAvailable: false,
         }),
       ]),
-      costAvailable: true,
+      costAvailable: false,
       models: [
         { costUsd: "0.01", invocations: 1, model: "model-a", totalTokens: 15 },
         { costUsd: "0.02", invocations: 1, model: "model-b", totalTokens: 15 },
+        expect.objectContaining({ costAvailable: false, invocations: 1, model: "Unknown model", totalTokensAvailable: false }),
       ],
       partial: false,
       resolution: "hour",
-      totals: { costUsd: "0.03", inputTokens: 18, invocations: 1, outputTokens: 12, totalTokens: 30 },
+      totals: {
+        costAvailable: false,
+        costUsd: "0.03",
+        inputTokens: 18,
+        inputTokensAvailable: false,
+        invocations: 2,
+        outputTokens: 12,
+        outputTokensAvailable: false,
+        totalTokens: 30,
+        totalTokensAvailable: false,
+      },
     })
     expect(invocationUsage((await invocations.get("usage-invocation"))!)).toMatchObject({
       cost: { estimated: true, source: "mixed", usd: "0.03" },

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -1987,6 +1987,7 @@ describe("Agent invocation console", () => {
       buckets: expect.arrayContaining([
         expect.objectContaining({
           costAvailable: false,
+          costEstimated: true,
           costUsd: "0.03",
           invocations: 2,
           start: "2026-08-27T10:00:00.000Z",
@@ -1996,13 +1997,14 @@ describe("Agent invocation console", () => {
       ]),
       costAvailable: false,
       models: [
-        { costUsd: "0.01", invocations: 1, model: "model-a", totalTokens: 15 },
-        { costUsd: "0.02", invocations: 1, model: "model-b", totalTokens: 15 },
+        { costEstimated: false, costUsd: "0.01", invocations: 1, model: "model-a", totalTokens: 15 },
+        { costEstimated: true, costUsd: "0.02", invocations: 1, model: "model-b", totalTokens: 15 },
       ],
       partial: false,
       resolution: "hour",
       totals: {
         costAvailable: false,
+        costEstimated: true,
         costUsd: "0.03",
         inputTokens: 18,
         inputTokensAvailable: false,
@@ -2013,17 +2015,21 @@ describe("Agent invocation console", () => {
         totalTokensAvailable: false,
       },
     })
-    const summary = await createUsageSummary(invocations, {
+    await expect(createUsageSummary(invocations, {
       now: "2026-08-27T12:00:00.000Z",
       window: "24h",
-    }) as { buckets: Array<Record<string, unknown>> }
-    expect(summary.buckets).toContainEqual(expect.objectContaining({
-      costAvailable: true,
-      costUsd: "0",
-      invocations: 0,
-      start: "2026-08-27T11:00:00.000Z",
-      totalTokensAvailable: true,
-    }))
+    })).resolves.toMatchObject({
+      buckets: expect.arrayContaining([
+        expect.objectContaining({
+          costAvailable: true,
+          costEstimated: false,
+          costUsd: "0",
+          invocations: 0,
+          start: "2026-08-27T11:00:00.000Z",
+          totalTokensAvailable: true,
+        }),
+      ]),
+    })
     expect(invocationUsage((await invocations.get("usage-invocation"))!)).toMatchObject({
       cost: { estimated: true, source: "mixed", usd: "0.03" },
       inputTokens: 18,
@@ -2143,6 +2149,9 @@ describe("Agent invocation console", () => {
 
   it("does not synthesize complete parent evidence across raw-only calls", async () => {
     const record = {
+      completedAt: "2026-08-27T10:00:00.000Z",
+      createdAt: "2026-08-27T10:00:00.000Z",
+      id: "raw-only-usage",
       observations: [{
         attributes: {
           "usage.record": {
@@ -2156,8 +2165,14 @@ describe("Agent invocation console", () => {
           },
         },
         name: "agent.invocation.finish",
+        sequence: 1,
+        timestamp: "2026-08-27T10:00:00.000Z",
+        type: "lifecycle" as const,
       }],
-    } as unknown as Parameters<typeof invocationUsage>[0]
+      status: "completed" as const,
+      traceId: "trace-raw-only-usage",
+      updatedAt: "2026-08-27T10:00:00.000Z",
+    } satisfies Parameters<typeof invocationUsage>[0]
 
     const projected = invocationUsage(record)
     expect(projected).not.toHaveProperty("cost")

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -2000,7 +2000,7 @@ describe("Agent invocation console", () => {
         { costEstimated: false, costUsd: "0.01", invocations: 1, model: "model-a", totalTokens: 15 },
         { costEstimated: true, costUsd: "0.02", invocations: 1, model: "model-b", totalTokens: 15 },
       ],
-      partial: false,
+      partial: true,
       resolution: "hour",
       totals: {
         costAvailable: false,

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -44,6 +44,7 @@ import { consoleSearch } from "../src/console/runtime/server/search.ts"
 import sectionsHandler from "../src/console/runtime/server/sections.get.ts"
 import { installConsoleSections } from "../src/console/runtime/server/sections.ts"
 import { consoleInvocationRootPlugin, consoleVitePlugin, updateConsoleInvocationRootState } from "../src/console/vite.ts"
+import { createUsageSummary, invocationUsage } from "../src/console/runtime/server/usage.ts"
 
 import { runAgent } from "@vite-hub/agent"
 import { createMemoryAgentInvocationStore, defineAgentInvocations } from "@vite-hub/agent/server"
@@ -468,6 +469,7 @@ describe("Agent invocation console", () => {
         "/api/_vitehub/console/invocations",
         "/api/_vitehub/console/invocations/:id",
         "/api/_vitehub/console/search",
+        "/api/_vitehub/console/usage",
         "/_vitehub",
         "/_vitehub/**",
       ])
@@ -1915,6 +1917,86 @@ describe("Agent invocation console", () => {
     } while (cursor)
 
     expect([...new Set(ids)]).toEqual(["pending-3", "completed-1", "pending-2", "completed-0"])
+  })
+
+  it("summarizes recorded usage without requiring the Usage Capability", async () => {
+    const store = createMemoryAgentInvocationStore()
+    store.create({
+      agentName: "review",
+      completedAt: "2026-08-27T10:00:00.000Z",
+      createdAt: "2026-08-27T09:59:00.000Z",
+      id: "usage-invocation",
+      observations: [{
+        attributes: {
+          "usage.record": {
+            calls: [
+              {
+                cost: { display: "$0.01", estimated: false, source: "provider", usd: "0.01" },
+                model: "model-a",
+                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              },
+              {
+                cost: { display: "$0.02", estimated: true, source: "estimated", usd: "0.02" },
+                model: "model-b",
+                usage: { inputTokens: 8, outputTokens: 7, totalTokens: 15 },
+              },
+            ],
+          },
+        },
+        name: "agent.invocation.finish",
+        sequence: 1,
+        timestamp: "2026-08-27T10:00:00.000Z",
+        type: "lifecycle",
+      }],
+      status: "completed",
+      traceId: "trace-usage",
+      updatedAt: "2026-08-27T10:00:00.000Z",
+    })
+    store.create({
+      completedAt: "2026-08-28T10:00:00.000Z",
+      createdAt: "2026-08-28T10:00:00.000Z",
+      id: "future-usage",
+      observations: [{
+        attributes: { "usage.record": { usage: { totalTokens: 999 } } },
+        name: "agent.invocation.finish",
+        sequence: 1,
+        timestamp: "2026-08-28T10:00:00.000Z",
+        type: "lifecycle",
+      }],
+      status: "completed",
+      traceId: "trace-future-usage",
+      updatedAt: "2026-08-28T10:00:00.000Z",
+    })
+    const invocations = defineAgentInvocations({ store })
+
+    await expect(createUsageSummary(invocations, {
+      now: "2026-08-27T12:00:00.000Z",
+      window: "24h",
+    })).resolves.toMatchObject({
+      available: true,
+      buckets: expect.arrayContaining([
+        expect.objectContaining({
+          costUsd: "0.03",
+          invocations: 1,
+          start: "2026-08-27T10:00:00.000Z",
+          totalTokens: 30,
+        }),
+      ]),
+      costAvailable: true,
+      models: [
+        { costUsd: "0.01", invocations: 1, model: "model-a", totalTokens: 15 },
+        { costUsd: "0.02", invocations: 1, model: "model-b", totalTokens: 15 },
+      ],
+      partial: false,
+      resolution: "hour",
+      totals: { costUsd: "0.03", inputTokens: 18, invocations: 1, outputTokens: 12, totalTokens: 30 },
+    })
+    expect(invocationUsage((await invocations.get("usage-invocation"))!)).toMatchObject({
+      cost: { estimated: true, source: "mixed", usd: "0.03" },
+      inputTokens: 18,
+      outputTokens: 12,
+      totalTokens: 30,
+    })
   })
 
   it("searches session text through the console Collection", async () => {

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -523,7 +523,7 @@ describe("ViteHub Nuxt integration", () => {
     expect(development.nuxt.options.devServerHandlers).toEqual([{ handler: existingConsoleHandler, route: "/api/_vitehub/console" }])
     expect(development.nuxt.options.vite.plugins).toContainEqual(expect.objectContaining({ name: "vite-hub/console-invocation-root" }))
     await expect(readFile("/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs", "utf8")).resolves.toContain(
-      `installConsoleSections("/tmp/vitehub-nuxt", ["agents","kv"])`,
+      `installConsoleSections("/tmp/vitehub-nuxt", ["agents","usage","kv"])`,
     )
     expect(development.nuxt.options.vite.plugins).toContainEqual(
       expect.objectContaining({ name: "vite-hub/console-cli" }),

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -506,6 +506,7 @@ describe("ViteHub Nuxt integration", () => {
         name: "vitehub-console-invocation",
         path: "/_vitehub/agents/:agent/invocations/:invocation",
       }),
+      expect.objectContaining({ name: "vitehub-console-usage", path: "/_vitehub/usage" }),
       expect.objectContaining({ name: "vitehub-console-kv", path: "/_vitehub/kv" }),
     ])
     expect(development.nuxt.options.nitro).toMatchObject({
@@ -515,6 +516,7 @@ describe("ViteHub Nuxt integration", () => {
         { route: "/api/_vitehub/console/invocations" },
         { route: "/api/_vitehub/console/invocations/:id" },
         { route: "/api/_vitehub/console/search" },
+        { route: "/api/_vitehub/console/usage" },
       ],
       plugins: ["/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs"],
     })
@@ -555,6 +557,7 @@ describe("ViteHub Nuxt integration", () => {
         name: "vitehub-console-invocation",
         path: "/_vitehub/agents/:agent/invocations/:invocation",
       }),
+      expect.objectContaining({ name: "vitehub-console-usage", path: "/_vitehub/usage" }),
       expect.objectContaining({ name: "vitehub-console-kv", path: "/_vitehub/kv" }),
     ])
     expect(production.nuxt.options.nitro).toMatchObject({
@@ -564,6 +567,7 @@ describe("ViteHub Nuxt integration", () => {
         { route: "/api/_vitehub/console/invocations" },
         { route: "/api/_vitehub/console/invocations/:id" },
         { route: "/api/_vitehub/console/search" },
+        { route: "/api/_vitehub/console/usage" },
       ],
       plugins: ["/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs"],
     })

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -324,6 +324,8 @@ describe("framework package contract", () => {
     expect(consoleSearch).toContain('label: "All primitives"')
     expect(consoleSearch).toContain('label: "Pages"')
     expect(consoleSearch).toContain('label: debouncedSearchTerm.value ? "Sessions" : "Recent sessions"')
+    expect(existsSync(`${packageRoot}/dist/console/runtime/components/console-usage-summary.vue`)).toBe(true)
+    expect(existsSync(`${packageRoot}/dist/console/runtime/components/console-usage.vue`)).toBe(true)
     const consoleClient = readFileSync(`${packageRoot}/dist/console/runtime/public/console/console.js`, "utf8")
     expect(consoleClient).toContain("ViteHub")
     expect(consoleClient).toContain("/agents/:agent/invocations/:invocation")

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -360,7 +360,8 @@ describe("framework package contract", () => {
       if (!Array.isArray(handlers) || !Array.isArray(publicAssets)) {
         throw new TypeError("Expected the distributed Console Nitro configuration.")
       }
-      expect(handlers).toHaveLength(7)
+      expect(handlers).toHaveLength(8)
+      expect(handlers).toContainEqual(expect.objectContaining({ route: "/api/_vitehub/console/usage" }))
       for (const registration of handlers) {
         const handler = Reflect.get(Object(registration), "handler")
         if (String(handler) !== handler) throw new TypeError("Expected a Console handler path.")

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -100,6 +100,7 @@ export default defineConfig({
       "src/console/runtime/server/page.get.ts",
       "src/console/runtime/server/search.get.ts",
       "src/console/runtime/server/sections.get.ts",
+      "src/console/runtime/server/usage.get.ts",
     ],
     exports: {
       exclude: ["bin"],
@@ -116,6 +117,7 @@ export default defineConfig({
         delete exports["./console/runtime/server/search.get"]
         delete exports["./console/runtime/server/sections.get"]
         delete exports["./console/runtime/server/sections"]
+        delete exports["./console/runtime/server/usage.get"]
         return {
           ...exports,
           "./console/sections": "./dist/console/runtime/server/sections.js",

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -68,6 +68,8 @@ export default defineConfig({
         from: "src/console/runtime/components/console-search.vue",
         to: "dist/console/runtime/components",
       },
+      { from: "src/console/runtime/components/console-usage-summary.vue", to: "dist/console/runtime/components" },
+      { from: "src/console/runtime/components/console-usage.vue", to: "dist/console/runtime/components" },
       { from: "src/console/runtime/pages/agents.vue", to: "dist/console/runtime/pages" },
       { from: "src/console/runtime/pages/index.vue", to: "dist/console/runtime/pages" },
       { from: "src/console/runtime/pages/kv.vue", to: "dist/console/runtime/pages" },


### PR DESCRIPTION
## Summary

- add a first-class Usage route to the redesigned Console for 24-hour, 7-day, 30-day, and 90-day views
- aggregate canonical finish-event usage by time and model with exact decimal cost sums, zero-filled buckets, future-record exclusion, and an explicit 10,000-record partial-result boundary
- project normalized usage into invocation details without requiring the optional Usage Capability
- register the route and read-only API for standalone Vite and Nuxt hosts and document the evidence contract

## Stack

This PR targets `codex/unify-console-design` and should merge after #1064. It intentionally reuses that PR’s Console shell instead of duplicating its layout changes.

## Verification

- `corepack pnpm --filter vite-hub build`
- `corepack pnpm --filter vite-hub typecheck`
- `corepack pnpm --filter vite-hub exec vp test -- console.test.ts agent-route.test.ts package.test.ts` (52 tests, no type errors)
- isolated Nuxt Console registration test (1 passed)
- focused oxlint over the changed Console, Nuxt, and test files

## Visual verification

The production client bundle compiles successfully. Browser visual QA was unavailable because this T3 session has no preview automation host attached.