### PR TITLE
fix(agent): release settled invocation listeners

### DIFF
--- a/packages/agent/src/agent-invocation.ts
+++ b/packages/agent/src/agent-invocation.ts
@@ -75,13 +75,20 @@ export interface LiveAgentInvocationOptions<TOutput = unknown, CALL_OPTIONS = un
   support?: (id: string) => Partial<AgentInvocationInputSupport>
 }
 
-export interface BackedAgentInvocationOptions<TOutput = unknown> {
+export interface BackedAgentInvocationOptions<TOutput = unknown, CALL_OPTIONS = unknown> {
   cancel: () => Promise<AgentInvocationSnapshot<TOutput> | undefined>
   errorOutcome: (error: unknown) => "unsupported" | "unavailable"
   id: string
   inspect: () => Promise<AgentInvocationSnapshot<TOutput> | undefined>
   parentAbortSignal?: AbortSignal
   result: Promise<unknown>
+  sendInput?: (
+    id: string,
+    input: AgentRunInput<CALL_OPTIONS>,
+    options: { mode: AgentInvocationInputMode },
+  ) => Promise<AgentInvocationControlOutcome>
+  settled?: Promise<unknown>
+  support?: (id: string) => Partial<AgentInvocationInputSupport>
 }
 
 const agentInvocationResult = Symbol.for("vitehub.agentInvocationResult")
@@ -98,7 +105,7 @@ export function createAgentInvocationController<
   adapter: AgentInvocationControllerAdapter<TOutput, CALL_OPTIONS>,
   result: Promise<unknown>,
 ): AgentInvocationController<TOutput, CALL_OPTIONS> {
-  const resolveSupport = () => typeof adapter.support === "function" ? adapter.support() : adapter.support
+  const resolveSupport = () => adapter.support instanceof Function ? adapter.support() : adapter.support
   const support: AgentInvocationInputSupport = Object.freeze({
     get followUp() {
       return resolveSupport()?.followUp === true
@@ -126,6 +133,7 @@ export function createAgentInvocationController<
 }
 
 export function awaitAgentInvocationResult(controller: AgentInvocationController): Promise<unknown> {
+  // SAFETY: createAgentInvocationController attaches this private result symbol to every controller it returns.
   return (controller as InternalAgentInvocationController)[agentInvocationResult]
 }
 
@@ -152,11 +160,15 @@ export function startLiveAgentInvocation<TOutput = unknown, CALL_OPTIONS = unkno
     id,
     onFinish(outcome) {
       observedFinish = true
-      snapshot = outcome.status === "completed"
-        ? { id, ...(outcome.output !== undefined ? { output: outcome.output } : {}), status: "completed" }
-        : abortSignal.aborted
+      if (outcome.status === "completed") {
+        snapshot = { id, status: "completed" }
+        if (outcome.output !== undefined) snapshot.output = outcome.output
+      }
+      else {
+        snapshot = abortSignal.aborted
           ? { id, status: "cancelled" }
           : { error: outcome.error, id, status: "failed" }
+      }
     },
   })
   void result.catch((error) => {
@@ -187,7 +199,7 @@ export function startLiveAgentInvocation<TOutput = unknown, CALL_OPTIONS = unkno
 }
 
 export function createBackedAgentInvocationController<TOutput = unknown, CALL_OPTIONS = unknown>(
-  options: BackedAgentInvocationOptions<TOutput>,
+  options: BackedAgentInvocationOptions<TOutput, CALL_OPTIONS>,
 ): AgentInvocationController<TOutput, CALL_OPTIONS> {
   let removeParentAbortListener: (() => void) | undefined
   const stopObservingParent = () => {
@@ -229,9 +241,13 @@ export function createBackedAgentInvocationController<TOutput = unknown, CALL_OP
       }
     },
     inspect,
-    async sendInput() {
-      return { id: options.id, outcome: "unsupported" }
+    async sendInput(input, inputOptions) {
+      const outcome = options.sendInput
+        ? await options.sendInput(options.id, input, inputOptions)
+        : "unsupported"
+      return { id: options.id, outcome }
     },
+    support: options.support ? () => options.support!(options.id) : undefined,
   }, options.result)
   if (options.parentAbortSignal) {
     const parentAbortSignal = options.parentAbortSignal
@@ -242,6 +258,6 @@ export function createBackedAgentInvocationController<TOutput = unknown, CALL_OP
       removeParentAbortListener = () => parentAbortSignal.removeEventListener("abort", cancel)
     }
   }
-  void options.result.then(stopObservingParent, stopObservingParent)
+  void options.settled?.then(stopObservingParent, stopObservingParent)
   return controller
 }

--- a/packages/agent/src/agent-invocation.ts
+++ b/packages/agent/src/agent-invocation.ts
@@ -190,10 +190,13 @@ export function createBackedAgentInvocationController<TOutput = unknown, CALL_OP
   options: BackedAgentInvocationOptions<TOutput>,
 ): AgentInvocationController<TOutput, CALL_OPTIONS> {
   let removeParentAbortListener: (() => void) | undefined
+  const stopObservingParent = () => {
+    removeParentAbortListener?.()
+    removeParentAbortListener = undefined
+  }
   const observeTerminalSnapshot = (snapshot: AgentInvocationSnapshot<TOutput> | undefined) => {
     if (snapshot && isTerminalAgentInvocationStatus(snapshot.status)) {
-      removeParentAbortListener?.()
-      removeParentAbortListener = undefined
+      stopObservingParent()
     }
     return snapshot
   }
@@ -239,5 +242,6 @@ export function createBackedAgentInvocationController<TOutput = unknown, CALL_OP
       removeParentAbortListener = () => parentAbortSignal.removeEventListener("abort", cancel)
     }
   }
+  void options.result.then(stopObservingParent, stopObservingParent)
   return controller
 }

--- a/packages/agent/src/agent-invocation.ts
+++ b/packages/agent/src/agent-invocation.ts
@@ -1,3 +1,4 @@
+import { hasRuntimeType } from "./internal/runtime-type.ts"
 import type { AgentRunInput } from "./types.ts"
 
 export type AgentInvocationStatus = "pending" | "running" | "completed" | "failed" | "cancelled"
@@ -75,20 +76,14 @@ export interface LiveAgentInvocationOptions<TOutput = unknown, CALL_OPTIONS = un
   support?: (id: string) => Partial<AgentInvocationInputSupport>
 }
 
