### PR TITLE
docs(cli): complete public command index

### DIFF
--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -24,7 +24,7 @@ Libraries and advanced integrations that do not use the framework distribution
 can install `@vite-hub/cli` directly.
 
 Expected help lists available namespaces.
-The Agent Package contributes `agent` and `channels` when `hubAgent()` is active, Database contributes `db` when `hubDb()` is active, Workspace contributes `workspace` when `hubWorkspace()` is active, and the CLI includes the built-in `provision` namespace.
+The Agent Package contributes `agent` and `channels` when `hubAgent()` is active, Database contributes `db` when `hubDb()` is active, Workspace contributes `workspace` when `hubWorkspace()` is active, the framework contributes `types`, and the CLI includes the built-in `provision` namespace.
 
 ```txt [Output]
 Usage: vitehub <namespace> <feature> [args...]
@@ -33,6 +33,7 @@ Available namespaces:
   channels    External Channel registration workflows.
   db          Database development workflows.
   workspace   Workspace development workflows.
+  types       Generate ViteHub TypeScript declarations.
   provision   Idempotently create missing provider resources.
 ```
 

--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -49,6 +49,7 @@ Available namespaces:
 | `vitehub db generate` | Available | Database Package | Refresh generated Database artifacts and generate Drizzle migrations. |
 | `vitehub db migrate` | Available | Database Package | Refresh generated Database artifacts and apply Drizzle migrations. |
 | `vitehub workspace dev` | Available | Workspace Package | Run commands through a Workspace Session exposed by a Compatible Vite Development Server. |
+| `vitehub types prepare` | Available | ViteHub Framework | Prepare generated TypeScript declarations for editors and type checking. |
 | `vitehub provision run` | Available | ViteHub CLI plus package Provision Steps | Create missing provider resources idempotently. |
 
 ## Synchronize Channel webhooks

--- a/docs/content/docs/development/cli.md
+++ b/docs/content/docs/development/cli.md
@@ -43,6 +43,7 @@ Available namespaces:
 | `vitehub agent eval` | Opt-in tooling | Agent Package | Run discovered Agent Evals through ViteHub defaults. |
 | `vitehub agent info` | Available | Agent Package | Inspect resolved Agent metadata through a running Vite Development Server. |
 | `vitehub agent dev` | Available | Agent Package | Talk to a discovered Agent through a running Vite Development Server. |
+| `vitehub agent invocations` | Available | Agent Package | List, inspect, or follow records in the application's Agent Invocation journal. |
 | `vitehub channels history` | Available | Agent Package | Download one deployed conversation and its attachments. |
 | `vitehub channels sync` | Available | Agent Package | Inspect or apply provider-owned webhook registrations for a deployed stage. |
 | `vitehub db generate` | Available | Database Package | Refresh generated Database artifacts and generate Drizzle migrations. |

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,44 +1,76 @@
 # @vite-hub/cli
 
-<p>
-  <a href="https://vitehub.dev"><img alt="ViteHub" src="https://img.shields.io/badge/ViteHub-vitehub.dev-646cff?style=flat-square"></a>
-  <img alt="TypeScript" src="https://img.shields.io/badge/TypeScript-ready-3178c6?style=flat-square">
-  <img alt="CLI" src="https://img.shields.io/badge/CLI-package%20workflows-18181b?style=flat-square">
-</p>
+`@vite-hub/cli` runs the development commands contributed by a ViteHub project's active Vite plugins. It loads the local Vite or Nuxt config, combines their command namespaces, and adds the built-in `provision` command.
 
-`@vite-hub/cli` loads the local Vite config, collects package-contributed commands, and runs them from `vitehub`.
+## Choose the package
 
-## Install
+Install `vite-hub` in an application that uses the framework distribution. It includes the CLI and publishes both `vitehub` and `vite-hub` as binary names.
 
 ```sh
-pnpm add -D @vite-hub/cli
+pnpm add vite-hub
+pnpm vitehub --help
 ```
 
