### PR TITLE
test: allow full consumer host matrix to finish

### DIFF
--- a/test/consumer/vite-hub.test.ts
+++ b/test/consumer/vite-hub.test.ts
@@ -1249,5 +1249,5 @@ describe.skipIf(process.env.VITEHUB_CONSUMER_CONTRACT !== "1")("published vite-h
     finally {
       await rm(root, { force: true, recursive: true })
     }
-  }, 1_800_000)
+  }, 3_600_000)
 })


### PR DESCRIPTION
## Summary

Raise the packed `vite-hub` consumer contract timeout from 30 to 60 minutes. The test now exercises enough sequential host builds to exceed 30 minutes on GitHub Actions; main run 33817951839 reached the final builds but timed out at exactly 1,800,000 ms.

## Verification

- all five preceding assertions in the timed test passed on main
- the failure was Vitest's exact test timeout, not a product assertion
- `git diff --check`