### PR TITLE
docs: qualify landing host support claim

### DIFF
--- a/docs/app/components/landing/Hero.vue
+++ b/docs/app/components/landing/Hero.vue
@@ -14,7 +14,7 @@ import AgentPlayground from "./AgentPlayground.vue"
         </h1>
         <p class="mt-7 max-w-[44ch] text-lg/8 text-muted text-pretty sm:text-xl/8">
           Bring any model or coding provider, compose your own Capabilities around a persistent Workspace,
-          and deploy the same Agent to any host.
+          and deploy the same Agent across supported hosts.
         </p>
 
         <LandingInstallCommand class="mt-9" />

--- a/docs/app/pages/index.vue
+++ b/docs/app/pages/index.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 const title = "Agents and Server Primitives for Vite";
 const description =
-  "Define inspectable Agents with explicit runtime boundaries, then run them on any host with portable Server Primitives for Vite.";
+  "Define inspectable Agents with explicit runtime boundaries, then run them across supported hosts with portable Server Primitives for Vite.";
 
 useSeo({
   title,

--- a/docs/test/landing.test.ts
+++ b/docs/test/landing.test.ts
@@ -58,6 +58,7 @@ describe("landing page", () => {
     expect(normalizedSource).toContain(
       "Bring any model or coding provider, compose your own Capabilities around a persistent Workspace",
     );
+    expect(normalizedSource).toContain("deploy the same Agent across supported hosts.");
     for (const term of [
       "driver.model",
       "driver.provider",
@@ -79,7 +80,7 @@ describe("landing page", () => {
       /Pick this path|Verified contract|First success \/|The map \/|Your move \/|DIRECT|COMPOSED/,
     );
     expect(source).not.toMatch(/Math\.random|Date\.now|window\.matchMedia/);
-    expect(source).not.toMatch(/Agents for any host|Deploy anywhere|Write it once/);
+    expect(source).not.toMatch(/any host|Deploy anywhere|Write it once/i);
     expect(source).toContain(":aria-pressed");
     expect(source).not.toMatch(/role="(?:tab|tablist|radio|radiogroup)"/);
   });
@@ -128,6 +129,8 @@ describe("landing page", () => {
     expect(source).toContain("useSeo({");
     expect(source).toContain('type: "website"');
     expect(source).toContain('defineOgImage("Landing"');
+    expect(source).toContain("run them across supported hosts");
+    expect(source).not.toMatch(/any host/i);
     expect(source).not.toContain("titleTemplate");
   });
 });


### PR DESCRIPTION
Changes the landing page deployment promise from “any host” to “supported hosts” in the visible hero, SEO metadata, schema data, and generated social card. This keeps the launch copy consistent with the documented provider and host limits while preserving the existing headline, install path, and landing interactions.

## Test plan

- `pnpm exec vp run -t @vite-hub/ui#build`
- `pnpm --dir docs typecheck`
- `pnpm --dir docs exec vp test test/landing.test.ts`
- `pnpm exec vp lint docs/app/components/landing/Hero.vue docs/app/pages/index.vue docs/test/landing.test.ts`
- `pnpm --dir docs build`
- `git diff origin/main...HEAD --check`