### PR TITLE
feat(ui): improve chat composer attachments and invocation links

### DIFF
--- a/docs/content/docs/agents/channels.md
+++ b/docs/content/docs/agents/channels.md
@@ -129,6 +129,8 @@ const { messages, status, sendMessage, stop } = useChat(agent)
 </script>
 ```
 
+`useChat()` also exposes a reactive `invocationId`. It is populated when the generated route accepts a request so an application can link to `/_vitehub/agents/~support/invocations/${invocationId.value}`.
+
 Add `route.admission.authenticate` when the generated route needs authentication. ViteHub reads the raw body once, verifies the shared UI-message contract, and copies only fields named in `route.input.trust` after authentication.
 
 Agent chat and webhook routes accept at most 1 MiB by default. Set `route.maxBodyBytes` to a smaller limit or raise it as high as 10 MiB for a web chat with larger JSON payloads. ViteHub checks `Content-Length` and the streamed byte count, so chunked requests cannot bypass the limit.

--- a/docs/content/docs/ui/chat-prompt.md
+++ b/docs/content/docs/ui/chat-prompt.md
@@ -27,6 +27,7 @@ icon: i-ph-paper-plane-tilt-light
 
 | Event               | Payload                                                     |
 | ------------------- | ----------------------------------------------------------- |
+| `error`             | Attachment filtering or conversion error.                   |
 | `update:modelValue` | Current prompt text.                                        |
 | `update:files`      | Current `FileUIPart[]`.                                     |
 | `submit`            | `{ text, files }`. Empty text is accepted when files exist. |

--- a/docs/content/docs/ui/chat-prompt.md
+++ b/docs/content/docs/ui/chat-prompt.md
@@ -34,3 +34,5 @@ icon: i-ph-paper-plane-tilt-light
 | `stop`              | No payload. Connect it to the AI SDK `stop()` helper.       |
 
 Use `#files`, `#actions`, and `#submit` to replace each built-in section without rebuilding keyboard behavior. The composer, attachment picker, and status-aware submit action have default accessible names; pass `aria-label` to override the composer name.
+
+The picker and clipboard paste share the same file path. Pasted images become attachments even when the clipboard also contains text. Other pasted files become attachments only when the clipboard contains no text. `filter-files` receives the raw files before ViteHub converts them to AI SDK file parts. Return the accepted files in their desired order, or return `[]` to reject the batch.

--- a/packages/agent/src/chat-message-input.ts
+++ b/packages/agent/src/chat-message-input.ts
@@ -127,12 +127,14 @@ function uiAttachmentPartToAgentPart(part: Record<string, unknown>): MessagePart
   if (!type || !mediaType) return []
 
   const id = firstString(part.id)
-  const data = isAttachmentData(part.data) ? part.data : undefined
+  const url = typeof part.url === "string" && part.url ? part.url : undefined
+  const data = isAttachmentData(part.data)
+    ? part.data
+    : url?.startsWith("data:") ? url : undefined
   const fetchData = typeof part.fetchData === "function"
     ? part.fetchData as () => AttachmentData | Promise<AttachmentData>
     : undefined
   const name = firstString(part.name, part.filename)
-  const url = typeof part.url === "string" && part.url ? part.url : undefined
   if (!data && !fetchData && !url) return []
   const attachment = {
     ...(data ? { data } : {}),
@@ -143,7 +145,7 @@ function uiAttachmentPartToAgentPart(part: Record<string, unknown>): MessagePart
     ...(typeof part.fetchMetadata === "object" && part.fetchMetadata !== null ? { fetchMetadata: part.fetchMetadata as Record<string, string> } : {}),
     mediaType,
     type,
-    ...(url ? { url } : {}),
+    ...(url && !data ? { url } : {}),
   } satisfies AttachmentPart
   return [attachment]
 }

--- a/packages/agent/src/internal/routes.ts
+++ b/packages/agent/src/internal/routes.ts
@@ -1,4 +1,5 @@
 export const defaultAgentChatRoute = "/api/_vitehub/agents/[agent]/chat"
+export const agentChatInvocationIdHeader = "x-vitehub-invocation-id"
 export const defaultAgentDiscordGatewayRoute = "/api/_vitehub/agents/[agent]/discord/gateway"
 export const defaultAgentInspectionRoute = "/api/_vitehub/agents/[agent]/inspection"
 export const defaultAgentWebhookRoute = "/api/_vitehub/agents/[agent]/webhooks/[webhook]"

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -31,6 +31,7 @@ import {
 import { normalizeCapabilities } from "../capability-runtime.ts"
 import { deliveryArtifactAttachments } from "../delivery-artifacts.ts"
 import { createAgentInvocationContextStore } from "../invocation-context.ts"
+import { agentInvocationId } from "../invocations.ts"
 import { finalChannelOutputContextKey, hasOnlyPortableAgentWorkflowCapabilities, requireAgentWorkflowContextKey } from "../internal/final-channel-output.ts"
 import { agentChannelHistoryHeader } from "../internal/channel-history.ts"
 import { agentChannelSyncProviderHeader } from "../internal/channel-sync.ts"
@@ -51,6 +52,7 @@ import { messageChannelStateContextKey } from "../internal/channels.ts"
 import { chatFinishDeliveryRegistrarKey, chatFinishDirectReplyTrace } from "../internal/chat-finish-delivery.ts"
 import type { ChatFinishDeliveryCallback, ChatFinishDeliveryCapture, ChatFinishDeliveryRegistrar } from "../internal/chat-finish-delivery.ts"
 import { createAgentChatApprovalCustody, resolveAgentChatApprovalTtl } from "../internal/chat-approvals.ts"
+import { agentChatInvocationIdHeader } from "../internal/routes.ts"
 import { requireAtomicAgentStateQueue } from "../internal/state-queue.ts"
 import { isAmbiguousAgentWorkflowStartFailure } from "../internal/workflow-start.ts"
 import { registerAgentWorkflowRetry } from "../internal/workflow-retry.ts"
@@ -6304,6 +6306,17 @@ async function toAgentChatFetchResponse(result: unknown): Promise<Response> {
   return createAgentUIMessageStreamResponse({ stream: readableStreamFromResult(result) })
 }
 
+function withAgentChatInvocationId(response: Response, invocationId: string): Response {
+  const headers = new Headers(response.headers)
+  headers.set(agentChatInvocationIdHeader, invocationId)
+  headers.delete("content-length")
+  return new Response(response.body, {
+    headers,
+    status: response.status,
+    statusText: response.statusText,
+  })
+}
+
 function agentChatSessionBoundaryKey(invokerId: string, sessionId: string, manualId: string): string {
   return `invoker:${encodeURIComponent(invokerId)}:session:${encodeURIComponent(sessionId)}:manual:${encodeURIComponent(manualId)}:boundary`
 }
@@ -6544,7 +6557,10 @@ export function createChannelChatRouteHandler(
           }),
       )
       if (approvalCustody) result = approvalCustody.observe(result)
