### PR TITLE
fix(agent): cancel abandoned invocation streams

### DIFF
--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -53,6 +53,7 @@ export function readAgentInvocationStream(body: ReadableStream<Uint8Array>): Asy
   let error: unknown
   let pending = ""
   let cancellation: Promise<void> | undefined
+  let interrupted = false
   let released = false
 
   function releaseReader(): void {
@@ -66,6 +67,7 @@ export function readAgentInvocationStream(body: ReadableStream<Uint8Array>): Asy
       for (;;) {
         const { done, value } = await reader.read()
         if (done) {
+          if (interrupted) break
           pending += decoder.decode()
           completed = true
           break
@@ -109,6 +111,7 @@ export function readAgentInvocationStream(body: ReadableStream<Uint8Array>): Asy
       let cancellationError: unknown
       let cancellationFailed = false
       if (!completed) {
+        interrupted = true
         try {
           cancellation ||= reader.cancel()
           await cancellation
@@ -125,6 +128,7 @@ export function readAgentInvocationStream(body: ReadableStream<Uint8Array>): Asy
     },
     async throw(cause) {
       if (!completed) {
+        interrupted = true
         cancellation ||= reader.cancel(cause)
         await cancellation.catch(() => undefined)
       }

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -123,7 +123,18 @@ export function readAgentInvocationStream(body: ReadableStream<Uint8Array>): Asy
       if (cancellationFailed) throw cancellationError
       return result
     },
-    throw: events.throw.bind(events),
+    async throw(cause) {
+      if (!completed) {
+        cancellation ||= reader.cancel(cause)
+        await cancellation.catch(() => undefined)
+      }
+      try {
+        return await events.throw(cause)
+      }
+      finally {
+        releaseReader()
+      }
+    },
   }
 }
 

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -53,6 +53,13 @@ export function readAgentInvocationStream(body: ReadableStream<Uint8Array>): Asy
   let error: unknown
   let pending = ""
   let cancellation: Promise<void> | undefined
+  let released = false
+
+  function releaseReader(): void {
+    if (released) return
+    released = true
+    reader.releaseLock()
+  }
 
   const events = (async function* () {
     try {
@@ -85,7 +92,7 @@ export function readAgentInvocationStream(body: ReadableStream<Uint8Array>): Asy
         }
       }
       finally {
-        reader.releaseLock()
+        releaseReader()
       }
     }
   })()
@@ -112,6 +119,7 @@ export function readAgentInvocationStream(body: ReadableStream<Uint8Array>): Asy
         }
       }
       const result = await events.return(value)
+      releaseReader()
       if (cancellationFailed) throw cancellationError
       return result
     },

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -38,11 +38,16 @@ export type AgentInvocationStreamEvent =
 
 export async function* readAgentInvocationStream(body: ReadableStream<Uint8Array>): AsyncGenerator<AgentInvocationStreamEvent> {
   const reader = body.pipeThrough(new TextDecoderStream()).getReader()
+  let completed = false
+  let error: unknown
   let pending = ""
   try {
     for (;;) {
       const { done, value } = await reader.read()
-      if (done) break
+      if (done) {
+        completed = true
+        break
+      }
       pending += value
       const lines = pending.split("\n")
       pending = lines.pop() || ""
@@ -52,7 +57,12 @@ export async function* readAgentInvocationStream(body: ReadableStream<Uint8Array
     }
     if (pending.trim()) yield JSON.parse(pending) as AgentInvocationStreamEvent
   }
+  catch (cause) {
+    error = cause
+    throw cause
+  }
   finally {
+    if (!completed) await reader.cancel(error).catch(() => undefined)
     reader.releaseLock()
   }
 }

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -46,44 +46,76 @@ function parseAgentInvocationStreamEvent(line: string): AgentInvocationStreamEve
   return event as AgentInvocationStreamEvent
 }
 
