### PR TITLE
fix(workflow): tolerate concurrent output cleanup

### DIFF
--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -378,6 +378,7 @@ async function removeEmptyDirectories(directory: string): Promise<boolean> {
   }
   catch (error) {
     // Another provider finalizer may create or remove the directory after its contents are visited.
+    // SAFETY: Node filesystem failures expose their POSIX code through NodeJS.ErrnoException.
     const code = (error as NodeJS.ErrnoException).code
     if (code === "ENOTEMPTY" || code === "EEXIST") return false
     if (code === "ENOENT") return true

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -373,14 +373,14 @@ async function removeEmptyDirectories(directory: string): Promise<boolean> {
   for (const entry of entries) {
     if (entry.isDirectory()) await removeEmptyDirectories(resolve(directory, entry.name))
   }
-  if ((await readdir(directory)).length) return false
   try {
     await rmdir(directory)
   }
   catch (error) {
-    // Another provider finalizer may create or remove the directory after the emptiness check.
-    if ((error as NodeJS.ErrnoException).code === "ENOTEMPTY") return false
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return true
+    // Another provider finalizer may create or remove the directory after its contents are visited.
+    const code = (error as NodeJS.ErrnoException).code
+    if (code === "ENOTEMPTY" || code === "EEXIST") return false
+    if (code === "ENOENT") return true
     throw error
   }
   return true

--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -374,7 +374,15 @@ async function removeEmptyDirectories(directory: string): Promise<boolean> {
     if (entry.isDirectory()) await removeEmptyDirectories(resolve(directory, entry.name))
   }
   if ((await readdir(directory)).length) return false
-  await rmdir(directory)
+  try {
+    await rmdir(directory)
+  }
+  catch (error) {
+    // Another provider finalizer may create or remove the directory after the emptiness check.
+    if ((error as NodeJS.ErrnoException).code === "ENOTEMPTY") return false
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return true
+    throw error
+  }
   return true
 }
 

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -25,6 +25,10 @@ const workflowBackupRetirement = vi.hoisted<{
   options: undefined,
 }))
 
+const emptyDirectoryRemoval = vi.hoisted<{
+  behavior?: "removed" | "written"
+}>(() => ({}))
+
 vi.mock("node:fs/promises", async (importOriginal) => {
   const fs = await importOriginal<typeof import("node:fs/promises")>()
   return {
@@ -41,6 +45,20 @@ vi.mock("node:fs/promises", async (importOriginal) => {
         throw Object.assign(new Error("Workflow backup is busy"), { code: "EBUSY" })
       }
       return await fs.rm(...args)
+    },
+    async rmdir(...args: Parameters<typeof fs.rmdir>) {
+      const path = String(args[0])
+      const behavior = emptyDirectoryRemoval.behavior
+      if (behavior && /[\\/]\.well-known[\\/]workflow$/.test(path)) {
+        emptyDirectoryRemoval.behavior = undefined
+        if (behavior === "written") {
+          await fs.writeFile(`${path}/concurrent.mjs`, "concurrent\n")
+          throw Object.assign(new Error("Workflow output is no longer empty"), { code: "ENOTEMPTY" })
+        }
+        await fs.rmdir(...args)
+        throw Object.assign(new Error("Workflow output was removed concurrently"), { code: "ENOENT" })
+      }
+      return await fs.rmdir(...args)
     },
   }
 })
