### PR TITLE
fix(ui): fade collapsed invocation messages

### DIFF
--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -709,22 +709,13 @@
 
 .vh-invocation-message__content {
   min-width: 0;
-  position: relative;
 }
 
 .vh-invocation-message__content[data-collapsed="true"] {
+  -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 1.75rem), transparent);
+  mask-image: linear-gradient(to bottom, black calc(100% - 1.75rem), transparent);
   max-height: 10.5rem;
   overflow: hidden;
-}
-
-.vh-invocation-message__content[data-collapsed="true"]::after {
-  background: linear-gradient(to bottom, transparent, var(--vh-ui-bg-elevated));
-  bottom: 0;
-  content: "";
-  height: 3.5rem;
-  inset-inline: 0;
-  pointer-events: none;
-  position: absolute;
 }
 
 .vh-invocation-message__more {


### PR DESCRIPTION
Collapsed Agent Invocation messages now fade through a CSS mask before the Read more control. The previous overlay ended at a translucent surface token, so text still met a hard clipping edge in the Console.

## Test plan

- `pnpm exec vp test run test/invocation-ui.test.ts --reporter=dot` from `packages/ui` (97 passed, no type errors)
- Verified the collapsed, expanded, and re-collapsed states on the [reported live invocation](https://babysitter.vitehub.dev/_vitehub/agents/~babysitter/invocations/sha256_9b4d17b25db80b2f08d74acfde92a53605875f2cf20cd73ab447085dd1d42704)
