### PR TITLE
fix(console): keep new chat available for historical agents

### DIFF
--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -11,6 +11,7 @@ import { useAgentInvocation, useAgentInvocations } from "vite-hub/agent/vue";
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { isConsoleHealth } from "./console-health-model";
+import { resolveConsoleNewChatAgent } from "./console-new-chat";
 
 import type { DropdownMenuItem, SplitterItem } from "@nuxt/ui";
 import type {
@@ -197,6 +198,9 @@ const invocationItems = computed<AgentInvocationListItem[]>(() =>
 const hasMultipleAgents = computed(() => agentNames.value.length > 1);
 const selectedAgentInvocation = computed(() =>
   selectedAgentName.value ? agentInvocationOptions.value[selectedAgentName.value] : undefined,
+);
+const newChatTargetName = computed(() =>
+  resolveConsoleNewChatAgent(selectedAgentName.value, agentInvocationOptions.value),
 );
 const selectedAgentLabel = computed(
   () => selectedAgentName.value || (agentsLoading.value ? "Loading agents" : "Agents"),
@@ -444,11 +448,12 @@ async function selectStartedInvocation(invocation: { agent: string; id: string }
 }
 
 async function startNewChat(): Promise<void> {
-  const agentName = selectedAgentName.value;
-  if (!agentName || !selectedAgentInvocation.value) return;
+  const agentName = newChatTargetName.value;
+  if (!agentName) return;
   showSessions();
   sessionsOpen.value = false;
   newChatAgentName.value = agentName;
+  updateSelectedAgentName(agentName);
   selectedInvocationId.value = undefined;
   closeDetails();
   await router.push({
@@ -919,7 +924,7 @@ onBeforeUnmount(() => {
             label="Search console"
             :ui="{ trailing: 'vitehub-console__search-shortcut' }"
           />
-          <UTooltip v-if="!collapsed && selectedAgentInvocation" text="New chat">
+          <UTooltip v-if="!collapsed && newChatTargetName" text="New chat">
             <UButton
               aria-label="New chat"
               color="neutral"

--- a/packages/vite-hub/src/console/runtime/components/console-new-chat.ts
+++ b/packages/vite-hub/src/console/runtime/components/console-new-chat.ts
@@ -1,0 +1,9 @@
+export function resolveConsoleNewChatAgent(
+  selectedAgentName: string | undefined,
+  invocationOptions: Record<string, unknown>,
+): string | undefined {
+  if (selectedAgentName && Object.hasOwn(invocationOptions, selectedAgentName)) {
+    return selectedAgentName;
+  }
+  return Object.keys(invocationOptions)[0];
+}

--- a/packages/vite-hub/test/console-new-chat.test.ts
+++ b/packages/vite-hub/test/console-new-chat.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveConsoleNewChatAgent } from "../src/console/runtime/components/console-new-chat.ts"
+
+describe("console new chat agent", () => {
+  it("keeps the selected agent when it can start invocations", () => {
+    expect(resolveConsoleNewChatAgent("support", { support: { profiles: [] } })).toBe("support")
+  })
+
+  it("falls back to an invokable agent for a historical selection", () => {
+    expect(resolveConsoleNewChatAgent("chat", { bot: { profiles: [] } })).toBe("bot")
+  })
+
+  it("returns no target when the console has no invokable agents", () => {
+    expect(resolveConsoleNewChatAgent("chat", {})).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Historical invocation journals can contain Agent names that are no longer invokable. Keep those sessions browseable while showing the New chat action whenever any current Agent accepts invocations; starting from a historical session falls back to the first invokable Agent.

## Test plan

- `pnpm exec vp test run test/console-new-chat.test.ts test/console-route.test.ts`
- `pnpm --filter vite-hub typecheck`
- `pnpm exec vp run -t vite-hub#build`
- `pnpm exec vp lint packages/vite-hub/src/console/runtime/components/console-app.vue packages/vite-hub/src/console/runtime/components/console-new-chat.ts packages/vite-hub/test/console-new-chat.test.ts`
