### PR TITLE
feat(agent): attach browser screenshots

### DIFF
--- a/packages/agent/src/capabilities/browser.ts
+++ b/packages/agent/src/capabilities/browser.ts
@@ -2,6 +2,7 @@ import { defineCapability, workspaceMaterializationPathsSymbol } from "../capabi
 import { toAgentRunResult } from "../agent-output.ts"
 import { readAgentWorkspaceDiff } from "../agent-workspace-runtime.ts"
 import { normalizeDeliveryArtifactPath } from "../delivery-artifacts.ts"
+import { isRuntimeRecord } from "../internal/runtime-type.ts"
 import { cloneWithPropertyDescriptors } from "../internal/stream-result.ts"
 
 import type { AgentCapabilityDefinition, AgentDeliveryArtifact } from "../types.ts"
@@ -78,12 +79,14 @@ function attachBrowserScreenshots(
     (match, alt: string, reference: string) => {
       const screenshot = screenshotReferencePath(reference)
       if (!screenshot || !changedPaths.has(screenshot.path)) return match
-      screenshots.set(screenshot.path, {
-        ...(alt.trim() ? { alt: alt.trim() } : {}),
+      const artifact: AgentDeliveryArtifact = {
         mediaType: screenshot.mediaType,
         path: screenshot.path,
         placement: "attachment",
-      })
+      }
+      const trimmedAlt = alt.trim()
+      if (trimmedAlt) artifact.alt = trimmedAlt
+      screenshots.set(screenshot.path, artifact)
       return ""
     },
   )
