### PR TITLE
feat(ui): navigate and explore console traces

### DIFF
--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -151,12 +151,13 @@ function matchingPayloadRows(
   rows: Array<{ path: string; value: string }> = [],
   depth = 0,
 ) {
-  if (rows.length >= 500 || depth >= 12) return rows;
+  if (rows.length >= 500) return rows;
   if (typeof value !== "object" || value === null) {
     const label = jsonValueLabel(value);
     if (`${path} ${label}`.toLocaleLowerCase().includes(query)) rows.push({ path, value: label });
     return rows;
   }
+  if (depth >= 12) return rows;
   for (const [key, item] of Object.entries(value)) {
     matchingPayloadRows(item, query, Array.isArray(value) ? `${path}[${key}]` : `${path}.${key}`, rows, depth + 1);
     if (rows.length >= 500) break;
@@ -187,18 +188,24 @@ function renderPayloadTree(
     ]);
   }
   const entries = Object.entries(value);
-  const visibleEntries = entries.slice(0, Math.max(0, budget.remaining - 1));
-  const truncated = visibleEntries.length < entries.length;
+  const children: ReturnType<typeof h>[] = [];
+  for (let index = 0; index < entries.length; index++) {
+    if (budget.remaining <= 0) break;
+    if (budget.remaining === 1) {
+      budget.remaining--;
+      children.push(h("li", { class: "vh-invocation-payload__leaf" }, "More fields hidden"));
+      break;
+    }
+    const [key, item] = entries[index]!;
+    children.push(renderPayloadTree(item, key, depth + 1, budget));
+  }
   return h("li", { class: "vh-invocation-payload__branch" }, [
     h("details", { open: depth < 1 }, [
       h("summary", [
         label ? h("code", { class: "vh-invocation-payload__key" }, label) : null,
         h("span", Array.isArray(value) ? `Array(${entries.length})` : `{${entries.length}}`),
       ]),
-      h("ul", [
-        ...visibleEntries.map(([key, item]) => renderPayloadTree(item, key, depth + 1, budget)),
-        truncated ? h("li", { class: "vh-invocation-payload__leaf" }, "More fields hidden") : null,
-      ]),
+      h("ul", children),
     ]),
   ]);
 }
