### PR TITLE
docs(blob): install quick-start dependencies

### DIFF
--- a/packages/blob/README.md
+++ b/packages/blob/README.md
@@ -12,7 +12,8 @@
 ## Install
 
 ```sh
-pnpm add @vite-hub/blob
+pnpm add @vite-hub/blob h3
+pnpm add -D vite
 ```
 
 Add the SDK required by the driver you configure.


### PR DESCRIPTION
Updates the Blob owner-package quick start to install H3 as a runtime dependency and Vite as a dev dependency. This makes every direct import in the copied example resolvable under strict pnpm isolation without changing Blob runtime behavior.

## Test plan

- `pnpm --filter vitehub-docs test` — 17 files and 131 tests passed
- `TMPDIR=/var/tmp pnpm --filter @vite-hub/blob exec vp test test/vite.test.ts` — 25 tests passed
- Packed `@vite-hub/blob` into an isolated pnpm consumer and resolved `@vite-hub/blob`, `@vite-hub/blob/vite`, `h3`, and `vite`
- `pnpm exec vp run lint` — passed with pre-existing warnings
- `git diff --check`

`pnpm exec vp run docs:build` compiled the client and server and prerendered the documentation, then failed on an unrelated existing OG-image renderer timeout for the landing page.