### PR TITLE
feat(console): make Usage the session history page

### DIFF
--- a/docs/content/docs/console/usage.md
+++ b/docs/content/docs/console/usage.md
@@ -1,17 +1,25 @@
-# Usage and provider status
+# Session history and usage
 
-The Console Usage page combines provider readiness, subscription quota, recorded usage, and invocation history. Readiness checks inspect the configured provider account without sending a model prompt. A successful check is evidence at its checked time; it does not guarantee the next reply.
+The Console Usage page lists completed, failed, and cancelled sessions, newest first. Open a session title to return to its existing conversation and inspector. Active sessions stay in the Agents panel.
 
-The date and agent filters apply to totals, average cost, most expensive invocations, and the paginated invocation table. Completed, failed, and cancelled invocations contribute any cost they recorded. Subscription quota is separate from USD cost. Providers without cost evidence keep token and invocation history; monetary panels appear only when cost is configured or has been recorded.
+Each history row uses the same Agent Invocation ID as the Console session panel. A transport thread ID can contain separate executions, so history does not merge invocations by thread or title. Tokens and cost come from the recorded usage for that invocation, including its model calls.
+
+Filter by date, Agent, status, or session title and ID. The search also matches Agent names. Filters stay in the URL, so returning from a session restores the selected history view. Sessions remain visible when usage is missing. An unavailable value is not zero; partial totals are labeled `recorded`.
+
+Expand **Usage breakdown** for charts, model totals, averages, and the most expensive invocations. **Provider status** contains readiness and subscription quota. Readiness checks inspect the configured provider account without sending a model prompt. A successful check is evidence at its checked time; it does not guarantee the next reply.
+
+All history filters apply to totals, average cost, most expensive invocations, and the paginated history table. Completed, failed, and cancelled invocations contribute any cost they recorded. Subscription quota is separate from USD cost. Providers without cost evidence keep token and session history; monetary panels appear only when cost is configured or has been recorded.
 
 Averages divide the recorded decimal cost by the number of priced invocations. Unknown cost is not zero. A recorded zero is included in coverage and averages. Model averages combine calls using the same model within an invocation so auxiliary calls contribute once to that invocation/model row. Estimated amounts carry a `~` prefix.
 
 ## Persistence and API
 
-`GET /api/_vitehub/console/usage?window=30d&agent=bot` uses the same authenticated Console access policy as session inspection. It returns time buckets, totals, agent/model groups, the ten most expensive invocations, and up to fifty invocation rows. Pass the returned `cursor` to retrieve the next page. Supported windows are `24h`, `7d`, `30d`, and `90d`.
+`GET /api/_vitehub/console/usage?window=30d&agent=bot&status=failed&search=release` uses the same authenticated Console access policy as session inspection. The Console client carries this operation over its existing RPC connection. The response contains `sessions`, `sessionCount`, time buckets, totals, Agent/model groups, and the ten most expensive invocations. Each session includes its invocation ID, Agent, recorded title when available, status, last activity, models, and usage totals. Up to fifty session rows are returned per page. Pass the returned opaque `cursor` unchanged to retrieve the next page with the same filters. The cursor fixes the first page’s date cutoff, so newly completed sessions appear after Refresh resets pagination. Totals cover all matching sessions within that cutoff. Deletion and historical backfill can still change rows and totals; the cursor does not hold a database snapshot. Invalid cursors or changed filters return HTTP 400.
+
+Supported windows are `24h`, `7d`, `30d`, and `90d`. Optional `status` accepts `completed`, `failed`, or `cancelled`. Search is a case-insensitive literal match against title, ID, and Agent name. Date filtering uses completion time, falling back to last update or creation time when completion time is absent.
 
 The standard Console SQLite database maintains a rebuildable usage projection. Change triggers enqueue changed invocation IDs. Historical backfill reads only the final usage observation inside SQLite, then stores compact usage summaries. Aggregates use indexed date/agent queries; decimal cost groups are summed with bigint arithmetic so SQLite floating-point conversion cannot change a monetary total. Expensive-invocation ordering compares normalized decimal parts.
 
-Backfill runs in bounded batches. `projection.complete: false` and `partial: true` mean totals are still incomplete. Refresh after backfill finishes. This projection does not change invocation retention or hold transcripts. Deleting an invocation removes its projection. A process restart resumes pending work. A custom invocation store uses its existing paginated read interface instead of the Console SQLite projection.
+Backfill runs in bounded batches. `projection.complete: false` and `partial: true` mean totals are still incomplete. Refresh after backfill finishes. This projection does not change invocation retention or hold transcripts. Deleting an invocation removes its projection. A process restart resumes pending work. The version 2 history projection has separate tables and triggers, so an older process can keep using its version 1 projection during a rolling update. A custom invocation store uses its existing paginated read interface instead of the Console SQLite projection.
 
 The native SQLite regression fixture is `packages/vite-hub/test/console-usage-index.test.ts`. It exercises 100,001 invocations, exact decimal totals, missing cost, failed and cancelled runs, auxiliary calls, pagination, replay, updates, and deletion without invoking a model.

--- a/packages/vite-hub/README.md
+++ b/packages/vite-hub/README.md
@@ -133,6 +133,8 @@ Built-in Agent Drivers and Box runtimes are selected by literal or tagged values
 
 ## Invoke Agents from the Console
 
+The Console **Usage** page provides session history with date, Agent, status, and search filters. Open a row to inspect that session in the existing Agents view. History keeps completed, failed, and cancelled Agent Invocations visible even when token or cost evidence is unavailable. Totals use the same filters as the history table. See [Session history and usage](https://vitehub.dev/docs/console/usage) for the identity, coverage, and pagination contract.
+
 Set `console: { access: "auth", invoke: true }` to use ViteHub Auth, or `console: { exposure: "host-managed", invoke: true }` when host middleware protects all `/_vitehub/**` routes. Explicit access configurations keep invocation disabled by default. The development shorthand `console: true` enables invocation.
 
 Console invocation requests accept a `prompt`, optional `invokerProfileId`, and optional prior `messages`. Use the `ConsoleAgentInvocationInput` type from `vite-hub/console`. History requires valid user or assistant Messages with unique IDs and only text, file, image, or audio parts. The Console rejects tool and approval parts, appends the new user prompt, and starts a new invocation. See the [Console guide](https://vitehub.dev/docs/development/console#start-agent-invocations) for the access and history contracts.

--- a/packages/vite-hub/package.json
+++ b/packages/vite-hub/package.json
@@ -235,6 +235,7 @@
     "@vite-hub/internal": "workspace:*",
     "@vitejs/plugin-vue": "^6.0.8",
     "h3-v1": "npm:h3@^1.15.11",
+    "miniflare": "4.20260714.0",
     "publint": "catalog:tooling",
     "reka-ui": "^2.10.4",
     "tailwindcss": "^4.3.3",

--- a/packages/vite-hub/src/console/runtime/components/console-usage.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-usage.vue
@@ -2,7 +2,7 @@
 import { computed, onBeforeUnmount, ref, watch } from "vue";
 import * as v from "valibot";
 
-import { useRoute } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
 import { encodeAgentRouteParam, resolveConsoleRouteName } from "../console-route";
 import { requestConsole } from "../client/request";
 
@@ -50,6 +50,16 @@ const usageRunSchema = v.object({
     }),
   ),
 });
