### PR TITLE
fix(console): load colocated agent skills in production

### DIFF
--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -27,6 +27,7 @@ import { agentRouteUsesParam, defaultAgentChatRoute, normalizeAgentRoute } from 
 import { hasRuntimeType } from "./internal/runtime-type.ts"
 import { readColocatedAgentInstructions } from "./vite/colocated-agent-instructions.ts"
 import { readColocatedAgentSkills, resolveColocatedAgentSkillsRoot } from "./vite/colocated-agent-skills.ts"
+export { readColocatedAgentSkills } from "./vite/colocated-agent-skills.ts"
 
 import type { Plugin, ResolvedConfig, UserConfig } from "vite"
 import type { ProviderDeploymentOutputWriter, ProviderOutputCatalog } from "@vite-hub/internal/build/deployment-output"

--- a/packages/vite-hub/src/console/plugin.ts
+++ b/packages/vite-hub/src/console/plugin.ts
@@ -2,6 +2,8 @@ import { mkdir, readFile, writeFile } from "node:fs/promises"
 import { resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 
+import { readColocatedAgentSkills } from "@vite-hub/agent/vite"
+
 import type { AgentInvocationsOptions } from "@vite-hub/agent/server"
 import type { ConsoleAgentEntry, ConsoleBuildCatalog } from "./build.ts"
 import type { ConsoleSectionId } from "./runtime/sections.ts"
@@ -25,6 +27,14 @@ function renderConsoleNitroPlugin(
   invoke = false,
   observations?: AgentInvocationsOptions["observations"],
 ): string {
+  const definitions = agents.map((agent, index) => {
+    const skills = readColocatedAgentSkills(agent.handler)
+    const module = `vitehubConsoleAgent${index}`
+    const definition = skills
+      ? `agentWithColocatedSkills(${module}.default ?? ${module}, ${JSON.stringify(skills)})`
+      : module
+    return `{ definition: ${definition}, fallbackName: ${JSON.stringify(agent.name)} }`
+  }).join(", ")
   const agentsEnabled = sections.includes("agents")
   const blobEnabled = sections.includes("blob")
   const databaseEnabled = sections.includes("databases")
@@ -41,7 +51,7 @@ function renderConsoleNitroPlugin(
         ]
       : []),
     ...(agentsEnabled
-      ? [`import { installConsoleAgentDefinitions, installConsoleFixtureInvocations } from "vite-hub/console/server"`]
+      ? [`import { installConsoleAgentDefinitions, installConsoleFixtureInvocations } from "vite-hub/console/server"`, `import { agentWithColocatedSkills } from "@vite-hub/agent/runtime/workflow"`]
       : []),
     ...(definitionsEnabled ? [`import { installConsoleDefinitions } from "vite-hub/console/definitions"`] : []),
     ...(databaseEnabled
@@ -70,9 +80,9 @@ function renderConsoleNitroPlugin(
       ? fixture
         ? [
             `const vitehubConsoleInvocations = installConsoleFixtureInvocations(${JSON.stringify(projectRoot)}, ${JSON.stringify(fixture)}, ${fixtureSource}, ${JSON.stringify(revision)}, ${JSON.stringify(runtimeBinding)})`,
-            `installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { invocations: vitehubConsoleInvocations })`,
+            `installConsoleAgentDefinitions([${definitions}], { invocations: vitehubConsoleInvocations })`,
           ]
-        : [`installConsoleAgentDefinitions([${agents.map((agent, index) => `{ definition: vitehubConsoleAgent${index}, fallbackName: ${JSON.stringify(agent.name)} }`).join(", ")}], { projectRoot: ${JSON.stringify(projectRoot)}${invoke ? ", invoke: true" : ""}${observations !== undefined ? `, observations: ${JSON.stringify(observations)}` : ""} })`]
+        : [`installConsoleAgentDefinitions([${definitions}], { projectRoot: ${JSON.stringify(projectRoot)}${invoke ? ", invoke: true" : ""}${observations !== undefined ? `, observations: ${JSON.stringify(observations)}` : ""} })`]
       : []),
     ...(kvEnabled
       ? [`installConsoleKV(${JSON.stringify(projectRoot)}, vitehubConsoleKV, ${JSON.stringify(kvStores)})`]

--- a/packages/vite-hub/test/console-colocated-skills.test.ts
+++ b/packages/vite-hub/test/console-colocated-skills.test.ts
@@ -1,0 +1,35 @@
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { expect, it, vi } from "vitest"
+import { defineAgent } from "@vite-hub/agent"
+import { agentWithColocatedSkills } from "@vite-hub/agent/runtime/workflow"
+import { writeConsoleNitroPlugin } from "../src/console/plugin.ts"
+
+it("loads colocated Skills into the production Console definition", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-console-skills-"))
+  try {
+    const handler = join(root, "bot-dev", "agent.ts")
+    await mkdir(join(root, "bot-dev"), { recursive: true })
+    await mkdir(join(root, "bot", "skills", "review", "references"), { recursive: true })
+    await writeFile(handler, "export default {}\n")
+    await writeFile(join(root, "bot", "skills", "review", "SKILL.md"), "# Review\n")
+    await writeFile(join(root, "bot", "skills", "review", "references", "evidence.md"), "Use the mounted evidence.\n")
+    await symlink("../bot/skills", join(root, "bot-dev", "skills"))
+    const plugin = join(root, "plugin.mjs")
+    await writeConsoleNitroPlugin(plugin, root, ["agents"], [{ name: "bot-dev", handler }], { agents: [], definitions: {} }, [], [], undefined, undefined, true)
+    const generated = await readFile(plugin, "utf8")
+    const install = vi.fn()
+    const definition = defineAgent({ driver: "codex", runtime: false, workspace: {} })
+    const execute = new Function("installConsoleSections", "installConsoleProjectName", "installConsoleAgentDefinitions", "agentWithColocatedSkills", "vitehubConsoleAgent0", generated.replace(/^import .+$/gm, "").replace("export default function", "function"))
+    execute(() => {}, () => {}, install, agentWithColocatedSkills, { default: definition })
+    const installed = install.mock.calls[0]?.[0]?.[0]?.definition
+    expect(installed?.[Symbol.for("vitehub.agent.colocatedSkills")]).toMatchObject({
+      "__vitehubAgentSkill:skills/review/SKILL.md": { content: new TextEncoder().encode("# Review\n"), workspacePath: "skills/review/SKILL.md" },
+      "__vitehubAgentSkill:skills/review/references/evidence.md": { content: new TextEncoder().encode("Use the mounted evidence.\n"), workspacePath: "skills/review/references/evidence.md" },
+    })
+  }
+  finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
Production Console invocations load the raw Agent module, so colocated Skills never reach the provider workspace. In Quiver, the agent could read its main instructions but could not load the `quiver-evidence` skill those instructions referenced.

Embed the same colocated Skill sources used by Agent discovery and attach them to the Console definition with the existing runtime helper. This preserves symlinked skill directories and reference files.

Validation: the generated-Console regression fails without the fix and passes with it; Agent build and typecheck, host build/publint, and targeted lint pass. The broader local Console suite requires unbuilt sibling package exports, so CI will run it after the workspace build. Quiver's production browser test will verify the published package.

Model: GPT-6. Harness: Codex.
