### PR TITLE
fix(console): simplify session states and navigation

### DIFF
--- a/packages/ui/src/internal/channel-icon.ts
+++ b/packages/ui/src/internal/channel-icon.ts
@@ -1,7 +1,7 @@
 import { h } from "vue";
 
-// Built-in channel kinds use Phosphor's MIT-licensed marks in both navigation and receipts.
-const channelMarks: Record<string, { label: string; body: string }> = {
+// MIT-licensed marks from Phosphor, with GitHub's official Octicons mark.
+const channelMarks: Record<string, { label: string; body: string; viewBox?: string }> = {
   "teams": {
     "label": "Microsoft Teams",
     "body": "<path fill=\"currentColor\" d=\"M112 104a8 8 0 0 1-8 8h-8v40a8 8 0 0 1-16 0v-40h-8a8 8 0 0 1 0-16h32a8 8 0 0 1 8 8m120-11.26V152a40 40 0 0 1-36.63 39.85a64 64 0 0 1-118.7.15H40a16 16 0 0 1-16-16V80a16 16 0 0 1 16-16h56.81a40 40 0 0 1 73.31-28.85A32 32 0 0 1 211.69 80h7.57A12.76 12.76 0 0 1 232 92.74M112 56a23.8 23.8 0 0 0 1.38 8H136a16 16 0 0 1 15.07 10.68A24 24 0 1 0 112 56m24 120V80H40v96zm48-80h-32v80a16 16 0 0 1-16 16H94.44A48 48 0 0 0 184 168Zm16-32a16 16 0 0 0-24.4-13.6A39.9 39.9 0 0 1 168 80h16a16 16 0 0 0 16-16m16 32h-16v72a63 63 0 0 1-.36 6.75A24 24 0 0 0 216 152Z\"/>"
@@ -20,7 +20,8 @@ const channelMarks: Record<string, { label: string; body: string }> = {
   },
   "github": {
     "label": "GitHub",
-    "body": "<path fill=\"currentColor\" d=\"M208.31 75.68A59.78 59.78 0 0 0 202.93 28a8 8 0 0 0-6.93-4a59.75 59.75 0 0 0-48 24h-24a59.75 59.75 0 0 0-48-24a8 8 0 0 0-6.93 4a59.78 59.78 0 0 0-5.38 47.68A58.14 58.14 0 0 0 56 104v8a56.06 56.06 0 0 0 48.44 55.47A39.8 39.8 0 0 0 96 192v8H72a24 24 0 0 1-24-24a40 40 0 0 0-40-40a8 8 0 0 0 0 16a24 24 0 0 1 24 24a40 40 0 0 0 40 40h24v16a8 8 0 0 0 16 0v-40a24 24 0 0 1 48 0v40a8 8 0 0 0 16 0v-40a39.8 39.8 0 0 0-8.44-24.53A56.06 56.06 0 0 0 216 112v-8a58.14 58.14 0 0 0-7.69-28.32M200 112a40 40 0 0 1-40 40h-48a40 40 0 0 1-40-40v-8a41.74 41.74 0 0 1 6.9-22.48a8 8 0 0 0 1.1-7.69a43.8 43.8 0 0 1 .79-33.58a43.88 43.88 0 0 1 32.32 20.06a8 8 0 0 0 6.71 3.69h32.35a8 8 0 0 0 6.74-3.69a43.87 43.87 0 0 1 32.32-20.06a43.8 43.8 0 0 1 .77 33.58a8.09 8.09 0 0 0 1 7.65a41.7 41.7 0 0 1 7 22.52Z\"/>"
+    "viewBox": "0 0 16 16",
+    "body": "<path fill=\"currentColor\" d=\"M6.766 11.328c-2.063-.25-3.516-1.734-3.516-3.656 0-.781.281-1.625.75-2.188-.203-.515-.172-1.609.063-2.062.625-.078 1.468.25 1.968.703.594-.187 1.219-.281 1.985-.281.765 0 1.39.094 1.953.265.484-.437 1.344-.765 1.969-.687.218.422.25 1.515.046 2.047.5.593.766 1.39.766 2.203 0 1.922-1.453 3.375-3.547 3.64.531.344.89 1.094.89 1.954v1.625c0 .468.391.734.86.547C13.781 14.359 16 11.53 16 8.03 16 3.61 12.406 0 7.984 0 3.563 0 0 3.61 0 8.031a7.88 7.88 0 0 0 5.172 7.422c.422.156.828-.125.828-.547v-1.25c-.219.094-.5.156-.75.156-1.031 0-1.64-.562-2.078-1.609-.172-.422-.36-.672-.719-.719-.187-.015-.25-.093-.25-.187 0-.188.313-.328.625-.328.453 0 .844.281 1.25.86.313.452.64.655 1.031.655s.641-.14 1-.5c.266-.265.47-.5.657-.656\"/>"
   },
   "web-chat": {
     "label": "Web chat",
@@ -42,6 +43,6 @@ export function channelIcon(channel: string) {
   const label = knownMark?.label ?? channel;
   return h("span", { class: "vh-channel-icon vh-invocation-list__channel", title: label, "aria-label": label }, [
     // Only bundled SVG constants enter innerHTML; channel labels never become markup.
-    h("svg", { width: "1em", height: "1em", viewBox: "0 0 256 256", fill: "currentColor", "aria-hidden": "true", innerHTML: mark.body }),
+    h("svg", { width: "1em", height: "1em", viewBox: knownMark?.viewBox ?? "0 0 256 256", fill: "currentColor", "aria-hidden": "true", innerHTML: mark.body }),
   ]);
 }

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -349,7 +349,9 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
   let latestFinalSequence = -Infinity;
   for (const observations of groups.values()) {
     const sequence = Math.max(...observations.map(item => item.sequence));
-    if (sequence > latestFinalSequence && observations.every(item => item.attributes?.["message.phase"] !== "commentary")) latestFinalSequence = sequence;
+    if (sequence > latestFinalSequence && observations.every(item => item.name.startsWith("agent.message")
+      && item.attributes?.["message.phase"] !== "commentary"
+      && (item.attributes?.["message.role"] === undefined || item.attributes["message.role"] === "assistant"))) latestFinalSequence = sequence;
   }
   for (const observations of groups.values()) {
     if (Math.max(...observations.map(item => item.sequence)) !== latestFinalSequence) continue;

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -343,6 +343,25 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
     else groups.set(key, [groupedObservation]);
   }
 
+  // A finish record can truncate usage metadata while preserving the whole response.
+  // Only suppress its message warning when an untruncated assistant turn proves it intact.
+  const completeAssistantTexts = new Set<string>();
+  for (const observations of groups.values()) {
+    if (observations.some(item => item.attributes?.["vitehub.observation.truncated"] === true)) continue;
+    if (!observations.every(item => item.name.startsWith("agent.message")
+      && (item.attributes?.["message.role"] === undefined || item.attributes["message.role"] === "assistant"))) continue;
+    const text = observations.map(item => stringAttribute(item.attributes ?? {}, "message.content") ?? "").join("");
+    if (!text) continue;
+    completeAssistantTexts.add(text);
+    try {
+      const response = record(JSON.parse(text));
+      const responseText = response && stringAttribute(response, "text");
+      if (responseText) completeAssistantTexts.add(responseText);
+    } catch {
+      // Plain text and incomplete JSON cannot verify a structured response's text field.
+    }
+  }
+
   const activities = [...groups.entries()]
     .map(([id, observations]): InvocationActivity => {
       const sorted = observations.slice().sort((left, right) => left.sequence - right.sequence);
@@ -404,6 +423,7 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
         ...(role ? { role } : {}),
         status: failed || approvalDenied ? "failed" : completed || !started ? "completed" : unfinishedTerminalStatus ?? "running",
         ...(sorted.some(item => item.attributes?.["vitehub.observation.truncated"] === true)
+          && !(first.name === "agent.invocation.finish" && completeAssistantTexts.has(stringAttribute(attributes, "result.text") ?? ""))
           ? { truncated: true }
           : {}),
         ...(numericAttribute(attributes, "usage.totalTokens") !== undefined

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -382,20 +382,22 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
   // A finish record can truncate usage metadata while preserving the whole response.
   // Only suppress its message warning when an untruncated assistant turn proves it intact.
   const completeAssistantTexts = new Set<string>();
-  let latestFinalSequence = -Infinity;
+  let latestMessageSequence = -Infinity;
   for (const observations of groups.values()) {
     const sequence = Math.max(...observations.map(item => item.sequence));
-    if (sequence > latestFinalSequence && observations.every(item => item.name.startsWith("agent.message")
-      && item.attributes?.["message.phase"] !== "commentary"
-      && (item.attributes?.["message.role"] === undefined || item.attributes["message.role"] === "assistant"))) latestFinalSequence = sequence;
+    if (sequence > latestMessageSequence && observations.every(item => item.name.startsWith("agent.message")
+      || item.name === "agent.input.message")) latestMessageSequence = sequence;
   }
   for (const observations of groups.values()) {
-    if (Math.max(...observations.map(item => item.sequence)) !== latestFinalSequence) continue;
+    if (Math.max(...observations.map(item => item.sequence)) !== latestMessageSequence) continue;
     if (observations.some(item => item.attributes?.["vitehub.observation.truncated"] === true)) continue;
     if (!observations.every(item => item.name.startsWith("agent.message")
       && (item.attributes?.["message.role"] === undefined || item.attributes["message.role"] === "assistant")
       && item.attributes?.["message.phase"] !== "commentary")) continue;
-    const text = observations.map(item => stringAttribute(item.attributes ?? {}, "message.content") ?? "").join("");
+    const text = observations.map(item => {
+      const content = item.attributes?.["message.content"];
+      return typeof content === "string" ? content : "";
+    }).join("").trim();
     if (!text) continue;
     completeAssistantTexts.add(text);
     try {

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -349,7 +349,8 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
   for (const observations of groups.values()) {
     if (observations.some(item => item.attributes?.["vitehub.observation.truncated"] === true)) continue;
     if (!observations.every(item => item.name.startsWith("agent.message")
-      && (item.attributes?.["message.role"] === undefined || item.attributes["message.role"] === "assistant"))) continue;
+      && (item.attributes?.["message.role"] === undefined || item.attributes["message.role"] === "assistant")
+      && item.attributes?.["message.phase"] !== "commentary")) continue;
     const text = observations.map(item => stringAttribute(item.attributes ?? {}, "message.content") ?? "").join("");
     if (!text) continue;
     completeAssistantTexts.add(text);

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -396,7 +396,7 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
       && item.attributes?.["message.phase"] !== "commentary")) continue;
     const text = observations.map(item => {
       const content = item.attributes?.["message.content"];
-      return typeof content === "string" ? content : "";
+      return hasRuntimeType(content, "string") ? content : "";
     }).join("").trim();
     if (!text) continue;
     completeAssistantTexts.add(text);

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -346,7 +346,13 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
   // A finish record can truncate usage metadata while preserving the whole response.
   // Only suppress its message warning when an untruncated assistant turn proves it intact.
   const completeAssistantTexts = new Set<string>();
+  let latestFinalSequence = -Infinity;
   for (const observations of groups.values()) {
+    const sequence = Math.max(...observations.map(item => item.sequence));
+    if (sequence > latestFinalSequence && observations.every(item => item.attributes?.["message.phase"] !== "commentary")) latestFinalSequence = sequence;
+  }
+  for (const observations of groups.values()) {
+    if (Math.max(...observations.map(item => item.sequence)) !== latestFinalSequence) continue;
     if (observations.some(item => item.attributes?.["vitehub.observation.truncated"] === true)) continue;
     if (!observations.every(item => item.name.startsWith("agent.message")
       && (item.attributes?.["message.role"] === undefined || item.attributes["message.role"] === "assistant")

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -1749,6 +1749,42 @@ describe("Agent Invocation UI", () => {
     expect(invocationActivities(invocation).map(activity => activity.body)).toEqual(["Final answer."]);
   });
 
+  it.each([
+    { sourceText: JSON.stringify({ disposition: "complete", text: "Final answer." }), sourceTruncated: false, expectedTruncated: false },
+    { sourceText: JSON.stringify({ disposition: "complete", text: "Final answer." }), sourceTruncated: true, expectedTruncated: true },
+    { sourceText: JSON.stringify({ text: "Different answer." }), sourceTruncated: false, expectedTruncated: true },
+    { sourceText: '{"text":"Final answer."', sourceTruncated: false, expectedTruncated: true },
+  ])("checks preserved response content before applying a finish metadata warning: $expectedTruncated ($sourceText, $sourceTruncated)", ({ sourceText, sourceTruncated, expectedTruncated }) => {
+    const timestamp = "2026-08-22T00:00:00.000Z";
+    const invocation: AgentInvocationView = {
+      id: "structured-finish", status: "completed", traceId: "trace", createdAt: timestamp, updatedAt: timestamp,
+      observationsTruncated: true,
+      observations: [
+        { name: "agent.message.delta", sequence: 1, timestamp, type: "lifecycle", attributes: {
+          "message.content": "Checking the branch.", "message.role": "assistant", "message.phase": "commentary",
+        } },
+        { name: "agent.message.delta", sequence: 2, timestamp, type: "lifecycle", attributes: {
+          "message.content": sourceText.slice(0, 10), "message.role": "assistant", "message.phase": "final",
+        } },
+        { name: "agent.message.delta", sequence: 3, timestamp, type: "lifecycle", attributes: {
+          "message.content": sourceText.slice(10), "message.role": "assistant", "message.phase": "final",
+          "vitehub.observation.truncated": sourceTruncated,
+        } },
+        { name: "agent.invocation.finish", sequence: 4, timestamp, type: "lifecycle", attributes: {
+          "result.text": "Final answer.", "result.kind": "object",
+          "usage.record": { raw: "[Truncated]" }, "vitehub.observation.truncated": true,
+        } },
+      ],
+    };
+    const activities = invocationActivities(invocation);
+    const result = activities.find(activity => activity.name === "agent.invocation.finish");
+    expect(result?.body).toBe("Final answer.");
+    expect(result?.truncated === true).toBe(expectedTruncated);
+    expect(activities.some(activity => activity.name === "vitehub.observation.truncated")).toBe(true);
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    expect(wrapper.findAll('[data-role="assistant"] .vh-invocation-event__notice').length > 0).toBe(expectedTruncated);
+  });
+
   it("keeps an aggregate final answer when no matching deltas exist", () => {
     const timestamp = "2026-08-22T00:00:00.000Z";
     const invocation = {

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -1942,6 +1942,26 @@ describe("Agent Invocation UI", () => {
     ]);
   });
 
+  it.each(["commentary", "user"] as const)("does not use an earlier response after later %s", (laterMessage) => {
+    const timestamp = "2026-08-22T00:00:00.000Z";
+    const invocation: AgentInvocationView = {
+      id: "missing-final", status: "completed", traceId: "trace", createdAt: timestamp, updatedAt: timestamp,
+      observations: [
+        { name: "agent.message.delta", sequence: 1, timestamp, type: "lifecycle", attributes: {
+          "message.id": "earlier", "message.content": JSON.stringify({ text: "Done" }), "message.role": "assistant", "message.phase": "final",
+        } },
+        { name: "agent.message.delta", sequence: 2, timestamp, type: "lifecycle", attributes: {
+          "message.id": "later", "message.content": "Check again", "message.role": laterMessage === "user" ? "user" : "assistant",
+          "message.phase": laterMessage === "commentary" ? "commentary" : undefined,
+        } },
+        { name: "agent.invocation.finish", sequence: 3, timestamp, type: "lifecycle", attributes: {
+          "result.text": "Done", "vitehub.observation.truncated": true,
+        } },
+      ],
+    };
+    expect(invocationActivities(invocation).find(activity => activity.name === "agent.invocation.finish")?.truncated).toBe(true);
+  });
+
   it("does not replay an aggregate final answer after matching deltas", () => {
     const timestamp = "2026-08-22T00:00:00.000Z";
     const invocation = {
@@ -1965,7 +1985,9 @@ describe("Agent Invocation UI", () => {
     { sourceText: JSON.stringify({ disposition: "complete", text: "Final answer." }), sourceTruncated: true, expectedTruncated: true },
     { sourceText: JSON.stringify({ text: "Different answer." }), sourceTruncated: false, expectedTruncated: true },
     { sourceText: '{"text":"Final answer."', sourceTruncated: false, expectedTruncated: true },
-  ])("checks preserved response content before applying a finish metadata warning: $expectedTruncated ($sourceText, $sourceTruncated)", ({ sourceText, sourceTruncated, expectedTruncated }) => {
+  ].flatMap(testCase => [10, testCase.sourceText.indexOf(" answer"), testCase.sourceText.indexOf(" answer") + 1]
+    .filter(splitAt => splitAt > 0)
+    .map(splitAt => ({ ...testCase, splitAt }))))("checks preserved response content before applying a finish metadata warning: $expectedTruncated ($sourceText, $sourceTruncated, $splitAt)", ({ sourceText, sourceTruncated, expectedTruncated, splitAt }) => {
     const timestamp = "2026-08-22T00:00:00.000Z";
     const invocation: AgentInvocationView = {
       id: "structured-finish", status: "completed", traceId: "trace", createdAt: timestamp, updatedAt: timestamp,
@@ -1975,10 +1997,10 @@ describe("Agent Invocation UI", () => {
           "message.content": "Checking the branch.", "message.role": "assistant", "message.phase": "commentary",
         } },
         { name: "agent.message.delta", sequence: 2, timestamp, type: "lifecycle", attributes: {
-          "message.content": sourceText.slice(0, 10), "message.role": "assistant", "message.phase": "final",
+          "message.content": sourceText.slice(0, splitAt), "message.role": "assistant", "message.phase": "final",
         } },
         { name: "agent.message.delta", sequence: 3, timestamp, type: "lifecycle", attributes: {
-          "message.content": sourceText.slice(10), "message.role": "assistant", "message.phase": "final",
+          "message.content": sourceText.slice(splitAt), "message.role": "assistant", "message.phase": "final",
           "vitehub.observation.truncated": sourceTruncated,
         } },
         { name: "agent.invocation.finish", sequence: 4, timestamp, type: "lifecycle", attributes: {

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -26,6 +26,7 @@ import {
 import { isRetryableConsoleRequestError, requestConsole } from "../client/request";
 import { rememberConsoleSection } from "../sections";
 import ConsoleFrame from "./console-frame.vue";
+import ConsoleConnectionState from "./console-connection-state.vue";
 import ConsolePrimitiveSwitcher from "./console-primitive-switcher.vue";
 import ConsoleInvocationComposer from "./console-invocation-composer.vue";
 import ConsoleMark from "./console-mark.vue";
@@ -168,6 +169,11 @@ watch(
   },
   { flush: "sync", immediate: true },
 );
+
+const connectionUnavailable = computed(() => {
+  const errors = [agentsError.value, list.error.value, detail.error.value].filter(Boolean);
+  return errors.length > 1 && errors.every(isRetryableConsoleRequestError);
+});
 
 const invocationItems = computed<AgentInvocationListItem[]>(() =>
   list.invocations.value.map((invocation) => ({
@@ -880,7 +886,7 @@ onBeforeUnmount(() => {
       </template>
 
       <template #default>
-        <div v-if="errorMessage(agentsError)" class="px-3 pb-3">
+        <div v-if="!connectionUnavailable && errorMessage(agentsError)" class="px-3 pb-3">
           <UAlert
             color="error"
             variant="subtle"
@@ -990,7 +996,7 @@ onBeforeUnmount(() => {
           </UPopover>
         </div>
         <div
-          v-if="errorMessage(list.error.value || list.loadMoreError.value)"
+          v-if="!connectionUnavailable && errorMessage(list.error.value || list.loadMoreError.value)"
           class="px-3"
         >
           <UAlert
@@ -1023,7 +1029,7 @@ onBeforeUnmount(() => {
           />
         </div>
         <div
-          v-if="(agentsLoading || list.isLoading.value) && !invocationItems.length"
+          v-if="!connectionUnavailable && (agentsLoading || list.isLoading.value) && !invocationItems.length"
           class="grid gap-1 px-2"
           aria-label="Loading sessions"
           role="status"
@@ -1137,7 +1143,15 @@ onBeforeUnmount(() => {
       :ui="{ body: 'min-h-0 overflow-hidden p-0 gap-0' }"
     >
       <template #body>
-        <div class="h-full min-h-0 overflow-hidden" aria-live="polite">
+        <div class="flex h-full min-h-0 w-full flex-col overflow-hidden" aria-live="polite">
+          <ConsoleConnectionState
+            v-if="connectionUnavailable"
+            :compact="Boolean(invocationView)"
+            :retrying="refreshing"
+            @retry="refresh"
+            @open-sessions="sessionsOpen = true"
+          />
+          <div v-if="!connectionUnavailable || invocationView" class="min-h-0 w-full flex-1 overflow-hidden">
           <div
             v-if="isDesktop && detailsOpen && detailsMaximized && selectedInvocationId"
             class="h-full min-h-0 overflow-hidden"
@@ -1200,7 +1214,7 @@ onBeforeUnmount(() => {
                   @toggle-details="detailsOpen = !detailsOpen"
                 />
                 <UAlert
-                  v-if="invocationView && errorMessage(detail.error.value)"
+                  v-if="!connectionUnavailable && invocationView && errorMessage(detail.error.value)"
                   class="m-3 shrink-0"
                   color="error"
                   variant="subtle"
@@ -1358,6 +1372,7 @@ onBeforeUnmount(() => {
                 />
               </template>
             </USlideover>
+          </div>
           </div>
         </div>
       </template>

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -23,7 +23,7 @@ import {
   encodeAgentRouteParam,
   resolveConsoleRouteName,
 } from "../console-route";
-import { requestConsole } from "../client/request";
+import { isRetryableConsoleRequestError, requestConsole } from "../client/request";
 import { useConsoleConnectionUnavailable } from "./console-connection";
 import { rememberConsoleSection } from "../sections";
 import ConsoleFrame from "./console-frame.vue";
@@ -997,7 +997,7 @@ onBeforeUnmount(() => {
           </UPopover>
         </div>
         <div
-          v-if="!connectionUnavailable && errorMessage(list.error.value || list.loadMoreError.value)"
+          v-if="errorMessage((!connectionUnavailable && list.error.value) || list.loadMoreError.value)"
           class="px-3"
         >
           <UAlert
@@ -1005,9 +1005,9 @@ onBeforeUnmount(() => {
             variant="subtle"
             icon="i-ph-cloud-slash-light"
             title="Could not load sessions"
-            :description="errorMessage(list.error.value || list.loadMoreError.value)"
+            :description="errorMessage((!connectionUnavailable && list.error.value) || list.loadMoreError.value)"
             :actions="
-              list.error.value
+              !connectionUnavailable && list.error.value
                 ? [
                     {
                       label: 'Try again',

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -23,7 +23,8 @@ import {
   encodeAgentRouteParam,
   resolveConsoleRouteName,
 } from "../console-route";
-import { isRetryableConsoleRequestError, requestConsole } from "../client/request";
+import { requestConsole } from "../client/request";
+import { useConsoleConnectionUnavailable } from "./console-connection";
 import { rememberConsoleSection } from "../sections";
 import ConsoleFrame from "./console-frame.vue";
 import ConsoleConnectionState from "./console-connection-state.vue";
@@ -170,10 +171,10 @@ watch(
   { flush: "sync", immediate: true },
 );
 
-const connectionUnavailable = computed(() => {
-  const errors = [agentsError.value, list.error.value, detail.error.value].filter(Boolean);
-  return errors.length > 1 && errors.every(isRetryableConsoleRequestError);
-});
+const connectionUnavailable = useConsoleConnectionUnavailable(() => ({
+  errors: [agentsError.value, list.error.value, detail.error.value],
+  pending: refreshing.value || agentsLoading.value || list.isLoading.value || detail.isLoading.value,
+}));
 
 const invocationItems = computed<AgentInvocationListItem[]>(() =>
   list.invocations.value.map((invocation) => ({
@@ -1322,7 +1323,7 @@ onBeforeUnmount(() => {
             />
             <div v-else-if="invocationView" class="flex min-h-0 flex-1 flex-col">
               <UAlert
-                v-if="errorMessage(detail.error.value)"
+                v-if="!connectionUnavailable && errorMessage(detail.error.value)"
                 class="m-3 shrink-0"
                 color="error"
                 variant="subtle"

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -25,7 +25,7 @@ import {
 } from "../console-route";
 import { isRetryableConsoleRequestError, requestConsole } from "../client/request";
 import { useConsoleConnectionUnavailable } from "./console-connection";
-import { rememberConsoleSection } from "../sections";
+import { consoleSectionDetails, rememberConsoleSection } from "../sections";
 import ConsoleFrame from "./console-frame.vue";
 import ConsoleConnectionState from "./console-connection-state.vue";
 import ConsolePrimitiveSwitcher from "./console-primitive-switcher.vue";
@@ -83,8 +83,8 @@ const sessionsOpen = ref(false);
 const detailsOpen = ref(false);
 const detailsMaximized = ref(false);
 const inspectorTab = ref<"details" | "trace" | "workspace">("details");
-const inspectorActiveSurface = ref("view:details");
-const inspectorOpenViews = ref<Array<"details" | "trace" | "workspace">>(["details"]);
+const inspectorActiveSurface = ref("");
+const inspectorOpenViews = ref<Array<"details" | "trace" | "workspace">>([]);
 const inspectorOpenPaths = ref<string[]>([]);
 const inspectorSelectedPath = ref<string>();
 const inspectorWorkspaceIdentity = ref<string>();
@@ -246,6 +246,9 @@ const invocationView = computed<AgentInvocationView | undefined>(() => {
   return view;
 });
 const selectedDisplay = computed(() => invocationView.value ?? selectedSummary.value);
+const selectedRefreshable = computed(() =>
+  selectedDisplay.value?.status === "pending" || selectedDisplay.value?.status === "running",
+);
 const selectedCost = computed(() => invocationCostDisplay(selectedDisplay.value));
 const selectedTokens = computed(() => invocationTokenDisplay(selectedDisplay.value));
 const selectedTitle = computed(() =>
@@ -617,13 +620,20 @@ async function refresh(): Promise<void> {
   }
 }
 
-function inspectSession(target: "agent" | "workspace"): void {
+function inspectSession(target: "agent" | "workspace", path?: string): void {
   const view = target === "agent" ? "details" : "workspace";
   inspectorTab.value = view;
   if (!inspectorOpenViews.value.includes(view)) {
     inspectorOpenViews.value = [...inspectorOpenViews.value, view];
   }
-  inspectorActiveSurface.value = `view:${view}`;
+  if (view === "workspace" && path) {
+    if (!inspectorOpenPaths.value.includes(path)) inspectorOpenPaths.value = [...inspectorOpenPaths.value, path];
+    inspectorSelectedPath.value = path;
+    inspectorActiveSurface.value = `file:${path}`;
+  } else {
+    inspectorSelectedPath.value = undefined;
+    inspectorActiveSurface.value = `view:${view}`;
+  }
   detailsOpen.value = true;
 }
 
@@ -876,7 +886,7 @@ onBeforeUnmount(() => {
               class="min-w-0 justify-start rounded-md border border-default px-1.5 hover:bg-elevated"
               color="neutral"
               :label="selectedAgentLabel"
-              trailing-icon="i-ph-caret-up-down-light"
+              trailing-icon="i-ph-caret-down-light"
               size="xs"
               variant="ghost"
               :aria-label="`Switch Agent. ${selectedAgentLabel} selected.`"
@@ -1113,11 +1123,11 @@ onBeforeUnmount(() => {
             />
             <UTooltip v-if="!isUsageRoute" text="Usage">
               <UButton
-                icon="i-lucide-chart-no-axes-column"
+                :icon="consoleSectionDetails.usage.icon"
                 color="neutral"
                 variant="ghost"
                 size="xs"
-                aria-label="Usage"
+                aria-label="Open Usage"
                 @click="toggleUsage"
               />
             </UTooltip>
@@ -1207,6 +1217,7 @@ onBeforeUnmount(() => {
                   :has-display="Boolean(selectedDisplay)"
                   :has-selection="Boolean(selectedInvocationId)"
                   :loading="refreshing"
+                  :refreshable="selectedRefreshable"
                   :project="hasMultipleAgents ? selectedProject : ''"
                   :title="selectedTitle"
                   :tokens="selectedTokens"
@@ -1298,6 +1309,7 @@ onBeforeUnmount(() => {
               :has-display="Boolean(selectedDisplay)"
               :has-selection="Boolean(selectedInvocationId)"
               :loading="refreshing"
+              :refreshable="selectedRefreshable"
               :project="hasMultipleAgents ? selectedProject : ''"
               :title="selectedTitle"
               :tokens="selectedTokens"

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -860,6 +860,7 @@ onBeforeUnmount(() => {
           <ConsoleMark class="size-4" />
           <span class="shrink-0 text-xs font-medium text-muted">ViteHub Agent</span>
           <UDropdownMenu
+            v-if="hasMultipleAgents"
             :items="agentMenuItems"
             :content="{ align: 'start', collisionPadding: 12 }"
             :ui="{ content: 'w-(--reka-dropdown-menu-trigger-width)' }"
@@ -868,16 +869,13 @@ onBeforeUnmount(() => {
               class="min-w-0 justify-start rounded-md border border-default px-1.5 hover:bg-elevated"
               color="neutral"
               :label="selectedAgentLabel"
-              :trailing-icon="hasMultipleAgents ? 'i-ph-caret-up-down-light' : undefined"
+              trailing-icon="i-ph-caret-up-down-light"
               size="xs"
               variant="ghost"
-              :aria-label="
-                hasMultipleAgents
-                  ? `Switch Agent. ${selectedAgentLabel} selected.`
-                  : selectedAgentLabel
-              "
+              :aria-label="`Switch Agent. ${selectedAgentLabel} selected.`"
             />
           </UDropdownMenu>
+          <span v-else class="min-w-0 truncate text-xs text-default">{{ selectedAgentLabel }}</span>
         </div>
       </template>
 

--- a/packages/vite-hub/src/console/runtime/components/console-connection-state.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-connection-state.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+defineProps<{ compact?: boolean; retrying?: boolean }>();
+defineEmits<{ retry: []; openSessions: [] }>();
+</script>
+
+<template>
+  <div
+    role="alert"
+    class="relative w-full shrink-0"
+    :class="compact
+      ? 'flex items-center gap-3 border-b border-default px-5 py-3'
+      : 'flex h-full min-h-0 flex-col items-center justify-center gap-3 px-6 text-center'"
+  >
+    <UButton
+      v-if="!compact"
+      class="absolute left-3 top-3 md:hidden"
+      icon="i-lucide-panel-left"
+      color="neutral"
+      variant="ghost"
+      size="xs"
+      aria-label="Open sessions"
+      @click="$emit('openSessions')"
+    />
+    <UIcon name="i-lucide-wifi-off" class="shrink-0 text-muted" :class="compact ? 'size-4' : 'mb-1 size-5'" />
+    <div :class="compact ? 'min-w-0 flex-1' : 'max-w-xs'">
+      <h2 class="text-sm font-medium text-highlighted">{{ compact ? 'Connection lost' : 'Unable to connect' }}</h2>
+      <p class="mt-1 text-xs leading-5 text-muted">
+        {{ compact
+          ? 'Showing the last loaded session. Reconnect to get updates.'
+          : 'The agent server may be restarting or offline. Try reconnecting in a moment.' }}
+      </p>
+    </div>
+    <UButton
+      :label="retrying ? 'Reconnecting…' : 'Reconnect'"
+      icon="i-lucide-refresh-cw"
+      color="neutral"
+      variant="soft"
+      size="xs"
+      :disabled="retrying"
+      @click="$emit('retry')"
+    />
+  </div>
+</template>

--- a/packages/vite-hub/src/console/runtime/components/console-connection-state.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-connection-state.vue
@@ -14,7 +14,7 @@ defineEmits<{ retry: []; openSessions: [] }>();
     <UButton
       v-if="!compact"
       class="absolute left-3 top-3 md:hidden"
-      icon="i-lucide-panel-left"
+      icon="i-lucide-menu"
       color="neutral"
       variant="ghost"
       size="xs"

--- a/packages/vite-hub/src/console/runtime/components/console-connection.ts
+++ b/packages/vite-hub/src/console/runtime/components/console-connection.ts
@@ -1,0 +1,14 @@
+import { readonly, shallowRef, watch } from "vue"
+
+import { isRetryableConsoleRequestError } from "../client/request"
+
+export function useConsoleConnectionUnavailable(state: () => { errors: unknown[]; pending: boolean }) {
+  const unavailable = shallowRef(false)
+  watch(state, ({ errors, pending }) => {
+    // Request resources clear their errors before a retry settles.
+    if (unavailable.value && pending) return
+    const failures = errors.filter(Boolean)
+    unavailable.value = failures.length > 1 && failures.every(isRetryableConsoleRequestError)
+  }, { immediate: true, flush: "sync" })
+  return readonly(unavailable)
+}

--- a/packages/vite-hub/src/console/runtime/components/console-session-loading.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-loading.vue
@@ -19,7 +19,7 @@ const emit = defineEmits<{
 <template>
   <div
     :aria-label="props.error ? 'Session load failed' : 'Loading session'"
-    class="h-full overflow-hidden"
+    class="h-full w-full min-w-0 overflow-hidden"
     :role="props.error ? 'alert' : 'status'"
   >
     <template v-if="surface === 'inspector'">

--- a/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
@@ -36,6 +36,7 @@ defineEmits<{
   <UDashboardNavbar
     class="vitehub-console__session-navbar"
     :title="title"
+    :toggle="false"
     :ui="{ root: 'border-0', title: 'min-w-0 flex-1' }"
   >
     <template #title>

--- a/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
@@ -49,12 +49,12 @@ defineEmits<{
       </div>
       <span v-else class="text-sm font-medium">{{ title }}</span>
     </template>
-    <template #right>
+    <template #leading>
       <UTooltip text="Open sessions">
         <UButton
           data-slot="mobile-session-navigation"
           class="md:hidden"
-          icon="i-lucide-panel-left"
+          icon="i-lucide-menu"
           color="neutral"
           variant="ghost"
           size="xs"
@@ -62,6 +62,8 @@ defineEmits<{
           @click="$emit('openSessions')"
         />
       </UTooltip>
+    </template>
+    <template #right>
       <UTooltip v-if="externalUrl && externalTarget" :text="externalTarget.label">
         <UButton
           :to="externalUrl"

--- a/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
@@ -18,11 +18,11 @@ const externalTarget = computed(() => {
   try {
     const host = new URL(props.externalUrl).hostname.toLowerCase();
     if (host === "github.com" || host.endsWith(".github.com"))
-      return { icon: "i-lucide-github", label: "Open on GitHub" };
+      return { github: true, icon: undefined, label: "Open on GitHub" };
   } catch {
     // Keep malformed or relative consumer links usable with the generic action.
   }
-  return { icon: "i-lucide-external-link", label: "Open related page" };
+  return { github: false, icon: "i-lucide-external-link", label: "Open related page" };
 });
 
 defineEmits<{
@@ -70,7 +70,14 @@ defineEmits<{
           variant="ghost"
           size="xs"
           :aria-label="externalTarget.label"
-        />
+        >
+          <template v-if="externalTarget.github" #leading>
+            <!-- GitHub's official MIT-licensed Octicons mark. -->
+            <svg class="size-4 shrink-0" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+              <path d="M6.766 11.328c-2.063-.25-3.516-1.734-3.516-3.656 0-.781.281-1.625.75-2.188-.203-.515-.172-1.609.063-2.062.625-.078 1.468.25 1.968.703.594-.187 1.219-.281 1.985-.281.765 0 1.39.094 1.953.265.484-.437 1.344-.765 1.969-.687.218.422.25 1.515.046 2.047.5.593.766 1.39.766 2.203 0 1.922-1.453 3.375-3.547 3.64.531.344.89 1.094.89 1.954v1.625c0 .468.391.734.86.547C13.781 14.359 16 11.53 16 8.03 16 3.61 12.406 0 7.984 0 3.563 0 0 3.61 0 8.031a7.88 7.88 0 0 0 5.172 7.422c.422.156.828-.125.828-.547v-1.25c-.219.094-.5.156-.75.156-1.031 0-1.64-.562-2.078-1.609-.172-.422-.36-.672-.719-.719-.187-.015-.25-.093-.25-.187 0-.188.313-.328.625-.328.453 0 .844.281 1.25.86.313.452.64.655 1.031.655s.641-.14 1-.5c.266-.265.47-.5.657-.656" />
+            </svg>
+          </template>
+        </UButton>
       </UTooltip>
       <UTooltip text="Refresh session">
         <UButton

--- a/packages/vite-hub/test/console-connection.test.ts
+++ b/packages/vite-hub/test/console-connection.test.ts
@@ -1,0 +1,47 @@
+import { effectScope, ref } from "vue"
+import { expect, it } from "vitest"
+
+import { ConsoleRequestError } from "../src/console/runtime/client/request"
+import { useConsoleConnectionUnavailable } from "../src/console/runtime/components/console-connection"
+
+it("preserves the outage through automatic polling and the complete reconnect attempt", () => {
+  const scope = effectScope()
+  const errors = ref<unknown[]>([new Error("offline"), new Error("offline")])
+  const pending = ref(false)
+  const unavailable = scope.run(() => useConsoleConnectionUnavailable(() => ({
+    errors: errors.value, pending: pending.value,
+  })))!
+  expect(unavailable.value).toBe(true)
+
+  pending.value = true
+  errors.value = [errors.value[0], null]
+  expect(unavailable.value).toBe(true)
+  errors.value = [errors.value[0], new Error("offline")]
+  pending.value = false
+  expect(unavailable.value).toBe(true)
+
+  pending.value = true
+  errors.value = [null, null]
+  expect(unavailable.value).toBe(true)
+  pending.value = false
+  expect(unavailable.value).toBe(false)
+  scope.stop()
+})
+
+it("leaves independent request failures in their owning views after recovery", () => {
+  const scope = effectScope()
+  const errors = ref<unknown[]>([new Error("offline")])
+  const pending = ref(false)
+  const unavailable = scope.run(() => useConsoleConnectionUnavailable(() => ({
+    errors: errors.value, pending: pending.value,
+  })))!
+  expect(unavailable.value).toBe(false)
+  errors.value = [new Error("offline"), new Error("offline")]
+  expect(unavailable.value).toBe(true)
+  pending.value = true
+  errors.value = [null, new ConsoleRequestError(404)]
+  expect(unavailable.value).toBe(true)
+  pending.value = false
+  expect(unavailable.value).toBe(false)
+  scope.stop()
+})

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -414,7 +414,8 @@ describe("framework package contract", () => {
     expect(consolePage).toContain(':maximizable="Boolean(selectedInvocationId)"');
     expect(consoleSessionNavbar).toContain('data-slot="session-details-toggle"');
     expect(consoleSessionNavbar).toContain(':disabled="!hasSelection"');
-    expect(consoleSessionNavbar).toContain('icon: "i-lucide-github"');
+    expect(consoleSessionNavbar).toContain('v-if="externalTarget.github"');
+    expect(consoleSessionNavbar).toContain('fill="currentColor"');
     expect(consoleSessionNavbar).toContain('label: "Open on GitHub"');
     expect(consolePage).toMatch(/scrollbar-width: none;/);
     expect(consolePage).toMatch(/::-webkit-scrollbar[\s\S]*?display: none;/);

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -85,6 +85,10 @@ export default defineConfig({
         to: "dist/console/runtime/components",
       },
       {
+        from: "src/console/runtime/components/console-connection-state.vue",
+        to: "dist/console/runtime/components",
+      },
+      {
         from: "src/console/runtime/components/console-connection.ts",
         to: "dist/console/runtime/components",
       },

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -85,6 +85,10 @@ export default defineConfig({
         to: "dist/console/runtime/components",
       },
       {
+        from: "src/console/runtime/components/console-connection.ts",
+        to: "dist/console/runtime/components",
+      },
+      {
         from: "src/console/runtime/components/console-session-bootstrap.ts",
         to: "dist/console/runtime/components",
       },


### PR DESCRIPTION
Console repeats a shared connection failure across four views, offers four retry buttons, and exposes the transport error. Show one connection state with one Reconnect action. If a session was already loaded, keep it visible with a compact connection notice. Keep independent request errors in their owning views.

The loading inspector now fills its pane, matching the loaded inspector. Disable the navbar's default hamburger, which appears beside the already-visible sidebar at tablet widths. Show the hamburger before the title only below 768 px, when the session sidebar is hidden. It opens the session menu at 390 and 767 px and stays hidden at 768 and 1,000 px.

Also show plain text for a single agent, preserve the dropdown for multiple agents, and use GitHub's official filled Octicons mark in the session list and navbar. Suppress the final response's omission notice only when an untruncated assistant turn independently preserves the same text. Genuine message and trace truncation warnings remain.

Verified in the Console playground by aborting requests and delaying the selected session request. Browser assertions cover one connection notice and retry, reconnecting without navigation, preserving cached data, inspector width, the absence of the duplicate hamburger, and working mobile navigation. Focused lint, Console build, 135 invocation UI tests, UI typecheck, and the patched Babysitter build and typecheck pass.

The combined `pnpm patch` is in Babysitter commit `2756df03`. It retains the repository-scoped GitHub credentials from #1343. Remove the patch when the consumer is repinned to a published package containing these changes.

<details>
<summary>Connection failure before and after</summary>

<img width="1000" height="900" alt="Before: repeated connection errors and retry buttons" src="https://github.com/user-attachments/assets/9dfcf40b-fd92-44a7-b01c-8c4cb0919a49" />
<img width="1000" height="900" alt="After: one connection message and Reconnect action" src="https://github.com/user-attachments/assets/f9c5ebc3-249a-4f8a-99b1-fce907a45677" />

</details>

<details>
<summary>Loading inspector and navigation after</summary>

<img width="1000" height="900" alt="Loading inspector fills its pane; the duplicate hamburger is gone" src="https://github.com/user-attachments/assets/67d537a6-27f2-4811-b5c2-00a5dadff835" />

</details>

<details>
<summary>Agent label, GitHub marks, and response warning before and after</summary>

<img width="1280" height="800" alt="Before: single-agent button, outlined GitHub marks, and false response warning" src="https://github.com/user-attachments/assets/612a0571-ded3-46a8-93a9-c4d3530deda4" />
<img width="1280" height="800" alt="After: plain agent label, filled GitHub marks, and complete response without a warning" src="https://github.com/user-attachments/assets/fbcefddf-09f9-4e98-bdb5-5cdcad121982" />

</details>

<details>
<summary>Hamburger when the sidebar is hidden</summary>

<img width="390" height="844" alt="Hamburger before the session title on mobile" src="https://github.com/user-attachments/assets/e0f6006d-84fb-4355-bd79-ce0d9833a33a" />

</details>

Model: GPT-6. Harness: Codex.


