### PR TITLE
test: accept release-versioned internal peers

### DIFF
--- a/packages/agent/test/providers.test.ts
+++ b/packages/agent/test/providers.test.ts
@@ -2841,9 +2841,10 @@ export default defineAgent({
     )
       throw new Error("Expected package dependency metadata.")
 
+    expect(pkg.version).toEqual(expect.any(String))
     expect(pkg.dependencies?.["@vite-hub/schedule"]).toBeUndefined()
-    expect(pkg.devDependencies?.["@vite-hub/schedule"]).toBe("workspace:*")
-    expect(pkg.peerDependencies?.["@vite-hub/schedule"]).toBe("workspace:*")
+    expect(["workspace:*", pkg.version]).toContain(pkg.devDependencies?.["@vite-hub/schedule"])
+    expect(["workspace:*", pkg.version]).toContain(pkg.peerDependencies?.["@vite-hub/schedule"])
     expect(pkg.peerDependenciesMeta?.["@vite-hub/schedule"]).toEqual({ optional: true })
   })
 

--- a/packages/workspace/test/public-api.test.ts
+++ b/packages/workspace/test/public-api.test.ts
@@ -113,7 +113,8 @@ describe("workspace public API", () => {
     const builtRuntime = (await Promise.all(runtimeFiles.map(file => readFile(new URL(file, distDir), "utf8")))).join("\n")
 
     expect(packageJson.dependencies?.["@vite-hub/shell"]).toBeUndefined()
-    expect(packageJson.peerDependencies?.["@vite-hub/shell"]).toBe("workspace:*")
+    expect(packageJson.version).toEqual(expect.any(String))
+    expect(["workspace:*", packageJson.version]).toContain(packageJson.peerDependencies?.["@vite-hub/shell"])
     expect(packageJson.peerDependenciesMeta?.["@vite-hub/shell"]).toEqual({ optional: true })
     expect(builtAiDeclarations).not.toContain("@vite-hub/shell")
     expect(builtAi).not.toContain("from\"@vite-hub/shell")


### PR DESCRIPTION
## Summary

- keep the optional internal peer contracts strict in source workspaces
- also accept the package's exact version after the release workflow rewrites internal ranges
- unblock tagged release verification without weakening dependency placement checks

## Verification

- affected Agent test passes with `workspace:*` and simulated `0.0.4` ranges
- affected Workspace test passes with `workspace:*` and simulated `0.0.4` ranges
- `vp run lint`

Release run 33824370351 exposed this after `Apply release version`; npm publication and GitHub release creation were skipped.