### PR TITLE
feat(agent): support shared box configuration

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -1742,6 +1742,7 @@ function defineBaseAgent<
 
   // SAFETY: Agent definition normalization establishes the asserted internal Agent contract.
   const definition = {
+    box: options.box,
     ...(driver.kind === "model" ? { [baseAgentModel]: driver.model } : {}),
     [baseAgentDriverKind]: driver.kind,
     ...(driver.output ? { [baseAgentOutput]: driver.output } : {}),

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -1460,6 +1460,8 @@ type AgentSharedSettings<
   TCapabilities extends AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined = AgentCapabilitiesInput<TRuntimeConfig, WorkspaceName, CALL_OPTIONS> | undefined,
   TOutput = unknown,
 > = {
+  /** Shared host resources and credentials available to the agent. */
+  box?: AgentBox
   capabilities?: TCapabilities
   channels?: AgentChannelInputs<TRuntimeConfig>
   cli?: AgentDefinitionCliOptions
@@ -1497,6 +1499,7 @@ export interface AgentDefinition<
   TContextValues extends object = AgentInvocationContextValues,
   TOutput = unknown,
 > {
+  box?: AgentBox
   [agentOutputType]?: TOutput
   capabilities?: AgentCapabilityDefinition<TRuntimeConfig>[]
   channels?: AgentChannels<TRuntimeConfig>
@@ -1517,6 +1520,10 @@ export interface AgentDefinition<
   uiMessageStream?: AgentUIMessageStreamProjectionResolver<TRuntimeConfig, CALL_OPTIONS, TContextValues>
   version?: string
   workspace?: WorkspaceAgentWorkspaceConfig
+}
+
+export interface AgentBox {
+  [key: string]: unknown
 }
 
 export type AgentInput<


### PR DESCRIPTION
Experimental DX batch foundation: adds a typed shared box configuration to agent settings and preserves it on normalized AgentDefinition instances for runtime integrations.