### PR TITLE
refactor(workspace): clarify snapshot results

### DIFF
--- a/packages/workspace/src/storage/utils.ts
+++ b/packages/workspace/src/storage/utils.ts
@@ -5,7 +5,7 @@ import type { WorkspaceDiff, WorkspaceEntry, WorkspaceSnapshot, WorkspaceStore }
 const snapshotStatConcurrency = 16
 
 async function mapWithConcurrency<T, U>(values: readonly T[], concurrency: number, visit: (value: T) => Promise<U>) {
-  const results = new Array<U>(values.length)
+  const results: U[] = []
   let next = 0
   await Promise.all(Array.from({ length: Math.min(concurrency, values.length) }, async () => {
     while (next < values.length) {


### PR DESCRIPTION
## Summary

Build concurrent Workspace snapshot results by indexed assignment without the ambiguous single-argument Array constructor.

Snapshot order, stat concurrency, digest hydration, and empty snapshots are unchanged. This clears the helper no-new-array warning.

## Proof

- vp test test/github-publisher.test.ts (14 passed, no type errors)
- tsc --noEmit -p tsconfig.json
- vp exec oxlint packages/workspace/src/storage/utils.ts
- git diff --check