### PR TITLE
refactor(schedule): settle pending work directly

### DIFF
--- a/packages/schedule/src/runtime/wait-until.ts
+++ b/packages/schedule/src/runtime/wait-until.ts
@@ -11,7 +11,7 @@ export function createLocalWaitUntil(): LocalWaitUntil {
   return {
     async flush() {
       while (pending.size > 0) {
-        await Promise.allSettled([...pending])
+        await Promise.allSettled(pending)
       }
       if (failed) throw error
     },


### PR DESCRIPTION
## Summary

Pass Schedule pending work directly to Promise.allSettled instead of copying the Set on every drain iteration.

Nested waitUntil registration, first-error reporting, and settle-all behavior remain unchanged.

## Proof

- vp test test/wait-until.test.ts (5 passed, no type errors)
- tsc --noEmit -p tsconfig.json
- vp exec oxlint packages/schedule/src/runtime/wait-until.ts
- git diff --check