### PR TITLE
refactor(workspace): dedupe fetch query keys directly

### DIFF
--- a/packages/workspace/src/sources/fetch.ts
+++ b/packages/workspace/src/sources/fetch.ts
@@ -299,7 +299,7 @@ function schemaProjection(schema: FetchSourceStandardJsonSchemaV1, option: strin
 function concreteQueryFromOptions(options: Pick<FetchSourceOptions<any, any>, "query" | "url">): Record<string, unknown> | undefined {
   const parsed = options.url instanceof URL ? options.url : new URL(options.url)
   const query: Record<string, unknown> = {}
-  for (const key of new Set([...parsed.searchParams.keys()])) {
+  for (const key of new Set(parsed.searchParams.keys())) {
     const values = parsed.searchParams.getAll(key)
     query[key] = values.length > 1 ? values : values[0]
   }
@@ -452,7 +452,7 @@ function requestBaseUrl(url: string | URL): URL {
 
 function queryFromUrl(url: URL): Record<string, unknown> | undefined {
   const query: Record<string, unknown> = {}
-  for (const key of new Set([...url.searchParams.keys()])) {
+  for (const key of new Set(url.searchParams.keys())) {
     const values = url.searchParams.getAll(key)
     query[key] = values.length > 1 ? values : values[0]
   }


### PR DESCRIPTION
## Summary

Construct Source fetch query-key sets directly from URLSearchParams iteration in both descriptor and execution normalization.

Repeated parameters, key order, declared query overrides, and request matching remain unchanged; the intermediate arrays are removed.

## Proof

- vp test test/fetch-source.test.ts (18 passed, no type errors)
- tsc --noEmit -p tsconfig.json
- vp exec oxlint packages/workspace/src/sources/fetch.ts
- git diff --check