### PR TITLE
fix(console): simplify session errors and recorded setup

### DIFF
--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -966,10 +966,15 @@ function inspectorCollection(title: string, items: readonly string[]) {
 
 function inspectorExecution(configuration: AgentInvocationConfiguration) {
   const model = configuration.driver?.model;
-  const provider = invocationBrand(model?.provider ?? configuration.driver?.provider);
+  const modelId = model?.id;
+  const provider = invocationBrand(
+    model?.provider
+      ?? configuration.driver?.provider
+      ?? (modelId?.includes("/") ? modelId.split("/")[0] : undefined),
+  );
   const runtime = configuration.runtime?.name;
   const rows = [
-    inspectorRow("Model", model?.id ? invocationModelName(model.id) : undefined),
+    inspectorRow("Model", modelId ? invocationModelName(modelId) : undefined),
     inspectorRow("Provider", provider?.label),
     inspectorRow("Runtime", runtime && runtime !== "unknown" ? runtime : undefined),
     inspectorRow("Workspace", workspaceLabel(configuration)),

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -92,32 +92,6 @@ function invocationBrand(value: string | undefined): InvocationBrand | undefined
   };
 }
 
-function invocationBrandMark(brand: InvocationBrand | undefined, className: string) {
-  if (!brand) return null;
-  if (brand.id === "z-ai") {
-    return h("svg", {
-      "aria-hidden": "true",
-      class: `vh-invocation-brand__logo ${className}`,
-      viewBox: "0 0 30 30",
-    }, [
-      h("rect", { fill: "#2d2d2d", height: "28", rx: "4", width: "28", x: "1", y: "1" }),
-      h("path", {
-        d: "M15.47 7.1l-1.3 1.85c-.2.29-.54.47-.9.47h-7.1V7.09h9.3Zm8.83 0L13.14 22.91H5.7L16.86 7.1h7.44Zm-9.77 15.81 1.31-1.86c.2-.29.54-.47.9-.47h7.09v2.33h-9.3Z",
-        fill: "#fff",
-      }),
-    ]);
-  }
-  if (brand.id === "openrouter") {
-    return h("svg", {
-      "aria-hidden": "true",
-      class: `vh-invocation-brand__logo ${className}`,
-      viewBox: "0 0 401.4 293.7",
-    }, [
-      h("path", { d: "M303.9475 17.1993c42.7973 0 77.4893 34.6933 77.4893 77.4893s-34.692 77.4893-77.4893 77.4893l76.8617 76.8625c9.7637 9.7631 2.849 26.4566-10.957 26.4566H148.9688C77.642 275.497 19.82 217.675 19.82 146.348S77.642 17.199 148.9688 17.199h154.9787ZM148.9688 68.8588c-42.796 0-77.4893 34.6933-77.4893 77.4893s34.6933 77.4894 77.4893 77.4894 77.4894-34.6933 77.4894-77.4894-34.6933-77.4893-77.4894-77.4893Z" }),
-    ]);
-  }
-  return h("span", { class: `vh-invocation-brand__fallback ${className}` }, brand.label.slice(0, 1));
-}
 
 function invocationModelName(value: string): string {
   const slug = value.split("/").at(-1) ?? "";
@@ -992,37 +966,19 @@ function inspectorCollection(title: string, items: readonly string[]) {
 
 function inspectorExecution(configuration: AgentInvocationConfiguration) {
   const model = configuration.driver?.model;
-  if (!model?.id) return null;
-  const maker = invocationBrand(model.id.includes("/") ? model.id.split("/")[0] : undefined);
-  const provider = invocationBrand(model.provider ?? configuration.driver?.provider);
-  const modelBrand = maker ?? provider;
-  const context = [
-    inspectorRow("Driver", configuration.driver?.kind),
-    inspectorRow("Runtime", configuration.runtime?.name),
+  const provider = invocationBrand(model?.provider ?? configuration.driver?.provider);
+  const runtime = configuration.runtime?.name;
+  const rows = [
+    inspectorRow("Model", model?.id ? invocationModelName(model.id) : undefined),
+    inspectorRow("Provider", provider?.label),
+    inspectorRow("Runtime", runtime && runtime !== "unknown" ? runtime : undefined),
     inspectorRow("Workspace", workspaceLabel(configuration)),
   ].filter(item => item !== null);
-  return h("div", {
-    class: "vh-invocation-inspector__group vh-invocation-inspector__group--execution",
-  }, [
-    h("div", { class: "vh-invocation-inspector__group-heading" }, [h("strong", "Execution")]),
-    h("div", { class: "vh-invocation-execution" }, [
-      h("div", { class: "vh-invocation-execution__model", title: model.id }, [
-        invocationBrandMark(modelBrand, "vh-invocation-execution__model-logo"),
-        h("div", [
-          h("strong", invocationModelName(model.id)),
-          maker ? h("span", `by ${maker.label}`) : null,
-        ]),
-      ]),
-      provider
-        ? h("div", { class: "vh-invocation-execution__route" }, [
-            h("span", "via"),
-            invocationBrandMark(provider, "vh-invocation-execution__provider-logo"),
-            h("strong", provider.label),
-          ])
-        : null,
-    ]),
-    context.length ? h("dl", { class: "vh-invocation-inspector__list" }, context) : null,
-  ]);
+  return rows.length
+    ? h("div", { class: "vh-invocation-inspector__group vh-invocation-inspector__group--execution" }, [
+        h("dl", { class: "vh-invocation-inspector__list" }, rows),
+      ])
+    : null;
 }
 
 function inspectorTools(
@@ -1067,7 +1023,7 @@ function renderConfiguration(configuration: AgentInvocationConfiguration, invoca
   const workspace = workspaceLabel(configuration);
   const setup = [
     inspectorRow("Driver", driver),
-    inspectorRow("Runtime", configuration.runtime?.name),
+    inspectorRow("Runtime", configuration.runtime?.name === "unknown" ? undefined : configuration.runtime?.name),
     inspectorRow("Workspace", workspace),
   ].filter((item) => item !== null);
   const execution = inspectorExecution(configuration);
@@ -1137,20 +1093,15 @@ function renderConfiguration(configuration: AgentInvocationConfiguration, invoca
         )
       : null,
   ].filter((item) => item !== null);
-  return [
-    configuration.truncated
-      ? h("div", { class: "vh-invocation-inspector__notice", role: "note" }, [
-          h("strong", "Configuration truncated"),
-          h("p", "Some values were shortened by the invocation journal."),
-        ])
-      : null,
-    groups.length
-      ? inspectorSection(
-          "Captured setup",
-          h("div", { class: "vh-invocation-inspector__groups" }, groups),
-        )
-      : null,
-  ];
+  return groups.length || configuration.truncated
+    ? [inspectorSection("Agent setup", h("div", { class: "vh-invocation-inspector__groups" }, [
+        configuration.truncated
+          ? h("p", { class: "vh-invocation-inspector__notice", role: "note" },
+              "Some setup values were shortened when this run was recorded.")
+          : null,
+        ...groups,
+      ]))]
+    : [];
 }
 
 function renderInvocationActivity(
@@ -1441,6 +1392,7 @@ export const AgentInvocationInspector = defineComponent({
     invocation: { required: true, type: Object as PropType<AgentInvocationView> },
     showStatus: { default: true, type: Boolean },
     showTimeline: { default: true, type: Boolean },
+    showError: { default: true, type: Boolean },
   },
   setup(props, { emit, slots }) {
     const activities = computed(() => invocationActivities(props.invocation));
@@ -1568,7 +1520,7 @@ export const AgentInvocationInspector = defineComponent({
                       : null,
                   ])
                 : null,
-              props.invocation.error
+              props.showError && props.invocation.error
                 ? h("div", { class: "vh-invocation-inspector__error" }, [
                     h("strong", props.invocation.error.name ?? "Invocation failed"),
                     h("p", props.invocation.error.message),

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -1728,13 +1728,14 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 }
 
 .vh-invocation-inspector__notice {
-  background: color-mix(in oklab, var(--ui-warning, #a16207) 7%, transparent);
+  background: transparent;
   border: 0;
-  border-inline-start: 2px solid color-mix(in oklab, currentColor 55%, transparent);
   border-radius: 0;
-  color: var(--ui-warning, #a16207);
-  margin-block-start: 1rem;
-  padding: 0.6rem 0.7rem;
+  color: var(--vh-ui-muted);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  margin: 0;
+  padding: 0;
 }
 
 .vh-invocation-inspector__error strong,
@@ -1947,96 +1948,12 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   border-block-start: 0;
 }
 
-.vh-invocation-inspector__group--execution {
-  background:
-    radial-gradient(circle at 95% 0%, color-mix(in oklab, var(--ui-primary, #2563eb) 9%, transparent), transparent 48%),
-    color-mix(in oklab, var(--vh-ui-bg-elevated) 54%, transparent);
-  border: 1px solid color-mix(in oklab, var(--vh-ui-border) 78%, transparent);
-  border-radius: calc(var(--vh-ui-radius) * 1.2);
-  padding: 0.8rem;
+.vh-invocation-inspector__group--execution .vh-invocation-inspector__list {
+  margin: 0;
 }
 
-.vh-invocation-execution {
-  display: grid;
-  gap: 0.65rem;
-  margin-block-start: 0.65rem;
-}
-
-.vh-invocation-execution__model {
-  align-items: center;
-  display: grid;
-  gap: 0.7rem;
-  grid-template-columns: 2.35rem minmax(0, 1fr);
-  min-width: 0;
-}
-
-.vh-invocation-execution__model > div {
-  display: grid;
-  gap: 0.08rem;
-  min-width: 0;
-}
-
-.vh-invocation-execution__model strong {
-  color: var(--vh-ui-text);
-  font-size: 0.875rem;
-  font-weight: 670;
-  letter-spacing: -0.015em;
-  line-height: 1.3;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.vh-invocation-execution__model span {
-  color: var(--vh-ui-dimmed);
-  font-size: 0.6875rem;
-}
-
-.vh-invocation-brand__logo,
-.vh-invocation-brand__fallback {
-  display: block;
-  flex: none;
-}
-
-.vh-invocation-brand__logo {
-  fill: currentColor;
-  height: 1rem;
-  width: 1rem;
-}
-
-.vh-invocation-execution__provider-logo {
-  color: #7624f4;
-}
-
-.vh-invocation-execution__model-logo,
-.vh-invocation-brand__fallback.vh-invocation-execution__model-logo {
-  height: 2.35rem;
-  width: 2.35rem;
-}
-
-.vh-invocation-brand__fallback {
-  align-items: center;
-  background: color-mix(in oklab, var(--ui-primary, #2563eb) 10%, var(--vh-ui-bg));
-  border: 1px solid color-mix(in oklab, var(--ui-primary, #2563eb) 20%, var(--vh-ui-border));
-  border-radius: calc(var(--vh-ui-radius) * 0.9);
-  color: var(--vh-ui-muted);
-  font-size: 0.65rem;
-  font-weight: 700;
-  justify-content: center;
-}
-
-.vh-invocation-execution__route {
-  align-items: center;
-  color: var(--vh-ui-dimmed);
-  display: flex;
-  font-size: 0.6875rem;
-  gap: 0.35rem;
-  margin-inline-start: 3.05rem;
-}
-
-.vh-invocation-execution__route strong {
-  color: var(--vh-ui-muted);
-  font-weight: 600;
+.vh-invocation-inspector__group--execution dd {
+  overflow-wrap: anywhere;
 }
 
 .vh-invocation-tool-list {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -2702,6 +2702,18 @@ describe("Agent Invocation UI", () => {
     expect(wrapper.get(".vh-invocation-inspector__groups").text()).toContain("1 of 2 used");
     expect(wrapper.findAll(".vh-agent-tool-list > *").map(item => item.attributes("data-used"))).toEqual(["true", "false"]);
 
+    const namespacedModel = mount(AgentInvocationInspector, { props: {
+      invocation: {
+        ...invocation,
+        configuration: {
+          ...invocation.configuration,
+          driver: { kind: "provider", model: { id: "openai/gpt-5" } },
+        },
+      },
+    } });
+    expect(namespacedModel.get(".vh-invocation-inspector__group--execution").text()).toContain("GPT 5");
+    expect(namespacedModel.get(".vh-invocation-inspector__group--execution").text()).toContain("OpenAI");
+
     const compact = mount(AgentInvocationInspector, {
       props: { invocation, showStatus: false, showTimeline: false },
     });

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -1638,6 +1638,10 @@ describe("Agent Invocation UI", () => {
     expect(wrapper.get(".vh-invocation-inspector__error").text()).toBe(
       "Provider errorThe provider stopped before returning a result.",
     );
+    const secondary = mount(AgentInvocationInspector, { props: { invocation, showError: false } });
+    expect(secondary.text()).toContain("Failed");
+    expect(secondary.find(".vh-invocation-inspector__error").exists()).toBe(false);
+
   });
 
   it("keeps bounded runtime diagnostics available behind a disclosure", () => {
@@ -2684,17 +2688,17 @@ describe("Agent Invocation UI", () => {
     };
     const wrapper = mount(AgentInvocationInspector, { props: { invocation } });
 
-    expect(wrapper.get(".vh-invocation-execution__model").attributes("title")).toBe("gpt-5.6-sol");
+    expect(wrapper.get(".vh-invocation-inspector__group--execution").text()).toContain("GPT 5.6 Sol");
     expect(wrapper.get(".vh-invocation-inspector__content").text()).toContain("OpenAI");
     expect(wrapper.get(".vh-invocation-inspector__content").text()).toContain("node");
     expect(wrapper.get(".vh-invocation-inspector__agent").text()).toContain("v2");
     expect(wrapper.get(".vh-invocation-inspector__groups").text()).toContain("reviews · github");
-    expect(wrapper.findAll(".vh-invocation-inspector__content > section h4").map(node => node.text())).toContain("Captured setup");
+    expect(wrapper.findAll(".vh-invocation-inspector__content > section h4").map(node => node.text())).toContain("Agent setup");
     expect(wrapper.get(".vh-invocation-inspector__groups").text()).toContain("Instructions");
     expect(wrapper.get(".vh-agent-tool-list__disclosure").text()).toContain("Run a shell command.");
     expect(wrapper.get(".vh-agent-tool-list__schema").text()).toContain("command");
-    expect(wrapper.get(".vh-invocation-execution").text()).toContain("GPT 5.6 Sol");
-    expect(wrapper.get(".vh-invocation-execution").text()).toContain("OpenAI");
+    expect(wrapper.get(".vh-invocation-inspector__group--execution").text()).toContain("GPT 5.6 Sol");
+    expect(wrapper.get(".vh-invocation-inspector__group--execution").text()).toContain("OpenAI");
     expect(wrapper.get(".vh-invocation-inspector__groups").text()).toContain("1 of 2 used");
     expect(wrapper.findAll(".vh-agent-tool-list > *").map(item => item.attributes("data-used"))).toEqual(["true", "false"]);
 
@@ -2703,6 +2707,12 @@ describe("Agent Invocation UI", () => {
     });
     expect(compact.find(".vh-invocation-inspector__status").exists()).toBe(false);
     expect(compact.find(".vh-invocation-timeline").exists()).toBe(false);
-    expect(compact.text()).toContain("Captured setup");
+    expect(compact.text()).toContain("Agent setup");
+    const shortened = mount(AgentInvocationInspector, { props: {
+      invocation: { ...invocation, configuration: { ...invocation.configuration, runtime: { name: "unknown" }, truncated: true } },
+    } });
+    expect(shortened.get('[role="note"]').text()).toContain("Some setup values were shortened");
+    expect(shortened.get(".vh-invocation-inspector__group--execution").text()).not.toContain("unknown");
+
   });
 });

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -180,7 +180,6 @@ const invocationItems = computed<AgentInvocationListItem[]>(() =>
       [invocationCostDisplay(invocation), agentInvocationContext(invocation)]
         .filter((value): value is string => Boolean(value))
         .join(" · ") || undefined,
-    description: invocation.error?.message,
     id: invocation.id,
     project: agentInvocationProject(invocation),
     provider:

--- a/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
@@ -568,6 +568,7 @@ function message(error: unknown) {
     <AgentInvocationInspector
       v-else-if="tab === 'details'"
       :invocation="invocation"
+      :show-error="false"
       :show-status="false"
       :show-timeline="false"
       class="session-inspector__details"


### PR DESCRIPTION
A failed session repeats the same error in the list, conversation, and inspector. The Console now keeps the full error in the conversation and the failure status in the list. Standalone inspectors still show errors by default.

Recorded setup uses compact model, provider, runtime, and workspace rows. Unknown runtime values are omitted, and shortened setup values get a small note beside the details. This changes presentation only; archived failures and recorded data stay intact.

| Before | After |
| --- | --- |
| ![Oversized recorded setup card](https://github.com/user-attachments/assets/d2c9c5db-f095-4758-a0bd-7d7c48656e22) | ![One error with compact setup details](https://github.com/user-attachments/assets/c64210f3-5bd3-431c-a4f5-7993de3555a9) |

Browser verification used a synthetic failed session with truncated setup, on desktop and mobile.

Model: GPT-6. Harness: Codex.
