### PR TITLE
fix(console): prevent search indexing

### DIFF
--- a/docs/content/docs/development/console.md
+++ b/docs/content/docs/development/console.md
@@ -125,6 +125,8 @@ Fixtures often contain prompts and model output. Use synthetic or scrubbed recor
 
 The Console registers the page under `/_vitehub/**` and its read API under `/api/_vitehub/console/**`. A production build rejects bare `console: true` so these inspection routes cannot be exposed accidentally.
 
+ViteHub sends `X-Robots-Tag: noindex, nofollow` on both route groups and includes the equivalent robots meta tag in the standalone Console page. These directives keep the Console out of search engines that honor them. They do not restrict access, so keep the production access policy below.
+
 If the app uses ViteHub Auth, set `console: { access: 'auth' }` and guard both route groups in the Primary Auth Definition. The host decides what makes a user an administrator.
 
 ```ts [vite.config.ts]
@@ -171,6 +173,19 @@ export default defineConfig({
 ```
 
 `host-managed` is an acknowledgement, not middleware. ViteHub does not inspect or enforce the host's access policy in this mode.
+
+Nuxt does not need an SEO module for the `X-Robots-Tag` default. If the app already uses `@nuxtjs/robots` or `@nuxtjs/seo`, add route metadata so its robots and sitemap modules also know that Console pages are not indexable:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  routeRules: {
+    '/_vitehub': { robots: false },
+    '/_vitehub/**': { robots: false },
+  },
+})
+```
+
+Do not use `robots.txt` as access control. A crawler can ignore it, and a disallowed URL may still be listed without its contents.
 
 Read [Auth](/docs/server-primitives/auth#authorize-access-routes) for sign-in redirects and the complete callback contract.
 

--- a/packages/vite-hub/src/console/runtime/server/page.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/page.get.ts
@@ -10,6 +10,7 @@ const page = `<!doctype html>
     <meta name="theme-color" content="#fdfdfd" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#0a0a0a" media="(prefers-color-scheme: dark)">
     <meta name="description" content="Read-only ViteHub project inspection">
+    <meta name="robots" content="noindex, nofollow">
     <title>ViteHub Console</title>
     <link rel="stylesheet" href="/_vitehub/assets/console.css">
   </head>

