### PR TITLE
fix(console): open invocation workspaces

### DIFF
--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -614,8 +614,7 @@ async function refresh(): Promise<void> {
 }
 
 function inspectSession(target: "agent" | "workspace"): void {
-  if (target !== "agent") return;
-  const view = "details";
+  const view = target === "agent" ? "details" : "workspace";
   inspectorTab.value = view;
   if (!inspectorOpenViews.value.includes(view)) {
     inspectorOpenViews.value = [...inspectorOpenViews.value, view];
@@ -1192,6 +1191,7 @@ onBeforeUnmount(() => {
               v-if="invocationView"
               :invocation="invocationView"
               :maximized="true"
+              :workspace-base="`${hostBase}/api/_vitehub/console/invocations`"
               v-model:tab="inspectorTab"
               v-model:active-surface="inspectorActiveSurface"
               v-model:open-views="inspectorOpenViews"
@@ -1275,7 +1275,7 @@ onBeforeUnmount(() => {
                   :header="false"
                   :invocation="invocationView"
                   :selected-activity-id="selectedActivityId"
-                  :workspace-inspectable="false"
+                  :workspace-inspectable="true"
                   class="min-h-0 flex-1"
                   @inspect="inspectSession"
                 />
@@ -1285,6 +1285,7 @@ onBeforeUnmount(() => {
               <ConsoleSessionInspector
                 v-if="invocationView"
                 :invocation="invocationView"
+                :workspace-base="`${hostBase}/api/_vitehub/console/invocations`"
                 v-model:tab="inspectorTab"
                 v-model:active-surface="inspectorActiveSurface"
                 v-model:open-views="inspectorOpenViews"
@@ -1373,7 +1374,7 @@ onBeforeUnmount(() => {
                 :header="false"
                 :invocation="invocationView"
                 :selected-activity-id="selectedActivityId"
-                :workspace-inspectable="false"
+                :workspace-inspectable="true"
                 class="min-h-0 flex-1"
                 @inspect="inspectSession"
               />
@@ -1396,6 +1397,7 @@ onBeforeUnmount(() => {
                 <ConsoleSessionInspector
                   :invocation="invocationView"
                   :maximizable="false"
+                  :workspace-base="`${hostBase}/api/_vitehub/console/invocations`"
                   v-model:tab="inspectorTab"
                   v-model:active-surface="inspectorActiveSurface"
                   v-model:open-views="inspectorOpenViews"

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -325,6 +325,15 @@ describe("framework package contract", () => {
     expect(consolePage).toContain('aria-label="Filter sessions"');
     expect(consolePage).toContain("selectedCapabilityId");
     expect(consolePage).not.toContain(':workspace-base="`${hostBase}/api/invocations`"');
+    expect(
+      consolePage.match(
+        /:workspace-base="`\$\{hostBase\}\/api\/_vitehub\/console\/invocations`"/g,
+      ),
+    ).toHaveLength(3);
+    expect(consolePage.match(/:workspace-inspectable="true"/g)).toHaveLength(2);
+    expect(consolePage).toContain(
+      'const view = target === "agent" ? "details" : "workspace";',
+    );
     expect(consolePage).toContain('invocation.annotations?.["agent.model.provider"]');
     expect(consolePage).toContain("ConsoleSessionInspector");
     expect(consolePage).toContain("ConsoleHealth");


### PR DESCRIPTION
## What changed

- enable the Workspace inspect action for agent invocations
- route Workspace inspection to the authenticated console invocation workspace API
- wire the endpoint through split, maximized, and mobile inspector layouts
- cover the published console component contract

## Why

The invocation UI already exposed a Workspace action and the inspector already knew how to render a workspace, but the console discarded that action and never supplied the workspace endpoint. The result was an inert control and a hidden Workspace view.

## Verification

- `pnpm exec vp run -t vite-hub#build`
- `pnpm --filter vite-hub exec vp test run test/package.test.ts`
- `pnpm exec vp lint packages/vite-hub/src/console/runtime/components/console-app.vue packages/vite-hub/test/package.test.ts`
- `git diff --check`