### PR TITLE
feat(runtime): own work checkpoints and retry cooldowns

### DIFF
--- a/packages/runtime/README.md
+++ b/packages/runtime/README.md
@@ -177,3 +177,19 @@ Do not import from `src`, `dist`, or ViteHub's `_internal` paths.
 - [Stable import paths](https://vitehub.dev/docs/reference/import-paths)
 - [Node Runtime diagnostics](https://vitehub.dev/docs/capabilities/diagnostics)
 - [Report a Runtime issue](https://github.com/vite-hub/vitehub/issues/new)
+
+### Work checkpoints
+
+`createWorkTracker({ store })` owns single-process work deduplication and durable park/retry checkpoints. The store exposes asynchronous `get(key)` and `set(key, checkpoint)` operations. The application supplies a meaningful state fingerprint and decides whether a completed run should park or retry.
+
+```ts
+import { createWorkTracker } from '@vite-hub/runtime'
+
+const work = createWorkTracker({ store, retryMs: 60_000, maxRetryMs: 3_600_000 })
+await work.run(key, observedFingerprint, async () => {
+  await repair()
+  return { disposition: 'park', fingerprint: repairedFingerprint }
+})
+```
+
+Unchanged parked work is skipped. Retries use bounded exponential backoff, including thrown errors. A changed fingerprint bypasses cooldown. Failed checkpoint writes retain a local cooldown and propagate the persistence failure; they do not claim durability. Active keys are exclusive within one tracker. Use an external lease for multiple hosts sharing work. `eligible(key, fingerprint)` supports discovery filtering, while `run` rechecks eligibility after acquiring local ownership.

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1283,3 +1283,6 @@ export async function resolveCapabilityPolicy(
   if (!policy) return "allow"
   return hasRuntimeType(policy, "function") ? await policy(context) : policy
 }
+
+export { createWorkTracker } from "./work.ts"
+export type { WorkCheckpoint, WorkCheckpointStore, WorkOutcome, WorkTracker } from "./work.ts"

--- a/packages/runtime/src/work.ts
+++ b/packages/runtime/src/work.ts
@@ -78,22 +78,23 @@ export function createWorkTracker(options: {
     async run(key: string, fingerprint: string, run: () => Promise<WorkOutcome>): Promise<boolean> {
       if (active.has(key)) return false
       active.add(key)
-      let previous: WorkCheckpoint | undefined
-      let current = fingerprint
       try {
-        previous = await read(key)
+        const previous = await read(key)
         if (!eligible(previous, fingerprint)) return false
-        const result = await run()
-        if (result.disposition !== "park" && result.disposition !== "retry") throw new TypeError("Work must return a park or retry disposition.")
-        current = result.fingerprint ?? fingerprint
-        await write(key, result.disposition === "retry" ? retry(current, previous)
-          : { version: 1, fingerprint: current, disposition: "park", attempt: 0 })
-        return true
-      }
-      catch (error) {
-        try { await write(key, retry(current, previous)) }
-        catch (checkpointError) { throw new AggregateError([error, checkpointError], "Work failed and its retry checkpoint could not be persisted.") }
-        throw error
+        let current = fingerprint
+        try {
+          const result = await run()
+          if (result.disposition !== "park" && result.disposition !== "retry") throw new TypeError("Work must return a park or retry disposition.")
+          current = result.fingerprint ?? fingerprint
+          await write(key, result.disposition === "retry" ? retry(current, previous)
+            : { version: 1, fingerprint: current, disposition: "park", attempt: 0 })
+          return true
+        }
+        catch (error) {
+          try { await write(key, retry(current, previous)) }
+          catch (checkpointError) { throw new AggregateError([error, checkpointError], "Work failed and its retry checkpoint could not be persisted.") }
+          throw error
+        }
       }
       finally { active.delete(key) }
     },

--- a/packages/runtime/src/work.ts
+++ b/packages/runtime/src/work.ts
@@ -1,0 +1,101 @@
+import { hasRuntimeType, isRuntimeObject } from "./internal/runtime-type.ts"
+
+/** Durable completion state for one observed version of a work item. */
+export interface WorkCheckpoint {
+  version: 1
+  fingerprint: string
+  disposition: "park" | "retry"
+  attempt: number
+  retryAt?: number
+}
+export interface WorkCheckpointStore {
+  get(key: string): Promise<unknown>
+  set(key: string, value: WorkCheckpoint): Promise<void>
+}
+export interface WorkOutcome {
+  disposition: "park" | "retry"
+  /** Use the newly observed version when the run changed the work item. */
+  fingerprint?: string
+}
+
+/** Single-process ownership with durable park/retry state. Shared hosts need an external lease. */
+export interface WorkTracker {
+  readonly active: number
+  has(key: string): boolean
+  eligible(key: string, fingerprint: string): Promise<boolean>
+  run(key: string, fingerprint: string, run: () => Promise<WorkOutcome>): Promise<boolean>
+}
+
+export function createWorkTracker(options: {
+  store: WorkCheckpointStore
+  retryMs?: number
+  maxRetryMs?: number
+  now?: () => number
+}): WorkTracker {
+  const retryMs = options.retryMs ?? 15 * 60_000
+  const maxRetryMs = options.maxRetryMs ?? 6 * 60 * 60_000
+  if (!Number.isFinite(retryMs) || retryMs <= 0 || !Number.isFinite(maxRetryMs) || maxRetryMs < retryMs) {
+    throw new TypeError("Work retry intervals must be positive and maxRetryMs must be at least retryMs.")
+  }
+  const now = options.now ?? Date.now
+  const active = new Set<string>()
+  const fallback = new Map<string, WorkCheckpoint>()
+  function checkpoint(value: unknown): WorkCheckpoint | undefined {
+    if (!isRuntimeObject(value)) return
+    // SAFETY: This untrusted checkpoint is returned only after validating every control field below.
+    const state = value as WorkCheckpoint
+    if (state.version !== 1 || !hasRuntimeType(state.fingerprint, "string")
+      || !Number.isSafeInteger(state.attempt) || state.attempt < 0) return
+    if (state.disposition === "park") return state
+    if (state.disposition === "retry" && Number.isFinite(state.retryAt)) return state
+  }
+  async function read(key: string) {
+    // A failed durable write must still cool down the job on this host.
+    return fallback.get(key) ?? checkpoint(await options.store.get(key))
+  }
+  function eligible(state: WorkCheckpoint | undefined, fingerprint: string) {
+    return !state || state.fingerprint !== fingerprint
+      || state.disposition === "retry" && state.retryAt! <= now()
+  }
+  async function write(key: string, state: WorkCheckpoint) {
+    fallback.set(key, state)
+    await options.store.set(key, state)
+    fallback.delete(key)
+  }
+  function retry(fingerprint: string, previous?: WorkCheckpoint): WorkCheckpoint {
+    const attempt = previous?.fingerprint === fingerprint ? previous.attempt + 1 : 1
+    return {
+      version: 1, fingerprint, disposition: "retry", attempt,
+      retryAt: now() + Math.min(retryMs * 2 ** Math.min(attempt - 1, 30), maxRetryMs),
+    }
+  }
+  return {
+    get active() { return active.size },
+    has(key: string) { return active.has(key) },
+    async eligible(key: string, fingerprint: string) {
+      return !active.has(key) && eligible(await read(key), fingerprint)
+    },
+    async run(key: string, fingerprint: string, run: () => Promise<WorkOutcome>): Promise<boolean> {
+      if (active.has(key)) return false
+      active.add(key)
+      let previous: WorkCheckpoint | undefined
+      let current = fingerprint
+      try {
+        previous = await read(key)
+        if (!eligible(previous, fingerprint)) return false
+        const result = await run()
+        if (result.disposition !== "park" && result.disposition !== "retry") throw new TypeError("Work must return a park or retry disposition.")
+        current = result.fingerprint ?? fingerprint
+        await write(key, result.disposition === "retry" ? retry(current, previous)
+          : { version: 1, fingerprint: current, disposition: "park", attempt: 0 })
+        return true
+      }
+      catch (error) {
+        try { await write(key, retry(current, previous)) }
+        catch (checkpointError) { throw new AggregateError([error, checkpointError], "Work failed and its retry checkpoint could not be persisted.") }
+        throw error
+      }
+      finally { active.delete(key) }
+    },
+  }
+}

--- a/packages/runtime/test/work.test.ts
+++ b/packages/runtime/test/work.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest"
+import { createWorkTracker } from "../src/work.ts"
+
+function fixture() {
+  let time = 0
+  const records = new Map<string, unknown>()
+  const store = { get: async (key: string) => records.get(key), set: async (key: string, state: unknown) => { records.set(key, state) } }
+  const tracker = createWorkTracker({ store, retryMs: 100, maxRetryMs: 400, now: () => time })
+  return { tracker, records, store, advance: (ms: number) => { time += ms } }
+}
+describe("work checkpoints", () => {
+  it("parks unchanged work and admits a new fingerprint", async () => {
+    const { tracker } = fixture()
+    expect(await tracker.run("a", "v1", async () => ({ disposition: "park" }))).toBe(true)
+    expect(await tracker.eligible("a", "v1")).toBe(false)
+    expect(await tracker.eligible("a", "v2")).toBe(true)
+  })
+  it("parks the new version produced by a repair", async () => {
+    const { tracker } = fixture()
+    await tracker.run("a", "v1", async () => ({ disposition: "park", fingerprint: "v2" }))
+    expect(await tracker.eligible("a", "v2")).toBe(false)
+  })
+  it("cools down exceptions and increases bounded retry delays", async () => {
+    const { tracker, records, advance } = fixture()
+    const fail = async (): Promise<never> => { throw new Error("checkout unavailable") }
+    await expect(tracker.run("a", "v1", fail)).rejects.toThrow("checkout unavailable")
+    expect(tracker.active).toBe(0)
+    expect(await tracker.eligible("a", "v1")).toBe(false)
+    advance(100)
+    await expect(tracker.run("a", "v1", fail)).rejects.toThrow()
+    expect(records.get("a")).toMatchObject({ attempt: 2, retryAt: 300 })
+    expect(await tracker.eligible("a", "v2")).toBe(true)
+  })
+  it("keeps a local cooldown when persistence fails", async () => {
+    const { tracker, store } = fixture()
+    store.set = async () => { throw new Error("disk unavailable") }
+    await expect(tracker.run("a", "v1", async () => { throw new Error("provider unavailable") })).rejects.toThrow("could not be persisted")
+    expect(await tracker.eligible("a", "v1")).toBe(false)
+    expect(tracker.active).toBe(0)
+  })
+  it("excludes concurrent owners and releases after completion", async () => {
+    const { tracker } = fixture()
+    let release!: () => void
+    const waiting = new Promise<void>(resolve => { release = resolve })
+    const first = tracker.run("a", "v1", async () => { await waiting; return { disposition: "park" } })
+    expect(await tracker.run("a", "v1", async () => ({ disposition: "retry" }))).toBe(false)
+    release()
+    await first
+    expect(tracker.active).toBe(0)
+  })
+  it("retains cooldown after restart", async () => {
+    const { tracker, store } = fixture()
+    await tracker.run("a", "v1", async () => ({ disposition: "retry" }))
+    const restarted = createWorkTracker({ store, now: () => 50 })
+    expect(await restarted.eligible("a", "v1")).toBe(false)
+  })
+  it("cools down the repaired version when its checkpoint write fails", async () => {
+    const { tracker, store } = fixture()
+    store.set = async () => { throw new Error("disk unavailable") }
+    await expect(tracker.run("a", "v1", async () => ({ disposition: "park", fingerprint: "v2" }))).rejects.toThrow()
+    expect(await tracker.eligible("a", "v2")).toBe(false)
+  })
+
+})

--- a/packages/runtime/test/work.test.ts
+++ b/packages/runtime/test/work.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { createWorkTracker } from "../src/work.ts"
 
 function fixture() {
@@ -37,6 +37,27 @@ describe("work checkpoints", () => {
     await expect(tracker.run("a", "v1", async () => { throw new Error("provider unavailable") })).rejects.toThrow("could not be persisted")
     expect(await tracker.eligible("a", "v1")).toBe(false)
     expect(tracker.active).toBe(0)
+  })
+  it.each([
+    { version: 1, fingerprint: "v1", disposition: "park", attempt: 0 },
+    { version: 1, fingerprint: "v1", disposition: "retry", attempt: 8, retryAt: 400 },
+  ])("preserves $disposition state when the checkpoint read fails", async (state) => {
+    const { tracker, records, store } = fixture()
+    records.set("a", state)
+    const error = new Error("read unavailable")
+    const get = vi.spyOn(store, "get").mockRejectedValueOnce(error)
+    const set = vi.spyOn(store, "set")
+    const run = vi.fn(async () => ({ disposition: "park" as const }))
+
+    await expect(tracker.run("a", "v1", run)).rejects.toBe(error)
+    expect(run).not.toHaveBeenCalled()
+    expect(set).not.toHaveBeenCalled()
+    expect(records.get("a")).toBe(state)
+    expect(tracker.active).toBe(0)
+    expect(tracker.has("a")).toBe(false)
+    expect(await tracker.run("a", "v1", run)).toBe(false)
+    expect(get).toHaveBeenCalledTimes(2)
+    expect(run).not.toHaveBeenCalled()
   })
   it("excludes concurrent owners and releases after completion", async () => {
     const { tracker } = fixture()


### PR DESCRIPTION
Applications that repeatedly reconcile external work currently have to implement their own completion fingerprints, retry encodings, and in-process ownership. A fast thrown failure can otherwise be immediately selected again.

Add `createWorkTracker({ store })` to ViteHub Runtime. It parks unchanged versions, retries with bounded exponential backoff, admits changed versions immediately, and excludes concurrent local owners. Failed checkpoint writes retain a local cooldown while reporting the persistence error. Multiple hosts still require an external lease.

Babysitter now consumes this API through a temporary pnpm patch and is running it in release `ab622ff5`. PR-specific fingerprints and prioritization stay in Babysitter.

Validation: seven focused lifecycle tests, package build, workspace typecheck, strict TypeScript Doctor with no errors or warnings, and the built Babysitter consumer's typecheck and eight tests.
