### PR TITLE
docs(agent): add offline Vite example

### DIFF
--- a/packages/agent/examples/showcase.json
+++ b/packages/agent/examples/showcase.json
@@ -1,0 +1,35 @@
+{
+  "label": "Agent",
+  "description": "A credential-free Agent Definition with local discovery and invocation.",
+  "icon": "i-lucide-bot",
+  "order": 1,
+  "defaultPhase": "define",
+  "frameworks": {
+    "vite": {
+      "modes": {
+        "dev": {
+          "phases": {
+            "configure": "vite.config.ts",
+            "define": "server/agents/greeting.ts",
+            "run": "src/server.ts"
+          },
+          "supplementalFiles": [
+            "README.md",
+            "package.json"
+          ]
+        },
+        "build": {
+          "phases": {
+            "configure": "vite.config.ts",
+            "define": "server/agents/greeting.ts",
+            "run": "src/server.ts"
+          },
+          "supplementalFiles": [
+            "README.md",
+            "package.json"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/packages/agent/examples/showcase.json
+++ b/packages/agent/examples/showcase.json
@@ -15,7 +15,8 @@
           },
           "supplementalFiles": [
             "README.md",
-            "package.json"
+            "package.json",
+            "vitehub.mjs"
           ]
         },
         "build": {
@@ -26,7 +27,8 @@
           },
           "supplementalFiles": [
             "README.md",
-            "package.json"
+            "package.json",
+            "vitehub.mjs"
           ]
         }
       }

--- a/packages/agent/examples/vite/README.md
+++ b/packages/agent/examples/vite/README.md
@@ -1,0 +1,65 @@
+# Offline Agent with Vite
+
+This example defines one Agent, discovers it through Vite, and invokes it without a model API key. Its custom `driver.run` returns a fixed-format greeting, so the same input always produces the same output.
+
+You need Node.js 24.15 or newer and pnpm. From the repository root, install the workspace dependencies, then enter this example:
+
+```sh
+corepack pnpm install
+cd packages/agent/examples/vite
+```
+
+## Inspect and invoke the Agent
+
+Start the Vite Development Server:
+
+```sh
+pnpm dev
+```
+
+Keep it running, then use another terminal in this directory to inspect the discovered Definition:
+
+```sh
+pnpm vitehub agent info --agent greeting --json
+```
+
+The JSON includes these fields:
+
+```json
+{
+  "config": {
+    "driver": {
+      "kind": "run"
+    }
+  },
+  "name": "greeting"
+}
+```
+
+Invoke the Agent through the local Agent Dev Loop:
+
+```sh
+pnpm vitehub agent dev --agent greeting --prompt Ada
+```
+
+Expected output:
+
+```txt
+Hello, Ada. This Agent ran without credentials.
+```
+
+Stop the Vite server with `Ctrl+C` when you finish. The Agent Dev Loop is a local development endpoint, not an authenticated production API. Do not expose it publicly.
+
+## Build the application route
+
+`src/server.ts` also shows an application-owned H3 route that calls the same Definition with `runAgent()`:
+
+```sh
+pnpm build
+```
+
+The build writes `dist/server.js`. That file is a server bundle, not a running server or deployment. A host integration must mount the exported H3 app, provide its process lifecycle, and connect `waitUntil` to the host's real request lifetime.
+
+The `/greet` route has no authentication or runtime input validation. Treat it as learning and test code. Authenticate callers and validate untrusted request data before adapting it for a public application.
+
+The custom Driver also runs as ordinary application code in the Vite or host process. It has no model credentials, but it is not isolated or sandboxed. Replace it with a model or coding provider only when you are ready to configure that provider's credentials, authority, cost, timeout, and deployment requirements.

--- a/packages/agent/examples/vite/README.md
+++ b/packages/agent/examples/vite/README.md
@@ -2,10 +2,12 @@
 
 This example defines one Agent, discovers it through Vite, and invokes it without a model API key. Its custom `driver.run` returns a fixed-format greeting, so the same input always produces the same output.
 
-You need Node.js 24.15 or newer and pnpm. From the repository root, install the workspace dependencies, then enter this example:
+You need Node.js 24.15 or newer and pnpm. From the repository root, install the workspace dependencies, build the Agent and CLI packages used by the example, then enter its directory:
 
 ```sh
 corepack pnpm install
+corepack pnpm exec vp run -t @vite-hub/agent#build
+corepack pnpm exec vp run -t @vite-hub/cli#build
 cd packages/agent/examples/vite
 ```
 

--- a/packages/agent/examples/vite/package.json
+++ b/packages/agent/examples/vite/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@vite-hub/agent-example-vite",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vp build",
+    "dev": "vp dev --host 127.0.0.1"
+  },
+  "dependencies": {
+    "@vite-hub/agent": "workspace:*",
+    "h3": "catalog:unjs",
+    "vite": "catalog:vite"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:tooling",
+    "@vite-hub/cli": "workspace:*",
+    "vite-plus": "catalog:tooling"
+  }
+}

