### PR TITLE
test(netlify): pin the Vite+ scaffolder version

### DIFF
--- a/test/local/netlify-real-project.mjs
+++ b/test/local/netlify-real-project.mjs
@@ -180,6 +180,17 @@ async function createProject({ packageSource, preview }) {
     env: { VP_VERSION: vitePlus.version },
   })
 
+  const rootPackage = await readPackageJson(join(repoRoot, "package.json"))
+  const appPackage = await readPackageJson(join(appDir, "package.json"))
+  if (appPackage.packageManager !== rootPackage.packageManager) {
+    appPackage.packageManager = rootPackage.packageManager
+    await writeFile(join(appDir, "package.json"), `${JSON.stringify(appPackage, null, 2)}\n`, "utf8")
+    await Promise.all([
+      rm(join(appDir, "node_modules"), { force: true, recursive: true }),
+      rm(join(appDir, "pnpm-lock.yaml"), { force: true }),
+    ])
+  }
+
   const overrides = packageSource === "local"
     ? await createLocalPackageSpecs(join(baseDir, "vitehub-packs"))
     : { "vite-hub": previewSpec("vite-hub", preview) }

--- a/test/local/netlify-real-project.mjs
+++ b/test/local/netlify-real-project.mjs
@@ -174,7 +174,11 @@ async function writeFixtureFiles(overrides) {
 async function createProject({ packageSource, preview }) {
   await mkdir(baseDir, { recursive: true })
   await rm(appDir, { force: true, recursive: true })
-  run("vp", ["create", "vite:application", "--directory", appName, "--no-interactive", "--no-hooks", "--package-manager", "pnpm"], { cwd: baseDir })
+  const vitePlus = await readPackageJson(join(repoRoot, "node_modules/vite-plus/package.json"))
+  run("vp", ["create", "vite:application", "--directory", appName, "--no-interactive", "--no-hooks", "--package-manager", "pnpm"], {
+    cwd: baseDir,
+    env: { VP_VERSION: vitePlus.version },
+  })
 
   const overrides = packageSource === "local"
     ? await createLocalPackageSpecs(join(baseDir, "vitehub-packs"))

--- a/test/local/netlify-real-project.mjs
+++ b/test/local/netlify-real-project.mjs
@@ -57,7 +57,7 @@ function previewSpec(packageName, preview) {
   return `https://pkg.pr.new/vite-hub/vitehub/${packageName}@${preview}`
 }
 
-function renderWorkspaceYaml(overrides) {
+function renderWorkspaceYaml(overrides, vitePlusVersion) {
   const overrideLines = Object.entries(overrides).map(([name, spec]) => `  ${JSON.stringify(name)}: ${JSON.stringify(spec)}`)
   return [
     "allowBuilds:",
@@ -68,9 +68,9 @@ function renderWorkspaceYaml(overrides) {
     "  msgpackr-extract: false",
     "  node-liblzma: true",
     "catalog:",
-    "  vite: npm:@voidzero-dev/vite-plus-core@0.1.24",
-    "  vitest: npm:@voidzero-dev/vite-plus-test@0.1.24",
-    "  vite-plus: 0.1.24",
+    `  vite: npm:@voidzero-dev/vite-plus-core@${vitePlusVersion}`,
+    `  vitest: npm:@voidzero-dev/vite-plus-test@${vitePlusVersion}`,
+    `  vite-plus: ${vitePlusVersion}`,
     "overrides:",
     "  vite: \"catalog:\"",
     "  vitest: \"catalog:\"",
@@ -86,8 +86,8 @@ function renderWorkspaceYaml(overrides) {
   ].join("\n")
 }
 
-async function writeFixtureFiles(overrides) {
-  await writeFile(join(appDir, "pnpm-workspace.yaml"), renderWorkspaceYaml(overrides), "utf8")
+async function writeFixtureFiles(overrides, vitePlusVersion) {
+  await writeFile(join(appDir, "pnpm-workspace.yaml"), renderWorkspaceYaml(overrides, vitePlusVersion), "utf8")
   await mkdir(join(appDir, "src", "lib"), { recursive: true })
   await mkdir(join(appDir, "server", "agents"), { recursive: true })
   await writeFile(join(appDir, "src", "lib", "reply.ts"), "export const replyMarker = \"netlify-alias-ok\"\n", "utf8")
@@ -194,7 +194,7 @@ async function createProject({ packageSource, preview }) {
   const overrides = packageSource === "local"
     ? await createLocalPackageSpecs(join(baseDir, "vitehub-packs"))
     : { "vite-hub": previewSpec("vite-hub", preview) }
-  await writeFixtureFiles(overrides)
+  await writeFixtureFiles(overrides, vitePlus.version)
 
   const packageSpecs = packageSource === "local"
     ? [overrides["@vite-hub/agent"], overrides["vite-hub"]]


### PR DESCRIPTION
The Netlify end-to-end check fails inside `vp create` before installing ViteHub. The repository runs Vite+ 0.1.24, but the scaffold installs `latest`; the older runner then loads a native binding through a newer package that no longer exports `/binding`.

Use the installed Vite+ version for both `VP_VERSION` and every generated Vite/Vitest/Vite+ catalog entry, so the toolchain stays aligned with the runner after upgrades. Give the generated app the repository package-manager pin and reinstall its temporary dependencies when the scaffolder chose a different pnpm major.

Validation: the original scaffold reproduced the missing binding and its build failed. With the version pin, scaffolding and the generated project's production build pass. The complete local Netlify flow passes: packed-package installation, production build, function bundling, and an offline chat request returning HTTP 200 with the expected alias and reply text. Local verification used Netlify CLI 27.1.2 and task-specific ports; CI uses CLI 23.15.1. The script passes Node syntax and diff checks. Combined CI also passes the complete Netlify flow with the CI-pinned CLI 23.15.1: https://github.com/vite-hub/vitehub/actions/runs/34165217356/job/101874813835.

Model: GPT-6. Harness: Codex.
