### PR TITLE
fix(ui): add labeled scroll-to-end control

### DIFF
--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -13245,7 +13245,7 @@ describe("server helpers", () => {
       await state.disconnect()
       await rm(stateDir, { force: true, recursive: true })
     }
-  })
+  }, 10_000)
 
   it("starts the recovered steer head with its request before a reclaiming different invoker", async () => {
     const { defineAgent } = await import("../src/index.ts")
@@ -13339,7 +13339,7 @@ describe("server helpers", () => {
       await state.disconnect()
       await rm(stateDir, { force: true, recursive: true })
     }
-  })
+  }, 10_000)
 
   it.each([
     { persistentOutage: false, title: "retries a definitively rejected recovered steer start without another webhook" },

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -12995,7 +12995,7 @@ describe("server helpers", () => {
       await state.disconnect()
       await rm(stateDir, { force: true, recursive: true })
     }
-  })
+  }, 10_000)
 
   it("preserves shared history and distinct id-less messages while deduplicating a replayed durable steer delivery", async () => {
     const { defineAgent } = await import("../src/index.ts")
@@ -13091,7 +13091,7 @@ describe("server helpers", () => {
       await state.disconnect()
       await rm(stateDir, { force: true, recursive: true })
     }
-  })
+  }, 10_000)
 
   it("restores queued portable Capability overrides from persistent State", async () => {
     const blobList = vi.fn(async () => ({ blobs: [] }))
@@ -13245,7 +13245,7 @@ describe("server helpers", () => {
       await state.disconnect()
       await rm(stateDir, { force: true, recursive: true })
     }
-  }, 10_000)
+  })
 
   it("starts the recovered steer head with its request before a reclaiming different invoker", async () => {
     const { defineAgent } = await import("../src/index.ts")
@@ -13339,7 +13339,7 @@ describe("server helpers", () => {
       await state.disconnect()
       await rm(stateDir, { force: true, recursive: true })
     }
-  }, 10_000)
+  })
 
   it.each([
     { persistentOutage: false, title: "retries a definitively rejected recovered steer start without another webhook" },

--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -12995,7 +12995,7 @@ describe("server helpers", () => {
       await state.disconnect()
       await rm(stateDir, { force: true, recursive: true })
     }
-  }, 10_000)
+  })
 
   it("preserves shared history and distinct id-less messages while deduplicating a replayed durable steer delivery", async () => {
     const { defineAgent } = await import("../src/index.ts")
@@ -13091,7 +13091,7 @@ describe("server helpers", () => {
       await state.disconnect()
       await rm(stateDir, { force: true, recursive: true })
     }
-  }, 10_000)
+  })
 
   it("restores queued portable Capability overrides from persistent State", async () => {
     const blobList = vi.fn(async () => ({ blobs: [] }))

--- a/packages/ui/src/components/agent-chat.ts
+++ b/packages/ui/src/components/agent-chat.ts
@@ -1,5 +1,5 @@
 import type { ChatStatus, UIMessage } from "ai";
-import { defineComponent, h, type PropType } from "vue";
+import { defineComponent, h, type PropType, resolveComponent } from "vue";
 import {
   MessageScrollerButton,
   MessageScrollerContent,
@@ -17,10 +17,12 @@ export const AgentChat = defineComponent({
     edgeThreshold: { type: Number },
     messages: { default: () => [], type: Array as PropType<readonly UIMessage[]> },
     previousItemPeek: { type: Number },
+    scrollButtonLabel: { default: "Scroll to end", type: String },
     status: { default: "ready", type: String as PropType<ChatStatus> },
   },
   setup(props, { attrs, slots }) {
     const defaults = useViteHubUI();
+    const UButton = resolveComponent("UButton");
     return () => {
       const messageSlots = Object.fromEntries(
         Object.entries(slots).filter(
@@ -83,8 +85,18 @@ export const AgentChat = defineComponent({
             ),
             h(
               MessageScrollerButton,
-              { class: "vh-chat__scroll-button" },
-              { default: () => slots["scroll-button"]?.() ?? "↓" },
+              {
+                "aria-label": props.scrollButtonLabel,
+                as: UButton,
+                class: "vh-chat__scroll-button",
+                color: "neutral",
+                icon: "i-lucide-chevron-down",
+                size: "xs",
+                type: "button",
+                ui: { leadingIcon: "size-3.5" },
+                variant: "outline",
+              },
+              { default: () => slots["scroll-button"]?.() ?? props.scrollButtonLabel },
             ),
             slots.default?.(),
           ],

--- a/packages/ui/src/headless/message-scroller.ts
+++ b/packages/ui/src/headless/message-scroller.ts
@@ -350,7 +350,7 @@ export const MessageScrollerButton = defineComponent({
     return () => {
       const active = context.isScrollable.value && !context.atEnd.value;
       const content = slots.default?.({ scrollToEnd: context.scrollToEnd }) ?? "↓";
-      const children = typeof props.as === "string" ? content : { default: () => content };
+      const children = String(props.as) === props.as ? content : { default: () => content };
       return h(
         props.as,
         mergeProps({

--- a/packages/ui/src/headless/message-scroller.ts
+++ b/packages/ui/src/headless/message-scroller.ts
@@ -12,6 +12,7 @@ import {
   reactive,
   ref,
   type CSSProperties,
+  type Component,
   type InjectionKey,
   type PropType,
   type Ref,
@@ -338,13 +339,18 @@ export const MessageScrollerButton = defineComponent({
   name: "MessageScrollerButton",
   inheritAttrs: false,
   props: {
-    as: { default: "button", type: String },
+    as: {
+      default: "button",
+      type: [String, Object, Function] as PropType<string | Component>,
+    },
     behavior: { default: "smooth", type: String as PropType<MessageScrollBehavior> },
   },
   setup(props, { attrs, slots }) {
     const context = useInternalMessageScroller();
     return () => {
       const active = context.isScrollable.value && !context.atEnd.value;
+      const content = slots.default?.({ scrollToEnd: context.scrollToEnd }) ?? "↓";
+      const children = typeof props.as === "string" ? content : { default: () => content };
       return h(
         props.as,
         mergeProps({
@@ -362,9 +368,9 @@ export const MessageScrollerButton = defineComponent({
           hidden: active ? attrs.hidden : true,
           inert: active ? undefined : true,
           tabindex: active ? attrs.tabindex : -1,
-          type: props.as === "button" ? "button" : undefined,
+          type: attrs.type ?? (props.as === "button" ? "button" : undefined),
         }),
-        slots.default?.({ scrollToEnd: context.scrollToEnd }) ?? "↓",
+        children,
       );
     };
   },

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -59,20 +59,35 @@
 
 .vh-chat__scroll-button {
   align-items: center;
-  background: var(--vh-ui-bg-elevated);
+  -webkit-backdrop-filter: blur(12px) saturate(1.14);
+  backdrop-filter: blur(12px) saturate(1.14);
+  background: color-mix(in srgb, var(--vh-ui-bg) 80%, transparent);
   border: 1px solid var(--vh-ui-border);
   border-radius: 999px;
   bottom: 1rem;
-  box-shadow: 0 4px 16px color-mix(in oklab, black 10%, transparent);
+  box-shadow: 0 1px 3px color-mix(in oklab, black 12%, transparent);
+  color: var(--vh-ui-muted);
   cursor: pointer;
   display: flex;
-  height: 2rem;
+  gap: 0.375rem;
   justify-content: center;
   left: 50%;
+  padding-inline: 0.75rem;
   position: absolute;
   transform: translateX(-50%);
-  width: 2rem;
+  white-space: nowrap;
+  width: auto;
   z-index: 2;
+}
+
+.vh-chat__scroll-button:hover {
+  color: var(--vh-ui-text);
+}
+
+@supports not ((-webkit-backdrop-filter: blur(1px)) or (backdrop-filter: blur(1px))) {
+  .vh-chat__scroll-button {
+    background: var(--vh-ui-bg);
+  }
 }
 
 .vh-message-parts {

--- a/packages/ui/test/message-scroller.test.ts
+++ b/packages/ui/test/message-scroller.test.ts
@@ -44,6 +44,22 @@ class MutationObserverStub {
 
 const resizeObservers: ResizeObserverStub[] = [];
 
+const ChatButtonStub = defineComponent({
+  name: "UButton",
+  inheritAttrs: false,
+  props: {
+    color: String,
+    icon: String,
+    size: String,
+    type: String,
+    ui: Object,
+    variant: String,
+  },
+  setup(props, { attrs, slots }) {
+    return () => h("button", { ...attrs, type: props.type }, slots.default?.());
+  },
+});
+
 beforeEach(() => {
   resizeObservers.length = 0;
   vi.stubGlobal("ResizeObserver", ResizeObserverStub);
@@ -96,6 +112,42 @@ describe("message scroller behavior", () => {
       edgeThreshold: 12,
       previousItemPeek: 72,
     });
+  });
+
+  it("renders the styled jump control through Nuxt UI without component-slot warnings", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const wrapper = mount(AgentChat, {
+      global: { components: { UButton: ChatButtonStub } },
+    });
+
+    expect(wrapper.getComponent(ChatButtonStub).props()).toMatchObject({
+      color: "neutral",
+      icon: "i-lucide-chevron-down",
+      size: "xs",
+      type: "button",
+      ui: { leadingIcon: "size-3.5" },
+      variant: "outline",
+    });
+    expect(wrapper.get("[data-slot='message-scroller-button']").attributes()).toMatchObject({
+      "aria-label": "Scroll to end",
+      type: "button",
+    });
+    expect(wrapper.get("[data-slot='message-scroller-button']").text()).toBe("Scroll to end");
+    expect(warn.mock.calls.flat().join(" ")).not.toContain("Non-function value");
+
+    warn.mockRestore();
+  });
+
+  it("preserves custom jump-control content", () => {
+    const wrapper = mount(AgentChat, {
+      global: { components: { UButton: ChatButtonStub } },
+      props: { scrollButtonLabel: "Jump to newest" },
+      slots: { "scroll-button": () => "Newest message" },
+    });
+
+    const button = wrapper.get("[data-slot='message-scroller-button']");
+    expect(button.attributes("aria-label")).toBe("Jump to newest");
+    expect(button.text()).toBe("Newest message");
   });
 
   it("renders root default content once without replacing message bodies", () => {


### PR DESCRIPTION
## Summary

- Render the AgentChat jump control as a Nuxt UI button with a chevron and visible label.
- Expose a localizable scrollButtonLabel while preserving custom scroll-button slot content.
- Let the headless MessageScrollerButton render component targets without Vue non-function slot warnings.
- Style the control as the translucent pill already exercised in the Portal chat.

## Context

[Portal PR 886](https://github.com/quiverdk/portal/pull/886) currently carries this shared UI behavior as a pnpm patch. Moving it into @vite-hub/ui lets the consumer patch be removed once Portal pins an upstream preview or release.

## Verification

- pnpm --filter @vite-hub/ui test — 14 files and 161 tests passed; no type errors; package build and publint passed.
- pnpm --filter @vite-hub/ui typecheck
- pnpm exec vp check --no-fmt on the changed files
- Exercised the scroll-away, visible control, click-to-end, and hidden-at-end path in the Portal consumer.