### PR TITLE
fix(console): make slow session loads feel immediate

### DIFF
--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -114,6 +114,22 @@ function payloadPreview(value: unknown, text: string): string {
   return compact.length > 112 ? `${compact.slice(0, 111)}…` : compact || "Empty payload";
 }
 
+function diagnosticDetails(error: NonNullable<AgentInvocationView["error"]>) {
+  const details: Record<string, unknown> = {};
+  if (error.code !== undefined) details.code = error.code;
+  if (error.requestId) details.requestId = error.requestId;
+  if (error.status !== undefined) details.status = error.status;
+  if (error.statusCode !== undefined) details.statusCode = error.statusCode;
+  if (error.details) details.details = error.details;
+  if (error.cause) details.cause = error.cause;
+  if (error.errors?.length) details.errors = error.errors;
+  if (!Object.keys(details).length) return null;
+  return h("details", { class: "vh-invocation-error__details" }, [
+    h("summary", "Diagnostic details"),
+    h("pre", payloadText(details)),
+  ]);
+}
+
 function jsonValueLabel(value: unknown): string {
   if (hasRuntimeType(value, "string")) return JSON.stringify(value);
   if (value === null) return "null";
@@ -1249,6 +1265,7 @@ export const AgentInvocation = defineComponent({
               ? h("div", { class: "vh-invocation-session__error", role: "alert" }, [
                   h("strong", props.invocation.error.name ?? "Invocation failed"),
                   h("span", props.invocation.error.message),
+                  diagnosticDetails(props.invocation.error),
                 ])
               : null,
             h("div", {
@@ -1415,6 +1432,7 @@ export const AgentInvocationInspector = defineComponent({
                 ? h("div", { class: "vh-invocation-inspector__error" }, [
                     h("strong", props.invocation.error.name ?? "Invocation failed"),
                     h("p", props.invocation.error.message),
+                    diagnosticDetails(props.invocation.error),
                   ])
                 : null,
             ]),

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -338,13 +338,13 @@ function renderMessage(
 }
 
 type ActivityIcon =
+  | "activity"
   | "action"
   | "approval"
-  | "bot"
   | "change"
   | "check"
   | "command"
-  | "error"
+  | "cpu"
   | "eye"
   | "folder"
   | "github"
@@ -355,13 +355,13 @@ type ActivityIcon =
   | "tool";
 
 function activityIcon(activity: InvocationActivity): ActivityIcon {
-  if (activity.status === "failed" || activity.kind === "error") return "error";
   const name = String(activity.attributes["tool.name"] ?? "").toLocaleLowerCase();
   if (activity.command) return "command";
+  if (activity.kind === "error") return "activity";
   if (activity.kind === "change") return "change";
   if (name.includes("read") || name.includes("image") || name.includes("view")) return "eye";
   if (name.includes("search") || name.includes("find")) return "search";
-  if (activity.kind === "reasoning" || activity.kind === "model") return "bot";
+  if (activity.kind === "reasoning" || activity.kind === "model" || activity.kind === "run") return "activity";
   if (activity.kind === "approval") return "approval";
   if (activity.kind === "delivery") {
     const delivery = String(activity.attributes["channel.effect.kind"] ?? "").toLocaleLowerCase();
@@ -375,22 +375,22 @@ function activityIcon(activity: InvocationActivity): ActivityIcon {
     if (title.includes("pull request")) return "pull-request";
     if (title.includes("github")) return "github";
     if (title.includes("workspace")) return "folder";
-    if (title.includes("agent")) return "bot";
+    if (title.includes("agent")) return "cpu";
     if (title.includes("prompt")) return "message";
     return "check";
   }
-  if (activity.kind === "system") return "bot";
-  return "tool";
+  if (activity.kind === "system") return "cpu";
+  return activity.kind === "tool" ? "tool" : "activity";
 }
 
 const activityIconPaths: Record<ActivityIcon, readonly string[]> = {
+  activity: ["M12 12h.01"],
   action: ["M13 2 3 14h9l-1 8 10-12h-9z"],
   approval: ["M12 3v12", "m8 11 4 4 4-4", "M5 21h14"],
-  bot: ["M12 8V4H8", "M4 8h16v10H4z", "M8 12h.01", "M16 12h.01"],
   change: ["M12 20h9", "M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z"],
   check: ["m5 12 4 4L19 6"],
   command: ["m4 17 6-6-6-6", "M12 19h8"],
-  error: ["M18 6 6 18", "m6 6 12 12"],
+  cpu: ["M9 9h6v6H9z", "M9 2v3", "M15 2v3", "M9 19v3", "M15 19v3", "M2 9h3", "M2 15h3", "M19 9h3", "M19 15h3", "M5 5h14v14H5z"],
   eye: ["M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12", "M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6"],
   folder: ["M3 6.5h6l2 2h10v9.5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"],
   github: ["M15 22v-4a4.8 4.8 0 0 0-1-3.5c3.28-.36 6.72-1.61 6.72-7A5.4 5.4 0 0 0 19.22 3.77 5.07 5.07 0 0 0 19.13.32S17.95-.04 15 1.8a13.38 13.38 0 0 0-6 0C6.05-.04 4.87.32 4.87.32A5.07 5.07 0 0 0 4.78 3.77a5.4 5.4 0 0 0-1.5 3.78c0 5.42 3.44 6.61 6.72 7A4.8 4.8 0 0 0 9 18v4", "M9 18c-4.51 2-5-2-7-2"],
@@ -403,21 +403,46 @@ const activityIconPaths: Record<ActivityIcon, readonly string[]> = {
     "M18 21a3 3 0 1 0 0-6 3 3 0 0 0 0 6",
   ],
   search: ["m21 21-4.35-4.35", "M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16"],
-  tool: ["M9 7V5h6v2", "M4 8h16v11H4z", "M4 12h5v2h6v-2h5"],
+  tool: ["M14.7 6.3a4 4 0 0 0-5 5L3 18l3 3 6.7-6.7a4 4 0 0 0 5-5l-2.5 2.5-3-3Z"],
 };
 
 function renderActivityIcon(activity: InvocationActivity) {
-  return renderNamedActivityIcon(activityIcon(activity));
+  return h("span", {
+    class: "vh-invocation-event__icon",
+    "data-failed": activity.status === "failed" ? "true" : undefined,
+    "data-icon": activityIcon(activity),
+    "aria-hidden": "true",
+  }, [
+    renderActivityIconSvg(activityIcon(activity)),
+    activity.status === "failed"
+      ? h("svg", {
+          class: "vh-invocation-event__failure-icon",
+          fill: "currentColor",
+          viewBox: "0 0 24 24",
+        }, [
+          h("path", {
+            "clip-rule": "evenodd",
+            d: "M12 2a10 10 0 1 0 0 20 10 10 0 0 0 0-20Zm-1 5h2v7h-2V7Zm0 9h2v2h-2v-2Z",
+            "fill-rule": "evenodd",
+            stroke: "none",
+          }),
+        ])
+      : null,
+  ]);
 }
 
 function renderNamedActivityIcon(icon: ActivityIcon) {
   return h("span", { class: "vh-invocation-event__icon", "data-icon": icon, "aria-hidden": "true" }, [
-    h("svg", { fill: "none", viewBox: "0 0 24 24" }, activityIconPaths[icon].map(path => h("path", {
-      d: path,
-      "stroke-linecap": "round",
-      "stroke-linejoin": "round",
-    }))),
+    renderActivityIconSvg(icon),
   ]);
+}
+
+function renderActivityIconSvg(icon: ActivityIcon) {
+  return h("svg", { fill: "none", viewBox: "0 0 24 24" }, activityIconPaths[icon].map(path => h("path", {
+    d: path,
+    "stroke-linecap": "round",
+    "stroke-linejoin": "round",
+  })));
 }
 
 function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarget) => void) {
@@ -546,7 +571,7 @@ function renderPreparationAction(activity: InvocationActivity, inspect: (target:
     class: "vh-invocation-preparation__action",
     onClick: () => inspect(target),
     type: "button",
-  }, [renderNamedActivityIcon(target === "workspace" ? "folder" : "bot")]);
+  }, [renderNamedActivityIcon(target === "workspace" ? "folder" : "cpu")]);
 }
 
 function renderPreparationContext(invocation: AgentInvocationView, url: string | undefined) {
@@ -597,15 +622,15 @@ function renderPreparationGroup(
   inspect: (target: InspectTarget) => void,
 ) {
   const url = agentInvocationExternalUrl(invocation);
-  const failed = activities.some(activity => activity.status === "failed");
+  const failedActivity = activities.find(activity => activity.status === "failed");
   return h("li", {
     class: "vh-invocation-preparation",
     key: `preparation:${activities[0]?.id}`,
   }, [
     h("details", { class: "vh-invocation-preparation__details" }, [
       h("summary", { class: "vh-invocation-preparation__summary" }, [
-        renderNamedActivityIcon(failed ? "error" : "check"),
-        h("strong", failed ? "Session preparation failed" : "Session prepared"),
+        failedActivity ? renderActivityIcon(failedActivity) : renderNamedActivityIcon("check"),
+        h("strong", failedActivity ? "Session preparation failed" : "Session prepared"),
         renderPreparationContext(invocation, url),
         h("small", `${activities.length} steps`),
         renderChevronDown("vh-invocation-preparation__disclosure"),
@@ -1057,6 +1082,33 @@ function renderWorkSummary(
   ]);
 }
 
+function orderSessionThread(activities: readonly InvocationActivity[]): readonly InvocationActivity[] {
+  const firstPreparation = activities.findIndex(activity => activity.kind === "preparation");
+  if (firstPreparation < 0) return activities;
+  const firstRuntimeWork = activities.findIndex(activity =>
+    activity.kind === "reasoning"
+    || activity.kind === "model"
+    || activity.kind === "tool"
+    || (
+      activity.kind === "message"
+      && activity.role === "assistant"
+      && activity.name !== "agent.input.message"
+    ),
+  );
+  if (firstRuntimeWork >= 0 && firstPreparation > firstRuntimeWork) return activities;
+
+  let preparationEnd = firstPreparation + 1;
+  while (activities[preparationEnd]?.kind === "preparation") preparationEnd += 1;
+  const initialConfiguration = activities.findIndex((activity, index) =>
+    index < firstPreparation && activity.name === "vitehub.agent.configured",
+  );
+  return [
+    ...activities.slice(firstPreparation, preparationEnd),
+    ...activities.slice(0, firstPreparation).filter((_activity, index) => index !== initialConfiguration),
+    ...activities.slice(preparationEnd),
+  ];
+}
+
 function renderInvocationActivities(
   activities: readonly InvocationActivity[],
   invocation: AgentInvocationView,
@@ -1066,28 +1118,29 @@ function renderInvocationActivities(
   toggleExpanded: (id: string) => void,
   inspect: (target: InspectTarget) => void,
 ) {
+  const orderedActivities = orderSessionThread(activities);
   if (invocation.status === "pending" || invocation.status === "running") {
-    return renderActivitySequence(activities, invocation, expanded, toggleExpanded, inspect);
+    return renderActivitySequence(orderedActivities, invocation, expanded, toggleExpanded, inspect);
   }
-  const firstUser = activities.findIndex(activity => activity.kind === "message" && activity.role === "user");
+  const firstUser = orderedActivities.findIndex(activity => activity.kind === "message" && activity.role === "user");
   let lastUser = -1;
-  for (let index = activities.length - 1; index >= 0; index -= 1) {
-    if (activities[index]!.kind === "message" && activities[index]!.role === "user") {
+  for (let index = orderedActivities.length - 1; index >= 0; index -= 1) {
+    if (orderedActivities[index]!.kind === "message" && orderedActivities[index]!.role === "user") {
       lastUser = index;
       break;
     }
   }
   let lastAssistant = -1;
-  for (let index = activities.length - 1; index >= 0; index -= 1) {
-    if (index > lastUser && activities[index]!.kind === "message" && activities[index]!.role === "assistant") {
+  for (let index = orderedActivities.length - 1; index >= 0; index -= 1) {
+    if (index > lastUser && orderedActivities[index]!.kind === "message" && orderedActivities[index]!.role === "assistant") {
       lastAssistant = index;
       break;
     }
   }
-  if (firstUser < 0) return renderActivitySequence(activities, invocation, expanded, toggleExpanded, inspect);
+  if (firstUser < 0) return renderActivitySequence(orderedActivities, invocation, expanded, toggleExpanded, inspect);
 
-  const prefix = activities.slice(0, firstUser + 1);
-  const tail = activities.slice(firstUser + 1);
+  const prefix = orderedActivities.slice(0, firstUser + 1);
+  const tail = orderedActivities.slice(firstUser + 1);
   const terminal = tail.filter(activity => activity.name === "vitehub.observation.truncated");
   const visibleBeforeFinal = tail.filter((activity, offset) =>
     activity.name !== "vitehub.observation.truncated"
@@ -1109,7 +1162,7 @@ function renderInvocationActivities(
     ...renderActivitySequence(prefix, invocation, expanded, toggleExpanded, inspect),
     ...renderActivitySequence(visibleBeforeFinal, invocation, expanded, toggleExpanded, inspect),
     renderWorkSummary(work, invocation, expanded, workOpen, setWorkOpen, toggleExpanded, inspect),
-    ...(lastAssistant >= 0 ? [renderInvocationActivity(activities[lastAssistant]!, expanded, toggleExpanded, inspect)] : []),
+    ...(lastAssistant >= 0 ? [renderInvocationActivity(orderedActivities[lastAssistant]!, expanded, toggleExpanded, inspect)] : []),
     ...renderActivitySequence(visibleAfterFinal, invocation, expanded, toggleExpanded, inspect),
     ...renderActivitySequence(terminal, invocation, expanded, toggleExpanded, inspect),
   ].filter(item => item !== null);
@@ -1229,6 +1282,8 @@ export const AgentInvocationInspector = defineComponent({
   },
   props: {
     invocation: { required: true, type: Object as PropType<AgentInvocationView> },
+    showStatus: { default: true, type: Boolean },
+    showTimeline: { default: true, type: Boolean },
   },
   setup(props, { emit, slots }) {
     const activities = computed(() => invocationActivities(props.invocation));
@@ -1327,7 +1382,7 @@ export const AgentInvocationInspector = defineComponent({
                 ? `${copyError.value === "trace" ? "Trace" : "Invocation"} ID could not be copied`
                 : ""),
             h("section", { class: "vh-invocation-inspector__identity" }, [
-              h(
+              props.showStatus ? h(
                 "div",
                 {
                   "aria-atomic": "true",
@@ -1342,7 +1397,7 @@ export const AgentInvocationInspector = defineComponent({
                   h("strong", statusLabel(props.invocation.status)),
                   h("small", duration),
                 ],
-              ),
+              ) : null,
               h("h4", agentInvocationTitle(props.invocation)),
               agentInvocationContext(props.invocation) !== props.invocation.id
                 ? h("p", agentInvocationContext(props.invocation))
@@ -1379,7 +1434,9 @@ export const AgentInvocationInspector = defineComponent({
                   : null,
               ]),
             ),
-            traceTimeline(activities.value, props.invocation, id => emit("selectActivity", id)),
+            props.showTimeline
+              ? traceTimeline(activities.value, props.invocation, id => emit("selectActivity", id))
+              : null,
             ...(configuration ? renderConfiguration(configuration) : []),
             slots.metadata?.({ invocation: props.invocation }),
             inspectorSection(

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -277,6 +277,10 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
   for (const observation of invocation.observations ?? []) {
     if (observation.name === "agent.title.recorded") continue;
     const originalAttributes = observation.attributes ?? {};
+    if (
+      observation.name === "agent.stream.error"
+      && originalAttributes["error.recoverable"] === true
+    ) continue;
     const delta = messageText({ parts: [{ text: originalAttributes["message.content"] }] });
     const role = messageRole(originalAttributes["message.role"]);
     const resultText = messageText({ parts: [{ text: originalAttributes["result.text"] }] });

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -79,7 +79,7 @@ export interface AgentInvocationView {
   completedAt?: string;
   configuration?: AgentInvocationConfiguration;
   createdAt: string;
-  error?: { message: string; name?: string };
+  error?: import("@vite-hub/runtime").RuntimeDiagnosticError;
   failedAt?: string;
   id: string;
   observations: readonly import("@vite-hub/runtime").TraceEventLogEntry[];

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -1078,6 +1078,7 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   flex: 0 0 1.25rem;
   height: 1.25rem;
   justify-content: center;
+  position: relative;
   width: 1.25rem;
 }
 
@@ -1089,8 +1090,21 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   width: 0.875rem;
 }
 
-.vh-invocation-activity[data-status="failed"] .vh-invocation-event__icon {
-  color: var(--vh-ui-error);
+.vh-invocation-event__icon[data-icon="activity"] > svg:first-child {
+  stroke-width: 5;
+}
+
+.vh-invocation-event__failure-icon {
+  background: var(--vh-ui-bg);
+  border-radius: 999px;
+  bottom: -0.05rem;
+  color: var(--vh-ui-text);
+  height: 0.65rem !important;
+  opacity: 0.86 !important;
+  position: absolute;
+  right: -0.05rem;
+  stroke: none !important;
+  width: 0.65rem !important;
 }
 
 .vh-invocation-event__title {
@@ -1456,7 +1470,8 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 }
 
 .vh-invocation-command__bar span[data-failed="true"] {
-  color: var(--vh-ui-error);
+  color: var(--vh-ui-text);
+  font-weight: 600;
 }
 
 .vh-invocation-command__cwd {

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -1679,6 +1679,28 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   margin: 0.2rem 0 0;
 }
 
+.vh-invocation-error__details {
+  color: inherit;
+  font-size: 0.6875rem;
+  margin-block-start: 0.45rem;
+}
+
+.vh-invocation-error__details summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.vh-invocation-error__details pre {
+  background: color-mix(in oklab, currentColor 6%, transparent);
+  border-radius: calc(var(--vh-ui-radius) * 0.75);
+  margin: 0.45rem 0 0;
+  max-height: 18rem;
+  overflow: auto;
+  padding: 0.6rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 .vh-invocation-inspector__metrics {
   display: grid;
   gap: 0.375rem;

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -1491,6 +1491,8 @@ describe("Agent Invocation UI", () => {
     const wrapper = mount(AgentInvocation, { props: { invocation } });
 
     expect(wrapper.get(".vh-invocation-command__bar code").text()).toBe("pnpm test");
+    expect(wrapper.get('.vh-invocation-event__icon[data-icon="command"]')).toBeTruthy();
+    expect(wrapper.get(".vh-invocation-event__failure-icon")).toBeTruthy();
     expect(wrapper.get(".vh-invocation-command .vh-invocation-event__payload > strong").text()).toBe("Error");
     expect(wrapper.get(".vh-invocation-command .vh-invocation-event__payload pre").text()).toBe("Command timed out");
   });
@@ -2202,12 +2204,33 @@ describe("Agent Invocation UI", () => {
       observations: [
         {
           attributes: {
+            "input.messages": [
+              { id: "old-user", parts: [{ text: "Earlier question", type: "text" }], role: "user" },
+              { id: "old-assistant", parts: [{ text: "Earlier answer", type: "text" }], role: "assistant" },
+            ],
+          },
+          name: "agent.invocation.started",
+          sequence: 1,
+          timestamp,
+          type: "lifecycle" as const,
+        },
+        {
+          attributes: {
+            "vitehub.agent.configuration": { driver: { model: { id: "gpt-5.6-sol" } } },
+          },
+          name: "vitehub.agent.configured",
+          sequence: 2,
+          timestamp,
+          type: "lifecycle" as const,
+        },
+        {
+          attributes: {
             "vitehub.activity.detail": "vite-hub/vitehub · PR #1030",
             "vitehub.activity.kind": "preparation",
             "vitehub.activity.title": "Pull request selected",
           },
           name: "vitehub.pull-request.selected",
-          sequence: 1,
+          sequence: 3,
           timestamp,
           type: "lifecycle" as const,
         },
@@ -2219,7 +2242,7 @@ describe("Agent Invocation UI", () => {
             "vitehub.inspect.target": "workspace",
           },
           name: "vitehub.workspace.materialization.completed",
-          sequence: 2,
+          sequence: 4,
           timestamp,
           type: "lifecycle" as const,
         },
@@ -2230,21 +2253,21 @@ describe("Agent Invocation UI", () => {
             "message.role": "user",
           },
           name: "agent.message",
-          sequence: 3,
+          sequence: 5,
           timestamp,
           type: "lifecycle" as const,
         },
         {
           attributes: { "vitehub.activity.kind": "reasoning", "vitehub.activity.body": "Checked the diff." },
           name: "agent.reasoning.finish",
-          sequence: 4,
+          sequence: 6,
           timestamp,
           type: "lifecycle" as const,
         },
         {
           attributes: { "message.content": "Merged after checks passed.", "message.id": "assistant", "message.role": "assistant" },
           name: "agent.message",
-          sequence: 5,
+          sequence: 7,
           timestamp,
           type: "lifecycle" as const,
         },
@@ -2255,7 +2278,7 @@ describe("Agent Invocation UI", () => {
             "vitehub.activity.group": "github-lifecycle",
           },
           name: "vitehub.channel.delivery",
-          sequence: 6,
+          sequence: 8,
           timestamp,
           type: "lifecycle" as const,
         },
@@ -2266,7 +2289,13 @@ describe("Agent Invocation UI", () => {
       updatedAt: "2026-08-24T00:02:43.000Z",
     } satisfies AgentInvocationView;
     const wrapper = mount(AgentInvocation, { props: { invocation } });
+    const threadItems = wrapper.findAll('[role="log"] > ol > li');
 
+    expect(threadItems[0]!.classes()).toContain("vh-invocation-preparation");
+    expect(threadItems[1]!.attributes("data-role")).toBe("user");
+    expect(threadItems[1]!.text()).toContain("Earlier question");
+    expect(threadItems[2]!.text()).toContain("Earlier answer");
+    expect(wrapper.find('[data-kind="system"]').exists()).toBe(false);
     expect(wrapper.get(".vh-invocation-preparation__summary").text()).toContain("Session prepared");
     expect(wrapper.get(".vh-invocation-preparation__summary").text()).toContain("2 steps");
     expect(wrapper.get('.vh-invocation-preparation__context a').attributes("href")).toBe(invocation.annotations["github.url"]);
@@ -2274,7 +2303,7 @@ describe("Agent Invocation UI", () => {
     await wrapper.get('button[aria-label="Open Workspace"]').trigger("click");
     expect(wrapper.emitted("inspect")).toEqual([["workspace"]]);
 
-    const prompt = wrapper.get('.vh-invocation-message[data-role="user"]');
+    const prompt = wrapper.findAll('.vh-invocation-message[data-role="user"]').at(-1)!;
     expect(prompt.get(".vh-invocation-message__content").attributes("data-collapsed")).toBe("true");
     await prompt.get(".vh-invocation-message__more").trigger("click");
     expect(prompt.get(".vh-invocation-message__content").attributes("data-collapsed")).toBeUndefined();
@@ -2286,7 +2315,7 @@ describe("Agent Invocation UI", () => {
     work.element.open = true;
     await work.trigger("toggle");
     expect(wrapper.get(".vh-invocation-work__activities").text()).toContain("Checked the diff.");
-    expect(wrapper.get('.vh-invocation-message[data-role="assistant"]').text()).toContain("Merged after checks passed.");
+    expect(wrapper.findAll('.vh-invocation-message[data-role="assistant"]').at(-1)!.text()).toContain("Merged after checks passed.");
     expect(wrapper.get('.vh-invocation-lifecycle[data-activity-group="github-lifecycle"] .vh-invocation-lifecycle__emoji').text()).toBe("👀");
   });
 
@@ -2449,7 +2478,8 @@ describe("Agent Invocation UI", () => {
     const wrapper = mount(AgentInvocation, { props: { invocation } });
     const row = wrapper.get('[data-activity-group="github-lifecycle"] [data-status="failed"]');
 
-    expect(row.get('[data-icon="error"]').attributes("data-icon")).toBe("error");
+    expect(row.get('[data-icon="check"]').attributes("data-icon")).toBe("check");
+    expect(row.find(".vh-invocation-event__failure-icon").exists()).toBe(true);
     expect(row.get(".vh-invocation-lifecycle__title").text()).toBe("Failed to add label");
     expect(row.get(".vh-invocation-lifecycle__failure").text()).toBe("GitHub rejected the label update");
     expect(row.get(".vh-invocation-lifecycle__label").text()).toBe("Agent: Working");
@@ -2607,5 +2637,12 @@ describe("Agent Invocation UI", () => {
     expect(wrapper.get(".vh-invocation-inspector__groups").text()).toContain("reviews · github");
     expect(wrapper.findAll(".vh-invocation-inspector__content > section h4").map(node => node.text())).toContain("Captured setup");
     expect(wrapper.get(".vh-invocation-inspector__groups").text()).toContain("Instructions");
+
+    const compact = mount(AgentInvocationInspector, {
+      props: { invocation, showStatus: false, showTimeline: false },
+    });
+    expect(compact.find(".vh-invocation-inspector__status").exists()).toBe(false);
+    expect(compact.find(".vh-invocation-timeline").exists()).toBe(false);
+    expect(compact.text()).toContain("Captured setup");
   });
 });

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -1641,6 +1641,33 @@ describe("Agent Invocation UI", () => {
     );
   });
 
+  it("keeps bounded runtime diagnostics available behind a disclosure", () => {
+    const invocation: AgentInvocationView = {
+      createdAt: "2026-08-22T00:00:00.000Z",
+      error: {
+        cause: { message: "The upstream socket closed.", name: "SocketError" },
+        code: "provider_unavailable",
+        message: "The provider stopped before returning a result.",
+        name: "Provider error",
+        requestId: "request-123",
+        statusCode: 503,
+      },
+      failedAt: "2026-08-22T00:00:05.000Z",
+      id: "failed-with-diagnostics",
+      observations: [],
+      startedAt: "2026-08-22T00:00:00.000Z",
+      status: "failed",
+      traceId: "trace",
+      updatedAt: "2026-08-22T00:00:05.000Z",
+    };
+    const wrapper = mount(AgentInvocationInspector, { props: { invocation } });
+
+    expect(wrapper.get(".vh-invocation-error__details summary").text()).toBe("Diagnostic details");
+    expect(wrapper.get(".vh-invocation-error__details pre").text()).toContain('"code": "provider_unavailable"');
+    expect(wrapper.get(".vh-invocation-error__details pre").text()).toContain('"requestId": "request-123"');
+    expect(wrapper.get(".vh-invocation-error__details pre").text()).toContain("The upstream socket closed.");
+  });
+
   it("uses the cancellation timestamp for terminal duration", () => {
     const invocation: AgentInvocationView = {
       cancelledAt: "2026-08-22T00:01:05.000Z",

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -1458,7 +1458,7 @@ describe("Agent Invocation UI", () => {
         { attributes: { "tool.id": "tool", "tool.input": { query: "agent UI" }, "tool.name": "search", "tool.title": "airtable · search" }, name: "agent.tool.start", sequence: 1, timestamp, type: "lifecycle" as const },
         { attributes: { "tool.id": "tool", "tool.name": "search" }, name: "agent.tool.start", sequence: 2, timestamp, type: "lifecycle" as const },
         { attributes: { "tool.durationMs": 42, "tool.error": "Search unavailable", "tool.id": "tool" }, name: "agent.tool.error", sequence: 3, timestamp, type: "error" as const },
-        { attributes: { "error.message": "Recoverable stream error" }, name: "agent.stream.error", sequence: 4, timestamp, type: "error" as const },
+        { attributes: { "error.message": "Recoverable stream error", "error.recoverable": true }, name: "agent.stream.error", sequence: 4, timestamp, type: "error" as const },
         { attributes: { "approval.id": "approval", "approval.name": "Run command" }, name: "agent.approval.request", sequence: 5, timestamp, type: "approval" as const },
         { attributes: { "approval.approved": false, "approval.id": "approval", "approval.reason": "Command is destructive" }, name: "agent.approval.decision", sequence: 6, timestamp, type: "approval" as const },
       ],
@@ -1470,7 +1470,6 @@ describe("Agent Invocation UI", () => {
     const activities = invocationActivities(invocation);
     expect(activities.map(activity => [invocationActivityTitle(activity), activity.body, activity.status])).toEqual([
       ["Airtable · search", "Search unavailable", "failed"],
-      ["Agent stream", "Recoverable stream error", "failed"],
       ["Approval denied", "Command is destructive", "failed"],
     ]);
   });

--- a/packages/vite-hub/src/console/runtime/client/main.js
+++ b/packages/vite-hub/src/console/runtime/client/main.js
@@ -267,11 +267,18 @@ const applyPreferredColorScheme = ({ matches }) => {
 applyPreferredColorScheme(preferredColorScheme);
 preferredColorScheme.addEventListener("change", applyPreferredColorScheme);
 
-router.beforeEach(async (to) => {
+router.beforeEach((to) => {
   const section = to.meta.consoleSection;
   if (!isConsoleSectionId(section)) return;
-  const installed = await loadSections();
-  if (installed && !installed.includes(section)) return { name: "vitehub-console" };
+  void loadSections().then((installed) => {
+    if (
+      installed &&
+      !installed.includes(section) &&
+      router.currentRoute.value.fullPath === to.fullPath
+    ) {
+      void router.replace({ name: "vitehub-console" });
+    }
+  });
 });
 
 router.afterEach((to) => {

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -35,7 +35,7 @@ import ConsoleSessionNavbar from "./console-session-navbar.vue";
 import ConsoleSessionInspector from "./console-session-inspector.vue";
 import ConsoleSearch from "./console-search.vue";
 import ConsoleUsage from "./console-usage.vue";
-import { usePreservedAgentSelectionRefresh } from "./console-session-bootstrap";
+import { useConsoleSessionBootstrap } from "./console-session-bootstrap";
 import "./console-session.css";
 
 const route = useRoute();
@@ -81,7 +81,6 @@ let agentsRequest: AbortController | undefined;
 let capabilitiesRequest: AbortController | undefined;
 let refreshCount = 0;
 let invocationListRefreshQueued = false;
-let usageSessionBootstrap = false;
 const sessionPollingEnabled = computed(
   () =>
     pageVisible.value &&
@@ -108,7 +107,11 @@ const list = useAgentInvocations({
 const selectedSummary = computed(() =>
   list.invocations.value.find((invocation) => invocation.id === selectedInvocationId.value),
 );
-const { preserveInvocationListFor } = usePreservedAgentSelectionRefresh({
+const { selectAgentName } = useConsoleSessionBootstrap({
+  agentNames,
+  firstInvocation: computed(() => list.invocations.value[0]),
+  initialBootstrapPending,
+  isUsageRoute,
   isLoading: list.isLoading,
   scheduleRefresh: scheduleInvocationListRefresh,
   selectedAgentName,
@@ -422,9 +425,7 @@ async function loadAgents(): Promise<void> {
 }
 
 function updateSelectedAgentName(name: string, preserveInvocationList = false): void {
-  if (name === selectedAgentName.value) return;
-  if (preserveInvocationList) preserveInvocationListFor(name);
-  selectedAgentName.value = name;
+  selectAgentName(name, preserveInvocationList);
 }
 
 function scheduleInvocationListRefresh(): void {
@@ -520,12 +521,9 @@ watch(
       if (!firstInvocation) return;
       if (!firstInvocation.agentName) {
         initialBootstrapPending.value = false;
-        usageSessionBootstrap = false;
         return;
       }
       selectedInvocationId.value = firstInvocation.id;
-      updateSelectedAgentName(firstInvocation.agentName, usageSessionBootstrap);
-      usageSessionBootstrap = false;
       try {
         await router.replace({
           name: resolveConsoleRouteName(route.name, "vitehub-console-invocation"),
@@ -565,11 +563,7 @@ watch(
         : currentAgent && names.includes(currentAgent)
           ? currentAgent
           : names[0];
-    updateSelectedAgentName(
-      agentName,
-      usageSessionBootstrap && !requestedAgent && !currentAgent,
-    );
-    usageSessionBootstrap = false;
+    updateSelectedAgentName(agentName);
     if (requestedAgent !== agentName) {
       await router.replace({
         name: resolveConsoleRouteName(route.name, "vitehub-console-agent"),
@@ -636,10 +630,7 @@ watch(
   isUsageRoute,
   (usageRoute) => {
     rememberConsoleSection(usageRoute ? "usage" : "agents");
-    if (usageRoute) {
-      usageSessionBootstrap = false;
-    } else {
-      usageSessionBootstrap = !selectedAgentName.value;
+    if (!usageRoute) {
       if (!selectedAgentName.value) initialBootstrapPending.value = true;
       if (!list.isLoading.value && list.invocations.value.length === 0) {
         scheduleInvocationListRefresh();

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -1012,6 +1012,7 @@ onBeforeUnmount(() => {
               <ConsoleSessionLoading
                 v-else-if="detail.isLoading.value || initialSessionLoading"
                 class="h-full min-h-0"
+                :maximizable="Boolean(selectedInvocationId)"
                 surface="inspector"
                 @close="closeDetails"
                 @toggle-maximized="detailsMaximized = true"

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -52,6 +52,7 @@ const props = defineProps<{
 const initialAgentParam = decodeAgentRouteParam(route.params.agent);
 const selectedInvocationId = ref<string>();
 const selectedAgentName = ref(initialAgentParam?.trim() ? initialAgentParam : undefined);
+const initialBootstrapPending = ref(!selectedAgentName.value);
 const agentNames = ref<string[]>([]);
 const agentsLoading = ref(true);
 const agentsError = ref<unknown>();
@@ -78,7 +79,6 @@ let media: MediaQueryList | undefined;
 let agentsRequest: AbortController | undefined;
 let capabilitiesRequest: AbortController | undefined;
 let refreshCount = 0;
-let initialListPending = !selectedAgentName.value;
 const sessionPollingEnabled = computed(
   () =>
     pageVisible.value &&
@@ -86,10 +86,13 @@ const sessionPollingEnabled = computed(
     route.name !== resolveConsoleRouteName(route.name, "vitehub-console-usage"),
 );
 const listPollInterval = computed(() => (sessionPollingEnabled.value ? 5_000 : false));
+const isUsageRoute = computed(
+  () => route.name === resolveConsoleRouteName(route.name, "vitehub-console-usage"),
+);
 
 const list = useAgentInvocations({
   baseURL: props.apiBase,
-  immediate: pageVisible.value && !initialListPending,
+  immediate: pageVisible.value && !isUsageRoute.value,
   pollInterval: listPollInterval,
   request: requestConsole,
   requestSummaries: requestConsole,
@@ -173,9 +176,6 @@ const routeInvocation = computed(() => {
 const routeAgent = computed(() => {
   return decodeAgentRouteParam(route.params.agent);
 });
-const isUsageRoute = computed(
-  () => route.name === resolveConsoleRouteName(route.name, "vitehub-console-usage"),
-);
 const invocationView = computed<AgentInvocationView | undefined>(() => {
   const invocation = detail.invocation.value;
   if (!invocation || invocation.id !== selectedInvocationId.value) return;
@@ -395,7 +395,6 @@ async function loadAgents(): Promise<void> {
         })
       : [];
     if (agentsRequest === controller) {
-      if (names.length && !isUsageRoute.value) initialListPending = false;
       agentNames.value = [...new Set(names)];
       agentsError.value = undefined;
     }
@@ -409,10 +408,6 @@ async function loadAgents(): Promise<void> {
     if (agentsRequest === controller) {
       agentsRequest = undefined;
       agentsLoading.value = false;
-      if (initialListPending && !selectedAgentName.value) {
-        initialListPending = false;
-        if (pageVisible.value) void list.refresh();
-      }
     }
   }
 }
@@ -422,13 +417,10 @@ async function refresh(): Promise<void> {
   refreshing.value = true;
   try {
     const agents = loadAgents();
-    const invocations = initialListPending && !selectedAgentName.value
-      ? agents.then(() => undefined)
-      : list.refresh();
     await Promise.all([
       detectHostCapabilities(),
       agents,
-      invocations,
+      list.refresh(),
       selectedInvocationId.value ? detail.refresh() : Promise.resolve(),
     ]);
   } finally {
@@ -481,7 +473,7 @@ watch(
   [
     routeInvocation,
     routeAgent,
-    () => list.invocations.value[0]?.id,
+    () => list.invocations.value[0],
     selectedAgentName,
     isUsageRoute,
   ],
@@ -490,19 +482,39 @@ watch(
     previous,
   ) => {
     if (usageRoute) {
+      initialBootstrapPending.value = false;
       selectedInvocationId.value = undefined;
       return;
     }
     const routeChanged =
       !previous || requestedInvocation !== previous[0] || requestedAgent !== previous[1];
-    if ((requestedInvocation || requestedAgent) && routeChanged) showSessions();
+    if (requestedInvocation || requestedAgent) {
+      initialBootstrapPending.value = false;
+      if (routeChanged) showSessions();
+    }
+    if (!requestedAgent && !agentName && firstInvocation?.agentName) {
+      selectedInvocationId.value = firstInvocation.id;
+      try {
+        await router.replace({
+          name: resolveConsoleRouteName(route.name, "vitehub-console-invocation"),
+          params: {
+            agent: encodeAgentRouteParam(firstInvocation.agentName),
+            invocation: firstInvocation.id,
+          },
+        });
+        selectedAgentName.value = firstInvocation.agentName;
+      } finally {
+        initialBootstrapPending.value = false;
+      }
+      return;
+    }
     const agentRouteReady = !requestedAgent || requestedAgent === agentName;
     selectedInvocationId.value =
-      requestedInvocation || (agentRouteReady ? firstInvocation : undefined);
-    if (!requestedInvocation && firstInvocation && agentName && agentRouteReady) {
+      requestedInvocation || (agentRouteReady ? firstInvocation?.id : undefined);
+    if (!requestedInvocation && firstInvocation?.id && agentName && agentRouteReady) {
       await router.replace({
         name: resolveConsoleRouteName(route.name, "vitehub-console-invocation"),
-        params: { agent: encodeAgentRouteParam(agentName), invocation: firstInvocation },
+        params: { agent: encodeAgentRouteParam(agentName), invocation: firstInvocation.id },
       });
     }
   },
@@ -510,11 +522,18 @@ watch(
 );
 
 watch(
-  [routeAgent, agentNames, isUsageRoute],
-  async ([requestedAgent, names, usageRoute]) => {
+  [routeAgent, agentNames, isUsageRoute, initialBootstrapPending],
+  async ([requestedAgent, names, usageRoute, bootstrapPending]) => {
     if (usageRoute) return;
     if (!names.length) return;
-    const agentName = requestedAgent && names.includes(requestedAgent) ? requestedAgent : names[0];
+    if (!requestedAgent && bootstrapPending) return;
+    const currentAgent = selectedAgentName.value;
+    const agentName =
+      requestedAgent && names.includes(requestedAgent)
+        ? requestedAgent
+        : currentAgent && names.includes(currentAgent)
+          ? currentAgent
+          : names[0];
     selectedAgentName.value = agentName;
     if (requestedAgent !== agentName) {
       await router.replace({
@@ -524,6 +543,19 @@ watch(
     }
   },
   { immediate: true },
+);
+
+watch(
+  [() => list.isLoading.value, () => list.error.value],
+  ([loading, error]) => {
+    if (
+      initialBootstrapPending.value &&
+      !loading &&
+      (Boolean(error) || list.invocations.value.length === 0)
+    ) {
+      initialBootstrapPending.value = false;
+    }
+  },
 );
 
 watch(
@@ -569,9 +601,22 @@ watch(
   isUsageRoute,
   (usageRoute) => {
     rememberConsoleSection(usageRoute ? "usage" : "agents");
+    if (!usageRoute) {
+      void nextTick(() => {
+        if (
+          pageVisible.value &&
+          !list.isLoading.value &&
+          list.invocations.value.length === 0
+        ) {
+          void list.refresh();
+        }
+      });
+    }
   },
   { immediate: true },
 );
+
+if (pageVisible.value) void loadAgents();
 
 onMounted(() => {
   media = window.matchMedia("(min-width: 981px)");
@@ -580,7 +625,6 @@ onMounted(() => {
   media.addEventListener("change", updateDesktop);
   document.addEventListener("visibilitychange", updatePageVisibility);
   updatePageVisibility();
-  if (pageVisible.value) void loadAgents();
   void detectHostCapabilities();
 });
 
@@ -697,11 +741,25 @@ onBeforeUnmount(() => {
           v-if="
             !collapsed && (agentsLoading || list.isLoading.value) && !invocationItems.length
           "
-          class="grid gap-2 px-3"
+          class="grid gap-1 px-2"
           aria-label="Loading sessions"
           role="status"
         >
-          <USkeleton v-for="index in 4" :key="index" class="h-16 rounded-lg" />
+          <div
+            v-for="index in 6"
+            :key="index"
+            class="grid grid-cols-[1rem_minmax(0,1fr)] gap-x-2 gap-y-2 rounded-md px-2 py-2.5"
+          >
+            <USkeleton class="mt-0.5 size-4 rounded" />
+            <div class="grid min-w-0 gap-2">
+              <div class="flex items-center justify-between gap-3">
+                <USkeleton class="h-3 w-16 rounded" />
+                <USkeleton class="h-3 w-14 rounded" />
+              </div>
+              <USkeleton class="h-4 rounded" :class="index % 3 === 0 ? 'w-3/4' : 'w-full'" />
+              <USkeleton class="h-3 w-2/3 rounded" />
+            </div>
+          </div>
         </div>
         <div v-if="collapsed" class="min-h-0 flex-1 overflow-y-auto">
           <div class="grid gap-1 px-2 py-1">
@@ -858,26 +916,24 @@ onBeforeUnmount(() => {
             <ConsoleSessionLoading
               v-else-if="detail.isLoading.value"
               class="h-full min-h-0"
+              :maximized="true"
+              surface="inspector"
+              @close="closeDetails"
+              @toggle-maximized="detailsMaximized = false"
             />
-            <UEmpty
+            <ConsoleSessionLoading
               v-else
               class="h-full min-h-0"
-              icon="i-ph-cloud-slash-light"
-              title="Could not load this session"
-              :description="errorMessage(detail.error.value)"
-              :actions="[
-                { label: 'Try again', icon: 'i-ph-arrows-clockwise-light', onClick: refresh },
-                {
-                  label: 'Show conversation',
-                  icon: 'i-lucide-panel-right-close',
-                  variant: 'ghost',
-                  onClick: () => (detailsMaximized = false),
-                },
-              ]"
+              :error="errorMessage(detail.error.value)"
+              :maximized="true"
+              surface="inspector"
+              @close="closeDetails"
+              @retry="refresh"
+              @toggle-maximized="detailsMaximized = false"
             />
           </div>
           <USplitter
-            v-else-if="isDesktop && detailsOpen && selectedInvocationId"
+            v-else-if="isDesktop && detailsOpen && (selectedInvocationId || initialSessionLoading)"
             id="agent-session-layout"
             auto-save-id="vitehub-agent-session-layout"
             :items="splitterItems"
@@ -910,7 +966,7 @@ onBeforeUnmount(() => {
                   ]"
                 />
                 <ConsoleSessionLoading
-                  v-if="detail.isLoading.value && !invocationView"
+                  v-if="(detail.isLoading.value || initialSessionLoading) && !invocationView"
                   class="min-h-0 flex-1"
                 />
                 <UEmpty
@@ -949,18 +1005,20 @@ onBeforeUnmount(() => {
                 @toggle-maximized="detailsMaximized = true"
               />
               <ConsoleSessionLoading
-                v-else-if="detail.isLoading.value"
+                v-else-if="detail.isLoading.value || initialSessionLoading"
                 class="h-full min-h-0"
+                surface="inspector"
+                @close="closeDetails"
+                @toggle-maximized="detailsMaximized = true"
               />
-              <UEmpty
+              <ConsoleSessionLoading
                 v-else
                 class="h-full min-h-0"
-                icon="i-ph-cloud-slash-light"
-                title="Could not load session details"
-                :description="errorMessage(detail.error.value)"
-                :actions="[
-                  { label: 'Try again', icon: 'i-ph-arrows-clockwise-light', onClick: refresh },
-                ]"
+                :error="errorMessage(detail.error.value)"
+                surface="inspector"
+                @close="closeDetails"
+                @retry="refresh"
+                @toggle-maximized="detailsMaximized = true"
               />
             </template>
             <template #resize-handle>
@@ -1063,6 +1121,19 @@ onBeforeUnmount(() => {
   height: 100dvh;
   min-height: 0;
   overflow: hidden;
+}
+
+.vitehub-console,
+.vitehub-console :where(*) {
+  scrollbar-gutter: auto !important;
+  scrollbar-width: none;
+}
+
+.vitehub-console::-webkit-scrollbar,
+.vitehub-console :where(*)::-webkit-scrollbar {
+  display: none;
+  height: 0;
+  width: 0;
 }
 
 .vitehub-console [data-slot="invocation"],

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -492,7 +492,12 @@ watch(
       initialBootstrapPending.value = false;
       if (routeChanged) showSessions();
     }
-    if (!requestedAgent && !agentName && firstInvocation?.agentName) {
+    if (!requestedAgent && !agentName) {
+      if (!firstInvocation) return;
+      if (!firstInvocation.agentName) {
+        initialBootstrapPending.value = false;
+        return;
+      }
       selectedInvocationId.value = firstInvocation.id;
       try {
         await router.replace({

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -35,6 +35,7 @@ import ConsoleSessionNavbar from "./console-session-navbar.vue";
 import ConsoleSessionInspector from "./console-session-inspector.vue";
 import ConsoleSearch from "./console-search.vue";
 import ConsoleUsage from "./console-usage.vue";
+import { usePreservedAgentSelectionRefresh } from "./console-session-bootstrap";
 import "./console-session.css";
 
 const route = useRoute();
@@ -80,8 +81,6 @@ let agentsRequest: AbortController | undefined;
 let capabilitiesRequest: AbortController | undefined;
 let refreshCount = 0;
 let invocationListRefreshQueued = false;
-let preservedAgentSelection: string | undefined;
-let refreshAfterPreservedAgentSelection = false;
 let usageSessionBootstrap = false;
 const sessionPollingEnabled = computed(
   () =>
@@ -109,6 +108,11 @@ const list = useAgentInvocations({
 const selectedSummary = computed(() =>
   list.invocations.value.find((invocation) => invocation.id === selectedInvocationId.value),
 );
+const { preserveInvocationListFor } = usePreservedAgentSelectionRefresh({
+  isLoading: list.isLoading,
+  scheduleRefresh: scheduleInvocationListRefresh,
+  selectedAgentName,
+});
 const selectedDetailStatus = ref<{
   id: string;
   status: AgentInvocationListItem["status"];
@@ -419,7 +423,7 @@ async function loadAgents(): Promise<void> {
 
 function updateSelectedAgentName(name: string, preserveInvocationList = false): void {
   if (name === selectedAgentName.value) return;
-  if (preserveInvocationList) preservedAgentSelection = name;
+  if (preserveInvocationList) preserveInvocationListFor(name);
   selectedAgentName.value = name;
 }
 
@@ -643,28 +647,6 @@ watch(
     }
   },
   { immediate: true },
-);
-
-watch(selectedAgentName, (agentName) => {
-  if (agentName && preservedAgentSelection === agentName) {
-    preservedAgentSelection = undefined;
-    refreshAfterPreservedAgentSelection = true;
-    if (!list.isLoading.value) {
-      refreshAfterPreservedAgentSelection = false;
-      scheduleInvocationListRefresh();
-    }
-    return;
-  }
-  scheduleInvocationListRefresh();
-});
-
-watch(
-  () => list.isLoading.value,
-  (loading) => {
-    if (loading || !refreshAfterPreservedAgentSelection) return;
-    refreshAfterPreservedAgentSelection = false;
-    scheduleInvocationListRefresh();
-  },
 );
 
 if (pageVisible.value) void loadAgents();

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -81,6 +81,7 @@ let capabilitiesRequest: AbortController | undefined;
 let refreshCount = 0;
 let invocationListRefreshQueued = false;
 let preservedAgentSelection: string | undefined;
+let refreshAfterPreservedAgentSelection = false;
 let usageSessionBootstrap = false;
 const sessionPollingEnabled = computed(
   () =>
@@ -647,10 +648,24 @@ watch(
 watch(selectedAgentName, (agentName) => {
   if (agentName && preservedAgentSelection === agentName) {
     preservedAgentSelection = undefined;
+    refreshAfterPreservedAgentSelection = true;
+    if (!list.isLoading.value) {
+      refreshAfterPreservedAgentSelection = false;
+      scheduleInvocationListRefresh();
+    }
     return;
   }
   scheduleInvocationListRefresh();
 });
+
+watch(
+  () => list.isLoading.value,
+  (loading) => {
+    if (loading || !refreshAfterPreservedAgentSelection) return;
+    refreshAfterPreservedAgentSelection = false;
+    scheduleInvocationListRefresh();
+  },
+);
 
 if (pageVisible.value) void loadAgents();
 

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -79,6 +79,9 @@ let media: MediaQueryList | undefined;
 let agentsRequest: AbortController | undefined;
 let capabilitiesRequest: AbortController | undefined;
 let refreshCount = 0;
+let invocationListRefreshQueued = false;
+let preservedAgentSelection: string | undefined;
+let usageSessionBootstrap = false;
 const sessionPollingEnabled = computed(
   () =>
     pageVisible.value &&
@@ -96,6 +99,7 @@ const list = useAgentInvocations({
   pollInterval: listPollInterval,
   request: requestConsole,
   requestSummaries: requestConsole,
+  watch: false,
   query: computed(() => ({
     ...(selectedAgentName.value ? { agent: selectedAgentName.value } : {}),
     limit: 10,
@@ -332,7 +336,7 @@ async function selectInvocation(
   if (!agentName) return;
   showSessions();
   sessionsOpen.value = false;
-  selectedAgentName.value = agentName;
+  updateSelectedAgentName(agentName);
   await router.push({
     name: resolveConsoleRouteName(route.name, "vitehub-console-invocation"),
     params: { agent: encodeAgentRouteParam(agentName), invocation: invocation.id },
@@ -342,7 +346,7 @@ async function selectInvocation(
 async function selectAgent(name: string): Promise<void> {
   if (name === selectedAgentName.value) return;
   showSessions();
-  selectedAgentName.value = name;
+  updateSelectedAgentName(name);
   selectedInvocationId.value = undefined;
   await router.push({
     name: resolveConsoleRouteName(route.name, "vitehub-console-agent"),
@@ -412,6 +416,21 @@ async function loadAgents(): Promise<void> {
   }
 }
 
+function updateSelectedAgentName(name: string, preserveInvocationList = false): void {
+  if (name === selectedAgentName.value) return;
+  if (preserveInvocationList) preservedAgentSelection = name;
+  selectedAgentName.value = name;
+}
+
+function scheduleInvocationListRefresh(): void {
+  if (invocationListRefreshQueued) return;
+  invocationListRefreshQueued = true;
+  void nextTick(() => {
+    invocationListRefreshQueued = false;
+    if (pageVisible.value && !isUsageRoute.value) void list.refresh();
+  });
+}
+
 async function refresh(): Promise<void> {
   refreshCount++;
   refreshing.value = true;
@@ -420,7 +439,7 @@ async function refresh(): Promise<void> {
     await Promise.all([
       detectHostCapabilities(),
       agents,
-      list.refresh(),
+      isUsageRoute.value ? Promise.resolve() : list.refresh(),
       selectedInvocationId.value ? detail.refresh() : Promise.resolve(),
     ]);
   } finally {
@@ -496,9 +515,12 @@ watch(
       if (!firstInvocation) return;
       if (!firstInvocation.agentName) {
         initialBootstrapPending.value = false;
+        usageSessionBootstrap = false;
         return;
       }
       selectedInvocationId.value = firstInvocation.id;
+      updateSelectedAgentName(firstInvocation.agentName, usageSessionBootstrap);
+      usageSessionBootstrap = false;
       try {
         await router.replace({
           name: resolveConsoleRouteName(route.name, "vitehub-console-invocation"),
@@ -507,7 +529,6 @@ watch(
             invocation: firstInvocation.id,
           },
         });
-        selectedAgentName.value = firstInvocation.agentName;
       } finally {
         initialBootstrapPending.value = false;
       }
@@ -539,7 +560,11 @@ watch(
         : currentAgent && names.includes(currentAgent)
           ? currentAgent
           : names[0];
-    selectedAgentName.value = agentName;
+    updateSelectedAgentName(
+      agentName,
+      usageSessionBootstrap && !requestedAgent && !currentAgent,
+    );
+    usageSessionBootstrap = false;
     if (requestedAgent !== agentName) {
       await router.replace({
         name: resolveConsoleRouteName(route.name, "vitehub-console-agent"),
@@ -606,20 +631,26 @@ watch(
   isUsageRoute,
   (usageRoute) => {
     rememberConsoleSection(usageRoute ? "usage" : "agents");
-    if (!usageRoute) {
-      void nextTick(() => {
-        if (
-          pageVisible.value &&
-          !list.isLoading.value &&
-          list.invocations.value.length === 0
-        ) {
-          void list.refresh();
-        }
-      });
+    if (usageRoute) {
+      usageSessionBootstrap = false;
+    } else {
+      usageSessionBootstrap = !selectedAgentName.value;
+      if (!selectedAgentName.value) initialBootstrapPending.value = true;
+      if (!list.isLoading.value && list.invocations.value.length === 0) {
+        scheduleInvocationListRefresh();
+      }
     }
   },
   { immediate: true },
 );
+
+watch(selectedAgentName, (agentName) => {
+  if (agentName && preservedAgentSelection === agentName) {
+    preservedAgentSelection = undefined;
+    return;
+  }
+  scheduleInvocationListRefresh();
+});
 
 if (pageVisible.value) void loadAgents();
 

--- a/packages/vite-hub/src/console/runtime/components/console-session-bootstrap.ts
+++ b/packages/vite-hub/src/console/runtime/components/console-session-bootstrap.ts
@@ -1,0 +1,37 @@
+import { watch } from "vue";
+
+import type { Ref } from "vue";
+
+export function usePreservedAgentSelectionRefresh(options: {
+  isLoading: Readonly<Ref<boolean>>;
+  scheduleRefresh: () => void;
+  selectedAgentName: Readonly<Ref<string | undefined>>;
+}) {
+  let preservedAgentSelection: string | undefined;
+  let refreshAfterPreservedAgentSelection = false;
+
+  watch(options.selectedAgentName, (agentName) => {
+    if (agentName && preservedAgentSelection === agentName) {
+      preservedAgentSelection = undefined;
+      refreshAfterPreservedAgentSelection = true;
+      if (!options.isLoading.value) {
+        refreshAfterPreservedAgentSelection = false;
+        options.scheduleRefresh();
+      }
+      return;
+    }
+    options.scheduleRefresh();
+  });
+
+  watch(options.isLoading, (loading) => {
+    if (loading || !refreshAfterPreservedAgentSelection) return;
+    refreshAfterPreservedAgentSelection = false;
+    options.scheduleRefresh();
+  });
+
+  return {
+    preserveInvocationListFor(agentName: string) {
+      preservedAgentSelection = agentName;
+    },
+  };
+}

--- a/packages/vite-hub/src/console/runtime/components/console-session-bootstrap.ts
+++ b/packages/vite-hub/src/console/runtime/components/console-session-bootstrap.ts
@@ -2,13 +2,27 @@ import { watch } from "vue";
 
 import type { Ref } from "vue";
 
-export function usePreservedAgentSelectionRefresh(options: {
+interface BootstrapInvocation {
+  agentName?: string;
+}
+
+export function useConsoleSessionBootstrap(options: {
+  agentNames: Readonly<Ref<readonly string[]>>;
+  firstInvocation: Readonly<Ref<BootstrapInvocation | undefined>>;
+  initialBootstrapPending: Ref<boolean>;
+  isUsageRoute: Readonly<Ref<boolean>>;
   isLoading: Readonly<Ref<boolean>>;
   scheduleRefresh: () => void;
-  selectedAgentName: Readonly<Ref<string | undefined>>;
+  selectedAgentName: Ref<string | undefined>;
 }) {
   let preservedAgentSelection: string | undefined;
   let refreshAfterPreservedAgentSelection = false;
+
+  function selectAgentName(agentName: string, preserveInvocationList = false): void {
+    if (agentName === options.selectedAgentName.value) return;
+    if (preserveInvocationList) preservedAgentSelection = agentName;
+    options.selectedAgentName.value = agentName;
+  }
 
   watch(options.selectedAgentName, (agentName) => {
     if (agentName && preservedAgentSelection === agentName) {
@@ -29,9 +43,33 @@ export function usePreservedAgentSelectionRefresh(options: {
     options.scheduleRefresh();
   });
 
-  return {
-    preserveInvocationListFor(agentName: string) {
-      preservedAgentSelection = agentName;
+  watch(options.firstInvocation, (invocation) => {
+    if (
+      options.isUsageRoute.value ||
+      !options.initialBootstrapPending.value ||
+      options.selectedAgentName.value ||
+      !invocation
+    )
+      return;
+    options.initialBootstrapPending.value = false;
+    if (invocation.agentName) selectAgentName(invocation.agentName, true);
+  });
+
+  watch(
+    [options.agentNames, options.initialBootstrapPending, options.isUsageRoute],
+    ([agentNames, bootstrapPending, isUsageRoute]) => {
+      if (
+        isUsageRoute ||
+        bootstrapPending ||
+        options.selectedAgentName.value ||
+        !agentNames.length
+      )
+        return;
+      selectAgentName(agentNames[0]!);
     },
+  );
+
+  return {
+    selectAgentName,
   };
 }

--- a/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
@@ -562,6 +562,8 @@ function message(error: unknown) {
     <AgentInvocationInspector
       v-else-if="tab === 'details'"
       :invocation="invocation"
+      :show-status="false"
+      :show-timeline="false"
       class="session-inspector__details"
       @select-activity="emit('focusActivity', $event)"
     >

--- a/packages/vite-hub/src/console/runtime/components/console-session-loading.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-loading.vue
@@ -1,22 +1,113 @@
+<script setup lang="ts">
+const props = withDefaults(
+  defineProps<{
+    error?: string;
+    maximized?: boolean;
+    surface?: "thread" | "inspector";
+  }>(),
+  { error: undefined, maximized: false, surface: "thread" },
+);
+
+const emit = defineEmits<{
+  close: [];
+  retry: [];
+  toggleMaximized: [];
+}>();
+</script>
+
 <template>
   <div
     aria-label="Loading session"
-    class="h-full overflow-hidden px-6 py-10 sm:px-10 lg:px-14"
+    class="h-full overflow-hidden"
     role="status"
   >
-    <div class="mx-auto grid w-full max-w-4xl gap-6">
-      <USkeleton class="h-14 rounded-lg" />
-      <div class="mx-auto grid w-full max-w-3xl gap-4 rounded-3xl bg-elevated/60 p-7">
-        <USkeleton class="h-8 w-44 rounded-md" />
-        <USkeleton class="mt-2 h-5 w-4/5 rounded" />
-        <USkeleton class="h-5 w-full rounded" />
-        <USkeleton class="h-5 w-2/3 rounded" />
+    <template v-if="surface === 'inspector'">
+      <div class="flex h-13 items-center justify-between gap-3 border-b border-default px-3">
+        <USkeleton class="h-6 w-28 rounded-md" />
+        <div class="flex items-center gap-0.5">
+          <UTooltip text="Open inspector view">
+            <UButton
+              icon="i-lucide-plus"
+              color="neutral"
+              variant="ghost"
+              size="sm"
+              disabled
+              aria-label="Open inspector view"
+            />
+          </UTooltip>
+          <UTooltip :text="props.maximized ? 'Restore split view' : 'Maximize details'">
+            <UButton
+              :icon="props.maximized ? 'i-lucide-minimize-2' : 'i-lucide-maximize-2'"
+              color="neutral"
+              variant="ghost"
+              size="sm"
+              :aria-label="props.maximized ? 'Restore split view' : 'Maximize details'"
+              @click="emit('toggleMaximized')"
+            />
+          </UTooltip>
+          <UTooltip text="Close details">
+            <UButton
+              icon="i-lucide-panel-right-close"
+              color="neutral"
+              variant="ghost"
+              size="sm"
+              aria-label="Close details"
+              @click="emit('close')"
+            />
+          </UTooltip>
+        </div>
       </div>
-      <USkeleton class="h-12 rounded-lg" />
-      <div class="grid gap-3 px-1">
-        <USkeleton class="h-5 w-1/3 rounded" />
-        <USkeleton class="h-5 w-4/5 rounded" />
-        <USkeleton class="h-5 w-3/5 rounded" />
+      <UEmpty
+        v-if="props.error"
+        class="h-[calc(100%-3.25rem)] min-h-0"
+        icon="i-ph-cloud-slash-light"
+        title="Could not load session details"
+        :description="props.error"
+        :actions="[
+          {
+            label: 'Try again',
+            icon: 'i-ph-arrows-clockwise-light',
+            onClick: () => emit('retry'),
+          },
+        ]"
+      />
+      <div v-else class="grid gap-8 px-5 py-6">
+        <section class="grid gap-3">
+          <USkeleton class="h-6 w-28 rounded-md" />
+          <USkeleton class="h-4 w-3/4 rounded" />
+          <USkeleton class="h-4 w-32 rounded" />
+        </section>
+        <section class="grid gap-3">
+          <USkeleton class="h-3 w-24 rounded" />
+          <div class="grid grid-cols-3 gap-2">
+            <USkeleton v-for="index in 3" :key="index" class="h-20 rounded-lg" />
+          </div>
+        </section>
+        <section class="grid gap-4">
+          <USkeleton class="h-3 w-28 rounded" />
+          <div v-for="index in 5" :key="index" class="grid gap-2">
+            <USkeleton class="h-4 rounded" :class="index % 2 === 0 ? 'w-2/3' : 'w-1/2'" />
+            <USkeleton class="h-1 w-full rounded-full" />
+          </div>
+        </section>
+      </div>
+    </template>
+    <div v-else class="px-6 py-10 sm:px-10 lg:px-14">
+      <div class="mx-auto grid w-full max-w-4xl gap-6">
+        <USkeleton class="h-14 rounded-lg" />
+        <div class="mx-auto grid w-full max-w-3xl gap-4 rounded-3xl bg-elevated/60 p-7">
+          <USkeleton class="h-8 w-44 rounded-md" />
+          <USkeleton class="mt-2 h-5 w-4/5 rounded" />
+          <USkeleton class="h-5 w-full rounded" />
+          <USkeleton class="h-5 w-2/3 rounded" />
+        </div>
+        <USkeleton class="h-12 rounded-lg" />
+        <div class="grid gap-4 px-1">
+          <div v-for="index in 4" :key="index" class="grid gap-2">
+            <USkeleton class="h-4 rounded" :class="index % 2 === 0 ? 'w-3/5' : 'w-4/5'" />
+            <USkeleton class="h-3 w-1/3 rounded" />
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/vite-hub/src/console/runtime/components/console-session-loading.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-loading.vue
@@ -2,10 +2,11 @@
 const props = withDefaults(
   defineProps<{
     error?: string;
+    maximizable?: boolean;
     maximized?: boolean;
     surface?: "thread" | "inspector";
   }>(),
-  { error: undefined, maximized: false, surface: "thread" },
+  { error: undefined, maximizable: true, maximized: false, surface: "thread" },
 );
 
 const emit = defineEmits<{
@@ -17,46 +18,52 @@ const emit = defineEmits<{
 
 <template>
   <div
-    aria-label="Loading session"
+    :aria-label="props.error ? 'Session load failed' : 'Loading session'"
     class="h-full overflow-hidden"
-    role="status"
+    :role="props.error ? 'alert' : 'status'"
   >
     <template v-if="surface === 'inspector'">
-      <div class="flex h-13 items-center justify-between gap-3 border-b border-default px-3">
-        <USkeleton class="h-6 w-28 rounded-md" />
-        <div class="flex items-center gap-0.5">
+      <header class="session-inspector__header">
+        <div class="session-inspector__tabstrip">
+          <USkeleton class="h-6 w-28 rounded-md" />
           <UTooltip text="Open inspector view">
             <UButton
+              class="session-inspector__icon-button"
               icon="i-lucide-plus"
               color="neutral"
               variant="ghost"
-              size="sm"
+              size="xs"
               disabled
               aria-label="Open inspector view"
             />
           </UTooltip>
+        </div>
+        <div class="session-inspector__actions">
           <UTooltip :text="props.maximized ? 'Restore split view' : 'Maximize details'">
             <UButton
+              class="session-inspector__icon-button"
               :icon="props.maximized ? 'i-lucide-minimize-2' : 'i-lucide-maximize-2'"
               color="neutral"
               variant="ghost"
-              size="sm"
+              size="xs"
+              :disabled="!props.maximizable"
               :aria-label="props.maximized ? 'Restore split view' : 'Maximize details'"
               @click="emit('toggleMaximized')"
             />
           </UTooltip>
           <UTooltip text="Close details">
             <UButton
+              class="session-inspector__icon-button"
               icon="i-lucide-panel-right-close"
               color="neutral"
               variant="ghost"
-              size="sm"
+              size="xs"
               aria-label="Close details"
               @click="emit('close')"
             />
           </UTooltip>
         </div>
-      </div>
+      </header>
       <UEmpty
         v-if="props.error"
         class="h-[calc(100%-3.25rem)] min-h-0"

--- a/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
@@ -66,12 +66,14 @@ defineEmits<{
           @click="$emit('refresh')"
         />
       </UTooltip>
-      <UTooltip v-if="hasSelection" text="Session details">
+      <UTooltip :text="hasSelection ? 'Session details' : 'Select a session to inspect'">
         <UButton
+          data-slot="session-details-toggle"
           icon="i-lucide-panel-right"
           color="neutral"
           :variant="detailsOpen ? 'soft' : 'ghost'"
           size="sm"
+          :disabled="!hasSelection"
           aria-label="Session details"
           :aria-pressed="detailsOpen"
           @click="$emit('toggleDetails')"

--- a/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-defineProps<{
+import { computed } from "vue";
+
+const props = defineProps<{
   detailsOpen: boolean;
   externalUrl?: string;
   hasDisplay: boolean;
@@ -8,6 +10,18 @@ defineProps<{
   project: string;
   title: string;
 }>();
+
+const externalTarget = computed(() => {
+  if (!props.externalUrl) return;
+  try {
+    const host = new URL(props.externalUrl).hostname.toLowerCase();
+    if (host === "github.com" || host.endsWith(".github.com"))
+      return { icon: "i-lucide-github", label: "Open on GitHub" };
+  } catch {
+    // Keep malformed or relative consumer links usable with the generic action.
+  }
+  return { icon: "i-lucide-external-link", label: "Open related page" };
+});
 
 defineEmits<{
   openSessions: [];
@@ -44,15 +58,15 @@ defineEmits<{
           @click="$emit('openSessions')"
         />
       </UTooltip>
-      <UTooltip v-if="externalUrl" text="Open related page">
+      <UTooltip v-if="externalUrl && externalTarget" :text="externalTarget.label">
         <UButton
           :to="externalUrl"
           target="_blank"
-          icon="i-lucide-external-link"
+          :icon="externalTarget.icon"
           color="neutral"
           variant="ghost"
           size="sm"
-          aria-label="Open related page"
+          :aria-label="externalTarget.label"
         />
       </UTooltip>
       <UTooltip text="Refresh session">

--- a/packages/vite-hub/src/console/runtime/components/console-session-trace.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-trace.vue
@@ -66,7 +66,7 @@ const traceEndMs = computed(() =>
     ...spans.value.map((span) => traceSpanEndMs(span.startMs, span.endMs, span.durationMs)),
   ),
 );
-const traceDurationMs = computed(() => Math.max(1, traceEndMs.value - traceStartMs.value));
+const traceWindowMs = computed(() => Math.max(1, traceEndMs.value - traceStartMs.value));
 const filteredSpans = computed(() => {
   const query = spanQuery.value.trim().toLowerCase();
   if (!query) return spans.value;
@@ -104,7 +104,7 @@ const filteredAttributes = computed(() => {
 });
 const ticks = computed(() =>
   [0, 0.25, 0.5, 0.75, 1].map((position) => ({
-    label: formatAxis(traceDurationMs.value * position),
+    label: formatAxis(traceWindowMs.value * position),
     position,
   })),
 );
@@ -422,9 +422,9 @@ function spanIcon(operation: string) {
 function barStyle(span: TraceSpan) {
   const left = Math.max(
     0,
-    Math.min(100, ((span.startMs - traceStartMs.value) / traceDurationMs.value) * 100),
+    Math.min(100, ((span.startMs - traceStartMs.value) / traceWindowMs.value) * 100),
   );
-  const width = Math.max(0, Math.min(100 - left, (span.durationMs / traceDurationMs.value) * 100));
+  const width = Math.max(0, Math.min(100 - left, (span.durationMs / traceWindowMs.value) * 100));
   return { left: `${left}%`, width: `max(3px, ${width}%)` };
 }
 
@@ -588,7 +588,7 @@ async function copyAttributes() {
                 />
                 <span
                   class="session-trace__bar"
-                  :data-wide="span.durationMs / traceDurationMs > 0.16"
+                  :data-wide="span.durationMs / traceWindowMs > 0.16"
                   :style="barStyle(span)"
                   ><span>{{ formatDuration(span.durationMs) }}</span></span
                 >

--- a/packages/vite-hub/src/console/runtime/components/console-session.css
+++ b/packages/vite-hub/src/console/runtime/components/console-session.css
@@ -594,17 +594,21 @@
   min-width: max-content;
 }
 
-.session-code-preview .shiki {
+.session-code-preview .shiki,
+.session-code-preview__plain {
   background: transparent !important;
-  counter-reset: line;
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-size: 0.75rem;
-  line-height: 1.45;
+  font-size: 0.6875rem;
+  line-height: 1.4;
   margin: 0;
   min-height: 100%;
   min-width: max-content;
   padding: 0.625rem 0 1.5rem;
   tab-size: 2;
+}
+
+.session-code-preview .shiki {
+  counter-reset: line;
 }
 
 .session-code-preview .line {

--- a/packages/vite-hub/test/console-bootstrap.test.ts
+++ b/packages/vite-hub/test/console-bootstrap.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from "node:fs";
 
 import { useAgentInvocations } from "../../agent/src/invocations-vue";
+import { usePreservedAgentSelectionRefresh } from "../src/console/runtime/components/console-session-bootstrap";
 import { computed, effectScope, nextTick, ref, watch } from "vue";
 import { describe, expect, it } from "vitest";
 
@@ -29,8 +30,6 @@ describe.each(["agents-first", "invocations-first"] as const)(
       const agentNames = ref<string[]>([]);
       const initialBootstrapPending = ref(true);
       const selectedAgentName = ref<string>();
-      let preservedAgentSelection: string | undefined;
-      let refreshAfterPreservedAgentSelection = false;
       let refreshQueued = false;
       const requests: Array<{
         path: string;
@@ -59,6 +58,11 @@ describe.each(["agents-first", "invocations-first"] as const)(
             void resource.refresh();
           });
         };
+        const { preserveInvocationListFor } = usePreservedAgentSelectionRefresh({
+          isLoading: resource.isLoading,
+          scheduleRefresh,
+          selectedAgentName,
+        });
         watch(agentNames, (names) => {
           if (!names.length || initialBootstrapPending.value || selectedAgentName.value) return;
           selectedAgentName.value = names[0];
@@ -67,28 +71,11 @@ describe.each(["agents-first", "invocations-first"] as const)(
           () => resource.invocations.value[0],
           (invocation) => {
             if (!invocation?.agentName || selectedAgentName.value) return;
-            preservedAgentSelection = invocation.agentName;
+            preserveInvocationListFor(invocation.agentName);
             selectedAgentName.value = invocation.agentName;
             initialBootstrapPending.value = false;
           },
         );
-        watch(selectedAgentName, (agentName) => {
-          if (agentName && preservedAgentSelection === agentName) {
-            preservedAgentSelection = undefined;
-            refreshAfterPreservedAgentSelection = true;
-            if (!resource.isLoading.value) {
-              refreshAfterPreservedAgentSelection = false;
-              scheduleRefresh();
-            }
-            return;
-          }
-          scheduleRefresh();
-        });
-        watch(resource.isLoading, (loading) => {
-          if (loading || !refreshAfterPreservedAgentSelection) return;
-          refreshAfterPreservedAgentSelection = false;
-          scheduleRefresh();
-        });
         return resource;
       })!;
 

--- a/packages/vite-hub/test/console-bootstrap.test.ts
+++ b/packages/vite-hub/test/console-bootstrap.test.ts
@@ -1,6 +1,8 @@
 import { readFileSync } from "node:fs";
 
-import { expect, it } from "vitest";
+import { useAgentInvocations } from "../../agent/src/invocations-vue";
+import { computed, effectScope, nextTick, ref, watch } from "vue";
+import { describe, expect, it } from "vitest";
 
 const consolePage = readFileSync(
   new URL("../src/console/runtime/components/console-app.vue", import.meta.url),
@@ -9,6 +11,98 @@ const consolePage = readFileSync(
 
 it("releases bare Agents bootstrap when the newest invocation is unnamed", () => {
   expect(consolePage).toMatch(
-    /if \(!firstInvocation\.agentName\) \{\s+initialBootstrapPending\.value = false;\s+return;\s+\}/,
+    /if \(!firstInvocation\.agentName\) \{\s+initialBootstrapPending\.value = false;\s+usageSessionBootstrap = false;\s+return;\s+\}/,
   );
 });
+
+it("keeps shared refreshes on Usage free of Invocation requests", () => {
+  expect(consolePage).toContain(
+    "isUsageRoute.value ? Promise.resolve() : list.refresh()",
+  );
+});
+
+describe.each(["agents-first", "invocations-first"] as const)(
+  "Usage-to-Sessions bootstrap (%s)",
+  (responseOrder) => {
+    it("keeps one Invocation request alive while selecting the Agent", async () => {
+      const scope = effectScope();
+      const agentNames = ref<string[]>([]);
+      const initialBootstrapPending = ref(true);
+      const selectedAgentName = ref<string>();
+      let preservedAgentSelection: string | undefined;
+      const requests: Array<{
+        resolve: (value: unknown) => void;
+        signal: AbortSignal;
+      }> = [];
+
+      const list = scope.run(() => {
+        const resource = useAgentInvocations({
+          immediate: false,
+          query: computed(() => ({
+            ...(selectedAgentName.value ? { agent: selectedAgentName.value } : {}),
+            limit: 10,
+          })),
+          request: (_path, { signal }) =>
+            new Promise((resolve) => {
+              requests.push({ resolve, signal: signal! });
+            }),
+          watch: false,
+        });
+        watch(agentNames, (names) => {
+          if (!names.length || initialBootstrapPending.value || selectedAgentName.value) return;
+          selectedAgentName.value = names[0];
+        });
+        watch(
+          () => resource.invocations.value[0],
+          (invocation) => {
+            if (!invocation?.agentName || selectedAgentName.value) return;
+            preservedAgentSelection = invocation.agentName;
+            selectedAgentName.value = invocation.agentName;
+            initialBootstrapPending.value = false;
+          },
+        );
+        watch(selectedAgentName, (agentName) => {
+          if (agentName && preservedAgentSelection === agentName) {
+            preservedAgentSelection = undefined;
+            return;
+          }
+          void resource.refresh();
+        });
+        return resource;
+      })!;
+
+      const listRequest = list.refresh();
+      expect(requests).toHaveLength(1);
+      const invocationResponse = {
+        invocations: [
+          {
+            agentName: "alpha",
+            createdAt: "2026-09-01T00:00:00.000Z",
+            cursor: "cursor-1",
+            id: "invocation-1",
+            status: "running",
+            traceId: "trace-1",
+            updatedAt: "2026-09-01T00:00:00.000Z",
+          },
+        ],
+      };
+
+      if (responseOrder === "agents-first") {
+        agentNames.value = ["alpha"];
+        await nextTick();
+        requests[0]!.resolve(invocationResponse);
+        await listRequest;
+      } else {
+        requests[0]!.resolve(invocationResponse);
+        await listRequest;
+        agentNames.value = ["alpha"];
+      }
+      await nextTick();
+
+      expect(selectedAgentName.value).toBe("alpha");
+      expect(requests).toHaveLength(1);
+      expect(requests[0]!.signal.aborted).toBe(false);
+      scope.stop();
+    });
+  },
+);

--- a/packages/vite-hub/test/console-bootstrap.test.ts
+++ b/packages/vite-hub/test/console-bootstrap.test.ts
@@ -30,7 +30,10 @@ describe.each(["agents-first", "invocations-first"] as const)(
       const initialBootstrapPending = ref(true);
       const selectedAgentName = ref<string>();
       let preservedAgentSelection: string | undefined;
+      let refreshAfterPreservedAgentSelection = false;
+      let refreshQueued = false;
       const requests: Array<{
+        path: string;
         resolve: (value: unknown) => void;
         signal: AbortSignal;
       }> = [];
@@ -42,12 +45,20 @@ describe.each(["agents-first", "invocations-first"] as const)(
             ...(selectedAgentName.value ? { agent: selectedAgentName.value } : {}),
             limit: 10,
           })),
-          request: (_path, { signal }) =>
+          request: (path, { signal }) =>
             new Promise((resolve) => {
-              requests.push({ resolve, signal: signal! });
+              requests.push({ path, resolve, signal: signal! });
             }),
           watch: false,
         });
+        const scheduleRefresh = () => {
+          if (refreshQueued) return;
+          refreshQueued = true;
+          void nextTick(() => {
+            refreshQueued = false;
+            void resource.refresh();
+          });
+        };
         watch(agentNames, (names) => {
           if (!names.length || initialBootstrapPending.value || selectedAgentName.value) return;
           selectedAgentName.value = names[0];
@@ -64,9 +75,19 @@ describe.each(["agents-first", "invocations-first"] as const)(
         watch(selectedAgentName, (agentName) => {
           if (agentName && preservedAgentSelection === agentName) {
             preservedAgentSelection = undefined;
+            refreshAfterPreservedAgentSelection = true;
+            if (!resource.isLoading.value) {
+              refreshAfterPreservedAgentSelection = false;
+              scheduleRefresh();
+            }
             return;
           }
-          void resource.refresh();
+          scheduleRefresh();
+        });
+        watch(resource.isLoading, (loading) => {
+          if (loading || !refreshAfterPreservedAgentSelection) return;
+          refreshAfterPreservedAgentSelection = false;
+          scheduleRefresh();
         });
         return resource;
       })!;
@@ -100,8 +121,11 @@ describe.each(["agents-first", "invocations-first"] as const)(
       await nextTick();
 
       expect(selectedAgentName.value).toBe("alpha");
-      expect(requests).toHaveLength(1);
+      expect(requests).toHaveLength(2);
       expect(requests[0]!.signal.aborted).toBe(false);
+      expect(requests[1]!.path).toContain("agent=alpha");
+      requests[1]!.resolve(invocationResponse);
+      await nextTick();
       scope.stop();
     });
   },

--- a/packages/vite-hub/test/console-bootstrap.test.ts
+++ b/packages/vite-hub/test/console-bootstrap.test.ts
@@ -1,8 +1,8 @@
 import { readFileSync } from "node:fs";
 
 import { useAgentInvocations } from "../../agent/src/invocations-vue";
-import { usePreservedAgentSelectionRefresh } from "../src/console/runtime/components/console-session-bootstrap";
-import { computed, effectScope, nextTick, ref, watch } from "vue";
+import { useConsoleSessionBootstrap } from "../src/console/runtime/components/console-session-bootstrap";
+import { computed, effectScope, nextTick, ref } from "vue";
 import { describe, expect, it } from "vitest";
 
 const consolePage = readFileSync(
@@ -10,10 +10,30 @@ const consolePage = readFileSync(
   "utf8",
 );
 
-it("releases bare Agents bootstrap when the newest invocation is unnamed", () => {
-  expect(consolePage).toMatch(
-    /if \(!firstInvocation\.agentName\) \{\s+initialBootstrapPending\.value = false;\s+usageSessionBootstrap = false;\s+return;\s+\}/,
-  );
+it("releases bare Agents bootstrap when the newest invocation is unnamed", async () => {
+  const scope = effectScope();
+  const firstInvocation = ref<{ agentName?: string }>();
+  const initialBootstrapPending = ref(true);
+  const selectedAgentName = ref<string>();
+
+  scope.run(() => {
+    useConsoleSessionBootstrap({
+      agentNames: ref([]),
+      firstInvocation,
+      initialBootstrapPending,
+      isLoading: ref(false),
+      isUsageRoute: ref(false),
+      scheduleRefresh: () => undefined,
+      selectedAgentName,
+    });
+  });
+
+  firstInvocation.value = {};
+  await nextTick();
+
+  expect(initialBootstrapPending.value).toBe(false);
+  expect(selectedAgentName.value).toBeUndefined();
+  scope.stop();
 });
 
 it("keeps shared refreshes on Usage free of Invocation requests", () => {
@@ -58,24 +78,15 @@ describe.each(["agents-first", "invocations-first"] as const)(
             void resource.refresh();
           });
         };
-        const { preserveInvocationListFor } = usePreservedAgentSelectionRefresh({
+        useConsoleSessionBootstrap({
+          agentNames,
+          firstInvocation: computed(() => resource.invocations.value[0]),
+          initialBootstrapPending,
+          isUsageRoute: ref(false),
           isLoading: resource.isLoading,
           scheduleRefresh,
           selectedAgentName,
         });
-        watch(agentNames, (names) => {
-          if (!names.length || initialBootstrapPending.value || selectedAgentName.value) return;
-          selectedAgentName.value = names[0];
-        });
-        watch(
-          () => resource.invocations.value[0],
-          (invocation) => {
-            if (!invocation?.agentName || selectedAgentName.value) return;
-            preserveInvocationListFor(invocation.agentName);
-            selectedAgentName.value = invocation.agentName;
-            initialBootstrapPending.value = false;
-          },
-        );
         return resource;
       })!;
 

--- a/packages/vite-hub/test/console-bootstrap.test.ts
+++ b/packages/vite-hub/test/console-bootstrap.test.ts
@@ -1,0 +1,14 @@
+import { readFileSync } from "node:fs";
+
+import { expect, it } from "vitest";
+
+const consolePage = readFileSync(
+  new URL("../src/console/runtime/components/console-app.vue", import.meta.url),
+  "utf8",
+);
+
+it("releases bare Agents bootstrap when the newest invocation is unnamed", () => {
+  expect(consolePage).toMatch(
+    /if \(!firstInvocation\.agentName\) \{\s+initialBootstrapPending\.value = false;\s+return;\s+\}/,
+  );
+});

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -337,11 +337,13 @@ describe("framework package contract", () => {
     expect(consolePage).toContain(':loading="list.isLoading.value || list.isLoadingMore.value"');
     expect(consolePage).toContain("immediate: pageVisible.value && !isUsageRoute.value");
     expect(consolePage).not.toContain("initialListPending");
-    expect(consolePage).toMatch(
-      /await Promise\.all\(\[[\s\S]*?agents,[\s\S]*?list\.refresh\(\),/,
+    expect(consolePage).toContain(
+      "isUsageRoute.value ? Promise.resolve() : list.refresh()",
     );
+    expect(consolePage).toContain("watch: false");
     expect(consolePage).toContain("const initialBootstrapPending = ref(!selectedAgentName.value)");
-    expect(consolePage).toContain("!requestedAgent && !agentName && firstInvocation?.agentName");
+    expect(consolePage).toContain("if (!requestedAgent && !agentName)");
+    expect(consolePage).toContain("if (!firstInvocation) return");
     expect(consolePage).toContain("selectedInvocationId.value = firstInvocation.id");
     expect(consolePage).toContain("invocation: firstInvocation.id");
     expect(consolePage).toContain("if (!requestedAgent && bootstrapPending) return");
@@ -350,7 +352,7 @@ describe("framework package contract", () => {
       consolePage.indexOf("onMounted(() =>"),
     );
     expect(consolePage).toMatch(
-      /if \(!usageRoute\) \{[\s\S]*?void nextTick\(\(\) => \{[\s\S]*?!list\.isLoading\.value[\s\S]*?void list\.refresh\(\);/,
+      /usageSessionBootstrap = !selectedAgentName\.value;[\s\S]*?!list\.isLoading\.value[\s\S]*?scheduleInvocationListRefresh\(\);/,
     );
     expect(consolePage).toContain(
       'v-else-if="isDesktop && detailsOpen && (selectedInvocationId || initialSessionLoading)"',

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -355,9 +355,6 @@ describe("framework package contract", () => {
     expect(consolePage.indexOf("if (pageVisible.value) void loadAgents();")).toBeLessThan(
       consolePage.indexOf("onMounted(() =>"),
     );
-    expect(consolePage).toMatch(
-      /usageSessionBootstrap = !selectedAgentName\.value;[\s\S]*?!list\.isLoading\.value[\s\S]*?scheduleInvocationListRefresh\(\);/,
-    );
     expect(consolePage).toContain(
       'v-else-if="isDesktop && detailsOpen && (selectedInvocationId || initialSessionLoading)"',
     );

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -375,10 +375,16 @@ describe("framework package contract", () => {
       `${packageRoot}/dist/console/runtime/components/console-session-loading.vue`,
       "utf8",
     );
-    expect(consoleSessionLoading).toContain('aria-label="Loading session"');
-    expect(consoleSessionLoading).toContain('surface === \'inspector\'');
+    expect(consoleSessionLoading).toContain(
+      ":aria-label=\"props.error ? 'Session load failed' : 'Loading session'\"",
+    );
+    expect(consoleSessionLoading).toContain(":role=\"props.error ? 'alert' : 'status'\"");
+    expect(consoleSessionLoading).toContain("surface === 'inspector'");
     expect(consoleSessionLoading).toContain('icon="i-lucide-panel-right-close"');
+    expect(consoleSessionLoading).toContain(':disabled="!props.maximizable"');
+    expect(consoleSessionLoading).toContain('class="session-inspector__header"');
     expect(consoleSessionLoading).toContain("emit('toggleMaximized')");
+    expect(consolePage).toContain(':maximizable="Boolean(selectedInvocationId)"');
     expect(consoleSessionNavbar).toContain('data-slot="session-details-toggle"');
     expect(consoleSessionNavbar).toContain(':disabled="!hasSelection"');
     expect(consolePage).toMatch(/scrollbar-width: none;/);

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -300,6 +300,10 @@ describe("framework package contract", () => {
       /\[data-slot="invocation"\],[\s\S]*?\[data-slot="invocation-inspector"\]\s*\{[\s\S]*?height: 100%;[\s\S]*?width: 100%;[\s\S]*?\}/,
     );
     expect(consolePage).toContain('from "../console-route"');
+    expect(consolePage).toContain('from "./console-session-bootstrap"');
+    expect(
+      existsSync(`${packageRoot}/dist/console/runtime/components/console-session-bootstrap.ts`),
+    ).toBe(true);
     expect(existsSync(`${packageRoot}/dist/console/runtime/console-route.js`)).toBe(true);
     expect(existsSync(`${packageRoot}/dist/console/runtime/sections.js`)).toBe(true);
     expect(existsSync(`${packageRoot}/dist/console/runtime/client/request.js`)).toBe(true);

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -389,6 +389,8 @@ describe("framework package contract", () => {
     expect(consolePage).toContain(':maximizable="Boolean(selectedInvocationId)"');
     expect(consoleSessionNavbar).toContain('data-slot="session-details-toggle"');
     expect(consoleSessionNavbar).toContain(':disabled="!hasSelection"');
+    expect(consoleSessionNavbar).toContain('icon: "i-lucide-github"');
+    expect(consoleSessionNavbar).toContain('label: "Open on GitHub"');
     expect(consolePage).toMatch(/scrollbar-width: none;/);
     expect(consolePage).toMatch(/::-webkit-scrollbar[\s\S]*?display: none;/);
     const consoleClientMain = readFileSync(
@@ -402,6 +404,8 @@ describe("framework package contract", () => {
       "utf8",
     );
     expect(sessionInspector).toContain("Workspace unavailable");
+    expect(sessionInspector).toContain(':show-status="false"');
+    expect(sessionInspector).toContain(':show-timeline="false"');
     expect(sessionInspector).toContain('...(props.workspaceBase ? (["workspace"] as const) : [])');
     expect(sessionInspector).toContain('if (tab.value === "workspace") void loadWorkspace();');
     expect(sessionInspector).toContain("workspaceLoading.value = false;");
@@ -435,6 +439,8 @@ describe("framework package contract", () => {
     expect(sessionTraceModel).toContain('"error",');
     expect(sessionTraceModel).toContain('"failed",');
     expect(sessionTrace).toContain("traceSpanEndMs(");
+    expect(sessionTrace).toContain("const traceWindowMs = computed");
+    expect(sessionTrace).not.toContain("const traceDurationMs = computed");
     expect(sessionTrace).toContain("isTerminalToolObservation");
     expect(
       readFileSync(
@@ -442,6 +448,9 @@ describe("framework package contract", () => {
         "utf8",
       ),
     ).toContain("highlightingFailed");
+    expect(consoleSessionCss).toMatch(
+      /\.session-code-preview \.shiki,[\s\S]*?\.session-code-preview__plain[\s\S]*?font-size: 0\.6875rem;/,
+    );
     expect(
       readFileSync(`${packageRoot}/dist/console/runtime/components/console-health.vue`, "utf8"),
     ).toContain("<h1>Health</h1>");

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -335,17 +335,31 @@ describe("framework package contract", () => {
     expect(consolePage).toContain('label="Load older sessions"');
     expect(consolePage).not.toContain('@end-reached="list.loadMore()"');
     expect(consolePage).toContain(':loading="list.isLoading.value || list.isLoadingMore.value"');
-    expect(consolePage).toContain("immediate: pageVisible.value && !initialListPending");
-    expect(consolePage).toContain("if (initialListPending && !selectedAgentName.value)");
-    expect(consolePage).toContain("if (names.length && !isUsageRoute.value)");
+    expect(consolePage).toContain("immediate: pageVisible.value && !isUsageRoute.value");
+    expect(consolePage).not.toContain("initialListPending");
+    expect(consolePage).toMatch(
+      /await Promise\.all\(\[[\s\S]*?agents,[\s\S]*?list\.refresh\(\),/,
+    );
+    expect(consolePage).toContain("const initialBootstrapPending = ref(!selectedAgentName.value)");
+    expect(consolePage).toContain("!requestedAgent && !agentName && firstInvocation?.agentName");
+    expect(consolePage).toContain("selectedInvocationId.value = firstInvocation.id");
+    expect(consolePage).toContain("invocation: firstInvocation.id");
+    expect(consolePage).toContain("if (!requestedAgent && bootstrapPending) return");
+    expect(consolePage).toContain("currentAgent && names.includes(currentAgent)");
+    expect(consolePage.indexOf("if (pageVisible.value) void loadAgents();")).toBeLessThan(
+      consolePage.indexOf("onMounted(() =>"),
+    );
+    expect(consolePage).toMatch(
+      /if \(!usageRoute\) \{[\s\S]*?void nextTick\(\(\) => \{[\s\S]*?!list\.isLoading\.value[\s\S]*?void list\.refresh\(\);/,
+    );
     expect(consolePage).toContain(
-      'v-else-if="isDesktop && detailsOpen && selectedInvocationId"',
+      'v-else-if="isDesktop && detailsOpen && (selectedInvocationId || initialSessionLoading)"',
     );
     expect(consolePage).toContain(
       'v-if="isDesktop && detailsOpen && detailsMaximized && selectedInvocationId"',
     );
-    expect(consolePage).toContain('v-if="detail.isLoading.value && !invocationView"');
-    expect(consolePage).toContain("Show conversation");
+    expect(consolePage).toContain("detail.isLoading.value || initialSessionLoading");
+    expect(consolePage).toContain('@toggle-maximized="detailsMaximized = false"');
     expect(consolePage).not.toContain("min-height: 32rem");
     expect(consoleFrame).toContain("min-height: 0");
     expect(consoleFrame).not.toContain("min-height: 32rem");
@@ -362,7 +376,19 @@ describe("framework package contract", () => {
       "utf8",
     );
     expect(consoleSessionLoading).toContain('aria-label="Loading session"');
-    expect(consoleSessionNavbar).toContain('v-if="hasSelection" text="Session details"');
+    expect(consoleSessionLoading).toContain('surface === \'inspector\'');
+    expect(consoleSessionLoading).toContain('icon="i-lucide-panel-right-close"');
+    expect(consoleSessionLoading).toContain("emit('toggleMaximized')");
+    expect(consoleSessionNavbar).toContain('data-slot="session-details-toggle"');
+    expect(consoleSessionNavbar).toContain(':disabled="!hasSelection"');
+    expect(consolePage).toMatch(/scrollbar-width: none;/);
+    expect(consolePage).toMatch(/::-webkit-scrollbar[\s\S]*?display: none;/);
+    const consoleClientMain = readFileSync(
+      `${packageRoot}/src/console/runtime/client/main.js`,
+      "utf8",
+    );
+    expect(consoleClientMain).toContain("void loadSections().then((installed) => {");
+    expect(consoleClientMain).not.toContain("const installed = await loadSections()");
     const sessionInspector = readFileSync(
       `${packageRoot}/dist/console/runtime/components/console-session-inspector.vue`,
       "utf8",

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -62,6 +62,10 @@ export default defineConfig({
         to: "dist/console/runtime/components",
       },
       {
+        from: "src/console/runtime/components/console-session-bootstrap.ts",
+        to: "dist/console/runtime/components",
+      },
+      {
         from: "src/console/runtime/components/console-blob.vue",
         to: "dist/console/runtime/components",
       },


### PR DESCRIPTION
## Summary

- mount Console immediately and start Agent discovery plus compact session loading concurrently
- keep the T3-style split layout, inspector controls, and content-shaped loading geometry visible through slow or failed requests
- restore preparation-first session threads, compact Details, Trace, Workspace code, and neutral failure icons without duplicating telemetry
- preserve the first Usage-to-Sessions list load, then replace its global result and cursor with an Agent-filtered refresh
- expose structured runtime diagnostics behind a bounded error disclosure so consumers no longer need a UI patch

## Performance evidence

- controlled cold navigation: Agent and session-list requests started 9.9 ms apart
- bare Agents bootstrap: one unfiltered list, one initial detail, then one filtered list; no duplicate detail request
- direct Usage: zero Invocation requests
- Usage → Sessions: one uninterrupted unfiltered bootstrap followed by one Agent-filtered refresh; no abort/restart pair

The compact summary and storage work from #1216 remains unchanged. This follow-up removes serial client orchestration and improves perceived loading without adding a cache or state-management layer.

## Verification

- `pnpm vp lint <changed files>`
- `pnpm vp run doctor:typescript` — 0 blockers, errors, or warnings
- `pnpm --filter vite-hub typecheck`
- `pnpm vp run -t vite-hub#build`
- `pnpm vp test run test/console-bootstrap.test.ts test/package.test.ts` — 15/15, no type errors
- `pnpm vp test test/invocation-ui.test.ts` — 97/97, no type errors
- response-order proof for Agent-first and Invocation-first bootstrap using the production handoff controller
- fresh Babysitter preview pin: production build, 7/7 tests, and typecheck

## Design references

- T3 Code: persistent 52 px navigation, full-height split inspector, compact icon controls
- Mobbin: persistent split-pane loading geometry and content-shaped skeletons