### PR TITLE
fix(docs): budget Google Fonts metadata outages

### DIFF
--- a/docs/scripts/build.mjs
+++ b/docs/scripts/build.mjs
@@ -33,6 +33,16 @@ export const buildWarningBudget = Object.freeze([
   },
   { name: "Nuxt UI button imports", maximum: 2, text: "[INEFFECTIVE_DYNAMIC_IMPORT]" },
   { name: "Vite chunk size", maximum: 1, text: "[plugin builtin:vite-reporter]" },
+  {
+    name: "Google Fonts icon metadata fetch",
+    maximum: 1,
+    text: "Could not fetch from https://fonts.google.com/metadata/icons?key=material_symbols&incomplete=true",
+  },
+  {
+    name: "Google Fonts font metadata fetch",
+    maximum: 1,
+    text: "Could not fetch from https://fonts.google.com/metadata/fonts",
+  },
   { name: "Nitro Cloudflare assets override", maximum: 1, text: "Wrangler config assetsset" },
   {
     name: "Nuxt Nitro server unused H3Event import",

--- a/docs/scripts/build.mjs
+++ b/docs/scripts/build.mjs
@@ -36,12 +36,12 @@ export const buildWarningBudget = Object.freeze([
   {
     name: "Google Fonts icon metadata fetch",
     maximum: 1,
-    text: "Could not fetch from https://fonts.google.com/metadata/icons?key=material_symbols&incomplete=true",
+    text: "Could not fetch from https://fonts.google.com/metadata/icons?key=material_symbols&incomplete=true. Will retry in",
   },
   {
     name: "Google Fonts font metadata fetch",
     maximum: 1,
-    text: "Could not fetch from https://fonts.google.com/metadata/fonts",
+    text: "Could not fetch from https://fonts.google.com/metadata/fonts. Will retry in",
   },
   { name: "Nitro Cloudflare assets override", maximum: 1, text: "Wrangler config assetsset" },
   {

--- a/docs/test/build-warnings.test.ts
+++ b/docs/test/build-warnings.test.ts
@@ -46,6 +46,15 @@ describe("docs build warning budget", () => {
     ).toThrow("warning budget exceeded for Google Fonts icon metadata fetch: 2/1");
   });
 
+  it("rejects other Google Fonts metadata endpoints", () => {
+    for (const warning of [
+      "[warn] Could not fetch from `https://fonts.google.com/metadata/fonts/Roboto`. Will retry in `1000ms`. `3` retries left.",
+      "[warn] Could not fetch from `https://fonts.google.com/metadata/fonts?unexpected=true`. Will retry in `1000ms`. `3` retries left.",
+    ]) {
+      expect(() => assertBuildWarningBudget(warning)).toThrow("unbudgeted warning");
+    }
+  });
+
   it("rejects non-timeout loading warnings for allowed icons", () => {
     expect(() =>
       assertBuildWarningBudget(

--- a/docs/test/build-warnings.test.ts
+++ b/docs/test/build-warnings.test.ts
@@ -32,6 +32,20 @@ describe("docs build warning budget", () => {
     ).not.toThrow();
   });
 
+  it("accepts the two external Google Fonts metadata fetch warnings", () => {
+    const iconMetadataWarning =
+      "[warn] Could not fetch from `https://fonts.google.com/metadata/icons?key=material_symbols&incomplete=true`. Will retry in `1000ms`. `3` retries left.";
+    const fontMetadataWarning =
+      "[warn] Could not fetch from `https://fonts.google.com/metadata/fonts`. Will retry in `1000ms`. `3` retries left.";
+    expect(() =>
+      assertBuildWarningBudget([iconMetadataWarning, fontMetadataWarning].join("\n")),
+    ).not.toThrow();
+
+    expect(() =>
+      assertBuildWarningBudget([iconMetadataWarning, iconMetadataWarning].join("\n")),
+    ).toThrow("warning budget exceeded for Google Fonts icon metadata fetch: 2/1");
+  });
+
   it("rejects non-timeout loading warnings for allowed icons", () => {
     expect(() =>
       assertBuildWarningBudget(


### PR DESCRIPTION
Two exact-head docs jobs, #1180 and #1181, completed the Nuxt build and then failed because Google Fonts metadata endpoints were unavailable. The warning budget treated both retry warnings as unknown, so an external metadata outage blocked otherwise valid branches.

Budget each observed metadata warning once. Other Google Fonts endpoints, duplicate warnings, and every unrelated unknown warning still fail the build.

Verification:
- The focused regression failed before the budget entries were added.
- `pnpm --filter vitehub-docs test -- test/build-warnings.test.ts` passes 10 tests.
- `pnpm --filter vitehub-docs test` passes 132 tests across 17 files.
- `git diff --check` passes.