### PR TITLE
fix(content): isolate source revisions per load

### DIFF
--- a/docs/content/docs/server-primitives/content.md
+++ b/docs/content/docs/server-primitives/content.md
@@ -37,7 +37,9 @@ await content.search(['docs'], 'runtime')
 
 ViteHub discovers `server/content.ts` and serves its exported `content` instance at `/api/content/**` in Vite and Nuxt. No manual framework route or `fetch()` wrapper is required.
 
-Registered ViteHub Source names, explicit Source Readers, and native Comark Content Sources can coexist. The ViteHub adapter gives each Comark cache refresh a new Source Reader, so each load uses one origin revision.
+Registered ViteHub Source names, explicit Source Readers, and native Comark Content Sources can coexist. `defineContent()` gives each adapted Source load a separate adapter that keeps its selected Reader until all parser reads finish. Registered Source names and Reader factories select a new Reader for each load. Explicit Readers stay fixed. Overlapping refreshes, fresh snapshots, and fresh document reads therefore keep their selected revisions. Raw media uses the newest successfully enumerated Source revision. Native Comark Content Sources pass through unchanged.
+
+A direct `contentSource()` adapter selects a Reader when `keys()` starts an enumeration. Its later `getItem()` calls use that Reader until the next enumeration. Use `defineContent()` to isolate overlapping loads.
 
 Use `sqlite-wasm` where Node SQLite is unavailable. Comark Content owns parsed document cache entries and exposes `refresh(source)`, `invalidate(key)`, and `expire(key)`.
 

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -23,7 +23,9 @@ await content.get("/guide")
 await content.navigation(["docs"])
 ```
 
-Each Comark cache refresh creates a ViteHub Source Reader. Each load therefore reads one pinned origin revision. Native Comark Sources pass through unchanged.
+`defineContent()` gives each adapted Source load a separate adapter that keeps its selected Reader until all parser reads finish. Registered Source names and Reader factories select a new Reader for each load. Explicit Readers stay fixed. Overlapping refreshes, fresh snapshots, and fresh document reads therefore keep their selected revisions. Raw media uses the newest successfully enumerated Source revision. Native Comark Sources pass through unchanged.
+
+A direct `contentSource()` adapter selects a Reader when `keys()` starts an enumeration. Its later `getItem()` calls use that Reader until the next enumeration. Use `defineContent()` to isolate overlapping loads.
 
 The combined `vite-hub` framework discovers `server/content.ts` and serves its exported `content` instance at `/api/content/**`.
 

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -30,6 +30,14 @@ export interface ContentSourceOptions {
 }
 
 type ContentSourceItem = SourceItem<string, unknown, object>
+type ContentSourceFactory = {
+  create(options?: ContentSourceOptions): ComarkContentSource
+}
+type ContentSourceState = {
+  latestItems?: Map<string, ContentSourceItem>
+  latestSequence: number
+  nextSequence: number
+}
 type NodeContentRequest = {
   aborted: boolean
   headers: Record<string, string | string[] | undefined>
@@ -39,6 +47,8 @@ type NodeContentRequest = {
   once(event: "aborted", listener: () => void): unknown
 }
 export type ContentSourceInput = SourceName | SourceReader | (() => SourceReader) | ComarkContentSource
+
+const contentSourceFactory = Symbol("vitehub.contentSourceFactory")
 
 function normalizeContentSourcePath(path = ""): string {
   const raw = path.replace(/\\/g, "/")
@@ -132,83 +142,142 @@ function configuredContentSource(input: ComarkContentSource, options: ContentSou
   return source
 }
 
+function getContentSourceFactory(source: ComarkContentSource): ContentSourceFactory | undefined {
+  // SAFETY: Only adapters created below define this private symbol, and they store a ContentSourceFactory.
+  return (source as ComarkContentSource & { [contentSourceFactory]?: ContentSourceFactory })[contentSourceFactory]
+}
+
+function contentSourceOptions(
+  defaults: ContentSourceOptions,
+  overrides: ContentSourceOptions,
+): ContentSourceOptions {
+  return {
+    prefix: overrides.prefix ?? defaults.prefix,
+    schema: overrides.schema ?? defaults.schema,
+  }
+}
+
+function createContentSourceFactory(
+  sourceInput: SourceName | SourceReader | (() => SourceReader),
+  defaults: ContentSourceOptions,
+): ContentSourceFactory {
+  const state: ContentSourceState = { latestSequence: 0, nextSequence: 0 }
+  const factory: ContentSourceFactory = {
+    create(overrides = {}) {
+      const options = contentSourceOptions(defaults, overrides)
+      let itemsPromise: Promise<Map<string, ContentSourceItem>> | undefined
+
+      function loadItems() {
+        if (!itemsPromise) {
+          const sequence = ++state.nextSequence
+          itemsPromise = (async () => {
+            const nextItems = new Map<string, ContentSourceItem>()
+            const currentReader = isSourceName(sourceInput)
+              ? useSource(sourceInput)
+              : isSourceReaderFactory(sourceInput)
+                ? sourceInput()
+                : sourceInput
+            for (const item of await currentReader.items()) {
+              const path = contentPath(item)
+              if (nextItems.has(path)) {
+                throw new TypeError(`[vitehub] contentSource() received duplicate content path ${JSON.stringify(path)}.`)
+              }
+              nextItems.set(path, item)
+            }
+            if (sequence >= state.latestSequence) {
+              state.latestItems = nextItems
+              state.latestSequence = sequence
+            }
+            return nextItems
+          })()
+        }
+        return itemsPromise
+      }
+
+      const source: ComarkContentSource = {
+        async keys() {
+          itemsPromise = undefined
+          return [...(await loadItems()).keys()]
+        },
+        async getItem(key) {
+          const path = normalizeContentSourcePath(key)
+          const item = (await loadItems()).get(path)
+          if (!item) throw new TypeError(`[vitehub] contentSource() could not find ${JSON.stringify(key)}.`)
+          return textContent(item)
+        },
+        async getItemRaw(key) {
+          const path = normalizeContentSourcePath(key)
+          let items = state.latestItems
+          if (itemsPromise) {
+            try {
+              items = await itemsPromise
+            } catch (error) {
+              if (!items) throw error
+            }
+          } else if (!items) {
+            items = await loadItems()
+          }
+          const item = items.get(path)
+          if (!item) return
+          return item.data ?? item.content
+        },
+      }
+      if (options.prefix !== undefined) source.prefix = options.prefix
+      if (options.schema !== undefined) source.schema = options.schema
+      Object.defineProperty(source, contentSourceFactory, {
+        value: {
+          create: (overrides = {}) => factory.create(contentSourceOptions(options, overrides)),
+        } satisfies ContentSourceFactory,
+      })
+      return source
+    },
+  }
+  return factory
+}
+
+// Comark reads each enumerable entry once per load, so getters isolate adapted Source snapshots.
+function configuredContentSources(inputs: Record<string, ContentSourceInput>): Record<string, ComarkContentSource> {
+  const sources: Record<string, ComarkContentSource> = {}
+  for (const [name, input] of Object.entries(inputs)) {
+    const source = contentSource(input)
+    const factory = getContentSourceFactory(source)
+    if (factory) {
+      Object.defineProperty(sources, name, {
+        enumerable: true,
+        get: () => factory.create(),
+      })
+    } else {
+      Object.defineProperty(sources, name, {
+        enumerable: true,
+        value: source,
+      })
+    }
+  }
+  return sources
+}
+
 /** Adapt a registered ViteHub Source or Source Reader to the interface consumed by Comark Content. */
 export function contentSource(input: ContentSourceInput, options: ContentSourceOptions = {}): ComarkContentSource {
   if (isComarkContentSource(input)) {
+    const factory = getContentSourceFactory(input)
+    if (factory) return factory.create(options)
     return options.prefix === undefined && options.schema === undefined ? input : configuredContentSource(input, options)
   }
   // SAFETY: The native Comark Source branch returned above, leaving only ViteHub Source inputs.
   const sourceInput = input as SourceName | SourceReader | (() => SourceReader)
-  const pendingLoads: Map<string, ContentSourceItem>[] = []
-  let latestItems: Map<string, ContentSourceItem> | undefined
-
-  async function loadItems() {
-    const nextItems = new Map<string, ContentSourceItem>()
-    const currentReader = isSourceName(sourceInput)
-      ? useSource(sourceInput)
-      : isSourceReaderFactory(sourceInput)
-        ? sourceInput()
-        : sourceInput
-    for (const item of await currentReader.items()) {
-      const path = contentPath(item)
-      if (nextItems.has(path)) {
-        throw new TypeError(`[vitehub] contentSource() received duplicate content path ${JSON.stringify(path)}.`)
-      }
-      nextItems.set(path, item)
-    }
-    return nextItems
-  }
-
-  async function findItem(key: string) {
-    const path = normalizeContentSourcePath(key)
-    const loadIndex = pendingLoads.findIndex(items => items.has(path))
-    if (loadIndex !== -1) {
-      const items = pendingLoads[loadIndex]!
-      const item = items.get(path)
-      items.delete(path)
-      if (items.size === 0) pendingLoads.splice(loadIndex, 1)
-      return item
-    }
-    return (await loadItems()).get(path)
-  }
-
-  const source: ComarkContentSource = {
-    async keys() {
-      const items = await loadItems()
-      latestItems = items
-      const pendingItems = new Map(items)
-      pendingLoads.push(pendingItems)
-      setTimeout(() => {
-        const loadIndex = pendingLoads.indexOf(pendingItems)
-        if (loadIndex !== -1) pendingLoads.splice(loadIndex, 1)
-      }, 0)
-      return [...items.keys()]
-    },
-    async getItem(key) {
-      const item = await findItem(key)
-      if (!item) throw new TypeError(`[vitehub] contentSource() could not find ${JSON.stringify(key)}.`)
-      return textContent(item)
-    },
-    async getItemRaw(key) {
-      const path = normalizeContentSourcePath(key)
-      const item = (latestItems ?? await loadItems()).get(path)
-      if (!item) return
-      return item.data ?? item.content
-    },
-  }
-  if (options.prefix !== undefined) source.prefix = options.prefix
-  if (options.schema !== undefined) source.schema = options.schema
-  return source
+  return createContentSourceFactory(sourceInput, options).create()
 }
 
 /** Define the Comark Content runtime served by ViteHub from `server/content.ts`. */
 export function defineContent<
   const TPlugins extends ReadonlyArray<ContentPlugin<any, any>> = [],
 >(options: DefineContentOptions<TPlugins> = {}): ComarkContent & ContentMethods<TPlugins> {
-  const source = options.source ? contentSource(options.source) : undefined
-  const sources = options.sources
-    ? Object.fromEntries(Object.entries(options.sources).map(([name, input]) => [name, contentSource(input)]))
-    : undefined
+  let source = options.source ? contentSource(options.source) : undefined
+  let sources = options.sources ? configuredContentSources(options.sources) : undefined
+  if (source && getContentSourceFactory(source) && !sources) {
+    sources = configuredContentSources({ default: source })
+    source = undefined
+  }
 
   // SAFETY: Comark plugins add their declared methods to the returned runtime object.
   return comarkContent({

--- a/packages/content/test/content.test.ts
+++ b/packages/content/test/content.test.ts
@@ -1,6 +1,8 @@
+import { comarkContent, type ContentPlugin } from "comark-content"
 import sqlite from "comark-content/database/sqlite-node"
 import media from "comark-content/plugins/media"
 import sqliteFullTextSearch from "comark-content/plugins/sqlite-full-text-search"
+import { setTimeout as delay } from "node:timers/promises"
 import { afterEach, describe, expect, it } from "vitest"
 
 import { clearSources, registerSources, useSource } from "@vite-hub/source"
@@ -8,6 +10,18 @@ import { clearSources, registerSources, useSource } from "@vite-hub/source"
 import { contentSource, defineContent } from "../src/index.ts"
 
 afterEach(clearSources)
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function testPlugin(name: string, setup: ContentPlugin["setup"]): ContentPlugin {
+  return { name, setup }
+}
 
 describe("contentSource", () => {
   it("gives Comark Content parsed documents, navigation, cache, and runtime handling", async () => {
@@ -79,19 +93,72 @@ describe("contentSource", () => {
       },
     })
 
-    const content = defineContent({ sources: { live: "live" as any } })
+    const content = defineContent({ source: "live" as any })
     await expect(content.get("/", { fresh: true })).resolves.toEqual(
       expect.objectContaining({ nodes: expect.arrayContaining([expect.any(Array)]) }),
     )
 
     revision = 2
-    await content.cache.refresh("live")
+    await content.cache.refresh("default")
 
     const refreshed = await content.get("/")
     expect(JSON.stringify(refreshed?.nodes)).toContain("Revision 2")
   })
 
-  it("keeps overlapping loads on their selected reader revisions", async () => {
+  it("keeps each adapted source on one revision while async init parsers read", async () => {
+    const revisions = { first: 0, second: 0 }
+    const parsed: string[] = []
+    registerSources({
+      first: {
+        name: "first",
+        async resolveRevision() {
+          return { id: `first-${++revisions.first}`, immutable: true }
+        },
+        async getKeys() {
+          return ["one.slow", "two.slow"]
+        },
+        async getItem(key, ctx) {
+          return { content: `${ctx.revision?.id}:${key}`, key }
+        },
+      },
+      second: {
+        name: "second",
+        async resolveRevision() {
+          return { id: `second-${++revisions.second}`, immutable: true }
+        },
+        async getKeys() {
+          return ["one.slow", "two.slow"]
+        },
+        async getItem(key, ctx) {
+          return { content: `${ctx.revision?.id}:${key}`, key }
+        },
+      },
+    })
+
+    const content = defineContent({
+      plugins: [testPlugin("async-init", (content) => {
+        content.addParser([".slow"], async ({ partial, read }) => {
+          await delay(10)
+          const text = await read()
+          parsed.push(text)
+          return { data: { text }, kind: "document", partial }
+        })
+      })],
+      sources: { first: "first", second: "second" },
+    })
+
+    await content.init()
+
+    expect(revisions).toEqual({ first: 1, second: 1 })
+    expect(parsed.sort()).toEqual([
+      "first-1:one.slow",
+      "first-1:two.slow",
+      "second-1:one.slow",
+      "second-1:two.slow",
+    ])
+  })
+
+  it("keeps overlapping refreshes on separate reader revisions", async () => {
     let revision = 0
     registerSources({
       overlap: {
@@ -100,22 +167,155 @@ describe("contentSource", () => {
           return { id: String(++revision), immutable: true }
         },
         async getKeys() {
-          return ["index.md"]
+          return ["one.slow", "two.slow"]
         },
         async getItem(key, ctx) {
           return { content: `revision ${ctx.revision?.id}`, key }
         },
       },
     })
-    const source = contentSource(() => useSource("overlap" as any))
+    let readBarrier: ReturnType<typeof deferred> | undefined
+    let blockedParsers = 0
+    let expectedBlockedParsers = 2
+    let parsersStarted = deferred()
+    const content = defineContent({
+      plugins: [testPlugin("overlap", (content) => {
+        content.addParser([".slow"], async ({ partial, read }) => {
+          const firstText = await read()
+          if (readBarrier) {
+            blockedParsers++
+            if (blockedParsers === expectedBlockedParsers) parsersStarted.resolve()
+            await readBarrier.promise
+          }
+          const texts = [firstText, await read()]
+          return { data: { text: texts[0], texts }, kind: "document", partial }
+        })
+      })],
+      sources: { overlap: "overlap" },
+    })
+    await content.init()
 
-    await expect(Promise.all([
-      Promise.resolve(source.keys()).then(async keys => [keys, await source.getItem("index.md")]),
-      Promise.resolve(source.keys()).then(async keys => [keys, await source.getItem("index.md")]),
-    ])).resolves.toEqual([
-      [["index.md"], "revision 1"],
-      [["index.md"], "revision 2"],
+    readBarrier = deferred()
+    const firstRefresh = content.cache.refresh("overlap")
+    await parsersStarted.promise
+    expectedBlockedParsers = 4
+    parsersStarted = deferred()
+    const secondRefresh = content.cache.refresh("overlap")
+    await parsersStarted.promise
+
+    expect(revision).toBe(3)
+    readBarrier.resolve()
+    readBarrier = undefined
+
+    const [firstFiles, secondFiles] = await Promise.all([firstRefresh, secondRefresh])
+    expect(firstFiles.map(file => file.data.text)).toEqual(["revision 2", "revision 2"])
+    expect(secondFiles.map(file => file.data.text)).toEqual(["revision 3", "revision 3"])
+    expect(revision).toBe(3)
+
+    blockedParsers = 0
+    expectedBlockedParsers = 2
+    parsersStarted = deferred()
+    readBarrier = deferred()
+    const thirdRefresh = content.cache.refresh("overlap")
+    await parsersStarted.promise
+    expectedBlockedParsers = 4
+    parsersStarted = deferred()
+    const snapshot = content.cache.snapshot("overlap", { compress: false })
+    await parsersStarted.promise
+
+    expect(revision).toBe(5)
+    readBarrier.resolve()
+    readBarrier = undefined
+
+    const [, artifact] = await Promise.all([thirdRefresh, snapshot])
+    expect(artifact?.data).toContain('"text":"revision 5"')
+    expect(revision).toBe(5)
+
+    blockedParsers = 0
+    expectedBlockedParsers = 2
+    parsersStarted = deferred()
+    readBarrier = deferred()
+    const fourthRefresh = content.cache.refresh("overlap")
+    await parsersStarted.promise
+    expectedBlockedParsers = 3
+    parsersStarted = deferred()
+    const freshGet = content.get("/one", { fresh: true })
+    await parsersStarted.promise
+
+    expect(revision).toBe(7)
+    readBarrier.resolve()
+    readBarrier = undefined
+
+    const [, freshFile] = await Promise.all([fourthRefresh, freshGet])
+    expect(freshFile?.data.texts).toEqual(["revision 7", "revision 7"])
+    expect(revision).toBe(7)
+  })
+
+  it("retains a failed load until its other parsers settle", async () => {
+    let revision = 0
+    let failLoad = false
+    registerSources({
+      errors: {
+        name: "errors",
+        async resolveRevision() {
+          return { id: String(++revision), immutable: true }
+        },
+        async getKeys() {
+          return ["fail.test", "late.test"]
+        },
+        async getItem(key, ctx) {
+          return { content: `revision ${ctx.revision?.id}`, key }
+        },
+      },
+    })
+    const lateParserStarted = deferred()
+    const releaseLateParser = deferred()
+    const lateParserFinished = deferred()
+    const parsed: string[] = []
+    const content = defineContent({
+      logger: false,
+      onError: "throw",
+      plugins: [testPlugin("load-error", (content) => {
+        content.addParser([".test"], async ({ filepath, onError, partial, read }) => {
+          if (filepath === "fail.test" && failLoad) {
+            if (onError === "throw") throw new Error("expected parse failure")
+            return null
+          }
+          if (filepath === "late.test" && failLoad) {
+            lateParserStarted.resolve()
+            await releaseLateParser.promise
+          }
+          const text = await read()
+          parsed.push(text)
+          if (filepath === "late.test" && failLoad) lateParserFinished.resolve()
+          return { data: { text }, kind: "document", partial }
+        })
+      })],
+      sources: { errors: "errors" },
+    })
+    await content.init()
+
+    failLoad = true
+    let failedRefreshSettled = false
+    const failedRefresh = content.cache.refresh("errors").finally(() => {
+      failedRefreshSettled = true
+    })
+    await lateParserStarted.promise
+    await expect(failedRefresh).rejects.toThrow("expected parse failure")
+    expect(failedRefreshSettled).toBe(true)
+    expect(revision).toBe(2)
+
+    failLoad = false
+    const nextRefresh = content.cache.refresh("errors")
+    await expect(nextRefresh).resolves.toEqual([
+      expect.objectContaining({ data: { text: "revision 3" } }),
+      expect.objectContaining({ data: { text: "revision 3" } }),
     ])
+    failLoad = true
+    releaseLateParser.resolve()
+    await lateParserFinished.promise
+    expect(parsed).toContain("revision 2")
+    expect(revision).toBe(3)
   })
 
   it("serves media from the latest refreshed reader", async () => {
@@ -165,6 +365,87 @@ describe("contentSource", () => {
     await expect(source.getItemRaw("settings.json")).resolves.toEqual({ theme: "dark" })
   })
 
+  it("refreshes a direct adapter passed to raw Comark Content", async () => {
+    let revision = 0
+    const parsed: string[] = []
+    registerSources({
+      direct: {
+        name: "direct",
+        async resolveRevision() {
+          return { id: String(++revision), immutable: true }
+        },
+        async getKeys() {
+          return ["index.md"]
+        },
+        async getItem(key, ctx) {
+          return { content: `revision ${ctx.revision?.id}`, key }
+        },
+      },
+    })
+    const content = comarkContent({
+      plugins: [testPlugin("direct-refresh", (content) => {
+        content.addParser([".md"], async ({ partial, read }) => {
+          const texts = await Promise.all([read(), read()])
+          parsed.push(...texts)
+          return { data: { text: texts[0] }, kind: "document", partial }
+        })
+      })],
+      sources: { direct: contentSource("direct") },
+    })
+
+    await content.init()
+    await content.cache.refresh("direct")
+    await content.cache.refresh("direct")
+
+    expect(revision).toBe(3)
+    expect(parsed).toEqual([
+      "revision 1",
+      "revision 1",
+      "revision 2",
+      "revision 2",
+      "revision 3",
+      "revision 3",
+    ])
+  })
+
+  it("keeps the last completed raw enumeration after a direct adapter fails", async () => {
+    let fail = false
+    registerSources({
+      raw: {
+        name: "raw",
+        async getKeys() {
+          if (fail) throw new Error("expected enumeration failure")
+          return ["logo.png"]
+        },
+        async getItem(key) {
+          return { content: Uint8Array.of(1), key }
+        },
+      },
+    })
+    const source = contentSource("raw")
+
+    await expect(source.keys()).resolves.toEqual(["logo.png"])
+    await expect(source.getItemRaw("logo.png")).resolves.toEqual(Uint8Array.of(1))
+    fail = true
+    await expect(source.keys()).rejects.toThrow("expected enumeration failure")
+    await expect(source.getItemRaw("logo.png")).resolves.toEqual(Uint8Array.of(1))
+  })
+
+  it("preserves adapted source options across fresh load adapters", () => {
+    const schema = { properties: { title: { type: "string" } }, type: "object" } as const
+    const source = contentSource(contentSource("options", { prefix: "/base", schema }), { prefix: "/docs" })
+    const content = defineContent({ sources: { docs: source } })
+
+    expect(content.getSource("docs")).toMatchObject({ prefix: "/docs", schema })
+  })
+
+  it("rejects source and sources together", () => {
+    expect(() => defineContent({
+      source: "source",
+      sources: { docs: "sources" },
+    })).toThrow()
+  })
+
   it("preserves native Comark Content Sources", async () => {
     const source = {
       async keys() {
@@ -178,9 +459,26 @@ describe("contentSource", () => {
       },
     }
 
-    const content = defineContent({ sources: { native: source } })
-    expect(content.getSource("native")).toBe(source)
+    const content = defineContent({ source })
+    expect(content.getSource("default")).toBe(source)
     await expect(content.get("/")).resolves.toEqual(expect.objectContaining({ path: "/" }))
+  })
+
+  it("preserves a native Source named __proto__", () => {
+    const source = {
+      async keys() {
+        return ["index.md"]
+      },
+      async getItem() {
+        return "# Native"
+      },
+      async getItemRaw() {
+        return "# Native"
+      },
+    }
+    const content = defineContent({ sources: Object.fromEntries([["__proto__", source]]) })
+
+    expect(content.getSource("__proto__")).toBe(source)
   })
 
   it("preserves prototype-backed native Sources when applying options", async () => {


### PR DESCRIPTION
Async Comark parsers could outlive the adapter's zero-delay cache and reload the entire Source for each file. A single load could then mix Source revisions.

Give each `defineContent()` load a separate adapter that retains its selected Reader for delayed and repeated reads. Overlapping refreshes, fresh snapshots, and fresh document reads keep separate snapshots. Direct Comark adapters still refresh on enumeration. Native Sources, configured prefixes and schemas, and the last successful raw data after an enumeration error keep their behavior.

The [regression cases](https://github.com/vite-hub/vitehub/blob/93b16539032b1c2156ea899650b0ecc0ea169266/packages/content/test/content.test.ts) use Comark's actual parser and cache flows. This change isolates Source reads; Comark still owns manifest writes and parser failure handling.

Model: GPT-5.6 Sol
Harness: T3 Code / Codex
