### PR TITLE
fix(docs): restore Cloudflare Builds deployment

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -209,9 +209,7 @@ export default defineNuxtConfig({
         d1_databases: [
           {
             binding: "DB",
-            database_id:
-              process.env.CLOUDFLARE_D1_DATABASE_ID ??
-              "00000000-0000-0000-0000-000000000000",
+            database_id: "4a8731af-1899-4d41-ac8b-6870167ead95",
             database_name: "vitehub-docs",
           },
         ],

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "pretest": "nuxi prepare",
     "dev": "nuxi dev",
     "build": "node scripts/build.mjs",
-    "deploy:cloudflare": "test -n \"$CLOUDFLARE_D1_DATABASE_ID\" && vp run test && vp run build && vp dlx \"wrangler@4.112.0\" deploy --config .output/server/wrangler.json",
+    "deploy:cloudflare": "vp run test && vp run build && vp dlx \"wrangler@4.112.0\" deploy --config .output/server/wrangler.json",
     "test": "vp test",
     "test:links": "nuxi prepare && node scripts/check-doc-links.mjs",
     "test:links:external": "node scripts/check-example-links.mjs",


### PR DESCRIPTION
Cloudflare Workers Builds no longer depends on the build-time `CLOUDFLARE_D1_DATABASE_ID` variable. The docs configuration now owns the existing `vitehub-docs` D1 database ID, so the deploy command cannot exit before tests and build when that Cloudflare variable is missing.

## Verification

- `pnpm --dir docs run test` (216 tests)
- `env -u CLOUDFLARE_D1_DATABASE_ID pnpm --dir docs run build`
- generated `.output/server/wrangler.json` contains the `vitehub-docs` D1 binding
- `wrangler deploy --dry-run --config docs/.output/server/wrangler.json`
- `pnpm --dir docs run typecheck`

The production Workers Build only runs from `main`, so Cloudflare’s external build environment remains the post-merge verification.