### PR TITLE
test(agent): update trace contracts and await terminal reporting

### DIFF
--- a/packages/agent/test/diagnostics-capability.test.ts
+++ b/packages/agent/test/diagnostics-capability.test.ts
@@ -197,7 +197,8 @@ describe("diagnostics Capability", () => {
 
   it("does not overlap reporting between samples", async () => {
     const delivered: string[] = []
-    const terminalReported = Promise.withResolvers<void>()
+    let reportTerminal: (() => void) | undefined
+    const terminalReported = new Promise<void>((resolve) => { reportTerminal = resolve })
     let activeReporters = 0
     let inspections = 0
     let maxReporters = 0
@@ -218,7 +219,7 @@ describe("diagnostics Capability", () => {
             await pollBlocked
           }
           activeReporters -= 1
-          if (event.name === "agent.invocation.terminal") terminalReported.resolve()
+          if (event.name === "agent.invocation.terminal") reportTerminal?.()
         },
         resources: { inspect: async () => {
           inspections += 1
@@ -234,7 +235,7 @@ describe("diagnostics Capability", () => {
     })
 
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok")
-    await terminalReported.promise
+    await terminalReported
     expect(maxReporters).toBe(1)
     expect(inspections).toBeGreaterThanOrEqual(3)
     expect(delivered.at(-2)).toBe("agent.resource.snapshot:finish")

--- a/packages/agent/test/diagnostics-capability.test.ts
+++ b/packages/agent/test/diagnostics-capability.test.ts
@@ -197,6 +197,7 @@ describe("diagnostics Capability", () => {
 
   it("does not overlap reporting between samples", async () => {
     const delivered: string[] = []
+    const terminalReported = Promise.withResolvers<void>()
     let activeReporters = 0
     let inspections = 0
     let maxReporters = 0
@@ -217,6 +218,7 @@ describe("diagnostics Capability", () => {
             await pollBlocked
           }
           activeReporters -= 1
+          if (event.name === "agent.invocation.terminal") terminalReported.resolve()
         },
         resources: { inspect: async () => {
           inspections += 1
@@ -232,9 +234,9 @@ describe("diagnostics Capability", () => {
     })
 
     await expect(runAgent(agent, { memo: vi.fn(), runtime: "unknown", waitUntil: vi.fn() }, {})).resolves.toBe("ok")
+    await terminalReported.promise
     expect(maxReporters).toBe(1)
     expect(inspections).toBeGreaterThanOrEqual(3)
-    await new Promise(resolve => setTimeout(resolve, 10))
     expect(delivered.at(-2)).toBe("agent.resource.snapshot:finish")
     expect(delivered.at(-1)).toBe("agent.invocation.terminal:terminal")
   })

--- a/packages/agent/test/runtime.test.ts
+++ b/packages/agent/test/runtime.test.ts
@@ -1272,9 +1272,10 @@ describe("agent message protocol", () => {
     }, {})).rejects.toThrow("capability setup failed")
 
     expect(traceLog.entries().map(event => event.name)).toEqual([
+      "agent.capability.resolve",
       "agent.invocation.error",
     ])
-    expect(traceLog.entries()[0]!.attributes).toMatchObject({
+    expect(traceLog.entries().find(event => event.name === "agent.invocation.error")?.attributes).toMatchObject({
       "agent.invoker.id": "tenant-1",
       "agent.invoker.kind": "tenant",
       "agent.invoker.label": "Acme Tenant",
@@ -10874,6 +10875,8 @@ describe("agent message protocol", () => {
     expect(finish).toHaveBeenCalledOnce()
     expect(finish.mock.calls[0]![0].result).toBeInstanceOf(Response)
     expect(traceLog.entries().map(event => event.name)).toEqual([
+      "agent.capability.output",
+      "agent.capability.output",
       "agent.invocation.start",
       "agent.message.delta",
       "agent.tool.start",
@@ -11135,6 +11138,7 @@ describe("agent message protocol", () => {
     expect(finalRenderer).toHaveBeenCalledOnce()
     expect(finish.mock.calls[0]![0].result).toBe(nativeResult)
     expect(traceLog.entries().map(event => event.name)).toEqual([
+      "agent.capability.output",
       "agent.invocation.start",
       "agent.message.delta",
       "agent.stream.finish",


### PR DESCRIPTION
Package CI still expected the old trace sequences after Capability timing events were added. A diagnostics serialization test also checked terminal delivery after a fixed 10 ms delay, which raced asynchronous reporting.

Assert the new Capability events alongside the existing invocation and message events, and find the invocation error by name before checking its invoker metadata. Wait for the reporter's terminal event before asserting serialization and final delivery order.

Validation: all three trace assertions failed before the update; all four focused regressions and both complete test files now pass (458 tests). Agent typecheck also passes after replacing the newer Promise helper with the constructor pattern supported by the test library; all 13 diagnostics tests pass after that follow-up. Existing error, metadata, delivery-order, and non-overlap assertions remain covered.

Model: GPT-6. Harness: Codex.
