### PR TITLE
refactor(source)!: compose readers from Source definitions

### DIFF
--- a/docs/content/docs/server-primitives/content.md
+++ b/docs/content/docs/server-primitives/content.md
@@ -22,11 +22,12 @@ pnpm add vite-hub comark-content
 import sqlite from 'comark-content/database/sqlite-node'
 import sqliteFullTextSearch from 'comark-content/plugins/sqlite-full-text-search'
 import { defineContent } from 'vite-hub/content'
+import { glob } from 'vite-hub/source/glob'
 
 export const content = defineContent({
   plugins: [sqliteFullTextSearch({ database: sqlite() })],
   sources: {
-    docs: 'docs',
+    docs: glob({ include: 'docs/**/*.md' }),
   },
 })
 
@@ -37,9 +38,11 @@ await content.search(['docs'], 'runtime')
 
 ViteHub discovers `server/content.ts` and serves its exported `content` instance at `/api/content/**` in Vite and Nuxt. No manual framework route or `fetch()` wrapper is required.
 
-Registered ViteHub Source names, explicit Source Readers, and native Comark Content Sources can coexist. `defineContent()` gives each adapted Source load a separate adapter that keeps its selected Reader until all parser reads finish. Registered Source names and Reader factories select a new Reader for each load. Explicit Readers stay fixed. Overlapping refreshes, fresh snapshots, and fresh document reads therefore keep their selected revisions. Raw media uses the newest successfully enumerated Source revision. Native Comark Content Sources pass through unchanged.
+Pass Source definitions directly without registration. `defineContent()` gives each adapted Source load a separate adapter that keeps its selected Reader until all parser reads finish. Each definition, registered name, or reader factory selects a new Reader for each load. Overlapping refreshes, fresh snapshots, and fresh document reads keep their selected revisions. Use `defineContent({ source: definition })` for a single Source.
 
-A direct `contentSource()` adapter selects a Reader when `keys()` starts an enumeration. Its later `getItem()` calls use that Reader until the next enumeration. Use `defineContent()` to isolate overlapping loads.
+Explicit readers and native Comark Content Sources can coexist with definitions. An explicit reader keeps its selected revision across refreshes. Readers only need an `items()` method. Raw media uses the newest successfully enumerated Source revision. Native Comark Content Sources keep their own loading behavior.
+
+Use `contentSource(definition, { prefix, schema })` to set Comark options for one Source. A direct adapter selects a Reader when `keys()` starts an enumeration. Its later `getItem()` calls use that Reader until the next enumeration. Use `defineContent()` to isolate overlapping loads.
 
 Use `sqlite-wasm` where Node SQLite is unavailable. Comark Content owns parsed document cache entries and exposes `refresh(source)`, `invalidate(key)`, and `expire(key)`.
 

--- a/docs/content/docs/server-primitives/source.md
+++ b/docs/content/docs/server-primitives/source.md
@@ -20,29 +20,29 @@ Source retrieves content but doesn't place it in a persistent file tree. Bind a 
 pnpm add vite-hub
 ```
 
-### Configure
+### Define a Source
 
-```ts [server/sources.ts]
-import { defineSources, registerSources } from 'vite-hub/source'
-import { file } from 'vite-hub/source/file'
+```ts [server/sources/docs.ts]
+import { glob } from 'vite-hub/source/glob'
 
-export const sources = defineSources({
-  readme: file('README.md'),
-})
-
-registerSources(sources)
+export const docs = glob({ cwd: 'docs', include: '**/*.md' })
 ```
 
-### Start using it
+### Open a reader
 
-```ts [server/api/readme.get.ts]
-import '../sources'
-import { useSource } from 'vite-hub/source'
+```ts [server/api/docs.get.ts]
+import { createSource } from 'vite-hub/source'
+import { docs } from '../sources/docs'
 
