### PR TITLE
docs(workflow): explain provider durability

### DIFF
--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -34,12 +34,15 @@ Importing the provider-neutral package root does not load OpenWorkflow types. Wo
 import { defineWorkflow } from "@vite-hub/workflow";
 
 export default defineWorkflow<{ email: string }>(async ({ id, payload, provider }) => {
-  await createUser(payload.email);
-  await sendWelcomeEmail(payload.email);
+  const idempotencyKey = `onboard-user:${payload.email}`;
+  const user = await upsertUser(payload.email, { idempotencyKey });
+  await sendWelcomeEmail(user.email, { idempotencyKey: `${idempotencyKey}:welcome-email` });
 
   return { id, provider };
 });
 ```
+
+Both external operations receive keys derived from stable input. Preserve that idempotency when adding side effects so retrying a completed operation does not duplicate it.
 
 ViteHub discovers `server/workflows/<name>.ts`, folder workflows such as `server/workflows/onboard-user/index.ts`, and `src/<name>.workflow.ts`. The file name becomes the name passed to runtime helpers.
 
@@ -60,6 +63,32 @@ Set `provider` explicitly when the deployment target should not decide it. Other
 
 OpenWorkflow accepts one storage choice: `postgres.url` or `sqlite.path`. Hosted credentials belong in Server Env, not source code.
 
+### Run an OpenWorkflow worker
+
+`runWorkflow()` only enqueues an OpenWorkflow run. Start one worker in a long-lived Node or Docker process:
+
+```ts
+// worker.ts
+import type { WorkflowDefinition } from "@vite-hub/workflow";
+import { startOpenWorkflowWorker } from "@vite-hub/workflow/runtime/openworkflow-worker";
+import onboardUser from "./server/workflows/onboard-user.ts";
+
+const postgresUrl = process.env.OPENWORKFLOW_POSTGRES_URL;
+if (!postgresUrl) throw new Error("OPENWORKFLOW_POSTGRES_URL is required");
+
+const worker = await startOpenWorkflowWorker({
+  config: {
+    provider: "openworkflow",
+    postgres: { url: postgresUrl },
+  },
+  registry: {
+    "onboard-user": async () => ({ default: onboardUser as WorkflowDefinition }),
+  },
+});
+```
+
+Keep this process running while it should consume queued runs, and do not start a worker per request. `startOpenWorkflowWorker()` installs `SIGINT` and `SIGTERM` handlers. If the host owns shutdown, await `worker.stop()` from its shutdown hook.
+
 ## Start and inspect a run
 
 ```ts
