### PR TITLE
fix(ui): use the shared Vite compatibility peer range

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -82,7 +82,7 @@
   "peerDependencies": {
     "@nuxt/ui": "^4.11.0",
     "ai": "catalog:ai-compat",
-    "vite": "catalog:vite",
+    "vite": "catalog:vite-compat",
     "vue": "catalog:ui"
   },
   "peerDependenciesMeta": {


### PR DESCRIPTION
Strict pnpm consumers using Vite 8.0.8 could install the framework's declared Vite range but failed on `@vite-hub/ui`, whose optional Vite peer required 8.2.2. The UI package used the development catalog for its public peer contract.

Use the existing Vite compatibility catalog for the UI peer, consistent with the framework and other owner packages. Keep the development dependency on the current tooling version.

Validation: the full workspace build passes. Both previously failing packed-consumer tests pass with strict peer checks: Node declarations for Deno and the Nuxt database middleware build (2 tests). Diff checks pass.

Model: GPT-6. Harness: Codex.
