### PR TITLE
perf(vite-hub): resolve provider aliases on demand

### DIFF
--- a/packages/vite-hub/src/index.ts
+++ b/packages/vite-hub/src/index.ts
@@ -111,23 +111,27 @@ function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
   return value !== null && Object(value) === value && !Array.isArray(value)
 }
 
-const generatedOwnerProviderImportAliases = Object.fromEntries(generatedOwnerPackageNames.flatMap((packageName) => {
-  const manifestPath = fileURLToPath(import.meta.resolve(`${packageName}/package.json`))
-  const manifest: unknown = JSON.parse(readFileSync(manifestPath, "utf8"))
-  if (!isRecord(manifest) || !("exports" in manifest)) return []
-  const packageExports = manifest.exports
-  if (!isRecord(packageExports)) return []
-  return Object.keys(packageExports).flatMap((subpath) => {
-    if (subpath !== "." && !subpath.startsWith("./")) return []
-    const specifier = subpath === "." ? packageName : `${packageName}/${subpath.slice(2)}`
-    try {
-      return [[specifier, fileURLToPath(import.meta.resolve(specifier))] as const]
-    }
-    catch {
-      return []
-    }
-  })
-}))
+let generatedOwnerProviderImportAliases: Record<string, string> | undefined
+
+function getGeneratedOwnerProviderImportAliases(): Record<string, string> {
+  return generatedOwnerProviderImportAliases ??= Object.fromEntries(generatedOwnerPackageNames.flatMap((packageName) => {
+    const manifestPath = fileURLToPath(import.meta.resolve(`${packageName}/package.json`))
+    const manifest: unknown = JSON.parse(readFileSync(manifestPath, "utf8"))
+    if (!isRecord(manifest) || !("exports" in manifest)) return []
+    const packageExports = manifest.exports
+    if (!isRecord(packageExports)) return []
+    return Object.keys(packageExports).flatMap((subpath) => {
+      if (subpath !== "." && !subpath.startsWith("./")) return []
+      const specifier = subpath === "." ? packageName : `${packageName}/${subpath.slice(2)}`
+      try {
+        return [[specifier, fileURLToPath(import.meta.resolve(specifier))] as const]
+      }
+      catch {
+        return []
+      }
+    })
+  }))
+}
 
 const frameworkVirtualImporters = new Set([
   "\0#vitehub/auth/server",
@@ -194,7 +198,7 @@ function frameworkDependencyResolver(
     name: "vite-hub/dependencies",
     vitehub: {
       providerOutput: {
-        getImportAliases: () => generatedOwnerProviderImportAliases,
+        getImportAliases: getGeneratedOwnerProviderImportAliases,
       },
     },
     enforce: "pre",

--- a/packages/vite-hub/test/vite.test.ts
+++ b/packages/vite-hub/test/vite.test.ts
@@ -1,9 +1,15 @@
+import { readFileSync } from "node:fs"
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+vi.mock("node:fs", async importOriginal => {
+  const fs = await importOriginal<typeof import("node:fs")>()
+  return { ...fs, readFileSync: vi.fn(fs.readFileSync) }
+})
 
 const integrationMocks = vi.hoisted(() => ({
   discoverAgentDefinitionEntries: vi.fn(() => []),
@@ -213,6 +219,27 @@ function dependencyPluginByName(plugins: PluginOption[], name: string): Plugin {
 }
 
 describe("vitehub", () => {
+  it("reads owner manifests only when provider output needs aliases and reuses the result", async () => {
+    vi.resetModules()
+    vi.mocked(readFileSync).mockClear()
+    const ownerManifestPaths = new Set(generatedOwnerPackageCases
+      .filter(([, access]) => access === "resolve")
+      .map(([name]) => fileURLToPath(import.meta.resolve(`${name}/package.json`))))
+    const ownerReads = () => vi.mocked(readFileSync).mock.calls
+      .filter(([path]) => typeof path === "string" && ownerManifestPaths.has(path))
+    const { vitehub: freshVitehub } = await import("../src/index.ts")
+    const plugins = freshVitehub({ preset: "node" })
+    // SAFETY: The named dependency plugin owns the provider-output alias callback.
+    const plugin = dependencyPluginByName(plugins, "vite-hub/dependencies") as ProviderImportPlugin
+
+    expect(ownerReads()).toHaveLength(0)
+    const aliases = await plugin.vitehub.providerOutput.getImportAliases()
+    expect(aliases["@vite-hub/agent"]).toBe(fileURLToPath(import.meta.resolve("@vite-hub/agent")))
+    expect(ownerReads()).toHaveLength(ownerManifestPaths.size)
+    expect(await plugin.vitehub.providerOutput.getImportAliases()).toBe(aliases)
+    expect(ownerReads()).toHaveLength(ownerManifestPaths.size)
+  })
+
   it("serializes the built-in Provider Output finalizer", () => {
     const output = dependencyPluginByName(vitehub({ preset: "node" }), "vite-hub/deployment-output")
 


### PR DESCRIPTION
Importing `vite-hub` reads every generated owner package manifest and resolves its exports before any provider output is requested. Resolve these aliases when the provider-output callback first runs and cache the resulting map for later calls.

The regression verifies zero owner manifest reads during import and plugin configuration, one read per owner on first provider use, and no repeated reads. Alias values and callback behavior stay unchanged.

Validation on the integration checkout:
- `corepack pnpm exec vp run -t vite-hub#build` passed for all 27 packages and package validation.
- `corepack pnpm --dir packages/vite-hub exec vp test test/vite.test.ts --maxWorkers 1 --testTimeout 30000 --typecheck.enabled false` passed all 92 tests.
- `corepack pnpm --dir packages/vite-hub run typecheck` passed.
- `corepack pnpm exec vp run lint` passed with existing warnings.
- Full framework and consumer suites were interrupted under heavy server contention. The framework suite had failures in generated-type restart, Console, and CLI tests before interruption; those failures were not resolved by this change. Provider output checks remain unverified locally.

Model: GPT-6. Harness: Codex.
