### PR TITLE
fix(agent): make trigger history explicit

### DIFF
--- a/docs/content/docs/agents/chat-history-sessions.md
+++ b/docs/content/docs/agents/chat-history-sessions.md
@@ -8,6 +8,8 @@ icon: i-lucide-messages-square
 
 Chat History is the ordered set of prior messages eligible for one chat invocation. A Chat Session selects the host-visible conversation boundary. Neither is durable Agent Memory.
 
+ViteHub sends only the current message unless `triggerHistory` explicitly enables a bounded window. Adapter `threadHistory` controls backfill and caching but does not select model input.
+
 | Need | Use |
 | --- | --- |
 | Continue the visible thread | Thread-backed Chat History |
@@ -32,6 +34,7 @@ export default defineAgent({
       concurrency: 'queue',
       lockScope: 'thread',
       triggerHistory: {
+        maxAgeMs: 30 * 60 * 1000,
         maxMessages: 20,
         source: 'thread',
       },
@@ -40,7 +43,7 @@ export default defineAgent({
 })
 ```
 
-The window limits messages supplied to the next invocation; it does not delete preserved history. For application-owned routes that call `runAgentTrigger()` or `streamAgentTrigger()`, supply the ordered messages for the current thread, including the new message. `triggerHistory` bounds that caller-supplied array; it does not load history from `threadId` or a session id. Adapter-backed Channels can perform their own history backfill. Thread scope is the normal choice for Discord threads, Slack threads, Teams conversations, GitHub comment threads, and application-owned support chats.
+The window limits messages supplied to the next invocation; it does not delete preserved history. `maxMessages` includes the current message. `maxAgeMs` optionally removes the stale prefix relative to that current message, and history with missing timestamps starts a new boundary. For application-owned routes that call `runAgentTrigger()` or `streamAgentTrigger()`, supply the ordered messages for the current thread, including the new message. `triggerHistory` bounds that caller-supplied array; it does not load history from `threadId` or a session id. Adapter-backed Channels can perform their own history backfill. Thread scope is the normal choice for Discord threads, Slack threads, Teams conversations, GitHub comment threads, and application-owned support chats.
 
 ## Add a session
 

--- a/docs/content/docs/capabilities/chat.md
+++ b/docs/content/docs/capabilities/chat.md
@@ -62,7 +62,7 @@ For adapter-backed delivery, inspect the Channel-generated webhook registrations
 | `hooks` | `AgentChatEventHooks` | none | Chat event hooks such as `onDirectMessage`. |
 | `lifecycleHooks` | `Record<string, unknown>` | none | Additional lifecycle-hook settings for integrations that consume Chat Capability configuration. |
 | `event` | `"directMessage"` | none | Chat event binding hint. |
-| `triggerHistory` | `"none" \| { source: "thread"; maxMessages?: number }` | last 20 messages, or `threadHistory.maxMessages` when derived | Chat History Window sent into the `chat.message` Agent Trigger. |
+| `triggerHistory` | `"none" \| { source: "thread"; maxMessages: number; maxAgeMs?: number }` | current message only | Bounded Chat History Window sent into the `chat.message` Agent Trigger. `maxMessages` includes the current message. |
 | `threadHistory` | `{ maxMessages?: number; ttlMs?: number }` | inherited | Adapter thread backfill/cache; stores messages but does not by itself define model input. |
 | `messageHistory` | Chat SDK message-history configuration | inherited | Adapter message-history behavior passed to the Chat SDK. |
 | `logger` | Chat SDK logger | inherited | Logger passed to adapter-backed Chat SDK delivery. |

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -369,6 +369,10 @@ export function resolveChatTriggerHistory(
 export function chatTriggerHistoryLimit(triggerHistory: AgentChatTriggerHistory | undefined): number | undefined {
   if (triggerHistory === "none") return
   if (!triggerHistory || triggerHistory.source !== "thread") return
+  if (
+    Object.prototype.hasOwnProperty.call(triggerHistory, "maxAgeMs") &&
+    normalizedMaxAgeMs(triggerHistory.maxAgeMs) === undefined
+  ) return
   return normalizedMaxMessages(triggerHistory.maxMessages)
 }
 

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -382,6 +382,11 @@ export function chatTriggerHistoryLimit(triggerHistory: AgentChatTriggerHistory 
   return normalizedMaxMessages(triggerHistory.maxMessages)
 }
 
+export function chatTriggerHistoryMaxAgeMs(triggerHistory: AgentChatTriggerHistory | undefined): number | undefined {
+  if (!validChatTriggerHistory(triggerHistory)) return
+  return normalizedMaxAgeMs(triggerHistory.maxAgeMs)
+}
+
 function selectRecentChatHistory(messages: UIMessageLike[], triggerHistory: Exclude<AgentChatTriggerHistory, "none">): UIMessageLike[] {
   const maxAgeMs = normalizedMaxAgeMs(triggerHistory.maxAgeMs)
   if (maxAgeMs === undefined || messages.length < 2) return messages

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -1,6 +1,5 @@
 import { createMessage, isAttachmentData, isAttachmentPart } from "./messages.ts"
 import { normalizeAgentInvoker } from "./invoker.ts"
-import { isRuntimeNumber, isRuntimeObject } from "./internal/runtime-value.ts"
 
 import type {
   AgentChatAgentHookArgs,
@@ -48,8 +47,7 @@ export interface ChatMessageTriggerInputResult<TRuntimeConfig extends AgentRunti
 const derivedChatInvokers = new WeakMap<object, AgentInvoker>()
 
 export function markDerivedChatTriggerInvoker(invoker: unknown, source?: AgentInvoker): void {
-  // SAFETY: the object guard establishes the WeakMap key contract, and an omitted source means the guarded invoker is the derived invoker.
-  if (isRuntimeObject(invoker)) derivedChatInvokers.set(invoker, source || invoker as AgentInvoker)
+  if (typeof invoker === "object" && invoker !== null) derivedChatInvokers.set(invoker, source || invoker as AgentInvoker)
 }
 
 export function hasDerivedChatTriggerInvoker(invoker: unknown): boolean {
@@ -57,7 +55,7 @@ export function hasDerivedChatTriggerInvoker(invoker: unknown): boolean {
 }
 
 export function derivedChatTriggerInvoker(invoker: unknown): AgentInvoker | undefined {
-  return isRuntimeObject(invoker) ? derivedChatInvokers.get(invoker) : undefined
+  return typeof invoker === "object" && invoker !== null ? derivedChatInvokers.get(invoker) : undefined
 }
 
 function uiMessageText(message: UIMessageLike): string {
@@ -349,23 +347,15 @@ function selectChatSession(messages: UIMessageLike[], sessions: AgentChatOptions
 }
 
 function normalizedMaxMessages(value: unknown): number | undefined {
-  return isRuntimeNumber(value) && Number.isFinite(value) && value > 0
+  return typeof value === "number" && Number.isFinite(value)
     ? Math.max(1, Math.floor(value))
     : undefined
 }
 
 function normalizedMaxAgeMs(value: unknown): number | undefined {
-  return isRuntimeNumber(value) && Number.isFinite(value) && value >= 0
+  return typeof value === "number" && Number.isFinite(value)
     ? Math.max(0, value)
     : undefined
-}
-
-function validChatTriggerHistory(triggerHistory: unknown): triggerHistory is Exclude<AgentChatTriggerHistory, "none"> {
-  if (!isRuntimeObject(triggerHistory) || !("source" in triggerHistory) || triggerHistory.source !== "thread") return false
-  if (!("maxMessages" in triggerHistory) || normalizedMaxMessages(triggerHistory.maxMessages) === undefined) return false
-  return !("maxAgeMs" in triggerHistory)
-    || triggerHistory.maxAgeMs === undefined
-    || normalizedMaxAgeMs(triggerHistory.maxAgeMs) !== undefined
 }
 
 export function resolveChatTriggerHistory(
@@ -378,13 +368,8 @@ export function resolveChatTriggerHistory(
 
 export function chatTriggerHistoryLimit(triggerHistory: AgentChatTriggerHistory | undefined): number | undefined {
   if (triggerHistory === "none") return
-  if (!validChatTriggerHistory(triggerHistory)) return
+  if (!triggerHistory || triggerHistory.source !== "thread") return
   return normalizedMaxMessages(triggerHistory.maxMessages)
-}
-
-export function chatTriggerHistoryMaxAgeMs(triggerHistory: AgentChatTriggerHistory | undefined): number | undefined {
-  if (!validChatTriggerHistory(triggerHistory)) return
-  return normalizedMaxAgeMs(triggerHistory.maxAgeMs)
 }
 
 function selectRecentChatHistory(messages: UIMessageLike[], triggerHistory: Exclude<AgentChatTriggerHistory, "none">): UIMessageLike[] {
@@ -402,7 +387,7 @@ function selectRecentChatHistory(messages: UIMessageLike[], triggerHistory: Excl
 function selectChatHistory(messages: UIMessageLike[], triggerHistory: AgentChatTriggerHistory | undefined, sessions?: AgentChatOptions["sessions"], triggerSession?: AgentChatMessageTriggerInput["session"]): UIMessageLike[] {
   const sessionMessages = selectChatSession(messages, sessions, triggerSession)
   const limit = chatTriggerHistoryLimit(triggerHistory)
-  if (!limit || !validChatTriggerHistory(triggerHistory)) return sessionMessages.slice(-1)
+  if (!limit || !triggerHistory || triggerHistory === "none") return sessionMessages.slice(-1)
   return selectRecentChatHistory(sessionMessages, triggerHistory).slice(-limit)
 }
 

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -371,6 +371,7 @@ export function chatTriggerHistoryLimit(triggerHistory: AgentChatTriggerHistory 
   if (!triggerHistory || triggerHistory.source !== "thread") return
   if (
     Object.prototype.hasOwnProperty.call(triggerHistory, "maxAgeMs") &&
+    triggerHistory.maxAgeMs !== undefined &&
     normalizedMaxAgeMs(triggerHistory.maxAgeMs) === undefined
   ) return
   return normalizedMaxMessages(triggerHistory.maxMessages)

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -47,6 +47,7 @@ export interface ChatMessageTriggerInputResult<TRuntimeConfig extends AgentRunti
 const derivedChatInvokers = new WeakMap<object, AgentInvoker>()
 
 export function markDerivedChatTriggerInvoker(invoker: unknown, source?: AgentInvoker): void {
+  // SAFETY: Agent Invokers are object records, and this branch rejects every non-object runtime value.
   if (typeof invoker === "object" && invoker !== null) derivedChatInvokers.set(invoker, source || invoker as AgentInvoker)
 }
 
@@ -55,7 +56,7 @@ export function hasDerivedChatTriggerInvoker(invoker: unknown): boolean {
 }
 
 export function derivedChatTriggerInvoker(invoker: unknown): AgentInvoker | undefined {
-  return typeof invoker === "object" && invoker !== null ? derivedChatInvokers.get(invoker) : undefined
+  return invoker !== null && Object(invoker) === invoker ? derivedChatInvokers.get(Object(invoker)) : undefined
 }
 
 function uiMessageText(message: UIMessageLike): string {
@@ -353,8 +354,9 @@ function normalizedMaxMessages(value: unknown): number | undefined {
 }
 
 function normalizedMaxAgeMs(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value)
-    ? Math.max(0, value)
+  const numericValue = Object.prototype.toString.call(value) === "[object Number]" ? Number(value) : undefined
+  return numericValue !== undefined && Number.isFinite(numericValue) && numericValue >= 0
+    ? numericValue
     : undefined
 }
 

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -1,5 +1,6 @@
 import { createMessage, isAttachmentData, isAttachmentPart } from "./messages.ts"
 import { normalizeAgentInvoker } from "./invoker.ts"
+import { isRuntimeNumber, isRuntimeObject } from "./internal/runtime-value.ts"
 
 import type {
   AgentChatAgentHookArgs,
@@ -47,7 +48,8 @@ export interface ChatMessageTriggerInputResult<TRuntimeConfig extends AgentRunti
 const derivedChatInvokers = new WeakMap<object, AgentInvoker>()
 
 export function markDerivedChatTriggerInvoker(invoker: unknown, source?: AgentInvoker): void {
-  if (typeof invoker === "object" && invoker !== null) derivedChatInvokers.set(invoker, source || invoker as AgentInvoker)
+  // SAFETY: the object guard establishes the WeakMap key contract, and an omitted source means the guarded invoker is the derived invoker.
+  if (isRuntimeObject(invoker)) derivedChatInvokers.set(invoker, source || invoker as AgentInvoker)
 }
 
 export function hasDerivedChatTriggerInvoker(invoker: unknown): boolean {
@@ -55,7 +57,7 @@ export function hasDerivedChatTriggerInvoker(invoker: unknown): boolean {
 }
 
 export function derivedChatTriggerInvoker(invoker: unknown): AgentInvoker | undefined {
-  return typeof invoker === "object" && invoker !== null ? derivedChatInvokers.get(invoker) : undefined
+  return isRuntimeObject(invoker) ? derivedChatInvokers.get(invoker) : undefined
 }
 
 function uiMessageText(message: UIMessageLike): string {
@@ -347,15 +349,23 @@ function selectChatSession(messages: UIMessageLike[], sessions: AgentChatOptions
 }
 
 function normalizedMaxMessages(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value)
+  return isRuntimeNumber(value) && Number.isFinite(value) && value > 0
     ? Math.max(1, Math.floor(value))
     : undefined
 }
 
 function normalizedMaxAgeMs(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isFinite(value)
+  return isRuntimeNumber(value) && Number.isFinite(value) && value >= 0
     ? Math.max(0, value)
     : undefined
+}
+
+function validChatTriggerHistory(triggerHistory: unknown): triggerHistory is Exclude<AgentChatTriggerHistory, "none"> {
+  if (!isRuntimeObject(triggerHistory) || !("source" in triggerHistory) || triggerHistory.source !== "thread") return false
+  if (!("maxMessages" in triggerHistory) || normalizedMaxMessages(triggerHistory.maxMessages) === undefined) return false
+  return !("maxAgeMs" in triggerHistory)
+    || triggerHistory.maxAgeMs === undefined
+    || normalizedMaxAgeMs(triggerHistory.maxAgeMs) !== undefined
 }
 
 export function resolveChatTriggerHistory(
@@ -368,7 +378,7 @@ export function resolveChatTriggerHistory(
 
 export function chatTriggerHistoryLimit(triggerHistory: AgentChatTriggerHistory | undefined): number | undefined {
   if (triggerHistory === "none") return
-  if (!triggerHistory || triggerHistory.source !== "thread") return
+  if (!validChatTriggerHistory(triggerHistory)) return
   return normalizedMaxMessages(triggerHistory.maxMessages)
 }
 
@@ -387,7 +397,7 @@ function selectRecentChatHistory(messages: UIMessageLike[], triggerHistory: Excl
 function selectChatHistory(messages: UIMessageLike[], triggerHistory: AgentChatTriggerHistory | undefined, sessions?: AgentChatOptions["sessions"], triggerSession?: AgentChatMessageTriggerInput["session"]): UIMessageLike[] {
   const sessionMessages = selectChatSession(messages, sessions, triggerSession)
   const limit = chatTriggerHistoryLimit(triggerHistory)
-  if (!limit || !triggerHistory || triggerHistory === "none") return sessionMessages.slice(-1)
+  if (!limit || !validChatTriggerHistory(triggerHistory)) return sessionMessages.slice(-1)
   return selectRecentChatHistory(sessionMessages, triggerHistory).slice(-limit)
 }
 

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -352,33 +352,43 @@ function normalizedMaxMessages(value: unknown): number | undefined {
     : undefined
 }
 
-function threadHistoryMaxMessages(threadHistory: unknown): number | undefined {
-  if (!threadHistory || typeof threadHistory !== "object" || Array.isArray(threadHistory)) return
-  return normalizedMaxMessages((threadHistory as { maxMessages?: unknown }).maxMessages)
+function normalizedMaxAgeMs(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? Math.max(0, value)
+    : undefined
 }
 
 export function resolveChatTriggerHistory(
-  options: Pick<AgentChatOptions, "threadHistory" | "triggerHistory"> | undefined,
+  options: Pick<AgentChatOptions, "triggerHistory"> | undefined,
   triggerHistory?: AgentChatTriggerHistory,
 ): AgentChatTriggerHistory | undefined {
   if (triggerHistory !== undefined) return triggerHistory
-  if (options?.triggerHistory !== undefined) return options.triggerHistory
-  const maxMessages = threadHistoryMaxMessages(options?.threadHistory)
-  return maxMessages === undefined ? undefined : { maxMessages, source: "thread" }
+  return options?.triggerHistory
 }
 
 export function chatTriggerHistoryLimit(triggerHistory: AgentChatTriggerHistory | undefined): number | undefined {
   if (triggerHistory === "none") return
   if (!triggerHistory || triggerHistory.source !== "thread") return
-  return normalizedMaxMessages(triggerHistory.maxMessages) ?? 20
+  return normalizedMaxMessages(triggerHistory.maxMessages)
+}
+
+function selectRecentChatHistory(messages: UIMessageLike[], triggerHistory: Exclude<AgentChatTriggerHistory, "none">): UIMessageLike[] {
+  const maxAgeMs = normalizedMaxAgeMs(triggerHistory.maxAgeMs)
+  if (maxAgeMs === undefined || messages.length < 2) return messages
+  const latestTime = uiMessageTime(messages.at(-1)!)
+  if (latestTime === undefined) return messages.slice(-1)
+  for (let index = messages.length - 2; index >= 0; index--) {
+    const messageTime = uiMessageTime(messages[index]!)
+    if (messageTime === undefined || latestTime - messageTime > maxAgeMs) return messages.slice(index + 1)
+  }
+  return messages
 }
 
 function selectChatHistory(messages: UIMessageLike[], triggerHistory: AgentChatTriggerHistory | undefined, sessions?: AgentChatOptions["sessions"], triggerSession?: AgentChatMessageTriggerInput["session"]): UIMessageLike[] {
   const sessionMessages = selectChatSession(messages, sessions, triggerSession)
-  if (triggerHistory === "none") return sessionMessages.slice(-1)
   const limit = chatTriggerHistoryLimit(triggerHistory)
-  if (limit) return sessionMessages.slice(-limit)
-  return sessionMessages.slice(-20)
+  if (!limit || !triggerHistory || triggerHistory === "none") return sessionMessages.slice(-1)
+  return selectRecentChatHistory(sessionMessages, triggerHistory).slice(-limit)
 }
 
 function createChatTriggerHookArgs<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4114,7 +4114,7 @@ async function chatTriggerMessages(
     const idLessCandidates: ChatSdkMessage[] = []
     let exactIdLessCurrentIndex = -1
     for await (const item of thread.messages) {
-      if (++scanned > scanLimit && (!message.id || !foundCurrent)) break
+      if (++scanned > scanLimit + (message.id ? 0 : fetchedLimit) && !foundCurrent) break
       if (!message.id) {
         idLessCandidates.push(item)
         if (exactIdLessCurrentIndex < 0 && isExactChatSdkDelivery(item, message)) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4124,7 +4124,8 @@ async function chatTriggerMessages(
   } catch {}
 
   let durable = await durableChatThreadMessages(thread, limit)
-  if (message.id && foundCurrent) {
+  const durableContainsCurrent = message.id && durable.some((item) => isCurrentChatSdkMessage(item, message))
+  if (message.id && (foundCurrent || durableContainsCurrent)) {
     const currentTime = message.metadata.dateSent.getTime()
     durable = durable.filter((item) => isCurrentChatSdkMessage(item, message) || item.metadata.dateSent.getTime() < currentTime)
   }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4128,6 +4128,10 @@ async function chatTriggerMessages(
       : exactDurableCurrentIndices.length === 0 && structuralDurableCurrentIndices.length === 1
         ? structuralDurableCurrentIndices[0] ?? -1
         : -1
+  if (message.id && foundCurrent && durableCurrentIndex < 0) {
+    const currentTime = message.metadata.dateSent.getTime()
+    durable = durable.filter((item) => item.metadata.dateSent.getTime() < currentTime)
+  }
   if (!message.id) {
     durable = durableCurrentIndex >= 0 ? durable.slice(0, durableCurrentIndex + 1) : []
   }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -20,7 +20,6 @@ import { getAccessCapabilityOptions } from "../capabilities/access-metadata.ts"
 import { assertChatDeliveryOptions, CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCapabilityOptions, resolveChatErrorFallbackText } from "../chat-trigger.ts"
 import {
   chatTriggerHistoryLimit,
-  chatTriggerHistoryMaxAgeMs,
   createChatMessageTriggerInput,
   derivedChatTriggerInvoker,
   markDerivedChatTriggerInvoker,
@@ -3996,15 +3995,13 @@ function chatMessageMetadata(thread: Thread, message: ChatSdkMessage, messageCon
 async function chatSdkMessageToUiMessage(
   message: ChatSdkMessage,
   metadata?: Record<string, unknown>,
-  options?: { includeAttachments?: boolean; rejectOversizedTextAttachments?: boolean },
+  options?: { rejectOversizedTextAttachments?: boolean },
 ): Promise<UIMessageLike> {
   return {
     createdAt: isoDate(message.metadata.dateSent),
     id: message.id,
     ...(metadata ? { metadata } : {}),
-    parts: options?.includeAttachments === false
-      ? message.text ? [{ id: "text-0", text: message.text, type: "text" }] : []
-      : await chatMessagePartsWithReply(message, options),
+    parts: await chatMessagePartsWithReply(message, options),
     role: message.author.isMe ? "assistant" : "user",
   }
 }
@@ -4044,218 +4041,33 @@ async function durableChatThreadMessages(thread: Thread, limit: number): Promise
   }
 }
 
-const MAX_CHAT_TRIGGER_HISTORY_SCAN = 1_000
-
-function isCurrentChatSdkMessage(item: ChatSdkMessage, current: ChatSdkMessage): boolean {
-  if (item.id || current.id) return Boolean(item.id && current.id && item.id === current.id)
-  if (item === current) return true
-  return (
-    item.threadId === current.threadId &&
-    item.text === current.text &&
-    item.metadata.dateSent.getTime() === current.metadata.dateSent.getTime() &&
-    item.author.userId === current.author.userId &&
-    item.author.userName === current.author.userName
-  )
-}
-
-function chatRawDeliveryKey(message: ChatSdkMessage): string | undefined {
-  if (!isRuntimeObject(message.raw)) return
-  try {
-    return JSON.stringify(message.raw)
-  } catch {}
-}
-
-function isExactChatSdkDelivery(item: ChatSdkMessage, current: ChatSdkMessage): boolean {
-  return item === current || (isRuntimeObject(current.raw) && item.raw === current.raw)
-}
-
 async function chatTriggerMessages(
   thread: Thread,
   message: ChatSdkMessage,
   options: AgentChatOptions | undefined,
   messageContext?: MessageContext,
-): Promise<{ materializeAttachments: () => Promise<UIMessageLike[]>; messages: UIMessageLike[] }> {
-  const currentMetadata = chatMessageMetadata(thread, message, messageContext)
-  const current = await chatSdkMessageToUiMessage(message, currentMetadata, { includeAttachments: false })
-  const triggerHistory = resolveChatTriggerHistory(options)
-  const triggerLimit = chatTriggerHistoryLimit(triggerHistory)
-  const configuredThreadLimit = isRuntimeObject(options?.threadHistory)
-    ? "maxMessages" in options.threadHistory
-      ? options.threadHistory.maxMessages
-      : 100
-    : undefined
-  const sessionHistoryLimit = options?.sessions && isRuntimeNumber(configuredThreadLimit) && Number.isFinite(configuredThreadLimit) && configuredThreadLimit > 0
-    ? Math.floor(configuredThreadLimit)
-    : undefined
-  const limit = Math.max(triggerLimit || 0, sessionHistoryLimit || 0)
-  if (!limit) {
-    return {
-      materializeAttachments: async () => [await chatSdkMessageToUiMessage(message, currentMetadata, {
-        rejectOversizedTextAttachments: true,
-      })],
-      messages: [current],
-    }
-  }
-  const maxAgeMs = chatTriggerHistoryMaxAgeMs(triggerHistory)
-  const currentTime = message.metadata.dateSent.getTime()
-  const historySource = new WeakMap<UIMessageLike, ChatSdkMessage>()
-  historySource.set(current, message)
-  const toHistoryUiMessage = async (item: ChatSdkMessage): Promise<UIMessageLike> => {
-    const converted = await chatSdkMessageToUiMessage(item, undefined, { includeAttachments: false })
-    historySource.set(converted, item)
-    return converted
-  }
+  historyThroughCurrent = false,
+): Promise<UIMessageLike[]> {
+  const current = await chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext), {
+    rejectOversizedTextAttachments: true,
+  })
+  const limit = chatTriggerHistoryLimit(resolveChatTriggerHistory(options))
+  if (!limit) return [current]
 
   const fetchedNewestFirst: UIMessageLike[] = []
-  const fetchedLimit = message.id ? limit : limit - 1
-  const currentRawKey = message.id ? undefined : chatRawDeliveryKey(message)
-  let durable = await durableChatThreadMessages(thread, limit)
-  const durableCurrentIndexBeforeBoundary = message.id
-    ? durable.flatMap((item, index) => (isCurrentChatSdkMessage(item, message) ? [index] : [])).at(-1) ?? -1
-    : -1
-  const durableContainsCurrent = durableCurrentIndexBeforeBoundary >= 0
-  const fetchedAfterCurrent: ChatSdkMessage[] = []
-  const fetchedAfterIdLessCurrent: ChatSdkMessage[] = []
-  const fetchedBeforeCurrent: ChatSdkMessage[] = []
-  let foundCurrent = false
-  let scanned = 0
-  const scanLimit = Math.max(MAX_CHAT_TRIGGER_HISTORY_SCAN, limit)
   try {
-    const idLessCandidates: ChatSdkMessage[] = []
-    let exactIdLessCurrentIndex = -1
     for await (const item of thread.messages) {
-      if (++scanned > scanLimit + (message.id ? 0 : fetchedLimit) && !foundCurrent) break
-      if (!message.id) {
-        idLessCandidates.push(item)
-        if (exactIdLessCurrentIndex < 0 && isExactChatSdkDelivery(item, message)) {
-          exactIdLessCurrentIndex = idLessCandidates.length - 1
-        }
-        if (exactIdLessCurrentIndex >= 0 && idLessCandidates.length > exactIdLessCurrentIndex + fetchedLimit) break
-        continue
-      }
-      if (fetchedNewestFirst.length >= fetchedLimit) break
-      const isCurrent = isCurrentChatSdkMessage(item, message)
-      if (!foundCurrent && isCurrent) {
-        foundCurrent = true
-        for (const future of fetchedBeforeCurrent) {
-          fetchedAfterCurrent.push(future)
-        }
-      }
-      if (foundCurrent) {
-        const itemTime = item.metadata.dateSent.getTime()
-        const outsideTriggerAge = maxAgeMs !== undefined && !isCurrent && (!Number.isFinite(itemTime) || currentTime - itemTime > maxAgeMs)
-        if (outsideTriggerAge && !sessionHistoryLimit) break
-        fetchedNewestFirst.push(isCurrent ? current : await toHistoryUiMessage(item))
-      } else {
-        fetchedBeforeCurrent.push(item)
-      }
-    }
-    if (!foundCurrent && durableContainsCurrent) {
-      for (const item of fetchedBeforeCurrent) {
-        if (item.id && item.metadata.dateSent.getTime() >= currentTime) fetchedAfterCurrent.push(item)
-      }
-      const predecessors = fetchedBeforeCurrent
-        .filter(item => item.metadata.dateSent.getTime() < message.metadata.dateSent.getTime())
-        .slice(0, Math.max(0, limit - 1))
-      for (const item of predecessors) {
-        fetchedNewestFirst.push(await toHistoryUiMessage(item))
-      }
-    }
-    if (!message.id) {
-      const rawCurrentIndices = currentRawKey === undefined
-        ? []
-        : idLessCandidates.flatMap((item, index) => (chatRawDeliveryKey(item) === currentRawKey ? [index] : []))
-      const structuralCurrentIndices = idLessCandidates.flatMap((item, index) => (isCurrentChatSdkMessage(item, message) ? [index] : []))
-      const currentIndex = exactIdLessCurrentIndex >= 0
-        ? exactIdLessCurrentIndex
-        : rawCurrentIndices.length === 1
-          ? rawCurrentIndices[0] ?? -1
-          : structuralCurrentIndices.length === 1
-            ? structuralCurrentIndices[0] ?? -1
-            : -1
-      if (currentIndex >= 0) {
-        fetchedAfterIdLessCurrent.push(...idLessCandidates.slice(0, currentIndex))
-        for (const item of idLessCandidates.slice(currentIndex + 1, currentIndex + 1 + fetchedLimit)) {
-          fetchedNewestFirst.push(await toHistoryUiMessage(item))
-        }
-      }
+      fetchedNewestFirst.push(item.id && message.id && item.id === message.id ? current : await chatSdkMessageToUiMessage(item))
+      if (fetchedNewestFirst.length >= limit) break
     }
   } catch {}
 
-  if (message.id && durableContainsCurrent) {
-    const futureDurableIndices = new Set<number>()
-    for (const future of fetchedAfterCurrent) {
-      const idMatches = future.id
-        ? durable.flatMap((item, index) => (item.id === future.id ? [index] : []))
-        : []
-      if (idMatches.length === 1) {
-        futureDurableIndices.add(idMatches[0]!)
-        continue
-      }
-      const exactMatches = durable.flatMap((item, index) => (isExactChatSdkDelivery(item, future) ? [index] : []))
-      if (exactMatches.length === 1) {
-        futureDurableIndices.add(exactMatches[0]!)
-      }
-    }
-    durable = durable
-      .slice(0, durableCurrentIndexBeforeBoundary + 1)
-      .filter((_, index) => !futureDurableIndices.has(index))
-  } else if (message.id && foundCurrent) {
-    durable = durable.filter((item) => isCurrentChatSdkMessage(item, message) || item.metadata.dateSent.getTime() < currentTime)
-  }
-  if (!message.id && fetchedAfterIdLessCurrent.length > 0) {
-    const futureDurableIndices = new Set<number>()
-    for (const future of fetchedAfterIdLessCurrent) {
-      const idMatches = future.id
-        ? durable.flatMap((item, index) => (item.id === future.id ? [index] : []))
-        : []
-      if (idMatches.length === 1) {
-        futureDurableIndices.add(idMatches[0]!)
-        continue
-      }
-      const exactMatches = durable.flatMap((item, index) => (isExactChatSdkDelivery(item, future) ? [index] : []))
-      if (exactMatches.length === 1) {
-        futureDurableIndices.add(exactMatches[0]!)
-      }
-    }
-    durable = durable.filter((_, index) => !futureDurableIndices.has(index))
-  }
-  const exactDurableCurrentIndices = message.id
-    ? []
-    : durable.flatMap((item, index) => (isExactChatSdkDelivery(item, message) ? [index] : []))
-  const rawDurableCurrentIndices = message.id || currentRawKey === undefined
-    ? []
-    : durable.flatMap((item, index) => (chatRawDeliveryKey(item) === currentRawKey ? [index] : []))
-  const structuralDurableCurrentIndices = durable.flatMap((item, index) => (isCurrentChatSdkMessage(item, message) ? [index] : []))
-  const durableCurrentIndex = message.id
-    ? structuralDurableCurrentIndices.at(-1) ?? -1
-    : exactDurableCurrentIndices.length === 1
-      ? exactDurableCurrentIndices[0] ?? -1
-      : exactDurableCurrentIndices.length === 0 && rawDurableCurrentIndices.length === 1
-        ? rawDurableCurrentIndices[0] ?? -1
-        : exactDurableCurrentIndices.length === 0 && structuralDurableCurrentIndices.length === 1
-          ? structuralDurableCurrentIndices[0] ?? -1
-        : -1
-  if (!message.id) {
-    durable = durableCurrentIndex >= 0 ? durable.slice(0, durableCurrentIndex + 1) : []
-  }
+  const durable = await durableChatThreadMessages(thread, limit)
   let messages = [
-    ...(await Promise.all(durable.map((item, index) => {
-      if (index === durableCurrentIndex) return current
-      return toHistoryUiMessage(item)
-    }))),
+    ...(await Promise.all(durable.map((item) => (item.id && message.id && item.id === message.id ? current : chatSdkMessageToUiMessage(item))))),
     ...fetchedNewestFirst.slice().reverse(),
   ].reduce<UIMessageLike[]>((deduped, item) => {
     if (!item.id) {
-      const source = historySource.get(item)
-      const existing = source && deduped.findIndex((candidate) => {
-        const candidateSource = historySource.get(candidate)
-        return candidateSource && isExactChatSdkDelivery(candidateSource, source)
-      })
-      if (existing !== undefined && existing >= 0) {
-        deduped[existing] = item
-        return deduped
-      }
       deduped.push(item)
       return deduped
     }
@@ -4263,34 +4075,15 @@ async function chatTriggerMessages(
     if (existing === -1) deduped.push(item)
     else deduped[existing] = item
     return deduped
-  }, []).sort((left, right) => {
-    const leftTime = left.createdAt ? new Date(left.createdAt).getTime() : 0
-    const rightTime = right.createdAt ? new Date(right.createdAt).getTime() : 0
-    return leftTime - rightTime
-  })
+  }, [])
 
-  if (current.id) {
+  if (historyThroughCurrent && current.id) {
     const currentIndex = messages.findIndex((item) => item.id === current.id)
     messages = currentIndex >= 0 ? messages.slice(0, currentIndex + 1) : [current]
-  } else {
-    const currentIndex = messages.findIndex((item) => item === current)
-    messages = currentIndex >= 0 ? messages.slice(0, currentIndex + 1) : [...messages, current]
+  } else if (!current.id || !messages.some((item) => item.id === current.id)) {
+    messages.push(current)
   }
-  messages = messages.slice(-limit)
-  const triggerBoundary = messages.length - (triggerLimit ?? 1)
-  return {
-    materializeAttachments: async () => await Promise.all(messages.map(async (item, index) => {
-      const source = historySource.get(item)
-      if (!source || index < triggerBoundary) return item
-      if (source === message) {
-        return await chatSdkMessageToUiMessage(source, currentMetadata, { rejectOversizedTextAttachments: true })
-      }
-      const itemTime = source.metadata.dateSent.getTime()
-      const outsideTriggerAge = maxAgeMs !== undefined && (!Number.isFinite(itemTime) || currentTime - itemTime > maxAgeMs)
-      return outsideTriggerAge ? item : await chatSdkMessageToUiMessage(source)
-    })),
-    messages,
-  }
+  return messages.slice(-limit)
 }
 
 function createChatTriggerInput(
@@ -4879,6 +4672,7 @@ async function handleChatSdkMessage(
   state: { keyPrefix: string; state: StateAdapter; workflowCustodySupported?: boolean },
   messageContext?: MessageContext,
   maximumInvocationDeadline?: number,
+  historyThroughCurrent = false,
   durableSteerScope?: string,
 ): Promise<void> {
   const delivery =
@@ -4917,13 +4711,6 @@ async function handleChatSdkMessage(
     if (isRuntimeNumber(options?.timeout) && Number.isFinite(options.timeout) && options.timeout > 0) {
       input.timeout = options.timeout
     }
-    const collectedMessages = await chatTriggerMessages(thread, message, options, messageContext)
-    let messages = scopeCurrentChatUiMessage(
-      collectedMessages.messages,
-      message.id,
-      input.run?.runId || delivery.delivery.id,
-    )
-    input = { ...input, messages }
     const authorizationInput = await withParsedAgentMessageMeta(
       // SAFETY: generated chat routes provide the runtime config represented by ViteAgentRouteRuntimeConfig.
       agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined,
@@ -4935,11 +4722,6 @@ async function handleChatSdkMessage(
       await recordChannelDeliveryEvidence(delivery, { type: "rejected" })
       return
     }
-    messages = scopeCurrentChatUiMessage(
-      await collectedMessages.materializeAttachments(),
-      message.id,
-      input.run?.runId || delivery.delivery.id,
-    )
     const parsedChannelContext = authorizationInput.context?.channel
     input = withAgentInvokerRunAnnotation({
       ...input,
@@ -4947,6 +4729,11 @@ async function handleChatSdkMessage(
       ...(isRuntimeObject(parsedChannelContext) && isRuntimeObject(parsedChannelContext.meta) ? { meta: parsedChannelContext.meta } : {}),
     }, invoker)
 
+    const messages = scopeCurrentChatUiMessage(
+      await chatTriggerMessages(thread, message, options, messageContext, historyThroughCurrent),
+      message.id,
+      input.run?.runId || delivery.delivery.id,
+    )
     const currentMessage = message.id ? messages.find((item) => item.id === message.id) : messages.at(-1)
     if (!currentMessage || !Array.isArray(currentMessage.parts) || currentMessage.parts.length === 0) {
       await recordChannelDeliveryEvidence(delivery, { type: "rejected" })
@@ -5860,6 +5647,7 @@ async function handleChatSdkMessages(
           state,
           serial ? undefined : messageContext,
           maximumInvocationDeadline,
+          serial,
           durableSteerScope,
         )
       } catch (error) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4054,10 +4054,12 @@ async function chatTriggerMessages(
   if (!limit) return [current]
 
   const fetchedNewestFirst: UIMessageLike[] = []
+  let foundCurrent = false
   try {
     for await (const item of thread.messages) {
-      fetchedNewestFirst.push(item.id && message.id && item.id === message.id ? current : await chatSdkMessageToUiMessage(item))
-      if (fetchedNewestFirst.length >= limit) break
+      if (!foundCurrent && item.id && message.id && item.id === message.id) foundCurrent = true
+      if (foundCurrent) fetchedNewestFirst.push(item.id && message.id && item.id === message.id ? current : await chatSdkMessageToUiMessage(item))
+      if (foundCurrent && fetchedNewestFirst.length >= limit) break
     }
   } catch {}
 

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4072,13 +4072,33 @@ async function chatTriggerMessages(
   let foundCurrent = false
   let scanned = 0
   try {
+    const idLessCandidates: ChatSdkMessage[] = []
+    let exactIdLessCurrentIndex = -1
     for await (const item of thread.messages) {
       if (++scanned > MAX_CHAT_TRIGGER_HISTORY_SCAN) break
+      if (!message.id) {
+        idLessCandidates.push(item)
+        if (exactIdLessCurrentIndex < 0 && (item === message || (isRuntimeObject(message.raw) && item.raw === message.raw))) {
+          exactIdLessCurrentIndex = idLessCandidates.length - 1
+        }
+        if (exactIdLessCurrentIndex >= 0 && idLessCandidates.length > exactIdLessCurrentIndex + fetchedLimit) break
+        continue
+      }
       if (fetchedNewestFirst.length >= fetchedLimit) break
       const isCurrent = isCurrentChatSdkMessage(item, message)
       if (!foundCurrent && isCurrent) foundCurrent = true
-      if (foundCurrent && (message.id || !isCurrent)) {
+      if (foundCurrent) {
         fetchedNewestFirst.push(isCurrent ? current : await chatSdkMessageToUiMessage(item))
+      }
+    }
+    if (!message.id) {
+      const currentIndex = exactIdLessCurrentIndex >= 0
+        ? exactIdLessCurrentIndex
+        : idLessCandidates.findIndex((item) => isCurrentChatSdkMessage(item, message))
+      if (currentIndex >= 0) {
+        for (const item of idLessCandidates.slice(currentIndex + 1, currentIndex + 1 + fetchedLimit)) {
+          fetchedNewestFirst.push(await chatSdkMessageToUiMessage(item))
+        }
       }
     }
   } catch {}

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4131,7 +4131,7 @@ async function chatTriggerMessages(
   } catch {}
 
   if (message.id && durableContainsCurrent) {
-    durable = durable.slice(durableCurrentIndexBeforeBoundary)
+    durable = durable.slice(0, durableCurrentIndexBeforeBoundary + 1)
   } else if (message.id && foundCurrent) {
     const currentTime = message.metadata.dateSent.getTime()
     durable = durable.filter((item) => isCurrentChatSdkMessage(item, message) || item.metadata.dateSent.getTime() < currentTime)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4046,7 +4046,6 @@ async function chatTriggerMessages(
   message: ChatSdkMessage,
   options: AgentChatOptions | undefined,
   messageContext?: MessageContext,
-  historyThroughCurrent = false,
 ): Promise<UIMessageLike[]> {
   const current = await chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext), {
     rejectOversizedTextAttachments: true,
@@ -4077,7 +4076,7 @@ async function chatTriggerMessages(
     return deduped
   }, [])
 
-  if (historyThroughCurrent && current.id) {
+  if (current.id) {
     const currentIndex = messages.findIndex((item) => item.id === current.id)
     messages = currentIndex >= 0 ? messages.slice(0, currentIndex + 1) : [current]
   } else if (!current.id || !messages.some((item) => item.id === current.id)) {
@@ -4672,7 +4671,6 @@ async function handleChatSdkMessage(
   state: { keyPrefix: string; state: StateAdapter; workflowCustodySupported?: boolean },
   messageContext?: MessageContext,
   maximumInvocationDeadline?: number,
-  historyThroughCurrent = false,
   durableSteerScope?: string,
 ): Promise<void> {
   const delivery =
@@ -4730,7 +4728,7 @@ async function handleChatSdkMessage(
     }, invoker)
 
     const messages = scopeCurrentChatUiMessage(
-      await chatTriggerMessages(thread, message, options, messageContext, historyThroughCurrent),
+      await chatTriggerMessages(thread, message, options, messageContext),
       message.id,
       input.run?.runId || delivery.delivery.id,
     )
@@ -5647,7 +5645,6 @@ async function handleChatSdkMessages(
           state,
           serial ? undefined : messageContext,
           maximumInvocationDeadline,
-          serial,
           durableSteerScope,
         )
       } catch (error) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4086,7 +4086,7 @@ async function chatTriggerMessages(
     ? durable.flatMap((item, index) => (isCurrentChatSdkMessage(item, message) ? [index] : [])).at(-1) ?? -1
     : -1
   const durableContainsCurrent = durableCurrentIndexBeforeBoundary >= 0
-  const fetchedAfterCurrentIds = new Set<string>()
+  const fetchedAfterCurrent: ChatSdkMessage[] = []
   const fetchedBeforeCurrent: ChatSdkMessage[] = []
   let foundCurrent = false
   let scanned = 0
@@ -4108,7 +4108,7 @@ async function chatTriggerMessages(
       if (!foundCurrent && isCurrent) {
         foundCurrent = true
         for (const future of fetchedBeforeCurrent) {
-          if (future.id) fetchedAfterCurrentIds.add(future.id)
+          fetchedAfterCurrent.push(future)
         }
       }
       if (foundCurrent) {
@@ -4147,7 +4147,13 @@ async function chatTriggerMessages(
   if (message.id && durableContainsCurrent) {
     durable = durable
       .slice(0, durableCurrentIndexBeforeBoundary + 1)
-      .filter((item) => !item.id || !fetchedAfterCurrentIds.has(item.id))
+      .filter((item) => !fetchedAfterCurrent.some((future) => {
+        if (item.id || future.id) return Boolean(item.id && future.id && item.id === future.id)
+        if (isExactChatSdkDelivery(item, future)) return true
+        const itemRawKey = chatRawDeliveryKey(item)
+        const futureRawKey = chatRawDeliveryKey(future)
+        return (itemRawKey !== undefined && itemRawKey === futureRawKey) || isCurrentChatSdkMessage(item, future)
+      }))
   } else if (message.id && foundCurrent) {
     const currentTime = message.metadata.dateSent.getTime()
     durable = durable.filter((item) => isCurrentChatSdkMessage(item, message) || item.metadata.dateSent.getTime() < currentTime)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4083,9 +4083,13 @@ async function chatTriggerMessages(
     }
   } catch {}
 
-  const durable = await durableChatThreadMessages(thread, limit)
+  let durable = await durableChatThreadMessages(thread, limit)
+  if (!message.id) {
+    const currentIndex = durable.findIndex((item) => isCurrentChatSdkMessage(item, message))
+    durable = currentIndex >= 0 ? durable.slice(0, currentIndex + 1) : []
+  }
   let messages = [
-    ...(await Promise.all(durable.map((item) => (item.id && message.id && item.id === message.id ? current : chatSdkMessageToUiMessage(item))))),
+    ...(await Promise.all(durable.map((item) => (isCurrentChatSdkMessage(item, message) ? current : chatSdkMessageToUiMessage(item))))),
     ...fetchedNewestFirst.slice().reverse(),
   ].reduce<UIMessageLike[]>((deduped, item) => {
     if (!item.id) {
@@ -4105,8 +4109,9 @@ async function chatTriggerMessages(
   if (current.id) {
     const currentIndex = messages.findIndex((item) => item.id === current.id)
     messages = currentIndex >= 0 ? messages.slice(0, currentIndex + 1) : [current]
-  } else if (!current.id || !messages.some((item) => item.id === current.id)) {
-    messages.push(current)
+  } else {
+    const currentIndex = messages.findIndex((item) => item === current)
+    messages = currentIndex >= 0 ? messages.slice(0, currentIndex + 1) : [...messages, current]
   }
   return messages.slice(-limit)
 }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4074,10 +4074,9 @@ async function chatTriggerMessages(
   message: ChatSdkMessage,
   options: AgentChatOptions | undefined,
   messageContext?: MessageContext,
-): Promise<UIMessageLike[]> {
-  const current = await chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext), {
-    rejectOversizedTextAttachments: true,
-  })
+): Promise<{ materializeAttachments: () => Promise<UIMessageLike[]>; messages: UIMessageLike[] }> {
+  const currentMetadata = chatMessageMetadata(thread, message, messageContext)
+  const current = await chatSdkMessageToUiMessage(message, currentMetadata, { includeAttachments: false })
   const triggerHistory = resolveChatTriggerHistory(options)
   const triggerLimit = chatTriggerHistoryLimit(triggerHistory)
   const configuredThreadLimit = isRuntimeObject(options?.threadHistory)
@@ -4089,7 +4088,14 @@ async function chatTriggerMessages(
     ? Math.floor(configuredThreadLimit)
     : undefined
   const limit = Math.max(triggerLimit || 0, sessionHistoryLimit || 0)
-  if (!limit) return [current]
+  if (!limit) {
+    return {
+      materializeAttachments: async () => [await chatSdkMessageToUiMessage(message, currentMetadata, {
+        rejectOversizedTextAttachments: true,
+      })],
+      messages: [current],
+    }
+  }
   const maxAgeMs = chatTriggerHistoryMaxAgeMs(triggerHistory)
   const currentTime = message.metadata.dateSent.getTime()
   const historySource = new WeakMap<UIMessageLike, ChatSdkMessage>()
@@ -4272,13 +4278,19 @@ async function chatTriggerMessages(
   }
   messages = messages.slice(-limit)
   const triggerBoundary = messages.length - (triggerLimit || 0)
-  return await Promise.all(messages.map(async (item, index) => {
-    const source = historySource.get(item)
-    if (!source || source === message || index < triggerBoundary) return item
-    const itemTime = source.metadata.dateSent.getTime()
-    const outsideTriggerAge = maxAgeMs !== undefined && (!Number.isFinite(itemTime) || currentTime - itemTime > maxAgeMs)
-    return outsideTriggerAge ? item : await chatSdkMessageToUiMessage(source)
-  }))
+  return {
+    materializeAttachments: async () => await Promise.all(messages.map(async (item, index) => {
+      const source = historySource.get(item)
+      if (!source || index < triggerBoundary) return item
+      if (source === message) {
+        return await chatSdkMessageToUiMessage(source, currentMetadata, { rejectOversizedTextAttachments: true })
+      }
+      const itemTime = source.metadata.dateSent.getTime()
+      const outsideTriggerAge = maxAgeMs !== undefined && (!Number.isFinite(itemTime) || currentTime - itemTime > maxAgeMs)
+      return outsideTriggerAge ? item : await chatSdkMessageToUiMessage(source)
+    })),
+    messages,
+  }
 }
 
 function createChatTriggerInput(
@@ -4905,8 +4917,9 @@ async function handleChatSdkMessage(
     if (isRuntimeNumber(options?.timeout) && Number.isFinite(options.timeout) && options.timeout > 0) {
       input.timeout = options.timeout
     }
-    const messages = scopeCurrentChatUiMessage(
-      await chatTriggerMessages(thread, message, options, messageContext),
+    const collectedMessages = await chatTriggerMessages(thread, message, options, messageContext)
+    let messages = scopeCurrentChatUiMessage(
+      collectedMessages.messages,
       message.id,
       input.run?.runId || delivery.delivery.id,
     )
@@ -4922,6 +4935,11 @@ async function handleChatSdkMessage(
       await recordChannelDeliveryEvidence(delivery, { type: "rejected" })
       return
     }
+    messages = scopeCurrentChatUiMessage(
+      await collectedMessages.materializeAttachments(),
+      message.id,
+      input.run?.runId || delivery.delivery.id,
+    )
     const parsedChannelContext = authorizationInput.context?.channel
     input = withAgentInvokerRunAnnotation({
       ...input,

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4084,9 +4084,8 @@ async function chatTriggerMessages(
   } catch {}
 
   let durable = await durableChatThreadMessages(thread, limit)
-  let durableCurrentIndex = -1
+  const durableCurrentIndex = durable.findLastIndex((item) => isCurrentChatSdkMessage(item, message))
   if (!message.id) {
-    durableCurrentIndex = durable.findLastIndex((item) => isCurrentChatSdkMessage(item, message))
     durable = durableCurrentIndex >= 0 ? durable.slice(0, durableCurrentIndex + 1) : []
   }
   let messages = [

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4120,10 +4120,11 @@ async function chatTriggerMessages(
       }
     }
     if (!foundCurrent && durableContainsCurrent) {
-      for (const item of fetchedBeforeCurrent) {
-        if (item.metadata.dateSent.getTime() < message.metadata.dateSent.getTime()) {
-          fetchedNewestFirst.push(await chatSdkMessageToUiMessage(item))
-        }
+      const predecessors = fetchedBeforeCurrent
+        .filter(item => item.metadata.dateSent.getTime() < message.metadata.dateSent.getTime())
+        .slice(0, Math.max(0, limit - 1))
+      for (const item of predecessors) {
+        fetchedNewestFirst.push(await chatSdkMessageToUiMessage(item))
       }
     }
     if (!message.id) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4090,11 +4090,12 @@ async function chatTriggerMessages(
   const fetchedBeforeCurrent: ChatSdkMessage[] = []
   let foundCurrent = false
   let scanned = 0
+  const scanLimit = Math.max(MAX_CHAT_TRIGGER_HISTORY_SCAN, limit)
   try {
     const idLessCandidates: ChatSdkMessage[] = []
     let exactIdLessCurrentIndex = -1
     for await (const item of thread.messages) {
-      if (++scanned > MAX_CHAT_TRIGGER_HISTORY_SCAN) break
+      if (++scanned > scanLimit) break
       if (!message.id) {
         idLessCandidates.push(item)
         if (exactIdLessCurrentIndex < 0 && isExactChatSdkDelivery(item, message)) {
@@ -4160,15 +4161,11 @@ async function chatTriggerMessages(
         continue
       }
       const futureRawKey = chatRawDeliveryKey(future)
-      const rawMatches = futureRawKey === undefined
-        ? []
-        : durable.flatMap((item, index) => (chatRawDeliveryKey(item) === futureRawKey ? [index] : []))
-      if (rawMatches.length === 1) {
-        futureDurableIndices.add(rawMatches[0]!)
-        continue
-      }
       const structuralMatches = durable.flatMap((item, index) => (isCurrentChatSdkMessage(item, future) ? [index] : []))
-      if (structuralMatches.length === 1) futureDurableIndices.add(structuralMatches[0]!)
+      const rawAndStructuralMatches = futureRawKey === undefined
+        ? structuralMatches
+        : structuralMatches.filter((index) => chatRawDeliveryKey(durable[index]!) === futureRawKey)
+      if (rawAndStructuralMatches.length === 1) futureDurableIndices.add(rawAndStructuralMatches[0]!)
     }
     durable = durable
       .slice(0, durableCurrentIndexBeforeBoundary + 1)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4145,15 +4145,34 @@ async function chatTriggerMessages(
   } catch {}
 
   if (message.id && durableContainsCurrent) {
+    const futureDurableIndices = new Set<number>()
+    for (const future of fetchedAfterCurrent) {
+      const idMatches = future.id
+        ? durable.flatMap((item, index) => (item.id === future.id ? [index] : []))
+        : []
+      if (idMatches.length === 1) {
+        futureDurableIndices.add(idMatches[0]!)
+        continue
+      }
+      const exactMatches = durable.flatMap((item, index) => (isExactChatSdkDelivery(item, future) ? [index] : []))
+      if (exactMatches.length === 1) {
+        futureDurableIndices.add(exactMatches[0]!)
+        continue
+      }
+      const futureRawKey = chatRawDeliveryKey(future)
+      const rawMatches = futureRawKey === undefined
+        ? []
+        : durable.flatMap((item, index) => (chatRawDeliveryKey(item) === futureRawKey ? [index] : []))
+      if (rawMatches.length === 1) {
+        futureDurableIndices.add(rawMatches[0]!)
+        continue
+      }
+      const structuralMatches = durable.flatMap((item, index) => (isCurrentChatSdkMessage(item, future) ? [index] : []))
+      if (structuralMatches.length === 1) futureDurableIndices.add(structuralMatches[0]!)
+    }
     durable = durable
       .slice(0, durableCurrentIndexBeforeBoundary + 1)
-      .filter((item) => !fetchedAfterCurrent.some((future) => {
-        if (item.id || future.id) return Boolean(item.id && future.id && item.id === future.id)
-        if (isExactChatSdkDelivery(item, future)) return true
-        const itemRawKey = chatRawDeliveryKey(item)
-        const futureRawKey = chatRawDeliveryKey(future)
-        return (itemRawKey !== undefined && itemRawKey === futureRawKey) || isCurrentChatSdkMessage(item, future)
-      }))
+      .filter((_, index) => !futureDurableIndices.has(index))
   } else if (message.id && foundCurrent) {
     const currentTime = message.metadata.dateSent.getTime()
     durable = durable.filter((item) => isCurrentChatSdkMessage(item, message) || item.metadata.dateSent.getTime() < currentTime)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4041,6 +4041,20 @@ async function durableChatThreadMessages(thread: Thread, limit: number): Promise
   }
 }
 
+const MAX_CHAT_TRIGGER_HISTORY_SCAN = 1_000
+
+function isCurrentChatSdkMessage(item: ChatSdkMessage, current: ChatSdkMessage): boolean {
+  if (item.id || current.id) return Boolean(item.id && current.id && item.id === current.id)
+  if (item === current) return true
+  return (
+    item.threadId === current.threadId &&
+    item.text === current.text &&
+    item.metadata.dateSent.getTime() === current.metadata.dateSent.getTime() &&
+    item.author.userId === current.author.userId &&
+    item.author.userName === current.author.userName
+  )
+}
+
 async function chatTriggerMessages(
   thread: Thread,
   message: ChatSdkMessage,
@@ -4056,11 +4070,16 @@ async function chatTriggerMessages(
   const fetchedNewestFirst: UIMessageLike[] = []
   const fetchedLimit = message.id ? limit : limit - 1
   let foundCurrent = !message.id
+  let scanned = 0
   try {
     for await (const item of thread.messages) {
+      if (++scanned > MAX_CHAT_TRIGGER_HISTORY_SCAN) break
       if (fetchedNewestFirst.length >= fetchedLimit) break
-      if (!foundCurrent && item.id && message.id && item.id === message.id) foundCurrent = true
-      if (foundCurrent) fetchedNewestFirst.push(item.id && message.id && item.id === message.id ? current : await chatSdkMessageToUiMessage(item))
+      const isCurrent = isCurrentChatSdkMessage(item, message)
+      if (!foundCurrent && isCurrent) foundCurrent = true
+      if (foundCurrent && (message.id || !isCurrent)) {
+        fetchedNewestFirst.push(isCurrent ? current : await chatSdkMessageToUiMessage(item))
+      }
     }
   } catch {}
 

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4091,11 +4091,12 @@ async function chatTriggerMessages(
   const limit = Math.max(triggerLimit || 0, sessionHistoryLimit || 0)
   if (!limit) return [current]
   const maxAgeMs = chatTriggerHistoryMaxAgeMs(triggerHistory)
+  const includeHistoricalAttachments = triggerLimit !== undefined && triggerLimit > 1
   const currentTime = message.metadata.dateSent.getTime()
   const toHistoryUiMessage = async (item: ChatSdkMessage): Promise<UIMessageLike> => {
     const itemTime = item.metadata.dateSent.getTime()
     const outsideTriggerAge = maxAgeMs !== undefined && (!Number.isFinite(itemTime) || currentTime - itemTime > maxAgeMs)
-    return await chatSdkMessageToUiMessage(item, undefined, outsideTriggerAge ? { includeAttachments: false } : undefined)
+    return await chatSdkMessageToUiMessage(item, undefined, !includeHistoricalAttachments || outsideTriggerAge ? { includeAttachments: false } : undefined)
   }
 
   const fetchedNewestFirst: UIMessageLike[] = []

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4084,12 +4084,13 @@ async function chatTriggerMessages(
   } catch {}
 
   let durable = await durableChatThreadMessages(thread, limit)
+  let durableCurrentIndex = -1
   if (!message.id) {
-    const currentIndex = durable.findIndex((item) => isCurrentChatSdkMessage(item, message))
-    durable = currentIndex >= 0 ? durable.slice(0, currentIndex + 1) : []
+    durableCurrentIndex = durable.findLastIndex((item) => isCurrentChatSdkMessage(item, message))
+    durable = durableCurrentIndex >= 0 ? durable.slice(0, durableCurrentIndex + 1) : []
   }
   let messages = [
-    ...(await Promise.all(durable.map((item) => (isCurrentChatSdkMessage(item, message) ? current : chatSdkMessageToUiMessage(item))))),
+    ...(await Promise.all(durable.map((item, index) => (index === durableCurrentIndex ? current : chatSdkMessageToUiMessage(item))))),
     ...fetchedNewestFirst.slice().reverse(),
   ].reduce<UIMessageLike[]>((deduped, item) => {
     if (!item.id) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4239,34 +4239,18 @@ async function chatTriggerMessages(
   if (!message.id) {
     durable = durableCurrentIndex >= 0 ? durable.slice(0, durableCurrentIndex + 1) : []
   }
-  const durableMessages = await Promise.all(durable.map((item, index) => {
-    if (index === durableCurrentIndex) return current
-    return toHistoryUiMessage(item)
-  }))
-  const fetchedMessages = fetchedNewestFirst.slice().reverse()
-  const durableRawKeyCounts = new Map<string, number>()
-  const fetchedRawKeyCounts = new Map<string, number>()
-  for (const [items, counts] of [[durableMessages, durableRawKeyCounts], [fetchedMessages, fetchedRawKeyCounts]] as const) {
-    for (const item of items) {
-      const source = historySource.get(item)
-      const key = source && !source.id ? chatRawDeliveryKey(source) : undefined
-      if (key !== undefined) counts.set(key, (counts.get(key) ?? 0) + 1)
-    }
-  }
-  const durableMessageSet = new Set(durableMessages)
-  let messages = [...durableMessages, ...fetchedMessages].reduce<UIMessageLike[]>((deduped, item) => {
+  let messages = [
+    ...(await Promise.all(durable.map((item, index) => {
+      if (index === durableCurrentIndex) return current
+      return toHistoryUiMessage(item)
+    }))),
+    ...fetchedNewestFirst.slice().reverse(),
+  ].reduce<UIMessageLike[]>((deduped, item) => {
     if (!item.id) {
       const source = historySource.get(item)
       const existing = source && deduped.findIndex((candidate) => {
         const candidateSource = historySource.get(candidate)
-        if (!candidateSource) return false
-        if (isExactChatSdkDelivery(candidateSource, source)) return true
-        if (durableMessageSet.has(candidate) === durableMessageSet.has(item)) return false
-        const rawKey = chatRawDeliveryKey(source)
-        return rawKey !== undefined &&
-          chatRawDeliveryKey(candidateSource) === rawKey &&
-          durableRawKeyCounts.get(rawKey) === 1 &&
-          fetchedRawKeyCounts.get(rawKey) === 1
+        return candidateSource && isExactChatSdkDelivery(candidateSource, source)
       })
       if (existing !== undefined && existing >= 0) {
         deduped[existing] = item

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4277,7 +4277,7 @@ async function chatTriggerMessages(
     messages = currentIndex >= 0 ? messages.slice(0, currentIndex + 1) : [...messages, current]
   }
   messages = messages.slice(-limit)
-  const triggerBoundary = messages.length - (triggerLimit || 0)
+  const triggerBoundary = messages.length - (triggerLimit ?? 1)
   return {
     materializeAttachments: async () => await Promise.all(messages.map(async (item, index) => {
       const source = historySource.get(item)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4092,10 +4092,12 @@ async function chatTriggerMessages(
   if (!limit) return [current]
   const maxAgeMs = chatTriggerHistoryMaxAgeMs(triggerHistory)
   const currentTime = message.metadata.dateSent.getTime()
-  const toHistoryUiMessage = async (item: ChatSdkMessage, includeAttachments: boolean): Promise<UIMessageLike> => {
-    const itemTime = item.metadata.dateSent.getTime()
-    const outsideTriggerAge = maxAgeMs !== undefined && (!Number.isFinite(itemTime) || currentTime - itemTime > maxAgeMs)
-    return await chatSdkMessageToUiMessage(item, undefined, !includeAttachments || outsideTriggerAge ? { includeAttachments: false } : undefined)
+  const historySource = new WeakMap<UIMessageLike, ChatSdkMessage>()
+  historySource.set(current, message)
+  const toHistoryUiMessage = async (item: ChatSdkMessage): Promise<UIMessageLike> => {
+    const converted = await chatSdkMessageToUiMessage(item, undefined, { includeAttachments: false })
+    historySource.set(converted, item)
+    return converted
   }
 
   const fetchedNewestFirst: UIMessageLike[] = []
@@ -4137,7 +4139,7 @@ async function chatTriggerMessages(
         const itemTime = item.metadata.dateSent.getTime()
         const outsideTriggerAge = maxAgeMs !== undefined && !isCurrent && (!Number.isFinite(itemTime) || currentTime - itemTime > maxAgeMs)
         if (outsideTriggerAge && !sessionHistoryLimit) break
-        fetchedNewestFirst.push(isCurrent ? current : await toHistoryUiMessage(item, fetchedNewestFirst.length < (triggerLimit || 0)))
+        fetchedNewestFirst.push(isCurrent ? current : await toHistoryUiMessage(item))
       } else {
         fetchedBeforeCurrent.push(item)
       }
@@ -4150,7 +4152,7 @@ async function chatTriggerMessages(
         .filter(item => item.metadata.dateSent.getTime() < message.metadata.dateSent.getTime())
         .slice(0, Math.max(0, limit - 1))
       for (const item of predecessors) {
-        fetchedNewestFirst.push(await toHistoryUiMessage(item, fetchedNewestFirst.length < Math.max(0, (triggerLimit || 0) - 1)))
+        fetchedNewestFirst.push(await toHistoryUiMessage(item))
       }
     }
     if (!message.id) {
@@ -4168,7 +4170,7 @@ async function chatTriggerMessages(
       if (currentIndex >= 0) {
         fetchedAfterIdLessCurrent.push(...idLessCandidates.slice(0, currentIndex))
         for (const item of idLessCandidates.slice(currentIndex + 1, currentIndex + 1 + fetchedLimit)) {
-          fetchedNewestFirst.push(await toHistoryUiMessage(item, fetchedNewestFirst.length < Math.max(0, (triggerLimit || 0) - 1)))
+          fetchedNewestFirst.push(await toHistoryUiMessage(item))
         }
       }
     }
@@ -4234,15 +4236,20 @@ async function chatTriggerMessages(
   let messages = [
     ...(await Promise.all(durable.map((item, index) => {
       if (index === durableCurrentIndex) return current
-      const triggerPredecessorCount = Math.max(0, (triggerLimit || 0) - 1)
-      const triggerBoundary = durableCurrentIndex >= 0
-        ? durableCurrentIndex - triggerPredecessorCount
-        : durable.length - triggerPredecessorCount
-      return toHistoryUiMessage(item, index >= triggerBoundary)
+      return toHistoryUiMessage(item)
     }))),
     ...fetchedNewestFirst.slice().reverse(),
   ].reduce<UIMessageLike[]>((deduped, item) => {
     if (!item.id) {
+      const source = historySource.get(item)
+      const existing = source && deduped.findIndex((candidate) => {
+        const candidateSource = historySource.get(candidate)
+        return candidateSource && isExactChatSdkDelivery(candidateSource, source)
+      })
+      if (existing !== undefined && existing >= 0) {
+        deduped[existing] = item
+        return deduped
+      }
       deduped.push(item)
       return deduped
     }
@@ -4263,7 +4270,15 @@ async function chatTriggerMessages(
     const currentIndex = messages.findIndex((item) => item === current)
     messages = currentIndex >= 0 ? messages.slice(0, currentIndex + 1) : [...messages, current]
   }
-  return messages.slice(-limit)
+  messages = messages.slice(-limit)
+  const triggerBoundary = messages.length - (triggerLimit || 0)
+  return await Promise.all(messages.map(async (item, index) => {
+    const source = historySource.get(item)
+    if (!source || source === message || index < triggerBoundary) return item
+    const itemTime = source.metadata.dateSent.getTime()
+    const outsideTriggerAge = maxAgeMs !== undefined && (!Number.isFinite(itemTime) || currentTime - itemTime > maxAgeMs)
+    return outsideTriggerAge ? item : await chatSdkMessageToUiMessage(source)
+  }))
 }
 
 function createChatTriggerInput(

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4239,18 +4239,34 @@ async function chatTriggerMessages(
   if (!message.id) {
     durable = durableCurrentIndex >= 0 ? durable.slice(0, durableCurrentIndex + 1) : []
   }
-  let messages = [
-    ...(await Promise.all(durable.map((item, index) => {
-      if (index === durableCurrentIndex) return current
-      return toHistoryUiMessage(item)
-    }))),
-    ...fetchedNewestFirst.slice().reverse(),
-  ].reduce<UIMessageLike[]>((deduped, item) => {
+  const durableMessages = await Promise.all(durable.map((item, index) => {
+    if (index === durableCurrentIndex) return current
+    return toHistoryUiMessage(item)
+  }))
+  const fetchedMessages = fetchedNewestFirst.slice().reverse()
+  const durableRawKeyCounts = new Map<string, number>()
+  const fetchedRawKeyCounts = new Map<string, number>()
+  for (const [items, counts] of [[durableMessages, durableRawKeyCounts], [fetchedMessages, fetchedRawKeyCounts]] as const) {
+    for (const item of items) {
+      const source = historySource.get(item)
+      const key = source && !source.id ? chatRawDeliveryKey(source) : undefined
+      if (key !== undefined) counts.set(key, (counts.get(key) ?? 0) + 1)
+    }
+  }
+  const durableMessageSet = new Set(durableMessages)
+  let messages = [...durableMessages, ...fetchedMessages].reduce<UIMessageLike[]>((deduped, item) => {
     if (!item.id) {
       const source = historySource.get(item)
       const existing = source && deduped.findIndex((candidate) => {
         const candidateSource = historySource.get(candidate)
-        return candidateSource && isExactChatSdkDelivery(candidateSource, source)
+        if (!candidateSource) return false
+        if (isExactChatSdkDelivery(candidateSource, source)) return true
+        if (durableMessageSet.has(candidate) === durableMessageSet.has(item)) return false
+        const rawKey = chatRawDeliveryKey(source)
+        return rawKey !== undefined &&
+          chatRawDeliveryKey(candidateSource) === rawKey &&
+          durableRawKeyCounts.get(rawKey) === 1 &&
+          fetchedRawKeyCounts.get(rawKey) === 1
       })
       if (existing !== undefined && existing >= 0) {
         deduped[existing] = item

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4081,6 +4081,11 @@ async function chatTriggerMessages(
   const fetchedNewestFirst: UIMessageLike[] = []
   const fetchedLimit = message.id ? limit : limit - 1
   const currentRawKey = message.id ? undefined : chatRawDeliveryKey(message)
+  let durable = await durableChatThreadMessages(thread, limit)
+  const durableCurrentIndexBeforeBoundary = message.id
+    ? durable.flatMap((item, index) => (isCurrentChatSdkMessage(item, message) ? [index] : [])).at(-1) ?? -1
+    : -1
+  const durableContainsCurrent = durableCurrentIndexBeforeBoundary >= 0
   let foundCurrent = false
   let scanned = 0
   try {
@@ -4101,6 +4106,8 @@ async function chatTriggerMessages(
       if (!foundCurrent && isCurrent) foundCurrent = true
       if (foundCurrent) {
         fetchedNewestFirst.push(isCurrent ? current : await chatSdkMessageToUiMessage(item))
+      } else if (durableContainsCurrent && item.metadata.dateSent.getTime() < message.metadata.dateSent.getTime()) {
+        fetchedNewestFirst.push(await chatSdkMessageToUiMessage(item))
       }
     }
     if (!message.id) {
@@ -4123,9 +4130,9 @@ async function chatTriggerMessages(
     }
   } catch {}
 
-  let durable = await durableChatThreadMessages(thread, limit)
-  const durableContainsCurrent = message.id && durable.some((item) => isCurrentChatSdkMessage(item, message))
-  if (message.id && (foundCurrent || durableContainsCurrent)) {
+  if (message.id && durableContainsCurrent) {
+    durable = durable.slice(durableCurrentIndexBeforeBoundary)
+  } else if (message.id && foundCurrent) {
     const currentTime = message.metadata.dateSent.getTime()
     durable = durable.filter((item) => isCurrentChatSdkMessage(item, message) || item.metadata.dateSent.getTime() < currentTime)
   }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -20,6 +20,7 @@ import { getAccessCapabilityOptions } from "../capabilities/access-metadata.ts"
 import { assertChatDeliveryOptions, CHAT_FINISH_EXTENSION_CONTEXT_KEY, getChatCapabilityOptions, resolveChatErrorFallbackText } from "../chat-trigger.ts"
 import {
   chatTriggerHistoryLimit,
+  chatTriggerHistoryMaxAgeMs,
   createChatMessageTriggerInput,
   derivedChatTriggerInvoker,
   markDerivedChatTriggerInvoker,
@@ -3995,13 +3996,15 @@ function chatMessageMetadata(thread: Thread, message: ChatSdkMessage, messageCon
 async function chatSdkMessageToUiMessage(
   message: ChatSdkMessage,
   metadata?: Record<string, unknown>,
-  options?: { rejectOversizedTextAttachments?: boolean },
+  options?: { includeAttachments?: boolean; rejectOversizedTextAttachments?: boolean },
 ): Promise<UIMessageLike> {
   return {
     createdAt: isoDate(message.metadata.dateSent),
     id: message.id,
     ...(metadata ? { metadata } : {}),
-    parts: await chatMessagePartsWithReply(message, options),
+    parts: options?.includeAttachments === false
+      ? message.text ? [{ id: "text-0", text: message.text, type: "text" }] : []
+      : await chatMessagePartsWithReply(message, options),
     role: message.author.isMe ? "assistant" : "user",
   }
 }
@@ -4075,8 +4078,23 @@ async function chatTriggerMessages(
   const current = await chatSdkMessageToUiMessage(message, chatMessageMetadata(thread, message, messageContext), {
     rejectOversizedTextAttachments: true,
   })
-  const limit = chatTriggerHistoryLimit(resolveChatTriggerHistory(options))
+  const triggerHistory = resolveChatTriggerHistory(options)
+  const triggerLimit = chatTriggerHistoryLimit(triggerHistory)
+  const configuredThreadLimit = isRuntimeObject(options?.threadHistory) && "maxMessages" in options.threadHistory
+    ? options.threadHistory.maxMessages
+    : undefined
+  const sessionHistoryLimit = options?.sessions && isRuntimeNumber(configuredThreadLimit) && Number.isFinite(configuredThreadLimit) && configuredThreadLimit > 0
+    ? Math.floor(configuredThreadLimit)
+    : undefined
+  const limit = Math.max(triggerLimit || 0, sessionHistoryLimit || 0)
   if (!limit) return [current]
+  const maxAgeMs = chatTriggerHistoryMaxAgeMs(triggerHistory)
+  const currentTime = message.metadata.dateSent.getTime()
+  const toHistoryUiMessage = async (item: ChatSdkMessage): Promise<UIMessageLike> => {
+    const itemTime = item.metadata.dateSent.getTime()
+    const outsideTriggerAge = maxAgeMs !== undefined && (!Number.isFinite(itemTime) || currentTime - itemTime > maxAgeMs)
+    return await chatSdkMessageToUiMessage(item, undefined, outsideTriggerAge ? { includeAttachments: false } : undefined)
+  }
 
   const fetchedNewestFirst: UIMessageLike[] = []
   const fetchedLimit = message.id ? limit : limit - 1
@@ -4114,17 +4132,23 @@ async function chatTriggerMessages(
         }
       }
       if (foundCurrent) {
-        fetchedNewestFirst.push(isCurrent ? current : await chatSdkMessageToUiMessage(item))
+        const itemTime = item.metadata.dateSent.getTime()
+        const outsideTriggerAge = maxAgeMs !== undefined && !isCurrent && (!Number.isFinite(itemTime) || currentTime - itemTime > maxAgeMs)
+        if (outsideTriggerAge && !sessionHistoryLimit) break
+        fetchedNewestFirst.push(isCurrent ? current : await toHistoryUiMessage(item))
       } else {
         fetchedBeforeCurrent.push(item)
       }
     }
     if (!foundCurrent && durableContainsCurrent) {
+      for (const item of fetchedBeforeCurrent) {
+        if (item.id && item.metadata.dateSent.getTime() >= currentTime) fetchedAfterCurrent.push(item)
+      }
       const predecessors = fetchedBeforeCurrent
         .filter(item => item.metadata.dateSent.getTime() < message.metadata.dateSent.getTime())
         .slice(0, Math.max(0, limit - 1))
       for (const item of predecessors) {
-        fetchedNewestFirst.push(await chatSdkMessageToUiMessage(item))
+        fetchedNewestFirst.push(await toHistoryUiMessage(item))
       }
     }
     if (!message.id) {
@@ -4142,7 +4166,7 @@ async function chatTriggerMessages(
       if (currentIndex >= 0) {
         fetchedAfterIdLessCurrent.push(...idLessCandidates.slice(0, currentIndex))
         for (const item of idLessCandidates.slice(currentIndex + 1, currentIndex + 1 + fetchedLimit)) {
-          fetchedNewestFirst.push(await chatSdkMessageToUiMessage(item))
+          fetchedNewestFirst.push(await toHistoryUiMessage(item))
         }
       }
     }
@@ -4167,7 +4191,6 @@ async function chatTriggerMessages(
       .slice(0, durableCurrentIndexBeforeBoundary + 1)
       .filter((_, index) => !futureDurableIndices.has(index))
   } else if (message.id && foundCurrent) {
-    const currentTime = message.metadata.dateSent.getTime()
     durable = durable.filter((item) => isCurrentChatSdkMessage(item, message) || item.metadata.dateSent.getTime() < currentTime)
   }
   if (!message.id && fetchedAfterIdLessCurrent.length > 0) {
@@ -4207,7 +4230,7 @@ async function chatTriggerMessages(
     durable = durableCurrentIndex >= 0 ? durable.slice(0, durableCurrentIndex + 1) : []
   }
   let messages = [
-    ...(await Promise.all(durable.map((item, index) => (index === durableCurrentIndex ? current : chatSdkMessageToUiMessage(item))))),
+    ...(await Promise.all(durable.map((item, index) => (index === durableCurrentIndex ? current : toHistoryUiMessage(item))))),
     ...fetchedNewestFirst.slice().reverse(),
   ].reduce<UIMessageLike[]>((deduped, item) => {
     if (!item.id) {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4080,8 +4080,10 @@ async function chatTriggerMessages(
   })
   const triggerHistory = resolveChatTriggerHistory(options)
   const triggerLimit = chatTriggerHistoryLimit(triggerHistory)
-  const configuredThreadLimit = isRuntimeObject(options?.threadHistory) && "maxMessages" in options.threadHistory
-    ? options.threadHistory.maxMessages
+  const configuredThreadLimit = isRuntimeObject(options?.threadHistory)
+    ? "maxMessages" in options.threadHistory
+      ? options.threadHistory.maxMessages
+      : 100
     : undefined
   const sessionHistoryLimit = options?.sessions && isRuntimeNumber(configuredThreadLimit) && Number.isFinite(configuredThreadLimit) && configuredThreadLimit > 0
     ? Math.floor(configuredThreadLimit)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4087,6 +4087,7 @@ async function chatTriggerMessages(
     : -1
   const durableContainsCurrent = durableCurrentIndexBeforeBoundary >= 0
   const fetchedAfterCurrent: ChatSdkMessage[] = []
+  const fetchedAfterIdLessCurrent: ChatSdkMessage[] = []
   const fetchedBeforeCurrent: ChatSdkMessage[] = []
   let foundCurrent = false
   let scanned = 0
@@ -4138,6 +4139,7 @@ async function chatTriggerMessages(
             ? structuralCurrentIndices[0] ?? -1
             : -1
       if (currentIndex >= 0) {
+        fetchedAfterIdLessCurrent.push(...idLessCandidates.slice(0, currentIndex))
         for (const item of idLessCandidates.slice(currentIndex + 1, currentIndex + 1 + fetchedLimit)) {
           fetchedNewestFirst.push(await chatSdkMessageToUiMessage(item))
         }
@@ -4173,6 +4175,30 @@ async function chatTriggerMessages(
   } else if (message.id && foundCurrent) {
     const currentTime = message.metadata.dateSent.getTime()
     durable = durable.filter((item) => isCurrentChatSdkMessage(item, message) || item.metadata.dateSent.getTime() < currentTime)
+  }
+  if (!message.id && fetchedAfterIdLessCurrent.length > 0) {
+    const futureDurableIndices = new Set<number>()
+    for (const future of fetchedAfterIdLessCurrent) {
+      const idMatches = future.id
+        ? durable.flatMap((item, index) => (item.id === future.id ? [index] : []))
+        : []
+      if (idMatches.length === 1) {
+        futureDurableIndices.add(idMatches[0]!)
+        continue
+      }
+      const exactMatches = durable.flatMap((item, index) => (isExactChatSdkDelivery(item, future) ? [index] : []))
+      if (exactMatches.length === 1) {
+        futureDurableIndices.add(exactMatches[0]!)
+        continue
+      }
+      const futureRawKey = chatRawDeliveryKey(future)
+      const structuralMatches = durable.flatMap((item, index) => (isCurrentChatSdkMessage(item, future) ? [index] : []))
+      const rawAndStructuralMatches = futureRawKey === undefined
+        ? structuralMatches
+        : structuralMatches.filter((index) => chatRawDeliveryKey(durable[index]!) === futureRawKey)
+      if (rawAndStructuralMatches.length === 1) futureDurableIndices.add(rawAndStructuralMatches[0]!)
+    }
+    durable = durable.filter((_, index) => !futureDurableIndices.has(index))
   }
   const exactDurableCurrentIndices = message.id
     ? []

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4096,7 +4096,7 @@ async function chatTriggerMessages(
     const idLessCandidates: ChatSdkMessage[] = []
     let exactIdLessCurrentIndex = -1
     for await (const item of thread.messages) {
-      if (++scanned > scanLimit) break
+      if (++scanned > scanLimit && (!message.id || !foundCurrent)) break
       if (!message.id) {
         idLessCandidates.push(item)
         if (exactIdLessCurrentIndex < 0 && isExactChatSdkDelivery(item, message)) {
@@ -4160,14 +4160,7 @@ async function chatTriggerMessages(
       const exactMatches = durable.flatMap((item, index) => (isExactChatSdkDelivery(item, future) ? [index] : []))
       if (exactMatches.length === 1) {
         futureDurableIndices.add(exactMatches[0]!)
-        continue
       }
-      const futureRawKey = chatRawDeliveryKey(future)
-      const structuralMatches = durable.flatMap((item, index) => (isCurrentChatSdkMessage(item, future) ? [index] : []))
-      const rawAndStructuralMatches = futureRawKey === undefined
-        ? structuralMatches
-        : structuralMatches.filter((index) => chatRawDeliveryKey(durable[index]!) === futureRawKey)
-      if (rawAndStructuralMatches.length === 1) futureDurableIndices.add(rawAndStructuralMatches[0]!)
     }
     durable = durable
       .slice(0, durableCurrentIndexBeforeBoundary + 1)
@@ -4189,14 +4182,7 @@ async function chatTriggerMessages(
       const exactMatches = durable.flatMap((item, index) => (isExactChatSdkDelivery(item, future) ? [index] : []))
       if (exactMatches.length === 1) {
         futureDurableIndices.add(exactMatches[0]!)
-        continue
       }
-      const futureRawKey = chatRawDeliveryKey(future)
-      const structuralMatches = durable.flatMap((item, index) => (isCurrentChatSdkMessage(item, future) ? [index] : []))
-      const rawAndStructuralMatches = futureRawKey === undefined
-        ? structuralMatches
-        : structuralMatches.filter((index) => chatRawDeliveryKey(durable[index]!) === futureRawKey)
-      if (rawAndStructuralMatches.length === 1) futureDurableIndices.add(rawAndStructuralMatches[0]!)
     }
     durable = durable.filter((_, index) => !futureDurableIndices.has(index))
   }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4915,9 +4915,9 @@ async function handleChatSdkMessage(
     )
     const transportSessionId = input.run?.threadId ?? input.run?.runId
     const selectedSessionId = resolveChatSessionId(messages, options?.sessions, input.session)
-    const providerSessionId = input.context?.["chat.sessionId"] || (transportSessionId && selectedSessionId
+    const providerSessionId = transportSessionId && selectedSessionId
       ? `${transportSessionId}:chat-session:${selectedSessionId}`
-      : transportSessionId)
+      : transportSessionId
     if (providerSessionId) {
       input = {
         ...input,

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4069,7 +4069,7 @@ async function chatTriggerMessages(
 
   const fetchedNewestFirst: UIMessageLike[] = []
   const fetchedLimit = message.id ? limit : limit - 1
-  let foundCurrent = !message.id
+  let foundCurrent = false
   let scanned = 0
   try {
     for await (const item of thread.messages) {
@@ -4096,7 +4096,11 @@ async function chatTriggerMessages(
     if (existing === -1) deduped.push(item)
     else deduped[existing] = item
     return deduped
-  }, [])
+  }, []).sort((left, right) => {
+    const leftTime = left.createdAt ? new Date(left.createdAt).getTime() : 0
+    const rightTime = right.createdAt ? new Date(right.createdAt).getTime() : 0
+    return leftTime - rightTime
+  })
 
   if (current.id) {
     const currentIndex = messages.findIndex((item) => item.id === current.id)

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4905,6 +4905,12 @@ async function handleChatSdkMessage(
     if (isRuntimeNumber(options?.timeout) && Number.isFinite(options.timeout) && options.timeout > 0) {
       input.timeout = options.timeout
     }
+    const messages = scopeCurrentChatUiMessage(
+      await chatTriggerMessages(thread, message, options, messageContext),
+      message.id,
+      input.run?.runId || delivery.delivery.id,
+    )
+    input = { ...input, messages }
     const authorizationInput = await withParsedAgentMessageMeta(
       // SAFETY: generated chat routes provide the runtime config represented by ViteAgentRouteRuntimeConfig.
       agent as AgentDefinition<ViteAgentRouteRuntimeConfig> | undefined,
@@ -4923,25 +4929,6 @@ async function handleChatSdkMessage(
       ...(isRuntimeObject(parsedChannelContext) && isRuntimeObject(parsedChannelContext.meta) ? { meta: parsedChannelContext.meta } : {}),
     }, invoker)
 
-    const messages = scopeCurrentChatUiMessage(
-      await chatTriggerMessages(thread, message, options, messageContext),
-      message.id,
-      input.run?.runId || delivery.delivery.id,
-    )
-    const transportSessionId = input.run?.threadId ?? input.run?.runId
-    const selectedSessionId = resolveChatSessionId(messages, options?.sessions, input.session)
-    const providerSessionId = transportSessionId && selectedSessionId
-      ? `${transportSessionId}:chat-session:${selectedSessionId}`
-      : transportSessionId
-    if (providerSessionId) {
-      input = {
-        ...input,
-        context: {
-          ...input.context,
-          "chat.sessionId": providerSessionId,
-        },
-      }
-    }
     const currentMessage = message.id ? messages.find((item) => item.id === message.id) : messages.at(-1)
     if (!currentMessage || !Array.isArray(currentMessage.parts) || currentMessage.parts.length === 0) {
       await recordChannelDeliveryEvidence(delivery, { type: "rejected" })

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4091,12 +4091,11 @@ async function chatTriggerMessages(
   const limit = Math.max(triggerLimit || 0, sessionHistoryLimit || 0)
   if (!limit) return [current]
   const maxAgeMs = chatTriggerHistoryMaxAgeMs(triggerHistory)
-  const includeHistoricalAttachments = triggerLimit !== undefined && triggerLimit > 1
   const currentTime = message.metadata.dateSent.getTime()
-  const toHistoryUiMessage = async (item: ChatSdkMessage): Promise<UIMessageLike> => {
+  const toHistoryUiMessage = async (item: ChatSdkMessage, includeAttachments: boolean): Promise<UIMessageLike> => {
     const itemTime = item.metadata.dateSent.getTime()
     const outsideTriggerAge = maxAgeMs !== undefined && (!Number.isFinite(itemTime) || currentTime - itemTime > maxAgeMs)
-    return await chatSdkMessageToUiMessage(item, undefined, !includeHistoricalAttachments || outsideTriggerAge ? { includeAttachments: false } : undefined)
+    return await chatSdkMessageToUiMessage(item, undefined, !includeAttachments || outsideTriggerAge ? { includeAttachments: false } : undefined)
   }
 
   const fetchedNewestFirst: UIMessageLike[] = []
@@ -4138,7 +4137,7 @@ async function chatTriggerMessages(
         const itemTime = item.metadata.dateSent.getTime()
         const outsideTriggerAge = maxAgeMs !== undefined && !isCurrent && (!Number.isFinite(itemTime) || currentTime - itemTime > maxAgeMs)
         if (outsideTriggerAge && !sessionHistoryLimit) break
-        fetchedNewestFirst.push(isCurrent ? current : await toHistoryUiMessage(item))
+        fetchedNewestFirst.push(isCurrent ? current : await toHistoryUiMessage(item, fetchedNewestFirst.length < (triggerLimit || 0)))
       } else {
         fetchedBeforeCurrent.push(item)
       }
@@ -4151,7 +4150,7 @@ async function chatTriggerMessages(
         .filter(item => item.metadata.dateSent.getTime() < message.metadata.dateSent.getTime())
         .slice(0, Math.max(0, limit - 1))
       for (const item of predecessors) {
-        fetchedNewestFirst.push(await toHistoryUiMessage(item))
+        fetchedNewestFirst.push(await toHistoryUiMessage(item, fetchedNewestFirst.length < Math.max(0, (triggerLimit || 0) - 1)))
       }
     }
     if (!message.id) {
@@ -4169,7 +4168,7 @@ async function chatTriggerMessages(
       if (currentIndex >= 0) {
         fetchedAfterIdLessCurrent.push(...idLessCandidates.slice(0, currentIndex))
         for (const item of idLessCandidates.slice(currentIndex + 1, currentIndex + 1 + fetchedLimit)) {
-          fetchedNewestFirst.push(await toHistoryUiMessage(item))
+          fetchedNewestFirst.push(await toHistoryUiMessage(item, fetchedNewestFirst.length < Math.max(0, (triggerLimit || 0) - 1)))
         }
       }
     }
@@ -4233,7 +4232,14 @@ async function chatTriggerMessages(
     durable = durableCurrentIndex >= 0 ? durable.slice(0, durableCurrentIndex + 1) : []
   }
   let messages = [
-    ...(await Promise.all(durable.map((item, index) => (index === durableCurrentIndex ? current : toHistoryUiMessage(item))))),
+    ...(await Promise.all(durable.map((item, index) => {
+      if (index === durableCurrentIndex) return current
+      const triggerPredecessorCount = Math.max(0, (triggerLimit || 0) - 1)
+      const triggerBoundary = durableCurrentIndex >= 0
+        ? durableCurrentIndex - triggerPredecessorCount
+        : durable.length - triggerPredecessorCount
+      return toHistoryUiMessage(item, index >= triggerBoundary)
+    }))),
     ...fetchedNewestFirst.slice().reverse(),
   ].reduce<UIMessageLike[]>((deduped, item) => {
     if (!item.id) {
@@ -4907,6 +4913,20 @@ async function handleChatSdkMessage(
       message.id,
       input.run?.runId || delivery.delivery.id,
     )
+    const transportSessionId = input.run?.threadId ?? input.run?.runId
+    const selectedSessionId = resolveChatSessionId(messages, options?.sessions, input.session)
+    const providerSessionId = input.context?.["chat.sessionId"] || (transportSessionId && selectedSessionId
+      ? `${transportSessionId}:chat-session:${selectedSessionId}`
+      : transportSessionId)
+    if (providerSessionId) {
+      input = {
+        ...input,
+        context: {
+          ...input.context,
+          "chat.sessionId": providerSessionId,
+        },
+      }
+    }
     const currentMessage = message.id ? messages.find((item) => item.id === message.id) : messages.at(-1)
     if (!currentMessage || !Array.isArray(currentMessage.parts) || currentMessage.parts.length === 0) {
       await recordChannelDeliveryEvidence(delivery, { type: "rejected" })

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4055,6 +4055,18 @@ function isCurrentChatSdkMessage(item: ChatSdkMessage, current: ChatSdkMessage):
   )
 }
 
+function chatRawDeliveryKey(message: ChatSdkMessage): string | undefined {
+  if (!isRuntimeObject(message.raw)) return
+  try {
+    return JSON.stringify(message.raw)
+  } catch {}
+}
+
+function isExactChatSdkDelivery(item: ChatSdkMessage, current: ChatSdkMessage, currentRawKey?: string): boolean {
+  if (item === current || (isRuntimeObject(current.raw) && item.raw === current.raw)) return true
+  return currentRawKey !== undefined && chatRawDeliveryKey(item) === currentRawKey
+}
+
 async function chatTriggerMessages(
   thread: Thread,
   message: ChatSdkMessage,
@@ -4069,6 +4081,7 @@ async function chatTriggerMessages(
 
   const fetchedNewestFirst: UIMessageLike[] = []
   const fetchedLimit = message.id ? limit : limit - 1
+  const currentRawKey = message.id ? undefined : chatRawDeliveryKey(message)
   let foundCurrent = false
   let scanned = 0
   try {
@@ -4078,7 +4091,7 @@ async function chatTriggerMessages(
       if (++scanned > MAX_CHAT_TRIGGER_HISTORY_SCAN) break
       if (!message.id) {
         idLessCandidates.push(item)
-        if (exactIdLessCurrentIndex < 0 && (item === message || (isRuntimeObject(message.raw) && item.raw === message.raw))) {
+        if (exactIdLessCurrentIndex < 0 && isExactChatSdkDelivery(item, message, currentRawKey)) {
           exactIdLessCurrentIndex = idLessCandidates.length - 1
         }
         if (exactIdLessCurrentIndex >= 0 && idLessCandidates.length > exactIdLessCurrentIndex + fetchedLimit) break
@@ -4104,7 +4117,17 @@ async function chatTriggerMessages(
   } catch {}
 
   let durable = await durableChatThreadMessages(thread, limit)
-  const durableCurrentIndex = durable.findLastIndex((item) => isCurrentChatSdkMessage(item, message))
+  const exactDurableCurrentIndices = message.id
+    ? []
+    : durable.flatMap((item, index) => (isExactChatSdkDelivery(item, message, currentRawKey) ? [index] : []))
+  const structuralDurableCurrentIndices = durable.flatMap((item, index) => (isCurrentChatSdkMessage(item, message) ? [index] : []))
+  const durableCurrentIndex = message.id
+    ? structuralDurableCurrentIndices.at(-1) ?? -1
+    : exactDurableCurrentIndices.length === 1
+      ? exactDurableCurrentIndices[0] ?? -1
+      : exactDurableCurrentIndices.length === 0 && structuralDurableCurrentIndices.length === 1
+        ? structuralDurableCurrentIndices[0] ?? -1
+        : -1
   if (!message.id) {
     durable = durableCurrentIndex >= 0 ? durable.slice(0, durableCurrentIndex + 1) : []
   }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4112,7 +4112,7 @@ async function chatTriggerMessages(
         ? exactIdLessCurrentIndex
         : rawCurrentIndices.length === 1
           ? rawCurrentIndices[0] ?? -1
-          : rawCurrentIndices.length === 0 && structuralCurrentIndices.length === 1
+          : structuralCurrentIndices.length === 1
             ? structuralCurrentIndices[0] ?? -1
             : -1
       if (currentIndex >= 0) {
@@ -4124,6 +4124,10 @@ async function chatTriggerMessages(
   } catch {}
 
   let durable = await durableChatThreadMessages(thread, limit)
+  if (message.id && foundCurrent) {
+    const currentTime = message.metadata.dateSent.getTime()
+    durable = durable.filter((item) => isCurrentChatSdkMessage(item, message) || item.metadata.dateSent.getTime() < currentTime)
+  }
   const exactDurableCurrentIndices = message.id
     ? []
     : durable.flatMap((item, index) => (isExactChatSdkDelivery(item, message) ? [index] : []))
@@ -4137,13 +4141,9 @@ async function chatTriggerMessages(
       ? exactDurableCurrentIndices[0] ?? -1
       : exactDurableCurrentIndices.length === 0 && rawDurableCurrentIndices.length === 1
         ? rawDurableCurrentIndices[0] ?? -1
-        : exactDurableCurrentIndices.length === 0 && rawDurableCurrentIndices.length === 0 && structuralDurableCurrentIndices.length === 1
+        : exactDurableCurrentIndices.length === 0 && structuralDurableCurrentIndices.length === 1
           ? structuralDurableCurrentIndices[0] ?? -1
         : -1
-  if (message.id && foundCurrent && durableCurrentIndex < 0) {
-    const currentTime = message.metadata.dateSent.getTime()
-    durable = durable.filter((item) => item.metadata.dateSent.getTime() < currentTime)
-  }
   if (!message.id) {
     durable = durableCurrentIndex >= 0 ? durable.slice(0, durableCurrentIndex + 1) : []
   }

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4054,12 +4054,13 @@ async function chatTriggerMessages(
   if (!limit) return [current]
 
   const fetchedNewestFirst: UIMessageLike[] = []
-  let foundCurrent = false
+  const fetchedLimit = message.id ? limit : limit - 1
+  let foundCurrent = !message.id
   try {
     for await (const item of thread.messages) {
+      if (fetchedNewestFirst.length >= fetchedLimit) break
       if (!foundCurrent && item.id && message.id && item.id === message.id) foundCurrent = true
       if (foundCurrent) fetchedNewestFirst.push(item.id && message.id && item.id === message.id ? current : await chatSdkMessageToUiMessage(item))
-      if (foundCurrent && fetchedNewestFirst.length >= limit) break
     }
   } catch {}
 

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4062,9 +4062,8 @@ function chatRawDeliveryKey(message: ChatSdkMessage): string | undefined {
   } catch {}
 }
 
-function isExactChatSdkDelivery(item: ChatSdkMessage, current: ChatSdkMessage, currentRawKey?: string): boolean {
-  if (item === current || (isRuntimeObject(current.raw) && item.raw === current.raw)) return true
-  return currentRawKey !== undefined && chatRawDeliveryKey(item) === currentRawKey
+function isExactChatSdkDelivery(item: ChatSdkMessage, current: ChatSdkMessage): boolean {
+  return item === current || (isRuntimeObject(current.raw) && item.raw === current.raw)
 }
 
 async function chatTriggerMessages(
@@ -4091,7 +4090,7 @@ async function chatTriggerMessages(
       if (++scanned > MAX_CHAT_TRIGGER_HISTORY_SCAN) break
       if (!message.id) {
         idLessCandidates.push(item)
-        if (exactIdLessCurrentIndex < 0 && isExactChatSdkDelivery(item, message, currentRawKey)) {
+        if (exactIdLessCurrentIndex < 0 && isExactChatSdkDelivery(item, message)) {
           exactIdLessCurrentIndex = idLessCandidates.length - 1
         }
         if (exactIdLessCurrentIndex >= 0 && idLessCandidates.length > exactIdLessCurrentIndex + fetchedLimit) break
@@ -4105,9 +4104,17 @@ async function chatTriggerMessages(
       }
     }
     if (!message.id) {
+      const rawCurrentIndices = currentRawKey === undefined
+        ? []
+        : idLessCandidates.flatMap((item, index) => (chatRawDeliveryKey(item) === currentRawKey ? [index] : []))
+      const structuralCurrentIndices = idLessCandidates.flatMap((item, index) => (isCurrentChatSdkMessage(item, message) ? [index] : []))
       const currentIndex = exactIdLessCurrentIndex >= 0
         ? exactIdLessCurrentIndex
-        : idLessCandidates.findIndex((item) => isCurrentChatSdkMessage(item, message))
+        : rawCurrentIndices.length === 1
+          ? rawCurrentIndices[0] ?? -1
+          : rawCurrentIndices.length === 0 && structuralCurrentIndices.length === 1
+            ? structuralCurrentIndices[0] ?? -1
+            : -1
       if (currentIndex >= 0) {
         for (const item of idLessCandidates.slice(currentIndex + 1, currentIndex + 1 + fetchedLimit)) {
           fetchedNewestFirst.push(await chatSdkMessageToUiMessage(item))
@@ -4119,14 +4126,19 @@ async function chatTriggerMessages(
   let durable = await durableChatThreadMessages(thread, limit)
   const exactDurableCurrentIndices = message.id
     ? []
-    : durable.flatMap((item, index) => (isExactChatSdkDelivery(item, message, currentRawKey) ? [index] : []))
+    : durable.flatMap((item, index) => (isExactChatSdkDelivery(item, message) ? [index] : []))
+  const rawDurableCurrentIndices = message.id || currentRawKey === undefined
+    ? []
+    : durable.flatMap((item, index) => (chatRawDeliveryKey(item) === currentRawKey ? [index] : []))
   const structuralDurableCurrentIndices = durable.flatMap((item, index) => (isCurrentChatSdkMessage(item, message) ? [index] : []))
   const durableCurrentIndex = message.id
     ? structuralDurableCurrentIndices.at(-1) ?? -1
     : exactDurableCurrentIndices.length === 1
       ? exactDurableCurrentIndices[0] ?? -1
-      : exactDurableCurrentIndices.length === 0 && structuralDurableCurrentIndices.length === 1
-        ? structuralDurableCurrentIndices[0] ?? -1
+      : exactDurableCurrentIndices.length === 0 && rawDurableCurrentIndices.length === 1
+        ? rawDurableCurrentIndices[0] ?? -1
+        : exactDurableCurrentIndices.length === 0 && rawDurableCurrentIndices.length === 0 && structuralDurableCurrentIndices.length === 1
+          ? structuralDurableCurrentIndices[0] ?? -1
         : -1
   if (message.id && foundCurrent && durableCurrentIndex < 0) {
     const currentTime = message.metadata.dateSent.getTime()

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -4086,6 +4086,8 @@ async function chatTriggerMessages(
     ? durable.flatMap((item, index) => (isCurrentChatSdkMessage(item, message) ? [index] : [])).at(-1) ?? -1
     : -1
   const durableContainsCurrent = durableCurrentIndexBeforeBoundary >= 0
+  const fetchedAfterCurrentIds = new Set<string>()
+  const fetchedBeforeCurrent: ChatSdkMessage[] = []
   let foundCurrent = false
   let scanned = 0
   try {
@@ -4103,11 +4105,23 @@ async function chatTriggerMessages(
       }
       if (fetchedNewestFirst.length >= fetchedLimit) break
       const isCurrent = isCurrentChatSdkMessage(item, message)
-      if (!foundCurrent && isCurrent) foundCurrent = true
+      if (!foundCurrent && isCurrent) {
+        foundCurrent = true
+        for (const future of fetchedBeforeCurrent) {
+          if (future.id) fetchedAfterCurrentIds.add(future.id)
+        }
+      }
       if (foundCurrent) {
         fetchedNewestFirst.push(isCurrent ? current : await chatSdkMessageToUiMessage(item))
-      } else if (durableContainsCurrent && item.metadata.dateSent.getTime() < message.metadata.dateSent.getTime()) {
-        fetchedNewestFirst.push(await chatSdkMessageToUiMessage(item))
+      } else {
+        fetchedBeforeCurrent.push(item)
+      }
+    }
+    if (!foundCurrent && durableContainsCurrent) {
+      for (const item of fetchedBeforeCurrent) {
+        if (item.metadata.dateSent.getTime() < message.metadata.dateSent.getTime()) {
+          fetchedNewestFirst.push(await chatSdkMessageToUiMessage(item))
+        }
       }
     }
     if (!message.id) {
@@ -4131,7 +4145,9 @@ async function chatTriggerMessages(
   } catch {}
 
   if (message.id && durableContainsCurrent) {
-    durable = durable.slice(0, durableCurrentIndexBeforeBoundary + 1)
+    durable = durable
+      .slice(0, durableCurrentIndexBeforeBoundary + 1)
+      .filter((item) => !item.id || !fetchedAfterCurrentIds.has(item.id))
   } else if (message.id && foundCurrent) {
     const currentTime = message.metadata.dateSent.getTime()
     durable = durable.filter((item) => isCurrentChatSdkMessage(item, message) || item.metadata.dateSent.getTime() < currentTime)

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1540,7 +1540,7 @@ export interface AgentChatAgentBindingOptions {
   event?: "directMessage"
 }
 
-export type AgentChatTriggerHistory = "none" | { maxMessages?: number, source: "thread" }
+export type AgentChatTriggerHistory = "none" | { maxAgeMs?: number, maxMessages: number, source: "thread" }
 
 export interface AgentChatSessionOptions {
   idleTimeoutMs?: number

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -38,7 +38,10 @@ const outputSchema = {
       }),
       output: () => ({ type: "object" }),
     },
-    validate: (value: unknown) => ({ value: value as { title: string } }),
+    validate: (value: unknown) => {
+      // SAFETY: This test schema receives the fixed JSON object returned by generateResult above.
+      return { value: value as { title: string } }
+    },
     vendor: "vitehub-test",
     version: 1 as const,
   },
@@ -110,6 +113,7 @@ async function modelCallFor(channel: "discord" | "telegram", messages = history)
     },
     driver: {
       instructions: agentInstructions,
+      // SAFETY: createModel implements the AI SDK methods exercised by this test.
       model: model as never,
       output: { schema: outputSchema },
     },
@@ -147,6 +151,7 @@ describe("Channel instructions", () => {
         discord: discord(),
         support: telegram(),
       },
+      // SAFETY: Inspection reads Agent metadata without invoking the placeholder model.
       driver: { model: {} as never },
     })
     const inspected = [`Channel "support" instructions:\n\n${telegramInstructions}`]
@@ -166,9 +171,11 @@ describe("Channel instructions", () => {
   })
 
   it("retains Channel guidance for opaque adapter definitions", async () => {
+    // SAFETY: createModel implements the AI SDK methods exercised by this test.
     const agent = {
       channels: { support: telegram() },
       async resolve() {
+        // SAFETY: createModel implements the AI SDK methods exercised by this test.
         return createAiSdkAdapter({ model: createModel() as never })
       },
     } as never
@@ -179,10 +186,13 @@ describe("Channel instructions", () => {
   })
 
   it("retains consumer classification when an opaque definition decorates an adapter", async () => {
+    // SAFETY: createModel implements the AI SDK methods exercised by this test.
     const agent = {
       channels: { support: telegram() },
       async resolve() {
+        // SAFETY: createModel implements the AI SDK methods exercised by this test.
         return {
+          // SAFETY: createModel implements the AI SDK methods exercised by this test.
           ...createAiSdkAdapter({ model: createModel() as never }),
           decorated: true,
         }
@@ -195,6 +205,7 @@ describe("Channel instructions", () => {
   })
 
   it("omits guidance for opaque custom adapters that do not consume it", async () => {
+    // SAFETY: Inspection treats this intentionally partial object as an opaque Agent definition.
     const agent = {
       channels: { support: telegram() },
       async resolve() {
@@ -212,6 +223,7 @@ describe("Channel instructions", () => {
       resolved = true
       throw new Error("resolver must not run")
     }
+    // SAFETY: Inspection does not resolve this intentionally opaque Agent definition.
     const agent = { channels: { discord: discord() }, resolve } as never
 
     expect(await resolveAgentInspectionMetadata(agent)).not.toHaveProperty("instructions")
@@ -279,6 +291,7 @@ describe("Channel instructions", () => {
 
   it("selects guidance from trusted trigger context when run metadata is omitted", async () => {
     const model = createModel()
+    // SAFETY: createModel implements the AI SDK methods exercised by this test.
     const agent = defineAgent({
       channels: {
         support: telegram({
@@ -295,6 +308,7 @@ describe("Channel instructions", () => {
       },
       driver: {
         instructions: agentInstructions,
+        // SAFETY: createModel implements the AI SDK methods exercised by this test.
         model: model as never,
       },
     })
@@ -310,10 +324,12 @@ describe("Channel instructions", () => {
     const model = createModel()
     const adapter = createAiSdkAdapter({
       instructions: "Configured Agent instructions.",
+      // SAFETY: createModel implements the AI SDK methods exercised by this test.
       model: model as never,
     })
     const invoker = { id: "channel-test", kind: "user" }
 
+    // SAFETY: The test supplies every invocation field read by the adapter path under test.
     await adapter.generate({
       actor: invoker,
       context: createAgentInvocationContextStore({
@@ -341,12 +357,14 @@ describe("Channel instructions", () => {
     const model = createModel()
     const adapter = createAiSdkAdapter({
       instructions: "Generate one short title.",
+      // SAFETY: createModel implements the AI SDK methods exercised by this test.
       model: model as never,
     })
     const context = createAgentInvocationContextStore()
     bindMessageChannelInstructions(context, telegram())
     const invoker = { id: "channel-test", kind: "user" }
 
+    // SAFETY: The test supplies every invocation field read by the auxiliary adapter path.
     await adapter.generate(markAuxiliaryMessageChannelInstructionContext({
       actor: invoker,
       context,

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -118,6 +118,9 @@ async function modelCallFor(channel: "discord" | "telegram", messages = history)
         inputRoles = input.messages?.map(message => message.role) ?? []
       },
     },
+    messages: {
+      triggerHistory: { maxMessages: 10, source: "thread" },
+    },
   })
 
   const channelId = channel === "telegram" ? "support" : "discord"

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -38,10 +38,7 @@ const outputSchema = {
       }),
       output: () => ({ type: "object" }),
     },
-    validate: (value: unknown) => {
-      // SAFETY: these tests only pass the fixture's declared title object to this schema stub.
-      return { value: value as { title: string } }
-    },
+    validate: (value: unknown) => ({ value: value as { title: string } }),
     vendor: "vitehub-test",
     version: 1 as const,
   },
@@ -105,8 +102,6 @@ function expectInstructionsOnceInOrder(document: string, instructions: string[])
 
 async function modelCallFor(channel: "discord" | "telegram", messages = history) {
   const model = createModel()
-  // SAFETY: createModel implements the AI SDK model methods exercised by this test fixture.
-  const testModel = model as never
   let inputRoles: string[] = []
   const agent = defineAgent({
     channels: {
@@ -115,7 +110,7 @@ async function modelCallFor(channel: "discord" | "telegram", messages = history)
     },
     driver: {
       instructions: agentInstructions,
-      model: testModel,
+      model: model as never,
       output: { schema: outputSchema },
     },
     hooks: {
@@ -147,14 +142,12 @@ async function modelCallFor(channel: "discord" | "telegram", messages = history)
 
 describe("Channel instructions", () => {
   it("exposes private Channel guidance through Agent inspection", async () => {
-    // SAFETY: inspection does not execute the driver, so this fixture only needs a placeholder model.
-    const inspectionModel = {} as never
     const agent = defineAgent({
       channels: {
         discord: discord(),
         support: telegram(),
       },
-      driver: { model: inspectionModel },
+      driver: { model: {} as never },
     })
     const inspected = [`Channel "support" instructions:\n\n${telegramInstructions}`]
 
@@ -173,13 +166,10 @@ describe("Channel instructions", () => {
   })
 
   it("retains Channel guidance for opaque adapter definitions", async () => {
-    // SAFETY: this opaque definition implements the resolve path used by inspection.
     const agent = {
       channels: { support: telegram() },
       async resolve() {
-        // SAFETY: createModel implements the AI SDK model methods exercised by this inspection fixture.
-        const model = createModel() as never
-        return createAiSdkAdapter({ model })
+        return createAiSdkAdapter({ model: createModel() as never })
       },
     } as never
     const inspected = [`Channel "support" instructions:\n\n${telegramInstructions}`]
@@ -189,14 +179,11 @@ describe("Channel instructions", () => {
   })
 
   it("retains consumer classification when an opaque definition decorates an adapter", async () => {
-    // SAFETY: this opaque definition implements the resolve path used by inspection.
     const agent = {
       channels: { support: telegram() },
       async resolve() {
-        // SAFETY: createModel implements the AI SDK model methods exercised by this inspection fixture.
-        const model = createModel() as never
         return {
-          ...createAiSdkAdapter({ model }),
+          ...createAiSdkAdapter({ model: createModel() as never }),
           decorated: true,
         }
       },
@@ -208,7 +195,6 @@ describe("Channel instructions", () => {
   })
 
   it("omits guidance for opaque custom adapters that do not consume it", async () => {
-    // SAFETY: this opaque definition implements the resolve path used by inspection.
     const agent = {
       channels: { support: telegram() },
       async resolve() {
@@ -226,7 +212,6 @@ describe("Channel instructions", () => {
       resolved = true
       throw new Error("resolver must not run")
     }
-    // SAFETY: this opaque definition implements the resolve path used by inspection.
     const agent = { channels: { discord: discord() }, resolve } as never
 
     expect(await resolveAgentInspectionMetadata(agent)).not.toHaveProperty("instructions")
@@ -294,8 +279,6 @@ describe("Channel instructions", () => {
 
   it("selects guidance from trusted trigger context when run metadata is omitted", async () => {
     const model = createModel()
-    // SAFETY: createModel implements the AI SDK model methods exercised by this test fixture.
-    const testModel = model as never
     const agent = defineAgent({
       channels: {
         support: telegram({
@@ -312,7 +295,7 @@ describe("Channel instructions", () => {
       },
       driver: {
         instructions: agentInstructions,
-        model: testModel,
+        model: model as never,
       },
     })
 
@@ -325,16 +308,13 @@ describe("Channel instructions", () => {
 
   it("composes configured and resolved instructions without trusting public context", async () => {
     const model = createModel()
-    // SAFETY: createModel implements the AI SDK model methods exercised by this test fixture.
-    const testModel = model as never
     const adapter = createAiSdkAdapter({
       instructions: "Configured Agent instructions.",
-      model: testModel,
+      model: model as never,
     })
-    const invoker = { id: "channel-test", kind: "user" as const }
+    const invoker = { id: "channel-test", kind: "user" }
 
-    // SAFETY: this fixture supplies every runtime field read by createAiSdkAdapter.generate.
-    const generateInput = {
+    await adapter.generate({
       actor: invoker,
       context: createAgentInvocationContextStore({
         "agent.channelInstructions": "Injected Channel instructions.",
@@ -345,8 +325,7 @@ describe("Channel instructions", () => {
       messages: [createMessage({ role: "user", text: "Hello" })],
       output: { schema: outputSchema },
       runtime,
-    } as never
-    await adapter.generate(generateInput)
+    } as never)
 
     const systemMessages = model.doGenerateCalls[0]!.prompt.filter(message => message.role === "system")
     expect(systemMessages).toHaveLength(1)
@@ -360,18 +339,15 @@ describe("Channel instructions", () => {
 
   it("does not apply final-response guidance to auxiliary model calls", async () => {
     const model = createModel()
-    // SAFETY: createModel implements the AI SDK model methods exercised by this test fixture.
-    const testModel = model as never
     const adapter = createAiSdkAdapter({
       instructions: "Generate one short title.",
-      model: testModel,
+      model: model as never,
     })
     const context = createAgentInvocationContextStore()
     bindMessageChannelInstructions(context, telegram())
     const invoker = { id: "channel-test", kind: "user" }
 
-    // SAFETY: this fixture supplies every runtime field read by createAiSdkAdapter.generate.
-    const generateInput = markAuxiliaryMessageChannelInstructionContext({
+    await adapter.generate(markAuxiliaryMessageChannelInstructionContext({
       actor: invoker,
       context,
       input: {},
@@ -379,8 +355,7 @@ describe("Channel instructions", () => {
       messages: [],
       prompt: "Dinner plans",
       runtime,
-    }) as never
-    await adapter.generate(generateInput)
+    }) as never)
 
     const systemMessages = model.doGenerateCalls[0]!.prompt.filter(message => message.role === "system")
     expect(systemMessages).toHaveLength(1)

--- a/packages/agent/test/channel-instructions.test.ts
+++ b/packages/agent/test/channel-instructions.test.ts
@@ -38,7 +38,10 @@ const outputSchema = {
       }),
       output: () => ({ type: "object" }),
     },
-    validate: (value: unknown) => ({ value: value as { title: string } }),
+    validate: (value: unknown) => {
+      // SAFETY: these tests only pass the fixture's declared title object to this schema stub.
+      return { value: value as { title: string } }
+    },
     vendor: "vitehub-test",
     version: 1 as const,
   },
@@ -102,6 +105,8 @@ function expectInstructionsOnceInOrder(document: string, instructions: string[])
 
 async function modelCallFor(channel: "discord" | "telegram", messages = history) {
   const model = createModel()
+  // SAFETY: createModel implements the AI SDK model methods exercised by this test fixture.
+  const testModel = model as never
   let inputRoles: string[] = []
   const agent = defineAgent({
     channels: {
@@ -110,7 +115,7 @@ async function modelCallFor(channel: "discord" | "telegram", messages = history)
     },
     driver: {
       instructions: agentInstructions,
-      model: model as never,
+      model: testModel,
       output: { schema: outputSchema },
     },
     hooks: {
@@ -142,12 +147,14 @@ async function modelCallFor(channel: "discord" | "telegram", messages = history)
 
 describe("Channel instructions", () => {
   it("exposes private Channel guidance through Agent inspection", async () => {
+    // SAFETY: inspection does not execute the driver, so this fixture only needs a placeholder model.
+    const inspectionModel = {} as never
     const agent = defineAgent({
       channels: {
         discord: discord(),
         support: telegram(),
       },
-      driver: { model: {} as never },
+      driver: { model: inspectionModel },
     })
     const inspected = [`Channel "support" instructions:\n\n${telegramInstructions}`]
 
@@ -166,10 +173,13 @@ describe("Channel instructions", () => {
   })
 
   it("retains Channel guidance for opaque adapter definitions", async () => {
+    // SAFETY: this opaque definition implements the resolve path used by inspection.
     const agent = {
       channels: { support: telegram() },
       async resolve() {
-        return createAiSdkAdapter({ model: createModel() as never })
+        // SAFETY: createModel implements the AI SDK model methods exercised by this inspection fixture.
+        const model = createModel() as never
+        return createAiSdkAdapter({ model })
       },
     } as never
     const inspected = [`Channel "support" instructions:\n\n${telegramInstructions}`]
@@ -179,11 +189,14 @@ describe("Channel instructions", () => {
   })
 
   it("retains consumer classification when an opaque definition decorates an adapter", async () => {
+    // SAFETY: this opaque definition implements the resolve path used by inspection.
     const agent = {
       channels: { support: telegram() },
       async resolve() {
+        // SAFETY: createModel implements the AI SDK model methods exercised by this inspection fixture.
+        const model = createModel() as never
         return {
-          ...createAiSdkAdapter({ model: createModel() as never }),
+          ...createAiSdkAdapter({ model }),
           decorated: true,
         }
       },
@@ -195,6 +208,7 @@ describe("Channel instructions", () => {
   })
 
   it("omits guidance for opaque custom adapters that do not consume it", async () => {
+    // SAFETY: this opaque definition implements the resolve path used by inspection.
     const agent = {
       channels: { support: telegram() },
       async resolve() {
@@ -212,6 +226,7 @@ describe("Channel instructions", () => {
       resolved = true
       throw new Error("resolver must not run")
     }
+    // SAFETY: this opaque definition implements the resolve path used by inspection.
     const agent = { channels: { discord: discord() }, resolve } as never
 
     expect(await resolveAgentInspectionMetadata(agent)).not.toHaveProperty("instructions")
@@ -279,6 +294,8 @@ describe("Channel instructions", () => {
 
   it("selects guidance from trusted trigger context when run metadata is omitted", async () => {
     const model = createModel()
+    // SAFETY: createModel implements the AI SDK model methods exercised by this test fixture.
+    const testModel = model as never
     const agent = defineAgent({
       channels: {
         support: telegram({
@@ -295,7 +312,7 @@ describe("Channel instructions", () => {
       },
       driver: {
         instructions: agentInstructions,
-        model: model as never,
+        model: testModel,
       },
     })
 
@@ -308,13 +325,16 @@ describe("Channel instructions", () => {
 
   it("composes configured and resolved instructions without trusting public context", async () => {
     const model = createModel()
+    // SAFETY: createModel implements the AI SDK model methods exercised by this test fixture.
+    const testModel = model as never
     const adapter = createAiSdkAdapter({
       instructions: "Configured Agent instructions.",
-      model: model as never,
+      model: testModel,
     })
-    const invoker = { id: "channel-test", kind: "user" }
+    const invoker = { id: "channel-test", kind: "user" as const }
 
-    await adapter.generate({
+    // SAFETY: this fixture supplies every runtime field read by createAiSdkAdapter.generate.
+    const generateInput = {
       actor: invoker,
       context: createAgentInvocationContextStore({
         "agent.channelInstructions": "Injected Channel instructions.",
@@ -325,7 +345,8 @@ describe("Channel instructions", () => {
       messages: [createMessage({ role: "user", text: "Hello" })],
       output: { schema: outputSchema },
       runtime,
-    } as never)
+    } as never
+    await adapter.generate(generateInput)
 
     const systemMessages = model.doGenerateCalls[0]!.prompt.filter(message => message.role === "system")
     expect(systemMessages).toHaveLength(1)
@@ -339,15 +360,18 @@ describe("Channel instructions", () => {
 
   it("does not apply final-response guidance to auxiliary model calls", async () => {
     const model = createModel()
+    // SAFETY: createModel implements the AI SDK model methods exercised by this test fixture.
+    const testModel = model as never
     const adapter = createAiSdkAdapter({
       instructions: "Generate one short title.",
-      model: model as never,
+      model: testModel,
     })
     const context = createAgentInvocationContextStore()
     bindMessageChannelInstructions(context, telegram())
     const invoker = { id: "channel-test", kind: "user" }
 
-    await adapter.generate(markAuxiliaryMessageChannelInstructionContext({
+    // SAFETY: this fixture supplies every runtime field read by createAiSdkAdapter.generate.
+    const generateInput = markAuxiliaryMessageChannelInstructionContext({
       actor: invoker,
       context,
       input: {},
@@ -355,7 +379,8 @@ describe("Channel instructions", () => {
       messages: [],
       prompt: "Dinner plans",
       runtime,
-    }) as never)
+    }) as never
+    await adapter.generate(generateInput)
 
     const systemMessages = model.doGenerateCalls[0]!.prompt.filter(message => message.role === "system")
     expect(systemMessages).toHaveLength(1)

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest"
 
 import { createChatMessageTriggerInput, resolveChatSessionId } from "../src/chat-message-input.ts"
+import type { AgentChatMessageTriggerInput } from "../src/types.ts"
 
 describe("chat message trigger input", () => {
   it("keeps a fresh approval boundary stable for a new manual Chat Session", () => {
@@ -182,6 +183,21 @@ describe("chat message trigger input", () => {
       .map(part => part.text)
       .join(""))).toEqual(["recent", "latest"])
     expect(result.input.messages?.at(-1)?.role).toBe("user")
+  })
+
+  it("fails closed when a runtime trigger history age bound is malformed", () => {
+    const result = createChatMessageTriggerInput({}, {
+      messages: [
+        { parts: [{ text: "one", type: "text" }], role: "user" },
+        { parts: [{ text: "two", type: "text" }], role: "assistant" },
+      ],
+      triggerHistory: { maxAgeMs: null, maxMessages: 20, source: "thread" } as unknown as AgentChatMessageTriggerInput["triggerHistory"],
+    })
+
+    expect(result.input.messages?.map(message => message.parts
+      .filter((part): part is { text: string, type: "text" } => part.type === "text")
+      .map(part => part.text)
+      .join(""))).toEqual(["two"])
   })
 
   it("keeps stateless trigger history explicit", () => {

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest"
 
 import { createChatMessageTriggerInput, resolveChatSessionId } from "../src/chat-message-input.ts"
-import type { AgentChatMessageTriggerInput } from "../src/types.ts"
 
 describe("chat message trigger input", () => {
   it("keeps a fresh approval boundary stable for a new manual Chat Session", () => {
@@ -185,14 +184,15 @@ describe("chat message trigger input", () => {
     expect(result.input.messages?.at(-1)?.role).toBe("user")
   })
 
-  it("fails closed when a runtime trigger history age bound is malformed", () => {
-    const result = createChatMessageTriggerInput({}, {
+  it.each([null, -1])("fails closed when the runtime trigger history age bound is %s", (maxAgeMs) => {
+    const triggerInput = JSON.parse(JSON.stringify({
       messages: [
         { parts: [{ text: "one", type: "text" }], role: "user" },
         { parts: [{ text: "two", type: "text" }], role: "assistant" },
       ],
-      triggerHistory: { maxAgeMs: null, maxMessages: 20, source: "thread" } as unknown as AgentChatMessageTriggerInput["triggerHistory"],
-    })
+      triggerHistory: { maxAgeMs, maxMessages: 20, source: "thread" },
+    }))
+    const result = createChatMessageTriggerInput({}, triggerInput)
 
     expect(result.input.messages?.map(message => message.parts
       .filter((part): part is { text: string, type: "text" } => part.type === "text")

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -184,19 +184,6 @@ describe("chat message trigger input", () => {
     expect(result.input.messages?.at(-1)?.role).toBe("user")
   })
 
-  it("fails closed when a runtime trigger history age is malformed", () => {
-    const result = createChatMessageTriggerInput({}, {
-      messages: [
-        { parts: [{ text: "stale", type: "text" }], role: "assistant" },
-        { parts: [{ text: "current", type: "text" }], role: "user" },
-      ],
-      // SAFETY: this regression passes malformed JSON-reachable input through the public runtime boundary.
-      triggerHistory: { maxAgeMs: null, maxMessages: 20, source: "thread" } as never,
-    })
-
-    expect(result.input.messages?.map(message => message.role)).toEqual(["user"])
-  })
-
   it("keeps stateless trigger history explicit", () => {
     const result = createChatMessageTriggerInput({
       threadHistory: { maxMessages: 10 },

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -184,6 +184,19 @@ describe("chat message trigger input", () => {
     expect(result.input.messages?.at(-1)?.role).toBe("user")
   })
 
+  it("fails closed when a runtime trigger history age is malformed", () => {
+    const result = createChatMessageTriggerInput({}, {
+      messages: [
+        { parts: [{ text: "stale", type: "text" }], role: "assistant" },
+        { parts: [{ text: "current", type: "text" }], role: "user" },
+      ],
+      // SAFETY: this regression passes malformed JSON-reachable input through the public runtime boundary.
+      triggerHistory: { maxAgeMs: null, maxMessages: 20, source: "thread" } as never,
+    })
+
+    expect(result.input.messages?.map(message => message.role)).toEqual(["user"])
+  })
+
   it("keeps stateless trigger history explicit", () => {
     const result = createChatMessageTriggerInput({
       threadHistory: { maxMessages: 10 },

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -187,8 +187,8 @@ describe("chat message trigger input", () => {
   it.each([null, -1])("fails closed when the runtime trigger history age bound is %s", (maxAgeMs) => {
     const triggerInput = JSON.parse(JSON.stringify({
       messages: [
-        { parts: [{ text: "one", type: "text" }], role: "user" },
-        { parts: [{ text: "two", type: "text" }], role: "assistant" },
+        { createdAt: "2026-08-29T22:00:00.000Z", parts: [{ text: "one", type: "text" }], role: "user" },
+        { createdAt: "2026-08-29T22:00:00.000Z", parts: [{ text: "two", type: "text" }], role: "assistant" },
       ],
       triggerHistory: { maxAgeMs, maxMessages: 20, source: "thread" },
     }))

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -118,7 +118,21 @@ describe("chat message trigger input", () => {
     expect(resolveChatSessionId(messages, { idleTimeoutMs: 60_000, strategy: "hybrid" })).toBe("conversation-a:idle:m2")
   })
 
-  it("derives trigger history from explicit thread history", () => {
+  it("keeps trigger history current-only when omitted", () => {
+    const result = createChatMessageTriggerInput({}, {
+      messages: [
+        { parts: [{ text: "one", type: "text" }], role: "user" },
+        { parts: [{ text: "two", type: "text" }], role: "assistant" },
+      ],
+    })
+
+    expect(result.input.messages?.map(message => message.parts
+      .filter((part): part is { text: string, type: "text" } => part.type === "text")
+      .map(part => part.text)
+      .join(""))).toEqual(["two"])
+  })
+
+  it("does not derive trigger history from thread history", () => {
     const result = createChatMessageTriggerInput({
       threadHistory: { maxMessages: 2 },
     }, {
@@ -132,10 +146,10 @@ describe("chat message trigger input", () => {
     expect(result.input.messages?.map(message => message.parts
       .filter((part): part is { text: string, type: "text" } => part.type === "text")
       .map(part => part.text)
-      .join(""))).toEqual(["two", "three"])
+      .join(""))).toEqual(["three"])
   })
 
-  it("lets trigger history override derived thread history", () => {
+  it("uses an explicit trigger history window", () => {
     const result = createChatMessageTriggerInput({
       threadHistory: { maxMessages: 10 },
       triggerHistory: { maxMessages: 1, source: "thread" },
@@ -150,6 +164,24 @@ describe("chat message trigger input", () => {
       .filter((part): part is { text: string, type: "text" } => part.type === "text")
       .map(part => part.text)
       .join(""))).toEqual(["two"])
+  })
+
+  it("keeps only the contiguous recent trigger history", () => {
+    const result = createChatMessageTriggerInput({
+      triggerHistory: { maxAgeMs: 30 * 60 * 1_000, maxMessages: 20, source: "thread" },
+    }, {
+      messages: [
+        { createdAt: "2026-08-29T20:00:00.000Z", parts: [{ text: "old", type: "text" }], role: "user" },
+        { createdAt: "2026-08-29T21:55:00.000Z", parts: [{ text: "recent", type: "text" }], role: "assistant" },
+        { createdAt: "2026-08-29T22:00:00.000Z", parts: [{ text: "latest", type: "text" }], role: "user" },
+      ],
+    })
+
+    expect(result.input.messages?.map(message => message.parts
+      .filter((part): part is { text: string, type: "text" } => part.type === "text")
+      .map(part => part.text)
+      .join(""))).toEqual(["recent", "latest"])
+    expect(result.input.messages?.at(-1)?.role).toBe("user")
   })
 
   it("keeps stateless trigger history explicit", () => {
@@ -375,7 +407,9 @@ describe("chat message trigger input", () => {
   })
 
   it("drops incomplete UI tool calls from follow-up history", () => {
-    const result = createChatMessageTriggerInput({}, {
+    const result = createChatMessageTriggerInput({
+      triggerHistory: { maxMessages: 2, source: "thread" },
+    }, {
       messages: [
         {
           parts: [

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -200,6 +200,22 @@ describe("chat message trigger input", () => {
       .join(""))).toEqual(["two"])
   })
 
+  it("treats an explicitly undefined trigger history age bound as omitted", () => {
+    const result = createChatMessageTriggerInput({
+      triggerHistory: { maxAgeMs: undefined, maxMessages: 20, source: "thread" },
+    }, {
+      messages: [
+        { parts: [{ text: "one", type: "text" }], role: "user" },
+        { parts: [{ text: "two", type: "text" }], role: "assistant" },
+      ],
+    })
+
+    expect(result.input.messages?.map(message => message.parts
+      .filter((part): part is { text: string, type: "text" } => part.type === "text")
+      .map(part => part.text)
+      .join(""))).toEqual(["one", "two"])
+  })
+
   it("keeps stateless trigger history explicit", () => {
     const result = createChatMessageTriggerInput({
       threadHistory: { maxMessages: 10 },

--- a/packages/agent/test/discovery.test.ts
+++ b/packages/agent/test/discovery.test.ts
@@ -539,7 +539,7 @@ describe("agent chat capability discovery", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { agentInvocationStreamHeader, agentInvocationStreamHeaderValue, agentInvocationStreamRoute } = await import("../src/invocation-stream.ts")
     const agent = defineAgent({
-      capabilities: [chat()],
+      capabilities: [chat({ triggerHistory: { maxMessages: 3, source: "thread" } })],
       driver: {
         run: ({ messages }) => messages.map(message => `${message.role}:${getMessageText(message)}`).join(" | "),
       },
@@ -582,7 +582,7 @@ describe("agent chat capability discovery", () => {
       { type: "finish" },
       { type: "done" },
     ])
-  })
+  }, 10_000)
 
   it("runs invocation-resolved Capability CLI commands through the Vite endpoint", async () => {
     const root = await createTempRoot("vitehub-agent-invocation-stream-cli-")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17481,7 +17481,7 @@ describe("server helpers", () => {
           const thread = createThread(...arguments_)
           const history = Reflect.get(thread, "_threadHistory") as { getMessages(threadId: string, limit?: number): Promise<Message[]> }
           vi.spyOn(history, "getMessages").mockResolvedValue([
-            message("19-same-time", "same-time previous", "2026-06-10T12:00:20.000Z"),
+            idLessMessage("same-time previous", "2026-06-10T12:00:20.000Z"),
             idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z"),
             message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
             message("20", "current", "2026-06-10T12:00:20.000Z"),

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17390,7 +17390,7 @@ describe("server helpers", () => {
     expect(adapter.postMessage).toHaveBeenCalledWith("telegram:456", { markdown: "generated ok" })
   })
 
-  it("derives trigger history from thread history in chat webhook runs", async () => {
+  it("does not derive trigger history from thread history in chat webhook runs", async () => {
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { defineAgent } = await import("../src/index.ts")
     const { getMessageText } = await import("../src/messages.ts")
@@ -17438,7 +17438,7 @@ describe("server helpers", () => {
     await expect(handler(request(20, "remember BROWSER-HISTORY"), "telegram")).resolves.toMatchObject({ status: 200 })
     await expect(handler(request(21, "what marker did I ask you to remember?"), "telegram")).resolves.toMatchObject({ status: 200 })
 
-    expect(runs).toEqual([["remember BROWSER-HISTORY"], ["remember BROWSER-HISTORY", "reply 1", "what marker did I ask you to remember?"]])
+    expect(runs).toEqual([["remember BROWSER-HISTORY"], ["what marker did I ask you to remember?"]])
   })
 
   it("exports authenticated Channel history with attachment data", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17453,8 +17453,8 @@ describe("server helpers", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { getMessageText } = await import("../src/messages.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
-    const message = (id: string, text: string, date: string) => new Message({
-      attachments: [],
+    const message = (id: string, text: string, date: string, attachments: Message["attachments"] = []) => new Message({
+      attachments,
       author: { fullName: "Maxi", isBot: false, isMe: false, userId: "123", userName: "maxi" },
       formatted: { children: [], type: "root" },
       id,
@@ -17463,6 +17463,7 @@ describe("server helpers", () => {
       text,
       threadId: "telegram:456",
     })
+    const oldAttachmentFetch = vi.fn(async () => Buffer.from("old context"))
     const idLessMessage = (text: string, date: string) => {
       const result = message("id-less", text, date)
       Reflect.deleteProperty(result, "id")
@@ -17525,11 +17526,21 @@ describe("server helpers", () => {
     await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_860), "telegram")).resolves.toMatchObject({ status: 200 })
     adapter.fetchMessages.mockResolvedValue({
       messages: [
+        ...Array.from({ length: 10 }, (_, index) =>
+          message(String(index + 100), `old ${index}`, `2026-06-10T12:00:${String(index).padStart(2, "0")}.000Z`, [
+            {
+              fetchData: oldAttachmentFetch,
+              mimeType: "text/plain",
+              name: `old-${index}.txt`,
+              size: 11,
+              type: "file",
+            },
+          ]),
+        ),
         message("19", "previous", "2026-06-10T12:00:19.000Z"),
-        message("20", "current", "2026-06-10T12:00:20.000Z"),
         message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
         idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z"),
-        ...Array.from({ length: 997 }, (_, index) =>
+        ...Array.from({ length: 987 }, (_, index) =>
           message(String(index + 100), `newer cached ${index}`, "2026-06-10T12:01:00.000Z"),
         ),
       ],
@@ -17537,6 +17548,7 @@ describe("server helpers", () => {
     await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
 
     expect(runs).toEqual([["newer cached"], ["previous", "newer id-less cached", "current"]])
+    expect(oldAttachmentFetch).toHaveBeenCalledOnce()
   })
 
   it("exports authenticated Channel history with attachment data", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17825,6 +17825,56 @@ describe("server helpers", () => {
     expect(runs).toEqual([["nearest id-less", "current id-less"]])
   })
 
+  it("keeps distinct durable id-less messages with the current fingerprint", async () => {
+    const { telegram } = await import("../src/channels.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { getMessageText } = await import("../src/messages.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter({
+      bypassIdLessMessageDedupe: true,
+      missingIncomingMessageId: true,
+      persistThreadHistory: true,
+    })
+    const runs: string[][] = []
+    const agent = defineAgent({
+      channels: {
+        // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
+        telegram: testTelegram(telegram, { adapter: () => adapter as never }),
+      },
+      driver: {
+        run: ({ messages }) => {
+          runs.push(messages.map(getMessageText))
+          return "ok"
+        },
+      },
+      messages: {
+        stream: false,
+        triggerHistory: { maxMessages: 3, source: "thread" },
+      },
+    })
+    // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
+    const handler = createChannelWebhookRouteHandler(agent as never)
+    const request = (text: string) =>
+      new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+        body: JSON.stringify({
+          update_id: 22,
+          message: {
+            chat: { id: 456, type: "private" },
+            date: 1_781_092_822,
+            from: { first_name: "Maxi", id: 123, username: "maxi" },
+            text,
+          },
+        }),
+        method: "POST",
+      })
+
+    await expect(handler(request("current id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
+    await expect(handler(request("intervening id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
+    await expect(handler(request("current id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
+
+    expect(runs.at(-1)).toEqual(["current id-less", "intervening id-less", "current id-less"])
+  })
+
   it("does not run id-less chat deliveries without current message parts", async () => {
     const { telegram } = await import("../src/channels.ts")
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17482,7 +17482,7 @@ describe("server helpers", () => {
           // SAFETY: createThread returns Chat SDK's internal ThreadImpl, which owns this history cache.
           const history = Reflect.get(thread, "_threadHistory") as { getMessages(threadId: string, limit?: number): Promise<Message[]> }
           vi.spyOn(history, "getMessages").mockResolvedValue([
-            idLessMessage("same-time previous", "2026-06-10T12:00:20.000Z"),
+            idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z"),
             message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
             message("20", "current", "2026-06-10T12:00:20.000Z"),
           ])
@@ -17529,11 +17529,14 @@ describe("server helpers", () => {
         message("20", "current", "2026-06-10T12:00:20.000Z"),
         message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
         idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z"),
+        ...Array.from({ length: 997 }, (_, index) =>
+          message(String(index + 100), `newer cached ${index}`, "2026-06-10T12:01:00.000Z"),
+        ),
       ],
     })
     await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
 
-    expect(runs).toEqual([["newer cached"], ["previous", "same-time previous", "current"]])
+    expect(runs).toEqual([["newer cached"], ["previous", "newer id-less cached", "current"]])
   })
 
   it("exports authenticated Channel history with attachment data", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17495,18 +17495,23 @@ describe("server helpers", () => {
     await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_860), "telegram")).resolves.toMatchObject({ status: 200 })
     const chat = adapter._chatInstance()
     if (!chat) throw new Error("Expected the webhook to initialize Chat.")
-    // SAFETY: This fixture accesses the Chat SDK's internal thread cache to model an adapter restart.
-    const chatBoundary = chat as unknown as { thread(threadId: string): object }
-    const thread = chatBoundary.thread("telegram:456")
     adapter.fetchMessages.mockResolvedValue({ messages: [message("19", "previous", "2026-06-10T12:00:19.000Z")] })
-    Reflect.set(thread, "_threadHistory", {
-      getMessages: vi.fn(async () => [
-        message("19-same-time", "same-time previous", "2026-06-10T12:00:20.000Z"),
-        message("20", "current", "2026-06-10T12:00:20.000Z"),
-        message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
-      ]),
+    // SAFETY: This fixture intercepts Chat SDK's internal webhook thread factory to model an adapter restart.
+    const chatBoundary = chat as unknown as {
+      createThread(adapter: Adapter, threadId: string, initialMessage: Message, isSubscribedContext?: boolean): object
+    }
+    const createThread = chatBoundary.createThread.bind(chatBoundary)
+    vi.spyOn(chatBoundary, "createThread").mockImplementation((...arguments_) => {
+      const thread = createThread(...arguments_)
+      Reflect.set(thread, "_threadHistory", {
+        getMessages: vi.fn(async () => [
+          message("19-same-time", "same-time previous", "2026-06-10T12:00:20.000Z"),
+          message("20", "current", "2026-06-10T12:00:20.000Z"),
+          message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
+        ]),
+      })
+      return thread
     })
-    vi.spyOn(chatBoundary, "thread").mockReturnValue(thread)
     await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
 
     expect(runs).toEqual([["newer cached"], ["previous", "same-time previous", "current"]])

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -12914,6 +12914,7 @@ describe("server helpers", () => {
     const adapter = createTestChatAdapter({
       bypassIdLessMessageDedupe: true,
       missingIncomingMessageId: true,
+      persistThreadHistory: true,
     })
     const sharedHistory = new Message({
       attachments: [],
@@ -17951,7 +17952,7 @@ describe("server helpers", () => {
         body: JSON.stringify({
           update_id: updateId,
           message: {
-            chat: { id: 456, type: "private" },
+            chat: { id: 457, type: "private" },
             date: 1_781_092_822,
             from: { first_name: "Maxi", id: 123, username: "maxi" },
             text,

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17519,8 +17519,10 @@ describe("server helpers", () => {
       capabilities: [
         defineChatCapability({
           platforms: { telegram: () => platformAdapter },
+          sessions: { idleTimeoutMs: 60_000, strategy: "idle-timeout" },
           stream: false,
-          triggerHistory: { maxAgeMs: 30_000, maxMessages: 3, source: "thread" },
+          threadHistory: {},
+          triggerHistory: { maxMessages: 3, source: "thread" },
           webhooks: { telegram: {} },
         }),
       ],

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17498,9 +17498,9 @@ describe("server helpers", () => {
     adapter.fetchMessages.mockResolvedValue({ messages: [message("19", "previous", "2026-06-10T12:00:19.000Z")] })
     Reflect.set(thread ?? {}, "_threadHistory", {
       getMessages: vi.fn(async () => [
-        message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
-        message("20", "current", "2026-06-10T12:00:20.000Z"),
         message("19-same-time", "same-time previous", "2026-06-10T12:00:20.000Z"),
+        message("20", "current", "2026-06-10T12:00:20.000Z"),
+        message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
       ]),
     })
     await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17856,10 +17856,10 @@ describe("server helpers", () => {
     })
     // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
     const handler = createChannelWebhookRouteHandler(agent as never)
-    const request = (text: string) =>
+    const request = (updateId: number, text: string) =>
       new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
         body: JSON.stringify({
-          update_id: 22,
+          update_id: updateId,
           message: {
             chat: { id: 456, type: "private" },
             date: 1_781_092_822,
@@ -17870,9 +17870,9 @@ describe("server helpers", () => {
         method: "POST",
       })
 
-    await expect(handler(request("current id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
-    await expect(handler(request("intervening id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
-    await expect(handler(request("current id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
+    await expect(handler(request(20, "current id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
+    await expect(handler(request(21, "intervening id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
+    await expect(handler(request(22, "current id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
 
     expect(runs.at(-1)).toEqual(["current id-less", "ok", "intervening id-less", "ok", "current id-less"])
   })
@@ -17990,7 +17990,6 @@ describe("server helpers", () => {
         status: 200,
       })
       const resetAdapter = createTestChatAdapter({ persistThreadHistory: true })
-      resetAdapter.fetchMessages.mockResolvedValue({ messages: [] })
       await expect(handler(resetAdapter)(request(31, "what marker did I ask you to remember?"), "telegram")).resolves.toMatchObject({ status: 200 })
 
       expect(runs).toEqual([["remember DEPLOY-HISTORY"], ["remember DEPLOY-HISTORY", "reply 1", "what marker did I ask you to remember?"]])

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17423,6 +17423,7 @@ describe("server helpers", () => {
       driver: {
         run: ({ input, messages }) => {
           runs.push(messages.map(getMessageText))
+          // SAFETY: The Chat runtime stores its resolved session identifier as a string in this context field.
           sessionIds.push(input.context?.["chat.sessionId"] as string | undefined)
           return `reply ${runs.length}`
         },
@@ -17849,8 +17850,9 @@ describe("server helpers", () => {
       deserializedCurrent.metadata.dateSent = new Date("2026-06-10T12:00:22.000Z")
       Reflect.deleteProperty(deserializedCurrent, "id")
       newer.text = "newer id-less"
-      for (const item of [previous, nearest, deserializedCurrent, newer]) item.raw = { delivery: "same" }
-      return { messages: [previous, nearest, deserializedCurrent, newer] }
+      const future = Array.from({ length: 998 }, (_, index) => historicalMessage(`future id-less ${index}`))
+      for (const item of [previous, nearest, deserializedCurrent, newer, ...future]) item.raw = { delivery: "same" }
+      return { messages: [previous, nearest, deserializedCurrent, newer, ...future] }
     })
     const runs: string[][] = []
     const agent = defineAgent({

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17485,7 +17485,7 @@ describe("server helpers", () => {
       onInitialize: (chat) => {
         if (++initializedChats !== 2) return
         // SAFETY: This fixture intercepts Chat SDK's internal webhook thread factory to model an adapter restart.
-        const chatBoundary = chat as {
+        const chatBoundary = chat as unknown as {
           createThread(adapter: Adapter, threadId: string, initialMessage: Message, isSubscribedContext?: boolean): object
         }
         const createThread = chatBoundary.createThread.bind(chatBoundary)

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17473,16 +17473,16 @@ describe("server helpers", () => {
       onInitialize: (chat) => {
         if (++initializedChats !== 2) return
         // SAFETY: This fixture intercepts Chat SDK's internal webhook thread factory to model an adapter restart.
-        const chatBoundary = chat as unknown as {
+        const chatBoundary = chat as {
           createThread(adapter: Adapter, threadId: string, initialMessage: Message, isSubscribedContext?: boolean): object
         }
         const createThread = chatBoundary.createThread.bind(chatBoundary)
         vi.spyOn(chatBoundary, "createThread").mockImplementation((...arguments_) => {
           const thread = createThread(...arguments_)
+          // SAFETY: createThread returns Chat SDK's internal ThreadImpl, which owns this history cache.
           const history = Reflect.get(thread, "_threadHistory") as { getMessages(threadId: string, limit?: number): Promise<Message[]> }
           vi.spyOn(history, "getMessages").mockResolvedValue([
             idLessMessage("same-time previous", "2026-06-10T12:00:20.000Z"),
-            idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z"),
             message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
             message("20", "current", "2026-06-10T12:00:20.000Z"),
           ])

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17797,7 +17797,11 @@ describe("server helpers", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { getMessageText } = await import("../src/messages.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
-    const adapter = createTestChatAdapter({ missingIncomingMessageId: true })
+    const adapter = createTestChatAdapter({
+      bypassIdLessMessageDedupe: true,
+      missingIncomingMessageId: true,
+      persistThreadHistory: true,
+    })
     const historicalMessage = (text: string) => new Message({
       attachments: [],
       author: {
@@ -17848,26 +17852,24 @@ describe("server helpers", () => {
     })
     // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
     const handler = createChannelWebhookRouteHandler(agent as never)
-
-    await expect(
-      handler(
-        new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
-          body: JSON.stringify({
-            update_id: 22,
-            message: {
-              chat: { id: 456, type: "private" },
-              date: 1781092822,
-              from: { first_name: "Maxi", id: 123, username: "maxi" },
-              text: "current id-less",
-            },
-          }),
-          method: "POST",
+    const request = (updateId: number, text: string, date: number) =>
+      new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+        body: JSON.stringify({
+          update_id: updateId,
+          message: {
+            chat: { id: 456, type: "private" },
+            date,
+            from: { first_name: "Maxi", id: 123, username: "maxi" },
+            text,
+          },
         }),
-        "telegram",
-      ),
-    ).resolves.toMatchObject({ status: 200 })
+        method: "POST",
+      })
 
-    expect(runs).toEqual([["nearest id-less", "current id-less"]])
+    await expect(handler(request(23, "newer id-less", 1_781_092_823), "telegram")).resolves.toMatchObject({ status: 200 })
+    await expect(handler(request(22, "current id-less", 1_781_092_822), "telegram")).resolves.toMatchObject({ status: 200 })
+
+    expect(runs).toEqual([["newer id-less"], ["nearest id-less", "current id-less"]])
   })
 
   it("keeps distinct durable id-less messages with the current fingerprint", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17748,13 +17748,13 @@ describe("server helpers", () => {
     await rm(stateDir, { force: true, recursive: true })
   }, 15_000)
 
-  it("keeps fetched thread history when the current chat message has no id", async () => {
+  it("bounds fetched thread history when the current chat message has no id", async () => {
     const { telegram } = await import("../src/channels.ts")
     const { defineAgent } = await import("../src/index.ts")
     const { getMessageText } = await import("../src/messages.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter({ missingIncomingMessageId: true })
-    const historicalMessage = new Message({
+    const historicalMessage = (text: string) => new Message({
       attachments: [],
       author: {
         fullName: "Maxi",
@@ -17767,12 +17767,15 @@ describe("server helpers", () => {
       id: "missing-id",
       metadata: { dateSent: new Date("2026-06-10T12:00:00.000Z"), edited: false },
       raw: {},
-      text: "previous id-less",
+      text,
       threadId: "telegram:456",
     })
-    Reflect.deleteProperty(historicalMessage, "id")
+    const previous = historicalMessage("previous id-less")
+    const nearest = historicalMessage("nearest id-less")
+    Reflect.deleteProperty(previous, "id")
+    Reflect.deleteProperty(nearest, "id")
     adapter.fetchMessages.mockResolvedValue({
-      messages: [historicalMessage],
+      messages: [previous, nearest],
     })
     const runs: string[][] = []
     const agent = defineAgent({
@@ -17788,7 +17791,7 @@ describe("server helpers", () => {
       },
       messages: {
         stream: false,
-        triggerHistory: { maxMessages: 10, source: "thread" },
+        triggerHistory: { maxMessages: 2, source: "thread" },
       },
     })
     // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
@@ -17812,7 +17815,7 @@ describe("server helpers", () => {
       ),
     ).resolves.toMatchObject({ status: 200 })
 
-    expect(runs).toEqual([["previous id-less", "current id-less"]])
+    expect(runs).toEqual([["nearest id-less", "current id-less"]])
   })
 
   it("does not run id-less chat deliveries without current message parts", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17402,7 +17402,8 @@ describe("server helpers", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { getMessageText } = await import("../src/messages.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
-    const adapter = createTestChatAdapter({ persistThreadHistory: true })
+    const attachmentFetchData = vi.fn(async () => Buffer.from("session-only attachment"))
+    const adapter = createTestChatAdapter({ attachmentFetchData, persistThreadHistory: true })
     const runs: string[][] = []
     const sessionIds: Array<string | undefined> = []
     const agent = defineAgent({
@@ -17431,7 +17432,7 @@ describe("server helpers", () => {
     })
     // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
     const handler = createChannelWebhookRouteHandler(agent as never)
-    const request = (messageId: number, text: string) =>
+    const request = (messageId: number, text: string, withAttachment = false) =>
       new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
         body: JSON.stringify({
           update_id: messageId,
@@ -17441,15 +17442,20 @@ describe("server helpers", () => {
             from: { first_name: "Maxi", id: 123, username: "maxi" },
             message_id: messageId,
             text,
+            ...(withAttachment
+              ? { document: { content: "session-only attachment", file_name: "context.txt", mime_type: "text/plain" } }
+              : {}),
           },
         }),
         method: "POST",
       })
 
-    await expect(handler(request(20, "remember BROWSER-HISTORY"), "telegram")).resolves.toMatchObject({ status: 200 })
+    await expect(handler(request(20, "remember BROWSER-HISTORY", true), "telegram")).resolves.toMatchObject({ status: 200 })
     await expect(handler(request(21, "what marker did I ask you to remember?"), "telegram")).resolves.toMatchObject({ status: 200 })
 
-    expect(runs).toEqual([["remember BROWSER-HISTORY"], ["what marker did I ask you to remember?"]])
+    expect(runs[0]?.[0]).toContain("remember BROWSER-HISTORY")
+    expect(runs[1]).toEqual(["what marker did I ask you to remember?"])
+    expect(attachmentFetchData).toHaveBeenCalledOnce()
     expect(sessionIds[1]).toBe(sessionIds[0])
   })
 

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -116,6 +116,7 @@ function createTestChatAdapter(
 ) {
   let chatInstance: ChatInstance | undefined
   let idLessMessageSequence = 0
+  let latestIncomingDate = new Date("2026-06-10T12:00:00.000Z")
   let sentMessageId = 0
   const cachedMessages = new Map<string, Message[]>()
   const cacheMessage = (message: Message) => {
@@ -172,6 +173,7 @@ function createTestChatAdapter(
         | undefined
       const photo = photos?.at(-1)
       const date = isRuntimeNumber(rawMessage.date) ? new Date(rawMessage.date * 1000) : new Date("2026-06-10T12:00:00.000Z")
+      latestIncomingDate = date
       const message = new Message({
         attachments: rawMessage.audio
           ? [
@@ -293,7 +295,7 @@ function createTestChatAdapter(
           },
           formatted: { children: [], type: "root" },
           id,
-          metadata: { dateSent: new Date("2026-06-10T12:00:00.000Z"), edited: false },
+          metadata: { dateSent: latestIncomingDate, edited: false },
           raw: { message },
           text: isRuntimeString(message)
             ? message

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17406,6 +17406,7 @@ describe("server helpers", () => {
     const adapter = createTestChatAdapter({ attachmentFetchData, persistThreadHistory: true })
     const runs: string[][] = []
     const sessionIds: Array<string | undefined> = []
+    const invokerSessionIds: Array<string | undefined> = []
     const agent = defineAgent({
       capabilities: [
         defineChatCapability({
@@ -17421,6 +17422,12 @@ describe("server helpers", () => {
           },
         }),
       ],
+      invoker: {
+        resolve: ({ context, defaultInvoker }) => {
+          invokerSessionIds.push(context.get("chat.sessionId"))
+          return defaultInvoker
+        },
+      },
       driver: {
         run: ({ input, messages }) => {
           runs.push(messages.map(getMessageText))
@@ -17457,6 +17464,7 @@ describe("server helpers", () => {
     expect(runs[1]).toEqual(["what marker did I ask you to remember?"])
     expect(attachmentFetchData).toHaveBeenCalledOnce()
     expect(sessionIds[1]).toBe(sessionIds[0])
+    expect(invokerSessionIds).toEqual(sessionIds)
   })
 
   it("ends explicit trigger history at the webhook message", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17495,7 +17495,10 @@ describe("server helpers", () => {
     await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_860), "telegram")).resolves.toMatchObject({ status: 200 })
     const thread = adapter._chatInstance()?.thread("telegram:456")
     Reflect.set(thread ?? {}, "_threadHistory", {
-      getMessages: vi.fn(async () => [message("21", "newer cached", "2026-06-10T12:00:20.000Z")]),
+      getMessages: vi.fn(async () => [
+        message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
+        message("20", "current", "2026-06-10T12:00:20.000Z"),
+      ]),
     })
     await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
 
@@ -17787,10 +17790,13 @@ describe("server helpers", () => {
     const newer = historicalMessage("current id-less")
     newer.metadata.dateSent = new Date("2026-06-10T12:00:22.000Z")
     Reflect.deleteProperty(newer, "id")
-    adapter.fetchMessages.mockImplementation(async (threadId: string) => {
-      const cached = adapter._cachedMessages(threadId)
-      for (const item of [previous, nearest, ...cached, newer]) item.raw = { delivery: "same" }
-      return { messages: [previous, nearest, ...cached, newer] }
+    adapter.fetchMessages.mockImplementation(async () => {
+      const deserializedCurrent = historicalMessage("current id-less")
+      deserializedCurrent.metadata.dateSent = new Date("2026-06-10T12:00:22.000Z")
+      Reflect.deleteProperty(deserializedCurrent, "id")
+      newer.text = "newer id-less"
+      for (const item of [previous, nearest, deserializedCurrent, newer]) item.raw = { delivery: "same" }
+      return { messages: [previous, nearest, deserializedCurrent, newer] }
     })
     const runs: string[][] = []
     const agent = defineAgent({

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -324,11 +324,12 @@ function createTitleChatAdapter(setThreadTitle: (threadId: string, title: string
   return Object.assign(createTestChatAdapter(), { setThreadTitle })
 }
 
-function chatWebhookRequest(messageId: number, threadId = 456, text = "hello") {
+function chatWebhookRequest(messageId: number, threadId = 456, text = "hello", date?: number) {
   return new Request("https://example.com/api/_vitehub/agents/support/webhooks/channel", {
     body: JSON.stringify({
       message: {
         chat: { id: threadId, type: "private" },
+        ...(date === undefined ? {} : { date }),
         from: { id: 123, username: "maxi" },
         message_id: messageId,
         text,
@@ -17487,8 +17488,8 @@ describe("server helpers", () => {
     // SAFETY: defineAgent returns the runtime shape required by the internal webhook route fixture.
     const handler = createChannelWebhookRouteHandler(agent as never)
 
-    await expect(handler(chatWebhookRequest(21, 456, "newer cached"), "telegram")).resolves.toMatchObject({ status: 200 })
-    await expect(handler(chatWebhookRequest(20, 456, "current"), "telegram")).resolves.toMatchObject({ status: 200 })
+    await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_860), "telegram")).resolves.toMatchObject({ status: 200 })
+    await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
 
     expect(runs).toEqual([["newer cached"], ["previous", "current"]])
   })
@@ -17776,6 +17777,7 @@ describe("server helpers", () => {
     Reflect.deleteProperty(previous, "id")
     Reflect.deleteProperty(nearest, "id")
     const includedCurrent = historicalMessage("current id-less")
+    includedCurrent.metadata.dateSent = new Date("2026-06-10T12:00:22.000Z")
     Reflect.deleteProperty(includedCurrent, "id")
     const newer = historicalMessage("newer id-less")
     Reflect.deleteProperty(newer, "id")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17849,7 +17849,7 @@ describe("server helpers", () => {
       },
       messages: {
         stream: false,
-        triggerHistory: { maxMessages: 3, source: "thread" },
+        triggerHistory: { maxMessages: 5, source: "thread" },
       },
     })
     // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
@@ -17872,7 +17872,7 @@ describe("server helpers", () => {
     await expect(handler(request("intervening id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
     await expect(handler(request("current id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
 
-    expect(runs.at(-1)).toEqual(["current id-less", "intervening id-less", "current id-less"])
+    expect(runs.at(-1)).toEqual(["current id-less", "ok", "intervening id-less", "ok", "current id-less"])
   })
 
   it("does not run id-less chat deliveries without current message parts", async () => {
@@ -17944,6 +17944,7 @@ describe("server helpers", () => {
     const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-history-state-"))
     const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
     const runs: string[][] = []
+    const currentMetadata: unknown[] = []
     const request = (messageId: number, text: string) =>
       new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
         body: JSON.stringify({
@@ -17967,6 +17968,7 @@ describe("server helpers", () => {
         driver: {
           run: ({ messages }) => {
             runs.push(messages.map(getMessageText))
+            currentMetadata.push(messages.at(-1)?.metadata)
             return `reply ${runs.length}`
           },
         },
@@ -17985,11 +17987,17 @@ describe("server helpers", () => {
       await expect(handler(createTestChatAdapter({ persistThreadHistory: true }))(request(30, "remember DEPLOY-HISTORY"), "telegram")).resolves.toMatchObject({
         status: 200,
       })
-      await expect(
-        handler(createTestChatAdapter({ persistThreadHistory: true }))(request(31, "what marker did I ask you to remember?"), "telegram"),
-      ).resolves.toMatchObject({ status: 200 })
+      const resetAdapter = createTestChatAdapter({ persistThreadHistory: true })
+      resetAdapter.fetchMessages.mockResolvedValue({ messages: [] })
+      await expect(handler(resetAdapter)(request(31, "what marker did I ask you to remember?"), "telegram")).resolves.toMatchObject({ status: 200 })
 
       expect(runs).toEqual([["remember DEPLOY-HISTORY"], ["remember DEPLOY-HISTORY", "reply 1", "what marker did I ask you to remember?"]])
+      expect(currentMetadata.at(-1)).toMatchObject({
+        chat: {
+          messageId: "31",
+          platform: { channelId: "telegram:456", threadId: "telegram:456" },
+        },
+      })
     } finally {
       await rm(stateDir, { force: true, recursive: true })
     }

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17480,12 +17480,14 @@ describe("server helpers", () => {
       Reflect.deleteProperty(result, "id")
       return result
     }
+    const sharedIdLessMessage = idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z")
     let initializedChats = 0
     const adapter = createTestChatAdapter({
       onInitialize: (chat) => {
         if (++initializedChats !== 2) return
+        const unknownChat: unknown = chat
         // SAFETY: This fixture intercepts Chat SDK's internal webhook thread factory to model an adapter restart.
-        const chatBoundary = chat as unknown as {
+        const chatBoundary = unknownChat as {
           createThread(adapter: Adapter, threadId: string, initialMessage: Message, isSubscribedContext?: boolean): object
         }
         const createThread = chatBoundary.createThread.bind(chatBoundary)
@@ -17494,7 +17496,7 @@ describe("server helpers", () => {
           // SAFETY: createThread returns Chat SDK's internal ThreadImpl, which owns this history cache.
           const history = Reflect.get(thread, "_threadHistory") as { getMessages(threadId: string, limit?: number): Promise<Message[]> }
           vi.spyOn(history, "getMessages").mockResolvedValue([
-            idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z"),
+            sharedIdLessMessage,
             message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
             message("20", "current", "2026-06-10T12:00:20.000Z"),
           ])
@@ -17508,7 +17510,7 @@ describe("server helpers", () => {
         message("19", "previous", "2026-06-10T12:00:19.000Z"),
         message("20", "current", "2026-06-10T12:00:20.000Z"),
         message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
-        idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z"),
+        sharedIdLessMessage,
         message("22", "newest cached", "2026-06-10T12:02:00.000Z"),
       ],
     })
@@ -17552,7 +17554,7 @@ describe("server helpers", () => {
         ),
         message("19", "previous", "2026-06-10T12:00:19.000Z"),
         message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
-        idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z"),
+        sharedIdLessMessage,
         ...Array.from({ length: 987 }, (_, index) =>
           message(String(index + 100), `newer cached ${index}`, "2026-06-10T12:01:00.000Z"),
         ),
@@ -17560,7 +17562,10 @@ describe("server helpers", () => {
     })
     await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
 
-    expect(runs).toEqual([["newer cached"], ["previous", "newer id-less cached", "current"]])
+    expect(runs).toEqual([
+      ["previous", "current", "newer cached"],
+      ["previous", "newer id-less cached", "current"],
+    ])
     expect(oldAttachmentFetch).not.toHaveBeenCalled()
   })
 

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17774,8 +17774,10 @@ describe("server helpers", () => {
     const nearest = historicalMessage("nearest id-less")
     Reflect.deleteProperty(previous, "id")
     Reflect.deleteProperty(nearest, "id")
+    const includedCurrent = historicalMessage("current id-less")
+    Reflect.deleteProperty(includedCurrent, "id")
     adapter.fetchMessages.mockResolvedValue({
-      messages: [previous, nearest],
+      messages: [previous, nearest, includedCurrent],
     })
     const runs: string[][] = []
     const agent = defineAgent({

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17478,7 +17478,7 @@ describe("server helpers", () => {
         defineChatCapability({
           platforms: { telegram: () => platformAdapter },
           stream: false,
-          triggerHistory: { maxAgeMs: 30_000, maxMessages: 2, source: "thread" },
+          triggerHistory: { maxAgeMs: 30_000, maxMessages: 3, source: "thread" },
           webhooks: { telegram: {} },
         }),
       ],
@@ -17493,17 +17493,19 @@ describe("server helpers", () => {
     const handler = createChannelWebhookRouteHandler(agent as never)
 
     await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_860), "telegram")).resolves.toMatchObject({ status: 200 })
-    const thread = adapter._chatInstance()?.thread("telegram:456")
+    // SAFETY: This fixture accesses the Chat SDK's internal thread cache to model an adapter restart.
+    const thread = (adapter._chatInstance() as unknown as { thread(threadId: string): object } | undefined)?.thread("telegram:456")
     adapter.fetchMessages.mockResolvedValue({ messages: [message("19", "previous", "2026-06-10T12:00:19.000Z")] })
     Reflect.set(thread ?? {}, "_threadHistory", {
       getMessages: vi.fn(async () => [
         message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
         message("20", "current", "2026-06-10T12:00:20.000Z"),
+        message("19-same-time", "same-time previous", "2026-06-10T12:00:20.000Z"),
       ]),
     })
     await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
 
-    expect(runs).toEqual([["newer cached"], ["previous", "current"]])
+    expect(runs).toEqual([["newer cached"], ["previous", "same-time previous", "current"]])
   })
 
   it("exports authenticated Channel history with attachment data", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17414,7 +17414,7 @@ describe("server helpers", () => {
           },
           stream: false,
           sessions: { idleTimeoutMs: 60_000, strategy: "idle-timeout" },
-          threadHistory: { maxMessages: 25 },
+          threadHistory: {},
           webhooks: {
             telegram: {},
           },

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17493,6 +17493,11 @@ describe("server helpers", () => {
       return result
     }
     const sharedIdLessMessage = idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z")
+    sharedIdLessMessage.raw = { delivery: "shared-id-less" }
+    const deserializedSharedIdLessMessage = () => Object.assign(
+      idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z"),
+      { raw: { delivery: "shared-id-less" } },
+    )
     let initializedChats = 0
     const adapter = createTestChatAdapter({
       onInitialize: (chat) => {
@@ -17522,7 +17527,7 @@ describe("server helpers", () => {
         message("19", "previous", "2026-06-10T12:00:19.000Z"),
         message("20", "current", "2026-06-10T12:00:20.000Z"),
         message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
-        sharedIdLessMessage,
+        deserializedSharedIdLessMessage(),
         message("22", "newest cached", "2026-06-10T12:02:00.000Z"),
       ],
     })
@@ -17566,7 +17571,7 @@ describe("server helpers", () => {
         ),
         message("19", "previous", "2026-06-10T12:00:19.000Z"),
         message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
-        sharedIdLessMessage,
+        deserializedSharedIdLessMessage(),
         ...Array.from({ length: 987 }, (_, index) =>
           message(String(index + 100), `newer cached ${index}`, "2026-06-10T12:01:00.000Z"),
         ),

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17404,6 +17404,7 @@ describe("server helpers", () => {
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
     const adapter = createTestChatAdapter({ persistThreadHistory: true })
     const runs: string[][] = []
+    const sessionIds: Array<string | undefined> = []
     const agent = defineAgent({
       capabilities: [
         defineChatCapability({
@@ -17412,6 +17413,7 @@ describe("server helpers", () => {
             telegram: () => adapter as never,
           },
           stream: false,
+          sessions: { idleTimeoutMs: 60_000, strategy: "idle-timeout" },
           threadHistory: { maxMessages: 25 },
           webhooks: {
             telegram: {},
@@ -17419,8 +17421,9 @@ describe("server helpers", () => {
         }),
       ],
       driver: {
-        run: ({ messages }) => {
+        run: ({ input, messages }) => {
           runs.push(messages.map(getMessageText))
+          sessionIds.push(input.context?.["chat.sessionId"] as string | undefined)
           return `reply ${runs.length}`
         },
       },
@@ -17446,6 +17449,7 @@ describe("server helpers", () => {
     await expect(handler(request(21, "what marker did I ask you to remember?"), "telegram")).resolves.toMatchObject({ status: 200 })
 
     expect(runs).toEqual([["remember BROWSER-HISTORY"], ["what marker did I ask you to remember?"]])
+    expect(sessionIds[1]).toBe(sessionIds[0])
   })
 
   it("ends explicit trigger history at the webhook message", async () => {
@@ -17527,7 +17531,7 @@ describe("server helpers", () => {
     adapter.fetchMessages.mockResolvedValue({
       messages: [
         ...Array.from({ length: 10 }, (_, index) =>
-          message(String(index + 100), `old ${index}`, `2026-06-10T12:00:${String(index).padStart(2, "0")}.000Z`, [
+          message(String(index + 100), `old ${index}`, `2026-06-10T11:00:${String(index).padStart(2, "0")}.000Z`, [
             {
               fetchData: oldAttachmentFetch,
               mimeType: "text/plain",
@@ -17548,7 +17552,7 @@ describe("server helpers", () => {
     await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
 
     expect(runs).toEqual([["newer cached"], ["previous", "newer id-less cached", "current"]])
-    expect(oldAttachmentFetch).toHaveBeenCalledOnce()
+    expect(oldAttachmentFetch).not.toHaveBeenCalled()
   })
 
   it("exports authenticated Channel history with attachment data", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17446,7 +17446,7 @@ describe("server helpers", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { getMessageText } = await import("../src/messages.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
-    const adapter = createTestChatAdapter()
+    const adapter = createTestChatAdapter({ persistThreadHistory: true })
     const message = (id: string, text: string, date: string) => new Message({
       attachments: [],
       author: { fullName: "Maxi", isBot: false, isMe: false, userId: "123", userName: "maxi" },
@@ -17487,9 +17487,10 @@ describe("server helpers", () => {
     // SAFETY: defineAgent returns the runtime shape required by the internal webhook route fixture.
     const handler = createChannelWebhookRouteHandler(agent as never)
 
+    await expect(handler(chatWebhookRequest(21, 456, "newer cached"), "telegram")).resolves.toMatchObject({ status: 200 })
     await expect(handler(chatWebhookRequest(20, 456, "current"), "telegram")).resolves.toMatchObject({ status: 200 })
 
-    expect(runs).toEqual([["previous", "current"]])
+    expect(runs).toEqual([["newer cached"], ["previous", "current"]])
   })
 
   it("exports authenticated Channel history with attachment data", async () => {
@@ -17776,8 +17777,10 @@ describe("server helpers", () => {
     Reflect.deleteProperty(nearest, "id")
     const includedCurrent = historicalMessage("current id-less")
     Reflect.deleteProperty(includedCurrent, "id")
+    const newer = historicalMessage("newer id-less")
+    Reflect.deleteProperty(newer, "id")
     adapter.fetchMessages.mockResolvedValue({
-      messages: [previous, nearest, includedCurrent],
+      messages: [previous, nearest, includedCurrent, newer],
     })
     const runs: string[][] = []
     const agent = defineAgent({

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -12914,7 +12914,6 @@ describe("server helpers", () => {
     const adapter = createTestChatAdapter({
       bypassIdLessMessageDedupe: true,
       missingIncomingMessageId: true,
-      persistThreadHistory: true,
     })
     const sharedHistory = new Message({
       attachments: [],
@@ -17493,11 +17492,6 @@ describe("server helpers", () => {
       return result
     }
     const sharedIdLessMessage = idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z")
-    sharedIdLessMessage.raw = { delivery: "shared-id-less" }
-    const deserializedSharedIdLessMessage = () => Object.assign(
-      idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z"),
-      { raw: { delivery: "shared-id-less" } },
-    )
     let initializedChats = 0
     const adapter = createTestChatAdapter({
       onInitialize: (chat) => {
@@ -17527,7 +17521,7 @@ describe("server helpers", () => {
         message("19", "previous", "2026-06-10T12:00:19.000Z"),
         message("20", "current", "2026-06-10T12:00:20.000Z"),
         message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
-        deserializedSharedIdLessMessage(),
+        sharedIdLessMessage,
         message("22", "newest cached", "2026-06-10T12:02:00.000Z"),
       ],
     })
@@ -17555,7 +17549,7 @@ describe("server helpers", () => {
     // SAFETY: defineAgent returns the runtime shape required by the internal webhook route fixture.
     const handler = createChannelWebhookRouteHandler(agent as never)
 
-    await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
+    await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_860), "telegram")).resolves.toMatchObject({ status: 200 })
     adapter.fetchMessages.mockResolvedValue({
       messages: [
         ...Array.from({ length: 10 }, (_, index) =>
@@ -17571,7 +17565,7 @@ describe("server helpers", () => {
         ),
         message("19", "previous", "2026-06-10T12:00:19.000Z"),
         message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
-        deserializedSharedIdLessMessage(),
+        sharedIdLessMessage,
         ...Array.from({ length: 987 }, (_, index) =>
           message(String(index + 100), `newer cached ${index}`, "2026-06-10T12:01:00.000Z"),
         ),
@@ -17970,7 +17964,7 @@ describe("server helpers", () => {
     await expect(handler(request(21, "intervening id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
     await expect(handler(request(22, "current id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
 
-    expect(runs.at(-1)).toEqual(["current id-less", "intervening id-less", "current id-less"])
+    expect(runs.at(-1)).toEqual(["current id-less", "ok", "intervening id-less", "ok", "current id-less"])
   })
 
   it("does not run id-less chat deliveries without current message parts", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17466,7 +17466,7 @@ describe("server helpers", () => {
       messages: [
         message("19", "previous", "2026-06-10T12:00:19.000Z"),
         message("20", "current", "2026-06-10T12:00:20.000Z"),
-        message("21", "newer cached", "2026-06-10T12:01:00.000Z"),
+        message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
         message("22", "newest cached", "2026-06-10T12:02:00.000Z"),
       ],
     })
@@ -17493,6 +17493,10 @@ describe("server helpers", () => {
     const handler = createChannelWebhookRouteHandler(agent as never)
 
     await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_860), "telegram")).resolves.toMatchObject({ status: 200 })
+    const thread = adapter._chatInstance()?.thread("telegram:456")
+    Reflect.set(thread ?? {}, "_threadHistory", {
+      getMessages: vi.fn(async () => [message("21", "newer cached", "2026-06-10T12:00:20.000Z")]),
+    })
     await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
 
     expect(runs).toEqual([["newer cached"], ["previous", "current"]])

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17493,16 +17493,20 @@ describe("server helpers", () => {
     const handler = createChannelWebhookRouteHandler(agent as never)
 
     await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_860), "telegram")).resolves.toMatchObject({ status: 200 })
+    const chat = adapter._chatInstance()
+    if (!chat) throw new Error("Expected the webhook to initialize Chat.")
     // SAFETY: This fixture accesses the Chat SDK's internal thread cache to model an adapter restart.
-    const thread = (adapter._chatInstance() as unknown as { thread(threadId: string): object } | undefined)?.thread("telegram:456")
+    const chatBoundary = chat as unknown as { thread(threadId: string): object }
+    const thread = chatBoundary.thread("telegram:456")
     adapter.fetchMessages.mockResolvedValue({ messages: [message("19", "previous", "2026-06-10T12:00:19.000Z")] })
-    Reflect.set(thread ?? {}, "_threadHistory", {
+    Reflect.set(thread, "_threadHistory", {
       getMessages: vi.fn(async () => [
         message("19-same-time", "same-time previous", "2026-06-10T12:00:20.000Z"),
         message("20", "current", "2026-06-10T12:00:20.000Z"),
         message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
       ]),
     })
+    vi.spyOn(chatBoundary, "thread").mockReturnValue(thread)
     await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
 
     expect(runs).toEqual([["newer cached"], ["previous", "same-time previous", "current"]])

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17474,13 +17474,12 @@ describe("server helpers", () => {
         const createThread = chatBoundary.createThread.bind(chatBoundary)
         vi.spyOn(chatBoundary, "createThread").mockImplementation((...arguments_) => {
           const thread = createThread(...arguments_)
-          Reflect.set(thread, "_threadHistory", {
-            getMessages: vi.fn(async () => [
-              message("19-same-time", "same-time previous", "2026-06-10T12:00:20.000Z"),
-              message("20", "current", "2026-06-10T12:00:20.000Z"),
-              message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
-            ]),
-          })
+          const history = Reflect.get(thread, "_threadHistory") as { getMessages(threadId: string, limit?: number): Promise<Message[]> }
+          vi.spyOn(history, "getMessages").mockResolvedValue([
+            message("19-same-time", "same-time previous", "2026-06-10T12:00:20.000Z"),
+            message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
+            message("20", "current", "2026-06-10T12:00:20.000Z"),
+          ])
           return thread
         })
       },
@@ -17517,7 +17516,13 @@ describe("server helpers", () => {
     const handler = createChannelWebhookRouteHandler(agent as never)
 
     await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_860), "telegram")).resolves.toMatchObject({ status: 200 })
-    adapter.fetchMessages.mockResolvedValue({ messages: [message("19", "previous", "2026-06-10T12:00:19.000Z")] })
+    adapter.fetchMessages.mockResolvedValue({
+      messages: [
+        message("19", "previous", "2026-06-10T12:00:19.000Z"),
+        message("20", "current", "2026-06-10T12:00:20.000Z"),
+        message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
+      ],
+    })
     await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
 
     expect(runs).toEqual([["newer cached"], ["previous", "same-time previous", "current"]])

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -107,6 +107,7 @@ function createTestChatAdapter(
     isDM?: boolean
     bypassIdLessMessageDedupe?: boolean
     missingIncomingMessageId?: boolean
+    onInitialize?: (chat: ChatInstance) => void
     persistThreadHistory?: boolean
     photoData?: Blob
     rawMessageValue?: unknown
@@ -269,6 +270,7 @@ function createTestChatAdapter(
     deleteMessage: vi.fn(async () => {}),
     initialize: vi.fn(async (chat: ChatInstance) => {
       chatInstance = chat
+      options.onInitialize?.(chat)
     }),
     isDM: vi.fn(() => options.isDM ?? true),
     editMessage: vi.fn(async (threadId: string, messageId: string, message: unknown) => ({
@@ -17451,7 +17453,6 @@ describe("server helpers", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { getMessageText } = await import("../src/messages.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
-    const adapter = createTestChatAdapter({ persistThreadHistory: true })
     const message = (id: string, text: string, date: string) => new Message({
       attachments: [],
       author: { fullName: "Maxi", isBot: false, isMe: false, userId: "123", userName: "maxi" },
@@ -17461,6 +17462,29 @@ describe("server helpers", () => {
       raw: {},
       text,
       threadId: "telegram:456",
+    })
+    let initializedChats = 0
+    const adapter = createTestChatAdapter({
+      onInitialize: (chat) => {
+        if (++initializedChats !== 2) return
+        // SAFETY: This fixture intercepts Chat SDK's internal webhook thread factory to model an adapter restart.
+        const chatBoundary = chat as unknown as {
+          createThread(adapter: Adapter, threadId: string, initialMessage: Message, isSubscribedContext?: boolean): object
+        }
+        const createThread = chatBoundary.createThread.bind(chatBoundary)
+        vi.spyOn(chatBoundary, "createThread").mockImplementation((...arguments_) => {
+          const thread = createThread(...arguments_)
+          Reflect.set(thread, "_threadHistory", {
+            getMessages: vi.fn(async () => [
+              message("19-same-time", "same-time previous", "2026-06-10T12:00:20.000Z"),
+              message("20", "current", "2026-06-10T12:00:20.000Z"),
+              message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
+            ]),
+          })
+          return thread
+        })
+      },
+      persistThreadHistory: true,
     })
     adapter.fetchMessages.mockResolvedValue({
       messages: [
@@ -17493,25 +17517,7 @@ describe("server helpers", () => {
     const handler = createChannelWebhookRouteHandler(agent as never)
 
     await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_860), "telegram")).resolves.toMatchObject({ status: 200 })
-    const chat = adapter._chatInstance()
-    if (!chat) throw new Error("Expected the webhook to initialize Chat.")
     adapter.fetchMessages.mockResolvedValue({ messages: [message("19", "previous", "2026-06-10T12:00:19.000Z")] })
-    // SAFETY: This fixture intercepts Chat SDK's internal webhook thread factory to model an adapter restart.
-    const chatBoundary = chat as unknown as {
-      createThread(adapter: Adapter, threadId: string, initialMessage: Message, isSubscribedContext?: boolean): object
-    }
-    const createThread = chatBoundary.createThread.bind(chatBoundary)
-    vi.spyOn(chatBoundary, "createThread").mockImplementation((...arguments_) => {
-      const thread = createThread(...arguments_)
-      Reflect.set(thread, "_threadHistory", {
-        getMessages: vi.fn(async () => [
-          message("19-same-time", "same-time previous", "2026-06-10T12:00:20.000Z"),
-          message("20", "current", "2026-06-10T12:00:20.000Z"),
-          message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
-        ]),
-      })
-      return thread
-    })
     await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
 
     expect(runs).toEqual([["newer cached"], ["previous", "same-time previous", "current"]])

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -19270,7 +19270,8 @@ describe("server helpers", () => {
         }
       },
     })
-    const adapter = createTestChatAdapter()
+    const attachmentFetchData = vi.fn(async () => Buffer.from("secret"))
+    const adapter = createTestChatAdapter({ attachmentFetchData })
     const run = vi.fn(() => "unused")
     const agent = defineAgent({
       capabilities: [
@@ -19303,7 +19304,12 @@ describe("server helpers", () => {
               chat: { id: 456, type: "private" },
               from: { id: 999 },
               message_id: 7,
-              text: "hello",
+              document: {
+                content: "secret",
+                file_id: "secret-file",
+                file_name: "secret.txt",
+                mime_type: "text/plain",
+              },
             },
           }),
           method: "POST",
@@ -19315,6 +19321,7 @@ describe("server helpers", () => {
       expect(response.status).toBe(200)
       await expect(response.json()).resolves.toEqual({ ok: true })
       expect(eventAppends).toBe(3)
+      expect(attachmentFetchData).not.toHaveBeenCalled()
       expect(run).not.toHaveBeenCalled()
       expect(adapter.postMessage).not.toHaveBeenCalled()
     } finally {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17463,6 +17463,11 @@ describe("server helpers", () => {
       text,
       threadId: "telegram:456",
     })
+    const idLessMessage = (text: string, date: string) => {
+      const result = message("id-less", text, date)
+      Reflect.deleteProperty(result, "id")
+      return result
+    }
     let initializedChats = 0
     const adapter = createTestChatAdapter({
       onInitialize: (chat) => {
@@ -17477,6 +17482,7 @@ describe("server helpers", () => {
           const history = Reflect.get(thread, "_threadHistory") as { getMessages(threadId: string, limit?: number): Promise<Message[]> }
           vi.spyOn(history, "getMessages").mockResolvedValue([
             message("19-same-time", "same-time previous", "2026-06-10T12:00:20.000Z"),
+            idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z"),
             message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
             message("20", "current", "2026-06-10T12:00:20.000Z"),
           ])
@@ -17490,6 +17496,7 @@ describe("server helpers", () => {
         message("19", "previous", "2026-06-10T12:00:19.000Z"),
         message("20", "current", "2026-06-10T12:00:20.000Z"),
         message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
+        idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z"),
         message("22", "newest cached", "2026-06-10T12:02:00.000Z"),
       ],
     })
@@ -17521,6 +17528,7 @@ describe("server helpers", () => {
         message("19", "previous", "2026-06-10T12:00:19.000Z"),
         message("20", "current", "2026-06-10T12:00:20.000Z"),
         message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
+        idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z"),
       ],
     })
     await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -122,6 +122,7 @@ function createTestChatAdapter(
     cachedMessages.set(message.threadId, [...(cachedMessages.get(message.threadId) ?? []), message])
   }
   const adapter = {
+    _cachedMessages: (threadId: string) => cachedMessages.get(threadId) ?? [],
     _chatInstance: () => chatInstance,
     channelIdFromThreadId: vi.fn((threadId: string) => threadId),
     handleWebhook: vi.fn(async (request: Request, webhookOptions?: WebhookOptions) => {
@@ -310,6 +311,7 @@ function createTestChatAdapter(
   const adapterBoundary: unknown = adapter
   // SAFETY: the returned intersection lists methods defined on the object above.
   return adapterBoundary as Adapter & {
+    _cachedMessages: (threadId: string) => Message[]
     _chatInstance: () => ChatInstance | undefined
     deleteMessage: ReturnType<typeof vi.fn>
     handleWebhook: ReturnType<typeof vi.fn>
@@ -17776,14 +17778,12 @@ describe("server helpers", () => {
     const nearest = historicalMessage("nearest id-less")
     Reflect.deleteProperty(previous, "id")
     Reflect.deleteProperty(nearest, "id")
-    const includedCurrent = historicalMessage("current id-less")
-    includedCurrent.metadata.dateSent = new Date("2026-06-10T12:00:22.000Z")
-    Reflect.deleteProperty(includedCurrent, "id")
-    const newer = historicalMessage("newer id-less")
+    const newer = historicalMessage("current id-less")
+    newer.metadata.dateSent = new Date("2026-06-10T12:00:22.000Z")
     Reflect.deleteProperty(newer, "id")
-    adapter.fetchMessages.mockResolvedValue({
-      messages: [previous, nearest, includedCurrent, newer],
-    })
+    adapter.fetchMessages.mockImplementation(async (threadId: string) => ({
+      messages: [previous, nearest, ...adapter._cachedMessages(threadId), newer],
+    }))
     const runs: string[][] = []
     const agent = defineAgent({
       channels: {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17462,15 +17462,18 @@ describe("server helpers", () => {
         message("19", "previous", "2026-06-10T12:00:19.000Z"),
         message("20", "current", "2026-06-10T12:00:20.000Z"),
         message("21", "newer cached", "2026-06-10T12:01:00.000Z"),
+        message("22", "newest cached", "2026-06-10T12:02:00.000Z"),
       ],
     })
     const runs: string[][] = []
+    // SAFETY: createTestChatAdapter implements the adapter methods exercised by this webhook fixture.
+    const platformAdapter = adapter as never
     const agent = defineAgent({
       capabilities: [
         defineChatCapability({
-          platforms: { telegram: () => adapter as never },
+          platforms: { telegram: () => platformAdapter },
           stream: false,
-          triggerHistory: { maxAgeMs: 30_000, maxMessages: 10, source: "thread" },
+          triggerHistory: { maxAgeMs: 30_000, maxMessages: 2, source: "thread" },
           webhooks: { telegram: {} },
         }),
       ],
@@ -17481,6 +17484,7 @@ describe("server helpers", () => {
         },
       },
     })
+    // SAFETY: defineAgent returns the runtime shape required by the internal webhook route fixture.
     const handler = createChannelWebhookRouteHandler(agent as never)
 
     await expect(handler(chatWebhookRequest(20, 456, "current"), "telegram")).resolves.toMatchObject({ status: 200 })

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17441,6 +17441,53 @@ describe("server helpers", () => {
     expect(runs).toEqual([["remember BROWSER-HISTORY"], ["what marker did I ask you to remember?"]])
   })
 
+  it("ends explicit trigger history at the webhook message", async () => {
+    const { defineChatCapability } = await import("../src/chat-trigger.ts")
+    const { defineAgent } = await import("../src/index.ts")
+    const { getMessageText } = await import("../src/messages.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const message = (id: string, text: string, date: string) => new Message({
+      attachments: [],
+      author: { fullName: "Maxi", isBot: false, isMe: false, userId: "123", userName: "maxi" },
+      formatted: { children: [], type: "root" },
+      id,
+      metadata: { dateSent: new Date(date), edited: false },
+      raw: {},
+      text,
+      threadId: "telegram:456",
+    })
+    adapter.fetchMessages.mockResolvedValue({
+      messages: [
+        message("19", "previous", "2026-06-10T12:00:19.000Z"),
+        message("20", "current", "2026-06-10T12:00:20.000Z"),
+        message("21", "newer cached", "2026-06-10T12:01:00.000Z"),
+      ],
+    })
+    const runs: string[][] = []
+    const agent = defineAgent({
+      capabilities: [
+        defineChatCapability({
+          platforms: { telegram: () => adapter as never },
+          stream: false,
+          triggerHistory: { maxAgeMs: 30_000, maxMessages: 10, source: "thread" },
+          webhooks: { telegram: {} },
+        }),
+      ],
+      driver: {
+        run: ({ messages }) => {
+          runs.push(messages.map(getMessageText))
+          return "ok"
+        },
+      },
+    })
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    await expect(handler(chatWebhookRequest(20, 456, "current"), "telegram")).resolves.toMatchObject({ status: 200 })
+
+    expect(runs).toEqual([["previous", "current"]])
+  })
+
   it("exports authenticated Channel history with attachment data", async () => {
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { defineAgent } = await import("../src/index.ts")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -11748,7 +11748,7 @@ describe("server helpers", () => {
       await expect(firstResponse).resolves.toMatchObject({ status: 200 })
       expect(order).toEqual(["A", "B", "C", "D"])
       expect(run).toHaveBeenCalledTimes(4)
-      expect(histories).toEqual([["A"], ["B"], ["C"], ["D"]])
+      expect(histories).toEqual([["A"], ["A", "B"], ["B", "C"], ["C", "D"]])
       const deliveries = await handler.deliveries(await serialRequest(91_013, "D"), "telegram", {
         agentName: "support",
       })
@@ -12911,7 +12911,11 @@ describe("server helpers", () => {
     const { resetWorkflowRuntime, setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
     const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-idless-steer-state-"))
     const state = Object.assign(createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` }), { workflowCustody: true })
