### PR TITLE
fix(workspace): resolve Vercel alias on Windows

### DIFF
--- a/packages/workspace/test/build-config.test.ts
+++ b/packages/workspace/test/build-config.test.ts
@@ -1,0 +1,24 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+describe("Workspace build aliases", () => {
+  it("converts the Vercel fetch shim URL to a Windows filesystem path", async () => {
+    const source = await readFile(new URL("../vite.config.ts", import.meta.url), "utf8");
+    const alias = fileURLToPath(
+      new URL("file:///D:/a/vitehub/vitehub/packages/workspace/src/internal/vercel-fetch.ts"),
+      { windows: true },
+    );
+
+    expect(source).toContain(
+      'fileURLToPath(new URL("./src/internal/vercel-fetch.ts", import.meta.url))',
+    );
+    expect(source).not.toContain(
+      'new URL("./src/internal/vercel-fetch.ts", import.meta.url).pathname',
+    );
+    expect(alias).toBe(
+      "D:\\a\\vitehub\\vitehub\\packages\\workspace\\src\\internal\\vercel-fetch.ts",
+    );
+  });
+});

--- a/packages/workspace/vite.config.ts
+++ b/packages/workspace/vite.config.ts
@@ -1,9 +1,11 @@
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vite-plus";
 
 export default defineConfig({
   pack: {
     alias: {
-      undici: new URL("./src/internal/vercel-fetch.ts", import.meta.url).pathname,
+      undici: fileURLToPath(new URL("./src/internal/vercel-fetch.ts", import.meta.url)),
     },
     tsconfig: "tsconfig.build.json",
     deps: {


### PR DESCRIPTION
## Summary

- convert the Workspace Vercel Blob `undici` shim URL with `fileURLToPath`
- cover Windows drive-letter conversion so `/D:/...` cannot return

## Failure

The [#1112 Windows credential job](https://github.com/vite-hub/vitehub/actions/runs/33192271419/job/98920476198) failed while packing `@vite-hub/workspace`: Rolldown matched the `undici` alias but could not resolve it from `src/providers/vercel/blob-store.ts`. URL `.pathname` produced `/D:/...`, which is not the Windows filesystem target expected by the resolver.

## Verification

- `pnpm --filter @vite-hub/workspace exec vp test test/build-config.test.ts --run --maxWorkers=1`
- `pnpm --filter @vite-hub/workspace build`
- `pnpm --filter @vite-hub/workspace typecheck`
- `VITE_DOCTOR_SINCE=HEAD pnpm exec vp run doctor:typescript`
- focused format and lint checks