### PR TITLE
fix(console): tighten inspector panel layout

### DIFF
--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -228,7 +228,7 @@ const splitterItems: SplitterItem[] = [
     id: "thread",
     slot: "thread",
     minSize: 360,
-    defaultSize: 680,
+    defaultSize: 720,
     sizeUnit: "px",
     class: "h-full min-h-0 min-w-0 overflow-hidden",
   },
@@ -237,7 +237,7 @@ const splitterItems: SplitterItem[] = [
     slot: "details",
     minSize: 360,
     maxSize: 1080,
-    defaultSize: 540,
+    defaultSize: 440,
     sizeUnit: "px",
     class: "h-full min-h-0 min-w-0 overflow-hidden",
   },
@@ -959,7 +959,7 @@ onBeforeUnmount(() => {
           <USplitter
             v-else-if="isDesktop && detailsOpen && (selectedInvocationId || initialSessionLoading)"
             id="agent-session-layout"
-            auto-save-id="vitehub-agent-session-layout"
+            auto-save-id="vitehub-agent-session-layout-v2"
             :items="splitterItems"
             class="h-full min-h-0 overflow-hidden"
           >

--- a/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
@@ -471,7 +471,7 @@ function message(error: unknown) {
           variant="pill"
           :ui="{
             root: 'min-w-0',
-            list: 'w-max min-w-full gap-1 bg-transparent p-0',
+            list: 'w-max min-w-0 gap-1 bg-transparent p-0',
             indicator: 'hidden',
             trigger:
               'group/tab h-6 max-w-36 shrink-0 grow-0 cursor-pointer justify-start gap-0.5 rounded-md px-1.5 py-0 text-xs',

--- a/packages/vite-hub/src/console/runtime/components/console-session.css
+++ b/packages/vite-hub/src/console/runtime/components/console-session.css
@@ -27,19 +27,20 @@
 
 .session-inspector__tabstrip {
   align-items: center;
-  display: grid;
+  display: flex;
   gap: 0.25rem;
-  grid-template-columns: minmax(0, 1fr) 2rem;
   min-width: 0;
   overflow: hidden;
 }
 
 .session-inspector__tabs {
+  flex: 0 1 auto;
+  max-width: calc(100% - 2rem);
   min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
   scrollbar-width: none;
-  width: 100%;
+  width: max-content;
 }
 
 .session-inspector__tabs::-webkit-scrollbar {
@@ -48,7 +49,7 @@
 
 .session-inspector__tabs [data-slot="list"] {
   gap: 4px !important;
-  min-width: 100%;
+  min-width: 0;
   width: max-content;
 }
 

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -423,6 +423,16 @@ describe("framework package contract", () => {
     expect(sessionInspector).toContain("workspace.pullRequest !== undefined");
     expect(sessionInspector).toContain("hasPullRequest && (pullRequest === undefined");
     expect(sessionInspector).toContain('openViews.value.includes("workspace")');
+    expect(sessionInspector).toContain("list: 'w-max min-w-0 gap-1 bg-transparent p-0'");
+    expect(consoleSessionCss).toMatch(
+      /\.session-inspector__tabstrip \{[\s\S]*?display: flex;[\s\S]*?overflow: hidden;/,
+    );
+    expect(consoleSessionCss).toMatch(
+      /\.session-inspector__tabs \{[\s\S]*?flex: 0 1 auto;[\s\S]*?max-width: calc\(100% - 2rem\);[\s\S]*?width: max-content;/,
+    );
+    expect(consoleSessionCss).toMatch(
+      /\.session-inspector__tabs \[data-slot="list"\] \{[\s\S]*?min-width: 0;[\s\S]*?width: max-content;/,
+    );
     const sessionTrace = readFileSync(
       `${packageRoot}/dist/console/runtime/components/console-session-trace.vue`,
       "utf8",
@@ -479,7 +489,10 @@ describe("framework package contract", () => {
     expect(consoleSessionNavbar).toContain('class="md:hidden"');
     expect(consoleSessionNavbar).not.toContain('class="lg:hidden"');
     expect(consolePage).toContain(':header="false"');
-    expect(consolePage).toContain('auto-save-id="vitehub-agent-session-layout"');
+    expect(consolePage).toContain('auto-save-id="vitehub-agent-session-layout-v2"');
+    expect(consolePage).toMatch(
+      /id: "thread",[\s\S]*?defaultSize: 720,[\s\S]*?id: "details",[\s\S]*?defaultSize: 440,/,
+    );
     expect(consolePage).toContain(':continuation-key="list.cursor.value"');
     expect(consolePage).not.toContain(':retry-key="invocationPaginationKey"');
     expect(consolePage).toContain("list.loadMoreError.value");
@@ -519,9 +532,9 @@ describe("framework package contract", () => {
       /\.vitehub-console__session-panel > \[data-slot="body"\][\s\S]*?padding: 0 !important;/,
     );
     expect(consolePage).toContain("minSize: 360");
-    expect(consolePage).toContain("defaultSize: 680");
+    expect(consolePage).toContain("defaultSize: 720");
     expect(consolePage).toContain("maxSize: 1080");
-    expect(consolePage).toContain("defaultSize: 540");
+    expect(consolePage).toContain("defaultSize: 440");
     expect(consolePage).toContain("max-width: 48rem");
     expect(consolePage).not.toContain("route.query.agent");
     expect(consolePage).not.toContain("groupConsoleSessions");


### PR DESCRIPTION
## Summary
- give the session thread more room while keeping the inspector resizable
- place the tab launcher directly after the last open inspector tab
- reset the saved desktop split so the improved loading geometry applies immediately

## Verification
- `pnpm exec vp run -t vite-hub#build`
- `pnpm --filter vite-hub typecheck`
- `pnpm --filter vite-hub exec vp test test/package.test.ts`
- focused oxlint and Vite Doctor strict scan
- Babysitter `pnpm patch` proof: build, typecheck, tests, and compiled runtime assertions pass

## Suite note
The full `vite-hub` suite reported two pre-existing fixture-root failures in `test/vite.test.ts`; both are unrelated to these console component/CSS changes. A transient KV timeout passed when rerun in isolation.