### PR TITLE
perf(workspace): resolve live file metadata from the path map

### DIFF
--- a/packages/workspace/src/sources/view.ts
+++ b/packages/workspace/src/sources/view.ts
@@ -782,7 +782,12 @@ function isListedLiveEntry(entry: WorkspaceEntry, path: string, options: ListOpt
 }
 
 function liveSourceStat(source: ReturnType<typeof normalizeWorkspaceSources>[number], workspacePath: string): WorkspaceStat | undefined {
-  return liveSourceEntries(source).find(entry => entry.path === workspacePath)
+  const paths = source.livePaths
+  if (!paths) return
+  if (Object.hasOwn(paths, workspacePath)) return { path: workspacePath, type: "file" }
+  if (Object.keys(paths).some(path => path.startsWith(`${workspacePath}/`))) {
+    return { path: workspacePath, type: "directory" }
+  }
 }
 
 async function currentSourceTreePaths(source: ReturnType<typeof normalizeWorkspaceSources>[number], sourceContext: ReturnType<typeof createSourceContext>) {

--- a/packages/workspace/test/lazy-sources.test.ts
+++ b/packages/workspace/test/lazy-sources.test.ts
@@ -1787,6 +1787,47 @@ describe("lazy sources", () => {
     expect(getItem).toHaveBeenCalledTimes(6)
   })
 
+  it("looks up live files without enumerating the Source tree", async () => {
+    const paths: Record<string, string> = { "docs/guides/start.md": "/local/start.md" }
+    const ownKeys = vi.fn((target: Record<string, string>) => Reflect.ownKeys(target))
+    const getItem = vi.fn(async (key: string) => ({ key, content: "unused" }))
+    const source = markLiveWorkspaceSource(custom({
+      materialize: "lazy",
+      async getKeys() { return ["guides/start.md"] },
+      getItem,
+    }), new Proxy(paths, { ownKeys }))
+    const view = createWorkspaceSourceView({ name: "live-stat", sources: { docs: source } }, createMemoryWorkspaceStore())
+
+    await expect(view.stat("docs/guides/start.md")).resolves.toEqual({ path: "docs/guides/start.md", type: "file" })
+    await expect(view.exists("docs/guides/start.md")).resolves.toBe(true)
+    expect(ownKeys).not.toHaveBeenCalled()
+    await expect(view.stat("docs/guides")).resolves.toEqual({ path: "docs/guides", type: "directory" })
+    await expect(view.exists("docs/guide")).resolves.toBe(false)
+    await expect(view.exists("docs/toString")).resolves.toBe(false)
+    await expect(view.stat("docs/missing.md")).rejects.toThrow("Workspace path does not exist")
+
+    delete paths["docs/guides/start.md"]
+    paths["docs/reference/api.md"] = "/local/api.md"
+    await expect(view.exists("docs/guides/start.md")).resolves.toBe(false)
+    await expect(view.exists("docs/guides")).resolves.toBe(false)
+    await expect(view.stat("docs/reference/api.md")).resolves.toEqual({ path: "docs/reference/api.md", type: "file" })
+    await expect(view.stat("docs/reference")).resolves.toEqual({ path: "docs/reference", type: "directory" })
+    expect(getItem).not.toHaveBeenCalled()
+  })
+
+  it("looks up live paths populated during preparation", async () => {
+    const paths: Record<string, string> = {}
+    const source = markLiveWorkspaceSource(custom({
+      materialize: "lazy",
+      async prepare() { paths["docs/ready.md"] = "/local/ready.md" },
+      async getKeys() { return ["ready.md"] },
+      async getItem(key) { return { key, content: "unused" } },
+    }), paths)
+    const view = createWorkspaceSourceView({ name: "prepared-live-stat", sources: { docs: source } }, createMemoryWorkspaceStore())
+    await expect(view.stat("docs/ready.md")).resolves.toEqual({ path: "docs/ready.md", type: "file" })
+    await expect(view.stat("docs")).resolves.toEqual({ path: "docs", type: "directory" })
+  })
+
   it("serves prepared startup live Sources from their snapshot", async () => {
     const getItem = vi.fn(async (key: string) => ({ key, content: `version ${getItem.mock.calls.length}\n` }))
     const source = markLiveWorkspaceSource(custom({


### PR DESCRIPTION
Live Source `stat()` and `exists()` rebuilt every directory and file entry before finding one path. Read files directly from the existing path map and scan prefixes only for directories. Preparation and in-place path additions or removals remain visible without a second cache.

A local Node 24 benchmark of 100 file metadata lookups across 10,000 paths fell from 1,547 ms to 0.011 ms. This measures the lookup function, not end-to-end Workspace calls.

Validation:
- `corepack pnpm --dir packages/workspace run test` built the package and its dependencies.
- `corepack pnpm --dir packages/workspace exec vp test`: all 730 tests passed, with no type errors.
- `corepack pnpm --dir packages/workspace run typecheck`: passed.
- `corepack pnpm exec vp run lint`: passed with existing warnings.

Regression coverage includes file lookup without tree enumeration, implicit directories, missing paths, preparation, and in-place path changes.

Model: GPT-6. Harness: Codex.
