### PR TITLE
feat(docs): mark ViteHub as alpha

### DIFF
--- a/docs/app/components/AppHeader.vue
+++ b/docs/app/components/AppHeader.vue
@@ -21,14 +21,23 @@ const mobileLinks = [
 
 <template>
   <div class="sticky top-0 z-50">
-    <UHeader :to="'/'" title="ViteHub" :ui="{ toggle: isSupportMatrix ? 'hidden' : undefined }">
-      <template #title>
-        <span class="vh-brand" aria-label="ViteHub">
-          <span class="vh-brand-mark" aria-hidden="true">
-            <img src="/vitehub-mark.svg" alt="" class="h-4 w-[1.125rem]" />
-          </span>
-          <span>ViteHub</span>
-        </span>
+    <UHeader :ui="{ toggle: isSupportMatrix ? 'hidden' : undefined }">
+      <template #left>
+        <UTooltip
+          text="Just a library where I test different solutions and agents. APIs break all the time."
+          :content="{ side: 'bottom', sideOffset: 8 }"
+          :ui="{ content: 'h-auto max-w-64 whitespace-normal px-3 py-2 text-left leading-5' }"
+        >
+          <ULink to="/" class="vh-brand" aria-label="ViteHub alpha">
+            <span class="vh-brand-mark" aria-hidden="true">
+              <img src="/vitehub-mark.svg" alt="" class="h-4 w-[1.125rem]" />
+            </span>
+            <span class="vh-brand-name">
+              <span>ViteHub</span>
+              <span class="vh-brand-alpha">alpha</span>
+            </span>
+          </ULink>
+        </UTooltip>
       </template>
 
       <nav class="flex items-center gap-1" aria-label="Primary">
@@ -94,9 +103,11 @@ const mobileLinks = [
 <style scoped>
 .vh-brand {
   display: inline-flex;
+  flex-shrink: 0;
   align-items: center;
   gap: 0.5rem;
   color: var(--ui-text-highlighted);
+  font-size: 0.875rem;
   font-weight: 650;
   letter-spacing: 0;
 }
@@ -108,5 +119,28 @@ const mobileLinks = [
   place-items: center;
   border: 1px solid var(--ui-border);
   background: #fafafa;
+}
+
+.vh-brand-name {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.3rem;
+}
+
+.vh-brand-alpha {
+  position: relative;
+  top: -0.2em;
+  border-bottom: 1px dotted currentcolor;
+  color: var(--ui-text-muted);
+  font-family: var(--font-mono);
+  font-size: 0.625rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  transition: color 150ms ease;
+}
+
+.vh-brand:hover .vh-brand-alpha {
+  color: var(--ui-text-highlighted);
 }
 </style>

--- a/docs/app/components/AppHeader.vue
+++ b/docs/app/components/AppHeader.vue
@@ -128,8 +128,6 @@ const mobileLinks = [
 }
 
 .vh-brand-alpha {
-  position: relative;
-  top: -0.2em;
   border-bottom: 1px dotted currentcolor;
   color: var(--ui-text-muted);
   font-family: var(--font-mono);

--- a/docs/test/app-header.test.ts
+++ b/docs/test/app-header.test.ts
@@ -1,0 +1,18 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+
+describe("docs header", () => {
+  it("labels the current release state and explains it on hover", async () => {
+    const header = await readFile(
+      new URL("../app/components/AppHeader.vue", import.meta.url),
+      "utf8",
+    );
+
+    expect(header).toContain("<UTooltip");
+    expect(header).toContain(
+      'text="Just a library where I test different solutions and agents. APIs break all the time."',
+    );
+    expect(header).toContain('aria-label="ViteHub alpha"');
+    expect(header).toContain('<span class="vh-brand-alpha">alpha</span>');
+  });
+});


### PR DESCRIPTION
ViteHub changes APIs often while it tests different solutions and Agents, but the docs header does not make that status clear. This adds a small `alpha` label to the ViteHub wordmark and explains the project state on hover or keyboard focus.

The home link and the rest of the header keep their current behavior.

## Before and after

| Before | After |
| --- | --- |
| ![ViteHub docs header before the alpha label](https://gist.githubusercontent.com/onmax/b60e56fd233fad55d50512a866e51f91/raw/1a8f2624fc54fca1845f55308cb4bec04c3f75ec/before.svg) | ![ViteHub docs header with the alpha label aligned to the wordmark baseline](https://gist.githubusercontent.com/onmax/b60e56fd233fad55d50512a866e51f91/raw/2f3b71f7fee9d3550f479a7d5c78021bbb82cf40/after.svg) |

## Verification

- `pnpm --dir docs typecheck`
- `pnpm --dir docs test -- test/app-header.test.ts` (1 passed)
- Browser check at 1280 px confirms the label shares the wordmark baseline and does not shift the centered navigation.

`pnpm --dir docs build` is blocked during prerender because the current lockfile resolves Reka UI with Vue 3.5.42 while Nuxt renders with Vue 3.5.40. This PR does not change dependencies.

Model: `GPT-5`
Harness: `T3 Code Codex`
