### PR TITLE
fix(source): keep glob paths inside the source root

### DIFF
--- a/docs/content/docs/server-primitives/source.md
+++ b/docs/content/docs/server-primitives/source.md
@@ -91,12 +91,14 @@ Source has no discovery or Vite Integration by itself. Import the module that re
 | --- | --- | --- |
 | `file(input)` | A path string, `{ path, workspacePath?, mediaType? }`, or inline `{ workspacePath, content, mediaType? }`. | Reads one file from the Source Context root. `workspacePath` controls the Source key. |
 | `markdown(options)` | `{ path, workspacePath?, mediaType? }` or inline `{ workspacePath, content, mediaType? }`. | Uses the `file()` contract with `text/markdown` as the default media type. Unlike `file()`, it requires an options object. |
-| `glob(options)` | `include`, `cwd`, `ignore`, `dot`, `followSymlinks`, `keyCache`, `prefix`. | Expands local files with `tinyglobby`; `keyCache: false` refreshes keys on each read path. |
+| `glob(options)` | `include`, `cwd`, `ignore`, `dot`, `followSymlinks`, `keyCache`, `prefix`. | Expands local files with `tinyglobby`; `keyCache: false` disables the cached key snapshot. Symbolic links are off by default. |
 | `github(options)` | `repo`, `ref`, `root`, `auth`, `include`, `ignore`, `cache`. | Retrieves repository archive content. `auth` can be a token string or a trusted callback. |
 | `mcpResources(options)` | `server`, `include`, `ignore`, `path`, `request`, `cache`. | Reads MCP Resource content. `server` can be a client, client config, or resolver. |
 | `custom(source)` | A `Source` object. | Use when the built-in loaders do not match the origin contract. |
 
 Use `sourceIgnores` from `vite-hub/source` for reusable dependency, generated-output, media, secret, and system-file patterns. Workspace GitHub Sources apply `sourceIgnores.defaults` automatically; pass `ignore: false` to opt out or provide more patterns to extend the defaults.
+
+`file()` follows a symbolic link only when its resolved target stays inside the Source root. `glob()` is also confined to the Source root. By default, it rejects an item when its file or a parent directory is a symbolic link. Set `followSymlinks: true` to follow links when their resolved targets stay inside the Source root. This option controls which local files the Source can select. It does not isolate the process from concurrent file system changes.
 
 ### Cache options
 

