### PR TITLE
fix(agent): honor configured process concurrency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,51 +49,23 @@ jobs:
       - run: vp run examples:verify
       - name: Package tests
         run: vp run test
-
-  docs:
-    name: docs
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: ./.github/actions/setup
-
-      - run: vp run --filter vitehub-docs test
-      - run: vp run docs:build
-      - run: vp run --filter vitehub-docs test:artifact
+      - name: Consumer contracts
+        run: vp run test:consumer
+      - name: Docs tests
+        run: vp run --filter vitehub-docs test
+      - name: Docs build
+        run: vp run docs:build
+      - name: Docs artifact
+        run: vp run --filter vitehub-docs test:artifact
       - name: Verify Worker bundle
         working-directory: docs
         run: vp dlx "wrangler@4.112.0" deploy --dry-run --config .output/server/wrangler.json
 
-  consumer:
-    name: consumer
+  verify-providers:
+    name: verify providers
+    needs: ci
     runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: ./.github/actions/setup
-      - uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed # v2.0.5
-        with:
-          deno-version: 2.9.3
-
-      - run: vp run test:consumer
-
-  verify-cloudflare:
-    name: verify (cloudflare)
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: ./.github/actions/setup
-
-      - name: Provider Output Contract
-        run: vp run test:output:cloudflare
-      - name: Local Provider Run
-        run: vp run e2e:local --provider cloudflare
-
-  verify-vercel:
-    name: verify (vercel)
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     services:
       redis:
         image: redis:7-alpine
@@ -115,22 +87,19 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup
 
-      - name: Provider Output Contract
+      - name: Cloudflare output contract
+        run: vp run test:output:cloudflare
+      - name: Cloudflare local run
+        run: vp run e2e:local --provider cloudflare
+      - name: Vercel output contract
         run: vp run test:output:vercel
-      - name: Local Provider Run
+      - name: Vercel local run
         run: vp run e2e:local --provider vercel
         env:
           KV_REST_API_TOKEN: local-srh-token
           KV_REST_API_URL: http://127.0.0.1:8079
           TURSO_DATABASE_URL: http://127.0.0.1:8080
-
-  verify-netlify:
-    name: verify (netlify)
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: ./.github/actions/setup
-
-      - run: npm install -g netlify-cli@23.15.1
-      - run: vp run e2e:netlify
+      - name: Install Netlify CLI
+        run: npm install -g netlify-cli@23.15.1
+      - name: Netlify end-to-end
+        run: vp run e2e:netlify

