### PR TITLE
feat(agent): preserve Nostics error guidance

### DIFF
--- a/docs/content/docs/reference/errors-diagnostics.md
+++ b/docs/content/docs/reference/errors-diagnostics.md
@@ -31,6 +31,47 @@ Errors and diagnostics belong to the package that owns the failing boundary. Vit
 | `LLM_GATE_REJECTED` | Agent Package | LLM Gate Capability rejected before the main Agent Invocation. |
 | `Agent Invocation Stream timed out after <ms>.` | Agent Package | The dev-loop stream aborted a long or stalled Agent Invocation after its timeout. |
 
+## Agent diagnostics
+
+Agent lookup, basic Capability registration, mode validation, and retryable tool-policy failures use [Nostics](https://github.com/vercel-labs/nostics). These errors have a stable `code`, a `message`, a `fix`, and a documentation link. They extend `Error`; catch them by code rather than `TypeError`.
+
+| Code | Action |
+| --- | --- |
+| `AGENT_NOT_FOUND` | Use a discovered Agent name. The message includes nearby names when available. |
+| `AGENT_EXPORT_INVALID`, `AGENT_DEFINITION_INVALID` | Export or pass an Agent Definition created with `defineAgent()`. |
+| `AGENT_CAPABILITY_DEFINITION_INVALID`, `AGENT_CAPABILITY_ID_REQUIRED`, `AGENT_CAPABILITY_ID_INVALID` | Supply a Capability object with a valid id. |
+| `AGENT_TRIGGER_NAME_REQUIRED`, `AGENT_TRIGGER_NAME_INVALID` | Supply a trigger name that starts with a letter and uses letters, numbers, hyphens, or underscores. |
+| `AGENT_CAPABILITY_MODE_INVALID` | Set mode to `read` or `write`. |
+| `AGENT_CAPABILITIES_INVALID`, `AGENT_CAPABILITY_DUPLICATE` | Supply an ordered array with unique Capability ids. |
+| `AGENT_EXTENSION_NOT_COMPILED` | Load Eve extensions through the ViteHub Agent Vite plugin. |
+| `AGENT_CAPABILITY_DYNAMIC_UNSUPPORTED` | Move definition-time contributions to a static Capabilities array. |
+| `AGENT_TOOL_POLICY_RETRYABLE` | Retry when the policy permits execution. |
+
+Application tools can use their own Nostics catalog:
+
+```ts
+import { defineDiagnostics } from 'nostics'
+
+const errors = defineDiagnostics({
+  codes: {
+    SEARCH_INDEX_MISSING: {
+      why: 'Search index is missing.',
+      fix: 'Create the search index before searching.',
+    },
+  },
+})
+
+throw errors.SEARCH_INDEX_MISSING()
+```
+
+Install `nostics` as a direct dependency when using it in application code. Omit reporters for throw-only catalogs. ViteHub formats the error where it is reported.
+
+AI SDK tool results, Codex and Claude Code MCP tool responses, tool-step reports, and CLI error output retain the code and repair guidance. Formatting omits causes and stacks. Only put information suitable for the model in the diagnostic message, fix, sources, and docs. The AI SDK adapter wraps a Nostics tool failure in an `Error` with the formatted message because the SDK reads only `error.message`; the original diagnostic remains its `cause`.
+
+`normalizeRuntimeDiagnosticError(error)` preserves Nostics metadata in bounded diagnostic records, including serialized Nostics errors. `formatRuntimeDiagnosticError(error)` from `@vite-hub/runtime` formats those records for text output. Sources share the node limit, and all strings share the size limit. Large error records can omit metadata when these limits are reached.
+
+Public HTTP error mapping, approval decisions, and cancellation keep their existing contracts. A Nostics diagnostic does not become a public `ViteHubError`. Unknown public failures still map to `INTERNAL`.
+
 ## Agent public errors
 
 Agent routes and hooks expose a sanitized `AgentPublicError` beside the original

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -225,6 +225,26 @@ openapi({
 When `cli` is set, the operation tools are replaced by one CLI-named tool. ViteHub generates one subcommand per allowed operation, using the OpenAPI operation summary or description for command guidance.
 Capability `cli` can be a static command tree or an invocation resolver that returns `undefined` when the CLI should not be available. Generated command trees stay behind adapter-owned options such as `openapi({ cli })`, whose resolver may return `false` or `undefined` for the current invocation.
 
+## Error diagnostics
+
+Agent lookup and basic Capability setup errors use Nostics codes and repair
+instructions. Application tools can also throw diagnostics created with
+`defineDiagnostics()` from `nostics`. Add `nostics` as a direct dependency when
+using it in your application.
+
+AI SDK model tool results, Codex and Claude Code MCP tool responses, tool-step
+reports, and CLI error output include diagnostic codes and fixes. They omit
+causes and stacks. Keep diagnostic messages and metadata suitable for the model.
+The AI SDK adapter preserves the original diagnostic as the cause of an Error
+whose message includes the repair guidance.
+
+Public HTTP errors keep the `ViteHubError` mapping. An unrecognized diagnostic
+maps to the generic `INTERNAL` response. Approval and cancellation behavior does
+not change.
+
+See [Errors and diagnostics](https://vitehub.dev/docs/reference/errors-diagnostics#agent-diagnostics)
+for the codes and an application catalog example.
+
 ## Chat state
 
 Chat History and the Concurrent Invocation Guard need an Agent State Provider when they should survive a process restart. The default `provider: "auto"` uses Cloudflare state on Cloudflare and local SQLite at `file:.vitehub/data/agent-state.sqlite` during Vite development. Production Node and serverless output require `VITEHUB_AGENT_STATE_URL` or explicit provider options because ViteHub cannot infer a durable filesystem there.

--- a/packages/agent/package.json
+++ b/packages/agent/package.json
@@ -161,6 +161,7 @@
     "comark": "catalog:markdown",
     "effect": "catalog:effect",
     "esbuild": "catalog:esbuild-v27",
+    "nostics": "catalog:runtime",
     "valibot": "catalog:runtime"
   },
   "devDependencies": {

--- a/packages/agent/src/agent-diagnostics.ts
+++ b/packages/agent/src/agent-diagnostics.ts
@@ -1,0 +1,66 @@
+import { defineDiagnostics } from "nostics"
+
+import { formatUnknownAgentMessage } from "./registry-error.ts"
+
+// Throw-only diagnostics. The CLI and model adapters choose how to report them.
+export const agentDiagnostics = defineDiagnostics({
+  docsBase: () => "https://vitehub.dev/docs/reference/errors-diagnostics#agent-diagnostics",
+  codes: {
+    AGENT_NOT_FOUND: {
+      why: ({ name, available }: { name: string, available: string[] }) => formatUnknownAgentMessage(name, available, { prefix: true }),
+      fix: "Use a discovered Agent name. Check the Agent Definition and the ViteHub Agent plugin configuration.",
+    },
+    AGENT_EXPORT_INVALID: {
+      why: ({ name }: { name: string }) => `[vitehub] Agent "${name}" did not export a valid default agent.`,
+      fix: "Export the result of defineAgent() as the default export of the Agent Definition.",
+    },
+    AGENT_DEFINITION_INVALID: {
+      why: "[vitehub] Invalid agent definition.",
+      fix: "Pass an Agent Definition created with defineAgent().",
+    },
+    AGENT_CAPABILITY_DEFINITION_INVALID: {
+      why: "[vitehub] defineCapability() requires a capability definition.",
+      fix: "Pass an object with a non-empty id to defineCapability().",
+    },
+    AGENT_CAPABILITY_ID_REQUIRED: {
+      why: "[vitehub] Capability definitions require a non-empty string id.",
+      fix: "Set the Capability id to a string that starts with a letter.",
+    },
+    AGENT_CAPABILITY_ID_INVALID: {
+      why: ({ id }: { id: string }) => `[vitehub] Capability id "${id}" must be a stable identifier.`,
+      fix: "Start the id with a letter. Use only letters, numbers, hyphens, underscores, and dots.",
+    },
+    AGENT_TRIGGER_NAME_REQUIRED: {
+      why: ({ capability }: { capability: string }) => `[vitehub] Capability "${capability}" trigger names must be non-empty strings.`,
+      fix: "Set each trigger name to a non-empty string that starts with a letter.",
+    },
+    AGENT_TRIGGER_NAME_INVALID: {
+      why: ({ capability, name }: { capability: string, name: string }) => `[vitehub] Capability "${capability}" trigger "${name}" must be a stable local identifier.`,
+      fix: "Start the trigger name with a letter. Use only letters, numbers, hyphens, and underscores.",
+    },
+    AGENT_CAPABILITY_MODE_INVALID: {
+      why: ({ label }: { label: string }) => `[vitehub] ${label} mode must be "read" or "write".`,
+      fix: 'Set mode to "read" or "write", or omit it to use "read".',
+    },
+    AGENT_CAPABILITIES_INVALID: {
+      why: "[vitehub] defineAgent({ capabilities }) must be an ordered array.",
+      fix: "Pass an array of Capabilities in execution order.",
+    },
+    AGENT_EXTENSION_NOT_COMPILED: {
+      why: "[vitehub] Eve extensions must be compiled by the ViteHub Vite plugin.",
+      fix: "Load the Agent Definition through a Vite host with the ViteHub Agent plugin installed.",
+    },
+    AGENT_CAPABILITY_DUPLICATE: {
+      why: ({ id }: { id: string }) => `[vitehub] Duplicate capability id "${id}" in one agent.`,
+      fix: "Remove the duplicate Capability or give each Capability a unique id.",
+    },
+    AGENT_CAPABILITY_DYNAMIC_UNSUPPORTED: {
+      why: ({ id, unsupported }: { id: string, unsupported: string[] }) => `[vitehub] Invocation-resolved Capability "${id}" cannot contribute ${unsupported.join(", ")}. Attach definition-time behavior in a static capabilities array.`,
+      fix: "Move triggers, workspaceSources, and chat access to a static capabilities array.",
+    },
+    AGENT_TOOL_POLICY_RETRYABLE: {
+      why: ({ name }: { name: string }) => `[vitehub:agent] Tool "${name}" failed with a retryable policy decision.`,
+      fix: "Retry the tool when its policy permits execution. Do not bypass the policy.",
+    },
+  },
+})

--- a/packages/agent/src/agent-error.ts
+++ b/packages/agent/src/agent-error.ts
@@ -1,4 +1,5 @@
 import {
+  formatRuntimeDiagnosticError,
   getViteHubErrorShape,
 } from "@vite-hub/runtime"
 
@@ -49,6 +50,10 @@ function stringifyErrorValue(value: unknown): string | undefined {
 }
 
 export function formatAgentError(error: unknown, fallback = "Unknown error."): string {
+  if (hasRuntimeType(readAgentErrorProperty(error, "code"), "string")
+    || hasRuntimeType(readAgentErrorProperty(error, "why"), "string")) {
+    return formatRuntimeDiagnosticError(error)
+  }
   if (error instanceof Error) return error.stack || error.message || error.name || fallback
   if (hasRuntimeType(error, "string")) return error || fallback
   const text = stringifyErrorValue(error)

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -1,4 +1,6 @@
 import { asUnknownBoundary, hasRuntimeType } from "./internal/runtime-type.ts"
+import { formatRuntimeDiagnosticError } from "@vite-hub/runtime"
+import { readAgentErrorProperty } from "./agent-error.ts"
 import { getMessageText, isAttachmentData, isAttachmentPart, resolveAttachmentData } from "./messages.ts"
 import {
   cloneWithPropertyDescriptors,
@@ -601,7 +603,7 @@ function withWorkspaceFallbackToolEvidence<TTools extends AgentToolSet | undefin
           return output
         }
         catch (error) {
-          capture.collect({ error: error instanceof Error ? error.message : String(error), toolName: name, type: "tool-error" })
+          capture.collect({ error: formatRuntimeDiagnosticError(error), toolName: name, type: "tool-error" })
           throw error
         }
       },
@@ -829,6 +831,33 @@ const defaultToolInputSchemaJson = {
   properties: {},
   type: "object",
 } as const
+
+// AI SDK reads only Error.message for failed tools. Preserve the original diagnostic as cause.
+function withToolDiagnosticMessages(tools: AgentToolSet | undefined): AgentToolSet | undefined {
+  if (!tools) return tools
+  return Object.fromEntries(Object.entries(tools).map(([name, tool]) => {
+    const execute = tool?.execute
+    if (typeof execute !== "function") return [name, tool]
+    return [name, {
+      ...tool,
+      async execute(...args: Parameters<typeof execute>) {
+        try {
+          return await execute.apply(tool, args)
+        }
+        catch (error) {
+          const name = readAgentErrorProperty(error, "name")
+          const code = readAgentErrorProperty(error, "code")
+          const why = readAgentErrorProperty(error, "why")
+          if (typeof name === "string"
+            && (typeof why === "string" || typeof code === "string" && name === code)) {
+            throw new Error(formatRuntimeDiagnosticError(error), { cause: error })
+          }
+          throw error
+        }
+      },
+    }]
+  }))
+}
 
 function withDefaultToolInputSchemas<TTools extends Record<string, unknown> | undefined>(tools: TTools, createJsonSchema: (schema: JSONSchema7) => unknown): TTools {
   if (!tools) return tools
@@ -1262,10 +1291,10 @@ async function createAgent(
     context.workspaceInstructionBindings,
   )
   const adapterTools = await resolveTools(options, metadataContext, context.toolStepReporter)
-  const resolvedTools = withDefaultToolInputSchemas(withWorkspaceFallbackToolEvidence(await applyCapabilityToolTransforms({
+  const resolvedTools = withDefaultToolInputSchemas(withToolDiagnosticMessages(withWorkspaceFallbackToolEvidence(await applyCapabilityToolTransforms({
     ...context.tools,
     ...adapterTools,
-  }, []), fallbackCapture), jsonSchema)
+  }, []), fallbackCapture)), jsonSchema)
   const providerTools = Object.fromEntries((context.providerTools || []).map(tool => [tool.name, {
     args: tool.args || {},
     id: tool.id,

--- a/packages/agent/src/ai-sdk.ts
+++ b/packages/agent/src/ai-sdk.ts
@@ -837,7 +837,7 @@ function withToolDiagnosticMessages(tools: AgentToolSet | undefined): AgentToolS
   if (!tools) return tools
   return Object.fromEntries(Object.entries(tools).map(([name, tool]) => {
     const execute = tool?.execute
-    if (typeof execute !== "function") return [name, tool]
+    if (!hasRuntimeType(execute, "function")) return [name, tool]
     return [name, {
       ...tool,
       async execute(...args: Parameters<typeof execute>) {
@@ -848,8 +848,8 @@ function withToolDiagnosticMessages(tools: AgentToolSet | undefined): AgentToolS
           const name = readAgentErrorProperty(error, "name")
           const code = readAgentErrorProperty(error, "code")
           const why = readAgentErrorProperty(error, "why")
-          if (typeof name === "string"
-            && (typeof why === "string" || typeof code === "string" && name === code)) {
+          if (hasRuntimeType(name, "string")
+            && (hasRuntimeType(why, "string") || hasRuntimeType(code, "string") && name === code)) {
             throw new Error(formatRuntimeDiagnosticError(error), { cause: error })
           }
           throw error

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -1,3 +1,4 @@
+import { agentDiagnostics } from "./agent-diagnostics.ts"
 import { asUnknownBoundary, hasRuntimeType, isRuntimeRecord } from "./internal/runtime-type.ts"
 import { resolveRuntimeValue } from "@vite-hub/runtime"
 
@@ -157,19 +158,19 @@ export interface ResolvedAgentCapabilities {
 
 function assertCapabilityId(id: unknown): asserts id is string {
   if (!hasRuntimeType(id, "string") || !id.trim()) {
-    throw new TypeError("[vitehub] Capability definitions require a non-empty string id.")
+    throw agentDiagnostics.AGENT_CAPABILITY_ID_REQUIRED()
   }
   if (!/^[a-z][a-z0-9-_.]*$/i.test(id)) {
-    throw new TypeError(`[vitehub] Capability id "${id}" must be a stable identifier.`)
+    throw agentDiagnostics.AGENT_CAPABILITY_ID_INVALID({ id })
   }
 }
 
 function assertTriggerName(name: unknown, capabilityId: string): asserts name is string {
   if (!hasRuntimeType(name, "string") || !name.trim()) {
-    throw new TypeError(`[vitehub] Capability "${capabilityId}" trigger names must be non-empty strings.`)
+    throw agentDiagnostics.AGENT_TRIGGER_NAME_REQUIRED({ capability: capabilityId })
   }
   if (!/^[a-z][a-z0-9-_]*$/i.test(name)) {
-    throw new TypeError(`[vitehub] Capability "${capabilityId}" trigger "${name}" must be a stable local identifier.`)
+    throw agentDiagnostics.AGENT_TRIGGER_NAME_INVALID({ capability: capabilityId, name })
   }
 }
 
@@ -182,7 +183,7 @@ export function defineCapability<
   capability: ExactOptions<TCapability, AgentCapabilityDefinitionInput<TRuntimeConfig, Name, TTypeContract>>,
 ): TCapability {
   if (!capability || !hasRuntimeType(capability, "object")) {
-    throw new TypeError("[vitehub] defineCapability() requires a capability definition.")
+    throw agentDiagnostics.AGENT_CAPABILITY_DEFINITION_INVALID()
   }
   // SAFETY: Capability registration and resolution establish the asserted internal Capability contract.
   assertCapabilityId((capability as { id?: unknown }).id)
@@ -196,7 +197,7 @@ export function defineCapability<
 export function normalizeMode(value: unknown, label: string): AgentCapabilityMode {
   if (value === undefined) return "read"
   if (value === "read" || value === "write") return value
-  throw new TypeError(`[vitehub] ${label} mode must be "read" or "write".`)
+  throw agentDiagnostics.AGENT_CAPABILITY_MODE_INVALID({ label })
 }
 
 export function normalizeCapabilities(
@@ -204,18 +205,18 @@ export function normalizeCapabilities(
 ): AgentCapabilityDefinition[] {
   if (capabilities === undefined) return []
   if (!Array.isArray(capabilities)) {
-    throw new TypeError("[vitehub] defineAgent({ capabilities }) must be an ordered array.")
+    throw agentDiagnostics.AGENT_CAPABILITIES_INVALID()
   }
   // SAFETY: Capability registration and resolution establish the asserted internal Capability contract.
   if (capabilities.some(capability => (capability as Record<symbol, unknown>)?.[Symbol.for("eve.mounted-extension")] === true)) {
-    throw new TypeError("[vitehub] Eve extensions must be compiled by the ViteHub Vite plugin.")
+    throw agentDiagnostics.AGENT_EXTENSION_NOT_COMPILED()
   }
   // SAFETY: Capability registration and resolution establish the asserted internal Capability contract.
   const explicit = capabilities.map(capability => defineCapability(capability as AgentCapabilityDefinition))
   const explicitById = new Map<string, AgentCapabilityDefinition>()
   for (const capability of explicit) {
     if (explicitById.has(capability.id)) {
-      throw new Error(`[vitehub] Duplicate capability id "${capability.id}" in one agent.`)
+      throw agentDiagnostics.AGENT_CAPABILITY_DUPLICATE({ id: capability.id })
     }
     explicitById.set(capability.id, capability)
   }
@@ -264,7 +265,7 @@ export async function resolveAgentCapabilityDefinitions<
       accessMetadata?.chat === true ? "chat access" : undefined,
     ].filter((value): value is string => Boolean(value))
     if (unsupported.length) {
-      throw new Error(`[vitehub] Invocation-resolved Capability "${capability.id}" cannot contribute ${unsupported.join(", ")}. Attach definition-time behavior in a static capabilities array.`)
+      throw agentDiagnostics.AGENT_CAPABILITY_DYNAMIC_UNSUPPORTED({ id: capability.id, unsupported })
     }
   }
 

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -94,7 +94,7 @@ import {
   withResponseCleanup,
 } from "./capability-runtime.ts"
 import type { AgentCapabilityRegistries, CapabilityCleanupOutcome, ResolvedAgentFinishExtensionProvider, ResolvedAgentOutputExtensionProvider } from "./capability-runtime.ts"
-import { formatUnknownAgentMessage } from "./registry-error.ts"
+import { agentDiagnostics } from "./agent-diagnostics.ts"
 import { cancellableAsyncIterableSource, createAgentUIMessageStreamResponse, finalizeUiMessageStreamOutput, isUIMessageStreamResponse, isUIMessageStreamResult, normalizeUiMessageStream, uiMessageStreamFromResponse, uiMessageTextDelta, withReadableStreamCleanup } from "./stream-output.ts"
 import {
   applyAgentToolPolicies,
@@ -2228,7 +2228,7 @@ export async function resolveAgent<TContext extends AgentRuntimeContext>(
     return await agent.resolve(context as never)
   }
 
-  throw new TypeError("[vitehub] Invalid agent definition.")
+  throw agentDiagnostics.AGENT_DEFINITION_INVALID()
 }
 
 async function resolveAgentForRun<
@@ -2254,12 +2254,12 @@ export async function getAgentFromRegistry<TContext extends AgentRuntimeContext>
 ): Promise<AgentInput<TContext>> {
   const loader = registry[name]
   if (!loader) {
-    throw new Error(formatUnknownAgentMessage(name, Object.keys(registry).sort(), { prefix: true }))
+    throw agentDiagnostics.AGENT_NOT_FOUND({ name, available: Object.keys(registry).sort() })
   }
 
   const agent = resolveRegistryModule(await loader())
   if (!agent) {
-    throw new Error(`[vitehub] Agent "${name}" did not export a valid default agent.`)
+    throw agentDiagnostics.AGENT_EXPORT_INVALID({ name })
   }
 
   return agent

--- a/packages/agent/src/provider-agent.ts
+++ b/packages/agent/src/provider-agent.ts
@@ -7,7 +7,7 @@ import { createServer } from "node:http"
 import { hostname, tmpdir } from "node:os"
 import { basename, dirname, extname, join, relative, resolve } from "node:path"
 
-import { getViteHubErrorShape, normalizeExecutionAuthority, resolveRuntimeValue, ViteHubError } from "@vite-hub/runtime"
+import { formatRuntimeDiagnosticError, getViteHubErrorShape, normalizeExecutionAuthority, resolveRuntimeValue, ViteHubError } from "@vite-hub/runtime"
 import { resolveWorkspaceAutoCommit } from "@vite-hub/workspace"
 import { createProviderRuntime, createSqliteProviderRuntimeSessionStore } from "@t3tools/provider-runtime"
 
@@ -1160,6 +1160,7 @@ async function startToolServer(
         return toolResult(await tool.execute(input, { abortSignal: executionSignal }))
       }
       catch (error) {
+        let toolError = error
         const shape = getViteHubErrorShape(error)
         const approvalRequest = shape?.code === "APPROVAL_REQUIRED" && error instanceof Error && error.cause && hasRuntimeType(error.cause, "object")
           // SAFETY: Provider driver normalization establishes the asserted provider runtime contract.
@@ -1204,11 +1205,17 @@ async function startToolServer(
             const approve = (tool as AgentToolDefinition & { [agentToolPolicyApproveSymbol]?: (input: unknown) => void })[agentToolPolicyApproveSymbol]
             if (approve) {
               approve(approvalRequest.input)
-              return toolResult(await tool.execute!(approvalRequest.input, { abortSignal: executionSignal }))
+              try {
+                return toolResult(await tool.execute!(approvalRequest.input, { abortSignal: executionSignal }))
+              }
+              catch (approvedError) {
+                if (executionSignal.aborted) throw approvedError
+                toolError = approvedError
+              }
             }
           }
         }
-        return { content: [{ text: error instanceof Error ? error.message : String(error), type: "text" }], isError: true }
+        return { content: [{ text: formatRuntimeDiagnosticError(toolError), type: "text" }], isError: true }
       }
     })()
     activeExecutions.add(execution)

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -47,6 +47,7 @@ function withToolPolicy(tool: AgentToolDefinition): AgentToolDefinition {
   const policy = tool.policy
   const approvedInputs = new Set<unknown>()
 
+  // SAFETY: The wrapper preserves the tool fields and execute signature, and adds an internal approval symbol.
   return {
     ...tool,
     [agentToolPolicyApproveSymbol](input: unknown) {
@@ -187,6 +188,7 @@ export function withAgentToolStepReporting<TTools extends AgentToolSet>(tools: T
     return tools
   }
 
+  // SAFETY: Every tool key and field is preserved; execute forwards its arguments and returns the original output.
   return Object.fromEntries(Object.entries(tools).map(([name, tool]) => {
     if (!tool || typeof tool !== "object" || typeof (tool as { execute?: unknown }).execute !== "function") {
       return [name, tool]

--- a/packages/agent/src/tool-runtime.ts
+++ b/packages/agent/src/tool-runtime.ts
@@ -1,4 +1,6 @@
+import { agentDiagnostics } from "./agent-diagnostics.ts"
 import {
+  formatRuntimeDiagnosticError,
   resolveCapabilityPolicy,
   ViteHubError,
 } from "@vite-hub/runtime"
@@ -81,7 +83,7 @@ function withToolPolicy(tool: AgentToolDefinition): AgentToolDefinition {
         })
       }
       if (decision === "retryable-failure") {
-        throw new Error(`[vitehub:agent] Tool "${tool.name}" failed with a retryable policy decision.`)
+        throw agentDiagnostics.AGENT_TOOL_POLICY_RETRYABLE({ name: tool.name })
       }
 
       context?.abortSignal?.throwIfAborted()
@@ -133,10 +135,6 @@ function toolCallIdFromExecutionOptions(value: unknown): string | undefined {
   return typeof toolCallId === "string" && toolCallId ? toolCallId : undefined
 }
 
-function getErrorOutput(error: unknown): string {
-  return error instanceof Error ? error.message : String(error)
-}
-
 function materializeSummary(output: unknown): unknown {
   if (!output || typeof output !== "object") return output
   const result = output as {
@@ -180,7 +178,7 @@ export async function reportWorkspaceMaterialization(
     await reportToolStep?.({ toolResults: [{ ...toolCall, output: materializeSummary(output) }] })
   }
   catch (error) {
-    await reportToolStep?.({ toolErrors: [{ ...toolCall, output: getErrorOutput(error) }] })
+    await reportToolStep?.({ toolErrors: [{ ...toolCall, output: formatRuntimeDiagnosticError(error) }] })
   }
 }
 
@@ -216,7 +214,7 @@ export function withAgentToolStepReporting<TTools extends AgentToolSet>(tools: T
           return output
         }
         catch (error) {
-          await reportToolStep({ toolErrors: [{ ...toolCall, output: getErrorOutput(error) }] })
+          await reportToolStep({ toolErrors: [{ ...toolCall, output: formatRuntimeDiagnosticError(error) }] })
           throw error
         }
       },

--- a/packages/agent/test/agent-diagnostics.test.ts
+++ b/packages/agent/test/agent-diagnostics.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest"
+import { Diagnostic } from "nostics"
+import { formatRuntimeDiagnosticError } from "@vite-hub/runtime"
+
+import { defineCapability, normalizeCapabilities } from "../src/capability-runtime.ts"
+import { getAgentFromRegistry } from "../src/index.ts"
+import { formatAgentError, toAgentPublicError } from "../src/agent-error.ts"
+import { withAgentToolStepReporting } from "../src/tool-runtime.ts"
+
+describe("Agent diagnostics", () => {
+  it("reports a duplicate Capability with a code and a fix without logging", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {})
+    const error = vi.spyOn(console, "error").mockImplementation(() => {})
+    try {
+      const capability = defineCapability({ id: "search" })
+      expect(() => normalizeCapabilities([capability, capability])).toThrowError(expect.objectContaining({
+        code: "AGENT_CAPABILITY_DUPLICATE",
+        fix: "Remove the duplicate Capability or give each Capability a unique id.",
+      }))
+      expect(warn).not.toHaveBeenCalled()
+      expect(error).not.toHaveBeenCalled()
+    }
+    finally {
+      warn.mockRestore()
+      error.mockRestore()
+    }
+  })
+
+  it("keeps registry suggestions and supplies a repair instruction", async () => {
+    await expect(getAgentFromRegistry("triage", { triager: () => ({}) })).rejects.toMatchObject({
+      code: "AGENT_NOT_FOUND",
+      message: expect.stringContaining('Did you mean "triager"?'),
+      fix: expect.stringContaining("Use a discovered Agent name"),
+    })
+    await expect(getAgentFromRegistry("triager", { triager: () => ({ default: undefined }) })).rejects.toMatchObject({
+      code: "AGENT_EXPORT_INVALID",
+      fix: expect.stringContaining("default export"),
+    })
+  })
+
+  it("preserves tool diagnostic guidance and the original failure", async () => {
+    const failure = new Diagnostic({
+      cause: new Error("private provider response"),
+      code: "SEARCH_INDEX_MISSING",
+      docs: "https://example.com/search",
+      fix: "Create the search index before searching.",
+      sources: ["server/agents/search.ts:8:3"],
+      why: "Search index is missing.",
+    })
+    const reporter = vi.fn()
+    const tools = withAgentToolStepReporting({
+      search: { name: "search", execute() { throw failure } },
+    }, reporter)
+
+    await expect(tools.search.execute()).rejects.toBe(failure)
+    const text = formatRuntimeDiagnosticError(failure)
+    expect(reporter).toHaveBeenLastCalledWith({ toolErrors: [expect.objectContaining({ output: text })] })
+    expect(text).toContain("SEARCH_INDEX_MISSING")
+    expect(text).toContain("Create the search index")
+    expect(text).not.toContain("private provider response")
+    expect(formatAgentError(JSON.parse(JSON.stringify(failure)))).toBe(text)
+    expect(toAgentPublicError(failure, "http")).toEqual({ code: "INTERNAL", error: "Agent request failed." })
+  })
+
+  it("keeps cancellation errors unchanged in tool reporting", async () => {
+    const failure = new DOMException("Cancelled", "AbortError")
+    const tools = withAgentToolStepReporting({
+      search: { name: "search", execute() { throw failure } },
+    }, vi.fn())
+    await expect(tools.search.execute()).rejects.toBe(failure)
+  })
+})

--- a/packages/agent/test/ai-sdk-recovery.test.ts
+++ b/packages/agent/test/ai-sdk-recovery.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from "vitest"
+import { defineDiagnostics } from "nostics"
+import { normalizeRuntimeDiagnosticError } from "@vite-hub/runtime"
 
-import { defineAgent, defineCapability, runAgentInline } from "../src/index.ts"
+import { defineAgent, defineCapability, runAgentInline, streamAgentInline } from "../src/index.ts"
 import { hasRuntimeType, isRuntimeRecord } from "../src/internal/runtime-type.ts"
+import { isAsyncIterable } from "../src/internal/stream-result.ts"
 
 const outputSchema = {
   "~standard": {
@@ -46,8 +49,25 @@ function model(responses: ModelResponse[]) {
         warnings: [],
       }
     },
-    async doStream() {
-      throw new Error("Unexpected streaming model call")
+    async doStream(options: ModelOptions) {
+      const result = await this.doGenerate(options)
+      return {
+        stream: new ReadableStream({
+          start(controller) {
+            controller.enqueue({ type: "stream-start", warnings: [] })
+            for (const part of result.content) {
+              if (part.type === "text") {
+                controller.enqueue({ type: "text-start", id: "text-1" })
+                controller.enqueue({ type: "text-delta", id: "text-1", delta: part.text })
+                controller.enqueue({ type: "text-end", id: "text-1" })
+              }
+              else controller.enqueue(part)
+            }
+            controller.enqueue({ type: "finish", finishReason: result.finishReason, usage: result.usage })
+            controller.close()
+          },
+        }),
+      }
     },
     modelId: "vitehub-recovery-test",
     provider: "test",
@@ -115,6 +135,51 @@ function toolCallingAgent(fakeModel: ReturnType<typeof model>, execute: (input: 
 }
 
 describe("AI SDK recovery", () => {
+  it.each(["instance", "serialized", "normalized"].flatMap(form => ["generate", "stream"].map(mode => ({ form, mode }))))("includes $form diagnostic guidance in the next $mode model call", async ({ form, mode }) => {
+    const diagnostics = defineDiagnostics({
+      codes: {
+        SEARCH_INDEX_MISSING: {
+          why: "Search index is missing.",
+          fix: "Create the search index before searching.",
+          docs: "https://example.com/search",
+        },
+      },
+    })
+    const fakeModel = model([
+      [{ input: '{"query":"vitehub"}', toolCallId: "call-1", toolName: "search", type: "tool-call" }],
+      async (options) => {
+        const prompt = JSON.stringify(options.prompt)
+        expect(prompt).toContain("SEARCH_INDEX_MISSING")
+        expect(prompt).toContain("Create the search index before searching.")
+        expect(prompt).toContain("https://example.com/search")
+        expect(prompt).not.toContain("private provider response")
+        expect(prompt).not.toContain("private stack")
+        return "Create the search index first."
+      },
+    ])
+    const failure = diagnostics.SEARCH_INDEX_MISSING({ cause: { token: "private provider response" } })
+    failure.stack = "private stack"
+    const thrown: unknown = form === "serialized"
+      ? JSON.parse(JSON.stringify(failure))
+      : form === "normalized"
+        ? normalizeRuntimeDiagnosticError(failure, { includeStack: true })
+        : failure
+    const agent = toolCallingAgent(fakeModel, () => { throw thrown })
+    if (mode === "stream") {
+      const result = await streamAgentInline(agent, runtime, { prompt: "Search" })
+      if (!isAsyncIterable(result)) throw new TypeError("Expected an Agent event stream")
+      const events: unknown[] = []
+      for await (const event of result) events.push(event)
+      expect(JSON.stringify(events)).toContain("Create the search index first.")
+    }
+    else {
+      const result = textResult(await runAgentInline(agent, runtime, { prompt: "Search" }))
+      expect(result.text).toBe("Create the search index first.")
+    }
+    expect(fakeModel.calls).toHaveLength(2)
+    expect(failure.message).toBe("Search index is missing.")
+  })
+
   it("repairs structured output with three total attempts by default", async () => {
     const fakeModel = model(["{\"text\":1}", "{\"text\":2}", "{\"text\":\"repaired\"}"])
     const agent = defineAgent({

--- a/packages/agent/test/provider-agent.test.ts
+++ b/packages/agent/test/provider-agent.test.ts
@@ -6,6 +6,7 @@ import { hostname, tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 
 import { describe, expect, it, vi } from "vitest"
+import { Diagnostic } from "nostics"
 import { Client as McpClient } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { createTraceEventLog, getViteHubErrorShape, traceEventsToOpenTelemetrySpans } from "@vite-hub/runtime"
@@ -2825,6 +2826,47 @@ cli_auth_credentials_store = "keyring"
     expect(execute).toHaveBeenCalledWith({ query: "vitehub" }, expect.objectContaining({ abortSignal: expect.any(AbortSignal) }))
   })
 
+  it.each(["codex", "claude-code"] as const)("returns diagnostic guidance through %s Capability tools", async (provider) => {
+    const failure = new Diagnostic({
+      cause: new Error("private provider response"),
+      code: "SEARCH_INDEX_MISSING",
+      fix: "Create the search index before searching.",
+      why: "Search index is missing.",
+    })
+    runtime("thread-diagnostic", [event("turn.completed", "thread-diagnostic", { state: "completed" }, { turnId: "turn-1" })], {
+      async onSendTurn(mcp) {
+        const client = new McpClient({ name: "provider-test", version: "1" })
+        const transport = new StreamableHTTPClientTransport(new URL(mcp!.endpoint), {
+          requestInit: { headers: { Authorization: mcp!.authorizationHeader } },
+        })
+        await client.connect(transport)
+        try {
+          const result = await client.callTool({ arguments: {}, name: "search" })
+          expect(result).toMatchObject({
+            content: [{ text: expect.stringContaining("SEARCH_INDEX_MISSING"), type: "text" }],
+            isError: true,
+          })
+          expect(JSON.stringify(result)).toContain("Create the search index before searching.")
+          expect(JSON.stringify(result)).not.toContain("private provider response")
+        }
+        finally {
+          await client.close()
+        }
+      },
+    })
+    const adapter = createProviderAgentAdapter({ provider })
+    // SAFETY: This fixture supplies the runtime context exercised by the provider adapter.
+    await adapter.generate(context("thread-diagnostic", {
+      tools: {
+        search: {
+          execute() { throw failure },
+          inputSchema: { type: "object", properties: {} },
+          name: "search",
+        },
+      },
+    }) as never)
+  })
+
   it("publishes Capability approval requests raised through MCP", async () => {
     let toolCall!: Promise<unknown>
     // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
@@ -2874,6 +2916,55 @@ cli_auth_credentials_store = "keyring"
     ])).resolves.toEqual(["accepted", "unsupported"])
     await expect(toolCall).resolves.toMatchObject({ content: [{ text: "null", type: "text" }] })
     expect(reportToolStep).toHaveBeenCalledWith(expect.objectContaining({ toolResults: [expect.objectContaining({ output: null })] }))
+    await expect(stream.next()).resolves.toMatchObject({ value: { type: "finish" } })
+  })
+
+  it.each(["codex", "claude-code"] as const)("returns diagnostic guidance when an approved %s Capability tool fails", async (provider) => {
+    let toolCall!: Promise<unknown>
+    const failure = new Diagnostic({
+      code: "EMAIL_PROVIDER_UNAVAILABLE",
+      docs: "https://example.com/email",
+      fix: "Retry when the email provider is available.",
+      why: "The email provider is unavailable.",
+      cause: { message: "private provider response" },
+    })
+    const execute = vi.fn(async () => { throw failure })
+    const policy = vi.fn(() => "require-approval" as const)
+    runtime("thread-approved-diagnostic", [event("turn.completed", "thread-approved-diagnostic", { state: "completed" }, { turnId: "turn-1" })], {
+      async onSendTurn(mcp) {
+        const client = new McpClient({ name: "provider-test", version: "1" })
+        const transport = new StreamableHTTPClientTransport(new URL(mcp!.endpoint), {
+          requestInit: { headers: { Authorization: mcp!.authorizationHeader } },
+        })
+        await client.connect(transport)
+        toolCall = client.callTool({ arguments: {}, name: "email_send" }).finally(() => client.close())
+        await vi.waitFor(() => expect(policy).toHaveBeenCalledOnce())
+      },
+    })
+    const tools = applyAgentToolPolicies({ email_send: { execute, name: "email_send", policy } })!
+    const invocationId = "run-thread-approved-diagnostic"
+    const approvalContext = context("thread-approved-diagnostic", { tools })
+    approvalContext.runtime = withAgentInvocationResponseOwner(approvalContext.runtime, invocationId)
+    // SAFETY: This fixture supplies the runtime context exercised by the provider adapter.
+    const output = createProviderAgentAdapter({ provider }).stream!(approvalContext as never) as AsyncIterable<unknown>
+    const stream = output[Symbol.asyncIterator]()
+    const approval = await stream.next()
+    expect(approval.value).toMatchObject({ name: "email_send", type: "approval-request" })
+    expect(execute).not.toHaveBeenCalled()
+    // SAFETY: The preceding assertion checks the emitted approval request.
+    const approvalId = (approval.value as { id: string }).id
+    await expect(sendAgentInvocationInput(invocationId, {
+      messages: [{ id: "approval", parts: [{ approved: true, id: approvalId, type: "approval-decision" }], role: "user" }],
+    }, { mode: "respond" })).resolves.toBe("accepted")
+    const result = await toolCall
+    expect(result).toMatchObject({
+      content: [{ text: expect.stringContaining("EMAIL_PROVIDER_UNAVAILABLE"), type: "text" }],
+      isError: true,
+    })
+    expect(JSON.stringify(result)).toContain("Retry when the email provider is available.")
+    expect(JSON.stringify(result)).toContain("https://example.com/email")
+    expect(JSON.stringify(result)).not.toContain("private provider response")
+    expect(execute).toHaveBeenCalledOnce()
     await expect(stream.next()).resolves.toMatchObject({ value: { type: "finish" } })
   })
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -74,6 +74,11 @@ process.exitCode = exitCode;
 
 `runViteHubCli()` returns `0` for successful commands and help, or a non-zero code when a command reports failure. It rejects if config loading or a contributor throws. Pass custom `stdout`, `stderr`, `env`, or `spawn` implementations only when the host needs to capture output or control subprocesses.
 
+The binary catches these failures, writes them to stderr, and exits with code
+`1`. Nostics errors include the diagnostic code, message, fix, source locations,
+and documentation link when present. Causes and stacks are omitted. Plain errors
+print their message. Error output is bounded by Runtime's diagnostic limits.
+
 ## Limits and safety
 
 - Root and namespace help is human-readable text, not a structured output contract.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
     "test": "vp run -t @vite-hub/cli#build && vp test"
   },
   "dependencies": {
+    "@vite-hub/runtime": "workspace:*",
     "pathe": "catalog:unjs"
   },
   "devDependencies": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import process from "node:process"
 import { fileURLToPath } from "node:url"
 
 import { collectViteHubCliNamespaces, collectViteHubProvisionSteps } from "@vite-hub/internal/cli"
+import { formatRuntimeDiagnosticError } from "@vite-hub/runtime"
 import { resolve } from "pathe"
 
 import { runProvision } from "./provision.ts"
@@ -307,7 +308,7 @@ export function runViteHubCliEntrypoint(options: RunViteHubCliEntrypointOptions 
     }
     catch (error: unknown) {
       try {
-        stderr.stream.write(`${error instanceof Error ? error.message : error}\n`)
+        stderr.stream.write(`${formatRuntimeDiagnosticError(error)}\n`)
       }
       catch {}
       exitCode = 1

--- a/packages/cli/test/cli.test.ts
+++ b/packages/cli/test/cli.test.ts
@@ -50,6 +50,45 @@ function stream() {
 }
 
 describe("ViteHub CLI", () => {
+  it.each([
+    {
+      error: new Error("Config load failed"),
+      expected: ["Config load failed\n"],
+    },
+    {
+      error: {
+        cause: new Error("Private provider failure"),
+        docs: "https://vitehub.dev/docs/agent",
+        fix: "Set a model in the Agent Definition.",
+        name: "AGENT_MODEL_NOT_FOUND",
+        sources: ["agents/support.ts:4:2"],
+        stack: "Private stack",
+        why: "The Agent has no model.",
+      },
+      expected: [
+        "[AGENT_MODEL_NOT_FOUND] The Agent has no model.",
+        "Set a model in the Agent Definition.",
+        "agents/support.ts:4:2",
+        "https://vitehub.dev/docs/agent",
+      ],
+    },
+  ])("prints caught failures to stderr and exits with 1 ($error.name)", async ({ error, expected }) => {
+    const stderr = stream()
+    const stdout = stream()
+    // SAFETY: The mock deliberately returns so tests can observe the requested exit status.
+    const exit = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never)
+    runViteHubCliEntrypoint({
+      args: ["agent", "info"],
+      loadConfig: async () => { throw error },
+      stderr,
+      stdout,
+    })
+    await vi.waitFor(() => expect(exit).toHaveBeenCalledWith(1))
+    for (const text of expected) expect(stderr.output()).toContain(text)
+    expect(stderr.output()).not.toContain("Private")
+    expect(stdout.output()).toBe("")
+  })
+
   it.each(["--version", "-v"])("prints the packaged version for %s without loading project config", async (flag) => {
     const stdout = stream()
     const stderr = stream()

--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -143,6 +143,22 @@ details. Never put secrets in those fields; keep raw provider failures in `cause
 A `cause` is excluded from `toJSON()`, but remains available to code and loggers
 that inspect the Error instance.
 
+### Developer diagnostics
+
+`normalizeRuntimeDiagnosticError(error)` creates a bounded diagnostic record. It
+preserves Nostics codes, fixes, documentation links, and source locations from
+Error instances and JSON records. Causes, aggregate errors, details, and source
+locations share a node budget. All strings share a size budget. Stacks require
+`{ includeStack: true }`.
+
+Use `formatRuntimeDiagnosticError(error)` for terminal output or Agent tool error
+text. It prints the code, message, fix, source locations, and documentation link
+with Nostics formatting. It omits causes and stacks. Plain errors return their
+message. Both helpers accept `unknown` and handle failed property reads.
+
+These helpers produce developer diagnostics. They do not make arbitrary errors
+safe for public responses. Use the `ViteHubError` public contract at that boundary.
+
 ## Public entry points
 
 | Import                   | Provides                                                                                             |

--- a/packages/runtime/fixtures/published-types/consumer.ts
+++ b/packages/runtime/fixtures/published-types/consumer.ts
@@ -1,5 +1,7 @@
 import {
   createExecutionContext,
+  formatRuntimeDiagnosticError,
+  normalizeRuntimeDiagnosticError,
   ViteHubError,
   type ExecutionContext,
   type RuntimeCapabilities,
@@ -7,6 +9,11 @@ import {
 } from "@vite-hub/runtime"
 
 type RuntimeExports = typeof import("@vite-hub/runtime")
+const diagnostic = normalizeRuntimeDiagnosticError({ name: "SEARCH_FAILED", why: "Search failed.", fix: "Retry the search." })
+diagnostic.fix satisfies string | undefined
+diagnostic.docs satisfies string | undefined
+diagnostic.sources satisfies readonly string[] | undefined
+formatRuntimeDiagnosticError(diagnostic) satisfies string
 const hasNoResolveExecutionContext: "resolveExecutionContext" extends keyof RuntimeExports ? false : true = true
 const hasNoResolveRuntimeContext: "resolveRuntimeContext" extends keyof RuntimeExports ? false : true = true
 

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -41,6 +41,9 @@
     "typecheck": "tsc --noEmit -p ./tsconfig.json",
     "test": "vp run -t @vite-hub/runtime#build && vp test"
   },
+  "dependencies": {
+    "nostics": "catalog:runtime"
+  },
   "devDependencies": {
     "@types/node": "catalog:tooling",
     "publint": "catalog:tooling",

--- a/packages/runtime/src/diagnostics.ts
+++ b/packages/runtime/src/diagnostics.ts
@@ -1,3 +1,5 @@
+import { Diagnostic, formatDiagnostic } from "nostics"
+
 import { hasRuntimeType, isRuntimeObject } from "./internal/runtime-type.ts"
 import { getViteHubErrorShape } from "./errors.ts"
 
@@ -11,10 +13,13 @@ export interface RuntimeDiagnosticError {
   cause?: RuntimeDiagnosticError
   code?: number | string
   details?: Readonly<Record<string, unknown>>
+  docs?: string
   errors?: readonly RuntimeDiagnosticError[]
+  fix?: string
   message: string
   name?: string
   requestId?: string
+  sources?: readonly string[]
   stack?: string
   status?: number | string
   statusCode?: number | string
@@ -176,7 +181,9 @@ function normalizeError(value: unknown, state: ErrorNormalizationState, depth: n
   state.ancestors.add(value)
   try {
     const publicError = getViteHubErrorShape(value)
+    const why = readProperty(value, "why")
     const message = boundedString(readProperty(value, "message"), state)
+      || boundedString(why, state)
       || boundedString(safeString(value), state)
       || "Error"
     const name = boundedString(readProperty(value, "name"), state)
@@ -186,12 +193,18 @@ function normalizeError(value: unknown, state: ErrorNormalizationState, depth: n
       message,
       ...(name ? { name } : {}),
     }
-    const code = publicError?.code ? boundedString(publicError.code, state) : scalarProperty(value, "code", state)
+    const code = publicError?.code
+      ? boundedString(publicError.code, state)
+      : scalarProperty(value, "code", state) ?? (hasRuntimeType(why, "string") ? boundedString(name, state) : undefined)
+    const fix = boundedString(readProperty(value, "fix"), state)
+    const docs = boundedString(readProperty(value, "docs"), state)
     const requestId = publicError?.requestId ? boundedString(publicError.requestId, state) : boundedString(readProperty(value, "requestId"), state)
     const status = scalarProperty(value, "status", state)
     const statusCode = scalarProperty(value, "statusCode", state)
     const stack = state.includeStack ? boundedString(readProperty(value, "stack"), state) : undefined
     if (code !== undefined) result.code = code
+    if (fix) result.fix = fix
+    if (docs) result.docs = docs
     if (requestId) result.requestId = requestId
     if (stack) result.stack = stack
     if (status !== undefined) result.status = status
@@ -208,11 +221,32 @@ function normalizeError(value: unknown, state: ErrorNormalizationState, depth: n
     if (normalizedErrors?.length) result.errors = normalizedErrors
     const details = publicError?.details ? normalizeDetails(publicError.details, state, depth + 1) : undefined
     if (details) result.details = details
+    const sources = errorChildren(readProperty(value, "sources"), state.remainingNodes)?.flatMap((source) => {
+      state.remainingNodes -= 1
+      const normalized = boundedString(source, state)
+      return normalized ? [normalized] : []
+    })
+    if (sources?.length) result.sources = sources
     return result
   }
   finally {
     state.ancestors.delete(value)
   }
+}
+
+/** Formats bounded developer diagnostics without exposing causes or stacks. */
+export function formatRuntimeDiagnosticError(error: unknown): string {
+  const normalized = normalizeRuntimeDiagnosticError(error)
+  if (normalized.code === undefined && !normalized.fix && !normalized.docs && !normalized.sources?.length) {
+    return normalized.message
+  }
+  return formatDiagnostic(new Diagnostic({
+    code: normalized.code === undefined ? normalized.name || "Error" : String(normalized.code),
+    docs: normalized.docs,
+    fix: normalized.fix,
+    sources: normalized.sources ? [...normalized.sources] : undefined,
+    why: normalized.message,
+  }))
 }
 
 export function normalizeRuntimeDiagnosticError(

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -2,6 +2,7 @@ import { hasRuntimeType, isRuntimeObject } from "./internal/runtime-type.ts"
 import { ViteHubError } from "./errors.ts"
 
 export {
+  formatRuntimeDiagnosticError,
   normalizeRuntimeDiagnosticError,
   type RuntimeDiagnosticError,
   type RuntimeDiagnosticErrorOptions,

--- a/packages/runtime/test/diagnostic-errors.test.ts
+++ b/packages/runtime/test/diagnostic-errors.test.ts
@@ -1,9 +1,105 @@
 import { asUnknownBoundary, hasRuntimeType } from "../src/internal/runtime-type.ts"
 import { describe, expect, it } from "vitest"
+import { Diagnostic } from "nostics"
 
-import { normalizeRuntimeDiagnosticError, ViteHubError } from "../src/index.ts"
+import { formatRuntimeDiagnosticError, getViteHubErrorShape, normalizeRuntimeDiagnosticError, ViteHubError } from "../src/index.ts"
 
 describe("Runtime diagnostic errors", () => {
+  it("preserves Nostics metadata on instances and JSON records without making them public errors", () => {
+    const diagnostic = new Diagnostic({
+      cause: new Error("Provider failure"),
+      code: "AGENT_MODEL_NOT_FOUND",
+      docs: "https://vitehub.dev/docs/agent",
+      fix: "Set the model in the Agent Definition.",
+      sources: ["agents/support.ts:4:2"],
+      why: "The Agent has no model.",
+    })
+    const serialized: unknown = JSON.parse(JSON.stringify(diagnostic))
+    for (const error of [diagnostic, serialized]) {
+      const normalized = normalizeRuntimeDiagnosticError(error)
+      expect(normalized).toMatchObject({
+        code: "AGENT_MODEL_NOT_FOUND",
+        docs: "https://vitehub.dev/docs/agent",
+        fix: "Set the model in the Agent Definition.",
+        message: "The Agent has no model.",
+        name: "AGENT_MODEL_NOT_FOUND",
+        sources: ["agents/support.ts:4:2"],
+      })
+      expect(normalized.stack).toBeUndefined()
+      expect(getViteHubErrorShape(error)).toBeUndefined()
+      expect(normalizeRuntimeDiagnosticError(JSON.parse(JSON.stringify(normalized)))).toMatchObject({
+        code: normalized.code,
+        docs: normalized.docs,
+        fix: normalized.fix,
+        message: normalized.message,
+        sources: normalized.sources,
+      })
+    }
+  })
+
+  it("formats diagnostics across package copies and transport without causes or stacks", () => {
+    const record = {
+      cause: new Error("Private provider failure"),
+      docs: "https://vitehub.dev/docs/agent",
+      fix: "Set a model.",
+      name: "AGENT_MODEL_NOT_FOUND",
+      sources: ["agents/support.ts:4:2"],
+      stack: "Private stack",
+      why: "The Agent has no model.",
+    }
+    const expected = [
+      "[AGENT_MODEL_NOT_FOUND] The Agent has no model.",
+      "Set a model.",
+      "agents/support.ts:4:2",
+      "https://vitehub.dev/docs/agent",
+    ]
+    for (const error of [record, normalizeRuntimeDiagnosticError(record)]) {
+      const output = formatRuntimeDiagnosticError(error)
+      for (const text of expected) expect(output).toContain(text)
+      expect(output).not.toContain("Private")
+    }
+    expect(formatRuntimeDiagnosticError(new Error("Plain failure"))).toBe("Plain failure")
+    expect(formatRuntimeDiagnosticError("Plain failure")).toBe("Plain failure")
+    expect(formatRuntimeDiagnosticError(new ViteHubError("FAILED", "Operation failed"))).toBe("[FAILED] Operation failed")
+  })
+
+  it.each(["instance", "serialized"])("bounds %s diagnostic metadata with the shared string and node budgets", (form) => {
+    const diagnostic = {
+      ...(form === "instance" ? { code: "FAILED", message: "Failed" } : { name: "FAILED", why: "Failed" }),
+      docs: "d".repeat(10_000),
+      fix: "f".repeat(10_000),
+      sources: Array.from({ length: 10_000 }, () => "s".repeat(100)),
+    }
+    const normalized = normalizeRuntimeDiagnosticError(diagnostic, { maxErrors: 3, maxStringLength: 64 })
+    expect(normalized.docs?.length).toBeLessThanOrEqual(64)
+    expect(normalized.fix?.length).toBeLessThanOrEqual(64)
+    expect(normalized.sources?.length).toBeLessThanOrEqual(3)
+    const strings = [normalized.message, normalized.name, normalized.code, normalized.docs, normalized.fix, ...(normalized.sources || [])]
+    const total = strings.reduce<number>((sum, value) => sum + (hasRuntimeType(value, "string") ? value.length : 0), 0)
+    expect(total).toBeLessThanOrEqual(64 * 4)
+  })
+
+  it("ignores hostile and cyclic diagnostic metadata", () => {
+    const sources: unknown[] = ["agents/support.ts:4:2"]
+    sources.push(sources)
+    Object.defineProperty(sources, "2", { get() { throw new Error("blocked source") } })
+    const record = {
+      get docs() { throw new Error("blocked docs") },
+      get fix() { throw new Error("blocked fix") },
+      name: "FAILED",
+      sources,
+      why: "Operation failed",
+    }
+    expect(normalizeRuntimeDiagnosticError(record)).toEqual({
+      code: "FAILED",
+      message: "Operation failed",
+      name: "FAILED",
+      sources: ["agents/support.ts:4:2"],
+    })
+    const hostileSources = new Proxy([], { get() { throw new Error("blocked sources") } })
+    expect(formatRuntimeDiagnosticError({ name: "FAILED", sources: hostileSources, why: "Operation failed" })).toBe("[FAILED] Operation failed")
+  })
+
   it("normalizes causes, AggregateError children, codes, cycles, and budgets", () => {
     const cause = Object.assign(new Error("Git authentication failed"), { code: "EAUTH" })
     const checkout = new Error("Checkout failed", { cause })

--- a/packages/runtime/test/published-runtime.test.ts
+++ b/packages/runtime/test/published-runtime.test.ts
@@ -1,9 +1,24 @@
 import { describe, expect, it } from "vitest"
 
 const distEntry = new URL("../dist/index.js", import.meta.url)
-const { ViteHubError } = await import(distEntry.href)
+const { formatRuntimeDiagnosticError, normalizeRuntimeDiagnosticError, ViteHubError } = await import(distEntry.href)
 
 describe("published ViteHubError runtime", () => {
+  it("exports diagnostic normalization and formatting for transported errors", () => {
+    const record = normalizeRuntimeDiagnosticError({
+      name: "SEARCH_INDEX_MISSING",
+      why: "Search index is missing.",
+      fix: "Create the search index.",
+      cause: { token: "private provider response" },
+      stack: "private stack",
+    })
+    expect(record).toMatchObject({ code: "SEARCH_INDEX_MISSING", fix: "Create the search index." })
+    const text = formatRuntimeDiagnosticError(record)
+    expect(text).toContain("[SEARCH_INDEX_MISSING] Search index is missing.")
+    expect(text).toContain("fix: Create the search index.")
+    expect(text).not.toContain("private")
+  })
+
   it("keeps its construction-time public shape after source and instance mutation", () => {
     const cause = new Error("private provider cause")
     const details = { nested: { provider: "fixture" } }

--- a/packages/runtime/test/published-types.test.ts
+++ b/packages/runtime/test/published-types.test.ts
@@ -37,16 +37,11 @@ beforeAll(async () => {
   consumerRoot = await mkdtemp(join(tmpdir(), "vitehub-runtime-types-"))
   await cp(fixtureRoot, consumerRoot, { recursive: true })
   await syncPackedWorkspaceDependencies(consumerRoot, workspaceRoot, ["@vite-hub/runtime"])
-  const packResults = await Promise.allSettled([runProcess("npm", [
+  await runProcess("pnpm", [
     "pack",
     "--pack-destination",
     consumerRoot,
-    "--ignore-scripts",
-    "--cache",
-    join(consumerRoot, ".npm-cache"),
-  ], packageRoot)])
-  const failedPack = packResults.find(result => result.status === "rejected")
-  if (failedPack) throw failedPack.reason
+  ], packageRoot)
   await runProcess("npm", [
     "install",
     "--ignore-scripts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ catalogs:
     devframe:
       specifier: 0.9.12
       version: 0.9.12
+    nostics:
+      specifier: 1.2.0
+      version: 1.2.0
     ocache:
       specifier: ^0.3.0
       version: 0.3.0
@@ -730,6 +733,9 @@ importers:
       esbuild:
         specifier: catalog:esbuild-v27
         version: 0.27.7
+      nostics:
+        specifier: catalog:runtime
+        version: 1.2.0
       valibot:
         specifier: catalog:runtime
         version: 1.4.2(typescript@6.0.3)
@@ -1090,6 +1096,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@vite-hub/runtime':
+        specifier: workspace:*
+        version: link:../runtime
       nuxt:
         specifier: catalog:nuxt-compat
         version: 4.5.2(29226aa5a191f88b4ee58c023848d627)
@@ -1648,6 +1657,10 @@ importers:
         version: 3.5.40(typescript@6.0.3)
 
   packages/runtime:
+    dependencies:
+      nostics:
+        specifier: catalog:runtime
+        version: 1.2.0
     devDependencies:
       '@types/node':
         specifier: catalog:tooling

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -81,6 +81,7 @@ catalogs:
   runtime:
     "@standard-schema/spec": ^1.1.0
     devframe: 0.9.12
+    nostics: 1.2.0
     ocache: ^0.3.0
     valibot: ^1.4.2
   sandbox:


### PR DESCRIPTION
Agent tool failures lost Nostics codes and repair instructions when the AI SDK and provider tool servers reduced them to `error.message`. Preserve that guidance in model tool results, MCP responses, tool reports, and CLI output, while keeping causes and stacks out of the formatted text.

Migrate 14 Agent lookup, Capability setup, and tool-policy errors to a package-owned Nostics catalog. Add bounded Runtime normalization and formatting for both Error instances and serialized diagnostics. Public HTTP error mapping remains unchanged. This PR focuses on Agent errors; it does not convert every error in the repository.

Verified generation and streaming, serialized errors, Codex and Claude Code MCP responses, approval followed by failure, cancellation, public error mapping, CLI stderr and exit status, and packed Runtime types. Focused tests, package builds with publint, and typechecks pass. Lint reports existing warnings. The provider suite passed all 171 tests on a standalone rerun after timeouts during concurrent checks. The full repository suite was not run.

Model: GPT-6. Harness: Codex.
