### PR TITLE
fix(kv): resolve Cloudflare runtime from package

### DIFF
--- a/packages/kv/src/vite.ts
+++ b/packages/kv/src/vite.ts
@@ -22,7 +22,9 @@ const KV_RUNTIME_ID = "#vitehub/kv/runtime"
 const RESOLVED_KV_RUNTIME_ID = `\0${KV_RUNTIME_ID}`
 const KV_ERRORS_IMPORT_ID = new URL(import.meta.url.endsWith(".ts") ? "./errors.ts" : "./errors.js", import.meta.url).href
 const UPSTASH_DRIVER_IMPORT_ID = "@vite-hub/kv/runtime/upstash-driver"
-const CLOUDFLARE_KV_RUNTIME_IMPORT_ID = "@vite-hub/kv/runtime/cloudflare-kv"
+const CLOUDFLARE_KV_RUNTIME_IMPORT_ID = import.meta.url.endsWith(".ts")
+  ? "@vite-hub/kv/runtime/cloudflare-kv"
+  : new URL("./runtime/cloudflare-kv.js", import.meta.url).href
 const mergeNoExternal = createNoExternalMerger("@vite-hub/kv")
 const KV_CLOUDFLARE_BINDINGS_FILE = ".vitehub-kv-bindings.json"
 

--- a/packages/kv/test/vite-output.test.ts
+++ b/packages/kv/test/vite-output.test.ts
@@ -64,6 +64,12 @@ async function readOutput(root: string): Promise<string> {
 }
 
 describe("KV Vite output", () => {
+  it("resolves the Cloudflare runtime from the package entry", async () => {
+    const output = await readFile(new URL(`../${"dist"}/vite.js`, import.meta.url), "utf8")
+
+    expect(output).toContain(`new URL("./runtime/cloudflare-kv.js", import.meta.url).href`)
+  })
+
   it("runs an fs-lite server bundle without the optional Upstash peer", async () => {
     const rootDir = await createConsumerRoot()
     const entry = join(rootDir, "src", "worker.ts")


### PR DESCRIPTION
Makes the published KV Vite entry resolve its Cloudflare runtime relative to itself. Virtual modules no longer ask strict pnpm resolution to locate a bare self-import without a filesystem importer.\n\nSource-mode tests retain the existing package specifier, while published output uses the package-relative file URL.\n\nTest plan:\n- pnpm --filter @vite-hub/kv test\n- pnpm --filter @vite-hub/kv typecheck\n\nDownstream proof: vite-hub/strata@9ddb58d builds and runs Cloudflare KV-backed output with the equivalent pnpm patch.