@@ -75,7 +104,7 @@ export default defineEventHandler(async (event) => {
 });
 ```
 
-`runWorkflow()` returns a provider-backed run with an id and normalized status. `getWorkflowRun()` returns normalized run and step state, including timestamps, attempts, results, and failures when the provider supplies them.
+`runWorkflow()` returns a normalized acknowledgement with an id, provider, and status. `getWorkflowRun()` returns normalized run and step state, including timestamps, attempts, results, and failures when the provider supplies them.
 
 The other runtime helpers are:
 

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -162,21 +162,21 @@ interface OnboardPayload {
   email: string;
 }
 
-async function createUserStep(email: string) {
+async function upsertUserStep(email: string) {
   "use step";
 
-  return await createUser(email);
+  return await upsertUser(email, { idempotencyKey: `onboard-user:${email}` });
 }
 
 async function durableOnboard({ payload }: WorkflowExecutionContext<OnboardPayload>) {
   "use workflow";
 
-  const user = await createUserStep(payload.email);
+  const user = await upsertUserStep(payload.email);
   return { userId: user.id };
 }
 
 async function inlineOnboard({ payload }: WorkflowExecutionContext<OnboardPayload>) {
-  const user = await createUser(payload.email);
+  const user = await upsertUser(payload.email, { idempotencyKey: `onboard-user:${payload.email}` });
   return { userId: user.id };
 }
 

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -49,25 +49,57 @@ ViteHub discovers `server/workflows/<name>.ts`, folder workflows such as `server
 ## Configure the provider
 
 ```ts
-// vite.config.ts
-import { hubWorkflow } from "@vite-hub/workflow/vite";
-import { defineConfig } from "vite";
+// server/workflow-runtime.ts
+import type {
+  ResolvedWorkflowOptions,
+  WorkflowDefinition,
+  WorkflowDefinitionRegistry,
+} from "@vite-hub/workflow";
+import {
+  setWorkflowRuntimeConfig,
+  setWorkflowRuntimeRegistry,
+} from "@vite-hub/workflow/runtime/state";
+import onboardUser from "./workflows/onboard-user.ts";
 
 const postgresUrl = {
   kind: "env-variable",
   source: { kind: "env", name: "OPENWORKFLOW_POSTGRES_URL" },
 } as const;
 
+export const workflowConfig = {
+  provider: "openworkflow",
+  postgres: { url: postgresUrl },
+} satisfies ResolvedWorkflowOptions;
+
+const workflowRegistry = {
+  "onboard-user": async () => ({ default: onboardUser as WorkflowDefinition }),
+} satisfies WorkflowDefinitionRegistry;
+
+export function installWorkflowRuntime() {
+  const url = process.env.OPENWORKFLOW_POSTGRES_URL;
+  if (!url) throw new Error("OPENWORKFLOW_POSTGRES_URL is required");
+
+  setWorkflowRuntimeConfig({
+    ...workflowConfig,
+    postgres: { ...workflowConfig.postgres, url },
+  });
+  setWorkflowRuntimeRegistry(workflowRegistry);
+}
+```
+
+```ts
+// vite.config.ts
+import { hubWorkflow } from "@vite-hub/workflow/vite";
+import { defineConfig } from "vite";
+import { workflowConfig } from "./server/workflow-runtime.ts";
+
 export default defineConfig({
   plugins: [hubWorkflow()],
-  workflow: {
-    provider: "openworkflow",
-    postgres: { url: postgresUrl },
-  },
+  workflow: workflowConfig,
 });
 ```
 
-This config and the worker below read the same Postgres URL, so `runWorkflow()` enqueues work in the backend that the worker polls. Set `provider` explicitly when the deployment target should not decide it. Otherwise ViteHub selects Cloudflare on Cloudflare hosting and Vercel on other supported hosts. Node and Docker select OpenWorkflow when its storage is configured. Netlify cannot infer a provider.
+The Vite config, application process, and worker below share one provider config. The runtime installer also registers the same definitions in both processes. Set `provider` explicitly when the deployment target should not decide it. Otherwise ViteHub selects Cloudflare on Cloudflare hosting and Vercel on other supported hosts. Node and Docker select OpenWorkflow when its storage is configured. Netlify cannot infer a provider.
 
 OpenWorkflow accepts one storage choice: `postgres.url` or `sqlite.path`. Hosted credentials belong in Server Env, not source code.
 
@@ -77,22 +109,11 @@ OpenWorkflow accepts one storage choice: `postgres.url` or `sqlite.path`. Hosted
 
 ```ts
 // worker.ts
-import type { WorkflowDefinition } from "@vite-hub/workflow";
 import { startOpenWorkflowWorker } from "@vite-hub/workflow/runtime/openworkflow-worker";
-import onboardUser from "./server/workflows/onboard-user.ts";
+import { installWorkflowRuntime } from "./server/workflow-runtime.ts";
 
-const postgresUrl = process.env.OPENWORKFLOW_POSTGRES_URL;
-if (!postgresUrl) throw new Error("OPENWORKFLOW_POSTGRES_URL is required");
-
-const worker = await startOpenWorkflowWorker({
-  config: {
-    provider: "openworkflow",
-    postgres: { url: postgresUrl },
-  },
-  registry: {
-    "onboard-user": async () => ({ default: onboardUser as WorkflowDefinition }),
-  },
-});
+installWorkflowRuntime();
+const worker = await startOpenWorkflowWorker();
 ```
 
 Keep this process running while it should consume queued runs, and do not start a worker per request. `startOpenWorkflowWorker()` installs `SIGINT` and `SIGTERM` handlers. If the host owns shutdown, await `worker.stop()` from its shutdown hook.
