### PR TITLE
docs(contributing): map ownership and focused verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ Build the affected package and its dependencies before running focused tests. Fr
 
 ```sh
 corepack pnpm install --frozen-lockfile
-node test/run-package-task.mjs build --packages vite-hub
+corepack pnpm exec vp run -t vite-hub#build
 corepack pnpm --dir packages/vite-hub exec vp test test/console-colocated-skills.test.ts
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,161 +1,51 @@
-I'm Maxi. You're my agent. We will work together often, so these preferences should guide our work.
+# ViteHub contributor instructions
 
-I love to build. I want complex systems to feel simple. I look for ways to remove complexity without hiding real constraints. I welcome bold ideas when they produce a clearer result.
+ViteHub provides server APIs and portable Agents across Vite hosts. Applications use `vite-hub`; libraries can use the `@vite-hub/*` owner packages. Server Primitives work without Agents. Agents receive selected operations through Capabilities.
 
-Quick rules before the details:
+## Code map
 
-1. Keep writing short and easy to scan.
-2. Always use ASD-STE100 Simplified Technical English.
-3. Avoid LLM language, em dashes, filler, and long status recaps. Speak simply.
+| Path | Responsibility |
+| --- | --- |
+| `packages/vite-hub/src/` | Framework distribution, discovery, generated output, and host integration |
+| `packages/vite-hub/src/console/` | First-party inspection UI and server routes |
+| `packages/agent/src/` | Agent Definitions, Drivers, Invocations, and Capabilities |
+| `packages/runtime/src/` | Shared host-independent runtime contracts |
+| `packages/workspace/src/`, `packages/source/src/` | File-tree state, access, and mounted Sources |
+| Other `packages/*/src/` | Each Server Primitive or integration's implementation |
+| `playground/console/` | Real Console UI with synthetic API data |
+| `fixtures/`, `test/consumer/`, `test/output/` | Consumer applications and package/host output proof |
+| `docs/content/docs/` | User documentation; package READMEs describe package contracts |
 
-## Coding preferences - general
+## Critical boundaries
 
-- Keep things simple. Use YAGNI unless I ask for more.
-- Use types to make invalid states hard to represent.
-- Propose bold ideas when they can give us a much better result.
-- Be careful with destructive actions that I did not request.
-- Write focused tests for changed behavior. Do not add tests only to preserve deleted behavior or lock in an arbitrary visual constant.
-- Use concise comments above functions or classes when they clarify use or a non-obvious constraint. Update comments when the code changes.
-- Use existing libraries when they fit. Keep the product's developer experience in charge.
+- Put shared behavior in the package that owns it. Console inspects runtime behavior; runtime policy stays in its owner package. Product-specific workflows belong in consumers.
+- Prefer the final public contract. Before keeping a legacy path, find real callers. A downstream workaround can expose an upstream gap.
+- Trace contract changes from configuration through generated output, runtime, and consumers. Cover affected hosts, providers, and configuration forms.
+- Keep authority explicit through Capabilities, Workspace access, and Sources. Runtime features must be inspectable through code or CLI.
+- Use the existing Vite, Nuxt, Vue, and pnpm stack. Prefer inferred TypeScript types; do not use `any`. Keep comments and public documentation in sync.
 
-## Coding preferences - TypeScript
+## Complete the change
 
-- Prefer inferred types. Do not use `any`.
-- Model data so a change flows through inference instead of repeated annotations.
-- Avoid one-line wrappers that only cast a value.
-- Write TypeScript that uses the language well. Do not copy patterns from a dynamically typed language.
-- Use this repository's Vite, Nuxt, Vue, and pnpm choices. Do not replace the stack without a clear task requirement.
+Read [CONTRIBUTING.md](CONTRIBUTING.md) for setup, focused checks, design, UI, and PR guidance. Start from the latest cited issue, PR, or consumer. State the user-visible result and adjacent behavior to preserve.
 
-## Questions are read-only
+One owner integrates and verifies the result. Delegate only bounded, independent work that reduces total effort. Name file ownership first; avoid recursive delegation. When the same approach fails again, inspect the cause before retrying.
 
-A capability or design question asks for an answer, not a change. Answer it and offer the next action. Do not edit files or change external state.
+Build the affected package and its dependencies before running focused tests. From the repository root:
 
-A direct request phrased as a question, such as "can you fix this?" or "can you create this pull request?", authorizes the named action.
+```sh
+corepack pnpm install --frozen-lockfile
+node test/run-package-task.mjs build --packages vite-hub
+corepack pnpm --dir packages/vite-hub exec vp test test/console-colocated-skills.test.ts
+```
 
-## Match ceremony to the task
+Replace the package and test with the affected owner. [Verification guidance](CONTRIBUTING.md#verify-the-changed-behavior) explains other test layers and the full gate. Backend changes need regression coverage and the original reproduction or nearest real flow. Report what passed, failed, and remains unverified. Do not remove coverage without evidence that its protection is obsolete, redundant, or ineffective.
 
-- Use one agent for work it can finish in one pass.
-- Use subagents for broad research, independent review, or parallel work with separate ownership.
-- State file and repository ownership before parallel work starts.
-- The latest instruction wins. When I say "continue," inspect the current branch, pull request, worktree, consumer, and deployed state before you resume.
-- If a repository rule conflicts with the task, explain the conflict before you act. Ask me to approve the exception.
+## Permissions and communication
 
-## Visual and design work
-
-- Make interface, layout, and copy changes directly. Create a mock only when I ask.
-- When T3 Code is the named reference, inspect its current source and screenshots. Do not copy it from memory.
-- Use Nuxt UI components when they fit. Match ViteHub's compact spacing and T3 Code's interaction patterns.
-- Prefer dense layouts, small icons, minimal copy, true black in dark mode, white primary text, and few borders.
-- Avoid decorative cards, pills, shadows, and subtitle rows.
-- Avoid continuously repainting animations such as pulse, shimmer, blur, and spinning loaders.
-- Check overflow, narrow widths, long tab lists, empty states, keyboard access, and panel resizing when they apply.
-- Ask before opening a browser or starting a development server unless the task already requests it.
-
-## Blast radius
-
-- Before cross-repository or live-system work, state the exact repository, path, branch or pull request, and live target.
-- Mentioning another repository does not authorize changes there. An explicit request that names the repository does.
-- Never touch production, live databases, a development server that a maintainer is using, deployments, or external accounts without explicit approval.
-- Preserve changes made by other people or agents. Inspect collisions and adapt around them.
-- Remove worktrees, branches, and temporary files created by the task after their remote state is safe. Never remove pre-existing work without explicit approval.
-
-## Pull requests
-
-- Do not push changes, create a pull request, or update a pull request unless I ask.
-- Confirm the destination repository and check for an existing pull request before you open one.
-- Rebase onto the latest `main` before opening a pull request.
-- Open a real pull request, not a draft.
-- Keep one concern per pull request unless I ask to combine work.
-- Use the repository's conventional title style, for example `fix(workspace): preserve source grants`.
-- Start the body with the problem, then explain the fix in plain language. Omit commit hashes and boilerplate sections unless they help the reviewer.
-- End the body with the model and harness used.
-- Interface pull requests need before and after images. Changes to motion or timing need a short video. Upload this evidence to GitHub. Do not commit pull-request-only media.
-- When monitoring a pull request, inspect checks and comments newer than the last push. Verify bot findings against the source. Fix real issues and explain false positives. Separate code failures from infrastructure failures. Stay quiet when nothing changed. Stop when review bots and required checks are green on the latest commit.
-- Merge only when my request gives that authority.
-- Never force-push.
-
----
-
-# ViteHub
-
-## Current status
-
-ViteHub is in active development. Optimize for the final contract. Breaking changes, removal of legacy code, and dropped backward compatibility are welcome when they make that contract clearer.
-
-## Project direction
-
-ViteHub provides server primitives for any host. It also provides portable Agents across Vite hosts, with Better Auth-level developer experience.
-
-Use these references:
-
-- Better Auth for composition. Plugins and Capabilities should fit naturally around Agent Definitions.
-- UnJS for host-independent runtime behavior, discovery, storage, scheduling, invocation, inspection, and deployment.
-
-## Build primitives, not everything
-
-Build reusable primitives that developers should not have to recreate. These include Agent Definitions, Capabilities, Workspaces, Sources, runtime invocation, storage, scheduling, inspection, and framework integration.
-
-Product-specific workflows belong in consumers when they can be built from ViteHub primitives. The Console is the exception for first-party inspection and debugging. It may expose ViteHub primitives, but runtime policy stays in the package that owns it.
-
-## Fight for the obvious API
-
-Build complex things as simply as possible. Simple and obvious are not always the same. Accept internal machinery when it makes the public contract behave as a developer or Agent would expect.
-
-Normal work must not expose implementation details, framework details, or compatibility history. Put shared behavior at the ViteHub boundary that owns it. Preserve ViteHub abstractions over local convenience.
-
-Before you preserve a legacy path, search this repository and known consumers for real callers. Migrate those callers to the final contract. Delete speculative compatibility unless the task requires it.
-
-Treat a downstream workaround as evidence of a ViteHub gap unless it is product-specific.
-
-## Agent-first runtime design
-
-Every runtime feature must be inspectable through code or CLI. This includes generated state, bindings, discovered definitions, and provider output. A dashboard can help, but it must not be the only inspection path.
-
-Familiar interfaces such as filesystems, tools, and shells are useful. Keep their contracts honest. State durability, isolation, security, persistence, cost, and production readiness explicitly.
-
-## Before making changes
-
-Reopen the latest cited issue, pull request body, screenshot, or consumer. State the exact outcome and the adjacent behavior that must stay unchanged.
-
-For a contract change, name the affected variants and trace the value through its owner. Check definition or configuration, generated output, runtime behavior, and consumers. Verify each affected provider, framework, configuration form, and output mode.
-
-When code owns resources or durable state, verify the applicable success, error, abort, cancellation, timeout, cleanup, restart, and concurrent reuse behavior at that boundary.
-
-## Downstream patch loop
-
-Use `pnpm patch` in a consuming project to prove the smallest downstream fix:
-
-1. Patch the smallest downstream change.
-2. Verify the real consumer flow.
-3. Upstream the source fix with focused coverage.
-4. Update the consumer to the fixed version and remove the patch.
-
-The fix is complete when the consumer works without the patch. Retire combined patches one hunk at a time as their fixes land upstream.
-
-## Verification
-
-Use the smallest proof that covers the changed behavior. Run focused test files and the package-level lint, typecheck, or build tasks that apply. Do not run the full repository suite unless I ask or the change has repository-wide impact.
-
-Backend behavior changes need focused tests. A claimed runtime fix must include the original reproduction or the nearest real flow.
-
-## Worktrees and parallel work
-
-Pull request work belongs in a dedicated worktree. Reuse the current task worktree when it is already isolated. Otherwise create one from the refreshed target base.
-
-Assume other agents may be active. Preserve their changes. Inspect collisions and adapt around them instead of reverting them.
-
-## Documentation and work artifacts
-
-Do not commit temporary plans, raw thread exports, or agent scratch files. Use `.agents/research/` only for durable, cited research that supports a project decision.
-
-Document user-visible behavior in `docs/content/docs/` and the affected package README when it is part of that package's contract. Keep documentation and code comments in sync with behavior.
-
-## Language
-
-"You" means the contributor reading this file. "Maintainers" means Maxi and the people building ViteHub. "Users" means developers building with ViteHub. "Agents" means the Agents those users define and run.
-
-Use ViteHub framework language for `vite-hub`, `@vite-hub/*`, Agent Definitions, Capabilities, Workspaces, Sources, Agent Invocations, framework integrations, runtime behavior, and upstream design. Use package names for implementation ownership inside a package.
-
-## Related repositories
-
-Project source folders are separate Git repositories. Follow each repository's local instructions.
+- Preserve other people's changes. Before cross-repository or live work, state the exact repository, path, branch/PR, and target. Another repository's mention does not authorize edits there.
+- Never use production, live databases, maintainer development servers, deployments, or external accounts without explicit approval. Ask before opening a browser or starting a development server unless the task requests it.
+- Do not push, create/update PRs, merge, or deploy without authorization for that action. Never force-push. [PR rules](CONTRIBUTING.md#pull-requests) apply when authorized.
+- Use an isolated task worktree. Preserve pre-existing work; remove task-created temporary files and worktrees only after their remote state is safe.
+- Design and capability questions are read-only. A direct request such as "can you fix this?" authorizes that action. Explain repository-rule conflicts and ask for an exception before acting.
+- On "continue", inspect the current branch, PR, worktree, consumer, and deployed state before resuming. Use read-only inspection within existing permissions.
+- Write short, plain technical English using ASD-STE100 principles. Avoid filler and em dashes. "Users" are developers; "Agents" are the Agents they define.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,11 +40,13 @@ Keep one owner responsible for integration and completion. Record commands and i
 
 Package scripts own package-local build, test, and typecheck behavior. [`vite.config.ts`](vite.config.ts) and [`test/tasks.ts`](test/tasks.ts) define root tasks. [`test/layers.ts`](test/layers.ts) defines test discovery. Use these files when task details change; do not create a second task registry.
 
-Start with the affected package. The package runner builds its dependency graph before package tests:
+Start with the affected package's full `test` script so every package-owned test invocation runs, including suites with a separate configuration:
 
 ```sh
-node test/run-package-task.mjs test --packages vite-hub
+corepack pnpm --dir packages/vite-hub run test
 ```
+
+For example, use `corepack pnpm --dir packages/internal run test` for `@vite-hub/internal` to include its default and Workerd suites. The package runner currently substitutes plain `vp test` for these scripts and can omit additional test invocations.
 
 For one regression, build first, then run from the package directory so Vitest uses its package config:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,137 @@
+# Contributing to ViteHub
+
+Use this guide to turn a requested behavior into a tested change. [AGENTS.md](AGENTS.md) contains the code map, critical boundaries, and permission rules.
+
+## Set up a checkout
+
+Use the Node version required by `package.json`. For the full verification gate, install the Deno version in `.tool-versions` with the [official Deno installation guide](https://docs.deno.com/runtime/getting_started/installation/). CI reads the same pin.
+
+From a clean checkout, let Corepack select pnpm from `package.json` and install the workspace dependencies. This also installs Vite+.
+
+```sh
+corepack pnpm install --frozen-lockfile
+```
+
+Check the contributor tools without running tests:
+
+```sh
+corepack pnpm exec vp run preflight
+```
+
+Then run the full local gate:
+
+```sh
+corepack pnpm exec vp run verify
+```
+
+`verify` runs the preflight first and includes the native Deno package consumer test. A missing or different Deno version is a contributor setup error, not a ViteHub runtime failure. Package scripts own package-local test, build, and typecheck behavior.
+
+A global `vp` installation is not required. Use `corepack pnpm exec vp` after installation. Node and pnpm requirements come from `package.json`; the Deno pin comes from `.tool-versions`. The current preflight checks Deno. It does not validate credentials or every provider tool.
+
+## Start with one user outcome
+
+Reopen the latest issue, PR, screenshot, or consumer. State the input, action, and result that will prove completion. Name adjacent behavior that must remain unchanged. Start with one real feature before changing the delivery process.
+
+Trace only the parts the feature uses: interface or CLI, server entry, runtime, persistence, background work, and external services. For state or resource owners, cover applicable failure, abort, cancellation, timeout, cleanup, restart, and concurrent reuse behavior. A mock proves only the boundary it controls.
+
+Keep one owner responsible for integration and completion. Record commands and interventions in the PR; do not add a separate tracking system. Separate blocking defects from optional improvements. Add process only when this work shows why it is needed.
+
+## Verify the changed behavior
+
+Package scripts own package-local build, test, and typecheck behavior. [`vite.config.ts`](vite.config.ts) and [`test/tasks.ts`](test/tasks.ts) define root tasks. [`test/layers.ts`](test/layers.ts) defines test discovery. Use these files when task details change; do not create a second task registry.
+
+Start with the affected package. The package runner builds its dependency graph before package tests:
+
+```sh
+node test/run-package-task.mjs test --packages vite-hub
+```
+
+For one regression, build first, then run from the package directory so Vitest uses its package config:
+
+```sh
+node test/run-package-task.mjs build --packages vite-hub
+corepack pnpm --dir packages/vite-hub exec vp test test/console-colocated-skills.test.ts
+corepack pnpm --dir packages/vite-hub run typecheck
+```
+
+Replace `vite-hub` with a manifest package name, such as `@vite-hub/agent`, and use the matching directory. Add the following checks only when their behavior is affected:
+
+| Change | Check from the repository root |
+| --- | --- |
+| Source code | `corepack pnpm exec vp run lint` and the owner package's typecheck |
+| Root contracts or development tooling | `corepack pnpm exec vp test --config vitest.config.ts test/<file>.test.ts` after required builds |
+| Published imports or consumer integration | `corepack pnpm exec vp run test:consumer` |
+| Generated Cloudflare or Vercel output | `corepack pnpm exec vp run test:output:cloudflare` or `test:output:vercel` |
+| User documentation links | `corepack pnpm exec vp run --filter vitehub-docs test:links` |
+| Repository-wide impact | `corepack pnpm exec vp run verify` |
+
+Root contracts do not include package tests. The full local gate does not replace provider runtime or browser checks. Read [CI](.github/workflows/ci.yml) for checks enabled on each event and the [live smoke workflow](.github/workflows/live-smoke.yml) for external-service requirements. Do not run live tasks without authorization.
+
+The [Console playground](playground/console/README.md) exercises the real UI with synthetic data. It cannot prove invocation execution, persistence, or provider behavior. For a Console runtime change, also exercise the real route and runtime with a local consumer.
+
+Report the observed user result, exact commands, failures, and unverified parts. Separate setup and infrastructure failures from product failures. Stop when the requested outcome and relevant checks pass; do not broaden testing without a new concern.
+
+## Load relevant guidance
+
+Use the [ViteHub skill](docs/skills/vitehub/SKILL.md) when building or debugging a consuming application. Its reference table selects guidance for Agent Definitions, Workspaces, Channels, providers, and other features. Load only the matching references. For repository changes, current source and local user docs are the contract; use the skill's installed-package checks when reproducing a consumer problem.
+
+For package-specific contracts, read the affected package README and [user reference](docs/content/docs/reference/index.md). Do not copy those contracts into contributor instructions. Keep skill purposes separate from repository rules and from Skills loaded by product Agents.
+
+## Design and implementation
+
+Build complex things as simply as possible. Simple and obvious are not always the same. Accept internal machinery when it makes the public contract behave as a developer or Agent would expect.
+
+Normal work must not expose implementation details, framework details, or compatibility history. Put shared behavior at the ViteHub boundary that owns it. Preserve ViteHub abstractions over local convenience.
+
+Before you preserve a legacy path, search this repository and known consumers for real callers. Migrate those callers to the final contract. Delete speculative compatibility unless the task requires it.
+
+Treat a downstream workaround as evidence of a ViteHub gap unless it is product-specific.
+
+Every runtime feature must be inspectable through code or CLI. This includes generated state, bindings, discovered definitions, and provider output. A dashboard can help, but it must not be the only inspection path.
+
+Familiar interfaces such as filesystems, tools, and shells are useful. Keep their contracts honest. State durability, isolation, security, persistence, cost, and production readiness explicitly.
+
+Keep changes small. Use existing code or a suitable library before building infrastructure. Prefer inferred types that make invalid states hard to represent. Avoid cast-only wrappers. Comments should explain use or a non-obvious constraint. Measure before and after when claiming a performance improvement.
+
+ViteHub is in active development. Breaking changes and removal of unused compatibility are welcome when they clarify the final contract. Use Better Auth as a composition reference and UnJS for host-independent behavior. Document public behavior in `docs/content/docs/` and the affected package README.
+
+## Downstream patch loop
+
+Use `pnpm patch` in a consuming project to prove the smallest downstream fix:
+
+1. Patch the smallest downstream change.
+2. Verify the real consumer flow.
+3. Upstream the source fix with focused coverage.
+4. Update the consumer to the fixed version and remove the patch.
+
+The fix is complete when the consumer works without the patch. Retire combined patches one hunk at a time as their fixes land upstream.
+
+## Visual and design work
+
+- Make interface, layout, and copy changes directly. Create a mock only when I ask.
+- When T3 Code is the named reference, inspect its current source and screenshots. Do not copy it from memory.
+- Use Nuxt UI components when they fit. Match ViteHub's compact spacing and T3 Code's interaction patterns.
+- Prefer dense layouts, small icons, minimal copy, true black in dark mode, white primary text, and few borders.
+- Avoid decorative cards, pills, shadows, and subtitle rows.
+- Avoid continuously repainting animations such as pulse, shimmer, blur, and spinning loaders.
+- Check overflow, narrow widths, long tab lists, empty states, keyboard access, and panel resizing when they apply.
+- Ask before opening a browser or starting a development server unless the task already requests it.
+
+## Pull requests
+
+- Do not push changes, create a pull request, or update a pull request unless I ask.
+- Confirm the destination repository and check for an existing pull request before you open one.
+- Rebase onto the latest `main` before opening a pull request.
+- Open a real pull request, not a draft.
+- Keep one concern per pull request unless I ask to combine work.
+- Use the repository's conventional title style, for example `fix(workspace): preserve source grants`.
+- Start the body with the problem, then explain the fix in plain language. Omit commit hashes and boilerplate sections unless they help the reviewer.
+- End the body with the model and harness used.
+- Interface pull requests need before and after images. Changes to motion or timing need a short video. Upload this evidence to GitHub. Do not commit pull-request-only media.
+- When monitoring a pull request, inspect checks and comments newer than the last push. Verify bot findings against the source. Fix real issues and explain false positives. Separate code failures from infrastructure failures. Stay quiet when nothing changed. Stop when review bots and required checks are green on the latest commit.
+- Merge only when my request gives that authority.
+- Never force-push.
+
+Pull request work belongs in a dedicated worktree. Reuse an isolated task worktree, or create one from the refreshed target base. Inspect collisions and preserve other agents' work.
+
+Do not commit temporary plans, raw thread exports, or scratch files. Use `.agents/research/` only for durable, cited research that supports a project decision. Remove task-created temporary files and worktrees after their remote state is safe; never remove pre-existing work without authorization.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,12 +49,12 @@ node test/run-package-task.mjs test --packages vite-hub
 For one regression, build first, then run from the package directory so Vitest uses its package config:
 
 ```sh
-node test/run-package-task.mjs build --packages vite-hub
+corepack pnpm exec vp run -t vite-hub#build
 corepack pnpm --dir packages/vite-hub exec vp test test/console-colocated-skills.test.ts
 corepack pnpm --dir packages/vite-hub run typecheck
 ```
 
-Replace `vite-hub` with a manifest package name, such as `@vite-hub/agent`, and use the matching directory. Add the following checks only when their behavior is affected:
+Replace `vite-hub` with a manifest package name, such as `@vite-hub/agent`, and use the matching directory. Use the Vite+ target build for dependency builds; `run-package-task.mjs build --packages` builds only the selected packages. Add the following checks only when their behavior is affected:
 
 | Change | Check from the repository root |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -107,27 +107,7 @@ Libraries and focused integrations can depend on any `@vite-hub/*` owner package
 
 ## Development
 
-This repo requires Node 24.15 or newer and Deno 2.9.3. Use the [official Deno installation guide](https://docs.deno.com/runtime/getting_started/installation/) to install the pinned version. `.tool-versions` supplies that version to local checks and CI.
-
-From a clean checkout, let Corepack select pnpm 10.33.0 from `package.json` and install the workspace dependencies. This also installs Vite+.
-
-```sh
-corepack pnpm install --frozen-lockfile
-```
-
-Check the contributor tools without running tests:
-
-```sh
-corepack pnpm exec vp run preflight
-```
-
-Then run the full local gate:
-
-```sh
-corepack pnpm exec vp run verify
-```
-
-`verify` runs the preflight first and includes the native Deno package consumer test. A missing or different Deno version is a contributor setup error, not a ViteHub runtime failure. Package scripts own package-local test, build, and typecheck behavior.
+See [Contributing](CONTRIBUTING.md) for setup, package checks, and pull request guidance. [AGENTS.md](AGENTS.md) maps the code and critical boundaries.
 
 ## Project policies
 


### PR DESCRIPTION
Contributors had to infer code ownership and focused test commands from source. The root instructions mixed delivery rules, UI preferences, and design details, while the README mainly offered the full verification gate.

Reduce AGENTS.md from 161 to 51 lines with a code map, critical boundaries, and a tested package regression command. Move setup and deeper delivery guidance into CONTRIBUTING.md and link it from the README. Reuse the current ViteHub skill, package runner, and task definitions. Preserve release permissions and existing project preferences.

The pilot was production Console loading of colocated Agent Skills from #1291. The first pilot typecheck exposed missing sibling exports: the filtered package runner build does not build dependencies. The guide now uses `corepack pnpm exec vp run -t vite-hub#build`. That target build and the subsequent framework typecheck passed. The documented install also passed. Generated Console, new-chat, and invocation-history tests passed, 27 tests. Provider Workspace skill materialization, writeback exclusion, and symlink rejection passed, 2 selected tests. Contributor preflight tests passed, 3 tests. Local Markdown links resolve and git diff --check passes. Repository lint exits successfully with existing warnings.

The real preflight correctly reports missing Deno. The full verification gate, browser flow, durable restart, and live coding provider were not exercised. These instructions do not claim those checks passed. A separate CI change addresses package regressions being skipped on PRs.

Model: GPT-6. Harness: Codex.