-export interface BackedAgentInvocationOptions<TOutput = unknown, CALL_OPTIONS = unknown> {
+export interface BackedAgentInvocationOptions<TOutput = unknown> {
   cancel: () => Promise<AgentInvocationSnapshot<TOutput> | undefined>
   errorOutcome: (error: unknown) => "unsupported" | "unavailable"
   id: string
   inspect: () => Promise<AgentInvocationSnapshot<TOutput> | undefined>
   parentAbortSignal?: AbortSignal
   result: Promise<unknown>
-  sendInput?: (
-    id: string,
-    input: AgentRunInput<CALL_OPTIONS>,
-    options: { mode: AgentInvocationInputMode },
-  ) => Promise<AgentInvocationControlOutcome>
   settled?: Promise<unknown>
-  support?: (id: string) => Partial<AgentInvocationInputSupport>
 }
 
 const agentInvocationResult = Symbol.for("vitehub.agentInvocationResult")
@@ -105,7 +100,7 @@ export function createAgentInvocationController<
   adapter: AgentInvocationControllerAdapter<TOutput, CALL_OPTIONS>,
   result: Promise<unknown>,
 ): AgentInvocationController<TOutput, CALL_OPTIONS> {
-  const resolveSupport = () => adapter.support instanceof Function ? adapter.support() : adapter.support
+  const resolveSupport = () => hasRuntimeType(adapter.support, "function") ? adapter.support() : adapter.support
   const support: AgentInvocationInputSupport = Object.freeze({
     get followUp() {
       return resolveSupport()?.followUp === true
@@ -198,9 +193,9 @@ export function startLiveAgentInvocation<TOutput = unknown, CALL_OPTIONS = unkno
   }, result)
 }
 
-export function createBackedAgentInvocationController<TOutput = unknown, CALL_OPTIONS = unknown>(
-  options: BackedAgentInvocationOptions<TOutput, CALL_OPTIONS>,
-): AgentInvocationController<TOutput, CALL_OPTIONS> {
+export function createBackedAgentInvocationController<TOutput = unknown>(
+  options: BackedAgentInvocationOptions<TOutput>,
+): AgentInvocationController<TOutput> {
   let removeParentAbortListener: (() => void) | undefined
   const stopObservingParent = () => {
     removeParentAbortListener?.()
@@ -223,7 +218,7 @@ export function createBackedAgentInvocationController<TOutput = unknown, CALL_OP
       return { id: options.id, outcome: "unavailable" }
     }
   }
-  const controller = createAgentInvocationController<TOutput, CALL_OPTIONS>(options.id, {
+  const controller = createAgentInvocationController<TOutput>(options.id, {
     async cancel() {
       try {
         const snapshot = observeTerminalSnapshot(await options.cancel())
@@ -241,13 +236,9 @@ export function createBackedAgentInvocationController<TOutput = unknown, CALL_OP
       }
     },
     inspect,
-    async sendInput(input, inputOptions) {
-      const outcome = options.sendInput
-        ? await options.sendInput(options.id, input, inputOptions)
-        : "unsupported"
-      return { id: options.id, outcome }
+    async sendInput() {
+      return { id: options.id, outcome: "unsupported" }
     },
-    support: options.support ? () => options.support!(options.id) : undefined,
   }, options.result)
   if (options.parentAbortSignal) {
     const parentAbortSignal = options.parentAbortSignal

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -954,6 +954,9 @@ async function runAgentAsWorkflow<
     ...(context.trace ? { trace: context.trace } : {}),
   }
   const workflowSettlementTasks: Promise<unknown>[] = []
+  const observeSettlement = (promise: PromiseLike<unknown>) => {
+    workflowSettlementTasks.push(Promise.resolve(promise))
+  }
   const waitUntil = (promise: PromiseLike<unknown>) => {
     const task = Promise.resolve(promise)
     workflowSettlementTasks.push(task)
@@ -961,9 +964,11 @@ async function runAgentAsWorkflow<
   }
   const workflowEvent = {
     ...(cloudflareEnv ? { env: cloudflareEnv } : {}),
+    settled: observeSettlement,
     waitUntil,
     context: {
       ...(context.cloudflare ? { cloudflare: context.cloudflare } : {}),
+      settled: observeSettlement,
       waitUntil,
     },
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -691,6 +691,7 @@ interface StartedAgentWorkflow<CALL_OPTIONS = unknown, TOutput = unknown> {
   handle: WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, TOutput>
   invocationJournal?: AgentInvocationJournal
   run: AgentWorkflowRun<TOutput>
+  settled?: Promise<void>
 }
 interface ScheduleRunContextLike {
   attemptId?: string
@@ -952,12 +953,18 @@ async function runAgentAsWorkflow<
     ...(inheritedRun ? { run: inheritedRun } : {}),
     ...(context.trace ? { trace: context.trace } : {}),
   }
+  const workflowSettlementTasks: Promise<unknown>[] = []
+  const waitUntil = (promise: PromiseLike<unknown>) => {
+    const task = Promise.resolve(promise)
+    workflowSettlementTasks.push(task)
+    context.waitUntil?.(task)
+  }
   const workflowEvent = {
     ...(cloudflareEnv ? { env: cloudflareEnv } : {}),
-    waitUntil: context.waitUntil,
+    waitUntil,
     context: {
       ...(context.cloudflare ? { cloudflare: context.cloudflare } : {}),
-      waitUntil: context.waitUntil,
+      waitUntil,
     },
   }
   // Durable Channel recovery may be a fresh provider start while still owning
@@ -1023,6 +1030,13 @@ async function runAgentAsWorkflow<
     }
     throw error
   }
+  const settled = run.status === "cancelled" || run.status === "completed" || run.status === "failed"
+    ? Promise.resolve()
+    : workflowSettlementTasks.length
+      ? Promise.allSettled(workflowSettlementTasks).then(() => undefined)
+      : undefined
+  const started: StartedAgentWorkflow<CALL_OPTIONS, AgentWorkflowOutput<TOutput>> = { handle, run }
+  if (settled) started.settled = settled
   // Vercel's native Workflow owns durable suspension, but arbitrary Agent Definitions cannot
   // be compiled into that deterministic bundle. Its journal begins in the Agent worker instead.
   let invocationJournal: AgentInvocationJournal<TRuntimeConfig> | undefined
@@ -1030,7 +1044,7 @@ async function runAgentAsWorkflow<
     const snapshot = agentInvocationSnapshotFromWorkflow(run)
     if (!snapshot || (snapshot.status !== "cancelled" && snapshot.status !== "completed" && snapshot.status !== "failed")) {
       const sourceRunId = options.fresh && !durableChannelDelivery ? run.id : context.run?.runId ?? run.id
-      if (!await deferRecovery(run.id, sourceRunId)) return { handle, run }
+      if (!await deferRecovery(run.id, sourceRunId)) return started
     }
     invocationJournal = await bindAgentInvocations(agent.invocations, {
       ...context,
@@ -1040,7 +1054,8 @@ async function runAgentAsWorkflow<
       await invocationJournal?.finish(snapshot.status, snapshot.error)
     }
   }
-  return { handle, ...(invocationJournal ? { invocationJournal } : {}), run }
+  if (invocationJournal) started.invocationJournal = invocationJournal
+  return started
 }
 
 function resolveRegistryModule<TContext extends AgentRuntimeContext>(
@@ -4114,50 +4129,45 @@ async function resultWithStreamedTextAndUsage(
       }
     }
     const canonicalUsage = canonicalUsageRecord?.usage
-    const canonicalResolvedUsage = canonicalUsage
-      ? {
-          ...canonicalUsage,
-          ...(normalizedUsage?.details ? { details: normalizedUsage.details } : {}),
-          ...(normalizedUsage?.inputTokenDetails ? { inputTokenDetails: normalizedUsage.inputTokenDetails } : {}),
-          ...(normalizedUsage?.outputTokenDetails ? { outputTokenDetails: normalizedUsage.outputTokenDetails } : {}),
-          ...(normalizedUsage?.raw !== undefined ? { raw: normalizedUsage.raw } : {}),
-        }
-      : undefined
+    let canonicalResolvedUsage: AgentUsage | undefined
+    if (canonicalUsage) {
+      canonicalResolvedUsage = { ...canonicalUsage }
+      if (normalizedUsage?.details) canonicalResolvedUsage.details = normalizedUsage.details
+      if (normalizedUsage?.inputTokenDetails) canonicalResolvedUsage.inputTokenDetails = normalizedUsage.inputTokenDetails
+      if (normalizedUsage?.outputTokenDetails) canonicalResolvedUsage.outputTokenDetails = normalizedUsage.outputTokenDetails
+      if (normalizedUsage?.raw !== undefined) canonicalResolvedUsage.raw = normalizedUsage.raw
+    }
     const fallbackUsage = normalizedAgentUsage(fallbackUsageRecordProperties.usage)
     const streamedUsage = normalizedAgentUsage(streamedUsageRecordProperties.usage)
     const normalizedRecordUsage = normalizedAgentUsage(normalizedUsageRecordProperties.usage)
     const usageValues = [fallbackUsage, sourceUsage, normalizedRecordUsage, canonicalResolvedUsage, streamedUsage]
     const inputTokenDetails = mergedFiniteNumberObjects(...usageValues.map(value => value?.inputTokenDetails))
     const outputTokenDetails = mergedFiniteNumberObjects(...usageValues.map(value => value?.outputTokenDetails))
-    const mergedUsage = usageValues.some(Boolean)
-      ? {
-          ...mergedAgentUsageScalars(...usageValues),
-          ...(usageValues.some(value => value?.details)
-            ? {
-                details: {
-                  ...mergedReadableObjects(...usageValues.map(value => value?.details)),
-                },
-              }
-            : {}),
-          ...(Object.keys(inputTokenDetails).length ? { inputTokenDetails } : {}),
-          ...(Object.keys(outputTokenDetails).length ? { outputTokenDetails } : {}),
-        }
-      : undefined
+    let mergedUsage: AgentUsage | undefined
+    if (usageValues.some(Boolean)) {
+      mergedUsage = mergedAgentUsageScalars(...usageValues)
+      if (usageValues.some(value => value?.details)) {
+        mergedUsage.details = mergedReadableObjects(...usageValues.map(value => value?.details))
+      }
+      if (Object.keys(inputTokenDetails).length) mergedUsage.inputTokenDetails = inputTokenDetails
+      if (Object.keys(outputTokenDetails).length) mergedUsage.outputTokenDetails = outputTokenDetails
+    }
     const canonicalUsageRecordProperties = mergedUsageRecords(canonicalUsageRecord)
     const usageRecordValues = [fallbackUsageRecordProperties, sourceUsageRecordProperties, normalizedUsageRecordProperties, canonicalUsageRecordProperties, streamedUsageRecordProperties]
-    const mergedUsageRecord = mergedUsage || usageRecordValues.some(value => Object.keys(value).length > 0) || hasSourceUsageRecord
-      ? {
-          ...mergedUsageRecords(...usageRecordValues),
-          ...(["credentialSource", "latency", "response", "run"] as const).reduce<Record<string, unknown>>((properties, key) => {
-            const values = usageRecordValues.map(value => value[key])
-            if (values.some(Boolean)) {
-              properties[key] = mergedUsageRecordMetadata(key, ...values)
-            }
-            return properties
-          }, {}),
-          ...(mergedUsage ? { usage: mergedUsage } : {}),
-        }
-      : undefined
+    let mergedUsageRecord: AgentUsageRecord | undefined
+    if (mergedUsage || usageRecordValues.some(value => Object.keys(value).length > 0) || hasSourceUsageRecord) {
+      mergedUsageRecord = {
+        ...mergedUsageRecords(...usageRecordValues),
+        ...(["credentialSource", "latency", "response", "run"] as const).reduce<Record<string, unknown>>((properties, key) => {
+          const values = usageRecordValues.map(value => value[key])
+          if (values.some(Boolean)) {
+            properties[key] = mergedUsageRecordMetadata(key, ...values)
+          }
+          return properties
+        }, {}),
+      }
+      if (mergedUsage) mergedUsageRecord.usage = mergedUsage
+    }
     const normalizedWithoutUsage = { ...normalized }
     delete normalizedWithoutUsage.usage
     const finishResult = {
@@ -4288,12 +4298,13 @@ async function finishStreamAgentInvocation<
   catch (finishError) {
     await lifecycle.fail({ error: finishError, status: "error" }, finishError, failureMessage)
   }
-  await lifecycle.finish({
+  const finishOutcome: Parameters<typeof lifecycle.finish>[0] = {
     result: finishResult,
     status: "success",
     usage: finishUsage,
-    ...(outcome.usageResolved ? { usageResolved: true } : {}),
-  })
+  }
+  if (outcome.usageResolved) finishOutcome.usageResolved = true
+  await lifecycle.finish(finishOutcome)
   assignResolvedUsageRecord(result, finishUsage)
   const rawDescriptor = result && hasRuntimeType(result, "object")
     ? Object.getOwnPropertyDescriptor(result, "raw")
@@ -5478,14 +5489,15 @@ async function executeAgentInvocationWithCapacityLease<
                 ? (finishResult as { usageRecord?: AgentUsageRecord }).usageRecord
                 : undefined
               if (!outcome.failed && !outcome.completed) {
-                await lifecycle.finish({
+                const lifecycleOutcome: Parameters<typeof lifecycle.finish>[0] = {
                   result: finishResult,
                   status: "success",
-                  ...(finishUsageRecord
-                    ? { usage: await resolveAgentUsageRecord({ usageRecord: finishUsageRecord }, invocation.run) }
-                    : {}),
                   usageResolved: true,
-                })
+                }
+                if (finishUsageRecord) {
+                  lifecycleOutcome.usage = await resolveAgentUsageRecord({ usageRecord: finishUsageRecord }, invocation.run)
+                }
+                await lifecycle.finish(lifecycleOutcome)
               }
               else {
                 await finishStreamAgentInvocation(invocation, lifecycle, finishResult, finishOutcomeFromCleanup(outcome), runFailureMessage, outputExtensions)
@@ -5658,14 +5670,15 @@ async function executeAgentInvocationWithCapacityLease<
             finishTask = (async () => {
               const finishUsageRecord = streamed.finishUsage()
               if (!finalOutcome.failed && !finalOutcome.completed) {
-                await lifecycle.finish({
+                const lifecycleOutcome: Parameters<typeof lifecycle.finish>[0] = {
                   result: finishResult,
                   status: "success",
-                  ...(finishUsageRecord
-                    ? { usage: await resolveAgentUsageRecord({ usageRecord: finishUsageRecord }, invocation.run) }
-                    : {}),
                   usageResolved: true,
-                })
+                }
+                if (finishUsageRecord) {
+                  lifecycleOutcome.usage = await resolveAgentUsageRecord({ usageRecord: finishUsageRecord }, invocation.run)
+                }
+                await lifecycle.finish(lifecycleOutcome)
               }
               else {
                 await finishStreamAgentInvocation(invocation, lifecycle, finishResult, finishOutcomeFromCleanup(finalOutcome), runFailureMessage, outputExtensions)
@@ -6080,19 +6093,7 @@ async function executeAgentInvocationWithCapacityLease<
             : finishOutcome, streamFailureMessage, outputExtensions)
         }
       }
-      return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(enrichedRendered, invocation), shouldWrapOutput, async (outcome, streamedText, streamedUsageRecord) => {
-        const finishTask = finishUiMessageStream(outcome, streamedText, streamedUsageRecord)
-        if (!outcome.failed && !outcome.completed && options.holdCapacity !== true) {
-          const settled = await Promise.race([
-            finishTask.then(() => true, () => true),
-            new Promise<false>(resolve => setTimeout(() => resolve(false), 0)),
-          ])
-          if (settled) await finishTask
-          else void finishTask.catch(() => {})
-          return
-        }
-        await finishTask
-      }, {
+      const finalizationOptions: NonNullable<Parameters<typeof finalizeUiMessageStreamOutput>[3]> = {
         abortSignal: invocation.input.abortSignal,
         detachPendingReaderCancellation: options.holdCapacity !== true,
         cancelOnAbort: options.holdCapacity === true || rendererSource
@@ -6105,9 +6106,22 @@ async function executeAgentInvocationWithCapacityLease<
               ])
             }
           : undefined,
-        ...(collectToolResult ? { onNormalizedChunk: collectToolResult } : {}),
         projection,
-      })
+      }
+      if (collectToolResult) finalizationOptions.onNormalizedChunk = collectToolResult
+      return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(enrichedRendered, invocation), shouldWrapOutput, async (outcome, streamedText, streamedUsageRecord) => {
+        const finishTask = finishUiMessageStream(outcome, streamedText, streamedUsageRecord)
+        if (!outcome.failed && !outcome.completed && options.holdCapacity !== true) {
+          const settled = await Promise.race([
+            finishTask.then(() => true, () => true),
+            new Promise<false>(resolve => setTimeout(() => resolve(false), 0)),
+          ])
+          if (settled) await finishTask
+          else void finishTask.catch(() => {})
+          return
+        }
+        await finishTask
+      }, finalizationOptions)
     }
 
     let isStreamResult = hasTraceableStreamResult(rendered)
