### PR TITLE
docs: make README a public product selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 </p>
 
 <p align="center">
-  Server APIs and portable Agents for any Vite host.
+  Server APIs and portable Agents across Vite hosts.
 </p>
 
 <p align="center">
@@ -20,21 +20,23 @@
   <a href="https://vitehub.dev/docs/server-primitives">Server primitives</a>
 </p>
 
-ViteHub adds a server layer to Vite. Call its Server Primitives directly from application code, or combine them with models and tools in an Agent. ViteHub keeps the application API consistent while its integrations handle local development and supported deployment hosts.
+ViteHub adds a server layer to Vite applications. Call Server Primitives directly for auth, storage, background work, and other server behavior. Define an Agent when a named server-side actor needs a model, tools, or a coding provider. Use both when an Agent needs selected operations from the application.
 
-## Choose how to start
+ViteHub keeps feature imports consistent while its Vite integrations discover definitions and prepare output for the selected host.
 
-### Start with server primitives
+## Choose what to build
 
-Server Primitives give application code APIs for auth, environment values, storage, queues, workflows, schedules, sandboxes, workspace files, and more. Start with [your first Server Primitive](https://vitehub.dev/docs/getting-started/first-server-primitive).
+| You need                                     | Start here                                                                                                                      | First result                                                        |
+| -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Server behavior without an Agent             | [First Server Primitive](https://vitehub.dev/docs/getting-started/first-server-primitive)                                       | A credential-free local KV route writes and returns one value.      |
+| A named Agent Invocation                     | [First Agent](https://vitehub.dev/docs/getting-started/first-agent)                                                             | An offline Agent route returns a deterministic greeting.            |
+| An Agent that can use application operations | [First Agent](https://vitehub.dev/docs/getting-started/first-agent), then [Capabilities](https://vitehub.dev/docs/capabilities) | The Agent runs first, then receives only the operations you select. |
 
-### Agents
+Agents can compose Server Primitives. Server Primitives never require Agents.
 
-Agents are named server-side actors. An Agent Definition selects how the Agent runs, which Capabilities it receives, and which Workspace files it can use. Start with [your first Agent](https://vitehub.dev/docs/getting-started/first-agent).
+Applications should install the `vite-hub` framework distribution. It provides one Vite integration and public feature imports such as `vite-hub/agent` and `vite-hub/kv`. Libraries and custom integrations can install an `@vite-hub/*` owner package directly. Use the [package reference](https://vitehub.dev/docs/reference) to choose one.
 
-Agents may compose Server Primitives. Server Primitives never require Agents.
-
-## Install ViteHub
+## Install the framework distribution
 
 Install the framework distribution in a Vite application:
 
@@ -49,47 +51,17 @@ import { vitehub } from "vite-hub";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  plugins: [
-    vitehub({ preset: "node" }),
-  ],
+  plugins: [vitehub({ preset: "node" })],
 });
 ```
-
-Model strings use AI Gateway automatically. Set `AI_GATEWAY_API_KEY` in the server environment, or pass an explicit key with `{ id, apiKey }`.
 
 Requirements: Node 24.15 or newer, Vite 8 or newer, and a server app with `vite.config.ts`.
 
-## Run your first Agent
+## Check project and host support
 
-Create an Agent Definition.
+ViteHub is under active development and has not reached 1.0. Published 0.x packages are development snapshots, and interfaces may change as the final design settles. Security fixes land on the current `main` branch; published 0.x versions do not receive backports. Pin the versions you deploy and test upgrades before rollout. See the [security policy](SECURITY.md) for the supported-version policy and private reporting process.
 
-```ts
-import { defineAgent } from "vite-hub/agent";
-
-export default defineAgent({
-  driver: {
-    model: "openai/gpt-5.1-mini",
-    instructions: "Answer support questions with short, concrete replies.",
-  },
-});
-```
-
-Run it from server code.
-
-```ts
-import { runAgent } from "vite-hub/agent";
-import support from "../agents/support";
-
-export default defineEventHandler(async (event) => {
-  const body = await readBody<{ prompt: string }>(event);
-
-  return runAgent(support, { runtime: "vite" }, {
-    prompt: body.prompt,
-  });
-});
-```
-
-Add Capabilities when the Agent needs tools, storage, Workspace files, chat, product events, or external systems. An Agent receives only the Capabilities you select.
+Choose a built-in `cloudflare`, `netlify`, `vercel`, `deno`, or `node` deployment preset. Each enabled feature validates its host and provider requirements, and unsupported production combinations fail during configuration or build. Provider availability still differs by feature, so check [runtime and host support](https://vitehub.dev/docs/frameworks-hosts/support-matrix) before choosing a deployment target.
 
 ## How Agents work
 
@@ -106,18 +78,18 @@ Server code can call primitives directly. Agents do not receive every primitive 
 
 Server primitives are useful with or without Agents.
 
-| Need | Start with |
-| --- | --- |
-| Environment values and secrets | [`vite-hub/env`](https://vitehub.dev/docs/server-primitives/env) |
-| Auth and sessions | [`vite-hub/auth`](https://vitehub.dev/docs/server-primitives/auth) |
-| Small key-addressed state | [`vite-hub/kv`](https://vitehub.dev/docs/server-primitives/kv) |
-| Relational data | [`vite-hub/database`](https://vitehub.dev/docs/server-primitives/database) |
-| Uploads and generated assets | [`vite-hub/blob`](https://vitehub.dev/docs/server-primitives/blob) |
-| File-tree state and Sources | [`vite-hub/workspace`](https://vitehub.dev/docs/server-primitives/workspace) |
-| Background delivery | [`vite-hub/queue`](https://vitehub.dev/docs/server-primitives/queue) |
-| Durable long-running work | [`vite-hub/workflow`](https://vitehub.dev/docs/server-primitives/workflows) |
-| Delayed or recurring work | [`vite-hub/schedule`](https://vitehub.dev/docs/server-primitives/schedule) |
-| Isolated execution | [`vite-hub/sandbox`](https://vitehub.dev/docs/server-primitives/sandbox) |
+| Need                           | Start with                                                                   |
+| ------------------------------ | ---------------------------------------------------------------------------- |
+| Environment values and secrets | [`vite-hub/env`](https://vitehub.dev/docs/server-primitives/env)             |
+| Auth and sessions              | [`vite-hub/auth`](https://vitehub.dev/docs/server-primitives/auth)           |
+| Small key-addressed state      | [`vite-hub/kv`](https://vitehub.dev/docs/server-primitives/kv)               |
+| Relational data                | [`vite-hub/database`](https://vitehub.dev/docs/server-primitives/database)   |
+| Uploads and generated assets   | [`vite-hub/blob`](https://vitehub.dev/docs/server-primitives/blob)           |
+| File-tree state and Sources    | [`vite-hub/workspace`](https://vitehub.dev/docs/server-primitives/workspace) |
+| Background delivery            | [`vite-hub/queue`](https://vitehub.dev/docs/server-primitives/queue)         |
+| Durable long-running work      | [`vite-hub/workflow`](https://vitehub.dev/docs/server-primitives/workflows)  |
+| Delayed or recurring work      | [`vite-hub/schedule`](https://vitehub.dev/docs/server-primitives/schedule)   |
+| Isolated execution             | [`vite-hub/sandbox`](https://vitehub.dev/docs/server-primitives/sandbox)     |
 
 Each package provides its server API and Vite integration. Application code uses the same imports while the integration connects them to the selected host.
 
@@ -126,8 +98,8 @@ Libraries and focused integrations can depend on any `@vite-hub/*` owner package
 ## Learn more
 
 - [Installation](https://vitehub.dev/docs/getting-started/installation)
-- [First server primitive](https://vitehub.dev/docs/getting-started/first-server-primitive)
-- [First Agent](https://vitehub.dev/docs/getting-started/first-agent)
+- [Package reference](https://vitehub.dev/docs/reference)
+- [Runtime and host support](https://vitehub.dev/docs/frameworks-hosts/support-matrix)
 - [Agent Definitions](https://vitehub.dev/docs/agents/agent-definitions)
 - [Capabilities](https://vitehub.dev/docs/capabilities)
 - [Server primitives](https://vitehub.dev/docs/server-primitives)


### PR DESCRIPTION
## Summary

- turn the root README into an immediate selector for Server Primitives, Agents, and combined use
- route each choice to fixture-backed first-success documentation instead of an incomplete model-backed fragment
- clarify application versus owner-package installation and state the pre-1.0 release and host-support boundaries beside setup

## Why

The README described Server Primitives and Agents separately, then asked new readers to assemble and trust a partial Agent example with no run command or observable result. That obscured which product surface to choose and suggested broader host stability than the current support evidence.

This keeps ViteHub's server-layer positioning and primitive catalog intact while making the shortest verified path, package choice, and deployment caveats visible before deeper concepts.

## Verification

- `pnpm --dir docs exec vp test test/tutorials.test.ts test/support-proof.test.ts` (13 tests passed)
- built and ran `fixtures/tutorials/server-primitives`; documented POST returned `{"settings":{"theme":"dark"}}`
- built and ran `fixtures/tutorials/first-agent`; documented POST returned `{"text":"Hello, Ada. This result came from an Agent Invocation."}`
- `pnpm --dir packages/vite-hub exec vp test test/vite.test.ts -t "keeps coherent defaults and opt-in integrations"` (1 passed)
- checked all 22 external README links (HTTP 200) and all local link targets
- `pnpm exec vp fmt README.md --check`
- `git diff --check`

## Scope

Documentation only. Runtime behavior, package exports, primitive catalog, and contributor setup are unchanged.

## Test caveat

A full `packages/vite-hub/test/vite.test.ts` run passed 75 of 76 tests. The unrelated deployment-identity fallback test observed a shared `/tmp/package.json` from another concurrent worker and derived `tmp-` instead of the fixture's `api-`; the focused preset test above passed, and this PR does not touch runtime code or test setup.
