### PR TITLE
feat(agent): project invocation activity through channels

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -35,7 +35,7 @@ Built-in helpers include `discord()`, `github()`, `http()`, `slack()`, `teams()`
 
 Enable `activity` when an invocation should project its lifecycle into a Channel without treating that Channel as the Agent's conversation transport. GitHub reuses an authenticated app- or bot-owned issue or pull-request comment when one is visible, updates its status from queued through completion, renders normalized harness plans as a task list, and preserves earlier session links under a collapsed section.
 
-Activity updates are ordered within one process. Across concurrent hosts, GitHub delivery is eventually best-effort: intermediate updates can coalesce and separate hosts can temporarily create duplicate managed comments. A later update reconciles owned duplicates when possible. Updates from an older run do not replace the current run or regress its terminal state.
+Activity updates are ordered within one process. Across concurrent hosts, GitHub delivery is best-effort: intermediate updates can coalesce, separate hosts can temporarily create duplicate managed comments, and overlapping writes can briefly replace newer state. A later update reconciles owned duplicates and stale state when possible. Within one process, older updates do not replace the current or terminal run.
 
 ```ts [server/agents/reviewer.ts]
 import { defineAgent } from 'vite-hub/agent'

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -31,6 +31,48 @@ Built-in helpers include `discord()`, `github()`, `http()`, `slack()`, `teams()`
 
 `webChat()` enables a generated AI SDK chat route by default. `http()` is a generic HTTP Channel and keeps its route disabled unless you pass `http({ route: true })`.
 
+## Publish Agent activity without opening a chat
+
+Enable `activity` when an invocation should project its lifecycle into a Channel without treating that Channel as the Agent's conversation transport. GitHub keeps one managed issue or pull-request comment, updates its status from queued through completion, renders normalized harness plans as a task list, and preserves earlier session links under a collapsed section.
+
+```ts [server/agents/reviewer.ts]
+import { defineAgent } from 'vite-hub/agent'
+import { github } from 'vite-hub/agent/channels'
+
+export const agent = defineAgent({
+  channels: {
+    github: github({
+      activity: true,
+      app: true,
+      webhooks: false,
+    }),
+  },
+  driver: { model: 'openai/gpt-5.1-mini' },
+})
+```
+
+Select the Channel and its destination when the application starts the invocation. Links are application-owned; use them for the current session, memory, or another inspection surface.
+
+```ts
+import { runScheduledAgent } from 'vite-hub/agent'
+
+await runScheduledAgent(agent, schedule, {
+  run: {
+    activity: {
+      links: [
+        { label: 'Session', url: sessionUrl },
+        { label: 'Memory', url: memoryUrl },
+      ],
+      target: { repository: 'acme/storefront', issue: 42 },
+    },
+    channelId: 'github',
+    runId: schedule.runId,
+  },
+}, { prompt: 'Converge this pull request.' })
+```
+
+The runtime publishes `queued` before capacity admission, `running` after admission, `waiting` for approval requests, and a terminal state on every exit. `data-agent-plan` stream events update the task list, so Codex and other harnesses that expose normalized plans do not need provider-specific GitHub code. Activity delivery failures are reported without replacing the Agent result.
+
 ## Connect a web chat
 
 `webChat()` exposes the Agent through `/api/_vitehub/agents/[agent]/chat`. Set `route: false` to keep that Agent unreachable through the shared dispatcher.

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -33,7 +33,9 @@ Built-in helpers include `discord()`, `github()`, `http()`, `slack()`, `teams()`
 
 ## Publish Agent activity without opening a chat
 
-Enable `activity` when an invocation should project its lifecycle into a Channel without treating that Channel as the Agent's conversation transport. GitHub keeps one managed issue or pull-request comment, updates its status from queued through completion, renders normalized harness plans as a task list, and preserves earlier session links under a collapsed section.
+Enable `activity` when an invocation should project its lifecycle into a Channel without treating that Channel as the Agent's conversation transport. GitHub reuses an authenticated app- or bot-owned issue or pull-request comment when one is visible, updates its status from queued through completion, renders normalized harness plans as a task list, and preserves earlier session links under a collapsed section.
+
+Activity updates are ordered within one process. Across concurrent hosts, GitHub delivery is eventually best-effort: intermediate updates can coalesce and separate hosts can temporarily create duplicate managed comments. A later update reconciles owned duplicates when possible. Updates from an older run do not replace the current run or regress its terminal state.
 
 ```ts [server/agents/reviewer.ts]
 import { defineAgent } from 'vite-hub/agent'

--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -33,7 +33,7 @@ Built-in helpers include `discord()`, `github()`, `http()`, `slack()`, `teams()`
 
 ## Publish Agent activity without opening a chat
 
-Enable `activity` when an invocation should project its lifecycle into a Channel without treating that Channel as the Agent's conversation transport. GitHub reuses an authenticated app- or bot-owned issue or pull-request comment when one is visible, updates its status from queued through completion, renders normalized harness plans as a task list, and preserves earlier session links under a collapsed section.
+Enable `activity` when an invocation should project its lifecycle into a Channel without treating that Channel as the Agent's conversation transport. With GitHub App webhooks enabled, ViteHub creates the authenticated app-owned comment on `pull_request.opened`; later invocations reuse it. The compact comment shows lifecycle status, normalized harness plans, current links, errors, and earlier session links under a collapsed section. Full Agent output stays in the linked session.
 
 Activity updates are ordered within one process. Across concurrent hosts, GitHub delivery is best-effort: intermediate updates can coalesce, separate hosts can temporarily create duplicate managed comments, and overlapping writes can briefly replace newer state. A later update reconciles owned duplicates and stale state when possible. Within one process, older updates do not replace the current or terminal run.
 
@@ -46,7 +46,6 @@ export const agent = defineAgent({
     github: github({
       activity: true,
       app: true,
-      webhooks: false,
     }),
   },
   driver: { model: 'openai/gpt-5.1-mini' },

--- a/packages/agent/src/agent-invocation.ts
+++ b/packages/agent/src/agent-invocation.ts
@@ -58,6 +58,7 @@ export interface AgentInvocationControllerAdapter<
 }
 
 export type AgentInvocationFinishOutcome<TOutput = unknown> =
+  | { status: "cancelled" }
   | { output?: TOutput, status: "completed" }
   | { error: unknown, status: "failed" }
 
