### PR TITLE
docs(vite-hub): use canonical host support guide

### DIFF
--- a/packages/vite-hub/README.md
+++ b/packages/vite-hub/README.md
@@ -63,15 +63,9 @@ vitehub({
 });
 ```
 
-| Preset       | Blob                           | Queue             | Rate Limit                      | Sandbox               | Schedule    |
-| ------------ | ------------------------------ | ----------------- | ------------------------------- | --------------------- | ----------- |
-| `cloudflare` | R2                             | Cloudflare Queues | Cloudflare                      | Cloudflare Containers | Supported   |
-| `netlify`    | Netlify Blobs                  | Unsupported       | Unsupported                     | Unsupported           | Supported   |
-| `vercel`     | Vercel Blob                    | Vercel Queues     | Unsupported                     | Vercel Sandbox        | Supported   |
-| `deno`       | Unsupported                    | Unsupported       | Unsupported                     | Unsupported           | Unsupported |
-| `node`       | Local filesystem (single host) | Unsupported       | Process memory (single process) | Unsupported           | Supported   |
+See [Runtime and host support](https://vitehub.dev/docs/frameworks-hosts/support-matrix) for the providers, limitations, and proof available on each host.
 
-Selecting an unsupported opt-in capability fails the build with the preset policy. You can instead configure an explicit Blob driver through `blob` or compose an owner package directly when the application provides its own portable implementation.
+If an enabled capability is not supported by the preset, the build fails. You can instead configure an explicit Blob driver through `blob` or compose an owner package directly when the application provides its own portable implementation.
 
 The Deno preset uses Nitro's Deno entrypoint, so it rejects Schedule and `agent.runtime: "deno"`; those owner-package outputs require an explicit deployment integration.
 

--- a/packages/vite-hub/test/readme.test.ts
+++ b/packages/vite-hub/test/readme.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+const readme = readFileSync(new URL("../README.md", import.meta.url), "utf8");
+
+describe("framework package README", () => {
+  it("keeps host support in the canonical guide", () => {
+    expect(readme).toContain(
+      "[Runtime and host support](https://vitehub.dev/docs/frameworks-hosts/support-matrix)",
+    );
+    expect(readme).not.toMatch(/\| Preset\s+\| Blob/);
+  });
+});


### PR DESCRIPTION
Removes the partial five-feature preset matrix from the `vite-hub` package README and sends readers to the maintained Runtime and host support guide instead. The README still names every preset and explains the build-time rejection rule, while provider qualifications and proof now have one source.

## Test plan

- `pnpm exec vp run -t vite-hub#build`
- `pnpm --filter vite-hub typecheck`
- `pnpm --filter vite-hub exec vp test test/readme.test.ts`
- `pnpm exec vp lint packages/vite-hub/test/readme.test.ts packages/vite-hub/README.md`
- `pnpm exec vp fmt packages/vite-hub/README.md packages/vite-hub/test/readme.test.ts --check`
- `git diff --check`