### PR TITLE
feat(console): add authenticated agent invocation flow

### DIFF
--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -49,21 +49,21 @@ export function github(options: GitHubSourceOptions): Source<string> {
   const authByContext = new WeakMap<SourceContext, string | undefined>()
   const providerCache = normalizeGitHubCache(options)
 
-  function resolveAuth(): string | undefined {
-    const token = typeof options.auth === "function" ? options.auth() : options.auth
+  async function resolveAuth(): Promise<string | undefined> {
+    const token = typeof options.auth === "function" ? await options.auth() : options.auth
     return typeof token === "string" && token.length > 0 ? token : undefined
   }
 
-  function refreshAuth(): string | undefined {
-    const nextAuth = resolveAuth()
+  async function refreshAuth(): Promise<string | undefined> {
+    const nextAuth = await resolveAuth()
     if (nextAuth !== auth) {
       auth = nextAuth
     }
     return auth
   }
 
-  function contextAuth(ctx: SourceContext) {
-    return authByContext.has(ctx) ? authByContext.get(ctx) : refreshAuth()
+  async function contextAuth(ctx: SourceContext) {
+    return authByContext.has(ctx) ? authByContext.get(ctx) : await refreshAuth()
   }
 
   function keyForRepoPath(path: string) {
@@ -155,7 +155,7 @@ export function github(options: GitHubSourceOptions): Source<string> {
         () => resolveRef(token),
       )
 
-  async function getRef(token = refreshAuth(), signal?: AbortSignal) {
+  async function getRef(token: string | undefined, signal?: AbortSignal) {
     return await waitForCachedGitHubResult(() => cachedResolveRef(token), signal)
   }
 
@@ -225,7 +225,7 @@ export function github(options: GitHubSourceOptions): Source<string> {
         () => loadFiles(token, undefined, resolvedRef),
       )
 
-  function getFiles(token = refreshAuth(), signal?: AbortSignal, resolvedRef?: string) {
+  function getFiles(token: string | undefined, signal?: AbortSignal, resolvedRef?: string) {
     return waitForCachedGitHubResult(() => cachedLoadFiles(resolvedRef, token), signal)
   }
 
@@ -314,7 +314,7 @@ export function github(options: GitHubSourceOptions): Source<string> {
     }
   }
 
-  async function getFile(key: string, ctx?: SourceContext, token = refreshAuth()) {
+  async function getFile(key: string, ctx: SourceContext | undefined, token: string | undefined) {
     if (ctx?.abortSignal) return await loadFile(key, token, ctx.abortSignal, ctx.revision?.id)
     const file = (await getFiles(token, undefined, ctx?.revision?.id)).find(file => file.key === key)
     if (!file) {
@@ -352,15 +352,15 @@ export function github(options: GitHubSourceOptions): Source<string> {
     },
     name: "github",
     async resolveRevision(ctx) {
-      const token = refreshAuth()
+      const token = await refreshAuth()
       authByContext.set(ctx, token)
       return await resolveSourceRevision(token, ctx.abortSignal)
     },
     async getKeys(ctx) {
-      return (await getFiles(contextAuth(ctx), ctx.abortSignal, ctx.revision?.id)).map(file => file.key)
+      return (await getFiles(await contextAuth(ctx), ctx.abortSignal, ctx.revision?.id)).map(file => file.key)
     },
     async getItems(ctx) {
-      const token = contextAuth(ctx)
+      const token = await contextAuth(ctx)
       return await Promise.all((await getFiles(token, ctx.abortSignal, ctx.revision?.id)).map(async file => ({
         key: file.key,
         path: file.path,
@@ -372,7 +372,7 @@ export function github(options: GitHubSourceOptions): Source<string> {
       })))
     },
     async getMeta(key, ctx) {
-      const token = contextAuth(ctx)
+      const token = await contextAuth(ctx)
       const file = await waitForCachedGitHubResult(() => cachedLoadFileMetadata(key, ctx.revision?.id, token), ctx?.abortSignal)
       if (!file) return
       return {
@@ -381,7 +381,7 @@ export function github(options: GitHubSourceOptions): Source<string> {
       }
     },
     async getItem(key, ctx) {
-      const token = contextAuth(ctx)
+      const token = await contextAuth(ctx)
       const file = await getFile(key, ctx, token)
       return {
         key: file.key,

--- a/packages/source/src/sources/github/types.ts
+++ b/packages/source/src/sources/github/types.ts
@@ -4,7 +4,7 @@ export interface GitHubSourceOptions {
   repo: string
   ref?: string
   root?: string
-  auth?: false | string | (() => string | undefined)
+  auth?: false | string | (() => Promise<string | undefined> | string | undefined)
   include?: string | string[]
   ignore?: string | readonly string[]
   cache?: false | SourceCacheOptions

--- a/packages/source/test/sources/github.test.ts
+++ b/packages/source/test/sources/github.test.ts
@@ -423,6 +423,19 @@ describe("@vite-hub/source GitHub source", () => {
     expect((archiveCall?.[1]?.headers as Record<string, string> | undefined)?.authorization).toBe("Bearer github-token")
   })
 
+  it("awaits async GitHub auth before requests", async () => {
+    stubGitHubSource({
+      "docs/README.md": "# Docs\n",
+    }, { apiStatus: 403 })
+
+    registerSources({ docs: github({ auth: async () => "github-token", repo: "acme/app", root: "docs" }) })
+
+    await expect(useSource("docs").keys()).resolves.toEqual(["README.md"])
+
+    const archiveCall = vi.mocked(fetch).mock.calls.find(([url]) => String(url).startsWith("https://codeload.github.com/"))
+    expect((archiveCall?.[1]?.headers as Record<string, string> | undefined)?.authorization).toBe("Bearer github-token")
+  })
+
   it("omits GitHub auth when auth is explicitly false", async () => {
     stubGitHubSource({
       "docs/README.md": "# Docs\n",

--- a/packages/vite-hub/src/console/runtime/client/request.ts
+++ b/packages/vite-hub/src/console/runtime/client/request.ts
@@ -26,10 +26,17 @@ function consoleDevframeBase(path: string): string {
   return `${appBase}${consoleDevframePath}`
 }
 
-function consoleRpcCall(path: string): { id?: string; method: ConsoleRpcMethod } {
+function consoleRpcCall(path: string): { agent?: string; id?: string; method: ConsoleRpcMethod } {
   const url = new URL(path, "http://vitehub.local")
   const marker = url.pathname.indexOf(consoleApiMarker)
   const operation = marker === -1 ? "" : url.pathname.slice(marker + consoleApiMarker.length)
+  const agentInvocationMatch = /^agents\/([^/]+)\/invocations$/.exec(operation)
+  if (agentInvocationMatch) {
+    return {
+      agent: agentInvocationMatch[1]!,
+      method: consoleRpcMethods.agentInvocations,
+    }
+  }
   if (operation.startsWith("invocations/")) {
     return {
       id: decodeURIComponent(operation.slice("invocations/".length)),
@@ -92,6 +99,7 @@ export async function requestConsole(
   }
   const call = consoleRpcCall(path)
   const input: ConsoleRpcInput = { method: options.method ?? "GET", query }
+  if (call.agent !== undefined) input.agent = call.agent
   if (call.id !== undefined) input.id = call.id
   if (options.body !== undefined) input.body = options.body
   const client = await abortable(consoleDevframeClient(consoleDevframeBase(path)), options.signal)

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -559,7 +559,9 @@ async function loadAgents(): Promise<void> {
                 const id = stringValue(profile?.id)?.trim();
                 if (!id) return [];
                 const label = stringValue(profile?.label)?.trim();
-                return [{ id, ...(label ? { label } : {}) }];
+                const resolved: ConsoleAgentProfile = { id };
+                if (label) resolved.label = label;
+                return [resolved];
               })
             : [];
           return [[name, { profiles }] as const];

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -29,6 +29,7 @@ import ConsoleBrand from "./console-brand.vue";
 import ConsoleFrame from "./console-frame.vue";
 import ConsolePrimitiveSwitcher from "./console-primitive-switcher.vue";
 import ConsoleHealth from "./console-health.vue";
+import ConsoleInvocationComposer from "./console-invocation-composer.vue";
 import ConsoleMark from "./console-mark.vue";
 import ConsoleSessionLoading from "./console-session-loading.vue";
 import ConsoleSessionNavbar from "./console-session-navbar.vue";
@@ -60,6 +61,7 @@ const props = defineProps<{
 const initialAgentParam = decodeAgentRouteParam(route.params.agent);
 const selectedInvocationId = ref<string>();
 const selectedAgentName = ref(initialAgentParam?.trim() ? initialAgentParam : undefined);
+const newChatAgentName = ref<string>();
 const selectedCapabilityId = ref<string>();
 const filterOpen = ref(false);
 const capabilityIds = ref<string[]>([]);
@@ -69,6 +71,11 @@ const initialBootstrapPending = ref(!selectedAgentName.value);
 const agentNames = ref<string[]>([]);
 const agentsLoading = ref(true);
 const agentsError = ref<unknown>();
+interface ConsoleAgentProfile {
+  id: string;
+  label?: string;
+}
+const agentInvocationOptions = ref<Record<string, { profiles: ConsoleAgentProfile[] }>>({});
 const nowMs = ref(Date.now());
 const sessionsOpen = ref(false);
 const sessionsCollapsed = ref(false);
@@ -188,6 +195,9 @@ const invocationItems = computed<AgentInvocationListItem[]>(() =>
   })),
 );
 const hasMultipleAgents = computed(() => agentNames.value.length > 1);
+const selectedAgentInvocation = computed(() =>
+  selectedAgentName.value ? agentInvocationOptions.value[selectedAgentName.value] : undefined,
+);
 const selectedAgentLabel = computed(
   () => selectedAgentName.value || (agentsLoading.value ? "Loading agents" : "Agents"),
 );
@@ -420,6 +430,7 @@ async function selectInvocation(
   if (!agentName) return;
   showSessions();
   sessionsOpen.value = false;
+  newChatAgentName.value = undefined;
   updateSelectedAgentName(agentName);
   await router.push({
     name: resolveConsoleRouteName(route.name, "vitehub-console-invocation"),
@@ -427,9 +438,31 @@ async function selectInvocation(
   });
 }
 
+async function selectStartedInvocation(invocation: { agent: string; id: string }): Promise<void> {
+  await selectInvocation(invocation);
+  scheduleInvocationListRefresh();
+}
+
+async function startNewChat(): Promise<void> {
+  const agentName = selectedAgentName.value;
+  if (!agentName || !selectedAgentInvocation.value) return;
+  showSessions();
+  sessionsOpen.value = false;
+  newChatAgentName.value = agentName;
+  selectedInvocationId.value = undefined;
+  closeDetails();
+  await router.push({
+    name: resolveConsoleRouteName(route.name, "vitehub-console-agent"),
+    params: { agent: encodeAgentRouteParam(agentName) },
+  });
+  await nextTick();
+  document.querySelector<HTMLElement>('[aria-label="Test this Agent"]')?.focus();
+}
+
 async function selectAgent(name: string): Promise<void> {
   if (name === selectedAgentName.value) return;
   showSessions();
+  newChatAgentName.value = undefined;
   updateSelectedAgentName(name);
   selectedInvocationId.value = undefined;
   selectedCapabilityId.value = undefined;
@@ -441,6 +474,7 @@ async function selectAgent(name: string): Promise<void> {
 
 async function selectCapability(capabilityId?: string): Promise<void> {
   if (selectedCapabilityId.value === capabilityId) return;
+  newChatAgentName.value = undefined;
   selectedCapabilityId.value = capabilityId;
   filterOpen.value = false;
   selectedInvocationId.value = undefined;
@@ -514,6 +548,23 @@ async function loadAgents(): Promise<void> {
       : [];
     if (agentsRequest === controller) {
       agentNames.value = [...new Set(names)];
+      const invocation = record(value?.invocation);
+      agentInvocationOptions.value = Object.fromEntries(
+        agentNames.value.flatMap((name) => {
+          const options = record(invocation?.[name]);
+          if (!options) return [];
+          const profiles = Array.isArray(options.profiles)
+            ? options.profiles.flatMap((value) => {
+                const profile = record(value);
+                const id = stringValue(profile?.id)?.trim();
+                if (!id) return [];
+                const label = stringValue(profile?.label)?.trim();
+                return [{ id, ...(label ? { label } : {}) }];
+              })
+            : [];
+          return [[name, { profiles }] as const];
+        }),
+      );
       agentsError.value = undefined;
     }
   } catch (error) {
@@ -614,10 +665,12 @@ watch(
     previous,
   ) => {
     if (usageRoute) {
+      newChatAgentName.value = undefined;
       initialBootstrapPending.value = false;
       selectedInvocationId.value = undefined;
       return;
     }
+    if (requestedInvocation) newChatAgentName.value = undefined;
     const routeChanged =
       !previous || requestedInvocation !== previous[0] || requestedAgent !== previous[1];
     const preserveCapabilityFilter = routeChanged && isCapabilityFilterRouteTransition(
@@ -654,6 +707,10 @@ watch(
       } finally {
         initialBootstrapPending.value = false;
       }
+      return;
+    }
+    if (!requestedInvocation && requestedAgent && requestedAgent === newChatAgentName.value) {
+      selectedInvocationId.value = undefined;
       return;
     }
     const agentRouteReady = !requestedAgent || requestedAgent === agentName;
@@ -861,6 +918,16 @@ onBeforeUnmount(() => {
             label="Search console"
             :ui="{ trailing: 'vitehub-console__search-shortcut' }"
           />
+          <UTooltip v-if="!collapsed && selectedAgentInvocation" text="New chat">
+            <UButton
+              aria-label="New chat"
+              color="neutral"
+              icon="i-lucide-square-pen"
+              square
+              variant="ghost"
+              @click="startNewChat"
+            />
+          </UTooltip>
           <UPopover
             v-if="!collapsed"
             v-model:open="filterOpen"
@@ -1271,10 +1338,8 @@ onBeforeUnmount(() => {
             />
             <div
               v-else-if="!selectedInvocationId"
-              class="flex min-h-0 flex-1 items-center justify-center p-8 text-sm text-muted"
-            >
-              Select an Agent Invocation to inspect its work.
-            </div>
+              class="min-h-0 flex-1"
+            />
             <UEmpty
               v-else-if="errorMessage(detail.error.value) && !invocationView"
               class="min-h-0 flex-1"
@@ -1311,6 +1376,13 @@ onBeforeUnmount(() => {
                 @inspect="inspectSession"
               />
             </div>
+            <ConsoleInvocationComposer
+              v-if="selectedAgentName && selectedAgentInvocation && !selectedInvocationId"
+              :agent="selectedAgentName"
+              :base="agentsBase"
+              :profiles="selectedAgentInvocation.profiles"
+              @started="selectStartedInvocation"
+            />
             <USlideover
               v-if="!isDesktop && invocationView"
               v-model:open="detailsOpen"

--- a/packages/vite-hub/src/console/runtime/components/console-invocation-composer.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-invocation-composer.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import { AgentChatPrompt } from "@vite-hub/ui";
+import { computed, ref, watch } from "vue";
+
+import { requestConsole } from "../client/request";
+
+interface ConsoleAgentProfile {
+  id: string;
+  label?: string;
+}
+
+const props = defineProps<{
+  agent: string;
+  base: string;
+  profiles: ConsoleAgentProfile[];
+}>();
+
+const emit = defineEmits<{
+  started: [invocation: { agent: string; id: string }];
+}>();
+
+const draft = ref("");
+const error = ref<unknown>();
+const loading = ref(false);
+const selectedProfileId = ref<string>();
+const profileItems = computed(() =>
+  props.profiles.map((profile) => ({ label: profile.label || profile.id, value: profile.id })),
+);
+
+watch(
+  () => [props.agent, ...props.profiles.map((profile) => profile.id)],
+  () => {
+    if (!props.profiles.some((profile) => profile.id === selectedProfileId.value)) {
+      selectedProfileId.value = props.profiles[0]?.id;
+    }
+  },
+  { immediate: true },
+);
+
+function errorMessage(value: unknown): string {
+  return value instanceof Error ? value.message : "The Agent invocation could not be started.";
+}
+
+function rejectFiles(): [] {
+  return [];
+}
+
+async function submit(message: { text: string }): Promise<void> {
+  if (loading.value || !message.text.trim()) return;
+  loading.value = true;
+  error.value = undefined;
+  try {
+    const response = await requestConsole(
+      `${props.base}/${encodeURIComponent(props.agent)}/invocations`,
+      {
+        body: {
+          prompt: message.text,
+          ...(selectedProfileId.value ? { invokerProfileId: selectedProfileId.value } : {}),
+        },
+        method: "POST",
+      },
+    );
+    const result =
+      response instanceof Object && !Array.isArray(response)
+        ? Object.fromEntries(Object.entries(response))
+        : undefined;
+    const id = typeof result?.id === "string" ? result.id : undefined;
+    if (!id) throw new Error("The Agent invocation response did not include an id.");
+    draft.value = "";
+    emit("started", { agent: props.agent, id });
+  } catch (value) {
+    error.value = value;
+  } finally {
+    loading.value = false;
+  }
+}
+</script>
+
+<template>
+  <div
+    class="console-invocation-composer shrink-0 bg-default px-3 pb-5 pt-3 sm:px-5 sm:pb-6"
+  >
+    <div class="mx-auto grid w-full max-w-3xl gap-2">
+      <UAlert
+        v-if="error"
+        color="error"
+        icon="i-ph-warning-circle-light"
+        title="Could not start Agent"
+        :description="errorMessage(error)"
+        variant="subtle"
+      />
+      <div class="relative pb-9">
+        <div
+          aria-label="Invocation context"
+          class="console-invocation-composer__context absolute inset-x-[22px] bottom-0 flex h-12 items-end gap-3 overflow-hidden rounded-b-2xl bg-elevated/60 px-4 pb-2 text-xs text-muted ring-1 ring-default"
+        >
+          <span class="flex min-w-0 items-center gap-1.5">
+            <UIcon class="size-4 shrink-0" name="i-ph-folder-light" />
+            <span class="truncate">ViteHub Console</span>
+          </span>
+          <span class="h-4 w-px shrink-0 bg-default" />
+          <span class="flex min-w-0 items-center gap-1.5">
+            <UIcon class="size-4 shrink-0" name="i-ph-robot-light" />
+            <span class="truncate">Agent {{ agent }}</span>
+          </span>
+          <span class="ml-auto shrink-0 font-mono text-[11px]">New invocation</span>
+        </div>
+
+        <div class="console-invocation-composer__surface relative z-10 rounded-[22px] bg-default ring-1 ring-default shadow-sm transition-shadow has-[textarea:focus-visible]:ring-accented">
+          <AgentChatPrompt
+            v-model="draft"
+            aria-label="Test this Agent"
+            class="console-invocation-composer__prompt min-h-32 gap-3 rounded-[22px] bg-default px-4 pb-3 pt-4 [&_.vh-prompt__spacer]:hidden"
+            color="neutral"
+            :filter-files="rejectFiles"
+            :maxrows="8"
+            placeholder="Test this Agent..."
+            :rows="3"
+            :status="loading ? 'submitted' : 'ready'"
+            variant="naked"
+            :ui="{
+              body: 'min-h-14 items-start text-base leading-6',
+              footer: 'min-h-8 gap-2',
+            }"
+            @submit="submit"
+          >
+            <template #actions>
+              <div class="mr-auto flex min-w-0 items-center gap-2 text-sm text-muted">
+                <UIcon class="size-4 shrink-0" name="i-ph-robot-light" />
+                <span v-if="profiles.length <= 1" class="truncate">{{ profiles[0]?.label || agent }}</span>
+                <USelect
+                  v-else
+                  v-model="selectedProfileId"
+                  aria-label="Invoker profile"
+                  class="max-w-52"
+                  :items="profileItems"
+                  size="sm"
+                  variant="ghost"
+                />
+              </div>
+            </template>
+            <template #submit>
+              <UButton
+                aria-label="Start Agent"
+                class="console-invocation-composer__submit size-8 rounded-full active:scale-[0.97]"
+                color="primary"
+                icon="i-ph-arrow-up-light"
+                :disabled="!draft.trim() || loading"
+                :loading="loading"
+                square
+                size="sm"
+                type="button"
+                @click="submit({ text: draft })"
+              />
+            </template>
+          </AgentChatPrompt>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/packages/vite-hub/src/console/runtime/components/console-invocation-composer.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-invocation-composer.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { AgentChatPrompt } from "@vite-hub/ui";
+import * as v from "valibot";
 import { computed, ref, watch } from "vue";
 
 import { requestConsole } from "../client/request";
@@ -8,6 +9,8 @@ interface ConsoleAgentProfile {
   id: string;
   label?: string;
 }
+
+const invocationResultSchema = v.object({ id: v.string() });
 
 const props = defineProps<{
   agent: string;
@@ -50,24 +53,23 @@ async function submit(message: { text: string }): Promise<void> {
   loading.value = true;
   error.value = undefined;
   try {
+    const body: { invokerProfileId?: string; prompt: string } = {
+      prompt: message.text,
+    };
+    if (selectedProfileId.value) body.invokerProfileId = selectedProfileId.value;
     const response = await requestConsole(
       `${props.base}/${encodeURIComponent(props.agent)}/invocations`,
       {
-        body: {
-          prompt: message.text,
-          ...(selectedProfileId.value ? { invokerProfileId: selectedProfileId.value } : {}),
-        },
+        body,
         method: "POST",
       },
     );
-    const result =
-      response instanceof Object && !Array.isArray(response)
-        ? Object.fromEntries(Object.entries(response))
-        : undefined;
-    const id = typeof result?.id === "string" ? result.id : undefined;
-    if (!id) throw new Error("The Agent invocation response did not include an id.");
+    const result = v.safeParse(invocationResultSchema, response);
+    if (!result.success || !result.output.id) {
+      throw new Error("The Agent invocation response did not include an id.");
+    }
     draft.value = "";
-    emit("started", { agent: props.agent, id });
+    emit("started", { agent: props.agent, id: result.output.id });
   } catch (value) {
     error.value = value;
   } finally {

--- a/packages/vite-hub/src/console/runtime/components/console-session-code-preview.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-code-preview.vue
@@ -9,6 +9,7 @@ const highlightingFailed = ref(false);
 let renderId = 0;
 
 const language = computed<BundledLanguage | SpecialLanguage>(() => languageForPath(props.path));
+const plainLines = computed(() => props.content.split("\n"));
 
 watch(
   () => [props.content, props.path] as const,
@@ -25,7 +26,8 @@ watch(
         themes: { dark: "github-dark", light: "github-light" },
       });
       if (id === renderId) html.value = rendered;
-    } catch {
+    } catch (error) {
+      console.error("[vitehub] Workspace syntax highlighting failed.", error);
       if (id === renderId) highlightingFailed.value = true;
     } finally {
       if (id === renderId) loading.value = false;
@@ -70,7 +72,11 @@ function languageForPath(path: string): BundledLanguage | SpecialLanguage {
     <div v-if="loading && !html" class="session-inspector__state">
       <UIcon name="i-lucide-loader-circle" class="animate-spin" />Highlighting file…
     </div>
-    <pre v-else-if="highlightingFailed" class="session-code-preview__plain">{{ content }}</pre>
+    <pre v-else-if="highlightingFailed" class="session-code-preview__plain"><code><span
+      v-for="(line, index) in plainLines"
+      :key="index"
+      class="line"
+    ><span>{{ line || "\u200b" }}</span></span></code></pre>
     <div v-else class="session-code-preview__html" v-html="html" />
   </div>
 </template>

--- a/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
@@ -52,7 +52,7 @@ const viewMeta: Record<
     shortcut: "T",
   },
   workspace: {
-    description: "Browse the immutable materialized workspace.",
+    description: "Browse the mounted Agent workspace.",
     icon: "i-lucide-folder-tree",
     label: "Workspace",
     shortcut: "W",
@@ -78,7 +78,7 @@ onBeforeUnmount(() => {
 const workspaceLabel = computed(() =>
   workspace.value
     ? `${workspace.value.repository}@${workspace.value.revision.slice(0, 7)}`
-    : "Materialized Workspace",
+    : "Agent Workspace",
 );
 const invocationUsage = computed(() => record(props.invocation)?.usage);
 const breadcrumbs = computed(() => selectedPath.value?.split("/") ?? []);
@@ -179,9 +179,15 @@ watch(
 
 watch(activeSurface, async () => {
   await nextTick();
-  tabstrip.value
-    ?.querySelector<HTMLElement>('[data-state="active"]')
-    ?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  const scroller = tabstrip.value?.querySelector<HTMLElement>(".session-inspector__tabs");
+  const activeTab = scroller?.querySelector<HTMLElement>('[data-state="active"]');
+  if (!scroller || !activeTab) return;
+  const scrollerBounds = scroller.getBoundingClientRect();
+  const tabBounds = activeTab.getBoundingClientRect();
+  if (tabBounds.left < scrollerBounds.left)
+    scroller.scrollLeft -= scrollerBounds.left - tabBounds.left;
+  else if (tabBounds.right > scrollerBounds.right)
+    scroller.scrollLeft += tabBounds.right - scrollerBounds.right;
 });
 
 watch([workspace, treeOpen], async ([value, open]) => {

--- a/packages/vite-hub/src/console/runtime/components/console-session.css
+++ b/packages/vite-hub/src/console/runtime/components/console-session.css
@@ -553,6 +553,9 @@
 }
 
 .session-inspector__file {
+  display: grid;
+  grid-template-rows: minmax(0, 1fr);
+  height: 100%;
   min-height: 0;
   min-width: 0;
   overflow: hidden;
@@ -584,10 +587,12 @@
 }
 
 .session-code-preview {
-  height: 100%;
+  height: auto;
+  min-height: 0;
   min-width: 0;
   overflow: auto;
   overscroll-behavior: contain;
+  width: 100%;
 }
 
 .session-code-preview__html {
@@ -604,11 +609,12 @@
   margin: 0;
   min-height: 100%;
   min-width: max-content;
-  padding: 0.625rem 0 1.5rem;
+  padding: 1rem 1.5rem 2rem 0;
   tab-size: 2;
 }
 
-.session-code-preview .shiki {
+.session-code-preview .shiki,
+.session-code-preview__plain {
   counter-reset: line;
 }
 

--- a/packages/vite-hub/src/console/runtime/rpc.ts
+++ b/packages/vite-hub/src/console/runtime/rpc.ts
@@ -1,5 +1,6 @@
 export const consoleRpcMethods = {
   agents: "vitehub:console:agents",
+  agentInvocations: "vitehub:console:agent-invocations",
   blob: "vitehub:console:blob",
   database: "vitehub:console:database",
   definitions: "vitehub:console:definitions",
@@ -15,6 +16,7 @@ export const consoleRpcMethods = {
 export type ConsoleRpcMethod = (typeof consoleRpcMethods)[keyof typeof consoleRpcMethods]
 
 export interface ConsoleRpcInput {
+  agent?: string
   body?: unknown
   id?: string
   method?: "GET" | "POST"

--- a/packages/vite-hub/src/console/runtime/server/agent-invocations.post.ts
+++ b/packages/vite-hub/src/console/runtime/server/agent-invocations.post.ts
@@ -1,24 +1,31 @@
 import { agentInvocationId, startAgentInvocation } from "@vite-hub/agent"
 import { createExecutionContext, createRuntimeWaitUntilController } from "@vite-hub/runtime"
+import * as v from "valibot"
 
 import { encodeAgentRouteParam } from "../console-route.ts"
 import { console } from "../../server.ts"
 import { consoleAgentInvokerProfiles, getConsoleAgentDefinition } from "./agents.ts"
 import { assertConsoleRequest, consoleRequestJSON, consoleRequestURL, setConsoleResponseStatus } from "./request.ts"
 
-import type { AgentInput } from "@vite-hub/agent"
 import type { ConsoleRequestEvent } from "./request.ts"
 
 const allowedInputKeys = new Set(["prompt", "invokerProfileId"])
+const recordSchema = v.record(v.string(), v.unknown())
+const stringSchema = v.string()
 
 function consoleError(statusCode: number, statusMessage: string): Error {
   return Object.assign(new Error(statusMessage), { statusCode, statusMessage })
 }
 
 function record(value: unknown): Record<string, unknown> | undefined {
-  return value && typeof value === "object" && !Array.isArray(value)
-    ? Object.fromEntries(Object.entries(value))
-    : undefined
+  if (Array.isArray(value)) return
+  const result = v.safeParse(recordSchema, value)
+  return result.success ? result.output : undefined
+}
+
+function stringValue(value: unknown): string | undefined {
+  const result = v.safeParse(stringSchema, value)
+  return result.success ? result.output : undefined
 }
 
 function agentName(event: ConsoleRequestEvent): string {
@@ -36,6 +43,7 @@ function memo() {
   const values = new Map<string, unknown>()
   return <T>(key: string, create: () => T): T => {
     if (!values.has(key)) values.set(key, create())
+    // SAFETY: This closure stores and returns each value under the key from the same generic call.
     return values.get(key) as T
   }
 }
@@ -73,20 +81,20 @@ const agentInvocationsHandler: (event: ConsoleRequestEvent) => Promise<ConsoleAg
   const unknown = Object.keys(body).filter(key => !allowedInputKeys.has(key))
   if (unknown.length) throw consoleError(400, `Unsupported Agent invocation field: ${unknown[0]}.`)
 
-  const prompt = typeof body.prompt === "string" ? body.prompt.trim() : ""
+  const prompt = stringValue(body.prompt)?.trim() ?? ""
   if (!prompt) throw consoleError(400, "Agent invocation requires a prompt.")
   const profileValue = body.invokerProfileId
-  if (profileValue !== undefined && (typeof profileValue !== "string" || !profileValue.trim())) {
-    throw consoleError(400, "Agent invocation profile must be a non-empty string.")
+  let profileId: string | undefined
+  if (profileValue !== undefined) {
+    profileId = stringValue(profileValue)?.trim()
+    if (!profileId) throw consoleError(400, "Agent invocation profile must be a non-empty string.")
   }
-  const profileId = typeof profileValue === "string" ? profileValue.trim() : undefined
   if (profileId && !consoleAgentInvokerProfiles(agent).some(profile => profile.id === profileId)) {
     throw consoleError(400, "Unknown Agent invocation profile.")
   }
 
   const tasks = createRuntimeWaitUntilController({ forward: event.waitUntil })
-  // SAFETY: Console stores only discovered Agent Definition module exports at this boundary.
-  const controller = await startAgentInvocation(agent as unknown as AgentInput, createExecutionContext({
+  const controller = await startAgentInvocation(agent, createExecutionContext({
     agentIdentity: { name },
     capabilities: { console },
     memo: memo(),

--- a/packages/vite-hub/src/console/runtime/server/agent-invocations.post.ts
+++ b/packages/vite-hub/src/console/runtime/server/agent-invocations.post.ts
@@ -1,0 +1,111 @@
+import { agentInvocationId, startAgentInvocation } from "@vite-hub/agent"
+import { createExecutionContext, createRuntimeWaitUntilController } from "@vite-hub/runtime"
+
+import { encodeAgentRouteParam } from "../console-route.ts"
+import { console } from "../../server.ts"
+import { consoleAgentInvokerProfiles, getConsoleAgentDefinition } from "./agents.ts"
+import { assertConsoleRequest, consoleRequestJSON, consoleRequestURL, setConsoleResponseStatus } from "./request.ts"
+
+import type { AgentInput } from "@vite-hub/agent"
+import type { ConsoleRequestEvent } from "./request.ts"
+
+const allowedInputKeys = new Set(["prompt", "invokerProfileId"])
+
+function consoleError(statusCode: number, statusMessage: string): Error {
+  return Object.assign(new Error(statusMessage), { statusCode, statusMessage })
+}
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? Object.fromEntries(Object.entries(value))
+    : undefined
+}
+
+function agentName(event: ConsoleRequestEvent): string {
+  const value = event.context?.params?.agent?.trim()
+  if (!value) throw consoleError(400, "Missing Agent name.")
+  try {
+    return decodeURIComponent(value)
+  }
+  catch {
+    throw consoleError(400, "Invalid Agent name.")
+  }
+}
+
+function memo() {
+  const values = new Map<string, unknown>()
+  return <T>(key: string, create: () => T): T => {
+    if (!values.has(key)) values.set(key, create())
+    return values.get(key) as T
+  }
+}
+
+async function waitForInvocation(controller: Awaited<ReturnType<typeof startAgentInvocation>>): Promise<void> {
+  for (;;) {
+    const result = await controller.inspect()
+    if (result.outcome !== "available") return
+    if (["cancelled", "completed", "failed"].includes(result.invocation.status)) return
+    await new Promise(resolve => setTimeout(resolve, 250))
+  }
+}
+
+interface ConsoleAgentInvocationResult {
+  agent: string
+  id: string
+  url: string
+}
+
+const agentInvocationsHandler: (event: ConsoleRequestEvent) => Promise<ConsoleAgentInvocationResult> = async (event) => {
+  assertConsoleRequest(event, ["POST"])
+  const name = agentName(event)
+  const agent = getConsoleAgentDefinition(name)
+  if (!agent) throw consoleError(404, "Agent invocation is not available.")
+
+  let body: Record<string, unknown> | undefined
+  try {
+    body = record(await consoleRequestJSON(event))
+  }
+  catch (error) {
+    if (error instanceof Error && "statusCode" in error) throw error
+    throw consoleError(400, "Malformed Agent invocation payload.")
+  }
+  if (!body) throw consoleError(400, "Agent invocation payload must be an object.")
+  const unknown = Object.keys(body).filter(key => !allowedInputKeys.has(key))
+  if (unknown.length) throw consoleError(400, `Unsupported Agent invocation field: ${unknown[0]}.`)
+
+  const prompt = typeof body.prompt === "string" ? body.prompt.trim() : ""
+  if (!prompt) throw consoleError(400, "Agent invocation requires a prompt.")
+  const profileValue = body.invokerProfileId
+  if (profileValue !== undefined && (typeof profileValue !== "string" || !profileValue.trim())) {
+    throw consoleError(400, "Agent invocation profile must be a non-empty string.")
+  }
+  const profileId = typeof profileValue === "string" ? profileValue.trim() : undefined
+  if (profileId && !consoleAgentInvokerProfiles(agent).some(profile => profile.id === profileId)) {
+    throw consoleError(400, "Unknown Agent invocation profile.")
+  }
+
+  const tasks = createRuntimeWaitUntilController({ forward: event.waitUntil })
+  // SAFETY: Console stores only discovered Agent Definition module exports at this boundary.
+  const controller = await startAgentInvocation(agent as unknown as AgentInput, createExecutionContext({
+    agentIdentity: { name },
+    capabilities: { console },
+    memo: memo(),
+    request: new Request(consoleRequestURL(event), { method: "POST" }),
+    runtime: "unknown" as const,
+    runtimeConfig: {},
+    waitUntil: tasks.waitUntil,
+  }), {
+    context: profileId ? { invokerProfileId: profileId } : {},
+    prompt,
+  })
+  tasks.waitUntil(waitForInvocation(controller))
+  const id = await agentInvocationId(controller.id, name)
+  setConsoleResponseStatus(event, 202)
+  return {
+    agent: name,
+    id,
+    url: `/_vitehub/agents/${encodeURIComponent(encodeAgentRouteParam(name))}/invocations/${encodeURIComponent(id)}`,
+  }
+}
+
+export default agentInvocationsHandler

--- a/packages/vite-hub/src/console/runtime/server/agents.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.get.ts
@@ -18,10 +18,9 @@ const agentsHandler: (event: ConsoleRequestEvent) => Promise<ConsoleAgentsResult
     const agent = getConsoleAgentDefinition(name)
     return agent ? [[name, { profiles: consoleAgentInvokerProfiles(agent) }]] : []
   }))
-  return {
-    agents: names,
-    ...(Object.keys(invocation).length ? { invocation } : {}),
-  }
+  const result: ConsoleAgentsResult = { agents: names }
+  if (Object.keys(invocation).length) result.invocation = invocation
+  return result
 }
 
 export default agentsHandler

--- a/packages/vite-hub/src/console/runtime/server/agents.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.get.ts
@@ -1,4 +1,4 @@
-import { getConsoleAgents } from "./agents.ts"
+import { consoleAgentInvokerProfiles, getConsoleAgentDefinition, getConsoleAgents } from "./agents.ts"
 import { getConsoleInvocations } from "./invocations.ts"
 import { assertConsoleRequest } from "./request.ts"
 
@@ -6,13 +6,22 @@ import type { ConsoleRequestEvent } from "./request.ts"
 
 interface ConsoleAgentsResult {
   agents: readonly string[]
+  invocation?: Record<string, { profiles: ReturnType<typeof consoleAgentInvokerProfiles> }>
 }
 
 const agentsHandler: (event: ConsoleRequestEvent) => Promise<ConsoleAgentsResult> = async (event) => {
   assertConsoleRequest(event)
   const agents = new Set(getConsoleAgents())
   for (const agentName of await getConsoleInvocations().listAgentNames()) agents.add(agentName)
-  return { agents: [...agents].sort() }
+  const names = [...agents].sort()
+  const invocation = Object.fromEntries(names.flatMap((name) => {
+    const agent = getConsoleAgentDefinition(name)
+    return agent ? [[name, { profiles: consoleAgentInvokerProfiles(agent) }]] : []
+  }))
+  return {
+    agents: names,
+    ...(Object.keys(invocation).length ? { invocation } : {}),
+  }
 }
 
 export default agentsHandler

--- a/packages/vite-hub/src/console/runtime/server/agents.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.ts
@@ -4,6 +4,8 @@ import { installConsoleInvocations } from "./invocations.ts"
 import type { AgentInvocations } from "@vite-hub/agent"
 
 export const consoleAgentsKey: unique symbol = Symbol.for("vitehub.console.agents")
+export const consoleAgentDefinitionsKey: unique symbol = Symbol.for("vitehub.console.agent-definitions")
+export const consoleInvokeEnabledKey: unique symbol = Symbol.for("vitehub.console.invoke-enabled")
 
 export type ConsoleAgentDefinitionEntry = {
   definition: unknown
@@ -12,10 +14,12 @@ export type ConsoleAgentDefinitionEntry = {
 
 export type ConsoleAgentDefinitionInstallation =
   | { invocations: AgentInvocations, projectRoot?: never }
-  | { invocations?: never, projectRoot: string }
+  | { invocations?: never, invoke?: boolean, projectRoot: string }
 
 type ConsoleAgentInvocations = AgentInvocations & {
+  [consoleAgentDefinitionsKey]?: ReadonlyMap<string, Record<string, unknown>>
   [consoleAgentsKey]?: readonly string[]
+  [consoleInvokeEnabledKey]?: boolean
 }
 
 const consoleAssignedInvocations = new WeakMap<object, AgentInvocations>()
@@ -79,7 +83,7 @@ export function installConsoleAgentDefinitions(
 ): readonly string[] {
   const definitions = entries.map(resolveConsoleAgentDefinition)
   const invocations = resolveConsoleAgentInvocations(definitions, installation)
-  return installConsoleAgents(definitions.map(({ agent, fallbackName }) => {
+  const names = definitions.map(({ agent, fallbackName }) => {
     if (agent && Reflect.get(agent, consoleInvocationsFallbackKey) !== true) {
       const assigned = consoleAssignedInvocations.get(agent)
       if (agent.invocations === undefined || agent.invocations === assigned) {
@@ -92,10 +96,46 @@ export function installConsoleAgentDefinitions(
     }
     // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Agent Definitions may come from untyped JavaScript, so verify the identity before installing it.
     return typeof agent?.name === "string" && agent.name.trim() ? agent.name : fallbackName
-  }), invocations)
+  })
+  const installed = installConsoleAgents(names, invocations)
+  const consoleInvocations = invocations as ConsoleAgentInvocations
+  consoleInvocations[consoleAgentDefinitionsKey] = new Map(definitions.flatMap((definition, index) => {
+    const name = names[index]
+    return name && definition.agent ? [[name, definition.agent]] : []
+  }))
+  consoleInvocations[consoleInvokeEnabledKey] = "invoke" in installation && installation.invoke === true
+  return installed
 }
 
 export function getConsoleAgents(): readonly string[] {
   // SAFETY: The global journal registry may be absent; when present, installConsoleAgents owns this metadata field.
   return (resolveConsoleInvocations() as ConsoleAgentInvocations | undefined)?.[consoleAgentsKey] ?? []
+}
+
+export function getConsoleAgentDefinition(name: string): Record<string, unknown> | undefined {
+  const invocations = resolveConsoleInvocations() as ConsoleAgentInvocations | undefined
+  if (invocations?.[consoleInvokeEnabledKey] !== true) return undefined
+  return invocations[consoleAgentDefinitionsKey]?.get(name)
+}
+
+export interface ConsoleAgentInvokerProfile {
+  id: string
+  label?: string
+}
+
+export function consoleAgentInvokerProfiles(agent: Record<string, unknown>): ConsoleAgentInvokerProfile[] {
+  const invoker = agent.invoker
+  if (!invoker || typeof invoker !== "object" || Array.isArray(invoker)) return []
+  const profiles = Reflect.get(invoker, "profiles")
+  if (!Array.isArray(profiles)) return []
+  return profiles.flatMap((profile) => {
+    if (!profile || typeof profile !== "object" || Array.isArray(profile)) return []
+    const id = Reflect.get(profile, "id")
+    if (typeof id !== "string" || !id.trim()) return []
+    const label = Reflect.get(profile, "label")
+    return [{
+      id: id.trim(),
+      ...(typeof label === "string" && label.trim() ? { label: label.trim() } : {}),
+    }]
+  })
 }

--- a/packages/vite-hub/src/console/runtime/server/agents.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.ts
@@ -1,7 +1,8 @@
 import { consoleInvocationsFallbackKey, resolveConsoleInvocations } from "../../internal.ts"
 import { installConsoleInvocations } from "./invocations.ts"
+import * as v from "valibot"
 
-import type { AgentInvocations } from "@vite-hub/agent"
+import type { AgentInput, AgentInvocations } from "@vite-hub/agent"
 
 export const consoleAgentsKey: unique symbol = Symbol.for("vitehub.console.agents")
 export const consoleAgentDefinitionsKey: unique symbol = Symbol.for("vitehub.console.agent-definitions")
@@ -17,35 +18,49 @@ export type ConsoleAgentDefinitionInstallation =
   | { invocations?: never, invoke?: boolean, projectRoot: string }
 
 type ConsoleAgentInvocations = AgentInvocations & {
-  [consoleAgentDefinitionsKey]?: ReadonlyMap<string, Record<string, unknown>>
+  [consoleAgentDefinitionsKey]?: ReadonlyMap<string, AgentInput>
   [consoleAgentsKey]?: readonly string[]
   [consoleInvokeEnabledKey]?: boolean
 }
 
 const consoleAssignedInvocations = new WeakMap<object, AgentInvocations>()
+const functionSchema = v.function()
+const recordSchema = v.record(v.string(), v.unknown())
+const stringSchema = v.string()
 
 type ResolvedConsoleAgentDefinition = {
-  agent?: Record<string, unknown>
+  agent?: AgentInput
   fallbackName: string
 }
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  if (Array.isArray(value)) return
+  const result = v.safeParse(recordSchema, value)
+  return result.success ? result.output : undefined
+}
+
+function stringValue(value: unknown): string | undefined {
+  const result = v.safeParse(stringSchema, value)
+  return result.success ? result.output : undefined
+}
+
+const agentDefinitionSchema = v.custom<AgentInput>((value) => {
+  const input = record(value)
+  return Boolean(input && v.safeParse(functionSchema, input.resolve).success)
+})
 
 function resolveConsoleAgentDefinition(
   entry: ConsoleAgentDefinitionEntry,
 ): ResolvedConsoleAgentDefinition {
   const { definition, fallbackName } = entry
-  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Generated plugins can import arbitrary JavaScript definitions, so inspect their runtime shape at this boundary.
-  // SAFETY: The object check establishes the string-keyed record needed to inspect a generated module namespace.
-  const module = definition && typeof definition === "object" ? definition as Record<string, unknown> : undefined
-  let agent = module
-  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Generated plugins can provide an arbitrary default export, so inspect its runtime shape at this boundary.
-  if (module?.default && typeof module.default === "object") {
-    // SAFETY: The object check establishes the string-keyed record needed to inspect a generated module default export.
-    agent = module.default as Record<string, unknown>
-  }
+  const module = record(definition)
+  const defaultAgent = record(module?.default)
+  const result = v.safeParse(agentDefinitionSchema, defaultAgent ?? module)
+  const agent = result.success ? result.output : undefined
   return { agent, fallbackName }
 }
 
-function explicitAgentInvocations(agent: Record<string, unknown> | undefined): AgentInvocations | undefined {
+function explicitAgentInvocations(agent: AgentInput | undefined): AgentInvocations | undefined {
   if (!agent || Reflect.get(agent, consoleInvocationsFallbackKey) === true) return undefined
   const assigned = consoleAssignedInvocations.get(agent)
   const invocations = agent.invocations
@@ -94,10 +109,10 @@ export function installConsoleAgentDefinitions(
         consoleAssignedInvocations.delete(agent)
       }
     }
-    // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Agent Definitions may come from untyped JavaScript, so verify the identity before installing it.
-    return typeof agent?.name === "string" && agent.name.trim() ? agent.name : fallbackName
+    return agent?.name?.trim() ? agent.name : fallbackName
   })
   const installed = installConsoleAgents(names, invocations)
+  // SAFETY: This intersection only attaches console-owned metadata to the Agent invocation journal.
   const consoleInvocations = invocations as ConsoleAgentInvocations
   consoleInvocations[consoleAgentDefinitionsKey] = new Map(definitions.flatMap((definition, index) => {
     const name = names[index]
@@ -112,7 +127,8 @@ export function getConsoleAgents(): readonly string[] {
   return (resolveConsoleInvocations() as ConsoleAgentInvocations | undefined)?.[consoleAgentsKey] ?? []
 }
 
-export function getConsoleAgentDefinition(name: string): Record<string, unknown> | undefined {
+export function getConsoleAgentDefinition(name: string): AgentInput | undefined {
+  // SAFETY: The global journal registry may be absent; installConsoleAgentDefinitions owns these metadata fields.
   const invocations = resolveConsoleInvocations() as ConsoleAgentInvocations | undefined
   if (invocations?.[consoleInvokeEnabledKey] !== true) return undefined
   return invocations[consoleAgentDefinitionsKey]?.get(name)
@@ -123,19 +139,18 @@ export interface ConsoleAgentInvokerProfile {
   label?: string
 }
 
-export function consoleAgentInvokerProfiles(agent: Record<string, unknown>): ConsoleAgentInvokerProfile[] {
-  const invoker = agent.invoker
-  if (!invoker || typeof invoker !== "object" || Array.isArray(invoker)) return []
-  const profiles = Reflect.get(invoker, "profiles")
+export function consoleAgentInvokerProfiles(agent: AgentInput): ConsoleAgentInvokerProfile[] {
+  const invoker = record(agent.invoker)
+  if (!invoker) return []
+  const profiles = invoker.profiles
   if (!Array.isArray(profiles)) return []
   return profiles.flatMap((profile) => {
-    if (!profile || typeof profile !== "object" || Array.isArray(profile)) return []
-    const id = Reflect.get(profile, "id")
-    if (typeof id !== "string" || !id.trim()) return []
-    const label = Reflect.get(profile, "label")
-    return [{
-      id: id.trim(),
-      ...(typeof label === "string" && label.trim() ? { label: label.trim() } : {}),
-    }]
+    const input = record(profile)
+    const id = stringValue(input?.id)?.trim()
+    if (!id) return []
+    const label = stringValue(input?.label)?.trim()
+    const resolved: ConsoleAgentInvokerProfile = { id }
+    if (label) resolved.label = label
+    return [resolved]
   })
 }

--- a/packages/vite-hub/src/console/runtime/server/devframe.ts
+++ b/packages/vite-hub/src/console/runtime/server/devframe.ts
@@ -4,6 +4,7 @@ import { fromWebHandler } from "h3"
 
 import { consoleRpcMethods } from "../rpc.ts"
 import consoleAgentsHandler from "./agents.get.ts"
+import consoleAgentInvocationsHandler from "./agent-invocations.post.ts"
 import consoleBlobHandler from "./blob.get.ts"
 import consoleDatabaseHandler from "./database.get.ts"
 import consoleDefinitionsHandler from "./definitions.get.ts"
@@ -68,7 +69,7 @@ function requestEvent(operation: string, input: ConsoleRpcInput): ConsoleRequest
     else url.searchParams.set(key, value)
   }
   return {
-    context: input.id ? { params: { id: input.id } } : undefined,
+    context: input.agent || input.id ? { params: { ...(input.agent ? { agent: input.agent } : {}), ...(input.id ? { id: input.id } : {}) } } : undefined,
     method: input.method ?? "GET",
     req: {
       json: async () => input.body,
@@ -98,6 +99,7 @@ async function result(resolve: () => unknown | Promise<unknown>): Promise<Consol
 
 const operations = {
   [consoleRpcMethods.agents]: (input: ConsoleRpcInput) => consoleAgentsHandler(requestEvent("agents", input)),
+  [consoleRpcMethods.agentInvocations]: (input: ConsoleRpcInput) => consoleAgentInvocationsHandler(requestEvent(`agents/${input.agent ?? ""}/invocations`, input)),
   [consoleRpcMethods.blob]: (input: ConsoleRpcInput) => consoleBlobHandler(requestEvent("blob", input)),
   [consoleRpcMethods.database]: (input: ConsoleRpcInput) => consoleDatabaseHandler(requestEvent("database", input)),
   [consoleRpcMethods.definitions]: (input: ConsoleRpcInput) => consoleDefinitionsHandler(requestEvent("definitions", input)),

--- a/packages/vite-hub/src/console/runtime/server/devframe.ts
+++ b/packages/vite-hub/src/console/runtime/server/devframe.ts
@@ -68,8 +68,11 @@ function requestEvent(operation: string, input: ConsoleRpcInput): ConsoleRequest
     if (Array.isArray(value)) value.forEach((entry) => url.searchParams.append(key, entry))
     else url.searchParams.set(key, value)
   }
+  const params: Record<string, string> = {}
+  if (input.agent) params.agent = input.agent
+  if (input.id) params.id = input.id
   return {
-    context: input.agent || input.id ? { params: { ...(input.agent ? { agent: input.agent } : {}), ...(input.id ? { id: input.id } : {}) } } : undefined,
+    context: Object.keys(params).length ? { params } : undefined,
     method: input.method ?? "GET",
     req: {
       json: async () => input.body,

--- a/packages/vite-hub/src/console/runtime/server/page.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/page.get.ts
@@ -25,7 +25,7 @@ export default function consolePageHandler(event: ConsoleRequestEvent): Response
   return new Response(page, {
     headers: {
       "cache-control": "no-store",
-      "content-security-policy": "default-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
+      "content-security-policy": "default-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self' data:; frame-ancestors 'none'; base-uri 'none'; form-action 'none'",
       "content-type": "text/html; charset=utf-8",
       "referrer-policy": "no-referrer",
       "x-content-type-options": "nosniff",

--- a/packages/vite-hub/src/console/runtime/server/request.ts
+++ b/packages/vite-hub/src/console/runtime/server/request.ts
@@ -34,6 +34,12 @@ export interface ConsoleRequestEvent {
       set(name: string, value: string): void
     }
   }
+  waitUntil?: (task: Promise<unknown>) => void
+}
+
+export function setConsoleResponseStatus(event: ConsoleRequestEvent, status: number): void {
+  if (event.res) Object.assign(event.res, { status })
+  if (event.node?.res) Object.assign(event.node.res, { statusCode: status })
 }
 
 const maximumConsoleRequestBodyBytes = 64 * 1_024

--- a/packages/vite-hub/src/console/vite.ts
+++ b/packages/vite-hub/src/console/vite.ts
@@ -54,8 +54,8 @@ type ConsoleNitroConfig = {
 }
 
 export type ConsoleOptions =
-  | { access: "auth", exposure?: never }
-  | { access?: never, exposure: "host-managed" }
+  | { access: "auth", exposure?: never, invoke?: boolean }
+  | { access?: never, exposure: "host-managed", invoke?: never }
 
 interface ConsoleVitePluginOptions {
   blobStores?: readonly string[]
@@ -139,6 +139,9 @@ export function assertConsoleProductionAccess(
     auth?: ResolvedAuthViteConfig
   },
 ): void {
+  if (configured !== true && configured.exposure === "host-managed" && Reflect.get(configured, "invoke") === true) {
+    throw new Error('[vitehub] console.invoke requires console: { access: "auth" }.')
+  }
   if (options.development) return
   if (configured === true) {
     throw new Error('[vitehub] console: true is development-only. Production Console builds require console: { access: "auth" } or console: { exposure: "host-managed" }.')
@@ -166,6 +169,7 @@ function renderConsoleNitroPlugin(
   fixture?: string,
   fixtureSnapshot = fixture ? readConsoleFixture(fixture) : undefined,
   runtimeBinding?: string,
+  invoke = false,
 ): string {
   const agentsEnabled = sections.includes("agents")
   const blobEnabled = sections.includes("blob")
@@ -214,7 +218,7 @@ function renderConsoleNitroPlugin(
             `const vitehubConsoleInvocations = installConsoleFixtureInvocations(${JSON.stringify(projectRoot)}, ${JSON.stringify(fixture)}, ${fixtureSource}, ${JSON.stringify(revision)}, ${JSON.stringify(runtimeBinding)})`,
             `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { invocations: vitehubConsoleInvocations })`,
           ]
-        : [`installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { projectRoot: ${JSON.stringify(projectRoot)} })`]
+        : [`installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { projectRoot: ${JSON.stringify(projectRoot)}${invoke ? ", invoke: true" : ""} })`]
       : []),
     ...(kvEnabled
       ? [`installConsoleKV(${JSON.stringify(projectRoot)}, vitehubConsoleKV, ${JSON.stringify(kvStores)})`]
@@ -234,6 +238,7 @@ async function writeConsoleNitroPlugin(
   kvStores: readonly string[],
   fixture?: string,
   runtimeBinding?: string,
+  invoke = false,
   active: () => boolean = () => true,
 ): Promise<string> {
   const snapshot = fixture ? readConsoleFixture(fixture) : undefined
@@ -244,7 +249,7 @@ async function writeConsoleNitroPlugin(
     runtimeBinding,
   )
   if (!active()) return identity
-  const contents = renderConsoleNitroPlugin(projectRoot, sections, agents, catalog, blobStores, kvStores, fixture, snapshot, runtimeBinding)
+  const contents = renderConsoleNitroPlugin(projectRoot, sections, agents, catalog, blobStores, kvStores, fixture, snapshot, runtimeBinding, invoke)
   if (await readFile(file, "utf8").catch(() => undefined) !== contents) {
     await mkdir(resolve(file, ".."), { recursive: true })
     await writeFile(file, contents, "utf8")
@@ -283,11 +288,12 @@ export function consoleVitePlugin(options: ConsoleVitePluginOptions = {}): Plugi
   let workspaceDiscoveryRoot: string | undefined
   let fixture: string | undefined
   let cliDiscovery = false
+  let invoke = false
 
   const refreshConsoleCatalog = serializeConsoleRefresh(async () => {
     if (!generatedPlugin || !projectRoot || !root) return
     const catalog = await discoverConsoleBuildCatalog({ databaseDiscoveryRoot, discoveryRoot: root, projectRoot, rateLimitDiscoveryRoot, rateLimitScanDirs, sandboxDiscoveryRoot: root, scheduleDiscoveryRoot, sections, serverDirs, workspaceDiscoveryRoot })
-    const identity = await writeConsoleNitroPlugin(generatedPlugin, projectRoot, sections, catalog.agents, catalog, blobStores, kvStores, fixture, options.invocationRootState?.binding, () => !options.invocationRootState?.closed)
+    const identity = await writeConsoleNitroPlugin(generatedPlugin, projectRoot, sections, catalog.agents, catalog, blobStores, kvStores, fixture, options.invocationRootState?.binding, invoke, () => !options.invocationRootState?.closed)
     if (options.invocationRootState) updateConsoleInvocationRootState(options.invocationRootState, projectRoot, identity)
   })
 
@@ -387,6 +393,7 @@ export function consoleVitePlugin(options: ConsoleVitePluginOptions = {}): Plugi
         fixture = resolve(projectRoot, configuredFixture)
         readConsoleFixture(fixture)
       }
+      invoke = !fixture && (configured === true || configured.invoke === true)
       generatedPlugin = resolveGeneratedConsolePlugin(root, fixture, options.invocationRootState)
       if (fixture && options.invocationRootState) {
         configureConsoleFixtureLifecycle(options.invocationRootState, generatedPlugin, refreshConsoleCatalog)
@@ -405,6 +412,7 @@ export function consoleVitePlugin(options: ConsoleVitePluginOptions = {}): Plugi
           kvStores,
           fixture,
           options.invocationRootState?.binding,
+          invoke,
         )
       }
       // SAFETY: Nitro extends Vite's user config with this documented top-level configuration object.

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -938,7 +938,8 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
     ? Object.keys(resolvedConsoleKV.stores || { default: resolvedConsoleKV.store })
     : []
   const consoleInvocationRootState = createConsoleInvocationRootState()
-  const consoleInvokeEnabled = options.console === true || (typeof options.console === "object" && options.console.invoke === true)
+  const consoleInvokeEnabled = options.console === true
+    || (options.console !== false && options.console?.invoke === true)
   let resolvedConsoleFixture: string | undefined
   let generatedConsolePluginPath: string | undefined
   let consoleWorkflowConfigResolved = false

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -304,6 +304,7 @@ function renderConsoleNitroPlugin(
   fixture?: string,
   fixtureSnapshot = fixture ? readConsoleFixture(fixture) : undefined,
   runtimeBinding?: string,
+  invoke = false,
 ): string {
   const agentsEnabled = sections.includes("agents")
   const blobEnabled = sections.includes("blob")
@@ -352,7 +353,7 @@ function renderConsoleNitroPlugin(
             `const vitehubConsoleInvocations = installConsoleFixtureInvocations(${JSON.stringify(projectRoot)}, ${JSON.stringify(fixture)}, ${fixtureSource}, ${JSON.stringify(revision)}, ${JSON.stringify(runtimeBinding)})`,
             `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { invocations: vitehubConsoleInvocations })`,
           ]
-        : [`installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { projectRoot: ${JSON.stringify(projectRoot)} })`]
+        : [`installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { projectRoot: ${JSON.stringify(projectRoot)}${invoke ? ", invoke: true" : ""} })`]
       : []),
     ...(kvEnabled
       ? [`installConsoleKV(${JSON.stringify(projectRoot)}, vitehubConsoleKV, ${JSON.stringify(kvStores)})`]
@@ -372,6 +373,7 @@ async function writeConsoleNitroPlugin(
   kvStores: readonly string[],
   fixture?: string,
   runtimeBinding?: string,
+  invoke = false,
   active: () => boolean = () => true,
 ): Promise<string> {
   const snapshot = fixture ? readConsoleFixture(fixture) : undefined
@@ -382,7 +384,7 @@ async function writeConsoleNitroPlugin(
     runtimeBinding,
   )
   if (!active()) return identity
-  const contents = renderConsoleNitroPlugin(projectRoot, sections, agents, catalog, blobStores, kvStores, fixture, snapshot, runtimeBinding)
+  const contents = renderConsoleNitroPlugin(projectRoot, sections, agents, catalog, blobStores, kvStores, fixture, snapshot, runtimeBinding, invoke)
   if (await readFile(file, "utf8").catch(() => undefined) !== contents) {
     await mkdir(resolve(file, ".."), { recursive: true })
     await writeFile(file, contents, "utf8")
@@ -406,6 +408,7 @@ async function installConsole(
   serverDirs?: string[],
   installInvocations = true,
   writeGeneratedPlugin = true,
+  invoke = false,
   invocationRootState?: ConsoleInvocationRootState,
   canDiscoverDefinitions: () => boolean = () => true,
   discoveryOptions: Pick<Parameters<typeof discoverConsoleBuildCatalog>[0], "databaseDiscoveryRoot" | "rateLimitDiscoveryRoot" | "rateLimitScanDirs" | "scheduleDiscoveryRoot" | "workspaceDiscoveryRoot"> = {},
@@ -564,6 +567,7 @@ async function installConsole(
       kvStores,
       fixture,
       invocationRootState?.binding,
+      invoke,
       () => !invocationRootState?.closed,
     )
     if (invocationRootState) {
@@ -934,6 +938,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
     ? Object.keys(resolvedConsoleKV.stores || { default: resolvedConsoleKV.store })
     : []
   const consoleInvocationRootState = createConsoleInvocationRootState()
+  const consoleInvokeEnabled = options.console === true || (typeof options.console === "object" && options.console.invoke === true)
   let resolvedConsoleFixture: string | undefined
   let generatedConsolePluginPath: string | undefined
   let consoleWorkflowConfigResolved = false
@@ -1249,6 +1254,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
         consoleKVStores,
         resolvedConsoleFixture,
         consoleInvocationRootState.binding,
+        consoleInvokeEnabled && !resolvedConsoleFixture,
         () => !consoleInvocationRootState.closed,
       )
     }
@@ -1312,6 +1318,7 @@ const viteHubNuxtModule: ViteHubNuxtModule = async function viteHubNuxtModule(in
       nuxt.options.serverDir ? [nuxt.options.serverDir] : undefined,
       !nuxt.options.vitehubCliDiscovery,
       !nuxt.options.vitehubCliDiscovery,
+      consoleInvokeEnabled && !resolvedConsoleFixture,
       consoleInvocationRootState,
       () => consoleWorkflowConfigResolved,
       {

--- a/packages/vite-hub/test/console-request.test.ts
+++ b/packages/vite-hub/test/console-request.test.ts
@@ -84,6 +84,21 @@ describe("Console requests", () => {
     })
   })
 
+  it("routes Agent invocation writes with the encoded Agent identity", async () => {
+    mocks.call.mockResolvedValue({ ok: true, value: { agent: "support/team", id: "invocation" } })
+
+    await expect(requestConsole("/api/_vitehub/console/agents/support%2Fteam/invocations", {
+      body: { invokerProfileId: "person", prompt: "Test this Agent" },
+      method: "POST",
+    })).resolves.toEqual({ agent: "support/team", id: "invocation" })
+    expect(mocks.call).toHaveBeenCalledWith(consoleRpcMethods.agentInvocations, {
+      agent: "support%2Fteam",
+      body: { invokerProfileId: "person", prompt: "Test this Agent" },
+      method: "POST",
+      query: {},
+    })
+  })
+
   it("loads every KV page using the configured base and stops repeated cursors", async () => {
     mocks.call
       .mockResolvedValueOnce({ ok: true, value: { cursor: "next", keys: ["first"] } })

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -41,6 +41,7 @@ import {
 import { serializeConsoleRefresh } from "../src/console/refresh.ts"
 import { consoleFixtureEnvironmentVariable, consoleFixtureFallbackAgentName, consoleFixtureRevision, parseConsoleFixture } from "../src/console/fixture.ts"
 import agentsHandler from "../src/console/runtime/server/agents.get.ts"
+import agentInvocationsHandler from "../src/console/runtime/server/agent-invocations.post.ts"
 import { installConsoleAgentDefinitions, installConsoleAgents } from "../src/console/runtime/server/agents.ts"
 import { createConsoleFixtureInvocations, createConsoleInvocations, getConsoleInvocationsDatabase, installConsoleFixtureInvocations, installConsoleInvocations, resolveConsoleDatabaseOptions } from "../src/console/runtime/server/invocations.ts"
 import { console as consoleRuntime } from "../src/console/server.ts"
@@ -1272,6 +1273,22 @@ describe("Agent invocation console", () => {
     }])).rejects.toThrow("console: true is development-only")
   })
 
+  it("rejects invocation through host-managed Console exposure", async () => {
+    const plugin = consoleVitePlugin({
+      // SAFETY: This deliberately bypasses the public type to cover the runtime configuration boundary.
+      console: { exposure: "host-managed", invoke: true } as never,
+      preset: "node",
+    })
+    const configHook = plugin.config
+    if (!configHook) throw new TypeError("Expected a console config hook.")
+    const configHandler = "handler" in configHook ? configHook.handler : configHook
+
+    await expect(Reflect.apply(configHandler, {}, [{ root: process.cwd() }, {
+      command: "build",
+      mode: "production",
+    }])).rejects.toThrow('console.invoke requires console: { access: "auth" }')
+  })
+
   it("requires a ViteHub Auth authorize policy for the production Console route", async () => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-console-auth-host-"))
     const auth = (routes: ResolvedAuthViteConfig["access"]["routes"]): ResolvedAuthViteConfig => ({
@@ -1309,9 +1326,10 @@ describe("Agent invocation console", () => {
         .rejects.toThrow("/_vitehub/**")
 
       const protectedConsole = consoleVitePlugin({
-        console: { access: "auth" },
+        console: { access: "auth", invoke: true },
         preset: "node",
         resolveAuthConfig: () => auth([{ authorize: true, route: "/_vitehub/**" }]),
+        sections: ["agents"],
       })
       const protectedHook = protectedConsole.config
       if (!protectedHook) throw new TypeError("Expected a console config hook.")
@@ -1320,6 +1338,9 @@ describe("Agent invocation console", () => {
       await Reflect.apply(protectedHandler, {}, [config, { command: "build", mode: "production" }])
       expect(config.nitro?.handlers).toEqual(
         expect.arrayContaining([expect.objectContaining({ route: "/_vitehub/**" }), expect.objectContaining({ route: "/_vitehub/rpc/**" })]),
+      )
+      await expect(readFile(resolve(root, ".vitehub/nitro/console/plugin.mjs"), "utf8")).resolves.toContain(
+        `installConsoleAgentDefinitions([], { projectRoot: ${JSON.stringify(root)}, invoke: true })`,
       )
     } finally {
       await rm(root, { force: true, recursive: true })
@@ -1844,6 +1865,123 @@ describe("Agent invocation console", () => {
 
     expect(definition.invocations).toBe(invocations)
     await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({ agents: ["support"] })
+  })
+
+  it("advertises invokable Agents and their profiles only when invocation is enabled", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-console-invoke-agents-"))
+    try {
+      const definition = defineAgent({
+        driver: { run: () => "ok" },
+        invoker: {
+          profiles: [
+            { id: " support ", kind: "person", label: " Support agent " },
+            { id: "automation", kind: "service" },
+          ],
+        },
+        name: "support",
+      })
+      installConsoleAgentDefinitions([
+        { definition: { default: definition }, fallbackName: "help" },
+      ], { invoke: true, projectRoot: root })
+
+      await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({
+        agents: ["support"],
+        invocation: {
+          support: {
+            profiles: [
+              { id: "support", label: "Support agent" },
+              { id: "automation" },
+            ],
+          },
+        },
+      })
+
+      installConsoleAgentDefinitions([
+        { definition: { default: definition }, fallbackName: "help" },
+      ], { projectRoot: root })
+      await expect(agentsHandler(event("127.0.0.1"))).resolves.toEqual({ agents: ["support"] })
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("starts an enabled Agent invocation with a selected profile", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-console-invoke-agent-"))
+    try {
+      const definition = defineAgent({
+        driver: { run: () => "done" },
+        invoker: {
+          profiles: [{ id: "support", kind: "person", label: "Support agent" }],
+        },
+        name: "support",
+      })
+      installConsoleAgentDefinitions([
+        { definition: { default: definition }, fallbackName: "help" },
+      ], { invoke: true, projectRoot: root })
+      const response = { headers: new Headers() }
+      const invocation = await agentInvocationsHandler({
+        context: { params: { agent: "support" } },
+        method: "POST",
+        req: {
+          json: async () => ({ invokerProfileId: "support", prompt: " Test this Agent " }),
+          method: "POST",
+          url: "http://localhost/api/_vitehub/console/agents/support/invocations",
+        },
+        res: response,
+      })
+
+      expect(invocation).toMatchObject({
+        agent: "support",
+        id: expect.any(String),
+        url: expect.stringContaining("/_vitehub/agents/~support/invocations/"),
+      })
+      expect(Reflect.get(response, "status")).toBe(202)
+      await vi.waitFor(async () => {
+        await expect(definition.invocations?.get(invocation.id)).resolves.toMatchObject({
+          agentName: "support",
+          status: "completed",
+        })
+      })
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
+  })
+
+  it("rejects disabled Agents, unknown profiles, and unsupported fields", async () => {
+    const root = await mkdtemp(join(tmpdir(), "vitehub-console-invoke-validation-"))
+    const definition = defineAgent({
+      driver: { run: () => "done" },
+      invoker: { profiles: [{ id: "support", kind: "person" }] },
+      name: "support",
+    })
+    const request = (body: unknown) => ({
+      context: { params: { agent: "support" } },
+      method: "POST",
+      req: {
+        json: async () => body,
+        method: "POST",
+        url: "http://localhost/api/_vitehub/console/agents/support/invocations",
+      },
+    }) satisfies ConsoleRequestEvent
+    try {
+      installConsoleAgentDefinitions([
+        { definition: { default: definition }, fallbackName: "help" },
+      ], { projectRoot: root })
+      await expect(agentInvocationsHandler(request({ prompt: "hello" }))).rejects.toMatchObject({ statusCode: 404 })
+
+      installConsoleAgentDefinitions([
+        { definition: { default: definition }, fallbackName: "help" },
+      ], { invoke: true, projectRoot: root })
+      await expect(agentInvocationsHandler(request({ invokerProfileId: "unknown", prompt: "hello" })))
+        .rejects.toMatchObject({ statusCode: 400, statusMessage: "Unknown Agent invocation profile." })
+      await expect(agentInvocationsHandler(request({ extra: true, prompt: "hello" })))
+        .rejects.toMatchObject({ statusCode: 400, statusMessage: "Unsupported Agent invocation field: extra." })
+    }
+    finally {
+      await rm(root, { force: true, recursive: true })
+    }
   })
 
   it("keeps fallback Agent Definition journals bound to refreshed fixtures", () => {
@@ -4012,6 +4150,7 @@ describe("Agent invocation console", () => {
     expect(page).toContain("/_vitehub/assets/__VITEHUB_CONSOLE_STYLE_ASSET__")
     expect(page).toContain("/_vitehub/assets/__VITEHUB_CONSOLE_SCRIPT_ASSET__")
     expect(response.headers.get("cache-control")).toBe("no-store")
+    expect(response.headers.get("content-security-policy")).toContain("script-src 'self' 'wasm-unsafe-eval'")
     expect(response.headers.get("content-security-policy")).toContain("frame-ancestors 'none'")
     expect(response.headers.get("content-security-policy")).toContain("base-uri 'none'")
     expect(response.headers.get("content-security-policy")).toContain("form-action 'none'")

--- a/packages/vite-hub/test/nuxt.test.ts
+++ b/packages/vite-hub/test/nuxt.test.ts
@@ -506,7 +506,7 @@ describe("ViteHub Nuxt integration", () => {
     }])
   })
 
-  it("installs the read-only console in Nuxt development and production", async () => {
+  it("enables Agent invocation in Nuxt development and keeps production read-only by default", async () => {
     const development = createNuxt(true)
     const existingConsoleHandler = vi.fn()
     development.nuxt.options.devServerHandlers = [{ handler: existingConsoleHandler, route: "/api/_vitehub/console" }]
@@ -552,7 +552,7 @@ describe("ViteHub Nuxt integration", () => {
       expect.objectContaining({ name: "vite-hub/console-cli" }),
     )
     await expect(readFile("/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs", "utf8")).resolves.toContain(
-      `installConsoleAgentDefinitions([], { projectRoot: "/tmp/vitehub-nuxt" })`,
+      `installConsoleAgentDefinitions([], { projectRoot: "/tmp/vitehub-nuxt", invoke: true })`,
     )
     await expect(readFile("/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs", "utf8")).resolves.toContain(
       `installConsoleBlob("/tmp/vitehub-nuxt", vitehubConsoleBlob, ["default"])`,
@@ -597,6 +597,9 @@ describe("ViteHub Nuxt integration", () => {
     })
     expect(production.nuxt.options.devServerHandlers).toBeUndefined()
     expect(production.nuxt.options.vite.plugins).toContainEqual(expect.objectContaining({ name: "vite-hub/console-invocation-root" }))
+    await expect(readFile("/tmp/vitehub-nuxt/.vitehub/nitro/console/plugin.mjs", "utf8")).resolves.toContain(
+      `installConsoleAgentDefinitions([], { projectRoot: "/tmp/vitehub-nuxt" })`,
+    )
   })
 
   it("installs only KV navigation and metadata for a KV-only Console", async () => {

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -414,6 +414,10 @@ describe("framework package contract", () => {
       `${packageRoot}/dist/console/runtime/components/console-session-inspector.vue`,
       "utf8",
     );
+    const sessionCodePreview = readFileSync(
+      `${packageRoot}/dist/console/runtime/components/console-session-code-preview.vue`,
+      "utf8",
+    );
     expect(sessionInspector).toContain("Workspace unavailable");
     expect(sessionInspector).toContain(':show-status="false"');
     expect(sessionInspector).toContain(':show-timeline="false"');
@@ -434,6 +438,8 @@ describe("framework package contract", () => {
     expect(sessionInspector).toContain("hasPullRequest && (pullRequest === undefined");
     expect(sessionInspector).toContain('openViews.value.includes("workspace")');
     expect(sessionInspector).toContain("list: 'w-max min-w-0 gap-1 bg-transparent p-0'");
+    expect(sessionInspector).not.toContain("scrollIntoView");
+    expect(sessionInspector).toContain("scroller.scrollLeft");
     expect(consoleSessionCss).toMatch(
       /\.session-inspector__tabstrip \{[\s\S]*?display: flex;[\s\S]*?overflow: hidden;/,
     );
@@ -476,15 +482,16 @@ describe("framework package contract", () => {
     expect(sessionTrace).toContain("const traceWindowMs = computed");
     expect(sessionTrace).not.toContain("const traceDurationMs = computed");
     expect(sessionTrace).toContain("isTerminalToolObservation");
-    expect(
-      readFileSync(
-        `${packageRoot}/dist/console/runtime/components/console-session-code-preview.vue`,
-        "utf8",
-      ),
-    ).toContain("highlightingFailed");
+    expect(sessionCodePreview).toContain("highlightingFailed");
+    expect(sessionCodePreview).toContain('class="line"');
+    expect(sessionCodePreview).toContain("plainLines");
     expect(consoleSessionCss).toMatch(
       /\.session-code-preview \.shiki,[\s\S]*?\.session-code-preview__plain[\s\S]*?font-size: 0\.6875rem;/,
     );
+    expect(consoleSessionCss).toMatch(
+      /\.session-inspector__file \{[\s\S]*?grid-template-rows: minmax\(0, 1fr\);[\s\S]*?height: 100%;/,
+    );
+    expect(consoleSessionCss).toContain("padding: 1rem 1.5rem 2rem 0;");
     expect(
       readFileSync(`${packageRoot}/dist/console/runtime/components/console-health.vue`, "utf8"),
     ).toContain("<h1>Health</h1>");
@@ -684,6 +691,9 @@ describe("framework package contract", () => {
     expect(consoleCss).toContain("vitehub-console");
     expect(consoleCss).toContain("--ui-bg:#fdfdfd");
     expect(consoleCss).toContain("--ui-text:#27272a");
+    expect(
+      globSync("dist/console/runtime/public/console/chunks/*.js", { cwd: packageRoot }).length,
+    ).toBeGreaterThan(0);
     const consolePageSource = readFileSync(
       `${packageRoot}/dist/console/runtime/server/page.get.js`,
       "utf8",

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -112,6 +112,10 @@ export default defineConfig({
         to: "dist/console/runtime/components",
       },
       {
+        from: "src/console/runtime/components/console-invocation-composer.vue",
+        to: "dist/console/runtime/components",
+      },
+      {
         from: "src/console/runtime/components/console-kv.vue",
         to: "dist/console/runtime/components",
       },

--- a/packages/workspace/src/sources/github.ts
+++ b/packages/workspace/src/sources/github.ts
@@ -157,8 +157,8 @@ function pullRequestSource(value: unknown): { ref?: string, repo?: string } | un
 
 function createGitHubAuthResolver(auth: GitHubAuth | undefined) {
   if (auth === false) return false
-  return () => {
-    return resolveExplicitGitHubAuth(auth)
+  return async () => {
+    return await resolveExplicitGitHubAuth(auth)
       || getActiveCloudflareBinding<string>("GITHUB_TOKEN")
       || processEnv(process.env, ...githubTokenEnvNames)
   }
@@ -166,15 +166,15 @@ function createGitHubAuthResolver(auth: GitHubAuth | undefined) {
 
 async function resolveGitHubAuth(auth: GitHubAuth | undefined, rootDir: string): Promise<GitHubAuth | undefined> {
   if (auth === false) return false
-  return resolveExplicitGitHubAuth(auth)
+  return await resolveExplicitGitHubAuth(auth)
     || resolveGitHubTokenOption({})
     || await resolveGitHubEnvFileToken(rootDir)
     || await resolveGitHubCliToken()
 }
 
-function resolveExplicitGitHubAuth(auth: GitHubAuth | undefined): string | undefined {
+async function resolveExplicitGitHubAuth(auth: GitHubAuth | undefined): Promise<string | undefined> {
   if (auth === false) return undefined
-  if (typeof auth === "function") return auth()
+  if (typeof auth === "function") return await auth()
   return typeof auth === "string" ? auth : undefined
 }
 


### PR DESCRIPTION
## Summary

- add an opt-in, authenticated Console flow for starting agent invocations
- place New chat beside search, hide the redundant selector for a single agent, and retain capability filtering
- add a T3-style invocation composer while keeping follow-ups out of completed sessions
- improve workspace file inspection with reliable scrolling, content gutters, line numbers, and Shiki highlighting
- resolve asynchronous GitHub source authentication so materialized sources can use rotating credentials

## Verification

- `pnpm --filter vite-hub build`
- repository typecheck and lint
- ViteHub tests: 252 passed
- Vite integration tests: 89 passed
- GitHub source tests: 29 passed
- manually verified the patched consumer on its stable deployment, including new invocation creation, capability filtering, materialized workspace folders, maximized file inspection, and 15 completed support-agent invocations
