### PR TITLE
perf(workspace): reconcile root Sources once

### DIFF
--- a/packages/workspace/src/lifecycle.ts
+++ b/packages/workspace/src/lifecycle.ts
@@ -182,9 +182,10 @@ async function reconcileBuildSourceMounts(definition: WorkspaceDefinition, store
     await store.rm(mountPath, { recursive: true, force: true })
     abortSignal?.throwIfAborted()
   }
-  for (const source of [...previousSources, ...currentSources].filter(source => !source.mountPath)) {
+  const rootSourceKeys = new Set([...previousSources, ...currentSources].filter(source => !source.mountPath).map(source => source.key))
+  for (const key of rootSourceKeys) {
     abortSignal?.throwIfAborted()
-    const removedPaths = await rootBuildSourceFilePaths(store, source)
+    const removedPaths = await rootBuildSourceFilePaths(store, key)
     const affected: ResolvedWorkspaceSource[] = []
     for (const startup of startupSources) {
       if (!removedPaths.some(path => sourceMountIntersectsPath(startup, path))) continue
@@ -308,10 +309,10 @@ async function readSyncedBuildSources(store: WorkspaceStore): Promise<SyncedBuil
   return value.filter(isSyncedBuildSource)
 }
 
-async function rootBuildSourceFilePaths(store: WorkspaceStore, source: SyncedBuildSource) {
+async function rootBuildSourceFilePaths(store: WorkspaceStore, key: string) {
   const entries = await store.list("", { recursive: true })
   return entries
-    .filter(entry => entry.type === "file" && entry.metadata?.source === source.key)
+    .filter(entry => entry.type === "file" && entry.metadata?.source === key)
     .map(entry => entry.path)
 }
 

--- a/packages/workspace/test/source-loader-publisher.test.ts
+++ b/packages/workspace/test/source-loader-publisher.test.ts
@@ -1484,6 +1484,55 @@ describe("sources, loaders, and publishers", () => {
     await expect(store.readFile("AGENTS.md")).resolves.toBeUndefined()
   })
 
+  it.each([
+    { name: "unchanged", previousMount: "", currentMount: "" },
+    { name: "removed", previousMount: "", currentMount: undefined },
+    { name: "moved from root to nested", previousMount: "", currentMount: "nested" },
+    { name: "moved from nested to root", previousMount: "nested", currentMount: "" },
+  ])("reconciles each root-mounted build source once when sources are $name", async ({ previousMount, currentMount }) => {
+    const store = createMemoryWorkspaceStore()
+    const sourceKeys = ["docs", "instructions", "notes"]
+    const createSources = (mount: string) => Object.fromEntries(sourceKeys.map(key => [key, custom({
+      mount: mount ? `${mount}/${key}` : "",
+      files: [
+        { path: `${key}.md`, content: `# ${key}\n`, metadata: { label: key } },
+        { path: `${key}-extra.md`, content: `# Extra ${key}\n`, metadata: { label: key } },
+      ],
+    })]))
+    const definition = { name: "root-build-source-reconciliation", sources: createSources(previousMount) }
+    const unrelated = { path: "unrelated.md", content: "Keep me\n", metadata: { label: "unrelated" } }
+    await store.writeFile(unrelated.path, unrelated)
+    await syncWorkspaceDefinition(definition, store)
+    const list = vi.spyOn(store, "list")
+    const readFile = vi.spyOn(store, "readFile")
+    const remove = vi.spyOn(store, "rm")
+    const currentSources = currentMount === undefined ? {} : createSources(currentMount)
+
+    await syncWorkspaceDefinition({ ...definition, sources: currentSources }, store)
+
+    expect(list.mock.calls.filter(([prefix]) => prefix === "")).toEqual(sourceKeys.map(() => ["", { recursive: true }]))
+    expect(readFile).not.toHaveBeenCalled()
+    if (!previousMount) {
+      expect(remove.mock.calls.filter(([, options]) => !options?.recursive).map(([path]) => path)).toEqual(
+        sourceKeys.flatMap(key => [`${key}-extra.md`, `${key}.md`]),
+      )
+    }
+    await expect(store.getMeta?.("workspace:build-sources")).resolves.toHaveLength(Object.keys(currentSources).length)
+    await expect(store.getMeta?.("workspace:build-sources")).resolves.toEqual(expect.arrayContaining(
+      Object.entries(currentSources).map(([key, source]) => ({ key, mountPath: source.mount })),
+    ))
+    const expectedFiles = [unrelated, ...currentMount === undefined ? [] : sourceKeys.flatMap(key => {
+      const prefix = currentMount ? `${currentMount}/${key}/` : ""
+      return [
+        { path: `${prefix}${key}.md`, content: `# ${key}\n`, metadata: { label: key, source: key } },
+        { path: `${prefix}${key}-extra.md`, content: `# Extra ${key}\n`, metadata: { label: key, source: key } },
+      ]
+    })]
+    const entries = await store.list("", { recursive: true })
+    expect(entries.filter(entry => entry.type === "file").map(entry => entry.path)).toEqual(expectedFiles.map(file => file.path).sort())
+    for (const file of expectedFiles) await expect(store.readFile(file.path)).resolves.toMatchObject(file)
+  })
+
   it("purges stale local build source files after store restarts", async () => {
     const root = await createRoot()
     const storeRoot = join(root, ".vitehub", "workspaces", "docs")


### PR DESCRIPTION
Root-mounted Sources were reconciled once from the previous state and again from the current state. Three unchanged Sources therefore caused six recursive Store listings.

Deduplicate the root Source keys before reconciliation. The same case now needs three listings, with the same cleanup of owned files and preservation of unrelated files.

[Before](https://github.com/vite-hub/vitehub/blob/cf3b0ccc816c336179a97b3039dc48fabaf78ef5/packages/workspace/src/lifecycle.ts#L185) · [After](https://github.com/vite-hub/vitehub/blob/0f4f0d53a422114871c52c4599da949fc14c77eb/packages/workspace/test/source-loader-publisher.test.ts#L1487). The repository regression covers unchanged, removed, and moved Sources.

Broader Workspace verification still depends on refreshing stale package build outputs. Baseline comparison found no new failures beyond the repaired regression.

Model: GPT-6 Astra. Harness: Codex CLI.
