### PR TITLE
fix(provision): report provider error codes

### DIFF
--- a/packages/internal/src/provision.ts
+++ b/packages/internal/src/provision.ts
@@ -81,11 +81,12 @@ export interface ProvisionRequest {
 }
 
 export class ProvisionRequestError extends Error {
-  readonly codes: readonly number[]
+  readonly codes: readonly (number | string)[]
   readonly status: number
 
-  constructor(method: string, path: string, status: number, codes: readonly number[] = []) {
-    super(`Provision request failed: ${method} ${path} (${status}).`)
+  constructor(method: string, path: string, status: number, codes: readonly (number | string)[] = []) {
+    const suffix = codes.length ? ` Provider code${codes.length === 1 ? "" : "s"}: ${codes.join(", ")}.` : ""
+    super(`Provision request failed: ${method} ${path} (${status}).${suffix}`)
     this.name = "ProvisionRequestError"
     this.codes = codes
     this.status = status
@@ -106,8 +107,13 @@ function createJsonClient(baseURL: string, headers: Record<string, string>, fetc
     }
     const response = await fetchImpl(url, init)
     if (!response.ok) {
-      const body = await response.json().catch(() => undefined) as { errors?: Array<{ code?: unknown }> } | undefined
-      const codes = body?.errors?.flatMap(error => typeof error.code === "number" ? [error.code] : []) ?? []
+      const body = await response.json().catch(() => undefined) as {
+        error?: { code?: unknown }
+        errors?: Array<{ code?: unknown }>
+      } | undefined
+      const codes = [body?.error?.code, ...body?.errors?.map(error => error.code) ?? []]
+        .filter((code): code is number | string => typeof code === "number"
+          || (typeof code === "string" && /^[\w.-]{1,128}$/.test(code)))
       throw new ProvisionRequestError(options.method ?? "GET", path, response.status, codes)
     }
     const value: unknown = await response.json()

--- a/packages/internal/test/provision.test.ts
+++ b/packages/internal/test/provision.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest"
+
+import { createCloudflareProvisionClient, createVercelProvisionClient, ProvisionRequestError } from "../src/provision.ts"
+
+describe("provision request errors", () => {
+  it("reports Vercel error codes without leaking provider response details", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => Response.json({
+      error: { code: "invalid_connection_type", message: "provider-secret" },
+    }, { status: 400 }))
+    const request = createVercelProvisionClient({ token: "token" }, fetch)
+
+    const error = await request("/v1/storage/connections", { method: "POST" }).catch(error => error)
+
+    expect(error).toBeInstanceOf(ProvisionRequestError)
+    expect(error).toMatchObject({ codes: ["invalid_connection_type"], status: 400 })
+    expect(error.message).toBe("Provision request failed: POST /v1/storage/connections (400). Provider code: invalid_connection_type.")
+    expect(error.message).not.toContain("provider-secret")
+  })
+
+  it("preserves Cloudflare numeric error codes", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => Response.json({
+      errors: [{ code: 10004, message: "provider-secret" }],
+    }, { status: 409 }))
+    const request = createCloudflareProvisionClient({ accountId: "account", token: "token" }, fetch)
+
+    const error = await request("/storage/buckets").catch(error => error)
+
+    expect(error).toMatchObject({ codes: [10004], status: 409 })
+    expect(error.message).toBe("Provision request failed: GET /storage/buckets (409). Provider code: 10004.")
+    expect(error.message).not.toContain("provider-secret")
+  })
+
+  it("ignores unsafe provider error codes", async () => {
+    const fetch = vi.fn<typeof globalThis.fetch>(async () => Response.json({
+      error: { code: "provider-secret\nsecond-log-line" },
+    }, { status: 400 }))
+    const request = createVercelProvisionClient({ token: "token" }, fetch)
+
+    const error = await request("/v1/storage/connections").catch(error => error)
+
+    expect(error).toMatchObject({ codes: [] })
+    expect(error.message).toBe("Provision request failed: GET /v1/storage/connections (400).")
+  })
+})


### PR DESCRIPTION
Provision failures now include validated provider error codes while continuing to omit provider messages and response details. This makes failures such as the current Vercel Blob connection `400` diagnosable without putting secrets or untrusted multiline content in logs.

Cloudflare numeric codes remain available to existing recovery logic, and successful request parsing is unchanged.

Checks:
- `PATH="/tmp/vitehub-deno-2.9.3:$PATH" corepack pnpm exec vp test test/provision.test.ts` in `packages/internal`
- `corepack pnpm exec tsc --noEmit -p tsconfig.json` in `packages/internal`
- `corepack pnpm exec vp exec oxlint packages/internal/src/provision.ts packages/internal/test/provision.test.ts`
- `git diff --check`