@@ -6438,14 +6452,14 @@ function createWorkflowAgentInvocationController<CALL_OPTIONS, TOutput>(
   started: StartedAgentWorkflow<CALL_OPTIONS, TOutput>,
   parentAbortSignal?: AbortSignal,
 ): AgentInvocationController<TOutput | Response, CALL_OPTIONS> {
-  const { handle, invocationJournal, run } = started
+  const { handle, invocationJournal, run, settled } = started
   const reconcileJournal = async (snapshot: AgentInvocationSnapshot<TOutput> | undefined) => {
     if (snapshot?.status === "cancelled" || snapshot?.status === "completed" || snapshot?.status === "failed") {
       await invocationJournal?.finish(snapshot.status, snapshot.error)
     }
     return snapshot
   }
-  return createBackedAgentInvocationController<TOutput | Response, CALL_OPTIONS>({
+  return createBackedAgentInvocationController<TOutput | Response>({
     cancel: async () => {
       // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
       const snapshot = agentInvocationSnapshotFromWorkflow(await handle.cancel(run.id) as AgentWorkflowRun<TOutput>)
@@ -6459,6 +6473,7 @@ function createWorkflowAgentInvocationController<CALL_OPTIONS, TOutput>(
     )),
     parentAbortSignal,
     result: Promise.resolve(run),
+    settled,
   })
 }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -192,6 +192,7 @@ import type {
 import type {
   AgentInvocationController,
   AgentInvocationSnapshot,
+  BackedAgentInvocationOptions,
 } from "./agent-invocation.ts"
 import type { StreamEvent } from "./messages.ts"
 import type { AgentTraceContext } from "./trace.ts"
@@ -6464,7 +6465,7 @@ function createWorkflowAgentInvocationController<CALL_OPTIONS, TOutput>(
     }
     return snapshot
   }
-  return createBackedAgentInvocationController<TOutput | Response>({
+  const controllerOptions: BackedAgentInvocationOptions<TOutput | Response> = {
     cancel: async () => {
       // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
       const snapshot = agentInvocationSnapshotFromWorkflow(await handle.cancel(run.id) as AgentWorkflowRun<TOutput>)
@@ -6476,10 +6477,13 @@ function createWorkflowAgentInvocationController<CALL_OPTIONS, TOutput>(
       // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
       await handle.getRun(run.id) as AgentWorkflowRun<TOutput>,
     )),
-    parentAbortSignal,
     result: Promise.resolve(run),
-    settled,
-  })
+  }
+  if (settled) {
+    controllerOptions.settled = settled
+    if (parentAbortSignal) controllerOptions.parentAbortSignal = parentAbortSignal
+  }
+  return createBackedAgentInvocationController(controllerOptions)
 }
 
 function createInlineAgentInvocationController<

--- a/packages/agent/test/agent-invocation.test.ts
+++ b/packages/agent/test/agent-invocation.test.ts
@@ -10,7 +10,7 @@ import {
   withAgentInvocationControlId,
 } from "../src/internal/agent-invocation-control.ts"
 
-import type { AgentRuntimeContext, AgentToolDefinition } from "../src/index.ts"
+import type { AgentAdapter, AgentRuntimeContext, AgentToolDefinition } from "../src/index.ts"
 
 function runtime(overrides: Partial<AgentRuntimeContext> = {}): AgentRuntimeContext {
   return {
@@ -21,14 +21,22 @@ function runtime(overrides: Partial<AgentRuntimeContext> = {}): AgentRuntimeCont
   }
 }
 
+function backedController(id: string) {
+  return createBackedAgentInvocationController({
+    cancel: async () => undefined,
+    errorOutcome: () => "unavailable",
+    id,
+    inspect: async () => undefined,
+    result: Promise.resolve(),
+  })
+}
+
 describe("Agent Invocation controllers", () => {
   it("isolates active invocation owners by route state", () => {
     const firstState = {}
     const secondState = {}
-    // SAFETY: These minimal controllers only exercise route-state identity lookup.
-    const firstController = { id: "first" } as never
-    // SAFETY: These minimal controllers only exercise route-state identity lookup.
-    const secondController = { id: "second" } as never
+    const firstController = backedController("first")
+    const secondController = backedController("second")
     const unregisterFirst = registerActiveAgentInvocation("shared-key", firstController, Promise.resolve(), firstState)
     const unregisterSecond = registerActiveAgentInvocation("shared-key", secondController, Promise.resolve(), secondState)
 
@@ -135,6 +143,8 @@ describe("Agent Invocation controllers", () => {
 
   it("maps Workflow-backed identity and lifecycle without promising cancellation support", async () => {
     const waitUntilTasks: Array<Promise<unknown>> = []
+    const parent = new AbortController()
+    const removeEventListener = vi.spyOn(parent.signal, "removeEventListener")
     const agent = defineAgent({
       driver: { run: ({ run }) => run?.runId },
       runtime: workflow("controlled-child"),
@@ -143,7 +153,7 @@ describe("Agent Invocation controllers", () => {
       run: { origin: "parent", runId: "parent-run", threadId: "thread-1" },
       runtime: "vercel",
       waitUntil: promise => waitUntilTasks.push(Promise.resolve(promise)),
-    }), {})
+    }), { abortSignal: parent.signal })
 
     expect(controller.id).not.toBe("parent-run")
     await expect(controller.inspect()).resolves.toMatchObject({ outcome: "available" })
@@ -152,6 +162,8 @@ describe("Agent Invocation controllers", () => {
       outcome: "unsupported",
     })
     await Promise.all(waitUntilTasks)
+    await vi.waitFor(() => expect(removeEventListener).toHaveBeenCalledOnce())
+    parent.abort("too late")
     await expect(controller.inspect()).resolves.toEqual({
       invocation: { id: controller.id, output: controller.id, status: "completed" },
       outcome: "available",
@@ -198,12 +210,12 @@ describe("Agent Invocation controllers", () => {
     expect(cancel).not.toHaveBeenCalled()
   })
 
-  it("stops observing parent cancellation when a backed invocation result settles", async () => {
+  it("stops observing parent cancellation after explicit backed invocation settlement", async () => {
     const parent = new AbortController()
     const removeEventListener = vi.spyOn(parent.signal, "removeEventListener")
     const cancel = vi.fn(async () => ({ id: "child", status: "cancelled" as const }))
     let settle!: () => void
-    const result = new Promise<void>((resolve) => {
+    const settled = new Promise<void>((resolve) => {
       settle = resolve
     })
     createBackedAgentInvocationController({
@@ -212,12 +224,12 @@ describe("Agent Invocation controllers", () => {
       id: "child",
       inspect: async () => ({ id: "child", status: "running" }),
       parentAbortSignal: parent.signal,
-      result,
-      settled: result,
+      result: Promise.resolve(),
+      settled,
     })
 
     settle()
-    await result
+    await settled
     expect(removeEventListener).toHaveBeenCalledOnce()
     parent.abort("too late")
     expect(cancel).not.toHaveBeenCalled()
@@ -241,6 +253,7 @@ describe("Agent Invocation controllers", () => {
   })
 
   it("keeps subagents serializable while assigning fresh trusted identities", async () => {
+    const { MockLanguageModelV3 } = await import("ai/test")
     const child = defineAgent({ driver: { run: ({ run }) => run?.runId }, runtime: false })
     const parent = defineAgent({
       capabilities: [subagents({
@@ -248,11 +261,12 @@ describe("Agent Invocation controllers", () => {
           researcher: { agent: child, description: "Research one question." },
         },
       })],
-      // SAFETY: The test resolves tools without invoking this driver model.
-      driver: { model: {} as never },
+      driver: { model: new MockLanguageModelV3() },
     })
-    // SAFETY: Resolving the subagents capability adds its generated tool map to this adapter fixture.
-    const resolved = await parent.resolve(runtime()) as { tools: Record<string, AgentToolDefinition> }
+    // SAFETY: defineAgent resolves capability tools onto this internal adapter before returning it.
+    const resolved = await parent.resolve(runtime()) as AgentAdapter & {
+      tools: Record<string, AgentToolDefinition>
+    }
     const tool = resolved.tools.run_researcher!
     const first = await tool.execute?.({ message: "one" })
     const second = await tool.execute?.({ message: "two" })
@@ -260,7 +274,7 @@ describe("Agent Invocation controllers", () => {
     expect(first).toMatch(/^ainv_/)
     expect(second).toMatch(/^ainv_/)
     expect(second).not.toBe(first)
-    // SAFETY: Agent tool input schemas use object-shaped Standard Schema output in this test fixture.
-    expect((tool.inputSchema as { properties?: Record<string, unknown> }).properties).not.toHaveProperty("runId")
+    if (!tool.inputSchema || !("properties" in tool.inputSchema)) throw new Error("Expected a JSON Schema input.")
+    expect(tool.inputSchema.properties).not.toHaveProperty("runId")
   })
 })

--- a/packages/agent/test/agent-invocation.test.ts
+++ b/packages/agent/test/agent-invocation.test.ts
@@ -196,6 +196,30 @@ describe("Agent Invocation controllers", () => {
     expect(cancel).not.toHaveBeenCalled()
   })
 
+  it("stops observing parent cancellation when a backed invocation result settles", async () => {
+    const parent = new AbortController()
+    const removeEventListener = vi.spyOn(parent.signal, "removeEventListener")
+    const cancel = vi.fn(async () => ({ id: "child", status: "cancelled" as const }))
+    let settle!: () => void
+    const result = new Promise<void>((resolve) => {
+      settle = resolve
+    })
+    createBackedAgentInvocationController({
+      cancel,
+      errorOutcome: () => "unavailable",
+      id: "child",
+      inspect: async () => ({ id: "child", status: "running" }),
+      parentAbortSignal: parent.signal,
+      result,
+    })
+
+    settle()
+    await result
+    expect(removeEventListener).toHaveBeenCalledOnce()
+    parent.abort("too late")
+    expect(cancel).not.toHaveBeenCalled()
+  })
+
   it("keeps subagents serializable while assigning fresh trusted identities", async () => {
     const child = defineAgent({ driver: { run: ({ run }) => run?.runId }, runtime: false })
     const parent = defineAgent({

--- a/packages/agent/test/agent-invocation.test.ts
+++ b/packages/agent/test/agent-invocation.test.ts
@@ -25,7 +25,9 @@ describe("Agent Invocation controllers", () => {
   it("isolates active invocation owners by route state", () => {
     const firstState = {}
     const secondState = {}
+    // SAFETY: These minimal controllers only exercise route-state identity lookup.
     const firstController = { id: "first" } as never
+    // SAFETY: These minimal controllers only exercise route-state identity lookup.
     const secondController = { id: "second" } as never
     const unregisterFirst = registerActiveAgentInvocation("shared-key", firstController, Promise.resolve(), firstState)
     const unregisterSecond = registerActiveAgentInvocation("shared-key", secondController, Promise.resolve(), secondState)
@@ -211,6 +213,7 @@ describe("Agent Invocation controllers", () => {
       inspect: async () => ({ id: "child", status: "running" }),
       parentAbortSignal: parent.signal,
       result,
+      settled: result,
     })
 
     settle()
@@ -218,6 +221,23 @@ describe("Agent Invocation controllers", () => {
     expect(removeEventListener).toHaveBeenCalledOnce()
     parent.abort("too late")
     expect(cancel).not.toHaveBeenCalled()
+  })
+
+  it("keeps observing parent cancellation when only a backed start result settles", async () => {
+    const parent = new AbortController()
+    const cancel = vi.fn(async () => ({ id: "child", status: "cancelled" as const }))
+    createBackedAgentInvocationController({
+      cancel,
+      errorOutcome: () => "unavailable",
+      id: "child",
+      inspect: async () => ({ id: "child", status: "running" }),
+      parentAbortSignal: parent.signal,
+      result: Promise.resolve({ id: "child", status: "queued" }),
+    })
+
+    await Promise.resolve()
+    parent.abort("stop queued child")
+    await vi.waitFor(() => expect(cancel).toHaveBeenCalledOnce())
   })
 
   it("keeps subagents serializable while assigning fresh trusted identities", async () => {
@@ -228,11 +248,11 @@ describe("Agent Invocation controllers", () => {
           researcher: { agent: child, description: "Research one question." },
         },
       })],
+      // SAFETY: The test resolves tools without invoking this driver model.
       driver: { model: {} as never },
     })
-    const resolved = await parent.resolve(runtime()) as unknown as {
-      tools: Record<string, AgentToolDefinition>
-    }
+    // SAFETY: Resolving the subagents capability adds its generated tool map to this adapter fixture.
+    const resolved = await parent.resolve(runtime()) as { tools: Record<string, AgentToolDefinition> }
     const tool = resolved.tools.run_researcher!
     const first = await tool.execute?.({ message: "one" })
     const second = await tool.execute?.({ message: "two" })
@@ -240,6 +260,7 @@ describe("Agent Invocation controllers", () => {
     expect(first).toMatch(/^ainv_/)
     expect(second).toMatch(/^ainv_/)
     expect(second).not.toBe(first)
+    // SAFETY: Agent tool input schemas use object-shaped Standard Schema output in this test fixture.
     expect((tool.inputSchema as { properties?: Record<string, unknown> }).properties).not.toHaveProperty("runId")
   })
 })

--- a/packages/workflow/src/runtime/adapters.ts
+++ b/packages/workflow/src/runtime/adapters.ts
@@ -232,7 +232,7 @@ function createVercelAdapter(config: ResolvedWorkflowOptions): WorkflowRuntimeAd
           details: { ...(safeWorkflowName(name) ? { name } : {}), provider: "vercel" },
         })
       }
-      return await startVercelWorkflow(name, definition, payload)
+      return await startVercelWorkflow(name, definition, payload, resolveWaitUntil(event))
     },
   }
 }

--- a/packages/workflow/src/runtime/adapters.ts
+++ b/packages/workflow/src/runtime/adapters.ts
@@ -39,10 +39,12 @@ interface WorkflowRuntimeAdapter {
 function resolveSettlementObserver(event: unknown): ((promise: PromiseLike<unknown>) => void) | undefined {
   if (!event || !hasRuntimeType(event, "object")) return undefined
   const candidate = "settled" in event ? event.settled : undefined
+  // SAFETY: hasRuntimeType establishes that the runtime event member is callable.
   if (hasRuntimeType(candidate, "function")) return candidate as (promise: PromiseLike<unknown>) => void
   const context = "context" in event ? event.context : undefined
   if (!context || !hasRuntimeType(context, "object")) return undefined
   const nested = "settled" in context ? context.settled : undefined
+  // SAFETY: hasRuntimeType establishes that the nested runtime event member is callable.
   return hasRuntimeType(nested, "function") ? nested as (promise: PromiseLike<unknown>) => void : undefined
 }
 

--- a/packages/workflow/src/runtime/adapters.ts
+++ b/packages/workflow/src/runtime/adapters.ts
@@ -36,6 +36,16 @@ interface WorkflowRuntimeAdapter {
   run<TPayload = unknown, TResult = unknown>(context: RunWorkflowAdapterContext<TPayload, TResult>): Promise<WorkflowRun<TPayload, TResult>>
 }
 
+function resolveSettlementObserver(event: unknown): ((promise: PromiseLike<unknown>) => void) | undefined {
+  if (!event || !hasRuntimeType(event, "object")) return undefined
+  const candidate = "settled" in event ? event.settled : undefined
+  if (hasRuntimeType(candidate, "function")) return candidate as (promise: PromiseLike<unknown>) => void
+  const context = "context" in event ? event.context : undefined
+  if (!context || !hasRuntimeType(context, "object")) return undefined
+  const nested = "settled" in context ? context.settled : undefined
+  return hasRuntimeType(nested, "function") ? nested as (promise: PromiseLike<unknown>) => void : undefined
+}
+
 function unsupportedOperation(provider: "cloudflare" | "openworkflow" | "vercel", operation: WorkflowOperationName): never {
   throw createWorkflowError({
     code: "WORKFLOW_OPERATION_UNSUPPORTED",
@@ -232,7 +242,7 @@ function createVercelAdapter(config: ResolvedWorkflowOptions): WorkflowRuntimeAd
           details: { ...(safeWorkflowName(name) ? { name } : {}), provider: "vercel" },
         })
       }
-      return await startVercelWorkflow(name, definition, payload, resolveWaitUntil(event))
+      return await startVercelWorkflow(name, definition, payload, resolveSettlementObserver(event))
     },
   }
 }

--- a/packages/workflow/src/runtime/vercel.ts
+++ b/packages/workflow/src/runtime/vercel.ts
@@ -249,7 +249,7 @@ export async function startVercelWorkflow<TPayload = unknown, TResult = unknown>
   name: string,
   definition: WorkflowDefinition<TPayload, TResult>,
   payload?: TPayload,
-  waitUntil?: (promise: Promise<unknown>) => void,
+  observeSettlement?: (promise: PromiseLike<unknown>) => void,
 ): Promise<WorkflowRun<TPayload, TResult>> {
   const native = definition.options?.native
   if (!native) {
@@ -268,7 +268,7 @@ export async function startVercelWorkflow<TPayload = unknown, TResult = unknown>
     const run = await runtime.start(native as never, [context])
     return { id: normalizeRunId(run.runId), run }
   })
-  waitUntil?.(Promise.resolve(run.returnValue).then(() => undefined, () => undefined))
+  observeSettlement?.(Promise.resolve(run.returnValue).then(() => undefined, () => undefined))
   return {
     id,
     metadata: { workflow: name },

--- a/packages/workflow/src/runtime/vercel.ts
+++ b/packages/workflow/src/runtime/vercel.ts
@@ -1,5 +1,6 @@
 import { createWorkflowError } from "../errors.ts"
 
+import { hasRuntimeType } from "../internal/runtime-type.ts"
 import { isWorkflowBoundaryError, runWorkflowProviderOperation, safeWorkflowName } from "./provider-operation.ts"
 
 import type { WorkflowDefinition, WorkflowExecutionContext, WorkflowRun, WorkflowRunStatus, WorkflowRunStep, WorkflowSignalResult } from "../types.ts"
@@ -52,18 +53,21 @@ interface VercelWorkflowRuntimeModule {
 }
 
 async function loadVercelWorkflowRuntime(): Promise<VercelWorkflowRuntime> {
-  const importVercelWorkflow = new Function("specifier", "return import(specifier)") as <T>(specifier: string) => Promise<T>
+  // SAFETY: The generated function performs the platform dynamic import and always returns its module promise.
+  const importVercelWorkflow = new Function("specifier", "return import(specifier)") as (specifier: string) => Promise<unknown>
   const [api, runtime] = await Promise.all([
-    importVercelWorkflow<VercelWorkflowApiModule>("workflow/api"),
-    importVercelWorkflow<VercelWorkflowRuntimeModule>("workflow/runtime"),
+    importVercelWorkflow("workflow/api"),
+    importVercelWorkflow("workflow/runtime"),
   ])
-  return createVercelWorkflowRuntime(api, runtime)
+  // SAFETY: workflow/api and workflow/runtime own these module contracts.
+  return createVercelWorkflowRuntime(api as VercelWorkflowApiModule, runtime as VercelWorkflowRuntimeModule)
 }
 
 function createVercelWorkflowRuntime(api: VercelWorkflowApiModule, runtime: VercelWorkflowRuntimeModule): VercelWorkflowRuntime {
   const { getRun, resumeHook, start } = api
   const { getWorld } = runtime
   return {
+    // SAFETY: Vercel's workflow/api module defines getRun with the VercelRun contract normalized below.
     getRun: getRun as (id: string) => VercelRun,
     async listSteps(id) {
       const steps: VercelStep[] = []
@@ -74,12 +78,14 @@ function createVercelWorkflowRuntime(api: VercelWorkflowApiModule, runtime: Verc
           resolveData: "none",
           runId: id,
         })
+        // SAFETY: normalizeSteps validates every provider step before public use.
         steps.push(...(page.data as VercelStep[]))
         cursor = page.hasMore && page.cursor ? page.cursor : undefined
       } while (cursor)
       return steps
     },
     resumeHook,
+    // SAFETY: Vercel's workflow/api module defines start with this runtime contract.
     start: start as VercelWorkflowRuntime["start"],
   }
 }
@@ -122,12 +128,12 @@ function invalidVercelResult(field: string): TypeError {
 }
 
 function normalizeStatus(status: unknown): WorkflowRunStatus {
-  if (typeof status !== "string") throw invalidVercelResult("status")
+  if (!hasRuntimeType(status, "string")) throw invalidVercelResult("status")
   return statusMap[status.toLowerCase()] || "unknown"
 }
 
 function normalizeRunId(id: unknown): string {
-  if (typeof id !== "string" || !id) throw invalidVercelResult("run ID")
+  if (!hasRuntimeType(id, "string") || !id) throw invalidVercelResult("run ID")
   return id
 }
 
@@ -140,7 +146,7 @@ function normalizeDate(value: unknown, field: string): Date | undefined {
 function normalizeStepError(error: unknown): { code?: string; message: string } | undefined {
   if (error === undefined || error === null) return undefined
   if (error instanceof Error) return { message: error.message }
-  if (typeof error === "string") {
+  if (hasRuntimeType(error, "string")) {
     try {
       return normalizeStepError(JSON.parse(error)) || { message: error }
     }
@@ -148,13 +154,13 @@ function normalizeStepError(error: unknown): { code?: string; message: string } 
       return { message: error }
     }
   }
-  if (typeof error === "object") {
+  if (hasRuntimeType(error, "object") && error) {
+    // SAFETY: The object check establishes a provider error record whose members are validated below.
     const value = error as { code?: unknown, error?: unknown, message?: unknown }
-    if (typeof value.message === "string") {
-      return {
-        ...(typeof value.code === "string" ? { code: value.code } : {}),
-        message: value.message,
-      }
+    if (hasRuntimeType(value.message, "string")) {
+      const normalized: { code?: string; message: string } = { message: value.message }
+      if (hasRuntimeType(value.code, "string")) normalized.code = value.code
+      return normalized
     }
     if (value.error !== undefined) return normalizeStepError(value.error)
   }
@@ -165,11 +171,12 @@ function normalizeSteps(steps: unknown): WorkflowRunStep[] {
   if (!Array.isArray(steps)) throw invalidVercelResult("step list")
 
   return steps.map((step) => {
-    if (typeof step !== "object" || step === null) throw invalidVercelResult("step")
+    if (!hasRuntimeType(step, "object") || step === null) throw invalidVercelResult("step")
+    // SAFETY: The object check establishes a provider step record whose members are validated below.
     const value = step as Partial<VercelStep>
-    if (typeof value.attempt !== "number" || !Number.isFinite(value.attempt)) throw invalidVercelResult("step attempt")
-    if (typeof value.stepId !== "string" || !value.stepId) throw invalidVercelResult("step ID")
-    if (typeof value.stepName !== "string" || !value.stepName) throw invalidVercelResult("step name")
+    if (!hasRuntimeType(value.attempt, "number") || !Number.isFinite(value.attempt)) throw invalidVercelResult("step attempt")
+    if (!hasRuntimeType(value.stepId, "string") || !value.stepId) throw invalidVercelResult("step ID")
+    if (!hasRuntimeType(value.stepName, "string") || !value.stepName) throw invalidVercelResult("step name")
 
     return {
       attempt: value.attempt,
@@ -185,14 +192,15 @@ function normalizeSteps(steps: unknown): WorkflowRunStep[] {
 
 async function readRunIdentity(run: VercelRun): Promise<{ exists: false } | { exists: true, workflowName: string }> {
   const exists = await run.exists
-  if (typeof exists !== "boolean") throw invalidVercelResult("existence state")
+  if (!hasRuntimeType(exists, "boolean")) throw invalidVercelResult("existence state")
   if (!exists) return { exists }
   const workflowName = await run.workflowName
-  if (typeof workflowName !== "string") throw invalidVercelResult("workflow name")
+  if (!hasRuntimeType(workflowName, "string")) throw invalidVercelResult("workflow name")
   return { exists, workflowName }
 }
 
 function getNativeWorkflowName<TPayload, TResult>(name: string, definition: WorkflowDefinition<TPayload, TResult>): string {
+  // SAFETY: Vercel's transform attaches workflowId to the generated native handler.
   const workflowName = (definition.options?.native as WorkflowDefinition<TPayload, TResult>["handler"] & { workflowId?: string } | undefined)?.workflowId
   if (!workflowName) {
     throw createWorkflowError({
@@ -229,6 +237,7 @@ export async function inspectVercelWorkflowRun<TPayload = unknown, TResult = unk
     runWorkflowProviderOperation("vercel", "list-steps", async () => normalizeSteps(await runtime.listSteps(id))),
   ])
   const result = snapshot.status === "completed"
+    // SAFETY: A completed run's return value has the Workflow definition's declared result contract.
     ? await runWorkflowProviderOperation("vercel", "get-run", () => run.returnValue) as TResult
     : undefined
   return {
@@ -260,11 +269,13 @@ export async function startVercelWorkflow<TPayload = unknown, TResult = unknown>
   }
   const context: WorkflowExecutionContext<TPayload> = {
     name,
+    // SAFETY: The optional payload belongs to this Workflow definition's payload contract.
     payload: payload as TPayload,
     provider: "vercel",
   }
   const runtime = await getVercelWorkflowRuntime()
   const { id, run } = await runWorkflowProviderOperation("vercel", "start", async () => {
+    // SAFETY: Vercel's native transform produces the handler signature accepted by runtime.start.
     const run = await runtime.start(native as never, [context])
     return { id: normalizeRunId(run.runId), run }
   })

--- a/packages/workflow/src/runtime/vercel.ts
+++ b/packages/workflow/src/runtime/vercel.ts
@@ -245,7 +245,12 @@ export async function inspectVercelWorkflowRun<TPayload = unknown, TResult = unk
   }
 }
 
-export async function startVercelWorkflow<TPayload = unknown, TResult = unknown>(name: string, definition: WorkflowDefinition<TPayload, TResult>, payload?: TPayload): Promise<WorkflowRun<TPayload, TResult>> {
+export async function startVercelWorkflow<TPayload = unknown, TResult = unknown>(
+  name: string,
+  definition: WorkflowDefinition<TPayload, TResult>,
+  payload?: TPayload,
+  waitUntil?: (promise: Promise<unknown>) => void,
+): Promise<WorkflowRun<TPayload, TResult>> {
   const native = definition.options?.native
   if (!native) {
     throw createWorkflowError({
@@ -259,10 +264,11 @@ export async function startVercelWorkflow<TPayload = unknown, TResult = unknown>
     provider: "vercel",
   }
   const runtime = await getVercelWorkflowRuntime()
-  const id = await runWorkflowProviderOperation("vercel", "start", async () => {
+  const { id, run } = await runWorkflowProviderOperation("vercel", "start", async () => {
     const run = await runtime.start(native as never, [context])
-    return normalizeRunId(run.runId)
+    return { id: normalizeRunId(run.runId), run }
   })
+  waitUntil?.(Promise.resolve(run.returnValue).then(() => undefined, () => undefined))
   return {
     id,
     metadata: { workflow: name },

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -1876,6 +1876,8 @@ describe("workflow runtime", () => {
       start: vi.fn(async () => run),
     }
     setVercelWorkflowRuntimeLoader(async () => runtime)
+    const settlementTasks: Promise<unknown>[] = []
+    enterWorkflowRuntimeEvent({ waitUntil: (promise: PromiseLike<unknown>) => settlementTasks.push(Promise.resolve(promise)) })
     setWorkflowRuntimeConfig({ provider: "vercel" })
     setWorkflowRuntimeRegistry({
       welcome: async () => ({
@@ -1891,6 +1893,8 @@ describe("workflow runtime", () => {
 
     const pending = await runWorkflow("welcome", { message: "hello" })
     expect(pending).toMatchObject({ id: "wdk-1", provider: "vercel", status: "queued" })
+    expect(settlementTasks).toHaveLength(1)
+    await expect(settlementTasks[0]).resolves.toBeUndefined()
     expect(runtime.start).toHaveBeenCalledWith(native, [{ name: "welcome", payload: { message: "hello" }, provider: "vercel" }])
 
     status = "completed"

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -1877,7 +1877,11 @@ describe("workflow runtime", () => {
     }
     setVercelWorkflowRuntimeLoader(async () => runtime)
     const settlementTasks: Promise<unknown>[] = []
-    enterWorkflowRuntimeEvent({ waitUntil: (promise: PromiseLike<unknown>) => settlementTasks.push(Promise.resolve(promise)) })
+    const waitUntil = vi.fn()
+    enterWorkflowRuntimeEvent({
+      settled: (promise: PromiseLike<unknown>) => settlementTasks.push(Promise.resolve(promise)),
+      waitUntil,
+    })
     setWorkflowRuntimeConfig({ provider: "vercel" })
     setWorkflowRuntimeRegistry({
       welcome: async () => ({
@@ -1894,6 +1898,7 @@ describe("workflow runtime", () => {
     const pending = await runWorkflow("welcome", { message: "hello" })
     expect(pending).toMatchObject({ id: "wdk-1", provider: "vercel", status: "queued" })
     expect(settlementTasks).toHaveLength(1)
+    expect(waitUntil).not.toHaveBeenCalled()
     await expect(settlementTasks[0]).resolves.toBeUndefined()
     expect(runtime.start).toHaveBeenCalledWith(native, [{ name: "welcome", payload: { message: "hello" }, provider: "vercel" }])
 


### PR DESCRIPTION
## Summary

Detach a backed Agent Invocation parent abort listener when its result settles, including rejection.

Previously cleanup depended on a later inspect or cancel response reporting a terminal snapshot. A naturally settled invocation could therefore retain its parent signal and receive a late cancellation call.

## Proof

- vp test test/agent-invocation.test.ts (10 passed)
- tsc --noEmit -p tsconfig.json
- vp exec oxlint on both changed files
- git diff --check