### PR TITLE
fix(browser): resolve declared dependencies in packed fixture

### DIFF
--- a/packages/browser/test/optional-peer-bundle.test.ts
+++ b/packages/browser/test/optional-peer-bundle.test.ts
@@ -1,6 +1,6 @@
 import { execFile } from "node:child_process"
 import { promisify } from "node:util"
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 
@@ -41,6 +41,8 @@ describe("Browser optional peer bundle", () => {
       cwd: new URL("..", import.meta.url),
     })
     await promisify(execFile)("tar", ["-xzf", archive, "-C", packedRoot])
+    // Packing excludes installed dependencies such as nostics.
+    await symlink(new URL("../node_modules", import.meta.url), join(packedRoot, "node_modules"), "junction")
   })
   afterAll(async () => {
     if (packedRoot) await rm(packedRoot, { force: true, recursive: true })


### PR DESCRIPTION
The packed Browser fixture has no installed dependencies. Its Cloudflare entry loads diagnostics and fails to resolve the declared `nostics` dependency, so package CI stops before it can check optional-peer bundling.

Link the package's installed dependencies into the temporary unpacked fixture. Keep the existing Worker/Node bundle assertions and externals unchanged. No production code or dependency declarations change.

Validation: reproduced the unresolved nostics failure before the fix. All 113 Browser tests across 12 files now pass, including the 5 optional-peer bundle tests. Browser build/publint, typecheck, targeted lint, and git diff --check pass. These checks build bundles locally; no live browser provider was called.

Model: GPT-6. Harness: Codex.
