### PR TITLE
perf(workspace): parallelize hosted file copies

### DIFF
--- a/docs/content/docs/server-primitives/workspace.md
+++ b/docs/content/docs/server-primitives/workspace.md
@@ -451,6 +451,8 @@ export async function testDocs() {
 
 `startSession(options)` combines Workspace state with an open Box Session. `host` is required for execution. `paths` limits materialization and commits, and `target` defaults to `/workspace`. `abortSignal` cancels preparation, while `onProgress` reports materialization phases. Closing the Workspace Session doesn't close the Box host.
 
+Custom hosts copy Workspace files serially unless they declare a positive `materializationConcurrency` that they can safely support for independent file operations. The local Node host declares a limit of `8`.
+
 Set `writeBack.exclude` to Workspace-relative paths owned by the runtime rather than the invocation. Excluded paths remain usable in the host tree, but their changes are omitted from `diff()` and `commit()` and their pre-Session state is restored by `close()`. Set `writeBack: false` when the runtime must remain writable but its changes must never be published. That mode disables `diff()` and `commit()` and restores the authoritative Workspace on close without first scanning the runtime tree. Read-only Agent Workspaces select it automatically. ViteHub always applies the same excluded-path behavior to `.agent-runs`, `.git`, and `.vitehub`. Integrations that already own a live materialized tree can set `attach: true`; the Session preserves pre-existing live edits, never rematerializes the whole tree, and rolls back only its own uncommitted changes on close.
 
 | Method | Options | Behavior |

--- a/packages/agent/src/provider-agent.ts
+++ b/packages/agent/src/provider-agent.ts
@@ -1360,6 +1360,7 @@ export function localWorkspaceHost(): WorkspaceSessionHost {
       network: "unrestricted",
       processes: "arbitrary",
     }),
+    materializationConcurrency: 8,
     files: {
       async exists(path, options) {
         options?.signal?.throwIfAborted()

--- a/packages/agent/test/provider-agent.test.ts
+++ b/packages/agent/test/provider-agent.test.ts
@@ -3190,6 +3190,10 @@ cli_auth_credentials_store = "keyring"
     await rm(heartbeatFile, { force: true })
   })
 
