### PR TITLE
fix(console): preserve journal ownership and inspect usage

### DIFF
--- a/docs/content/docs/capabilities/usage.md
+++ b/docs/content/docs/capabilities/usage.md
@@ -72,6 +72,8 @@ Pass `pricing: false` when the application needs tokens without estimated cost.
 capabilities: [usage({ pricing: false })]
 ```
 
+The Capability exposes whether pricing is configured in `metadata.costSupported`. The Console uses this flag before recorded cost is available. Provider-recorded cost remains available when pricing is disabled.
+
 Pass `pricing` when the application owns its rates or provider mapping. Return exact USD as a decimal string. ViteHub derives the display value.
 
 ```ts [server/agents/support.ts]

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -194,7 +194,7 @@ Pass `--json` for the structured inspection contract.
 - `mcp()` connects tools from [Model Context Protocol](https://modelcontextprotocol.io/) servers through `@ai-sdk/mcp`.
 - `kv()`, `blob()`, `db()`, and `email()` expose [`@vite-hub/kv`](../kv/README.md), [`@vite-hub/blob`](../blob/README.md), [`@vite-hub/database`](../database/README.md), and [`@vite-hub/email`](../email/README.md).
 - `sandbox()` and `schedule()` expose [`@vite-hub/sandbox`](../sandbox/README.md) and [`@vite-hub/schedule`](../schedule/README.md).
-- `usage()` requests provider usage metadata, estimates missing cost from Models.dev, and exposes the normalized Agent Usage Record through its typed Finish Extension.
+- `usage()` requests provider usage metadata, estimates missing cost from Models.dev, and exposes the normalized Agent Usage Record through its typed Finish Extension. Its `metadata.costSupported` flag is false when `pricing: false` disables estimation.
 - `skills()`, `access()`, `memory()`, `fetch()`, `llmRoute()`, and `llmGate()` cover prompt skills, workspace scope, durable notes, HTTP reads, and pre-run decisions.
 
 ```ts

--- a/packages/agent/src/capabilities/usage.ts
+++ b/packages/agent/src/capabilities/usage.ts
@@ -33,6 +33,7 @@ export function usage(options: UsageOptions = {}): AgentCapabilityDefinition {
     instructionCoverage: false,
     metadata: {
       kind: "usage",
+      pricing: pricing !== undefined,
     },
     configure(context) {
       context.modelExecution.instrument({

--- a/packages/agent/src/capabilities/usage.ts
+++ b/packages/agent/src/capabilities/usage.ts
@@ -32,6 +32,7 @@ export function usage(options: UsageOptions = {}): AgentCapabilityDefinition {
     id: "usage",
     instructionCoverage: false,
     metadata: {
+      costSupported: pricing !== undefined,
       kind: "usage",
     },
     configure(context) {

--- a/packages/vite-hub/src/console/runtime/server/agents.ts
+++ b/packages/vite-hub/src/console/runtime/server/agents.ts
@@ -36,8 +36,8 @@ type ResolvedConsoleAgentDefinition = {
 
 function record(value: unknown): Record<string, unknown> | undefined {
   if (Array.isArray(value)) return
-  const result = v.safeParse(recordSchema, value)
-  return result.success ? result.output : undefined
+  // Keep definition identity and symbol metadata for journal ownership and rebinding.
+  return v.is(recordSchema, value) ? value : undefined
 }
 
 function stringValue(value: unknown): string | undefined {

--- a/packages/vite-hub/src/console/runtime/server/usage.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.get.ts
@@ -64,7 +64,9 @@ const usageHandler = async (event: ConsoleRequestEvent): Promise<Record<string, 
     const costConfigured = (agentName ? [agentName] : getConsoleAgents()).some((name) => {
       const capabilities = getConsoleAgentDefinition(name, "inspect")?.capabilities;
       return (
-        Array.isArray(capabilities) && capabilities.some((capability) => capability?.id === "usage")
+        Array.isArray(capabilities) && capabilities.some((capability) => (
+          capability?.id === "usage" && capability.metadata?.pricing === true
+        ))
       );
     });
     const index = getConsoleUsageIndex(invocations);

--- a/packages/vite-hub/src/console/runtime/server/usage.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.get.ts
@@ -64,7 +64,7 @@ const usageHandler = async (event: ConsoleRequestEvent): Promise<Record<string, 
     const costConfigured = (agentName ? [agentName] : getConsoleAgents()).some((name) => {
       const capabilities = getConsoleAgentDefinition(name, "inspect")?.capabilities;
       return (
-        Array.isArray(capabilities) && capabilities.some((capability) => capability?.id === "usage")
+        Array.isArray(capabilities) && capabilities.some((capability) => capability?.id === "usage" && capability.metadata?.costSupported === true)
       );
     });
     const index = getConsoleUsageIndex(invocations);

--- a/packages/vite-hub/src/console/runtime/server/usage.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.get.ts
@@ -62,9 +62,9 @@ const usageHandler = async (event: ConsoleRequestEvent): Promise<Record<string, 
   const invocations = getConsoleInvocations();
   return cached(invocations, JSON.stringify([agentName ?? null, window, cursor]), async () => {
     const costConfigured = (agentName ? [agentName] : getConsoleAgents()).some((name) => {
-      const capabilities = getConsoleAgentDefinition(name)?.capabilities;
+      const capabilities = getConsoleAgentDefinition(name, "inspect")?.capabilities;
       return (
-        Array.isArray(capabilities) && capabilities.some((capability) => capability?.id === "cost")
+        Array.isArray(capabilities) && capabilities.some((capability) => capability?.id === "usage")
       );
     });
     const index = getConsoleUsageIndex(invocations);

--- a/packages/vite-hub/test/console-usage-route.test.ts
+++ b/packages/vite-hub/test/console-usage-route.test.ts
@@ -23,11 +23,61 @@ it("registers one production Usage GET endpoint when configuration is reapplied"
   } finally { await rm(root, { recursive: true, force: true }) }
 })
 
-it.each([false, true])("recognizes built-in Usage before the first invocation when invoke is %s", async (invoke) => {
-  const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
+const pricingCases = [
+  { name: "default", capability: () => usage(), costSupported: true },
+  { name: "disabled", capability: () => usage({ pricing: false }), costSupported: false },
+  { name: "custom", capability: () => usage({ pricing: () => ({ usd: "0.001", estimated: true, source: "custom" }) }), costSupported: true },
+]
+
+it.each([false, true].flatMap(invoke => pricingCases.map(pricing => ({ ...pricing, invoke }))))(
+  "reports $name pricing before the first invocation when invoke is $invoke", async ({ capability, costSupported, invoke }) => {
+    const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
+    installConsoleAgentDefinitions([{
+      definition: {
+        capabilities: [capability()],
+        invocations,
+        async resolve() { throw new Error("Usage inspection must not invoke the Agent") },
+      },
+      fallbackName: "usage-agent",
+    }], { projectRoot: process.cwd(), invoke })
+
+    for (const query of ["", "?agent=usage-agent"]) {
+      expect(await usageHandler({
+        method: "GET",
+        req: { url: `http://localhost/api/_vitehub/console/usage${query}` },
+      })).toMatchObject({ available: false, costSupported })
+    }
+  },
+)
+
+it.each([false, true])("keeps provider-recorded cost when pricing is disabled and invoke is %s", async (invoke) => {
+  const store = createMemoryAgentInvocationStore()
+  const timestamp = new Date().toISOString()
+  await store.create({
+    agentName: "usage-agent",
+    completedAt: timestamp,
+    createdAt: timestamp,
+    id: "provider-cost",
+    observations: [{
+      attributes: {
+        "usage.record": {
+          cost: { usd: "0.01", estimated: false, source: "provider" },
+          usage: { inputTokens: 2, outputTokens: 3, totalTokens: 5 },
+        },
+      },
+      name: "agent.invocation.finish",
+      sequence: 1,
+      timestamp,
+      type: "lifecycle",
+    }],
+    status: "completed",
+    traceId: "provider-cost",
+    updatedAt: timestamp,
+  })
+  const invocations = defineAgentInvocations({ store })
   installConsoleAgentDefinitions([{
     definition: {
-      capabilities: [usage()],
+      capabilities: [usage({ pricing: false })],
       invocations,
       async resolve() { throw new Error("Usage inspection must not invoke the Agent") },
     },
@@ -38,6 +88,6 @@ it.each([false, true])("recognizes built-in Usage before the first invocation wh
     expect(await usageHandler({
       method: "GET",
       req: { url: `http://localhost/api/_vitehub/console/usage${query}` },
-    })).toMatchObject({ available: false, costSupported: true })
+    })).toMatchObject({ costSupported: true, totals: { costUsd: "0.01", costEstimated: false } })
   }
 })

