### PR TITLE
fix(ci): run package regressions on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
 
   package-tests:
     name: package tests
-    if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
Pull requests skip the package-test job, so package regressions can reach main even when PR checks pass. PR #1291 expected the broader Console suite to run in CI, but those tests are outside the root contract suite.

Run the existing package-test job on pull requests. It uses the existing `vp run test` task, including dependency builds and package failure summaries. Keep all other jobs and test coverage unchanged.

Validation: CI input policy check passed; CI policy, test-layer, and package-runner tests passed, 197 tests across 3 files; git diff --check passed.

The latest main package run exposes existing Blob cache-header and Browser packed-fixture failures. PR #1295 fixes the Browser fixture and PR #1297 fixes the Blob policy. Land those fixes before this CI change, then update this branch and rerun package tests. Hosted package results must be checked before merge; this change does not hide baseline failures. Package tests add CI work to each PR. No performance improvement is claimed.

Model: GPT-6. Harness: Codex.
