### PR TITLE
fix(browser): keep esbuild external

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -54,7 +54,8 @@
     "test": "vp run -t @vite-hub/browser#build && vp test"
   },
   "dependencies": {
-    "@vite-hub/runtime": "workspace:*"
+    "@vite-hub/runtime": "workspace:*",
+    "esbuild": "catalog:esbuild-v27"
   },
   "devDependencies": {
     "@types/node": "catalog:tooling",

--- a/packages/browser/test/optional-peer-bundle.test.ts
+++ b/packages/browser/test/optional-peer-bundle.test.ts
@@ -30,6 +30,12 @@ async function bundle(entry: string): Promise<string> {
 }
 
 describe("Browser optional peer bundle", () => {
+  it("keeps esbuild external in the Vite entry", async () => {
+    const output = await readFile(new URL(`../${"dist"}/vite.js`, import.meta.url), "utf8")
+
+    expect(output).toContain(`from "esbuild"`)
+  })
+
   it("keeps page-session peers out of root entry points", async () => {
     const builtEntry = new URL(`../${"dist"}/index.js`, import.meta.url).pathname
     const output = await bundle(builtEntry)

--- a/packages/browser/vite.config.ts
+++ b/packages/browser/vite.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
     tsconfig: "tsconfig.build.json",
     deps: {
       alwaysBundle: [/^@vite-hub\/internal/],
-      neverBundle: [/^#vitehub\/browser\//, "@cloudflare/playwright", "playwright-core", "vite"],
+      neverBundle: [/^#vitehub\/browser\//, "@cloudflare/playwright", "esbuild", "playwright-core", "vite"],
       onlyBundle: false,
     },
     entry: [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1000,9 +1000,12 @@ importers:
       '@vite-hub/runtime':
         specifier: workspace:*
         version: link:../runtime
+      esbuild:
+        specifier: catalog:esbuild-v27
+        version: 0.27.7
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
-        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(esbuild@0.28.1)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(esbuild@0.27.7)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
     devDependencies:
       '@types/node':
         specifier: catalog:tooling
@@ -1021,10 +1024,10 @@ importers:
         version: 6.0.3
       vite-plus:
         specifier: catalog:tooling
-        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)
+        version: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(happy-dom@20.11.6)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)
       vitest:
         specifier: npm:@voidzero-dev/vite-plus-test@0.1.24
-        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.28.1)(happy-dom@20.11.6)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
+        version: '@voidzero-dev/vite-plus-test@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitejs/devtools@0.1.19)(@voidzero-dev/vite-plus-core@0.1.24)(esbuild@0.27.7)(happy-dom@20.11.6)(jiti@2.7.0)(publint@0.3.21)(terser@5.49.0)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'
 
   packages/channels:
     dependencies:


### PR DESCRIPTION
Keeps esbuild out of the published Browser Vite bundle and declares it as a direct dependency. This prevents the bundled esbuild CommonJS shim from reading an undefined __filename during Cloudflare builds.\n\nTest plan:\n- pnpm --filter @vite-hub/browser test\n- pnpm --filter @vite-hub/browser typecheck\n- pnpm install --offline --lockfile-only --frozen-lockfile\n\nDownstream proof: vite-hub/strata@9ddb58d builds and runs on Cloudflare with the equivalent pnpm patch.