### PR TITLE
feat(runtime): add process reconciler and drain command

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -16,7 +16,7 @@ ViteHub packages and custom host integrations.
 | --------------------------------------------- | ------------------------- | --------------------------------------------------- |
 | A ViteHub application                         | `vite-hub`                | `vite-hub/runtime`                                  |
 | A reusable package or custom host integration | `@vite-hub/runtime`       | `@vite-hub/runtime`                                 |
-| Node resource diagnostics in either case      | The same selected package | `vite-hub/runtime/node` or `@vite-hub/runtime/node` |
+| Node diagnostics and process lifecycle        | The same selected package | `vite-hub/runtime/node` or `@vite-hub/runtime/node` |
 
 Use the `vite-hub` facade when it is already your application dependency. Install
 this owner package directly when the integration should depend only on Runtime's
@@ -32,6 +32,11 @@ pnpm add @vite-hub/runtime
 The package declares Node.js 24 or newer. Import the root entry for portable
 Runtime contracts. When inspected, the `/node` entry reads Node process
 information and, on Linux, `/proc` and cgroup v2 files.
+
+Long-lived Node services can also use `createProcessReconciler()` from the `/node`
+entry to coalesce event-driven work, run periodic repair, stop admission, and await
+tracked work during a graceful drain. Set `signal: "SIGUSR2"` when the service
+manager should trigger that drain through the included `vitehub-drain` command.
 
 ## Get a first result
 
@@ -138,7 +143,7 @@ that inspect the Error instance.
 | Import                   | Provides                                                                                             |
 | ------------------------ | ---------------------------------------------------------------------------------------------------- |
 | `@vite-hub/runtime`      | Context, capability, policy, approval, trace, lease, diagnostic, error, and execution-authority APIs |
-| `@vite-hub/runtime/node` | Node process observations plus Linux host and cgroup v2 observations when supported                  |
+| `@vite-hub/runtime/node` | Node process observations, reconciliation, and graceful-drain lifecycle primitives                  |
 
 Do not import from `src`, `dist`, or ViteHub's `_internal` paths.
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -39,7 +39,9 @@ tracked work during a graceful drain. Set `signal: "SIGUSR2"` when the service
 manager should trigger that drain through the `vitehub-drain` command included
 with the owner-package installation, `@vite-hub/runtime`. Lifecycle callbacks
 must return before an external caller starts `drain()`; calling `drain()` from an