@@ -103,6 +124,9 @@ Keep this process running while it should consume queued runs, and do not start 
 // server/api/onboard.post.ts
 import { getWorkflowRun, runWorkflow } from "@vite-hub/workflow";
 import { defineEventHandler, readBody } from "h3";
+import { installWorkflowRuntime } from "../workflow-runtime.ts";
+
+installWorkflowRuntime();
 
 export default defineEventHandler(async (event) => {
   const payload = await readBody<{ email: string }>(event);

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -7,9 +7,9 @@
   <img alt="Workflow" src="https://img.shields.io/badge/Workflow-durable%20steps-7c3aed?style=flat-square">
 </p>
 
-`@vite-hub/workflow` defines long-running work once and starts it through one `runWorkflow()` API.
+`@vite-hub/workflow` discovers named long-running work and exposes one provider-neutral API for starting and inspecting runs.
 
-Vercel definitions can register a native entry for durable execution. Definitions without one remain source-compatible, but execute inline and do not survive a function restart.
+Use a Workflow when the application needs a run id, durable state, retries, cancellation, or resumable work. Use [Queue](https://vitehub.dev/docs/server-primitives/queue) when background delivery is enough and the application does not need to inspect a run.
 
 ## Install
 
@@ -17,96 +17,146 @@ Vercel definitions can register a native entry for durable execution. Definition
 pnpm add @vite-hub/workflow
 ```
 
-Add the provider dependency for the workflow provider you configure.
-OpenWorkflow worker lifecycle helpers live at `@vite-hub/workflow/runtime/openworkflow-worker`, so importing the provider-agnostic package root does not require OpenWorkflow's types.
+Then install the dependency required by the selected provider:
 
-## Minimal API
+| Provider             | Additional dependency                                              | Durable state                                                            |
+| -------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| Cloudflare Workflows | None in application code                                           | Cloudflare owns run state.                                               |
+| Vercel Workflow      | `workflow` and `@workflow/builders` for native durable definitions | Native definitions survive function restarts; plain handlers run inline. |
+| OpenWorkflow         | `openworkflow`                                                     | Requires explicit SQLite, Postgres, or ViteHub Named Database storage.   |
+
+Importing the provider-neutral package root does not load OpenWorkflow types. Worker lifecycle helpers live at `@vite-hub/workflow/runtime/openworkflow-worker`.
+
+## Define a workflow
 
 ```ts
-// server/workflows/welcome.ts
-import { defineWorkflow } from "@vite-hub/workflow"
+// server/workflows/onboard-user.ts
+import { defineWorkflow } from "@vite-hub/workflow";
 
-export default defineWorkflow<{ email: string }>(async ({ id, payload, step }) => {
-  const email = await step?.do?.("send-email", {}, async () => {
-    return { sentTo: payload.email }
-  })
+export default defineWorkflow<{ email: string }>(async ({ id, payload, provider }) => {
+  await createUser(payload.email);
+  await sendWelcomeEmail(payload.email);
 
-  return { id, email }
-})
+  return { id, provider };
+});
 ```
 
-For a durable Vercel run, keep the same context-shaped interface and register a native entry containing the Workflow DevKit directive:
+ViteHub discovers `server/workflows/<name>.ts`, folder workflows such as `server/workflows/onboard-user/index.ts`, and `src/<name>.workflow.ts`. The file name becomes the name passed to runtime helpers.
+
+## Configure the provider
 
 ```ts
-import { defineWorkflow, type WorkflowExecutionContext } from "@vite-hub/workflow"
+// vite.config.ts
+import { hubWorkflow } from "@vite-hub/workflow/vite";
+import { defineConfig } from "vite";
 
-interface WelcomePayload {
-  email: string
-}
-
-async function durableWelcome({ payload }: WorkflowExecutionContext<WelcomePayload>) {
-  "use workflow"
-
-  return { sentTo: payload.email }
-}
-
-async function inlineWelcome({ payload }: WorkflowExecutionContext<WelcomePayload>) {
-  return { sentTo: payload.email }
-}
-
-export default defineWorkflow(inlineWelcome, { native: durableWelcome })
+export default defineConfig({
+  plugins: [hubWorkflow()],
+  workflow: { provider: "cloudflare" },
+});
 ```
 
-ViteHub transforms the native entry with Workflow DevKit when it generates Vercel provider output.
+Set `provider` explicitly when the deployment target should not decide it. Otherwise ViteHub selects Cloudflare on Cloudflare hosting and Vercel on other supported hosts. Node and Docker select OpenWorkflow when its storage is configured. Netlify cannot infer a provider.
+
+OpenWorkflow accepts exactly one storage choice: `database`, `postgres.url`, or `sqlite.path`. Hosted credentials belong in Server Env, not source code.
+
+## Start and inspect a run
 
 ```ts
-// server/api/welcome.post.ts
-import { getWorkflowRun, runWorkflow } from "@vite-hub/workflow"
-import { defineEventHandler, readBody } from "h3"
+// server/api/onboard.post.ts
+import { getWorkflowRun, runWorkflow } from "@vite-hub/workflow";
+import { defineEventHandler, readBody } from "h3";
 
 export default defineEventHandler(async (event) => {
-  const run = await runWorkflow("welcome", await readBody<{ email: string }>(event))
-  return getWorkflowRun("welcome", run.id)
-})
+  const payload = await readBody<{ email: string }>(event);
+  const started = await runWorkflow("onboard-user", payload);
+
+  return await getWorkflowRun("onboard-user", started.id);
+});
 ```
 
-`getWorkflowRun()` normalizes provider run and step state, including timestamps, attempts, and failures. `cancelWorkflow()` cancels a durable run, and `resumeWorkflowSignal()` forwards an opaque signal token created inside the native workflow. Providers that cannot perform an operation fail explicitly instead of simulating it.
+`runWorkflow()` returns a provider-backed run with an id and normalized status. `getWorkflowRun()` returns normalized run and step state, including timestamps, attempts, results, and failures when the provider supplies them.
+
+The other runtime helpers are:
+
+- `deferWorkflow()` starts through the deferred provider path when available.
+- `cancelWorkflow()` cancels a native Vercel run.
+- `resumeWorkflowSignal()` resumes a registered Vercel Workflow DevKit hook token.
+- `createWorkflow()` creates a named handle with `run`, `defer`, `getRun`, and `cancel` methods.
+
+Unsupported provider operations fail with `WORKFLOW_OPERATION_UNSUPPORTED`; ViteHub does not pretend that an inline run was cancelled or resumed.
+
+## Make a Vercel workflow durable
+
+A plain Vercel definition executes inline and does not survive a function restart. For durable execution, keep the same context-shaped handler and register a native Workflow DevKit entry:
+
+```sh
+pnpm add workflow @workflow/builders
+```
+
+```ts
+import { defineWorkflow, type WorkflowExecutionContext } from "@vite-hub/workflow";
+
+interface OnboardPayload {
+  email: string;
+}
+
+async function createUserStep(email: string) {
+  "use step";
+
+  return await createUser(email);
+}
+
+async function durableOnboard({ payload }: WorkflowExecutionContext<OnboardPayload>) {
+  "use workflow";
+
+  const user = await createUserStep(payload.email);
+  return { userId: user.id };
+}
+
+async function inlineOnboard({ payload }: WorkflowExecutionContext<OnboardPayload>) {
+  const user = await createUser(payload.email);
+  return { userId: user.id };
+}
+
+export default defineWorkflow(inlineOnboard, { native: durableOnboard });
+```
+
+ViteHub transforms `native` when it generates Vercel output. Other providers keep using the normal handler. Put external side effects in idempotent `use step` functions because a durable step may be retried.
+
+## Handle stable failures
 
 Throw `ViteHubError` when app callers need a stable, inspectable Workflow failure instead of parsing log output or provider-specific messages. ViteHub-owned failures use the package's fixed `WorkflowErrorCode` vocabulary.
 
 ```ts
-import { ViteHubError } from "@vite-hub/runtime"
+import { ViteHubError } from "@vite-hub/runtime";
 
 async function transcribe(recordingId: string) {
   try {
-    return await transcribeRecording(recordingId)
-  }
-  catch (cause) {
+    return await transcribeRecording(recordingId);
+  } catch (cause) {
     throw new ViteHubError("TRANSCRIPTION_FAILED", "Transcription failed.", {
       cause,
       details: { recordingId },
-    })
+    });
   }
 }
 ```
 
 `code` and `message` remain available through `error.toJSON()`. Keep `details` JSON-safe and free of secrets; `toJSON()` omits `cause`, which remains available only on the in-memory error. ViteHub's built-in codes are typed as `WorkflowErrorCode` and use code-derived messages and code-specific details. Workflow Step retry behavior belongs in the Step's retry options rather than the error.
 
-```ts
-// vite.config.ts
-import { hubWorkflow } from "@vite-hub/workflow/vite"
-import { defineConfig } from "vite"
+## Production checklist
 
