### PR TITLE
fix(realtime): clean up failed room initialization

### DIFF
--- a/packages/realtime/src/server.ts
+++ b/packages/realtime/src/server.ts
@@ -293,8 +293,14 @@ export function restoreRealtimeDocument(markdown: string, baselineDigest: string
   const storedDigest = typeof stored?.baseline_digest === "string" ? stored.baseline_digest : undefined
   if (!update || storedDigest !== baselineDigest) return markdownToYDoc(markdown)
   const document = new Y.Doc()
-  Y.applyUpdate(document, update)
-  return document
+  try {
+    Y.applyUpdate(document, update)
+    return document
+  }
+  catch (error) {
+    document.destroy()
+    throw error
+  }
 }
 
 function canRestoreRealtimeDocument(baselineDigest: string | undefined, stored: Record<string, unknown> | undefined): boolean {
@@ -495,38 +501,46 @@ export function createRealtimeHandler(registry: RealtimeRegistry): RealtimeHandl
           : undefined
         const restoresStoredDocument = workspaceDocument && canRestoreRealtimeDocument(initial.baselineDigest, stored)
         const document = workspaceDocument ? restoreRealtimeDocument(initial.markdown, initial.baselineDigest, stored) : new Y.Doc()
-        const storedUpdates = restoresStoredDocument && sql
-          ? sql.exec("SELECT update_blob FROM vitehub_realtime_updates WHERE room_key = ? ORDER BY sequence", key).toArray()
-          : []
-        for (const row of storedUpdates) {
-          const update = storedUpdate(row.update_blob)
-          if (update) Y.applyUpdate(document, update)
-        }
-        assertRealtimeRoomStateQuota(document)
-        const awareness = new awarenessProtocol.Awareness(document)
-        awareness.setLocalState(null)
-        const value: Room = {
-          awareness,
-          awarenessClientOwners: new Map(),
-          baselineDigest: initial.baselineDigest,
-          channel: `vitehub:realtime:${key}`,
-          document,
-          durableReady: !!sql || !!initial.baselineDigest,
-          key,
-          mutated: false,
-          peers: new Set(),
-          persistedUpdates: storedUpdates.length,
-          sql: workspaceDocument ? sql : undefined,
-        }
-        value.document.on("update", (update: Uint8Array, origin: unknown) => {
-          value.mutated = true
-          persistRoomUpdate(value, update)
-          if (origin && typeof origin === "object" && "publish" in origin) {
-            (origin as WebSocketPeer).publish(value.channel, encodeSyncUpdate(update))
+        let awareness: awarenessProtocol.Awareness | undefined
+        try {
+          const storedUpdates = restoresStoredDocument && sql
+            ? sql.exec("SELECT update_blob FROM vitehub_realtime_updates WHERE room_key = ? ORDER BY sequence", key).toArray()
+            : []
+          for (const row of storedUpdates) {
+            const update = storedUpdate(row.update_blob)
+            if (update) Y.applyUpdate(document, update)
           }
-        })
-        if (value.sql && !restoresStoredDocument) persistRoom(value)
-        return value
+          assertRealtimeRoomStateQuota(document)
+          awareness = new awarenessProtocol.Awareness(document)
+          awareness.setLocalState(null)
+          const value: Room = {
+            awareness,
+            awarenessClientOwners: new Map(),
+            baselineDigest: initial.baselineDigest,
+            channel: `vitehub:realtime:${key}`,
+            document,
+            durableReady: !!sql || !!initial.baselineDigest,
+            key,
+            mutated: false,
+            peers: new Set(),
+            persistedUpdates: storedUpdates.length,
+            sql: workspaceDocument ? sql : undefined,
+          }
+          value.document.on("update", (update: Uint8Array, origin: unknown) => {
+            value.mutated = true
+            persistRoomUpdate(value, update)
+            if (origin && typeof origin === "object" && "publish" in origin) {
+              (origin as WebSocketPeer).publish(value.channel, encodeSyncUpdate(update))
+            }
+          })
+          if (value.sql && !restoresStoredDocument) persistRoom(value)
+          return value
+        }
+        catch (error) {
+          awareness?.destroy()
+          document.destroy()
+          throw error
+        }
       })()
       rooms.set(key, room)
       room.catch(() => {

--- a/packages/realtime/test/server.test.ts
+++ b/packages/realtime/test/server.test.ts
@@ -29,7 +29,11 @@ vi.mock("@vite-hub/workspace", async (importOriginal) => ({
   useWorkspace: serverMocks.useWorkspace,
 }))
 
-afterEach(() => vi.unstubAllGlobals())
+afterEach(() => {
+  vi.useRealTimers()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
 
 beforeEach(() => {
   serverMocks.assertAuthOrigin.mockReset().mockResolvedValue({ api: { getSession: serverMocks.getSession } })
@@ -53,6 +57,14 @@ function realtimeRegistry(options: { auth?: boolean, checkpoint?: boolean } = {}
 
 function workspaceFacade(fs: Record<string, unknown>, capabilities = { conditionalWrites: true }) {
   return { capabilities: vi.fn().mockResolvedValue(capabilities), fs }
+}
+
+function durableRealtimeRequest(exec: (query: string, ...bindings: unknown[]) => { toArray(): Array<Record<string, unknown>> }) {
+  const request = new Request("https://example.com/api/_vitehub/realtime/docs/page.md", {
+    headers: { upgrade: "websocket" },
+  }) as Request & { runtime?: unknown }
+  request.runtime = { cloudflare: { context: { storage: { sql: { exec } } } } }
+  return request
 }
 
 describe("realtime server handler", () => {
@@ -825,6 +837,105 @@ describe("realtime server handler", () => {
     )
   })
 
+  it("retries room initialization after a Workspace read fails", async () => {
+    const stat = vi.fn()
+      .mockRejectedValueOnce(new Error("Workspace read failed"))
+      .mockResolvedValue(undefined)
+    const exec = vi.fn(() => ({ toArray: () => [] }))
+    serverMocks.useWorkspace.mockReturnValue(workspaceFacade({
+      exists: vi.fn().mockResolvedValue(false),
+      readFile: vi.fn(),
+      stat,
+    }))
+    const handler = createRealtimeHandler(realtimeRegistry())
+    const request = () => durableRealtimeRequest(exec)
+
+    expect((await handler.fetch(request())).status).toBe(500)
+    const response = await handler.fetch(request()) as Response & { crossws: { close(peer: object): void, open(peer: object): void } }
+    const peer = { close: vi.fn(), publish: vi.fn(), send: vi.fn(), subscribe: vi.fn(), unsubscribe: vi.fn() }
+    response.crossws.open(peer)
+    response.crossws.close(peer)
+
+    expect(stat).toHaveBeenCalledTimes(3)
+  })
+
+  it("cleans a failed initial durable snapshot before retrying", async () => {
+    vi.useFakeTimers()
+    const documentDestroy = vi.spyOn(Y.Doc.prototype, "destroy")
+    let failSnapshot = true
+    const exec = vi.fn((query: string) => {
+      if (query.startsWith("INSERT OR REPLACE") && failSnapshot) {
+        failSnapshot = false
+        throw new Error("disk unavailable")
+      }
+      return { toArray: () => [] }
+    })
+    serverMocks.useWorkspace.mockReturnValue(workspaceFacade({
+      exists: vi.fn().mockResolvedValue(false),
+      readFile: vi.fn(),
+      stat: vi.fn().mockResolvedValue(undefined),
+    }))
+    const handler = createRealtimeHandler(realtimeRegistry())
+    const request = () => durableRealtimeRequest(exec)
+
+    expect((await handler.fetch(request())).status).toBe(500)
+    expect(vi.getTimerCount()).toBe(0)
+    expect(documentDestroy).toHaveBeenCalledTimes(1)
+
+    const response = await handler.fetch(request()) as Response & { crossws: { close(peer: object): void, open(peer: object): void } }
+    const peer = { close: vi.fn(), publish: vi.fn(), send: vi.fn(), subscribe: vi.fn(), unsubscribe: vi.fn() }
+    expect(vi.getTimerCount()).toBe(1)
+    response.crossws.open(peer)
+    response.crossws.close(peer)
+
+    expect(vi.getTimerCount()).toBe(0)
+    expect(documentDestroy).toHaveBeenCalledTimes(2)
+    expect(exec.mock.calls.filter(([query]) => query.startsWith("INSERT OR REPLACE"))).toHaveLength(2)
+  })
+
+  it("shares one pending room initialization and destroys it after its last peer closes", async () => {
+    let releaseRead!: () => void
+    let reportReadStarted!: () => void
+    const readStarted = new Promise<void>((resolve) => { reportReadStarted = resolve })
+    const continueRead = new Promise<void>((resolve) => { releaseRead = resolve })
+    const stat = vi.fn(async () => {
+      reportReadStarted()
+      await continueRead
+      return undefined
+    })
+    const exec = vi.fn((_query: string) => ({ toArray: () => [] }))
+    serverMocks.useWorkspace.mockReturnValue(workspaceFacade({
+      exists: vi.fn().mockResolvedValue(false),
+      readFile: vi.fn(),
+      stat,
+    }))
+    vi.useFakeTimers()
+    const documentDestroy = vi.spyOn(Y.Doc.prototype, "destroy")
+    const handler = createRealtimeHandler(realtimeRegistry())
+    const request = () => durableRealtimeRequest(exec)
+
+    const firstRequest = handler.fetch(request())
+    await readStarted
+    const secondRequest = handler.fetch(request())
+    releaseRead()
+    const [first, second] = await Promise.all([firstRequest, secondRequest]) as Array<Response & { crossws: { close(peer: object): void, open(peer: object): void } }>
+    const firstPeer = { close: vi.fn(), publish: vi.fn(), send: vi.fn(), subscribe: vi.fn(), unsubscribe: vi.fn() }
+    const secondPeer = { close: vi.fn(), publish: vi.fn(), send: vi.fn(), subscribe: vi.fn(), unsubscribe: vi.fn() }
+    first.crossws.open(firstPeer)
+    second.crossws.open(secondPeer)
+
+    first.crossws.close(firstPeer)
+    expect(vi.getTimerCount()).toBe(1)
+    expect(documentDestroy).not.toHaveBeenCalled()
+    second.crossws.close(secondPeer)
+
+    expect(serverMocks.useWorkspace).toHaveBeenCalledTimes(2)
+    expect(stat).toHaveBeenCalledTimes(2)
+    expect(exec.mock.calls.filter(([query]) => query.startsWith("INSERT OR REPLACE"))).toHaveLength(1)
+    expect(vi.getTimerCount()).toBe(0)
+    expect(documentDestroy).toHaveBeenCalledOnce()
+  })
+
   it("does not retain awareness clients from a rejected update", async () => {
     serverMocks.getSession.mockResolvedValue({ user: { id: "user" } })
     serverMocks.useWorkspace.mockReturnValue(workspaceFacade({
@@ -944,6 +1055,16 @@ describe("realtime transport boundaries", () => {
 })
 
 describe("realtime Workspace documents", () => {
+  it("destroys a document when stored durable state cannot be restored", () => {
+    const destroy = vi.spyOn(Y.Doc.prototype, "destroy")
+
+    expect(() => restoreRealtimeDocument("", "baseline", {
+      baseline_digest: "baseline",
+      update_blob: new Uint8Array([255]).buffer,
+    })).toThrow()
+    expect(destroy).toHaveBeenCalledOnce()
+  })
+
   it("opens a new path as an empty document", async () => {
     const readFile = vi.fn()
     const result = await readRealtimeWorkspaceDocument(


### PR DESCRIPTION
Failed Realtime room initialization removed the pending room from its cache but left allocated Yjs documents and Awareness intervals alive. Repeated persistence failures created more live timers.

Destroy partial room resources before rethrowing, including documents whose stored state cannot be restored. Failed reads can retry, concurrent callers still share initialization, and successful durable rooms remain live until their last peer closes.

All 85 Realtime tests passed, along with package typecheck, build, publint, and scoped lint. The original reproduction left 3 Awareness intervals on the base code and 0 after this fix. New tests cover failure cleanup, retry, concurrent acquisition, and normal release.

Model: GPT-5.6 Sol
Harness: T3 Code / Codex
