### PR TITLE
test: classify Cloudflare KV runtime export

### DIFF
--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -94,6 +94,7 @@ const generatedRuntimeOwnerExports = new Set([
   "@vite-hub/database/runtime/vercel-vite",
   "@vite-hub/database/runtime/virtual-databases",
   "@vite-hub/database/runtime/virtual-schema",
+  "@vite-hub/kv/runtime/cloudflare-kv",
   "@vite-hub/kv/runtime/upstash-driver",
   "@vite-hub/queue/runtime/hosted",
   "@vite-hub/rate-limit/runtime",


### PR DESCRIPTION
Classifies `@vite-hub/kv/runtime/cloudflare-kv` as a generated/provider runtime so the umbrella package contract accepts the owner-only export added by #1095. Its missing classification was the sole package-test failure after #1166 cleared the earlier main CI gates in [run 33191156833](https://github.com/vite-hub/vitehub/actions/runs/33191156833).

Tests:
- `pnpm --filter vite-hub exec vp test package.test.ts --run --maxWorkers=1 -t "classifies every owner-package export"`
- `VITE_DOCTOR_SINCE=HEAD pnpm exec vp run doctor:typescript`