-export default defineEventHandler(() => {
-  return useSource('readme').read('README.md')
+export default defineEventHandler(async () => {
+  const reader = createSource(docs)
+  return reader.read('intro.md')
 })
 ```
+
+`createSource(definition, context?)` opens a reader directly. It infers keys,
+items, and metadata from the definition. No registry or global type map is needed.
+Reuse the same definition in Content or a Workspace Source Binding.
 
 ::
 
@@ -50,18 +50,19 @@ export default defineEventHandler(() => {
 
 | Import | Use |
 | --- | --- |
-| `defineSource`, `defineSources`, `createSource`, `combineSources`, `custom` from `vite-hub/source` | Define Sources, create context-dependent readers, and combine keyed readers. |
+| `defineSource`, `defineSources`, `createSource`, `combineSources` from `vite-hub/source` | Define loaders, open managed readers, and combine keyed readers. |
 | `defineCollection`, `table` from `vite-hub/source`, `useCollection` from `vite-hub/source/client` | Turn a table or custom loader into a typed, paginated HTTP read model and consume it from Vue. |
 | `useDatabase` from `vite-hub/database/drizzle` | Access a discovered database and its generated schema. |
 | `registerSource`, `registerSources`, `clearSources`, `getRegisteredSource`, `useSource` from `vite-hub/source` | Manage and read the process-local Source registry. |
 | `file`, `glob`, `github`, `markdown`, `mcpResources` from the matching `vite-hub/source/*` subpath | Select one built-in loader and its private implementation closure. |
+| `cachedSource` from `vite-hub/source/server` | Cache an existing keyed reader with Nitro cache options. |
 | `getViteHubErrorShape` from `vite-hub/runtime` | Inspect registry, path, and loader failures by `SOURCE_*` code. |
 
 Source, Source Reader, Source Item, revision, cache, and error types are exported from `vite-hub/source`. Loader option types live beside their implementation subpath. Libraries that install the package directly can use the matching `@vite-hub/source` paths.
 
 ## Register Sources
 
-Use `vite-hub/source` when you want a direct retrieval registry.
+Register Sources only when callers need lookup by name. Direct `createSource()` calls do not need registration.
 
 ```ts [server/sources.ts]
 import { defineSources, registerSources } from 'vite-hub/source'
@@ -79,11 +80,18 @@ export const sources = defineSources({
 })
 
 registerSources(sources)
+
+declare global {
+  interface ViteHubSourceMap {
+    readme: typeof sources.readme
+    docs: typeof sources.docs
+  }
+}
 ```
 
 Named Source Loader imports are the public authoring shape. Import the helpers you need directly.
 
-Source has no discovery or Vite Integration by itself. Import the module that registers Sources before calling `useSource()` in a process.
+Import the module that registers Sources before calling `useSource()` in a process. For typed name lookup, declare `ViteHubSourceMap` entries as `typeof` the matching definitions. The Vite integration generates Collection types and routes, but does not generate this named Source map.
 
 ## Source loader options
 
@@ -94,7 +102,7 @@ Source has no discovery or Vite Integration by itself. Import the module that re
 | `glob(options)` | `include`, `cwd`, `ignore`, `dot`, `followSymlinks`, `keyCache`, `prefix`. | Expands local files with `tinyglobby`; `keyCache: false` disables the cached key snapshot. Symbolic links are off by default. |
 | `github(options)` | `repo`, `ref`, `root`, `auth`, `include`, `ignore`, `cache`. | Retrieves repository archive content. `auth` can be a token string or a trusted callback. |
 | `mcpResources(options)` | `server`, `include`, `ignore`, `path`, `request`, `cache`. | Reads MCP Resource content. `server` can be a client, client config, or resolver. |
-| `custom(source)` | A `Source` object. | Use when the built-in loaders do not match the origin contract. |
+| `defineSource(loader)` | A loader with `name`, `getKeys`, and `getItem`. | Define custom retrieval behavior with inferred item types. |
 
 Use `sourceIgnores` from `vite-hub/source` for reusable dependency, generated-output, media, secret, and system-file patterns. Workspace GitHub Sources apply `sourceIgnores.defaults` automatically; pass `ignore: false` to opt out or provide more patterns to extend the defaults.
 
@@ -110,7 +118,33 @@ Use `sourceIgnores` from `vite-hub/source` for reusable dependency, generated-ou
 
 ## Source object contract
 
-A custom `Source` implements the retrieval behavior directly.
+`defineSource()` accepts a loader definition. Every loader has `name`,
+`getKeys()`, and `getItem()`. It does not accept reader objects or reader factories.
+
+```ts
+import { createSource, defineSource } from 'vite-hub/source'
+
+const articles = defineSource({
+  name: 'articles',
+  async getKeys() {
+    return ['article_123' as const]
+  },
+  async getItem(key: `article_${string}`) {
+    return { key, data: { title: 'Source API' }, metadata: { version: 1 } }
+  },
+})
+
+const reader = createSource(articles)
+const article = await reader.get('article_123')
+article.data.title
+article.metadata.version
+```
+
+`SourceReader<typeof articles>`, `SourceKey<typeof articles>`,
+`SourceData<typeof articles>`, and `SourceMetadata<typeof articles>` derive their
+types from the definition. A record reader has no typed `read()` or `list()`
+methods. File loaders return `FileSource`, whose `SourceFile` items always have
+`content`. Custom loaders that guarantee `content` receive these file methods too.
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -123,17 +157,18 @@ A custom `Source` implements the retrieval behavior directly.
 | `getItem(key, ctx)` | `function` | Returns a `SourceItem` for one key. |
 | `getItems(ctx)` | `function` | Optional bulk item reader. |
 | `getMeta(key, ctx)` | `function` | Optional metadata reader. |
-`getKeys()` and `getItem()` are required. `resolveRevision()` and `prepare()` each run at most once for every `useSource()` reader before its first operation. The resolved revision is added to the shared context, so preparation, keys, items, and metadata observe the same origin snapshot. `getItems()` lets a consumer load all items in one call; `getMeta()` can return origin metadata without loading content.
+
+`getKeys()` and `getItem()` are required. `resolveRevision()` and `prepare()` each run at most once for every `createSource()` or `useSource()` reader before its first operation. The resolved revision is added to the shared context. Revision-aware loaders use it for preparation, keys, items, and metadata. Loaders without revision support can observe origin changes. `getItems()` lets a consumer load all items in one call; `getMeta()` can return origin metadata without loading content.
 
 ### Source context
 
-The caller supplies `SourceContext` to every custom Source method.
+`createSource()` accepts a partial context and supplies the full `SourceContext` to each loader method. `useSource(name, context?)` uses the same reader lifecycle.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `rootDir` | `string` | `process.cwd()` for `useSource()` | Base project directory. |
+| `rootDir` | `string` | `process.cwd()` | Base project directory. |
 | `sourceRootDir` | `string` | None | Optional Source-specific root. Built-in local file loaders fall back to `rootDir` when it is absent. |
-| `source` | `string` | Registered Source name | Identifies the active Source. |
+| `source` | `string` | Definition name, or registered name for `useSource()` | Identifies the active Source. |
 | `workspace` | `string` | None | Identifies the Workspace consuming the Source. |
 | `abortSignal` | `AbortSignal` | None | Cancels in-flight work. Custom loaders must forward it to fetches and other abortable operations. |
 | `revision` | `SourceRevision` | None | The revision pinned by `resolveRevision()` for every later operation in this reader or Workspace lifecycle. |
@@ -161,11 +196,12 @@ export default defineEventHandler(async () => {
 | --- | --- |
 | `source.revision()` | The pinned origin revision, when supported. |
 | `source.keys()` | All Source keys. |
-| `source.get(key)` | A `SourceItem` with content, data, media type, and metadata. |
-| `source.read(key, options?)` | Text by default, or `Uint8Array` with `{ encoding: 'binary' }`. |
+| `source.get(key)` | The loader's inferred item. Items can hold content, structured data, or both. |
+| `source.items()` | All items, using `getItems()` when supplied, otherwise `getKeys()` and `getItem()`. |
+| `source.read(key, options?)` | File readers only. Text by default, or `Uint8Array` with `{ encoding: 'binary' }`. |
 | `source.meta(key)` | Metadata for one key, when the loader supports it. |
 | `source.exists(key)` | Whether a key exists. |
-| `source.list(prefix?)` | Direct child files and directories below a prefix. |
+| `source.list(prefix?)` | File readers only. Direct child files and directories below a prefix. |
 
 ```ts [server/api/docs.get.ts]
 import '../sources'
@@ -183,7 +219,18 @@ export default defineEventHandler(async () => {
 
 ## Parse and serve content
 
-Use [Content](/docs/server-primitives/content) when Source output should become parsed documents, navigation, queries, or full-text search.
+Use [Content](/docs/server-primitives/content) when Source output should become parsed documents, navigation, queries, or full-text search. Pass the definition directly:
+
+```ts [server/content.ts]
+import { defineContent } from 'vite-hub/content'
+import { docs } from './sources/docs'
+
+export const content = defineContent({ source: docs })
+```
+
+Content opens a new reader for each refresh. Each load keeps its own revision,
+including when refreshes overlap. Pass a definition when Content should own that
+lifecycle. An explicitly supplied reader retains its caller-owned lifecycle.
 
 ## Combine keyed Source readers
 
@@ -192,21 +239,21 @@ combined reader identifies each item with a `[source, key]` tuple, so the source
 alias remains part of the runtime value and its inferred type.
 
 ```ts [server/recaps.ts]
-import { combineSources, createSource, defineSource } from 'vite-hub/source'
+import { combineSources } from 'vite-hub/source'
 
-const github = defineSource(context => ({
-  async get(month: `${number}-${number}`) {
-    return { month, rootDir: context.rootDir }
-  },
-  async items() {
-    return [{ key: '2026-07' as const }]
-  },
-}))
+function githubRecaps(rootDir: string) {
+  return {
+    async get(month: `${number}-${number}`) {
+      return { month, rootDir }
+    },
+    async items() {
+      return [{ key: '2026-07' as const }]
+    },
+  }
+}
 
 export const recaps = combineSources({
-  sources: {
-    github: createSource(github, { rootDir: process.cwd() }),
-  },
+  sources: { github: githubRecaps(process.cwd()) },
 })
 
 await recaps.get(['github', '2026-07'])
@@ -214,15 +261,30 @@ await recaps.items()
 // [{ key: '2026-07', source: 'github', identity: ['github', '2026-07'] }]
 ```
 
-Source aliases must be strings. `get()` infers the accepted key and result
-for each alias. `items()` is available on every combined reader, but it rejects a
-partially enumerable reader before starting any work. When every reader
-implements `items()`, each returned item includes `source` and `identity`.
+Source aliases must be strings. `get()` infers the accepted key and result for
+each alias. `items()` exists only when every input reader implements it. Each
+listed item includes `source` and `identity`.
 
-`defineSource(context => reader)` declares a context-dependent keyed reader.
-`createSource()` creates that reader with a `SourceContext`. Combined readers do not
-change the process-local registry: `defineSources()`, `registerSources()`, and
-`useSource()` keep their existing behavior.
+Use ordinary objects or functions for custom keyed readers. Use `defineSource()`
+for loaders that need the managed revision and preparation lifecycle.
+
+### Cache a reader
+
+```ts
+import { cachedSource } from 'vite-hub/source/server'
+
+const cachedRecaps = cachedSource(githubRecaps(process.cwd()), {
+  name: 'recaps',
+  maxAge: 60,
+})
+
+await cachedRecaps.get('2026-07')
+```
+
+`cachedSource(reader, options)` accepts an existing keyed reader and Nitro cache
+options. Cache ordinary readers before passing them to `combineSources()`.
+Give each cache a name that identifies its origin and access scope.
+Do not share one cache name across callers who can see different data.
 
 ## Expose a typed Collection
 
@@ -319,28 +381,58 @@ filters return HTTP 400.
 Use Workspace Source Bindings when retrieved content needs to appear inside a persistent Workspace file tree.
 
 ```ts [server/workspaces/docs.ts]
-import { defineWorkspace, file, github } from 'vite-hub/workspace'
+import { defineWorkspace } from 'vite-hub/workspace'
+import { docs } from '../sources/docs'
 
 export default defineWorkspace({
   sources: {
-    readme: file('README.md'),
-    docs: github({
-      repo: 'acme/docs',
-      root: 'docs',
+    docs: {
+      source: docs,
       mount: 'docs',
       materialize: 'lazy',
-    }),
+    },
   },
 })
 ```
 
-The same loader names appear in both packages. Import them from `vite-hub/source/*` for direct retrieval through `useSource()`. Import them from `vite-hub/workspace` when retrieved items need Workspace paths, materialization, sync, validation, resolution, or access rules.
+Workspace owns placement, materialization, sync, and access rules. The Source
+still owns retrieval. The binding above reuses the same definition as direct
+reads and Content. The key `intro.md` appears at `docs/intro.md` in the Workspace.
 
-## Provider output
+Workspace also exports helpers such as `file()` and `github()` that combine
+loader options with Workspace binding options. Existing bindings remain valid.
 
-Source has no Vite integration. By itself, it doesn't generate host output, provider config, or discovered Definitions.
+## Framework output
 
-Workspace and other consuming packages can wrap Sources in discovered Definitions, runtime registries, generated metadata, or Provider Output when they need placement, persistence, or deployment wiring.
+`hubSource()` from `vite-hub/source/vite` discovers Collections and Content. It
+generates Collection type declarations and GET routes, plus the Content route.
+The Nuxt integration installs this behavior for Nuxt applications.
+
+Direct Source definitions and their optional process-local registry do not need
+Vite. The integration does not discover a `server/sources` directory or generate
+`ViteHubSourceMap`. Workspace owns its own discovered definitions and provider
+output.
+
+## Migrate existing Source code
+
+- Replace `defineSource(reader)` with the reader object itself. Replace
+  `defineSource(context => reader)` and `createSource(factory, context)` with
+  an ordinary factory function and call it directly.
+- Replace `custom(loader)` from `vite-hub/source` with `defineSource(loader)`.
+  Workspace's `custom()` binding helper remains available.
+- Replace the server `defineSource({ ...reader, cache: cacheOptions })` wrapper
+  with `cachedSource(reader, { name, ...cacheOptions })`.
+- Change `SourceReader<'docs'>` and the key, data, and metadata helper types to
+  use `typeof docs`. Use `RegisteredSource<'docs'>` when only the registry name
+  is available.
+- Use `get()` or `items()` for records. File readers expose `read()` and `list()`
+  only when their item type guarantees content. Declare file loaders as
+  `FileSource` if an explicit return type is needed.
+- A combined reader with any get-only input no longer exposes `items()`.
+- Pass loader definitions directly to Content when it should create a new
+  reader for each refresh.
+
+Collections retain their pagination, schema validation, and response shaping API.
 
 ## Production checks
 

--- a/docs/content/docs/server-primitives/workspace.md
+++ b/docs/content/docs/server-primitives/workspace.md
@@ -174,10 +174,40 @@ Instruction text reads scalar bindings with `{{ workspace.<name> }}` and file-ba
 
 ## Source Binding options
 
-Workspace Source Bindings can wrap Source Package loaders and add Workspace behavior.
+Bind a standalone Source definition with `{ source, mount, materialize }`. Reuse
+the definition for direct reads or Content:
+
+```ts [server/sources/docs.ts]
+import { glob } from 'vite-hub/source/glob'
+
+export const docs = glob({ cwd: 'docs', include: '**/*.md' })
+```
+
+```ts [server/workspaces/docs.ts]
+import { defineWorkspace } from 'vite-hub/workspace'
+import { docs } from '../sources/docs'
+
+export default defineWorkspace({
+  sources: {
+    docs: { source: docs, mount: 'docs', materialize: 'lazy' },
+  },
+})
+```
+
+The Source key `intro.md` appears at `docs/intro.md`. The binding owns placement,
+materialization, sync, and access rules. Source owns retrieval. Pass the same
+`docs` definition to `createSource(docs)` for direct reads or
+`defineContent({ source: docs })` for parsed Content. Each consumer owns its
+reader lifecycle and revision.
+
+The Workspace `file()`, `glob()`, and other binding helpers remain available
+when a definition is used only in Workspace. Standalone Source loaders use
+`defineSource()` for custom retrieval; Workspace's `custom()` helper adds
+Workspace binding behavior.
 
 | Option | Type | Description |
 | --- | --- | --- |
+| `source` | `Source` | Standalone loader definition to bind. Required in the explicit binding form. |
 | `mount` | `WorkspaceSourceMount` | Where retrieved items appear in the Workspace file tree. Accepts a path string or Mount options. |
 | `materialize` | `WorkspaceMaterializeMode` | Build-time, process-startup, lazy, or disabled materialization. Values: `build`, `startup`, `lazy`, `none`. Startup Sources remain available through lazy reads and can be prepared with `createWorkspacePreparation()`. |
 | `cache` | `false or WorkspaceCacheOptions` | Source cache policy. Use `false` to disable caching or `{ maxAge }` to set a TTL. |

--- a/packages/content/README.md
+++ b/packages/content/README.md
@@ -1,6 +1,6 @@
 # @vite-hub/content
 
-`@vite-hub/content` runs Comark Content with native Comark Sources, registered ViteHub Sources, or explicit ViteHub Source Readers.
+`@vite-hub/content` runs Comark Content with ViteHub Source definitions, registered names, explicit readers, or native Comark Sources.
 
 ## Install
 
@@ -12,10 +12,11 @@ pnpm add @vite-hub/content @vite-hub/source comark-content
 
 ```ts
 import { defineContent } from "@vite-hub/content"
+import { glob } from "@vite-hub/source/glob"
 
 export const content = defineContent({
   sources: {
-    docs: "docs",
+    docs: glob({ include: "docs/**/*.md" }),
   },
 })
 
@@ -23,9 +24,11 @@ await content.get("/guide")
 await content.navigation(["docs"])
 ```
 
-`defineContent()` gives each adapted Source load a separate adapter that keeps its selected Reader until all parser reads finish. Registered Source names and Reader factories select a new Reader for each load. Explicit Readers stay fixed. Overlapping refreshes, fresh snapshots, and fresh document reads therefore keep their selected revisions. Raw media uses the newest successfully enumerated Source revision. Native Comark Sources pass through unchanged.
+Pass Source definitions directly. No registration is required. `defineContent()` gives each adapted Source load a separate adapter that keeps its selected Reader until all parser reads finish. Definitions, registered names, and reader factories select a new Reader for each load. Overlapping refreshes, fresh snapshots, and fresh document reads keep their selected revisions.
 
-A direct `contentSource()` adapter selects a Reader when `keys()` starts an enumeration. Its later `getItem()` calls use that Reader until the next enumeration. Use `defineContent()` to isolate overlapping loads.
+`contentSource(definition, { prefix, schema })` adapts a definition with Comark options. A direct adapter selects a Reader when `keys()` starts an enumeration. Its later `getItem()` calls use that Reader until the next enumeration. Use `defineContent()` to isolate overlapping loads. `defineContent({ source: definition })` also accepts a single Source.
+
+An explicit reader keeps its selected revision across refreshes. Readers only need an `items()` method. Raw media uses the newest successfully enumerated Source revision. Native Comark Sources pass through unchanged.
 
 The combined `vite-hub` framework discovers `server/content.ts` and serves its exported `content` instance at `/api/content/**`.
 

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -1,7 +1,7 @@
 import { comarkContent } from "comark-content"
 import { defineEventHandler } from "h3"
 
-import { useSource } from "@vite-hub/source"
+import { createSource, useSource } from "@vite-hub/source"
 
 import type {
   ComarkContent,
@@ -11,7 +11,7 @@ import type {
   Source as ComarkContentSource,
 } from "comark-content"
 import type { H3Event } from "h3"
-import type { SourceItem, SourceName, SourceReader } from "@vite-hub/source"
+import type { Source, SourceItem, SourceName } from "@vite-hub/source"
 
 export interface ContentHandler {
   (event: unknown): Promise<unknown>
@@ -46,7 +46,16 @@ type NodeContentRequest = {
   [Symbol.asyncIterator](): AsyncIterator<Uint8Array>
   once(event: "aborted", listener: () => void): unknown
 }
-export type ContentSourceInput = SourceName | SourceReader | (() => SourceReader) | ComarkContentSource
+export interface ContentSourceReader {
+  items(): Promise<ContentSourceItem[]>
+}
+
+export type ContentSourceInput =
+  | Source<string, unknown, object>
+  | SourceName
+  | ContentSourceReader
+  | (() => ContentSourceReader)
+  | ComarkContentSource
 
 const contentSourceFactory = Symbol("vitehub.contentSourceFactory")
 
@@ -122,12 +131,14 @@ function isComarkContentSource(input: ContentSourceInput): input is ComarkConten
   )
 }
 
-function isSourceReaderFactory(input: SourceName | SourceReader | (() => SourceReader)): input is () => SourceReader {
-  return input instanceof Function
-}
-
-function isSourceName(input: SourceName | SourceReader | (() => SourceReader)): input is SourceName {
-  return !(input instanceof Object)
+function isSourceDefinition(input: ContentSourceInput): input is Source<string, unknown, object> {
+  return (
+    isRuntimeObject(input)
+    && "getKeys" in input
+    && isRuntimeFunction(input.getKeys)
+    && "getItem" in input
+    && isRuntimeFunction(input.getItem)
+  )
 }
 
 function configuredContentSource(input: ComarkContentSource, options: ContentSourceOptions): ComarkContentSource {
@@ -158,7 +169,7 @@ function contentSourceOptions(
 }
 
 function createContentSourceFactory(
-  sourceInput: SourceName | SourceReader | (() => SourceReader),
+  sourceInput: Source<string, unknown, object> | SourceName | ContentSourceReader | (() => ContentSourceReader),
   defaults: ContentSourceOptions,
 ): ContentSourceFactory {
   const state: ContentSourceState = { latestSequence: 0, nextSequence: 0 }
@@ -172,11 +183,13 @@ function createContentSourceFactory(
           const sequence = ++state.nextSequence
           itemsPromise = (async () => {
             const nextItems = new Map<string, ContentSourceItem>()
-            const currentReader = isSourceName(sourceInput)
+            const currentReader = typeof sourceInput === "string"
               ? useSource(sourceInput)
-              : isSourceReaderFactory(sourceInput)
-                ? sourceInput()
-                : sourceInput
+              : isSourceDefinition(sourceInput)
+                ? createSource(sourceInput)
+                : isRuntimeFunction(sourceInput)
+                  ? sourceInput()
+                  : sourceInput
             for (const item of await currentReader.items()) {
               const path = contentPath(item)
               if (nextItems.has(path)) {
@@ -256,16 +269,14 @@ function configuredContentSources(inputs: Record<string, ContentSourceInput>): R
   return sources
 }
 
-/** Adapt a registered ViteHub Source or Source Reader to the interface consumed by Comark Content. */
+/** Adapt a Source to Comark Content, opening a fresh reader for each definition load. */
 export function contentSource(input: ContentSourceInput, options: ContentSourceOptions = {}): ComarkContentSource {
   if (isComarkContentSource(input)) {
     const factory = getContentSourceFactory(input)
     if (factory) return factory.create(options)
     return options.prefix === undefined && options.schema === undefined ? input : configuredContentSource(input, options)
   }
-  // SAFETY: The native Comark Source branch returned above, leaving only ViteHub Source inputs.
-  const sourceInput = input as SourceName | SourceReader | (() => SourceReader)
-  return createContentSourceFactory(sourceInput, options).create()
+  return createContentSourceFactory(input, options).create()
 }
 
 /** Define the Comark Content runtime served by ViteHub from `server/content.ts`. */

--- a/packages/content/src/index.ts
+++ b/packages/content/src/index.ts
@@ -119,6 +119,10 @@ function isRuntimeObject(value: unknown): value is object {
   return value !== null && Object(value) === value && !isRuntimeFunction(value)
 }
 
+function isSourceName(input: ContentSourceInput): input is SourceName {
+  return Object(input) !== input && Object.prototype.toString.call(input) === "[object String]"
+}
+
 function isComarkContentSource(input: ContentSourceInput): input is ComarkContentSource {
   return (
     isRuntimeObject(input)
@@ -183,7 +187,7 @@ function createContentSourceFactory(
           const sequence = ++state.nextSequence
           itemsPromise = (async () => {
             const nextItems = new Map<string, ContentSourceItem>()
-            const currentReader = typeof sourceInput === "string"
+            const currentReader = isSourceName(sourceInput)
               ? useSource(sourceInput)
               : isSourceDefinition(sourceInput)
                 ? createSource(sourceInput)

--- a/packages/content/test/content.test.ts
+++ b/packages/content/test/content.test.ts
@@ -1,11 +1,12 @@
 import { comarkContent, type ContentPlugin } from "comark-content"
 import sqlite from "comark-content/database/sqlite-node"
+import json from "comark-content/plugins/json"
 import media from "comark-content/plugins/media"
 import sqliteFullTextSearch from "comark-content/plugins/sqlite-full-text-search"
 import { setTimeout as delay } from "node:timers/promises"
-import { afterEach, describe, expect, it } from "vitest"
+import { afterEach, describe, expect, expectTypeOf, it } from "vitest"
 
-import { clearSources, registerSources, useSource } from "@vite-hub/source"
+import { clearSources, createSource, defineSource, registerSources, useSource } from "@vite-hub/source"
 
 import { contentSource, defineContent } from "../src/index.ts"
 
@@ -25,25 +26,23 @@ function testPlugin(name: string, setup: ContentPlugin["setup"]): ContentPlugin 
 
 describe("contentSource", () => {
   it("gives Comark Content parsed documents, navigation, cache, and runtime handling", async () => {
-    registerSources({
-      docs: {
-        name: "docs",
-        async getKeys() {
-          return ["document_1"]
-        },
-        async getItem() {
-          return {
-            content: "---\ntitle: Introduction\n---\n# Start\n\nRuntime content.\n",
-            key: "document_1",
-            path: "guide/index.md",
-          }
-        },
+    const docs = defineSource({
+      name: "docs",
+      async getKeys() {
+        return ["document_1"]
+      },
+      async getItem() {
+        return {
+          content: "---\ntitle: Introduction\n---\n# Start\n\nRuntime content.\n",
+          key: "document_1",
+          path: "guide/index.md",
+        }
       },
     })
 
     const content = defineContent({
       plugins: [sqliteFullTextSearch({ database: sqlite() })],
-      sources: { docs: "docs" },
+      sources: { docs },
     })
 
     await expect(content.list("docs")).resolves.toEqual([
@@ -73,36 +72,40 @@ describe("contentSource", () => {
     await expect(content.cache.keys("docs")).resolves.toEqual(["docs:guide/index.md"])
   })
 
-  it("uses a fresh Source Reader when Comark refreshes runtime content", async () => {
+  it.each(["definition", "name", "factory"] as const)("uses a fresh reader on refresh with a %s", async (input) => {
     let revision = 1
-    registerSources({
-      live: {
-        name: "live",
-        async resolveRevision() {
-          return { id: String(revision), immutable: true }
-        },
-        async getKeys() {
-          return ["index.md"]
-        },
-        async getItem(_key, ctx) {
-          return {
-            content: `# Revision ${ctx.revision?.id}`,
-            key: "index.md",
-          }
-        },
+    const prepared: string[] = []
+    const docs = defineSource({
+      name: "live",
+      async resolveRevision() {
+        return { id: String(revision), immutable: true }
+      },
+      async prepare(ctx) {
+        prepared.push(ctx.revision!.id)
+      },
+      async getKeys() {
+        return ["index.md"]
+      },
+      async getItem(_key, ctx) {
+        return {
+          content: `# Revision ${ctx.revision?.id}`,
+          key: "index.md",
+        }
       },
     })
-
-    const content = defineContent({ source: "live" as any })
-    await expect(content.get("/", { fresh: true })).resolves.toEqual(
-      expect.objectContaining({ nodes: expect.arrayContaining([expect.any(Array)]) }),
-    )
+    registerSources({ docs })
+    const source = input === "definition" ? docs : input === "name" ? "docs" : () => createSource(docs)
+    const content = defineContent({ sources: { live: source } })
+    const initial = await content.get("/", { fresh: true })
+    expect(JSON.stringify(initial?.nodes)).toContain("Revision 1")
 
     revision = 2
-    await content.cache.refresh("default")
+    await content.cache.refresh("live")
 
     const refreshed = await content.get("/")
     expect(JSON.stringify(refreshed?.nodes)).toContain("Revision 2")
+    expect(prepared).toContain("1")
+    expect(prepared.at(-1)).toBe("2")
   })
 
   it("keeps each adapted source on one revision while async init parsers read", async () => {
@@ -316,6 +319,46 @@ describe("contentSource", () => {
     await lateParserFinished.promise
     expect(parsed).toContain("revision 2")
     expect(revision).toBe(3)
+  })
+
+  it("accepts an items-only reader and preserves its selected revision", async () => {
+    let revision = 1
+    const definition = defineSource({
+      name: "explicit",
+      async resolveRevision() {
+        return { id: String(revision), immutable: true }
+      },
+      async getKeys() {
+        return ["index.md"]
+      },
+      async getItem(key, ctx) {
+        return { content: `revision ${ctx.revision?.id}`, key }
+      },
+    })
+    const reader = createSource(definition)
+    const source = contentSource({ items: () => reader.items() })
+    await source.keys()
+    await expect(source.getItem("index.md")).resolves.toBe("revision 1")
+
+    revision = 2
+    await source.keys()
+    await expect(source.getItem("index.md")).resolves.toBe("revision 1")
+  })
+
+  it("accepts direct structured definitions in the single-source form", async () => {
+    const settings = defineSource({
+      name: "settings",
+      async getKeys() {
+        return ["settings.json"]
+      },
+      async getItem(key) {
+        return { key, data: { theme: "dark" as const } }
+      },
+    })
+    const reader = createSource(settings)
+    expectTypeOf(await reader.get("settings.json")).toMatchTypeOf<{ data: { theme: "dark" } }>()
+    const content = defineContent({ plugins: [json()], source: settings })
+    await expect(content.get("/settings")).resolves.toEqual(expect.objectContaining({ data: { theme: "dark" } }))
   })
 
   it("serves media from the latest refreshed reader", async () => {

--- a/packages/content/test/content.test.ts
+++ b/packages/content/test/content.test.ts
@@ -7,6 +7,7 @@ import { setTimeout as delay } from "node:timers/promises"
 import { afterEach, describe, expect, expectTypeOf, it } from "vitest"
 
 import { clearSources, createSource, defineSource, registerSources, useSource } from "@vite-hub/source"
+import type { SourceName } from "@vite-hub/source"
 
 import { contentSource, defineContent } from "../src/index.ts"
 
@@ -147,7 +148,7 @@ describe("contentSource", () => {
           return { data: { text }, kind: "document", partial }
         })
       })],
-      sources: { first: "first", second: "second" },
+      sources: { first: "first" as SourceName, second: "second" as SourceName },
     })
 
     await content.init()
@@ -194,7 +195,7 @@ describe("contentSource", () => {
           return { data: { text: texts[0], texts }, kind: "document", partial }
         })
       })],
-      sources: { overlap: "overlap" },
+      sources: { overlap: "overlap" as SourceName },
     })
     await content.init()
 
@@ -294,7 +295,7 @@ describe("contentSource", () => {
           return { data: { text }, kind: "document", partial }
         })
       })],
-      sources: { errors: "errors" },
+      sources: { errors: "errors" as SourceName },
     })
     await content.init()
 
@@ -433,7 +434,7 @@ describe("contentSource", () => {
           return { data: { text: texts[0] }, kind: "document", partial }
         })
       })],
-      sources: { direct: contentSource("direct") },
+      sources: { direct: contentSource("direct" as SourceName) },
     })
 
     await content.init()
@@ -465,7 +466,7 @@ describe("contentSource", () => {
         },
       },
     })
-    const source = contentSource("raw")
+    const source = contentSource("raw" as SourceName)
 
     await expect(source.keys()).resolves.toEqual(["logo.png"])
     await expect(source.getItemRaw("logo.png")).resolves.toEqual(Uint8Array.of(1))
@@ -476,7 +477,7 @@ describe("contentSource", () => {
 
   it("preserves adapted source options across fresh load adapters", () => {
     const schema = { properties: { title: { type: "string" } }, type: "object" } as const
-    const source = contentSource(contentSource("options", { prefix: "/base", schema }), { prefix: "/docs" })
+    const source = contentSource(contentSource("options" as SourceName, { prefix: "/base", schema }), { prefix: "/docs" })
     const content = defineContent({ sources: { docs: source } })
 
     expect(content.getSource("docs")).toMatchObject({ prefix: "/docs", schema })
@@ -484,8 +485,8 @@ describe("contentSource", () => {
 
   it("rejects source and sources together", () => {
     expect(() => defineContent({
-      source: "source",
-      sources: { docs: "sources" },
+      source: "source" as SourceName,
+      sources: { docs: "sources" as SourceName },
     })).toThrow()
   })
 

--- a/packages/source/README.md
+++ b/packages/source/README.md
@@ -14,84 +14,143 @@
 pnpm add @vite-hub/source
 ```
 
-## Minimal API
+## Open a Source
 
 ```ts
-// server/utils/sources.ts
-import { defineSources, registerSources, useSource } from "@vite-hub/source"
-import { file } from "@vite-hub/source/file"
-import { github } from "@vite-hub/source/github"
+import { createSource } from "@vite-hub/source"
 import { glob } from "@vite-hub/source/glob"
 
-registerSources(defineSources({
-  docs: glob({ include: "docs/**/*.md" }),
-  readme: file("README.md"),
-  upstream: github({ repo: "vite-hub/vitehub" }),
-}))
+export const docs = glob({ cwd: "docs", include: "**/*.md" })
 
-const docs = useSource("docs", { rootDir: process.cwd() })
-const revision = await docs.revision()
-const keys = await docs.keys()
-const first = await docs.read(keys[0]!)
+const reader = createSource(docs, { rootDir: process.cwd() })
+const revision = await reader.revision()
+const keys = await reader.keys()
+const first = await reader.read(keys[0]!)
 ```
+
+`createSource(definition, context?)` infers keys, items, and metadata from the
+Source definition. It resolves a revision and prepares the Source once per
+reader. Revision-aware loaders receive the same pinned revision on every
+operation. Loaders without revision support can observe origin changes. Create
+another reader to resolve a new revision. No registration or global type map is needed.
 
 `file()` follows a symbolic link only when its resolved target stays inside the Source root. `glob()` is also confined to the Source root. It does not follow symbolic links by default, and it checks each file path again before it reads content or metadata. Set `followSymlinks: true` to follow links when their resolved targets stay inside the Source root. This option controls file selection. It does not isolate the process from concurrent file system changes.
 
-`revision()` resolves an origin snapshot once per reader. Revision-aware loaders
-then use the same immutable identity for preparation, keys, and item reads.
-
-## Use a Source with Comark Content
-
-Install `@vite-hub/content` when Source output should become parsed documents,
-navigation, queries, or full-text search. The Content package adapts registered
-Sources and explicit Source Readers without adding content behavior to this
-package.
-
-Structured sources preserve record and metadata types through `useSource()`:
+Use `defineSource()` for custom loaders:
 
 ```ts
-import type { Source } from "@vite-hub/source"
+import { createSource, defineSource } from "@vite-hub/source"
 
-interface Article {
-  author: string
-  cover: { key: string, mediaType: string }
-  title: string
-}
+const articles = defineSource({
+  name: "articles",
+  async getKeys() {
+    return ["article_123" as const]
+  },
+  async getItem(key: `article_${string}`) {
+    return { key, data: { title: "Source API" }, metadata: { version: 1 } }
+  },
+})
 
-interface ArticleMetadata {
-  revision: string
-}
+const article = await createSource(articles).get("article_123")
+article.data.title
+article.metadata.version
+```
+
+Every loader has `name`, `getKeys()`, and `getItem()`. Optional hooks include
+`resolveRevision()`, `prepare()`, `getItems()`, and `getMeta()`.
+`SourceReader<typeof articles>`, `SourceKey<typeof articles>`,
+`SourceData<typeof articles>`, and `SourceMetadata<typeof articles>` use the
+definition type.
+
+All managed readers expose `revision()`, `keys()`, `get()`, `items()`, `meta()`,
+and `exists()`. File readers also expose `read()` and `list()`. Built-in `file`,
+`glob`, `github`, `markdown`, and `mcpResources` loaders return `FileSource`.
+Their `SourceFile` items guarantee `content`. Custom loaders that guarantee
+content receive file methods too. Record readers use `get()` and `items()`.
+
+## Reuse a definition
+
+Content accepts Source definitions directly. It opens a new reader on each
+refresh, so overlapping loads keep separate revisions:
+
+```ts
+import { defineContent } from "@vite-hub/content"
+
+export const content = defineContent({ source: docs })
+```
+
+Workspace binds the same definition to a persistent file tree:
+
+```ts
+import { defineWorkspace } from "@vite-hub/workspace"
+
+export default defineWorkspace({
+  sources: {
+    docs: { source: docs, mount: "docs", materialize: "lazy" },
+  },
+})
+```
+
+Workspace owns paths, materialization, sync, and access rules. Source owns
+retrieval. Content owns parsed documents, navigation, queries, and search.
+
+## Optional name lookup
+
+```ts
+import { defineSources, registerSources, useSource } from "@vite-hub/source"
+
+const sources = defineSources({ docs })
+registerSources(sources)
 
 declare global {
   interface ViteHubSourceMap {
-    articles: Source<`article_${string}`, Article, ArticleMetadata>
+    docs: typeof docs
   }
 }
 
-const article = await useSource("articles").get("article_123")
-article.data?.title
-article.metadata?.revision
-
-const articles = await useSource("articles").items()
+await useSource("docs").read("intro.md")
 ```
 
-Combine runtime Source readers when keys can overlap:
+`useSource(name, context?)` opens the same managed reader through a process-local
+registry. Import the registration module before lookup. The Vite integration
+for Collections and Content does not generate `ViteHubSourceMap`.
+
+## Combine keyed readers
+
+Use ordinary objects or functions for readers that do not need a loader
+lifecycle. `combineSources()` keeps aliases in each key and result:
 
 ```ts
-import { combineSources, defineSource } from "@vite-hub/source"
+import { combineSources } from "@vite-hub/source"
 
 const recaps = combineSources({
   sources: {
-    github: defineSource({
+    github: {
       get: async (month: `${number}-${number}`) => ({ month }),
       items: async () => [{ key: "2026-07" as const }],
-    }),
+    },
   },
 })
 
 await recaps.get(["github", "2026-07"])
 await recaps.items() // [{ key: "2026-07", source: "github", identity: ["github", "2026-07"] }]
 ```
+
+A combined reader exposes `items()` only when every input implements it.
+
+Use `cachedSource()` to add Nitro caching to a keyed reader:
+
+```ts
+import { cachedSource } from "vite-hub/source/server"
+
+const cachedDocs = cachedSource(createSource(docs), { name: "docs", maxAge: 60 })
+await cachedDocs.get("intro.md")
+```
+
+Use a different cache name for each origin and access scope. Cache ordinary
+readers before passing them to `combineSources()`.
+
+## Collections
 
 Define a Collection when a database or other origin should become a typed,
 paginated client read model:
@@ -142,6 +201,26 @@ transport, response shaping, and the exact item and filter types consumed by
 Keep binary assets behind the Blob boundary and store a serializable reference in
 the record. This keeps ordinary record reads lazy while treating the structured
 data and its assets as one logical item.
+
+## Migration
+
+- `defineSource()` now accepts only loader definitions. Use reader objects and
+  factory functions directly instead of wrapping them with `defineSource()`.
+- `createSource()` now opens a loader definition. Call custom reader factories
+  directly.
+- Replace the Source `custom(loader)` helper with `defineSource(loader)`.
+- Replace the server `defineSource({ ...reader, cache: cacheOptions })` wrapper
+  with `cachedSource(reader, { name, ...cacheOptions })`.
+- Change `SourceReader<"docs">` and related helper types to
+  `SourceReader<typeof docs>`. `RegisteredSource<"docs">` resolves a name to its
+  definition type when needed.
+- File methods require items with guaranteed content. Use `FileSource` for
+  explicit file loader types. Combined readers with a get-only input have no
+  `items()` method.
+
+Collections keep their existing pagination and response API. Workspace bindings
+remain valid. Content can now receive the same loader definition used by
+`createSource()`.
 
 ## Used by
 

--- a/packages/source/src/core/combine-sources.ts
+++ b/packages/source/src/core/combine-sources.ts
@@ -78,12 +78,13 @@ interface CombinedSourcesDefinition<TSources extends CombinedSources> {
   readonly sources: TSources & ValidCombinedSources<TSources> & Record<Exclude<keyof TSources, string>, never>
 }
 
-interface CombinedSourcesReader<TSources extends CombinedSources> {
+type CombinedSourcesReader<TSources extends CombinedSources> = {
   get<const TIdentity extends CombinedIdentity<TSources>>(
     identity: TIdentity,
   ): Promise<CombinedIdentityValue<TSources, TIdentity>>
-  items(): Promise<Array<CombinedItem<TSources>>>
-}
+} & (TSources[keyof TSources] extends { items(): Promise<Array<{ key: string }>> }
+  ? { items(): Promise<Array<CombinedItem<TSources>>> }
+  : {})
 
 export function combineSources<const TSources extends CombinedSources>(
   definition: CombinedSourcesDefinition<TSources>,
@@ -134,5 +135,9 @@ export function combineSources<const TSources extends CombinedSources>(
     return flattened as Array<CombinedItem<TSources>>
   }
 
-  return { get, items }
+  const reader = Object.values(sources).every(source => typeof source.items === "function")
+    ? { get, items }
+    : { get }
+  // SAFETY: Enumeration is exposed only when every input reader supports it.
+  return reader as CombinedSourcesReader<TSources>
 }

--- a/packages/source/src/core/combine-sources.ts
+++ b/packages/source/src/core/combine-sources.ts
@@ -135,7 +135,7 @@ export function combineSources<const TSources extends CombinedSources>(
     return flattened as Array<CombinedItem<TSources>>
   }
 
-  const reader = Object.values(sources).every(source => typeof source.items === "function")
+  const reader = Object.values(sources).every(source => source.items instanceof Function)
     ? { get, items }
     : { get }
   // SAFETY: Enumeration is exposed only when every input reader supports it.

--- a/packages/source/src/core/define.ts
+++ b/packages/source/src/core/define.ts
@@ -1,30 +1,10 @@
-import type { Source, SourceContext } from "./types.ts"
+import type { Source } from "./types.ts"
 
-interface KeyedSourceReader {
-  get(key: never): Promise<unknown>
-}
-
-type RuntimeSourceDefinition<TReader extends KeyedSourceReader> =
-  (context: SourceContext) => TReader
-
-export function defineSource<const TSource extends Source>(source: TSource): TSource
-export function defineSource<const TReader extends KeyedSourceReader>(source: TReader): TReader
-export function defineSource<const TReader extends KeyedSourceReader>(
-  definition: RuntimeSourceDefinition<TReader>,
-): RuntimeSourceDefinition<TReader>
-export function defineSource(
-  source: Source | KeyedSourceReader | RuntimeSourceDefinition<KeyedSourceReader>,
-) {
+/** Define a loader. Open it with createSource() to bind its runtime context. */
+export function defineSource<const TSource extends Source>(source: TSource): TSource {
   return source
 }
 
 export function defineSources<const TSources extends Record<string, Source>>(sources: TSources): TSources {
   return sources
-}
-
-export function createSource<const TReader extends KeyedSourceReader>(
-  definition: RuntimeSourceDefinition<TReader>,
-  context: SourceContext,
-): TReader {
-  return definition(context)
 }

--- a/packages/source/src/core/reader.ts
+++ b/packages/source/src/core/reader.ts
@@ -1,0 +1,134 @@
+import { sourceError } from "./errors.ts"
+import { decodeSourceContent, normalizeSafeSourcePath, normalizeSourcePath } from "./path.ts"
+
+import type {
+  ReadSourceOptions,
+  ReadSourceResult,
+  Source,
+  SourceContext,
+  SourceItem,
+  SourceListEntry,
+  SourceReader,
+  SourceRevision,
+} from "./types.ts"
+
+function createSourceContext(name: string, context: Partial<SourceContext> = {}): SourceContext {
+  return {
+    abortSignal: context.abortSignal,
+    revision: context.revision,
+    rootDir: context.rootDir || process.cwd(),
+    source: context.source || name,
+    sourceRootDir: context.sourceRootDir,
+    workspace: context.workspace,
+  }
+}
+
+function createMissingContentError(key: string) {
+  return sourceError(`[vitehub] Source item ${JSON.stringify(key)} does not provide readable content.`)
+}
+
+function isNestedUnder(path: string, prefix: string) {
+  return !prefix || path === prefix || path.startsWith(`${prefix}/`)
+}
+
+function createDirectorySet(paths: string[]) {
+  const directories = new Set<string>()
+
+  for (const path of paths) {
+    const segments = normalizeSourcePath(path).split("/").filter(Boolean)
+    for (let index = 1; index < segments.length; index++) {
+      directories.add(segments.slice(0, index).join("/"))
+    }
+  }
+
+  return directories
+}
+
+export function createSource<const TSource extends Source>(
+  source: TSource,
+  context?: Partial<SourceContext>,
+): SourceReader<TSource>
+export function createSource(source: Source, context?: Partial<SourceContext>) {
+  const ctx = createSourceContext(source.name, context)
+  let revisionPromise: Promise<SourceRevision | undefined> | undefined
+  let preparePromise: Promise<void> | undefined
+
+  async function revision() {
+    if (ctx.revision) return ctx.revision
+    revisionPromise ||= source.resolveRevision?.(ctx) ?? Promise.resolve(undefined)
+    const resolved = await revisionPromise
+    if (resolved) ctx.revision = resolved
+    return resolved
+  }
+
+  async function ensurePrepared() {
+    await revision()
+    if (!source.prepare) return
+    preparePromise ||= source.prepare(ctx)
+    await preparePromise
+  }
+
+  async function keys() {
+    await ensurePrepared()
+    return await source.getKeys(ctx)
+  }
+
+  async function get(
+    key: string,
+  ): Promise<SourceItem> {
+    await ensurePrepared()
+    return await source.getItem(key, ctx)
+  }
+
+  const reader = {
+    revision,
+    keys,
+    get,
+    async items() {
+      await ensurePrepared()
+      if (source.getItems) return await source.getItems(ctx)
+      return await Promise.all((await keys()).map(get))
+    },
+    async read<TOptions extends ReadSourceOptions | undefined = undefined>(
+      key: string,
+      options?: TOptions,
+    ): Promise<ReadSourceResult<TOptions>> {
+      const item = await get(key)
+      if (typeof item.content === "undefined") throw createMissingContentError(key)
+      return decodeSourceContent(item.content, options)
+    },
+    async meta(key: string) {
+      await ensurePrepared()
+      return await source.getMeta?.(key, ctx)
+    },
+    async exists(key: string) {
+      return (await keys()).includes(key)
+    },
+    async list(prefix = "") {
+      await ensurePrepared()
+      const normalizedPrefix = prefix ? normalizeSafeSourcePath(prefix, { allowEmpty: true }) : ""
+      const sourceKeys = await keys()
+      const directories = createDirectorySet(sourceKeys)
+      const result = new Map<string, SourceListEntry<string>>()
+
+      for (const directory of directories) {
+        if (directory === normalizedPrefix) continue
+        if (!isNestedUnder(directory, normalizedPrefix)) continue
+        const rest = normalizeSourcePath(directory.slice(normalizedPrefix.length)).replace(/^\//, "")
+        if (rest.includes("/")) continue
+        result.set(directory, { key: directory, type: "directory" })
+      }
+
+      for (const key of sourceKeys) {
+        if (key === normalizedPrefix) continue
+        if (!isNestedUnder(key, normalizedPrefix)) continue
+        const rest = normalizeSourcePath(key.slice(normalizedPrefix.length)).replace(/^\//, "")
+        if (rest.includes("/")) continue
+        result.set(key, { key, type: "file" })
+      }
+
+      return [...result.values()].sort((left, right) => left.key.localeCompare(right.key))
+    },
+  }
+  return reader
+}

--- a/packages/source/src/core/reader.ts
+++ b/packages/source/src/core/reader.ts
@@ -94,7 +94,7 @@ export function createSource(source: Source, context?: Partial<SourceContext>) {
       options?: TOptions,
     ): Promise<ReadSourceResult<TOptions>> {
       const item = await get(key)
-      if (typeof item.content === "undefined") throw createMissingContentError(key)
+      if (item.content === undefined) throw createMissingContentError(key)
       return decodeSourceContent(item.content, options)
     },
     async meta(key: string) {

--- a/packages/source/src/core/registry.ts
+++ b/packages/source/src/core/registry.ts
@@ -1,20 +1,7 @@
-import { sourceNotFoundError, sourceError } from "./errors.ts"
-import { decodeSourceContent, normalizeSafeSourcePath, normalizeSourcePath } from "./path.ts"
+import { sourceNotFoundError } from "./errors.ts"
+import { createSource } from "./reader.ts"
 
-import type {
-  ReadSourceOptions,
-  ReadSourceResult,
-  Source,
-  SourceContext,
-  SourceData,
-  SourceItem,
-  SourceKey,
-  SourceListEntry,
-  SourceMetadata,
-  SourceName,
-  SourceReader,
-  SourceRevision,
-} from "./types.ts"
+import type { RegisteredSource, Source, SourceContext, SourceName, SourceReader } from "./types.ts"
 
 const sourceRegistry = new Map<string, Source>()
 
@@ -35,132 +22,20 @@ export function registerSources<const TSources extends Record<string, Source>>(s
 
 export function getRegisteredSource<TName extends SourceName>(
   name: TName,
-): Source<SourceKey<TName>, SourceData<TName>, SourceMetadata<TName>> {
+): RegisteredSource<TName> {
   const source = sourceRegistry.get(name)
   if (!source) throw sourceNotFoundError(name)
-  return source as Source<SourceKey<TName>, SourceData<TName>, SourceMetadata<TName>>
+  return source as RegisteredSource<TName>
 }
 
 export function clearSources(): void {
   sourceRegistry.clear()
 }
 
-function createSourceContext(name: string, context: Partial<SourceContext> = {}): SourceContext {
-  return {
-    abortSignal: context.abortSignal,
-    revision: context.revision,
-    rootDir: context.rootDir || process.cwd(),
-    source: context.source || name,
-    sourceRootDir: context.sourceRootDir,
-    workspace: context.workspace,
-  }
-}
-
-function createMissingContentError(key: string) {
-  return sourceError(`[vitehub] Source item ${JSON.stringify(key)} does not provide readable content.`)
-}
-
-function isNestedUnder(path: string, prefix: string) {
-  return !prefix || path === prefix || path.startsWith(`${prefix}/`)
-}
-
-function createDirectorySet(paths: string[]) {
-  const directories = new Set<string>()
-
-  for (const path of paths) {
-    const segments = normalizeSourcePath(path).split("/").filter(Boolean)
-    for (let index = 1; index < segments.length; index++) {
-      directories.add(segments.slice(0, index).join("/"))
-    }
-  }
-
-  return directories
-}
-
+/** Open a registered definition with the same lifecycle as direct Source readers. */
 export function useSource<TName extends SourceName>(
   name: TName,
   context?: Partial<SourceContext>,
-): SourceReader<TName> {
-  const source = getRegisteredSource(name)
-  const ctx = createSourceContext(name, context)
-  let revisionPromise: Promise<SourceRevision | undefined> | undefined
-  let preparePromise: Promise<void> | undefined
-
-  async function revision() {
-    if (ctx.revision) return ctx.revision
-    revisionPromise ||= source.resolveRevision?.(ctx) ?? Promise.resolve(undefined)
-    const resolved = await revisionPromise
-    if (resolved) ctx.revision = resolved
-    return resolved
-  }
-
-  async function ensurePrepared() {
-    await revision()
-    if (!source.prepare) return
-    preparePromise ||= source.prepare(ctx)
-    await preparePromise
-  }
-
-  async function keys() {
-    await ensurePrepared()
-    return await source.getKeys(ctx)
-  }
-
-  async function get(
-    key: SourceKey<TName>,
-  ): Promise<SourceItem<SourceKey<TName>, SourceData<TName>, SourceMetadata<TName>>> {
-    await ensurePrepared()
-    return await source.getItem(key, ctx)
-  }
-
-  return {
-    revision,
-    keys,
-    get,
-    async items() {
-      await ensurePrepared()
-      if (source.getItems) return await source.getItems(ctx)
-      return await Promise.all((await keys()).map(get))
-    },
-    async read<TOptions extends ReadSourceOptions | undefined = undefined>(
-      key: SourceKey<TName>,
-      options?: TOptions,
-    ): Promise<ReadSourceResult<TOptions>> {
-      const item = await get(key)
-      if (typeof item.content === "undefined") throw createMissingContentError(key)
-      return decodeSourceContent(item.content, options)
-    },
-    async meta(key) {
-      await ensurePrepared()
-      return await source.getMeta?.(key, ctx)
-    },
-    async exists(key) {
-      return (await keys()).includes(key)
-    },
-    async list(prefix = "") {
-      await ensurePrepared()
-      const normalizedPrefix = prefix ? normalizeSafeSourcePath(prefix, { allowEmpty: true }) : ""
-      const sourceKeys = await keys()
-      const directories = createDirectorySet(sourceKeys)
-      const result = new Map<string, SourceListEntry<SourceKey<TName>>>()
-
-      for (const directory of directories) {
-        if (directory === normalizedPrefix) continue
-        if (!isNestedUnder(directory, normalizedPrefix)) continue
-        const rest = normalizeSourcePath(directory.slice(normalizedPrefix.length)).replace(/^\//, "")
-        if (rest.includes("/")) continue
-        result.set(directory, { key: directory as SourceKey<TName>, type: "directory" })
-      }
-
-      for (const key of sourceKeys) {
-        if (key === normalizedPrefix) continue
-        if (!isNestedUnder(key, normalizedPrefix)) continue
-        const rest = normalizeSourcePath(key.slice(normalizedPrefix.length)).replace(/^\//, "")
-        if (rest.includes("/")) continue
-        result.set(key, { key, type: "file" })
-      }
-
-      return [...result.values()].sort((left, right) => left.key.localeCompare(right.key))
-    },
-  }
+): SourceReader<RegisteredSource<TName>> {
+  return createSource(getRegisteredSource(name), { ...context, source: context?.source ?? name })
 }

--- a/packages/source/src/core/types.ts
+++ b/packages/source/src/core/types.ts
@@ -29,7 +29,7 @@ export interface SourceRevision {
 export interface SourceItem<
   TKey extends string = string,
   TData = unknown,
-  TMetadata extends object = Record<string, unknown>,
+  TMetadata extends object = object,
 > {
   key: TKey
   path?: string
@@ -42,7 +42,7 @@ export interface SourceItem<
 export interface Source<
   TKey extends string = string,
   TData = unknown,
-  TMetadata extends object = Record<string, unknown>,
+  TMetadata extends object = object,
 > {
   name: string
   cache?: false | SourceCacheOptions
@@ -66,33 +66,65 @@ declare global {
 
 export interface SourceMap extends ViteHubSourceMap {}
 
-type SourceKeyOf<TSource> = TSource extends Source<infer TKey, any, any> ? TKey : string
-type SourceDataOf<TSource> = TSource extends Source<any, infer TData, any> ? TData : unknown
-type SourceMetadataOf<TSource> = TSource extends Source<any, any, infer TMetadata> ? TMetadata : Record<string, unknown>
-type RegisteredSource<TName extends SourceName> =
-  TName extends keyof ViteHubSourceMap ? ViteHubSourceMap[TName] : Source
+/** Resolve an optional registered name to its loader definition. */
+export type RegisteredSource<TName extends SourceName> =
+  TName extends keyof ViteHubSourceMap
+    ? ViteHubSourceMap[TName] extends Source ? ViteHubSourceMap[TName] : never
+    : Source
 
 export type SourceName = [keyof ViteHubSourceMap] extends [never] ? string : Extract<keyof ViteHubSourceMap, string>
 
-export type SourceKey<TName extends SourceName = SourceName> =
-  Extract<SourceKeyOf<RegisteredSource<TName>>, string>
+type SourceKeyFunction<TSource extends Source> =
+  TSource extends unknown ? (key: Parameters<TSource["getItem"]>[0]) => void : never
 
-export type SourceData<TName extends SourceName = SourceName> =
-  SourceDataOf<RegisteredSource<TName>>
+/** Keys accepted by every possible definition variant. */
+export type SourceKey<TSource extends Source = Source> =
+  SourceKeyFunction<TSource> extends (key: infer TKey) => void ? Extract<TKey, string> : never
+export type SourceEntry<TSource extends Source = Source> = Awaited<ReturnType<TSource["getItem"]>>
+type ItemData<TItem> = TItem extends { data?: infer TData } ? TData : never
+type ItemMetadata<TItem> = TItem extends { metadata?: infer TMetadata } ? TMetadata : never
 
-export type SourceMetadata<TName extends SourceName = SourceName> =
-  SourceMetadataOf<RegisteredSource<TName>>
+export type SourceData<TSource extends Source = Source> = ItemData<SourceEntry<TSource>>
+export type SourceMetadata<TSource extends Source = Source> = ItemMetadata<SourceEntry<TSource>>
 
-export interface SourceReader<TName extends SourceName = SourceName> {
-  revision(): Promise<SourceRevision | undefined>
-  keys(): Promise<SourceKey<TName>[]>
-  get(key: SourceKey<TName>): Promise<SourceItem<SourceKey<TName>, SourceData<TName>, SourceMetadata<TName>>>
-  items(): Promise<Array<SourceItem<SourceKey<TName>, SourceData<TName>, SourceMetadata<TName>>>>
-  read<TOptions extends ReadSourceOptions | undefined = undefined>(
-    key: SourceKey<TName>,
-    options?: TOptions
-  ): Promise<ReadSourceResult<TOptions>>
-  meta(key: SourceKey<TName>): Promise<SourceMetadata<TName> | undefined>
-  exists(key: SourceKey<TName>): Promise<boolean>
-  list(prefix?: SourceKey<TName> | (string & {}) | ""): Promise<SourceListEntry<SourceKey<TName>>[]>
+type SourceMeta<TSource extends Source> = TSource extends unknown
+  ? "getMeta" extends keyof TSource
+    ? Awaited<ReturnType<NonNullable<TSource["getMeta"]>>> | (undefined extends TSource["getMeta"] ? undefined : never)
+    : undefined
+  : never
+
+type SourceEntries<TSource extends Source> = TSource extends unknown
+  ? "getItems" extends keyof TSource
+    ? Awaited<ReturnType<NonNullable<TSource["getItems"]>>> | (undefined extends TSource["getItems"] ? SourceEntry<TSource>[] : never)
+    : SourceEntry<TSource>[]
+  : never
+
+export interface SourceFile<TKey extends string = string, TMetadata extends object = Record<string, unknown>>
+  extends SourceItem<TKey, unknown, TMetadata> {
+  content: SourceContent
 }
+
+/** File loaders guarantee readable content for every item. */
+export interface FileSource<TKey extends string = string, TMetadata extends object = Record<string, unknown>>
+  extends Source<TKey, unknown, TMetadata> {
+  getItem(key: TKey, ctx: SourceContext): Promise<SourceFile<TKey, TMetadata>>
+  getItems?(ctx: SourceContext): Promise<SourceFile<TKey, TMetadata>[]>
+}
+
+interface SourceFileMethods<TKey extends string> {
+  read<TOptions extends ReadSourceOptions | undefined = undefined>(
+    key: TKey,
+    options?: TOptions,
+  ): Promise<ReadSourceResult<TOptions>>
+  list(prefix?: string): Promise<SourceListEntry[]>
+}
+
+/** A reader owns one revision and preparation attempt. Create another reader to refresh. */
+export type SourceReader<TSource extends Source = Source> = {
+  revision(): Promise<SourceRevision | undefined>
+  keys(): Promise<Awaited<ReturnType<TSource["getKeys"]>>>
+  get(key: SourceKey<TSource>): Promise<SourceEntry<TSource>>
+  items(): Promise<SourceEntries<TSource>>
+  meta(key: SourceKey<TSource>): Promise<SourceMeta<TSource>>
+  exists(key: SourceKey<TSource>): Promise<boolean>
+} & (SourceEntry<TSource> extends { content: SourceContent } ? SourceFileMethods<SourceKey<TSource>> : object)

--- a/packages/source/src/index.ts
+++ b/packages/source/src/index.ts
@@ -15,7 +15,8 @@ export type {
   CollectionRequestQuery,
 } from "./core/collection.ts"
 export { combineSources } from "./core/combine-sources.ts"
-export { createSource, defineSource, defineSources } from "./core/define.ts"
+export { defineSource, defineSources } from "./core/define.ts"
+export { createSource } from "./core/reader.ts"
 export {
   clearSources,
   getRegisteredSource,
@@ -26,4 +27,3 @@ export {
 export type * from "./core/types.ts"
 export type { SourceErrorCode } from "./core/errors.ts"
 export { sourceIgnores } from "./ignores.ts"
-export { custom } from "./sources/custom.ts"

--- a/packages/source/src/sources/custom.ts
+++ b/packages/source/src/sources/custom.ts
@@ -1,5 +1,0 @@
-import type { Source } from "../core/types.ts"
-
-export function custom<const TSource extends Source>(source: TSource): TSource {
-  return source
-}

--- a/packages/source/src/sources/file.ts
+++ b/packages/source/src/sources/file.ts
@@ -3,7 +3,7 @@ import { lookup } from "mrmime"
 import { sourceError, sourcePathError } from "../core/errors.ts"
 import { normalizeSafeSourcePath, normalizeSourcePath } from "../core/path.ts"
 
-import type { Source, SourceContent, SourceContext } from "../core/types.ts"
+import type { FileSource, SourceContent, SourceContext } from "../core/types.ts"
 
 export interface FileSourcePathOptions<TKey extends string = string> {
   path: string
@@ -61,7 +61,7 @@ async function resolveSafeSourceFilePath(path: string, ctx: SourceContext) {
   return target
 }
 
-export function file<const TKey extends string = string>(input: FileSourceInput<TKey>): Source<TKey> {
+export function file<const TKey extends string = string>(input: FileSourceInput<TKey>): FileSource<TKey> {
   const options = normalizeFileSourceOptions(input)
   const key = sourceKey(options)
   const mediaType = options.mediaType || lookup(key)

--- a/packages/source/src/sources/github/index.ts
+++ b/packages/source/src/sources/github/index.ts
@@ -9,7 +9,7 @@ import { createGitHubCacheKey, githubAuthenticationScope, normalizeGitHubCache }
 import { fetchGitHubArchive, requestGitHubJson } from "./client.ts"
 import { getGitSparsePatterns, loadGitArchiveFiles } from "./git.ts"
 
-import type { Source, SourceContext, SourceRevision } from "../../core/types.ts"
+import type { FileSource, SourceContext, SourceRevision } from "../../core/types.ts"
 import type { GitHubCommitResponse, GitHubContentResponse, GitHubFile, GitHubRepositoryResponse, GitHubSourceOptions } from "./types.ts"
 
 function normalizeGitHubRoot(path = "") {
@@ -41,7 +41,7 @@ async function waitForCachedGitHubResult<TResult>(load: () => Promise<TResult>, 
   })
 }
 
-export function github(options: GitHubSourceOptions): Source<string> {
+export function github(options: GitHubSourceOptions): FileSource<string> {
   const configuredRef = options.ref
   const root = normalizeGitHubRoot(options.root || "")
   const sparsePatterns = getGitSparsePatterns(root, options.include)

--- a/packages/source/src/sources/glob.ts
+++ b/packages/source/src/sources/glob.ts
@@ -4,7 +4,7 @@ import { sourceError } from "../core/errors.ts"
 import { normalizeSafeSourcePath, normalizeSourcePath } from "../core/path.ts"
 import { matchesAny } from "./path.ts"
 
-import type { Source, SourceContext, SourceItem } from "../core/types.ts"
+import type { FileSource, SourceContext, SourceFile } from "../core/types.ts"
 
 export interface GlobSourceOptions {
   cwd?: string
@@ -16,7 +16,7 @@ export interface GlobSourceOptions {
   prefix?: string
 }
 
-export function glob(options: GlobSourceOptions): Source<string> {
+export function glob(options: GlobSourceOptions): FileSource<string> {
   let snapshot: { key: string, keys: Promise<string[]> } | undefined
   let latest: { key: string, keys: string[] } | undefined
 
@@ -92,7 +92,7 @@ export function glob(options: GlobSourceOptions): Source<string> {
     return path
   }
 
-  const source: Source<string> = {
+  const source: FileSource<string> = {
     name: "glob",
     async prepare(ctx: SourceContext) {
       snapshot = undefined
@@ -110,7 +110,7 @@ export function glob(options: GlobSourceOptions): Source<string> {
         digest: `${info.size}:${info.mtimeMs}`,
       }
     },
-    async getItem(key: string, ctx: SourceContext): Promise<SourceItem<string>> {
+    async getItem(key: string, ctx: SourceContext): Promise<SourceFile<string>> {
       await assertKey(key, ctx)
       const { readFile, stat } = await import("node:fs/promises")
       const filePath = await resolveGlobFilePath(key, ctx)

--- a/packages/source/src/sources/markdown.ts
+++ b/packages/source/src/sources/markdown.ts
@@ -1,8 +1,8 @@
 import { file, type FileSourceOptions } from "./file.ts"
 
-import type { Source } from "../core/types.ts"
+import type { FileSource } from "../core/types.ts"
 
-export function markdown<const TKey extends string = string>(options: FileSourceOptions<TKey>): Source<TKey> {
+export function markdown<const TKey extends string = string>(options: FileSourceOptions<TKey>): FileSource<TKey> {
   return file<TKey>({
     ...options,
     mediaType: options.mediaType || "text/markdown",

--- a/packages/source/src/sources/mcp-resources.ts
+++ b/packages/source/src/sources/mcp-resources.ts
@@ -5,7 +5,7 @@ import { sourceError } from "../core/errors.ts"
 import { normalizeSafeSourcePath } from "../core/path.ts"
 import { matchesAny } from "./path.ts"
 
-import type { Source, SourceCacheOptions, SourceContent, SourceContext } from "../core/types.ts"
+import type { FileSource, SourceCacheOptions, SourceContent, SourceContext } from "../core/types.ts"
 import type { SSEClientTransportOptions } from "@modelcontextprotocol/sdk/client/sse.js"
 import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js"
@@ -373,7 +373,7 @@ function createResourceItem<TKey extends string>(
   }
 }
 
-export function mcpResources<const TKey extends string = string>(options: McpResourcesSourceOptions<TKey>): Source<TKey> {
+export function mcpResources<const TKey extends string = string>(options: McpResourcesSourceOptions<TKey>): FileSource<TKey> {
   if (!options || typeof options !== "object" || !options.server) {
     throw new TypeError("[vitehub] mcpResources({ server }) requires an MCP server.")
   }

--- a/packages/source/test/collection.test.ts
+++ b/packages/source/test/collection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest"
 
-import { combineSources, createSource, defineSource } from "../src/index.ts"
+import { combineSources } from "../src/index.ts"
 
 function enumerable<const TKey extends string, TData>(key: TKey, data: TData) {
   return {
@@ -29,20 +29,16 @@ describe("combined Sources", () => {
     await expect(collection.get(["second", "same"])).resolves.toEqual({ data: 2, key: "same" })
   })
 
-  it("supports keyed context Sources and validates Collection failures", async () => {
-    const definition = defineSource(context => ({
+  it("supports get-only readers and validates Collection failures", async () => {
+    const keyed = {
       async get(key: string) {
-        return `${context.rootDir}:${key.toUpperCase()}`
+        return key.toUpperCase()
       },
-    }))
-    const keyed = createSource(definition, { rootDir: "/recaps" })
+    }
     const collection = combineSources({ sources: { keyed } })
 
-    await expect(collection.get(["keyed", "july"])).resolves.toBe("/recaps:JULY")
-    await expect(collection.items()).rejects.toMatchObject({
-      code: "SOURCE_FAILED",
-      name: "ViteHubError",
-    })
+    await expect(collection.get(["keyed", "july"])).resolves.toBe("JULY")
+    expect(collection).not.toHaveProperty("items")
     // SAFETY: The test deliberately supplies a missing alias to exercise runtime validation.
     const missingIdentity = ["missing" as "keyed", "july"] as const
     await expect(collection.get(missingIdentity)).rejects.toThrow('Combined Source alias "missing" is not defined')
@@ -50,7 +46,7 @@ describe("combined Sources", () => {
     await expect(collection.get("keyed:july" as never)).rejects.toBeInstanceOf(TypeError)
   })
 
-  it("rejects non-enumerable Collections before reading any Source", async () => {
+  it("omits enumeration when any reader only supports get", async () => {
     const items = vi.fn(async () => [{ key: "one" }])
     const collection = combineSources({
       sources: {
@@ -68,7 +64,9 @@ describe("combined Sources", () => {
       },
     })
 
-    await expect(collection.items()).rejects.toThrow('Combined Source alias "keyed" is not enumerable')
+    expect(collection).not.toHaveProperty("items")
+    await expect(collection.get(["enumerable", "one"])).resolves.toBe("one")
+    await expect(collection.get(["keyed", "two"])).resolves.toBe("two")
     expect(items).not.toHaveBeenCalled()
   })
 })

--- a/packages/source/test/reader.test.ts
+++ b/packages/source/test/reader.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+
+import { clearSources, createSource, defineSource, registerSource, useSource } from "../src/index.ts"
+import { file } from "../src/file.ts"
+import type { SourceContext } from "../src/index.ts"
+
+afterEach(clearSources)
+
+describe("direct Source readers", () => {
+  it("reads a file definition without registration", async () => {
+    const reader = createSource(file({ workspacePath: "guide/start.md", content: "# Start" }))
+
+    await expect(reader.keys()).resolves.toEqual(["guide/start.md"])
+    await expect(reader.read("guide/start.md")).resolves.toBe("# Start")
+    await expect(reader.read("guide/start.md", { encoding: "binary" })).resolves.toEqual(new TextEncoder().encode("# Start"))
+    await expect(reader.list()).resolves.toEqual([{ key: "guide", type: "directory" }])
+    await expect(reader.list("guide")).resolves.toEqual([{ key: "guide/start.md", type: "file" }])
+  })
+
+  it("uses typed records and bulk loading directly", async () => {
+    const getItem = vi.fn(async (key: "article_1") => ({ key, data: { title: "One" } }))
+    const getItems = vi.fn(async () => [{ key: "article_1" as const, data: { title: "One" } }])
+    const reader = createSource(defineSource({
+      name: "articles",
+      async getKeys() { return ["article_1"] },
+      getItem,
+      getItems,
+      async getMeta() { return { revision: "1" } },
+    }))
+
+    await expect(reader.items()).resolves.toEqual([{ key: "article_1", data: { title: "One" } }])
+    expect(getItems).toHaveBeenCalledOnce()
+    expect(getItem).not.toHaveBeenCalled()
+    await expect(reader.get("article_1")).resolves.toEqual({ key: "article_1", data: { title: "One" } })
+    await expect(reader.meta("article_1")).resolves.toEqual({ revision: "1" })
+  })
+
+  it("pins one revision for concurrent operations and refreshes with another reader", async () => {
+    let originRevision = 1
+    const prepare = vi.fn(async (context: SourceContext) => {
+      expect(context.revision?.id).toBeDefined()
+    })
+    const resolveRevision = vi.fn(async () => ({ id: String(originRevision), immutable: true }))
+    const source = defineSource({
+      name: "docs",
+      resolveRevision,
+      prepare,
+      async getKeys() { return ["index.md"] },
+      async getItem(key: string, context: SourceContext) {
+        return { key, content: `Revision ${context.revision?.id}` }
+      },
+    })
+    const reader = createSource(source)
+    await expect(Promise.all([reader.keys(), reader.read("index.md"), reader.items()])).resolves.toEqual([
+      ["index.md"], "Revision 1", [{ key: "index.md", content: "Revision 1" }],
+    ])
+    expect(resolveRevision).toHaveBeenCalledOnce()
+    expect(prepare).toHaveBeenCalledOnce()
+
+    originRevision = 2
+    await expect(reader.read("index.md")).resolves.toBe("Revision 1")
+    await expect(createSource(source).read("index.md")).resolves.toBe("Revision 2")
+    expect(resolveRevision).toHaveBeenCalledTimes(2)
+    expect(prepare).toHaveBeenCalledTimes(2)
+  })
+
+  it.each(["revision", "prepare"] as const)("keeps a failed %s attempt local to its reader", async stage => {
+    const failure = new Error(stage)
+    let fail = true
+    const attempt = vi.fn(async () => { if (fail) throw failure })
+    const getItem = vi.fn(async (key: string) => ({ key, content: "ready" }))
+    const source = defineSource({
+      name: "docs",
+      async resolveRevision() {
+        if (stage === "revision") await attempt()
+        return { id: "1", immutable: true }
+      },
+      async prepare() { if (stage === "prepare") await attempt() },
+      async getKeys() { return ["index.md"] },
+      getItem,
+    })
+    const reader = createSource(source)
+    await expect(reader.read("index.md")).rejects.toBe(failure)
+    fail = false
+    await expect(reader.read("index.md")).rejects.toBe(failure)
+    expect(attempt).toHaveBeenCalledOnce()
+    expect(getItem).not.toHaveBeenCalled()
+    await expect(createSource(source).read("index.md")).resolves.toBe("ready")
+  })
+
+  it("keeps reader contexts and cancellation separate when definitions are reused", async () => {
+    const canceled = new AbortController()
+    const active = new AbortController()
+    const contexts: SourceContext[] = []
+    const source = defineSource({
+      name: "docs",
+      async getKeys(context: SourceContext) {
+        contexts.push(context)
+        context.abortSignal?.throwIfAborted()
+        return ["index.md"]
+      },
+      async getItem(key: string) { return { key, content: "ready" } },
+    })
+    const first = createSource(source, { rootDir: "/first", abortSignal: canceled.signal })
+    const second = createSource(source, { rootDir: "/second", abortSignal: active.signal })
+    canceled.abort()
+
+    await expect(first.keys()).rejects.toMatchObject({ name: "AbortError" })
+    await expect(second.keys()).resolves.toEqual(["index.md"])
+    expect(contexts.map(context => context.rootDir)).toEqual(["/first", "/second"])
+    expect(contexts[0]).not.toBe(contexts[1])
+    expect(contexts[1]?.abortSignal).toBe(active.signal)
+  })
+
+  it("uses the same lifecycle for registered definitions without mutating caller context", async () => {
+    const contexts: SourceContext[] = []
+    const source = defineSource({
+      name: "provider",
+      async prepare(context: SourceContext) { contexts.push(context) },
+      async getKeys() { return ["README.md"] },
+      async getItem(key: string, context: SourceContext) { return { key, content: context.revision?.id ?? "" } },
+    })
+    registerSource("readme", source)
+    const context = { rootDir: "/docs", revision: { id: "pinned", immutable: true } }
+    await expect(createSource(source, context).read("README.md")).resolves.toBe("pinned")
+    await expect(useSource("readme", context).read("README.md")).resolves.toBe("pinned")
+    expect(contexts.map(value => value.source)).toEqual(["provider", "readme"])
+    expect(contexts.every(value => value !== context)).toBe(true)
+    expect(context).toEqual({ rootDir: "/docs", revision: { id: "pinned", immutable: true } })
+  })
+})

--- a/packages/source/test/registry.test.ts
+++ b/packages/source/test/registry.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest"
 
 import {
   clearSources,
-  custom,
+  defineSource,
   defineSources,
   registerSource,
   registerSources,
@@ -56,7 +56,7 @@ describe("@vite-hub/source registry", () => {
   it("registers sources and reads through useSource", async () => {
     registerSources(defineSources({
       docs: file({ content: "# Docs\n", workspacePath: "README.md" }),
-      custom: custom({
+      custom: defineSource({
         name: "custom",
         async getKeys() {
           return ["data.json"]
@@ -86,7 +86,7 @@ describe("@vite-hub/source registry", () => {
       { data: { title: "Two" }, key: "two" },
     ])
 
-    registerSource("articles", custom({
+    registerSource("articles", defineSource({
       name: "articles",
       async getKeys() {
         return ["one", "two"]
@@ -109,7 +109,7 @@ describe("@vite-hub/source registry", () => {
     let receivedSignal: AbortSignal | undefined
 
     registerSources({
-      custom: custom({
+      custom: defineSource({
         name: "custom",
         async getKeys(ctx) {
           receivedSignal = ctx.abortSignal

--- a/packages/source/test/types.test-d.ts
+++ b/packages/source/test/types.test-d.ts
@@ -7,13 +7,16 @@ import {
   combineSources,
   type CollectionQuery,
   createSource,
-  custom,
   defineCollection,
   defineSource,
   defineSources,
   registerSources,
   sourceIgnores,
   type Source,
+  type FileSource,
+  type SourceFile,
+  type SourceContext,
+  type SourceReader,
   type SourceData,
   type SourceItem,
   type SourceMetadata,
@@ -46,12 +49,12 @@ declare global {
   interface ViteHubSourceMap {
     articles: Source
     custom: Source
-    dbt: Source
-    docs: Source<"README.md" | "guide/setup.md">
-    dynamic: Source
-    github: Source
+    dbt: FileSource
+    docs: FileSource<"README.md" | "guide/setup.md">
+    dynamic: FileSource
+    github: FileSource
     meals: Source<`meal_${string}`, Meal, MealMetadata>
-    readme: Source<"README.md">
+    readme: FileSource<"README.md">
   }
 }
 
@@ -68,15 +71,15 @@ describe("@vite-hub/source types", () => {
       }
     }
 
-    const keyedDefinition = defineSource(context => ({
+    const keyedDefinition = (context: SourceContext) => ({
       async get(month: "2026-07") {
         return { month, rootDir: context.rootDir }
       },
-    }))
+    })
     const collection = combineSources({
       sources: {
         count: reader("same", 1),
-        keyed: createSource(keyedDefinition, { rootDir: "/recaps" }),
+        keyed: keyedDefinition({ rootDir: "/recaps" }),
         title: reader("same", "Title"),
       },
     })
@@ -89,7 +92,8 @@ describe("@vite-hub/source types", () => {
       month: "2026-07"
       rootDir: string
     }>()
-    expectTypeOf((await collection.items())[0]!.source).toEqualTypeOf<"count" | "title">()
+    // @ts-expect-error A get-only input cannot enumerate.
+    collection.items()
 
     const variants = combineSources({
       sources: {
@@ -172,8 +176,8 @@ describe("@vite-hub/source types", () => {
             },
           }
     const mixedCollection = combineSources({ sources: { mixed: mixedUnion } })
-    const mixedIdentity = (await mixedCollection.items())[0]!.identity
-    await mixedCollection.get(mixedIdentity)
+    // @ts-expect-error Every possible reader variant must support enumeration.
+    mixedCollection.items()
     combineSources({
       sources: {
         // @ts-expect-error Mixed reader unions cannot emit a variant-only key either
@@ -221,6 +225,74 @@ describe("@vite-hub/source types", () => {
     })
     // @ts-expect-error Collection aliases must be strings
     combineSources({ sources: { 0: reader("same", 1) } })
+  })
+
+  it("infers direct reader records and restricts file methods to readable items", async () => {
+    const records = defineSource({
+      name: "records",
+      async getKeys() { return ["article_1"] },
+      async getItem(key: `article_${number}`) {
+        return { key, data: { title: "One", count: 1 }, metadata: { revision: "1" } }
+      },
+      async getMeta() { return { revision: "1" } },
+    })
+    const reader = createSource(records)
+    const item = await reader.get("article_1")
+    expectTypeOf(item.data).toEqualTypeOf<{ title: string; count: number }>()
+    expectTypeOf(item.metadata).toEqualTypeOf<{ revision: string }>()
+    expectTypeOf<SourceData<typeof records>>().toEqualTypeOf<{ title: string; count: number }>()
+    expectTypeOf<SourceMetadata<typeof records>>().toEqualTypeOf<{ revision: string }>()
+    expectTypeOf(reader).toEqualTypeOf<SourceReader<typeof records>>()
+    expectTypeOf(await reader.items()).toEqualTypeOf<Array<typeof item>>()
+    // @ts-expect-error Record readers have no readable content guarantee.
+    reader.read("article_1")
+    // @ts-expect-error Record keys are not filesystem directories.
+    reader.list()
+    // @ts-expect-error The reader retains the definition's key type.
+    reader.get("other")
+
+    const docs = createSource(file("README.md"))
+    expectTypeOf(await docs.read("README.md")).toBeString()
+    expectTypeOf(await docs.read("README.md", { encoding: "binary" })).toEqualTypeOf<Uint8Array>()
+    // @ts-expect-error File keys stay inferred without a global map.
+    docs.read("missing.md")
+    // @ts-expect-error Definitions describe loaders; keyed readers are plain objects.
+    defineSource({ get: async (key: string) => key })
+    // @ts-expect-error createSource opens a definition, not an arbitrary reader factory.
+    createSource(() => ({ get: async (key: string) => key }))
+  })
+
+  it("accepts only shared keys when a direct definition is a union", async () => {
+    const definition = Math.random() > 0.5 ? file("a.md") : file("b.md")
+    const reader = createSource(definition)
+    expectTypeOf(await reader.keys()).toEqualTypeOf<"a.md"[] | "b.md"[]>()
+    // @ts-expect-error A key must be valid for every possible definition.
+    reader.get("a.md")
+    // @ts-expect-error File helpers retain the same safe input keys.
+    reader.read("b.md")
+  })
+
+  it("preserves optional bulk and metadata implementations", async () => {
+    const source = defineSource({
+      name: "records",
+      async getKeys() { return ["one"] },
+      async getItem(key: string) { return { key, data: { title: "One" } } },
+      ...(Math.random() > 0.5 ? {
+        async getItems() { return [{ key: "one", data: { count: 1 } }] },
+        async getMeta() { return { revision: "1" } },
+      } : {}),
+    })
+    const reader = createSource(source)
+    expectTypeOf(await reader.items()).toEqualTypeOf<
+      Array<{ key: string; data: { title: string } }> | Array<{ key: string; data: { count: number } }>
+    >()
+    expectTypeOf(await reader.meta("one")).toEqualTypeOf<{ revision: string } | undefined>()
+    const noMeta = createSource(defineSource({
+      name: "records",
+      async getKeys() { return ["one"] },
+      async getItem(key: string) { return { key, data: { title: "One" } } },
+    }))
+    expectTypeOf(await noMeta.meta("one")).toEqualTypeOf<undefined>()
   })
 
   it("infers Collection source rows, transformed items, cursors, and queries", async () => {
@@ -320,15 +392,15 @@ describe("@vite-hub/source types", () => {
     const dynamic = useSource("dynamic")
 
     expectTypeOf(await docs.keys()).toEqualTypeOf<Array<"README.md" | "guide/setup.md">>()
-    expectTypeOf(await docs.get("README.md")).toEqualTypeOf<SourceItem<"README.md" | "guide/setup.md">>()
+    expectTypeOf(await docs.get("README.md")).toEqualTypeOf<SourceFile<"README.md" | "guide/setup.md">>()
     expectTypeOf(await docs.read("README.md")).toEqualTypeOf<string>()
     expectTypeOf(await docs.read("README.md", { encoding: "binary" })).toEqualTypeOf<Uint8Array>()
     expectTypeOf(await docs.exists("guide/setup.md")).toEqualTypeOf<boolean>()
     expectTypeOf(await docs.meta("README.md")).toEqualTypeOf<Record<string, unknown> | undefined>()
     expectTypeOf(await docs.revision()).toEqualTypeOf<SourceRevision | undefined>()
     expectTypeOf(await dynamic.keys()).toEqualTypeOf<string[]>()
-    expectTypeOf<SourceData<"meals">>().toEqualTypeOf<Meal>()
-    expectTypeOf<SourceMetadata<"meals">>().toEqualTypeOf<MealMetadata>()
+    expectTypeOf<SourceData<ViteHubSourceMap["meals"]>>().toEqualTypeOf<Meal>()
+    expectTypeOf<SourceMetadata<ViteHubSourceMap["meals"]>>().toEqualTypeOf<MealMetadata>()
 
     const meal = await useSource("meals").get("meal_123")
     expectTypeOf(meal).toEqualTypeOf<SourceItem<`meal_${string}`, Meal, MealMetadata>>()
@@ -347,7 +419,7 @@ describe("@vite-hub/source types", () => {
 
   it("preserves explicit source key generics", async () => {
     const source = defineSource(
-      custom({
+      {
         name: "typed",
         async getKeys() {
           return ["one.md", "two.md"]
@@ -355,7 +427,7 @@ describe("@vite-hub/source types", () => {
         async getItem(key: "one.md" | "two.md") {
           return { key, content: "# Doc\n" }
         },
-      } satisfies Source<"one.md" | "two.md">),
+      } satisfies Source<"one.md" | "two.md">,
     )
 
     expectTypeOf(source).toMatchTypeOf<Source<"one.md" | "two.md">>()
@@ -363,7 +435,7 @@ describe("@vite-hub/source types", () => {
 
   it("preserves record and metadata types from a custom source", async () => {
     const source: Source<"meal_123", Meal, MealMetadata> = defineSource(
-      custom({
+      {
         name: "meals",
         async getKeys() {
           return ["meal_123"] as const
@@ -380,7 +452,7 @@ describe("@vite-hub/source types", () => {
             metadata: { revision: "1" },
           }
         },
-      } satisfies Source<"meal_123", Meal, MealMetadata>),
+      } satisfies Source<"meal_123", Meal, MealMetadata>,
     )
 
     expectTypeOf(await source.getItem("meal_123", { rootDir: "." })).toEqualTypeOf<

--- a/packages/vite-hub/src/source/server.ts
+++ b/packages/vite-hub/src/source/server.ts
@@ -6,6 +6,16 @@ interface KeyedSourceReader {
   get(key: never): Promise<unknown>
 }
 
+function isRuntimeFunction(value: unknown): value is Function {
+  if (value === null || Object(value) !== value) return false
+  try {
+    Function.prototype.toString.call(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
 type ValidCachedGet<TReader extends KeyedSourceReader> =
   (<T>() => T extends TReader["get"] ? 1 : 2) extends
   (<T>() => T extends (key: Parameters<TReader["get"]>[0]) => ReturnType<TReader["get"]> ? 1 : 2)
@@ -39,14 +49,13 @@ export function cachedSource<const TReader extends KeyedSourceReader>(
     return await (await cachedGet)(key)
   }
 
-  // SAFETY: The facade inherits the reader and forwards access to it. Its own
-  // properties stay configurable so frozen reader methods can be wrapped.
+  // SAFETY: Object.create(reader) returns an object that inherits TReader's full public contract.
   const facade = Object.create(reader) as TReader
   return new Proxy(facade, {
     get(_target, property) {
       if (property === "get") return readCached
       const value: unknown = Reflect.get(reader, property, reader)
-      return typeof value === "function" ? value.bind(reader) : value
+      return isRuntimeFunction(value) ? value.bind(reader) : value
     },
     set(_target, property, value: unknown) {
       return Reflect.set(reader, property, value, reader)

--- a/packages/vite-hub/src/source/server.ts
+++ b/packages/vite-hub/src/source/server.ts
@@ -1,6 +1,3 @@
-import { defineSource as defineCoreSource } from "@vite-hub/source"
-
-import type { Source, SourceContext } from "@vite-hub/source"
 import type { CacheOptions } from "nitro/types"
 
 export * from "@vite-hub/source/server"
@@ -9,58 +6,57 @@ interface KeyedSourceReader {
   get(key: never): Promise<unknown>
 }
 
-type RuntimeSourceDefinition<TReader extends KeyedSourceReader> =
-  (context: SourceContext) => TReader
+type ValidCachedGet<TReader extends KeyedSourceReader> =
+  (<T>() => T extends TReader["get"] ? 1 : 2) extends
+  (<T>() => T extends (key: Parameters<TReader["get"]>[0]) => ReturnType<TReader["get"]> ? 1 : 2)
+    ? unknown
+    : never
 
-export type SourceReaderCacheOptions<TKey extends string, TValue> =
+export type SourceReaderCacheOptions<TKey, TValue> =
   & Omit<CacheOptions<TValue, [key: TKey]>, "name">
   & { name: string }
 
-interface CachedSourceReader<TKey extends string, TValue> {
-  cache: false | SourceReaderCacheOptions<TKey, TValue>
-  get(key: TKey): Promise<TValue>
-}
+// Cache keyed retrieval in the host while preserving the reader's other operations.
+export function cachedSource<const TReader extends KeyedSourceReader>(
+  reader: TReader & ValidCachedGet<TReader>,
+  options: SourceReaderCacheOptions<Parameters<TReader["get"]>[0], Awaited<ReturnType<TReader["get"]>>>,
+): TReader {
+  type Key = Parameters<TReader["get"]>[0]
+  type Value = Awaited<ReturnType<TReader["get"]>>
+  let cachedGet: Promise<(key: Key) => Promise<Value>> | undefined
 
-function isCachedSourceReader(source: unknown): source is CachedSourceReader<string, unknown> {
-  return Object(source) === source
-    && !(source instanceof Function)
-    && Reflect.get(Object(source), "get") instanceof Function
-    && Boolean(Reflect.get(Object(source), "cache"))
-}
+  // SAFETY: The key and value types come from this reader's get method.
+  const get = reader.get as (key: Key) => Promise<Value>
 
-function defineCachedSourceGet(source: CachedSourceReader<string, unknown>) {
-  let cachedGet: Promise<(key: string) => Promise<unknown>> | undefined
-
-  return async (key: string) => {
+  async function readCached(key: Key) {
     cachedGet ??= import("nitro/cache").then(({ defineCachedFunction }) => defineCachedFunction(
-      value => source.get.call(source, value),
+      value => get.call(reader, value),
       {
         swr: false,
-        ...source.cache,
+        ...options,
       },
     ))
     return await (await cachedGet)(key)
   }
-}
 
-export function defineSource<
-  const TKey extends string,
-  TValue,
-  const TReader extends CachedSourceReader<TKey, TValue>,
->(source: TReader): TReader
-export function defineSource<const TSource extends Source>(source: TSource): TSource
-export function defineSource<const TReader extends KeyedSourceReader>(source: TReader & { cache?: never }): TReader
-export function defineSource<const TReader extends KeyedSourceReader>(
-  definition: RuntimeSourceDefinition<TReader>,
-): RuntimeSourceDefinition<TReader>
-export function defineSource(source: unknown): unknown {
-  if (!isCachedSourceReader(source)) {
-    const core: unknown = defineCoreSource
-    // SAFETY: The public overloads above are the ViteHub subset of the core defineSource input contract.
-    return (core as (input: unknown) => unknown)(source)
-  }
-  return {
-    ...source,
-    get: defineCachedSourceGet(source),
-  }
+  // SAFETY: The facade inherits the reader and forwards access to it. Its own
+  // properties stay configurable so frozen reader methods can be wrapped.
+  const facade = Object.create(reader) as TReader
+  return new Proxy(facade, {
+    get(_target, property) {
+      if (property === "get") return readCached
+      const value: unknown = Reflect.get(reader, property, reader)
+      return typeof value === "function" ? value.bind(reader) : value
+    },
+    set(_target, property, value: unknown) {
+      return Reflect.set(reader, property, value, reader)
+    },
+    ownKeys() {
+      return Reflect.ownKeys(reader)
+    },
+    getOwnPropertyDescriptor(_target, property) {
+      const descriptor = Reflect.getOwnPropertyDescriptor(reader, property)
+      return descriptor ? { ...descriptor, configurable: true } : undefined
+    },
+  })
 }

--- a/packages/vite-hub/test/source-server.test.ts
+++ b/packages/vite-hub/test/source-server.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest"
 
 const cache = new Map<string, unknown>()
 let cacheModuleLoads = 0
@@ -17,47 +17,44 @@ vi.mock("nitro/cache", () => {
   return { defineCachedFunction }
 })
 
-const { defineSource } = await import("../src/source/server.ts")
+const { cachedSource } = await import("../src/source/server.ts")
 
-describe("server Source readers", () => {
+describe("cached Source readers", () => {
   beforeEach(() => {
     cache.clear()
     defineCachedFunction.mockClear()
   })
 
-  it("loads Nitro cache only when a cached reader is used", async () => {
+  it("loads Nitro cache only on the first get", async () => {
     expect(cacheModuleLoads).toBe(0)
 
-    defineSource({
+    const source = cachedSource({
       async get(key: string) {
         return key
       },
-    })
-    expect(cacheModuleLoads).toBe(0)
-
-    const source = defineSource({
-      cache: { name: "lazy" },
-      async get(key: string) {
-        return key
+      async items() {
+        return [{ key: "news" }]
       },
-    })
+    }, { name: "lazy" })
+    await expect(source.items()).resolves.toEqual([{ key: "news" }])
     expect(cacheModuleLoads).toBe(0)
 
     await expect(source.get("news")).resolves.toBe("news")
     expect(cacheModuleLoads).toBe(1)
   })
 
-  it("wraps keyed readers with the configured Nitro cache", async () => {
-    const reader = {
-      cache: { maxAge: 60, name: "uppercase" },
+  it("caches keyed retrieval with the configured Nitro options", async () => {
+    const get = vi.fn(async (key: string) => key.toUpperCase())
+    const source = cachedSource({
       async get(key: string) {
-        return key.toUpperCase()
+        return get(key)
       },
-    }
-
-    const source = defineSource(reader)
+    }, { maxAge: 60, name: "uppercase" })
 
     await expect(source.get("news")).resolves.toBe("NEWS")
+    await expect(source.get("news")).resolves.toBe("NEWS")
+    expect(get).toHaveBeenCalledTimes(1)
+    expect(defineCachedFunction).toHaveBeenCalledTimes(1)
     expect(defineCachedFunction).toHaveBeenCalledWith(expect.any(Function), {
       maxAge: 60,
       name: "uppercase",
@@ -66,53 +63,160 @@ describe("server Source readers", () => {
   })
 
   it("isolates cached readers by name", async () => {
-    const news = defineSource({
-      cache: { name: "news" },
+    const news = cachedSource({
       async get(key: string) {
         return `news:${key}`
       },
-    })
-    const docs = defineSource({
-      cache: { name: "docs" },
+    }, { name: "news" })
+    const docs = cachedSource({
       async get(key: string) {
         return `docs:${key}`
       },
-    })
+    }, { name: "docs" })
 
     await expect(news.get("shared")).resolves.toBe("news:shared")
     await expect(docs.get("shared")).resolves.toBe("docs:shared")
   })
 
-  it("requires a name for cached readers", () => {
-    defineSource({
-      // @ts-expect-error Cached readers require a stable namespace.
-      cache: { maxAge: 60 },
+  it("keeps get bound to the original reader and preserves other operations", async () => {
+    const reader = {
+      prefix: "news",
+      async get(key: "today" | "yesterday") {
+        expect(this).toBe(reader)
+        return `${this.prefix}:${key}`
+      },
+      async items() {
+        return [{ key: "today" as const }]
+      },
+    }
+    const source = cachedSource(reader, { name: "bound" })
+
+    expectTypeOf(source).toEqualTypeOf(reader)
+    expect(source.prefix).toBe("news")
+    await expect(source.get("today")).resolves.toBe("news:today")
+    await expect(source.items()).resolves.toEqual([{ key: "today" }])
+  })
+
+  it("preserves prototype methods and accessors that use private state", async () => {
+    class Reader {
+      #prefix = "news"
+
+      get prefix() {
+        return this.#prefix
+      }
+
+      set prefix(value: string) {
+        this.#prefix = value
+      }
+
+      async get(key: string) {
+        return `${this.#prefix}:${key}`
+      }
+
+      async items() {
+        return [{ key: this.#prefix }]
+      }
+    }
+
+    const reader = new Reader()
+    const source = cachedSource(reader, { name: "class" })
+
+    expect(source).toBeInstanceOf(Reader)
+    expect(source.prefix).toBe("news")
+    source.prefix = "docs"
+    expect(reader.prefix).toBe("docs")
+    await expect(source.get("today")).resolves.toBe("docs:today")
+    await expect(source.items()).resolves.toEqual([{ key: "docs" }])
+  })
+
+  it("wraps frozen readers and preserves their enumerable properties", async () => {
+    const get = vi.fn(async (key: string) => key.toUpperCase())
+    const reader = Object.freeze({
+      name: "frozen",
+      async get(key: string) {
+        expect(this).toBe(reader)
+        return get(key)
+      },
+      async items() {
+        expect(this).toBe(reader)
+        return [{ key: this.name }]
+      },
+    })
+    const source = cachedSource(reader, { name: "frozen" })
+
+    await expect(source.get("news")).resolves.toBe("NEWS")
+    await expect(source.get("news")).resolves.toBe("NEWS")
+    await expect(source.items()).resolves.toEqual([{ key: "frozen" }])
+    expect(Object.keys(source)).toEqual(Object.keys(reader))
+
+    const copy = { ...source }
+    expect(copy.name).toBe("frozen")
+    await expect(copy.get("news")).resolves.toBe("NEWS")
+    await expect(copy.items()).resolves.toEqual([{ key: "frozen" }])
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  it("uses explicit options regardless of a reader's cache field", async () => {
+    const source = cachedSource({
+      cache: { name: "reader-owned", swr: false },
       async get(key: string) {
         return key
+      },
+    }, { name: "explicit", swr: true })
+
+    await expect(source.get("news")).resolves.toBe("news")
+    expect(source.cache.name).toBe("reader-owned")
+    expect(defineCachedFunction).toHaveBeenCalledWith(expect.any(Function), {
+      name: "explicit",
+      swr: true,
+    })
+  })
+
+  it("requires a name and infers cache callback types from the reader", () => {
+    const reader = {
+      async get(key: "today" | "yesterday") {
+        return { title: key }
+      },
+    }
+
+    // @ts-expect-error Cached readers require a stable namespace.
+    cachedSource(reader, { maxAge: 60 })
+    cachedSource(reader, {
+      name: "typed",
+      getKey(key) {
+        expectTypeOf(key).toEqualTypeOf<"today" | "yesterday">()
+        return key
+      },
+      validate(entry) {
+        expectTypeOf(entry.value).toEqualTypeOf<{ title: "today" | "yesterday" } | undefined>()
+        return Boolean(entry.value)
       },
     })
   })
 
-  it("leaves readers without cache settings unchanged", () => {
-    const reader = {
-      async get(key: string) {
+  it("rejects retrieval signatures that cannot share one cache callback contract", () => {
+    const generic = {
+      async get<TKey extends string>(key: TKey) {
         return key
       },
     }
+    // @ts-expect-error A generic result cannot be represented by one cache entry type.
+    cachedSource(generic, { name: "generic" })
 
-    expect(defineSource(reader)).toBe(reader)
-    expect(defineCachedFunction).not.toHaveBeenCalled()
-  })
+    function get(key: "news"): Promise<number>
+    function get(key: "docs"): Promise<string>
+    async function get(key: "news" | "docs"): Promise<number | string> {
+      return key === "news" ? 1 : "docs"
+    }
+    // @ts-expect-error Cache callbacks cannot infer all overload key and result pairs.
+    cachedSource({ get }, { name: "overloaded" })
 
-  it("leaves readers with caching disabled unchanged", () => {
-    const reader = {
-      cache: false as const,
-      async get(key: string) {
-        return key
+    const options = {
+      async get(key: string, uppercase = false) {
+        return uppercase ? key.toUpperCase() : key
       },
     }
-
-    expect(defineSource(reader)).toBe(reader)
-    expect(defineCachedFunction).not.toHaveBeenCalled()
+    // @ts-expect-error Only a single key can determine a cached result.
+    cachedSource(options, { name: "extra-options" })
   })
 })

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -144,7 +144,36 @@ export default defineConfig({
 })
 ```
 
-Use named Workspace Source Binding helpers such as `file()` and `github()`. The lower-level Source registry lives in `@vite-hub/source`; install and import it directly only when you use that package's registry APIs.
+## Reuse a Source definition
+
+Bind a standalone Source definition when direct reads, Content, and Workspace
+need the same origin:
+
+```ts
+import { createSource } from "@vite-hub/source"
+import { glob } from "@vite-hub/source/glob"
+import { defineWorkspace } from "@vite-hub/workspace"
+
+const docs = glob({ cwd: "docs", include: "**/*.md" })
+const reader = createSource(docs)
+await reader.read("intro.md")
+
+export default defineWorkspace({
+  sources: {
+    docs: { source: docs, mount: "docs", materialize: "lazy" },
+  },
+})
+```
+
+The key `intro.md` appears at `docs/intro.md` in the Workspace. The binding owns
+placement, materialization, sync, and access rules. Source owns retrieval.
+Content also accepts the definition with `defineContent({ source: docs })` and
+opens a new reader for each refresh.
+
+Use Workspace helpers such as `file()` and `github()` when a definition only
+needs Workspace binding options. Existing bindings remain valid. For standalone
+custom loaders, replace the Source `custom()` helper with `defineSource()`.
+Workspace's `custom()` helper remains available.
 
 Workspace resolves a Source revision once before preparation and materialization.
 `materializeSources()` reports that generic revision in each Source status, and

--- a/packages/workspace/test/direct-source.test.ts
+++ b/packages/workspace/test/direct-source.test.ts
@@ -1,0 +1,38 @@
+import { createSource } from "@vite-hub/source"
+import { file } from "@vite-hub/source/file"
+import { describe, expect, it } from "vitest"
+
+import { createWorkspace } from "../src/core/workspace.ts"
+import { defineWorkspace } from "../src/index.ts"
+
+describe("standalone Source definitions", () => {
+  it("reuses a file definition for direct reads and a protected Workspace mount", async () => {
+    const guide = file({ workspacePath: "intro.md", content: "# Introduction\n" })
+    const workspace = createWorkspace({
+      ...defineWorkspace({
+        store: { provider: "memory" },
+        sources: {
+          guide: { source: guide, mount: "docs", materialize: "lazy" },
+        },
+      }),
+      name: "direct-source",
+    })
+
+    await expect(createSource(guide).read("intro.md")).resolves.toBe("# Introduction\n")
+    await expect(workspace.readFile("docs/intro.md")).resolves.toBe("# Introduction\n")
+    await expect(workspace.writeFile("docs/intro.md", "changed")).rejects.toThrow("read-only")
+    await expect(workspace.rm("docs/intro.md")).rejects.toThrow("read-only")
+    await expect(workspace.writeFile("drafts/notes.md", "notes")).resolves.toBe("drafts/notes.md")
+
+    const session = await workspace.startSession({ paths: ["docs"] })
+    try {
+      await expect(session.readFile("docs/intro.md")).resolves.toBe("# Introduction\n")
+      await expect(session.readFile("drafts/notes.md")).rejects.toThrow("does not exist")
+      expect((await session.glob("**/*.md")).map(entry => entry.path)).toEqual(["docs/intro.md"])
+      await expect(session.writeFile("drafts/new.md", "outside")).rejects.toThrow("outside the session scope")
+    }
+    finally {
+      await session.close()
+    }
+  })
+})

--- a/test/consumer/source-closures.test.ts
+++ b/test/consumer/source-closures.test.ts
@@ -115,7 +115,7 @@ describe("packed Source capability closures", () => {
           private: true,
           type: "module",
           dependencies: { "vite-hub": overrides["vite-hub"] },
-          devDependencies: { typescript: "6.0.3", wrangler: "4.72.0" },
+          devDependencies: { typescript: "6.0.3", wrangler: "4.112.0" },
         }, null, 2)),
         writeFile(join(appDir, "pnpm-workspace.yaml"), workspaceConfig(overrides)),
         writeFile(join(appDir, "tsconfig.json"), JSON.stringify({
@@ -123,19 +123,19 @@ describe("packed Source capability closures", () => {
           include: ["src/**/*.ts"],
         }, null, 2)),
         writeFile(join(appDir, "src/lightweight.ts"), `
-import { custom } from "vite-hub/source"
+import { createSource, defineSource } from "vite-hub/source"
 import { file } from "vite-hub/source/file"
 import { github } from "vite-hub/source/github"
 import { glob } from "vite-hub/source/glob"
 import { markdown } from "vite-hub/source/markdown"
 
-const local = custom({ name: "local", getKeys: async () => ["ok"], getItem: async key => ({ key, content: "ok" }) })
+const local = defineSource({ name: "local", getKeys: async () => ["ok"], getItem: async key => ({ key, content: "ok" }) })
 const inline = file({ content: "ok", workspacePath: "inline.txt" })
 const remote = github({ auth: false, repo: "vite-hub/vitehub" })
 const matches = glob({ include: "**/*.md" })
 const document = markdown({ content: "# ok", workspacePath: "readme.md" })
 
-export default { fetch: () => new Response(local.name + inline.name + remote.name + matches.name + document.name) }
+export default { fetch: async () => new Response(await createSource(local).read("ok") + await createSource(inline).read("inline.txt") + remote.name + matches.name + document.name) }
 `),
         writeFile(join(appDir, "src/mcp.ts"), `
 import { mcpResources } from "vite-hub/source/mcp"
@@ -156,6 +156,8 @@ const sourceTransport: McpResourcesTransport = {
 void sourceTransport
 `),
         writeFile(join(appDir, "mcp-run.mjs"), `
+import { createSource, defineSource } from "vite-hub/source"
+import { file } from "vite-hub/source/file"
 import { mcpResources } from "vite-hub/source/mcp"
 
 const transport = {
@@ -172,7 +174,11 @@ const transport = {
   },
 }
 const source = mcpResources({ server: { transport } })
-const item = await source.getItem("packed/readme.txt", { rootDir: process.cwd() })
+const item = await createSource(source).get("packed/readme.txt")
+const inline = createSource(file({ workspacePath: "readme.md", content: "direct reader ok" }))
+if (await inline.read("readme.md") !== "direct reader ok") throw new Error("Direct file reader failed")
+const records = createSource(defineSource({ name: "records", getKeys: async () => ["one"], getItem: async key => ({ key, data: { count: 1 } }) }))
+if ((await records.get("one")).data.count !== 1) throw new Error("Direct record reader failed")
 if (item.content !== "packed MCP runtime ok") throw new Error(String(item.content))
 console.log(item.content)
 `),


### PR DESCRIPTION
Source loader definitions required registration to open managed readers, while `defineSource()` also accepted unrelated reader and factory shapes. `createSource(definition, context?)` now opens an inferred reader directly. The same definition can feed Content and Workspace.

```ts
const docs = file({ workspacePath: 'guide.md', content: '# Guide' })
const reader = createSource(docs)
await reader.read('guide.md')
```

Content opens a fresh reader for each load. Workspace documentation shows direct bindings with mount and materialization options. Revision resolution and preparation remain scoped to each reader.

This is a breaking change:

- `defineSource()` accepts loader definitions only. Use plain objects and functions for arbitrary readers and factories. Replace Source `custom()` with `defineSource()`.
- Reader helper types take definition types. File operations require items with content. Combined readers expose `items()` only when every input can enumerate.
- Replace the server `defineSource({ ...reader, cache })` wrapper with `cachedSource(reader, options)` from `vite-hub/source/server`.

See the [migration guide](https://github.com/vite-hub/vitehub/blob/be1ce371837/docs/content/docs/server-primitives/source.md#migrate-existing-source-code).

**Before:** [registered reader flow](https://github.com/vite-hub/vitehub/blob/cf3b0ccc816/packages/source/test/registry.test.ts). **After:** [direct reader flow](https://github.com/vite-hub/vitehub/blob/be1ce371837/packages/source/test/reader.test.ts) and [packed consumer flow](https://github.com/vite-hub/vitehub/blob/be1ce371837/test/consumer/source-closures.test.ts). These repository examples cover native Node and Workers bundle behavior.

Model: GPT-6
Harness: Codex