@@ -1123,11 +1130,12 @@ export const AgentInvocation = defineComponent({
     }
 
     async function focusActivity(id: string | undefined) {
-      clearSelectedElement();
-      if (!id) return;
       await nextTick();
       const target = [...(root.value?.querySelectorAll<HTMLElement>("[data-activity-id]") ?? [])]
         .find(element => element.dataset.activityId === id);
+      if (target && target === selectedElement) return;
+      clearSelectedElement();
+      if (!id) return;
       if (!target) return;
       let details = target.closest("details");
       while (details) {
@@ -1142,7 +1150,7 @@ export const AgentInvocation = defineComponent({
       selectedElement = target;
     }
 
-    watch([() => props.selectedActivityId, activities], ([id]) => void focusActivity(id), { immediate: true });
+    watch([() => props.selectedActivityId, activities], ([id]) => void focusActivity(id), { flush: "post", immediate: true });
     onBeforeUnmount(clearSelectedElement);
 
     return () => {

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -187,13 +187,18 @@ function renderPayloadTree(
     ]);
   }
   const entries = Object.entries(value);
+  const visibleEntries = entries.slice(0, Math.max(0, budget.remaining - 1));
+  const truncated = visibleEntries.length < entries.length;
   return h("li", { class: "vh-invocation-payload__branch" }, [
     h("details", { open: depth < 1 }, [
       h("summary", [
         label ? h("code", { class: "vh-invocation-payload__key" }, label) : null,
         h("span", Array.isArray(value) ? `Array(${entries.length})` : `{${entries.length}}`),
       ]),
-      h("ul", entries.slice(0, Math.max(0, budget.remaining)).map(([key, item]) => renderPayloadTree(item, key, depth + 1, budget))),
+      h("ul", [
+        ...visibleEntries.map(([key, item]) => renderPayloadTree(item, key, depth + 1, budget)),
+        truncated ? h("li", { class: "vh-invocation-payload__leaf" }, "More fields hidden") : null,
+      ]),
     ]),
   ]);
 }
@@ -202,7 +207,7 @@ const InvocationPayload = defineComponent({
   name: "InvocationPayload",
   props: {
     label: { required: true, type: String },
-    value: { required: true, type: null as unknown as PropType<unknown> },
+    value: { required: true },
   },
   setup(props) {
     const mode = ref<"tree" | "raw">("tree");
@@ -483,7 +488,7 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
               ]),
               command.cwd ? h("div", { class: "vh-invocation-command__cwd" }, command.cwd) : null,
               command.output ? h("pre", terminalText(command.output)) : null,
-              renderEventPayload("Error", activity.attributes["tool.error"]),
+              renderCommandError(activity.attributes["tool.error"]),
             ])
           : hasPayloads
             ? h("div", { class: "vh-invocation-event__payloads" }, [
@@ -509,6 +514,15 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
 function renderEventPayload(label: string, value: unknown) {
   if (value === undefined) return null;
   return h(InvocationPayload, { label, value });
+}
+
+function renderCommandError(value: unknown) {
+  if (value === undefined) return null;
+  const text = Object.prototype.toString.call(value) === "[object String]" ? String(value) : JSON.stringify(value, null, 2);
+  return h("section", { class: "vh-invocation-event__payload" }, [
+    h("strong", "Error"),
+    h("pre", text),
+  ]);
 }
 
 function activityDetail(activity: InvocationActivity): string | undefined {
@@ -1128,7 +1142,7 @@ export const AgentInvocation = defineComponent({
       selectedElement = target;
     }
 
-    watch(() => props.selectedActivityId, id => void focusActivity(id), { immediate: true });
+    watch([() => props.selectedActivityId, activities], ([id]) => void focusActivity(id), { immediate: true });
     onBeforeUnmount(clearSelectedElement);
 
     return () => {

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -148,21 +148,23 @@ function matchingPayloadRows(
   value: unknown,
   query: string,
   path = "$",
-  rows: Array<{ path: string; value: string }> = [],
+  result: { rows: Array<{ path: string; value: string }>; truncated: boolean } = { rows: [], truncated: false },
   depth = 0,
 ) {
-  if (rows.length >= 500) return rows;
-  if (typeof value !== "object" || value === null) {
-    const label = jsonValueLabel(value);
-    if (`${path} ${label}`.toLocaleLowerCase().includes(query)) rows.push({ path, value: label });
-    return rows;
+  const label = jsonValueLabel(value);
+  if (`${path} ${label}`.toLocaleLowerCase().includes(query)) {
+    if (result.rows.length >= 500) {
+      result.truncated = true;
+      return result;
+    }
+    result.rows.push({ path, value: label });
   }
-  if (depth >= 12) return rows;
+  if (typeof value !== "object" || value === null || depth >= 12) return result;
   for (const [key, item] of Object.entries(value)) {
-    matchingPayloadRows(item, query, Array.isArray(value) ? `${path}[${key}]` : `${path}.${key}`, rows, depth + 1);
-    if (rows.length >= 500) break;
+    matchingPayloadRows(item, query, Array.isArray(value) ? `${path}[${key}]` : `${path}.${key}`, result, depth + 1);
+    if (result.truncated) break;
   }
-  return rows;
+  return result;
 }
 
 function renderPayloadTree(
@@ -235,7 +237,7 @@ const InvocationPayload = defineComponent({
     const structured = computed(() => typeof normalized.value === "object" && normalized.value !== null);
     const matches = computed(() => query.value
       ? matchingPayloadRows(normalized.value, query.value.toLocaleLowerCase())
-      : []);
+      : { rows: [], truncated: false });
     const rawMatches = computed(() => {
       if (!query.value) return text.value;
       const normalizedQuery = query.value.toLocaleLowerCase();
@@ -293,11 +295,14 @@ const InvocationPayload = defineComponent({
         ]),
         h("span", { "aria-live": "polite", class: "vh-visually-hidden", role: "status" }, copyFailed.value ? `${props.label} could not be copied` : copied.value ? `${props.label} copied` : ""),
         query.value && structured.value && mode.value === "tree"
-          ? matches.value.length
-            ? h("ol", { class: "vh-invocation-payload__matches" }, matches.value.map(match => h("li", [
-                h("code", match.path),
-                h("code", match.value),
-              ])))
+          ? matches.value.rows.length
+            ? h("ol", { class: "vh-invocation-payload__matches" }, [
+                ...matches.value.rows.map(match => h("li", [
+                  h("code", match.path),
+                  h("code", match.value),
+                ])),
+                matches.value.truncated ? h("li", "More matches hidden. Refine your search.") : null,
+              ])
             : h("p", { class: "vh-invocation-payload__empty" }, "No matching fields")
           : structured.value && mode.value === "tree"
             ? h("ul", { class: "vh-invocation-payload__tree" }, [renderPayloadTree(normalized.value)])

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -1,4 +1,4 @@
-import { computed, defineComponent, h, nextTick, onBeforeUnmount, ref, type PropType, Suspense } from "vue";
+import { computed, defineComponent, h, nextTick, onBeforeUnmount, ref, type PropType, Suspense, watch } from "vue";
 import type { AgentInvocationConfiguration, AgentInvocationView } from "../types.ts";
 import {
   agentConfigurationSummary,
@@ -113,6 +113,189 @@ function renderFolderIcon() {
 }
 
 type InspectTarget = "agent" | "workspace";
+
+function payloadText(value: unknown): string {
+  if (typeof value === "string") return value;
+  const ancestors: object[] = [];
+  try {
+    return JSON.stringify(value, function (this: unknown, _key, item: unknown) {
+      if (typeof item === "bigint") return `${item}n`;
+      if (typeof item !== "object" || item === null) return item;
+      while (ancestors.length && ancestors.at(-1) !== this) ancestors.pop();
+      if (ancestors.includes(item)) return "[Circular]";
+      ancestors.push(item);
+      return item;
+    }, 2) ?? String(value);
+  } catch (error) {
+    return error instanceof Error ? `[Unable to display payload: ${error.message}]` : "[Unable to display payload]";
+  }
+}
+
+function payloadPreview(value: unknown, text: string): string {
+  const source = typeof value === "string" ? value : text.replaceAll(/\s+/g, " ");
+  const compact = source.trim();
+  return compact.length > 112 ? `${compact.slice(0, 111)}…` : compact || "Empty payload";
+}
+
+function jsonValueLabel(value: unknown): string {
+  if (typeof value === "string") return JSON.stringify(value);
+  if (value === null) return "null";
+  if (typeof value === "object") return Array.isArray(value) ? `Array(${value.length})` : "Object";
+  return String(value);
+}
+
+function matchingPayloadRows(
+  value: unknown,
+  query: string,
+  path = "$",
+  rows: Array<{ path: string; value: string }> = [],
+  depth = 0,
+) {
+  if (rows.length >= 500 || depth >= 12) return rows;
+  if (typeof value !== "object" || value === null) {
+    const label = jsonValueLabel(value);
+    if (`${path} ${label}`.toLocaleLowerCase().includes(query)) rows.push({ path, value: label });
+    return rows;
+  }
+  for (const [key, item] of Object.entries(value)) {
+    matchingPayloadRows(item, query, Array.isArray(value) ? `${path}[${key}]` : `${path}.${key}`, rows, depth + 1);
+    if (rows.length >= 500) break;
+  }
+  return rows;
+}
+
+function renderPayloadTree(
+  value: unknown,
+  label?: string,
+  depth = 0,
+  budget: { remaining: number } = { remaining: 500 },
+): ReturnType<typeof h> {
+  budget.remaining--;
+  if (budget.remaining < 0) {
+    return h("li", { class: "vh-invocation-payload__leaf" }, "More fields hidden");
+  }
+  if (depth >= 12 && typeof value === "object" && value !== null) {
+    return h("li", { class: "vh-invocation-payload__leaf" }, [
+      label ? h("code", { class: "vh-invocation-payload__key" }, label) : null,
+      h("code", { class: "vh-invocation-payload__value" }, "Nested content hidden"),
+    ]);
+  }
+  if (typeof value !== "object" || value === null) {
+    return h("li", { class: "vh-invocation-payload__leaf" }, [
+      label ? h("code", { class: "vh-invocation-payload__key" }, label) : null,
+      h("code", { class: "vh-invocation-payload__value", "data-type": value === null ? "null" : typeof value }, jsonValueLabel(value)),
+    ]);
+  }
+  const entries = Object.entries(value);
+  return h("li", { class: "vh-invocation-payload__branch" }, [
+    h("details", { open: depth < 1 }, [
+      h("summary", [
+        label ? h("code", { class: "vh-invocation-payload__key" }, label) : null,
+        h("span", Array.isArray(value) ? `Array(${entries.length})` : `{${entries.length}}`),
+      ]),
+      h("ul", entries.slice(0, Math.max(0, budget.remaining)).map(([key, item]) => renderPayloadTree(item, key, depth + 1, budget))),
+    ]),
+  ]);
+}
+
+const InvocationPayload = defineComponent({
+  name: "InvocationPayload",
+  props: {
+    label: { required: true, type: String },
+    value: { required: true, type: null as unknown as PropType<unknown> },
+  },
+  setup(props) {
+    const mode = ref<"tree" | "raw">("tree");
+    const query = ref("");
+    const open = ref(false);
+    const copied = ref(false);
+    const copyFailed = ref(false);
+    let copyTimer: ReturnType<typeof setTimeout> | undefined;
+    const text = computed(() => payloadText(props.value));
+    const normalized = computed<unknown>(() => {
+      if (typeof props.value !== "object" || props.value === null) return props.value;
+      try {
+        return JSON.parse(text.value);
+      } catch {
+        return text.value;
+      }
+    });
+    const structured = computed(() => typeof normalized.value === "object" && normalized.value !== null);
+    const matches = computed(() => query.value
+      ? matchingPayloadRows(normalized.value, query.value.toLocaleLowerCase())
+      : []);
+    const rawMatches = computed(() => {
+      if (!query.value) return text.value;
+      const normalizedQuery = query.value.toLocaleLowerCase();
+      return text.value.split("\n").filter(line => line.toLocaleLowerCase().includes(normalizedQuery)).join("\n");
+    });
+
+    async function copyPayload() {
+      copyFailed.value = false;
+      if (!("navigator" in globalThis) || !navigator.clipboard) {
+        copyFailed.value = true;
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(text.value);
+        copied.value = true;
+        if (copyTimer) clearTimeout(copyTimer);
+        copyTimer = setTimeout(() => { copied.value = false; }, 1_600);
+      } catch {
+        copyFailed.value = true;
+      }
+    }
+
+    onBeforeUnmount(() => {
+      if (copyTimer) clearTimeout(copyTimer);
+    });
+
+    return () => h("details", {
+      class: "vh-invocation-event__payload",
+      onToggle: (event: Event) => { open.value = (event.currentTarget as HTMLDetailsElement).open; },
+      open: open.value,
+    }, [
+      h("summary", [
+        h("strong", props.label),
+        h("code", payloadPreview(props.value, text.value)),
+        h("span", { "aria-hidden": "true", class: "vh-invocation-event__disclosure" }, "⌄"),
+      ]),
+      open.value ? h("div", { class: "vh-invocation-payload__content" }, [
+        h("div", { class: "vh-invocation-payload__toolbar" }, [
+          structured.value ? h("div", { "aria-label": `${props.label} view`, class: "vh-invocation-payload__modes", role: "group" }, [
+            h("button", { "aria-pressed": mode.value === "tree", onClick: () => { mode.value = "tree"; }, type: "button" }, "Tree"),
+            h("button", { "aria-pressed": mode.value === "raw", onClick: () => { mode.value = "raw"; }, type: "button" }, "Raw"),
+          ]) : null,
+          structured.value || text.value.length > 240
+            ? h("label", { class: "vh-invocation-payload__search" }, [
+                h("span", { class: "vh-visually-hidden" }, `Search ${props.label}`),
+                h("input", {
+                  onInput: (event: Event) => { query.value = (event.target as HTMLInputElement).value; },
+                  placeholder: "Search payload",
+                  type: "search",
+                  value: query.value,
+                }),
+              ])
+            : null,
+          h("button", { class: "vh-invocation-payload__copy", onClick: () => void copyPayload(), type: "button" }, copied.value ? "Copied" : "Copy"),
+        ]),
+        h("span", { "aria-live": "polite", class: "vh-visually-hidden", role: "status" }, copyFailed.value ? `${props.label} could not be copied` : copied.value ? `${props.label} copied` : ""),
+        query.value && structured.value && mode.value === "tree"
+          ? matches.value.length
+            ? h("ol", { class: "vh-invocation-payload__matches" }, matches.value.map(match => h("li", [
+                h("code", match.path),
+                h("code", match.value),
+              ])))
+            : h("p", { class: "vh-invocation-payload__empty" }, "No matching fields")
+          : structured.value && mode.value === "tree"
+            ? h("ul", { class: "vh-invocation-payload__tree" }, [renderPayloadTree(normalized.value)])
+            : rawMatches.value
+              ? h("pre", rawMatches.value)
+              : h("p", { class: "vh-invocation-payload__empty" }, "No matching content"),
+      ]) : null,
+    ]);
+  },
+});
 
 const messageRoleLabels: Record<NonNullable<InvocationActivity["role"]>, string> = {
   assistant: "Assistant",
@@ -325,11 +508,7 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
 
 function renderEventPayload(label: string, value: unknown) {
   if (value === undefined) return null;
-  const text = Object.prototype.toString.call(value) === "[object String]" ? String(value) : JSON.stringify(value, null, 2);
-  return h("section", { class: "vh-invocation-event__payload" }, [
-    h("strong", label),
-    h("pre", text),
-  ]);
+  return h(InvocationPayload, { label, value });
 }
 
 function activityDetail(activity: InvocationActivity): string | undefined {
@@ -549,7 +728,11 @@ function timelineOwner(activity: InvocationActivity): "agent" | "vitehub" {
   return "agent";
 }
 
-function traceTimeline(activities: readonly InvocationActivity[], invocation: AgentInvocationView) {
+function traceTimeline(
+  activities: readonly InvocationActivity[],
+  invocation: AgentInvocationView,
+  selectActivity: (id: string) => void,
+) {
   const items = activities.filter(activity => activity.kind !== "message" && Number.isFinite(Date.parse(activity.startedAt ?? "")));
   if (!items.length) return null;
   const invocationStart = Date.parse(invocation.startedAt ?? invocation.createdAt ?? "");
@@ -583,23 +766,26 @@ function traceTimeline(activities: readonly InvocationActivity[], invocation: Ag
       const detail = activityDetail(activity);
       const width = Math.max(1.5, Math.min(100, (duration / span) * 100));
       const left = Math.min(100 - width, Math.max(0, (offset / span) * 100));
-      return h("li", {
-        class: "vh-invocation-timeline__row",
-        "data-owner": owner,
-        key: `timeline:${activity.id}`,
-        tabindex: "0",
-        title: detail ? `${title} — ${detail}` : title,
-      }, [
-        h("div", { class: "vh-invocation-timeline__heading" }, [
-          h("strong", title),
-          h("time", timing),
-        ]),
-        detail ? h("code", { class: "vh-invocation-timeline__detail" }, detail) : null,
-        h("div", { class: "vh-invocation-timeline__track", "aria-hidden": "true" }, [
-          h("span", { style: {
-            left: `${left}%`,
-            width: `${width}%`,
-          } }),
+      return h("li", { key: `timeline:${activity.id}` }, [
+        h("button", {
+          class: "vh-invocation-timeline__row",
+          "data-activity-id": activity.id,
+          "data-owner": owner,
+          onClick: () => selectActivity(activity.id),
+          title: detail ? `${title} — ${detail}` : title,
+          type: "button",
+        }, [
+          h("div", { class: "vh-invocation-timeline__heading" }, [
+            h("strong", title),
+            h("time", timing),
+          ]),
+          detail ? h("code", { class: "vh-invocation-timeline__detail" }, detail) : null,
+          h("div", { class: "vh-invocation-timeline__track", "aria-hidden": "true" }, [
+            h("span", { style: {
+              left: `${left}%`,
+              width: `${width}%`,
+            } }),
+          ]),
         ]),
       ]);
     })),
@@ -900,10 +1086,13 @@ export const AgentInvocation = defineComponent({
   props: {
     header: { default: true, type: Boolean },
     invocation: { required: true, type: Object as PropType<AgentInvocationView> },
+    selectedActivityId: { default: undefined, type: String },
   },
   setup(props, { emit, slots }) {
     const activities = computed(() => invocationActivities(props.invocation));
     const expandedMessages = ref<ReadonlySet<string>>(new Set());
+    const root = ref<HTMLElement>();
+    let selectedElement: HTMLElement | undefined;
 
     function toggleExpanded(id: string) {
       const next = new Set(expandedMessages.value);
@@ -912,11 +1101,42 @@ export const AgentInvocation = defineComponent({
       expandedMessages.value = next;
     }
 
+    function clearSelectedElement() {
+      if (!selectedElement) return;
+      selectedElement.removeAttribute("data-selected");
+      selectedElement.removeAttribute("tabindex");
+      selectedElement = undefined;
+    }
+
+    async function focusActivity(id: string | undefined) {
+      clearSelectedElement();
+      if (!id) return;
+      await nextTick();
+      const target = [...(root.value?.querySelectorAll<HTMLElement>("[data-activity-id]") ?? [])]
+        .find(element => element.dataset.activityId === id);
+      if (!target) return;
+      let details = target.closest("details");
+      while (details) {
+        details.open = true;
+        details = details.parentElement?.closest("details") ?? null;
+      }
+      target.dataset.selected = "true";
+      target.tabIndex = -1;
+      target.focus({ preventScroll: true });
+      const reduceMotion = "matchMedia" in globalThis && matchMedia("(prefers-reduced-motion: reduce)").matches;
+      target.scrollIntoView?.({ behavior: reduceMotion ? "auto" : "smooth", block: "center" });
+      selectedElement = target;
+    }
+
+    watch(() => props.selectedActivityId, id => void focusActivity(id), { immediate: true });
+    onBeforeUnmount(clearSelectedElement);
+
     return () => {
       return h("article", {
         class: ["vh-invocation-session", { "vh-invocation-session--headerless": !props.header }],
         "data-status": props.invocation.status,
         "data-slot": "invocation",
+        ref: root,
       }, [
         props.header ? h("header", { class: "vh-invocation-header" }, [
           h("div", { class: "vh-invocation-header__breadcrumb", title: `${invocationProject(props.invocation)} / ${invocationTitle(props.invocation)}` }, [
@@ -959,10 +1179,13 @@ export const AgentInvocation = defineComponent({
 
 export const AgentInvocationInspector = defineComponent({
   name: "AgentInvocationInspector",
+  emits: {
+    selectActivity: (id: string) => Boolean(id),
+  },
   props: {
     invocation: { required: true, type: Object as PropType<AgentInvocationView> },
   },
-  setup(props, { slots }) {
+  setup(props, { emit, slots }) {
     const activities = computed(() => invocationActivities(props.invocation));
     const copied = ref<"invocation" | "trace">();
     const copyError = ref<"invocation" | "trace">();
@@ -1108,7 +1331,7 @@ export const AgentInvocationInspector = defineComponent({
                   : null,
               ]),
             ),
-            traceTimeline(activities.value, props.invocation),
+            traceTimeline(activities.value, props.invocation, id => emit("selectActivity", id)),
             ...(configuration ? renderConfiguration(configuration) : []),
             slots.metadata?.({ invocation: props.invocation }),
             inspectorSection(

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -89,8 +89,12 @@ function activityBody(attributes: Record<string, unknown>): string | undefined {
     const value = attributes[key];
     if (value === undefined || value === "undefined") continue;
     if (typeof value === "string" && value) return value;
-    const json = JSON.stringify(value, null, 2);
-    if (json) return json;
+    try {
+      const json = JSON.stringify(value, (_key, item: unknown) => typeof item === "bigint" ? `${item}n` : item, 2);
+      if (json) return json;
+    } catch (error) {
+      return error instanceof Error ? `[Unable to display payload: ${error.message}]` : "[Unable to display payload]";
+    }
   }
 }
 

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -959,6 +959,14 @@ button.vh-invocation-lifecycle__row:focus-visible {
   white-space: nowrap;
 }
 
+[data-slot="invocation"] [data-activity-id][data-selected="true"] {
+  background: color-mix(in oklab, var(--vh-ui-info) 9%, transparent);
+  border-radius: calc(var(--vh-ui-radius) * 0.85);
+  outline: 2px solid color-mix(in oklab, var(--vh-ui-info) 42%, transparent);
+  outline-offset: 2px;
+  scroll-margin-block: 5rem;
+}
+
 .vh-invocation-event__summary {
   align-items: center;
   border-radius: inherit;
@@ -1132,23 +1140,119 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 }
 
 .vh-invocation-event__payload {
+  border: 1px solid color-mix(in oklab, var(--vh-ui-border) 78%, transparent);
+  border-radius: calc(var(--vh-ui-radius) * 0.9);
   min-width: 0;
+  overflow: hidden;
 }
 
-.vh-invocation-event__payload > strong {
+.vh-invocation-event__payload > summary {
+  align-items: center;
+  background: color-mix(in oklab, var(--vh-ui-bg-elevated) 65%, transparent);
+  cursor: pointer;
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  list-style: none;
+  min-height: 2.25rem;
+  padding: 0.45rem 0.65rem;
+}
+
+.vh-invocation-event__payload > summary::-webkit-details-marker {
+  display: none;
+}
+
+.vh-invocation-event__payload > summary:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--vh-ui-info) 55%, transparent);
+  outline-offset: -2px;
+}
+
+.vh-invocation-event__payload > summary strong {
   color: var(--vh-ui-dimmed);
-  display: block;
   font-size: 0.6875rem;
   font-weight: 650;
   letter-spacing: 0.08em;
-  margin-block-end: 0.3rem;
   text-transform: uppercase;
 }
 
-.vh-invocation-event__payload > pre {
+.vh-invocation-event__payload > summary code {
+  color: var(--vh-ui-muted);
+  font: 0.75rem/1.4 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.vh-invocation-event__payload[open] > summary .vh-invocation-event__disclosure {
+  transform: rotate(180deg);
+}
+
+.vh-invocation-payload__content {
+  border-block-start: 1px solid color-mix(in oklab, var(--vh-ui-border) 72%, transparent);
+  padding: 0.6rem;
+}
+
+.vh-invocation-payload__toolbar {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  margin-block-end: 0.55rem;
+}
+
+.vh-invocation-payload__modes {
+  background: color-mix(in oklab, var(--vh-ui-bg-muted) 76%, transparent);
+  border-radius: calc(var(--vh-ui-radius) * 0.72);
+  display: inline-flex;
+  padding: 0.125rem;
+}
+
+.vh-invocation-payload__toolbar button {
+  background: transparent;
+  border: 0;
+  border-radius: calc(var(--vh-ui-radius) * 0.6);
+  color: var(--vh-ui-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.6875rem;
+  min-height: 1.75rem;
+  padding: 0.25rem 0.5rem;
+}
+
+.vh-invocation-payload__toolbar button:is(:hover, [aria-pressed="true"]) {
+  background: var(--vh-ui-bg-elevated);
+  color: var(--vh-ui-text);
+}
+
+.vh-invocation-payload__toolbar button:focus-visible,
+.vh-invocation-payload__search input:focus-visible {
+  outline: 2px solid color-mix(in oklab, var(--vh-ui-info) 55%, transparent);
+  outline-offset: 1px;
+}
+
+.vh-invocation-payload__search {
+  flex: 1 1 8rem;
+}
+
+.vh-invocation-payload__search input {
+  background: var(--vh-ui-bg);
+  border: 1px solid var(--vh-ui-border);
+  border-radius: calc(var(--vh-ui-radius) * 0.72);
+  color: var(--vh-ui-text);
+  font: inherit;
+  font-size: 0.6875rem;
+  min-height: 1.75rem;
+  padding: 0.25rem 0.5rem;
+  width: 100%;
+}
+
+.vh-invocation-payload__copy {
+  margin-inline-start: auto;
+}
+
+.vh-invocation-payload__content > pre {
   background: color-mix(in oklab, var(--vh-ui-bg-elevated) 65%, transparent);
-  border: 1px solid color-mix(in oklab, var(--vh-ui-border) 78%, transparent);
-  border-radius: calc(var(--vh-ui-radius) * 0.9);
+  border-radius: calc(var(--vh-ui-radius) * 0.72);
   color: var(--vh-ui-text);
   font: 0.75rem/1.55 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   margin: 0;
@@ -1157,6 +1261,79 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   padding: 0.625rem 0.75rem;
   white-space: pre-wrap;
   word-break: break-word;
+}
+
+.vh-invocation-payload__tree,
+.vh-invocation-payload__tree ul,
+.vh-invocation-payload__matches {
+  display: grid;
+  gap: 0.2rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.vh-invocation-payload__tree ul {
+  border-inline-start: 1px solid var(--vh-ui-border);
+  margin: 0.2rem 0 0 0.45rem;
+  padding-inline-start: 0.75rem;
+}
+
+.vh-invocation-payload__branch summary,
+.vh-invocation-payload__leaf {
+  align-items: baseline;
+  display: flex;
+  gap: 0.45rem;
+  min-height: 1.4rem;
+}
+
+.vh-invocation-payload__branch summary {
+  color: var(--vh-ui-dimmed);
+  cursor: pointer;
+  font-size: 0.6875rem;
+}
+
+.vh-invocation-payload__key,
+.vh-invocation-payload__value,
+.vh-invocation-payload__matches code {
+  font: 0.71875rem/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.vh-invocation-payload__key {
+  color: var(--vh-ui-info);
+}
+
+.vh-invocation-payload__value {
+  color: var(--vh-ui-text);
+  overflow-wrap: anywhere;
+}
+
+.vh-invocation-payload__value[data-type="string"] {
+  color: var(--vh-ui-success);
+}
+
+.vh-invocation-payload__matches li {
+  display: grid;
+  gap: 0.15rem;
+  grid-template-columns: minmax(7rem, 0.45fr) minmax(0, 1fr);
+}
+
+.vh-invocation-payload__matches code:first-child {
+  color: var(--vh-ui-info);
+  overflow-wrap: anywhere;
+}
+
+.vh-invocation-payload__matches code:last-child {
+  color: var(--vh-ui-text);
+  overflow-wrap: anywhere;
+}
+
+.vh-invocation-payload__empty {
+  color: var(--vh-ui-dimmed);
+  font-size: 0.75rem;
+  margin: 0;
+  padding: 0.5rem;
+  text-align: center;
 }
 
 .vh-invocation-event__body,
@@ -1474,12 +1651,20 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 }
 
 .vh-invocation-timeline__row {
+  background: transparent;
+  border: 0;
   border-radius: calc(var(--vh-ui-radius) * 0.9);
+  color: inherit;
+  cursor: pointer;
+  display: block;
+  font: inherit;
   min-width: 0;
   outline: 2px solid transparent;
   outline-offset: -2px;
   padding: 0.45rem 0.5rem;
+  text-align: start;
   transition: background-color 160ms cubic-bezier(0.23, 1, 0.32, 1);
+  width: 100%;
 }
 
 .vh-invocation-timeline__row:focus-visible {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -647,6 +647,24 @@ describe("Agent Invocation UI", () => {
     await deepPayload.trigger("toggle");
     await deepPayload.get('input[type="search"]').setValue("visible boundary");
     expect(deepPayload.text()).toContain("$.nested");
+
+    const searchWrapper = mount(AgentInvocation, { props: { invocation: {
+      ...invocation,
+      observations: [{ attributes: {
+        "tool.id": "inspect",
+        "tool.input": { empty: {}, matches: Object.fromEntries(Array.from({ length: 501 }, (_, index) => [`match${index}`, "needle"])) },
+        "tool.name": "inspect",
+      }, name: "agent.tool.start", sequence: 1, timestamp, type: "run" as const }],
+      status: "running" as const,
+    } } });
+    const searchPayload = searchWrapper.get(".vh-invocation-event__payload");
+    (searchPayload.element as HTMLDetailsElement).open = true;
+    await searchPayload.trigger("toggle");
+    await searchPayload.get('input[type="search"]').setValue("empty");
+    expect(searchPayload.text()).toContain("$.empty");
+    await searchPayload.get('input[type="search"]').setValue("needle");
+    expect(searchPayload.findAll(".vh-invocation-payload__matches li")).toHaveLength(501);
+    expect(searchPayload.text()).toContain("More matches hidden. Refine your search.");
   });
 
   it("renders unsafe payloads before a tool reaches a terminal state", () => {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -446,7 +446,7 @@ describe("Agent Invocation UI", () => {
     });
   });
 
-  it("renders structured tool payloads and a timed Agent and ViteHub trace", () => {
+  it("explores structured tool payloads and selects a timed trace activity", async () => {
     const invocation = {
       completedAt: "2026-08-22T00:00:03.000Z",
       createdAt: "2026-08-22T00:00:00.000Z",
@@ -520,14 +520,30 @@ describe("Agent Invocation UI", () => {
     ]);
 
     const thread = mount(AgentInvocation, { props: { invocation } });
-    expect(thread.findAll(".vh-invocation-event__payload > strong").map(item => item.text())).toEqual([
+    expect(thread.findAll(".vh-invocation-event__payload > summary > strong").map(item => item.text())).toEqual([
       "Input",
       "Output",
       "Error",
     ]);
     expect(thread.text()).toContain("Private query omitted.");
-    expect(thread.findAll(".vh-invocation-event__payload pre").at(-2)!.element.textContent).toBe("  Returned 1 row.\n");
-    expect(thread.findAll(".vh-invocation-event__payload pre").at(-1)!.text()).toBe("Result was incomplete.");
+    expect(thread.text()).toContain("Returned 1 row.");
+    expect(thread.text()).toContain("Result was incomplete.");
+    const payloads = thread.findAll(".vh-invocation-event__payload");
+    expect(payloads[0]!.get("summary code").text()).toContain("Private query omitted.");
+    expect(payloads[0]!.find(".vh-invocation-payload__content").exists()).toBe(false);
+    (payloads[0]!.element as HTMLDetailsElement).open = true;
+    await payloads[0]!.trigger("toggle");
+    expect(payloads[0]!.findAll(".vh-invocation-payload__key").map(item => item.text())).toContain("summary");
+    await payloads[0]!.get('button[aria-pressed="false"]').trigger("click");
+    expect(payloads[0]!.get("pre").text()).toContain('"summary": "Private query omitted."');
+    await payloads[0]!.get('input[type="search"]').setValue("missing");
+    await payloads[0]!.get('button[aria-pressed="false"]').trigger("click");
+    expect(payloads[0]!.text()).toContain("No matching fields");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", { configurable: true, value: { writeText } });
+    await payloads[0]!.get(".vh-invocation-payload__copy").trigger("click");
+    expect(writeText).toHaveBeenCalledWith('{\n  "summary": "Private query omitted."\n}');
+    expect(payloads[0]!.get(".vh-invocation-payload__copy").text()).toBe("Copied");
 
     const inspector = mount(AgentInvocationInspector, { props: { invocation } });
     const rows = inspector.findAll(".vh-invocation-timeline__row");
@@ -539,6 +555,76 @@ describe("Agent Invocation UI", () => {
     expect(rows[0]!.text()).toContain("+250ms · 500ms");
     expect(rows[1]!.attributes("data-owner")).toBe("agent");
     expect(rows[1]!.text()).toContain("+1s · 1s");
+    await rows[1]!.trigger("click");
+    expect(inspector.emitted("selectActivity")).toEqual([[rows[1]!.attributes("data-activity-id")]]);
+
+    const selected = mount(AgentInvocation, {
+      props: { invocation, selectedActivityId: rows[0]!.attributes("data-activity-id") },
+    });
+    await nextTick();
+    const selectedEvent = selected.get(`[data-activity-id="${rows[0]!.attributes("data-activity-id")}"]`);
+    expect(selectedEvent.attributes("data-selected")).toBe("true");
+    expect((selectedEvent.element.closest("details") as HTMLDetailsElement).open).toBe(true);
+    await selected.setProps({ selectedActivityId: undefined });
+    await selected.setProps({ selectedActivityId: rows[0]!.attributes("data-activity-id") });
+    await nextTick();
+    expect(selected.get(`[data-activity-id="${rows[0]!.attributes("data-activity-id")}"]`).attributes("data-selected")).toBe("true");
+  });
+
+  it("bounds large payload trees and safely serializes repeated and circular values", async () => {
+    const shared = { value: "shared" };
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const input = {
+      big: 12n,
+      circular,
+      fields: Object.fromEntries(Array.from({ length: 800 }, (_, index) => [`field${index}`, index])),
+      first: shared,
+      second: shared,
+    };
+    const timestamp = "2026-08-22T00:00:00.000Z";
+    const invocation = {
+      createdAt: timestamp,
+      id: "large-payload",
+      observations: [
+        { attributes: { "tool.id": "inspect", "tool.input": input, "tool.name": "inspect" }, name: "agent.tool.start", sequence: 1, timestamp, type: "run" as const },
+        { attributes: { "tool.id": "inspect", "tool.name": "inspect", "tool.output": { ok: true } }, name: "agent.tool.finish", sequence: 2, timestamp, type: "run" as const },
+      ],
+      status: "completed" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    const payload = wrapper.findAll(".vh-invocation-event__payload")[0]!;
+
+    expect(payload.find(".vh-invocation-payload__tree").exists()).toBe(false);
+    (payload.element as HTMLDetailsElement).open = true;
+    await payload.trigger("toggle");
+    expect(payload.findAll(".vh-invocation-payload__leaf").length).toBeLessThanOrEqual(500);
+
+    await payload.get('button[aria-pressed="false"]').trigger("click");
+    const raw = payload.get("pre").text();
+    expect(raw.match(/"value": "shared"/g)).toHaveLength(2);
+    expect(raw).toContain('"self": "[Circular]"');
+    expect(raw).toContain('"big": "12n"');
+  });
+
+  it("renders a safe fallback when reading a payload throws", () => {
+    const input = { toJSON() { throw new Error("serialization failed"); } };
+    const timestamp = "2026-08-22T00:00:00.000Z";
+    const invocation = {
+      createdAt: timestamp,
+      id: "throwing-payload",
+      observations: [
+        { attributes: { "tool.id": "inspect", "tool.input": input, "tool.name": "inspect" }, name: "agent.tool.start", sequence: 1, timestamp, type: "run" as const },
+        { attributes: { "tool.id": "inspect", "tool.name": "inspect", "tool.output": { ok: true } }, name: "agent.tool.finish", sequence: 2, timestamp, type: "run" as const },
+      ],
+      status: "completed" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+
+    expect(mount(AgentInvocation, { props: { invocation } }).text()).toContain("Unable to display payload: serialization failed");
   });
 
   it("keeps rounded and terminal trace timings inside their bounds", () => {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -582,6 +582,11 @@ describe("Agent Invocation UI", () => {
       props: { invocation: { ...regroupedInvocation, status: "running" }, selectedActivityId: regroupedActivityId },
     });
     await nextTick();
+    const focusedEvent = regrouped.get(`[data-activity-id="${regroupedActivityId}"]`).element;
+    const focus = vi.spyOn(focusedEvent as HTMLElement, "focus");
+    await regrouped.setProps({ invocation: { ...regroupedInvocation, status: "running" } });
+    await nextTick();
+    expect(focus).not.toHaveBeenCalled();
     await regrouped.setProps({ invocation: regroupedInvocation });
     await nextTick();
     const regroupedEvent = regrouped.get(`[data-activity-id="${regroupedActivityId}"]`);
@@ -597,6 +602,7 @@ describe("Agent Invocation UI", () => {
       big: 12n,
       circular,
       fields: Object.fromEntries(Array.from({ length: 800 }, (_, index) => [`field${index}`, index])),
+      siblings: Object.fromEntries(Array.from({ length: 800 }, (_, index) => [`sibling${index}`, index])),
       first: shared,
       second: shared,
     };
@@ -618,7 +624,7 @@ describe("Agent Invocation UI", () => {
     expect(payload.find(".vh-invocation-payload__tree").exists()).toBe(false);
     (payload.element as HTMLDetailsElement).open = true;
     await payload.trigger("toggle");
-    expect(payload.findAll(".vh-invocation-payload__leaf").length).toBeLessThanOrEqual(500);
+    expect(payload.findAll("li")).toHaveLength(500);
     expect(payload.text()).toContain("More fields hidden");
 
     await payload.get('button[aria-pressed="false"]').trigger("click");
@@ -626,6 +632,21 @@ describe("Agent Invocation UI", () => {
     expect(raw.match(/"value": "shared"/g)).toHaveLength(2);
     expect(raw).toContain('"self": "[Circular]"');
     expect(raw).toContain('"big": "12n"');
+
+    const deep = Array.from({ length: 11 }).reduce<Record<string, unknown>>(
+      value => ({ nested: value }),
+      { needle: "visible boundary" },
+    );
+    const deepWrapper = mount(AgentInvocation, { props: { invocation: {
+      ...invocation,
+      observations: [{ attributes: { "tool.id": "inspect", "tool.input": deep, "tool.name": "inspect" }, name: "agent.tool.start", sequence: 1, timestamp, type: "run" as const }],
+      status: "running" as const,
+    } } });
+    const deepPayload = deepWrapper.get(".vh-invocation-event__payload");
+    (deepPayload.element as HTMLDetailsElement).open = true;
+    await deepPayload.trigger("toggle");
+    await deepPayload.get('input[type="search"]').setValue("visible boundary");
+    expect(deepPayload.text()).toContain("$.nested");
   });
 
   it("renders unsafe payloads before a tool reaches a terminal state", () => {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -569,6 +569,24 @@ describe("Agent Invocation UI", () => {
     await selected.setProps({ selectedActivityId: rows[0]!.attributes("data-activity-id") });
     await nextTick();
     expect(selected.get(`[data-activity-id="${rows[0]!.attributes("data-activity-id")}"]`).attributes("data-selected")).toBe("true");
+
+    const regroupedInvocation = {
+      ...invocation,
+      observations: [
+        { attributes: { "message.content": "Inspect the repository", "message.id": "user", "message.role": "user" }, name: "agent.message", sequence: 0, timestamp: invocation.startedAt, type: "lifecycle" as const },
+        ...invocation.observations,
+      ],
+    } satisfies AgentInvocationView;
+    const regroupedActivityId = invocationActivities(regroupedInvocation).find(activity => activity.kind === "tool")!.id;
+    const regrouped = mount(AgentInvocation, {
+      props: { invocation: { ...regroupedInvocation, status: "running" }, selectedActivityId: regroupedActivityId },
+    });
+    await nextTick();
+    await regrouped.setProps({ invocation: regroupedInvocation });
+    await nextTick();
+    const regroupedEvent = regrouped.get(`[data-activity-id="${regroupedActivityId}"]`);
+    expect(regroupedEvent.attributes("data-selected")).toBe("true");
+    expect(regroupedEvent.element.closest(".vh-invocation-work__details")).toHaveProperty("open", true);
   });
 
   it("bounds large payload trees and safely serializes repeated and circular values", async () => {
@@ -601,6 +619,7 @@ describe("Agent Invocation UI", () => {
     (payload.element as HTMLDetailsElement).open = true;
     await payload.trigger("toggle");
     expect(payload.findAll(".vh-invocation-payload__leaf").length).toBeLessThanOrEqual(500);
+    expect(payload.text()).toContain("More fields hidden");
 
     await payload.get('button[aria-pressed="false"]').trigger("click");
     const raw = payload.get("pre").text();
@@ -609,7 +628,7 @@ describe("Agent Invocation UI", () => {
     expect(raw).toContain('"big": "12n"');
   });
 
-  it("renders a safe fallback when reading a payload throws", () => {
+  it("renders unsafe payloads before a tool reaches a terminal state", () => {
     const input = { toJSON() { throw new Error("serialization failed"); } };
     const timestamp = "2026-08-22T00:00:00.000Z";
     const invocation = {
@@ -617,9 +636,8 @@ describe("Agent Invocation UI", () => {
       id: "throwing-payload",
       observations: [
         { attributes: { "tool.id": "inspect", "tool.input": input, "tool.name": "inspect" }, name: "agent.tool.start", sequence: 1, timestamp, type: "run" as const },
-        { attributes: { "tool.id": "inspect", "tool.name": "inspect", "tool.output": { ok: true } }, name: "agent.tool.finish", sequence: 2, timestamp, type: "run" as const },
       ],
-      status: "completed" as const,
+      status: "running" as const,
       traceId: "trace",
       updatedAt: timestamp,
     } satisfies AgentInvocationView;

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { AgentInvocation, AgentInvocationInspector, AgentInvocationList } from "@vite-hub/ui";
 import { useAgentInvocation, useAgentInvocations } from "vite-hub/agent/vue";
-import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 
 import type { DropdownMenuItem, SplitterItem } from "@nuxt/ui";
@@ -30,6 +30,7 @@ const nowMs = ref(Date.now());
 const sessionsOpen = ref(false);
 const sessionsCollapsed = ref(false);
 const detailsOpen = ref(false);
+const selectedActivityId = ref<string>();
 const isDesktop = ref(false);
 const pageVisible = ref(!import.meta.env.SSR && document.visibilityState !== "hidden");
 let clock: ReturnType<typeof setInterval> | undefined;
@@ -152,6 +153,12 @@ const syncLabel = computed(() => {
   if (!syncStale.value) return "Updated now";
   return `Stale · ${relativeDuration(syncAgeMs.value)}`;
 });
+
+function selectActivity(id: string) {
+  selectedActivityId.value = undefined;
+  if (!isDesktop.value) detailsOpen.value = false;
+  void nextTick(() => { selectedActivityId.value = id; });
+}
 
 function record(value: unknown): Record<string, unknown> | undefined {
   return value instanceof Object && !Array.isArray(value)
@@ -316,6 +323,10 @@ watch(
     });
   },
 );
+
+watch(selectedInvocationId, () => {
+  selectedActivityId.value = undefined;
+});
 
 onMounted(() => {
   media = window.matchMedia("(min-width: 1024px)");
@@ -558,7 +569,7 @@ onBeforeUnmount(() => {
             class="min-h-0 flex-1"
           >
             <template #thread
-              ><AgentInvocation :invocation="invocationView" class="h-full"
+              ><AgentInvocation :invocation="invocationView" :selected-activity-id="selectedActivityId" class="h-full"
                 ><template #title>{{ selectedTitle }}</template
                 ><template #actions
                   ><UTooltip text="Session details"
@@ -572,7 +583,7 @@ onBeforeUnmount(() => {
                       @click="detailsOpen = !detailsOpen" /></UTooltip></template></AgentInvocation
             ></template>
             <template #details
-              ><AgentInvocationInspector :invocation="invocationView" class="h-full"
+              ><AgentInvocationInspector :invocation="invocationView" class="h-full" @select-activity="selectActivity"
                 ><template #actions
                   ><UButton
                     icon="i-lucide-panel-right-close"
@@ -583,7 +594,7 @@ onBeforeUnmount(() => {
                     @click="detailsOpen = false" /></template></AgentInvocationInspector
             ></template>
           </USplitter>
-          <AgentInvocation v-else :invocation="invocationView" class="min-h-0 flex-1"
+          <AgentInvocation v-else :invocation="invocationView" :selected-activity-id="selectedActivityId" class="min-h-0 flex-1"
             ><template #title>{{ selectedTitle }}</template
             ><template #actions
               ><div class="flex items-center gap-1">
@@ -610,7 +621,7 @@ onBeforeUnmount(() => {
             title="Session details"
             :ui="{ content: 'w-full max-w-sm p-0' }"
             ><template #content
-              ><AgentInvocationInspector :invocation="invocationView" class="h-full"
+              ><AgentInvocationInspector :invocation="invocationView" class="h-full" @select-activity="selectActivity"
                 ><template #actions
                   ><UButton
                     icon="i-lucide-x"


### PR DESCRIPTION
Trace timeline rows are now accessible navigation controls that reveal, focus, and highlight the corresponding event in the session thread. Structured tool payloads stay compact by default, then provide bounded Tree and Raw views with search and copy actions; serialization preserves shared references, labels true cycles, and safely handles unsupported values. Existing command, file-diff, and ViteHub preparation renderers remain unchanged.

## Test plan

- `pnpm --filter @vite-hub/ui exec vp test test/invocation-ui.test.ts` (69 tests passed, no type errors)
- `pnpm --filter @vite-hub/ui exec tsc --noEmit -p ./tsconfig.json`
- Strict Vite Doctor scan against `origin/main` (no new errors)
