### PR TITLE
feat(agent): simplify process-owned GitHub agents

### DIFF
--- a/docs/skills/code-review/SKILL.md
+++ b/docs/skills/code-review/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: code-review
+description: Review a branch, pull request, or work-in-progress diff against a fixed point along independent Engineering and Spec axes. Use for code-review requests, pull requests, or "review since X" comparisons.
+---
+
+Review the diff between `HEAD` and a fixed point along two independent axes:
+
+- **Engineering** — correctness, security, repository standards, maintainability, and simplicity.
+- **Spec** — missing, extra, or incorrectly implemented requirements.
+
+Run both reviews in parallel read-only sub-agents, then validate their findings before reporting them separately.
+
+## Process
+
+### 1. Bound the diff
+
+Use the caller's fixed point. When none is supplied, resolve the repository's default branch and use its merge-base with `HEAD`.
+
+Verify the ref and capture these commands once:
+
+```sh
+git diff <fixed-point>...HEAD
+git log <fixed-point>..HEAD --oneline
+```
+
+Stop when the ref is invalid or the diff is empty.
+
+### 2. Resolve the spec
+
+Use the first available source:
+
+1. A pull request body, issue, PRD, or path supplied by the caller.
+2. An issue linked from pull request or commit metadata.
+3. A matching file under `docs/`, `specs/`, or `.scratch/`.
+
+When no spec exists, skip the Spec reviewer and report that boundary. Never invent requirements.
+
+### 3. Collect engineering evidence
+
+Find repository instructions and coding standards such as `AGENTS.md`, `CONTRIBUTING.md`, or `CODING_STANDARDS.md`. Read [references/simplicity.md](references/simplicity.md) and give it to the Engineering reviewer. When the diff crosses configuration forms, generated/runtime/consumer representations, providers, frameworks, output modes, or resource lifecycles, also read and provide [references/contract-coverage.md](references/contract-coverage.md). Treat automated formatting and lint rules as tooling concerns rather than review findings.
+
+### 4. Review in parallel
+
+Send one parallel dispatch containing both prompts. Give each reviewer the diff command and commit list.
+
+**Engineering reviewer** — also provide the repository standards, the spec as a scope boundary, and the simplicity lens:
+
+> Inspect only the diff. Report every actionable P0–P3 correctness, security, data-loss, concurrency, compatibility, standards, maintainability, contract-coverage, or justified simplicity finding. For each finding, cite the tightest file and line, explain the concrete failure mechanism and consequence, and give the smallest safe fix. Repository rules, correctness, and explicit requirements override heuristics. Omit praise, tooling-enforced style, and concerns without a concrete failure path. Stay under 500 words.
+
+**Spec reviewer** — also provide the spec:
+
+> Compare the diff with the spec. Report missing or partial requirements, unrequested behavior, and implementations that appear present but behave incorrectly. Cite both the requirement and the tightest diff location; explain the user-visible consequence and smallest correction. Stay under 400 words.
+
+Use `P0` for catastrophic release, security, or data-loss failures; `P1` for merge-blocking defects; `P2` for material behavior or maintenance risks; and `P3` for worthwhile non-blocking corrections.
+
+### 5. Validate and report
+
+Re-read every cited hunk and source. Remove unsupported, duplicate, or out-of-scope findings; do not invent replacements for rejected findings.
+
+Report validated findings by severity under `## Engineering` and `## Spec`. Keep the axes separate so strength on one cannot mask failure on the other. If an axis has no findings, say so. End with finding counts by severity and axis, without an overall score or merge verdict.

--- a/docs/skills/code-review/references/contract-coverage.md
+++ b/docs/skills/code-review/references/contract-coverage.md
@@ -1,0 +1,22 @@
+# Contract Coverage
+
+Derive the affected contract variants from the diff and its callers. Include only dimensions the change touches:
+
+- configuration forms such as omitted, boolean, shorthand, and object;
+- providers, hosts, and frameworks;
+- definition, generated artifact, runtime, and consumer representations;
+- streaming and non-streaming output, success and failure paths;
+- resource or durable-state lifecycle exits.
+
+For each affected cell, find runnable proof or report the exact gap. One passing variant proves only itself. Do not expand the matrix with speculative compatibility.
+
+When the change owns a resource, background task, session, claim, or durable state, cover the applicable success, error, abort, cancellation, timeout, cleanup, restart, and concurrent-reuse transitions at the owning boundary.
+
+For package exports, generated loaders or registries, provider bindings, deployment output, or consumer patches, keep four evidence rows separate:
+
+1. source and package checks;
+2. generated-artifact inspection;
+3. packed-consumer execution;
+4. affected host or provider runtime.
+
+Missing credentials or external infrastructure leave a named unverified row; local evidence does not convert it into a pass.

--- a/docs/skills/code-review/references/simplicity.md
+++ b/docs/skills/code-review/references/simplicity.md
@@ -1,0 +1,15 @@
+# Simplicity lens
+
+Review for complexity that does not earn its cost. Prefer the smallest design that fully satisfies the spec, repository standards, clarity, and operability. Treat line count as evidence, never as the target.
+
+Check in order:
+
+1. Delete behavior, dead flexibility, and scaffolding the spec does not require.
+2. Reuse an existing repository primitive or pattern.
+3. Prefer the standard library, native platform, or an installed dependency over custom machinery.
+4. Inline abstractions, configuration, and delegation layers with only one concrete use.
+5. Shrink verbose logic only when the replacement is at least as clear and preserves every relevant behavior.
+
+Classify each justified simplification as `delete`, `reuse`, `stdlib`, `native`, `inline`, or `shrink`. Keep it to one complete line when the mechanism, consequence, and replacement remain clear; otherwise use the normal Engineering finding format.
+
+Preserve required validation, error handling, security, accessibility, tests, and genuine domain boundaries. Route correctness, security, and performance defects through the normal review instead of disguising them as simplification. Do not score line reduction or issue a merge verdict. When no cut is justified, report `No simplicity findings.`

--- a/docs/skills/resolving-merge-conflicts/SKILL.md
+++ b/docs/skills/resolving-merge-conflicts/SKILL.md
@@ -1,0 +1,14 @@
+---
+name: resolving-merge-conflicts
+description: "Use when you need to resolve an in-progress git merge/rebase conflict."
+---
+
+1. **See the current state** of the merge/rebase. Check git history, and the conflicting files.
+
+2. **Find the primary sources** for each conflict. Understand deeply why each change was made, and what the original intent was. Read the commit messages, check the PRs, check original issues/tickets.
+
+3. **Resolve each hunk.** Preserve both intents where possible. Where incompatible, pick the one matching the merge's stated goal and note the trade-off. Do **not** invent new behaviour. Always resolve; never `--abort`.
+
+4. Discover the project's **automated checks** and run them — typically typecheck, then tests, then format. Fix anything the merge broke.
+
+5. **Finish the merge/rebase.** Stage everything and commit. If rebasing, continue the rebase process until all commits are rebased.

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -376,7 +376,7 @@ Agent Definition. `host.health()` reports provider availability and stale record
 For Nitro, add `processAgentHost({ entry: './server/host.ts' })` from
 `@vite-hub/agent/vite` to the Vite plugins. The entry exports the host as default.
 The plugin starts it and closes it with Nitro, and serves drain status at
-`/api/_vitehub/drain`, configurable with `drainRoute`. SIGUSR2 starts a drain.
+`/api/drain`, configurable with `drainRoute`. SIGUSR2 starts a drain.
 Use the runtime drain CLI before replacing the process.
 
 `createGitHubPullRequests(host)` from `@vite-hub/agent/server/github` reads PR

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -347,3 +347,48 @@ Child configuration overrides parent defaults. Channels, Sources, Skills, and ho
 `createPapercutReporter()` from `@vite-hub/agent/capabilities` journals reports in persistent Agent Invocations before delivery and replays pending reports after restart. See [evlog](../../docs/content/docs/agents/evlog.md) for delivery, privacy and shutdown contracts.
 
 GitHub Channels with `activity: true` keep one managed comment per pull request. A single table lists current and recent session links, status, relative start times, and completed durations. Task checkboxes and the latest result appear below; previous results are collapsed. Full transcripts stay in the linked sessions.
+
+### Process-owned agents
+
+For a single Node process that discovers background work, `createProcessAgentHost`
+from `@vite-hub/agent/runtime/process` combines capacity, invocation storage and
+recovery, provider-session storage, and a draining reconciler. Its data directory
+must belong exclusively to this host. It is not a distributed lease.
+
+```ts
+export default await createProcessAgentHost({
+  name: 'reviewer',
+  dataDir: '.vitehub',
+  providerCommand: 'codex',
+  capacity: { concurrency: 4 },
+  async run(reason, { track }, accepting) {
+    const jobs = await discoverWork()
+    if (accepting()) track(runJobs(jobs))
+  },
+})
+```
+
+Use the host's `capacity`, `invocations`, and `providerSessionStorePath` in the
+Agent Definition. `host.health()` reports provider availability and stale records.
+`host.wake()` requests discovery after work completes. `host.start()` is idempotent;
+`host.close()` stops admission and waits for tracked work.
+
+For Nitro, add `processAgentHost({ entry: './server/host.ts' })` from
+`@vite-hub/agent/vite` to the Vite plugins. The entry exports the host as default.
+The plugin starts it and closes it with Nitro, and serves drain status at
+`/api/_vitehub/drain`, configurable with `drainRoute`. SIGUSR2 starts a drain.
+Use the runtime drain CLI before replacing the process.
+
+`createGitHubPullRequests(host)` from `@vite-hub/agent/server/github` reads PR
+snapshots with paginated feedback, required checks, and host budget admission.
+An explicit `activityAuthors` list excludes only those authors' managed activity
+comments from feedback fingerprints. `feedback.hasDiscussion` is conservative;
+consumers must still check failures and conflicts before deciding to wait.
+`publishAgentActivity()` updates a channel without starting an invocation.
+
+`host.channel({ activity: true })` shares a GitHub host's credentials and identity.
+A provider `env` resolver can call `host.environment()` inside
+`withPullRequestCheckout()`. The environment binds to that callback's checkout,
+including concurrent callbacks. Await the entire agent run before returning.
+Use `defineAgent({ extends: agent, name, workspace })` to bind the workspace
+without rebuilding driver configuration.

