### PR TITLE
refactor(console): share generated runtime writer

### DIFF
--- a/packages/vite-hub/src/console/plugin.ts
+++ b/packages/vite-hub/src/console/plugin.ts
@@ -1,0 +1,113 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+
+import type { ConsoleAgentEntry, ConsoleBuildCatalog } from "./build.ts"
+import type { ConsoleSectionId } from "./runtime/sections.ts"
+
+import { consoleFixtureRevision, readConsoleFixture } from "./fixture.ts"
+import { createConsoleInvocationsIdentity } from "./internal.ts"
+import { resolveConsoleProjectNameFromRoot } from "./project.ts"
+import { consoleDefinitionSectionIds } from "./runtime/definitions.ts"
+import { installConsoleFixtureInvocations } from "./runtime/server/invocations.ts"
+
+function renderConsoleNitroPlugin(
+  projectRoot: string,
+  sections: readonly ConsoleSectionId[],
+  agents: readonly ConsoleAgentEntry[],
+  catalog: ConsoleBuildCatalog,
+  blobStores: readonly string[],
+  kvStores: readonly string[],
+  fixture?: string,
+  fixtureSnapshot = fixture ? readConsoleFixture(fixture) : undefined,
+  runtimeBinding?: string,
+  invoke = false,
+): string {
+  const agentsEnabled = sections.includes("agents")
+  const blobEnabled = sections.includes("blob")
+  const databaseEnabled = sections.includes("databases")
+  const kvEnabled = sections.includes("kv")
+  const definitionsEnabled = consoleDefinitionSectionIds.some(section => sections.includes(section))
+  const revision = fixtureSnapshot ? consoleFixtureRevision(fixtureSnapshot) : undefined
+  const fixtureSource = fixtureSnapshot ? `JSON.parse(${JSON.stringify(JSON.stringify(fixtureSnapshot))})` : undefined
+  return [
+    `import { installConsoleProjectName, installConsoleSections } from "vite-hub/console/sections"`,
+    ...(blobEnabled
+      ? [
+          `import { installConsoleBlob } from "vite-hub/console/blob"`,
+          `import { blob as vitehubConsoleBlob } from "vite-hub/blob"`,
+        ]
+      : []),
+    ...(agentsEnabled
+      ? [`import { installConsoleAgentDefinitions, installConsoleFixtureInvocations } from "vite-hub/console/server"`]
+      : []),
+    ...(definitionsEnabled ? [`import { installConsoleDefinitions } from "vite-hub/console/definitions"`] : []),
+    ...(databaseEnabled
+      ? [
+          `import { installConsoleDatabase } from "vite-hub/console/database"`,
+          `import { databases as vitehubConsoleDatabases } from "vite-hub/database/drizzle"`,
+        ]
+      : []),
+    ...(kvEnabled
+      ? [
+          `import { installConsoleKV } from "vite-hub/console/kv"`,
+          `import { kv as vitehubConsoleKV } from "vite-hub/kv"`,
+        ]
+      : []),
+    ...agents.map((agent, index) => `import * as vitehubConsoleAgent${index} from ${JSON.stringify(pathToFileURL(agent.handler).href)}`),
+    `installConsoleSections(${JSON.stringify(projectRoot)}, ${JSON.stringify(sections)})`,
+    ...(blobEnabled
+      ? [`installConsoleBlob(${JSON.stringify(projectRoot)}, vitehubConsoleBlob, ${JSON.stringify(blobStores)})`]
+      : []),
+    `installConsoleProjectName(${JSON.stringify(projectRoot)}, ${JSON.stringify(resolveConsoleProjectNameFromRoot(projectRoot))})`,
+    ...(definitionsEnabled ? [`installConsoleDefinitions(${JSON.stringify(projectRoot)}, ${JSON.stringify(catalog.definitions)})`] : []),
+    ...(databaseEnabled
+      ? [`installConsoleDatabase(${JSON.stringify(projectRoot)}, vitehubConsoleDatabases, ${JSON.stringify(catalog.definitions.databases?.map(definition => definition.name) ?? [])})`]
+      : []),
+    ...(agentsEnabled
+      ? fixture
+        ? [
+            `const vitehubConsoleInvocations = installConsoleFixtureInvocations(${JSON.stringify(projectRoot)}, ${JSON.stringify(fixture)}, ${fixtureSource}, ${JSON.stringify(revision)}, ${JSON.stringify(runtimeBinding)})`,
+            `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { invocations: vitehubConsoleInvocations })`,
+          ]
+        : [`installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { projectRoot: ${JSON.stringify(projectRoot)}${invoke ? ", invoke: true" : ""} })`]
+      : []),
+    ...(kvEnabled
+      ? [`installConsoleKV(${JSON.stringify(projectRoot)}, vitehubConsoleKV, ${JSON.stringify(kvStores)})`]
+      : []),
+    "export default function viteHubConsolePlugin() {}",
+    "",
+  ].join("\n")
+}
+
+export async function writeConsoleNitroPlugin(
+  file: string,
+  projectRoot: string,
+  sections: readonly ConsoleSectionId[],
+  agents: readonly ConsoleAgentEntry[],
+  catalog: ConsoleBuildCatalog,
+  blobStores: readonly string[],
+  kvStores: readonly string[],
+  fixture?: string,
+  runtimeBinding?: string,
+  invoke = false,
+  active: () => boolean = () => true,
+): Promise<string> {
+  const snapshot = fixture ? readConsoleFixture(fixture) : undefined
+  const identity = createConsoleInvocationsIdentity(
+    projectRoot,
+    fixture,
+    snapshot ? consoleFixtureRevision(snapshot) : undefined,
+    runtimeBinding,
+  )
+  if (!active()) return identity
+  const contents = renderConsoleNitroPlugin(projectRoot, sections, agents, catalog, blobStores, kvStores, fixture, snapshot, runtimeBinding, invoke)
+  if (await readFile(file, "utf8").catch(() => undefined) !== contents) {
+    await mkdir(resolve(file, ".."), { recursive: true })
+    await writeFile(file, contents, "utf8")
+  }
+  if (fixture && snapshot) {
+    installConsoleFixtureInvocations(projectRoot, fixture, snapshot, consoleFixtureRevision(snapshot), runtimeBinding)
+  }
+  return identity
+}