--- a/packages/source/README.md
+++ b/packages/source/README.md
@@ -35,6 +35,8 @@ const keys = await docs.keys()
 const first = await docs.read(keys[0]!)
 ```
 
+`file()` follows a symbolic link only when its resolved target stays inside the Source root. `glob()` is also confined to the Source root. It does not follow symbolic links by default, and it checks each file path again before it reads content or metadata. Set `followSymlinks: true` to follow links when their resolved targets stay inside the Source root. This option controls file selection. It does not isolate the process from concurrent file system changes.
+
 `revision()` resolves an origin snapshot once per reader. Revision-aware loaders
 then use the same immutable identity for preparation, keys, and item reads.
 

--- a/packages/source/src/sources/glob.ts
+++ b/packages/source/src/sources/glob.ts
@@ -21,23 +21,31 @@ export function glob(options: GlobSourceOptions): Source<string> {
   let latest: { key: string, keys: string[] } | undefined
 
   async function getContextKey(ctx: SourceContext) {
-    return resolveCwd(resolveSourceRoot(ctx), options.cwd)
+    const { root, cwd } = await resolveGlobPaths(resolveSourceRoot(ctx), options.cwd)
+    return `${root}\0${cwd}`
   }
 
   async function loadKeys(ctx: SourceContext) {
-    const cwd = await resolveCwd(resolveSourceRoot(ctx), options.cwd)
+    const paths = await resolveGlobPaths(resolveSourceRoot(ctx), options.cwd)
     const ignore = normalizePatterns(options.ignore)
     const files = await tinyglobby(options.include, {
-      cwd,
+      cwd: paths.cwd,
       dot: options.dot ?? false,
       followSymbolicLinks: options.followSymlinks ?? false,
       ignore: ["**/.git/**", "**/node_modules/**", ...ignore],
       onlyFiles: true,
     })
-    return files
-      .map(file => normalizeSourcePath(file))
+    let keys = files
+      .map(file => normalizeSafeSourcePath(file, { allowReserved: true }))
       .filter(file => matchesAny(file, options.include) && !matchesAny(file, ignore))
-      .sort((left, right) => left.localeCompare(right))
+    if (options.followSymlinks) {
+      const rooted: string[] = []
+      for (const key of keys) {
+        if (await resolveRootedGlobFilePath(key, paths, true)) rooted.push(key)
+      }
+      keys = rooted
+    }
+    return keys.sort((left, right) => left.localeCompare(right))
   }
 
   async function refreshKeys(ctx: SourceContext) {
@@ -71,10 +79,17 @@ export function glob(options: GlobSourceOptions): Source<string> {
     const keys = await getKnownKeys(ctx)
     if (keys.includes(key)) return
     if (options.keyCache !== false) {
-      throw sourceError(`[vitehub] glob could not find ${JSON.stringify(key)}.`)
+      throw missingKeyError(key)
     }
     if ((await refreshKeys(ctx)).includes(key)) return
-    throw sourceError(`[vitehub] glob could not find ${JSON.stringify(key)}.`)
+    throw missingKeyError(key)
+  }
+
+  async function resolveGlobFilePath(key: string, ctx: SourceContext) {
+    const paths = await resolveGlobPaths(resolveSourceRoot(ctx), options.cwd)
+    const path = await resolveRootedGlobFilePath(key, paths, options.followSymlinks === true)
+    if (!path) throw missingKeyError(key)
+    return path
   }
 
   const source: Source<string> = {
@@ -89,9 +104,8 @@ export function glob(options: GlobSourceOptions): Source<string> {
     async getMeta(key: string, ctx: SourceContext) {
       await assertKey(key, ctx)
       const { stat } = await import("node:fs/promises")
-      const { resolve } = await import("node:path")
-      const cwd = await resolveCwd(resolveSourceRoot(ctx), options.cwd)
-      const info = await stat(resolve(cwd, key))
+      const path = await resolveGlobFilePath(key, ctx)
+      const info = await stat(path)
       return {
         digest: `${info.size}:${info.mtimeMs}`,
       }
@@ -99,11 +113,10 @@ export function glob(options: GlobSourceOptions): Source<string> {
     async getItem(key: string, ctx: SourceContext): Promise<SourceItem<string>> {
       await assertKey(key, ctx)
       const { readFile, stat } = await import("node:fs/promises")
-      const { resolve } = await import("node:path")
-      const cwd = await resolveCwd(resolveSourceRoot(ctx), options.cwd)
+      const filePath = await resolveGlobFilePath(key, ctx)
       const prefix = normalizeSafeSourcePath(options.prefix || "", { allowEmpty: true })
-      const bytes = await readFile(resolve(cwd, key))
-      const info = await stat(resolve(cwd, key))
+      const bytes = await readFile(filePath)
+      const info = await stat(filePath)
       return {
         key,
         path: normalizeSourcePath(prefix ? `${prefix}/${key}` : key),
@@ -115,6 +128,10 @@ export function glob(options: GlobSourceOptions): Source<string> {
   return source
 }
 
+function missingKeyError(key: string) {
+  return sourceError(`[vitehub] glob could not find ${JSON.stringify(key)}.`)
+}
+
 function normalizePatterns(patterns: string | readonly string[] | undefined): readonly string[] {
   if (!patterns) return []
   return Array.isArray(patterns) ? patterns : [String(patterns)]
@@ -124,15 +141,59 @@ function resolveSourceRoot(ctx: SourceContext) {
   return ctx.sourceRootDir || ctx.rootDir
 }
 
-async function resolveCwd(rootDir: string, cwd = "."): Promise<string> {
+interface ResolvedGlobPaths {
+  root: string
+  cwd: string
+}
+
+async function resolveGlobPaths(rootDir: string, cwd = "."): Promise<ResolvedGlobPaths> {
   const { realpath } = await import("node:fs/promises")
-  const { isAbsolute, relative, resolve } = await import("node:path")
+  const { isAbsolute, relative, resolve, sep } = await import("node:path")
   const resolvedRoot = await realpath(resolve(rootDir))
   const resolvedCwdPath = isAbsolute(cwd) ? resolve(cwd) : resolve(resolvedRoot, cwd)
   const resolvedCwd = await realpath(resolvedCwdPath)
   const rel = relative(resolvedRoot, resolvedCwd)
-  if (rel && (rel.startsWith("..") || isAbsolute(rel))) {
+  if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) {
     throw sourceError(`[vitehub] glob cwd escapes the source root: ${JSON.stringify(cwd)}.`)
   }
-  return resolvedCwd
+  return { root: resolvedRoot, cwd: resolvedCwd }
+}
+
+async function resolveRootedGlobFilePath(
+  key: string,
+  paths: ResolvedGlobPaths,
+  followSymlinks: boolean,
+): Promise<string | undefined> {
+  const { lstat, realpath } = await import("node:fs/promises")
+  const { isAbsolute, relative, resolve, sep } = await import("node:path")
+  const safeKey = normalizeSafeSourcePath(key, { allowReserved: true })
+  const path = resolve(paths.cwd, safeKey)
+
+  if (followSymlinks) {
+    let target: string
+    try {
+      target = await realpath(path)
+    }
+    catch (error) {
+      if (isUnavailablePathError(error)) return
+      throw error
+    }
+    const rel = relative(paths.root, target)
+    if (rel === ".." || rel.startsWith(`..${sep}`) || isAbsolute(rel)) return
+    return target
+  }
+
+  let current = paths.cwd
+  for (const part of safeKey.split("/")) {
+    current = resolve(current, part)
+    if ((await lstat(current)).isSymbolicLink()) return
+  }
+  return path
+}
+
+function isUnavailablePathError(error: unknown) {
+  return typeof error === "object"
+    && error !== null
+    && "code" in error
+    && (error.code === "ENOENT" || error.code === "ELOOP")
 }

--- a/packages/source/src/sources/glob.ts
+++ b/packages/source/src/sources/glob.ts
@@ -192,8 +192,6 @@ async function resolveRootedGlobFilePath(
 }
 
 function isUnavailablePathError(error: unknown) {
-  return typeof error === "object"
-    && error !== null
-    && "code" in error
-    && (error.code === "ENOENT" || error.code === "ELOOP")
+  return error instanceof Error
+    && ["ENOENT", "ELOOP"].includes(String(Reflect.get(error, "code")))
 }

--- a/packages/source/test/sources/glob-symlinks.test.ts
+++ b/packages/source/test/sources/glob-symlinks.test.ts
@@ -1,0 +1,154 @@
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join, relative } from "node:path"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+import { glob } from "../../src/glob.ts"
+
+const tempDirs: string[] = []
+
+async function createRoot() {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-source-glob-symlinks-"))
+  tempDirs.push(root)
+  return root
+}
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map(path => rm(path, { recursive: true, force: true })))
+})
+
+describe("@vite-hub/source glob symbolic links", () => {
+  it.each([
+    ["the default options", {}],
+    ["followSymlinks: false", { followSymlinks: false }],
+    ["keyCache: false", { keyCache: false }],
+  ])("rejects a file replaced by a symbolic link with %s", async (_name, options) => {
+    const root = await createRoot()
+    const outside = await createRoot()
+    await writeFile(join(root, "doc.md"), "public")
+    await writeFile(join(outside, "secret.md"), "secret")
+
+    const docs = glob({ include: "**/*.md", ...options })
+    const ctx = { rootDir: root }
+    await expect(docs.getKeys(ctx)).resolves.toEqual(["doc.md"])
+
+    await rm(join(root, "doc.md"))
+    await symlink(join(outside, "secret.md"), join(root, "doc.md"))
+
+    await expect(docs.getItem("doc.md", ctx)).rejects.toThrow("glob could not find")
+    await expect(docs.getMeta?.("doc.md", ctx)).rejects.toThrow("glob could not find")
+  })
+
+  it("rejects a file whose parent directory becomes a symbolic link", async () => {
+    const root = await createRoot()
+    const outside = await createRoot()
+    await mkdir(join(root, "docs"))
+    await writeFile(join(root, "docs", "guide.md"), "public")
+    await writeFile(join(outside, "guide.md"), "secret")
+
+    const docs = glob({ include: "**/*.md" })
+    const ctx = { rootDir: root }
+    await expect(docs.getKeys(ctx)).resolves.toEqual(["docs/guide.md"])
+
+    await rm(join(root, "docs"), { recursive: true })
+    await symlink(outside, join(root, "docs"))
+
+    await expect(docs.getItem("docs/guide.md", ctx)).rejects.toThrow("glob could not find")
+    await expect(docs.getMeta?.("docs/guide.md", ctx)).rejects.toThrow("glob could not find")
+  })
+
+  it("rejects a file replaced by a dangling symbolic link", async () => {
+    const root = await createRoot()
+    await writeFile(join(root, "doc.md"), "public")
+
+    const docs = glob({ include: "**/*.md" })
+    const ctx = { rootDir: root }
+    await expect(docs.getKeys(ctx)).resolves.toEqual(["doc.md"])
+
+    await rm(join(root, "doc.md"))
+    await symlink(join(root, "missing.md"), join(root, "doc.md"))
+
+    await expect(docs.getItem("doc.md", ctx)).rejects.toThrow("glob could not find")
+    await expect(docs.getMeta?.("doc.md", ctx)).rejects.toThrow("glob could not find")
+  })
+
+  it("rejects a symbolic link whose target stays inside the source root", async () => {
+    const root = await createRoot()
+    await writeFile(join(root, "doc.md"), "public")
+    await writeFile(join(root, "target.md"), "target")
+
+    const docs = glob({ include: "doc.md" })
+    const ctx = { rootDir: root }
+    await expect(docs.getKeys(ctx)).resolves.toEqual(["doc.md"])
+
+    await rm(join(root, "doc.md"))
+    await symlink(join(root, "target.md"), join(root, "doc.md"))
+
+    await expect(docs.getItem("doc.md", ctx)).rejects.toThrow("glob could not find")
+    await expect(docs.getMeta?.("doc.md", ctx)).rejects.toThrow("glob could not find")
+  })
+
+  it("rejects include patterns that select a parent path", async () => {
+    const root = await createRoot()
+    const outside = await createRoot()
+    await writeFile(join(outside, "secret.md"), "secret")
+
+    const include = relative(root, join(outside, "secret.md")).replaceAll("\\", "/")
+
+    await expect(glob({ include }).getKeys({ rootDir: root }))
+      .rejects.toThrow("Source path escapes the source root")
+  })
+
+  it("follows only root-confined symbolic links when followSymlinks is true", async () => {
+    const root = await createRoot()
+    const outside = await createRoot()
+    await mkdir(join(root, "workspace"))
+    await mkdir(join(root, "shared"))
+    await writeFile(join(root, "shared", "inside.md"), "inside")
+    await writeFile(join(outside, "outside.md"), "outside")
+    await writeFile(join(root, "workspace", "replace-inside.md"), "public")
+    await writeFile(join(root, "workspace", "replace-outside.md"), "public")
+    await symlink(join(root, "shared", "inside.md"), join(root, "workspace", "inside.md"))
+    await symlink(join(outside, "outside.md"), join(root, "workspace", "outside.md"))
+
+    const docs = glob({ cwd: "workspace", followSymlinks: true, include: "**/*.md" })
+    const ctx = { rootDir: root }
+
+    await expect(docs.getKeys(ctx)).resolves.toEqual([
+      "inside.md",
+      "replace-inside.md",
+      "replace-outside.md",
+    ])
+
+    await rm(join(root, "workspace", "replace-inside.md"))
+    await rm(join(root, "workspace", "replace-outside.md"))
+    await symlink(join(root, "shared", "inside.md"), join(root, "workspace", "replace-inside.md"))
+    await symlink(join(outside, "outside.md"), join(root, "workspace", "replace-outside.md"))
+
+    await expect(docs.getItem("inside.md", ctx)).resolves.toMatchObject({
+      content: new TextEncoder().encode("inside"),
+    })
+    await expect(docs.getItem("replace-inside.md", ctx)).resolves.toMatchObject({
+      content: new TextEncoder().encode("inside"),
+    })
+    await expect(docs.getMeta?.("replace-inside.md", ctx)).resolves.toMatchObject({
+      digest: expect.any(String),
+    })
+    await expect(docs.getItem("replace-outside.md", ctx)).rejects.toThrow("glob could not find")
+    await expect(docs.getMeta?.("replace-outside.md", ctx)).rejects.toThrow("glob could not find")
+  })
+
+  it("separates cached keys for different source roots with the same cwd", async () => {
+    const root = await createRoot()
+    const workspace = join(root, "workspace")
+    await mkdir(workspace)
+    await writeFile(join(root, "shared.md"), "shared")
+    await symlink(join(root, "shared.md"), join(workspace, "linked.md"))
+
+    const docs = glob({ cwd: workspace, followSymlinks: true, include: "**/*.md" })
+
+    await expect(docs.getKeys({ rootDir: root })).resolves.toEqual(["linked.md"])
+    await expect(docs.getKeys({ rootDir: workspace })).resolves.toEqual([])
+  })
+})


### PR DESCRIPTION
A cached glob key could be replaced with a symbolic link after enumeration. Content and metadata reads then followed it outside the Source root even though links are disabled by default. Parent-directory include patterns could also select paths outside the root.

Revalidate selected paths before reading. Default options and `followSymlinks: false` reject file and ancestor links. `followSymlinks: true` permits only targets inside the Source root. Reject parent paths, exclude outside link targets from discovery, and distinguish cached contexts by root and working directory.

The README and Source guide describe the boundary. These checks do not isolate a process from a hostile concurrent filesystem writer.

All 118 Source tests passed with a 20-second per-test limit. The default 10-second run hit a nested-install timeout; that test also passed in isolation. Package typecheck, build, publint, changed-file lint, and the original source and built-output reproductions passed.

Model: GPT-5.6 Sol
Harness: T3 Code / Codex
