### PR TITLE
fix(console): restore fast complete session inspection

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -3523,6 +3523,13 @@ async function createAgentInvocationContext<
       capabilities: [...capabilityTelemetryMetadata.entries()]
         .map(([id, metadata]) => ({ id, ...(Object.keys(metadata).length ? { metadata } : {}) }))
         .sort((left, right) => left.id.localeCompare(right.id)),
+      ...(definition?.channels
+        ? {
+            channels: Object.entries(definition.channels)
+              .map(([id, channel]) => ({ id, kind: channel.kind }))
+              .sort((left, right) => left.id.localeCompare(right.id)),
+          }
+        : {}),
       driver: {
         kind: driverKind,
         ...(configuredDriver?.kind === "provider" ? { provider: configuredDriver.provider } : {}),

--- a/packages/agent/src/invocations-vue.ts
+++ b/packages/agent/src/invocations-vue.ts
@@ -45,7 +45,9 @@ export interface UseAgentInvocationsReturn {
 }
 
 export interface AgentInvocationDetailResult {
+  appendObservations?: boolean;
   invocation: AgentInvocationSummary;
+  observationCursor?: string;
   observations: readonly TraceEventLogEntry[];
 }
 
@@ -146,7 +148,21 @@ function parseAgentInvocationDetailResult(value: unknown): AgentInvocationDetail
       type: observation.type,
     };
   });
