### PR TITLE
docs(browser): improve first-use README

### DIFF
--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -1,43 +1,28 @@
 # `@vite-hub/browser`
 
-Browser Definitions and provider-backed actions for deterministic server-side browser automation.
+`@vite-hub/browser` runs trusted server-side browser work through named Browser Definitions, stateless actions, or caller-managed sessions.
 
-Use an action directly when the operation does not need a persistent session:
+Browser Definitions and actions currently use Cloudflare Browser Run. Low-level clients can instead start a local Chromium process on a trusted Node host.
 
-```ts
-import { runBrowserContent } from "@vite-hub/browser/actions"
+The package requires Node.js 24.15 or newer.
 
-const [error, html] = await runBrowserContent("https://example.com")
-if (error) throw error
-```
+## Choose the package
 
-Application code can also define a named browser operation without exposing its provider:
+| Project                              | Install                      | Import from                                                               |
+| ------------------------------------ | ---------------------------- | ------------------------------------------------------------------------- |
+| A ViteHub application                | `pnpm add vite-hub`          | `vite-hub/browser` and `vite-hub/browser/actions`                         |
+| A direct Vite integration or library | `pnpm add @vite-hub/browser` | `@vite-hub/browser`, its `/actions` subpath, and `@vite-hub/browser/vite` |
 
-```ts
-import { defineBrowser } from "@vite-hub/browser"
+Use `vite-hub` for normal application code. It includes this package and keeps the Browser integration with the rest of the ViteHub deployment.
 
-export default defineBrowser(async (
-  input: { url: string },
-  { browser },
-) => {
-  return await browser.content(input.url)
-})
-```
+Install `@vite-hub/browser` directly when you compose Vite integrations yourself or need explicit providers and controllers. Choose one import family for application code so its package dependency stays clear.
 
-Place definitions in `server/browsers/` or name them `*.browser.ts`, then run them by name:
+## Get rendered HTML
+
+Enable Browser on a Cloudflare deployment:
 
 ```ts
-import { runBrowser } from "@vite-hub/browser"
-
-const [error, image] = await runBrowser("code-image", {
-  url: "https://example.com",
-})
-if (error) throw error
-```
-
-Enable Browser through the ViteHub deployment:
-
-```ts
+// vite.config.ts
 import { defineConfig } from "vite"
 import { vitehub } from "vite-hub"
 
@@ -51,32 +36,142 @@ export default defineConfig({
 })
 ```
 
-ViteHub generates the Cloudflare Browser Run binding and uses its Quick Actions directly for `browser.content()` and `browser.run()`. The Kitesurf default applies only when `browser.open()` creates a full browser session. `runBrowser()` returns an error-first result, so application code handles runtime failures without a `try/catch`.
+Call a stateless action from trusted server code:
 
-Use a definition-owned page when the operation needs multiple interactions. ViteHub controls the page through CDP and closes it after the definition finishes.
+```ts
+import { runBrowserContent } from "vite-hub/browser/actions"
 
-Kitesurf sessions work with the Browser binding alone. When `browser: { engine: "chromium" }` opens a persistent Chromium session, install the optional `@cloudflare/playwright` and `playwright-core` peers used to acquire that session.
+export async function checkExampleDomain() {
+  const [error, html] = await runBrowserContent("https://example.com")
+  if (error) throw error
 
-## Low-level sessions
+  return { found: html.includes("<h1>Example Domain</h1>") }
+}
+```
 
