### PR TITLE
fix(blob): preserve configured cache policy in Nitro routes

### DIFF
--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -192,7 +192,7 @@ function renderNitroBlobMiddleware(importBase = blobPackageName): string {
 
 function renderBlobServeRouteHandler(serve: BlobServeConfig, importBase = blobPackageName): string {
   const headers = serve.headers && Object.keys(serve.headers).length > 0 ? serve.headers : undefined
-  const cacheControl = Object.entries(headers ?? {}).find(([name]) => name.toLowerCase() === "cache-control")?.[1]
+  const cacheControl = Object.entries(headers ?? {}).findLast(([name]) => name.toLowerCase() === "cache-control")?.[1]
   return [
     `import { blob } from '${importBase}'`,
     `import { createError, getRouterParam${cacheControl !== undefined ? ", handleCacheHeaders, setResponseHeader" : ""}${headers ? ", removeResponseHeader, setResponseHeaders" : ""} } from 'h3'`,

--- a/packages/blob/src/vite.ts
+++ b/packages/blob/src/vite.ts
@@ -192,9 +192,10 @@ function renderNitroBlobMiddleware(importBase = blobPackageName): string {
 
 function renderBlobServeRouteHandler(serve: BlobServeConfig, importBase = blobPackageName): string {
   const headers = serve.headers && Object.keys(serve.headers).length > 0 ? serve.headers : undefined
+  const cacheControl = Object.entries(headers ?? {}).find(([name]) => name.toLowerCase() === "cache-control")?.[1]
   return [
     `import { blob } from '${importBase}'`,
-    `import { createError, getRouterParam${headers ? ", removeResponseHeader, setResponseHeaders" : ""} } from 'h3'`,
+    `import { createError, getRouterParam${cacheControl !== undefined ? ", handleCacheHeaders, setResponseHeader" : ""}${headers ? ", removeResponseHeader, setResponseHeaders" : ""} } from 'h3'`,
     "import { defineCachedHandler } from 'nitro/cache'",
     "",
     `const storeName = ${JSON.stringify(serve.store)}`,
@@ -223,7 +224,20 @@ function renderBlobServeRouteHandler(serve: BlobServeConfig, importBase = blobPa
           "  if (error) throw error",
           "  return stream",
         ]),
-    "}, { headersOnly: true, maxAge: 0 })",
+    ...(cacheControl !== undefined
+      ? [
+          "}, {",
+          "  headersOnly: true,",
+          "  maxAge: 0,",
+          "  // Keep the configured policy after conditional request handling sets default cache headers.",
+          "  handleCacheHeaders(event, conditions) {",
+          "    const handled = handleCacheHeaders(event, conditions)",
+          `    setResponseHeader(event, 'Cache-Control', ${JSON.stringify(cacheControl)})`,
+          "    return handled",
+          "  },",
+          "})",
+        ]
+      : ["}, { headersOnly: true, maxAge: 0 })"]),
     "",
   ].join("\n")
 }

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -768,28 +768,38 @@ describe("hubBlob", () => {
     )
   })
 
-  it.each([
+  it.each<{ expectedCacheControl: string, headers: Record<string, string> | undefined, name: string }>([
     {
       expectedCacheControl: "public, max-age=0, s-maxage=0",
-      headerName: undefined,
+      headers: undefined,
       name: "default",
     },
     {
       expectedCacheControl: "private, max-age=60",
-      headerName: "Cache-Control",
+      headers: { "Cache-Control": "private, max-age=60" },
       name: "configured",
     },
     {
       expectedCacheControl: "private, max-age=60",
-      headerName: "cache-control",
+      headers: { "cache-control": "private, max-age=60" },
       name: "lowercase configured",
     },
-  ])("preserves non-text bytes with $name cache headers", async ({ expectedCacheControl, headerName }) => {
+    {
+      expectedCacheControl: "public, max-age=300",
+      headers: { "Cache-Control": "private, max-age=60", "cache-control": "public, max-age=300" },
+      name: "duplicate lowercase last",
+    },
+    {
+      expectedCacheControl: "private, max-age=60",
+      headers: { "cache-control": "public, max-age=300", "Cache-Control": "private, max-age=60" },
+      name: "duplicate canonical last",
+    },
+  ])("preserves non-text bytes with $name cache headers", async ({ expectedCacheControl, headers }) => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-blob-cached-route-"))
     try {
       const plugin = hubBlob({
         driver: "fs",
-        serve: { headers: headerName ? { [headerName]: expectedCacheControl } : undefined },
+        serve: { headers },
       }, { importBase: "virtual:blob-test" })
       await (plugin.configResolved as (config: unknown) => void | Promise<void>)({
         build: { outDir: "dist" },

--- a/packages/blob/test/vite.test.ts
+++ b/packages/blob/test/vite.test.ts
@@ -761,7 +761,8 @@ describe("hubBlob", () => {
     expect(handler).toContain("statusCode: 404")
     expect(handler).toContain("for (const name of Object.keys(responseHeaders)) removeResponseHeader(event, name)")
     expect(handler).toContain("throw error")
-    expect(handler).toContain("}, { headersOnly: true, maxAge: 0 })")
+    expect(handler).toContain("headersOnly: true")
+    expect(handler).toContain("maxAge: 0")
     expect(handler.indexOf("setResponseHeaders(event, responseHeaders)")).toBeLessThan(
       handler.indexOf("blob.store(storeName).serve(event, pathname)"),
     )
@@ -770,20 +771,25 @@ describe("hubBlob", () => {
   it.each([
     {
       expectedCacheControl: "public, max-age=0, s-maxage=0",
-      headers: undefined,
+      headerName: undefined,
       name: "default",
     },
     {
       expectedCacheControl: "private, max-age=60",
-      headers: { "Cache-Control": "private, max-age=60" },
+      headerName: "Cache-Control",
       name: "configured",
     },
-  ])("preserves non-text bytes with $name cache headers", async ({ expectedCacheControl, headers }) => {
+    {
+      expectedCacheControl: "private, max-age=60",
+      headerName: "cache-control",
+      name: "lowercase configured",
+    },
+  ])("preserves non-text bytes with $name cache headers", async ({ expectedCacheControl, headerName }) => {
     const root = await mkdtemp(join(tmpdir(), "vitehub-blob-cached-route-"))
     try {
       const plugin = hubBlob({
         driver: "fs",
-        serve: { headers },
+        serve: { headers: headerName ? { [headerName]: expectedCacheControl } : undefined },
       }, { importBase: "virtual:blob-test" })
       await (plugin.configResolved as (config: unknown) => void | Promise<void>)({
         build: { outDir: "dist" },
@@ -815,7 +821,7 @@ describe("hubBlob", () => {
                 "      serve(_event, pathname) {",
                 "        if (pathname !== 'binary.bin') throw new Error(`Unexpected pathname: ${pathname}`)",
                 "        return [null, new Response(new Uint8Array([0, 128, 255, 195, 40]), {",
-                "          headers: { 'Content-Type': 'application/octet-stream' },",
+                "          headers: { 'Content-Type': 'application/octet-stream', ETag: '\"binary-v1\"' },",
                 "        })]",
                 "      },",
                 "    }",
@@ -839,6 +845,16 @@ describe("hubBlob", () => {
       expect(response.headers.get("Cache-Control")).toBe(expectedCacheControl)
       expect(response.headers.get("Content-Type")).toBe("application/octet-stream")
       expect(new Uint8Array(await response.arrayBuffer())).toEqual(new Uint8Array([0, 128, 255, 195, 40]))
+
+      const conditionalEvent = new H3Event(new Request("http://localhost/i/binary.bin", {
+        headers: { "If-None-Match": '"binary-v1"' },
+      }))
+      conditionalEvent.context.params = { _: "binary.bin" }
+      const notModified = await toResponse(await artifact.default(conditionalEvent), conditionalEvent)
+
+      expect(notModified.status).toBe(304)
+      expect(notModified.headers.get("Cache-Control")).toBe(expectedCacheControl)
+      expect(await notModified.text()).toBe("")
     }
     finally {
       await rm(root, { force: true, recursive: true })


### PR DESCRIPTION
Generated Blob serve routes lose configured Cache-Control when Nitro applies its default cache headers. A route configured with private, max-age=60 returns public, max-age=0 instead.

Preserve the configured policy after h3 handles conditional requests. Match the header name without case sensitivity. Keep default cache behavior, binary bytes, and ETag handling intact.

Validation: reproduced the existing configured-policy test failure before the fix. All 27 Blob Vite tests passed. The three generated-route cases cover default policy, configured policy, lowercase header names, binary HTTP responses, and ETag 304 responses. Blob build/publint, typecheck, targeted oxlint, and diff check passed.

The proof runs generated code with Nitro/h3 and a stubbed storage adapter. No external storage service or live application was exercised.

Model: GPT-6. Harness: Codex.