+  it("advertises bounded parallel Workspace materialization for the local host", () => {
+    expect(localWorkspaceHost().materializationConcurrency).toBe(8)
+  })
+
   it("reports executable modes while listing local Workspace files", async () => {
     const root = `/tmp/vitehub-provider-file-modes-${crypto.randomUUID()}`
     await mkdir(root, { recursive: true })

--- a/packages/workspace/README.md
+++ b/packages/workspace/README.md
@@ -192,6 +192,8 @@ Use `startSession({ attach: true, host })` only when another integration already
 
 Use `startSession({ host, writeBack: false })` for a private writable runtime that must never publish its changes. `diff()` and `commit()` are unavailable in this mode, and `close()` restores the authoritative Workspace without first scanning the runtime tree. Agent Definitions select this mode automatically for read-only Workspaces.
 
+Custom `WorkspaceSessionHost` implementations copy Workspace files serially by default. A host can set `materializationConcurrency` to a positive integer when it supports that many independent file reads and writes safely. ViteHub's local Node host uses `8`.
+
 ## MountX projection
 
 Use the `@vite-hub/workspace/mountx` integration when an Agent, editor, CLI, or VM needs a real filesystem instead of Workspace methods. The adapter keeps Workspace Session diff and commit semantics in ViteHub while MountX owns the host transport.

--- a/packages/workspace/src/core/types.ts
+++ b/packages/workspace/src/core/types.ts
@@ -173,6 +173,8 @@ export interface WorkspaceSessionHostFiles {
 export interface WorkspaceSessionHost {
   readonly executionAuthority: ExecutionAuthority
   readonly inspectionConcurrency?: number
+  /** Maximum independent workspace files copied into this host concurrently. Defaults to 1. */
+  readonly materializationConcurrency?: number
   detachAbortSignal?(): void
   files: WorkspaceSessionHostFiles
   exec(

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -42,6 +42,40 @@ function resolveHostInspectionConcurrency(host: WorkspaceSessionHost): number {
   return concurrency
 }
 
+function resolveHostMaterializationConcurrency(host: WorkspaceSessionHost): number {
+  const concurrency = host.materializationConcurrency ?? 1
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw workspaceError("[vitehub] Workspace host materializationConcurrency must be a positive integer.")
+  }
+  return concurrency
+}
+
+async function mapHostMaterialization<T>(
+  host: WorkspaceSessionHost,
+  values: readonly T[],
+  visit: (value: T) => Promise<void>,
+  signal?: AbortSignal,
+) {
+  let next = 0
+  let failure: unknown
+  const workers = Array.from({ length: Math.min(values.length, resolveHostMaterializationConcurrency(host)) }, async () => {
+    while (failure === undefined) {
+      signal?.throwIfAborted()
+      const index = next++
+      if (index >= values.length) return
+      try {
+        await visit(values[index]!)
+      }
+      catch (error) {
+        failure ??= error
+      }
+    }
+  })
+  await Promise.allSettled(workers)
+  if (failure !== undefined) throw failure
+  signal?.throwIfAborted()
+}
+
 function resolveHostInspectionLimiter(host: WorkspaceSessionHost) {
   const existing = hostInspectionLimiters.get(host)
   if (existing) return existing
@@ -790,9 +824,8 @@ async function materializeWorkspace(
     label: "Reading workspace files",
   }, async () => {
     abortSignal?.throwIfAborted()
-    for (const entry of entries) {
+    await mapHostMaterialization(host, entries.filter(entry => entry.type === "file"), async (entry) => {
       abortSignal?.throwIfAborted()
-      if (entry.type !== "file") continue
       const target = toHostPath(root, entry.path)
       await ensureHostParent(host, target, abortSignal)
       if (isGitSymlinkEntry(entry)) {
@@ -809,7 +842,7 @@ async function materializeWorkspace(
         if (entry.metadata?.gitMode === "100755") await makeHostFileExecutable(host, root, target, abortSignal)
       }
       abortSignal?.throwIfAborted()
-    }
+    }, abortSignal)
   })
   if (revision && await materializer?.currentRevision({ abortSignal: options?.abortSignal }) !== revision.revision) {
     throw workspaceConflict(`[vitehub] Workspace revision changed while this Session materialized: ${revision.revision}.`)
@@ -866,6 +899,7 @@ export async function createHostedWorkspaceSession(
     throw workspaceErrorDiagnostics.WORKSPACE_R0045({ message: "[vitehub] Workspace session host must declare executionAuthority." })
   }
   resolveHostInspectionConcurrency(host)
+  resolveHostMaterializationConcurrency(host)
   const root = normalizeTarget(options.target)
   const sessionPaths = normalizeSessionPaths(options)
   const excludedWriteBackPaths = [

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -32,7 +32,8 @@ import { workspaceErrorDiagnostics } from "../error-diagnostics.ts"
 
 const publicationQueues = new WeakMap<object, Promise<void>>()
 const defaultHostInspectionConcurrency = 16
-const hostInspectionLimiters = new WeakMap<object, <T>(inspect: () => Promise<T>, signal?: AbortSignal) => Promise<T>>()
+const hostInspectionLimiters = new WeakMap<object, ReturnType<typeof createHostLimiter>>()
+const hostMaterializationLimiters = new WeakMap<object, ReturnType<typeof createHostLimiter>>()
 
 function resolveHostInspectionConcurrency(host: WorkspaceSessionHost): number {
   const concurrency = host.inspectionConcurrency ?? defaultHostInspectionConcurrency
@@ -56,16 +57,32 @@ async function mapHostMaterialization<T>(
   visit: (value: T) => Promise<void>,
   signal?: AbortSignal,
 ) {
+  const concurrency = resolveHostMaterializationConcurrency(host)
+  let limit = hostMaterializationLimiters.get(host)
+  if (!limit) {
+    limit = createHostLimiter(concurrency)
+    hostMaterializationLimiters.set(host, limit)
+  }
   let next = 0
   let failed = false
   let failure: unknown
-  const workers = Array.from({ length: Math.min(values.length, resolveHostMaterializationConcurrency(host)) }, async () => {
+  const workers = Array.from({ length: Math.min(values.length, concurrency) }, async () => {
     while (!failed) {
       signal?.throwIfAborted()
       const index = next++
       if (index >= values.length) return
       try {
-        await visit(values[index]!)
+        await limit(async () => {
+          if (failed) return
+          signal?.throwIfAborted()
+          try {
+            await visit(values[index]!)
+          }
+          catch (error) {
+            if (!failed) failure = error
+            failed = true
+          }
+        }, signal)
       }
       catch (error) {
         if (!failed) failure = error
@@ -81,7 +98,12 @@ async function mapHostMaterialization<T>(
 function resolveHostInspectionLimiter(host: WorkspaceSessionHost) {
   const existing = hostInspectionLimiters.get(host)
   if (existing) return existing
-  const concurrency = resolveHostInspectionConcurrency(host)
+  const limit = createHostLimiter(resolveHostInspectionConcurrency(host))
+  hostInspectionLimiters.set(host, limit)
+  return limit
+}
+
+function createHostLimiter(concurrency: number) {
   let active = 0
   const queued: Array<{ grant: () => void }> = []
   const run = async <T>(inspect: () => Promise<T>, signal?: AbortSignal): Promise<T> => {
@@ -115,7 +137,6 @@ function resolveHostInspectionLimiter(host: WorkspaceSessionHost) {
       queued.shift()?.grant()
     }
   }
-  hostInspectionLimiters.set(host, run)
   return run
 }
 

--- a/packages/workspace/src/session/host.ts
+++ b/packages/workspace/src/session/host.ts
@@ -57,9 +57,10 @@ async function mapHostMaterialization<T>(
   signal?: AbortSignal,
 ) {
   let next = 0
+  let failed = false
   let failure: unknown
   const workers = Array.from({ length: Math.min(values.length, resolveHostMaterializationConcurrency(host)) }, async () => {
-    while (failure === undefined) {
+    while (!failed) {
       signal?.throwIfAborted()
       const index = next++
       if (index >= values.length) return
@@ -67,12 +68,13 @@ async function mapHostMaterialization<T>(
         await visit(values[index]!)
       }
       catch (error) {
-        failure ??= error
+        if (!failed) failure = error
+        failed = true
       }
     }
   })
   await Promise.allSettled(workers)
-  if (failure !== undefined) throw failure
+  if (failed) throw failure
   signal?.throwIfAborted()
 }
 

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1669,6 +1669,34 @@ describe("workspace host sessions", () => {
     expect(maximum).toBe(3)
   })
 
+  it.each([undefined, 1, 3])("shares host materialization concurrency %s across sessions", async (concurrency) => {
+    const docs = workspace()
+    for (let index = 0; index < 6; index++) await docs.writeFile(`files/${index}.txt`, String(index))
+    await docs.snapshot({ name: "baseline" })
+    const host = Object.assign(memoryHost(), { materializationConcurrency: concurrency })
+    const write = host.files.write.bind(host.files)
+    let active = 0
+    let maximum = 0
+    host.files.write = async (path, content, options) => {
+      active++
+      maximum = Math.max(maximum, active)
+      try {
+        await new Promise(resolve => setTimeout(resolve, 5))
+        await write(path, content, options)
+      }
+      finally {
+        active--
+      }
+    }
+
+    const sessions = await Promise.all(["/first", "/second"].map(target => docs.startSession({ host, target, writeBack: false })))
+    expect(maximum).toBe(concurrency ?? 1)
+    for (const target of ["/first", "/second"]) {
+      for (let index = 0; index < 6; index++) expect(host.readText(`${target}/files/${index}.txt`)).toBe(String(index))
+    }
+    await Promise.all(sessions.map(session => session.close()))
+  })
+
   it("preserves undefined copy failures and drains active copies before cleanup", async () => {
     const docs = workspace()
     for (let index = 0; index < 5; index++) await docs.writeFile(`files/${index}.txt`, String(index))

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1669,7 +1669,7 @@ describe("workspace host sessions", () => {
     expect(maximum).toBe(3)
   })
 
-  it("drains active copies and skips queued files before failed-session cleanup", async () => {
+  it("preserves undefined copy failures and drains active copies before cleanup", async () => {
     const docs = workspace()
     for (let index = 0; index < 5; index++) await docs.writeFile(`files/${index}.txt`, String(index))
     await docs.snapshot({ name: "baseline" })
@@ -1686,7 +1686,7 @@ describe("workspace host sessions", () => {
       if (!recovering) startedBeforeCleanup.push(path)
       try {
         if (!recovering && path.endsWith("/files/0.txt")) await firstBlocked
-        if (!recovering && path.endsWith("/files/1.txt")) throw new Error("copy failed")
+        if (!recovering && path.endsWith("/files/1.txt")) throw undefined
         await write(path, content, options)
       }
       finally {
@@ -1705,7 +1705,7 @@ describe("workspace host sessions", () => {
     await vi.waitFor(() => expect(startedBeforeCleanup).toHaveLength(2))
     releaseFirst()
 
-    await expect(starting).rejects.toThrow("copy failed")
+    await expect(starting).rejects.toBeUndefined()
     expect(startedBeforeCleanup).toHaveLength(2)
   })
 

--- a/packages/workspace/test/host-session.test.ts
+++ b/packages/workspace/test/host-session.test.ts
@@ -1643,6 +1643,122 @@ describe("workspace host sessions", () => {
     )
   })
 
+  it("copies independent workspace files at the host materialization concurrency", async () => {
+    const docs = workspace()
+    for (let index = 0; index < 6; index++) await docs.writeFile(`files/${index}.txt`, String(index))
+    await docs.snapshot({ name: "baseline" })
+    const host = Object.assign(memoryHost(), { materializationConcurrency: 3 })
+    const write = host.files.write.bind(host.files)
+    let active = 0
+    let maximum = 0
+    host.files.write = async (path, content, options) => {
+      active++
+      maximum = Math.max(maximum, active)
+      await new Promise(resolve => setTimeout(resolve, 5))
+      try {
+        await write(path, content, options)
+      }
+      finally {
+        active--
+      }
+    }
+
+    const session = await docs.startSession({ host, writeBack: false })
+    await session.close()
+
+    expect(maximum).toBe(3)
+  })
+
+  it("drains active copies and skips queued files before failed-session cleanup", async () => {
+    const docs = workspace()
+    for (let index = 0; index < 5; index++) await docs.writeFile(`files/${index}.txt`, String(index))
+    await docs.snapshot({ name: "baseline" })
+    const host = Object.assign(memoryHost(), { materializationConcurrency: 2 })
+    const write = host.files.write.bind(host.files)
+    const remove = host.files.remove.bind(host.files)
+    let active = 0
+    let recovering = false
+    const startedBeforeCleanup: string[] = []
+    let releaseFirst!: () => void
+    const firstBlocked = new Promise<void>((resolve) => { releaseFirst = resolve })
+    host.files.write = async (path, content, options) => {
+      active++
+      if (!recovering) startedBeforeCleanup.push(path)
+      try {
+        if (!recovering && path.endsWith("/files/0.txt")) await firstBlocked
+        if (!recovering && path.endsWith("/files/1.txt")) throw new Error("copy failed")
+        await write(path, content, options)
+      }
+      finally {
+        active--
+      }
+    }
+    host.files.remove = async (path, options) => {
+      if (!recovering) {
+        expect(active).toBe(0)
+        recovering = true
+      }
+      await remove(path, options)
+    }
+
+    const starting = docs.startSession({ host, writeBack: false })
+    await vi.waitFor(() => expect(startedBeforeCleanup).toHaveLength(2))
+    releaseFirst()
+
+    await expect(starting).rejects.toThrow("copy failed")
+    expect(startedBeforeCleanup).toHaveLength(2)
+  })
+
+  it("drains active copies and skips queued files before aborted-session cleanup", async () => {
+    const docs = workspace()
+    for (let index = 0; index < 5; index++) await docs.writeFile(`files/${index}.txt`, String(index))
+    await docs.snapshot({ name: "baseline" })
+    const host = Object.assign(memoryHost(), { materializationConcurrency: 2 })
+    const write = host.files.write.bind(host.files)
+    const remove = host.files.remove.bind(host.files)
+    let active = 0
+    let recovering = false
+    let startedBeforeCleanup = 0
+    let release!: () => void
+    const blocked = new Promise<void>((resolve) => { release = resolve })
+    host.files.write = async (path, content, options) => {
+      active++
+      if (!recovering) startedBeforeCleanup++
+      try {
+        if (!recovering) await blocked
+        await write(path, content, options)
+      }
+      finally {
+        active--
+      }
+    }
+    host.files.remove = async (path, options) => {
+      if (!recovering) {
+        expect(active).toBe(0)
+        recovering = true
+      }
+      await remove(path, options)
+    }
+    const controller = new AbortController()
+    const reason = new Error("copy expired")
+    const starting = docs.startSession({ abortSignal: controller.signal, host, writeBack: false })
+    await vi.waitFor(() => expect(startedBeforeCleanup).toBe(2))
+    controller.abort(reason)
+    release()
+
+    await expect(starting).rejects.toBe(reason)
+    expect(startedBeforeCleanup).toBe(2)
+  })
+
+  it("rejects invalid host materialization concurrency", async () => {
+    const docs = workspace()
+    const host = Object.assign(memoryHost(), { materializationConcurrency: 0 })
+
+    await expect(docs.startSession({ host })).rejects.toThrow(
+      "Workspace host materializationConcurrency must be a positive integer",
+    )
+  })
+
   it("uses host-reported executable modes without spawning probes", async () => {
     const docs = workspace()
     const host = memoryHost()


### PR DESCRIPTION
Hosted workspace setup copied every fallback file serially, so independent Store reads and host writes accumulated their latency before an Agent could start. This adds an explicit `WorkspaceSessionHost.materializationConcurrency` contract, keeps custom hosts serial by default, and lets the built-in Node provider host copy up to eight files concurrently.

The bounded worker pool stops dequeuing after the first failure or abort and drains accepted copies before failed-session cleanup begins. Existing path normalization, symlink handling, executable modes, revision validation, and snapshot behavior remain in their owning paths.

A controlled `startSession` benchmark used 24 1 KiB files with deterministic 15 ms Store-read and 15 ms host-write delays, three samples per bound:

- concurrency 1: 1064 ms, 846 ms, 786 ms
- concurrency 4: 202 ms, 195 ms, 202 ms
- concurrency 8: 111 ms, 103 ms, 96 ms

These measurements demonstrate the copy-bound effect under injected latency. The server was heavily loaded, so they are not production wall-time estimates.

Validation:

- `pnpm --dir packages/workspace exec vp test test/host-session.test.ts` (65 tests)
- focused workspace concurrency, failure, abort, and validation tests after rebasing onto current `origin/main` (4 tests)
- focused Node provider host ownership test
- `pnpm --filter @vite-hub/workspace typecheck`
- `pnpm --filter @vite-hub/agent typecheck`
- `VITE_DOCTOR_SINCE=origin/main pnpm exec vp run doctor:typescript`

Model: gpt-5.6-sol
Harness: Codex (API)

Production follow-up: the warm arithmetic workspace file-read/copy phase changed from 1.706 s to 0.920 s after deployment through Quiver pnpm patches. Sources persisted across deployment. Expired-source refresh remains a separate roughly 53-second cost; this change does not bypass freshness checks. Individual production samples are noisy.
