### PR TITLE
refactor(agent): trim title capability imports

### DIFF
--- a/packages/agent/src/capabilities/title.ts
+++ b/packages/agent/src/capabilities/title.ts
@@ -36,7 +36,7 @@ import type {
   Message,
   StreamEvent,
 } from "../messages.ts"
-import type { MessageChannelTitleDeliveryAttempt, MessageChannelStateBinding } from "../internal/channels.ts"
+import type { MessageChannelTitleDeliveryAttempt } from "../internal/channels.ts"
 
 type ToUIMessageStream = (...args: unknown[]) => ReadableStream<unknown>
 type TitleResolutionValue = string | typeof skippedTitleDelivery | undefined


### PR DESCRIPTION
## Summary

Remove the stale MessageChannelStateBinding type import from the Title Capability.

Runtime behavior and public types are unchanged; this clears the package unused-import warning and narrows the internal dependency edge.

## Proof

- vp test test/runtime.test.ts -t title (69 passed)
- tsc --noEmit -p tsconfig.json
- vp exec oxlint packages/agent/src/capabilities/title.ts
- git diff --check