### PR TITLE
refactor(agent): remove phantom subagent generics

### DIFF
--- a/packages/agent/src/capabilities/subagents.ts
+++ b/packages/agent/src/capabilities/subagents.ts
@@ -1,6 +1,7 @@
 import { capabilityWorkspaceSources, defineCapability } from "../capability-runtime.ts"
 import { awaitAgentInvocationResult } from "../agent-invocation.ts"
 import { withResolvedAgentInvokerInput } from "../invoker.ts"
+import { hasRuntimeType, isRuntimeRecord } from "../internal/runtime-type.ts"
 
 import type {
   AgentCapabilityContext,
@@ -13,7 +14,7 @@ import type {
   AgentToolSet,
 } from "../types.ts"
 import type { Message } from "../messages.ts"
-import type { WorkspaceDefinition, WorkspaceName } from "@vite-hub/workspace"
+import type { WorkspaceDefinition } from "@vite-hub/workspace"
 import type { JSONSchema7 } from "json-schema"
 
 export interface SubagentToolInput<
@@ -71,7 +72,7 @@ function inputSchema(description: string): JSONSchema7 {
 function normalizeAgents<TRuntimeConfig extends AgentRuntimeConfig>(
   options: SubagentsOptions<TRuntimeConfig>,
 ) {
-  if (!options?.agents || typeof options.agents !== "object" || Array.isArray(options.agents) || !Object.keys(options.agents).length) {
+  if (!options?.agents || !hasRuntimeType(options.agents, "object") || Array.isArray(options.agents) || !Object.keys(options.agents).length) {
     throw new TypeError("[vitehub] subagents({ agents }) requires at least one subagent.")
   }
   const toolNames = new Set<string>()
@@ -86,20 +87,22 @@ function normalizeAgents<TRuntimeConfig extends AgentRuntimeConfig>(
   })
 }
 
+function workspaceAgentCapabilities(agent: unknown): AgentCapabilityDefinition[] | undefined {
+  if (!isRuntimeRecord(agent)) return undefined
+  // SAFETY: capabilityWorkspaceSources validates every discovered capability before reading it.
+  if (Array.isArray(agent.capabilities)) return agent.capabilities as AgentCapabilityDefinition[]
+  const options = agent.__vitehubWorkspaceAgentOptions
+  if (!isRuntimeRecord(options) || !Array.isArray(options.capabilities)) return undefined
+  // SAFETY: capabilityWorkspaceSources validates every discovered capability before reading it.
+  return options.capabilities as AgentCapabilityDefinition[]
+}
+
 function subagentWorkspaceSources(
   agents: ReturnType<typeof normalizeAgents>,
 ): WorkspaceDefinition["sources"] | undefined {
   const sources: NonNullable<WorkspaceDefinition["sources"]> = {}
   for (const { definition, name } of agents) {
-    const workspaceAgent = definition.agent as Partial<{
-      __vitehubWorkspaceAgentOptions: { capabilities?: unknown }
-      capabilities: unknown
-    }>
-    const capabilities = Array.isArray(workspaceAgent.capabilities)
-      ? workspaceAgent.capabilities
-      : Array.isArray(workspaceAgent.__vitehubWorkspaceAgentOptions?.capabilities)
-        ? workspaceAgent.__vitehubWorkspaceAgentOptions.capabilities
-        : undefined
+    const capabilities = workspaceAgentCapabilities(definition.agent)
     const contributed = capabilityWorkspaceSources(
       capabilities,
     )
@@ -122,11 +125,14 @@ function createTool<TRuntimeConfig extends AgentRuntimeConfig>(
     description: definition.description,
     async execute(input: unknown) {
       const { startAgentInvocation } = await import("../index.ts")
+      // SAFETY: Capability execution supplies either its public context or the same context nested under runtimeContext.
       const runtimeContext = (parentContext.runtimeContext || parentContext) as AgentRuntimeContext<TRuntimeConfig>
+      // SAFETY: The tool input schema validates AgentRunInput fields before execute is called.
+      const runInput = input as AgentRunInput
       const controller = await startAgentInvocation(
         definition.agent,
         runtimeContext,
-        withResolvedAgentInvokerInput(input as AgentRunInput, parentContext.invoker),
+        withResolvedAgentInvokerInput(runInput, parentContext.invoker),
       )
       return await awaitAgentInvocationResult(controller)
     },
@@ -137,24 +143,26 @@ function createTool<TRuntimeConfig extends AgentRuntimeConfig>(
 
 export function subagents<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
-  Name extends WorkspaceName = WorkspaceName,
   const TAgents extends Record<string, SubagentDefinition<TRuntimeConfig>> = Record<string, SubagentDefinition<TRuntimeConfig>>,
 >(
   options: SubagentsOptions<TRuntimeConfig, TAgents>,
-): AgentCapabilityDefinition<TRuntimeConfig, Name> {
+): AgentCapabilityDefinition<TRuntimeConfig> {
   const id = options.id || "subagents"
   const agents = normalizeAgents(options)
   const workspaceSources = subagentWorkspaceSources(agents)
 
-  return defineCapability({
-    id,
-    ...(workspaceSources ? { workspaceSources } : {}),
-    tools(context) {
-      const tools: AgentToolSet = {}
-      for (const { definition, toolName } of agents) {
-        tools[toolName] = createTool(definition, toolName, context)
-      }
-      return tools
-    },
-  })
+  const tools = (context: AgentCapabilityContext<TRuntimeConfig>) => {
+    const resolved: AgentToolSet = {}
+    for (const { definition, toolName } of agents) {
+      resolved[toolName] = createTool(definition, toolName, context)
+    }
+    return resolved
+  }
+
+  return workspaceSources
+    ? defineCapability({ id, tools, workspaceSources })
+    : defineCapability({
+      id,
+      tools,
+    })
 }

--- a/packages/agent/src/capabilities/subagents.ts
+++ b/packages/agent/src/capabilities/subagents.ts
@@ -26,11 +26,7 @@ export interface SubagentToolInput<
   timeout?: number
 }
 
-export interface SubagentDefinition<
-  TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
-  CALL_OPTIONS = unknown,
-  TContext extends object = Record<string, unknown>,
-> {
+export interface SubagentDefinition<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
   agent: AgentInput<AgentRuntimeContext<TRuntimeConfig>>
   description: string
   toolName?: string
@@ -38,7 +34,7 @@ export interface SubagentDefinition<
 
 export interface SubagentsOptions<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
-  TAgents extends Record<string, SubagentDefinition<TRuntimeConfig, any, any>> = Record<string, SubagentDefinition<TRuntimeConfig>>,
+  TAgents extends Record<string, SubagentDefinition<TRuntimeConfig>> = Record<string, SubagentDefinition<TRuntimeConfig>>,
 > {
   agents: TAgents
   id?: string
@@ -142,7 +138,7 @@ function createTool<TRuntimeConfig extends AgentRuntimeConfig>(
 export function subagents<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
-  const TAgents extends Record<string, SubagentDefinition<TRuntimeConfig, any, any>> = Record<string, SubagentDefinition<TRuntimeConfig>>,
+  const TAgents extends Record<string, SubagentDefinition<TRuntimeConfig>> = Record<string, SubagentDefinition<TRuntimeConfig>>,
 >(
   options: SubagentsOptions<TRuntimeConfig, TAgents>,
 ): AgentCapabilityDefinition<TRuntimeConfig, Name> {


### PR DESCRIPTION
## Summary

Remove `CALL_OPTIONS`, `TContext`, and workspace `Name` type parameters that had no input evidence in the subagent capability contract.

Subagent tool input remains the owner of model-facing context and call-option types. Workspace capability discovery now validates unknown agent metadata before reading it, and the capability definition avoids conditional spread plumbing.

This is an intentional pre-launch public type simplification.

## Proof

- `vp test test/agent-invocation.test.ts test/runtime.test.ts -t subagent` (7 passed)
- `tsc --noEmit` for `@vite-hub/agent`
- `oxlint packages/agent/src/capabilities/subagents.ts`
- exact changed-file TypeScript doctor: 100/100
- `git diff --check`