-  return { invocation: parseInvocationSummary(value.invocation), observations };
+  if (value.appendObservations !== undefined && typeof value.appendObservations !== "boolean") {
+    throw new TypeError("Invalid Agent Invocation observation page.");
+  }
+  const observationCursor = value.observationCursor;
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Invocation detail responses are untrusted JSON at this requester boundary.
+  if (observationCursor !== undefined && typeof observationCursor !== "string") {
+    throw new TypeError("Invalid Agent Invocation observation cursor.");
+  }
+  const result: AgentInvocationDetailResult = {
+    invocation: parseInvocationSummary(value.invocation),
+    observations,
+  };
+  if (value.appendObservations === true) result.appendObservations = true;
+  if (observationCursor !== undefined) result.observationCursor = observationCursor;
+  return result;
 }
 
 function isAbortError(error: unknown): boolean {
@@ -526,22 +542,43 @@ export function useAgentInvocation(
   const observations = shallowRef<readonly TraceEventLogEntry[]>([]);
   const request = options.request;
   const baseURL = options.baseURL ?? defaultBaseURL;
+  let loadedSource: string | undefined;
+  let loadedObservationCursor: string | undefined;
+  let requestedSource: string | undefined;
 
   const resource = useInvocationResource<AgentInvocationDetailResult>({
     apply(result) {
+      const append = result.appendObservations
+        && loadedSource === requestedSource
+        && invocation.value?.id === result.invocation.id;
       invocation.value = result.invocation;
-      observations.value = result.observations;
+      observations.value = append
+        ? [...observations.value, ...result.observations]
+        : result.observations;
+      loadedSource = requestedSource;
+      loadedObservationCursor = result.observationCursor;
     },
     clear() {
       invocation.value = null;
       observations.value = [];
+      loadedSource = undefined;
+      loadedObservationCursor = undefined;
+      requestedSource = undefined;
     },
     immediate:
       options.immediate !== false && (options.request !== undefined || "window" in globalThis),
     load(signal) {
       const resolvedId = toValue(id);
       if (resolvedId === undefined) return Promise.resolve(undefined);
-      return request(detailPath(toValue(baseURL), resolvedId), { signal }).then(
+      const resolvedBaseURL = toValue(baseURL);
+      const source = JSON.stringify([resolvedBaseURL, resolvedId]);
+      requestedSource = source;
+      const canRequestDelta = loadedSource === source && loadedObservationCursor !== undefined;
+      const path = appendQuery(detailPath(resolvedBaseURL, resolvedId), {
+        observationCount: canRequestDelta ? observations.value.length : undefined,
+        observationCursor: canRequestDelta ? loadedObservationCursor : undefined,
+      });
+      return request(path, { signal }).then(
         parseAgentInvocationDetailResult,
       );
     },

--- a/packages/agent/src/invocations.ts
+++ b/packages/agent/src/invocations.ts
@@ -238,6 +238,17 @@ function configurationAnnotations(
   return normalizeAnnotations(annotations)
 }
 
+function mergeConfigurationAnnotations(
+  annotations: AgentInvocationRecord["annotations"],
+  configured: Record<string, AgentInvocationAnnotationValue>,
+): Record<string, AgentInvocationAnnotationValue> | undefined {
+  const merged: Record<string, AgentInvocationAnnotationValue> = { ...configured }
+  for (const [key, value] of Object.entries(annotations || {})) {
+    if (!Object.hasOwn(configured, key)) merged[key] = value
+  }
+  return normalizeAnnotations(merged)
+}
+
 function normalizeLimit(limit: number | undefined): number {
   if (limit === undefined) return DEFAULT_LIST_LIMIT
   if (!Number.isInteger(limit) || limit < 1) {
@@ -848,7 +859,7 @@ export function applyAgentInvocationStoreUpdate(
   return {
     ...record,
     ...(configuredAnnotations
-      ? { annotations: normalizeAnnotations({ ...record.annotations, ...configuredAnnotations }) }
+      ? { annotations: mergeConfigurationAnnotations(record.annotations, configuredAnnotations) }
       : {}),
     ...(input.error ? { error: input.error } : {}),
     observations,

--- a/packages/agent/src/invocations.ts
+++ b/packages/agent/src/invocations.ts
@@ -1,4 +1,5 @@
 import { hasRuntimeType } from "./internal/runtime-type.ts"
+import { searchableAgentInvocationText } from "./invocations/search.ts"
 import { createTraceEventLog, isTraceContentAttributeKey, normalizeRuntimeDiagnosticError } from "@vite-hub/runtime"
 import { registerAgentInvocationRecovery } from "./internal/invocation-recovery.ts"
 import { agentInvocationJournalContentTraceLogSymbol, agentInvocationJournalTraceLogSymbol } from "./trace.ts"
@@ -272,8 +273,7 @@ function normalizeSearch(search: string | undefined): string | undefined {
 
 function matchesInvocationSearch(record: AgentInvocationRecord, search: string | undefined): boolean {
   if (!search) return true
-  const { cursor: _cursor, ...searchable } = record
-  return JSON.stringify(searchable).toLowerCase().includes(search.toLowerCase())
+  return searchableAgentInvocationText(record).includes(search.toLowerCase())
 }
 
 function normalizeBuiltInCursor(cursor: string | undefined): string | undefined {

--- a/packages/agent/src/invocations.ts
+++ b/packages/agent/src/invocations.ts
@@ -21,6 +21,7 @@ const MAX_OBSERVATIONS = 256
 const MAX_OBSERVATION_ATTRIBUTES = 32
 const MAX_OBSERVATION_COLLECTION_ITEMS = 32
 const MAX_OBSERVATION_DEPTH = 4
+const MAX_AGENT_CONFIGURATION_DEPTH = 8
 const MAX_OBSERVATION_VALUE_ITEMS = 256
 export const AGENT_INVOCATION_OBSERVATION_TRUNCATED_ATTRIBUTE = "vitehub.observation.truncated"
 const AGENT_INVOCATION_OBSERVATION_ID_ATTRIBUTE = "vitehub.observation.id"
@@ -197,6 +198,10 @@ function annotationKey(key: string): boolean {
   return key.length <= MAX_ANNOTATION_KEY_LENGTH && /^[A-Za-z][A-Za-z0-9_.-]*$/.test(key)
 }
 
+function isStringRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && hasRuntimeType(value, "object") && !Array.isArray(value)
+}
+
 function normalizeAnnotations(input: AgentRunMetadata["annotations"]): Record<string, AgentInvocationAnnotationValue> | undefined {
   if (!input || !hasRuntimeType(input, "object")) return
   const annotations: Record<string, AgentInvocationAnnotationValue> = {}
@@ -208,6 +213,29 @@ function normalizeAnnotations(input: AgentRunMetadata["annotations"]): Record<st
     else if (hasRuntimeType(value, "boolean") || value === null) annotations[key] = value
   }
   return Object.keys(annotations).length ? annotations : undefined
+}
+
+function configurationAnnotations(
+  observation: TraceEventLogEntry,
+): Record<string, AgentInvocationAnnotationValue> | undefined {
+  if (observation.name !== "vitehub.agent.configured") return
+  const configuration = observation.attributes?.["vitehub.agent.configuration"]
+  if (!isStringRecord(configuration)) return
+  const driver = configuration.driver
+  if (!isStringRecord(driver)) return
+  const modelRecord = isStringRecord(driver.model) ? driver.model : undefined
+  const provider = hasRuntimeType(modelRecord?.provider, "string")
+    ? modelRecord.provider
+    : hasRuntimeType(driver.provider, "string")
+      ? driver.provider
+      : undefined
+  const modelId = hasRuntimeType(modelRecord?.id, "string")
+    ? modelRecord.id
+    : undefined
+  const annotations: AgentRunMetadata["annotations"] = {}
+  if (modelId) annotations["agent.model.id"] = modelId
+  if (provider) annotations["agent.model.provider"] = provider
+  return normalizeAnnotations(annotations)
 }
 
 function normalizeLimit(limit: number | undefined): number {
@@ -257,6 +285,7 @@ function normalizedTimestamp(value: Date | string): string {
 
 interface ObservationBudget {
   items: number
+  maxDepth?: number
   stringLength: number
   truncated: boolean
 }
@@ -408,7 +437,7 @@ function boundedObservationValue(
     if (string.length > MAX_METADATA_STRING_LENGTH) budget.truncated = true
     return boundedString(string)
   }
-  if (depth >= MAX_OBSERVATION_DEPTH) {
+  if (depth >= (budget.maxDepth ?? MAX_OBSERVATION_DEPTH)) {
     budget.truncated = true
     return "[truncated]"
   }
@@ -544,6 +573,23 @@ function boundedObservationPayload(
   if (payload?.visibility === "private") return { visibility: "private" }
 }
 
+function boundedObservationAttributeValue(
+  key: string,
+  value: unknown,
+  budget: ObservationBudget,
+  maxStringLength: number,
+  builtIns?: ReadonlyMap<object, BoundedObservationBuiltIn>,
+): unknown {
+  const maxDepth = budget.maxDepth
+  if (key === "vitehub.agent.configuration") budget.maxDepth = MAX_AGENT_CONFIGURATION_DEPTH
+  try {
+    return boundedObservationValue(value, budget, 0, maxStringLength, builtIns)
+  }
+  finally {
+    budget.maxDepth = maxDepth
+  }
+}
+
 function boundedObservation(
   observation: TraceEventLogEntry,
   builtIns?: ReadonlyMap<object, BoundedObservationBuiltIn>,
@@ -583,7 +629,13 @@ function boundedObservation(
           .slice(0, ordinaryAttributeLimit)
         .flatMap(([key, value]) => {
           if (key.length > MAX_METADATA_STRING_LENGTH) budget.truncated = true
-          return value === undefined ? [] : [[boundedString(key), boundedObservationValue(value, budget, 0, isTraceContentAttributeKey(key) ? MAX_OBSERVATION_CONTENT_STRING_LENGTH : MAX_METADATA_STRING_LENGTH, builtIns)]]
+          return value === undefined ? [] : [[boundedString(key), boundedObservationAttributeValue(
+            key,
+            value,
+            budget,
+            isTraceContentAttributeKey(key) ? MAX_OBSERVATION_CONTENT_STRING_LENGTH : MAX_METADATA_STRING_LENGTH,
+            builtIns,
+          )]]
         })),
         ...canonicalAttributes,
       }
@@ -764,6 +816,9 @@ export function applyAgentInvocationStoreUpdate(
   const status = input.status && (!terminalStatus(record.status) || input.status === record.status)
     ? input.status
     : record.status
+  const configuredAnnotations = input.observation
+    ? configurationAnnotations(input.observation)
+    : undefined
   const observations = input.observation && !duplicateObservation
     ? record.observations.length < MAX_OBSERVATIONS
       ? (() => {
@@ -792,6 +847,9 @@ export function applyAgentInvocationStoreUpdate(
     : record.observations
   return {
     ...record,
+    ...(configuredAnnotations
+      ? { annotations: normalizeAnnotations({ ...record.annotations, ...configuredAnnotations }) }
+      : {}),
     ...(input.error ? { error: input.error } : {}),
     observations,
     ...(input.observationsTruncated || (input.observation && !duplicateObservation && record.observations.length >= MAX_OBSERVATIONS)

--- a/packages/agent/src/invocations.ts
+++ b/packages/agent/src/invocations.ts
@@ -104,6 +104,7 @@ export interface AgentInvocationStore {
   get(id: string): MaybePromise<AgentInvocationRecord | undefined>
   getClaimToken(id: string): MaybePromise<string | undefined>
   list(options?: AgentInvocationListOptions): MaybePromise<AgentInvocationListResult>
+  listAgentNames?(): MaybePromise<readonly string[]>
   release(id: string, claimId: string): MaybePromise<void>
   /** Updates are idempotent for observations carrying the ViteHub observation identity attribute. */
   update(id: string, input: AgentInvocationStoreUpdateInput, claimId?: string): MaybePromise<AgentInvocationRecord | undefined>
@@ -120,6 +121,7 @@ export interface AgentInvocations {
   get(id: string): Promise<AgentInvocationRecord | undefined>
   getByRunId(runId: string, agentName?: string): Promise<AgentInvocationRecord | undefined>
   list(options?: AgentInvocationListOptions): Promise<AgentInvocationListResult>
+  listAgentNames(): Promise<readonly string[]>
 }
 
 interface BoundAgentInvocations extends AgentInvocations {
@@ -856,6 +858,10 @@ export function createMemoryAgentInvocationStore(): AgentInvocationStore {
         }),
       }
     },
+    listAgentNames() {
+      return [...new Set([...records.values()].flatMap(record => record.agentName?.trim() || []))]
+        .sort()
+    },
     release(id, claimId) {
       if (claims.get(id)?.claimId === claimId) claims.delete(id)
     },
@@ -1455,6 +1461,22 @@ export function defineAgentInvocations(options: AgentInvocationsOptions): AgentI
       if (search) normalized.search = search
       else delete normalized.search
       return await store.list(normalized)
+    },
+    async listAgentNames() {
+      if (store.listAgentNames) {
+        return [...new Set((await store.listAgentNames()).map(name => name.trim()).filter(Boolean))]
+          .sort()
+      }
+      const names = new Set<string>()
+      let cursor: string | undefined
+      do {
+        const page = await store.list({ cursor, limit: MAX_LIST_LIMIT })
+        for (const invocation of page.invocations) {
+          if (invocation.agentName?.trim()) names.add(invocation.agentName.trim())
+        }
+        cursor = page.cursor
+      } while (cursor)
+      return [...names].sort()
     },
   }
   return invocations

--- a/packages/agent/src/invocations/search.ts
+++ b/packages/agent/src/invocations/search.ts
@@ -29,6 +29,7 @@ const maximumObservationSearchCharacters = 128 * 1024
 
 function appendSearchValue(value: SearchValue, output: SearchValues): void {
   if (output.values.has(value) || output.characters >= output.maximumCharacters) return
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- SearchValue is a deliberate primitive union and strings require bounded slicing.
   if (typeof value !== "string") {
     output.values.add(value)
     output.characters += String(value).length
@@ -47,10 +48,12 @@ function appendContentStrings(
   includeKeys: boolean,
   seen = new Set<object>(),
 ): void {
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Invocation metadata is recursively unknown at this search-projection boundary.
   if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
     appendSearchValue(value, output)
     return
   }
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Recursive invocation metadata must be object-checked before traversal.
   if (!value || typeof value !== "object" || seen.has(value) || output.characters >= output.maximumCharacters) return
   seen.add(value)
   for (const [key, child] of Object.entries(value)) {
@@ -65,6 +68,7 @@ function appendSearchableObservation(observation: TraceEventLogEntry, output: Se
   appendSearchValue(observation.type, output)
   for (const [key, value] of Object.entries(observation.attributes ?? {})) {
     if (excludedObservationContent.has(key)) continue
+    // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Trace attributes are recursively unknown at this search-projection boundary.
     if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
       appendSearchValue(key, output)
       appendSearchValue(value, output)

--- a/packages/agent/src/invocations/search.ts
+++ b/packages/agent/src/invocations/search.ts
@@ -1,0 +1,107 @@
+import type { AgentInvocationRecord } from "../invocations.ts"
+import type { TraceEventLogEntry } from "@vite-hub/runtime"
+
+const searchableObservationContent = new Set([
+  "channel.effect.content",
+  "input.messages",
+  "input.prompt",
+  "message.content",
+  "result.text",
+  "vitehub.activity.progress",
+])
+
+const excludedObservationContent = new Set([
+  "tool.input",
+  "tool.output",
+  "vitehub.activity.body",
+])
+
+type SearchValue = boolean | number | string
+type SearchValues = {
+  characters: number
+  maximumCharacters: number
+  values: Set<SearchValue>
+}
+
+const maximumSearchStringCharacters = 16 * 1024
+const maximumSummarySearchCharacters = 32 * 1024
+const maximumObservationSearchCharacters = 128 * 1024
+
+function appendSearchValue(value: SearchValue, output: SearchValues): void {
+  if (output.values.has(value) || output.characters >= output.maximumCharacters) return
+  if (typeof value !== "string") {
+    output.values.add(value)
+    output.characters += String(value).length
+    return
+  }
+  const remaining = output.maximumCharacters - output.characters
+  const searchable = value.slice(0, Math.min(maximumSearchStringCharacters, remaining))
+  if (!searchable || output.values.has(searchable)) return
+  output.values.add(searchable)
+  output.characters += searchable.length
+}
+
+function appendContentStrings(
+  value: unknown,
+  output: SearchValues,
+  includeKeys: boolean,
+  seen = new Set<object>(),
+): void {
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    appendSearchValue(value, output)
+    return
+  }
+  if (!value || typeof value !== "object" || seen.has(value) || output.characters >= output.maximumCharacters) return
+  seen.add(value)
+  for (const [key, child] of Object.entries(value)) {
+    if (includeKeys && !Array.isArray(value)) appendSearchValue(key, output)
+    appendContentStrings(child, output, includeKeys, seen)
+  }
+}
+
+function appendSearchableObservation(observation: TraceEventLogEntry, output: SearchValues): void {
+  appendSearchValue(observation.name, output)
+  appendSearchValue(observation.timestamp, output)
+  appendSearchValue(observation.type, output)
+  for (const [key, value] of Object.entries(observation.attributes ?? {})) {
+    if (excludedObservationContent.has(key)) continue
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+      appendSearchValue(key, output)
+      appendSearchValue(value, output)
+      continue
+    }
+    if (searchableObservationContent.has(key) || key.startsWith("error.")) {
+      appendSearchValue(key, output)
+      appendContentStrings(value, output, true)
+    }
+  }
+}
+
+function searchableSummary(
+  record: AgentInvocationRecord | Omit<AgentInvocationRecord, "cursor">,
+): Omit<AgentInvocationRecord, "cursor" | "observations"> {
+  if ("cursor" in record) {
+    const { cursor: _cursor, observations: _observations, ...summary } = record
+    return summary
+  }
+  const { observations: _observations, ...summary } = record
+  return summary
+}
+
+export function searchableAgentInvocationText(
+  record: AgentInvocationRecord | Omit<AgentInvocationRecord, "cursor">,
+): string {
+  const summaryValues: SearchValues = {
+    characters: 0,
+    maximumCharacters: maximumSummarySearchCharacters,
+    values: new Set(),
+  }
+  const observationValues: SearchValues = {
+    characters: 0,
+    maximumCharacters: maximumObservationSearchCharacters,
+    values: new Set(),
+  }
+  appendContentStrings(searchableSummary(record), summaryValues, true)
+  for (const observation of record.observations) appendSearchableObservation(observation, observationValues)
+  return JSON.stringify([[...summaryValues.values], [...observationValues.values]]).toLowerCase()
+}

--- a/packages/agent/src/invocations/sqlite.ts
+++ b/packages/agent/src/invocations/sqlite.ts
@@ -475,6 +475,19 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
         }),
       }
     },
+    async listAgentNames() {
+      await initialize()
+      const result = await client.execute(`SELECT DISTINCT name FROM (
+        SELECT agent_name AS name FROM ${table} WHERE agent_name <> ''
+        UNION ALL
+        SELECT json_extract(record, '$.agentName') AS name FROM ${table}
+          WHERE agent_name IS NULL OR agent_name = ''
+      ) WHERE typeof(name) = 'text' AND name <> '' ORDER BY name`)
+      return result.rows.flatMap((row) => {
+        // doctor-disable-next-line typescript/strict/no-runtime-typeof -- LibSQL rows are external storage values, so validate the indexed Agent name before exposing it.
+        return typeof row.name === "string" ? [row.name] : []
+      })
+    },
     async release(id, claimId) {
       await write(async () => {
         await initialize()

--- a/packages/agent/src/invocations/sqlite.ts
+++ b/packages/agent/src/invocations/sqlite.ts
@@ -162,21 +162,27 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
       if (!missingSearch.rows.length) break
       const searchUpdates = missingSearch.rows.flatMap((row) => {
         backfillSequence = Math.max(backfillSequence, numberValue(row.sequence))
-        const record = deserialize(row.record, row.sequence)
-        return record
-          ? [{
-              args: [searchableAgentInvocationText(storedRecord(record)), searchVersion, numberValue(row.sequence)],
-              sql: `UPDATE ${table} SET search = ?, search_version = ? WHERE sequence = ?`,
-            }]
-          : []
+          const record = deserialize(row.record, row.sequence)
+          return record
+            ? [{
+                args: [
+                  searchableAgentInvocationText(storedRecord(record)),
+                  searchVersion,
+                  numberValue(row.sequence),
+                  searchVersion,
+                  String(row.record),
+                ],
+                sql: `UPDATE ${table} SET search = ?, search_version = ?
+                  WHERE sequence = ? AND search_version < ? AND record = ?`,
+              }]
+            : []
       })
       if (searchUpdates.length) await client.batch(searchUpdates, "write")
     }
   }
   const ensureSearchBackfill = () => {
-    if (!searchBackfill) searchBackfill = backfillSearch().catch((error) => {
+    if (!searchBackfill) searchBackfill = backfillSearch().finally(() => {
       searchBackfill = undefined
-      throw error
     })
     return searchBackfill
   }

--- a/packages/agent/src/invocations/sqlite.ts
+++ b/packages/agent/src/invocations/sqlite.ts
@@ -144,11 +144,44 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
   const maxAgeMs = retentionValue(options.maxAgeMs, defaultMaxAgeMs, "maxAgeMs", maximumDateMs)
   const maxRecords = retentionValue(options.maxRecords, defaultMaxRecords, "maxRecords")
   let initialized: Promise<void> | undefined
+  let searchBackfill: Promise<void> | undefined
   let writes = Promise.resolve()
   const write = <T>(operation: () => Promise<T>): Promise<T> => {
     const result = writes.then(operation, operation)
     writes = result.then(() => undefined, () => undefined)
     return result
+  }
+  const backfillSearch = async () => {
+    let backfillSequence = 0
+    while (true) {
+      const missingSearch = await client.execute({
+        args: [searchVersion, backfillSequence, backfillPageSize],
+        sql: `SELECT sequence, record FROM ${table}
+          WHERE (search IS NULL OR search_version < ?) AND sequence > ? ORDER BY sequence LIMIT ?`,
+      })
+      if (!missingSearch.rows.length) break
+      const searchUpdates = missingSearch.rows.flatMap((row) => {
+        backfillSequence = Math.max(backfillSequence, numberValue(row.sequence))
+        const record = deserialize(row.record, row.sequence)
+        return record
+          ? [{
+              args: [searchableAgentInvocationText(storedRecord(record)), searchVersion, numberValue(row.sequence)],
+              sql: `UPDATE ${table} SET search = ?, search_version = ? WHERE sequence = ?`,
+            }]
+          : []
+      })
+      if (searchUpdates.length) await client.batch(searchUpdates, "write")
+    }
+  }
+  const ensureSearchBackfill = () => {
+    if (!searchBackfill) searchBackfill = backfillSearch().catch((error) => {
+      searchBackfill = undefined
+      throw error
+    })
+    return searchBackfill
+  }
+  const startSearchBackfill = () => {
+    void ensureSearchBackfill().catch(() => undefined)
   }
   const initialize = async () => {
     if (!initialized) initialized = (async () => {
@@ -224,26 +257,6 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
       await client.execute(`CREATE INDEX IF NOT EXISTS ${table}_missing_updated_at_sequence
         ON ${table} (sequence) WHERE updated_at = '' OR updated_at IS NULL`)
       let backfillSequence = 0
-      while (true) {
-        const missingSearch = await client.execute({
-          args: [searchVersion, backfillSequence, backfillPageSize],
-          sql: `SELECT sequence, record FROM ${table}
-            WHERE (search IS NULL OR search_version < ?) AND sequence > ? ORDER BY sequence LIMIT ?`,
-        })
-        if (!missingSearch.rows.length) break
-        const searchBackfill = missingSearch.rows.flatMap((row) => {
-          backfillSequence = Math.max(backfillSequence, numberValue(row.sequence))
-          const record = deserialize(row.record, row.sequence)
-          return record
-            ? [{
-                args: [searchableAgentInvocationText(storedRecord(record)), searchVersion, numberValue(row.sequence)],
-                sql: `UPDATE ${table} SET search = ?, search_version = ? WHERE sequence = ?`,
-              }]
-            : []
-        })
-        if (searchBackfill.length) await client.batch(searchBackfill, "write")
-      }
-      backfillSequence = 0
       while (true) {
         const missingAgentNames = await client.execute({
           args: [backfillSequence, backfillPageSize],
@@ -322,6 +335,7 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
           SET claimed_at = CAST(unixepoch('subsec') * 1000 AS INTEGER), claim_token = lower(hex(randomblob(16)))
           WHERE id = NEW.id;
         END`)
+      startSearchBackfill()
     })().catch((error) => {
       initialized = undefined
       throw error
@@ -452,6 +466,7 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
       }
       const search = searchValue(listOptions.search)
       if (search) {
+        await ensureSearchBackfill()
         filters.push("search LIKE ? ESCAPE '\\'")
         args.push(`%${escapeLike(search.toLowerCase())}%`)
       }

--- a/packages/agent/src/invocations/sqlite.ts
+++ b/packages/agent/src/invocations/sqlite.ts
@@ -2,6 +2,7 @@ import { createClient } from "@libsql/client"
 
 import { hasRuntimeType } from "../internal/runtime-type.ts"
 import { applyAgentInvocationStoreUpdate } from "../invocations.ts"
+import { searchableAgentInvocationText } from "./search.ts"
 
 import type {
   AgentInvocationListOptions,
@@ -27,7 +28,7 @@ const defaultMaxAgeMs = 30 * 24 * 60 * 60 * 1000
 const defaultMaxRecords = 10_000
 const maximumDateMs = 8_640_000_000_000_000
 const backfillPageSize = 100
-const searchVersion = 2
+const searchVersion = 3
 const terminalStatuses = ["completed", "failed", "cancelled"] as const
 
 function tableName(prefix = "vitehub_agent_"): string {
@@ -73,10 +74,6 @@ function deserialize(value: unknown, cursor: unknown): AgentInvocationRecord | u
 function storedRecord(record: AgentInvocationRecord): Omit<AgentInvocationRecord, "cursor"> {
   const { cursor: _cursor, ...stored } = record
   return stored
-}
-
-function searchableRecord(record: Omit<AgentInvocationRecord, "cursor">): string {
-  return JSON.stringify(record).toLowerCase()
 }
 
 function agentNameRecord(record: Omit<AgentInvocationRecord, "cursor">): string {
@@ -239,7 +236,7 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
           const record = deserialize(row.record, row.sequence)
           return record
             ? [{
-                args: [searchableRecord(storedRecord(record)), searchVersion, numberValue(row.sequence)],
+                args: [searchableAgentInvocationText(storedRecord(record)), searchVersion, numberValue(row.sequence)],
                 sql: `UPDATE ${table} SET search = ?, search_version = ? WHERE sequence = ?`,
               }]
             : []
@@ -398,7 +395,7 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
           const statements = [
             ...prePrune,
             {
-              args: [input.id, input.status, agentNameRecord(input), searchableRecord(input), searchVersion, input.updatedAt, serialize(input)],
+              args: [input.id, input.status, agentNameRecord(input), searchableAgentInvocationText(input), searchVersion, input.updatedAt, serialize(input)],
               sql: `INSERT OR IGNORE INTO ${table} (id, status, agent_name, search, search_version, updated_at, record) VALUES (?, ?, ?, ?, ?, ?, ?)`,
             }
           ]
@@ -522,7 +519,7 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
               sql: `UPDATE ${table} SET search_version = -1 WHERE id = ?`,
             })
             await transaction.execute({
-              args: [updated.status, agentNameRecord(stored), searchableRecord(stored), searchVersion, updated.updatedAt, serialize(stored), id],
+              args: [updated.status, agentNameRecord(stored), searchableAgentInvocationText(stored), searchVersion, updated.updatedAt, serialize(stored), id],
               sql: `UPDATE ${table} SET status = ?, agent_name = ?, search = ?, search_version = ?, updated_at = ?, record = ? WHERE id = ?`,
             })
             if (updated.status === "completed" || updated.status === "failed" || updated.status === "cancelled") {

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -313,6 +313,10 @@ export interface AgentTelemetryConfiguration {
     version?: string
   }
   capabilities?: AgentTelemetryCapabilityMetadata[]
+  channels?: Array<{
+    id: string
+    kind: string
+  }>
   driver: {
     kind: AgentDriverKind
     model?: {

--- a/packages/agent/test/invocations-vue.test.ts
+++ b/packages/agent/test/invocations-vue.test.ts
@@ -188,6 +188,63 @@ describe("Agent Invocation Vue composables", () => {
     expect(resource.isLoading.value).toBe(false);
   });
 
+  it("requests and appends only observations after the latest sequence", async () => {
+    const { calls, request } = controlledRequester();
+    const scope = effectScope();
+    const resource = scope.run(() =>
+      useAgentInvocation("inv-1", { immediate: false, request }),
+    )!;
+
+    const initial = resource.refresh();
+    expect(calls[0]!.path).toBe("/api/invocations/inv-1");
+    calls[0]!.resolve({
+      invocation: record("inv-1"),
+      observationCursor: "cursor-1",
+      observations: [observation(1)],
+    } satisfies AgentInvocationDetailResult);
+    await initial;
+
+    const poll = resource.refresh();
+    expect(calls[1]!.path).toBe(
+      "/api/invocations/inv-1?observationCount=1&observationCursor=cursor-1",
+    );
+    calls[1]!.resolve({
+      appendObservations: true,
+      invocation: record("inv-1"),
+      observationCursor: "cursor-2",
+      observations: [observation(2)],
+    } satisfies AgentInvocationDetailResult);
+    await poll;
+
+    expect(resource.observations.value).toEqual([observation(1), observation(2)]);
+    scope.stop();
+  });
+
+  it("loads a full detail when the invocation endpoint changes", async () => {
+    const { calls, request } = controlledRequester();
+    const baseURL = ref("/first/invocations");
+    const scope = effectScope();
+    const resource = scope.run(() => useAgentInvocation("inv-1", { baseURL, request }))!;
+
+    calls[0]!.resolve({
+      invocation: record("inv-1"),
+      observations: [observation(1)],
+    } satisfies AgentInvocationDetailResult);
+    await settle();
+
+    baseURL.value = "/second/invocations";
+    await nextTick();
+    expect(calls[1]!.path).toBe("/second/invocations/inv-1");
+    calls[1]!.resolve({
+      invocation: record("inv-1"),
+      observations: [observation(10)],
+    } satisfies AgentInvocationDetailResult);
+    await settle();
+
+    expect(resource.observations.value).toEqual([observation(10)]);
+    scope.stop();
+  });
+
   it("does not paginate while refreshing the first page", async () => {
     const { calls, request } = controlledRequester();
     const scope = effectScope();

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -3866,6 +3866,105 @@ describe("Agent Invocations", () => {
     }
   })
 
+  it("keeps ordinary libSQL reads available while compact search backfills", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "vitehub-agent-invocations-background-search-"))
+    const client = createClient({ url: `file:${join(directory, "invocations.sqlite")}` })
+    let releaseBackfill: (() => void) | undefined
+    try {
+      await client.execute(`CREATE TABLE vitehub_agent_invocations (
+        sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+        id TEXT NOT NULL UNIQUE,
+        status TEXT NOT NULL,
+        agent_name TEXT NOT NULL DEFAULT '',
+        search TEXT,
+        search_version INTEGER NOT NULL DEFAULT 0,
+        updated_at TEXT NOT NULL DEFAULT '',
+        record TEXT NOT NULL
+      )`)
+      const timestamp = "2026-01-01T00:00:00.000Z"
+      const record = {
+        agentName: "review",
+        createdAt: timestamp,
+        id: "legacy-search-v2",
+        observations: [{
+          attributes: { "message.content": "Legacy searchable message" },
+          name: "agent.message",
+          sequence: 1,
+          timestamp,
+          type: "run",
+        }],
+        status: "completed",
+        traceId: "legacy-search-v2-trace",
+        updatedAt: timestamp,
+      }
+      await client.execute({
+        args: [record.id, record.status, record.agentName, JSON.stringify(record).toLowerCase(), 2, timestamp, JSON.stringify(record)],
+        sql: `INSERT INTO vitehub_agent_invocations
+          (id, status, agent_name, search, search_version, updated_at, record)
+          VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      })
+
+      let markBackfillStarted!: () => void
+      const backfillStarted = new Promise<void>((resolve) => {
+        markBackfillStarted = resolve
+      })
+      const backfillReleased = new Promise<void>((resolve) => {
+        releaseBackfill = resolve
+      })
+      // SAFETY: The proxy forwards every Client member and only pauses the v3 search-backfill query.
+      const stalledClient = new Proxy(client, {
+        get(target, property) {
+          const value = Reflect.get(target, property)
+          if (property !== "execute") return value instanceof Function ? value.bind(target) : value
+          return async (...args: unknown[]) => {
+            const input = args[0]
+            const sql = input !== null && hasRuntimeType(input, "object") && "sql" in input && hasRuntimeType(input.sql, "string")
+              ? input.sql
+              : ""
+            if (sql.includes("search_version < ?")) {
+              markBackfillStarted()
+              await backfillReleased
+            }
+            // SAFETY: The proxy receives Client.execute arguments and forwards them unchanged.
+            return await (client.execute as (...executeArgs: unknown[]) => Promise<unknown>)(...args)
+          }
+        },
+      }) as Client
+      const store = createLibsqlAgentInvocationStore({ client: stalledClient, maxAgeMs: false, maxRecords: false })
+      const ordinaryReads = Promise.all([
+        store.get("legacy-search-v2"),
+        store.list(),
+        store.listAgentNames!(),
+      ])
+
+      await backfillStarted
+      await expect(ordinaryReads).resolves.toEqual([
+        expect.objectContaining({ id: "legacy-search-v2" }),
+        { invocations: [expect.objectContaining({ id: "legacy-search-v2" })] },
+        ["review"],
+      ])
+      let searchSettled = false
+      const search = Promise.resolve(store.list({ search: "legacy searchable message" }))
+      void search.then(() => {
+        searchSettled = true
+      }, () => {
+        searchSettled = true
+      })
+      await Promise.resolve()
+      expect(searchSettled).toBe(false)
+
+      releaseBackfill?.()
+      await expect(search).resolves.toEqual({
+        invocations: [expect.objectContaining({ id: "legacy-search-v2" })],
+      })
+    }
+    finally {
+      releaseBackfill?.()
+      client.close()
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
   it("filters old-shape writes in fresh libSQL journals", async () => {
     const directory = await mkdtemp(join(tmpdir(), "vitehub-agent-invocations-fresh-overlap-"))
     const client = createClient({ url: `file:${join(directory, "invocations.sqlite")}` })
@@ -3982,7 +4081,7 @@ describe("Agent Invocations", () => {
       })
       const store = createLibsqlAgentInvocationStore({ client: flakyClient })
 
-      await expect(store.list()).rejects.toThrow("migration interrupted")
+      await expect(store.list({ search: "repository-204" })).rejects.toThrow("migration interrupted")
       const committed = await client.execute("SELECT count(*) AS count FROM vitehub_agent_invocations WHERE search IS NOT NULL")
       expect(Number(committed.rows[0]?.count)).toBe(100)
 

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -554,6 +554,29 @@ describe("Agent Invocations", () => {
     }
   })
 
+  it("lists Agent names through every page for stores without an optimized index", async () => {
+    const memory = createMemoryAgentInvocationStore()
+    const timestamp = new Date().toISOString()
+    for (let index = 0; index < 101; index++) {
+      const agentName = index % 3 === 0 ? " beta " : index % 3 === 1 ? "alpha" : undefined
+      await memory.create({
+        ...(agentName ? { agentName } : {}),
+        createdAt: timestamp,
+        id: `fallback-${index}`,
+        observations: [],
+        status: "completed",
+        traceId: `fallback-${index}-trace`,
+        updatedAt: timestamp,
+      })
+    }
+    const { listAgentNames: _listAgentNames, ...fallback } = memory
+    const list = vi.fn(fallback.list)
+
+    await expect(defineAgentInvocations({ store: { ...fallback, list } }).listAgentNames())
+      .resolves.toEqual(["alpha", "beta"])
+    expect(list).toHaveBeenCalledTimes(2)
+  })
+
   it("does not let a stalled store block Agent execution", async () => {
     const memory = createMemoryAgentInvocationStore()
     const invocations = defineAgentInvocations({
@@ -1137,6 +1160,41 @@ describe("Agent Invocations", () => {
     expect(configured?.attributes?.["vitehub.agent.configurationTruncated"]).toBe(true)
   })
 
+  it("preserves sanitized Agent configuration depth and indexes its resolved model", async () => {
+    const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
+    const journal = await bindAgentInvocations(invocations, runtime("nested-configuration"))
+    if (!journal) throw new Error("Expected the invocation journal to be configured.")
+    await journal.context.traceLog?.append({
+      attributes: {
+        "vitehub.agent.configuration": {
+          capabilities: [{ id: "otlp", metadata: { signals: ["traces"] } }],
+          driver: { kind: "provider", model: { id: "gpt-5.6-sol", provider: "codex" } },
+          runtime: { name: "ViteHub" },
+        },
+      },
+      name: "vitehub.agent.configured",
+      type: "run",
+    })
+    await journal.finish("completed")
+
+    const record = await invocations.getByRunId("nested-configuration")
+    const configured = record?.observations.findLast(entry => entry.name === "vitehub.agent.configured")
+    expect(configured?.attributes).not.toHaveProperty("vitehub.agent.configurationTruncated")
+    expect(configured?.attributes?.["vitehub.agent.configuration"]).toMatchObject({
+      capabilities: [{ id: "otlp", metadata: { signals: ["traces"] } }],
+    })
+    expect(record?.annotations).toMatchObject({
+      "agent.model.id": "gpt-5.6-sol",
+      "agent.model.provider": "codex",
+    })
+    await expect(invocations.list()).resolves.toMatchObject({
+      invocations: [{ annotations: {
+        "agent.model.id": "gpt-5.6-sol",
+        "agent.model.provider": "codex",
+      } }],
+    })
+  })
+
   it("marks bounded ordinary observations as truncated", async () => {
     const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
     const journal = await bindAgentInvocations(invocations, runtime("bounded-ordinary-observation"))
@@ -1515,6 +1573,7 @@ describe("Agent Invocations", () => {
     const { MockLanguageModelV3 } = await import("ai/test")
     const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
     const agent = defineAgent({
+      channels: { reviews: { kind: "github" } },
       driver: {
         instructions: "Sensitive resolved instructions",
         model: new MockLanguageModelV3({
@@ -1544,6 +1603,9 @@ describe("Agent Invocations", () => {
       },
     })
     expect(configured?.attributes?.["vitehub.agent.configuration"]).not.toHaveProperty("instructions")
+    expect(configured?.attributes?.["vitehub.agent.configuration"]).toMatchObject({
+      channels: [{ id: "reviews", kind: "github" }],
+    })
   })
 
   it("persists resolved instructions when invocation content is enabled", async () => {

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -1162,7 +1162,13 @@ describe("Agent Invocations", () => {
 
   it("preserves sanitized Agent configuration depth and indexes its resolved model", async () => {
     const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
-    const journal = await bindAgentInvocations(invocations, runtime("nested-configuration"))
+    const saturatedAnnotations = Object.fromEntries(
+      Array.from({ length: 32 }, (_, index) => [`custom.${index}`, index]),
+    )
+    const journal = await bindAgentInvocations(
+      invocations,
+      runtime("nested-configuration", saturatedAnnotations),
+    )
     if (!journal) throw new Error("Expected the invocation journal to be configured.")
     await journal.context.traceLog?.append({
       attributes: {
@@ -1187,6 +1193,7 @@ describe("Agent Invocations", () => {
       "agent.model.id": "gpt-5.6-sol",
       "agent.model.provider": "codex",
     })
+    expect(Object.keys(record?.annotations || {})).toHaveLength(32)
     await expect(invocations.list()).resolves.toMatchObject({
       invocations: [{ annotations: {
         "agent.model.id": "gpt-5.6-sol",

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -3273,6 +3273,117 @@ describe("Agent Invocations", () => {
     }
   })
 
+  it("stores a compact searchable SQLite projection without raw tool payloads", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "vitehub-agent-invocation-search-projection-"))
+    const client = createClient({ url: `file:${join(directory, "invocations.sqlite")}` })
+    const store = createLibsqlAgentInvocationStore({ client, maxAgeMs: false, maxRecords: false })
+    const timestamp = "2026-01-01T00:00:00.000Z"
+    const bulkyToolPayload = `raw-tool-payload-${"x".repeat(512 * 1024)}`
+    try {
+      await store.create({
+        agentName: "babysitter",
+        annotations: { "github.repository": "vite-hub/vitehub" },
+        createdAt: timestamp,
+        id: "compact-search",
+        observations: [{
+          attributes: {
+            "input.messages": [{ content: "Investigate the slow session picker", role: "user" }],
+            "message.content": "The selected session now opens quickly.",
+            "tool.name": "shell",
+            "tool.output": { content: bulkyToolPayload },
+            "vitehub.activity.body": bulkyToolPayload,
+          },
+          name: "agent.message",
+          sequence: 1,
+          timestamp,
+          type: "run",
+        }],
+        status: "completed",
+        traceId: "compact-search-trace",
+        updatedAt: timestamp,
+      })
+
+      await expect(store.list({ search: "selected session now opens" })).resolves.toMatchObject({
+        invocations: [expect.objectContaining({ id: "compact-search" })],
+      })
+      await expect(store.list({ search: "slow session picker" })).resolves.toMatchObject({
+        invocations: [expect.objectContaining({ id: "compact-search" })],
+      })
+      await expect(store.list({ search: "raw-tool-payload" })).resolves.toEqual({ invocations: [] })
+      await expect(store.list({ search: "vite-hub/vitehub" })).resolves.toMatchObject({
+        invocations: [expect.objectContaining({ id: "compact-search" })],
+      })
+      const indexed = await client.execute(`SELECT length(record) AS record_bytes,
+        length(search) AS search_bytes, search, search_version
+        FROM vitehub_agent_invocations WHERE id = 'compact-search'`)
+      expect(Number(indexed.rows[0]?.search_version)).toBe(3)
+      expect(Number(indexed.rows[0]?.search_bytes)).toBeLessThan(Number(indexed.rows[0]?.record_bytes) / 100)
+      expect(String(indexed.rows[0]?.search)).not.toContain("raw-tool-payload")
+    }
+    finally {
+      client.close()
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
+  it("rebuilds version-two SQLite search rows with the compact projection", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "vitehub-agent-invocation-search-v3-migration-"))
+    const client = createClient({ url: `file:${join(directory, "invocations.sqlite")}` })
+    const timestamp = "2026-01-01T00:00:00.000Z"
+    const bulkyToolPayload = `legacy-tool-payload-${"x".repeat(256 * 1024)}`
+    const record = {
+      agentName: "review",
+      createdAt: timestamp,
+      id: "legacy-search-v2",
+      observations: [{
+        attributes: {
+          "message.content": "Legacy searchable message",
+          "tool.output": bulkyToolPayload,
+        },
+        name: "agent.message",
+        sequence: 1,
+        timestamp,
+        type: "run",
+      }],
+      status: "completed",
+      traceId: "legacy-search-v2-trace",
+      updatedAt: timestamp,
+    }
+    try {
+      await client.execute(`CREATE TABLE vitehub_agent_invocations (
+        sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+        id TEXT NOT NULL UNIQUE,
+        status TEXT NOT NULL,
+        agent_name TEXT NOT NULL DEFAULT '',
+        search TEXT,
+        search_version INTEGER NOT NULL DEFAULT 0,
+        updated_at TEXT NOT NULL DEFAULT '',
+        record TEXT NOT NULL
+      )`)
+      await client.execute({
+        args: [record.id, record.status, record.agentName, JSON.stringify(record).toLowerCase(), 2, timestamp, JSON.stringify(record)],
+        sql: `INSERT INTO vitehub_agent_invocations
+          (id, status, agent_name, search, search_version, updated_at, record)
+          VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      })
+
+      const store = createLibsqlAgentInvocationStore({ client, maxAgeMs: false, maxRecords: false })
+      await expect(store.list({ search: "legacy searchable message" })).resolves.toMatchObject({
+        invocations: [expect.objectContaining({ id: "legacy-search-v2" })],
+      })
+      await expect(store.list({ search: "legacy-tool-payload" })).resolves.toEqual({ invocations: [] })
+      const migrated = await client.execute(`SELECT length(record) AS record_bytes,
+        length(search) AS search_bytes, search_version
+        FROM vitehub_agent_invocations WHERE id = 'legacy-search-v2'`)
+      expect(Number(migrated.rows[0]?.search_version)).toBe(3)
+      expect(Number(migrated.rows[0]?.search_bytes)).toBeLessThan(Number(migrated.rows[0]?.record_bytes) / 100)
+    }
+    finally {
+      client.close()
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
   it("omits SQLite observation payloads before reading list rows", async () => {
     const directory = await mkdtemp(join(tmpdir(), "vitehub-agent-invocation-summaries-"))
     const client = createClient({ url: `file:${join(directory, "invocations.sqlite")}` })

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -516,6 +516,44 @@ describe("Agent Invocations", () => {
     })
   })
 
+  it("lists distinct Agent names without paging through invocation summaries", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "vitehub-agent-names-"))
+    const client = createClient({ url: `file:${join(directory, "invocations.sqlite")}` })
+    const stores = [createMemoryAgentInvocationStore(), createLibsqlAgentInvocationStore({ client })]
+    const timestamp = new Date().toISOString()
+    try {
+      for (const [index, store] of stores.entries()) {
+        for (const [record, agentName] of ["review", "support", "review", "legacy"].entries()) {
+          await store.create({
+            agentName,
+            createdAt: timestamp,
+            id: `${index}-${record}`,
+            observations: [],
+            status: "completed",
+            traceId: `${index}-${record}-trace`,
+            updatedAt: timestamp,
+          })
+        }
+        if (index === 1) {
+          await client.execute({
+            args: [`${index}-3`],
+            sql: "UPDATE vitehub_agent_invocations SET agent_name = '' WHERE id = ?",
+          })
+        }
+
+        await expect(defineAgentInvocations({ store }).listAgentNames()).resolves.toEqual([
+          "legacy",
+          "review",
+          "support",
+        ])
+      }
+    }
+    finally {
+      client.close()
+      await rm(directory, { force: true, recursive: true })
+    }
+  })
+
   it("does not let a stalled store block Agent execution", async () => {
     const memory = createMemoryAgentInvocationStore()
     const invocations = defineAgentInvocations({

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -3992,7 +3992,9 @@ describe("Agent Invocations", () => {
       await expect(store.list({ agentName: "review" })).resolves.toMatchObject({
         invocations: [expect.objectContaining({ id: "fresh-overlapping-legacy-writer" })],
       })
-      await expect(store.list({ search: "fresh observation-only" })).resolves.toEqual({ invocations: [] })
+      await expect(store.list({ search: "fresh observation-only" })).resolves.toMatchObject({
+        invocations: [expect.objectContaining({ id: "fresh-overlapping-legacy-writer" })],
+      })
       await expect(createLibsqlAgentInvocationStore({ client, maxAgeMs: false, maxRecords: false }).list({ search: "fresh observation-only" }))
         .resolves.toMatchObject({ invocations: [expect.objectContaining({ id: "fresh-overlapping-legacy-writer" })] })
 
@@ -4023,7 +4025,9 @@ describe("Agent Invocations", () => {
       )
       expect(overlappingUpdate.rows[0]?.status).toBe("completed")
       expect(overlappingUpdate.rows[0]?.updated_at).toBe("2026-01-01T00:02:00.000Z")
-      await expect(store.list({ search: "updated observation-only" })).resolves.toEqual({ invocations: [] })
+      await expect(store.list({ search: "updated observation-only" })).resolves.toMatchObject({
+        invocations: [expect.objectContaining({ id: "fresh-overlapping-legacy-writer" })],
+      })
       await expect(createLibsqlAgentInvocationStore({ client, maxAgeMs: false, maxRecords: false }).list({ search: "updated observation-only" }))
         .resolves.toMatchObject({ invocations: [expect.objectContaining({ id: "fresh-overlapping-legacy-writer" })] })
     }

--- a/packages/ui/src/components/agent-invocation-list.ts
+++ b/packages/ui/src/components/agent-invocation-list.ts
@@ -158,9 +158,9 @@ export const AgentInvocationList = defineComponent({
     const groups = computed(() => {
       const sorted = sortInvocationItems(props.items);
       return [
-        { collapsible: false, items: sorted.filter(item => item.status === "running"), key: "working", label: "Working" },
-        { collapsible: true, defaultOpen: true, items: sorted.filter(item => item.status === "pending"), key: "queued", label: "Queued" },
-        { collapsible: true, defaultOpen: false, items: sorted.filter(item => item.status !== "running" && item.status !== "pending"), key: "done", label: "Done" },
+        { collapsible: false, hasMore: props.hasMore && props.remainingStatuses.includes("running"), items: sorted.filter(item => item.status === "running"), key: "working", label: "Working" },
+        { collapsible: true, defaultOpen: true, hasMore: props.hasMore && props.remainingStatuses.includes("pending"), items: sorted.filter(item => item.status === "pending"), key: "queued", label: "Queued" },
+        { collapsible: true, defaultOpen: false, hasMore: props.hasMore && props.remainingStatuses.some(status => status !== "running" && status !== "pending"), items: sorted.filter(item => item.status !== "running" && item.status !== "pending"), key: "done", label: "Done" },
       ].filter(group => group.items.length > 0);
     });
     const visibleItems = computed(() => props.items.filter((item) => {
@@ -266,9 +266,9 @@ export const AgentInvocationList = defineComponent({
     const renderGroupHeading = (group: (typeof groups.value)[number]) => [
       h("span", { class: "vh-invocation-list__group-label" }, group.label),
       h("span", {
-        "aria-label": `${group.items.length} ${group.items.length === 1 ? "session" : "sessions"}`,
+        "aria-label": `${group.hasMore ? "At least " : ""}${group.items.length} ${group.items.length === 1 ? "session" : "sessions"}${group.hasMore ? "; more available" : ""}`,
         class: "vh-invocation-list__group-count",
-      }, String(group.items.length)),
+      }, `${group.items.length}${group.hasMore ? "+" : ""}`),
     ];
     const renderGroup = (group: (typeof groups.value)[number]) => group.collapsible
       ? h("details", {

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -906,6 +906,14 @@ function renderConfiguration(configuration: AgentInvocationConfiguration) {
     configuration.workspace?.sources?.length
       ? inspectorCollection("Sources", configuration.workspace.sources)
       : null,
+    configuration.channels?.length
+      ? inspectorCollection(
+          "Channels",
+          configuration.channels.map((channel) =>
+            channel.id === channel.kind ? channel.id : `${channel.id} · ${channel.kind}`,
+          ),
+        )
+      : null,
     configuration.capabilities?.length
       ? h("div", { class: "vh-invocation-inspector__group" }, [
           h("div", { class: "vh-invocation-inspector__group-heading" }, [
@@ -1343,6 +1351,9 @@ export const AgentInvocationInspector = defineComponent({
                 ? h("div", { class: "vh-invocation-inspector__agent" }, [
                     h("span", "Agent"),
                     h("code", agentName),
+                    configuration?.agent?.version
+                      ? h("small", `v${configuration.agent.version}`)
+                      : null,
                   ])
                 : null,
               props.invocation.error

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -1022,6 +1022,8 @@ function renderWorkSummary(
   activities: readonly InvocationActivity[],
   invocation: AgentInvocationView,
   expanded: ReadonlySet<string>,
+  open: boolean,
+  setOpen: (open: boolean) => void,
   toggleExpanded: (id: string) => void,
   inspect: (target: InspectTarget) => void,
 ) {
@@ -1029,13 +1031,20 @@ function renderWorkSummary(
   const endedAt = invocation.completedAt ?? invocation.failedAt ?? invocation.cancelledAt ?? invocation.updatedAt;
   const duration = formatDuration(invocation.startedAt, endedAt);
   return h("li", { class: "vh-invocation-work", key: "invocation-work" }, [
-    h("details", { class: "vh-invocation-work__details" }, [
+    h("details", {
+      class: "vh-invocation-work__details",
+      // SAFETY: DOM toggle events for this details element expose HTMLDetailsElement as currentTarget.
+      onToggle: (event: Event) => setOpen((event.currentTarget as HTMLDetailsElement).open),
+      open,
+    }, [
       h("summary", { class: "vh-invocation-work__summary" }, [
         h("span", { class: "vh-invocation-work__title" }, duration ? `Worked for ${duration}` : "Work details"),
         renderChevronDown("vh-invocation-work__disclosure"),
       ]),
       h("div", { "aria-hidden": "true", class: "vh-invocation-work__divider" }),
-      h("ol", { class: "vh-invocation-work__activities" }, renderActivitySequence(activities, invocation, expanded, toggleExpanded, inspect)),
+      open
+        ? h("ol", { class: "vh-invocation-work__activities" }, renderActivitySequence(activities, invocation, expanded, toggleExpanded, inspect))
+        : null,
     ]),
   ]);
 }
@@ -1044,6 +1053,8 @@ function renderInvocationActivities(
   activities: readonly InvocationActivity[],
   invocation: AgentInvocationView,
   expanded: ReadonlySet<string>,
+  workOpen: boolean,
+  setWorkOpen: (open: boolean) => void,
   toggleExpanded: (id: string) => void,
   inspect: (target: InspectTarget) => void,
 ) {
@@ -1089,7 +1100,7 @@ function renderInvocationActivities(
   return [
     ...renderActivitySequence(prefix, invocation, expanded, toggleExpanded, inspect),
     ...renderActivitySequence(visibleBeforeFinal, invocation, expanded, toggleExpanded, inspect),
-    renderWorkSummary(work, invocation, expanded, toggleExpanded, inspect),
+    renderWorkSummary(work, invocation, expanded, workOpen, setWorkOpen, toggleExpanded, inspect),
     ...(lastAssistant >= 0 ? [renderInvocationActivity(activities[lastAssistant]!, expanded, toggleExpanded, inspect)] : []),
     ...renderActivitySequence(visibleAfterFinal, invocation, expanded, toggleExpanded, inspect),
     ...renderActivitySequence(terminal, invocation, expanded, toggleExpanded, inspect),
@@ -1109,6 +1120,7 @@ export const AgentInvocation = defineComponent({
   setup(props, { emit, slots }) {
     const activities = computed(() => invocationActivities(props.invocation));
     const expandedMessages = ref<ReadonlySet<string>>(new Set());
+    const workOpen = ref(false);
     const root = ref<HTMLElement>();
     let selectedElement: HTMLElement | undefined;
 
@@ -1127,6 +1139,7 @@ export const AgentInvocation = defineComponent({
     }
 
     async function focusActivity(id: string | undefined) {
+      if (id) workOpen.value = true;
       await nextTick();
       const target = [...(root.value?.querySelectorAll<HTMLElement>("[data-activity-id]") ?? [])]
         .find(element => element.dataset.activityId === id);
@@ -1148,6 +1161,9 @@ export const AgentInvocation = defineComponent({
     }
 
     watch([() => props.selectedActivityId, activities], ([id]) => void focusActivity(id), { flush: "post", immediate: true });
+    watch(() => props.invocation.id, () => {
+      workOpen.value = false;
+    });
     onBeforeUnmount(clearSelectedElement);
 
     return () => {
@@ -1182,6 +1198,8 @@ export const AgentInvocation = defineComponent({
               activities.value,
               props.invocation,
               expandedMessages.value,
+              workOpen.value,
+              open => workOpen.value = open,
               toggleExpanded,
               target => emit("inspect", target),
             ))]),

--- a/packages/ui/src/invocation-display.ts
+++ b/packages/ui/src/invocation-display.ts
@@ -31,7 +31,13 @@ export function agentInvocationContext(source: AgentInvocationDisplaySource): st
   if (repository && (typeof pullRequest === "string" || typeof pullRequest === "number")) {
     return `${repository} · PR #${pullRequest}`;
   }
-  return source.threadId ?? source.origin ?? source.channelId ?? source.id;
+  return (
+    annotation(source, "triggeredBy") ??
+    source.threadId ??
+    source.origin ??
+    source.channelId ??
+    source.id
+  );
 }
 
 export function agentInvocationProject(source: AgentInvocationDisplaySource): string {

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -47,6 +47,10 @@ export interface AgentInvocationConfiguration {
     id: string;
     metadata?: Readonly<Record<string, AgentInspectionValue>>;
   }[];
+  channels?: readonly {
+    id: string;
+    kind: string;
+  }[];
   driver?: {
     kind?: string;
     model?: {

--- a/packages/ui/test/invocation-display.test.ts
+++ b/packages/ui/test/invocation-display.test.ts
@@ -40,6 +40,16 @@ describe("Agent Invocation display", () => {
     expect(agentInvocationContext({ channelId: "telegram", id: "invocation-2" })).toBe("telegram");
   });
 
+  it("shows the invoking user when no repository context is available", () => {
+    expect(
+      agentInvocationContext({
+        annotations: { triggeredBy: "Maxi" },
+        id: "invocation-4",
+        threadId: "thread-4",
+      }),
+    ).toBe("Maxi");
+  });
+
   it("rejects unsafe external links", () => {
     expect(
       agentInvocationExternalUrl({

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -184,6 +184,23 @@ describe("Agent Invocation UI", () => {
     ]);
   });
 
+  it("marks lifecycle counts as partial while older matching sessions remain", () => {
+    const wrapper = mount(AgentInvocationList, {
+      props: {
+        hasMore: true,
+        items: [
+          { id: "working", status: "running", title: "Working" },
+          { id: "done", status: "completed", title: "Done" },
+        ],
+        remainingStatuses: ["completed"],
+      },
+    });
+
+    const counts = wrapper.findAll(".vh-invocation-list__group-count");
+    expect(counts.map(count => count.text())).toEqual(["1", "1+"]);
+    expect(counts[1]!.attributes("aria-label")).toBe("At least 1 session; more available");
+  });
+
   it("reveals the selected terminal session", () => {
     const wrapper = mount(AgentInvocationList, {
       props: {
@@ -574,7 +591,7 @@ describe("Agent Invocation UI", () => {
     expect(wrapper.get(".vh-invocation-message__more").text()).toBe("Show less");
   });
 
-  it("groups terminal work while keeping external effects and the final answer visible", () => {
+  it("groups terminal work while keeping external effects and the final answer visible", async () => {
     const timestamp = "2026-08-22T00:00:00.000Z";
     const invocation = {
       cancelledAt: "2026-08-22T00:00:05.000Z",
@@ -620,6 +637,11 @@ describe("Agent Invocation UI", () => {
     expect(rows[1]!.attributes("data-kind")).toBe("delivery");
     expect(rows[2]!.attributes("data-kind")).toBe("delivery");
     expect(wrapper.findAll(".vh-invocation-work")).toHaveLength(1);
+    expect(wrapper.find(".vh-invocation-work__activities").exists()).toBe(false);
+    const work = wrapper.get(".vh-invocation-work__details");
+    if (!(work.element instanceof HTMLDetailsElement)) throw new TypeError("Expected work details");
+    work.element.open = true;
+    await work.trigger("toggle");
     expect(wrapper.get(".vh-invocation-work__activities").text()).toContain("Shell");
     expect(wrapper.get(".vh-invocation-work__activities").text()).toContain("Verify");
     expect(rows[4]!.text()).toContain("Done.");
@@ -627,7 +649,7 @@ describe("Agent Invocation UI", () => {
     expect(rows[2]!.get(".vh-invocation-delivery__body").text()).toBe("The Telegram reply body.");
   });
 
-  it("keeps adjacent completed lifecycle activities grouped", () => {
+  it("keeps adjacent completed lifecycle activities grouped", async () => {
     const timestamp = "2026-08-22T00:00:00.000Z";
     const invocation = {
       createdAt: timestamp,
@@ -642,6 +664,10 @@ describe("Agent Invocation UI", () => {
       updatedAt: timestamp,
     } satisfies AgentInvocationView;
     const wrapper = mount(AgentInvocation, { props: { invocation } });
+    const work = wrapper.get(".vh-invocation-work__details");
+    if (!(work.element instanceof HTMLDetailsElement)) throw new TypeError("Expected work details");
+    work.element.open = true;
+    await work.trigger("toggle");
 
     expect(wrapper.findAll(".vh-invocation-lifecycle")).toHaveLength(1);
     expect(wrapper.findAll(".vh-invocation-lifecycle li")).toHaveLength(2);
@@ -2218,6 +2244,12 @@ describe("Agent Invocation UI", () => {
     expect(prompt.get(".vh-invocation-message__content").attributes("data-collapsed")).toBeUndefined();
 
     expect(wrapper.get(".vh-invocation-work__title").text()).toBe("Worked for 2m 43s");
+    expect(wrapper.find(".vh-invocation-work__activities").exists()).toBe(false);
+    const work = wrapper.get(".vh-invocation-work__details");
+    if (!(work.element instanceof HTMLDetailsElement)) throw new TypeError("Expected work details");
+    work.element.open = true;
+    await work.trigger("toggle");
+    expect(wrapper.get(".vh-invocation-work__activities").text()).toContain("Checked the diff.");
     expect(wrapper.get('.vh-invocation-message[data-role="assistant"]').text()).toContain("Merged after checks passed.");
     expect(wrapper.get('.vh-invocation-lifecycle[data-activity-group="github-lifecycle"] .vh-invocation-lifecycle__emoji').text()).toBe("👀");
   });

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -2546,8 +2546,9 @@ describe("Agent Invocation UI", () => {
   it("groups recorded Agent Definition details as captured setup", () => {
     const invocation: AgentInvocationView = {
       configuration: {
-        agent: { name: "babysitter" },
+        agent: { name: "babysitter", version: "2" },
         capabilities: [{ id: "github" }],
+        channels: [{ id: "reviews", kind: "github" }],
         driver: { kind: "provider", model: { id: "gpt-5.6-sol", provider: "openai" } },
         instructions: ["Follow repository instructions."],
         runtime: { name: "node" },
@@ -2566,6 +2567,8 @@ describe("Agent Invocation UI", () => {
     expect(wrapper.get(".vh-invocation-inspector__content").text()).toContain("gpt-5.6-sol");
     expect(wrapper.get(".vh-invocation-inspector__content").text()).toContain("openai");
     expect(wrapper.get(".vh-invocation-inspector__content").text()).toContain("node");
+    expect(wrapper.get(".vh-invocation-inspector__agent").text()).toContain("v2");
+    expect(wrapper.get(".vh-invocation-inspector__groups").text()).toContain("reviews · github");
     expect(wrapper.findAll(".vh-invocation-inspector__content > section h4").map(node => node.text())).toContain("Captured setup");
     expect(wrapper.get(".vh-invocation-inspector__groups").text()).toContain("Instructions");
   });

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -55,7 +55,6 @@ const selectedAgentName = ref(initialAgentParam?.trim() ? initialAgentParam : un
 const agentNames = ref<string[]>([]);
 const agentsLoading = ref(true);
 const agentsError = ref<unknown>();
-const paginationRetryRevision = ref(0);
 const nowMs = ref(Date.now());
 const sessionsOpen = ref(false);
 const sessionsCollapsed = ref(false);
@@ -130,7 +129,6 @@ const invocationItems = computed<AgentInvocationListItem[]>(() =>
     updatedAt: invocation.updatedAt || invocation.startedAt || invocation.createdAt,
   })),
 );
-const invocationPaginationKey = computed(() => paginationRetryRevision.value);
 const hasMultipleAgents = computed(() => agentNames.value.length > 1);
 const selectedAgentLabel = computed(
   () => selectedAgentName.value || (agentsLoading.value ? "Loading agents" : "Agents"),
@@ -406,10 +404,6 @@ function inspectSession(target: "agent" | "workspace"): void {
   detailsOpen.value = true;
 }
 
-function retryPagination(): void {
-  paginationRetryRevision.value++;
-}
-
 function statusIcon(status: AgentInvocationListItem["status"]): string {
   if (status === "running") return "i-ph-circle-notch-light";
   if (status === "completed") return "i-ph-check-light";
@@ -643,7 +637,7 @@ onBeforeUnmount(() => {
             size="sm"
             variant="soft"
             :loading="list.isLoadingMore.value"
-            @click="retryPagination"
+            @click="list.loadMore"
           />
         </div>
         <div
@@ -685,7 +679,6 @@ onBeforeUnmount(() => {
           :loading="list.isLoading.value || list.isLoadingMore.value"
           :remaining-statuses="list.remainingStatuses.value"
           :now="nowMs"
-          :retry-key="invocationPaginationKey"
           :selected-id="selectedInvocationId"
           @select="selectInvocation($event)"
         >

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -30,6 +30,7 @@ import ConsoleFrame from "./console-frame.vue";
 import ConsolePrimitiveSwitcher from "./console-primitive-switcher.vue";
 import ConsoleHealth from "./console-health.vue";
 import ConsoleMark from "./console-mark.vue";
+import ConsoleSessionNavbar from "./console-session-navbar.vue";
 import ConsoleSessionInspector from "./console-session-inspector.vue";
 import ConsoleSearch from "./console-search.vue";
 import ConsoleUsage from "./console-usage.vue";
@@ -74,18 +75,28 @@ let clock: ReturnType<typeof setInterval> | undefined;
 let media: MediaQueryList | undefined;
 let agentsRequest: AbortController | undefined;
 let capabilitiesRequest: AbortController | undefined;
+let initialListPending = !selectedAgentName.value;
 const listPollInterval = computed(() => (pageVisible.value ? 5_000 : false));
-const detailPollInterval = computed(() =>
-  pageVisible.value && selectedInvocationId.value ? 3_000 : false,
-);
 
 const list = useAgentInvocations({
   baseURL: props.apiBase,
-  immediate: pageVisible.value,
+  immediate: pageVisible.value && !initialListPending,
   pollInterval: listPollInterval,
   request: requestConsole,
   requestSummaries: requestConsole,
-  query: computed(() => (selectedAgentName.value ? { agent: selectedAgentName.value } : {})),
+  query: computed(() => ({
+    ...(selectedAgentName.value ? { agent: selectedAgentName.value } : {}),
+    limit: 10,
+  })),
+});
+const selectedSummary = computed(() =>
+  list.invocations.value.find((invocation) => invocation.id === selectedInvocationId.value),
+);
+const selectedDetailStatus = ref<AgentInvocationListItem["status"]>();
+const detailPollInterval = computed(() => {
+  if (!pageVisible.value || !selectedInvocationId.value) return false;
+  const status = selectedSummary.value?.status ?? selectedDetailStatus.value;
+  return status === "completed" || status === "failed" || status === "cancelled" ? false : 3_000;
 });
 const detail = useAgentInvocation(selectedInvocationId, {
   baseURL: props.apiBase,
@@ -101,6 +112,7 @@ const invocationItems = computed<AgentInvocationListItem[]>(() =>
     description: invocation.error?.message,
     id: invocation.id,
     project: agentInvocationProject(invocation),
+    provider: stringValue(invocation.annotations?.["agent.model.provider"]),
     startedAt: invocation.startedAt,
     status: invocation.status,
     title: agentInvocationTitle(invocation),
@@ -129,9 +141,6 @@ const routeAgent = computed(() => {
 });
 const isUsageRoute = computed(
   () => route.name === resolveConsoleRouteName(route.name, "vitehub-console-usage"),
-);
-const selectedSummary = computed(() =>
-  list.invocations.value.find((invocation) => invocation.id === selectedInvocationId.value),
 );
 const invocationView = computed<AgentInvocationView | undefined>(() => {
   const invocation = detail.invocation.value;
@@ -175,7 +184,7 @@ const splitterItems: SplitterItem[] = [
     minSize: 220,
     defaultSize: 680,
     sizeUnit: "px",
-    class: "min-h-0 min-w-0 overflow-hidden",
+    class: "h-full min-h-0 min-w-0 overflow-hidden",
   },
   {
     id: "details",
@@ -184,7 +193,7 @@ const splitterItems: SplitterItem[] = [
     maxSize: 1080,
     defaultSize: 560,
     sizeUnit: "px",
-    class: "min-h-0 min-w-0 overflow-hidden",
+    class: "h-full min-h-0 min-w-0 overflow-hidden",
   },
 ];
 
@@ -337,6 +346,7 @@ async function loadAgents(): Promise<void> {
         })
       : [];
     if (agentsRequest === controller) {
+      if (names.length) initialListPending = false;
       agentNames.value = [...new Set(names)];
       agentsError.value = undefined;
     }
@@ -347,17 +357,35 @@ async function loadAgents(): Promise<void> {
     if (agentsRequest === controller) {
       agentsRequest = undefined;
       agentsLoading.value = false;
+      if (initialListPending && !selectedAgentName.value) {
+        initialListPending = false;
+        if (pageVisible.value) void list.refresh();
+      }
     }
   }
 }
 
 async function refresh(): Promise<void> {
+  const agents = loadAgents();
+  const invocations = initialListPending && !selectedAgentName.value
+    ? agents.then(() => undefined)
+    : list.refresh();
   await Promise.all([
     detectHostCapabilities(),
-    loadAgents(),
-    list.refresh(),
+    agents,
+    invocations,
     selectedInvocationId.value ? detail.refresh() : Promise.resolve(),
   ]);
+}
+
+function inspectSession(target: "agent" | "workspace"): void {
+  const view = target === "agent" ? "details" : "workspace";
+  inspectorTab.value = view;
+  if (!inspectorOpenViews.value.includes(view)) {
+    inspectorOpenViews.value = [...inspectorOpenViews.value, view];
+  }
+  inspectorActiveSurface.value = `view:${view}`;
+  detailsOpen.value = true;
 }
 
 function retryPagination(): void {
@@ -463,6 +491,7 @@ watch(
 
 watch(selectedInvocationId, () => {
   selectedActivityId.value = undefined;
+  selectedDetailStatus.value = undefined;
   const identity = selectedInvocationId.value
     ? `${props.hostBase}/api/invocations/${selectedInvocationId.value}`
     : undefined;
@@ -472,6 +501,13 @@ watch(selectedInvocationId, () => {
     inspectorOpenPaths.value = [];
   }
 });
+
+watch(
+  () => detail.invocation.value?.status,
+  (status) => {
+    selectedDetailStatus.value = status;
+  },
+);
 
 watch(
   isUsageRoute,
@@ -619,7 +655,7 @@ onBeforeUnmount(() => {
           :continuation-key="list.cursor.value"
           :has-more="Boolean(list.cursor.value)"
           :items="invocationItems"
-          :loading="list.isLoadingMore.value"
+          :loading="list.isLoading.value || list.isLoadingMore.value"
           :remaining-statuses="list.remainingStatuses.value"
           :now="nowMs"
           :retry-key="invocationPaginationKey"
@@ -627,6 +663,18 @@ onBeforeUnmount(() => {
           @end-reached="list.loadMore()"
           @select="selectInvocation($event)"
         >
+          <template #footer>
+            <div v-if="list.cursor.value" class="flex justify-center px-2 py-3">
+              <UButton
+                color="neutral"
+                label="Load older sessions"
+                size="xs"
+                variant="soft"
+                :loading="list.isLoadingMore.value"
+                @click="list.loadMore()"
+              />
+            </div>
+          </template>
           <template #empty
             ><UEmpty
               class="px-4"
@@ -708,175 +756,147 @@ onBeforeUnmount(() => {
     </UDashboardPanel>
 
     <UDashboardPanel v-else id="agent-session" :ui="{ body: 'min-h-0 overflow-hidden p-0 gap-0' }">
-      <template #header>
-        <UDashboardNavbar
-          class="vitehub-console__session-navbar"
-          :title="selectedTitle"
-          :ui="{ root: 'border-0', title: 'min-w-0 flex-1' }"
-        >
-          <template #title>
-            <div v-if="selectedDisplay" class="flex min-w-0 items-center gap-2 text-sm">
-              <UIcon name="i-ph-folder-light" class="size-4 shrink-0 text-muted opacity-70" />
-              <span class="max-w-40 shrink-0 truncate font-normal text-muted">{{
-                selectedProject
-              }}</span>
-              <span class="text-dimmed" aria-hidden="true">/</span>
-              <strong class="min-w-0 truncate font-medium text-highlighted">{{
-                selectedTitle
-              }}</strong>
-            </div>
-            <span v-else class="text-sm font-medium">{{ selectedTitle }}</span>
-          </template>
-          <template #right>
-            <UTooltip text="Open sessions">
-              <UButton
-                data-slot="mobile-session-navigation"
-                class="lg:hidden"
-                icon="i-ph-sidebar-simple-light"
-                color="neutral"
-                variant="ghost"
-                size="sm"
-                aria-label="Open sessions"
-                @click="sessionsOpen = true"
-              />
-            </UTooltip>
-            <UTooltip v-if="selectedExternalUrl" text="Open related page">
-              <UButton
-                :to="selectedExternalUrl"
-                target="_blank"
-                icon="i-ph-arrow-square-out-light"
-                color="neutral"
-                variant="ghost"
-                size="sm"
-                aria-label="Open related page"
-              />
-            </UTooltip>
-            <UTooltip text="Refresh session">
-              <UButton
-                icon="i-ph-arrows-clockwise-light"
-                color="neutral"
-                variant="ghost"
-                size="sm"
-                :loading="list.isLoading.value || detail.isLoading.value"
-                aria-label="Refresh session"
-                @click="refresh"
-              />
-            </UTooltip>
-            <UTooltip v-if="invocationView" text="Session details">
-              <UButton
-                icon="i-ph-sidebar-simple-light"
-                color="neutral"
-                :variant="detailsOpen ? 'soft' : 'ghost'"
-                size="sm"
-                aria-label="Session details"
-                :aria-pressed="detailsOpen"
-                @click="detailsOpen = !detailsOpen"
-              />
-            </UTooltip>
-          </template>
-        </UDashboardNavbar>
-      </template>
-
       <template #body>
         <div class="h-full min-h-0 overflow-hidden" aria-live="polite">
-          <div
-            v-if="!selectedInvocationId"
-            class="flex h-full items-center justify-center p-8 text-sm text-muted"
-          >
-            Select an Agent Invocation to inspect its work.
-          </div>
-          <UEmpty
-            v-else-if="errorMessage(detail.error.value) && !invocationView"
+          <ConsoleSessionInspector
+            v-if="invocationView && isDesktop && detailsOpen && detailsMaximized"
+            :invocation="invocationView"
+            :maximized="true"
+            :workspace-base="`${hostBase}/api/invocations`"
+            v-model:tab="inspectorTab"
+            v-model:active-surface="inspectorActiveSurface"
+            v-model:open-views="inspectorOpenViews"
+            v-model:open-paths="inspectorOpenPaths"
+            v-model:selected-path="inspectorSelectedPath"
             class="h-full"
-            icon="i-ph-cloud-slash-light"
-            title="Could not load this session"
-            :description="errorMessage(detail.error.value)"
-            :actions="[
-              { label: 'Try again', icon: 'i-ph-arrows-clockwise-light', onClick: refresh },
-            ]"
+            @close="closeDetails"
+            @focus-activity="selectActivity"
+            @toggle-maximized="detailsMaximized = false"
           />
-          <div
-            v-else-if="detail.isLoading.value && !invocationView"
-            class="flex h-full items-center justify-center"
+          <USplitter
+            v-else-if="invocationView && isDesktop && detailsOpen"
+            id="agent-session-layout"
+            auto-save-id="vitehub-agent-session-layout"
+            :items="splitterItems"
+            class="h-full min-h-0 overflow-hidden"
           >
-            <UIcon
-              name="i-ph-circle-notch-light"
-              class="size-4 animate-spin text-muted opacity-70"
+            <template #thread>
+              <div class="flex h-full min-h-0 flex-col overflow-hidden">
+                <ConsoleSessionNavbar
+                  :details-open="detailsOpen"
+                  :external-url="selectedExternalUrl"
+                  :has-display="Boolean(selectedDisplay)"
+                  :has-selection="Boolean(selectedInvocationId)"
+                  :loading="list.isLoading.value || detail.isLoading.value"
+                  :project="selectedProject"
+                  :title="selectedTitle"
+                  @open-sessions="sessionsOpen = true"
+                  @refresh="refresh"
+                  @toggle-details="detailsOpen = !detailsOpen"
+                />
+                <UAlert
+                  v-if="errorMessage(detail.error.value)"
+                  class="m-3 shrink-0"
+                  color="error"
+                  variant="subtle"
+                  icon="i-ph-cloud-slash-light"
+                  title="Could not refresh this session"
+                  :description="errorMessage(detail.error.value)"
+                  :actions="[
+                    { label: 'Try again', icon: 'i-ph-arrows-clockwise-light', onClick: refresh },
+                  ]"
+                />
+                <AgentInvocation
+                  :header="false"
+                  :invocation="invocationView"
+                  :selected-activity-id="selectedActivityId"
+                  class="min-h-0 flex-1"
+                  @inspect="inspectSession"
+                />
+              </div>
+            </template>
+            <template #details>
+              <ConsoleSessionInspector
+                :invocation="invocationView"
+                :workspace-base="`${hostBase}/api/invocations`"
+                v-model:tab="inspectorTab"
+                v-model:active-surface="inspectorActiveSurface"
+                v-model:open-views="inspectorOpenViews"
+                v-model:open-paths="inspectorOpenPaths"
+                v-model:selected-path="inspectorSelectedPath"
+                class="h-full"
+                @close="closeDetails"
+                @focus-activity="selectActivity"
+                @toggle-maximized="detailsMaximized = true"
+              />
+            </template>
+            <template #resize-handle>
+              <span
+                class="pointer-events-none absolute inset-y-0 start-1/2 w-px -translate-x-1/2 bg-(--ui-border) transition-colors group-hover:bg-primary group-focus-visible:bg-primary"
+              />
+            </template>
+          </USplitter>
+          <div v-else class="flex h-full min-h-0 flex-col overflow-hidden">
+            <ConsoleSessionNavbar
+              :details-open="detailsOpen"
+              :external-url="selectedExternalUrl"
+              :has-display="Boolean(selectedDisplay)"
+              :has-selection="Boolean(selectedInvocationId)"
+              :loading="list.isLoading.value || detail.isLoading.value"
+              :project="selectedProject"
+              :title="selectedTitle"
+              @open-sessions="sessionsOpen = true"
+              @refresh="refresh"
+              @toggle-details="detailsOpen = !detailsOpen"
             />
-          </div>
-          <div v-else-if="invocationView" class="flex h-full min-h-0 flex-col">
-            <UAlert
-              v-if="errorMessage(detail.error.value)"
-              class="m-3 shrink-0"
-              color="error"
-              variant="subtle"
+            <div
+              v-if="!selectedInvocationId"
+              class="flex min-h-0 flex-1 items-center justify-center p-8 text-sm text-muted"
+            >
+              Select an Agent Invocation to inspect its work.
+            </div>
+            <UEmpty
+              v-else-if="errorMessage(detail.error.value) && !invocationView"
+              class="min-h-0 flex-1"
               icon="i-ph-cloud-slash-light"
-              title="Could not refresh this session"
+              title="Could not load this session"
               :description="errorMessage(detail.error.value)"
               :actions="[
                 { label: 'Try again', icon: 'i-ph-arrows-clockwise-light', onClick: refresh },
               ]"
             />
-            <ConsoleSessionInspector
-              v-if="isDesktop && detailsOpen && detailsMaximized"
-              :invocation="invocationView"
-              :maximized="true"
-              :workspace-base="`${hostBase}/api/invocations`"
-              v-model:tab="inspectorTab"
-              v-model:active-surface="inspectorActiveSurface"
-              v-model:open-views="inspectorOpenViews"
-              v-model:open-paths="inspectorOpenPaths"
-              v-model:selected-path="inspectorSelectedPath"
-              class="min-h-0 flex-1"
-              @close="closeDetails"
-              @focus-activity="selectActivity"
-              @toggle-maximized="detailsMaximized = false"
-            />
-            <USplitter
-              v-else-if="isDesktop && detailsOpen"
-              id="agent-session-layout"
-              auto-save-id="vitehub-agent-session-layout"
-              :items="splitterItems"
-              class="min-h-0 flex-1 overflow-hidden"
+            <div
+              v-else-if="detail.isLoading.value && !invocationView"
+              class="flex min-h-0 flex-1 items-center justify-center"
             >
-              <template #thread>
-                <AgentInvocation
-                  :header="false"
-                  :invocation="invocationView"
-                  :selected-activity-id="selectedActivityId"
-                  class="h-full"
-                />
-              </template>
-              <template #details>
-                <ConsoleSessionInspector
-                  :invocation="invocationView"
-                  :workspace-base="`${hostBase}/api/invocations`"
-                  v-model:tab="inspectorTab"
-                  v-model:active-surface="inspectorActiveSurface"
-                  v-model:open-views="inspectorOpenViews"
-                  v-model:open-paths="inspectorOpenPaths"
-                  v-model:selected-path="inspectorSelectedPath"
-                  class="h-full"
-                  @close="closeDetails"
-                  @focus-activity="selectActivity"
-                  @toggle-maximized="detailsMaximized = true"
-                />
-              </template>
-              <template #resize-handle>
-                <span
-                  class="pointer-events-none absolute inset-y-0 start-1/2 w-px -translate-x-1/2 bg-(--ui-border) transition-colors group-hover:bg-primary group-focus-visible:bg-primary"
-                />
-              </template>
-            </USplitter>
-            <AgentInvocation
-              v-else
-              :header="false"
-              :invocation="invocationView"
-              :selected-activity-id="selectedActivityId"
-              class="min-h-0 flex-1"
-            />
+              <UIcon
+                name="i-ph-circle-notch-light"
+                class="size-4 animate-spin text-muted opacity-70"
+              />
+            </div>
+            <div v-else-if="invocationView" class="flex min-h-0 flex-1 flex-col">
+              <UAlert
+                v-if="errorMessage(detail.error.value)"
+                class="m-3 shrink-0"
+                color="error"
+                variant="subtle"
+                icon="i-ph-cloud-slash-light"
+                title="Could not refresh this session"
+                :description="errorMessage(detail.error.value)"
+                :actions="[
+                  { label: 'Try again', icon: 'i-ph-arrows-clockwise-light', onClick: refresh },
+                ]"
+              />
+              <AgentInvocation
+                :header="false"
+                :invocation="invocationView"
+                :selected-activity-id="selectedActivityId"
+                class="min-h-0 flex-1"
+                @inspect="inspectSession"
+              />
+            </div>
             <USlideover
-              v-if="!isDesktop"
+              v-if="!isDesktop && invocationView"
               v-model:open="detailsOpen"
               side="right"
               title="Session details"

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -109,11 +109,11 @@ const initialSessionLoading = computed(() =>
 );
 const detailPollInterval = computed(() => {
   if (!sessionPollingEnabled.value || !selectedInvocationId.value) return false;
+  const detailStatus = selectedDetailStatus.value;
   const status =
-    selectedSummary.value?.status ??
-    (selectedDetailStatus.value?.id === selectedInvocationId.value
-      ? selectedDetailStatus.value.status
-      : undefined);
+    detailStatus?.id === selectedInvocationId.value
+      ? detailStatus.status
+      : selectedSummary.value?.status;
   return status === "completed" || status === "failed" || status === "cancelled" ? false : 3_000;
 });
 const detail = useAgentInvocation(selectedInvocationId, {

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -30,6 +30,7 @@ import ConsoleFrame from "./console-frame.vue";
 import ConsolePrimitiveSwitcher from "./console-primitive-switcher.vue";
 import ConsoleHealth from "./console-health.vue";
 import ConsoleMark from "./console-mark.vue";
+import ConsoleSessionLoading from "./console-session-loading.vue";
 import ConsoleSessionNavbar from "./console-session-navbar.vue";
 import ConsoleSessionInspector from "./console-session-inspector.vue";
 import ConsoleSearch from "./console-search.vue";
@@ -71,10 +72,12 @@ const healthAvailable = ref(false);
 const selectedActivityId = ref<string>();
 const isDesktop = ref(false);
 const pageVisible = ref(!import.meta.env.SSR && document.visibilityState !== "hidden");
+const refreshing = ref(false);
 let clock: ReturnType<typeof setInterval> | undefined;
 let media: MediaQueryList | undefined;
 let agentsRequest: AbortController | undefined;
 let capabilitiesRequest: AbortController | undefined;
+let refreshCount = 0;
 let initialListPending = !selectedAgentName.value;
 const listPollInterval = computed(() => (pageVisible.value ? 5_000 : false));
 
@@ -93,6 +96,9 @@ const selectedSummary = computed(() =>
   list.invocations.value.find((invocation) => invocation.id === selectedInvocationId.value),
 );
 const selectedDetailStatus = ref<AgentInvocationListItem["status"]>();
+const initialSessionLoading = computed(() =>
+  !selectedInvocationId.value && (agentsLoading.value || list.isLoading.value),
+);
 const detailPollInterval = computed(() => {
   if (!pageVisible.value || !selectedInvocationId.value) return false;
   const status = selectedSummary.value?.status ?? selectedDetailStatus.value;
@@ -112,7 +118,12 @@ const invocationItems = computed<AgentInvocationListItem[]>(() =>
     description: invocation.error?.message,
     id: invocation.id,
     project: agentInvocationProject(invocation),
-    provider: stringValue(invocation.annotations?.["agent.model.provider"]),
+    provider:
+      stringValue(invocation.annotations?.["agent.model.provider"]) ||
+      (invocation.id === selectedInvocationId.value
+        ? invocationView.value?.configuration?.driver?.model?.provider ||
+          invocationView.value?.configuration?.driver?.provider
+        : undefined),
     startedAt: invocation.startedAt,
     status: invocation.status,
     title: agentInvocationTitle(invocation),
@@ -366,16 +377,23 @@ async function loadAgents(): Promise<void> {
 }
 
 async function refresh(): Promise<void> {
-  const agents = loadAgents();
-  const invocations = initialListPending && !selectedAgentName.value
-    ? agents.then(() => undefined)
-    : list.refresh();
-  await Promise.all([
-    detectHostCapabilities(),
-    agents,
-    invocations,
-    selectedInvocationId.value ? detail.refresh() : Promise.resolve(),
-  ]);
+  refreshCount++;
+  refreshing.value = true;
+  try {
+    const agents = loadAgents();
+    const invocations = initialListPending && !selectedAgentName.value
+      ? agents.then(() => undefined)
+      : list.refresh();
+    await Promise.all([
+      detectHostCapabilities(),
+      agents,
+      invocations,
+      selectedInvocationId.value ? detail.refresh() : Promise.resolve(),
+    ]);
+  } finally {
+    refreshCount--;
+    refreshing.value = refreshCount > 0;
+  }
 }
 
 function inspectSession(target: "agent" | "workspace"): void {
@@ -611,6 +629,11 @@ onBeforeUnmount(() => {
             icon="i-ph-cloud-slash-light"
             title="Could not load sessions"
             :description="errorMessage(list.error.value || list.loadMoreError.value)"
+            :actions="
+              list.error.value
+                ? [{ label: 'Try again', icon: 'i-ph-arrows-clockwise-light', onClick: list.refresh }]
+                : undefined
+            "
           />
           <UButton
             v-if="invocationItems.length && list.cursor.value && list.loadMoreError.value"
@@ -624,8 +647,12 @@ onBeforeUnmount(() => {
           />
         </div>
         <div
-          v-if="!collapsed && list.isLoading.value && !invocationItems.length"
+          v-if="
+            !collapsed && (agentsLoading || list.isLoading.value) && !invocationItems.length
+          "
           class="grid gap-2 px-3"
+          aria-label="Loading sessions"
+          role="status"
         >
           <USkeleton v-for="index in 4" :key="index" class="h-16 rounded-lg" />
         </div>
@@ -663,6 +690,7 @@ onBeforeUnmount(() => {
           @end-reached="list.loadMore()"
           @select="selectInvocation($event)"
         >
+          <template #loading />
           <template #footer>
             <div v-if="list.cursor.value" class="flex justify-center px-2 py-3">
               <UButton
@@ -787,7 +815,7 @@ onBeforeUnmount(() => {
                   :external-url="selectedExternalUrl"
                   :has-display="Boolean(selectedDisplay)"
                   :has-selection="Boolean(selectedInvocationId)"
-                  :loading="list.isLoading.value || detail.isLoading.value"
+                  :loading="refreshing"
                   :project="selectedProject"
                   :title="selectedTitle"
                   @open-sessions="sessionsOpen = true"
@@ -842,15 +870,19 @@ onBeforeUnmount(() => {
               :external-url="selectedExternalUrl"
               :has-display="Boolean(selectedDisplay)"
               :has-selection="Boolean(selectedInvocationId)"
-              :loading="list.isLoading.value || detail.isLoading.value"
+              :loading="refreshing"
               :project="selectedProject"
               :title="selectedTitle"
               @open-sessions="sessionsOpen = true"
               @refresh="refresh"
               @toggle-details="detailsOpen = !detailsOpen"
             />
+            <ConsoleSessionLoading
+              v-if="initialSessionLoading"
+              class="min-h-0 flex-1"
+            />
             <div
-              v-if="!selectedInvocationId"
+              v-else-if="!selectedInvocationId"
               class="flex min-h-0 flex-1 items-center justify-center p-8 text-sm text-muted"
             >
               Select an Agent Invocation to inspect its work.
@@ -865,15 +897,10 @@ onBeforeUnmount(() => {
                 { label: 'Try again', icon: 'i-ph-arrows-clockwise-light', onClick: refresh },
               ]"
             />
-            <div
+            <ConsoleSessionLoading
               v-else-if="detail.isLoading.value && !invocationView"
-              class="flex min-h-0 flex-1 items-center justify-center"
-            >
-              <UIcon
-                name="i-ph-circle-notch-light"
-                class="size-4 animate-spin text-muted opacity-70"
-              />
-            </div>
+              class="min-h-0 flex-1"
+            />
             <div v-else-if="invocationView" class="flex min-h-0 flex-1 flex-col">
               <UAlert
                 v-if="errorMessage(detail.error.value)"

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -94,13 +94,20 @@ const list = useAgentInvocations({
 const selectedSummary = computed(() =>
   list.invocations.value.find((invocation) => invocation.id === selectedInvocationId.value),
 );
-const selectedDetailStatus = ref<AgentInvocationListItem["status"]>();
+const selectedDetailStatus = ref<{
+  id: string;
+  status: AgentInvocationListItem["status"];
+}>();
 const initialSessionLoading = computed(() =>
   !selectedInvocationId.value && (agentsLoading.value || list.isLoading.value),
 );
 const detailPollInterval = computed(() => {
   if (!pageVisible.value || !selectedInvocationId.value) return false;
-  const status = selectedSummary.value?.status ?? selectedDetailStatus.value;
+  const status =
+    selectedSummary.value?.status ??
+    (selectedDetailStatus.value?.id === selectedInvocationId.value
+      ? selectedDetailStatus.value.status
+      : undefined);
   return status === "completed" || status === "failed" || status === "cancelled" ? false : 3_000;
 });
 const detail = useAgentInvocation(selectedInvocationId, {
@@ -515,9 +522,9 @@ watch(selectedInvocationId, () => {
 });
 
 watch(
-  () => detail.invocation.value?.status,
-  (status) => {
-    selectedDetailStatus.value = status;
+  [() => detail.invocation.value?.id, () => detail.invocation.value?.status],
+  ([id, status]) => {
+    selectedDetailStatus.value = id && status ? { id, status } : undefined;
   },
 );
 

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -78,7 +78,13 @@ let agentsRequest: AbortController | undefined;
 let capabilitiesRequest: AbortController | undefined;
 let refreshCount = 0;
 let initialListPending = !selectedAgentName.value;
-const listPollInterval = computed(() => (pageVisible.value ? 5_000 : false));
+const sessionPollingEnabled = computed(
+  () =>
+    pageVisible.value &&
+    activePage.value === "sessions" &&
+    route.name !== resolveConsoleRouteName(route.name, "vitehub-console-usage"),
+);
+const listPollInterval = computed(() => (sessionPollingEnabled.value ? 5_000 : false));
 
 const list = useAgentInvocations({
   baseURL: props.apiBase,
@@ -102,7 +108,7 @@ const initialSessionLoading = computed(() =>
   !selectedInvocationId.value && (agentsLoading.value || list.isLoading.value),
 );
 const detailPollInterval = computed(() => {
-  if (!pageVisible.value || !selectedInvocationId.value) return false;
+  if (!sessionPollingEnabled.value || !selectedInvocationId.value) return false;
   const status =
     selectedSummary.value?.status ??
     (selectedDetailStatus.value?.id === selectedInvocationId.value

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -357,7 +357,7 @@ async function loadAgents(): Promise<void> {
         })
       : [];
     if (agentsRequest === controller) {
-      if (names.length) initialListPending = false;
+      if (names.length && !isUsageRoute.value) initialListPending = false;
       agentNames.value = [...new Set(names)];
       agentsError.value = undefined;
     }

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -687,7 +687,6 @@ onBeforeUnmount(() => {
           :now="nowMs"
           :retry-key="invocationPaginationKey"
           :selected-id="selectedInvocationId"
-          @end-reached="list.loadMore()"
           @select="selectInvocation($event)"
         >
           <template #loading />

--- a/packages/vite-hub/src/console/runtime/components/console-health-model.ts
+++ b/packages/vite-hub/src/console/runtime/components/console-health-model.ts
@@ -10,7 +10,7 @@ export type ConsoleHealth = {
   }>;
   status: "degraded" | "healthy";
   summary: string;
-  workload: { active: number; completed: number; failed: number; snapshots: number; total: number };
+  workload: { active: number; completed: number; failed: number; snapshots?: number; total: number };
 };
 
 const diagnosticSchema = v.object({
@@ -36,7 +36,7 @@ const healthSchema = v.object({
       active: workloadCountSchema,
       completed: workloadCountSchema,
       failed: workloadCountSchema,
-      snapshots: workloadCountSchema,
+      snapshots: v.optional(workloadCountSchema),
       total: workloadCountSchema,
     }),
     v.check(

--- a/packages/vite-hub/src/console/runtime/components/console-health.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-health.vue
@@ -32,7 +32,9 @@ const totals = computed(() =>
         { label: "Active", value: health.value.workload.active },
         { label: "Completed", value: health.value.workload.completed },
         { label: "Failed", value: health.value.workload.failed },
-        { label: "Snapshots", value: health.value.workload.snapshots },
+        ...(health.value.workload.snapshots === undefined
+          ? []
+          : [{ label: "Snapshots", value: health.value.workload.snapshots }]),
       ]
     : [],
 );

--- a/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
@@ -219,8 +219,10 @@ function openFile(path: string) {
 }
 
 async function openWorkspaceInstructions() {
+  const invocationId = props.invocation.id;
   openView("workspace");
   if (!workspace.value) await loadWorkspace();
+  if (props.invocation.id !== invocationId) return;
   const path = workspace.value?.paths
     .filter((path) => /(^|\/)AGENTS\.md$/i.test(path))
     .sort(
@@ -314,12 +316,14 @@ async function requestWorkspace() {
   workspaceLoading.value = true;
   workspaceError.value = undefined;
   try {
-    workspace.value = parseWorkspaceDescriptor(
+    const loadedWorkspace = parseWorkspaceDescriptor(
       await requestJson(
         `${props.workspaceBase}/${encodeURIComponent(props.invocation.id)}/workspace`,
         controller.signal,
       ),
     );
+    if (workspaceRequest !== controller) return;
+    workspace.value = loadedWorkspace;
     if (selectedPath.value) void loadFile(selectedPath.value);
   } catch (error) {
     if (!controller.signal.aborted) {

--- a/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
@@ -600,7 +600,7 @@ function message(error: unknown) {
         >
           <h4>System instructions</h4>
           <p>Resolved instructions were not recorded for this invocation.</p>
-          <button v-if="workspace" type="button" @click="openWorkspaceInstructions">
+          <button v-if="props.workspaceBase" type="button" @click="openWorkspaceInstructions">
             <UIcon name="i-lucide-file-text" />Open AGENTS.md in Workspace<UIcon
               name="i-lucide-arrow-right"
             />

--- a/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
@@ -67,6 +67,7 @@ const treeOpen = ref(true);
 const tabstrip = ref<HTMLElement>();
 const filesPanel = ref<HTMLElement>();
 let workspaceRequest: AbortController | undefined;
+let workspaceLoad: Promise<void> | undefined;
 let fileRequest: AbortController | undefined;
 
 onBeforeUnmount(() => {
@@ -130,6 +131,7 @@ watch(
   () => {
     workspaceRequest?.abort();
     workspaceRequest = undefined;
+    workspaceLoad = undefined;
     workspaceLoading.value = false;
     fileRequest?.abort();
     fileRequest = undefined;
@@ -218,7 +220,7 @@ function openFile(path: string) {
 
 async function openWorkspaceInstructions() {
   openView("workspace");
-  if (!workspace.value && !workspaceLoading.value) await loadWorkspace();
+  if (!workspace.value) await loadWorkspace();
   const path = workspace.value?.paths
     .filter((path) => /(^|\/)AGENTS\.md$/i.test(path))
     .sort(
@@ -294,6 +296,17 @@ function fileName(path: string) {
 }
 
 async function loadWorkspace() {
+  if (workspaceLoad) return workspaceLoad;
+  const load = requestWorkspace();
+  workspaceLoad = load;
+  try {
+    await load;
+  } finally {
+    if (workspaceLoad === load) workspaceLoad = undefined;
+  }
+}
+
+async function requestWorkspace() {
   if (!props.workspaceBase) return;
   workspaceRequest?.abort();
   const controller = new AbortController();

--- a/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
@@ -129,7 +129,10 @@ watch(
   [() => props.invocation.id, () => props.workspaceBase],
   () => {
     workspaceRequest?.abort();
+    workspaceRequest = undefined;
+    workspaceLoading.value = false;
     fileRequest?.abort();
+    fileRequest = undefined;
     workspace.value = undefined;
     workspaceError.value = undefined;
     file.value = undefined;
@@ -310,8 +313,10 @@ async function loadWorkspace() {
       workspaceError.value = message(error);
     }
   } finally {
-    if (!controller.signal.aborted && workspaceRequest === controller)
+    if (workspaceRequest === controller) {
+      workspaceRequest = undefined;
       workspaceLoading.value = false;
+    }
   }
 }
 
@@ -337,7 +342,10 @@ async function loadFile(path: string) {
   } catch (error) {
     if (!controller.signal.aborted && fileRequest === controller) fileError.value = message(error);
   } finally {
-    if (!controller.signal.aborted && fileRequest === controller) fileLoading.value = false;
+    if (fileRequest === controller) {
+      fileRequest = undefined;
+      fileLoading.value = false;
+    }
   }
 }
 

--- a/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
@@ -30,7 +30,6 @@ const openViews = defineModel<InspectorTab[]>("openViews", { default: () => ["de
 const openPaths = defineModel<string[]>("openPaths", { default: () => [] });
 const selectedPath = defineModel<string | undefined>("selectedPath");
 const workspace = ref<WorkspaceDescriptor>();
-const workspaceSupported = ref<boolean>();
 const workspaceError = ref<string>();
 const workspaceLoading = ref(false);
 const file = ref<WorkspaceFile>();
@@ -62,10 +61,7 @@ const viewMeta: Record<
 const inspectorViews = computed<InspectorTab[]>(() => [
   "details",
   "trace",
-  ...(workspaceSupported.value === true ||
-  (workspaceSupported.value === undefined && openViews.value.includes("workspace"))
-    ? (["workspace"] as const)
-    : []),
+  ...(props.workspaceBase ? (["workspace"] as const) : []),
 ]);
 const treeOpen = ref(true);
 const tabstrip = ref<HTMLElement>();
@@ -135,12 +131,11 @@ watch(
     workspaceRequest?.abort();
     fileRequest?.abort();
     workspace.value = undefined;
-    workspaceSupported.value = undefined;
     workspaceError.value = undefined;
     file.value = undefined;
     fileError.value = undefined;
     fileLoading.value = false;
-    void loadWorkspace();
+    if (tab.value === "workspace") void loadWorkspace();
   },
   { immediate: true },
 );
@@ -309,28 +304,15 @@ async function loadWorkspace() {
         controller.signal,
       ),
     );
-    workspaceSupported.value = true;
     if (selectedPath.value) void loadFile(selectedPath.value);
   } catch (error) {
     if (!controller.signal.aborted) {
-      workspaceSupported.value = !(error instanceof RequestError && error.status === 404);
-      workspaceError.value = workspaceSupported.value ? message(error) : undefined;
-      if (!workspaceSupported.value) clearWorkspaceState();
+      workspaceError.value = message(error);
     }
   } finally {
     if (!controller.signal.aborted && workspaceRequest === controller)
       workspaceLoading.value = false;
   }
-}
-
-function clearWorkspaceState() {
-  fileRequest?.abort();
-  workspace.value = undefined;
-  selectedPath.value = undefined;
-  openPaths.value = [];
-  file.value = undefined;
-  fileError.value = undefined;
-  fileLoading.value = false;
 }
 
 async function loadFile(path: string) {

--- a/packages/vite-hub/src/console/runtime/components/console-session-loading.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-loading.vue
@@ -1,0 +1,23 @@
+<template>
+  <div
+    aria-label="Loading session"
+    class="h-full overflow-hidden px-6 py-10 sm:px-10 lg:px-14"
+    role="status"
+  >
+    <div class="mx-auto grid w-full max-w-4xl gap-6">
+      <USkeleton class="h-14 rounded-lg" />
+      <div class="mx-auto grid w-full max-w-3xl gap-4 rounded-3xl bg-elevated/60 p-7">
+        <USkeleton class="h-8 w-44 rounded-md" />
+        <USkeleton class="mt-2 h-5 w-4/5 rounded" />
+        <USkeleton class="h-5 w-full rounded" />
+        <USkeleton class="h-5 w-2/3 rounded" />
+      </div>
+      <USkeleton class="h-12 rounded-lg" />
+      <div class="grid gap-3 px-1">
+        <USkeleton class="h-5 w-1/3 rounded" />
+        <USkeleton class="h-5 w-4/5 rounded" />
+        <USkeleton class="h-5 w-3/5 rounded" />
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
@@ -1,0 +1,82 @@
+<script setup lang="ts">
+defineProps<{
+  detailsOpen: boolean;
+  externalUrl?: string;
+  hasDisplay: boolean;
+  hasSelection: boolean;
+  loading: boolean;
+  project: string;
+  title: string;
+}>();
+
+defineEmits<{
+  openSessions: [];
+  refresh: [];
+  toggleDetails: [];
+}>();
+</script>
+
+<template>
+  <UDashboardNavbar
+    class="vitehub-console__session-navbar"
+    :title="title"
+    :ui="{ root: 'border-0', title: 'min-w-0 flex-1' }"
+  >
+    <template #title>
+      <div v-if="hasDisplay" class="flex min-w-0 items-center gap-2 text-sm">
+        <UIcon name="i-ph-folder-light" class="size-4 shrink-0 text-muted opacity-70" />
+        <span class="max-w-40 shrink-0 truncate font-normal text-muted">{{ project }}</span>
+        <span class="text-dimmed" aria-hidden="true">/</span>
+        <strong class="min-w-0 truncate font-medium text-highlighted">{{ title }}</strong>
+      </div>
+      <span v-else class="text-sm font-medium">{{ title }}</span>
+    </template>
+    <template #right>
+      <UTooltip text="Open sessions">
+        <UButton
+          data-slot="mobile-session-navigation"
+          class="lg:hidden"
+          icon="i-ph-sidebar-simple-light"
+          color="neutral"
+          variant="ghost"
+          size="sm"
+          aria-label="Open sessions"
+          @click="$emit('openSessions')"
+        />
+      </UTooltip>
+      <UTooltip v-if="externalUrl" text="Open related page">
+        <UButton
+          :to="externalUrl"
+          target="_blank"
+          icon="i-ph-arrow-square-out-light"
+          color="neutral"
+          variant="ghost"
+          size="sm"
+          aria-label="Open related page"
+        />
+      </UTooltip>
+      <UTooltip text="Refresh session">
+        <UButton
+          icon="i-ph-arrows-clockwise-light"
+          color="neutral"
+          variant="ghost"
+          size="sm"
+          :loading="loading"
+          aria-label="Refresh session"
+          @click="$emit('refresh')"
+        />
+      </UTooltip>
+      <UTooltip v-if="hasSelection" text="Session details">
+        <UButton
+          icon="i-ph-sidebar-simple-light"
+          color="neutral"
+          :variant="detailsOpen ? 'soft' : 'ghost'"
+          size="sm"
+          aria-label="Session details"
+          :aria-pressed="detailsOpen"
+          @click="$emit('toggleDetails')"
+        />
+      </UTooltip>
+    </template>
+  </UDashboardNavbar>
+</template>

--- a/packages/vite-hub/src/console/runtime/components/console-session-trace-model.ts
+++ b/packages/vite-hub/src/console/runtime/components/console-session-trace-model.ts
@@ -296,6 +296,9 @@ export function indexTraceLifecycles<Observation extends TraceObservationIdentit
     const identity = identityOf(observation);
     const sequenceStarts = startsBySequence.get(observation.sequence) ?? [];
     const sequenceFinishes = finishesBySequence.get(observation.sequence) ?? [];
+    const identityFinishes = sequenceFinishes.filter(
+      (lifecycle) => identityOf(lifecycle.start) === identity,
+    );
     if (isLifecycleStartObservation(observation.name)) {
       for (const lifecycle of sequenceStarts) {
         if (identityOf(lifecycle.start) !== identity) continue;
@@ -305,8 +308,8 @@ export function indexTraceLifecycles<Observation extends TraceObservationIdentit
       continue;
     }
     if (isLifecycleTerminalObservation(observation.name)) {
-      for (const lifecycle of sequenceFinishes) appendLifecycleObservation(lifecycle, observation);
-      for (const lifecycle of sequenceFinishes) deactivate(lifecycle);
+      for (const lifecycle of identityFinishes) appendLifecycleObservation(lifecycle, observation);
+      for (const lifecycle of identityFinishes) deactivate(lifecycle);
       continue;
     }
 
@@ -317,7 +320,7 @@ export function indexTraceLifecycles<Observation extends TraceObservationIdentit
       appendLifecycleObservation(lifecycle, observation);
       activate(lifecycle);
     }
-    for (const lifecycle of sequenceFinishes) deactivate(lifecycle);
+    for (const lifecycle of identityFinishes) deactivate(lifecycle);
   }
 
   return lifecycles;

--- a/packages/vite-hub/src/console/runtime/components/console-session-trace-model.ts
+++ b/packages/vite-hub/src/console/runtime/components/console-session-trace-model.ts
@@ -164,6 +164,165 @@ export function invocationOutcomeTimestamp(
   return timestamps.updatedAt;
 }
 
+export type TraceLifecycle<Observation extends TraceObservationIdentity> = {
+  finish: Observation | undefined;
+  observations: Observation[];
+  start: Observation;
+};
+
+type MutableTraceLifecycle<Observation extends TraceObservationIdentity> =
+  TraceLifecycle<Observation> & {
+    terminalNames: readonly string[];
+  };
+
+type PendingLifecycleQueue<Observation extends TraceObservationIdentity> = {
+  head: number;
+  lifecycles: MutableTraceLifecycle<Observation>[];
+};
+
+function pendingLifecycleQueue<Observation extends TraceObservationIdentity>(
+  queues: Map<string, Map<string, PendingLifecycleQueue<Observation>>>,
+  identity: string,
+  terminalName: string,
+): PendingLifecycleQueue<Observation> {
+  let identityQueues = queues.get(identity);
+  if (!identityQueues) {
+    identityQueues = new Map();
+    queues.set(identity, identityQueues);
+  }
+  let queue = identityQueues.get(terminalName);
+  if (!queue) {
+    queue = { head: 0, lifecycles: [] };
+    identityQueues.set(terminalName, queue);
+  }
+  return queue;
+}
+
+function appendLifecycleObservation<Observation extends TraceObservationIdentity>(
+  lifecycle: MutableTraceLifecycle<Observation>,
+  observation: Observation,
+) {
+  lifecycle.observations.push(observation);
+}
+
+/**
+ * Pairs and correlates sequence-ordered Trace observations in one indexed pass.
+ * Work is linear in the input plus correlated event references, which may be shared
+ * when same-identity lifecycles overlap.
+ */
+export function indexTraceLifecycles<Observation extends TraceObservationIdentity>(
+  starts: Observation[],
+  observations: Observation[],
+  terminalNamesForStart: (start: Observation) => readonly string[],
+): TraceLifecycle<Observation>[] {
+  const identities = new WeakMap<Observation, string>();
+  const identityOf = (observation: Observation) => {
+    const cached = identities.get(observation);
+    if (cached !== undefined) return cached;
+    const identity = traceEventId(observation);
+    identities.set(observation, identity);
+    return identity;
+  };
+  const lifecycles: MutableTraceLifecycle<Observation>[] = starts.map((start) => ({
+    finish: undefined,
+    observations: [],
+    start,
+    terminalNames: terminalNamesForStart(start),
+  }));
+  const lifecycleQueues = new Map<string, Map<string, PendingLifecycleQueue<Observation>>>();
+  const standaloneQueues = new Map<string, Map<string, PendingLifecycleQueue<Observation>>>();
+  let startIndex = 0;
+
+  for (const observation of observations) {
+    while (startIndex < lifecycles.length) {
+      const lifecycle = lifecycles[startIndex]!;
+      if (lifecycle.start.sequence > observation.sequence) break;
+      const queues = isLifecycleStartObservation(lifecycle.start.name)
+        ? lifecycleQueues
+        : standaloneQueues;
+      const identity = identityOf(lifecycle.start);
+      for (const terminalName of new Set(lifecycle.terminalNames))
+        pendingLifecycleQueue(queues, identity, terminalName).lifecycles.push(lifecycle);
+      startIndex += 1;
+    }
+
+    const identity = identityOf(observation);
+    const lifecycleQueue = lifecycleQueues.get(identity)?.get(observation.name);
+    if (lifecycleQueue) {
+      while (lifecycleQueue.head < lifecycleQueue.lifecycles.length) {
+        const lifecycle = lifecycleQueue.lifecycles[lifecycleQueue.head++]!;
+        if (lifecycle.finish) continue;
+        lifecycle.finish = observation;
+        break;
+      }
+    }
+    const standaloneQueue = standaloneQueues.get(identity)?.get(observation.name);
+    if (standaloneQueue) {
+      while (standaloneQueue.head < standaloneQueue.lifecycles.length) {
+        const lifecycle = standaloneQueue.lifecycles[standaloneQueue.head++]!;
+        if (!lifecycle.finish) lifecycle.finish = observation;
+      }
+    }
+  }
+
+  const startsBySequence = new Map<number, MutableTraceLifecycle<Observation>[]>();
+  const finishesBySequence = new Map<number, MutableTraceLifecycle<Observation>[]>();
+  for (const lifecycle of lifecycles) {
+    const sequenceStarts = startsBySequence.get(lifecycle.start.sequence) ?? [];
+    sequenceStarts.push(lifecycle);
+    startsBySequence.set(lifecycle.start.sequence, sequenceStarts);
+    if (!lifecycle.finish) continue;
+    const sequenceFinishes = finishesBySequence.get(lifecycle.finish.sequence) ?? [];
+    sequenceFinishes.push(lifecycle);
+    finishesBySequence.set(lifecycle.finish.sequence, sequenceFinishes);
+  }
+
+  const activeByIdentity = new Map<string, Set<MutableTraceLifecycle<Observation>>>();
+  const activate = (lifecycle: MutableTraceLifecycle<Observation>) => {
+    if (!lifecycle.finish || lifecycle.finish.sequence <= lifecycle.start.sequence) return;
+    const identity = identityOf(lifecycle.start);
+    const active = activeByIdentity.get(identity) ?? new Set();
+    active.add(lifecycle);
+    activeByIdentity.set(identity, active);
+  };
+  const deactivate = (lifecycle: MutableTraceLifecycle<Observation>) => {
+    const identity = identityOf(lifecycle.start);
+    const active = activeByIdentity.get(identity);
+    active?.delete(lifecycle);
+    if (active?.size === 0) activeByIdentity.delete(identity);
+  };
+
+  for (const observation of observations) {
+    const identity = identityOf(observation);
+    const sequenceStarts = startsBySequence.get(observation.sequence) ?? [];
+    const sequenceFinishes = finishesBySequence.get(observation.sequence) ?? [];
+    if (isLifecycleStartObservation(observation.name)) {
+      for (const lifecycle of sequenceStarts) {
+        if (identityOf(lifecycle.start) !== identity) continue;
+        appendLifecycleObservation(lifecycle, observation);
+        activate(lifecycle);
+      }
+      continue;
+    }
+    if (isLifecycleTerminalObservation(observation.name)) {
+      for (const lifecycle of sequenceFinishes) appendLifecycleObservation(lifecycle, observation);
+      for (const lifecycle of sequenceFinishes) deactivate(lifecycle);
+      continue;
+    }
+
+    for (const lifecycle of activeByIdentity.get(identity) ?? [])
+      appendLifecycleObservation(lifecycle, observation);
+    for (const lifecycle of sequenceStarts) {
+      if (identityOf(lifecycle.start) !== identity) continue;
+      appendLifecycleObservation(lifecycle, observation);
+      activate(lifecycle);
+    }
+    for (const lifecycle of sequenceFinishes) deactivate(lifecycle);
+  }
+
+  return lifecycles;
+}
+
 export function pairedToolTerminal<Observation extends TraceObservationIdentity>(
   start: Observation,
   observations: Observation[],

--- a/packages/vite-hub/src/console/runtime/components/console-session-trace-model.ts
+++ b/packages/vite-hub/src/console/runtime/components/console-session-trace-model.ts
@@ -266,15 +266,15 @@ export function indexTraceLifecycles<Observation extends TraceObservationIdentit
   }
 
   const startsBySequence = new Map<number, MutableTraceLifecycle<Observation>[]>();
-  const finishesBySequence = new Map<number, MutableTraceLifecycle<Observation>[]>();
+  const finishesByObservation = new WeakMap<Observation, MutableTraceLifecycle<Observation>[]>();
   for (const lifecycle of lifecycles) {
     const sequenceStarts = startsBySequence.get(lifecycle.start.sequence) ?? [];
     sequenceStarts.push(lifecycle);
     startsBySequence.set(lifecycle.start.sequence, sequenceStarts);
     if (!lifecycle.finish) continue;
-    const sequenceFinishes = finishesBySequence.get(lifecycle.finish.sequence) ?? [];
-    sequenceFinishes.push(lifecycle);
-    finishesBySequence.set(lifecycle.finish.sequence, sequenceFinishes);
+    const observationFinishes = finishesByObservation.get(lifecycle.finish) ?? [];
+    observationFinishes.push(lifecycle);
+    finishesByObservation.set(lifecycle.finish, observationFinishes);
   }
 
   const activeByIdentity = new Map<string, Set<MutableTraceLifecycle<Observation>>>();
@@ -295,10 +295,7 @@ export function indexTraceLifecycles<Observation extends TraceObservationIdentit
   for (const observation of observations) {
     const identity = identityOf(observation);
     const sequenceStarts = startsBySequence.get(observation.sequence) ?? [];
-    const sequenceFinishes = finishesBySequence.get(observation.sequence) ?? [];
-    const identityFinishes = sequenceFinishes.filter(
-      (lifecycle) => identityOf(lifecycle.start) === identity,
-    );
+    const observationFinishes = finishesByObservation.get(observation) ?? [];
     if (isLifecycleStartObservation(observation.name)) {
       for (const lifecycle of sequenceStarts) {
         if (identityOf(lifecycle.start) !== identity) continue;
@@ -307,11 +304,13 @@ export function indexTraceLifecycles<Observation extends TraceObservationIdentit
       }
       continue;
     }
-    if (isLifecycleTerminalObservation(observation.name)) {
-      for (const lifecycle of identityFinishes) appendLifecycleObservation(lifecycle, observation);
-      for (const lifecycle of identityFinishes) deactivate(lifecycle);
+    if (observationFinishes.length > 0) {
+      for (const lifecycle of observationFinishes)
+        appendLifecycleObservation(lifecycle, observation);
+      for (const lifecycle of observationFinishes) deactivate(lifecycle);
       continue;
     }
+    if (isLifecycleTerminalObservation(observation.name)) continue;
 
     for (const lifecycle of activeByIdentity.get(identity) ?? [])
       appendLifecycleObservation(lifecycle, observation);
@@ -320,7 +319,6 @@ export function indexTraceLifecycles<Observation extends TraceObservationIdentit
       appendLifecycleObservation(lifecycle, observation);
       activate(lifecycle);
     }
-    for (const lifecycle of identityFinishes) deactivate(lifecycle);
   }
 
   return lifecycles;

--- a/packages/vite-hub/src/console/runtime/components/console-session-trace.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-trace.vue
@@ -2,7 +2,7 @@
 import type { AgentInvocationView } from "@vite-hub/ui";
 import { computed, ref, watch } from "vue";
 import {
-  correlatedLifecycleObservations,
+  indexTraceLifecycles,
   isDeniedApproval,
   isLifecycleStartObservation,
   isLifecycleTerminalObservation,
@@ -14,8 +14,6 @@ import {
   invocationSpanStatus,
   invocationTerminalNames,
   lifecycleTerminalNames,
-  pairedLifecycleTerminal,
-  pairedToolTerminal,
   standaloneSuccessfulLifecycleSequences,
   traceDurationMs,
   traceEventId,
@@ -130,15 +128,14 @@ function buildSpans(invocation: AgentInvocationView): TraceSpan[] {
     (left, right) => left.sequence - right.sequence,
   );
   const starts = traceStarts(observations);
-  const pairs = starts.map((start) => ({
-    finish: pairedTerminal(start, observations, invocation),
-    start,
-  }));
-  const result = pairs.map(({ start, finish }) =>
-    pairedSpan(start, finish, observations, invocation),
+  const lifecycles = indexTraceLifecycles(starts, observations, (start) =>
+    terminalNames(start, invocation),
+  );
+  const result = lifecycles.map(({ start, finish, observations: events }) =>
+    pairedSpan(start, finish, events, invocation),
   );
   const representedSequences = new Set(
-    pairs.flatMap(({ finish }) => (finish ? [finish.sequence] : [])),
+    lifecycles.flatMap(({ finish }) => (finish ? [finish.sequence] : [])),
   );
   const standaloneSuccessfulTerminals = standaloneSuccessfulLifecycleSequences(
     observations,
@@ -256,11 +253,10 @@ function traceStarts(observations: Observation[]): Observation[] {
 function pairedSpan(
   start: Observation,
   finish: Observation | undefined,
-  observations: Observation[],
+  events: Observation[],
   invocation: AgentInvocationView,
 ): TraceSpan {
   const id = eventId(start);
-  const events = correlatedLifecycleObservations(start, finish, observations);
   const attributes = Object.assign({}, ...events.map((event) => event.attributes ?? {}));
   const startMs = timestamp(start.timestamp);
   const operation = operationName(start, attributes);
@@ -291,22 +287,13 @@ function pairedSpan(
   };
 }
 
-function pairedTerminal(
-  start: Observation,
-  observations: Observation[],
-  invocation: AgentInvocationView,
-): Observation | undefined {
-  const terminalNames =
-    start.name.startsWith("agent.invocation.") && isLifecycleStartObservation(start.name)
-      ? invocationTerminalNames(invocation.status)
-      : start.name === "agent.task.started"
-        ? ["agent.task.completed", "agent.task.failed", "agent.task.cancelled"]
-        : start.name === "agent.approval.request"
-          ? ["agent.approval.decision"]
-          : lifecycleTerminalNames(start.name);
-  if (start.name.startsWith("agent.tool.") && isLifecycleStartObservation(start.name))
-    return pairedToolTerminal(start, observations);
-  return pairedLifecycleTerminal(start, observations, terminalNames);
+function terminalNames(start: Observation, invocation: AgentInvocationView): string[] {
+  if (start.name.startsWith("agent.invocation.") && isLifecycleStartObservation(start.name))
+    return invocationTerminalNames(invocation.status);
+  if (start.name === "agent.task.started")
+    return ["agent.task.completed", "agent.task.failed", "agent.task.cancelled"];
+  if (start.name === "agent.approval.request") return ["agent.approval.decision"];
+  return lifecycleTerminalNames(start.name);
 }
 
 function invocationSpan(invocation: AgentInvocationView, observations: Observation[]): TraceSpan {

--- a/packages/vite-hub/src/console/runtime/components/console-session.css
+++ b/packages/vite-hub/src/console/runtime/components/console-session.css
@@ -4,6 +4,7 @@
   display: grid;
   grid-template-columns: minmax(0, 1fr);
   grid-template-rows: auto minmax(0, 1fr);
+  height: 100%;
   min-height: 0;
   min-width: 0;
   overflow: hidden;

--- a/packages/vite-hub/src/console/runtime/pages/agents.vue
+++ b/packages/vite-hub/src/console/runtime/pages/agents.vue
@@ -29,8 +29,28 @@ useHead({ title: computed(() => route.name?.toString().startsWith("vitehub-conso
       />
     </ConsoleProvider>
     <template #fallback>
-      <div class="flex h-dvh min-h-[32rem] items-center justify-center text-sm text-muted">
-        Loading ViteHub Console…
+      <div
+        aria-label="Loading ViteHub Console"
+        class="flex h-dvh min-h-[32rem] overflow-hidden bg-default"
+        role="status"
+      >
+        <aside class="hidden w-80 shrink-0 border-r border-default p-4 lg:grid lg:grid-rows-[auto_auto_1fr] lg:gap-5">
+          <USkeleton class="h-8 w-36 rounded" />
+          <USkeleton class="h-9 rounded-lg" />
+          <div class="grid content-start gap-3">
+            <USkeleton v-for="index in 5" :key="index" class="h-16 rounded-lg" />
+          </div>
+        </aside>
+        <main class="min-w-0 flex-1">
+          <header class="flex h-14 items-center border-b border-default px-6">
+            <USkeleton class="h-5 w-72 max-w-3/5 rounded" />
+          </header>
+          <div class="grid gap-6 px-6 py-10 sm:px-10 lg:px-14">
+            <USkeleton class="h-14 rounded-lg" />
+            <USkeleton class="mx-auto h-72 w-full max-w-3xl rounded-3xl" />
+            <USkeleton class="h-12 rounded-lg" />
+          </div>
+        </main>
       </div>
     </template>
   </ClientOnly>

--- a/packages/vite-hub/src/console/runtime/server/agents.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.get.ts
@@ -11,15 +11,7 @@ interface ConsoleAgentsResult {
 const agentsHandler: (event: ConsoleRequestEvent) => Promise<ConsoleAgentsResult> = async (event) => {
   assertConsoleRequest(event)
   const agents = new Set(getConsoleAgents())
-  let cursor: string | undefined
-  // ponytail: Add a store-level distinct-name query if large journals make this compatibility scan measurable.
-  do {
-    const page = await getConsoleInvocations().list({ cursor, limit: 100 })
-    for (const invocation of page.invocations) {
-      if (invocation.agentName) agents.add(invocation.agentName)
-    }
-    cursor = page.cursor
-  } while (cursor)
+  for (const agentName of await getConsoleInvocations().listAgentNames()) agents.add(agentName)
   return { agents: [...agents].sort() }
 }
 

--- a/packages/vite-hub/src/console/runtime/server/invocation.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocation.get.ts
@@ -7,8 +7,24 @@ import type { AgentInvocationSummary } from "@vite-hub/agent"
 import type { TraceEventLogEntry } from "@vite-hub/runtime"
 
 interface ConsoleInvocationDetail {
+  appendObservations?: boolean
   invocation: AgentInvocationSummary & { usage?: ReturnType<typeof invocationUsage> }
+  observationCursor: string
   observations: readonly TraceEventLogEntry[]
+}
+
+function observationCursor(observations: readonly TraceEventLogEntry[], count = observations.length): string {
+  let fnv = 2_166_136_261
+  let djb = 5_381
+  for (let index = 0; index < count; index++) {
+    const serialized = JSON.stringify(observations[index])
+    for (let offset = 0; offset <= serialized.length; offset++) {
+      const code = offset === serialized.length ? 0 : serialized.charCodeAt(offset)
+      fnv = Math.imul(fnv ^ code, 16_777_619)
+      djb = Math.imul(djb, 33) ^ code
+    }
+  }
+  return `${count.toString(36)}-${(fnv >>> 0).toString(36)}-${(djb >>> 0).toString(36)}`
 }
 
 const invocationHandler: (event: ConsoleRequestEvent) => Promise<ConsoleInvocationDetail> = async (event) => {
@@ -24,7 +40,26 @@ const invocationHandler: (event: ConsoleRequestEvent) => Promise<ConsoleInvocati
   }
   const { observations, ...summary } = invocation
   const usage = invocationUsage(invocation)
-  return { invocation: { ...summary, ...(usage ? { usage } : {}) }, observations }
+  const requestURL = consoleRequestURL(event)
+  const countValue = requestURL.searchParams.get("observationCount")
+  const requestedCursor = requestURL.searchParams.get("observationCursor")
+  const observationCount = countValue === null ? undefined : Number(countValue)
+  const canAppend = invocation.observationsTruncated !== true
+    && requestedCursor !== null
+    && observationCount !== undefined
+    && Number.isSafeInteger(observationCount)
+    && observationCount >= 0
+    && observationCount <= observations.length
+    && requestedCursor === observationCursor(observations, observationCount)
+  const detail: ConsoleInvocationDetail = {
+    invocation: { ...summary, ...(usage ? { usage } : {}) },
+    observationCursor: observationCursor(observations),
+    observations: canAppend
+      ? observations.slice(observationCount)
+      : observations,
+  }
+  if (canAppend) detail.appendObservations = true
+  return detail
 }
 
 export default invocationHandler

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -183,6 +183,7 @@ function configureProviderOptionalImportAliases(
 
 function frameworkDependencyResolver(
   options: ViteHubOptions,
+  envPlugin: EnvVitePlugin | undefined,
   providerImportAliases: Record<string, string>,
   blobEnabled: boolean,
   presetKVOptions?: KVModuleOptions,
@@ -205,8 +206,9 @@ function frameworkDependencyResolver(
       }
     },
     configResolved(config) {
-      if (options.env !== false && config.root) {
-        providerImportAliases["#vitehub/env/server"] = resolve(config.root, ".vitehub/env/server.mjs")
+      if (envPlugin && config.root) {
+        const envProjectRoot = envPlugin.api.resolveProjectRoot(config.root)
+        providerImportAliases["#vitehub/env/server"] = resolve(envProjectRoot, ".vitehub/env/server.mjs")
       }
       configureProviderOptionalImportAliases(
         providerImportAliases,
@@ -745,7 +747,7 @@ export function vitehub(options: ViteHubOptions): PluginOption[] {
   configureProviderOptionalImportAliases(providerImportAliases, options, presetKVOptions || undefined)
   const workspaceDependencyRuntimeImports = frameworkWorkspaceDependencyRuntimeImports(sandboxEnabled)
 
-  plugins.push(frameworkDependencyResolver(options, providerImportAliases, blobEnabled, presetKVOptions || undefined))
+  plugins.push(frameworkDependencyResolver(options, envPlugin, providerImportAliases, blobEnabled, presetKVOptions || undefined))
   plugins.push(hubMarkdownTemplate({ runtimeImport: `${generatedImportBase}/markdown-template` }))
 
   if (envPlugin) plugins.push(envPlugin)

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -205,6 +205,9 @@ function frameworkDependencyResolver(
       }
     },
     configResolved(config) {
+      if (options.env !== false && config.root) {
+        providerImportAliases["#vitehub/env/server"] = resolve(config.root, ".vitehub/env/server.mjs")
+      }
       configureProviderOptionalImportAliases(
         providerImportAliases,
         options,

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -213,6 +213,7 @@ function frameworkDependencyResolver(
       configureProviderOptionalImportAliases(
         providerImportAliases,
         options,
+        // SAFETY: Vite's resolved config may be extended by the configured deployment preset with KV options.
         (config as typeof config & { kv?: KVModuleOptions }).kv ?? presetKVOptions,
       )
     },

--- a/packages/vite-hub/test/console-health-model.test.ts
+++ b/packages/vite-hub/test/console-health-model.test.ts
@@ -15,6 +15,11 @@ describe("Console Health model", () => {
     expect(isConsoleHealth(health)).toBe(true);
   });
 
+  it("accepts hosts that do not persist Workspace snapshots", () => {
+    const { snapshots: _snapshots, ...workload } = health.workload;
+    expect(isConsoleHealth({ ...health, workload })).toBe(true);
+  });
+
   it("rejects malformed diagnostics during capability discovery", () => {
     expect(isConsoleHealth({ ...health, diagnostics: [{ label: "Storage" }] })).toBe(false);
   });

--- a/packages/vite-hub/test/console-session-trace-model.test.ts
+++ b/packages/vite-hub/test/console-session-trace-model.test.ts
@@ -86,6 +86,31 @@ describe("Console session trace model", () => {
     ]);
   });
 
+  it("keeps same-sequence terminals scoped to their lifecycle identity", () => {
+    const observations = [
+      { attributes: { "model.call.id": "first" }, name: "agent.model.start", sequence: 1 },
+      { attributes: { "model.call.id": "second" }, name: "agent.model.start", sequence: 2 },
+      { attributes: { "model.call.id": "first" }, name: "agent.model.output", sequence: 3 },
+      { attributes: { "model.call.id": "second" }, name: "agent.model.output", sequence: 4 },
+      { attributes: { "model.call.id": "first" }, name: "agent.model.finish", sequence: 5 },
+      { attributes: { "model.call.id": "second" }, name: "agent.model.finish", sequence: 5 },
+    ];
+    const starts = [observations[0]!, observations[1]!];
+
+    const lifecycles = indexTraceLifecycles(starts, observations, (start) =>
+      lifecycleTerminalNames(start.name),
+    );
+
+    expect(
+      lifecycles.map(({ observations: events }) =>
+        events.map((event) => event.attributes["model.call.id"]),
+      ),
+    ).toEqual([
+      ["first", "first", "first"],
+      ["second", "second", "second"],
+    ]);
+  });
+
   it("does not correlate later observations into an unpaired lifecycle", () => {
     const observations = [
       { attributes: { "step.id": "step" }, name: "agent.task.started", sequence: 1 },

--- a/packages/vite-hub/test/console-session-trace-model.test.ts
+++ b/packages/vite-hub/test/console-session-trace-model.test.ts
@@ -111,6 +111,41 @@ describe("Console session trace model", () => {
     ]);
   });
 
+  it("keeps same-sequence terminals scoped to their exact overlapping lifecycle", () => {
+    const observations = [
+      { attributes: { "model.call.id": "shared" }, name: "agent.model.start", sequence: 1 },
+      { attributes: { "model.call.id": "shared" }, name: "agent.model.start", sequence: 2 },
+      { attributes: { "model.call.id": "shared" }, name: "agent.model.output", sequence: 3 },
+      {
+        attributes: { "model.call.id": "shared", result: "first" },
+        name: "agent.model.finish",
+        sequence: 4,
+      },
+      {
+        attributes: { "model.call.id": "shared", result: "second" },
+        name: "agent.model.finish",
+        sequence: 4,
+      },
+    ];
+    const starts = [observations[0]!, observations[1]!];
+
+    const lifecycles = indexTraceLifecycles(starts, observations, (start) =>
+      lifecycleTerminalNames(start.name),
+    );
+
+    expect(
+      lifecycles.map(({ finish, observations: events }) => ({
+        finish: finish?.attributes?.result,
+        terminalResults: events.flatMap((event) =>
+          event.name === "agent.model.finish" ? [event.attributes?.result] : [],
+        ),
+      })),
+    ).toEqual([
+      { finish: "first", terminalResults: ["first"] },
+      { finish: "second", terminalResults: ["second"] },
+    ]);
+  });
+
   it("does not correlate later observations into an unpaired lifecycle", () => {
     const observations = [
       { attributes: { "step.id": "step" }, name: "agent.task.started", sequence: 1 },

--- a/packages/vite-hub/test/console-session-trace-model.test.ts
+++ b/packages/vite-hub/test/console-session-trace-model.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  indexTraceLifecycles,
   correlatedLifecycleObservations,
   isDeniedApproval,
   isLifecycleStartObservation,
@@ -24,6 +25,81 @@ import {
 } from "../src/console/runtime/components/console-session-trace-model";
 
 describe("Console session trace model", () => {
+  it("indexes lifecycle terminals and correlated observations with linear identity reads", () => {
+    let identityReads = 0;
+    const observations = Array.from({ length: 100 }, (_, index) => {
+      const id = `step-${index}`;
+      const attributes = Object.defineProperty({}, "step.id", {
+        enumerable: true,
+        get() {
+          identityReads += 1;
+          return id;
+        },
+      });
+      const sequence = index * 3 + 1;
+      return [
+        { attributes, name: "agent.model.start", sequence },
+        { attributes, name: "agent.model.output", sequence: sequence + 1 },
+        { attributes, name: "agent.model.finish", sequence: sequence + 2 },
+      ];
+    }).flat();
+    const starts = observations.filter((observation) =>
+      isLifecycleStartObservation(observation.name),
+    );
+
+    const lifecycles = indexTraceLifecycles(starts, observations, (start) =>
+      lifecycleTerminalNames(start.name),
+    );
+
+    expect(lifecycles).toHaveLength(100);
+    expect(lifecycles.at(-1)?.finish?.sequence).toBe(300);
+    expect(lifecycles.at(-1)?.observations.map((observation) => observation.sequence)).toEqual([
+      298, 299, 300,
+    ]);
+    expect(identityReads).toBe(observations.length);
+  });
+
+  it("preserves overlapping lifecycle correlation while pairing terminals in sequence order", () => {
+    const observations = [
+      { attributes: { "model.call.id": "model" }, name: "agent.model.start", sequence: 1 },
+      { attributes: { "model.call.id": "model" }, name: "agent.model.output", sequence: 2 },
+      { attributes: { "model.call.id": "model" }, name: "agent.model.start", sequence: 3 },
+      { attributes: { "model.call.id": "model" }, name: "agent.model.output", sequence: 4 },
+      { attributes: { "model.call.id": "model" }, name: "agent.model.finish", sequence: 5 },
+      { attributes: { "model.call.id": "model" }, name: "agent.model.output", sequence: 6 },
+      { attributes: { "model.call.id": "model" }, name: "agent.model.finish", sequence: 7 },
+    ];
+    const starts = [observations[0]!, observations[2]!];
+
+    const lifecycles = indexTraceLifecycles(starts, observations, (start) =>
+      lifecycleTerminalNames(start.name),
+    );
+
+    expect(
+      lifecycles.map(({ finish, observations: events }) => ({
+        events: events.map((event) => event.sequence),
+        finish: finish?.sequence,
+      })),
+    ).toEqual([
+      { events: [1, 2, 4, 5], finish: 5 },
+      { events: [3, 4, 6, 7], finish: 7 },
+    ]);
+  });
+
+  it("does not correlate later observations into an unpaired lifecycle", () => {
+    const observations = [
+      { attributes: { "step.id": "step" }, name: "agent.task.started", sequence: 1 },
+      { attributes: { "step.id": "step" }, name: "agent.task.progress", sequence: 2 },
+    ];
+
+    const [lifecycle] = indexTraceLifecycles([observations[0]!], observations, () => [
+      "agent.task.completed",
+    ]);
+
+    expect(lifecycle?.finish).toBeUndefined();
+    expect(lifecycle?.observations.map((observation) => observation.sequence)).toEqual([1]);
+  });
+
   it("pairs approval requests and decisions by approval identity", () => {
     const request = {
       attributes: { "approval.id": "approval-1" },

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -42,6 +42,7 @@ import { consoleFixtureEnvironmentVariable, consoleFixtureFallbackAgentName, con
 import agentsHandler from "../src/console/runtime/server/agents.get.ts"
 import { installConsoleAgentDefinitions, installConsoleAgents } from "../src/console/runtime/server/agents.ts"
 import { createConsoleFixtureInvocations, createConsoleInvocations, installConsoleFixtureInvocations, installConsoleInvocations, resolveConsoleDatabaseOptions } from "../src/console/runtime/server/invocations.ts"
+import invocationHandler from "../src/console/runtime/server/invocation.get.ts"
 import invocationsHandler from "../src/console/runtime/server/invocations.get.ts"
 import consolePageHandler from "../src/console/runtime/server/page.get.ts"
 import { assertConsoleRequest } from "../src/console/runtime/server/request.ts"
@@ -2038,6 +2039,69 @@ describe("Agent invocation console", () => {
     await expect(invocationsHandler(requestEvent)).resolves.toMatchObject({
       invocations: [{ agentName: "review" }],
     })
+  })
+
+  it("returns only observations after a matching detail prefix", async () => {
+    const store = createMemoryAgentInvocationStore()
+    store.create({
+      createdAt: "2026-08-23T12:00:00.000Z",
+      id: "inv-delta",
+      observations: [1, 2].map(sequence => ({
+        name: "agent.invocation.running",
+        sequence,
+        timestamp: "2026-08-23T12:00:00.000Z",
+        type: "lifecycle" as const,
+      })),
+      status: "running",
+      traceId: "trace-delta",
+      updatedAt: "2026-08-23T12:00:03.000Z",
+    })
+    installConsoleInvocationFallback(defineAgentInvocations({ store }), process.cwd())
+    const requestEvent = event("127.0.0.1")
+    const detailURL = "http://localhost/api/_vitehub/console/invocations/inv-delta"
+    requestEvent.node!.req!.url = detailURL
+    requestEvent.req!.url = detailURL
+    const initial = await invocationHandler(requestEvent)
+    await store.update("inv-delta", {
+      observation: {
+        name: "agent.invocation.running",
+        sequence: 3,
+        timestamp: "2026-08-23T12:00:03.000Z",
+        type: "lifecycle",
+      },
+      timestamp: "2026-08-23T12:00:03.000Z",
+    })
+    const url = `${detailURL}?observationCount=2&observationCursor=${encodeURIComponent(initial.observationCursor)}`
+    requestEvent.node!.req!.url = url
+    requestEvent.req!.url = url
+
+    await expect(invocationHandler(requestEvent)).resolves.toMatchObject({
+      appendObservations: true,
+      invocation: { id: "inv-delta" },
+      observations: [{ sequence: 3 }],
+    })
+
+    await store.update("inv-delta", {
+      observation: {
+        name: "agent.invocation.started",
+        sequence: 0,
+        timestamp: "2026-08-23T11:59:59.000Z",
+        type: "lifecycle",
+      },
+      timestamp: "2026-08-23T12:00:04.000Z",
+    })
+    const replaced = await invocationHandler(requestEvent)
+    expect(replaced.appendObservations).toBeUndefined()
+    expect(replaced.observations.map(observation => observation.sequence)).toEqual([0, 1, 2, 3])
+
+    await store.update("inv-delta", {
+      observationsTruncated: true,
+      timestamp: "2026-08-23T12:00:05.000Z",
+    })
+    const truncatedURL = `${detailURL}?observationCount=4&observationCursor=${encodeURIComponent(replaced.observationCursor)}`
+    requestEvent.node!.req!.url = truncatedURL
+    requestEvent.req!.url = truncatedURL
+    await expect(invocationHandler(requestEvent)).resolves.not.toHaveProperty("appendObservations")
   })
 
   it("bounds each console response to the requested page size", async () => {

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -1608,6 +1608,30 @@ describe("Agent invocation console", () => {
     })
   })
 
+  it("serves Agent names without paging through invocation summaries", async () => {
+    const store = createMemoryAgentInvocationStore()
+    await store.create({
+      agentName: "archived",
+      createdAt: "2026-08-31T00:00:00.000Z",
+      id: "archived",
+      observations: [],
+      status: "completed",
+      traceId: "archived-trace",
+      updatedAt: "2026-08-31T00:00:00.000Z",
+    })
+    const invocations = defineAgentInvocations({ store })
+    installConsoleInvocationFallback(invocations, process.cwd())
+    installConsoleAgents(["current"], invocations)
+    store.list = vi.fn(() => {
+      throw new Error("The Console should use the distinct Agent-name index.")
+    })
+
+    await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({
+      agents: ["archived", "current"],
+    })
+    expect(store.list).not.toHaveBeenCalled()
+  })
+
   it("serves enabled Console sections in stable order for the active project", () => {
     installConsoleSections("/first", ["agents"])
     installConsoleProjectName("/first", "first-app")

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -358,8 +358,13 @@ describe("framework package contract", () => {
     expect(sessionInspector).toContain("workspaceLoading.value = false;");
     expect(sessionInspector).toContain("workspaceRequest = undefined;");
     expect(sessionInspector).toContain('<button v-if="props.workspaceBase"');
-    expect(sessionInspector).toContain("if (!workspace.value) await loadWorkspace();");
+    expect(sessionInspector).toMatch(
+      /const invocationId = props\.invocation\.id;[\s\S]*?if \(!workspace\.value\) await loadWorkspace\(\);[\s\S]*?if \(props\.invocation\.id !== invocationId\) return;/,
+    );
     expect(sessionInspector).toContain("if (workspaceLoad) return workspaceLoad;");
+    expect(sessionInspector).toMatch(
+      /const loadedWorkspace = parseWorkspaceDescriptor\([\s\S]*?if \(workspaceRequest !== controller\) return;[\s\S]*?workspace\.value = loadedWorkspace;/,
+    );
     expect(sessionInspector).toContain("invocationUsage.totalTokens");
     expect(sessionInspector).toContain("workspace.pullRequest !== undefined");
     expect(sessionInspector).toContain("hasPullRequest && (pullRequest === undefined");

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -317,6 +317,12 @@ describe("framework package contract", () => {
     expect(consoleSessionCss).toMatch(/\.session-inspector\s*\{[\s\S]*?height: 100%;/);
     expect(consolePage).toContain("limit: 10");
     expect(consolePage).toContain("const initialSessionLoading = computed");
+    expect(consolePage).toContain(
+      "[() => detail.invocation.value?.id, () => detail.invocation.value?.status]",
+    );
+    expect(consolePage).toContain(
+      "selectedDetailStatus.value?.id === selectedInvocationId.value",
+    );
     expect(consolePage).toContain('v-if="initialSessionLoading"');
     expect(consolePage).toContain(':loading="refreshing"');
     expect(consolePage).toContain("<template #loading />");

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -357,6 +357,10 @@ describe("framework package contract", () => {
     expect(sessionInspector).toContain('if (tab.value === "workspace") void loadWorkspace();');
     expect(sessionInspector).toContain("workspaceLoading.value = false;");
     expect(sessionInspector).toContain("workspaceRequest = undefined;");
+    expect(sessionInspector).toContain('<button v-if="props.workspaceBase"');
+    expect(sessionInspector).toContain(
+      "if (!workspace.value && !workspaceLoading.value) await loadWorkspace();",
+    );
     expect(sessionInspector).toContain("invocationUsage.totalTokens");
     expect(sessionInspector).toContain("workspace.pullRequest !== undefined");
     expect(sessionInspector).toContain("hasPullRequest && (pullRequest === undefined");

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -347,6 +347,8 @@ describe("framework package contract", () => {
     expect(sessionInspector).toContain("Workspace unavailable");
     expect(sessionInspector).toContain('...(props.workspaceBase ? (["workspace"] as const) : [])');
     expect(sessionInspector).toContain('if (tab.value === "workspace") void loadWorkspace();');
+    expect(sessionInspector).toContain("workspaceLoading.value = false;");
+    expect(sessionInspector).toContain("workspaceRequest = undefined;");
     expect(sessionInspector).toContain("invocationUsage.totalTokens");
     expect(sessionInspector).toContain("workspace.pullRequest !== undefined");
     expect(sessionInspector).toContain("hasPullRequest && (pullRequest === undefined");

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -395,12 +395,10 @@ describe("framework package contract", () => {
     expect(consolePage).toContain(':header="false"');
     expect(consolePage).toContain('auto-save-id="vitehub-agent-session-layout"');
     expect(consolePage).toContain(':continuation-key="list.cursor.value"');
-    expect(consolePage).toContain(':retry-key="invocationPaginationKey"');
-    expect(consolePage).toContain(
-      "const invocationPaginationKey = computed(() => paginationRetryRevision.value);",
-    );
+    expect(consolePage).not.toContain(':retry-key="invocationPaginationKey"');
     expect(consolePage).toContain("list.loadMoreError.value");
     expect(consolePage).toContain("Retry loading older sessions");
+    expect(consolePage).toContain('@click="list.loadMore"');
     expect(consolePage).toContain("Switch Agent");
     expect(consolePage).toContain("agentMenuItems");
     expect(consolePage).toContain("invocation.agentName !== selectedAgentName.value");

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -316,6 +316,10 @@ describe("framework package contract", () => {
     );
     expect(consoleSessionCss).toMatch(/\.session-inspector\s*\{[\s\S]*?height: 100%;/);
     expect(consolePage).toContain("limit: 10");
+    expect(consolePage).toContain("const initialSessionLoading = computed");
+    expect(consolePage).toContain('v-if="initialSessionLoading"');
+    expect(consolePage).toContain(':loading="refreshing"');
+    expect(consolePage).toContain("<template #loading />");
     expect(consolePage).toContain('status === "completed" || status === "failed" || status === "cancelled"');
     expect(consolePage).toContain('label="Load older sessions"');
     expect(consolePage).toContain(':loading="list.isLoading.value || list.isLoadingMore.value"');
@@ -330,12 +334,19 @@ describe("framework package contract", () => {
       `${packageRoot}/dist/console/runtime/components/console-session-navbar.vue`,
       "utf8",
     );
+    const consoleSessionLoading = readFileSync(
+      `${packageRoot}/dist/console/runtime/components/console-session-loading.vue`,
+      "utf8",
+    );
+    expect(consoleSessionLoading).toContain('aria-label="Loading session"');
     expect(consoleSessionNavbar).toContain('v-if="hasSelection" text="Session details"');
     const sessionInspector = readFileSync(
       `${packageRoot}/dist/console/runtime/components/console-session-inspector.vue`,
       "utf8",
     );
     expect(sessionInspector).toContain("Workspace unavailable");
+    expect(sessionInspector).toContain('...(props.workspaceBase ? (["workspace"] as const) : [])');
+    expect(sessionInspector).toContain('if (tab.value === "workspace") void loadWorkspace();');
     expect(sessionInspector).toContain("invocationUsage.totalTokens");
     expect(sessionInspector).toContain("workspace.pullRequest !== undefined");
     expect(sessionInspector).toContain("hasPullRequest && (pullRequest === undefined");
@@ -414,6 +425,8 @@ describe("framework package contract", () => {
     expect(consoleRoute).toContain('import { useHead, useRuntimeConfig } from "#imports"');
     expect(consoleRoute).toContain("<ClientOnly>");
     expect(consoleRoute).toContain("<ConsoleProvider>");
+    expect(consoleRoute).toContain('aria-label="Loading ViteHub Console"');
+    expect(consoleRoute).toContain("lg:grid-rows-[auto_auto_1fr]");
     const consoleIndexRoute = readFileSync(
       `${packageRoot}/dist/console/runtime/pages/index.vue`,
       "utf8",

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -322,6 +322,7 @@ describe("framework package contract", () => {
     expect(consolePage).toContain("<template #loading />");
     expect(consolePage).toContain('status === "completed" || status === "failed" || status === "cancelled"');
     expect(consolePage).toContain('label="Load older sessions"');
+    expect(consolePage).not.toContain('@end-reached="list.loadMore()"');
     expect(consolePage).toContain(':loading="list.isLoading.value || list.isLoadingMore.value"');
     expect(consolePage).toContain("immediate: pageVisible.value && !initialListPending");
     expect(consolePage).toContain("if (initialListPending && !selectedAgentName.value)");

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -307,8 +307,30 @@ describe("framework package contract", () => {
     expect(manifest.exports).not.toHaveProperty("./console/runtime/client/request");
     expect(manifest.exports).not.toHaveProperty("./console/runtime/client/time");
     expect(consolePage).toContain("AgentInvocationList");
+    expect(consolePage).toContain('invocation.annotations?.["agent.model.provider"]');
     expect(consolePage).toContain("ConsoleSessionInspector");
     expect(consolePage).toContain("ConsoleHealth");
+    const consoleSessionCss = readFileSync(
+      `${packageRoot}/dist/console/runtime/components/console-session.css`,
+      "utf8",
+    );
+    expect(consoleSessionCss).toMatch(/\.session-inspector\s*\{[\s\S]*?height: 100%;/);
+    expect(consolePage).toContain("limit: 10");
+    expect(consolePage).toContain('status === "completed" || status === "failed" || status === "cancelled"');
+    expect(consolePage).toContain('label="Load older sessions"');
+    expect(consolePage).toContain(':loading="list.isLoading.value || list.isLoadingMore.value"');
+    expect(consolePage).toContain("immediate: pageVisible.value && !initialListPending");
+    expect(consolePage).toContain("if (initialListPending && !selectedAgentName.value)");
+    expect(consolePage).toContain('v-else-if="invocationView && isDesktop && detailsOpen"');
+    expect(consolePage).toContain("<ConsoleSessionNavbar");
+    expect(consolePage).toMatch(/<template #thread>[\s\S]*?<ConsoleSessionNavbar/);
+    expect(consolePage).toContain('@inspect="inspectSession"');
+    expect(consolePage).toContain("function inspectSession");
+    const consoleSessionNavbar = readFileSync(
+      `${packageRoot}/dist/console/runtime/components/console-session-navbar.vue`,
+      "utf8",
+    );
+    expect(consoleSessionNavbar).toContain('v-if="hasSelection" text="Session details"');
     const sessionInspector = readFileSync(
       `${packageRoot}/dist/console/runtime/components/console-session-inspector.vue`,
       "utf8",
@@ -352,9 +374,9 @@ describe("framework package contract", () => {
       existsSync(`${packageRoot}/dist/console/runtime/components/console-health-model.ts`),
     ).toBe(true);
     expect(consolePage).toContain("agentInvocationTitle");
-    expect(consolePage).toContain("<UDashboardNavbar");
-    expect(consolePage).toContain('class="lg:hidden"');
-    expect(consolePage).not.toContain('class="xl:hidden"');
+    expect(consoleSessionNavbar).toContain("<UDashboardNavbar");
+    expect(consoleSessionNavbar).toContain('class="lg:hidden"');
+    expect(consoleSessionNavbar).not.toContain('class="xl:hidden"');
     expect(consolePage).toContain(':header="false"');
     expect(consolePage).toContain('auto-save-id="vitehub-agent-session-layout"');
     expect(consolePage).toContain(':continuation-key="list.cursor.value"');
@@ -373,9 +395,9 @@ describe("framework package contract", () => {
     );
     expect(consolePage).toContain("encodeAgentRouteParam(agentName)");
     expect(consolePage).toContain("decodeAgentRouteParam(route.params.agent)");
-    expect(consolePage).toContain('data-slot="mobile-session-navigation"');
+    expect(consoleSessionNavbar).toContain('data-slot="mobile-session-navigation"');
     expect(consolePage).toContain('window.matchMedia("(min-width: 1024px)")');
-    expect(consolePage).toContain('class="vitehub-console__session-navbar"');
+    expect(consoleSessionNavbar).toContain('class="vitehub-console__session-navbar"');
     expect(consolePage).toContain("minSize: 220");
     expect(consolePage).toContain("defaultSize: 680");
     expect(consolePage).toContain("maxSize: 1080");
@@ -399,7 +421,9 @@ describe("framework package contract", () => {
     expect(consoleIndexRoute).toContain("<ConsoleHome");
     expect(consoleIndexRoute).toContain(":sections-base=");
     expect(existsSync(`${packageRoot}/dist/console/runtime/pages/blob.vue`)).toBe(true);
-    expect(existsSync(`${packageRoot}/dist/console/runtime/components/console-blob.vue`)).toBe(true);
+    expect(existsSync(`${packageRoot}/dist/console/runtime/components/console-blob.vue`)).toBe(
+      true,
+    );
     expect(existsSync(`${packageRoot}/dist/console/runtime/pages/databases.vue`)).toBe(true);
     expect(existsSync(`${packageRoot}/dist/console/runtime/pages/kv.vue`)).toBe(true);
     const consoleKVRoute = readFileSync(`${packageRoot}/dist/console/runtime/pages/kv.vue`, "utf8");

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -320,8 +320,8 @@ describe("framework package contract", () => {
     expect(consolePage).toContain(
       "[() => detail.invocation.value?.id, () => detail.invocation.value?.status]",
     );
-    expect(consolePage).toContain(
-      "selectedDetailStatus.value?.id === selectedInvocationId.value",
+    expect(consolePage).toMatch(
+      /const detailStatus = selectedDetailStatus\.value;[\s\S]*?detailStatus\?\.id === selectedInvocationId\.value[\s\S]*?\? detailStatus\.status[\s\S]*?: selectedSummary\.value\?\.status/,
     );
     expect(consolePage).toContain('v-if="initialSessionLoading"');
     expect(consolePage).toContain(':loading="refreshing"');
@@ -358,9 +358,8 @@ describe("framework package contract", () => {
     expect(sessionInspector).toContain("workspaceLoading.value = false;");
     expect(sessionInspector).toContain("workspaceRequest = undefined;");
     expect(sessionInspector).toContain('<button v-if="props.workspaceBase"');
-    expect(sessionInspector).toContain(
-      "if (!workspace.value && !workspaceLoading.value) await loadWorkspace();",
-    );
+    expect(sessionInspector).toContain("if (!workspace.value) await loadWorkspace();");
+    expect(sessionInspector).toContain("if (workspaceLoad) return workspaceLoad;");
     expect(sessionInspector).toContain("invocationUsage.totalTokens");
     expect(sessionInspector).toContain("workspace.pullRequest !== undefined");
     expect(sessionInspector).toContain("hasPullRequest && (pullRequest === undefined");

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -326,6 +326,7 @@ describe("framework package contract", () => {
     expect(consolePage).toContain(':loading="list.isLoading.value || list.isLoadingMore.value"');
     expect(consolePage).toContain("immediate: pageVisible.value && !initialListPending");
     expect(consolePage).toContain("if (initialListPending && !selectedAgentName.value)");
+    expect(consolePage).toContain("if (names.length && !isUsageRoute.value)");
     expect(consolePage).toContain('v-else-if="invocationView && isDesktop && detailsOpen"');
     expect(consolePage).toContain("<ConsoleSessionNavbar");
     expect(consolePage).toMatch(/<template #thread>[\s\S]*?<ConsoleSessionNavbar/);

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -962,6 +962,16 @@ describe("vitehub", () => {
     expect(aliases["@vite-hub/workflow/runtime/state"]).toMatch(/packages\/workflow\/dist\/runtime\/state\.js$/)
   })
 
+  it("retains generated Server Env for deferred provider bundles", () => {
+    const plugins = vitehub({ agent: true, preset: "node" })
+    const aliases = providerAliasesFromCall(integrationMocks.hubAgent.mock.calls.at(-1))
+    const dependency = plugins.find(candidate => (candidate as Plugin).name === "vite-hub/dependencies") as Plugin
+
+    callHook(dependency.configResolved, [{ root: "/app" }])
+
+    expect(aliases["#vitehub/env/server"]).toBe("/app/.vitehub/env/server.mjs")
+  })
+
   it.each([
     ["cloudflare", "cloudflare-module"],
     ["netlify", "netlify"],

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -24,11 +24,12 @@ const integrationMocks = vi.hoisted(() => ({
   hubDb: vi.fn(() => ({ name: "@vite-hub/database/vite" })),
   hubEmail: vi.fn(() => ({ name: "@vite-hub/email/vite" })),
   hubEmailOptionalPeerResolver: vi.fn(() => ({ name: "@vite-hub/email/optional-peer-resolver" })),
-  hubEnv: vi.fn(() => ({
+  hubEnv: vi.fn((options?: { projectRoot?: string }) => ({
     api: {
       createServerEnvRegistry: () => ({}),
       getServerEnvRegistry: () => ({}),
       onServerEnvRegistry: () => {},
+      resolveProjectRoot: (viteRoot: string) => options?.projectRoot ? join(viteRoot, options.projectRoot) : viteRoot,
     },
     name: "@vite-hub/env/vite",
   })),
@@ -968,6 +969,16 @@ describe("vitehub", () => {
     const dependency = plugins.find(candidate => (candidate as Plugin).name === "vite-hub/dependencies") as Plugin
 
     callHook(dependency.configResolved, [{ root: "/app" }])
+
+    expect(aliases["#vitehub/env/server"]).toBe("/app/.vitehub/env/server.mjs")
+  })
+
+  it("retains generated Server Env from the resolved Env project root", () => {
+    const plugins = vitehub({ agent: true, env: { projectRoot: ".." }, preset: "node" })
+    const aliases = providerAliasesFromCall(integrationMocks.hubAgent.mock.calls.at(-1))
+    const dependency = plugins.find(candidate => (candidate as Plugin).name === "vite-hub/dependencies") as Plugin
+
+    callHook(dependency.configResolved, [{ root: "/app/client" }])
 
     expect(aliases["#vitehub/env/server"]).toBe("/app/.vitehub/env/server.mjs")
   })

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -122,6 +122,10 @@ export default defineConfig({
         to: "dist/console/runtime/components",
       },
       {
+        from: "src/console/runtime/components/console-session-navbar.vue",
+        to: "dist/console/runtime/components",
+      },
+      {
         from: "src/console/runtime/components/console-session-trace-model.ts",
         to: "dist/console/runtime/components",
       },

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -122,6 +122,10 @@ export default defineConfig({
         to: "dist/console/runtime/components",
       },
       {
+        from: "src/console/runtime/components/console-session-loading.vue",
+        to: "dist/console/runtime/components",
+      },
+      {
         from: "src/console/runtime/components/console-session-navbar.vue",
         to: "dist/console/runtime/components",
       },


### PR DESCRIPTION
## Summary

- restore the full-height session inspector beside the thread while keeping the navbar inside the shrinking thread pane
- wire session, activity, setup, trace, workspace, tools, file diff, and CSS diff inspection into the built-in console
- preserve complete setup metadata, including channels, agent version, provider/model, capabilities, runtime, tools, and deeper configuration
- replace broken first-load and polling states with stable dashboard/session skeletons and explicit retry behavior
- load 10 sessions first, page older history explicitly, discover agent names with an indexed query, defer workspace/heavy terminal work, and stop static or terminal polling
- poll active sessions with prefix-validated observation deltas, build Trace indexes in linear time, and keep ordinary reads available during a deferred compact-search migration

## Why

The console migration removed the Babysitter-specific shell before the built-in console had the same host contract and layout. It also scanned, indexed, and transferred substantially more invocation data than the first screen needed.

Before this change on the current Babysitter database:

- agent discovery: about 2.51 s median because it scanned 1,000 invocation rows
- bounded indexed agent discovery: about 0.24–0.62 ms directly against SQLite
- 10-row first page: about 26–32 ms directly against the store
- 50-row page: about 480 ms directly against the store
- invocation detail payloads reach 6.79 MB and were retransmitted every 3 seconds while active
- SQLite search duplicated 5.41 MB of retained records into another 5.41 MB column

The compact search projection reduces that real search corpus to 159 KB (97.06% smaller) and generated it about 10.3x faster. The smaller first page is deliberate: history remains reachable through the explicit “Load older sessions” control, and group counts use a plus suffix while more pages exist.

## Verification

- @vite-hub/agent: 113 invocation tests, 29 Vue invocation tests, and TypeScript
- @vite-hub/ui: 95 focused tests and TypeScript
- vite-hub: package build, publint, 123 console tests, 25 Trace tests, and TypeScript
- repository lint and vite-doctor strict/new-only: zero warnings
- exact-head preview consumers: Babysitter 7 tests/typecheck/build; Quiver 23 tests/lint/typecheck/build
- built console assets parse as ESM in both consumers
- git diff --check
- independent UI, loading-state, setup-parity, data-performance, delta-protocol, deployment, and final code reviews

Exact-head required CI is running against 01a2c40e89cc3190c8c5f966f2cb4eb608b197e1.
