### PR TITLE
fix(console): preserve URL query parameters over RPC

### DIFF
--- a/packages/vite-hub/src/console/runtime/client/request.ts
+++ b/packages/vite-hub/src/console/runtime/client/request.ts
@@ -92,7 +92,12 @@ export async function requestConsole(
     signal?: AbortSignal
   } = {},
 ): Promise<unknown> {
+  const url = new URL(path, "http://vitehub.local")
   const query: Record<string, string | string[]> = {}
+  for (const key of new Set(url.searchParams.keys())) {
+    const values = url.searchParams.getAll(key)
+    query[key] = values.length === 1 ? values[0]! : values
+  }
   for (const [key, value] of Object.entries(options.query ?? {})) {
     if (value === undefined) continue
     query[key] = Array.isArray(value) ? value.map(String) : String(value)

--- a/packages/vite-hub/test/console-request.test.ts
+++ b/packages/vite-hub/test/console-request.test.ts
@@ -49,6 +49,40 @@ describe("Console requests", () => {
     })
   })
 
+  it("preserves URL query values and lets explicit options replace them", async () => {
+    mocks.call.mockResolvedValue({ ok: true, value: { invocations: [] } })
+
+    await expect(requestConsole(
+      "/api/_vitehub/console/invocations?id=old-1&id=old-2&agent=old&limit=10&status=old",
+      { query: { agent: ["selected"], limit: 20, status: [] } },
+    )).resolves.toEqual({ invocations: [] })
+    expect(mocks.call).toHaveBeenCalledWith(consoleRpcMethods.invocations, {
+      method: "GET",
+      query: {
+        agent: ["selected"],
+        id: ["old-1", "old-2"],
+        limit: "20",
+        status: [],
+      },
+    })
+  })
+
+  it("preserves invocation delta cursors from the URL", async () => {
+    mocks.call.mockResolvedValue({ ok: true, value: { observations: [] } })
+
+    await expect(requestConsole(
+      "/api/_vitehub/console/invocations/run-1?observationCount=100&observationCursor=cursor-100",
+    )).resolves.toEqual({ observations: [] })
+    expect(mocks.call).toHaveBeenCalledWith(consoleRpcMethods.invocation, {
+      id: "run-1",
+      method: "GET",
+      query: {
+        observationCount: "100",
+        observationCursor: "cursor-100",
+      },
+    })
+  })
+
   it("preserves remote status and retries only transient request failures", async () => {
     mocks.call.mockResolvedValue({ message: "Upstream unavailable.", ok: false, status: 502 })
 


### PR DESCRIPTION
Console Agent hooks put invocation filters, pagination cursors, summary IDs, and observation cursors in request URLs. The Devframe requester ignored those values, so RPC handlers received an empty query.

Parse URL query values before the RPC call, preserving repeated keys as arrays. Explicit request options keep precedence and their existing scalar or array shape.

The 13 Console request tests, the saved list/summary/detail query reproduction, and changed-file lint passed. The package typecheck could not complete because this isolated worktree lacks prerequisite workspace build outputs and generated `#vitehub/*` modules. No full workspace build was run for this request-adapter change.

Model: GPT-5.6 Sol
Harness: T3 Code / Codex
