### PR TITLE
test(console): initialize the invalid usage cursor fixture

### DIFF
--- a/packages/vite-hub/test/console.test.ts
+++ b/packages/vite-hub/test/console.test.ts
@@ -3460,6 +3460,7 @@ describe("Agent invocation console", () => {
   })
 
   it("reports the diagnostic code for an invalid usage cursor", async () => {
+    installConsoleInvocationFallback(defineAgentInvocations({ store: createMemoryAgentInvocationStore() }), process.cwd())
     const requestEvent = event("127.0.0.1")
     const url = "http://localhost/api/_vitehub/console/usage?cursor=invalid"
     if (!requestEvent.node?.req || !requestEvent.req) throw new TypeError("Expected a request event.")


### PR DESCRIPTION
The Console invalid-cursor test called the usage endpoint without installing an invocation store. It failed with the runtime-not-installed diagnostic before it could exercise cursor validation, blocking package CI.

Install an empty in-memory invocation store in that test, as the adjacent usage endpoint tests do. Keep the existing invalid-cursor diagnostic and HTTP 400 assertions.

Validation: the focused test reproduced the failure before the fixture change and passes after it, with no type errors. Runtime code is unchanged.

Model: GPT-6. Harness: Codex.