--- a/packages/vite-hub/test/console-usage-route.test.ts
+++ b/packages/vite-hub/test/console-usage-route.test.ts
@@ -23,11 +23,16 @@ it("registers one production Usage GET endpoint when configuration is reapplied"
   } finally { await rm(root, { recursive: true, force: true }) }
 })
 
-it.each([false, true])("recognizes built-in Usage before the first invocation when invoke is %s", async (invoke) => {
+it.each([
+  { costSupported: true, invoke: false, pricing: true },
+  { costSupported: true, invoke: true, pricing: true },
+  { costSupported: false, invoke: false, pricing: false },
+  { costSupported: false, invoke: true, pricing: false },
+])("reports cost support as $costSupported before the first invocation when pricing is $pricing and invoke is $invoke", async ({ costSupported, invoke, pricing }) => {
   const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
   installConsoleAgentDefinitions([{
     definition: {
-      capabilities: [usage()],
+      capabilities: [pricing ? usage() : usage({ pricing: false })],
       invocations,
       async resolve() { throw new Error("Usage inspection must not invoke the Agent") },
     },
@@ -38,6 +43,6 @@ it.each([false, true])("recognizes built-in Usage before the first invocation wh
     expect(await usageHandler({
       method: "GET",
       req: { url: `http://localhost/api/_vitehub/console/usage${query}` },
-    })).toMatchObject({ available: false, costSupported: true })
+    })).toMatchObject({ available: false, costSupported })
   }
 })

--- a/packages/vite-hub/test/console-usage-route.test.ts
+++ b/packages/vite-hub/test/console-usage-route.test.ts
@@ -2,7 +2,11 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { expect, it } from "vitest"
+import { usage } from "@vite-hub/agent/capabilities"
+import { createMemoryAgentInvocationStore, defineAgentInvocations } from "@vite-hub/agent/server"
 import { consoleVitePlugin } from "../src/console/vite.ts"
+import { installConsoleAgentDefinitions } from "../src/console/runtime/server/agents.ts"
+import usageHandler from "../src/console/runtime/server/usage.get.ts"
 
 it("registers one production Usage GET endpoint when configuration is reapplied", async () => {
   const root = await mkdtemp(join(tmpdir(), "vitehub-usage-route-"))
@@ -17,4 +21,23 @@ it("registers one production Usage GET endpoint when configuration is reapplied"
       { handler: expect.stringMatching(/server\/usage\.get\.js$/), route: "/api/_vitehub/console/usage", method: "get" },
     ])
   } finally { await rm(root, { recursive: true, force: true }) }
+})
+
+it.each([false, true])("recognizes built-in Usage before the first invocation when invoke is %s", async (invoke) => {
+  const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
+  installConsoleAgentDefinitions([{
+    definition: {
+      capabilities: [usage()],
+      invocations,
+      async resolve() { throw new Error("Usage inspection must not invoke the Agent") },
+    },
+    fallbackName: "usage-agent",
+  }], { projectRoot: process.cwd(), invoke })
+
+  for (const query of ["", "?agent=usage-agent"]) {
+    expect(await usageHandler({
+      method: "GET",
+      req: { url: `http://localhost/api/_vitehub/console/usage${query}` },
+    })).toMatchObject({ available: false, costSupported: true })
+  }
 })