-active callback rejects to prevent that callback from waiting on itself.
+active callback rejects to prevent that callback from waiting on itself. Keep the
+status endpoint available until `vitehub-drain` observes the terminal `drained`
+status; process exit or endpoint loss before that acknowledgement is a failed drain.
 
 ## Get a first result
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -37,7 +37,9 @@ Long-lived Node services can also use `createProcessReconciler()` from the `/nod
 entry to coalesce event-driven work, run periodic repair, stop admission, and await
 tracked work during a graceful drain. Set `signal: "SIGUSR2"` when the service
 manager should trigger that drain through the `vitehub-drain` command included
-with the owner-package installation, `@vite-hub/runtime`.
+with the owner-package installation, `@vite-hub/runtime`. Lifecycle callbacks
+must return before an external caller starts `drain()`; calling `drain()` from an
+active callback rejects to prevent that callback from waiting on itself.
 
 ## Get a first result
 

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -36,7 +36,8 @@ information and, on Linux, `/proc` and cgroup v2 files.
 Long-lived Node services can also use `createProcessReconciler()` from the `/node`
 entry to coalesce event-driven work, run periodic repair, stop admission, and await
 tracked work during a graceful drain. Set `signal: "SIGUSR2"` when the service
-manager should trigger that drain through the included `vitehub-drain` command.
+manager should trigger that drain through the `vitehub-drain` command included
+with the owner-package installation, `@vite-hub/runtime`.
 
 ## Get a first result
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -23,7 +23,12 @@
     "package.json"
   ],
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "./dist/drain.js"
+  ],
+  "bin": {
+    "vitehub-drain": "./dist/drain.js"
+  },
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",

--- a/packages/runtime/src/drain.ts
+++ b/packages/runtime/src/drain.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 
 import { hasRuntimeType } from "./internal/runtime-type.ts"
-import { processExitCompletedDrain } from "./internal/drain.ts"
 
 const pidInput: string | undefined = process.argv[2]
 const statusUrl: string = process.argv[3] || "http://127.0.0.1:3000/api/drain"
@@ -50,7 +49,6 @@ try {
     }
     await new Promise(resolve => setTimeout(resolve, 1_000))
   }
-  if (processExitCompletedDrain(signaled)) process.exit(0)
   throw new Error(`Process ${pid} exited before drain completed.`)
 }
 catch (error) {

--- a/packages/runtime/src/drain.ts
+++ b/packages/runtime/src/drain.ts
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+const pidInput: string | undefined = process.argv[2]
+const statusUrl: string = process.argv[3] || "http://127.0.0.1:3000/api/drain"
+const pid: number = Number(pidInput)
+
+if (!Number.isSafeInteger(pid) || pid <= 0) {
+  console.error("usage: vitehub-drain MAINPID [STATUS_URL]")
+  process.exit(2)
+}
+
+function running(): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  }
+  catch {
+    return false
+  }
+}
+
+async function readStatus(): Promise<"accepting" | "drained" | "draining" | "failed" | "invalid" | "unavailable"> {
+  try {
+    const response = await fetch(statusUrl, { signal: AbortSignal.timeout(5_000) })
+    if (!response.ok) return "unavailable"
+    const body: unknown = await response.json()
+    const status = typeof body === "object" && body !== null && "status" in body ? body.status : undefined
+    return status === "accepting" || status === "drained" || status === "draining" || status === "failed"
+      ? status
+      : "invalid"
+  }
+  catch {
+    return "unavailable"
+  }
+}
+
+try {
+  let signaled = false
+  while (running()) {
+    const status = await readStatus()
+    if (status === "failed" || status === "invalid") throw new Error(`Process drain reported ${status}.`)
+    if (status === "drained") process.exit(0)
+    if (status === "accepting" && !signaled) {
+      process.kill(pid, "SIGUSR2")
+      signaled = true
+    }
+    await new Promise(resolve => setTimeout(resolve, 1_000))
+  }
+  throw new Error(`Process ${pid} exited before drain completed.`)
+}
+catch (error) {
+  console.error(error instanceof Error ? error.message : error)
+  process.exit(1)
+}

--- a/packages/runtime/src/drain.ts
+++ b/packages/runtime/src/drain.ts
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { hasRuntimeType } from "./internal/runtime-type.ts"
+
 const pidInput: string | undefined = process.argv[2]
 const statusUrl: string = process.argv[3] || "http://127.0.0.1:3000/api/drain"
 const pid: number = Number(pidInput)
@@ -24,7 +26,8 @@ async function readStatus(): Promise<"accepting" | "drained" | "draining" | "fai
     const response = await fetch(statusUrl, { signal: AbortSignal.timeout(5_000) })
     if (!response.ok) return "unavailable"
     const body: unknown = await response.json()
-    const status = typeof body === "object" && body !== null && "status" in body ? body.status : undefined
+    // SAFETY: The status endpoint response is validated before its value is used.
+    const status = body && hasRuntimeType(body, "object") ? (body as { status?: unknown }).status : undefined
     return status === "accepting" || status === "drained" || status === "draining" || status === "failed"
       ? status
       : "invalid"

--- a/packages/runtime/src/drain.ts
+++ b/packages/runtime/src/drain.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { hasRuntimeType } from "./internal/runtime-type.ts"
+import { processExitCompletedDrain } from "./internal/drain.ts"
 
 const pidInput: string | undefined = process.argv[2]
 const statusUrl: string = process.argv[3] || "http://127.0.0.1:3000/api/drain"
@@ -49,6 +50,7 @@ try {
     }
     await new Promise(resolve => setTimeout(resolve, 1_000))
   }
+  if (processExitCompletedDrain(signaled)) process.exit(0)
   throw new Error(`Process ${pid} exited before drain completed.`)
 }
 catch (error) {

--- a/packages/runtime/src/internal/drain.ts
+++ b/packages/runtime/src/internal/drain.ts
@@ -1,0 +1,3 @@
+export function processExitCompletedDrain(signaled: boolean): boolean {
+  return signaled
+}

--- a/packages/runtime/src/internal/drain.ts
+++ b/packages/runtime/src/internal/drain.ts
@@ -1,3 +1,0 @@
-export function processExitCompletedDrain(signaled: boolean): boolean {
-  return signaled
-}

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -293,7 +293,7 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
       rejectActive = reject
     })
     running = active
-    void (async () => {
+    const runAdmitted = async (): Promise<void> => {
       let failure: unknown
       let hasFailure = false
       do {
@@ -318,14 +318,25 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
         }
       } while (rerun)
       if (hasFailure) throw failure
-    })().then(resolveActive, rejectActive)
-    try {
-      await active
     }
-    finally {
-      if (running === active) running = undefined
+    const complete = (failure?: unknown, hasFailure = false): void => {
+      if (rerun) {
+        void runAdmitted().then(
+          () => complete(failure, hasFailure),
+          error => complete(hasFailure ? failure : error, true),
+        )
+        return
+      }
+      running = undefined
       scheduleRepair()
+      if (hasFailure) rejectActive(failure)
+      else resolveActive()
     }
+    void runAdmitted().then(
+      () => complete(),
+      error => complete(error, true),
+    )
+    await active
   }
 
   const wake = (nextReason: string) => {

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -224,7 +224,7 @@ export interface ProcessReconciler extends ProcessReconcilerRunContext {
 }
 
 export function createProcessReconciler(options: ProcessReconcilerOptions): ProcessReconciler {
-  if (!Number.isFinite(options.intervalMs) || options.intervalMs <= 0 || options.intervalMs > 2_147_483_647) {
+  if (!Number.isFinite(options.intervalMs) || options.intervalMs < 1 || options.intervalMs > 2_147_483_647) {
     throw new TypeError("Process reconciler intervalMs must be between 1 and 2,147,483,647 milliseconds.")
   }
 
@@ -263,12 +263,18 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
 
   const execute = async (): Promise<void> => {
     queued = false
-    if (closed) return
     if (running) {
       rerun = true
       return await running
     }
-    running = (async () => {
+    let resolveActive!: () => void
+    let rejectActive!: (error: unknown) => void
+    const active = new Promise<void>((resolve, reject) => {
+      resolveActive = resolve
+      rejectActive = reject
+    })
+    running = active
+    void (async () => {
       do {
         rerun = false
         const currentReason = reason
@@ -279,12 +285,15 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
         catch (error) {
           await options.onError?.(error, currentReason)
         }
-      } while (!closed && rerun)
-    })().finally(() => {
-      running = undefined
+      } while (rerun)
+    })().then(resolveActive, rejectActive)
+    try {
+      await active
+    }
+    finally {
+      if (running === active) running = undefined
       scheduleRepair()
-    })
-    return await running
+    }
   }
 
   const wake = (nextReason: string) => {
@@ -327,6 +336,7 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
 
       status = "draining"
       closed = true
+      if (queued && !running) await Promise.resolve()
       const admittedRun = running
       if (timer) clearTimeout(timer)
       timer = undefined

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -199,3 +199,147 @@ export function nodeRuntimeResources(options: NodeRuntimeResourceInspectorOption
     },
   }
 }
+
+export type ProcessReconcilerStatus = "accepting" | "drained" | "draining" | "failed"
+
+export interface ProcessReconcilerRunContext {
+  track<T>(work: Promise<T>): Promise<T>
+}
+
+export interface ProcessReconcilerOptions {
+  intervalMs: number
+  onDrained?: () => Promise<void> | void
+  onError?: (error: unknown, reason: string) => Promise<void> | void
+  onQuiesce?: () => Promise<void> | void
+  repairReason?: string
+  run: (reason: string, context: ProcessReconcilerRunContext) => Promise<void> | void
+  signal?: false | NodeJS.Signals
+}
+
+export interface ProcessReconciler extends ProcessReconcilerRunContext {
+  close: () => Promise<void>
+  drain: () => Promise<void>
+  status: () => ProcessReconcilerStatus
+  wake: (reason: string) => void
+}
+
+export function createProcessReconciler(options: ProcessReconcilerOptions): ProcessReconciler {
+  if (!Number.isFinite(options.intervalMs) || options.intervalMs <= 0) {
+    throw new TypeError("Process reconciler intervalMs must be positive.")
+  }
+
+  let closed = false
+  let drainPromise: Promise<void> | undefined
+  let queued = false
+  let reason = "coalesced"
+  let rerun = false
+  let running: Promise<void> | undefined
+  let status: ProcessReconcilerStatus = "accepting"
+  let timer: NodeJS.Timeout | undefined
+  const tracked = new Set<Promise<unknown>>()
+
+  const track: ProcessReconcilerRunContext["track"] = (work) => {
+    const promise = Promise.resolve(work)
+    tracked.add(promise)
+    void promise.finally(() => tracked.delete(promise)).catch(() => {})
+    return promise
+  }
+
+  const scheduleRepair = () => {
+    if (closed || timer) return
+    timer = setTimeout(() => {
+      timer = undefined
+      wake(options.repairReason || "repair")
+    }, options.intervalMs)
+    timer.unref?.()
+  }
+
+  const execute = async (): Promise<void> => {
+    queued = false
+    if (closed) return
+    if (running) {
+      rerun = true
+      return await running
+    }
+    running = (async () => {
+      do {
+        rerun = false
+        const currentReason = reason
+        reason = "coalesced"
+        try {
+          await options.run(currentReason, { track })
+        }
+        catch (error) {
+          await options.onError?.(error, currentReason)
+        }
+      } while (!closed && rerun)
+    })().finally(() => {
+      running = undefined
+      scheduleRepair()
+    })
+    return await running
+  }
+
+  const wake = (nextReason: string) => {
+    if (closed) return
+    reason = nextReason
+    if (timer) clearTimeout(timer)
+    timer = undefined
+    if (running) {
+      rerun = true
+      return
+    }
+    if (queued) return
+    queued = true
+    queueMicrotask(() => void execute().catch(() => {}))
+  }
+
+  const drain = (): Promise<void> => {
+    if (drainPromise) return drainPromise
+    drainPromise = (async () => {
+      status = "draining"
+      closed = true
+      const acceptedWork = [...tracked]
+      if (timer) clearTimeout(timer)
+      timer = undefined
+      await options.onQuiesce?.()
+      await running
+      await Promise.all(new Set([...acceptedWork, ...tracked]))
+      while (tracked.size) await Promise.all(tracked)
+      status = "drained"
+      await options.onDrained?.()
+    })().catch((error) => {
+      status = "failed"
+      throw error
+    })
+    return drainPromise
+  }
+
+  const signal = options.signal === false ? undefined : options.signal
+  const listener = signal
+    ? () => {
+        void drain().catch(async (error) => {
+          try {
+            await options.onError?.(error, "drain")
+          }
+          catch {}
+        })
+      }
+    : undefined
+  if (signal && listener) process.on(signal, listener)
+
+  return {
+    async close() {
+      try {
+        await drain()
+      }
+      finally {
+        if (signal && listener) process.off(signal, listener)
+      }
+    },
+    drain,
+    status: () => status,
+    track,
+    wake,
+  }
+}

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -202,6 +202,7 @@ export function nodeRuntimeResources(options: NodeRuntimeResourceInspectorOption
 }
 
 export type ProcessReconcilerStatus = "accepting" | "drained" | "draining" | "failed"
+export type ProcessReconcilerSignal = Exclude<NodeJS.Signals, "SIGKILL" | "SIGSTOP">
 
 export interface ProcessReconcilerRunContext {
   track<T>(work: Promise<T>): Promise<T>
@@ -214,7 +215,7 @@ export interface ProcessReconcilerOptions {
   onQuiesce?: () => Promise<void> | void
   repairReason?: string
   run: (reason: string, context: ProcessReconcilerRunContext) => Promise<void> | void
-  signal?: false | NodeJS.Signals
+  signal?: false | ProcessReconcilerSignal
 }
 
 export interface ProcessReconciler extends ProcessReconcilerRunContext {
@@ -227,6 +228,10 @@ export interface ProcessReconciler extends ProcessReconcilerRunContext {
 export function createProcessReconciler(options: ProcessReconcilerOptions): ProcessReconciler {
   if (!Number.isFinite(options.intervalMs) || options.intervalMs < 1 || options.intervalMs > 2_147_483_647) {
     throw new TypeError("Process reconciler intervalMs must be between 1 and 2,147,483,647 milliseconds.")
+  }
+  const configuredSignal: string | false | undefined = options.signal
+  if (configuredSignal === "SIGKILL" || configuredSignal === "SIGSTOP") {
+    throw new TypeError(`Process reconciler signal ${configuredSignal} cannot be handled.`)
   }
 
   let closed = false
@@ -289,6 +294,8 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
     })
     running = active
     void (async () => {
+      let failure: unknown
+      let hasFailure = false
       do {
         rerun = false
         const currentReason = reason
@@ -297,9 +304,20 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
           await invokeCallback(() => options.run(currentReason, { track }))
         }
         catch (error) {
-          if (options.onError) await invokeCallback(() => options.onError!(error, currentReason))
+          if (options.onError) {
+            try {
+              await invokeCallback(() => options.onError!(error, currentReason))
+            }
+            catch (reportingError) {
+              if (!hasFailure) {
+                failure = reportingError
+                hasFailure = true
+              }
+            }
+          }
         }
       } while (rerun)
+      if (hasFailure) throw failure
     })().then(resolveActive, rejectActive)
     try {
       await active

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -224,8 +224,8 @@ export interface ProcessReconciler extends ProcessReconcilerRunContext {
 }
 
 export function createProcessReconciler(options: ProcessReconcilerOptions): ProcessReconciler {
-  if (!Number.isFinite(options.intervalMs) || options.intervalMs <= 0) {
-    throw new TypeError("Process reconciler intervalMs must be positive.")
+  if (!Number.isFinite(options.intervalMs) || options.intervalMs <= 0 || options.intervalMs > 2_147_483_647) {
+    throw new TypeError("Process reconciler intervalMs must be between 1 and 2,147,483,647 milliseconds.")
   }
 
   let closed = false
@@ -304,10 +304,21 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
       timer = undefined
       await options.onQuiesce?.()
       await running
-      await Promise.all(new Set([...acceptedWork, ...tracked]))
-      while (tracked.size) await Promise.all(tracked)
-      status = "drained"
+      let failure: unknown
+      let hasFailure = false
+      let pending = new Set([...acceptedWork, ...tracked])
+      while (pending.size) {
+        const results = await Promise.allSettled(pending)
+        const rejected = results.find(result => result.status === "rejected")
+        if (!hasFailure && rejected) {
+          failure = rejected.reason
+          hasFailure = true
+        }
+        pending = new Set(tracked)
+      }
+      if (hasFailure) throw failure
       await options.onDrained?.()
+      status = "drained"
     })().catch((error) => {
       status = "failed"
       throw error
@@ -327,6 +338,7 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
       }
     : undefined
   if (signal && listener) process.on(signal, listener)
+  scheduleRepair()
 
   return {
     async close() {

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -236,12 +236,18 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
   let running: Promise<void> | undefined
   let status: ProcessReconcilerStatus = "accepting"
   let timer: NodeJS.Timeout | undefined
-  const tracked = new Set<Promise<unknown>>()
+  const settlements = new Map<Promise<unknown>, Promise<PromiseSettledResult<unknown>>>()
 
   const track: ProcessReconcilerRunContext["track"] = (work) => {
     const promise = Promise.resolve(work)
-    tracked.add(promise)
-    void promise.finally(() => tracked.delete(promise)).catch(() => {})
+    const settlement = promise.then(
+      (value): PromiseSettledResult<unknown> => ({ status: "fulfilled", value }),
+      (reason): PromiseSettledResult<unknown> => ({ reason, status: "rejected" }),
+    )
+    settlements.set(promise, settlement)
+    void settlement.then(() => {
+      if (status === "accepting") settlements.delete(promise)
+    })
     return promise
   }
 
@@ -297,27 +303,31 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
   const drain = (): Promise<void> => {
     if (drainPromise) return drainPromise
     drainPromise = (async () => {
+      const settleTrackedWork = async (): Promise<void> => {
+        let failure: unknown
+        let hasFailure = false
+        while (settlements.size) {
+          const batch = [...settlements.entries()]
+          const results = await Promise.all(batch.map(([, settlement]) => settlement))
+          for (const [promise] of batch) settlements.delete(promise)
+          const rejected = results.find(result => result.status === "rejected")
+          if (!hasFailure && rejected) {
+            failure = rejected.reason
+            hasFailure = true
+          }
+        }
+        if (hasFailure) throw failure
+      }
+
       status = "draining"
       closed = true
-      const acceptedWork = [...tracked]
       if (timer) clearTimeout(timer)
       timer = undefined
       await options.onQuiesce?.()
       await running
-      let failure: unknown
-      let hasFailure = false
-      let pending = new Set([...acceptedWork, ...tracked])
-      while (pending.size) {
-        const results = await Promise.allSettled(pending)
-        const rejected = results.find(result => result.status === "rejected")
-        if (!hasFailure && rejected) {
-          failure = rejected.reason
-          hasFailure = true
-        }
-        pending = new Set(tracked)
-      }
-      if (hasFailure) throw failure
+      await settleTrackedWork()
       await options.onDrained?.()
+      await settleTrackedWork()
       status = "drained"
     })().catch((error) => {
       status = "failed"

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -240,6 +240,7 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
 
   const track: ProcessReconcilerRunContext["track"] = (work) => {
     const promise = Promise.resolve(work)
+    if (status === "drained" || status === "failed") return promise
     const settlement = promise.then(
       (value): PromiseSettledResult<unknown> => ({ status: "fulfilled", value }),
       (reason): PromiseSettledResult<unknown> => ({ reason, status: "rejected" }),
@@ -303,36 +304,57 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
   const drain = (): Promise<void> => {
     if (drainPromise) return drainPromise
     drainPromise = (async () => {
-      const settleTrackedWork = async (): Promise<void> => {
-        let failure: unknown
-        let hasFailure = false
-        while (settlements.size) {
+      let failure: unknown
+      let hasFailure = false
+      const retainFailure = (error: unknown) => {
+        if (hasFailure) return
+        failure = error
+        hasFailure = true
+      }
+      const settleTrackedWork = async (final: boolean): Promise<void> => {
+        while (true) {
+          if (settlements.size === 0) {
+            if (final) status = hasFailure ? "failed" : "drained"
+            return
+          }
           const batch = [...settlements.entries()]
           const results = await Promise.all(batch.map(([, settlement]) => settlement))
           for (const [promise] of batch) settlements.delete(promise)
           const rejected = results.find(result => result.status === "rejected")
-          if (!hasFailure && rejected) {
-            failure = rejected.reason
-            hasFailure = true
-          }
+          if (rejected) retainFailure(rejected.reason)
         }
-        if (hasFailure) throw failure
       }
 
       status = "draining"
       closed = true
+      const admittedRun = running
       if (timer) clearTimeout(timer)
       timer = undefined
-      await options.onQuiesce?.()
-      await running
-      await settleTrackedWork()
-      await options.onDrained?.()
-      await settleTrackedWork()
-      status = "drained"
-    })().catch((error) => {
-      status = "failed"
-      throw error
-    })
+      try {
+        await options.onQuiesce?.()
+      }
+      catch (error) {
+        retainFailure(error)
+      }
+      try {
+        await admittedRun
+      }
+      catch (error) {
+        retainFailure(error)
+      }
+      await settleTrackedWork(false)
+      if (!hasFailure && options.onDrained) {
+        try {
+          await options.onDrained()
+          await new Promise<void>(resolve => setImmediate(resolve))
+        }
+        catch (error) {
+          retainFailure(error)
+        }
+      }
+      await settleTrackedWork(true)
+      if (hasFailure) throw failure
+    })()
     return drainPromise
   }
 

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -402,12 +402,8 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
 
   return {
     async close() {
-      try {
-        await drain()
-      }
-      finally {
-        if (signal && listener) process.off(signal, listener)
-      }
+      await drain()
+      if (signal && listener) process.off(signal, listener)
     },
     drain,
     status: () => status,

--- a/packages/runtime/src/node.ts
+++ b/packages/runtime/src/node.ts
@@ -1,4 +1,5 @@
 import { hasRuntimeType } from "./internal/runtime-type.ts"
+import { AsyncLocalStorage } from "node:async_hooks"
 import { readFile } from "node:fs/promises"
 import { join } from "node:path"
 import { availableMemory, memoryUsage, resourceUsage } from "node:process"
@@ -236,7 +237,20 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
   let running: Promise<void> | undefined
   let status: ProcessReconcilerStatus = "accepting"
   let timer: NodeJS.Timeout | undefined
+  const activeCallbacks = new Set<object>()
+  const callbackContext = new AsyncLocalStorage<object>()
   const settlements = new Map<Promise<unknown>, Promise<PromiseSettledResult<unknown>>>()
+
+  const invokeCallback = async <T>(callback: () => Promise<T> | T): Promise<T> => {
+    const token = {}
+    activeCallbacks.add(token)
+    try {
+      return await callbackContext.run(token, callback)
+    }
+    finally {
+      activeCallbacks.delete(token)
+    }
+  }
 
   const track: ProcessReconcilerRunContext["track"] = (work) => {
     const promise = Promise.resolve(work)
@@ -280,10 +294,10 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
         const currentReason = reason
         reason = "coalesced"
         try {
-          await options.run(currentReason, { track })
+          await invokeCallback(() => options.run(currentReason, { track }))
         }
         catch (error) {
-          await options.onError?.(error, currentReason)
+          if (options.onError) await invokeCallback(() => options.onError!(error, currentReason))
         }
       } while (rerun)
     })().then(resolveActive, rejectActive)
@@ -311,6 +325,10 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
   }
 
   const drain = (): Promise<void> => {
+    const caller = callbackContext.getStore()
+    if (caller && activeCallbacks.has(caller)) {
+      return Promise.reject(new TypeError("Process reconciler callbacks cannot call drain() while active."))
+    }
     if (drainPromise) return drainPromise
     drainPromise = (async () => {
       let failure: unknown
@@ -341,7 +359,7 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
       if (timer) clearTimeout(timer)
       timer = undefined
       try {
-        await options.onQuiesce?.()
+        if (options.onQuiesce) await invokeCallback(options.onQuiesce)
       }
       catch (error) {
         retainFailure(error)
@@ -355,7 +373,7 @@ export function createProcessReconciler(options: ProcessReconcilerOptions): Proc
       await settleTrackedWork(false)
       if (!hasFailure && options.onDrained) {
         try {
-          await options.onDrained()
+          await invokeCallback(options.onDrained)
           await new Promise<void>(resolve => setImmediate(resolve))
         }
         catch (error) {

--- a/packages/runtime/test/drain.test.ts
+++ b/packages/runtime/test/drain.test.ts
@@ -1,13 +1,26 @@
+import { spawn } from "node:child_process"
+import { once } from "node:events"
+import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
 
-import { processExitCompletedDrain } from "../src/internal/drain.ts"
-
 describe("process drain command", () => {
-  it("accepts a clean process exit after signaling drain", () => {
-    expect(processExitCompletedDrain(true)).toBe(true)
-  })
+  it("rejects when signal delivery terminates a target without completing drain", async () => {
+    const target = spawn(process.execPath, ["-e", `
+      const { createServer } = require("node:http")
+      const server = createServer((_request, response) => {
+        response.setHeader("content-type", "application/json")
+        response.end(JSON.stringify({ status: "accepting" }))
+      })
+      server.listen(0, "127.0.0.1", () => process.send(server.address().port))
+    `], { stdio: ["ignore", "ignore", "ignore", "ipc"] })
+    const [port] = await once(target, "message") as [number]
+    const command = spawn(process.execPath, [
+      fileURLToPath(new URL("../src/drain.ts", import.meta.url)),
+      String(target.pid),
+      `http://127.0.0.1:${port}`,
+    ])
+    const [code] = await once(command, "exit")
 
