### PR TITLE
fix(workspace): normalize Source request boundaries

### DIFF
--- a/packages/workspace/src/sources/request-execution.ts
+++ b/packages/workspace/src/sources/request-execution.ts
@@ -103,7 +103,7 @@ function bodyShapeMatches(request: NonNullable<WorkspaceSourceRequestDescriptor[
 
 function queryFromUrl(url: URL): Record<string, unknown> | undefined {
   const query: Record<string, unknown> = {}
-  for (const key of new Set([...url.searchParams.keys()])) {
+  for (const key of new Set(url.searchParams.keys())) {
     const values = url.searchParams.getAll(key)
     query[key] = values.length > 1 ? values : values[0]
   }

--- a/packages/workspace/src/sources/request-execution.ts
+++ b/packages/workspace/src/sources/request-execution.ts
@@ -15,6 +15,10 @@ export interface WorkspaceSourceRequestExecutionTarget {
 
 const sourceRequestExecutions = new WeakMap<object, WorkspaceSourceRequestExecutionTarget>()
 
+function isWeakKey(value: unknown): value is object {
+  return Object(value) === value
+}
+
 export function attachWorkspaceSourceRequestExecution<T extends object>(
   target: T,
   executor: WorkspaceSourceRequestExecutionTarget | undefined,
@@ -24,7 +28,8 @@ export function attachWorkspaceSourceRequestExecution<T extends object>(
   return target
 }
 
-export function getWorkspaceSourceRequestExecution(input: object): WorkspaceSourceRequestExecutionTarget | undefined {
+export function getWorkspaceSourceRequestExecution(input: unknown): WorkspaceSourceRequestExecutionTarget | undefined {
+  if (!isWeakKey(input)) return undefined
   return sourceRequestExecutions.get(input)
 }
 
@@ -97,8 +102,8 @@ function requestShapeMatches(descriptor: WorkspaceSourceRequestDescriptor, input
 
 function bodyShapeMatches(request: NonNullable<WorkspaceSourceRequestDescriptor["request"]> | undefined, input: WorkspaceSourceRequestExecutionInput): boolean {
   if (request?.bodySchema) return true
-  if (typeof request?.body !== "undefined") return jsonEqual(input.body, request.body)
-  return typeof input.body === "undefined"
+  if (request && "body" in request) return jsonEqual(input.body, request.body)
+  return input.body === undefined
 }
 
 function queryFromUrl(url: URL): Record<string, unknown> | undefined {


### PR DESCRIPTION
## Summary

Normalize Source request execution at its two owning boundaries:

- reject primitive execution owners before WeakMap lookup
- distinguish declared request bodies without runtime typeof narrowing
- construct query-key sets directly from URLSearchParams iteration

Repeated query parameters, matching order, and valid Workspace callers remain unchanged.

## Proof

- vp test test/fetch-source.test.ts (18 passed, no type errors)
- tsc --noEmit -p tsconfig.json
- vp exec oxlint packages/workspace/src/sources/request-execution.ts
- VITE_DOCTOR_SINCE=HEAD^ vp run doctor:typescript (100/100)
- git diff --check