### PR TITLE
fix(agent): keep browser declarations free of Node globals

### DIFF
--- a/packages/agent/src/server/github-host.ts
+++ b/packages/agent/src/server/github-host.ts
@@ -66,7 +66,7 @@ export interface GitHubGraphQLBudgetOptions extends GitHubHostCheckoutOptions {
 
 export interface GitHubHostCommandOptions extends GitHubHostCheckoutOptions {
   cwd?: string
-  env?: NodeJS.ProcessEnv
+  env?: Record<string, string | undefined>
   repository?: string
 }
 

--- a/packages/agent/test/browser-declarations.test.ts
+++ b/packages/agent/test/browser-declarations.test.ts
@@ -1,0 +1,30 @@
+import { resolve } from "node:path"
+
+import ts from "typescript"
+import { expect, it } from "vitest"
+
+it("exposes Vue declarations without Node ambient types", () => {
+  const dist = resolve(import.meta.dirname, "../dist")
+  const options: ts.CompilerOptions = {
+    module: ts.ModuleKind.NodeNext,
+    moduleResolution: ts.ModuleResolutionKind.NodeNext,
+    noEmit: true,
+    skipLibCheck: false,
+    strict: true,
+    target: ts.ScriptTarget.ESNext,
+    types: [],
+  }
+  const host = ts.createCompilerHost(options)
+  const getSourceFile = host.getSourceFile
+  // Installed browser consumers do not inherit the workspace's Node globals.
+  host.getSourceFile = (fileName, ...args) => fileName.replaceAll("\\", "/").includes("/@types/node/")
+    ? undefined
+    : getSourceFile(fileName, ...args)
+  const entry = resolve(dist, "vue.d.ts")
+  const program = ts.createProgram([entry], options, host)
+  expect(program.getSourceFile(entry)).toBeDefined()
+  const distPrefix = `${dist.replaceAll("\\", "/")}/`
+  const diagnostics = program.getSemanticDiagnostics().filter(diagnostic => diagnostic.file?.fileName.replaceAll("\\", "/").startsWith(distPrefix))
+
+  expect(ts.formatDiagnostics(diagnostics, host)).toBe("")
+}, 30_000)


### PR DESCRIPTION
An installed consumer of Agent's Vue entrypoint fails TypeScript checking with `Cannot find namespace NodeJS`. Its shared declarations include `GitHubHostCommandOptions.env`, which used `NodeJS.ProcessEnv` even though browser consumers do not provide Node ambient types.

Use `Record<string, string | undefined>` for the environment map. This preserves the accepted values and removes the Node namespace dependency. A regression compiles the built Vue declarations with Node ambient types unavailable and checks diagnostics in Agent's published files.

Validation: Agent and dependency builds, Agent typecheck, repository lint, the declaration regression, and 66 GitHub-host tests pass. Restoring the original generated declaration makes the new regression fail with the original `NodeJS` error. The installed-export failure was observed in combined CI: https://github.com/vite-hub/vitehub/actions/runs/34165217356/job/101874813909. The full installed-export check now passes with this fix: https://github.com/vite-hub/vitehub/actions/runs/34166402810/job/101878479189. All 7,846 package tests and the complete combined CI gate also pass: https://github.com/vite-hub/vitehub/actions/runs/34166402810.

Model: GPT-6. Harness: Codex.
