### PR TITLE
fix(console): preserve host-authorized Workspace inspection over RPC

### DIFF
--- a/packages/agent/README.md
+++ b/packages/agent/README.md
@@ -423,6 +423,10 @@ The defaults are `/api/health` and
 `{ exportName, route }`. Omit an option to omit its route. Workspace exports accept
 `(invocationId, path?)` and return a Response; for GitHub checkouts, use
 `createGitHubInvocationWorkspaceHandler({ host: github, invocations })`.
+The default Workspace route also serves Console RPC inspection, so retained GitHub
+snapshots remain available after disposable checkouts are removed. A custom route
+keeps its own URL and does not replace the default Console inspector.
+
 These are opt-in host routes: the application owns access control, including any
 middleware protecting Workspace content. They do not grant Console authorization.
 

--- a/packages/agent/src/host-routes-vite.ts
+++ b/packages/agent/src/host-routes-vite.ts
@@ -1,3 +1,4 @@
+import { agentHostWorkspaceRoute } from './server/host-workspace.ts'
 import { createHash } from 'node:crypto'
 import { hasRuntimeType } from './internal/runtime-type.ts'
 import { mkdir, writeFile } from 'node:fs/promises'
@@ -21,13 +22,14 @@ export function agentHostRoutes(options: {
       const root = resolve(config.root ?? process.cwd())
       const entry = resolve(root, options.entry)
       const directory = resolve(root, '.vitehub/agent-host-routes')
+      const plugins: string[] = []
       const handlers: { route: string, handler: string, method: 'get' | 'head' }[] = []
       // SAFETY: Nitro extends Vite configuration with optional route registrations.
       const existing = (config as UserConfig & { nitro?: { handlers?: { route?: string }[] } }).nitro?.handlers ?? []
       for (const kind of ['health', 'workspace'] as const) {
         const configured = options[kind]
         if (configured === undefined) continue
-        const { exportName, route = kind === 'health' ? '/api/health' : '/api/_vitehub/console/invocations/:id/workspace' } = hasRuntimeType(configured, 'string') ? { exportName: configured } : configured
+        const { exportName, route = kind === 'health' ? '/api/health' : agentHostWorkspaceRoute } = hasRuntimeType(configured, 'string') ? { exportName: configured } : configured
         if (!/^[$_\p{ID_Start}][$\u200C\u200D\p{ID_Continue}]*$/u.test(exportName))
           throw new Error('Agent host route exportName must be a JavaScript identifier.')
         if (!route.startsWith('/') || /[?#*]/.test(route) || (kind === 'workspace' && !route.split('/').includes(':id')))
@@ -44,8 +46,13 @@ export function agentHostRoutes(options: {
         await mkdir(directory, { recursive: true })
         await writeFile(handler, body)
         handlers.push({ route, handler, method: 'get' }, { route, handler, method: 'head' })
+        if (kind === 'workspace') {
+          const plugin = handler.replace(/\.ts$/, '-plugin.ts')
+          await writeFile(plugin, `import { registerAgentHostWorkspaceInspector } from '@vite-hub/agent/server'\n${moduleImport}\nexport default () => { registerAgentHostWorkspaceInspector(${JSON.stringify(route)}, inspect) }\n`)
+          plugins.push(plugin)
+        }
       }
-      const result: UserConfig & { nitro: { handlers: typeof handlers } } = { nitro: { handlers } }
+      const result: UserConfig & { nitro: { handlers: typeof handlers, plugins: string[] } } = { nitro: { handlers, plugins } }
       return result
     },
   }

--- a/packages/agent/src/server.ts
+++ b/packages/agent/src/server.ts
@@ -85,3 +85,6 @@ export type { AgentConsoleDelivery } from './server/console-delivery.ts'
 export { createAgentStatusReader } from './server/provider-status.ts'
 export { createAgentHealth } from './server/health.ts'
 export type { AgentHealthDiagnostic, AgentHealthOptions, AgentHealthReport } from './server/health.ts'
+
+export { agentHostWorkspaceRoute, getAgentHostWorkspaceInspector, registerAgentHostWorkspaceInspector } from "./server/host-workspace.ts"
+export type { AgentHostWorkspaceInspector } from "./server/host-workspace.ts"

--- a/packages/agent/src/server/host-workspace.ts
+++ b/packages/agent/src/server/host-workspace.ts
@@ -1,0 +1,17 @@
+/** Host-authorized inspection of a retained invocation Workspace. */
+export type AgentHostWorkspaceInspector = (id: string, path?: string) => Response | Promise<Response>
+
+export const agentHostWorkspaceRoute = "/api/_vitehub/console/invocations/:id/workspace"
+const inspectorsKey: unique symbol = Symbol.for("vitehub.agent.host-workspace-inspectors")
+// SAFETY: This module owns the process registry shared by separately bundled host and Console modules.
+const state = globalThis as typeof globalThis & { [inspectorsKey]?: Map<string, AgentHostWorkspaceInspector> }
+
+/** Register only routes explicitly enabled by the application through agentHostRoutes. */
+export function registerAgentHostWorkspaceInspector(route: string, inspector: AgentHostWorkspaceInspector): void {
+  const inspectors = state[inspectorsKey] ??= new Map()
+  inspectors.set(route, inspector)
+}
+
+export function getAgentHostWorkspaceInspector(route: string): AgentHostWorkspaceInspector | undefined {
+  return state[inspectorsKey]?.get(route)
+}

--- a/packages/agent/test/agent-host-routes.test.ts
+++ b/packages/agent/test/agent-host-routes.test.ts
@@ -1,4 +1,6 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { pathToFileURL } from 'node:url'
+import { getAgentHostWorkspaceInspector, agentHostWorkspaceRoute } from '../src/server/host-workspace.ts'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { expect, it } from 'vitest'
@@ -43,4 +45,26 @@ it.each([
   { health: { exportName: 'health', route: '/:id' }, workspace: { exportName: 'workspace', route: '/:id' } },
 ])('rejects malformed or colliding route configuration', async configured => {
   await expect(configure({ entry: 'agent.ts', ...configured }, {})).rejects.toThrow()
+})
+
+it('registers the configured Workspace inspector at host startup without replacing other routes', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'agent-host-inspector-'))
+  const route = `/host-${crypto.randomUUID()}/:id/workspace`
+  const previous = getAgentHostWorkspaceInspector(agentHostWorkspaceRoute)
+  try {
+    await mkdir(join(root, 'node_modules/@vite-hub'), { recursive: true })
+    await symlink(process.cwd(), join(root, 'node_modules/@vite-hub/agent'), 'dir')
+    await writeFile(join(root, 'agent.ts'), 'export const workspace = (id, path) => Response.json({ id, path })')
+    const result = await configure({ entry: 'agent.ts', workspace: { exportName: 'workspace', route } }, { root })
+    // SAFETY: This config hook contributes the Nitro startup plugins asserted by this integration test.
+    const plugins = (result as { nitro: { plugins: string[] } }).nitro.plugins
+    expect(plugins).toHaveLength(1)
+    const plugin = await import(pathToFileURL(plugins[0]!).href)
+    plugin.default()
+    const inspect = getAgentHostWorkspaceInspector(route)
+    expect(inspect).toBeDefined()
+    const response = await inspect!('retained-run', 'src/index.ts')
+    expect(await response.json()).toEqual({ id: 'retained-run', path: 'src/index.ts' })
+    expect(getAgentHostWorkspaceInspector(agentHostWorkspaceRoute)).toBe(previous)
+  } finally { await rm(root, { recursive: true, force: true }) }
 })

--- a/packages/agent/test/agent-host-routes.test.ts
+++ b/packages/agent/test/agent-host-routes.test.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { pathToFileURL } from 'node:url'
-import { getAgentHostWorkspaceInspector, agentHostWorkspaceRoute } from '../src/server/host-workspace.ts'
+import { execFile as execFileCallback } from 'node:child_process'
+import { promisify } from 'node:util'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { expect, it } from 'vitest'
@@ -50,7 +51,6 @@ it.each([
 it('registers the configured Workspace inspector at host startup without replacing other routes', async () => {
   const root = await mkdtemp(join(tmpdir(), 'agent-host-inspector-'))
   const route = `/host-${crypto.randomUUID()}/:id/workspace`
-  const previous = getAgentHostWorkspaceInspector(agentHostWorkspaceRoute)
   try {
     await mkdir(join(root, 'node_modules/@vite-hub'), { recursive: true })
     await symlink(process.cwd(), join(root, 'node_modules/@vite-hub/agent'), 'dir')
@@ -59,12 +59,13 @@ it('registers the configured Workspace inspector at host startup without replaci
     // SAFETY: This config hook contributes the Nitro startup plugins asserted by this integration test.
     const plugins = (result as { nitro: { plugins: string[] } }).nitro.plugins
     expect(plugins).toHaveLength(1)
-    const plugin = await import(pathToFileURL(plugins[0]!).href)
-    plugin.default()
-    const inspect = getAgentHostWorkspaceInspector(route)
-    expect(inspect).toBeDefined()
-    const response = await inspect!('retained-run', 'src/index.ts')
-    expect(await response.json()).toEqual({ id: 'retained-run', path: 'src/index.ts' })
-    expect(getAgentHostWorkspaceInspector(agentHostWorkspaceRoute)).toBe(previous)
+    const { stdout } = await promisify(execFileCallback)(process.execPath, ['--input-type=module', '--eval', `
+      import plugin from ${JSON.stringify(pathToFileURL(plugins[0]!).href)}
+      import { getAgentHostWorkspaceInspector, agentHostWorkspaceRoute } from '@vite-hub/agent/server'
+      plugin()
+      const response = await getAgentHostWorkspaceInspector(${JSON.stringify(route)})('retained-run', 'src/index.ts')
+      console.log(JSON.stringify({ result: await response.json(), defaultRegistered: Boolean(getAgentHostWorkspaceInspector(agentHostWorkspaceRoute)) }))
+    `], { cwd: root, timeout: 10_000 })
+    expect(JSON.parse(stdout)).toEqual({ result: { id: 'retained-run', path: 'src/index.ts' }, defaultRegistered: false })
   } finally { await rm(root, { recursive: true, force: true }) }
-})
+}, 15_000)

--- a/packages/vite-hub/src/console/runtime/server/invocation-workspace.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocation-workspace.get.ts
@@ -1,3 +1,4 @@
+import { agentHostWorkspaceRoute, getAgentHostWorkspaceInspector } from "@vite-hub/agent/server"
 import { useWorkspace } from "@vite-hub/workspace/runtime"
 import * as v from "valibot"
 import { getConsoleAgentDefinition } from "./agents.ts"
@@ -7,6 +8,10 @@ import { viteHubErrorDiagnostics } from "../../../error-diagnostics.ts"
 import type { ConsoleRequestEvent } from "./request.ts"
 
 const configurationSchema = v.object({ workspace: v.object({ name: v.string() }) })
+const hostWorkspaceSchema = v.union([
+  v.object({ paths: v.array(v.string()), repository: v.string(), revision: v.string() }),
+  v.object({ content: v.string(), path: v.string(), revision: v.string(), size: v.number() }),
+])
 const maxFileBytes = 512 * 1024
 
 function failure(statusCode: number, message: string): Error {
@@ -20,7 +25,15 @@ function visiblePath(path: string): boolean {
 
 export default async function consoleInvocationWorkspaceHandler(event: ConsoleRequestEvent): Promise<{ paths: string[], repository: string, revision: string } | { content: string, path: string, revision: string, size: number }> {
   assertConsoleRequest(event)
-  const invocation = await getConsoleInvocations().get(event.context?.params?.id ?? "")
+  const id = event.context?.params?.id ?? ""
+  const path = consoleRequestURL(event).searchParams.get("path")
+  const inspect = getAgentHostWorkspaceInspector(agentHostWorkspaceRoute)
+  if (inspect) {
+    const response = await inspect(id, path ?? undefined)
+    if (!response.ok) throw failure(response.status, await response.text())
+    return v.parse(hostWorkspaceSchema, await response.json())
+  }
+  const invocation = await getConsoleInvocations().get(id)
   if (!invocation) throw failure(404, "Invocation not found.")
   const agent = invocation.agentName && getConsoleAgentDefinition(invocation.agentName, "inspect")
   if (!agent || !agent.workspace) throw failure(404, "This Agent has no mounted Workspace available on this host.")
@@ -29,7 +42,6 @@ export default async function consoleInvocationWorkspaceHandler(event: ConsoleRe
   if (!configuration?.success) throw failure(404, "This run did not record its Workspace. Open a newer run to inspect its mounted files.")
   const name = configuration.output.workspace.name
   const workspace = useWorkspace(name)
-  const path = consoleRequestURL(event).searchParams.get("path")
   // These are the mounted files now, not a retained snapshot of the invocation.
   const revision = "current"
   if (path !== null) {

--- a/packages/vite-hub/test/console-invocation-workspace.test.ts
+++ b/packages/vite-hub/test/console-invocation-workspace.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-const mocks = vi.hoisted(() => ({ get: vi.fn(), definition: vi.fn(), glob: vi.fn(), stat: vi.fn(), readFile: vi.fn() }))
+const mocks = vi.hoisted(() => ({ inspector: vi.fn(), get: vi.fn(), definition: vi.fn(), glob: vi.fn(), stat: vi.fn(), readFile: vi.fn() }))
+vi.mock("@vite-hub/agent/server", () => ({ agentHostWorkspaceRoute: "/api/_vitehub/console/invocations/:id/workspace", getAgentHostWorkspaceInspector: mocks.inspector }))
 vi.mock("../src/console/runtime/server/invocations.ts", () => ({ getConsoleInvocations: () => ({ get: mocks.get }) }))
 vi.mock("../src/console/runtime/server/agents.ts", () => ({ getConsoleAgentDefinition: mocks.definition }))
 vi.mock("@vite-hub/workspace/runtime", () => ({ useWorkspace: () => ({ fs: mocks }) }))
@@ -14,6 +15,28 @@ beforeEach(() => {
   mocks.readFile.mockResolvedValue("test")
 })
 describe("invocation Workspace inspection", () => {
+  it("uses the host-authorized immutable snapshot when no mounted Workspace exists", async () => {
+    mocks.definition.mockReturnValue(undefined)
+    mocks.get.mockResolvedValue(undefined)
+    const inspect = vi.fn(async () => Response.json({ repository: "org/repo", revision: "abc123", paths: ["AGENTS.md"] }))
+    mocks.inspector.mockReturnValue(inspect)
+    expect(await handler(request())).toEqual({ repository: "org/repo", revision: "abc123", paths: ["AGENTS.md"] })
+    expect(inspect).toHaveBeenCalledWith("run", undefined)
+    expect(mocks.get).not.toHaveBeenCalled()
+    expect(mocks.glob).not.toHaveBeenCalled()
+  })
+  it("passes the file path to the configured host inspector", async () => {
+    const file = { content: "test", path: "src/a b.ts", revision: "abc123", size: 4 }
+    const inspect = vi.fn(async () => Response.json(file))
+    mocks.inspector.mockReturnValue(inspect)
+    expect(await handler(request(file.path))).toEqual(file)
+    expect(inspect).toHaveBeenCalledWith("run", file.path)
+  })
+  it.each([403, 404, 422])("preserves host inspection failure %i without falling back to mounted files", async status => {
+    mocks.inspector.mockReturnValue(async () => new Response("Snapshot unavailable", { status }))
+    await expect(handler(request())).rejects.toMatchObject({ statusCode: status, statusMessage: "Snapshot unavailable" })
+    expect(mocks.glob).not.toHaveBeenCalled()
+  })
   it("identifies current mounted files without claiming a historical snapshot", async () => {
     expect(await handler(request())).toEqual({ paths: ["AGENTS.md"], repository: "bot", revision: "current" })
     expect(mocks.definition).toHaveBeenCalledWith("bot", "inspect")


### PR DESCRIPTION
Babysitter registers an immutable GitHub Workspace inspector through `agentHostRoutes`. Console RPC bypassed that handler and returned “This Agent has no mounted Workspace available on this host,” even though the same invocation’s HTTP route returned its 2,242-file snapshot.

Register explicitly configured inspectors during Nitro startup and let the Console Workspace RPC use the default route’s inspector. Preserve the host’s invocation lookup, file path, status, and error response. Applications without a registered inspector retain mounted Workspace inspection; custom routes keep their own URL.

Validation: ViteHub and dependency build passed; all 7 host-route tests and 17 Console Workspace tests passed; focused lint passed. The generated startup plugin runs in a real Node subprocess. Agent and ViteHub typechecks passed. Production browser verification passed after installing the combined preview: the previously failing invocation now lists all 2,242 files at its immutable revision and opens AGENTS.md.

Model: GPT-6. Harness: Codex.