--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -489,6 +489,7 @@ describe("Agent invocation console", () => {
       if (!config.nitro) throw new TypeError("Expected the console Nitro configuration.")
 
       expect(config.nitro.handlers.map((handler) => handler.route)).toEqual([
+        "/api/_vitehub/console/status",
         "/api/_vitehub/console/usage",
         "/_vitehub",
         "/_vitehub/**",
@@ -542,6 +543,7 @@ describe("Agent invocation console", () => {
       await Reflect.apply(configHandler, {}, [config, { command: "build", mode: "production" }])
 
       expect(config.nitro?.handlers.map(handler => handler.route)).toEqual([
+        "/api/_vitehub/console/status",
         "/api/_vitehub/console/usage",
         "/_vitehub",
         "/_vitehub/**",
@@ -610,7 +612,7 @@ describe("Agent invocation console", () => {
 
       await Reflect.apply(configHandler, {}, [config, { command: "build", mode: "production" }])
 
-      expect(config.nitro?.handlers.map((handler) => handler.route)).toEqual(["/api/_vitehub/console/usage", "/_vitehub", "/_vitehub/**", "/_vitehub/rpc/**"])
+      expect(config.nitro?.handlers.map((handler) => handler.route)).toEqual(["/api/_vitehub/console/status", "/api/_vitehub/console/usage", "/_vitehub", "/_vitehub/**", "/_vitehub/rpc/**"])
       const generated = await readFile(config.nitro!.plugins[0]!, "utf8")
       expect(generated).toContain(`from "vite-hub/console/sections"`)
       expect(generated).not.toContain(`from "vite-hub/console/server"`)
@@ -809,6 +811,7 @@ describe("Agent invocation console", () => {
       await callPluginHook(plugin.configResolved, {}, [config])
 
       expect(config.nitro?.handlers.map(handler => handler.route)).toEqual([
+        "/api/_vitehub/console/status",
         "/api/_vitehub/console/usage",
         "/_vitehub",
         "/_vitehub/**",
@@ -857,6 +860,7 @@ describe("Agent invocation console", () => {
       await Reflect.apply(configHandler, {}, [config, { command: "build", mode: "production" }])
 
       expect(config.nitro?.handlers.map(handler => handler.route)).toEqual([
+        "/api/_vitehub/console/status",
         "/api/_vitehub/console/usage",
         "/_vitehub",
         "/_vitehub/**",
@@ -904,6 +908,7 @@ describe("Agent invocation console", () => {
       await Reflect.apply(configHandler, {}, [config, { command: "build", mode: "production" }])
 
       expect(config.nitro?.handlers.map(handler => handler.route)).toEqual([
+        "/api/_vitehub/console/status",
         "/api/_vitehub/console/usage",
         "/_vitehub",
         "/_vitehub/**",
@@ -990,6 +995,7 @@ describe("Agent invocation console", () => {
       await Reflect.apply(configHandler, {}, [config, { command: "build", mode: "production" }])
 
       expect(config.nitro?.handlers.map(handler => handler.route)).toEqual([
+        "/api/_vitehub/console/status",
         "/api/_vitehub/console/usage",
         "/_vitehub",
         "/_vitehub/**",
@@ -2055,7 +2061,7 @@ describe("Agent invocation console", () => {
     const first = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
     const second = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
     const explicit = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
-    const definition: { invocations?: AgentInvocations, name: string } = { name: "support" }
+    const definition = { ...defineAgent({ name: "support", driver: { run: () => "ok" } }) }
     const entries = [{ definition: { default: definition }, fallbackName: "help" }]
 
     installConsoleAgentDefinitions(entries, { invocations: first })
@@ -3331,7 +3337,7 @@ describe("Agent invocation console", () => {
     expect(projected).not.toHaveProperty("totalTokens")
   })
 
-  it("keeps completed sessions without usage in the no-usage state", async () => {
+  it("includes completed sessions while keeping missing usage unavailable", async () => {
     const store = createMemoryAgentInvocationStore()
     store.create({
       completedAt: "2026-08-27T10:00:00.000Z",
@@ -3347,7 +3353,7 @@ describe("Agent invocation console", () => {
       now: "2026-08-27T12:00:00.000Z",
       window: "24h",
     })).resolves.toMatchObject({
-      available: false,
+      available: true,
       models: [],
       totals: { costAvailable: false, invocations: 1, totalTokensAvailable: false },
     })


### PR DESCRIPTION
Console copies discovered Agent Definitions during validation, so journal assignments do not reach the original definition. Its Usage endpoint also misses the built-in `usage()` Capability before the first invocation, especially when Agent invocation is disabled.

Validate definitions without copying them, and inspect the `usage` Capability through inspection access. Console-owned journals can be rebound; later journals assigned by the contributor stay in place. Usage declares whether pricing is configured, so disabling cost estimation keeps monetary panels hidden until provider-recorded cost exists. Update route and usage expectations to match the merged provider-status contract.

| | Description | GitHub |
| --- | --- | --- |
| Before | Definition validation loses object identity; empty journals report no Usage support. | [Source](https://github.com/vite-hub/vitehub/blob/09637c93998833b183192a11dce5977b773fafee/packages/vite-hub/src/console/runtime/server/agents.ts) |
| After | Direct definitions retain journal ownership. Usage inspection respects pricing configuration with invocation enabled or disabled. | [Source](https://github.com/vite-hub/vitehub/blob/5f95560d81c2944ba6f8c73aedfbfb64bd24b244/packages/vite-hub/test/console-usage-route.test.ts) |

These reproductions use the repository's Console server fixtures.

Model: GPT-6. Harness: Codex.
