### PR TITLE
fix(console): use plain Agent route slugs

### DIFF
--- a/packages/vite-hub/src/console/runtime/console-route.ts
+++ b/packages/vite-hub/src/console/runtime/console-route.ts
@@ -3,13 +3,18 @@ export const consoleDatabaseTablePath = "/database/:table?"
 export const consoleDatabasesSchemaPath = "/databases/:database/schema/diagram"
 export const consoleDatabasesTablePath = "/databases/:database?/:table?"
 
+const agentRouteParamPattern = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
+
 export function encodeAgentRouteParam(name: string): string {
-  return `~${name}`
+  if (!agentRouteParamPattern.test(name)) {
+    throw new TypeError(`[vitehub] Agent name ${JSON.stringify(name)} must use lowercase letters, numbers, and single hyphens.`)
+  }
+  return name
 }
 
 export function decodeAgentRouteParam(value: string | string[] | undefined): string | undefined {
   const segment = Array.isArray(value) ? value[0] : value
-  return segment?.startsWith("~") && segment.length > 1 ? segment.slice(1) : undefined
+  return segment && agentRouteParamPattern.test(segment) ? segment : undefined
 }
 
 export function resolveConsoleRouteName(currentRouteName: string | symbol | null | undefined, targetRouteName: string): string {

--- a/packages/vite-hub/test/console-route.test.ts
+++ b/packages/vite-hub/test/console-route.test.ts
@@ -20,16 +20,29 @@ describe("Console routes", () => {
     expect(consoleDatabasesSchemaPath).toBe("/databases/:database/schema/diagram")
   })
 
-  it.each([".", "..", "~", "support/team"])(
-    "round-trips the Agent identity %j through a normalized URL",
+  it.each(["chat", "support-bot", "bot2"])(
+    "uses the Agent identity %j directly in the URL",
     (agentName) => {
       const encoded = encodeAgentRouteParam(agentName)
       const url = new URL(`/agents/${encodeURIComponent(encoded)}`, "https://console.vitehub.dev")
 
-      expect(url.pathname).toBe(`/agents/${encodeURIComponent(encoded)}`)
+      expect(encoded).toBe(agentName)
+      expect(url.pathname).toBe(`/agents/${agentName}`)
       expect(decodeAgentRouteParam(decodeURIComponent(url.pathname.slice("/agents/".length)))).toBe(agentName)
     },
   )
+
+  it.each(["", ".", "..", "~", "~chat", "support/team", "Chat", "chat_bot", "-chat", "chat-", "chat--bot"])(
+    "rejects the invalid Agent identity %j",
+    (agentName) => {
+      expect(() => encodeAgentRouteParam(agentName)).toThrow(TypeError)
+      expect(decodeAgentRouteParam(agentName)).toBeUndefined()
+    },
+  )
+
+  it("decodes the first route segment", () => {
+    expect(decodeAgentRouteParam(["chat", "ignored"])).toBe("chat")
+  })
 
   it("preserves host-decorated route names across console navigation", () => {
     expect(resolveConsoleRouteName("vitehub-console-agent___en", "vitehub-console-invocation"))

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -1934,7 +1934,7 @@ describe("Agent invocation console", () => {
       expect(invocation).toMatchObject({
         agent: "support",
         id: expect.any(String),
-        url: expect.stringContaining("/_vitehub/agents/~support/invocations/"),
+        url: expect.stringContaining("/_vitehub/agents/support/invocations/"),
       })
       expect(Reflect.get(response, "status")).toBe(202)
       await vi.waitFor(async () => {
@@ -3878,12 +3878,12 @@ describe("Agent invocation console", () => {
         request: new Request("https://chat.example/api/agents/support"),
       })
       expect(resolved.invocationUrl(invocation)).toBe(
-        `https://chat.example/_vitehub/agents/~agent/invocations/${encodeURIComponent(invocation.id)}`,
+        `https://chat.example/_vitehub/agents/agent/invocations/${encodeURIComponent(invocation.id)}`,
       )
 
       vi.stubGlobal("__VITEHUB_APP_BASE_URL__", "/portal/")
       expect(resolved.invocationUrl(invocation)).toBe(
-        `https://chat.example/portal/_vitehub/agents/~agent/invocations/${encodeURIComponent(invocation.id)}`,
+        `https://chat.example/portal/_vitehub/agents/agent/invocations/${encodeURIComponent(invocation.id)}`,
       )
       vi.unstubAllGlobals()
     }


### PR DESCRIPTION
Agent names now appear directly in Console URLs, so `chat` uses `/agents/chat/...` instead of the sentinel-prefixed `/agents/~chat/...`. Console route names are restricted to lowercase letters, numbers, and single hyphens; malformed names fail while generating a route and do not decode from URL params.

## Verification

- `pnpm --filter vite-hub exec vp test run test/console-route.test.ts` (17 passed)
- focused Console integration tests for created and runtime-generated invocation URLs (2 passed)
- `pnpm exec vp lint packages/vite-hub/src/console/runtime/console-route.ts packages/vite-hub/test/console-route.test.ts packages/vite-hub/test/console.test.ts`
- `pnpm exec vp run -t vite-hub#build`
- verified the patched package on `chat-stable.quiver.dk`: invocation URLs use `/agents/chat/...`, and old `~chat` URLs canonicalize to the plain route