### PR TITLE
fix(runtime): drain waitUntil work before rejection

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1171,9 +1171,17 @@ export function createRuntimeWaitUntilController(options: {
   const pending: Promise<unknown>[] = []
   return {
     async flushWaitUntil() {
+      let error: unknown
+      let failed = false
       while (pending.length > 0) {
-        await Promise.all(pending.splice(0))
+        for (const result of await Promise.allSettled(pending.splice(0))) {
+          if (!failed && result.status === "rejected") {
+            error = result.reason
+            failed = true
+          }
+        }
       }
+      if (failed) throw error
     },
     waitUntil(task) {
       pending.push(task)

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1174,12 +1174,16 @@ export function createRuntimeWaitUntilController(options: {
       let error: unknown
       let failed = false
       while (pending.length > 0) {
-        for (const result of await Promise.allSettled(pending.splice(0))) {
-          if (!failed && result.status === "rejected") {
-            error = result.reason
+        await Promise.all(pending.splice(0).map(async task => {
+          try {
+            await task
+          }
+          catch (reason) {
+            if (failed) return
+            error = reason
             failed = true
           }
-        }
+        }))
       }
       if (failed) throw error
     },

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -3,6 +3,7 @@ import { runInNewContext } from "node:vm"
 
 import {
   createExecutionContext,
+  createRuntimeWaitUntilController,
   createTraceEventLog,
   deriveTraceRuns,
   defineCapability,
@@ -25,6 +26,33 @@ import {
 } from "../src/index.ts"
 
 describe("@vite-hub/runtime", () => {
+  it("drains nested waitUntil work before reporting a rejection", async () => {
+    const controller = createRuntimeWaitUntilController()
+    const failure = new Error("deferred failure")
+    let nestedCompleted = false
+    let releaseNested: (() => void) | undefined
+    controller.waitUntil(Promise.resolve().then(() => {
+      controller.waitUntil(new Promise<void>((resolve) => {
+        releaseNested = () => {
+          nestedCompleted = true
+          resolve()
+        }
+      }))
+      throw failure
+    }))
+
+    const flushing = controller.flushWaitUntil()
+    let settled = false
+    void flushing.then(() => { settled = true }, () => { settled = true })
+    await vi.waitFor(() => expect(releaseNested).toBeTypeOf("function"))
+    expect(settled).toBe(false)
+
+    releaseNested!()
+    await expect(flushing).rejects.toBe(failure)
+    expect(nestedCompleted).toBe(true)
+    await expect(controller.flushWaitUntil()).resolves.toBeUndefined()
+  })
+
   it("creates complete execution contexts from omitted host fields", () => {
     const first = createExecutionContext({ memo: vi.fn(), runtime: "vite", waitUntil: vi.fn() })
     const second = createExecutionContext({ memo: vi.fn(), runtime: "vite", waitUntil: vi.fn() })

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -53,6 +53,22 @@ describe("@vite-hub/runtime", () => {
     await expect(controller.flushWaitUntil()).resolves.toBeUndefined()
   })
 
+  it("reports the first waitUntil rejection by settlement time", async () => {
+    const controller = createRuntimeWaitUntilController()
+    const firstFailure = new Error("first failure")
+    let rejectEarlierTask: ((reason: Error) => void) | undefined
+    controller.waitUntil(new Promise((_, reject) => {
+      rejectEarlierTask = reject
+    }))
+    controller.waitUntil(Promise.reject(firstFailure))
+
+    const flushing = controller.flushWaitUntil()
+    await vi.waitFor(() => expect(rejectEarlierTask).toBeTypeOf("function"))
+    rejectEarlierTask!(new Error("later failure"))
+
+    await expect(flushing).rejects.toBe(firstFailure)
+  })
+
   it("creates complete execution contexts from omitted host fields", () => {
     const first = createExecutionContext({ memo: vi.fn(), runtime: "vite", waitUntil: vi.fn() })
     const second = createExecutionContext({ memo: vi.fn(), runtime: "vite", waitUntil: vi.fn() })


### PR DESCRIPTION
Runtime `waitUntil` flushing now drains every deferred task, including work registered while an earlier task settles, before reporting the first rejection. This prevents rejected Agent Invocation cleanup from letting nested work continue after the owning Runtime context has finished flushing.

The regression holds nested work open after its parent rejects, verifies flushing remains pending, then confirms the original rejection is preserved only after the nested task completes. A second flush remains empty and successful.

## Verification

- `pnpm exec vp test test/runtime.test.ts` (79 passed)
- `pnpm exec vp test test/published-types.test.ts` (1 passed)
- `pnpm --filter @vite-hub/runtime typecheck`
- `pnpm --filter @vite-hub/runtime build`
- `pnpm exec oxlint packages/runtime/src/index.ts packages/runtime/test/runtime.test.ts`
- `git diff --check origin/main...HEAD`