--- a/docs/app/data/support-proof.ts
+++ b/docs/app/data/support-proof.ts
@@ -95,7 +95,7 @@ const contractOwner: ProofOwner = {
 
 const docsOwner: ProofOwner = {
   task: { name: "test", path: "docs/package.json" },
-  workflow: { job: "docs", path: ".github/workflows/ci.yml" },
+  workflow: { job: "ci", path: ".github/workflows/ci.yml" },
 };
 
 const liveSmokeOwner: ProofOwner = {
@@ -153,19 +153,19 @@ const claimDefinitions = {
       "Enabled integrations compose a Worker, wrangler.json, bindings, callbacks, and runtime modules.",
       {
         task: { name: "test:output:cloudflare", path: "test/tasks.ts" },
-        workflow: { job: "verify-cloudflare", path: ".github/workflows/ci.yml" },
+        workflow: { job: "verify-providers", path: ".github/workflows/ci.yml" },
       },
     ),
     vercel: ciClaim(
       "Enabled integrations write Vercel Build Output, functions, routes, cron entries, and runtime modules.",
       {
         task: { name: "test:output:vercel", path: "test/tasks.ts" },
-        workflow: { job: "verify-vercel", path: ".github/workflows/ci.yml" },
+        workflow: { job: "verify-providers", path: ".github/workflows/ci.yml" },
       },
     ),
     netlify: ciClaim("Agent and Schedule write functions under .netlify/v1/functions.", {
       task: { name: "e2e:netlify", path: "vite.config.ts" },
-      workflow: { job: "verify-netlify", path: ".github/workflows/ci.yml" },
+      workflow: { job: "verify-providers", path: ".github/workflows/ci.yml" },
     }),
     deno: ciClaim(
       "Agent and Schedule write Deno entrypoints. ViteHub does not generate one general Deno bundle.",
@@ -181,19 +181,19 @@ const claimDefinitions = {
       "Pull requests run the shared primitive playground against local Cloudflare output.",
       {
         task: { name: "e2e:local", path: "vite.config.ts" },
-        workflow: { job: "verify-cloudflare", path: ".github/workflows/ci.yml" },
+        workflow: { job: "verify-providers", path: ".github/workflows/ci.yml" },
       },
     ),
     vercel: ciClaim(
       "Pull requests run the shared primitive playground against local Vercel adapters.",
       {
         task: { name: "e2e:local", path: "vite.config.ts" },
-        workflow: { job: "verify-vercel", path: ".github/workflows/ci.yml" },
+        workflow: { job: "verify-providers", path: ".github/workflows/ci.yml" },
       },
     ),
     netlify: ciClaim("CI runs a real-project fixture through Netlify CLI.", {
       task: { name: "e2e:netlify", path: "vite.config.ts" },
-      workflow: { job: "verify-netlify", path: ".github/workflows/ci.yml" },
+      workflow: { job: "verify-providers", path: ".github/workflows/ci.yml" },
     }),
     deno: unpublishedClaim("ViteHub does not publish one shared local Deno provider run."),
     nitro: unpublishedClaim("ViteHub does not publish one unified local Nitro matrix run."),

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -115,7 +115,7 @@ export default defineAgent({
 
 Queued invocations start in FIFO order. An invocation is rejected immediately when the queue is full, rejected when its queue timeout expires, and removed from the queue when its abort signal fires. Capacity remains occupied until streamed Driver output finishes or is cancelled, so returning a stream does not allow the next invocation to start early. Agent inspection metadata and `vitehub agent info` expose the configured limits plus the process's current active and pending counts. A literal capacity config is local to one Agent Definition in one process; use provider-level or application-level coordination when capacity must span processes.
 
-For a self-hosted Node process, `createProcessAgentCapacity()` adjusts new admissions from host CPU and memory pressure while keeping `concurrency` as a hard maximum. When capacity reaches zero, work stays in the same FIFO queue and resumes automatically after pressure recovers. Active invocations are never preempted.
+For a self-hosted Node process, `createProcessAgentCapacity()` adjusts new admissions from host CPU and memory pressure while keeping `concurrency` as a hard maximum. It does not cap I/O-heavy work to the host CPU count. When capacity reaches zero, work stays in the same FIFO queue and resumes automatically after pressure recovers. Active invocations are never preempted.
 
 ```ts
 // server/agent-capacity.ts

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -127,7 +127,7 @@ export const agentCapacity = createProcessAgentCapacity({
 })
 ```
 
-Import the same `agentCapacity` object into each Agent Definition that should share one process-local budget. Linux hosts use cgroup v2 memory limits, memory events, and pressure stall information when available; other hosts fall back to Node's available-memory and parallelism signals. Sampling failures or samples exceeding `sampleTimeoutMs` (one second by default) use `fallbackConcurrency`, which defaults to one. Custom samplers should pass `context.signal` to abortable I/O. Tune `memory.perInvocationBytes`, `memory.reserveBytes`, and the CPU or memory pressure thresholds when workload measurements justify different admission behavior.
+Import the same `agentCapacity` object into each Agent Definition that should share one process-local budget. Linux hosts use cgroup v2 memory limits, memory events, and pressure stall information when available; other hosts use Node's available-memory signal without CPU-pressure admission. Sampling failures or samples exceeding `sampleTimeoutMs` (one second by default) use `fallbackConcurrency`, which defaults to one. Custom samplers should pass `context.signal` to abortable I/O. Tune `memory.perInvocationBytes`, `memory.reserveBytes`, and the CPU or memory pressure thresholds when workload measurements justify different admission behavior.
 
 For model-backed drivers, put free-form guidance for configured Sources, Capabilities, and Skills in `driver.instructions` or a deterministic imported instruction file. Tool descriptions and schemas stay with the tools as structured contracts.
 

--- a/packages/agent/src/runtime/process.ts
+++ b/packages/agent/src/runtime/process.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises"
-import { availableParallelism, freemem } from "node:os"
+import { freemem } from "node:os"
 
 import { resolveLinuxCgroupV2Path } from "@vite-hub/runtime/node"
 
@@ -40,7 +40,6 @@ interface ProcessResourceSample {
   memoryHighEvents: number
   memoryMax: number
   memoryPressure: number
-  parallelism: number
 }
 
 export function createProcessAgentCapacity(options: ProcessAgentCapacityOptions): AgentDriverCapacityOptions {
@@ -116,8 +115,7 @@ export function createProcessAgentCapacity(options: ProcessAgentCapacityOptions)
       const availableMemory = Math.min(resources.availableMemory, cgroupAvailableMemory)
       const additional = Math.max(0, Math.floor((availableMemory - memory.reserveBytes) / memory.perInvocationBytes))
       const memoryConcurrency = context.active + additional
-      const cpuConcurrency = Math.max(1, resources.parallelism)
-      const concurrency = Math.max(0, Math.min(context.concurrency, memoryConcurrency, cpuConcurrency))
+      const concurrency = Math.max(0, Math.min(context.concurrency, memoryConcurrency))
       return concurrency > context.active
         ? { concurrency, reason: `capacity available (${formatBytes(availableMemory)} memory headroom)` }
         : { concurrency, reason: `waiting for capacity (${formatBytes(availableMemory)} memory headroom)` }
@@ -154,11 +152,10 @@ async function readProcessResources(signal: AbortSignal): Promise<ProcessResourc
     memoryHighEvents: cgroup?.memoryHighEvents ?? 0,
     memoryMax: cgroup?.memoryMax ?? Number.POSITIVE_INFINITY,
     memoryPressure: cgroup?.memoryPressure ?? 0,
-    parallelism: availableParallelism(),
   }
 }
 
-async function readCgroupResources(signal: AbortSignal): Promise<Omit<ProcessResourceSample, "availableMemory" | "parallelism">> {
+async function readCgroupResources(signal: AbortSignal): Promise<Omit<ProcessResourceSample, "availableMemory">> {
   const membership = await readFile("/proc/self/cgroup", { encoding: "utf8", signal })
   const relative = membership.split(/\r?\n/).find((line) => line.startsWith("0::"))?.slice(3)
   if (relative === undefined) throw new Error("cgroup v2 membership is unavailable")

--- a/packages/agent/test/process-capacity.test.ts
+++ b/packages/agent/test/process-capacity.test.ts
@@ -140,6 +140,19 @@ describe("process Agent capacity", () => {
     })
   })
 
+  it("honors configured concurrency above host CPU count", async () => {
+    resources.availableMemory = 16 * GiB
+    resources.memoryHigh = 20 * GiB
+    resources.memoryMax = 20 * GiB
+    resources.parallelism = 2
+    const sample = createBuiltInSample({ concurrency: 10 })
+
+    await expect(sample({ active: 0, concurrency: 10, pending: 1, signal: new AbortController().signal })).resolves.toEqual({
+      concurrency: 10,
+      reason: "capacity available (16.0 GiB memory headroom)",
+    })
+  })
+
   it("bounds cgroup headroom by Node available memory", async () => {
     resources.availableMemory = 3 * GiB
     const sample = createBuiltInSample({


### PR DESCRIPTION
## Summary

- make `createProcessAgentCapacity()` treat configured concurrency as the hard maximum instead of silently capping it to host CPU count
- retain adaptive memory and CPU-pressure admission controls
- consolidate six CI jobs into a core job and a dependent provider job without removing checks

This lets I/O-heavy agents use intentional concurrency while reducing hosted-runner fanout from six repository jobs per commit to two. Including package preview and review automation, the expected PR fanout drops from eight jobs to four.

## Verification

- `pnpm --filter @vite-hub/agent exec vp test run test/process-capacity.test.ts` (11 passed)
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm exec vp run -t @vite-hub/agent#build`
- scoped `vp check --no-fmt`
- workflow parsed as YAML and checked for both jobs plus all original commands
- `git diff --check`