--- a/packages/vite-hub/src/console/vite.ts
+++ b/packages/vite-hub/src/console/vite.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "node:crypto"
 import { existsSync } from "node:fs"
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises"
+import { rm } from "node:fs/promises"
 import { join, resolve } from "node:path"
-import { fileURLToPath, pathToFileURL } from "node:url"
+import { fileURLToPath } from "node:url"
 
 import { discoverAgentDefinitionEntries } from "@vite-hub/agent/vite"
 import { resolveViteHubProjectRoot, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
@@ -12,14 +12,12 @@ import type { ViteHubCliContributingPlugin } from "@vite-hub/internal/cli"
 import type { Environment, Plugin } from "vite"
 import type { ConsoleSectionId } from "./runtime/sections.ts"
 
-import { discoverConsoleBuildCatalog, type ConsoleAgentEntry, type ConsoleBuildCatalog } from "./build.ts"
+import { discoverConsoleBuildCatalog } from "./build.ts"
+import { writeConsoleNitroPlugin } from "./plugin.ts"
 import { serializeConsoleRefresh } from "./refresh.ts"
-import { resolveConsoleProjectNameFromRoot } from "./project.ts"
 import { createConsoleCliNamespace } from "./cli.ts"
 import { consoleFixtureEnvironmentVariable, consoleFixtureRevision, readConsoleFixture } from "./fixture.ts"
 import { bindConsoleInvocationsIdentity, createConsoleInvocationsIdentity, releaseConsoleInvocationsBinding } from "./internal.ts"
-import { installConsoleFixtureInvocations } from "./runtime/server/invocations.ts"
-import { consoleDefinitionSectionIds } from "./runtime/definitions.ts"
 import { addConsoleDevframeHandler } from "./nitro.ts"
 
 const frameworkAgentSpecifier = "vite-hub/agent"
@@ -157,107 +155,6 @@ export function assertConsoleProductionAccess(
   if (missing.length) {
     throw new Error(`[vitehub] Console Auth access must configure an authorize callback for ${missing.join(" and ")}.`)
   }
-}
-
-function renderConsoleNitroPlugin(
-  projectRoot: string,
-  sections: readonly ConsoleSectionId[],
-  agents: readonly ConsoleAgentEntry[],
-  catalog: ConsoleBuildCatalog,
-  blobStores: readonly string[],
-  kvStores: readonly string[],
-  fixture?: string,
-  fixtureSnapshot = fixture ? readConsoleFixture(fixture) : undefined,
-  runtimeBinding?: string,
-  invoke = false,
-): string {
-  const agentsEnabled = sections.includes("agents")
-  const blobEnabled = sections.includes("blob")
-  const databaseEnabled = sections.includes("databases")
-  const kvEnabled = sections.includes("kv")
-  const definitionsEnabled = consoleDefinitionSectionIds.some(section => sections.includes(section))
-  const revision = fixtureSnapshot ? consoleFixtureRevision(fixtureSnapshot) : undefined
-  const fixtureSource = fixtureSnapshot ? `JSON.parse(${JSON.stringify(JSON.stringify(fixtureSnapshot))})` : undefined
-  return [
-    `import { installConsoleProjectName, installConsoleSections } from "vite-hub/console/sections"`,
-    ...(blobEnabled
-      ? [
-          `import { installConsoleBlob } from "vite-hub/console/blob"`,
-          `import { blob as vitehubConsoleBlob } from "vite-hub/blob"`,
-        ]
-      : []),
-    ...(agentsEnabled
-      ? [`import { installConsoleAgentDefinitions, installConsoleFixtureInvocations } from "vite-hub/console/server"`]
-      : []),
-    ...(definitionsEnabled ? [`import { installConsoleDefinitions } from "vite-hub/console/definitions"`] : []),
-    ...(databaseEnabled
-      ? [
-          `import { installConsoleDatabase } from "vite-hub/console/database"`,
-          `import { databases as vitehubConsoleDatabases } from "vite-hub/database/drizzle"`,
-        ]
-      : []),
-    ...(kvEnabled
-      ? [
-          `import { installConsoleKV } from "vite-hub/console/kv"`,
-          `import { kv as vitehubConsoleKV } from "vite-hub/kv"`,
-        ]
-      : []),
-    ...agents.map((agent, index) => `import * as vitehubConsoleAgent${index} from ${JSON.stringify(pathToFileURL(agent.handler).href)}`),
-    `installConsoleSections(${JSON.stringify(projectRoot)}, ${JSON.stringify(sections)})`,
-    ...(blobEnabled
-      ? [`installConsoleBlob(${JSON.stringify(projectRoot)}, vitehubConsoleBlob, ${JSON.stringify(blobStores)})`]
-      : []),
-    `installConsoleProjectName(${JSON.stringify(projectRoot)}, ${JSON.stringify(resolveConsoleProjectNameFromRoot(projectRoot))})`,
-    ...(definitionsEnabled ? [`installConsoleDefinitions(${JSON.stringify(projectRoot)}, ${JSON.stringify(catalog.definitions)})`] : []),
-    ...(databaseEnabled
-      ? [`installConsoleDatabase(${JSON.stringify(projectRoot)}, vitehubConsoleDatabases, ${JSON.stringify(catalog.definitions.databases?.map(definition => definition.name) ?? [])})`]
-      : []),
-    ...(agentsEnabled
-      ? fixture
-        ? [
-            `const vitehubConsoleInvocations = installConsoleFixtureInvocations(${JSON.stringify(projectRoot)}, ${JSON.stringify(fixture)}, ${fixtureSource}, ${JSON.stringify(revision)}, ${JSON.stringify(runtimeBinding)})`,
-            `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { invocations: vitehubConsoleInvocations })`,
-          ]
-        : [`installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { projectRoot: ${JSON.stringify(projectRoot)}${invoke ? ", invoke: true" : ""} })`]
-      : []),
-    ...(kvEnabled
-      ? [`installConsoleKV(${JSON.stringify(projectRoot)}, vitehubConsoleKV, ${JSON.stringify(kvStores)})`]
-      : []),
-    "export default function viteHubConsolePlugin() {}",
-    "",
-  ].join("\n")
-}
-
-async function writeConsoleNitroPlugin(
-  file: string,
-  projectRoot: string,
-  sections: readonly ConsoleSectionId[],
-  agents: readonly ConsoleAgentEntry[],
-  catalog: ConsoleBuildCatalog,
-  blobStores: readonly string[],
-  kvStores: readonly string[],
-  fixture?: string,
-  runtimeBinding?: string,
-  invoke = false,
-  active: () => boolean = () => true,
-): Promise<string> {
-  const snapshot = fixture ? readConsoleFixture(fixture) : undefined
-  const identity = createConsoleInvocationsIdentity(
-    projectRoot,
-    fixture,
-    snapshot ? consoleFixtureRevision(snapshot) : undefined,
-    runtimeBinding,
-  )
-  if (!active()) return identity
-  const contents = renderConsoleNitroPlugin(projectRoot, sections, agents, catalog, blobStores, kvStores, fixture, snapshot, runtimeBinding, invoke)
-  if (await readFile(file, "utf8").catch(() => undefined) !== contents) {
-    await mkdir(resolve(file, ".."), { recursive: true })
-    await writeFile(file, contents, "utf8")
-  }
-  if (fixture && snapshot) {
-    installConsoleFixtureInvocations(projectRoot, fixture, snapshot, consoleFixtureRevision(snapshot), runtimeBinding)
-  }
-  return identity
 }
 
 export function discoverConsoleAgentNames(

--- a/packages/vite-hub/src/nuxt.ts
+++ b/packages/vite-hub/src/nuxt.ts
@@ -1,6 +1,5 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { join, relative, resolve } from "node:path"
-import { fileURLToPath, pathToFileURL } from "node:url"
+import { fileURLToPath } from "node:url"
 
 import { resolveViteHubProjectRoot, VITEHUB_GENERATED_ROOT, VITEHUB_NITRO_CONFIG_CONTEXT, VITEHUB_PROJECT_ROOT, VITEHUB_SERVER_DIRS } from "@vite-hub/internal/build/vite"
 import { normalizeNitroPreset, resolveDeploymentPlan } from "@vite-hub/internal/deployment"
@@ -18,8 +17,9 @@ import { vitehub } from "./index.ts"
 import { createConsoleCliNamespace } from "./console/cli.ts"
 import { consoleFixtureEnvironmentVariable, consoleFixtureRevision, readConsoleFixture } from "./console/fixture.ts"
 import { createConsoleInvocationsIdentity } from "./console/internal.ts"
-import { installConsoleFixtureInvocations, installConsoleInvocations } from "./console/runtime/server/invocations.ts"
-import { discoverConsoleBuildCatalog, type ConsoleBuildCatalog } from "./console/build.ts"
+import { installConsoleInvocations } from "./console/runtime/server/invocations.ts"
+import { discoverConsoleBuildCatalog } from "./console/build.ts"
+import { writeConsoleNitroPlugin } from "./console/plugin.ts"
 import { installConsoleProjectName, installConsoleSections } from "./console/runtime/server/sections.ts"
 import { resolveConsoleProjectNameFromRoot } from "./console/project.ts"
 import { resolveConsoleSectionIds, type ConsoleSectionId } from "./console/runtime/sections.ts"
@@ -292,107 +292,6 @@ function addVueImports(nuxt: NuxtLike, from: string, names: string[]): void {
     }
     if (!existing) imports.push({ from, name })
   }
-}
-
-function renderConsoleNitroPlugin(
-  projectRoot: string,
-  sections: readonly ConsoleSectionId[],
-  agents: readonly { handler: string; name: string }[],
-  catalog: ConsoleBuildCatalog,
-  blobStores: readonly string[],
-  kvStores: readonly string[],
-  fixture?: string,
-  fixtureSnapshot = fixture ? readConsoleFixture(fixture) : undefined,
-  runtimeBinding?: string,
-  invoke = false,
-): string {
-  const agentsEnabled = sections.includes("agents")
-  const blobEnabled = sections.includes("blob")
-  const databaseEnabled = sections.includes("databases")
-  const kvEnabled = sections.includes("kv")
-  const definitionsEnabled = consoleDefinitionSectionIds.some(section => sections.includes(section))
-  const revision = fixtureSnapshot ? consoleFixtureRevision(fixtureSnapshot) : undefined
-  const fixtureSource = fixtureSnapshot ? `JSON.parse(${JSON.stringify(JSON.stringify(fixtureSnapshot))})` : undefined
-  return [
-    `import { installConsoleProjectName, installConsoleSections } from "vite-hub/console/sections"`,
-    ...(blobEnabled
-      ? [
-          `import { installConsoleBlob } from "vite-hub/console/blob"`,
-          `import { blob as vitehubConsoleBlob } from "vite-hub/blob"`,
-        ]
-      : []),
-    ...(agentsEnabled
-      ? [`import { installConsoleAgentDefinitions, installConsoleFixtureInvocations } from "vite-hub/console/server"`]
-      : []),
-    ...(definitionsEnabled ? [`import { installConsoleDefinitions } from "vite-hub/console/definitions"`] : []),
-    ...(databaseEnabled
-      ? [
-          `import { installConsoleDatabase } from "vite-hub/console/database"`,
-          `import { databases as vitehubConsoleDatabases } from "vite-hub/database/drizzle"`,
-        ]
-      : []),
-    ...(kvEnabled
-      ? [
-          `import { installConsoleKV } from "vite-hub/console/kv"`,
-          `import { kv as vitehubConsoleKV } from "vite-hub/kv"`,
-        ]
-      : []),
-    ...agents.map((agent, index) => `import * as vitehubConsoleAgent${index} from ${JSON.stringify(pathToFileURL(agent.handler).href)}`),
-    `installConsoleSections(${JSON.stringify(projectRoot)}, ${JSON.stringify(sections)})`,
-    ...(blobEnabled
-      ? [`installConsoleBlob(${JSON.stringify(projectRoot)}, vitehubConsoleBlob, ${JSON.stringify(blobStores)})`]
-      : []),
-    `installConsoleProjectName(${JSON.stringify(projectRoot)}, ${JSON.stringify(resolveConsoleProjectNameFromRoot(projectRoot))})`,
-    ...(definitionsEnabled ? [`installConsoleDefinitions(${JSON.stringify(projectRoot)}, ${JSON.stringify(catalog.definitions)})`] : []),
-    ...(databaseEnabled
-      ? [`installConsoleDatabase(${JSON.stringify(projectRoot)}, vitehubConsoleDatabases, ${JSON.stringify(catalog.definitions.databases?.map(definition => definition.name) ?? [])})`]
-      : []),
-    ...(agentsEnabled
-      ? fixture
-        ? [
-            `const vitehubConsoleInvocations = installConsoleFixtureInvocations(${JSON.stringify(projectRoot)}, ${JSON.stringify(fixture)}, ${fixtureSource}, ${JSON.stringify(revision)}, ${JSON.stringify(runtimeBinding)})`,
-            `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { invocations: vitehubConsoleInvocations })`,
-          ]
-        : [`installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { projectRoot: ${JSON.stringify(projectRoot)}${invoke ? ", invoke: true" : ""} })`]
-      : []),
-    ...(kvEnabled
-      ? [`installConsoleKV(${JSON.stringify(projectRoot)}, vitehubConsoleKV, ${JSON.stringify(kvStores)})`]
-      : []),
-    "export default function viteHubConsolePlugin() {}",
-    "",
-  ].join("\n")
-}
-
-async function writeConsoleNitroPlugin(
-  file: string,
-  projectRoot: string,
-  sections: readonly ConsoleSectionId[],
-  agents: readonly { handler: string; name: string }[],
-  catalog: ConsoleBuildCatalog,
-  blobStores: readonly string[],
-  kvStores: readonly string[],
-  fixture?: string,
-  runtimeBinding?: string,
-  invoke = false,
-  active: () => boolean = () => true,
-): Promise<string> {
-  const snapshot = fixture ? readConsoleFixture(fixture) : undefined
-  const identity = createConsoleInvocationsIdentity(
-    projectRoot,
-    fixture,
-    snapshot ? consoleFixtureRevision(snapshot) : undefined,
-    runtimeBinding,
-  )
-  if (!active()) return identity
-  const contents = renderConsoleNitroPlugin(projectRoot, sections, agents, catalog, blobStores, kvStores, fixture, snapshot, runtimeBinding, invoke)
-  if (await readFile(file, "utf8").catch(() => undefined) !== contents) {
-    await mkdir(resolve(file, ".."), { recursive: true })
-    await writeFile(file, contents, "utf8")
-  }
-  if (fixture && snapshot) {
-    installConsoleFixtureInvocations(projectRoot, fixture, snapshot, consoleFixtureRevision(snapshot), runtimeBinding)
-  }
-  return identity
 }
 
 async function installConsole(


### PR DESCRIPTION
Vite and Nuxt each had a copy of the Console runtime renderer and file writer. Move that shared implementation into one private Console module, keeping both hosts' generated output and registration behavior unchanged.

Both function bodies are byte-identical to their previous host-owned copies. No public export or new test framework is added.

[Before](https://github.com/vite-hub/vitehub/blob/bcf459ecc42e533b6e92d7e7494cd299c4e972e0/packages/vite-hub/src/console/vite.ts#L162) · [After](https://github.com/vite-hub/vitehub/blob/ab5da8167b19b2b5ee310784308007616044e259/packages/vite-hub/src/console/plugin.ts#L14).

Package typechecking remains blocked by the same pre-existing missing package and generated-module declarations.

Model: GPT-6 Astra. Harness: Codex CLI.