-      const response = await observeChannelDeliveryResponse(await toAgentChatFetchResponse(result), delivery, triggerInput.run?.runId)
+      let response = await observeChannelDeliveryResponse(await toAgentChatFetchResponse(result), delivery, triggerInput.run?.runId)
+      if (triggerInput.run?.runId) {
+        response = withAgentChatInvocationId(response, await agentInvocationId(triggerInput.run.runId, agentName))
+      }
       if (!resumableClaim) return response
       return resumableClaim.complete(response, {
         messageId: resumableMessageId,

--- a/packages/agent/src/vue.ts
+++ b/packages/agent/src/vue.ts
@@ -2,7 +2,7 @@ import { useChat as useAiChat } from "@ai-sdk/vue"
 import { DefaultChatTransport } from "ai"
 import { computed, onScopeDispose, shallowRef, toValue, watch } from "vue"
 
-import { defaultAgentChatRoute, resolveAgentRoutePath } from "./internal/routes.ts"
+import { agentChatInvocationIdHeader, defaultAgentChatRoute, resolveAgentRoutePath } from "./internal/routes.ts"
 import { updateAgentChatStreamedParts } from "./internal/chat-data.ts"
 import { createAgentChatData } from "./messages.ts"
 
@@ -34,6 +34,7 @@ export type AgentChatReactiveInit<UI_MESSAGE extends UIMessage = UIMessage> = Om
 
 export interface AgentChatHelpers<UI_MESSAGE extends UIMessage> extends UseChatHelpers<UI_MESSAGE> {
   readonly data: ComputedRef<AgentChatData>
+  readonly invocationId: ComputedRef<string | undefined>
 }
 
 export function useAgent(name: string): AgentClient {
@@ -67,6 +68,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
   const constructorOptions = shallowRef(initialOptions)
   const latestOptions = shallowRef(initialOptions)
   const streamedParts = shallowRef<AgentChatStreamedPart[]>([])
+  const invocationId = shallowRef<string>()
   const reconnecting = shallowRef(false)
   let resumableMessageId = initialOptions.messages?.at(-1)?.id
   let reconnectGeneration = 0
@@ -79,6 +81,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
       api: route,
       async fetch(input, init) {
         const response = await globalThis.fetch(input, init)
+        invocationId.value = response.headers.get(agentChatInvocationIdHeader) || invocationId.value
         if (init?.method === "GET" && generation === reconnectGeneration) {
           resumableMessageId = response.headers.get("x-vitehub-message-id") || undefined
         }
@@ -108,6 +111,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
       reconnectGeneration++
       reconnectStatusGeneration++
       reconnecting.value = false
+      invocationId.value = undefined
       resumableMessageId = args[0].messageId ?? args[0].messages.at(-1)?.id
       return resolveTransport().sendMessages(...args)
     },
@@ -135,6 +139,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
       reconnectStatusGeneration++
       constructorOptions.value = next
       streamedParts.value = []
+      invocationId.value = undefined
       resumableMessageId = undefined
       const shouldReconnect = Boolean(next.resume && isBrowserRuntime() && next.messages?.length)
       reconnecting.value = shouldReconnect
@@ -189,6 +194,7 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
       ...chat.messages.value.flatMap(message => message.parts),
       ...streamedParts.value,
     ])),
+    invocationId: computed(() => invocationId.value),
   }
 }
 