@@ -606,6 +624,25 @@ it("removes stale WDK functions and routes", async () => {
 
   expect(existsSync(workflowRoot)).toBe(false)
   expect(JSON.parse(await readFile(configFile, "utf8")).routes).toEqual([{ src: "/user", dest: "/user" }])
+})
+
+it.each([
+  ["preserves output written concurrently", "written", true],
+  ["accepts output removed concurrently", "removed", false],
+] as const)("%s while pruning empty native Workflow directories", async (_name, behavior, remains) => {
+  const rootDir = await createWorkspaceTempDir(`vitehub-workflow-concurrent-${behavior}-`)
+  const workflowRoot = join(rootDir, ".vercel", "output", "functions", ".well-known", "workflow")
+  await mkdir(workflowRoot, { recursive: true })
+  await writeFile(join(workflowRoot, "stale.mjs"), "stale\n")
+  await writeViteHubWorkflowOwnership(workflowRoot, ["stale.mjs"], [])
+  emptyDirectoryRemoval.behavior = behavior
+
+  await cleanVercelNativeWorkflowOutput(rootDir)
+
+  expect(existsSync(workflowRoot)).toBe(remains)
+  if (remains) {
+    await expect(readFile(join(workflowRoot, "concurrent.mjs"), "utf8")).resolves.toBe("concurrent\n")
+  }
 })
 
 it("preserves WDK output that replaced a prior ViteHub build", async () => {

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -26,7 +26,7 @@ const workflowBackupRetirement = vi.hoisted<{
 }))
 
 const emptyDirectoryRemoval = vi.hoisted<{
-  behavior?: "removed" | "written"
+  behavior?: "removed" | "written-eexist" | "written-enotempty"
 }>(() => ({}))
 
 vi.mock("node:fs/promises", async (importOriginal) => {
@@ -51,9 +51,10 @@ vi.mock("node:fs/promises", async (importOriginal) => {
       const behavior = emptyDirectoryRemoval.behavior
       if (behavior && /[\\/]\.well-known[\\/]workflow$/.test(path)) {
         emptyDirectoryRemoval.behavior = undefined
-        if (behavior === "written") {
+        if (behavior.startsWith("written-")) {
           await fs.writeFile(`${path}/concurrent.mjs`, "concurrent\n")
-          throw Object.assign(new Error("Workflow output is no longer empty"), { code: "ENOTEMPTY" })
+          const code = behavior === "written-eexist" ? "EEXIST" : "ENOTEMPTY"
+          throw Object.assign(new Error("Workflow output is no longer empty"), { code })
         }
         await fs.rmdir(...args)
         throw Object.assign(new Error("Workflow output was removed concurrently"), { code: "ENOENT" })
@@ -627,7 +628,8 @@ it("removes stale WDK functions and routes", async () => {
 })
 
 it.each([
-  ["preserves output written concurrently", "written", true],
+  ["preserves output written concurrently when rmdir reports ENOTEMPTY", "written-enotempty", true],
+  ["preserves output written concurrently when rmdir reports EEXIST", "written-eexist", true],
   ["accepts output removed concurrently", "removed", false],
 ] as const)("%s while pruning empty native Workflow directories", async (_name, behavior, remains) => {
   const rootDir = await createWorkspaceTempDir(`vitehub-workflow-concurrent-${behavior}-`)

--- a/packages/workflow/test/vite-output.test.ts
+++ b/packages/workflow/test/vite-output.test.ts
@@ -159,7 +159,7 @@ it("keeps suffix Workflow discovery relative to a nested Vite root", async () =>
   expect(artifacts.definitions.map(definition => definition.name)).toEqual(["cleanup"])
 })
 
-it("seeds provider source retention with Workflow Definition handlers and steps", async () => {
+it("seeds provider source retention with Workflow Definition handlers and steps", { timeout: buildOutputTestTimeout }, async () => {
   const rootDir = await createWorkspaceTempDir("vitehub-workflow-provider-sources-")
   const handler = join(rootDir, "server", "workflows", "welcome.ts")
   const workflowDirectory = join(rootDir, "server", "workflows", "cleanup")


### PR DESCRIPTION
## Summary

- tolerate a provider finalizer writing into an empty Workflow directory between the final check and removal
- accept another finalizer removing that directory first
- cover both races without weakening unexpected filesystem error handling

## Verification

- `pnpm --filter @vite-hub/workflow typecheck`
- `pnpm --filter @vite-hub/workflow exec vp test -- test/vite-output.test.ts -t "pruning empty native Workflow directories"` (2 passed)