@@ -158,6 +159,9 @@ export function startLiveAgentInvocation<TOutput = unknown, CALL_OPTIONS = unkno
       if (outcome.status === "completed") {
         snapshot = { id, status: "completed" }
         if (outcome.output !== undefined) snapshot.output = outcome.output
+      }
+      else if (outcome.status === "cancelled") {
+        snapshot = { id, status: "cancelled" }
       }
       else {
         snapshot = abortSignal.aborted

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1320,7 +1320,7 @@ function githubActivityBadge(status: AgentActivityStatus): string {
 function githubActivityTask(task: AgentActivityTask): string {
   const title = task.title
     .replace(/[\r\n]+/g, " ")
-    .replace(/([\\`*_[\]<>])/g, "\\$1")
+    .replace(/([\\`*_()[\]<>])/g, "\\$1")
     .slice(0, 300)
   if (task.status === "completed") return `- [x] ${title}`
   if (task.status === "in-progress") return `- [ ] ⏳ ${title}`

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1317,11 +1317,15 @@ function githubActivityBadge(status: AgentActivityStatus): string {
   return `![Agent: ${value.label}](https://img.shields.io/badge/agent-${encodeURIComponent(value.label)}-${value.color})`
 }
 
-function githubActivityTask(task: AgentActivityTask): string {
-  const title = task.title
+function githubActivityText(value: string, limit: number): string {
+  return value
     .replace(/[\r\n]+/g, " ")
-    .replace(/([\\`*_()[\]<>])/g, "\\$1")
-    .slice(0, 300)
+    .replace(/([\\`*_()[\]<>#@!|{}])/g, "\\$1")
+    .slice(0, limit)
+}
+
+function githubActivityTask(task: AgentActivityTask): string {
+  const title = githubActivityText(task.title, 300)
   if (task.status === "completed") return `- [x] ${title}`
   if (task.status === "in-progress") return `- [ ] ⏳ ${title}`
   return `- [ ] ${title}`
@@ -1342,7 +1346,7 @@ function renderGithubActivity(
   const links = githubActivityLinksState(activity.links)
   if (links.length) sections.push(githubActivityLinks(links))
   if (activity.tasks.length) sections.push(activity.tasks.slice(0, githubActivityTaskLimit).map(githubActivityTask).join("\n"))
-  if (activity.error) sections.push(`Agent stopped: ${activity.error.slice(0, 1_000)}`)
+  if (activity.error) sections.push(`Agent stopped: ${githubActivityText(activity.error, 1_000)}`)
   if (state.history.length) {
     const history = state.history
       .filter(entry => entry.links.length)

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1337,8 +1337,9 @@ function renderGithubActivity(
 
 function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
   app: true | GitHubAppOptions<TRuntimeConfig> | undefined,
-  trackActiveRuns = true,
+  mode: "initialize" | "lifecycle" = "lifecycle",
 ): NonNullable<AgentChannelDefinition<TRuntimeConfig>["activity"]> {
+  const trackActiveRuns = mode === "lifecycle"
   const options = githubAppOptions(app) || {}
   return {
     async update(context) {
@@ -1362,6 +1363,7 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         const owned = comments.filter(comment => maybeNumber(isRecord(comment) ? comment.id : undefined)
           && isOwnedGithubActivityComment(comment, identity))
         const existing = owned[0]
+        if (mode === "initialize" && existing) return
         const previous = decodeGithubActivityState(isRecord(existing) ? existing.body : undefined)
         const current = { links: githubActivityLinksState(context.activity.links), runId, status: context.activity.status }
         const reconcileDuplicates = async () => {
@@ -2447,7 +2449,7 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
 ): AgentChannelDefinition<TRuntimeConfig> {
   const { activity, app: appOptions, pullRequest, ...channelOptions } = options
   const activityDefinition = activity ? githubAgentActivity(appOptions) : undefined
-  const openedActivityDefinition = activity ? githubAgentActivity(appOptions, false) : undefined
+  const openedActivityDefinition = activity ? githubAgentActivity(appOptions, "initialize") : undefined
   const app = githubAppOptions(appOptions)
   const pullRequestOptions = pullRequest === true ? {} : pullRequest || {}
   const workspace = pullRequest ? githubPullRequestWorkspacePolicy(pullRequestOptions) : undefined

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1218,10 +1218,14 @@ function githubActivityLinksState(links: readonly { label: string, url: string }
 }
 
 function isOwnedGithubActivityComment(comment: unknown, identity: GitHubActivityIdentity): boolean {
-  if (!isRecord(comment) || !hasRuntimeType(comment.body, "string") || !comment.body.includes(githubActivityMarker)) return false
+  if (!isRecord(comment) || !hasRuntimeType(comment.body, "string") || !comment.body.startsWith(githubActivityMarker)) return false
   const user = isRecord(comment.user) ? maybeString(comment.user.login) : undefined
   const appId = isRecord(comment.performed_via_github_app) ? maybeNumber(comment.performed_via_github_app.id) : undefined
   return Boolean(identity.appId ? appId === identity.appId : identity.login && user === identity.login)
+}
+
+function githubActivityIdentityKey(identity: GitHubActivityIdentity): string {
+  return identity.appId ? `app:${identity.appId}` : `user:${identity.login}`
 }
 
 function githubActivityRunId(agentName: string, runId: string): string {
@@ -1345,14 +1349,15 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
       const headers = githubApiHeaders(token, options.userAgent)
       const apiBaseUrl = options.apiBaseUrl || "https://api.github.com"
       const identity = await githubActivityIdentity(fetcher, apiBaseUrl, headers, token, app, context)
-      const activityKey = `${apiBaseUrl}/repos/${target.repository}/issues/${target.issue}`
+      const commentsTarget = `${apiBaseUrl}/repos/${target.repository}/issues/${target.issue}`
+      const activityKey = `${githubActivityIdentityKey(identity)}\0${commentsTarget}`
       const previousUpdate = githubActivityUpdates.get(activityKey) || Promise.resolve()
       const update = previousUpdate.catch(() => {}).then(async () => {
         const runId = githubActivityRunId(context.activity.agentName || "", context.activity.runId)
         const activeRuns = githubActivityActiveRuns.get(activityKey) || new Set<string>()
         const knownActiveRun = activeRuns.has(runId)
         const terminal = ["cancelled", "completed", "failed"].includes(context.activity.status)
-        const commentsUrl = `${activityKey}/comments?sort=created&direction=desc`
+        const commentsUrl = `${commentsTarget}/comments?sort=created&direction=desc`
         const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, 0)
         const owned = comments.filter(comment => maybeNumber(isRecord(comment) ? comment.id : undefined)
           && isOwnedGithubActivityComment(comment, identity))

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1146,6 +1146,7 @@ const githubActivityHistoryLimit = 10
 const githubActivityLinkLimit = 3
 const githubActivityLinkUrlLimit = 1_000
 const githubActivityBodyLimit = 65_000
+const githubActivityStateLimit = 50_000
 const githubActivityCommentLookupLimit = 100
 const githubActivityPreviousRunLimit = 100
 const githubActivityTaskLimit = 25
@@ -1275,7 +1276,26 @@ function decodeGithubActivityState(body: unknown): GitHubActivityCommentState {
 }
 
 function encodeGithubActivityState(state: GitHubActivityCommentState): string {
-  return `${githubActivityMarker}${Buffer.from(JSON.stringify(state)).toString("base64url")} -->`
+  const bounded: GitHubActivityCommentState = {
+    current: state.current && { ...state.current, links: [...state.current.links] },
+    history: state.history.map(entry => ({ ...entry, links: [...entry.links] })),
+    previousRunIds: [...state.previousRunIds],
+  }
+  const encode = () => `${githubActivityMarker}${Buffer.from(JSON.stringify(bounded)).toString("base64url")} -->`
+  let marker = encode()
+  while (Buffer.byteLength(marker) > githubActivityStateLimit && bounded.history.length) {
+    bounded.history = bounded.history.slice(0, -1)
+    marker = encode()
+  }
+  while (Buffer.byteLength(marker) > githubActivityStateLimit && bounded.previousRunIds.length) {
+    bounded.previousRunIds = bounded.previousRunIds.slice(0, -1)
+    marker = encode()
+  }
+  while (Buffer.byteLength(marker) > githubActivityStateLimit && bounded.current?.links.length) {
+    bounded.current = { ...bounded.current, links: bounded.current.links.slice(0, -1) }
+    marker = encode()
+  }
+  return marker
 }
 
 function githubActivityBadge(status: AgentActivityStatus): string {
@@ -1323,8 +1343,9 @@ function renderGithubActivity(
   }
   const body = sections.join("\n\n")
   if (Buffer.byteLength(body) <= githubActivityBodyLimit) return body
-  let bounded = ""
-  for (const section of sections) {
+  const stateMarker = sections[0]!
+  let bounded = stateMarker
+  for (const section of sections.slice(1)) {
     const separator = bounded ? "\n\n" : ""
     const remaining = githubActivityBodyLimit - Buffer.byteLength(bounded) - Buffer.byteLength(separator)
     if (remaining <= 0) break
@@ -1365,7 +1386,18 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, githubActivityCommentLookupLimit)
         const owned = comments.filter(comment => maybeNumber(isRecord(comment) ? comment.id : undefined)
           && isOwnedGithubActivityComment(comment, identity))
-        const existing = owned.find(comment => maybeNumber(isRecord(comment) ? comment.id : undefined) === knownCommentId) || owned[0]
+        let existing = owned.find(comment => maybeNumber(isRecord(comment) ? comment.id : undefined) === knownCommentId)
+        if (knownCommentId && !existing) {
+          const response = await fetcher(`${apiBaseUrl}/repos/${target.repository}/issues/comments/${knownCommentId}`, { headers, method: "GET" })
+          if (response.ok) {
+            const known = await response.json().catch(() => undefined)
+            if (isOwnedGithubActivityComment(known, identity)) existing = known
+          }
+          else if (response.status !== 404) {
+            throw new Error(`[vitehub] GitHub metadata request failed with ${response.status}.`)
+          }
+        }
+        existing ||= owned[0]
         if (knownCommentId && !existing) commentIds.delete(activityKey)
         if (mode === "initialize" && existing) return
         const previous = decodeGithubActivityState(isRecord(existing) ? existing.body : undefined)

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1144,6 +1144,7 @@ async function githubApiJsonPages(fetcher: typeof fetch, url: string, headers: R
 const githubActivityMarker = "<!-- vitehub-agent-activity:"
 const githubActivityHistoryLimit = 10
 const githubActivityLinkLimit = 3
+const githubActivityPreviousRunLimit = 100
 const githubActivityTaskLimit = 25
 const githubActivityUpdates = new Map<string, Promise<void>>()
 
@@ -1166,7 +1167,7 @@ interface GitHubActivityCommentState {
 }
 
 interface GitHubActivityIdentity {
-  app?: string
+  appId?: number
   login?: string
 }
 
@@ -1179,9 +1180,9 @@ async function githubAppIdentity<TRuntimeConfig extends AgentRuntimeConfig>(
   const appId = requiredString(await githubAppSetting(options, env, "appId", "appId", context), "appId")
   const headers = githubApiHeaders(githubAppJwt(appId, await githubAppPrivateKey(options, env, context)), options.userAgent)
   const appMetadata = await githubApiJson(options.fetch || fetch, `${options.apiBaseUrl || "https://api.github.com"}/app`, headers)
-  const slug = isRecord(appMetadata) ? maybeString(appMetadata.slug) : undefined
-  if (!slug) throw new Error("[vitehub] GitHub App metadata did not include a slug.")
-  return { app: slug }
+  const resolvedAppId = isRecord(appMetadata) ? maybeNumber(appMetadata.id) : undefined
+  if (!resolvedAppId) throw new Error("[vitehub] GitHub App metadata did not include an ID.")
+  return { appId: resolvedAppId }
 }
 
 async function githubActivityIdentity<TRuntimeConfig extends AgentRuntimeConfig>(
@@ -1211,8 +1212,12 @@ function githubActivityLinksState(links: readonly { label: string, url: string }
 function isOwnedGithubActivityComment(comment: unknown, identity: GitHubActivityIdentity): boolean {
   if (!isRecord(comment) || !hasRuntimeType(comment.body, "string") || !comment.body.includes(githubActivityMarker)) return false
   const user = isRecord(comment.user) ? maybeString(comment.user.login) : undefined
-  const app = isRecord(comment.performed_via_github_app) ? maybeString(comment.performed_via_github_app.slug) : undefined
-  return Boolean(identity.app ? app === identity.app : identity.login && user === identity.login)
+  const appId = isRecord(comment.performed_via_github_app) ? maybeNumber(comment.performed_via_github_app.id) : undefined
+  return Boolean(identity.appId ? appId === identity.appId : identity.login && user === identity.login)
+}
+
+function githubActivityRunId(runId: string): string {
+  return createHash("sha256").update(runId).digest("base64url")
 }
 
 function githubActivityTarget(value: unknown): GitHubActivityTarget {
@@ -1240,6 +1245,7 @@ function decodeGithubActivityState(body: unknown): GitHubActivityCommentState {
             ? [{ label: maybeString(link.label)!, url: maybeString(link.url)! }]
             : []))
           const status = maybeString(item.status)
+          // SAFETY: The membership check limits status to AgentActivityStatus values.
           return [{ links, runId: maybeString(item.runId)!, ...(status && ["cancelled", "completed", "failed", "queued", "running", "waiting"].includes(status) ? { status: status as AgentActivityStatus } : {}) }]
         })
       : []
@@ -1248,7 +1254,7 @@ function decodeGithubActivityState(body: unknown): GitHubActivityCommentState {
     const previousRunIds = Array.isArray(value.previousRunIds)
       ? value.previousRunIds.flatMap(runId => maybeString(runId) || []).filter(runId => runId !== current?.runId)
       : history.map(entry => entry.runId)
-    return { current, history, previousRunIds: [...new Set(previousRunIds)] }
+    return { current, history, previousRunIds: [...new Set(previousRunIds)].slice(0, githubActivityPreviousRunLimit) }
   }
   catch {
     return { history: [], previousRunIds: [] }
@@ -1328,7 +1334,7 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
           && isOwnedGithubActivityComment(comment, identity))
         const existing = owned[0]
         const previous = decodeGithubActivityState(isRecord(existing) ? existing.body : undefined)
-        const current = { links: githubActivityLinksState(context.activity.links), runId: context.activity.runId, status: context.activity.status }
+        const current = { links: githubActivityLinksState(context.activity.links), runId: githubActivityRunId(context.activity.runId), status: context.activity.status }
         const reconcileDuplicates = async () => {
           for (const duplicate of owned.slice(1)) {
             const duplicateId = isRecord(duplicate) ? maybeNumber(duplicate.id) : undefined
@@ -1361,7 +1367,8 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
                 .filter((entry): entry is GitHubActivityHistoryEntry => entry !== undefined && entry.runId !== current.runId)
                 .slice(0, githubActivityHistoryLimit),
               previousRunIds: [previous.current?.runId, ...previous.previousRunIds]
-                .filter((runId): runId is string => runId !== undefined && runId !== current.runId),
+                .filter((runId): runId is string => runId !== undefined && runId !== current.runId)
+                .slice(0, githubActivityPreviousRunLimit),
             }
         const body = renderGithubActivity(context.activity, state)
         const commentId = isRecord(existing) ? maybeNumber(existing.id) : undefined

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1205,7 +1205,12 @@ async function githubActivityIdentity<TRuntimeConfig extends AgentRuntimeConfig>
     if (login) return { login }
   }
   const processEnv = globalThis.process?.env
-  if (!processEnv?.VITEHUB_GITHUB_TOKEN && (processEnv?.GH_TOKEN === token || processEnv?.GITHUB_TOKEN === token)) {
+  if (
+    processEnv?.GITHUB_ACTIONS === "true"
+    && !processEnv.VITEHUB_GITHUB_TOKEN
+    && !processEnv.GH_TOKEN
+    && processEnv.GITHUB_TOKEN === token
+  ) {
     return { login: "github-actions[bot]" }
   }
   if (app) return githubAppIdentity(app, context)
@@ -1383,7 +1388,7 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         const terminal = ["cancelled", "completed", "failed"].includes(context.activity.status)
         const commentsUrl = `${commentsTarget}/comments?sort=created&direction=desc`
         const knownCommentId = commentIds.get(activityKey)
-        const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, githubActivityCommentLookupLimit)
+        const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, knownCommentId ? githubActivityCommentLookupLimit : 0)
         const owned = comments.filter(comment => maybeNumber(isRecord(comment) ? comment.id : undefined)
           && isOwnedGithubActivityComment(comment, identity))
         let existing = owned.find(comment => maybeNumber(isRecord(comment) ? comment.id : undefined) === knownCommentId)

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1135,7 +1135,8 @@ async function githubApiJsonPages(fetcher: typeof fetch, url: string, headers: R
     if (!Array.isArray(pageItems) || !pageItems.length) break
     items.push(...pageItems)
     if (limit > 0 && items.length >= limit) break
-    nextUrl = githubApiNextPageUrl(response.headers.get("link")) || githubApiPageUrl(url, ++page)
+    const link = response.headers.get("link")
+    nextUrl = link === null ? githubApiPageUrl(url, ++page) : githubApiNextPageUrl(link)
   }
   return limit > 0 ? items.slice(0, limit) : items
 }
@@ -1153,11 +1154,40 @@ interface GitHubActivityTarget {
 interface GitHubActivityHistoryEntry {
   links: readonly { label: string, url: string }[]
   runId: string
+  status?: AgentActivityStatus
 }
 
 interface GitHubActivityCommentState {
   current?: GitHubActivityHistoryEntry
   history: readonly GitHubActivityHistoryEntry[]
+}
+
+interface GitHubActivityIdentity {
+  app?: string
+  login?: string
+}
+
+async function githubActivityIdentity(fetcher: typeof fetch, apiBaseUrl: string, headers: Record<string, string>): Promise<GitHubActivityIdentity> {
+  const userResponse = await fetcher(`${apiBaseUrl}/user`, { headers, method: "GET" })
+  if (userResponse.ok) {
+    const user = await userResponse.json().catch(() => undefined)
+    const login = isRecord(user) ? maybeString(user.login) : undefined
+    if (login) return { login }
+  }
+  const installationResponse = await fetcher(`${apiBaseUrl}/installation`, { headers, method: "GET" })
+  if (installationResponse.ok) {
+    const installation = await installationResponse.json().catch(() => undefined)
+    const app = isRecord(installation) ? maybeString(installation.app_slug) : undefined
+    if (app) return { app }
+  }
+  throw new Error("[vitehub] GitHub Agent activity could not resolve the authenticated identity.")
+}
+
+function isOwnedGithubActivityComment(comment: unknown, identity: GitHubActivityIdentity): boolean {
+  if (!isRecord(comment) || !hasRuntimeType(comment.body, "string") || !comment.body.includes(githubActivityMarker)) return false
+  const user = isRecord(comment.user) ? maybeString(comment.user.login) : undefined
+  const app = isRecord(comment.performed_via_github_app) ? maybeString(comment.performed_via_github_app.slug) : undefined
+  return Boolean(identity.app ? app === identity.app : identity.login && user === identity.login)
 }
 
 function githubActivityTarget(value: unknown): GitHubActivityTarget {
@@ -1184,7 +1214,8 @@ function decodeGithubActivityState(body: unknown): GitHubActivityCommentState {
           const links = item.links.flatMap(link => isRecord(link) && maybeString(link.label) && maybeString(link.url)
             ? [{ label: maybeString(link.label)!, url: maybeString(link.url)! }]
             : [])
-          return [{ links, runId: maybeString(item.runId)! }]
+          const status = maybeString(item.status)
+          return [{ links, runId: maybeString(item.runId)!, ...(status && ["cancelled", "completed", "failed", "queued", "running", "waiting"].includes(status) ? { status: status as AgentActivityStatus } : {}) }]
         })
       : []
     return {
@@ -1235,7 +1266,7 @@ function renderGithubActivity(
   if (activity.links.length) sections.push(githubActivityLinks(activity.links))
   if (activity.tasks.length) sections.push(activity.tasks.map(githubActivityTask).join("\n"))
   if (activity.summary) sections.push(activity.summary.slice(0, 12_000))
-  else if (activity.error) sections.push(`Agent stopped: ${activity.error.slice(0, 1_000)}`)
+  if (activity.error) sections.push(`Agent stopped: ${activity.error.slice(0, 1_000)}`)
   if (state.history.length) {
     const history = state.history
       .filter(entry => entry.links.length)
@@ -1258,17 +1289,41 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
       if (!token) throw new Error("[vitehub] GitHub Agent activity requires GitHub authentication.")
       const headers = githubApiHeaders(token, options.userAgent)
       const apiBaseUrl = options.apiBaseUrl || "https://api.github.com"
+      const identity = await githubActivityIdentity(fetcher, apiBaseUrl, headers)
       const activityKey = `${apiBaseUrl}/repos/${target.repository}/issues/${target.issue}`
       const previousUpdate = githubActivityUpdates.get(activityKey) || Promise.resolve()
       const update = previousUpdate.catch(() => {}).then(async () => {
         const commentsUrl = `${activityKey}/comments?sort=created&direction=desc`
         const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, 0)
-        const existing = comments.find(comment => isRecord(comment)
-          && maybeNumber(comment.id)
-          && hasRuntimeType(comment.body, "string")
-          && comment.body.includes(githubActivityMarker))
+        const owned = comments.filter(comment => maybeNumber(isRecord(comment) ? comment.id : undefined)
+          && isOwnedGithubActivityComment(comment, identity))
+        const existing = owned[0]
         const previous = decodeGithubActivityState(isRecord(existing) ? existing.body : undefined)
-        const current = { links: context.activity.links, runId: context.activity.runId }
+        const current = { links: context.activity.links, runId: context.activity.runId, status: context.activity.status }
+        const reconcileDuplicates = async () => {
+          for (const duplicate of owned.slice(1)) {
+            const duplicateId = isRecord(duplicate) ? maybeNumber(duplicate.id) : undefined
+            if (!duplicateId) continue
+            await githubApi(fetcher, `${apiBaseUrl}/repos/${target.repository}/issues/comments/${duplicateId}`, {
+              body: JSON.stringify({ body: "This Agent activity was superseded by a newer managed comment." }),
+              headers,
+              method: "PATCH",
+            })
+          }
+        }
+        const staleRun = previous.current?.runId !== current.runId
+          && (previous.history.some(entry => entry.runId === current.runId)
+            || owned.slice(1).some(comment => {
+              const state = decodeGithubActivityState(isRecord(comment) ? comment.body : undefined)
+              return state.current?.runId === current.runId || state.history.some(entry => entry.runId === current.runId)
+            }))
+        if (staleRun) {
+          await reconcileDuplicates()
+          return
+        }
+        if (previous.current?.runId === current.runId
+          && previous.current.status && ["cancelled", "completed", "failed"].includes(previous.current.status)
+          && !["cancelled", "completed", "failed"].includes(current.status)) return
         const state: GitHubActivityCommentState = previous.current?.runId === current.runId
           ? { current, history: previous.history }
           : {
@@ -1284,6 +1339,7 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
           headers,
           method: commentId ? "PATCH" : "POST",
         })
+        await reconcileDuplicates()
       })
       githubActivityUpdates.set(activityKey, update)
       try {

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1190,6 +1190,7 @@ async function githubActivityIdentity<TRuntimeConfig extends AgentRuntimeConfig>
   fetcher: typeof fetch,
   apiBaseUrl: string,
   headers: Record<string, string>,
+  token: string,
   app: true | GitHubAppOptions<TRuntimeConfig> | undefined,
   context: GitHubAppContext<TRuntimeConfig>,
 ): Promise<GitHubActivityIdentity> {
@@ -1200,6 +1201,10 @@ async function githubActivityIdentity<TRuntimeConfig extends AgentRuntimeConfig>
     if (login) return { login }
   }
   if (app) return githubAppIdentity(app, context)
+  const processEnv = globalThis.process?.env
+  if (processEnv?.GITHUB_TOKEN === token && !processEnv.VITEHUB_GITHUB_TOKEN && !processEnv.GH_TOKEN) {
+    return { login: "github-actions[bot]" }
+  }
   throw new Error("[vitehub] GitHub Agent activity could not resolve the authenticated identity.")
 }
 
@@ -1337,7 +1342,7 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
       if (!token) throw new Error("[vitehub] GitHub Agent activity requires GitHub authentication.")
       const headers = githubApiHeaders(token, options.userAgent)
       const apiBaseUrl = options.apiBaseUrl || "https://api.github.com"
-      const identity = await githubActivityIdentity(fetcher, apiBaseUrl, headers, app, context)
+      const identity = await githubActivityIdentity(fetcher, apiBaseUrl, headers, token, app, context)
       const activityKey = `${apiBaseUrl}/repos/${target.repository}/issues/${target.issue}`
       const previousUpdate = githubActivityUpdates.get(activityKey) || Promise.resolve()
       const update = previousUpdate.catch(() => {}).then(async () => {

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1148,6 +1148,7 @@ const githubActivityLinkUrlLimit = 1_000
 const githubActivityBodyLimit = 65_000
 const githubActivityPreviousRunLimit = 100
 const githubActivityTaskLimit = 25
+const githubActivityActiveRuns = new Map<string, Set<string>>()
 const githubActivityUpdates = new Map<string, Promise<void>>()
 
 interface GitHubActivityTarget {
@@ -1347,13 +1348,21 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
       const activityKey = `${apiBaseUrl}/repos/${target.repository}/issues/${target.issue}`
       const previousUpdate = githubActivityUpdates.get(activityKey) || Promise.resolve()
       const update = previousUpdate.catch(() => {}).then(async () => {
+        const runId = githubActivityRunId(context.activity.runId)
+        const activeRuns = githubActivityActiveRuns.get(activityKey) || new Set<string>()
+        const knownActiveRun = activeRuns.has(runId)
+        const terminal = ["cancelled", "completed", "failed"].includes(context.activity.status)
+        if (!terminal) {
+          activeRuns.add(runId)
+          githubActivityActiveRuns.set(activityKey, activeRuns)
+        }
         const commentsUrl = `${activityKey}/comments?sort=created&direction=desc`
         const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, 0)
         const owned = comments.filter(comment => maybeNumber(isRecord(comment) ? comment.id : undefined)
           && isOwnedGithubActivityComment(comment, identity))
         const existing = owned[0]
         const previous = decodeGithubActivityState(isRecord(existing) ? existing.body : undefined)
-        const current = { links: githubActivityLinksState(context.activity.links), runId: githubActivityRunId(context.activity.runId), status: context.activity.status }
+        const current = { links: githubActivityLinksState(context.activity.links), runId, status: context.activity.status }
         const reconcileDuplicates = async () => {
           for (const duplicate of owned.slice(1)) {
             const duplicateId = isRecord(duplicate) ? maybeNumber(duplicate.id) : undefined
@@ -1366,18 +1375,25 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
           }
         }
         const staleRun = previous.current?.runId !== current.runId
-          && (previous.previousRunIds.includes(current.runId)
+          && (knownActiveRun
+            || previous.previousRunIds.includes(current.runId)
             || owned.slice(1).some(comment => {
               const state = decodeGithubActivityState(isRecord(comment) ? comment.body : undefined)
               return state.current?.runId === current.runId || state.previousRunIds.includes(current.runId)
             }))
         if (staleRun) {
           await reconcileDuplicates()
+          if (terminal) activeRuns.delete(runId)
+          if (!activeRuns.size) githubActivityActiveRuns.delete(activityKey)
           return
         }
         if (previous.current?.runId === current.runId
           && previous.current.status && ["cancelled", "completed", "failed"].includes(previous.current.status)
-          && !["cancelled", "completed", "failed"].includes(current.status)) return
+          && !terminal) {
+          activeRuns.delete(runId)
+          if (!activeRuns.size) githubActivityActiveRuns.delete(activityKey)
+          return
+        }
         const state: GitHubActivityCommentState = previous.current?.runId === current.runId
           ? { current, history: previous.history, previousRunIds: previous.previousRunIds }
           : {
@@ -1397,6 +1413,8 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
           method: commentId ? "PATCH" : "POST",
         })
         await reconcileDuplicates()
+        if (terminal) activeRuns.delete(runId)
+        if (!activeRuns.size) githubActivityActiveRuns.delete(activityKey)
       })
       githubActivityUpdates.set(activityKey, update)
       try {

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1345,15 +1345,15 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
     async update(context) {
       const target = githubActivityTarget(context.target)
       const fetcher = options.fetch || fetch
-      const token = await githubPullRequestMetadataToken(app, context, target.installationId)
-      if (!token) throw new Error("[vitehub] GitHub Agent activity requires GitHub authentication.")
-      const headers = githubApiHeaders(token, options.userAgent)
       const apiBaseUrl = options.apiBaseUrl || "https://api.github.com"
-      const identity = await githubActivityIdentity(fetcher, apiBaseUrl, headers, token, app, context)
       const commentsTarget = `${apiBaseUrl}/repos/${target.repository}/issues/${target.issue}`
-      const activityKey = `${githubActivityIdentityKey(identity)}\0${commentsTarget}`
-      const previousUpdate = githubActivityUpdates.get(activityKey) || Promise.resolve()
+      const previousUpdate = githubActivityUpdates.get(commentsTarget) || Promise.resolve()
       const update = previousUpdate.catch(() => {}).then(async () => {
+        const token = await githubPullRequestMetadataToken(app, context, target.installationId)
+        if (!token) throw new Error("[vitehub] GitHub Agent activity requires GitHub authentication.")
+        const headers = githubApiHeaders(token, options.userAgent)
+        const identity = await githubActivityIdentity(fetcher, apiBaseUrl, headers, token, app, context)
+        const activityKey = `${githubActivityIdentityKey(identity)}\0${commentsTarget}`
         const runId = githubActivityRunId(context.activity.agentName || "", context.activity.runId)
         const activeRuns = githubActivityActiveRuns.get(activityKey) || new Set<string>()
         const knownActiveRun = trackActiveRuns && activeRuns.has(runId)
@@ -1423,12 +1423,12 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         if (terminal) activeRuns.delete(runId)
         if (!activeRuns.size) githubActivityActiveRuns.delete(activityKey)
       })
-      githubActivityUpdates.set(activityKey, update)
+      githubActivityUpdates.set(commentsTarget, update)
       try {
         await update
       }
       finally {
-        if (githubActivityUpdates.get(activityKey) === update) githubActivityUpdates.delete(activityKey)
+        if (githubActivityUpdates.get(commentsTarget) === update) githubActivityUpdates.delete(commentsTarget)
       }
     },
   }
@@ -2283,7 +2283,7 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
         const payload = inputPayloadOrBody(input)
         const activityTarget = githubOpenedPullRequestActivityTarget(input, payload)
         if (activity && activityTarget) {
-          const update = activity.update({
+          const update = Promise.resolve(activity.update({
             ...context,
             activity: {
               ...(context.agentIdentity?.name ? { agentName: context.agentIdentity.name } : {}),
@@ -2293,7 +2293,7 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
               tasks: [],
             },
             target: { ...activityTarget },
-          })
+          }))
           context.waitUntil(update.catch(error => console.error(new Error(
             "[vitehub] GitHub pull request activity initialization failed.",
             { cause: error },

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1148,6 +1148,7 @@ const githubActivityLinkUrlLimit = 1_000
 const githubActivityBodyLimit = 65_000
 const githubActivityStateLimit = 50_000
 const githubActivityCommentLookupLimit = 100
+const githubActivityRestartLookupLimit = 500
 const githubActivityPreviousRunLimit = 100
 const githubActivityTaskLimit = 25
 const githubActivityActiveRuns = new Map<string, Set<string>>()
@@ -1317,7 +1318,10 @@ function githubActivityBadge(status: AgentActivityStatus): string {
 }
 
 function githubActivityTask(task: AgentActivityTask): string {
-  const title = task.title.slice(0, 300)
+  const title = task.title
+    .replace(/[\r\n]+/g, " ")
+    .replace(/([\\`*_[\]<>])/g, "\\$1")
+    .slice(0, 300)
   if (task.status === "completed") return `- [x] ${title}`
   if (task.status === "in-progress") return `- [ ] ⏳ ${title}`
   return `- [ ] ${title}`
@@ -1388,7 +1392,12 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         const terminal = ["cancelled", "completed", "failed"].includes(context.activity.status)
         const commentsUrl = `${commentsTarget}/comments?sort=created&direction=desc`
         const knownCommentId = commentIds.get(activityKey)
-        const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, knownCommentId ? githubActivityCommentLookupLimit : 0)
+        const comments = await githubApiJsonPages(
+          fetcher,
+          commentsUrl,
+          headers,
+          knownCommentId ? githubActivityCommentLookupLimit : githubActivityRestartLookupLimit,
+        )
         const owned = comments.filter(comment => maybeNumber(isRecord(comment) ? comment.id : undefined)
           && isOwnedGithubActivityComment(comment, identity))
         let existing = owned.find(comment => maybeNumber(isRecord(comment) ? comment.id : undefined) === knownCommentId)

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1313,7 +1313,6 @@ function renderGithubActivity(
   if (links.length) sections.push(githubActivityLinks(links))
   if (activity.tasks.length) sections.push(activity.tasks.slice(0, githubActivityTaskLimit).map(githubActivityTask).join("\n"))
   if (activity.error) sections.push(`Agent stopped: ${activity.error.slice(0, 1_000)}`)
-  if (activity.summary) sections.push(activity.summary.slice(0, 12_000))
   if (state.history.length) {
     const history = state.history
       .filter(entry => entry.links.length)
@@ -1338,6 +1337,7 @@ function renderGithubActivity(
 
 function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
   app: true | GitHubAppOptions<TRuntimeConfig> | undefined,
+  trackActiveRuns = true,
 ): NonNullable<AgentChannelDefinition<TRuntimeConfig>["activity"]> {
   const options = githubAppOptions(app) || {}
   return {
@@ -1355,7 +1355,7 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
       const update = previousUpdate.catch(() => {}).then(async () => {
         const runId = githubActivityRunId(context.activity.agentName || "", context.activity.runId)
         const activeRuns = githubActivityActiveRuns.get(activityKey) || new Set<string>()
-        const knownActiveRun = activeRuns.has(runId)
+        const knownActiveRun = trackActiveRuns && activeRuns.has(runId)
         const terminal = ["cancelled", "completed", "failed"].includes(context.activity.status)
         const commentsUrl = `${commentsTarget}/comments?sort=created&direction=desc`
         const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, 0)
@@ -1413,7 +1413,7 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
           headers,
           method: commentId ? "PATCH" : "POST",
         })
-        if (!terminal) {
+        if (!terminal && trackActiveRuns) {
           activeRuns.add(runId)
           githubActivityActiveRuns.set(activityKey, activeRuns)
         }
@@ -2255,30 +2255,60 @@ function githubDevPayload(input: unknown): GitHubIssueCommentPayload | undefined
   return input as GitHubIssueCommentPayload
 }
 
+function githubOpenedPullRequestActivityTarget(input: unknown, payload: unknown): GitHubActivityTarget | undefined {
+  if (!isRecord(payload) || payload.action !== "opened" || !isRecord(payload.pull_request)) return
+  const facts = inputGithubFacts(input)
+  const event = maybeString(facts?.event)
+  if (event && event !== "pull_request") return
+  const repository = isRecord(payload.repository) ? maybeString(payload.repository.full_name) : undefined
+  const issue = maybeNumber(payload.number) ?? maybeNumber(payload.pull_request.number)
+  const installationId = maybeNumber(facts?.installationId)
+    ?? (isRecord(payload.installation) ? maybeNumber(payload.installation.id) : undefined)
+  if (!repository || !issue) return
+  return { repository, issue, ...(installationId ? { installationId } : {}) }
+}
+
 function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
   pullRequest: boolean | GitHubPullRequestCommentEventOptions<TRuntimeConfig> | undefined,
   app?: true | GitHubAppOptions<TRuntimeConfig>,
+  activity?: NonNullable<AgentChannelDefinition<TRuntimeConfig>["activity"]>,
 ): AgentChannelDefinition<TRuntimeConfig>["triggers"] {
-  if (!pullRequest) return undefined
-  const options = pullRequest === true ? {} : pullRequest
+  if (!pullRequest && !activity) return undefined
+  const options = pullRequest === true || !pullRequest ? {} : pullRequest
   return {
     webhook: {
       async invoke(context, input): Promise<AgentTriggerInvokeResult> {
         const payload = inputPayloadOrBody(input)
+        const activityTarget = githubOpenedPullRequestActivityTarget(input, payload)
+        if (activity && activityTarget) {
+          await activity.update({
+            ...context,
+            activity: {
+              ...(context.agentIdentity?.name ? { agentName: context.agentIdentity.name } : {}),
+              links: [],
+              runId: `github:pull_request.opened:${activityTarget.repository}#${activityTarget.issue}`,
+              status: "queued",
+              tasks: [],
+            },
+            target: { ...activityTarget },
+          })
+          return ignored("activity_queued")
+        }
+        if (!pullRequest) return ignored(payload ? "not_command" : "missing_payload")
         const command = githubPullRequestCommandFromInput(isRecord(input) ? { ...input, payload } : { payload })
         if (!payload && !command) return options.ignored?.("missing_payload") || ignored("missing_payload")
         if (!command) return options.ignored?.("not_command") || ignored("not_command")
         if (declaredInputCommand(context, command.command) === false) return options.ignored?.("not_command") || ignored("not_command")
         const metadata = await githubPullRequestMetadata(app, context, command, options, payload)
-        const pullRequest = githubPullRequestRunContext(command, {
+        const pullRequestContext = githubPullRequestRunContext(command, {
           ...options,
           threadId: options.threadId || maybeString(payload?.issue?.pull_request?.html_url) || maybeString(payload?.issue?.html_url) || command.pullRequestUrl,
         }, payload, metadata)
         const finishEffects = githubPullRequestCommentFinishEffects(options)
         return {
           ...(finishEffects ? { delivery: { finishEffects } } : {}),
-          input: pullRequestCommandInput(command, pullRequest),
-          run: githubPullRequestRunMetadata(pullRequest, context.trigger.channelId),
+          input: pullRequestCommandInput(command, pullRequestContext),
+          run: githubPullRequestRunMetadata(pullRequestContext, context.trigger.channelId),
         }
       },
     },
@@ -2416,6 +2446,8 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
   options: GitHubChannelOptions<TRuntimeConfig> = {},
 ): AgentChannelDefinition<TRuntimeConfig> {
   const { activity, app: appOptions, pullRequest, ...channelOptions } = options
+  const activityDefinition = activity ? githubAgentActivity(appOptions) : undefined
+  const openedActivityDefinition = activity ? githubAgentActivity(appOptions, false) : undefined
   const app = githubAppOptions(appOptions)
   const pullRequestOptions = pullRequest === true ? {} : pullRequest || {}
   const workspace = pullRequest ? githubPullRequestWorkspacePolicy(pullRequestOptions) : undefined
@@ -2432,7 +2464,7 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
     : undefined
   return defineChannel("github", {
     ...channelOptions,
-    activity: activity ? githubAgentActivity(appOptions) : undefined,
+    activity: activityDefinition,
     capabilities: [
       ...(workspaceCapability ? [workspaceCapability] : []),
       ...channelOptions.capabilities || [],
@@ -2441,7 +2473,7 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
     effects: appEffects ? { ...appEffects, ...options.effects } as AgentChannelDeliveryEffects<TRuntimeConfig> : options.effects,
     messages: false,
     triggers: {
-      ...githubEventTriggers(pullRequest, appOptions),
+      ...githubEventTriggers(pullRequest, appOptions, openedActivityDefinition),
       ...options.triggers,
     },
     webhooks: githubWebhookDefaults(options.webhooks, appOptions),

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1341,6 +1341,7 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
 ): NonNullable<AgentChannelDefinition<TRuntimeConfig>["activity"]> {
   const trackActiveRuns = mode === "lifecycle"
   const options = githubAppOptions(app) || {}
+  const commentIds = new Map<string, number>()
   return {
     async update(context) {
       const target = githubActivityTarget(context.target)
@@ -1359,7 +1360,11 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         const knownActiveRun = trackActiveRuns && activeRuns.has(runId)
         const terminal = ["cancelled", "completed", "failed"].includes(context.activity.status)
         const commentsUrl = `${commentsTarget}/comments?sort=created&direction=desc`
-        const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, 0)
+        const knownCommentId = commentIds.get(activityKey)
+        const knownComment = knownCommentId
+          ? await githubApiJson(fetcher, `${apiBaseUrl}/repos/${target.repository}/issues/comments/${knownCommentId}`, headers)
+          : undefined
+        const comments = knownCommentId ? [knownComment] : await githubApiJsonPages(fetcher, commentsUrl, headers, 0)
         const owned = comments.filter(comment => maybeNumber(isRecord(comment) ? comment.id : undefined)
           && isOwnedGithubActivityComment(comment, identity))
         const existing = owned[0]
@@ -1410,11 +1415,14 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
             }
         const body = renderGithubActivity(context.activity, state)
         const commentId = isRecord(existing) ? maybeNumber(existing.id) : undefined
-        await githubApi(fetcher, commentId ? `${apiBaseUrl}/repos/${target.repository}/issues/comments/${commentId}` : commentsUrl, {
+        const response = await githubApi(fetcher, commentId ? `${apiBaseUrl}/repos/${target.repository}/issues/comments/${commentId}` : commentsUrl, {
           body: JSON.stringify({ body }),
           headers,
           method: commentId ? "PATCH" : "POST",
         })
+        const written = await response.clone().json().catch(() => undefined)
+        const writtenCommentId = commentId || maybeNumber(isRecord(written) ? written.id : undefined)
+        if (writtenCommentId) commentIds.set(activityKey, writtenCommentId)
         if (!terminal && trackActiveRuns) {
           activeRuns.add(runId)
           githubActivityActiveRuns.set(activityKey, activeRuns)

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1202,11 +1202,11 @@ async function githubActivityIdentity<TRuntimeConfig extends AgentRuntimeConfig>
     const login = isRecord(user) ? maybeString(user.login) : undefined
     if (login) return { login }
   }
-  if (app) return githubAppIdentity(app, context)
   const processEnv = globalThis.process?.env
   if (processEnv?.GITHUB_TOKEN === token && !processEnv.VITEHUB_GITHUB_TOKEN && !processEnv.GH_TOKEN) {
     return { login: "github-actions[bot]" }
   }
+  if (app) return githubAppIdentity(app, context)
   throw new Error("[vitehub] GitHub Agent activity could not resolve the authenticated identity.")
 }
 

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1224,8 +1224,8 @@ function isOwnedGithubActivityComment(comment: unknown, identity: GitHubActivity
   return Boolean(identity.appId ? appId === identity.appId : identity.login && user === identity.login)
 }
 
-function githubActivityRunId(runId: string): string {
-  return createHash("sha256").update(runId).digest("base64url")
+function githubActivityRunId(agentName: string, runId: string): string {
+  return createHash("sha256").update(`${agentName}\0${runId}`).digest("base64url")
 }
 
 function githubActivityTarget(value: unknown): GitHubActivityTarget {
@@ -1348,14 +1348,10 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
       const activityKey = `${apiBaseUrl}/repos/${target.repository}/issues/${target.issue}`
       const previousUpdate = githubActivityUpdates.get(activityKey) || Promise.resolve()
       const update = previousUpdate.catch(() => {}).then(async () => {
-        const runId = githubActivityRunId(context.activity.runId)
+        const runId = githubActivityRunId(context.activity.agentName || "", context.activity.runId)
         const activeRuns = githubActivityActiveRuns.get(activityKey) || new Set<string>()
         const knownActiveRun = activeRuns.has(runId)
         const terminal = ["cancelled", "completed", "failed"].includes(context.activity.status)
-        if (!terminal) {
-          activeRuns.add(runId)
-          githubActivityActiveRuns.set(activityKey, activeRuns)
-        }
         const commentsUrl = `${activityKey}/comments?sort=created&direction=desc`
         const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, 0)
         const owned = comments.filter(comment => maybeNumber(isRecord(comment) ? comment.id : undefined)
@@ -1412,6 +1408,10 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
           headers,
           method: commentId ? "PATCH" : "POST",
         })
+        if (!terminal) {
+          activeRuns.add(runId)
+          githubActivityActiveRuns.set(activityKey, activeRuns)
+        }
         await reconcileDuplicates()
         if (terminal) activeRuns.delete(runId)
         if (!activeRuns.size) githubActivityActiveRuns.delete(activityKey)

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1205,7 +1205,7 @@ async function githubActivityIdentity<TRuntimeConfig extends AgentRuntimeConfig>
     if (login) return { login }
   }
   const processEnv = globalThis.process?.env
-  if (processEnv?.GITHUB_TOKEN === token && !processEnv.VITEHUB_GITHUB_TOKEN && !processEnv.GH_TOKEN) {
+  if (!processEnv?.VITEHUB_GITHUB_TOKEN && (processEnv?.GH_TOKEN === token || processEnv?.GITHUB_TOKEN === token)) {
     return { login: "github-actions[bot]" }
   }
   if (app) return githubAppIdentity(app, context)

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1149,14 +1149,15 @@ async function githubApiJsonRecentPages(fetcher: typeof fetch, url: string, head
   const lastPage = githubApiLastPage(firstResponse.headers.get("link"))
   if (!lastPage || lastPage === 1) return firstItems.slice(-limit).reverse()
   const items: unknown[] = []
-  const pageLimit = Math.ceil(limit / 100)
-  for (let page = lastPage; page > Math.max(0, lastPage - pageLimit) && items.length < limit; page--) {
+  const pageLimit = Math.ceil(limit / 100) + 1
+  for (let page = lastPage; page > Math.max(1, lastPage - pageLimit) && items.length < limit; page--) {
     const response = await fetcher(githubApiPageUrl(url, page), { headers, method: "GET" })
     if (!response.ok) throw new Error(`[vitehub] GitHub metadata request failed with ${response.status}.`)
     const pageItems = await response.json().catch(() => undefined)
     if (!Array.isArray(pageItems)) break
     items.push(...pageItems.reverse())
   }
+  if (items.length < limit && lastPage <= pageLimit) items.push(...firstItems.reverse())
   return items.slice(0, limit)
 }
 

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1162,6 +1162,7 @@ interface GitHubActivityHistoryEntry {
 interface GitHubActivityCommentState {
   current?: GitHubActivityHistoryEntry
   history: readonly GitHubActivityHistoryEntry[]
+  previousRunIds: readonly string[]
 }
 
 interface GitHubActivityIdentity {
@@ -1226,12 +1227,12 @@ function githubActivityTarget(value: unknown): GitHubActivityTarget {
 }
 
 function decodeGithubActivityState(body: unknown): GitHubActivityCommentState {
-  if (!hasRuntimeType(body, "string")) return { history: [] }
+  if (!hasRuntimeType(body, "string")) return { history: [], previousRunIds: [] }
   const encoded = body.match(/<!-- vitehub-agent-activity:([A-Za-z0-9_-]+) -->/)?.[1]
-  if (!encoded) return { history: [] }
+  if (!encoded) return { history: [], previousRunIds: [] }
   try {
     const value = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"))
-    if (!isRecord(value)) return { history: [] }
+    if (!isRecord(value)) return { history: [], previousRunIds: [] }
     const entries = (items: unknown): GitHubActivityHistoryEntry[] => Array.isArray(items)
       ? items.flatMap((item) => {
           if (!isRecord(item) || !maybeString(item.runId) || !Array.isArray(item.links)) return []
@@ -1242,13 +1243,15 @@ function decodeGithubActivityState(body: unknown): GitHubActivityCommentState {
           return [{ links, runId: maybeString(item.runId)!, ...(status && ["cancelled", "completed", "failed", "queued", "running", "waiting"].includes(status) ? { status: status as AgentActivityStatus } : {}) }]
         })
       : []
-    return {
-      current: entries(value.current ? [value.current] : [])[0],
-      history: entries(value.history).slice(0, githubActivityHistoryLimit),
-    }
+    const current = entries(value.current ? [value.current] : [])[0]
+    const history = entries(value.history).slice(0, githubActivityHistoryLimit)
+    const previousRunIds = Array.isArray(value.previousRunIds)
+      ? value.previousRunIds.flatMap(runId => maybeString(runId) || []).filter(runId => runId !== current?.runId)
+      : history.map(entry => entry.runId)
+    return { current, history, previousRunIds: [...new Set(previousRunIds)] }
   }
   catch {
-    return { history: [] }
+    return { history: [], previousRunIds: [] }
   }
 }
 
@@ -1338,10 +1341,10 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
           }
         }
         const staleRun = previous.current?.runId !== current.runId
-          && (previous.history.some(entry => entry.runId === current.runId)
+          && (previous.previousRunIds.includes(current.runId)
             || owned.slice(1).some(comment => {
               const state = decodeGithubActivityState(isRecord(comment) ? comment.body : undefined)
-              return state.current?.runId === current.runId || state.history.some(entry => entry.runId === current.runId)
+              return state.current?.runId === current.runId || state.previousRunIds.includes(current.runId)
             }))
         if (staleRun) {
           await reconcileDuplicates()
@@ -1351,12 +1354,14 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
           && previous.current.status && ["cancelled", "completed", "failed"].includes(previous.current.status)
           && !["cancelled", "completed", "failed"].includes(current.status)) return
         const state: GitHubActivityCommentState = previous.current?.runId === current.runId
-          ? { current, history: previous.history }
+          ? { current, history: previous.history, previousRunIds: previous.previousRunIds }
           : {
               current,
               history: [previous.current, ...previous.history]
                 .filter((entry): entry is GitHubActivityHistoryEntry => entry !== undefined && entry.runId !== current.runId)
                 .slice(0, githubActivityHistoryLimit),
+              previousRunIds: [previous.current?.runId, ...previous.previousRunIds]
+                .filter((runId): runId is string => runId !== undefined && runId !== current.runId),
             }
         const body = renderGithubActivity(context.activity, state)
         const commentId = isRecord(existing) ? maybeNumber(existing.id) : undefined

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1137,11 +1137,12 @@ async function githubApiJsonPages(fetcher: typeof fetch, url: string, headers: R
     if (limit > 0 && items.length >= limit) break
     nextUrl = githubApiNextPageUrl(response.headers.get("link")) || githubApiPageUrl(url, ++page)
   }
-  return limit > 0 ? items.slice(0, limit) : []
+  return limit > 0 ? items.slice(0, limit) : items
 }
 
 const githubActivityMarker = "<!-- vitehub-agent-activity:"
 const githubActivityHistoryLimit = 10
+const githubActivityUpdates = new Map<string, Promise<void>>()
 
 interface GitHubActivityTarget {
   installationId?: number
@@ -1257,29 +1258,40 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
       if (!token) throw new Error("[vitehub] GitHub Agent activity requires GitHub authentication.")
       const headers = githubApiHeaders(token, options.userAgent)
       const apiBaseUrl = options.apiBaseUrl || "https://api.github.com"
-      const commentsUrl = `${apiBaseUrl}/repos/${target.repository}/issues/${target.issue}/comments?sort=created&direction=desc`
-      const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, 100)
-      const existing = comments.find(comment => isRecord(comment)
-        && maybeNumber(comment.id)
-        && hasRuntimeType(comment.body, "string")
-        && comment.body.includes(githubActivityMarker))
-      const previous = decodeGithubActivityState(isRecord(existing) ? existing.body : undefined)
-      const current = { links: context.activity.links, runId: context.activity.runId }
-      const state: GitHubActivityCommentState = previous.current?.runId === current.runId
-        ? { current, history: previous.history }
-        : {
-            current,
-            history: [previous.current, ...previous.history]
-              .filter((entry): entry is GitHubActivityHistoryEntry => entry !== undefined && entry.runId !== current.runId)
-              .slice(0, githubActivityHistoryLimit),
-          }
-      const body = renderGithubActivity(context.activity, state)
-      const commentId = isRecord(existing) ? maybeNumber(existing.id) : undefined
-      await githubApi(fetcher, commentId ? `${apiBaseUrl}/repos/${target.repository}/issues/comments/${commentId}` : commentsUrl, {
-        body: JSON.stringify({ body }),
-        headers,
-        method: commentId ? "PATCH" : "POST",
+      const activityKey = `${apiBaseUrl}/repos/${target.repository}/issues/${target.issue}`
+      const previousUpdate = githubActivityUpdates.get(activityKey) || Promise.resolve()
+      const update = previousUpdate.catch(() => {}).then(async () => {
+        const commentsUrl = `${activityKey}/comments?sort=created&direction=desc`
+        const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, 0)
+        const existing = comments.find(comment => isRecord(comment)
+          && maybeNumber(comment.id)
+          && hasRuntimeType(comment.body, "string")
+          && comment.body.includes(githubActivityMarker))
+        const previous = decodeGithubActivityState(isRecord(existing) ? existing.body : undefined)
+        const current = { links: context.activity.links, runId: context.activity.runId }
+        const state: GitHubActivityCommentState = previous.current?.runId === current.runId
+          ? { current, history: previous.history }
+          : {
+              current,
+              history: [previous.current, ...previous.history]
+                .filter((entry): entry is GitHubActivityHistoryEntry => entry !== undefined && entry.runId !== current.runId)
+                .slice(0, githubActivityHistoryLimit),
+            }
+        const body = renderGithubActivity(context.activity, state)
+        const commentId = isRecord(existing) ? maybeNumber(existing.id) : undefined
+        await githubApi(fetcher, commentId ? `${apiBaseUrl}/repos/${target.repository}/issues/comments/${commentId}` : commentsUrl, {
+          body: JSON.stringify({ body }),
+          headers,
+          method: commentId ? "PATCH" : "POST",
+        })
       })
+      githubActivityUpdates.set(activityKey, update)
+      try {
+        await update
+      }
+      finally {
+        if (githubActivityUpdates.get(activityKey) === update) githubActivityUpdates.delete(activityKey)
+      }
     },
   }
 }

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1144,6 +1144,7 @@ async function githubApiJsonPages(fetcher: typeof fetch, url: string, headers: R
 const githubActivityMarker = "<!-- vitehub-agent-activity:"
 const githubActivityHistoryLimit = 10
 const githubActivityLinkLimit = 3
+const githubActivityLinkUrlLimit = 1_000
 const githubActivityBodyLimit = 65_000
 const githubActivityPreviousRunLimit = 100
 const githubActivityTaskLimit = 25
@@ -1209,10 +1210,10 @@ async function githubActivityIdentity<TRuntimeConfig extends AgentRuntimeConfig>
 }
 
 function githubActivityLinksState(links: readonly { label: string, url: string }[]): { label: string, url: string }[] {
-  return links.slice(0, githubActivityLinkLimit).map(link => ({
-    label: link.label.slice(0, 80),
-    url: link.url.slice(0, 400),
-  }))
+  return links
+    .filter(link => Buffer.byteLength(link.url) <= githubActivityLinkUrlLimit)
+    .slice(0, githubActivityLinkLimit)
+    .map(link => ({ label: link.label.slice(0, 80), url: link.url }))
 }
 
 function isOwnedGithubActivityComment(comment: unknown, identity: GitHubActivityIdentity): boolean {

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1141,6 +1141,25 @@ async function githubApiJsonPages(fetcher: typeof fetch, url: string, headers: R
   return limit > 0 ? items.slice(0, limit) : items
 }
 
+async function githubApiJsonRecentPages(fetcher: typeof fetch, url: string, headers: Record<string, string>, limit: number): Promise<unknown[]> {
+  const firstResponse = await fetcher(githubApiPageUrl(url, 1), { headers, method: "GET" })
+  if (!firstResponse.ok) throw new Error(`[vitehub] GitHub metadata request failed with ${firstResponse.status}.`)
+  const firstItems = await firstResponse.json().catch(() => undefined)
+  if (!Array.isArray(firstItems) || !firstItems.length) return []
+  const lastPage = githubApiLastPage(firstResponse.headers.get("link"))
+  if (!lastPage || lastPage === 1) return firstItems.slice(-limit).reverse()
+  const items: unknown[] = []
+  const pageLimit = Math.ceil(limit / 100)
+  for (let page = lastPage; page > Math.max(0, lastPage - pageLimit) && items.length < limit; page--) {
+    const response = await fetcher(githubApiPageUrl(url, page), { headers, method: "GET" })
+    if (!response.ok) throw new Error(`[vitehub] GitHub metadata request failed with ${response.status}.`)
+    const pageItems = await response.json().catch(() => undefined)
+    if (!Array.isArray(pageItems)) break
+    items.push(...pageItems.reverse())
+  }
+  return items.slice(0, limit)
+}
+
 const githubActivityMarker = "<!-- vitehub-agent-activity:"
 const githubActivityHistoryLimit = 10
 const githubActivityLinkLimit = 3
@@ -1394,14 +1413,10 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         const activeRuns = githubActivityActiveRuns.get(activityKey) || new Set<string>()
         const knownActiveRun = trackActiveRuns && activeRuns.has(runId)
         const terminal = ["cancelled", "completed", "failed"].includes(context.activity.status)
-        const commentsUrl = `${commentsTarget}/comments?sort=created&direction=desc`
+        const commentsUrl = `${commentsTarget}/comments`
         const knownCommentId = commentIds.get(activityKey)
-        const comments = await githubApiJsonPages(
-          fetcher,
-          commentsUrl,
-          headers,
-          knownCommentId ? githubActivityCommentLookupLimit : githubActivityRestartLookupLimit,
-        )
+        const comments = await githubApiJsonRecentPages(fetcher, commentsUrl, headers,
+          knownCommentId ? githubActivityCommentLookupLimit : githubActivityRestartLookupLimit)
         const owned = comments.filter(comment => maybeNumber(isRecord(comment) ? comment.id : undefined)
           && isOwnedGithubActivityComment(comment, identity))
         let existing = owned.find(comment => maybeNumber(isRecord(comment) ? comment.id : undefined) === knownCommentId)
@@ -1500,6 +1515,13 @@ function githubApiPageUrl(url: string, page: number): string {
 
 function githubApiNextPageUrl(link: string | null): string | undefined {
   return link?.split(",").map(part => part.trim()).find(part => part.endsWith(`rel="next"`))?.match(/^<([^>]+)>/)?.[1]
+}
+
+function githubApiLastPage(link: string | null): number | undefined {
+  const last = link?.split(",").map(part => part.trim()).find(part => part.endsWith(`rel="last"`))?.match(/^<([^>]+)>/)?.[1]
+  if (!last) return
+  const page = Number(new URL(last).searchParams.get("page"))
+  return Number.isSafeInteger(page) && page > 0 ? page : undefined
 }
 
 function reactionContent<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1144,6 +1144,7 @@ async function githubApiJsonPages(fetcher: typeof fetch, url: string, headers: R
 const githubActivityMarker = "<!-- vitehub-agent-activity:"
 const githubActivityHistoryLimit = 10
 const githubActivityLinkLimit = 3
+const githubActivityBodyLimit = 65_000
 const githubActivityPreviousRunLimit = 100
 const githubActivityTaskLimit = 25
 const githubActivityUpdates = new Map<string, Promise<void>>()
@@ -1300,8 +1301,8 @@ function renderGithubActivity(
   const links = githubActivityLinksState(activity.links)
   if (links.length) sections.push(githubActivityLinks(links))
   if (activity.tasks.length) sections.push(activity.tasks.slice(0, githubActivityTaskLimit).map(githubActivityTask).join("\n"))
-  if (activity.summary) sections.push(activity.summary.slice(0, 12_000))
   if (activity.error) sections.push(`Agent stopped: ${activity.error.slice(0, 1_000)}`)
+  if (activity.summary) sections.push(activity.summary.slice(0, 12_000))
   if (state.history.length) {
     const history = state.history
       .filter(entry => entry.links.length)
@@ -1309,7 +1310,19 @@ function renderGithubActivity(
       .join("\n")
     if (history) sections.push(`<details>\n<summary>Previous sessions</summary>\n\n<ul>\n${history}\n</ul>\n</details>`)
   }
-  return sections.join("\n\n")
+  const body = sections.join("\n\n")
+  if (Buffer.byteLength(body) <= githubActivityBodyLimit) return body
+  let bounded = ""
+  for (const section of sections) {
+    const separator = bounded ? "\n\n" : ""
+    const remaining = githubActivityBodyLimit - Buffer.byteLength(bounded) - Buffer.byteLength(separator)
+    if (remaining <= 0) break
+    const sectionBytes = Buffer.from(section)
+    bounded += separator + (sectionBytes.byteLength <= remaining
+      ? section
+      : sectionBytes.subarray(0, remaining).toString("utf8").replace(/\uFFFD$/u, ""))
+  }
+  return bounded
 }
 
 function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -2283,7 +2283,7 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
         const payload = inputPayloadOrBody(input)
         const activityTarget = githubOpenedPullRequestActivityTarget(input, payload)
         if (activity && activityTarget) {
-          await activity.update({
+          const update = activity.update({
             ...context,
             activity: {
               ...(context.agentIdentity?.name ? { agentName: context.agentIdentity.name } : {}),
@@ -2294,6 +2294,10 @@ function githubEventTriggers<TRuntimeConfig extends AgentRuntimeConfig>(
             },
             target: { ...activityTarget },
           })
+          context.waitUntil(update.catch(error => console.error(new Error(
+            "[vitehub] GitHub pull request activity initialization failed.",
+            { cause: error },
+          ))))
           return ignored("activity_queued")
         }
         if (!pullRequest) return ignored(payload ? "not_command" : "missing_payload")

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1146,6 +1146,7 @@ const githubActivityHistoryLimit = 10
 const githubActivityLinkLimit = 3
 const githubActivityLinkUrlLimit = 1_000
 const githubActivityBodyLimit = 65_000
+const githubActivityCommentLookupLimit = 100
 const githubActivityPreviousRunLimit = 100
 const githubActivityTaskLimit = 25
 const githubActivityActiveRuns = new Map<string, Set<string>>()
@@ -1361,18 +1362,16 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         const terminal = ["cancelled", "completed", "failed"].includes(context.activity.status)
         const commentsUrl = `${commentsTarget}/comments?sort=created&direction=desc`
         const knownCommentId = commentIds.get(activityKey)
-        const knownComment = knownCommentId
-          ? await githubApiJson(fetcher, `${apiBaseUrl}/repos/${target.repository}/issues/comments/${knownCommentId}`, headers)
-          : undefined
-        const comments = knownCommentId ? [knownComment] : await githubApiJsonPages(fetcher, commentsUrl, headers, 0)
+        const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, githubActivityCommentLookupLimit)
         const owned = comments.filter(comment => maybeNumber(isRecord(comment) ? comment.id : undefined)
           && isOwnedGithubActivityComment(comment, identity))
-        const existing = owned[0]
+        const existing = owned.find(comment => maybeNumber(isRecord(comment) ? comment.id : undefined) === knownCommentId) || owned[0]
+        if (knownCommentId && !existing) commentIds.delete(activityKey)
         if (mode === "initialize" && existing) return
         const previous = decodeGithubActivityState(isRecord(existing) ? existing.body : undefined)
         const current = { links: githubActivityLinksState(context.activity.links), runId, status: context.activity.status }
         const reconcileDuplicates = async () => {
-          for (const duplicate of owned.slice(1)) {
+          for (const duplicate of owned.filter(comment => comment !== existing)) {
             const duplicateId = isRecord(duplicate) ? maybeNumber(duplicate.id) : undefined
             if (!duplicateId) continue
             await githubApi(fetcher, `${apiBaseUrl}/repos/${target.repository}/issues/comments/${duplicateId}`, {
@@ -1385,7 +1384,7 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         const staleRun = previous.current?.runId !== current.runId
           && (knownActiveRun
             || previous.previousRunIds.includes(current.runId)
-            || owned.slice(1).some(comment => {
+            || owned.filter(comment => comment !== existing).some(comment => {
               const state = decodeGithubActivityState(isRecord(comment) ? comment.body : undefined)
               return state.current?.runId === current.runId || state.previousRunIds.includes(current.runId)
             }))

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1143,6 +1143,8 @@ async function githubApiJsonPages(fetcher: typeof fetch, url: string, headers: R
 
 const githubActivityMarker = "<!-- vitehub-agent-activity:"
 const githubActivityHistoryLimit = 10
+const githubActivityLinkLimit = 3
+const githubActivityTaskLimit = 25
 const githubActivityUpdates = new Map<string, Promise<void>>()
 
 interface GitHubActivityTarget {
@@ -1167,20 +1169,42 @@ interface GitHubActivityIdentity {
   login?: string
 }
 
-async function githubActivityIdentity(fetcher: typeof fetch, apiBaseUrl: string, headers: Record<string, string>): Promise<GitHubActivityIdentity> {
+async function githubAppIdentity<TRuntimeConfig extends AgentRuntimeConfig>(
+  app: true | GitHubAppOptions<TRuntimeConfig>,
+  context: GitHubAppContext<TRuntimeConfig>,
+): Promise<GitHubActivityIdentity> {
+  const options = githubAppOptions(app) || {}
+  const env = await githubEnv(context)
+  const appId = requiredString(await githubAppSetting(options, env, "appId", "appId", context), "appId")
+  const headers = githubApiHeaders(githubAppJwt(appId, await githubAppPrivateKey(options, env, context)), options.userAgent)
+  const appMetadata = await githubApiJson(options.fetch || fetch, `${options.apiBaseUrl || "https://api.github.com"}/app`, headers)
+  const slug = isRecord(appMetadata) ? maybeString(appMetadata.slug) : undefined
+  if (!slug) throw new Error("[vitehub] GitHub App metadata did not include a slug.")
+  return { app: slug }
+}
+
+async function githubActivityIdentity<TRuntimeConfig extends AgentRuntimeConfig>(
+  fetcher: typeof fetch,
+  apiBaseUrl: string,
+  headers: Record<string, string>,
+  app: true | GitHubAppOptions<TRuntimeConfig> | undefined,
+  context: GitHubAppContext<TRuntimeConfig>,
+): Promise<GitHubActivityIdentity> {
   const userResponse = await fetcher(`${apiBaseUrl}/user`, { headers, method: "GET" })
   if (userResponse.ok) {
     const user = await userResponse.json().catch(() => undefined)
     const login = isRecord(user) ? maybeString(user.login) : undefined
     if (login) return { login }
   }
-  const installationResponse = await fetcher(`${apiBaseUrl}/installation`, { headers, method: "GET" })
-  if (installationResponse.ok) {
-    const installation = await installationResponse.json().catch(() => undefined)
-    const app = isRecord(installation) ? maybeString(installation.app_slug) : undefined
-    if (app) return { app }
-  }
+  if (app) return githubAppIdentity(app, context)
   throw new Error("[vitehub] GitHub Agent activity could not resolve the authenticated identity.")
+}
+
+function githubActivityLinksState(links: readonly { label: string, url: string }[]): { label: string, url: string }[] {
+  return links.slice(0, githubActivityLinkLimit).map(link => ({
+    label: link.label.slice(0, 80),
+    url: link.url.slice(0, 400),
+  }))
 }
 
 function isOwnedGithubActivityComment(comment: unknown, identity: GitHubActivityIdentity): boolean {
@@ -1211,9 +1235,9 @@ function decodeGithubActivityState(body: unknown): GitHubActivityCommentState {
     const entries = (items: unknown): GitHubActivityHistoryEntry[] => Array.isArray(items)
       ? items.flatMap((item) => {
           if (!isRecord(item) || !maybeString(item.runId) || !Array.isArray(item.links)) return []
-          const links = item.links.flatMap(link => isRecord(link) && maybeString(link.label) && maybeString(link.url)
+          const links = githubActivityLinksState(item.links.flatMap(link => isRecord(link) && maybeString(link.label) && maybeString(link.url)
             ? [{ label: maybeString(link.label)!, url: maybeString(link.url)! }]
-            : [])
+            : []))
           const status = maybeString(item.status)
           return [{ links, runId: maybeString(item.runId)!, ...(status && ["cancelled", "completed", "failed", "queued", "running", "waiting"].includes(status) ? { status: status as AgentActivityStatus } : {}) }]
         })
@@ -1246,9 +1270,10 @@ function githubActivityBadge(status: AgentActivityStatus): string {
 }
 
 function githubActivityTask(task: AgentActivityTask): string {
-  if (task.status === "completed") return `- [x] ${task.title}`
-  if (task.status === "in-progress") return `- [ ] ⏳ ${task.title}`
-  return `- [ ] ${task.title}`
+  const title = task.title.slice(0, 300)
+  if (task.status === "completed") return `- [x] ${title}`
+  if (task.status === "in-progress") return `- [ ] ⏳ ${title}`
+  return `- [ ] ${title}`
 }
 
 function githubActivityLinks(links: readonly { label: string, url: string }[]): string {
@@ -1263,8 +1288,9 @@ function renderGithubActivity(
     encodeGithubActivityState(state),
     githubActivityBadge(activity.status),
   ]
-  if (activity.links.length) sections.push(githubActivityLinks(activity.links))
-  if (activity.tasks.length) sections.push(activity.tasks.map(githubActivityTask).join("\n"))
+  const links = githubActivityLinksState(activity.links)
+  if (links.length) sections.push(githubActivityLinks(links))
+  if (activity.tasks.length) sections.push(activity.tasks.slice(0, githubActivityTaskLimit).map(githubActivityTask).join("\n"))
   if (activity.summary) sections.push(activity.summary.slice(0, 12_000))
   if (activity.error) sections.push(`Agent stopped: ${activity.error.slice(0, 1_000)}`)
   if (state.history.length) {
@@ -1289,7 +1315,7 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
       if (!token) throw new Error("[vitehub] GitHub Agent activity requires GitHub authentication.")
       const headers = githubApiHeaders(token, options.userAgent)
       const apiBaseUrl = options.apiBaseUrl || "https://api.github.com"
-      const identity = await githubActivityIdentity(fetcher, apiBaseUrl, headers)
+      const identity = await githubActivityIdentity(fetcher, apiBaseUrl, headers, app, context)
       const activityKey = `${apiBaseUrl}/repos/${target.repository}/issues/${target.issue}`
       const previousUpdate = githubActivityUpdates.get(activityKey) || Promise.resolve()
       const update = previousUpdate.catch(() => {}).then(async () => {
@@ -1299,7 +1325,7 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
           && isOwnedGithubActivityComment(comment, identity))
         const existing = owned[0]
         const previous = decodeGithubActivityState(isRecord(existing) ? existing.body : undefined)
-        const current = { links: context.activity.links, runId: context.activity.runId, status: context.activity.status }
+        const current = { links: githubActivityLinksState(context.activity.links), runId: context.activity.runId, status: context.activity.status }
         const reconcileDuplicates = async () => {
           for (const duplicate of owned.slice(1)) {
             const duplicateId = isRecord(duplicate) ? maybeNumber(duplicate.id) : undefined

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -17,6 +17,9 @@ import type {
 } from "./delivery-artifacts.ts"
 
 import type {
+  AgentActivityStatus,
+  AgentActivityTask,
+  AgentActivityUpdate,
   AgentCallbackContext,
   AgentCapabilityDefinition,
   AgentChatFinishExtension,
@@ -70,6 +73,14 @@ export type {
 } from "./delivery-artifacts.ts"
 export { defineFinishEffect } from "./delivery-effects.ts"
 export type {
+  AgentActivityLink,
+  AgentActivityStatus,
+  AgentActivityTask,
+  AgentActivityTaskStatus,
+  AgentActivityTarget,
+  AgentActivityUpdate,
+  AgentChannelActivityContext,
+  AgentChannelActivityDefinition,
   AgentChannelDeliveryEffectContext,
   AgentChannelDeliveryEffectHandler,
   AgentChannelDeliveryEffectIntent,
@@ -362,6 +373,7 @@ export interface GitHubPullRequestCommentEventOptions<TRuntimeConfig extends Age
 
 export interface GitHubChannelOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>
   extends AgentChannelOptions<TRuntimeConfig> {
+  activity?: boolean
   app?: true | GitHubAppOptions<TRuntimeConfig>
   pullRequest?: boolean | GitHubPullRequestCommentEventOptions<TRuntimeConfig>
 }
@@ -1126,6 +1138,150 @@ async function githubApiJsonPages(fetcher: typeof fetch, url: string, headers: R
     nextUrl = githubApiNextPageUrl(response.headers.get("link")) || githubApiPageUrl(url, ++page)
   }
   return limit > 0 ? items.slice(0, limit) : []
+}
+
+const githubActivityMarker = "<!-- vitehub-agent-activity:"
+const githubActivityHistoryLimit = 10
+
+interface GitHubActivityTarget {
+  installationId?: number
+  issue: number
+  repository: string
+}
+
+interface GitHubActivityHistoryEntry {
+  links: readonly { label: string, url: string }[]
+  runId: string
+}
+
+interface GitHubActivityCommentState {
+  current?: GitHubActivityHistoryEntry
+  history: readonly GitHubActivityHistoryEntry[]
+}
+
+function githubActivityTarget(value: unknown): GitHubActivityTarget {
+  if (!isRecord(value)) throw new TypeError("[vitehub] GitHub Agent activity requires a target with repository and issue.")
+  const repository = maybeString(value.repository)
+  const issue = maybeNumber(value.issue)
+  const installationId = maybeNumber(value.installationId)
+  if (!repository || !/^[^/\s]+\/[^/\s]+$/.test(repository) || !Number.isSafeInteger(issue) || issue! < 1) {
+    throw new TypeError("[vitehub] GitHub Agent activity requires a target with repository and issue.")
+  }
+  return { repository, issue: issue!, ...(installationId ? { installationId } : {}) }
+}
+
+function decodeGithubActivityState(body: unknown): GitHubActivityCommentState {
+  if (!hasRuntimeType(body, "string")) return { history: [] }
+  const encoded = body.match(/<!-- vitehub-agent-activity:([A-Za-z0-9_-]+) -->/)?.[1]
+  if (!encoded) return { history: [] }
+  try {
+    const value = JSON.parse(Buffer.from(encoded, "base64url").toString("utf8"))
+    if (!isRecord(value)) return { history: [] }
+    const entries = (items: unknown): GitHubActivityHistoryEntry[] => Array.isArray(items)
+      ? items.flatMap((item) => {
+          if (!isRecord(item) || !maybeString(item.runId) || !Array.isArray(item.links)) return []
+          const links = item.links.flatMap(link => isRecord(link) && maybeString(link.label) && maybeString(link.url)
+            ? [{ label: maybeString(link.label)!, url: maybeString(link.url)! }]
+            : [])
+          return [{ links, runId: maybeString(item.runId)! }]
+        })
+      : []
+    return {
+      current: entries(value.current ? [value.current] : [])[0],
+      history: entries(value.history).slice(0, githubActivityHistoryLimit),
+    }
+  }
+  catch {
+    return { history: [] }
+  }
+}
+
+function encodeGithubActivityState(state: GitHubActivityCommentState): string {
+  return `${githubActivityMarker}${Buffer.from(JSON.stringify(state)).toString("base64url")} -->`
+}
+
+function githubActivityBadge(status: AgentActivityStatus): string {
+  const values: Record<AgentActivityStatus, { color: string, label: string }> = {
+    cancelled: { color: "6e7781", label: "cancelled" },
+    completed: { color: "1f883d", label: "completed" },
+    failed: { color: "d1242f", label: "failed" },
+    queued: { color: "6e7781", label: "queued" },
+    running: { color: "0969da", label: "running" },
+    waiting: { color: "bf8700", label: "waiting for input" },
+  }
+  const value = values[status]
+  return `![Agent: ${value.label}](https://img.shields.io/badge/agent-${encodeURIComponent(value.label)}-${value.color})`
+}
+
+function githubActivityTask(task: AgentActivityTask): string {
+  if (task.status === "completed") return `- [x] ${task.title}`
+  if (task.status === "in-progress") return `- [ ] ⏳ ${task.title}`
+  return `- [ ] ${task.title}`
+}
+
+function githubActivityLinks(links: readonly { label: string, url: string }[]): string {
+  return links.map(link => `[${link.label}](<${link.url}>)`).join(" · ")
+}
+
+function renderGithubActivity(
+  activity: AgentActivityUpdate,
+  state: GitHubActivityCommentState,
+): string {
+  const sections = [
+    encodeGithubActivityState(state),
+    githubActivityBadge(activity.status),
+  ]
+  if (activity.links.length) sections.push(githubActivityLinks(activity.links))
+  if (activity.tasks.length) sections.push(activity.tasks.map(githubActivityTask).join("\n"))
+  if (activity.summary) sections.push(activity.summary.slice(0, 12_000))
+  else if (activity.error) sections.push(`Agent stopped: ${activity.error.slice(0, 1_000)}`)
+  if (state.history.length) {
+    const history = state.history
+      .filter(entry => entry.links.length)
+      .map(entry => `<li>${githubActivityLinks(entry.links)}</li>`)
+      .join("\n")
+    if (history) sections.push(`<details>\n<summary>Previous sessions</summary>\n\n<ul>\n${history}\n</ul>\n</details>`)
+  }
+  return sections.join("\n\n")
+}
+
+function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
+  app: true | GitHubAppOptions<TRuntimeConfig> | undefined,
+): NonNullable<AgentChannelDefinition<TRuntimeConfig>["activity"]> {
+  const options = githubAppOptions(app) || {}
+  return {
+    async update(context) {
+      const target = githubActivityTarget(context.target)
+      const fetcher = options.fetch || fetch
+      const token = await githubPullRequestMetadataToken(app, context, target.installationId)
+      if (!token) throw new Error("[vitehub] GitHub Agent activity requires GitHub authentication.")
+      const headers = githubApiHeaders(token, options.userAgent)
+      const apiBaseUrl = options.apiBaseUrl || "https://api.github.com"
+      const commentsUrl = `${apiBaseUrl}/repos/${target.repository}/issues/${target.issue}/comments?sort=created&direction=desc`
+      const comments = await githubApiJsonPages(fetcher, commentsUrl, headers, 100)
+      const existing = comments.find(comment => isRecord(comment)
+        && maybeNumber(comment.id)
+        && hasRuntimeType(comment.body, "string")
+        && comment.body.includes(githubActivityMarker))
+      const previous = decodeGithubActivityState(isRecord(existing) ? existing.body : undefined)
+      const current = { links: context.activity.links, runId: context.activity.runId }
+      const state: GitHubActivityCommentState = previous.current?.runId === current.runId
+        ? { current, history: previous.history }
+        : {
+            current,
+            history: [previous.current, ...previous.history]
+              .filter((entry): entry is GitHubActivityHistoryEntry => entry !== undefined && entry.runId !== current.runId)
+              .slice(0, githubActivityHistoryLimit),
+          }
+      const body = renderGithubActivity(context.activity, state)
+      const commentId = isRecord(existing) ? maybeNumber(existing.id) : undefined
+      await githubApi(fetcher, commentId ? `${apiBaseUrl}/repos/${target.repository}/issues/comments/${commentId}` : commentsUrl, {
+        body: JSON.stringify({ body }),
+        headers,
+        method: commentId ? "PATCH" : "POST",
+      })
+    },
+  }
 }
 
 function githubApiPageUrl(url: string, page: number): string {
@@ -2111,7 +2267,7 @@ export function discord<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntime
 export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>(
   options: GitHubChannelOptions<TRuntimeConfig> = {},
 ): AgentChannelDefinition<TRuntimeConfig> {
-  const { app: appOptions, pullRequest, ...channelOptions } = options
+  const { activity, app: appOptions, pullRequest, ...channelOptions } = options
   const app = githubAppOptions(appOptions)
   const pullRequestOptions = pullRequest === true ? {} : pullRequest || {}
   const workspace = pullRequest ? githubPullRequestWorkspacePolicy(pullRequestOptions) : undefined
@@ -2128,6 +2284,7 @@ export function github<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeC
     : undefined
   return defineChannel("github", {
     ...channelOptions,
+    activity: activity ? githubAgentActivity(appOptions) : undefined,
     capabilities: [
       ...(workspaceCapability ? [workspaceCapability] : []),
       ...channelOptions.capabilities || [],

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5750,7 +5750,7 @@ async function executeAgentInvocationWithCapacityLease<
               if (!outcome.failed && !outcome.completed) {
                 const lifecycleOutcome: Parameters<typeof lifecycle.finish>[0] = {
                   result: finishResult,
-                  status: "success",
+                  status: "cancelled",
                   usageResolved: true,
                 }
                 if (finishUsageRecord) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -4678,7 +4678,12 @@ type AgentInvocationFinishOutcome =
   | { error: unknown, status: "error" }
 
 function finishOutcomeFromCleanup(outcome: { completed?: boolean, failed: false } | { error: unknown, failed: true }, result?: unknown): AgentInvocationFinishOutcome {
-  return outcome.failed ? { error: outcome.error, status: "error" } : outcome.completed === false ? { result, status: "cancelled" } : { result, status: "success" }
+  if (outcome.failed) return { error: outcome.error, status: "error" }
+  if (outcome.completed !== false) return { result, status: "success" }
+  const usage = result && hasRuntimeType(result, "object")
+    ? toAgentRunResult(result).usageRecord
+    : undefined
+  return { result, status: "cancelled", usage, usageResolved: true }
 }
 
 function isWritableWorkspaceFacade(workspace: unknown): workspace is WritableWorkspaceFacade {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5811,7 +5811,7 @@ async function executeAgentInvocationWithCapacityLease<
                     },
                     {
                       abortSignal: invocation.input.abortSignal,
-                      detachPendingReaderCancellation: true,
+                      detachPendingReaderCancellation: false,
                       cancelOnAbort: async reason => {
                         await Promise.allSettled([
                           source.cancel(reason),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -130,6 +130,8 @@ import {
 } from "./workspace-agent.ts"
 
 import type {
+  AgentActivityStatus,
+  AgentActivityTask,
   AgentAdapter,
   AgentAdapterFactory,
   AgentAdapterRunContext,
@@ -1119,6 +1121,93 @@ function activeAgentChannel<TRuntimeConfig extends AgentRuntimeConfig>(
   const channelId = run?.channelId || trigger?.channelId
   const channel = channelId ? channels?.[channelId] : undefined
   return channel && channelId ? { channel, channelId, trigger } : undefined
+}
+
+type ActiveAgentActivity = {
+  event(event: StreamEvent): Promise<void>
+  update(status: AgentActivityStatus, error?: unknown): Promise<void>
+}
+
+function agentActivityTasks(value: unknown): AgentActivityTask[] | undefined {
+  if (!isRuntimeRecord(value) || !Array.isArray(value.plan)) return
+  return value.plan.flatMap((item) => {
+    if (!isRuntimeRecord(item)) return []
+    const title = [item.step, item.title, item.description].find(value => hasRuntimeType(value, "string") && value.trim())
+    if (!hasRuntimeType(title, "string")) return []
+    const rawStatus = hasRuntimeType(item.status, "string") ? item.status.replaceAll(/[^a-z]/gi, "").toLowerCase() : "pending"
+    const status = rawStatus === "completed" || rawStatus === "complete" || rawStatus === "done"
+      ? "completed"
+      : rawStatus === "inprogress" || rawStatus === "running" || rawStatus === "active"
+        ? "in-progress"
+        : "pending"
+    return [{ status, title: title.trim() } satisfies AgentActivityTask]
+  })
+}
+
+function createActiveAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
+  definition: AgentDefinition<TRuntimeConfig> | undefined,
+  context: AgentRuntimeContext<TRuntimeConfig>,
+): ActiveAgentActivity | undefined {
+  const run = context.run
+  const channel = run?.channelId ? definition?.channels?.[run.channelId] : undefined
+  if (!run?.activity || !channel?.activity) return
+  let state = {
+    agentName: definition?.name || context.agentIdentity?.name,
+    links: [...run.activity.links || []],
+    runId: run.runId,
+    status: "queued" as AgentActivityStatus,
+    summary: "",
+    tasks: [] as AgentActivityTask[],
+  }
+  let delivery = Promise.resolve()
+  let lastSnapshot: string | undefined
+  const publish = async (status: AgentActivityStatus, error?: unknown) => {
+    state = { ...state, status }
+    const snapshot = {
+      ...state,
+      ...(error === undefined ? {} : { error: agentErrorMessage(error) }),
+      ...(state.summary ? { summary: state.summary } : {}),
+      tasks: [...state.tasks],
+    }
+    const fingerprint = JSON.stringify(snapshot)
+    if (fingerprint === lastSnapshot) {
+      await delivery
+      return
+    }
+    lastSnapshot = fingerprint
+    delivery = delivery.catch(() => {}).then(async () => {
+      try {
+        await channel.activity!.update({
+          ...createAgentCallbackContext(context),
+          activity: snapshot,
+          channel,
+          target: run.activity!.target,
+        })
+      }
+      catch (deliveryError) {
+        if (lastSnapshot === fingerprint) lastSnapshot = undefined
+        console.error(new Error("[vitehub] Agent activity delivery failed.", { cause: deliveryError }))
+      }
+    })
+    await delivery
+  }
+  return {
+    async event(event) {
+      if (event.type === "text-delta" && event.phase !== "commentary" && event.role !== "user") {
+        state.summary = `${state.summary}${event.text}`.slice(-12_000)
+        return
+      }
+      if (event.type === "data-agent-plan") {
+        const tasks = agentActivityTasks(event.data)
+        if (tasks) state.tasks = tasks
+        await publish(state.status === "waiting" ? "waiting" : "running")
+        return
+      }
+      if (event.type === "approval-request") await publish("waiting")
+      else if (event.type === "approval-decision" && event.approved) await publish("running")
+    },
+    update: publish,
+  }
 }
 
 async function setChannelDeliverySupportContext<TRuntimeConfig extends AgentRuntimeConfig, CALL_OPTIONS>(
@@ -2168,6 +2257,7 @@ type AgentInvocationContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 > = AgentRunContext<TRuntimeConfig, CALL_OPTIONS> & {
+  activity?: ActiveAgentActivity
   channels?: AgentChannels<TRuntimeConfig>
   close: () => Promise<void>
   deliveryEffectIntents: AgentChannelDeliveryEffectIntent[]
@@ -3535,6 +3625,7 @@ type InvocationRunContext<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 > = {
+  activity?: ActiveAgentActivity
   channels?: AgentChannels<TRuntimeConfig>
   close: () => Promise<void>
   context: AgentInvocationContextStore
@@ -3589,21 +3680,24 @@ function maybeTraceAgentStream<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(stream: AsyncIterable<StreamEvent>, context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>): AsyncIterable<StreamEvent> {
-  if (!context.runtimeContext.traceLog) return stream
+  if (!context.runtimeContext.traceLog && !context.activity) return stream
   const toolNames = new Map<string, string>()
   const toolActivities = agentToolActivities(context.tools)
   const textPhases = new Map<string, AgentMessagePhase | "hidden">()
-  const tracer = createAgentStreamEventTracer(toTraceContext(context))
+  const tracer = context.runtimeContext.traceLog ? createAgentStreamEventTracer(toTraceContext(context)) : undefined
   return (async function* () {
     try {
       for await (const event of stream) {
         const normalized = toAgentStreamEvent(event, toolNames, textPhases, toolActivities)
-        if (normalized) await tracer.write(normalized)
+        if (normalized) {
+          await tracer?.write(normalized)
+          await context.activity?.event(normalized)
+        }
         yield event
       }
     }
     finally {
-      await tracer.flush()
+      await tracer?.flush()
     }
   })()
 }
@@ -5049,10 +5143,9 @@ async function finishAgentInvocation<
       if (outcomeFailed) await traceFinishError(error, "outcome")
       if (closeError !== undefined) await traceFinishError(closeError, "teardown", teardownActivity)
     }
-    await context.invocationJournal?.finish(
-      failed && context.input.abortSignal?.aborted ? "cancelled" : failed ? "failed" : "completed",
-      error,
-    )
+    const status = failed && context.input.abortSignal?.aborted ? "cancelled" : failed ? "failed" : "completed"
+    await context.activity?.update(status, error)
+    await context.invocationJournal?.finish(status, error)
     if (closeError !== undefined) {
       throwingCloseError = true
       throw closeError
@@ -5062,10 +5155,9 @@ async function finishAgentInvocation<
     if (outcomeFailed) await traceFinishError(error, "outcome")
     if (closeError !== undefined) await traceFinishError(closeError, "teardown", teardownActivity)
     if (!throwingCloseError) await traceFinishError(finishError, "finish", finishFailureActivity)
-    await context.invocationJournal?.finish(
-      failed && context.input.abortSignal?.aborted ? "cancelled" : "failed",
-      failed ? error : finishError,
-    )
+    const status = failed && context.input.abortSignal?.aborted ? "cancelled" : "failed"
+    await context.activity?.update(status, failed ? error : finishError)
+    await context.invocationJournal?.finish(status, failed ? error : finishError)
     if (closeError !== undefined && !throwingCloseError) {
       throw new AggregateError([closeError, finishError], "[vitehub] Capability cleanup and Agent finish lifecycle both failed.")
     }
@@ -5380,6 +5472,7 @@ async function executeAgentInvocationWithCapacityLease<
   options: AgentInvocationExecutionOptions,
   preparedInvocation?: AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS>,
   invocationJournal?: AgentInvocationJournal<TRuntimeConfig>,
+  activity?: ActiveAgentActivity,
 ): Promise<Response | AsyncIterable<StreamEvent> | unknown> {
   const customRun = hasCustomRun<TRuntimeConfig, CALL_OPTIONS>(agent)
   const definition = hasAgentDefinition(agent)
@@ -5388,6 +5481,7 @@ async function executeAgentInvocationWithCapacityLease<
     : undefined
   const invocation = preparedInvocation
     ?? await createAgentInvocationContextWithWorkflowFailureDelivery(definition, context, input, options.kind, invocationJournal)
+  invocation.activity = activity
   const shouldHoldInvocationOutput = () => options.holdCapacity === true || shouldWrapInvocationOutput(invocation)
   const lifecycle = await openAgentInvocationLifecycle<AgentInvocationFinishOutcome>(
     async (outcome) => {
@@ -6405,6 +6499,8 @@ async function executeAgentInvocation<
     }, { agentName: (definition as AgentDefinition).name || context.agentIdentity?.name })
     : undefined
   if (invocationJournal) context = invocationJournal.context
+  const activity = createActiveAgentActivity(definition as AgentDefinition<TRuntimeConfig> | undefined, context)
+  await activity?.update("queued")
   let preparedInvocation: AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS> | undefined
   let release: (() => void) | undefined
   try {
@@ -6420,7 +6516,8 @@ async function executeAgentInvocation<
     }
     if (preparedInvocation?.handledResponse) {
       await invocationJournal?.running()
-      return await executeAgentInvocationWithCapacityLease(agent, context, input, options, preparedInvocation, invocationJournal)
+      await activity?.update("running")
+      return await executeAgentInvocationWithCapacityLease(agent, context, input, options, preparedInvocation, invocationJournal, activity)
     }
     release = definition
       ? await acquireAgentCapacity(definition, input.abortSignal)
@@ -6433,15 +6530,18 @@ async function executeAgentInvocation<
       await finishPreparedInvocationFailure(preparedInvocation, error, workflowExecution)
     }
     await invocationJournal?.finish(input.abortSignal?.aborted ? "cancelled" : "failed", error)
+    await activity?.update(input.abortSignal?.aborted ? "cancelled" : "failed", error)
     throw error
   }
   if (!release) {
     await invocationJournal?.running()
+    await activity?.update("running")
     try {
-      return await executeAgentInvocationWithCapacityLease(agent, context, input, options, preparedInvocation, invocationJournal)
+      return await executeAgentInvocationWithCapacityLease(agent, context, input, options, preparedInvocation, invocationJournal, activity)
     }
     catch (error) {
       await invocationJournal?.finish(input.abortSignal?.aborted ? "cancelled" : "failed", error)
+      await activity?.update(input.abortSignal?.aborted ? "cancelled" : "failed", error)
       throw error
     }
   }
@@ -6454,6 +6554,7 @@ async function executeAgentInvocation<
   }
   try {
     await invocationJournal?.running()
+    await activity?.update("running")
     return await executeAgentInvocationWithCapacityLease(agent, context, input, {
       ...options,
       holdCapacity: true,
@@ -6466,10 +6567,11 @@ async function executeAgentInvocation<
           releaseOnce()
         }
       },
-    }, preparedInvocation, invocationJournal)
+    }, preparedInvocation, invocationJournal, activity)
   }
   catch (error) {
     await invocationJournal?.finish(input.abortSignal?.aborted ? "cancelled" : "failed", error)
+    await activity?.update(input.abortSignal?.aborted ? "cancelled" : "failed", error)
     releaseOnce()
     throw error
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5799,13 +5799,19 @@ async function executeAgentInvocationWithCapacityLease<
                     toReadableAsyncIterableStream(renderedStream),
                     async (outcome) => {
                       if (!outcome.failed && !outcome.completed) {
-                        await Promise.all([
+                        const cancellationTask = Promise.all([
                           source.settleCancellation(),
                           ...(rendererSource ? [rendererSource.settleCancellation()] : []),
                         ]).then(
                           async () => await finishPreserved(outcome),
                           async error => await finishPreserved({ error, failed: true }),
                         )
+                        const settled = await Promise.race([
+                          cancellationTask.then(() => true, () => true),
+                          new Promise<false>(resolve => setTimeout(() => resolve(false), 0)),
+                        ])
+                        if (settled) await cancellationTask
+                        else void cancellationTask.catch(() => {})
                         return
                       }
                       if (outcome.failed) await source.settleCancellation(outcome.error)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5694,7 +5694,9 @@ async function executeAgentInvocationWithCapacityLease<
       const shouldPreserveStreamResult = (hasTraceableStreamResult(rendered) || isUIMessageStreamResult(rendered))
         && !(options.renderOutput && invocation.output)
         && (options.holdCapacity === true
-          || (hasFinishConsumer(invocation) && rendered !== rawDriverResult && rawDriverHasDeferredUsage)
+          || (hasFinishConsumer(invocation)
+            && rendered !== rawDriverResult
+            && (rawDriverHasDeferredUsage || isUIMessageStreamResult(rendered)))
           || (invocation.finishHook
             && !invocation.finishDeliveryEffectProviders.length
             && !invocation.finishExtensionProviders.length
@@ -5811,7 +5813,7 @@ async function executeAgentInvocationWithCapacityLease<
                     },
                     {
                       abortSignal: invocation.input.abortSignal,
-                      detachPendingReaderCancellation: false,
+                      detachPendingReaderCancellation: true,
                       cancelOnAbort: async reason => {
                         await Promise.allSettled([
                           source.cancel(reason),
@@ -6371,7 +6373,17 @@ async function executeAgentInvocationWithCapacityLease<
       }
       if (collectToolResult) finalizationOptions.onNormalizedChunk = collectToolResult
       return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(enrichedRendered, invocation), shouldWrapOutput, async (outcome, streamedText, streamedUsageRecord) => {
-        await finishUiMessageStream(outcome, streamedText, streamedUsageRecord)
+        const finishTask = finishUiMessageStream(outcome, streamedText, streamedUsageRecord)
+        if (!outcome.failed && !outcome.completed && options.holdCapacity !== true) {
+          const settled = await Promise.race([
+            finishTask.then(() => true, () => true),
+            new Promise<false>(resolve => setTimeout(() => resolve(false), 0)),
+          ])
+          if (settled) await finishTask
+          else void finishTask.catch(() => {})
+          return
+        }
+        await finishTask
       }, finalizationOptions)
     }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -704,6 +704,7 @@ interface AgentWorkflowRun<TOutput = unknown> {
 }
 type AgentWorkflowOutput<TOutput> = TOutput extends Response ? AgentRunResult : TOutput | AgentRunResult
 interface StartedAgentWorkflow<CALL_OPTIONS = unknown, TOutput = unknown> {
+  activity?: ActiveAgentActivity
   handle: WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, TOutput>
   invocationJournal?: AgentInvocationJournal
   run: AgentWorkflowRun<TOutput>
@@ -1076,7 +1077,7 @@ async function runAgentAsWorkflow<
     : workflowSettlementTasks.length
       ? Promise.allSettled(workflowSettlementTasks).then(() => undefined)
       : undefined
-  const started: StartedAgentWorkflow<CALL_OPTIONS, AgentWorkflowOutput<TOutput>> = { handle, run }
+  const started: StartedAgentWorkflow<CALL_OPTIONS, AgentWorkflowOutput<TOutput>> = { activity, handle, run }
   if (settled) started.settled = settled
   // Vercel's native Workflow owns durable suspension, but arbitrary Agent Definitions cannot
   // be compiled into that deterministic bundle. Its journal begins in the Agent worker instead.
@@ -4489,7 +4490,7 @@ async function finishStreamAgentInvocation<
   failureMessage: string,
   outputExtensions = new Map<string, unknown>(),
 ): Promise<void> {
-  if (outcome.status === "error") {
+  if (outcome.status !== "success") {
     await lifecycle.finish(outcome)
     return
   }
@@ -4654,11 +4655,12 @@ async function resolveFinishUsageRecord<
 }
 
 type AgentInvocationFinishOutcome =
+  | { status: "cancelled" }
   | { result?: unknown, status: "success", usage?: AgentUsageRecord, usageResolved?: boolean }
   | { error: unknown, status: "error" }
 
-function finishOutcomeFromCleanup(outcome: { failed: false } | { error: unknown, failed: true }, result?: unknown): AgentInvocationFinishOutcome {
-  return outcome.failed ? { error: outcome.error, status: "error" } : { result, status: "success" }
+function finishOutcomeFromCleanup(outcome: { completed?: boolean, failed: false } | { error: unknown, failed: true }, result?: unknown): AgentInvocationFinishOutcome {
+  return outcome.failed ? { error: outcome.error, status: "error" } : outcome.completed === false ? { status: "cancelled" } : { result, status: "success" }
 }
 
 function isWritableWorkspaceFacade(workspace: unknown): workspace is WritableWorkspaceFacade {
@@ -4978,6 +4980,7 @@ async function finishAgentInvocation<
   outcome: AgentInvocationFinishOutcome,
 ): Promise<void> {
   const durationMs = Date.now() - context.startedAt
+  const outcomeCancelled = outcome.status === "cancelled"
   const outcomeFailed = outcome.status === "error"
   let failed = outcomeFailed
   let error = outcome.status === "error" ? outcome.error : undefined
@@ -5197,7 +5200,7 @@ async function finishAgentInvocation<
       if (outcomeFailed) await traceFinishError(error, "outcome")
       if (closeError !== undefined) await traceFinishError(closeError, "teardown", teardownActivity)
     }
-    const status = failed && context.input.abortSignal?.aborted ? "cancelled" : failed ? "failed" : "completed"
+    const status = outcomeCancelled || (failed && context.input.abortSignal?.aborted) ? "cancelled" : failed ? "failed" : "completed"
     await context.activity?.update(status, error, text)
     await context.invocationJournal?.finish(status, error)
     if (closeError !== undefined) {
@@ -6710,9 +6713,14 @@ function createWorkflowAgentInvocationController<CALL_OPTIONS, TOutput>(
   started: StartedAgentWorkflow<CALL_OPTIONS, TOutput>,
   parentAbortSignal?: AbortSignal,
 ): AgentInvocationController<TOutput | Response, CALL_OPTIONS> {
-  const { handle, invocationJournal, run, settled } = started
+  const { activity, handle, invocationJournal, run, settled } = started
   const reconcileJournal = async (snapshot: AgentInvocationSnapshot<TOutput> | undefined) => {
     if (snapshot?.status === "cancelled" || snapshot?.status === "completed" || snapshot?.status === "failed") {
+      await activity?.update(
+        snapshot.status,
+        snapshot.status === "failed" ? snapshot.error : undefined,
+        snapshot.status === "completed" ? finalTextFromAgentOutput(snapshot.output) : undefined,
+      )
       await invocationJournal?.finish(snapshot.status, snapshot.error)
     }
     return snapshot
@@ -6757,6 +6765,7 @@ function createInlineAgentInvocationController<
     }, { ...input, abortSignal }, {
       kind: "run",
       onFinish(outcome) {
+        if (outcome.status === "cancelled") return
         onFinish(outcome.status === "success"
           // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
           ? { ...(outcome.result !== undefined ? { output: outcome.result as TOutput | Response } : {}), status: "completed" }
@@ -6815,7 +6824,11 @@ export async function runAgent<
     return workflow.run
   }
   if (input.context?.[requireAgentWorkflowContextKey] === true) {
-    throw new Error("[vitehub] Durable Channel delivery requires this Agent invocation to start a Workflow. Disable durable delivery or remove nonportable Capabilities and configure a Workflow provider.")
+    const error = new Error("[vitehub] Durable Channel delivery requires this Agent invocation to start a Workflow. Disable durable delivery or remove nonportable Capabilities and configure a Workflow provider.")
+    const activity = hasAgentDefinition(agent) ? createActiveAgentActivity(agent, invocationContext) : undefined
+    await activity?.update("queued")
+    await activity?.update(input.abortSignal?.aborted ? "cancelled" : "failed", error)
+    throw error
   }
   return await runAgentInline(agent, invocationContext, input)
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5811,6 +5811,7 @@ async function executeAgentInvocationWithCapacityLease<
                     },
                     {
                       abortSignal: invocation.input.abortSignal,
+                      detachPendingReaderCancellation: true,
                       cancelOnAbort: async reason => {
                         await Promise.allSettled([
                           source.cancel(reason),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1184,10 +1184,7 @@ function createActiveAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
       tasks: [...state.tasks],
     }
     const fingerprint = JSON.stringify(snapshot)
-    if (fingerprint === lastSnapshot) {
-      await delivery
-      return
-    }
+    if (fingerprint === lastSnapshot) return
     lastSnapshot = fingerprint
     delivery = delivery.catch(() => {}).then(async () => {
       try {
@@ -1203,7 +1200,6 @@ function createActiveAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         console.error(new Error("[vitehub] Agent activity delivery failed.", { cause: deliveryError }))
       }
     })
-    await delivery
   }
   return {
     async event(event) {
@@ -1222,7 +1218,7 @@ function createActiveAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         await publish("waiting")
       }
       else if (event.type === "data-agent-input" && isRuntimeRecord(event.data) && event.data.status === "requested") {
-        const requestId = maybeString(event.data.requestId)
+        const requestId = hasRuntimeType(event.data.requestId, "string") ? event.data.requestId : undefined
         if (requestId) pendingInputRequests.add(`input:${requestId}`)
         await publish("waiting")
       }
@@ -1231,7 +1227,7 @@ function createActiveAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         await publish(pendingInputRequests.size ? "waiting" : "running")
       }
       else if (event.type === "data-agent-input" && isRuntimeRecord(event.data) && event.data.status === "resolved") {
-        const requestId = maybeString(event.data.requestId)
+        const requestId = hasRuntimeType(event.data.requestId, "string") ? event.data.requestId : undefined
         if (requestId) pendingInputRequests.delete(`input:${requestId}`)
         await publish(pendingInputRequests.size ? "waiting" : "running")
       }
@@ -5234,7 +5230,7 @@ async function finalizeAgentInvocationResult<
         || responseMediaType?.endsWith("+json")
         || responseMediaType === "application/xml"
         || responseMediaType?.endsWith("+xml"))
-      const responseDecoder = context.context.get(responseTitleFallbackContextKey) === true && responseIsText
+      const responseDecoder = (context.context.get(responseTitleFallbackContextKey) === true || Boolean(context.activity)) && responseIsText
         ? new TextDecoder()
         : undefined
       let responseText = ""
@@ -5748,7 +5744,7 @@ async function executeAgentInvocationWithCapacityLease<
                     invocation,
                     rendered,
                   )
-                  const renderedStream = invocation.runtimeContext.traceLog
+                  const renderedStream = invocation.runtimeContext.traceLog || invocation.activity
                     ? traceUiMessageStream(toReadableAsyncIterableStream(enrichedStream), invocation)
                     : enrichedStream
                   return withReadableStreamCleanup(
@@ -6015,7 +6011,7 @@ async function executeAgentInvocationWithCapacityLease<
                   : withStreamedResult(enrichedStream, rendered, driverUsageFallback, invocation.toolResults, invocation.tools)
                 const tracedStream = existingStream
                   ? enrichedStream
-                  : invocation.runtimeContext.traceLog
+                  : invocation.runtimeContext.traceLog || invocation.activity
                   ? traceUiMessageStream(toReadableAsyncIterableStream(streamed!.stream), invocation)
                   : streamed!.stream
                 const source = existingSource
@@ -6517,22 +6513,29 @@ async function executeAgentInvocation<
 ): Promise<Response | AsyncIterable<StreamEvent> | unknown> {
   // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
   const definition = hasAgentDefinition(agent) ? agent as object : undefined
-  const invocationJournal = definition
-    // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
-    ? await bindAgentInvocations((definition as AgentDefinition).invocations, {
-      ...context,
-      // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
-      ...((context as AgentRuntimeContext & { [agentInvocationRunId]?: string })[agentInvocationRunId]
-        // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
-        ? { run: { ...context.run, runId: (context as AgentRuntimeContext & { [agentInvocationRunId]: string })[agentInvocationRunId] } }
-        : {}),
-    // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
-    }, { agentName: (definition as AgentDefinition).name || context.agentIdentity?.name })
-    : undefined
-  if (invocationJournal) context = invocationJournal.context
   // SAFETY: hasAgentDefinition validated the object before this internal contract assertion.
   const activity = createActiveAgentActivity(definition as AgentDefinition<TRuntimeConfig> | undefined, context)
   await activity?.update("queued")
+  let invocationJournal: AgentInvocationJournal<TRuntimeConfig> | undefined
+  try {
+    invocationJournal = definition
+      // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
+      ? await bindAgentInvocations((definition as AgentDefinition).invocations, {
+        ...context,
+        // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
+        ...((context as AgentRuntimeContext & { [agentInvocationRunId]?: string })[agentInvocationRunId]
+          // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
+          ? { run: { ...context.run, runId: (context as AgentRuntimeContext & { [agentInvocationRunId]: string })[agentInvocationRunId] } }
+          : {}),
+      // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
+      }, { agentName: (definition as AgentDefinition).name || context.agentIdentity?.name })
+      : undefined
+  }
+  catch (error) {
+    await activity?.update(input.abortSignal?.aborted ? "cancelled" : "failed", error)
+    throw error
+  }
+  if (invocationJournal) context = invocationJournal.context
   let preparedInvocation: AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS> | undefined
   let release: (() => void) | undefined
   try {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -931,9 +931,16 @@ async function runAgentAsWorkflow<
   if ("discoveryDefault" in binding && workflowConfig === false) return undefined
   if (input.context?.[requireAgentWorkflowContextKey] === true && workflowConfig && workflowConfig.provider === "cloudflare") {
     if (!cloudflareEnv) return undefined
-    const workflowName = resolveAgentWorkflowName(agent, binding, context)
-    const workflowBindingName = workflowConfig.binding || (await loadAgentWorkflowModule()).getCloudflareWorkflowBindingName(workflowName)
-    if (!cloudflareEnv[workflowBindingName]) return undefined
+    await activity?.update("queued")
+    try {
+      const workflowName = resolveAgentWorkflowName(agent, binding, context)
+      const workflowBindingName = workflowConfig.binding || (await loadAgentWorkflowModule()).getCloudflareWorkflowBindingName(workflowName)
+      if (!cloudflareEnv[workflowBindingName]) return undefined
+    }
+    catch (error) {
+      await activity?.update(input.abortSignal?.aborted ? "cancelled" : "failed", error)
+      throw error
+    }
   }
   if (activateCloudflareWorkflow) {
     workflowRuntimeState.setWorkflowRuntimeConfig(workflowConfig)
@@ -951,7 +958,9 @@ async function runAgentAsWorkflow<
   if (input.context?.[requireAgentWorkflowContextKey] === true && hasNonportableCapabilities) return undefined
   if ("discoveryDefault" in binding && hasNonportableCapabilities) return undefined
 
-  await activity?.update("queued")
+  if (!(input.context?.[requireAgentWorkflowContextKey] === true && workflowConfig && workflowConfig.provider === "cloudflare")) {
+    await activity?.update("queued")
+  }
   let workflowName: string
   let handle: WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, AgentWorkflowOutput<TOutput>>
   let parsedInput: AgentRunInput<CALL_OPTIONS>

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1054,6 +1054,13 @@ async function runAgentAsWorkflow<
     }
     throw error
   }
+  if (run.status === "cancelled" || run.status === "completed" || run.status === "failed") {
+    await activity?.update(
+      run.status,
+      run.status === "failed" ? run.metadata : undefined,
+      run.status === "completed" ? finalTextFromAgentOutput(run.result) : undefined,
+    )
+  }
   const settled = run.status === "cancelled" || run.status === "completed" || run.status === "failed"
     ? Promise.resolve()
     : workflowSettlementTasks.length

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -106,6 +106,7 @@ import {
   agentInvocationJournalContentTraceLogSymbol,
   agentInvocationJournalTraceLogSymbol,
   agentInvocationTraceIdContextKey,
+  traceAgentInvocationCancelled,
   traceAgentInvocationError,
   traceAgentChannelDeliveryEffect,
   traceAgentInvocationFinish,
@@ -2586,7 +2587,7 @@ function agentContentTraceLog(
       else tailEntries[(count - maxEntries / 2) % tailEntries.length] = entry
       const isFailure = entry.name === "run.error" || (entry.name === "agent.stream.error" && entry.attributes?.["error.recoverable"] !== true)
       if (isFailure) failure = entry
-      if (entry.name === "agent.invocation.finish" || entry.name === "run.finish" || entry.name === "agent.invocation.error" || isFailure) terminal = entry
+      if (entry.name === "agent.invocation.cancelled" || entry.name === "agent.invocation.finish" || entry.name === "run.finish" || entry.name === "agent.invocation.error" || isFailure) terminal = entry
       count += 1
       await destination?.append(correlated)
       return entry
@@ -5195,7 +5196,10 @@ async function finishAgentInvocation<
     if (!failed) {
       await runFinishActivity(teardownActivity, async () => await commitWorkspaceChanges(context))
     }
-    if (!failed) {
+    if (outcomeCancelled) {
+      await traceAgentInvocationCancelled(toTraceContext(context))
+    }
+    else if (!failed) {
       await traceAgentInvocationFinish(toTraceContext(context), {
         "invocation.durationMs": durationMs,
         "result.hasValue": result !== undefined,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -942,15 +942,16 @@ async function runAgentAsWorkflow<
 
   const activity = hasAgentDefinition(agent) ? createActiveAgentActivity(agent, context) : undefined
   await activity?.update("queued")
-  const workflowName = resolveAgentWorkflowName(agent, binding, context)
+  let workflowName: string
   let handle: WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, AgentWorkflowOutput<TOutput>>
   let parsedInput: AgentRunInput<CALL_OPTIONS>
   let workflowInput: AgentRunInput<CALL_OPTIONS>
   try {
+    workflowName = resolveAgentWorkflowName(agent, binding, context)
     handle = await getAgentWorkflowHandle<TRuntimeConfig, CALL_OPTIONS, TOutput>(agent, workflowName, Boolean(context.agentIdentity))
     // ponytail: AbortSignal is live process state and cannot cross a durable Workflow payload.
     parsedInput = hasAgentDefinition(agent)
-      ? await withParsedAgentMessageMeta(agent, input, context.run)
+      ? await withParsedAgentMessageMeta<TRuntimeConfig, CALL_OPTIONS>(agent, input, context.run)
       : input
     workflowInput = await portableAgentWorkflowInput(parsedInput)
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -910,7 +910,16 @@ async function runAgentAsWorkflow<
   const binding = resolveAgentWorkflowRuntimeBinding<TRuntimeConfig>(agent)
   const cloudflareEnv = context.cloudflare?.env || getCloudflareEnv(context)
   if (!binding || ("discoveryDefault" in binding && !context.agentIdentity)) return undefined
-  const workflowRuntimeState = await loadAgentWorkflowRuntimeStateModule()
+  const activity = hasAgentDefinition(agent) ? createActiveAgentActivity(agent, context) : undefined
+  let workflowRuntimeState: Awaited<ReturnType<typeof loadAgentWorkflowRuntimeStateModule>>
+  try {
+    workflowRuntimeState = await loadAgentWorkflowRuntimeStateModule()
+  }
+  catch (error) {
+    await activity?.update("queued")
+    await activity?.update(input.abortSignal?.aborted ? "cancelled" : "failed", error)
+    throw error
+  }
   let workflowConfig = workflowRuntimeState.getWorkflowRuntimeConfig()
   let activateCloudflareWorkflow = false
   if ("discoveryDefault" in binding && workflowConfig === undefined) {
@@ -941,7 +950,6 @@ async function runAgentAsWorkflow<
   if (input.context?.[requireAgentWorkflowContextKey] === true && hasNonportableCapabilities) return undefined
   if ("discoveryDefault" in binding && hasNonportableCapabilities) return undefined
 
-  const activity = hasAgentDefinition(agent) ? createActiveAgentActivity(agent, context) : undefined
   await activity?.update("queued")
   let workflowName: string
   let handle: WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, AgentWorkflowOutput<TOutput>>

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6443,11 +6443,15 @@ async function executeAgentInvocationWithCapacityLease<
           const rejected = cancellations.find((result): result is PromiseRejectedResult => result.status === "rejected")
           if (rejected) outcome = { error: rejected.reason, failed: true }
           const finishResult = await streamed.finishResult(rendered, !outcome.failed && outcome.completed === true)
+          const finishUsageRecord = streamed.finishUsage()
           if (!outcome.failed && !outcome.completed) {
+            const usage = finishUsageRecord
+              ? await resolveAgentUsageRecord({ usageRecord: finishUsageRecord }, invocation.run)
+              : undefined
             await finishStreamAgentInvocation(invocation, lifecycle, finishResult, {
               result: finishResult,
               status: "cancelled",
-              usage: streamed.finishUsage(),
+              usage,
               usageResolved: true,
             }, streamFailureMessage, outputExtensions)
           }
@@ -6458,7 +6462,13 @@ async function executeAgentInvocationWithCapacityLease<
               lifecycle,
               finishResult,
               finishOutcome.status === "success"
-                ? { ...finishOutcome, usage: streamed.finishUsage(), usageResolved: true }
+                ? {
+                    ...finishOutcome,
+                    usage: finishUsageRecord
+                      ? await resolveAgentUsageRecord({ usageRecord: finishUsageRecord }, invocation.run)
+                      : undefined,
+                    usageResolved: true,
+                  }
                 : finishOutcome,
               streamFailureMessage,
               outputExtensions,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -4982,7 +4982,7 @@ async function finishAgentInvocation<
   const durationMs = Date.now() - context.startedAt
   const outcomeCancelled = outcome.status === "cancelled"
   const outcomeFailed = outcome.status === "error"
-  let failed = outcomeFailed
+  let failed = outcomeFailed || outcomeCancelled
   let error = outcome.status === "error" ? outcome.error : undefined
   let result = outcome.status === "success" ? outcome.result : undefined
   let usage = outcome.status === "success" ? outcome.usage : undefined
@@ -5039,7 +5039,7 @@ async function finishAgentInvocation<
         // Invocation data must not change Agent output or mask the original failure.
       }
     }
-    if (hasFinishWork(context)) {
+    if (!outcomeCancelled && hasFinishWork(context)) {
       const details = failed ? agentErrorDetails(error) : undefined
       const eventBase = {
         ...(failed ? { error } : {}),
@@ -6765,11 +6765,12 @@ function createInlineAgentInvocationController<
     }, { ...input, abortSignal }, {
       kind: "run",
       onFinish(outcome) {
-        if (outcome.status === "cancelled") return
-        onFinish(outcome.status === "success"
+        onFinish(outcome.status === "cancelled"
+          ? { status: "cancelled" }
+          : outcome.status === "success"
           // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
-          ? { ...(outcome.result !== undefined ? { output: outcome.result as TOutput | Response } : {}), status: "completed" }
-          : { error: outcome.error, status: "failed" })
+            ? { ...(outcome.result !== undefined ? { output: outcome.result as TOutput | Response } : {}), status: "completed" }
+            : { error: outcome.error, status: "failed" })
       },
       renderOutput: true,
     }),

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -4998,9 +4998,9 @@ async function finishAgentInvocation<
   outcome: AgentInvocationFinishOutcome,
 ): Promise<void> {
   const durationMs = Date.now() - context.startedAt
-  const outcomeCancelled = outcome.status === "cancelled"
+  let outcomeCancelled = outcome.status === "cancelled"
   const outcomeFailed = outcome.status === "error"
-  let failed = outcomeFailed || outcomeCancelled
+  let failed = outcomeFailed
   let error = outcome.status === "error" ? outcome.error : undefined
   let result = outcome.status === "success" ? outcome.result : undefined
   let usage = outcome.status === "success" ? outcome.usage : undefined
@@ -5039,6 +5039,7 @@ async function finishAgentInvocation<
     catch (cleanupError) {
       closeError = cleanupError
       if (!failed) {
+        outcomeCancelled = false
         failed = true
         result = undefined
         runResult = undefined

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -216,6 +216,8 @@ import type {
 import type { WorkflowHandle } from "@vite-hub/workflow"
 import type { OpenTelemetryLogRecordView, OpenTelemetrySpanView, TraceActivityContext, TraceEventLogEntry } from "@vite-hub/runtime"
 
+export { agentInvocationId } from "./invocations.ts"
+
 export type {
   AgentInvocationAnnotationValue,
   AgentInvocationListOptions,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5279,12 +5279,7 @@ async function finalizeAgentInvocationResult<
         const finishResult = retainedResponseText && !outcome.failed
           ? { raw: result, text: retainedResponseText }
           : result
-        if (!outcome.failed && !outcome.completed) {
-          await lifecycle.finish({ result: finishResult, status: "success", usageResolved: true })
-        }
-        else {
-          await lifecycle.finish(finishOutcomeFromCleanup(outcome, finishResult))
-        }
+        await lifecycle.finish(finishOutcomeFromCleanup(outcome, finishResult))
       }, {
         abortSignal: context.input.abortSignal,
         onChunk: chunk => responseText.append(responseDecoder?.decode(chunk, { stream: true }) ?? ""),
@@ -5306,14 +5301,6 @@ async function finalizeAgentInvocationResult<
             const finishResult = await streamed.finishResult(result, !outcome.failed && outcome.completed === true)
             const finishOutcome = finishOutcomeFromCleanup(outcome, finishResult)
             const usage = streamed.finishUsage()
-            if (!outcome.failed && !outcome.completed) {
-              return lifecycle.finish({
-                result: finishResult,
-                status: "success",
-                ...(usage ? { usage: await resolveAgentUsageRecord({ usageRecord: usage }, context.run) } : {}),
-                usageResolved: true,
-              })
-            }
             return lifecycle.finish(finishOutcome.status === "success"
               ? {
                   ...finishOutcome,

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1173,6 +1173,7 @@ function createActiveAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
   }
   let delivery = Promise.resolve()
   let lastSnapshot: string | undefined
+  const pendingInputRequests = new Set<string>()
   const publish = async (status: AgentActivityStatus, error?: unknown, summary?: string) => {
     if (!state.summary && summary) state.summary = summary.slice(-12_000)
     state = { ...state, status }
@@ -1216,10 +1217,24 @@ function createActiveAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         await publish(state.status === "waiting" ? "waiting" : "running")
         return
       }
-      if (event.type === "approval-request"
-        || (event.type === "data-agent-input" && isRuntimeRecord(event.data) && event.data.status === "requested")) await publish("waiting")
-      else if (event.type === "approval-decision"
-        || (event.type === "data-agent-input" && isRuntimeRecord(event.data) && event.data.status === "resolved")) await publish("running")
+      if (event.type === "approval-request") {
+        pendingInputRequests.add(`approval:${event.id}`)
+        await publish("waiting")
+      }
+      else if (event.type === "data-agent-input" && isRuntimeRecord(event.data) && event.data.status === "requested") {
+        const requestId = maybeString(event.data.requestId)
+        if (requestId) pendingInputRequests.add(`input:${requestId}`)
+        await publish("waiting")
+      }
+      else if (event.type === "approval-decision") {
+        pendingInputRequests.delete(`approval:${event.id}`)
+        await publish(pendingInputRequests.size ? "waiting" : "running")
+      }
+      else if (event.type === "data-agent-input" && isRuntimeRecord(event.data) && event.data.status === "resolved") {
+        const requestId = maybeString(event.data.requestId)
+        if (requestId) pendingInputRequests.delete(`input:${requestId}`)
+        await publish(pendingInputRequests.size ? "waiting" : "running")
+      }
     },
     update: publish,
   }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -4673,12 +4673,12 @@ async function resolveFinishUsageRecord<
 }
 
 type AgentInvocationFinishOutcome =
-  | { status: "cancelled" }
+  | { result?: unknown, status: "cancelled", usage?: AgentUsageRecord, usageResolved?: boolean }
   | { result?: unknown, status: "success", usage?: AgentUsageRecord, usageResolved?: boolean }
   | { error: unknown, status: "error" }
 
 function finishOutcomeFromCleanup(outcome: { completed?: boolean, failed: false } | { error: unknown, failed: true }, result?: unknown): AgentInvocationFinishOutcome {
-  return outcome.failed ? { error: outcome.error, status: "error" } : outcome.completed === false ? { status: "cancelled" } : { result, status: "success" }
+  return outcome.failed ? { error: outcome.error, status: "error" } : outcome.completed === false ? { result, status: "cancelled" } : { result, status: "success" }
 }
 
 function isWritableWorkspaceFacade(workspace: unknown): workspace is WritableWorkspaceFacade {
@@ -5002,9 +5002,9 @@ async function finishAgentInvocation<
   const outcomeFailed = outcome.status === "error"
   let failed = outcomeFailed
   let error = outcome.status === "error" ? outcome.error : undefined
-  let result = outcome.status === "success" ? outcome.result : undefined
-  let usage = outcome.status === "success" ? outcome.usage : undefined
-  const usageResolved = outcome.status === "success" && outcome.usageResolved
+  let result = outcome.status === "error" ? undefined : outcome.result
+  let usage = outcome.status === "error" ? undefined : outcome.usage
+  const usageResolved = outcome.status !== "error" && outcome.usageResolved
   let runResult = failed || result === undefined ? undefined : toAgentRunResult(result)
   let text = runResult?.text
   let closeError: unknown
@@ -5058,7 +5058,7 @@ async function finishAgentInvocation<
         // Invocation data must not change Agent output or mask the original failure.
       }
     }
-    if (!outcomeCancelled && hasFinishWork(context)) {
+    if (hasFinishWork(context)) {
       const details = failed ? agentErrorDetails(error) : undefined
       const eventBase = {
         ...(failed ? { error } : {}),
@@ -6325,7 +6325,15 @@ async function executeAgentInvocationWithCapacityLease<
           : driverUsageFallback
         const finishResult = await resultWithStreamedTextAndUsage(rendered, streamedText || "", streamedUsageRecord, resolvedDriverUsageRecord, resolveUsage)
         if (!outcome.failed && !outcome.completed) {
-          await lifecycle.finish(finishOutcomeFromCleanup(outcome))
+          const usage = finishResult && hasRuntimeType(finishResult, "object")
+            ? toAgentRunResult(finishResult).usageRecord
+            : undefined
+          await finishStreamAgentInvocation(invocation, lifecycle, finishResult, {
+            result: finishResult,
+            status: "cancelled",
+            usage,
+            usageResolved: true,
+          }, streamFailureMessage, outputExtensions)
         }
         else {
           const finishOutcome = finishOutcomeFromCleanup(outcome)
@@ -6431,7 +6439,12 @@ async function executeAgentInvocationWithCapacityLease<
           if (rejected) outcome = { error: rejected.reason, failed: true }
           const finishResult = await streamed.finishResult(rendered, !outcome.failed && outcome.completed === true)
           if (!outcome.failed && !outcome.completed) {
-            await lifecycle.finish(finishOutcomeFromCleanup(outcome))
+            await finishStreamAgentInvocation(invocation, lifecycle, finishResult, {
+              result: finishResult,
+              status: "cancelled",
+              usage: streamed.finishUsage(),
+              usageResolved: true,
+            }, streamFailureMessage, outputExtensions)
           }
           else {
             const finishOutcome = finishOutcomeFromCleanup(outcome)
@@ -6469,7 +6482,15 @@ async function executeAgentInvocationWithCapacityLease<
           const collectToolResult = shouldWrapOutput ? agentToolResultStreamCollector(invocation.toolResults) : undefined
           const finalized = await finalizeUiMessageStreamOutput(tracedResponseStream, shouldWrapOutput, async (outcome, streamedText, streamedUsageRecord) => {
             if (!outcome.failed && !outcome.completed) {
-              await lifecycle.finish(finishOutcomeFromCleanup(outcome))
+              const usage = streamedUsageRecord
+                ? await resolveAgentUsageRecord({ usageRecord: streamedUsageRecord }, invocation.run)
+                : undefined
+              await finishStreamAgentInvocation(invocation, lifecycle, response, {
+                result: response,
+                status: "cancelled",
+                usage,
+                usageResolved: true,
+              }, streamFailureMessage, outputExtensions)
             }
             else {
               const finishOutcome = finishOutcomeFromCleanup(outcome)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5797,7 +5797,10 @@ async function executeAgentInvocationWithCapacityLease<
                     toReadableAsyncIterableStream(renderedStream),
                     async (outcome) => {
                       if (!outcome.failed && !outcome.completed) {
-                        await (rendererSource ?? source).settleCancellation().then(
+                        await Promise.all([
+                          source.settleCancellation(),
+                          ...(rendererSource ? [rendererSource.settleCancellation()] : []),
+                        ]).then(
                           async () => await finishPreserved(outcome),
                           async error => await finishPreserved({ error, failed: true }),
                         )

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5797,10 +5797,10 @@ async function executeAgentInvocationWithCapacityLease<
                     toReadableAsyncIterableStream(renderedStream),
                     async (outcome) => {
                       if (!outcome.failed && !outcome.completed) {
-                        void (rendererSource ?? source).settleCancellation().then(
+                        await (rendererSource ?? source).settleCancellation().then(
                           async () => await finishPreserved(outcome),
                           async error => await finishPreserved({ error, failed: true }),
-                        ).catch(() => {})
+                        )
                         return
                       }
                       if (outcome.failed) await source.settleCancellation(outcome.error)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1125,7 +1125,7 @@ function activeAgentChannel<TRuntimeConfig extends AgentRuntimeConfig>(
 
 type ActiveAgentActivity = {
   event(event: StreamEvent): Promise<void>
-  update(status: AgentActivityStatus, error?: unknown): Promise<void>
+  update(status: AgentActivityStatus, error?: unknown, summary?: string): Promise<void>
 }
 
 function agentActivityTasks(value: unknown): AgentActivityTask[] | undefined {
@@ -1151,17 +1151,27 @@ function createActiveAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
   const run = context.run
   const channel = run?.channelId ? definition?.channels?.[run.channelId] : undefined
   if (!run?.activity || !channel?.activity) return
-  let state = {
+  const initialStatus: AgentActivityStatus = "queued"
+  const initialTasks: AgentActivityTask[] = []
+  let state: {
+    agentName?: string
+    links: AgentActivityUpdate["links"]
+    runId?: string
+    status: AgentActivityStatus
+    summary: string
+    tasks: AgentActivityTask[]
+  } = {
     agentName: definition?.name || context.agentIdentity?.name,
     links: [...run.activity.links || []],
     runId: run.runId,
-    status: "queued" as AgentActivityStatus,
+    status: initialStatus,
     summary: "",
-    tasks: [] as AgentActivityTask[],
+    tasks: initialTasks,
   }
   let delivery = Promise.resolve()
   let lastSnapshot: string | undefined
-  const publish = async (status: AgentActivityStatus, error?: unknown) => {
+  const publish = async (status: AgentActivityStatus, error?: unknown, summary?: string) => {
+    if (!state.summary && summary) state.summary = summary.slice(-12_000)
     state = { ...state, status }
     const snapshot = {
       ...state,
@@ -1204,7 +1214,7 @@ function createActiveAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         return
       }
       if (event.type === "approval-request") await publish("waiting")
-      else if (event.type === "approval-decision" && event.approved) await publish("running")
+      else if (event.type === "approval-decision") await publish("running")
     },
     update: publish,
   }
@@ -4493,7 +4503,7 @@ function traceUiMessageStream<
   const toolNames = new Map<string, string>()
   const toolActivities = agentToolActivities(context.tools)
   const textPhases = new Map<string, AgentMessagePhase | "hidden">()
-  const tracer = createAgentStreamEventTracer(toTraceContext(context))
+  const tracer = context.runtimeContext.traceLog ? createAgentStreamEventTracer(toTraceContext(context)) : undefined
   let finished = false
   let released = false
   const release = () => {
@@ -4506,8 +4516,8 @@ function traceUiMessageStream<
       try {
         const result = await reader.read()
         if (result.done) {
-          if (!finished) await tracer.write({ type: "finish" })
-          await tracer.flush()
+          if (!finished) await tracer?.write({ type: "finish" })
+          await tracer?.flush()
           release()
           controller.close()
           return
@@ -4515,12 +4525,13 @@ function traceUiMessageStream<
         const event = toAgentStreamEvent(result.value, toolNames, textPhases, toolActivities)
         if (event) {
           if (event.type === "finish") finished = true
-          await tracer.write(event)
+          await tracer?.write(event)
+          await context.activity?.event(event)
         }
         controller.enqueue(result.value)
       }
       catch (error) {
-        await tracer.flush()
+        await tracer?.flush()
         release()
         controller.error(error)
       }
@@ -4530,7 +4541,7 @@ function traceUiMessageStream<
         await reader.cancel(reason)
       }
       finally {
-        await tracer.flush()
+        await tracer?.flush()
         release()
       }
     },
@@ -4556,7 +4567,7 @@ function maybeTraceUiMessageStreamOutput<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(rendered: unknown, context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS>): unknown {
-  if (context.runtimeContext.traceLog) {
+  if (context.runtimeContext.traceLog || context.activity) {
     if (isUIMessageStreamResult(rendered)) return maybeTraceUiMessageStreamResult(rendered, context)
     // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
     if (isAsyncIterable(rendered)) return maybeTraceAgentStream(rendered as AsyncIterable<StreamEvent>, context)
@@ -5144,7 +5155,7 @@ async function finishAgentInvocation<
       if (closeError !== undefined) await traceFinishError(closeError, "teardown", teardownActivity)
     }
     const status = failed && context.input.abortSignal?.aborted ? "cancelled" : failed ? "failed" : "completed"
-    await context.activity?.update(status, error)
+    await context.activity?.update(status, error, text)
     await context.invocationJournal?.finish(status, error)
     if (closeError !== undefined) {
       throwingCloseError = true
@@ -6499,6 +6510,7 @@ async function executeAgentInvocation<
     }, { agentName: (definition as AgentDefinition).name || context.agentIdentity?.name })
     : undefined
   if (invocationJournal) context = invocationJournal.context
+  // SAFETY: hasAgentDefinition validated the object before this internal contract assertion.
   const activity = createActiveAgentActivity(definition as AgentDefinition<TRuntimeConfig> | undefined, context)
   await activity?.update("queued")
   let preparedInvocation: AgentInvocationContext<TRuntimeConfig, CALL_OPTIONS> | undefined

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6325,17 +6325,7 @@ async function executeAgentInvocationWithCapacityLease<
           : driverUsageFallback
         const finishResult = await resultWithStreamedTextAndUsage(rendered, streamedText || "", streamedUsageRecord, resolvedDriverUsageRecord, resolveUsage)
         if (!outcome.failed && !outcome.completed) {
-          const usage = finishResult && hasRuntimeType(finishResult, "object")
-            ? toAgentRunResult(finishResult).usageRecord
-            : undefined
-          await lifecycle.finish({
-            result: finishResult,
-            status: "success",
-            ...(usage
-              ? { usage: await resolveAgentUsageRecord({ usageRecord: usage }, invocation.run) }
-              : {}),
-            usageResolved: true,
-          })
+          await lifecycle.finish(finishOutcomeFromCleanup(outcome))
         }
         else {
           const finishOutcome = finishOutcomeFromCleanup(outcome)
@@ -6441,14 +6431,7 @@ async function executeAgentInvocationWithCapacityLease<
           if (rejected) outcome = { error: rejected.reason, failed: true }
           const finishResult = await streamed.finishResult(rendered, !outcome.failed && outcome.completed === true)
           if (!outcome.failed && !outcome.completed) {
-            await lifecycle.finish({
-              result: finishResult,
-              status: "success",
-              ...(streamed.finishUsage()
-                ? { usage: await resolveAgentUsageRecord({ usageRecord: streamed.finishUsage() }, invocation.run) }
-                : {}),
-              usageResolved: true,
-            })
+            await lifecycle.finish(finishOutcomeFromCleanup(outcome))
           }
           else {
             const finishOutcome = finishOutcomeFromCleanup(outcome)
@@ -6486,14 +6469,7 @@ async function executeAgentInvocationWithCapacityLease<
           const collectToolResult = shouldWrapOutput ? agentToolResultStreamCollector(invocation.toolResults) : undefined
           const finalized = await finalizeUiMessageStreamOutput(tracedResponseStream, shouldWrapOutput, async (outcome, streamedText, streamedUsageRecord) => {
             if (!outcome.failed && !outcome.completed) {
-              await lifecycle.finish({
-                result: await resultWithStreamedTextAndUsage(response, streamedText || "", streamedUsageRecord),
-                status: "success",
-                ...(streamedUsageRecord
-                  ? { usage: await resolveAgentUsageRecord({ usageRecord: streamedUsageRecord }, invocation.run) }
-                  : {}),
-                usageResolved: true,
-              })
+              await lifecycle.finish(finishOutcomeFromCleanup(outcome))
             }
             else {
               const finishOutcome = finishOutcomeFromCleanup(outcome)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5,6 +5,7 @@ import { normalizeAgentDriver } from "./internal/agent-driver.ts"
 import { agentOutputEventObserverContextKey, progressSummaryOutputContextKey, type AgentOutputEventObserver } from "./internal/agent-output-events.ts"
 import { openAgentInvocationLifecycle, type AgentInvocationLifecycle } from "./internal/invocation-lifecycle.ts"
 import { cloneWithPropertyDescriptors, toReadableAsyncIterableStream } from "./internal/stream-result.ts"
+import { createBoundedTextAccumulator } from "./internal/bounded-text.ts"
 import { validateAgentOutput } from "./internal/agent-structured-output.ts"
 import { loadAgentWorkflowModule, loadAgentWorkflowRuntimeStateModule } from "./internal/workflow-runtime-loaders.ts"
 import { cloneWorkflowJsonValue, workflowBytesToBase64 } from "./internal/workflow-portability.ts"
@@ -5243,14 +5244,12 @@ async function finalizeAgentInvocationResult<
         ? new TextDecoder()
         : undefined
       const responseTextLimit = context.context.get(responseTitleFallbackContextKey) === true ? Number.POSITIVE_INFINITY : 12_000
-      let responseText = ""
-      const appendResponseText = (text: string) => {
-        responseText = `${responseText}${text}`.slice(-responseTextLimit)
-      }
+      const responseText = createBoundedTextAccumulator(responseTextLimit)
       const response = shouldWrapOutput ? await withResponseCleanup(result, async (outcome) => {
-        appendResponseText(responseDecoder?.decode() ?? "")
-        const finishResult = responseText && !outcome.failed
-          ? { raw: result, text: responseText }
+        responseText.append(responseDecoder?.decode() ?? "")
+        const retainedResponseText = responseText.value()
+        const finishResult = retainedResponseText && !outcome.failed
+          ? { raw: result, text: retainedResponseText }
           : result
         if (!outcome.failed && !outcome.completed) {
           await lifecycle.finish({ result: finishResult, status: "success", usageResolved: true })
@@ -5260,7 +5259,7 @@ async function finalizeAgentInvocationResult<
         }
       }, {
         abortSignal: context.input.abortSignal,
-        onChunk: chunk => appendResponseText(responseDecoder?.decode(chunk, { stream: true }) ?? ""),
+        onChunk: chunk => responseText.append(responseDecoder?.decode(chunk, { stream: true }) ?? ""),
       }) : result
       return response
     }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1024,6 +1024,8 @@ async function runAgentAsWorkflow<
     }
   }
   let run: AgentWorkflowRun<AgentWorkflowOutput<TOutput>>
+  const activity = hasAgentDefinition(agent) ? createActiveAgentActivity(agent, context) : undefined
+  await activity?.update("queued")
   try {
     // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
     run = await workflowRuntimeState.runWithWorkflowRuntimeEvent(workflowEvent, () => handle.run(
@@ -1032,6 +1034,7 @@ async function runAgentAsWorkflow<
     )) as AgentWorkflowRun<AgentWorkflowOutput<TOutput>>
   }
   catch (error) {
+    await activity?.update(input.abortSignal?.aborted ? "cancelled" : "failed", error)
     const ambiguous = isAmbiguousWorkflowStartFailure(error)
     const failedRunId = !options.fresh && context.run?.runId
       ? context.run.runId
@@ -1200,6 +1203,12 @@ function createActiveAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         console.error(new Error("[vitehub] Agent activity delivery failed.", { cause: deliveryError }))
       }
     })
+    try {
+      context.waitUntil?.(delivery)
+    }
+    catch (waitUntilError) {
+      console.error(new Error("[vitehub] Agent activity delivery could not be retained.", { cause: waitUntilError }))
+    }
   }
   return {
     async event(event) {

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5929,15 +5929,15 @@ async function executeAgentInvocationWithCapacityLease<
             finishTask = (async () => {
               const finishUsageRecord = streamed.finishUsage()
               if (!finalOutcome.failed && !finalOutcome.completed) {
-                const lifecycleOutcome: Parameters<typeof lifecycle.finish>[0] = {
+                const lifecycleOutcome: AgentInvocationFinishOutcome = {
                   result: finishResult,
-                  status: "success",
+                  status: "cancelled",
                   usageResolved: true,
                 }
                 if (finishUsageRecord) {
                   lifecycleOutcome.usage = await resolveAgentUsageRecord({ usageRecord: finishUsageRecord }, invocation.run)
                 }
-                await lifecycle.finish(lifecycleOutcome)
+                await finishStreamAgentInvocation(invocation, lifecycle, finishResult, lifecycleOutcome, runFailureMessage, outputExtensions)
               }
               else {
                 await finishStreamAgentInvocation(invocation, lifecycle, finishResult, finishOutcomeFromCleanup(finalOutcome), runFailureMessage, outputExtensions)
@@ -6087,14 +6087,14 @@ async function executeAgentInvocationWithCapacityLease<
                       finishResult = preserved
                     }
                     finishTask = !finalOutcome.failed && !finalOutcome.completed
-                      ? lifecycle.finish({
+                      ? finishStreamAgentInvocation(invocation, lifecycle, finishResult, {
                           result: finishResult,
-                          status: "success",
+                          status: "cancelled",
                           ...(streamed?.finishUsage()
                             ? { usage: await resolveAgentUsageRecord({ usageRecord: streamed.finishUsage() }, invocation.run) }
                             : {}),
                           usageResolved: true,
-                        })
+                        }, runFailureMessage, outputExtensions)
                       : finishStreamAgentInvocation(invocation, lifecycle, finishResult, finishOutcomeFromCleanup(finalOutcome), runFailureMessage, outputExtensions)
                     return await finishTask
                   },

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -132,6 +132,7 @@ import {
 import type {
   AgentActivityStatus,
   AgentActivityTask,
+  AgentActivityUpdate,
   AgentAdapter,
   AgentAdapterFactory,
   AgentAdapterRunContext,
@@ -1156,7 +1157,7 @@ function createActiveAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
   let state: {
     agentName?: string
     links: AgentActivityUpdate["links"]
-    runId?: string
+    runId: string
     status: AgentActivityStatus
     summary: string
     tasks: AgentActivityTask[]

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -6371,17 +6371,7 @@ async function executeAgentInvocationWithCapacityLease<
       }
       if (collectToolResult) finalizationOptions.onNormalizedChunk = collectToolResult
       return finalizeUiMessageStreamOutput(maybeTraceUiMessageStreamOutput(enrichedRendered, invocation), shouldWrapOutput, async (outcome, streamedText, streamedUsageRecord) => {
-        const finishTask = finishUiMessageStream(outcome, streamedText, streamedUsageRecord)
-        if (!outcome.failed && !outcome.completed && options.holdCapacity !== true) {
-          const settled = await Promise.race([
-            finishTask.then(() => true, () => true),
-            new Promise<false>(resolve => setTimeout(() => resolve(false), 0)),
-          ])
-          if (settled) await finishTask
-          else void finishTask.catch(() => {})
-          return
-        }
-        await finishTask
+        await finishUiMessageStream(outcome, streamedText, streamedUsageRecord)
       }, finalizationOptions)
     }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1169,7 +1169,7 @@ function createActiveAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
   } = {
     agentName: definition?.name || context.agentIdentity?.name,
     links: [...run.activity.links || []],
-    runId: run.runId,
+    runId: run.activity.runId || run.runId,
     status: initialStatus,
     summary: "",
     tasks: initialTasks,
@@ -6759,9 +6759,18 @@ export async function startAgentInvocation<
   options: { runId?: string } = {},
 ): Promise<AgentInvocationController<TOutput | Response | AgentRunResult, CALL_OPTIONS>> {
   const invocationContext = withAgentIdentityOwner(agent, context)
+  const workflowContext = invocationContext.run?.activity && !invocationContext.run.activity.runId
+    ? {
+        ...invocationContext,
+        run: {
+          ...invocationContext.run,
+          activity: { ...invocationContext.run.activity, runId: invocationContext.run.runId },
+        },
+      }
+    : invocationContext
   const workflow = await runAgentAsWorkflow<TRuntimeConfig, CALL_OPTIONS, TOutput>(
     agent,
-    invocationContext,
+    workflowContext,
     input,
     { fresh: true },
   )

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1214,8 +1214,10 @@ function createActiveAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         await publish(state.status === "waiting" ? "waiting" : "running")
         return
       }
-      if (event.type === "approval-request") await publish("waiting")
-      else if (event.type === "approval-decision") await publish("running")
+      if (event.type === "approval-request"
+        || (event.type === "data-agent-input" && isRuntimeRecord(event.data) && event.data.status === "requested")) await publish("waiting")
+      else if (event.type === "approval-decision"
+        || (event.type === "data-agent-input" && isRuntimeRecord(event.data) && event.data.status === "resolved")) await publish("running")
     },
     update: publish,
   }
@@ -4642,7 +4644,7 @@ function shouldWrapInvocationOutput<
   TRuntimeConfig extends AgentRuntimeConfig,
   CALL_OPTIONS,
 >(context: InvocationRunContext<TRuntimeConfig, CALL_OPTIONS> & { hasCapabilityCleanup: boolean }): boolean {
-  return shouldDeferFinish(context) || Boolean(context.runtimeContext.traceLog)
+  return shouldDeferFinish(context) || Boolean(context.runtimeContext.traceLog) || Boolean(context.activity)
 }
 
 async function commitWorkspaceChanges<

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5242,9 +5242,13 @@ async function finalizeAgentInvocationResult<
       const responseDecoder = (context.context.get(responseTitleFallbackContextKey) === true || Boolean(context.activity)) && responseIsText
         ? new TextDecoder()
         : undefined
+      const responseTextLimit = context.context.get(responseTitleFallbackContextKey) === true ? Number.POSITIVE_INFINITY : 12_000
       let responseText = ""
+      const appendResponseText = (text: string) => {
+        responseText = `${responseText}${text}`.slice(-responseTextLimit)
+      }
       const response = shouldWrapOutput ? await withResponseCleanup(result, async (outcome) => {
-        responseText += responseDecoder?.decode() ?? ""
+        appendResponseText(responseDecoder?.decode() ?? "")
         const finishResult = responseText && !outcome.failed
           ? { raw: result, text: responseText }
           : result
@@ -5256,7 +5260,7 @@ async function finalizeAgentInvocationResult<
         }
       }, {
         abortSignal: context.input.abortSignal,
-        onChunk: chunk => responseText += responseDecoder?.decode(chunk, { stream: true }) ?? "",
+        onChunk: chunk => appendResponseText(responseDecoder?.decode(chunk, { stream: true }) ?? ""),
       }) : result
       return response
     }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -940,14 +940,25 @@ async function runAgentAsWorkflow<
   if (input.context?.[requireAgentWorkflowContextKey] === true && hasNonportableCapabilities) return undefined
   if ("discoveryDefault" in binding && hasNonportableCapabilities) return undefined
 
+  const activity = hasAgentDefinition(agent) ? createActiveAgentActivity(agent, context) : undefined
+  await activity?.update("queued")
   const workflowName = resolveAgentWorkflowName(agent, binding, context)
-  const handle = await getAgentWorkflowHandle<TRuntimeConfig, CALL_OPTIONS, TOutput>(agent, workflowName, Boolean(context.agentIdentity))
+  let handle: WorkflowHandle<AgentWorkflowInvocationPayload<CALL_OPTIONS>, AgentWorkflowOutput<TOutput>>
+  let parsedInput: AgentRunInput<CALL_OPTIONS>
+  let workflowInput: AgentRunInput<CALL_OPTIONS>
+  try {
+    handle = await getAgentWorkflowHandle<TRuntimeConfig, CALL_OPTIONS, TOutput>(agent, workflowName, Boolean(context.agentIdentity))
+    // ponytail: AbortSignal is live process state and cannot cross a durable Workflow payload.
+    parsedInput = hasAgentDefinition(agent)
+      ? await withParsedAgentMessageMeta(agent, input, context.run)
+      : input
+    workflowInput = await portableAgentWorkflowInput(parsedInput)
+  }
+  catch (error) {
+    await activity?.update(input.abortSignal?.aborted ? "cancelled" : "failed", error)
+    throw error
+  }
   const resolvedContext = createResolvedRuntimeContext(context)
-  // ponytail: AbortSignal is live process state and cannot cross a durable Workflow payload.
-  const parsedInput = hasAgentDefinition(agent)
-    ? await withParsedAgentMessageMeta(agent, input, context.run)
-    : input
-  const workflowInput = await portableAgentWorkflowInput(parsedInput)
   const channelDeliveryBinding = input.context?.[agentChannelDeliveryWorkflowContextKey]
   const durableChannelDelivery = isAgentChannelDeliveryWorkflowBinding(channelDeliveryBinding)
   const inheritedRun = options.fresh && context.run && !durableChannelDelivery
@@ -1025,8 +1036,6 @@ async function runAgentAsWorkflow<
     }
   }
   let run: AgentWorkflowRun<AgentWorkflowOutput<TOutput>>
-  const activity = hasAgentDefinition(agent) ? createActiveAgentActivity(agent, context) : undefined
-  await activity?.update("queued")
   try {
     // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
     run = await workflowRuntimeState.runWithWorkflowRuntimeEvent(workflowEvent, () => handle.run(

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -5737,12 +5737,12 @@ async function executeAgentInvocationWithCapacityLease<
           const finishPreserved = async (outcome: CapabilityCleanupOutcome) => {
             invocation.input.abortSignal?.removeEventListener("abort", onAbort)
             if (finishTask) return await finishTask
-            const resolveUsage = !outcome.failed && outcome.completed === true
-            const resolvedDriverUsageRecord = hasRuntimeType(driverUsageFallback, "function")
-              ? await driverUsageFallback(resolveUsage)
-              : driverUsageFallback
-            const finishResult = await resultWithStreamedTextAndUsage(preserved, streamedText, streamedUsageRecord, resolvedDriverUsageRecord, resolveUsage)
             finishTask = (async () => {
+              const resolveUsage = !outcome.failed && outcome.completed === true
+              const resolvedDriverUsageRecord = hasRuntimeType(driverUsageFallback, "function")
+                ? await driverUsageFallback(resolveUsage)
+                : driverUsageFallback
+              const finishResult = await resultWithStreamedTextAndUsage(preserved, streamedText, streamedUsageRecord, resolvedDriverUsageRecord, resolveUsage)
               const finishUsageRecord = finishResult && hasRuntimeType(finishResult, "object")
                 // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
                 ? (finishResult as { usageRecord?: AgentUsageRecord }).usageRecord

--- a/packages/agent/src/internal/bounded-text.ts
+++ b/packages/agent/src/internal/bounded-text.ts
@@ -1,0 +1,16 @@
+export interface BoundedTextAccumulator {
+  append: (text: string) => void
+  value: () => string
+}
+
+export function createBoundedTextAccumulator(limit: number): BoundedTextAccumulator {
+  let retained = ""
+  return {
+    append(text) {
+      retained = `${retained}${text}`.slice(-limit)
+    },
+    value() {
+      return retained
+    },
+  }
+}

--- a/packages/agent/src/invocations.ts
+++ b/packages/agent/src/invocations.ts
@@ -637,6 +637,11 @@ function assertInvocationId(id: string): void {
   }
 }
 
+export async function agentInvocationId(runId: string, agentName?: string): Promise<string> {
+  assertInvocationId(runId)
+  return await boundedIdentity(invocationIdentity(runId, agentName))
+}
+
 function assertStore(store: AgentInvocationStore | undefined): asserts store is AgentInvocationStore {
   if (!store
     || !hasRuntimeType(store.claim, "function")
@@ -1021,7 +1026,7 @@ export function defineAgentInvocations(options: AgentInvocationsOptions): AgentI
     ): Promise<AgentInvocationJournal<TRuntimeConfig>> {
       const runId = context.run?.runId || createInvocationId()
       const agentName = bindOptions.agentName || context.agentIdentity?.name
-      const recordId = await boundedIdentity(invocationIdentity(runId, agentName))
+      const recordId = await agentInvocationId(runId, agentName)
       const claimId = createInvocationId()
       const traceId = await boundedIdentity(context.trace?.id || runId)
       const annotations = normalizeAnnotations(context.run?.annotations)
@@ -1436,8 +1441,7 @@ export function defineAgentInvocations(options: AgentInvocationsOptions): AgentI
       return await store.get(id)
     },
     async getByRunId(runId, agentName) {
-      assertInvocationId(runId)
-      return await store.get(await boundedIdentity(invocationIdentity(runId, agentName)))
+      return await store.get(await agentInvocationId(runId, agentName))
     },
     async list(options = {}) {
       const search = normalizeSearch(options.search)

--- a/packages/agent/src/invocations.ts
+++ b/packages/agent/src/invocations.ts
@@ -664,7 +664,11 @@ function terminalStatus(status: AgentInvocationRecordStatus): boolean {
 }
 
 function terminalObservation(observation: TraceEventLogEntry): boolean {
-  return observation.name === "agent.invocation.finish" || observation.name === "agent.invocation.error" || observation.name === "run.finish" || observation.name === "run.error"
+  return observation.name === "agent.invocation.finish"
+    || observation.name === "agent.invocation.error"
+    || observation.name === "agent.invocation.cancelled"
+    || observation.name === "run.finish"
+    || observation.name === "run.error"
 }
 
 function failureEvidenceObservation(observation: TraceEventLogEntry): boolean {

--- a/packages/agent/src/stream-output.ts
+++ b/packages/agent/src/stream-output.ts
@@ -190,9 +190,10 @@ export function withReadableStreamCleanup<T>(
   const reader = stream.getReader()
   let cleaned = false
   let cleanupTask: Promise<void> | undefined
+  let pendingCleanupOutcome: StreamCleanupOutcome | undefined
   let pendingError: unknown
   let wrappedController: ReadableStreamDefaultController<T> | undefined
-  const runCleanup = async (outcome: StreamCleanupOutcome = { completed: true, failed: false }) => {
+  const runCleanup = async (outcome: StreamCleanupOutcome = pendingCleanupOutcome ?? { completed: true, failed: false }) => {
     if (cleanupTask) return await cleanupTask
     cleaned = true
     options.abortSignal?.removeEventListener("abort", onAbort)
@@ -202,6 +203,7 @@ export function withReadableStreamCleanup<T>(
   const onAbort = () => {
     const reason = options.abortSignal?.reason ?? new DOMException("[vitehub] Agent Invocation stream aborted.", "AbortError")
     if (cleaned) return
+    pendingCleanupOutcome = { error: reason, failed: true }
     cleaned = true
     options.abortSignal?.removeEventListener("abort", onAbort)
     wrappedController?.error(reason)
@@ -256,6 +258,7 @@ export function withReadableStreamCleanup<T>(
     },
     async cancel(reason) {
       let outcome: StreamCleanupOutcome = reason === undefined ? { completed: false, failed: false } : { error: reason, failed: true }
+      pendingCleanupOutcome = outcome
       let detachedReaderSettlement: Promise<true> | undefined
       try {
         await options.cancelOnAbort?.(reason)
@@ -268,6 +271,7 @@ export function withReadableStreamCleanup<T>(
       }
       catch (error) {
         outcome = { error, failed: true }
+        pendingCleanupOutcome = outcome
         throw error
       }
       finally {

--- a/packages/agent/src/trace.ts
+++ b/packages/agent/src/trace.ts
@@ -335,6 +335,16 @@ export async function traceAgentInvocationFinish<TRuntimeConfig extends AgentRun
   })
 }
 
+export async function traceAgentInvocationCancelled<TRuntimeConfig extends AgentRuntimeConfig>(
+  context: AgentTraceContext<TRuntimeConfig>,
+): Promise<void> {
+  await traceAgentEvent(context, {
+    attributes: invocationAttributes(context),
+    name: "agent.invocation.cancelled",
+    type: "run",
+  })
+}
+
 export async function traceAgentInvocationError<TRuntimeConfig extends AgentRuntimeConfig>(
   context: AgentTraceContext<TRuntimeConfig>,
   error: unknown,

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -244,6 +244,7 @@ export interface AgentActivityTask {
 
 export interface AgentRunActivity {
   links?: readonly AgentActivityLink[]
+  runId?: string
   target: AgentActivityTarget
 }
 

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -220,7 +220,35 @@ export interface AgentScheduleInvocationInput {
   target?: string
 }
 
+export interface AgentActivityLink {
+  label: string
+  url: string
+}
+
+export type AgentActivityStatus = "cancelled" | "completed" | "failed" | "queued" | "running" | "waiting"
+
+export type AgentActivityTaskStatus = "completed" | "in-progress" | "pending"
+
+export type AgentActivityTarget =
+  | boolean
+  | number
+  | string
+  | null
+  | readonly AgentActivityTarget[]
+  | { readonly [key: string]: AgentActivityTarget }
+
+export interface AgentActivityTask {
+  status: AgentActivityTaskStatus
+  title: string
+}
+
+export interface AgentRunActivity {
+  links?: readonly AgentActivityLink[]
+  target: AgentActivityTarget
+}
+
 export interface AgentRunMetadata<TOrigin extends string = string> {
+  activity?: AgentRunActivity
   annotations?: Record<string, AgentInvocationAnnotationValue>
   channelId?: string
   messageId?: string
@@ -1686,7 +1714,29 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
   [key: string]: unknown
 }
 
+export interface AgentActivityUpdate {
+  agentName?: string
+  error?: string
+  links: readonly AgentActivityLink[]
+  runId: string
+  status: AgentActivityStatus
+  summary?: string
+  tasks: readonly AgentActivityTask[]
+}
+
+export interface AgentChannelActivityContext<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig>
+  extends AgentCallbackContext<TRuntimeConfig> {
+  activity: AgentActivityUpdate
+  channel: AgentChannelDefinition<TRuntimeConfig>
+  target: AgentActivityTarget
+}
+
+export interface AgentChannelActivityDefinition<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+  update(context: AgentChannelActivityContext<TRuntimeConfig>): MaybePromise<void>
+}
+
 export interface AgentChannelDefinition<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+  activity?: AgentChannelActivityDefinition<TRuntimeConfig>
   adapter?: AgentChatPlatformResolver<TRuntimeConfig>
   capabilities?: readonly AgentCapabilityDefinition<TRuntimeConfig>[]
   effects?: AgentChannelDeliveryEffects<TRuntimeConfig>

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -1335,6 +1335,7 @@ export async function transformEveExtensionCapabilities(
     visitNodes(program, (node, parent) => {
       if (hasSurvivingReference || node.type !== "Identifier" || node.name !== extension.local) return
       if (parent?.type === "Property" && parent.computed !== true && parent.shorthand !== true && parent.key === node) return
+      if (parent?.type === "ImportSpecifier" && parent.imported === node && parent.local !== node) return
       if (parent?.type === "MemberExpression" && parent.computed !== true && parent.property === node) return
       if (node.start >= extension.declaration.start && node.end <= extension.declaration.end) return
       if (extensions.some((candidate) => {

--- a/packages/agent/test/agent-invocation.test.ts
+++ b/packages/agent/test/agent-invocation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { createBackedAgentInvocationController } from "../src/agent-invocation.ts"
+import { awaitAgentInvocationResult, createBackedAgentInvocationController } from "../src/agent-invocation.ts"
 import { defineAgent, startAgentInvocation, workflow } from "../src/index.ts"
 import {
   agentInvocationControlId,
@@ -119,6 +119,31 @@ describe("Agent Invocation controllers", () => {
       })
     })
     await expect(controlled.cancel()).resolves.toMatchObject({ outcome: "invalid-state" })
+  })
+
+  it("records clean output cancellation in the inline controller", async () => {
+    const agent = defineAgent({
+      driver: {
+        run: () => new Response(new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode("partial"))
+          },
+        })),
+      },
+      runtime: false,
+    })
+    const controller = await startAgentInvocation(agent, runtime(), {})
+    const response = await awaitAgentInvocationResult(controller)
+    if (!(response instanceof Response)) throw new Error("Expected an Agent Response.")
+
+    await response.body?.cancel()
+
+    await vi.waitFor(async () => {
+      await expect(controller.inspect()).resolves.toEqual({
+        invocation: { id: controller.id, status: "cancelled" },
+        outcome: "available",
+      })
+    })
   })
 
   it("reports follow-up and steering as unsupported without simulating input", async () => {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -114,7 +114,7 @@ describe("agent channels", () => {
       expect(methods.filter(method => method === "PATCH")).toHaveLength(2)
       expect(stored?.body).toContain("agent-running-0969da")
       expect(stored?.body).toContain("- [ ] ⏳ Review changes")
-      expect(stored?.body).toContain("- [ ] Untrusted # \\[link\\]\\(https://example.com) \\*text\\*")
+      expect(stored?.body).toContain("- [ ] Untrusted \\# \\[link\\]\\(https://example.com) \\*text\\*")
       expect(stored?.body).not.toContain("\n# [link]")
       expect(stored?.body).toContain("https://console.test/invocations/run-2")
       expect(stored?.body).toContain("<summary>Previous sessions</summary>")
@@ -609,7 +609,7 @@ describe("agent channels", () => {
       // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
       await channel.activity?.update({
         activity: {
-          error: "e".repeat(1_000),
+          error: "failure\n\n## Deployment succeeded\n[Open report](https://example.test) @team",
           links,
           runId: "x".repeat(50_000),
           status: "failed",
@@ -627,6 +627,8 @@ describe("agent channels", () => {
       expect(storedBody).toMatch(/^<!-- vitehub-agent-activity:[A-Za-z0-9_-]+ -->/)
       expect(storedBody).not.toContain("x".repeat(1_000))
       expect(storedBody).toContain("Agent stopped:")
+      expect(storedBody).toContain("Agent stopped: failure \\#\\# Deployment succeeded \\[Open report\\]\\(https://example.test\\) \\@team")
+      expect(storedBody).not.toContain("\n\n## Deployment succeeded")
       expect(storedBody).toContain(links[0]!.url)
     }
     finally {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -164,12 +164,25 @@ describe("agent channels", () => {
   it("creates queued GitHub activity when a pull request opens", async () => {
     const { github } = await import("../src/channels.ts")
     let storedBody = ""
+    let releaseIdentity: (() => void) | undefined
+    let identityBlocked = true
+    const background: Promise<unknown>[] = []
     const methods: string[] = []
     const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
       const method = init?.method || "GET"
       methods.push(method)
-      if (url.pathname === "/user") return Response.json({ login: "vitehub-bot" })
+      if (url.pathname === "/user") {
+        if (identityBlocked) {
+          await new Promise<void>((resolve) => {
+            releaseIdentity = () => {
+              identityBlocked = false
+              resolve()
+            }
+          })
+        }
+        return Response.json({ login: "vitehub-bot" })
+      }
       if (method === "GET") {
         return Response.json(url.searchParams.get("page") === "2" || !storedBody
           ? []
@@ -192,11 +205,17 @@ describe("agent channels", () => {
         agentIdentity: { name: "reviewer" },
         channel,
         trigger: { channelId: "github", id: "github.webhook", name: "webhook", source: "channel" },
+        waitUntil: (task: Promise<unknown>) => background.push(task),
       } as never
       const opened = { github: { event: "pull_request" }, payload: githubPullRequestOpenedPayload() }
       const result = await trigger.invoke(triggerContext, opened)
 
       expect(result).toBeInstanceOf(Response)
+      expect(background).toHaveLength(1)
+      expect(storedBody).toBe("")
+      await vi.waitFor(() => expect(releaseIdentity).toBeTypeOf("function"))
+      releaseIdentity!()
+      await background[0]
       expect(fetcher).toHaveBeenCalledWith(expect.stringContaining("/repos/acme/app/issues/42/comments"), expect.objectContaining({ method: "POST" }))
       expect(storedBody).toContain("agent-queued-6e7781")
 
@@ -212,6 +231,7 @@ describe("agent channels", () => {
       } as never)
       const runningBody = storedBody
       await trigger.invoke(triggerContext, opened)
+      await background[1]
 
       expect(methods.filter(method => method === "POST")).toHaveLength(1)
       expect(methods.filter(method => method === "PATCH")).toHaveLength(1)

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -544,13 +544,20 @@ describe("agent channels", () => {
       if (url.pathname === "/user") return Response.json({ login: "vitehub-bot" })
       if (url.pathname === "/repos/acme/app/issues/42/comments" && init?.method === "GET") {
         const page = url.searchParams.get("page")
-        if (page === null) {
+        if (page === "1") {
           return Response.json(Array.from({ length: 100 }, (_, id) => ({ body: "ordinary", id: id + 1 })), {
-            headers: { link: `<https://api.github.com/repos/acme/app/issues/42/comments?per_page=100&page=7>; rel="last"` },
+            headers: { link: `<https://api.github.com/repos/acme/app/issues/42/comments?per_page=100&page=6>; rel="last"` },
           })
         }
-        if (page === "7") return Response.json([{ body: "<!-- vitehub-agent-activity:e30 -->", id: 7, user: { login: "vitehub-bot" } }])
-        return Response.json([])
+        if (page === "6") return Response.json([{ body: "ordinary", id: 501 }])
+        if (page === "2") return Response.json([
+          { body: "<!-- vitehub-agent-activity:e30 -->", id: 7, user: { login: "vitehub-bot" } },
+          ...Array.from({ length: 99 }, (_, id) => ({ body: "ordinary", id: id + 101 })),
+        ])
+        if (page && Number(page) >= 3 && Number(page) <= 5) {
+          return Response.json(Array.from({ length: 100 }, (_, id) => ({ body: "ordinary", id: Number(page) * 100 + id })))
+        }
+        throw new Error(`Unexpected comments page: ${page}`)
       }
       if (url.pathname === "/repos/acme/app/issues/comments/7" && init?.method === "PATCH") return Response.json({ id: 7 })
       throw new Error(`Unexpected GitHub API call: ${url}`)

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -114,7 +114,7 @@ describe("agent channels", () => {
       expect(methods.filter(method => method === "PATCH")).toHaveLength(2)
       expect(stored?.body).toContain("agent-running-0969da")
       expect(stored?.body).toContain("- [ ] ⏳ Review changes")
-      expect(stored?.body).toContain("- [ ] Untrusted \\# \\[link\\]\\(https://example.com) \\*text\\*")
+      expect(stored?.body).toContain("- [ ] Untrusted \\# \\[link\\]\\(https://example.com\\) \\*text\\*")
       expect(stored?.body).not.toContain("\n# [link]")
       expect(stored?.body).toContain("https://console.test/invocations/run-2")
       expect(stored?.body).toContain("<summary>Previous sessions</summary>")
@@ -544,8 +544,12 @@ describe("agent channels", () => {
       if (url.pathname === "/user") return Response.json({ login: "vitehub-bot" })
       if (url.pathname === "/repos/acme/app/issues/42/comments" && init?.method === "GET") {
         const page = url.searchParams.get("page")
-        if (page === "1") return Response.json(Array.from({ length: 100 }, (_, id) => ({ body: "ordinary", id: id + 100 })))
-        if (page === "2") return Response.json([{ body: "<!-- vitehub-agent-activity:e30 -->", id: 7, user: { login: "vitehub-bot" } }])
+        if (page === null) {
+          return Response.json(Array.from({ length: 100 }, (_, id) => ({ body: "ordinary", id: id + 1 })), {
+            headers: { link: `<https://api.github.com/repos/acme/app/issues/42/comments?per_page=100&page=7>; rel="last"` },
+          })
+        }
+        if (page === "7") return Response.json([{ body: "<!-- vitehub-agent-activity:e30 -->", id: 7, user: { login: "vitehub-bot" } }])
         return Response.json([])
       }
       if (url.pathname === "/repos/acme/app/issues/comments/7" && init?.method === "PATCH") return Response.json({ id: 7 })

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -205,7 +205,11 @@ describe("agent channels", () => {
     const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
       if (url.pathname === "/user") return Response.json({ login: "vitehub-bot" })
-      if (init?.method === "GET") return Response.json(storedBody ? [{ body: storedBody, id: 7, user: { login: "vitehub-bot" } }] : [])
+      if (init?.method === "GET") {
+        return Response.json(url.searchParams.get("page") === "2" || !storedBody
+          ? []
+          : [{ body: storedBody, id: 7, user: { login: "vitehub-bot" } }])
+      }
       const payload: unknown = JSON.parse(String(init?.body))
       if (!isRuntimeRecord(payload) || !hasRuntimeType(payload.body, "string")) throw new Error("Invalid comment body.")
       storedBody = payload.body
@@ -215,7 +219,7 @@ describe("agent channels", () => {
     vi.stubGlobal("fetch", fetcher)
     try {
       const channel = github({ activity: true })
-      const links = Array.from({ length: 3 }, (_, index) => ({ label: `link-${index}-${"l".repeat(80)}`, url: `https://example.test/${"u".repeat(400)}` }))
+      const links = Array.from({ length: 3 }, (_, index) => ({ label: `link-${index}-${"l".repeat(80)}`, url: `https://example.test/${"u".repeat(800)}` }))
       for (let index = 0; index < 101; index++) {
         // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
         await channel.activity?.update({
@@ -248,6 +252,7 @@ describe("agent channels", () => {
       expect(Buffer.byteLength(storedBody)).toBeLessThan(65_536)
       expect(storedBody).not.toContain("x".repeat(1_000))
       expect(storedBody).toContain("Agent stopped:")
+      expect(storedBody).toContain(links[0]!.url)
     }
     finally {
       vi.unstubAllGlobals()

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -32,6 +32,16 @@ function githubIssueCommentPayload(body = "/review please") {
   }
 }
 
+function githubPullRequestOpenedPayload() {
+  return {
+    action: "opened",
+    installation: { id: 123 },
+    number: 42,
+    pull_request: { number: 42 },
+    repository: { full_name: "acme/app" },
+  }
+}
+
 describe("agent channels", () => {
   it("creates and updates one GitHub Agent activity comment with session history", async () => {
     const { github } = await import("../src/channels.ts")
@@ -86,6 +96,7 @@ describe("agent channels", () => {
       await update(context("run-1", "running") as never)
       // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
       await update(context("run-1", "completed") as never)
+      expect(stored?.body).not.toContain("Review complete.")
       // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
       await update(context("run-2", "running") as never)
 
@@ -143,6 +154,41 @@ describe("agent channels", () => {
       await update(context("long-running", "completed") as never)
       expect(stored?.body).toBe(newestBody)
       expect(stored?.body).toContain("https://console.test/invocations/newer-100")
+    }
+    finally {
+      vi.unstubAllGlobals()
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it("creates queued GitHub activity when a pull request opens", async () => {
+    const { github } = await import("../src/channels.ts")
+    let storedBody = ""
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
+      if (url.pathname === "/user") return Response.json({ login: "vitehub-bot" })
+      if (init?.method === "GET") return Response.json([])
+      const payload: unknown = JSON.parse(String(init?.body))
+      if (!isRuntimeRecord(payload) || !hasRuntimeType(payload.body, "string")) throw new Error("Invalid comment body.")
+      storedBody = payload.body
+      return Response.json({ id: 7 }, { status: 201 })
+    })
+    vi.stubEnv("GITHUB_TOKEN", "test-token")
+    vi.stubGlobal("fetch", fetcher)
+    try {
+      const channel = github({ activity: true })
+      const trigger = channel.triggers?.webhook
+      if (!trigger) throw new Error("Missing GitHub webhook trigger.")
+      const result = await trigger.invoke({
+        agentCapabilities: [],
+        agentIdentity: { name: "reviewer" },
+        channel,
+        trigger: { channelId: "github", id: "github.webhook", name: "webhook", source: "channel" },
+      } as never, { github: { event: "pull_request" }, payload: githubPullRequestOpenedPayload() })
+
+      expect(result).toBeInstanceOf(Response)
+      expect(fetcher).toHaveBeenCalledWith(expect.stringContaining("/repos/acme/app/issues/42/comments"), expect.objectContaining({ method: "POST" }))
+      expect(storedBody).toContain("agent-queued-6e7781")
     }
     finally {
       vi.unstubAllGlobals()

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -33,6 +33,68 @@ function githubIssueCommentPayload(body = "/review please") {
 }
 
 describe("agent channels", () => {
+  it("creates and updates one GitHub Agent activity comment with session history", async () => {
+    const { github } = await import("../src/channels.ts")
+    let stored: { body: string, id: number } | undefined
+    const methods: string[] = []
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url)
+      const method = init?.method || "GET"
+      methods.push(method)
+      if (method === "GET") {
+        const comments = url.searchParams.get("page") === "2" || !stored
+          ? []
+          : [{ body: stored.body, id: stored.id }]
+        return new Response(JSON.stringify(comments), { headers: { "content-type": "application/json" } })
+      }
+      const body = JSON.parse(String(init?.body)) as { body: string }
+      stored = { body: body.body, id: 7 }
+      return new Response(JSON.stringify(stored), { headers: { "content-type": "application/json" }, status: method === "POST" ? 201 : 200 })
+    })
+    vi.stubEnv("GITHUB_TOKEN", "test-token")
+    vi.stubGlobal("fetch", fetcher)
+    try {
+      const channel = github({ activity: true })
+      const update = channel.activity?.update
+      if (!update) throw new Error("Missing GitHub Agent activity updater.")
+      const context = (runId: string, status: "completed" | "running") => ({
+        activity: {
+          links: [{ label: "Session", url: `https://console.test/invocations/${runId}` }],
+          runId,
+          status,
+          ...(status === "completed" ? { summary: "Review complete." } : {}),
+          tasks: [{ status: status === "completed" ? "completed" : "in-progress", title: "Review changes" }],
+        },
+        channel,
+        memo: vi.fn(),
+        run: { runId },
+        runtime: "unknown",
+        target: { issue: 42, repository: "acme/app" },
+        waitUntil: vi.fn(),
+      })
+
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await update(context("run-1", "running") as never)
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await update(context("run-1", "completed") as never)
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await update(context("run-2", "running") as never)
+
+      expect(methods.filter(method => method === "POST")).toHaveLength(1)
+      expect(methods.filter(method => method === "PATCH")).toHaveLength(2)
+      expect(stored?.body).toContain("agent-running-0969da")
+      expect(stored?.body).toContain("- [ ] ⏳ Review changes")
+      expect(stored?.body).toContain("https://console.test/invocations/run-2")
+      expect(stored?.body).toContain("<summary>Previous sessions</summary>")
+      expect(stored?.body).toContain("https://console.test/invocations/run-1")
+      expect(stored?.body.match(/vitehub-agent-activity:/g)).toHaveLength(1)
+    }
+    finally {
+      vi.unstubAllGlobals()
+      vi.unstubAllEnvs()
+    }
+  })
+
   it("uses normalized finish context text for default GitHub PR replies", async () => {
     const { github } = await import("../src/channels.ts")
     const channel = github({ pullRequest: true })

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -126,8 +126,11 @@ describe("agent channels", () => {
         return Response.json({ expires_at: new Date(Date.now() + 600_000).toISOString(), token: "installation-token" })
       }
       if (url.pathname === "/user") return Response.json({ message: "Requires authentication" }, { status: 401 })
-      if (url.pathname === "/app") return Response.json({ slug: "vitehub-app" })
-      if (url.pathname === "/repos/acme/app/issues/42/comments" && init?.method === "GET") return Response.json([])
+      if (url.pathname === "/app") return Response.json({ id: 2468, slug: "vitehub-app" })
+      if (url.pathname === "/repos/acme/app/issues/42/comments" && init?.method === "GET") {
+        return Response.json([{ body: "<!-- vitehub-agent-activity:e30 -->", id: 7, performed_via_github_app: { id: 2468 } }])
+      }
+      if (url.pathname === "/repos/acme/app/issues/comments/7" && init?.method === "PATCH") return Response.json({ id: 7 })
       if (url.pathname === "/repos/acme/app/issues/42/comments" && init?.method === "POST") return Response.json({ id: 7 }, { status: 201 })
       throw new Error(`Unexpected GitHub API call: ${url}`)
     })
@@ -159,6 +162,42 @@ describe("agent channels", () => {
       headers: expect.objectContaining({ authorization: expect.stringMatching(/^Bearer .+\..+\..+$/) }),
       method: "GET",
     }))
+    expect(fetcher).toHaveBeenCalledWith("https://api.github.test/repos/acme/app/issues/comments/7", expect.objectContaining({ method: "PATCH" }))
+  })
+
+  it("bounds serialized GitHub activity run identity", async () => {
+    const { github } = await import("../src/channels.ts")
+    let storedBody = ""
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
+      if (url.pathname === "/user") return Response.json({ login: "vitehub-bot" })
+      if (init?.method === "GET") return Response.json([])
+      const payload: unknown = JSON.parse(String(init?.body))
+      if (!isRuntimeRecord(payload) || !hasRuntimeType(payload.body, "string")) throw new Error("Invalid comment body.")
+      storedBody = payload.body
+      return Response.json({ id: 7 }, { status: 201 })
+    })
+    vi.stubEnv("GITHUB_TOKEN", "test-token")
+    vi.stubGlobal("fetch", fetcher)
+    try {
+      const channel = github({ activity: true })
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await channel.activity?.update({
+        activity: { links: [], runId: "x".repeat(50_000), status: "running", tasks: [] },
+        channel,
+        memo: vi.fn(),
+        run: { runId: "x".repeat(50_000) },
+        runtime: "unknown",
+        target: { issue: 42, repository: "acme/app" },
+        waitUntil: vi.fn(),
+      } as never)
+      expect(storedBody.length).toBeLessThan(65_536)
+      expect(storedBody).not.toContain("x".repeat(1_000))
+    }
+    finally {
+      vi.unstubAllGlobals()
+      vi.unstubAllEnvs()
+    }
   })
 
   it("uses normalized finish context text for default GitHub PR replies", async () => {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -46,6 +46,7 @@ describe("agent channels", () => {
   it("creates and updates one GitHub Agent activity comment with session history", async () => {
     const { github } = await import("../src/channels.ts")
     let stored: { body: string, id: number } | undefined
+    const deleteStored = () => { stored = undefined }
     let failNextCommentsGet = false
     const methods: string[] = []
     const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
@@ -123,6 +124,13 @@ describe("agent channels", () => {
       // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
       await update(context("retry-run", "running") as never)
       expect(stored?.body).toContain("https://console.test/invocations/retry-run")
+
+      // A deleted cached comment must be rediscovered as missing and recreated.
+      deleteStored()
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await update(context("replacement-run", "running") as never)
+      expect(methods.filter(method => method === "POST")).toHaveLength(2)
+      expect(stored?.body).toContain("https://console.test/invocations/replacement-run")
 
       const largeActivity = context("run-3", "running")
       largeActivity.activity.tasks = Array.from({ length: 100 }, (_, index) => ({ status: "pending", title: `${index}: ${"x".repeat(1_000)}` }))
@@ -410,9 +418,13 @@ describe("agent channels", () => {
     vi.stubGlobal("fetch", fetcher)
     try {
       const channel = github({ activity: true })
-      const first = channel.activity?.update(context(channel, "run-first") as never)
+      const firstContext = context(channel, "run-first")
+      const secondContext = context(channel, "run-second")
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      const first = channel.activity?.update(firstContext as never)
       await vi.waitFor(() => expect(identityCalls).toBe(1))
-      const second = channel.activity?.update(context(channel, "run-second") as never)
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      const second = channel.activity?.update(secondContext as never)
 
       await Promise.resolve()
       expect(identityCalls).toBe(1)

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -109,6 +109,18 @@ describe("agent channels", () => {
       await update(context("run-1", "completed") as never)
       expect(stored?.body).toBe(currentBody)
       expect(stored?.body).toContain("https://console.test/invocations/run-14")
+
+      // Keep an active run stale even after bounded serialized tombstones evict it.
+      await update(context("long-running", "running") as never)
+      for (let index = 0; index <= 100; index++) {
+        // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+        await update(context(`newer-${index}`, "completed") as never)
+      }
+      const newestBody = stored?.body
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await update(context("long-running", "completed") as never)
+      expect(stored?.body).toBe(newestBody)
+      expect(stored?.body).toContain("https://console.test/invocations/newer-100")
     }
     finally {
       vi.unstubAllGlobals()

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -460,7 +460,7 @@ describe("agent channels", () => {
     }
   })
 
-  it.each(["GITHUB_TOKEN", "GH_TOKEN"] as const)("reuses GitHub Actions bot activity when its installation token is selected through %s", async (tokenKey) => {
+  it("reuses GitHub Actions bot activity for the built-in Actions token", async () => {
     const { github } = await import("../src/channels.ts")
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
     const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs1" }).toString()
@@ -474,7 +474,8 @@ describe("agent channels", () => {
       if (url.pathname === "/repos/acme/app/issues/comments/7" && init?.method === "PATCH") return Response.json({ id: 7 })
       throw new Error(`Unexpected GitHub API call: ${url}`)
     })
-    vi.stubEnv(tokenKey, "actions-installation-token")
+    vi.stubEnv("GITHUB_ACTIONS", "true")
+    vi.stubEnv("GITHUB_TOKEN", "actions-installation-token")
     vi.stubGlobal("fetch", fetcher)
     try {
       const channel = github({
@@ -492,6 +493,55 @@ describe("agent channels", () => {
         waitUntil: vi.fn(),
       } as never)
 
+      expect(fetcher).toHaveBeenCalledWith("https://api.github.com/repos/acme/app/issues/comments/7", expect.objectContaining({ method: "PATCH" }))
+    }
+    finally {
+      vi.unstubAllGlobals()
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it("does not treat an unresolved GH_TOKEN as the GitHub Actions bot", async () => {
+    const { github } = await import("../src/channels.ts")
+    const fetcher = vi.fn(async (input: string | URL | Request) => {
+      const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
+      if (url.pathname === "/user") return Response.json({ message: "Forbidden" }, { status: 403 })
+      throw new Error(`Unexpected GitHub API call: ${url}`)
+    })
+    vi.stubEnv("GITHUB_ACTIONS", "true")
+    vi.stubEnv("GH_TOKEN", "user-token")
+    vi.stubGlobal("fetch", fetcher)
+    try {
+      const channel = github({ activity: true })
+      await expect(channel.activity?.update(context(channel, "run-user-token") as never))
+        .rejects.toThrow("could not resolve the authenticated identity")
+      expect(fetcher).not.toHaveBeenCalledWith(expect.stringContaining("/comments"), expect.anything())
+    }
+    finally {
+      vi.unstubAllGlobals()
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it("finds an owned activity comment beyond the first restart lookup page", async () => {
+    const { github } = await import("../src/channels.ts")
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
+      if (url.pathname === "/user") return Response.json({ login: "vitehub-bot" })
+      if (url.pathname === "/repos/acme/app/issues/42/comments" && init?.method === "GET") {
+        const page = url.searchParams.get("page")
+        if (page === "1") return Response.json(Array.from({ length: 100 }, (_, id) => ({ body: "ordinary", id: id + 100 })))
+        if (page === "2") return Response.json([{ body: "<!-- vitehub-agent-activity:e30 -->", id: 7, user: { login: "vitehub-bot" } }])
+        return Response.json([])
+      }
+      if (url.pathname === "/repos/acme/app/issues/comments/7" && init?.method === "PATCH") return Response.json({ id: 7 })
+      throw new Error(`Unexpected GitHub API call: ${url}`)
+    })
+    vi.stubEnv("GITHUB_TOKEN", "test-token")
+    vi.stubGlobal("fetch", fetcher)
+    try {
+      const channel = github({ activity: true })
+      await channel.activity?.update(context(channel, "run-restarted") as never)
       expect(fetcher).toHaveBeenCalledWith("https://api.github.com/repos/acme/app/issues/comments/7", expect.objectContaining({ method: "PATCH" }))
     }
     finally {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -91,11 +91,64 @@ describe("agent channels", () => {
       expect(stored?.body).toContain("<summary>Previous sessions</summary>")
       expect(stored?.body).toContain("https://console.test/invocations/run-1")
       expect(stored?.body.match(/vitehub-agent-activity:/g)).toHaveLength(1)
+
+      const largeActivity = context("run-3", "running")
+      largeActivity.activity.tasks = Array.from({ length: 100 }, (_, index) => ({ status: "pending", title: `${index}: ${"x".repeat(1_000)}` }))
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await update(largeActivity as never)
+      expect(stored?.body.length).toBeLessThan(65_536)
+      expect(stored?.body).toContain("24:")
+      expect(stored?.body).not.toContain("25:")
     }
     finally {
       vi.unstubAllGlobals()
       vi.unstubAllEnvs()
     }
+  })
+
+  it("resolves GitHub App activity ownership with app JWT metadata", async () => {
+    const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs1" }).toString()
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
+      if (url.pathname === "/app/installations/987/access_tokens") {
+        return Response.json({ expires_at: new Date(Date.now() + 600_000).toISOString(), token: "installation-token" })
+      }
+      if (url.pathname === "/user") return Response.json({ message: "Requires authentication" }, { status: 401 })
+      if (url.pathname === "/app") return Response.json({ slug: "vitehub-app" })
+      if (url.pathname === "/repos/acme/app/issues/42/comments" && init?.method === "GET") return Response.json([])
+      if (url.pathname === "/repos/acme/app/issues/42/comments" && init?.method === "POST") return Response.json({ id: 7 }, { status: 201 })
+      throw new Error(`Unexpected GitHub API call: ${url}`)
+    })
+    const channel = github({
+      activity: true,
+      app: {
+        apiBaseUrl: "https://api.github.test",
+        appId: "activity-app",
+        // SAFETY: This test fixture intentionally supplies a Fetch-compatible mock.
+        fetch: fetcher as typeof fetch,
+        installationId: 987,
+        privateKey: privateKeyPem,
+      },
+    })
+    const update = channel.activity?.update
+    if (!update) throw new Error("Missing GitHub Agent activity updater.")
+    // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+    await update({
+      activity: { links: [], runId: "run-app", status: "running", tasks: [] },
+      channel,
+      memo: vi.fn(),
+      run: { runId: "run-app" },
+      runtime: "unknown",
+      target: { installationId: 987, issue: 42, repository: "acme/app" },
+      waitUntil: vi.fn(),
+    } as never)
+
+    expect(fetcher).toHaveBeenCalledWith("https://api.github.test/app", expect.objectContaining({
+      headers: expect.objectContaining({ authorization: expect.stringMatching(/^Bearer .+\..+\..+$/) }),
+      method: "GET",
+    }))
   })
 
   it("uses normalized finish context text for default GitHub PR replies", async () => {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -146,6 +146,10 @@ describe("agent channels", () => {
       expect(methods.filter(method => method === "POST")).toHaveLength(2)
       expect(stored?.body).toContain("https://console.test/invocations/replacement-run")
 
+      // Rebuild the stale-run history after deleting the comment that stored it.
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await update(context("run-1", "running") as never)
+
       const largeActivity = context("run-3", "running")
       largeActivity.activity.tasks = Array.from({ length: 100 }, (_, index) => ({ status: "pending", title: `${index}: ${"x".repeat(1_000)}` }))
       // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
@@ -456,7 +460,7 @@ describe("agent channels", () => {
     }
   })
 
-  it("reuses GitHub Actions bot activity when its installation token cannot resolve /user", async () => {
+  it.each(["GITHUB_TOKEN", "GH_TOKEN"] as const)("reuses GitHub Actions bot activity when its installation token is selected through %s", async (tokenKey) => {
     const { github } = await import("../src/channels.ts")
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
     const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs1" }).toString()
@@ -470,7 +474,7 @@ describe("agent channels", () => {
       if (url.pathname === "/repos/acme/app/issues/comments/7" && init?.method === "PATCH") return Response.json({ id: 7 })
       throw new Error(`Unexpected GitHub API call: ${url}`)
     })
-    vi.stubEnv("GITHUB_TOKEN", "actions-installation-token")
+    vi.stubEnv(tokenKey, "actions-installation-token")
     vi.stubGlobal("fetch", fetcher)
     try {
       const channel = github({

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -41,10 +41,11 @@ describe("agent channels", () => {
       const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
       const method = init?.method || "GET"
       methods.push(method)
+      if (url.pathname === "/user") return new Response(JSON.stringify({ login: "vitehub-bot" }), { headers: { "content-type": "application/json" } })
       if (method === "GET") {
         const comments = url.searchParams.get("page") === "2" || !stored
           ? []
-          : [{ body: stored.body, id: stored.id }]
+          : [{ body: stored.body, id: stored.id, user: { login: "vitehub-bot" } }]
         return new Response(JSON.stringify(comments), { headers: { "content-type": "application/json" } })
       }
       const parsedBody: unknown = JSON.parse(String(init?.body))

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -165,6 +165,40 @@ describe("agent channels", () => {
     expect(fetcher).toHaveBeenCalledWith("https://api.github.test/repos/acme/app/issues/comments/7", expect.objectContaining({ method: "PATCH" }))
   })
 
+  it("reuses GitHub Actions bot activity when its installation token cannot resolve /user", async () => {
+    const { github } = await import("../src/channels.ts")
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
+      if (url.pathname === "/user") return Response.json({ message: "Resource not accessible by integration" }, { status: 403 })
+      if (url.pathname === "/repos/acme/app/issues/42/comments" && init?.method === "GET") {
+        return Response.json([{ body: "<!-- vitehub-agent-activity:e30 -->", id: 7, user: { login: "github-actions[bot]" } }])
+      }
+      if (url.pathname === "/repos/acme/app/issues/comments/7" && init?.method === "PATCH") return Response.json({ id: 7 })
+      throw new Error(`Unexpected GitHub API call: ${url}`)
+    })
+    vi.stubEnv("GITHUB_TOKEN", "actions-installation-token")
+    vi.stubGlobal("fetch", fetcher)
+    try {
+      const channel = github({ activity: true })
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await channel.activity?.update({
+        activity: { links: [], runId: "run-actions", status: "running", tasks: [] },
+        channel,
+        memo: vi.fn(),
+        run: { runId: "run-actions" },
+        runtime: "unknown",
+        target: { issue: 42, repository: "acme/app" },
+        waitUntil: vi.fn(),
+      } as never)
+
+      expect(fetcher).toHaveBeenCalledWith("https://api.github.com/repos/acme/app/issues/comments/7", expect.objectContaining({ method: "PATCH" }))
+    }
+    finally {
+      vi.unstubAllGlobals()
+      vi.unstubAllEnvs()
+    }
+  })
+
   it("bounds the complete serialized GitHub activity comment", async () => {
     const { github } = await import("../src/channels.ts")
     let storedBody = ""

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -164,14 +164,21 @@ describe("agent channels", () => {
   it("creates queued GitHub activity when a pull request opens", async () => {
     const { github } = await import("../src/channels.ts")
     let storedBody = ""
+    const methods: string[] = []
     const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
+      const method = init?.method || "GET"
+      methods.push(method)
       if (url.pathname === "/user") return Response.json({ login: "vitehub-bot" })
-      if (init?.method === "GET") return Response.json([])
+      if (method === "GET") {
+        return Response.json(url.searchParams.get("page") === "2" || !storedBody
+          ? []
+          : [{ body: storedBody, id: 7, user: { login: "vitehub-bot" } }])
+      }
       const payload: unknown = JSON.parse(String(init?.body))
       if (!isRuntimeRecord(payload) || !hasRuntimeType(payload.body, "string")) throw new Error("Invalid comment body.")
       storedBody = payload.body
-      return Response.json({ id: 7 }, { status: 201 })
+      return Response.json({ id: 7 }, { status: method === "POST" ? 201 : 200 })
     })
     vi.stubEnv("GITHUB_TOKEN", "test-token")
     vi.stubGlobal("fetch", fetcher)
@@ -180,16 +187,36 @@ describe("agent channels", () => {
       const trigger = channel.triggers?.webhook
       if (!trigger) throw new Error("Missing GitHub webhook trigger.")
       // SAFETY: This fixture supplies the callback fields consumed by GitHub activity initialization.
-      const result = await trigger.invoke({
+      const triggerContext = {
         agentCapabilities: [],
         agentIdentity: { name: "reviewer" },
         channel,
         trigger: { channelId: "github", id: "github.webhook", name: "webhook", source: "channel" },
-      } as never, { github: { event: "pull_request" }, payload: githubPullRequestOpenedPayload() })
+      } as never
+      const opened = { github: { event: "pull_request" }, payload: githubPullRequestOpenedPayload() }
+      const result = await trigger.invoke(triggerContext, opened)
 
       expect(result).toBeInstanceOf(Response)
       expect(fetcher).toHaveBeenCalledWith(expect.stringContaining("/repos/acme/app/issues/42/comments"), expect.objectContaining({ method: "POST" }))
       expect(storedBody).toContain("agent-queued-6e7781")
+
+      // SAFETY: This fixture supplies the callback fields consumed by the activity updater.
+      await channel.activity?.update({
+        activity: { links: [], runId: "real-run", status: "running", tasks: [] },
+        channel,
+        memo: vi.fn(),
+        run: { runId: "real-run" },
+        runtime: "unknown",
+        target: { issue: 42, repository: "acme/app" },
+        waitUntil: vi.fn(),
+      } as never)
+      const runningBody = storedBody
+      await trigger.invoke(triggerContext, opened)
+
+      expect(methods.filter(method => method === "POST")).toHaveLength(1)
+      expect(methods.filter(method => method === "PATCH")).toHaveLength(1)
+      expect(storedBody).toBe(runningBody)
+      expect(storedBody).toContain("agent-running-0969da")
     }
     finally {
       vi.unstubAllGlobals()

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -280,8 +280,11 @@ describe("agent channels", () => {
 
   it("reuses GitHub Actions bot activity when its installation token cannot resolve /user", async () => {
     const { github } = await import("../src/channels.ts")
+    const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })
+    const privateKeyPem = privateKey.export({ format: "pem", type: "pkcs1" }).toString()
     const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
+      if (url.pathname === "/app/installations/123/access_tokens") return Response.json({ message: "Not Found" }, { status: 404 })
       if (url.pathname === "/user") return Response.json({ message: "Resource not accessible by integration" }, { status: 403 })
       if (url.pathname === "/repos/acme/app/issues/42/comments" && init?.method === "GET") {
         return Response.json([{ body: "<!-- vitehub-agent-activity:e30 -->", id: 7, user: { login: "github-actions[bot]" } }])
@@ -292,7 +295,10 @@ describe("agent channels", () => {
     vi.stubEnv("GITHUB_TOKEN", "actions-installation-token")
     vi.stubGlobal("fetch", fetcher)
     try {
-      const channel = github({ activity: true })
+      const channel = github({
+        activity: true,
+        app: { appId: "1", fetch: fetcher, installationId: 123, privateKey: privateKeyPem },
+      })
       // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
       await channel.activity?.update({
         activity: { links: [], runId: "run-actions", status: "running", tasks: [] },
@@ -300,7 +306,7 @@ describe("agent channels", () => {
         memo: vi.fn(),
         run: { runId: "run-actions" },
         runtime: "unknown",
-        target: { issue: 42, repository: "acme/app" },
+        target: { installationId: 123, issue: 42, repository: "acme/app" },
         waitUntil: vi.fn(),
       } as never)
 

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -218,6 +218,7 @@ describe("agent channels", () => {
     vi.stubGlobal("fetch", fetcher)
     try {
       const channel = github({ activity: true })
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
       await channel.activity?.update({
         activity: { links: [], runId: "run-quoted", status: "running", tasks: [] },
         channel,
@@ -242,6 +243,7 @@ describe("agent channels", () => {
     const posts: string[] = []
     const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
+      // SAFETY: The fixture controls the request headers and supplies a string-keyed header record.
       const authorization = String((init?.headers as Record<string, string> | undefined)?.authorization || "")
       if (url.pathname === "/user") return Response.json({ login: authorization.endsWith("token-a") ? "bot-a" : "bot-b" })
       if (init?.method === "GET") return Response.json([])
@@ -262,8 +264,10 @@ describe("agent channels", () => {
       const channelA = github({ activity: true })
       const channelB = github({ activity: true })
       vi.stubEnv("GITHUB_TOKEN", "token-a")
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
       await channelA.activity?.update(context(channelA) as never)
       vi.stubEnv("GITHUB_TOKEN", "token-b")
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
       await channelB.activity?.update(context(channelB) as never)
 
       expect(posts).toEqual(["Bearer token-a", "Bearer token-b"])

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -48,6 +48,7 @@ describe("agent channels", () => {
     let stored: { body: string, id: number } | undefined
     const deleteStored = () => { stored = undefined }
     let failNextCommentsGet = false
+    let hideStoredFromList = false
     const methods: string[] = []
     const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
@@ -59,7 +60,12 @@ describe("agent channels", () => {
           failNextCommentsGet = false
           throw new Error("GitHub unavailable")
         }
-        const comments = url.searchParams.get("page") === "2" || !stored
+        if (url.pathname === "/repos/acme/app/issues/comments/7") {
+          return stored
+            ? Response.json({ body: stored.body, id: stored.id, user: { login: "vitehub-bot" } })
+            : Response.json({ message: "Not Found" }, { status: 404 })
+        }
+        const comments = url.searchParams.get("page") === "2" || !stored || hideStoredFromList
           ? []
           : [{ body: stored.body, id: stored.id, user: { login: "vitehub-bot" } }]
         return new Response(JSON.stringify(comments), { headers: { "content-type": "application/json" } })
@@ -124,6 +130,14 @@ describe("agent channels", () => {
       // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
       await update(context("retry-run", "running") as never)
       expect(stored?.body).toContain("https://console.test/invocations/retry-run")
+
+      // A cached managed comment remains reusable after newer replies push it outside the listing window.
+      hideStoredFromList = true
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await update(context("cached-run", "running") as never)
+      expect(methods.filter(method => method === "POST")).toHaveLength(1)
+      expect(stored?.body).toContain("https://console.test/invocations/cached-run")
+      hideStoredFromList = false
 
       // A deleted cached comment must be rediscovered as missing and recreated.
       deleteStored()
@@ -533,6 +547,7 @@ describe("agent channels", () => {
         waitUntil: vi.fn(),
       } as never)
       expect(Buffer.byteLength(storedBody)).toBeLessThan(65_536)
+      expect(storedBody).toMatch(/^<!-- vitehub-agent-activity:[A-Za-z0-9_-]+ -->/)
       expect(storedBody).not.toContain("x".repeat(1_000))
       expect(storedBody).toContain("Agent stopped:")
       expect(storedBody).toContain(links[0]!.url)

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -89,7 +89,10 @@ describe("agent channels", () => {
           runId,
           status,
           ...(status === "completed" ? { summary: "Review complete." } : {}),
-          tasks: [{ status: status === "completed" ? "completed" : "in-progress", title: "Review changes" }],
+          tasks: [
+            { status: status === "completed" ? "completed" : "in-progress", title: "Review changes" },
+            { status: "pending", title: "Untrusted\n# [link](https://example.com) *text*" },
+          ],
         },
         channel,
         memo: vi.fn(),
@@ -111,6 +114,8 @@ describe("agent channels", () => {
       expect(methods.filter(method => method === "PATCH")).toHaveLength(2)
       expect(stored?.body).toContain("agent-running-0969da")
       expect(stored?.body).toContain("- [ ] ⏳ Review changes")
+      expect(stored?.body).toContain("- [ ] Untrusted # \\[link\\]\\(https://example.com) \\*text\\*")
+      expect(stored?.body).not.toContain("\n# [link]")
       expect(stored?.body).toContain("https://console.test/invocations/run-2")
       expect(stored?.body).toContain("<summary>Previous sessions</summary>")
       expect(stored?.body).toContain("https://console.test/invocations/run-1")
@@ -513,7 +518,16 @@ describe("agent channels", () => {
     vi.stubGlobal("fetch", fetcher)
     try {
       const channel = github({ activity: true })
-      await expect(channel.activity?.update(context(channel, "run-user-token") as never))
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await expect(channel.activity?.update({
+        activity: { links: [], runId: "run-user-token", status: "running", tasks: [] },
+        channel,
+        memo: vi.fn(),
+        run: { runId: "run-user-token" },
+        runtime: "unknown",
+        target: { issue: 42, repository: "acme/app" },
+        waitUntil: vi.fn(),
+      } as never))
         .rejects.toThrow("could not resolve the authenticated identity")
       expect(fetcher).not.toHaveBeenCalledWith(expect.stringContaining("/comments"), expect.anything())
     }
@@ -541,7 +555,16 @@ describe("agent channels", () => {
     vi.stubGlobal("fetch", fetcher)
     try {
       const channel = github({ activity: true })
-      await channel.activity?.update(context(channel, "run-restarted") as never)
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await channel.activity?.update({
+        activity: { links: [], runId: "run-restarted", status: "running", tasks: [] },
+        channel,
+        memo: vi.fn(),
+        run: { runId: "run-restarted" },
+        runtime: "unknown",
+        target: { issue: 42, repository: "acme/app" },
+        waitUntil: vi.fn(),
+      } as never)
       expect(fetcher).toHaveBeenCalledWith("https://api.github.com/repos/acme/app/issues/comments/7", expect.objectContaining({ method: "PATCH" }))
     }
     finally {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -372,6 +372,64 @@ describe("agent channels", () => {
     }
   })
 
+  it("orders GitHub activity before resolving authenticated identity", async () => {
+    const { github } = await import("../src/channels.ts")
+    let storedBody = ""
+    let identityCalls = 0
+    let releaseFirstIdentity!: () => void
+    const firstIdentityPending = new Promise<void>(resolve => { releaseFirstIdentity = resolve })
+    const writes: string[] = []
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
+      if (url.pathname === "/user") {
+        identityCalls++
+        if (identityCalls === 1) await firstIdentityPending
+        return Response.json({ login: "vitehub-bot" })
+      }
+      if (init?.method === "GET") {
+        return Response.json(url.searchParams.has("page") || !storedBody
+          ? []
+          : [{ body: storedBody, id: 7, user: { login: "vitehub-bot" } }])
+      }
+      const payload: unknown = JSON.parse(String(init?.body))
+      if (!isRuntimeRecord(payload) || !hasRuntimeType(payload.body, "string")) throw new Error("Invalid comment body.")
+      storedBody = payload.body
+      writes.push(storedBody)
+      return Response.json({ id: 7 }, { status: init?.method === "POST" ? 201 : 200 })
+    })
+    const context = (channel: ReturnType<typeof github>, runId: string) => ({
+      activity: { links: [{ label: "Session", url: `https://console.test/invocations/${runId}` }], runId, status: "running" as const, tasks: [] },
+      channel,
+      memo: vi.fn(),
+      run: { runId },
+      runtime: "unknown",
+      target: { issue: 42, repository: "acme/app" },
+      waitUntil: vi.fn(),
+    })
+    vi.stubEnv("GITHUB_TOKEN", "test-token")
+    vi.stubGlobal("fetch", fetcher)
+    try {
+      const channel = github({ activity: true })
+      const first = channel.activity?.update(context(channel, "run-first") as never)
+      await vi.waitFor(() => expect(identityCalls).toBe(1))
+      const second = channel.activity?.update(context(channel, "run-second") as never)
+
+      await Promise.resolve()
+      expect(identityCalls).toBe(1)
+      releaseFirstIdentity()
+      await Promise.all([first, second])
+
+      expect(identityCalls).toBe(2)
+      expect(writes).toHaveLength(2)
+      expect(writes[0]).toContain("run-first")
+      expect(writes[1]).toContain("run-second")
+    }
+    finally {
+      vi.unstubAllGlobals()
+      vi.unstubAllEnvs()
+    }
+  })
+
   it("reuses GitHub Actions bot activity when its installation token cannot resolve /user", async () => {
     const { github } = await import("../src/channels.ts")
     const { privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 })

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -49,8 +49,8 @@ describe("agent channels", () => {
       }
       const parsedBody: unknown = JSON.parse(String(init?.body))
       if (!isRuntimeRecord(parsedBody) || !hasRuntimeType(parsedBody.body, "string")) throw new Error("Invalid comment body.")
-      const body = parsedBody
-      stored = { body: body.body, id: 7 }
+      const body = parsedBody.body
+      stored = { body, id: 7 }
       return new Response(JSON.stringify(stored), { headers: { "content-type": "application/json" }, status: method === "POST" ? 201 : 200 })
     })
     vi.stubEnv("GITHUB_TOKEN", "test-token")

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -544,7 +544,7 @@ describe("agent channels", () => {
       if (url.pathname === "/user") return Response.json({ login: "vitehub-bot" })
       if (url.pathname === "/repos/acme/app/issues/42/comments" && init?.method === "GET") {
         const page = url.searchParams.get("page")
-        if (page === "1") {
+        if (page === null) {
           return Response.json(Array.from({ length: 100 }, (_, id) => ({ body: "ordinary", id: id + 1 })), {
             headers: { link: `<https://api.github.com/repos/acme/app/issues/42/comments?per_page=100&page=6>; rel="last"` },
           })

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -199,6 +199,81 @@ describe("agent channels", () => {
     expect(fetcher).toHaveBeenCalledWith("https://api.github.test/repos/acme/app/issues/comments/7", expect.objectContaining({ method: "PATCH" }))
   })
 
+  it("does not reuse owned replies that only quote the activity marker", async () => {
+    const { github } = await import("../src/channels.ts")
+    const methods: string[] = []
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
+      const method = init?.method || "GET"
+      methods.push(method)
+      if (url.pathname === "/user") return Response.json({ login: "vitehub-bot" })
+      if (method === "GET") {
+        return Response.json(url.searchParams.has("page")
+          ? []
+          : [{ body: "Quoted source: <!-- vitehub-agent-activity:e30 -->", id: 7, user: { login: "vitehub-bot" } }])
+      }
+      return Response.json({ id: 8 }, { status: 201 })
+    })
+    vi.stubEnv("GITHUB_TOKEN", "test-token")
+    vi.stubGlobal("fetch", fetcher)
+    try {
+      const channel = github({ activity: true })
+      await channel.activity?.update({
+        activity: { links: [], runId: "run-quoted", status: "running", tasks: [] },
+        channel,
+        memo: vi.fn(),
+        run: { runId: "run-quoted" },
+        runtime: "unknown",
+        target: { issue: 42, repository: "acme/app" },
+        waitUntil: vi.fn(),
+      } as never)
+
+      expect(methods).toContain("POST")
+      expect(methods).not.toContain("PATCH")
+    }
+    finally {
+      vi.unstubAllGlobals()
+      vi.unstubAllEnvs()
+    }
+  })
+
+  it("orders GitHub activity separately for each authenticated identity", async () => {
+    const { github } = await import("../src/channels.ts")
+    const posts: string[] = []
+    const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
+      const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
+      const authorization = String((init?.headers as Record<string, string> | undefined)?.authorization || "")
+      if (url.pathname === "/user") return Response.json({ login: authorization.endsWith("token-a") ? "bot-a" : "bot-b" })
+      if (init?.method === "GET") return Response.json([])
+      posts.push(authorization)
+      return Response.json({ id: posts.length }, { status: 201 })
+    })
+    const context = (channel: ReturnType<typeof github>) => ({
+      activity: { links: [], runId: "shared-run", status: "running", tasks: [] },
+      channel,
+      memo: vi.fn(),
+      run: { runId: "shared-run" },
+      runtime: "unknown",
+      target: { issue: 42, repository: "acme/app" },
+      waitUntil: vi.fn(),
+    })
+    vi.stubGlobal("fetch", fetcher)
+    try {
+      const channelA = github({ activity: true })
+      const channelB = github({ activity: true })
+      vi.stubEnv("GITHUB_TOKEN", "token-a")
+      await channelA.activity?.update(context(channelA) as never)
+      vi.stubEnv("GITHUB_TOKEN", "token-b")
+      await channelB.activity?.update(context(channelB) as never)
+
+      expect(posts).toEqual(["Bearer token-a", "Bearer token-b"])
+    }
+    finally {
+      vi.unstubAllGlobals()
+      vi.unstubAllEnvs()
+    }
+  })
+
   it("reuses GitHub Actions bot activity when its installation token cannot resolve /user", async () => {
     const { github } = await import("../src/channels.ts")
     const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -99,6 +99,16 @@ describe("agent channels", () => {
       expect(stored?.body.length).toBeLessThan(65_536)
       expect(stored?.body).toContain("24:")
       expect(stored?.body).not.toContain("25:")
+
+      for (let index = 4; index <= 14; index++) {
+        // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+        await update(context(`run-${index}`, "running") as never)
+      }
+      const currentBody = stored?.body
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await update(context("run-1", "completed") as never)
+      expect(stored?.body).toBe(currentBody)
+      expect(stored?.body).toContain("https://console.test/invocations/run-14")
     }
     finally {
       vi.unstubAllGlobals()

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path"
 
 import { describe, expect, it, vi } from "vitest"
 
-import { hasRuntimeType } from "../src/internal/runtime-type.ts"
+import { hasRuntimeType, isRuntimeRecord } from "../src/internal/runtime-type.ts"
 
 function githubIssueCommentPayload(body = "/review please") {
   return {
@@ -38,7 +38,7 @@ describe("agent channels", () => {
     let stored: { body: string, id: number } | undefined
     const methods: string[] = []
     const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-      const url = new URL(typeof input === "string" || input instanceof URL ? input : input.url)
+      const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
       const method = init?.method || "GET"
       methods.push(method)
       if (method === "GET") {
@@ -47,7 +47,9 @@ describe("agent channels", () => {
           : [{ body: stored.body, id: stored.id }]
         return new Response(JSON.stringify(comments), { headers: { "content-type": "application/json" } })
       }
-      const body = JSON.parse(String(init?.body)) as { body: string }
+      const parsedBody: unknown = JSON.parse(String(init?.body))
+      if (!isRuntimeRecord(parsedBody) || !hasRuntimeType(parsedBody.body, "string")) throw new Error("Invalid comment body.")
+      const body = parsedBody
       stored = { body: body.body, id: 7 }
       return new Response(JSON.stringify(stored), { headers: { "content-type": "application/json" }, status: method === "POST" ? 201 : 200 })
     })

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -36,6 +36,7 @@ describe("agent channels", () => {
   it("creates and updates one GitHub Agent activity comment with session history", async () => {
     const { github } = await import("../src/channels.ts")
     let stored: { body: string, id: number } | undefined
+    let failNextCommentsGet = false
     const methods: string[] = []
     const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
@@ -43,6 +44,10 @@ describe("agent channels", () => {
       methods.push(method)
       if (url.pathname === "/user") return new Response(JSON.stringify({ login: "vitehub-bot" }), { headers: { "content-type": "application/json" } })
       if (method === "GET") {
+        if (failNextCommentsGet) {
+          failNextCommentsGet = false
+          throw new Error("GitHub unavailable")
+        }
         const comments = url.searchParams.get("page") === "2" || !stored
           ? []
           : [{ body: stored.body, id: stored.id, user: { login: "vitehub-bot" } }]
@@ -60,8 +65,9 @@ describe("agent channels", () => {
       const channel = github({ activity: true })
       const update = channel.activity?.update
       if (!update) throw new Error("Missing GitHub Agent activity updater.")
-      const context = (runId: string, status: "completed" | "running") => ({
+      const context = (runId: string, status: "completed" | "running", agentName = "reviewer") => ({
         activity: {
+          agentName,
           links: [{ label: "Session", url: `https://console.test/invocations/${runId}` }],
           runId,
           status,
@@ -92,6 +98,21 @@ describe("agent channels", () => {
       expect(stored?.body).toContain("https://console.test/invocations/run-1")
       expect(stored?.body.match(/vitehub-agent-activity:/g)).toHaveLength(1)
 
+      // Agent identity keeps equal provider run IDs as separate activity sessions.
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await update(context("run-2", "completed") as never)
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await update(context("run-2", "running", "writer") as never)
+      expect(stored?.body).toContain("agent-running-0969da")
+
+      // A failed initial projection must not mark the run stale for its retry.
+      failNextCommentsGet = true
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await expect(update(context("retry-run", "running") as never)).rejects.toThrow("GitHub unavailable")
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+      await update(context("retry-run", "running") as never)
+      expect(stored?.body).toContain("https://console.test/invocations/retry-run")
+
       const largeActivity = context("run-3", "running")
       largeActivity.activity.tasks = Array.from({ length: 100 }, (_, index) => ({ status: "pending", title: `${index}: ${"x".repeat(1_000)}` }))
       // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
@@ -111,6 +132,7 @@ describe("agent channels", () => {
       expect(stored?.body).toContain("https://console.test/invocations/run-14")
 
       // Keep an active run stale even after bounded serialized tombstones evict it.
+      // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
       await update(context("long-running", "running") as never)
       for (let index = 0; index <= 100; index++) {
         // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -179,6 +179,7 @@ describe("agent channels", () => {
       const channel = github({ activity: true })
       const trigger = channel.triggers?.webhook
       if (!trigger) throw new Error("Missing GitHub webhook trigger.")
+      // SAFETY: This fixture supplies the callback fields consumed by GitHub activity initialization.
       const result = await trigger.invoke({
         agentCapabilities: [],
         agentIdentity: { name: "reviewer" },

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -165,13 +165,13 @@ describe("agent channels", () => {
     expect(fetcher).toHaveBeenCalledWith("https://api.github.test/repos/acme/app/issues/comments/7", expect.objectContaining({ method: "PATCH" }))
   })
 
-  it("bounds serialized GitHub activity run identity", async () => {
+  it("bounds the complete serialized GitHub activity comment", async () => {
     const { github } = await import("../src/channels.ts")
     let storedBody = ""
     const fetcher = vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
       const url = new URL(hasRuntimeType(input, "string") || input instanceof URL ? input : input.url)
       if (url.pathname === "/user") return Response.json({ login: "vitehub-bot" })
-      if (init?.method === "GET") return Response.json([])
+      if (init?.method === "GET") return Response.json(storedBody ? [{ body: storedBody, id: 7, user: { login: "vitehub-bot" } }] : [])
       const payload: unknown = JSON.parse(String(init?.body))
       if (!isRuntimeRecord(payload) || !hasRuntimeType(payload.body, "string")) throw new Error("Invalid comment body.")
       storedBody = payload.body
@@ -181,9 +181,29 @@ describe("agent channels", () => {
     vi.stubGlobal("fetch", fetcher)
     try {
       const channel = github({ activity: true })
+      const links = Array.from({ length: 3 }, (_, index) => ({ label: `link-${index}-${"l".repeat(80)}`, url: `https://example.test/${"u".repeat(400)}` }))
+      for (let index = 0; index < 101; index++) {
+        // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
+        await channel.activity?.update({
+          activity: { links, runId: `prior-${index}`, status: "completed", tasks: [] },
+          channel,
+          memo: vi.fn(),
+          run: { runId: `prior-${index}` },
+          runtime: "unknown",
+          target: { issue: 42, repository: "acme/app" },
+          waitUntil: vi.fn(),
+        } as never)
+      }
       // SAFETY: This fixture supplies the complete callback fields consumed by the activity updater.
       await channel.activity?.update({
-        activity: { links: [], runId: "x".repeat(50_000), status: "running", tasks: [] },
+        activity: {
+          error: "e".repeat(1_000),
+          links,
+          runId: "x".repeat(50_000),
+          status: "failed",
+          summary: "s".repeat(12_000),
+          tasks: Array.from({ length: 25 }, (_, index) => ({ status: "pending" as const, title: `task-${index}-${"t".repeat(300)}` })),
+        },
         channel,
         memo: vi.fn(),
         run: { runId: "x".repeat(50_000) },
@@ -191,8 +211,9 @@ describe("agent channels", () => {
         target: { issue: 42, repository: "acme/app" },
         waitUntil: vi.fn(),
       } as never)
-      expect(storedBody.length).toBeLessThan(65_536)
+      expect(Buffer.byteLength(storedBody)).toBeLessThan(65_536)
       expect(storedBody).not.toContain("x".repeat(1_000))
+      expect(storedBody).toContain("Agent stopped:")
     }
     finally {
       vi.unstubAllGlobals()

--- a/packages/agent/test/eve-extension.test.ts
+++ b/packages/agent/test/eve-extension.test.ts
@@ -931,6 +931,25 @@ describe("Eve extension capabilities", () => {
     )).rejects.toThrow("cannot be referenced outside its static Capability mount")
   })
 
+  it("ignores the imported side of an aliased non-extension import", async () => {
+    const transformed = await transformEveExtensionCapabilities(
+      `
+        import { defineAgent } from "@vite-hub/agent"
+        import github from "@github-tools/eve-extension"
+        import { github as githubChannel } from "@vite-hub/agent/channels"
+        export default defineAgent({
+          capabilities: [github()],
+          channels: { github: githubChannel({ activity: true }) },
+        })
+      `,
+      parseAst,
+      async source => source === "@github-tools/eve-extension",
+    )
+
+    expect(transformed).toContain("__vitehubEveExtensionCapability(")
+    expect(transformed).toContain("githubChannel({ activity: true })")
+  })
+
   it("rejects extension factory references inside mount config", async () => {
     await expect(transformEveExtensionCapabilities(
       `

--- a/packages/agent/test/invocation-lifecycle.test.ts
+++ b/packages/agent/test/invocation-lifecycle.test.ts
@@ -262,6 +262,11 @@ describe("Agent Invocation Interface lifecycle", () => {
     await iterator.return?.()
 
     expect(finish).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(finish).toHaveBeenCalledOnce())
+    expect(finish.mock.calls[0]![0]).toMatchObject({
+      result: { raw, text: "partial" },
+    })
+    expect(finish.mock.calls[0]![0].result).not.toHaveProperty("usage")
   })
 
   it("does not await pending raw-stream usage after full consumption", async () => {

--- a/packages/agent/test/invocation-lifecycle.test.ts
+++ b/packages/agent/test/invocation-lifecycle.test.ts
@@ -1374,8 +1374,10 @@ describe("Agent Invocation Interface lifecycle", () => {
     const result = await runAgent(agent, createInvocationRuntime(), { prompt: "hello" }) as {
       toUIMessageStream: () => ReadableStream<unknown>
     }
+    expect(finish).not.toHaveBeenCalled()
     const reader = result.toUIMessageStream().getReader()
     await reader.read()
+    expect(finish).not.toHaveBeenCalled()
     await reader.cancel()
 
     expect(finish).toHaveBeenCalledOnce()

--- a/packages/agent/test/invocation-lifecycle.test.ts
+++ b/packages/agent/test/invocation-lifecycle.test.ts
@@ -1344,6 +1344,7 @@ describe("Agent Invocation Interface lifecycle", () => {
       invocation: { usage: { usage: { totalTokens: 2 } } },
       result: { usage: { totalTokens: 2 }, usageRecord: { usage: { totalTokens: 2 } } },
     })
+    expect(finish.mock.calls[0]![0].runtime.traceLog.entries().at(-1)?.name).toBe("agent.invocation.cancelled")
   })
 
   it("preserves snapshotted usage when a rendered UI stream exits early", async () => {
@@ -1382,6 +1383,7 @@ describe("Agent Invocation Interface lifecycle", () => {
       invocation: { usage: { usage: { totalTokens: 3 } } },
       result: { usage: { totalTokens: 3 }, usageRecord: { usage: { totalTokens: 3 } } },
     })
+    expect(finish.mock.calls[0]![0].runtime.traceLog.entries().at(-1)?.name).toBe("agent.invocation.cancelled")
   })
 
   it.each([

--- a/packages/agent/test/invocation-lifecycle.test.ts
+++ b/packages/agent/test/invocation-lifecycle.test.ts
@@ -261,7 +261,6 @@ describe("Agent Invocation Interface lifecycle", () => {
     await expect(iterator.next()).resolves.toMatchObject({ done: false })
     await iterator.return?.()
 
-    expect(finish).not.toHaveBeenCalled()
     await vi.waitFor(() => expect(finish).toHaveBeenCalledOnce())
     expect(finish.mock.calls[0]![0]).toMatchObject({
       result: { raw, text: "partial" },

--- a/packages/agent/test/invocation-lifecycle.test.ts
+++ b/packages/agent/test/invocation-lifecycle.test.ts
@@ -243,7 +243,7 @@ describe("Agent Invocation Interface lifecycle", () => {
     probe.expectFinished(["driver", "stream:return", "close", "finish"])
   })
 
-  it("does not await pending raw-stream usage after early termination", async () => {
+  it("does not await pending raw-stream usage after cancellation", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const finish = vi.fn()
     const usage = new Promise<never>(() => {})
@@ -261,7 +261,7 @@ describe("Agent Invocation Interface lifecycle", () => {
     await expect(iterator.next()).resolves.toMatchObject({ done: false })
     await iterator.return?.()
 
-    expect(finish).toHaveBeenCalledOnce()
+    expect(finish).not.toHaveBeenCalled()
   })
 
   it("does not await pending raw-stream usage after full consumption", async () => {

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -136,6 +136,47 @@ describe("Agent Invocations", () => {
     expect(record.observations.slice(-3).every(observation => observation.attributes?.["vitehub.trace.truncated"] === true)).toBe(true)
   })
 
+  it("retains identified cancellation when the observation journal is full", () => {
+    const createdAt = "2026-02-02T02:02:02.000Z"
+    const ordinary = Array.from({ length: 256 }, (_, index) => ({
+      attributes: { "vitehub.observation.id": `journal:${index}` },
+      name: `ordinary-${index}`,
+      sequence: index,
+      timestamp: createdAt,
+      type: "run" as const,
+    }))
+    const cancelled = {
+      attributes: { "vitehub.observation.id": "journal:cancelled" },
+      name: "agent.invocation.cancelled",
+      sequence: 256,
+      timestamp: createdAt,
+      type: "run" as const,
+    }
+
+    const record = applyAgentInvocationStoreUpdate({
+      createdAt,
+      cursor: "1",
+      id: "cancelled-at-capacity",
+      observations: ordinary,
+      status: "cancelled",
+      traceId: "trace",
+      updatedAt: createdAt,
+    }, {
+      observation: cancelled,
+      timestamp: createdAt,
+    })
+
+    expect(record).toMatchObject({ observationsTruncated: true })
+    expect(record.observations).toHaveLength(256)
+    expect(record.observations.at(-1)).toMatchObject({
+      attributes: {
+        "vitehub.observation.id": "journal:cancelled",
+        "vitehub.trace.truncated": true,
+      },
+      name: "agent.invocation.cancelled",
+    })
+  })
+
   it("reserves lifecycle evidence before recent delivery outcomes", () => {
     const createdAt = "2026-02-02T02:02:02.000Z"
     const lifecycle = [

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path"
 import { tmpdir } from "node:os"
 import { describe, expect, it, vi } from "vitest"
 
-import { defineAgent, defineCapability, runAgent, runAgentInline, streamAgent } from "../src/index.ts"
+import { agentInvocationId, defineAgent, defineCapability, runAgent, runAgentInline, streamAgent } from "../src/index.ts"
 import { applyAgentInvocationStoreUpdate, bindAgentInvocations } from "../src/invocations.ts"
 import { createMemoryAgentInvocationStore, defineAgentInvocations } from "../src/server.ts"
 import { createLibsqlAgentInvocationStore } from "../src/invocations/sqlite.ts"
@@ -2945,6 +2945,17 @@ describe("Agent Invocations", () => {
     await expect(invocations.getByRunId("shared-run", "support")).resolves.toMatchObject({ agentName: "support" })
     await expect(invocations.getByRunId("shared-run", "review")).resolves.toMatchObject({ agentName: "review" })
     await expect(invocations.list()).resolves.toMatchObject({ invocations: [{}, {}] })
+  })
+
+  it("resolves the public invocation ID from a run and Agent Definition", async () => {
+    const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
+    const agent = defineAgent({ name: "support", driver: { run: () => "done" }, invocations, runtime: false })
+
+    await runAgent(agent, runtime("linked-run"), {})
+
+    const id = await agentInvocationId("linked-run", "support")
+    await expect(invocations.get(id)).resolves.toMatchObject({ agentName: "support" })
+    await expect(agentInvocationId("linked-run", "review")).resolves.not.toBe(id)
   })
 
   it("encodes Agent Definition and run identities without delimiter collisions", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12251,6 +12251,49 @@ describe("agent message protocol", () => {
       }
     })
 
+    it("projects activity when Workflow preparation fails", async () => {
+      const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
+      const { defineChannel } = await import("../src/channels.ts")
+      const { setAgentWorkflowRuntimeLoaders } = await import("../src/internal/workflow-runtime-loaders.ts")
+      const failure = new Error("workflow preparation failed")
+      const statuses: AgentActivityUpdate["status"][] = []
+      setAgentWorkflowRuntimeLoaders({
+        // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
+        state: async () => ({
+          getInlineWorkflowDefinitions: () => new Map(),
+          getWorkflowRuntimeConfig: () => ({ provider: "openworkflow" }),
+          getWorkflowRuntimeRegistry: () => undefined,
+        }) as never,
+        // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
+        workflow: async () => ({ createWorkflow: () => { throw failure } }) as never,
+      })
+      try {
+        await expect(runAgent(defineAgent({
+          channels: {
+            work: defineChannel("work", {
+              activity: { update: ({ activity }) => { statuses.push(activity.status) } },
+              messages: false,
+            }),
+          },
+          driver: { run: () => "unreachable" },
+          runtime: workflow("preparation-failure-agent"),
+        }), {
+          memo: vi.fn(),
+          run: { activity: { target: "work-1" }, channelId: "work", runId: "workflow-run-1" },
+          runtime: "unknown",
+          waitUntil: vi.fn(),
+        }, {})).rejects.toBe(failure)
+
+        expect(statuses).toEqual(["queued", "failed"])
+      }
+      finally {
+        setAgentWorkflowRuntimeLoaders({
+          state: () => import("@vite-hub/workflow/runtime/state"),
+          workflow: () => import("@vite-hub/workflow"),
+        })
+      }
+    })
+
     it("projects terminal activity from an already-settled Workflow run", async () => {
       const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
       const { defineChannel } = await import("../src/channels.ts")
@@ -12293,8 +12336,8 @@ describe("agent message protocol", () => {
           waitUntil: vi.fn(),
         }, {})
 
-        expect(updates).toMatchObject([
-          { status: "queued" },
+        expect(updates.map(({ status, summary }) => ({ status, summary }))).toEqual([
+          { status: "queued", summary: undefined },
           { status: "completed", summary: "Already finished." },
         ])
       }

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12294,6 +12294,47 @@ describe("agent message protocol", () => {
       }
     })
 
+    it("projects failed activity when a direct Workflow has no name", async () => {
+      const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
+      const { defineChannel } = await import("../src/channels.ts")
+      const { setAgentWorkflowRuntimeLoaders } = await import("../src/internal/workflow-runtime-loaders.ts")
+      const statuses: AgentActivityUpdate["status"][] = []
+      setAgentWorkflowRuntimeLoaders({
+        // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
+        state: async () => ({
+          getInlineWorkflowDefinitions: () => new Map(),
+          getWorkflowRuntimeConfig: () => ({ provider: "openworkflow" }),
+          getWorkflowRuntimeRegistry: () => undefined,
+        }) as never,
+        workflow: () => import("@vite-hub/workflow"),
+      })
+      try {
+        await expect(runAgent(defineAgent({
+          channels: {
+            work: defineChannel("work", {
+              activity: { update: ({ activity }) => { statuses.push(activity.status) } },
+              messages: false,
+            }),
+          },
+          driver: { run: () => "unreachable" },
+          runtime: workflow(),
+        }), {
+          memo: vi.fn(),
+          run: { activity: { target: "work-1" }, channelId: "work", runId: "workflow-run-1" },
+          runtime: "unknown",
+          waitUntil: vi.fn(),
+        }, {})).rejects.toThrow("requires a name")
+
+        expect(statuses).toEqual(["queued", "failed"])
+      }
+      finally {
+        setAgentWorkflowRuntimeLoaders({
+          state: () => import("@vite-hub/workflow/runtime/state"),
+          workflow: () => import("@vite-hub/workflow"),
+        })
+      }
+    })
+
     it("projects terminal activity from an already-settled Workflow run", async () => {
       const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
       const { defineChannel } = await import("../src/channels.ts")
@@ -12337,7 +12378,7 @@ describe("agent message protocol", () => {
         }, {})
 
         expect(updates.map(({ status, summary }) => ({ status, summary }))).toEqual([
-          { status: "queued", summary: undefined },
+          { status: "queued", summary: "" },
           { status: "completed", summary: "Already finished." },
         ])
       }

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11232,7 +11232,7 @@ describe("agent message protocol", () => {
     })
     expect(traceLog!.entries().map(event => event.name)).toEqual([
       "agent.invocation.start",
-      "agent.stream.start",
+      "agent.stream.finish",
       "agent.invocation.cancelled",
     ])
     expect(deriveTraceRuns(traceLog!.entries())).toMatchObject([{ status: "cancelled" }])

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11402,7 +11402,7 @@ describe("agent message protocol", () => {
     expect(deriveTraceRuns(agentError.mock.calls[0]![0].runtime.traceLog.entries())).toMatchObject([{ status: "failed" }])
   })
 
-  it("runs agent finish hooks when Response bodies are canceled", async () => {
+  it("keeps canceled Response bodies out of the success lifecycle", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const finish = vi.fn()
     const agent = defineAgent({
@@ -11419,8 +11419,7 @@ describe("agent message protocol", () => {
     // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
     const response = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}) as Response
     await response.body?.cancel()
-    expect(finish).toHaveBeenCalledTimes(1)
-    expect(deriveTraceRuns(finish.mock.calls[0]![0].runtime.traceLog.entries())).toMatchObject([{ status: "completed" }])
+    expect(finish).not.toHaveBeenCalled()
   })
 
   it("runs Agent Error Hooks when Response wrapping fails", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11462,7 +11462,7 @@ describe("agent message protocol", () => {
     expect(deriveTraceRuns(agentError.mock.calls[0]![0].runtime.traceLog.entries())).toMatchObject([{ status: "failed" }])
   })
 
-  it("keeps canceled Response bodies out of the success lifecycle", async () => {
+  it("finalizes canceled Response bodies as cancelled", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const finish = vi.fn()
     const agent = defineAgent({
@@ -11479,7 +11479,8 @@ describe("agent message protocol", () => {
     // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
     const response = await runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {}) as Response
     await response.body?.cancel()
-    expect(finish).not.toHaveBeenCalled()
+    await vi.waitFor(() => expect(finish).toHaveBeenCalledOnce())
+    expect(deriveTraceRuns(finish.mock.calls[0]![0].runtime.traceLog.entries())).toMatchObject([{ status: "cancelled" }])
   })
 
   it("runs Agent Error Hooks when Response wrapping fails", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11,6 +11,7 @@ import { isAsyncIterable } from "../src/internal/stream-result.ts"
 import { adapterDefinition } from "./adapter-definition.ts"
 
 import type { AgentChannelDeliveryFinishEffectCallback, AgentChannelDeliveryFinishEffectResult, AgentFinishEvent } from "../src/index.ts"
+import type { AgentActivityUpdate } from "../src/types.ts"
 import type { WritableWorkspaceFacade } from "@vite-hub/workspace"
 
 const loadAiSdk = vi.hoisted(() => vi.fn())
@@ -5768,13 +5769,13 @@ describe("agent message protocol", () => {
   it("projects invocation status, harness plans, approvals, and final text through the active Channel", async () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
-    const updates: Array<Record<string, unknown>> = []
+    const updates: AgentActivityUpdate[] = []
     const agent = defineAgent({
       channels: {
         work: defineChannel("work", {
           activity: {
             update: ({ activity }) => {
-              updates.push(structuredClone(activity) as unknown as Record<string, unknown>)
+              updates.push(structuredClone(activity))
             },
           },
           messages: false,
@@ -5783,7 +5784,7 @@ describe("agent message protocol", () => {
       driver: { run: () => (async function* () {
           yield { data: { plan: [{ status: "inProgress", step: "Read files" }, { status: "pending", step: "Run tests" }] }, type: "data-agent-plan" }
           yield { id: "approval-1", name: "deploy", type: "approval-request" }
-          yield { approved: true, id: "approval-1", type: "approval-decision" }
+          yield { approved: false, id: "approval-1", type: "approval-decision" }
           yield { phase: "final", role: "assistant", text: "Finished the review.", type: "text-delta" }
           yield { type: "finish" }
         })() },

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12251,6 +12251,61 @@ describe("agent message protocol", () => {
       }
     })
 
+    it("projects terminal activity from an already-settled Workflow run", async () => {
+      const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
+      const { defineChannel } = await import("../src/channels.ts")
+      const { setAgentWorkflowRuntimeLoaders } = await import("../src/internal/workflow-runtime-loaders.ts")
+      const updates: AgentActivityUpdate[] = []
+      setAgentWorkflowRuntimeLoaders({
+        // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
+        state: async () => ({
+          getInlineWorkflowDefinitions: () => new Map(),
+          getWorkflowRuntimeConfig: () => ({ provider: "openworkflow" }),
+          getWorkflowRuntimeRegistry: () => undefined,
+          runWithWorkflowRuntimeEvent: (_event: unknown, callback: () => unknown) => callback(),
+        }) as never,
+        // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
+        workflow: async () => ({
+          createWorkflow: () => ({
+            run: async () => ({
+              id: "existing-run",
+              provider: "openworkflow",
+              result: { text: "Already finished." },
+              status: "completed",
+            }),
+          }),
+        }) as never,
+      })
+      try {
+        await runAgent(defineAgent({
+          channels: {
+            work: defineChannel("work", {
+              activity: { update: ({ activity }) => { updates.push(structuredClone(activity)) } },
+              messages: false,
+            }),
+          },
+          driver: { run: () => "unreachable" },
+          runtime: workflow("settled-agent"),
+        }), {
+          memo: vi.fn(),
+          run: { activity: { target: "work-1" }, channelId: "work", runId: "existing-run" },
+          runtime: "unknown",
+          waitUntil: vi.fn(),
+        }, {})
+
+        expect(updates).toMatchObject([
+          { status: "queued" },
+          { status: "completed", summary: "Already finished." },
+        ])
+      }
+      finally {
+        setAgentWorkflowRuntimeLoaders({
+          state: () => import("@vite-hub/workflow/runtime/state"),
+          workflow: () => import("@vite-hub/workflow"),
+        })
+      }
+    })
+
     it("keeps ambiguous accepted OpenWorkflow starts recoverable", async () => {
       const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
       const { setAgentWorkflowRuntimeLoaders } = await import("../src/internal/workflow-runtime-loaders.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11181,7 +11181,8 @@ describe("agent message protocol", () => {
         traceLog = context.traceLog
         return {
           fullStream: (async function* () {
-            yield { type: "finish" }
+            yield { type: "start" }
+            await new Promise<void>(() => {})
           })(),
           toUIMessageStream() {
             return new ReadableStream({
@@ -11228,7 +11229,7 @@ describe("agent message protocol", () => {
     expect(cancelReason).toBeUndefined()
     expect(traceLog!.entries().map(event => event.name)).toEqual([
       "agent.invocation.start",
-      "agent.stream.finish",
+      "agent.stream.start",
       "agent.invocation.cancelled",
     ])
     expect(deriveTraceRuns(traceLog!.entries())).toMatchObject([{ status: "cancelled" }])

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11219,13 +11219,13 @@ describe("agent message protocol", () => {
 
     expect(pulls).toBeLessThanOrEqual(2)
     const cancelResult = await Promise.race([
-      stream.cancel("client disconnected").then(() => "cancelled"),
+      stream.cancel().then(() => "cancelled"),
       new Promise(resolve => setTimeout(() => resolve("timeout"), 50)),
     ])
     releaseBlockedPull?.()
 
     expect(cancelResult).toBe("cancelled")
-    expect(cancelReason).toBe("client disconnected")
+    expect(cancelReason).toBeUndefined()
     expect(traceLog!.entries().map(event => event.name)).toEqual([
       "agent.invocation.start",
       "agent.stream.finish",

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11229,9 +11229,9 @@ describe("agent message protocol", () => {
     expect(traceLog!.entries().map(event => event.name)).toEqual([
       "agent.invocation.start",
       "agent.stream.finish",
-      "agent.invocation.error",
+      "agent.invocation.cancelled",
     ])
-    expect(deriveTraceRuns(traceLog!.entries())).toMatchObject([{ status: "failed" }])
+    expect(deriveTraceRuns(traceLog!.entries())).toMatchObject([{ status: "cancelled" }])
   })
 
   it("emits one title data part when async event streams become UI message streams", async () => {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5784,8 +5784,8 @@ describe("agent message protocol", () => {
       driver: { run: () => (async function* () {
           yield { data: { plan: [{ status: "inProgress", step: "Read files" }, { status: "pending", step: "Run tests" }] }, type: "data-agent-plan" }
           yield { id: "approval-1", name: "deploy", type: "approval-request" }
-          yield { approved: false, id: "approval-1", type: "approval-decision" }
           yield { data: { requestId: "input-1", status: "requested" }, type: "data-agent-input" }
+          yield { approved: false, id: "approval-1", type: "approval-decision" }
           yield { data: { answers: { scope: "workspace" }, requestId: "input-1", status: "resolved" }, type: "data-agent-input" }
           yield { phase: "final", role: "assistant", text: "Finished the review.", type: "text-delta" }
           yield { type: "finish" }
@@ -5808,7 +5808,7 @@ describe("agent message protocol", () => {
     // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
     for await (const _event of stream as AsyncIterable<unknown>) {}
 
-    expect(updates.map(update => update.status)).toEqual(["queued", "running", "running", "waiting", "running", "waiting", "running", "completed"])
+    expect(updates.map(update => update.status)).toEqual(["queued", "running", "running", "waiting", "waiting", "waiting", "running", "completed"])
     expect(updates[2]?.tasks).toEqual([
       { status: "in-progress", title: "Read files" },
       { status: "pending", title: "Run tests" },

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5833,6 +5833,39 @@ describe("agent message protocol", () => {
     expect(waitUntil).toHaveBeenCalled()
   })
 
+  it("bounds text retained from Response streams for Channel activity", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const updates: AgentActivityUpdate[] = []
+    const agent = defineAgent({
+      channels: {
+        work: defineChannel("work", {
+          activity: {
+            update: ({ activity }) => {
+              updates.push(structuredClone(activity))
+            },
+          },
+          messages: false,
+        }),
+      },
+      driver: { run: () => new Response("a".repeat(20_000), { headers: { "content-type": "text/plain" } }) },
+    })
+
+    const response = await runAgent(agent, {
+      memo: vi.fn(),
+      run: {
+        activity: { runId: "run-1", target: { id: "work-1" } },
+        channelId: "work",
+        runId: "provider-run-1",
+      },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {}) as Response
+    await response.text()
+
+    expect(updates.at(-1)).toMatchObject({ status: "completed", summary: "a".repeat(12_000) })
+  })
+
   it("projects setup failures without replacing the Agent error", async () => {
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11234,6 +11234,62 @@ describe("agent message protocol", () => {
     expect(deriveTraceRuns(traceLog!.entries())).toMatchObject([{ status: "cancelled" }])
   })
 
+  it("preserves Capability cleanup failures after UI stream cancellation", async () => {
+    const { defineAgent, defineCapability, streamAgent } = await import("../src/index.ts")
+    const cleanupFailure = new Error("cleanup failed after cancellation")
+    let releaseBlockedPull: (() => void) | undefined
+    let traceLog: ReturnType<typeof createTraceEventLog> | undefined
+    const agent = defineAgent({
+      capabilities: [defineCapability({
+        close: async () => { throw cleanupFailure },
+        id: "failing-cleanup",
+      })],
+      driver: { run: (context) => {
+        traceLog = context.traceLog
+        return {
+          fullStream: (async function* () {
+            yield { type: "finish" }
+          })(),
+          toUIMessageStream() {
+            return new ReadableStream({
+              pull(controller) {
+                if (releaseBlockedPull) return
+                controller.enqueue({ type: "start", messageId: "assistant-1" })
+                return new Promise<void>((resolve) => {
+                  releaseBlockedPull = resolve
+                })
+              },
+              cancel() {
+                releaseBlockedPull?.()
+              },
+            })
+          },
+        }
+      } },
+    })
+
+    // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
+    const stream = await streamAgent(agent, {
+      memo: vi.fn(),
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {
+      messages: [createMessage({ role: "user", text: "Explain availability" })],
+    }, { output: "ui-message-stream" }) as ReadableStream<never>
+    await Promise.resolve()
+    await Promise.resolve()
+
+    await expect(stream.cancel()).rejects.toBe(cleanupFailure)
+    releaseBlockedPull?.()
+    expect(traceLog!.entries().filter(event => event.name === "agent.invocation.error")).toMatchObject([
+      {
+        activity: { owner: "vitehub", phase: "teardown" },
+        attributes: { "error.message": cleanupFailure.message },
+      },
+    ])
+    expect(deriveTraceRuns(traceLog!.entries())).toMatchObject([{ status: "failed" }])
+  })
+
   it("emits one title data part when async event streams become UI message streams", async () => {
     const { readUIMessageStream } = await import("ai")
     const { defineAgent, streamAgent } = await import("../src/index.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5787,6 +5787,7 @@ describe("agent message protocol", () => {
           yield { id: "approval-1", name: "deploy", type: "approval-request" }
           yield { data: { requestId: "input-1", status: "requested" }, type: "data-agent-input" }
           yield { approved: false, id: "approval-1", type: "approval-decision" }
+          yield { data: { plan: [{ status: "completed", step: "Read files" }, { status: "inProgress", step: "Run tests" }] }, type: "data-agent-plan" }
           yield { data: { answers: { scope: "workspace" }, requestId: "input-1", status: "resolved" }, type: "data-agent-input" }
           yield { phase: "final", role: "assistant", text: "Finished the review.", type: "text-delta" }
           yield { type: "finish" }
@@ -5798,10 +5799,11 @@ describe("agent message protocol", () => {
       run: {
         activity: {
           links: [{ label: "Session", url: "https://console.test/invocations/run-1" }],
+          runId: "run-1",
           target: { id: "work-1" },
         },
         channelId: "work",
-        runId: "run-1",
+        runId: "provider-run-1",
       },
       runtime: "unknown",
       waitUntil,
@@ -5809,11 +5811,18 @@ describe("agent message protocol", () => {
     // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
     for await (const _event of stream as AsyncIterable<unknown>) {}
 
-    expect(updates.map(update => update.status)).toEqual(["queued", "running", "running", "waiting", "waiting", "waiting", "running", "completed"])
+    expect(updates.map(update => update.status)).toEqual(["queued", "running", "running", "waiting", "waiting", "running", "completed"])
     expect(updates[2]?.tasks).toEqual([
       { status: "in-progress", title: "Read files" },
       { status: "pending", title: "Run tests" },
     ])
+    expect(updates[4]).toMatchObject({
+      status: "waiting",
+      tasks: [
+        { status: "completed", title: "Read files" },
+        { status: "in-progress", title: "Run tests" },
+      ],
+    })
     expect(updates.at(-1)).toMatchObject({
       agentName: "reviewer",
       links: [{ label: "Session", url: "https://console.test/invocations/run-1" }],

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -11227,6 +11227,9 @@ describe("agent message protocol", () => {
 
     expect(cancelResult).toBe("cancelled")
     expect(cancelReason).toBeUndefined()
+    await vi.waitFor(() => {
+      expect(traceLog!.entries().at(-1)?.name).toBe("agent.invocation.cancelled")
+    })
     expect(traceLog!.entries().map(event => event.name)).toEqual([
       "agent.invocation.start",
       "agent.stream.start",

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5770,6 +5770,7 @@ describe("agent message protocol", () => {
     const { defineAgent, streamAgent } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     const updates: AgentActivityUpdate[] = []
+    const waitUntil = vi.fn()
     const agent = defineAgent({
       channels: {
         work: defineChannel("work", {
@@ -5803,7 +5804,7 @@ describe("agent message protocol", () => {
         runId: "run-1",
       },
       runtime: "unknown",
-      waitUntil: vi.fn(),
+      waitUntil,
     }, {})
     // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
     for await (const _event of stream as AsyncIterable<unknown>) {}
@@ -5820,6 +5821,7 @@ describe("agent message protocol", () => {
       status: "completed",
       summary: "Finished the review.",
     })
+    expect(waitUntil).toHaveBeenCalled()
   })
 
   it("projects setup failures without replacing the Agent error", async () => {
@@ -12148,10 +12150,13 @@ describe("agent message protocol", () => {
 
     it("journals Workflow provider start failures", async () => {
       const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
+      const { defineChannel } = await import("../src/channels.ts")
       const { setAgentWorkflowRuntimeLoaders } = await import("../src/internal/workflow-runtime-loaders.ts")
       const { createMemoryAgentInvocationStore, defineAgentInvocations } = await import("../src/server.ts")
       const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
       const failure = new Error("provider start failed")
+      const statuses: AgentActivityUpdate["status"][] = []
+      const waitUntil = vi.fn()
       setAgentWorkflowRuntimeLoaders({
         // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
         state: async () => ({
@@ -12169,18 +12174,27 @@ describe("agent message protocol", () => {
       })
       try {
         await expect(runAgent(defineAgent({
+          channels: {
+            work: defineChannel("work", {
+              activity: { update: ({ activity }) => { statuses.push(activity.status) } },
+              messages: false,
+            }),
+          },
           driver: { run: () => "unreachable" },
           invocations,
           runtime: workflow("start-failure-agent"),
         }), {
           memo: vi.fn(),
+          run: { activity: { target: "work-1" }, channelId: "work", runId: "workflow-run-1" },
           runtime: "unknown",
-          waitUntil: vi.fn(),
+          waitUntil,
         }, {})).rejects.toBe(failure)
 
         await expect(invocations.list()).resolves.toMatchObject({
           invocations: [{ error: { message: failure.message }, status: "failed" }],
         })
+        expect(statuses).toEqual(["queued", "failed"])
+        expect(waitUntil).toHaveBeenCalledTimes(2)
       }
       finally {
         setAgentWorkflowRuntimeLoaders({

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5834,9 +5834,14 @@ describe("agent message protocol", () => {
   })
 
   it("bounds text retained from Response streams for Channel activity", async () => {
+    const { createBoundedTextAccumulator } = await import("../src/internal/bounded-text.ts")
     const { defineAgent, runAgent } = await import("../src/index.ts")
     const { defineChannel } = await import("../src/channels.ts")
     const updates: AgentActivityUpdate[] = []
+    const retained = createBoundedTextAccumulator(12_000)
+    retained.append("a".repeat(8_000))
+    retained.append("b".repeat(8_000))
+    expect(retained.value()).toBe(`${"a".repeat(4_000)}${"b".repeat(8_000)}`)
     const agent = defineAgent({
       channels: {
         work: defineChannel("work", {

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5785,6 +5785,8 @@ describe("agent message protocol", () => {
           yield { data: { plan: [{ status: "inProgress", step: "Read files" }, { status: "pending", step: "Run tests" }] }, type: "data-agent-plan" }
           yield { id: "approval-1", name: "deploy", type: "approval-request" }
           yield { approved: false, id: "approval-1", type: "approval-decision" }
+          yield { data: { requestId: "input-1", status: "requested" }, type: "data-agent-input" }
+          yield { data: { answers: { scope: "workspace" }, requestId: "input-1", status: "resolved" }, type: "data-agent-input" }
           yield { phase: "final", role: "assistant", text: "Finished the review.", type: "text-delta" }
           yield { type: "finish" }
         })() },
@@ -5806,7 +5808,7 @@ describe("agent message protocol", () => {
     // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
     for await (const _event of stream as AsyncIterable<unknown>) {}
 
-    expect(updates.map(update => update.status)).toEqual(["queued", "running", "running", "waiting", "running", "completed"])
+    expect(updates.map(update => update.status)).toEqual(["queued", "running", "running", "waiting", "running", "waiting", "running", "completed"])
     expect(updates[2]?.tasks).toEqual([
       { status: "in-progress", title: "Read files" },
       { status: "pending", title: "Run tests" },

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -12293,6 +12293,43 @@ describe("agent message protocol", () => {
       }
     })
 
+    it("projects activity when the Workflow runtime state fails to load", async () => {
+      const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
+      const { defineChannel } = await import("../src/channels.ts")
+      const { setAgentWorkflowRuntimeLoaders } = await import("../src/internal/workflow-runtime-loaders.ts")
+      const failure = new Error("workflow runtime state failed to load")
+      const statuses: AgentActivityUpdate["status"][] = []
+      setAgentWorkflowRuntimeLoaders({
+        state: async () => { throw failure },
+        workflow: () => import("@vite-hub/workflow"),
+      })
+      try {
+        await expect(runAgent(defineAgent({
+          channels: {
+            work: defineChannel("work", {
+              activity: { update: ({ activity }) => { statuses.push(activity.status) } },
+              messages: false,
+            }),
+          },
+          driver: { run: () => "unreachable" },
+          runtime: workflow("runtime-state-failure-agent"),
+        }), {
+          memo: vi.fn(),
+          run: { activity: { target: "work-1" }, channelId: "work", runId: "workflow-run-1" },
+          runtime: "unknown",
+          waitUntil: vi.fn(),
+        }, {})).rejects.toBe(failure)
+
+        expect(statuses).toEqual(["queued", "failed"])
+      }
+      finally {
+        setAgentWorkflowRuntimeLoaders({
+          state: () => import("@vite-hub/workflow/runtime/state"),
+          workflow: () => import("@vite-hub/workflow"),
+        })
+      }
+    })
+
     it("projects failed activity when a direct Workflow has no name", async () => {
       const { defineAgent, runAgent, workflow } = await import("../src/index.ts")
       const { defineChannel } = await import("../src/channels.ts")

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -5765,6 +5765,88 @@ describe("agent message protocol", () => {
     })).toThrowError(new TypeError('[vitehub] Channel factory "broken" must return an Agent Channel definition.'))
   })
 
+  it("projects invocation status, harness plans, approvals, and final text through the active Channel", async () => {
+    const { defineAgent, streamAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const updates: Array<Record<string, unknown>> = []
+    const agent = defineAgent({
+      channels: {
+        work: defineChannel("work", {
+          activity: {
+            update: ({ activity }) => {
+              updates.push(structuredClone(activity) as unknown as Record<string, unknown>)
+            },
+          },
+          messages: false,
+        }),
+      },
+      driver: { run: () => (async function* () {
+          yield { data: { plan: [{ status: "inProgress", step: "Read files" }, { status: "pending", step: "Run tests" }] }, type: "data-agent-plan" }
+          yield { id: "approval-1", name: "deploy", type: "approval-request" }
+          yield { approved: true, id: "approval-1", type: "approval-decision" }
+          yield { phase: "final", role: "assistant", text: "Finished the review.", type: "text-delta" }
+          yield { type: "finish" }
+        })() },
+      name: "reviewer",
+    })
+    const stream = await streamAgent(agent, {
+      memo: vi.fn(),
+      run: {
+        activity: {
+          links: [{ label: "Session", url: "https://console.test/invocations/run-1" }],
+          target: { id: "work-1" },
+        },
+        channelId: "work",
+        runId: "run-1",
+      },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})
+    // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
+    for await (const _event of stream as AsyncIterable<unknown>) {}
+
+    expect(updates.map(update => update.status)).toEqual(["queued", "running", "running", "waiting", "running", "completed"])
+    expect(updates[2]?.tasks).toEqual([
+      { status: "in-progress", title: "Read files" },
+      { status: "pending", title: "Run tests" },
+    ])
+    expect(updates.at(-1)).toMatchObject({
+      agentName: "reviewer",
+      links: [{ label: "Session", url: "https://console.test/invocations/run-1" }],
+      runId: "run-1",
+      status: "completed",
+      summary: "Finished the review.",
+    })
+  })
+
+  it("projects setup failures without replacing the Agent error", async () => {
+    const { defineAgent, runAgent } = await import("../src/index.ts")
+    const { defineChannel } = await import("../src/channels.ts")
+    const failure = new Error("driver failed")
+    const statuses: string[] = []
+    const agent = defineAgent({
+      channels: {
+        work: defineChannel("work", {
+          activity: {
+            update: ({ activity }) => {
+              statuses.push(activity.status)
+            },
+          },
+          messages: false,
+        }),
+      },
+      driver: { run: () => { throw failure } },
+    })
+
+    await expect(runAgent(agent, {
+      memo: vi.fn(),
+      run: { activity: { target: "work-1" }, channelId: "work", runId: "run-1" },
+      runtime: "unknown",
+      waitUntil: vi.fn(),
+    }, {})).rejects.toBe(failure)
+    expect(statuses).toEqual(["queued", "running", "failed"])
+  })
+
   it("enables equivalent generated routes for shorthand and explicit Web Chat Channels", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { webChat } = await import("../src/channels.ts")

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -920,10 +920,10 @@ export function deriveTraceRuns(events: Iterable<TraceEventLogEntry>): TraceRunV
 
     const terminal = sorted.slice().reverse().find(isTraceRunTerminal)
     const failed = sorted.some(isTraceRunFailureEvidence)
-    const status: TraceRunStatus = terminal?.name === "agent.invocation.cancelled"
-      ? "cancelled"
-      : failed || (terminal && isTraceRunError(terminal))
+    const status: TraceRunStatus = failed || (terminal && isTraceRunError(terminal))
       ? "failed"
+      : terminal?.name === "agent.invocation.cancelled"
+        ? "cancelled"
       : terminal
         ? "completed"
       : "running"

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -145,7 +145,7 @@ export type TraceEventPayload =
   | { visibility: "private" }
 
 export type TraceEventContentPolicy = "content" | "metadata"
-export type TraceRunStatus = "completed" | "failed" | "running"
+export type TraceRunStatus = "cancelled" | "completed" | "failed" | "running"
 export type TraceStepStatus = "completed" | "failed" | "running"
 
 export interface TraceEvent {
@@ -856,7 +856,7 @@ function stepStatus(event: TraceEventLogEntry): TraceStepStatus {
 }
 
 function isTraceRunFinish(event: TraceEventLogEntry): boolean {
-  return event.name === "agent.invocation.finish" || event.name === "run.finish"
+  return event.name === "agent.invocation.cancelled" || event.name === "agent.invocation.finish" || event.name === "run.finish"
 }
 
 function isTraceRunError(event: TraceEventLogEntry): boolean {
@@ -920,7 +920,9 @@ export function deriveTraceRuns(events: Iterable<TraceEventLogEntry>): TraceRunV
 
     const terminal = sorted.slice().reverse().find(isTraceRunTerminal)
     const failed = sorted.some(isTraceRunFailureEvidence)
-    const status: TraceRunStatus = failed || (terminal && isTraceRunError(terminal))
+    const status: TraceRunStatus = terminal?.name === "agent.invocation.cancelled"
+      ? "cancelled"
+      : failed || (terminal && isTraceRunError(terminal))
       ? "failed"
       : terminal
         ? "completed"

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1401,6 +1401,17 @@ describe("@vite-hub/runtime", () => {
     ])
   })
 
+  it("keeps stream failure evidence ahead of later cancellation", async () => {
+    const log = createTraceEventLog()
+    await log.append({ name: "agent.invocation.start", timestamp: "2026-01-01T00:00:00.000Z", trace: { id: "run-1" }, type: "run" })
+    await log.append({ attributes: { "error.recoverable": false }, name: "agent.stream.error", timestamp: "2026-01-01T00:00:00.010Z", trace: { id: "run-1" }, type: "error" })
+    await log.append({ name: "agent.invocation.cancelled", timestamp: "2026-01-01T00:00:00.020Z", trace: { id: "run-1" }, type: "run" })
+
+    expect(deriveTraceRuns(log.entries())).toEqual([
+      expect.objectContaining({ status: "failed" }),
+    ])
+  })
+
   it("keeps runs successful after recoverable stream warnings", async () => {
     const log = createTraceEventLog()
     await log.append({ name: "agent.invocation.start", timestamp: "2026-01-01T00:00:00.000Z", trace: { id: "run-1" }, type: "run" })

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -1387,6 +1387,20 @@ describe("@vite-hub/runtime", () => {
     expect(traceEventsToOpenTelemetrySpans(log.entries())[0]).toMatchObject({ status: { code: "OK" } })
   })
 
+  it("derives cancelled Agent Invocations as terminal cancelled runs", async () => {
+    const log = createTraceEventLog()
+    await log.append({ name: "agent.invocation.start", timestamp: "2026-01-01T00:00:00.000Z", trace: { id: "run-1" }, type: "run" })
+    await log.append({ name: "agent.invocation.cancelled", timestamp: "2026-01-01T00:00:00.020Z", trace: { id: "run-1" }, type: "run" })
+
+    expect(deriveTraceRuns(log.entries())).toEqual([
+      expect.objectContaining({
+        durationMs: 20,
+        endTime: "2026-01-01T00:00:00.020Z",
+        status: "cancelled",
+      }),
+    ])
+  })
+
   it("keeps runs successful after recoverable stream warnings", async () => {
     const log = createTraceEventLog()
     await log.append({ name: "agent.invocation.start", timestamp: "2026-01-01T00:00:00.000Z", trace: { id: "run-1" }, type: "run" })

--- a/packages/workflow/src/runtime/openworkflow.ts
+++ b/packages/workflow/src/runtime/openworkflow.ts
@@ -15,7 +15,9 @@ type OpenWorkflowBackend = Awaited<ReturnType<OpenWorkflowPostgresModule["Backen
 type OpenWorkflowRunnable = ReturnType<OpenWorkflowClient["defineWorkflow"]>
 type OpenWorkflowRun = Awaited<ReturnType<OpenWorkflowBackend["getWorkflowRun"]>>
 type OpenWorkflowStepApi = Parameters<Parameters<OpenWorkflowClient["defineWorkflow"]>[1]>[0]["step"]
+// doctor-disable-next-line typescript/evidence/no-caller-chosen-result-type -- Dynamic imports preserve the module type supplied by each internal call site.
 type OpenWorkflowImporter = <T>(specifier: string) => Promise<T>
+// SAFETY: The generated function implements the importer signature above and returns the requested dynamic module.
 const defaultImporter = new Function("specifier", "return import(specifier)") as OpenWorkflowImporter
 let openWorkflowImporter = defaultImporter
 const defaultOpenWorkflowSqlitePath = ".vitehub/data/openworkflow.sqlite.db"
@@ -28,17 +30,21 @@ interface OpenWorkflowRuntime {
 
 let runtimes = new Map<string, Promise<OpenWorkflowRuntime>>()
 
+// doctor-disable-next-line typescript/evidence/no-caller-chosen-result-type -- The internal importer contract carries each requested module type.
 async function importOpenWorkflowModule<T>(specifier: string, importer: OpenWorkflowImporter): Promise<T> {
   return await runWorkflowProviderOperation("openworkflow", "import", () => importer<T>(specifier))
 }
 
 function readEnv(name: string): string | undefined {
+  // SAFETY: This provider runs in hosts where Node's process global is optional.
   const env = (globalThis as { process?: { env?: Record<string, string | undefined> } }).process?.env
   const value = env?.[name]
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Environment values cross an optional host boundary and require representation validation.
   return typeof value === "string" && value.trim() ? value.trim() : undefined
 }
 
 function resolveRuntimeConfigValue(value: WorkflowRuntimeConfigValue | undefined): string | undefined {
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Runtime configuration accepts a string or an environment declaration at this boundary.
   if (typeof value === "string" || typeof value === "undefined") {
     return value
   }
@@ -46,6 +52,7 @@ function resolveRuntimeConfigValue(value: WorkflowRuntimeConfigValue | undefined
     const resolved = readEnv(name)
     if (resolved) return resolved
   }
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Declaration defaults cross the runtime configuration boundary as unknown values.
   return typeof value.default === "string" && value.default.trim() ? value.default.trim() : undefined
 }
 
@@ -132,14 +139,18 @@ async function createOpenWorkflowRuntime(
   const { backend, client } = await runWorkflowProviderOperation("openworkflow", "connect", async () => {
     let backend: OpenWorkflowBackend
     if (options.backend === "sqlite") {
+      // SAFETY: The discriminated storage options select the matching dynamically imported backend module.
       backend = await (backendModule as OpenWorkflowSqliteModule).BackendSqlite.connect(await prepareSqlitePath(options.path, importer), {
         namespaceId: options.namespaceId,
+        // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Provider configuration accepts an optional external boolean.
         ...(typeof options.runMigrations === "boolean" ? { runMigrations: options.runMigrations } : {}),
       })
     }
     else {
+      // SAFETY: The discriminated storage options select the matching dynamically imported backend module.
       backend = await (backendModule as OpenWorkflowPostgresModule).BackendPostgres.connect(options.url, {
         namespaceId: options.namespaceId,
+        // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Provider configuration accepts an optional external boolean.
         ...(typeof options.runMigrations === "boolean" ? { runMigrations: options.runMigrations } : {}),
         schema: options.schema,
       })
@@ -183,7 +194,9 @@ function toOpenWorkflowRetryPolicy(options: WorkflowStepOptions): Partial<RetryP
 
   return {
     ...(retries.backoff ? { backoffCoefficient: retries.backoff === "exponential" ? 2 : 1 } : {}),
+    // SAFETY: ViteHub's duration input matches OpenWorkflow's accepted interval representation.
     ...(retries.delay ? { initialInterval: retries.delay as RetryPolicy["initialInterval"] } : {}),
+    // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Retry limits enter through public Workflow step options and require numeric validation.
     ...(typeof retries.limit === "number" ? { maximumAttempts: retries.limit } : {}),
   }
 }
@@ -196,6 +209,7 @@ function createOpenWorkflowProviderStep(step: OpenWorkflowStepApi): WorkflowProv
         ...(toOpenWorkflowRetryPolicy(options) ? { retryPolicy: toOpenWorkflowRetryPolicy(options) } : {}),
       }, run)
     },
+    // SAFETY: ViteHub's duration input matches OpenWorkflow's accepted sleep duration representation.
     sleep: async (name, duration) => await step.sleep(name, duration as Parameters<OpenWorkflowStepApi["sleep"]>[1]),
   }
 }
@@ -210,6 +224,8 @@ export async function registerOpenWorkflowDefinition(
     return existing
   }
 
+  // SAFETY: The registered ViteHub definition and OpenWorkflow runnable share this payload and result contract.
+  const openWorkflowDefinition = definition as never
   const workflow = runtime.client.defineWorkflow({ name }, async ({ input, run, step }) => {
     return await runWorkflowHandler({
       id: run.id,
@@ -217,7 +233,7 @@ export async function registerOpenWorkflowDefinition(
       payload: input,
       provider: "openworkflow",
       step: createOpenWorkflowProviderStep(step),
-    }, definition as never)
+    }, openWorkflowDefinition)
   })
   runtime.workflows.set(name, workflow)
   return workflow
@@ -241,7 +257,8 @@ function normalizeOpenWorkflowStatus(status: unknown): WorkflowRunStatus {
   }
 }
 
-function serializeOpenWorkflowRun(run: OpenWorkflowRun, name: string): WorkflowRun {
+// doctor-disable-next-line typescript/evidence/no-caller-chosen-result-type -- The registered Workflow Definition determines the provider result type.
+function serializeOpenWorkflowRun<TResult = unknown>(run: OpenWorkflowRun, name: string): WorkflowRun<unknown, TResult> {
   if (!run || run.workflowName !== name) {
     return {
       id: run?.id || "",
@@ -250,6 +267,8 @@ function serializeOpenWorkflowRun(run: OpenWorkflowRun, name: string): WorkflowR
     }
   }
 
+  // SAFETY: OpenWorkflow returns the result produced by the registered WorkflowDefinition<TResult>.
+  const result = run.output as TResult | undefined
   return {
     id: run.id,
     metadata: run.error || {
@@ -258,7 +277,7 @@ function serializeOpenWorkflowRun(run: OpenWorkflowRun, name: string): WorkflowR
       workflowName: run.workflowName,
     },
     provider: "openworkflow",
-    result: run.output ?? undefined,
+    result,
     status: normalizeOpenWorkflowStatus(run.status),
   }
 }
@@ -271,6 +290,7 @@ export async function runOpenWorkflow<TPayload = unknown, TResult = unknown>(
   options: WorkflowDeferOptions,
 ): Promise<WorkflowRun<TPayload, TResult>> {
   const runtime = await getOpenWorkflowRuntime(config)
+  // SAFETY: Registration preserves this Workflow Definition's payload and result contract in the provider runnable.
   const workflow = await registerOpenWorkflowDefinition(runtime, name, definition as never)
   let firstAcknowledgementUnknown = false
   const handle = await runWorkflowProviderOperation("openworkflow", "run", async () => {
@@ -282,7 +302,7 @@ export async function runOpenWorkflow<TPayload = unknown, TResult = unknown>(
     })
   }, { acknowledgementUnknown: (_error, status) => firstAcknowledgementUnknown || status === undefined })
   return await runWorkflowProviderOperation("openworkflow", "run", async () => {
-    const serialized = serializeOpenWorkflowRun(handle.workflowRun, name)
+    const serialized = serializeOpenWorkflowRun<TResult>(handle.workflowRun, name)
     return {
       ...serialized,
       metadata: serialized.status === "failed"
@@ -293,6 +313,7 @@ export async function runOpenWorkflow<TPayload = unknown, TResult = unknown>(
   })
 }
 
+// doctor-disable-next-line typescript/evidence/no-caller-chosen-result-type -- Workflow handles intentionally retain their definition's payload and result types across provider reads.
 export async function getOpenWorkflowRun<TPayload = unknown, TResult = unknown>(
   config: ResolvedWorkflowOptions,
   name: string,
@@ -303,6 +324,7 @@ export async function getOpenWorkflowRun<TPayload = unknown, TResult = unknown>(
     const run = await runtime.backend.getWorkflowRun({ workflowRunId: id })
     const serialized = serializeOpenWorkflowRun(run, name)
     return serialized.id
+      // SAFETY: The caller's Workflow Definition supplies the payload and result types retained by this provider run.
       ? serialized as WorkflowRun<TPayload, TResult>
       : {
           id,

--- a/packages/workflow/src/runtime/openworkflow.ts
+++ b/packages/workflow/src/runtime/openworkflow.ts
@@ -259,8 +259,8 @@ function normalizeOpenWorkflowStatus(status: unknown): WorkflowRunStatus {
 }
 
 // doctor-disable-next-line typescript/evidence/no-caller-chosen-result-type -- The registered Workflow Definition determines the provider result type.
-function serializeOpenWorkflowRun<TResult = unknown>(run: OpenWorkflowRun, name: string): WorkflowRun<unknown, TResult> {
-  if (!run || run.workflowName !== name) {
+function serializeOpenWorkflowRun<TResult = unknown>(run: OpenWorkflowRun, name: string, acceptMissingName = false): WorkflowRun<unknown, TResult> {
+  if (!run || (run.workflowName ? run.workflowName !== name : !acceptMissingName)) {
     return {
       id: run?.id || "",
       provider: "openworkflow",
@@ -303,7 +303,7 @@ export async function runOpenWorkflow<TPayload = unknown, TResult = unknown>(
     })
   }, { acknowledgementUnknown: (_error, status) => firstAcknowledgementUnknown || status === undefined })
   return await runWorkflowProviderOperation("openworkflow", "run", async () => {
-    const serialized = serializeOpenWorkflowRun<TResult>(handle.workflowRun, name)
+    const serialized = serializeOpenWorkflowRun<TResult>(handle.workflowRun, name, true)
     return {
       ...serialized,
       metadata: serialized.status === "failed"

--- a/packages/workflow/src/runtime/openworkflow.ts
+++ b/packages/workflow/src/runtime/openworkflow.ts
@@ -282,15 +282,13 @@ export async function runOpenWorkflow<TPayload = unknown, TResult = unknown>(
     })
   }, { acknowledgementUnknown: (_error, status) => firstAcknowledgementUnknown || status === undefined })
   return await runWorkflowProviderOperation("openworkflow", "run", async () => {
+    const serialized = serializeOpenWorkflowRun(handle.workflowRun, name)
     return {
-      id: handle.workflowRun.id,
-      metadata: {
-        ...(options.id ? { idempotencyKey: options.id } : {}),
-        workflow: name,
-      },
+      ...serialized,
+      metadata: serialized.status === "failed"
+        ? serialized.metadata
+        : { ...(options.id ? { idempotencyKey: options.id } : {}), workflow: name },
       payload,
-      provider: "openworkflow" as const,
-      status: normalizeOpenWorkflowStatus(handle.workflowRun.status),
     }
   })
 }

--- a/packages/workflow/src/runtime/openworkflow.ts
+++ b/packages/workflow/src/runtime/openworkflow.ts
@@ -259,8 +259,8 @@ function normalizeOpenWorkflowStatus(status: unknown): WorkflowRunStatus {
 }
 
 // doctor-disable-next-line typescript/evidence/no-caller-chosen-result-type -- The registered Workflow Definition determines the provider result type.
-function serializeOpenWorkflowRun<TResult = unknown>(run: OpenWorkflowRun, name: string, acceptMissingName = false): WorkflowRun<unknown, TResult> {
-  if (!run || (run.workflowName ? run.workflowName !== name : !acceptMissingName)) {
+function serializeOpenWorkflowRun<TResult = unknown>(run: OpenWorkflowRun, name: string): WorkflowRun<unknown, TResult> {
+  if (!run || run.workflowName !== name) {
     return {
       id: run?.id || "",
       provider: "openworkflow",
@@ -303,7 +303,7 @@ export async function runOpenWorkflow<TPayload = unknown, TResult = unknown>(
     })
   }, { acknowledgementUnknown: (_error, status) => firstAcknowledgementUnknown || status === undefined })
   return await runWorkflowProviderOperation("openworkflow", "run", async () => {
-    const serialized = serializeOpenWorkflowRun<TResult>(handle.workflowRun, name, true)
+    const serialized = serializeOpenWorkflowRun<TResult>(handle.workflowRun, name)
     return {
       ...serialized,
       metadata: serialized.status === "failed"

--- a/packages/workflow/src/runtime/openworkflow.ts
+++ b/packages/workflow/src/runtime/openworkflow.ts
@@ -245,6 +245,7 @@ function normalizeOpenWorkflowStatus(status: unknown): WorkflowRunStatus {
     case "succeeded":
       return "completed"
     case "canceled":
+      return "cancelled"
     case "failed":
       return "failed"
     case "pending":

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -1296,7 +1296,8 @@ describe("workflow runtime", () => {
   it.each([
     { error: null, output: { text: "Already finished." }, status: "completed" as const },
     { error: new Error("Already failed."), output: null, status: "failed" as const },
-  ])("preserves details from an already-$status OpenWorkflow run", async ({ error, output, status }) => {
+    { error: null, output: null, providerStatus: "canceled", status: "cancelled" as const },
+  ])("preserves details from an already-$status OpenWorkflow run", async ({ error, output, providerStatus, status }) => {
     class SettledOpenWorkflow {
       defineWorkflow() {
         return {
@@ -1306,7 +1307,7 @@ describe("workflow runtime", () => {
               id: "existing-run",
               namespaceId: "production",
               output,
-              status,
+              status: providerStatus || status,
               version: null,
               workflowName: "welcome",
             },

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -1262,7 +1262,15 @@ describe("workflow runtime", () => {
   it("recovers OpenWorkflow runs after a lost creation acknowledgement", async () => {
     const run = vi.fn()
       .mockRejectedValueOnce(new Error("creation acknowledgement lost"))
-      .mockResolvedValueOnce({ workflowRun: { id: "accepted-run", status: "pending" } })
+      .mockResolvedValueOnce({ workflowRun: {
+        error: null,
+        id: "accepted-run",
+        namespaceId: "default",
+        output: null,
+        status: "pending",
+        version: null,
+        workflowName: "welcome",
+      } })
     class RecoveringOpenWorkflow {
       defineWorkflow() {
         return { run }

--- a/packages/workflow/test/runtime.test.ts
+++ b/packages/workflow/test/runtime.test.ts
@@ -1293,6 +1293,52 @@ describe("workflow runtime", () => {
     expect(run).toHaveBeenNthCalledWith(2, {}, { idempotencyKey: "source-run" })
   })
 
+  it.each([
+    { error: null, output: { text: "Already finished." }, status: "completed" as const },
+    { error: new Error("Already failed."), output: null, status: "failed" as const },
+  ])("preserves details from an already-$status OpenWorkflow run", async ({ error, output, status }) => {
+    class SettledOpenWorkflow {
+      defineWorkflow() {
+        return {
+          run: async () => ({
+            workflowRun: {
+              error,
+              id: "existing-run",
+              namespaceId: "production",
+              output,
+              status,
+              version: null,
+              workflowName: "welcome",
+            },
+          }),
+        }
+      }
+    }
+    setOpenWorkflowImporter(async (specifier) => {
+      // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
+      if (specifier === "openworkflow") return { OpenWorkflow: SettledOpenWorkflow } as never
+      if (specifier === "openworkflow/sqlite") {
+        // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
+        return { BackendSqlite: { connect: openWorkflowMock.sqliteConnect } } as never
+      }
+      // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
+      return await import(specifier) as never
+    })
+    setWorkflowRuntimeConfig({ provider: "openworkflow", sqlite: { path: ":memory:" } })
+    setWorkflowRuntimeRegistry({
+      welcome: async () => ({ default: { handler: async () => ({ ok: true }) } }),
+    })
+
+    const run = await runWorkflow("welcome", {}, { id: "existing-run" })
+
+    expect(run).toMatchObject({
+      ...(error ? { metadata: error } : { result: output }),
+      id: "existing-run",
+      provider: "openworkflow",
+      status,
+    })
+  })
+
   it("narrows malformed OpenWorkflow run results at the public boundary", async () => {
     const cause = new Error("provider-secret:run-result")
     class MalformedOpenWorkflow {


### PR DESCRIPTION
Moves invocation lifecycle reporting into a generic Agent Channel activity contract, so consumers select a Channel and target without owning provider-specific status code. The runtime projects queued, running, waiting, and terminal states while normalizing harness plans and final output.

The GitHub Channel reuses authenticated app- or bot-owned activity comments, reconciles owned duplicates when possible, and prevents stale runs from regressing current or terminal state. Agent Invocations also expose their stable ID from a run ID and Agent Definition name, so activity links can deep-link into Console without copying the invocation identity algorithm. Ordering is process-scoped: concurrent hosts can temporarily create duplicate comments or coalesce intermediate updates.

## Test plan

- `pnpm --filter @vite-hub/agent build`
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm --filter @vite-hub/agent exec vp test test/channels.test.ts test/runtime.test.ts test/eve-extension.test.ts` (516 tests)
- `pnpm --filter @vite-hub/agent exec vp test test/invocations.test.ts` (107 tests)
- `pnpm --dir docs test -- test/examples.test.ts`
- Verified the preview consumer in ViteHub Babysitter with `pnpm typecheck` and `pnpm build`; its local test suite is intentionally removed in the consumer PR.
