### PR TITLE
docs(channels): install Vite for discovery

### DIFF
--- a/packages/channels/README.md
+++ b/packages/channels/README.md
@@ -56,6 +56,12 @@ The connector receives `Build finished.` and `{ label: "release" }`. The call ad
 
 ## Discover named Channel Definitions
 
+Install Vite before enabling discovery:
+
+```sh
+pnpm add -D vite
+```
+
 Use the Vite integration when several call sites should load the same named Channel Definition.
 
 ```ts


### PR DESCRIPTION
Adds the Vite dev-install command at the Channel Definition discovery boundary. Direct `createChannel()` users still install only `@vite-hub/channels`, while the discovery path now declares every package imported by its example.

## Test plan

- `TMPDIR=/var/tmp pnpm --filter @vite-hub/channels test` — 5 files and 18 tests passed
- `pnpm --filter vitehub-docs test` — 17 files and 131 tests passed
- Packed `@vite-hub/channels` into an isolated pnpm 10.33 consumer and verified the base and Vite discovery import variants separately
- `pnpm exec vp run lint` — passed with pre-existing warnings
- `git diff --check`