### PR TITLE
fix(box): preserve trusted-host startup cancellation

### DIFF
--- a/packages/box/src/internal/trusted-host.ts
+++ b/packages/box/src/internal/trusted-host.ts
@@ -564,6 +564,7 @@ async function createTrustedHostSession(options: {
         options.root,
         runOptions.workingDirectory ?? this.defaultWorkingDirectory,
       );
+      runOptions.abortSignal?.throwIfAborted();
       const child = spawnChildProcess(runOptions.command, {
         cwd,
         detached: process.platform !== "win32",
@@ -957,6 +958,7 @@ function processHandle(
   let abortReason: unknown;
   let forceKillTimer: ReturnType<typeof setTimeout> | undefined;
   const abort = () => {
+    if (abortReason) return;
     abortReason = abortSignal?.reason || new Error("Box command aborted.");
     signalProcessTree(child, "SIGTERM");
     forceKillTimer = setTimeout(() => signalProcessTree(child, "SIGKILL"), 250);
@@ -972,6 +974,7 @@ function processHandle(
       else resolvePromise({ exitCode: code ?? 1 });
     });
   });
+  if (abortSignal?.aborted) abort();
   return {
     pid: child.pid,
     stderr: Readable.toWeb(child.stderr) as ReadableStream<Uint8Array>,

--- a/packages/box/test/trusted-host.test.ts
+++ b/packages/box/test/trusted-host.test.ts
@@ -427,6 +427,65 @@ describe("createTrustedHostRuntime", () => {
     await session.destroy?.();
   });
 
+  it("does not start commands cancelled during working-directory resolution", async () => {
+    const root = await temporaryRoot();
+    const marker = join(root, "started");
+    const box = await resolveBox({ runtime: createTrustedHostRuntime() }, {});
+    const session = await boxProvider(box).createSession();
+    const controller = new AbortController();
+    const reason = new Error("cancelled");
+
+    try {
+      const running = session.run({
+        abortSignal: controller.signal,
+        command: `touch '${marker}'`,
+      });
+      controller.abort(reason);
+
+      await expect(running).rejects.toBe(reason);
+      await expect(stat(marker)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      await session.destroy?.();
+    }
+  });
+
+  it("preserves cancellation when abort listener registration starts late", async () => {
+    const box = await resolveBox({ runtime: createTrustedHostRuntime() }, {});
+    const session = await boxProvider(box).createSession();
+    const controller = new AbortController();
+    const reason = new Error("cancelled");
+    const addEventListener = controller.signal.addEventListener.bind(controller.signal);
+    const registration = vi
+      .spyOn(controller.signal, "addEventListener")
+      .mockImplementation((type, listener, options) => {
+        controller.abort(reason);
+        addEventListener(type, listener, options);
+      });
+
+    try {
+      const child = await session.spawn({
+        abortSignal: controller.signal,
+        command: `node -e "setInterval(() => {}, 1000)"`,
+      });
+      const settled = child.wait().then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+
+      await expect(
+        Promise.race([
+          settled,
+          new Promise((resolvePromise) => setTimeout(resolvePromise, 1_500, "still-running")),
+        ]),
+      ).resolves.toBe(reason);
+      if (process.platform !== "win32")
+        await vi.waitFor(() => expect(() => process.kill(-child.pid!, 0)).toThrow());
+    } finally {
+      registration.mockRestore();
+      await session.destroy?.();
+    }
+  });
+
   it("force-kills commands that ignore abort termination", async () => {
     if (process.platform === "win32") return;
     const root = await temporaryRoot();


### PR DESCRIPTION
Trusted-host commands could start after cancellation during working-directory resolution. Cancellation during abort-listener setup could also leave a child running.

Check the signal again before child creation and detect an already-aborted signal when process handling starts. Terminate the process tree and retain the original rejection reason, with one abort handler and force-kill timer.

The original startup reproduction now rejects before spawning. Trusted-host and public-session tests passed 38 checks, including late cancellation and POSIX process-group cleanup. Package typecheck, build, publint, and focused lint passed. Windows process-group behavior was not tested locally.

Model: GPT-5.6 Sol
Harness: T3 Code / Codex
