### PR TITLE
fix(test): run complete package test scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Start with the affected package's full `test` script so every package-owned test
 corepack pnpm --dir packages/vite-hub run test
 ```
 
-For example, use `corepack pnpm --dir packages/internal run test` for `@vite-hub/internal` to include its default and Workerd suites. The package runner currently substitutes plain `vp test` for these scripts and can omit additional test invocations.
+For example, use `corepack pnpm --dir packages/internal run test` for `@vite-hub/internal` to include its default and Workerd suites. The root package runner uses these same scripts after building the selected packages and their dependencies.
 
 For one regression, build first, then run from the package directory so Vitest uses its package config:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Start with the affected package's full `test` script so every package-owned test
 corepack pnpm --dir packages/vite-hub run test
 ```
 
-For example, use `corepack pnpm --dir packages/internal run test` for `@vite-hub/internal` to include its default and Workerd suites. The root package runner uses these same scripts after building the selected packages and their dependencies.
+For example, use `corepack pnpm --dir packages/internal run test` for `@vite-hub/internal` to include its default and Workerd suites. The root package runner builds the selected packages and their dependencies once, then runs every command in these scripts after removing leading `vp run -t <package>#build` commands for builds it already completed.
 
 For one regression, build first, then run from the package directory so Vitest uses its package config:
 

--- a/test/run-package-task.mjs
+++ b/test/run-package-task.mjs
@@ -104,6 +104,20 @@ function signalExitCode(signal) {
 }
 
 function executePackage(pkg, phase, options) {
+  if (phase === "test") {
+    const packageScript = pkg.manifest.scripts.test
+    let testScript = packageScript.trim()
+    // Only remove leading build tasks that this runner has already completed.
+    for (;;) {
+      const build = /^vp run -t ([@\w./-]+)#build(?:\s*&&\s*|$)/.exec(testScript)
+      if (!build || options.buildResults?.get(build[1])?.status !== "passed") break
+      testScript = testScript.slice(build[0].length)
+    }
+    if (!testScript) return Promise.resolve({ code: 0, signal: undefined })
+    if (testScript !== packageScript.trim()) {
+      return spawnCommand("corepack", ["pnpm", "--dir", pkg.dir, "--shell-mode", "exec", testScript], options.workspaceRoot, options.signal)
+    }
+  }
   return spawnCommand("corepack", ["pnpm", "--dir", pkg.dir, "run", phase], options.workspaceRoot, options.signal)
 }
 