--- a/packages/agent/examples/vite/package.json
+++ b/packages/agent/examples/vite/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "build": "vp build",
-    "dev": "vp dev --host 127.0.0.1"
+    "dev": "vp dev --host 127.0.0.1",
+    "vitehub": "node ./vitehub.mjs"
   },
   "dependencies": {
     "@vite-hub/agent": "workspace:*",

--- a/packages/agent/examples/vite/server/agents/greeting.ts
+++ b/packages/agent/examples/vite/server/agents/greeting.ts
@@ -1,0 +1,17 @@
+import { defineAgent } from "@vite-hub/agent"
+
+export default defineAgent({
+  description: "Returns a deterministic greeting without a model or provider.",
+  runtime: false,
+  driver: {
+    run({ messages, prompt }) {
+      const latestMessage = messages.findLast(message => message.role === "user")
+      const latestText = latestMessage?.parts.find(part => part.type === "text")?.text
+      const name = (prompt || latestText)?.trim() || "friend"
+
+      return {
+        text: `Hello, ${name}. This Agent ran without credentials.`,
+      }
+    },
+  },
+})

--- a/packages/agent/examples/vite/src/server.ts
+++ b/packages/agent/examples/vite/src/server.ts
@@ -8,6 +8,7 @@ function createMemo() {
 
   return <T>(key: string, create: () => T): T => {
     if (!values.has(key)) values.set(key, create())
+    // SAFETY: values for each memo key are created and read through this generic callback contract.
     return values.get(key) as T
   }
 }

--- a/packages/agent/examples/vite/src/server.ts
+++ b/packages/agent/examples/vite/src/server.ts
@@ -1,0 +1,27 @@
+import { H3, readBody } from "h3"
+
+import { runAgent } from "@vite-hub/agent"
+import greeting from "../server/agents/greeting"
+
+function createMemo() {
+  const values = new Map<string, unknown>()
+
+  return <T>(key: string, create: () => T): T => {
+    if (!values.has(key)) values.set(key, create())
+    return values.get(key) as T
+  }
+}
+
+const app = new H3().post("/greet", async (event) => {
+  const body = await readBody<{ name?: string }>(event) || {}
+
+  return await runAgent(greeting, {
+    memo: createMemo(),
+    runtime: "vite",
+    waitUntil: task => { void task.catch(error => console.error(error)) },
+  }, {
+    prompt: body.name?.trim() || "friend",
+  })
+})
+
+export default app

--- a/packages/agent/examples/vite/vite.config.ts
+++ b/packages/agent/examples/vite/vite.config.ts
@@ -13,6 +13,9 @@ export default defineConfig({
     },
   },
   plugins: [hubAgent()],
+  server: {
+    strictPort: true,
+  },
   ssr: {
     external: ["@vite-hub/agent"],
   },

--- a/packages/agent/examples/vite/vite.config.ts
+++ b/packages/agent/examples/vite/vite.config.ts
@@ -1,0 +1,19 @@
+import { resolve } from "node:path"
+
+import { hubAgent } from "@vite-hub/agent/vite"
+import { defineConfig } from "vite"
+
+export default defineConfig({
+  appType: "custom",
+  build: {
+    ssr: true,
+    rollupOptions: {
+      input: resolve(import.meta.dirname, "src/server.ts"),
+      output: { entryFileNames: "server.js" },
+    },
+  },
+  plugins: [hubAgent()],
+  ssr: {
+    external: ["@vite-hub/agent"],
+  },
+})

--- a/packages/agent/examples/vite/vitehub.mjs
+++ b/packages/agent/examples/vite/vitehub.mjs
@@ -1,0 +1,3 @@
+import { runViteHubCli } from "@vite-hub/cli"
+
+process.exitCode = await runViteHubCli()

--- a/packages/agent/test/example.test.ts
+++ b/packages/agent/test/example.test.ts
@@ -30,7 +30,7 @@ async function availablePort() {
   await once(server, "listening")
 
   const address = server.address()
-  if (!address || typeof address === "string") throw new Error("Could not allocate an Agent example test port")
+  if (!address || !("port" in address)) throw new Error("Could not allocate an Agent example test port")
 
   await new Promise<void>((resolveClose, reject) => server.close(error => error ? reject(error) : resolveClose()))
   return address.port
@@ -60,6 +60,7 @@ describe("offline Agent Vite example", () => {
 
   it("builds a request route from public package imports", async () => {
     const moduleUrl = pathToFileURL(join(exampleRoot, "dist/server.js")).href
+    // SAFETY: the example build emits its default H3 app from src/server.ts.
     const { default: app } = await import(moduleUrl) as { default: { request: (path: string, init?: RequestInit) => Promise<Response> } }
     const response = await app.request("/greet", {
       body: JSON.stringify({ name: "Ada" }),

--- a/packages/agent/test/example.test.ts
+++ b/packages/agent/test/example.test.ts
@@ -6,7 +6,7 @@ import { pathToFileURL } from "node:url"
 import { promisify } from "node:util"
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest"
-import { createServer, type ViteDevServer } from "vite"
+import { createServer, resolveConfig, type ViteDevServer } from "vite"
 
 import { runAgentDevCli, runAgentInfoCli } from "@vite-hub/agent/cli"
 
@@ -56,6 +56,12 @@ describe("offline Agent Vite example", () => {
 
   afterAll(async () => {
     await server?.close()
+  })
+
+  it("keeps the documented CLI URL pinned to the development port", async () => {
+    const config = await resolveConfig({ configFile: join(exampleRoot, "vite.config.ts"), root: exampleRoot }, "serve")
+
+    expect(config.server.strictPort).toBe(true)
   })
 
   it("builds a request route from public package imports", async () => {

--- a/packages/agent/test/example.test.ts
+++ b/packages/agent/test/example.test.ts
@@ -1,0 +1,117 @@
+import { execFile } from "node:child_process"
+import { once } from "node:events"
+import { createServer as createPortServer } from "node:net"
+import { join, resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+import { promisify } from "node:util"
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest"
+import { createServer, type ViteDevServer } from "vite"
+
+import { runAgentDevCli, runAgentInfoCli } from "@vite-hub/agent/cli"
+
+const execFileAsync = promisify(execFile)
+const repoRoot = resolve(import.meta.dirname, "../../..")
+const exampleRoot = resolve(import.meta.dirname, "../examples/vite")
+
+function outputStream() {
+  let value = ""
+  return {
+    output: () => value,
+    write(chunk: string | Uint8Array) {
+      value += chunk.toString()
+    },
+  }
+}
+
+async function availablePort() {
+  const server = createPortServer()
+  server.listen(0, "127.0.0.1")
+  await once(server, "listening")
+
+  const address = server.address()
+  if (!address || typeof address === "string") throw new Error("Could not allocate an Agent example test port")
+
+  await new Promise<void>((resolveClose, reject) => server.close(error => error ? reject(error) : resolveClose()))
+  return address.port
+}
+
+describe("offline Agent Vite example", () => {
+  let server: ViteDevServer | undefined
+  let url = ""
+
+  beforeAll(async () => {
+    await execFileAsync(resolve(repoRoot, "node_modules/.bin/vp"), ["build"], { cwd: exampleRoot })
+
+    const port = await availablePort()
+    server = await createServer({
+      configFile: join(exampleRoot, "vite.config.ts"),
+      logLevel: "silent",
+      root: exampleRoot,
+      server: { host: "127.0.0.1", port, strictPort: true },
+    })
+    await server.listen()
+    url = `http://127.0.0.1:${port}`
+  }, 30_000)
+
+  afterAll(async () => {
+    await server?.close()
+  })
+
+  it("builds a request route from public package imports", async () => {
+    const moduleUrl = pathToFileURL(join(exampleRoot, "dist/server.js")).href
+    const { default: app } = await import(moduleUrl) as { default: { request: (path: string, init?: RequestInit) => Promise<Response> } }
+    const response = await app.request("/greet", {
+      body: JSON.stringify({ name: "Ada" }),
+      headers: { "content-type": "application/json" },
+      method: "POST",
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      text: "Hello, Ada. This Agent ran without credentials.",
+    })
+  })
+
+  it("discovers and invokes the Agent through the public CLI contract", async () => {
+    const infoStdout = outputStream()
+    const infoStderr = outputStream()
+    const context = {
+      cwd: exampleRoot,
+      env: {},
+      rootDir: exampleRoot,
+      stderr: infoStderr,
+      stdout: infoStdout,
+    }
+
+    expect(await runAgentInfoCli(["--agent", "greeting", "--json", "--url", url], context)).toBe(0)
+    expect(infoStderr.output()).toBe("")
+    expect(JSON.parse(infoStdout.output())).toMatchObject({
+      config: { driver: { kind: "run" } },
+      name: "greeting",
+    })
+
+    const devStdout = outputStream()
+    const devStderr = outputStream()
+    expect(await runAgentDevCli(["--agent", "greeting", "--prompt", "Ada", "--url", url], {
+      ...context,
+      stderr: devStderr,
+      stdout: devStdout,
+    })).toBe(0)
+    expect(devStdout.output()).toBe("Hello, Ada. This Agent ran without credentials.\n")
+  })
+
+  it("reports an unknown discovered Agent", async () => {
+    const stderr = outputStream()
+    const exitCode = await runAgentDevCli(["--agent", "missing", "--prompt", "Ada", "--url", url], {
+      cwd: exampleRoot,
+      env: {},
+      rootDir: exampleRoot,
+      stderr,
+      stdout: outputStream(),
+    })
+
+    expect(exitCode).toBe(1)
+    expect(stderr.output()).toContain("Unknown Agent Dev Loop Target: missing")
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -721,6 +721,28 @@ importers:
         specifier: catalog:ai
         version: 4.0.38(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
 
+  packages/agent/examples/vite:
+    dependencies:
+      '@vite-hub/agent':
+        specifier: workspace:*
+        version: link:../..
+      h3:
+        specifier: catalog:unjs
+        version: 2.0.1-rc.25(crossws@0.4.10(srvx@0.11.22))
+      vite:
+        specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
+        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
+    devDependencies:
+      '@types/node':
+        specifier: catalog:tooling
+        version: 24.13.3
+      '@vite-hub/cli':
+        specifier: workspace:*
+        version: link:../../../cli
+      vite-plus:
+        specifier: catalog:tooling
+        version: 0.1.24(5d15fef75f428e841044fb19409e0e71)
+
   packages/auth:
     dependencies:
       '@vite-hub/env':

--- a/test/package-examples.json
+++ b/test/package-examples.json
@@ -1,6 +1,13 @@
 {
   "examples": [
     {
+      "artifact": "server-bundle",
+      "framework": "vite",
+      "id": "agent",
+      "mode": "build",
+      "outputs": ["dist/server.js"]
+    },
+    {
       "artifact": "provider-output",
       "framework": "vite",
       "id": "blob",


### PR DESCRIPTION
Adds a credential-free Vite Agent example to the package showcase, so readers can discover and invoke an Agent locally before configuring a model or provider. The README keeps the development route, built server bundle, custom-driver boundary, and production security and lifecycle limits explicit.

The focused test builds through public package exports, exercises the bundled H3 request, inspects and invokes the Agent through the public CLI contract, verifies the unknown-Agent diagnostic, and closes the Vite server after the suite.

This does not change Agent runtime or provider behavior, generated provider output, authentication policy, or the Nuxt template.

## Verification

- `corepack pnpm exec vp run -t @vite-hub/agent#build`
- `corepack pnpm --dir packages/agent exec vp test test/example.test.ts`
- `corepack pnpm --dir packages/agent exec vp test test/cli.test.ts test/discovery.test.ts test/public-api.test.ts`
- `corepack pnpm exec vp test test/package-examples.test.ts`
- `corepack pnpm exec vp test test/contracts.test.ts -t 'keeps existing showcase manifests pointed at real files'`
- `corepack pnpm exec vp check --no-fmt packages/agent/examples/vite/server/agents/greeting.ts packages/agent/examples/vite/src/server.ts packages/agent/examples/vite/vite.config.ts packages/agent/test/example.test.ts`
- Manual CLI smoke: `agent info`, successful `agent dev`, unknown-Agent failure, and Ctrl-C cleanup

## Caveat

The full `test/contracts.test.ts` run hit its existing 30-second all-package license-pack timeout. The showcase-manifest assertion affected by this change passes when run directly.
