### PR TITLE
fix(console): keep image uploads within invocation boundaries

### DIFF
--- a/docs/content/docs/development/console.md
+++ b/docs/content/docs/development/console.md
@@ -310,3 +310,9 @@ The Console does not calculate missing provider data. Token counts, model metada
 | The page returns `403` | Check the host's `authorize` callback and the current user's role or permission. |
 
 Use [Agent Invocations](/docs/agents/invocations) for custom stores and invocation lifecycle behavior. Use [Invocation UI](/docs/ui/invocation) when building an application-owned inspection page instead of mounting the complete Console.
+
+### Image upload boundaries
+
+Console image uploads require `console.invoke` to be enabled. The Agent and invoker profile selected when you submit stay fixed while images upload. If you switch Agents, the pending request does not redirect the input or open its result in the new Agent view.
+
+Images must be PNG, JPEG, WebP, or GIF, with at most ten images and 10 MiB combined per invocation. Blob storage must return an HTTP or relative serving URL. The Console removes an upload if it cannot return a usable URL. Other uploads, including those from a failed invocation attempt, remain under `vitehub-console-attachments/` and follow your Blob storage retention policy.

--- a/docs/content/docs/development/console.md
+++ b/docs/content/docs/development/console.md
@@ -315,4 +315,4 @@ Use [Agent Invocations](/docs/agents/invocations) for custom stores and invocati
 
 Console image uploads require `console.invoke` to be enabled. The Agent and invoker profile selected when you submit stay fixed while images upload. If you switch Agents, the pending request does not redirect the input or open its result in the new Agent view.
 
-Images must be PNG, JPEG, WebP, or GIF, with at most ten images and 10 MiB combined per invocation. Blob storage must return an HTTP or relative serving URL. The Console removes an upload if it cannot return a usable URL. Other uploads, including those from a failed invocation attempt, remain under `vitehub-console-attachments/` and follow your Blob storage retention policy.
+Images must be PNG, JPEG, WebP, or GIF, with at most ten images and 10 MiB combined per invocation. Blob storage must return an HTTP or relative serving URL. The Console rolls back new uploads if storage or invocation setup fails before the Agent takes ownership. Images handed to an Agent remain under `vitehub-console-attachments/` and follow your Blob storage retention policy.