-`createBrowser()` remains available for standalone integrations where the caller explicitly owns provider selection, controller selection, and cleanup. Playwright stays on this path instead of being selected implicitly by a Browser Definition:
+Calling `checkExampleDomain()` through a server route, Queue, or Workflow returns:
+
+```json
+{ "found": true }
+```
+
+This example uses a fixed public URL. If a request supplies the destination, validate the protocol and allow-list the hosts before starting browser work. A browser can send requests to every destination its provider can reach, and the returned page is untrusted input.
+
+ViteHub writes the Cloudflare Browser binding and required compatibility fields to generated Provider Output. The action runs only where that binding is available. For local Wrangler development that must call the hosted Browser Run service, configure `browser: { remote: true }`. This uses a Cloudflare account and network access; it does not switch Browser Definitions to the local Chromium provider.
+
+## Reuse a named operation
+
+Use a Browser Definition when several callers need the same input and result contract. Place the file in `server/browsers/` or name it `*.browser.ts`:
+
+```ts
+// server/browsers/page-content.ts
+import { defineBrowser } from "vite-hub/browser"
+
+export default defineBrowser(async (input: { url: string }, { browser }) => {
+  return await browser.content(input.url)
+})
+```
+
+Run the discovered Definition by name:
+
+```ts
+import { runBrowser } from "vite-hub/browser"
+
+const [error, html] = await runBrowser("page-content", {
+  url: "https://example.com",
+})
+if (error) throw error
+
+console.log(html.includes("<h1>Example Domain</h1>")) // true
+```
+
+The generated Browser registry infers the Definition's input and result types. `runBrowser()` returns an error-first result with a stable `BROWSER_*` code when discovery or provider execution fails.
+
+Keep target validation beside the route or job that accepts the URL. A reusable Definition does not make an untrusted destination safe.
+
+## Keep one page for several interactions
+
+Use `browser.open()` inside a Definition when one operation needs navigation, form input, or several reads from the same page:
+
+```ts
+import { defineBrowser } from "vite-hub/browser"
+
+export default defineBrowser(async (input: { url: string }, { browser }) => {
+  const session = await browser.open()
+  await session.page.goto(input.url)
+  await session.page.locator("main").waitFor()
+  return await session.page.locator("h1").count()
+})
+```
+
+ViteHub releases the controller and closes Definition-owned sessions after the handler succeeds or fails. Call `session.close()` when the operation can release the session sooner.
+
+The default Kitesurf engine uses the Browser binding and does not support live handoff. Set `browser: { engine: "chromium" }` for a persistent Cloudflare Chromium session. That path requires the optional `@cloudflare/playwright` and `playwright-core` peers.
+
+Browser sessions can observe authenticated pages, cookies, network responses, screenshots, and rendered private UI. Do not log provider session ids, CDP endpoints, authorization headers, cookies, or handoff references. Apply the application's access, retention, and deletion rules to screenshots and downloads.
+
+## Use the owner package directly
+
+When another server build already composes Vite and Cloudflare output, register the package integration directly:
+
+```bash
+pnpm add @vite-hub/browser vite
+```
+
+```ts
+// vite.config.ts
+import { hubBrowser } from "@vite-hub/browser/vite"
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  plugins: [hubBrowser()],
+})
+```
+
+Use `@vite-hub/browser` and `@vite-hub/browser/actions` in the corresponding server code. `hubBrowser()` discovers Browser Definitions and writes Cloudflare Browser Provider Output. It does not deploy the Worker, authenticate Cloudflare, or select a local browser.
+
+## Manage a local Chromium process
+
+`createBrowser()` is the low-level interface for a caller that owns provider selection, controller attachment, and cleanup. The local provider starts the supplied Chromium executable on the current trusted Node host.
+
+```bash
+pnpm add @vite-hub/browser playwright-core
+```
 
 ```ts
 import { createBrowser } from "@vite-hub/browser"
 import { playwright } from "@vite-hub/browser/controllers/playwright"
-import { cloudflareBrowser } from "@vite-hub/browser/providers/cloudflare"
+import { localBrowser } from "@vite-hub/browser/providers/local"
 
-const browser = createBrowser({ provider: cloudflareBrowser() })
+const browser = createBrowser({
+  provider: localBrowser({ executablePath: "/usr/bin/chromium" }),
+})
 const session = await browser.open()
 const control = await session.attach(playwright())
 
 try {
-  await control.client.doSomething()
-}
-finally {
-  await control.release()
-  await session.close()
+  await control.client.page.goto("https://example.com")
+  console.log(await control.client.page.title()) // Example Domain
+} finally {
+  try {
+    await control.release()
+  } finally {
+    await session.close()
+  }
 }
 ```
 
