### PR TITLE
refactor(workspace): clarify inspection results

### DIFF
--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -106,7 +106,7 @@ async function mapHostInspections<T, U>(
   visit: (value: T, batch: { assertActive: () => void, fail: (error: unknown) => void }) => Promise<U>,
   _signal?: AbortSignal,
 ) {
-  const results = new Array<U>(values.length)
+  const results: U[] = []
   let next = 0
   let failed = false
   let failure: unknown


### PR DESCRIPTION
## Summary

Build the concurrent host-inspection result list by indexed assignment without the ambiguous single-argument Array constructor.

Ordering, concurrency, early failure, and the returned array are unchanged. This clears the no-new-array warning at the owning helper.

## Proof

- vp test test/host-session.test.ts -t host inspection (2 passed)
- tsc --noEmit -p tsconfig.json
- vp exec oxlint packages/workspace/src/session/host.ts (changed warning cleared; one unrelated existing warning remains at line 453)
- git diff --check