### PR TITLE
fix(ci): ignore generated ViteHub actions

### DIFF
--- a/.github/scripts/check-ci-inputs.mjs
+++ b/.github/scripts/check-ci-inputs.mjs
@@ -1028,7 +1028,7 @@ export async function findGitHubCIPolicyFiles(repoRoot) {
   const githubRoot = resolve(repoRoot, ".github")
   const [workflows, actions] = await Promise.all([
     findYamlFiles(resolve(githubRoot, "workflows"), name => /\.ya?ml$/.test(name), new Set(), false),
-    findYamlFiles(repoRoot, name => /^action\.ya?ml$/.test(name), new Set([".git", "node_modules"])),
+    findYamlFiles(repoRoot, name => /^action\.ya?ml$/.test(name), new Set([".git", ".vitehub", "node_modules"])),
   ])
   return [...new Set([...workflows, ...actions])].sort()
 }

--- a/test/github-ci-policy.test.ts
+++ b/test/github-ci-policy.test.ts
@@ -48,6 +48,19 @@ describe("GitHub CI input policy", () => {
     await expect(checkGitHubCIInputs(repoRoot)).resolves.toEqual([])
   })
 
+  it("ignores composite action copies in generated ViteHub output", async () => {
+    const root = await createFixture({
+      ".github/actions/setup/action.yml": "runs:\n  using: composite\n  steps: []\n",
+      ".vitehub/workflow/sources/0/.github/actions/setup/action.yml": "generated copy\n",
+    })
+
+    const files = await findGitHubCIPolicyFiles(root)
+
+    expect(files.map(path => relative(root, path).replaceAll("\\", "/"))).toEqual([
+      ".github/actions/setup/action.yml",
+    ])
+  })
+
   it("allows full commit pins with version comments and local actions", async () => {
     const root = await createFixture({
       ".github/actions/setup/action.yaml": `runs:\n  using: composite\n  steps:\n    - uses: ${pinnedCheckout}\n`,


### PR DESCRIPTION
## Summary

- exclude generated `.vitehub` trees when discovering repository composite actions
- keep source workflows and composite actions under CI policy enforcement
- add a regression test for copied actions inside deployment output

## Verification

- `vp test test/github-ci-policy.test.ts` (189 passed)
- `vp run lint`

Release run 33828775657 reproduced the issue after package tests generated copied workflow sources; exact-tarball contract testing then found 12 CI files instead of the 8 repository sources. npm and GitHub publication were skipped.