### PR TITLE
docs(vite-hub): make the package entry point actionable

### DIFF
--- a/packages/vite-hub/README.md
+++ b/packages/vite-hub/README.md
@@ -1,6 +1,8 @@
 # vite-hub
 
-`vite-hub` is the cohesive ViteHub framework distribution. It gives applications one ViteHub dependency, one `vitehub()` Vite entry, and deliberate feature subpaths while every `@vite-hub/*` package keeps owning its implementation and remains independently installable.
+`vite-hub` is the ViteHub application distribution. It registers enabled integrations through one `vitehub()` call and exposes application APIs on explicit `vite-hub/*` feature imports.
+
+Use it for a Vite or Nuxt application that needs Server Primitives, Agents, or both. Install an `@vite-hub/*` owner package directly when you are building a library, another framework integration, or a custom package composition.
 
 ## Install
 
@@ -8,19 +10,32 @@
 pnpm add vite-hub
 ```
 
+You need Node.js 24.15 or newer, Vite 8 or newer, and an ESM package with `"type": "module"` or a `vite.config.mts` file. Hosted primitives and model providers can also require credentials, network access, and billed accounts. Their feature guides list those requirements before the first provider call.
+
 ## Configure ViteHub
 
 Choose one built-in deployment preset. Application routes and feature imports stay unchanged when the target changes.
 
 ```ts
 // vite.config.ts
-import { vitehub } from "vite-hub"
-import { defineConfig } from "vite"
+import { vitehub } from "vite-hub";
+import { defineConfig } from "vite";
 
 export default defineConfig({
   plugins: [vitehub({ preset: "node" })],
-})
+});
 ```
+
+This registers ViteHub's build integration. Your application still needs a server entry or a framework such as Nuxt. For Nuxt, use the `vite-hub/nuxt` module shown in the [installation guide](https://vitehub.dev/docs/getting-started/installation).
+
+## Run a complete first result
+
+Choose the result that matches the application you are building:
+
+- [First Server Primitive](https://vitehub.dev/docs/getting-started/first-server-primitive) builds and starts a local Node server, writes and reads a KV value, and returns `{"settings":{"theme":"system"}}` from `curl`.
+- [First Agent](https://vitehub.dev/docs/getting-started/first-agent) builds and starts a local Node server, runs an offline Agent Invocation, and returns `{"text":"Hello, Ada. This result came from an Agent Invocation."}`.
+
+Both guides use `vite-hub`, include complete files and commands, and need no provider credentials. Do not treat the configuration fragment above as a successful runtime check by itself.
 
 The public presets are `cloudflare`, `netlify`, `vercel`, `deno`, and `node`. Each resolves once to a host, runtime, Nitro output, packaging policy, and service adapters; do not also set `nitro.preset`, `NITRO_PRESET`, `SERVER_PRESET`, or `VITEHUB_HOSTING`.
 
@@ -45,22 +60,30 @@ vitehub({
   schedule: true,
   workflow: true,
   workspace: true,
-})
+});
 ```
 
-| Preset | Blob | Queue | Rate Limit | Sandbox | Schedule |
-| --- | --- | --- | --- | --- | --- |
-| `cloudflare` | R2 | Cloudflare Queues | Cloudflare | Cloudflare Containers | Supported |
-| `netlify` | Netlify Blobs | Unsupported | Unsupported | Unsupported | Supported |
-| `vercel` | Vercel Blob | Vercel Queues | Unsupported | Vercel Sandbox | Supported |
-| `deno` | Unsupported | Unsupported | Unsupported | Unsupported | Unsupported |
-| `node` | Local filesystem (single host) | Unsupported | Process memory (single process) | Unsupported | Supported |
+| Preset       | Blob                           | Queue             | Rate Limit                      | Sandbox               | Schedule    |
+| ------------ | ------------------------------ | ----------------- | ------------------------------- | --------------------- | ----------- |
+| `cloudflare` | R2                             | Cloudflare Queues | Cloudflare                      | Cloudflare Containers | Supported   |
+| `netlify`    | Netlify Blobs                  | Unsupported       | Unsupported                     | Unsupported           | Supported   |
+| `vercel`     | Vercel Blob                    | Vercel Queues     | Unsupported                     | Vercel Sandbox        | Supported   |
+| `deno`       | Unsupported                    | Unsupported       | Unsupported                     | Unsupported           | Unsupported |
+| `node`       | Local filesystem (single host) | Unsupported       | Process memory (single process) | Unsupported           | Supported   |
 
 Selecting an unsupported opt-in capability fails the build with the preset policy. You can instead configure an explicit Blob driver through `blob` or compose an owner package directly when the application provides its own portable implementation.
 
 The Deno preset uses Nitro's Deno entrypoint, so it rejects Schedule and `agent.runtime: "deno"`; those owner-package outputs require an explicit deployment integration.
 
 The Deno preset emits `.output/deno.json`, stages emitted runtime packages and installed optional native dependencies under `.output/node_modules`, and writes `.output/deploy.mjs`, a non-interactive create-or-update runner used by the `node ./deploy.mjs` command in `.output/nitro.json`; set `DENO_DEPLOY_ORG` before deployment. The runner uses the resolved deployment identity as its app name, with `DENO_DEPLOY_APP` as an optional override, and uploads node modules when it creates or updates an app. The Node preset emits a plain Node server artifact suitable for a VPS or container image; Docker is not a hosting preset.