-Live handoff transfers ownership of the exact provider session through an opaque, audience-bound reference. Cloudflare's Kitesurf default is sessionless, so select `engine: "chromium"` when live handoff is required. A handed-off session is not automatically closed.
+Set `executablePath` to an installed Chromium-compatible browser. The path above is a Linux example. `playwright-core` supplies the controller but does not download a browser.
+
+Use this adapter only when the process is allowed to start Chromium and isolate it according to the host's threat model. It uses a temporary browser profile and removes that profile when the session closes. ViteHub does not provide an untrusted-code sandbox around the browser process.
+
+Low-level Cloudflare sessions can also transfer an exact provider session through an audience-bound live handoff reference. Handoff requires the persistent Chromium engine. The receiving caller must claim the reference, and a handed-off session is not closed for the original caller. Treat the reference as a short-lived credential and close the claimed session when its work finishes.
+
+## Production checks
+
+- Keep Browser calls in trusted server code. Give an Agent the narrower `browser()` Capability instead of exposing raw provider or controller access.
+- Inspect the generated Cloudflare `wrangler.json` before deployment. It is Provider Output, not an application import or a file to edit by hand.
+- Test the deployed Worker when the result depends on Browser Run bindings. A successful package build proves imports and generated output, not provider availability.
+- Handle `BROWSER_*` failures at the route, Queue, or Workflow that can retry, reject input, or report the failure.
+
+Read the [Browser guide](https://vitehub.dev/docs/server-primitives/browser) for configuration, actions, sessions, and live handoff. See [Cloudflare deployment](https://vitehub.dev/docs/frameworks-hosts/cloudflare) for the generated binding and local Wrangler choices.

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -165,7 +165,7 @@ Set `executablePath` to an installed Chromium-compatible browser. The path above
 
 Use this adapter only when the process is allowed to start Chromium and isolate it according to the host's threat model. It uses a temporary browser profile and removes that profile when the session closes. ViteHub does not provide an untrusted-code sandbox around the browser process.
 
-Low-level Cloudflare sessions can also transfer an exact provider session through an audience-bound live handoff reference. Handoff requires the persistent Chromium engine. The receiving caller must claim the reference, and a handed-off session is not closed for the original caller. Treat the reference as a short-lived credential and close the claimed session when its work finishes.
+Low-level Cloudflare sessions can also transfer an exact provider session through an audience-bound live handoff reference. Handoff requires the persistent Chromium engine. The receiver must claim the reference through the same `createBrowser()` client that created the session; references do not cross clients or processes. A handed-off session is not closed for the original caller. Treat the reference as a short-lived credential and close the claimed session when its work finishes.
 
 ## Production checks
 

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -99,7 +99,7 @@ import { defineBrowser } from "vite-hub/browser"
 export default defineBrowser(async (input: { url: string }, { browser }) => {
   const session = await browser.open()
   await session.page.goto(input.url)
-  await session.page.locator("main").waitFor()
+  await session.page.locator("h1").waitFor()
   return await session.page.locator("h1").count()
 })
 ```

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -55,7 +55,7 @@ Calling `checkExampleDomain()` through a server route, Queue, or Workflow return
 { "found": true }
 ```
 
-This example uses a fixed public URL. If a request supplies the destination, validate the protocol and allow-list the hosts before starting browser work. A browser can send requests to every destination its provider can reach, and the returned page is untrusted input.
+This example uses a fixed public URL. If a request supplies the destination, validate the protocol and allow-list the hosts before starting browser work. Enforce the same policy after every redirect and for every resolved IP address, or restrict browser egress at the provider or network boundary. A browser can send requests to every destination its provider can reach, and the returned page is untrusted input.
 
 ViteHub writes the Cloudflare Browser binding and required compatibility fields to generated Provider Output. The action runs only where that binding is available. For local Wrangler development that must call the hosted Browser Run service, configure `browser: { remote: true }`. This uses a Cloudflare account and network access; it does not switch Browser Definitions to the local Chromium provider.
 

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -147,17 +147,18 @@ const browser = createBrowser({
   provider: localBrowser({ executablePath: "/usr/bin/chromium" }),
 })
 const session = await browser.open()
-const control = await session.attach(playwright())
 
 try {
-  await control.client.page.goto("https://example.com")
-  console.log(await control.client.page.title()) // Example Domain
-} finally {
+  const control = await session.attach(playwright())
+
   try {
-    await control.release()
+    await control.client.page.goto("https://example.com")
+    console.log(await control.client.page.title()) // Example Domain
   } finally {
-    await session.close()
+    await control.release()
   }
+} finally {
+  await session.close()
 }
 ```
 

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -170,7 +170,7 @@ Low-level Cloudflare sessions can also transfer an exact provider session throug
 
 ## Production checks
 
-- Keep Browser calls in trusted server code. Give an Agent the narrower `browser()` Capability instead of exposing raw provider or controller access.
+- Keep Browser calls in trusted server code. For Provider Agent browser work, add the `browser()` Capability and install its `agent-browser` CLI in the provider environment. The Capability supplies workspace instructions for using that CLI through the Agent's existing shell; it does not narrow shell authority or expose this Browser primitive.
 - Inspect the generated Cloudflare `wrangler.json` before deployment. It is Provider Output, not an application import or a file to edit by hand.
 - Test the deployed Worker when the result depends on Browser Run bindings. A successful package build proves imports and generated output, not provider availability.
 - Handle `BROWSER_*` failures at the route, Queue, or Workflow that can retry, reject input, or report the failure.

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -55,7 +55,7 @@ Calling `checkExampleDomain()` through a server route, Queue, or Workflow return
 { "found": true }
 ```
 
-This example uses a fixed public URL. If a request supplies the destination, validate the protocol and allow-list the hosts before starting browser work. Enforce the same policy after every redirect and for every resolved IP address, or restrict browser egress at the provider or network boundary. A browser can send requests to every destination its provider can reach, and the returned page is untrusted input.
+This example uses a fixed public URL. If a request supplies the destination, do not rely on validating only the initial URL. Enforce protocol, host, and resolved-address policy for every browser network request, including redirects and subresources, or restrict browser egress at the provider or network boundary. A browser can send requests to every destination its provider can reach, and the returned page is untrusted input.
 
 ViteHub writes the Cloudflare Browser binding and required compatibility fields to generated Provider Output. The action runs only where that binding is available. For local Wrangler development that must call the hosted Browser Run service, configure `browser: { remote: true }`. This uses a Cloudflare account and network access; it does not switch Browser Definitions to the local Chromium provider.
 


### PR DESCRIPTION
Rewrites the Browser package README around the first public decision: use `vite-hub/browser` in a ViteHub app, or install `@vite-hub/browser` for direct Vite and low-level provider control. The first path now produces a visible HTML check, while provider output, local Chromium, security, and cleanup limits sit beside the code they qualify.

Provider selection, generated Cloudflare output, Browser errors, and session lifecycle behavior are unchanged.

## Test plan

- `corepack pnpm --filter @vite-hub/browser test` (103 tests, typecheck, package build, and publint)
- `corepack pnpm exec vp test test/vite.test.ts -t "Browser"` in `packages/vite-hub` (facade Browser config)
- `corepack pnpm exec vp test --config test/consumer/vitest.config.ts test/consumer/vite-hub.test.ts -t "publishes Browser actions without installing Playwright by default"` (packed consumer import)
- `git diff --check`
- Both linked ViteHub guide URLs return HTTP 200

No live Cloudflare Browser Run smoke was performed. The README calls out that a package build proves imports and generated output, not provider availability.
