### PR TITLE
fix(browser): adapt Cloudflare Playwright explicitly

### DIFF
--- a/packages/browser/src/controllers/playwright.ts
+++ b/packages/browser/src/controllers/playwright.ts
@@ -42,9 +42,10 @@ async function loadCloudflare(): Promise<NonNullable<PlaywrightControllerOptions
   try {
     const cloudflare = await import("@cloudflare/playwright")
     return {
-      connect(binding, sessionId) {
+      async connect(binding, sessionId) {
         // SAFETY: Cloudflare supplies the Browser Worker binding accepted by its Playwright adapter.
-        return cloudflare.connect(binding as never, sessionId)
+        const browser = await cloudflare.connect(binding as never, sessionId)
+        return asPlaywrightBrowser(browser)
       },
       async launch(binding, options) {
         // SAFETY: Cloudflare supplies the Browser endpoint accepted by its Playwright adapter.

--- a/packages/browser/src/controllers/playwright.ts
+++ b/packages/browser/src/controllers/playwright.ts
@@ -51,9 +51,10 @@ export function playwright(options: PlaywrightControllerOptions = {}): BrowserCo
         ? connection.engine === "kitesurf"
           ? await (options.cloudflare || await loadCloudflare()).launch(connection.binding, { browser: "kitesurf" })
           : await (options.cloudflare || await loadCloudflare()).connect(connection.binding, connection.sessionId)
-        : await (options.chromium || await loadChromium()).connectOverCDP(connection.endpoint, {
-            ...(connection.headers ? { headers: connection.headers } : {}),
-          })
+        : await (options.chromium || await loadChromium()).connectOverCDP(
+            connection.endpoint,
+            connection.headers ? { headers: connection.headers } : {},
+          )
       return await attachPlaywrightBrowser(browser, connection)
     },
   }

--- a/packages/browser/src/controllers/playwright.ts
+++ b/packages/browser/src/controllers/playwright.ts
@@ -33,9 +33,25 @@ async function loadChromium(): Promise<Pick<BrowserType, "connectOverCDP">> {
   }
 }
 
+function asPlaywrightBrowser(browser: unknown): Browser {
+  // SAFETY: Both Playwright packages expose the Browser surface consumed by ViteHub's controller.
+  return browser as Browser
+}
+
 async function loadCloudflare(): Promise<NonNullable<PlaywrightControllerOptions["cloudflare"]>> {
   try {
-    return await import("@cloudflare/playwright") as unknown as NonNullable<PlaywrightControllerOptions["cloudflare"]>
+    const cloudflare = await import("@cloudflare/playwright")
+    return {
+      connect(binding, sessionId) {
+        // SAFETY: Cloudflare supplies the Browser Worker binding accepted by its Playwright adapter.
+        return cloudflare.connect(binding as never, sessionId)
+      },
+      async launch(binding, options) {
+        // SAFETY: Cloudflare supplies the Browser endpoint accepted by its Playwright adapter.
+        const browser = await cloudflare.launch(binding as never, options)
+        return asPlaywrightBrowser(browser)
+      },
+    }
   }
   catch (error) {
     throw browserProviderError("playwright", "load @cloudflare/playwright", { cause: error })


### PR DESCRIPTION
## Summary

Adapt Cloudflare Playwright through explicit connect and launch methods instead of asserting the entire optional module to ViteHub’s controller contract.

Both adapter methods now contain Cloudflare's forked `Browser` type at the provider boundary, so the aggregate `vite-hub` facade sees the standard Playwright contract. Header forwarding and standard CDP attachment remain unchanged.

## Proof

- `vp test test/playwright.test.ts` (4 passed, no type errors)
- Browser package typecheck
- Aggregate `vite-hub` facade typecheck after a full package build
- Full 25-package build
- Focused oxlint
- `VITE_DOCTOR_SINCE=HEAD^ vp run doctor:typescript` (100/100)
- `git diff --check`
