### PR TITLE
perf(agent): cache complete SQLite invocation capability IDs

### DIFF
--- a/packages/agent/src/invocations/sqlite.ts
+++ b/packages/agent/src/invocations/sqlite.ts
@@ -88,6 +88,19 @@ function storedRecord(record: AgentInvocationRecord): Omit<AgentInvocationRecord
   return stored
 }
 
+function capabilityIdsProjection() {
+  return `(SELECT json_group_array(capability_id) FROM (
+    SELECT trim(capability.value) AS capability_id
+      FROM json_each(CASE WHEN json_valid(record) THEN record ELSE '{}' END, '$.capabilityIds') AS capability
+      WHERE typeof(capability.value) = 'text' AND trim(capability.value) <> ''
+    UNION
+    SELECT trim(json_extract(observation.value, '$."attributes"."capability.id"')) AS capability_id
+      FROM json_each(CASE WHEN json_valid(record) THEN record ELSE '{}' END, '$.observations') AS observation
+      WHERE json_type(observation.value, '$."attributes"."capability.id"') = 'text'
+        AND trim(json_extract(observation.value, '$."attributes"."capability.id"')) <> ''
+  ))`
+}
+
 function serializedSummary(record: Omit<AgentInvocationRecord, "cursor">): string {
   const { observations: _observations, ...summary } = record
   return JSON.stringify(summary, (_key, value) => typeof value === "bigint" ? String(value) : value)
@@ -242,6 +255,7 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
         search TEXT,
         search_version INTEGER NOT NULL DEFAULT 0,
         summary TEXT,
+        capability_ids TEXT,
         updated_at TEXT NOT NULL DEFAULT '',
         record TEXT NOT NULL
       )`)
@@ -282,6 +296,20 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
           if (!currentColumns.rows.some(row => row.name === "summary")) throw error
         }
       }
+      if (!columns.rows.some(row => row.name === "capability_ids")) {
+        try {
+          await client.execute(`ALTER TABLE ${table} ADD COLUMN capability_ids TEXT`)
+        }
+        catch (error) {
+          const currentColumns = await client.execute(`PRAGMA table_info(${table})`)
+          if (!currentColumns.rows.some(row => row.name === "capability_ids")) throw error
+        }
+      }
+      await client.execute(`CREATE TRIGGER IF NOT EXISTS ${table}_capability_ids_update
+        AFTER UPDATE OF record ON ${table}
+        BEGIN
+          UPDATE ${table} SET capability_ids = NULL WHERE sequence = NEW.sequence;
+        END`)
       if (!columns.rows.some(row => row.name === "updated_at")) {
         try {
           await client.execute(`ALTER TABLE ${table} ADD COLUMN updated_at TEXT NOT NULL DEFAULT ''`)
@@ -603,20 +631,23 @@ export function createLibsqlAgentInvocationStore(options: LibsqlAgentInvocationS
       if (selectedAgent) {
         args.push(selectedAgent, selectedAgent)
       }
+      const filter = selectedAgent
+        ? "(agent_name = ? OR ((agent_name IS NULL OR agent_name = '') AND json_extract(record, '$.agentName') = ?))"
+        : "1 = 1"
+      // Cache complete IDs only when requested. Record writes invalidate the projection,
+      // including writes from older clients that do not know about this column.
+      await write(async () => await retrySqliteBusy(async () => await client.execute({
+        args,
+        sql: `UPDATE ${table} SET capability_ids = ${capabilityIdsProjection()}
+          WHERE capability_ids IS NULL AND ${filter}`,
+      })))
       const result = await client.execute({
         args,
-        sql: `SELECT DISTINCT capability_id FROM (
-          SELECT trim(capability.value) AS capability_id, agent_name, record
-            FROM ${table}, json_each(CASE WHEN json_valid(record) THEN record ELSE '{}' END, '$.capabilityIds') AS capability
-            WHERE typeof(capability.value) = 'text' AND trim(capability.value) <> ''
-          UNION ALL
-          SELECT trim(json_extract(observation.value, '$."attributes"."capability.id"')) AS capability_id, agent_name, record
-            FROM ${table}, json_each(CASE WHEN json_valid(record) THEN record ELSE '{}' END, '$.observations') AS observation
-            WHERE json_type(observation.value, '$."attributes"."capability.id"') = 'text'
-              AND trim(json_extract(observation.value, '$."attributes"."capability.id"')) <> ''
-        ) WHERE ${selectedAgent
-          ? "(agent_name = ? OR ((agent_name IS NULL OR agent_name = '') AND json_extract(record, '$.agentName') = ?))"
-          : "1 = 1"} ORDER BY capability_id`,
+        // A writer can invalidate the cache between these statements. Resolve those rows
+        // from their current record so an active Invocation never returns stale IDs.
+        sql: `SELECT DISTINCT capability.value AS capability_id
+          FROM ${table}, json_each(COALESCE(capability_ids, ${capabilityIdsProjection()})) AS capability
+          WHERE ${filter} ORDER BY capability_id`,
       })
       return result.rows.flatMap((row) => {
         return hasRuntimeType(row.capability_id, "string") ? [row.capability_id] : []

--- a/packages/agent/test/invocation-capability-projection.test.ts
+++ b/packages/agent/test/invocation-capability-projection.test.ts
@@ -1,0 +1,108 @@
+import { createClient } from "@libsql/client"
+import type { InStatement } from "@libsql/client"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { createLibsqlAgentInvocationStore } from "../src/invocations/sqlite.ts"
+import type { AgentInvocationStoreCreateInput } from "../src/invocations.ts"
+
+const timestamp = "2026-09-05T00:00:00.000Z"
+const invocation = (id: string, input: Partial<AgentInvocationStoreCreateInput> = {}): AgentInvocationStoreCreateInput => ({
+  agentName: "review",
+  createdAt: timestamp,
+  id,
+  observations: [],
+  status: "running",
+  traceId: id,
+  updatedAt: timestamp,
+  ...input,
+})
+const observation = (capabilityId: string, sequence = 1) => ({
+  attributes: { "capability.id": capabilityId },
+  name: "agent.tool.call",
+  sequence,
+  timestamp,
+  type: "run" as const,
+})
+
+describe("SQLite invocation Capability projection", () => {
+  let client: ReturnType<typeof createClient>
+  beforeEach(() => { client = createClient({ url: "file::memory:" }) })
+  afterEach(() => { vi.restoreAllMocks(); client.close() })
+  const store = () => createLibsqlAgentInvocationStore({ client, maxAgeMs: false, maxRecords: false })
+  const projection = async (id: string) => (await client.execute({
+    args: [id],
+    sql: "SELECT capability_ids FROM vitehub_agent_invocations WHERE id = ?",
+  })).rows[0]?.capability_ids
+
+  it("caches complete IDs beyond the summary cap without rewriting cached rows", async () => {
+    const journal = store()
+    const ids = Array.from({ length: 256 }, (_, index) => `capability-${index}`)
+    await journal.create(invocation("complete", {
+      capabilityIds: ids,
+      observations: [observation(" observation-only "), observation(" ", 2)],
+    }))
+    expect(await projection("complete")).toBeNull()
+    const expected = [...ids, "observation-only"].sort()
+    expect(await journal.listCapabilityIds!()).toEqual(expected)
+    expect(JSON.parse(String(await projection("complete"))).sort()).toEqual(expected)
+    const changes = (await client.execute("SELECT total_changes() AS count")).rows[0]?.count
+    expect(await journal.listCapabilityIds!()).toEqual(expected)
+    expect((await client.execute("SELECT total_changes() AS count")).rows[0]?.count).toBe(changes)
+    expect((await journal.getSummary("complete"))?.capabilityIds).toEqual(ids)
+  })
+
+  it("scopes cache population and invalidates on record updates", async () => {
+    const journal = store()
+    await journal.create(invocation("review", { observations: [observation("first")] }))
+    await journal.create(invocation("other", { agentName: "other", capabilityIds: ["other"] }))
+    expect(await journal.listCapabilityIds!(" review ")).toEqual(["first"])
+    expect(await projection("other")).toBeNull()
+    await journal.update("review", { observation: observation("second", 2), timestamp })
+    expect(await projection("review")).toBeNull()
+    expect(await journal.listCapabilityIds!("review")).toEqual(["first", "second"])
+    expect(await journal.listCapabilityIds!()).toEqual(["first", "other", "second"])
+  })
+
+  it("migrates legacy rows and invalidates cached IDs for older writers", async () => {
+    await client.execute(`CREATE TABLE vitehub_agent_invocations (
+      sequence INTEGER PRIMARY KEY AUTOINCREMENT, id TEXT NOT NULL UNIQUE,
+      status TEXT NOT NULL, record TEXT NOT NULL
+    )`)
+    const legacy = invocation("legacy", { observations: [observation("legacy-only")] })
+    await client.execute({ args: [legacy.id, legacy.status, JSON.stringify(legacy)], sql: "INSERT INTO vitehub_agent_invocations (id, status, record) VALUES (?, ?, ?)" })
+    const journal = store()
+    expect(await journal.listCapabilityIds!("review")).toEqual(["legacy-only"])
+    await client.execute({
+      args: [JSON.stringify({ ...legacy, observations: [observation("replacement")] })],
+      sql: "UPDATE vitehub_agent_invocations SET record = ? WHERE id = 'legacy'",
+    })
+    expect(await projection("legacy")).toBeNull()
+    expect(await journal.listCapabilityIds!("review")).toEqual(["replacement"])
+    await client.execute("DELETE FROM vitehub_agent_invocations WHERE id = 'legacy'")
+    expect(await journal.listCapabilityIds!()).toEqual([])
+  })
+
+  it("reads current IDs when another writer changes a row after cache population", async () => {
+    const journal = store()
+    const record = invocation("concurrent", { observations: [observation("before")] })
+    await journal.create(record)
+    const execute = client.execute.bind(client)
+    let changed = false
+    vi.spyOn(client, "execute").mockImplementation(async (statement: InStatement) => {
+      const result = await execute(statement)
+      const sql = typeof statement === "string" ? statement : statement.sql
+      if (!changed && sql.includes("SET capability_ids = (SELECT")) {
+        changed = true
+        await execute({
+          args: [JSON.stringify({ ...record, observations: [observation("after")] })],
+          sql: "UPDATE vitehub_agent_invocations SET record = ? WHERE id = 'concurrent'",
+        })
+      }
+      return result
+    })
+    expect(await journal.listCapabilityIds!()).toEqual(["after"])
+    expect(changed).toBe(true)
+    expect(await projection("concurrent")).toBeNull()
+    expect(await journal.listCapabilityIds!()).toEqual(["after"])
+  })
+})


### PR DESCRIPTION
Opening the Console capability filter made the SQLite Invocation Store expand observation JSON across retained records on every request. Cache the complete capability list in a private nullable column and populate it on demand for the selected Agent. A trigger invalidates the cache on record writes, including older clients. The read falls back to current record data if another writer invalidates a row after cache population.

The projection includes IDs found only in observations and IDs beyond the 256-ID summary cap. Migration is automatic for SQLite; this change does not alter the D1 schema or adapter.

A local SQLite 3.45 benchmark with 500 records, 128 observations per record, and 512-byte payloads measured 361 ms before and 0.87 ms with a warm cache. Initial cache population and lookup took 385 ms. These are synthetic query timings, not Console request latency.

Validation:
- `corepack pnpm exec vp run -t @vite-hub/agent#build`
- `corepack pnpm --dir packages/agent exec vp test test/invocation-capability-projection.test.ts test/invocations.test.ts`: 129 passed on the combined task branch.
- `corepack pnpm --dir packages/agent run typecheck`
- `corepack pnpm exec vp run lint`: passed with existing warnings.

Regression coverage includes existing tables, older writers, Agent scoping, cache reuse, complete IDs, record deletion, and a write between cache population and read.

The full `corepack pnpm --dir packages/agent run test` run passed 2,908 tests and failed six provider/process/tutorial checks. After `corepack pnpm exec vp run -t vite-hub#build`, rerunning those six cases on unmodified `main` passed three and reproduced these three baseline failures:
- Retained folder Agent Workspace source publication: missing generated `context.md`.
- Generated Nitro webhook handler assertion: expected import text differs from generated output.
- Canonical process schedule integration: module resolution fails.

The performance regressions pass. The full Agent suite is not green on the baseline.

Model: GPT-6. Harness: Codex.
