### PR TITLE
docs(env): install imported packages

### DIFF
--- a/packages/env/README.md
+++ b/packages/env/README.md
@@ -14,6 +14,7 @@ Most applications install `vite-hub` and enable Env through the framework preset
 
 ```sh
 pnpm add @vite-hub/env
+pnpm add -D vite
 ```
 
 ## Choose an Env section
@@ -144,6 +145,12 @@ The generated `#vitehub/env/server` module is not blocked from client builds. Ke
 ## Structured errors
 
 ViteHub-owned Env resolution failures use the shared `ViteHubError` contract with Env-specific codes. Custom source resolvers keep application-owned errors unchanged, so callers can preserve their own error contract without translating it through ViteHub.
+
+Install the shared runtime package before inspecting structured errors:
+
+```sh
+pnpm add @vite-hub/runtime
+```
 
 ```ts
 import { getViteHubErrorShape } from "@vite-hub/runtime";


### PR DESCRIPTION
## Summary

- install Vite as a development dependency in the Env quick start
- install `@vite-hub/runtime` where the structured-error example first imports it
- keep the base Env runtime dependency and optional feature dependencies separate

## Test plan

- `TMPDIR=/var/tmp pnpm --filter @vite-hub/env test` (58 tests)
- `pnpm --filter vitehub-docs test` (131 tests)
- packed `@vite-hub/env` and `@vite-hub/runtime`, then verified both README install boundaries in an isolated pnpm 10.33 consumer
- `pnpm exec vp run lint` (passes with existing repository warnings)
- `git diff --check`
