### PR TITLE
fix(ci): connect Pullfrog to the pooled AI proxy

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -24,9 +24,22 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+      - name: Configure proxy access
+        run: |
+          cat > "$RUNNER_TEMP/pullfrog-opencode.json" <<'JSON'
+          {"provider":{"openai-compatible":{"options":{"headers":{"CF-Access-Client-Id":"{env:CF_ACCESS_CLIENT_ID}","CF-Access-Client-Secret":"{env:CF_ACCESS_CLIENT_SECRET}"}}}}}
+          JSON
       - name: Run agent
         uses: pullfrog/pullfrog@7ba9425d187df30638b003d6cee67f3d36023243 # v0.1.65
         with:
           prompt: ${{ inputs.prompt }}
+          model: openai-compatible/byok
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_COMPATIBLE_BASE_URL: https://ai.onmax.me/v1
+          OPENAI_COMPATIBLE_API_KEY: ${{ secrets.CLIPROXY_API_KEY }}
+          OPENAI_COMPATIBLE_MODEL: gpt-5.6-sol
+          OPENAI_COMPATIBLE_CONTEXT: "921000"
+          OPENAI_COMPATIBLE_MAX_OUTPUT: "128000"
+          OPENCODE_CONFIG: ${{ runner.temp }}/pullfrog-opencode.json
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CLIPROXY_CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CLIPROXY_CF_ACCESS_CLIENT_SECRET }}


### PR DESCRIPTION
Pullfrog reviews fail before starting because the workflow requests direct OpenAI access with an empty `OPENAI_API_KEY`. Route this repository through the existing pooled provider at `https://ai.onmax.me/v1` with `gpt-5.6-sol` and the configured context/output limits.

Load the Cloudflare service headers through OpenCode's custom configuration file. The dedicated repository secrets grant access only to `/v1/*`; the dashboard keeps its browser login.

Verified a real Sol completion through the public endpoint. Anonymous requests are blocked, the proxy API key remains required, and the service credential cannot open the dashboard. [GitHub Actions smoke test](https://github.com/vite-hub/vitehub/actions/runs/33950217285) passed: the Pullfrog agent resolved `openai-compatible/gpt-5.6-sol` and returned `POOL_OK`.

Model: GPT-6 Astra. Harness: Codex.