--- a/packages/agent/src/capabilities/skills.ts
+++ b/packages/agent/src/capabilities/skills.ts
@@ -9,6 +9,8 @@ import type { WorkspaceSourceInput } from "@vite-hub/workspace"
 import { agentDiagnostics } from "../agent-diagnostics.ts"
 
 export interface SkillsCapabilityOptions {
+  /** Distinguish multiple skill sources in the same Agent Definition. */
+  id?: string
   path?: string
   shellExecution?: AgentCapabilityMode
   source?: WorkspaceSourceInput
@@ -104,7 +106,7 @@ export function skills(options: SkillsCapabilityOptions = {}): AgentCapabilityDe
     : undefined
 
   const capability = defineCapability({
-    id: "skills",
+    id: options.id ?? "skills",
     metadata: {
       path: normalizedPath,
       skillPath,

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1189,7 +1189,7 @@ async function githubAppInstallationToken<TRuntimeConfig extends AgentRuntimeCon
 ) {
   const options = githubAppOptions(app) || {}
   if (options.token) {
-    const token = typeof options.token === 'function' ? await options.token(context) : options.token
+    const token = hasRuntimeType(options.token, 'function') ? await options.token(context) : options.token
     return requiredString(token, 'token')
   }
   const env = await githubEnv(context)

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -141,6 +141,10 @@ type GitHubAppContext<TRuntimeConfig extends AgentRuntimeConfig> =
   AgentCallbackContext<TRuntimeConfig> | AgentChannelDeliveryEffectContext<TRuntimeConfig>
 
 export interface GitHubAppOptions<TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig> {
+  /** Use a host-managed credential resolver instead of minting another installation token. */
+  token?: GitHubAppValue<string | undefined, TRuntimeConfig>
+  /** Trusted login of the host's authenticated GitHub identity. */
+  identity?: { login: string }
   apiBaseUrl?: string
   appId?: GitHubAppValue<number | string | undefined, TRuntimeConfig>
   artifacts?: false | {
@@ -1184,6 +1188,10 @@ async function githubAppInstallationToken<TRuntimeConfig extends AgentRuntimeCon
   installation?: number,
 ) {
   const options = githubAppOptions(app) || {}
+  if (options.token) {
+    const token = typeof options.token === 'function' ? await options.token(context) : options.token
+    return requiredString(token, 'token')
+  }
   const env = await githubEnv(context)
   const appId = requiredString(await githubAppSetting(options, env, "appId", "appId", context), "appId")
   // SAFETY: Presence of the effect discriminator establishes the delivery-effect context variant.
@@ -1360,6 +1368,7 @@ async function githubAppIdentity<TRuntimeConfig extends AgentRuntimeConfig>(
   context: GitHubAppContext<TRuntimeConfig>,
 ): Promise<GitHubActivityIdentity> {
   const options = githubAppOptions(app) || {}
+  if (options.identity) return options.identity
   const env = await githubEnv(context)
   const appId = requiredString(await githubAppSetting(options, env, "appId", "appId", context), "appId")
   const headers = githubApiHeaders(githubAppJwt(appId, await githubAppPrivateKey(options, env, context)), options.userAgent)
@@ -1525,10 +1534,14 @@ function renderGithubActivity(
 ): string {
   const sections = [encodeGithubActivityState(state)]
   const current = state.current
-  const sessions = [current, ...state.history].filter((entry): entry is GitHubActivityHistoryEntry => !!entry && (entry === current || entry.links.length > 0))
+  const sessions = [current, ...state.history].filter((entry): entry is GitHubActivityHistoryEntry => !!entry && (entry.links.length > 0 || entry.status !== "queued"))
   const labels: Record<AgentActivityStatus, string> = {
     queued: "Starting", running: "Running", waiting: "Waiting for input",
     completed: "Completed", failed: "Failed", cancelled: "Cancelled",
+  }
+  if (activity.status === "queued" && !current?.links.length) {
+    sections.push(activity.summary ? githubActivityText(activity.summary, 2_000) : "Waiting to start.")
+    if (!sessions.length) return sections.join("\n\n")
   }
   sections.push([
     "| Session | Status | Started | Duration |",
@@ -1659,7 +1672,7 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
           : {
               current,
               history: [previous.current, ...previous.history]
-                .filter((entry): entry is GitHubActivityHistoryEntry => entry !== undefined && entry.runId !== current.runId)
+                .filter((entry): entry is GitHubActivityHistoryEntry => entry !== undefined && entry.runId !== current.runId && (entry.links.length > 0 || entry.status !== "queued"))
                 .slice(0, githubActivityHistoryLimit),
               previousRunIds: [previous.current?.runId, ...previous.previousRunIds]
                 .filter((runId): runId is string => runId !== undefined && runId !== current.runId)
@@ -1675,7 +1688,7 @@ function githubAgentActivity<TRuntimeConfig extends AgentRuntimeConfig>(
         const written = await response.clone().json().catch(() => undefined)
         const writtenCommentId = commentId || maybeNumber(isRecord(written) ? written.id : undefined)
         if (writtenCommentId) commentIds.set(activityKey, writtenCommentId)
-        if (!terminal && trackActiveRuns) {
+        if (!terminal && trackActiveRuns && (current.links.length > 0 || current.status !== "queued")) {
           activeRuns.add(runId)
           githubActivityActiveRuns.set(activityKey, activeRuns)
         }

--- a/packages/agent/src/channels.ts
+++ b/packages/agent/src/channels.ts
@@ -1189,7 +1189,7 @@ async function githubAppInstallationToken<TRuntimeConfig extends AgentRuntimeCon
 ) {
   const options = githubAppOptions(app) || {}
   if (options.token) {
-    const token = typeof options.token === 'function' ? await options.token(context) : options.token
+    const token = hasRuntimeType(options.token, "function") ? await options.token(context) : options.token
     return requiredString(token, 'token')
   }
   const env = await githubEnv(context)

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -7116,6 +7116,7 @@ export async function publishAgentActivity(
     capabilities: {},
     memo<T>(key: string, create: () => T): T {
       if (!memoized.has(key)) memoized.set(key, create())
+      // SAFETY: Each memo key is populated by its caller-supplied factory of T.
       return memoized.get(key) as T
     },
     waitUntil: work => { pending.push(Promise.resolve(work)) },

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -136,6 +136,7 @@ import {
 
 import type {
   AgentActivityStatus,
+  AgentActivityTarget,
   AgentActivityTask,
   AgentActivityUpdate,
   AgentAdapter,
@@ -7099,4 +7100,28 @@ export async function getAgent<TContext extends AgentRuntimeContext>(
   context: TContext,
 ): Promise<AgentAdapter> {
   return await resolveAgent(agent, context)
+}
+
+/** Publish a scheduler wait or progress update without creating an invocation. */
+export async function publishAgentActivity(
+  agent: Pick<AgentDefinition, 'name' | 'channels'>,
+  options: { channelId: string, target: AgentActivityTarget, activity: AgentActivityUpdate },
+): Promise<void> {
+  const channel = agent.channels?.[options.channelId]
+  if (!channel?.activity) throw new Error(`Agent channel ${options.channelId} does not support activity.`)
+  const pending: Promise<unknown>[] = []
+  const memoized = new Map<string, unknown>()
+  await channel.activity.update({
+    runtime: 'unknown',
+    capabilities: {},
+    memo<T>(key: string, create: () => T): T {
+      if (!memoized.has(key)) memoized.set(key, create())
+      return memoized.get(key) as T
+    },
+    waitUntil: work => { pending.push(Promise.resolve(work)) },
+    channel,
+    target: options.target,
+    activity: { agentName: agent.name, ...options.activity },
+  })
+  await Promise.all(pending)
 }

--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -7116,6 +7116,7 @@ export async function publishAgentActivity(
     capabilities: {},
     memo<T>(key: string, create: () => T): T {
       if (!memoized.has(key)) memoized.set(key, create())
+      // SAFETY: Each memo key retains the value created by its caller for this activity update.
       return memoized.get(key) as T
     },
     waitUntil: work => { pending.push(Promise.resolve(work)) },

--- a/packages/agent/src/process-host-vite.ts
+++ b/packages/agent/src/process-host-vite.ts
@@ -1,0 +1,37 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import type { Plugin } from "vite";
+
+/** Install a process host exported as default from an application module into Nitro. */
+export function processAgentHost(options: { entry: string; drainRoute?: string }): Plugin {
+  return {
+    name: "vitehub:process-agent-host",
+    async config(config) {
+      const root = resolve(config.root ?? process.cwd());
+      const directory = resolve(root, ".vitehub/process-host");
+      const entry = resolve(root, options.entry);
+      const drainRoute = options.drainRoute ?? "/api/_vitehub/drain";
+      if (!drainRoute.startsWith("/") || /[?#*]/.test(drainRoute))
+        throw new Error(
+          "Process host drainRoute must be an absolute route without query, hash, or wildcard.",
+        );
+      const nitro = (config as typeof config & { nitro?: { handlers?: { route?: string }[] } })
+        .nitro;
+      if (nitro?.handlers?.some((handler) => handler.route === drainRoute))
+        throw new Error(`Process host route already registered: ${drainRoute}`);
+      await mkdir(directory, { recursive: true });
+      const plugin = resolve(directory, "plugin.ts");
+      const drain = resolve(directory, "drain.ts");
+      await writeFile(
+        plugin,
+        `import host from ${JSON.stringify(entry)}\nexport default function(app) { host.start(); app.hooks.hook('close', () => host.close()) }\n`,
+      );
+      await writeFile(
+        drain,
+        `import host from ${JSON.stringify(entry)}\nexport default () => ({ status: host.status() })\n`,
+      );
+      const result: import("vite").UserConfig & { nitro: { plugins: string[], handlers: { route: string, handler: string }[] } } = { nitro: { plugins: [plugin], handlers: [{ route: drainRoute, handler: drain }] } };
+      return result
+    },
+  };
+}

--- a/packages/agent/src/process-host-vite.ts
+++ b/packages/agent/src/process-host-vite.ts
@@ -15,6 +15,7 @@ export function processAgentHost(options: { entry: string; drainRoute?: string }
         throw new Error(
           "Process host drainRoute must be an absolute route without query, hash, or wildcard.",
         );
+      // SAFETY: Nitro adds an optional handlers configuration to Vite UserConfig.
       const nitro = (config as typeof config & { nitro?: { handlers?: { route?: string }[] } })
         .nitro;
       if (nitro?.handlers?.some((handler) => handler.route === drainRoute))

--- a/packages/agent/src/process-host-vite.ts
+++ b/packages/agent/src/process-host-vite.ts
@@ -15,6 +15,7 @@ export function processAgentHost(options: { entry: string; drainRoute?: string }
         throw new Error(
           "Process host drainRoute must be an absolute route without query, hash, or wildcard.",
         );
+      // SAFETY: Nitro extends Vite config with this optional handlers list; Vite omits plugin-specific fields.
       const nitro = (config as typeof config & { nitro?: { handlers?: { route?: string }[] } })
         .nitro;
       if (nitro?.handlers?.some((handler) => handler.route === drainRoute))

--- a/packages/agent/src/process-host-vite.ts
+++ b/packages/agent/src/process-host-vite.ts
@@ -10,7 +10,7 @@ export function processAgentHost(options: { entry: string; drainRoute?: string }
       const root = resolve(config.root ?? process.cwd());
       const directory = resolve(root, ".vitehub/process-host");
       const entry = resolve(root, options.entry);
-      const drainRoute = options.drainRoute ?? "/api/_vitehub/drain";
+      const drainRoute = options.drainRoute ?? "/api/drain";
       if (!drainRoute.startsWith("/") || /[?#*]/.test(drainRoute))
         throw new Error(
           "Process host drainRoute must be an absolute route without query, hash, or wildcard.",

--- a/packages/agent/src/runtime/process-host.ts
+++ b/packages/agent/src/runtime/process-host.ts
@@ -1,0 +1,142 @@
+import { execFile } from "node:child_process"
+import { promisify } from "node:util"
+import { join } from "node:path";
+import {
+  createProcessReconciler,
+  type ProcessReconciler,
+  type ProcessReconcilerOptions,
+  type ProcessReconcilerStatus,
+} from "@vite-hub/runtime/node";
+import { normalizeRuntimeDiagnosticError } from "@vite-hub/runtime";
+import { createLibsqlAgentInvocationStore } from "../invocations/sqlite.ts";
+import { readAgentInvocationWorkload } from "../server/invocation-health.ts";
+import {
+  createProcessAgentCapacity,
+  createProcessAgentInvocations,
+  type ProcessAgentCapacityOptions,
+} from "./process.ts";
+import type { AgentInvocations } from "../invocations.ts";
+import type { AgentDriverCapacityOptions } from "../types.ts";
+
+export interface ProcessAgentHostOptions {
+  /** Exclusively owned by this process. Do not share with another running host. */
+  dataDir?: string;
+  name?: string
+  providerCommand?: string;
+  capacity: ProcessAgentCapacityOptions;
+  intervalMs?: number;
+  run: (
+    reason: string,
+    context: Parameters<ProcessReconcilerOptions["run"]>[1],
+    accepting: () => boolean,
+  ) => Promise<void> | void;
+}
+
+export interface ProcessAgentDiagnostic {
+  label: string
+  status: "neutral" | "ok" | "warning"
+  value: string
+  detail?: string
+}
+
+export interface ProcessAgentHost {
+  capacity: AgentDriverCapacityOptions;
+  invocations: AgentInvocations;
+  providerSessionStorePath: string;
+  event(event: string, detail?: Record<string, unknown>): void;
+  error(event: string, error: unknown, detail?: Record<string, unknown>): void;
+  start(): void;
+  close(): Promise<void>;
+  wake(reason?: string): void;
+  status(): ProcessReconcilerStatus | "starting";
+  health(): Promise<{ diagnostics: ProcessAgentDiagnostic[];
+    checkedAt: string;
+    status: "healthy" | "degraded";
+    workload: Awaited<ReturnType<typeof readAgentInvocationWorkload>>;
+  }>;
+}
+
+/** Own process admission, interrupted invocation recovery, and graceful drain together. */
+export async function createProcessAgentHost(
+  options: ProcessAgentHostOptions,
+): Promise<ProcessAgentHost> {
+  const dataDir = options.dataDir ?? ".vitehub";
+  const startedAt = Date.now();
+  const capacity = createProcessAgentCapacity(options.capacity);
+  const invocations = await createProcessAgentInvocations({
+    content: "content",
+    store: createLibsqlAgentInvocationStore({
+      maxRecords: 5_000,
+      url: `file:${join(dataDir, "invocations.sqlite")}`,
+    }),
+    recovery: { before: startedAt, recover: () => true },
+  });
+  let reconciler: ProcessReconciler | undefined;
+  let accepting = false;
+  let closed = false;
+  const event = (event: string, detail: Record<string, unknown> = {}) =>
+    console.info(
+      `[${options.name ?? "vitehub"}]`,
+      JSON.stringify({ ...detail, event, timestamp: new Date().toISOString() }),
+    );
+  const error = (event: string, error: unknown, detail: Record<string, unknown> = {}) =>
+    console.error(
+      `[${options.name ?? "vitehub"}]`,
+      JSON.stringify({
+        ...detail,
+        event,
+        timestamp: new Date().toISOString(),
+        error: normalizeRuntimeDiagnosticError(error, { includeStack: true }),
+      }),
+    );
+  return {
+    event,
+    error,
+    capacity,
+    invocations,
+    providerSessionStorePath: join(dataDir, "provider-sessions.sqlite"),
+    start() {
+      if (reconciler || closed) return;
+      accepting = true;
+      reconciler = createProcessReconciler({
+        intervalMs: options.intervalMs ?? 120_000,
+        signal: "SIGUSR2",
+        onQuiesce: () => {
+          accepting = false;
+        },
+        onError: (cause, reason) => error("process.reconcile.failed", cause, { reason }),
+        run: (reason, context) => options.run(reason, context, () => accepting),
+      });
+      reconciler.wake("startup");
+    },
+    async close() {
+      closed = true;
+      accepting = false;
+      await reconciler?.close();
+    },
+    wake(reason = "work-completed") {
+      if (accepting) reconciler?.wake(reason);
+    },
+    status: () => reconciler?.status() ?? "starting",
+    async health() {
+      const workload = await readAgentInvocationWorkload(invocations, startedAt);
+      const diagnostics: ProcessAgentDiagnostic[] = [
+        { label: "Runtime", status: "ok", value: `Node ${process.version}`, detail: `Up for ${Math.floor(process.uptime() / 60)}m` },
+        { label: "Invocation state", status: workload.stale ? "warning" : "ok", value: workload.stale ? `${workload.stale} stale` : "Reconciled", detail: "Process-owned invocation recovery" },
+      ]
+      if (options.providerCommand) {
+        try {
+          const { stdout } = await promisify(execFile)(options.providerCommand, ["--version"], { timeout: 2_000 })
+          diagnostics.push({ label: "Provider", status: "ok", value: stdout.trim().split(/\r?\n/, 1)[0] || "Available" })
+        }
+        catch { diagnostics.push({ label: "Provider", status: "warning", value: "Executable unavailable" }) }
+      }
+      return {
+        diagnostics,
+        checkedAt: new Date().toISOString(),
+        status: diagnostics.some(item => item.status === "warning") ? "degraded" : "healthy",
+        workload,
+      };
+    },
+  };
+}

--- a/packages/agent/src/runtime/process-host.ts
+++ b/packages/agent/src/runtime/process-host.ts
@@ -1,3 +1,4 @@
+import { mkdir } from "node:fs/promises"
 import { execFile } from "node:child_process"
 import { promisify } from "node:util"
 import { join } from "node:path";
@@ -61,6 +62,7 @@ export async function createProcessAgentHost(
   options: ProcessAgentHostOptions,
 ): Promise<ProcessAgentHost> {
   const dataDir = options.dataDir ?? ".vitehub";
+  await mkdir(dataDir, { recursive: true });
   const startedAt = Date.now();
   const capacity = createProcessAgentCapacity(options.capacity);
   const invocations = await createProcessAgentInvocations({

--- a/packages/agent/src/runtime/process.ts
+++ b/packages/agent/src/runtime/process.ts
@@ -223,3 +223,6 @@ export async function createProcessAgentInvocations(
   await failInterruptedAgentInvocations(options.store, options.recovery)
   return defineAgentInvocations(options)
 }
+
+export { createProcessAgentHost } from './process-host.ts'
+export type { ProcessAgentHost, ProcessAgentHostOptions } from './process-host.ts'

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -67,3 +67,6 @@ export type {
   AgentDiscordGatewayRouteOptions,
   AgentTelegramPollingRouteOptions,
 } from "./server/routes.ts"
+
+export { createAgentConsoleDelivery } from './server/console-delivery.ts'
+export type { AgentConsoleDelivery } from './server/console-delivery.ts'

--- a/packages/agent/src/server/console-delivery.ts
+++ b/packages/agent/src/server/console-delivery.ts
@@ -1,0 +1,35 @@
+import { otlp } from "../capabilities/otlp.ts";
+import type { AgentCapabilityDefinition } from "../types.ts";
+
+export interface AgentConsoleDelivery {
+  capability: AgentCapabilityDefinition;
+  endpoint(path: string): string;
+  headers(): Record<string, string>;
+}
+
+/** Validate optional Console delivery and configure its telemetry exporter together. */
+export function createAgentConsoleDelivery(options: {
+  url?: string;
+  token?: string | { unseal(): string };
+}): AgentConsoleDelivery | undefined {
+  if (!options.url && !options.token) return;
+  if (!options.url || !options.token)
+    throw new Error("Console delivery requires both url and token.");
+  const base = new URL(options.url);
+  if (!["http:", "https:"].includes(base.protocol) || base.username || base.password)
+    throw new Error("Console delivery requires an HTTP(S) URL without embedded credentials.");
+  const token = options.token;
+  const headers = () => ({
+    authorization: `Bearer ${typeof token === "string" ? token : token.unseal()}`,
+  });
+  const endpoint = (path: string) => new URL(path, base).href;
+  return {
+    endpoint,
+    headers,
+    capability: otlp({
+      endpoint: endpoint("/api/otlp"),
+      headers,
+      resource: { "service.namespace": "vitehub" },
+    }),
+  };
+}

--- a/packages/agent/src/server/console-delivery.ts
+++ b/packages/agent/src/server/console-delivery.ts
@@ -1,3 +1,4 @@
+import { hasRuntimeType } from "../internal/runtime-type.ts"
 import { otlp } from "../capabilities/otlp.ts";
 import type { AgentCapabilityDefinition } from "../types.ts";
 
@@ -20,7 +21,7 @@ export function createAgentConsoleDelivery(options: {
     throw new Error("Console delivery requires an HTTP(S) URL without embedded credentials.");
   const token = options.token;
   const headers = () => ({
-    authorization: `Bearer ${typeof token === "string" ? token : token.unseal()}`,
+    authorization: `Bearer ${hasRuntimeType(token, "string") ? token : token.unseal()}`,
   });
   const endpoint = (path: string) => new URL(path, base).href;
   return {

--- a/packages/agent/src/server/console-delivery.ts
+++ b/packages/agent/src/server/console-delivery.ts
@@ -1,3 +1,4 @@
+import { hasRuntimeType } from "../internal/runtime-type.ts";
 import { otlp } from "../capabilities/otlp.ts";
 import type { AgentCapabilityDefinition } from "../types.ts";
 
@@ -20,7 +21,7 @@ export function createAgentConsoleDelivery(options: {
     throw new Error("Console delivery requires an HTTP(S) URL without embedded credentials.");
   const token = options.token;
   const headers = () => ({
-    authorization: `Bearer ${typeof token === "string" ? token : token.unseal()}`,
+    authorization: `Bearer ${hasRuntimeType(token, "string") ? token : token.unseal()}`,
   });
   const endpoint = (path: string) => new URL(path, base).href;
   return {

--- a/packages/agent/src/server/github-host.ts
+++ b/packages/agent/src/server/github-host.ts
@@ -1,3 +1,6 @@
+import { github, type GitHubChannelOptions } from '../channels.ts'
+import type { AgentChannelDefinition } from '../types.ts'
+import { AsyncLocalStorage } from 'node:async_hooks'
 import { execFile } from "node:child_process"
 import type { ExecFileOptionsWithStringEncoding } from "node:child_process"
 import { createHash, createSign } from "node:crypto"
@@ -86,6 +89,9 @@ export interface GitHubGraphQLReservation extends GitHubGraphQLRateLimit {
 }
 
 export interface GitHubHost {
+  channel(options?: Omit<GitHubChannelOptions, 'app'>): AgentChannelDefinition
+  /** Resolve credentials and Git binding for the current checkout callback. */
+  environment(): Promise<Record<string, string>>
   access(input?: GitHubHostAccessOptions): Promise<GitHubHostAccess>
   budget(): { limited: false } | { limited: true, remaining: number, resetAt: number }
   command(args: string[], input?: GitHubHostCommandOptions): Promise<{ stderr: string, stdout: string }>
@@ -216,6 +222,7 @@ export function parseGraphQLRateLimit(value: unknown, checkedAt: number = Date.n
 }
 
 export function createGitHubHost(options: GitHubHostOptions): GitHubHost {
+  const checkoutScope = new AsyncLocalStorage<GitHubHostAccess & { path: string }>()
   const reserve = options.reserve ?? 1_500
   const cacheMs = options.cacheMs ?? 15_000
   const graphQLCheckTimeout = options.graphQLCheckTimeout ?? GITHUB_GRAPHQL_CHECK_TIMEOUT_MS
@@ -659,7 +666,7 @@ export function createGitHubHost(options: GitHubHostOptions): GitHubHost {
           signal: operation.signal,
         })
       }
-      return await run({ ...baseAuth, path: checkout, push, signal: operation.signal })
+      return await checkoutScope.run({ ...baseAuth, path: checkout }, () => run({ ...baseAuth, path: checkout, push, signal: operation.signal }))
     }
     finally {
       operation.close()
@@ -668,6 +675,14 @@ export function createGitHubHost(options: GitHubHostOptions): GitHubHost {
   }
 
   return {
+    channel(channelOptions = {}) {
+      return github({ ...channelOptions, app: { token: async () => (await access()).token, ...(identity.login ? { identity: { login: identity.login } } : {}) } })
+    },
+    async environment() {
+      const current = checkoutScope.getStore()
+      if (!current) return (await access({ fallback: true })).env
+      return { ...current.env, GIT_DIR: join(current.path, '.git'), GIT_WORK_TREE: '.' }
+    },
     access,
     budget,
     command,

--- a/packages/agent/src/server/github-pull-requests.ts
+++ b/packages/agent/src/server/github-pull-requests.ts
@@ -1,4 +1,6 @@
 import { createHash } from "node:crypto";
+import * as v from "valibot";
+import { hasRuntimeType, isRuntimeRecord } from "../internal/runtime-type.ts";
 import type { GitHubHost } from "./github-host.ts";
 
 export type PullRequestFeedback = {
@@ -30,6 +32,31 @@ export type PullRequest = {
   updatedAt: string;
   url: string;
 };
+
+const pullRequestSchema = v.object({
+  baseRefOid: v.string(),
+  baseRefName: v.string(),
+  body: v.string(),
+  headRefName: v.string(),
+  headRefOid: v.string(),
+  headRepository: v.nullable(v.object({ nameWithOwner: v.string() })),
+  isDraft: v.boolean(),
+  labels: v.optional(v.unknown()),
+  mergeStateStatus: v.string(),
+  number: v.pipe(v.number(), v.integer(), v.minValue(1)),
+  reviewDecision: v.nullable(v.string()),
+  state: v.string(),
+  statusCheckRollup: v.unknown(),
+  title: v.string(),
+  updatedAt: v.string(),
+  url: v.string(),
+});
+
+function repositoryParts(repository: string) {
+  const [owner, name, extra] = repository.split("/");
+  if (!owner || !name || extra !== undefined) throw new Error("Expected a GitHub owner/repository.");
+  return { owner, name };
+}
 
 type Connection<T> = { nodes: T[]; pageInfo: { hasNextPage: boolean; endCursor: string } };
 export type GitHubPullRequestComment = {
@@ -82,7 +109,7 @@ export function createGitHubPullRequests(
         ),
         readOpenPullRequestFeedback(repository),
       ]);
-      const pullRequests = JSON.parse(result.stdout) as PullRequest[];
+      const pullRequests = v.parse(v.array(pullRequestSchema), JSON.parse(result.stdout));
       return await Promise.all(
         pullRequests.map((pullRequest) =>
           readRequiredCheckState(repository, {
@@ -106,7 +133,7 @@ export function createGitHubPullRequests(
         readPullRequestFeedback(repository, number),
       ]);
       return await readRequiredCheckState(repository, {
-        ...(JSON.parse(result.stdout) as PullRequest),
+        ...v.parse(pullRequestSchema, JSON.parse(result.stdout)),
         ...(feedback ? { feedback } : {}),
       });
     });
@@ -127,7 +154,7 @@ export function createGitHubPullRequests(
 
   async function readOpenPullRequestFeedback(repository: string) {
     // Bulk first pages keep discovery cheap; large discussions fall back to pagination.
-    const [owner, name] = repository.split("/") as [string, string];
+    const { owner, name } = repositoryParts(repository);
     const query = `query($owner:String!,$name:String!,$comments:String,$reviews:String,$threads:String){repository(owner:$owner,name:$name){pullRequests(first:100,states:OPEN){nodes{number ${feedbackFields}}}}}`;
     const result = await github.command(
       ["api", "graphql", "-f", `owner=${owner}`, "-f", `name=${name}`, "-f", `query=${query}`],
@@ -139,7 +166,7 @@ export function createGitHubPullRequests(
     return new Map<number, PullRequestFeedback>(
       await Promise.all(
         nodes.map(
-          async (node) =>
+          async (node): Promise<[number, PullRequestFeedback]> =>
             [
               node.number,
               Object.values(feedbackConnections(node)).some(
@@ -150,7 +177,7 @@ export function createGitHubPullRequests(
               )
                 ? await readPullRequestFeedback(repository, node.number)
                 : digestFeedback(node),
-            ] as [number, PullRequestFeedback],
+            ],
         ),
       ),
     );
@@ -189,7 +216,7 @@ export function createGitHubPullRequests(
     repository: string,
     number: number,
   ): Promise<PullRequestFeedback> {
-    const [owner, name] = repository.split("/") as [string, string];
+    const { owner, name } = repositoryParts(repository);
     const query = `query($owner:String!,$name:String!,$number:Int!,$comments:String,$reviews:String,$threads:String){repository(owner:$owner,name:$name){pullRequest(number:$number){${feedbackFields}}}}`;
     const cursors = new Map<string, string>();
     const collected = {
@@ -216,18 +243,17 @@ export function createGitHubPullRequests(
       );
       const node: FeedbackNode = JSON.parse(result.stdout)?.data?.repository?.pullRequest;
       let more = false;
-      for (const [key, connection] of Object.entries(feedbackConnections(node))) {
-        const items = collected[key as keyof typeof collected];
-        for (const item of connection.nodes)
-          (items as Map<string, GitHubPullRequestComment | FeedbackReview | FeedbackThread>).set(
-            item.id,
-            item,
-          );
+      feedbackConnections(node);
+      function collect<T extends { id: string }>(key: string, connection: Connection<T>, items: Map<string, T>) {
+        for (const item of connection.nodes) items.set(item.id, item);
         if (connection.pageInfo.hasNextPage) {
           cursors.set(key, connection.pageInfo.endCursor);
           more = true;
         }
       }
+      collect("comments", node.comments, collected.comments);
+      collect("reviews", node.reviews, collected.reviews);
+      collect("threads", node.reviewThreads, collected.threads);
       if (!more) break;
     } while (true);
     for (const thread of collected.threads.values()) {
@@ -284,10 +310,10 @@ export function createGitHubPullRequests(
       const result = await github.command(args, { repository });
       return parseRequiredChecks(result.stdout, result.stderr);
     } catch (error) {
-      const result = error as Error & { stderr?: unknown; stdout?: unknown };
+      const result = isRuntimeRecord(error) ? error : {};
       const checks = parseRequiredChecks(
-        typeof result.stdout === "string" ? result.stdout : "",
-        typeof result.stderr === "string" ? result.stderr : "",
+        hasRuntimeType(result.stdout, "string") ? result.stdout : "",
+        hasRuntimeType(result.stderr, "string") ? result.stderr : "",
       );
       if (checks !== undefined) return checks;
       throw new Error(`Failed to read required checks for ${repository}#${number}.`, {
@@ -314,11 +340,11 @@ export function pullRequestCheckState(
   ]);
   let pending = false;
   for (const value of statusCheckRollup) {
-    if (!value || typeof value !== "object") {
+    if (!isRuntimeRecord(value)) {
       pending = true;
       continue;
     }
-    const { bucket, conclusion, state, status } = value as Record<string, unknown>;
+    const { bucket, conclusion, state, status } = value;
     if (bucket === "fail" || bucket === "cancel") return "failed";
     if (bucket === "pending") {
       pending = true;
@@ -329,12 +355,12 @@ export function pullRequestCheckState(
       state === "ERROR" ||
       state === "FAILURE" ||
       (status === "COMPLETED" &&
-        typeof conclusion === "string" &&
+        hasRuntimeType(conclusion, "string") &&
         failedConclusions.has(conclusion))
     )
       return "failed";
     if (status === "COMPLETED") {
-      if (typeof conclusion !== "string" || !conclusion) pending = true;
+      if (!hasRuntimeType(conclusion, "string") || !conclusion) pending = true;
     } else if (status !== undefined || state !== "SUCCESS") pending = true;
   }
   return pending ? "pending" : "passed";

--- a/packages/agent/src/server/github-pull-requests.ts
+++ b/packages/agent/src/server/github-pull-requests.ts
@@ -1,0 +1,373 @@
+import { createHash } from "node:crypto";
+import type { GitHubHost } from "./github-host.ts";
+
+export type PullRequestFeedback = {
+  comments: string;
+  reviews: string;
+  threads: string;
+  hasDiscussion: boolean;
+};
+
+export type PullRequest = {
+  baseRefOid: string;
+  baseRefName: string;
+  body: string;
+  comments?: unknown;
+  feedback?: PullRequestFeedback;
+  headRefName: string;
+  headRefOid: string;
+  headRepository: { nameWithOwner: string } | null;
+  isDraft: boolean;
+  labels?: unknown;
+  mergeStateStatus: string;
+  number: number;
+  reviewDecision: string | null;
+  reviews?: unknown;
+  requiredStatusCheckRollup?: unknown;
+  state: string;
+  statusCheckRollup: unknown;
+  title: string;
+  updatedAt: string;
+  url: string;
+};
+
+type Connection<T> = { nodes: T[]; pageInfo: { hasNextPage: boolean; endCursor: string } };
+export type GitHubPullRequestComment = {
+  id: string;
+  body: string;
+  updatedAt: string;
+  author?: { login: string } | null;
+};
+type FeedbackReview = {
+  id: string;
+  body: string;
+  updatedAt: string;
+  state: string;
+  commit: { oid: string } | null;
+};
+type FeedbackThread = { id: string; isResolved: boolean; comments: Connection<GitHubPullRequestComment> };
+type FeedbackNode = {
+  comments: Connection<GitHubPullRequestComment>;
+  reviews: Connection<FeedbackReview>;
+  reviewThreads: Connection<FeedbackThread>;
+};
+
+/** Read PR state and fully paginated feedback through the host's credentials and budget. */
+export function createGitHubPullRequests(
+  github: Pick<GitHubHost, "command" | "ensureGraphQLBudget">,
+  options: { activityAuthors?: readonly string[], ignoreComment?: (comment: GitHubPullRequestComment) => boolean } = {},
+): {
+  list(repository: string): Promise<PullRequest[]>;
+  read(repository: string, number: number): Promise<PullRequest>;
+} {
+  const pullRequestFields =
+    "baseRefOid,baseRefName,body,headRefName,headRefOid,headRepository,isDraft,labels,mergeStateStatus,number,reviewDecision,state,statusCheckRollup,title,updatedAt,url";
+  async function listPullRequests(repository: string) {
+    return await withGraphQLBudget(repository, 256, async () => {
+      const [result, feedback] = await Promise.all([
+        github.command(
+          [
+            "pr",
+            "list",
+            "--repo",
+            repository,
+            "--state",
+            "open",
+            "--limit",
+            "100",
+            "--json",
+            pullRequestFields,
+          ],
+          { repository },
+        ),
+        readOpenPullRequestFeedback(repository),
+      ]);
+      const pullRequests = JSON.parse(result.stdout) as PullRequest[];
+      return await Promise.all(
+        pullRequests.map((pullRequest) =>
+          readRequiredCheckState(repository, {
+            ...pullRequest,
+            ...(feedback.has(pullRequest.number)
+              ? { feedback: feedback.get(pullRequest.number) }
+              : {}),
+          }),
+        ),
+      );
+    });
+  }
+
+  async function readPullRequest(repository: string, number: number) {
+    return await withGraphQLBudget(repository, 16, async () => {
+      const [result, feedback] = await Promise.all([
+        github.command(
+          ["pr", "view", String(number), "--repo", repository, "--json", pullRequestFields],
+          { repository },
+        ),
+        readPullRequestFeedback(repository, number),
+      ]);
+      return await readRequiredCheckState(repository, {
+        ...(JSON.parse(result.stdout) as PullRequest),
+        ...(feedback ? { feedback } : {}),
+      });
+    });
+  }
+
+  async function withGraphQLBudget<T>(repository: string, cost: number, run: () => Promise<T>) {
+    const reservation = await github.ensureGraphQLBudget(repository, { cost });
+    reservation.submit();
+    try {
+      return await run();
+    } finally {
+      // The gh CLI does not expose actual query cost, so settle the reserved upper bound.
+      reservation.settle(cost);
+    }
+  }
+
+  const feedbackFields = `comments(first:100,after:$comments){nodes{id body updatedAt author{login}} pageInfo{hasNextPage endCursor}} reviews(first:100,after:$reviews){nodes{id body updatedAt state commit{oid}} pageInfo{hasNextPage endCursor}} reviewThreads(first:100,after:$threads){nodes{id isResolved comments(first:20){nodes{id body updatedAt} pageInfo{hasNextPage endCursor}}} pageInfo{hasNextPage endCursor}}`;
+
+  async function readOpenPullRequestFeedback(repository: string) {
+    // Bulk first pages keep discovery cheap; large discussions fall back to pagination.
+    const [owner, name] = repository.split("/") as [string, string];
+    const query = `query($owner:String!,$name:String!,$comments:String,$reviews:String,$threads:String){repository(owner:$owner,name:$name){pullRequests(first:100,states:OPEN){nodes{number ${feedbackFields}}}}}`;
+    const result = await github.command(
+      ["api", "graphql", "-f", `owner=${owner}`, "-f", `name=${name}`, "-f", `query=${query}`],
+      { repository },
+    );
+    const nodes: (FeedbackNode & { number: number })[] = JSON.parse(result.stdout)?.data?.repository
+      ?.pullRequests?.nodes;
+    if (!Array.isArray(nodes)) throw new Error("GitHub did not return pull request feedback.");
+    return new Map<number, PullRequestFeedback>(
+      await Promise.all(
+        nodes.map(
+          async (node) =>
+            [
+              node.number,
+              Object.values(feedbackConnections(node)).some(
+                (connection) => connection.pageInfo.hasNextPage,
+              ) ||
+              node.reviewThreads.nodes.some(
+                (thread: FeedbackThread) => thread.comments.pageInfo.hasNextPage,
+              )
+                ? await readPullRequestFeedback(repository, node.number)
+                : digestFeedback(node),
+            ] as [number, PullRequestFeedback],
+        ),
+      ),
+    );
+  }
+
+  function feedbackConnections(
+    node: FeedbackNode,
+  ): Record<string, Connection<GitHubPullRequestComment | FeedbackReview | FeedbackThread>> {
+    if (!node?.comments?.nodes || !node?.reviews?.nodes || !node?.reviewThreads?.nodes)
+      throw new Error("Incomplete GitHub feedback response.");
+    return { comments: node.comments, reviews: node.reviews, threads: node.reviewThreads };
+  }
+
+  function digestFeedback(node: {
+    comments: { nodes: GitHubPullRequestComment[] };
+    reviews: { nodes: FeedbackReview[] };
+    reviewThreads: { nodes: FeedbackThread[] };
+  }): PullRequestFeedback {
+    const comments = node.comments.nodes.filter(comment => !(
+      options.activityAuthors?.includes(comment.author?.login ?? "") && comment.body.startsWith("<!-- vitehub-agent-activity:")
+    ) && !options.ignoreComment?.(comment))
+    const digest = (items: { id: string }[]) => createHash("sha256")
+      .update(JSON.stringify([...items].sort((a, b) => a.id.localeCompare(b.id)), (key, value) => key === "updatedAt" || key === "pageInfo" ? undefined : value))
+      .digest("hex")
+    return {
+      hasDiscussion: comments.some(comment => !!comment.body.trim())
+        || node.reviews.nodes.some(review => !!review.body.trim() || review.state === "CHANGES_REQUESTED")
+        || node.reviewThreads.nodes.some(thread => !thread.isResolved),
+      comments: digest(comments),
+      reviews: digest(node.reviews.nodes),
+      threads: digest(node.reviewThreads.nodes),
+    };
+  }
+
+  async function readPullRequestFeedback(
+    repository: string,
+    number: number,
+  ): Promise<PullRequestFeedback> {
+    const [owner, name] = repository.split("/") as [string, string];
+    const query = `query($owner:String!,$name:String!,$number:Int!,$comments:String,$reviews:String,$threads:String){repository(owner:$owner,name:$name){pullRequest(number:$number){${feedbackFields}}}}`;
+    const cursors = new Map<string, string>();
+    const collected = {
+      comments: new Map<string, GitHubPullRequestComment>(),
+      reviews: new Map<string, FeedbackReview>(),
+      threads: new Map<string, FeedbackThread>(),
+    };
+    do {
+      const result = await github.command(
+        [
+          "api",
+          "graphql",
+          "-f",
+          `owner=${owner}`,
+          "-f",
+          `name=${name}`,
+          "-F",
+          `number=${number}`,
+          "-f",
+          `query=${query}`,
+          ...[...cursors].flatMap(([key, value]) => ["-f", `${key}=${value}`]),
+        ],
+        { repository },
+      );
+      const node: FeedbackNode = JSON.parse(result.stdout)?.data?.repository?.pullRequest;
+      let more = false;
+      for (const [key, connection] of Object.entries(feedbackConnections(node))) {
+        const items = collected[key as keyof typeof collected];
+        for (const item of connection.nodes)
+          (items as Map<string, GitHubPullRequestComment | FeedbackReview | FeedbackThread>).set(
+            item.id,
+            item,
+          );
+        if (connection.pageInfo.hasNextPage) {
+          cursors.set(key, connection.pageInfo.endCursor);
+          more = true;
+        }
+      }
+      if (!more) break;
+    } while (true);
+    for (const thread of collected.threads.values()) {
+      while (thread.comments.pageInfo.hasNextPage) {
+        const query =
+          "query($id:ID!,$after:String){node(id:$id){... on PullRequestReviewThread{comments(first:100,after:$after){nodes{id body updatedAt} pageInfo{hasNextPage endCursor}}}}}";
+        const result = await github.command(
+          [
+            "api",
+            "graphql",
+            "-f",
+            `id=${thread.id}`,
+            "-f",
+            `after=${thread.comments.pageInfo.endCursor}`,
+            "-f",
+            `query=${query}`,
+          ],
+          { repository },
+        );
+        const page = JSON.parse(result.stdout)?.data?.node?.comments;
+        if (!page?.nodes || !page.pageInfo)
+          throw new Error("Incomplete GitHub review thread response.");
+        thread.comments.nodes.push(...page.nodes);
+        thread.comments.pageInfo = page.pageInfo;
+      }
+    }
+    return digestFeedback({
+      comments: { nodes: [...collected.comments.values()] },
+      reviews: { nodes: [...collected.reviews.values()] },
+      reviewThreads: { nodes: [...collected.threads.values()] },
+    });
+  }
+
+  async function readRequiredCheckState(repository: string, pullRequest: PullRequest) {
+    if (pullRequestCheckState(pullRequest.statusCheckRollup) === "passed") return pullRequest;
+    const requiredStatusCheckRollup = await readRequiredChecks(repository, pullRequest.number);
+    return requiredStatusCheckRollup === undefined
+      ? pullRequest
+      : { ...pullRequest, requiredStatusCheckRollup };
+  }
+
+  async function readRequiredChecks(repository: string, number: number) {
+    const args = [
+      "pr",
+      "checks",
+      String(number),
+      "--repo",
+      repository,
+      "--required",
+      "--json",
+      "bucket,name,state,workflow",
+    ];
+    try {
+      const result = await github.command(args, { repository });
+      return parseRequiredChecks(result.stdout, result.stderr);
+    } catch (error) {
+      const result = error as Error & { stderr?: unknown; stdout?: unknown };
+      const checks = parseRequiredChecks(
+        typeof result.stdout === "string" ? result.stdout : "",
+        typeof result.stderr === "string" ? result.stderr : "",
+      );
+      if (checks !== undefined) return checks;
+      throw new Error(`Failed to read required checks for ${repository}#${number}.`, {
+        cause: error,
+      });
+    }
+  }
+
+  return { list: listPullRequests, read: readPullRequest };
+}
+
+export function pullRequestCheckState(
+  statusCheckRollup: unknown,
+  empty: "passed" | "pending" = "pending",
+): "failed" | "passed" | "pending" {
+  if (!Array.isArray(statusCheckRollup) || statusCheckRollup.length === 0) return empty;
+  const failedConclusions = new Set([
+    "ACTION_REQUIRED",
+    "CANCELLED",
+    "FAILURE",
+    "STALE",
+    "STARTUP_FAILURE",
+    "TIMED_OUT",
+  ]);
+  let pending = false;
+  for (const value of statusCheckRollup) {
+    if (!value || typeof value !== "object") {
+      pending = true;
+      continue;
+    }
+    const { bucket, conclusion, state, status } = value as Record<string, unknown>;
+    if (bucket === "fail" || bucket === "cancel") return "failed";
+    if (bucket === "pending") {
+      pending = true;
+      continue;
+    }
+    if (bucket === "pass" || bucket === "skipping") continue;
+    if (
+      state === "ERROR" ||
+      state === "FAILURE" ||
+      (status === "COMPLETED" &&
+        typeof conclusion === "string" &&
+        failedConclusions.has(conclusion))
+    )
+      return "failed";
+    if (status === "COMPLETED") {
+      if (typeof conclusion !== "string" || !conclusion) pending = true;
+    } else if (status !== undefined || state !== "SUCCESS") pending = true;
+  }
+  return pending ? "pending" : "passed";
+}
+
+export function parseRequiredChecks(stdout: string, stderr: string): unknown[] | undefined {
+  if (stdout.trim()) {
+    try {
+      const checks: unknown = JSON.parse(stdout);
+      return Array.isArray(checks) ? checks : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  const message = stderr.trim();
+  return /^no (?:required )?checks reported on the '.+' branch$/.test(message) ? [] : undefined;
+}
+
+/** Derive stable PR thread identity, inspection annotations, and a session link. */
+export async function createGitHubPullRequestRun(
+  repository: string,
+  pullRequest: Pick<PullRequest, 'number' | 'headRefOid' | 'title' | 'url'>,
+  options: { agentName: string, runId: string, publicUrl?: string, sessionUrl?: string },
+): Promise<import('../types.ts').AgentRunMetadata> {
+  const { agentInvocationId } = await import('../invocations.ts')
+  const sessionUrl = options.publicUrl
+    ? new URL(`/_vitehub/agents/${encodeURIComponent(options.agentName)}/invocations/${encodeURIComponent(await agentInvocationId(options.runId, options.agentName))}`, options.publicUrl).href
+    : options.sessionUrl
+  return {
+    runId: options.runId,
+    channelId: 'github',
+    threadId: `github:${repository.toLowerCase()}:pull-request:${pullRequest.number}`,
+    annotations: { 'github.head': pullRequest.headRefOid, 'github.pullRequest': pullRequest.number, 'github.repository': repository, 'github.title': pullRequest.title, 'github.url': pullRequest.url },
+    activity: { target: { repository, issue: pullRequest.number }, links: sessionUrl ? [{ label: 'Current session', url: sessionUrl }] : [] },
+  }
+}

--- a/packages/agent/src/server/github-pull-requests.ts
+++ b/packages/agent/src/server/github-pull-requests.ts
@@ -1,3 +1,4 @@
+import * as v from "valibot"
 import { hasRuntimeType, isRuntimeRecord } from "../internal/runtime-type.ts"
 import { createHash } from "node:crypto";
 import type { GitHubHost } from "./github-host.ts";
@@ -53,6 +54,31 @@ type FeedbackNode = {
   reviewThreads: Connection<FeedbackThread>;
 };
 
+const pullRequestSchema = v.object({
+  baseRefOid: v.string(),
+  baseRefName: v.string(),
+  body: v.string(),
+  headRefName: v.string(),
+  headRefOid: v.string(),
+  headRepository: v.nullable(v.object({ nameWithOwner: v.string() })),
+  isDraft: v.boolean(),
+  labels: v.optional(v.unknown()),
+  mergeStateStatus: v.string(),
+  number: v.pipe(v.number(), v.integer(), v.minValue(1)),
+  reviewDecision: v.nullable(v.string()),
+  state: v.string(),
+  statusCheckRollup: v.unknown(),
+  title: v.string(),
+  updatedAt: v.string(),
+  url: v.string(),
+});
+
+function repositoryParts(repository: string) {
+  const [owner, name, extra] = repository.split("/");
+  if (!owner || !name || extra !== undefined) throw new Error("Expected a GitHub owner/repository.");
+  return { owner, name };
+}
+
 function record(value: unknown): Record<string, unknown> {
   if (!isRuntimeRecord(value)) throw new Error("Incomplete GitHub response.")
   return value
@@ -75,16 +101,7 @@ function graphQL(stdout: string, ...path: string[]): unknown {
   return value
 }
 function parsePullRequest(value: unknown): PullRequest {
-  const pr = record(value)
-  return {
-    baseRefOid: text(pr.baseRefOid), baseRefName: text(pr.baseRefName), body: text(pr.body),
-    headRefName: text(pr.headRefName), headRefOid: text(pr.headRefOid),
-    headRepository: pr.headRepository === null ? null : { nameWithOwner: text(record(pr.headRepository).nameWithOwner) },
-    isDraft: boolean(pr.isDraft), labels: pr.labels, mergeStateStatus: text(pr.mergeStateStatus),
-    number: number(pr.number), reviewDecision: pr.reviewDecision === null ? null : text(pr.reviewDecision),
-    state: text(pr.state), statusCheckRollup: pr.statusCheckRollup,
-    title: text(pr.title), updatedAt: text(pr.updatedAt), url: text(pr.url),
-  }
+  return v.parse(pullRequestSchema, value)
 }
 function parseConnection<T>(value: unknown, parse: (item: unknown) => T): Connection<T> {
   const connection = record(value)
@@ -191,7 +208,7 @@ export function createGitHubPullRequests(
 
   async function readOpenPullRequestFeedback(repository: string) {
     // Bulk first pages keep discovery cheap; large discussions fall back to pagination.
-    const [owner, name] = repository.split("/");
+    const { owner, name } = repositoryParts(repository);
     const query = `query($owner:String!,$name:String!,$comments:String,$reviews:String,$threads:String){repository(owner:$owner,name:$name){pullRequests(first:100,states:OPEN){nodes{number ${feedbackFields}}}}}`;
     const result = await github.command(
       ["api", "graphql", "-f", `owner=${owner}`, "-f", `name=${name}`, "-f", `query=${query}`],
@@ -245,7 +262,7 @@ export function createGitHubPullRequests(
     repository: string,
     number: number,
   ): Promise<PullRequestFeedback> {
-    const [owner, name] = repository.split("/");
+    const { owner, name } = repositoryParts(repository);
     const query = `query($owner:String!,$name:String!,$number:Int!,$comments:String,$reviews:String,$threads:String){repository(owner:$owner,name:$name){pullRequest(number:$number){${feedbackFields}}}}`;
     const cursors = new Map<string, string>();
     const collected = {

--- a/packages/agent/src/server/github-pull-requests.ts
+++ b/packages/agent/src/server/github-pull-requests.ts
@@ -1,3 +1,4 @@
+import { hasRuntimeType, isRuntimeRecord } from "../internal/runtime-type.ts"
 import { createHash } from "node:crypto";
 import type { GitHubHost } from "./github-host.ts";
 
@@ -52,6 +53,67 @@ type FeedbackNode = {
   reviewThreads: Connection<FeedbackThread>;
 };
 
+function record(value: unknown): Record<string, unknown> {
+  if (!isRuntimeRecord(value)) throw new Error("Incomplete GitHub response.")
+  return value
+}
+function text(value: unknown): string {
+  if (!hasRuntimeType(value, "string")) throw new Error("GitHub returned an invalid string field.")
+  return value
+}
+function number(value: unknown): number {
+  if (!hasRuntimeType(value, "number") || !Number.isInteger(value) || value <= 0) throw new Error("GitHub returned an invalid PR number.")
+  return value
+}
+function boolean(value: unknown): boolean {
+  if (!hasRuntimeType(value, "boolean")) throw new Error("GitHub returned an invalid boolean field.")
+  return value
+}
+function graphQL(stdout: string, ...path: string[]): unknown {
+  let value: unknown = JSON.parse(stdout)
+  for (const key of path) value = record(value)[key]
+  return value
+}
+function parsePullRequest(value: unknown): PullRequest {
+  const pr = record(value)
+  return {
+    baseRefOid: text(pr.baseRefOid), baseRefName: text(pr.baseRefName), body: text(pr.body),
+    headRefName: text(pr.headRefName), headRefOid: text(pr.headRefOid),
+    headRepository: pr.headRepository === null ? null : { nameWithOwner: text(record(pr.headRepository).nameWithOwner) },
+    isDraft: boolean(pr.isDraft), labels: pr.labels, mergeStateStatus: text(pr.mergeStateStatus),
+    number: number(pr.number), reviewDecision: pr.reviewDecision === null ? null : text(pr.reviewDecision),
+    state: text(pr.state), statusCheckRollup: pr.statusCheckRollup,
+    title: text(pr.title), updatedAt: text(pr.updatedAt), url: text(pr.url),
+  }
+}
+function parseConnection<T>(value: unknown, parse: (item: unknown) => T): Connection<T> {
+  const connection = record(value)
+  if (!Array.isArray(connection.nodes)) throw new Error("Incomplete GitHub connection.")
+  const page = record(connection.pageInfo)
+  const hasNextPage = boolean(page.hasNextPage)
+  const endCursor = page.endCursor === null ? "" : text(page.endCursor)
+  if (hasNextPage && !endCursor) throw new Error("GitHub omitted a pagination cursor.")
+  return { nodes: connection.nodes.map(parse), pageInfo: { hasNextPage, endCursor } }
+}
+function parseComment(value: unknown): GitHubPullRequestComment {
+  const item = record(value)
+  return { id: text(item.id), body: text(item.body), updatedAt: text(item.updatedAt), author: item.author == null ? null : { login: text(record(item.author).login) } }
+}
+function parseFeedback(value: unknown): FeedbackNode {
+  const node = record(value)
+  return {
+    comments: parseConnection(node.comments, parseComment),
+    reviews: parseConnection(node.reviews, value => {
+      const item = record(value)
+      return { id: text(item.id), body: text(item.body), updatedAt: text(item.updatedAt), state: text(item.state), commit: item.commit === null ? null : { oid: text(record(item.commit).oid) } }
+    }),
+    reviewThreads: parseConnection(node.reviewThreads, value => {
+      const item = record(value)
+      return { id: text(item.id), isResolved: boolean(item.isResolved), comments: parseConnection(item.comments, parseComment) }
+    }),
+  }
+}
+
 /** Read PR state and fully paginated feedback through the host's credentials and budget. */
 export function createGitHubPullRequests(
   github: Pick<GitHubHost, "command" | "ensureGraphQLBudget">,
@@ -82,7 +144,9 @@ export function createGitHubPullRequests(
         ),
         readOpenPullRequestFeedback(repository),
       ]);
-      const pullRequests = JSON.parse(result.stdout) as PullRequest[];
+      const payload: unknown = JSON.parse(result.stdout);
+      if (!Array.isArray(payload)) throw new Error("GitHub did not return a PR list.");
+      const pullRequests = payload.map(parsePullRequest);
       return await Promise.all(
         pullRequests.map((pullRequest) =>
           readRequiredCheckState(repository, {
@@ -106,8 +170,8 @@ export function createGitHubPullRequests(
         readPullRequestFeedback(repository, number),
       ]);
       return await readRequiredCheckState(repository, {
-        ...(JSON.parse(result.stdout) as PullRequest),
-        ...(feedback ? { feedback } : {}),
+        ...parsePullRequest(JSON.parse(result.stdout)),
+        feedback,
       });
     });
   }
@@ -127,31 +191,23 @@ export function createGitHubPullRequests(
 
   async function readOpenPullRequestFeedback(repository: string) {
     // Bulk first pages keep discovery cheap; large discussions fall back to pagination.
-    const [owner, name] = repository.split("/") as [string, string];
+    const [owner, name] = repository.split("/");
     const query = `query($owner:String!,$name:String!,$comments:String,$reviews:String,$threads:String){repository(owner:$owner,name:$name){pullRequests(first:100,states:OPEN){nodes{number ${feedbackFields}}}}}`;
     const result = await github.command(
       ["api", "graphql", "-f", `owner=${owner}`, "-f", `name=${name}`, "-f", `query=${query}`],
       { repository },
     );
-    const nodes: (FeedbackNode & { number: number })[] = JSON.parse(result.stdout)?.data?.repository
-      ?.pullRequests?.nodes;
+    const nodes = graphQL(result.stdout, "data", "repository", "pullRequests", "nodes");
     if (!Array.isArray(nodes)) throw new Error("GitHub did not return pull request feedback.");
     return new Map<number, PullRequestFeedback>(
       await Promise.all(
-        nodes.map(
-          async (node) =>
-            [
-              node.number,
-              Object.values(feedbackConnections(node)).some(
-                (connection) => connection.pageInfo.hasNextPage,
-              ) ||
-              node.reviewThreads.nodes.some(
-                (thread: FeedbackThread) => thread.comments.pageInfo.hasNextPage,
-              )
-                ? await readPullRequestFeedback(repository, node.number)
-                : digestFeedback(node),
-            ] as [number, PullRequestFeedback],
-        ),
+        nodes.map(async (value): Promise<[number, PullRequestFeedback]> => {
+          const node = parseFeedback(value)
+          const prNumber = number(record(value).number)
+          const more = Object.values(feedbackConnections(node)).some(connection => connection.pageInfo.hasNextPage)
+            || node.reviewThreads.nodes.some(thread => thread.comments.pageInfo.hasNextPage)
+          return [prNumber, more ? await readPullRequestFeedback(repository, prNumber) : digestFeedback(node)]
+        }),
       ),
     );
   }
@@ -189,7 +245,7 @@ export function createGitHubPullRequests(
     repository: string,
     number: number,
   ): Promise<PullRequestFeedback> {
-    const [owner, name] = repository.split("/") as [string, string];
+    const [owner, name] = repository.split("/");
     const query = `query($owner:String!,$name:String!,$number:Int!,$comments:String,$reviews:String,$threads:String){repository(owner:$owner,name:$name){pullRequest(number:$number){${feedbackFields}}}}`;
     const cursors = new Map<string, string>();
     const collected = {
@@ -214,20 +270,19 @@ export function createGitHubPullRequests(
         ],
         { repository },
       );
-      const node: FeedbackNode = JSON.parse(result.stdout)?.data?.repository?.pullRequest;
+      const node = parseFeedback(graphQL(result.stdout, "data", "repository", "pullRequest"));
       let more = false;
-      for (const [key, connection] of Object.entries(feedbackConnections(node))) {
-        const items = collected[key as keyof typeof collected];
-        for (const item of connection.nodes)
-          (items as Map<string, GitHubPullRequestComment | FeedbackReview | FeedbackThread>).set(
-            item.id,
-            item,
-          );
+      function collect<T extends { id: string }>(key: string, items: Map<string, T>, connection: Connection<T>) {
+        for (const item of connection.nodes) items.set(item.id, item)
         if (connection.pageInfo.hasNextPage) {
-          cursors.set(key, connection.pageInfo.endCursor);
-          more = true;
+          if (cursors.get(key) === connection.pageInfo.endCursor) throw new Error("GitHub pagination did not advance.")
+          cursors.set(key, connection.pageInfo.endCursor)
+          more = true
         }
       }
+      collect("comments", collected.comments, node.comments)
+      collect("reviews", collected.reviews, node.reviews)
+      collect("threads", collected.threads, node.reviewThreads)
       if (!more) break;
     } while (true);
     for (const thread of collected.threads.values()) {
@@ -247,9 +302,8 @@ export function createGitHubPullRequests(
           ],
           { repository },
         );
-        const page = JSON.parse(result.stdout)?.data?.node?.comments;
-        if (!page?.nodes || !page.pageInfo)
-          throw new Error("Incomplete GitHub review thread response.");
+        const page = parseConnection(graphQL(result.stdout, "data", "node", "comments"), parseComment);
+        if (page.pageInfo.hasNextPage && page.pageInfo.endCursor === thread.comments.pageInfo.endCursor) throw new Error("GitHub thread pagination did not advance.");
         thread.comments.nodes.push(...page.nodes);
         thread.comments.pageInfo = page.pageInfo;
       }
@@ -284,10 +338,10 @@ export function createGitHubPullRequests(
       const result = await github.command(args, { repository });
       return parseRequiredChecks(result.stdout, result.stderr);
     } catch (error) {
-      const result = error as Error & { stderr?: unknown; stdout?: unknown };
+      const result = isRuntimeRecord(error) ? error : {};
       const checks = parseRequiredChecks(
-        typeof result.stdout === "string" ? result.stdout : "",
-        typeof result.stderr === "string" ? result.stderr : "",
+        hasRuntimeType(result.stdout, "string") ? result.stdout : "",
+        hasRuntimeType(result.stderr, "string") ? result.stderr : "",
       );
       if (checks !== undefined) return checks;
       throw new Error(`Failed to read required checks for ${repository}#${number}.`, {
@@ -314,11 +368,11 @@ export function pullRequestCheckState(
   ]);
   let pending = false;
   for (const value of statusCheckRollup) {
-    if (!value || typeof value !== "object") {
+    if (!isRuntimeRecord(value)) {
       pending = true;
       continue;
     }
-    const { bucket, conclusion, state, status } = value as Record<string, unknown>;
+    const { bucket, conclusion, state, status } = value;
     if (bucket === "fail" || bucket === "cancel") return "failed";
     if (bucket === "pending") {
       pending = true;
@@ -329,12 +383,12 @@ export function pullRequestCheckState(
       state === "ERROR" ||
       state === "FAILURE" ||
       (status === "COMPLETED" &&
-        typeof conclusion === "string" &&
+        hasRuntimeType(conclusion, "string") &&
         failedConclusions.has(conclusion))
     )
       return "failed";
     if (status === "COMPLETED") {
-      if (typeof conclusion !== "string" || !conclusion) pending = true;
+      if (!hasRuntimeType(conclusion, "string") || !conclusion) pending = true;
     } else if (status !== undefined || state !== "SUCCESS") pending = true;
   }
   return pending ? "pending" : "passed";

--- a/packages/agent/src/server/github-workspace.ts
+++ b/packages/agent/src/server/github-workspace.ts
@@ -70,7 +70,7 @@ export function createGitHubInvocationWorkspaceHandler(options: {
     const invocation = await options.invocations.get(id)
     const repository = invocation?.annotations?.['github.repository']
     const revision = invocation?.annotations?.['github.head']
-    if (typeof repository !== 'string' || typeof revision !== 'string') return new Response('Workspace snapshot not found', { status: 404 })
+    if (!hasRuntimeType(repository, "string") || !hasRuntimeType(revision, "string")) return new Response('Workspace snapshot not found', { status: 404 })
     const workspace = { repository, revision }
     try {
       return Response.json(path === undefined ? { ...workspace, paths: await inspector.list(workspace) } : await inspector.read(workspace, path))

--- a/packages/agent/src/server/github-workspace.ts
+++ b/packages/agent/src/server/github-workspace.ts
@@ -70,7 +70,7 @@ export function createGitHubInvocationWorkspaceHandler(options: {
     const invocation = await options.invocations.get(id)
     const repository = invocation?.annotations?.['github.repository']
     const revision = invocation?.annotations?.['github.head']
-    if (typeof repository !== 'string' || typeof revision !== 'string') return new Response('Workspace snapshot not found', { status: 404 })
+    if (!hasRuntimeType(repository, 'string') || !hasRuntimeType(revision, 'string')) return new Response('Workspace snapshot not found', { status: 404 })
     const workspace = { repository, revision }
     try {
       return Response.json(path === undefined ? { ...workspace, paths: await inspector.list(workspace) } : await inspector.read(workspace, path))

--- a/packages/agent/src/server/github-workspace.ts
+++ b/packages/agent/src/server/github-workspace.ts
@@ -59,3 +59,24 @@ export function createGitHubWorkspaceInspector(host: Pick<GitHubHost, "command">
     },
   }
 }
+
+/** Serve an invocation's immutable GitHub checkout through a host-managed route. */
+export function createGitHubInvocationWorkspaceHandler(options: {
+  host: Pick<GitHubHost, 'command'>
+  invocations: Pick<import('../invocations.ts').AgentInvocations, 'get'>
+}): (id: string, path?: string) => Promise<Response> {
+  const inspector = createGitHubWorkspaceInspector(options.host)
+  return async (id, path) => {
+    const invocation = await options.invocations.get(id)
+    const repository = invocation?.annotations?.['github.repository']
+    const revision = invocation?.annotations?.['github.head']
+    if (typeof repository !== 'string' || typeof revision !== 'string') return new Response('Workspace snapshot not found', { status: 404 })
+    const workspace = { repository, revision }
+    try {
+      return Response.json(path === undefined ? { ...workspace, paths: await inspector.list(workspace) } : await inspector.read(workspace, path))
+    }
+    catch {
+      return new Response('Workspace snapshot unavailable', { status: 422 })
+    }
+  }
+}

--- a/packages/agent/src/server/github.ts
+++ b/packages/agent/src/server/github.ts
@@ -16,5 +16,8 @@ export type {
   GitHubHostSecret,
 } from "./github-host.ts"
 
-export { createGitHubWorkspaceInspector } from "./github-workspace.ts"
+export { createGitHubWorkspaceInspector, createGitHubInvocationWorkspaceHandler } from "./github-workspace.ts"
 export type { GitHubWorkspaceRevision, GitHubWorkspaceInspector } from "./github-workspace.ts"
+
+export { createGitHubPullRequests, createGitHubPullRequestRun, pullRequestCheckState, parseRequiredChecks } from './github-pull-requests.ts'
+export type { PullRequest, PullRequestFeedback, GitHubPullRequestComment } from './github-pull-requests.ts'

--- a/packages/agent/src/vite.ts
+++ b/packages/agent/src/vite.ts
@@ -3031,3 +3031,5 @@ declare module "vite" {
     agent?: false | AgentModuleOptions
   }
 }
+
+export { processAgentHost } from './process-host-vite.ts'

--- a/packages/agent/test/channels.test.ts
+++ b/packages/agent/test/channels.test.ts
@@ -277,7 +277,8 @@ describe("agent channels", () => {
       releaseIdentity!()
       await background[0]
       expect(fetcher).toHaveBeenCalledWith(expect.stringContaining("/repos/acme/app/issues/42/comments"), expect.objectContaining({ method: "POST" }))
-      expect(storedBody).toContain("| Starting |")
+      expect(storedBody).toContain("Waiting to start.")
+      expect(storedBody).not.toContain("| Session |")
 
       // SAFETY: This fixture supplies the callback fields consumed by the activity updater.
       await channel.activity?.update({

--- a/packages/agent/test/console-delivery.test.ts
+++ b/packages/agent/test/console-delivery.test.ts
@@ -1,0 +1,12 @@
+import { expect, it } from 'vitest'
+import { createAgentConsoleDelivery } from '../src/server/console-delivery.ts'
+
+it('requires a complete optional console configuration', () => {
+  expect(createAgentConsoleDelivery({})).toBeUndefined()
+  expect(() => createAgentConsoleDelivery({ url: 'https://console.example' })).toThrow('both')
+  expect(() => createAgentConsoleDelivery({ token: 'token' })).toThrow('both')
+  expect(() => createAgentConsoleDelivery({ url: 'file:///tmp/token', token: 'token' })).toThrow('HTTP(S)')
+  const client = createAgentConsoleDelivery({ url: 'https://console.example', token: { unseal: () => 'token' } })!
+  expect(client.endpoint('/api/otlp')).toBe('https://console.example/api/otlp')
+  expect(client.headers()).toEqual({ authorization: 'Bearer token' })
+})

--- a/packages/agent/test/github-host-environment.test.ts
+++ b/packages/agent/test/github-host-environment.test.ts
@@ -1,0 +1,46 @@
+import { expect, it, vi } from "vitest";
+
+vi.mock("node:child_process", async () => {
+  const { promisify } = await import("node:util");
+  return {
+    execFile: Object.assign(() => {}, {
+      [promisify.custom]: async (_command: string, args: string[]) => ({
+        stdout: args.includes("rev-parse") ? "a".repeat(40) : "",
+        stderr: "",
+      }),
+    }),
+  };
+});
+
+import { createGitHubHost } from "../src/server/github-host.ts";
+
+it("isolates provider credentials and git directories across concurrent checkouts", async () => {
+  let token = 0
+  const host = createGitHubHost({
+    credentials: () => ({ token: `token-${++token}`, rateLimitKey: "test" }),
+    identity: { login: "worker" },
+  });
+  let release!: () => void;
+  let arrived = 0;
+  const barrier = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const directories = await Promise.all(
+    ["acme/one", "acme/two"].map((repository) =>
+      host.withPullRequestCheckout(
+        { repository, number: 1, headSha: "a".repeat(40) },
+        async (checkout) => {
+          if (++arrived === 2) release();
+          await barrier;
+          const env = await host.environment();
+          expect(env.GH_TOKEN).toBe(checkout.token);
+          expect(env.GIT_DIR).toBe(`${checkout.path}/.git`);
+          expect(env.GIT_WORK_TREE).toBe(".");
+          return env.GIT_DIR;
+        },
+      ),
+    ),
+  );
+  expect(directories[0]).not.toBe(directories[1]);
+  expect((await host.environment()).GIT_DIR).toBeUndefined();
+});

--- a/packages/agent/test/github-pull-requests.test.ts
+++ b/packages/agent/test/github-pull-requests.test.ts
@@ -21,7 +21,7 @@ function host(node = feedback()) {
     stderr: "",
     stdout: JSON.stringify(
       args[0] === "pr"
-        ? { number: 1, statusCheckRollup: [{ state: "SUCCESS" }] }
+        ? { number: 1, baseRefOid: "base", baseRefName: "main", body: "", headRefName: "feature", headRefOid: "head", headRepository: null, isDraft: false, mergeStateStatus: "CLEAN", reviewDecision: null, state: "OPEN", title: "Title", updatedAt: "now", url: "https://github.com/acme/app/pull/1", statusCheckRollup: [{ state: "SUCCESS" }] }
         : { data: { repository: { pullRequest: node } } },
     ),
   }));

--- a/packages/agent/test/github-pull-requests.test.ts
+++ b/packages/agent/test/github-pull-requests.test.ts
@@ -15,13 +15,20 @@ const feedback = (body = "hello", login = "reviewer") => ({
   reviewThreads: connection(),
 });
 
-function host(node = feedback()) {
+const snapshot = {
+  number: 1, baseRefOid: "base", baseRefName: "main", body: "", headRefName: "feature",
+  headRefOid: "head", headRepository: { nameWithOwner: "acme/app" }, isDraft: false,
+  mergeStateStatus: "CLEAN", reviewDecision: null, state: "OPEN", title: "Change",
+  updatedAt: "now", url: "https://github.com/acme/app/pull/1", statusCheckRollup: [{ state: "SUCCESS" }],
+};
+
+function host(node = feedback(), pullRequest: unknown = snapshot) {
   const settle = vi.fn();
   const command = vi.fn(async (args: string[]) => ({
     stderr: "",
     stdout: JSON.stringify(
       args[0] === "pr"
-        ? { number: 1, statusCheckRollup: [{ state: "SUCCESS" }] }
+        ? pullRequest
         : { data: { repository: { pullRequest: node } } },
     ),
   }));
@@ -79,3 +86,42 @@ it('ignores timestamp-only edits while retaining changed feedback', async () => 
   const third = await createGitHubPullRequests(host(node)).read('acme/app', 1)
   expect(third.feedback).not.toEqual(second.feedback)
 })
+
+
+it("rejects malformed snapshots and settles admission", async () => {
+  for (const invalid of [null, { ...snapshot, number: "1" }, { ...snapshot, headRefOid: null }]) {
+    const github = host(feedback(), invalid);
+    await expect(createGitHubPullRequests(github).read("acme/app", 1)).rejects.toThrow();
+    expect(github.settle).toHaveBeenCalledWith(16);
+  }
+});
+
+it("validates every listed snapshot", async () => {
+  const github = host();
+  github.command.mockImplementation(async (args: string[]) => ({ stderr: "", stdout: JSON.stringify(
+    args[0] === "pr" ? [snapshot] : { data: { repository: { pullRequests: { nodes: [{ number: 1, ...feedback() }] } } } },
+  ) }));
+  expect(await createGitHubPullRequests(github).list("acme/app")).toEqual([
+    expect.objectContaining({ number: 1, headRefOid: "head" }),
+  ]);
+});
+
+
+it("collects each feedback connection across pages", async () => {
+  const first = feedback();
+  const second = feedback("Second comment");
+  second.comments.nodes[0]!.id = "c2";
+  const github = host();
+  github.command.mockImplementation(async (args: string[]) => ({ stderr: "", stdout: JSON.stringify(
+    args[0] === "pr" ? snapshot : { data: { repository: { pullRequest: args.includes("comments=cursor") ? second : {
+      ...first,
+      comments: { ...first.comments, pageInfo: { hasNextPage: true, endCursor: "cursor" } },
+    } } } },
+  ) }));
+  const combined = feedback();
+  combined.comments.nodes.push(...second.comments.nodes);
+  const expected = await createGitHubPullRequests(host(combined)).read("acme/app", 1);
+  const actual = await createGitHubPullRequests(github).read("acme/app", 1);
+  expect(actual.feedback).toEqual(expected.feedback);
+  expect(github.command).toHaveBeenCalledTimes(3);
+});

--- a/packages/agent/test/github-pull-requests.test.ts
+++ b/packages/agent/test/github-pull-requests.test.ts
@@ -15,13 +15,20 @@ const feedback = (body = "hello", login = "reviewer") => ({
   reviewThreads: connection(),
 });
 
-function host(node = feedback()) {
+const snapshot = {
+  number: 1, baseRefOid: "base", baseRefName: "main", body: "", headRefName: "feature",
+  headRefOid: "head", headRepository: { nameWithOwner: "acme/app" }, isDraft: false,
+  mergeStateStatus: "CLEAN", reviewDecision: null, state: "OPEN", title: "Change",
+  updatedAt: "now", url: "https://github.com/acme/app/pull/1", statusCheckRollup: [{ state: "SUCCESS" }],
+};
+
+function host(node = feedback(), pullRequest: unknown = snapshot) {
   const settle = vi.fn();
   const command = vi.fn(async (args: string[]) => ({
     stderr: "",
     stdout: JSON.stringify(
       args[0] === "pr"
-        ? { number: 1, baseRefOid: "base", baseRefName: "main", body: "", headRefName: "feature", headRefOid: "head", headRepository: null, isDraft: false, mergeStateStatus: "CLEAN", reviewDecision: null, state: "OPEN", title: "Title", updatedAt: "now", url: "https://github.com/acme/app/pull/1", statusCheckRollup: [{ state: "SUCCESS" }] }
+        ? pullRequest
         : { data: { repository: { pullRequest: node } } },
     ),
   }));
@@ -79,3 +86,42 @@ it('ignores timestamp-only edits while retaining changed feedback', async () => 
   const third = await createGitHubPullRequests(host(node)).read('acme/app', 1)
   expect(third.feedback).not.toEqual(second.feedback)
 })
+
+
+it("rejects malformed snapshots and settles admission", async () => {
+  for (const invalid of [null, { ...snapshot, number: "1" }, { ...snapshot, headRefOid: null }]) {
+    const github = host(feedback(), invalid);
+    await expect(createGitHubPullRequests(github).read("acme/app", 1)).rejects.toThrow();
+    expect(github.settle).toHaveBeenCalledWith(16);
+  }
+});
+
+it("validates every listed snapshot", async () => {
+  const github = host();
+  github.command.mockImplementation(async (args: string[]) => ({ stderr: "", stdout: JSON.stringify(
+    args[0] === "pr" ? [snapshot] : { data: { repository: { pullRequests: { nodes: [{ number: 1, ...feedback() }] } } } },
+  ) }));
+  expect(await createGitHubPullRequests(github).list("acme/app")).toEqual([
+    expect.objectContaining({ number: 1, headRefOid: "head" }),
+  ]);
+});
+
+
+it("collects each feedback connection across pages", async () => {
+  const first = feedback();
+  const second = feedback("Second comment");
+  second.comments.nodes[0]!.id = "c2";
+  const github = host();
+  github.command.mockImplementation(async (args: string[]) => ({ stderr: "", stdout: JSON.stringify(
+    args[0] === "pr" ? snapshot : { data: { repository: { pullRequest: args.includes("comments=cursor") ? second : {
+      ...first,
+      comments: { ...first.comments, pageInfo: { hasNextPage: true, endCursor: "cursor" } },
+    } } } },
+  ) }));
+  const combined = feedback();
+  combined.comments.nodes.push(...second.comments.nodes);
+  const expected = await createGitHubPullRequests(host(combined)).read("acme/app", 1);
+  const actual = await createGitHubPullRequests(github).read("acme/app", 1);
+  expect(actual.feedback).toEqual(expected.feedback);
+  expect(github.command).toHaveBeenCalledTimes(3);
+});

--- a/packages/agent/test/github-pull-requests.test.ts
+++ b/packages/agent/test/github-pull-requests.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  createGitHubPullRequests,
+  parseRequiredChecks,
+  pullRequestCheckState,
+} from "../src/server/github-pull-requests.ts";
+
+const connection = <T>(nodes: T[] = []) => ({
+  nodes,
+  pageInfo: { hasNextPage: false, endCursor: null },
+});
+const feedback = (body = "hello", login = "reviewer") => ({
+  comments: connection([{ id: "c1", body, updatedAt: "now", author: { login } }]),
+  reviews: connection(),
+  reviewThreads: connection(),
+});
+
+function host(node = feedback()) {
+  const settle = vi.fn();
+  const command = vi.fn(async (args: string[]) => ({
+    stderr: "",
+    stdout: JSON.stringify(
+      args[0] === "pr"
+        ? { number: 1, statusCheckRollup: [{ state: "SUCCESS" }] }
+        : { data: { repository: { pullRequest: node } } },
+    ),
+  }));
+  return {
+    command,
+    ensureGraphQLBudget: vi.fn(async () => ({ submit: vi.fn(), settle, release: vi.fn(), checkedAt: 0, remaining: 5000, resetAt: 9999999 })),
+    settle,
+  };
+}
+
+describe("GitHub pull request snapshots", () => {
+  it("keeps failures actionable when another check is pending", () => {
+    expect(pullRequestCheckState([{ bucket: "pending" }, { bucket: "fail" }])).toBe("failed");
+    expect(pullRequestCheckState([{ state: "SUCCESS" }])).toBe("passed");
+    expect(parseRequiredChecks("", "no required checks reported on the 'main' branch")).toEqual([]);
+    expect(parseRequiredChecks("invalid", "")).toBeUndefined();
+  });
+
+  it("ignores activity only from configured identities", async () => {
+    const first = host(feedback("<!-- vitehub-agent-activity:one -->", "agent[bot]"));
+    const second = host(feedback("<!-- vitehub-agent-activity:two -->", "agent[bot]"));
+    const options = { activityAuthors: ["agent[bot]"] };
+    expect((await createGitHubPullRequests(first, options).read("acme/app", 1)).feedback).toEqual(
+      (await createGitHubPullRequests(second, options).read("acme/app", 1)).feedback,
+    );
+    expect((await createGitHubPullRequests(first).read("acme/app", 1)).feedback).not.toEqual(
+      (await createGitHubPullRequests(second).read("acme/app", 1)).feedback,
+    );
+    expect(first.settle).toHaveBeenCalledWith(16);
+  });
+
+  it("propagates transport failures and settles admission", async () => {
+    const github = host();
+    github.command.mockRejectedValue(new Error("network unavailable"));
+    await expect(createGitHubPullRequests(github).read("acme/app", 1)).rejects.toThrow(
+      "network unavailable",
+    );
+    expect(github.settle).toHaveBeenCalledOnce();
+  });
+});
+
+it("retains discussions for conservative scheduler wait decisions", async () => {
+  expect((await createGitHubPullRequests(host()).read("acme/app", 1)).feedback?.hasDiscussion).toBe(
+    true,
+  );
+});
+
+it('ignores timestamp-only edits while retaining changed feedback', async () => {
+  const node = feedback()
+  const first = await createGitHubPullRequests(host(node)).read('acme/app', 1)
+  node.comments.nodes[0]!.updatedAt = 'later'
+  const second = await createGitHubPullRequests(host(node)).read('acme/app', 1)
+  expect(first.feedback).toEqual(second.feedback)
+  node.comments.nodes[0]!.body = 'Fix this defect'
+  const third = await createGitHubPullRequests(host(node)).read('acme/app', 1)
+  expect(third.feedback).not.toEqual(second.feedback)
+})

--- a/packages/agent/test/process-host-vite.test.ts
+++ b/packages/agent/test/process-host-vite.test.ts
@@ -1,0 +1,22 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, it } from 'vitest'
+import { processAgentHost } from '../src/process-host-vite.ts'
+import { hasRuntimeType } from '../src/internal/runtime-type.ts'
+
+it('generates the route used by the drain CLI by default', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'vitehub-host-plugin-'))
+  try {
+    const hook = processAgentHost({ entry: 'host.ts' }).config
+    if (!hasRuntimeType(hook, 'function')) throw new Error('Expected a config hook')
+    // SAFETY: This plugin config hook uses only the supplied config root, not its Vite context.
+    const result = await hook.call({} as never, { root }, { command: 'build', mode: 'production' })
+    const drain = await readFile(join(root, '.vitehub/process-host/drain.ts'), 'utf8')
+    const cli = await readFile(new URL('../../runtime/src/drain.ts', import.meta.url), 'utf8')
+    expect(cli).toContain('/api/drain')
+    expect(drain).toContain('host.status()')
+    // The generated Nitro route must match the CLI, as well as the handler file.
+    expect(result).toMatchObject({ nitro: { handlers: [{ route: '/api/drain' }] } })
+  } finally { await rm(root, { recursive: true, force: true }) }
+})

--- a/packages/agent/test/process-host.test.ts
+++ b/packages/agent/test/process-host.test.ts
@@ -1,0 +1,41 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, it, vi } from "vitest";
+import { createProcessAgentHost } from "../src/runtime/process.ts";
+
+it("starts once and drains tracked work before closing", async () => {
+  const dataDir = await mkdtemp(join(tmpdir(), "vitehub-process-host-"));
+  let release!: () => void;
+  const work = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const run = vi.fn((_reason, { track }, accepting) => {
+    expect(accepting()).toBe(true);
+    track(work);
+  });
+  const host = await createProcessAgentHost({ dataDir, capacity: { concurrency: 1 }, run });
+  try {
+    expect(host.status()).toBe("starting");
+    host.start();
+    host.start();
+    await vi.waitFor(() => expect(run).toHaveBeenCalledOnce());
+    let closed = false;
+    const close = host.close().then(() => {
+      closed = true;
+    });
+    await Promise.resolve();
+    expect(closed).toBe(false);
+    release();
+    await close;
+    expect(host.status()).toBe("drained");
+    host.wake();
+    host.start();
+    expect(run).toHaveBeenCalledOnce();
+    expect((await host.health()).workload.stale).toBe(0);
+  } finally {
+    release();
+    await host.close();
+    await rm(dataDir, { recursive: true, force: true });
+  }
+});

--- a/packages/agent/test/process-host.test.ts
+++ b/packages/agent/test/process-host.test.ts
@@ -14,7 +14,7 @@ it("starts once and drains tracked work before closing", async () => {
     expect(accepting()).toBe(true);
     track(work);
   });
-  const host = await createProcessAgentHost({ dataDir, capacity: { concurrency: 1 }, run });
+  const host = await createProcessAgentHost({ dataDir: join(dataDir, "nested"), capacity: { concurrency: 1 }, run });
   try {
     expect(host.status()).toBe("starting");
     host.start();

--- a/packages/agent/test/publish-activity.test.ts
+++ b/packages/agent/test/publish-activity.test.ts
@@ -1,0 +1,31 @@
+import { expect, it, vi } from "vitest";
+import { publishAgentActivity } from "../src/index.ts";
+
+it("publishes a deterministic wait without resolving an agent or starting a provider", async () => {
+  const update = vi.fn();
+  const resolve = vi.fn(() => {
+    throw new Error("must not start a provider");
+  });
+  const agent = {
+    name: "worker",
+    resolve,
+    channels: { github: { kind: "github", activity: { update } } },
+  };
+  await publishAgentActivity(agent, {
+    channelId: "github",
+    target: { repository: "acme/app", issue: 1 },
+    activity: {
+      runId: "wait:head",
+      status: "queued",
+      links: [],
+      tasks: [],
+      summary: "Waiting for checks.",
+    },
+  });
+  expect(resolve).not.toHaveBeenCalled();
+  expect(update).toHaveBeenCalledWith(
+    expect.objectContaining({
+      activity: expect.objectContaining({ summary: "Waiting for checks.", agentName: "worker" }),
+    }),
+  );
+});

--- a/packages/agent/test/publish-activity.test.ts
+++ b/packages/agent/test/publish-activity.test.ts
@@ -1,4 +1,6 @@
 import { expect, it, vi } from "vitest";
+vi.mock("#vitehub/agent/registry", () => ({ default: {} }));
+
 import { publishAgentActivity } from "../src/index.ts";
 
 it("publishes a deterministic wait without resolving an agent or starting a provider", async () => {


### PR DESCRIPTION
Babysitter currently rebuilds agent drivers for each PR checkout and implements GitHub snapshot reads, process startup/drain, storage recovery, and Console delivery itself. This change puts those shared operations in ViteHub, leaving PR selection and merge policy in the application.

The process host composes existing capacity and invocation recovery with Nitro lifecycle integration. GitHub hosts share channel credentials and resolve provider environments within each concurrent checkout. Typed PR snapshots include paginated feedback and required checks, while deterministic activity updates can report waiting without starting a provider. A claimed comment shows “Waiting to start.” until a session exists. Session links, prior results, and immutable workspace inspection remain available.

The Babysitter consumer applies the built package through `pnpm patch`. Consumer build and typecheck passed. Upstream package build/typecheck, repository lint, and 71 focused tests passed, including concurrent credential isolation, drain completion, activity claims, and feedback change detection. Generic review and merge-conflict skills are available as versioned Sources.

The process data directory remains exclusive to one running host. PR-specific wait, review, and merge policy remains in Babysitter.

Model: GPT-6 Astra, medium. Harness: Codex.
