### PR TITLE
feat(ui): add console trace context

### DIFF
--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -551,7 +551,7 @@ function timelineOwner(activity: InvocationActivity): "agent" | "vitehub" {
 }
 
 function traceTimeline(activities: readonly InvocationActivity[], invocation: AgentInvocationView) {
-  const items = activities.filter(activity => activity.kind !== "message");
+  const items = activities.filter(activity => activity.kind !== "message" && Number.isFinite(Date.parse(activity.startedAt ?? "")));
   if (!items.length) return null;
   const invocationStart = Date.parse(invocation.startedAt ?? invocation.createdAt ?? "");
   const observedStarts = items

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -326,7 +326,7 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
 
 function renderEventPayload(label: string, value: unknown) {
   if (value === undefined) return null;
-  const text = stringAttribute({ value }, "value") ?? JSON.stringify(value, null, 2);
+  const text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
   return h("section", { class: "vh-invocation-event__payload" }, [
     h("strong", label),
     h("pre", text),

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -79,8 +79,8 @@ function formatTimelineDuration(value: number): string | undefined {
   if (value < 60_000) {
     return `${new Intl.NumberFormat("en", { maximumFractionDigits: 1 }).format(value / 1_000)}s`;
   }
-  const minutes = Math.floor(value / 60_000);
-  return `${minutes}m ${Math.round((value % 60_000) / 1_000)}s`;
+  const seconds = Math.round(value / 1_000);
+  return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
 }
 
 function driverLabel(configuration: AgentInvocationConfiguration): string | undefined {
@@ -582,6 +582,8 @@ function traceTimeline(activities: readonly InvocationActivity[], invocation: Ag
       ].filter(Boolean).join(" · ");
       const title = invocationActivityTitle(activity);
       const detail = activityDetail(activity);
+      const width = Math.max(1.5, Math.min(100, (duration / span) * 100));
+      const left = Math.min(100 - width, Math.max(0, (offset / span) * 100));
       return h("li", {
         class: "vh-invocation-timeline__row",
         "data-owner": owner,
@@ -596,8 +598,8 @@ function traceTimeline(activities: readonly InvocationActivity[], invocation: Ag
         detail ? h("code", { class: "vh-invocation-timeline__detail" }, detail) : null,
         h("div", { class: "vh-invocation-timeline__track", "aria-hidden": "true" }, [
           h("span", { style: {
-            left: `${Math.min(100, (offset / span) * 100)}%`,
-            width: `${Math.max(1.5, Math.min(100, (duration / span) * 100))}%`,
+            left: `${left}%`,
+            width: `${width}%`,
           } }),
         ]),
       ]);

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -326,7 +326,7 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
 
 function renderEventPayload(label: string, value: unknown) {
   if (value === undefined) return null;
-  const text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
+  const text = Object.prototype.toString.call(value) === "[object String]" ? String(value) : JSON.stringify(value, null, 2);
   return h("section", { class: "vh-invocation-event__payload" }, [
     h("strong", label),
     h("pre", text),

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -326,7 +326,7 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
 
 function renderEventPayload(label: string, value: unknown) {
   if (value === undefined) return null;
-  const text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
+  const text = stringAttribute({ value }, "value") ?? JSON.stringify(value, null, 2);
   return h("section", { class: "vh-invocation-event__payload" }, [
     h("strong", label),
     h("pre", text),

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -300,6 +300,7 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
               ]),
               command.cwd ? h("div", { class: "vh-invocation-command__cwd" }, command.cwd) : null,
               command.output ? h("pre", terminalText(command.output)) : null,
+              renderEventPayload("Error", activity.attributes["tool.error"]),
             ])
           : hasPayloads
             ? h("div", { class: "vh-invocation-event__payloads" }, [

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -305,10 +305,8 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
           : hasPayloads
             ? h("div", { class: "vh-invocation-event__payloads" }, [
                 renderEventPayload("Input", activity.attributes["tool.input"]),
-                renderEventPayload(
-                  activity.attributes["tool.error"] !== undefined ? "Error" : "Output",
-                  activity.attributes["tool.error"] ?? activity.attributes["tool.output"],
-                ),
+                renderEventPayload("Output", activity.attributes["tool.output"]),
+                renderEventPayload("Error", activity.attributes["tool.error"]),
               ].filter(Boolean))
           : activity.body
             ? h("div", { class: "vh-invocation-event__body" }, [markdown(activity.body, "vh-invocation-event__markdown")])

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -73,6 +73,16 @@ function formatDuration(startedAt: string | undefined, completedAt: string | und
   return `${Math.floor(seconds / 60)}m ${seconds % 60}s`;
 }
 
+function formatTimelineDuration(value: number): string | undefined {
+  if (!Number.isFinite(value) || value < 0) return;
+  if (value < 1_000) return `${Math.round(value)}ms`;
+  if (value < 60_000) {
+    return `${new Intl.NumberFormat("en", { maximumFractionDigits: 1 }).format(value / 1_000)}s`;
+  }
+  const minutes = Math.floor(value / 60_000);
+  return `${minutes}m ${Math.round((value % 60_000) / 1_000)}s`;
+}
+
 function driverLabel(configuration: AgentInvocationConfiguration): string | undefined {
   const driver = configuration.driver;
   const model = driver?.model;
@@ -238,7 +248,12 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
   const suffix = agentConfigurationSummary(activity)
     ?? channelDeliverySummary(activity)
     ?? (activity.preview ? compactCommand(activity.preview) : tokenLabel);
-  const hasDetails = activity.patches.length > 0 || Boolean(command || activity.body || activity.truncated);
+  const hasPayloads = activity.kind === "tool" && (
+    activity.attributes["tool.input"] !== undefined
+    || activity.attributes["tool.output"] !== undefined
+    || activity.attributes["tool.error"] !== undefined
+  );
+  const hasDetails = activity.patches.length > 0 || Boolean(command || hasPayloads || activity.body || activity.truncated);
   const inspectTarget = activity.attributes["vitehub.inspect.target"] ?? (activity.name === "vitehub.agent.configured" ? "agent" : undefined);
   const inspectable = inspectTarget === "agent" || inspectTarget === "workspace";
   const summaryContent = [
@@ -286,6 +301,14 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
               command.cwd ? h("div", { class: "vh-invocation-command__cwd" }, command.cwd) : null,
               command.output ? h("pre", terminalText(command.output)) : null,
             ])
+          : hasPayloads
+            ? h("div", { class: "vh-invocation-event__payloads" }, [
+                renderEventPayload("Input", activity.attributes["tool.input"]),
+                renderEventPayload(
+                  activity.attributes["tool.error"] !== undefined ? "Error" : "Output",
+                  activity.attributes["tool.error"] ?? activity.attributes["tool.output"],
+                ),
+              ].filter(Boolean))
           : activity.body
             ? h("div", { class: "vh-invocation-event__body" }, [markdown(activity.body, "vh-invocation-event__markdown")])
             : null,
@@ -298,6 +321,15 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
           : null,
       ]) : null,
     ]),
+  ]);
+}
+
+function renderEventPayload(label: string, value: unknown) {
+  if (value === undefined) return null;
+  const text = typeof value === "string" ? value : JSON.stringify(value, null, 2);
+  return h("section", { class: "vh-invocation-event__payload" }, [
+    h("strong", label),
+    h("pre", text),
   ]);
 }
 
@@ -502,6 +534,75 @@ function renderActivityGroup(
 
 function inspectorSection(title: string, body: ReturnType<typeof h>) {
   return h("section", [h("h4", title), body]);
+}
+
+function timelineOwner(activity: InvocationActivity): "agent" | "vitehub" {
+  const tool = String(activity.attributes["tool.name"] ?? "").toLocaleLowerCase();
+  if (
+    activity.kind === "preparation"
+    || activity.kind === "action"
+    || activity.kind === "system"
+    || activity.kind === "delivery"
+    || activity.name.startsWith("vitehub.")
+    || tool === "materialize_sources"
+    || tool.startsWith("vitehub_")
+  ) return "vitehub";
+  return "agent";
+}
+
+function traceTimeline(activities: readonly InvocationActivity[], invocation: AgentInvocationView) {
+  const items = activities.filter(activity => activity.kind !== "message");
+  if (!items.length) return null;
+  const invocationStart = Date.parse(invocation.startedAt ?? invocation.createdAt ?? "");
+  const observedStarts = items
+    .map(activity => Date.parse(activity.startedAt ?? ""))
+    .filter(Number.isFinite);
+  const zero = Number.isFinite(invocationStart) ? invocationStart : Math.min(...observedStarts);
+  const invocationEnd = Date.parse(
+    invocation.completedAt ?? invocation.failedAt ?? invocation.cancelledAt ?? invocation.updatedAt ?? "",
+  );
+  const observedEnds = items
+    .map(activity => Date.parse(activity.endedAt ?? activity.startedAt ?? ""))
+    .filter(Number.isFinite);
+  const end = Number.isFinite(invocationEnd) ? invocationEnd : Math.max(...observedEnds, zero + 1);
+  const span = Math.max(1, end - zero);
+  return inspectorSection("Trace timeline", h("div", { class: "vh-invocation-timeline" }, [
+    h("div", { class: "vh-invocation-timeline__legend", "aria-hidden": "true" }, [
+      h("span", { "data-owner": "agent" }, "Agent"),
+      h("span", { "data-owner": "vitehub" }, "ViteHub"),
+    ]),
+    h("ol", items.map((activity) => {
+      const started = Date.parse(activity.startedAt ?? "");
+      const duration = Number.isFinite(activity.durationMs) ? (activity.durationMs ?? 0) : 0;
+      const offset = Number.isFinite(started) ? Math.max(0, started - zero) : 0;
+      const owner = timelineOwner(activity);
+      const timing = [
+        offset ? `+${formatTimelineDuration(offset)}` : "start",
+        duration ? formatTimelineDuration(duration) : undefined,
+      ].filter(Boolean).join(" · ");
+      const title = invocationActivityTitle(activity);
+      const detail = activityDetail(activity);
+      return h("li", {
+        class: "vh-invocation-timeline__row",
+        "data-owner": owner,
+        key: `timeline:${activity.id}`,
+        tabindex: "0",
+        title: detail ? `${title} — ${detail}` : title,
+      }, [
+        h("div", { class: "vh-invocation-timeline__heading" }, [
+          h("strong", title),
+          h("time", timing),
+        ]),
+        detail ? h("code", { class: "vh-invocation-timeline__detail" }, detail) : null,
+        h("div", { class: "vh-invocation-timeline__track", "aria-hidden": "true" }, [
+          h("span", { style: {
+            left: `${Math.min(100, (offset / span) * 100)}%`,
+            width: `${Math.max(1.5, Math.min(100, (duration / span) * 100))}%`,
+          } }),
+        ]),
+      ]);
+    })),
+  ]));
 }
 
 function inspectorRow(label: string, value: string | number | undefined) {
@@ -1006,6 +1107,7 @@ export const AgentInvocationInspector = defineComponent({
                   : null,
               ]),
             ),
+            traceTimeline(activities.value, props.invocation),
             ...(configuration ? renderConfiguration(configuration) : []),
             slots.metadata?.({ invocation: props.invocation }),
             inspectorSection(

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -344,18 +344,21 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
           ? "user"
           : undefined);
       const command = commandDetails(attributes, sorted);
-      const endedAt = sorted.at(-1)?.timestamp;
-      const observedDuration = Date.parse(endedAt ?? "") - Date.parse(first.timestamp);
-      const durationMs = numericAttribute(attributes, "tool.durationMs")
-        ?? (Number.isFinite(observedDuration) ? Math.max(0, observedDuration) : undefined);
+      const observedEndedAt = sorted.at(-1)?.timestamp;
+      const invocationEndedAt = invocation.completedAt ?? invocation.failedAt ?? invocation.cancelledAt;
       const started = /\.(request|start|started)$/.test(first.name);
-      const terminalStartedAt = !started && endedAt && durationMs !== undefined
-        ? new Date(Date.parse(endedAt) - durationMs).toISOString()
-        : undefined;
       const unfinishedTerminalStatus = started
+        && !completed
         && invocation.status !== "pending"
         && invocation.status !== "running"
         ? invocation.status === "failed" ? "failed" : "completed"
+        : undefined;
+      const endedAt = unfinishedTerminalStatus ? invocationEndedAt ?? observedEndedAt : observedEndedAt;
+      const observedDuration = Date.parse(endedAt ?? "") - Date.parse(first.timestamp);
+      const durationMs = numericAttribute(attributes, "tool.durationMs")
+        ?? (Number.isFinite(observedDuration) ? Math.max(0, observedDuration) : undefined);
+      const terminalStartedAt = !started && endedAt && durationMs !== undefined
+        ? new Date(Date.parse(endedAt) - durationMs).toISOString()
         : undefined;
       const draft = {
         attributes,

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -334,7 +334,7 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
         .join("");
       const { patches, paths } = fileChanges(attributes);
       const kind = activityKind(first, attributes, paths.length ? paths : patches);
-      const failed = sorted.some(item => item.type === "error" || item.name.endsWith(".error"));
+      const failed = sorted.some(item => item.type === "error" || /\.(error|failed)$/.test(item.name));
       const approvalDenied = attributes["approval.approved"] === false;
       const completed = sorted.some(item => /\.(abort|cancelled|completed|decision|error|failed|finish|recorded)$/.test(item.name));
       const explicitRole = messageRole(attributes["message.role"]);
@@ -353,7 +353,11 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
         && invocation.status !== "running"
         ? invocation.status === "failed" ? "failed" : "completed"
         : undefined;
-      const endedAt = unfinishedTerminalStatus ? invocationEndedAt ?? observedEndedAt : observedEndedAt;
+      const endedAt = unfinishedTerminalStatus
+        ? invocationEndedAt ?? observedEndedAt
+        : started && !completed && invocation.status === "running"
+          ? invocation.updatedAt
+          : observedEndedAt;
       const observedDuration = Date.parse(endedAt ?? "") - Date.parse(first.timestamp);
       const durationMs = numericAttribute(attributes, "tool.durationMs")
         ?? (Number.isFinite(observedDuration) ? Math.max(0, observedDuration) : undefined);

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -336,7 +336,7 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
       const kind = activityKind(first, attributes, paths.length ? paths : patches);
       const failed = sorted.some(item => item.type === "error" || item.name.endsWith(".error"));
       const approvalDenied = attributes["approval.approved"] === false;
-      const completed = sorted.some(item => /\.(abort|cancelled|completed|decision|error|finish|recorded)$/.test(item.name));
+      const completed = sorted.some(item => /\.(abort|cancelled|completed|decision|error|failed|finish|recorded)$/.test(item.name));
       const explicitRole = messageRole(attributes["message.role"]);
       const role = explicitRole ?? (attributes["result.text"]
         ? "assistant"

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -349,6 +349,9 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
       const durationMs = numericAttribute(attributes, "tool.durationMs")
         ?? (Number.isFinite(observedDuration) ? Math.max(0, observedDuration) : undefined);
       const started = /\.(request|start|started)$/.test(first.name);
+      const terminalStartedAt = !started && endedAt && durationMs !== undefined
+        ? new Date(Date.parse(endedAt) - durationMs).toISOString()
+        : undefined;
       const unfinishedTerminalStatus = started
         && invocation.status !== "pending"
         && invocation.status !== "running"
@@ -366,7 +369,7 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
         patches,
         paths,
         sequence: first.sequence,
-        startedAt: first.timestamp,
+        startedAt: terminalStartedAt ?? first.timestamp,
         ...(numericAttribute(attributes, "usage.reasoningTokens", "usage.reasoningOutputTokens") !== undefined
           ? { reasoningTokens: numericAttribute(attributes, "usage.reasoningTokens", "usage.reasoningOutputTokens") }
           : {}),

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -336,7 +336,7 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
       const kind = activityKind(first, attributes, paths.length ? paths : patches);
       const failed = sorted.some(item => item.type === "error" || item.name.endsWith(".error"));
       const approvalDenied = attributes["approval.approved"] === false;
-      const completed = sorted.some(item => /\.(cancelled|completed|decision|finish|recorded)$/.test(item.name));
+      const completed = sorted.some(item => /\.(abort|cancelled|completed|decision|error|finish|recorded)$/.test(item.name));
       const explicitRole = messageRole(attributes["message.role"]);
       const role = explicitRole ?? (attributes["result.text"]
         ? "assistant"

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -28,6 +28,8 @@ export interface InvocationActivity {
   attributes: Record<string, unknown>;
   body?: string;
   command?: InvocationCommand;
+  durationMs?: number;
+  endedAt?: string;
   id: string;
   kind: InvocationActivityKind;
   name: string;
@@ -37,6 +39,7 @@ export interface InvocationActivity {
   reasoningTokens?: number;
   role?: "assistant" | "system" | "tool" | "user";
   sequence: number;
+  startedAt?: string;
   status: "running" | "completed" | "failed";
   totalTokens?: number;
   truncated?: boolean;
@@ -182,7 +185,7 @@ function payloadDetail(attributes: Record<string, unknown>): string | undefined 
   for (const key of ["tool.output", "tool.input"]) {
     const payload = record(attributes[key]);
     const item = record(payload?.item) ?? payload;
-    const detail = item && stringAttribute(item, "detail", "output", "query", "path");
+    const detail = item && stringAttribute(item, "detail", "summary", "output", "query", "path");
     if (detail) return detail.split(/\r?\n/).find(Boolean)?.trim();
   }
   return stringAttribute(attributes, "tool.detail", "tool.output.summary", "vitehub.activity.detail");
@@ -341,6 +344,10 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
           ? "user"
           : undefined);
       const command = commandDetails(attributes, sorted);
+      const endedAt = sorted.at(-1)?.timestamp;
+      const observedDuration = Date.parse(endedAt ?? "") - Date.parse(first.timestamp);
+      const durationMs = numericAttribute(attributes, "tool.durationMs")
+        ?? (Number.isFinite(observedDuration) ? Math.max(0, observedDuration) : undefined);
       const started = /\.(request|start|started)$/.test(first.name);
       const unfinishedTerminalStatus = started
         && invocation.status !== "pending"
@@ -351,12 +358,15 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
         attributes,
         body: patches.join("") || messageBody || activityBody(attributes),
         command,
+        ...(durationMs !== undefined ? { durationMs } : {}),
+        ...(endedAt ? { endedAt } : {}),
         id,
         kind,
         name: first.name,
         patches,
         paths,
         sequence: first.sequence,
+        startedAt: first.timestamp,
         ...(numericAttribute(attributes, "usage.reasoningTokens", "usage.reasoningOutputTokens") !== undefined
           ? { reasoningTokens: numericAttribute(attributes, "usage.reasoningTokens", "usage.reasoningOutputTokens") }
           : {}),

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -1117,12 +1117,46 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 
 .vh-invocation-event__body,
 .vh-invocation-command,
-.vh-invocation-event__diffs {
+.vh-invocation-event__diffs,
+.vh-invocation-event__payloads {
   border-inline-start: 1px solid var(--vh-ui-border);
   margin: 0.25rem 0 0 1.75rem;
   max-height: 16rem;
   overflow: auto;
   padding-inline-start: 0.75rem;
+}
+
+.vh-invocation-event__payloads {
+  display: grid;
+  gap: 0.625rem;
+}
+
+.vh-invocation-event__payload {
+  min-width: 0;
+}
+
+.vh-invocation-event__payload > strong {
+  color: var(--vh-ui-dimmed);
+  display: block;
+  font-size: 0.6875rem;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  margin-block-end: 0.3rem;
+  text-transform: uppercase;
+}
+
+.vh-invocation-event__payload > pre {
+  background: color-mix(in oklab, var(--vh-ui-bg-elevated) 65%, transparent);
+  border: 1px solid color-mix(in oklab, var(--vh-ui-border) 78%, transparent);
+  border-radius: calc(var(--vh-ui-radius) * 0.9);
+  color: var(--vh-ui-text);
+  font: 0.75rem/1.55 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  margin: 0;
+  max-height: 18rem;
+  overflow: auto;
+  padding: 0.625rem 0.75rem;
+  white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .vh-invocation-event__body,
@@ -1399,6 +1433,124 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   font-weight: 650;
   margin: 0.25rem 0 0;
   overflow-wrap: anywhere;
+}
+
+.vh-invocation-timeline {
+  display: grid;
+  gap: 0.625rem;
+}
+
+.vh-invocation-timeline__legend {
+  color: var(--vh-ui-dimmed);
+  display: flex;
+  font-size: 0.6875rem;
+  gap: 0.875rem;
+}
+
+.vh-invocation-timeline__legend span {
+  align-items: center;
+  display: inline-flex;
+  gap: 0.35rem;
+}
+
+.vh-invocation-timeline__legend span::before {
+  background: var(--vh-ui-info);
+  border-radius: 999px;
+  content: "";
+  height: 0.45rem;
+  width: 0.45rem;
+}
+
+.vh-invocation-timeline__legend span[data-owner="vitehub"]::before {
+  background: var(--vh-ui-success);
+}
+
+.vh-invocation-timeline ol {
+  display: grid;
+  gap: 0.2rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.vh-invocation-timeline__row {
+  border-radius: calc(var(--vh-ui-radius) * 0.9);
+  min-width: 0;
+  outline: 2px solid transparent;
+  outline-offset: -2px;
+  padding: 0.45rem 0.5rem;
+  transition: background-color 160ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.vh-invocation-timeline__row:focus-visible {
+  outline-color: color-mix(in oklab, var(--vh-ui-info) 55%, transparent);
+}
+
+.vh-invocation-timeline__heading {
+  align-items: baseline;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  min-width: 0;
+}
+
+.vh-invocation-timeline__heading strong,
+.vh-invocation-timeline__detail {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vh-invocation-timeline__heading strong {
+  color: var(--vh-ui-text);
+  font-size: 0.75rem;
+  font-weight: 580;
+}
+
+.vh-invocation-timeline__heading time {
+  color: var(--vh-ui-dimmed);
+  flex: none;
+  font: 0.6875rem/1.4 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-variant-numeric: tabular-nums;
+}
+
+.vh-invocation-timeline__detail {
+  color: var(--vh-ui-dimmed);
+  display: block;
+  font-size: 0.6875rem;
+  margin-block-start: 0.15rem;
+}
+
+.vh-invocation-timeline__row:is(:hover, :focus-visible) .vh-invocation-timeline__heading strong,
+.vh-invocation-timeline__row:is(:hover, :focus-visible) .vh-invocation-timeline__detail {
+  overflow: visible;
+  white-space: normal;
+}
+
+.vh-invocation-timeline__track {
+  background: color-mix(in oklab, var(--vh-ui-border) 60%, transparent);
+  border-radius: 999px;
+  height: 0.25rem;
+  margin-block-start: 0.4rem;
+  overflow: hidden;
+  position: relative;
+}
+
+.vh-invocation-timeline__track span {
+  background: var(--vh-ui-info);
+  border-radius: inherit;
+  inset-block: 0;
+  position: absolute;
+}
+
+.vh-invocation-timeline__row[data-owner="vitehub"] .vh-invocation-timeline__track span {
+  background: var(--vh-ui-success);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .vh-invocation-timeline__row:hover {
+    background: color-mix(in oklab, var(--vh-ui-bg-elevated) 72%, transparent);
+  }
 }
 
 .vh-invocation-inspector__groups {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -931,6 +931,26 @@ describe("Agent Invocation UI", () => {
     ]);
   });
 
+  it("renders failed command diagnostics with command details", () => {
+    const timestamp = "2026-08-22T00:00:00.000Z";
+    const invocation = {
+      createdAt: timestamp,
+      id: "failed-command",
+      observations: [
+        { attributes: { "tool.id": "command", "tool.input": { command: "pnpm test" }, "tool.name": "shell" }, name: "agent.tool.start", sequence: 1, timestamp, type: "run" as const },
+        { attributes: { "tool.error": "Command timed out", "tool.id": "command", "tool.name": "shell" }, name: "agent.tool.error", sequence: 2, timestamp, type: "error" as const },
+      ],
+      status: "failed" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+
+    expect(wrapper.get(".vh-invocation-command__bar code").text()).toBe("pnpm test");
+    expect(wrapper.get(".vh-invocation-command .vh-invocation-event__payload > strong").text()).toBe("Error");
+    expect(wrapper.get(".vh-invocation-command .vh-invocation-event__payload pre").text()).toBe("Command timed out");
+  });
+
   it("keeps an undecided approval request running", () => {
     const timestamp = "2026-08-22T00:00:00.000Z";
     const invocation = {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -538,6 +538,31 @@ describe("Agent Invocation UI", () => {
     expect(rows[1]!.text()).toContain("+1s · 1s");
   });
 
+  it("keeps rounded and terminal trace timings inside their bounds", () => {
+    const invocation = {
+      completedAt: "2026-08-22T00:01:59.999Z",
+      createdAt: "2026-08-22T00:00:00.000Z",
+      id: "trace-boundaries",
+      observations: [{
+        attributes: { "tool.id": "terminal", "tool.name": "finish" },
+        name: "agent.tool.finish",
+        sequence: 1,
+        timestamp: "2026-08-22T00:01:59.999Z",
+        type: "run" as const,
+      }],
+      startedAt: "2026-08-22T00:00:00.000Z",
+      status: "completed" as const,
+      traceId: "trace",
+      updatedAt: "2026-08-22T00:01:59.999Z",
+    } satisfies AgentInvocationView;
+
+    const row = mount(AgentInvocationInspector, { props: { invocation } })
+      .get(".vh-invocation-timeline__row");
+    expect(row.text()).toContain("+2m 0s");
+    expect(row.get(".vh-invocation-timeline__track span").attributes("style"))
+      .toContain("left: 98.5%");
+  });
+
   it.each([
     ["direct output", "clean"],
     ["completed output", { output: "clean" }],

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -110,6 +110,9 @@ describe("Agent Invocation UI", () => {
     const inspector = mount(AgentInvocationInspector, { props: { invocation } });
     const metrics = inspector.findAll(".vh-invocation-inspector__metrics > div");
     expect(metrics.find(metric => metric.get("dt").text() === "Steps")?.get("dd").text()).toBe("1");
+    const timelineRows = inspector.findAll(".vh-invocation-timeline__row");
+    expect(timelineRows).toHaveLength(1);
+    expect(timelineRows[0]!.text()).not.toContain("Trace content was truncated");
   });
 
   it("renders only HTTP source URLs as links", () => {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -1029,7 +1029,13 @@ describe("Agent Invocation UI", () => {
       cancelledAt: "2026-08-22T00:01:05.000Z",
       createdAt: "2026-08-22T00:00:00.000Z",
       id: "cancelled",
-      observations: [],
+      observations: [{
+        attributes: { "tool.id": "search", "tool.name": "search" },
+        name: "agent.tool.start",
+        sequence: 1,
+        timestamp: "2026-08-22T00:01:00.000Z",
+        type: "run",
+      }],
       startedAt: "2026-08-22T00:00:00.000Z",
       status: "cancelled",
       traceId: "trace",
@@ -1038,6 +1044,13 @@ describe("Agent Invocation UI", () => {
 
     const wrapper = mount(AgentInvocationInspector, { props: { invocation } });
     expect(wrapper.get(".vh-invocation-inspector__status small").text()).toBe("1m 5s");
+    expect(invocationActivities(invocation)[0]).toMatchObject({
+      durationMs: 5_000,
+      endedAt: "2026-08-22T00:01:05.000Z",
+      startedAt: "2026-08-22T00:01:00.000Z",
+      status: "completed",
+    });
+    expect(wrapper.get(".vh-invocation-timeline__row").text()).toContain("+1m 0s · 5s");
   });
 
   it("carries rounded duration seconds into minutes", () => {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -493,6 +493,7 @@ describe("Agent Invocation UI", () => {
         {
           attributes: {
             "tool.id": "query",
+            "tool.error": "Result was incomplete.",
             "tool.name": "database_query",
             "tool.output": "  Returned 1 row.\n",
           },
@@ -522,9 +523,11 @@ describe("Agent Invocation UI", () => {
     expect(thread.findAll(".vh-invocation-event__payload > strong").map(item => item.text())).toEqual([
       "Input",
       "Output",
+      "Error",
     ]);
     expect(thread.text()).toContain("Private query omitted.");
-    expect(thread.findAll(".vh-invocation-event__payload pre").at(-1)!.element.textContent).toBe("  Returned 1 row.\n");
+    expect(thread.findAll(".vh-invocation-event__payload pre").at(-2)!.element.textContent).toBe("  Returned 1 row.\n");
+    expect(thread.findAll(".vh-invocation-event__payload pre").at(-1)!.text()).toBe("Result was incomplete.");
 
     const inspector = mount(AgentInvocationInspector, { props: { invocation } });
     const rows = inspector.findAll(".vh-invocation-timeline__row");

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -443,6 +443,98 @@ describe("Agent Invocation UI", () => {
     });
   });
 
+  it("renders structured tool payloads and a timed Agent and ViteHub trace", () => {
+    const invocation = {
+      completedAt: "2026-08-22T00:00:03.000Z",
+      createdAt: "2026-08-22T00:00:00.000Z",
+      id: "trace-context",
+      observations: [
+        {
+          attributes: {
+            "step.id": "materialize",
+            "tool.id": "materialize",
+            "tool.input": { path: "workspace root" },
+            "tool.name": "materialize_sources",
+            "vitehub.activity.kind": "preparation",
+            "vitehub.activity.title": "Materialized ViteHub workspace",
+          },
+          name: "agent.tool.start",
+          sequence: 1,
+          timestamp: "2026-08-22T00:00:00.250Z",
+          type: "run" as const,
+        },
+        {
+          attributes: {
+            "step.id": "materialize",
+            "tool.durationMs": 500,
+            "tool.id": "materialize",
+            "tool.name": "materialize_sources",
+            "tool.output": { files: 12, summary: "Materialized repository (12 files)." },
+          },
+          name: "agent.tool.finish",
+          sequence: 2,
+          timestamp: "2026-08-22T00:00:00.750Z",
+          type: "run" as const,
+        },
+        {
+          attributes: {
+            "tool.id": "query",
+            "tool.input": { summary: "Private query omitted." },
+            "tool.name": "database_query",
+          },
+          name: "agent.tool.start",
+          sequence: 3,
+          timestamp: "2026-08-22T00:00:01.000Z",
+          type: "run" as const,
+        },
+        {
+          attributes: {
+            "tool.id": "query",
+            "tool.name": "database_query",
+            "tool.output": { rows: 1, summary: "Returned 1 row." },
+          },
+          name: "agent.tool.finish",
+          sequence: 4,
+          timestamp: "2026-08-22T00:00:02.000Z",
+          type: "run" as const,
+        },
+      ],
+      startedAt: "2026-08-22T00:00:00.000Z",
+      status: "completed" as const,
+      traceId: "trace",
+      updatedAt: "2026-08-22T00:00:03.000Z",
+    } satisfies AgentInvocationView;
+
+    expect(invocationActivities(invocation)).toEqual([
+      expect.objectContaining({
+        durationMs: 500,
+        endedAt: "2026-08-22T00:00:00.750Z",
+        preview: "Materialized repository (12 files).",
+        startedAt: "2026-08-22T00:00:00.250Z",
+      }),
+      expect.objectContaining({ durationMs: 1_000 }),
+    ]);
+
+    const thread = mount(AgentInvocation, { props: { invocation } });
+    expect(thread.findAll(".vh-invocation-event__payload > strong").map(item => item.text())).toEqual([
+      "Input",
+      "Output",
+    ]);
+    expect(thread.text()).toContain("Private query omitted.");
+    expect(thread.text()).toContain("Returned 1 row.");
+
+    const inspector = mount(AgentInvocationInspector, { props: { invocation } });
+    const rows = inspector.findAll(".vh-invocation-timeline__row");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]!.attributes()).toMatchObject({
+      "data-owner": "vitehub",
+      title: "Materialized ViteHub workspace — Materialized repository (12 files).",
+    });
+    expect(rows[0]!.text()).toContain("+250ms · 500ms");
+    expect(rows[1]!.attributes("data-owner")).toBe("agent");
+    expect(rows[1]!.text()).toContain("+1s · 1s");
+  });
+
   it.each([
     ["direct output", "clean"],
     ["completed output", { output: "clean" }],

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -612,6 +612,29 @@ describe("Agent Invocation UI", () => {
     },
   );
 
+  it("bounds failed tasks by their observed failure", () => {
+    const timestamp = "2026-08-22T00:00:00.000Z";
+    const failedAt = "2026-08-22T00:00:01.000Z";
+    const invocation = {
+      completedAt: "2026-08-22T00:00:03.000Z",
+      createdAt: timestamp,
+      id: "failed-task",
+      observations: [
+        { attributes: { "step.id": "task" }, name: "agent.task.started", sequence: 1, timestamp, type: "run" as const },
+        { attributes: { "error.message": "Task failed", "step.id": "task" }, name: "agent.task.failed", sequence: 2, timestamp: failedAt, type: "error" as const },
+      ],
+      status: "completed" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+
+    expect(invocationActivities(invocation)[0]).toMatchObject({
+      durationMs: 1_000,
+      endedAt: failedAt,
+      status: "failed",
+    });
+  });
+
   it.each([
     ["cancelled", "completed"],
     ["failed", "failed"],

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -494,7 +494,7 @@ describe("Agent Invocation UI", () => {
           attributes: {
             "tool.id": "query",
             "tool.name": "database_query",
-            "tool.output": { rows: 1, summary: "Returned 1 row." },
+            "tool.output": "  Returned 1 row.\n",
           },
           name: "agent.tool.finish",
           sequence: 4,
@@ -515,7 +515,7 @@ describe("Agent Invocation UI", () => {
         preview: "Materialized repository (12 files).",
         startedAt: "2026-08-22T00:00:00.250Z",
       }),
-      expect.objectContaining({ durationMs: 1_000 }),
+      expect.objectContaining({ durationMs: 1_000, startedAt: "2026-08-22T00:00:01.000Z" }),
     ]);
 
     const thread = mount(AgentInvocation, { props: { invocation } });
@@ -524,7 +524,7 @@ describe("Agent Invocation UI", () => {
       "Output",
     ]);
     expect(thread.text()).toContain("Private query omitted.");
-    expect(thread.text()).toContain("Returned 1 row.");
+    expect(thread.findAll(".vh-invocation-event__payload pre").at(-1)!.element.textContent).toBe("  Returned 1 row.\n");
 
     const inspector = mount(AgentInvocationInspector, { props: { invocation } });
     const rows = inspector.findAll(".vh-invocation-timeline__row");
@@ -544,7 +544,7 @@ describe("Agent Invocation UI", () => {
       createdAt: "2026-08-22T00:00:00.000Z",
       id: "trace-boundaries",
       observations: [{
-        attributes: { "tool.id": "terminal", "tool.name": "finish" },
+        attributes: { "tool.durationMs": 1_000, "tool.id": "terminal", "tool.name": "finish" },
         name: "agent.tool.finish",
         sequence: 1,
         timestamp: "2026-08-22T00:01:59.999Z",
@@ -558,7 +558,7 @@ describe("Agent Invocation UI", () => {
 
     const row = mount(AgentInvocationInspector, { props: { invocation } })
       .get(".vh-invocation-timeline__row");
-    expect(row.text()).toContain("+2m 0s");
+    expect(row.text()).toContain("+1m 59s · 1s");
     expect(row.get(".vh-invocation-timeline__track span").attributes("style"))
       .toContain("left: 98.5%");
   });

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -587,7 +587,9 @@ describe("Agent Invocation UI", () => {
     "preserves streamed Provider command output through %s",
     (terminalName) => {
       const timestamp = "2026-08-22T00:00:00.000Z";
+      const terminalTimestamp = "2026-08-22T00:00:01.000Z";
       const invocation = {
+        completedAt: "2026-08-22T00:00:03.000Z",
         createdAt: timestamp,
         id: "provider-command",
         observations: [
@@ -595,14 +597,18 @@ describe("Agent Invocation UI", () => {
           { attributes: { "tool.id": "command", "tool.output": "first\n", "tool.name": "shell" }, name: "agent.tool.output", sequence: 2, timestamp, type: "run" as const },
           { attributes: { "tool.id": "command", "tool.output": "second\n", "tool.name": "shell" }, name: "agent.tool.output", sequence: 3, timestamp, type: "run" as const },
           { attributes: { "tool.id": "command", "tool.output": { summary: "Still running" }, "tool.name": "shell" }, name: "agent.tool.progress", sequence: 4, timestamp, type: "run" as const },
-          { attributes: { "tool.id": "command", "tool.output": { detail: "terminal state" }, "tool.name": "shell" }, name: terminalName, sequence: 5, timestamp, type: terminalName.endsWith(".error") ? "error" as const : "run" as const },
+          { attributes: { "tool.id": "command", "tool.output": { detail: "terminal state" }, "tool.name": "shell" }, name: terminalName, sequence: 5, timestamp: terminalTimestamp, type: terminalName.endsWith(".error") ? "error" as const : "run" as const },
         ],
         status: "completed" as const,
         traceId: "trace",
         updatedAt: timestamp,
       } satisfies AgentInvocationView;
 
-      expect(invocationActivities(invocation)[0]?.command?.output).toBe("first\nsecond\n");
+      expect(invocationActivities(invocation)[0]).toMatchObject({
+        command: { output: "first\nsecond\n" },
+        durationMs: 1_000,
+        endedAt: terminalTimestamp,
+      });
     },
   );
 

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -621,7 +621,7 @@ describe("Agent Invocation UI", () => {
       id: "failed-task",
       observations: [
         { attributes: { "step.id": "task" }, name: "agent.task.started", sequence: 1, timestamp, type: "run" as const },
-        { attributes: { "error.message": "Task failed", "step.id": "task" }, name: "agent.task.failed", sequence: 2, timestamp: failedAt, type: "error" as const },
+        { attributes: { "error.message": "Task failed", "step.id": "task" }, name: "agent.task.failed", sequence: 2, timestamp: failedAt, type: "run" as const },
       ],
       status: "completed" as const,
       traceId: "trace",
@@ -632,6 +632,28 @@ describe("Agent Invocation UI", () => {
       durationMs: 1_000,
       endedAt: failedAt,
       status: "failed",
+    });
+  });
+
+  it("extends running activities through the invocation update", () => {
+    const timestamp = "2026-08-22T00:00:00.000Z";
+    const updatedAt = "2026-08-22T00:00:03.000Z";
+    const invocation = {
+      createdAt: timestamp,
+      id: "running-tool",
+      observations: [
+        { attributes: { "tool.id": "command", "tool.name": "shell" }, name: "agent.tool.start", sequence: 1, timestamp, type: "run" as const },
+        { attributes: { "tool.id": "command", "tool.name": "shell" }, name: "agent.tool.progress", sequence: 2, timestamp: "2026-08-22T00:00:01.000Z", type: "run" as const },
+      ],
+      status: "running" as const,
+      traceId: "trace",
+      updatedAt,
+    } satisfies AgentInvocationView;
+
+    expect(invocationActivities(invocation)[0]).toMatchObject({
+      durationMs: 3_000,
+      endedAt: updatedAt,
+      status: "running",
     });
   });
 

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -636,6 +636,7 @@ onBeforeUnmount(() => {
 .vitehub-console [data-slot="invocation"],
 .vitehub-console [data-slot="invocation-inspector"] {
   height: 100%;
+  width: 100%;
 }
 
 .vitehub-console [data-slot="invocation-inspector"] {

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -29,6 +29,7 @@ export function createConsoleInvocations(projectRoot: string): AgentInvocations 
       "input.prompt",
       "message.content",
       "result.text",
+      "tool.error",
       "tool.input",
       "tool.output",
       "vitehub.activity.progress",

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -29,6 +29,8 @@ export function createConsoleInvocations(projectRoot: string): AgentInvocations 
       "input.prompt",
       "message.content",
       "result.text",
+      "tool.input",
+      "tool.output",
       "vitehub.activity.progress",
     ],
     store: createLibsqlAgentInvocationStore({

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -29,7 +29,6 @@ export function createConsoleInvocations(projectRoot: string): AgentInvocations 
       "input.prompt",
       "message.content",
       "result.text",
-      "tool.error",
       "tool.input",
       "tool.output",
       "vitehub.activity.progress",

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -783,13 +783,12 @@ describe("Agent invocation console", () => {
       for await (const _event of result as AsyncIterable<unknown>) {}
 
       const invocation = await createConsoleInvocations(projectRoot).getByRunId("console-tool-error")
-      expect(invocation?.observations).toContainEqual(expect.objectContaining({
-        attributes: expect.objectContaining({
-          "content.omitted": expect.not.arrayContaining(["tool.error"]),
-          "tool.error": "Lookup failed",
-        }),
+      const observation = invocation?.observations.find(item => item.name === "agent.tool.error")
+      expect(observation).toEqual(expect.objectContaining({
+        attributes: expect.objectContaining({ "tool.error": "Lookup failed" }),
         name: "agent.tool.error",
       }))
+      expect(observation?.attributes["content.omitted"] ?? []).not.toContain("tool.error")
     }
     finally {
       await rm(projectRoot, { force: true, recursive: true })

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -766,6 +766,36 @@ describe("Agent invocation console", () => {
     }
   })
 
+  it("preserves failed tool payloads in the console journal", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "vitehub-console-tool-error-"))
+    try {
+      installConsoleInvocations(projectRoot)
+      const agent = defineAgent({
+        driver: { run: () => (async function* () {
+            yield { id: "tool-1", input: { query: "missing" }, name: "lookup", type: "tool-call" }
+            yield { error: "Lookup failed", id: "tool-1", name: "lookup", type: "tool-result" }
+            yield { type: "finish" }
+          })() },
+        runtime: false,
+      })
+      const result = await runAgent(agent, runtime("console-tool-error"), {})
+      // SAFETY: This Driver fixture always returns the async generator defined above.
+      for await (const _event of result as AsyncIterable<unknown>) {}
+
+      const invocation = await createConsoleInvocations(projectRoot).getByRunId("console-tool-error")
+      expect(invocation?.observations).toContainEqual(expect.objectContaining({
+        attributes: expect.objectContaining({
+          "content.omitted": expect.not.arrayContaining(["tool.error"]),
+          "tool.error": "Lookup failed",
+        }),
+        name: "agent.tool.error",
+      }))
+    }
+    finally {
+      await rm(projectRoot, { force: true, recursive: true })
+    }
+  })
+
   it("accepts public read-only requests", () => {
     expect(() => assertConsoleRequest(event("203.0.113.2"))).not.toThrow()
     expect(() => assertConsoleRequest(event(undefined))).not.toThrow()

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -754,7 +754,8 @@ describe("Agent invocation console", () => {
       const invocation = await createConsoleInvocations(projectRoot).getByRunId("console-progress-summary")
       expect(invocation?.observations).toContainEqual(expect.objectContaining({
         attributes: expect.objectContaining({
-          "content.omitted": expect.arrayContaining(["tool.output", "vitehub.activity.body", "vitehub.activity.title"]),
+          "content.omitted": expect.not.arrayContaining(["tool.output"]),
+          "tool.output": expect.anything(),
           "vitehub.activity.progress": "Checking Airtable for assigned tasks.",
         }),
         name: "agent.tool.finish",

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -262,6 +262,7 @@ describe("framework package contract", () => {
     expect(readFileSync(`${packageRoot}/dist/cloudflare-types.d.ts`, "utf8")).toContain("@cloudflare/workers-types")
     const consolePage = readFileSync(`${packageRoot}/dist/console/runtime/components/console-app.vue`, "utf8")
     expect(consolePage).toContain('from "../agent-route"')
+    expect(consolePage).toMatch(/\[data-slot="invocation"\],[\s\S]*?\[data-slot="invocation-inspector"\]\s*\{[\s\S]*?height: 100%;[\s\S]*?width: 100%;[\s\S]*?\}/)
     expect(existsSync(`${packageRoot}/dist/console/runtime/agent-route.js`)).toBe(true)
     expect(existsSync(`${packageRoot}/dist/console/runtime/client/request.js`)).toBe(true)
     expect(existsSync(`${packageRoot}/dist/console/runtime/client/request.d.ts`)).toBe(true)


### PR DESCRIPTION
The Console now shows a timed Agent and ViteHub trace in invocation details and renders ordinary tool payloads as separate Input, Output, or Error blocks. It also fixes splitter child sizing so the session and inspector do not collapse, while keeping existing ViteHub action, command, and file-diff rendering unchanged.

## Test plan

- `pnpm --filter @vite-hub/ui test` (116 tests passed, no type errors)
- `pnpm --filter vite-hub exec vp test test/package.test.ts` (10 tests passed, no type errors)
- Patched Calories consumer verified in the browser at desktop and mobile widths, including hover, focus, tool disclosure, and the inspector slideover

The full `vite-hub` suite reached 212 passing tests, but 20 unrelated tests failed because this requested `/tmp` clone resolves a stray `/tmp/package.json` as the project root. The focused built-package contract test passes.