### PR TITLE
fix(box): preserve Vercel file errors

### DIFF
--- a/packages/box/src/vercel.ts
+++ b/packages/box/src/vercel.ts
@@ -190,7 +190,7 @@ async function loadVercelSandbox() {
   try {
     const { Sandbox } = await import(/* @vite-ignore */ vercelSandboxPackage);
     return async (options: VercelSandboxCreateOptions) =>
-      await Sandbox.create(options as Parameters<typeof Sandbox.create>[0]) as unknown as VercelSandboxInstance;
+      await Sandbox.create(options);
   } catch (error) {
     throw new Error(
       `[vitehub] The vercel Box runtime requires @vercel/sandbox: ${error instanceof Error ? error.message : error}`,
@@ -199,7 +199,7 @@ async function loadVercelSandbox() {
 }
 
 function isMissingFile(error: unknown) {
-  return Boolean(error && typeof error === "object" && "code" in error && error.code === "ENOENT");
+  return error instanceof Error && "code" in error && error.code === "ENOENT";
 }
 
 function createVercelSession(

--- a/packages/box/src/vercel.ts
+++ b/packages/box/src/vercel.ts
@@ -198,6 +198,10 @@ async function loadVercelSandbox() {
   }
 }
 
+function isMissingFile(error: unknown) {
+  return Boolean(error && typeof error === "object" && "code" in error && error.code === "ENOENT");
+}
+
 function createVercelSession(
   id: string,
   instance: VercelSandboxInstance,
@@ -253,8 +257,9 @@ function createVercelSession(
         try {
           await fs.access(path, { signal: abortSignal });
           return true;
-        } catch {
-          return false;
+        } catch (error) {
+          if (isMissingFile(error)) return false;
+          throw error;
         }
       }
       return (await run({ abortSignal, command: `test -e ${shellQuote(path)}` })).exitCode === 0;
@@ -324,7 +329,7 @@ function createVercelSession(
           : await instance.readFileToBuffer({ path }, { signal: abortSignal });
         return contents === null ? null : new Uint8Array(contents);
       } catch (error) {
-        if (!(await this.existsFile({ abortSignal, path }))) return null;
+        if (isMissingFile(error)) return null;
         throw error;
       }
     },

--- a/packages/box/test/remote-providers.test.ts
+++ b/packages/box/test/remote-providers.test.ts
@@ -261,6 +261,40 @@ describe("remote Box providers", () => {
     expect(session.ports).toBeUndefined();
     await session.close();
   });
+
+  it("distinguishes missing Vercel files from filesystem failures", async () => {
+    const missing = Object.assign(new Error("missing"), { code: "ENOENT" });
+    let accessFailure = missing;
+    let readFailure = missing;
+    const access = vi.fn(async () => { throw accessFailure; });
+    const instance = vercelInstance();
+    instance.fs = {
+      access,
+      async mkdir() {},
+      async readFile() { throw readFailure; },
+      async readdir() { return []; },
+      async rename() {},
+      async rm() {},
+      async stat() { throw missing; },
+      async writeFile() {},
+    };
+    const box = await resolveBox({ runtime: createVercelRuntime({ create: async () => instance }) }, {});
+    const session = await box.open();
+
+    await expect(session.files.exists("/workspace/missing.txt")).resolves.toBe(false);
+    await expect(session.files.read("/workspace/missing.txt")).resolves.toBeNull();
+
+    const deniedAccess = Object.assign(new Error("permission denied"), { code: "EACCES" });
+    accessFailure = deniedAccess;
+    await expect(session.files.exists("/workspace/private.txt")).rejects.toBe(deniedAccess);
+
+    const deniedRead = Object.assign(new Error("read denied"), { code: "EACCES" });
+    readFailure = deniedRead;
+    const accessCalls = access.mock.calls.length;
+    await expect(session.files.read("/workspace/private.txt")).rejects.toBe(deniedRead);
+    expect(access).toHaveBeenCalledTimes(accessCalls);
+    await session.close();
+  });
 });
 
 function namespace(stub: CloudflareSandboxStub) {


### PR DESCRIPTION
Vercel Box now treats only `ENOENT` as a missing path. Permission, abort, and provider failures propagate unchanged, and a failed read no longer runs a second existence probe that can replace or hide the original error.

The regression covers the Vercel `fs.access` fallback and `fs.readFile`: missing paths still return `false` or `null`, while `EACCES` retains the exact provider error.

## Coordination

#1171 also changes `packages/box/src/vercel.ts`, but only in the separate port URL hunk. A synthetic Git merge with its current head completed without conflicts.

## Verification

- `pnpm exec vp test test/provider-conformance.test.ts test/remote-providers.test.ts` (31 passed)
- `pnpm --filter @vite-hub/box typecheck`
- `pnpm --filter @vite-hub/box build`
- `pnpm exec oxlint packages/box/src/vercel.ts packages/box/test/remote-providers.test.ts`
- `git diff --check origin/main...HEAD`

The full Box run passed 157 of 158 tests locally. The unrelated Crabbox process-reparenting test expected `PPid: 1`, but this host kept the process under `PPid: 850`; its focused rerun failed the same environment assertion.
