### PR TITLE
Refine invocation UI and Console inspection

### DIFF
--- a/packages/agent/src/index.ts
+++ b/packages/agent/src/index.ts
@@ -27,7 +27,7 @@ import {
 } from "./delivery-effects.ts"
 import { createExecutionContext, createTraceEventLog, deriveTraceRuns, getViteHubErrorShape, isTraceContentAttributeKey, normalizeRuntimeDiagnosticError, traceEventsToOpenTelemetryLogRecords, traceEventsToOpenTelemetrySpans } from "@vite-hub/runtime"
 import { agentTelemetryTask } from "./internal/telemetry-task.ts"
-import { getAgentTelemetryConfiguration, safeAgentTelemetryMetadata, setAgentTelemetryConfiguration } from "./internal/agent-telemetry.ts"
+import { agentTelemetryWorkspaceSources, getAgentTelemetryConfiguration, safeAgentTelemetryMetadata, setAgentTelemetryConfiguration } from "./internal/agent-telemetry.ts"
 import { getCloudflareEnv } from "@vite-hub/internal/runtime/cloudflare-env"
 import { getAgentInvocationRecoveryWorkflowName } from "@vite-hub/internal/agent-workflow"
 import { agentResultKind, agentStreamErrorSymbol, appendLatestFinalText, finalTextFromAgentOutput, hasTraceableStreamResult, isAsyncIterable, resolveAgentUsageRecord, streamAgentOutputToEvents, toAgentRunResult, toAgentStreamEvent, usageRecordFromStreamChunk } from "./agent-output.ts"
@@ -3743,7 +3743,7 @@ async function createAgentInvocationContext<
             workspace: {
               mode: workspaceMode,
               ...(activeWorkspaceDefinition.name ? { name: activeWorkspaceDefinition.name } : {}),
-              ...(activeWorkspaceDefinition.sources ? { sources: Object.keys(activeWorkspaceDefinition.sources).sort() } : {}),
+              ...(activeWorkspaceDefinition.sources ? { sources: agentTelemetryWorkspaceSources(activeWorkspaceDefinition.sources) } : {}),
             },
           }
         : {}),

