### PR TITLE
feat(agent): stream loading commentary and expose console context

### DIFF
--- a/packages/agent/src/capabilities/input-commands.ts
+++ b/packages/agent/src/capabilities/input-commands.ts
@@ -1,3 +1,6 @@
+import { getCapability, resolveRuntimeValue } from "@vite-hub/runtime"
+
+import { agentInvocationId } from "../invocations.ts"
 import { hasRuntimeType } from "../internal/runtime-type.ts"
 import { defineCapability } from "../capability-runtime.ts"
 import {
@@ -54,10 +57,17 @@ export interface InputCommand {
 
 export type InputCommandResult = Partial<AgentRunInput> | Response | string | void
 
+export interface ViteHubInputCommandContext {}
+
+export interface InputCommandRuntimeContext extends AgentCapabilityRuntimeContext, ViteHubInputCommandContext {
+  invocation: AgentCapabilityRuntimeContext["invocation"] & { id?: string }
+  reply: (body: string) => Promise<Response>
+}
+
 export interface InputCommandRunInput {
   args: string
   command: InputCommand
-  context: AgentCapabilityRuntimeContext
+  context: InputCommandRuntimeContext
   input: AgentRunInput
   message?: Message
   name: string
@@ -351,6 +361,28 @@ function inputPhaseMessage(context: AgentCapabilityRuntimeContext): InputCommand
   })
 }
 
+async function inputCommandRuntimeContext(context: AgentCapabilityRuntimeContext): Promise<InputCommandRuntimeContext> {
+  const capabilities = await Promise.all(Object.keys(context.capabilities).map(async (name) => {
+    if (name in context) return [] as const
+    const value = getCapability(context, name).value
+    if (value === false || value === undefined) return [] as const
+    return [name, await resolveRuntimeValue(value as never, context as never)] as const
+  }))
+  const message = inputPhaseMessage(context)
+  const id = context.run?.runId && context.agentIdentity?.name
+    ? await agentInvocationId(context.run.runId, context.agentIdentity.name)
+    : undefined
+  return {
+    ...context,
+    ...Object.fromEntries(capabilities.filter(entry => entry.length === 2)),
+    invocation: { ...context.invocation, ...(id ? { id } : {}) },
+    async reply(body) {
+      await message.reply(body)
+      return new Response(null, { status: 204 })
+    },
+  } as InputCommandRuntimeContext
+}
+
 function finishPhaseMessage(effects: AgentChannelDeliveryEffectIntent[]): InputCommandDeliveryMessage {
   return createInputCommandMessage(intent => effects.push(intent))
 }
@@ -433,7 +465,7 @@ export function inputCommands(options: InputCommandsOptions): AgentCapabilityDef
           args: invocation.args,
           command,
           // SAFETY: Input command parsing establishes the asserted command contract.
-          context: context as AgentCapabilityRuntimeContext,
+          context: await inputCommandRuntimeContext(context as AgentCapabilityRuntimeContext),
           input,
           message: target.message,
           name: invocation.name,

--- a/packages/agent/src/capabilities/input-commands.ts
+++ b/packages/agent/src/capabilities/input-commands.ts
@@ -366,12 +366,14 @@ async function inputCommandRuntimeContext(context: AgentCapabilityRuntimeContext
     if (name in context) return [] as const
     const value = getCapability(context, name).value
     if (value === false || value === undefined) return [] as const
+    // SAFETY: The generated Capability registry pairs each runtime value with this normalized runtime context.
     return [name, await resolveRuntimeValue(value as never, context as never)] as const
   }))
   const message = inputPhaseMessage(context)
   const id = context.run?.runId && context.agentIdentity?.name
     ? await agentInvocationId(context.run.runId, context.agentIdentity.name)
     : undefined
