### PR TITLE
fix(playground): allow Cloudflare queue marker callbacks

### DIFF
--- a/playground/vite/build/vite-e2e.ts
+++ b/playground/vite/build/vite-e2e.ts
@@ -1327,7 +1327,7 @@ async function writeCloudflareOutput(options: ViteE2EComposerOptions, artifacts:
 
   const wranglerConfig: CloudflareWranglerConfig = {
     compatibility_date: defaultCloudflareCompatibilityDate,
-    compatibility_flags: ["nodejs_compat"],
+    compatibility_flags: ["global_fetch_strictly_public", "nodejs_compat"],
     ...(d1Databases ? { d1_databases: d1Databases } : {}),
     main: "index.js",
     name: workerName,

--- a/test/output/cloudflare.test.ts
+++ b/test/output/cloudflare.test.ts
@@ -34,6 +34,10 @@ describe.runIf(providerEnabled("cloudflare"))("cloudflare provider output", () =
     expect(wrangler().triggers?.crons).toContain("* * * * *")
   })
 
+  it("allows queue consumers to report live markers through the public Worker URL", () => {
+    expect(wrangler().compatibility_flags).toContain("global_fetch_strictly_public")
+  })
+
   it("wrangler.json declares kv namespaces", () => {
     expect(Array.isArray(wrangler().kv_namespaces)).toBe(true)
     expect(wrangler().kv_namespaces.length).toBeGreaterThan(0)


### PR DESCRIPTION
## What

Enable `global_fetch_strictly_public` in the Cloudflare live-smoke fixture output and lock the requirement into its provider-output contract.

## Why

The Queue live smoke enqueues successfully, then its consumer reports direct and deferred markers by fetching the same deployed Worker URL. Cloudflare requires this compatibility flag for Worker-to-Worker global fetch; without it, same-zone requests fail with error 1042 and both messages retry without recording markers.

This is fixture-only: public Queue runtime behavior, Vercel output, and ordinary package-generated Cloudflare configurations are unchanged.

## Proof

- Rebuilt the Cloudflare e2e playground output and verified `wrangler.json` contains both `global_fetch_strictly_public` and `nodejs_compat`.
- Focused provider-output regression: 1 passed.
- Full output file otherwise had one pre-existing local D1 fixture failure because no provision state was present.
- `git diff --check` passed.

Refs #285 and #716.