### PR TITLE
feat(cli): print the installed version

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -20,6 +20,14 @@ pnpm vitehub --help
 
 `@vite-hub/cli` requires Node.js 24 or newer. The current `vite-hub` distribution requires Node.js 24.15 or newer.
 
+Print the installed CLI version without loading project config:
+
+```sh
+pnpm vitehub --version
+```
+
+`-v` is equivalent.
+
 ## Open project help
 
 Run help from the project root. The CLI loads the project config before it prints help, so only run it in a repository whose config you trust.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -4,6 +4,8 @@ import { existsSync, realpathSync } from "node:fs"
 import process from "node:process"
 import { fileURLToPath } from "node:url"
 
+import cliPackageManifest from "../package.json" with { type: "json" }
+
 import { collectViteHubCliNamespaces, collectViteHubProvisionSteps } from "@vite-hub/internal/cli"
 import { resolve } from "pathe"
 
@@ -180,9 +182,14 @@ function isRootHelp(args: string[]): boolean {
 
 export async function runViteHubCli(options: RunViteHubCliOptions = {}): Promise<number> {
   const args = options.args || process.argv.slice(2)
+  const stdout = options.stdout || process.stdout
+  if (args[0] === "-v" || args[0] === "--version") {
+    stdout.write(`${cliPackageManifest.version}\n`)
+    return 0
+  }
+
   const cwd = options.cwd || process.cwd()
   const env = options.env || process.env
-  const stdout = options.stdout || process.stdout
   const stderr = options.stderr || process.stderr
   const config = await (options.loadConfig || loadViteConfig)(cwd)
   const nuxtConfig = config.vitehubConfigResolved

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -178,12 +178,20 @@ function isRootHelp(args: string[]): boolean {
   return args[0] === "-h" || args[0] === "--help"
 }
 
+function readPackageVersion(): string {
+  const manifest = readFileSync(new URL("../package.json", import.meta.url), "utf8")
+  const version = /"version"\s*:\s*"([^"\\]+)"/u.exec(manifest)?.[1]
+  if (!version) {
+    throw new TypeError("[vitehub] The installed @vite-hub/cli package manifest has no valid version.")
+  }
+  return version
+}
+
 export async function runViteHubCli(options: RunViteHubCliOptions = {}): Promise<number> {
   const args = options.args || process.argv.slice(2)
   const stdout = options.stdout || process.stdout
   if (args[0] === "-v" || args[0] === "--version") {
-    const manifest = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as { version: string }
-    stdout.write(`${manifest.version}\n`)
+    stdout.write(`${readPackageVersion()}\n`)
     return 0
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process"
-import { existsSync, realpathSync } from "node:fs"
+import { existsSync, readFileSync, realpathSync } from "node:fs"
 import process from "node:process"
 import { fileURLToPath } from "node:url"
-
-import cliPackageManifest from "../package.json" with { type: "json" }
 
 import { collectViteHubCliNamespaces, collectViteHubProvisionSteps } from "@vite-hub/internal/cli"
 import { resolve } from "pathe"
@@ -184,7 +182,8 @@ export async function runViteHubCli(options: RunViteHubCliOptions = {}): Promise
   const args = options.args || process.argv.slice(2)
   const stdout = options.stdout || process.stdout
   if (args[0] === "-v" || args[0] === "--version") {
-    stdout.write(`${cliPackageManifest.version}\n`)
+    const manifest = JSON.parse(readFileSync(new URL("../package.json", import.meta.url), "utf8")) as { version: string }
+    stdout.write(`${manifest.version}\n`)
     return 0
   }
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process"
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
+import { cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
@@ -63,13 +63,19 @@ describe("ViteHub CLI", () => {
     expect(loadConfig).not.toHaveBeenCalled()
   })
 
-  it("prints the version through the built binary outside a project", async () => {
+  it("prints the installed manifest version through the built binary outside a project", async () => {
     const rootDir = await createTempDir()
-    const { stderr, stdout } = await execFileAsync(process.execPath, [resolve(import.meta.dirname, "../dist/index.js"), "--version"], {
+    const packageDir = join(rootDir, "package")
+    await mkdir(packageDir, { recursive: true })
+    await cp(resolve(import.meta.dirname, "../dist"), join(packageDir, "dist"), { recursive: true })
+    await writeFile(join(packageDir, "package.json"), JSON.stringify({ type: "module", version: "0.0.0-preview.1174" }))
+    await symlink(resolve(import.meta.dirname, "../../../node_modules"), join(packageDir, "node_modules"), "dir")
+
+    const { stderr, stdout } = await execFileAsync(process.execPath, [join(packageDir, "dist/index.js"), "--version"], {
       cwd: rootDir,
     })
 
-    expect(stdout).toBe(`${cliPackageManifest.version}\n`)
+    expect(stdout).toBe("0.0.0-preview.1174\n")
     expect(stderr).toBe("")
   })
 

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -69,7 +69,7 @@ describe("ViteHub CLI", () => {
     await mkdir(packageDir, { recursive: true })
     await cp(resolve(import.meta.dirname, "../dist"), join(packageDir, "dist"), { recursive: true })
     await writeFile(join(packageDir, "package.json"), JSON.stringify({ type: "module", version: "0.0.0-preview.1174" }))
-    await symlink(resolve(import.meta.dirname, "../../../node_modules"), join(packageDir, "node_modules"), "dir")
+    await symlink(resolve(import.meta.dirname, "../node_modules"), join(packageDir, "node_modules"), "dir")
 
     const { stderr, stdout } = await execFileAsync(process.execPath, [join(packageDir, "dist/index.js"), "--version"], {
       cwd: rootDir,

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -1,12 +1,17 @@
+import { execFile } from "node:child_process"
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
+import { promisify } from "node:util"
 
 import { afterEach, describe, expect, it, vi } from "vitest"
+
+import cliPackageManifest from "../package.json" with { type: "json" }
 
 import { runViteHubCli, runViteHubCliEntrypoint } from "../src/index.ts"
 
 const directories: string[] = []
+const execFileAsync = promisify(execFile)
 
 afterEach(async () => {
   vi.restoreAllMocks()
@@ -45,6 +50,29 @@ function stream() {
 }
 
 describe("ViteHub CLI", () => {
+  it.each(["--version", "-v"])("prints the packaged version for %s without loading project config", async (flag) => {
+    const stdout = stream()
+    const stderr = stream()
+    const loadConfig = vi.fn()
+
+    const exitCode = await runViteHubCli({ args: [flag], loadConfig, stderr, stdout })
+
+    expect(exitCode).toBe(0)
+    expect(stdout.output()).toBe(`${cliPackageManifest.version}\n`)
+    expect(stderr.output()).toBe("")
+    expect(loadConfig).not.toHaveBeenCalled()
+  })
+
+  it("prints the version through the built binary outside a project", async () => {
+    const rootDir = await createTempDir()
+    const { stderr, stdout } = await execFileAsync(process.execPath, [resolve(import.meta.dirname, "../dist/index.js"), "--version"], {
+      cwd: rootDir,
+    })
+
+    expect(stdout).toBe(`${cliPackageManifest.version}\n`)
+    expect(stderr).toBe("")
+  })
+
   it("flushes configured entrypoint streams before exiting", async () => {
     const callbacks: Array<() => void> = []
     const createStream = () => ({


### PR DESCRIPTION
Adds `vitehub --version` and `vitehub -v`. Both print the packaged `@vite-hub/cli` version and exit before Vite or Nuxt project config discovery, so they also work outside a project. Existing help, namespace, and feature parsing remains unchanged.

## Test plan

- `pnpm --filter @vite-hub/cli build`
- `pnpm --filter @vite-hub/cli exec vp test test/cli.test.ts` (26 tests)
- `pnpm --filter @vite-hub/cli typecheck`
- `pnpm exec vp lint packages/cli/src/index.ts packages/cli/test/cli.test.ts packages/cli/README.md`
- invoked both flags through `packages/cli/dist/index.js` from an empty temporary directory