+
+## Build, inspect, and deploy
+
+The preset tells ViteHub which integrations and Provider Output to generate. Depending on the host and enabled features, a build can write Runtime Registries under `.vitehub`, Cloudflare Worker output and `wrangler.json` under `dist`, Vercel Build Output under `.vercel/output`, Netlify functions under `.netlify/v1`, or Node and Deno artifacts under `.output`.
+
+A successful build proves that ViteHub discovered the configured definitions and wrote the selected output. It does not prove that remote resources exist, credentials are valid, deployment succeeded, or a hosted provider completed a live operation. Follow the selected [host guide](https://vitehub.dev/docs/frameworks-hosts) for provisioning, environment variables, deployment commands, and current proof.
+
+Generated files are for inspection and deployment. Application code must not import `.vitehub/**`, provider output directories, Vite virtual module IDs, or `vite-hub/_internal/*`. Use the public paths in the [import reference](https://vitehub.dev/docs/reference/import-paths).
 
 ## Configure TypeScript
 
@@ -88,16 +111,22 @@ Vite config resolution and builds also refresh the entry. Defining `files` in th
 ## Use feature APIs
 
 ```ts
-import { defineAgent } from "vite-hub/agent"
-import { workspaceShell } from "vite-hub/agent/capabilities"
-import { env } from "vite-hub/env"
-import { renderMarkdownTemplate } from "vite-hub/markdown-template"
-import { defineWorkspace } from "vite-hub/workspace"
-import { defineWorkflow } from "vite-hub/workflow"
+import { defineAgent } from "vite-hub/agent";
+import { workspaceShell } from "vite-hub/agent/capabilities";
+import { env } from "vite-hub/env";
+import { renderMarkdownTemplate } from "vite-hub/markdown-template";
+import { defineWorkspace } from "vite-hub/workspace";
+import { defineWorkflow } from "vite-hub/workflow";
 ```
 
 The root export intentionally contains only the framework configuration API. Feature code belongs on a feature subpath, which forwards to the package that owns it.
 
 Built-in Agent Drivers and Box runtimes are selected by literal or tagged values, so they do not need provider-specific ViteHub imports. Install an optional external provider or SDK explicitly when its runtime requires one.
 
-Install an `@vite-hub/*` owner package directly when building a custom composition, another framework integration, or package-level tooling.
+## Read the reference
+
+- [Installation and owner-package selection](https://vitehub.dev/docs/getting-started/installation)
+- [Configuration options](https://vitehub.dev/docs/reference/config-options)
+- [Runtime and host support](https://vitehub.dev/docs/frameworks-hosts/support-matrix)
+- [Generated files](https://vitehub.dev/docs/development/generated-files)
+- [Public import paths](https://vitehub.dev/docs/reference/import-paths)


### PR DESCRIPTION
## Summary

- makes the `vite-hub` npm page choose the application distribution before configuration and distinguishes it from direct `@vite-hub/*` owner-package use
- routes readers from the smallest config fragment to complete, credential-free Server Primitive and Agent first results with observable output
- documents generated output, provisioning, deployment, credentials, and public-import boundaries without changing runtime behavior or the root README

## Verification

- `pnpm --filter vite-hub build`
- `pnpm --filter vite-hub typecheck`
- exact README configuration and feature-import snippets compiled in an isolated TypeScript fixture
- packed README is byte-identical to the source README; all 116 packed export, type, and bin targets exist
- all eight documentation links return HTTP 200
- `pnpm exec vp fmt packages/vite-hub/README.md --check`
- `git diff --check`

`pnpm --filter vite-hub test` passes 230 of 232 tests with no type errors. The two unchanged Nuxt path assertions see `/tmp/vitehub-nuxt/package.json`, which is owned by another concurrent worker, and therefore resolve the fixture root one directory higher than the assertions expect. This is the same environment-dependent fixture collision already recorded on #1132 and #1085; this PR changes documentation only.

## Ownership

The only other open PR touching this file is #1085. Its Email driver correction (`unemail/driver/resend` to `resend`) is intentionally left unchanged here.
