### PR TITLE
test(agent): isolate fatal observation retry from wall-clock pressure

### DIFF
--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -2760,56 +2760,63 @@ describe("Agent Invocations", () => {
   })
 
   it("requeues an in-flight earliest fatal observation when its write fails", async () => {
-    let releaseFatal!: () => void
-    let reportFatalStarted!: () => void
-    let failFatal = true
-    const fatalGate = new Promise<void>((resolve) => { releaseFatal = resolve })
-    const fatalStarted = new Promise<void>((resolve) => { reportFatalStarted = resolve })
-    const memory = createMemoryAgentInvocationStore()
-    const invocations = defineAgentInvocations({
-      store: {
-        ...memory,
-        async update(id, input, claimId) {
-          if (failFatal && input.observation?.attributes?.["error.message"] === "earliest fatal") {
-            reportFatalStarted()
-            await fatalGate
-            failFatal = false
-            return
-          }
-          return memory.update(id, input, claimId)
+    // This test covers retry ordering and the count limit, not the wall-clock flush deadline.
+    vi.useFakeTimers({ toFake: ["Date"] })
+    try {
+      let releaseFatal!: () => void
+      let reportFatalStarted!: () => void
+      let failFatal = true
+      const fatalGate = new Promise<void>((resolve) => { releaseFatal = resolve })
+      const fatalStarted = new Promise<void>((resolve) => { reportFatalStarted = resolve })
+      const memory = createMemoryAgentInvocationStore()
+      const invocations = defineAgentInvocations({
+        store: {
+          ...memory,
+          async update(id, input, claimId) {
+            if (failFatal && input.observation?.attributes?.["error.message"] === "earliest fatal") {
+              reportFatalStarted()
+              await fatalGate
+              failFatal = false
+              return
+            }
+            return memory.update(id, input, claimId)
+          },
         },
-      },
-    })
-    const journal = await bindAgentInvocations(invocations, runtime("retried-earliest-fatal"))
-    if (!journal) throw new Error("Expected the invocation journal to be configured.")
-    await journal.running()
-    await journal.context.traceLog?.append({
-      attributes: { "error.message": "earliest fatal" },
-      name: "agent.stream.error",
-      type: "error",
-    })
-    await fatalStarted
-    for (let index = 0; index < 255; index++) {
-      await journal.context.traceLog?.append({ name: `ordinary-${index}`, type: "run" })
+      })
+      const journal = await bindAgentInvocations(invocations, runtime("retried-earliest-fatal"))
+      if (!journal) throw new Error("Expected the invocation journal to be configured.")
+      await journal.running()
+      await journal.context.traceLog?.append({
+        attributes: { "error.message": "earliest fatal" },
+        name: "agent.stream.error",
+        type: "error",
+      })
+      await fatalStarted
+      for (let index = 0; index < 255; index++) {
+        await journal.context.traceLog?.append({ name: `ordinary-${index}`, type: "run" })
+      }
+      await journal.context.traceLog?.append({
+        attributes: { "error.message": "later fatal" },
+        name: "agent.stream.error",
+        type: "error",
+      })
+      await journal.context.traceLog?.append({ name: "agent.invocation.finish", type: "run" })
+
+      const finishing = journal.finish("failed", new Error("earliest fatal"))
+      releaseFatal()
+      await finishing
+
+      const record = await invocations.getByRunId("retried-earliest-fatal")
+      expect(record?.observations).toHaveLength(256)
+      expect(record?.observations.filter(observation => outcomeObservationNames.has(observation.name))).toMatchObject([
+        { attributes: { "error.message": "earliest fatal" }, name: "agent.stream.error" },
+        { attributes: { "error.message": "later fatal" }, name: "agent.stream.error" },
+        { name: "agent.invocation.finish" },
+      ])
     }
-    await journal.context.traceLog?.append({
-      attributes: { "error.message": "later fatal" },
-      name: "agent.stream.error",
-      type: "error",
-    })
-    await journal.context.traceLog?.append({ name: "agent.invocation.finish", type: "run" })
-
-    const finishing = journal.finish("failed", new Error("earliest fatal"))
-    releaseFatal()
-    await finishing
-
-    const record = await invocations.getByRunId("retried-earliest-fatal")
-    expect(record?.observations).toHaveLength(256)
-    expect(record?.observations.filter(observation => outcomeObservationNames.has(observation.name))).toMatchObject([
-      { attributes: { "error.message": "earliest fatal" }, name: "agent.stream.error" },
-      { attributes: { "error.message": "later fatal" }, name: "agent.stream.error" },
-      { name: "agent.invocation.finish" },
-    ])
+    finally {
+      vi.useRealTimers()
+    }
   })
 
   it("requeues an in-flight earliest fatal observation after its write times out", async () => {

--- a/packages/agent/test/invocations.test.ts
+++ b/packages/agent/test/invocations.test.ts
@@ -2765,21 +2765,28 @@ describe("Agent Invocations", () => {
     try {
       let releaseFatal!: () => void
       let reportFatalStarted!: () => void
+      let reportFatalRetried!: () => void
+      let fatalWrites = 0
       let failFatal = true
       const fatalGate = new Promise<void>((resolve) => { releaseFatal = resolve })
       const fatalStarted = new Promise<void>((resolve) => { reportFatalStarted = resolve })
+      const fatalRetried = new Promise<void>((resolve) => { reportFatalRetried = resolve })
       const memory = createMemoryAgentInvocationStore()
       const invocations = defineAgentInvocations({
         store: {
           ...memory,
           async update(id, input, claimId) {
-            if (failFatal && input.observation?.attributes?.["error.message"] === "earliest fatal") {
+            const isEarliestFatal = input.observation?.attributes?.["error.message"] === "earliest fatal"
+            if (isEarliestFatal) fatalWrites++
+            if (failFatal && isEarliestFatal) {
               reportFatalStarted()
               await fatalGate
               failFatal = false
               return
             }
-            return memory.update(id, input, claimId)
+            const updated = await memory.update(id, input, claimId)
+            if (isEarliestFatal) reportFatalRetried()
+            return updated
           },
         },
       })
@@ -2802,9 +2809,10 @@ describe("Agent Invocations", () => {
       })
       await journal.context.traceLog?.append({ name: "agent.invocation.finish", type: "run" })
 
-      const finishing = journal.finish("failed", new Error("earliest fatal"))
       releaseFatal()
-      await finishing
+      await fatalRetried
+      expect(fatalWrites).toBe(2)
+      await journal.finish("failed", new Error("earliest fatal"))
 
       const record = await invocations.getByRunId("retried-earliest-fatal")
       expect(record?.observations).toHaveLength(256)


### PR DESCRIPTION
The fatal-observation retry test can fail on a busy host because the production flush deadline expires before all 256 observations persist. During Babysitter upgrade validation it retained 190 observations; the unchanged isolated rerun passed. It also finished the journal before the failed write settled, which let terminal snapshot handling bypass the retry branch.

Freeze only `Date`, keeping real timer callbacks active. Release the failed write and require a second fatal-observation write before finishing the journal. All count and ordering assertions remain, and the adjacent write-timeout test continues to cover deadline behavior. Restore the clock in `finally`.

Validation: Agent and dependency build, Agent typecheck, and lint passed. All 133 invocation tests passed after clock isolation; both focused retry tests passed after the sequencing correction. Disabling normal failed-write requeue makes the corrected test time out, confirming that it detects the regression. CI passed the invocation suite but failed the unrelated immutable Nuxt runtime-output fixture with HTTP 500.

Model: GPT-6. Harness: Codex.
