### PR TITLE
test(agent): synchronize provider cleanup before advancing timers

### DIFF
--- a/packages/agent/test/provider-agent.test.ts
+++ b/packages/agent/test/provider-agent.test.ts
@@ -3982,7 +3982,12 @@ cli_auth_credentials_store = "keyring"
     try {
       const threadId = "thread-cleanup-timeout"
       const provider = runtime(threadId, [event("turn.completed", threadId, { state: "completed" }, { turnId: "turn-1" })])
-      provider.close.mockImplementationOnce(() => new Promise(() => {}))
+      let reportCloseStarted!: () => void
+      const closeStarted = new Promise<void>((resolve) => { reportCloseStarted = resolve })
+      provider.close.mockImplementationOnce(() => {
+        reportCloseStarted()
+        return new Promise(() => {})
+      })
       const adapter = createProviderAgentAdapter({
         credentials: JSON.stringify({ OPENAI_API_KEY: "private" }),
         provider: "codex",
@@ -3991,7 +3996,9 @@ cli_auth_credentials_store = "keyring"
       const stream = await adapter.stream!(context(threadId) as never)
       const result = collect(stream)
 
-      await vi.waitFor(() => expect(provider.close).toHaveBeenCalledOnce())
+      // Let filesystem setup finish before advancing the cleanup deadline.
+      await closeStarted
+      expect(provider.close).toHaveBeenCalledOnce()
       const runtimeCall = createProviderRuntime.mock.lastCall
       expect(runtimeCall).toBeDefined()
       // SAFETY: The mocked Codex runtime call records the credential homePath setting.
@@ -4014,7 +4021,12 @@ cli_auth_credentials_store = "keyring"
     try {
       const threadId = "thread-profile-cleanup-timeout"
       const provider = runtime(threadId, [event("turn.completed", threadId, { state: "completed" }, { turnId: "turn-1" })])
-      provider.close.mockImplementationOnce(() => new Promise(() => {}))
+      let reportCloseStarted!: () => void
+      const closeStarted = new Promise<void>((resolve) => { reportCloseStarted = resolve })
+      provider.close.mockImplementationOnce(() => {
+        reportCloseStarted()
+        return new Promise(() => {})
+      })
       const options = {
         credentialProfile: `cleanup-timeout-${crypto.randomUUID()}`,
         credentials: JSON.stringify({ OPENAI_API_KEY: "private" }),
@@ -4023,7 +4035,9 @@ cli_auth_credentials_store = "keyring"
       // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
       const result = createProviderAgentAdapter(options).generate(context(threadId) as never)
 
-      await vi.waitFor(() => expect(provider.close).toHaveBeenCalledOnce())
+      // Let filesystem setup finish before advancing the cleanup deadline.
+      await closeStarted
+      expect(provider.close).toHaveBeenCalledOnce()
       await vi.advanceTimersByTimeAsync(10_000)
       await expect(result).resolves.toBeDefined()
 


### PR DESCRIPTION
Provider cleanup tests poll with `vi.waitFor` while fake timers are active. Polling advances the clock while asynchronous filesystem setup is still running, so a loaded host can spend the timeout before cleanup starts.

Wait for an explicit signal from the mocked `close` method before advancing the cleanup deadline. Apply this to successful-turn cleanup and named-profile quarantine, retaining their existing resource and result assertions.

Validation on the current main baseline: Agent and dependency build passed; both affected tests passed; Agent typecheck and focused lint passed. This changes test synchronization only.

Model: GPT-6. Harness: Codex.
