### PR TITLE
fix(console): refresh standalone assets after deploy

### DIFF
--- a/packages/vite-hub/console.vite.config.ts
+++ b/packages/vite-hub/console.vite.config.ts
@@ -42,10 +42,10 @@ export default defineConfig({
       input: resolve(clientRoot, "main.js"),
       output: {
         assetFileNames: asset => asset.names.some(name => name.endsWith(".css"))
-          ? "console.css"
+          ? "console-[hash][extname]"
           : "assets/[name]-[hash][extname]",
         chunkFileNames: "chunks/[name]-[hash].js",
-        entryFileNames: "console.js",
+        entryFileNames: "console-[hash].js",
       },
     },
   },

--- a/packages/vite-hub/src/console/runtime/server/page.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/page.get.ts
@@ -2,7 +2,6 @@ import { assertConsoleRequest } from "./request.ts";
 
 import type { ConsoleRequestEvent } from "./request.ts";
 
-const assetVersion = Date.now().toString(36);
 const page = `<!doctype html>
 <html lang="en">
   <head>
@@ -13,11 +12,11 @@ const page = `<!doctype html>
     <meta name="description" content="Read-only ViteHub project inspection">
     <meta name="robots" content="noindex, nofollow">
     <title>ViteHub Console</title>
-    <link rel="stylesheet" href="/_vitehub/assets/console.css?v=${assetVersion}">
+    <link rel="stylesheet" href="/_vitehub/assets/__VITEHUB_CONSOLE_STYLE_ASSET__">
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/_vitehub/assets/console.js?v=${assetVersion}"></script>
+    <script type="module" src="/_vitehub/assets/__VITEHUB_CONSOLE_SCRIPT_ASSET__"></script>
   </body>
 </html>`;
 

--- a/packages/vite-hub/src/console/runtime/server/page.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/page.get.ts
@@ -2,6 +2,7 @@ import { assertConsoleRequest } from "./request.ts";
 
 import type { ConsoleRequestEvent } from "./request.ts";
 
+const assetVersion = Date.now().toString(36);
 const page = `<!doctype html>
 <html lang="en">
   <head>
@@ -12,11 +13,11 @@ const page = `<!doctype html>
     <meta name="description" content="Read-only ViteHub project inspection">
     <meta name="robots" content="noindex, nofollow">
     <title>ViteHub Console</title>
-    <link rel="stylesheet" href="/_vitehub/assets/console.css">
+    <link rel="stylesheet" href="/_vitehub/assets/console.css?v=${assetVersion}">
   </head>
   <body>
     <div id="app"></div>
-    <script type="module" src="/_vitehub/assets/console.js"></script>
+    <script type="module" src="/_vitehub/assets/console.js?v=${assetVersion}"></script>
   </body>
 </html>`;
 

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -3854,12 +3854,12 @@ describe("Agent invocation console", () => {
     ]))
   })
 
