### PR TITLE
feat(agent): trace capability setup and cleanup durations

### DIFF
--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -157,9 +157,9 @@ the stable codes and redaction rules.
 
 Every invocation also has an in-memory metadata trace through `runtime.trace` and `runtime.traceLog`. The default log is process-local and is not persisted across a Workflow boundary.
 
-Capability setup callbacks (`configure`, `prepare`, `bind`, `input`, `resolve`, `output`) and `close` emit one `agent.capability.<phase>` event when the callback settles. These events measure the callback itself with a monotonic clock, excluding before/after hooks and trace persistence. Read `agent.capability.id`, `agent.capability.phase`, `agent.capability.outcome`, and `agent.capability.durationMs` to distinguish slow integration setup from model execution. Outcomes are `success`, `error`, or `cancelled`; cancellation means the callback failed while the invocation's abort signal was set.
+Capability setup callbacks (`configure`, `prepare`, `bind`, `input`, `resolve`, `output`) and `close` emit one `agent.capability.<phase>` event when the callback settles. These events measure the callback itself with a monotonic clock, excluding before/after hooks and trace persistence. Read `agent.capability.id`, `agent.capability.phase`, `agent.capability.outcome`, and `agent.capability.durationMs` to distinguish slow integration setup from model execution. Outcomes are `success`, `error`, or `cancelled`; cancellation means the callback failed while the effective invocation input's abort signal was set.
 
-Timing events carry the available invocation, run, and trace identifiers. They contain no callback arguments, results, configuration, or thrown error messages, and follow the normal trace and journal retention policy. A missing event means timing is unavailable, not zero. Trace persistence failure does not change the callback's result or prevent cleanup.
+Timing events carry the available invocation, run, and trace identifiers. They contain no callback arguments, results, configuration, or thrown error messages, and follow the normal trace and journal retention policy. A missing event means timing is unavailable, not zero. Emission does not await arbitrary trace sinks: pending or rejected persistence cannot change callback results or prevent cleanup. The host still owns its trace sink's flushing and retention policy.
 
 Attach the `otlp()` Capability to send completed invocation traces to any OTLP/HTTP JSON receiver:
 

--- a/docs/content/docs/agents/invocations.md
+++ b/docs/content/docs/agents/invocations.md
@@ -157,6 +157,10 @@ the stable codes and redaction rules.
 
 Every invocation also has an in-memory metadata trace through `runtime.trace` and `runtime.traceLog`. The default log is process-local and is not persisted across a Workflow boundary.
 
+Capability setup callbacks (`configure`, `prepare`, `bind`, `input`, `resolve`, `output`) and `close` emit one `agent.capability.<phase>` event when the callback settles. These events measure the callback itself with a monotonic clock, excluding before/after hooks and trace persistence. Read `agent.capability.id`, `agent.capability.phase`, `agent.capability.outcome`, and `agent.capability.durationMs` to distinguish slow integration setup from model execution. Outcomes are `success`, `error`, or `cancelled`; cancellation means the callback failed while the invocation's abort signal was set.
+
+Timing events carry the available invocation, run, and trace identifiers. They contain no callback arguments, results, configuration, or thrown error messages, and follow the normal trace and journal retention policy. A missing event means timing is unavailable, not zero. Trace persistence failure does not change the callback's result or prevent cleanup.
+
 Attach the `otlp()` Capability to send completed invocation traces to any OTLP/HTTP JSON receiver:
 
 ```ts [server/agents/support.ts]

--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -166,6 +166,8 @@ The portable `@vite-hub/agent/server` entry exports `failInterruptedAgentInvocat
 
 `defineAgentInvocations({ observations, store })` configures retained observation count, content string length, encoded byte budget, and finish drain time. Defaults remain 256 observations, 65,536 UTF-16 code units of content strings, and a one-second drain, with a 16 MiB aggregate storage limit. Explicit limits support longer traces without removing bounds; records keep those limits across restarts. See [Agent Invocations](../../docs/content/docs/agents/invocations.md) for the limits and privacy policy.
 