@@ -91,7 +94,7 @@ function attachBrowserScreenshots(
   const artifacts = new Map<string, AgentDeliveryArtifact>(screenshots)
   for (const artifact of runResult.artifacts || []) artifacts.set(artifact.path, artifact)
   const nextText = text.replace(/\n{3,}/g, "\n\n").trim()
-  if (typeof result === "object" && result !== null) {
+  if (isRuntimeRecord(result)) {
     return cloneWithPropertyDescriptors(result, {
       artifacts: {
         configurable: true,

--- a/packages/agent/src/capabilities/browser.ts
+++ b/packages/agent/src/capabilities/browser.ts
@@ -1,6 +1,10 @@
 import { defineCapability, workspaceMaterializationPathsSymbol } from "../capability-runtime.ts"
+import { toAgentRunResult } from "../agent-output.ts"
+import { readAgentWorkspaceDiff } from "../agent-workspace-runtime.ts"
+import { normalizeDeliveryArtifactPath } from "../delivery-artifacts.ts"
+import { cloneWithPropertyDescriptors } from "../internal/stream-result.ts"
 
-import type { AgentCapabilityDefinition } from "../types.ts"
+import type { AgentCapabilityDefinition, AgentDeliveryArtifact } from "../types.ts"
 
 export interface BrowserCapabilityOptions {
   command?: string
@@ -15,7 +19,16 @@ Use the \`agent-browser\` CLI through the provider's shell for headless browser 
 
 - Run \`agent-browser --help\` before non-trivial browser work.
 - Create \`screenshots/\` before screenshots, then save screenshots inside that workspace directory.
+- To attach a screenshot to the final reply, add \`![Description](screenshots/name.png)\` on its own line. ViteHub removes the marker and sends the file.
 `
+
+const screenshotRoot = "screenshots"
+const screenshotMediaTypes: Record<string, string> = {
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  png: "image/png",
+  webp: "image/webp",
+}
 
 function normalizeSkillPath(path: string): string {
   return path.replace(/^\/+|\/+$/g, "") || "skills/browser/SKILL.md"
@@ -28,6 +41,79 @@ function assertCommand(command: string): string {
   return command
 }
 
+function screenshotReferencePath(reference: string): { mediaType: string, path: string } | undefined {
+  const normalizedReference = reference.trim().replace(/\\/g, "/")
+  if (normalizedReference.startsWith("//")) return
+  const workspaceRelative = normalizedReference.match(/^\/workspace\/(.+)$/)?.[1]
+  const sessionRelative = workspaceRelative?.match(/^[^/]+\/(.+)$/)?.[1]
+  const candidates = workspaceRelative
+    ? [workspaceRelative, ...(sessionRelative ? [sessionRelative] : [])]
+    : normalizedReference.startsWith("/") ? [] : [normalizedReference]
+  for (const candidate of candidates) {
+    let path: string
+    try {
+      path = normalizeDeliveryArtifactPath(candidate)
+    }
+    catch {
+      continue
+    }
+    const mediaType = screenshotMediaTypes[path.split(".").pop()?.toLowerCase() || ""]
+    if (path.startsWith(`${screenshotRoot}/`) && mediaType) return { mediaType, path }
+  }
+}
+
+function attachBrowserScreenshots(
+  result: unknown,
+  context: Parameters<NonNullable<AgentCapabilityDefinition["output"]>>[0],
+): unknown {
+  const diff = readAgentWorkspaceDiff(context.context)
+  const runResult = toAgentRunResult(result)
+  if (!diff || !runResult.text) return result
+  const changedPaths = new Set(diff.entries.flatMap(entry =>
+    (entry.type === "added" || entry.type === "modified") && entry.after?.type === "file" ? [entry.path] : [],
+  ))
+  const screenshots = new Map<string, AgentDeliveryArtifact>()
+  const text = runResult.text.replace(
+    /!\[([^\]\r\n]*)\]\(\s*<?([^\s)<>]+)>?\s*\)/g,
+    (match, alt: string, reference: string) => {
+      const screenshot = screenshotReferencePath(reference)
+      if (!screenshot || !changedPaths.has(screenshot.path)) return match
+      screenshots.set(screenshot.path, {
+        ...(alt.trim() ? { alt: alt.trim() } : {}),
+        mediaType: screenshot.mediaType,
+        path: screenshot.path,
+        placement: "attachment",
+      })
+      return ""
+    },
+  )
+  if (!screenshots.size) return result
+  const artifacts = new Map<string, AgentDeliveryArtifact>(screenshots)
+  for (const artifact of runResult.artifacts || []) artifacts.set(artifact.path, artifact)
+  const nextText = text.replace(/\n{3,}/g, "\n\n").trim()
+  if (typeof result === "object" && result !== null) {
+    return cloneWithPropertyDescriptors(result, {
+      artifacts: {
+        configurable: true,
+        enumerable: true,
+        value: [...artifacts.values()],
+        writable: true,
+      },
+      text: {
+        configurable: true,
+        enumerable: true,
+        value: nextText,
+        writable: true,
+      },
+    })
+  }
+  return {
+    ...runResult,
+    artifacts: [...artifacts.values()],
+    text: nextText,
+  }
+}
+
 export function browser(options: BrowserCapabilityOptions = {}): AgentCapabilityDefinition {
   const command = assertCommand(options.command || "agent-browser")
   const skillPath = normalizeSkillPath(options.skillPath || "skills/browser/SKILL.md")
@@ -37,11 +123,19 @@ export function browser(options: BrowserCapabilityOptions = {}): AgentCapability
   return Object.assign(defineCapability({
     id: "browser",
     metadata: { command, skillPath, sourceKey },
+    output(context) {
+      if (context.driver?.kind === "provider") {
+        context.output.final(result => attachBrowserScreenshots(result, context), { order: "last" })
+      }
+    },
     requires: [{ primitive: "workspace", workspace: { mode: "write", required: true } }],
     prepare(context) {
       if (context.driver?.kind !== "provider") throw new Error("[vitehub] browser() requires a Provider Agent Driver.")
     },
     workspace: {
+      rules: {
+        [`${screenshotRoot}/**`]: { commit: true, write: true },
+      },
       sources: {
         [sourceKey]: {
           content: skillContent,

--- a/packages/agent/test/capability-runtime.test.ts
+++ b/packages/agent/test/capability-runtime.test.ts
@@ -779,10 +779,11 @@ describe("agent capability runtime", () => {
     expect(resolved.registries.workspaceContributions).toEqual([
       {
         capabilityId: "browser",
-        rules: [],
+        rules: ["screenshots/**"],
         sources: ["skill.browser"],
       },
     ])
+    expect(resolved.workspaceDefinition?.rules?.["screenshots/**"]).toEqual({ commit: true, write: true })
   })
 
   it("does not mention Blob tools in the default browser skill", async () => {
@@ -805,8 +806,105 @@ describe("agent capability runtime", () => {
     if (!source || typeof source !== "object") throw new Error("Expected browser skill source object.")
     const content = (source as { content?: unknown }).content
     expect(content).toContain("save screenshots inside that workspace directory")
+    expect(content).toContain("![Description](screenshots/name.png)")
     expect(content).not.toContain("blob_edit")
     expect(content).not.toContain("Blob")
+  })
+
+  it("attaches changed browser screenshots referenced by Provider final replies", async () => {
+    const { applyOutputRenderers, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { browser } = await import("../src/capabilities.ts")
+    const { setAgentWorkspaceDiff } = await import("../src/agent-workspace-runtime.ts")
+    const { createAgentInvocationContextStore } = await import("../src/invocation-context.ts")
+    const invocationContext = createAgentInvocationContextStore()
+    setAgentWorkspaceDiff(invocationContext, {
+      entries: [
+        { after: { type: "file" }, path: "screenshots/login.png", type: "added" },
+        { after: { type: "file" }, path: "screenshots/detail.webp", type: "modified" },
+        { after: { type: "file" }, path: "screenshots/notes.txt", type: "added" },
+      ],
+      to: "next",
+    })
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [browser()],
+    }, {
+      ...runtime(),
+      driver: { kind: "provider" },
+    } as never, {}, emptyWorkspace() as never, "write", {
+      context: invocationContext,
+      driverKind: "provider",
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+
+    await expect(applyOutputRenderers({
+      artifacts: [{ path: "report.md", placement: "link" }],
+      text: [
+        "Done.",
+        "",
+        "![Login](screenshots/login.png)",
+        "![Detail](/workspace/session-1/screenshots/detail.webp)",
+        "![Unchanged](screenshots/old.png)",
+        "![Unsupported](screenshots/notes.txt)",
+        "![Unsafe](screenshots/../secret.png)",
+      ].join("\n"),
+    }, resolved.registries.finalOutputRenderers)).resolves.toEqual({
+      artifacts: [
+        {
+          alt: "Login",
+          mediaType: "image/png",
+          path: "screenshots/login.png",
+          placement: "attachment",
+        },
+        {
+          alt: "Detail",
+          mediaType: "image/webp",
+          path: "screenshots/detail.webp",
+          placement: "attachment",
+        },
+        { path: "report.md", placement: "link" },
+      ],
+      text: [
+        "Done.",
+        "",
+        "![Unchanged](screenshots/old.png)",
+        "![Unsupported](screenshots/notes.txt)",
+        "![Unsafe](screenshots/../secret.png)",
+      ].join("\n"),
+    })
+
+    await expect(applyOutputRenderers(
+      "![Login](screenshots/login.png)",
+      resolved.registries.finalOutputRenderers,
+    )).resolves.toEqual({
+      artifacts: [{
+        alt: "Login",
+        mediaType: "image/png",
+        path: "screenshots/login.png",
+        placement: "attachment",
+      }],
+      raw: "![Login](screenshots/login.png)",
+      text: "",
+    })
+  })
+
+  it("leaves browser screenshot references unchanged outside Provider runs", async () => {
+    const { applyOutputRenderers, resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { browser } = await import("../src/capabilities.ts")
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [browser()],
+    }, runtime(), {}, emptyWorkspace() as never, "write", {
+      driverKind: "provider",
+      workspaceDefinition: {
+        name: "review",
+        sources: {},
+      },
+    })
+    const result = { text: "![Login](screenshots/login.png)" }
+
+    await expect(applyOutputRenderers(result, resolved.registries.finalOutputRenderers)).resolves.toBe(result)
   })
 
   it("applies Access Source grants to capability workspace contribution sources", async () => {


### PR DESCRIPTION
The Browser Capability now turns Markdown image references to changed files under `screenshots/` into reply attachments. This lets Provider Agents send browser evidence through Channels without requiring a separate Blob Capability or leaving a dead workspace path in the final message.

Only newly added or modified PNG, JPEG, and WebP files qualify. ViteHub validates workspace-relative paths, preserves existing artifacts, and leaves unsupported, unchanged, or unsafe references untouched.

## Verification

- `pnpm --filter @vite-hub/agent exec vp test run test/capability-runtime.test.ts` (60 passed)
- `pnpm exec vp lint packages/agent/src/capabilities/browser.ts packages/agent/test/capability-runtime.test.ts`
- `pnpm exec vp run -t @vite-hub/agent#build`