-export async function* readAgentInvocationStream(body: ReadableStream<Uint8Array>): AsyncGenerator<AgentInvocationStreamEvent> {
+export function readAgentInvocationStream(body: ReadableStream<Uint8Array>): AsyncGenerator<AgentInvocationStreamEvent> {
   const reader = body.getReader()
   const decoder = new TextDecoder()
   let completed = false
   let error: unknown
   let pending = ""
-  try {
-    for (;;) {
-      const { done, value } = await reader.read()
-      if (done) {
-        pending += decoder.decode()
-        completed = true
-        break
-      }
-      pending += decoder.decode(value, { stream: true })
-      const lines = pending.split("\n")
-      pending = lines.pop() || ""
-      for (const line of lines) {
-        if (line.trim()) yield parseAgentInvocationStreamEvent(line)
-      }
-    }
-    if (pending.trim()) yield parseAgentInvocationStreamEvent(pending)
-  }
-  catch (cause) {
-    error = cause
-    throw cause
-  }
-  finally {
+  let cancellation: Promise<void> | undefined
+
+  const events = (async function* () {
     try {
-      if (!completed) {
-        const cancellation = reader.cancel(error)
-        if (error) await cancellation.catch(() => undefined)
-        else await cancellation
+      for (;;) {
+        const { done, value } = await reader.read()
+        if (done) {
+          pending += decoder.decode()
+          completed = true
+          break
+        }
+        pending += decoder.decode(value, { stream: true })
+        const lines = pending.split("\n")
+        pending = lines.pop() || ""
+        for (const line of lines) {
+          if (line.trim()) yield parseAgentInvocationStreamEvent(line)
+        }
       }
+      if (pending.trim()) yield parseAgentInvocationStreamEvent(pending)
+    }
+    catch (cause) {
+      error = cause
+      throw cause
     }
     finally {
-      reader.releaseLock()
+      try {
+        if (!completed) {
+          cancellation ||= reader.cancel(error)
+          if (error) await cancellation.catch(() => undefined)
+          else await cancellation
+        }
+      }
+      finally {
+        reader.releaseLock()
+      }
     }
+  })()
+
+  return {
+    async [Symbol.asyncDispose]() {
+      await this.return(undefined)
+    },
+    [Symbol.asyncIterator]() {
+      return this
+    },
+    next: events.next.bind(events),
+    async return(value) {
+      let cancellationError: unknown
+      let cancellationFailed = false
+      if (!completed) {
+        try {
+          cancellation ||= reader.cancel()
+          await cancellation
+        }
+        catch (cause) {
+          cancellationError = cause
+          cancellationFailed = true
+        }
+      }
+      const result = await events.return(value)
+      if (cancellationFailed) throw cancellationError
+      return result
+    },
+    throw: events.throw.bind(events),
   }
 }
 
@@ -196,10 +228,10 @@ export function createAgentInvocationStreamResponse(
           if (emit(controller, { type: "done" })) close(controller)
         })
     },
-    cancel() {
+    cancel(reason) {
       clearInactivityTimeout()
       closed = true
-      abort()
+      abort(reason)
     },
   }), {
     headers: { "content-type": "application/x-ndjson" },

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -1,4 +1,5 @@
 import { toAgentPublicError } from "./agent-error.ts"
+import { hasRuntimeType, isRuntimeRecord } from "./internal/runtime-type.ts"
 import type { StreamEvent } from "./messages.ts"
 import type { AgentPublicErrorCode, AgentPublicErrorDetails } from "./agent-error.ts"
 import type { AgentChannelDeliveryEffectIntent, AgentInspectionMetadata, AgentRunMetadata } from "./types.ts"
@@ -36,6 +37,15 @@ export type AgentInvocationStreamEvent =
   | { agent: string, metadata?: Record<string, unknown>, run?: unknown, trigger?: string, type: "start" }
   | { type: "done" }
 
+function parseAgentInvocationStreamEvent(line: string): AgentInvocationStreamEvent {
+  const event: unknown = JSON.parse(line)
+  if (!isRuntimeRecord(event) || !hasRuntimeType(event.type, "string")) {
+    throw new TypeError("Invalid Agent Invocation Stream event.")
+  }
+  // SAFETY: The stream endpoint owns the event payloads; the reader validates their shared discriminated-union boundary.
+  return event as AgentInvocationStreamEvent
+}
+
 export async function* readAgentInvocationStream(body: ReadableStream<Uint8Array>): AsyncGenerator<AgentInvocationStreamEvent> {
   const reader = body.pipeThrough(new TextDecoderStream()).getReader()
   let completed = false
@@ -52,10 +62,10 @@ export async function* readAgentInvocationStream(body: ReadableStream<Uint8Array
       const lines = pending.split("\n")
       pending = lines.pop() || ""
       for (const line of lines) {
-        if (line.trim()) yield JSON.parse(line) as AgentInvocationStreamEvent
+        if (line.trim()) yield parseAgentInvocationStreamEvent(line)
       }
     }
-    if (pending.trim()) yield JSON.parse(pending) as AgentInvocationStreamEvent
+    if (pending.trim()) yield parseAgentInvocationStreamEvent(pending)
   }
   catch (cause) {
     error = cause

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -79,7 +79,7 @@ export function readAgentInvocationStream(body: ReadableStream<Uint8Array>): Asy
           if (line.trim()) yield parseAgentInvocationStreamEvent(line)
         }
       }