+  // SAFETY: Capability resolution above fills the open ViteHubInputCommandContext with every configured runtime value.
   return {
     ...context,
     ...Object.fromEntries(capabilities.filter(entry => entry.length === 2)),

--- a/packages/agent/src/chat-trigger.ts
+++ b/packages/agent/src/chat-trigger.ts
@@ -251,7 +251,7 @@ async function resolveChatThinkingFallback<TRuntimeConfig extends AgentRuntimeCo
   options: AgentChatOptions<TRuntimeConfig>,
   args: AgentChatAgentHookArgs<TRuntimeConfig>,
 ): Promise<string | null | undefined> {
-  const fallback = options.fallbackStreamingPlaceholderText
+  const fallback = options.loading?.text ?? options.fallbackStreamingPlaceholderText
   if (fallback === null) return null
   if (hasRuntimeType(fallback, "function")) {
     const resolved = await fallback(args)
@@ -415,13 +415,23 @@ function createChatMessageTrigger<TRuntimeConfig extends AgentRuntimeConfig>(
 }
 
 export function assertChatDeliveryOptions(options: AgentChatOptions): void {
-  if (options.delivery === "manual" && (options.stream === true || options.commentary !== undefined)) {
+  const manualDelivery = options.loading !== undefined || options.delivery === "manual"
+  if (manualDelivery && (options.stream === true || options.commentary !== undefined)) {
     throw new TypeError("[vitehub] messages.delivery \"manual\" cannot be combined with messages.stream or messages.commentary.")
+  }
+  if (options.loading?.updates !== undefined && options.loading.updates !== "commentary") {
+    throw new TypeError('[vitehub] messages.loading.updates must be "commentary".')
+  }
+  if (options.loading?.intervalMs !== undefined && (!Number.isFinite(options.loading.intervalMs) || options.loading.intervalMs <= 0)) {
+    throw new TypeError("[vitehub] messages.loading.intervalMs must be a positive finite number.")
+  }
+  if (options.final?.delivery !== undefined && options.final.delivery !== "new-message") {
+    throw new TypeError('[vitehub] messages.final.delivery must be "new-message".')
   }
   if (options.timeout !== undefined && (!Number.isFinite(options.timeout) || options.timeout <= 0)) {
     throw new TypeError("[vitehub] messages.timeout must be a positive finite number.")
   }
-  if (options.durable && options.delivery !== "manual") {
+  if (options.durable && !manualDelivery) {
     throw new TypeError("[vitehub] messages.durable requires delivery: \"manual\" so Agent finish effects own the deferred reply.")
   }
   if (options.durable && options.concurrency !== undefined && options.concurrency !== "parallel" && options.concurrency !== "steer") {

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -1699,14 +1699,13 @@ function createManualDeliveryProgressUpdater(
   }
 
   const drain = async () => {
-    while (active && latest && manualDelivery.placeholder) {
-      const summary = latest
-      latest = undefined
-      await replaceManualDeliveryPlaceholder(manualDelivery.placeholder, {
-        markdown: summary,
-      }).catch(() => false)
-      lastUpdateAt = Date.now()
-    }
+    if (!active || !latest || !manualDelivery.placeholder) return
+    const summary = latest
+    latest = undefined
+    await replaceManualDeliveryPlaceholder(manualDelivery.placeholder, {
+      markdown: summary,
+    }).catch(() => false)
+    lastUpdateAt = Date.now()
   }
   const startDrain = () => {
     if (draining) return
@@ -4518,6 +4517,9 @@ async function flushChatFinishExtensionMessages(
   const messages = chat[chatFinishMessagesKey].splice(0)
   for (const [index, queued] of messages.entries()) {
     const callbacks = queued.directCallback ? [queued.directCallback, ...queued.callbacks] : queued.callbacks
+    const runCallbacks = async (capture: ChatFinishDeliveryCapture) => {
+      await Promise.allSettled(callbacks.map(callback => Promise.resolve().then(() => callback(capture))))
+    }
     let { message } = queued
     const capture: ChatFinishDeliveryCapture = { content: "", truncated: false }
     if (isAsyncIterable(message) && callbacks.length) {
@@ -4538,26 +4540,26 @@ async function flushChatFinishExtensionMessages(
         }
         const placeholder = manualDelivery.placeholder
         if (finalDelivery === "new-message") {
+          let posted = false
           try {
             await postChatMessage(thread, message, abortSignal)
+            posted = true
+          }
+          catch (postError) {
+            abortSignal?.throwIfAborted()
+            if (!await replaceManualDeliveryPlaceholder(placeholder, message).catch(() => false)) throw postError
+          }
+          if (posted) {
             if (manualDelivery.placeholder === placeholder) manualDelivery.placeholder = undefined
             const placeholderCleanup = deleteManualDeliveryPlaceholder(placeholder).catch(() => undefined)
             manualDelivery.placeholderCleanup = placeholderCleanup
             waitUntil(placeholderCleanup.finally(() => {
               if (manualDelivery.placeholderCleanup === placeholderCleanup) manualDelivery.placeholderCleanup = undefined
             }))
-            for (const callback of callbacks) await callback(capture)
-            continue
           }
-          catch (postError) {
-            abortSignal?.throwIfAborted()
-            if (await replaceManualDeliveryPlaceholder(placeholder, message).catch(() => false)) {
-              manualDelivery.placeholder = undefined
-              for (const callback of callbacks) await callback(capture)
-              continue
-            }
-            throw postError
-          }
+          else if (manualDelivery.placeholder === placeholder) manualDelivery.placeholder = undefined
+          await runCallbacks(capture)
+          continue
         }
         let deliveredToPlaceholder = false
         const placeholderCleanup = (async () => {
@@ -4580,7 +4582,7 @@ async function flushChatFinishExtensionMessages(
           }
         }
         if (deliveredToPlaceholder) {
-          for (const callback of callbacks) await callback(capture)
+          await runCallbacks(capture)
           continue
         }
       }
@@ -4588,7 +4590,7 @@ async function flushChatFinishExtensionMessages(
     }
     catch (error) {
       capture.error = error instanceof Error ? error.message : String(error)
-      for (const callback of callbacks) await callback(capture)
+      await runCallbacks(capture)
       const skippedCapture: ChatFinishDeliveryCapture = {
         content: "",
         skipped: `Skipped after an earlier queued reply failed: ${capture.error}`,
@@ -4600,7 +4602,7 @@ async function flushChatFinishExtensionMessages(
       }
       throw error
     }
-    for (const callback of callbacks) await callback(capture)
+    await runCallbacks(capture)
   }
 }
 

--- a/packages/agent/src/server/routes.ts
+++ b/packages/agent/src/server/routes.ts
@@ -35,7 +35,6 @@ import { agentInvocationId } from "../invocations.ts"
 import { finalChannelOutputContextKey, hasOnlyPortableAgentWorkflowCapabilities, requireAgentWorkflowContextKey } from "../internal/final-channel-output.ts"
 import { agentChannelHistoryHeader } from "../internal/channel-history.ts"
 import { agentChannelSyncProviderHeader } from "../internal/channel-sync.ts"
-import { agentOutputEventObserverContextKey } from "../internal/agent-output-events.ts"
 import { attachmentStringBytes, isAttachmentData } from "../messages.ts"
 import { agentInvokerLabel, hasResolvedAgentInvokerInput, resolveInputAgentInvoker, resolveAgentInvoker, withResolvedAgentInvokerInput } from "../invoker.ts"
 import { createAgentRuntimeContext } from "../runtime/context.ts"
@@ -1611,7 +1610,7 @@ function fallbackWebhookFromRequest(request: Request): string | undefined {
 
 async function collectAgentOutput(
   result: unknown,
-  onProgress?: (summary: string) => void,
+  onProgress?: (event: unknown) => void,
   onToolResult?: (result: AgentToolStepItem) => void,
 ): Promise<string> {
   if (result instanceof Response) {
@@ -1638,6 +1637,7 @@ async function collectAgentOutput(
   let finalTextId: string | undefined
   let unphasedText = ""
   for await (const event of streamAgentOutputToEvents(result)) {
+    onProgress?.(event)
     if (event.type === "text-delta") {
       if (event.phase === undefined) {
         if (!explicitPhaseSeen) unphasedText += event.text
@@ -1651,8 +1651,6 @@ async function collectAgentOutput(
         }
       }
     }
-    const summary = progressSummaryFromEvent(event)
-    if (summary) onProgress?.(summary)
     if (event.type === "tool-result" && !event.error) {
       onToolResult?.({
         output: event.output,
@@ -1679,13 +1677,26 @@ function createManualDeliveryProgressUpdater(
   manualDelivery: { placeholder?: unknown },
   waitUntil: AgentWaitUntil,
   abortSignal?: AbortSignal,
+  options?: { intervalMs?: number, updates?: "commentary" },
 ): {
   finish: () => Promise<void>
-  update: (summary: string) => void
+  update: (event: unknown) => void
 } {
   let latest: string | undefined
+  let commentary = ""
   let active = true
   let draining: Promise<void> | undefined
+  let timer: ReturnType<typeof setTimeout> | undefined
+  let lastUpdateAt = 0
+
+  const textFromEvent = (event: unknown): string | undefined => {
+    if (options?.updates === "commentary") {
+      if (!isRecord(event) || event.type !== "text-delta" || event.phase !== "commentary" || !isRuntimeString(event.text)) return
+      commentary += event.text
+      return commentary.trim() || undefined
+    }
+    return progressSummaryFromEvent(event)
+  }
 
   const drain = async () => {
     while (active && latest && manualDelivery.placeholder) {
@@ -1694,10 +1705,20 @@ function createManualDeliveryProgressUpdater(
       await replaceManualDeliveryPlaceholder(manualDelivery.placeholder, {
         markdown: summary,
       }).catch(() => false)
+      lastUpdateAt = Date.now()
     }
   }
   const startDrain = () => {
     if (draining) return
+    const intervalMs = options?.intervalMs ?? 0
+    const delay = Math.max(0, intervalMs - (Date.now() - lastUpdateAt))
+    if (delay > 0) {
+      if (!timer) timer = setTimeout(() => {
+        timer = undefined
+        startDrain()
+      }, delay)
+      return
+    }
     draining = drain().finally(() => {
       draining = undefined
       if (active && latest && manualDelivery.placeholder) startDrain()
@@ -1707,6 +1728,7 @@ function createManualDeliveryProgressUpdater(
   return {
     async finish() {
       active = false
+      if (timer) clearTimeout(timer)
       if (!draining) return
 
       let timeout: ReturnType<typeof setTimeout> | undefined
@@ -1730,8 +1752,10 @@ function createManualDeliveryProgressUpdater(
       })
       waitUntil(cleanup)
     },
-    update(summary) {
+    update(event) {
       if (!manualDelivery.placeholder) return
+      const summary = textFromEvent(event)
+      if (!summary) return
       latest = summary
       startDrain()
     },
@@ -3673,9 +3697,10 @@ async function chatSdkLockKey(adapter: Adapter, threadId: string, options: Agent
 }
 
 function createChatSdkConfig(adapterName: string, adapter: Adapter, state: StateAdapter, options: AgentChatOptions | undefined): ChatConfig {
-  const fallbackStreamingPlaceholderText = isRuntimeString(options?.fallbackStreamingPlaceholderText)
-    ? options.fallbackStreamingPlaceholderText
-    : options?.fallbackStreamingPlaceholderText === null
+  const configuredPlaceholderText = options?.loading?.text ?? options?.fallbackStreamingPlaceholderText
+  const fallbackStreamingPlaceholderText = isRuntimeString(configuredPlaceholderText)
+    ? configuredPlaceholderText
+    : configuredPlaceholderText === null
       ? null
       : undefined
   const identity: ChatConfig["identity"] =
@@ -3694,11 +3719,15 @@ function createChatSdkConfig(adapterName: string, adapter: Adapter, state: State
     logger: chatSdkOption<ChatConfig["logger"]>(options, "logger"),
     messageHistory: chatSdkOption<ChatConfig["messageHistory"]>(options, "messageHistory"),
     state,
-    streamingUpdateIntervalMs: chatSdkOption<number>(options, "streamingUpdateIntervalMs"),
+    streamingUpdateIntervalMs: options?.loading?.intervalMs ?? chatSdkOption<number>(options, "streamingUpdateIntervalMs"),
     threadHistory: chatSdkOption<ChatConfig["threadHistory"]>(options, "threadHistory"),
     transcripts: options?.transcripts,
     userName: options?.userName || "vitehub",
   }) as ChatConfig
+}
+
+function chatFinalDelivery(options: AgentChatOptions | undefined): "new-message" | undefined {
+  if (options?.final?.delivery === "new-message" || options?.finalDelivery === "new-message") return "new-message"
 }
 
 function isoDate(value: unknown): string | undefined {
@@ -4482,6 +4511,8 @@ async function flushChatFinishExtensionMessages(
   thread: Thread,
   chat: AgentChatQueuedFinishExtension,
   manualDelivery: ManualChatDeliveryState,
+  waitUntil: AgentWaitUntil,
+  finalDelivery?: "new-message",
   abortSignal?: AbortSignal,
 ): Promise<void> {
   const messages = chat[chatFinishMessagesKey].splice(0)
@@ -4506,6 +4537,28 @@ async function flushChatFinishExtensionMessages(
           abortSignal?.throwIfAborted()
         }
         const placeholder = manualDelivery.placeholder
+        if (finalDelivery === "new-message") {
+          try {
+            await postChatMessage(thread, message, abortSignal)
+            if (manualDelivery.placeholder === placeholder) manualDelivery.placeholder = undefined
+            const placeholderCleanup = deleteManualDeliveryPlaceholder(placeholder).catch(() => undefined)
+            manualDelivery.placeholderCleanup = placeholderCleanup
+            waitUntil(placeholderCleanup.finally(() => {
+              if (manualDelivery.placeholderCleanup === placeholderCleanup) manualDelivery.placeholderCleanup = undefined
+            }))
+            for (const callback of callbacks) await callback(capture)
+            continue
+          }
+          catch (postError) {
+            abortSignal?.throwIfAborted()
+            if (await replaceManualDeliveryPlaceholder(placeholder, message).catch(() => false)) {
+              manualDelivery.placeholder = undefined
+              for (const callback of callbacks) await callback(capture)
+              continue
+            }
+            throw postError
+          }
+        }
         let deliveredToPlaceholder = false
         const placeholderCleanup = (async () => {
           try {
@@ -4751,7 +4804,7 @@ async function handleChatSdkMessage(
       }
     }
 
-    const manualDelivery = options?.delivery === "manual"
+    const manualDelivery = options?.loading !== undefined || options?.delivery === "manual"
     const streamsPhasedReplies = !manualDelivery && (options?.stream !== false || options?.commentary !== undefined)
     input = { ...input, messages }
     // SAFETY: The owning Agent runtime boundary creates this value with the asserted route contract.
@@ -5367,7 +5420,12 @@ async function handleChatSdkMessage(
       )
     }
     chatFinish = createChatFinishExtension(input, registration)
-    progress = manualDelivery ? createManualDeliveryProgressUpdater(manualDeliveryState, context.waitUntil, invocationDeadlineAbort?.signal) : undefined
+    progress = manualDelivery
+      ? createManualDeliveryProgressUpdater(manualDeliveryState, context.waitUntil, invocationDeadlineAbort?.signal, {
+          intervalMs: options?.loading?.intervalMs,
+          updates: options?.loading?.updates,
+        })
+      : undefined
     const remainingMaximumInvocationTimeout = maximumInvocationDeadline === undefined ? undefined : Math.max(0, maximumInvocationDeadline - Date.now())
     const invocationInput = withChatFinishExtension(
       withResolvedAgentInvokerInput(
@@ -5384,14 +5442,6 @@ async function handleChatSdkMessage(
           context: {
             ...resolvedInvocationInput.context,
             [messageChannelStateContextKey]: state,
-            ...(progress
-              ? {
-                  [agentOutputEventObserverContextKey]: (event: unknown) => {
-                    const summary = progressSummaryFromEvent(event)
-                    if (summary) progress?.update(summary)
-                  },
-                }
-              : {}),
             ...(options?.stream === false || manualDelivery ? { [finalChannelOutputContextKey]: true } : {}),
           },
         },
@@ -5425,7 +5475,7 @@ async function handleChatSdkMessage(
             }
           }
           await progress?.finish()
-          await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState, invocationDeadlineAbort?.signal)
+          await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState, context.waitUntil, chatFinalDelivery(options), invocationDeadlineAbort?.signal)
           invocationDeadlineAbort?.signal.throwIfAborted()
           const completedPlaceholder = manualDeliveryState.placeholder
           if (completedPlaceholder) {
@@ -5507,7 +5557,7 @@ async function handleChatSdkMessage(
           } finally {
             typing?.stop()
           }
-          await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState, invocationDeadlineAbort?.signal)
+          await flushChatFinishExtensionMessages(thread, chatFinish, manualDeliveryState, context.waitUntil, chatFinalDelivery(options), invocationDeadlineAbort?.signal)
         })(),
         maximumInvocationDeadline === undefined ? undefined : invocationInput.timeout,
         invocationDeadlineAbort,
@@ -5552,9 +5602,10 @@ function createChatSdkMessageThread(
   message: ChatSdkMessage,
   options: AgentChatOptions | undefined,
 ): Thread {
-  const fallbackStreamingPlaceholderText = isRuntimeString(options?.fallbackStreamingPlaceholderText)
-    ? options.fallbackStreamingPlaceholderText
-    : options?.fallbackStreamingPlaceholderText === null
+  const configuredPlaceholderText = options?.loading?.text ?? options?.fallbackStreamingPlaceholderText
+  const fallbackStreamingPlaceholderText = isRuntimeString(configuredPlaceholderText)
+    ? configuredPlaceholderText
+    : configuredPlaceholderText === null
       ? null
       : undefined
   return new ThreadImpl({
@@ -5568,7 +5619,7 @@ function createChatSdkMessageThread(
     isDM: adapter.isDM?.(message.threadId) ?? false,
     logger: chat.getLogger(),
     stateAdapter: state,
-    streamingUpdateIntervalMs: chatSdkOption<number>(options, "streamingUpdateIntervalMs"),
+    streamingUpdateIntervalMs: options?.loading?.intervalMs ?? chatSdkOption<number>(options, "streamingUpdateIntervalMs"),
     // SAFETY: The route normalized this value for an internal boundary whose generic signature cannot express the narrowed variant.
     threadHistory: chatThreadHistoryCache(source) as never,
   })

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1741,8 +1741,16 @@ export interface AgentMessageChannelSettings<TRuntimeConfig extends AgentRuntime
   durable?: boolean
   errorFallbackText?: string | null | ((context: AgentChatErrorHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
   fallbackStreamingPlaceholderText?: string | readonly string[] | null | ((context: AgentChatAgentHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
+  final?: {
+    delivery: "new-message"
+  }
   filter?: AgentMessageFilter<TRuntimeConfig>
   identity?: IdentityResolver
+  loading?: {
+    intervalMs?: number
+    text: string | readonly string[] | null | ((context: AgentChatAgentHookArgs<TRuntimeConfig>) => MaybePromise<string | null | undefined>)
+    updates?: "commentary"
+  }
   lockScope?: AgentMessageLockScope
   messageHistory?: unknown
   meta?: StandardSchemaV1<unknown, Record<string, unknown>>

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -141,6 +141,7 @@ interface GeneratedAgentRuntimeCapability {
 
 const generatedAgentRuntimeCapabilityDefinitions: GeneratedAgentRuntimeCapability[] = [
   { importName: "blob", name: "blob", packageName: "@vite-hub/blob", pluginName: "@vite-hub/blob/vite" },
+  { importName: "console", name: "console", packageName: "vite-hub/console/server", pluginName: "vite-hub/console" },
   { importName: "agentDb", name: "db", packageName: "@vite-hub/database/drizzle", pluginName: "@vite-hub/database/vite" },
   { importName: "email", name: "email", packageName: "@vite-hub/email/server", pluginName: "@vite-hub/email/vite" },
   { importName: "kv", name: "kv", packageName: "@vite-hub/kv", pluginName: "@vite-hub/kv/vite" },

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -11,6 +11,40 @@ const runtime = () => ({
 })
 
 describe("inputCommands", () => {
+  it("exposes resolved runtime primitives and can reply without running the driver", async () => {
+    const { agentInvocationId } = await import("../src/invocations.ts")
+    const { inputCommands } = await import("../src/capabilities.ts")
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const diagnosticsRuntime = { invocations: { db: "db", schema: "schema" } }
+    const runId = "debug-command-run"
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [inputCommands({
+        commands: {
+          debug: {
+            async call({ context }) {
+              expect((context as typeof context & { diagnostics: typeof diagnosticsRuntime }).diagnostics).toBe(diagnosticsRuntime)
+              expect(context.invocation.id).toBe(await agentInvocationId(runId, "support"))
+              return context.reply("https://chat.example/_vitehub/invocations/previous")
+            },
+          },
+        },
+      })],
+    }, {
+      ...runtime(),
+      agentIdentity: { name: "support" },
+      capabilities: {
+        diagnostics: { resolve: () => diagnosticsRuntime },
+      },
+      run: { runId },
+    }, { prompt: "/debug" })
+
+    expect(resolved.response?.status).toBe(204)
+    expect(resolved.registries.deliveryEffectIntents).toEqual([
+      { kind: "reply", payload: "https://chat.example/_vitehub/invocations/previous" },
+    ])
+  })
+
   it("replaces command text in a string prompt", async () => {
     const { inputCommands } = await import("../src/capabilities.ts")
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")

--- a/packages/agent/test/input-commands.test.ts
+++ b/packages/agent/test/input-commands.test.ts
@@ -23,6 +23,7 @@ describe("inputCommands", () => {
         commands: {
           debug: {
             async call({ context }) {
+              // SAFETY: This test registers diagnostics in the runtime Capability map below.
               expect((context as typeof context & { diagnostics: typeof diagnosticsRuntime }).diagnostics).toBe(diagnosticsRuntime)
               expect(context.invocation.id).toBe(await agentInvocationId(runId, "support"))
               return context.reply("https://chat.example/_vitehub/invocations/previous")

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -16255,6 +16255,65 @@ describe("server helpers", () => {
     expect(adapter.postMessage.mock.invocationCallOrder[1]).toBeLessThan(adapter.deleteMessage.mock.invocationCallOrder[0]!)
   })
 
+  it("throttles commentary queued during an in-flight loading edit", async () => {
+    vi.useFakeTimers()
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const firstEdit = deferred<void>()
+    const finishStream = deferred<void>()
+    adapter.editMessage.mockImplementationOnce(async (threadId, messageId, message) => {
+      await firstEdit.promise
+      return { id: messageId, raw: { message }, threadId }
+    })
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
+          adapter: () => adapter as never,
+          messages: {
+            final: { delivery: "new-message" },
+            loading: { intervalMs: 1_000, text: "Loading…", updates: "commentary" },
+          },
+        }),
+      },
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield { delta: "First update. ", phase: "commentary", type: "text-delta" }
+            yield { delta: "Second update.", phase: "commentary", type: "text-delta" }
+            await finishStream.promise
+            yield { finishReason: "stop", type: "finish" }
+          })(),
+        }),
+      },
+      hooks: {
+        "agent:finish": event => event.reply("Final reply"),
+      },
+    })
+    // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    try {
+      const response = handler(chatWebhookRequest(91_115), "telegram")
+      await vi.waitFor(() => expect(adapter.editMessage).toHaveBeenCalledOnce(), { interval: 0 })
+      firstEdit.resolve()
+      await Promise.resolve()
+      await vi.advanceTimersByTimeAsync(999)
+      expect(adapter.editMessage).toHaveBeenCalledOnce()
+      await vi.advanceTimersByTimeAsync(1)
+      expect(adapter.editMessage).toHaveBeenNthCalledWith(2, "telegram:456", "sent-1", {
+        markdown: "First update. Second update.",
+      })
+      finishStream.resolve()
+      await expect(response).resolves.toMatchObject({ status: 200 })
+    }
+    finally {
+      vi.useRealTimers()
+    }
+  })
+
   it("uses only the latest final message for a manual final reply", { timeout: 30_000 }, async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
@@ -16604,6 +16663,50 @@ describe("server helpers", () => {
       markdown: "Final reply",
     })
     expect(adapter.deleteMessage).not.toHaveBeenCalled()
+  })
+
+  it("does not redeliver a posted final reply when its delivery callback rejects", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { chatFinishDeliveryRegistrarKey } = await import("../src/internal/chat-finish-delivery.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const callback = vi.fn(async () => {
+      throw new Error("trace sink failed")
+    })
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
+          adapter: () => adapter as never,
+          messages: {
+            final: { delivery: "new-message" },
+            loading: { text: "Loading…" },
+          },
+        }),
+      },
+      driver: { run: () => "Private output" },
+      hooks: {
+        "agent:finish": async (event) => {
+          const message = "Final reply"
+          // SAFETY: The Chat extension owns the delivery registrar used by this focused failure fixture.
+          const chat = event.extensions.get("chat") as {
+            [chatFinishDeliveryRegistrarKey]?: (message: string, callback: () => Promise<void>) => boolean
+            sendMessage?: (message: string) => Promise<void>
+          } | undefined
+          await chat?.sendMessage?.(message)
+          expect(chat?.[chatFinishDeliveryRegistrarKey]?.(message, callback)).toBe(true)
+        },
+      },
+    })
+    // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    await expect(handler(chatWebhookRequest(91_116), "telegram")).resolves.toMatchObject({ status: 200 })
+    expect(callback).toHaveBeenCalledOnce()
+    expect(adapter.postMessage).toHaveBeenCalledTimes(2)
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", { markdown: "Final reply" })
+    expect(adapter.editMessage).not.toHaveBeenCalled()
   })
 
   it("does not overwrite the first manual reply when a later reply fails", async () => {

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -16200,6 +16200,61 @@ describe("server helpers", () => {
     })
   })
 
+  it("streams surfaced commentary into the loading message without exposing tools", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
+          adapter: () => adapter as never,
+          messages: {
+            final: { delivery: "new-message" },
+            loading: {
+              text: "Loading…",
+              updates: "commentary",
+            },
+          },
+        }),
+      },
+      driver: {
+        run: () => ({
+          stream: (async function* () {
+            yield { delta: "Checking the request. ", phase: "commentary", type: "text-delta" }
+            yield { delta: "Comparing the records.", phase: "commentary", type: "text-delta" }
+            yield { input: { query: "private" }, name: "database", toolCallId: "tool-1", type: "tool-call" }
+            yield { delta: "Private final output", phase: "final", type: "text-delta" }
+            yield { finishReason: "stop", type: "finish" }
+          })(),
+        }),
+      },
+      hooks: {
+        "agent:finish": (event) => event.reply("Final customer reply"),
+      },
+    })
+    // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_113), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(1, "telegram:456", "Loading…")
+    expect(adapter.editMessage).toHaveBeenLastCalledWith("telegram:456", "sent-1", {
+      markdown: "Checking the request. Comparing the records.",
+    })
+    expect(adapter.editMessage).not.toHaveBeenCalledWith(
+      "telegram:456",
+      "sent-1",
+      expect.objectContaining({ markdown: expect.stringContaining("database") }),
+    )
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", {
+      markdown: "Final customer reply",
+    })
+    expect(adapter.postMessage.mock.invocationCallOrder[1]).toBeLessThan(adapter.deleteMessage.mock.invocationCallOrder[0]!)
+  })
+
   it("uses only the latest final message for a manual final reply", { timeout: 30_000 }, async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
@@ -16479,7 +16534,7 @@ describe("server helpers", () => {
     })
   })
 
-  it("delivers the final reply through the placeholder when deletion fails", async () => {
+  it("keeps the posted final reply when loading-message deletion fails", async () => {
     const { defineAgent } = await import("../src/index.ts")
     const { telegram } = await import("../src/channels.ts")
     const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
@@ -16491,8 +16546,8 @@ describe("server helpers", () => {
           // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
           adapter: () => adapter as never,
           messages: {
-            delivery: "manual",
-            fallbackStreamingPlaceholderText: "Analyzing photo…",
+            final: { delivery: "new-message" },
+            loading: { text: "Analyzing photo…" },
           },
         }),
       },
@@ -16508,10 +16563,47 @@ describe("server helpers", () => {
 
     expect(response.status).toBe(200)
     expect(adapter.deleteMessage).toHaveBeenCalledWith("telegram:456", "sent-1")
+    expect(adapter.postMessage).toHaveBeenNthCalledWith(2, "telegram:456", {
+      markdown: "Final reply",
+    })
+    expect(adapter.editMessage).not.toHaveBeenCalled()
+  })
+
+  it("falls back to the loading message when the final post fails", async () => {
+    const { defineAgent } = await import("../src/index.ts")
+    const { telegram } = await import("../src/channels.ts")
+    const { createChannelWebhookRouteHandler } = await import("../src/server/internal.ts")
+    const adapter = createTestChatAdapter()
+    adapter.postMessage
+      .mockImplementationOnce(async (threadId) => ({ id: "sent-1", threadId }))
+      .mockRejectedValueOnce(new Error("post failed"))
+    const agent = defineAgent({
+      channels: {
+        telegram: testTelegram(telegram, {
+          // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
+          adapter: () => adapter as never,
+          messages: {
+            final: { delivery: "new-message" },
+            loading: { text: "Loading…", updates: "commentary" },
+          },
+        }),
+      },
+      driver: { run: () => "Private output" },
+      hooks: {
+        "agent:finish": (event) => event.reply("Final reply"),
+      },
+    })
+    // SAFETY: This fixture is intentionally constructed with the asserted test-only contract.
+    const handler = createChannelWebhookRouteHandler(agent as never)
+
+    const response = await handler(chatWebhookRequest(91_114), "telegram")
+
+    expect(response.status).toBe(200)
+    expect(adapter.postMessage).toHaveBeenCalledTimes(2)
     expect(adapter.editMessage).toHaveBeenCalledWith("telegram:456", "sent-1", {
       markdown: "Final reply",
     })
-    expect(adapter.postMessage).toHaveBeenCalledOnce()
+    expect(adapter.deleteMessage).not.toHaveBeenCalled()
   })
 
   it("does not overwrite the first manual reply when a later reply fails", async () => {

--- a/packages/vite-hub/package.json
+++ b/packages/vite-hub/package.json
@@ -174,6 +174,7 @@
     "@cloudflare/workers-types": "^4.20260509.1",
     "@google-cloud/storage": "catalog:storage",
     "@googleapis/drive": "catalog:storage",
+    "@libsql/client": "catalog:database",
     "@microsoft/microsoft-graph-client": "catalog:storage",
     "@standard-schema/spec": "catalog:runtime",
     "@supabase/storage-js": "catalog:storage",
@@ -219,7 +220,6 @@
   "devDependencies": {
     "@iconify-json/lucide": "catalog:ui",
     "@iconify-json/ph": "catalog:ui",
-    "@libsql/client": "catalog:database",
     "@nuxt/ui": "catalog:nuxt",
     "@vite-hub/internal": "workspace:*",
     "@vitejs/plugin-vue": "^6.0.8",

--- a/packages/vite-hub/src/agent/capabilities.ts
+++ b/packages/vite-hub/src/agent/capabilities.ts
@@ -23,5 +23,6 @@ export interface ConsoleInputCommandsOptions extends Omit<InputCommandsOptions, 
 }
 
 export function inputCommands(options: ConsoleInputCommandsOptions): AgentCapabilityDefinition {
+  // SAFETY: This wrapper only narrows the Console command context supplied by the generated Console Runtime Capability.
   return baseInputCommands(options as InputCommandsOptions)
 }

--- a/packages/vite-hub/src/agent/capabilities.ts
+++ b/packages/vite-hub/src/agent/capabilities.ts
@@ -1,1 +1,27 @@
 export * from "@vite-hub/agent/capabilities"
+
+import { inputCommands as baseInputCommands } from "@vite-hub/agent/capabilities"
+
+import type { AgentCapabilityDefinition } from "@vite-hub/agent"
+import type {
+  InputCommand,
+  InputCommandResult,
+  InputCommandRunInput,
+  InputCommandsOptions,
+} from "@vite-hub/agent/capabilities"
+import type { ConsoleRuntime } from "../console/server.ts"
+
+export type ConsoleInputCommand = Omit<InputCommand, "call"> & {
+  call?: (input: Omit<InputCommandRunInput, "command" | "context"> & {
+    command: ConsoleInputCommand
+    context: InputCommandRunInput["context"] & { console: ConsoleRuntime }
+  }) => InputCommandResult | Promise<InputCommandResult>
+}
+
+export interface ConsoleInputCommandsOptions extends Omit<InputCommandsOptions, "commands"> {
+  commands: Record<string, ConsoleInputCommand>
+}
+
+export function inputCommands(options: ConsoleInputCommandsOptions): AgentCapabilityDefinition {
+  return baseInputCommands(options as InputCommandsOptions)
+}

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -21,7 +21,7 @@ import { consoleFixtureRevision, readConsoleFixture } from "../../fixture.ts"
 import type { AgentInvocationRecord, AgentInvocationSummary, AgentInvocations } from "@vite-hub/agent"
 import type { ConsoleFixture } from "../../fixture.ts"
 import type { LibSQLDatabase } from "drizzle-orm/libsql"
-import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core"
+import type { AnySQLiteColumn, SQLiteTableWithColumns } from "drizzle-orm/sqlite-core"
 
 const consoleMetadataContent = [
   "channel.effect.content",
@@ -34,11 +34,31 @@ const consoleMetadataContent = [
   "vitehub.activity.progress",
 ] as const
 
-type ConsoleInvocationsTable = ReturnType<typeof sqliteTable> & Record<
-  "agentName" | "id" | "record" | "search" | "searchVersion" | "sequence" | "status" | "summary" | "updatedAt",
-  AnySQLiteColumn
->
+type ConsoleInvocationColumn<Data, NotNull extends boolean> = AnySQLiteColumn<{
+  data: Data
+  notNull: NotNull
+  tableName: "vitehub_agent_invocations"
+}>
 
+type ConsoleInvocationsTable = SQLiteTableWithColumns<{
+  columns: {
+    agentName: ConsoleInvocationColumn<string, true>
+    id: ConsoleInvocationColumn<string, true>
+    record: ConsoleInvocationColumn<Omit<AgentInvocationRecord, "cursor">, true>
+    search: ConsoleInvocationColumn<string, false>
+    searchVersion: ConsoleInvocationColumn<number, true>
+    sequence: ConsoleInvocationColumn<number, true>
+    status: ConsoleInvocationColumn<string, true>
+    summary: ConsoleInvocationColumn<AgentInvocationSummary, false>
+    updatedAt: ConsoleInvocationColumn<string, true>
+  }
+  dialect: "sqlite"
+  name: "vitehub_agent_invocations"
+  schema: undefined
+}>
+
+// doctor-disable-next-line typescript/evidence/no-chained-type-assertions -- Drizzle's inferred table type cannot be emitted under isolatedDeclarations, so keep the public schema explicit here.
+// SAFETY: The explicit table type mirrors every column constructed immediately below.
 const consoleInvocationsTable = sqliteTable("vitehub_agent_invocations", {
   sequence: integer().primaryKey({ autoIncrement: true }),
   id: text().notNull().unique(),

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -2,8 +2,11 @@ import { mkdirSync } from "node:fs"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath, pathToFileURL } from "node:url"
 
+import { createClient } from "@libsql/client"
 import { createLibsqlAgentInvocationStore } from "@vite-hub/agent/invocations/sqlite"
 import { createMemoryAgentInvocationStore, defineAgentInvocations } from "@vite-hub/agent/server"
+import { drizzle } from "drizzle-orm/libsql"
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core"
 
 import {
   createConsoleInvocationsIdentity,
@@ -15,8 +18,10 @@ import {
 } from "../../internal.ts"
 import { consoleFixtureRevision, readConsoleFixture } from "../../fixture.ts"
 
-import type { AgentInvocations } from "@vite-hub/agent"
+import type { AgentInvocationRecord, AgentInvocationSummary, AgentInvocations } from "@vite-hub/agent"
 import type { ConsoleFixture } from "../../fixture.ts"
+import type { LibSQLDatabase } from "drizzle-orm/libsql"
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core"
 
 const consoleMetadataContent = [
   "channel.effect.content",
@@ -29,12 +34,49 @@ const consoleMetadataContent = [
   "vitehub.activity.progress",
 ] as const
 
+type ConsoleInvocationsTable = ReturnType<typeof sqliteTable> & Record<
+  "agentName" | "id" | "record" | "search" | "searchVersion" | "sequence" | "status" | "summary" | "updatedAt",
+  AnySQLiteColumn
+>
+
+const consoleInvocationsTable = sqliteTable("vitehub_agent_invocations", {
+  sequence: integer().primaryKey({ autoIncrement: true }),
+  id: text().notNull().unique(),
+  status: text().notNull(),
+  agentName: text("agent_name").notNull().default(""),
+  search: text(),
+  searchVersion: integer("search_version").notNull().default(0),
+  summary: text({ mode: "json" }).$type<AgentInvocationSummary>(),
+  updatedAt: text("updated_at").notNull().default(""),
+  record: text({ mode: "json" }).$type<Omit<AgentInvocationRecord, "cursor">>().notNull(),
+}) as unknown as ConsoleInvocationsTable
+
+const consoleInvocationSchema: { invocations: typeof consoleInvocationsTable } = {
+  invocations: consoleInvocationsTable,
+}
+
+export interface ConsoleInvocationsDatabase {
+  db: LibSQLDatabase<typeof consoleInvocationSchema>
+  schema: typeof consoleInvocationSchema
+}
+
+const consoleInvocationDatabases = new WeakMap<AgentInvocations, ConsoleInvocationsDatabase>()
+
 export function getConsoleInvocations(): AgentInvocations {
   const invocations = resolveConsoleInvocations()
   if (!invocations) {
     throw new TypeError("[vitehub] The Agent invocation console has not been installed for this runtime.")
   }
   return invocations
+}
+
+export function getConsoleInvocationsDatabase(): ConsoleInvocationsDatabase {
+  const invocations = getConsoleInvocations()
+  const database = consoleInvocationDatabases.get(invocations)
+  if (!database) {
+    throw new TypeError("[vitehub] The Agent invocation console is not backed by the Console Drizzle database.")
+  }
+  return database
 }
 
 interface ConsoleDatabaseOptions {
@@ -70,14 +112,20 @@ export function resolveConsoleDatabaseOptions(projectRoot: string): ConsoleDatab
 }
 
 export function createConsoleInvocations(projectRoot: string): AgentInvocations {
-  return defineAgentInvocations({
+  const client = createClient(resolveConsoleDatabaseOptions(projectRoot))
+  const invocations = defineAgentInvocations({
     metadataContent: consoleMetadataContent,
     store: createLibsqlAgentInvocationStore({
+      client,
       maxAgeMs: false,
       maxRecords: false,
-      ...resolveConsoleDatabaseOptions(projectRoot),
     }),
   })
+  consoleInvocationDatabases.set(invocations, {
+    db: drizzle(client, { schema: consoleInvocationSchema }),
+    schema: consoleInvocationSchema,
+  })
+  return invocations
 }
 
 function createConsoleFixtureInvocationsFromSnapshot(fixture: ConsoleFixture): AgentInvocations {

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -21,6 +21,7 @@ import { consoleFixtureRevision, readConsoleFixture } from "../../fixture.ts"
 import type { AgentInvocationRecord, AgentInvocationSummary, AgentInvocations } from "@vite-hub/agent"
 import type { ConsoleFixture } from "../../fixture.ts"
 import type { LibSQLDatabase } from "drizzle-orm/libsql"
+import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core"
 
 const consoleMetadataContent = [
   "channel.effect.content",
@@ -33,6 +34,11 @@ const consoleMetadataContent = [
   "vitehub.activity.progress",
 ] as const
 
+type ConsoleInvocationsTable = ReturnType<typeof sqliteTable> & Record<
+  "agentName" | "id" | "record" | "search" | "searchVersion" | "sequence" | "status" | "summary" | "updatedAt",
+  AnySQLiteColumn
+>
+
 const consoleInvocationsTable = sqliteTable("vitehub_agent_invocations", {
   sequence: integer().primaryKey({ autoIncrement: true }),
   id: text().notNull().unique(),
@@ -43,7 +49,7 @@ const consoleInvocationsTable = sqliteTable("vitehub_agent_invocations", {
   summary: text({ mode: "json" }).$type<AgentInvocationSummary>(),
   updatedAt: text("updated_at").notNull().default(""),
   record: text({ mode: "json" }).$type<Omit<AgentInvocationRecord, "cursor">>().notNull(),
-})
+}) as unknown as ConsoleInvocationsTable
 
 const consoleInvocationSchema: { invocations: typeof consoleInvocationsTable } = {
   invocations: consoleInvocationsTable,

--- a/packages/vite-hub/src/console/runtime/server/invocations.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocations.ts
@@ -21,7 +21,6 @@ import { consoleFixtureRevision, readConsoleFixture } from "../../fixture.ts"
 import type { AgentInvocationRecord, AgentInvocationSummary, AgentInvocations } from "@vite-hub/agent"
 import type { ConsoleFixture } from "../../fixture.ts"
 import type { LibSQLDatabase } from "drizzle-orm/libsql"
-import type { AnySQLiteColumn } from "drizzle-orm/sqlite-core"
 
 const consoleMetadataContent = [
   "channel.effect.content",
@@ -34,11 +33,6 @@ const consoleMetadataContent = [
   "vitehub.activity.progress",
 ] as const
 
-type ConsoleInvocationsTable = ReturnType<typeof sqliteTable> & Record<
-  "agentName" | "id" | "record" | "search" | "searchVersion" | "sequence" | "status" | "summary" | "updatedAt",
-  AnySQLiteColumn
->
-
 const consoleInvocationsTable = sqliteTable("vitehub_agent_invocations", {
   sequence: integer().primaryKey({ autoIncrement: true }),
   id: text().notNull().unique(),
@@ -49,7 +43,7 @@ const consoleInvocationsTable = sqliteTable("vitehub_agent_invocations", {
   summary: text({ mode: "json" }).$type<AgentInvocationSummary>(),
   updatedAt: text("updated_at").notNull().default(""),
   record: text({ mode: "json" }).$type<Omit<AgentInvocationRecord, "cursor">>().notNull(),
-}) as unknown as ConsoleInvocationsTable
+})
 
 const consoleInvocationSchema: { invocations: typeof consoleInvocationsTable } = {
   invocations: consoleInvocationsTable,

--- a/packages/vite-hub/src/console/server.ts
+++ b/packages/vite-hub/src/console/server.ts
@@ -32,11 +32,12 @@ export interface ConsoleRuntime {
 
 export const console = {
   resolve(context: RuntimeHostContext<unknown>): ConsoleRuntime {
-    const request = context.request
-    if (!request) throw new TypeError("[vitehub] Console invocation URLs require a request context.")
     return {
       invocations: getConsoleInvocationsDatabase(),
       invocationUrl(invocation) {
+        const request = context.request
+        if (!request) throw new TypeError("[vitehub] Console invocation URLs require a request context.")
+        // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Invocation links accept records from external database adapters, so validate both required identities at this boundary.
         if (typeof invocation.agentName !== "string" || typeof invocation.id !== "string") {
           throw new TypeError("[vitehub] Console invocation URLs require an invocation with agentName and id.")
         }

--- a/packages/vite-hub/src/console/server.ts
+++ b/packages/vite-hub/src/console/server.ts
@@ -2,9 +2,11 @@ import {
   createConsoleInvocations,
   createConsoleFixtureInvocations,
   getConsoleInvocations,
+  getConsoleInvocationsDatabase,
   installConsoleFixtureInvocations,
   installConsoleInvocations,
 } from "./runtime/server/invocations.ts"
+import { encodeAgentRouteParam } from "./runtime/console-route.ts"
 import {
   getConsoleAgents,
   installConsoleAgentDefinitions,
@@ -15,6 +17,37 @@ import { getConsoleKV, installConsoleKV } from "./runtime/server/kv.ts"
 import { getConsoleBlob, installConsoleBlob } from "./runtime/server/blob.ts"
 import { getConsoleDefinitions, installConsoleDefinitions } from "./runtime/server/definitions.ts"
 
+import type { ConsoleInvocationsDatabase } from "./runtime/server/invocations.ts"
+import type { RuntimeHostContext } from "@vite-hub/runtime"
+
+export interface ConsoleInvocationLink {
+  agentName: string
+  id: string
+}
+
+export interface ConsoleRuntime {
+  invocations: ConsoleInvocationsDatabase
+  invocationUrl: (invocation: ConsoleInvocationLink | Record<string, unknown>) => string
+}
+
+export const console = {
+  resolve(context: RuntimeHostContext<unknown>): ConsoleRuntime {
+    const request = context.request
+    if (!request) throw new TypeError("[vitehub] Console invocation URLs require a request context.")
+    return {
+      invocations: getConsoleInvocationsDatabase(),
+      invocationUrl(invocation) {
+        if (typeof invocation.agentName !== "string" || typeof invocation.id !== "string") {
+          throw new TypeError("[vitehub] Console invocation URLs require an invocation with agentName and id.")
+        }
+        const agent = encodeURIComponent(encodeAgentRouteParam(invocation.agentName))
+        const id = encodeURIComponent(invocation.id)
+        return new URL(`/_vitehub/agents/${agent}/invocations/${id}`, request.url).href
+      },
+    }
+  },
+}
+
 export {
   createConsoleInvocations,
   createConsoleFixtureInvocations,
@@ -22,6 +55,7 @@ export {
   getConsoleAgents,
   getConsoleDefinitions,
   getConsoleInvocations,
+  getConsoleInvocationsDatabase,
   getConsoleKV,
   getConsoleSections,
   getConsoleProjectName,

--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -824,6 +824,7 @@ export function vitehub(options: ViteHubOptions): PluginOption[] {
       providerImportAliases,
       runtimeCapabilityImports: {
         blob: blobEnabled ? `${generatedImportBase}/blob` : false,
+        console: options.console ? "vite-hub/console/server" : false,
         db: options.database ? "vite-hub/database/drizzle" : false,
         email: "vite-hub/email/server",
         kv: `${generatedImportBase}/kv`,

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -3687,14 +3687,19 @@ describe("Agent invocation console", () => {
 
       const { db, schema } = getConsoleInvocationsDatabase()
       const [invocation] = await db.select().from(schema.invocations).orderBy(desc(schema.invocations.sequence)).limit(1)
+      if (!invocation) throw new Error("Expected the Console invocation journal to contain the completed invocation.")
       expect(invocation).toMatchObject({ agentName: "agent", status: "completed" })
+
+      const requestless = consoleRuntime.resolve(runtime("console-requestless"))
+      expect(requestless.invocations).toEqual({ db, schema })
+      expect(() => requestless.invocationUrl(invocation)).toThrow("Console invocation URLs require a request context")
 
       const resolved = consoleRuntime.resolve({
         ...runtime("console-link"),
         request: new Request("https://chat.example/api/agents/support"),
       })
-      expect(resolved.invocationUrl(invocation!)).toBe(
-        `https://chat.example/_vitehub/agents/~agent/invocations/${encodeURIComponent(invocation!.id as string)}`,
+      expect(resolved.invocationUrl(invocation)).toBe(
+        `https://chat.example/_vitehub/agents/~agent/invocations/${encodeURIComponent(invocation.id)}`,
       )
     }
     finally {

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -7,6 +7,7 @@ import { pathToFileURL } from "node:url"
 import { runInNewContext } from "node:vm"
 
 import { H3 } from "h3"
+import { desc } from "drizzle-orm"
 import { afterEach, describe, expect, it, vi } from "vitest"
 import { createServer } from "vite"
 
@@ -41,7 +42,8 @@ import { serializeConsoleRefresh } from "../src/console/refresh.ts"
 import { consoleFixtureEnvironmentVariable, consoleFixtureFallbackAgentName, consoleFixtureRevision, parseConsoleFixture } from "../src/console/fixture.ts"
 import agentsHandler from "../src/console/runtime/server/agents.get.ts"
 import { installConsoleAgentDefinitions, installConsoleAgents } from "../src/console/runtime/server/agents.ts"
-import { createConsoleFixtureInvocations, createConsoleInvocations, installConsoleFixtureInvocations, installConsoleInvocations, resolveConsoleDatabaseOptions } from "../src/console/runtime/server/invocations.ts"
+import { createConsoleFixtureInvocations, createConsoleInvocations, getConsoleInvocationsDatabase, installConsoleFixtureInvocations, installConsoleInvocations, resolveConsoleDatabaseOptions } from "../src/console/runtime/server/invocations.ts"
+import { console as consoleRuntime } from "../src/console/server.ts"
 import invocationHandler from "../src/console/runtime/server/invocation.get.ts"
 import invocationCapabilitiesHandler from "../src/console/runtime/server/invocation-capabilities.get.ts"
 import invocationsHandler from "../src/console/runtime/server/invocations.get.ts"
@@ -3673,6 +3675,30 @@ describe("Agent invocation console", () => {
     finally {
       await rm(projectRoot, { force: true, recursive: true })
       await rm(unrelatedCwd, { force: true, recursive: true })
+    }
+  })
+
+  it("exposes the Console invocation journal through Drizzle and builds invocation URLs", async () => {
+    const projectRoot = await mkdtemp(join(tmpdir(), "vitehub-console-drizzle-"))
+    try {
+      installConsoleInvocations(projectRoot)
+      const agent = defineAgent({ driver: { run: () => "done" }, runtime: false })
+      await runAgent(agent, { ...runtime("console-drizzle"), agentIdentity: { name: "agent" } }, {})
+
+      const { db, schema } = getConsoleInvocationsDatabase()
+      const [invocation] = await db.select().from(schema.invocations).orderBy(desc(schema.invocations.sequence)).limit(1)
+      expect(invocation).toMatchObject({ agentName: "agent", status: "completed" })
+
+      const resolved = consoleRuntime.resolve({
+        ...runtime("console-link"),
+        request: new Request("https://chat.example/api/agents/support"),
+      })
+      expect(resolved.invocationUrl(invocation!)).toBe(
+        `https://chat.example/_vitehub/agents/~agent/invocations/${encodeURIComponent(invocation!.id as string)}`,
+      )
+    }
+    finally {
+      await rm(projectRoot, { force: true, recursive: true })
     }
   })
 

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -585,6 +585,7 @@ describe("vitehub", () => {
       },
       runtimeCapabilityImports: {
         blob: "vite-hub/_internal/blob",
+        console: false,
         db: "vite-hub/database/drizzle",
         email: "vite-hub/email/server",
         kv: "vite-hub/_internal/kv",
@@ -645,11 +646,15 @@ describe("vitehub", () => {
     }))
     vitehub({ agent: true, preset: "node" })
     expect(integrationMocks.hubAgent).toHaveBeenLastCalledWith(expect.objectContaining({
-      runtimeCapabilityImports: expect.objectContaining({ db: false }),
+      runtimeCapabilityImports: expect.objectContaining({ console: false, db: false }),
     }))
     expect(integrationMocks.hubWorkflow).toHaveBeenLastCalledWith({}, expect.objectContaining({
       implicitlyEnabled: true,
       includeUserAppEntry: false,
+    }))
+    vitehub({ agent: true, console: true, preset: "node" })
+    expect(integrationMocks.hubAgent).toHaveBeenLastCalledWith(expect.objectContaining({
+      runtimeCapabilityImports: expect.objectContaining({ console: "vite-hub/console/server" }),
     }))
     expect(integrationMocks.hubWorkspace).toHaveBeenLastCalledWith({
       hosting: "node-server",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1975,6 +1975,9 @@ importers:
       '@googleapis/drive':
         specifier: catalog:storage
         version: 20.2.0
+      '@libsql/client':
+        specifier: catalog:database
+        version: 0.17.4
       '@microsoft/microsoft-graph-client':
         specifier: catalog:storage
         version: 3.0.7(@azure/identity@4.13.1)
@@ -2120,9 +2123,6 @@ importers:
       '@iconify-json/ph':
         specifier: catalog:ui
         version: 1.2.2
-      '@libsql/client':
-        specifier: catalog:database
-        version: 0.17.4
       '@nuxt/ui':
         specifier: catalog:nuxt
         version: 4.11.0(dc51c387986a40ed3d11a7721c2ab2fd)


### PR DESCRIPTION
## Summary

- add structured loading/final message options and stream surfaced commentary into the loading placeholder
- post new-message finals before background placeholder cleanup, with placeholder fallback when posting fails
- expose resolved runtime primitives, invocation IDs, and direct replies to input commands
- expose the Console invocation journal as Drizzle and add invocation URL generation

## Verification

- `pnpm vp run -t vite-hub#build`
- `pnpm typecheck` in `packages/agent`
- `pnpm typecheck` in `packages/vite-hub`
- input command suite: 32 passed
- affected provider regressions: 8 passed
- Console regression: passed
- full provider suite: 333 passed; one unrelated existing Netlify retained-workspace fixture fails standalone with a missing generated fixture path