+Capability setup and close callbacks emit `agent.capability.<phase>` timing events through the invocation trace. They include capability ID, measured duration, outcome, and available correlation IDs, without callback payloads or thrown messages. See [Agent Invocations](../../docs/content/docs/agents/invocations.md#observe-the-outcome) for the event contract.
+
 `title()` accepts message input or a plain `prompt`. Its default prompt follows T3 Code’s subject-and-outcome rules, requests `{ "title": "..." }`, and caps the title at 39 characters. An explicit title Driver uses the configured fallback on failure or timeout. For a journaled run, title generation starts beside the main answer and cleanup joins it within its timeout. Metadata journals keep title text only when `metadataContent` includes `vitehub.session.title`.
 
 For model-backed drivers, put free-form guidance for configured Sources, Capabilities, and Skills in `driver.instructions` or a deterministic imported instruction file. Tool descriptions and schemas stay with the tools as structured contracts.

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -918,19 +918,20 @@ export async function resolveAgentCapabilities<
     }
     finally {
       const invocationId = invocationContext.get(agentInvocationTraceIdContextKey)
+      const attributes: Record<string, string | number> = {
+        "agent.capability.id": capabilityId,
+        "agent.capability.phase": phase,
+        "agent.capability.outcome": outcome,
+        "agent.capability.durationMs": performance.now() - started,
+      }
+      if (hasRuntimeType(invocationId, "string")) attributes["agent.invocation.id"] = invocationId
+      if (runtime.run?.runId) attributes["agent.run.id"] = runtime.run.runId
       try {
         await runtime.traceLog.append({
           name: `agent.capability.${phase}`,
           type: "lifecycle",
           trace: runtime.trace,
-          attributes: {
-            "agent.capability.id": capabilityId,
-            "agent.capability.phase": phase,
-            "agent.capability.outcome": outcome,
-            "agent.capability.durationMs": performance.now() - started,
-            ...(typeof invocationId === "string" ? { "agent.invocation.id": invocationId } : {}),
-            ...(runtime.run?.runId ? { "agent.run.id": runtime.run.runId } : {}),
-          },
+          attributes,
         })
       }
       catch {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -913,7 +913,7 @@ export async function resolveAgentCapabilities<
       return await callback()
     }
     catch (error) {
-      outcome = input.abortSignal?.aborted ? "cancelled" : "error"
+      outcome = currentInput.abortSignal?.aborted ? "cancelled" : "error"
       throw error
     }
     finally {
@@ -927,12 +927,13 @@ export async function resolveAgentCapabilities<
       if (hasRuntimeType(invocationId, "string")) attributes["agent.invocation.id"] = invocationId
       if (runtime.run?.runId) attributes["agent.run.id"] = runtime.run.runId
       try {
-        await runtime.traceLog.append({
+        const emission = runtime.traceLog.append({
           name: `agent.capability.${phase}`,
           type: "lifecycle",
           trace: runtime.trace,
           attributes,
         })
+        void Promise.resolve(emission).catch(() => undefined)
       }
       catch {
         // Timing evidence must not replace callback results or cleanup errors.

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -18,6 +18,7 @@ import { runObservedAgentHook } from "./hooks.ts"
 import { nextWithAbort } from "./internal/abortable-stream.ts"
 import { materializeAgentModel } from "./internal/agent-model.ts"
 import { openAgentCapabilityScope } from "./internal/capability-scope.ts"
+import { agentInvocationTraceIdContextKey } from "./trace.ts"
 import type {
   AgentCapabilitiesInput,
   AgentCapabilitiesResolverContext,
@@ -904,6 +905,39 @@ export async function resolveAgentCapabilities<
 ): Promise<ResolvedAgentCapabilities> {
   const runtimeContext = toAgentCallbackContext(runtime)
   const invocationContext = invocationOptions.context || createAgentInvocationContextStore(input.context)
+  async function runCapabilityCallback<T>(capabilityId: string, phase: string, callback: () => Promise<T> | T): Promise<T> {
+    if (!runtime.traceLog) return await callback()
+    const started = performance.now()
+    let outcome = "success"
+    try {
+      return await callback()
+    }
+    catch (error) {
+      outcome = input.abortSignal?.aborted ? "cancelled" : "error"
+      throw error
+    }
+    finally {
+      const invocationId = invocationContext.get(agentInvocationTraceIdContextKey)
+      try {
+        await runtime.traceLog.append({
+          name: `agent.capability.${phase}`,
+          type: "lifecycle",
+          trace: runtime.trace,
+          attributes: {
+            "agent.capability.id": capabilityId,
+            "agent.capability.phase": phase,
+            "agent.capability.outcome": outcome,
+            "agent.capability.durationMs": performance.now() - started,
+            ...(typeof invocationId === "string" ? { "agent.invocation.id": invocationId } : {}),
+            ...(runtime.run?.runId ? { "agent.run.id": runtime.run.runId } : {}),
+          },
+        })
+      }
+      catch {
+        // Timing evidence must not replace callback results or cleanup errors.
+      }
+    }
+  }
   const invoker = invocationOptions.invoker || resolveInputAgentInvoker(input.context) || createFallbackAgentInvoker(runtime.run)
   const driverKind = invocationOptions.driverKind || "model"
   const resolveCapabilityCli = invocationOptions.resolveCapabilityCli ?? driverKind !== "provider"
@@ -1243,14 +1277,17 @@ export async function resolveAgentCapabilities<
         capabilityScope ??= await openAgentCapabilityScope()
         await capabilityScope.add(async () => {
           await callHooks("capability:close", capabilityContext, options?.hooks)
-          await capability.close?.(capabilityContext)
+          if (capability.close) await runCapabilityCallback(capability.id, "close", () => capability.close!(capabilityContext))
           await callHooks("capability:close:after", capabilityContext, options?.hooks)
         })
       }
 
       for (const phase of phases) {
         await callHooks(`capability:${phase}`, capabilityContext, options?.hooks)
-        const result = await capability[phase]?.(capabilityContext)
+        const callback = capability[phase]
+        const result = callback
+          ? await runCapabilityCallback(capability.id, phase, () => callback.call(capability, capabilityContext))
+          : undefined
         await callHooks(`capability:${phase}:after`, capabilityContext, options?.hooks)
         if (result instanceof Response) {
           return {

--- a/packages/agent/src/capability-runtime.ts
+++ b/packages/agent/src/capability-runtime.ts
@@ -926,17 +926,13 @@ export async function resolveAgentCapabilities<
       }
       if (hasRuntimeType(invocationId, "string")) attributes["agent.invocation.id"] = invocationId
       if (runtime.run?.runId) attributes["agent.run.id"] = runtime.run.runId
-      try {
-        await runtime.traceLog.append({
-          name: `agent.capability.${phase}`,
-          type: "lifecycle",
-          trace: runtime.trace,
-          attributes,
-        })
-      }
-      catch {
-        // Timing evidence must not replace callback results or cleanup errors.
-      }
+      // Persist timing asynchronously so a slow or unavailable sink cannot stall callback completion or cleanup.
+      void runtime.traceLog.append({
+        name: `agent.capability.${phase}`,
+        type: "lifecycle",
+        trace: runtime.trace,
+        attributes,
+      }).catch(() => {})
     }
   }
   const invoker = invocationOptions.invoker || resolveInputAgentInvoker(input.context) || createFallbackAgentInvoker(runtime.run)

--- a/packages/agent/test/capability-timing.test.ts
+++ b/packages/agent/test/capability-timing.test.ts
@@ -99,7 +99,7 @@ describe("capability lifecycle timing", () => {
         capabilities: [
           defineCapability({
             id: "example",
-            resolve() {
+            input() {
               expect(this.id).toBe("example");
               return response;
             },

--- a/packages/agent/test/capability-timing.test.ts
+++ b/packages/agent/test/capability-timing.test.ts
@@ -1,69 +1,138 @@
-import { afterEach, describe, expect, it, vi } from "vitest"
-import { createTraceEventLog } from "@vite-hub/runtime"
-import { defineCapability, resolveAgentCapabilities } from "../src/capability-runtime.ts"
-import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createTraceEventLog } from "@vite-hub/runtime";
+import { defineCapability, resolveAgentCapabilities } from "../src/capability-runtime.ts";
+import { createAgentInvocationContextStore } from "../src/invocation-context.ts";
 
-const runtime = () => ({ capabilities: {}, memo: vi.fn(), runtime: "unknown" as const, runtimeConfig: {}, waitUntil: vi.fn() })
+const runtime = () => ({
+  capabilities: {},
+  memo: vi.fn(),
+  runtime: "unknown" as const,
+  runtimeConfig: {},
+  waitUntil: vi.fn(),
+});
 
 describe("capability lifecycle timing", () => {
-  afterEach(() => vi.restoreAllMocks())
+  afterEach(() => vi.restoreAllMocks());
   it("records actual callbacks with invocation correlation and no configuration or result bodies", async () => {
-    let time = 100
-    vi.spyOn(performance, "now").mockImplementation(() => time)
-    const traceLog = createTraceEventLog({ content: "content" })
-    const context = createAgentInvocationContextStore()
-    context.set("agent.invocation.traceId", "invocation-1")
-    const resolved = await resolveAgentCapabilities({ capabilities: [defineCapability({
-      id: "example",
-      metadata: { token: "private-value" },
-      resolve() { time += 25 },
-      close() { time += 7 },
-    })] }, { ...runtime(), traceLog, trace: { id: "trace-1" } }, {}, undefined, "read", { context })
-    await resolved.close()
-    const events = traceLog.entries()
-    expect(events.map(event => event.name)).toEqual(["agent.capability.resolve", "agent.capability.close"])
+    let time = 100;
+    vi.spyOn(performance, "now").mockImplementation(() => time);
+    const traceLog = createTraceEventLog({ content: "content" });
+    const context = createAgentInvocationContextStore();
+    context.set("agent.invocation.traceId", "invocation-1");
+    const resolved = await resolveAgentCapabilities(
+      {
+        capabilities: [
+          defineCapability({
+            id: "example",
+            metadata: { token: "private-value" },
+            resolve() {
+              time += 25;
+            },
+            close() {
+              time += 7;
+            },
+          }),
+        ],
+      },
+      { ...runtime(), traceLog, trace: { id: "trace-1" } },
+      {},
+      undefined,
+      "read",
+      { context },
+    );
+    await resolved.close();
+    const events = traceLog.entries();
+    expect(events.map((event) => event.name)).toEqual([
+      "agent.capability.resolve",
+      "agent.capability.close",
+    ]);
     for (const event of events) {
-      expect(event.attributes).toMatchObject({ "agent.capability.id": "example", "agent.invocation.id": "invocation-1", "agent.capability.outcome": "success", "agent.capability.durationMs": expect.any(Number) })
-      expect(event.trace).toEqual({ id: "trace-1" })
+      expect(event.attributes).toMatchObject({
+        "agent.capability.id": "example",
+        "agent.invocation.id": "invocation-1",
+        "agent.capability.outcome": "success",
+        "agent.capability.durationMs": expect.any(Number),
+      });
+      expect(event.trace).toEqual({ id: "trace-1" });
     }
-    expect(events.map(event => event.attributes?.["agent.capability.durationMs"])).toEqual([25, 7])
-    expect(JSON.stringify(events)).not.toContain("private-value")
-  })
+    expect(events.map((event) => event.attributes?.["agent.capability.durationMs"])).toEqual([
+      25, 7,
+    ]);
+    expect(JSON.stringify(events)).not.toContain("private-value");
+  });
 
   it("records failures without serializing thrown secrets and still cleans up", async () => {
-    const traceLog = createTraceEventLog({ content: "content" })
-    const failure = new Error("token=private-value")
-    const close = vi.fn()
-    await expect(resolveAgentCapabilities({ capabilities: [defineCapability({ id: "example", resolve() { throw failure }, close })] }, { ...runtime(), traceLog }, {})).rejects.toBe(failure)
-    expect(close).toHaveBeenCalledOnce()
-    expect(traceLog.entries().map(event => event.attributes?.["agent.capability.outcome"])).toEqual(["error", "success"])
-    expect(JSON.stringify(traceLog.entries())).not.toContain("private-value")
-  })
+    const traceLog = createTraceEventLog({ content: "content" });
+    const failure = new Error("token=private-value");
+    const close = vi.fn();
+    await expect(
+      resolveAgentCapabilities(
+        {
+          capabilities: [
+            defineCapability({
+              id: "example",
+              resolve() {
+                throw failure;
+              },
+              close,
+            }),
+          ],
+        },
+        { ...runtime(), traceLog },
+        {},
+      ),
+    ).rejects.toBe(failure);
+    expect(close).toHaveBeenCalledOnce();
+    expect(
+      traceLog.entries().map((event) => event.attributes?.["agent.capability.outcome"]),
+    ).toEqual(["error", "success"]);
+    expect(JSON.stringify(traceLog.entries())).not.toContain("private-value");
+  });
 
   it("reports cancellation and preserves callback receivers and response short circuits", async () => {
-    const traceLog = createTraceEventLog({ content: "content" })
-    const abort = new AbortController()
-    const reason = new Error("cancelled")
-    const response = new Response("private-result")
-    const resolved = await resolveAgentCapabilities({ capabilities: [defineCapability({
-      id: "example",
-      resolve() { expect(this.id).toBe("example"); return response },
-      close() { abort.abort(reason); throw reason },
-    })] }, { ...runtime(), traceLog }, { abortSignal: abort.signal })
-    expect(resolved.response).toBe(response)
-    await expect(resolved.close()).rejects.toBe(reason)
-    expect(traceLog.entries().map(event => event.attributes?.["agent.capability.outcome"])).toEqual(["success", "cancelled"])
-    expect(JSON.stringify(traceLog.entries())).not.toContain("private-result")
-  })
+    const traceLog = createTraceEventLog({ content: "content" });
+    const abort = new AbortController();
+    const reason = new Error("cancelled");
+    const response = new Response("private-result");
+    const resolved = await resolveAgentCapabilities(
+      {
+        capabilities: [
+          defineCapability({
+            id: "example",
+            resolve() {
+              expect(this.id).toBe("example");
+              return response;
+            },
+            close() {
+              abort.abort(reason);
+              throw reason;
+            },
+          }),
+        ],
+      },
+      { ...runtime(), traceLog },
+      { abortSignal: abort.signal },
+    );
+    expect(resolved.response).toBe(response);
+    await expect(resolved.close()).rejects.toBe(reason);
+    expect(
+      traceLog.entries().map((event) => event.attributes?.["agent.capability.outcome"]),
+    ).toEqual(["success", "cancelled"]);
+    expect(JSON.stringify(traceLog.entries())).not.toContain("private-result");
+  });
 
   it("does not fail callbacks when trace persistence fails", async () => {
-    const traceLog = createTraceEventLog({ content: "content" })
-    vi.spyOn(traceLog, "append").mockRejectedValue(new Error("unavailable"))
-    const resolve = vi.fn()
-    const close = vi.fn()
-    const result = await resolveAgentCapabilities({ capabilities: [defineCapability({ id: "example", resolve, close })] }, { ...runtime(), traceLog }, {})
-    await result.close()
-    expect(resolve).toHaveBeenCalledOnce()
-    expect(close).toHaveBeenCalledOnce()
-  })
-})
+    const traceLog = createTraceEventLog({ content: "content" });
+    vi.spyOn(traceLog, "append").mockRejectedValue(new Error("unavailable"));
+    const resolve = vi.fn();
+    const close = vi.fn();
+    const result = await resolveAgentCapabilities(
+      { capabilities: [defineCapability({ id: "example", resolve, close })] },
+      { ...runtime(), traceLog },
+      {},
+    );
+    await result.close();
+    expect(resolve).toHaveBeenCalledOnce();
+    expect(close).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/agent/test/capability-timing.test.ts
+++ b/packages/agent/test/capability-timing.test.ts
@@ -135,4 +135,73 @@ describe("capability lifecycle timing", () => {
     expect(resolve).toHaveBeenCalledOnce();
     expect(close).toHaveBeenCalledOnce();
   });
+  it("settles setup and all cleanup while a trace append remains pending", async () => {
+    const traceLog = createTraceEventLog({ content: "content" });
+    vi.spyOn(traceLog, "append").mockReturnValue(new Promise<never>(() => {}));
+    const close = vi.fn();
+    const work = (async () => {
+      const resolved = await resolveAgentCapabilities(
+        {
+          capabilities: [
+            defineCapability({ id: "first", resolve() {}, close }),
+            defineCapability({ id: "second", close }),
+          ],
+        },
+        { ...runtime(), traceLog },
+        {},
+      );
+      await resolved.close();
+      return "settled";
+    })();
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+    try {
+      expect(
+        await Promise.race([
+          work,
+          new Promise((resolve) => {
+            timeout = setTimeout(() => resolve("blocked"), 500);
+          }),
+        ]),
+      ).toBe("settled");
+      expect(close).toHaveBeenCalledTimes(2);
+    } finally {
+      clearTimeout(timeout);
+    }
+  });
+
+  it.each([true, false])(
+    "uses the effective replacement input signal (aborted=%s)",
+    async (effectiveAborted) => {
+      const traceLog = createTraceEventLog({ content: "content" });
+      const original = new AbortController();
+      const effective = new AbortController();
+      const failure = new Error("failure");
+      const work = resolveAgentCapabilities(
+        {
+          capabilities: [
+            defineCapability({
+              id: "replace",
+              input(context) {
+                context.input.set({ ...context.input.get(), abortSignal: effective.signal });
+              },
+            }),
+            defineCapability({
+              id: "fail",
+              resolve() {
+                (effectiveAborted ? effective : original).abort();
+                throw failure;
+              },
+            }),
+          ],
+        },
+        { ...runtime(), traceLog },
+        { abortSignal: original.signal },
+      );
+      await expect(work).rejects.toBe(failure);
+      expect(
+        traceLog.entries().find((event) => event.attributes?.["agent.capability.id"] === "fail")
+          ?.attributes?.["agent.capability.outcome"],
+      ).toBe(effectiveAborted ? "cancelled" : "error");
+    },
+  );
 });

--- a/packages/agent/test/capability-timing.test.ts
+++ b/packages/agent/test/capability-timing.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { createTraceEventLog } from "@vite-hub/runtime"
+import { defineCapability, resolveAgentCapabilities } from "../src/capability-runtime.ts"
+import { createAgentInvocationContextStore } from "../src/invocation-context.ts"
+
+const runtime = () => ({ capabilities: {}, memo: vi.fn(), runtime: "unknown" as const, runtimeConfig: {}, waitUntil: vi.fn() })
+
+describe("capability lifecycle timing", () => {
+  afterEach(() => vi.restoreAllMocks())
+  it("records actual callbacks with invocation correlation and no configuration or result bodies", async () => {
+    let time = 100
+    vi.spyOn(performance, "now").mockImplementation(() => time)
+    const traceLog = createTraceEventLog({ content: "content" })
+    const context = createAgentInvocationContextStore()
+    context.set("agent.invocation.traceId", "invocation-1")
+    const resolved = await resolveAgentCapabilities({ capabilities: [defineCapability({
+      id: "example",
+      metadata: { token: "private-value" },
+      resolve() { time += 25 },
+      close() { time += 7 },
+    })] }, { ...runtime(), traceLog, trace: { id: "trace-1" } }, {}, undefined, "read", { context })
+    await resolved.close()
+    const events = traceLog.entries()
+    expect(events.map(event => event.name)).toEqual(["agent.capability.resolve", "agent.capability.close"])
+    for (const event of events) {
+      expect(event.attributes).toMatchObject({ "agent.capability.id": "example", "agent.invocation.id": "invocation-1", "agent.capability.outcome": "success", "agent.capability.durationMs": expect.any(Number) })
+      expect(event.trace).toEqual({ id: "trace-1" })
+    }
+    expect(events.map(event => event.attributes?.["agent.capability.durationMs"])).toEqual([25, 7])
+    expect(JSON.stringify(events)).not.toContain("private-value")
+  })
+
+  it("records failures without serializing thrown secrets and still cleans up", async () => {
+    const traceLog = createTraceEventLog({ content: "content" })
+    const failure = new Error("token=private-value")
+    const close = vi.fn()
+    await expect(resolveAgentCapabilities({ capabilities: [defineCapability({ id: "example", resolve() { throw failure }, close })] }, { ...runtime(), traceLog }, {})).rejects.toBe(failure)
+    expect(close).toHaveBeenCalledOnce()
+    expect(traceLog.entries().map(event => event.attributes?.["agent.capability.outcome"])).toEqual(["error", "success"])
+    expect(JSON.stringify(traceLog.entries())).not.toContain("private-value")
+  })
+
+  it("reports cancellation and preserves callback receivers and response short circuits", async () => {
+    const traceLog = createTraceEventLog({ content: "content" })
+    const abort = new AbortController()
+    const reason = new Error("cancelled")
+    const response = new Response("private-result")
+    const resolved = await resolveAgentCapabilities({ capabilities: [defineCapability({
+      id: "example",
+      resolve() { expect(this.id).toBe("example"); return response },
+      close() { abort.abort(reason); throw reason },
+    })] }, { ...runtime(), traceLog }, { abortSignal: abort.signal })
+    expect(resolved.response).toBe(response)
+    await expect(resolved.close()).rejects.toBe(reason)
+    expect(traceLog.entries().map(event => event.attributes?.["agent.capability.outcome"])).toEqual(["success", "cancelled"])
+    expect(JSON.stringify(traceLog.entries())).not.toContain("private-result")
+  })
+
+  it("does not fail callbacks when trace persistence fails", async () => {
+    const traceLog = createTraceEventLog({ content: "content" })
+    vi.spyOn(traceLog, "append").mockRejectedValue(new Error("unavailable"))
+    const resolve = vi.fn()
+    const close = vi.fn()
+    const result = await resolveAgentCapabilities({ capabilities: [defineCapability({ id: "example", resolve, close })] }, { ...runtime(), traceLog }, {})
+    await result.close()
+    expect(resolve).toHaveBeenCalledOnce()
+    expect(close).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
Agent setup and cleanup can consume seconds before or after model execution, but the invocation trace did not measure the capability callbacks responsible. Existing hook observations measured the hooks around those callbacks.

Record one metadata event when each configured setup or close callback settles. Events contain the capability, phase, measured duration, outcome, and available invocation/run/trace IDs. They exclude configuration, callback bodies, and thrown messages. Timing uses a monotonic clock, preserves callback receivers and response short circuits, and cannot replace callback results or interrupt cleanup when trace persistence fails.

Validation: 67 focused capability runtime/timing tests passed; the new timing tests failed on the original implementation. Targeted package/dependency build and scoped lint passed. Tests cover measured durations, correlation, privacy, failure cleanup, cancellation, response preservation, trace-store failure, never-settling sinks, and replacement input cancellation signals. Package typecheck passed after rebasing onto current main; strict TypeScript doctor is clean.

Model: GPT-6
Harness: Codex (API)

Production follow-up: ten setup/close events per completed Quiver test persisted in the canonical Console journal with numeric duration, phase/outcome and invocation correlation. No unexpected timing attribute keys or callback bodies were present. Measured MCP resolve/close exposed previously unmeasured setup costs. The existing Quiver evlog exporter still sends a run summary rather than mirroring every callback event.