-export default defineConfig({
-  plugins: [hubWorkflow()],
-  workflow: { provider: "openworkflow" },
-})
-```
+- Confirm that the selected provider is durable enough for the work; inline Vercel handlers are not durable.
+- Make side-effecting steps idempotent so retries do not duplicate work.
+- Keep provider credentials and database URLs in Server Env.
+- Configure durable OpenWorkflow storage and run its migrations before serving traffic.
+- Verify start, inspection, failure, retry, cancellation, timeout, and restart behavior on the deployment host.
 
-## Vite Integration
+## Documentation
 
-Use `hubWorkflow()` in Vite to discover `server/workflows/<name>.ts`, folder workflows such as `server/workflows/welcome/index.ts` with numbered step files, and `src/<name>.workflow.ts`.
-
-Providers map to [OpenWorkflow](https://openworkflow.dev/docs/overview), [Cloudflare Workflows](https://developers.cloudflare.com/workflows/), or [Vercel Workflow](https://vercel.com/docs/workflow).
-
-Learn more at [vitehub.dev](https://vitehub.dev).
+- [Workflow guide](https://vitehub.dev/docs/server-primitives/workflows)
+- [Runtime and host support](https://vitehub.dev/docs/frameworks-hosts/support-matrix)
+- [OpenWorkflow](https://openworkflow.dev/docs/overview)
+- [Cloudflare Workflows](https://developers.cloudflare.com/workflows/)
+- [Vercel Workflow](https://vercel.com/docs/workflow)

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -53,13 +53,21 @@ ViteHub discovers `server/workflows/<name>.ts`, folder workflows such as `server
 import { hubWorkflow } from "@vite-hub/workflow/vite";
 import { defineConfig } from "vite";
 