@@ -238,6 +252,7 @@ export async function runPackageTask(options) {
   const controller = options.controller ?? new AbortController()
   const execute = options.execute ?? ((pkg, phase, executionOptions) => executePackage(pkg, phase, {
     ...executionOptions,
+    buildResults,
     workspaceRoot,
   }))
   let buildResults

--- a/test/run-package-task.mjs
+++ b/test/run-package-task.mjs
@@ -104,13 +104,6 @@ function signalExitCode(signal) {
 }
 
 function executePackage(pkg, phase, options) {
-  const packageScript = pkg.manifest.scripts?.[phase]
-  if (phase === "test" && packageScript && /(?:^|&&\s*)vp test(?:\s|$)/.test(packageScript)) {
-    return spawnCommand(join(options.workspaceRoot, "node_modules/.bin/vp"), ["test"], pkg.dir, options.signal)
-  }
-  if (phase === "test" && packageScript?.trim() === `vp run -t ${pkg.name}#build`) {
-    return Promise.resolve({ code: 0, signal: undefined })
-  }
   return spawnCommand("corepack", ["pnpm", "--dir", pkg.dir, "run", phase], options.workspaceRoot, options.signal)
 }
 

--- a/test/run-package-task.test.ts
+++ b/test/run-package-task.test.ts
@@ -1,5 +1,5 @@
 import { execFile, spawn } from "node:child_process"
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
+import { chmod, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join, resolve } from "node:path"
 import { promisify } from "node:util"
@@ -58,6 +58,38 @@ async function runFixture(packages: string[], env: NodeJS.ProcessEnv = {}) {
 }
 
 describe("package task runner", () => {
+  it("runs every command and preserves failures in compound package test scripts", async () => {
+    const log = await tempFile("events.log")
+    const workspace = join(log, "..")
+    const packageDir = join(workspace, "packages/compound")
+    const binDir = join(workspace, "node_modules/.bin")
+    await mkdir(packageDir, { recursive: true })
+    await mkdir(binDir, { recursive: true })
+    await writeFile(join(workspace, "package.json"), JSON.stringify({ private: true, packageManager: "pnpm@10.33.0" }))
+    await writeFile(join(workspace, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
+    await writeFile(join(packageDir, "package.json"), JSON.stringify({
+      name: "@fixture/compound",
+      scripts: { test: "vp test && vp test --config workerd.config.ts" },
+    }))
+    const fakeVp = join(binDir, "vp")
+    await writeFile(fakeVp, [
+      "#!/usr/bin/env node",
+      'const { appendFileSync } = require("node:fs")',
+      'appendFileSync(process.env.VITEHUB_FIXTURE_LOG, JSON.stringify(process.argv.slice(2)) + "\\n")',
+      'if (process.argv.includes("--config")) process.exitCode = 7',
+    ].join("\n"))
+    await chmod(fakeVp, 0o755)
+    await writeFile(`${fakeVp}.cmd`, `@node "${fakeVp}" %*`)
+
+    const result = await execFileAsync(process.execPath, [runner, "test", "--workspace", workspace], {
+      env: { ...process.env, VITEHUB_FIXTURE_LOG: log },
+    }).then(result => ({ ...result, code: 0 }), (error: Error & { code: number, stdout: string }) => error)
+
+    expect(result.code, result.stdout).toBe(7)
+    expect(await readFile(log, "utf8")).toBe('["test"]\n["test","--config","workerd.config.ts"]\n')
+    expect(result.stdout).toContain("FAIL @fixture/compound")
+  }, 30_000)
+
   it("aggregates independent failures, skips dependents, and builds the diamond once", async () => {
     const result = await runFixture(
       ["@fixture/app", "@fixture/core", "@vite-hub/env", "@vite-hub/markdown-template", "@vite-hub/runtime"],

--- a/test/run-package-task.test.ts
+++ b/test/run-package-task.test.ts
@@ -58,7 +58,11 @@ async function runFixture(packages: string[], env: NodeJS.ProcessEnv = {}) {
 }
 
 describe("package task runner", () => {
-  it("runs every command and preserves failures in compound package test scripts", async () => {
+  it.each([
+    "",
+    "vp run -t @fixture/compound#build && ",
+    "vp run -t @fixture/shared#build && vp run -t @fixture/compound#build && ",
+  ])("runs all test commands without replaying completed builds: %s", async (buildPrefix) => {
     const log = await tempFile("events.log")
     const workspace = join(log, "..")
     const packageDir = join(workspace, "packages/compound")
@@ -69,7 +73,14 @@ describe("package task runner", () => {
     await writeFile(join(workspace, "pnpm-workspace.yaml"), "packages:\n  - packages/*\n")
     await writeFile(join(packageDir, "package.json"), JSON.stringify({
       name: "@fixture/compound",
-      scripts: { test: "vp test && vp test --config workerd.config.ts" },
+      dependencies: { "@fixture/shared": "workspace:*" },
+      scripts: { build: "vp pack compound", test: `${buildPrefix}vp test && vp test --config workerd.config.ts` },
+    }))
+    const sharedDir = join(workspace, "packages/shared")
+    await mkdir(sharedDir, { recursive: true })
+    await writeFile(join(sharedDir, "package.json"), JSON.stringify({
+      name: "@fixture/shared",
+      scripts: { build: "vp pack shared" },
     }))
     const fakeVp = join(binDir, "vp")
     await writeFile(fakeVp, [
@@ -86,7 +97,7 @@ describe("package task runner", () => {
     }).then(result => ({ ...result, code: 0 }), (error: Error & { code: number, stdout: string }) => error)
 
     expect(result.code, result.stdout).toBe(7)
-    expect(await readFile(log, "utf8")).toBe('["test"]\n["test","--config","workerd.config.ts"]\n')
+    expect(await readFile(log, "utf8")).toBe('["pack","shared"]\n["pack","compound"]\n["test"]\n["test","--config","workerd.config.ts"]\n')
     expect(result.stdout).toContain("FAIL @fixture/compound")
   }, 30_000)
 


### PR DESCRIPTION
The root package test runner replaced compound scripts with plain `vp test`. This omitted the internal package's Workerd suite and could report success when a later test command would fail.

Run each package's declared script after the existing dependency build phase. Remove only leading build commands recorded as successful in that phase, so compound scripts keep their remaining commands without nesting Vite+ builds. The regression uses two test commands and verifies that the second command runs and its failure reaches the root exit status. Update the contributor guidance to match.

Validation: the initial regression failed before the fix; all three focused runner regressions now pass. The internal package build and both Workerd tests passed. Lint passed with existing warnings. The broader local runner suite hit timing limits on this shared server; GitHub CI must confirm it. Current main also has an unrelated Agent/Nuxt failure caused by the optional evlog import, addressed separately.

Model: GPT-6. Harness: Codex.