-      if (pending.trim()) yield parseAgentInvocationStreamEvent(pending)
+      if (!interrupted && pending.trim()) yield parseAgentInvocationStreamEvent(pending)
     }
     catch (cause) {
       error = cause

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -72,8 +72,16 @@ export async function* readAgentInvocationStream(body: ReadableStream<Uint8Array
     throw cause
   }
   finally {
-    if (!completed) await reader.cancel(error).catch(() => undefined)
-    reader.releaseLock()
+    try {
+      if (!completed) {
+        const cancellation = reader.cancel(error)
+        if (error) await cancellation.catch(() => undefined)
+        else await cancellation
+      }
+    }
+    finally {
+      reader.releaseLock()
+    }
   }
 }
 

--- a/packages/agent/src/invocation-stream.ts
+++ b/packages/agent/src/invocation-stream.ts
@@ -47,7 +47,8 @@ function parseAgentInvocationStreamEvent(line: string): AgentInvocationStreamEve
 }
 
 export async function* readAgentInvocationStream(body: ReadableStream<Uint8Array>): AsyncGenerator<AgentInvocationStreamEvent> {
-  const reader = body.pipeThrough(new TextDecoderStream()).getReader()
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
   let completed = false
   let error: unknown
   let pending = ""
@@ -55,10 +56,11 @@ export async function* readAgentInvocationStream(body: ReadableStream<Uint8Array
     for (;;) {
       const { done, value } = await reader.read()
       if (done) {
+        pending += decoder.decode()
         completed = true
         break
       }
-      pending += value
+      pending += decoder.decode(value, { stream: true })
       const lines = pending.split("\n")
       pending = lines.pop() || ""
       for (const line of lines) {

--- a/packages/agent/test/invocation-stream.test.ts
+++ b/packages/agent/test/invocation-stream.test.ts
@@ -7,6 +7,45 @@ import { writeResponse } from "../src/vite/invocation-stream-endpoint.ts"
 import type { ServerResponse } from "node:http"
 
 describe("Agent Invocation Stream", () => {
+  it("cancels the invocation when its reader stops early", async () => {
+    let signal: AbortSignal | undefined
+    const response = createAgentInvocationStreamResponse(async (emit, runSignal) => {
+      signal = runSignal
+      emit({ text: "first", type: "text-delta" })
+      await new Promise<void>(resolve => runSignal.addEventListener("abort", () => resolve(), { once: true }))
+    })
+
+    for await (const event of readAgentInvocationStream(response.body!)) {
+      expect(event).toEqual({ text: "first", type: "text-delta" })
+      break
+    }
+
+    expect(signal?.aborted).toBe(true)
+  })
+
+  it("preserves parser errors when stream cancellation also fails", async () => {
+    const cleanupFailure = new Error("cleanup failed")
+    const cancel = vi.fn(async () => { throw cleanupFailure })
+    const body = new ReadableStream<Uint8Array>({
+      cancel,
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("not json\n"))
+      },
+    })
+
+    let failure: unknown
+    try {
+      for await (const _event of readAgentInvocationStream(body)) {}
+    }
+    catch (error) {
+      failure = error
+    }
+
+    expect(failure).toBeInstanceOf(SyntaxError)
+    expect(failure).not.toBe(cleanupFailure)
+    expect(cancel).toHaveBeenCalledWith(failure)
+  })
+
   it("closes timed-out streams even when the run does not settle", async () => {
     let aborted = false
     const response = createAgentInvocationStreamResponse(async (_emit, signal) => {

--- a/packages/agent/test/invocation-stream.test.ts
+++ b/packages/agent/test/invocation-stream.test.ts
@@ -1,10 +1,11 @@
+import { IncomingMessage, ServerResponse } from "node:http"
+import { Socket } from "node:net"
+
 import { describe, expect, it, vi } from "vitest"
 
 import { ViteHubError } from "@vite-hub/runtime"
 import { createAgentInvocationStreamResponse, readAgentInvocationStream } from "../src/invocation-stream.ts"
 import { writeResponse } from "../src/vite/invocation-stream-endpoint.ts"
-
-import type { ServerResponse } from "node:http"
 
 describe("Agent Invocation Stream", () => {
   it("cancels the invocation when its reader stops early", async () => {
@@ -44,6 +45,18 @@ describe("Agent Invocation Stream", () => {
     expect(failure).toBeInstanceOf(SyntaxError)
     expect(failure).not.toBe(cleanupFailure)
     expect(cancel).toHaveBeenCalledWith(failure)
+  })
+
+  it("rejects stream lines without an event discriminator", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("null\n"))
+      },
+    })
+
+    await expect(async () => {
+      for await (const _event of readAgentInvocationStream(body)) {}
+    }).rejects.toThrow("Invalid Agent Invocation Stream event.")
   })
 
   it("closes timed-out streams even when the run does not settle", async () => {
@@ -125,16 +138,10 @@ describe("Agent Invocation Stream", () => {
   })
 
   it("only treats closed-response AbortError body failures as cleanup", async () => {
-    const destroy = vi.fn()
-    const res = {
-      destroy,
-      end: vi.fn(),
-      off: vi.fn(),
-      once: vi.fn(),
-      setHeader: vi.fn(),
-      statusCode: 200,
-      write: vi.fn(() => true),
-    } as unknown as ServerResponse
+    const res = new ServerResponse(new IncomingMessage(new Socket()))
+    const destroy = vi.spyOn(res, "destroy").mockImplementation(() => res)
+    vi.spyOn(res, "end").mockImplementation(() => res)
+    vi.spyOn(res, "write").mockImplementation(() => true)
 
     await writeResponse(res, new Response(new ReadableStream<Uint8Array>({
       pull() {
@@ -145,31 +152,24 @@ describe("Agent Invocation Stream", () => {
     expect(destroy).toHaveBeenCalledWith(expect.any(DOMException))
     destroy.mockClear()
 
-    let close: (() => void) | undefined
-    const closedRes = {
-      destroy,
-      end: vi.fn(),
-      off: vi.fn(),
-      once: vi.fn((_event: string, callback: () => void) => {
-        close = callback
-      }),
-      setHeader: vi.fn(),
-      statusCode: 200,
-      write: vi.fn(() => true),
-    } as unknown as ServerResponse
+    const closedRes = new ServerResponse(new IncomingMessage(new Socket()))
+    const closedDestroy = vi.spyOn(closedRes, "destroy").mockImplementation(() => closedRes)
+    vi.spyOn(closedRes, "end").mockImplementation(() => closedRes)
+    vi.spyOn(closedRes, "write").mockImplementation(() => true)
 
     await writeResponse(closedRes, new Response(new ReadableStream<Uint8Array>({
       pull() {
-        close?.()
+        closedRes.emit("close")
         throw new DOMException("aborted", "AbortError")
       },
     })))
 
-    expect(destroy).not.toHaveBeenCalled()
+    expect(closedDestroy).not.toHaveBeenCalled()
   })
 
   it("closes with an error when event serialization fails", async () => {
     const response = createAgentInvocationStreamResponse(async (emit) => {
+      // SAFETY: This intentionally violates the serializable data contract to exercise response error handling.
       emit({ data: 1n, type: "data" } as never)
     })
 

--- a/packages/agent/test/invocation-stream.test.ts
+++ b/packages/agent/test/invocation-stream.test.ts
@@ -38,6 +38,33 @@ describe("Agent Invocation Stream", () => {
     expect(body.locked).toBe(false)
   })
 
+  it("discards a partial line when its iterator closes during a pending read", async () => {
+    const cancel = vi.fn()
+    let markReading!: () => void
+    const reading = new Promise<void>((resolve) => {
+      markReading = resolve
+    })
+    const body = new ReadableStream<Uint8Array>({
+      cancel,
+      pull() {
+        markReading()
+      },
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"type":"done"'))
+      },
+    })
+    const events = readAgentInvocationStream(body)
+
+    const next = events.next()
+    await reading
+    const returned = events.return(undefined)
+
+    await expect(returned).resolves.toEqual({ done: true, value: undefined })
+    await expect(next).resolves.toEqual({ done: true, value: undefined })
+    expect(cancel).toHaveBeenCalledWith(undefined)
+    expect(body.locked).toBe(false)
+  })
+
   it("releases the reader when its iterator closes before the first read", async () => {
     const cancel = vi.fn()
     const body = new ReadableStream<Uint8Array>({ cancel })

--- a/packages/agent/test/invocation-stream.test.ts
+++ b/packages/agent/test/invocation-stream.test.ts
@@ -24,6 +24,40 @@ describe("Agent Invocation Stream", () => {
     expect(signal?.aborted).toBe(true)
   })
 
+  it("cancels an idle invocation when its iterator closes during a pending read", async () => {
+    const cancel = vi.fn()
+    const body = new ReadableStream<Uint8Array>({ cancel })
+    const events = readAgentInvocationStream(body)
+
+    const next = events.next()
+    const returned = events.return(undefined)
+
+    await expect(returned).resolves.toEqual({ done: true, value: undefined })
+    await expect(next).resolves.toEqual({ done: true, value: undefined })
+    expect(cancel).toHaveBeenCalledWith(undefined)
+    expect(body.locked).toBe(false)
+  })
+
+  it("forwards reader failures to the paired invocation signal", async () => {
+    let signal: AbortSignal | undefined
+    const response = createAgentInvocationStreamResponse(async (emit, runSignal) => {
+      signal = runSignal
+      emit({} as never)
+      await new Promise<void>(resolve => runSignal.addEventListener("abort", () => resolve(), { once: true }))
+    })
+
+    let failure: unknown
+    try {
+      for await (const _event of readAgentInvocationStream(response.body!)) {}
+    }
+    catch (error) {
+      failure = error
+    }
+
+    expect(failure).toEqual(new TypeError("Invalid Agent Invocation Stream event."))
+    expect(signal?.reason).toBe(failure)
+  })
+
   it("preserves parser errors when stream cancellation also fails", async () => {
     const cleanupFailure = new Error("cleanup failed")
     const cancel = vi.fn(async () => { throw cleanupFailure })

--- a/packages/agent/test/invocation-stream.test.ts
+++ b/packages/agent/test/invocation-stream.test.ts
@@ -47,6 +47,23 @@ describe("Agent Invocation Stream", () => {
     expect(cancel).toHaveBeenCalledWith(failure)
   })
 
+  it("surfaces cancellation failures when its reader stops early", async () => {
+    const cleanupFailure = new Error("cleanup failed")
+    const cancel = vi.fn(async () => { throw cleanupFailure })
+    const body = new ReadableStream<Uint8Array>({
+      cancel,
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode('{"type":"done"}\n'))
+      },
+    })
+
+    await expect(async () => {
+      for await (const _event of readAgentInvocationStream(body)) break
+    }).rejects.toBe(cleanupFailure)
+    expect(cancel).toHaveBeenCalledWith(undefined)
+    expect(body.locked).toBe(false)
+  })
+
   it("rejects stream lines without an event discriminator", async () => {
     const body = new ReadableStream<Uint8Array>({
       start(controller) {

--- a/packages/agent/test/invocation-stream.test.ts
+++ b/packages/agent/test/invocation-stream.test.ts
@@ -38,10 +38,21 @@ describe("Agent Invocation Stream", () => {
     expect(body.locked).toBe(false)
   })
 
+  it("releases the reader when its iterator closes before the first read", async () => {
+    const cancel = vi.fn()
+    const body = new ReadableStream<Uint8Array>({ cancel })
+    const events = readAgentInvocationStream(body)
+
+    await expect(events.return(undefined)).resolves.toEqual({ done: true, value: undefined })
+    expect(cancel).toHaveBeenCalledWith(undefined)
+    expect(body.locked).toBe(false)
+  })
+
   it("forwards reader failures to the paired invocation signal", async () => {
     let signal: AbortSignal | undefined
     const response = createAgentInvocationStreamResponse(async (emit, runSignal) => {
       signal = runSignal
+      // SAFETY: The invalid payload deliberately exercises the reader's runtime validation boundary.
       emit({} as never)
       await new Promise<void>(resolve => runSignal.addEventListener("abort", () => resolve(), { once: true }))
     })

--- a/packages/agent/test/invocation-stream.test.ts
+++ b/packages/agent/test/invocation-stream.test.ts
@@ -48,6 +48,22 @@ describe("Agent Invocation Stream", () => {
     expect(body.locked).toBe(false)
   })
 
+  it.each([
+    ["before the first read", false],
+    ["during a pending read", true],
+  ])("cancels the invocation when its iterator throws %s", async (_label, startRead) => {
+    const failure = new Error("consumer failed")
+    const cancel = vi.fn()
+    const body = new ReadableStream<Uint8Array>({ cancel })
+    const events = readAgentInvocationStream(body)
+    const next = startRead ? events.next() : undefined
+
+    await expect(events.throw(failure)).rejects.toBe(failure)
+    if (next) await expect(next).resolves.toEqual({ done: true, value: undefined })
+    expect(cancel).toHaveBeenCalledWith(failure)
+    expect(body.locked).toBe(false)
+  })
+
   it("forwards reader failures to the paired invocation signal", async () => {
     let signal: AbortSignal | undefined
     const response = createAgentInvocationStreamResponse(async (emit, runSignal) => {


### PR DESCRIPTION
## What changed

- cancel the decoded invocation response when a consumer stops iterating before EOF
- forward parser and read failures as the cancellation reason
- keep cancellation failures from replacing the original stream error

## Why

`readAgentInvocationStream()` previously released its reader lock without cancelling the stream. An early-returning consumer therefore left `createAgentInvocationStreamResponse()` running, including its invocation task and inactivity timer. Cancelling at the reader boundary reaches the response producer's existing cancellation hook, which clears the timer and aborts the invocation signal.

Normal EOF remains unchanged and does not cancel the completed stream.

## Verification

- `pnpm exec vp test test/invocation-stream.test.ts` (9 tests)
- `pnpm --filter @vite-hub/agent build`
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm exec oxlint packages/agent/src/invocation-stream.ts packages/agent/test/invocation-stream.test.ts`
- `git diff --check`
