### PR TITLE
fix: unblock release checks

### DIFF
--- a/fallow.toml
+++ b/fallow.toml
@@ -153,6 +153,8 @@ ignoreDependencies = [
   "@azure/storage-blob",
   # The umbrella package owns the AI SDK 6 peer required by files-sdk.
   "ai",
+  # Provides the optional peer selected by Devframe's H3 dependency.
+  "ocache",
   # Box provider adapters load these only from runtime-selected chunks.
   "@asciidev/box-sdk",
   "@cloudflare/computer",

--- a/packages/agent/src/capabilities/papercuts.ts
+++ b/packages/agent/src/capabilities/papercuts.ts
@@ -56,7 +56,7 @@ interface PapercutResult {
 }
 
 const papercutMaxMessageLength = 1_000
-const papercutReportDescription = "Proactively report small friction as soon as it happens, even when non-blocking: a missed or retried tool call, confusing or undocumented setup, flaky command, stale cache, misleading error, or non-obvious gotcha. In one or two sentences, say what you were doing and what got in the way; a likely cause or fix is a bonus. Never include secrets or customer data."
+const papercutReportDescription = "Never include secrets or customer data. Proactively report small friction as soon as it happens, even when non-blocking: a missed or retried tool call, confusing or undocumented setup, flaky command, stale cache, misleading error, or non-obvious gotcha. In one or two sentences, say what you were doing and what got in the way; a likely cause or fix is a bonus."
 const papercutInputSchema: AgentToolSchema<PapercutInput> = {
   additionalProperties: false,
   properties: {

--- a/packages/vite-hub/src/source/server.ts
+++ b/packages/vite-hub/src/source/server.ts
@@ -1,5 +1,4 @@
 import { defineSource as defineCoreSource } from "@vite-hub/source"
-import { defineCachedFunction } from "nitro/cache"
 
 import type { Source, SourceContext } from "@vite-hub/source"
 import type { CacheOptions } from "nitro/types"
@@ -29,6 +28,21 @@ function isCachedSourceReader(source: unknown): source is CachedSourceReader<str
     && Boolean(Reflect.get(Object(source), "cache"))
 }
 
+function defineCachedSourceGet(source: CachedSourceReader<string, unknown>) {
+  let cachedGet: Promise<(key: string) => Promise<unknown>> | undefined
+
+  return async (key: string) => {
+    cachedGet ??= import("nitro/cache").then(({ defineCachedFunction }) => defineCachedFunction(
+      value => source.get.call(source, value),
+      {
+        swr: false,
+        ...source.cache,
+      },
+    ))
+    return await (await cachedGet)(key)
+  }
+}
+
 export function defineSource<
   const TKey extends string,
   TValue,
@@ -47,9 +61,6 @@ export function defineSource(source: unknown): unknown {
   }
   return {
     ...source,
-    get: defineCachedFunction((...args) => source.get.apply(source, args), {
-      swr: false,
-      ...source.cache,
-    }),
+    get: defineCachedSourceGet(source),
   }
 }

--- a/packages/vite-hub/test/source-server.test.ts
+++ b/packages/vite-hub/test/source-server.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const cache = new Map<string, unknown>()
+let cacheModuleLoads = 0
 const defineCachedFunction = vi.fn(
   (reader: (...args: unknown[]) => unknown, options: { name?: string }) => async (...args: unknown[]) => {
     const key = `${options.name}:${JSON.stringify(args)}`
@@ -11,7 +12,10 @@ const defineCachedFunction = vi.fn(
   },
 )
 
-vi.mock("nitro/cache", () => ({ defineCachedFunction }))
+vi.mock("nitro/cache", () => {
+  cacheModuleLoads += 1
+  return { defineCachedFunction }
+})
 
 const { defineSource } = await import("../src/source/server.ts")
 
@@ -19,6 +23,28 @@ describe("server Source readers", () => {
   beforeEach(() => {
     cache.clear()
     defineCachedFunction.mockClear()
+  })
+
+  it("loads Nitro cache only when a cached reader is used", async () => {
+    expect(cacheModuleLoads).toBe(0)
+
+    defineSource({
+      async get(key: string) {
+        return key
+      },
+    })
+    expect(cacheModuleLoads).toBe(0)
+
+    const source = defineSource({
+      cache: { name: "lazy" },
+      async get(key: string) {
+        return key
+      },
+    })
+    expect(cacheModuleLoads).toBe(0)
+
+    await expect(source.get("news")).resolves.toBe("news")
+    expect(cacheModuleLoads).toBe(1)
   })
 
   it("wraps keyed readers with the configured Nitro cache", async () => {


### PR DESCRIPTION
Fix the three failures exposed by the post-merge `main` run.

- lazy-load Nitro cache for cached Source readers so `vite-hub/source/server` imports in isolated consumers
- keep the papercuts safety instruction inside inspected tool-description limits
- document `ocache` as Devframe H3 peer wiring for dead-code analysis

Verified with ViteHub’s 548 package tests, 216 docs tests, affected typechecks, lint, TypeScript doctor, the isolated import repro, and Fallow (zero issues).