### PR TITLE
fix(content): update package inventory and reference

### DIFF
--- a/docs/content/docs/reference/index.md
+++ b/docs/content/docs/reference/index.md
@@ -30,6 +30,7 @@ instead of one root barrel.
 | `@vite-hub/browser` | Browser Definitions, invocation-scoped sessions, controllers and providers, live handoff, and Browser Run output | `@vite-hub/browser`, `@vite-hub/browser/controllers/*`, `@vite-hub/browser/providers/*`, `@vite-hub/browser/vite` |
 | `@vite-hub/box` | Box Definitions and provider-neutral execution sessions | `@vite-hub/box` |
 | `@vite-hub/channels` | Provider-neutral Channel definitions, server access, and Vite discovery | `@vite-hub/channels`, `@vite-hub/channels/server`, `@vite-hub/channels/vite` |
+| `@vite-hub/content` | Comark Content runtime, ViteHub Source adaptation, server handler, and typed client | `@vite-hub/content`, `@vite-hub/content/client` |
 | `@vite-hub/database` | Database Definitions, Drizzle schema generation, D1 and hosted database wiring | `@vite-hub/database`, `@vite-hub/database/drizzle`, `@vite-hub/database/vite` |
 | `@vite-hub/email` | Portable provider integration, built-in transports, runtime delivery, Dynamic Markdown composition, and test capture | `@vite-hub/email`, `@vite-hub/email/markdown`, `@vite-hub/email/server`, `@vite-hub/email/test`, `@vite-hub/email/vite` |
 | `@vite-hub/env` | Env Declarations, Public Env, Server Env, Secret Env, generated env access | `@vite-hub/env`, `@vite-hub/env/vite`, `@vite-hub/env/server`, `@vite-hub/env/secret` |

--- a/packages/internal/test/workspace-inventory.test.ts
+++ b/packages/internal/test/workspace-inventory.test.ts
@@ -15,6 +15,7 @@ describe("workspace inventory", () => {
       "browser",
       "channels",
       "cli",
+      "content",
       "database",
       "email",
       "env",


### PR DESCRIPTION
The Content package extraction added a publishable workspace package but left it out of the expected package inventory and package reference. Those omissions fail the package and docs checks on `main`.

Add Content to the existing inventory expectation and document its runtime and client imports. Package discovery already finds Content correctly.

Verified the existing workspace inventory tests, 4 passed, and launch documentation tests, 6 passed. Changed-file lint passed. An independent review checked the public exports and other package inventory consumers.

Model: GPT-5.6 Sol review with Codex implementation
Harness: T3 Code / Codex