--- a/packages/agent/src/internal/agent-telemetry.ts
+++ b/packages/agent/src/internal/agent-telemetry.ts
@@ -25,9 +25,12 @@ export function agentTelemetryWorkspaceSources(
     while (hasRuntimeType(source, "object") && source !== null && "source" in source) source = source.source
     if (!hasRuntimeType(source, "object") || source === null) return id
     // GitHub sources expose the repository in their credential-free fingerprint.
-    const metadata = "name" in source && source.name === "github" && "fingerprint" in source
+    let metadata = "name" in source && source.name === "github" && "fingerprint" in source
       ? source.fingerprint
       : source
+    while (metadata && hasRuntimeType(metadata, "object") && "sourceResolution" in metadata && "source" in metadata) {
+      metadata = metadata.source
+    }
     const repository = metadata && hasRuntimeType(metadata, "object") && "repo" in metadata
       ? metadata.repo
       : undefined

--- a/packages/agent/src/internal/agent-telemetry.ts
+++ b/packages/agent/src/internal/agent-telemetry.ts
@@ -1,4 +1,5 @@
 import { hasRuntimeType } from "./runtime-type.ts"
+import type { WorkspaceDefinition } from "@vite-hub/workspace"
 import { agentInvocationConfigurationUpdatedContextKey } from "../invocation-context.ts"
 import type {
   AgentInspectionValue,
@@ -15,6 +16,26 @@ function compareCodeUnits(left: string, right: string): number {
 }
 
 const configurationByContext = new WeakMap<AgentInvocationContextStore, AgentTelemetryConfigurationState>()
+
+export function agentTelemetryWorkspaceSources(
+  sources: NonNullable<WorkspaceDefinition["sources"]>,
+): NonNullable<NonNullable<AgentTelemetryConfiguration["workspace"]>["sources"]> {
+  return Object.keys(sources).sort().map((id) => {
+    let source = sources[id]
+    while (hasRuntimeType(source, "object") && source !== null && "source" in source) source = source.source
+    if (!hasRuntimeType(source, "object") || source === null) return id
+    // GitHub sources expose the repository in their credential-free fingerprint.
+    const metadata = "name" in source && source.name === "github" && "fingerprint" in source
+      ? source.fingerprint
+      : source
+    const repository = metadata && hasRuntimeType(metadata, "object") && "repo" in metadata
+      ? metadata.repo
+      : undefined
+    return hasRuntimeType(repository, "string") && /^[\w.-]+\/[\w.-]+$/.test(repository)
+      ? { id, repository }
+      : id
+  })
+}
 
 function secretMetadataKey(key: string): boolean {
   const normalized = key

--- a/packages/agent/src/internal/agent-telemetry.ts
+++ b/packages/agent/src/internal/agent-telemetry.ts
@@ -24,10 +24,13 @@ export function agentTelemetryWorkspaceSources(
     let source = sources[id]
     while (hasRuntimeType(source, "object") && source !== null && "source" in source) source = source.source
     if (!hasRuntimeType(source, "object") || source === null) return id
+    // Custom Sources own their fields; only plain shorthand infers GitHub from repo.
+    const customSource = "getKeys" in source && hasRuntimeType(source.getKeys, "function")
+      && "getItem" in source && hasRuntimeType(source.getItem, "function")
     // GitHub sources expose the repository in their credential-free fingerprint.
     let metadata = "name" in source && source.name === "github" && "fingerprint" in source
       ? source.fingerprint
-      : source
+      : customSource ? undefined : source
     while (metadata && hasRuntimeType(metadata, "object") && "sourceResolution" in metadata && "source" in metadata) {
       metadata = metadata.source
     }

--- a/packages/agent/src/types.ts
+++ b/packages/agent/src/types.ts
@@ -371,7 +371,7 @@ export interface AgentTelemetryConfiguration {
   workspace?: {
     mode: AgentCapabilityMode
     name?: string
-    sources?: string[]
+    sources?: Array<string | { id: string, repository?: string }>
   }
 }
 

--- a/packages/agent/test/telemetry-workspace-sources.test.ts
+++ b/packages/agent/test/telemetry-workspace-sources.test.ts
@@ -1,4 +1,5 @@
 import { github } from "@vite-hub/workspace"
+import { resolveWorkspaceSources } from "@vite-hub/workspace/runtime"
 import { expect, it } from "vitest"
 import { agentTelemetryWorkspaceSources } from "../src/internal/agent-telemetry.ts"
 
@@ -16,5 +17,29 @@ it("retains GitHub repositories from Workspace sources without exporting credent
     "invalid",
     "local",
     { id: "shorthand", repository: "owner/shorthand" },
+  ])
+})
+
+it("retains repositories from resolved GitHub sources without exporting resolution context", async () => {
+  const resolved = await resolveWorkspaceSources({
+    name: "review",
+    sources: {
+      docs: github(() => ({ repo: "owner/docs", auth: "private-token", root: "private-path" })),
+      invalid: github(() => ({ repo: "https://user:secret@github.com/owner/repo" })),
+    },
+  }, {
+    invocation: {
+      context: {
+        entries: () => new Map<string, unknown>().entries(),
+        get: () => undefined,
+        has: () => false,
+        toJSON: () => ({}),
+      },
+    },
+  })
+
+  expect(agentTelemetryWorkspaceSources(resolved.sources ?? {})).toEqual([
+    { id: "docs", repository: "owner/docs" },
+    "invalid",
   ])
 })

--- a/packages/agent/test/telemetry-workspace-sources.test.ts
+++ b/packages/agent/test/telemetry-workspace-sources.test.ts
@@ -1,0 +1,20 @@
+import { github } from "@vite-hub/workspace"
+import { expect, it } from "vitest"
+import { agentTelemetryWorkspaceSources } from "../src/internal/agent-telemetry.ts"
+
+it("retains GitHub repositories from Workspace sources without exporting credentials or paths", () => {
+  const sources = agentTelemetryWorkspaceSources({
+    "docs:api": github({ repo: "owner/docs", auth: "private-token", root: "private-path" }),
+    bound: { source: github({ repo: "owner/bound" }), mount: "docs" },
+    shorthand: { repo: "owner/shorthand", auth: "private-token" },
+    local: "./private-file.md",
+    invalid: github({ repo: "https://user:secret@github.com/owner/repo" }),
+  })
+  expect(sources).toEqual([
+    { id: "bound", repository: "owner/bound" },
+    { id: "docs:api", repository: "owner/docs" },
+    "invalid",
+    "local",
+    { id: "shorthand", repository: "owner/shorthand" },
+  ])
+})

--- a/packages/agent/test/telemetry-workspace-sources.test.ts
+++ b/packages/agent/test/telemetry-workspace-sources.test.ts
@@ -3,6 +3,20 @@ import { resolveWorkspaceSources } from "@vite-hub/workspace/runtime"
 import { expect, it } from "vitest"
 import { agentTelemetryWorkspaceSources } from "../src/internal/agent-telemetry.ts"
 
+it("does not infer GitHub provenance from custom Source repository fields", () => {
+  const custom = {
+    name: "custom",
+    repo: "owner/not-github",
+    fingerprint: { repo: "owner/not-github" },
+    async getKeys() { return [] },
+    async getItem() { throw new Error("unused") },
+  }
+  expect(agentTelemetryWorkspaceSources({
+    bound: { source: custom, mount: "docs" },
+    custom,
+  })).toEqual(["bound", "custom"])
+})
+
 it("retains GitHub repositories from Workspace sources without exporting credentials or paths", () => {
   const sources = agentTelemetryWorkspaceSources({
     "docs:api": github({ repo: "owner/docs", auth: "private-token", root: "private-path" }),

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -686,12 +686,10 @@ function imageViewPath(activity: InvocationActivity): string | undefined {
 }
 
 function imageViewDetails(activity: InvocationActivity, path: string) {
-  const evidence = {
-    path,
-    ...(activity.attributes["tool.input"] !== undefined ? { input: activity.attributes["tool.input"] } : {}),
-    ...(activity.attributes["tool.output"] !== undefined ? { output: activity.attributes["tool.output"] } : {}),
-    ...(activity.attributes["tool.error"] !== undefined ? { error: activity.attributes["tool.error"] } : {}),
-  };
+  const evidence: Record<string, unknown> = { path };
+  if (activity.attributes["tool.input"] !== undefined) evidence.input = activity.attributes["tool.input"];
+  if (activity.attributes["tool.output"] !== undefined) evidence.output = activity.attributes["tool.output"];
+  if (activity.attributes["tool.error"] !== undefined) evidence.error = activity.attributes["tool.error"];
   return h("section", { class: "vh-invocation-image-details", "aria-label": "Image view details" }, [
     h("strong", "Path"),
     h("code", path),
@@ -1215,10 +1213,8 @@ function statusIcon(status: AgentInvocationView["status"]) {
 }
 
 function sourcePresentation(source: string | { id: string; repository?: string }) {
-  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Recorded sources explicitly allow string IDs and structured descriptors.
-  const id = typeof source === "string" ? source : source.id;
-  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Only string IDs encode repositories with the gh: prefix; descriptors carry a separate field.
-  const repository = typeof source === "string"
+  const id = hasRuntimeType(source, "string") ? source : source.id;
+  const repository = hasRuntimeType(source, "string")
     ? /^gh:([\w.-]+\/[\w.-]+)(?:\/.*)?$/.exec(source)?.[1]
     : /^[\w.-]+\/[\w.-]+$/.test(source.repository ?? "") ? source.repository : undefined;
   return repository
@@ -1622,8 +1618,7 @@ function renderInvocationActivities(
 export const AgentInvocation = defineComponent({
   name: "AgentInvocation",
   emits: {
-    // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Vue's runtime event validator checks the optional path argument at the component boundary.
-    inspect: (target: InspectTarget, path?: string) => (target === "agent" || target === "workspace") && (path === undefined || typeof path === "string"),
+    inspect: (target: InspectTarget, path?: string) => (target === "agent" || target === "workspace") && (path === undefined || hasRuntimeType(path, "string")),
   },
   props: {
     header: { default: true, type: Boolean },

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -186,7 +186,9 @@ function markdown(value: string | undefined, className: string) {
 }
 
 export function workspaceArtifactPath(value: string): string | undefined {
-  const match = /^\/workspace\/[^/]+\/(.+)$/.exec(value);
+  // Separate URL metadata before decoding literal filename delimiters.
+  const pathname = value.split(/[?#]/, 1)[0]!;
+  const match = /^\/workspace\/[^/]+\/(.+)$/.exec(pathname);
   if (!match) return;
   const path = (() => { try { return decodeURIComponent(match[1]!); } catch { return match[1]!; } })();
   if (!path || path.startsWith("/") || path.includes("\\") || path.split("/").some(part => !part || part === "." || part === "..")) return;

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -675,11 +675,11 @@ function imageViewPath(activity: InvocationActivity): string | undefined {
   for (const key of ["tool.input", "tool.output"]) {
     const payload = activity.attributes[key];
     if (!hasRuntimeType(payload, "object") || payload === null || Array.isArray(payload)) continue;
-    const item = hasRuntimeType(payload.item, "object") && payload.item !== null && !Array.isArray(payload.item) ? payload.item : payload;
-    if (hasRuntimeType(item.path, "string") && item.path) return item.path;
-    if (!Array.isArray(item.commandActions)) continue;
+    const item = "item" in payload && hasRuntimeType(payload.item, "object") && payload.item !== null && !Array.isArray(payload.item) ? payload.item : payload;
+    if ("path" in item && hasRuntimeType(item.path, "string") && item.path) return item.path;
+    if (!("commandActions" in item) || !Array.isArray(item.commandActions)) continue;
     for (const value of item.commandActions) {
-      if (hasRuntimeType(value, "object") && value !== null && !Array.isArray(value) && hasRuntimeType(value.path, "string") && value.path) return value.path;
+      if (hasRuntimeType(value, "object") && value !== null && !Array.isArray(value) && "path" in value && hasRuntimeType(value.path, "string") && value.path) return value.path;
     }
   }
   return activity.preview?.startsWith("/") ? activity.preview : undefined;
@@ -1215,12 +1215,14 @@ function statusIcon(status: AgentInvocationView["status"]) {
 }
 
 function sourcePresentation(source: string | { id: string; repository?: string }) {
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Recorded sources explicitly allow string IDs and structured descriptors.
   const id = typeof source === "string" ? source : source.id;
+  // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Only string IDs encode repositories with the gh: prefix; descriptors carry a separate field.
   const repository = typeof source === "string"
     ? /^gh:([\w.-]+\/[\w.-]+)(?:\/.*)?$/.exec(source)?.[1]
     : /^[\w.-]+\/[\w.-]+$/.test(source.repository ?? "") ? source.repository : undefined;
   return repository
-    ? { href: `https://github.com/${repository}`, icon: invocationBrandMark({ id: "github", label: "GitHub" }), label: id }
+    ? { href: `https://github.com/${repository}`, icon: channelIcon("github"), label: id }
     : { label: id };
 }
 
@@ -1555,7 +1557,7 @@ function renderInvocationActivities(
   workOpen: boolean,
   setWorkOpen: (open: boolean) => void,
   toggleExpanded: (id: string) => void,
-  inspect: (target: InspectTarget) => void,
+  inspect: InspectHandler,
   messageRendering: MessageRendering,
 ) {
   const orderedActivities = activities.filter(activity => activity.kind !== "message" || isVisibleMessage(activity));
@@ -1620,6 +1622,7 @@ function renderInvocationActivities(
 export const AgentInvocation = defineComponent({
   name: "AgentInvocation",
   emits: {
+    // doctor-disable-next-line typescript/strict/no-runtime-typeof -- Vue's runtime event validator checks the optional path argument at the component boundary.
     inspect: (target: InspectTarget, path?: string) => (target === "agent" || target === "workspace") && (path === undefined || typeof path === "string"),
   },
   props: {

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -1924,11 +1924,14 @@ export const AgentInvocationInspector = defineComponent({
                 inspectorRow("Tokens", (props.invocation.usage?.totalTokens ?? metrics.value.tokens) === undefined
                   ? "Unknown"
                   : new Intl.NumberFormat("en").format((props.invocation.usage?.totalTokens ?? metrics.value.tokens)!)),
-                inspectorRow("Cost", props.invocation.usage?.cost?.display ?? "Unknown"),
+                inspectorRow("Cost", usage?.cost?.display
+                  ? `${usage.cost.display}${usage.cost.estimated === true ? " (estimated)" : usage.cost.estimated === false ? " (reported)" : ""}`
+                  : "Unknown"),
                 ...([
                   ["Input", partition?.inputTokens],
                   ["Output", partition?.outputTokens],
                   ["Cached", partition?.cachedInputTokens],
+                  ["Cache writes", partition?.cacheWriteTokens],
                   ["Reasoning", partition?.reasoningTokens],
                 ] as const).flatMap(([label, value]) => value === undefined
                   ? []

--- a/packages/ui/src/components/agent-invocation.ts
+++ b/packages/ui/src/components/agent-invocation.ts
@@ -185,6 +185,14 @@ function markdown(value: string | undefined, className: string) {
   });
 }
 
+export function workspaceArtifactPath(value: string): string | undefined {
+  const match = /^\/workspace\/[^/]+\/(.+)$/.exec(value);
+  if (!match) return;
+  const path = (() => { try { return decodeURIComponent(match[1]!); } catch { return match[1]!; } })();
+  if (!path || path.startsWith("/") || path.includes("\\") || path.split("/").some(part => !part || part === "." || part === "..")) return;
+  return path;
+}
+
 function renderFolderIcon() {
   return h("svg", { "aria-hidden": "true", fill: "none", viewBox: "0 0 24 24" }, [
     h("path", { d: "M3 6.5h6l2 2h10v9.5a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z", "stroke-linecap": "round", "stroke-linejoin": "round" }),
@@ -192,6 +200,7 @@ function renderFolderIcon() {
 }
 
 type InspectTarget = "agent" | "workspace";
+type InspectHandler = (target: InspectTarget, path?: string) => void;
 
 function payloadText(value: unknown): string {
   if (hasRuntimeType(value, "string")) return value;
@@ -462,17 +471,20 @@ function renderMessage(
   expanded: ReadonlySet<string>,
   toggleExpanded: (id: string) => void,
   messageRendering: MessageRendering,
+  insideWork = false,
 ) {
   const body = activity.body ?? "";
   const collapsible = activity.role === "user" && (body.length > 720 || body.split(/\r?\n/).length > 12);
   const isExpanded = expanded.has(activity.id);
   const sentAt = messageTimestamp(activity, messageRendering.now, messageRendering.mounted, activity.id === messageRendering.promptId ? messageRendering.sentAt : undefined);
   const copyStatus = messageRendering.copiedId === activity.id ? messageRendering.copyStatus : undefined;
-  const hasMessageMeta = activity.role === "user" || activity.role === "assistant";
+  const commentary = activity.attributes["message.phase"] === "commentary";
+  const hasMessageMeta = (activity.role === "user" || activity.role === "assistant") && !(insideWork && commentary);
   return h(
     "li",
     {
       class: "vh-invocation-message",
+      "data-phase": commentary ? "commentary" : undefined,
       "data-role": activity.role,
       key: activity.id,
     },
@@ -657,12 +669,45 @@ function renderActivityIconSvg(icon: ActivityIcon) {
   })));
 }
 
-function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarget) => void) {
+function imageViewPath(activity: InvocationActivity): string | undefined {
+  const name = String(activity.attributes["tool.name"] ?? "").trim().toLocaleLowerCase();
+  if (name !== "image view" && name !== "view image" && name !== "view_image") return;
+  for (const key of ["tool.input", "tool.output"]) {
+    const payload = activity.attributes[key];
+    if (!hasRuntimeType(payload, "object") || payload === null || Array.isArray(payload)) continue;
+    const item = hasRuntimeType(payload.item, "object") && payload.item !== null && !Array.isArray(payload.item) ? payload.item : payload;
+    if (hasRuntimeType(item.path, "string") && item.path) return item.path;
+    if (!Array.isArray(item.commandActions)) continue;
+    for (const value of item.commandActions) {
+      if (hasRuntimeType(value, "object") && value !== null && !Array.isArray(value) && hasRuntimeType(value.path, "string") && value.path) return value.path;
+    }
+  }
+  return activity.preview?.startsWith("/") ? activity.preview : undefined;
+}
+
+function imageViewDetails(activity: InvocationActivity, path: string) {
+  const evidence = {
+    path,
+    ...(activity.attributes["tool.input"] !== undefined ? { input: activity.attributes["tool.input"] } : {}),
+    ...(activity.attributes["tool.output"] !== undefined ? { output: activity.attributes["tool.output"] } : {}),
+    ...(activity.attributes["tool.error"] !== undefined ? { error: activity.attributes["tool.error"] } : {}),
+  };
+  return h("section", { class: "vh-invocation-image-details", "aria-label": "Image view details" }, [
+    h("strong", "Path"),
+    h("code", path),
+    h("strong", "Raw details"),
+    h("pre", payloadText(evidence)),
+  ]);
+}
+
+function renderEvent(activity: InvocationActivity, inspect: InspectHandler) {
   const command = activity.command;
+  const viewedImagePath = imageViewPath(activity);
   const tokenLabel = activity.kind === "reasoning" || activity.kind === "model"
     ? formatTokens(activity.reasoningTokens)
     : undefined;
-  const suffix = agentConfigurationSummary(activity)
+  const suffix = viewedImagePath?.split("/").filter(Boolean).at(-1)
+    ?? agentConfigurationSummary(activity)
     ?? channelDeliverySummary(activity)
     ?? (activity.preview ? compactCommand(activity.preview) : tokenLabel);
   const hasPayloads = activity.kind === "tool" && (
@@ -682,11 +727,27 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
     : undefined;
   const hasDetails = Boolean(deliveryFailure || activity.truncated)
     || (!visibleDelivery && (activity.patches.length > 0 || Boolean(command || hasPayloads || activity.body || activity.truncated)));
-  const inspectTarget = activity.attributes["vitehub.inspect.target"] ?? (activity.name === "vitehub.agent.configured" ? "agent" : undefined);
+  const skillReads = activity.skills ?? (activity.skill ? [activity.skill] : []);
+  const inspectTarget = skillReads.length === 1 ? "workspace" : activity.attributes["vitehub.inspect.target"] ?? (activity.name === "vitehub.agent.configured" ? "agent" : undefined);
+  const inspectPath = activity.skill?.path;
   const inspectable = inspectTarget === "agent" || inspectTarget === "workspace";
+  const title = skillReads.length
+    ? h("span", { class: "vh-invocation-event__title" }, skillReads.flatMap((skill, index) => [
+        index ? h("span", { "aria-hidden": "true" }, " · ") : null,
+        h("button", {
+        class: "vh-invocation-event__title vh-invocation-event__title-link",
+        onClick: (event: Event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          inspect("workspace", skill.path);
+        },
+        type: "button",
+        }, `Read ${skill.name} skill`),
+      ]))
+    : h("span", { class: "vh-invocation-event__title" }, viewedImagePath ? "View image" : invocationActivityTitle(activity));
   const summaryContent = [
     activity.name === "vitehub.agent.configured" ? frameworkMark() : activity.kind === "delivery" ? channelIcon(activityChannel(activity)) : renderActivityIcon(activity),
-    h("span", { class: "vh-invocation-event__title" }, invocationActivityTitle(activity)),
+    title,
     activity.status === "failed" ? h("span", { class: "vh-visually-hidden" }, "Failed") : null,
     suffix ? h("code", { class: "vh-invocation-event__suffix" }, suffix) : null,
     hasDetails
@@ -696,7 +757,7 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
   const summary = inspectable && !hasDetails
     ? h("button", {
         class: "vh-invocation-event__summary",
-        onClick: () => inspect(inspectTarget),
+        onClick: () => inspect(inspectTarget, inspectPath),
         type: "button",
       }, summaryContent)
     : h(hasDetails ? "summary" : "div", { class: "vh-invocation-event__summary" }, summaryContent);
@@ -733,6 +794,8 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
               command.output ? h("pre", terminalText(command.output)) : null,
               renderCommandError(activity.attributes["tool.error"]),
             ])
+          : viewedImagePath
+            ? imageViewDetails(activity, viewedImagePath)
           : hasPayloads
             ? h("div", { class: "vh-invocation-event__payloads" }, [
                 renderEventPayload("Input", activity.attributes["tool.input"]),
@@ -745,7 +808,7 @@ function renderEvent(activity: InvocationActivity, inspect: (target: InspectTarg
         inspectable
           ? h("button", {
               class: "vh-invocation-event__inspect",
-              onClick: () => inspect(inspectTarget),
+              onClick: () => inspect(inspectTarget, inspectPath),
               type: "button",
             }, `Inspect ${inspectTarget}`)
           : null,
@@ -775,7 +838,7 @@ function activityDetail(activity: InvocationActivity): string | undefined {
   return activity.preview ?? stringAttribute(activity.attributes, "vitehub.activity.detail");
 }
 
-function renderPreparationAction(activity: InvocationActivity, inspect: (target: InspectTarget) => void) {
+function renderPreparationAction(activity: InvocationActivity, inspect: InspectHandler) {
   const target = activity.attributes["vitehub.inspect.target"];
   if (target !== "workspace" && target !== "agent") return;
   return h("button", {
@@ -845,7 +908,7 @@ function activityChannel(activity: InvocationActivity): string {
 function renderPreparationGroup(
   activities: readonly InvocationActivity[],
   invocation: AgentInvocationView,
-  inspect: (target: InspectTarget) => void,
+  inspect: InspectHandler,
 ) {
   const url = agentInvocationExternalUrl(invocation);
   const failedActivity = activities.find(activity => activity.status === "failed");
@@ -855,34 +918,81 @@ function renderPreparationGroup(
   }, [
     h("details", { class: "vh-invocation-preparation__details" }, [
       h("summary", { class: "vh-invocation-preparation__summary" }, [
-        failedActivity ? renderActivityIcon(failedActivity) : frameworkMark(),
-        h("strong", failedActivity ? "Session preparation failed" : "Session prepared"),
-        renderPreparationContext(invocation, url),
-        h("small", `${activities.length} steps`),
         renderDisclosureChevron("vh-invocation-preparation__disclosure"),
+        failedActivity ? renderActivityIcon(failedActivity) : null,
+        h("strong", failedActivity ? "Session preparation failed" : "Prepared workspace"),
+        failedActivity ? renderPreparationContext(invocation, url) : null,
+        failedActivity ? h("small", `${activities.length} steps`) : null,
       ]),
-      h("ol", { class: "vh-invocation-preparation__steps" }, activities.map(activity => h("li", {
-        "data-activity-id": activity.id,
-        "data-kind": "preparation",
-        key: activity.id,
-      }, [
-        renderActivityIcon(activity),
-        h("strong", invocationActivityTitle(activity)),
-        renderPreparationDetail(activity, url),
-        renderPreparationAction(activity, inspect),
-        activity.body
-          ? h("p", { class: "vh-invocation-preparation__body" }, activity.body)
-          : null,
-        activity.truncated
-          ? h("p", { class: "vh-invocation-event__notice" }, "Some activity details were omitted.")
-          : null,
-      ]))),
+      h("ol", { class: "vh-invocation-preparation__steps" }, activities.map(activity => renderPreparationStep(activity, url, inspect))),
     ]),
   ]);
 }
 
+function renderPreparationStep(activity: InvocationActivity, url: string | undefined, inspect: InspectHandler) {
+  return h("li", {
+    class: "vh-invocation-preparation__step",
+    "data-activity-id": activity.id,
+    "data-kind": "preparation",
+    key: activity.id,
+  }, [
+    renderActivityIcon(activity),
+    h("strong", invocationActivityTitle(activity)),
+    renderPreparationDetail(activity, url),
+    renderPreparationAction(activity, inspect),
+    activity.body ? h("p", { class: "vh-invocation-preparation__body" }, activity.body) : null,
+    activity.truncated ? h("p", { class: "vh-invocation-event__notice" }, "Some activity details were omitted.") : null,
+  ]);
+}
+
 function activityGroup(activity: InvocationActivity | undefined): string | undefined {
-  return activity ? stringAttribute(activity.attributes, "vitehub.activity.group") : undefined;
+  if (!activity) return;
+  if (activity.name === "vitehub.agent.configured") return "agent-configuration-lifecycle";
+  if (/^agent\.capability\.(?:input|output|configure|prepare|resolve|close)$/.test(activity.name)) return "agent-capability-lifecycle";
+  return stringAttribute(activity.attributes, "vitehub.activity.group");
+}
+
+function renderCapabilityGroup(activities: readonly InvocationActivity[], inspect: InspectHandler) {
+  const capabilities = [...new Set(activities.flatMap(activity => {
+    const id = stringAttribute(activity.attributes, "agent.capability.id");
+    return id ? [id] : [];
+  }))];
+  const failures = activities.filter(activity => activity.status === "failed").length;
+  const phases = new Set(activities.map(activity => activity.name.split(".").at(-1)));
+  const summary = capabilities.length
+    ? `${capabilities.length} ${capabilities.length === 1 ? "capability" : "capabilities"}`
+    : `${activities.length} ${activities.length === 1 ? "event" : "events"}`;
+  return h("li", { class: "vh-invocation-capabilities", key: `capabilities:${activities[0]?.id}` }, [
+    h("details", { class: "vh-invocation-capabilities__details" }, [
+      h("summary", { class: "vh-invocation-capabilities__summary" }, [
+        renderDisclosureChevron("vh-invocation-capabilities__disclosure"),
+        h("span", failures
+          ? `Capability activity failed · ${summary}`
+          : !capabilities.length
+            ? `Capability activity · ${summary}`
+            : [...phases].every(phase => phase === "close")
+              ? `Closed ${summary}`
+              : [...phases].every(phase => phase === "output" || phase === "close")
+                ? `Finalized ${summary}`
+                : `Prepared ${summary}`),
+      ]),
+      h("ol", { class: "vh-invocation-capabilities__rows" }, activities.map(activity => renderEvent(activity, inspect))),
+    ]),
+  ]);
+}
+
+function renderAgentConfigurationGroup(activities: readonly InvocationActivity[], inspect: InspectHandler) {
+  const activity = activities[0]!;
+  return h("li", { class: "vh-invocation-capabilities", key: `configuration:${activity.id}` }, [
+    h("details", { class: "vh-invocation-capabilities__details" }, [
+      h("summary", { class: "vh-invocation-capabilities__summary" }, [
+        renderDisclosureChevron("vh-invocation-capabilities__disclosure"),
+        h("span", "Agent configured"),
+        agentConfigurationSummary(activity) ? h("small", agentConfigurationSummary(activity)) : null,
+      ]),
+      h("ol", { class: "vh-invocation-capabilities__rows" }, activities.map(item => renderEvent(item, inspect))),
+    ]),
+  ]);
 }
 
 function labelStyle(color: string | undefined): Record<string, string> {
@@ -941,7 +1051,7 @@ function renderGroupedActivityIcon(activity: InvocationActivity) {
 function renderActivityGroup(
   group: string,
   activities: readonly InvocationActivity[],
-  inspect: (target: InspectTarget) => void,
+  inspect: InspectHandler,
 ) {
   return h("li", {
     class: "vh-invocation-lifecycle",
@@ -1104,32 +1214,39 @@ function statusIcon(status: AgentInvocationView["status"]) {
   );
 }
 
-function inspectorCollection(title: string, items: readonly string[]) {
+function sourcePresentation(source: string | { id: string; repository?: string }) {
+  const id = typeof source === "string" ? source : source.id;
+  const repository = typeof source === "string"
+    ? /^gh:([\w.-]+\/[\w.-]+)(?:\/.*)?$/.exec(source)?.[1]
+    : /^[\w.-]+\/[\w.-]+$/.test(source.repository ?? "") ? source.repository : undefined;
+  return repository
+    ? { href: `https://github.com/${repository}`, icon: invocationBrandMark({ id: "github", label: "GitHub" }), label: id }
+    : { label: id };
+}
+
+function inspectorSources(sources: NonNullable<AgentInvocationConfiguration["workspace"]>["sources"] & readonly unknown[]) {
   return h("div", { class: "vh-invocation-inspector__group" }, [
-    h("div", { class: "vh-invocation-inspector__group-heading" }, [
-      h("strong", title),
-      h("small", items.length),
-    ]),
-    h(
-      "ul",
-      { class: "vh-invocation-inspector__items" },
-      items.map((item) => h("li", { key: item }, [h("code", item)])),
-    ),
+    h("div", { class: "vh-invocation-inspector__group-heading" }, [h("strong", "Sources"), h("small", sources.length)]),
+    h("div", { class: "vh-invocation-inspector__badges" }, sources.map((source) => {
+      const presentation = sourcePresentation(source);
+      const children = [presentation.icon, h("span", presentation.label)];
+      return presentation.href
+        ? h("a", { class: "vh-invocation-inspector__badge", href: presentation.href, rel: "noreferrer", target: "_blank" }, children)
+        : h("span", { class: "vh-invocation-inspector__badge" }, children);
+    })),
   ]);
 }
 
-function workspaceIcon() {
-  return h("svg", {
-    "aria-hidden": "true",
-    fill: "none",
-    stroke: "currentColor",
-    "stroke-width": 1.5,
-    viewBox: "0 0 24 24"
-  }, [h("path", {
-    d: "M3 7.5A2.5 2.5 0 0 1 5.5 5h3l2 2H18.5A2.5 2.5 0 0 1 21 9.5v7a2.5 2.5 0 0 1-2.5 2.5h-13A2.5 2.5 0 0 1 3 16.5z",
-    "stroke-linecap": "round",
-    "stroke-linejoin": "round"
-  })]);
+function inspectorChannels(channels: NonNullable<AgentInvocationConfiguration["channels"]>) {
+  return h("div", { class: "vh-invocation-inspector__group" }, [
+    h("div", { class: "vh-invocation-inspector__group-heading" }, [h("strong", "Channels"), h("small", channels.length)]),
+    h("div", { class: "vh-invocation-inspector__badges" }, channels.map((channel) => {
+      return h("span", { class: "vh-invocation-inspector__badge" }, [
+        channelIcon(channel.kind),
+        h("span", channel.id),
+      ]);
+    })),
+  ]);
 }
 
 function inspectorExecution(configuration: AgentInvocationConfiguration) {
@@ -1140,11 +1257,10 @@ function inspectorExecution(configuration: AgentInvocationConfiguration) {
       ?? configuration.driver?.provider
       ?? (modelId?.includes("/") ? modelId.split("/")[0] : undefined),
   );
-  const workspace = configuration.workspace;
   const runtime = configuration.runtime?.name;
-  if (!modelId && !provider && !workspace) return null;
+  if (!modelId && !provider && (!runtime || runtime === "unknown")) return null;
   return h("div", { class: "vh-invocation-inspector__group vh-invocation-inspector__group--execution" }, [
-    h("div", { class: "vh-invocation-inspector__group-heading" }, [h("strong", "Model and workspace")]),
+    h("div", { class: "vh-invocation-inspector__group-heading" }, [h("strong", "Model")]),
     h("div", { class: "vh-invocation-execution" }, [
       modelId || provider ? h("div", { class: "vh-invocation-execution__model" }, [
         invocationBrandMark(provider ?? { id: "fallback", label: "Model" }, "vh-invocation-execution__model-icon"),
@@ -1153,13 +1269,6 @@ function inspectorExecution(configuration: AgentInvocationConfiguration) {
           modelId && provider ? h("span", { class: "vh-invocation-execution__provider" }, [
             invocationBrandMark(provider, "vh-invocation-execution__provider-icon"), provider.label,
           ]) : null,
-        ]),
-      ]) : null,
-      workspace ? h("div", { class: "vh-invocation-execution__workspace" }, [
-        workspaceIcon(),
-        h("div", { class: "vh-invocation-execution__details" }, [
-          h("strong", workspace.name || "Workspace"),
-          workspace.mode ? h("span", workspace.mode === "write" ? "Read and write" : "Read only") : null,
         ]),
       ]) : null,
       runtime && runtime !== "unknown" ? h("dl", { class: "vh-invocation-inspector__list vh-invocation-execution__runtime" }, [
@@ -1230,15 +1339,10 @@ function renderConfiguration(configuration: AgentInvocationConfiguration, invoca
         ])
       : null,
     configuration.workspace?.sources?.length
-      ? inspectorCollection("Sources", configuration.workspace.sources)
+      ? inspectorSources(configuration.workspace.sources)
       : null,
     configuration.channels?.length
-      ? inspectorCollection(
-          "Channels",
-          configuration.channels.map((channel) =>
-            channel.id === channel.kind ? channel.id : `${channel.id} · ${channel.kind}`,
-          ),
-        )
+      ? inspectorChannels(configuration.channels)
       : null,
     configuration.capabilities?.length
       ? h("div", { class: "vh-invocation-inspector__group" }, [
@@ -1298,11 +1402,12 @@ function renderInvocationActivity(
   activity: InvocationActivity,
   expanded: ReadonlySet<string>,
   toggleExpanded: (id: string) => void,
-  inspect: (target: InspectTarget) => void,
+  inspect: InspectHandler,
   messageRendering: MessageRendering,
+  insideWork = false,
 ) {
   return activity.kind === "message"
-    ? renderMessage(activity, expanded, toggleExpanded, messageRendering)
+    ? renderMessage(activity, expanded, toggleExpanded, messageRendering, insideWork)
     : renderEvent(activity, inspect);
 }
 
@@ -1311,8 +1416,9 @@ function renderActivitySequence(
   invocation: AgentInvocationView,
   expanded: ReadonlySet<string>,
   toggleExpanded: (id: string) => void,
-  inspect: (target: InspectTarget) => void,
+  inspect: InspectHandler,
   messageRendering: MessageRendering,
+  insideWork = false,
 ) {
   const rendered = [];
   for (let index = 0; index < activities.length;) {
@@ -1320,12 +1426,16 @@ function renderActivitySequence(
     if (group) {
       let end = index + 1;
       while (activityGroup(activities[end]) === group) end += 1;
-      rendered.push(renderActivityGroup(group, activities.slice(index, end), inspect));
+      rendered.push(group === "agent-capability-lifecycle"
+        ? renderCapabilityGroup(activities.slice(index, end), inspect)
+        : group === "agent-configuration-lifecycle"
+          ? renderAgentConfigurationGroup(activities.slice(index, end), inspect)
+        : renderActivityGroup(group, activities.slice(index, end), inspect));
       index = end;
       continue;
     }
     if (activities[index]!.kind !== "preparation") {
-      rendered.push(renderInvocationActivity(activities[index]!, expanded, toggleExpanded, inspect, messageRendering));
+      rendered.push(renderInvocationActivity(activities[index]!, expanded, toggleExpanded, inspect, messageRendering, insideWork));
       index += 1;
       continue;
     }
@@ -1344,7 +1454,7 @@ function renderWorkSummary(
   open: boolean,
   setOpen: (open: boolean) => void,
   toggleExpanded: (id: string) => void,
-  inspect: (target: InspectTarget) => void,
+  inspect: InspectHandler,
   messageRendering: MessageRendering,
 ) {
   if (!activities.length) return null;
@@ -1361,12 +1471,11 @@ function renderWorkSummary(
     }, [
       h("summary", { class: "vh-invocation-work__summary" }, [
         renderDisclosureChevron("vh-invocation-work__disclosure"),
-        frameworkMark(),
         h("span", { class: "vh-invocation-work__title" }, active ? "Working…" : duration ? `Worked for ${duration}` : "Work details"),
       ]),
       h("div", { "aria-hidden": "true", class: "vh-invocation-work__divider" }),
       detailsOpen
-        ? h("ol", { class: "vh-invocation-work__activities" }, renderActivitySequence(activities, invocation, expanded, toggleExpanded, inspect, messageRendering))
+        ? h("ol", { class: "vh-invocation-work__activities" }, renderActivitySequence(activities, invocation, expanded, toggleExpanded, inspect, messageRendering, true))
         : null,
     ]),
   ]);
@@ -1409,7 +1518,7 @@ function renderPreviousMessages(
   invocation: AgentInvocationView,
   expanded: ReadonlySet<string>,
   toggleExpanded: (id: string) => void,
-  inspect: (target: InspectTarget) => void,
+  inspect: InspectHandler,
   messageRendering: MessageRendering,
 ) {
   if (!messages.length) return null;
@@ -1511,7 +1620,7 @@ function renderInvocationActivities(
 export const AgentInvocation = defineComponent({
   name: "AgentInvocation",
   emits: {
-    inspect: (target: InspectTarget) => target === "agent" || target === "workspace",
+    inspect: (target: InspectTarget, path?: string) => (target === "agent" || target === "workspace") && (path === undefined || typeof path === "string"),
   },
   props: {
     header: { default: true, type: Boolean },
@@ -1521,10 +1630,10 @@ export const AgentInvocation = defineComponent({
   },
   setup(props, { emit, slots }) {
     const activities = computed(() => invocationActivities(props.invocation).map((activity) => {
-      if (props.workspaceInspectable || activity.attributes["vitehub.inspect.target"] !== "workspace") return activity;
+      if (props.workspaceInspectable) return activity;
       const attributes = { ...activity.attributes };
       delete attributes["vitehub.inspect.target"];
-      return { ...activity, attributes };
+      return { ...activity, attributes, skill: undefined, skills: undefined };
     }));
     const expandedMessages = ref<ReadonlySet<string>>(new Set());
     const mounted = useMounted();
@@ -1540,6 +1649,15 @@ export const AgentInvocation = defineComponent({
       if (next.has(id)) next.delete(id);
       else next.add(id);
       expandedMessages.value = next;
+    }
+
+    function inspectWorkspaceArtifact(event: MouseEvent) {
+      if (!props.workspaceInspectable || event.defaultPrevented || event.button !== 0) return;
+      const target = event.target instanceof Element ? event.target.closest<HTMLAnchorElement>("a[href]") : undefined;
+      const path = target ? workspaceArtifactPath(target.getAttribute("href") || "") : undefined;
+      if (!path) return;
+      event.preventDefault();
+      emit("inspect", "workspace", path);
     }
 
     function clearSelectedElement() {
@@ -1604,6 +1722,7 @@ export const AgentInvocation = defineComponent({
         class: ["vh-invocation-session", { "vh-invocation-session--headerless": !props.header }],
         "data-status": props.invocation.status,
         "data-slot": "invocation",
+        onClick: inspectWorkspaceArtifact,
         ref: root,
       }, [
         props.header ? h("header", { class: "vh-invocation-header" }, [
@@ -1630,7 +1749,9 @@ export const AgentInvocation = defineComponent({
               workOpen.value,
               open => workOpen.value = open,
               toggleExpanded,
-              target => emit("inspect", target),
+              (target, path) => path === undefined
+                ? emit("inspect", target)
+                : emit("inspect", target, path),
               {
                 ...promptMetadata,
                 now: now.value,
@@ -1710,11 +1831,6 @@ export const AgentInvocationInspector = defineComponent({
         },
         [
           h("span", { class: "vh-invocation-inspector__copy-label" }, label),
-          h(
-            "span",
-            { class: "vh-invocation-inspector__copy-state" },
-            didCopy ? "Copied" : "Copy",
-          ),
           h("span", { class: "vh-invocation-inspector__copy-icon" }, [copyIcon(didCopy)]),
         ],
       );
@@ -1727,6 +1843,12 @@ export const AgentInvocationInspector = defineComponent({
     return () => {
       const configuration = props.invocation.configuration;
       const agentName = configuration?.agent?.name ?? props.invocation.agentName;
+      const usage = props.invocation.usage;
+      // Older sessions can pair a thread total with only the last response's counts.
+      const partition = usage?.inputTokens !== undefined && usage.outputTokens !== undefined
+        && (usage.totalTokens === undefined || usage.inputTokens + usage.outputTokens === usage.totalTokens)
+        ? usage
+        : undefined;
       const endedAt =
         props.invocation.completedAt ?? props.invocation.failedAt ?? props.invocation.cancelledAt;
       const duration =
@@ -1775,7 +1897,10 @@ export const AgentInvocationInspector = defineComponent({
                   h("small", duration),
                 ],
               ) : null,
-              h("h4", { class: "vh-invocation-inspector__title" }, agentInvocationTitle(props.invocation)),
+              h("div", { class: "vh-invocation-inspector__title-row" }, [
+                h("h4", { class: "vh-invocation-inspector__title" }, agentInvocationTitle(props.invocation)),
+                slots.identityActions?.({ invocation: props.invocation }),
+              ]),
               agentInvocationContext(props.invocation) !== props.invocation.id
                 ? h("p", agentInvocationContext(props.invocation))
                 : null,
@@ -1798,10 +1923,18 @@ export const AgentInvocationInspector = defineComponent({
                 metrics.value.changes
                   ? h("div", [h("dt", "Changes"), h("dd", metrics.value.changes)])
                   : null,
-                inspectorRow("Tokens", metrics.value.tokens === undefined
+                inspectorRow("Tokens", (props.invocation.usage?.totalTokens ?? metrics.value.tokens) === undefined
                   ? "Unknown"
-                  : new Intl.NumberFormat("en").format(metrics.value.tokens)),
+                  : new Intl.NumberFormat("en").format((props.invocation.usage?.totalTokens ?? metrics.value.tokens)!)),
                 inspectorRow("Cost", props.invocation.usage?.cost?.display ?? "Unknown"),
+                ...([
+                  ["Input", partition?.inputTokens],
+                  ["Output", partition?.outputTokens],
+                  ["Cached", partition?.cachedInputTokens],
+                  ["Reasoning", partition?.reasoningTokens],
+                ] as const).flatMap(([label, value]) => value === undefined
+                  ? []
+                  : [inspectorRow(label, new Intl.NumberFormat("en").format(value))]),
               ]),
             ),
             props.showTimeline

--- a/packages/ui/src/internal/channel-icon.ts
+++ b/packages/ui/src/internal/channel-icon.ts
@@ -36,7 +36,10 @@ const channelMarks: Record<string, { label: string; body: string }> = {
 const genericChannelMark = { body: "<path fill=\"currentColor\" d=\"M128 88a40 40 0 1 0 40 40a40 40 0 0 0-40-40m0 64a24 24 0 1 1 24-24a24 24 0 0 1-24 24m73.71 7.14a80 80 0 0 1-14.08 22.2a8 8 0 0 1-11.92-10.67a63.95 63.95 0 0 0 0-85.33a8 8 0 1 1 11.92-10.67a80.08 80.08 0 0 1 14.08 84.47M69 103.09a64 64 0 0 0 11.26 67.58a8 8 0 0 1-11.92 10.67a79.93 79.93 0 0 1 0-106.67a8 8 0 1 1 11.95 10.67A63.8 63.8 0 0 0 69 103.09M248 128a119.58 119.58 0 0 1-34.29 84a8 8 0 1 1-11.42-11.2a103.9 103.9 0 0 0 0-145.56A8 8 0 1 1 213.71 44A119.58 119.58 0 0 1 248 128M53.71 200.78A8 8 0 1 1 42.29 212a119.87 119.87 0 0 1 0-168a8 8 0 1 1 11.42 11.2a103.9 103.9 0 0 0 0 145.56Z\"/>" };
 
 export function channelIcon(channel: string) {
-  const normalized = channel.toLowerCase().replace(/^microsoft[ ._-]?/, "").replace(/^github-pull-request(?:-comment)?$/, "github");
+  const normalized = channel.toLowerCase()
+    .replace(/^msteams$/, "teams")
+    .replace(/^microsoft[ ._-]?/, "")
+    .replace(/^github-pull-request(?:-comment)?$/, "github");
   const knownMark = Object.hasOwn(channelMarks, normalized) ? channelMarks[normalized] : undefined;
   const mark = knownMark ?? genericChannelMark;
   const label = knownMark?.label ?? channel;

--- a/packages/ui/src/internal/invocation-activity.ts
+++ b/packages/ui/src/internal/invocation-activity.ts
@@ -25,6 +25,11 @@ interface InvocationCommand {
   output?: string;
 }
 
+interface InvocationSkillRead {
+  name: string;
+  path: string;
+}
+
 export interface InvocationActivity {
   attributes: Record<string, unknown>;
   body?: string;
@@ -40,6 +45,8 @@ export interface InvocationActivity {
   reasoningTokens?: number;
   role?: "assistant" | "system" | "tool" | "user";
   sequence: number;
+  skill?: InvocationSkillRead;
+  skills?: readonly InvocationSkillRead[];
   startedAt?: string;
   status: "running" | "completed" | "failed";
   totalTokens?: number;
@@ -183,6 +190,35 @@ function commandDetails(
     ...(hasRuntimeType(output?.exitCode, "number") ? { exitCode: output.exitCode } : hasRuntimeType(input?.exitCode, "number") ? { exitCode: input.exitCode } : {}),
     ...(outputText !== undefined ? { output: outputText } : {}),
   };
+}
+
+function skillReadDetails(attributes: Record<string, unknown>): InvocationSkillRead[] {
+  const reads: InvocationSkillRead[] = [];
+  const add = (path: string) => {
+    if (path.includes("\\") || path.includes("//")) return;
+    const match = /^\.agents\/skills\/([^/.][^/]*)\/SKILL\.md$/.exec(path);
+    if (match?.[1] && !reads.some(read => read.path === path)) reads.push({ name: match[1], path });
+  };
+  for (const key of ["tool.output", "tool.input"]) {
+    const payload = record(attributes[key]);
+    const item = record(payload?.item) ?? payload;
+    if (!item || !Array.isArray(item.commandActions)) continue;
+    for (const value of item.commandActions) {
+      const action = record(value);
+      const cwd = hasRuntimeType(item.cwd, "string") ? item.cwd.replace(/\/+$/, "") : undefined;
+      if (action?.type === "read" && hasRuntimeType(action.path, "string")) {
+        add(cwd && action.path.startsWith(`${cwd}/`)
+          ? action.path.slice(cwd.length + 1)
+          : action.path.replace(/^\.\//, ""));
+        continue;
+      }
+      if (action?.type !== "unknown" || !hasRuntimeType(action.command, "string")) continue;
+      const tokens = action.command.trim().split(/\s+/);
+      if (tokens[0] !== "cat" || tokens.length < 2 || tokens.slice(1).some(token => token.startsWith("-") || /[\\'"`$;&|<>(){}\[\]*?!]/.test(token))) continue;
+      for (const token of tokens.slice(1)) add(token.replace(/^\.\//, ""));
+    }
+  }
+  return reads;
 }
 
 export function stringAttribute(attributes: Record<string, unknown>, ...keys: string[]): string | undefined {
@@ -355,7 +391,8 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
       const { patches, paths } = fileChanges(attributes);
       const kind = activityKind(first, attributes, paths.length ? paths : patches);
       const failed = sorted.some(item => item.type === "error" || /\.(error|failed)$/.test(item.name))
-        || (kind === "delivery" && Boolean(stringAttribute(attributes, "error.message")));
+        || (kind === "delivery" && Boolean(stringAttribute(attributes, "error.message")))
+        || attributes["agent.capability.outcome"] === "error";
       const approvalDenied = attributes["approval.approved"] === false;
       const completed = sorted.some(item => /\.(abort|cancelled|completed|decision|error|failed|finish|recorded)$/.test(item.name));
       const explicitRole = messageRole(attributes["message.role"]);
@@ -365,6 +402,7 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
           ? "user"
           : undefined);
       const command = commandDetails(attributes, sorted);
+      const skills = skillReadDetails(attributes);
       const observedEndedAt = sorted.at(-1)?.timestamp;
       const invocationEndedAt = invocation.completedAt ?? invocation.failedAt ?? invocation.cancelledAt;
       const started = /\.(request|start|started)$/.test(first.name);
@@ -397,6 +435,7 @@ export function invocationActivities(invocation: AgentInvocationView): Invocatio
         patches,
         paths,
         sequence: first.sequence,
+        ...(skills.length ? { skill: skills[0], skills } : {}),
         startedAt: terminalStartedAt ?? first.timestamp,
         ...(numericAttribute(attributes, "usage.reasoningTokens", "usage.reasoningOutputTokens") !== undefined
           ? { reasoningTokens: numericAttribute(attributes, "usage.reasoningTokens", "usage.reasoningOutputTokens") }
@@ -446,6 +485,7 @@ export function invocationActivityTitle(activity: InvocationActivity): string {
   if (hasRuntimeType(explicit, "string") && explicit.trim()) return explicit.trim();
   if (activity.name === "vitehub.observation.truncated") return "Trace content was truncated";
   if (activity.name === "vitehub.agent.configured") return "Agent configured";
+  if (activity.skill) return `Read ${activity.skill.name} skill`;
   if (activity.kind === "preparation") return "Prepared session";
   if (activity.kind === "system") return "System configuration";
   if (activity.kind === "delivery") return channelDeliveryTitle(activity);

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -78,7 +78,7 @@ export interface AgentInvocationConfiguration {
   workspace?: {
     mode?: string;
     name?: string;
-    sources?: readonly string[];
+    sources?: readonly (string | { id: string; repository?: string })[];
   };
 }
 
@@ -102,6 +102,11 @@ export interface AgentInvocationView {
   traceId: string;
   updatedAt: string;
   usage?: {
+    totalTokens?: number;
+    inputTokens?: number;
+    outputTokens?: number;
+    cachedInputTokens?: number;
+    reasoningTokens?: number;
     cost?: { display?: string };
   };
 }

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -106,7 +106,8 @@ export interface AgentInvocationView {
     inputTokens?: number;
     outputTokens?: number;
     cachedInputTokens?: number;
+    cacheWriteTokens?: number;
     reasoningTokens?: number;
-    cost?: { display?: string };
+    cost?: { display?: string; estimated?: boolean; source?: string };
   };
 }

--- a/packages/ui/styles.css
+++ b/packages/ui/styles.css
@@ -1046,7 +1046,8 @@
   padding: 0 0 0.1875rem;
 }
 
-.vh-invocation-preparation__steps > li {
+.vh-invocation-preparation__steps > li,
+.vh-invocation-preparation__step {
   align-items: center;
   color: var(--vh-ui-muted);
   display: grid;
@@ -1056,8 +1057,13 @@
   padding: 0 0.375rem;
 }
 
+.vh-invocation-preparation__step {
+  list-style: none;
+}
+
 .vh-invocation-preparation__body,
-.vh-invocation-preparation__steps .vh-invocation-event__notice {
+.vh-invocation-preparation__steps .vh-invocation-event__notice,
+.vh-invocation-preparation__step .vh-invocation-event__notice {
   grid-column: 2 / -1;
   margin: 0 0 0.375rem;
 }
@@ -1068,14 +1074,16 @@
   white-space: pre-wrap;
 }
 
-.vh-invocation-preparation__steps strong {
+.vh-invocation-preparation__steps strong,
+.vh-invocation-preparation__step strong {
   color: var(--vh-ui-text);
   flex: 0 0 auto;
   font-size: 0.75rem;
   font-weight: 500;
 }
 
-.vh-invocation-preparation__steps code {
+.vh-invocation-preparation__steps code,
+.vh-invocation-preparation__step code {
   color: var(--vh-ui-dimmed);
   flex: 0 1 auto;
   font-size: 0.6875rem;
@@ -1342,6 +1350,44 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   line-height: 1.25rem;
 }
 
+.vh-invocation-event__title-link {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  cursor: pointer;
+  font-family: inherit;
+  padding: 0;
+  text-align: start;
+}
+
+.vh-invocation-event__title-link:hover,
+.vh-invocation-event__title-link:focus-visible {
+  color: var(--vh-ui-text);
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+}
+
+.vh-invocation-image-details {
+  display: grid;
+  gap: 0.375rem;
+  min-width: 0;
+}
+
+.vh-invocation-image-details > strong {
+  color: var(--ui-text-muted);
+  font-size: 0.625rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.vh-invocation-image-details > code,
+.vh-invocation-image-details > pre {
+  margin: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
 .vh-invocation-event__suffix {
   color: var(--vh-ui-dimmed);
   flex: 1;
@@ -1432,6 +1478,54 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 
 .vh-invocation-work__details:not([open]) > .vh-invocation-work__activities {
   display: none;
+}
+
+.vh-invocation-work__activities > .vh-invocation-message[data-phase="commentary"] {
+  margin-block: 0.375rem;
+  padding: 0.125rem 0.25rem;
+}
+
+.vh-invocation-capabilities {
+  list-style: none;
+}
+
+.vh-invocation-capabilities__summary {
+  align-items: center;
+  color: var(--vh-ui-muted);
+  cursor: pointer;
+  display: flex;
+  font-size: 0.75rem;
+  gap: 0.375rem;
+  list-style: none;
+  min-height: 1.5rem;
+  padding: 0.125rem;
+}
+
+.vh-invocation-capabilities__summary::-webkit-details-marker {
+  display: none;
+}
+
+.vh-invocation-capabilities__summary > small {
+  color: var(--vh-ui-dimmed);
+  font-size: 0.6875rem;
+}
+
+.vh-invocation-capabilities__disclosure {
+  height: 0.75rem;
+  opacity: 0.65;
+  transition: transform 140ms ease;
+  width: 0.75rem;
+}
+
+.vh-invocation-capabilities__details[open] .vh-invocation-capabilities__disclosure {
+  transform: rotate(90deg);
+}
+
+.vh-invocation-capabilities__rows {
+  display: grid;
+  list-style: none;
+  margin: 0.25rem 0 0 1.625rem;
+  padding: 0;
 }
 
 .vh-invocation-history {
@@ -1912,6 +2006,13 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   text-transform: none;
 }
 
+.vh-invocation-inspector__title-row {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
+
 .vh-invocation-inspector__identity p {
   color: var(--vh-ui-dimmed);
   font-size: 0.75rem;
@@ -1994,23 +2095,17 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 }
 
 .vh-invocation-inspector__metrics {
-  border-block: 1px solid var(--vh-ui-border);
-  display: grid;
-  gap: 0;
-  grid-template-columns: repeat(auto-fit, minmax(6rem, 1fr));
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1rem;
   margin: 0;
 }
 
 .vh-invocation-inspector__metrics > div {
-  background: transparent;
-  border: 0;
-  border-radius: 0;
+  align-items: baseline;
+  display: flex;
+  gap: 0.35rem;
   min-width: 0;
-  padding: 0.6rem 0.65rem;
-}
-
-.vh-invocation-inspector__metrics > div + div {
-  border-inline-start: 1px solid var(--vh-ui-border);
 }
 
 .vh-invocation-inspector__metrics dt {
@@ -2169,9 +2264,8 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
 }
 
 .vh-invocation-execution {
-  background: var(--vh-ui-bg-elevated);
-  border: 1px solid var(--vh-ui-border);
-  border-radius: 0.75rem;
+  background: transparent;
+  border: 0;
   margin-block-start: 0.6rem;
   overflow: hidden;
 }
@@ -2182,17 +2276,50 @@ details.vh-invocation-event > .vh-invocation-event__summary:hover {
   display: flex;
   gap: 0.75rem;
   min-width: 0;
-  padding: 0.9rem;
+  padding: 0.25rem 0;
 }
 
 .vh-invocation-execution__workspace {
   gap: 0.75rem;
-  padding-block: 0.75rem;
+  padding-block: 0.25rem;
 }
 
 .vh-invocation-execution > * + * {
-  border-block-start: 1px solid var(--vh-ui-border);
+  border-block-start: 0;
+  margin-block-start: 0.35rem;
 }
+
+.vh-invocation-inspector__badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-block-start: 0.45rem;
+}
+
+.vh-invocation-inspector__badge {
+  align-items: center;
+  background: var(--vh-ui-bg-elevated);
+  border: 1px solid var(--vh-ui-border);
+  border-radius: 999px;
+  color: var(--vh-ui-muted);
+  display: inline-flex;
+  font-size: 0.6875rem;
+  gap: 0.3rem;
+  max-width: 100%;
+  min-height: 1.5rem;
+  overflow: hidden;
+  padding: 0.15rem 0.5rem;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+a.vh-invocation-inspector__badge:hover {
+  border-color: var(--vh-ui-border-strong);
+  color: var(--vh-ui-text);
+}
+
+.vh-invocation-inspector__badge svg { height: 0.75rem; width: 0.75rem; }
 
 .vh-invocation-execution__details {
   display: grid;
@@ -2395,9 +2522,8 @@ summary.vh-invocation-inspector__group-heading:focus-visible,
 }
 
 .vh-invocation-inspector__copy-list {
-  border: 1px solid var(--vh-ui-border);
-  border-radius: calc(var(--vh-ui-radius) * 1.05);
-  overflow: hidden;
+  display: flex;
+  gap: 0.35rem;
 }
 
 .vh-invocation-inspector__copy {
@@ -2407,32 +2533,27 @@ summary.vh-invocation-inspector__group-heading:focus-visible,
   border: 0;
   color: var(--vh-ui-muted);
   cursor: pointer;
-  display: grid;
+  border-radius: calc(var(--vh-ui-radius) * 0.8);
+  display: inline-flex;
   font: inherit;
   gap: 0.5rem;
-  grid-template-columns: minmax(0, 1fr) auto 1rem;
-  min-height: 2.4rem;
-  padding: 0.45rem 0.65rem;
+  min-height: 1.75rem;
+  padding: 0.3rem 0.45rem;
   text-align: start;
   transition:
     background-color 120ms ease,
     color 120ms ease;
-  width: 100%;
+  width: auto;
 }
 
 .vh-invocation-inspector__copy + .vh-invocation-inspector__copy {
-  border-block-start: 1px solid var(--vh-ui-border);
+  border-block-start: 0;
 }
 
 .vh-invocation-inspector__copy-label {
   color: var(--vh-ui-text);
   font-size: 0.75rem;
   min-width: 0;
-}
-
-.vh-invocation-inspector__copy-state {
-  color: var(--vh-ui-dimmed);
-  font-size: 0.625rem;
 }
 
 .vh-invocation-inspector__copy:hover,
@@ -2801,7 +2922,7 @@ summary.vh-invocation-inspector__group-heading:focus-visible,
   text-transform: none;
 }
 
-.vh-invocation-session__timestamp { display: block; color: var(--ui-text-muted); font-size: 0.6875rem; margin-block: 0.5rem; font-variant-numeric: tabular-nums; }
+.vh-invocation-session__timestamp { display: block; color: var(--ui-text-muted); font-size: 0.6875rem; margin-block: 0.5rem; font-variant-numeric: tabular-nums; text-align: center; }
 .vh-invocation-error { margin-block: 0.75rem; min-width: 0; }
 .vh-invocation-error__message { display: -webkit-box; -webkit-line-clamp: 3; -webkit-box-orient: vertical; overflow: hidden; overflow-wrap: anywhere; }
 .vh-invocation-error__recovery { margin-block-start: 0.5rem; }

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -6,7 +6,7 @@ import { renderToString } from "@vue/server-renderer";
 import { describe, expect, it, vi } from "vitest";
 import type { UIMessage } from "ai";
 import { AgentInvocationList } from "../src/components/agent-invocation-list.ts";
-import { AgentInvocation, AgentInvocationInspector } from "../src/components/agent-invocation.ts";
+import { AgentInvocation, AgentInvocationInspector, workspaceArtifactPath } from "../src/components/agent-invocation.ts";
 import { AgentMessageParts } from "../src/components/agent-message-parts.ts";
 import { channelIcon } from "../src/internal/channel-icon.ts";
 import { invocationActivities, invocationActivityTitle } from "../src/internal/invocation-activity.ts";
@@ -14,6 +14,31 @@ import { invocationActivities, invocationActivityTitle } from "../src/internal/i
 import type { AgentInvocationView } from "../src/types.ts";
 
 describe("Agent Invocation UI", () => {
+  it("recognizes safe absolute provider Workspace artifact links", () => {
+    expect(workspaceArtifactPath("/workspace/vitehub-provider-DjQaJy/artifacts/source-map.html")).toBe("artifacts/source-map.html");
+    expect(workspaceArtifactPath("/workspace/run/../.env")).toBeUndefined();
+  });
+
+  it("opens provider Workspace artifact links through the inspector", async () => {
+    const wrapper = mount(AgentInvocation, { props: { invocation: {
+      createdAt: "2026-09-08T00:00:00.000Z",
+      id: "artifact-run",
+      observations: [{
+        attributes: { "message.content": "[Source map](/workspace/provider-session/artifacts/source-map.html)", "message.id": "answer", "message.role": "assistant" },
+        name: "agent.message",
+        sequence: 1,
+        timestamp: "2026-09-08T00:00:01.000Z",
+        type: "lifecycle",
+      }],
+      status: "completed",
+      updatedAt: "2026-09-08T00:00:01.000Z",
+    } } });
+    const link = document.createElement("a");
+    link.href = "/workspace/provider-session/artifacts/source-map.html";
+    wrapper.element.append(link);
+    link.dispatchEvent(new MouseEvent("click", { bubbles: true, button: 0, cancelable: true }));
+    expect(wrapper.emitted("inspect")?.at(-1)).toEqual(["workspace", "artifacts/source-map.html"]);
+  });
   it.each(["ticketing", "constructor", "<custom-channel>"])("renders %s with a neutral Channel mark and its own label", (origin) => {
     const wrapper = mount({ render: () => channelIcon(origin) });
     const custom = mount({ render: () => channelIcon("application-channel") });
@@ -32,6 +57,26 @@ describe("Agent Invocation UI", () => {
     const github = mount({ render: () => channelIcon("github") });
     expect(wrapper.attributes("aria-label")).toBe("GitHub");
     expect(wrapper.get("svg").html()).toBe(github.get("svg").html());
+  });
+
+  it("normalizes the Microsoft Teams channel kind", () => {
+    const wrapper = mount({ render: () => channelIcon("msteams") });
+    expect(wrapper.attributes("aria-label")).toBe("Microsoft Teams");
+  });
+
+  it("uses channel marks for configured invocation channels", () => {
+    const timestamp = "2026-09-08T00:00:00.000Z";
+    const wrapper = mount(AgentInvocationInspector, { props: { invocation: {
+      configuration: { channels: [{ id: "support", kind: "msteams" }, { id: "records", kind: "airtable" }] },
+      createdAt: timestamp,
+      id: "configured-channels",
+      observations: [],
+      status: "completed",
+      traceId: "trace",
+      updatedAt: timestamp,
+    } } });
+    const icons = wrapper.findAll(".vh-invocation-inspector__badge .vh-channel-icon");
+    expect(icons.map(icon => icon.attributes("aria-label"))).toEqual(["Microsoft Teams", "airtable"]);
   });
 
   it("hydrates message timestamps before applying browser locale formatting", async () => {
@@ -456,6 +501,7 @@ describe("Agent Invocation UI", () => {
     ]);
 
     const wrapper = mount(AgentInvocation, { props: { invocation } });
+    expect(wrapper.get(".vh-invocation-capabilities__summary").text()).toContain("Agent configured");
     expect(wrapper.get('[data-kind="system"] .vh-invocation-event__suffix').text()).toBe("claude-sonnet-4-5 · 2 capabilities · 1 tool");
     const system = wrapper.get('[data-kind="system"]');
     expect(system.get("summary").element.tagName).toBe("SUMMARY");
@@ -1156,6 +1202,166 @@ describe("Agent Invocation UI", () => {
       exitCode: 0,
       output: "clean",
     });
+  });
+
+  it("links structured workspace skill reads without inferring them from command text", async () => {
+    const timestamp = "2026-08-22T00:00:00.000Z";
+    const skillPath = ".agents/skills/quiver-evidence/SKILL.md";
+    const invocation = {
+      createdAt: timestamp,
+      id: "skill-read",
+      observations: [{
+        attributes: {
+          "tool.id": "skill",
+          "tool.input": {
+            item: {
+              command: "/bin/sh -lc 'cat .agents/skills/quiver-evidence/SKILL.md'",
+              commandActions: [{
+                command: "cat .agents/skills/quiver-evidence/SKILL.md",
+                name: "SKILL.md",
+                path: `/workspace/capsule/${skillPath}`,
+                type: "read",
+              }],
+              cwd: "/workspace/capsule",
+            },
+          },
+          "tool.name": "Ran command",
+        },
+        name: "agent.tool.finish",
+        sequence: 1,
+        timestamp,
+        type: "run" as const,
+      }, {
+        attributes: {
+          "tool.id": "mention-only",
+          "tool.input": { command: "echo .agents/skills/not-used/SKILL.md" },
+          "tool.name": "Ran command",
+        },
+        name: "agent.tool.finish",
+        sequence: 2,
+        timestamp,
+        type: "run" as const,
+      }, ...["../outside", ".agents/skills/../other/SKILL.md", ".agents//skills/other/SKILL.md", ".agents\\skills\\other\\SKILL.md"].map((path, index) => ({
+        attributes: {
+          "tool.id": `invalid-skill-${index}`,
+          "tool.input": {
+            item: {
+              commandActions: [{ path, type: "read" }],
+              cwd: "/workspace/capsule",
+            },
+          },
+          "tool.name": "Ran command",
+        },
+        name: "agent.tool.finish",
+        sequence: index + 3,
+        timestamp,
+        type: "run" as const,
+      }))],
+      status: "completed" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+
+    const activities = invocationActivities(invocation);
+    expect(activities[0]?.skill).toEqual({ name: "quiver-evidence", path: skillPath });
+    expect(invocationActivityTitle(activities[0]!)).toBe("Read quiver-evidence skill");
+    expect(activities[1]?.skill).toBeUndefined();
+    expect(activities.slice(2).every(activity => activity.skill === undefined)).toBe(true);
+
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    await wrapper.get('[data-activity-id="skill"] .vh-invocation-event__title-link').trigger("click");
+    expect(wrapper.emitted("inspect")).toEqual([["workspace", skillPath]]);
+
+    const withoutWorkspace = mount(AgentInvocation, { props: { invocation, workspaceInspectable: false } });
+    expect(withoutWorkspace.find(".vh-invocation-event__title-link").exists()).toBe(false);
+  });
+
+  it("links every literal skill path in a structured cat action", async () => {
+    const timestamp = "2026-09-08T00:00:00.000Z";
+    const invocation = {
+      createdAt: timestamp,
+      id: "literal-cat-skill-reads",
+      observations: [{
+        attributes: {
+          "tool.id": "cat-skills",
+          "tool.input": { item: {
+            commandActions: [{
+              command: "cat AGENTS.md .agents/skills/show-me/SKILL.md .agents/skills/unslop/SKILL.md",
+              type: "unknown",
+            }],
+            cwd: "/workspace/capsule",
+          } },
+          "tool.name": "Ran command",
+        },
+        name: "agent.tool.finish",
+        sequence: 1,
+        timestamp,
+        type: "run" as const,
+      }, {
+        attributes: {
+          "tool.id": "not-cat",
+          "tool.input": { item: { commandActions: [{ command: "echo .agents/skills/not-read/SKILL.md", type: "unknown" }] } },
+          "tool.name": "Ran command",
+        },
+        name: "agent.tool.finish",
+        sequence: 2,
+        timestamp,
+        type: "run" as const,
+      }],
+      status: "completed" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+
+    const activities = invocationActivities(invocation);
+    expect(activities[0]?.skills).toEqual([
+      { name: "show-me", path: ".agents/skills/show-me/SKILL.md" },
+      { name: "unslop", path: ".agents/skills/unslop/SKILL.md" },
+    ]);
+    expect(activities[1]?.skills).toBeUndefined();
+
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    const links = wrapper.findAll('[data-activity-id="cat-skills"] .vh-invocation-event__title-link');
+    expect(links.map(link => link.text())).toEqual(["Read show-me skill", "Read unslop skill"]);
+    expect(wrapper.get('[data-activity-id="cat-skills"] .vh-invocation-event__disclosure').exists()).toBe(true);
+    await links[0]!.trigger("click");
+    await links[1]!.trigger("click");
+    expect(wrapper.emitted("inspect")).toEqual([
+      ["workspace", ".agents/skills/show-me/SKILL.md"],
+      ["workspace", ".agents/skills/unslop/SKILL.md"],
+    ]);
+  });
+
+  it("presents image-view tools as one readable disclosure", () => {
+    const timestamp = "2026-09-08T00:00:00.000Z";
+    const invocation = {
+      createdAt: timestamp,
+      id: "image-view",
+      observations: [{
+        attributes: {
+          "tool.id": "image",
+          "tool.input": { item: { id: "exec-9f5", path: "/tmp/source-map.png", type: "imageView" } },
+          "tool.name": "Image view",
+          "tool.output": { completedAtMs: 1_788_851, item: { path: "/tmp/source-map.png" } },
+        },
+        name: "agent.tool.finish",
+        sequence: 1,
+        timestamp,
+        type: "run" as const,
+      }],
+      status: "completed" as const,
+      traceId: "trace",
+      updatedAt: timestamp,
+    } satisfies AgentInvocationView;
+
+    const row = mount(AgentInvocation, { props: { invocation } }).get('[data-activity-id="image"]');
+    expect(row.get(".vh-invocation-event__title").text()).toBe("View image");
+    expect(row.get(".vh-invocation-event__suffix").text()).toBe("source-map.png");
+    expect(row.get('[data-icon="eye"]').exists()).toBe(true);
+    expect(row.findAll("details")).toHaveLength(1);
+    expect(row.findAll(".vh-invocation-event__payload")).toHaveLength(0);
+    expect(row.get(".vh-invocation-image-details").text()).toContain("/tmp/source-map.png");
+    expect(row.get(".vh-invocation-image-details pre").text()).toContain('"completedAtMs": 1788851');
   });
 
   it("explores structured tool payloads and selects a timed trace activity", async () => {
@@ -1886,8 +2092,7 @@ describe("Agent Invocation UI", () => {
 
     expect(writeText).toHaveBeenCalledWith(invocation.traceId);
     expect(copy.attributes("aria-label")).toBe("Trace ID copied");
-    expect(copy.text()).toContain("Copied");
-    expect(copy.find(".vh-invocation-inspector__copy-state").attributes("aria-live")).toBeUndefined();
+    expect(copy.find(".vh-invocation-inspector__copy-icon").exists()).toBe(true);
     expect(wrapper.get('[role="status"]').text()).toBe("Trace ID copied");
     wrapper.unmount();
   });
@@ -1911,7 +2116,7 @@ describe("Agent Invocation UI", () => {
     await Promise.resolve();
 
     expect(wrapper.get('[role="status"]').text()).toBe("Trace ID could not be copied");
-    expect(wrapper.get('button[aria-label="Copy Trace ID"]').text()).toContain("Copy");
+    expect(wrapper.get('button[aria-label="Copy Trace ID"]').find(".vh-invocation-inspector__copy-icon").exists()).toBe(true);
 
     const status = wrapper.get('[role="status"]');
     await wrapper.get('button[aria-label="Copy Trace ID"]').trigger("click");
@@ -2698,7 +2903,92 @@ describe("Agent Invocation UI", () => {
     const activities = wrapper.get(".vh-invocation-work__activities");
     expect(activities.text()).toContain("Checking the fix.");
     expect(activities.text().indexOf("Checking the fix.")).toBeLessThan(activities.text().indexOf("Shell"));
+    const commentary = activities.get('.vh-invocation-message[data-phase="commentary"]');
+    expect(commentary.find(".vh-invocation-message__meta").exists()).toBe(false);
     wrapper.unmount();
+  });
+
+  it("keeps provider summary and commentary items as separate markdown blocks", async () => {
+    const timestamp = "2026-08-24T00:00:00.000Z";
+    const invocation: AgentInvocationView = {
+      createdAt: timestamp,
+      id: "reasoning-commentary-boundary",
+      observations: [
+        { attributes: { "input.messages": [{ id: "prompt", role: "user", parts: [{ type: "text", text: "Check this" }] }] }, name: "agent.input", sequence: 1, timestamp, type: "run" },
+        { attributes: { "message.content": "**Reading related facts**", "message.id": "reasoning_summary_text:turn", "message.phase": "commentary", "message.role": "assistant" }, name: "agent.message.delta", sequence: 2, timestamp, type: "lifecycle" },
+        { attributes: { "message.content": "I’m also applying the evidence skill.", "message.id": "assistant_text:comment", "message.phase": "commentary", "message.role": "assistant" }, name: "agent.message.delta", sequence: 3, timestamp, type: "lifecycle" },
+        { attributes: { "tool.id": "check", "tool.name": "search" }, name: "agent.tool.start", sequence: 4, timestamp, type: "run" },
+      ],
+      status: "running",
+      traceId: "trace",
+      updatedAt: timestamp,
+    };
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    const work = wrapper.get(".vh-invocation-work__details");
+    if (!(work.element instanceof HTMLDetailsElement)) throw new TypeError("Expected work details");
+    work.element.open = true;
+    await work.trigger("toggle");
+    const rows = wrapper.get(".vh-invocation-work__activities").findAll(":scope > li");
+    expect(rows[0]!.attributes("data-phase")).toBe("commentary");
+    expect(rows[0]!.text()).toContain("Reading related facts");
+    expect(rows[1]!.attributes("data-phase")).toBe("commentary");
+    expect(rows[1]!.text()).toContain("I’m also applying the evidence skill.");
+    expect(rows[0]!.text()).not.toContain("I’m also applying");
+    expect(rows[1]!.find(".vh-invocation-message__meta").exists()).toBe(false);
+  });
+
+  it("folds consecutive capability lifecycle evidence into one quiet row", async () => {
+    const timestamp = "2026-08-24T00:00:00.000Z";
+    const invocation: AgentInvocationView = {
+      createdAt: timestamp,
+      id: "capability-lifecycle",
+      observations: [
+        { attributes: { "input.messages": [{ id: "prompt", role: "user", parts: [{ type: "text", text: "Run it" }] }] }, name: "agent.input", sequence: 1, timestamp, type: "run" },
+        { attributes: { "agent.capability.id": "workspace", "agent.capability.outcome": "success" }, name: "agent.capability.input", sequence: 2, timestamp, type: "run" },
+        { attributes: { "agent.capability.id": "workspace", "agent.capability.outcome": "success" }, name: "agent.capability.output", sequence: 3, timestamp, type: "run" },
+        { attributes: { "agent.capability.id": "workspace", "agent.capability.outcome": "success" }, name: "agent.capability.configure", sequence: 4, timestamp, type: "run" },
+        { attributes: { "agent.capability.id": "sources", "agent.capability.outcome": "success" }, name: "agent.capability.prepare", sequence: 5, timestamp, type: "run" },
+        { attributes: { "agent.capability.id": "sources", "agent.capability.outcome": "success" }, name: "agent.capability.resolve", sequence: 6, timestamp, type: "run" },
+        { attributes: { "agent.capability.id": "sources", "agent.capability.outcome": "error" }, name: "agent.capability.close", sequence: 7, timestamp, type: "run" },
+      ],
+      status: "running",
+      traceId: "trace",
+      updatedAt: timestamp,
+    };
+    const wrapper = mount(AgentInvocation, { props: { invocation } });
+    const group = wrapper.get(".vh-invocation-capabilities__details");
+    expect(group.get("summary").text()).toContain("Capability activity failed · 2 capabilities");
+    expect(group.get("summary").text()).toContain("2 capabilities");
+    expect(group.get("summary").find('[data-icon="activity"]').exists()).toBe(false);
+    expect(group.findAll(".vh-invocation-capabilities__rows > li")).toHaveLength(6);
+    expect(group.get('[data-activity-id="observation:7"]').attributes("data-status")).toBe("failed");
+    expect((group.element as HTMLDetailsElement).open).toBe(false);
+
+    const successful = mount(AgentInvocation, { props: { invocation: {
+      ...invocation,
+      observations: invocation.observations.map(observation => ({
+        ...observation,
+        attributes: { ...observation.attributes, "agent.capability.outcome": "success" },
+      })),
+    } } });
+    expect(successful.get(".vh-invocation-capabilities__summary").text()).toBe("Prepared 2 capabilities");
+  });
+
+  it("uses a generic capability summary when lifecycle events omit capability IDs", () => {
+    const timestamp = "2026-08-24T00:00:00.000Z";
+    const invocation: AgentInvocationView = {
+      createdAt: timestamp,
+      id: "anonymous-capability-lifecycle",
+      observations: [
+        { attributes: {}, name: "agent.capability.configure", sequence: 1, timestamp, type: "run" },
+        { attributes: {}, name: "agent.capability.prepare", sequence: 2, timestamp, type: "run" },
+      ],
+      status: "running",
+      traceId: "trace",
+      updatedAt: timestamp,
+    };
+    const summary = mount(AgentInvocation, { props: { invocation } }).get(".vh-invocation-capabilities__summary").text();
+    expect(summary).toContain("Capability activity · 2 events");
   });
 
   it.each([
@@ -2896,10 +3186,13 @@ describe("Agent Invocation UI", () => {
     if (!(work.element instanceof HTMLDetailsElement)) throw new TypeError("Expected work details");
     work.element.open = true;
     await work.trigger("toggle");
-    expect(wrapper.get(".vh-invocation-preparation__summary").text()).toContain("Session prepared");
-    expect(wrapper.get(".vh-invocation-preparation__summary").text()).toContain("2 steps");
-    expect(wrapper.get('.vh-invocation-preparation__context a').attributes("href")).toBe(invocation.annotations["github.url"]);
-    await wrapper.get(".vh-invocation-preparation__summary").trigger("click");
+    expect(wrapper.get(".vh-invocation-preparation__summary").text()).toBe("Prepared workspace");
+    expect(wrapper.findAll(".vh-invocation-preparation__steps > li")).toHaveLength(2);
+    const preparation = wrapper.get(".vh-invocation-preparation__details");
+    if (!(preparation.element instanceof HTMLDetailsElement)) throw new TypeError("Expected preparation details");
+    preparation.element.open = true;
+    await preparation.trigger("toggle");
+    expect(wrapper.get('.vh-invocation-preparation__steps .vh-invocation-preparation__context a').attributes("href")).toBe(invocation.annotations["github.url"]);
     await wrapper.get('button[aria-label="Open Workspace"]').trigger("click");
     expect(wrapper.emitted("inspect")).toEqual([["workspace"]]);
 
@@ -2910,7 +3203,7 @@ describe("Agent Invocation UI", () => {
     if (!(withoutWorkspaceWork.element instanceof HTMLDetailsElement)) throw new TypeError("Expected work details");
     withoutWorkspaceWork.element.open = true;
     await withoutWorkspaceWork.trigger("toggle");
-    await withoutWorkspace.get(".vh-invocation-preparation__summary").trigger("click");
+    expect(withoutWorkspace.get(".vh-invocation-preparation__summary").text()).toBe("Prepared workspace");
     expect(withoutWorkspace.find('button[aria-label="Open Workspace"]').exists()).toBe(false);
 
     const prompt = wrapper.findAll('.vh-invocation-message[data-role="user"]').at(-1)!;
@@ -2920,7 +3213,7 @@ describe("Agent Invocation UI", () => {
 
     expect(wrapper.get(".vh-invocation-work__title").text()).toBe("Worked for 2m 43s");
     expect(wrapper.get(".vh-invocation-work__summary").element.firstElementChild?.classList).toContain("vh-invocation-work__disclosure");
-    expect(wrapper.find(".vh-invocation-work__summary .vh-invocation-framework-mark").exists()).toBe(true);
+    expect(wrapper.find(".vh-invocation-work__summary .vh-invocation-framework-mark").exists()).toBe(false);
     expect(wrapper.get(".vh-invocation-framework-mark").attributes("style")).toBeUndefined();
     expect(wrapper.get(".vh-invocation-work__activities").text()).toContain("Checked the diff.");
     expect(wrapper.findAll('.vh-invocation-message[data-role="assistant"]').at(-1)!.text()).toContain("Merged after checks passed.");
@@ -3233,6 +3526,23 @@ describe("Agent Invocation UI", () => {
     expect(wrapper.get('[role="note"]').text()).toContain("Some setup values were shortened");
   });
 
+  it("does not label a historical response breakdown as invocation usage", () => {
+    const wrapper = mount(AgentInvocationInspector, { props: { invocation: {
+      createdAt: "2026-09-08T00:00:00.000Z",
+      id: "historic-usage",
+      observations: [],
+      status: "completed",
+      traceId: "trace",
+      updatedAt: "2026-09-08T00:01:00.000Z",
+      usage: { totalTokens: 59222, inputTokens: 21267, outputTokens: 118, cachedInputTokens: 20352 },
+    } } });
+    const summary = wrapper.get(".vh-invocation-inspector__metrics").text();
+    expect(summary).toContain("Tokens59,222");
+    expect(summary).not.toContain("Input");
+    expect(summary).not.toContain("Output");
+    expect(summary).not.toContain("Cached");
+  });
+
   it("groups recorded Agent Definition details as captured setup", () => {
     const invocation: AgentInvocationView = {
       configuration: {
@@ -3250,7 +3560,7 @@ describe("Agent Invocation UI", () => {
           },
           { description: "Search the workspace.", name: "search" },
         ],
-        workspace: { mode: "write", name: "babysitter", sources: ["github:vite-hub/vitehub"] },
+        workspace: { mode: "write", name: "babysitter", sources: [{ id: "vitehub", repository: "vite-hub/vitehub" }] },
       },
       createdAt: "2026-08-24T00:00:00.000Z",
       id: "configured",
@@ -3274,18 +3584,28 @@ describe("Agent Invocation UI", () => {
       traceId: "trace",
       updatedAt: "2026-08-24T00:00:01.000Z",
     };
+    invocation.usage = { totalTokens: 1200, inputTokens: 1100, outputTokens: 100, cachedInputTokens: 0 };
     const wrapper = mount(AgentInvocationInspector, { props: { invocation } });
+
+    const summary = wrapper.get(".vh-invocation-inspector__metrics").text();
+    expect(summary).toContain("Tokens1,200");
+    expect(summary).toContain("Input1,100");
+    expect(summary).toContain("Output100");
+    expect(summary).toContain("Cached0");
+    expect(summary).not.toContain("Reasoning");
+    expect(summary).toContain("CostUnknown");
 
     expect(wrapper.get(".vh-invocation-inspector__group--execution").text()).toContain("GPT 5.6 Sol");
     expect(wrapper.get(".vh-invocation-inspector__content").text()).toContain("OpenAI");
     expect(wrapper.find(".vh-invocation-execution__model-icon path").exists()).toBe(true);
-    expect(wrapper.get(".vh-invocation-execution__workspace svg").attributes("stroke")).toBe("currentColor");
-    expect(wrapper.get(".vh-invocation-execution__workspace").text()).toContain("Read and write");
+    expect(wrapper.find(".vh-invocation-execution__workspace").exists()).toBe(false);
     expect(wrapper.get(".vh-invocation-inspector__content").text()).toContain("node");
     expect(wrapper.get(".vh-invocation-inspector__agent").text()).toContain("v2");
-    expect(wrapper.get(".vh-invocation-inspector__groups").text()).toContain("reviews · github");
+    expect(wrapper.get(".vh-invocation-inspector__groups").text()).toContain("reviews");
+    expect(wrapper.get(".vh-invocation-inspector__badges").find("svg").exists()).toBe(true);
     expect(wrapper.findAll(".vh-invocation-inspector__content > section h4").map(node => node.text())).toContain("Agent setup");
     expect(wrapper.get(".vh-invocation-inspector__groups").text()).toContain("Instructions");
+    expect(wrapper.get('.vh-invocation-inspector__badge[href="https://github.com/vite-hub/vitehub"]').text()).toBe("vitehub");
     expect(wrapper.get(".vh-agent-tool-list__disclosure").text()).toContain("Run a shell command.");
     expect(wrapper.get(".vh-agent-tool-list__schema").text()).toContain("command");
     expect(wrapper.get(".vh-invocation-inspector__group--execution").text()).toContain("GPT 5.6 Sol");

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -3535,13 +3535,32 @@ describe("Agent Invocation UI", () => {
       status: "completed",
       traceId: "trace",
       updatedAt: "2026-09-08T00:01:00.000Z",
-      usage: { totalTokens: 59222, inputTokens: 21267, outputTokens: 118, cachedInputTokens: 20352 },
+      usage: { totalTokens: 59222, inputTokens: 21267, outputTokens: 118, cachedInputTokens: 20352, cacheWriteTokens: 100 },
     } } });
     const summary = wrapper.get(".vh-invocation-inspector__metrics").text();
     expect(summary).toContain("Tokens59,222");
     expect(summary).not.toContain("Input");
     expect(summary).not.toContain("Output");
     expect(summary).not.toContain("Cached");
+    expect(summary).not.toContain("Cache writes");
+  });
+
+  it.each([true, false])("preserves cache writes and the cost estimate qualifier (%s)", estimated => {
+    const wrapper = mount(AgentInvocationInspector, { props: { invocation: {
+      createdAt: "2026-09-08T00:00:00.000Z",
+      id: "usage-details",
+      observations: [],
+      status: "completed",
+      traceId: "trace",
+      updatedAt: "2026-09-08T00:01:00.000Z",
+      usage: {
+        totalTokens: 1200, inputTokens: 1100, outputTokens: 100, cacheWriteTokens: 1024,
+        cost: { display: "$0.01", estimated, source: estimated ? "pricing" : "provider" },
+      },
+    } } });
+    const summary = wrapper.get(".vh-invocation-inspector__metrics").text();
+    expect(summary).toContain("Cache writes1,024");
+    expect(summary).toContain(`Cost$0.01 (${estimated ? "estimated" : "reported"})`);
   });
 
   it("groups recorded Agent Definition details as captured setup", () => {
@@ -3585,7 +3604,7 @@ describe("Agent Invocation UI", () => {
       traceId: "trace",
       updatedAt: "2026-08-24T00:00:01.000Z",
     };
-    invocation.usage = { totalTokens: 1200, inputTokens: 1100, outputTokens: 100, cachedInputTokens: 0 };
+    invocation.usage = { totalTokens: 1200, inputTokens: 1100, outputTokens: 100, cachedInputTokens: 0, cacheWriteTokens: 0 };
     const wrapper = mount(AgentInvocationInspector, { props: { invocation } });
 
     const summary = wrapper.get(".vh-invocation-inspector__metrics").text();
@@ -3593,6 +3612,7 @@ describe("Agent Invocation UI", () => {
     expect(summary).toContain("Input1,100");
     expect(summary).toContain("Output100");
     expect(summary).toContain("Cached0");
+    expect(summary).toContain("Cache writes0");
     expect(summary).not.toContain("Reasoning");
     expect(summary).toContain("CostUnknown");
 

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -23,6 +23,7 @@ describe("Agent Invocation UI", () => {
     const wrapper = mount(AgentInvocation, { props: { invocation: {
       createdAt: "2026-09-08T00:00:00.000Z",
       id: "artifact-run",
+      traceId: "artifact-trace",
       observations: [{
         attributes: { "message.content": "[Source map](/workspace/provider-session/artifacts/source-map.html)", "message.id": "answer", "message.role": "assistant" },
         name: "agent.message",
@@ -1323,7 +1324,7 @@ describe("Agent Invocation UI", () => {
     const wrapper = mount(AgentInvocation, { props: { invocation } });
     const links = wrapper.findAll('[data-activity-id="cat-skills"] .vh-invocation-event__title-link');
     expect(links.map(link => link.text())).toEqual(["Read show-me skill", "Read unslop skill"]);
-    expect(wrapper.get('[data-activity-id="cat-skills"] .vh-invocation-event__disclosure').exists()).toBe(true);
+    expect(wrapper.find('[data-activity-id="cat-skills"] .vh-invocation-event__disclosure').exists()).toBe(true);
     await links[0]!.trigger("click");
     await links[1]!.trigger("click");
     expect(wrapper.emitted("inspect")).toEqual([
@@ -1357,7 +1358,7 @@ describe("Agent Invocation UI", () => {
     const row = mount(AgentInvocation, { props: { invocation } }).get('[data-activity-id="image"]');
     expect(row.get(".vh-invocation-event__title").text()).toBe("View image");
     expect(row.get(".vh-invocation-event__suffix").text()).toBe("source-map.png");
-    expect(row.get('[data-icon="eye"]').exists()).toBe(true);
+    expect(row.find('[data-icon="eye"]').exists()).toBe(true);
     expect(row.findAll("details")).toHaveLength(1);
     expect(row.findAll(".vh-invocation-event__payload")).toHaveLength(0);
     expect(row.get(".vh-invocation-image-details").text()).toContain("/tmp/source-map.png");
@@ -3606,6 +3607,7 @@ describe("Agent Invocation UI", () => {
     expect(wrapper.findAll(".vh-invocation-inspector__content > section h4").map(node => node.text())).toContain("Agent setup");
     expect(wrapper.get(".vh-invocation-inspector__groups").text()).toContain("Instructions");
     expect(wrapper.get('.vh-invocation-inspector__badge[href="https://github.com/vite-hub/vitehub"]').text()).toBe("vitehub");
+    expect(wrapper.get('.vh-invocation-inspector__badge[href="https://github.com/vite-hub/vitehub"] .vh-channel-icon').attributes("aria-label")).toBe("GitHub");
     expect(wrapper.get(".vh-agent-tool-list__disclosure").text()).toContain("Run a shell command.");
     expect(wrapper.get(".vh-agent-tool-list__schema").text()).toContain("command");
     expect(wrapper.get(".vh-invocation-inspector__group--execution").text()).toContain("GPT 5.6 Sol");

--- a/packages/ui/test/invocation-ui.test.ts
+++ b/packages/ui/test/invocation-ui.test.ts
@@ -17,6 +17,10 @@ describe("Agent Invocation UI", () => {
   it("recognizes safe absolute provider Workspace artifact links", () => {
     expect(workspaceArtifactPath("/workspace/vitehub-provider-DjQaJy/artifacts/source-map.html")).toBe("artifacts/source-map.html");
     expect(workspaceArtifactPath("/workspace/run/../.env")).toBeUndefined();
+    expect(workspaceArtifactPath("/workspace/run/report.html#summary")).toBe("report.html");
+    expect(workspaceArtifactPath("/workspace/run/image.png?download=1#preview")).toBe("image.png");
+    expect(workspaceArtifactPath("/workspace/run/report%23summary%3Fdraft.html?download=1")).toBe("report#summary?draft.html");
+    expect(workspaceArtifactPath("/workspace/run/%2e%2e/.env?download=1")).toBeUndefined();
   });
 
   it("opens provider Workspace artifact links through the inspector", async () => {

--- a/packages/vite-hub/src/console/runtime/components/console-app.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-app.vue
@@ -24,7 +24,7 @@ import {
   resolveConsoleRouteName,
 } from "../console-route";
 import { isRetryableConsoleRequestError, requestConsole } from "../client/request";
-import { rememberConsoleSection } from "../sections";
+import { consoleSectionDetails, rememberConsoleSection } from "../sections";
 import ConsoleFrame from "./console-frame.vue";
 import ConsolePrimitiveSwitcher from "./console-primitive-switcher.vue";
 import ConsoleInvocationComposer from "./console-invocation-composer.vue";
@@ -81,8 +81,8 @@ const sessionsOpen = ref(false);
 const detailsOpen = ref(false);
 const detailsMaximized = ref(false);
 const inspectorTab = ref<"details" | "trace" | "workspace">("details");
-const inspectorActiveSurface = ref("view:details");
-const inspectorOpenViews = ref<Array<"details" | "trace" | "workspace">>(["details"]);
+const inspectorActiveSurface = ref("");
+const inspectorOpenViews = ref<Array<"details" | "trace" | "workspace">>([]);
 const inspectorOpenPaths = ref<string[]>([]);
 const inspectorSelectedPath = ref<string>();
 const inspectorWorkspaceIdentity = ref<string>();
@@ -239,6 +239,9 @@ const invocationView = computed<AgentInvocationView | undefined>(() => {
   return view;
 });
 const selectedDisplay = computed(() => invocationView.value ?? selectedSummary.value);
+const selectedRefreshable = computed(() =>
+  selectedDisplay.value?.status === "pending" || selectedDisplay.value?.status === "running",
+);
 const selectedCost = computed(() => invocationCostDisplay(selectedDisplay.value));
 const selectedTokens = computed(() => invocationTokenDisplay(selectedDisplay.value));
 const selectedTitle = computed(() =>
@@ -610,13 +613,20 @@ async function refresh(): Promise<void> {
   }
 }
 
-function inspectSession(target: "agent" | "workspace"): void {
+function inspectSession(target: "agent" | "workspace", path?: string): void {
   const view = target === "agent" ? "details" : "workspace";
   inspectorTab.value = view;
   if (!inspectorOpenViews.value.includes(view)) {
     inspectorOpenViews.value = [...inspectorOpenViews.value, view];
   }
-  inspectorActiveSurface.value = `view:${view}`;
+  if (view === "workspace" && path) {
+    if (!inspectorOpenPaths.value.includes(path)) inspectorOpenPaths.value = [...inspectorOpenPaths.value, path];
+    inspectorSelectedPath.value = path;
+    inspectorActiveSurface.value = `file:${path}`;
+  } else {
+    inspectorSelectedPath.value = undefined;
+    inspectorActiveSurface.value = `view:${view}`;
+  }
   detailsOpen.value = true;
 }
 
@@ -868,7 +878,7 @@ onBeforeUnmount(() => {
               class="min-w-0 justify-start rounded-md border border-default px-1.5 hover:bg-elevated"
               color="neutral"
               :label="selectedAgentLabel"
-              :trailing-icon="hasMultipleAgents ? 'i-ph-caret-up-down-light' : undefined"
+              :trailing-icon="hasMultipleAgents ? 'i-ph-caret-down-light' : undefined"
               size="xs"
               variant="ghost"
               :aria-label="
@@ -1108,11 +1118,11 @@ onBeforeUnmount(() => {
             />
             <UTooltip v-if="!isUsageRoute" text="Usage">
               <UButton
-                icon="i-lucide-chart-no-axes-column"
+                :icon="consoleSectionDetails.usage.icon"
                 color="neutral"
                 variant="ghost"
                 size="xs"
-                aria-label="Usage"
+                aria-label="Open Usage"
                 @click="toggleUsage"
               />
             </UTooltip>
@@ -1194,6 +1204,7 @@ onBeforeUnmount(() => {
                   :has-display="Boolean(selectedDisplay)"
                   :has-selection="Boolean(selectedInvocationId)"
                   :loading="refreshing"
+                  :refreshable="selectedRefreshable"
                   :project="hasMultipleAgents ? selectedProject : ''"
                   :title="selectedTitle"
                   :tokens="selectedTokens"
@@ -1285,6 +1296,7 @@ onBeforeUnmount(() => {
               :has-display="Boolean(selectedDisplay)"
               :has-selection="Boolean(selectedInvocationId)"
               :loading="refreshing"
+              :refreshable="selectedRefreshable"
               :project="hasMultipleAgents ? selectedProject : ''"
               :title="selectedTitle"
               :tokens="selectedTokens"
@@ -1403,7 +1415,7 @@ onBeforeUnmount(() => {
 }
 
 .vitehub-console__search {
-  border: 0;
+  border: 1px solid var(--ui-border);
 }
 
 .vitehub-console__search-shortcut {

--- a/packages/vite-hub/src/console/runtime/components/console-blob.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-blob.vue
@@ -237,15 +237,8 @@ onBeforeUnmount(() => {
       </template>
 
       <template #default="{ collapsed }">
-        <div v-if="!collapsed" class="flex items-end justify-between px-4 pb-3 pt-5">
-          <div>
-            <span class="text-[10px] font-semibold uppercase tracking-[.1em] text-muted">Object storage</span>
-            <h1 class="mt-1 text-lg font-semibold tracking-tight text-highlighted">Objects</h1>
-          </div>
-          <span class="text-xs text-muted">{{ blobs.length }}{{ hasMore ? "+" : "" }}</span>
-        </div>
-        <div class="px-2 pb-3" :class="collapsed ? 'pt-2' : ''">
-          <UDashboardSearchButton :collapsed="collapsed" block class="w-full bg-transparent ring-default" label="Search console" />
+        <div class="flex shrink-0 items-center gap-1 px-[0.875rem] pb-2 pt-1">
+          <UDashboardSearchButton :collapsed="collapsed" block class="vitehub-console__search min-w-0 flex-1 rounded-md border border-default bg-transparent px-2 ring-0 hover:bg-elevated/60" label="Search console" />
         </div>
         <div v-if="!collapsed" class="grid gap-2 px-3 pb-3">
           <USelect v-if="stores.length > 1" v-model="selectedStore" :items="storeItems" aria-label="Blob store" size="sm" />

--- a/packages/vite-hub/src/console/runtime/components/console-brand.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-brand.vue
@@ -4,6 +4,7 @@ import { useRoute } from "vue-router"
 
 import { loadConsoleNavigation, subscribeConsoleNavigation } from "../client/sections"
 import { resolveConsoleRouteName } from "../console-route"
+import ConsoleMark from "./console-mark.vue"
 
 const props = defineProps<{
   collapsed?: boolean
@@ -25,10 +26,11 @@ onBeforeUnmount(() => unsubscribeNavigation?.())
 </script>
 
 <template>
-  <div class="flex h-10 w-full min-w-0 items-center px-1.5">
+  <div class="flex h-10 w-full min-w-0 items-center gap-2 px-[0.875rem]">
+    <ConsoleMark class="size-4 shrink-0" />
     <RouterLink
       v-if="!collapsed"
-      class="truncate text-[13px] font-semibold text-highlighted"
+      class="truncate text-xs font-medium text-muted"
       :to="{ name: resolveConsoleRouteName(route.name, 'vitehub-console') }"
     >
       {{ projectName ? `ViteHub ${projectName}` : "ViteHub" }}

--- a/packages/vite-hub/src/console/runtime/components/console-database.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-database.vue
@@ -340,23 +340,15 @@ onBeforeUnmount(() => {
       </template>
 
       <template #default="{ collapsed }">
-        <div class="px-2 py-2">
+        <div class="flex shrink-0 items-center gap-1 px-[0.875rem] pb-2 pt-1">
           <UDashboardSearchButton
             :collapsed="collapsed"
             block
-            class="w-full bg-transparent ring-0 hover:bg-elevated/60"
+            class="vitehub-console__search min-w-0 flex-1 rounded-md border border-default bg-transparent px-2 ring-0 hover:bg-elevated/60"
             label="Search console"
           />
         </div>
 
-        <div v-if="!collapsed" class="flex items-center gap-2 px-3 pb-1.5 pt-3">
-          <span class="font-mono text-[10px] font-medium uppercase tracking-[.1em] text-muted">
-            Database
-          </span>
-          <span class="ml-auto text-[10px] tabular-nums text-muted">{{
-            database?.tables.length || 0
-          }}</span>
-        </div>
         <div v-if="!collapsed && database" class="px-2 pb-2">
           <USelect
             v-if="database.databases.length > 1"

--- a/packages/vite-hub/src/console/runtime/components/console-definitions.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-definitions.vue
@@ -220,20 +220,11 @@ onBeforeUnmount(() => request?.abort());
       </template>
 
       <template #default="{ collapsed }">
-        <div v-if="!collapsed" class="flex items-end justify-between px-4 pb-3 pt-5">
-          <div>
-            <span class="text-[10px] font-semibold uppercase tracking-[.1em] text-muted"
-              >Discovered</span
-            >
-            <h1 class="mt-1 text-lg font-semibold tracking-tight text-highlighted">Definitions</h1>
-          </div>
-          <span class="text-xs text-muted">{{ definitions.length }}</span>
-        </div>
-        <div class="px-2 pb-3" :class="collapsed ? 'pt-2' : ''">
+        <div class="flex shrink-0 items-center gap-1 px-[0.875rem] pb-2 pt-1">
           <UDashboardSearchButton
             :collapsed="collapsed"
             block
-            class="w-full bg-transparent ring-default"
+            class="vitehub-console__search min-w-0 flex-1 rounded-md border border-default bg-transparent px-2 ring-0 hover:bg-elevated/60"
             label="Search console"
           />
         </div>

--- a/packages/vite-hub/src/console/runtime/components/console-home.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-home.vue
@@ -112,11 +112,11 @@ onBeforeUnmount(() => request++);
           class="grid gap-1 px-2"
           :class="collapsed ? 'pt-2' : ''"
         >
-          <div class="pb-2">
+          <div class="flex shrink-0 items-center gap-1 pb-2 pt-1">
             <UDashboardSearchButton
               :collapsed="collapsed"
               block
-              class="w-full bg-transparent ring-default"
+              class="vitehub-console__search min-w-0 flex-1 rounded-md border border-default bg-transparent px-2 ring-0 hover:bg-elevated/60"
               label="Search console"
             />
           </div>

--- a/packages/vite-hub/src/console/runtime/components/console-kv.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-kv.vue
@@ -352,11 +352,11 @@ onBeforeUnmount(() => {
       </template>
 
       <template #default="{ collapsed }">
-        <div class="px-2 py-2">
+        <div class="flex shrink-0 items-center gap-1 px-[0.875rem] pb-2 pt-1">
           <UDashboardSearchButton
             :collapsed="collapsed"
             block
-            class="w-full bg-transparent ring-0 hover:bg-elevated/60"
+            class="vitehub-console__search min-w-0 flex-1 rounded-md border border-default bg-transparent px-2 ring-0 hover:bg-elevated/60"
             label="Search console"
           />
         </div>

--- a/packages/vite-hub/src/console/runtime/components/console-primitive-switcher.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-primitive-switcher.vue
@@ -54,7 +54,16 @@ onMounted(loadSections);
         @click="openSection(item.id)"
       />
     </UTooltip>
-    <UButton v-if="sections.includes('usage') && !exclude?.includes('usage')" aria-label="Usage" label="Usage" icon="i-lucide-chart-no-axes-column" color="neutral" variant="ghost" size="xs" @click="openSection('usage')" />
+    <UTooltip v-if="sections.includes('usage') && !exclude?.includes('usage')" :text="consoleSectionDetails.usage.label">
+      <UButton
+        :aria-label="`Open ${consoleSectionDetails.usage.label}`"
+        color="neutral"
+        :icon="consoleSectionDetails.usage.icon"
+        size="xs"
+        :variant="active === 'usage' ? 'soft' : 'ghost'"
+        @click="openSection('usage')"
+      />
+    </UTooltip>
     <UTooltip v-if="navigationFailed" text="Retry loading primitives">
       <UButton
         aria-label="Retry loading primitives"

--- a/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
@@ -163,7 +163,8 @@ watch(
       if (tab.value === "workspace") tab.value = "details";
       if (activeSurface.value === "view:workspace" || activeSurface.value.startsWith("file:")) activeSurface.value = "view:details";
     }
-    if (tab.value === "workspace") void loadWorkspace();
+    if (selectedPath.value) void loadFile(selectedPath.value);
+    else if (tab.value === "workspace") void loadWorkspace();
   },
   { immediate: true },
 );

--- a/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
@@ -225,6 +225,7 @@ function openView(value: InspectorTab) {
     file.value = undefined;
     fileError.value = undefined;
     fileLoading.value = false;
+    if (!workspace.value && !workspaceLoading.value) void loadWorkspace();
   }
 }
 

--- a/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
@@ -4,6 +4,7 @@ import type { DropdownMenuItem, TabsItem } from "@nuxt/ui";
 import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
 import ConsoleSessionCodePreview from "./console-session-code-preview.vue";
 import ConsoleSessionTrace from "./console-session-trace.vue";
+import { matchesWorkspaceFile } from "./console-workspace-file";
 import { useConsoleWordWrap } from "./console-wrap";
 import { requestConsole } from "../client/request";
 import { viteHubErrorDiagnostics } from "../../../error-diagnostics";
@@ -172,7 +173,8 @@ watch(
   (value) => {
     if (!activeSurface.value) return;
     if (!openViews.value.includes(value)) openViews.value = [...openViews.value, value];
-    if (value === "workspace" && !workspace.value && !workspaceLoading.value) void loadWorkspace();
+    if (value === "workspace" && !selectedPath.value && !workspace.value && !workspaceLoading.value)
+      void loadWorkspace();
   },
 );
 
@@ -364,7 +366,7 @@ async function loadFile(path: string) {
         controller.signal,
       ),
     );
-    if (loadedFile.path !== path || loadedFile.revision !== workspace.value?.revision)
+    if (!matchesWorkspaceFile(loadedFile, path, workspace.value))
       throw viteHubErrorDiagnostics.VITE_HUB_R0107({
         message: "The host returned a Workspace file for a different path or revision.",
       });
@@ -424,7 +426,9 @@ function parseWorkspaceFile(value: unknown): WorkspaceFile {
     throw viteHubErrorDiagnostics.VITE_HUB_R0109({
       message: "The host returned an invalid Workspace file.",
     });
-  return { content, path, ...(source ? { provenance: { source } } : {}), revision, size };
+  const result: WorkspaceFile = { content, path, revision, size };
+  if (source) result.provenance = { source };
+  return result;
 }
 
 function record(value: unknown): Record<string, unknown> | undefined {
@@ -611,7 +615,7 @@ function message(error: unknown) {
               aria-label="Reload Workspace"
               @click="loadWorkspace"
           /></UTooltip>
-          <UTooltip :text="treeOpen ? 'Hide file tree' : 'Show file tree'"
+          <UTooltip v-if="workspace" :text="treeOpen ? 'Hide file tree' : 'Show file tree'"
             ><UButton
               icon="i-lucide-folder-tree"
               color="neutral"
@@ -623,21 +627,21 @@ function message(error: unknown) {
           /></UTooltip>
         </div>
       </div>
-      <div v-if="workspaceLoading" class="session-inspector__state">
+      <div v-if="workspaceLoading && !selectedPath" class="session-inspector__state">
         <UIcon name="i-lucide-loader-circle" class="animate-spin" />Loading Workspace…
       </div>
       <UEmpty
         :ui="{ root: 'border-0' }"
-        v-else-if="workspaceError"
+        v-else-if="workspaceError && !selectedPath"
         icon="i-lucide-folder-x"
         title="Workspace unavailable"
         :description="workspaceError"
         :actions="[{ label: 'Try again', onClick: loadWorkspace }]"
       />
-      <template v-else-if="workspace">
-        <div class="session-inspector__workspace-body" :data-tree-open="treeOpen">
+      <template v-else-if="workspace || selectedPath">
+        <div class="session-inspector__workspace-body" :data-tree-open="treeOpen && !!workspace">
           <div class="session-inspector__file">
-            <div v-if="!selectedPath" class="session-inspector__snapshot">
+            <div v-if="!selectedPath && workspace" class="session-inspector__snapshot">
               <UIcon name="i-lucide-folder-git-2" />
               <span class="session-inspector__eyebrow">{{
                 ["current", "live"].includes(workspace.revision) ? "Live workspace" : "Immutable snapshot"
@@ -665,7 +669,7 @@ function message(error: unknown) {
               <UIcon name="i-lucide-mouse-pointer-2" />Select a file to preview it.
             </div>
           </div>
-          <aside v-if="treeOpen" ref="filesPanel" class="session-inspector__files">
+          <aside v-if="treeOpen && workspace" ref="filesPanel" class="session-inspector__files">
             <AgentFileTree
               class="session-inspector__tree"
               :paths="workspace.paths"
@@ -674,10 +678,11 @@ function message(error: unknown) {
           </aside>
         </div>
       </template>
-      <footer v-if="workspace" class="session-inspector__file-status">
-        <span :title="workspace.revision === 'current' ? 'Files currently mounted on this host; not a snapshot of this run.' : workspace.revision">{{ workspace.revision === 'current' ? 'Current mounted files' : workspace.revision }}</span>
+      <footer v-if="workspace || file" class="session-inspector__file-status">
+        <span v-if="workspace" :title="workspace.revision === 'current' ? 'Files currently mounted on this host; not a snapshot of this run.' : workspace.revision">{{ workspace.revision === 'current' ? 'Current mounted files' : workspace.revision }}</span>
+        <span v-else-if="file">{{ file.revision === "current" ? "Current mounted file" : file.revision }}</span>
         <span v-if="file?.provenance">From {{ file.provenance.source }}</span>
-        <span>{{ workspace.paths.length }} files<span v-if="file"> · {{ file.size.toLocaleString() }} bytes</span></span>
+        <span><template v-if="workspace">{{ workspace.paths.length }} files<span v-if="file"> · </span></template><template v-if="file">{{ file.size.toLocaleString() }} bytes</template></span>
       </footer>
     </div>
   </aside>

--- a/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-inspector.vue
@@ -15,7 +15,7 @@ type WorkspaceDescriptor = {
   repository: string;
   revision: string;
 };
-type WorkspaceFile = { content: string; path: string; revision: string; size: number };
+type WorkspaceFile = { content: string; path: string; provenance?: { source: string }; revision: string; size: number };
 
 const props = withDefaults(
   defineProps<{
@@ -28,8 +28,8 @@ const props = withDefaults(
 );
 const emit = defineEmits<{ close: []; focusActivity: [activityId: string]; toggleMaximized: [] }>();
 const tab = defineModel<InspectorTab>("tab", { default: "details" });
-const activeSurface = defineModel<string>("activeSurface", { default: "view:details" });
-const openViews = defineModel<InspectorTab[]>("openViews", { default: () => ["details"] });
+const activeSurface = defineModel<string>("activeSurface", { default: "" });
+const openViews = defineModel<InspectorTab[]>("openViews", { default: () => [] });
 const openPaths = defineModel<string[]>("openPaths", { default: () => [] });
 const selectedPath = defineModel<string | undefined>("selectedPath");
 const workspace = ref<WorkspaceDescriptor>();
@@ -86,7 +86,6 @@ const workspaceLabel = computed(() =>
       : `${workspace.value.repository}@${workspace.value.revision.slice(0, 7)}`
     : "Agent Workspace",
 );
-const invocationUsage = computed(() => record(props.invocation)?.usage);
 const breadcrumbs = computed(() => selectedPath.value?.split("/") ?? []);
 type InspectorSurfaceItem = TabsItem & {
   icon: string;
@@ -171,10 +170,10 @@ watch(
 watch(
   tab,
   (value) => {
+    if (!activeSurface.value) return;
     if (!openViews.value.includes(value)) openViews.value = [...openViews.value, value];
     if (value === "workspace" && !workspace.value && !workspaceLoading.value) void loadWorkspace();
   },
-  { immediate: true },
 );
 
 watch(selectedPath, (path) => {
@@ -419,11 +418,13 @@ function parseWorkspaceFile(value: unknown): WorkspaceFile {
   const path = stringValue(file?.path);
   const revision = stringValue(file?.revision);
   const size = numericValue(file?.size);
+  const provenanceValue = record(file?.provenance);
+  const source = stringValue(provenanceValue?.source);
   if (content === undefined || !path || !revision || size === undefined)
     throw viteHubErrorDiagnostics.VITE_HUB_R0109({
       message: "The host returned an invalid Workspace file.",
     });
-  return { content, path, revision, size };
+  return { content, path, ...(source ? { provenance: { source } } : {}), revision, size };
 }
 
 function record(value: unknown): Record<string, unknown> | undefined {
@@ -442,14 +443,6 @@ function numericValue(value: unknown): number | undefined {
   return typeof value === "number" && Number.isFinite(value) ? value : undefined;
 }
 
-function formatTokens(value: unknown): string {
-  const resolved = numericValue(value);
-  if (resolved === undefined) return "Unavailable";
-  return new Intl.NumberFormat("en", {
-    maximumFractionDigits: 1,
-    notation: resolved >= 10_000 ? "compact" : "standard",
-  }).format(resolved);
-}
 
 function message(error: unknown) {
   return error instanceof Error ? error.message : "This session data is unavailable.";
@@ -568,67 +561,15 @@ function message(error: unknown) {
       class="session-inspector__details"
       @select-activity="emit('focusActivity', $event)"
     >
-      <template #metadata>
-        <section v-if="invocationUsage">
-          <h4>Usage</h4>
-          <dl class="grid grid-cols-2 gap-3">
-            <div>
-              <dt class="text-xs text-muted">Processed tokens</dt>
-              <dd class="mt-1 text-sm font-semibold tabular-nums">
-                {{ formatTokens(invocationUsage.totalTokens) }}
-              </dd>
-            </div>
-            <div v-if="record(invocationUsage.cost)">
-              <dt class="text-xs text-muted">Cost</dt>
-              <dd class="mt-1 text-sm font-semibold tabular-nums">
-                {{ stringValue(record(invocationUsage.cost)?.display) || "Unavailable" }}
-              </dd>
-            </div>
-            <div>
-              <dt class="text-xs text-muted">Input</dt>
-              <dd class="mt-1 text-xs tabular-nums text-toned">
-                {{ formatTokens(invocationUsage.inputTokens) }}
-              </dd>
-            </div>
-            <div>
-              <dt class="text-xs text-muted">Output</dt>
-              <dd class="mt-1 text-xs tabular-nums text-toned">
-                {{ formatTokens(invocationUsage.outputTokens) }}
-              </dd>
-            </div>
-            <div v-if="numericValue(invocationUsage.cachedInputTokens) !== undefined">
-              <dt class="text-xs text-muted">Cached input</dt>
-              <dd class="mt-1 text-xs tabular-nums text-toned">
-                {{ formatTokens(invocationUsage.cachedInputTokens) }}
-              </dd>
-            </div>
-            <div v-if="numericValue(invocationUsage.cacheWriteTokens) !== undefined">
-              <dt class="text-xs text-muted">Cache writes</dt>
-              <dd class="mt-1 text-xs tabular-nums text-toned">
-                {{ formatTokens(invocationUsage.cacheWriteTokens) }}
-              </dd>
-            </div>
-            <div v-if="numericValue(invocationUsage.reasoningTokens) !== undefined">
-              <dt class="text-xs text-muted">Reasoning</dt>
-              <dd class="mt-1 text-xs tabular-nums text-toned">
-                {{ formatTokens(invocationUsage.reasoningTokens) }}
-              </dd>
-            </div>
-          </dl>
-          <p v-if="record(invocationUsage.cost)" class="mt-3 text-[11px] leading-4 text-dimmed">
-            {{ record(invocationUsage.cost)?.estimated === true ? "Estimated" : "Reported" }}
-            by {{ stringValue(record(invocationUsage.cost)?.source) || "the provider" }}
-          </p>
-        </section>
-        <section v-if="props.workspaceBase" class="session-inspector__instruction-fallback">
-          <h4>Workspace instructions</h4>
-          <p>Inspect the root AGENTS.md when this Workspace provides one.</p>
-          <button v-if="props.workspaceBase" type="button" @click="openWorkspaceInstructions">
-            <UIcon name="i-lucide-file-text" />Find root AGENTS.md in Workspace<UIcon
-              name="i-lucide-arrow-right"
-            />
-          </button>
-        </section>
+      <template #identityActions>
+        <button
+          v-if="props.workspaceBase"
+          class="session-inspector__instructions-link"
+          type="button"
+          @click="openWorkspaceInstructions"
+        >
+          <UIcon name="i-lucide-file-text" />Instructions
+        </button>
       </template>
     </AgentInvocationInspector>
 
@@ -735,6 +676,7 @@ function message(error: unknown) {
       </template>
       <footer v-if="workspace" class="session-inspector__file-status">
         <span :title="workspace.revision === 'current' ? 'Files currently mounted on this host; not a snapshot of this run.' : workspace.revision">{{ workspace.revision === 'current' ? 'Current mounted files' : workspace.revision }}</span>
+        <span v-if="file?.provenance">From {{ file.provenance.source }}</span>
         <span>{{ workspace.paths.length }} files<span v-if="file"> · {{ file.size.toLocaleString() }} bytes</span></span>
       </footer>
     </div>

--- a/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
+++ b/packages/vite-hub/src/console/runtime/components/console-session-navbar.vue
@@ -8,6 +8,7 @@ const props = defineProps<{
   hasDisplay: boolean;
   hasSelection: boolean;
   loading: boolean;
+  refreshable: boolean;
   project: string;
   title: string;
   tokens?: string;
@@ -72,7 +73,7 @@ defineEmits<{
           :aria-label="externalTarget.label"
         />
       </UTooltip>
-      <UTooltip text="Refresh session">
+      <UTooltip v-if="refreshable" text="Refresh session">
         <UButton
           icon="i-lucide-refresh-cw"
           color="neutral"

--- a/packages/vite-hub/src/console/runtime/components/console-session.css
+++ b/packages/vite-hub/src/console/runtime/components/console-session.css
@@ -274,7 +274,7 @@
 }
 
 .session-inspector__details .vh-invocation-inspector__content > section {
-  padding: 0.75rem 1rem !important;
+  padding: 0.625rem 0.875rem !important;
 }
 
 .session-inspector__details .vh-invocation-inspector__content > section:first-child {
@@ -294,39 +294,61 @@
   text-align: start !important;
 }
 
-.session-inspector__instruction-fallback p {
-  color: var(--ui-text-muted);
-  font-size: 0.6875rem;
-  margin: 0 0 0.5rem;
+.session-inspector__details .vh-invocation-inspector__identity {
+  gap: 0.25rem;
 }
-.session-inspector__instruction-fallback button {
+
+.session-inspector__details .vh-invocation-inspector__title-row {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
+
+.session-inspector__instructions-link {
   align-items: center;
   background: transparent;
   border: 0;
-  border-radius: 0.4rem;
-  color: var(--ui-text);
+  border-radius: 0.35rem;
+  color: var(--ui-text-muted);
   cursor: pointer;
-  display: flex;
+  display: inline-flex;
+  flex: 0 0 auto;
   font: inherit;
   font-size: 0.6875rem;
-  gap: 0.45rem;
-  min-height: 1.875rem;
-  padding: 0.3rem 0.4rem;
-  width: 100%;
+  gap: 0.3rem;
+  padding: 0.25rem 0.4rem;
 }
-.session-inspector__instruction-fallback button:hover,
-.session-inspector__instruction-fallback button:focus-visible {
-  background: var(--ui-bg-elevated);
-  outline: none;
+.session-inspector__instructions-link:hover { background: var(--ui-bg-elevated); color: var(--ui-text); }
+.session-inspector__instructions-link svg { height: 0.75rem; width: 0.75rem; }
+
+.session-inspector__details .vh-invocation-inspector__metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1rem;
 }
-.session-inspector__instruction-fallback button svg {
-  color: var(--ui-text-muted);
-  height: 0.8rem;
-  width: 0.8rem;
+.session-inspector__details .vh-invocation-inspector__metrics > div {
+  align-items: baseline;
+  border: 0 !important;
+  display: flex;
+  flex: 0 0 auto;
+  gap: 0.35rem;
+  padding: 0 !important;
 }
-.session-inspector__instruction-fallback button svg:last-child {
-  margin-inline-start: auto;
+.session-inspector__details .vh-invocation-inspector__metrics dt { font-size: 0.6875rem; }
+.session-inspector__details .vh-invocation-inspector__metrics dd { font-size: 0.75rem; }
+
+.session-inspector__details .vh-invocation-execution__model {
+  background: transparent;
+  border: 0;
+  padding: 0;
 }
+.session-inspector__details .vh-invocation-execution__workspace {
+  background: transparent;
+  border: 0;
+  padding: 0;
+}
+
 
 .session-inspector__scroll,
 .session-inspector__workspace {
@@ -624,7 +646,7 @@
   margin: 0;
   min-height: 100%;
   min-width: max-content;
-  padding: 1rem 1.5rem 2rem 0;
+  padding: 0.75rem 0 1.5rem;
   tab-size: 2;
 }
 
@@ -643,7 +665,7 @@
   counter-increment: line;
   display: block;
   min-height: 1rem;
-  padding-inline: 3.25rem 1rem;
+  padding-inline: 2.75rem 0.5rem;
   position: relative;
   white-space: pre;
 }
@@ -656,7 +678,7 @@
   padding-inline-end: 0.85rem;
   text-align: end;
   user-select: none;
-  width: 3.25rem;
+  width: 2.75rem;
 }
 
 .session-code-preview[data-wrap="true"]
@@ -1535,9 +1557,9 @@
 /* Shared compact Console session chrome. */
 .vitehub-console__search {
   justify-content: flex-start !important;
-  border: 0 !important;
+  border: 1px solid var(--ui-border) !important;
   box-shadow: none !important;
-  padding: 0 !important;
+  padding-inline: 0.5rem !important;
   font-size: 0.75rem !important;
   min-height: 1.5rem !important;
 }

--- a/packages/vite-hub/src/console/runtime/components/console-workspace-file.ts
+++ b/packages/vite-hub/src/console/runtime/components/console-workspace-file.ts
@@ -1,0 +1,12 @@
+export interface ConsoleWorkspaceFileIdentity {
+  path: string;
+  revision: string;
+}
+
+export function matchesWorkspaceFile(
+  file: ConsoleWorkspaceFileIdentity,
+  path: string,
+  workspace?: { revision: string },
+): boolean {
+  return file.path === path && (!workspace || file.revision === workspace.revision);
+}

--- a/packages/vite-hub/src/console/runtime/server/invocation-workspace.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocation-workspace.get.ts
@@ -10,7 +10,7 @@ import type { ConsoleRequestEvent } from "./request.ts"
 const configurationSchema = v.object({ workspace: v.object({ name: v.string() }) })
 const hostWorkspaceSchema = v.union([
   v.object({ paths: v.array(v.string()), repository: v.string(), revision: v.string() }),
-  v.object({ content: v.string(), path: v.string(), revision: v.string(), size: v.number() }),
+  v.object({ content: v.string(), path: v.string(), provenance: v.optional(v.object({ source: v.string() })), revision: v.string(), size: v.number() }),
 ])
 const maxFileBytes = 512 * 1024
 
@@ -23,7 +23,7 @@ function visiblePath(path: string): boolean {
     && !path.split("/").some(part => !part || part === ".." || part === "." || /^(?:\.git|\.ssh|\.env(?:\..*)?|auth\.json|credentials(?:\..*)?)$/i.test(part))
 }
 
-export default async function consoleInvocationWorkspaceHandler(event: ConsoleRequestEvent): Promise<{ paths: string[], repository: string, revision: string } | { content: string, path: string, revision: string, size: number }> {
+export default async function consoleInvocationWorkspaceHandler(event: ConsoleRequestEvent): Promise<{ paths: string[], repository: string, revision: string } | { content: string, path: string, provenance?: { source: string }, revision: string, size: number }> {
   assertConsoleRequest(event)
   const id = event.context?.params?.id ?? ""
   const path = consoleRequestURL(event).searchParams.get("path")
@@ -41,21 +41,23 @@ export default async function consoleInvocationWorkspaceHandler(event: ConsoleRe
     .find(result => result.success)
   if (!configuration?.success) throw failure(404, "This run did not record its Workspace. Open a newer run to inspect its mounted files.")
   const name = configuration.output.workspace.name
-  const workspace = useWorkspace(name)
+  const workspace = useWorkspace(name, { mode: "read", refresh: false })
   // These are the mounted files now, not a retained snapshot of the invocation.
   const revision = "current"
   if (path !== null) {
     if (!visiblePath(path)) throw failure(400, "Choose a visible file inside this Workspace.")
-    const visible = (await workspace.fs.glob("**/*")).some(entry => entry.type === "file" && entry.path === path)
-    if (!visible) throw failure(404, "This file is not in the mounted Workspace.")
     const stat = await workspace.fs.stat(path)
+    if (!stat) throw failure(404, "This file is not in the mounted Workspace.")
     if (stat.type !== "file") throw failure(400, "Choose a file to preview.")
     if (stat.size !== undefined && stat.size > maxFileBytes) throw failure(413, "This file is too large to preview. The Console limit is 512 KiB.")
     const content = await workspace.fs.readFile(path, { encoding: "utf8" })
     const size = new TextEncoder().encode(content).byteLength
     if (size > maxFileBytes) throw failure(413, "This file is too large to preview. The Console limit is 512 KiB.")
     if (content.includes("\0")) throw failure(415, "Binary files cannot be previewed as text.")
-    return { content, path, revision, size }
+    const promoted = stat.metadata?.promotedSourceSkill
+    const source = promoted && typeof promoted === "object" && "source" in promoted && typeof promoted.source === "string"
+      && /^[A-Za-z0-9._-]{1,100}$/.test(promoted.source) ? promoted.source : undefined
+    return { content, path, ...(source ? { provenance: { source } } : {}), revision, size }
   }
   const entries = await workspace.fs.glob("**/*")
   const paths = entries.filter(entry => entry.type === "file" && visiblePath(entry.path)).map(entry => entry.path).sort()

--- a/packages/vite-hub/src/console/runtime/server/invocation-workspace.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocation-workspace.get.ts
@@ -8,7 +8,7 @@ import { viteHubErrorDiagnostics } from "../../../error-diagnostics.ts"
 import type { ConsoleRequestEvent } from "./request.ts"
 
 const configurationSchema = v.object({ workspace: v.object({ name: v.string() }) })
-const sourceSchema = v.pipe(v.string(), v.regex(/^[A-Za-z0-9._-]{1,100}$/))
+const sourceSchema = v.pipe(v.string(), v.nonEmpty(), v.regex(/^[^\p{Cc}]+$/u))
 const hostWorkspaceSchema = v.union([
   v.object({ paths: v.array(v.string()), repository: v.string(), revision: v.string() }),
   v.object({ content: v.string(), path: v.string(), provenance: v.optional(v.object({ source: v.string() })), revision: v.string(), size: v.number() }),

--- a/packages/vite-hub/src/console/runtime/server/invocation-workspace.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocation-workspace.get.ts
@@ -8,6 +8,7 @@ import { viteHubErrorDiagnostics } from "../../../error-diagnostics.ts"
 import type { ConsoleRequestEvent } from "./request.ts"
 
 const configurationSchema = v.object({ workspace: v.object({ name: v.string() }) })
+const promotedSourceSchema = v.object({ source: v.pipe(v.string(), v.regex(/^[A-Za-z0-9._-]{1,100}$/)) })
 const hostWorkspaceSchema = v.union([
   v.object({ paths: v.array(v.string()), repository: v.string(), revision: v.string() }),
   v.object({ content: v.string(), path: v.string(), provenance: v.optional(v.object({ source: v.string() })), revision: v.string(), size: v.number() }),
@@ -41,7 +42,7 @@ export default async function consoleInvocationWorkspaceHandler(event: ConsoleRe
     .find(result => result.success)
   if (!configuration?.success) throw failure(404, "This run did not record its Workspace. Open a newer run to inspect its mounted files.")
   const name = configuration.output.workspace.name
-  const workspace = useWorkspace(name, { mode: "read", refresh: false })
+  const workspace = useWorkspace(name, { mode: "read" })
   // These are the mounted files now, not a retained snapshot of the invocation.
   const revision = "current"
   if (path !== null) {
@@ -54,9 +55,8 @@ export default async function consoleInvocationWorkspaceHandler(event: ConsoleRe
     const size = new TextEncoder().encode(content).byteLength
     if (size > maxFileBytes) throw failure(413, "This file is too large to preview. The Console limit is 512 KiB.")
     if (content.includes("\0")) throw failure(415, "Binary files cannot be previewed as text.")
-    const promoted = stat.metadata?.promotedSourceSkill
-    const source = promoted && typeof promoted === "object" && "source" in promoted && typeof promoted.source === "string"
-      && /^[A-Za-z0-9._-]{1,100}$/.test(promoted.source) ? promoted.source : undefined
+    const promoted = v.safeParse(promotedSourceSchema, stat.metadata?.promotedSourceSkill)
+    const source = promoted.success ? promoted.output.source : undefined
     return { content, path, ...(source ? { provenance: { source } } : {}), revision, size }
   }
   const entries = await workspace.fs.glob("**/*")

--- a/packages/vite-hub/src/console/runtime/server/invocation-workspace.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocation-workspace.get.ts
@@ -57,7 +57,9 @@ export default async function consoleInvocationWorkspaceHandler(event: ConsoleRe
     if (content.includes("\0")) throw failure(415, "Binary files cannot be previewed as text.")
     const promoted = v.safeParse(promotedSourceSchema, stat.metadata?.promotedSourceSkill)
     const source = promoted.success ? promoted.output.source : undefined
-    return { content, path, ...(source ? { provenance: { source } } : {}), revision, size }
+    const result: { content: string, path: string, provenance?: { source: string }, revision: string, size: number } = { content, path, revision, size }
+    if (source) result.provenance = { source }
+    return result
   }
   const entries = await workspace.fs.glob("**/*")
   const paths = entries.filter(entry => entry.type === "file" && visiblePath(entry.path)).map(entry => entry.path).sort()

--- a/packages/vite-hub/src/console/runtime/server/invocation-workspace.get.ts
+++ b/packages/vite-hub/src/console/runtime/server/invocation-workspace.get.ts
@@ -8,7 +8,7 @@ import { viteHubErrorDiagnostics } from "../../../error-diagnostics.ts"
 import type { ConsoleRequestEvent } from "./request.ts"
 
 const configurationSchema = v.object({ workspace: v.object({ name: v.string() }) })
-const promotedSourceSchema = v.object({ source: v.pipe(v.string(), v.regex(/^[A-Za-z0-9._-]{1,100}$/)) })
+const sourceSchema = v.pipe(v.string(), v.regex(/^[A-Za-z0-9._-]{1,100}$/))
 const hostWorkspaceSchema = v.union([
   v.object({ paths: v.array(v.string()), repository: v.string(), revision: v.string() }),
   v.object({ content: v.string(), path: v.string(), provenance: v.optional(v.object({ source: v.string() })), revision: v.string(), size: v.number() }),
@@ -47,6 +47,7 @@ export default async function consoleInvocationWorkspaceHandler(event: ConsoleRe
   const revision = "current"
   if (path !== null) {
     if (!visiblePath(path)) throw failure(400, "Choose a visible file inside this Workspace.")
+    if (!await workspace.fs.exists(path)) throw failure(404, "This file is not in the mounted Workspace.")
     const stat = await workspace.fs.stat(path)
     if (!stat) throw failure(404, "This file is not in the mounted Workspace.")
     if (stat.type !== "file") throw failure(400, "Choose a file to preview.")
@@ -55,8 +56,8 @@ export default async function consoleInvocationWorkspaceHandler(event: ConsoleRe
     const size = new TextEncoder().encode(content).byteLength
     if (size > maxFileBytes) throw failure(413, "This file is too large to preview. The Console limit is 512 KiB.")
     if (content.includes("\0")) throw failure(415, "Binary files cannot be previewed as text.")
-    const promoted = v.safeParse(promotedSourceSchema, stat.metadata?.promotedSourceSkill)
-    const source = promoted.success ? promoted.output.source : undefined
+    const parsedSource = v.safeParse(sourceSchema, stat.metadata?.source)
+    const source = parsedSource.success ? parsedSource.output : undefined
     const result: { content: string, path: string, provenance?: { source: string }, revision: string, size: number } = { content, path, revision, size }
     if (source) result.provenance = { source }
     return result

--- a/packages/vite-hub/test/console-bootstrap.test.ts
+++ b/packages/vite-hub/test/console-bootstrap.test.ts
@@ -14,6 +14,30 @@ const consolePage = readFileSync(
   new URL("../src/console/runtime/components/console-app.vue", import.meta.url),
   "utf8",
 );
+const sessionInspector = readFileSync(
+  new URL("../src/console/runtime/components/console-session-inspector.vue", import.meta.url),
+  "utf8",
+);
+const sessionNavbar = readFileSync(
+  new URL("../src/console/runtime/components/console-session-navbar.vue", import.meta.url),
+  "utf8",
+);
+
+it("opens the inspector on its launcher and keeps terminal session chrome quiet", () => {
+  expect(consolePage).toContain('const inspectorActiveSurface = ref("");');
+  expect(consolePage).toContain('ref<Array<"details" | "trace" | "workspace">>([])');
+  expect(consolePage).toContain("selectedDisplay.value?.status === \"pending\"");
+  expect(consolePage).toContain("i-ph-caret-down-light");
+  expect(consolePage).not.toContain("i-ph-caret-up-down-light");
+  expect(sessionNavbar).toContain('v-if="refreshable" text="Refresh session"');
+});
+
+it("keeps inspector links and metadata compact", () => {
+  expect(sessionInspector).toContain('class="session-inspector__surface-launcher"');
+  expect(sessionInspector).toContain('<template #identityActions>');
+  expect(sessionInspector).toContain('class="session-inspector__instructions-link"');
+  expect(sessionInspector).not.toContain("Find root AGENTS.md in Workspace");
+});
 
 it("releases bare Agents bootstrap when the newest invocation is unnamed", async () => {
   const scope = effectScope();

--- a/packages/vite-hub/test/console-invocation-workspace.test.ts
+++ b/packages/vite-hub/test/console-invocation-workspace.test.ts
@@ -63,18 +63,18 @@ describe("invocation Workspace inspection", () => {
     expect(mocks.stat).not.toHaveBeenCalled()
     expect(mocks.readFile).not.toHaveBeenCalled()
   })
-  it("reports safe mounted source provenance", async () => {
+  it.each(["portal", "docs:api", "org/repo", "../source", "日本語", "a".repeat(101)])("reports mounted source provenance %s as display text", async source => {
     mocks.glob.mockResolvedValue([{ path: ".agents/skills/perf/SKILL.md", type: "file" }])
-    mocks.stat.mockResolvedValue({ type: "file", size: 4, metadata: { source: "portal" } })
+    mocks.stat.mockResolvedValue({ type: "file", size: 4, metadata: { source } })
     expect(await handler(request(".agents/skills/perf/SKILL.md"))).toEqual({
       path: ".agents/skills/perf/SKILL.md",
       content: "test",
-      provenance: { source: "portal" },
+      provenance: { source },
       size: 4,
       revision: "current",
     })
   })
-  it.each([null, 42, {}, "../secret", "", "a".repeat(101)])("omits invalid source provenance %j while preserving the file preview", async source => {
+  it.each([null, 42, {}, "", "source\u0000key", "source\nkey"])("omits invalid source provenance %j while preserving the file preview", async source => {
     mocks.stat.mockResolvedValue({ type: "file", size: 4, metadata: { source } })
     expect(await handler(request("AGENTS.md"))).toEqual({ path: "AGENTS.md", content: "test", size: 4, revision: "current" })
   })

--- a/packages/vite-hub/test/console-invocation-workspace.test.ts
+++ b/packages/vite-hub/test/console-invocation-workspace.test.ts
@@ -41,7 +41,7 @@ describe("invocation Workspace inspection", () => {
   it("identifies current mounted files without claiming a historical snapshot", async () => {
     expect(await handler(request())).toEqual({ paths: ["AGENTS.md"], repository: "bot", revision: "current" })
     expect(mocks.definition).toHaveBeenCalledWith("bot", "inspect")
-    expect(mocks.useWorkspace).toHaveBeenCalledWith("bot", { mode: "read", refresh: false })
+    expect(mocks.useWorkspace).toHaveBeenCalledWith("bot", { mode: "read" })
   })
   it("reads a visible file", async () => {
     expect(await handler(request("AGENTS.md"))).toEqual({ path: "AGENTS.md", content: "test", size: 4, revision: "current" })
@@ -63,6 +63,10 @@ describe("invocation Workspace inspection", () => {
       size: 4,
       revision: "current",
     })
+  })
+  it.each([null, "portal", {}, { source: 42 }, { source: "../secret" }, { source: "" }, { source: "a".repeat(101) }])("omits invalid promoted provenance %j while preserving the file preview", async promotedSourceSkill => {
+    mocks.stat.mockResolvedValue({ type: "file", size: 4, metadata: { promotedSourceSkill } })
+    expect(await handler(request("AGENTS.md"))).toEqual({ path: "AGENTS.md", content: "test", size: 4, revision: "current" })
   })
   it.each(["../secret", "/etc/passwd", "repo/../../secret", "repo\\secret", ".env.local", "repo/.git/config", "auth.json"])("rejects unsafe path %s before reading", async path => {
     await expect(handler(request(path))).rejects.toMatchObject({ statusCode: 400 })

--- a/packages/vite-hub/test/console-invocation-workspace.test.ts
+++ b/packages/vite-hub/test/console-invocation-workspace.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-const mocks = vi.hoisted(() => ({ inspector: vi.fn(), get: vi.fn(), definition: vi.fn(), glob: vi.fn(), stat: vi.fn(), readFile: vi.fn(), useWorkspace: vi.fn() }))
+const mocks = vi.hoisted(() => ({ inspector: vi.fn(), get: vi.fn(), definition: vi.fn(), glob: vi.fn(), exists: vi.fn(), stat: vi.fn(), readFile: vi.fn(), useWorkspace: vi.fn() }))
 vi.mock("@vite-hub/agent/server", () => ({ agentHostWorkspaceRoute: "/api/_vitehub/console/invocations/:id/workspace", getAgentHostWorkspaceInspector: mocks.inspector }))
 vi.mock("../src/console/runtime/server/invocations.ts", () => ({ getConsoleInvocations: () => ({ get: mocks.get }) }))
 vi.mock("../src/console/runtime/server/agents.ts", () => ({ getConsoleAgentDefinition: mocks.definition }))
@@ -12,6 +12,7 @@ beforeEach(() => {
   mocks.get.mockResolvedValue({ agentName: "bot", observations: [{ attributes: { "vitehub.agent.configuration": { workspace: { name: "bot" } } } }] })
   mocks.definition.mockReturnValue({ workspace: { name: "bot" } })
   mocks.glob.mockResolvedValue([{ path: "AGENTS.md", type: "file" }, { path: ".env", type: "file" }, { path: "repo/.git/config", type: "file" }, { path: "src", type: "directory" }])
+  mocks.exists.mockResolvedValue(true)
   mocks.stat.mockResolvedValue({ type: "file", size: 4 })
   mocks.readFile.mockResolvedValue("test")
 })
@@ -47,15 +48,24 @@ describe("invocation Workspace inspection", () => {
     expect(await handler(request("AGENTS.md"))).toEqual({ path: "AGENTS.md", content: "test", size: 4, revision: "current" })
     expect(mocks.glob).not.toHaveBeenCalled()
   })
-  it("reports a missing file from its direct stat without listing the Workspace", async () => {
-    mocks.stat.mockResolvedValue(undefined)
+  it("reports a missing file without stat or listing the Workspace", async () => {
+    mocks.exists.mockResolvedValue(false)
+    mocks.stat.mockRejectedValue(new Error("[vitehub] Workspace path does not exist: missing.md."))
     await expect(handler(request("missing.md"))).rejects.toMatchObject({ statusCode: 404 })
     expect(mocks.glob).not.toHaveBeenCalled()
     expect(mocks.readFile).not.toHaveBeenCalled()
+    expect(mocks.stat).not.toHaveBeenCalled()
   })
-  it("reports safe promoted skill provenance", async () => {
+  it("preserves Workspace failures during the existence check", async () => {
+    const error = new Error("Source unavailable")
+    mocks.exists.mockRejectedValue(error)
+    await expect(handler(request("AGENTS.md"))).rejects.toBe(error)
+    expect(mocks.stat).not.toHaveBeenCalled()
+    expect(mocks.readFile).not.toHaveBeenCalled()
+  })
+  it("reports safe mounted source provenance", async () => {
     mocks.glob.mockResolvedValue([{ path: ".agents/skills/perf/SKILL.md", type: "file" }])
-    mocks.stat.mockResolvedValue({ type: "file", size: 4, metadata: { promotedSourceSkill: { source: "portal", sourcePath: "portal/.agents/skills/perf/SKILL.md" } } })
+    mocks.stat.mockResolvedValue({ type: "file", size: 4, metadata: { source: "portal" } })
     expect(await handler(request(".agents/skills/perf/SKILL.md"))).toEqual({
       path: ".agents/skills/perf/SKILL.md",
       content: "test",
@@ -64,8 +74,8 @@ describe("invocation Workspace inspection", () => {
       revision: "current",
     })
   })
-  it.each([null, "portal", {}, { source: 42 }, { source: "../secret" }, { source: "" }, { source: "a".repeat(101) }])("omits invalid promoted provenance %j while preserving the file preview", async promotedSourceSkill => {
-    mocks.stat.mockResolvedValue({ type: "file", size: 4, metadata: { promotedSourceSkill } })
+  it.each([null, 42, {}, "../secret", "", "a".repeat(101)])("omits invalid source provenance %j while preserving the file preview", async source => {
+    mocks.stat.mockResolvedValue({ type: "file", size: 4, metadata: { source } })
     expect(await handler(request("AGENTS.md"))).toEqual({ path: "AGENTS.md", content: "test", size: 4, revision: "current" })
   })
   it.each(["../secret", "/etc/passwd", "repo/../../secret", "repo\\secret", ".env.local", "repo/.git/config", "auth.json"])("rejects unsafe path %s before reading", async path => {

--- a/packages/vite-hub/test/console-invocation-workspace.test.ts
+++ b/packages/vite-hub/test/console-invocation-workspace.test.ts
@@ -1,13 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
-const mocks = vi.hoisted(() => ({ inspector: vi.fn(), get: vi.fn(), definition: vi.fn(), glob: vi.fn(), stat: vi.fn(), readFile: vi.fn() }))
+const mocks = vi.hoisted(() => ({ inspector: vi.fn(), get: vi.fn(), definition: vi.fn(), glob: vi.fn(), stat: vi.fn(), readFile: vi.fn(), useWorkspace: vi.fn() }))
 vi.mock("@vite-hub/agent/server", () => ({ agentHostWorkspaceRoute: "/api/_vitehub/console/invocations/:id/workspace", getAgentHostWorkspaceInspector: mocks.inspector }))
 vi.mock("../src/console/runtime/server/invocations.ts", () => ({ getConsoleInvocations: () => ({ get: mocks.get }) }))
 vi.mock("../src/console/runtime/server/agents.ts", () => ({ getConsoleAgentDefinition: mocks.definition }))
-vi.mock("@vite-hub/workspace/runtime", () => ({ useWorkspace: () => ({ fs: mocks }) }))
+vi.mock("@vite-hub/workspace/runtime", () => ({ useWorkspace: mocks.useWorkspace }))
 import handler from "../src/console/runtime/server/invocation-workspace.get.ts"
 const request = (path?: string) => ({ method: "GET", context: { params: { id: "run" } }, req: { url: `http://localhost/api/_vitehub/console/invocations/run/workspace${path === undefined ? "" : `?path=${encodeURIComponent(path)}`}` } })
 beforeEach(() => {
   vi.resetAllMocks()
+  mocks.useWorkspace.mockReturnValue({ fs: mocks })
   mocks.get.mockResolvedValue({ agentName: "bot", observations: [{ attributes: { "vitehub.agent.configuration": { workspace: { name: "bot" } } } }] })
   mocks.definition.mockReturnValue({ workspace: { name: "bot" } })
   mocks.glob.mockResolvedValue([{ path: "AGENTS.md", type: "file" }, { path: ".env", type: "file" }, { path: "repo/.git/config", type: "file" }, { path: "src", type: "directory" }])
@@ -40,9 +41,28 @@ describe("invocation Workspace inspection", () => {
   it("identifies current mounted files without claiming a historical snapshot", async () => {
     expect(await handler(request())).toEqual({ paths: ["AGENTS.md"], repository: "bot", revision: "current" })
     expect(mocks.definition).toHaveBeenCalledWith("bot", "inspect")
+    expect(mocks.useWorkspace).toHaveBeenCalledWith("bot", { mode: "read", refresh: false })
   })
   it("reads a visible file", async () => {
     expect(await handler(request("AGENTS.md"))).toEqual({ path: "AGENTS.md", content: "test", size: 4, revision: "current" })
+    expect(mocks.glob).not.toHaveBeenCalled()
+  })
+  it("reports a missing file from its direct stat without listing the Workspace", async () => {
+    mocks.stat.mockResolvedValue(undefined)
+    await expect(handler(request("missing.md"))).rejects.toMatchObject({ statusCode: 404 })
+    expect(mocks.glob).not.toHaveBeenCalled()
+    expect(mocks.readFile).not.toHaveBeenCalled()
+  })
+  it("reports safe promoted skill provenance", async () => {
+    mocks.glob.mockResolvedValue([{ path: ".agents/skills/perf/SKILL.md", type: "file" }])
+    mocks.stat.mockResolvedValue({ type: "file", size: 4, metadata: { promotedSourceSkill: { source: "portal", sourcePath: "portal/.agents/skills/perf/SKILL.md" } } })
+    expect(await handler(request(".agents/skills/perf/SKILL.md"))).toEqual({
+      path: ".agents/skills/perf/SKILL.md",
+      content: "test",
+      provenance: { source: "portal" },
+      size: 4,
+      revision: "current",
+    })
   })
   it.each(["../secret", "/etc/passwd", "repo/../../secret", "repo\\secret", ".env.local", "repo/.git/config", "auth.json"])("rejects unsafe path %s before reading", async path => {
     await expect(handler(request(path))).rejects.toMatchObject({ statusCode: 400 })

--- a/packages/vite-hub/test/console-navigation-layout.test.ts
+++ b/packages/vite-hub/test/console-navigation-layout.test.ts
@@ -29,4 +29,9 @@ describe("shared Console navigation layout", () => {
     expect(switcher).toContain(':icon="consoleSectionDetails.usage.icon"')
     expect(switcher).not.toContain('label="Usage"')
   })
+
+  it("loads the Workspace when its active tab is reopened from a file", () => {
+    const inspector = component("console-session-inspector")
+    expect(inspector).toMatch(/selectedPath\.value = undefined;[\s\S]*?if \(!workspace\.value && !workspaceLoading\.value\) void loadWorkspace\(\);/)
+  })
 })

--- a/packages/vite-hub/test/console-navigation-layout.test.ts
+++ b/packages/vite-hub/test/console-navigation-layout.test.ts
@@ -1,0 +1,32 @@
+import { readFileSync } from "node:fs"
+
+import { describe, expect, it } from "vitest"
+
+const component = (name: string) => readFileSync(
+  new URL(`../src/console/runtime/components/${name}.vue`, import.meta.url),
+  "utf8",
+)
+
+describe("shared Console navigation layout", () => {
+  it("uses one branded header and one aligned search row across primitive modules", () => {
+    expect(component("console-brand")).toContain('<ConsoleMark class="size-4 shrink-0" />')
+    for (const name of ["console-home", "console-definitions", "console-blob", "console-database", "console-kv"]) {
+      expect(component(name)).toContain("<ConsoleBrand")
+      expect(component(name)).toContain("vitehub-console__search")
+      expect(component(name)).toContain("border border-default")
+    }
+  })
+
+  it("keeps primitive identity in the page header instead of repeating sidebar headings", () => {
+    expect(component("console-definitions")).not.toContain(">Definitions</h1>")
+    expect(component("console-blob")).not.toContain(">Objects</h1>")
+    expect(component("console-database")).not.toContain("tracking-[.1em] text-muted\">\n            Database")
+  })
+
+  it("renders Usage as the same accessible icon primitive everywhere", () => {
+    const switcher = component("console-primitive-switcher")
+    expect(switcher).toContain(':text="consoleSectionDetails.usage.label"')
+    expect(switcher).toContain(':icon="consoleSectionDetails.usage.icon"')
+    expect(switcher).not.toContain('label="Usage"')
+  })
+})

--- a/packages/vite-hub/test/console-session-inspector.test.ts
+++ b/packages/vite-hub/test/console-session-inspector.test.ts
@@ -1,0 +1,55 @@
+import { createRenderer, nextTick, ssrContextKey } from "vue"
+import { describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({ request: vi.fn() }))
+vi.mock("../src/console/runtime/client/request", () => ({ requestConsole: mocks.request }))
+vi.mock("@vite-hub/ui", () => ({ AgentFileTree: {}, AgentInvocationInspector: {} }))
+vi.mock("../src/console/runtime/components/console-session-code-preview.vue", () => ({ default: {} }))
+vi.mock("../src/console/runtime/components/console-session-trace.vue", () => ({ default: {} }))
+
+import Inspector from "../src/console/runtime/components/console-session-inspector.vue"
+
+// Run the real component setup and watchers without the presentation components.
+const renderer = createRenderer({
+  createComment: () => ({}),
+  createElement: () => ({}),
+  createText: () => ({}),
+  insert() {},
+  nextSibling: () => null,
+  parentNode: () => null,
+  patchProp() {},
+  remove() {},
+  setElementText() {},
+  setText() {},
+})
+
+describe("Console inspector initialization", () => {
+  it("requests a preselected file without waiting for a Workspace scan", async () => {
+    const path = ".agents/skills/runs/SKILL.md"
+    let resolveResponse: (value: unknown) => void = () => {}
+    const response = new Promise<unknown>(resolve => { resolveResponse = resolve })
+    mocks.request.mockReturnValue(response)
+    const app = renderer.createApp({ ...Inspector, render: () => null }, {
+      invocation: { id: "run" },
+      workspaceBase: "/api/invocations",
+      tab: "workspace",
+      activeSurface: `file:${path}`,
+      selectedPath: path,
+      openPaths: [path],
+    })
+    app.provide(ssrContextKey, {})
+    try {
+      app.mount({})
+      expect(mocks.request).toHaveBeenCalledExactlyOnceWith(
+        `/api/invocations/run/workspace?path=${encodeURIComponent(path)}`,
+        { signal: expect.any(AbortSignal) },
+      )
+      resolveResponse({ path, content: "Skill instructions", revision: "current", size: 18 })
+      await response
+      await nextTick()
+      expect(mocks.request).toHaveBeenCalledTimes(1)
+    } finally {
+      app.unmount()
+    }
+  })
+})

--- a/packages/vite-hub/test/console-workspace-file.test.ts
+++ b/packages/vite-hub/test/console-workspace-file.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { matchesWorkspaceFile } from "../src/console/runtime/components/console-workspace-file";
+
+describe("Console Workspace file previews", () => {
+  const file = { path: ".agents/skills/runs/SKILL.md", revision: "current" };
+
+  it("accepts a requested file before the Workspace descriptor finishes loading", () => {
+    expect(matchesWorkspaceFile(file, file.path)).toBe(true);
+  });
+
+  it("rejects files from a stale Workspace descriptor revision", () => {
+    expect(matchesWorkspaceFile(file, file.path, { revision: "previous" })).toBe(false);
+  });
+});

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -439,7 +439,7 @@ describe("framework package contract", () => {
     expect(sessionInspector).toContain('if (tab.value === "workspace") void loadWorkspace();');
     expect(sessionInspector).toContain("workspaceLoading.value = false;");
     expect(sessionInspector).toContain("workspaceRequest = undefined;");
-    expect(sessionInspector).toContain('<button v-if="props.workspaceBase"');
+    expect(sessionInspector).toMatch(/<button\s+v-if="props.workspaceBase"/);
     expect(sessionInspector).toMatch(
       /const invocationId = props\.invocation\.id;[\s\S]*?if \(!workspace\.value\) await loadWorkspace\(\);[\s\S]*?if \(props\.invocation\.id !== invocationId\) return;/,
     );
@@ -447,7 +447,7 @@ describe("framework package contract", () => {
     expect(sessionInspector).toMatch(
       /const loadedWorkspace = parseWorkspaceDescriptor\([\s\S]*?if \(workspaceRequest !== controller\) return;[\s\S]*?workspace\.value = loadedWorkspace;/,
     );
-    expect(sessionInspector).toContain("invocationUsage.totalTokens");
+    expect(sessionInspector).toContain("<template #identityActions>");
     expect(sessionInspector).toContain("workspace.pullRequest !== undefined");
     expect(sessionInspector).toContain("hasPullRequest && (pullRequest === undefined");
     expect(sessionInspector).toContain('openViews.value.includes("workspace")');
@@ -505,7 +505,7 @@ describe("framework package contract", () => {
     expect(consoleSessionCss).toMatch(
       /\.session-inspector__file \{[\s\S]*?grid-template-rows: minmax\(0, 1fr\);[\s\S]*?height: 100%;/,
     );
-    expect(consoleSessionCss).toContain("padding: 1rem 1.5rem 2rem 0;");
+    expect(consoleSessionCss).toContain("padding: 0.75rem 0 1.5rem;");
     expect(consolePage).not.toContain("/api/health");
     expect(existsSync(`${packageRoot}/dist/console/runtime/server/status.get.js`)).toBe(true);
     expect(consolePage).toContain("agentInvocationTitle");

--- a/packages/vite-hub/test/package.test.ts
+++ b/packages/vite-hub/test/package.test.ts
@@ -316,6 +316,9 @@ describe("framework package contract", () => {
     expect(
       existsSync(`${packageRoot}/dist/console/runtime/components/console-session-bootstrap.ts`),
     ).toBe(true);
+    expect(
+      existsSync(`${packageRoot}/dist/console/runtime/components/console-workspace-file.ts`),
+    ).toBe(true);
     expect(existsSync(`${packageRoot}/dist/console/runtime/console-route.js`)).toBe(true);
     expect(existsSync(`${packageRoot}/dist/console/runtime/sections.js`)).toBe(true);
     expect(existsSync(`${packageRoot}/dist/console/runtime/client/request.js`)).toBe(true);

--- a/packages/vite-hub/test/vue.d.ts
+++ b/packages/vite-hub/test/vue.d.ts
@@ -1,0 +1,6 @@
+declare module "*.vue" {
+  import type { DefineComponent } from "vue"
+
+  const component: DefineComponent
+  export default component
+}

--- a/packages/vite-hub/vite.config.ts
+++ b/packages/vite-hub/vite.config.ts
@@ -145,6 +145,10 @@ export default defineConfig({
         to: "dist/console/runtime/components",
       },
       {
+        from: "src/console/runtime/components/console-workspace-file.ts",
+        to: "dist/console/runtime/components",
+      },
+      {
         from: "src/console/runtime/components/console-session-loading.vue",
         to: "dist/console/runtime/components",
       },

--- a/packages/vite-hub/vitest.config.ts
+++ b/packages/vite-hub/vitest.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "vitest/config"
+import vue from "@vitejs/plugin-vue"
 
 export default defineConfig({
+  plugins: [vue()],
   test: {
     environment: "node",
     include: ["test/**/*.test.ts"],


### PR DESCRIPTION
Invocation timelines previously spread setup, capability, tool, and token evidence across visually heavy rows, while the Console opened the inspector eagerly and repeated usage and workspace information across surfaces. This change makes successful setup activity compact, preserves failure diagnostics and raw tool evidence, and moves invocation metadata into a focused inspector that opens only when requested.

The Console now uses consistent compact navigation across primitives, exposes mounted workspace files through the authorized RPC without relisting for each preview, and shows safe source provenance when the workspace provides it. The UI also recognizes configured channel icons, structured skill links, and provider workspace artifacts while keeping commentary and reasoning distinct.

This is related to #1344 and overlaps its Console presentation area; it does not close or supersede that PR.

Validation:

- `packages/ui`: 142 invocation UI tests passed, with no type errors
- `packages/vite-hub`: 44 focused Console and package-contract tests passed, with no type errors
- `@vite-hub/agent` and `vite-hub` builds passed, including `publint`
- Live Quiver deployment `be4b4445` verified compact setup rows, the complete 5,956-character skill preview, and the file-to-Workspace transition showing 3,694 files without refresh


Known workspace-file links now fetch and render the requested file immediately. They no longer wait behind a full workspace descriptor scan; descriptor revision checks still reject stale file responses once a descriptor is available.


The Workspace tab explicitly loads its descriptor when opened after a direct file preview. A focused navigation regression covers this transition.