-## Minimal API
+Install `@vite-hub/cli` directly when a library or custom Vite integration needs the command runner without the framework distribution. The standalone package publishes the `vitehub` binary and requires Vite. Install Nuxt too when the project has a Nuxt config but no Vite config.
+
+```sh
+pnpm add -D @vite-hub/cli vite
+pnpm vitehub --help
+```
+
+`@vite-hub/cli` requires Node.js 24 or newer. The current `vite-hub` distribution requires Node.js 24.15 or newer.
+
+## Open project help
+
+Run help from the project root. The CLI loads the project config before it prints help, so only run it in a repository whose config you trust.
 
 ```sh
 pnpm vitehub --help
-pnpm vitehub agent info
-pnpm vitehub agent dev
-pnpm vitehub agent eval
-pnpm vitehub db generate
-pnpm vitehub db migrate
-pnpm vitehub workspace dev docs
-pnpm vitehub provision run --provider cloudflare --dry-run
 ```
+
+Every project includes `provision`. Other namespaces appear when their Vite integrations are active.
+
+```txt
+Usage: vitehub <namespace> <feature> [args...]
+
+Available namespaces:
+  provision    Idempotently create missing provider resources.
+```
+
+Open namespace help to see the commands contributed by one integration. Open feature help for its current arguments and defaults.
+
+```sh
+pnpm vitehub agent --help
+pnpm vitehub agent invocations --help
+```
+
+The Agent integration contributes `info`, `dev`, and `invocations`, plus `channels history` and `channels sync`. It adds `eval` only when the project contains an Agent Eval file. Database contributes `generate` and `migrate`, and Workspace contributes `dev`. The Agent and Database integrations can disable their commands through their integration options.
+
+See the [complete command index](https://vitehub.dev/docs/development/cli#commands) for command availability and the task each command performs.
+
+## Run the CLI from code
+
+Use `runViteHubCli()` when another command runner needs ViteHub's config discovery and exit code without starting the binary entry point.
 
 ```ts
 // scripts/vitehub.ts
-import { runViteHubCli } from "@vite-hub/cli"
+import { runViteHubCli } from "@vite-hub/cli";
 
 const exitCode = await runViteHubCli({
-  args: ["agent", "eval"],
+  args: ["agent", "invocations", "list", "--json"],
   cwd: process.cwd(),
-})
+});
+
+process.exitCode = exitCode;
 ```
 
-## Vite
+`runViteHubCli()` returns `0` for successful commands and help, or a non-zero code when a command reports failure. It rejects if config loading or a contributor throws. Pass custom `stdout`, `stderr`, `env`, or `spawn` implementations only when the host needs to capture output or control subprocesses.
 
-Commands come from the active Vite plugins, so package CLIs stay package-owned. The Agent integration contributes `agent info`, `agent dev`, and Evalite-backed `agent eval`; Database contributes `db generate` and `db migrate`; Workspace contributes `workspace dev`. The CLI also owns `provision run` for executing package-contributed provider provisioning steps.
+## Limits and safety
 
-Learn more at [vitehub.dev](https://vitehub.dev).
+- Root and namespace help is human-readable text, not a structured output contract.
+- Help loads and executes the local Vite or Nuxt config. A missing dependency or config error can stop help before it prints.
+- Command effects come from the package that contributes the command. Review command-specific help before applying Database migrations, Channel registration changes, or Provider provisioning.
+- `provision run` creates missing resources but does not delete or replace existing resources. Start with `--dry-run` and pass a provider explicitly.
+
+Read the [CLI guide](https://vitehub.dev/docs/development/cli) for every public command, examples, and troubleshooting.

--- a/packages/vite-hub/test/cli-docs.test.ts
+++ b/packages/vite-hub/test/cli-docs.test.ts
@@ -8,6 +8,8 @@ import { createDbCliContributor } from "@vite-hub/database/cli";
 import { hubWorkspace } from "@vite-hub/workspace/vite";
 import { describe, expect, it } from "vitest";
 
+import { viteHubTypesPlugin } from "../src/internal/types.ts";
+
 const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
 const cliReference = join(repoRoot, "docs/content/docs/development/cli.md");
 const evalFixtureRoot = join(repoRoot, "packages/agent/test/fixtures");
@@ -40,7 +42,12 @@ describe("CLI documentation contract", () => {
     const agent = createAgentCliContributor({ rootDir: evalFixtureRoot });
     const database = createDbCliContributor();
     if (!agent || !database) throw new TypeError("Expected the default CLI contributors.");
-    const plugins = [{ vitehub: { cli: agent } }, { vitehub: { cli: database } }, hubWorkspace()];
+    const plugins = [
+      { vitehub: { cli: agent } },
+      { vitehub: { cli: database } },
+      hubWorkspace(),
+      viteHubTypesPlugin(),
+    ];
     const loadConfig = async () => ({ plugins, root: repoRoot });
     const rootHelp = stream();
 

--- a/packages/vite-hub/test/cli-docs.test.ts
+++ b/packages/vite-hub/test/cli-docs.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createAgentCliContributor } from "@vite-hub/agent/cli";
+import { runViteHubCli } from "@vite-hub/cli";
+import { createDbCliContributor } from "@vite-hub/database/cli";
+import { hubWorkspace } from "@vite-hub/workspace/vite";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = fileURLToPath(new URL("../../..", import.meta.url));
+const cliReference = join(repoRoot, "docs/content/docs/development/cli.md");
+const evalFixtureRoot = join(repoRoot, "packages/agent/test/fixtures");
+
+function stream() {
+  let value = "";
+  return {
+    output: () => value,
+    write(chunk: string | Uint8Array) {
+      value += String(chunk);
+    },
+  };
+}
+
+function helpNames(output: string, heading: string): string[] {
+  const section = output.split(`${heading}\n`, 2)[1];
+  if (section === undefined) throw new TypeError(`Missing CLI help heading: ${heading}`);
+  return [...section.matchAll(/^ {2}(\S+)(?:\s{2,}|$)/gm)].map((match) => match[1]!);
+}
+
+function documentedCommands(): string[] {
+  const source = readFileSync(cliReference, "utf8");
+  return [...source.matchAll(/^\| `vitehub ([a-z0-9-]+) ([a-z0-9-]+)` \|/gm)]
+    .map((match) => `${match[1]} ${match[2]}`)
+    .sort();
+}
+
+describe("CLI documentation contract", () => {
+  it("indexes every command from the live package contributors", async () => {
+    const agent = createAgentCliContributor({ rootDir: evalFixtureRoot });
+    const database = createDbCliContributor();
+    if (!agent || !database) throw new TypeError("Expected the default CLI contributors.");
+    const plugins = [{ vitehub: { cli: agent } }, { vitehub: { cli: database } }, hubWorkspace()];
+    const loadConfig = async () => ({ plugins, root: repoRoot });
+    const rootHelp = stream();
+
+    await expect(runViteHubCli({ args: ["--help"], loadConfig, stdout: rootHelp })).resolves.toBe(
+      0,
+    );
+    const namespaces = helpNames(rootHelp.output(), "Available namespaces:");
+    const commands: string[] = [];
+
+    for (const namespace of namespaces) {
+      const namespaceHelp = stream();
+      await expect(
+        runViteHubCli({ args: [namespace, "--help"], loadConfig, stdout: namespaceHelp }),
+      ).resolves.toBe(0);
+      for (const feature of helpNames(namespaceHelp.output(), "Available features:")) {
+        commands.push(`${namespace} ${feature}`);
+      }
+    }
+
+    expect(documentedCommands()).toEqual(expect.arrayContaining(commands.sort()));
+  });
+});

--- a/packages/vite-hub/test/cli-docs.test.ts
+++ b/packages/vite-hub/test/cli-docs.test.ts
@@ -60,6 +60,6 @@ describe("CLI documentation contract", () => {
       }
     }
 
-    expect(documentedCommands()).toEqual(expect.arrayContaining(commands.sort()));
+    expect(documentedCommands()).toEqual(commands.sort());
   });
 });


### PR DESCRIPTION
Makes the CLI package README a self-contained install, selection, first-help, programmatic-use, and safety entry point. The public command index now includes Agent Invocation inspection, and a contract derives all current Agent, Database, Workspace, Channel, Eval, and built-in Provision commands from live CLI help so missing rows fail tests.

It does not change CLI runtime behavior, help formatting, command semantics, structured help, pre-config help, or the stream-flush exit coverage merged through #1106.

Verification:
- `corepack pnpm --filter vite-hub exec vp test test/cli-docs.test.ts`
- `corepack pnpm --filter @vite-hub/cli test`
- `corepack pnpm --filter vite-hub typecheck`
- `corepack pnpm --filter vitehub-docs test`
- `corepack pnpm pack --pack-destination /tmp/vitehub-cli-pack-r3` from `packages/cli`
- built `node dist/index.js --help` transcript matches the README
- README links return HTTP 200
- formatting and `git diff --check` pass