### PR TITLE
fix(agent): bundle provider runtime in Nitro output

### DIFF
--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto"
 import { existsSync, statSync } from "node:fs"
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
 import { dirname, join, relative, resolve } from "node:path"
-import { pathToFileURL } from "node:url"
+import { fileURLToPath, pathToFileURL } from "node:url"
 
 import { contributeProviderDeploymentOutput, createProviderDeploymentOutputGenerationState, finalizeProviderDeploymentOutputs, useProviderOutputCatalog, writeProviderDeploymentOutputs } from "@vite-hub/internal/build/deployment-output"
 import { encodeProviderOutputAliases } from "@vite-hub/internal/build/esbuild"
@@ -778,7 +778,7 @@ function createAgentProviderRuntimePackagesNitroModule(rootDir: string): (nitro:
     if (nitro.options.dev !== false || deploymentPresetFromNitro(nitro.options.preset) !== "node") return
     nitro.hooks.hook("compiled", async () => {
       const packages = [
-        { includePeerDependencies: true, name: "@t3tools/provider-runtime", resolveFrom: import.meta.url },
+        { includePeerDependencies: true, name: "@t3tools/provider-runtime", resolveFrom: fileURLToPath(import.meta.url) },
         ...resolveProviderRuntimePackages({ rootDir }),
       ]
       await copyNodeRuntimePackages({

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -777,8 +777,10 @@ function createAgentProviderRuntimePackagesNitroModule(rootDir: string): (nitro:
   return (nitro) => {
     if (nitro.options.dev !== false || deploymentPresetFromNitro(nitro.options.preset) !== "node") return
     nitro.hooks.hook("compiled", async () => {
-      const packages = resolveProviderRuntimePackages({ rootDir })
-      if (!packages.length) return
+      const packages = [
+        { includePeerDependencies: true, name: "@t3tools/provider-runtime" },
+        ...resolveProviderRuntimePackages({ rootDir }),
+      ]
       await copyNodeRuntimePackages({
         outputNodeModules: join(nitro.options.output.serverDir, "node_modules"),
         packages,

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -778,7 +778,7 @@ function createAgentProviderRuntimePackagesNitroModule(rootDir: string): (nitro:
     if (nitro.options.dev !== false || deploymentPresetFromNitro(nitro.options.preset) !== "node") return
     nitro.hooks.hook("compiled", async () => {
       const packages = [
-        { includePeerDependencies: true, name: "@t3tools/provider-runtime" },
+        { includePeerDependencies: true, name: "@t3tools/provider-runtime", resolveFrom: import.meta.url },
         ...resolveProviderRuntimePackages({ rootDir }),
       ]
       await copyNodeRuntimePackages({

--- a/packages/agent/test/nuxt-runtime-output.test.ts
+++ b/packages/agent/test/nuxt-runtime-output.test.ts
@@ -1,7 +1,7 @@
 import { hasRuntimeType } from "../src/internal/runtime-type.ts"
 import { execFile, spawn } from "node:child_process"
 import { once } from "node:events"
-import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from "node:fs/promises"
+import { access, mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from "node:fs/promises"
 import { createServer } from "node:net"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
@@ -142,6 +142,7 @@ export default defineEventHandler(async () => {
     await runPnpm(["exec", "nuxt", "build"], root)
 
     const outputServer = join(root, ".output", "server")
+    await expect(access(join(outputServer, "node_modules", "@t3tools", "provider-runtime", "package.json"))).resolves.toBeUndefined()
     const output = await readTree(outputServer)
     expect(output).toContain("createMCPClient")
     expect(output).not.toContain('["@ai-sdk", "mcp"].join("/")')

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1284,6 +1284,7 @@ describe("agent Vite plugin", () => {
       expect(copyNodeRuntimePackages).toHaveBeenCalledWith({
         outputNodeModules: join(root, ".output", "server", "node_modules"),
         packages: [
+          { includePeerDependencies: true, name: "@t3tools/provider-runtime" },
           { name: "@openai/codex", resolveFrom: join(root, "package.json") },
           { name: platformPackage, resolveFrom: join(codexPackageDir, "package.json") },
           {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1284,7 +1284,11 @@ describe("agent Vite plugin", () => {
       expect(copyNodeRuntimePackages).toHaveBeenCalledWith({
         outputNodeModules: join(root, ".output", "server", "node_modules"),
         packages: [
-          { includePeerDependencies: true, name: "@t3tools/provider-runtime" },
+          {
+            includePeerDependencies: true,
+            name: "@t3tools/provider-runtime",
+            resolveFrom: pathToFileURL(resolve(import.meta.dirname, "../src/vite.ts")).href,
+          },
           { name: "@openai/codex", resolveFrom: join(root, "package.json") },
           { name: platformPackage, resolveFrom: join(codexPackageDir, "package.json") },
           {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -1287,7 +1287,7 @@ describe("agent Vite plugin", () => {
           {
             includePeerDependencies: true,
             name: "@t3tools/provider-runtime",
-            resolveFrom: pathToFileURL(resolve(import.meta.dirname, "../src/vite.ts")).href,
+            resolveFrom: resolve(import.meta.dirname, "../src/vite.ts"),
           },
           { name: "@openai/codex", resolveFrom: join(root, "package.json") },
           { name: platformPackage, resolveFrom: join(codexPackageDir, "package.json") },


### PR DESCRIPTION
Self-hosted Nitro builds now copy `@t3tools/provider-runtime` and its peer dependencies into the server output alongside installed provider executables. This keeps the externalized Agent provider runtime resolvable after deployment.

## Test plan

- `pnpm exec vp run -t @vite-hub/agent#build`
- `pnpm --filter @vite-hub/agent exec vp test run test/providers.test.ts -t "packages installed provider runtimes into self-hosted Node output"`
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm exec oxlint packages/agent/src/vite.ts packages/agent/test/providers.test.ts`