--- a/packages/vite-hub/README.md
+++ b/packages/vite-hub/README.md
@@ -144,3 +144,5 @@ Set `console.observations` to configure the fallback journal's observation count
 ## Console images
 
 The Console accepts up to ten PNG, JPEG, WebP, or GIF images per message, within a combined 10 MiB limit. Configure durable Blob storage to keep the bytes, and content-enabled Invocation storage to keep message references. Agents can return published Blob image URLs in Markdown. See [Console usage](https://vitehub.dev/docs/console/usage).
+
+Console image uploads require invocation to be enabled. The Console fixes the Agent, route, and invoker profile when submission starts, so switching Agents during an upload cannot redirect the input. Uploads without a usable Blob serving URL are removed before the request fails.

--- a/packages/vite-hub/src/console/runtime/client/invocation.ts
+++ b/packages/vite-hub/src/console/runtime/client/invocation.ts
@@ -1,0 +1,36 @@
+import * as v from "valibot"
+
+import { requestConsole } from "./request.ts"
+import { viteHubErrorDiagnostics } from "../../../error-diagnostics.ts"
+
+import type { FileUIPart } from "ai"
+import type { ConsoleAgentInvocationInput } from "../rpc.ts"
+
+interface ConsoleInvocationTarget {
+  agent: string
+  base: string
+  invokerProfileId?: string
+}
+const invocationResultSchema = v.object({ id: v.pipe(v.string(), v.nonEmpty()) })
+
+/** Capture the destination before uploads so switching Agents cannot redirect the input. */
+export async function startConsoleAgentInvocation(
+  { agent, base, invokerProfileId }: ConsoleInvocationTarget,
+  message: { text: string, files?: readonly FileUIPart[] },
+): Promise<{ agent: string, id: string }> {
+  const body: ConsoleAgentInvocationInput = { prompt: message.text }
+  if (invokerProfileId) body.invokerProfileId = invokerProfileId
+  const files = [...message.files ?? []]
+  if (files.length > 10) throw new Error("Use at most ten images.")
+  if (files.length) {
+    body.attachments = []
+    for (const file of files) {
+      const uploaded = await requestConsole(`${base.replace(/\/agents$/, "")}/attachments`, { method: "POST", body: file })
+      body.attachments.push({ id: v.parse(invocationResultSchema, uploaded).id, name: file.filename?.slice(0, 255) || "image" })
+    }
+  }
+  const response = await requestConsole(`${base}/${encodeURIComponent(agent)}/invocations`, { body, method: "POST" })
+  const result = v.safeParse(invocationResultSchema, response)
+  if (!result.success) throw viteHubErrorDiagnostics.VITE_HUB_R0102({ message: "The Agent invocation response did not include an id." })
+  return { agent, id: result.output.id }
+}

--- a/packages/vite-hub/src/console/runtime/client/invocation.ts
+++ b/packages/vite-hub/src/console/runtime/client/invocation.ts
@@ -1,4 +1,5 @@
 import * as v from "valibot"
+import { watch } from "vue"
 
 import { requestConsole } from "./request.ts"
 import { viteHubErrorDiagnostics } from "../../../error-diagnostics.ts"
@@ -13,6 +14,19 @@ interface ConsoleInvocationTarget {
 }
 const invocationResultSchema = v.object({ id: v.pipe(v.string(), v.nonEmpty()) })
 
+/** Each selection change invalidates pending results, even when returning to the same Agent. */
+export function useConsoleInvocationTarget(target: () => ConsoleInvocationTarget): () => { target: ConsoleInvocationTarget, isCurrent: () => boolean } {
+  let generation = 0
+  watch(() => {
+    const { agent, base, invokerProfileId } = target()
+    return [agent, base, invokerProfileId]
+  }, () => { generation++ }, { flush: "sync" })
+  return () => {
+    const captured = generation
+    return { target: { ...target() }, isCurrent: () => generation === captured }
+  }
+}
+
 /** Capture the destination before uploads so switching Agents cannot redirect the input. */
 export async function startConsoleAgentInvocation(
   { agent, base, invokerProfileId }: ConsoleInvocationTarget,
@@ -23,11 +37,7 @@ export async function startConsoleAgentInvocation(
   const files = [...message.files ?? []]
   if (files.length > 10) throw new Error("Use at most ten images.")
   if (files.length) {
-    body.attachments = []
-    for (const file of files) {
-      const uploaded = await requestConsole(`${base.replace(/\/agents$/, "")}/attachments`, { method: "POST", body: file })
-      body.attachments.push({ id: v.parse(invocationResultSchema, uploaded).id, name: file.filename?.slice(0, 255) || "image" })
-    }
+    body.files = files.map(file => ({ url: file.url, filename: file.filename?.slice(0, 255) || "image" }))
   }
   const response = await requestConsole(`${base}/${encodeURIComponent(agent)}/invocations`, { body, method: "POST" })
   const result = v.safeParse(invocationResultSchema, response)

--- a/packages/vite-hub/src/console/runtime/components/console-invocation-composer.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-invocation-composer.vue
@@ -1,19 +1,14 @@
 <script setup lang="ts">
 import { AgentChatPrompt } from "@vite-hub/ui";
-import * as v from "valibot";
 import type { FileUIPart } from "ai";
 import { computed, ref, watch } from "vue";
 
-import { requestConsole } from "../client/request";
-import type { ConsoleAgentInvocationInput } from "../rpc";
-import { viteHubErrorDiagnostics } from "../../../error-diagnostics";
+import { startConsoleAgentInvocation } from "../client/invocation";
 
 interface ConsoleAgentProfile {
   id: string;
   label?: string;
 }
-
-const invocationResultSchema = v.object({ id: v.string() });
 
 const props = defineProps<{
   agent: string;
@@ -51,37 +46,27 @@ function errorMessage(value: unknown): string {
 function filterFiles(selected: readonly File[]): readonly File[] {
   const accepted = selected.filter(file => ["image/png", "image/jpeg", "image/webp", "image/gif"].includes(file.type));
   if (accepted.length !== selected.length) error.value = new Error("Use a PNG, JPEG, WebP, or GIF image. Other files are not supported by this Console input yet.");
-  return accepted;
+  if (accepted.some(file => file.size > 10 * 1024 * 1024)) {
+    error.value = new Error("Images must be at most 10 MiB.");
+  }
+  return accepted.filter(file => file.size <= 10 * 1024 * 1024);
 }
 
 async function submit(message: { text: string; files?: readonly FileUIPart[] }): Promise<void> {
   if (loading.value || (!message.text.trim() && !message.files?.length)) return;
   loading.value = true;
   error.value = undefined;
+  const agent = props.agent;
+  const base = props.base;
   try {
-    const body: ConsoleAgentInvocationInput = {
-      prompt: message.text,
-    };
-    if (message.files?.length) {
-      body.files = message.files.map(({ url, filename }) => ({ url, filename }));
+    const started = await startConsoleAgentInvocation({ agent, base, invokerProfileId: selectedProfileId.value }, message);
+    if (props.agent === agent && props.base === base) {
+      draft.value = "";
+      files.value = [];
+      emit("started", started);
     }
-    if (selectedProfileId.value) body.invokerProfileId = selectedProfileId.value;
-    const response = await requestConsole(
-      `${props.base}/${encodeURIComponent(props.agent)}/invocations`,
-      {
-        body,
-        method: "POST",
-      },
-    );
-    const result = v.safeParse(invocationResultSchema, response);
-    if (!result.success || !result.output.id) {
-      throw viteHubErrorDiagnostics.VITE_HUB_R0102({ message: "The Agent invocation response did not include an id." });
-    }
-    draft.value = "";
-    files.value = [];
-    emit("started", { agent: props.agent, id: result.output.id });
   } catch (value) {
-    error.value = value;
+    if (props.agent === agent && props.base === base) error.value = value;
   } finally {
     loading.value = false;
   }
@@ -140,13 +125,13 @@ async function submit(message: { text: string; files?: readonly FileUIPart[] }):
             }"
             @submit="submit"
           >
-            <template #submit>
+            <template #submit="{ canSubmit }">
               <UButton
                 aria-label="Start Agent"
                 class="console-invocation-composer__submit size-8 rounded-full active:scale-[0.97]"
                 color="primary"
                 icon="i-ph-arrow-up-light"
-                :disabled="(!draft.trim() && !files.length) || loading"
+                :disabled="!canSubmit"
                 :loading="loading"
                 square
                 size="sm"

--- a/packages/vite-hub/src/console/runtime/components/console-invocation-composer.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-invocation-composer.vue
@@ -3,7 +3,7 @@ import { AgentChatPrompt } from "@vite-hub/ui";
 import type { FileUIPart } from "ai";
 import { computed, ref, watch } from "vue";
 
-import { startConsoleAgentInvocation } from "../client/invocation";
+import { startConsoleAgentInvocation, useConsoleInvocationTarget } from "../client/invocation";
 
 interface ConsoleAgentProfile {
   id: string;
@@ -25,6 +25,11 @@ const files = ref<FileUIPart[]>([]);
 const error = ref<unknown>();
 const loading = ref(false);
 const selectedProfileId = ref<string>();
+const captureTarget = useConsoleInvocationTarget(() => ({
+  agent: props.agent,
+  base: props.base,
+  invokerProfileId: selectedProfileId.value,
+}));
 const profileItems = computed(() =>
   props.profiles.map((profile) => ({ label: profile.label || profile.id, value: profile.id })),
 );
@@ -56,17 +61,16 @@ async function submit(message: { text: string; files?: readonly FileUIPart[] }):
   if (loading.value || (!message.text.trim() && !message.files?.length)) return;
   loading.value = true;
   error.value = undefined;
-  const agent = props.agent;
-  const base = props.base;
+  const { target, isCurrent } = captureTarget();
   try {
-    const started = await startConsoleAgentInvocation({ agent, base, invokerProfileId: selectedProfileId.value }, message);
-    if (props.agent === agent && props.base === base) {
+    const started = await startConsoleAgentInvocation(target, message);
+    if (isCurrent()) {
       draft.value = "";
       files.value = [];
       emit("started", started);
     }
   } catch (value) {
-    if (props.agent === agent && props.base === base) error.value = value;
+    if (isCurrent()) error.value = value;
   } finally {
     loading.value = false;
   }

--- a/packages/vite-hub/src/console/runtime/server/attachments.ts
+++ b/packages/vite-hub/src/console/runtime/server/attachments.ts
@@ -1,84 +1,56 @@
 import * as v from "valibot"
 import { createMessage } from "@vite-hub/agent"
+import { getConsoleAgentDefinition, getConsoleAgents } from "./agents.ts"
 import { getConsoleBlob } from "./blob.ts"
-import { isConsoleAttachmentPendingCleanup, consoleAttachmentPrefix as prefix, retryConsoleAttachmentCleanup, rollbackConsoleAttachments } from "./attachment-cleanup.ts"
+import { assertConsoleRequest, consoleRequestJSON } from "./request.ts"
 import type { ImagePart } from "@vite-hub/agent"
+import type { ConsoleRequestEvent } from "./request.ts"
 
-const uploadSchema = v.object({ files: v.pipe(v.array(v.object({ url: v.string(), filename: v.optional(v.string(), "image") })), v.minLength(1), v.maxLength(10)) })
+const uploadSchema = v.object({ url: v.string(), filename: v.optional(v.string(), "image") })
 const attachmentIdsSchema = v.pipe(v.array(v.object({ id: v.pipe(v.string(), v.uuid()), name: v.pipe(v.string(), v.maxLength(255)) })), v.maxLength(10))
 
+const prefix = "vitehub-console-attachments/"
 const maximumBytes = 10 * 1024 * 1024
-export const consoleAttachmentRequestBytes = Math.ceil(maximumBytes * 4 / 3) + 40960
 const imageTypes = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"])
 
 function error(statusCode: number, message: string): Error {
   return Object.assign(new Error(message), { statusCode, statusMessage: message })
 }
 
-/** Roll back new objects if input reconstruction fails before the Agent owns them. */
-export async function storeConsoleInputMessage(prompt: string, body: unknown): Promise<ReturnType<typeof createMessage>> {
-  return withStoredConsoleAttachments(body, attachments => inputMessage(prompt, attachments, new Set(attachments.map(part => part.id))))
-}
-
-/** Keep rollback available until the Agent signals runtime handoff. */
-export async function withConsoleInputMessage<T>(prompt: string, body: unknown, consume: (message: ReturnType<typeof createMessage>, handoff: () => void) => Promise<T>): Promise<T> {
-  return withStoredConsoleAttachments(body, async (attachments, handoff) => consume(await inputMessage(prompt, attachments, new Set(attachments.map(part => part.id))), handoff))
-}
-
-async function withStoredConsoleAttachments<T>(body: unknown, consume: (attachments: ImagePart[], handoff: () => void) => Promise<T>): Promise<T> {
+/** Store bytes before starting an invocation. Only durable references enter its journal. */
+export async function consoleAttachmentUpload(event: ConsoleRequestEvent): Promise<ImagePart> {
+  assertConsoleRequest(event, ["POST"])
+  if (!getConsoleAgents().some(name => getConsoleAgentDefinition(name))) throw error(404, "Agent invocation is not available.")
+  const body = await consoleRequestJSON(event, Math.ceil(maximumBytes * 4 / 3) + 4096)
   const parsed = v.safeParse(uploadSchema, body)
-  if (!parsed.success) throw error(400, "Provide between 1 and 10 image data URLs.")
-  let totalBytes = 0
-  const files = parsed.output.files.map(file => {
-    const match = /^data:(image\/(?:png|jpeg|webp|gif));base64,([A-Za-z0-9+/]*={0,2})$/.exec(file.url)
-    if (!match || !imageTypes.has(match[1]!)) throw error(415, "Use a PNG, JPEG, WebP, or GIF image.")
-    const bytes = Buffer.from(match[2]!, "base64")
-    totalBytes += bytes.length
-    if (!bytes.length || totalBytes > maximumBytes) throw error(413, "Images must be non-empty and total at most 10 MiB.")
-    return { bytes, mediaType: match[1]!, name: file.filename.slice(0, 255) }
-  })
+  if (!parsed.success) throw error(400, "An image data URL is required.")
+  const match = /^data:(image\/(?:png|jpeg|webp|gif));base64,([A-Za-z0-9+/]*={0,2})$/.exec(parsed.output.url)
+  if (!match || !imageTypes.has(match[1]!)) throw error(415, "Use a PNG, JPEG, WebP, or GIF image.")
+  const bytes = Buffer.from(match[2]!, "base64")
+  if (!bytes.length || bytes.length > maximumBytes) throw error(413, "Images must be between 1 byte and 10 MiB.")
+  if (bytes.toString("base64") !== match[2]) throw error(400, "The image data is not valid base64.")
+  const id = crypto.randomUUID()
+  const name = parsed.output.filename.slice(0, 255)
   let storage: ReturnType<typeof getConsoleBlob>["storage"]
   try { storage = getConsoleBlob().storage }
   catch { throw error(503, "Configure ViteHub Blob storage to send and retain Console attachments.") }
-  await retryConsoleAttachmentCleanup(storage)
-  const paths: string[] = []
-  const attachments: ImagePart[] = []
-  let handedOff = false
-  try {
-    for (const file of files) {
-      const id = crypto.randomUUID()
-      const path = `${prefix}${id}`
-      // Include the attempted write: providers may store bytes before reporting an error.
-      paths.push(path)
-      const [failure, stored] = await storage.put(path, file.bytes, { contentType: file.mediaType })
-      if (failure) throw failure
-      if (!stored.url) throw error(503, "Configure Blob serving so Console attachments can be opened after reload.")
-      attachments.push({ id, mediaType: file.mediaType, name: file.name, size: file.bytes.length, type: "image", url: stored.url })
-    }
-    return await consume(attachments, () => { handedOff = true })
+  const [failure, stored] = await storage.put(`${prefix}${id}`, bytes, { contentType: match[1] })
+  if (failure) throw failure
+  if (!stored.url || !/^(https?:\/\/|\/(?!\/))/.test(stored.url)) {
+    const [cleanupError] = await storage.del(`${prefix}${id}`)
+    if (cleanupError) throw cleanupError
+    throw error(503, "Configure Blob serving so Console attachments can be opened after reload.")
   }
-  catch (failure) {
-    if (handedOff) throw failure
-    const cleanupErrors = await rollbackConsoleAttachments(storage, paths)
-    if (cleanupErrors.length) throw new AggregateError([failure, ...cleanupErrors], "Attachment upload failed and some uploaded objects could not be removed.")
-    throw failure
-  }
+  return { id, mediaType: match[1]!, name, size: bytes.length, type: "image", url: stored.url }
 }
 
 export async function consoleInputMessage(prompt: string, attachments: unknown): Promise<ReturnType<typeof createMessage>> {
-  return inputMessage(prompt, attachments)
-}
-
-// Only IDs generated and stored by this request can bypass historical ownership
-// checks. Caller-supplied references always go through consoleInputMessage.
-async function inputMessage(prompt: string, attachments: unknown, fresh = new Set<string | undefined>()): Promise<ReturnType<typeof createMessage>> {
   const parsed = v.safeParse(attachmentIdsSchema, attachments)
   if (!parsed.success) throw error(400, "Invalid attachment ID.")
   let totalBytes = 0
   const parts: ImagePart[] = []
   for (const { id, name } of new Map(parsed.output.map(part => [part.id, part])).values()) {
     const storage = getConsoleBlob().storage
-    if (!fresh.has(id) && await isConsoleAttachmentPendingCleanup(storage, id)) throw error(404, "The stored image is pending deletion.")
     const [headError, metadata] = await storage.head(`${prefix}${id}`)
     if (headError) throw headError
     if (!metadata || !metadata.contentType || !imageTypes.has(metadata.contentType)) throw error(404, "The stored image is unavailable.")

--- a/packages/vite-hub/src/console/runtime/server/attachments.ts
+++ b/packages/vite-hub/src/console/runtime/server/attachments.ts
@@ -1,56 +1,85 @@
 import * as v from "valibot"
 import { createMessage } from "@vite-hub/agent"
-import { getConsoleAgentDefinition, getConsoleAgents } from "./agents.ts"
 import { getConsoleBlob } from "./blob.ts"
-import { assertConsoleRequest, consoleRequestJSON } from "./request.ts"
+import { isConsoleAttachmentPendingCleanup, consoleAttachmentPrefix as prefix, retryConsoleAttachmentCleanup, rollbackConsoleAttachments } from "./attachment-cleanup.ts"
 import type { ImagePart } from "@vite-hub/agent"
-import type { ConsoleRequestEvent } from "./request.ts"
 
-const uploadSchema = v.object({ url: v.string(), filename: v.optional(v.string(), "image") })
+const uploadSchema = v.object({ files: v.pipe(v.array(v.object({ url: v.string(), filename: v.optional(v.string(), "image") })), v.minLength(1), v.maxLength(10)) })
 const attachmentIdsSchema = v.pipe(v.array(v.object({ id: v.pipe(v.string(), v.uuid()), name: v.pipe(v.string(), v.maxLength(255)) })), v.maxLength(10))
 
-const prefix = "vitehub-console-attachments/"
 const maximumBytes = 10 * 1024 * 1024
+export const consoleAttachmentRequestBytes = Math.ceil(maximumBytes * 4 / 3) + 40960
 const imageTypes = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"])
 
 function error(statusCode: number, message: string): Error {
   return Object.assign(new Error(message), { statusCode, statusMessage: message })
 }
 
-/** Store bytes before starting an invocation. Only durable references enter its journal. */
-export async function consoleAttachmentUpload(event: ConsoleRequestEvent): Promise<ImagePart> {
-  assertConsoleRequest(event, ["POST"])
-  if (!getConsoleAgents().some(name => getConsoleAgentDefinition(name))) throw error(404, "Agent invocation is not available.")
-  const body = await consoleRequestJSON(event, Math.ceil(maximumBytes * 4 / 3) + 4096)
+/** Roll back new objects if input reconstruction fails before the Agent owns them. */
+export async function storeConsoleInputMessage(prompt: string, body: unknown): Promise<ReturnType<typeof createMessage>> {
+  return withStoredConsoleAttachments(body, attachments => inputMessage(prompt, attachments, new Set(attachments.map(part => part.id))))
+}
+
+/** Keep rollback available until the Agent signals runtime handoff. */
+export async function withConsoleInputMessage<T>(prompt: string, body: unknown, consume: (message: ReturnType<typeof createMessage>, handoff: () => void) => Promise<T>): Promise<T> {
+  return withStoredConsoleAttachments(body, async (attachments, handoff) => consume(await inputMessage(prompt, attachments, new Set(attachments.map(part => part.id))), handoff))
+}
+
+async function withStoredConsoleAttachments<T>(body: unknown, consume: (attachments: ImagePart[], handoff: () => void) => Promise<T>): Promise<T> {
   const parsed = v.safeParse(uploadSchema, body)
-  if (!parsed.success) throw error(400, "An image data URL is required.")
-  const match = /^data:(image\/(?:png|jpeg|webp|gif));base64,([A-Za-z0-9+/]*={0,2})$/.exec(parsed.output.url)
-  if (!match || !imageTypes.has(match[1]!)) throw error(415, "Use a PNG, JPEG, WebP, or GIF image.")
-  const bytes = Buffer.from(match[2]!, "base64")
-  if (!bytes.length || bytes.length > maximumBytes) throw error(413, "Images must be between 1 byte and 10 MiB.")
-  if (bytes.toString("base64") !== match[2]) throw error(400, "The image data is not valid base64.")
-  const id = crypto.randomUUID()
-  const name = parsed.output.filename.slice(0, 255)
+  if (!parsed.success) throw error(400, "Provide between 1 and 10 image data URLs.")
+  let totalBytes = 0
+  const files = parsed.output.files.map(file => {
+    const match = /^data:(image\/(?:png|jpeg|webp|gif));base64,([A-Za-z0-9+/]*={0,2})$/.exec(file.url)
+    if (!match || !imageTypes.has(match[1]!)) throw error(415, "Use a PNG, JPEG, WebP, or GIF image.")
+    const bytes = Buffer.from(match[2]!, "base64")
+    if (bytes.toString("base64") !== match[2]) throw error(400, "The image data is not valid base64.")
+    totalBytes += bytes.length
+    if (!bytes.length || totalBytes > maximumBytes) throw error(413, "Images must be non-empty and total at most 10 MiB.")
+    return { bytes, mediaType: match[1]!, name: file.filename.slice(0, 255) }
+  })
   let storage: ReturnType<typeof getConsoleBlob>["storage"]
   try { storage = getConsoleBlob().storage }
   catch { throw error(503, "Configure ViteHub Blob storage to send and retain Console attachments.") }
-  const [failure, stored] = await storage.put(`${prefix}${id}`, bytes, { contentType: match[1] })
-  if (failure) throw failure
-  if (!stored.url || !/^(https?:\/\/|\/(?!\/))/.test(stored.url)) {
-    const [cleanupError] = await storage.del(`${prefix}${id}`)
-    if (cleanupError) throw cleanupError
-    throw error(503, "Configure Blob serving so Console attachments can be opened after reload.")
+  await retryConsoleAttachmentCleanup(storage)
+  const paths: string[] = []
+  const attachments: ImagePart[] = []
+  let handedOff = false
+  try {
+    for (const file of files) {
+      const id = crypto.randomUUID()
+      const path = `${prefix}${id}`
+      // Include the attempted write: providers may store bytes before reporting an error.
+      paths.push(path)
+      const [failure, stored] = await storage.put(path, file.bytes, { contentType: file.mediaType })
+      if (failure) throw failure
+      if (!stored.url || !/^(https?:\/\/|\/(?!\/))/.test(stored.url)) throw error(503, "Configure Blob serving so Console attachments can be opened after reload.")
+      attachments.push({ id, mediaType: file.mediaType, name: file.name, size: file.bytes.length, type: "image", url: stored.url })
+    }
+    return await consume(attachments, () => { handedOff = true })
   }
-  return { id, mediaType: match[1]!, name, size: bytes.length, type: "image", url: stored.url }
+  catch (failure) {
+    if (handedOff) throw failure
+    const cleanupErrors = await rollbackConsoleAttachments(storage, paths)
+    if (cleanupErrors.length) throw new AggregateError([failure, ...cleanupErrors], "Attachment upload failed and some uploaded objects could not be removed.")
+    throw failure
+  }
 }
 
 export async function consoleInputMessage(prompt: string, attachments: unknown): Promise<ReturnType<typeof createMessage>> {
+  return inputMessage(prompt, attachments)
+}
+
+// Only IDs generated and stored by this request can bypass historical ownership
+// checks. Caller-supplied references always go through consoleInputMessage.
+async function inputMessage(prompt: string, attachments: unknown, fresh = new Set<string | undefined>()): Promise<ReturnType<typeof createMessage>> {
   const parsed = v.safeParse(attachmentIdsSchema, attachments)
   if (!parsed.success) throw error(400, "Invalid attachment ID.")
   let totalBytes = 0
   const parts: ImagePart[] = []
   for (const { id, name } of new Map(parsed.output.map(part => [part.id, part])).values()) {
     const storage = getConsoleBlob().storage
+    if (!fresh.has(id) && await isConsoleAttachmentPendingCleanup(storage, id)) throw error(404, "The stored image is pending deletion.")
     const [headError, metadata] = await storage.head(`${prefix}${id}`)
     if (headError) throw headError
     if (!metadata || !metadata.contentType || !imageTypes.has(metadata.contentType)) throw error(404, "The stored image is unavailable.")

--- a/packages/vite-hub/test/console-attachments.test.ts
+++ b/packages/vite-hub/test/console-attachments.test.ts
@@ -1,22 +1,28 @@
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterEach, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, expect, it, vi } from "vitest"
 import { blob } from "../../blob/src/runtime/storage.ts"
-import { blobError } from "../../blob/src/errors.ts"
 import { setBlobRuntimeConfig, setBlobRuntimeStorage } from "../../blob/src/runtime/state.ts"
 import { installConsoleBlob } from "../src/console/runtime/server/blob.ts"
-import { consoleInputMessage, storeConsoleInputMessage, withConsoleInputMessage } from "../src/console/runtime/server/attachments.ts"
+import { consoleAttachmentUpload, consoleInputMessage } from "../src/console/runtime/server/attachments.ts"
+
+import { defineAgent } from "@vite-hub/agent"
+import { createMemoryAgentInvocationStore, defineAgentInvocations } from "@vite-hub/agent/server"
+import { installConsoleAgentDefinitions } from "../src/console/runtime/server/agents.ts"
+
+const root = "/console-attachment-permissions-test"
+function installInvocationAccess(invoke: boolean) {
+  const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
+  const definition = defineAgent({ name: "images", invocations, runtime: false, driver: { run: () => "Done" } })
+  installConsoleAgentDefinitions([{ definition, fallbackName: "images" }], { projectRoot: root, invoke })
+}
+beforeEach(() => installInvocationAccess(true))
 
 const dirs: string[] = []
-afterEach(async () => {
-  setBlobRuntimeStorage(undefined)
-  setBlobRuntimeConfig(undefined)
-  for (const dir of dirs.splice(0)) await rm(dir, { recursive: true, force: true })
-})
+afterEach(async () => { vi.restoreAllMocks(); setBlobRuntimeStorage(undefined); for (const dir of dirs.splice(0)) await rm(dir, { recursive: true, force: true }) })
 const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jD1sAAAAASUVORK5CYII="
-const uploadBatch = async (files: Array<{ url: string, filename?: string }>) => (await storeConsoleInputMessage("", { files })).parts.filter(part => part.type === "image")
-const upload = async (url: string) => (await uploadBatch([{ url, filename: "test.png" }]))[0]!
+const upload = (url: string) => consoleAttachmentUpload({ method: "POST", req: { json: async () => ({ url, filename: "test.png" }) } })
 
 it("retains image bytes and metadata across storage restart without embedding bytes in the message", async () => {
   const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
@@ -50,181 +56,35 @@ it("rejects remote URLs, unsupported files, missing images, and path traversal",
   await expect(consoleInputMessage("", [{ id: "../../secret", name: "secret" }])).rejects.toMatchObject({ statusCode: 400 })
 })
 
-it("removes a rejected upload when Blob serving is not configured", async () => {
-  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
-  setBlobRuntimeConfig({ store: { driver: "fs", base } })
-  installConsoleBlob(base, blob)
-
-  await expect(upload(`data:image/png;base64,${png}`)).rejects.toMatchObject({ statusCode: 503 })
-  const [failure, result] = await blob.list({ prefix: "vitehub-console-attachments/" })
-  expect(failure).toBeNull()
-  expect(result?.blobs).toEqual([])
-})
-
-it("surfaces a rejected upload's cleanup failure", async () => {
-  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
-  setBlobRuntimeConfig({ store: { driver: "fs", base } })
-  const cleanupError = blobError("BLOB_OPERATION_FAILED", "del", "default")
-  installConsoleBlob(base, {
-    ...blob,
-    async del() { return [cleanupError, undefined] },
-  })
-
-  await expect(upload(`data:image/png;base64,${png}`)).rejects.toMatchObject({ errors: [expect.objectContaining({ statusCode: 503 }), cleanupError] })
-  const [, pending] = await blob.list({ prefix: "vitehub-console-attachments/" })
-  const id = pending!.blobs[0]!.pathname.split("/")[1]!
-  await expect(consoleInputMessage("retry", [{ id, name: "image" }])).rejects.toMatchObject({ statusCode: 404, message: "The stored image is pending deletion." })
-})
-
 it.each([null, [], "image", {}, { url: 123 }])("rejects malformed upload bodies: %j", async (body) => {
-  await expect(storeConsoleInputMessage("", body))
-    .rejects.toMatchObject({ statusCode: 400, message: "Provide between 1 and 10 image data URLs." })
+  await expect(consoleAttachmentUpload({ method: "POST", req: { json: async () => body } }))
+    .rejects.toMatchObject({ statusCode: 400, message: "An image data URL is required." })
 })
 
 it.each([[123], [null], [{}], ["../../secret"]])("rejects invalid attachment IDs: %j", async (id) => {
   await expect(consoleInputMessage("", [id])).rejects.toMatchObject({ statusCode: 400, message: "Invalid attachment ID." })
 })
 
-it("validates all files and the combined budget before writing any objects", async () => {
-  const put = vi.fn(blob.put)
-  installConsoleBlob("/batch-validation", { ...blob, put })
-  const file = { url: `data:image/png;base64,${png}` }
-  await expect(uploadBatch([file, { url: "data:text/html;base64,PHNjcmlwdD4=" }])).rejects.toMatchObject({ statusCode: 415 })
-  await expect(uploadBatch(Array.from({ length: 11 }, () => file))).rejects.toMatchObject({ statusCode: 400 })
-  await expect(uploadBatch([])).rejects.toMatchObject({ statusCode: 400 })
-  const large = { url: `data:image/png;base64,${Buffer.alloc(6 * 1024 * 1024).toString("base64")}` }
-  await expect(uploadBatch([large, large])).rejects.toMatchObject({ statusCode: 413 })
+
+it("disables uploads when Console invocation is disabled", async () => {
+  installInvocationAccess(false)
+  const put = vi.spyOn(blob, "put")
+  await expect(upload(`data:image/png;base64,${png}`)).rejects.toMatchObject({ statusCode: 404 })
   expect(put).not.toHaveBeenCalled()
 })
 
-it("rolls back a partially written batch without deleting an earlier successful upload", async () => {
-  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
-  setBlobRuntimeConfig({ store: { driver: "fs", base }, serve: { route: "/files/", store: "default", publicBaseUrl: "https://example.test" } })
+it("rejects malformed base64 before storing an image", async () => {
+  const put = vi.spyOn(blob, "put")
+  await expect(upload("data:image/png;base64,YQ")).rejects.toMatchObject({ statusCode: 400 })
+  expect(put).not.toHaveBeenCalled()
+})
+
+it("removes uploads that cannot produce a usable serving URL", async () => {
+  const base = await mkdtemp(join(tmpdir(), "console-upload-cleanup-")); dirs.push(base)
+  setBlobRuntimeConfig({ store: { driver: "fs", base } })
   installConsoleBlob(base, blob)
-  const retained = await upload(`data:image/png;base64,${png}`)
-  const failure = blobError("BLOB_OPERATION_FAILED", "put", "default")
-  let writes = 0
-  installConsoleBlob(base, {
-    ...blob,
-    async put(path, bytes, options) {
-      const result = await blob.put(path, bytes, options)
-      // Simulate a provider error after the second object's bytes were written.
-      if (++writes === 2) return [failure, undefined]
-      return result
-    },
-  })
-  await expect(uploadBatch([{ url: `data:image/png;base64,${png}` }, { url: `data:image/png;base64,${png}` }])).rejects.toBe(failure)
-  const [listError, result] = await blob.list({ prefix: "vitehub-console-attachments/" })
-  expect(listError).toBeNull()
-  expect(result?.blobs.map(item => item.pathname)).toEqual([`vitehub-console-attachments/${retained.id}`])
-})
-
-it("attempts every rollback even when one deletion fails", async () => {
-  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
-  setBlobRuntimeConfig({ store: { driver: "fs", base }, serve: { route: "/files/", store: "default", publicBaseUrl: "https://example.test" } })
-  const failure = new Error("Upload interrupted")
-  const cleanupError = blobError("BLOB_OPERATION_FAILED", "del", "default")
-  let writes = 0
-  let deletions = 0
-  const del = vi.fn(async (path: string | string[]) => {
-    if (++deletions === 1) throw cleanupError
-    return blob.del(path)
-  })
-  installConsoleBlob(base, {
-    ...blob,
-    del,
-    async put(path, bytes, options) {
-      if (++writes === 2) throw failure
-      return blob.put(path, bytes, options)
-    },
-  })
-  await expect(uploadBatch([{ url: `data:image/png;base64,${png}` }, { url: `data:image/png;base64,${png}` }])).rejects.toMatchObject({ errors: [failure, cleanupError] })
-  expect(del.mock.calls.filter(([path]) => typeof path === "string" && path.startsWith("vitehub-console-attachments/"))).toHaveLength(2)
-})
-
-it("returns durable references for every file in a successful batch", async () => {
-  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
-  setBlobRuntimeConfig({ store: { driver: "fs", base }, serve: { route: "/files/", store: "default", publicBaseUrl: "https://example.test" } })
-  installConsoleBlob(base, blob)
-  const parts = await uploadBatch([
-    { url: `data:image/png;base64,${png}`, filename: "first.png" },
-    { url: `data:image/png;base64,${png}`, filename: "second.png" },
-  ])
-  expect(parts.map(part => part.name)).toEqual(["first.png", "second.png"])
-  expect(new Set(parts.map(part => part.id)).size).toBe(2)
-  setBlobRuntimeStorage(undefined)
-  const message = await consoleInputMessage("both images", parts)
-  expect(message.parts.map(part => part.type)).toEqual(["text", "image", "image"])
-  for (const part of message.parts) {
-    if (part.type === "image") expect(await part.fetchData!()).toBeInstanceOf(Blob)
-  }
-})
-
-it.each([false, true])("rolls back a new input batch when reconstruction fails, cleanup failure: %s", async (failCleanup) => {
-  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
-  setBlobRuntimeConfig({ store: { driver: "fs", base }, serve: { route: "/files/", store: "default", publicBaseUrl: "https://example.test" } })
-  installConsoleBlob(base, blob)
-  const retained = await upload(`data:image/png;base64,${png}`)
-  const failure = blobError("BLOB_OPERATION_FAILED", "head", "default")
-  const cleanupError = blobError("BLOB_OPERATION_FAILED", "del", "default")
-  let reads = 0
-  let deletions = 0
-  installConsoleBlob(base, {
-    ...blob,
-    async head(path) {
-      if (++reads === 2) return [failure, undefined]
-      return blob.head(path)
-    },
-    async del(path) {
-      if (typeof path === "string" && path.startsWith("vitehub-console-attachments/") && ++deletions === 1 && failCleanup) return [cleanupError, undefined]
-      return blob.del(path)
-    },
-  })
-  const input = storeConsoleInputMessage("test", { files: [
-    { url: `data:image/png;base64,${png}` },
-    { url: `data:image/png;base64,${png}` },
-  ] })
-  if (failCleanup) await expect(input).rejects.toMatchObject({ errors: [failure, cleanupError] })
-  else await expect(input).rejects.toBe(failure)
-  expect(deletions).toBe(2)
-  const [listError, result] = await blob.list({ prefix: "vitehub-console-attachments/" })
-  expect(listError).toBeNull()
-  expect(result?.blobs).toHaveLength(failCleanup ? 2 : 1)
-  expect(result?.blobs.map(item => item.pathname)).toContain(`vitehub-console-attachments/${retained.id}`)
-})
-
-it.each([false, true])("only rolls back startup failures before runtime handoff: %s", async (handedOff) => {
-  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
-  setBlobRuntimeConfig({ store: { driver: "fs", base }, serve: { route: "/files/", store: "default", publicBaseUrl: "https://example.test" } })
-  installConsoleBlob(base, blob)
-  const retained = await upload(`data:image/png;base64,${png}`)
-  const failure = new Error("Agent startup failed")
-  await expect(withConsoleInputMessage("test", { files: [{ url: `data:image/png;base64,${png}` }] }, async (_message, handoff) => {
-    if (handedOff) handoff()
-    throw failure
-  })).rejects.toBe(failure)
-  const [listError, result] = await blob.list({ prefix: "vitehub-console-attachments/" })
-  expect(listError).toBeNull()
-  expect(result?.blobs).toHaveLength(handedOff ? 2 : 1)
-  expect(result?.blobs.map(item => item.pathname)).toContain(`vitehub-console-attachments/${retained.id}`)
-})
-
-
-it("accepts fresh images after quarantining corruption across restart but rejects stored reuse", async () => {
-  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
-  const connect = () => {
-    setBlobRuntimeStorage(undefined)
-    setBlobRuntimeConfig({ store: { driver: "fs", base }, serve: { route: "/files/", store: "default", publicBaseUrl: "https://example.test" } })
-    installConsoleBlob(base, blob)
-  }
-  connect()
-  const old = await upload(`data:image/png;base64,${png}`)
-  await blob.put(`vitehub-console-attachment-cleanup/batch/${crypto.randomUUID()}`, "{", { contentType: "application/json" })
-  for (let attempt = 0; attempt < 2; attempt++) {
-    connect()
-    const fresh = await upload(`data:image/png;base64,${png}`)
-    expect(fresh.type).toBe("image")
-    expect(Buffer.from(await (await fresh.fetchData!() as Blob).arrayBuffer()).toString("base64")).toBe(png)
-    await expect(consoleInputMessage("", [{ id: old.id, name: old.name }])).rejects.toThrow("quarantined")
-  }
+  await expect(upload(`data:image/png;base64,${png}`)).rejects.toMatchObject({ statusCode: 503 })
+  const [failure, listing] = await blob.list()
+  expect(failure).toBeNull()
+  expect(listing?.blobs).toEqual([])
 })

--- a/packages/vite-hub/test/console-attachments.test.ts
+++ b/packages/vite-hub/test/console-attachments.test.ts
@@ -1,28 +1,43 @@
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { afterEach, beforeEach, expect, it, vi } from "vitest"
+import { afterEach, expect, it, vi } from "vitest"
 import { blob } from "../../blob/src/runtime/storage.ts"
+import { blobError } from "../../blob/src/errors.ts"
 import { setBlobRuntimeConfig, setBlobRuntimeStorage } from "../../blob/src/runtime/state.ts"
 import { installConsoleBlob } from "../src/console/runtime/server/blob.ts"
-import { consoleAttachmentUpload, consoleInputMessage } from "../src/console/runtime/server/attachments.ts"
-
-import { defineAgent } from "@vite-hub/agent"
-import { createMemoryAgentInvocationStore, defineAgentInvocations } from "@vite-hub/agent/server"
-import { installConsoleAgentDefinitions } from "../src/console/runtime/server/agents.ts"
-
-const root = "/console-attachment-permissions-test"
-function installInvocationAccess(invoke: boolean) {
-  const invocations = defineAgentInvocations({ store: createMemoryAgentInvocationStore() })
-  const definition = defineAgent({ name: "images", invocations, runtime: false, driver: { run: () => "Done" } })
-  installConsoleAgentDefinitions([{ definition, fallbackName: "images" }], { projectRoot: root, invoke })
-}
-beforeEach(() => installInvocationAccess(true))
+import { consoleInputMessage, storeConsoleInputMessage, withConsoleInputMessage } from "../src/console/runtime/server/attachments.ts"
 
 const dirs: string[] = []
-afterEach(async () => { vi.restoreAllMocks(); setBlobRuntimeStorage(undefined); for (const dir of dirs.splice(0)) await rm(dir, { recursive: true, force: true }) })
+afterEach(async () => {
+  setBlobRuntimeStorage(undefined)
+  setBlobRuntimeConfig(undefined)
+  for (const dir of dirs.splice(0)) await rm(dir, { recursive: true, force: true })
+})
 const png = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jD1sAAAAASUVORK5CYII="
-const upload = (url: string) => consoleAttachmentUpload({ method: "POST", req: { json: async () => ({ url, filename: "test.png" }) } })
+const uploadBatch = async (files: Array<{ url: string, filename?: string }>) => (await storeConsoleInputMessage("", { files })).parts.filter(part => part.type === "image")
+const upload = async (url: string) => (await uploadBatch([{ url, filename: "test.png" }]))[0]!
+
+it.each(["YQ", "YR=="])("rejects non-canonical base64 before storing bytes: %s", async (data) => {
+  await expect(upload(`data:image/png;base64,${data}`)).rejects.toMatchObject({ statusCode: 400 })
+})
+
+it.each(["//other.test/image", "javascript:alert(1)"])("rolls back an image with an unusable serving URL: %s", async (url) => {
+  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
+  setBlobRuntimeConfig({ store: { driver: "fs", base }, serve: { route: "/files/", store: "default", publicBaseUrl: "https://example.test" } })
+  installConsoleBlob(base, {
+    ...blob,
+    async put(path, bytes, options) {
+      const result = await blob.put(path, bytes, options)
+      if (result[1]) result[1].url = url
+      return result
+    },
+  })
+  await expect(upload(`data:image/png;base64,${png}`)).rejects.toMatchObject({ statusCode: 503 })
+  const [failure, listing] = await blob.list()
+  expect(failure).toBeNull()
+  expect(listing?.blobs).toEqual([])
+})
 
 it("retains image bytes and metadata across storage restart without embedding bytes in the message", async () => {
   const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
@@ -56,35 +71,181 @@ it("rejects remote URLs, unsupported files, missing images, and path traversal",
   await expect(consoleInputMessage("", [{ id: "../../secret", name: "secret" }])).rejects.toMatchObject({ statusCode: 400 })
 })
 
+it("removes a rejected upload when Blob serving is not configured", async () => {
+  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
+  setBlobRuntimeConfig({ store: { driver: "fs", base } })
+  installConsoleBlob(base, blob)
+
+  await expect(upload(`data:image/png;base64,${png}`)).rejects.toMatchObject({ statusCode: 503 })
+  const [failure, result] = await blob.list({ prefix: "vitehub-console-attachments/" })
+  expect(failure).toBeNull()
+  expect(result?.blobs).toEqual([])
+})
+
+it("surfaces a rejected upload's cleanup failure", async () => {
+  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
+  setBlobRuntimeConfig({ store: { driver: "fs", base } })
+  const cleanupError = blobError("BLOB_OPERATION_FAILED", "del", "default")
+  installConsoleBlob(base, {
+    ...blob,
+    async del() { return [cleanupError, undefined] },
+  })
+
+  await expect(upload(`data:image/png;base64,${png}`)).rejects.toMatchObject({ errors: [expect.objectContaining({ statusCode: 503 }), cleanupError] })
+  const [, pending] = await blob.list({ prefix: "vitehub-console-attachments/" })
+  const id = pending!.blobs[0]!.pathname.split("/")[1]!
+  await expect(consoleInputMessage("retry", [{ id, name: "image" }])).rejects.toMatchObject({ statusCode: 404, message: "The stored image is pending deletion." })
+})
+
 it.each([null, [], "image", {}, { url: 123 }])("rejects malformed upload bodies: %j", async (body) => {
-  await expect(consoleAttachmentUpload({ method: "POST", req: { json: async () => body } }))
-    .rejects.toMatchObject({ statusCode: 400, message: "An image data URL is required." })
+  await expect(storeConsoleInputMessage("", body))
+    .rejects.toMatchObject({ statusCode: 400, message: "Provide between 1 and 10 image data URLs." })
 })
 
 it.each([[123], [null], [{}], ["../../secret"]])("rejects invalid attachment IDs: %j", async (id) => {
   await expect(consoleInputMessage("", [id])).rejects.toMatchObject({ statusCode: 400, message: "Invalid attachment ID." })
 })
 
-
-it("disables uploads when Console invocation is disabled", async () => {
-  installInvocationAccess(false)
-  const put = vi.spyOn(blob, "put")
-  await expect(upload(`data:image/png;base64,${png}`)).rejects.toMatchObject({ statusCode: 404 })
+it("validates all files and the combined budget before writing any objects", async () => {
+  const put = vi.fn(blob.put)
+  installConsoleBlob("/batch-validation", { ...blob, put })
+  const file = { url: `data:image/png;base64,${png}` }
+  await expect(uploadBatch([file, { url: "data:text/html;base64,PHNjcmlwdD4=" }])).rejects.toMatchObject({ statusCode: 415 })
+  await expect(uploadBatch(Array.from({ length: 11 }, () => file))).rejects.toMatchObject({ statusCode: 400 })
+  await expect(uploadBatch([])).rejects.toMatchObject({ statusCode: 400 })
+  const large = { url: `data:image/png;base64,${Buffer.alloc(6 * 1024 * 1024).toString("base64")}` }
+  await expect(uploadBatch([large, large])).rejects.toMatchObject({ statusCode: 413 })
   expect(put).not.toHaveBeenCalled()
 })
 
-it("rejects malformed base64 before storing an image", async () => {
-  const put = vi.spyOn(blob, "put")
-  await expect(upload("data:image/png;base64,YQ")).rejects.toMatchObject({ statusCode: 400 })
-  expect(put).not.toHaveBeenCalled()
-})
-
-it("removes uploads that cannot produce a usable serving URL", async () => {
-  const base = await mkdtemp(join(tmpdir(), "console-upload-cleanup-")); dirs.push(base)
-  setBlobRuntimeConfig({ store: { driver: "fs", base } })
+it("rolls back a partially written batch without deleting an earlier successful upload", async () => {
+  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
+  setBlobRuntimeConfig({ store: { driver: "fs", base }, serve: { route: "/files/", store: "default", publicBaseUrl: "https://example.test" } })
   installConsoleBlob(base, blob)
-  await expect(upload(`data:image/png;base64,${png}`)).rejects.toMatchObject({ statusCode: 503 })
-  const [failure, listing] = await blob.list()
-  expect(failure).toBeNull()
-  expect(listing?.blobs).toEqual([])
+  const retained = await upload(`data:image/png;base64,${png}`)
+  const failure = blobError("BLOB_OPERATION_FAILED", "put", "default")
+  let writes = 0
+  installConsoleBlob(base, {
+    ...blob,
+    async put(path, bytes, options) {
+      const result = await blob.put(path, bytes, options)
+      // Simulate a provider error after the second object's bytes were written.
+      if (++writes === 2) return [failure, undefined]
+      return result
+    },
+  })
+  await expect(uploadBatch([{ url: `data:image/png;base64,${png}` }, { url: `data:image/png;base64,${png}` }])).rejects.toBe(failure)
+  const [listError, result] = await blob.list({ prefix: "vitehub-console-attachments/" })
+  expect(listError).toBeNull()
+  expect(result?.blobs.map(item => item.pathname)).toEqual([`vitehub-console-attachments/${retained.id}`])
+})
+
+it("attempts every rollback even when one deletion fails", async () => {
+  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
+  setBlobRuntimeConfig({ store: { driver: "fs", base }, serve: { route: "/files/", store: "default", publicBaseUrl: "https://example.test" } })
+  const failure = new Error("Upload interrupted")
+  const cleanupError = blobError("BLOB_OPERATION_FAILED", "del", "default")
+  let writes = 0
+  let deletions = 0
+  const del = vi.fn(async (path: string | string[]) => {
+    if (++deletions === 1) throw cleanupError
+    return blob.del(path)
+  })
+  installConsoleBlob(base, {
+    ...blob,
+    del,
+    async put(path, bytes, options) {
+      if (++writes === 2) throw failure
+      return blob.put(path, bytes, options)
+    },
+  })
+  await expect(uploadBatch([{ url: `data:image/png;base64,${png}` }, { url: `data:image/png;base64,${png}` }])).rejects.toMatchObject({ errors: [failure, cleanupError] })
+  expect(del.mock.calls.filter(([path]) => typeof path === "string" && path.startsWith("vitehub-console-attachments/"))).toHaveLength(2)
+})
+
+it("returns durable references for every file in a successful batch", async () => {
+  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
+  setBlobRuntimeConfig({ store: { driver: "fs", base }, serve: { route: "/files/", store: "default", publicBaseUrl: "https://example.test" } })
+  installConsoleBlob(base, blob)
+  const parts = await uploadBatch([
+    { url: `data:image/png;base64,${png}`, filename: "first.png" },
+    { url: `data:image/png;base64,${png}`, filename: "second.png" },
+  ])
+  expect(parts.map(part => part.name)).toEqual(["first.png", "second.png"])
+  expect(new Set(parts.map(part => part.id)).size).toBe(2)
+  setBlobRuntimeStorage(undefined)
+  const message = await consoleInputMessage("both images", parts)
+  expect(message.parts.map(part => part.type)).toEqual(["text", "image", "image"])
+  for (const part of message.parts) {
+    if (part.type === "image") expect(await part.fetchData!()).toBeInstanceOf(Blob)
+  }
+})
+
+it.each([false, true])("rolls back a new input batch when reconstruction fails, cleanup failure: %s", async (failCleanup) => {
+  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
+  setBlobRuntimeConfig({ store: { driver: "fs", base }, serve: { route: "/files/", store: "default", publicBaseUrl: "https://example.test" } })
+  installConsoleBlob(base, blob)
+  const retained = await upload(`data:image/png;base64,${png}`)
+  const failure = blobError("BLOB_OPERATION_FAILED", "head", "default")
+  const cleanupError = blobError("BLOB_OPERATION_FAILED", "del", "default")
+  let reads = 0
+  let deletions = 0
+  installConsoleBlob(base, {
+    ...blob,
+    async head(path) {
+      if (++reads === 2) return [failure, undefined]
+      return blob.head(path)
+    },
+    async del(path) {
+      if (typeof path === "string" && path.startsWith("vitehub-console-attachments/") && ++deletions === 1 && failCleanup) return [cleanupError, undefined]
+      return blob.del(path)
+    },
+  })
+  const input = storeConsoleInputMessage("test", { files: [
+    { url: `data:image/png;base64,${png}` },
+    { url: `data:image/png;base64,${png}` },
+  ] })
+  if (failCleanup) await expect(input).rejects.toMatchObject({ errors: [failure, cleanupError] })
+  else await expect(input).rejects.toBe(failure)
+  expect(deletions).toBe(2)
+  const [listError, result] = await blob.list({ prefix: "vitehub-console-attachments/" })
+  expect(listError).toBeNull()
+  expect(result?.blobs).toHaveLength(failCleanup ? 2 : 1)
+  expect(result?.blobs.map(item => item.pathname)).toContain(`vitehub-console-attachments/${retained.id}`)
+})
+
+it.each([false, true])("only rolls back startup failures before runtime handoff: %s", async (handedOff) => {
+  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
+  setBlobRuntimeConfig({ store: { driver: "fs", base }, serve: { route: "/files/", store: "default", publicBaseUrl: "https://example.test" } })
+  installConsoleBlob(base, blob)
+  const retained = await upload(`data:image/png;base64,${png}`)
+  const failure = new Error("Agent startup failed")
+  await expect(withConsoleInputMessage("test", { files: [{ url: `data:image/png;base64,${png}` }] }, async (_message, handoff) => {
+    if (handedOff) handoff()
+    throw failure
+  })).rejects.toBe(failure)
+  const [listError, result] = await blob.list({ prefix: "vitehub-console-attachments/" })
+  expect(listError).toBeNull()
+  expect(result?.blobs).toHaveLength(handedOff ? 2 : 1)
+  expect(result?.blobs.map(item => item.pathname)).toContain(`vitehub-console-attachments/${retained.id}`)
+})
+
+
+it("accepts fresh images after quarantining corruption across restart but rejects stored reuse", async () => {
+  const base = await mkdtemp(join(tmpdir(), "console-attachments-")); dirs.push(base)
+  const connect = () => {
+    setBlobRuntimeStorage(undefined)
+    setBlobRuntimeConfig({ store: { driver: "fs", base }, serve: { route: "/files/", store: "default", publicBaseUrl: "https://example.test" } })
+    installConsoleBlob(base, blob)
+  }
+  connect()
+  const old = await upload(`data:image/png;base64,${png}`)
+  await blob.put(`vitehub-console-attachment-cleanup/batch/${crypto.randomUUID()}`, "{", { contentType: "application/json" })
+  for (let attempt = 0; attempt < 2; attempt++) {
+    connect()
+    const fresh = await upload(`data:image/png;base64,${png}`)
+    expect(fresh.type).toBe("image")
+    expect(Buffer.from(await (await fresh.fetchData!() as Blob).arrayBuffer()).toString("base64")).toBe(png)
+    await expect(consoleInputMessage("", [{ id: old.id, name: old.name }])).rejects.toThrow("quarantined")
+  }
 })

--- a/packages/vite-hub/test/console-invocation-input.test.ts
+++ b/packages/vite-hub/test/console-invocation-input.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest"
+import { startConsoleAgentInvocation } from "../src/console/runtime/client/invocation.ts"
+import { requestConsole } from "../src/console/runtime/client/request.ts"
+
+vi.mock("../src/console/runtime/client/request.ts", () => ({ requestConsole: vi.fn() }))
+
+describe("Console invocation input", () => {
+  it("keeps the Agent, route, and profile selected when image uploads begin", async () => {
+    const uploaded = Promise.withResolvers<unknown>()
+    vi.mocked(requestConsole).mockReset().mockReturnValueOnce(uploaded.promise).mockResolvedValueOnce({ id: "invocation" })
+    const target = { agent: "first", base: "/first/api/_vitehub/console/agents", invokerProfileId: "reader" }
+    const started = startConsoleAgentInvocation(target, { text: "Explain this image", files: [{ type: "file", mediaType: "image/png", url: "data:image/png;base64,aQ==" }] })
+    target.agent = "second"
+    target.base = "/second/api/_vitehub/console/agents"
+    target.invokerProfileId = "administrator"
+    uploaded.resolve({ id: "image" })
+    expect(await started).toEqual({ agent: "first", id: "invocation" })
+    expect(requestConsole).toHaveBeenNthCalledWith(2, "/first/api/_vitehub/console/agents/first/invocations", {
+      body: { attachments: [{ id: "image", name: "image" }], invokerProfileId: "reader", prompt: "Explain this image" }, method: "POST",
+    })
+  })
+
+  it("does not start an invocation when an upload fails", async () => {
+    vi.mocked(requestConsole).mockReset().mockRejectedValueOnce(new Error("Storage unavailable"))
+    await expect(startConsoleAgentInvocation({ agent: "first", base: "/api/_vitehub/console/agents" }, { text: "", files: [{ type: "file", mediaType: "image/png", url: "data:image/png;base64,aQ==" }] })).rejects.toThrow("Storage unavailable")
+    expect(requestConsole).toHaveBeenCalledOnce()
+  })
+})

--- a/packages/vite-hub/test/console-invocation-input.test.ts
+++ b/packages/vite-hub/test/console-invocation-input.test.ts
@@ -1,23 +1,44 @@
 import { describe, expect, it, vi } from "vitest"
-import { startConsoleAgentInvocation } from "../src/console/runtime/client/invocation.ts"
+import { effectScope, reactive } from "vue"
+import { startConsoleAgentInvocation, useConsoleInvocationTarget } from "../src/console/runtime/client/invocation.ts"
 import { requestConsole } from "../src/console/runtime/client/request.ts"
 
 vi.mock("../src/console/runtime/client/request.ts", () => ({ requestConsole: vi.fn() }))
 
 describe("Console invocation input", () => {
   it("keeps the Agent, route, and profile selected when image uploads begin", async () => {
-    const uploaded = Promise.withResolvers<unknown>()
-    vi.mocked(requestConsole).mockReset().mockReturnValueOnce(uploaded.promise).mockResolvedValueOnce({ id: "invocation" })
+    let complete: (value: unknown) => void = () => {}
+    const uploaded = new Promise<unknown>(resolve => { complete = resolve })
+    vi.mocked(requestConsole).mockReset().mockReturnValueOnce(uploaded)
     const target = { agent: "first", base: "/first/api/_vitehub/console/agents", invokerProfileId: "reader" }
     const started = startConsoleAgentInvocation(target, { text: "Explain this image", files: [{ type: "file", mediaType: "image/png", url: "data:image/png;base64,aQ==" }] })
     target.agent = "second"
     target.base = "/second/api/_vitehub/console/agents"
     target.invokerProfileId = "administrator"
-    uploaded.resolve({ id: "image" })
+    complete({ id: "invocation" })
     expect(await started).toEqual({ agent: "first", id: "invocation" })
-    expect(requestConsole).toHaveBeenNthCalledWith(2, "/first/api/_vitehub/console/agents/first/invocations", {
-      body: { attachments: [{ id: "image", name: "image" }], invokerProfileId: "reader", prompt: "Explain this image" }, method: "POST",
+    expect(requestConsole).toHaveBeenCalledExactlyOnceWith("/first/api/_vitehub/console/agents/first/invocations", {
+      body: { files: [{ url: "data:image/png;base64,aQ==", filename: "image" }], invokerProfileId: "reader", prompt: "Explain this image" }, method: "POST",
     })
+  })
+
+  it.each(["agent", "base", "invokerProfileId"] as const)("invalidates a pending result when %s changes away and back", (field) => {
+    const scope = effectScope()
+    try {
+      scope.run(() => {
+        const target = reactive({ agent: "first", base: "/agents", invokerProfileId: "reader" })
+        const capture = useConsoleInvocationTarget(() => target)
+        const pending = capture()
+        expect(pending.isCurrent()).toBe(true)
+        const initial = target[field]
+        target[field] = "other"
+        target[field] = initial
+        expect(pending.isCurrent()).toBe(false)
+        expect(capture().isCurrent()).toBe(true)
+      })
+    } finally {
+      scope.stop()
+    }
   })
 
   it("does not start an invocation when an upload fails", async () => {

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -211,6 +211,7 @@ export default defineConfig({
     entry: [
       ...distributionEntries,
       "src/console/runtime/console-route.ts",
+      "src/console/runtime/client/invocation.ts",
       "src/console/runtime/client/request.ts",
       "src/console/runtime/client/time.ts",
       "src/console/runtime/definitions.ts",
@@ -238,6 +239,7 @@ export default defineConfig({
       customExports(exports) {
         delete exports["./console/runtime/console-route"];
         delete exports["./console/runtime/client/sections"];
+        delete exports["./console/runtime/client/invocation"];
         delete exports["./console/runtime/client/request"];
         delete exports["./console/runtime/client/time"];
         delete exports["./console/runtime/definitions"];


### PR DESCRIPTION
Switching Agents while images upload could send input to the newly selected Agent and profile. This change captures the destination before submission and invalidates pending results after any Agent, route, or profile change, including switching away and back.

Images travel in the invocation request so the transactional storage and runtime handoff from #1298 retain ownership. Validation happens before storage; setup failures roll back new uploads. Existing stored `{ id, name }` references still work. Strict base64 validation rejects malformed data, and unusable serving URLs trigger rollback. The composer rejects images above 10 MiB before upload and uses the prompt component's submit readiness.

This is a focused follow-up to #1298. Quiver files and patches are unchanged; patch retirement still needs released upstream packages.

Validation: 57 tests passed for submission destination, selection generations, upload validation, storage rollback, restart, real workflow handoff, package exports, and shipped Console imports. Console production assets, package build, publint, changed-source lint, and package typecheck passed. The full package run passed 732 tests and exposed inherited failures. The parent now fixes export classification and copied assets. The remaining invalid usage-cursor diagnostic fixture is unchanged from main; three other failures were timeouts under concurrent build load.

Earlier browser verification used synthetic data and confirmed oversized files are rejected before upload.

Before, an oversized image remained selected:

![Before: oversized image accepted](https://github.com/user-attachments/assets/1490e9ff-f02b-4a80-bd24-243a252458e7)

After, the composer rejects the same file:

![After: oversized image rejected](https://github.com/user-attachments/assets/70b3add3-bca9-4574-8003-b3302772c9eb)

Model: GPT-6. Harness: Codex in T3 Code.