-  it("serves the standalone shell with content-addressed assets and a restrictive non-cacheable policy", async () => {
+  it("serves the standalone shell with build-replaceable assets and a restrictive non-cacheable policy", async () => {
     const response = consolePageHandler(event("127.0.0.1"))
     const page = await response.text()
 
-    expect(page).toMatch(/\/_vitehub\/assets\/console-[^"']+\.css/)
-    expect(page).toMatch(/\/_vitehub\/assets\/console-[^"']+\.js/)
+    expect(page).toContain("/_vitehub/assets/__VITEHUB_CONSOLE_STYLE_ASSET__")
+    expect(page).toContain("/_vitehub/assets/__VITEHUB_CONSOLE_SCRIPT_ASSET__")
     expect(response.headers.get("cache-control")).toBe("no-store")
     expect(response.headers.get("content-security-policy")).toContain("frame-ancestors 'none'")
     expect(response.headers.get("content-security-policy")).toContain("base-uri 'none'")

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -3854,14 +3854,12 @@ describe("Agent invocation console", () => {
     ]))
   })
 
-  it("serves the standalone shell with versioned assets and a restrictive non-cacheable policy", async () => {
+  it("serves the standalone shell with content-addressed assets and a restrictive non-cacheable policy", async () => {
     const response = consolePageHandler(event("127.0.0.1"))
     const page = await response.text()
-    const assetVersions = [...page.matchAll(/\/_vitehub\/assets\/console\.(?:css|js)\?v=([^"']+)/g)]
-      .map(match => match[1])
 
-    expect(assetVersions).toHaveLength(2)
-    expect(new Set(assetVersions).size).toBe(1)
+    expect(page).toMatch(/\/_vitehub\/assets\/console-[^"']+\.css/)
+    expect(page).toMatch(/\/_vitehub\/assets\/console-[^"']+\.js/)
     expect(response.headers.get("cache-control")).toBe("no-store")
     expect(response.headers.get("content-security-policy")).toContain("frame-ancestors 'none'")
     expect(response.headers.get("content-security-policy")).toContain("base-uri 'none'")

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -3854,14 +3854,19 @@ describe("Agent invocation console", () => {
     ]))
   })
 
-  it("serves the standalone shell with a restrictive non-cacheable policy", async () => {
+  it("serves the standalone shell with versioned assets and a restrictive non-cacheable policy", async () => {
     const response = consolePageHandler(event("127.0.0.1"))
+    const page = await response.text()
+    const assetVersions = [...page.matchAll(/\/_vitehub\/assets\/console\.(?:css|js)\?v=([^"']+)/g)]
+      .map(match => match[1])
 
+    expect(assetVersions).toHaveLength(2)
+    expect(new Set(assetVersions).size).toBe(1)
     expect(response.headers.get("cache-control")).toBe("no-store")
     expect(response.headers.get("content-security-policy")).toContain("frame-ancestors 'none'")
     expect(response.headers.get("content-security-policy")).toContain("base-uri 'none'")
     expect(response.headers.get("content-security-policy")).toContain("form-action 'none'")
-    expect(await response.text()).toContain('<meta name="robots" content="noindex, nofollow">')
+    expect(page).toContain('<meta name="robots" content="noindex, nofollow">')
     expect(response.headers.get("x-robots-tag")).toBe("noindex, nofollow")
   })
 

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -628,10 +628,13 @@ describe("framework package contract", () => {
     expect(existsSync(`${packageRoot}/dist/console/runtime/components/console-usage.vue`)).toBe(
       true,
     );
-    const consoleClient = readFileSync(
-      `${packageRoot}/dist/console/runtime/public/console/console.js`,
-      "utf8",
-    );
+    const consoleClientFiles = globSync("dist/console/runtime/public/console/console-*.js", {
+      cwd: packageRoot,
+    });
+    expect(consoleClientFiles).toHaveLength(1);
+    const [consoleClientFile] = consoleClientFiles;
+    if (!consoleClientFile) throw new TypeError("Expected one hashed Console client asset.");
+    const consoleClient = readFileSync(`${packageRoot}/${consoleClientFile}`, "utf8");
     expect(consoleClient).toContain('"robot-light":{"width":256');
     expect(consoleClient).toContain('"folder-tree":{"width":24');
     expect(consoleClient).toContain("prefers-color-scheme: dark");
@@ -648,13 +651,23 @@ describe("framework package contract", () => {
     expect(consoleClient).toContain("/sandboxes");
     expect(consoleClient).toContain("/workspaces");
     expect(consoleClient).toContain("currentRoute.value");
-    const consoleCss = readFileSync(
-      `${packageRoot}/dist/console/runtime/public/console/console.css`,
-      "utf8",
-    );
+    const consoleCssFiles = globSync("dist/console/runtime/public/console/console-*.css", {
+      cwd: packageRoot,
+    });
+    expect(consoleCssFiles).toHaveLength(1);
+    const [consoleCssFile] = consoleCssFiles;
+    if (!consoleCssFile) throw new TypeError("Expected one hashed Console stylesheet asset.");
+    const consoleCss = readFileSync(`${packageRoot}/${consoleCssFile}`, "utf8");
     expect(consoleCss).toContain("vitehub-console");
     expect(consoleCss).toContain("--ui-bg:#fdfdfd");
     expect(consoleCss).toContain("--ui-text:#27272a");
+    const consolePageSource = readFileSync(
+      `${packageRoot}/dist/console/runtime/server/page.get.js`,
+      "utf8",
+    );
+    expect(consolePageSource).toContain(`/_vitehub/assets/${consoleClientFile.split("/").at(-1)}`);
+    expect(consolePageSource).toContain(`/_vitehub/assets/${consoleCssFile.split("/").at(-1)}`);
+    expect(consolePageSource).not.toContain("__VITEHUB_CONSOLE_");
     expect(manifest.dependencies).toHaveProperty("@cloudflare/workers-types");
   });
 

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -1,6 +1,7 @@
-import { defineConfig } from "vite-plus";
 import { readdirSync } from "node:fs";
 import { resolve } from "node:path";
+
+import { defineConfig } from "vite-plus";
 import * as v from "valibot";
 
 import frameworkPackageManifest from "./package.json" with { type: "json" };

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -1,4 +1,6 @@
 import { defineConfig } from "vite-plus";
+import { readdirSync } from "node:fs";
+import { resolve } from "node:path";
 import * as v from "valibot";
 
 import frameworkPackageManifest from "./package.json" with { type: "json" };
@@ -46,6 +48,17 @@ const distributionEntries = [
   ]),
   "src/console/runtime/client/sections.ts",
 ].sort();
+
+const consoleAssetRoot = resolve(import.meta.dirname, ".vitehub/console");
+
+function consoleAsset(extension: ".css" | ".js"): string {
+  const matches = readdirSync(consoleAssetRoot)
+    .filter(file => file.startsWith("console-") && file.endsWith(extension));
+  if (matches.length !== 1) {
+    throw new TypeError(`Expected one hashed Console ${extension} asset, found ${matches.length}.`);
+  }
+  return matches[0]!;
+}
 
 export default defineConfig({
   pack: {
@@ -169,6 +182,21 @@ export default defineConfig({
       onlyBundle: false,
     },
     plugins: [
+      {
+        name: "vite-hub-console-assets",
+        generateBundle(_options, bundle) {
+          const page = Object.values(bundle).find(output =>
+            output.type === "chunk"
+            && output.facadeModuleId?.replaceAll("\\", "/").endsWith("/src/console/runtime/server/page.get.ts")
+          );
+          if (!page || page.type !== "chunk") {
+            throw new TypeError("Expected the standalone Console page in the package bundle.");
+          }
+          page.code = page.code
+            .replaceAll("__VITEHUB_CONSOLE_STYLE_ASSET__", consoleAsset(".css"))
+            .replaceAll("__VITEHUB_CONSOLE_SCRIPT_ASSET__", consoleAsset(".js"));
+        },
+      },
       {
         name: "vite-hub-env-config-declarations",
         generateBundle(_options, bundle) {


### PR DESCRIPTION
The standalone Console shell used stable asset URLs, so a tab or browser cache could keep the pre-deploy two-column trace bundle after the server had started serving the new bottom splitter.

Emit content-hashed filenames for the Console CSS and JavaScript, then insert those exact filenames into the packaged standalone shell. A rolling deployment cannot serve old bytes for a new asset URL. The existing Nuxt UI vertical splitter remains the owning layout: waterfall above, selected-span details below, draggable horizontal boundary, and scrollable detail content.

Verified locally:
- targeted lint
- TypeScript doctor
- diff check

The focused test and package typecheck require workspace build output, so exact-head CI provides those checks.