### PR TITLE
fix(agent): keep cumulative usage totals unpartitioned

### DIFF
--- a/packages/agent/src/provider-agent.ts
+++ b/packages/agent/src/provider-agent.ts
@@ -1709,9 +1709,10 @@ async function respondToInput(runtime: ProviderRuntime, threadId: ThreadId, mess
 
 function usageEvent(event: Extract<ProviderRuntimeEvent, { type: "thread.token-usage.updated" }>): StreamEvent {
   const usage = event.payload.usage
-  const isCumulative = usage.totalProcessedTokens !== undefined
-  const inputTokens = isCumulative ? undefined : usage.inputTokens ?? usage.lastInputTokens
-  const outputTokens = isCumulative ? undefined : usage.outputTokens ?? usage.lastOutputTokens
+  const inputTokens = usage.inputTokens ?? usage.lastInputTokens
+  const outputTokens = usage.outputTokens ?? usage.lastOutputTokens
+  const omitPartition = usage.totalProcessedTokens !== undefined
+    && (inputTokens === undefined || outputTokens === undefined || inputTokens + outputTokens !== usage.totalProcessedTokens)
   return {
     type: "usage",
     usageRecord: {
@@ -1719,12 +1720,12 @@ function usageEvent(event: Extract<ProviderRuntimeEvent, { type: "thread.token-u
       raw: usage,
       usage: {
         details: {
-          ...(isCumulative || usage.cachedInputTokens === undefined ? {} : { cachedInputTokens: usage.cachedInputTokens }),
-          ...(isCumulative || usage.reasoningOutputTokens === undefined ? {} : { reasoningOutputTokens: usage.reasoningOutputTokens }),
-          ...(isCumulative || usage.toolUses === undefined ? {} : { toolUses: usage.toolUses }),
+          ...(omitPartition || usage.cachedInputTokens === undefined ? {} : { cachedInputTokens: usage.cachedInputTokens }),
+          ...(omitPartition || usage.reasoningOutputTokens === undefined ? {} : { reasoningOutputTokens: usage.reasoningOutputTokens }),
+          ...(omitPartition || usage.toolUses === undefined ? {} : { toolUses: usage.toolUses }),
         },
-        inputTokens,
-        outputTokens,
+        inputTokens: omitPartition ? undefined : inputTokens,
+        outputTokens: omitPartition ? undefined : outputTokens,
         totalTokens: usage.totalProcessedTokens ?? usage.usedTokens ?? (inputTokens ?? 0) + (outputTokens ?? 0),
       },
     },

--- a/packages/agent/src/provider-agent.ts
+++ b/packages/agent/src/provider-agent.ts
@@ -1709,8 +1709,9 @@ async function respondToInput(runtime: ProviderRuntime, threadId: ThreadId, mess
 
 function usageEvent(event: Extract<ProviderRuntimeEvent, { type: "thread.token-usage.updated" }>): StreamEvent {
   const usage = event.payload.usage
-  const inputTokens = usage.inputTokens ?? usage.lastInputTokens
-  const outputTokens = usage.outputTokens ?? usage.lastOutputTokens
+  const isCumulative = usage.totalProcessedTokens !== undefined
+  const inputTokens = isCumulative ? undefined : usage.inputTokens ?? usage.lastInputTokens
+  const outputTokens = isCumulative ? undefined : usage.outputTokens ?? usage.lastOutputTokens
   return {
     type: "usage",
     usageRecord: {
@@ -1718,9 +1719,9 @@ function usageEvent(event: Extract<ProviderRuntimeEvent, { type: "thread.token-u
       raw: usage,
       usage: {
         details: {
-          ...(usage.cachedInputTokens === undefined ? {} : { cachedInputTokens: usage.cachedInputTokens }),
-          ...(usage.reasoningOutputTokens === undefined ? {} : { reasoningOutputTokens: usage.reasoningOutputTokens }),
-          ...(usage.toolUses === undefined ? {} : { toolUses: usage.toolUses }),
+          ...(isCumulative || usage.cachedInputTokens === undefined ? {} : { cachedInputTokens: usage.cachedInputTokens }),
+          ...(isCumulative || usage.reasoningOutputTokens === undefined ? {} : { reasoningOutputTokens: usage.reasoningOutputTokens }),
+          ...(isCumulative || usage.toolUses === undefined ? {} : { toolUses: usage.toolUses }),
         },
         inputTokens,
         outputTokens,

--- a/packages/agent/test/provider-agent.test.ts
+++ b/packages/agent/test/provider-agent.test.ts
@@ -1996,12 +1996,35 @@ cli_auth_credentials_store = "keyring"
     ])
     expect(events[1]).toMatchObject({ phase: "commentary", text: "thinking" })
     expect(events[6]).toMatchObject({ phase: "final", text: "done" })
-    expect(events[7]).toMatchObject({ usageRecord: { usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 } } })
+    expect(events[7]).toMatchObject({ usageRecord: { usage: { inputTokens: undefined, outputTokens: undefined, totalTokens: 5 } } })
     expect(provider.startSession).toHaveBeenCalledWith(expect.objectContaining({ runtimeMode: "approval-required", threadId }))
     expect(provider.close).toHaveBeenCalledOnce()
     // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
     const cwd = (createProviderRuntime.mock.calls.at(-1)![0] as { cwd: string }).cwd
     await expect(access(cwd)).rejects.toMatchObject({ code: "ENOENT" })
+  })
+
+  it("keeps last-response usage raw when reporting a cumulative total", async () => {
+    const threadId = "thread-cumulative-usage"
+    runtime(threadId, [
+      event("thread.token-usage.updated", threadId, { usage: {
+        cachedInputTokens: 2,
+        inputTokens: 7,
+        outputTokens: 5,
+        reasoningOutputTokens: 3,
+        totalProcessedTokens: 100,
+        usedTokens: 12,
+      } }),
+      event("turn.completed", threadId, { state: "completed" }, { turnId: "turn-1" }),
+    ])
+
+    const events = await collect(await createProviderAgentAdapter({ provider: "codex" }).stream!(context(threadId) as never)) as Array<Record<string, unknown>>
+    expect(events.find(item => item.type === "usage")).toMatchObject({
+      usageRecord: {
+        raw: { cachedInputTokens: 2, inputTokens: 7, outputTokens: 5, reasoningOutputTokens: 3, totalProcessedTokens: 100, usedTokens: 12 },
+        usage: { details: {}, inputTokens: undefined, outputTokens: undefined, totalTokens: 100 },
+      },
+    })
   })
 
   it("keeps assistant item phases separate and forgets completed items", async () => {

--- a/packages/agent/test/provider-agent.test.ts
+++ b/packages/agent/test/provider-agent.test.ts
@@ -1996,12 +1996,38 @@ cli_auth_credentials_store = "keyring"
     ])
     expect(events[1]).toMatchObject({ phase: "commentary", text: "thinking" })
     expect(events[6]).toMatchObject({ phase: "final", text: "done" })
-    expect(events[7]).toMatchObject({ usageRecord: { usage: { inputTokens: undefined, outputTokens: undefined, totalTokens: 5 } } })
+    expect(events[7]).toMatchObject({ usageRecord: { usage: { inputTokens: 3, outputTokens: 2, totalTokens: 5 } } })
     expect(provider.startSession).toHaveBeenCalledWith(expect.objectContaining({ runtimeMode: "approval-required", threadId }))
     expect(provider.close).toHaveBeenCalledOnce()
     // SAFETY: This test fixture intentionally constructs the exact asserted runtime contract.
     const cwd = (createProviderRuntime.mock.calls.at(-1)![0] as { cwd: string }).cwd
     await expect(access(cwd)).rejects.toMatchObject({ code: "ENOENT" })
+  })
+
+  it.each([
+    { inputTokens: 7, outputTokens: 5 },
+    { lastInputTokens: 7, lastOutputTokens: 5 },
+    { inputTokens: 0, outputTokens: 12 },
+  ])("preserves a complete partition matching the cumulative total: %j", async (partition) => {
+    const threadId = "thread-matching-usage"
+    const usage = { ...partition, cachedInputTokens: 0, reasoningOutputTokens: 3, totalProcessedTokens: 12 }
+    runtime(threadId, [
+      event("thread.token-usage.updated", threadId, { usage }),
+      event("turn.completed", threadId, { state: "completed" }, { turnId: "turn-1" }),
+    ])
+
+    const events = await collect(await createProviderAgentAdapter({ provider: "codex" }).stream!(context(threadId) as never)) as Array<Record<string, unknown>>
+    expect(events.find(item => item.type === "usage")).toMatchObject({
+      usageRecord: {
+        raw: usage,
+        usage: {
+          details: { cachedInputTokens: 0, reasoningOutputTokens: 3 },
+          inputTokens: "inputTokens" in partition ? partition.inputTokens : partition.lastInputTokens,
+          outputTokens: "outputTokens" in partition ? partition.outputTokens : partition.lastOutputTokens,
+          totalTokens: 12,
+        },
+      },
+    })
   })
 
   it("keeps last-response usage raw when reporting a cumulative total", async () => {


### PR DESCRIPTION
Provider runtimes can report a cumulative `totalProcessedTokens` value beside token counts for only the latest response. Presenting those fields together makes the latest response look like a breakdown of the cumulative total—for example, 40 input + 2 output beside 900 total.

When a cumulative total is present, this change exposes only that total in normalized aggregate usage unless complete input/output counts sum to the same total. Matching partitions and their details remain available for cost estimation. The original per-response counts and details remain available unchanged in `usageRecord.raw`. Non-cumulative usage mapping is unchanged.

Validation:
- Focused provider usage tests: 3 passed

Production follow-up: the ROP invocation records totalTokens=201383 without a fabricated input/output breakdown. PostHog received the same total_tokens value and the corrected Console deep link. Cost remains unknown; no estimate is derived from incomplete cumulative usage.
