### PR TITLE
docs(shell): clarify first-use boundaries

### DIFF
--- a/packages/shell/README.md
+++ b/packages/shell/README.md
@@ -6,7 +6,9 @@
   <img alt="Shell" src="https://img.shields.io/badge/Shell-controlled%20runtime-18181b?style=flat-square">
 </p>
 
-`@vite-hub/shell` gives agents and workspace tools structured command execution with explicit boundaries.
+`@vite-hub/shell` gives server code structured command analysis and execution with explicit filesystem, network, process, and timeout boundaries.
+
+Applications that only need an Agent to inspect or edit its Workspace usually use the `workspaceShell()` Capability from `@vite-hub/agent/capabilities`. Install this owner package directly when you are building a Capability, Workspace adapter, or host integration.
 
 ## Install
 
@@ -14,43 +16,68 @@
 pnpm add @vite-hub/shell
 ```
 
-## Minimal API
+## Inspect a command
 
 ```ts
-// server/utils/shell.ts
-import { analyzeShellCommand, createShellRuntime } from "@vite-hub/shell"
-import type { ShellExecutionProvider } from "@vite-hub/shell"
+import { analyzeShellCommand } from "@vite-hub/shell";
 
-const provider: ShellExecutionProvider = {
-  boundary: {
-    cwd: true,
-    env: true,
-    filesystem: { writable: false },
-    network: false,
-    processes: { background: false, interactive: false },
-    streaming: false,
-    timeout: { enforcedBy: "runtime", supported: true },
-  },
-  async exec(command) {
-    return {
-      command,
-      event: "command_finished",
-      exitCode: 0,
-      stderr: "",
-      stdout: "ok\n",
-    }
-  },
-}
+const analysis = await analyzeShellCommand("rg TODO src");
 
-const runtime = createShellRuntime({ provider, policy: { maxShellCalls: 5 } })
-const analysis = await analyzeShellCommand("echo ok")
-const result = analysis.ok ? await runtime.exec("echo ok") : undefined
+console.log(analysis.commands); // ["rg"]
+console.log(analysis.hasPipelines); // false
+console.log(analysis.ok); // true
 ```
 
-## Used by
+Analysis reports command names, pipelines, redirects, heredocs, and command substitution. It does not make a command safe to run. The caller's policy and the execution provider remain the enforcement boundaries.
 
-`workspaceShell()` in [`@vite-hub/agent`](../agent/README.md) uses this package to expose scoped shell work to an agent. Workspace adapters live in `@vite-hub/shell/workspace`.
+## Run against a Workspace
+
+The built-in Just Bash provider executes Bash-compatible commands against the filesystem adapter you give it. This example mounts a ViteHub Workspace read-only, permits four inspection commands, and returns a structured observation.
+
+```sh
+pnpm add @vite-hub/shell @vite-hub/workspace
+```
+
+```ts
+// server/tasks/search-docs.ts
+import { createShellRuntime } from "@vite-hub/shell";
+import { createJustBashProvider } from "@vite-hub/shell/providers/just-bash";
+import { createReadonlyWorkspaceFs, workspaceMountPoint } from "@vite-hub/shell/workspace";
+import { useWorkspace } from "@vite-hub/workspace";
+
+export async function searchDocs() {
+  const workspace = useWorkspace("docs");
+  const shell = createShellRuntime({
+    policy: {
+      maxOutputLength: 10_000,
+      maxShellCalls: 1,
+      timeout: 30_000,
+    },
+    provider: createJustBashProvider({
+      commands: ["cat", "ls", "pwd", "rg"],
+      cwd: workspaceMountPoint,
+      fs: createReadonlyWorkspaceFs(workspace.fs),
+    }),
+  });
+
+  return shell.exec("rg auth docs", { cwd: workspaceMountPoint });
+}
+```
+
+`shell.exec()` creates a short-lived Shell Session and returns a Shell Observation with `event`, `exitCode`, `stdout`, and `stderr`. The provider above has no network access, background processes, or interactive processes, and its Workspace filesystem cannot write.
+
+## Providers and boundaries
+
+- `@vite-hub/shell/providers/just-bash` runs selected commands in `just-bash` against a supplied filesystem adapter.
+- `@vite-hub/shell/providers/cloudflare` adapts a Cloudflare execution client and reports the boundary that client can prove.
+- A custom `ShellExecutionProvider` declares its boundary and implements execution for another host.
+
+Shell policy can bound calls, processes, output size, and timeouts. A declared boundary describes the provider contract; it is not proof of operating-system isolation. Use [Sandbox](https://vitehub.dev/docs/server-primitives/sandbox) when work needs provider-managed isolation.
+
+## Use with Agents
+
+`workspaceShell()` in [`@vite-hub/agent`](../agent/README.md) exposes scoped shell work through an Agent Capability. It attaches Workspace Scope, Shell policy, metadata, and tools to the Agent Definition; do not expose an unrestricted raw runtime to a model.
 
 Built on [just-bash](https://www.npmjs.com/package/just-bash) for the built-in shell provider and [sh-syntax](https://www.npmjs.com/package/sh-syntax) for command analysis.
 
-Learn more at [vitehub.dev](https://vitehub.dev).
+Read the complete [Shell guide](https://vitehub.dev/docs/server-primitives/shell), the [Bash contract](https://vitehub.dev/docs/concepts/bash), and the [official Capabilities guide](https://vitehub.dev/docs/capabilities/official-capabilities).

--- a/packages/shell/README.md
+++ b/packages/shell/README.md
@@ -60,7 +60,7 @@ export async function searchDocs() {
     }),
   });
 
-  return shell.exec("rg auth docs", { cwd: workspaceMountPoint });
+  return shell.exec("rg auth .", { cwd: workspaceMountPoint });
 }
 ```
 


### PR DESCRIPTION
## Summary

- explain when applications should use the Agent `workspaceShell()` Capability and when integrations should install `@vite-hub/shell` directly
- replace the hand-written provider stub with an executable command-analysis result and the built-in read-only Just Bash + Workspace path
- document provider boundaries, structured observations, isolation limits, and precise next-step guides

## Why

The package README currently asks a first-time reader to implement `ShellExecutionProvider` before it shows a built-in provider or an observable result. That makes the public npm entry point look lower-level than the supported API.

Runtime behavior and public exports are unchanged.

## Verification

- `pnpm --filter @vite-hub/shell test` — 2 files, 22 tests passed; build and publint also passed
- `pnpm --filter @vite-hub/shell typecheck` — passed
- executed the documented `analyzeShellCommand("rg TODO src")` result against the built public entry point
- `npm pack --dry-run --json` — packed README present
- all ViteHub documentation links returned HTTP 200; linked npm packages exist in the registry
- `vp fmt --check packages/shell/README.md`
- `git diff --check`

## Boundaries

- command analysis is explicitly not presented as enforcement
- the Just Bash example is read-only and has no network, background-process, or interactive-process access
- provider boundaries are not described as operating-system isolation; the README routes isolation requirements to Sandbox