-  it("rejects a process exit before signaling drain", () => {
-    expect(processExitCompletedDrain(false)).toBe(false)
+    expect(code).toBe(1)
   })
 })

--- a/packages/runtime/test/drain.test.ts
+++ b/packages/runtime/test/drain.test.ts
@@ -13,6 +13,7 @@ describe("process drain command", () => {
       })
       server.listen(0, "127.0.0.1", () => process.send(server.address().port))
     `], { stdio: ["ignore", "ignore", "ignore", "ipc"] })
+    // SAFETY: The child sends exactly one numeric listening port from its listen callback.
     const [port] = await once(target, "message") as [number]
     const command = spawn(process.execPath, [
       fileURLToPath(new URL("../src/drain.ts", import.meta.url)),

--- a/packages/runtime/test/drain.test.ts
+++ b/packages/runtime/test/drain.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest"
+
+import { processExitCompletedDrain } from "../src/internal/drain.ts"
+
+describe("process drain command", () => {
+  it("accepts a clean process exit after signaling drain", () => {
+    expect(processExitCompletedDrain(true)).toBe(true)
+  })
+
+  it("rejects a process exit before signaling drain", () => {
+    expect(processExitCompletedDrain(false)).toBe(false)
+  })
+})

--- a/packages/runtime/test/package.test.ts
+++ b/packages/runtime/test/package.test.ts
@@ -1,9 +1,20 @@
-import { describe, it } from "vitest"
+import { access, readFile, stat } from "node:fs/promises"
+
+import { describe, expect, it } from "vitest"
 
 import { verifyBuiltPackageExports } from "../../internal/test-utils/built-package-exports.js"
+import manifest from "../package.json" with { type: "json" }
 
 describe("@vite-hub/runtime package contract", () => {
   it("loads documented exports from built package targets", async () => {
     await verifyBuiltPackageExports(new URL("../", import.meta.url), "@vite-hub/runtime", [".", "./node"])
+  })
+
+  it("publishes the drain executable", async () => {
+    expect(manifest.bin).toEqual({ "vitehub-drain": "./dist/drain.js" })
+    const executable = new URL("../dist/drain.js", import.meta.url)
+    await expect(access(executable)).resolves.toBeUndefined()
+    await expect(readFile(executable, "utf8")).resolves.toMatch(/^#!\/usr\/bin\/env node/)
+    expect((await stat(executable)).mode & 0o111).not.toBe(0)
   })
 })

--- a/packages/runtime/test/process-reconciler.test.ts
+++ b/packages/runtime/test/process-reconciler.test.ts
@@ -6,14 +6,14 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-function deferred<T = void>(): {
-  promise: Promise<T>
+function deferred(): {
+  promise: Promise<void>
   reject: (error: unknown) => void
-  resolve: (value: T | PromiseLike<T>) => void
+  resolve: () => void
 } {
   let reject!: (error: unknown) => void
-  let resolve!: (value: T | PromiseLike<T>) => void
-  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise, rejectPromise) => {
     reject = rejectPromise
     resolve = resolvePromise
   })
@@ -134,6 +134,21 @@ describe("createProcessReconciler", () => {
     unfinished.resolve()
 
     await expect(draining).rejects.toThrow("tracked work failed")
+    expect(reconciler.status()).toBe("failed")
+  })
+
+  it("retains failures from work tracked during an active drain", async () => {
+    const initial = deferred()
+    const late = deferred()
+    const reconciler = createProcessReconciler({ intervalMs: 60_000, run() {}, signal: false })
+    reconciler.track(initial.promise)
+    const draining = reconciler.drain()
+    reconciler.track(late.promise)
+    late.reject(new Error("late tracked work failed"))
+    await Promise.resolve()
+    initial.resolve()
+
+    await expect(draining).rejects.toThrow("late tracked work failed")
     expect(reconciler.status()).toBe("failed")
   })
 

--- a/packages/runtime/test/process-reconciler.test.ts
+++ b/packages/runtime/test/process-reconciler.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { createProcessReconciler } from "../src/node.ts"
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+function deferred<T = void>(): {
+  promise: Promise<T>
+  reject: (error: unknown) => void
+  resolve: (value: T | PromiseLike<T>) => void
+} {
+  let reject!: (error: unknown) => void
+  let resolve!: (value: T | PromiseLike<T>) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    reject = rejectPromise
+    resolve = resolvePromise
+  })
+  return { promise, reject, resolve }
+}
+
+describe("createProcessReconciler", () => {
+  it("coalesces synchronous wakes and keeps the latest reason", async () => {
+    const run = vi.fn()
+    const reconciler = createProcessReconciler({ intervalMs: 60_000, run, signal: false })
+
+    reconciler.wake("webhook")
+    reconciler.wake("queue")
+
+    await vi.waitFor(() => expect(run).toHaveBeenCalledOnce())
+    expect(run).toHaveBeenCalledWith("queue", expect.objectContaining({ track: expect.any(Function) }))
+    await reconciler.close()
+  })
+
+  it("runs once more when work arrives during reconciliation", async () => {
+    const first = deferred()
+    const reasons: string[] = []
+    const reconciler = createProcessReconciler({
+      intervalMs: 60_000,
+      run: async (reason) => {
+        reasons.push(reason)
+        if (reasons.length === 1) await first.promise
+      },
+      signal: false,
+    })
+
+    reconciler.wake("startup")
+    await vi.waitFor(() => expect(reasons).toEqual(["startup"]))
+    reconciler.wake("webhook")
+    reconciler.wake("queue")
+    first.resolve()
+
+    await vi.waitFor(() => expect(reasons).toEqual(["startup", "queue"]))
+    await reconciler.close()
+  })
+
+  it("quiesces and waits for tracked work before reporting drained", async () => {
+    const work = deferred()
+    const lifecycle: string[] = []
+    const reconciler = createProcessReconciler({
+      intervalMs: 60_000,
+      onDrained: () => { lifecycle.push("drained") },
+      onQuiesce: () => { lifecycle.push("quiesced") },
+      run(_reason, context) {
+        lifecycle.push("running")
+        context.track(work.promise)
+      },
+      signal: false,
+    })
+    reconciler.wake("startup")
+    await vi.waitFor(() => expect(lifecycle).toEqual(["running"]))
+
+    const draining = reconciler.drain()
+    await vi.waitFor(() => expect(lifecycle).toEqual(["running", "quiesced"]))
+    expect(reconciler.status()).toBe("draining")
+    work.resolve()
+    await draining
+
+    expect(lifecycle).toEqual(["running", "quiesced", "drained"])
+    expect(reconciler.status()).toBe("drained")
+  })
+
+  it("reports run failures and continues periodic repair", async () => {
+    vi.useFakeTimers()
+    const onError = vi.fn()
+    const run = vi.fn(async (reason: string) => {
+      if (reason === "startup") throw new Error("transient")
+    })
+    const reconciler = createProcessReconciler({ intervalMs: 1_000, onError, run, signal: false })
+
+    reconciler.wake("startup")
+    await vi.runAllTicks()
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: "transient" }), "startup")
+    expect(run).toHaveBeenCalledWith("repair", expect.anything())
+    await reconciler.close()
+  })
+
+  it("fails the drain when tracked work fails", async () => {
+    const work = deferred()
+    const reconciler = createProcessReconciler({ intervalMs: 60_000, run() {}, signal: false })
+    reconciler.track(work.promise)
+    const draining = reconciler.drain()
+    work.reject(new Error("unfinished work failed"))
+
+    await expect(draining).rejects.toThrow("unfinished work failed")
+    expect(reconciler.status()).toBe("failed")
+  })
+
+  it("removes its signal listener when closed", async () => {
+    const listeners = process.listenerCount("SIGUSR2")
+    const reconciler = createProcessReconciler({ intervalMs: 60_000, run() {}, signal: "SIGUSR2" })
+
+    expect(process.listenerCount("SIGUSR2")).toBe(listeners + 1)
+    await reconciler.close()
+    expect(process.listenerCount("SIGUSR2")).toBe(listeners)
+  })
+
+  it("rejects invalid repair intervals", () => {
+    expect(() => createProcessReconciler({ intervalMs: 0, run() {} })).toThrow(
+      "Process reconciler intervalMs must be positive.",
+    )
+  })
+})

--- a/packages/runtime/test/process-reconciler.test.ts
+++ b/packages/runtime/test/process-reconciler.test.ts
@@ -152,6 +152,77 @@ describe("createProcessReconciler", () => {
     expect(reconciler.status()).toBe("failed")
   })
 
+  it("settles admitted work after quiescing fails", async () => {
+    const work = deferred()
+    const reconciler = createProcessReconciler({
+      intervalMs: 60_000,
+      onQuiesce: () => { throw new Error("quiescing failed") },
+      run() {},
+      signal: false,
+    })
+    reconciler.track(work.promise)
+
+    const draining = reconciler.drain()
+    await Promise.resolve()
+    expect(reconciler.status()).toBe("draining")
+    work.resolve()
+
+    await expect(draining).rejects.toThrow("quiescing failed")
+    expect(reconciler.status()).toBe("failed")
+  })
+
+  it("settles admitted work after reconciliation error reporting fails", async () => {
+    const runStarted = deferred()
+    const work = deferred()
+    const reconciler = createProcessReconciler({
+      intervalMs: 60_000,
+      onError: () => { throw new Error("error reporting failed") },
+      run(_reason, context) {
+        context.track(work.promise)
+        runStarted.resolve()
+        throw new Error("reconciliation failed")
+      },
+      signal: false,
+    })
+    reconciler.wake("startup")
+    await runStarted.promise
+
+    const draining = reconciler.drain()
+    await Promise.resolve()
+    expect(reconciler.status()).toBe("draining")
+    work.resolve()
+
+    await expect(draining).rejects.toThrow("error reporting failed")
+    expect(reconciler.status()).toBe("failed")
+  })
+
+  it("retains nested microtask work at the final drain boundary", async () => {
+    const late = deferred()
+    const reconciler = createProcessReconciler({
+      intervalMs: 60_000,
+      onDrained() {
+        queueMicrotask(() => queueMicrotask(() => {
+          reconciler.track(late.promise)
+          late.reject(new Error("final tracked work failed"))
+        }))
+      },
+      run() {},
+      signal: false,
+    })
+
+    await expect(reconciler.drain()).rejects.toThrow("final tracked work failed")
+    expect(reconciler.status()).toBe("failed")
+    expect(reconciler.track(Promise.resolve("terminal"))).resolves.toBe("terminal")
+  })
+
+  it("does not retain work tracked after a successful drain", async () => {
+    const reconciler = createProcessReconciler({ intervalMs: 60_000, run() {}, signal: false })
+    await reconciler.drain()
+
+    await expect(reconciler.track(Promise.resolve("terminal"))).resolves.toBe("terminal")
+    expect(reconciler.status()).toBe("drained")
+  })
+
   it("reports drained only after asynchronous cleanup completes", async () => {
     const cleanup = deferred()
     const reconciler = createProcessReconciler({

--- a/packages/runtime/test/process-reconciler.test.ts
+++ b/packages/runtime/test/process-reconciler.test.ts
@@ -202,6 +202,52 @@ describe("createProcessReconciler", () => {
     expect(reconciler.status()).toBe("failed")
   })
 
+  it("runs a rerun admitted during active-run settlement", async () => {
+    const reasons: string[] = []
+    let reconciler!: ProcessReconciler
+    const retry = deferred()
+    reconciler = createProcessReconciler({
+      intervalMs: 60_000,
+      onError() {
+        queueMicrotask(() => queueMicrotask(() => reconciler.wake("retry")))
+        throw new Error("error reporting failed")
+      },
+      run(reason) {
+        reasons.push(reason)
+        if (reason === "startup") throw new Error("reconciliation failed")
+        return retry.promise
+      },
+      signal: false,
+    })
+
+    reconciler.wake("startup")
+    await vi.waitFor(() => expect(reasons).toEqual(["startup", "retry"]))
+    const draining = reconciler.drain()
+    retry.resolve()
+
+    await expect(draining).rejects.toThrow("error reporting failed")
+    expect(reconciler.status()).toBe("failed")
+  })
+
+  it("queues a wake that arrives after active-run settlement", async () => {
+    const reasons: string[] = []
+    let reconciler!: ProcessReconciler
+    reconciler = createProcessReconciler({
+      intervalMs: 60_000,
+      run(reason) {
+        reasons.push(reason)
+        if (reason === "startup") {
+          queueMicrotask(() => queueMicrotask(() => queueMicrotask(() => reconciler.wake("retry"))))
+        }
+      },
+      signal: false,
+    })
+
+    reconciler.wake("startup")
+    await vi.waitFor(() => expect(reasons).toEqual(["startup", "retry"]))
+    await reconciler.close()
+  })
+
   it("starts periodic repair without an event-driven wake", async () => {
     vi.useFakeTimers()
     const run = vi.fn()
@@ -387,6 +433,7 @@ describe("createProcessReconciler", () => {
   })
 
   it.each(["SIGKILL", "SIGSTOP"] as const)("rejects the uncatchable %s signal", (signal) => {
+    // SAFETY: This verifies the runtime guard for values intentionally excluded from the public type.
     expect(() => createProcessReconciler({ intervalMs: 60_000, run() {}, signal: signal as never }))
       .toThrow(`Process reconciler signal ${signal} cannot be handled.`)
   })

--- a/packages/runtime/test/process-reconciler.test.ts
+++ b/packages/runtime/test/process-reconciler.test.ts
@@ -98,6 +98,17 @@ describe("createProcessReconciler", () => {
     await reconciler.close()
   })
 
+  it("starts periodic repair without an event-driven wake", async () => {
+    vi.useFakeTimers()
+    const run = vi.fn()
+    const reconciler = createProcessReconciler({ intervalMs: 1_000, run, signal: false })
+
+    await vi.advanceTimersByTimeAsync(1_000)
+
+    expect(run).toHaveBeenCalledWith("repair", expect.anything())
+    await reconciler.close()
+  })
+
   it("fails the drain when tracked work fails", async () => {
     const work = deferred()
     const reconciler = createProcessReconciler({ intervalMs: 60_000, run() {}, signal: false })
@@ -107,6 +118,41 @@ describe("createProcessReconciler", () => {
 
     await expect(draining).rejects.toThrow("unfinished work failed")
     expect(reconciler.status()).toBe("failed")
+  })
+
+  it("waits for all tracked work before failing the drain", async () => {
+    const failed = deferred()
+    const unfinished = deferred()
+    const reconciler = createProcessReconciler({ intervalMs: 60_000, run() {}, signal: false })
+    reconciler.track(failed.promise)
+    reconciler.track(unfinished.promise)
+    const draining = reconciler.drain()
+    failed.reject(new Error("tracked work failed"))
+    await Promise.resolve()
+
+    expect(reconciler.status()).toBe("draining")
+    unfinished.resolve()
+
+    await expect(draining).rejects.toThrow("tracked work failed")
+    expect(reconciler.status()).toBe("failed")
+  })
+
+  it("reports drained only after asynchronous cleanup completes", async () => {
+    const cleanup = deferred()
+    const reconciler = createProcessReconciler({
+      intervalMs: 60_000,
+      onDrained: () => cleanup.promise,
+      run() {},
+      signal: false,
+    })
+
+    const draining = reconciler.drain()
+    await Promise.resolve()
+    expect(reconciler.status()).toBe("draining")
+    cleanup.resolve()
+    await draining
+
+    expect(reconciler.status()).toBe("drained")
   })
 
   it("removes its signal listener when closed", async () => {
@@ -120,7 +166,10 @@ describe("createProcessReconciler", () => {
 
   it("rejects invalid repair intervals", () => {
     expect(() => createProcessReconciler({ intervalMs: 0, run() {} })).toThrow(
-      "Process reconciler intervalMs must be positive.",
+      "Process reconciler intervalMs must be between 1 and 2,147,483,647 milliseconds.",
+    )
+    expect(() => createProcessReconciler({ intervalMs: 2_147_483_648, run() {} })).toThrow(
+      "Process reconciler intervalMs must be between 1 and 2,147,483,647 milliseconds.",
     )
   })
 })

--- a/packages/runtime/test/process-reconciler.test.ts
+++ b/packages/runtime/test/process-reconciler.test.ts
@@ -90,13 +90,14 @@ describe("createProcessReconciler", () => {
     expect(reconciler.status()).toBe("drained")
   })
 
-  it("publishes the active run to a reentrant drain", async () => {
+  it("rejects a drain awaited by the active run", async () => {
     const finished = deferred()
-    let draining: Promise<void> | undefined
     const reconciler = createProcessReconciler({
       intervalMs: 60_000,
-      run() {
-        draining = reconciler.drain()
+      async run() {
+        await expect(reconciler.drain()).rejects.toThrow(
+          "Process reconciler callbacks cannot call drain() while active.",
+        )
         finished.resolve()
       },
       signal: false,
@@ -104,7 +105,28 @@ describe("createProcessReconciler", () => {
 
     reconciler.wake("startup")
     await finished.promise
-    await draining
+    await reconciler.drain()
+
+    expect(reconciler.status()).toBe("drained")
+  })
+
+  it("rejects a drain awaited by active error reporting", async () => {
+    const finished = deferred()
+    const reconciler = createProcessReconciler({
+      intervalMs: 60_000,
+      async onError() {
+        await expect(reconciler.drain()).rejects.toThrow(
+          "Process reconciler callbacks cannot call drain() while active.",
+        )
+        finished.resolve()
+      },
+      run() { throw new Error("reconciliation failed") },
+      signal: false,
+    })
+
+    reconciler.wake("startup")
+    await finished.promise
+    await reconciler.drain()
 
     expect(reconciler.status()).toBe("drained")
   })

--- a/packages/runtime/test/process-reconciler.test.ts
+++ b/packages/runtime/test/process-reconciler.test.ts
@@ -175,6 +175,33 @@ describe("createProcessReconciler", () => {
     await reconciler.close()
   })
 
+  it("runs an admitted rerun when error reporting fails", async () => {
+    const reasons: string[] = []
+    let reconciler!: ProcessReconciler
+    const retry = deferred()
+    reconciler = createProcessReconciler({
+      intervalMs: 60_000,
+      onError() {
+        reconciler.wake("retry")
+        throw new Error("error reporting failed")
+      },
+      run(reason) {
+        reasons.push(reason)
+        if (reason === "startup") throw new Error("reconciliation failed")
+        return retry.promise
+      },
+      signal: false,
+    })
+
+    reconciler.wake("startup")
+    await vi.waitFor(() => expect(reasons).toEqual(["startup", "retry"]))
+    const draining = reconciler.drain()
+    retry.resolve()
+
+    await expect(draining).rejects.toThrow("error reporting failed")
+    expect(reconciler.status()).toBe("failed")
+  })
+
   it("starts periodic repair without an event-driven wake", async () => {
     vi.useFakeTimers()
     const run = vi.fn()
@@ -357,5 +384,10 @@ describe("createProcessReconciler", () => {
     expect(() => createProcessReconciler({ intervalMs: 2_147_483_648, run() {} })).toThrow(
       "Process reconciler intervalMs must be between 1 and 2,147,483,647 milliseconds.",
     )
+  })
+
+  it.each(["SIGKILL", "SIGSTOP"] as const)("rejects the uncatchable %s signal", (signal) => {
+    expect(() => createProcessReconciler({ intervalMs: 60_000, run() {}, signal: signal as never }))
+      .toThrow(`Process reconciler signal ${signal} cannot be handled.`)
   })
 })

--- a/packages/runtime/test/process-reconciler.test.ts
+++ b/packages/runtime/test/process-reconciler.test.ts
@@ -55,6 +55,60 @@ describe("createProcessReconciler", () => {
     await reconciler.close()
   })
 
+  it("drains a wake admitted before its queued execution", async () => {
+    const run = vi.fn()
+    const reconciler = createProcessReconciler({ intervalMs: 60_000, run, signal: false })
+
+    reconciler.wake("webhook")
+    await reconciler.drain()
+
+    expect(run).toHaveBeenCalledOnce()
+    expect(run).toHaveBeenCalledWith("webhook", expect.anything())
+    expect(reconciler.status()).toBe("drained")
+  })
+
+  it("drains a rerun admitted during reconciliation", async () => {
+    const first = deferred()
+    const reasons: string[] = []
+    const reconciler = createProcessReconciler({
+      intervalMs: 60_000,
+      run: async (reason) => {
+        reasons.push(reason)
+        if (reasons.length === 1) await first.promise
+      },
+      signal: false,
+    })
+
+    reconciler.wake("startup")
+    await vi.waitFor(() => expect(reasons).toEqual(["startup"]))
+    reconciler.wake("webhook")
+    const draining = reconciler.drain()
+    first.resolve()
+    await draining
+
+    expect(reasons).toEqual(["startup", "webhook"])
+    expect(reconciler.status()).toBe("drained")
+  })
+
+  it("publishes the active run to a reentrant drain", async () => {
+    const finished = deferred()
+    let draining: Promise<void> | undefined
+    const reconciler = createProcessReconciler({
+      intervalMs: 60_000,
+      run() {
+        draining = reconciler.drain()
+        finished.resolve()
+      },
+      signal: false,
+    })
+
+    reconciler.wake("startup")
+    await finished.promise
+    await draining
+
+    expect(reconciler.status()).toBe("drained")
+  })
+
   it("quiesces and waits for tracked work before reporting drained", async () => {
     const work = deferred()
     const lifecycle: string[] = []
@@ -212,7 +266,7 @@ describe("createProcessReconciler", () => {
 
     await expect(reconciler.drain()).rejects.toThrow("final tracked work failed")
     expect(reconciler.status()).toBe("failed")
-    expect(reconciler.track(Promise.resolve("terminal"))).resolves.toBe("terminal")
+    await expect(reconciler.track(Promise.resolve("terminal"))).resolves.toBe("terminal")
   })
 
   it("does not retain work tracked after a successful drain", async () => {
@@ -252,6 +306,9 @@ describe("createProcessReconciler", () => {
 
   it("rejects invalid repair intervals", () => {
     expect(() => createProcessReconciler({ intervalMs: 0, run() {} })).toThrow(
+      "Process reconciler intervalMs must be between 1 and 2,147,483,647 milliseconds.",
+    )
+    expect(() => createProcessReconciler({ intervalMs: 0.5, run() {} })).toThrow(
       "Process reconciler intervalMs must be between 1 and 2,147,483,647 milliseconds.",
     )
     expect(() => createProcessReconciler({ intervalMs: 2_147_483_648, run() {} })).toThrow(

--- a/packages/runtime/test/process-reconciler.test.ts
+++ b/packages/runtime/test/process-reconciler.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
 import { createProcessReconciler } from "../src/node.ts"
+import type { ProcessReconciler } from "../src/node.ts"
 
 afterEach(() => {
   vi.useRealTimers()
@@ -321,6 +322,26 @@ describe("createProcessReconciler", () => {
     const listeners = process.listenerCount("SIGUSR2")
     const reconciler = createProcessReconciler({ intervalMs: 60_000, run() {}, signal: "SIGUSR2" })
 
+    expect(process.listenerCount("SIGUSR2")).toBe(listeners + 1)
+    await reconciler.close()
+    expect(process.listenerCount("SIGUSR2")).toBe(listeners)
+  })
+
+  it("retains its signal listener when close rejects", async () => {
+    const listeners = process.listenerCount("SIGUSR2")
+    let reconciler!: ProcessReconciler
+    reconciler = createProcessReconciler({
+      intervalMs: 60_000,
+      async run() {
+        await expect(reconciler.close()).rejects.toThrow("cannot call drain() while active")
+      },
+      signal: "SIGUSR2",
+    })
+
+    reconciler.wake("test")
+    await new Promise<void>(resolve => setImmediate(resolve))
+
+    expect(reconciler.status()).toBe("accepting")
     expect(process.listenerCount("SIGUSR2")).toBe(listeners + 1)
     await reconciler.close()
     expect(process.listenerCount("SIGUSR2")).toBe(listeners)

--- a/packages/runtime/vite.config.ts
+++ b/packages/runtime/vite.config.ts
@@ -3,8 +3,15 @@ import { defineConfig } from "vite-plus";
 export default defineConfig({
   pack: {
     tsconfig: "tsconfig.build.json",
-    entry: ["src/index.ts", "src/node.ts"],
+    entry: ["src/drain.ts", "src/index.ts", "src/node.ts"],
     exports: {
+      bin: {
+        "vitehub-drain": "src/drain.ts",
+      },
+      customExports(exports) {
+        delete exports["./drain"]
+        return exports
+      },
       inlinedDependencies: false,
     },
     outExtensions: () => ({


### PR DESCRIPTION
## Summary

- add a coalescing process reconciler with periodic repair, tracked work, explicit lifecycle status, and graceful drain hooks
- add the `vitehub-drain` process/status handshake for service-manager shutdowns
- publish the executable with shebang and execute permissions

This upstreams the reusable Runtime behavior currently carried by Babysitter as a pnpm patch. The source version also fixes synchronous wake coalescing and retains accepted tracked failures through quiescing.

## Validation

- `pnpm --filter @vite-hub/runtime build`
- `pnpm --filter @vite-hub/runtime typecheck`
- `pnpm --filter @vite-hub/runtime exec vp test test/process-reconciler.test.ts test/package.test.ts test/published-types.test.ts`
- focused `vp lint`