+const postgresUrl = {
+  kind: "env-variable",
+  source: { kind: "env", name: "OPENWORKFLOW_POSTGRES_URL" },
+} as const;
+
 export default defineConfig({
   plugins: [hubWorkflow()],
-  workflow: { provider: "cloudflare" },
+  workflow: {
+    provider: "openworkflow",
+    postgres: { url: postgresUrl },
+  },
 });
 ```
 
-Set `provider` explicitly when the deployment target should not decide it. Otherwise ViteHub selects Cloudflare on Cloudflare hosting and Vercel on other supported hosts. Node and Docker select OpenWorkflow when its storage is configured. Netlify cannot infer a provider.
+This config and the worker below read the same Postgres URL, so `runWorkflow()` enqueues work in the backend that the worker polls. Set `provider` explicitly when the deployment target should not decide it. Otherwise ViteHub selects Cloudflare on Cloudflare hosting and Vercel on other supported hosts. Node and Docker select OpenWorkflow when its storage is configured. Netlify cannot infer a provider.
 
 OpenWorkflow accepts one storage choice: `postgres.url` or `sqlite.path`. Hosted credentials belong in Server Env, not source code.
 

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -23,7 +23,7 @@ Then install the dependency required by the selected provider:
 | -------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------ |
 | Cloudflare Workflows | None in application code                                           | Cloudflare owns run state.                                               |
 | Vercel Workflow      | `workflow` and `@workflow/builders` for native durable definitions | Native definitions survive function restarts; plain handlers run inline. |
-| OpenWorkflow         | `openworkflow`                                                     | Requires explicit SQLite or Postgres storage.                            |
+| OpenWorkflow         | `openworkflow`; add `postgres` when using Postgres                 | Requires explicit SQLite or Postgres storage.                            |
 
 Importing the provider-neutral package root does not load OpenWorkflow types. Worker lifecycle helpers live at `@vite-hub/workflow/runtime/openworkflow-worker`.
 
@@ -59,8 +59,6 @@ import {
   setWorkflowRuntimeConfig,
   setWorkflowRuntimeRegistry,
 } from "@vite-hub/workflow/runtime/state";
-import onboardUser from "./workflows/onboard-user.ts";
-
 const postgresUrl = {
   kind: "env-variable",
   source: { kind: "env", name: "OPENWORKFLOW_POSTGRES_URL" },
@@ -72,7 +70,9 @@ export const workflowConfig = {
 } satisfies ResolvedWorkflowOptions;
 
 const workflowRegistry = {
-  "onboard-user": async () => ({ default: onboardUser as WorkflowDefinition }),
+  "onboard-user": async () => ({
+    default: (await import("./workflows/onboard-user.ts")).default as WorkflowDefinition,
+  }),
 } satisfies WorkflowDefinitionRegistry;
 
 export function installWorkflowRuntime() {

--- a/packages/workflow/README.md
+++ b/packages/workflow/README.md
@@ -23,7 +23,7 @@ Then install the dependency required by the selected provider:
 | -------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------ |
 | Cloudflare Workflows | None in application code                                           | Cloudflare owns run state.                                               |
 | Vercel Workflow      | `workflow` and `@workflow/builders` for native durable definitions | Native definitions survive function restarts; plain handlers run inline. |
-| OpenWorkflow         | `openworkflow`                                                     | Requires explicit SQLite, Postgres, or ViteHub Named Database storage.   |
+| OpenWorkflow         | `openworkflow`                                                     | Requires explicit SQLite or Postgres storage.                            |
 
 Importing the provider-neutral package root does not load OpenWorkflow types. Worker lifecycle helpers live at `@vite-hub/workflow/runtime/openworkflow-worker`.
 
@@ -58,7 +58,7 @@ export default defineConfig({
 
 Set `provider` explicitly when the deployment target should not decide it. Otherwise ViteHub selects Cloudflare on Cloudflare hosting and Vercel on other supported hosts. Node and Docker select OpenWorkflow when its storage is configured. Netlify cannot infer a provider.
 
-OpenWorkflow accepts exactly one storage choice: `database`, `postgres.url`, or `sqlite.path`. Hosted credentials belong in Server Env, not source code.
+OpenWorkflow accepts one storage choice: `postgres.url` or `sqlite.path`. Hosted credentials belong in Server Env, not source code.
 
 ## Start and inspect a run
 


### PR DESCRIPTION
## Summary

- turn the Workflow package README into a provider-selection and first-run guide
- replace the optional-step minimal example with a complete named Workflow Definition and start/inspect route
- document Cloudflare, Vercel, and OpenWorkflow dependency and durability boundaries
- make unsupported operations, idempotency, secrets, storage, migrations, and production verification explicit

## Why

The existing README introduced the API, but it made the provider configuration appear late, used optional chaining around a Workflow Step that could silently skip work, and did not give readers a compact way to choose a provider or understand which execution paths are durable. This change keeps the package behavior unchanged while making the public contract and production boundaries visible at the package entry point.

## Verification

- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm exec vp run build` — all 25 public/workspace package builds passed, including publint
- `corepack pnpm --filter @vite-hub/workflow test` — 180/181 passed in the loaded full run; the only failure was the existing 5-second timeout in `published-types.test.ts`
- isolated retry of `published-types.test.ts` — 3/3 passed in 4.5 seconds
- isolated unaffected Workflow suite — 143/143 passed
- `corepack pnpm --filter @vite-hub/workflow typecheck`
- README snippets compiled against the built public exports
- package-local publint passed and `pnpm pack --dry-run` included the README and every declared export target
- all six documentation/provider links returned HTTP 200
- `vp fmt --check packages/workflow/README.md`
- `git diff --check`

## Boundaries

- README only; runtime behavior, discovery, provider output, and exports are unchanged
- open PR #1073 changes Workflow registry rendering but does not own this README
- no credentialed hosted run was attempted; provider durability claims are traced to current source/tests and the canonical ViteHub provider guide