+const usageSessionSchema = v.object({
+  id: v.string(),
+  agent: v.string(),
+  title: v.optional(v.string()),
+  status: v.picklist(["completed", "failed", "cancelled"]),
+  at: v.string(),
+  models: v.array(v.string()),
+  partial: v.boolean(),
+  totals: usageTotalsSchema,
+});
 const providerStatusSchema = v.object({
   agents: v.array(
     v.object({
@@ -82,6 +92,8 @@ const usageSummarySchema = v.object({
   available: v.boolean(),
   costSupported: v.boolean(),
   agents: v.array(v.object({ ...usageTotalsEntries, agent: v.string() })),
+  sessions: v.array(usageSessionSchema),
+  sessionCount: v.number(),
   runs: v.array(usageRunSchema),
   expensive: v.array(usageRunSchema),
   cursor: v.optional(v.string()),
@@ -99,22 +111,60 @@ type UsageTotals = v.InferOutput<typeof usageTotalsSchema>;
 type UsageSummary = v.InferOutput<typeof usageSummarySchema>;
 
 const route = useRoute();
+const router = useRouter();
 const props = defineProps<{ base: string }>();
 const emit = defineEmits<{ openSessions: [] }>();
-const window = ref<UsageWindow>("30d");
+function setFilter(key: string, value: string) {
+  void router.replace({ query: { ...route.query, [key]: value || undefined } });
+}
+const window = computed<UsageWindow>({
+  get: () => {
+    const parsed = v.safeParse(v.picklist(["24h", "7d", "30d", "90d"]), route.query.window);
+    return parsed.success ? parsed.output : "30d";
+  },
+  set: value => setFilter("window", value),
+});
 const metric = ref<UsageMetric>("cost");
 const breakdown = ref<UsageBreakdown>("model");
 const summary = ref<UsageSummary>();
 const loading = ref(true);
 const error = ref<unknown>();
-const agent = ref("");
+const agent = computed(() => String(route.query.agent || ""));
+const selectedAgent = computed({
+  get: () => agent.value ? `agent:${agent.value}` : "all",
+  set: (value: string) => setFilter("agent", value.startsWith("agent:") ? value.slice(6) : ""),
+});
+const status = computed({
+  get: () => {
+    const parsed = v.safeParse(v.picklist(["completed", "failed", "cancelled"]), route.query.status);
+    return parsed.success ? parsed.output : "all";
+  },
+  set: (value: string) => setFilter("status", value === "all" ? "" : value),
+});
+const search = computed(() => String(route.query.search || "").trim());
+const searchInput = ref(search.value);
+let searchTimer: ReturnType<typeof setTimeout> | undefined;
+watch(search, value => { searchInput.value = value; });
+watch(searchInput, value => {
+  clearTimeout(searchTimer);
+  if (value.trim() === search.value) return;
+  searchTimer = setTimeout(() => setFilter("search", value.trim()), 250);
+});
+const statusOptions = [
+  { label: "All statuses", value: "all" },
+  { label: "Completed", value: "completed" },
+  { label: "Failed", value: "failed" },
+  { label: "Cancelled", value: "cancelled" },
+];
+const statusIcons = { completed: "i-lucide-check", failed: "i-lucide-x", cancelled: "i-lucide-ban" };
+const statusLabels = { completed: "Completed", failed: "Failed", cancelled: "Cancelled" };
 const statuses = ref<v.InferOutput<typeof providerStatusSchema>["agents"]>([]);
 const statusError = ref<string>();
 const runCursor = ref<string>();
 const previousCursors = ref<Array<string | undefined>>([]);
 const costSupported = computed(() => summary.value?.costSupported === true);
 const agentOptions = computed(() => [
-  { label: "All agents", value: "" },
+  { label: "All agents", value: "all" },
   ...[
     ...new Set([
       ...statuses.value.map((status) => status.agent),
@@ -123,22 +173,21 @@ const agentOptions = computed(() => [
   ]
     .filter(Boolean)
     .sort()
-    .map((value) => ({ label: value, value })),
+    .map((value) => ({ label: value, value: `agent:${value}` })),
 ]);
-function runRoute(run: v.InferOutput<typeof usageRunSchema>) {
+function runRoute(run: { id: string; agent: string }) {
   try {
     return { name: resolveConsoleRouteName(route.name, "vitehub-console-invocation"), params: { agent: encodeAgentRouteParam(run.agent), invocation: run.id } };
   } catch { return undefined; }
 }
 
 function nextRuns() {
-  previousCursors.value.push(runCursor.value);
-  runCursor.value = summary.value?.cursor;
-  void load();
+  if (loading.value || !summary.value?.cursor) return;
+  void loadPage({ cursor: summary.value.cursor, previous: [...previousCursors.value, runCursor.value] });
 }
 function previousRuns() {
-  runCursor.value = previousCursors.value.pop();
-  void load();
+  if (loading.value || !previousCursors.value.length) return;
+  void loadPage({ cursor: previousCursors.value.at(-1), previous: previousCursors.value.slice(0, -1) });
 }
 
 let request: AbortController | undefined;
@@ -267,13 +316,13 @@ function formatMetricNumber(value: number): string {
 }
 
 function formatTokenEvidence(value: number, complete: boolean): string {
-  if (!complete && value === 0) return "—";
+  if (!complete && value === 0) return "Unavailable";
   const display = formatTokens(value);
   return complete ? display : `${display} recorded`;
 }
 
 function formatCostEvidence(value: string, estimated: boolean, complete: boolean): string {
-  if (!complete && (Number(value) || 0) === 0) return "—";
+  if (!complete && (Number(value) || 0) === 0) return "Unavailable";
   const display = formatCost(value, estimated);
   return complete ? display : `${display} recorded`;
 }
@@ -297,6 +346,14 @@ function errorMessage(value: unknown): string | undefined {
 }
 
 async function load(): Promise<void> {
+  return loadPage({ cursor: runCursor.value, previous: previousCursors.value });
+}
+
+async function refresh(): Promise<void> {
+  return loadPage({ cursor: undefined, previous: [] });
+}
+
+async function loadPage(page: { cursor: string | undefined; previous: Array<string | undefined> }): Promise<void> {
   request?.abort();
   const controller = new AbortController();
   request = controller;
@@ -309,13 +366,17 @@ async function load(): Promise<void> {
         query: {
           window: window.value,
           ...(agent.value ? { agent: agent.value } : {}),
-          ...(runCursor.value ? { cursor: runCursor.value } : {}),
+          ...(status.value !== "all" ? { status: status.value } : {}),
+          ...(search.value ? { search: search.value } : {}),
+          ...(page.cursor ? { cursor: page.cursor } : {}),
         },
         signal: controller.signal,
       }),
     );
     if (request !== controller) return;
     summary.value = result;
+    runCursor.value = page.cursor;
+    previousCursors.value = page.previous;
     error.value = undefined;
     if (!result.costSupported) metric.value = "tokens";
   } catch (value) {
@@ -342,205 +403,100 @@ async function loadStatus(): Promise<void> {
   }
 }
 watch(
-  [() => props.base, window, agent],
+  [() => props.base, window, agent, status, search],
   () => {
     runCursor.value = undefined;
     previousCursors.value = [];
+    summary.value = undefined;
     void load();
-    void loadStatus();
   },
   { immediate: true },
 );
-onBeforeUnmount(() => request?.abort());
+watch(() => props.base, () => { void loadStatus(); }, { immediate: true });
+onBeforeUnmount(() => { request?.abort(); clearTimeout(searchTimer); });
 </script>
 
 <template>
-  <UDashboardPanel id="console-usage" :ui="{ body: 'min-h-0 overflow-y-auto p-0 gap-0' }">
+  <UDashboardPanel id="console-usage" class="console-usage" :ui="{ body: 'min-h-0 overflow-y-auto p-0 gap-0' }">
     <template #header>
       <UDashboardNavbar title="Usage" :ui="{ root: 'border-b border-default' }">
         <template #right>
-          <UTooltip text="Open sessions">
-            <UButton
-              class="lg:hidden"
-              icon="i-ph-sidebar-simple-light"
-              color="neutral"
-              variant="ghost"
-              size="sm"
-              aria-label="Open sessions"
-              @click="emit('openSessions')"
-            />
-          </UTooltip>
-          <div
-            v-if="summary"
-            class="hidden rounded-md bg-elevated p-0.5 sm:inline-flex"
-            aria-label="Usage metric"
-          >
-            <UButton
-              v-for="option in metricOptions"
-              :key="option.value"
-              :label="option.label"
-              color="neutral"
-              size="xs"
-              :variant="metric === option.value ? 'solid' : 'ghost'"
-              @click="metric = option.value"
-            />
-          </div>
-          <USelect
-            v-model="agent"
-            :items="agentOptions"
-            value-key="value"
-            aria-label="Agent"
-            size="sm"
-            class="max-w-44"
-          />
-          <USelect
-            v-model="window"
-            aria-label="Usage period"
-            class="w-24 sm:w-28"
-            size="sm"
-            value-key="value"
-            :items="windowOptions"
-          />
-          <UTooltip text="Refresh usage">
-            <UButton
-              class="hidden sm:inline-flex"
-              aria-label="Refresh usage"
-              color="neutral"
-              icon="i-ph-arrows-clockwise-light"
-              size="sm"
-              variant="ghost"
-              :loading="loading"
-              @click="
-                load();
-                loadStatus();
-              "
-            />
-          </UTooltip>
+          <UButton class="md:hidden" icon="i-lucide-panel-left" color="neutral" variant="ghost" size="sm" aria-label="Open sessions" @click="emit('openSessions')" />
+          <USelect v-model="window" aria-label="Usage period" class="w-28" size="sm" value-key="value" :items="windowOptions" />
+          <UButton aria-label="Refresh usage" color="neutral" icon="i-lucide-refresh-cw" size="sm" variant="ghost" :disabled="loading" @click="refresh(); loadStatus();" />
         </template>
       </UDashboardNavbar>
     </template>
-
     <template #body>
-      <main class="mx-auto flex w-full max-w-6xl flex-col gap-8 px-4 py-8 sm:px-6 lg:py-10">
-        <div
-          v-if="summary"
-          class="inline-flex self-start rounded-md bg-elevated p-0.5 sm:hidden"
-          aria-label="Usage metric"
-        >
-          <UButton
-            v-for="option in metricOptions"
-            :key="option.value"
-            :label="option.label"
-            color="neutral"
-            size="xs"
-            :variant="metric === option.value ? 'solid' : 'ghost'"
-            @click="metric = option.value"
-          />
+      <main class="mx-auto flex w-full max-w-7xl flex-col gap-6 px-4 py-5 sm:px-6" :aria-busy="loading">
+        <div class="flex flex-wrap items-center gap-2" role="search" aria-label="Session history filters">
+          <UInput v-model="searchInput" type="search" icon="i-lucide-search" placeholder="Search sessions" aria-label="Search session history" class="min-w-40 flex-1 sm:max-w-80" size="sm" />
+          <USelect v-model="selectedAgent" :items="agentOptions" value-key="value" aria-label="Agent" size="sm" class="w-40 max-w-full" />
+          <USelect v-model="status" :items="statusOptions" value-key="value" aria-label="Session status" size="sm" class="w-36" />
         </div>
-        <section class="rounded-lg border border-default">
-          <div class="border-b border-default px-5 py-3">
-            <h2 class="text-sm font-semibold">ViteHub status</h2>
-            <p class="mt-1 text-xs text-muted">
-              Account and subscription checks. These checks do not send a message to the model.
-            </p>
+        <UAlert v-if="errorMessage(error)" color="error" variant="subtle" title="Could not load session history" :description="errorMessage(error)" :actions="[{ label: 'Try again', onClick: load }]" />
+        <p v-if="summary?.partial" class="flex items-start gap-2 text-xs text-muted" role="status">
+          <UIcon name="i-lucide-info" class="mt-0.5 size-3.5 shrink-0" />
+          Some usage is unavailable. Recorded totals include only the evidence received.
+        </p>
+        <template v-if="summary">
+          <dl class="grid grid-cols-2 gap-x-6 gap-y-4 sm:grid-cols-4" aria-label="Session history totals">
+            <div><dt class="text-xs text-muted">Sessions</dt><dd class="mt-1 text-2xl font-semibold tabular-nums">{{ summary.sessionCount.toLocaleString('en') }}{{ summary.totals.invocationsAvailable ? '' : ' recorded' }}</dd></div>
+            <div><dt class="text-xs text-muted">Tokens</dt><dd class="mt-1 text-lg font-semibold tabular-nums">{{ formatTokenEvidence(summary.totals.totalTokens, summary.totals.totalTokensAvailable) }}</dd></div>
+            <div v-if="costSupported"><dt class="text-xs text-muted">Cost</dt><dd class="mt-1 text-lg font-semibold tabular-nums">{{ formatCostEvidence(summary.totals.costUsd, summary.totals.costEstimated, summary.totals.costAvailable) }}</dd></div>
+            <div v-if="costSupported"><dt class="text-xs text-muted">Average per priced session</dt><dd class="mt-1 text-lg font-semibold tabular-nums">{{ summary.totals.averageCostUsd === undefined ? 'Unavailable' : formatCost(summary.totals.averageCostUsd, summary.totals.costEstimated) }}</dd></div>
+          </dl>
+        </template>
+        <p v-else-if="loading" class="py-5 text-sm text-muted" role="status">Loading session history...</p>
+        <section v-if="summary" aria-labelledby="session-history-heading">
+          <div class="mb-3 flex items-baseline justify-between gap-3">
+            <h2 id="session-history-heading" class="text-sm font-semibold">Session history</h2>
+            <span class="text-xs text-muted">Newest first</span>
           </div>
-          <p v-if="statusError" class="p-5 text-sm text-warning">{{ statusError }}</p>
-          <div v-else class="grid divide-y divide-default lg:grid-cols-2 lg:divide-y-0">
-            <article
-              v-for="status in statuses.filter((item) => !agent || item.agent === agent)"
-              :key="status.agent"
-              class="space-y-3 p-5"
-            >
-              <div class="flex items-center justify-between gap-3">
-                <div>
-                  <h3 class="text-sm font-medium">{{ status.agent }}</h3>
-                  <p class="text-xs text-muted">{{ status.provider || "Provider" }}</p>
-                </div>
-                <UBadge
-                  :color="
-                    status.readiness === 'ready' && !status.stale
-                      ? 'success'
-                      : status.readiness === 'unavailable'
-                        ? 'error'
-                        : 'neutral'
-                  "
-                  variant="subtle"
-                  >{{ status.stale ? "Stale" : status.readiness }}</UBadge
-                >
-              </div>
-              <p v-if="status.reason" class="text-xs text-muted">{{ status.reason }}</p>
-              <div class="flex flex-wrap gap-4 text-xs text-muted">
-                <span v-if="status.authenticated !== undefined"
-                  >Account: {{ status.authenticated ? "Signed in" : "Signed out" }}</span
-                >
-                <span>Checked {{ formatPeriod(status.checkedAt, "hour") }}</span>
-              </div>
-              <div
-                v-for="limit in status.usageLimits?.windows ?? []"
-                :key="limit.id"
-                class="space-y-1.5"
-              >
-                <div class="flex justify-between gap-3 text-xs">
-                  <span>{{ limit.label }}</span
-                  ><span class="tabular-nums">{{ limit.usedPercent.toFixed(0) }}% used</span>
-                </div>
-                <progress
-                  class="h-1.5 w-full accent-primary"
-                  :value="Math.min(100, Math.max(0, limit.usedPercent))"
-                  max="100"
-                  :aria-label="limit.label"
-                />
-                <p v-if="limit.resetsAt" class="text-xs text-muted">
-                  Resets {{ formatPeriod(limit.resetsAt, "hour") }}
-                </p>
-              </div>
-              <p v-if="status.usageLimits?.unavailable" class="text-xs text-muted">
-                Subscription usage
-                {{
-                  status.usageLimits.unavailable.reason === "unsupported"
-                    ? "is not reported by this provider"
-                    : "could not be checked"
-                }}.
-              </p>
-            </article>
+          <div class="overflow-x-auto">
+            <table class="w-full min-w-[42rem] table-fixed text-sm" data-slot="session-history">
+              <thead class="border-b border-default text-left text-xs text-muted">
+                <tr>
+                  <th class="w-[34%] py-2 pr-4 font-medium" scope="col">Session</th>
+                  <th class="w-[19%] py-2 pr-4 font-medium" scope="col">Agent / model</th>
+                  <th class="w-[15%] py-2 pr-4 font-medium" scope="col">Last activity</th>
+                  <th class="w-[13%] py-2 pr-4 font-medium" scope="col">Status</th>
+                  <th class="py-2 pl-2 text-right font-medium" scope="col">Tokens</th>
+                  <th v-if="costSupported" class="py-2 pl-4 text-right font-medium" scope="col">Cost</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="session in summary.sessions" :key="session.id" class="border-b border-default/50 hover:bg-elevated/40">
+                  <td class="py-3 pr-4 align-top">
+                    <RouterLink v-if="runRoute(session)" :to="runRoute(session)!" class="block truncate font-medium text-highlighted underline-offset-4 hover:underline focus-visible:underline" :title="session.title || session.id">{{ session.title || session.id }}</RouterLink>
+                    <span v-else class="block truncate" :title="session.title || session.id">{{ session.title || session.id }}</span>
+                  </td>
+                  <td class="py-3 pr-4 align-top"><span class="block truncate" :title="session.agent">{{ session.agent || 'Unknown agent' }}</span><span class="block truncate text-xs text-muted" :title="session.models.join(', ')">{{ session.models.length ? session.models.join(', ') : 'Model unavailable' }}</span></td>
+                  <td class="py-3 pr-4 align-top text-xs text-muted"><time :datetime="session.at" :title="new Date(session.at).toLocaleString()">{{ formatPeriod(session.at, 'hour') }}</time></td>
+                  <td class="py-3 pr-4 align-top"><span class="inline-flex items-center gap-1.5 text-xs" :class="session.status === 'failed' ? 'text-error' : 'text-muted'"><UIcon :name="statusIcons[session.status]" class="size-3.5 shrink-0" />{{ statusLabels[session.status] }}</span></td>
+                  <td class="py-3 pl-2 text-right align-top text-xs tabular-nums" :class="session.totals.totalTokensAvailable ? 'text-highlighted' : 'text-muted'">{{ formatTokenEvidence(session.totals.totalTokens, session.totals.totalTokensAvailable) }}</td>
+                  <td v-if="costSupported" class="py-3 pl-4 text-right align-top text-xs font-medium tabular-nums" :class="session.totals.costAvailable ? 'text-highlighted' : 'text-muted'">{{ formatCostEvidence(session.totals.costUsd, session.totals.costEstimated, session.totals.costAvailable) }}</td>
+                </tr>
+                <tr v-if="!summary.sessions.length"><td :colspan="costSupported ? 6 : 5" class="py-12 text-center text-sm text-muted">{{ !summary.totals.invocationsAvailable ? 'Session history is still loading. Refresh to check progress.' : search || agent || status !== 'all' ? 'No sessions match these filters.' : 'No completed sessions in this period.' }}</td></tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="mt-3 flex items-center justify-between gap-3 text-xs text-muted">
+            <span>{{ summary.sessions.length ? `${previousCursors.length * 50 + 1}–${previousCursors.length * 50 + summary.sessions.length} of ${summary.sessionCount}` : `${summary.sessionCount} sessions` }}{{ summary.totals.invocationsAvailable ? '' : ' recorded' }}</span>
+            <div class="flex gap-1">
+              <UButton label="Previous" aria-label="Previous history page" color="neutral" variant="ghost" size="xs" :disabled="!previousCursors.length || loading" @click="previousRuns" />
+              <UButton label="Next" aria-label="Next history page" color="neutral" variant="ghost" size="xs" :disabled="!summary.cursor || loading" @click="nextRuns" />
+            </div>
           </div>
         </section>
+        <details v-if="summary?.available" class="border-t border-default pt-4">
+          <summary class="cursor-pointer text-sm font-medium">Usage breakdown</summary>
+          <div class="mt-4 flex flex-col gap-6">
+            <div class="flex gap-1" aria-label="Usage metric">
+              <UButton v-for="option in metricOptions" :key="option.value" :label="option.label" color="neutral" size="xs" :variant="metric === option.value ? 'soft' : 'ghost'" :aria-pressed="metric === option.value" @click="metric = option.value" />
+            </div>
 
-        <UAlert
-          v-if="errorMessage(error)"
-          color="error"
-          variant="subtle"
-          icon="i-ph-cloud-slash-light"
-          title="Could not load usage"
-          :description="errorMessage(error)"
-          :actions="[{ label: 'Try again', icon: 'i-ph-arrows-clockwise-light', onClick: load }]"
-        />
-        <UAlert
-          v-if="summary?.partial"
-          color="warning"
-          variant="subtle"
-          icon="i-ph-warning-light"
-          title="Partial usage"
-          description="Some usage evidence is unavailable for this period. Values labeled recorded exclude missing usage."
-        />
-
-        <template v-if="loading && !summary">
-          <section class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            <USkeleton v-for="index in 4" :key="index" class="h-28 rounded-lg" />
-          </section>
-          <USkeleton class="h-72 rounded-lg" />
-        </template>
-
-        <UEmpty
-          v-else-if="!error && !summary?.available"
-          class="min-h-96"
-          icon="i-ph-chart-bar-light"
-          title="No usage recorded yet"
-          description="Usage appears here after an Agent Invocation. Provider readiness is available before the first run."
-        />
-
-        <template v-else-if="summary">
-          <section class="overflow-hidden rounded-lg border border-default bg-elevated/20">
+          <section class="overflow-hidden">
             <div class="grid lg:grid-cols-[17rem_minmax(0,1fr)]">
               <div
                 class="flex flex-col justify-between gap-8 border-b border-default p-5 lg:border-r lg:border-b-0 sm:p-6"
@@ -717,7 +673,7 @@ onBeforeUnmount(() => request?.abort());
               <p class="text-xs text-muted">Provider-reported evidence</p>
             </div>
             <dl
-              class="grid overflow-hidden rounded-lg border border-default sm:grid-cols-2 lg:grid-cols-4"
+              class="grid overflow-hidden border-t border-default sm:grid-cols-2 lg:grid-cols-4"
             >
               <div v-if="costSupported" class="border-b border-default p-4 sm:border-r">
                 <dt class="text-xs text-muted">Total cost</dt>
@@ -811,7 +767,7 @@ onBeforeUnmount(() => request?.abort());
             </dl>
           </section>
 
-          <section class="overflow-hidden rounded-lg border border-default">
+          <section class="overflow-hidden border-t border-default">
             <div
               class="flex items-center justify-between gap-4 border-b border-default px-4 py-3 sm:px-5"
             >
@@ -903,7 +859,7 @@ onBeforeUnmount(() => request?.abort());
               </table>
             </div>
           </section>
-          <section v-if="costSupported" class="overflow-hidden rounded-lg border border-default">
+          <section v-if="costSupported" class="overflow-hidden border-t border-default">
             <div class="border-b border-default px-5 py-3">
               <h2 class="text-sm font-semibold">Average cost per run</h2>
               <p class="mt-1 text-xs text-muted">
@@ -965,10 +921,9 @@ onBeforeUnmount(() => request?.abort());
           <section
             v-for="table in [
               { key: 'expensive', title: 'Most expensive runs', rows: summary.expensive },
-              { key: 'runs', title: 'Every run', rows: summary.runs },
             ].filter((table) => table.key === 'runs' || costSupported)"
             :key="table.key"
-            class="overflow-hidden rounded-lg border border-default"
+            class="overflow-hidden border-t border-default"
           >
             <div class="flex items-center justify-between gap-3 border-b border-default px-5 py-3">
               <h2 class="text-sm font-semibold">{{ table.title }}</h2>
@@ -1025,32 +980,80 @@ onBeforeUnmount(() => request?.abort());
                 </tbody>
               </table>
             </div>
-            <div
-              v-if="table.key === 'runs'"
-              class="flex items-center justify-between border-t border-default px-5 py-3"
-            >
-              <span class="text-xs text-muted">Page {{ previousCursors.length + 1 }}</span>
-              <div class="flex gap-2">
-                <UButton
-                  label="Previous"
-                  color="neutral"
-                  variant="ghost"
-                  size="sm"
-                  :disabled="!previousCursors.length || loading"
-                  @click="previousRuns"
-                /><UButton
-                  label="Next"
-                  color="neutral"
-                  variant="ghost"
-                  size="sm"
-                  :disabled="!summary.cursor || loading"
-                  @click="nextRuns"
-                />
-              </div>
-            </div>
+
           </section>
-        </template>
+
+          </div>
+        </details>
+        <details class="border-t border-default pt-4">
+          <summary class="cursor-pointer text-sm font-medium">Provider status</summary>
+
+          <p v-if="statusError" class="p-5 text-sm text-warning">{{ statusError }}</p>
+          <div v-else class="grid divide-y divide-default lg:grid-cols-2 lg:divide-y-0">
+            <article
+              v-for="status in statuses.filter((item) => !agent || item.agent === agent)"
+              :key="status.agent"
+              class="space-y-3 p-5"
+            >
+              <div class="flex items-center justify-between gap-3">
+                <div>
+                  <h3 class="text-sm font-medium">{{ status.agent }}</h3>
+                  <p class="text-xs text-muted">{{ status.provider || "Provider" }}</p>
+                </div>
+                <UBadge
+                  :color="
+                    status.readiness === 'ready' && !status.stale
+                      ? 'success'
+                      : status.readiness === 'unavailable'
+                        ? 'error'
+                        : 'neutral'
+                  "
+                  variant="subtle"
+                  >{{ status.stale ? "Stale" : status.readiness }}</UBadge
+                >
+              </div>
+              <p v-if="status.reason" class="text-xs text-muted">{{ status.reason }}</p>
+              <div class="flex flex-wrap gap-4 text-xs text-muted">
+                <span v-if="status.authenticated !== undefined"
+                  >Account: {{ status.authenticated ? "Signed in" : "Signed out" }}</span
+                >
+                <span>Checked {{ formatPeriod(status.checkedAt, "hour") }}</span>
+              </div>
+              <div
+                v-for="limit in status.usageLimits?.windows ?? []"
+                :key="limit.id"
+                class="space-y-1.5"
+              >
+                <div class="flex justify-between gap-3 text-xs">
+                  <span>{{ limit.label }}</span
+                  ><span class="tabular-nums">{{ limit.usedPercent.toFixed(0) }}% used</span>
+                </div>
+                <progress
+                  class="h-1.5 w-full accent-primary"
+                  :value="Math.min(100, Math.max(0, limit.usedPercent))"
+                  max="100"
+                  :aria-label="limit.label"
+                />
+                <p v-if="limit.resetsAt" class="text-xs text-muted">
+                  Resets {{ formatPeriod(limit.resetsAt, "hour") }}
+                </p>
+              </div>
+              <p v-if="status.usageLimits?.unavailable" class="text-xs text-muted">
+                Subscription usage
+                {{
+                  status.usageLimits.unavailable.reason === "unsupported"
+                    ? "is not reported by this provider"
+                    : "could not be checked"
+                }}.
+              </p>
+            </article>
+          </div>
+        </details>
       </main>
     </template>
   </UDashboardPanel>
 </template>
+
+<style scoped>
+:global(.dark .console-usage) { background: #000; }
+</style>

--- a/packages/vite-hub/src/console/runtime/server/usage-index.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage-index.ts
@@ -7,9 +7,12 @@ import {
   publicTotals,
   stringValue,
   usageNode,
+  usageSession,
+  usageCursor,
+  usageQueryWindow,
 } from "./usage.ts";
 
-import type { ConsoleInvocationUsage, ConsoleUsageWindow, UsageTotal } from "./usage.ts";
+import type { ConsoleInvocationUsage, UsageQuery, UsageTotal } from "./usage.ts";
 import type { Client, InStatement, Row } from "@libsql/client";
 import { viteHubErrorDiagnostics } from "../../../error-diagnostics.ts";
 
@@ -21,19 +24,13 @@ const metrics = [
   "cacheWriteTokens",
   "reasoningTokens",
 ] as const;
-const table = "vitehub_console_usage_v1";
-const dirty = "vitehub_console_usage_v1_dirty";
+const table = "vitehub_console_usage_v2";
+const dirty = "vitehub_console_usage_v2_dirty";
 const source = "vitehub_agent_invocations";
-const durations = { "24h": 1, "7d": 7, "30d": 30, "90d": 90 };
 const terminalStatuses = new Set(["completed", "failed", "cancelled"]);
-const terminalStatusList = [...terminalStatuses].map(status => `'${status}'`).join(",");
+const terminalStatusList = [...terminalStatuses].map((status) => `'${status}'`).join(",");
 
-export interface UsageQuery {
-  agentName?: string;
-  cursor?: string;
-  now?: Date | number | string;
-  window?: ConsoleUsageWindow;
-}
+export type { UsageQuery } from "./usage.ts";
 
 /** A rebuildable projection. Invocation records remain the authoritative evidence. */
 export function createConsoleUsageIndex(client: Client): {
@@ -46,19 +43,21 @@ export function createConsoleUsageIndex(client: Client): {
     (initialization ??= (async () => {
       await client.batch(
         [
+          // Older processes can still use v1 during a rollout. This index owns only v2 resources.
           `CREATE TABLE IF NOT EXISTS ${table} (
         id TEXT NOT NULL, model_key TEXT NOT NULL, sequence INTEGER NOT NULL,
         agent TEXT NOT NULL, at TEXT NOT NULL, status TEXT NOT NULL, model TEXT,
         usage TEXT, incomplete INTEGER NOT NULL, revision TEXT NOT NULL,
+        title TEXT, created_at TEXT NOT NULL, model_names TEXT NOT NULL, search_text TEXT NOT NULL,
         cost_whole TEXT, cost_fraction TEXT, cost_usd TEXT, estimated INTEGER,
-        ${metrics.map(metric => `${metric} INTEGER`).join(",")},
+        ${metrics.map((metric) => `${metric} INTEGER`).join(",")},
         PRIMARY KEY (id, model_key))`,
-          `CREATE INDEX IF NOT EXISTS ${table}_at ON ${table}(model_key, at, sequence)`,
-          `CREATE INDEX IF NOT EXISTS ${table}_agent_at ON ${table}(model_key, agent, at, sequence)`,
+          `CREATE INDEX IF NOT EXISTS ${table}_at ON ${table}(model_key, at DESC, id DESC)`,
+          `CREATE INDEX IF NOT EXISTS ${table}_agent_at ON ${table}(model_key, agent, at DESC, id DESC)`,
           `CREATE INDEX IF NOT EXISTS ${table}_cost ON ${table}(model_key, length(cost_whole) DESC, cost_whole DESC, cost_fraction DESC, sequence DESC)`,
           `CREATE TABLE IF NOT EXISTS ${dirty} (id TEXT PRIMARY KEY, generation INTEGER NOT NULL DEFAULT 1)`,
           ...["INSERT", "UPDATE"].map(
-            event => `DROP TRIGGER IF EXISTS ${table}_${event.toLowerCase()}`,
+            (event) => `DROP TRIGGER IF EXISTS ${table}_${event.toLowerCase()}`,
           ),
           ...["INSERT", "UPDATE"].map(
             (event) => `CREATE TRIGGER IF NOT EXISTS ${table}_${event.toLowerCase()}
@@ -95,6 +94,8 @@ export function createConsoleUsageIndex(client: Client): {
       await client.execute(`SELECT d.id, d.generation, s.sequence, s.agent_name, s.status, s.updated_at,
       COALESCE(json_extract(s.record, '$.completedAt'), s.updated_at) AS at,
       json_extract(s.record, '$.annotations."agent.model.id"') AS model,
+      json_extract(s.record, '$.title') AS title,
+      COALESCE(json_extract(s.record, '$.createdAt'), s.updated_at) AS created_at,
       (SELECT j.value FROM json_each(s.record, '$.observations') j
         WHERE json_extract(j.value, '$.name') = 'agent.invocation.finish'
         ORDER BY CAST(j.key AS INTEGER) DESC LIMIT 1) AS finish
@@ -105,13 +106,10 @@ export function createConsoleUsageIndex(client: Client): {
       const finishValue = stringValue(row.finish);
       const finish = finishValue === undefined ? undefined : JSON.parse(finishValue);
       const incomplete = finish?.attributes?.["vitehub.observation.truncated"] === true;
+      const configuredModel = stringValue(row.model)?.trim() || undefined;
       const usage = incomplete
         ? undefined
-        : usageNode(
-            finish?.attributes?.["usage.record"],
-            true,
-            stringValue(row.model),
-          );
+        : usageNode(finish?.attributes?.["usage.record"], true, configuredModel);
       const entries: Array<[string, ConsoleInvocationUsage | undefined]> = terminalStatuses.has(
         String(row.status),
       )
@@ -126,7 +124,7 @@ export function createConsoleUsageIndex(client: Client): {
         const amount = decimal(projected?.cost?.usd);
         const [whole, fraction = ""] = amount ? decimalString(amount).split(".") : [];
         writes.push({
-          sql: `INSERT OR REPLACE INTO ${table}(id,model_key,sequence,agent,at,status,model,usage,incomplete,revision,cost_whole,cost_fraction,cost_usd,estimated,${metrics.join(",")}) SELECT ${Array(20).fill("?").join(",")} WHERE EXISTS(SELECT 1 FROM ${dirty} d JOIN ${source} s ON s.id = d.id WHERE d.id = ? AND d.generation = ?)`,
+          sql: `INSERT OR REPLACE INTO ${table}(id,model_key,sequence,agent,at,status,model,usage,incomplete,revision,cost_whole,cost_fraction,cost_usd,estimated,title,created_at,model_names,search_text,${metrics.join(",")}) SELECT ${Array(24).fill("?").join(",")} WHERE EXISTS(SELECT 1 FROM ${dirty} d JOIN ${source} s ON s.id = d.id WHERE d.id = ? AND d.generation = ?)`,
           args: [
             row.id!,
             key,
@@ -134,7 +132,7 @@ export function createConsoleUsageIndex(client: Client): {
             row.agent_name!,
             row.at!,
             row.status!,
-            projected?.model ?? null,
+            projected?.model ?? configuredModel ?? null,
             projected ? JSON.stringify({ ...projected, calls: undefined }) : null,
             incomplete ? 1 : 0,
             row.updated_at!,
@@ -142,7 +140,20 @@ export function createConsoleUsageIndex(client: Client): {
             amount ? fraction : null,
             projected?.cost?.usd ?? null,
             projected?.cost?.estimated ? 1 : 0,
-            ...metrics.map(metric => projected?.[metric] ?? null),
+            row.title ?? null,
+            row.created_at!,
+            JSON.stringify(
+              projected
+                ? [...modelUsage(projected).keys()]
+                : configuredModel
+                  ? [configuredModel]
+                  : [],
+            ),
+            [row.id, row.agent_name, row.title]
+              .filter((value) => value != null)
+              .join("\n")
+              .toLowerCase(),
+            ...metrics.map((metric) => projected?.[metric] ?? null),
             row.id!,
             row.generation!,
           ],
@@ -163,7 +174,7 @@ export function createConsoleUsageIndex(client: Client): {
       backfill = (async () => {
         while (await projectPage()) {
           // Yield to HTTP requests, cancellation, and the bounded first-response timer.
-          await new Promise<void>(resolve => setTimeout(resolve, 0));
+          await new Promise<void>((resolve) => setTimeout(resolve, 0));
         }
       })().finally(() => {
         backfill = undefined;
@@ -174,6 +185,7 @@ export function createConsoleUsageIndex(client: Client): {
   return {
     rebuild,
     async query(options = {}) {
+      const { window, now, to, from, after } = usageQueryWindow(options);
       await initialize();
       // Large historical archives rebuild in the background. Never claim complete totals while queued.
       const rebuilding = rebuild();
@@ -188,17 +200,20 @@ export function createConsoleUsageIndex(client: Client): {
       } finally {
         clearTimeout(timer);
       }
-      const now = new Date(options.now ?? Date.now());
-      const window = options.window ?? "30d";
-      const to = now.toISOString();
-      const from = new Date(now.valueOf() - durations[window] * 86_400_000).toISOString();
-      const resolution = window === "24h" ? "hour" : "day";
+      const resolution = window.bucket;
       const bucket =
         resolution === "hour"
           ? "strftime('%Y-%m-%dT%H:00:00.000Z', at)"
           : "strftime('%Y-%m-%dT00:00:00.000Z', at)";
-      const filter = `status IN (${terminalStatusList}) AND at >= ? AND at <= ?${options.agentName ? " AND agent = ?" : ""}`;
-      const args = [from, to, ...(options.agentName ? [options.agentName] : [])];
+      const filter = `status IN (${terminalStatusList}) AND at >= ? AND at <= ?${options.agentName ? " AND agent = ?" : ""}${options.status ? " AND status = ?" : ""}${options.search ? " AND instr(search_text, ?) > 0" : ""}`;
+      const search = options.search?.toLowerCase();
+      const args = [
+        from,
+        to,
+        ...(options.agentName ? [options.agentName] : []),
+        ...(options.status ? [options.status] : []),
+        ...(search ? [search] : []),
+      ];
       const aggregate = (group: string, modelRows = false): InStatement => ({
         // Group equal decimal costs before multiplication in JS bigint. SQLite REAL must not round money.
         sql: `SELECT ${group} AS grouping, cost_usd AS cost,
@@ -215,8 +230,8 @@ export function createConsoleUsageIndex(client: Client): {
           aggregate("model_key", true),
           aggregate("agent"),
           {
-            sql: `SELECT * FROM ${table} WHERE model_key = '' AND ${filter}${options.cursor ? " AND sequence < ?" : ""} ORDER BY sequence DESC LIMIT 51`,
-            args: [...args, ...(options.cursor ? [Number(options.cursor)] : [])],
+            sql: `SELECT * FROM ${table} WHERE model_key = '' AND ${filter}${after ? " AND (at < ? OR (at = ? AND id < ?))" : ""} ORDER BY at DESC, id DESC LIMIT 51`,
+            args: [...args, ...(after ? [after.at, after.at, after.id] : [])],
           },
           {
             sql: `SELECT * FROM ${table} WHERE model_key = '' AND ${filter} AND cost_usd IS NOT NULL ORDER BY length(cost_whole) DESC, cost_whole DESC, cost_fraction DESC, sequence DESC LIMIT 10`,
@@ -229,7 +244,9 @@ export function createConsoleUsageIndex(client: Client): {
       );
       const [periods, models, agents, runs, expensive, remaining] = results;
       if (!periods || !models || !agents || !runs || !expensive || !remaining)
-        throw viteHubErrorDiagnostics.VITE_HUB_R0119({ message: "Expected six usage query results" });
+        throw viteHubErrorDiagnostics.VITE_HUB_R0119({
+          message: "Expected six usage query results",
+        });
       const incomplete = Number(remaining.rows[0]?.count) > 0;
       const groups = (rows: Row[]) => {
         const result = new Map<string, UsageTotal>();
@@ -288,6 +305,7 @@ export function createConsoleUsageIndex(client: Client): {
         partial:
           incomplete ||
           recorded < totals.invocations ||
+          (totals.invocations > 0 && !totals.totalTokensAvailable) ||
           periods.rows.some((row) => Number(row.incomplete)),
         projection: { complete: !incomplete, pending: Number(remaining.rows[0]?.count) },
         from,
@@ -304,8 +322,24 @@ export function createConsoleUsageIndex(client: Client): {
           agent,
           ...publicTotals(total, !incomplete),
         })),
+        sessionCount: totals.invocations,
+        sessions: runs.rows.slice(0, 50).map((row) => ({
+          ...usageSession(
+            {
+              id: String(row.id),
+              agentName: String(row.agent),
+              title: stringValue(row.title),
+              status: String(row.status),
+              createdAt: String(row.created_at),
+              completedAt: String(row.at),
+              updatedAt: String(row.revision),
+            },
+            row.usage ? JSON.parse(String(row.usage)) : undefined,
+          ),
+          models: JSON.parse(String(row.model_names)),
+        })),
         runs: runs.rows.slice(0, 50).map(run),
-        ...(runs.rows.length > 50 ? { cursor: String(runs.rows[49]!.sequence) } : {}),
+        ...(runs.rows.length > 50 ? { cursor: usageCursor(options, to, run(runs.rows[49]!)) } : {}),
         expensive: expensive.rows.map(run),
       };
     },

--- a/packages/vite-hub/src/console/runtime/server/usage.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.get.ts
@@ -1,7 +1,7 @@
 import { getConsoleAgentDefinition, getConsoleAgents } from "./agents.ts";
 import { getConsoleInvocations, getConsoleUsageIndex } from "./invocations.ts";
 import { assertConsoleRequest, consoleRequestURL } from "./request.ts";
-import { createUsageSummary, parseConsoleUsageWindow } from "./usage.ts";
+import { createUsageSummary, parseConsoleUsageStatus, parseConsoleUsageWindow } from "./usage.ts";
 
 import type { ConsoleRequestEvent } from "./request.ts";
 import type { AgentInvocations } from "@vite-hub/agent";
@@ -48,40 +48,60 @@ const usageHandler = async (event: ConsoleRequestEvent): Promise<Record<string, 
   const windowValue = query.get("window");
   const window = windowValue === null ? "30d" : parseConsoleUsageWindow(windowValue);
   if (!window) {
-    throw Object.assign(viteHubErrorDiagnostics.VITE_HUB_R0071({ message: "Invalid usage window" }), {
-      statusCode: 400,
-      statusMessage: "Invalid usage window",
-    });
-  }
-  const cursor = query.get("cursor") ?? undefined;
-  if (
-    cursor !== undefined &&
-    (!/^[1-9]\d*$/.test(cursor) || !Number.isSafeInteger(Number(cursor)))
-  ) {
     throw Object.assign(
-      viteHubErrorDiagnostics.VITE_HUB_R0115({ message: "Invalid usage cursor" }),
+      viteHubErrorDiagnostics.VITE_HUB_R0071({ message: "Invalid usage window" }),
+      {
+        statusCode: 400,
+        statusMessage: "Invalid usage window",
+      },
+    );
+  }
+  const statusValue = query.get("status");
+  const status = statusValue === null ? undefined : parseConsoleUsageStatus(statusValue);
+  if (statusValue !== null && !status) {
+    throw Object.assign(
+      viteHubErrorDiagnostics.VITE_HUB_R0072({ message: "Invalid usage status" }),
       { statusCode: 400 },
     );
   }
+  const search = query.get("search")?.trim() || undefined;
+  if (search && search.length > 512) {
+    throw Object.assign(
+      viteHubErrorDiagnostics.VITE_HUB_R0072({ message: "Invalid usage search" }),
+      { statusCode: 400 },
+    );
+  }
+  const cursor = query.get("cursor") ?? undefined;
   const invocations = getConsoleInvocations();
-  return cached(invocations, JSON.stringify([agentName ?? null, window, cursor]), async () => {
-    const costConfigured = (agentName ? [agentName] : getConsoleAgents()).some((name) => {
-      const capabilities = getConsoleAgentDefinition(name, "inspect")?.capabilities;
-      return (
-        Array.isArray(capabilities) && capabilities.some((capability) => (
-          capability?.id === "usage" && capability.metadata?.pricing === true
-        ))
-      );
-    });
-    const index = getConsoleUsageIndex(invocations);
-    if (index) {
-      await invocations.list({ limit: 1 }); // Initialize the owning invocation store before projecting it.
-      const result = await index.query({ agentName, cursor, window });
+  return cached(
+    invocations,
+    JSON.stringify([agentName ?? null, window, cursor, status, search]),
+    async () => {
+      const costConfigured = (agentName ? [agentName] : getConsoleAgents()).some((name) => {
+        const capabilities = getConsoleAgentDefinition(name, "inspect")?.capabilities;
+        return (
+          Array.isArray(capabilities) &&
+          capabilities.some(
+            (capability) => capability?.id === "usage" && capability.metadata?.pricing === true,
+          )
+        );
+      });
+      const index = getConsoleUsageIndex(invocations);
+      if (index) {
+        await invocations.list({ limit: 1 }); // Initialize the owning invocation store before projecting it.
+        const result = await index.query({ agentName, cursor, window, status, search });
+        return { ...result, costSupported: costConfigured || result.costSupported === true };
+      }
+      const result = await createUsageSummary(invocations, {
+        agentName,
+        cursor,
+        window,
+        status,
+        search,
+      });
       return { ...result, costSupported: costConfigured || result.costSupported === true };
-    }
-    const result = await createUsageSummary(invocations, { agentName, cursor, window });
-    return { ...result, costSupported: costConfigured || result.costSupported === true };
-  });
+    },
+  );
 };
 
 export default usageHandler;

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -1,4 +1,3 @@
-import { Buffer } from "node:buffer";
 import type {
   AgentInvocationRecord,
   AgentInvocationSummary,
@@ -183,7 +182,10 @@ export function usageQueryWindow(options: UsageQuery): {
       if (options.cursor.length > 32_768) throw new Error("Cursor too long");
       after = v.parse(
         historyCursorSchema,
-        JSON.parse(Buffer.from(options.cursor, "base64url").toString("utf8")),
+        JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(
+          Uint8Array.from(atob(options.cursor.replace(/-/g, "+").replace(/_/g, "/")),
+            (character) => character.charCodeAt(0)),
+        )),
       );
       if (
         after.scope !== cursorScope(options) ||
@@ -218,9 +220,11 @@ export function usageCursor(
   to: string,
   last: { at: string; id: string },
 ): string {
-  return Buffer.from(
+  const bytes = new TextEncoder().encode(
     JSON.stringify({ version: 1, to, at: last.at, id: last.id, scope: cursorScope(options) }),
-  ).toString("base64url");
+  );
+  return btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(""))
+    .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
 // SQLite's binary text ordering compares Unicode code points, including IDs outside the BMP.

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -1,4 +1,8 @@
-import type { AgentInvocationRecord, AgentInvocations } from "@vite-hub/agent";
+import type {
+  AgentInvocationRecord,
+  AgentInvocationSummary,
+  AgentInvocations,
+} from "@vite-hub/agent";
 import * as v from "valibot";
 import { viteHubErrorDiagnostics } from "../../../error-diagnostics.ts";
 
@@ -80,6 +84,58 @@ export interface PublicUsageTotals {
 
 export type ConsoleUsageWindow = "24h" | "7d" | "30d" | "90d";
 
+export type ConsoleUsageStatus = "completed" | "failed" | "cancelled";
+
+export interface UsageQuery {
+  agentName?: string;
+  cursor?: string;
+  now?: Date | number | string;
+  search?: string;
+  status?: ConsoleUsageStatus;
+  window?: ConsoleUsageWindow;
+}
+
+export interface ConsoleUsageSession {
+  id: string;
+  agent: string;
+  title?: string;
+  status: string;
+  at: string;
+  createdAt: string;
+  models: string[];
+  partial: boolean;
+  totals: PublicUsageTotals;
+}
+
+export function parseConsoleUsageStatus(value: string): ConsoleUsageStatus | undefined {
+  if (value === "completed" || value === "failed" || value === "cancelled") return value;
+}
+
+/** Console sessions use durable invocation IDs. Transport thread IDs do not identify provider sessions. */
+export function usageSession(
+  record: Pick<
+    AgentInvocationSummary,
+    "id" | "agentName" | "annotations" | "title" | "createdAt" | "completedAt" | "updatedAt"
+  > & { status: string },
+  usage?: ConsoleInvocationUsage,
+): ConsoleUsageSession {
+  const totals = emptyTotals();
+  if (usage) addUsage(totals, usage);
+  else addMissingUsage(totals);
+  const configuredModel = stringValue(record.annotations?.["agent.model.id"])?.trim();
+  return {
+    id: record.id,
+    agent: record.agentName ?? "",
+    ...(record.title ? { title: record.title } : {}),
+    status: record.status,
+    at: usageTime(record),
+    createdAt: record.createdAt,
+    models: usage ? [...modelUsage(usage).keys()] : configuredModel ? [configuredModel] : [],
+    partial: usage?.totalTokens === undefined,
+    totals: publicTotals(totals),
+  };
+}
+
 const usageWindows: Record<ConsoleUsageWindow, UsageWindow> = {
   "24h": { bucket: "hour", durationMs: 24 * 60 * 60 * 1_000 },
   "7d": { bucket: "day", durationMs: 7 * 24 * 60 * 60 * 1_000 },
@@ -89,6 +145,99 @@ const usageWindows: Record<ConsoleUsageWindow, UsageWindow> = {
 
 export function parseConsoleUsageWindow(value: string): ConsoleUsageWindow | undefined {
   if (value === "24h" || value === "7d" || value === "30d" || value === "90d") return value;
+}
+
+const historyCursorSchema = v.strictObject({
+  version: v.literal(1),
+  to: v.string(),
+  at: v.string(),
+  id: v.pipe(v.string(), v.minLength(1), v.maxLength(512)),
+  scope: v.string(),
+});
+
+function cursorScope(options: UsageQuery): string {
+  return JSON.stringify([
+    options.window ?? "30d",
+    options.agentName ?? null,
+    options.status ?? null,
+    options.search?.toLowerCase() ?? null,
+  ]);
+}
+
+/** Keep every page inside the first request's date window and filter scope. */
+export function usageQueryWindow(options: UsageQuery): {
+  windowName: ConsoleUsageWindow;
+  window: UsageWindow;
+  now: Date;
+  to: string;
+  from: string;
+  after: { at: string; id: string } | undefined;
+} {
+  const windowName = options.window ?? "30d";
+  const window = usageWindows[windowName];
+  if (!window) throw consoleError("Invalid usage window");
+  let after: v.InferOutput<typeof historyCursorSchema> | undefined;
+  if (options.cursor !== undefined) {
+    try {
+      if (options.cursor.length > 32_768) throw new Error("Cursor too long");
+      after = v.parse(historyCursorSchema, JSON.parse(decodeURIComponent(options.cursor)));
+      if (
+        after.scope !== cursorScope(options) ||
+        new Date(after.to).toISOString() !== after.to ||
+        new Date(after.at).toISOString() !== after.at ||
+        after.at > after.to ||
+        Date.parse(after.at) < Date.parse(after.to) - window.durationMs
+      ) {
+        throw new Error("Cursor does not match this query");
+      }
+    } catch {
+      throw Object.assign(
+        viteHubErrorDiagnostics.VITE_HUB_R0115({ message: "Invalid usage cursor" }),
+        { statusCode: 400 },
+      );
+    }
+  }
+  const now = new Date(after?.to ?? options.now ?? Date.now());
+  if (!Number.isFinite(now.valueOf())) throw consoleError("Invalid usage timestamp");
+  return {
+    windowName,
+    window,
+    now,
+    to: now.toISOString(),
+    from: new Date(now.valueOf() - window.durationMs).toISOString(),
+    after,
+  };
+}
+
+export function usageCursor(
+  options: UsageQuery,
+  to: string,
+  last: { at: string; id: string },
+): string {
+  return encodeURIComponent(
+    JSON.stringify({ version: 1, to, at: last.at, id: last.id, scope: cursorScope(options) }),
+  );
+}
+
+// SQLite's binary text ordering compares Unicode code points, including IDs outside the BMP.
+function compareText(left: string, right: string): number {
+  let a = 0;
+  let b = 0;
+  while (a < left.length && b < right.length) {
+    const l = left.codePointAt(a)!;
+    const r = right.codePointAt(b)!;
+    if (l !== r) return l - r;
+    a += l > 0xffff ? 2 : 1;
+    b += r > 0xffff ? 2 : 1;
+  }
+  return left.length - a - (right.length - b);
+}
+
+function compareSessions(
+  left: { at: string; id: string },
+  right: { at: string; id: string },
+): number {
+  return compareText(right.at, left.at) || compareText(right.id, left.id);
 }
 
 const finiteNumberSchema = v.pipe(
@@ -148,6 +297,15 @@ export function decimalString(value: Decimal): string {
   const whole = value.units / scale;
   const fraction = (value.units % scale).toString().padStart(value.scale, "0").replace(/0+$/, "");
   return fraction ? `${whole}.${fraction}` : whole.toString();
+}
+
+function compareUsageCost(left?: ConsoleUsageCost, right?: ConsoleUsageCost): number {
+  const a = decimal(left?.usd) ?? { scale: 0, units: 0n };
+  const b = decimal(right?.usd) ?? { scale: 0, units: 0n };
+  const scale = Math.max(a.scale, b.scale);
+  const difference =
+    a.units * 10n ** BigInt(scale - a.scale) - b.units * 10n ** BigInt(scale - b.scale);
+  return difference > 0n ? 1 : difference < 0n ? -1 : 0;
 }
 
 function allPresent<T>(values: Array<T | undefined>): values is T[] {
@@ -253,14 +411,26 @@ export function modelUsage(usage: ConsoleInvocationUsage): Map<string, ConsoleIn
     const model = call.model || usage.model || "Unknown model";
     groups.set(model, [...(groups.get(model) ?? []), call]);
   }
-  return new Map([...groups].map(([model, calls]) => [model, usageNode({
-    model,
-    calls: calls.map(call => ({ model: call.model, cost: call.cost, usage: {
-      ...call,
-      inputTokenDetails: { cacheReadTokens: call.cachedInputTokens, cacheWriteTokens: call.cacheWriteTokens },
-      outputTokenDetails: { reasoningTokens: call.reasoningTokens },
-    } })),
-  })!]));
+  return new Map(
+    [...groups].map(([model, calls]) => [
+      model,
+      usageNode({
+        model,
+        calls: calls.map((call) => ({
+          model: call.model,
+          cost: call.cost,
+          usage: {
+            ...call,
+            inputTokenDetails: {
+              cacheReadTokens: call.cachedInputTokens,
+              cacheWriteTokens: call.cacheWriteTokens,
+            },
+            outputTokenDetails: { reasoningTokens: call.reasoningTokens },
+          },
+        })),
+      })!,
+    ]),
+  );
 }
 
 function invocationUsageProjection(record: AgentInvocationRecord): InvocationUsageProjection {
@@ -273,7 +443,7 @@ function invocationUsageProjection(record: AgentInvocationRecord): InvocationUsa
     if (observation.attributes?.["vitehub.observation.truncated"] === true) {
       return { incomplete: true };
     }
-    if (usage) return { incomplete: false, usage };
+    return { incomplete: false, usage };
   }
   return { incomplete: false };
 }
@@ -407,21 +577,10 @@ function consoleError(message: string): Error {
 
 export async function createUsageSummary(
   invocations: AgentInvocations,
-  options: {
-    agentName?: string;
-    cursor?: string;
-    now?: Date | number | string;
-    window?: ConsoleUsageWindow;
-  } = {},
+  options: UsageQuery = {},
 ): Promise<Record<string, unknown>> {
-  const windowName = options.window ?? "30d";
-  const window = usageWindows[windowName];
-  if (!window) throw consoleError("Invalid usage window");
-  const now = options.now instanceof Date ? options.now : new Date(options.now ?? Date.now());
-  if (!Number.isFinite(now.valueOf())) throw consoleError("Invalid usage timestamp");
-  const to = now.toISOString();
-  const fromDate = new Date(now.valueOf() - window.durationMs);
-  const from = fromDate.toISOString();
+  const { window, now, to, from, after } = usageQueryWindow(options);
+  const fromDate = new Date(from);
   const totals = emptyTotals();
   const buckets = new Map<string, UsageTotal>();
   const bucketModels = new Map<string, Map<string, UsageTotal>>();
@@ -434,9 +593,26 @@ export async function createUsageSummary(
     at: string;
     usage?: ConsoleInvocationUsage;
   }> = [];
+  const sessions: ConsoleUsageSession[] = [];
   let cursor: string | undefined;
   let partial = false;
   const scanTruncated = false;
+
+  const search = options.search?.toLowerCase();
+  const matches = (summary: AgentInvocationSummary) => {
+    const timestamp = Date.parse(usageTime(summary));
+    return (
+      ["completed", "failed", "cancelled"].includes(summary.status) &&
+      (!options.status || summary.status === options.status) &&
+      (!options.agentName || summary.agentName === options.agentName) &&
+      (!search ||
+        [summary.id, summary.title ?? "", summary.agentName ?? ""].some((value) =>
+          value.toLowerCase().includes(search),
+        )) &&
+      timestamp >= fromDate.valueOf() &&
+      timestamp <= now.valueOf()
+    );
+  };
 
   do {
     const page = await invocations.list({
@@ -444,14 +620,7 @@ export async function createUsageSummary(
       ...(cursor === undefined ? {} : { cursor }),
       limit: 100,
     });
-    const summaries = page.invocations.filter((summary) => {
-      const timestamp = Date.parse(usageTime(summary));
-      return (
-        ["completed", "failed", "cancelled"].includes(summary.status) &&
-        timestamp >= fromDate.valueOf() &&
-        timestamp <= now.valueOf()
-      );
-    });
+    const summaries = page.invocations.filter(matches);
     const records = await Promise.all(summaries.map((summary) => invocations.get(summary.id)));
     for (const [index, record] of records.entries()) {
       if (!record) {
@@ -462,14 +631,22 @@ export async function createUsageSummary(
           addMissingUsage(bucketTotal);
           buckets.set(bucket, bucketTotal);
         }
+        sessions.push(usageSession(summaries[index]!));
+        const agent = summaries[index]!.agentName ?? "";
+        const agentTotal = agents.get(agent) ?? emptyTotals();
+        addMissingUsage(agentTotal);
+        agents.set(agent, agentTotal);
         partial = true;
         continue;
       }
+      if (!matches(record)) continue;
       const bucket = bucketStart(usageTime(record), window.bucket);
       if (!bucket) continue;
       const bucketTotal = buckets.get(bucket) ?? emptyTotals();
       const projection = invocationUsageProjection(record);
       const usage = projection.usage;
+      partial ||= usage?.totalTokens === undefined;
+      sessions.push(usageSession(record, usage));
       runs.push({
         id: record.id,
         agent: record.agentName ?? "",
@@ -506,21 +683,24 @@ export async function createUsageSummary(
   } while (cursor !== undefined);
 
   const publicTotal = publicTotals(totals, !scanTruncated);
+  sessions.sort(compareSessions);
+  runs.sort(compareSessions);
+  const page = sessions
+    .filter((session) => !after || compareSessions(session, after) > 0)
+    .slice(0, 51);
+  const pageIds = new Set(page.slice(0, 50).map((session) => session.id));
 
   return {
     available: totals.invocations > 0,
+    sessions: page.slice(0, 50),
+    sessionCount: sessions.length,
     costSupported: totals.pricedInvocations > 0,
     agents: [...agents].map(([agent, total]) => ({ agent, ...publicTotals(total) })),
-    runs: runs.slice(
-      options.cursor ? Number(options.cursor) : 0,
-      (options.cursor ? Number(options.cursor) : 0) + 50,
-    ),
-    ...(runs.length > (options.cursor ? Number(options.cursor) : 0) + 50
-      ? { cursor: String((options.cursor ? Number(options.cursor) : 0) + 50) }
-      : {}),
+    runs: runs.filter((run) => pageIds.has(run.id)),
+    ...(page.length > 50 ? { cursor: usageCursor(options, to, page[49]!) } : {}),
     expensive: runs
       .filter((run) => run.usage?.cost)
-      .sort((a, b) => Number(b.usage?.cost?.usd) - Number(a.usage?.cost?.usd))
+      .sort((a, b) => compareUsageCost(b.usage?.cost, a.usage?.cost))
       .slice(0, 10),
     buckets: bucketStarts(from, to, window.bucket).map((start) => ({
       start,

--- a/packages/vite-hub/src/console/runtime/server/usage.ts
+++ b/packages/vite-hub/src/console/runtime/server/usage.ts
@@ -1,3 +1,4 @@
+import { Buffer } from "node:buffer";
 import type {
   AgentInvocationRecord,
   AgentInvocationSummary,
@@ -180,7 +181,10 @@ export function usageQueryWindow(options: UsageQuery): {
   if (options.cursor !== undefined) {
     try {
       if (options.cursor.length > 32_768) throw new Error("Cursor too long");
-      after = v.parse(historyCursorSchema, JSON.parse(decodeURIComponent(options.cursor)));
+      after = v.parse(
+        historyCursorSchema,
+        JSON.parse(Buffer.from(options.cursor, "base64url").toString("utf8")),
+      );
       if (
         after.scope !== cursorScope(options) ||
         new Date(after.to).toISOString() !== after.to ||
@@ -214,9 +218,9 @@ export function usageCursor(
   to: string,
   last: { at: string; id: string },
 ): string {
-  return encodeURIComponent(
+  return Buffer.from(
     JSON.stringify({ version: 1, to, at: last.at, id: last.id, scope: cursorScope(options) }),
-  );
+  ).toString("base64url");
 }
 
 // SQLite's binary text ordering compares Unicode code points, including IDs outside the BMP.

--- a/packages/vite-hub/test/console-usage-history-route.test.ts
+++ b/packages/vite-hub/test/console-usage-history-route.test.ts
@@ -1,0 +1,60 @@
+import { expect, it } from "vitest";
+import { createMemoryAgentInvocationStore, defineAgentInvocations } from "@vite-hub/agent/server";
+import { installConsoleAgentDefinitions } from "../src/console/runtime/server/agents.ts";
+import usageHandler from "../src/console/runtime/server/usage.get.ts";
+
+it("validates session history filters and keeps filtered responses separate in the cache", async () => {
+  const store = createMemoryAgentInvocationStore();
+  const timestamp = new Date().toISOString();
+  for (const [id, status, title] of [
+    ["finished", "completed", "Release"],
+    ["failed", "failed", "Investigate"],
+  ] as const) {
+    await store.create({
+      id,
+      agentName: "history",
+      status,
+      title,
+      createdAt: timestamp,
+      completedAt: timestamp,
+      updatedAt: timestamp,
+      traceId: id,
+      observations: [],
+    });
+  }
+  const invocations = defineAgentInvocations({ store });
+  installConsoleAgentDefinitions(
+    [
+      {
+        definition: {
+          invocations,
+          async resolve() {
+            throw new Error("History inspection must not invoke the Agent");
+          },
+        },
+        fallbackName: "history",
+      },
+    ],
+    { projectRoot: process.cwd(), invoke: false },
+  );
+  const request = (query: string) =>
+    usageHandler({
+      method: "GET",
+      req: { url: `http://localhost/api/_vitehub/console/usage?${query}` },
+    });
+  expect(await request("status=failed")).toMatchObject({
+    sessionCount: 1,
+    sessions: [{ id: "failed" }],
+    totals: { invocations: 1 },
+  });
+  expect(await request("search=release")).toMatchObject({
+    sessionCount: 1,
+    sessions: [{ id: "finished" }],
+    totals: { invocations: 1 },
+  });
+  expect(await request("")).toMatchObject({ sessionCount: 2, totals: { invocations: 2 } });
+  await expect(request("cursor=50")).rejects.toMatchObject({ statusCode: 400 });
+  await expect(request("cursor=%25")).rejects.toMatchObject({ statusCode: 400 });
+  await expect(request("status=running")).rejects.toMatchObject({ statusCode: 400 });
+  await expect(request(`search=${"x".repeat(513)}`)).rejects.toMatchObject({ statusCode: 400 });
+});

--- a/packages/vite-hub/test/console-usage-history-route.test.ts
+++ b/packages/vite-hub/test/console-usage-history-route.test.ts
@@ -1,3 +1,8 @@
+import { createRpcClient } from "devframe/rpc/client";
+import { createSseRpcChannel } from "devframe/rpc/transports/sse-client";
+import { consoleRpcMethods } from "../src/console/runtime/rpc.ts";
+import type { ConsoleRpcFunctions } from "../src/console/runtime/rpc.ts";
+import { createConsoleDevframeHandler } from "../src/console/runtime/server/devframe.ts";
 import { expect, it } from "vitest";
 import { createMemoryAgentInvocationStore, defineAgentInvocations } from "@vite-hub/agent/server";
 import { installConsoleAgentDefinitions } from "../src/console/runtime/server/agents.ts";
@@ -58,3 +63,57 @@ it("validates session history filters and keeps filtered responses separate in t
   await expect(request("status=running")).rejects.toMatchObject({ statusCode: 400 });
   await expect(request(`search=${"x".repeat(513)}`)).rejects.toMatchObject({ statusCode: 400 });
 });
+
+
+it.each(["100%_", "%41", "雪% &+?#"])(
+  "round-trips history cursors through HTTP and RPC with filter %s",
+  async (filter) => {
+    const store = createMemoryAgentInvocationStore();
+    const timestamp = new Date().toISOString();
+    for (let i = 0; i < 51; i++) {
+      const id = `session-${String(i).padStart(2, "0")}`;
+      await store.create({
+        id, agentName: filter, title: filter, status: "completed",
+        createdAt: timestamp, completedAt: timestamp, updatedAt: timestamp,
+        traceId: id, observations: [],
+      });
+    }
+    const invocations = defineAgentInvocations({ store });
+    installConsoleAgentDefinitions([{
+      definition: {
+        invocations,
+        async resolve() { throw new Error("History must not invoke the Agent"); },
+      },
+      fallbackName: filter,
+    }], { projectRoot: process.cwd(), invoke: false });
+    const query = { agent: filter, search: filter };
+    const request = (queryString: string) => usageHandler({
+      method: "GET",
+      req: { url: `http://localhost/api/_vitehub/console/usage?${queryString}` },
+    });
+    const first = await request(new URLSearchParams(query).toString());
+    expect(first.sessions).toHaveLength(50);
+    expect(first.cursor).toEqual(expect.any(String));
+    const cursor = String(first.cursor);
+    const expected = { sessions: [{ id: "session-00" }], from: first.from, to: first.to };
+    // Direct HTTP callers paste the returned opaque token into the raw URL.
+    expect(await request(`${new URLSearchParams(query)}&cursor=${cursor}`)).toMatchObject(expected);
+    const handler = createConsoleDevframeHandler();
+    const channel = createSseRpcChannel({
+      fetch: async (input, init) => {
+        const request = new Request(input, init);
+        // SAFETY: Supply the request fields read by the H3 adapter.
+        return (await handler({ method: request.method, req: request } as never)) as Response;
+      },
+      url: "http://vitehub.local/_vitehub/rpc/__sse",
+    });
+    const client = createRpcClient<ConsoleRpcFunctions>({}, { channel });
+    try {
+      expect(await client.$call(consoleRpcMethods.usage, { query: { ...query, cursor } }))
+        .toMatchObject({ ok: true, value: expected });
+    } finally {
+      channel.close();
+      await handler.close();
+    }
+  },
+);

--- a/packages/vite-hub/test/console-usage-index.test.ts
+++ b/packages/vite-hub/test/console-usage-index.test.ts
@@ -108,7 +108,7 @@ describe("Console persisted usage index", () => {
           sql: `UPDATE vitehub_agent_invocations SET updated_at = ? WHERE status = 'running'`,
           args: [new Date(Date.parse(now) + revision++).toISOString()],
         });
-        await new Promise<void>(resolve => setTimeout(resolve, 0));
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
       }
     })();
     try {
@@ -143,6 +143,42 @@ describe("Console persisted usage index", () => {
     await client.execute("DELETE FROM vitehub_agent_invocations WHERE id = 'run'");
     expect(await replacement.query({ now })).toMatchObject({ totals: { invocations: 0 } });
   });
+  it("preserves the v1 projection while old and new processes overlap", async () => {
+    const { client, insert, index } = await fixture();
+    await insert("shared", priced("0.1"));
+    await client.batch(
+      [
+        `CREATE TABLE vitehub_console_usage_v1 (id TEXT PRIMARY KEY, usage TEXT)`,
+        `INSERT INTO vitehub_console_usage_v1 VALUES ('shared', 'old projection')`,
+        `CREATE TABLE vitehub_console_usage_v1_dirty (id TEXT PRIMARY KEY, generation INTEGER NOT NULL DEFAULT 1)`,
+        `CREATE TRIGGER vitehub_console_usage_v1_update AFTER UPDATE ON vitehub_agent_invocations BEGIN
+        INSERT INTO vitehub_console_usage_v1_dirty(id) VALUES (NEW.id)
+        ON CONFLICT(id) DO UPDATE SET generation = generation + 1;
+      END`,
+      ],
+      "write",
+    );
+    await index.rebuild();
+    expect(await index.query({ now })).toMatchObject({ sessionCount: 1 });
+    expect(
+      (await client.execute(`SELECT usage FROM vitehub_console_usage_v1 WHERE id = 'shared'`)).rows,
+    ).toEqual([{ usage: "old projection" }]);
+    await client.execute(
+      `UPDATE vitehub_agent_invocations SET record = json_set(record, '$.title', 'Updated') WHERE id = 'shared'`,
+    );
+    for (const version of ["v1", "v2"]) {
+      expect(
+        (await client.execute(`SELECT id FROM vitehub_console_usage_${version}_dirty`)).rows,
+      ).toEqual([{ id: "shared" }]);
+    }
+    expect(await index.query({ now })).toMatchObject({
+      sessions: [{ id: "shared", title: "Updated" }],
+    });
+    expect(
+      (await client.execute(`SELECT usage FROM vitehub_console_usage_v1 WHERE id = 'shared'`)).rows,
+    ).toEqual([{ usage: "old projection" }]);
+  });
+
   it("uses the same agent and date filters for aggregates and pages", async () => {
     const { insert, index } = await fixture();
     for (let i = 0; i < 55; i++) await insert(`run-${i}`, priced("0.000000000000001"));
@@ -161,6 +197,113 @@ describe("Console persisted usage index", () => {
     expect(next.runs).toHaveLength(5);
     expect(next.cursor).toBeUndefined();
   });
+  it("keeps sessions with shared titles and threads distinct, including missing usage", async () => {
+    const { client, insert, index } = await fixture();
+    await insert("a", priced("0"));
+    await insert("b", undefined, "failed");
+    await insert("c", priced("0.2"), "completed", "other");
+    await client.execute(
+      `UPDATE vitehub_agent_invocations SET record = json_set(record, '$.title', 'Same title', '$.threadId', 'shared-thread', '$.createdAt', '${now}')`,
+    );
+    await index.rebuild();
+    const summary = await index.query({ now });
+    expect(summary).toMatchObject({
+      available: true,
+      sessionCount: 3,
+      sessions: [
+        {
+          id: "c",
+          agent: "other",
+          title: "Same title",
+          totals: { costUsd: "0.2", costAvailable: true },
+        },
+        {
+          id: "b",
+          models: ["model"],
+          title: "Same title",
+          partial: true,
+          totals: { totalTokensAvailable: false, costAvailable: false },
+        },
+        {
+          id: "a",
+          title: "Same title",
+          partial: false,
+          totals: { costUsd: "0", costAvailable: true },
+        },
+      ],
+    });
+    await client.execute(
+      `UPDATE vitehub_agent_invocations SET record = json_set(record, '$.title', 'Änderung') WHERE id = 'a'`,
+    );
+    expect(await index.query({ now, search: "änderung" })).toMatchObject({
+      sessionCount: 1,
+      sessions: [{ id: "a", title: "Änderung" }],
+    });
+    await client.execute(`DELETE FROM vitehub_agent_invocations WHERE id = 'a'`);
+    expect(await index.query({ now, search: "änderung" })).toMatchObject({
+      sessionCount: 0,
+      sessions: [],
+    });
+  });
+
+  it("distinguishes partial provider usage from recorded zero usage", async () => {
+    const { insert, index } = await fixture();
+    await insert("partial", { usage: { inputTokens: 12 } });
+    await insert("zero", { usage: { totalTokens: 0 } });
+    await index.rebuild();
+    expect(await index.query({ now })).toMatchObject({
+      partial: true,
+      sessions: [
+        { id: "zero", partial: false, totals: { totalTokens: 0, totalTokensAvailable: true } },
+        {
+          id: "partial",
+          partial: true,
+          totals: { inputTokens: 12, inputTokensAvailable: true, totalTokensAvailable: false },
+        },
+      ],
+    });
+  });
+
+  it("applies literal search, status, Agent, and time filters to all pages and totals", async () => {
+    const { client, insert, index } = await fixture();
+    for (let i = 0; i < 55; i++)
+      await insert(`run-${String(i).padStart(2, "0")}`, priced("0.000000000000001"), "failed");
+    await insert("completed", priced("10"));
+    await insert("other", priced("10"), "failed", "other");
+    await insert("old", priced("10"), "failed", "bot", "2026-08-01T00:00:00.000Z");
+    await client.execute(
+      `UPDATE vitehub_agent_invocations SET record = json_set(record, '$.title', 'Fix 100%_complete')`,
+    );
+    await insert("wrong-title", priced("10"), "failed");
+    await index.rebuild();
+    const options = {
+      now,
+      window: "24h" as const,
+      agentName: "bot",
+      status: "failed" as const,
+      search: "100%_",
+    };
+    const first = await index.query(options);
+    expect(first).toMatchObject({
+      sessionCount: 55,
+      totals: { invocations: 55, costUsd: "0.000000000000055" },
+    });
+    expect(first.sessions).toHaveLength(50);
+    const second = await index.query({ ...options, cursor: String(first.cursor) });
+    expect(second).toMatchObject({
+      sessionCount: 55,
+      totals: first.totals,
+      sessions: [
+        { id: "run-04" },
+        { id: "run-03" },
+        { id: "run-02" },
+        { id: "run-01" },
+        { id: "run-00" },
+      ],
+    });
+    expect(second.cursor).toBeUndefined();
+  });
+
   it("aggregates more than 100,000 runs without a scan ceiling", async () => {
     const { client, index } = await fixture();
     const record = JSON.stringify({

--- a/packages/vite-hub/test/console-usage-pagination.test.ts
+++ b/packages/vite-hub/test/console-usage-pagination.test.ts
@@ -1,0 +1,115 @@
+import { createClient } from "@libsql/client";
+import { createLibsqlAgentInvocationStore } from "@vite-hub/agent/invocations/sqlite";
+import { defineAgentInvocations } from "@vite-hub/agent/server";
+import { expect, it } from "vitest";
+import { createConsoleUsageIndex } from "../src/console/runtime/server/usage-index.ts";
+import { createUsageSummary } from "../src/console/runtime/server/usage.ts";
+import type { UsageQuery } from "../src/console/runtime/server/usage.ts";
+
+const timestamp = "2026-09-05T12:00:00.000Z";
+
+it.each(["index", "custom"] as const)(
+  "keeps %s history pages stable across insertions and deletions",
+  async (mode) => {
+    const client = createClient({ url: "file::memory:" });
+    try {
+      const store = createLibsqlAgentInvocationStore({
+        client,
+        maxAgeMs: false,
+        maxRecords: false,
+      });
+      const invocations = defineAgentInvocations({ store });
+      const index = createConsoleUsageIndex(client);
+      const query = (options: UsageQuery) =>
+        mode === "index" ? index.query(options) : createUsageSummary(invocations, options);
+      const insert = (id: string, at = timestamp) =>
+        store.create({
+          id,
+          agentName: "bot",
+          title: "Task",
+          status: "completed",
+          traceId: id,
+          createdAt: at,
+          completedAt: at,
+          updatedAt: at,
+          observations: [
+            {
+              name: "agent.invocation.finish",
+              sequence: 1,
+              timestamp: at,
+              type: "lifecycle",
+              attributes: { "usage.record": { usage: { totalTokens: 5 } } },
+            },
+          ],
+        });
+      for (let i = 0; i < 55; i++) await insert(`session-${String(i).padStart(2, "0")}`);
+      if (mode === "index") await index.rebuild();
+      const options = {
+        now: timestamp,
+        window: "24h" as const,
+        agentName: "bot",
+        status: "completed" as const,
+        search: "Task",
+      };
+      const first = await query(options);
+      expect(first.sessions).toHaveLength(50);
+      const cursor = String(first.cursor);
+      expect(cursor).not.toMatch(/^\d+$/);
+
+      // Backfilled records can enter before the page boundary. Normal new completions are after the fixed cutoff.
+      await insert("zz-backfill");
+      await insert("zz-later", "2026-09-05T12:00:01.000Z");
+      const nextOptions = { ...options, now: "2026-09-07T12:00:00.000Z", cursor };
+      const second = await query(nextOptions);
+      expect(second).toMatchObject({
+        from: first.from,
+        to: first.to,
+        sessionCount: 56,
+        totals: { invocations: 56, totalTokens: 280 },
+        sessions: [
+          { id: "session-04" },
+          { id: "session-03" },
+          { id: "session-02" },
+          { id: "session-01" },
+          { id: "session-00" },
+        ],
+      });
+      expect(second.cursor).toBeUndefined();
+
+      // Removing both a seen row and the boundary row must not shift the next page.
+      await client.execute(
+        `DELETE FROM vitehub_agent_invocations WHERE id IN ('session-54', 'session-05', 'session-02')`,
+      );
+      expect(await query(nextOptions)).toMatchObject({
+        from: first.from,
+        to: first.to,
+        sessionCount: 53,
+        totals: { invocations: 53, totalTokens: 265 },
+        sessions: [
+          { id: "session-04" },
+          { id: "session-03" },
+          { id: "session-01" },
+          { id: "session-00" },
+        ],
+      });
+
+      for (const changed of [
+        { window: "7d" as const },
+        { agentName: "other" },
+        { status: "failed" as const },
+        { search: "different" },
+      ]) {
+        await expect(query({ ...nextOptions, ...changed })).rejects.toMatchObject({
+          statusCode: 400,
+        });
+      }
+      for (const invalid of ["50", "%", encodeURIComponent(JSON.stringify({ version: 1 }))]) {
+        await expect(query({ ...options, cursor: invalid })).rejects.toMatchObject({
+          statusCode: 400,
+        });
+      }
+    } finally {
+      client.close();
+    }
+  },
+);

--- a/packages/vite-hub/test/console-usage-workerd.test.ts
+++ b/packages/vite-hub/test/console-usage-workerd.test.ts
@@ -1,0 +1,64 @@
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { Miniflare } from "miniflare";
+import { ModuleKind, ScriptTarget, transpileModule } from "typescript";
+import * as v from "valibot";
+import { expect, it } from "vitest";
+
+it("paginates Console usage in Cloudflare without Node compatibility", async () => {
+  const root = resolve(import.meta.dirname, "..");
+  const sourceModule = async (path: string) => ({
+    type: "ESModule" as const,
+    path: resolve(root, path),
+    contents: transpileModule(await readFile(resolve(root, path), "utf8"), {
+      compilerOptions: { module: ModuleKind.ESNext, target: ScriptTarget.ES2023 },
+    }).outputText,
+  });
+  // Load the real usage module and its dependencies without bundling or Node shims.
+  const worker = new Miniflare({
+    compatibilityDate: "2026-04-20",
+    compatibilityFlags: [],
+    modulesRoot: root,
+    modules: [
+      {
+        type: "ESModule",
+        path: resolve(root, "worker.mjs"),
+        contents: `
+          import { usageCursor, usageQueryWindow } from "./src/console/runtime/server/usage.ts";
+          export default {
+            async fetch(request) {
+              const query = await request.json();
+              const to = "2026-09-05T12:00:00.000Z";
+              const last = { at: to, id: "雪🌍%41" };
+              const cursor = query.cursor ?? usageCursor(query, to, last);
+              const page = usageQueryWindow({ ...query, cursor });
+              return Response.json({ cursor, after: page.after, to: page.to, buffer: typeof Buffer });
+            }
+          };
+        `,
+      },
+      await sourceModule("src/console/runtime/server/usage.ts"),
+      await sourceModule("src/error-diagnostics.ts"),
+      { type: "ESModule", path: resolve(root, "src/console/runtime/server/valibot"), contents: await readFile(new URL(import.meta.resolve("valibot")), "utf8") },
+      { type: "ESModule", path: resolve(root, "src/nostics"), contents: await readFile(new URL(import.meta.resolve("nostics")), "utf8") },
+    ],
+  });
+  try {
+    const query = { agentName: "雪🌍%41", search: "100%_ &+?#" };
+    const request = (body: object) => worker.dispatchFetch("http://console.test", {
+      method: "POST", body: JSON.stringify(body),
+    });
+    const first = await request(query);
+    expect(first.status).toBe(200);
+    const page = await first.json();
+    const { cursor } = v.parse(v.object({ cursor: v.string() }), page);
+    expect(page).toMatchObject({
+      buffer: "undefined", after: { id: "雪🌍%41", at: "2026-09-05T12:00:00.000Z" },
+    });
+    const next = await request({ ...query, cursor });
+    expect(next.status).toBe(200);
+    expect(await next.json()).toEqual(page);
+  } finally {
+    await worker.dispose();
+  }
+}, 30_000);

--- a/packages/vite-hub/test/console-usage.test.ts
+++ b/packages/vite-hub/test/console-usage.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createMemoryAgentInvocationStore, defineAgentInvocations } from "@vite-hub/agent/server";
 
 import { createUsageSummary, invocationUsage } from "../src/console/runtime/server/usage.ts";
 
@@ -249,6 +250,132 @@ describe("Console usage projection", () => {
       available: true,
       partial: true,
       totals: { invocations: 1, totalTokensAvailable: false },
+    });
+  });
+});
+
+describe("Console session usage history with a custom store", () => {
+  it("keeps missing usage sessions and applies filters to the complete history", async () => {
+    const store = createMemoryAgentInvocationStore();
+    const invocations = defineAgentInvocations({ store });
+    for (let index = 0; index < 55; index++) {
+      const record = invocationRecord({ totalTokens: 10 });
+      await store.create({
+        ...record,
+        id: `session-${String(index).padStart(2, "0")}`,
+        title: "Shared 100%_title",
+        annotations: { "agent.model.id": "known-model" },
+        threadId: "shared-thread",
+        agentName: "bot",
+        status: "failed",
+        ...(index === 0 ? { observations: [] } : {}),
+      });
+    }
+    await store.create({
+      ...invocationRecord({ totalTokens: 999 }),
+      id: "other-agent",
+      title: "Shared 100%_title",
+      threadId: "shared-thread",
+      agentName: "other",
+      status: "failed",
+    });
+    await store.create({
+      ...invocationRecord({ totalTokens: 999 }),
+      id: "completed",
+      title: "Shared 100%_title",
+      agentName: "bot",
+    });
+    const options = {
+      now: "2026-08-27T12:00:00.000Z",
+      window: "24h" as const,
+      agentName: "bot",
+      status: "failed" as const,
+      search: "100%_",
+    };
+    const first = await createUsageSummary(invocations, options);
+    expect(first).toMatchObject({
+      available: true,
+      sessionCount: 55,
+      totals: { invocations: 55, totalTokens: 540, totalTokensAvailable: false },
+    });
+    expect(first.sessions).toHaveLength(50);
+    const second = await createUsageSummary(invocations, {
+      ...options,
+      cursor: String(first.cursor),
+    });
+    expect(second).toMatchObject({
+      sessionCount: 55,
+      totals: first.totals,
+      sessions: [
+        { id: "session-04" },
+        { id: "session-03" },
+        { id: "session-02" },
+        { id: "session-01" },
+        {
+          id: "session-00",
+          models: ["known-model"],
+          title: "Shared 100%_title",
+          partial: true,
+          totals: { totalTokensAvailable: false },
+        },
+      ],
+    });
+    expect(second.cursor).toBeUndefined();
+  });
+
+  it("rechecks filters when a session title changes after listing", async () => {
+    const store = createMemoryAgentInvocationStore();
+    const record = invocationRecord({ totalTokens: 10 });
+    await store.create({ ...record, title: "Old title" });
+    const invocations = defineAgentInvocations({ store });
+    const list = invocations.list.bind(invocations);
+    vi.spyOn(invocations, "list").mockImplementationOnce(async (options) => {
+      const page = await list(options);
+      await store.update(record.id, {
+        timestamp: record.updatedAt,
+        observation: {
+          name: "agent.title.recorded",
+          type: "lifecycle",
+          sequence: 2,
+          timestamp: record.updatedAt,
+          attributes: { "vitehub.session.title": "New title" },
+        },
+      });
+      return page;
+    });
+    expect(
+      await createUsageSummary(invocations, { now: "2026-08-27T12:00:00.000Z", search: "old" }),
+    ).toMatchObject({ sessionCount: 0, sessions: [], totals: { invocations: 0 } });
+  });
+
+  it("uses the final finish evidence and preserves decimal ordering", async () => {
+    const record = invocationRecord({ totalTokens: 10 });
+    expect(
+      invocationUsage({
+        ...record,
+        observations: [
+          ...record.observations,
+          { ...record.observations[0]!, attributes: {}, sequence: 2 },
+        ],
+      }),
+    ).toBeUndefined();
+    const store = createMemoryAgentInvocationStore();
+    for (const [id, usd] of [
+      ["higher", "1.000000000000000002"],
+      ["lower", "1.000000000000000001"],
+    ]) {
+      await store.create({
+        ...invocationRecordFromUsageRecord({ cost: { usd }, usage: { totalTokens: 10 } }),
+        id: id!,
+      });
+    }
+    expect(
+      await createUsageSummary(defineAgentInvocations({ store }), {
+        now: "2026-08-27T12:00:00.000Z",
+      }),
+    ).toMatchObject({
+      expensive: [{ id: "higher" }, { id: "lower" }],
+      totals: { costUsd: "2.000000000000000003" },
     });
   });
 });

--- a/playground/console/README.md
+++ b/playground/console/README.md
@@ -11,7 +11,9 @@ load directly from source, so UI edits use Vite hot module replacement.
 
 The Agent Invocation records live in `console.fixture.json`. `mock-api.ts` adds
 the read-only Usage, KV, Workflow, Queue, and search responses needed by the
-Console. This playground does not change the Console routes generated for Vite
+Console. `rpc.ts` connects the Console's SSE RPC transport to those local fixture
+routes. Usage filters and pagination use the real usage aggregation code.
+This playground does not change the Console routes generated for Vite
 or Nuxt applications.
 
 To share the running playground temporarily, expose the same local server:

--- a/playground/console/mock-api.ts
+++ b/playground/console/mock-api.ts
@@ -5,6 +5,7 @@ import { parseConsoleFixture } from "../../packages/vite-hub/src/console/fixture
 import {
   createUsageSummary,
   invocationUsage,
+  parseConsoleUsageStatus,
   parseConsoleUsageWindow,
 } from "../../packages/vite-hub/src/console/runtime/server/usage.ts"
 import { consoleSearchExcerpt } from "../../packages/vite-hub/src/console/runtime/server/search.ts"
@@ -195,6 +196,17 @@ async function handleAPI(request: IncomingMessage, response: ServerResponse, url
     return true
   }
 
+  if (path === "/api/_vitehub/console/status") {
+    json(response, { agents: [...new Set(fixture.invocations.map(record => record.agentName).filter(Boolean))].map(agent => ({
+      agent,
+      checkedAt: "2026-08-30T18:00:00.000Z",
+      readiness: "unsupported",
+      stale: false,
+      reason: "Synthetic playground data",
+    })) })
+    return true
+  }
+
   if (path === "/api/_vitehub/console/invocations") {
     const ids = url.searchParams.getAll("id")
     if (ids.length) {
@@ -244,6 +256,9 @@ async function handleAPI(request: IncomingMessage, response: ServerResponse, url
     }
     json(response, await createUsageSummary(invocations, {
       agentName: url.searchParams.get("agent") || undefined,
+      cursor: url.searchParams.get("cursor") || undefined,
+      search: url.searchParams.get("search") || undefined,
+      status: parseConsoleUsageStatus(url.searchParams.get("status") || ""),
       now: "2026-08-30T18:00:00.000Z",
       window,
     }))

--- a/playground/console/package.json
+++ b/playground/console/package.json
@@ -11,6 +11,8 @@
   "devDependencies": {
     "@iconify-json/ph": "catalog:ui",
     "@vitejs/plugin-vue": "^6.0.8",
+    "devframe": "catalog:runtime",
+    "h3": "catalog:unjs",
     "vite": "catalog:vite"
   },
   "engines": {

--- a/playground/console/rpc.ts
+++ b/playground/console/rpc.ts
@@ -24,12 +24,12 @@ export function consoleMockRPC(): Plugin {
               type: "query",
               jsonSerializable: true,
               async handler(input: ConsoleRpcInput = {}): Promise<ConsoleRpcResult> {
-                const address = server.httpServer?.address()
-                if (!address || typeof address === "string") throw new Error("Playground server is not listening")
+                const serverUrl = server.resolvedUrls?.local[0] ?? server.resolvedUrls?.network[0]
+                if (!serverUrl) throw new Error("Playground server is not listening")
                 const path = operation === "invocation" ? `invocations/${encodeURIComponent(input.id ?? "")}`
                   : operation === "agentInvocations" ? `agents/${input.agent ?? ""}/invocations`
                     : operation === "invocationCapabilities" ? "invocation-capabilities" : operation
-                const url = new URL(`/api/_vitehub/console/${path}`, `http://127.0.0.1:${address.port}`)
+                const url = new URL(`/api/_vitehub/console/${path}`, serverUrl)
                 for (const [key, value] of Object.entries(input.query ?? {})) {
                   for (const entry of Array.isArray(value) ? value : [value]) url.searchParams.append(key, entry)
                 }

--- a/playground/console/rpc.ts
+++ b/playground/console/rpc.ts
@@ -1,0 +1,63 @@
+import { defineDevframe, defineRpcFunction } from "devframe"
+import { initDevframe } from "devframe/initiate"
+import { H3, fromWebHandler } from "h3"
+import { toNodeHandler } from "h3/node"
+
+import { consoleRpcMethods } from "../../packages/vite-hub/src/console/runtime/rpc.ts"
+
+import type { ConsoleRpcInput, ConsoleRpcResult } from "../../packages/vite-hub/src/console/runtime/rpc.ts"
+import type { Plugin } from "vite"
+
+// Exercise the real Console transport against this playground's synthetic HTTP fixtures.
+export function consoleMockRPC(): Plugin {
+  return {
+    name: "vitehub-console-playground-rpc",
+    configureServer(server) {
+      const definition = defineDevframe({
+        name: "Console playground",
+        packageName: "playground-console",
+        version: "0.0.1",
+        setup(context) {
+          for (const [operation, name] of Object.entries(consoleRpcMethods)) {
+            context.rpc.register(defineRpcFunction({
+              name,
+              type: "query",
+              jsonSerializable: true,
+              async handler(input: ConsoleRpcInput = {}): Promise<ConsoleRpcResult> {
+                const address = server.httpServer?.address()
+                if (!address || typeof address === "string") throw new Error("Playground server is not listening")
+                const path = operation === "invocation" ? `invocations/${encodeURIComponent(input.id ?? "")}`
+                  : operation === "agentInvocations" ? `agents/${input.agent ?? ""}/invocations`
+                    : operation === "invocationCapabilities" ? "invocation-capabilities" : operation
+                const url = new URL(`/api/_vitehub/console/${path}`, `http://127.0.0.1:${address.port}`)
+                for (const [key, value] of Object.entries(input.query ?? {})) {
+                  for (const entry of Array.isArray(value) ? value : [value]) url.searchParams.append(key, entry)
+                }
+                const response = await fetch(url, {
+                  method: input.method ?? "GET",
+                  ...(input.body === undefined ? {} : { body: JSON.stringify(input.body), headers: { "content-type": "application/json" } }),
+                })
+                if (!response.ok) return { ok: false, status: response.status, message: await response.text() }
+                return { ok: true, value: await response.json() }
+              },
+            }))
+          }
+        },
+      })
+      const instance = initDevframe(definition, {
+        allowedOrigins: false,
+        auth: false,
+        base: "/_vitehub/rpc/",
+        distDir: false,
+        mcp: false,
+        ws: false,
+      })
+      const handler = toNodeHandler(new H3().all("/**", fromWebHandler(instance.handler)))
+      server.middlewares.use((request, response, next) => {
+        if (request.url?.startsWith("/_vitehub/rpc/")) void handler(request, response)
+        else next()
+      })
+      server.httpServer?.once("close", () => { void instance.close() })
+    },
+  }
+}

--- a/playground/console/vite.config.ts
+++ b/playground/console/vite.config.ts
@@ -4,6 +4,7 @@ import { resolve } from "node:path"
 import { defineConfig } from "vite"
 
 import { consoleMockAPI } from "./mock-api.ts"
+import { consoleMockRPC } from "./rpc.ts"
 import { consoleAppConfig } from "../../packages/vite-hub/src/console/app.config.ts"
 
 const workspaceRoot = resolve(import.meta.dirname, "../..")
@@ -13,6 +14,7 @@ export default defineConfig({
   base: "/_vitehub/",
   plugins: [
     consoleMockAPI(),
+    consoleMockRPC(),
     vue(),
     ...ui({
       comark: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2273,6 +2273,9 @@ importers:
       h3-v1:
         specifier: npm:h3@^1.15.11
         version: h3@1.15.11
+      miniflare:
+        specifier: 4.20260714.0
+        version: 4.20260714.0
       publint:
         specifier: catalog:tooling
         version: 0.3.24

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2503,6 +2503,12 @@ importers:
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
         version: 6.0.8(@voidzero-dev/vite-plus-core@0.1.24)(vue@3.5.40(typescript@6.0.3))
+      devframe:
+        specifier: catalog:runtime
+        version: 0.9.12(@modelcontextprotocol/client@2.0.0)(cac@7.0.0)(ocache@0.3.0)(srvx@1.0.3)
+      h3:
+        specifier: catalog:unjs
+        version: 2.0.1-rc.31(crossws@0.4.12(srvx@1.0.3))(ocache@0.3.0)
       vite:
         specifier: npm:@voidzero-dev/vite-plus-core@0.1.24
         version: '@voidzero-dev/vite-plus-core@0.1.24(patch_hash=2a3e7f22b1c403326435bc0142aea49806b195205c97949baa8de261eb157f59)(@types/node@26.4.1)(@vitejs/devtools@0.1.19)(esbuild@0.28.2)(jiti@2.7.0)(publint@0.3.24)(terser@5.51.2)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.36)(yaml@2.9.0)'


### PR DESCRIPTION
Finding a past session required scanning invocation IDs below Usage charts. Usage now opens with a compact session history table, based on T3 Code's current Usage implementation and the existing Console session routes.

Filter by date, Agent, status, or search, then open a session title in the existing conversation and inspector. Filters stay in the URL. Completed, failed, and cancelled sessions remain visible when cost or token evidence is missing. Charts and provider status remain available in expandable sections. The Agents panel and session flow are unchanged.

History uses durable Agent Invocation IDs and does not merge separate executions by thread or title. SQLite and custom stores share keyset pagination with a fixed date cutoff. Failed page requests preserve the current page, Refresh resets pagination, and incomplete backfill shows recorded counts. The v2 projection leaves v1 resources available to older processes during a rolling update. The synthetic Console playground now uses the real SSE RPC transport.

Validation: 33 focused Usage tests passed after rebasing onto main. The 100,001-invocation archive test passed separately. Package lint, Console assets, package build, and publint passed. Browser checks cover filtering, keyboard selection, session navigation and Back, empty states, light/dark themes, 390px overflow, and 55-session pagination with an injected request failure. Package typecheck remains blocked by four pre-existing missing browser virtual-module declarations; no changed-file diagnostics remain.

Before:

![Before: charts above invocation history](https://github.com/user-attachments/assets/dca453ad-412c-4d39-952a-399a36de45d5)

After:

![After: session history first](https://github.com/user-attachments/assets/94029497-c3cd-4291-92ca-7bbcd859d180)

Phone width:

![Session history at 390px](https://github.com/user-attachments/assets/1f7b4718-13f1-4c02-b1b0-9aea7192279f)

Screenshots use synthetic fixture data. Quiver and T3 Code source were read-only references.

Model: GPT-6. Harness: Codex in T3 Code.