-    const adapter = createTestChatAdapter({ bypassIdLessMessageDedupe: true, missingIncomingMessageId: true })
+    const adapter = createTestChatAdapter({
+      bypassIdLessMessageDedupe: true,
+      missingIncomingMessageId: true,
+      persistThreadHistory: true,
+    })
     const sharedHistory = new Message({
       attachments: [],
       author: { fullName: "Maxi", isBot: false, isMe: false, userId: "123", userName: "maxi" },
@@ -17546,7 +17550,7 @@ describe("server helpers", () => {
     // SAFETY: defineAgent returns the runtime shape required by the internal webhook route fixture.
     const handler = createChannelWebhookRouteHandler(agent as never)
 
-    await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_860), "telegram")).resolves.toMatchObject({ status: 200 })
+    await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
     adapter.fetchMessages.mockResolvedValue({
       messages: [
         ...Array.from({ length: 10 }, (_, index) =>
@@ -17961,7 +17965,7 @@ describe("server helpers", () => {
     await expect(handler(request(21, "intervening id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
     await expect(handler(request(22, "current id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
 
-    expect(runs.at(-1)).toEqual(["current id-less", "ok", "intervening id-less", "ok", "current id-less"])
+    expect(runs.at(-1)).toEqual(["current id-less", "intervening id-less", "current id-less"])
   })
 
   it("does not run id-less chat deliveries without current message parts", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17494,6 +17494,7 @@ describe("server helpers", () => {
 
     await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_860), "telegram")).resolves.toMatchObject({ status: 200 })
     const thread = adapter._chatInstance()?.thread("telegram:456")
+    adapter.fetchMessages.mockResolvedValue({ messages: [message("19", "previous", "2026-06-10T12:00:19.000Z")] })
     Reflect.set(thread ?? {}, "_threadHistory", {
       getMessages: vi.fn(async () => [
         message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
@@ -17959,13 +17960,14 @@ describe("server helpers", () => {
     const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
     const runs: string[][] = []
     const currentMetadata: unknown[] = []
+    const nowSeconds = Math.floor(Date.now() / 1_000)
     const request = (messageId: number, text: string) =>
       new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
         body: JSON.stringify({
           update_id: messageId,
           message: {
             chat: { id: 456, type: "private" },
-            date: 1781092800 + messageId,
+            date: nowSeconds + (messageId - 30) * 2 - 1,
             from: { first_name: "Maxi", id: 123, username: "maxi" },
             message_id: messageId,
             text,

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -107,7 +107,6 @@ function createTestChatAdapter(
     isDM?: boolean
     bypassIdLessMessageDedupe?: boolean
     missingIncomingMessageId?: boolean
-    onInitialize?: (chat: ChatInstance) => void
     persistThreadHistory?: boolean
     photoData?: Blob
     rawMessageValue?: unknown
@@ -117,14 +116,12 @@ function createTestChatAdapter(
 ) {
   let chatInstance: ChatInstance | undefined
   let idLessMessageSequence = 0
-  let latestIncomingDate = new Date("2026-06-10T12:00:00.000Z")
   let sentMessageId = 0
   const cachedMessages = new Map<string, Message[]>()
   const cacheMessage = (message: Message) => {
     cachedMessages.set(message.threadId, [...(cachedMessages.get(message.threadId) ?? []), message])
   }
   const adapter = {
-    _cachedMessages: (threadId: string) => cachedMessages.get(threadId) ?? [],
     _chatInstance: () => chatInstance,
     channelIdFromThreadId: vi.fn((threadId: string) => threadId),
     handleWebhook: vi.fn(async (request: Request, webhookOptions?: WebhookOptions) => {
@@ -174,7 +171,6 @@ function createTestChatAdapter(
         | undefined
       const photo = photos?.at(-1)
       const date = isRuntimeNumber(rawMessage.date) ? new Date(rawMessage.date * 1000) : new Date("2026-06-10T12:00:00.000Z")
-      latestIncomingDate = date
       const message = new Message({
         attachments: rawMessage.audio
           ? [
@@ -270,7 +266,6 @@ function createTestChatAdapter(
     deleteMessage: vi.fn(async () => {}),
     initialize: vi.fn(async (chat: ChatInstance) => {
       chatInstance = chat
-      options.onInitialize?.(chat)
     }),
     isDM: vi.fn(() => options.isDM ?? true),
     editMessage: vi.fn(async (threadId: string, messageId: string, message: unknown) => ({
@@ -297,7 +292,7 @@ function createTestChatAdapter(
           },
           formatted: { children: [], type: "root" },
           id,
-          metadata: { dateSent: latestIncomingDate, edited: false },
+          metadata: { dateSent: new Date("2026-06-10T12:00:00.000Z"), edited: false },
           raw: { message },
           text: isRuntimeString(message)
             ? message
@@ -315,7 +310,6 @@ function createTestChatAdapter(
   const adapterBoundary: unknown = adapter
   // SAFETY: the returned intersection lists methods defined on the object above.
   return adapterBoundary as Adapter & {
-    _cachedMessages: (threadId: string) => Message[]
     _chatInstance: () => ChatInstance | undefined
     deleteMessage: ReturnType<typeof vi.fn>
     handleWebhook: ReturnType<typeof vi.fn>
@@ -330,12 +324,11 @@ function createTitleChatAdapter(setThreadTitle: (threadId: string, title: string
   return Object.assign(createTestChatAdapter(), { setThreadTitle })
 }
 
-function chatWebhookRequest(messageId: number, threadId = 456, text = "hello", date?: number) {
+function chatWebhookRequest(messageId: number, threadId = 456, text = "hello") {
   return new Request("https://example.com/api/_vitehub/agents/support/webhooks/channel", {
     body: JSON.stringify({
       message: {
         chat: { id: threadId, type: "private" },
-        ...(date === undefined ? {} : { date }),
         from: { id: 123, username: "maxi" },
         message_id: messageId,
         text,
@@ -11748,7 +11741,7 @@ describe("server helpers", () => {
       await expect(firstResponse).resolves.toMatchObject({ status: 200 })
       expect(order).toEqual(["A", "B", "C", "D"])
       expect(run).toHaveBeenCalledTimes(4)
-      expect(histories).toEqual([["A"], ["A", "B"], ["B", "C"], ["C", "D"]])
+      expect(histories).toEqual([["A"], ["B"], ["C"], ["D"]])
       const deliveries = await handler.deliveries(await serialRequest(91_013, "D"), "telegram", {
         agentName: "support",
       })
@@ -12911,11 +12904,7 @@ describe("server helpers", () => {
     const { resetWorkflowRuntime, setWorkflowRuntimeConfig } = await import("@vite-hub/workflow/runtime/state")
     const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-idless-steer-state-"))
     const state = Object.assign(createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` }), { workflowCustody: true })
-    const adapter = createTestChatAdapter({
-      bypassIdLessMessageDedupe: true,
-      missingIncomingMessageId: true,
-      persistThreadHistory: true,
-    })
+    const adapter = createTestChatAdapter({ bypassIdLessMessageDedupe: true, missingIncomingMessageId: true })
     const sharedHistory = new Message({
       attachments: [],
       author: { fullName: "Maxi", isBot: false, isMe: false, userId: "123", userName: "maxi" },
@@ -17406,11 +17395,8 @@ describe("server helpers", () => {
     const { defineAgent } = await import("../src/index.ts")
     const { getMessageText } = await import("../src/messages.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
-    const attachmentFetchData = vi.fn(async () => Buffer.from("session-only attachment"))
-    const adapter = createTestChatAdapter({ attachmentFetchData, persistThreadHistory: true })
+    const adapter = createTestChatAdapter({ persistThreadHistory: true })
     const runs: string[][] = []
-    const sessionIds: Array<string | undefined> = []
-    const invokerSessionIds: Array<string | undefined> = []
     const agent = defineAgent({
       capabilities: [
         defineChatCapability({
@@ -17419,31 +17405,22 @@ describe("server helpers", () => {
             telegram: () => adapter as never,
           },
           stream: false,
-          sessions: { idleTimeoutMs: 60_000, strategy: "idle-timeout" },
-          threadHistory: {},
+          threadHistory: { maxMessages: 25 },
           webhooks: {
             telegram: {},
           },
         }),
       ],
-      invoker: {
-        resolve: ({ context, defaultInvoker }) => {
-          invokerSessionIds.push(context.get("chat.sessionId"))
-          return defaultInvoker
-        },
-      },
       driver: {
-        run: ({ input, messages }) => {
+        run: ({ messages }) => {
           runs.push(messages.map(getMessageText))
-          // SAFETY: The Chat runtime stores its resolved session identifier as a string in this context field.
-          sessionIds.push(input.context?.["chat.sessionId"] as string | undefined)
           return `reply ${runs.length}`
         },
       },
     })
     // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
     const handler = createChannelWebhookRouteHandler(agent as never)
-    const request = (messageId: number, text: string, withAttachment = false) =>
+    const request = (messageId: number, text: string) =>
       new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
         body: JSON.stringify({
           update_id: messageId,
@@ -17453,132 +17430,15 @@ describe("server helpers", () => {
             from: { first_name: "Maxi", id: 123, username: "maxi" },
             message_id: messageId,
             text,
-            ...(withAttachment
-              ? { document: { content: "session-only attachment", file_name: "context.txt", mime_type: "text/plain" } }
-              : {}),
           },
         }),
         method: "POST",
       })
 
-    await expect(handler(request(20, "remember BROWSER-HISTORY", true), "telegram")).resolves.toMatchObject({ status: 200 })
+    await expect(handler(request(20, "remember BROWSER-HISTORY"), "telegram")).resolves.toMatchObject({ status: 200 })
     await expect(handler(request(21, "what marker did I ask you to remember?"), "telegram")).resolves.toMatchObject({ status: 200 })
 
-    expect(runs[0]?.[0]).toContain("remember BROWSER-HISTORY")
-    expect(runs[1]).toEqual(["what marker did I ask you to remember?"])
-    expect(attachmentFetchData).toHaveBeenCalledOnce()
-    expect(sessionIds[1]).toBe(sessionIds[0])
-    expect(invokerSessionIds).toEqual(sessionIds)
-  })
-
-  it("ends explicit trigger history at the webhook message", async () => {
-    const { defineChatCapability } = await import("../src/chat-trigger.ts")
-    const { defineAgent } = await import("../src/index.ts")
-    const { getMessageText } = await import("../src/messages.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
-    const message = (id: string, text: string, date: string, attachments: Message["attachments"] = []) => new Message({
-      attachments,
-      author: { fullName: "Maxi", isBot: false, isMe: false, userId: "123", userName: "maxi" },
-      formatted: { children: [], type: "root" },
-      id,
-      metadata: { dateSent: new Date(date), edited: false },
-      raw: {},
-      text,
-      threadId: "telegram:456",
-    })
-    const oldAttachmentFetch = vi.fn(async () => Buffer.from("old context"))
-    const idLessMessage = (text: string, date: string) => {
-      const result = message("id-less", text, date)
-      Reflect.deleteProperty(result, "id")
-      return result
-    }
-    const sharedIdLessMessage = idLessMessage("newer id-less cached", "2026-06-10T12:00:20.000Z")
-    let initializedChats = 0
-    const adapter = createTestChatAdapter({
-      onInitialize: (chat) => {
-        if (++initializedChats !== 2) return
-        const unknownChat: unknown = chat
-        // SAFETY: This fixture intercepts Chat SDK's internal webhook thread factory to model an adapter restart.
-        const chatBoundary = unknownChat as {
-          createThread(adapter: Adapter, threadId: string, initialMessage: Message, isSubscribedContext?: boolean): object
-        }
-        const createThread = chatBoundary.createThread.bind(chatBoundary)
-        vi.spyOn(chatBoundary, "createThread").mockImplementation((...arguments_) => {
-          const thread = createThread(...arguments_)
-          // SAFETY: createThread returns Chat SDK's internal ThreadImpl, which owns this history cache.
-          const history = Reflect.get(thread, "_threadHistory") as { getMessages(threadId: string, limit?: number): Promise<Message[]> }
-          vi.spyOn(history, "getMessages").mockResolvedValue([
-            sharedIdLessMessage,
-            message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
-            message("20", "current", "2026-06-10T12:00:20.000Z"),
-          ])
-          return thread
-        })
-      },
-      persistThreadHistory: true,
-    })
-    adapter.fetchMessages.mockResolvedValue({
-      messages: [
-        message("19", "previous", "2026-06-10T12:00:19.000Z"),
-        message("20", "current", "2026-06-10T12:00:20.000Z"),
-        message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
-        sharedIdLessMessage,
-        message("22", "newest cached", "2026-06-10T12:02:00.000Z"),
-      ],
-    })
-    const runs: string[][] = []
-    // SAFETY: createTestChatAdapter implements the adapter methods exercised by this webhook fixture.
-    const platformAdapter = adapter as never
-    const agent = defineAgent({
-      capabilities: [
-        defineChatCapability({
-          platforms: { telegram: () => platformAdapter },
-          sessions: { idleTimeoutMs: 60_000, strategy: "idle-timeout" },
-          stream: false,
-          threadHistory: {},
-          triggerHistory: { maxMessages: 3, source: "thread" },
-          webhooks: { telegram: {} },
-        }),
-      ],
-      driver: {
-        run: ({ messages }) => {
-          runs.push(messages.map(getMessageText))
-          return "ok"
-        },
-      },
-    })
-    // SAFETY: defineAgent returns the runtime shape required by the internal webhook route fixture.
-    const handler = createChannelWebhookRouteHandler(agent as never)
-
-    await expect(handler(chatWebhookRequest(21, 456, "newer cached", 1_781_092_860), "telegram")).resolves.toMatchObject({ status: 200 })
-    adapter.fetchMessages.mockResolvedValue({
-      messages: [
-        ...Array.from({ length: 10 }, (_, index) =>
-          message(String(index + 100), `old ${index}`, `2026-06-10T11:00:${String(index).padStart(2, "0")}.000Z`, [
-            {
-              fetchData: oldAttachmentFetch,
-              mimeType: "text/plain",
-              name: `old-${index}.txt`,
-              size: 11,
-              type: "file",
-            },
-          ]),
-        ),
-        message("19", "previous", "2026-06-10T12:00:19.000Z"),
-        message("21", "newer cached", "2026-06-10T12:00:20.000Z"),
-        sharedIdLessMessage,
-        ...Array.from({ length: 987 }, (_, index) =>
-          message(String(index + 100), `newer cached ${index}`, "2026-06-10T12:01:00.000Z"),
-        ),
-      ],
-    })
-    await expect(handler(chatWebhookRequest(20, 456, "current", 1_781_092_820), "telegram")).resolves.toMatchObject({ status: 200 })
-
-    expect(runs).toEqual([
-      ["previous", "current", "newer cached"],
-      ["previous", "newer id-less cached", "current"],
-    ])
-    expect(oldAttachmentFetch).not.toHaveBeenCalled()
+    expect(runs).toEqual([["remember BROWSER-HISTORY"], ["what marker did I ask you to remember?"]])
   })
 
   it("exports authenticated Channel history with attachment data", async () => {
@@ -17837,17 +17697,13 @@ describe("server helpers", () => {
     await rm(stateDir, { force: true, recursive: true })
   }, 15_000)
 
-  it("bounds fetched thread history when the current chat message has no id", async () => {
+  it("keeps fetched thread history when the current chat message has no id", async () => {
     const { telegram } = await import("../src/channels.ts")
     const { defineAgent } = await import("../src/index.ts")
     const { getMessageText } = await import("../src/messages.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
-    const adapter = createTestChatAdapter({
-      bypassIdLessMessageDedupe: true,
-      missingIncomingMessageId: true,
-      persistThreadHistory: true,
-    })
-    const historicalMessage = (text: string) => new Message({
+    const adapter = createTestChatAdapter({ missingIncomingMessageId: true })
+    const historicalMessage = new Message({
       attachments: [],
       author: {
         fullName: "Maxi",
@@ -17860,24 +17716,12 @@ describe("server helpers", () => {
       id: "missing-id",
       metadata: { dateSent: new Date("2026-06-10T12:00:00.000Z"), edited: false },
       raw: {},
-      text,
+      text: "previous id-less",
       threadId: "telegram:456",
     })
-    const previous = historicalMessage("previous id-less")
-    const nearest = historicalMessage("nearest id-less")
-    Reflect.deleteProperty(previous, "id")
-    Reflect.deleteProperty(nearest, "id")
-    const newer = historicalMessage("current id-less")
-    newer.metadata.dateSent = new Date("2026-06-10T12:00:22.000Z")
-    Reflect.deleteProperty(newer, "id")
-    adapter.fetchMessages.mockImplementation(async () => {
-      const deserializedCurrent = historicalMessage("current id-less")
-      deserializedCurrent.metadata.dateSent = new Date("2026-06-10T12:00:22.000Z")
-      Reflect.deleteProperty(deserializedCurrent, "id")
-      newer.text = "newer id-less"
-      const future = Array.from({ length: 998 }, (_, index) => historicalMessage(`future id-less ${index}`))
-      for (const item of [previous, nearest, deserializedCurrent, newer, ...future]) item.raw = { delivery: "same" }
-      return { messages: [previous, nearest, deserializedCurrent, newer, ...future] }
+    Reflect.deleteProperty(historicalMessage, "id")
+    adapter.fetchMessages.mockResolvedValue({
+      messages: [historicalMessage],
     })
     const runs: string[][] = []
     const agent = defineAgent({
@@ -17893,79 +17737,31 @@ describe("server helpers", () => {
       },
       messages: {
         stream: false,
-        triggerHistory: { maxMessages: 2, source: "thread" },
+        triggerHistory: { maxMessages: 10, source: "thread" },
       },
     })
     // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
     const handler = createChannelWebhookRouteHandler(agent as never)
-    const request = (updateId: number, text: string, date: number) =>
-      new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
-        body: JSON.stringify({
-          update_id: updateId,
-          message: {
-            chat: { id: 456, type: "private" },
-            date,
-            from: { first_name: "Maxi", id: 123, username: "maxi" },
-            text,
-          },
+
+    await expect(
+      handler(
+        new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
+          body: JSON.stringify({
+            update_id: 22,
+            message: {
+              chat: { id: 456, type: "private" },
+              date: 1781092822,
+              from: { first_name: "Maxi", id: 123, username: "maxi" },
+              text: "current id-less",
+            },
+          }),
+          method: "POST",
         }),
-        method: "POST",
-      })
+        "telegram",
+      ),
+    ).resolves.toMatchObject({ status: 200 })
 
-    await expect(handler(request(23, "newer id-less", 1_781_092_823), "telegram")).resolves.toMatchObject({ status: 200 })
-    await expect(handler(request(22, "current id-less", 1_781_092_822), "telegram")).resolves.toMatchObject({ status: 200 })
-
-    expect(runs).toEqual([["newer id-less"], ["nearest id-less", "current id-less"]])
-  })
-
-  it("keeps distinct durable id-less messages with the current fingerprint", async () => {
-    const { telegram } = await import("../src/channels.ts")
-    const { defineAgent } = await import("../src/index.ts")
-    const { getMessageText } = await import("../src/messages.ts")
-    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
-    const adapter = createTestChatAdapter({
-      bypassIdLessMessageDedupe: true,
-      missingIncomingMessageId: true,
-      persistThreadHistory: true,
-    })
-    const runs: string[][] = []
-    const agent = defineAgent({
-      channels: {
-        // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
-        telegram: testTelegram(telegram, { adapter: () => adapter as never }),
-      },
-      driver: {
-        run: ({ messages }) => {
-          runs.push(messages.map(getMessageText))
-          return "ok"
-        },
-      },
-      messages: {
-        stream: false,
-        triggerHistory: { maxMessages: 5, source: "thread" },
-      },
-    })
-    // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
-    const handler = createChannelWebhookRouteHandler(agent as never)
-    const request = (updateId: number, text: string) =>
-      new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
-        body: JSON.stringify({
-          update_id: updateId,
-          message: {
-            chat: { id: 457, type: "private" },
-            date: 1_781_092_822,
-            from: { first_name: "Maxi", id: 123, username: "maxi" },
-            text,
-          },
-        }),
-        method: "POST",
-      })
-
-    await expect(handler(request(20, "current id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
-    await expect(handler(request(21, "intervening id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
-    await expect(handler(request(22, "current id-less"), "telegram")).resolves.toMatchObject({ status: 200 })
-
-    expect(runs.at(-1)).toEqual(["current id-less", "ok", "intervening id-less", "ok", "current id-less"])
+    expect(runs).toEqual([["previous id-less", "current id-less"]])
   })
 
   it("does not run id-less chat deliveries without current message parts", async () => {
@@ -18037,15 +17833,13 @@ describe("server helpers", () => {
     const stateDir = await mkdtemp(join(tmpdir(), "vitehub-chat-history-state-"))
     const state = createLibsqlAgentState({ url: `file:${join(stateDir, "state.sqlite")}` })
     const runs: string[][] = []
-    const currentMetadata: unknown[] = []
-    const nowSeconds = Math.floor(Date.now() / 1_000)
     const request = (messageId: number, text: string) =>
       new Request("https://example.com/api/_vitehub/agents/support/webhooks/telegram", {
         body: JSON.stringify({
           update_id: messageId,
           message: {
             chat: { id: 456, type: "private" },
-            date: nowSeconds + (messageId - 30) * 2 - 1,
+            date: 1781092800 + messageId,
             from: { first_name: "Maxi", id: 123, username: "maxi" },
             message_id: messageId,
             text,
@@ -18062,7 +17856,6 @@ describe("server helpers", () => {
         driver: {
           run: ({ messages }) => {
             runs.push(messages.map(getMessageText))
-            currentMetadata.push(messages.at(-1)?.metadata)
             return `reply ${runs.length}`
           },
         },
@@ -18081,16 +17874,11 @@ describe("server helpers", () => {
       await expect(handler(createTestChatAdapter({ persistThreadHistory: true }))(request(30, "remember DEPLOY-HISTORY"), "telegram")).resolves.toMatchObject({
         status: 200,
       })
-      const resetAdapter = createTestChatAdapter({ persistThreadHistory: true })
-      await expect(handler(resetAdapter)(request(31, "what marker did I ask you to remember?"), "telegram")).resolves.toMatchObject({ status: 200 })
+      await expect(
+        handler(createTestChatAdapter({ persistThreadHistory: true }))(request(31, "what marker did I ask you to remember?"), "telegram"),
+      ).resolves.toMatchObject({ status: 200 })
 
       expect(runs).toEqual([["remember DEPLOY-HISTORY"], ["remember DEPLOY-HISTORY", "reply 1", "what marker did I ask you to remember?"]])
-      expect(currentMetadata.at(-1)).toMatchObject({
-        chat: {
-          messageId: "31",
-          platform: { channelId: "telegram:456", threadId: "telegram:456" },
-        },
-      })
     } finally {
       await rm(stateDir, { force: true, recursive: true })
     }
@@ -19274,8 +19062,7 @@ describe("server helpers", () => {
         }
       },
     })
-    const attachmentFetchData = vi.fn(async () => Buffer.from("secret"))
-    const adapter = createTestChatAdapter({ attachmentFetchData })
+    const adapter = createTestChatAdapter()
     const run = vi.fn(() => "unused")
     const agent = defineAgent({
       capabilities: [
@@ -19308,12 +19095,7 @@ describe("server helpers", () => {
               chat: { id: 456, type: "private" },
               from: { id: 999 },
               message_id: 7,
-              document: {
-                content: "secret",
-                file_id: "secret-file",
-                file_name: "secret.txt",
-                mime_type: "text/plain",
-              },
+              text: "hello",
             },
           }),
           method: "POST",
@@ -19325,7 +19107,6 @@ describe("server helpers", () => {
       expect(response.status).toBe(200)
       await expect(response.json()).resolves.toEqual({ ok: true })
       expect(eventAppends).toBe(3)
-      expect(attachmentFetchData).not.toHaveBeenCalled()
       expect(run).not.toHaveBeenCalled()
       expect(adapter.postMessage).not.toHaveBeenCalled()
     } finally {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -17787,9 +17787,11 @@ describe("server helpers", () => {
     const newer = historicalMessage("current id-less")
     newer.metadata.dateSent = new Date("2026-06-10T12:00:22.000Z")
     Reflect.deleteProperty(newer, "id")
-    adapter.fetchMessages.mockImplementation(async (threadId: string) => ({
-      messages: [previous, nearest, ...adapter._cachedMessages(threadId), newer],
-    }))
+    adapter.fetchMessages.mockImplementation(async (threadId: string) => {
+      const cached = adapter._cachedMessages(threadId)
+      for (const item of [previous, nearest, ...cached, newer]) item.raw = { delivery: "same" }
+      return { messages: [previous, nearest, ...cached, newer] }
+    })
     const runs: string[][] = []
     const agent = defineAgent({
       channels: {

--- a/packages/agent/test/types.test-d.ts
+++ b/packages/agent/test/types.test-d.ts
@@ -666,6 +666,11 @@ describe("agent public types", () => {
       sessions: true,
       triggerHistory: { maxMessages: 20, source: "thread" },
     }
+    const invalidMessages: AgentMessageChannelSettings = {
+      // @ts-expect-error Thread-backed trigger history requires an explicit message bound.
+      triggerHistory: { source: "thread" },
+    }
+    expectTypeOf(invalidMessages).toEqualTypeOf<AgentMessageChannelSettings>()
     const channel: AgentChannelDefinition = teams()
     expectTypeOf(channel.kind).toEqualTypeOf<string>()
     const reviewFinishEffect: AgentChannelDeliveryFinishEffect = context => ({


### PR DESCRIPTION
## Summary

- Send only the current chat message by default.
- Keep adapter `threadHistory` backfill/cache separate from model-visible `triggerHistory`.
- Let each Agent or Channel opt into an explicit count-bounded thread window, with an optional age bound.
- Document the contract and update history-dependent tests to opt in.

## Behavior

An enabled window is now explicit and bounded:

```ts
triggerHistory: {
  source: 'thread',
  maxMessages: 20,
  maxAgeMs: 30 * 60 * 1000,
}
```

`maxMessages` includes the current message. `maxAgeMs` removes a stale prefix relative to that message while preserving the current message as the final input. Missing timestamps start a new history boundary.

This is intentionally a type-level breaking change for enabled windows: `maxMessages` is required. Omitted or invalid runtime history settings fail closed to the current message.

## Why

History retrieval and model context are different decisions. A Channel may need thread backfill for transcripts or delivery state without automatically sending that entire cache to the model. Keeping selection explicit gives one-thread Channels a current-only default while allowing conversational products to choose their own count and recency policy.

## Verification

- `pnpm vp run -t @vite-hub/agent#build`
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm vp test run test/chat-message-input.test.ts test/channel-instructions.test.ts` (38 passed)
- Agent Dev Loop explicit-history integration (1 passed)
- adapter webhook current-only regression (1 passed)
- `git diff --check`

The full local Agent suite completed with 2,549 passing and 2 skipped tests. Nine unrelated tests failed in the local harness: six generated-route fixtures hit an H3 mock-request error, one published-package fixture inherited `/tmp/package.json`'s npm package-manager setting, and two provider coordination tests were timing-sensitive under the full-suite load.
