### PR TITLE
perf(agent): resolve MCP servers concurrently

### DIFF
--- a/packages/agent/src/internal/mcp-tool-capability.ts
+++ b/packages/agent/src/internal/mcp-tool-capability.ts
@@ -211,7 +211,9 @@ export function defineMcpToolCapability<
       const clients = clientsByContext.get(context) || []
       clientsByContext.delete(context)
       const errors: unknown[] = []
-      const closes = await Promise.allSettled(clients.splice(0).reverse().flatMap(client => client ? [client.close()] : []))
+      const closes = await Promise.allSettled(clients.splice(0).reverse().map(async client => {
+        await client?.close()
+      }))
       for (const result of closes) if (result.status === "rejected") errors.push(result.reason)
       if (errors.length === 1) throw errors[0]
       if (errors.length > 1) throw new AggregateError(errors, "[vitehub] Multiple MCP clients failed to close.")

--- a/packages/agent/src/internal/mcp-tool-capability.ts
+++ b/packages/agent/src/internal/mcp-tool-capability.ts
@@ -168,6 +168,7 @@ export function defineMcpToolCapability<
       if (definitionFailure?.status === "rejected") throw definitionFailure.reason
       const needsMcpRuntime = definitions.some(result => result.status === "fulfilled"
         && result.value
+        && !isMcpClient(result.value.connection)
         && isMcpClientConfig(result.value.connection))
       const mcpRuntime = needsMcpRuntime ? await import("@ai-sdk/mcp") : undefined
       const results = await Promise.allSettled(options.servers.map(async (server, index) => {

--- a/packages/agent/src/internal/mcp-tool-capability.ts
+++ b/packages/agent/src/internal/mcp-tool-capability.ts
@@ -152,7 +152,7 @@ export function defineMcpToolCapability<
   TRuntimeConfig extends AgentRuntimeConfig = AgentRuntimeConfig,
   Name extends WorkspaceName = WorkspaceName,
 >(options: McpToolCapabilityOptions<TRuntimeConfig, Name>): AgentCapabilityDefinition<TRuntimeConfig, Name> {
-  const clientsByContext = new WeakMap<AgentCapabilityRuntimeContext<TRuntimeConfig, Name>, McpClient[]>()
+  const clientsByContext = new WeakMap<AgentCapabilityRuntimeContext<TRuntimeConfig, Name>, Array<McpClient | undefined>>()
   return defineCapability({
     id: options.id,
     metadata: options.metadata,
@@ -160,15 +160,22 @@ export function defineMcpToolCapability<
       const tools: AgentToolSet = {}
       const clients: McpClient[] = []
       clientsByContext.set(context, clients)
-      for (const server of options.servers) {
+      const results = await Promise.allSettled(options.servers.map(async (server, index) => {
         const serverDefinition = await server.resolve(context)
-        if (serverDefinition === false || serverDefinition === null || serverDefinition === undefined) continue
+        if (serverDefinition === false || serverDefinition === null || serverDefinition === undefined) return
         const { client, metadata, owned } = await resolveMcpToolServer(serverDefinition, options.invalidServerMessage)
-        if (owned) clients.push(client)
+        if (owned) clients[index] = client
         const serverTools = await client.tools()
         if (serverDefinition.integrity) {
           await assertMcpToolIntegrity(server.name, serverTools, serverDefinition.integrity, options.integrityLabel)
         }
+        return { metadata, server, serverTools }
+      }))
+      const failure = results.find(result => result.status === "rejected")
+      if (failure?.status === "rejected") throw failure.reason
+      for (const result of results) {
+        if (result.status !== "fulfilled" || !result.value) continue
+        const { metadata, server, serverTools } = result.value
         for (const [toolName, tool] of Object.entries(serverTools || {})) {
           // SAFETY: McpClient.tools() establishes that each discovered entry is an Agent tool definition.
           const definition = tool as AgentToolDefinition & { metadata?: Record<string, unknown> }
@@ -194,14 +201,8 @@ export function defineMcpToolCapability<
       const clients = clientsByContext.get(context) || []
       clientsByContext.delete(context)
       const errors: unknown[] = []
-      for (const client of clients.splice(0).reverse()) {
-        try {
-          await client.close()
-        }
-        catch (error) {
-          errors.push(error)
-        }
-      }
+      const closes = await Promise.allSettled(clients.splice(0).reverse().flatMap(client => client ? [client.close()] : []))
+      for (const result of closes) if (result.status === "rejected") errors.push(result.reason)
       if (errors.length === 1) throw errors[0]
       if (errors.length > 1) throw new AggregateError(errors, "[vitehub] Multiple MCP clients failed to close.")
     },

--- a/packages/agent/src/internal/mcp-tool-capability.ts
+++ b/packages/agent/src/internal/mcp-tool-capability.ts
@@ -157,7 +157,13 @@ export function defineMcpToolCapability<
       const tools: AgentToolSet = {}
       const clients: McpClient[] = []
       clientsByContext.set(context, clients)
-      const definitions = await Promise.allSettled(options.servers.map(server => server.resolve(context)))
+      const definitions = await Promise.allSettled(options.servers.map(async server => await server.resolve(context)))
+      for (const [index, definition] of definitions.entries()) {
+        if (definition.status !== "fulfilled" || !definition.value) continue
+        if (isMcpClient(definition.value.connection) && definition.value.owned !== false) {
+          clients[index] = definition.value.connection
+        }
+      }
       const definitionFailure = definitions.find(result => result.status === "rejected")
       if (definitionFailure?.status === "rejected") throw definitionFailure.reason
       const needsMcpRuntime = definitions.some(result => result.status === "fulfilled"

--- a/packages/agent/src/internal/mcp-tool-capability.ts
+++ b/packages/agent/src/internal/mcp-tool-capability.ts
@@ -106,11 +106,6 @@ export function sanitizeMcpMetadata(value: unknown, seen = new WeakSet<object>()
   return output
 }
 
-async function createMcpClient(config: McpClientConfig): Promise<McpClient> {
-  const runtime = await import("@ai-sdk/mcp")
-  return await runtime.createMCPClient(config)
-}
-
 async function assertMcpToolIntegrity(server: string, tools: Record<string, unknown>, baseline: McpToolFingerprints, integrityLabel: string): Promise<void> {
   const aiSdk = await loadAiSdk()
   if (!hasRuntimeType(aiSdk.fingerprintTools, "function") || !hasRuntimeType(aiSdk.detectToolDrift, "function")) {
@@ -127,6 +122,7 @@ async function assertMcpToolIntegrity(server: string, tools: Record<string, unkn
 async function resolveMcpToolServer(
   resolved: ResolvedMcpToolServer,
   invalidServerMessage: string,
+  createMcpClient?: (config: McpClientConfig) => Promise<McpClient>,
 ): Promise<{ client: McpClient, metadata: unknown, owned: boolean }> {
   if (isMcpClient(resolved.connection)) {
     return {
@@ -139,6 +135,7 @@ async function resolveMcpToolServer(
     }
   }
   if (isMcpClientConfig(resolved.connection)) {
+    if (!createMcpClient) throw agentDiagnostics.AGENT_R0562({ message: invalidServerMessage })
     return {
       client: await createMcpClient(resolved.connection),
       metadata: sanitizeMcpMetadata(resolved.connection),
@@ -160,10 +157,23 @@ export function defineMcpToolCapability<
       const tools: AgentToolSet = {}
       const clients: McpClient[] = []
       clientsByContext.set(context, clients)
+      const definitions = await Promise.allSettled(options.servers.map(server => server.resolve(context)))
+      const definitionFailure = definitions.find(result => result.status === "rejected")
+      if (definitionFailure?.status === "rejected") throw definitionFailure.reason
+      const needsMcpRuntime = definitions.some(result => result.status === "fulfilled"
+        && result.value
+        && isMcpClientConfig(result.value.connection))
+      const mcpRuntime = needsMcpRuntime ? await import("@ai-sdk/mcp") : undefined
       const results = await Promise.allSettled(options.servers.map(async (server, index) => {
-        const serverDefinition = await server.resolve(context)
+        const definition = definitions[index]
+        if (definition?.status !== "fulfilled") return
+        const serverDefinition = definition.value
         if (serverDefinition === false || serverDefinition === null || serverDefinition === undefined) return
-        const { client, metadata, owned } = await resolveMcpToolServer(serverDefinition, options.invalidServerMessage)
+        const { client, metadata, owned } = await resolveMcpToolServer(
+          serverDefinition,
+          options.invalidServerMessage,
+          mcpRuntime ? config => mcpRuntime.createMCPClient(config) : undefined,
+        )
         if (owned) clients[index] = client
         const serverTools = await client.tools()
         if (serverDefinition.integrity) {

--- a/packages/agent/test/mcp-capability.test.ts
+++ b/packages/agent/test/mcp-capability.test.ts
@@ -449,6 +449,26 @@ describe("mcp capability", () => {
     }, runtime(), {})).rejects.toThrow("credential lookup failed")
   })
 
+  it("contains synchronous resolver failures and closes already-resolved owned clients", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { mcp } = await import("../src/capabilities.ts")
+    const owned = createClient({ lookup: { execute: vi.fn() } })
+    const borrowed = createClient({ search: { execute: vi.fn() } })
+
+    await expect(resolveAgentCapabilities({
+      capabilities: [mcp({
+        servers: {
+          owned: () => owned,
+          broken: () => { throw new Error("synchronous resolver failure") },
+          borrowed: () => ({ connection: borrowed, owned: false }),
+        },
+      })],
+    }, runtime(), {})).rejects.toThrow("synchronous resolver failure")
+
+    expect(owned.close).toHaveBeenCalledTimes(1)
+    expect(borrowed.close).not.toHaveBeenCalled()
+  })
+
   it("does not treat malformed configured servers as absent configuration", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { mcp } = await import("../src/capabilities.ts")
@@ -497,6 +517,22 @@ describe("mcp capability", () => {
     }, runtime(), {})
 
     await expect(resolved.close()).rejects.toThrow("second close failed")
+    expect(second.close).toHaveBeenCalledTimes(1)
+    expect(first.close).toHaveBeenCalledTimes(1)
+  })
+
+  it("drains remaining owned clients when a close throws synchronously", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { mcp } = await import("../src/capabilities.ts")
+    const first = createClient({ first: { execute: vi.fn() } })
+    const second = createClient({ second: { execute: vi.fn() } })
+    second.close.mockImplementationOnce(() => { throw new Error("synchronous close failure") })
+
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [mcp({ servers: { first: () => first, second: () => second } })],
+    }, runtime(), {})
+
+    await expect(resolved.close()).rejects.toThrow("synchronous close failure")
     expect(second.close).toHaveBeenCalledTimes(1)
     expect(first.close).toHaveBeenCalledTimes(1)
   })

--- a/packages/agent/test/mcp-capability.test.ts
+++ b/packages/agent/test/mcp-capability.test.ts
@@ -483,12 +483,14 @@ describe("mcp capability", () => {
     expect(second.close).toHaveBeenCalledTimes(1)
   })
 
-  it("attempts every owned client close when one fails", async () => {
+  it.each(["rejects", "throws"])("attempts every owned client close when one %s", async (failure) => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { mcp } = await import("../src/capabilities.ts")
     const first = createClient({ first: { execute: vi.fn() } })
     const second = createClient({ second: { execute: vi.fn() } })
-    second.close.mockRejectedValueOnce(new Error("second close failed"))
+    const error = new Error("second close failed")
+    if (failure === "throws") second.close.mockImplementationOnce(() => { throw error })
+    else second.close.mockRejectedValueOnce(error)
 
     const resolved = await resolveAgentCapabilities({
       capabilities: [mcp({ servers: { first: () => first, second: () => second } })],

--- a/packages/agent/test/mcp-capability.test.ts
+++ b/packages/agent/test/mcp-capability.test.ts
@@ -370,6 +370,31 @@ describe("mcp capability", () => {
     }
   })
 
+  it("does not load the MCP runtime for direct clients with transport fields", async () => {
+    vi.doMock("@ai-sdk/mcp", () => {
+      throw new Error("MCP runtime should not load")
+    })
+
+    try {
+      const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+      const { mcp } = await import("../src/capabilities.ts")
+      const client = Object.assign(createClient({ lookup: { execute: vi.fn() } }), {
+        transport: { type: "http", url: "https://example.com/mcp" },
+      })
+      const resolved = await resolveAgentCapabilities({
+        capabilities: [mcp({ servers: { custom: () => client } })],
+      }, runtime(), {})
+
+      expect(Object.keys(resolved.tools || {})).toEqual(["mcp_custom_lookup"])
+      expect(client.tools).toHaveBeenCalledTimes(1)
+      await resolved.close()
+      expect(client.close).toHaveBeenCalledTimes(1)
+    }
+    finally {
+      vi.doUnmock("@ai-sdk/mcp")
+    }
+  })
+
   it("does not load the MCP runtime when every server is absent", async () => {
     vi.doMock("@ai-sdk/mcp", () => {
       throw new Error("MCP runtime should not load")
@@ -460,7 +485,7 @@ describe("mcp capability", () => {
         servers: {
           owned: () => owned,
           broken: () => { throw new Error("synchronous resolver failure") },
-          borrowed: () => ({ connection: borrowed, owned: false }),
+          borrowed,
         },
       })],
     }, runtime(), {})).rejects.toThrow("synchronous resolver failure")

--- a/packages/agent/test/mcp-capability.test.ts
+++ b/packages/agent/test/mcp-capability.test.ts
@@ -40,6 +40,54 @@ async function fingerprintTools(tools: Record<string, unknown>) {
 }
 
 describe("mcp capability", () => {
+  it("resolves independent servers concurrently while preserving configured tool order", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { mcp } = await import("../src/capabilities.ts")
+    const delay = (duration: number) => new Promise(resolve => setTimeout(resolve, duration))
+    let activeResolvers = 0
+    let maximumActiveResolvers = 0
+    const client = (name: string) => {
+      const value = createClient({ [name]: { execute: vi.fn() } })
+      value.tools.mockImplementation(async () => {
+        await delay(80)
+        return { [name]: { execute: vi.fn() } }
+      })
+      return value
+    }
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [mcp({
+        servers: {
+          first: async () => {
+            maximumActiveResolvers = Math.max(maximumActiveResolvers, ++activeResolvers)
+            await delay(80)
+            activeResolvers--
+            return client("one")
+          },
+          second: async () => {
+            maximumActiveResolvers = Math.max(maximumActiveResolvers, ++activeResolvers)
+            await delay(80)
+            activeResolvers--
+            return client("two")
+          },
+          third: async () => {
+            maximumActiveResolvers = Math.max(maximumActiveResolvers, ++activeResolvers)
+            await delay(80)
+            activeResolvers--
+            return client("three")
+          },
+        },
+      })],
+    }, runtime(), {})
+
+    expect(maximumActiveResolvers).toBe(3)
+    expect(Object.keys(resolved.tools || {})).toEqual([
+      "mcp_first_one",
+      "mcp_second_two",
+      "mcp_third_three",
+    ])
+    await resolved.close()
+  }, 60_000)
+
   it("loads direct client tools with namespaced metadata without closing the borrowed client", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
     const { mcp } = await import("../src/capabilities.ts")
@@ -450,6 +498,28 @@ describe("mcp capability", () => {
     expect(second.close).toHaveBeenCalledTimes(1)
     expect(first.close).toHaveBeenCalledTimes(1)
   })
+
+  it("closes independent owned clients concurrently", async () => {
+    const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")
+    const { mcp } = await import("../src/capabilities.ts")
+    const delay = (duration: number) => new Promise(resolve => setTimeout(resolve, duration))
+    const clients = [createClient({ first: {} }), createClient({ second: {} }), createClient({ third: {} })]
+    let activeCloses = 0
+    let maximumActiveCloses = 0
+    for (const client of clients) client.close.mockImplementation(async () => {
+      maximumActiveCloses = Math.max(maximumActiveCloses, ++activeCloses)
+      await delay(80)
+      activeCloses--
+      return undefined
+    })
+    const resolved = await resolveAgentCapabilities({
+      capabilities: [mcp({ servers: { first: () => clients[0]!, second: () => clients[1]!, third: () => clients[2]! } })],
+    }, runtime(), {})
+    await resolved.close()
+
+    expect(maximumActiveCloses).toBe(3)
+    for (const client of clients) expect(client.close).toHaveBeenCalledTimes(1)
+  }, 60_000)
 
   it("admits tools that match an approved integrity baseline", async () => {
     const { resolveAgentCapabilities } = await import("../src/capability-runtime.ts")


### PR DESCRIPTION
MCP capabilities resolved each configured server and closed each owned client in series, so independent network round trips added directly to Agent startup and teardown time. Resolve server definitions concurrently, load the MCP runtime once when needed, initialize and inspect clients concurrently, then merge tools in configuration order. Close owned clients concurrently while retaining deterministic error aggregation.

A controlled three-server regression test observes one active resolver and one active close before this change, and three after it. The same test verifies stable tool order. Existing focused coverage verifies optional server reevaluation, per-invocation ownership, failure cleanup, duplicate names, and integrity checks.

After module import, three controlled samples with 80 ms resolver, discovery, and close delays produced these medians on the loaded test host:
- serial: 523.0 ms setup, 248.4 ms close, peak concurrency 1
- parallel: 181.3 ms setup, 94.5 ms close, peak concurrency 3

Validation:
- new concurrency tests: 2 passed
- focused ownership, failure, duplicate, and integrity cases: 9 passed
- full MCP Capability file: 25 passed, 1 environment failure
- unchanged `origin/main` in the same worktree: 23 passed, the same environment failure
- Vite Doctor TypeScript: clean

The shared failure is the root import test because this isolated worktree does not provide generated `#vitehub/agent/registry` output. A protocol-discovery mock race exposed by concurrent dynamic imports was fixed by importing the MCP runtime once before parallel client initialization; its regression now passes.

Production follow-up: deployed through Quiver pnpm patches on 7 September 2026. Three-server MCP resolve measured 688 ms on a warm arithmetic request and 766 ms on a ROP request; close measured 86 ms and 138 ms. Warm request overhead changed from 2.082 s to 0.894 s. These are individual end-to-end observations, not an isolated causal benchmark; the controlled-delay benchmark above isolates concurrency.