--- a/packages/vite-hub/src/console/runtime/server/request.ts
+++ b/packages/vite-hub/src/console/runtime/server/request.ts
@@ -102,6 +102,7 @@ export function setConsoleResponseHeaders(event: ConsoleRequestEvent): void {
   const headers = {
     "cache-control": "no-store",
     "x-content-type-options": "nosniff",
+    "x-robots-tag": "noindex, nofollow",
   }
   for (const [name, value] of Object.entries(headers)) {
     event.res?.headers?.set(name, value)

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -86,6 +86,10 @@ type NuxtLike = {
     }
     modules?: unknown[]
     nitro?: Record<string, unknown>
+    routeRules?: Record<string, {
+      headers?: Record<string, string>
+      [key: string]: unknown
+    }>
     rootDir?: string
     serverDir?: string
     srcDir?: string
@@ -467,6 +471,11 @@ async function installConsole(
   installConsoleSections(projectRoot, sections)
   installConsoleProjectName(projectRoot, resolveConsoleProjectNameFromRoot(projectRoot))
   if (installInvocations && sections.includes("agents") && !fixture) installConsoleInvocations(projectRoot)
+  const routeRules = (nuxt.options.routeRules ??= {})
+  for (const route of ["/_vitehub", "/_vitehub/**"]) {
+    const rule = (routeRules[route] ??= {})
+    rule.headers = { ...rule.headers, "x-robots-tag": "noindex, nofollow" }
+  }
   // doctor-disable-next-line typescript/evidence/no-chained-type-assertions -- Nuxt exposes hook overloads, while this structural seam keeps narrow nitro-only test hosts assignable.
   const hookPages = nuxt.hook as unknown as ((name: "pages:extend", callback: (pages: NuxtPage[]) => void) => void) | undefined
   hookPages?.("pages:extend", (pages) => {

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -3838,7 +3838,7 @@ describe("Agent invocation console", () => {
     expect(() => assertConsoleRequest(event(undefined))).not.toThrow()
   })
 
-  it("marks every console API response as non-cacheable", () => {
+  it("marks every console API response as non-cacheable and non-indexable", () => {
     const responseHeaders = new Map<string, string>()
     const requestEvent = event("127.0.0.1")
     requestEvent.node!.res = {
@@ -3850,16 +3850,18 @@ describe("Agent invocation console", () => {
     expect(responseHeaders).toEqual(new Map([
       ["cache-control", "no-store"],
       ["x-content-type-options", "nosniff"],
+      ["x-robots-tag", "noindex, nofollow"],
     ]))
   })
 
-  it("serves the standalone shell with a restrictive non-cacheable policy", () => {
+  it("serves the standalone shell with a restrictive non-cacheable policy", async () => {
     const response = consolePageHandler(event("127.0.0.1"))
 
     expect(response.headers.get("cache-control")).toBe("no-store")
     expect(response.headers.get("content-security-policy")).toContain("frame-ancestors 'none'")
     expect(response.headers.get("content-security-policy")).toContain("base-uri 'none'")
     expect(response.headers.get("content-security-policy")).toContain("form-action 'none'")
+    expect(await response.text()).toContain('<meta name="robots" content="noindex, nofollow">')
     expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow")
   })
 

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -134,6 +134,7 @@ function createNuxt(dev = false, plugins: PluginOption[] = []) {
       }> | undefined,
       modules: undefined as unknown[] | undefined,
       nitro: {} as Record<string, unknown>,
+      routeRules: {} as Record<string, { headers?: Record<string, string>; [key: string]: unknown }>,
       rootDir: "/tmp/vitehub-nuxt",
       serverDir: "/tmp/vitehub-nuxt/custom-server" as string | undefined,
       srcDir: "/tmp/vitehub-nuxt/app",
@@ -509,6 +510,10 @@ describe("ViteHub Nuxt integration", () => {
     const development = createNuxt(true)
     const existingConsoleHandler = vi.fn()
     development.nuxt.options.devServerHandlers = [{ handler: existingConsoleHandler, route: "/api/_vitehub/console" }]
+    development.nuxt.options.routeRules["/_vitehub/**"] = {
+      headers: { "cache-control": "private" },
+      swr: false,
+    }
     await viteHubNuxtModule({ agent: true, blob: true, console: true, kv: true, preset: "node" }, development.nuxt)
     const pages: Array<{ file: string; name: string; path: string }> = []
     development.runPagesHook(pages)
@@ -540,6 +545,13 @@ describe("ViteHub Nuxt integration", () => {
         { route: "/api/_vitehub/console/usage" },
       ],
       plugins: ["/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs"],
+    })
+    expect(development.nuxt.options.routeRules).toMatchObject({
+      "/_vitehub": { headers: { "x-robots-tag": "noindex, nofollow" } },
+      "/_vitehub/**": {
+        headers: { "cache-control": "private", "x-robots-tag": "noindex, nofollow" },
+        swr: false,
+      },
     })
     expect(development.nuxt.options.devServerHandlers).toEqual([{ handler: existingConsoleHandler, route: "/api/_vitehub/console" }])
     expect(development.nuxt.options.vite.plugins).toContainEqual(expect.objectContaining({ name: "vite-hub/console-invocation-root" }))
@@ -600,6 +612,10 @@ describe("ViteHub Nuxt integration", () => {
         { route: "/api/_vitehub/console/usage" },
       ],
       plugins: ["/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs"],
+    })
+    expect(production.nuxt.options.routeRules).toMatchObject({
+      "/_vitehub": { headers: { "x-robots-tag": "noindex, nofollow" } },
+      "/_vitehub/**": { headers: { "x-robots-tag": "noindex, nofollow" } },
     })
     expect(production.nuxt.options.devServerHandlers).toBeUndefined()
     expect(production.nuxt.options.vite.plugins).toContainEqual(expect.objectContaining({ name: "vite-hub/console-invocation-root" }))
@@ -1683,6 +1699,7 @@ describe("ViteHub Nuxt integration", () => {
     expect(mocks.uiModule).not.toHaveBeenCalled()
     expect(pageHooks).toHaveLength(0)
     expect(nuxt.options.nitro).not.toHaveProperty("handlers")
+    expect(nuxt.options.routeRules).toEqual({})
   })
 
   it("does not install the console when explicitly disabled", async () => {
@@ -1692,6 +1709,7 @@ describe("ViteHub Nuxt integration", () => {
     expect(mocks.uiModule).not.toHaveBeenCalled()
     expect(pageHooks).toHaveLength(0)
     expect(nuxt.options.nitro).not.toHaveProperty("handlers")
+    expect(nuxt.options.routeRules).toEqual({})
     expect(nuxt.options.vite.plugins).not.toContainEqual(
       expect.objectContaining({ name: "vite-hub/console-invocation-root" }),
     )


### PR DESCRIPTION
## Summary

- mark every Console API response as `noindex, nofollow`
- apply the same policy to Nuxt Console pages while preserving existing route rules
- add a robots meta fallback to the standalone shell and document optional Nuxt Robots/Nuxt SEO metadata

## Why

Console routes expose operational project data and should not be eligible for indexing by compliant crawlers. ViteHub now owns that default across framework integrations; authentication remains the access-control boundary because crawler directives are not security controls.

## Verification

- `TMPDIR=<clean-directory> pnpm --filter vite-hub test` — 25 files, 522 tests passed; no type errors
- `pnpm exec vp test test/console.test.ts test/nuxt.test.ts` — 219 tests passed; no type errors
- `pnpm --dir docs run test:links` — 757 internal links validated
- changed-file `oxlint` and `git diff --check`
