### PR TITLE
fix: restore main CI contracts

### DIFF
--- a/packages/agent/test/executor-capability.test.ts
+++ b/packages/agent/test/executor-capability.test.ts
@@ -4,6 +4,7 @@ import type { Mock } from "vitest"
 import type { MCPClient, MCPTransport } from "@ai-sdk/mcp"
 
 const runtime = () => ({
+  capabilities: {},
   memo: vi.fn(),
   runtime: "unknown" as const,
   runtimeConfig: {},

--- a/packages/blob/src/internal/vercel-retry.ts
+++ b/packages/blob/src/internal/vercel-retry.ts
@@ -37,11 +37,15 @@ export default async function retry<T>(
 
   for (let attempt = 1; ; attempt++) {
     let bailError: unknown
+    let rejectBail!: (error: unknown) => void
+    const bailPromise = new Promise<never>((_, reject) => {
+      rejectBail = reject
+    })
     try {
-      const result = await operation((error = new Error("Aborted")) => {
+      const result = await Promise.race([Promise.resolve().then(() => operation((error = new Error("Aborted")) => {
         bailError = error || new Error("Aborted")
-      }, attempt)
-      if (bailError !== undefined) throw bailError
+        rejectBail(bailError)
+      }, attempt)), bailPromise])
       return result
     }
     catch (error) {

--- a/packages/blob/src/internal/vercel-retry.ts
+++ b/packages/blob/src/internal/vercel-retry.ts
@@ -1,0 +1,36 @@
+interface RetryOptions {
+  factor?: number
+  maxTimeout?: number
+  minTimeout?: number
+  onRetry?: (error: unknown, attempt: number) => void
+  randomize?: boolean
+  retries?: number
+}
+
+export default async function retry<T>(
+  operation: (bail: (error?: unknown) => void, attempt: number) => T | Promise<T>,
+  options: RetryOptions = {},
+): Promise<T> {
+  const retries = options.retries ?? 10
+  const factor = options.factor ?? 2
+  const minTimeout = options.minTimeout ?? 1_000
+  const maxTimeout = options.maxTimeout ?? Infinity
+
+  for (let attempt = 1; ; attempt++) {
+    let bailError: unknown
+    try {
+      const result = await operation((error = new Error("Aborted")) => {
+        bailError = error || new Error("Aborted")
+      }, attempt)
+      if (bailError !== undefined) throw bailError
+      return result
+    }
+    catch (error) {
+      if (bailError !== undefined || (error && typeof error === "object" && Reflect.get(error, "bail")) || attempt > retries) throw error
+      options.onRetry?.(error, attempt)
+      const random = options.randomize === false ? 1 : Math.random() + 1
+      const timeout = Math.min(Math.round(random * Math.max(minTimeout, 1) * factor ** (attempt - 1)), maxTimeout)
+      await new Promise(resolve => setTimeout(resolve, timeout))
+    }
+  }
+}

--- a/packages/blob/src/internal/vercel-retry.ts
+++ b/packages/blob/src/internal/vercel-retry.ts
@@ -37,15 +37,14 @@ export default async function retry<T>(
 
   for (let attempt = 1; ; attempt++) {
     let bailError: unknown
-    let rejectBail!: (error: unknown) => void
-    const bailPromise = new Promise<never>((_, reject) => {
-      rejectBail = reject
-    })
     try {
-      const result = await Promise.race([Promise.resolve().then(() => operation((error = new Error("Aborted")) => {
-        bailError = error || new Error("Aborted")
-        rejectBail(bailError)
-      }, attempt)), bailPromise])
+      const result = await new Promise<T>((resolve, reject) => {
+        const value = operation((error = new Error("Aborted")) => {
+          bailError = error || new Error("Aborted")
+          reject(bailError)
+        }, attempt)
+        Promise.resolve(value).then(resolve, reject)
+      })
       return result
     }
     catch (error) {

--- a/packages/blob/src/internal/vercel-retry.ts
+++ b/packages/blob/src/internal/vercel-retry.ts
@@ -7,6 +7,24 @@ interface RetryOptions {
   retries?: number
 }
 
+function mainError(errors: unknown[]): unknown {
+  const counts = new Map<unknown, number>()
+  let selected = errors[0]
+  let selectedCount = 0
+
+  for (const error of errors) {
+    const message = error && typeof error === "object" ? Reflect.get(error, "message") : undefined
+    const count = (counts.get(message) ?? 0) + 1
+    counts.set(message, count)
+    if (count >= selectedCount) {
+      selected = error
+      selectedCount = count
+    }
+  }
+
+  return selected
+}
+
 export default async function retry<T>(
   operation: (bail: (error?: unknown) => void, attempt: number) => T | Promise<T>,
   options: RetryOptions = {},
@@ -15,6 +33,7 @@ export default async function retry<T>(
   const factor = options.factor ?? 2
   const minTimeout = options.minTimeout ?? 1_000
   const maxTimeout = options.maxTimeout ?? Infinity
+  const errors: unknown[] = []
 
   for (let attempt = 1; ; attempt++) {
     let bailError: unknown
@@ -26,7 +45,9 @@ export default async function retry<T>(
       return result
     }
     catch (error) {
-      if (bailError !== undefined || (error && typeof error === "object" && Reflect.get(error, "bail")) || Number.isNaN(retries) || attempt > retries) throw error
+      if (bailError !== undefined || (error && typeof error === "object" && Reflect.get(error, "bail")) || Number.isNaN(retries)) throw error
+      errors.push(error)
+      if (attempt > retries) throw mainError(errors)
       options.onRetry?.(error, attempt)
       const random = options.randomize === false ? 1 : Math.random() + 1
       const timeout = Math.min(Math.round(random * Math.max(minTimeout, 1) * factor ** (attempt - 1)), maxTimeout)

--- a/packages/blob/src/internal/vercel-retry.ts
+++ b/packages/blob/src/internal/vercel-retry.ts
@@ -26,7 +26,7 @@ export default async function retry<T>(
       return result
     }
     catch (error) {
-      if (bailError !== undefined || (error && typeof error === "object" && Reflect.get(error, "bail")) || attempt > retries) throw error
+      if (bailError !== undefined || (error && typeof error === "object" && Reflect.get(error, "bail")) || Number.isNaN(retries) || attempt > retries) throw error
       options.onRetry?.(error, attempt)
       const random = options.randomize === false ? 1 : Math.random() + 1
       const timeout = Math.min(Math.round(random * Math.max(minTimeout, 1) * factor ** (attempt - 1)), maxTimeout)

--- a/packages/blob/src/internal/vercel-retry.ts
+++ b/packages/blob/src/internal/vercel-retry.ts
@@ -13,7 +13,7 @@ function mainError(errors: unknown[]): unknown {
   let selectedCount = 0
 
   for (const error of errors) {
-    const message = error && typeof error === "object" ? Reflect.get(error, "message") : undefined
+    const message = error ? Reflect.get(Object(error), "message") : undefined
     const count = (counts.get(message) ?? 0) + 1
     counts.set(message, count)
     if (count >= selectedCount) {
@@ -48,7 +48,7 @@ export default async function retry<T>(
       return result
     }
     catch (error) {
-      if (bailError !== undefined || (error && typeof error === "object" && Reflect.get(error, "bail")) || Number.isNaN(retries)) throw error
+      if (bailError !== undefined || (error && Reflect.get(Object(error), "bail")) || Number.isNaN(retries)) throw error
       errors.push(error)
       if (attempt > retries) throw mainError(errors)
       options.onRetry?.(error, attempt)

--- a/packages/blob/src/internal/vercel-throttle.ts
+++ b/packages/blob/src/internal/vercel-throttle.ts
@@ -1,0 +1,21 @@
+export default function throttle<TThis, TArgs extends unknown[]>(
+  callback: (this: TThis, ...args: TArgs) => void,
+  wait: number,
+) {
+  let lastCallTime = 0
+  let timeout: ReturnType<typeof setTimeout> | undefined
+
+  return function throttled(this: TThis, ...args: TArgs) {
+    clearTimeout(timeout)
+    const delay = wait - (Date.now() - lastCallTime)
+    if (delay <= 0) {
+      lastCallTime = Date.now()
+      callback.apply(this, args)
+      return
+    }
+    timeout = setTimeout(() => {
+      lastCallTime = Date.now()
+      callback.apply(this, args)
+    }, delay)
+  }
+}

--- a/packages/blob/test/optional-peer.test.ts
+++ b/packages/blob/test/optional-peer.test.ts
@@ -103,6 +103,20 @@ describe("optional peer imports", () => {
     expect(attempts).toBe(1)
   })
 
+  it("returns Vercel's most frequent retry error and breaks ties with the latest error", async () => {
+    const repeated = new Error("repeated")
+    const final = new Error("final")
+    await expect(retry((_, attempt) => {
+      throw attempt < 3 ? repeated : final
+    }, { minTimeout: 0, randomize: false, retries: 2 })).rejects.toBe(repeated)
+
+    const first = new Error("first")
+    const latest = new Error("latest")
+    await expect(retry((_, attempt) => {
+      throw attempt === 1 ? first : latest
+    }, { minTimeout: 0, randomize: false, retries: 1 })).rejects.toBe(latest)
+  })
+
   it("ships the patched Vercel Blob runtime through the public driver", async () => {
     const built = await readFile(new URL("../dist/drivers/vercel.js", import.meta.url), "utf8")
 

--- a/packages/blob/test/optional-peer.test.ts
+++ b/packages/blob/test/optional-peer.test.ts
@@ -83,6 +83,17 @@ describe("optional peer imports", () => {
     expect(attempts).toEqual([1, 2])
   })
 
+  it("starts the first Vercel attempt synchronously", async () => {
+    let started = false
+    const result = retry(() => {
+      started = true
+      return "done"
+    }, { retries: 0 })
+
+    expect(started).toBe(true)
+    await expect(result).resolves.toBe("done")
+  })
+
   it("stops Vercel retries when the request bails", async () => {
     const error = new Error("stop")
     let attempts = 0

--- a/packages/blob/test/optional-peer.test.ts
+++ b/packages/blob/test/optional-peer.test.ts
@@ -1,11 +1,12 @@
 import { readFile } from "node:fs/promises"
 
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 
 import { filesSdkDriverPeers, getFilesSdkPeerInstall } from "../src/internal/files-sdk-peers.ts"
 import { importOptionalPeer } from "../src/internal/optional-peer.ts"
 import isBuffer from "../src/internal/vercel-is-buffer.ts"
 import retry from "../src/internal/vercel-retry.ts"
+import throttle from "../src/internal/vercel-throttle.ts"
 
 async function readLocalClosure(entry: URL, seen = new Set<string>()): Promise<string[]> {
   if (seen.has(entry.href)) return []
@@ -115,6 +116,26 @@ describe("optional peer imports", () => {
     await expect(retry((_, attempt) => {
       throw attempt === 1 ? first : latest
     }, { minTimeout: 0, randomize: false, retries: 1 })).rejects.toBe(latest)
+  })
+
+  it("throttles Vercel callbacks with a leading call and the latest trailing call", () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const calls: string[] = []
+      const throttled = throttle((value: string) => calls.push(value), 100)
+
+      throttled("first")
+      throttled("stale")
+      throttled("latest")
+      expect(calls).toEqual(["first"])
+
+      vi.advanceTimersByTime(100)
+      expect(calls).toEqual(["first", "latest"])
+    }
+    finally {
+      vi.useRealTimers()
+    }
   })
 
   it("ships the patched Vercel Blob runtime through the public driver", async () => {

--- a/packages/blob/test/optional-peer.test.ts
+++ b/packages/blob/test/optional-peer.test.ts
@@ -93,6 +93,14 @@ describe("optional peer imports", () => {
     expect(attempts).toBe(1)
   })
 
+  it("rejects immediately when a bailed Vercel request stays pending", async () => {
+    const error = new Error("stop")
+    await expect(retry((bail) => {
+      bail(error)
+      return new Promise(() => {})
+    }, { minTimeout: 0, retries: 2 })).rejects.toBe(error)
+  })
+
   it("does not retry when Vercel supplies an invalid retry count", async () => {
     const error = new Error("invalid retries")
     let attempts = 0

--- a/packages/blob/test/optional-peer.test.ts
+++ b/packages/blob/test/optional-peer.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest"
 import { filesSdkDriverPeers, getFilesSdkPeerInstall } from "../src/internal/files-sdk-peers.ts"
 import { importOptionalPeer } from "../src/internal/optional-peer.ts"
 import isBuffer from "../src/internal/vercel-is-buffer.ts"
+import retry from "../src/internal/vercel-retry.ts"
 
 async function readLocalClosure(entry: URL, seen = new Set<string>()): Promise<string[]> {
   if (seen.has(entry.href)) return []
@@ -69,6 +70,26 @@ describe("optional peer imports", () => {
     expect(closure).toContain("new Uint8Array(result.value)")
     expect(closure).toContain("value.destroy(reason)")
     expect(closure).not.toContain("reason instanceof Error ? reason : void 0")
+  })
+
+  it("retries Vercel requests without a CommonJS runtime", async () => {
+    const attempts: number[] = []
+    await expect(retry((_, attempt) => {
+      attempts.push(attempt)
+      if (attempt === 1) throw new Error("retry")
+      return "done"
+    }, { minTimeout: 0, randomize: false, retries: 1 })).resolves.toBe("done")
+    expect(attempts).toEqual([1, 2])
+  })
+
+  it("stops Vercel retries when the request bails", async () => {
+    const error = new Error("stop")
+    let attempts = 0
+    await expect(retry((bail) => {
+      attempts++
+      bail(error)
+    }, { minTimeout: 0, retries: 2 })).rejects.toBe(error)
+    expect(attempts).toBe(1)
   })
 
   it("ships the patched Vercel Blob runtime through the public driver", async () => {

--- a/packages/blob/test/optional-peer.test.ts
+++ b/packages/blob/test/optional-peer.test.ts
@@ -92,6 +92,17 @@ describe("optional peer imports", () => {
     expect(attempts).toBe(1)
   })
 
+  it("does not retry when Vercel supplies an invalid retry count", async () => {
+    const error = new Error("invalid retries")
+    let attempts = 0
+    await expect(retry(() => {
+      attempts++
+      if (attempts === 1) throw error
+      return "unexpected retry"
+    }, { minTimeout: 0, retries: Number.NaN })).rejects.toBe(error)
+    expect(attempts).toBe(1)
+  })
+
   it("ships the patched Vercel Blob runtime through the public driver", async () => {
     const built = await readFile(new URL("../dist/drivers/vercel.js", import.meta.url), "utf8")
 

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -373,7 +373,7 @@ describe("hubBlob", () => {
         "const values = new Map()",
         "globalThis.fetch = async (input, init = {}) => {",
         "  const url = new URL(input.toString())",
-        "  const method = init.method || 'GET'",
+        "  const method = (init.method || 'GET').toUpperCase()",
         "  if (url.hostname === 'api.netlify.com') return Response.json({ url: 'https://signed.blobs.example.test/netlify.txt' })",
         "  if (method === 'PUT') {",
         "    const bytes = await new Response(init.body).arrayBuffer()",
@@ -414,7 +414,13 @@ describe("hubBlob", () => {
         .filter(imported => imported.external)
         .map(imported => imported.path)
       expect(externalImports.every(path => path.startsWith("node:"))).toBe(true)
-      const { stdout } = await execFileAsync(process.execPath, [artifactFile], { cwd: artifactRoot })
+      const { stdout } = await execFileAsync(process.execPath, [artifactFile], {
+        cwd: artifactRoot,
+        env: {
+          ...process.env,
+          NETLIFY_BLOBS_CONTEXT: Buffer.from(JSON.stringify({ siteID: "test-site", token: "test-token" })).toString("base64"),
+        },
+      })
       expect(stdout.trim()).toBe("netlify-store")
     }
     finally {

--- a/packages/blob/vite.config.ts
+++ b/packages/blob/vite.config.ts
@@ -39,7 +39,9 @@ export default defineConfig({
   pack: {
     alias: {
       "@vercel/oidc": new URL("./src/internal/vercel-oidc.ts", import.meta.url).pathname,
+      "async-retry": new URL("./src/internal/vercel-retry.ts", import.meta.url).pathname,
       "is-buffer": new URL("./src/internal/vercel-is-buffer.ts", import.meta.url).pathname,
+      throttleit: new URL("./src/internal/vercel-throttle.ts", import.meta.url).pathname,
       undici: new URL("./src/internal/vercel-fetch.ts", import.meta.url).pathname,
     },
     tsconfig: "tsconfig.build.json",


### PR DESCRIPTION
## Summary

- align the Executor test runtime fixture with the required Runtime Capabilities contract introduced by #1069
- keep Vercel Blob output free of CommonJS runtime injection by replacing its two CommonJS helpers with scoped ESM equivalents
- preserve retry, bailout, invalid retry-count, exhausted-error selection, and upload-throttling behavior used by Vercel Blob
- model Netlify Blob v11 credential context and lowercase HTTP methods in the packed artifact test

Both repairs are included together because current main fails in Agent typechecking and Blob provider tests; either repair alone would remain red on the other gate.

## Verification

- @vite-hub/agent typecheck
- Executor capability tests: 21 passed
- full workspace build
- @vite-hub/blob build and typecheck
- full Blob suite: 13 files, 210 tests passed
- focused Vercel helper and packed-closure tests: 18 passed
- focused Netlify packed artifact execution passed
- changed-file lint and git diff --check

Live Vercel and Netlify credentials were not used; provider behavior is covered through the built closure and executable artifact fixtures.