### PR TITLE
fix(blob): resolve Vercel aliases on Windows

### DIFF
--- a/packages/blob/test/build-config.test.ts
+++ b/packages/blob/test/build-config.test.ts
@@ -1,0 +1,22 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+describe("Blob build aliases", () => {
+  it("converts Vercel shim URLs to Windows filesystem paths", async () => {
+    const source = await readFile(new URL("../vite.config.ts", import.meta.url), "utf8");
+    const alias = fileURLToPath(
+      new URL("file:///D:/a/vitehub/vitehub/packages/blob/src/internal/vercel-fetch.ts"),
+      { windows: true },
+    );
+
+    for (const shim of ["oidc", "retry", "is-buffer", "throttle", "fetch"]) {
+      expect(source).toContain(
+        `fileURLToPath(new URL("./src/internal/vercel-${shim}.ts", import.meta.url))`,
+      );
+    }
+    expect(source).not.toContain("import.meta.url).pathname");
+    expect(alias).toBe("D:\\a\\vitehub\\vitehub\\packages\\blob\\src\\internal\\vercel-fetch.ts");
+  });
+});

--- a/packages/blob/vite.config.ts
+++ b/packages/blob/vite.config.ts
@@ -1,3 +1,5 @@
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vite-plus";
 
 const bundledFilesSdkDrivers = new Set([
@@ -38,11 +40,11 @@ const filesSdkProviderPeers = [
 export default defineConfig({
   pack: {
     alias: {
-      "@vercel/oidc": new URL("./src/internal/vercel-oidc.ts", import.meta.url).pathname,
-      "async-retry": new URL("./src/internal/vercel-retry.ts", import.meta.url).pathname,
-      "is-buffer": new URL("./src/internal/vercel-is-buffer.ts", import.meta.url).pathname,
-      throttleit: new URL("./src/internal/vercel-throttle.ts", import.meta.url).pathname,
-      undici: new URL("./src/internal/vercel-fetch.ts", import.meta.url).pathname,
+      "@vercel/oidc": fileURLToPath(new URL("./src/internal/vercel-oidc.ts", import.meta.url)),
+      "async-retry": fileURLToPath(new URL("./src/internal/vercel-retry.ts", import.meta.url)),
+      "is-buffer": fileURLToPath(new URL("./src/internal/vercel-is-buffer.ts", import.meta.url)),
+      throttleit: fileURLToPath(new URL("./src/internal/vercel-throttle.ts", import.meta.url)),
+      undici: fileURLToPath(new URL("./src/internal/vercel-fetch.ts", import.meta.url)),
     },
     tsconfig: "tsconfig.build.json",
     copy: [{ from: "src/virtual-module.d.ts", rename: "virtual.d.ts", to: "dist" }],


### PR DESCRIPTION
## Summary

- convert the Blob Vercel shim URLs with `fileURLToPath`
- cover every sibling shim alias and Windows drive-letter conversion so `/D:/...` cannot return

## Failure

The [#1112 Windows credential job](https://github.com/vite-hub/vitehub/actions/runs/33201100416/job/98950495652) failed while packing `@vite-hub/blob`: Rolldown matched the `undici` alias but could not resolve it from `src/drivers/vercel-bundled.ts`. Blob's shim aliases used URL `.pathname`, which produces `/D:/...` instead of a Windows filesystem path.

## Verification

- `pnpm --filter @vite-hub/blob exec vp test test/build-config.test.ts --run --maxWorkers=1`
- `pnpm --filter @vite-hub/blob build`
- `pnpm --filter @vite-hub/blob typecheck`
- `VITE_DOCTOR_SINCE=HEAD pnpm exec vp run doctor:typescript`
- focused format and lint checks
