### PR TITLE
fix(ui): guard prompt submission during pending work

### DIFF
--- a/docs/content/docs/ui/chat-prompt.md
+++ b/docs/content/docs/ui/chat-prompt.md
@@ -18,7 +18,7 @@ icon: i-ph-paper-plane-tilt-light
   accept="image/*,.pdf"
   :status
   @submit="({ text, files }) => sendMessage({ text, files })"
-  @reload="reload"
+  @reload="regenerate"
   @stop="stop"
 />
 ```
@@ -31,9 +31,17 @@ icon: i-ph-paper-plane-tilt-light
 | `update:modelValue` | Current prompt text.                                        |
 | `update:files`      | Current `FileUIPart[]`.                                     |
 | `submit`            | `{ text, files }`. Empty text is accepted when files exist. |
-| `reload`            | No payload. Connect it to the AI SDK `reload()` helper.     |
+| `reload`            | No payload. Connect it to the AI SDK `regenerate()` helper. |
 | `stop`              | No payload. Connect it to the AI SDK `stop()` helper.       |
 
 Use `#files`, `#actions`, and `#submit` to replace each built-in section without rebuilding keyboard behavior. The composer, attachment picker, and status-aware submit action have default accessible names; pass `aria-label` to override the composer name.
+
+## Submission behavior
+
+Enter and form submission emit `submit` only when `status` is `ready`, text or files exist, and all attachment batches have finished conversion. The Send button uses the same guard. You can edit the draft while a response streams or files are being prepared. Stop and Retry remain available in their corresponding states; Enter does not trigger them.
+
+The `#submit` slot receives `{ status, canSubmit, preparingFiles }`. Use `canSubmit` to disable a custom Send button and `preparingFiles` to show file preparation state. Custom Stop and Retry controls can remain active during preparation.
+
+An attachment conversion error emits `error` and releases the submission guard. It does not clear the draft or existing attachments. The application owns draft recovery after a failed send and decides when to clear `input` and `files`. Unmount the prompt when changing to another session to prevent a pending file read from updating that session.
 
 The picker and clipboard paste share the same file path. Pasted images become attachments even when the clipboard also contains text. Other pasted files become attachments only when the clipboard contains no text. `filter-files` receives the raw files before ViteHub converts them to AI SDK file parts. Return the accepted files in their desired order, or return `[]` to reject the batch.

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -98,6 +98,7 @@ The page displays **ViteHub UI is ready.** in bold. This confirms the public com
 
 - Published builds require Node.js 24.15 or newer. The package is pre-1.0, so pin its version and review changes before upgrading.
 - The components render state supplied by the application. They do not send messages, fetch Agent Invocations, choose routes, persist sessions, or authorize access to instruction and trace data.
+- `AgentChatPrompt` submits only in the ready state after attachment conversion finishes. It preserves the draft while blocked; Stop and Retry remain separate actions. Custom submit slots receive `canSubmit` and `preparingFiles`. The application owns draft recovery and clearing after a send; unmount the prompt when switching sessions with pending file reads.
 - Primary chat and invocation output supports Vue server rendering. Scrolling observers, clipboard actions, and attachment conversion use browser APIs and become interactive after hydration. Upload and persist raw files yourself when data URLs are not appropriate.
 - The styled components depend on Nuxt UI components and tokens. `@vite-hub/ui/styles.css` adds ViteHub presentation but is not a replacement for the Tailwind and Nuxt UI imports.
 - The package supplies accessible defaults for its message log, prompt, scroll controls, lists, and built-in actions. The application remains responsible for accessible names on custom controls and slots, meaningful status and error copy, focus behavior around application-owned navigation, and testing the completed interface.

--- a/packages/ui/src/components/agent-chat-prompt.ts
+++ b/packages/ui/src/components/agent-chat-prompt.ts
@@ -1,5 +1,5 @@
 import type { ChatStatus, FileUIPart } from "ai";
-import { defineComponent, h, mergeProps, type PropType, ref, resolveComponent } from "vue";
+import { computed, defineComponent, h, mergeProps, onBeforeUnmount, type PropType, ref, resolveComponent } from "vue";
 import { fileToUIPart } from "../composables/attachments.ts";
 import { nextPromptFiles } from "../internal/prompt-files.ts";
 
