### PR TITLE
perf(source): derive only immediate listing directories

### DIFF
--- a/packages/source/src/core/reader.ts
+++ b/packages/source/src/core/reader.ts
@@ -31,14 +31,15 @@ function isNestedUnder(path: string, prefix: string) {
   return !prefix || path === prefix || path.startsWith(`${prefix}/`)
 }
 
-function createDirectorySet(paths: string[]) {
+function createDirectorySet(paths: string[], prefix: string) {
   const directories = new Set<string>()
+  const start = prefix ? prefix.length + 1 : 0
 
   for (const path of paths) {
-    const segments = normalizeSourcePath(path).split("/").filter(Boolean)
-    for (let index = 1; index < segments.length; index++) {
-      directories.add(segments.slice(0, index).join("/"))
-    }
+    const normalized = normalizeSourcePath(path).split("/").filter(Boolean).join("/")
+    if (prefix && !normalized.startsWith(`${prefix}/`)) continue
+    const end = normalized.indexOf("/", start)
+    if (end !== -1) directories.add(normalized.slice(0, end))
   }
 
   return directories
@@ -108,14 +109,10 @@ export function createSource(source: Source, context?: Partial<SourceContext>) {
       await ensurePrepared()
       const normalizedPrefix = prefix ? normalizeSafeSourcePath(prefix, { allowEmpty: true }) : ""
       const sourceKeys = await keys()
-      const directories = createDirectorySet(sourceKeys)
+      const directories = createDirectorySet(sourceKeys, normalizedPrefix)
       const result = new Map<string, SourceListEntry<string>>()
 
       for (const directory of directories) {
-        if (directory === normalizedPrefix) continue
-        if (!isNestedUnder(directory, normalizedPrefix)) continue
-        const rest = normalizeSourcePath(directory.slice(normalizedPrefix.length)).replace(/^\//, "")
-        if (rest.includes("/")) continue
         result.set(directory, { key: directory, type: "directory" })
       }
 

--- a/packages/source/test/reader.test.ts
+++ b/packages/source/test/reader.test.ts
@@ -35,6 +35,56 @@ describe("direct Source readers", () => {
     await expect(reader.meta("article_1")).resolves.toEqual({ revision: "1" })
   })
 
+  it("lists only immediate children and lets files replace matching directories", async () => {
+    const reader = createSource(defineSource({
+      name: "docs",
+      async getKeys() {
+        return [
+          "guide/api/deep/nested/example.md",
+          "guide/start.md",
+          "guide/api/other.md",
+          "guide/api",
+          "guide/api/later.md",
+          "guides/elsewhere.md",
+          "reference/api/deep/nested/example.md",
+        ]
+      },
+      async getItem(key: string) { return { key, content: key } },
+    }))
+
+    await expect(reader.list()).resolves.toEqual([
+      { key: "guide", type: "directory" },
+      { key: "guides", type: "directory" },
+      { key: "reference", type: "directory" },
+    ])
+    await expect(reader.list("guide/")).resolves.toEqual([
+      { key: "guide/api", type: "file" },
+      { key: "guide/start.md", type: "file" },
+    ])
+    await expect(reader.list("guide\\api")).resolves.toEqual([
+      { key: "guide/api/deep", type: "directory" },
+      { key: "guide/api/later.md", type: "file" },
+      { key: "guide/api/other.md", type: "file" },
+    ])
+    await expect(reader.list("guide/api/deep/nested")).resolves.toEqual([
+      { key: "guide/api/deep/nested/example.md", type: "file" },
+    ])
+    await expect(reader.list("missing")).resolves.toEqual([])
+  })
+
+  it("normalizes separators when deriving directories from Source keys", async () => {
+    const reader = createSource(defineSource({
+      name: "docs",
+      async getKeys() { return ["guide\\windows\\example.md", "guide//nested///example.md"] },
+      async getItem(key: string) { return { key, content: key } },
+    }))
+
+    await expect(reader.list("guide")).resolves.toEqual([
+      { key: "guide/nested", type: "directory" },
+      { key: "guide/windows", type: "directory" },
+    ])
+  })
+
   it("pins one revision for concurrent operations and refreshes with another reader", async () => {
     let originRevision = 1
     const prepare = vi.fn(async (context: SourceContext) => {


### PR DESCRIPTION
Listing one Source directory constructs all ancestors of every key, then discards directories outside the requested level. Derive only immediate child directories during the key scan. Preserve sorting, separator handling, prefix boundaries, and file precedence when a file and directory share a key.

A synthetic directory-extraction benchmark with 10,000 keys nested 30 levels deep took about 688 ms before and 168 ms after. This measures the directory loop, not Source I/O or end-to-end application latency.

Validation on the integration checkout:
- `corepack pnpm exec vp run -t vite-hub#build` passed, including Source and its dependencies.
- `corepack pnpm --dir packages/source exec vp test test/reader.test.ts` passed all 9 tests.
- Source full suite passed 124 tests; three unchanged packaging tests hit timeouts under server contention. A serial packaging rerun passed the glob bundle check; export and TypeScript-config checks still timed out.
- `corepack pnpm --dir packages/source run typecheck` passed.
- `corepack pnpm exec vp run lint` passed with existing warnings.

Model: GPT-6. Harness: Codex.
