### PR TITLE
fix(workflow): resolve the Vercel world from its owning package

### DIFF
--- a/packages/workflow/src/internal/vite-build.ts
+++ b/packages/workflow/src/internal/vite-build.ts
@@ -27,6 +27,11 @@ import type { CloudflareProviderDeploymentOutput, ProviderDeploymentOutputOption
 import type { Plugin as VitePlugin } from "vite"
 import { workflowErrorDiagnostics } from "../error-diagnostics.ts"
 
+export function resolveVercelWorkflowWorld(workflowApi: string): string {
+  const workflowCore = createRequire(workflowApi).resolve("@workflow/core")
+  return createRequire(workflowCore).resolve("@workflow/world-vercel")
+}
+
 export const workflowPackageName = "@vite-hub/workflow"
 const productName = "workflow"
 const vercelNativeWorkflowOwnershipMarker = ".vitehub-owned"

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -150,7 +150,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions, internalOptions: In
         [`${importBase}/runtime/vercel-vite`]: projectRequire.resolve(`${importBase}/runtime/vercel-vite`),
         ...(workflowApi && workflowRequire
           ? {
-              "@workflow/core/runtime/world-target": createRequire(workflowRequire.resolve("@workflow/builders")).resolve("@workflow/world-vercel"),
+              "@workflow/core/runtime/world-target": createRequire(workflowApi).resolve("@workflow/world-vercel"),
               "workflow/api": workflowApi,
               "workflow/runtime": workflowRequire.resolve("workflow/runtime"),
             }

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -10,7 +10,7 @@ import { collectViteHubProviderImportAliases, createNoExternalMerger, isServerEn
 import { normalizeHosting } from "@vite-hub/internal/hosting"
 
 import { normalizeWorkflowOptions } from "./config.ts"
-import { createCloudflareWorkflowNitroConfig, createOptionalViteDevtoolsPlugin, createVercelWorkflowTransformPlugin, discoverWorkflowProviderSources, generateWorkflowProviderOutputs, hasVercelNativeWorkflowEntry, workflowPackageName, writeProviderEntries } from "./internal/vite-build.ts"
+import { createCloudflareWorkflowNitroConfig, createOptionalViteDevtoolsPlugin, createVercelWorkflowTransformPlugin, discoverWorkflowProviderSources, generateWorkflowProviderOutputs, hasVercelNativeWorkflowEntry, resolveVercelWorkflowWorld, workflowPackageName, writeProviderEntries } from "./internal/vite-build.ts"
 
 import type { WorkflowModuleOptions } from "./types.ts"
 import type { ProviderDeploymentOutputGeneration, ProviderOutputCatalog } from "@vite-hub/internal/build/deployment-output"
@@ -150,7 +150,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions, internalOptions: In
         [`${importBase}/runtime/vercel-vite`]: projectRequire.resolve(`${importBase}/runtime/vercel-vite`),
         ...(workflowApi && workflowRequire
           ? {
-              "@workflow/core/runtime/world-target": createRequire(createRequire(workflowApi).resolve("@workflow/core")).resolve("@workflow/world-vercel"),
+              "@workflow/core/runtime/world-target": resolveVercelWorkflowWorld(workflowApi),
               "workflow/api": workflowApi,
               "workflow/runtime": workflowRequire.resolve("workflow/runtime"),
             }

--- a/packages/workflow/src/vite.ts
+++ b/packages/workflow/src/vite.ts
@@ -150,7 +150,7 @@ export function hubWorkflow(options?: WorkflowModuleOptions, internalOptions: In
         [`${importBase}/runtime/vercel-vite`]: projectRequire.resolve(`${importBase}/runtime/vercel-vite`),
         ...(workflowApi && workflowRequire
           ? {
-              "@workflow/core/runtime/world-target": createRequire(workflowApi).resolve("@workflow/world-vercel"),
+              "@workflow/core/runtime/world-target": createRequire(createRequire(workflowApi).resolve("@workflow/core")).resolve("@workflow/world-vercel"),
               "workflow/api": workflowApi,
               "workflow/runtime": workflowRequire.resolve("workflow/runtime"),
             }

--- a/packages/workflow/test/vercel-world-resolution.test.ts
+++ b/packages/workflow/test/vercel-world-resolution.test.ts
@@ -1,0 +1,27 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+
+import { expect, it } from "vitest"
+
+import { resolveVercelWorkflowWorld } from "../src/internal/vite-build.ts"
+
+it("resolves the Vercel world owned by core in an isolated dependency layout", async () => {
+  const root = await mkdtemp(join(tmpdir(), "vitehub-workflow-world-"))
+  try {
+    const workflow = join(root, "node_modules/workflow")
+    const core = join(workflow, "node_modules/@workflow/core")
+    const world = join(core, "node_modules/@workflow/world-vercel")
+    const unrelatedWorld = join(root, "node_modules/@workflow/world-vercel")
+    for (const directory of [workflow, core, world, unrelatedWorld]) {
+      await mkdir(directory, { recursive: true })
+      await writeFile(join(directory, "package.json"), JSON.stringify({ main: "index.js" }))
+      await writeFile(join(directory, "index.js"), "module.exports = {}\n")
+    }
+
+    expect(resolveVercelWorkflowWorld(join(workflow, "index.js"))).toBe(join(world, "index.js"))
+  }
+  finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
A packed consumer's native Schedule build failed with `Cannot find module '@workflow/world-vercel'`. Runtime preparation resolved that package relative to `@workflow/builders`, which does not own the dependency; workspace hoisting concealed the mistake.

Resolve `@workflow/core` from the installed `workflow/api` entrypoint, then resolve the Vercel world from core, its declared dependency owner. The runtime aliases remain unchanged. A filesystem regression gives core its own private world dependency and places a different world at the application root, so an incorrect lookup cannot pass through hoisting.

Validation: Workflow and dependency builds, Workflow typecheck, repository lint, and all 216 Workflow tests across 14 files pass. The complete packed-consumer flow now passes, including the native Vercel Schedule build, cross-host output, and runtime assertions: https://github.com/vite-hub/vitehub/actions/runs/34166402810/job/101878479179. The full combined CI gate is green.

Model: GPT-6. Harness: Codex.