--- a/packages/agent/src/vue.ts
+++ b/packages/agent/src/vue.ts
@@ -81,7 +81,9 @@ export function useChat<UI_MESSAGE extends UIMessage = UIMessage>(
       api: route,
       async fetch(input, init) {
         const response = await globalThis.fetch(input, init)
-        invocationId.value = response.headers.get(agentChatInvocationIdHeader) || invocationId.value
+        if (init?.method !== "GET" || generation === reconnectGeneration) {
+          invocationId.value = response.headers.get(agentChatInvocationIdHeader) || invocationId.value
+        }
         if (init?.method === "GET" && generation === reconnectGeneration) {
           resumableMessageId = response.headers.get("x-vitehub-message-id") || undefined
         }

--- a/packages/agent/test/chat-message-input.test.ts
+++ b/packages/agent/test/chat-message-input.test.ts
@@ -3,6 +3,27 @@ import { describe, expect, it } from "vitest"
 import { createChatMessageTriggerInput, resolveChatSessionId } from "../src/chat-message-input.ts"
 
 describe("chat message trigger input", () => {
+  it("materializes UI data URL attachments for provider agents", () => {
+    const result = createChatMessageTriggerInput({}, {
+      messages: [{
+        parts: [{
+          filename: "clipboard.png",
+          mediaType: "image/png",
+          type: "file",
+          url: "data:image/png;base64,AQID",
+        }],
+        role: "user",
+      }],
+    })
+
+    expect(result.input.messages?.[0]?.parts).toEqual([{
+      data: "data:image/png;base64,AQID",
+      mediaType: "image/png",
+      name: "clipboard.png",
+      type: "image",
+    }])
+  })
+
   it("keeps a fresh approval boundary stable for a new manual Chat Session", () => {
     const messages = [
       { id: "message-new", metadata: { sessionId: "chat" }, parts: [], role: "user" as const },

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2804,7 +2804,7 @@ describe("server helpers", () => {
   })
 
   it("serves AI SDK UI message chat requests through the chat trigger", async () => {
-    const { defineAgent } = await import("../src/index.ts")
+    const { agentInvocationId, defineAgent } = await import("../src/index.ts")
     const { defineChatCapability } = await import("../src/chat-trigger.ts")
     const { createChannelChatRouteHandler } = await import("../src/server/internal.ts")
     const resolveInvoker = vi.fn(({ defaultInvoker, request }) => ({
@@ -2858,6 +2858,9 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get("x-vercel-ai-ui-message-stream")).toBe("v1")
+    expect(response.headers.get("x-vitehub-invocation-id")).toBe(
+      await agentInvocationId(run.mock.calls[0]![0].run.runId, "support"),
+    )
     await expect(response.text()).resolves.toContain("echo hello for customer:acme via http on unknown from portal-user after anonymous:http")
     await expect(
       handler.deliveries(new Request("https://example.com/api/_vitehub/agents/support/chat"), {

--- a/packages/agent/test/vue-types.test-d.ts
+++ b/packages/agent/test/vue-types.test-d.ts
@@ -31,6 +31,7 @@ describe("Agent Vue client types", () => {
     expectTypeOf(chat.id).toEqualTypeOf<ComputedRef<string>>()
     expectTypeOf(chat.messages).toEqualTypeOf<ShallowRef<UIMessage[]>>()
     expectTypeOf(chat.data).toEqualTypeOf<ComputedRef<import("../src/messages.ts").AgentChatData>>()
+    expectTypeOf(chat.invocationId).toEqualTypeOf<ComputedRef<string | undefined>>()
     expectTypeOf(chat.status.value).toEqualTypeOf<"submitted" | "streaming" | "ready" | "error">()
     expectTypeOf(chat.sendMessage).toBeFunction()
     expectTypeOf(useChat).toBeCallableWith(agent, (() => init) satisfies MaybeRefOrGetter<AgentChatReactiveInit>)

--- a/packages/agent/test/vue.test.ts
+++ b/packages/agent/test/vue.test.ts
@@ -253,11 +253,17 @@ describe("Agent Vue clients", () => {
     await nextTick()
     await vi.waitFor(() => expect(responses.has("/api/_vitehub/agents/support/chat?id=chat-b")).toBe(true))
     responses.get("/api/_vitehub/agents/support/chat?id=chat-b")!(new Response(null, {
-      headers: { "x-vitehub-message-id": "message-b" },
+      headers: {
+        "x-vitehub-invocation-id": "invocation-b",
+        "x-vitehub-message-id": "message-b",
+      },
       status: 204,
     }))
     responses.get("/api/_vitehub/agents/support/chat?id=chat-a")!(createUIMessageStreamResponse({
-      headers: { "x-vitehub-message-id": "message-a" },
+      headers: {
+        "x-vitehub-invocation-id": "invocation-a",
+        "x-vitehub-message-id": "message-a",
+      },
       stream: createUIMessageStream({
         execute({ writer }) {
           writer.write({ id: "answer", type: "text-start" })
@@ -268,6 +274,7 @@ describe("Agent Vue clients", () => {
     }))
     await vi.waitFor(() => expect(chat.status.value).toBe("ready"))
     expect(chat.messages.value).toEqual(messages)
+    expect(chat.invocationId.value).toBe("invocation-b")
     await chat.stop()
 
     expect(fetch).toHaveBeenLastCalledWith("/api/_vitehub/agents/support/chat?id=chat-b&messageId=message-b", {
@@ -394,6 +401,7 @@ describe("Agent Vue clients", () => {
       const body = parse(object({ messages: array(object({ id: string() })) }), JSON.parse(String(init?.body)))
       submittedMessageId = body.messages.at(-1)?.id
       return createUIMessageStreamResponse({
+        headers: { "x-vitehub-invocation-id": "invocation-fresh" },
         stream: createUIMessageStream({
           execute({ writer }) {
             writer.write({ id: "fresh", type: "text-start" })
@@ -417,7 +425,10 @@ describe("Agent Vue clients", () => {
     ))
     await chat.sendMessage({ text: "New question" })
     finishReconnect(createUIMessageStreamResponse({
-      headers: { "x-vitehub-message-id": "user-1" },
+      headers: {
+        "x-vitehub-invocation-id": "invocation-stale",
+        "x-vitehub-message-id": "user-1",
+      },
       stream: createUIMessageStream({
         execute({ writer }) {
           writer.write({ id: "stale", type: "text-start" })
@@ -432,6 +443,7 @@ describe("Agent Vue clients", () => {
       parts: [{ text: "Fresh answer", type: "text" }],
       role: "assistant",
     })
+    expect(chat.invocationId.value).toBe("invocation-fresh")
     expect(chat.messages.value).not.toContainEqual(expect.objectContaining({ id: "stale" }))
     await chat.stop()
     expect(fetch).toHaveBeenLastCalledWith(`/api/_vitehub/agents/support/chat?id=chat-1&messageId=${submittedMessageId}`, {

--- a/packages/agent/test/vue.test.ts
+++ b/packages/agent/test/vue.test.ts
@@ -7,6 +7,7 @@ import { updateAgentChatStreamedParts } from "../src/internal/chat-data.ts"
 import { useAgent, useChat } from "../src/vue.ts"
 
 import type { ChatTransport, UIMessage } from "ai"
+import type { AgentChatInit } from "../src/vue.ts"
 
 afterEach(() => vi.unstubAllGlobals())
 
@@ -581,15 +582,16 @@ describe("Agent Vue clients", () => {
         : [{ text: "Hello", type: "text" }],
       role: "assistant",
     }] as UIMessage[]
-    const chat = scope.run(() => useChat(useAgent("support"), {
+    const options: AgentChatInit = {
       api: "/chat/support",
       id: "chat-1",
       messages,
       resume: true,
-      ...(trigger === "submit-message"
-        ? { sendAutomaticallyWhen: vi.fn().mockReturnValueOnce(true).mockReturnValue(false) }
-        : {}),
-    }))!
+    }
+    if (trigger === "submit-message") {
+      options.sendAutomaticallyWhen = vi.fn().mockReturnValueOnce(true).mockReturnValue(false)
+    }
+    const chat = scope.run(() => useChat(useAgent("support"), options))!
 
     const request = trigger === "regenerate-message" ? chat.regenerate({ messageId }) : undefined
     if (trigger === "submit-message") await chat.addToolOutput({ output: "sunny", tool: "weather", toolCallId: "tool-1" })

--- a/packages/agent/test/vue.test.ts
+++ b/packages/agent/test/vue.test.ts
@@ -30,6 +30,7 @@ describe("Agent Vue clients", () => {
 
   it("sends Agent chat requests to the generated route and streams reactive messages", async () => {
     const fetch = vi.fn<typeof globalThis.fetch>(async () => createUIMessageStreamResponse({
+      headers: { "x-vitehub-invocation-id": "invocation-1" },
       stream: createUIMessageStream({
         execute({ writer }) {
           writer.write({ id: "answer", type: "text-start" })
@@ -53,6 +54,7 @@ describe("Agent Vue clients", () => {
       trigger: "submit-message",
     })
     expect(chat.status.value).toBe("ready")
+    expect(chat.invocationId.value).toBe("invocation-1")
     expect(chat.messages.value.at(-1)).toMatchObject({
       parts: [{ text: "Hello from ViteHub", type: "text" }],
       role: "assistant",

--- a/packages/ui/src/components/agent-chat-prompt.ts
+++ b/packages/ui/src/components/agent-chat-prompt.ts
@@ -1,5 +1,5 @@
 import type { ChatStatus, FileUIPart } from "ai";
-import { defineComponent, h, type PropType, ref, resolveComponent } from "vue";
+import { defineComponent, h, mergeProps, type PropType, ref, resolveComponent } from "vue";
 import { fileToUIPart } from "../composables/attachments.ts";
 import { nextPromptFiles } from "../internal/prompt-files.ts";
 
@@ -16,6 +16,7 @@ export const AgentChatPrompt = defineComponent({
   props: {
     accept: { type: String },
     files: { default: () => [], type: Array as PropType<readonly FileUIPart[]> },
+    filterFiles: { type: Function as PropType<(files: readonly File[]) => readonly File[]> },
     modelValue: { default: "", type: String },
     multiple: { default: true, type: Boolean },
     placeholder: { type: String },
@@ -32,14 +33,32 @@ export const AgentChatPrompt = defineComponent({
         "update:files",
         props.files.filter((_, current) => current !== index),
       );
+    const addFiles = async (input: FileList | Iterable<File>) => {
+      const rawFiles = Array.from(input);
+      const acceptedFiles = props.filterFiles?.(rawFiles) ?? rawFiles;
+      if (acceptedFiles.length === 0) return;
+      const files = await Promise.all(Array.from(acceptedFiles, fileToUIPart));
+      emit("update:files", nextPromptFiles(props.files, files, props.multiple));
+    };
+    const paste = async (event: ClipboardEvent) => {
+      const clipboard = event.clipboardData;
+      if (!clipboard) return;
+      const hasText = clipboard.getData("text/plain").length > 0;
+      const files = Array.from(clipboard.files).filter(
+        (file) => file.type.startsWith("image/") || !hasText,
+      );
+      if (files.length === 0) return;
+      event.preventDefault();
+      await addFiles(files);
+    };
     return () =>
       h(
         UChatPrompt,
-        {
-          ...attrs,
+        mergeProps(attrs, {
           "aria-label": attrs["aria-label"] ?? "Message",
-          class: ["vh-prompt", attrs.class],
+          class: "vh-prompt",
           modelValue: props.modelValue || (props.files.length > 0 ? attachmentSubmitSentinel : ""),
+          onPaste: paste,
           placeholder: props.placeholder,
           "onUpdate:modelValue": (value: string) =>
             emit("update:modelValue", value.replace(attachmentSubmitSentinel, "")),
@@ -48,7 +67,7 @@ export const AgentChatPrompt = defineComponent({
             if (!text && props.files.length === 0) return;
             emit("submit", { files: props.files, text } satisfies AgentChatPromptSubmit);
           },
-        },
+        }),
         {
           header: () =>
             props.files.length > 0 || slots.files
@@ -56,12 +75,23 @@ export const AgentChatPrompt = defineComponent({
                   "div",
                   { class: "vh-prompt__attachments" },
                   slots.files?.({ files: props.files, remove }) ??
-                    props.files.map((file, index) =>
-                      h(
+                    props.files.map((file, index) => {
+                      const image = file.mediaType.startsWith("image/");
+                      const label = file.filename ?? file.mediaType;
+                      return h(
                         "span",
-                        { class: "vh-prompt__attachment", key: `${file.filename}-${index}` },
+                        {
+                          class: ["vh-prompt__attachment", image && "vh-prompt__attachment--image"],
+                          key: `${file.filename}-${index}`,
+                        },
                         [
-                          h("span", file.filename ?? file.mediaType),
+                          image
+                            ? h("img", {
+                                alt: label,
+                                class: "vh-prompt__attachment-preview",
+                                src: file.url,
+                              })
+                            : h("span", label),
                           h(
                             "button",
                             {
@@ -72,8 +102,8 @@ export const AgentChatPrompt = defineComponent({
                             "×",
                           ),
                         ],
-                      ),
-                    ),
+                      );
+                    }),
                 )
               : null,
           footer: () =>
@@ -84,16 +114,14 @@ export const AgentChatPrompt = defineComponent({
                 class: "vh-visually-hidden",
                 multiple: props.multiple,
                 onChange: async (event: Event) => {
-                  const files = await Promise.all(
-                    Array.from((event.target as HTMLInputElement).files ?? []).map(fileToUIPart),
-                  );
-                  emit("update:files", nextPromptFiles(props.files, files, props.multiple));
+                  await addFiles((event.target as HTMLInputElement).files ?? []);
                   (event.target as HTMLInputElement).value = "";
                 },
                 ref: input,
                 tabindex: -1,
                 type: "file",
               }),
+              h("span", { class: "vh-prompt__spacer" }),
               slots.actions?.() ??
                 h(UButton, {
                   "aria-label": "Add attachment",
@@ -103,7 +131,6 @@ export const AgentChatPrompt = defineComponent({
                   type: "button",
                   variant: "ghost",
                 }),
-              h("span", { class: "vh-prompt__spacer" }),
               slots.submit?.({ status: props.status }) ??
                 h(UChatPromptSubmit, {
                   "aria-label": {

--- a/packages/ui/src/components/agent-chat-prompt.ts
+++ b/packages/ui/src/components/agent-chat-prompt.ts
@@ -22,7 +22,7 @@ export const AgentChatPrompt = defineComponent({
     placeholder: { type: String },
     status: { default: "ready", type: String as PropType<ChatStatus> },
   },
-  emits: ["reload", "submit", "stop", "update:files", "update:modelValue"],
+  emits: ["error", "reload", "submit", "stop", "update:files", "update:modelValue"],
   setup(props, { attrs, emit, slots }) {
     const input = ref<HTMLInputElement | null>(null);
     const UButton = resolveComponent("UButton");
@@ -34,11 +34,15 @@ export const AgentChatPrompt = defineComponent({
         props.files.filter((_, current) => current !== index),
       );
     const addFiles = async (input: FileList | Iterable<File>) => {
-      const rawFiles = Array.from(input);
-      const acceptedFiles = props.filterFiles?.(rawFiles) ?? rawFiles;
-      if (acceptedFiles.length === 0) return;
-      const files = await Promise.all(Array.from(acceptedFiles, fileToUIPart));
-      emit("update:files", nextPromptFiles(props.files, files, props.multiple));
+      try {
+        const rawFiles = Array.from(input);
+        const acceptedFiles = props.filterFiles?.(rawFiles) ?? rawFiles;
+        if (acceptedFiles.length === 0) return;
+        const files = await Promise.all(Array.from(acceptedFiles, fileToUIPart));
+        emit("update:files", nextPromptFiles(props.files, files, props.multiple));
+      } catch (error) {
+        emit("error", error);
+      }
     };
     const paste = async (event: ClipboardEvent) => {
       const clipboard = event.clipboardData;

--- a/packages/ui/src/components/agent-chat-prompt.ts
+++ b/packages/ui/src/components/agent-chat-prompt.ts
@@ -121,8 +121,10 @@ export const AgentChatPrompt = defineComponent({
                 class: "vh-visually-hidden",
                 multiple: props.multiple,
                 onChange: async (event: Event) => {
-                  await addFiles((event.target as HTMLInputElement).files ?? []);
-                  (event.target as HTMLInputElement).value = "";
+                  const target = event.currentTarget;
+                  if (!(target instanceof HTMLInputElement)) return;
+                  await addFiles(target.files ?? []);
+                  target.value = "";
                 },
                 ref: input,
                 tabindex: -1,

--- a/packages/ui/src/components/agent-chat-prompt.ts
+++ b/packages/ui/src/components/agent-chat-prompt.ts
@@ -33,11 +33,15 @@ export const AgentChatPrompt = defineComponent({
         "update:files",
         props.files.filter((_, current) => current !== index),
       );
-    const addFiles = async (input: FileList | Iterable<File>) => {
+    const addFiles = async (
+      input: FileList | Iterable<File>,
+      onAccepted?: () => void,
+    ) => {
       try {
         const rawFiles = Array.from(input);
         const acceptedFiles = props.filterFiles?.(rawFiles) ?? rawFiles;
         if (acceptedFiles.length === 0) return;
+        onAccepted?.();
         const files = await Promise.all(Array.from(acceptedFiles, fileToUIPart));
         emit("update:files", nextPromptFiles(props.files, files, props.multiple));
       } catch (error) {
@@ -52,8 +56,7 @@ export const AgentChatPrompt = defineComponent({
         (file) => file.type.startsWith("image/") || !hasText,
       );
       if (files.length === 0) return;
-      event.preventDefault();
-      await addFiles(files);
+      await addFiles(files, () => event.preventDefault());
     };
     return () =>
       h(

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -418,9 +418,7 @@
   min-height: 4.875rem;
   padding: 0.65rem 0.75rem;
   text-align: start;
-  transition:
-    background-color 120ms ease,
-    color 120ms ease;
+  transition: background-color 120ms ease, color 120ms ease;
   width: 100%;
 }
 
@@ -1047,8 +1045,7 @@ button.vh-invocation-lifecycle__row:focus-visible {
 
 .vh-invocation-lifecycle__label {
   background: var(--vh-invocation-label-bg, var(--vh-ui-border));
-  border: 1px solid
-    color-mix(in srgb, var(--vh-invocation-label-bg, var(--vh-ui-border)) 80%, #000000);
+  border: 1px solid color-mix(in srgb, var(--vh-invocation-label-bg, var(--vh-ui-border)) 80%, #000000);
   border-radius: 999px;
   color: var(--vh-invocation-label-fg, var(--vh-ui-text));
   flex: 0 1 auto;
@@ -1078,9 +1075,7 @@ button.vh-invocation-lifecycle__row:focus-visible {
   gap: 0.375rem;
   min-height: 1.5rem;
   padding: 0.125rem;
-  transition:
-    background-color 140ms ease,
-    color 140ms ease;
+  transition: background-color 140ms ease, color 140ms ease;
 }
 
 button.vh-invocation-event__summary {
@@ -1167,9 +1162,7 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   height: 0.75rem;
   opacity: 0.65;
   transform: rotate(0);
-  transition:
-    opacity 140ms ease,
-    transform 140ms ease;
+  transition: opacity 140ms ease, transform 140ms ease;
   width: 0.75rem;
 }
 
@@ -1298,13 +1291,7 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 
 .vh-invocation-event__payload > summary code {
   color: var(--vh-ui-muted);
-  font:
-    0.75rem/1.4 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    monospace;
+  font: 0.75rem/1.4 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1381,13 +1368,7 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   background: color-mix(in oklab, var(--vh-ui-bg-elevated) 65%, transparent);
   border-radius: calc(var(--vh-ui-radius) * 0.72);
   color: var(--vh-ui-text);
-  font:
-    0.75rem/1.55 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    monospace;
+  font: 0.75rem/1.55 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   margin: 0;
   max-height: 18rem;
   overflow: auto;
@@ -1429,13 +1410,7 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 .vh-invocation-payload__key,
 .vh-invocation-payload__value,
 .vh-invocation-payload__matches code {
-  font:
-    0.71875rem/1.45 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    monospace;
+  font: 0.71875rem/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
 }
 
 .vh-invocation-payload__key {
@@ -1869,13 +1844,7 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 .vh-invocation-timeline__heading time {
   color: var(--vh-ui-dimmed);
   flex: none;
-  font:
-    0.6875rem/1.4 ui-monospace,
-    SFMono-Regular,
-    Menlo,
-    Monaco,
-    Consolas,
-    monospace;
+  font: 0.6875rem/1.4 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-variant-numeric: tabular-nums;
 }
 

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -218,6 +218,37 @@
   font: inherit;
 }
 
+.vh-prompt__attachment--image {
+  border-radius: calc(var(--vh-ui-radius) * 1.25);
+  flex: 0 0 4rem;
+  height: 4rem;
+  overflow: hidden;
+  padding: 0;
+  position: relative;
+  width: 4rem;
+}
+
+.vh-prompt__attachment-preview {
+  height: 100%;
+  object-fit: cover;
+  width: 100%;
+}
+
+.vh-prompt__attachment--image button {
+  align-items: center;
+  background: color-mix(in oklab, black 65%, transparent);
+  border-radius: 9999px;
+  color: white;
+  display: flex;
+  height: 1.25rem;
+  justify-content: center;
+  line-height: 1;
+  position: absolute;
+  right: 0.25rem;
+  top: 0.25rem;
+  width: 1.25rem;
+}
+
 .vh-prompt__footer {
   align-items: center;
   display: flex;
@@ -387,7 +418,9 @@
   min-height: 4.875rem;
   padding: 0.65rem 0.75rem;
   text-align: start;
-  transition: background-color 120ms ease, color 120ms ease;
+  transition:
+    background-color 120ms ease,
+    color 120ms ease;
   width: 100%;
 }
 
@@ -1014,7 +1047,8 @@ button.vh-invocation-lifecycle__row:focus-visible {
 
 .vh-invocation-lifecycle__label {
   background: var(--vh-invocation-label-bg, var(--vh-ui-border));
-  border: 1px solid color-mix(in srgb, var(--vh-invocation-label-bg, var(--vh-ui-border)) 80%, #000000);
+  border: 1px solid
+    color-mix(in srgb, var(--vh-invocation-label-bg, var(--vh-ui-border)) 80%, #000000);
   border-radius: 999px;
   color: var(--vh-invocation-label-fg, var(--vh-ui-text));
   flex: 0 1 auto;
@@ -1044,7 +1078,9 @@ button.vh-invocation-lifecycle__row:focus-visible {
   gap: 0.375rem;
   min-height: 1.5rem;
   padding: 0.125rem;
-  transition: background-color 140ms ease, color 140ms ease;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease;
 }
 
 button.vh-invocation-event__summary {
@@ -1131,7 +1167,9 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   height: 0.75rem;
   opacity: 0.65;
   transform: rotate(0);
-  transition: opacity 140ms ease, transform 140ms ease;
+  transition:
+    opacity 140ms ease,
+    transform 140ms ease;
   width: 0.75rem;
 }
 
@@ -1260,7 +1298,13 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 
 .vh-invocation-event__payload > summary code {
   color: var(--vh-ui-muted);
-  font: 0.75rem/1.4 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font:
+    0.75rem/1.4 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -1337,7 +1381,13 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   background: color-mix(in oklab, var(--vh-ui-bg-elevated) 65%, transparent);
   border-radius: calc(var(--vh-ui-radius) * 0.72);
   color: var(--vh-ui-text);
-  font: 0.75rem/1.55 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font:
+    0.75rem/1.55 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace;
   margin: 0;
   max-height: 18rem;
   overflow: auto;
@@ -1379,7 +1429,13 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 .vh-invocation-payload__key,
 .vh-invocation-payload__value,
 .vh-invocation-payload__matches code {
-  font: 0.71875rem/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font:
+    0.71875rem/1.45 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace;
 }
 
 .vh-invocation-payload__key {
@@ -1813,7 +1869,13 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 .vh-invocation-timeline__heading time {
   color: var(--vh-ui-dimmed);
   flex: none;
-  font: 0.6875rem/1.4 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font:
+    0.6875rem/1.4 ui-monospace,
+    SFMono-Regular,
+    Menlo,
+    Monaco,
+    Consolas,
+    monospace;
   font-variant-numeric: tabular-nums;
 }
 

--- a/packages/ui/test/chat-prompt.test.ts
+++ b/packages/ui/test/chat-prompt.test.ts
@@ -49,13 +49,7 @@ describe("AgentSession", () => {
   it("keeps session header and footer slots out of message rendering", () => {
     const session = {
       id: "session-1",
-      messages: [
-        {
-          id: "message-1",
-          parts: [{ text: "Hello", type: "text" as const }],
-          role: "assistant" as const,
-        },
-      ],
+      messages: [{ id: "message-1", parts: [{ text: "Hello", type: "text" as const }], role: "assistant" as const }],
       title: "Session",
     };
     const wrapper = mount(AgentSession, {
@@ -70,8 +64,7 @@ describe("AgentSession", () => {
       },
       props: { session },
       slots: {
-        header: ({ session: value }: { session: typeof session }) =>
-          h("div", { class: "session-header" }, value.title),
+        header: ({ session: value }: { session: typeof session }) => h("div", { class: "session-header" }, value.title),
       },
     });
 
@@ -91,18 +84,16 @@ const ChatPromptSubmitStub = defineComponent({
   props: { status: { default: "ready", type: String } },
   emits: ["reload", "stop"],
   setup(props, { attrs, emit }) {
-    return () =>
-      h("button", {
-        ...attrs,
-        "data-submit": "",
-        onClick:
-          props.status === "error"
-            ? () => emit("reload")
-            : props.status === "ready"
-              ? undefined
-              : () => emit("stop"),
-        type: "button",
-      });
+    return () => h("button", {
+      ...attrs,
+      "data-submit": "",
+      onClick: props.status === "error"
+        ? () => emit("reload")
+        : props.status === "ready"
+          ? undefined
+          : () => emit("stop"),
+      type: "button",
+    });
   },
 });
 
@@ -236,26 +227,13 @@ describe("AgentChatPrompt", () => {
     ]);
 
     expect(attachments.inputProps.value.multiple).toBe(true);
-    expect(attachments.files.value.map(({ file }) => file.name)).toEqual([
-      "first.txt",
-      "second.txt",
-    ]);
+    expect(attachments.files.value.map(({ file }) => file.name)).toEqual(["first.txt", "second.txt"]);
     scope.stop();
   });
 
   it("replaces the controlled attachment when multiple files are disabled", () => {
-    const oldFile = {
-      filename: "old.txt",
-      mediaType: "text/plain",
-      type: "file" as const,
-      url: "data:,old",
-    };
-    const newFile = {
-      filename: "new.txt",
-      mediaType: "text/plain",
-      type: "file" as const,
-      url: "data:,new",
-    };
+    const oldFile = { filename: "old.txt", mediaType: "text/plain", type: "file" as const, url: "data:,old" };
+    const newFile = { filename: "new.txt", mediaType: "text/plain", type: "file" as const, url: "data:,new" };
 
     expect(nextPromptFiles([oldFile], [newFile], false)).toEqual([newFile]);
   });

--- a/packages/ui/test/chat-prompt.test.ts
+++ b/packages/ui/test/chat-prompt.test.ts
@@ -159,7 +159,7 @@ describe("AgentChatPrompt", () => {
   });
 
   it("filters picker and pasted files before conversion", async () => {
-    const filterFiles = vi.fn(() => [] as File[]);
+    const filterFiles = vi.fn((): File[] => []);
     const wrapper = mount(AgentChatPrompt, { global, props: { filterFiles } });
     const picked = new File(["picked"], "picked.png", { type: "image/png" });
     const pasted = new File(["pasted"], "pasted.png", { type: "image/png" });

--- a/packages/ui/test/chat-prompt.test.ts
+++ b/packages/ui/test/chat-prompt.test.ts
@@ -1,15 +1,16 @@
 // @vitest-environment happy-dom
 
 import type { ChatStatus } from "ai";
-import { mount } from "@vue/test-utils";
+import { flushPromises, mount } from "@vue/test-utils";
 import { defineComponent, effectScope, h } from "vue";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AgentChatPrompt } from "../src/components/agent-chat-prompt.ts";
 import { AgentSession } from "../src/components/agent-session.ts";
 import { nextPromptFiles } from "../src/internal/prompt-files.ts";
 import { useAgentAttachments } from "../src/composables/attachments.ts";
 
 const TrimGuardPrompt = defineComponent({
+  inheritAttrs: false,
   props: { modelValue: { default: "", type: String } },
   emits: ["submit", "update:modelValue"],
   setup(props, { attrs, emit, slots }) {
@@ -35,10 +36,11 @@ const TrimGuardPrompt = defineComponent({
               submit(event);
             }
           },
+          onPaste: attrs.onPaste,
           value: props.modelValue,
         }),
         slots.header?.(),
-        slots.footer?.(),
+        h("div", { "data-slot": "footer" }, slots.footer?.()),
       ]);
   },
 });
@@ -47,7 +49,13 @@ describe("AgentSession", () => {
   it("keeps session header and footer slots out of message rendering", () => {
     const session = {
       id: "session-1",
-      messages: [{ id: "message-1", parts: [{ text: "Hello", type: "text" as const }], role: "assistant" as const }],
+      messages: [
+        {
+          id: "message-1",
+          parts: [{ text: "Hello", type: "text" as const }],
+          role: "assistant" as const,
+        },
+      ],
       title: "Session",
     };
     const wrapper = mount(AgentSession, {
@@ -62,7 +70,8 @@ describe("AgentSession", () => {
       },
       props: { session },
       slots: {
-        header: ({ session: value }: { session: typeof session }) => h("div", { class: "session-header" }, value.title),
+        header: ({ session: value }: { session: typeof session }) =>
+          h("div", { class: "session-header" }, value.title),
       },
     });
 
@@ -82,16 +91,18 @@ const ChatPromptSubmitStub = defineComponent({
   props: { status: { default: "ready", type: String } },
   emits: ["reload", "stop"],
   setup(props, { attrs, emit }) {
-    return () => h("button", {
-      ...attrs,
-      "data-submit": "",
-      onClick: props.status === "error"
-        ? () => emit("reload")
-        : props.status === "ready"
-          ? undefined
-          : () => emit("stop"),
-      type: "button",
-    });
+    return () =>
+      h("button", {
+        ...attrs,
+        "data-submit": "",
+        onClick:
+          props.status === "error"
+            ? () => emit("reload")
+            : props.status === "ready"
+              ? undefined
+              : () => emit("stop"),
+        type: "button",
+      });
   },
 });
 
@@ -112,7 +123,89 @@ describe("AgentChatPrompt", () => {
       "aria-label": "Add attachment",
       tabindex: "-1",
     });
-    expect(wrapper.get('button[aria-label="Add attachment"]')).toBeDefined();
+    expect(
+      wrapper.get(
+        '[data-slot="footer"] button[aria-label="Add attachment"] + button[aria-label="Send prompt"]',
+      ),
+    ).toBeDefined();
+  });
+
+  it("adds pasted images to the controlled files", async () => {
+    const wrapper = mount(AgentChatPrompt, { global });
+    const image = new File(["image"], "clipboard.png", { type: "image/png" });
+
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: { files: [image], getData: () => "clipboard image" },
+    });
+    wrapper.get("textarea").element.dispatchEvent(event);
+    await vi.waitFor(() => expect(wrapper.emitted("update:files")).toHaveLength(1));
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(wrapper.emitted("update:files")?.at(-1)?.[0]).toEqual([
+      {
+        filename: "clipboard.png",
+        mediaType: "image/png",
+        type: "file",
+        url: "data:image/png;base64,aW1hZ2U=",
+      },
+    ]);
+  });
+
+  it("leaves generic clipboard files alone when text is present", async () => {
+    const wrapper = mount(AgentChatPrompt, { global });
+    const document = new File(["notes"], "notes.txt", { type: "text/plain" });
+
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: { files: [document], getData: () => "keep this text" },
+    });
+    wrapper.get("textarea").element.dispatchEvent(event);
+    await flushPromises();
+
+    expect(event.defaultPrevented).toBe(false);
+    expect(wrapper.emitted("update:files")).toBeUndefined();
+  });
+
+  it("filters picker and pasted files before conversion", async () => {
+    const filterFiles = vi.fn(() => [] as File[]);
+    const wrapper = mount(AgentChatPrompt, { global, props: { filterFiles } });
+    const picked = new File(["picked"], "picked.png", { type: "image/png" });
+    const pasted = new File(["pasted"], "pasted.png", { type: "image/png" });
+    const input = wrapper.get('input[type="file"]');
+    Object.defineProperty(input.element, "files", { configurable: true, value: [picked] });
+
+    await input.trigger("change");
+    const event = new Event("paste", { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "clipboardData", {
+      value: { files: [pasted], getData: () => "" },
+    });
+    wrapper.get("textarea").element.dispatchEvent(event);
+    await flushPromises();
+
+    expect(filterFiles.mock.calls).toEqual([[[picked]], [[pasted]]]);
+    expect(wrapper.emitted("update:files")).toBeUndefined();
+  });
+
+  it("previews image attachments above the editor", () => {
+    const wrapper = mount(AgentChatPrompt, {
+      global,
+      props: {
+        files: [
+          {
+            filename: "preview.png",
+            mediaType: "image/png",
+            type: "file",
+            url: "data:image/png;base64,aW1hZ2U=",
+          },
+        ],
+      },
+    });
+
+    expect(wrapper.get(".vh-prompt__attachment--image img").attributes()).toMatchObject({
+      alt: "preview.png",
+      src: "data:image/png;base64,aW1hZ2U=",
+    });
   });
 
   it.each([
@@ -143,13 +236,26 @@ describe("AgentChatPrompt", () => {
     ]);
 
     expect(attachments.inputProps.value.multiple).toBe(true);
-    expect(attachments.files.value.map(({ file }) => file.name)).toEqual(["first.txt", "second.txt"]);
+    expect(attachments.files.value.map(({ file }) => file.name)).toEqual([
+      "first.txt",
+      "second.txt",
+    ]);
     scope.stop();
   });
 
   it("replaces the controlled attachment when multiple files are disabled", () => {
-    const oldFile = { filename: "old.txt", mediaType: "text/plain", type: "file" as const, url: "data:,old" };
-    const newFile = { filename: "new.txt", mediaType: "text/plain", type: "file" as const, url: "data:,new" };
+    const oldFile = {
+      filename: "old.txt",
+      mediaType: "text/plain",
+      type: "file" as const,
+      url: "data:,old",
+    };
+    const newFile = {
+      filename: "new.txt",
+      mediaType: "text/plain",
+      type: "file" as const,
+      url: "data:,new",
+    };
 
     expect(nextPromptFiles([oldFile], [newFile], false)).toEqual([newFile]);
   });

--- a/packages/ui/test/chat-prompt.test.ts
+++ b/packages/ui/test/chat-prompt.test.ts
@@ -178,6 +178,28 @@ describe("AgentChatPrompt", () => {
     expect(wrapper.emitted("update:files")).toBeUndefined();
   });
 
+  it("reports attachment preparation errors", async () => {
+    const error = new Error("could not prepare attachment");
+    const wrapper = mount(AgentChatPrompt, {
+      global,
+      props: {
+        filterFiles: () => {
+          throw error;
+        },
+      },
+    });
+    const input = wrapper.get('input[type="file"]');
+    Object.defineProperty(input.element, "files", {
+      configurable: true,
+      value: [new File(["image"], "broken.png", { type: "image/png" })],
+    });
+
+    await input.trigger("change");
+    await flushPromises();
+
+    expect(wrapper.emitted("error")).toEqual([[error]]);
+  });
+
   it("previews image attachments above the editor", () => {
     const wrapper = mount(AgentChatPrompt, {
       global,

--- a/packages/ui/test/chat-prompt.test.ts
+++ b/packages/ui/test/chat-prompt.test.ts
@@ -169,12 +169,13 @@ describe("AgentChatPrompt", () => {
     await input.trigger("change");
     const event = new Event("paste", { bubbles: true, cancelable: true });
     Object.defineProperty(event, "clipboardData", {
-      value: { files: [pasted], getData: () => "" },
+      value: { files: [pasted], getData: () => "keep this text" },
     });
     wrapper.get("textarea").element.dispatchEvent(event);
     await flushPromises();
 
     expect(filterFiles.mock.calls).toEqual([[[picked]], [[pasted]]]);
+    expect(event.defaultPrevented).toBe(false);
     expect(wrapper.emitted("update:files")).toBeUndefined();
   });
 

--- a/patches/nitro@3.0.260610-beta.patch
+++ b/patches/nitro@3.0.260610-beta.patch
@@ -1,0 +1,23 @@
+diff --git a/package.json b/package.json
+index 70c839508ff888bbee0f292aacb32dec34575568..3d04d5dfeeea540ccd023d1cd12e4fb2b6fd18d5 100644
+--- a/package.json
++++ b/package.json
+@@ -38,7 +38,10 @@
+     "./config": "./dist/runtime/config.mjs",
+     "./context": "./dist/runtime/context.mjs",
+     "./database": "./dist/runtime/database.mjs",
+-    "./h3": "./lib/h3.mjs",
++    "./h3": {
++      "types": "./h3.d.ts",
++      "default": "./lib/h3.mjs"
++    },
+     "./meta": "./dist/runtime/meta.mjs",
+     "./package.json": "./package.json",
+     "./runtime-config": "./dist/runtime/runtime-config.mjs",
+diff --git a/h3.d.ts b/h3.d.ts
+new file mode 100644
+index 0000000000000000000000000000000000000000..3092049d901e20894fe19df326f9a8f2904d9313
+--- /dev/null
++++ b/h3.d.ts
+@@ -0,0 +1 @@
++export * from './lib/h3.mjs'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -431,6 +431,9 @@ patchedDependencies:
   '@vercel/blob@2.8.0':
     hash: 015566b186d9cff0cbb8b65329ee62915fc585ee6aa848ecd8d81ab91dd44b25
     path: patches/@vercel__blob@2.8.0.patch
+  nitro@3.0.260610-beta:
+    hash: c9de7f8985f39c0733c1fbeb992d7fbabd2fa5e68f44efff313ffee0abc418bf
+    path: patches/nitro@3.0.260610-beta.patch
 
 importers:
 
@@ -26784,7 +26787,7 @@ snapshots:
   eve@0.46.1(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@libsql/client@0.17.4)(@netlify/blobs@10.7.5)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(@vercel/blob@2.8.0(patch_hash=015566b186d9cff0cbb8b65329ee62915fc585ee6aa848ecd8d81ab91dd44b25))(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.3))(@vercel/queue@0.0.0-alpha.40)(@voidzero-dev/vite-plus-core@0.1.24)(ai@7.0.58(zod@4.4.3))(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(bun-types@1.4.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1))(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(just-bash@3.4.2)(lru-cache@11.5.2)(miniflare@4.20260714.0)(rollup@4.62.2)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.3))(wrangler@4.126.0(@cloudflare/workers-types@4.20260509.1)):
     dependencies:
       ai: 7.0.58(zod@4.4.3)
-      nitro: 3.0.260610-beta(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@libsql/client@0.17.4)(@netlify/blobs@10.7.5)(@upstash/redis@1.38.0)(@vercel/blob@2.8.0(patch_hash=015566b186d9cff0cbb8b65329ee62915fc585ee6aa848ecd8d81ab91dd44b25))(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.3))(@vercel/queue@0.0.0-alpha.40)(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(bun-types@1.4.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1))(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(lru-cache@11.5.2)(miniflare@4.20260714.0)(rollup@4.62.2)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.3))(wrangler@4.126.0(@cloudflare/workers-types@4.20260509.1))
+      nitro: 3.0.260610-beta(patch_hash=c9de7f8985f39c0733c1fbeb992d7fbabd2fa5e68f44efff313ffee0abc418bf)(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@libsql/client@0.17.4)(@netlify/blobs@10.7.5)(@upstash/redis@1.38.0)(@vercel/blob@2.8.0(patch_hash=015566b186d9cff0cbb8b65329ee62915fc585ee6aa848ecd8d81ab91dd44b25))(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.3))(@vercel/queue@0.0.0-alpha.40)(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(bun-types@1.4.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1))(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(lru-cache@11.5.2)(miniflare@4.20260714.0)(rollup@4.62.2)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.3))(wrangler@4.126.0(@cloudflare/workers-types@4.20260509.1))
       undici: 8.9.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -29263,7 +29266,7 @@ snapshots:
       - uploadthing
       - wrangler
 
-  nitro@3.0.260610-beta(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@libsql/client@0.17.4)(@netlify/blobs@10.7.5)(@upstash/redis@1.38.0)(@vercel/blob@2.8.0(patch_hash=015566b186d9cff0cbb8b65329ee62915fc585ee6aa848ecd8d81ab91dd44b25))(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.3))(@vercel/queue@0.0.0-alpha.40)(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(bun-types@1.4.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1))(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(lru-cache@11.5.2)(miniflare@4.20260714.0)(rollup@4.62.2)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.3))(wrangler@4.126.0(@cloudflare/workers-types@4.20260509.1)):
+  nitro@3.0.260610-beta(patch_hash=c9de7f8985f39c0733c1fbeb992d7fbabd2fa5e68f44efff313ffee0abc418bf)(@azure/identity@4.13.1)(@azure/storage-blob@12.31.0)(@libsql/client@0.17.4)(@netlify/blobs@10.7.5)(@upstash/redis@1.38.0)(@vercel/blob@2.8.0(patch_hash=015566b186d9cff0cbb8b65329ee62915fc585ee6aa848ecd8d81ab91dd44b25))(@vercel/functions@3.7.5(@aws-sdk/credential-provider-web-identity@3.972.65)(ws@8.21.3))(@vercel/queue@0.0.0-alpha.40)(@voidzero-dev/vite-plus-core@0.1.24)(aws4fetch@1.0.20)(better-sqlite3@12.9.0)(chokidar@5.0.0)(dotenv@17.4.2)(drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260509.1)(@libsql/client@0.17.4)(@opentelemetry/api@1.9.1)(@upstash/redis@1.38.0)(better-sqlite3@12.9.0)(bun-types@1.4.0)(kysely@0.29.3)(postgres@3.4.9)(sql.js@1.14.1))(giget@3.3.0)(ioredis@5.11.1)(jiti@2.7.0)(lru-cache@11.5.2)(miniflare@4.20260714.0)(rollup@4.62.2)(uploadthing@7.7.4(express@5.2.1)(h3@1.15.11)(tailwindcss@4.3.3))(wrangler@4.126.0(@cloudflare/workers-types@4.20260509.1)):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.10(srvx@0.11.22)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -188,3 +188,4 @@ patchedDependencies:
   '@pierre/diffs@1.3.5': patches/@pierre__diffs@1.3.5.patch
   '@pierre/trees@1.0.0-beta.6': patches/@pierre__trees@1.0.0-beta.6.patch
   '@vercel/blob@2.8.0': patches/@vercel__blob@2.8.0.patch
+  nitro@3.0.260610-beta: patches/nitro@3.0.260610-beta.patch


### PR DESCRIPTION
AgentChatPrompt now follows the T3 Code composer contract for attachments: picker and clipboard files share one filter/conversion path, pasted images get previews, rejected clipboard text is preserved, and the paperclip sits beside send in the bottom action row.

The agent adapter materializes AI SDK `data:` URL attachments before provider dispatch, so pasted images work without weakening the existing remote-URL ownership guard. The generated web-chat response also exposes its exact invocation ID through the Vue client, allowing consumers to link directly to the matching ViteHub console run without an extra list request.

This also moves Portal’s applicable Nitro compatibility patch into ViteHub itself and declares it through `patchedDependencies`. The other Portal patches target packages or versions ViteHub does not install and were intentionally not copied.

## Test plan
- `pnpm --filter @vite-hub/ui test`
- `pnpm --dir packages/ui exec vp test test/chat-prompt.test.ts`
- `pnpm --filter @vite-hub/agent typecheck`
- `pnpm --dir packages/agent exec vp test test/chat-message-input.test.ts test/vue.test.ts`
- `pnpm --filter @vite-hub/agent test -- test/providers.test.ts -t "serves AI SDK UI message chat requests through the chat trigger"`
- pkg.pr.new tarballs for `vite-hub`, `@vite-hub/agent`, and `@vite-hub/workspace` return HTTP 200