@@ -25,6 +25,17 @@ export const AgentChatPrompt = defineComponent({
   emits: ["error", "reload", "submit", "stop", "update:files", "update:modelValue"],
   setup(props, { attrs, emit, slots }) {
     const input = ref<HTMLInputElement | null>(null);
+    const pendingFiles = ref(0);
+    const preparingFiles = computed(() => pendingFiles.value > 0);
+    const canSubmit = computed(() =>
+      props.status === "ready" &&
+      !preparingFiles.value &&
+      (props.modelValue.trim().length > 0 || props.files.length > 0),
+    );
+    let disposed = false;
+    onBeforeUnmount(() => {
+      disposed = true;
+    });
     const UButton = resolveComponent("UButton");
     const UChatPrompt = resolveComponent("UChatPrompt");
     const UChatPromptSubmit = resolveComponent("UChatPromptSubmit");
@@ -37,15 +48,18 @@ export const AgentChatPrompt = defineComponent({
       input: FileList | Iterable<File>,
       onAccepted?: () => void,
     ) => {
+      pendingFiles.value++;
       try {
         const rawFiles = Array.from(input);
         const acceptedFiles = props.filterFiles?.(rawFiles) ?? rawFiles;
         if (acceptedFiles.length === 0) return;
         onAccepted?.();
         const files = await Promise.all(Array.from(acceptedFiles, fileToUIPart));
-        emit("update:files", nextPromptFiles(props.files, files, props.multiple));
+        if (!disposed) emit("update:files", nextPromptFiles(props.files, files, props.multiple));
       } catch (error) {
-        emit("error", error);
+        if (!disposed) emit("error", error);
+      } finally {
+        pendingFiles.value--;
       }
     };
     const paste = async (event: ClipboardEvent) => {
@@ -70,8 +84,8 @@ export const AgentChatPrompt = defineComponent({
           "onUpdate:modelValue": (value: string) =>
             emit("update:modelValue", value.replace(attachmentSubmitSentinel, "")),
           onSubmit: () => {
+            if (!canSubmit.value) return;
             const text = props.modelValue.trim();
-            if (!text && props.files.length === 0) return;
             emit("submit", { files: props.files, text } satisfies AgentChatPromptSubmit);
           },
         }),
@@ -140,7 +154,11 @@ export const AgentChatPrompt = defineComponent({
                   type: "button",
                   variant: "ghost",
                 }),
-              slots.submit?.({ status: props.status }) ??
+              slots.submit?.({
+                canSubmit: canSubmit.value,
+                preparingFiles: preparingFiles.value,
+                status: props.status,
+              }) ??
                 h(UChatPromptSubmit, {
                   "aria-label": {
                     error: "Retry prompt",
@@ -148,6 +166,7 @@ export const AgentChatPrompt = defineComponent({
                     streaming: "Stop response",
                     submitted: "Stop response",
                   }[props.status],
+                  disabled: props.status === "ready" && !canSubmit.value,
                   onReload: () => emit("reload"),
                   status: props.status,
                   onStop: () => emit("stop"),

--- a/packages/ui/src/components/agent-chat-prompt.ts
+++ b/packages/ui/src/components/agent-chat-prompt.ts
@@ -33,6 +33,8 @@ export const AgentChatPrompt = defineComponent({
       (props.modelValue.trim().length > 0 || props.files.length > 0),
     );
     let disposed = false;
+    let nextBatch = 0;
+    const convertedBatches = new Map<number, readonly FileUIPart[]>();
     onBeforeUnmount(() => {
       disposed = true;
     });
@@ -48,6 +50,7 @@ export const AgentChatPrompt = defineComponent({
       input: FileList | Iterable<File>,
       onAccepted?: () => void,
     ) => {
+      const batch = nextBatch++;
       pendingFiles.value++;
       try {
         const rawFiles = Array.from(input);
@@ -55,11 +58,18 @@ export const AgentChatPrompt = defineComponent({
         if (acceptedFiles.length === 0) return;
         onAccepted?.();
         const files = await Promise.all(Array.from(acceptedFiles, fileToUIPart));
-        if (!disposed) emit("update:files", nextPromptFiles(props.files, files, props.multiple));
+        if (!disposed) convertedBatches.set(batch, files);
       } catch (error) {
         if (!disposed) emit("error", error);
       } finally {
         pendingFiles.value--;
+        if (!disposed && pendingFiles.value === 0 && convertedBatches.size > 0) {
+          const files = [...convertedBatches]
+            .sort(([first], [second]) => first - second)
+            .flatMap(([, converted]) => converted);
+          convertedBatches.clear();
+          emit("update:files", nextPromptFiles(props.files, files, props.multiple));
+        }
       }
     };
     const paste = async (event: ClipboardEvent) => {

--- a/packages/ui/test/chat-prompt-submission.test.ts
+++ b/packages/ui/test/chat-prompt-submission.test.ts
@@ -90,14 +90,12 @@ describe("AgentChatPrompt submission with Nuxt UI", () => {
     expect(wrapper.emitted("submit")).toBeUndefined();
     expect(wrapper.get('button[aria-label="Send prompt"]').attributes("disabled")).toBeDefined();
 
+    const secondFile = { ...filePart, filename: "second.txt" };
     first.resolve(filePart);
+    second.resolve(secondFile);
     await flushPromises();
-    await wrapper.setProps({ files: [filePart] });
-    expect(wrapper.get('button[aria-label="Send prompt"]').attributes("disabled")).toBeDefined();
-    second.resolve({ ...filePart, filename: "second.txt" });
-    await flushPromises();
-    const files = [filePart, { ...filePart, filename: "second.txt" }];
-    expect(wrapper.emitted("update:files")?.at(-1)).toEqual([files]);
+    const files = [filePart, secondFile];
+    expect(wrapper.emitted("update:files")).toEqual([[files]]);
     await wrapper.setProps({ files });
 
     expect(wrapper.get('button[aria-label="Send prompt"]').attributes("disabled")).toBeUndefined();

--- a/packages/ui/test/chat-prompt-submission.test.ts
+++ b/packages/ui/test/chat-prompt-submission.test.ts
@@ -1,0 +1,157 @@
+// @vitest-environment happy-dom
+
+import type { ChatStatus, FileUIPart } from "ai";
+import UButton from "@nuxt/ui/components/Button.vue";
+import UChatPrompt from "@nuxt/ui/components/ChatPrompt.vue";
+import UChatPromptSubmit from "@nuxt/ui/components/ChatPromptSubmit.vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { AgentChatPrompt } from "../src/components/agent-chat-prompt.ts";
+import * as attachments from "../src/composables/attachments.ts";
+
+const filePart: FileUIPart = {
+  filename: "notes.txt",
+  mediaType: "text/plain",
+  type: "file",
+  url: "data:text/plain,notes",
+};
+
+async function renderPrompt(status: ChatStatus = "ready") {
+  const wrapper = mount(AgentChatPrompt, {
+    global: { components: { UButton, UChatPrompt, UChatPromptSubmit }, stubs: { UIcon: true } },
+    props: { modelValue: "Read these notes", status },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+async function pickFile(wrapper: Awaited<ReturnType<typeof renderPrompt>>) {
+  const input = wrapper.get('input[type="file"]');
+  Object.defineProperty(input.element, "files", {
+    configurable: true,
+    value: [new File(["notes"], "notes.txt", { type: "text/plain" })],
+  });
+  await input.trigger("change");
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("AgentChatPrompt submission with Nuxt UI", () => {
+  it.each(["submitted", "streaming", "error"] satisfies ChatStatus[])(
+    "keeps Enter and form submission inert in the %s state without losing the draft",
+    async (status) => {
+      const wrapper = await renderPrompt(status);
+      await wrapper.get("textarea").trigger("keydown", { key: "Enter" });
+      await wrapper.get("form").trigger("submit");
+      expect(wrapper.emitted("submit")).toBeUndefined();
+      expect(wrapper.get("textarea").element.value).toBe("Read these notes");
+
+      const event = status === "error" ? "reload" : "stop";
+      const label = status === "error" ? "Retry prompt" : "Stop response";
+      await wrapper.get(`button[aria-label="${label}"]`).trigger("click");
+      expect(wrapper.emitted(event)).toHaveLength(1);
+
+      await wrapper.setProps({ status: "ready" });
+      await wrapper.get("textarea").trigger("keydown", { key: "Enter" });
+      expect(wrapper.emitted("submit")).toEqual([[{ text: "Read these notes", files: [] }]]);
+      wrapper.unmount();
+    },
+  );
+
+  it("keeps IME composition and Shift+Enter out of submission", async () => {
+    const wrapper = await renderPrompt();
+    await wrapper.get("textarea").trigger("keydown", { key: "Enter", isComposing: true });
+    await wrapper.get("textarea").trigger("keydown", { key: "Enter", shiftKey: true });
+    expect(wrapper.emitted("submit")).toBeUndefined();
+    wrapper.unmount();
+  });
+
+  it("supports attachment-only submission through the real Nuxt UI guard", async () => {
+    const wrapper = await renderPrompt();
+    await wrapper.setProps({ modelValue: "", files: [filePart] });
+    expect(wrapper.get('button[aria-label="Send prompt"]').attributes("disabled")).toBeUndefined();
+    await wrapper.get("textarea").trigger("keydown", { key: "Enter" });
+    expect(wrapper.emitted("submit")).toEqual([[{ text: "", files: [filePart] }]]);
+    wrapper.unmount();
+  });
+
+  it("waits for all concurrent attachment batches before allowing submission", async () => {
+    const first = Promise.withResolvers<FileUIPart>();
+    const second = Promise.withResolvers<FileUIPart>();
+    vi.spyOn(attachments, "fileToUIPart")
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    const wrapper = await renderPrompt();
+    await pickFile(wrapper);
+    await pickFile(wrapper);
+
+    await wrapper.get("textarea").trigger("keydown", { key: "Enter" });
+    await wrapper.get("form").trigger("submit");
+    expect(wrapper.emitted("submit")).toBeUndefined();
+    expect(wrapper.get('button[aria-label="Send prompt"]').attributes("disabled")).toBeDefined();
+
+    first.resolve(filePart);
+    await flushPromises();
+    await wrapper.setProps({ files: [filePart] });
+    expect(wrapper.get('button[aria-label="Send prompt"]').attributes("disabled")).toBeDefined();
+    second.resolve({ ...filePart, filename: "second.txt" });
+    await flushPromises();
+    const files = [filePart, { ...filePart, filename: "second.txt" }];
+    expect(wrapper.emitted("update:files")?.at(-1)).toEqual([files]);
+    await wrapper.setProps({ files });
+
+    expect(wrapper.get('button[aria-label="Send prompt"]').attributes("disabled")).toBeUndefined();
+    await wrapper.get("form").trigger("submit");
+    expect(wrapper.emitted("submit")).toEqual([[{ text: "Read these notes", files }]]);
+    wrapper.unmount();
+  });
+
+  it("restores submission after a read fails and preserves the draft and existing files", async () => {
+    const pending = Promise.withResolvers<FileUIPart>();
+    vi.spyOn(attachments, "fileToUIPart").mockReturnValue(pending.promise);
+    const wrapper = await renderPrompt();
+    await wrapper.setProps({ files: [filePart] });
+    await pickFile(wrapper);
+    const error = new Error("File read failed");
+    pending.reject(error);
+    await flushPromises();
+
+    expect(wrapper.emitted("error")).toEqual([[error]]);
+    expect(wrapper.emitted("update:files")).toBeUndefined();
+    expect(wrapper.get('button[aria-label="Send prompt"]').attributes("disabled")).toBeUndefined();
+    await wrapper.get("textarea").trigger("keydown", { key: "Enter" });
+    expect(wrapper.emitted("submit")).toEqual([[{ text: "Read these notes", files: [filePart] }]]);
+    wrapper.unmount();
+  });
+
+  it.each(["streaming", "error"] satisfies ChatStatus[])(
+    "keeps the %s action available during attachment preparation",
+    async (status) => {
+      const pending = Promise.withResolvers<FileUIPart>();
+      vi.spyOn(attachments, "fileToUIPart").mockReturnValue(pending.promise);
+      const wrapper = await renderPrompt(status);
+      await pickFile(wrapper);
+      const label = status === "error" ? "Retry prompt" : "Stop response";
+      const button = wrapper.get(`button[aria-label="${label}"]`);
+      expect(button.attributes("disabled")).toBeUndefined();
+      await button.trigger("click");
+      expect(wrapper.emitted(status === "error" ? "reload" : "stop")).toHaveLength(1);
+      pending.resolve(filePart);
+      await flushPromises();
+      wrapper.unmount();
+    },
+  );
+
+  it.each(["resolve", "reject"] as const)("does not emit after unmount when a file read settles via %s", async (result) => {
+    const pending = Promise.withResolvers<FileUIPart>();
+    vi.spyOn(attachments, "fileToUIPart").mockReturnValue(pending.promise);
+    const wrapper = await renderPrompt();
+    await pickFile(wrapper);
+    wrapper.unmount();
+    if (result === "resolve") pending.resolve(filePart);
+    else pending.reject(new Error("File read failed"));
+    await flushPromises();
+    expect(wrapper.emitted("update:files")).toBeUndefined();
+    expect(wrapper.emitted("error")).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Enter could submit a new prompt while the button showed Stop or Retry, or before attached files finished conversion. `AgentChatPrompt` now allows a new submission only in the ready state after all pending file batches settle. It keeps the draft editable and preserves Stop and Retry actions.

Custom submit slots receive `canSubmit` and `preparingFiles`. File conversion no longer emits updates or errors after unmount. The prompt docs explain these states and connect the reload event to AI SDK's `regenerate()` helper.

| | Description | StackBlitz | GitHub |
| --- | --- | --- | --- |
| Before | Enter during streaming emitted a new submission. | Local browser reproduction; no hosted sandbox. | [Source](https://github.com/vite-hub/vitehub/blob/b89983051a0/packages/ui/src/components/agent-chat-prompt.ts#L72) |
| After | Enter stays inactive during streaming; Stop still works. Submission waits for file preparation and recovers after a read error. | Local browser reproduction; no hosted sandbox. | [Source](https://github.com/vite-hub/vitehub/blob/455354ef689d4c09c781f09d29d71ae63e3212e1/packages/ui/test/chat-prompt-submission.test.ts) |

Maintainer policy: before/after images and demonstration video are not required for this pull request.

Model: GPT-6. Harness: Codex in T3 Code.
