### PR TITLE
feat(agent): load process hosts from named exports

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -373,6 +373,16 @@ Agent Definition. `host.health()` reports provider availability and stale record
 `host.wake()` requests discovery after work completes. `host.start()` is idempotent;
 `host.close()` stops admission and waits for tracked work.
 
+The host can also live beside an Agent Definition as a named export. Keep the
+Agent Definition as the module's default export and select the host in Vite:
+
+```ts
+processAgentHost({ entry: './server/agents/babysitter/agent.ts', exportName: 'host' })
+```
+
+`exportName` defaults to `default`. Both startup/shutdown and the drain route use
+the selected export; no separate host entry file is required.
+
 For Nitro, add `processAgentHost({ entry: './server/host.ts' })` from
 `@vite-hub/agent/vite` to the Vite plugins. The entry exports the host as default.
 The plugin starts it and closes it with Nitro, and serves drain status at

--- a/packages/agent/src/process-host-vite.ts
+++ b/packages/agent/src/process-host-vite.ts
@@ -2,14 +2,20 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { resolve } from "node:path";
 import type { Plugin } from "vite";
 
-/** Install a process host exported as default from an application module into Nitro. */
-export function processAgentHost(options: { entry: string; drainRoute?: string }): Plugin {
+/** Install a process host exported from an application module into Nitro. */
+export function processAgentHost(options: { entry: string; exportName?: string; drainRoute?: string }): Plugin {
   return {
     name: "vitehub:process-agent-host",
     async config(config) {
       const root = resolve(config.root ?? process.cwd());
       const directory = resolve(root, ".vitehub/process-host");
       const entry = resolve(root, options.entry);
+      const exportName = options.exportName ?? "default";
+      if (!/^[A-Za-z_$][\w$]*$/.test(exportName))
+        throw new Error("Process host exportName must be a JavaScript identifier.");
+      const hostImport = exportName !== "default"
+        ? `import { ${exportName} as host } from ${JSON.stringify(entry)}`
+        : `import host from ${JSON.stringify(entry)}`;
       const drainRoute = options.drainRoute ?? "/api/drain";
       if (!drainRoute.startsWith("/") || /[?#*]/.test(drainRoute))
         throw new Error(
@@ -25,11 +31,11 @@ export function processAgentHost(options: { entry: string; drainRoute?: string }
       const drain = resolve(directory, "drain.ts");
       await writeFile(
         plugin,
-        `import host from ${JSON.stringify(entry)}\nexport default function(app) { host.start(); app.hooks.hook('close', () => host.close()) }\n`,
+        `${hostImport}\nexport default function(app) { host.start(); app.hooks.hook('close', () => host.close()) }\n`,
       );
       await writeFile(
         drain,
-        `import host from ${JSON.stringify(entry)}\nexport default () => ({ status: host.status() })\n`,
+        `${hostImport}\nexport default () => ({ status: host.status() })\n`,
       );
       const result: import("vite").UserConfig & { nitro: { plugins: string[], handlers: { route: string, handler: string }[] } } = { nitro: { plugins: [plugin], handlers: [{ route: drainRoute, handler: drain }] } };
       return result

--- a/packages/agent/src/process-host-vite.ts
+++ b/packages/agent/src/process-host-vite.ts
@@ -11,7 +11,7 @@ export function processAgentHost(options: { entry: string; exportName?: string; 
       const directory = resolve(root, ".vitehub/process-host");
       const entry = resolve(root, options.entry);
       const exportName = options.exportName ?? "default";
-      if (!/^[A-Za-z_$][\w$]*$/.test(exportName))
+      if (!/^[$_\p{ID_Start}][$\u200C\u200D\p{ID_Continue}]*$/u.test(exportName))
         throw new Error("Process host exportName must be a JavaScript identifier.");
       const hostImport = exportName !== "default"
         ? `import { ${exportName} as host } from ${JSON.stringify(entry)}`

--- a/packages/agent/test/process-host-vite.test.ts
+++ b/packages/agent/test/process-host-vite.test.ts
@@ -20,3 +20,32 @@ it('generates the route used by the drain CLI by default', async () => {
     expect(result).toMatchObject({ nitro: { handlers: [{ route: '/api/drain' }] } })
   } finally { await rm(root, { recursive: true, force: true }) }
 })
+
+it.each([undefined, 'default', 'host', '$host'])('wires lifecycle and drain to export %s', async (exportName) => {
+  const root = await mkdtemp(join(tmpdir(), 'vitehub-host-export-'))
+  try {
+    const hook = processAgentHost({ entry: 'agent.ts', exportName, drainRoute: '/drain' }).config
+    if (!hasRuntimeType(hook, 'function')) throw new Error('Expected a config hook')
+    // SAFETY: This plugin config hook uses only the supplied config root, not its Vite context.
+    const result = await hook.call({} as never, { root }, { command: 'build', mode: 'production' })
+    const plugin = await readFile(join(root, '.vitehub/process-host/plugin.ts'), 'utf8')
+    const drain = await readFile(join(root, '.vitehub/process-host/drain.ts'), 'utf8')
+    const expected = exportName && exportName !== 'default'
+      ? `import { ${exportName} as host } from ${JSON.stringify(join(root, 'agent.ts'))}`
+      : `import host from ${JSON.stringify(join(root, 'agent.ts'))}`
+    expect(plugin).toContain(expected)
+    expect(drain).toContain(expected)
+    expect(plugin).toContain('host.start()')
+    expect(plugin).toContain('host.close()')
+    expect(drain).toContain('host.status()')
+    expect(result).toMatchObject({ nitro: { handlers: [{ route: '/drain' }] } })
+  } finally { await rm(root, { recursive: true, force: true }) }
+})
+
+it.each(['', 'host"name', 'host;throw', 'a.b'])('rejects invalid export name %j', async (exportName) => {
+  const hook = processAgentHost({ entry: 'agent.ts', exportName }).config
+  if (!hasRuntimeType(hook, 'function')) throw new Error('Expected a config hook')
+  // SAFETY: This plugin config hook uses only the supplied config, not its Vite context.
+  await expect(hook.call({} as never, {}, { command: 'build', mode: 'production' }))
+    .rejects.toThrow('exportName must be a JavaScript identifier')
+})

--- a/packages/agent/test/process-host-vite.test.ts
+++ b/packages/agent/test/process-host-vite.test.ts
@@ -21,7 +21,7 @@ it('generates the route used by the drain CLI by default', async () => {
   } finally { await rm(root, { recursive: true, force: true }) }
 })
 
-it.each([undefined, 'default', 'host', '$host'])('wires lifecycle and drain to export %s', async (exportName) => {
+it.each([undefined, 'default', 'host', '$host', 'π', '变量', 'host\u200Cname', 'host\u200Dname'])('wires lifecycle and drain to export %s', async (exportName) => {
   const root = await mkdtemp(join(tmpdir(), 'vitehub-host-export-'))
   try {
     const hook = processAgentHost({ entry: 'agent.ts', exportName, drainRoute: '/drain' }).config
@@ -42,7 +42,7 @@ it.each([undefined, 'default', 'host', '$host'])('wires lifecycle and drain to e
   } finally { await rm(root, { recursive: true, force: true }) }
 })
 
-it.each(['', 'host"name', 'host;throw', 'a.b'])('rejects invalid export name %j', async (exportName) => {
+it.each(['', 'host"name', 'host;throw', 'a.b', '1host', '\u200Chost', '💥'])('rejects invalid export name %j', async (exportName) => {
   const hook = processAgentHost({ entry: 'agent.ts', exportName }).config
   if (!hasRuntimeType(hook, 'function')) throw new Error('Expected a config hook')
   // SAFETY: This plugin config hook uses only the supplied config, not its Vite context.


### PR DESCRIPTION
Applications currently need a separate default-exported host module to use `processAgentHost`, even when the host configuration belongs beside an Agent Definition.

Add `exportName` to select a named host export for both the generated Nitro lifecycle plugin and drain handler. It defaults to `default`; invalid identifiers fail during configuration. Babysitter can now keep its host, GitHub configuration, and Console delivery in `agent.ts` and delete three configuration-only files.

Verified with 16 focused regression cases (default, named, Unicode, and malformed identifiers), package build/typecheck, lint, strict TypeScript source checks, and a real Babysitter production build/typecheck using `pnpm patch`.

The broad local suite was also attempted: provider source-publication and generated-handler assertions failed, the schedule fixture could not resolve its runtime import, and the tutorial build timed out. These fixtures do not call `processAgentHost`. Some failures in the first long run captured intermediate plugin code; a fresh focused run against the final source passes all 16 cases. The required CI job and Pullfrog passed. After merge, the broader package-test job reported failures in the unchanged generated-handler assertion, schedule-process fixture, and published-chat-adapter dependency installation (ERR_PNPM_EXOTIC_SUBDEP). All 16 named-export cases passed in CI. Babysitter now uses the merged packages without a patch; its exact release build/typecheck passed.

Model: GPT-6 Astra (medium). Harness: Codex.
